### PR TITLE
Prioritize ambient captions with per-bed priorities

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -221,6 +221,8 @@ Focus: make the experience inclusive and globally friendly.
 - Subtitle/captions system for ambient audio callouts and POI narration.
   - ✅ Audio subtitles overlay now surfaces ambient beds and POI narration with cooldown-aware captions.
   - ✅ Photo sensitivity safe mode now smooths pulses and mutes emissive lighting to avoid flicker spikes.
+  - ✨ Ambient caption bridge now honors per-bed priorities so critical narration can override
+    gentle ambient beds while still surfacing once the higher-priority clip ends.
 
 3. **Localization Pipeline**
    - ✅ Extract UI + POI copy into i18n catalog with English baseline.

--- a/src/systems/audio/ambientAudio.ts
+++ b/src/systems/audio/ambientAudio.ts
@@ -20,6 +20,8 @@ export interface AmbientAudioBedDefinition {
   caption?: string;
   /** Minimum rendered volume before the caption is considered audible. Defaults to 0.18. */
   captionThreshold?: number;
+  /** Priority forwarded to the subtitles overlay when this bed becomes audible. */
+  captionPriority?: number;
 }
 
 export interface AmbientAudioBedSnapshot {

--- a/src/systems/audio/ambientCaptionBridge.ts
+++ b/src/systems/audio/ambientCaptionBridge.ts
@@ -21,6 +21,18 @@ const DEFAULT_COOLDOWN_MS = 8000;
 
 const DEFAULT_THRESHOLD = 0.18;
 
+const DEFAULT_CAPTION_PRIORITY = 1;
+
+const resolveCaptionPriority = (value: number | undefined): number => {
+  if (typeof value !== 'number') {
+    return DEFAULT_CAPTION_PRIORITY;
+  }
+  if (!Number.isFinite(value)) {
+    return DEFAULT_CAPTION_PRIORITY;
+  }
+  return value;
+};
+
 export class AmbientCaptionBridge {
   private readonly controller: AmbientAudioController;
 
@@ -94,7 +106,7 @@ export class AmbientCaptionBridge {
           id: messageId,
           text: caption,
           source: 'ambient',
-          priority: 1,
+          priority: resolveCaptionPriority(definition.captionPriority),
         });
 
         const updatedMessage = this.subtitles.getCurrent();

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -40,6 +40,7 @@ describe('AmbientAudioController', () => {
       falloffCurve: overrides.falloffCurve,
       caption: overrides.caption,
       captionThreshold: overrides.captionThreshold,
+      captionPriority: overrides.captionPriority,
       source,
     };
     return { bed, source };
@@ -156,7 +157,11 @@ describe('AmbientAudioController', () => {
   });
 
   it('exposes immutable snapshots with current and target volume metadata', () => {
-    const { bed } = createBed({ caption: 'Interior hum', baseVolume: 0.42 });
+    const { bed } = createBed({
+      caption: 'Interior hum',
+      baseVolume: 0.42,
+      captionPriority: 3,
+    });
     const controller = new AmbientAudioController([bed], { smoothing: 0 });
     controller.enable();
     controller.update({ x: 0, z: 0 }, 0.016);
@@ -166,6 +171,7 @@ describe('AmbientAudioController', () => {
     expect(snapshot.id).toBe(bed.id);
     expect(snapshot.definition).not.toBe(bed);
     expect(snapshot.definition.caption).toBe('Interior hum');
+    expect(snapshot.definition.captionPriority).toBe(3);
     expect(snapshot.currentVolume).toBeCloseTo(0.42, 5);
     expect(snapshot.targetVolume).toBeCloseTo(0.42, 5);
     snapshot.definition.center.x = 999;

--- a/src/tests/ambientCaptionBridge.test.ts
+++ b/src/tests/ambientCaptionBridge.test.ts
@@ -89,6 +89,7 @@ describe('AmbientCaptionBridge', () => {
     controller.setVolume(0.3);
     bridge.update();
     expect(show).toHaveBeenCalledTimes(1);
+    expect(show.mock.calls[0][0].priority).toBe(1);
 
     bridge.update();
     expect(show).toHaveBeenCalledTimes(1);
@@ -233,5 +234,102 @@ describe('AmbientCaptionBridge priority handling', () => {
     bridge.update();
     expect(show).toHaveBeenCalledTimes(3);
     expect(current?.id).toBe('ambient-hum');
+  });
+
+  it('uses bed-defined caption priority values when available', () => {
+    const controller = new FakeController({
+      id: 'hum',
+      center: { x: 0, z: 0 },
+      innerRadius: 1,
+      outerRadius: 4,
+      baseVolume: 0.4,
+      source: fakeSource,
+      caption: 'Soft hum fills the room.',
+      captionPriority: 5,
+    });
+
+    let current: AudioSubtitleMessage | null = {
+      id: 'poi-1',
+      source: 'poi',
+      text: 'POI narration',
+      priority: 2,
+    };
+
+    const show = vi.fn((message: AudioSubtitleMessage) => {
+      const nextPriority = message.priority ?? 0;
+      const currentPriority = current?.priority ?? 0;
+      if (
+        current &&
+        current.id !== message.id &&
+        nextPriority < currentPriority
+      ) {
+        return;
+      }
+      current = { ...message, priority: nextPriority };
+    });
+
+    const subtitles = {
+      show,
+      clear: vi.fn(() => {
+        current = null;
+      }),
+      dispose: vi.fn(),
+      getCurrent: vi.fn(() => current),
+    };
+
+    const bridge = new AmbientCaptionBridge({
+      controller,
+      subtitles,
+      cooldownMs: 0,
+      now: () => 0,
+    });
+
+    controller.setVolume(0.3);
+    bridge.update();
+
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(current?.id).toBe('ambient-hum');
+    expect(current?.priority).toBe(5);
+  });
+
+  it('falls back to default priority when captionPriority is invalid', () => {
+    const controller = new FakeController({
+      id: 'hum',
+      center: { x: 0, z: 0 },
+      innerRadius: 1,
+      outerRadius: 4,
+      baseVolume: 0.4,
+      source: fakeSource,
+      caption: 'Soft hum fills the room.',
+      // Deliberately pass NaN to verify sanitisation.
+      captionPriority: Number.NaN,
+    });
+
+    let current: AudioSubtitleMessage | null = null;
+    const show = vi.fn((message: AudioSubtitleMessage) => {
+      current = { ...message };
+    });
+
+    const subtitles = {
+      show,
+      clear: vi.fn(() => {
+        current = null;
+      }),
+      dispose: vi.fn(),
+      getCurrent: vi.fn(() => current),
+    };
+
+    const bridge = new AmbientCaptionBridge({
+      controller,
+      subtitles,
+      cooldownMs: 0,
+      now: () => 0,
+    });
+
+    controller.setVolume(0.3);
+    bridge.update();
+
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(show.mock.calls[0][0].priority).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- allow ambient beds to define caption priorities for subtitles
- sanitise invalid priorities and cover the path with new tests
- document the accessibility upgrade in the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke


------
https://chatgpt.com/codex/tasks/task_e_68f1c664738c832f884b7408b5f3b728