### PR TITLE
Add high contrast accessibility preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ lightweight.
 - **Lighting debug** – Press `Shift` + `L` to toggle bloom and LED strips for comparison captures.
 - **Mode toggle** – Press `T` or select the "Text mode" overlay button to jump into the
   lightweight portfolio view at any time.
-- **Accessibility presets** – Pick Standard, Calm, or Photosensitive-safe modes from the HUD
-  to soften bloom, reduce motion cues, and boost overlay contrast. The
+- **Accessibility presets** – Pick Standard, Calm, High contrast, or Photosensitive-safe modes
+  from the HUD to soften bloom, boost readability, reduce motion cues, and tune emissive
+  lighting. The
   Photosensitive-safe preset now also smooths greenhouse grow lights, walkway lanterns, and
   holographic beacons so emissive pulses settle into a steady glow for flicker-sensitive players.
 - **Help** – Press `H` or `?`, or tap the HUD Help button to open a modal with controls,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -191,6 +191,8 @@ Focus: make the experience inclusive and globally friendly.
 
 2. **Visual & Audio Accessibility**
    - High-contrast material set, colorblind-safe lighting palettes, and adjustable motion blur.
+   - ✅ High contrast accessibility preset now boosts HUD readability without disabling cinematic
+     lighting cues.
 
 - Subtitle/captions system for ambient audio callouts and POI narration.
   - ✅ Audio subtitles overlay now surfaces ambient beds and POI narration with cooldown-aware captions.

--- a/src/accessibility/presetManager.ts
+++ b/src/accessibility/presetManager.ts
@@ -6,7 +6,11 @@ import type {
   LedMaterialLike,
 } from '../graphics/qualityManager';
 
-export type AccessibilityPresetId = 'standard' | 'calm' | 'photosensitive';
+export type AccessibilityPresetId =
+  | 'standard'
+  | 'calm'
+  | 'high-contrast'
+  | 'photosensitive';
 
 type MotionSetting = 'default' | 'reduced';
 type ContrastSetting = 'standard' | 'high';
@@ -84,6 +88,29 @@ export const ACCESSIBILITY_PRESETS: readonly AccessibilityPresetDefinition[] = [
     },
     audio: {
       volumeScale: 0.8,
+    },
+  },
+  {
+    id: 'high-contrast',
+    label: 'High contrast',
+    description: 'Boosts HUD readability while keeping motion cues active.',
+    motion: 'default',
+    contrast: 'high',
+    animation: {
+      pulseScale: 1,
+      flickerScale: 1,
+    },
+    bloom: {
+      strengthScale: 1.1,
+      radiusScale: 1,
+      thresholdOffset: -0.02,
+    },
+    led: {
+      emissiveScale: 1.15,
+      lightScale: 1.1,
+    },
+    audio: {
+      volumeScale: 1,
     },
   },
   {

--- a/src/tests/accessibilityPresetControl.test.ts
+++ b/src/tests/accessibilityPresetControl.test.ts
@@ -15,6 +15,11 @@ const OPTIONS = [
     description: 'Reduce motion cues.',
   },
   {
+    id: 'high-contrast' as AccessibilityPresetId,
+    label: 'High contrast',
+    description: 'Increase HUD contrast without disabling effects.',
+  },
+  {
     id: 'photosensitive' as AccessibilityPresetId,
     label: 'Photosensitive safe',
     description: 'Disable bloom and boost contrast.',
@@ -49,7 +54,7 @@ describe('createAccessibilityPresetControl', () => {
     const wrapper = container.querySelector<HTMLElement>(
       '.accessibility-presets'
     );
-    expect(radios).toHaveLength(3);
+    expect(radios).toHaveLength(4);
     expect(wrapper?.dataset.pending).toBe('false');
 
     radios[1].checked = true;
@@ -57,8 +62,8 @@ describe('createAccessibilityPresetControl', () => {
     expect(wrapper?.dataset.pending).toBe('true');
 
     // While pending, subsequent selections are ignored.
-    radios[2].checked = true;
-    radios[2].dispatchEvent(new Event('change'));
+    radios[3].checked = true;
+    radios[3].dispatchEvent(new Event('change'));
     expect(wrapper?.dataset.pending).toBe('true');
 
     resolveSelection?.();
@@ -70,7 +75,7 @@ describe('createAccessibilityPresetControl', () => {
 
     active = 'photosensitive';
     handle.refresh();
-    expect(radios[2].checked).toBe(true);
+    expect(radios[3].checked).toBe(true);
 
     handle.dispose();
     expect(container.querySelector('.accessibility-presets')).toBeNull();

--- a/src/tests/accessibilityPresetManager.test.ts
+++ b/src/tests/accessibilityPresetManager.test.ts
@@ -225,7 +225,9 @@ describe('createAccessibilityPresetManager', () => {
     );
     expect(document.documentElement.dataset.accessibilityContrast).toBe('high');
     expect(document.documentElement.dataset.accessibilityPulseScale).toBe('1');
-    expect(document.documentElement.dataset.accessibilityFlickerScale).toBe('1');
+    expect(document.documentElement.dataset.accessibilityFlickerScale).toBe(
+      '1'
+    );
     expect(bloomPass.enabled).toBe(true);
     expect(bloomPass.strength).toBeCloseTo(1.32, 5);
     expect(bloomPass.radius).toBeCloseTo(0.95, 5);

--- a/src/tests/accessibilityPresetManager.test.ts
+++ b/src/tests/accessibilityPresetManager.test.ts
@@ -177,6 +177,67 @@ describe('createAccessibilityPresetManager', () => {
     restoreDataset();
   });
 
+  it('enables the high-contrast preset while keeping motion assists active', () => {
+    const bloomPass: BloomPassLike = {
+      enabled: true,
+      strength: 1.2,
+      radius: 0.95,
+      threshold: 0.65,
+    };
+    const ledMaterial: LedMaterialLike = { emissiveIntensity: 0.8 };
+    const ledLight: LedLightLike = { intensity: 0.9 };
+
+    const baseline = () => {
+      bloomPass.enabled = true;
+      bloomPass.strength = 1.2;
+      bloomPass.radius = 0.95;
+      bloomPass.threshold = 0.65;
+      ledMaterial.emissiveIntensity = 0.8;
+      ledLight.intensity = 0.9;
+    };
+
+    const graphicsManager = createStubGraphicsQualityManager(baseline);
+
+    let masterVolume = 0.7;
+    const ambientAudio = {
+      getMasterVolume: () => masterVolume,
+      setMasterVolume: (value: number) => {
+        masterVolume = value;
+      },
+    };
+
+    const manager = createAccessibilityPresetManager({
+      documentElement: document.documentElement,
+      graphicsQualityManager: graphicsManager,
+      bloomPass,
+      ledStripMaterials: [ledMaterial],
+      ledFillLights: [ledLight],
+      ambientAudioController: ambientAudio,
+    });
+
+    manager.setPreset('high-contrast');
+
+    expect(document.documentElement.dataset.accessibilityPreset).toBe(
+      'high-contrast'
+    );
+    expect(document.documentElement.dataset.accessibilityMotion).toBe(
+      'default'
+    );
+    expect(document.documentElement.dataset.accessibilityContrast).toBe('high');
+    expect(document.documentElement.dataset.accessibilityPulseScale).toBe('1');
+    expect(document.documentElement.dataset.accessibilityFlickerScale).toBe('1');
+    expect(bloomPass.enabled).toBe(true);
+    expect(bloomPass.strength).toBeCloseTo(1.32, 5);
+    expect(bloomPass.radius).toBeCloseTo(0.95, 5);
+    expect(bloomPass.threshold).toBeCloseTo(0.63, 5);
+    expect(ledMaterial.emissiveIntensity).toBeCloseTo(0.92, 5);
+    expect(ledLight.intensity).toBeCloseTo(0.99, 5);
+    expect(masterVolume).toBeCloseTo(0.7, 5);
+
+    manager.dispose();
+    restoreDataset();
+  });
+
   it('handles storage failures and re-applies on quality changes', () => {
     const bloomPass: BloomPassLike = {
       enabled: true,


### PR DESCRIPTION
## What
- add high contrast preset with bloom and led boosts
- document availability in README and roadmap

## Why
- advance phase 4 visual and audio accessibility goals

## How to test
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e55c80ee44832fb1b6a2ac8c96abea