### PR TITLE
Fix POI analytics argument handling for runtime instrumentation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,6 +92,8 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✨ Pedestals fade in tooltips and halo guides as players enter their interaction radii.
    - ✅ Desktop pointer interaction manager highlights POIs and emits selection events.
    - ✅ Analytics hooks emit hover and selection lifecycle events for instrumentation pipelines.
+   - ✅ Interaction manager now normalizes analytics injection so instrumentation fires when
+     options are omitted in runtime wiring.
    - ✅ Accessibility overlay mirrors POI metadata in HTML so screen readers capture
      hover/selection state.
    - ✅ Registry validation enforces room bounds, unique ids, and safe spacing at build time.

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -480,4 +480,33 @@ describe('PoiInteractionManager', () => {
     manager.dispose();
     expect(selectionCleared).toHaveBeenCalledWith(definition);
   });
+
+  it('supports analytics passed without options for backward compatibility', () => {
+    const analytics = {
+      hoverStarted: vi.fn(),
+      hoverEnded: vi.fn(),
+      selected: vi.fn(),
+      selectionCleared: vi.fn(),
+    } satisfies PoiAnalytics;
+
+    manager.dispose();
+    manager = new PoiInteractionManager(domElement, camera, [poi], analytics);
+    manager.start();
+
+    domElement.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 200, clientY: 200 })
+    );
+    expect(analytics.hoverStarted).toHaveBeenCalledWith(definition);
+
+    domElement.dispatchEvent(
+      new MouseEvent('click', { clientX: 200, clientY: 200 })
+    );
+    expect(analytics.selected).toHaveBeenCalledWith(definition);
+
+    domElement.dispatchEvent(new MouseEvent('mouseleave'));
+    expect(analytics.hoverEnded).toHaveBeenCalledWith(definition);
+
+    manager.dispose();
+    expect(analytics.selectionCleared).toHaveBeenCalledWith(definition);
+  });
 });


### PR DESCRIPTION
## Summary
- allow PoiInteractionManager to treat analytics as 4th arg
- add regression test verifying instrumentation when options omitted
- update roadmap entry for analytics wiring

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68df7ded39c8832f93181fc3ff3a2e0e