### PR TITLE
Fix teleport when approaching upper stairs from the west

### DIFF
--- a/src/movement/stairs.ts
+++ b/src/movement/stairs.ts
@@ -75,6 +75,11 @@ export const predictStairFloorId = (
       return 'upper';
     }
 
+    const baseExitHalfWidth = Math.max(
+      geometry.halfWidth - behavior.transitionMargin * 0.5,
+      geometry.halfWidth * 0.5
+    );
+
     const withinLanding = isWithinLanding(
       geometry,
       x,
@@ -89,7 +94,12 @@ export const predictStairFloorId = (
       rampHeight < geometry.totalRise - behavior.stepRise * 0.1;
     const nearBottomBuffer = geometry.bottomZ - behavior.transitionMargin * 0.5;
 
-    if ((hasLeftLanding && z <= nearBottomBuffer) || z >= geometry.bottomZ) {
+    if (hasLeftLanding && z <= nearBottomBuffer) {
+      return 'ground';
+    }
+
+    const withinBaseExit = Math.abs(x - geometry.centerX) <= baseExitHalfWidth;
+    if (withinBaseExit && z >= geometry.bottomZ) {
       return 'ground';
     }
 

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -54,6 +54,22 @@ describe('stair floor transitions', () => {
     expect(result).toBe('upper');
   });
 
+  it('does not leave the upper floor when west of the stair base', () => {
+    const currentFloor: FloorId = 'upper';
+    const westLandingX =
+      STAIR_GEOMETRY.centerX - STAIR_GEOMETRY.halfWidth + toWorldUnits(0.15);
+    const southOfLandingZ = STAIR_GEOMETRY.bottomZ + toWorldUnits(0.35);
+    const result = predictStairFloorId(
+      STAIR_GEOMETRY,
+      STAIR_BEHAVIOR,
+      westLandingX,
+      southOfLandingZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+  });
+
   it('switches to the ground floor after leaving the landing for the ramp', () => {
     const currentFloor: FloorId = 'upper';
     const firstStepZ = STAIR_GEOMETRY.topZ + toWorldUnits(0.3);


### PR DESCRIPTION
## Summary
- tighten the stair exit check so only the actual base transitions floors
- cover the west-of-stairs walkway case with a regression test

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68e8a7bf6628832faaf88d4e0c04a9cf