### PR TITLE
docs: emphasize 100% patch coverage guidance

### DIFF
--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -16,8 +16,9 @@ USER:
 1. Select an accessibility initiative from Phase 4 of `docs/roadmap.md`.
 2. Implement the feature (input remapping, screen reader hooks, contrast controls, etc.).
 3. Add automated checks where possible (axe, jest-axe, custom validators).
-4. Document usage and configuration in README or dedicated docs.
-5. Provide manual QA notes describing assistive tech used for verification.
+4. Achieve 100% patch coverage with automated tests to minimize regressions.
+5. Document usage and configuration in README or dedicated docs.
+6. Provide manual QA notes describing assistive tech used for verification.
 
 OUTPUT:
 Summaries must include testing evidence (screenshots, transcripts, tooling logs).
@@ -45,8 +46,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/animation.md
+++ b/docs/prompts/codex/animation.md
@@ -16,7 +16,7 @@ USER:
 1. Implement an animation feature from Phase 5 of `docs/roadmap.md`.
 2. Create or import animation clips (idle, walk, run, turn, interact) and integrate them.
 3. Wire the character controller to drive animation state machines.
-4. Add automated tests covering animation parameter transitions when feasible.
+4. Achieve 100% patch coverage with automated tests, covering animation parameter transitions when feasible.
 5. Document tuning knobs (speeds, blend times) and manual QA steps.
 
 OUTPUT:
@@ -45,8 +45,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -36,7 +36,8 @@ REQUEST:
 1. Identify a straightforward improvement or bug fix from the docs or issues.
 2. Implement the change using the existing project style.
 3. Update documentation when needed.
-4. Run the commands listed above.
+4. Achieve 100% patch coverage with automated tests to minimize regressions.
+5. Run the commands listed above.
 
 ACCEPTANCE_CHECK:
 {"patch":"<unified diff>", "summary":"<80-char msg>", "tests_pass":true}
@@ -83,8 +84,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/avatar.md
+++ b/docs/prompts/codex/avatar.md
@@ -15,7 +15,7 @@ Respect performance budgets and ensure graceful fallback to the placeholder acto
 USER:
 1. Deliver a Phase 5 (Hero Avatar) milestone from `docs/roadmap.md`.
 2. Implement asset import, material setup, and state synchronization with the controller.
-3. Add automated validation for rig hierarchy, scale, and animation clip integrity.
+3. Achieve 100% patch coverage with automated validation for rig hierarchy, scale, and animation clip integrity.
 4. Document asset preparation steps for future custom models.
 5. Run visual smoke tests (screenshots/video) and record known issues.
 
@@ -45,8 +45,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/floorplan.md
+++ b/docs/prompts/codex/floorplan.md
@@ -16,8 +16,9 @@ USER:
 1. Choose a layout increment from Phase 1 of `docs/roadmap.md` (rooms, doorways, stairs).
 2. Prototype geometry in Three.js using reusable prefabs and grid-aligned transforms.
 3. Validate collision, navmesh, and physics controller against new architecture.
-4. Update minimap/plan docs or diagrams if included in the repo.
-5. Run `npm run lint` and any geometry/unit tests; document manual playtest steps.
+4. Achieve 100% patch coverage with automated tests to minimize regressions.
+5. Update minimap/plan docs or diagrams if included in the repo.
+6. Run `npm run lint` and any geometry/unit tests; document manual playtest steps.
 
 OUTPUT:
 Provide summary, tests, and QA notes.
@@ -45,8 +46,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/hud.md
+++ b/docs/prompts/codex/hud.md
@@ -16,7 +16,7 @@ USER:
 1. Implement a HUD feature from Phase 3 of `docs/roadmap.md` (controls, settings, help).
 2. Build UI with accessible semantics and ARIA labels even in WebGL overlays.
 3. Wire HUD controls to Three.js scene systems (audio, graphics quality, assists).
-4. Add unit/integration tests for UI state reducers or hooks.
+4. Achieve 100% patch coverage with unit/integration tests for UI state reducers or hooks.
 5. Update documentation/screenshot references in `docs/roadmap.md` or README.
 
 OUTPUT:
@@ -45,8 +45,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/i18n.md
+++ b/docs/prompts/codex/i18n.md
@@ -16,7 +16,7 @@ USER:
 1. Advance a localization milestone from Phase 4 of `docs/roadmap.md`.
 2. Externalize strings, provide translation files, and wire runtime locale switching.
 3. Ensure layout accommodates RTL and wide glyph sets; add font fallbacks.
-4. Write unit tests for translation loading and pluralization helpers.
+4. Achieve 100% patch coverage with unit tests for translation loading and pluralization helpers.
 5. Update documentation describing how to add or preview new locales.
 
 OUTPUT:
@@ -45,8 +45,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -19,8 +19,9 @@ USER:
 1. Pick a scoped task from `docs/roadmap.md` or an associated prompt doc.
 2. Implement the change with production-quality TypeScript/Three.js code.
 3. Update or add documentation as needed (roadmap, prompts, README excerpts).
-4. Run `npm run lint`, `npm run test:ci`, and any task-specific scripts.
-5. Produce a concise summary and list of manual verification steps, if any.
+4. Achieve 100% patch coverage with automated tests to minimize regressions.
+5. Run `npm run lint`, `npm run test:ci`, and any task-specific scripts.
+6. Produce a concise summary and list of manual verification steps, if any.
 
 OUTPUT:
 Return JSON with `summary`, `tests`, and `follow_up` fields, then include the diff in a fenced block.
@@ -49,8 +50,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/lighting.md
+++ b/docs/prompts/codex/lighting.md
@@ -16,8 +16,9 @@ USER:
 1. Implement a lighting upgrade from Phase 1 or 2 in `docs/roadmap.md`.
 2. Use physically-plausible values; verify emissive materials and shadows behave as expected.
 3. Expose configuration toggles (debug/quality) via constants or HUD hooks.
-4. Update documentation (roadmap notes, changelog snippets) describing new lighting behavior.
-5. Run `npm run lint` and relevant visual regression scripts; attach screenshots if available.
+4. Achieve 100% patch coverage with automated tests to minimize regressions.
+5. Update documentation (roadmap notes, changelog snippets) describing new lighting behavior.
+6. Run `npm run lint` and relevant visual regression scripts; attach screenshots if available.
 
 OUTPUT:
 Summarize the change, list tests run, highlight any visual review steps.
@@ -45,8 +46,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/modes.md
+++ b/docs/prompts/codex/modes.md
@@ -16,7 +16,7 @@ USER:
 1. Deliver a feature from Phase 3 (Experience Toggle) in `docs/roadmap.md`.
 2. Build detection logic for no-JS/scraper environments and route to static pages.
 3. Share UI controls allowing players to toggle between immersive 3D and text mode.
-4. Add tests covering SSR/CSR paths and user-agent heuristics.
+4. Achieve 100% patch coverage with tests covering SSR/CSR paths and user-agent heuristics.
 5. Update documentation on how to force modes for debugging.
 
 OUTPUT:
@@ -45,8 +45,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/outdoor.md
+++ b/docs/prompts/codex/outdoor.md
@@ -16,8 +16,9 @@ USER:
 1. Implement a backyard or exterior improvement from `docs/roadmap.md` (Phase 1 or 2).
 2. Add environment art (terrain, foliage, skybox) using lightweight assets.
 3. Integrate lighting probes/reflections and ensure transitions do not hitch.
-4. Document environmental audio or VFX cues added for immersion.
-5. Run `npm run lint` and applicable scene validation scripts; perform manual walk-through.
+4. Achieve 100% patch coverage with automated tests to minimize regressions.
+5. Document environmental audio or VFX cues added for immersion.
+6. Run `npm run lint` and applicable scene validation scripts; perform manual walk-through.
 
 OUTPUT:
 Summarize features, list tests, mention manual checks.
@@ -45,8 +46,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -16,8 +16,9 @@ USER:
 1. Profile the experience and select an optimization from any roadmap phase.
 2. Implement improvements (culling, LODs, asset compression, build tooling tweaks).
 3. Add automated benchmarks or metrics dashboards when practical.
-4. Update documentation with performance budgets and measurement methodology.
-5. Run `npm run build`, `npm run test:ci`, and share perf before/after notes.
+4. Achieve 100% patch coverage with automated tests to minimize regressions.
+5. Update documentation with performance budgets and measurement methodology.
+6. Run `npm run build`, `npm run test:ci`, and share perf before/after notes.
 
 OUTPUT:
 Summaries must include metrics and test evidence.
@@ -45,8 +46,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/poi-content.md
+++ b/docs/prompts/codex/poi-content.md
@@ -17,7 +17,8 @@ USER:
 2. Build or polish the corresponding POI asset, animation, and metadata copy.
 3. Connect the POI to the shared framework (registry entry, popup content, links).
 4. Ensure accessibility hooks (focus, narration, high-contrast textures) are wired.
-5. Update `docs/roadmap.md` progress notes or add showcase screenshots.
+5. Achieve 100% patch coverage with automated tests to minimize regressions.
+6. Update `docs/roadmap.md` progress notes or add showcase screenshots.
 
 OUTPUT:
 Share summary, tests, manual QA, and any follow-up ideas.
@@ -45,8 +46,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/codex/poi-framework.md
+++ b/docs/prompts/codex/poi-framework.md
@@ -16,7 +16,7 @@ USER:
 1. Build or refine POI infrastructure from Phase 2 of `docs/roadmap.md`.
 2. Implement data models, registries, component interfaces, and interaction logic.
 3. Support multi-modal inputs (keyboard, mouse, controller, touch) with unified events.
-4. Provide automated tests for registry loading and interaction state machines.
+4. Achieve 100% patch coverage with automated tests for registry loading and interaction state machines.
 5. Document new APIs in `docs/roadmap.md` or dedicated README sections.
 
 OUTPUT:
@@ -45,8 +45,9 @@ and `npm run smoke` pass before committing.
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/`.
 2. Fix outdated instructions, links, or formatting.
-3. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
-4. Run the checks above.
+3. Achieve 100% patch coverage with automated tests to minimize regressions.
+4. Update `docs/prompts/summary.md` if your edits change the prompt catalog.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts/summary.md
+++ b/docs/prompts/summary.md
@@ -2,7 +2,8 @@
 
 This index summarizes the Codex prompts available for the immersive portfolio project.
 Each prompt is evergreen unless noted otherwise and is intended to be copied verbatim
-when spinning up an agentic task.
+when spinning up an agentic task. Every prompt now explicitly directs agents to achieve
+100% patch coverage so regressions stay unlikely.
 
 | Prompt                                           | Purpose                                            | One-click? |
 | ------------------------------------------------ | -------------------------------------------------- | ---------- |


### PR DESCRIPTION
## Summary
- add 100% patch coverage requirement to each Codex prompt doc
- highlight coverage expectation in prompt index introduction

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d8e8476238832fa848067892a2c5cb