### PR TITLE
Add audio caption overlay for ambient and POI cues

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ lightweight.
   keyboard users receive the same context. Metadata is authored in TypeScript so future automations
   can extend exhibits by updating data alone, and the studio desk now hosts a Jobbot holographic
   terminal that pulses in sync with the new automation POI.
+- **Audio captions** – A subtitles overlay now calls out ambient beds and POI narration with
+  cooldown-aware timing so visitors who mute audio or rely on captions still catch the
+  story beats.
 - **Backyard installations** – The dusk courtyard now features a dSpace-inspired model rocket on a
   lit launch pad with a safety halo, tying the exterior exhibits into the narrative while the nav
   colliders keep players clear of the ignition zone.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -184,9 +184,11 @@ Focus: make the experience inclusive and globally friendly.
 
 2. **Visual & Audio Accessibility**
    - High-contrast material set, colorblind-safe lighting palettes, and adjustable motion blur.
+
 - Subtitle/captions system for ambient audio callouts and POI narration.
   - ✅ Audio subtitles overlay now surfaces ambient beds and POI narration with cooldown-aware captions.
-   - Photo sensitivity safe mode (reduced flicker, muted emissives).
+  - Photo sensitivity safe mode (reduced flicker, muted emissives).
+
 3. **Localization Pipeline**
    - Extract UI + POI copy into i18n catalog with English baseline.
    - Provide translation scaffolding (e.g., JSON/PO files) and fallback strings.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -184,7 +184,8 @@ Focus: make the experience inclusive and globally friendly.
 
 2. **Visual & Audio Accessibility**
    - High-contrast material set, colorblind-safe lighting palettes, and adjustable motion blur.
-   - Subtitle/captions system for ambient audio callouts and POI narration.
+- Subtitle/captions system for ambient audio callouts and POI narration.
+  - ✅ Audio subtitles overlay now surfaces ambient beds and POI narration with cooldown-aware captions.
    - Photo sensitivity safe mode (reduced flicker, muted emissives).
 3. **Localization Pipeline**
    - Extract UI + POI copy into i18n catalog with English baseline.

--- a/src/audio/ambientCaptionBridge.ts
+++ b/src/audio/ambientCaptionBridge.ts
@@ -36,7 +36,8 @@ export class AmbientCaptionBridge {
     controller,
     subtitles,
     cooldownMs = DEFAULT_COOLDOWN_MS,
-    now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now()),
+    now = () =>
+      typeof performance !== 'undefined' ? performance.now() : Date.now(),
   }: AmbientCaptionBridgeOptions) {
     this.controller = controller;
     this.subtitles = subtitles;
@@ -78,21 +79,27 @@ export class AmbientCaptionBridge {
       audible: false,
       lastShownAt: null,
     };
+    const wasAudible = state.audible;
+    const messageId = `ambient-${snapshot.id}`;
+    let didDisplay = false;
 
     if (isAudible && !state.audible) {
       const lastShownAt = state.lastShownAt ?? -Infinity;
       if (currentTime - lastShownAt >= this.cooldownMs) {
         this.subtitles.show({
-          id: `ambient-${snapshot.id}`,
+          id: messageId,
           text: caption,
           source: 'ambient',
           priority: 1,
         });
-        state.lastShownAt = currentTime;
+        if (this.subtitles.getCurrent()?.id === messageId) {
+          state.lastShownAt = currentTime;
+          didDisplay = true;
+        }
       }
     }
 
-    state.audible = isAudible;
+    state.audible = isAudible && (wasAudible || didDisplay);
     this.states.set(snapshot.id, state);
   }
 }

--- a/src/audio/ambientCaptionBridge.ts
+++ b/src/audio/ambientCaptionBridge.ts
@@ -1,0 +1,98 @@
+import type { AudioSubtitlesHandle } from '../hud/audioSubtitles';
+
+import type {
+  AmbientAudioBedSnapshot,
+  AmbientAudioController,
+} from './ambientAudio';
+
+export interface AmbientCaptionBridgeOptions {
+  controller: AmbientAudioController;
+  subtitles: AudioSubtitlesHandle;
+  cooldownMs?: number;
+  now?: () => number;
+}
+
+interface AmbientCaptionState {
+  audible: boolean;
+  lastShownAt: number | null;
+}
+
+const DEFAULT_COOLDOWN_MS = 8000;
+
+const DEFAULT_THRESHOLD = 0.18;
+
+export class AmbientCaptionBridge {
+  private readonly controller: AmbientAudioController;
+
+  private readonly subtitles: AudioSubtitlesHandle;
+
+  private readonly cooldownMs: number;
+
+  private readonly now: () => number;
+
+  private readonly states = new Map<string, AmbientCaptionState>();
+
+  constructor({
+    controller,
+    subtitles,
+    cooldownMs = DEFAULT_COOLDOWN_MS,
+    now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now()),
+  }: AmbientCaptionBridgeOptions) {
+    this.controller = controller;
+    this.subtitles = subtitles;
+    this.cooldownMs = Math.max(0, cooldownMs);
+    this.now = now;
+  }
+
+  update(): void {
+    const snapshots = this.controller.getBedSnapshots();
+    const snapshotIds = new Set<string>();
+    const currentTime = this.now();
+
+    for (const snapshot of snapshots) {
+      snapshotIds.add(snapshot.id);
+      this.processSnapshot(snapshot, currentTime);
+    }
+
+    for (const id of Array.from(this.states.keys())) {
+      if (!snapshotIds.has(id)) {
+        this.states.delete(id);
+      }
+    }
+  }
+
+  private processSnapshot(
+    snapshot: AmbientAudioBedSnapshot,
+    currentTime: number
+  ): void {
+    const { definition, currentVolume } = snapshot;
+    const caption = definition.caption;
+    if (!caption) {
+      this.states.delete(snapshot.id);
+      return;
+    }
+
+    const threshold = definition.captionThreshold ?? DEFAULT_THRESHOLD;
+    const isAudible = currentVolume >= threshold;
+    const state = this.states.get(snapshot.id) ?? {
+      audible: false,
+      lastShownAt: null,
+    };
+
+    if (isAudible && !state.audible) {
+      const lastShownAt = state.lastShownAt ?? -Infinity;
+      if (currentTime - lastShownAt >= this.cooldownMs) {
+        this.subtitles.show({
+          id: `ambient-${snapshot.id}`,
+          text: caption,
+          source: 'ambient',
+          priority: 1,
+        });
+        state.lastShownAt = currentTime;
+      }
+    }
+
+    state.audible = isAudible;
+    this.states.set(snapshot.id, state);
+  }
+}

--- a/src/audio/ambientCaptionBridge.ts
+++ b/src/audio/ambientCaptionBridge.ts
@@ -79,9 +79,13 @@ export class AmbientCaptionBridge {
       audible: false,
       lastShownAt: null,
     };
-    const wasAudible = state.audible;
     const messageId = `ambient-${snapshot.id}`;
-    let didDisplay = false;
+    const currentMessage = this.subtitles.getCurrent();
+    const hasFocus = currentMessage?.id === messageId;
+
+    if (!hasFocus) {
+      state.audible = false;
+    }
 
     if (isAudible && !state.audible) {
       const lastShownAt = state.lastShownAt ?? -Infinity;
@@ -92,14 +96,17 @@ export class AmbientCaptionBridge {
           source: 'ambient',
           priority: 1,
         });
+
         if (this.subtitles.getCurrent()?.id === messageId) {
           state.lastShownAt = currentTime;
-          didDisplay = true;
+          state.audible = true;
+          this.states.set(snapshot.id, state);
+          return;
         }
       }
     }
 
-    state.audible = isAudible && (wasAudible || didDisplay);
+    state.audible = isAudible && this.subtitles.getCurrent()?.id === messageId;
     this.states.set(snapshot.id, state);
   }
 }

--- a/src/audio/ambientCaptionBridge.ts
+++ b/src/audio/ambientCaptionBridge.ts
@@ -97,16 +97,24 @@ export class AmbientCaptionBridge {
           priority: 1,
         });
 
-        if (this.subtitles.getCurrent()?.id === messageId) {
+        const updatedMessage = this.subtitles.getCurrent();
+        const gainedFocus = updatedMessage?.id === messageId;
+
+        if (gainedFocus) {
           state.lastShownAt = currentTime;
           state.audible = true;
           this.states.set(snapshot.id, state);
           return;
         }
+
+        state.audible = false;
+        this.states.set(snapshot.id, state);
+        return;
       }
     }
 
-    state.audible = isAudible && this.subtitles.getCurrent()?.id === messageId;
+    const refreshedMessage = this.subtitles.getCurrent();
+    state.audible = isAudible && refreshedMessage?.id === messageId;
     this.states.set(snapshot.id, state);
   }
 }

--- a/src/hud/audioSubtitles.ts
+++ b/src/hud/audioSubtitles.ts
@@ -1,0 +1,140 @@
+export type AudioSubtitleSource = 'ambient' | 'poi';
+
+export interface AudioSubtitleMessage {
+  id?: string;
+  text: string;
+  source: AudioSubtitleSource;
+  /** Higher values override lower priority captions. Defaults to 0. */
+  priority?: number;
+  /** Duration before auto-hiding in milliseconds. Defaults to 5000 ms. */
+  durationMs?: number;
+}
+
+export interface AudioSubtitlesHandle {
+  show(message: AudioSubtitleMessage): void;
+  clear(messageId?: string): void;
+  dispose(): void;
+  /** Returns the currently visible caption if any. */
+  getCurrent(): AudioSubtitleMessage | null;
+}
+
+export interface AudioSubtitlesOptions {
+  container?: HTMLElement;
+  ariaLive?: 'polite' | 'assertive';
+  labels?: Partial<Record<AudioSubtitleSource, string>>;
+  documentTarget?: Document;
+}
+
+const DEFAULT_DURATION_MS = 5000;
+
+const DEFAULT_LABELS: Record<AudioSubtitleSource, string> = {
+  ambient: 'Ambient audio',
+  poi: 'Narration',
+};
+
+export function createAudioSubtitles({
+  container = document.body,
+  ariaLive = 'polite',
+  labels: providedLabels,
+  documentTarget = document,
+}: AudioSubtitlesOptions = {}): AudioSubtitlesHandle {
+  const root = documentTarget.createElement('div');
+  root.className = 'audio-subtitles';
+  root.setAttribute('role', 'log');
+  root.setAttribute('aria-live', ariaLive);
+  root.dataset.visible = 'false';
+
+  const label = documentTarget.createElement('div');
+  label.className = 'audio-subtitles__label';
+  label.setAttribute('aria-hidden', 'true');
+  root.appendChild(label);
+
+  const caption = documentTarget.createElement('p');
+  caption.className = 'audio-subtitles__caption';
+  root.appendChild(caption);
+
+  container.appendChild(root);
+
+  const labels = { ...DEFAULT_LABELS, ...providedLabels };
+
+  let hideTimeout: number | null = null;
+  let current: AudioSubtitleMessage | null = null;
+
+  const clearTimer = () => {
+    if (hideTimeout !== null) {
+      window.clearTimeout(hideTimeout);
+      hideTimeout = null;
+    }
+  };
+
+  const hide = () => {
+    clearTimer();
+    current = null;
+    root.dataset.visible = 'false';
+    caption.textContent = '';
+  };
+
+  const scheduleHide = (message: AudioSubtitleMessage) => {
+    clearTimer();
+    const duration =
+      message.durationMs === undefined
+        ? DEFAULT_DURATION_MS
+        : message.durationMs;
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return;
+    }
+    hideTimeout = window.setTimeout(() => {
+      if (!current) {
+        return;
+      }
+      if (message.id && current.id && message.id !== current.id) {
+        return;
+      }
+      if (!message.id && current !== message) {
+        return;
+      }
+      hide();
+    }, duration);
+  };
+
+  const show = (message: AudioSubtitleMessage) => {
+    const nextPriority = message.priority ?? 0;
+    const currentPriority = current?.priority ?? 0;
+    const sameId =
+      current?.id !== undefined && message.id !== undefined
+        ? current.id === message.id
+        : false;
+
+    if (current && !sameId && nextPriority < currentPriority) {
+      return;
+    }
+
+    current = { ...message, priority: nextPriority };
+    root.dataset.visible = 'true';
+    label.textContent = labels[message.source] ?? DEFAULT_LABELS[message.source];
+    caption.textContent = message.text;
+    scheduleHide(current);
+  };
+
+  return {
+    show(message) {
+      show(message);
+    },
+    clear(messageId) {
+      if (!current) {
+        return;
+      }
+      if (messageId && current.id && messageId !== current.id) {
+        return;
+      }
+      hide();
+    },
+    dispose() {
+      hide();
+      root.remove();
+    },
+    getCurrent() {
+      return current;
+    },
+  };
+}

--- a/src/hud/audioSubtitles.ts
+++ b/src/hud/audioSubtitles.ts
@@ -111,7 +111,8 @@ export function createAudioSubtitles({
 
     current = { ...message, priority: nextPriority };
     root.dataset.visible = 'true';
-    label.textContent = labels[message.source] ?? DEFAULT_LABELS[message.source];
+    label.textContent =
+      labels[message.source] ?? DEFAULT_LABELS[message.source];
     caption.textContent = message.text;
     scheduleHide(current);
   };

--- a/src/poi/registry.ts
+++ b/src/poi/registry.ts
@@ -22,6 +22,10 @@ const definitions: PoiDefinition[] = [
       { label: 'Docs', href: 'https://futuroptimist.dev' },
     ],
     status: 'prototype',
+    narration: {
+      caption:
+        'Futuroptimist media wall radiates highlight reels across the living room.',
+    },
   },
   {
     id: 'flywheel-studio-flywheel',
@@ -47,6 +51,10 @@ const definitions: PoiDefinition[] = [
       { label: 'Docs', href: 'https://flywheel.futuroptimist.dev' },
     ],
     status: 'prototype',
+    narration: {
+      caption:
+        'Flywheel kinetic hub whirs alive, spotlighting automation prompts and tooling.',
+    },
   },
   {
     id: 'jobbot-studio-terminal',
@@ -69,6 +77,10 @@ const definitions: PoiDefinition[] = [
       { label: 'Automation Log', href: 'https://futuroptimist.dev/automation' },
     ],
     status: 'prototype',
+    narration: {
+      caption:
+        'Jobbot holographic terminal streams automation telemetry in shimmering overlays.',
+    },
   },
   {
     id: 'dspace-backyard-rocket',
@@ -94,6 +106,11 @@ const definitions: PoiDefinition[] = [
       },
     ],
     status: 'prototype',
+    narration: {
+      caption:
+        'dSpace launch pad crackles with countdown energy beside the backyard path.',
+      durationMs: 6000,
+    },
   },
   {
     id: 'sugarkube-backyard-greenhouse',
@@ -125,6 +142,11 @@ const definitions: PoiDefinition[] = [
       },
     ],
     status: 'prototype',
+    narration: {
+      caption:
+        'Sugarkube greenhouse cycles soft grow lights and koi pond ambience in sync.',
+      durationMs: 6500,
+    },
   },
 ];
 

--- a/src/poi/types.ts
+++ b/src/poi/types.ts
@@ -19,6 +19,11 @@ export interface PoiLink {
   href: string;
 }
 
+export interface PoiNarration {
+  caption: string;
+  durationMs?: number;
+}
+
 export interface PoiFootprint {
   /** Width of the POI stand footprint in world units. */
   width: number;
@@ -41,6 +46,7 @@ export interface PoiDefinition {
   links?: PoiLink[];
   /** Optional note to surface prototype status in tooltips. */
   status?: 'prototype' | 'live';
+  narration?: PoiNarration;
 }
 
 export interface PoiAnalytics {

--- a/src/styles.css
+++ b/src/styles.css
@@ -197,6 +197,52 @@ canvas {
   font-variant-numeric: tabular-nums;
 }
 
+.audio-subtitles {
+  position: fixed;
+  left: 50%;
+  bottom: 3.5rem;
+  transform: translateX(-50%);
+  max-width: min(90vw, 36rem);
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.9rem;
+  background: rgba(5, 12, 21, 0.82);
+  border: 1px solid rgba(88, 183, 255, 0.32);
+  box-shadow: 0 22px 48px rgba(3, 9, 18, 0.6);
+  color: #e7f1ff;
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease;
+  z-index: 30;
+}
+
+.audio-subtitles[data-visible='true'] {
+  opacity: 1;
+}
+
+.audio-subtitles__label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(148, 208, 255, 0.85);
+}
+
+.audio-subtitles__caption {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: rgba(230, 243, 255, 0.95);
+}
+
+html[data-hudLayout='mobile'] .audio-subtitles {
+  bottom: 6.5rem;
+  padding: 0.85rem 1.05rem;
+  font-size: 0.95rem;
+}
+
 .graphics-quality {
   position: fixed;
   top: 13.6rem;

--- a/src/tests/ambientCaptionBridge.test.ts
+++ b/src/tests/ambientCaptionBridge.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  AmbientAudioBedDefinition,
+  AmbientAudioBedSnapshot,
+  AmbientAudioController,
+  AmbientAudioSource,
+} from '../audio/ambientAudio';
+import { AmbientCaptionBridge } from '../audio/ambientCaptionBridge';
+
+class FakeController implements AmbientAudioController {
+  private snapshot: AmbientAudioBedSnapshot;
+
+  constructor(definition: AmbientAudioBedDefinition) {
+    this.snapshot = {
+      id: definition.id,
+      currentVolume: 0,
+      targetVolume: 0,
+      definition,
+    };
+  }
+
+  setVolume(volume: number) {
+    this.snapshot = {
+      ...this.snapshot,
+      currentVolume: volume,
+      targetVolume: volume,
+    };
+  }
+
+  enable = vi.fn(async () => {});
+  disable = vi.fn(() => {});
+  dispose = vi.fn(() => {});
+  isEnabled = vi.fn(() => true);
+  update = vi.fn(() => {});
+  setMasterVolume = vi.fn(() => {});
+  getMasterVolume = vi.fn(() => 1);
+
+  getBedSnapshots(): AmbientAudioBedSnapshot[] {
+    return [this.snapshot];
+  }
+}
+
+const fakeSource: AmbientAudioSource = {
+  id: 'test',
+  isPlaying: false,
+  play: () => {},
+  stop: () => {},
+  setVolume: () => {},
+};
+
+describe('AmbientCaptionBridge', () => {
+  it('emits captions when beds cross the audible threshold and respects cooldowns', () => {
+    let currentTime = 0;
+    const controller = new FakeController({
+      id: 'hum',
+      center: { x: 0, z: 0 },
+      innerRadius: 1,
+      outerRadius: 4,
+      baseVolume: 0.4,
+      source: fakeSource,
+      caption: 'Soft hum fills the room.',
+    });
+
+    const show = vi.fn();
+    const subtitles = {
+      show,
+      clear: vi.fn(),
+      dispose: vi.fn(),
+      getCurrent: vi.fn(() => null),
+    };
+
+    const bridge = new AmbientCaptionBridge({
+      controller,
+      subtitles,
+      cooldownMs: 1000,
+      now: () => currentTime,
+    });
+
+    bridge.update();
+    expect(show).not.toHaveBeenCalled();
+
+    controller.setVolume(0.3);
+    bridge.update();
+    expect(show).toHaveBeenCalledTimes(1);
+
+    bridge.update();
+    expect(show).toHaveBeenCalledTimes(1);
+
+    controller.setVolume(0);
+    currentTime += 500;
+    bridge.update();
+
+    controller.setVolume(0.3);
+    bridge.update();
+    expect(show).toHaveBeenCalledTimes(1);
+
+    currentTime += 600;
+    controller.setVolume(0);
+    bridge.update();
+
+    controller.setVolume(0.3);
+    bridge.update();
+    expect(show).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/tests/ambientCaptionBridge.test.ts
+++ b/src/tests/ambientCaptionBridge.test.ts
@@ -169,4 +169,69 @@ describe('AmbientCaptionBridge priority handling', () => {
     expect(show).toHaveBeenCalledTimes(2);
     expect(current?.id).toBe('ambient-hum');
   });
+
+  it('restores ambient captions when a higher-priority message preempts them', () => {
+    let currentTime = 0;
+    const controller = new FakeController({
+      id: 'hum',
+      center: { x: 0, z: 0 },
+      innerRadius: 1,
+      outerRadius: 4,
+      baseVolume: 0.4,
+      source: fakeSource,
+      caption: 'Soft hum fills the room.',
+    });
+
+    let current: AudioSubtitleMessage | null = null;
+    const show = vi.fn((message: AudioSubtitleMessage) => {
+      const nextPriority = message.priority ?? 0;
+      const currentPriority = current?.priority ?? 0;
+      if (
+        current &&
+        current.id !== message.id &&
+        nextPriority < currentPriority
+      ) {
+        return;
+      }
+      current = { ...message, priority: nextPriority };
+    });
+
+    const subtitles = {
+      show,
+      clear: vi.fn(() => {
+        current = null;
+      }),
+      dispose: vi.fn(),
+      getCurrent: vi.fn(() => current),
+    };
+
+    const bridge = new AmbientCaptionBridge({
+      controller,
+      subtitles,
+      cooldownMs: 0,
+      now: () => currentTime,
+    });
+
+    controller.setVolume(0.3);
+    bridge.update();
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(current?.id).toBe('ambient-hum');
+
+    currentTime += 100;
+    current = {
+      id: 'poi-1',
+      source: 'poi',
+      text: 'POI narration',
+      priority: 2,
+    };
+
+    bridge.update();
+    expect(show).toHaveBeenCalledTimes(2);
+    expect(current?.id).toBe('poi-1');
+
+    current = null;
+    bridge.update();
+    expect(show).toHaveBeenCalledTimes(3);
+    expect(current?.id).toBe('ambient-hum');
+  });
 });

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -28,9 +28,9 @@ describe('audio subtitles overlay', () => {
     expect(element?.querySelector('.audio-subtitles__label')?.textContent).toBe(
       'Ambient audio'
     );
-    expect(element?.querySelector('.audio-subtitles__caption')?.textContent).toBe(
-      'Soft interior hum envelopes the living room.'
-    );
+    expect(
+      element?.querySelector('.audio-subtitles__caption')?.textContent
+    ).toBe('Soft interior hum envelopes the living room.');
 
     vi.advanceTimersByTime(1199);
     expect(element?.dataset.visible).toBe('true');
@@ -59,7 +59,9 @@ describe('audio subtitles overlay', () => {
     });
 
     let caption = document.querySelector('.audio-subtitles__caption');
-    expect(caption?.textContent).toBe('Flywheel hub spins up with automation prompts.');
+    expect(caption?.textContent).toBe(
+      'Flywheel hub spins up with automation prompts.'
+    );
 
     vi.advanceTimersByTime(3000);
 
@@ -72,7 +74,9 @@ describe('audio subtitles overlay', () => {
     });
 
     caption = document.querySelector('.audio-subtitles__caption');
-    expect(caption?.textContent).toBe('Flywheel hub spins up with automation prompts.');
+    expect(caption?.textContent).toBe(
+      'Flywheel hub spins up with automation prompts.'
+    );
     vi.advanceTimersByTime(1999);
     expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
       'true'

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { createAudioSubtitles } from '../hud/audioSubtitles';
+
+describe('audio subtitles overlay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('shows captions with labels and auto-hides after the configured duration', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Soft interior hum envelopes the living room.',
+      source: 'ambient',
+      durationMs: 1200,
+    });
+
+    const element = document.querySelector('.audio-subtitles');
+    expect(element).toBeTruthy();
+    expect(element?.getAttribute('aria-live')).toBe('polite');
+    expect(element?.dataset.visible).toBe('true');
+    expect(element?.querySelector('.audio-subtitles__label')?.textContent).toBe(
+      'Ambient audio'
+    );
+    expect(element?.querySelector('.audio-subtitles__caption')?.textContent).toBe(
+      'Soft interior hum envelopes the living room.'
+    );
+
+    vi.advanceTimersByTime(1199);
+    expect(element?.dataset.visible).toBe('true');
+
+    vi.advanceTimersByTime(1);
+    expect(element?.dataset.visible).toBe('false');
+    handle.dispose();
+  });
+
+  it('respects priorities and refreshes timers for identical message ids', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-flywheel',
+      text: 'Flywheel hub spins up with automation prompts.',
+      source: 'poi',
+      priority: 5,
+      durationMs: 5000,
+    });
+
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Interior hum lingers in the background.',
+      source: 'ambient',
+      priority: 1,
+      durationMs: 2000,
+    });
+
+    let caption = document.querySelector('.audio-subtitles__caption');
+    expect(caption?.textContent).toBe('Flywheel hub spins up with automation prompts.');
+
+    vi.advanceTimersByTime(3000);
+
+    handle.show({
+      id: 'poi-flywheel',
+      text: 'Flywheel hub spins up with automation prompts.',
+      source: 'poi',
+      priority: 0,
+      durationMs: 2000,
+    });
+
+    caption = document.querySelector('.audio-subtitles__caption');
+    expect(caption?.textContent).toBe('Flywheel hub spins up with automation prompts.');
+    vi.advanceTimersByTime(1999);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'true'
+    );
+    vi.advanceTimersByTime(1);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
+  it('clears captions only when the matching identifier is provided', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-jobbot',
+      text: 'Jobbot terminal emits cascading telemetry.',
+      source: 'poi',
+      durationMs: 0,
+    });
+
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'true'
+    );
+    handle.clear('different');
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'true'
+    );
+    handle.clear('poi-jobbot');
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
+  it('guards anonymous captions against stale hide timers', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      text: 'First ambient cue',
+      source: 'ambient',
+      durationMs: 1000,
+    });
+
+    handle.show({
+      text: 'Second ambient cue',
+      source: 'ambient',
+      durationMs: 1000,
+    });
+
+    vi.advanceTimersByTime(999);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'true'
+    );
+    vi.advanceTimersByTime(1);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- add an audio subtitles overlay so ambient beds and POI narration surface captions
- bridge the ambient audio controller to caption events and expose bed snapshots for analytics
- update roadmap/README docs and add focused tests for the new UI and bridge logic

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e40afb7bb4832fb2d0d00947a6743f