### PR TITLE
Add holographic visited badges for POIs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -153,7 +153,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
      portfolio while honoring manual immersive overrides.
 3. **Progression & State**
    - Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
-   - In-world visual cues for discovered content (e.g., glowing trims, checkmarks).
+   - ✅ In-world visual cues for discovered content (e.g., glowing trims, checkmarks).
+     - ✅ Visited POIs now reveal holographic checkmark badges that hover above each pedestal.
    - Optional guided tour mode that highlights the next recommended POI.
    - ✅ Visited POI progress persists across reloads, powering halo highlights and tooltip badges.
    - ✅ Guided tour overlay surfaces the next recommended POI whenever the player is idle.

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,7 @@ import { getPoiDefinitions } from './poi/registry';
 import { injectPoiStructuredData } from './poi/structuredData';
 import { PoiTooltipOverlay } from './poi/tooltipOverlay';
 import { PoiTourGuide } from './poi/tourGuide';
+import { updateVisitedBadge } from './poi/visitedBadge';
 import { PoiVisitedState } from './poi/visitedState';
 import {
   createFlywheelShowpiece,
@@ -2177,6 +2178,15 @@ function initializeImmersiveScene(
         poi.visitedHighlight.mesh.visible = visitedOpacity > 0.02;
         const visitedScale = 1 + visitedEmphasis * 0.12;
         poi.visitedHighlight.mesh.scale.setScalar(visitedScale);
+      }
+
+      if (poi.visitedBadge) {
+        updateVisitedBadge(poi.visitedBadge, {
+          elapsedTime,
+          delta,
+          visitedEmphasis,
+          floatPhase: poi.floatPhase,
+        });
       }
 
       if (!poi.displayHighlight) {

--- a/src/poi/markers.ts
+++ b/src/poi/markers.ts
@@ -18,6 +18,7 @@ import {
 } from 'three';
 
 import type { PoiDefinition, PoiId } from './types';
+import { createVisitedBadge, type PoiVisitedBadge } from './visitedBadge';
 
 export interface PoiDisplayHighlight {
   mesh: Mesh;
@@ -72,6 +73,7 @@ export interface PoiInstance {
     mesh: Mesh;
     material: MeshBasicMaterial;
   };
+  visitedBadge?: PoiVisitedBadge;
 }
 
 export function createPoiInstances(
@@ -169,6 +171,13 @@ function createPedestalPoiInstance(
   label.position.set(0, labelBaseHeight, 0);
   label.renderOrder = 12;
   group.add(label);
+
+  const badgeBaseHeight = labelBaseHeight + labelHeight * 0.42;
+  const visitedBadge = createVisitedBadge({
+    baseHeight: badgeBaseHeight,
+  });
+  visitedBadge.mesh.position.set(0, badgeBaseHeight, 0);
+  group.add(visitedBadge.mesh);
 
   const haloInnerRadius = Math.max(baseRadiusX, baseRadiusZ) * 0.92;
   const haloOuterRadius = haloInnerRadius + 0.36;
@@ -272,6 +281,7 @@ function createPedestalPoiInstance(
     visited: false,
     visitedStrength: 0,
     visitedHighlight: { mesh: visitedRing, material: visitedRingMaterial },
+    visitedBadge,
   };
 }
 

--- a/src/poi/visitedBadge.ts
+++ b/src/poi/visitedBadge.ts
@@ -1,0 +1,132 @@
+import {
+  CanvasTexture,
+  DoubleSide,
+  MathUtils,
+  Mesh,
+  MeshBasicMaterial,
+  PlaneGeometry,
+  SRGBColorSpace,
+} from 'three';
+
+export interface PoiVisitedBadge {
+  mesh: Mesh;
+  material: MeshBasicMaterial;
+  baseHeight: number;
+  rotationSpeed: number;
+}
+
+export interface CreateVisitedBadgeOptions {
+  baseHeight: number;
+  width?: number;
+  height?: number;
+  rotationSpeedRange?: { min: number; max: number };
+  random?: (min: number, max: number) => number;
+}
+
+export interface UpdateVisitedBadgeContext {
+  elapsedTime: number;
+  delta: number;
+  visitedEmphasis: number;
+  floatPhase: number;
+}
+
+function createVisitedBadgeTexture(): CanvasTexture {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 512;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Unable to acquire 2D context for visited badge texture.');
+  }
+
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  const centerX = canvas.width / 2;
+  const centerY = canvas.height / 2;
+  const radius = 220;
+
+  context.fillStyle = 'rgba(10, 36, 24, 0.78)';
+  context.beginPath();
+  context.arc(centerX, centerY, radius, 0, Math.PI * 2);
+  context.closePath();
+  context.fill();
+
+  context.strokeStyle = 'rgba(112, 244, 196, 0.42)';
+  context.lineWidth = 28;
+  context.beginPath();
+  context.arc(centerX, centerY, radius * 0.92, 0, Math.PI * 2);
+  context.stroke();
+
+  context.lineCap = 'round';
+  context.lineJoin = 'round';
+  context.strokeStyle = 'rgba(172, 255, 214, 0.95)';
+  context.lineWidth = 42;
+  context.beginPath();
+  context.moveTo(centerX - 80, centerY - 8);
+  context.lineTo(centerX - 22, centerY + 70);
+  context.lineTo(centerX + 120, centerY - 90);
+  context.stroke();
+
+  const texture = new CanvasTexture(canvas);
+  texture.colorSpace = SRGBColorSpace;
+  texture.anisotropy = 4;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+export function createVisitedBadge(
+  options: CreateVisitedBadgeOptions
+): PoiVisitedBadge {
+  const width = options.width ?? 0.9;
+  const height = options.height ?? 0.9;
+  const geometry = new PlaneGeometry(width, height);
+  const texture = createVisitedBadgeTexture();
+  const material = new MeshBasicMaterial({
+    map: texture,
+    transparent: true,
+    opacity: 0,
+    depthWrite: false,
+    side: DoubleSide,
+  });
+
+  const mesh = new Mesh(geometry, material);
+  mesh.name = 'POI_VisitedBadge';
+  mesh.visible = false;
+  mesh.renderOrder = 16;
+  mesh.position.y = options.baseHeight;
+
+  const range = options.rotationSpeedRange ?? { min: 0.55, max: 0.9 };
+  const random = options.random ?? MathUtils.randFloat;
+  const rotationSpeed = random(range.min, range.max);
+
+  return {
+    mesh,
+    material,
+    baseHeight: options.baseHeight,
+    rotationSpeed,
+  } satisfies PoiVisitedBadge;
+}
+
+export function updateVisitedBadge(
+  badge: PoiVisitedBadge,
+  context: UpdateVisitedBadgeContext
+): void {
+  const visited = MathUtils.clamp(context.visitedEmphasis, 0, 1);
+  const bob = Math.sin(context.elapsedTime * 1.4 + context.floatPhase) * 0.12;
+  const hoverLift = MathUtils.lerp(0, 0.24, visited);
+  badge.mesh.position.y = badge.baseHeight + hoverLift + bob * visited;
+
+  const scale = MathUtils.lerp(0.68, 0.95, visited);
+  badge.mesh.scale.setScalar(scale);
+
+  const opacity = MathUtils.lerp(0, 0.88, visited);
+  badge.material.opacity = opacity;
+  badge.mesh.visible = opacity > 0.035;
+
+  if (context.delta > 0) {
+    badge.mesh.rotation.y += badge.rotationSpeed * context.delta;
+  }
+}
+
+export const _testables = {
+  createVisitedBadgeTexture,
+};

--- a/src/tests/poiVisitedBadge.test.ts
+++ b/src/tests/poiVisitedBadge.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { createVisitedBadge, updateVisitedBadge } from '../poi/visitedBadge';
+
+beforeAll(() => {
+  const noop = () => {};
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value(type: string) {
+      if (type !== '2d') {
+        return null;
+      }
+      return {
+        clearRect: noop,
+        beginPath: noop,
+        arc: noop,
+        closePath: noop,
+        fill: noop,
+        stroke: noop,
+        moveTo: noop,
+        lineTo: noop,
+        fillStyle: '',
+        strokeStyle: '',
+        lineWidth: 0,
+        lineCap: 'round',
+        lineJoin: 'round',
+      } as CanvasRenderingContext2D;
+    },
+  });
+});
+
+describe('createVisitedBadge', () => {
+  it('builds a textured badge mesh positioned at the base height', () => {
+    const badge = createVisitedBadge({ baseHeight: 3 });
+    expect(badge.mesh.name).toBe('POI_VisitedBadge');
+    expect(badge.mesh.position.y).toBe(3);
+    expect(badge.material.transparent).toBe(true);
+    expect(badge.material.opacity).toBe(0);
+    expect(badge.mesh.visible).toBe(false);
+    expect(badge.material.map).toBeDefined();
+  });
+});
+
+describe('updateVisitedBadge', () => {
+  it('reveals, lifts, and spins the badge as exhibits are discovered', () => {
+    const badge = createVisitedBadge({
+      baseHeight: 1.2,
+      random: () => 0.75,
+    });
+
+    updateVisitedBadge(badge, {
+      elapsedTime: 2.4,
+      delta: 0.016,
+      visitedEmphasis: 0.8,
+      floatPhase: 0,
+    });
+
+    expect(badge.material.opacity).toBeGreaterThan(0.6);
+    expect(badge.mesh.visible).toBe(true);
+    expect(badge.mesh.position.y).toBeGreaterThan(1.2);
+    expect(badge.mesh.scale.x).toBeGreaterThan(0.68);
+    expect(badge.mesh.rotation.y).toBeCloseTo(0.75 * 0.016, 5);
+  });
+
+  it('clamps emphasis and hides the badge when emphasis is zero', () => {
+    const badge = createVisitedBadge({ baseHeight: 2, random: () => 0.6 });
+    badge.material.opacity = 0.5;
+    badge.mesh.visible = true;
+
+    updateVisitedBadge(badge, {
+      elapsedTime: 0.5,
+      delta: 0.02,
+      visitedEmphasis: 0,
+      floatPhase: Math.PI / 4,
+    });
+
+    expect(badge.material.opacity).toBe(0);
+    expect(badge.mesh.visible).toBe(false);
+    expect(badge.mesh.position.y).toBeCloseTo(2, 5);
+
+    updateVisitedBadge(badge, {
+      elapsedTime: 0.5,
+      delta: 0,
+      visitedEmphasis: 2.5,
+      floatPhase: Math.PI / 4,
+    });
+
+    expect(badge.material.opacity).toBeCloseTo(0.88, 2);
+    expect(badge.mesh.scale.x).toBeLessThanOrEqual(0.95);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable visited badge helper that spawns textured checkmark meshes
- animate visited emphasis each frame to surface hovering badges for discovered POIs
- mark the roadmap milestone and verify badge behavior with targeted unit tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e35a2c8d90832f818b819d5652c6f4