### PR TITLE
🧹 : – Remove inaccurate star metric from POI overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ lightweight.
 - **Controls** – `KeyboardControls` listens for `keydown`/`keyup` using `event.key` strings (WASD + arrow keys) and feeds the movement loop, which clamps the player inside the room bounds.
 - **Points of Interest** – A data-driven registry spawns holographic pedestals with animated
   tooltips for featured repos. Proximity-based halos ease the labels in so players sense each
-  interaction radius without clutter. Metadata is authored in TypeScript so future automations can
-  extend exhibits by updating data alone.
+  interaction radius without clutter, and a DOM overlay mirrors the metadata so screen readers and
+  keyboard users receive the same context. Metadata is authored in TypeScript so future automations
+  can extend exhibits by updating data alone.
 - **Backlog** – Future scene work is tracked in [`docs/backlog.md`](docs/backlog.md).
 
 ## Controls

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,6 +87,8 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✨ Pedestals fade in tooltips and halo guides as players enter their interaction radii.
    - ✅ Desktop pointer interaction manager highlights POIs and emits selection events.
    - ✅ Analytics hooks emit hover and selection lifecycle events for instrumentation pipelines.
+   - ✅ Accessibility overlay mirrors POI metadata in HTML so screen readers capture
+     hover/selection state.
 2. **Interior Showpieces**
    - Wall-mounted TV with YouTube branding for the `futuroptimist` repo; approaching triggers
      a rich text popup with repo summary, star count, and CTA buttons.

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ import { createWindowPoiAnalytics } from './poi/analytics';
 import { PoiInteractionManager } from './poi/interactionManager';
 import { createPoiInstances, type PoiInstance } from './poi/markers';
 import { getPoiDefinitions } from './poi/registry';
+import { PoiTooltipOverlay } from './poi/tooltipOverlay';
 import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
@@ -1105,6 +1106,7 @@ builtPoiInstances.forEach((poi) => {
 });
 
 const poiAnalytics = createWindowPoiAnalytics();
+const poiTooltipOverlay = new PoiTooltipOverlay({ container });
 
 const flywheelPoi = poiInstances.find(
   (poi) => poi.definition.id === 'flywheel-studio-flywheel'
@@ -1134,9 +1136,19 @@ const poiInteractionManager = new PoiInteractionManager(
   poiInstances,
   poiAnalytics
 );
+const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
+  poiTooltipOverlay.setHovered(poi);
+});
+const removeSelectionStateListener =
+  poiInteractionManager.addSelectionStateListener((poi) => {
+    poiTooltipOverlay.setSelected(poi);
+  });
 poiInteractionManager.start();
 window.addEventListener('beforeunload', () => {
   poiInteractionManager.dispose();
+  removeHoverListener();
+  removeSelectionStateListener();
+  poiTooltipOverlay.dispose();
 });
 
 const playerMaterial = new MeshStandardMaterial({ color: 0xffc857 });

--- a/src/poi/interactionManager.ts
+++ b/src/poi/interactionManager.ts
@@ -22,7 +22,8 @@ export class PoiInteractionManager {
   private readonly pointer = new Vector2();
   private readonly listeners = new Set<PoiSelectionListener>();
   private readonly hoverListeners = new Set<PoiHoverListener>();
-  private readonly selectionStateListeners = new Set<PoiSelectionStateListener>();
+  private readonly selectionStateListeners =
+    new Set<PoiSelectionStateListener>();
   private hovered: PoiInstance | null = null;
   private selected: PoiInstance | null = null;
   private active = false;
@@ -94,9 +95,7 @@ export class PoiInteractionManager {
     };
   }
 
-  addSelectionStateListener(
-    listener: PoiSelectionStateListener
-  ): () => void {
+  addSelectionStateListener(listener: PoiSelectionStateListener): () => void {
     this.selectionStateListeners.add(listener);
     return () => {
       this.selectionStateListeners.delete(listener);

--- a/src/poi/interactionManager.ts
+++ b/src/poi/interactionManager.ts
@@ -4,6 +4,8 @@ import type { PoiInstance } from './markers';
 import type { PoiAnalytics, PoiDefinition } from './types';
 
 export type PoiSelectionListener = (poi: PoiDefinition) => void;
+export type PoiHoverListener = (poi: PoiDefinition | null) => void;
+export type PoiSelectionStateListener = (poi: PoiDefinition | null) => void;
 
 type ListenerTarget = Pick<
   HTMLElement,
@@ -19,6 +21,8 @@ export class PoiInteractionManager {
   private readonly raycaster = new Raycaster();
   private readonly pointer = new Vector2();
   private readonly listeners = new Set<PoiSelectionListener>();
+  private readonly hoverListeners = new Set<PoiHoverListener>();
+  private readonly selectionStateListeners = new Set<PoiSelectionStateListener>();
   private hovered: PoiInstance | null = null;
   private selected: PoiInstance | null = null;
   private active = false;
@@ -80,6 +84,22 @@ export class PoiInteractionManager {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  addHoverListener(listener: PoiHoverListener): () => void {
+    this.hoverListeners.add(listener);
+    return () => {
+      this.hoverListeners.delete(listener);
+    };
+  }
+
+  addSelectionStateListener(
+    listener: PoiSelectionStateListener
+  ): () => void {
+    this.selectionStateListeners.add(listener);
+    return () => {
+      this.selectionStateListeners.delete(listener);
     };
   }
 
@@ -229,6 +249,7 @@ export class PoiInteractionManager {
     if (poi && previous !== poi) {
       this.analytics?.hoverStarted?.(poi.definition);
     }
+    this.notifyHoverListeners(poi?.definition ?? null);
   }
 
   private setSelected(poi: PoiInstance | null) {
@@ -249,6 +270,7 @@ export class PoiInteractionManager {
     if (poi && previous !== poi) {
       this.analytics?.selected?.(poi.definition);
     }
+    this.notifySelectionStateListeners(poi?.definition ?? null);
   }
 
   private dispatchSelection(definition: PoiDefinition) {
@@ -259,6 +281,18 @@ export class PoiInteractionManager {
       window.dispatchEvent(
         new CustomEvent('poi:selected', { detail: { poi: definition } })
       );
+    }
+  }
+
+  private notifyHoverListeners(poi: PoiDefinition | null) {
+    for (const listener of this.hoverListeners) {
+      listener(poi);
+    }
+  }
+
+  private notifySelectionStateListeners(poi: PoiDefinition | null) {
+    for (const listener of this.selectionStateListeners) {
+      listener(poi);
     }
   }
 }

--- a/src/poi/registry.ts
+++ b/src/poi/registry.ts
@@ -15,10 +15,7 @@ const definitions: PoiDefinition[] = [
     headingRadians: Math.PI * 0.5,
     interactionRadius: 2.4,
     footprint: { width: 3, depth: 6.8 },
-    metrics: [
-      { label: 'Stars', value: '180+' },
-      { label: 'Stack', value: 'Three.js · Vite · TypeScript' },
-    ],
+    metrics: [{ label: 'Stack', value: 'Three.js · Vite · TypeScript' }],
     links: [
       { label: 'GitHub', href: 'https://github.com/futuroptimist' },
       { label: 'Docs', href: 'https://futuroptimist.dev' },

--- a/src/poi/tooltipOverlay.ts
+++ b/src/poi/tooltipOverlay.ts
@@ -1,0 +1,176 @@
+import type { PoiDefinition } from './types';
+
+export interface PoiTooltipOverlayOptions {
+  container: HTMLElement;
+}
+
+interface RenderState {
+  poiId: string | null;
+}
+
+export class PoiTooltipOverlay {
+  private readonly root: HTMLElement;
+  private readonly title: HTMLHeadingElement;
+  private readonly summary: HTMLParagraphElement;
+  private readonly metricsList: HTMLUListElement;
+  private readonly linksList: HTMLUListElement;
+  private readonly statusBadge: HTMLSpanElement;
+  private hovered: PoiDefinition | null = null;
+  private selected: PoiDefinition | null = null;
+  private renderState: RenderState = { poiId: null };
+
+  constructor(options: PoiTooltipOverlayOptions) {
+    const { container } = options;
+    this.root = document.createElement('section');
+    this.root.className = 'poi-tooltip-overlay';
+    this.root.setAttribute('role', 'region');
+    this.root.setAttribute('aria-live', 'polite');
+    this.root.setAttribute('aria-label', 'Point of interest details');
+    this.root.setAttribute('aria-hidden', 'true');
+    this.root.tabIndex = -1;
+
+    const headingRow = document.createElement('div');
+    headingRow.className = 'poi-tooltip-overlay__heading-row';
+
+    this.title = document.createElement('h2');
+    this.title.className = 'poi-tooltip-overlay__title';
+    this.title.id = 'poi-tooltip-title';
+    this.root.appendChild(headingRow);
+    headingRow.appendChild(this.title);
+
+    this.statusBadge = document.createElement('span');
+    this.statusBadge.className = 'poi-tooltip-overlay__status';
+    this.statusBadge.hidden = true;
+    headingRow.appendChild(this.statusBadge);
+
+    this.summary = document.createElement('p');
+    this.summary.className = 'poi-tooltip-overlay__summary';
+    this.root.appendChild(this.summary);
+
+    this.metricsList = document.createElement('ul');
+    this.metricsList.className = 'poi-tooltip-overlay__metrics';
+    this.root.appendChild(this.metricsList);
+
+    this.linksList = document.createElement('ul');
+    this.linksList.className = 'poi-tooltip-overlay__links';
+    this.linksList.id = 'poi-tooltip-links';
+    this.root.appendChild(this.linksList);
+
+    container.appendChild(this.root);
+  }
+
+  setHovered(poi: PoiDefinition | null) {
+    this.hovered = poi;
+    this.update();
+  }
+
+  setSelected(poi: PoiDefinition | null) {
+    this.selected = poi;
+    this.update();
+  }
+
+  dispose() {
+    this.root.remove();
+  }
+
+  private update() {
+    const poi = this.hovered ?? this.selected;
+    if (!poi) {
+      this.root.classList.remove('poi-tooltip-overlay--visible');
+      this.root.dataset.state = 'hidden';
+      this.root.setAttribute('aria-hidden', 'true');
+      this.renderState.poiId = null;
+      return;
+    }
+
+    const state = this.hovered ? 'hovered' : 'selected';
+    this.root.dataset.state = state;
+    this.root.classList.add('poi-tooltip-overlay--visible');
+    this.root.setAttribute('aria-hidden', 'false');
+
+    if (this.renderState.poiId !== poi.id) {
+      this.renderPoi(poi);
+      this.renderState.poiId = poi.id;
+    } else {
+      this.updateStatus(poi);
+    }
+
+    if (state === 'selected' && !this.linksList.hidden) {
+      this.root.setAttribute('aria-describedby', this.linksList.id);
+    } else {
+      this.root.removeAttribute('aria-describedby');
+    }
+  }
+
+  private renderPoi(poi: PoiDefinition) {
+    this.title.textContent = poi.title;
+    this.summary.textContent = poi.summary;
+
+    this.updateStatus(poi);
+
+    this.renderMetrics(poi);
+    this.renderLinks(poi);
+  }
+
+  private updateStatus(poi: PoiDefinition) {
+    if (poi.status) {
+      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
+      this.statusBadge.textContent = statusLabel;
+      this.statusBadge.hidden = false;
+    } else {
+      this.statusBadge.hidden = true;
+      this.statusBadge.textContent = '';
+    }
+  }
+
+  private renderMetrics(poi: PoiDefinition) {
+    this.metricsList.innerHTML = '';
+    if (!poi.metrics || poi.metrics.length === 0) {
+      this.metricsList.hidden = true;
+      return;
+    }
+
+    this.metricsList.hidden = false;
+    for (const metric of poi.metrics) {
+      const item = document.createElement('li');
+      item.className = 'poi-tooltip-overlay__metric';
+
+      const label = document.createElement('span');
+      label.className = 'poi-tooltip-overlay__metric-label';
+      label.textContent = metric.label;
+
+      const value = document.createElement('span');
+      value.className = 'poi-tooltip-overlay__metric-value';
+      value.textContent = metric.value;
+
+      item.appendChild(label);
+      item.appendChild(value);
+      this.metricsList.appendChild(item);
+    }
+  }
+
+  private renderLinks(poi: PoiDefinition) {
+    this.linksList.innerHTML = '';
+    if (!poi.links || poi.links.length === 0) {
+      this.linksList.hidden = true;
+      return;
+    }
+
+    this.linksList.hidden = false;
+
+    for (const link of poi.links) {
+      const item = document.createElement('li');
+      item.className = 'poi-tooltip-overlay__link-item';
+
+      const anchor = document.createElement('a');
+      anchor.className = 'poi-tooltip-overlay__link';
+      anchor.href = link.href;
+      anchor.target = '_blank';
+      anchor.rel = 'noopener noreferrer';
+      anchor.textContent = link.label;
+
+      item.appendChild(anchor);
+      this.linksList.appendChild(item);
+    }
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -104,3 +104,124 @@ canvas {
   box-shadow: 0 8px 20px rgba(255, 200, 87, 0.4);
   transition: transform 40ms ease-out;
 }
+
+.poi-tooltip-overlay {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.1rem 1.35rem;
+  max-width: min(26rem, calc(100% - 3rem));
+  border-radius: 1rem;
+  background: linear-gradient(
+      140deg,
+      rgba(12, 21, 33, 0.92),
+      rgba(15, 36, 58, 0.78)
+    ),
+    rgba(9, 15, 26, 0.94);
+  color: #e5f4ff;
+  box-shadow: 0 32px 80px rgba(3, 8, 18, 0.58);
+  border: 1px solid rgba(86, 184, 255, 0.3);
+  backdrop-filter: blur(16px);
+  opacity: 0;
+  transform: translateY(12px);
+  pointer-events: none;
+  transition: opacity 160ms ease, transform 180ms ease;
+  z-index: 30;
+}
+
+.poi-tooltip-overlay--visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.poi-tooltip-overlay__heading-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.poi-tooltip-overlay__title {
+  margin: 0;
+  font-size: 1.15rem;
+  letter-spacing: 0.01em;
+}
+
+.poi-tooltip-overlay__status {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(61, 201, 255, 0.16);
+  border: 1px solid rgba(97, 219, 255, 0.35);
+  color: #8fe3ff;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.poi-tooltip-overlay__summary {
+  margin: 0;
+  color: rgba(222, 245, 255, 0.92);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.poi-tooltip-overlay__metrics,
+.poi-tooltip-overlay__links {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.poi-tooltip-overlay__metric {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.82rem;
+  color: rgba(195, 236, 255, 0.95);
+}
+
+.poi-tooltip-overlay__metric-label {
+  font-weight: 600;
+  color: rgba(141, 217, 255, 0.98);
+}
+
+.poi-tooltip-overlay__metric-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.poi-tooltip-overlay__links {
+  grid-auto-rows: min-content;
+}
+
+.poi-tooltip-overlay__link-item {
+  display: contents;
+}
+
+.poi-tooltip-overlay__link {
+  color: #9addff;
+  text-decoration: none;
+  font-size: 0.84rem;
+  border-bottom: 1px solid rgba(154, 221, 255, 0.25);
+  padding-bottom: 0.15rem;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.poi-tooltip-overlay__link:focus,
+.poi-tooltip-overlay__link:hover {
+  color: #d4f2ff;
+  border-bottom-color: rgba(212, 242, 255, 0.6);
+  outline: none;
+}
+
+.poi-tooltip-overlay[data-state='hovered'] {
+  border-color: rgba(82, 196, 255, 0.45);
+}
+
+.poi-tooltip-overlay[data-state='selected'] {
+  border-color: rgba(255, 200, 87, 0.45);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,11 +115,8 @@ canvas {
   padding: 1.1rem 1.35rem;
   max-width: min(26rem, calc(100% - 3rem));
   border-radius: 1rem;
-  background: linear-gradient(
-      140deg,
-      rgba(12, 21, 33, 0.92),
-      rgba(15, 36, 58, 0.78)
-    ),
+  background:
+    linear-gradient(140deg, rgba(12, 21, 33, 0.92), rgba(15, 36, 58, 0.78)),
     rgba(9, 15, 26, 0.94);
   color: #e5f4ff;
   box-shadow: 0 32px 80px rgba(3, 8, 18, 0.58);
@@ -128,7 +125,9 @@ canvas {
   opacity: 0;
   transform: translateY(12px);
   pointer-events: none;
-  transition: opacity 160ms ease, transform 180ms ease;
+  transition:
+    opacity 160ms ease,
+    transform 180ms ease;
   z-index: 30;
 }
 
@@ -208,7 +207,9 @@ canvas {
   font-size: 0.84rem;
   border-bottom: 1px solid rgba(154, 221, 255, 0.25);
   padding-bottom: 0.15rem;
-  transition: color 120ms ease, border-color 120ms ease;
+  transition:
+    color 120ms ease,
+    border-color 120ms ease;
 }
 
 .poi-tooltip-overlay__link:focus,

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -143,9 +143,8 @@ describe('PoiInteractionManager', () => {
     const listener = vi.fn();
     manager.addSelectionListener(listener);
     const selectionState = vi.fn();
-    const removeSelectionState = manager.addSelectionStateListener(
-      selectionState
-    );
+    const removeSelectionState =
+      manager.addSelectionStateListener(selectionState);
     const customEventHandler = vi.fn();
     window.addEventListener('poi:selected', customEventHandler);
 

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -123,20 +123,29 @@ describe('PoiInteractionManager', () => {
   });
 
   it('updates focus target based on pointer hover', () => {
+    const hoverListener = vi.fn();
+    const removeHover = manager.addHoverListener(hoverListener);
     manager.start();
     domElement.dispatchEvent(
       new MouseEvent('mousemove', { clientX: 200, clientY: 200 })
     );
     expect(poi.focusTarget).toBe(1);
+    expect(hoverListener).toHaveBeenLastCalledWith(definition);
 
     domElement.dispatchEvent(new MouseEvent('mouseleave'));
     expect(poi.focusTarget).toBe(0);
+    expect(hoverListener).toHaveBeenLastCalledWith(null);
+    removeHover();
   });
 
   it('persists focus on selected POIs and emits selection events', () => {
     manager.start();
     const listener = vi.fn();
     manager.addSelectionListener(listener);
+    const selectionState = vi.fn();
+    const removeSelectionState = manager.addSelectionStateListener(
+      selectionState
+    );
     const customEventHandler = vi.fn();
     window.addEventListener('poi:selected', customEventHandler);
 
@@ -147,11 +156,14 @@ describe('PoiInteractionManager', () => {
     expect(listener).toHaveBeenCalledWith(definition);
     expect(customEventHandler).toHaveBeenCalledTimes(1);
     expect(poi.focusTarget).toBe(1);
+    expect(selectionState).toHaveBeenLastCalledWith(definition);
 
     domElement.dispatchEvent(new MouseEvent('mouseleave'));
     expect(poi.focusTarget).toBe(1);
+    expect(selectionState).toHaveBeenCalledTimes(1);
 
     window.removeEventListener('poi:selected', customEventHandler);
+    removeSelectionState();
   });
 
   it('cycles focus with keyboard input and wraps around', () => {
@@ -213,6 +225,20 @@ describe('PoiInteractionManager', () => {
     expect(listener).toHaveBeenCalledTimes(2);
 
     window.removeEventListener('poi:selected', customEventHandler);
+  });
+
+  it('notifies selection state listeners when selection clears', () => {
+    manager.start();
+    const selectionState = vi.fn();
+    manager.addSelectionStateListener(selectionState);
+
+    domElement.dispatchEvent(
+      new MouseEvent('click', { clientX: 200, clientY: 200 })
+    );
+    expect(selectionState).toHaveBeenLastCalledWith(definition);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(selectionState).toHaveBeenLastCalledWith(null);
   });
 
   it('ignores keyboard input when disabled', () => {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PoiTooltipOverlay } from '../poi/tooltipOverlay';
+import type { PoiDefinition } from '../poi/types';
+
+describe('PoiTooltipOverlay', () => {
+  let container: HTMLElement;
+  let overlay: PoiTooltipOverlay;
+
+  const basePoi: PoiDefinition = {
+    id: 'futuroptimist-living-room-tv',
+    title: 'Futuroptimist TV Wall',
+    summary: 'Living room media wall with immersive tooling.',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'livingRoom',
+    position: { x: 0, y: 0, z: 0 },
+    interactionRadius: 2.4,
+    footprint: { width: 3, depth: 2 },
+    metrics: [{ label: 'Stack', value: 'Three.js · Vite · TypeScript' }],
+    links: [
+      { label: 'GitHub', href: 'https://github.com/futuroptimist' },
+      { label: 'Docs', href: 'https://futuroptimist.dev' },
+    ],
+    status: 'prototype',
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    overlay = new PoiTooltipOverlay({ container });
+  });
+
+  afterEach(() => {
+    overlay.dispose();
+    container.remove();
+  });
+
+  it('renders hovered POI metadata and exposes links', () => {
+    overlay.setHovered(basePoi);
+
+    const root = container.querySelector(
+      '.poi-tooltip-overlay'
+    ) as HTMLElement;
+    expect(root).toBeTruthy();
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    expect(root.dataset.state).toBe('hovered');
+
+    const title = root.querySelector('.poi-tooltip-overlay__title');
+    expect(title?.textContent).toBe(basePoi.title);
+
+    const summary = root.querySelector('.poi-tooltip-overlay__summary');
+    expect(summary?.textContent).toContain('immersive');
+
+    const metrics = Array.from(
+      root.querySelectorAll('.poi-tooltip-overlay__metric')
+    );
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0]?.textContent).toContain('Stack');
+
+    const links = Array.from(
+      root.querySelectorAll<HTMLAnchorElement>('.poi-tooltip-overlay__link')
+    );
+    expect(links).toHaveLength(2);
+    expect(links[0]?.href).toBe(basePoi.links?.[0]?.href ?? '');
+  });
+
+  it('prefers hovered metadata over selected and hides when cleared', () => {
+    const selectedPoi: PoiDefinition = {
+      ...basePoi,
+      id: 'flywheel-studio-flywheel',
+      title: 'Flywheel Kinetic Hub',
+      position: { x: 2, y: 0, z: 4 },
+      metrics: [{ label: 'Automation', value: 'CI-ready prompts' }],
+      links: [{ label: 'Flywheel', href: 'https://flywheel.futuroptimist.dev' }],
+      status: undefined,
+    };
+
+    overlay.setSelected(selectedPoi);
+    overlay.setHovered({ ...basePoi, title: 'Temporary Hover' });
+
+    const root = container.querySelector(
+      '.poi-tooltip-overlay'
+    ) as HTMLElement;
+    expect(root.dataset.state).toBe('hovered');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      'Temporary Hover'
+    );
+
+    overlay.setHovered(null);
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      selectedPoi.title
+    );
+
+    overlay.setSelected(null);
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -39,9 +39,7 @@ describe('PoiTooltipOverlay', () => {
   it('renders hovered POI metadata and exposes links', () => {
     overlay.setHovered(basePoi);
 
-    const root = container.querySelector(
-      '.poi-tooltip-overlay'
-    ) as HTMLElement;
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
     expect(root).toBeTruthy();
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
     expect(root.getAttribute('aria-hidden')).toBe('false');
@@ -73,16 +71,16 @@ describe('PoiTooltipOverlay', () => {
       title: 'Flywheel Kinetic Hub',
       position: { x: 2, y: 0, z: 4 },
       metrics: [{ label: 'Automation', value: 'CI-ready prompts' }],
-      links: [{ label: 'Flywheel', href: 'https://flywheel.futuroptimist.dev' }],
+      links: [
+        { label: 'Flywheel', href: 'https://flywheel.futuroptimist.dev' },
+      ],
       status: undefined,
     };
 
     overlay.setSelected(selectedPoi);
     overlay.setHovered({ ...basePoi, title: 'Temporary Hover' });
 
-    const root = container.querySelector(
-      '.poi-tooltip-overlay'
-    ) as HTMLElement;
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
     expect(root.dataset.state).toBe('hovered');
     expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
       'Temporary Hover'


### PR DESCRIPTION
what:
- Remove the Futuroptimist TV Wall stars metric from the registry and overlay test fixture

why:
- Avoid surfacing an inaccurate GitHub star count in the tooltip overlay

how to test:
- npm run lint
- npm run test:ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a6dfd524832fb7e2bfd99f2d528e