### PR TITLE
Add HUD ambient audio volume control

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -131,6 +131,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
 1. **HUD Layer**
    - Responsive overlay with movement legend, interaction prompt, and help modal.
    - Sliders/toggles for audio volume, graphics quality, and accessibility presets.
+   - ✅ Ambient audio HUD now exposes a mute toggle and keyboard-friendly volume slider.
    - Mobile-friendly layout that coexists with on-screen joystick.
 2. **Experience Toggle**
    - Mode switch between immersive 3D view and a fast-loading text portfolio.

--- a/src/audio/ambientAudio.ts
+++ b/src/audio/ambientAudio.ts
@@ -70,6 +70,12 @@ export class AmbientAudioController {
 
   private enabled = false;
 
+  private masterVolume = 1;
+
+  private lastListenerPosition: { x: number; z: number } = { x: 0, z: 0 };
+
+  private hasListenerPosition = false;
+
   constructor(
     beds: AmbientAudioBedDefinition[],
     options: AmbientAudioControllerOptions = {}
@@ -128,6 +134,11 @@ export class AmbientAudioController {
   }
 
   update(listenerPosition: { x: number; z: number }, delta: number): void {
+    this.lastListenerPosition = {
+      x: listenerPosition.x,
+      z: listenerPosition.z,
+    };
+    this.hasListenerPosition = true;
     const factor = smoothingFactor(this.smoothing, delta);
     for (const bed of this.beds) {
       const distance = Math.hypot(
@@ -140,7 +151,7 @@ export class AmbientAudioController {
         bed.definition.outerRadius
       );
       const targetVolume = this.enabled
-        ? clamp(bed.definition.baseVolume * attenuation, 0, 1)
+        ? clamp(bed.definition.baseVolume * attenuation * this.masterVolume, 0, 1)
         : 0;
       const nextVolume =
         bed.currentVolume + (targetVolume - bed.currentVolume) * factor;
@@ -148,6 +159,22 @@ export class AmbientAudioController {
       bed.currentVolume = clampedVolume;
       bed.definition.source.setVolume(clampedVolume);
     }
+  }
+
+  getMasterVolume(): number {
+    return this.masterVolume;
+  }
+
+  setMasterVolume(volume: number): void {
+    const clamped = clamp(volume, 0, 1);
+    if (clamped === this.masterVolume) {
+      return;
+    }
+    this.masterVolume = clamped;
+    if (!this.enabled || !this.hasListenerPosition) {
+      return;
+    }
+    this.update(this.lastListenerPosition, 0);
   }
 }
 

--- a/src/controls/audioHudControl.ts
+++ b/src/controls/audioHudControl.ts
@@ -1,0 +1,185 @@
+export interface AudioHudControlOptions {
+  container: HTMLElement;
+  getEnabled: () => boolean;
+  setEnabled: (enabled: boolean) => void | Promise<void>;
+  getVolume: () => number;
+  setVolume: (volume: number) => void;
+  windowTarget?: Window;
+  toggleKey?: string;
+  volumeStep?: number;
+  toggleLabelOn?: string;
+  toggleLabelOff?: string;
+}
+
+export interface AudioHudControlHandle {
+  readonly element: HTMLDivElement;
+  refresh(): void;
+  dispose(): void;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<void> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+const formatVolume = (volume: number) => `${Math.round(volume * 100)}%`;
+
+export function createAudioHudControl({
+  container,
+  getEnabled,
+  setEnabled,
+  getVolume,
+  setVolume,
+  windowTarget = window,
+  toggleKey = 'm',
+  volumeStep = 0.05,
+  toggleLabelOn = 'Audio: On · Press M to mute',
+  toggleLabelOff = 'Audio: Off · Press M to unmute',
+}: AudioHudControlOptions): AudioHudControlHandle {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'audio-hud';
+  wrapper.setAttribute('role', 'group');
+  wrapper.setAttribute('aria-label', 'Ambient audio controls');
+
+  const toggleButton = document.createElement('button');
+  toggleButton.type = 'button';
+  toggleButton.className = 'audio-toggle';
+  toggleButton.title = 'Toggle ambient audio';
+  toggleButton.setAttribute('aria-pressed', 'false');
+
+  const volumeLabel = document.createElement('label');
+  volumeLabel.className = 'audio-volume';
+  volumeLabel.htmlFor = 'audio-volume-slider';
+  const labelText = document.createElement('span');
+  labelText.className = 'audio-volume__label';
+  labelText.textContent = 'Ambient volume';
+
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.id = 'audio-volume-slider';
+  slider.className = 'audio-volume__slider';
+  slider.name = 'ambient-audio-volume';
+  slider.min = '0';
+  slider.max = '1';
+  slider.step = volumeStep.toString();
+  slider.setAttribute('aria-label', 'Ambient audio volume');
+
+  const valueText = document.createElement('span');
+  valueText.className = 'audio-volume__value';
+  valueText.setAttribute('aria-live', 'polite');
+
+  volumeLabel.appendChild(labelText);
+  volumeLabel.appendChild(slider);
+  volumeLabel.appendChild(valueText);
+
+  wrapper.appendChild(toggleButton);
+  wrapper.appendChild(volumeLabel);
+  container.appendChild(wrapper);
+
+  let pending = false;
+
+  const updateToggle = () => {
+    const enabled = getEnabled();
+    const nextLabel = enabled ? toggleLabelOn : toggleLabelOff;
+    toggleButton.dataset.state = enabled ? 'on' : 'off';
+    toggleButton.textContent = nextLabel;
+    toggleButton.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    toggleButton.disabled = pending;
+    wrapper.dataset.pending = pending ? 'true' : 'false';
+  };
+
+  const updateVolume = () => {
+    const volume = clamp(getVolume(), 0, 1);
+    slider.value = volume.toString();
+    slider.setAttribute('aria-valuenow', volume.toFixed(2));
+    slider.setAttribute('aria-valuetext', formatVolume(volume));
+    valueText.textContent = formatVolume(volume);
+  };
+
+  const finalizeToggle = () => {
+    pending = false;
+    updateToggle();
+  };
+
+  const activateToggle = () => {
+    if (pending) {
+      return;
+    }
+    const enabled = getEnabled();
+    const nextState = !enabled;
+    pending = true;
+    updateToggle();
+    try {
+      const result = setEnabled(nextState);
+      if (isPromiseLike(result)) {
+        result
+          .catch((error) => {
+            console.warn('Failed to toggle ambient audio:', error);
+          })
+          .finally(() => {
+            finalizeToggle();
+          });
+      } else {
+        finalizeToggle();
+      }
+    } catch (error) {
+      console.warn('Failed to toggle ambient audio:', error);
+      finalizeToggle();
+    }
+  };
+
+  const handleSliderInput = () => {
+    const value = clamp(Number.parseFloat(slider.value), 0, 1);
+    setVolume(value);
+    updateVolume();
+  };
+
+  const handleToggleClick = () => {
+    activateToggle();
+  };
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (event.key !== toggleKey && event.key !== toggleKey.toUpperCase()) {
+      return;
+    }
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+    event.preventDefault();
+    activateToggle();
+  };
+
+  toggleButton.addEventListener('click', handleToggleClick);
+  slider.addEventListener('input', handleSliderInput);
+  windowTarget.addEventListener('keydown', handleKeydown);
+
+  updateToggle();
+  updateVolume();
+
+  return {
+    element: wrapper,
+    refresh() {
+      updateToggle();
+      updateVolume();
+    },
+    dispose() {
+      toggleButton.removeEventListener('click', handleToggleClick);
+      slider.removeEventListener('input', handleSliderInput);
+      windowTarget.removeEventListener('keydown', handleKeydown);
+      if (wrapper.parentElement) {
+        wrapper.remove();
+      }
+    },
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -113,21 +113,43 @@ canvas {
   color: #ffe5c4;
 }
 
-.audio-toggle {
+
+.audio-hud {
   position: fixed;
   top: 4.5rem;
   right: 1.5rem;
-  padding: 0.6rem 0.9rem;
-  border-radius: 0.5rem;
-  background: rgba(5, 12, 21, 0.8);
+  width: 16rem;
+  max-width: calc(100vw - 3rem);
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(5, 12, 21, 0.82);
   color: #e7f1ff;
   font-size: 0.85rem;
   letter-spacing: 0.01em;
   backdrop-filter: blur(12px);
   border: 1px solid rgba(86, 184, 255, 0.3);
-  box-shadow: 0 8px 24px rgba(3, 9, 18, 0.55);
-  cursor: pointer;
+  box-shadow: 0 12px 28px rgba(3, 9, 18, 0.55);
   z-index: 25;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.audio-hud[data-pending='true'] {
+  opacity: 0.82;
+}
+
+.audio-toggle {
+  width: 100%;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.5rem;
+  background: rgba(8, 16, 28, 0.95);
+  color: #e7f1ff;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  border: 1px solid rgba(86, 184, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(7, 28, 48, 0.4);
+  cursor: pointer;
   transition:
     border-color 120ms ease,
     background 120ms ease,
@@ -150,9 +172,35 @@ canvas {
   cursor: progress;
 }
 
+.audio-volume {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: rgba(215, 235, 255, 0.88);
+}
+
+.audio-volume__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(180, 220, 255, 0.85);
+}
+
+.audio-volume__slider {
+  width: 100%;
+  accent-color: #58b7ff;
+}
+
+.audio-volume__value {
+  font-size: 0.78rem;
+  text-align: right;
+  color: rgba(224, 244, 255, 0.92);
+  font-variant-numeric: tabular-nums;
+}
+
 .mode-toggle {
   position: fixed;
-  top: 7.25rem;
+  top: 10.25rem;
   right: 1.5rem;
   padding: 0.6rem 0.9rem;
   border-radius: 0.5rem;

--- a/src/tests/audioHudControl.test.ts
+++ b/src/tests/audioHudControl.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAudioHudControl } from '../controls/audioHudControl';
+
+describe('createAudioHudControl', () => {
+  it('renders controls, syncs state, and handles async toggles', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let enabled = false;
+    let volume = 0.6;
+    let toggleCallCount = 0;
+    let resolveToggle: (() => void) | null = null;
+
+    const handle = createAudioHudControl({
+      container,
+      getEnabled: () => enabled,
+      setEnabled: (next) => {
+        enabled = next;
+        toggleCallCount += 1;
+        return new Promise<void>((resolve) => {
+          resolveToggle = resolve;
+        });
+      },
+      getVolume: () => volume,
+      setVolume: (value) => {
+        volume = value;
+      },
+    });
+
+    const button = container.querySelector('button.audio-toggle');
+    const slider = container.querySelector<HTMLInputElement>('.audio-volume__slider');
+    const valueText = container.querySelector('.audio-volume__value');
+    expect(button).toBeTruthy();
+    expect(slider).toBeTruthy();
+    expect(valueText?.textContent).toBe('60%');
+
+    button?.dispatchEvent(new Event('click'));
+    expect(toggleCallCount).toBe(1);
+    expect(button?.disabled).toBe(true);
+
+    // Second click while pending should be ignored.
+    button?.dispatchEvent(new Event('click'));
+    expect(toggleCallCount).toBe(1);
+
+    resolveToggle?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(button?.disabled).toBe(false);
+    expect(button?.dataset.state).toBe('on');
+
+    slider!.value = '0.82';
+    slider?.dispatchEvent(new Event('input'));
+    expect(volume).toBeCloseTo(0.82, 5);
+    expect(valueText?.textContent).toBe('82%');
+
+    volume = 0.25;
+    enabled = false;
+    handle.refresh();
+    expect(button?.dataset.state).toBe('off');
+    expect(valueText?.textContent).toBe('25%');
+
+    slider!.value = '1.6';
+    slider?.dispatchEvent(new Event('input'));
+    expect(volume).toBe(1);
+    expect(valueText?.textContent).toBe('100%');
+
+    handle.dispose();
+    expect(container.querySelector('.audio-hud')).toBeNull();
+  });
+
+  it('responds to keyboard toggles and recovers from failures', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let enabled = true;
+    let rejected = false;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const handle = createAudioHudControl({
+      container,
+      getEnabled: () => enabled,
+      setEnabled: () => {
+        enabled = !enabled;
+        if (!rejected) {
+          rejected = true;
+          return Promise.reject(new Error('fail'));
+        }
+        return undefined;
+      },
+      getVolume: () => 0.4,
+      setVolume: vi.fn(),
+      toggleKey: 'm',
+    });
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'm', ctrlKey: true })
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    const event = new KeyboardEvent('keydown', { key: 'M' });
+    window.dispatchEvent(event);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to toggle ambient audio:',
+      expect.any(Error)
+    );
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    handle.dispose();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add audio HUD module with mute toggle and volume slider
- support master volume control in ambient audio controller
- restyle overlay and document HUD progress in the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68de047c7aac832f878acfce421899a8