### PR TITLE
🛠️ Restore DoubleSide import for immersive scene

### DIFF
--- a/outages/2025-09-29-threejs-double-side-regression.json
+++ b/outages/2025-09-29-threejs-double-side-regression.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-09-29-threejs-double-side-regression",
+  "date": "2025-09-29",
+  "component": "webapp",
+  "rootCause": "Omitting the DoubleSide import during the white-pop-in refactor left it undefined and crashed init.",
+  "resolution": "Re-import DoubleSide in src/main.ts so materials can set side without triggering a ReferenceError.",
+  "references": [
+    "https://github.com/danielsmith-io/danielsmith.io/blob/main/src/main.ts#L772"
+  ]
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   Clock,
   Color,
   DirectionalLight,
+  DoubleSide,
   Group,
   HemisphereLight,
   MathUtils,


### PR DESCRIPTION
what: restore the missing DoubleSide import and log outage
why: fix the ReferenceError and capture the regression report
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68da2fddd0e4832fbf55ae9a0c5d884e