### PR TITLE
Simplify POI markers: footprint-sized rings; remove pedestal base

### DIFF
--- a/src/poi/markers.ts
+++ b/src/poi/markers.ts
@@ -130,9 +130,7 @@ function createPedestalPoiInstance(
   });
   const orb = new Mesh(orbGeometry, orbMaterial);
   const orbBaseHeight =
-    (baseHeight +
-      orbRadius +
-      scalePoiValue(POI_ORB_VERTICAL_OFFSET)) *
+    (baseHeight + orbRadius + scalePoiValue(POI_ORB_VERTICAL_OFFSET)) *
     POI_ORB_HEIGHT_MULTIPLIER;
   orb.position.y = orbBaseHeight;
   group.add(orb);


### PR DESCRIPTION
This refines the POI ground markers for clarity and spacing.

What
- Remove pedestal base disc from pedestal POIs
- Keep outer additive halo + visited ring
- Size rings from the underlying model footprint to avoid overlaps
- Adjust hit area height and orb baseline after base removal

Why
- The previous base discs felt heavy and could overlap; footprint-sized rings keep spacing predictable.

How to test
1. npm run dev
2. Open `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`
3. Verify each POI shows a single ring that corresponds to its stand/model size
4. Confirm hover focus animates halo; visited state expands green ring

Refs: n/a