### PR TITLE
Route automated clients to text fallback

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -137,7 +137,9 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - Mobile-friendly layout that coexists with on-screen joystick.
 2. **Experience Toggle**
    - Mode switch between immersive 3D view and a fast-loading text portfolio.
-   - Detect low-end/no-JS/scraper clients and auto-route to static mode.
+   - ✅ Detect low-end/no-JS/scraper clients and auto-route to static mode.
+     Automated UA heuristics now default preview bots to the text portfolio while low-memory
+     detection handles budget devices.
    - Share canonical content via structured data (JSON-LD) for SEO and bots.
    - ✅ JSON-LD structured data now mirrors the POI registry so bots and scrapers receive the
      same exhibit catalog as players.


### PR DESCRIPTION
## Summary
- add automated client heuristics so scrapers default to the text portfolio
- expose detector overrides, extend fallback messaging, and update the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68dec11e3588832f94e9be7b33661687