### PR TITLE
🧰 : – Grant launch screenshot auto-commit perms

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,9 @@
   ],
   "settings": {
     "import/resolver": {
-      "typescript": true
+      "typescript": {
+        "project": ["tsconfig.json", "playwright/tsconfig.json"]
+      }
     }
   },
   "rules": {
@@ -36,6 +38,15 @@
       "files": ["src/tests/**/*.ts"],
       "env": {
         "node": true
+      }
+    },
+    {
+      "files": ["playwright.config.ts", "playwright/**/*.ts"],
+      "env": {
+        "node": true
+      },
+      "rules": {
+        "import/no-unresolved": "off"
       }
     }
   ]

--- a/.github/workflows/04-launch-screenshot.yml
+++ b/.github/workflows/04-launch-screenshot.yml
@@ -1,0 +1,76 @@
+name: Launch screenshot
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Capture launch screenshot
+        run: npm run screenshot
+
+      - name: Evaluate screenshot state
+        id: screenshot_state
+        run: |
+          set -euo pipefail
+          screenshot_path="docs/assets/game-launch.png"
+
+          if git ls-files --error-unmatch "$screenshot_path" >/dev/null 2>&1; then
+            tracked=true
+          else
+            tracked=false
+          fi
+
+          if [ -f "$screenshot_path" ]; then
+            if [ "$tracked" = "true" ]; then
+              if git diff --quiet -- "$screenshot_path"; then
+                changed=false
+              else
+                changed=true
+              fi
+            else
+              changed=true
+            fi
+          else
+            echo "Screenshot not found at $screenshot_path" >&2
+            exit 1
+          fi
+
+          echo "tracked=$tracked" >>"$GITHUB_OUTPUT"
+          echo "changed=$changed" >>"$GITHUB_OUTPUT"
+
+      - name: Upload screenshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: launch-screenshot
+          path: docs/assets/game-launch.png
+
+      - name: Commit refreshed screenshot
+        if: ${{ github.ref == 'refs/heads/main' && steps.screenshot_state.outputs.changed == 'true' }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: '📸 : – Refresh launch screenshot'
+          file_pattern: docs/assets/game-launch.png

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 dist-ssr
 *.log
 coverage
+test-results/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/danielsmith.io/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/danielsmith.io/actions/workflows/01-lint-format.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/danielsmith.io/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/danielsmith.io/actions/workflows/02-tests.yml)
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/danielsmith.io/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/danielsmith.io/actions/workflows/03-docs.yml)
+[![Launch screenshot](https://img.shields.io/github/actions/workflow/status/futuroptimist/danielsmith.io/.github/workflows/04-launch-screenshot.yml?label=launch%20screenshot)](https://github.com/futuroptimist/danielsmith.io/actions/workflows/04-launch-screenshot.yml)
 [![Floorplan Diagram](https://img.shields.io/github/actions/workflow/status/futuroptimist/danielsmith.io/.github/workflows/floorplan-diagram.yml?label=floorplan)](https://github.com/futuroptimist/danielsmith.io/actions/workflows/floorplan-diagram.yml)
 [![Resume](https://img.shields.io/github/actions/workflow/status/futuroptimist/danielsmith.io/.github/workflows/resume.yml?label=resume)](https://github.com/futuroptimist/danielsmith.io/actions/workflows/resume.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -12,6 +13,13 @@ The scene renders an orthographic isometric room with keyboard-driven sphere mov
 we can iterate on spatial UX while keeping repo hygiene tight. The project was originally
 bootstrapped from the [`flywheel`](https://github.com/futuroptimist/flywheel) template and
 keeps the familiar conventions while focusing purely on the web stack.
+
+## Launch state
+
+![Launch-ready room at initial load](docs/assets/game-launch.png)
+
+> The `Launch screenshot` workflow regenerates and auto-commits this asset after merges to
+> `main`, keeping the README image in sync without storing binaries in feature branches.
 
 ## Key resources
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "three": "^0.161.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.44.0",
         "@types/jszip": "^3.4.0",
         "@types/node": "^20.11.17",
         "@types/three": "^0.161.0",
@@ -896,6 +897,22 @@
       "license": "MIT",
       "dependencies": {
         "pako": "^1.0.10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5145,6 +5162,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --strictPort --port 5173",
+    "screenshot": "playwright test",
     "lint": "eslint . --ext .ts",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
@@ -38,6 +39,7 @@
     "tsx": "^4.7.0",
     "typescript": "~5.3.3",
     "vite": "^5.0.12",
-    "vitest": "^1.2.1"
+    "vitest": "^1.2.1",
+    "@playwright/test": "^1.44.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'playwright',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    viewport: { width: 1280, height: 720 },
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 5173',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/playwright/screenshot.spec.ts
+++ b/playwright/screenshot.spec.ts
@@ -1,0 +1,10 @@
+import { test } from '@playwright/test';
+const screenshotPath = 'docs/assets/game-launch.png';
+
+const WAIT_FOR_RENDER_MS = 2000;
+
+test('capture launch state screenshot', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(WAIT_FOR_RENDER_MS);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+});

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client", "node", "@playwright/test"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["./**/*.ts"]
+}

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Lightweight secret scanner for staged diffs.
+
+The script reads diff content from stdin and exits non-zero if high-risk
+credentials (AWS keys, generic secret markers, private keys) are detected.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from typing import Iterable
+
+PATTERNS: Iterable[tuple[str, re.Pattern[str]]] = (
+    ("AWS Access Key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("AWS Temporary Access Key", re.compile(r"ASIA[0-9A-Z]{16}")),
+    ("Google API Key", re.compile(r"AIza[0-9A-Za-z_-]{35}")),
+    (
+        "Generic Secret",
+        re.compile(r"(?i)(api|auth|secret|token|password)[^\n]{0,5}[:=][ \t]*['\"]?[A-Za-z0-9/_\-]{16,}"),
+    ),
+    ("Private Key Block", re.compile(r"-----BEGIN (?:RSA |DSA |EC )?PRIVATE KEY-----")),
+)
+
+
+def main() -> int:
+    diff = sys.stdin.read()
+    if not diff.strip():
+        return 0
+
+    findings: list[str] = []
+    for label, pattern in PATTERNS:
+        if pattern.search(diff):
+            findings.append(label)
+
+    if findings:
+        unique_labels = sorted(set(findings))
+        sys.stderr.write(
+            "Potential secret patterns detected: " + ", ".join(unique_labels) + "\n"
+        )
+        return 1
+
+    print("No high-risk secrets detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    exclude: [...configDefaults.exclude, 'playwright/**'],
     coverage: {
       enabled: false,
     },


### PR DESCRIPTION
what: allow the launch screenshot workflow to push refreshed assets by enabling contents: write and fetching full history
why: the auto-commit step fails on repositories with read-only workflow tokens, preventing screenshot updates
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d7892f743c832faf65c90440248695