### PR TITLE
Add touch support to POI interaction manager

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,6 +95,7 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✅ Accessibility overlay mirrors POI metadata in HTML so screen readers capture
      hover/selection state.
    - ✅ Registry validation enforces room bounds, unique ids, and safe spacing at build time.
+   - ✅ Touch interactions now share the pointer pipeline so mobile taps mirror desktop focus.
 2. **Interior Showpieces**
    - Wall-mounted TV with YouTube branding for the `futuroptimist` repo; approaching triggers
      a rich text popup with repo summary, star count, and CTA buttons.

--- a/src/poi/interactionManager.ts
+++ b/src/poi/interactionManager.ts
@@ -31,6 +31,7 @@ export class PoiInteractionManager {
   private readonly enableKeyboard: boolean;
   private keyboardIndex: number | null = null;
   private usingKeyboard = false;
+  private touchPointerId: number | null = null;
 
   constructor(
     private readonly domElement: HTMLElement,
@@ -43,6 +44,10 @@ export class PoiInteractionManager {
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleTouchStart = this.handleTouchStart.bind(this);
+    this.handleTouchMove = this.handleTouchMove.bind(this);
+    this.handleTouchEnd = this.handleTouchEnd.bind(this);
+    this.handleTouchCancel = this.handleTouchCancel.bind(this);
 
     const defaultKeyboardTarget =
       options.keyboardTarget ??
@@ -60,6 +65,10 @@ export class PoiInteractionManager {
     this.domElement.addEventListener('mousemove', this.handleMouseMove);
     this.domElement.addEventListener('mouseleave', this.handleMouseLeave);
     this.domElement.addEventListener('click', this.handleClick);
+    this.domElement.addEventListener('touchstart', this.handleTouchStart);
+    this.domElement.addEventListener('touchmove', this.handleTouchMove);
+    this.domElement.addEventListener('touchend', this.handleTouchEnd);
+    this.domElement.addEventListener('touchcancel', this.handleTouchCancel);
     if (this.enableKeyboard) {
       this.keyboardTarget?.addEventListener('keydown', this.handleKeyDown);
     }
@@ -73,6 +82,10 @@ export class PoiInteractionManager {
     this.domElement.removeEventListener('mousemove', this.handleMouseMove);
     this.domElement.removeEventListener('mouseleave', this.handleMouseLeave);
     this.domElement.removeEventListener('click', this.handleClick);
+    this.domElement.removeEventListener('touchstart', this.handleTouchStart);
+    this.domElement.removeEventListener('touchmove', this.handleTouchMove);
+    this.domElement.removeEventListener('touchend', this.handleTouchEnd);
+    this.domElement.removeEventListener('touchcancel', this.handleTouchCancel);
     if (this.enableKeyboard) {
       this.keyboardTarget?.removeEventListener('keydown', this.handleKeyDown);
     }
@@ -144,6 +157,68 @@ export class PoiInteractionManager {
     this.dispatchSelection(poi.definition);
   }
 
+  private handleTouchStart(event: TouchEvent) {
+    if (!event.changedTouches.length) {
+      return;
+    }
+    const touch = event.changedTouches[0];
+    this.touchPointerId = touch.identifier;
+    this.usingKeyboard = false;
+    if (!this.updatePointerFromTouch(touch)) {
+      return;
+    }
+    const poi = this.pickPoi();
+    this.setHovered(poi);
+  }
+
+  private handleTouchMove(event: TouchEvent) {
+    if (!event.changedTouches.length) {
+      return;
+    }
+    const touch = this.getActiveTouch(event.changedTouches);
+    if (!touch) {
+      return;
+    }
+    this.usingKeyboard = false;
+    if (this.touchPointerId === null || touch.identifier !== this.touchPointerId) {
+      this.touchPointerId = touch.identifier;
+    }
+    if (!this.updatePointerFromTouch(touch)) {
+      return;
+    }
+    const poi = this.pickPoi();
+    this.setHovered(poi);
+  }
+
+  private handleTouchEnd(event: TouchEvent) {
+    const touch = this.getActiveTouch(event.changedTouches);
+    this.usingKeyboard = false;
+    if (!touch) {
+      this.touchPointerId = null;
+      this.setHovered(null);
+      return;
+    }
+    this.touchPointerId = null;
+    if (!this.updatePointerFromTouch(touch)) {
+      return;
+    }
+    const poi = this.pickPoi();
+    if (!poi) {
+      this.setSelected(null);
+      this.setHovered(null);
+      return;
+    }
+    this.setHovered(poi);
+    this.setSelected(poi);
+    this.dispatchSelection(poi.definition);
+  }
+
+  private handleTouchCancel() {
+    this.touchPointerId = null;
+    this.usingKeyboard = false;
+    this.setHovered(null);
+  }
+
   private handleKeyDown(event: KeyboardEvent) {
     if (!this.enableKeyboard || this.poiInstances.length === 0) {
       return;
@@ -205,12 +280,23 @@ export class PoiInteractionManager {
   }
 
   private updatePointer(event: MouseEvent): boolean {
+    return this.updatePointerFromClientPosition(event.clientX, event.clientY);
+  }
+
+  private updatePointerFromTouch(touch: Touch): boolean {
+    return this.updatePointerFromClientPosition(touch.clientX, touch.clientY);
+  }
+
+  private updatePointerFromClientPosition(
+    clientX: number,
+    clientY: number
+  ): boolean {
     const rect = this.domElement.getBoundingClientRect();
     if (!rect.width || !rect.height) {
       return false;
     }
-    const normalizedX = (event.clientX - rect.left) / rect.width;
-    const normalizedY = (event.clientY - rect.top) / rect.height;
+    const normalizedX = (clientX - rect.left) / rect.width;
+    const normalizedY = (clientY - rect.top) / rect.height;
     this.pointer.set(normalizedX * 2 - 1, -(normalizedY * 2 - 1));
     return true;
   }
@@ -307,5 +393,21 @@ export class PoiInteractionManager {
     for (const listener of this.selectionStateListeners) {
       listener(poi);
     }
+  }
+
+  private getActiveTouch(touches: TouchList): Touch | null {
+    if (touches.length === 0) {
+      return null;
+    }
+    if (this.touchPointerId === null) {
+      return touches[0] ?? null;
+    }
+    for (let index = 0; index < touches.length; index += 1) {
+      const touch = touches.item(index);
+      if (touch && touch.identifier === this.touchPointerId) {
+        return touch;
+      }
+    }
+    return touches[0] ?? null;
   }
 }

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -109,6 +109,65 @@ function createCanvas(): HTMLCanvasElement {
   return canvas;
 }
 
+interface MockTouchInit {
+  clientX: number;
+  clientY: number;
+  identifier?: number;
+}
+
+function createTouchList(
+  target: EventTarget,
+  touches: MockTouchInit[]
+): TouchList {
+  const entries = touches.map((touch, index) => ({
+    clientX: touch.clientX,
+    clientY: touch.clientY,
+    screenX: touch.clientX,
+    screenY: touch.clientY,
+    pageX: touch.clientX,
+    pageY: touch.clientY,
+    radiusX: 0,
+    radiusY: 0,
+    rotationAngle: 0,
+    force: 0,
+    identifier: touch.identifier ?? index,
+    target,
+  })) as unknown as Touch[];
+  const touchList = {
+    length: entries.length,
+    item(index: number) {
+      return entries[index] ?? null;
+    },
+    [Symbol.iterator]: entries[Symbol.iterator].bind(entries),
+  } as TouchList & { [index: number]: Touch };
+  entries.forEach((touch, index) => {
+    (touchList as { [key: number]: Touch })[index] = touch;
+  });
+  return touchList;
+}
+
+function dispatchTouchEvent(
+  target: HTMLElement,
+  type: 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel',
+  touches: MockTouchInit[]
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  const changedTouches = createTouchList(target, touches);
+  const activeTouches =
+    type === 'touchend' || type === 'touchcancel'
+      ? createTouchList(target, [])
+      : changedTouches;
+  Object.defineProperty(event, 'changedTouches', {
+    configurable: true,
+    value: changedTouches,
+  });
+  Object.defineProperty(event, 'touches', {
+    configurable: true,
+    value: activeTouches,
+  });
+  target.dispatchEvent(event);
+}
+
 describe('PoiInteractionManager', () => {
   const definition: PoiDefinition = {
     id: 'futuroptimist-living-room-tv',
@@ -184,6 +243,49 @@ describe('PoiInteractionManager', () => {
 
     window.removeEventListener('poi:selected', customEventHandler);
     removeSelectionState();
+  });
+
+  it('supports touch interactions for hover and selection', () => {
+    manager.start();
+    const selection = vi.fn();
+    const hover = vi.fn();
+    manager.addSelectionListener(selection);
+    manager.addHoverListener(hover);
+
+    dispatchTouchEvent(domElement, 'touchstart', [
+      { clientX: 200, clientY: 200, identifier: 42 },
+    ]);
+    expect(hover).toHaveBeenLastCalledWith(definition);
+    expect(poi.focusTarget).toBe(1);
+
+    dispatchTouchEvent(domElement, 'touchmove', [
+      { clientX: 210, clientY: 210, identifier: 42 },
+    ]);
+    expect(hover).toHaveBeenLastCalledWith(definition);
+
+    dispatchTouchEvent(domElement, 'touchmove', [
+      { clientX: 205, clientY: 205, identifier: 99 },
+    ]);
+    expect(hover).toHaveBeenLastCalledWith(definition);
+
+    dispatchTouchEvent(domElement, 'touchend', [
+      { clientX: 210, clientY: 210, identifier: 42 },
+    ]);
+    expect(selection).toHaveBeenCalledWith(definition);
+    expect(poi.focusTarget).toBe(1);
+
+    dispatchTouchEvent(domElement, 'touchend', []);
+    expect(hover).toHaveBeenLastCalledWith(null);
+    expect(poi.focusTarget).toBe(1);
+
+    dispatchTouchEvent(domElement, 'touchmove', [
+      { clientX: 200, clientY: 200, identifier: 7 },
+    ]);
+    expect(hover).toHaveBeenLastCalledWith(definition);
+
+    dispatchTouchEvent(domElement, 'touchcancel', []);
+    expect(hover).toHaveBeenLastCalledWith(null);
+    expect(poi.focusTarget).toBe(1);
   });
 
   it('cycles focus with keyboard input and wraps around', () => {


### PR DESCRIPTION
## Summary
- add touch event handling to the POI interaction manager
- exercise touch hover and selection flows through new vitest helpers
- document roadmap progress toward touch parity in the POI framework

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68dcd480aefc832fac58d4c4e6ff35c7