### PR TITLE
Fix resume PDF artifacts from forced LaTeX breaks

### DIFF
--- a/docs/resume/2025-09/resume.tex
+++ b/docs/resume/2025-09/resume.tex
@@ -21,9 +21,9 @@
 
 \vspace{-2mm}
 \section*{Summary}
-Site Reliability Engineer with 6+ years at YouTube (Google) delivering planet-scale reliability\%
-through automation, observability, and on-call leadership. Builder of developer platforms and\%
-AI-assisted tooling (flywheel, jobbot3000, sugarkube) that help teams ship safer software faster\%
+Site Reliability Engineer with 6+ years at YouTube (Google) delivering planet-scale reliability
+through automation, observability, and on-call leadership. Builder of developer platforms and
+AI-assisted tooling (flywheel, jobbot3000, sugarkube) that help teams ship safer software faster
 across consumer, enterprise, and startup environments.
 
 \vspace{-2mm}
@@ -60,23 +60,23 @@ across consumer, enterprise, and startup environments.
 \vspace{-2mm}
 \section*{Selected Open Source \& Personal Projects}
 \begin{itemize}
-  \item \textbf{\href{https://github.com/democratizedspace/dspace/tree/v3}{DSPACE}} — Retro-futurist text sim\%
+  \item \textbf{\href{https://github.com/democratizedspace/dspace/tree/v3}{DSPACE}} — Retro-futurist text sim
 live since 2022; offline-first quests teach real-world hobbies.
-  \item \textbf{\href{https://token.place}{token.place}} — Peer-to-peer generative AI mesh where\%
+  \item \textbf{\href{https://token.place}{token.place}} — Peer-to-peer generative AI mesh where
 encrypted compute tokens let volunteers share GPUs safely.
-  \item \textbf{\href{https://github.com/futuroptimist/gabriel}{gabriel}} — Privacy-first guardian-angel\%
+  \item \textbf{\href{https://github.com/futuroptimist/gabriel}{gabriel}} — Privacy-first guardian-angel
 LLM delivering local security coaching and incident triage.
-  \item \textbf{\href{https://github.com/futuroptimist/flywheel}{flywheel}} — GitHub template bundling\%
+  \item \textbf{\href{https://github.com/futuroptimist/flywheel}{flywheel}} — GitHub template bundling
 CI/tests/docs and \textbf{prompt docs}; cross-repo index in \texttt{docs/prompt-docs-summary.md}.
-  \item \textbf{\href{https://github.com/futuroptimist/sigma}{sigma}} — ESP32 AI pin with on-device\%
+  \item \textbf{\href{https://github.com/futuroptimist/sigma}{sigma}} — ESP32 AI pin with on-device
 speech, LLM, and TTS inside a 3D-printed wearable.
-  \item \textbf{\href{https://github.com/futuroptimist/f2clipboard}{f2clipboard}} — CLI that parses Codex\%
+  \item \textbf{\href{https://github.com/futuroptimist/f2clipboard}{f2clipboard}} — CLI that parses Codex
 tasks and GitHub logs to ship concise debugging reports.
-  \item \textbf{\href{https://github.com/futuroptimist/danielsmith.io}{danielsmith.io}} — Interactive\%
+  \item \textbf{\href{https://github.com/futuroptimist/danielsmith.io}{danielsmith.io}} — Interactive
 Three.js/WebGL portfolio (orthographic scene; keyboard navigation) with text-only fallback.
-  \item \textbf{\href{https://github.com/futuroptimist/jobbot3000}{jobbot3000}} — Resume and interview-prep\%
+  \item \textbf{\href{https://github.com/futuroptimist/jobbot3000}{jobbot3000}} — Resume and interview-prep
 pipeline (LLM-assisted prompts, templating, checklists).
-  \item \textbf{\href{https://github.com/futuroptimist/sugarkube}{sugarkube}} — k3s plus Cloudflare-tunnel\%
+  \item \textbf{\href{https://github.com/futuroptimist/sugarkube}{sugarkube}} — k3s plus Cloudflare-tunnel
 hosting for personal sites; Raspberry Pi-friendly, outage-resistant.
 \end{itemize}
 


### PR DESCRIPTION
what: remove forced \\% line breaks from resume summary/projects.
why: prevent stray glyph artifacts in generated PDF output.
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d72a897c48832fb111f23eb8c4a59c