### PR TITLE
Input-aware movement legend overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ lightweight.
   with a lightweight bloom pass so the room inherits a soft gradient glow without heavy shadows.
   A Shift+L debug toggle disables bloom/LED accents to compare raw material response.
 - **Controls** – `KeyboardControls` listens for `keydown`/`keyup` using `event.key` strings (WASD + arrow keys) and feeds the movement loop, which clamps the player inside the room bounds.
+- **HUD overlay** – The floating movement legend now reacts to the most recent input method
+  (keyboard, mouse, or touch) and swaps the interact hint to match, so visitors always see the
+  action verb that applies to their device.
 - **Points of Interest** – A data-driven registry spawns holographic pedestals with animated
   tooltips for featured repos. Proximity-based halos ease the labels in so players sense each
   interaction radius without clutter, and a DOM overlay mirrors the metadata so screen readers and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,6 +133,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
 
 1. **HUD Layer**
    - Responsive overlay with movement legend, interaction prompt, and help modal.
+   - ✨ Movement legend now detects the last input method (keyboard, mouse, or touch) and
+     refreshes the interact prompt copy so players always see the relevant control hint.
    - ✅ Help modal opens from the HUD button or `H`/`?` hotkeys and surfaces controls,
      accessibility tips, and failover guidance.
    - ✅ Accessibility HUD presets now expose Standard, Calm, and Photosensitive-safe modes

--- a/index.html
+++ b/index.html
@@ -78,10 +78,21 @@
         display: flex;
         align-items: flex-start;
         gap: 0.75rem;
+        border-radius: 0.6rem;
+        padding: 0.25rem 0.35rem;
+        transition:
+          background-color 180ms ease,
+          box-shadow 180ms ease,
+          color 180ms ease;
       }
 
       .overlay__item[hidden] {
         display: none;
+      }
+
+      .overlay__item[data-state='active'] {
+        background: rgba(32, 82, 128, 0.28);
+        box-shadow: 0 0 0 1px rgba(114, 210, 255, 0.28);
       }
 
       .overlay__keys {
@@ -91,9 +102,17 @@
         color: rgba(143, 214, 255, 0.9);
       }
 
+      .overlay__item[data-state='active'] .overlay__keys {
+        color: rgba(173, 236, 255, 0.96);
+      }
+
       .overlay__description {
         flex: 1;
         color: rgba(239, 245, 255, 0.88);
+      }
+
+      .overlay__item[data-state='active'] .overlay__description {
+        color: rgba(244, 250, 255, 0.96);
       }
 
       .overlay__item--touch {
@@ -286,41 +305,60 @@
     <div class="overlay" id="control-overlay">
       <p class="overlay__heading">Controls</p>
       <ul class="overlay__list">
-        <li class="overlay__item">
+        <li class="overlay__item" data-input-methods="keyboard">
           <span class="overlay__keys">WASD / Arrow keys</span>
           <span class="overlay__description">Move</span>
         </li>
-        <li class="overlay__item overlay__item--desktop">
+        <li
+          class="overlay__item overlay__item--desktop"
+          data-input-methods="pointer"
+        >
           <span class="overlay__keys">Left mouse button</span>
           <span class="overlay__description">Drag to pan</span>
         </li>
-        <li class="overlay__item overlay__item--desktop">
+        <li
+          class="overlay__item overlay__item--desktop"
+          data-input-methods="pointer"
+        >
           <span class="overlay__keys">Scroll wheel</span>
           <span class="overlay__description">Zoom</span>
         </li>
-        <li class="overlay__item overlay__item--touch">
+        <li
+          class="overlay__item overlay__item--touch"
+          data-input-methods="touch"
+        >
           <span class="overlay__keys">Touch</span>
           <span class="overlay__description">
             Drag the left half to move and the right half to pan
           </span>
         </li>
-        <li class="overlay__item overlay__item--touch">
+        <li
+          class="overlay__item overlay__item--touch"
+          data-input-methods="touch"
+        >
           <span class="overlay__keys">Pinch</span>
           <span class="overlay__description">Zoom</span>
         </li>
-        <li class="overlay__item">
+        <li class="overlay__item" data-input-methods="keyboard">
           <span class="overlay__keys">Q / E</span>
           <span class="overlay__description">Cycle POIs</span>
         </li>
-        <li class="overlay__item">
+        <li class="overlay__item" data-input-methods="keyboard">
           <span class="overlay__keys">T</span>
           <span class="overlay__description">Switch to text mode</span>
         </li>
-        <li class="overlay__item" data-control="interact" hidden>
-          <span class="overlay__keys">F</span>
+        <li
+          class="overlay__item"
+          data-control="interact"
+          data-role="interact"
+          data-input-methods="keyboard pointer touch"
+          hidden
+        >
+          <span class="overlay__keys" data-role="interact-label">F</span>
           <span
             class="overlay__description"
             data-control="interact-description"
+            data-role="interact-description"
           >
             Interact
           </span>

--- a/src/hud/movementLegend.ts
+++ b/src/hud/movementLegend.ts
@@ -1,0 +1,302 @@
+export type InputMethod = 'keyboard' | 'pointer' | 'touch';
+
+export interface MovementLegendOptions {
+  container: HTMLElement;
+  windowTarget?: Window;
+  initialMethod?: InputMethod;
+  interactLabels?: Partial<Record<InputMethod, string>>;
+  defaultInteractDescription?: string;
+}
+
+export interface MovementLegendHandle {
+  getActiveMethod(): InputMethod;
+  setActiveMethod(method: InputMethod): void;
+  setInteractPrompt(description: string | null): void;
+  dispose(): void;
+}
+
+interface LegendItem {
+  element: HTMLElement;
+  methods: InputMethod[];
+}
+
+interface MovementLegendContext {
+  items: LegendItem[];
+  interactItem: HTMLElement | null;
+  interactLabel: HTMLElement | null;
+  interactDescription: HTMLElement | null;
+  defaultInteractDescription: string;
+}
+
+const DEFAULT_INTERACT_LABELS: Record<InputMethod, string> = {
+  keyboard: 'F',
+  pointer: 'Click',
+  touch: 'Tap',
+};
+
+const MODIFIER_KEYS = new Set([
+  'Shift',
+  'Control',
+  'Alt',
+  'Meta',
+  'CapsLock',
+  'NumLock',
+  'ScrollLock',
+]);
+
+function detectInitialMethod(options: {
+  explicit?: InputMethod;
+  windowTarget?: Window;
+}): InputMethod {
+  if (options.explicit) {
+    return options.explicit;
+  }
+
+  const win = options.windowTarget;
+  const nav = win?.navigator as
+    | (Navigator & { maxTouchPoints?: number })
+    | undefined;
+
+  if (typeof nav?.maxTouchPoints === 'number' && nav.maxTouchPoints > 0) {
+    return 'touch';
+  }
+
+  if (typeof win?.matchMedia === 'function') {
+    const query = win.matchMedia('(hover: none) and (pointer: coarse)');
+    if (query.matches) {
+      return 'touch';
+    }
+  }
+
+  return 'keyboard';
+}
+
+function parseInputMethods(value: string | null | undefined): InputMethod[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(/[\s,]+/)
+    .map((method) => method.trim())
+    .filter(
+      (method): method is InputMethod =>
+        method === 'keyboard' || method === 'pointer' || method === 'touch'
+    );
+}
+
+function resolvePointerMethod(event: PointerEvent | MouseEvent): InputMethod {
+  const pointerType = 'pointerType' in event ? event.pointerType : undefined;
+  if (typeof pointerType === 'string') {
+    const normalized = pointerType.toLowerCase();
+    if (normalized === 'touch') {
+      return 'touch';
+    }
+    if (normalized === 'mouse' || normalized === 'pen') {
+      return 'pointer';
+    }
+  }
+  return 'pointer';
+}
+
+function collectContext(container: HTMLElement): MovementLegendContext {
+  const items = Array.from(
+    container.querySelectorAll<HTMLElement>('[data-input-methods]')
+  ).map((element) => ({
+    element,
+    methods: parseInputMethods(element.dataset.inputMethods),
+  }));
+
+  const interactItem = container.querySelector<HTMLElement>(
+    '[data-role="interact"]'
+  );
+  const interactLabel =
+    interactItem?.querySelector<HTMLElement>('[data-role="interact-label"]') ??
+    null;
+  const interactDescription =
+    interactItem?.querySelector<HTMLElement>(
+      '[data-role="interact-description"]'
+    ) ?? null;
+
+  const defaultInteractDescription = interactDescription?.textContent?.trim()
+    ? interactDescription.textContent.trim()
+    : 'Interact';
+
+  return {
+    items,
+    interactItem: interactItem ?? null,
+    interactLabel,
+    interactDescription,
+    defaultInteractDescription,
+  };
+}
+
+function updateActiveState(
+  context: MovementLegendContext,
+  method: InputMethod
+) {
+  for (const item of context.items) {
+    if (item.methods.includes(method)) {
+      item.element.dataset.state = 'active';
+    } else {
+      delete item.element.dataset.state;
+    }
+  }
+}
+
+function updateInteractLabel(
+  context: MovementLegendContext,
+  labels: Record<InputMethod, string>,
+  method: InputMethod
+) {
+  if (!context.interactLabel) {
+    return;
+  }
+  const nextLabel = labels[method] ?? labels.keyboard;
+  context.interactLabel.textContent = nextLabel;
+}
+
+export function createMovementLegend(
+  options: MovementLegendOptions
+): MovementLegendHandle {
+  const {
+    container,
+    windowTarget = typeof window !== 'undefined' ? window : undefined,
+    initialMethod,
+    interactLabels,
+    defaultInteractDescription = 'Interact',
+  } = options;
+
+  const context = collectContext(container);
+
+  const labels: Record<InputMethod, string> = {
+    ...DEFAULT_INTERACT_LABELS,
+    ...interactLabels,
+  } as Record<InputMethod, string>;
+
+  if (context.interactDescription) {
+    context.interactDescription.textContent =
+      context.defaultInteractDescription || defaultInteractDescription;
+  }
+
+  const activeLabelsDescription = context.interactDescription
+    ? context.interactDescription.textContent
+    : defaultInteractDescription;
+  context.defaultInteractDescription = activeLabelsDescription || 'Interact';
+
+  let activeMethod = detectInitialMethod({
+    explicit: initialMethod,
+    windowTarget,
+  });
+
+  const applyMethod = (method: InputMethod) => {
+    if (activeMethod === method) {
+      return;
+    }
+    activeMethod = method;
+    if (container.dataset.activeInput !== method) {
+      container.dataset.activeInput = method;
+    }
+    updateActiveState(context, method);
+    updateInteractLabel(context, labels, method);
+  };
+
+  const ensureInteractLabel = () => {
+    updateInteractLabel(context, labels, activeMethod);
+  };
+
+  const setActiveMethod = (method: InputMethod) => {
+    applyMethod(method);
+  };
+
+  const setInteractPrompt = (description: string | null) => {
+    if (!context.interactItem || !context.interactDescription) {
+      return;
+    }
+    if (description) {
+      context.interactItem.hidden = false;
+      context.interactDescription.textContent = description;
+    } else {
+      context.interactItem.hidden = true;
+      context.interactDescription.textContent =
+        context.defaultInteractDescription;
+    }
+    ensureInteractLabel();
+  };
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+    if (MODIFIER_KEYS.has(event.key)) {
+      return;
+    }
+    applyMethod('keyboard');
+  };
+
+  const handlePointerEvent = (event: PointerEvent | MouseEvent) => {
+    const method = resolvePointerMethod(event);
+    applyMethod(method);
+  };
+
+  const handleTouchStart = () => {
+    applyMethod('touch');
+  };
+
+  const listeners: Array<() => void> = [];
+
+  if (windowTarget) {
+    const addListener = <K extends keyof WindowEventMap>(
+      type: K,
+      listener: (event: WindowEventMap[K]) => void,
+      options?: boolean | AddEventListenerOptions
+    ) => {
+      windowTarget.addEventListener(type, listener as EventListener, options);
+      listeners.push(() =>
+        windowTarget.removeEventListener(
+          type,
+          listener as EventListener,
+          options
+        )
+      );
+    };
+
+    addListener('keydown', handleKeydown);
+    addListener('pointerdown', handlePointerEvent as EventListener);
+    addListener('mousedown', handlePointerEvent as EventListener);
+    addListener('touchstart', handleTouchStart, { passive: true });
+  }
+
+  // Apply the initial method after listeners to ensure the DOM is in sync.
+  container.dataset.activeInput = activeMethod;
+  updateActiveState(context, activeMethod);
+  ensureInteractLabel();
+
+  return {
+    getActiveMethod() {
+      return activeMethod;
+    },
+    setActiveMethod,
+    setInteractPrompt,
+    dispose() {
+      while (listeners.length > 0) {
+        const remove = listeners.pop();
+        remove?.();
+      }
+      context.items.forEach((item) => {
+        delete item.element.dataset.state;
+      });
+      delete container.dataset.activeInput;
+      if (context.interactItem) {
+        context.interactItem.hidden = true;
+      }
+      if (context.interactDescription) {
+        context.interactDescription.textContent =
+          context.defaultInteractDescription;
+      }
+      ensureInteractLabel();
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,6 +96,10 @@ import {
   type HudLayoutManagerHandle,
 } from './hud/layoutManager';
 import {
+  createMovementLegend,
+  type MovementLegendHandle,
+} from './hud/movementLegend';
+import {
   createLightingDebugController,
   type LightingMode,
 } from './lighting/debugControls';
@@ -1335,6 +1339,9 @@ function initializeImmersiveScene(
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
+  const movementLegend: MovementLegendHandle | null = controlOverlay
+    ? createMovementLegend({ container: controlOverlay })
+    : null;
   const helpModal = createHelpModal({ container: document.body });
   let helpButtonClickHandler: (() => void) | null = null;
   if (helpButton) {
@@ -2242,6 +2249,15 @@ function initializeImmersiveScene(
       return;
     }
     interactablePoi = poi;
+    if (movementLegend) {
+      if (poi) {
+        movementLegend.setInteractPrompt(
+          `Interact with ${poi.definition.title}`
+        );
+      } else {
+        movementLegend.setInteractPrompt(null);
+      }
+    }
     if (!interactControl || !interactDescription) {
       return;
     }
@@ -2343,6 +2359,7 @@ function initializeImmersiveScene(
       window.removeEventListener('beforeunload', beforeUnloadHandler);
       beforeUnloadHandler = null;
     }
+    movementLegend?.dispose();
     helpModal.dispose();
   }
 

--- a/src/tests/movementLegend.test.ts
+++ b/src/tests/movementLegend.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMovementLegend } from '../hud/movementLegend';
+
+function createOverlayContainer(): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `
+    <ul>
+      <li class="overlay__item" data-input-methods="keyboard">
+        <span class="overlay__keys">WASD / Arrow keys</span>
+        <span class="overlay__description">Move</span>
+      </li>
+      <li class="overlay__item" data-input-methods="pointer">
+        <span class="overlay__keys">Left mouse</span>
+        <span class="overlay__description">Pan</span>
+      </li>
+      <li class="overlay__item" data-input-methods="touch">
+        <span class="overlay__keys">Touch</span>
+        <span class="overlay__description">Drag</span>
+      </li>
+      <li
+        class="overlay__item"
+        data-role="interact"
+        data-input-methods="keyboard pointer touch"
+        hidden
+      >
+        <span class="overlay__keys" data-role="interact-label">F</span>
+        <span class="overlay__description" data-role="interact-description">
+          Interact
+        </span>
+      </li>
+    </ul>
+  `;
+  return wrapper.firstElementChild as HTMLElement;
+}
+
+function createStubWindow(
+  options: {
+    maxTouchPoints?: number;
+    coarsePointer?: boolean;
+  } = {}
+) {
+  const { maxTouchPoints = 0, coarsePointer = false } = options;
+  class StubWindow extends EventTarget {
+    navigator = { maxTouchPoints };
+    matchMedia(query: string) {
+      const matches =
+        coarsePointer && query === '(hover: none) and (pointer: coarse)';
+      return {
+        matches,
+        media: query,
+        onchange: null,
+        addListener() {},
+        removeListener() {},
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent() {
+          return false;
+        },
+      };
+    }
+  }
+  return new StubWindow() as unknown as Window;
+}
+
+function dispatchPointerEvent(target: Window, pointerType: string): void {
+  let event: Event;
+  if (typeof window.PointerEvent === 'function') {
+    event = new window.PointerEvent('pointerdown', { pointerType });
+  } else {
+    event = new window.Event('pointerdown');
+    Object.assign(event, { pointerType });
+  }
+  target.dispatchEvent(event);
+}
+
+describe('createMovementLegend', () => {
+  it('highlights the configured input method and allows manual switching', () => {
+    const container = createOverlayContainer();
+    const legend = createMovementLegend({
+      container,
+      initialMethod: 'keyboard',
+    });
+
+    const [keyboardItem, pointerItem] = container.querySelectorAll('li');
+    expect(keyboardItem?.dataset.state).toBe('active');
+    expect(pointerItem?.dataset.state).toBeUndefined();
+
+    legend.setActiveMethod('pointer');
+    expect(keyboardItem?.dataset.state).toBeUndefined();
+    expect(pointerItem?.dataset.state).toBe('active');
+
+    legend.dispose();
+  });
+
+  it('updates the interact prompt visibility and labels per input method', () => {
+    const container = createOverlayContainer();
+    const legend = createMovementLegend({
+      container,
+      initialMethod: 'keyboard',
+    });
+
+    const interactItem = container.querySelector('[data-role="interact"]');
+    const interactLabel = container.querySelector(
+      '[data-role="interact-label"]'
+    );
+    const interactDescription = container.querySelector(
+      '[data-role="interact-description"]'
+    );
+
+    legend.setInteractPrompt('Interact with Futuroptimist');
+    expect(interactItem?.hidden).toBe(false);
+    expect(interactDescription?.textContent).toBe(
+      'Interact with Futuroptimist'
+    );
+    expect(interactLabel?.textContent).toBe('F');
+
+    legend.setActiveMethod('touch');
+    expect(interactLabel?.textContent).toBe('Tap');
+
+    legend.setInteractPrompt(null);
+    expect(interactItem?.hidden).toBe(true);
+    expect(interactDescription?.textContent).toBe('Interact');
+
+    legend.dispose();
+  });
+
+  it('reacts to runtime input signals from window events', () => {
+    const container = createOverlayContainer();
+    const legend = createMovementLegend({ container, windowTarget: window });
+
+    dispatchPointerEvent(window, 'touch');
+    expect(legend.getActiveMethod()).toBe('touch');
+
+    const keyboardEvent = new window.KeyboardEvent('keydown', { key: 'w' });
+    window.dispatchEvent(keyboardEvent);
+    expect(legend.getActiveMethod()).toBe('keyboard');
+
+    dispatchPointerEvent(window, 'mouse');
+    expect(legend.getActiveMethod()).toBe('pointer');
+
+    legend.dispose();
+  });
+
+  it('derives the initial method from navigator touch heuristics', () => {
+    const container = createOverlayContainer();
+    const stubWindow = createStubWindow({ maxTouchPoints: 3 });
+    const legend = createMovementLegend({
+      container,
+      windowTarget: stubWindow,
+    });
+
+    expect(legend.getActiveMethod()).toBe('touch');
+    legend.dispose();
+  });
+
+  it('falls back to coarse pointer media query when touch points are zero', () => {
+    const container = createOverlayContainer();
+    const stubWindow = createStubWindow({ coarsePointer: true });
+    const legend = createMovementLegend({
+      container,
+      windowTarget: stubWindow,
+    });
+
+    expect(legend.getActiveMethod()).toBe('touch');
+    legend.dispose();
+  });
+
+  it('cleans up listeners and restores defaults on dispose', () => {
+    const container = createOverlayContainer();
+    const legend = createMovementLegend({
+      container,
+      initialMethod: 'pointer',
+    });
+
+    legend.setInteractPrompt('Interact with Exhibit');
+    legend.dispose();
+
+    expect(container.dataset.activeInput).toBeUndefined();
+    const interactItem = container.querySelector('[data-role="interact"]');
+    const interactDescription = container.querySelector(
+      '[data-role="interact-description"]'
+    );
+    expect(interactItem?.hidden).toBe(true);
+    expect(interactDescription?.textContent).toBe('Interact');
+
+    dispatchPointerEvent(window, 'touch');
+    expect(legend.getActiveMethod()).toBe('pointer');
+  });
+});


### PR DESCRIPTION
## Summary
- highlight the HUD movement legend based on the last input method and surface device-specific interact hints
- add a movement legend controller that tracks keyboard, pointer, and touch signals with proper teardown hooks
- cover the controller with targeted tests and document the responsive overlay milestone

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e35a2c8d90832f818b819d5652c6f4