### PR TITLE
🧪 : – Cover immersive startup with Playwright

### DIFF
--- a/outages/2025-09-30-immersive-static-collider-regression.json
+++ b/outages/2025-09-30-immersive-static-collider-regression.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-09-30-immersive-static-collider-regression",
+  "date": "2025-09-30",
+  "component": "webapp",
+  "rootCause": "The scene refactor dropped the staticColliders array, so pushes now throw at init time.",
+  "resolution": "Restore the static colliders collection and include it in ground occupancy checks.",
+  "references": [
+    "https://github.com/danielsmith-io/danielsmith.io/blob/main/src/main.ts#L226-L233",
+    "https://github.com/danielsmith-io/danielsmith.io/blob/main/src/main.ts#L1296-L1311"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "docs:check": "node scripts/check-docs.cjs",
     "smoke": "npm run build && node scripts/assert-dist.cjs",
     "check": "npm run lint && npm run test:ci && npm run docs:check",
-    "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts"
+    "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "three": "^0.161.0"

--- a/playwright/immersive-mode.spec.ts
+++ b/playwright/immersive-mode.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+
+const collectConsoleErrors = (page: Page): string[] => {
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      errors.push(message.text());
+    }
+  });
+  return errors;
+};
+
+const collectPageErrors = (page: Page): string[] => {
+  const errors: string[] = [];
+  page.on('pageerror', (error) => {
+    errors.push(error instanceof Error ? error.message : String(error));
+  });
+  return errors;
+};
+
+test.describe('immersive experience', () => {
+  test('initializes without falling back to text mode', async ({ page }) => {
+    const consoleErrors = collectConsoleErrors(page);
+    const pageErrors = collectPageErrors(page);
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+    await expect(page.locator('#app canvas')).toHaveCount(1);
+    await expect(page.locator('#control-overlay')).toBeVisible();
+
+    const immersiveInitFailures = consoleErrors.filter((message) =>
+      message.includes('Failed to initialize immersive scene')
+    );
+
+    expect.soft(immersiveInitFailures).toHaveLength(0);
+    expect.soft(pageErrors).toHaveLength(0);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -225,6 +225,7 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const upperFloorColliders: RectCollider[] = [];
+const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
 let flywheelShowpiece: FlywheelShowpieceBuild | null = null;
 let jobbotTerminal: JobbotTerminalBuild | null = null;
@@ -1287,9 +1288,25 @@ function initializeImmersiveScene(
     return 'ground';
   };
 
-  const canOccupyPosition = (x: number, z: number, floorId: FloorId): boolean =>
-    isInsideAnyRoom(floorPlansById[floorId], x, z) &&
-    !collidesWithColliders(x, z, PLAYER_RADIUS, floorColliders[floorId]);
+  const canOccupyPosition = (x: number, z: number, floorId: FloorId): boolean => {
+    const inside = isInsideAnyRoom(floorPlansById[floorId], x, z);
+    if (!inside) {
+      return false;
+    }
+
+    if (collidesWithColliders(x, z, PLAYER_RADIUS, floorColliders[floorId])) {
+      return false;
+    }
+
+    if (
+      floorId === 'ground' &&
+      collidesWithColliders(x, z, PLAYER_RADIUS, staticColliders)
+    ) {
+      return false;
+    }
+
+    return true;
+  };
 
   const setActiveFloorId = (next: FloorId) => {
     if (activeFloorId === next) {


### PR DESCRIPTION
what:
- add an immersive-mode Playwright check that waits for the scene to boot and ensures no fallback occurs
- expose an npm script for running the Playwright suite locally

why:
- guard immersive mode against regressions like the missing static collider bug by exercising the UI in CI-ready tooling

how to test:
- npm run test:ci

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68da323a7c40832faced075e2bdc8888