### PR TITLE
Add manual text mode toggle and fallback cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ lightweight.
 - **Movement** – Use `WASD` or arrow keys to roll the sphere.
 - **Touch** – Drag the on-screen joysticks (left: movement, right: camera pan) on touch devices.
 - **Lighting debug** – Press `Shift` + `L` to toggle bloom and LED strips for comparison captures.
+- **Mode toggle** – Press `T` or select the "Text mode" overlay button to jump into the
+  lightweight portfolio view at any time.
 - **Failover** – Append `?mode=text` to the URL to load the lightweight text view.
   Automatic detection now covers missing WebGL support and sustained frame rates below 30 FPS;
   `?mode=immersive` switches back when supported.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,5 +13,4 @@ tasks that deserve immediate attention while the roadmap handles long-range plan
 - docs: add README "Play demo" entry w/ GIF + fallback messaging
 - docs: publish release tags per phase w/ changelog + screenshots
 - chore: wire telemetry-friendly console budget + error reporting (Sentry or proxy)
-- feat: extend failover heuristics (memory/FPS) and surface a HUD toggle for text mode
 - docs: spin up `docs/case-studies/` for POI impact blurbs + KPI receipts

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,6 +135,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - Mode switch between immersive 3D view and a fast-loading text portfolio.
    - Detect low-end/no-JS/scraper clients and auto-route to static mode.
    - Share canonical content via structured data (JSON-LD) for SEO and bots.
+   - ✅ HUD toggle + `T` keybinding now trigger the text portfolio without a page reload.
 3. **Progression & State**
    - Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
    - In-world visual cues for discovered content (e.g., glowing trims, checkmarks).

--- a/index.html
+++ b/index.html
@@ -142,6 +142,10 @@
           <span class="overlay__keys">Q / E</span>
           <span class="overlay__description">Cycle POIs</span>
         </li>
+        <li class="overlay__item">
+          <span class="overlay__keys">T</span>
+          <span class="overlay__description">Switch to text mode</span>
+        </li>
         <li class="overlay__item" data-control="interact" hidden>
           <span class="overlay__keys">F</span>
           <span

--- a/src/failover/manualModeToggle.ts
+++ b/src/failover/manualModeToggle.ts
@@ -1,0 +1,119 @@
+export interface ManualModeToggleOptions {
+  container: HTMLElement;
+  onToggle: () => void | Promise<void>;
+  getIsFallbackActive: () => boolean;
+  windowTarget?: Window;
+  label?: string;
+  description?: string;
+  keyHint?: string;
+}
+
+export interface ManualModeToggleHandle {
+  readonly element: HTMLButtonElement;
+  dispose(): void;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<void> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+export function createManualModeToggle({
+  container,
+  onToggle,
+  getIsFallbackActive,
+  windowTarget = window,
+  label = 'Text mode · Press T',
+  description = 'Switch to the text-only portfolio',
+  keyHint = 'T',
+}: ManualModeToggleOptions): ManualModeToggleHandle {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'mode-toggle';
+  button.textContent = label;
+  button.title = `${description} (${keyHint})`;
+  button.setAttribute('aria-label', description);
+  button.dataset.state = 'idle';
+  container.appendChild(button);
+
+  let pending = false;
+
+  const setPendingState = (next: boolean) => {
+    pending = next;
+    button.disabled = next;
+    button.dataset.state = next ? 'pending' : 'idle';
+    if (next) {
+      button.textContent = 'Switching to text mode…';
+    } else {
+      button.textContent = label;
+    }
+  };
+
+  const activate = () => {
+    if (pending || getIsFallbackActive()) {
+      return;
+    }
+    setPendingState(true);
+    const finalize = () => {
+      queueMicrotask(() => {
+        if (!getIsFallbackActive()) {
+          setPendingState(false);
+        }
+      });
+    };
+    try {
+      const result = onToggle();
+      if (isPromiseLike(result)) {
+        result
+          .then(() => {
+            finalize();
+          })
+          .catch((error) => {
+            console.warn('Manual mode toggle failed:', error);
+            finalize();
+          });
+      } else {
+        finalize();
+      }
+    } catch (error) {
+      console.warn('Manual mode toggle failed:', error);
+      finalize();
+    }
+  };
+
+  const handleClick = () => {
+    activate();
+  };
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (event.key !== keyHint && event.key !== keyHint.toLowerCase()) {
+      return;
+    }
+    if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+      return;
+    }
+    if (pending || getIsFallbackActive()) {
+      return;
+    }
+    event.preventDefault();
+    activate();
+  };
+
+  button.addEventListener('click', handleClick);
+  windowTarget.addEventListener('keydown', handleKeydown);
+
+  return {
+    element: button,
+    dispose() {
+      button.removeEventListener('click', handleClick);
+      windowTarget.removeEventListener('keydown', handleKeydown);
+      if (button.parentElement) {
+        button.remove();
+      }
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1667,10 +1667,7 @@ function initializeImmersiveScene(
       audioButton.textContent = enabled
         ? 'Audio: On · Press M to mute'
         : 'Audio: Off · Press M to unmute';
-      audioButton.setAttribute(
-        'aria-pressed',
-        enabled ? 'true' : 'false'
-      );
+      audioButton.setAttribute('aria-pressed', enabled ? 'true' : 'false');
       audioButton.disabled = audioTogglePending;
     };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -150,6 +150,38 @@ canvas {
   cursor: progress;
 }
 
+.mode-toggle {
+  position: fixed;
+  top: 7.25rem;
+  right: 1.5rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.5rem;
+  background: rgba(5, 12, 21, 0.8);
+  color: #e7f1ff;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(86, 184, 255, 0.3);
+  box-shadow: 0 8px 24px rgba(3, 9, 18, 0.55);
+  cursor: pointer;
+  z-index: 25;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+
+.mode-toggle:hover,
+.mode-toggle:focus-visible {
+  border-color: rgba(143, 214, 255, 0.75);
+  outline: none;
+}
+
+.mode-toggle[data-state='pending'] {
+  cursor: progress;
+  opacity: 0.78;
+}
+
 .overlay {
   position: fixed;
   bottom: 1.5rem;

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createManualModeToggle,
+  type ManualModeToggleHandle,
+} from '../failover/manualModeToggle';
+
+describe('createManualModeToggle', () => {
+  const createContainer = () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    return container;
+  };
+
+  const cleanupHandle = (handle: ManualModeToggleHandle) => {
+    handle.dispose();
+    if (handle.element.parentElement) {
+      handle.element.remove();
+    }
+  };
+
+  it('activates via click and disables while pending', () => {
+    const container = createContainer();
+    let fallbackActive = false;
+    const onToggle = vi.fn(() => {
+      fallbackActive = true;
+    });
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => fallbackActive,
+    });
+
+    handle.element.click();
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.dataset.state).toBe('pending');
+
+    cleanupHandle(handle);
+    container.remove();
+  });
+
+  it('ignores activation when fallback already active', () => {
+    const container = createContainer();
+    const onToggle = vi.fn();
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => true,
+    });
+
+    handle.element.click();
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(handle.element.disabled).toBe(false);
+    expect(handle.element.dataset.state).toBe('idle');
+
+    cleanupHandle(handle);
+    container.remove();
+  });
+
+  it('re-enables the button if onToggle rejects', async () => {
+    const container = createContainer();
+    const handle = createManualModeToggle({
+      container,
+      onToggle: vi
+        .fn()
+        .mockImplementation(() => Promise.reject(new Error('failed'))),
+      getIsFallbackActive: () => false,
+    });
+
+    handle.element.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.element.disabled).toBe(false);
+    expect(handle.element.dataset.state).toBe('idle');
+
+    cleanupHandle(handle);
+    container.remove();
+  });
+
+  it('activates via keyboard using the key hint', () => {
+    const container = createContainer();
+    const onToggle = vi.fn();
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => false,
+      keyHint: 'T',
+    });
+
+    const event = new KeyboardEvent('keydown', { key: 't' });
+    window.dispatchEvent(event);
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    cleanupHandle(handle);
+    container.remove();
+  });
+
+  it('removes listeners and element on dispose', () => {
+    const container = createContainer();
+    const onToggle = vi.fn();
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => false,
+    });
+
+    handle.dispose();
+
+    expect(container.contains(handle.element)).toBe(false);
+
+    handle.element.click();
+    expect(onToggle).not.toHaveBeenCalled();
+
+    const event = new KeyboardEvent('keydown', { key: 'T' });
+    window.dispatchEvent(event);
+    expect(onToggle).not.toHaveBeenCalled();
+
+    container.remove();
+  });
+});

--- a/src/tests/performanceFailover.test.ts
+++ b/src/tests/performanceFailover.test.ts
@@ -114,4 +114,41 @@ describe('createPerformanceFailoverHandler', () => {
     expect(handler.hasTriggered()).toBe(false);
     expect(renderFallback).not.toHaveBeenCalled();
   });
+
+  it('allows manual fallback triggering with preparation hooks', () => {
+    const { renderer, canvas, setAnimationLoop, dispose } = createRenderer();
+    const removeSpy = vi.spyOn(canvas, 'remove');
+    const container = createContainer();
+    container.appendChild(canvas);
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const onTrigger = vi.fn();
+    const onBeforeFallback = vi.fn();
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: '/?mode=immersive',
+      markAppReady,
+      renderFallback,
+      onTrigger,
+      onBeforeFallback,
+    });
+
+    handler.triggerFallback('manual');
+
+    expect(handler.hasTriggered()).toBe(true);
+    expect(onBeforeFallback).toHaveBeenCalledWith('manual');
+    expect(onTrigger).not.toHaveBeenCalled();
+    expect(setAnimationLoop).toHaveBeenCalledWith(null);
+    expect(dispose).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+    expect(renderFallback).toHaveBeenCalledWith(container, {
+      reason: 'manual',
+      immersiveUrl: '/?mode=immersive',
+      resumeUrl: undefined,
+      githubUrl: undefined,
+    });
+    expect(markAppReady).toHaveBeenCalledWith('fallback');
+  });
 });


### PR DESCRIPTION
## Summary
- add a HUD text mode toggle with a T key shortcut for manual fallback
- refactor performance failover to share manual trigger and cleanup hooks
- document the new control in roadmap, backlog, and README

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68dcd480aefc832fac58d4c4e6ff35c7