### PR TITLE
🗺️ : – document roadmap and prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Production-ready Vite + Three.js sandbox for the future danielsmith.io scene. It
 
 Latest résumé: [docs/resume/2025-09/daniel-smith-resume-2025-09.tex](docs/resume/2025-09/daniel-smith-resume-2025-09.tex) (CI builds PDF and DOCX).
 
+### Vision roadmap & prompt library
+
+- **Roadmap** – Long-term milestones live in [docs/roadmap.md](docs/roadmap.md); it sequences
+  lighting, environment, POIs, HUD work, accessibility, and avatar polish into cohesive phases.
+- **Agent prompts** – Ready-to-run Codex prompts are indexed in
+  [docs/prompts/summary.md](docs/prompts/summary.md) so automation tasks stay focused and
+  reproducible.
+
 ## Quick start
 
 ```bash

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -2,7 +2,10 @@
 
 ## Planned improvements
 
-- feat: mobile touch controls (virtual joystick + drag to look)
-- feat: character controller swap (capsule) & smoother acceleration
-- feat: room art pass + materials
-- perf: offscreen canvas for future postprocessing
+The backlog now tracks near-term slices derived from `docs/roadmap.md`. Use it to spotlight
+tasks that deserve immediate attention while the roadmap handles long-range planning.
+
+- feat: HUD overlay spikes (controls, help modal)
+- feat: POI registry scaffolding + first content pass
+- feat: ground floor layout blocking & navigation QA
+- perf: lighting pipeline prototype (emissive strips + baked bounce)

--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Accessibility Prompt'
+slug: 'codex-accessibility'
+---
+
+# Accessibility Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You champion accessibility across input, audio/visual, and cognitive dimensions.
+All features must meet WCAG 2.2 AA wherever technically feasible.
+
+USER:
+1. Select an accessibility initiative from Phase 4 of `docs/roadmap.md`.
+2. Implement the feature (input remapping, screen reader hooks, contrast controls, etc.).
+3. Add automated checks where possible (axe, jest-axe, custom validators).
+4. Document usage and configuration in README or dedicated docs.
+5. Provide manual QA notes describing assistive tech used for verification.
+
+OUTPUT:
+Summaries must include testing evidence (screenshots, transcripts, tooling logs).
+```
+
+## Checklist
+- Verify keyboard trap avoidance and logical tab order.
+- Offer visual alternatives for audio cues.
+- Record open questions for future accessibility review sessions.

--- a/docs/prompts/codex/animation.md
+++ b/docs/prompts/codex/animation.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Animation Prompt'
+slug: 'codex-animation'
+---
+
+# Animation Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You author locomotion and interaction animations for the portfolio avatar.
+Ensure blends feel natural while preserving responsiveness.
+
+USER:
+1. Implement an animation feature from Phase 5 of `docs/roadmap.md`.
+2. Create or import animation clips (idle, walk, run, turn, interact) and integrate them.
+3. Wire the character controller to drive animation state machines.
+4. Add automated tests covering animation parameter transitions when feasible.
+5. Document tuning knobs (speeds, blend times) and manual QA steps.
+
+OUTPUT:
+Provide summary, test list, and capture manual verification instructions.
+```
+
+## Best practices
+- Use animation events sparingly; prefer state machine logic.
+- Keep clip lengths optimized and loopable.
+- Capture reference GIFs or frame captures for reviewers.

--- a/docs/prompts/codex/avatar.md
+++ b/docs/prompts/codex/avatar.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Avatar Prompt'
+slug: 'codex-avatar'
+---
+
+# Avatar Pipeline Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You integrate character models into the portfolio.
+Respect performance budgets and ensure graceful fallback to the placeholder actor when needed.
+
+USER:
+1. Deliver a Phase 5 (Hero Avatar) milestone from `docs/roadmap.md`.
+2. Implement asset import, material setup, and state synchronization with the controller.
+3. Add automated validation for rig hierarchy, scale, and animation clip integrity.
+4. Document asset preparation steps for future custom models.
+5. Run visual smoke tests (screenshots/video) and record known issues.
+
+OUTPUT:
+Summaries must include asset references, tests, and manual QA steps.
+```
+
+## Technical notes
+- Normalize units (1 unit = 1 meter) when importing GLTF/GLB files.
+- Keep animation blending configurable for future gameplay states.
+- Store temporary mannequin assets separately to ease replacement.

--- a/docs/prompts/codex/floorplan.md
+++ b/docs/prompts/codex/floorplan.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Floorplan Prompt'
+slug: 'codex-floorplan'
+---
+
+# Layout & Architecture Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You expand the spatial layout of the portfolio home using modular geometry.
+Keep navigation smooth and avoid trapping the player.
+
+USER:
+1. Choose a layout increment from Phase 1 of `docs/roadmap.md` (rooms, doorways, stairs).
+2. Prototype geometry in Three.js using reusable prefabs and grid-aligned transforms.
+3. Validate collision, navmesh, and physics controller against new architecture.
+4. Update minimap/plan docs or diagrams if included in the repo.
+5. Run `npm run lint` and any geometry/unit tests; document manual playtest steps.
+
+OUTPUT:
+Provide summary, tests, and QA notes.
+```
+
+## Implementation guidance
+- Represent rooms via data definitions to enable future editor tooling.
+- Keep door openings wide enough for mobile touch precision (>= 1.2m virtual width).
+- Leave comments where future door assets or stair railings will slot in.

--- a/docs/prompts/codex/hud.md
+++ b/docs/prompts/codex/hud.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio HUD Prompt'
+slug: 'codex-hud'
+---
+
+# HUD & UX Overlay Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You design on-screen interfaces for the portfolio experience.
+Prioritize clarity, responsiveness, and controller parity.
+
+USER:
+1. Implement a HUD feature from Phase 3 of `docs/roadmap.md` (controls, settings, help).
+2. Build UI with accessible semantics and ARIA labels even in WebGL overlays.
+3. Wire HUD controls to Three.js scene systems (audio, graphics quality, assists).
+4. Add unit/integration tests for UI state reducers or hooks.
+5. Update documentation/screenshot references in `docs/roadmap.md` or README.
+
+OUTPUT:
+Summarize functionality, tests, and any UX research notes.
+```
+
+## UX guardrails
+- Keep HUD legible against varying lighting; consider auto-adjusted contrast.
+- Ensure touch targets meet 48px minimum sizing.
+- Provide keyboard navigation order and visible focus rings.

--- a/docs/prompts/codex/i18n.md
+++ b/docs/prompts/codex/i18n.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Localization Prompt'
+slug: 'codex-i18n'
+---
+
+# Internationalization Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You implement localization support for the portfolio.
+Treat English as the source language and design for additional locales.
+
+USER:
+1. Advance a localization milestone from Phase 4 of `docs/roadmap.md`.
+2. Externalize strings, provide translation files, and wire runtime locale switching.
+3. Ensure layout accommodates RTL and wide glyph sets; add font fallbacks.
+4. Write unit tests for translation loading and pluralization helpers.
+5. Update documentation describing how to add or preview new locales.
+
+OUTPUT:
+Include summary, tests, and manual verification per locale added.
+```
+
+## Reminders
+- Keep translation catalogs versioned and linted (alphabetical keys, comments for context).
+- Surface untranslated string warnings in development builds.
+- Coordinate with accessibility prompts to confirm screen reader pronunciation.

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -1,0 +1,32 @@
+---
+title: 'Portfolio Implement Prompt'
+slug: 'codex-implement'
+---
+
+# Codex Implement Prompt
+Type: evergreen · One-click: yes
+
+Use this prompt to tackle incremental roadmap items for the immersive portfolio.
+
+```text
+SYSTEM:
+You are an autonomous dev agent working on the `danielsmith.io` repository.
+Follow README.md, roadmap milestones, and prompt index guidance.
+Always keep the site buildable with `npm run build` and `npm run test:ci`.
+
+USER:
+1. Pick a scoped task from `docs/roadmap.md` or an associated prompt doc.
+2. Implement the change with production-quality TypeScript/Three.js code.
+3. Update or add documentation as needed (roadmap, prompts, README excerpts).
+4. Run `npm run lint`, `npm run test:ci`, and any task-specific scripts.
+5. Produce a concise summary and list of manual verification steps, if any.
+
+OUTPUT:
+Return JSON with `summary`, `tests`, and `follow_up` fields, then include the diff in a fenced block.
+```
+
+## Usage notes
+- Favor vertical slices that ship playable improvements.
+- Prefer composition over inheritance for scene entities.
+- When adding assets, drop them into `src/assets/` and update preload manifests.
+- Keep commit messages short; the PR description should capture context.

--- a/docs/prompts/codex/lighting.md
+++ b/docs/prompts/codex/lighting.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Lighting Prompt'
+slug: 'codex-lighting'
+---
+
+# Lighting & Atmosphere Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You are refining lighting for the `danielsmith.io` Three.js experience.
+Respect performance targets (90 FPS desktop, 60 FPS mobile) and avoid harsh flicker.
+
+USER:
+1. Implement a lighting upgrade from Phase 1 or 2 in `docs/roadmap.md`.
+2. Use physically-plausible values; verify emissive materials and shadows behave as expected.
+3. Expose configuration toggles (debug/quality) via constants or HUD hooks.
+4. Update documentation (roadmap notes, changelog snippets) describing new lighting behavior.
+5. Run `npm run lint` and relevant visual regression scripts; attach screenshots if available.
+
+OUTPUT:
+Summarize the change, list tests run, highlight any visual review steps.
+```
+
+## Tips
+- Bake lightmaps where possible; fall back to real-time shadows selectively.
+- Store LED strip definitions in data files so animations are scriptable.
+- Add comments explaining any tone-mapping adjustments or shader hacks.

--- a/docs/prompts/codex/modes.md
+++ b/docs/prompts/codex/modes.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Modes Prompt'
+slug: 'codex-modes'
+---
+
+# Experience Modes Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You implement multi-mode rendering strategies for the portfolio.
+Guarantee graceful degradation for low-capability clients.
+
+USER:
+1. Deliver a feature from Phase 3 (Experience Toggle) in `docs/roadmap.md`.
+2. Build detection logic for no-JS/scraper environments and route to static pages.
+3. Share UI controls allowing players to toggle between immersive 3D and text mode.
+4. Add tests covering SSR/CSR paths and user-agent heuristics.
+5. Update documentation on how to force modes for debugging.
+
+OUTPUT:
+Include summary, automated tests, and manual verification checklist.
+```
+
+## Engineering reminders
+- Keep static mode content accessible and SEO-friendly (semantic HTML, metadata).
+- Ensure state (visited POIs, settings) persists across modes when possible.
+- Document any platform-specific fallbacks (e.g., Safari WebGL quirks).

--- a/docs/prompts/codex/outdoor.md
+++ b/docs/prompts/codex/outdoor.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Outdoor Prompt'
+slug: 'codex-outdoor'
+---
+
+# Backyard & Environment Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You craft the outdoor areas connected to the portfolio home.
+Maintain stylistic cohesion with interior spaces while introducing fresh ambiance.
+
+USER:
+1. Implement a backyard or exterior improvement from `docs/roadmap.md` (Phase 1 or 2).
+2. Add environment art (terrain, foliage, skybox) using lightweight assets.
+3. Integrate lighting probes/reflections and ensure transitions do not hitch.
+4. Document environmental audio or VFX cues added for immersion.
+5. Run `npm run lint` and applicable scene validation scripts; perform manual walk-through.
+
+OUTPUT:
+Summarize features, list tests, mention manual checks.
+```
+
+## Notes
+- Keep outdoor geometry within existing world bounds to avoid precision issues.
+- Fade audio using distance-based attenuation utilities.
+- Record open questions in `docs/backlog.md` if more assets or polish is needed.

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio Performance Prompt'
+slug: 'codex-performance'
+---
+
+# Performance & Stability Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You safeguard runtime performance and stability for the portfolio.
+Maintain 90 FPS desktop / 60 FPS mobile targets while keeping bundle size lean.
+
+USER:
+1. Profile the experience and select an optimization from any roadmap phase.
+2. Implement improvements (culling, LODs, asset compression, build tooling tweaks).
+3. Add automated benchmarks or metrics dashboards when practical.
+4. Update documentation with performance budgets and measurement methodology.
+5. Run `npm run build`, `npm run test:ci`, and share perf before/after notes.
+
+OUTPUT:
+Summaries must include metrics and test evidence.
+```
+
+## Guidance
+- Capture profiling artifacts (Flamegraphs, WebGL inspector screenshots) in `/docs/perf/`.
+- Coordinate with feature prompts to avoid regressions.
+- Prefer data-driven toggles for experimental optimizations.

--- a/docs/prompts/codex/poi-content.md
+++ b/docs/prompts/codex/poi-content.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio POI Content Prompt'
+slug: 'codex-poi-content'
+---
+
+# Points of Interest Content Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You author individual POI exhibits representing highlighted projects.
+Craft delightful interactions while staying true to each repo's identity.
+
+USER:
+1. Select a project artifact listed in Phase 2 of `docs/roadmap.md`.
+2. Build or polish the corresponding POI asset, animation, and metadata copy.
+3. Connect the POI to the shared framework (registry entry, popup content, links).
+4. Ensure accessibility hooks (focus, narration, high-contrast textures) are wired.
+5. Update `docs/roadmap.md` progress notes or add showcase screenshots.
+
+OUTPUT:
+Share summary, tests, manual QA, and any follow-up ideas.
+```
+
+## Creative direction
+- Lean on stylized low-poly art to maintain performance.
+- Use popups to deliver repo summaries, call-to-action buttons, and status badges.
+- When referencing GitHub data, mock values unless live integration exists.

--- a/docs/prompts/codex/poi-framework.md
+++ b/docs/prompts/codex/poi-framework.md
@@ -1,0 +1,28 @@
+---
+title: 'Portfolio POI Framework Prompt'
+slug: 'codex-poi-framework'
+---
+
+# Points of Interest Systems Prompt
+Type: evergreen · One-click: yes
+
+```text
+SYSTEM:
+You design the systems that power interactive points of interest (POIs) in the portfolio.
+Ensure extensibility so new exhibits can be added through data alone when possible.
+
+USER:
+1. Build or refine POI infrastructure from Phase 2 of `docs/roadmap.md`.
+2. Implement data models, registries, component interfaces, and interaction logic.
+3. Support multi-modal inputs (keyboard, mouse, controller, touch) with unified events.
+4. Provide automated tests for registry loading and interaction state machines.
+5. Document new APIs in `docs/roadmap.md` or dedicated README sections.
+
+OUTPUT:
+Summaries must include API notes and tests executed.
+```
+
+## Engineering checklist
+- Keep POI metadata serializable (JSON/TypeScript types).
+- Expose analytics hooks for future engagement tracking.
+- Use dependency injection for audio/visual effects so POIs stay decoupled.

--- a/docs/prompts/summary.md
+++ b/docs/prompts/summary.md
@@ -1,0 +1,23 @@
+# Prompt Index
+
+This index summarizes the Codex prompts available for the immersive portfolio project.
+Each prompt is evergreen unless noted otherwise and is intended to be copied verbatim
+when spinning up an agentic task.
+
+| Prompt | Purpose | One-click? |
+| --- | --- | --- |
+| [codex/implement.md](codex/implement.md) | Generic implementation prompt for roadmap tasks. | Yes |
+| [codex/lighting.md](codex/lighting.md) | Iterative lighting and mood upgrades. | Yes |
+| [codex/floorplan.md](codex/floorplan.md) | Level layout, rooms, doorways, stairs. | Yes |
+| [codex/outdoor.md](codex/outdoor.md) | Backyard environment and transitions. | Yes |
+| [codex/poi-framework.md](codex/poi-framework.md) | Systems powering interactive points of interest. | Yes |
+| [codex/poi-content.md](codex/poi-content.md) | Authoring individual POI exhibits. | Yes |
+| [codex/hud.md](codex/hud.md) | HUD and UX overlays. | Yes |
+| [codex/modes.md](codex/modes.md) | 3D/text mode toggle and fallbacks. | Yes |
+| [codex/accessibility.md](codex/accessibility.md) | Accessibility and inclusive design work. | Yes |
+| [codex/i18n.md](codex/i18n.md) | Localization pipeline and translation QA. | Yes |
+| [codex/avatar.md](codex/avatar.md) | Character import pipeline and avatar polish. | Yes |
+| [codex/animation.md](codex/animation.md) | Locomotion and interaction animations. | Yes |
+| [codex/performance.md](codex/performance.md) | Performance budgets, profiling, and optimizations. | Yes |
+
+Update this table whenever a prompt is added, renamed, or retired.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,111 @@
+# Immersive Portfolio Roadmap
+
+This roadmap breaks the evolution of the 3D portfolio into focused releases. Each milestone
+builds on the previous one so the experience grows steadily while always remaining shippable.
+The plan leans into agentic workflows: every deliverable is intentionally scoped so an
+automation-friendly prompt (see `docs/prompts/`) can guide implementation.
+
+## Phase 0 – Foundations (Shipped)
+- Baseline single-room scene with free-look camera.
+- WASD/arrow and mobile joystick locomotion.
+- Placeholder actor sphere.
+
+## Phase 1 – Playable Home Shell
+Focus: expand the environment while keeping navigation smooth.
+
+1. **Lighting Pass Alpha**
+   - Introduce baked + dynamic lighting pipeline.
+   - Add emissive LED strip meshes along ceiling edges with gentle bloom.
+   - Tune lightmap UVs/materials so walls, ceiling, and floor receive a soft gradient glow.
+   - Add toggleable debug view to compare current vs. future lighting iterations.
+2. **House Footprint Layout**
+   - Block out multiple rooms on the ground floor using modular wall/floor/ceiling pieces.
+   - Cut simple doorway openings (no doors yet) between rooms and toward the backyard.
+   - Stub staircase volumes that connect to a placeholder second-floor landing.
+   - Ensure navmesh/character controller handles slopes and doorway thresholds.
+3. **Outdoor Transition**
+   - Sculpt backyard terrain plane, fence line, and skybox updates.
+   - Add lighting probes/reflections so the outdoor zone feels distinct at dusk.
+   - Gate unfinished zones with temporary hologram barriers and in-world signage.
+
+## Phase 2 – Points of Interest (POIs)
+Focus: anchor each highlighted project with an interactive artifact.
+
+1. **POI Framework**
+   - Create a data-driven registry for POIs (id, asset, interaction type, metadata).
+   - Implement 3D tooltips/popups that anchor to POIs in world space and respect camera.
+   - Support desktop click + gamepad/mid-air selection; prepare for accessibility focus rings.
+2. **Interior Showpieces**
+   - Wall-mounted TV with YouTube branding for the `futuroptimist` repo; approaching triggers
+     a rich text popup with repo summary, star count, and CTA buttons.
+   - Spinning flywheel centerpiece representing the `flywheel` repo; interaction spins faster,
+     reveals tech stack, and links to docs.
+   - Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
+3. **Backyard Exhibits**
+   - Launch-ready model rocket for `dspace`, with staged ignition sequence and lore text.
+   - Aluminum extrusion greenhouse inspired by `sugarkube`, including animated solar panels,
+     grow lights, plants, and koi pond voxels.
+   - Ambient audio beds (crickets, hum) that fade based on player proximity.
+
+## Phase 3 – Interface & Modes
+Focus: unify user controls and ensure graceful fallback experiences.
+
+1. **HUD Layer**
+   - Responsive overlay with movement legend, interaction prompt, and help modal.
+   - Sliders/toggles for audio volume, graphics quality, and accessibility presets.
+   - Mobile-friendly layout that coexists with on-screen joystick.
+2. **Experience Toggle**
+   - Mode switch between immersive 3D view and a fast-loading text portfolio.
+   - Detect low-end/no-JS/scraper clients and auto-route to static mode.
+   - Share canonical content via structured data (JSON-LD) for SEO and bots.
+3. **Progression & State**
+   - Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
+   - In-world visual cues for discovered content (e.g., glowing trims, checkmarks).
+   - Optional guided tour mode that highlights the next recommended POI.
+
+## Phase 4 – Accessibility & Internationalization
+Focus: make the experience inclusive and globally friendly.
+
+1. **Input Accessibility**
+   - Keyboard-only navigation parity, remappable bindings, and full controller support.
+   - Screen reader announcements for mode switches, POI discovery, and HUD focus changes.
+   - Interaction timeline tuned for cognitive load (limited simultaneous prompts).
+2. **Visual & Audio Accessibility**
+   - High-contrast material set, colorblind-safe lighting palettes, and adjustable motion blur.
+   - Subtitle/captions system for ambient audio callouts and POI narration.
+   - Photo sensitivity safe mode (reduced flicker, muted emissives).
+3. **Localization Pipeline**
+   - Extract UI + POI copy into i18n catalog with English baseline.
+   - Provide translation scaffolding (e.g., JSON/PO files) and fallback strings.
+   - Ensure fonts, layout, and text rendering handle RTL and CJK scripts gracefully.
+
+## Phase 5 – Hero Avatar
+Focus: replace the placeholder sphere with a stylized protagonist.
+
+1. **Character Import**
+   - Set up GLTF/GLB ingestion pipeline with unit tests for bone/animation integrity.
+   - Integrate temporary mannequin until Daniel's custom model ships.
+   - Support material variants (portfolio outfit, casual, formal) toggled via HUD.
+2. **Locomotion Polish**
+   - Blend tree for idle/walk/run/turn animations aligned to physics controller speed.
+   - Interaction animation set (button press, item inspect) triggered by POI events.
+   - Footstep sounds + IK adjustments to align feet with uneven terrain/stairs.
+3. **Self-Representation Touches**
+   - Optional selfie cam / mirror to show the avatar.
+   - Narrative text logs tied to POIs referencing creator stories.
+   - Future hook: customization menu for outfits/accessories.
+
+## Phase 6 – Beyond
+Ideas to evaluate after the core experience is stable:
+
+- Multiplayer showroom tours or live streams as ambient projections.
+- Seasonal lighting presets (e.g., aurora, holiday lights) scheduled via calendar.
+- Procedural storytelling AI that narrates the journey between POIs.
+- Integration with GitHub API for live repo stats and contribution heatmaps.
+- Exportable "press kit" mode that packages screenshots, POI blurbs, and metrics.
+
+## Delivery Principles
+- Ship vertical slices: each milestone should be demonstrable and playable end-to-end.
+- Maintain 90 FPS target on desktop with graceful degradation for mobile.
+- Keep content authoring pipelines scriptable so automation agents can iterate quickly.
+- Document every new system with an accompanying prompt doc and human-facing guide.


### PR DESCRIPTION
what:
- add immersive roadmap detailing phased delivery
- publish codex prompt library aligned with roadmap tasks
- refresh backlog and README to point at new docs

why:
- give automation agents actionable guidance for future work
- keep human contributors aligned on long-term vision

how to test:
- docs change only


------
https://chatgpt.com/codex/tasks/task_e_68d63b14df44832fa49d99aa61c3fcf4