### PR TITLE
Align resume artifact step naming

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -26,11 +26,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y texlive-full latexmk pandoc
 
-      - name: Build PDF with latexmk
+      - name: Generate PDF with latexmk
         run: |
           latexmk -pdf -interaction=nonstopmode docs/resume/2025-09/daniel-smith-resume-2025-09.tex
 
-      - name: Convert LaTeX to DOCX
+      - name: Generate DOCX with pandoc
         run: |
           pandoc docs/resume/2025-09/daniel-smith-resume-2025-09.tex -o docs/resume/2025-09/daniel-smith-resume-2025-09.docx
 


### PR DESCRIPTION
what: Update resume workflow to use consistent build step labels.
why: Keep PDF and DOCX artifact generation steps aligned.
how to test: Inspect the GitHub Actions job step names.


------
https://chatgpt.com/codex/tasks/task_e_68d7193970a8832fa3490f34b7e78bf2