### PR TITLE
Add guided POI tour overlay recommendation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -154,6 +154,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - In-world visual cues for discovered content (e.g., glowing trims, checkmarks).
    - Optional guided tour mode that highlights the next recommended POI.
    - ✅ Visited POI progress persists across reloads, powering halo highlights and tooltip badges.
+   - ✅ Guided tour overlay surfaces the next recommended POI whenever the player is idle.
 
 ## Phase 4 – Accessibility & Internationalization
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1240,9 +1240,11 @@ function initializeImmersiveScene(
 
   const removeVisitedSubscription =
     poiVisitedState.subscribe(handleVisitedUpdate);
-  const removeTourGuideSubscription = poiTourGuide.subscribe((recommendation) => {
-    poiTooltipOverlay.setRecommendation(recommendation);
-  });
+  const removeTourGuideSubscription = poiTourGuide.subscribe(
+    (recommendation) => {
+      poiTooltipOverlay.setRecommendation(recommendation);
+    }
+  );
 
   const flywheelPoi = poiInstances.find(
     (poi) => poi.definition.id === 'flywheel-studio-flywheel'

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,7 @@ import {
 import { getPoiDefinitions } from './poi/registry';
 import { injectPoiStructuredData } from './poi/structuredData';
 import { PoiTooltipOverlay } from './poi/tooltipOverlay';
+import { PoiTourGuide } from './poi/tourGuide';
 import { PoiVisitedState } from './poi/visitedState';
 import {
   createFlywheelShowpiece,
@@ -1215,6 +1216,17 @@ function initializeImmersiveScene(
   const poiAnalytics = createWindowPoiAnalytics();
   const poiTooltipOverlay = new PoiTooltipOverlay({ container });
   const poiVisitedState = new PoiVisitedState();
+  const poiTourGuide = new PoiTourGuide({
+    definitions: poiDefinitions,
+    visitedState: poiVisitedState,
+    priorityOrder: [
+      'futuroptimist-living-room-tv',
+      'flywheel-studio-flywheel',
+      'jobbot-studio-terminal',
+      'dspace-backyard-rocket',
+      'sugarkube-backyard-greenhouse',
+    ],
+  });
 
   const handleVisitedUpdate = (visited: ReadonlySet<string>) => {
     for (const poi of poiInstances) {
@@ -1228,6 +1240,9 @@ function initializeImmersiveScene(
 
   const removeVisitedSubscription =
     poiVisitedState.subscribe(handleVisitedUpdate);
+  const removeTourGuideSubscription = poiTourGuide.subscribe((recommendation) => {
+    poiTooltipOverlay.setRecommendation(recommendation);
+  });
 
   const flywheelPoi = poiInstances.find(
     (poi) => poi.definition.id === 'flywheel-studio-flywheel'
@@ -2255,7 +2270,9 @@ function initializeImmersiveScene(
     removeSelectionStateListener();
     removeSelectionListener();
     removeVisitedSubscription();
+    removeTourGuideSubscription();
     poiTooltipOverlay.dispose();
+    poiTourGuide.dispose();
     if (manualModeToggle) {
       manualModeToggle.dispose();
       manualModeToggle = null;

--- a/src/poi/tooltipOverlay.ts
+++ b/src/poi/tooltipOverlay.ts
@@ -16,8 +16,10 @@ export class PoiTooltipOverlay {
   private readonly linksList: HTMLUListElement;
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
+  private readonly recommendationBadge: HTMLSpanElement;
   private hovered: PoiDefinition | null = null;
   private selected: PoiDefinition | null = null;
+  private recommendation: PoiDefinition | null = null;
   private renderState: RenderState = { poiId: null };
   private visitedPoiIds: ReadonlySet<string> = new Set();
 
@@ -51,6 +53,12 @@ export class PoiTooltipOverlay {
     this.visitedBadge.hidden = true;
     headingRow.appendChild(this.visitedBadge);
 
+    this.recommendationBadge = document.createElement('span');
+    this.recommendationBadge.className = 'poi-tooltip-overlay__recommendation';
+    this.recommendationBadge.textContent = 'Next highlight';
+    this.recommendationBadge.hidden = true;
+    headingRow.appendChild(this.recommendationBadge);
+
     this.summary = document.createElement('p');
     this.summary.className = 'poi-tooltip-overlay__summary';
     this.root.appendChild(this.summary);
@@ -77,6 +85,11 @@ export class PoiTooltipOverlay {
     this.update();
   }
 
+  setRecommendation(poi: PoiDefinition | null) {
+    this.recommendation = poi;
+    this.update();
+  }
+
   setVisitedPoiIds(ids: ReadonlySet<string>) {
     this.visitedPoiIds = ids;
     this.update();
@@ -87,23 +100,29 @@ export class PoiTooltipOverlay {
   }
 
   private update() {
-    const poi = this.hovered ?? this.selected;
+    const poi = this.hovered ?? this.selected ?? this.recommendation;
     if (!poi) {
       this.root.classList.remove('poi-tooltip-overlay--visible');
       this.root.dataset.state = 'hidden';
       this.root.setAttribute('aria-hidden', 'true');
       this.renderState.poiId = null;
       this.visitedBadge.hidden = true;
+      this.recommendationBadge.hidden = true;
       return;
     }
 
-    const state = this.hovered ? 'hovered' : 'selected';
+    const state = this.hovered
+      ? 'hovered'
+      : this.selected
+        ? 'selected'
+        : 'recommended';
     this.root.dataset.state = state;
     this.root.classList.add('poi-tooltip-overlay--visible');
     this.root.setAttribute('aria-hidden', 'false');
 
     const visited = this.visitedPoiIds.has(poi.id);
     this.visitedBadge.hidden = !visited;
+    this.recommendationBadge.hidden = state !== 'recommended';
 
     if (this.renderState.poiId !== poi.id) {
       this.renderPoi(poi);

--- a/src/poi/tourGuide.ts
+++ b/src/poi/tourGuide.ts
@@ -1,0 +1,157 @@
+import type { PoiDefinition, PoiId } from './types';
+import { PoiVisitedState } from './visitedState';
+
+export type PoiTourGuideListener = (recommendation: PoiDefinition | null) => void;
+
+export interface PoiTourGuideOptions {
+  definitions: PoiDefinition[];
+  visitedState: PoiVisitedState;
+  priorityOrder?: PoiId[];
+}
+
+/**
+ * Computes the next recommended POI based on a configurable priority order and
+ * visited state updates. The guide listens to {@link PoiVisitedState}
+ * notifications so downstream UI can highlight the next suggested exhibit for
+ * the guided tour experience described in the roadmap.
+ */
+export class PoiTourGuide {
+  private readonly visitedState: PoiVisitedState;
+
+  private readonly listeners = new Set<PoiTourGuideListener>();
+
+  private readonly definitionsById = new Map<PoiId, PoiDefinition>();
+
+  private allDefinitions: PoiDefinition[] = [];
+
+  private priorityOrder: PoiId[] = [];
+
+  private recommendation: PoiDefinition | null = null;
+
+  private unsubscribeVisited: (() => void) | null = null;
+
+  constructor(options: PoiTourGuideOptions) {
+    this.visitedState = options.visitedState;
+    this.setDefinitions(options.definitions);
+    this.priorityOrder = this.normalizePriority(
+      options.priorityOrder ?? options.definitions.map((definition) => definition.id)
+    );
+
+    this.refreshRecommendation();
+    this.unsubscribeVisited = this.visitedState.subscribe(() => {
+      this.refreshRecommendation();
+    });
+  }
+
+  getRecommendation(): PoiDefinition | null {
+    return this.recommendation;
+  }
+
+  subscribe(listener: PoiTourGuideListener): () => void {
+    this.listeners.add(listener);
+    listener(this.recommendation);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  setPriorityOrder(order: PoiId[]): void {
+    const normalized = this.normalizePriority(order);
+    if (this.areOrdersEqual(normalized, this.priorityOrder)) {
+      return;
+    }
+    this.priorityOrder = normalized;
+    this.refreshRecommendation();
+  }
+
+  dispose(): void {
+    if (this.unsubscribeVisited) {
+      this.unsubscribeVisited();
+      this.unsubscribeVisited = null;
+    }
+    this.listeners.clear();
+  }
+
+  private setDefinitions(definitions: PoiDefinition[]) {
+    this.allDefinitions = definitions.slice();
+    this.definitionsById.clear();
+    for (const definition of definitions) {
+      this.definitionsById.set(definition.id, definition);
+    }
+  }
+
+  private normalizePriority(order: PoiId[]): PoiId[] {
+    const unique: PoiId[] = [];
+    const seen = new Set<PoiId>();
+    for (const id of order) {
+      if (!this.definitionsById.has(id) || seen.has(id)) {
+        continue;
+      }
+      unique.push(id);
+      seen.add(id);
+    }
+    return unique;
+  }
+
+  private refreshRecommendation() {
+    const visited = this.visitedState.snapshot();
+    const next = this.computeRecommendation(visited);
+    if (next?.id === this.recommendation?.id) {
+      return;
+    }
+    this.recommendation = next;
+    this.emit(next);
+  }
+
+  private computeRecommendation(visited: ReadonlySet<PoiId>): PoiDefinition | null {
+    const order = this.buildOrderedDefinitions();
+    for (const definition of order) {
+      if (!visited.has(definition.id)) {
+        return definition;
+      }
+    }
+    return null;
+  }
+
+  private buildOrderedDefinitions(): PoiDefinition[] {
+    const prioritized: PoiDefinition[] = [];
+    const used = new Set<PoiId>();
+    for (const id of this.priorityOrder) {
+      const definition = this.definitionsById.get(id);
+      if (!definition || used.has(id)) {
+        continue;
+      }
+      prioritized.push(definition);
+      used.add(id);
+    }
+
+    if (used.size === this.definitionsById.size) {
+      return prioritized;
+    }
+
+    const remaining = this.allDefinitions
+      .filter((definition) => !used.has(definition.id))
+      .slice()
+      .sort((a, b) => a.title.localeCompare(b.title));
+
+    return prioritized.concat(remaining);
+  }
+
+  private areOrdersEqual(a: PoiId[], b: PoiId[]): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i += 1) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private emit(recommendation: PoiDefinition | null) {
+    for (const listener of this.listeners) {
+      listener(recommendation);
+    }
+  }
+}

--- a/src/poi/tourGuide.ts
+++ b/src/poi/tourGuide.ts
@@ -1,7 +1,9 @@
 import type { PoiDefinition, PoiId } from './types';
 import { PoiVisitedState } from './visitedState';
 
-export type PoiTourGuideListener = (recommendation: PoiDefinition | null) => void;
+export type PoiTourGuideListener = (
+  recommendation: PoiDefinition | null
+) => void;
 
 export interface PoiTourGuideOptions {
   definitions: PoiDefinition[];
@@ -34,7 +36,8 @@ export class PoiTourGuide {
     this.visitedState = options.visitedState;
     this.setDefinitions(options.definitions);
     this.priorityOrder = this.normalizePriority(
-      options.priorityOrder ?? options.definitions.map((definition) => definition.id)
+      options.priorityOrder ??
+        options.definitions.map((definition) => definition.id)
     );
 
     this.refreshRecommendation();
@@ -103,7 +106,9 @@ export class PoiTourGuide {
     this.emit(next);
   }
 
-  private computeRecommendation(visited: ReadonlySet<PoiId>): PoiDefinition | null {
+  private computeRecommendation(
+    visited: ReadonlySet<PoiId>
+  ): PoiDefinition | null {
     const order = this.buildOrderedDefinitions();
     for (const definition of order) {
       if (!visited.has(definition.id)) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -788,6 +788,17 @@ canvas {
   text-transform: uppercase;
 }
 
+.poi-tooltip-overlay__recommendation {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 207, 129, 0.14);
+  border: 1px solid rgba(255, 207, 129, 0.4);
+  color: #ffd79a;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .poi-tooltip-overlay__summary {
   margin: 0;
   color: rgba(222, 245, 255, 0.92);
@@ -853,4 +864,8 @@ canvas {
 
 .poi-tooltip-overlay[data-state='selected'] {
   border-color: rgba(255, 200, 87, 0.45);
+}
+
+.poi-tooltip-overlay[data-state='recommended'] {
+  border-color: rgba(255, 207, 129, 0.42);
 }

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -112,4 +112,21 @@ describe('PoiTooltipOverlay', () => {
     overlay.setSelected(basePoi);
     expect(visitedBadge.hidden).toBe(true);
   });
+
+  it('renders a guided tour recommendation when available', () => {
+    overlay.setRecommendation(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('recommended');
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+
+    const recommendationBadge = root.querySelector(
+      '.poi-tooltip-overlay__recommendation'
+    ) as HTMLSpanElement;
+    expect(recommendationBadge.hidden).toBe(false);
+    expect(recommendationBadge.textContent).toBe('Next highlight');
+
+    overlay.setRecommendation(null);
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+  });
 });

--- a/src/tests/poiTourGuide.test.ts
+++ b/src/tests/poiTourGuide.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { PoiTourGuide } from '../poi/tourGuide';
+import type { PoiDefinition } from '../poi/types';
+import { PoiVisitedState } from '../poi/visitedState';
+
+const DEFINITIONS: PoiDefinition[] = [
+  {
+    id: 'futuroptimist-living-room-tv',
+    title: 'Futuroptimist TV Wall',
+    summary: 'Living room media wall with immersive tooling.',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'livingRoom',
+    position: { x: 0, y: 0, z: 0 },
+    interactionRadius: 2.4,
+    footprint: { width: 3, depth: 2 },
+  },
+  {
+    id: 'flywheel-studio-flywheel',
+    title: 'Flywheel Kinetic Hub',
+    summary: 'Automation centerpiece with responsive rotation.',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'studio',
+    position: { x: 2, y: 0, z: 4 },
+    interactionRadius: 2.2,
+    footprint: { width: 2, depth: 2 },
+  },
+  {
+    id: 'jobbot-studio-terminal',
+    title: 'Jobbot Holographic Terminal',
+    summary: 'Telemetry console broadcasting automation metrics.',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'studio',
+    position: { x: 4, y: 0, z: 6 },
+    interactionRadius: 2.3,
+    footprint: { width: 2.4, depth: 2 },
+  },
+  {
+    id: 'dspace-backyard-rocket',
+    title: 'dSpace Launch Pad',
+    summary: 'Backyard launch gantry staging the dSpace model rocket.',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'backyard',
+    position: { x: -4, y: 0, z: 8 },
+    interactionRadius: 2.6,
+    footprint: { width: 3.4, depth: 3.4 },
+  },
+];
+
+const createVisitedState = () => new PoiVisitedState({ storage: null });
+
+describe('PoiTourGuide', () => {
+  it('recommends the first unvisited POI using the configured priority order', () => {
+    const visitedState = createVisitedState();
+    const guide = new PoiTourGuide({
+      definitions: DEFINITIONS,
+      visitedState,
+      priorityOrder: [
+        'flywheel-studio-flywheel',
+        'futuroptimist-living-room-tv',
+        'flywheel-studio-flywheel',
+        'sugarkube-backyard-greenhouse',
+      ],
+    });
+
+    const recommendations: Array<string | null> = [];
+    const unsubscribe = guide.subscribe((recommendation) => {
+      recommendations.push(recommendation?.id ?? null);
+    });
+
+    expect(recommendations.at(-1)).toBe('flywheel-studio-flywheel');
+
+    visitedState.markVisited('flywheel-studio-flywheel');
+    expect(recommendations.at(-1)).toBe('futuroptimist-living-room-tv');
+
+    visitedState.markVisited('futuroptimist-living-room-tv');
+    expect(recommendations.at(-1)).toBe('dspace-backyard-rocket');
+
+    visitedState.markVisited('dspace-backyard-rocket');
+    expect(recommendations.at(-1)).toBe('jobbot-studio-terminal');
+
+    visitedState.markVisited('jobbot-studio-terminal');
+    expect(recommendations.at(-1)).toBe(null);
+
+    unsubscribe();
+    guide.dispose();
+  });
+
+  it('updates recommendation when the priority order changes', () => {
+    const visitedState = createVisitedState();
+    const guide = new PoiTourGuide({
+      definitions: DEFINITIONS,
+      visitedState,
+    });
+
+    let latest: string | null = null;
+    const unsubscribe = guide.subscribe((recommendation) => {
+      latest = recommendation?.id ?? null;
+    });
+
+    expect(latest).toBe('futuroptimist-living-room-tv');
+
+    guide.setPriorityOrder([
+      'jobbot-studio-terminal',
+      'futuroptimist-living-room-tv',
+      'jobbot-studio-terminal',
+    ]);
+    expect(latest).toBe('jobbot-studio-terminal');
+
+    guide.setPriorityOrder([
+      'jobbot-studio-terminal',
+      'futuroptimist-living-room-tv',
+      'jobbot-studio-terminal',
+    ]);
+    expect(latest).toBe('jobbot-studio-terminal');
+
+    unsubscribe();
+    guide.dispose();
+  });
+
+  it('stops notifying listeners after dispose', () => {
+    const visitedState = createVisitedState();
+    const guide = new PoiTourGuide({
+      definitions: DEFINITIONS,
+      visitedState,
+    });
+
+    const recommendations: Array<string | null> = [];
+    guide.subscribe((recommendation) => {
+      recommendations.push(recommendation?.id ?? null);
+    });
+
+    guide.dispose();
+    visitedState.markVisited('futuroptimist-living-room-tv');
+
+    expect(recommendations).toEqual(['futuroptimist-living-room-tv']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a PoiTourGuide engine that listens to visited state and surfaces the next POI
- render guided tour recommendations in the tooltip overlay and style the new badge
- update the roadmap to reflect the guided tour progression milestone

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e1b6f03d24832fb76b84de569f2206