### PR TITLE
Add Sugarkube greenhouse POI content

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -110,6 +110,7 @@ Focus: anchor each highlighted project with an interactive artifact.
      countdown-ready stance, and an interactive POI that links to the mission log.
    - ✨ Aluminum extrusion greenhouse inspired by `sugarkube`, complete with animated solar
      trackers, pulsing grow lights, interior planter beds, and a koi pond plinth.
+     - ✅ Sugarkube greenhouse POI now surfaces automation metrics and dual CTAs in the registry.
    - ✨ Ambient audio beds (crickets, hum) that fade based on player proximity.
 
 ## Phase 3 – Interface & Modes

--- a/src/poi/registry.ts
+++ b/src/poi/registry.ts
@@ -108,7 +108,10 @@ const definitions: PoiDefinition[] = [
     interactionRadius: 2.4,
     footprint: { width: 3.6, depth: 3.2 },
     metrics: [
-      { label: 'Automation', value: 'Sugarkube schedules solar tilt + irrigation' },
+      {
+        label: 'Automation',
+        value: 'Sugarkube schedules solar tilt + irrigation',
+      },
       { label: 'Throughput', value: '3× daily harvest cadence maintained' },
     ],
     links: [

--- a/src/poi/registry.ts
+++ b/src/poi/registry.ts
@@ -95,6 +95,34 @@ const definitions: PoiDefinition[] = [
     ],
     status: 'prototype',
   },
+  {
+    id: 'sugarkube-backyard-greenhouse',
+    title: 'Sugarkube Solar Greenhouse',
+    summary:
+      'Adaptive greenhouse showcasing Sugarkube automation with responsive grow lights and solar tracking.',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'backyard',
+    position: { x: 14.08, y: 0, z: 28.2 },
+    headingRadians: Math.PI * 0.55,
+    interactionRadius: 2.4,
+    footprint: { width: 3.6, depth: 3.2 },
+    metrics: [
+      { label: 'Automation', value: 'Sugarkube schedules solar tilt + irrigation' },
+      { label: 'Throughput', value: '3× daily harvest cadence maintained' },
+    ],
+    links: [
+      {
+        label: 'GitHub',
+        href: 'https://github.com/futuroptimist/sugarkube',
+      },
+      {
+        label: 'Greenhouse Log',
+        href: 'https://futuroptimist.dev/projects/sugarkube',
+      },
+    ],
+    status: 'prototype',
+  },
 ];
 
 assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });

--- a/src/poi/types.ts
+++ b/src/poi/types.ts
@@ -2,7 +2,8 @@ export type PoiId =
   | 'futuroptimist-living-room-tv'
   | 'flywheel-studio-flywheel'
   | 'jobbot-studio-terminal'
-  | 'dspace-backyard-rocket';
+  | 'dspace-backyard-rocket'
+  | 'sugarkube-backyard-greenhouse';
 
 export type PoiCategory = 'project' | 'environment';
 

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -51,4 +51,22 @@ describe('POI registry', () => {
       rocket?.metrics?.some((metric) => metric.label === 'Countdown')
     ).toBe(true);
   });
+
+  it('registers the greenhouse POI with Sugarkube storytelling hooks', () => {
+    const greenhouse = pois.find(
+      (poi) => poi.id === 'sugarkube-backyard-greenhouse'
+    );
+    expect(greenhouse).toBeDefined();
+    expect(greenhouse?.roomId).toBe('backyard');
+    expect(greenhouse?.interactionRadius).toBeGreaterThan(2);
+    expect(greenhouse?.footprint.width).toBeGreaterThan(3);
+    expect(greenhouse?.links?.some((link) =>
+      link.href.includes('sugarkube')
+    )).toBe(true);
+    expect(
+      greenhouse?.metrics?.some((metric) =>
+        /irrigation|solar tilt/i.test(metric.value)
+      )
+    ).toBe(true);
+  });
 });

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -60,9 +60,9 @@ describe('POI registry', () => {
     expect(greenhouse?.roomId).toBe('backyard');
     expect(greenhouse?.interactionRadius).toBeGreaterThan(2);
     expect(greenhouse?.footprint.width).toBeGreaterThan(3);
-    expect(greenhouse?.links?.some((link) =>
-      link.href.includes('sugarkube')
-    )).toBe(true);
+    expect(
+      greenhouse?.links?.some((link) => link.href.includes('sugarkube'))
+    ).toBe(true);
     expect(
       greenhouse?.metrics?.some((metric) =>
         /irrigation|solar tilt/i.test(metric.value)


### PR DESCRIPTION
## Summary
- register backyard greenhouse POI metadata tied to the Sugarkube exhibit
- document the roadmap note for the greenhouse registry hooks
- extend POI registry tests to cover the new backyard entry

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc4c79bd14832f93484492b6ba8b4a