### PR TITLE
Add doorway clearance validation for POIs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,6 +63,7 @@ Focus: expand the environment while keeping navigation smooth.
    - Cut simple doorway openings (no doors yet) between rooms and toward the backyard.
    - Stub staircase volumes that connect to a placeholder second-floor landing.
    - Ensure navmesh/character controller handles slopes and doorway thresholds.
+     - ✅ Doorway clearance validator now protects thresholds from POI crowding during registry checks.
    - ✅ Feature staircase prefab links the living room to a loft landing stub with nav blockers.
 3. **Outdoor Transition**
    - Sculpt backyard terrain plane, fence line, and skybox updates.

--- a/src/floorPlan/doorways.ts
+++ b/src/floorPlan/doorways.ts
@@ -1,0 +1,132 @@
+import type { RectCollider } from '../collision';
+import {
+  type DoorwayDefinition,
+  type FloorPlanDefinition,
+  type RoomDefinition,
+  type RoomWall,
+  WALL_THICKNESS,
+} from '../floorPlan';
+
+export interface DoorwayClearanceZone {
+  roomId: string;
+  wall: RoomWall;
+  doorway: DoorwayDefinition;
+  bounds: RectCollider;
+}
+
+export interface DoorwayClearanceOptions {
+  /** Depth to reserve inside the room for each doorway threshold. */
+  depth?: number;
+  /** Extra clearance on each horizontal side of the doorway opening. */
+  sidePadding?: number;
+  /** Comparison epsilon to avoid floating point issues. */
+  epsilon?: number;
+}
+
+const DEFAULT_OPTIONS: Required<DoorwayClearanceOptions> = {
+  depth: WALL_THICKNESS * 2,
+  sidePadding: 0.6,
+  epsilon: 1e-4,
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export function getDoorwayClearanceZones(
+  plan: FloorPlanDefinition,
+  options: DoorwayClearanceOptions = {}
+): DoorwayClearanceZone[] {
+  const { depth, sidePadding, epsilon } = { ...DEFAULT_OPTIONS, ...options };
+
+  const zones: DoorwayClearanceZone[] = [];
+
+  const normalizeRange = (doorway: DoorwayDefinition) => {
+    const start = Math.min(doorway.start, doorway.end);
+    const end = Math.max(doorway.start, doorway.end);
+    return { start, end };
+  };
+
+  const createZone = (
+    room: RoomDefinition,
+    doorway: DoorwayDefinition
+  ): RectCollider | null => {
+    const range = normalizeRange(doorway);
+    const paddedStart = range.start - sidePadding;
+    const paddedEnd = range.end + sidePadding;
+
+    switch (doorway.wall) {
+      case 'north': {
+        const maxZ = room.bounds.maxZ + epsilon;
+        const minZ = clamp(room.bounds.maxZ - depth, room.bounds.minZ, maxZ);
+        if (maxZ - minZ <= epsilon) {
+          return null;
+        }
+        return {
+          minX: clamp(paddedStart, room.bounds.minX, room.bounds.maxX),
+          maxX: clamp(paddedEnd, room.bounds.minX, room.bounds.maxX),
+          minZ,
+          maxZ,
+        };
+      }
+      case 'south': {
+        const minZ = room.bounds.minZ - epsilon;
+        const maxZ = clamp(room.bounds.minZ + depth, minZ, room.bounds.maxZ);
+        if (maxZ - minZ <= epsilon) {
+          return null;
+        }
+        return {
+          minX: clamp(paddedStart, room.bounds.minX, room.bounds.maxX),
+          maxX: clamp(paddedEnd, room.bounds.minX, room.bounds.maxX),
+          minZ,
+          maxZ,
+        };
+      }
+      case 'east': {
+        const maxX = room.bounds.maxX + epsilon;
+        const minX = clamp(room.bounds.maxX - depth, room.bounds.minX, maxX);
+        if (maxX - minX <= epsilon) {
+          return null;
+        }
+        return {
+          minX,
+          maxX,
+          minZ: clamp(paddedStart, room.bounds.minZ, room.bounds.maxZ),
+          maxZ: clamp(paddedEnd, room.bounds.minZ, room.bounds.maxZ),
+        };
+      }
+      case 'west': {
+        const minX = room.bounds.minX - epsilon;
+        const maxX = clamp(room.bounds.minX + depth, minX, room.bounds.maxX);
+        if (maxX - minX <= epsilon) {
+          return null;
+        }
+        return {
+          minX,
+          maxX,
+          minZ: clamp(paddedStart, room.bounds.minZ, room.bounds.maxZ),
+          maxZ: clamp(paddedEnd, room.bounds.minZ, room.bounds.maxZ),
+        };
+      }
+      default:
+        return null;
+    }
+  };
+
+  plan.rooms.forEach((room) => {
+    room.doorways?.forEach((doorway) => {
+      const bounds = createZone(room, doorway);
+      if (!bounds) {
+        return;
+      }
+      if (
+        bounds.maxX - bounds.minX <= epsilon ||
+        bounds.maxZ - bounds.minZ <= epsilon
+      ) {
+        return;
+      }
+      zones.push({ roomId: room.id, wall: doorway.wall, doorway, bounds });
+    });
+  });
+
+  return zones;
+}

--- a/src/tests/floorPlanDoorways.test.ts
+++ b/src/tests/floorPlanDoorways.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN } from '../floorPlan';
+import { getDoorwayClearanceZones } from '../floorPlan/doorways';
+
+describe('getDoorwayClearanceZones', () => {
+  const zones = getDoorwayClearanceZones(FLOOR_PLAN, {
+    depth: 1.2,
+    sidePadding: 0.4,
+  });
+
+  it('generates doorway clearances for rooms with door definitions', () => {
+    const livingRoomZones = zones.filter((zone) => zone.roomId === 'livingRoom');
+    expect(livingRoomZones.length).toBeGreaterThan(0);
+  });
+
+  it('creates north wall clearances that extend toward positive Z', () => {
+    const livingNorth = zones.find(
+      (zone) => zone.roomId === 'livingRoom' && zone.wall === 'north'
+    );
+    expect(livingNorth).toBeDefined();
+    const { bounds } = livingNorth!;
+    const room = FLOOR_PLAN.rooms.find((entry) => entry.id === 'livingRoom')!;
+    expect(bounds.maxZ).toBeGreaterThan(room.bounds.maxZ);
+    expect(bounds.minZ).toBeLessThan(bounds.maxZ);
+  });
+
+  it('clamps doorway padding within room bounds', () => {
+    const studioEast = zones.find(
+      (zone) => zone.roomId === 'studio' && zone.wall === 'west'
+    );
+    expect(studioEast).toBeDefined();
+    const { bounds } = studioEast!;
+    const room = FLOOR_PLAN.rooms.find((entry) => entry.id === 'studio')!;
+    expect(bounds.minZ).toBeGreaterThanOrEqual(room.bounds.minZ - 1e-3);
+    expect(bounds.maxZ).toBeLessThanOrEqual(room.bounds.maxZ + 1e-3);
+  });
+});

--- a/src/tests/floorPlanDoorways.test.ts
+++ b/src/tests/floorPlanDoorways.test.ts
@@ -10,7 +10,9 @@ describe('getDoorwayClearanceZones', () => {
   });
 
   it('generates doorway clearances for rooms with door definitions', () => {
-    const livingRoomZones = zones.filter((zone) => zone.roomId === 'livingRoom');
+    const livingRoomZones = zones.filter(
+      (zone) => zone.roomId === 'livingRoom'
+    );
     expect(livingRoomZones.length).toBeGreaterThan(0);
   });
 

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -123,7 +123,10 @@ describe('validatePoiDefinitions', () => {
       poiId: doorwayPoi.id,
       roomId: doorwayPoi.roomId,
       wall: 'north',
-      doorway: expect.objectContaining({ start: expect.any(Number), end: expect.any(Number) }),
+      doorway: expect.objectContaining({
+        start: expect.any(Number),
+        end: expect.any(Number),
+      }),
     });
   });
 

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -103,6 +103,30 @@ describe('validatePoiDefinitions', () => {
     } satisfies PoiValidationIssue);
   });
 
+  it('flags POIs that intrude on reserved doorway clearances', () => {
+    const doorwayPoi = clonePoi({
+      id: 'futuroptimist-doorway-test' as (typeof baseDefinitions)[0]['id'],
+      position: {
+        x: livingRoomBounds.minX + 14,
+        y: baseDefinitions[0].position.y,
+        z: livingRoomBounds.maxZ - 0.4,
+      },
+      footprint: { width: 3.2, depth: 2.4 },
+    });
+
+    const issues = validatePoiDefinitions([...baseDefinitions, doorwayPoi], {
+      floorPlan: FLOOR_PLAN,
+    });
+
+    expect(issues).toContainEqual({
+      type: 'doorway-blocked',
+      poiId: doorwayPoi.id,
+      roomId: doorwayPoi.roomId,
+      wall: 'north',
+      doorway: expect.objectContaining({ start: expect.any(Number), end: expect.any(Number) }),
+    });
+  });
+
   it('includes interaction radii when checking for overlaps', () => {
     const poiA = clonePoi({
       id: 'futuroptimist-interaction-overlap-a' as (typeof baseDefinitions)[0]['id'],
@@ -188,6 +212,15 @@ describe('assertValidPoiDefinitions', () => {
         z: baseDefinitions[0].position.z,
       },
     });
+    const doorwayBlocker = clonePoi({
+      id: 'doorway-blocker' as PoiDefinition['id'],
+      position: {
+        x: livingRoomBounds.minX + 14,
+        y: baseDefinitions[0].position.y,
+        z: livingRoomBounds.maxZ - 0.35,
+      },
+      footprint: { width: 3.2, depth: 2.4 },
+    });
 
     const problematicList = [
       ...baseDefinitions,
@@ -196,6 +229,7 @@ describe('assertValidPoiDefinitions', () => {
       outOfBoundsPoi,
       overlapA,
       overlapB,
+      doorwayBlocker,
     ];
 
     expect(() =>
@@ -209,6 +243,7 @@ describe('assertValidPoiDefinitions', () => {
         expect(error.message).toContain('unknown room');
         expect(error.message).toContain('outside livingRoom');
         expect(error.message).toContain('overlap');
+        expect(error.message).toContain('doorway');
       } else {
         throw error;
       }


### PR DESCRIPTION
## Summary
- add doorway clearance zone utility to protect door thresholds
- fail POI validation when a footprint blocks a doorway clearance zone
- document the new guardrail on the roadmap and cover it with tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e35a2c8d90832f818b819d5652c6f4