### PR TITLE
Add baked lightmaps to interior surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ lightweight.
 ## Architecture notes
 
 - **Camera** – Orthographic camera with a constant world height (`CAMERA_SIZE = 20`). On resize we recompute the left/right bounds from the new aspect ratio and call `updateProjectionMatrix()` to keep scale consistent.
-- **Lighting** – Ambient + directional key lights are now complemented by emissive LED cove strips
-  with a lightweight bloom pass so the room inherits a soft gradient glow without heavy shadows.
+- **Lighting** – Ambient + directional key lights now pair with emissive LED cove strips and baked
+  gradient lightmaps so the room inherits a dusk bounce wash without heavy shadows.
   A Shift+L debug toggle disables bloom/LED accents to compare raw material response.
 - **Controls** – `KeyboardControls` listens for `keydown`/`keyup` using `event.key` strings (WASD + arrow keys) and feeds the movement loop, which clamps the player inside the room bounds.
 - **HUD overlay** – The floating movement legend now reacts to the most recent input method

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,6 +59,8 @@ Focus: expand the environment while keeping navigation smooth.
    - Tune lightmap UVs/materials so walls, ceiling, and floor receive a soft gradient glow.
    - ✅ Shift+L toggles a debug lighting view that disables bloom/LEDs for side-by-side comparisons.
    - ✅ Emissive cove strips now emit via bloom-tuned LED meshes and corner fill lights.
+   - ✨ Baked dusk lightmaps now bathe floors and walls in a gradient bounce wash that pairs with the LED strips.
+   - ✨ Interior walls and fences now expose dedicated UV2 channels so future bakes stay artifact-free.
 2. **House Footprint Layout**
    - Block out multiple rooms on the ground floor using modular wall/floor/ceiling pieces.
    - Cut simple doorway openings (no doors yet) between rooms and toward the backyard.

--- a/src/lighting/bakedLightmaps.ts
+++ b/src/lighting/bakedLightmaps.ts
@@ -1,0 +1,155 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  DataTexture,
+  LinearFilter,
+  MathUtils,
+  RGBAFormat,
+  SRGBColorSpace,
+  Vector2,
+} from 'three';
+
+export interface InteriorLightmapTextures {
+  readonly floor: DataTexture;
+  readonly wall: DataTexture;
+}
+
+export interface InteriorLightmapOptions {
+  readonly floorSize: { width: number; depth: number };
+  readonly floorResolution?: number;
+  readonly wallResolution?: number;
+}
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  if (edge0 === edge1) {
+    return x < edge0 ? 0 : 1;
+  }
+  const t = MathUtils.clamp((x - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+const FLOOR_BASE_COLOR = new Color(0.46, 0.5, 0.58);
+const FLOOR_DUSK_COLOR = new Color(0.7, 0.66, 0.62);
+const FLOOR_WALKWAY_COLOR = new Color(0.9, 0.82, 0.68);
+const FLOOR_PERIMETER_COLOR = new Color(0.34, 0.36, 0.42);
+
+const WALL_BASE_COLOR = new Color(0.3, 0.33, 0.4);
+const WALL_MID_COLOR = new Color(0.46, 0.5, 0.58);
+const WALL_CROWN_COLOR = new Color(0.92, 0.86, 0.72);
+const WALL_ACCENT_COLOR = new Color(0.64, 0.6, 0.54);
+
+function createGradientTexture(
+  resolution: Vector2,
+  sample: (uv: Vector2, output: Color) => void
+): DataTexture {
+  const { x: width, y: height } = resolution;
+  const pixels = new Uint8Array(width * height * 4);
+  const color = new Color();
+  const uv = new Vector2();
+  let offset = 0;
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      uv.set(
+        width <= 1 ? 0.5 : x / (width - 1),
+        height <= 1 ? 0.5 : y / (height - 1)
+      );
+      sample(uv, color);
+      const r = MathUtils.clamp(color.r, 0, 1);
+      const g = MathUtils.clamp(color.g, 0, 1);
+      const b = MathUtils.clamp(color.b, 0, 1);
+      pixels[offset] = Math.round(r * 255);
+      pixels[offset + 1] = Math.round(g * 255);
+      pixels[offset + 2] = Math.round(b * 255);
+      pixels[offset + 3] = 255;
+      offset += 4;
+    }
+  }
+
+  const texture = new DataTexture(pixels, width, height, RGBAFormat);
+  texture.colorSpace = SRGBColorSpace;
+  texture.magFilter = LinearFilter;
+  texture.minFilter = LinearFilter;
+  texture.generateMipmaps = false;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function sampleFloorLightmap(
+  uv: Vector2,
+  output: Color,
+  aspect: number
+): void {
+  const offsetX = uv.x - 0.48;
+  const offsetY = (uv.y - 0.42) * aspect;
+  const radialDistance = Math.sqrt(offsetX * offsetX + offsetY * offsetY);
+  const radialInfluence = smoothstep(0.65, 0.05, radialDistance);
+
+  const edgeDistance = Math.min(
+    Math.min(uv.x, 1 - uv.x),
+    Math.min(uv.y, 1 - uv.y)
+  );
+  const edgeBlend = smoothstep(0.08, 0.25, edgeDistance);
+
+  const walkwayWarmth = smoothstep(0.55, 0.98, uv.y);
+  const easternGlow = smoothstep(0.45, 1, uv.x);
+  const walkwayInfluence = walkwayWarmth * easternGlow;
+
+  output.copy(FLOOR_PERIMETER_COLOR);
+  output.lerp(FLOOR_BASE_COLOR, edgeBlend);
+  output.lerp(FLOOR_DUSK_COLOR, radialInfluence * 0.85);
+  output.lerp(FLOOR_WALKWAY_COLOR, walkwayInfluence * 0.9);
+}
+
+function sampleWallLightmap(uv: Vector2, output: Color): void {
+  const vertical = uv.y;
+  const horizontal = 1 - Math.abs(uv.x - 0.5) * 2;
+  const midBlend = smoothstep(0.1, 0.75, vertical);
+  const crownBlend = smoothstep(0.55, 1, vertical);
+  const accentBlend = smoothstep(0.35, 0.95, vertical) * smoothstep(0.2, 1, horizontal);
+
+  output.copy(WALL_BASE_COLOR);
+  output.lerp(WALL_MID_COLOR, midBlend);
+  output.lerp(WALL_ACCENT_COLOR, accentBlend * 0.6);
+  output.lerp(WALL_CROWN_COLOR, crownBlend);
+}
+
+export function createInteriorLightmapTextures(
+  options: InteriorLightmapOptions
+): InteriorLightmapTextures {
+  const floorResolution = Math.max(32, options.floorResolution ?? 256);
+  const wallResolution = Math.max(32, options.wallResolution ?? 128);
+  const aspect = Math.max(
+    0.5,
+    Math.min(options.floorSize.depth / options.floorSize.width || 1, 2.5)
+  );
+
+  const floor = createGradientTexture(
+    new Vector2(floorResolution, floorResolution),
+    (uv, color) => sampleFloorLightmap(uv, color, aspect)
+  );
+  floor.name = 'InteriorFloorLightmap';
+
+  const wall = createGradientTexture(
+    new Vector2(wallResolution, wallResolution),
+    (uv, color) => sampleWallLightmap(uv, color)
+  );
+  wall.name = 'InteriorWallLightmap';
+
+  return { floor, wall };
+}
+
+export function applyLightmapUv2(geometry: BufferGeometry): void {
+  const uv = geometry.getAttribute('uv');
+  if (!uv) {
+    return;
+  }
+  if (geometry.getAttribute('uv2')) {
+    return;
+  }
+  const source = uv as BufferAttribute;
+  const cloneArray = new Float32Array(source.array as ArrayLike<number>);
+  const clone = new BufferAttribute(cloneArray, source.itemSize, source.normalized);
+  geometry.setAttribute('uv2', clone);
+}

--- a/src/lighting/bakedLightmaps.ts
+++ b/src/lighting/bakedLightmaps.ts
@@ -76,11 +76,7 @@ function createGradientTexture(
   return texture;
 }
 
-function sampleFloorLightmap(
-  uv: Vector2,
-  output: Color,
-  aspect: number
-): void {
+function sampleFloorLightmap(uv: Vector2, output: Color, aspect: number): void {
   const offsetX = uv.x - 0.48;
   const offsetY = (uv.y - 0.42) * aspect;
   const radialDistance = Math.sqrt(offsetX * offsetX + offsetY * offsetY);
@@ -107,7 +103,8 @@ function sampleWallLightmap(uv: Vector2, output: Color): void {
   const horizontal = 1 - Math.abs(uv.x - 0.5) * 2;
   const midBlend = smoothstep(0.1, 0.75, vertical);
   const crownBlend = smoothstep(0.55, 1, vertical);
-  const accentBlend = smoothstep(0.35, 0.95, vertical) * smoothstep(0.2, 1, horizontal);
+  const accentBlend =
+    smoothstep(0.35, 0.95, vertical) * smoothstep(0.2, 1, horizontal);
 
   output.copy(WALL_BASE_COLOR);
   output.lerp(WALL_MID_COLOR, midBlend);
@@ -150,6 +147,10 @@ export function applyLightmapUv2(geometry: BufferGeometry): void {
   }
   const source = uv as BufferAttribute;
   const cloneArray = new Float32Array(source.array as ArrayLike<number>);
-  const clone = new BufferAttribute(cloneArray, source.itemSize, source.normalized);
+  const clone = new BufferAttribute(
+    cloneArray,
+    source.itemSize,
+    source.normalized
+  );
   geometry.setAttribute('uv2', clone);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,10 @@ import {
   shouldDisablePerformanceFailover,
 } from './immersiveUrl';
 import {
+  applyLightmapUv2,
+  createInteriorLightmapTextures,
+} from './lighting/bakedLightmaps';
+import {
   createLightingDebugController,
   type LightingMode,
 } from './lighting/debugControls';
@@ -822,6 +826,7 @@ function initializeImmersiveScene(
   }
   floorShape.closePath();
   const floorGeometry = new ShapeGeometry(floorShape);
+  applyLightmapUv2(floorGeometry);
   floorGeometry.rotateX(-Math.PI / 2);
   const floor = new Mesh(floorGeometry, floorMaterial);
   floor.position.y = 0;
@@ -829,6 +834,19 @@ function initializeImmersiveScene(
 
   const wallMaterial = new MeshStandardMaterial({ color: 0x3d4a63 });
   const fenceMaterial = new MeshStandardMaterial({ color: 0x4a5668 });
+
+  const interiorLightmaps = createInteriorLightmapTextures({
+    floorSize: {
+      width: floorBounds.maxX - floorBounds.minX,
+      depth: floorBounds.maxZ - floorBounds.minZ,
+    },
+  });
+  floorMaterial.lightMap = interiorLightmaps.floor;
+  floorMaterial.lightMapIntensity = 0.78;
+  wallMaterial.lightMap = interiorLightmaps.wall;
+  wallMaterial.lightMapIntensity = 0.68;
+  fenceMaterial.lightMap = interiorLightmaps.wall;
+  fenceMaterial.lightMapIntensity = 0.56;
   const wallGroup = new Group();
   const combinedWallSegments = getCombinedWallSegments(FLOOR_PLAN);
 
@@ -882,6 +900,7 @@ function initializeImmersiveScene(
     }
 
     const geometry = new BoxGeometry(width, segmentHeight, depth);
+    applyLightmapUv2(geometry);
     const wall = new Mesh(geometry, material);
     wall.position.set(baseX + offsetX, segmentHeight / 2, baseZ + offsetZ);
     wallGroup.add(wall);

--- a/src/tests/bakedLightmaps.test.ts
+++ b/src/tests/bakedLightmaps.test.ts
@@ -1,4 +1,9 @@
-import { BoxGeometry, BufferGeometry, DataTexture, SRGBColorSpace } from 'three';
+import {
+  BoxGeometry,
+  BufferGeometry,
+  DataTexture,
+  SRGBColorSpace,
+} from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -7,7 +12,11 @@ import {
 } from '../lighting/bakedLightmaps';
 
 function sampleLuminance(texture: DataTexture, u: number, v: number): number {
-  const image = texture.image as { data: Uint8Array; width: number; height: number };
+  const image = texture.image as {
+    data: Uint8Array;
+    width: number;
+    height: number;
+  };
   const width = image.width;
   const height = image.height;
   const x = Math.min(width - 1, Math.max(0, Math.round(u * (width - 1))));

--- a/src/tests/bakedLightmaps.test.ts
+++ b/src/tests/bakedLightmaps.test.ts
@@ -1,0 +1,77 @@
+import { BoxGeometry, BufferGeometry, DataTexture, SRGBColorSpace } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyLightmapUv2,
+  createInteriorLightmapTextures,
+} from '../lighting/bakedLightmaps';
+
+function sampleLuminance(texture: DataTexture, u: number, v: number): number {
+  const image = texture.image as { data: Uint8Array; width: number; height: number };
+  const width = image.width;
+  const height = image.height;
+  const x = Math.min(width - 1, Math.max(0, Math.round(u * (width - 1))));
+  const y = Math.min(height - 1, Math.max(0, Math.round(v * (height - 1))));
+  const index = (y * width + x) * 4;
+  const data = image.data as Uint8Array;
+  return data[index] + data[index + 1] + data[index + 2];
+}
+
+describe('createInteriorLightmapTextures', () => {
+  it('creates warm gradients that favour the greenhouse walkway', () => {
+    const textures = createInteriorLightmapTextures({
+      floorSize: { width: 32, depth: 48 },
+    });
+
+    const center = sampleLuminance(textures.floor, 0.5, 0.5);
+    const walkway = sampleLuminance(textures.floor, 0.88, 0.92);
+    const corner = sampleLuminance(textures.floor, 0.08, 0.08);
+
+    expect(textures.floor.colorSpace).toBe(SRGBColorSpace);
+    expect(walkway).toBeGreaterThan(center);
+    expect(center).toBeGreaterThan(corner);
+  });
+
+  it('produces wall lightmaps that brighten toward the ceiling', () => {
+    const textures = createInteriorLightmapTextures({
+      floorSize: { width: 24, depth: 30 },
+    });
+
+    const bottom = sampleLuminance(textures.wall, 0.5, 0.08);
+    const top = sampleLuminance(textures.wall, 0.5, 0.92);
+
+    expect(textures.wall.colorSpace).toBe(SRGBColorSpace);
+    expect(top).toBeGreaterThan(bottom);
+  });
+});
+
+describe('applyLightmapUv2', () => {
+  it('duplicates uv attributes into uv2 when missing', () => {
+    const geometry = new BoxGeometry(1, 1, 1);
+    const originalUv = geometry.getAttribute('uv');
+    expect(originalUv).toBeDefined();
+    expect(geometry.getAttribute('uv2')).toBeUndefined();
+
+    applyLightmapUv2(geometry);
+
+    const uv2 = geometry.getAttribute('uv2');
+    expect(uv2).toBeDefined();
+    expect(uv2?.itemSize).toBe(originalUv?.itemSize);
+    expect(uv2).not.toBe(originalUv);
+  });
+
+  it('leaves existing uv2 attributes untouched', () => {
+    const geometry = new BoxGeometry(1, 1, 1);
+    applyLightmapUv2(geometry);
+    const uv2Before = geometry.getAttribute('uv2');
+    applyLightmapUv2(geometry);
+    const uv2After = geometry.getAttribute('uv2');
+    expect(uv2After).toBe(uv2Before);
+  });
+
+  it('does nothing when geometry lacks uv data', () => {
+    const geometry = new BufferGeometry();
+    expect(() => applyLightmapUv2(geometry)).not.toThrow();
+    expect(geometry.getAttribute('uv2')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable gradient lightmap textures and uv2 helper
- apply baked lightmaps to floor and walls with documentation updates

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e40afb7bb4832fb2d0d00947a6743f