### PR TITLE
Fix immersive override precedence for duplicate mode params

### DIFF
--- a/src/immersiveUrl.ts
+++ b/src/immersiveUrl.ts
@@ -44,9 +44,14 @@ export const createImmersiveModeUrl = (location?: LocationLike) => {
 const toSearchParams = (value: string | URLSearchParams): URLSearchParams =>
   typeof value === 'string' ? new URLSearchParams(value) : value;
 
+const hasImmersiveModeValue = (params: URLSearchParams) =>
+  params
+    .getAll(IMMERSIVE_MODE_PARAM)
+    .some((value) => value === IMMERSIVE_MODE_VALUE);
+
 export const hasImmersiveOverride = (value: string | URLSearchParams) => {
   const params = toSearchParams(value);
-  return params.get(IMMERSIVE_MODE_PARAM) === IMMERSIVE_MODE_VALUE;
+  return hasImmersiveModeValue(params);
 };
 
 export const hasPerformanceFailoverBypass = (
@@ -63,5 +68,5 @@ export const shouldDisablePerformanceFailover = (
   value: string | URLSearchParams
 ) => {
   const params = toSearchParams(value);
-  return hasImmersiveOverride(params) || hasPerformanceFailoverBypass(params);
+  return hasImmersiveModeValue(params) || hasPerformanceFailoverBypass(params);
 };

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -110,6 +110,14 @@ describe('evaluateFailoverDecision', () => {
     expect(decision).toEqual({ shouldUseFallback: false });
   });
 
+  it('prioritizes immersive override when both immersive and text modes are present', () => {
+    const decision = evaluateFailoverDecision({
+      search: '?mode=text&mode=immersive',
+      createCanvas: canvasFactory,
+    });
+    expect(decision).toEqual({ shouldUseFallback: false });
+  });
+
   it('routes automated clients to text mode when mode is not forced', () => {
     const decision = evaluateFailoverDecision({
       createCanvas: canvasFactory,

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -64,4 +64,10 @@ describe('immersive flag helpers', () => {
     ).toBe(true);
     expect(shouldDisablePerformanceFailover('feature=preview')).toBe(false);
   });
+
+  it('treats any immersive mode value as an override even when duplicates exist', () => {
+    const params = new URLSearchParams('mode=text&mode=immersive');
+    expect(hasImmersiveOverride(params)).toBe(true);
+    expect(shouldDisablePerformanceFailover(params)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- honor immersive overrides when mixed mode params hit failover
- update helper to treat any immersive mode value as an override
- cover mixed mode query strings in failover and URL helper tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e88d4fe324832f9b3cfee9ed3d6b8f