### PR TITLE
Add visited POI persistence and highlights

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -136,6 +136,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
    - In-world visual cues for discovered content (e.g., glowing trims, checkmarks).
    - Optional guided tour mode that highlights the next recommended POI.
+   - ✅ Visited POI progress persists across reloads, powering halo highlights and tooltip badges.
 
 ## Phase 4 – Accessibility & Internationalization
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,7 @@ import {
 } from './poi/markers';
 import { getPoiDefinitions } from './poi/registry';
 import { PoiTooltipOverlay } from './poi/tooltipOverlay';
+import { PoiVisitedState } from './poi/visitedState';
 import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
@@ -1132,6 +1133,21 @@ function initializeImmersiveScene(
 
   const poiAnalytics = createWindowPoiAnalytics();
   const poiTooltipOverlay = new PoiTooltipOverlay({ container });
+  const poiVisitedState = new PoiVisitedState();
+
+  const handleVisitedUpdate = (visited: ReadonlySet<string>) => {
+    for (const poi of poiInstances) {
+      const isVisited = visited.has(poi.definition.id);
+      if (poi.visited !== isVisited) {
+        poi.visited = isVisited;
+      }
+    }
+    poiTooltipOverlay.setVisitedPoiIds(visited);
+  };
+
+  const removeVisitedSubscription = poiVisitedState.subscribe(
+    handleVisitedUpdate
+  );
 
   const flywheelPoi = poiInstances.find(
     (poi) => poi.definition.id === 'flywheel-studio-flywheel'
@@ -1190,11 +1206,18 @@ function initializeImmersiveScene(
     poiInteractionManager.addSelectionStateListener((poi) => {
       poiTooltipOverlay.setSelected(poi);
     });
+  const removeSelectionListener = poiInteractionManager.addSelectionListener(
+    (poi) => {
+      poiVisitedState.markVisited(poi.id);
+    }
+  );
   poiInteractionManager.start();
   window.addEventListener('beforeunload', () => {
     poiInteractionManager.dispose();
     removeHoverListener();
     removeSelectionStateListener();
+    removeSelectionListener();
+    removeVisitedSubscription();
     poiTooltipOverlay.dispose();
     ambientAudioController?.dispose();
     renderer.domElement.removeEventListener('wheel', handleWheelZoom);
@@ -1921,13 +1944,20 @@ function initializeImmersiveScene(
         0,
         1
       );
+      const visitedTarget = poi.visited ? 1 : 0;
       poi.activation = MathUtils.lerp(
         poi.activation,
         targetActivation,
         smoothing
       );
+      poi.visitedStrength = MathUtils.lerp(
+        poi.visitedStrength,
+        visitedTarget,
+        smoothing
+      );
       poi.focus = MathUtils.lerp(poi.focus, poi.focusTarget, smoothing);
       const emphasis = Math.max(poi.activation, poi.focus);
+      const visitedEmphasis = poi.visitedStrength;
 
       if (poi.activation > highestActivation) {
         highestActivation = poi.activation;
@@ -1935,7 +1965,8 @@ function initializeImmersiveScene(
       }
 
       if (poi.label && poi.labelMaterial) {
-        const labelOpacity = MathUtils.lerp(0.32, 1, emphasis);
+        const baseOpacity = MathUtils.lerp(0.32, 0.52, visitedEmphasis);
+        const labelOpacity = MathUtils.lerp(baseOpacity, 1, emphasis);
         poi.labelMaterial.opacity = labelOpacity;
         poi.label.visible = labelOpacity > 0.05;
       }
@@ -1949,20 +1980,29 @@ function initializeImmersiveScene(
           baseScale,
           focusScale,
         } = poi.displayHighlight;
+        const visitedOpacityBoost = MathUtils.lerp(0, 0.25, visitedEmphasis);
         const nextOpacity = MathUtils.lerp(baseOpacity, focusOpacity, emphasis);
-        material.opacity = nextOpacity;
-        mesh.visible = nextOpacity > 0.02;
+        const combinedOpacity = Math.min(nextOpacity + visitedOpacityBoost, 1);
+        material.opacity = combinedOpacity;
+        mesh.visible = combinedOpacity > 0.02;
         if (baseScale !== undefined && focusScale !== undefined && mesh.scale) {
           const nextScale = MathUtils.lerp(baseScale, focusScale, emphasis);
           mesh.scale.setScalar(nextScale);
         }
+      } else if (poi.visitedHighlight) {
+        const visitedOpacity = MathUtils.lerp(0, 0.55, visitedEmphasis);
+        poi.visitedHighlight.material.opacity = visitedOpacity;
+        poi.visitedHighlight.mesh.visible = visitedOpacity > 0.02;
+        const visitedScale = 1 + visitedEmphasis * 0.12;
+        poi.visitedHighlight.mesh.scale.setScalar(visitedScale);
       } else {
         if (
           poi.orbMaterial &&
           poi.orbEmissiveBase &&
           poi.orbEmissiveHighlight
         ) {
-          const orbEmissive = MathUtils.lerp(0.85, 1.7, emphasis);
+          const baseIntensity = MathUtils.lerp(0.85, 1.05, visitedEmphasis);
+          const orbEmissive = MathUtils.lerp(baseIntensity, 1.7, emphasis);
           poi.orbMaterial.emissiveIntensity = orbEmissive;
           poi.orbMaterial.emissive.lerpColors(
             poi.orbEmissiveBase,
@@ -1972,7 +2012,8 @@ function initializeImmersiveScene(
         }
 
         if (poi.accentMaterial && poi.accentBaseColor && poi.accentFocusColor) {
-          const accentEmissive = MathUtils.lerp(0.65, 1.05, emphasis);
+          const baseAccent = MathUtils.lerp(0.65, 0.82, visitedEmphasis);
+          const accentEmissive = MathUtils.lerp(baseAccent, 1.05, emphasis);
           poi.accentMaterial.emissiveIntensity = accentEmissive;
           poi.accentMaterial.color.lerpColors(
             poi.accentBaseColor,
@@ -1989,9 +2030,12 @@ function initializeImmersiveScene(
         ) {
           const haloPulse =
             1 + Math.sin(elapsedTime * 1.8 + poi.pulseOffset) * 0.08;
-          const haloScale = MathUtils.lerp(1, 1.18, emphasis) * haloPulse;
+          const baseHaloScale = MathUtils.lerp(1, 1.05, visitedEmphasis);
+          const haloScale =
+            MathUtils.lerp(baseHaloScale, 1.18, emphasis) * haloPulse;
           poi.halo.scale.setScalar(haloScale);
-          const haloOpacity = MathUtils.lerp(0.18, 0.62, emphasis);
+          const baseHaloOpacity = MathUtils.lerp(0.18, 0.32, visitedEmphasis);
+          const haloOpacity = MathUtils.lerp(baseHaloOpacity, 0.62, emphasis);
           poi.haloMaterial.opacity = haloOpacity;
           poi.halo.visible = haloOpacity > 0.04;
           poi.haloMaterial.color.lerpColors(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1145,9 +1145,8 @@ function initializeImmersiveScene(
     poiTooltipOverlay.setVisitedPoiIds(visited);
   };
 
-  const removeVisitedSubscription = poiVisitedState.subscribe(
-    handleVisitedUpdate
-  );
+  const removeVisitedSubscription =
+    poiVisitedState.subscribe(handleVisitedUpdate);
 
   const flywheelPoi = poiInstances.find(
     (poi) => poi.definition.id === 'flywheel-studio-flywheel'
@@ -1989,13 +1988,17 @@ function initializeImmersiveScene(
           const nextScale = MathUtils.lerp(baseScale, focusScale, emphasis);
           mesh.scale.setScalar(nextScale);
         }
-      } else if (poi.visitedHighlight) {
+      }
+
+      if (poi.visitedHighlight) {
         const visitedOpacity = MathUtils.lerp(0, 0.55, visitedEmphasis);
         poi.visitedHighlight.material.opacity = visitedOpacity;
         poi.visitedHighlight.mesh.visible = visitedOpacity > 0.02;
         const visitedScale = 1 + visitedEmphasis * 0.12;
         poi.visitedHighlight.mesh.scale.setScalar(visitedScale);
-      } else {
+      }
+
+      if (!poi.displayHighlight) {
         if (
           poi.orbMaterial &&
           poi.orbEmissiveBase &&

--- a/src/poi/markers.ts
+++ b/src/poi/markers.ts
@@ -66,6 +66,12 @@ export interface PoiInstance {
   orbEmissiveHighlight?: Color;
   visualMode: 'pedestal' | 'display';
   displayHighlight?: PoiDisplayHighlight;
+  visited: boolean;
+  visitedStrength: number;
+  visitedHighlight?: {
+    mesh: Mesh;
+    material: MeshBasicMaterial;
+  };
 }
 
 export function createPoiInstances(
@@ -188,6 +194,28 @@ function createPedestalPoiInstance(
   halo.renderOrder = 11;
   group.add(halo);
 
+  const visitedRingGeometry = new RingGeometry(
+    haloInnerRadius * 0.92,
+    haloOuterRadius * 1.05,
+    60,
+    1
+  );
+  const visitedRingMaterial = new MeshBasicMaterial({
+    color: new Color(0x7effc7),
+    transparent: true,
+    opacity: 0,
+    blending: AdditiveBlending,
+    depthWrite: false,
+  });
+  visitedRingMaterial.side = DoubleSide;
+  const visitedRing = new Mesh(visitedRingGeometry, visitedRingMaterial);
+  visitedRing.rotation.x = -Math.PI / 2;
+  visitedRing.position.y = 0.12;
+  visitedRing.renderOrder = 10;
+  visitedRing.visible = false;
+  visitedRing.scale.setScalar(1);
+  group.add(visitedRing);
+
   const hitAreaGeometry = new CylinderGeometry(
     baseRadiusX,
     baseRadiusX,
@@ -241,6 +269,9 @@ function createPedestalPoiInstance(
     orbEmissiveBase,
     orbEmissiveHighlight,
     visualMode: 'pedestal',
+    visited: false,
+    visitedStrength: 0,
+    visitedHighlight: { mesh: visitedRing, material: visitedRingMaterial },
   };
 }
 
@@ -302,6 +333,8 @@ function createDisplayPoiInstance(
     floatAmplitude: 0,
     visualMode: 'display',
     displayHighlight: override.highlight,
+    visited: false,
+    visitedStrength: 0,
   };
 }
 

--- a/src/poi/tooltipOverlay.ts
+++ b/src/poi/tooltipOverlay.ts
@@ -15,9 +15,11 @@ export class PoiTooltipOverlay {
   private readonly metricsList: HTMLUListElement;
   private readonly linksList: HTMLUListElement;
   private readonly statusBadge: HTMLSpanElement;
+  private readonly visitedBadge: HTMLSpanElement;
   private hovered: PoiDefinition | null = null;
   private selected: PoiDefinition | null = null;
   private renderState: RenderState = { poiId: null };
+  private visitedPoiIds: ReadonlySet<string> = new Set();
 
   constructor(options: PoiTooltipOverlayOptions) {
     const { container } = options;
@@ -42,6 +44,12 @@ export class PoiTooltipOverlay {
     this.statusBadge.className = 'poi-tooltip-overlay__status';
     this.statusBadge.hidden = true;
     headingRow.appendChild(this.statusBadge);
+
+    this.visitedBadge = document.createElement('span');
+    this.visitedBadge.className = 'poi-tooltip-overlay__visited';
+    this.visitedBadge.textContent = 'Visited';
+    this.visitedBadge.hidden = true;
+    headingRow.appendChild(this.visitedBadge);
 
     this.summary = document.createElement('p');
     this.summary.className = 'poi-tooltip-overlay__summary';
@@ -69,6 +77,11 @@ export class PoiTooltipOverlay {
     this.update();
   }
 
+  setVisitedPoiIds(ids: ReadonlySet<string>) {
+    this.visitedPoiIds = ids;
+    this.update();
+  }
+
   dispose() {
     this.root.remove();
   }
@@ -80,6 +93,7 @@ export class PoiTooltipOverlay {
       this.root.dataset.state = 'hidden';
       this.root.setAttribute('aria-hidden', 'true');
       this.renderState.poiId = null;
+      this.visitedBadge.hidden = true;
       return;
     }
 
@@ -87,6 +101,9 @@ export class PoiTooltipOverlay {
     this.root.dataset.state = state;
     this.root.classList.add('poi-tooltip-overlay--visible');
     this.root.setAttribute('aria-hidden', 'false');
+
+    const visited = this.visitedPoiIds.has(poi.id);
+    this.visitedBadge.hidden = !visited;
 
     if (this.renderState.poiId !== poi.id) {
       this.renderPoi(poi);

--- a/src/poi/visitedState.ts
+++ b/src/poi/visitedState.ts
@@ -1,0 +1,104 @@
+import type { PoiId } from './types';
+
+export type PoiVisitedListener = (visited: ReadonlySet<PoiId>) => void;
+
+export interface PoiVisitedStateOptions {
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  storageKey?: string;
+}
+
+const DEFAULT_STORAGE_KEY = 'danielsmith.io::poi::visited::v1';
+
+const getDefaultStorage = (): Storage | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.warn('Accessing localStorage failed, continuing without persistence.', error);
+    return null;
+  }
+};
+
+const normalizeVisitedList = (value: unknown): PoiId[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is PoiId => typeof item === 'string');
+};
+
+export class PoiVisitedState {
+  private readonly storage: PoiVisitedStateOptions['storage'];
+  private readonly storageKey: string;
+  private readonly visited = new Set<PoiId>();
+  private readonly listeners = new Set<PoiVisitedListener>();
+
+  constructor(options: PoiVisitedStateOptions = {}) {
+    this.storage =
+      options.storage === undefined ? getDefaultStorage() : options.storage;
+    this.storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
+    this.loadFromStorage();
+  }
+
+  isVisited(id: PoiId): boolean {
+    return this.visited.has(id);
+  }
+
+  snapshot(): ReadonlySet<PoiId> {
+    return new Set(this.visited);
+  }
+
+  markVisited(id: PoiId): void {
+    if (this.visited.has(id)) {
+      return;
+    }
+    this.visited.add(id);
+    this.persist();
+    this.notifyListeners();
+  }
+
+  subscribe(listener: PoiVisitedListener): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private loadFromStorage() {
+    if (!this.storage) {
+      return;
+    }
+    try {
+      const raw = this.storage.getItem(this.storageKey);
+      if (!raw) {
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      const visitedIds = normalizeVisitedList(parsed);
+      visitedIds.forEach((id) => this.visited.add(id));
+    } catch (error) {
+      console.warn('Failed to load visited POIs from storage.', error);
+    }
+  }
+
+  private persist() {
+    if (!this.storage) {
+      return;
+    }
+    try {
+      const payload = JSON.stringify(Array.from(this.visited));
+      this.storage.setItem(this.storageKey, payload);
+    } catch (error) {
+      console.warn('Failed to persist visited POIs to storage.', error);
+    }
+  }
+
+  private notifyListeners() {
+    const snapshot = this.snapshot();
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+}

--- a/src/poi/visitedState.ts
+++ b/src/poi/visitedState.ts
@@ -16,7 +16,10 @@ const getDefaultStorage = (): Storage | null => {
   try {
     return window.localStorage;
   } catch (error) {
-    console.warn('Accessing localStorage failed, continuing without persistence.', error);
+    console.warn(
+      'Accessing localStorage failed, continuing without persistence.',
+      error
+    );
     return null;
   }
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -307,6 +307,17 @@ canvas {
   text-transform: uppercase;
 }
 
+.poi-tooltip-overlay__visited {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(90, 255, 177, 0.12);
+  border: 1px solid rgba(144, 255, 204, 0.32);
+  color: #b7ffda;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .poi-tooltip-overlay__summary {
   margin: 0;
   color: rgba(222, 245, 255, 0.92);

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -83,6 +83,8 @@ function createMockPoi(definition: PoiDefinition): PoiInstance {
     orbEmissiveBase,
     orbEmissiveHighlight,
     visualMode: 'pedestal',
+    visited: false,
+    visitedStrength: 0,
   } satisfies PoiInstance;
 }
 

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -96,4 +96,20 @@ describe('PoiTooltipOverlay', () => {
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
     expect(root.getAttribute('aria-hidden')).toBe('true');
   });
+
+  it('surfaces visited badge when POI is marked as visited', () => {
+    overlay.setVisitedPoiIds(new Set([basePoi.id]));
+    overlay.setSelected(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const visitedBadge = root.querySelector(
+      '.poi-tooltip-overlay__visited'
+    ) as HTMLSpanElement;
+    expect(visitedBadge.hidden).toBe(false);
+    expect(visitedBadge.textContent).toBe('Visited');
+
+    overlay.setVisitedPoiIds(new Set());
+    overlay.setSelected(basePoi);
+    expect(visitedBadge.hidden).toBe(true);
+  });
 });

--- a/src/tests/poiVisitedState.test.ts
+++ b/src/tests/poiVisitedState.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PoiVisitedState } from '../poi/visitedState';
+
+describe('PoiVisitedState', () => {
+  const storageKey = 'test::visited';
+  let warnings: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    warnings = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnings.mockRestore();
+  });
+
+  it('loads visited ids from storage and deduplicates entries', () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue(
+        JSON.stringify([
+          'futuroptimist-living-room-tv',
+          'flywheel-studio-flywheel',
+          'flywheel-studio-flywheel',
+        ])
+      ),
+      setItem: vi.fn(),
+    } satisfies Pick<Storage, 'getItem' | 'setItem'>;
+
+    const state = new PoiVisitedState({ storage, storageKey });
+    expect(storage.getItem).toHaveBeenCalledWith(storageKey);
+    expect(state.isVisited('futuroptimist-living-room-tv')).toBe(true);
+    expect(state.isVisited('flywheel-studio-flywheel')).toBe(true);
+    expect(state.snapshot().size).toBe(2);
+    expect(warnings).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed storage payloads gracefully', () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue('{bad-json'),
+      setItem: vi.fn(),
+    } satisfies Pick<Storage, 'getItem' | 'setItem'>;
+
+    const state = new PoiVisitedState({ storage, storageKey });
+    expect(state.snapshot().size).toBe(0);
+    expect(warnings).toHaveBeenCalledWith(
+      'Failed to load visited POIs from storage.',
+      expect.any(SyntaxError)
+    );
+  });
+
+  it('persists new visits and notifies subscribers once per change', () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+    } satisfies Pick<Storage, 'getItem' | 'setItem'>;
+
+    const state = new PoiVisitedState({ storage, storageKey });
+    const listener = vi.fn();
+    const unsubscribe = state.subscribe(listener);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(new Set());
+
+    state.markVisited('dspace-backyard-rocket');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      storageKey,
+      JSON.stringify(['dspace-backyard-rocket'])
+    );
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(
+      new Set(['dspace-backyard-rocket'])
+    );
+
+    state.markVisited('dspace-backyard-rocket');
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    state.markVisited('jobbot-studio-terminal');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('suppresses persistence errors when storage is unavailable', () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn().mockImplementation(() => {
+        throw new Error('quota exceeded');
+      }),
+    } satisfies Pick<Storage, 'getItem' | 'setItem'>;
+
+    const state = new PoiVisitedState({ storage, storageKey });
+    state.markVisited('jobbot-studio-terminal');
+
+    expect(warnings).toHaveBeenLastCalledWith(
+      'Failed to persist visited POIs to storage.',
+      expect.any(Error)
+    );
+    expect(state.isVisited('jobbot-studio-terminal')).toBe(true);
+  });
+
+  it('operates entirely in-memory when storage is null', () => {
+    const state = new PoiVisitedState({ storage: null, storageKey });
+    const listener = vi.fn();
+    state.subscribe(listener);
+    state.markVisited('flywheel-studio-flywheel');
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(state.snapshot()).toEqual(
+      new Set(['flywheel-studio-flywheel'])
+    );
+    expect(warnings).not.toHaveBeenCalled();
+  });
+
+  it('handles window.localStorage access errors gracefully', () => {
+    const storageError = new Error('denied');
+    const windowStub = {} as Window;
+    Object.defineProperty(windowStub, 'localStorage', {
+      configurable: true,
+      get() {
+        throw storageError;
+      },
+    });
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: windowStub,
+    });
+
+    const state = new PoiVisitedState({ storageKey });
+    expect(state.snapshot().size).toBe(0);
+    expect(warnings).toHaveBeenLastCalledWith(
+      'Accessing localStorage failed, continuing without persistence.',
+      storageError
+    );
+
+    expect(Reflect.deleteProperty(globalThis, 'window')).toBe(true);
+    expect(state.snapshot().size).toBe(0);
+  });
+});

--- a/src/tests/poiVisitedState.test.ts
+++ b/src/tests/poiVisitedState.test.ts
@@ -16,13 +16,15 @@ describe('PoiVisitedState', () => {
 
   it('loads visited ids from storage and deduplicates entries', () => {
     const storage = {
-      getItem: vi.fn().mockReturnValue(
-        JSON.stringify([
-          'futuroptimist-living-room-tv',
-          'flywheel-studio-flywheel',
-          'flywheel-studio-flywheel',
-        ])
-      ),
+      getItem: vi
+        .fn()
+        .mockReturnValue(
+          JSON.stringify([
+            'futuroptimist-living-room-tv',
+            'flywheel-studio-flywheel',
+            'flywheel-studio-flywheel',
+          ])
+        ),
       setItem: vi.fn(),
     } satisfies Pick<Storage, 'getItem' | 'setItem'>;
 
@@ -104,9 +106,7 @@ describe('PoiVisitedState', () => {
     state.markVisited('flywheel-studio-flywheel');
 
     expect(listener).toHaveBeenCalledTimes(2);
-    expect(state.snapshot()).toEqual(
-      new Set(['flywheel-studio-flywheel'])
-    );
+    expect(state.snapshot()).toEqual(new Set(['flywheel-studio-flywheel']));
     expect(warnings).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- persist visited POI ids with a localStorage-aware state manager and tests
- surface visited progress in-scene via halo pulses and tooltip badges
- document the progression milestone update in the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc4c79bd14832f93484492b6ba8b4a