### PR TITLE
Add HUD accessibility presets and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ lightweight.
 - **Lighting debug** – Press `Shift` + `L` to toggle bloom and LED strips for comparison captures.
 - **Mode toggle** – Press `T` or select the "Text mode" overlay button to jump into the
   lightweight portfolio view at any time.
+- **Accessibility presets** – Pick Standard, Calm, or Photosensitive-safe modes from the HUD
+  to soften bloom, reduce motion cues, and boost overlay contrast.
 - **Help** – Press `H` or `?`, or tap the HUD Help button to open a modal with controls,
   accessibility tips, and failover guidance.
 - **Failover** – Append `?mode=text` to the URL to load the lightweight text view.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,7 +132,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - Responsive overlay with movement legend, interaction prompt, and help modal.
    - ✅ Help modal opens from the HUD button or `H`/`?` hotkeys and surfaces controls,
      accessibility tips, and failover guidance.
-   - Sliders/toggles for audio volume, graphics quality, and accessibility presets.
+   - ✅ Accessibility HUD presets now expose Standard, Calm, and Photosensitive-safe modes
+     that soften bloom, ease emissives, duck ambient audio, and boost HUD contrast.
      - ✅ Graphics HUD presets let players choose Cinematic, Balanced, or Performance modes
        that retune bloom, LED lighting, and pixel ratio for their device.
    - ✅ Ambient audio HUD now exposes a mute toggle and keyboard-friendly volume slider.

--- a/src/accessibility/presetManager.ts
+++ b/src/accessibility/presetManager.ts
@@ -57,7 +57,8 @@ export const ACCESSIBILITY_PRESETS: readonly AccessibilityPresetDefinition[] = [
   {
     id: 'calm',
     label: 'Calm',
-    description: 'Softens bloom, LED glow, and ambient audio for a gentler pass.',
+    description:
+      'Softens bloom, LED glow, and ambient audio for a gentler pass.',
     motion: 'reduced',
     contrast: 'standard',
     bloom: {
@@ -141,8 +142,12 @@ function clamp01(value: number): number {
   return value;
 }
 
-function isAccessibilityPresetId(value: unknown): value is AccessibilityPresetId {
-  return typeof value === 'string' && ACCESSIBILITY_PRESET_MAP.has(value as never);
+function isAccessibilityPresetId(
+  value: unknown
+): value is AccessibilityPresetId {
+  return (
+    typeof value === 'string' && ACCESSIBILITY_PRESET_MAP.has(value as never)
+  );
 }
 
 export function createAccessibilityPresetManager({
@@ -155,9 +160,7 @@ export function createAccessibilityPresetManager({
   storage,
   storageKey = DEFAULT_STORAGE_KEY,
 }: AccessibilityPresetManagerOptions): AccessibilityPresetManager {
-  const ledMaterials = ledStripMaterials
-    ? Array.from(ledStripMaterials)
-    : [];
+  const ledMaterials = ledStripMaterials ? Array.from(ledStripMaterials) : [];
   const ledLights = ledFillLights ? Array.from(ledFillLights) : [];
 
   let baseAudioVolume = clamp01(
@@ -178,7 +181,9 @@ export function createAccessibilityPresetManager({
 
   const listeners = new Set<(preset: AccessibilityPresetId) => void>();
 
-  const applyDocumentAttributes = (definition: AccessibilityPresetDefinition) => {
+  const applyDocumentAttributes = (
+    definition: AccessibilityPresetDefinition
+  ) => {
     documentElement.dataset.accessibilityPreset = definition.id;
     documentElement.dataset.accessibilityMotion =
       definition.motion === 'reduced' ? 'reduced' : 'default';
@@ -186,9 +191,7 @@ export function createAccessibilityPresetManager({
       definition.contrast === 'high' ? 'high' : 'standard';
   };
 
-  const applyBloomAndLighting = (
-    definition: AccessibilityPresetDefinition
-  ) => {
+  const applyBloomAndLighting = (definition: AccessibilityPresetDefinition) => {
     graphicsQualityManager.refresh();
 
     if (bloomPass) {

--- a/src/accessibility/presetManager.ts
+++ b/src/accessibility/presetManager.ts
@@ -1,0 +1,314 @@
+import type { AmbientAudioController } from '../audio/ambientAudio';
+import type {
+  BloomPassLike,
+  GraphicsQualityManager,
+  LedLightLike,
+  LedMaterialLike,
+} from '../graphics/qualityManager';
+
+export type AccessibilityPresetId = 'standard' | 'calm' | 'photosensitive';
+
+type MotionSetting = 'default' | 'reduced';
+type ContrastSetting = 'standard' | 'high';
+
+type BooleanLike = boolean | undefined;
+
+export interface AccessibilityPresetDefinition {
+  readonly id: AccessibilityPresetId;
+  readonly label: string;
+  readonly description: string;
+  readonly motion: MotionSetting;
+  readonly contrast: ContrastSetting;
+  readonly bloom: {
+    readonly enabled?: BooleanLike;
+    readonly strengthScale: number;
+    readonly radiusScale: number;
+    readonly thresholdOffset: number;
+  };
+  readonly led: {
+    readonly emissiveScale: number;
+    readonly lightScale: number;
+  };
+  readonly audio: {
+    readonly volumeScale: number;
+  };
+}
+
+export const ACCESSIBILITY_PRESETS: readonly AccessibilityPresetDefinition[] = [
+  {
+    id: 'standard',
+    label: 'Standard',
+    description: 'Default visuals and audio balance.',
+    motion: 'default',
+    contrast: 'standard',
+    bloom: {
+      strengthScale: 1,
+      radiusScale: 1,
+      thresholdOffset: 0,
+    },
+    led: {
+      emissiveScale: 1,
+      lightScale: 1,
+    },
+    audio: {
+      volumeScale: 1,
+    },
+  },
+  {
+    id: 'calm',
+    label: 'Calm',
+    description: 'Softens bloom, LED glow, and ambient audio for a gentler pass.',
+    motion: 'reduced',
+    contrast: 'standard',
+    bloom: {
+      strengthScale: 0.6,
+      radiusScale: 0.9,
+      thresholdOffset: 0.02,
+    },
+    led: {
+      emissiveScale: 0.75,
+      lightScale: 0.8,
+    },
+    audio: {
+      volumeScale: 0.8,
+    },
+  },
+  {
+    id: 'photosensitive',
+    label: 'Photosensitive safe',
+    description: 'Disables bloom, dulls emissives, and boosts HUD contrast.',
+    motion: 'reduced',
+    contrast: 'high',
+    bloom: {
+      enabled: false,
+      strengthScale: 0,
+      radiusScale: 1,
+      thresholdOffset: 0.05,
+    },
+    led: {
+      emissiveScale: 0.55,
+      lightScale: 0.6,
+    },
+    audio: {
+      volumeScale: 0.7,
+    },
+  },
+] as const;
+
+const ACCESSIBILITY_PRESET_MAP = new Map(
+  ACCESSIBILITY_PRESETS.map((preset) => [preset.id, preset])
+);
+
+const DEFAULT_STORAGE_KEY = 'danielsmith:accessibility-preset';
+
+interface GraphicsQualityManagerLike
+  extends Pick<GraphicsQualityManager, 'refresh' | 'onChange' | 'getLevel'> {}
+
+interface AmbientAudioControllerLike
+  extends Pick<AmbientAudioController, 'setMasterVolume' | 'getMasterVolume'> {}
+
+export interface AccessibilityPresetManagerOptions {
+  documentElement: HTMLElement;
+  graphicsQualityManager: GraphicsQualityManagerLike;
+  bloomPass?: BloomPassLike | null;
+  ledStripMaterials?: Iterable<LedMaterialLike>;
+  ledFillLights?: Iterable<LedLightLike>;
+  ambientAudioController?: AmbientAudioControllerLike | null;
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  storageKey?: string;
+}
+
+export interface AccessibilityPresetManager {
+  getPreset(): AccessibilityPresetId;
+  setPreset(preset: AccessibilityPresetId): void;
+  refresh(): void;
+  getBaseAudioVolume(): number;
+  setBaseAudioVolume(volume: number): void;
+  onChange(listener: (preset: AccessibilityPresetId) => void): () => void;
+  dispose(): void;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (value <= 0) {
+    return 0;
+  }
+  if (value >= 1) {
+    return 1;
+  }
+  return value;
+}
+
+function isAccessibilityPresetId(value: unknown): value is AccessibilityPresetId {
+  return typeof value === 'string' && ACCESSIBILITY_PRESET_MAP.has(value as never);
+}
+
+export function createAccessibilityPresetManager({
+  documentElement,
+  graphicsQualityManager,
+  bloomPass,
+  ledStripMaterials,
+  ledFillLights,
+  ambientAudioController,
+  storage,
+  storageKey = DEFAULT_STORAGE_KEY,
+}: AccessibilityPresetManagerOptions): AccessibilityPresetManager {
+  const ledMaterials = ledStripMaterials
+    ? Array.from(ledStripMaterials)
+    : [];
+  const ledLights = ledFillLights ? Array.from(ledFillLights) : [];
+
+  let baseAudioVolume = clamp01(
+    ambientAudioController?.getMasterVolume?.() ?? 1
+  );
+  let presetId: AccessibilityPresetId = 'standard';
+
+  if (storage?.getItem) {
+    try {
+      const stored = storage.getItem(storageKey);
+      if (isAccessibilityPresetId(stored)) {
+        presetId = stored;
+      }
+    } catch (error) {
+      console.warn('Failed to read persisted accessibility preset:', error);
+    }
+  }
+
+  const listeners = new Set<(preset: AccessibilityPresetId) => void>();
+
+  const applyDocumentAttributes = (definition: AccessibilityPresetDefinition) => {
+    documentElement.dataset.accessibilityPreset = definition.id;
+    documentElement.dataset.accessibilityMotion =
+      definition.motion === 'reduced' ? 'reduced' : 'default';
+    documentElement.dataset.accessibilityContrast =
+      definition.contrast === 'high' ? 'high' : 'standard';
+  };
+
+  const applyBloomAndLighting = (
+    definition: AccessibilityPresetDefinition
+  ) => {
+    graphicsQualityManager.refresh();
+
+    if (bloomPass) {
+      if (typeof definition.bloom.enabled === 'boolean') {
+        bloomPass.enabled = definition.bloom.enabled;
+      }
+      if (bloomPass.enabled) {
+        bloomPass.strength *= definition.bloom.strengthScale;
+        bloomPass.radius *= definition.bloom.radiusScale;
+        bloomPass.threshold += definition.bloom.thresholdOffset;
+      }
+    }
+
+    if (ledMaterials.length) {
+      for (const material of ledMaterials) {
+        if (Number.isFinite(material.emissiveIntensity)) {
+          material.emissiveIntensity *= definition.led.emissiveScale;
+        }
+      }
+    }
+
+    if (ledLights.length) {
+      for (const light of ledLights) {
+        if (Number.isFinite(light.intensity)) {
+          light.intensity *= definition.led.lightScale;
+        }
+      }
+    }
+  };
+
+  const applyAudio = (definition: AccessibilityPresetDefinition) => {
+    if (!ambientAudioController) {
+      return;
+    }
+    const effectiveVolume = clamp01(
+      baseAudioVolume * definition.audio.volumeScale
+    );
+    ambientAudioController.setMasterVolume(effectiveVolume);
+  };
+
+  const applyPreset = (definition: AccessibilityPresetDefinition) => {
+    applyDocumentAttributes(definition);
+    applyBloomAndLighting(definition);
+    applyAudio(definition);
+  };
+
+  const persist = (id: AccessibilityPresetId) => {
+    if (!storage?.setItem) {
+      return;
+    }
+    try {
+      storage.setItem(storageKey, id);
+    } catch (error) {
+      console.warn('Failed to persist accessibility preset:', error);
+    }
+  };
+
+  const notify = () => {
+    listeners.forEach((listener) => listener(presetId));
+  };
+
+  const getDefinition = (
+    id: AccessibilityPresetId
+  ): AccessibilityPresetDefinition => {
+    const definition = ACCESSIBILITY_PRESET_MAP.get(id);
+    if (!definition) {
+      throw new Error(`Unknown accessibility preset: ${id}`);
+    }
+    return definition;
+  };
+
+  const currentDefinition = () => getDefinition(presetId);
+
+  const qualityUnsubscribe = graphicsQualityManager.onChange(() => {
+    applyPreset(currentDefinition());
+  });
+
+  applyPreset(currentDefinition());
+
+  return {
+    getPreset() {
+      return presetId;
+    },
+    setPreset(id) {
+      if (!isAccessibilityPresetId(id)) {
+        throw new Error(`Unsupported accessibility preset: ${id}`);
+      }
+      if (presetId === id) {
+        persist(id);
+        applyPreset(currentDefinition());
+        return;
+      }
+      presetId = id;
+      persist(id);
+      applyPreset(currentDefinition());
+      notify();
+    },
+    refresh() {
+      applyPreset(currentDefinition());
+    },
+    getBaseAudioVolume() {
+      return baseAudioVolume;
+    },
+    setBaseAudioVolume(volume) {
+      const clamped = clamp01(volume);
+      if (clamped === baseAudioVolume) {
+        return;
+      }
+      baseAudioVolume = clamped;
+      applyAudio(currentDefinition());
+    },
+    onChange(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    dispose() {
+      qualityUnsubscribe?.();
+      listeners.clear();
+    },
+  };
+}

--- a/src/controls/accessibilityPresetControl.ts
+++ b/src/controls/accessibilityPresetControl.ts
@@ -41,7 +41,9 @@ export function createAccessibilityPresetControl({
   description = 'Tune motion assists and HUD contrast.',
 }: AccessibilityPresetControlOptions): AccessibilityPresetControlHandle {
   if (!options.length) {
-    throw new Error('Accessibility preset control requires at least one option.');
+    throw new Error(
+      'Accessibility preset control requires at least one option.'
+    );
   }
 
   const controlId = `accessibility-presets-${nextControlId++}`;
@@ -92,7 +94,8 @@ export function createAccessibilityPresetControl({
         label.dataset.state = isActive ? 'active' : 'idle';
       }
     });
-    const activeLabel = options.find((option) => option.id === active)?.label ?? active;
+    const activeLabel =
+      options.find((option) => option.id === active)?.label ?? active;
     updateLiveRegion(`${activeLabel} preset selected.`);
   };
 

--- a/src/controls/accessibilityPresetControl.ts
+++ b/src/controls/accessibilityPresetControl.ts
@@ -1,0 +1,196 @@
+import type { AccessibilityPresetId } from '../accessibility/presetManager';
+
+export interface AccessibilityPresetOption {
+  id: AccessibilityPresetId;
+  label: string;
+  description: string;
+}
+
+export interface AccessibilityPresetControlOptions {
+  container: HTMLElement;
+  options: readonly AccessibilityPresetOption[];
+  getActivePreset: () => AccessibilityPresetId;
+  setActivePreset: (preset: AccessibilityPresetId) => void | Promise<void>;
+  title?: string;
+  description?: string;
+}
+
+export interface AccessibilityPresetControlHandle {
+  readonly element: HTMLElement;
+  refresh(): void;
+  dispose(): void;
+}
+
+let nextControlId = 0;
+
+function isPromiseLike(value: unknown): value is PromiseLike<void> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+export function createAccessibilityPresetControl({
+  container,
+  options,
+  getActivePreset,
+  setActivePreset,
+  title = 'Accessibility presets',
+  description = 'Tune motion assists and HUD contrast.',
+}: AccessibilityPresetControlOptions): AccessibilityPresetControlHandle {
+  if (!options.length) {
+    throw new Error('Accessibility preset control requires at least one option.');
+  }
+
+  const controlId = `accessibility-presets-${nextControlId++}`;
+
+  const wrapper = document.createElement('section');
+  wrapper.className = 'accessibility-presets';
+  wrapper.dataset.pending = 'false';
+
+  const heading = document.createElement('h2');
+  heading.className = 'accessibility-presets__title';
+  heading.id = `${controlId}-title`;
+  heading.textContent = title;
+
+  const descriptionParagraph = document.createElement('p');
+  descriptionParagraph.className = 'accessibility-presets__description';
+  descriptionParagraph.textContent = description;
+
+  const list = document.createElement('div');
+  list.className = 'accessibility-presets__options';
+  list.setAttribute('role', 'radiogroup');
+  list.setAttribute('aria-labelledby', heading.id);
+
+  const liveRegion = document.createElement('div');
+  liveRegion.className = 'accessibility-presets__status';
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.setAttribute('aria-atomic', 'true');
+
+  wrapper.append(heading, descriptionParagraph, list, liveRegion);
+  container.appendChild(wrapper);
+
+  const inputs: HTMLInputElement[] = [];
+  const optionLabels = new Map<string, HTMLElement>();
+
+  let pending = false;
+
+  const updateLiveRegion = (text: string) => {
+    liveRegion.textContent = text;
+  };
+
+  const updateSelection = () => {
+    const active = getActivePreset();
+    inputs.forEach((input) => {
+      const isActive = input.value === active;
+      input.checked = isActive;
+      input.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      const label = optionLabels.get(input.value);
+      if (label) {
+        label.dataset.state = isActive ? 'active' : 'idle';
+      }
+    });
+    const activeLabel = options.find((option) => option.id === active)?.label ?? active;
+    updateLiveRegion(`${activeLabel} preset selected.`);
+  };
+
+  const setPending = (value: boolean) => {
+    pending = value;
+    wrapper.dataset.pending = value ? 'true' : 'false';
+    inputs.forEach((input) => {
+      input.disabled = value;
+    });
+  };
+
+  const handleError = (error: unknown) => {
+    console.warn('Failed to update accessibility preset:', error);
+    setPending(false);
+    updateSelection();
+  };
+
+  const handleSelection = (preset: AccessibilityPresetId) => {
+    if (pending) {
+      updateSelection();
+      return;
+    }
+    const current = getActivePreset();
+    if (current === preset) {
+      updateSelection();
+      return;
+    }
+    setPending(true);
+    try {
+      const result = setActivePreset(preset);
+      if (isPromiseLike(result)) {
+        result
+          .then(() => {
+            setPending(false);
+            updateSelection();
+          })
+          .catch(handleError);
+      } else {
+        setPending(false);
+        updateSelection();
+      }
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  options.forEach((option, index) => {
+    const label = document.createElement('label');
+    label.className = 'accessibility-presets__option';
+    label.dataset.state = 'idle';
+
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.className = 'accessibility-presets__radio';
+    input.name = controlId;
+    input.value = option.id;
+    input.setAttribute('role', 'radio');
+    input.setAttribute('aria-label', option.label);
+    if (index === 0) {
+      input.setAttribute('tabindex', '0');
+    }
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'accessibility-presets__option-title';
+    titleSpan.textContent = option.label;
+
+    const descriptionSpan = document.createElement('span');
+    descriptionSpan.className = 'accessibility-presets__option-description';
+    descriptionSpan.textContent = option.description;
+
+    input.addEventListener('change', () => {
+      if (input.checked) {
+        handleSelection(option.id);
+      }
+    });
+
+    label.append(input, titleSpan, descriptionSpan);
+    list.appendChild(label);
+
+    inputs.push(input);
+    optionLabels.set(option.id, label);
+  });
+
+  updateSelection();
+
+  return {
+    element: wrapper,
+    refresh() {
+      updateSelection();
+    },
+    dispose() {
+      inputs.forEach((input) => {
+        const clone = input.cloneNode(true) as HTMLInputElement;
+        input.replaceWith(clone);
+      });
+      if (wrapper.parentElement) {
+        wrapper.remove();
+      }
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -697,9 +697,11 @@ function initializeImmersiveScene(
   let graphicsQualityControl: GraphicsQualityControlHandle | null = null;
   let unsubscribeGraphicsQuality: (() => void) | null = null;
   let accessibilityPresetManager: AccessibilityPresetManager | null = null;
-  let accessibilityControlHandle: AccessibilityPresetControlHandle | null = null;
+  let accessibilityControlHandle: AccessibilityPresetControlHandle | null =
+    null;
   let unsubscribeAccessibility: (() => void) | null = null;
-  let getAmbientAudioVolume = () => ambientAudioController?.getMasterVolume() ?? 1;
+  let getAmbientAudioVolume = () =>
+    ambientAudioController?.getMasterVolume() ?? 1;
   let setAmbientAudioVolume = (volume: number) => {
     ambientAudioController?.setMasterVolume(volume);
   };

--- a/src/styles.css
+++ b/src/styles.css
@@ -295,6 +295,104 @@ canvas {
   border: 0;
 }
 
+.accessibility-presets {
+  position: fixed;
+  top: 21.8rem;
+  right: 1.5rem;
+  width: 16rem;
+  max-width: calc(100vw - 3rem);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(5, 12, 21, 0.82);
+  color: #e7f1ff;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(86, 184, 255, 0.28);
+  box-shadow: 0 12px 28px rgba(3, 9, 18, 0.55);
+  z-index: 25;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.accessibility-presets[data-pending='true'] {
+  opacity: 0.82;
+}
+
+.accessibility-presets__title {
+  margin: 0;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(196, 228, 255, 0.85);
+}
+
+.accessibility-presets__description {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(215, 235, 255, 0.88);
+  line-height: 1.4;
+}
+
+.accessibility-presets__options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.accessibility-presets__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(86, 184, 255, 0.22);
+  background: rgba(8, 16, 28, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(7, 28, 48, 0.3);
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+  cursor: pointer;
+}
+
+.accessibility-presets__option[data-state='active'] {
+  border-color: rgba(120, 212, 168, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(34, 180, 128, 0.35);
+}
+
+.accessibility-presets__option:hover,
+.accessibility-presets__option:focus-within {
+  border-color: rgba(143, 214, 255, 0.75);
+}
+
+.accessibility-presets__radio {
+  margin-top: 0.2rem;
+}
+
+.accessibility-presets__option-title {
+  font-weight: 600;
+  color: rgba(224, 244, 255, 0.94);
+}
+
+.accessibility-presets__option-description {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.76rem;
+  color: rgba(200, 224, 255, 0.78);
+}
+
+.accessibility-presets__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}
+
 .mode-toggle {
   position: fixed;
   top: 10.25rem;
@@ -396,6 +494,52 @@ canvas {
   .overlay__item--desktop {
     display: none;
   }
+}
+
+:root[data-accessibility-motion='reduced'] .audio-hud,
+:root[data-accessibility-motion='reduced'] .graphics-quality,
+:root[data-accessibility-motion='reduced'] .mode-toggle,
+:root[data-accessibility-motion='reduced'] .overlay,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
+:root[data-accessibility-motion='reduced'] .accessibility-presets {
+  transition: none !important;
+  animation: none !important;
+}
+
+:root[data-accessibility-contrast='high'] .audio-hud,
+:root[data-accessibility-contrast='high'] .graphics-quality,
+:root[data-accessibility-contrast='high'] .mode-toggle,
+:root[data-accessibility-contrast='high'] .overlay,
+:root[data-accessibility-contrast='high'] .poi-tooltip-overlay,
+:root[data-accessibility-contrast='high'] .accessibility-presets {
+  background: rgba(4, 10, 18, 0.92);
+  border-color: rgba(214, 238, 255, 0.5);
+  color: #f5f9ff;
+  box-shadow: 0 14px 36px rgba(2, 6, 12, 0.7);
+}
+
+:root[data-accessibility-contrast='high'] .audio-toggle {
+  background: rgba(10, 18, 30, 0.96);
+  border-color: rgba(174, 238, 255, 0.6);
+  color: #ffffff;
+}
+
+:root[data-accessibility-contrast='high'] .graphics-quality__option,
+:root[data-accessibility-contrast='high'] .accessibility-presets__option {
+  background: rgba(10, 18, 30, 0.92);
+  border-color: rgba(174, 238, 255, 0.5);
+}
+
+:root[data-accessibility-contrast='high'] .graphics-quality__option-title,
+:root[data-accessibility-contrast='high'] .accessibility-presets__option-title {
+  color: #f4fbff;
+}
+
+:root[data-accessibility-contrast='high'] .graphics-quality__option-description,
+:root[data-accessibility-contrast='high'] .accessibility-presets__option-description,
+:root[data-accessibility-contrast='high'] .audio-volume__label,
+:root[data-accessibility-contrast='high'] .audio-volume__value {
+  color: rgba(240, 250, 255, 0.88);
 }
 
 .overlay__help-button {

--- a/src/styles.css
+++ b/src/styles.css
@@ -536,7 +536,8 @@ canvas {
 }
 
 :root[data-accessibility-contrast='high'] .graphics-quality__option-description,
-:root[data-accessibility-contrast='high'] .accessibility-presets__option-description,
+:root[data-accessibility-contrast='high']
+  .accessibility-presets__option-description,
 :root[data-accessibility-contrast='high'] .audio-volume__label,
 :root[data-accessibility-contrast='high'] .audio-volume__value {
   color: rgba(240, 250, 255, 0.88);

--- a/src/tests/accessibilityPresetControl.test.ts
+++ b/src/tests/accessibilityPresetControl.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AccessibilityPresetId } from '../accessibility/presetManager';
+import { createAccessibilityPresetControl } from '../controls/accessibilityPresetControl';
+
+const OPTIONS = [
+  {
+    id: 'standard' as AccessibilityPresetId,
+    label: 'Standard',
+    description: 'Default presentation.',
+  },
+  {
+    id: 'calm' as AccessibilityPresetId,
+    label: 'Calm',
+    description: 'Reduce motion cues.',
+  },
+  {
+    id: 'photosensitive' as AccessibilityPresetId,
+    label: 'Photosensitive safe',
+    description: 'Disable bloom and boost contrast.',
+  },
+];
+
+describe('createAccessibilityPresetControl', () => {
+  it('renders options, syncs state, and handles async selection', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    let active: AccessibilityPresetId = 'standard';
+    let resolveSelection: (() => void) | null = null;
+
+    const handle = createAccessibilityPresetControl({
+      container,
+      options: OPTIONS,
+      getActivePreset: () => active,
+      setActivePreset: (next) => {
+        active = next;
+        return new Promise<void>((resolve) => {
+          resolveSelection = resolve;
+        });
+      },
+    });
+
+    const radios = Array.from(
+      container.querySelectorAll<HTMLInputElement>('.accessibility-presets__radio')
+    );
+    const wrapper = container.querySelector<HTMLElement>('.accessibility-presets');
+    expect(radios).toHaveLength(3);
+    expect(wrapper?.dataset.pending).toBe('false');
+
+    radios[1].checked = true;
+    radios[1].dispatchEvent(new Event('change'));
+    expect(wrapper?.dataset.pending).toBe('true');
+
+    // While pending, subsequent selections are ignored.
+    radios[2].checked = true;
+    radios[2].dispatchEvent(new Event('change'));
+    expect(wrapper?.dataset.pending).toBe('true');
+
+    resolveSelection?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(wrapper?.dataset.pending).toBe('false');
+    expect(radios[1].checked).toBe(true);
+
+    active = 'photosensitive';
+    handle.refresh();
+    expect(radios[2].checked).toBe(true);
+
+    handle.dispose();
+    expect(container.querySelector('.accessibility-presets')).toBeNull();
+  });
+
+  it('recovers from failures and logs warnings', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let active: AccessibilityPresetId = 'standard';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    createAccessibilityPresetControl({
+      container,
+      options: OPTIONS,
+      getActivePreset: () => active,
+      setActivePreset: (next) => {
+        active = next;
+        throw new Error('nope');
+      },
+    });
+
+    const radio = container.querySelector<HTMLInputElement>(
+      '.accessibility-presets__radio[value="calm"]'
+    );
+    expect(radio).toBeTruthy();
+    if (!radio) {
+      warnSpy.mockRestore();
+      return;
+    }
+
+    radio.checked = true;
+    radio.dispatchEvent(new Event('change'));
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to update accessibility preset:',
+      expect.any(Error)
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('throws when no options are provided', () => {
+    const container = document.createElement('div');
+    expect(() =>
+      createAccessibilityPresetControl({
+        container,
+        options: [],
+        getActivePreset: () => 'standard',
+        setActivePreset: () => undefined,
+      })
+    ).toThrow('Accessibility preset control requires at least one option.');
+  });
+});

--- a/src/tests/accessibilityPresetControl.test.ts
+++ b/src/tests/accessibilityPresetControl.test.ts
@@ -42,9 +42,13 @@ describe('createAccessibilityPresetControl', () => {
     });
 
     const radios = Array.from(
-      container.querySelectorAll<HTMLInputElement>('.accessibility-presets__radio')
+      container.querySelectorAll<HTMLInputElement>(
+        '.accessibility-presets__radio'
+      )
     );
-    const wrapper = container.querySelector<HTMLElement>('.accessibility-presets');
+    const wrapper = container.querySelector<HTMLElement>(
+      '.accessibility-presets'
+    );
     expect(radios).toHaveLength(3);
     expect(wrapper?.dataset.pending).toBe('false');
 

--- a/src/tests/accessibilityPresetManager.test.ts
+++ b/src/tests/accessibilityPresetManager.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAccessibilityPresetManager } from '../accessibility/presetManager';
+import type {
+  BloomPassLike,
+  GraphicsQualityLevel,
+  GraphicsQualityManager,
+  LedLightLike,
+  LedMaterialLike,
+} from '../graphics/qualityManager';
+
+function createStubGraphicsQualityManager(
+  applyBaseline: () => void
+): GraphicsQualityManager {
+  const listeners = new Set<(level: GraphicsQualityLevel) => void>();
+  return {
+    getLevel: () => 'cinematic',
+    setLevel: vi.fn(),
+    refresh: () => {
+      applyBaseline();
+    },
+    setBasePixelRatio: vi.fn(),
+    onChange: (listener: (level: GraphicsQualityLevel) => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+describe('createAccessibilityPresetManager', () => {
+  const restoreDataset = () => {
+    delete document.documentElement.dataset.accessibilityPreset;
+    delete document.documentElement.dataset.accessibilityMotion;
+    delete document.documentElement.dataset.accessibilityContrast;
+  };
+
+  it('applies stored preset, scales lighting, and adjusts audio', () => {
+    const bloomPass: BloomPassLike = {
+      enabled: true,
+      strength: 1.5,
+      radius: 0.9,
+      threshold: 0.8,
+    };
+    const ledMaterial: LedMaterialLike = { emissiveIntensity: 1 };
+    const ledLight: LedLightLike = { intensity: 1 };
+
+    const baseline = () => {
+      bloomPass.enabled = true;
+      bloomPass.strength = 1.5;
+      bloomPass.radius = 0.9;
+      bloomPass.threshold = 0.8;
+      ledMaterial.emissiveIntensity = 1;
+      ledLight.intensity = 1;
+    };
+
+    const graphicsManager = createStubGraphicsQualityManager(baseline);
+
+    let masterVolume = 1;
+    const ambientAudio = {
+      getMasterVolume: () => masterVolume,
+      setMasterVolume: (value: number) => {
+        masterVolume = value;
+      },
+    };
+
+    const storage = {
+      getItem: vi.fn(() => 'calm'),
+      setItem: vi.fn(),
+    };
+
+    const manager = createAccessibilityPresetManager({
+      documentElement: document.documentElement,
+      graphicsQualityManager: graphicsManager,
+      bloomPass,
+      ledStripMaterials: [ledMaterial],
+      ledFillLights: [ledLight],
+      ambientAudioController: ambientAudio,
+      storage,
+    });
+
+    expect(manager.getPreset()).toBe('calm');
+    expect(document.documentElement.dataset.accessibilityPreset).toBe('calm');
+    expect(document.documentElement.dataset.accessibilityMotion).toBe('reduced');
+    expect(document.documentElement.dataset.accessibilityContrast).toBe('standard');
+    expect(bloomPass.enabled).toBe(true);
+    expect(bloomPass.strength).toBeCloseTo(0.9, 5);
+    expect(bloomPass.radius).toBeCloseTo(0.81, 5);
+    expect(bloomPass.threshold).toBeCloseTo(0.82, 5);
+    expect(ledMaterial.emissiveIntensity).toBeCloseTo(0.75, 5);
+    expect(ledLight.intensity).toBeCloseTo(0.8, 5);
+    expect(masterVolume).toBeCloseTo(0.8, 5);
+
+    manager.dispose();
+    restoreDataset();
+  });
+
+  it('switches presets, persists selection, and updates audio base volume', () => {
+    const bloomPass: BloomPassLike = {
+      enabled: true,
+      strength: 2,
+      radius: 1,
+      threshold: 0.7,
+    };
+    const baseline = () => {
+      bloomPass.enabled = true;
+      bloomPass.strength = 2;
+      bloomPass.radius = 1;
+      bloomPass.threshold = 0.7;
+    };
+    const graphicsManager = createStubGraphicsQualityManager(baseline);
+
+    let masterVolume = 0.5;
+    const ambientAudio = {
+      getMasterVolume: () => masterVolume,
+      setMasterVolume: (value: number) => {
+        masterVolume = value;
+      },
+    };
+
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    };
+
+    const manager = createAccessibilityPresetManager({
+      documentElement: document.documentElement,
+      graphicsQualityManager: graphicsManager,
+      bloomPass,
+      ambientAudioController: ambientAudio,
+      storage,
+    });
+
+    expect(manager.getBaseAudioVolume()).toBeCloseTo(0.5, 5);
+
+    const listener = vi.fn();
+    manager.onChange(listener);
+
+    manager.setPreset('photosensitive');
+    expect(listener).toHaveBeenCalledWith('photosensitive');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'danielsmith:accessibility-preset',
+      'photosensitive'
+    );
+    expect(document.documentElement.dataset.accessibilityContrast).toBe('high');
+    expect(bloomPass.enabled).toBe(false);
+    expect(masterVolume).toBeCloseTo(0.35, 5);
+
+    manager.setBaseAudioVolume(0.9);
+    expect(manager.getBaseAudioVolume()).toBeCloseTo(0.9, 5);
+    expect(masterVolume).toBeCloseTo(0.63, 5);
+
+    manager.dispose();
+    restoreDataset();
+  });
+
+  it('handles storage failures and re-applies on quality changes', () => {
+    const bloomPass: BloomPassLike = {
+      enabled: true,
+      strength: 1,
+      radius: 1,
+      threshold: 0.5,
+    };
+    const baseline = () => {
+      bloomPass.enabled = true;
+      bloomPass.strength = 1;
+      bloomPass.radius = 1;
+      bloomPass.threshold = 0.5;
+    };
+    const graphicsManager = createStubGraphicsQualityManager(baseline);
+
+    let qualityListener: ((level: string) => void) | null = null;
+    const onChangeSpy = vi
+      .spyOn(graphicsManager, 'onChange')
+      .mockImplementation((listener: (level: string) => void) => {
+        qualityListener = listener;
+        return () => {
+          qualityListener = null;
+        };
+      });
+
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error('denied');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('boom');
+      }),
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const manager = createAccessibilityPresetManager({
+      documentElement: document.documentElement,
+      graphicsQualityManager: graphicsManager,
+      bloomPass,
+      storage,
+    });
+
+    manager.setPreset('calm');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to persist accessibility preset:',
+      expect.any(Error)
+    );
+
+    qualityListener?.('cinematic');
+    expect(bloomPass.strength).toBeCloseTo(0.6, 5);
+
+    manager.dispose();
+    onChangeSpy.mockRestore();
+    warnSpy.mockRestore();
+    restoreDataset();
+  });
+});

--- a/src/tests/accessibilityPresetManager.test.ts
+++ b/src/tests/accessibilityPresetManager.test.ts
@@ -82,8 +82,12 @@ describe('createAccessibilityPresetManager', () => {
 
     expect(manager.getPreset()).toBe('calm');
     expect(document.documentElement.dataset.accessibilityPreset).toBe('calm');
-    expect(document.documentElement.dataset.accessibilityMotion).toBe('reduced');
-    expect(document.documentElement.dataset.accessibilityContrast).toBe('standard');
+    expect(document.documentElement.dataset.accessibilityMotion).toBe(
+      'reduced'
+    );
+    expect(document.documentElement.dataset.accessibilityContrast).toBe(
+      'standard'
+    );
     expect(bloomPass.enabled).toBe(true);
     expect(bloomPass.strength).toBeCloseTo(0.9, 5);
     expect(bloomPass.radius).toBeCloseTo(0.81, 5);


### PR DESCRIPTION
## Summary
- add an accessibility preset manager with standard, calm, and photosensitive options that tune bloom, LEDs, and audio
- surface the presets via a HUD control with high-contrast styling plus roadmap/readme updates

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68df7ded39c8832f93181fc3ff3a2e0e