### PR TITLE
Persist accessibility HUD audio volume preference

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,6 +162,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
      - ✅ Visited POIs now reveal holographic checkmark badges that hover above each pedestal.
    - Optional guided tour mode that highlights the next recommended POI.
    - ✅ Visited POI progress persists across reloads, powering halo highlights and tooltip badges.
+   - ✅ Accessibility HUD now remembers ambient audio volume tweaks between play sessions.
    - ✅ Guided tour overlay surfaces the next recommended POI whenever the player is idle.
 
 ## Phase 4 – Accessibility & Internationalization


### PR DESCRIPTION
## Summary
- persist accessibility preset base audio volume and reuse it on load
- document the roadmap slice for remembering ambient audio tweaks

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e40afb7bb4832fb2d0d00947a6743f