### PR TITLE
Add live announcements for mode transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ lightweight.
   accessibility tips, and failover guidance.
 - **Failover** – Append `?mode=text` to the URL to load the lightweight text view.
   Automatic detection now covers missing WebGL support and sustained frame rates below 30 FPS;
-  `?mode=immersive` switches back when supported.
+  `?mode=immersive` switches back when supported. Screen readers now announce each switch so
+  assistive technology users know which mode is active.
 
 ## Automation prompts
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -168,9 +168,11 @@ Focus: make the experience inclusive and globally friendly.
 
 1. **Input Accessibility**
    - Keyboard-only navigation parity, remappable bindings, and full controller support.
-  - Screen reader announcements for mode switches, POI discovery, and HUD focus changes.
-    - ✅ Mode transitions now fire polite announcements describing immersive and text fallback states.
-   - Interaction timeline tuned for cognitive load (limited simultaneous prompts).
+
+- Screen reader announcements for mode switches, POI discovery, and HUD focus changes.
+  - ✅ Mode transitions now fire polite announcements describing immersive and text fallback states.
+- Interaction timeline tuned for cognitive load (limited simultaneous prompts).
+
 2. **Visual & Audio Accessibility**
    - High-contrast material set, colorblind-safe lighting palettes, and adjustable motion blur.
    - Subtitle/captions system for ambient audio callouts and POI narration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -168,7 +168,8 @@ Focus: make the experience inclusive and globally friendly.
 
 1. **Input Accessibility**
    - Keyboard-only navigation parity, remappable bindings, and full controller support.
-   - Screen reader announcements for mode switches, POI discovery, and HUD focus changes.
+  - Screen reader announcements for mode switches, POI discovery, and HUD focus changes.
+    - ✅ Mode transitions now fire polite announcements describing immersive and text fallback states.
    - Interaction timeline tuned for cognitive load (limited simultaneous prompts).
 2. **Visual & Audio Accessibility**
    - High-contrast material set, colorblind-safe lighting palettes, and adjustable motion blur.

--- a/src/accessibility/modeAnnouncer.ts
+++ b/src/accessibility/modeAnnouncer.ts
@@ -112,8 +112,10 @@ function readFallbackReason(documentTarget: Document): FallbackReason {
 }
 
 function handleModeChange(documentTarget: Document): void {
-  const mode = documentTarget.documentElement.dataset
-    .appMode as 'immersive' | 'fallback' | undefined;
+  const mode = documentTarget.documentElement.dataset.appMode as
+    | 'immersive'
+    | 'fallback'
+    | undefined;
   if (!mode) {
     return;
   }

--- a/src/accessibility/modeAnnouncer.ts
+++ b/src/accessibility/modeAnnouncer.ts
@@ -1,0 +1,173 @@
+import type { FallbackReason } from '../failover';
+
+export interface ModeAnnouncer {
+  readonly element: HTMLElement;
+  announceImmersiveReady(): void;
+  announceFallback(reason: FallbackReason): void;
+  dispose(): void;
+}
+
+export interface ModeAnnouncerOptions {
+  documentTarget?: Document;
+  container?: HTMLElement;
+  politeness?: 'polite' | 'assertive';
+  immersiveMessage?: string;
+  fallbackMessages?: Partial<Record<FallbackReason, string>>;
+}
+
+const DEFAULT_IMMERSIVE_MESSAGE =
+  'Immersive mode ready. Press T for the text tour or H for help.';
+
+const DEFAULT_FALLBACK_MESSAGES: Record<FallbackReason, string> = {
+  manual:
+    'Text mode enabled. Activate “Launch immersive mode” to return to the 3D tour.',
+  'low-memory':
+    'Device memory is constrained, so the fast text tour is now active for stability.',
+  'low-performance':
+    'Frame rates dipped below target. Switched to the responsive text tour to stay smooth.',
+  'immersive-init-error':
+    'The immersive scene hit an error. Showing the text portfolio while it recovers.',
+  'webgl-unsupported':
+    'WebGL is unavailable here, so the accessible text portfolio is now active.',
+  'automated-client':
+    'Detected an automated client. Presenting the text portfolio for reliable previews.',
+};
+
+function applyVisuallyHiddenStyles(element: HTMLElement): void {
+  element.style.position = 'absolute';
+  element.style.width = '1px';
+  element.style.height = '1px';
+  element.style.margin = '-1px';
+  element.style.border = '0';
+  element.style.padding = '0';
+  element.style.overflow = 'hidden';
+  element.style.clip = 'rect(0 0 0 0)';
+  element.style.clipPath = 'inset(50%)';
+  element.style.whiteSpace = 'nowrap';
+  element.style.pointerEvents = 'none';
+}
+
+function resolveContainer(
+  documentTarget: Document,
+  container?: HTMLElement
+): HTMLElement {
+  if (container) {
+    return container;
+  }
+  if (documentTarget.body) {
+    return documentTarget.body;
+  }
+  return documentTarget.documentElement;
+}
+
+export function createModeAnnouncer({
+  documentTarget = document,
+  container,
+  politeness = 'polite',
+  immersiveMessage = DEFAULT_IMMERSIVE_MESSAGE,
+  fallbackMessages = {},
+}: ModeAnnouncerOptions = {}): ModeAnnouncer {
+  const host = resolveContainer(documentTarget, container);
+  const region = documentTarget.createElement('div');
+  region.setAttribute('role', 'status');
+  region.setAttribute('aria-live', politeness);
+  region.setAttribute('aria-atomic', 'true');
+  region.dataset.modeAnnouncer = 'true';
+  applyVisuallyHiddenStyles(region);
+  host.appendChild(region);
+
+  const announce = (message: string) => {
+    region.textContent = '';
+    region.textContent = message;
+  };
+
+  return {
+    element: region,
+    announceImmersiveReady() {
+      announce(immersiveMessage);
+    },
+    announceFallback(reason) {
+      const resolved =
+        fallbackMessages[reason] ??
+        DEFAULT_FALLBACK_MESSAGES[reason] ??
+        DEFAULT_FALLBACK_MESSAGES.manual;
+      announce(resolved);
+    },
+    dispose() {
+      region.remove();
+    },
+  };
+}
+
+const announcers = new WeakMap<Document, ModeAnnouncer>();
+const observers = new WeakMap<Document, MutationObserver>();
+
+function readFallbackReason(documentTarget: Document): FallbackReason {
+  const fallback = documentTarget.querySelector<HTMLElement>('.text-fallback');
+  const reason = fallback?.dataset.reason as FallbackReason | undefined;
+  if (reason && reason in DEFAULT_FALLBACK_MESSAGES) {
+    return reason;
+  }
+  return 'manual';
+}
+
+function handleModeChange(documentTarget: Document): void {
+  const mode = documentTarget.documentElement.dataset
+    .appMode as 'immersive' | 'fallback' | undefined;
+  if (!mode) {
+    return;
+  }
+  const announcer = getModeAnnouncer(documentTarget);
+  if (mode === 'fallback') {
+    announcer.announceFallback(readFallbackReason(documentTarget));
+  } else if (mode === 'immersive') {
+    announcer.announceImmersiveReady();
+  }
+}
+
+export function getModeAnnouncer(
+  documentTarget: Document = document
+): ModeAnnouncer {
+  const existing = announcers.get(documentTarget);
+  if (existing) {
+    return existing;
+  }
+  const created = createModeAnnouncer({ documentTarget });
+  announcers.set(documentTarget, created);
+  return created;
+}
+
+export function initializeModeAnnouncementObserver(
+  documentTarget: Document = document
+): void {
+  if (observers.has(documentTarget)) {
+    return;
+  }
+  const observer = new MutationObserver(() => {
+    handleModeChange(documentTarget);
+  });
+  observer.observe(documentTarget.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-app-mode'],
+  });
+  observers.set(documentTarget, observer);
+}
+
+export function __resetModeAnnouncementForTests(
+  documentTarget: Document = document
+): void {
+  const announcer = announcers.get(documentTarget);
+  if (announcer) {
+    announcer.dispose();
+    announcers.delete(documentTarget);
+  }
+  const observer = observers.get(documentTarget);
+  if (observer) {
+    observer.disconnect();
+    observers.delete(documentTarget);
+  }
+  const region = documentTarget.querySelector<HTMLElement>(
+    '[data-mode-announcer="true"]'
+  );
+  region?.remove();
+}

--- a/src/failover.ts
+++ b/src/failover.ts
@@ -1,6 +1,11 @@
 import { initializeModeAnnouncementObserver } from './accessibility/modeAnnouncer';
 
-initializeModeAnnouncementObserver();
+if (
+  typeof document !== 'undefined' &&
+  typeof MutationObserver !== 'undefined'
+) {
+  initializeModeAnnouncementObserver();
+}
 
 const WEBGL_CONTEXT_NAMES = ['webgl2', 'webgl', 'experimental-webgl'] as const;
 

--- a/src/failover.ts
+++ b/src/failover.ts
@@ -1,3 +1,7 @@
+import { initializeModeAnnouncementObserver } from './accessibility/modeAnnouncer';
+
+initializeModeAnnouncementObserver();
+
 const WEBGL_CONTEXT_NAMES = ['webgl2', 'webgl', 'experimental-webgl'] as const;
 
 type WebglContextName = (typeof WEBGL_CONTEXT_NAMES)[number];

--- a/src/tests/modeAnnouncer.test.ts
+++ b/src/tests/modeAnnouncer.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetModeAnnouncementForTests,
+  createModeAnnouncer,
+  getModeAnnouncer,
+  initializeModeAnnouncementObserver,
+} from '../accessibility/modeAnnouncer';
+import { renderTextFallback } from '../failover';
+
+const flushObserver = async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+};
+
+describe('createModeAnnouncer', () => {
+  afterEach(() => {
+    __resetModeAnnouncementForTests();
+  });
+
+  it('creates a visually hidden live region with default messaging', () => {
+    const announcer = createModeAnnouncer();
+    expect(announcer.element.getAttribute('role')).toBe('status');
+    expect(announcer.element.getAttribute('aria-live')).toBe('polite');
+    announcer.announceFallback('manual');
+    expect(announcer.element.textContent).toMatch(/text mode enabled/i);
+    announcer.announceImmersiveReady();
+    expect(announcer.element.textContent).toMatch(/immersive mode ready/i);
+  });
+
+  it('respects custom messages when provided', () => {
+    const doc = document.implementation.createHTMLDocument('Mode');
+    const announcer = createModeAnnouncer({
+      documentTarget: doc,
+      immersiveMessage: 'Custom immersive',
+      fallbackMessages: { manual: 'Custom manual message' },
+    });
+    announcer.announceFallback('manual');
+    expect(announcer.element.textContent).toBe('Custom manual message');
+    announcer.announceImmersiveReady();
+    expect(announcer.element.textContent).toBe('Custom immersive');
+    announcer.dispose();
+  });
+});
+
+describe('initializeModeAnnouncementObserver', () => {
+  beforeEach(() => {
+    __resetModeAnnouncementForTests();
+    document.documentElement.dataset.appMode = 'loading';
+    document.documentElement.setAttribute('data-app-loading', '');
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.documentElement.dataset.appMode = 'loading';
+    document.documentElement.setAttribute('data-app-loading', '');
+    document.body.innerHTML = '';
+    __resetModeAnnouncementForTests();
+  });
+
+  it('announces fallback transitions using the rendered reason', async () => {
+    initializeModeAnnouncementObserver();
+    const container = document.createElement('div');
+    document.body.append(container);
+    renderTextFallback(container, {
+      reason: 'low-performance',
+      immersiveUrl: '/immersive',
+    });
+    document.documentElement.dataset.appMode = 'fallback';
+    await flushObserver();
+    const region = document.querySelector<HTMLElement>(
+      '[data-mode-announcer="true"]'
+    );
+    expect(region?.textContent).toMatch(/frame rates dipped/i);
+  });
+
+  it('announces immersive transitions when the mode changes back', async () => {
+    initializeModeAnnouncementObserver();
+    const announcer = getModeAnnouncer();
+    announcer.element.textContent = '';
+    document.documentElement.dataset.appMode = 'immersive';
+    await flushObserver();
+    const region = document.querySelector<HTMLElement>(
+      '[data-mode-announcer="true"]'
+    );
+    expect(region?.textContent).toMatch(/immersive mode ready/i);
+  });
+
+  it('reuses a single announcer instance per document', () => {
+    initializeModeAnnouncementObserver();
+    const first = getModeAnnouncer();
+    const second = getModeAnnouncer();
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable mode announcer that tracks data-app-mode changes
- document the accessibility win in the roadmap and README
- add targeted tests exercising fallback and immersive announcements

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e1b6f03d24832fb76b84de569f2206