### PR TITLE
Add HUD focus live region announcements

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,6 +187,8 @@ Focus: make the experience inclusive and globally friendly.
   - ✅ Screen reader announcements now trigger when players discover a new POI, narrating the
     exhibit name and summary via a live region.
   - ✅ Mode transitions now fire polite announcements describing immersive and text fallback states.
+  - ✅ HUD controls now announce focus changes through a dedicated live region tied to overlay and
+    control focus events.
 - Interaction timeline tuned for cognitive load (limited simultaneous prompts).
 
 2. **Visual & Audio Accessibility**

--- a/index.html
+++ b/index.html
@@ -364,7 +364,12 @@
           </span>
         </li>
       </ul>
-      <button class="overlay__help-button" type="button" data-control="help">
+      <button
+        class="overlay__help-button"
+        type="button"
+        data-control="help"
+        data-hud-announce="Open help overlay. Press H to review controls and accessibility tips."
+      >
         Open help · Press H
       </button>
     </div>

--- a/src/accessibility/hudFocusAnnouncer.ts
+++ b/src/accessibility/hudFocusAnnouncer.ts
@@ -1,0 +1,191 @@
+export type HudFocusAnnouncePoliteness = 'polite' | 'assertive';
+
+export interface HudFocusAnnouncerOptions {
+  documentTarget?: Document;
+  container?: HTMLElement | null;
+  politeness?: HudFocusAnnouncePoliteness;
+  datasetKey?: string;
+}
+
+export interface HudFocusAnnouncerHandle {
+  readonly element: HTMLElement;
+  announce(message: string): void;
+  dispose(): void;
+}
+
+const DEFAULT_DATASET_KEY = 'hudAnnounce';
+const DEFAULT_POLITENESS: HudFocusAnnouncePoliteness = 'polite';
+
+type DatasetRecord = Record<string, string | undefined>;
+
+function applyVisuallyHiddenStyles(element: HTMLElement): void {
+  element.style.position = 'absolute';
+  element.style.width = '1px';
+  element.style.height = '1px';
+  element.style.padding = '0';
+  element.style.margin = '-1px';
+  element.style.overflow = 'hidden';
+  element.style.clip = 'rect(0, 0, 0, 0)';
+  element.style.whiteSpace = 'nowrap';
+  element.style.border = '0';
+}
+
+function findDatasetElement(
+  element: Element | null,
+  datasetKey: string
+): HTMLElement | null {
+  let current: Element | null = element;
+  while (current) {
+    if (current instanceof HTMLElement) {
+      const datasetValue = (current.dataset as DatasetRecord)[datasetKey];
+      if (typeof datasetValue === 'string' && datasetValue.trim()) {
+        return current;
+      }
+    }
+    current = current.parentElement;
+  }
+  return element instanceof HTMLElement ? element : null;
+}
+
+function appendClause(base: string, addition: string): string {
+  const trimmedBase = base.trim();
+  const trimmedAddition = addition.trim();
+  if (!trimmedAddition) {
+    return trimmedBase;
+  }
+  if (!trimmedBase) {
+    return trimmedAddition;
+  }
+  const needsSeparator = /[.!?]\s*$/.test(trimmedBase) ? ' ' : '. ';
+  return `${trimmedBase}${needsSeparator}${trimmedAddition}`;
+}
+
+function collectDescription(
+  element: HTMLElement,
+  documentTarget: Document
+): string {
+  const describedBy = element.getAttribute('aria-describedby');
+  if (!describedBy) {
+    return '';
+  }
+  const ids = describedBy
+    .split(/\s+/)
+    .map((id) => id.trim())
+    .filter(Boolean);
+  if (ids.length === 0) {
+    return '';
+  }
+  const parts: string[] = [];
+  for (const id of ids) {
+    const describedElement = documentTarget.getElementById(id);
+    const text = describedElement?.textContent?.trim();
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.join(' ');
+}
+
+function resolveMessage(
+  focusTarget: HTMLElement,
+  datasetKey: string,
+  documentTarget: Document
+): string | null {
+  const datasetElement = findDatasetElement(focusTarget, datasetKey);
+  const datasetValue = datasetElement
+    ? ((datasetElement.dataset as DatasetRecord)[datasetKey] ?? '').trim()
+    : '';
+
+  let message = datasetValue;
+  if (!message) {
+    const ariaLabel = focusTarget.getAttribute('aria-label')?.trim();
+    if (ariaLabel) {
+      message = ariaLabel;
+    }
+  }
+  if (!message) {
+    const title = focusTarget.getAttribute('title')?.trim();
+    if (title) {
+      message = title;
+    }
+  }
+  if (!message) {
+    const textContent = focusTarget.textContent?.replace(/\s+/g, ' ').trim();
+    if (textContent) {
+      message = textContent;
+    }
+  }
+
+  const valueText =
+    focusTarget.getAttribute('aria-valuetext')?.trim() ??
+    focusTarget.getAttribute('aria-valuenow')?.trim() ??
+    '';
+  if (valueText) {
+    message = appendClause(message, `Current value ${valueText}.`);
+  }
+
+  const description = collectDescription(focusTarget, documentTarget);
+  if (description) {
+    message = appendClause(message, description);
+  }
+
+  return message.trim() ? message.trim() : null;
+}
+
+export function createHudFocusAnnouncer({
+  documentTarget = document,
+  container = documentTarget.body ?? documentTarget.documentElement,
+  politeness = DEFAULT_POLITENESS,
+  datasetKey = DEFAULT_DATASET_KEY,
+}: HudFocusAnnouncerOptions = {}): HudFocusAnnouncerHandle {
+  const host = container ?? documentTarget.body ?? documentTarget.documentElement;
+  if (!host) {
+    throw new Error('Unable to determine host element for HUD focus announcer.');
+  }
+
+  const liveRegion = documentTarget.createElement('div');
+  liveRegion.dataset.hudFocusAnnouncer = 'true';
+  liveRegion.setAttribute('role', 'status');
+  liveRegion.setAttribute('aria-live', politeness);
+  liveRegion.setAttribute('aria-atomic', 'true');
+  applyVisuallyHiddenStyles(liveRegion);
+  host.appendChild(liveRegion);
+
+  let lastMessage = '';
+
+  const announce = (message: string) => {
+    const trimmed = message.trim();
+    if (!trimmed || trimmed === lastMessage) {
+      return;
+    }
+    liveRegion.textContent = '';
+    liveRegion.textContent = trimmed;
+    lastMessage = trimmed;
+  };
+
+  const handleFocusIn = (event: FocusEvent) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    const message = resolveMessage(target, datasetKey, documentTarget);
+    if (message) {
+      announce(message);
+    }
+  };
+
+  documentTarget.addEventListener('focusin', handleFocusIn);
+
+  return {
+    element: liveRegion,
+    announce,
+    dispose() {
+      documentTarget.removeEventListener('focusin', handleFocusIn);
+      if (liveRegion.parentElement) {
+        liveRegion.remove();
+      }
+      liveRegion.textContent = '';
+      lastMessage = '';
+    },
+  };
+}

--- a/src/controls/audioHudControl.ts
+++ b/src/controls/audioHudControl.ts
@@ -74,6 +74,7 @@ export function createAudioHudControl({
   slider.max = '1';
   slider.step = volumeStep.toString();
   slider.setAttribute('aria-label', 'Ambient audio volume');
+  slider.dataset.hudAnnounce = 'Ambient audio volume slider.';
 
   const valueText = document.createElement('span');
   valueText.className = 'audio-volume__value';
@@ -89,6 +90,10 @@ export function createAudioHudControl({
 
   let pending = false;
 
+  const normalizeKey = (value: string) =>
+    value.length === 1 ? value.toUpperCase() : value;
+  const normalizedToggleKey = normalizeKey(toggleKey);
+
   const updateToggle = () => {
     const enabled = getEnabled();
     const nextLabel = enabled ? toggleLabelOn : toggleLabelOff;
@@ -97,6 +102,10 @@ export function createAudioHudControl({
     toggleButton.setAttribute('aria-pressed', enabled ? 'true' : 'false');
     toggleButton.disabled = pending;
     wrapper.dataset.pending = pending ? 'true' : 'false';
+    const toggleMessage = enabled
+      ? `Ambient audio on. Press ${normalizedToggleKey} to toggle.`
+      : `Ambient audio off. Press ${normalizedToggleKey} to toggle.`;
+    toggleButton.dataset.hudAnnounce = toggleMessage;
   };
 
   const updateVolume = () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,10 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
 
 import {
+  createHudFocusAnnouncer,
+  type HudFocusAnnouncerHandle,
+} from './accessibility/hudFocusAnnouncer';
+import {
   ACCESSIBILITY_PRESETS,
   createAccessibilityPresetManager,
   type AccessibilityPresetManager,
@@ -383,6 +387,7 @@ function initializeImmersiveScene(
   let accessibilityControlHandle: AccessibilityPresetControlHandle | null =
     null;
   let unsubscribeAccessibility: (() => void) | null = null;
+  let hudFocusAnnouncer: HudFocusAnnouncerHandle | null = null;
   let getAmbientAudioVolume = () =>
     ambientAudioController?.getMasterVolume() ?? 1;
   let setAmbientAudioVolume = (volume: number) => {
@@ -1084,6 +1089,10 @@ function initializeImmersiveScene(
     ? createMovementLegend({ container: controlOverlay })
     : null;
   const helpModal = createHelpModal({ container: document.body });
+  hudFocusAnnouncer = createHudFocusAnnouncer({
+    documentTarget: document,
+    container: document.body,
+  });
   let helpButtonClickHandler: (() => void) | null = null;
   if (helpButton) {
     helpButtonClickHandler = () => helpModal.open();
@@ -2128,6 +2137,10 @@ function initializeImmersiveScene(
     }
     movementLegend?.dispose();
     helpModal.dispose();
+    if (hudFocusAnnouncer) {
+      hudFocusAnnouncer.dispose();
+      hudFocusAnnouncer = null;
+    }
   }
 
   let hasPresentedFirstFrame = false;

--- a/src/tests/audioHudControl.test.ts
+++ b/src/tests/audioHudControl.test.ts
@@ -37,6 +37,10 @@ describe('createAudioHudControl', () => {
     expect(button).toBeTruthy();
     expect(slider).toBeTruthy();
     expect(valueText?.textContent).toBe('60%');
+    expect(button?.dataset.hudAnnounce).toBe(
+      'Ambient audio off. Press M to toggle.'
+    );
+    expect(slider?.dataset.hudAnnounce).toBe('Ambient audio volume slider.');
 
     button?.dispatchEvent(new Event('click'));
     expect(toggleCallCount).toBe(1);
@@ -52,6 +56,9 @@ describe('createAudioHudControl', () => {
 
     expect(button?.disabled).toBe(false);
     expect(button?.dataset.state).toBe('on');
+    expect(button?.dataset.hudAnnounce).toBe(
+      'Ambient audio on. Press M to toggle.'
+    );
 
     slider!.value = '0.82';
     slider?.dispatchEvent(new Event('input'));
@@ -63,6 +70,9 @@ describe('createAudioHudControl', () => {
     handle.refresh();
     expect(button?.dataset.state).toBe('off');
     expect(valueText?.textContent).toBe('25%');
+    expect(button?.dataset.hudAnnounce).toBe(
+      'Ambient audio off. Press M to toggle.'
+    );
 
     slider!.value = '1.6';
     slider?.dispatchEvent(new Event('input'));
@@ -109,9 +119,17 @@ describe('createAudioHudControl', () => {
       'Failed to toggle ambient audio:',
       expect.any(Error)
     );
+    const button = container.querySelector<HTMLButtonElement>('button.audio-toggle');
+    expect(button?.dataset.hudAnnounce).toBe(
+      'Ambient audio off. Press M to toggle.'
+    );
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));
     expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    expect(button?.dataset.hudAnnounce).toBe(
+      'Ambient audio on. Press M to toggle.'
+    );
 
     handle.dispose();
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));

--- a/src/tests/hudFocusAnnouncer.test.ts
+++ b/src/tests/hudFocusAnnouncer.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createHudFocusAnnouncer } from '../accessibility/hudFocusAnnouncer';
+
+describe('createHudFocusAnnouncer', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  const dispatchFocusIn = (element: HTMLElement) => {
+    const event = new FocusEvent('focusin', { bubbles: true });
+    element.dispatchEvent(event);
+  };
+
+  it('announces dataset-provided messages on focus', () => {
+    const announcer = createHudFocusAnnouncer({ documentTarget: document });
+    const button = document.createElement('button');
+    button.dataset.hudAnnounce = 'Open help overlay.';
+    document.body.appendChild(button);
+
+    dispatchFocusIn(button);
+
+    expect(announcer.element.textContent).toBe('Open help overlay.');
+
+    announcer.dispose();
+  });
+
+  it('appends value text to aria label announcements', () => {
+    const announcer = createHudFocusAnnouncer({ documentTarget: document });
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.setAttribute('aria-label', 'Ambient audio volume');
+    slider.setAttribute('aria-valuetext', '60%');
+    document.body.appendChild(slider);
+
+    dispatchFocusIn(slider);
+
+    expect(announcer.element.textContent).toBe(
+      'Ambient audio volume. Current value 60%.'
+    );
+
+    announcer.dispose();
+  });
+
+  it('incorporates aria-describedby content in announcements', () => {
+    const announcer = createHudFocusAnnouncer({ documentTarget: document });
+    const description = document.createElement('div');
+    description.id = 'hud-desc';
+    description.textContent = 'Press enter to activate.';
+    document.body.appendChild(description);
+
+    const button = document.createElement('button');
+    button.textContent = 'Manual mode';
+    button.setAttribute('aria-describedby', 'hud-desc');
+    document.body.appendChild(button);
+
+    dispatchFocusIn(button);
+
+    expect(announcer.element.textContent).toBe(
+      'Manual mode. Press enter to activate.'
+    );
+
+    announcer.dispose();
+  });
+
+  it('prefers ancestor dataset messages when targets lack overrides', () => {
+    const announcer = createHudFocusAnnouncer({ documentTarget: document });
+    const wrapper = document.createElement('div');
+    wrapper.dataset.hudAnnounce = 'Audio controls.';
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.setAttribute('aria-valuetext', '70%');
+    wrapper.appendChild(slider);
+    document.body.appendChild(wrapper);
+
+    dispatchFocusIn(slider);
+
+    expect(announcer.element.textContent).toBe(
+      'Audio controls. Current value 70%.'
+    );
+
+    announcer.dispose();
+  });
+
+  it('stops announcing once disposed', () => {
+    const announcer = createHudFocusAnnouncer({ documentTarget: document });
+    const liveRegion = announcer.element;
+    const button = document.createElement('button');
+    button.dataset.hudAnnounce = 'Should not announce after dispose.';
+    document.body.appendChild(button);
+
+    announcer.dispose();
+
+    dispatchFocusIn(button);
+
+    expect(liveRegion.textContent).toBe('');
+  });
+});

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -31,11 +31,18 @@ describe('createManualModeToggle', () => {
       getIsFallbackActive: () => fallbackActive,
     });
 
+    expect(handle.element.dataset.hudAnnounce).toBe(
+      'Switch to the text-only portfolio. Press T to activate.'
+    );
+
     handle.element.click();
 
     expect(onToggle).toHaveBeenCalledTimes(1);
     expect(handle.element.disabled).toBe(true);
     expect(handle.element.dataset.state).toBe('pending');
+    expect(handle.element.dataset.hudAnnounce).toBe(
+      'Switch to the text-only portfolio. Switching to text mode…'
+    );
 
     cleanupHandle(handle);
     container.remove();
@@ -49,6 +56,10 @@ describe('createManualModeToggle', () => {
       onToggle,
       getIsFallbackActive: () => true,
     });
+
+    expect(handle.element.dataset.hudAnnounce).toBe(
+      'Switch to the text-only portfolio. Text mode already active.'
+    );
 
     handle.element.click();
 
@@ -75,6 +86,9 @@ describe('createManualModeToggle', () => {
 
     expect(handle.element.disabled).toBe(false);
     expect(handle.element.dataset.state).toBe('idle');
+    expect(handle.element.dataset.hudAnnounce).toBe(
+      'Switch to the text-only portfolio. Press T to activate.'
+    );
 
     cleanupHandle(handle);
     container.remove();


### PR DESCRIPTION
## Summary
- add HUD focus announcer for overlay controls with dataset hints
- update hud controls, docs, and tests for the new screen reader cues

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e55c80ee44832fb1b6a2ac8c96abea