### PR TITLE
Add upgrade prompt block to Codex prompt docs

### DIFF
--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -28,3 +28,26 @@ Summaries must include testing evidence (screenshots, transcripts, tooling logs)
 - Verify keyboard trap avoidance and logical tab order.
 - Offer visual alternatives for audio cues.
 - Record open questions for future accessibility review sessions.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/animation.md
+++ b/docs/prompts/codex/animation.md
@@ -28,3 +28,26 @@ Provide summary, test list, and capture manual verification instructions.
 - Use animation events sparingly; prefer state machine logic.
 - Keep clip lengths optimized and loopable.
 - Capture reference GIFs or frame captures for reviewers.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -71,21 +71,22 @@ immediately actionable.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine Flywheel's own prompt documentation.
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
 
 ```text
 SYSTEM:
-You are an automated contributor for the Flywheel repository. Follow `AGENTS.md` and `README.md`. Ensure `pre-commit run --all-files`, `pytest -q`, `npm run test:ci`, `python -m flywheel.fit`, and `bash scripts/checks.sh` pass before committing. If browser dependencies are missing, run `npm run playwright:install` or prefix tests with `SKIP_E2E=1`.
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
 
 USER:
-1. Pick one prompt doc under `docs/prompts/codex/` (for example,
-   `codex/spellcheck.md`).
-2. Fix outdated instructions, links or formatting.
-3. Regenerate `docs/prompt-docs-summary.md` with
-   `python scripts/update_prompt_docs_summary.py --repos-from \
-   dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`.
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
 4. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
+

--- a/docs/prompts/codex/avatar.md
+++ b/docs/prompts/codex/avatar.md
@@ -28,3 +28,26 @@ Summaries must include asset references, tests, and manual QA steps.
 - Normalize units (1 unit = 1 meter) when importing GLTF/GLB files.
 - Keep animation blending configurable for future gameplay states.
 - Store temporary mannequin assets separately to ease replacement.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/floorplan.md
+++ b/docs/prompts/codex/floorplan.md
@@ -28,3 +28,26 @@ Provide summary, tests, and QA notes.
 - Represent rooms via data definitions to enable future editor tooling.
 - Keep door openings wide enough for mobile touch precision (>= 1.2m virtual width).
 - Leave comments where future door assets or stair railings will slot in.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/hud.md
+++ b/docs/prompts/codex/hud.md
@@ -28,3 +28,26 @@ Summarize functionality, tests, and any UX research notes.
 - Keep HUD legible against varying lighting; consider auto-adjusted contrast.
 - Ensure touch targets meet 48px minimum sizing.
 - Provide keyboard navigation order and visible focus rings.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/i18n.md
+++ b/docs/prompts/codex/i18n.md
@@ -28,3 +28,26 @@ Include summary, tests, and manual verification per locale added.
 - Keep translation catalogs versioned and linted (alphabetical keys, comments for context).
 - Surface untranslated string warnings in development builds.
 - Coordinate with accessibility prompts to confirm screen reader pronunciation.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -32,3 +32,26 @@ Return JSON with `summary`, `tests`, and `follow_up` fields, then include the di
 - Prefer composition over inheritance for scene entities.
 - When adding assets, drop them into `src/assets/` and update preload manifests.
 - Keep commit messages short; the PR description should capture context.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/lighting.md
+++ b/docs/prompts/codex/lighting.md
@@ -28,3 +28,26 @@ Summarize the change, list tests run, highlight any visual review steps.
 - Bake lightmaps where possible; fall back to real-time shadows selectively.
 - Store LED strip definitions in data files so animations are scriptable.
 - Add comments explaining any tone-mapping adjustments or shader hacks.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/modes.md
+++ b/docs/prompts/codex/modes.md
@@ -28,3 +28,26 @@ Include summary, automated tests, and manual verification checklist.
 - Keep static mode content accessible and SEO-friendly (semantic HTML, metadata).
 - Ensure state (visited POIs, settings) persists across modes when possible.
 - Document any platform-specific fallbacks (e.g., Safari WebGL quirks).
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/outdoor.md
+++ b/docs/prompts/codex/outdoor.md
@@ -28,3 +28,26 @@ Summarize features, list tests, mention manual checks.
 - Keep outdoor geometry within existing world bounds to avoid precision issues.
 - Fade audio using distance-based attenuation utilities.
 - Record open questions in `docs/backlog.md` if more assets or polish is needed.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -28,3 +28,26 @@ Summaries must include metrics and test evidence.
 - Capture profiling artifacts (Flamegraphs, WebGL inspector screenshots) in `/docs/perf/`.
 - Coordinate with feature prompts to avoid regressions.
 - Prefer data-driven toggles for experimental optimizations.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/poi-content.md
+++ b/docs/prompts/codex/poi-content.md
@@ -28,3 +28,26 @@ Share summary, tests, manual QA, and any follow-up ideas.
 - Lean on stylized low-poly art to maintain performance.
 - Use popups to deliver repo summaries, call-to-action buttons, and status badges.
 - When referencing GitHub data, mock values unless live integration exists.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+

--- a/docs/prompts/codex/poi-framework.md
+++ b/docs/prompts/codex/poi-framework.md
@@ -28,3 +28,26 @@ Summaries must include API notes and tests executed.
 - Keep POI metadata serializable (JSON/TypeScript types).
 - Expose analytics hooks for future engagement tracking.
 - Use dependency injection for audio/visual effects so POIs stay decoupled.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine danielsmith.io's Codex prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the danielsmith.io repository.
+Follow README.md for repository conventions.
+Ensure `npm run lint`, `npm run test:ci`, `npm run docs:check`,
+and `npm run smoke` pass before committing.
+
+USER:
+1. Pick one prompt doc under `docs/prompts/codex/`.
+2. Fix outdated instructions, links, or formatting.
+3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```
+


### PR DESCRIPTION
what: Added shared upgrade prompt section to each Codex doc.
why: Provide consistent guidance for maintaining prompt docs.
how to test: Docs only change; no automated tests run.


------
https://chatgpt.com/codex/tasks/task_e_68d6443c2bf4832faf750d4135a59380