### PR TITLE
Fix avatar facing alignment with camera-relative movement

### DIFF
--- a/src/movement/cameraRelativeMovement.ts
+++ b/src/movement/cameraRelativeMovement.ts
@@ -1,12 +1,10 @@
 import type { Camera } from 'three';
 import { Vector3 } from 'three';
 
-const cameraForward = new Vector3();
-const cameraRight = new Vector3();
-const WORLD_UP = new Vector3(0, 1, 0);
-const DEFAULT_FORWARD = new Vector3(0, 0, -1);
-const DEFAULT_RIGHT = new Vector3(1, 0, 0);
-const EPSILON = 1e-6;
+import { copyCameraPlanarBasis } from './facing';
+
+const CAMERA_FORWARD = new Vector3();
+const CAMERA_RIGHT = new Vector3();
 
 export function getCameraRelativeMovementVector(
   camera: Camera,
@@ -14,26 +12,12 @@ export function getCameraRelativeMovementVector(
   inputForward: number,
   target: Vector3
 ): Vector3 {
-  camera.getWorldDirection(cameraForward);
-  cameraForward.y = 0;
-
-  if (cameraForward.lengthSq() <= EPSILON) {
-    cameraForward.copy(DEFAULT_FORWARD);
-  } else {
-    cameraForward.normalize();
-  }
-
-  cameraRight.crossVectors(cameraForward, WORLD_UP);
-  if (cameraRight.lengthSq() <= EPSILON) {
-    cameraRight.copy(DEFAULT_RIGHT);
-  } else {
-    cameraRight.normalize();
-  }
+  copyCameraPlanarBasis(camera, CAMERA_FORWARD, CAMERA_RIGHT);
 
   target
-    .copy(cameraForward)
+    .copy(CAMERA_FORWARD)
     .multiplyScalar(inputForward)
-    .addScaledVector(cameraRight, inputRight);
+    .addScaledVector(CAMERA_RIGHT, inputRight);
   target.y = 0;
 
   return target;

--- a/src/tests/movement/facing.test.ts
+++ b/src/tests/movement/facing.test.ts
@@ -6,6 +6,7 @@ import {
   computeYawFromVector,
   angularDifference,
   dampYawTowards,
+  getCameraRelativeDirection,
   normalizeRadians,
 } from '../../movement/facing';
 
@@ -92,5 +93,16 @@ describe('facing helpers', () => {
     expect(
       computeCameraRelativeYaw(camera, forward.clone().negate())
     ).toBeCloseTo(Math.PI, 6);
+
+    const relativeForward = getCameraRelativeDirection(camera, 0);
+    expect(relativeForward.angleTo(forward)).toBeLessThan(1e-6);
+
+    const relativeRight = getCameraRelativeDirection(camera, Math.PI / 2);
+    expect(relativeRight.angleTo(right)).toBeLessThan(1e-6);
+
+    const relativeDiagonal = getCameraRelativeDirection(camera, Math.PI / 4);
+    expect(
+      relativeDiagonal.angleTo(forward.clone().add(right).normalize())
+    ).toBeLessThan(1e-6);
   });
 });


### PR DESCRIPTION
## Summary
- share a camera-planar basis across movement helpers and expose a camera-relative direction helper
- drive the mannequin rotation from the camera-relative yaw to ensure forward input faces away from the camera
- extend the facing unit tests to cover the new direction helper

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e895c928cc832f8f768362c689d629