### PR TITLE
Add manual dispatch to favicon workflow

### DIFF
--- a/.github/workflows/05-favicon.yml
+++ b/.github/workflows/05-favicon.yml
@@ -1,0 +1,40 @@
+name: Favicon
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - scripts/generate-favicon.ts
+      - package.json
+      - package-lock.json
+      - public/favicon.ico
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate favicon
+        run: npm run favicon
+
+      - name: Commit updated favicon
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'ci: update favicon'
+          file_pattern: public/favicon.ico


### PR DESCRIPTION
## Summary
- allow manually triggering the favicon regeneration workflow
- reuse existing script and auto-commit behavior when invoked

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68ecaa1eba44832fa554923116930368