### PR TITLE
Add persistent keyboard remapping support to the HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ lightweight.
 ## Controls
 
 - **Movement** – Use `WASD` or arrow keys to roll the sphere.
+- **Key remapping** – Use `portfolio.input.keyBindings.setBinding('interact', ['e'])`
+  in the browser console to try alternate bindings. HUD prompts update instantly and
+  the mapping persists locally.
 - **Touch** – Drag the on-screen joysticks (left: movement, right: camera pan) on touch devices.
 - **Lighting debug** – Press `Shift` + `L` to toggle bloom and LED strips for comparison captures.
 - **Mode toggle** – Press `T` or select the "Text mode" overlay button to jump into the
@@ -121,8 +124,8 @@ lightweight.
   to soften bloom, reduce motion cues, and boost overlay contrast. The
   Photosensitive-safe preset now also smooths greenhouse grow lights, walkway lanterns, and
   holographic beacons so emissive pulses settle into a steady glow for flicker-sensitive players.
-- **Help** – Press `H` or `?`, or tap the HUD Help button to open a modal with controls,
-  accessibility tips, and failover guidance.
+- **Help** – Use the help key (default `H` or `?`), or tap the HUD Help button to
+  open a modal with controls, accessibility tips, and failover guidance.
 - **Failover** – Append `?mode=text` to the URL to load the lightweight text view.
   Automatic detection now covers missing WebGL support and sustained frame rates below 30 FPS;
   `?mode=immersive&disablePerformanceFailover=1` forces the full scene even on

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -182,6 +182,8 @@ Focus: make the experience inclusive and globally friendly.
 
 1. **Input Accessibility**
    - Keyboard-only navigation parity, remappable bindings, and full controller support.
+     - ✅ Keyboard bindings now persist across sessions and update the HUD/help overlays
+       via the new remapping service.
 
 - Screen reader announcements for mode switches, POI discovery, and HUD focus changes.
   - ✅ Screen reader announcements now trigger when players discover a new POI, narrating the

--- a/src/controls/keyBindings.test.ts
+++ b/src/controls/keyBindings.test.ts
@@ -90,7 +90,9 @@ describe('formatKeyLabel', () => {
 describe('createKeyBindingAwareSource', () => {
   it('delegates to the provided controls', () => {
     const isPressed = vi.fn().mockReturnValue(true);
-    const controls = { isPressed } as unknown as import('./KeyboardControls').KeyboardControls;
+    const controls = {
+      isPressed,
+    } as unknown as import('./KeyboardControls').KeyboardControls;
     const source = createKeyBindingAwareSource(controls);
 
     expect(source.isPressed('f')).toBe(true);

--- a/src/controls/keyBindings.test.ts
+++ b/src/controls/keyBindings.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_KEY_BINDINGS,
+  KeyBindings,
+  createKeyBindingAwareSource,
+  formatKeyLabel,
+} from './keyBindings';
+
+describe('KeyBindings', () => {
+  it('normalises keys and deduplicates entries', () => {
+    const bindings = new KeyBindings();
+    bindings.setBindings('interact', ['F', ' f ', 'Space', 'spacebar', 'F']);
+
+    expect(bindings.getBindings('interact')).toEqual(['f', ' ']);
+  });
+
+  it('reports action state via a key press source', () => {
+    const bindings = new KeyBindings();
+    const pressed = new Set(['w']);
+    const source = { isPressed: (key: string) => pressed.has(key) };
+
+    expect(bindings.isActionActive('moveForward', source)).toBe(true);
+    expect(bindings.isActionActive('moveBackward', source)).toBe(false);
+
+    bindings.setBindings('moveForward', ['i']);
+    expect(bindings.isActionActive('moveForward', source)).toBe(false);
+
+    pressed.add('i');
+    expect(bindings.isActionActive('moveForward', source)).toBe(true);
+  });
+
+  it('emits changes to listeners and supports resets', () => {
+    const bindings = new KeyBindings();
+    const listener = vi.fn();
+    const unsubscribe = bindings.subscribe(listener);
+
+    bindings.setBindings('help', ['?']);
+    expect(listener).toHaveBeenLastCalledWith('help', ['?']);
+
+    listener.mockClear();
+    bindings.reset('help');
+    expect(listener).toHaveBeenLastCalledWith(
+      'help',
+      DEFAULT_KEY_BINDINGS.help.slice()
+    );
+
+    listener.mockClear();
+    bindings.resetAll();
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+    bindings.setBindings('help', ['h']);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('applies partial updates via update()', () => {
+    const bindings = new KeyBindings({ interact: ['e'] });
+    bindings.update({ moveLeft: ['j'], moveRight: ['l'] });
+
+    expect(bindings.getBindings('interact')).toEqual(['e']);
+    expect(bindings.getBindings('moveLeft')).toEqual(['j']);
+    expect(bindings.getBindings('moveRight')).toEqual(['l']);
+  });
+
+  it('ignores updates for unknown actions', () => {
+    const bindings = new KeyBindings();
+    const listener = vi.fn();
+    bindings.subscribe(listener);
+
+    bindings.update({ unknown: ['x'] } as unknown as Record<string, string[]>);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(bindings.getBindings('interact')).toEqual(
+      DEFAULT_KEY_BINDINGS.interact.slice()
+    );
+  });
+});
+
+describe('formatKeyLabel', () => {
+  it('formats single characters and known keys for display', () => {
+    expect(formatKeyLabel('f')).toBe('F');
+    expect(formatKeyLabel('ArrowUp')).toBe('Arrow Up');
+    expect(formatKeyLabel(' ')).toBe('Space');
+    expect(formatKeyLabel('Shift')).toBe('Shift');
+    expect(formatKeyLabel(undefined)).toBe('');
+  });
+});
+
+describe('createKeyBindingAwareSource', () => {
+  it('delegates to the provided controls', () => {
+    const isPressed = vi.fn().mockReturnValue(true);
+    const controls = { isPressed } as unknown as import('./KeyboardControls').KeyboardControls;
+    const source = createKeyBindingAwareSource(controls);
+
+    expect(source.isPressed('f')).toBe(true);
+    expect(isPressed).toHaveBeenCalledWith('f');
+  });
+});

--- a/src/controls/keyBindings.ts
+++ b/src/controls/keyBindings.ts
@@ -1,0 +1,188 @@
+import type { KeyboardControls } from './KeyboardControls';
+
+export type KeyBindingAction =
+  | 'moveForward'
+  | 'moveBackward'
+  | 'moveLeft'
+  | 'moveRight'
+  | 'interact'
+  | 'help';
+
+export type KeyBindingConfig = Partial<Record<KeyBindingAction, readonly string[]>>;
+
+export interface KeyPressSource {
+  isPressed(key: string): boolean;
+}
+
+export type KeyBindingListener = (
+  action: KeyBindingAction,
+  bindings: readonly string[]
+) => void;
+
+export const DEFAULT_KEY_BINDINGS: Record<KeyBindingAction, readonly string[]> = {
+  moveForward: ['w', 'ArrowUp'],
+  moveBackward: ['s', 'ArrowDown'],
+  moveLeft: ['a', 'ArrowLeft'],
+  moveRight: ['d', 'ArrowRight'],
+  interact: ['f'],
+  help: ['h', '?'],
+};
+
+type ActionEntries = [KeyBindingAction, readonly string[]];
+
+function normalizeKey(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const spacePattern = /^(space|spacebar)$/i;
+  if (spacePattern.test(trimmed)) {
+    return ' ';
+  }
+
+  if (trimmed.length === 1) {
+    return trimmed.toLowerCase();
+  }
+
+  return trimmed;
+}
+
+function normalizeKeys(keys: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const key of keys) {
+    if (typeof key !== 'string') {
+      continue;
+    }
+    const value = normalizeKey(key);
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    normalized.push(value);
+  }
+  return normalized;
+}
+
+export class KeyBindings {
+  private readonly bindings = new Map<KeyBindingAction, string[]>();
+
+  private readonly listeners = new Set<KeyBindingListener>();
+
+  constructor(initial?: KeyBindingConfig) {
+    for (const action of Object.keys(
+      DEFAULT_KEY_BINDINGS
+    ) as KeyBindingAction[]) {
+      if (!this.bindings.has(action)) {
+        this.bindings.set(action, []);
+      }
+    }
+    this.applyConfig(Object.entries(DEFAULT_KEY_BINDINGS) as ActionEntries[]);
+    if (initial) {
+      this.update(initial);
+    }
+  }
+
+  getBindings(action: KeyBindingAction): readonly string[] {
+    return this.bindings.get(action)?.slice() ?? [];
+  }
+
+  getPrimaryBinding(action: KeyBindingAction): string | null {
+    const bindings = this.bindings.get(action);
+    return bindings && bindings.length > 0 ? bindings[0] : null;
+  }
+
+  isActionActive(action: KeyBindingAction, source: KeyPressSource): boolean {
+    const bindings = this.bindings.get(action);
+    if (!bindings || bindings.length === 0) {
+      return false;
+    }
+    return bindings.some((binding) => source.isPressed(binding));
+  }
+
+  update(config: KeyBindingConfig): void {
+    const entries = Object.entries(config) as ActionEntries[];
+    this.applyConfig(entries);
+  }
+
+  setBindings(action: KeyBindingAction, keys: readonly string[]): void {
+    this.applyConfig([[action, keys]]);
+  }
+
+  reset(action: KeyBindingAction): void {
+    this.applyConfig([[action, DEFAULT_KEY_BINDINGS[action]]]);
+  }
+
+  resetAll(): void {
+    this.applyConfig(Object.entries(DEFAULT_KEY_BINDINGS) as ActionEntries[]);
+  }
+
+  subscribe(listener: KeyBindingListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private applyConfig(entries: ActionEntries[]): void {
+    for (const [action, keys] of entries) {
+      if (!action || !this.bindings.has(action)) {
+        continue;
+      }
+      const normalized = normalizeKeys(keys);
+      const previous = this.bindings.get(action) ?? [];
+      if (this.areBindingsEqual(previous, normalized)) {
+        continue;
+      }
+      this.bindings.set(action, normalized);
+      this.emit(action);
+    }
+  }
+
+  private areBindingsEqual(a: readonly string[], b: readonly string[]): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i += 1) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private emit(action: KeyBindingAction): void {
+    const bindings = this.bindings.get(action) ?? [];
+    for (const listener of this.listeners) {
+      listener(action, bindings);
+    }
+  }
+}
+
+export function formatKeyLabel(key: string | null | undefined): string {
+  if (!key) {
+    return '';
+  }
+  if (key === ' ') {
+    return 'Space';
+  }
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+  if (key.startsWith('Arrow')) {
+    const direction = key.slice('Arrow'.length);
+    return `Arrow ${direction}`;
+  }
+  return key;
+}
+
+export function createKeyBindingAwareSource(
+  controls: KeyboardControls
+): KeyPressSource {
+  return {
+    isPressed(key: string) {
+      return controls.isPressed(key);
+    },
+  };
+}

--- a/src/controls/keyBindings.ts
+++ b/src/controls/keyBindings.ts
@@ -8,7 +8,9 @@ export type KeyBindingAction =
   | 'interact'
   | 'help';
 
-export type KeyBindingConfig = Partial<Record<KeyBindingAction, readonly string[]>>;
+export type KeyBindingConfig = Partial<
+  Record<KeyBindingAction, readonly string[]>
+>;
 
 export interface KeyPressSource {
   isPressed(key: string): boolean;
@@ -19,14 +21,15 @@ export type KeyBindingListener = (
   bindings: readonly string[]
 ) => void;
 
-export const DEFAULT_KEY_BINDINGS: Record<KeyBindingAction, readonly string[]> = {
-  moveForward: ['w', 'ArrowUp'],
-  moveBackward: ['s', 'ArrowDown'],
-  moveLeft: ['a', 'ArrowLeft'],
-  moveRight: ['d', 'ArrowRight'],
-  interact: ['f'],
-  help: ['h', '?'],
-};
+export const DEFAULT_KEY_BINDINGS: Record<KeyBindingAction, readonly string[]> =
+  {
+    moveForward: ['w', 'ArrowUp'],
+    moveBackward: ['s', 'ArrowDown'],
+    moveLeft: ['a', 'ArrowLeft'],
+    moveRight: ['d', 'ArrowRight'],
+    interact: ['f'],
+    help: ['h', '?'],
+  };
 
 type ActionEntries = [KeyBindingAction, readonly string[]];
 
@@ -140,7 +143,10 @@ export class KeyBindings {
     }
   }
 
-  private areBindingsEqual(a: readonly string[], b: readonly string[]): boolean {
+  private areBindingsEqual(
+    a: readonly string[],
+    b: readonly string[]
+  ): boolean {
     if (a.length !== b.length) {
       return false;
     }

--- a/src/hud/helpModal.ts
+++ b/src/hud/helpModal.ts
@@ -27,7 +27,8 @@ export interface HelpModalHandle {
 
 const DEFAULT_HEADING = 'Quick Reference';
 const DEFAULT_DESCRIPTION =
-  'Review controls, accessibility tips, and failover shortcuts. Press H or ? to toggle this panel.';
+  'Review controls, accessibility tips, and failover shortcuts. ' +
+  'Use the help shortcut (default H or ?) to toggle this panel.';
 
 const DEFAULT_SECTIONS: HelpModalSection[] = [
   {
@@ -53,7 +54,8 @@ const DEFAULT_SECTIONS: HelpModalSection[] = [
     items: [
       {
         label: 'Approach glowing POIs',
-        description: 'Press F, tap, or click to open the exhibit overlay.',
+        description:
+          'Press your interact key (default F), tap, or click to open the exhibit overlay.',
       },
       {
         label: 'Q / E or ← / →',

--- a/src/hud/movementLegend.ts
+++ b/src/hud/movementLegend.ts
@@ -12,6 +12,7 @@ export interface MovementLegendHandle {
   getActiveMethod(): InputMethod;
   setActiveMethod(method: InputMethod): void;
   setInteractPrompt(description: string | null): void;
+  setKeyboardInteractLabel(label: string): void;
   dispose(): void;
 }
 
@@ -173,6 +174,8 @@ export function createMovementLegend(
     ...interactLabels,
   } as Record<InputMethod, string>;
 
+  const defaultKeyboardLabel = labels.keyboard;
+
   if (context.interactDescription) {
     context.interactDescription.textContent =
       context.defaultInteractDescription || defaultInteractDescription;
@@ -202,6 +205,15 @@ export function createMovementLegend(
 
   const ensureInteractLabel = () => {
     updateInteractLabel(context, labels, activeMethod);
+  };
+
+  const setKeyboardInteractLabel = (label: string) => {
+    const normalized = label && label.trim() ? label.trim() : defaultKeyboardLabel;
+    if (labels.keyboard === normalized) {
+      return;
+    }
+    labels.keyboard = normalized;
+    ensureInteractLabel();
   };
 
   const setActiveMethod = (method: InputMethod) => {
@@ -287,6 +299,7 @@ export function createMovementLegend(
     },
     setActiveMethod,
     setInteractPrompt,
+    setKeyboardInteractLabel,
     dispose() {
       while (listeners.length > 0) {
         const remove = listeners.pop();
@@ -303,6 +316,7 @@ export function createMovementLegend(
         context.interactDescription.textContent =
           context.defaultInteractDescription;
       }
+      labels.keyboard = defaultKeyboardLabel;
       ensureInteractLabel();
     },
   };

--- a/src/hud/movementLegend.ts
+++ b/src/hud/movementLegend.ts
@@ -208,7 +208,8 @@ export function createMovementLegend(
   };
 
   const setKeyboardInteractLabel = (label: string) => {
-    const normalized = label && label.trim() ? label.trim() : defaultKeyboardLabel;
+    const normalized =
+      label && label.trim() ? label.trim() : defaultKeyboardLabel;
     if (labels.keyboard === normalized) {
       return;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1234,7 +1234,8 @@ function initializeImmersiveScene(
       return;
     }
     const label =
-      formatKeyLabel(keyBindings.getPrimaryBinding('help')) || helpLabelFallback;
+      formatKeyLabel(keyBindings.getPrimaryBinding('help')) ||
+      helpLabelFallback;
     helpButton.textContent = `Open help · Press ${label}`;
   };
   updateHelpButtonLabel();
@@ -1243,8 +1244,7 @@ function initializeImmersiveScene(
   keyBindingUnsubscribes.push(
     keyBindings.subscribe((action, bindings) => {
       if (action === 'interact' && movementLegend) {
-        const label =
-          formatKeyLabel(bindings[0]) || interactLabelFallback;
+        const label = formatKeyLabel(bindings[0]) || interactLabelFallback;
         movementLegend.setKeyboardInteractLabel(label);
       }
       if (action === 'help') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,13 @@ import {
   createGraphicsQualityControl,
   type GraphicsQualityControlHandle,
 } from './controls/graphicsQualityControl';
+import {
+  KeyBindings,
+  createKeyBindingAwareSource,
+  formatKeyLabel,
+  type KeyBindingAction,
+  type KeyBindingConfig,
+} from './controls/keyBindings';
 import { KeyboardControls } from './controls/KeyboardControls';
 import { VirtualJoystick } from './controls/VirtualJoystick';
 import {
@@ -150,6 +157,23 @@ import { createImmersiveGradientTexture } from './theme/immersiveGradient';
 const WALL_HEIGHT = 6;
 const FENCE_HEIGHT = 2.4;
 const FENCE_THICKNESS = 0.28;
+type KeyBindingSnapshot = Record<KeyBindingAction, string[]>;
+
+declare global {
+  interface Window {
+    portfolio?: {
+      input?: {
+        keyBindings?: {
+          getBindings(): KeyBindingSnapshot;
+          setBinding(action: KeyBindingAction, keys: readonly string[]): void;
+          resetBinding(action: KeyBindingAction): void;
+          resetAll(): void;
+        };
+      };
+    };
+  }
+}
+
 const PLAYER_RADIUS = 0.75;
 const PLAYER_SPEED = 6;
 const MOVEMENT_SMOOTHING = 8;
@@ -1071,6 +1095,88 @@ function initializeImmersiveScene(
   scene.add(player);
 
   const controlOverlay = document.getElementById('control-overlay');
+  const keyBindings = new KeyBindings();
+  const KEY_BINDINGS_STORAGE_KEY = 'danielsmith.io:keyBindings';
+  const bindingActions: KeyBindingAction[] = [
+    'moveForward',
+    'moveBackward',
+    'moveLeft',
+    'moveRight',
+    'interact',
+    'help',
+  ];
+  const bindingActionSet = new Set<KeyBindingAction>(bindingActions);
+
+  const getBindingSnapshot = (): KeyBindingSnapshot => {
+    const snapshot = {} as KeyBindingSnapshot;
+    for (const action of bindingActions) {
+      snapshot[action] = [...keyBindings.getBindings(action)];
+    }
+    return snapshot;
+  };
+
+  const loadStoredKeyBindings = () => {
+    try {
+      const stored = window.localStorage?.getItem(KEY_BINDINGS_STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+      const parsed = JSON.parse(stored) as KeyBindingConfig;
+      if (parsed && typeof parsed === 'object') {
+        keyBindings.update(parsed);
+      }
+    } catch (error) {
+      console.warn('Failed to load key bindings from storage', error);
+    }
+  };
+
+  const saveKeyBindings = () => {
+    try {
+      window.localStorage?.setItem(
+        KEY_BINDINGS_STORAGE_KEY,
+        JSON.stringify(getBindingSnapshot())
+      );
+    } catch (error) {
+      console.warn('Failed to save key bindings', error);
+    }
+  };
+
+  loadStoredKeyBindings();
+
+  const ensureKeyBindingApi = () => {
+    const portfolioWindow = window as Window;
+    if (!portfolioWindow.portfolio) {
+      portfolioWindow.portfolio = {};
+    }
+    if (!portfolioWindow.portfolio.input) {
+      portfolioWindow.portfolio.input = {};
+    }
+    portfolioWindow.portfolio.input.keyBindings = {
+      getBindings() {
+        return getBindingSnapshot();
+      },
+      setBinding(action, keys) {
+        if (!bindingActionSet.has(action)) {
+          throw new Error(`Unknown key binding action: ${action}`);
+        }
+        keyBindings.setBindings(action, Array.from(keys));
+        saveKeyBindings();
+      },
+      resetBinding(action) {
+        if (!bindingActionSet.has(action)) {
+          throw new Error(`Unknown key binding action: ${action}`);
+        }
+        keyBindings.reset(action);
+        saveKeyBindings();
+      },
+      resetAll() {
+        keyBindings.resetAll();
+        saveKeyBindings();
+      },
+    };
+  };
+
+  ensureKeyBindingApi();
   const interactControl = controlOverlay?.querySelector<HTMLElement>(
     '[data-control="interact"]'
   );
@@ -1080,8 +1186,16 @@ function initializeImmersiveScene(
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
+  const interactLabelFallback = 'F';
   const movementLegend: MovementLegendHandle | null = controlOverlay
-    ? createMovementLegend({ container: controlOverlay })
+    ? createMovementLegend({
+        container: controlOverlay,
+        interactLabels: {
+          keyboard:
+            formatKeyLabel(keyBindings.getPrimaryBinding('interact')) ||
+            interactLabelFallback,
+        },
+      })
     : null;
   const helpModal = createHelpModal({ container: document.body });
   let helpButtonClickHandler: (() => void) | null = null;
@@ -1092,6 +1206,7 @@ function initializeImmersiveScene(
   let interactablePoi: PoiInstance | null = null;
 
   const controls = new KeyboardControls();
+  const keyPressSource = createKeyBindingAwareSource(controls);
   const joystick = new VirtualJoystick(renderer.domElement);
   const clock = new Clock();
   const targetVelocity = new Vector3();
@@ -1113,6 +1228,31 @@ function initializeImmersiveScene(
 
   let activeFloorId: FloorId = 'ground';
   let helpKeyWasPressed = false;
+  const helpLabelFallback = 'H';
+  const updateHelpButtonLabel = () => {
+    if (!helpButton) {
+      return;
+    }
+    const label =
+      formatKeyLabel(keyBindings.getPrimaryBinding('help')) || helpLabelFallback;
+    helpButton.textContent = `Open help · Press ${label}`;
+  };
+  updateHelpButtonLabel();
+
+  const keyBindingUnsubscribes: Array<() => void> = [];
+  keyBindingUnsubscribes.push(
+    keyBindings.subscribe((action, bindings) => {
+      if (action === 'interact' && movementLegend) {
+        const label =
+          formatKeyLabel(bindings[0]) || interactLabelFallback;
+        movementLegend.setKeyboardInteractLabel(label);
+      }
+      if (action === 'help') {
+        updateHelpButtonLabel();
+      }
+      saveKeyBindings();
+    })
+  );
 
   const isWithinStairWidth = (x: number, margin = 0) =>
     Math.abs(x - stairCenterX) <= stairHalfWidth + margin;
@@ -1715,11 +1855,11 @@ function initializeImmersiveScene(
 
   function updateMovement(delta: number) {
     const rightInput =
-      Number(controls.isPressed('d') || controls.isPressed('ArrowRight')) -
-      Number(controls.isPressed('a') || controls.isPressed('ArrowLeft'));
+      Number(keyBindings.isActionActive('moveRight', keyPressSource)) -
+      Number(keyBindings.isActionActive('moveLeft', keyPressSource));
     const forwardInput =
-      Number(controls.isPressed('w') || controls.isPressed('ArrowUp')) -
-      Number(controls.isPressed('s') || controls.isPressed('ArrowDown'));
+      Number(keyBindings.isActionActive('moveForward', keyPressSource)) -
+      Number(keyBindings.isActionActive('moveBackward', keyPressSource));
 
     const joystickMovement = joystick.getMovement();
     const combinedRight = rightInput + joystickMovement.x;
@@ -2033,7 +2173,7 @@ function initializeImmersiveScene(
   }
 
   function handleInteractionInput() {
-    const pressed = controls.isPressed('f');
+    const pressed = keyBindings.isActionActive('interact', keyPressSource);
     if (pressed && !interactKeyWasPressed && interactablePoi) {
       poiInteractionManager.selectPoiById(interactablePoi.definition.id);
     }
@@ -2041,7 +2181,7 @@ function initializeImmersiveScene(
   }
 
   function handleHelpInput() {
-    const pressed = controls.isPressed('h') || controls.isPressed('?');
+    const pressed = keyBindings.isActionActive('help', keyPressSource);
     if (immersiveDisposed) {
       helpKeyWasPressed = pressed;
       return;
@@ -2126,8 +2266,19 @@ function initializeImmersiveScene(
       window.removeEventListener('beforeunload', beforeUnloadHandler);
       beforeUnloadHandler = null;
     }
+    while (keyBindingUnsubscribes.length > 0) {
+      const unsubscribe = keyBindingUnsubscribes.pop();
+      unsubscribe?.();
+    }
+    if (window.portfolio?.input?.keyBindings) {
+      delete window.portfolio.input.keyBindings;
+    }
+    if (helpButton) {
+      helpButton.textContent = `Open help · Press ${helpLabelFallback}`;
+    }
     movementLegend?.dispose();
     helpModal.dispose();
+    controls.dispose();
   }
 
   let hasPresentedFirstFrame = false;

--- a/src/tests/movementLegend.test.ts
+++ b/src/tests/movementLegend.test.ts
@@ -125,6 +125,30 @@ describe('createMovementLegend', () => {
     legend.dispose();
   });
 
+  it('updates the keyboard interact label when bindings change', () => {
+    const container = createOverlayContainer();
+    const legend = createMovementLegend({
+      container,
+      initialMethod: 'keyboard',
+    });
+
+    const interactLabel = container.querySelector(
+      '[data-role="interact-label"]'
+    );
+
+    legend.setInteractPrompt('Interact with Exhibit');
+    legend.setKeyboardInteractLabel('E');
+    expect(interactLabel?.textContent).toBe('E');
+
+    legend.setActiveMethod('touch');
+    legend.setKeyboardInteractLabel('Space');
+    legend.setActiveMethod('keyboard');
+    expect(interactLabel?.textContent).toBe('Space');
+
+    legend.dispose();
+    expect(interactLabel?.textContent).toBe('F');
+  });
+
   it('reacts to runtime input signals from window events', () => {
     const container = createOverlayContainer();
     const legend = createMovementLegend({ container, windowTarget: window });


### PR DESCRIPTION
## Summary
- add a key binding registry with local storage persistence, a console API, and unit coverage
- refresh HUD movement legend and help modal so remapped keys stay in sync
- document the remapping workflow in the roadmap and README

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e55c80ee44832fb1b6a2ac8c96abea