### PR TITLE
Add dSpace rocket POI to the registry

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,8 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✨ Studio Jobbot terminal desk projects live automation telemetry via a holographic console
      and anchors the Jobbot3000 POI with reactive lighting and diagnostics beacons.
 3. **Backyard Exhibits**
-   - ✨ Launch-ready model rocket for `dspace`, complete with illuminated launch pad, caution halo, and countdown-ready stance.
+   - ✨ Launch-ready model rocket for `dspace`, complete with illuminated launch pad, caution halo,
+     countdown-ready stance, and an interactive POI that links to the mission log.
    - Aluminum extrusion greenhouse inspired by `sugarkube`, including animated solar panels,
      grow lights, plants, and koi pond voxels.
    - ✨ Ambient audio beds (crickets, hum) that fade based on player proximity.

--- a/src/poi/registry.ts
+++ b/src/poi/registry.ts
@@ -70,6 +70,31 @@ const definitions: PoiDefinition[] = [
     ],
     status: 'prototype',
   },
+  {
+    id: 'dspace-backyard-rocket',
+    title: 'dSpace Launch Pad',
+    summary:
+      'Backyard launch gantry staging the dSpace model rocket with telemetry-guided countdown cues.',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'backyard',
+    position: { x: -14.08, y: 0, z: 23.6 },
+    headingRadians: -Math.PI / 10,
+    interactionRadius: 2.6,
+    footprint: { width: 3.4, depth: 3.4 },
+    metrics: [
+      { label: 'Countdown', value: 'Autonomous T-0 sequencing' },
+      { label: 'Stack', value: 'Three.js FX · Spatial audio' },
+    ],
+    links: [
+      { label: 'GitHub', href: 'https://github.com/futuroptimist/dspace' },
+      {
+        label: 'Mission Log',
+        href: 'https://futuroptimist.dev/projects/dspace',
+      },
+    ],
+    status: 'prototype',
+  },
 ];
 
 assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });

--- a/src/poi/types.ts
+++ b/src/poi/types.ts
@@ -1,7 +1,8 @@
 export type PoiId =
   | 'futuroptimist-living-room-tv'
   | 'flywheel-studio-flywheel'
-  | 'jobbot-studio-terminal';
+  | 'jobbot-studio-terminal'
+  | 'dspace-backyard-rocket';
 
 export type PoiCategory = 'project' | 'environment';
 

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -1,12 +1,5 @@
 import { Group } from 'three';
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type SpyInstance,
-} from 'vitest';
+import { beforeEach, describe, expect, it, vi, type SpyInstance } from 'vitest';
 
 import { createBackyardEnvironment } from '../environments/backyard';
 

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -1,5 +1,12 @@
 import { Group } from 'three';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type SpyInstance,
+} from 'vitest';
 
 import { createBackyardEnvironment } from '../environments/backyard';
 
@@ -11,15 +18,16 @@ const BACKYARD_BOUNDS = {
 };
 
 describe('createBackyardEnvironment', () => {
-  let originalRandom: () => number;
-  let originalGetContext: HTMLCanvasElement['getContext'];
+  let randomSpy: SpyInstance<[], number>;
+  let getContextSpy: SpyInstance<
+    [contextId: string, ...args: unknown[]],
+    CanvasRenderingContext2D | null
+  >;
 
   beforeEach(() => {
-    originalRandom = Math.random;
-    Math.random = () => 0.42;
-    originalGetContext = HTMLCanvasElement.prototype.getContext;
-    HTMLCanvasElement.prototype.getContext = vi
-      .fn()
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.42);
+    getContextSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
       .mockImplementation((type) => {
         if (type === '2d') {
           return {
@@ -48,8 +56,8 @@ describe('createBackyardEnvironment', () => {
   });
 
   afterEach(() => {
-    Math.random = originalRandom;
-    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    randomSpy.mockRestore();
+    getContextSpy.mockRestore();
   });
 
   it('adds the model rocket installation and collider to the backyard', () => {

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -38,4 +38,15 @@ describe('POI registry', () => {
       expect(poi.summary.trim().length).toBeGreaterThan(20);
     });
   });
+
+  it('registers the backyard rocket POI with outdoor placement metadata', () => {
+    const rocket = pois.find((poi) => poi.id === 'dspace-backyard-rocket');
+    expect(rocket).toBeDefined();
+    expect(rocket?.roomId).toBe('backyard');
+    expect(rocket?.interaction).toBe('inspect');
+    expect(rocket?.interactionRadius).toBeGreaterThan(2);
+    expect(rocket?.footprint.width).toBeGreaterThan(3);
+    expect(rocket?.links?.[0]?.href).toContain('dspace');
+    expect(rocket?.metrics?.some((metric) => metric.label === 'Countdown')).toBe(true);
+  });
 });

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -47,6 +47,8 @@ describe('POI registry', () => {
     expect(rocket?.interactionRadius).toBeGreaterThan(2);
     expect(rocket?.footprint.width).toBeGreaterThan(3);
     expect(rocket?.links?.[0]?.href).toContain('dspace');
-    expect(rocket?.metrics?.some((metric) => metric.label === 'Countdown')).toBe(true);
+    expect(
+      rocket?.metrics?.some((metric) => metric.label === 'Countdown')
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add the backyard dSpace launch pad POI with mission links and metrics
- extend registry tests to cover the new exhibit metadata
- document that the rocket exhibit now exposes an interactive POI

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68db63d4174c832fbf1573e9307d4f80