### PR TITLE
Add mobile HUD layout manager for joystick safe zone

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -139,7 +139,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
      - ✅ Graphics HUD presets let players choose Cinematic, Balanced, or Performance modes
        that retune bloom, LED lighting, and pixel ratio for their device.
    - ✅ Ambient audio HUD now exposes a mute toggle and keyboard-friendly volume slider.
-   - Mobile-friendly layout that coexists with on-screen joystick.
+   - ✅ Mobile HUD layout now lifts instructional overlays above the joystick
+     safe zone so touch movement remains unobstructed.
 2. **Experience Toggle**
    - Mode switch between immersive 3D view and a fast-loading text portfolio.
    - Detect low-end/no-JS/scraper clients and auto-route to static mode.

--- a/src/hud/layoutManager.ts
+++ b/src/hud/layoutManager.ts
@@ -1,0 +1,166 @@
+export type HudLayout = 'desktop' | 'mobile';
+
+export interface HudLayoutManagerHandle {
+  getLayout(): HudLayout;
+  refresh(): void;
+  dispose(): void;
+}
+
+export interface HudLayoutManagerOptions {
+  root?: HTMLElement;
+  windowTarget?: Window;
+  matchMedia?: (query: string) => MediaQueryList;
+  mobileBreakpoint?: number;
+  pointerQuery?: string;
+  dataAttribute?: string;
+  onLayoutChange?: (layout: HudLayout) => void;
+}
+
+type MediaQueryListListener = (event: MediaQueryListEvent) => void;
+
+const DEFAULT_BREAKPOINT = 900;
+const DEFAULT_POINTER_QUERY = '(hover: none) and (pointer: coarse)';
+const DEFAULT_DATA_ATTRIBUTE = 'hudLayout';
+
+function addMediaQueryListener(
+  mediaQueryList: MediaQueryList | null,
+  listener: MediaQueryListListener
+): () => void {
+  if (!mediaQueryList) {
+    return () => {
+      /* noop */
+    };
+  }
+
+  if (typeof mediaQueryList.addEventListener === 'function') {
+    mediaQueryList.addEventListener('change', listener);
+    return () => {
+      mediaQueryList.removeEventListener('change', listener);
+    };
+  }
+
+  if (typeof mediaQueryList.addListener === 'function') {
+    mediaQueryList.addListener(listener);
+    return () => {
+      mediaQueryList.removeListener(listener);
+    };
+  }
+
+  return () => {
+    /* noop */
+  };
+}
+
+function setDatasetValue(
+  element: HTMLElement,
+  key: string,
+  value: string
+): void {
+  (element.dataset as Record<string, string>)[key] = value;
+}
+
+export function createHudLayoutManager({
+  root = document.documentElement,
+  windowTarget = window,
+  matchMedia: providedMatchMedia,
+  mobileBreakpoint = DEFAULT_BREAKPOINT,
+  pointerQuery = DEFAULT_POINTER_QUERY,
+  dataAttribute = DEFAULT_DATA_ATTRIBUTE,
+  onLayoutChange,
+}: HudLayoutManagerOptions = {}): HudLayoutManagerHandle {
+  const matchMedia =
+    providedMatchMedia ?? windowTarget.matchMedia?.bind(windowTarget) ?? null;
+
+  const pointerMedia = matchMedia ? matchMedia(pointerQuery) : null;
+  const widthMedia = matchMedia
+    ? matchMedia(`(max-width: ${mobileBreakpoint}px)`)
+    : null;
+
+  const mediaListeners: Array<() => void> = [];
+
+  let preferMobileFromTouch = false;
+  let layout: HudLayout = 'desktop';
+
+  const computeLayout = (): HudLayout => {
+    const pointerMobile = pointerMedia?.matches ?? false;
+    const widthMobile =
+      widthMedia?.matches ??
+      (typeof windowTarget.innerWidth === 'number'
+        ? windowTarget.innerWidth <= mobileBreakpoint
+        : false);
+
+    const shouldUseMobile =
+      preferMobileFromTouch || pointerMobile || widthMobile;
+
+    return shouldUseMobile ? 'mobile' : 'desktop';
+  };
+
+  const applyLayout = (next: HudLayout) => {
+    if (layout !== next) {
+      layout = next;
+      onLayoutChange?.(layout);
+    }
+    if (root) {
+      setDatasetValue(root, dataAttribute, layout);
+    }
+  };
+
+  const updateLayout = () => {
+    const nextLayout = computeLayout();
+    applyLayout(nextLayout);
+  };
+
+  const handleMediaChange: MediaQueryListListener = (event) => {
+    if (event.matches !== undefined) {
+      updateLayout();
+    }
+  };
+
+  mediaListeners.push(addMediaQueryListener(pointerMedia, handleMediaChange));
+  mediaListeners.push(addMediaQueryListener(widthMedia, handleMediaChange));
+
+  const handlePointerDown = (event: PointerEvent) => {
+    if (event.pointerType === 'touch') {
+      if (!preferMobileFromTouch) {
+        preferMobileFromTouch = true;
+        updateLayout();
+      }
+      return;
+    }
+
+    if (event.pointerType === 'mouse' && preferMobileFromTouch) {
+      preferMobileFromTouch = false;
+      updateLayout();
+    }
+  };
+
+  const handleResize = () => {
+    updateLayout();
+  };
+
+  windowTarget.addEventListener('pointerdown', handlePointerDown, {
+    passive: true,
+  });
+  windowTarget.addEventListener('resize', handleResize);
+  windowTarget.addEventListener('orientationchange', handleResize);
+
+  updateLayout();
+
+  return {
+    getLayout(): HudLayout {
+      return layout;
+    },
+    refresh(): void {
+      updateLayout();
+    },
+    dispose(): void {
+      mediaListeners.forEach((cleanup) => cleanup());
+      windowTarget.removeEventListener('pointerdown', handlePointerDown);
+      windowTarget.removeEventListener('resize', handleResize);
+      windowTarget.removeEventListener('orientationchange', handleResize);
+      if (root) {
+        delete (root.dataset as Record<string, string | undefined>)[dataAttribute];
+      }
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,10 @@ import {
 } from './graphics/qualityManager';
 import { createHelpModal } from './hud/helpModal';
 import {
+  createHudLayoutManager,
+  type HudLayoutManagerHandle,
+} from './hud/layoutManager';
+import {
   createLightingDebugController,
   type LightingMode,
 } from './lighting/debugControls';
@@ -690,6 +694,7 @@ function initializeImmersiveScene(
   ledFillLightsList.length = 0;
 
   let manualModeToggle: ManualModeToggleHandle | null = null;
+  let hudLayoutManager: HudLayoutManagerHandle | null = null;
   let immersiveDisposed = false;
   let beforeUnloadHandler: (() => void) | null = null;
   let audioHudHandle: AudioHudControlHandle | null = null;
@@ -1760,6 +1765,11 @@ function initializeImmersiveScene(
   let composer: EffectComposer | null = null;
   let bloomPass: UnrealBloomPass | null = null;
 
+  hudLayoutManager = createHudLayoutManager({
+    root: document.documentElement,
+    windowTarget: window,
+  });
+
   if (LIGHTING_OPTIONS.enableBloom) {
     composer = new EffectComposer(renderer);
     composer.addPass(new RenderPass(scene, camera));
@@ -2282,6 +2292,10 @@ function initializeImmersiveScene(
     if (audioHudHandle) {
       audioHudHandle.dispose();
       audioHudHandle = null;
+    }
+    if (hudLayoutManager) {
+      hudLayoutManager.dispose();
+      hudLayoutManager = null;
     }
     if (accessibilityControlHandle) {
       accessibilityControlHandle.dispose();

--- a/src/styles.css
+++ b/src/styles.css
@@ -496,6 +496,33 @@ canvas {
   }
 }
 
+:root[data-hud-layout='mobile'] {
+  --hud-mobile-safe-zone: calc(8.5rem + env(safe-area-inset-bottom, 0px));
+}
+
+:root[data-hud-layout='mobile'] .overlay {
+  bottom: var(--hud-mobile-safe-zone);
+  left: 1rem;
+  right: 1rem;
+  max-width: none;
+  width: auto;
+  padding: 0.9rem 1rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+:root[data-hud-layout='mobile'] .overlay__keys {
+  width: 8.5rem;
+}
+
+:root[data-hud-layout='mobile'] .poi-tooltip-overlay {
+  bottom: calc(var(--hud-mobile-safe-zone) + 1rem);
+  left: 1rem;
+  right: 1rem;
+  max-width: none;
+  width: auto;
+}
+
 :root[data-accessibility-motion='reduced'] .audio-hud,
 :root[data-accessibility-motion='reduced'] .graphics-quality,
 :root[data-accessibility-motion='reduced'] .mode-toggle,

--- a/src/tests/hudLayoutManager.test.ts
+++ b/src/tests/hudLayoutManager.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createHudLayoutManager, type HudLayout } from '../hud/layoutManager';
+
+type Listener<T> = (event: T) => void;
+
+const createWindowStub = (initialWidth = 1024) => {
+  const listeners = new Map<string, Set<Listener<unknown>>>();
+
+  return {
+    innerWidth: initialWidth,
+    addEventListener(type: string, listener: Listener<unknown>) {
+      if (!listeners.has(type)) {
+        listeners.set(type, new Set());
+      }
+      listeners.get(type)!.add(listener);
+    },
+    removeEventListener(type: string, listener: Listener<unknown>) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(type: string, event: unknown = {}) {
+      listeners.get(type)?.forEach((listener) => listener(event));
+    },
+  };
+};
+
+interface MediaQueryStub
+  extends Pick<MediaQueryList, 'media'>,
+    Record<string, unknown> {
+  matches: boolean;
+  trigger(next: boolean): void;
+}
+
+const createMediaQueryStub = (
+  initialMatches: boolean,
+  { legacy = false }: { legacy?: boolean } = {}
+) => {
+  let matches = initialMatches;
+  const listeners = new Set<Listener<MediaQueryListEvent>>();
+
+  const notify = () => {
+    const event = { matches } as MediaQueryListEvent;
+    listeners.forEach((listener) => listener(event));
+  };
+
+  const stub: Partial<MediaQueryStub> = {
+    media: '',
+    trigger(next: boolean) {
+      matches = next;
+      notify();
+    },
+  };
+
+  Object.defineProperty(stub, 'matches', {
+    get: () => matches,
+  });
+
+  if (legacy) {
+    const addListener = vi.fn((listener: Listener<MediaQueryListEvent>) => {
+      listeners.add(listener);
+    });
+    const removeListener = vi.fn((listener: Listener<MediaQueryListEvent>) => {
+      listeners.delete(listener);
+    });
+    Object.assign(stub, {
+      addListener,
+      removeListener,
+    });
+  } else {
+    Object.assign(stub, {
+      addEventListener: (_type: string, listener: Listener<MediaQueryListEvent>) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: Listener<MediaQueryListEvent>) => {
+        listeners.delete(listener);
+      },
+    });
+  }
+
+  return stub as MediaQueryList & MediaQueryStub;
+};
+
+describe('createHudLayoutManager', () => {
+  it('responds to media queries and emits layout changes', () => {
+    const pointerQuery = createMediaQueryStub(false);
+    const widthQuery = createMediaQueryStub(false);
+    const matchMedia = vi.fn((query: string) =>
+      query.includes('hover') ? pointerQuery : widthQuery
+    );
+    const windowStub = createWindowStub();
+    const root = document.createElement('div');
+    const layouts: HudLayout[] = [];
+
+    const manager = createHudLayoutManager({
+      root,
+      windowTarget: windowStub as unknown as Window,
+      matchMedia,
+      onLayoutChange: (layout) => {
+        layouts.push(layout);
+      },
+    });
+
+    expect(root.dataset.hudLayout).toBe('desktop');
+
+    pointerQuery.trigger(true);
+    expect(root.dataset.hudLayout).toBe('mobile');
+
+    pointerQuery.trigger(false);
+    expect(root.dataset.hudLayout).toBe('desktop');
+
+    widthQuery.trigger(true);
+    expect(root.dataset.hudLayout).toBe('mobile');
+
+    widthQuery.trigger(false);
+    expect(root.dataset.hudLayout).toBe('desktop');
+    expect(layouts).toEqual(['mobile', 'desktop', 'mobile', 'desktop']);
+    expect(manager.getLayout()).toBe('desktop');
+
+    manager.dispose();
+  });
+
+  it('prefers mobile layout after touch pointer interactions', () => {
+    const pointerQuery = createMediaQueryStub(false);
+    const widthQuery = createMediaQueryStub(false);
+    const matchMedia = vi.fn((query: string) =>
+      query.includes('hover') ? pointerQuery : widthQuery
+    );
+    const windowStub = createWindowStub();
+    const root = document.createElement('div');
+
+    const manager = createHudLayoutManager({
+      root,
+      windowTarget: windowStub as unknown as Window,
+      matchMedia,
+    });
+
+    expect(manager.getLayout()).toBe('desktop');
+
+    windowStub.dispatch('pointerdown', {
+      pointerType: 'touch',
+    } as PointerEvent);
+
+    expect(root.dataset.hudLayout).toBe('mobile');
+
+    windowStub.dispatch('pointerdown', {
+      pointerType: 'mouse',
+    } as PointerEvent);
+
+    expect(root.dataset.hudLayout).toBe('desktop');
+
+    manager.dispose();
+  });
+
+  it('uses viewport width when matchMedia is unavailable and cleans up on dispose', () => {
+    const windowStub = createWindowStub(540);
+    const root = document.createElement('div');
+
+    const manager = createHudLayoutManager({
+      root,
+      windowTarget: windowStub as unknown as Window,
+      matchMedia: undefined,
+      mobileBreakpoint: 720,
+    });
+
+    expect(root.dataset.hudLayout).toBe('mobile');
+
+    windowStub.innerWidth = 900;
+    windowStub.dispatch('resize');
+
+    expect(root.dataset.hudLayout).toBe('desktop');
+
+    manager.dispose();
+    expect(root.dataset.hudLayout).toBeUndefined();
+
+    windowStub.dispatch('resize');
+    expect(root.dataset.hudLayout).toBeUndefined();
+  });
+
+  it('supports legacy media query listeners', () => {
+    const pointerQuery = createMediaQueryStub(false, { legacy: true });
+    const widthQuery = createMediaQueryStub(false, { legacy: true });
+    const matchMedia = vi.fn((query: string) =>
+      query.includes('hover') ? pointerQuery : widthQuery
+    );
+    const windowStub = createWindowStub();
+    const root = document.createElement('div');
+
+    const manager = createHudLayoutManager({
+      root,
+      windowTarget: windowStub as unknown as Window,
+      matchMedia,
+    });
+
+    pointerQuery.trigger(true);
+    expect(root.dataset.hudLayout).toBe('mobile');
+
+    manager.dispose();
+
+    expect(pointerQuery.removeListener).toHaveBeenCalled();
+    expect(widthQuery.removeListener).toHaveBeenCalled();
+
+    pointerQuery.trigger(false);
+    expect(root.dataset.hudLayout).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a HUD layout manager that toggles a mobile safe-zone attribute based on input and viewport
- raise the movement overlay and POI tooltip with new CSS safe-zone styles for touch devices
- document the completed mobile HUD milestone in the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e1b6f03d24832fb76b84de569f2206