### PR TITLE
Fix Prettier drift in docs and lighting setup

### DIFF
--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -30,6 +30,7 @@ Summaries must include testing evidence (screenshots, transcripts, tooling logs)
 - Record open questions for future accessibility review sessions.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/animation.md
+++ b/docs/prompts/codex/animation.md
@@ -30,6 +30,7 @@ Provide summary, test list, and capture manual verification instructions.
 - Capture reference GIFs or frame captures for reviewers.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/avatar.md
+++ b/docs/prompts/codex/avatar.md
@@ -30,6 +30,7 @@ Summaries must include asset references, tests, and manual QA steps.
 - Store temporary mannequin assets separately to ease replacement.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/floorplan.md
+++ b/docs/prompts/codex/floorplan.md
@@ -30,6 +30,7 @@ Provide summary, tests, and QA notes.
 - Leave comments where future door assets or stair railings will slot in.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/hud.md
+++ b/docs/prompts/codex/hud.md
@@ -30,6 +30,7 @@ Summarize functionality, tests, and any UX research notes.
 - Provide keyboard navigation order and visible focus rings.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/i18n.md
+++ b/docs/prompts/codex/i18n.md
@@ -30,6 +30,7 @@ Include summary, tests, and manual verification per locale added.
 - Coordinate with accessibility prompts to confirm screen reader pronunciation.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -34,6 +34,7 @@ Return JSON with `summary`, `tests`, and `follow_up` fields, then include the di
 - Keep commit messages short; the PR description should capture context.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -54,4 +55,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/lighting.md
+++ b/docs/prompts/codex/lighting.md
@@ -30,6 +30,7 @@ Summarize the change, list tests run, highlight any visual review steps.
 - Add comments explaining any tone-mapping adjustments or shader hacks.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/modes.md
+++ b/docs/prompts/codex/modes.md
@@ -30,6 +30,7 @@ Include summary, automated tests, and manual verification checklist.
 - Document any platform-specific fallbacks (e.g., Safari WebGL quirks).
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/outdoor.md
+++ b/docs/prompts/codex/outdoor.md
@@ -30,6 +30,7 @@ Summarize features, list tests, mention manual checks.
 - Record open questions in `docs/backlog.md` if more assets or polish is needed.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -30,6 +30,7 @@ Summaries must include metrics and test evidence.
 - Prefer data-driven toggles for experimental optimizations.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/poi-content.md
+++ b/docs/prompts/codex/poi-content.md
@@ -30,6 +30,7 @@ Share summary, tests, manual QA, and any follow-up ideas.
 - When referencing GitHub data, mock values unless live integration exists.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/prompts/codex/poi-framework.md
+++ b/docs/prompts/codex/poi-framework.md
@@ -30,6 +30,7 @@ Summaries must include API notes and tests executed.
 - Use dependency injection for audio/visual effects so POIs stay decoupled.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt to refine danielsmith.io's Codex prompt documentation.
@@ -50,4 +51,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,14 +7,14 @@ automation-friendly prompt (see `docs/prompts/`) can guide implementation.
 
 ## Delivery scoreboard
 
-| Phase | Status | Demo | Key metrics |
-| --- | --- | --- | --- |
-| 0 | ✅ Shipped | – | Baseline scene boots in <2s; bundle 1.1 MB gz. |
-| 1 | 🚧 In progress | _(tag after slice)_ | Target: p95 FPS ≥90 desktop / ≥60 Pixel 6; LCP <2.5s. |
-| 2 | 🗓️ Next | _(tag after slice)_ | Target: ≥3 POIs w/ KPI impact notes + tooltips axe clean. |
-| 3 | 🗓️ Next | _(tag after slice)_ | Target: text fallback TTI <1.5s; HUD fully keyboardable. |
-| 4 | 🗓️ Next | _(tag after slice)_ | Target: axe CI 0 critical; locale switch en+rtl. |
-| 5 | 🗓️ Next | _(tag after slice)_ | Target: avatar swap ≤5% FPS regression; animation qa. |
+| Phase | Status         | Demo                | Key metrics                                               |
+| ----- | -------------- | ------------------- | --------------------------------------------------------- |
+| 0     | ✅ Shipped     | –                   | Baseline scene boots in <2s; bundle 1.1 MB gz.            |
+| 1     | 🚧 In progress | _(tag after slice)_ | Target: p95 FPS ≥90 desktop / ≥60 Pixel 6; LCP <2.5s.     |
+| 2     | 🗓️ Next        | _(tag after slice)_ | Target: ≥3 POIs w/ KPI impact notes + tooltips axe clean. |
+| 3     | 🗓️ Next        | _(tag after slice)_ | Target: text fallback TTI <1.5s; HUD fully keyboardable.  |
+| 4     | 🗓️ Next        | _(tag after slice)_ | Target: axe CI 0 critical; locale switch en+rtl.          |
+| 5     | 🗓️ Next        | _(tag after slice)_ | Target: avatar swap ≤5% FPS regression; animation qa.     |
 
 _Actions:_ cut a git tag + screenshot/GIF when each phase slices, update the table with a
 metrics snapshot (Lighthouse CI, WebPageTest, telemetry). Numbers are privacy-respecting lab

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,20 +109,36 @@ if (LIGHTING_OPTIONS.enableLedStrips) {
   }> = [
     {
       length: ROOM_HALF_WIDTH * 2 - 0.6,
-      position: new Vector3(0, ledHeight, ROOM_HALF_DEPTH - LED_STRIP_DEPTH / 2),
+      position: new Vector3(
+        0,
+        ledHeight,
+        ROOM_HALF_DEPTH - LED_STRIP_DEPTH / 2
+      ),
     },
     {
       length: ROOM_HALF_WIDTH * 2 - 0.6,
-      position: new Vector3(0, ledHeight, -ROOM_HALF_DEPTH + LED_STRIP_DEPTH / 2),
+      position: new Vector3(
+        0,
+        ledHeight,
+        -ROOM_HALF_DEPTH + LED_STRIP_DEPTH / 2
+      ),
     },
     {
       length: ROOM_HALF_DEPTH * 2 - 0.6,
-      position: new Vector3(ROOM_HALF_WIDTH - LED_STRIP_DEPTH / 2, ledHeight, 0),
+      position: new Vector3(
+        ROOM_HALF_WIDTH - LED_STRIP_DEPTH / 2,
+        ledHeight,
+        0
+      ),
       rotationY: Math.PI / 2,
     },
     {
       length: ROOM_HALF_DEPTH * 2 - 0.6,
-      position: new Vector3(-ROOM_HALF_WIDTH + LED_STRIP_DEPTH / 2, ledHeight, 0),
+      position: new Vector3(
+        -ROOM_HALF_WIDTH + LED_STRIP_DEPTH / 2,
+        ledHeight,
+        0
+      ),
       rotationY: Math.PI / 2,
     },
   ];
@@ -148,9 +164,21 @@ if (LIGHTING_OPTIONS.enableLedStrips) {
   const ledLightDistance = Math.max(ROOM_HALF_WIDTH, ROOM_HALF_DEPTH) * 0.9;
   const cornerOffsets = [
     new Vector3(ROOM_HALF_WIDTH - 1.1, ledHeight - 0.1, ROOM_HALF_DEPTH - 1.1),
-    new Vector3(-(ROOM_HALF_WIDTH - 1.1), ledHeight - 0.1, ROOM_HALF_DEPTH - 1.1),
-    new Vector3(ROOM_HALF_WIDTH - 1.1, ledHeight - 0.1, -(ROOM_HALF_DEPTH - 1.1)),
-    new Vector3(-(ROOM_HALF_WIDTH - 1.1), ledHeight - 0.1, -(ROOM_HALF_DEPTH - 1.1)),
+    new Vector3(
+      -(ROOM_HALF_WIDTH - 1.1),
+      ledHeight - 0.1,
+      ROOM_HALF_DEPTH - 1.1
+    ),
+    new Vector3(
+      ROOM_HALF_WIDTH - 1.1,
+      ledHeight - 0.1,
+      -(ROOM_HALF_DEPTH - 1.1)
+    ),
+    new Vector3(
+      -(ROOM_HALF_WIDTH - 1.1),
+      ledHeight - 0.1,
+      -(ROOM_HALF_DEPTH - 1.1)
+    ),
   ];
 
   cornerOffsets.forEach((offset) => {


### PR DESCRIPTION
what: restore prettier formatting across codex docs and led setup.
why: lint workflow flagged formatting regressions on main.
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d70695e31c832f986dce54f14ef5db