### PR TITLE
✨ : – unify POI pointer + keyboard input

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,7 +81,8 @@ Focus: anchor each highlighted project with an interactive artifact.
 1. **POI Framework**
    - Create a data-driven registry for POIs (id, asset, interaction type, metadata).
    - Implement 3D tooltips/popups that anchor to POIs in world space and respect camera.
-   - Support desktop click + gamepad/mid-air selection; prepare for accessibility focus rings.
+   - ✨ Unified focus state now supports desktop click + keyboard selection.
+     This paves the way for gamepad bindings and focus rings.
    - ⚙️ Data-driven registry now spawns holographic pedestals for Futuroptimist + Flywheel exhibits.
    - ✨ Pedestals fade in tooltips and halo guides as players enter their interaction radii.
    - ✅ Desktop pointer interaction manager highlights POIs and emits selection events.

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,11 +55,11 @@ import { getCameraRelativeMovementVector } from './movement/cameraRelativeMoveme
 import { PoiInteractionManager } from './poi/interactionManager';
 import { createPoiInstances, type PoiInstance } from './poi/markers';
 import { getPoiDefinitions } from './poi/registry';
-import { createLivingRoomMediaWall } from './structures/mediaWall';
 import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
 } from './structures/flywheel';
+import { createLivingRoomMediaWall } from './structures/mediaWall';
 import { createStaircase, type StaircaseConfig } from './structures/staircase';
 
 const CAMERA_SIZE = 20;

--- a/src/poi/keyboardNavigator.ts
+++ b/src/poi/keyboardNavigator.ts
@@ -1,0 +1,112 @@
+import type { PoiInteractionManager } from './interactionManager';
+import type { PoiInstance } from './markers';
+
+type KeydownTarget = Pick<EventTarget, 'addEventListener' | 'removeEventListener'>;
+
+export interface PoiKeyboardNavigatorOptions {
+  /**
+   * Event target to listen for keyboard input. Defaults to `window` when running in a browser.
+   */
+  eventTarget?: KeydownTarget;
+}
+
+export class PoiKeyboardNavigator {
+  private readonly poiInstances: PoiInstance[];
+  private readonly eventTarget?: KeydownTarget;
+  private readonly handleKeyDownBound: (event: KeyboardEvent) => void;
+  private focusIndex: number | null = null;
+  private active = false;
+
+  constructor(
+    private readonly manager: PoiInteractionManager,
+    poiInstances: PoiInstance[],
+    options: PoiKeyboardNavigatorOptions = {}
+  ) {
+    this.poiInstances = [...poiInstances];
+    this.eventTarget =
+      options.eventTarget ?? (typeof window !== 'undefined' ? (window as KeydownTarget) : undefined);
+    this.handleKeyDownBound = this.handleKeyDown.bind(this);
+  }
+
+  start() {
+    if (this.active || !this.eventTarget) {
+      return;
+    }
+    this.syncIndexWithManualFocus();
+    this.eventTarget.addEventListener('keydown', this.handleKeyDownBound as EventListener);
+    this.active = true;
+  }
+
+  dispose() {
+    if (!this.active || !this.eventTarget) {
+      return;
+    }
+    this.eventTarget.removeEventListener('keydown', this.handleKeyDownBound as EventListener);
+    this.active = false;
+  }
+
+  private handleKeyDown(event: KeyboardEvent) {
+    if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        this.advanceFocus(1, event);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        this.advanceFocus(-1, event);
+        break;
+      case 'Tab':
+        this.advanceFocus(event.shiftKey ? -1 : 1, event);
+        break;
+      case 'Enter':
+      case ' ': // Spacebar in modern browsers.
+      case 'Spacebar': // Legacy browsers may emit this string.
+      case 'Space':
+        this.activate(event);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private advanceFocus(direction: 1 | -1, event: KeyboardEvent) {
+    if (!this.poiInstances.length) {
+      return;
+    }
+    this.syncIndexWithManualFocus();
+    const count = this.poiInstances.length;
+    if (this.focusIndex === null) {
+      this.focusIndex = direction === 1 ? 0 : count - 1;
+    } else {
+      this.focusIndex = (this.focusIndex + direction + count) % count;
+    }
+    const instance = this.poiInstances[this.focusIndex];
+    if (this.manager.focusPoiById(instance.definition.id)) {
+      event.preventDefault();
+    }
+  }
+
+  private activate(event: KeyboardEvent) {
+    const definition = this.manager.activateFocusedPoi();
+    if (definition) {
+      this.syncIndexWithManualFocus();
+      event.preventDefault();
+    }
+  }
+
+  private syncIndexWithManualFocus() {
+    const manualFocus = this.manager.getManualFocus();
+    if (!manualFocus) {
+      this.focusIndex = null;
+      return;
+    }
+    const index = this.poiInstances.findIndex(
+      (poi) => poi.definition.id === manualFocus.id
+    );
+    this.focusIndex = index === -1 ? null : index;
+  }
+}


### PR DESCRIPTION
✨ : – unify POI pointer + keyboard input

what:
- add manual focus + programmatic activation to PoiInteractionManager
- introduce PoiKeyboardNavigator for keyboard traversal + tests
- document roadmap progress for unified input

why:
- extend POI framework toward multi-input access + accessibility

how to test:
- npm run lint
- npm run test:ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8eb0f3c60832fb95e5ecfc67ad3ea