### PR TITLE
Add greenhouse walkway ambient audio bed

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,7 +113,7 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✨ Aluminum extrusion greenhouse inspired by `sugarkube`, complete with animated solar
      trackers, pulsing grow lights, interior planter beds, and a koi pond plinth.
      - ✅ Sugarkube greenhouse POI now surfaces automation metrics and dual CTAs in the registry.
-   - ✨ Ambient audio beds (crickets, hum) that fade based on player proximity.
+   - ✨ Ambient audio beds (crickets, greenhouse chimes) fade based on player proximity.
 
 ## Phase 3 – Interface & Modes
 

--- a/src/audio/proceduralBuffers.ts
+++ b/src/audio/proceduralBuffers.ts
@@ -323,12 +323,7 @@ export function createLanternChimeBuffer<T extends BufferContext>(
   const data = buffer.getChannelData(0);
 
   const prng = createPrng(2027);
-  const overtoneFrequencies = [
-    180,
-    240,
-    320,
-    420,
-  ];
+  const overtoneFrequencies = [180, 240, 320, 420];
 
   for (let i = 0; i < length; i += 1) {
     const time = i / context.sampleRate;
@@ -342,10 +337,10 @@ export function createLanternChimeBuffer<T extends BufferContext>(
         2 * Math.PI * frequency * time +
         Math.sin(time * Math.PI * 0.6 + index * 0.5) * 0.8;
       const envelope =
-        slowPulse *
-          (0.28 + 0.12 * Math.sin(time * Math.PI * 0.5 + index)) +
+        slowPulse * (0.28 + 0.12 * Math.sin(time * Math.PI * 0.5 + index)) +
         shimmer;
-      value += Math.sin(phase + detune) * envelope * (1 / overtoneFrequencies.length);
+      value +=
+        Math.sin(phase + detune) * envelope * (1 / overtoneFrequencies.length);
     });
 
     const rustle = (prng() - 0.5) * 0.08 * slowPulse;

--- a/src/environments/backyard.ts
+++ b/src/environments/backyard.ts
@@ -27,6 +27,15 @@ export interface BackyardEnvironmentBuild {
   group: Group;
   colliders: RectCollider[];
   update(context: { elapsed: number; delta: number }): void;
+  ambientAudioBeds: BackyardAmbientAudioBed[];
+}
+
+export interface BackyardAmbientAudioBed {
+  id: string;
+  center: { x: number; z: number };
+  innerRadius: number;
+  outerRadius: number;
+  baseVolume: number;
 }
 
 function createSignageTexture(title: string, subtitle: string): CanvasTexture {
@@ -78,6 +87,7 @@ export function createBackyardEnvironment(
   const colliders: RectCollider[] = [];
   const updates: Array<(context: { elapsed: number; delta: number }) => void> =
     [];
+  const ambientAudioBeds: BackyardAmbientAudioBed[] = [];
 
   const width = bounds.maxX - bounds.minX;
   const depth = bounds.maxZ - bounds.minZ;
@@ -193,6 +203,15 @@ export function createBackyardEnvironment(
     greenhouseBase.z - greenhouseDepth * 0.65
   );
   group.add(walkway);
+
+  const walkwayMaxExtent = Math.max(walkwayWidth, walkwayDepth);
+  ambientAudioBeds.push({
+    id: 'backyard-greenhouse-chimes',
+    center: { x: walkway.position.x, z: walkway.position.z },
+    innerRadius: Math.max(1, (walkwayMaxExtent / 2) * 0.9),
+    outerRadius: Math.max(1.6, walkwayMaxExtent * 1.2 + 1.4),
+    baseVolume: 0.42,
+  });
 
   interface LanternAnimationTarget {
     glassMaterial: MeshStandardMaterial;
@@ -444,5 +463,5 @@ export function createBackyardEnvironment(
     });
   }
 
-  return { group, colliders, update };
+  return { group, colliders, update, ambientAudioBeds };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1654,9 +1654,8 @@ function initializeImmersiveScene(
           }
           audioBeds.push({
             ...bed,
-            source: createLoopingSource(
-              bed.id,
-              (context) => createLanternChimeBuffer(context)
+            source: createLoopingSource(bed.id, (context) =>
+              createLanternChimeBuffer(context)
             ),
           });
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import {
 import {
   createCricketChorusBuffer,
   createDistantHumBuffer,
+  createLanternChimeBuffer,
 } from './audio/proceduralBuffers';
 import { collidesWithColliders, type RectCollider } from './collision';
 import { KeyboardControls } from './controls/KeyboardControls';
@@ -1645,6 +1646,21 @@ function initializeImmersiveScene(
           createCricketChorusBuffer(context)
         ),
       });
+
+      if (backyardEnvironment) {
+        backyardEnvironment.ambientAudioBeds.forEach((bed) => {
+          if (bed.id !== 'backyard-greenhouse-chimes') {
+            return;
+          }
+          audioBeds.push({
+            ...bed,
+            source: createLoopingSource(
+              bed.id,
+              (context) => createLanternChimeBuffer(context)
+            ),
+          });
+        });
+      }
     }
 
     ambientAudioController = new AmbientAudioController(audioBeds, {

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -149,4 +149,25 @@ describe('createBackyardEnvironment', () => {
     expect(midLightIntensity).not.toBe(baselineLightIntensity);
     expect((firstLight as PointLight).intensity).not.toBe(midLightIntensity);
   });
+
+  it('exposes ambient audio beds centered on the greenhouse walkway', () => {
+    const environment = createBackyardEnvironment(BACKYARD_BOUNDS);
+    expect(environment.ambientAudioBeds.length).toBeGreaterThan(0);
+    const walkwayBed = environment.ambientAudioBeds.find(
+      (bed) => bed.id === 'backyard-greenhouse-chimes'
+    );
+    expect(walkwayBed).toBeDefined();
+
+    const walkway = environment.group.getObjectByName(
+      'BackyardGreenhouseWalkway'
+    ) as Mesh | null;
+    expect(walkway).toBeInstanceOf(Mesh);
+    expect(walkwayBed?.center.x).toBeCloseTo(walkway!.position.x, 5);
+    expect(walkwayBed?.center.z).toBeCloseTo(walkway!.position.z, 5);
+    expect(walkwayBed?.innerRadius).toBeGreaterThan(0);
+    expect(walkwayBed?.outerRadius).toBeGreaterThan(
+      walkwayBed?.innerRadius ?? 0
+    );
+    expect(walkwayBed?.baseVolume).toBeGreaterThan(0);
+  });
 });

--- a/src/tests/proceduralAudioBuffers.test.ts
+++ b/src/tests/proceduralAudioBuffers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createCricketChorusBuffer,
   createDistantHumBuffer,
+  createLanternChimeBuffer,
   type BufferContext,
   type AudioBufferLike,
   _applyLoopFades,
@@ -71,6 +72,23 @@ describe('procedural buffers', () => {
     const context = new FakeContext(5);
     const buffer = createCricketChorusBuffer(context);
     expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  it('builds lantern chimes with gentle shimmer and motion', () => {
+    const context = new FakeContext(48000);
+    const buffer = createLanternChimeBuffer(context);
+    expect(buffer.length).toBeGreaterThan(0);
+    const data = buffer.getChannelData(0);
+    expect(data.every(Number.isFinite)).toBe(true);
+    const totalEnergy = data.reduce((acc, value) => acc + Math.abs(value), 0);
+    expect(totalEnergy).toBeGreaterThan(10);
+    const maxMagnitude = data.reduce(
+      (acc, value) => Math.max(acc, Math.abs(value)),
+      0
+    );
+    expect(maxMagnitude).toBeLessThanOrEqual(1);
+    expect(Math.abs(data[0])).toBeLessThan(1e-3);
+    expect(Math.abs(data.at(-1) ?? 0)).toBeLessThan(1e-3);
   });
 });
 


### PR DESCRIPTION
what:
- add greenhouse walkway audio bed metadata and chime buffer
- wire ambient controller to play localized lantern chimes in backyard
- document the backyard audio slice and extend tests for coverage

why:
- deliver the roadmap backyard ambient audio fade experience

how to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68dcd480aefc832fac58d4c4e6ff35c7