### PR TITLE
Add smoothstep falloff to ambient audio beds

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,7 +116,8 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✨ Aluminum extrusion greenhouse inspired by `sugarkube`, complete with animated solar
      trackers, pulsing grow lights, interior planter beds, and a koi pond plinth.
      - ✅ Sugarkube greenhouse POI now surfaces automation metrics and dual CTAs in the registry.
-   - ✨ Ambient audio beds (crickets, greenhouse chimes) fade based on player proximity.
+       - ✅ Ambient audio beds (crickets, greenhouse chimes) now use smoothstep falloff so volume
+         eases in based on player proximity.
 
 ## Phase 3 – Interface & Modes
 

--- a/src/environments/backyard.ts
+++ b/src/environments/backyard.ts
@@ -18,6 +18,7 @@ import {
   Vector3,
 } from 'three';
 
+import type { AmbientAudioFalloffCurve } from '../audio/ambientAudio';
 import type { RectCollider } from '../collision';
 import type { Bounds2D } from '../floorPlan';
 import { createGreenhouse } from '../structures/greenhouse';
@@ -36,6 +37,7 @@ export interface BackyardAmbientAudioBed {
   innerRadius: number;
   outerRadius: number;
   baseVolume: number;
+  falloffCurve?: AmbientAudioFalloffCurve;
 }
 
 function createSignageTexture(title: string, subtitle: string): CanvasTexture {
@@ -211,6 +213,7 @@ export function createBackyardEnvironment(
     innerRadius: Math.max(1, (walkwayMaxExtent / 2) * 0.9),
     outerRadius: Math.max(1.6, walkwayMaxExtent * 1.2 + 1.4),
     baseVolume: 0.42,
+    falloffCurve: 'smoothstep',
   });
 
   interface LanternAnimationTarget {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1671,6 +1671,7 @@ function initializeImmersiveScene(
       innerRadius: homeHalfExtent * 0.55,
       outerRadius: homeHalfExtent * 1.2,
       baseVolume: 0.32,
+      falloffCurve: 'smoothstep',
       source: createLoopingSource('interior-hum', (context) =>
         createDistantHumBuffer(context)
       ),
@@ -1691,6 +1692,7 @@ function initializeImmersiveScene(
         innerRadius: backyardHalfExtent * 0.6,
         outerRadius: backyardHalfExtent + toWorldUnits(6),
         baseVolume: 0.65,
+        falloffCurve: 'smoothstep',
         source: createLoopingSource('backyard-crickets', (context) =>
           createCricketChorusBuffer(context)
         ),

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -122,7 +122,8 @@ describe('AmbientAudioController', () => {
     const { bed, source } = createBed({ falloffCurve: 'smoothstep' });
     const controller = new AmbientAudioController([bed], { smoothing: 0 });
     controller.enable();
-    const midDistance = bed.innerRadius + (bed.outerRadius - bed.innerRadius) * 0.7;
+    const midDistance =
+      bed.innerRadius + (bed.outerRadius - bed.innerRadius) * 0.7;
     controller.update({ x: midDistance, z: 0 }, 0.1);
     const expected =
       bed.baseVolume *
@@ -158,7 +159,10 @@ describe('attenuation helpers', () => {
     expect(_computeAttenuation(0, 2, 5)).toBe(1);
     expect(_computeAttenuation(10, 2, 5)).toBe(0);
     expect(_computeAttenuation(3.5, 2, 5)).toBeCloseTo(0.5, 2);
-    expect(_computeAttenuation(4.25, 2, 5, 'smoothstep')).toBeCloseTo(0.15625, 5);
+    expect(_computeAttenuation(4.25, 2, 5, 'smoothstep')).toBeCloseTo(
+      0.15625,
+      5
+    );
   });
 
   it('handles smoothing factor edge cases', () => {

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -37,6 +37,7 @@ describe('AmbientAudioController', () => {
       innerRadius: overrides.innerRadius ?? 2,
       outerRadius: overrides.outerRadius ?? 6,
       baseVolume: overrides.baseVolume ?? 0.8,
+      falloffCurve: overrides.falloffCurve,
       source,
     };
     return { bed, source };
@@ -117,6 +118,23 @@ describe('AmbientAudioController', () => {
     expect(scaled).toBeCloseTo(bed.baseVolume * 0.5, 5);
   });
 
+  it('applies configured falloff curve when computing attenuation', () => {
+    const { bed, source } = createBed({ falloffCurve: 'smoothstep' });
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+    controller.enable();
+    const midDistance = bed.innerRadius + (bed.outerRadius - bed.innerRadius) * 0.7;
+    controller.update({ x: midDistance, z: 0 }, 0.1);
+    const expected =
+      bed.baseVolume *
+      _computeAttenuation(
+        midDistance,
+        bed.innerRadius,
+        bed.outerRadius,
+        'smoothstep'
+      );
+    expect(source.volumes.at(-1)).toBeCloseTo(expected, 5);
+  });
+
   it('clamps master volume updates and defers when listener position unknown', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });
@@ -140,6 +158,7 @@ describe('attenuation helpers', () => {
     expect(_computeAttenuation(0, 2, 5)).toBe(1);
     expect(_computeAttenuation(10, 2, 5)).toBe(0);
     expect(_computeAttenuation(3.5, 2, 5)).toBeCloseTo(0.5, 2);
+    expect(_computeAttenuation(4.25, 2, 5, 'smoothstep')).toBeCloseTo(0.15625, 5);
   });
 
   it('handles smoothing factor edge cases', () => {


### PR DESCRIPTION
## Summary
- add a configurable falloff curve to the ambient audio controller and tests
- enable smoothstep fades for interior and backyard ambient beds and document the roadmap update

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e1b6f03d24832fb76b84de569f2206