### PR TITLE
Add regression test for resume artifacts page count

### DIFF
--- a/docs/resume/README.md
+++ b/docs/resume/README.md
@@ -3,3 +3,4 @@
 - The LaTeX source (`.tex`) is the source of truth. Commit updates to the appropriate dated directory.
 - Build locally with [`latexmk`](https://ctan.org/pkg/latexmk) or [`pandoc`](https://pandoc.org/) if you need quick PDF or DOCX outputs.
 - Continuous Integration automatically builds both `.pdf` and `.docx` artifacts on every push that touches `docs/resume/**`.
+- The automated test suite compiles the latest dated résumé with [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux binaries if they are not already on your `PATH` (other platforms should install the tools manually).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "three": "^0.161.0"
       },
       "devDependencies": {
+        "@types/jszip": "^3.4.0",
         "@types/node": "^20.11.17",
         "@types/three": "^0.161.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -21,6 +22,8 @@
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.1",
         "jsdom": "^23.0.1",
+        "jszip": "^3.10.1",
+        "pdf-lib": "^1.17.1",
         "prettier": "^3.2.4",
         "typescript": "~5.3.3",
         "vite": "^5.0.12",
@@ -823,6 +826,26 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
@@ -1176,6 +1199,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jszip": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-GFHqtQQP3R4NNuvZH3hNCYD0NbyBZ42bkN7kO3NDrU/SnvIZWMS8Bp38XCsRKBT5BXvgm0y1zqpZWp/ZkRzBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.17",
@@ -2272,6 +2305,13 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3770,6 +3810,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4371,6 +4418,19 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4393,6 +4453,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/local-pkg": {
@@ -4868,6 +4938,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4957,6 +5034,26 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5090,6 +5187,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -5145,6 +5249,29 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5371,6 +5498,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5487,6 +5621,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5660,6 +5801,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -6206,6 +6357,13 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.20",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "three": "^0.161.0"
   },
   "devDependencies": {
+    "@types/jszip": "^3.4.0",
     "@types/node": "^20.11.17",
     "@types/three": "^0.161.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -30,6 +31,8 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
     "jsdom": "^23.0.1",
+    "jszip": "^3.10.1",
+    "pdf-lib": "^1.17.1",
     "prettier": "^3.2.4",
     "typescript": "~5.3.3",
     "vite": "^5.0.12",

--- a/src/tests/resumeArtifacts.test.ts
+++ b/src/tests/resumeArtifacts.test.ts
@@ -1,0 +1,263 @@
+import { execFile } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import JSZip from 'jszip';
+import { PDFDocument } from 'pdf-lib';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(currentDir, '..', '..');
+const RESUME_ROOT = path.join(PROJECT_ROOT, 'docs', 'resume');
+const CACHE_ROOT = path.join(PROJECT_ROOT, 'node_modules', '.cache', 'resume-tools');
+
+const TECTONIC_VERSION = '0.15.0';
+const PANDOC_VERSION = '3.8';
+
+interface ResumeArtifacts {
+  pdfPath: string;
+  docxPath: string;
+  cleanup: () => Promise<void>;
+}
+
+let artifacts: ResumeArtifacts | null = null;
+let setupError: Error | null = null;
+
+beforeAll(async () => {
+  try {
+    artifacts = await buildLatestResumeArtifacts();
+  } catch (error) {
+    const original = error instanceof Error ? error : new Error(String(error));
+    setupError = new Error(
+      `Unable to prepare resume artifacts: ${original.message}. Ensure Tectonic and Pandoc are available or that the test environment can download the pinned binaries.`,
+      { cause: original }
+    );
+  }
+}, 120_000);
+
+afterAll(async () => {
+  if (artifacts) {
+    await artifacts.cleanup();
+  }
+});
+
+describe('latest resume artifacts stay within a single page', () => {
+  it('PDF build uses only one page', async function () {
+    if (setupError) {
+      throw setupError;
+    }
+
+    if (!artifacts) {
+      throw new Error('Failed to prepare resume artifacts.');
+    }
+
+    const pageCount = await countPdfPages(artifacts.pdfPath);
+    expect(pageCount).toBe(1);
+  });
+
+  it('DOCX conversion uses only one page', async function () {
+    if (setupError) {
+      throw setupError;
+    }
+
+    if (!artifacts) {
+      throw new Error('Failed to prepare resume artifacts.');
+    }
+
+    const pageCount = await countDocxPages(artifacts.docxPath);
+    expect(pageCount).toBe(1);
+  });
+});
+
+async function buildLatestResumeArtifacts(): Promise<ResumeArtifacts> {
+  const texPath = await getLatestResumeTexPath();
+  const outputDir = await createTempDir('resume-artifacts-');
+
+  const tectonic = await ensureTectonic();
+  const pandoc = await ensurePandoc();
+
+  await execFileAsync(tectonic, ['--outdir', outputDir, texPath], {
+    cwd: PROJECT_ROOT,
+  });
+
+  const baseName = path.basename(texPath, '.tex');
+  const pdfPath = path.join(outputDir, `${baseName}.pdf`);
+
+  await execFileAsync(pandoc, [texPath, '-o', path.join(outputDir, `${baseName}.docx`)], {
+    cwd: PROJECT_ROOT,
+  });
+
+  const docxPath = path.join(outputDir, `${baseName}.docx`);
+
+  return {
+    pdfPath,
+    docxPath,
+    cleanup: async () => {
+      await rm(outputDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function getLatestResumeTexPath(): Promise<string> {
+  const entries = await readdir(RESUME_ROOT, { withFileTypes: true });
+  const datedDirs = entries
+    .filter((entry) => entry.isDirectory() && /^\d{4}-\d{2}$/.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+
+  if (datedDirs.length === 0) {
+    throw new Error('No dated resume directories found.');
+  }
+
+  const latestDir = datedDirs[datedDirs.length - 1];
+  const latestPath = path.join(RESUME_ROOT, latestDir);
+  const files = await readdir(latestPath);
+  const texFile = files.find((file) => file.endsWith('.tex'));
+
+  if (!texFile) {
+    throw new Error(`No .tex file found in ${latestPath}.`);
+  }
+
+  return path.join(latestPath, texFile);
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  const tempRoot = path.join(CACHE_ROOT, 'tmp');
+  await mkdir(tempRoot, { recursive: true });
+  return mkdtemp(path.join(tempRoot, prefix));
+}
+
+async function ensureTectonic(): Promise<string> {
+  const existing = await findOnPath('tectonic');
+  if (existing) {
+    return existing;
+  }
+
+  if (process.platform !== 'linux' || process.arch !== 'x64') {
+    throw new Error('tectonic not found on PATH and automatic download is only supported on Linux x64.');
+  }
+
+  const cacheDir = path.join(CACHE_ROOT, `tectonic-${TECTONIC_VERSION}`);
+  const binaryPath = path.join(cacheDir, 'tectonic');
+
+  try {
+    await access(binaryPath, fsConstants.X_OK);
+    return binaryPath;
+  } catch {
+    // continue to download
+  }
+
+  await mkdir(cacheDir, { recursive: true });
+  const archivePath = path.join(cacheDir, `tectonic-${TECTONIC_VERSION}.tar.gz`);
+  const downloadUrl = `https://github.com/tectonic-typesetting/tectonic/releases/download/tectonic%40${TECTONIC_VERSION}/tectonic-${TECTONIC_VERSION}-x86_64-unknown-linux-gnu.tar.gz`;
+
+  await downloadFile(downloadUrl, archivePath);
+  await execFileAsync('tar', ['-xzf', archivePath, '-C', cacheDir]);
+  await chmod(binaryPath, 0o755);
+  return binaryPath;
+}
+
+async function ensurePandoc(): Promise<string> {
+  const existing = await findOnPath('pandoc');
+  if (existing) {
+    return existing;
+  }
+
+  if (process.platform !== 'linux' || process.arch !== 'x64') {
+    throw new Error('pandoc not found on PATH and automatic download is only supported on Linux x64.');
+  }
+
+  const cacheDir = path.join(CACHE_ROOT, `pandoc-${PANDOC_VERSION}`);
+  const binaryPath = path.join(cacheDir, `pandoc-${PANDOC_VERSION}`, 'bin', 'pandoc');
+
+  try {
+    await access(binaryPath, fsConstants.X_OK);
+    return binaryPath;
+  } catch {
+    // continue to download
+  }
+
+  await mkdir(cacheDir, { recursive: true });
+  const archivePath = path.join(cacheDir, `pandoc-${PANDOC_VERSION}.tar.gz`);
+  const downloadUrl = `https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz`;
+
+  await downloadFile(downloadUrl, archivePath);
+  await execFileAsync('tar', ['-xzf', archivePath, '-C', cacheDir]);
+  const pandocPath = path.join(cacheDir, `pandoc-${PANDOC_VERSION}`, 'bin', 'pandoc');
+  await chmod(pandocPath, 0o755);
+  return pandocPath;
+}
+
+async function findOnPath(binary: string): Promise<string | null> {
+  const locator = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    const { stdout } = await execFileAsync(locator, [binary]);
+    const first = stdout.split(/\r?\n/).find((line) => line.trim().length > 0);
+    return first ? first.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function downloadFile(url: string, destination: string): Promise<void> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    await writeFile(destination, buffer);
+    return;
+  } catch (error) {
+    const originalMessage = error instanceof Error ? error.message : String(error);
+    try {
+      await execFileAsync('curl', ['-L', '-o', destination, url]);
+      return;
+    } catch (curlError) {
+      const curlMessage =
+        curlError instanceof Error ? curlError.message : String(curlError);
+      throw new Error(
+        `Failed to download ${url}: ${originalMessage}; curl fallback: ${curlMessage}`,
+        { cause: curlError instanceof Error ? curlError : undefined }
+      );
+    }
+  }
+}
+
+async function countPdfPages(pdfPath: string): Promise<number> {
+  const data = await readFile(pdfPath);
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const pdf = await PDFDocument.load(bytes);
+  return pdf.getPageCount();
+}
+
+async function countDocxPages(docxPath: string): Promise<number> {
+  const data = await readFile(docxPath);
+  const zip = await JSZip.loadAsync(data);
+  const appXml = await zip.file('docProps/app.xml')?.async('string');
+  if (!appXml) {
+    throw new Error('docProps/app.xml missing from DOCX.');
+  }
+
+  const match = appXml.match(/<Pages>(\d+)<\/Pages>/);
+  if (!match) {
+    throw new Error('DOCX did not contain a <Pages> element.');
+  }
+
+  return Number.parseInt(match[1], 10);
+}


### PR DESCRIPTION
## Summary
- add a vitest that builds the latest résumé via tectonic/pandoc and asserts both outputs stay single-page
- download cached linux binaries when needed and reuse them across runs
- document the automated guard in docs/resume/README.md

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d62b2d7614832f9ca305ad07055471