### PR TITLE
Add screen reader announcements for POI discoveries

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -179,6 +179,8 @@ Focus: make the experience inclusive and globally friendly.
    - Keyboard-only navigation parity, remappable bindings, and full controller support.
 
 - Screen reader announcements for mode switches, POI discovery, and HUD focus changes.
+  - ✅ Screen reader announcements now trigger when players discover a new POI, narrating the
+    exhibit name and summary via a live region.
   - ✅ Mode transitions now fire polite announcements describing immersive and text fallback states.
 - Interaction timeline tuned for cognitive load (limited simultaneous prompts).
 


### PR DESCRIPTION
## Summary
- add a hidden aria-live region to the POI tooltip overlay so first-time selections announce the exhibit
- expose formatter/politeness options and cover them with new unit tests
- document the Phase 4 accessibility milestone for POI discovery callouts

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e40afb7bb4832fb2d0d00947a6743f