### PR TITLE
Add HUD graphics quality presets

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,6 +133,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - ✅ Help modal opens from the HUD button or `H`/`?` hotkeys and surfaces controls,
      accessibility tips, and failover guidance.
    - Sliders/toggles for audio volume, graphics quality, and accessibility presets.
+     - ✅ Graphics HUD presets let players choose Cinematic, Balanced, or Performance modes
+       that retune bloom, LED lighting, and pixel ratio for their device.
    - ✅ Ambient audio HUD now exposes a mute toggle and keyboard-friendly volume slider.
    - Mobile-friendly layout that coexists with on-screen joystick.
 2. **Experience Toggle**

--- a/src/controls/graphicsQualityControl.ts
+++ b/src/controls/graphicsQualityControl.ts
@@ -10,9 +10,7 @@ export interface GraphicsQualityControlOptions {
   container: HTMLElement;
   presets: ReadonlyArray<GraphicsQualityControlPreset>;
   getActiveLevel: () => GraphicsQualityLevel;
-  setActiveLevel: (
-    level: GraphicsQualityLevel
-  ) => void | Promise<void>;
+  setActiveLevel: (level: GraphicsQualityLevel) => void | Promise<void>;
   title?: string;
   description?: string;
 }

--- a/src/controls/graphicsQualityControl.ts
+++ b/src/controls/graphicsQualityControl.ts
@@ -1,0 +1,200 @@
+import type { GraphicsQualityLevel } from '../graphics/qualityManager';
+
+export interface GraphicsQualityControlPreset {
+  id: GraphicsQualityLevel;
+  label: string;
+  description: string;
+}
+
+export interface GraphicsQualityControlOptions {
+  container: HTMLElement;
+  presets: ReadonlyArray<GraphicsQualityControlPreset>;
+  getActiveLevel: () => GraphicsQualityLevel;
+  setActiveLevel: (
+    level: GraphicsQualityLevel
+  ) => void | Promise<void>;
+  title?: string;
+  description?: string;
+}
+
+export interface GraphicsQualityControlHandle {
+  readonly element: HTMLElement;
+  refresh(): void;
+  dispose(): void;
+}
+
+let nextControlId = 0;
+
+function isPromiseLike(value: unknown): value is PromiseLike<void> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+export function createGraphicsQualityControl({
+  container,
+  presets,
+  getActiveLevel,
+  setActiveLevel,
+  title = 'Graphics quality',
+  description = 'Pick a preset that matches your device performance.',
+}: GraphicsQualityControlOptions): GraphicsQualityControlHandle {
+  if (!presets.length) {
+    throw new Error('Graphics quality control requires at least one preset.');
+  }
+
+  const controlId = `graphics-quality-${nextControlId++}`;
+
+  const wrapper = document.createElement('section');
+  wrapper.className = 'graphics-quality';
+  wrapper.dataset.pending = 'false';
+
+  const heading = document.createElement('h2');
+  heading.className = 'graphics-quality__title';
+  heading.textContent = title;
+
+  const descriptionParagraph = document.createElement('p');
+  descriptionParagraph.className = 'graphics-quality__description';
+  descriptionParagraph.textContent = description;
+
+  const optionList = document.createElement('div');
+  optionList.className = 'graphics-quality__options';
+  optionList.setAttribute('role', 'radiogroup');
+  optionList.setAttribute('aria-labelledby', `${controlId}-title`);
+
+  heading.id = `${controlId}-title`;
+
+  const liveRegion = document.createElement('div');
+  liveRegion.className = 'graphics-quality__status';
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.setAttribute('aria-atomic', 'true');
+
+  wrapper.append(heading, descriptionParagraph, optionList, liveRegion);
+  container.appendChild(wrapper);
+
+  const inputs: HTMLInputElement[] = [];
+  const labels = new Map<string, HTMLElement>();
+
+  let pending = false;
+
+  const updateLiveRegion = (text: string) => {
+    liveRegion.textContent = text;
+  };
+
+  const updateSelection = () => {
+    const active = getActiveLevel();
+    inputs.forEach((input) => {
+      const isActive = input.value === active;
+      input.checked = isActive;
+      input.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      const label = labels.get(input.value);
+      if (label) {
+        label.dataset.state = isActive ? 'active' : 'idle';
+      }
+    });
+    updateLiveRegion(
+      `${presets.find((preset) => preset.id === active)?.label ?? active} preset selected.`
+    );
+  };
+
+  const setPending = (value: boolean) => {
+    pending = value;
+    wrapper.dataset.pending = value ? 'true' : 'false';
+    inputs.forEach((input) => {
+      input.disabled = value;
+    });
+  };
+
+  const handleError = (error: unknown) => {
+    console.warn('Failed to update graphics quality:', error);
+    setPending(false);
+    updateSelection();
+  };
+
+  const handleSelection = (level: GraphicsQualityLevel) => {
+    if (pending) {
+      updateSelection();
+      return;
+    }
+    const current = getActiveLevel();
+    if (current === level) {
+      updateSelection();
+      return;
+    }
+    setPending(true);
+    try {
+      const result = setActiveLevel(level);
+      if (isPromiseLike(result)) {
+        result
+          .then(() => {
+            setPending(false);
+            updateSelection();
+          })
+          .catch(handleError);
+      } else {
+        setPending(false);
+        updateSelection();
+      }
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  presets.forEach((preset, index) => {
+    const optionLabel = document.createElement('label');
+    optionLabel.className = 'graphics-quality__option';
+    optionLabel.dataset.state = 'idle';
+
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.className = 'graphics-quality__radio';
+    input.name = controlId;
+    input.value = preset.id;
+    input.setAttribute('aria-label', preset.label);
+    input.setAttribute('role', 'radio');
+    if (index === 0) {
+      input.setAttribute('tabindex', '0');
+    }
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'graphics-quality__option-title';
+    titleSpan.textContent = preset.label;
+
+    const descriptionSpan = document.createElement('span');
+    descriptionSpan.className = 'graphics-quality__option-description';
+    descriptionSpan.textContent = preset.description;
+
+    input.addEventListener('change', () => {
+      if (input.checked) {
+        handleSelection(preset.id);
+      }
+    });
+
+    optionLabel.append(input, titleSpan, descriptionSpan);
+    optionList.appendChild(optionLabel);
+
+    inputs.push(input);
+    labels.set(preset.id, optionLabel);
+  });
+
+  updateSelection();
+
+  return {
+    element: wrapper,
+    refresh() {
+      updateSelection();
+    },
+    dispose() {
+      inputs.forEach((input) => {
+        const clone = input.cloneNode(true) as HTMLInputElement;
+        input.replaceWith(clone);
+      });
+      if (wrapper.parentElement) {
+        wrapper.remove();
+      }
+    },
+  };
+}

--- a/src/graphics/qualityManager.ts
+++ b/src/graphics/qualityManager.ts
@@ -1,0 +1,265 @@
+export type GraphicsQualityLevel = 'cinematic' | 'balanced' | 'performance';
+
+export interface GraphicsQualityPresetDefinition {
+  id: GraphicsQualityLevel;
+  label: string;
+  description: string;
+  pixelRatioScale: number;
+  exposure: number;
+  bloom: {
+    enabled: boolean;
+    strengthScale: number;
+    radiusScale: number;
+    thresholdOffset: number;
+  };
+  led: {
+    emissiveScale: number;
+    lightScale: number;
+  };
+}
+
+export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[] = [
+  {
+    id: 'cinematic',
+    label: 'Cinematic',
+    description: 'Full post-processing with cinematic bloom and lighting.',
+    pixelRatioScale: 1,
+    exposure: 1.1,
+    bloom: {
+      enabled: true,
+      strengthScale: 1,
+      radiusScale: 1,
+      thresholdOffset: 0,
+    },
+    led: {
+      emissiveScale: 1,
+      lightScale: 1,
+    },
+  },
+  {
+    id: 'balanced',
+    label: 'Balanced',
+    description: 'Moderate bloom with slightly reduced resolution for laptops.',
+    pixelRatioScale: 0.85,
+    exposure: 1.02,
+    bloom: {
+      enabled: true,
+      strengthScale: 0.8,
+      radiusScale: 0.92,
+      thresholdOffset: 0.05,
+    },
+    led: {
+      emissiveScale: 0.85,
+      lightScale: 0.85,
+    },
+  },
+  {
+    id: 'performance',
+    label: 'Performance',
+    description: 'Disables bloom and lowers resolution to prioritize FPS.',
+    pixelRatioScale: 0.7,
+    exposure: 0.96,
+    bloom: {
+      enabled: false,
+      strengthScale: 0,
+      radiusScale: 0.8,
+      thresholdOffset: 0.12,
+    },
+    led: {
+      emissiveScale: 0.65,
+      lightScale: 0.6,
+    },
+  },
+] as const;
+
+export interface RendererLike {
+  getPixelRatio(): number;
+  setPixelRatio(value: number): void;
+  toneMappingExposure: number;
+}
+
+export interface BloomPassLike {
+  enabled: boolean;
+  strength: number;
+  radius: number;
+  threshold: number;
+}
+
+export interface LedMaterialLike {
+  emissiveIntensity: number;
+}
+
+export interface LedLightLike {
+  intensity: number;
+}
+
+export interface GraphicsQualityManagerOptions {
+  renderer: RendererLike;
+  bloomPass?: BloomPassLike | null;
+  ledStripMaterials?: Iterable<LedMaterialLike>;
+  ledFillLights?: Iterable<LedLightLike>;
+  basePixelRatio: number;
+  baseBloom: {
+    strength: number;
+    radius: number;
+    threshold: number;
+  };
+  baseLed: {
+    emissiveIntensity: number;
+    lightIntensity: number;
+  };
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  storageKey?: string;
+}
+
+export interface GraphicsQualityManager {
+  getLevel(): GraphicsQualityLevel;
+  setLevel(level: GraphicsQualityLevel): void;
+  refresh(): void;
+  setBasePixelRatio(pixelRatio: number): void;
+  onChange(listener: (level: GraphicsQualityLevel) => void): () => void;
+}
+
+const DEFAULT_STORAGE_KEY = 'danielsmith:graphics-quality-level';
+
+function isGraphicsQualityLevel(value: unknown): value is GraphicsQualityLevel {
+  return (
+    typeof value === 'string' &&
+    GRAPHICS_QUALITY_PRESETS.some((preset) => preset.id === value)
+  );
+}
+
+interface LedMaterialEntry {
+  target: LedMaterialLike;
+  baseIntensity: number;
+}
+
+interface LedLightEntry {
+  target: LedLightLike;
+  baseIntensity: number;
+}
+
+export function createGraphicsQualityManager({
+  renderer,
+  bloomPass,
+  ledStripMaterials,
+  ledFillLights,
+  basePixelRatio,
+  baseBloom,
+  baseLed,
+  storage,
+  storageKey = DEFAULT_STORAGE_KEY,
+}: GraphicsQualityManagerOptions): GraphicsQualityManager {
+  let currentBasePixelRatio = sanitizePixelRatio(basePixelRatio);
+  const ledMaterialEntries: LedMaterialEntry[] = ledStripMaterials
+    ? Array.from(ledStripMaterials, (material) => ({
+        target: material,
+        baseIntensity: Number.isFinite(material.emissiveIntensity)
+          ? material.emissiveIntensity
+          : baseLed.emissiveIntensity,
+      }))
+    : [];
+  const ledLightEntries: LedLightEntry[] = ledFillLights
+    ? Array.from(ledFillLights, (light) => ({
+        target: light,
+        baseIntensity: Number.isFinite(light.intensity)
+          ? light.intensity
+          : baseLed.lightIntensity,
+      }))
+    : [];
+
+  const listeners = new Set<(level: GraphicsQualityLevel) => void>();
+
+  let currentLevel: GraphicsQualityLevel = 'cinematic';
+  const stored = storage?.getItem?.(storageKey) ?? null;
+  if (isGraphicsQualityLevel(stored)) {
+    currentLevel = stored;
+  }
+
+  applyPreset(currentLevel);
+
+  function sanitizePixelRatio(value: number): number {
+    if (!Number.isFinite(value) || value <= 0) {
+      return 1;
+    }
+    return Math.max(0.5, Math.min(value, 3));
+  }
+
+  function applyPreset(level: GraphicsQualityLevel) {
+    const preset = GRAPHICS_QUALITY_PRESETS.find(
+      (definition) => definition.id === level
+    );
+    if (!preset) {
+      throw new Error(`Unknown graphics quality preset: ${level}`);
+    }
+
+    const scaledPixelRatio = sanitizePixelRatio(
+      currentBasePixelRatio * preset.pixelRatioScale
+    );
+    renderer.setPixelRatio(scaledPixelRatio);
+    renderer.toneMappingExposure = preset.exposure;
+
+    if (bloomPass) {
+      bloomPass.enabled = preset.bloom.enabled;
+      bloomPass.strength = baseBloom.strength * preset.bloom.strengthScale;
+      bloomPass.radius = baseBloom.radius * preset.bloom.radiusScale;
+      bloomPass.threshold =
+        baseBloom.threshold + preset.bloom.thresholdOffset;
+    }
+
+    ledMaterialEntries.forEach(({ target, baseIntensity }) => {
+      target.emissiveIntensity = baseIntensity * preset.led.emissiveScale;
+    });
+
+    ledLightEntries.forEach(({ target, baseIntensity }) => {
+      target.intensity = baseIntensity * preset.led.lightScale;
+    });
+  }
+
+  function persist(level: GraphicsQualityLevel) {
+    if (!storage) {
+      return;
+    }
+    try {
+      storage.setItem(storageKey, level);
+    } catch (error) {
+      console.warn('Failed to persist graphics quality level:', error);
+    }
+  }
+
+  function notify() {
+    listeners.forEach((listener) => listener(currentLevel));
+  }
+
+  return {
+    getLevel() {
+      return currentLevel;
+    },
+    setLevel(level) {
+      if (!isGraphicsQualityLevel(level)) {
+        throw new Error(`Unsupported graphics quality level: ${level}`);
+      }
+      if (level === currentLevel) {
+        persist(level);
+        return;
+      }
+      currentLevel = level;
+      persist(level);
+      applyPreset(level);
+      notify();
+    },
+    refresh() {
+      applyPreset(currentLevel);
+    },
+    setBasePixelRatio(pixelRatio: number) {
+      currentBasePixelRatio = sanitizePixelRatio(pixelRatio);
+      applyPreset(currentLevel);
+    },
+    onChange(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/src/graphics/qualityManager.ts
+++ b/src/graphics/qualityManager.ts
@@ -18,59 +18,61 @@ export interface GraphicsQualityPresetDefinition {
   };
 }
 
-export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[] = [
-  {
-    id: 'cinematic',
-    label: 'Cinematic',
-    description: 'Full post-processing with cinematic bloom and lighting.',
-    pixelRatioScale: 1,
-    exposure: 1.1,
-    bloom: {
-      enabled: true,
-      strengthScale: 1,
-      radiusScale: 1,
-      thresholdOffset: 0,
+export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[] =
+  [
+    {
+      id: 'cinematic',
+      label: 'Cinematic',
+      description: 'Full post-processing with cinematic bloom and lighting.',
+      pixelRatioScale: 1,
+      exposure: 1.1,
+      bloom: {
+        enabled: true,
+        strengthScale: 1,
+        radiusScale: 1,
+        thresholdOffset: 0,
+      },
+      led: {
+        emissiveScale: 1,
+        lightScale: 1,
+      },
     },
-    led: {
-      emissiveScale: 1,
-      lightScale: 1,
+    {
+      id: 'balanced',
+      label: 'Balanced',
+      description:
+        'Moderate bloom with slightly reduced resolution for laptops.',
+      pixelRatioScale: 0.85,
+      exposure: 1.02,
+      bloom: {
+        enabled: true,
+        strengthScale: 0.8,
+        radiusScale: 0.92,
+        thresholdOffset: 0.05,
+      },
+      led: {
+        emissiveScale: 0.85,
+        lightScale: 0.85,
+      },
     },
-  },
-  {
-    id: 'balanced',
-    label: 'Balanced',
-    description: 'Moderate bloom with slightly reduced resolution for laptops.',
-    pixelRatioScale: 0.85,
-    exposure: 1.02,
-    bloom: {
-      enabled: true,
-      strengthScale: 0.8,
-      radiusScale: 0.92,
-      thresholdOffset: 0.05,
+    {
+      id: 'performance',
+      label: 'Performance',
+      description: 'Disables bloom and lowers resolution to prioritize FPS.',
+      pixelRatioScale: 0.7,
+      exposure: 0.96,
+      bloom: {
+        enabled: false,
+        strengthScale: 0,
+        radiusScale: 0.8,
+        thresholdOffset: 0.12,
+      },
+      led: {
+        emissiveScale: 0.65,
+        lightScale: 0.6,
+      },
     },
-    led: {
-      emissiveScale: 0.85,
-      lightScale: 0.85,
-    },
-  },
-  {
-    id: 'performance',
-    label: 'Performance',
-    description: 'Disables bloom and lowers resolution to prioritize FPS.',
-    pixelRatioScale: 0.7,
-    exposure: 0.96,
-    bloom: {
-      enabled: false,
-      strengthScale: 0,
-      radiusScale: 0.8,
-      thresholdOffset: 0.12,
-    },
-    led: {
-      emissiveScale: 0.65,
-      lightScale: 0.6,
-    },
-  },
-] as const;
+  ] as const;
 
 export interface RendererLike {
   getPixelRatio(): number;
@@ -209,8 +211,7 @@ export function createGraphicsQualityManager({
       bloomPass.enabled = preset.bloom.enabled;
       bloomPass.strength = baseBloom.strength * preset.bloom.strengthScale;
       bloomPass.radius = baseBloom.radius * preset.bloom.radiusScale;
-      bloomPass.threshold =
-        baseBloom.threshold + preset.bloom.thresholdOffset;
+      bloomPass.threshold = baseBloom.threshold + preset.bloom.thresholdOffset;
     }
 
     ledMaterialEntries.forEach(({ target, baseIntensity }) => {

--- a/src/graphics/qualityManager.ts
+++ b/src/graphics/qualityManager.ts
@@ -171,9 +171,15 @@ export function createGraphicsQualityManager({
   const listeners = new Set<(level: GraphicsQualityLevel) => void>();
 
   let currentLevel: GraphicsQualityLevel = 'cinematic';
-  const stored = storage?.getItem?.(storageKey) ?? null;
-  if (isGraphicsQualityLevel(stored)) {
-    currentLevel = stored;
+  if (storage?.getItem) {
+    try {
+      const stored = storage.getItem(storageKey);
+      if (isGraphicsQualityLevel(stored)) {
+        currentLevel = stored;
+      }
+    } catch (error) {
+      console.warn('Failed to read persisted graphics quality level:', error);
+    }
   }
 
   applyPreset(currentLevel);

--- a/src/styles.css
+++ b/src/styles.css
@@ -252,7 +252,9 @@ canvas {
   border: 1px solid rgba(86, 184, 255, 0.22);
   background: rgba(8, 16, 28, 0.78);
   box-shadow: inset 0 0 0 1px rgba(7, 28, 48, 0.3);
-  transition: border-color 120ms ease, box-shadow 120ms ease;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
   cursor: pointer;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -197,6 +197,102 @@ canvas {
   font-variant-numeric: tabular-nums;
 }
 
+.graphics-quality {
+  position: fixed;
+  top: 13.6rem;
+  right: 1.5rem;
+  width: 16rem;
+  max-width: calc(100vw - 3rem);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(5, 12, 21, 0.82);
+  color: #e7f1ff;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(86, 184, 255, 0.28);
+  box-shadow: 0 12px 28px rgba(3, 9, 18, 0.55);
+  z-index: 25;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.graphics-quality[data-pending='true'] {
+  opacity: 0.8;
+}
+
+.graphics-quality__title {
+  margin: 0;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(196, 228, 255, 0.85);
+}
+
+.graphics-quality__description {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(215, 235, 255, 0.88);
+  line-height: 1.4;
+}
+
+.graphics-quality__options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.graphics-quality__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(86, 184, 255, 0.22);
+  background: rgba(8, 16, 28, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(7, 28, 48, 0.3);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+  cursor: pointer;
+}
+
+.graphics-quality__option[data-state='active'] {
+  border-color: rgba(120, 212, 168, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(34, 180, 128, 0.35);
+}
+
+.graphics-quality__option:hover,
+.graphics-quality__option:focus-within {
+  border-color: rgba(143, 214, 255, 0.75);
+}
+
+.graphics-quality__radio {
+  margin-top: 0.2rem;
+}
+
+.graphics-quality__option-title {
+  font-weight: 600;
+  color: rgba(224, 244, 255, 0.94);
+}
+
+.graphics-quality__option-description {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.76rem;
+  color: rgba(200, 224, 255, 0.78);
+}
+
+.graphics-quality__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}
+
 .mode-toggle {
   position: fixed;
   top: 10.25rem;

--- a/src/tests/graphicsQualityControl.test.ts
+++ b/src/tests/graphicsQualityControl.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGraphicsQualityControl } from '../controls/graphicsQualityControl';
+import {
+  GRAPHICS_QUALITY_PRESETS,
+  type GraphicsQualityLevel,
+} from '../graphics/qualityManager';
+
+describe('createGraphicsQualityControl', () => {
+  const presets = GRAPHICS_QUALITY_PRESETS.map(({ id, label, description }) => ({
+    id,
+    label,
+    description,
+  }));
+
+  it('renders presets, updates state, and handles refreshes', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    let level: GraphicsQualityLevel = 'cinematic';
+    const setActive = vi.fn((next: GraphicsQualityLevel) => {
+      level = next;
+    });
+
+    const control = createGraphicsQualityControl({
+      container,
+      presets,
+      getActiveLevel: () => level,
+      setActiveLevel: setActive,
+    });
+
+    const options = Array.from(
+      container.querySelectorAll<HTMLInputElement>(
+        '.graphics-quality__radio'
+      )
+    );
+    expect(options).toHaveLength(presets.length);
+    expect(options[0].checked).toBe(true);
+
+    options[1].checked = true;
+    options[1].dispatchEvent(new Event('change'));
+    expect(setActive).toHaveBeenCalledWith('balanced');
+    expect(level).toBe('balanced');
+
+    control.refresh();
+    expect(options[1].checked).toBe(true);
+    expect(container.querySelector('.graphics-quality__status')?.textContent).toContain(
+      'Balanced preset selected'
+    );
+
+    control.dispose();
+    expect(container.querySelector('.graphics-quality')).toBeNull();
+  });
+
+  it('handles async updates and reverts on failure', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    let level: GraphicsQualityLevel = 'cinematic';
+    let rejectNext = true;
+
+    const setActive = vi.fn((next: GraphicsQualityLevel) => {
+      if (rejectNext) {
+        rejectNext = false;
+        return Promise.reject(new Error('nope'));
+      }
+      level = next;
+      return Promise.resolve();
+    });
+
+    const control = createGraphicsQualityControl({
+      container,
+      presets,
+      getActiveLevel: () => level,
+      setActiveLevel: setActive,
+    });
+
+    const radios = container.querySelectorAll<HTMLInputElement>(
+      '.graphics-quality__radio'
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    radios[2].checked = true;
+    radios[2].dispatchEvent(new Event('change'));
+    await vi.waitFor(() =>
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to update graphics quality:',
+        expect.any(Error)
+      )
+    );
+    expect(radios[0].checked).toBe(true);
+
+    radios[2].checked = true;
+    radios[2].dispatchEvent(new Event('change'));
+    await vi.waitFor(() => expect(level).toBe('performance'));
+    expect(level).toBe('performance');
+    expect(radios[2].checked).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    control.dispose();
+    warnSpy.mockRestore();
+  });
+
+  it('throws when no presets are provided', () => {
+    expect(() =>
+      createGraphicsQualityControl({
+        container: document.createElement('div'),
+        presets: [],
+        getActiveLevel: () => 'cinematic',
+        setActiveLevel: () => {},
+      })
+    ).toThrow(/requires at least one preset/i);
+  });
+});

--- a/src/tests/graphicsQualityControl.test.ts
+++ b/src/tests/graphicsQualityControl.test.ts
@@ -7,11 +7,13 @@ import {
 } from '../graphics/qualityManager';
 
 describe('createGraphicsQualityControl', () => {
-  const presets = GRAPHICS_QUALITY_PRESETS.map(({ id, label, description }) => ({
-    id,
-    label,
-    description,
-  }));
+  const presets = GRAPHICS_QUALITY_PRESETS.map(
+    ({ id, label, description }) => ({
+      id,
+      label,
+      description,
+    })
+  );
 
   it('renders presets, updates state, and handles refreshes', async () => {
     const container = document.createElement('div');
@@ -30,9 +32,7 @@ describe('createGraphicsQualityControl', () => {
     });
 
     const options = Array.from(
-      container.querySelectorAll<HTMLInputElement>(
-        '.graphics-quality__radio'
-      )
+      container.querySelectorAll<HTMLInputElement>('.graphics-quality__radio')
     );
     expect(options).toHaveLength(presets.length);
     expect(options[0].checked).toBe(true);
@@ -44,9 +44,9 @@ describe('createGraphicsQualityControl', () => {
 
     control.refresh();
     expect(options[1].checked).toBe(true);
-    expect(container.querySelector('.graphics-quality__status')?.textContent).toContain(
-      'Balanced preset selected'
-    );
+    expect(
+      container.querySelector('.graphics-quality__status')?.textContent
+    ).toContain('Balanced preset selected');
 
     control.dispose();
     expect(container.querySelector('.graphics-quality')).toBeNull();

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  GRAPHICS_QUALITY_PRESETS,
+  createGraphicsQualityManager,
+  type BloomPassLike,
+  type GraphicsQualityLevel,
+  type RendererLike,
+} from '../graphics/qualityManager';
+
+describe('createGraphicsQualityManager', () => {
+  const baseBloom = {
+    strength: 0.55,
+    radius: 0.85,
+    threshold: 0.2,
+  } as const;
+
+  const baseLed = {
+    emissiveIntensity: 3.2,
+    lightIntensity: 1.4,
+  } as const;
+
+  const createRenderer = () => {
+    let pixelRatio = 1;
+    const renderer: RendererLike = {
+      getPixelRatio: () => pixelRatio,
+      setPixelRatio: (value: number) => {
+        pixelRatio = value;
+      },
+      toneMappingExposure: 1,
+    };
+    return { renderer, get pixelRatio() { return pixelRatio; } };
+  };
+
+  it('applies presets, persists selections, and notifies listeners', () => {
+    const { renderer } = createRenderer();
+    const bloom: BloomPassLike = {
+      enabled: true,
+      strength: baseBloom.strength,
+      radius: baseBloom.radius,
+      threshold: baseBloom.threshold,
+    };
+    const ledMaterial = { emissiveIntensity: baseLed.emissiveIntensity };
+    const ledLight = { intensity: baseLed.lightIntensity };
+    const storage = {
+      getItem: vi.fn<[], string | null>().mockReturnValue('balanced'),
+      setItem: vi.fn<[string, string], void>(),
+    };
+
+    const manager = createGraphicsQualityManager({
+      renderer,
+      bloomPass: bloom,
+      ledStripMaterials: [ledMaterial],
+      ledFillLights: [ledLight],
+      basePixelRatio: 2,
+      baseBloom,
+      baseLed,
+      storage,
+    });
+
+    expect(manager.getLevel()).toBe('balanced');
+    expect(renderer.getPixelRatio()).toBeCloseTo(2 * 0.85, 3);
+    expect(renderer.toneMappingExposure).toBeCloseTo(1.02, 3);
+    expect(bloom.enabled).toBe(true);
+    expect(bloom.strength).toBeCloseTo(baseBloom.strength * 0.8, 3);
+    expect(bloom.radius).toBeCloseTo(baseBloom.radius * 0.92, 3);
+    expect(bloom.threshold).toBeCloseTo(baseBloom.threshold + 0.05, 3);
+    expect(ledMaterial.emissiveIntensity).toBeCloseTo(
+      baseLed.emissiveIntensity * 0.85,
+      3
+    );
+    expect(ledLight.intensity).toBeCloseTo(
+      baseLed.lightIntensity * 0.85,
+      3
+    );
+
+    const listener = vi.fn();
+    const unsubscribe = manager.onChange(listener);
+
+    manager.setLevel('performance');
+    expect(listener).toHaveBeenCalledWith('performance');
+    expect(renderer.getPixelRatio()).toBeCloseTo(2 * 0.7, 3);
+    expect(renderer.toneMappingExposure).toBeCloseTo(0.96, 3);
+    expect(bloom.enabled).toBe(false);
+    expect(bloom.threshold).toBeCloseTo(baseBloom.threshold + 0.12, 3);
+    expect(ledMaterial.emissiveIntensity).toBeCloseTo(
+      baseLed.emissiveIntensity * 0.65,
+      3
+    );
+    expect(ledLight.intensity).toBeCloseTo(baseLed.lightIntensity * 0.6, 3);
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'danielsmith:graphics-quality-level',
+      'performance'
+    );
+
+    listener.mockClear();
+    manager.setLevel('performance');
+    expect(listener).not.toHaveBeenCalled();
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'danielsmith:graphics-quality-level',
+      'performance'
+    );
+
+    unsubscribe();
+    manager.setLevel('cinematic');
+    expect(listener).not.toHaveBeenCalled();
+    expect(renderer.getPixelRatio()).toBeCloseTo(2, 3);
+    expect(renderer.toneMappingExposure).toBeCloseTo(1.1, 3);
+  });
+
+  it('handles storage failures and optional bloom/lights gracefully', () => {
+    const { renderer } = createRenderer();
+    const storage = {
+      getItem: vi.fn().mockReturnValue('invalid'),
+      setItem: vi.fn(() => {
+        throw new Error('nope');
+      }),
+    } as const;
+
+    const manager = createGraphicsQualityManager({
+      renderer,
+      bloomPass: null,
+      ledStripMaterials: [],
+      ledFillLights: undefined,
+      basePixelRatio: Number.NaN,
+      baseBloom,
+      baseLed,
+      storage,
+    });
+
+    expect(manager.getLevel()).toBe('cinematic');
+    expect(renderer.getPixelRatio()).toBeCloseTo(1, 3);
+
+    manager.setLevel('balanced');
+    expect(renderer.getPixelRatio()).toBeCloseTo(0.85, 3);
+
+    manager.setBasePixelRatio(2.4);
+    expect(renderer.getPixelRatio()).toBeCloseTo(2.4 * 0.85, 3);
+
+    manager.refresh();
+    expect(renderer.getPixelRatio()).toBeCloseTo(2.4 * 0.85, 3);
+  });
+
+  it('throws for unsupported levels', () => {
+    const { renderer } = createRenderer();
+    const manager = createGraphicsQualityManager({
+      renderer,
+      basePixelRatio: 1,
+      baseBloom,
+      baseLed,
+    });
+
+    expect(() => manager.setLevel('balanced')).not.toThrow();
+    expect(() => manager.setLevel('invalid' as GraphicsQualityLevel)).toThrow(
+      /unsupported graphics quality level/i
+    );
+  });
+
+  it('exports preset metadata', () => {
+    const ids = GRAPHICS_QUALITY_PRESETS.map((preset) => preset.id);
+    expect(ids).toEqual(['cinematic', 'balanced', 'performance']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable HUD graphics quality control with accessibility affordances
- apply new quality presets to renderer, bloom, and LED lighting via a manager with storage support
- document the new preset in the roadmap and cover the change with dedicated tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68dec11e3588832f94e9be7b33661687