### PR TITLE
Improve automated fallback heuristics for WebDriver clients

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,6 +172,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - ✅ HUD toggle + `T` keybinding now trigger the text portfolio without a page reload.
    - ✅ Automated user-agent heuristics now route crawlers and headless previews to the text
      portfolio while honoring manual immersive overrides.
+   - ✅ WebDriver automation heuristics now check `navigator.webdriver` and steer scripted
+     browsers to the text experience unless the immersive override is set.
    - ✅ Manual mode toggle now exposes an active state with aria-pressed so assistive tech
      announces when the text tour is engaged.
 3. **Progression & State**

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -122,11 +122,32 @@ describe('evaluateFailoverDecision', () => {
     });
   });
 
+  it('routes webdriver-flagged clients to text mode when mode is not forced', () => {
+    const decision = evaluateFailoverDecision({
+      createCanvas: canvasFactory,
+      getUserAgent: () => undefined,
+      getIsWebDriver: () => true,
+    });
+    expect(decision).toEqual({
+      shouldUseFallback: true,
+      reason: 'automated-client',
+    });
+  });
+
   it('does not force fallback for automated client when immersive override is present', () => {
     const decision = evaluateFailoverDecision({
       search: IMMERSIVE_SEARCH,
       createCanvas: canvasFactory,
       getUserAgent: () => 'HeadlessChrome/118.0.0.0',
+    });
+    expect(decision).toEqual({ shouldUseFallback: false });
+  });
+
+  it('does not force fallback when webdriver flag is set but immersive override is present', () => {
+    const decision = evaluateFailoverDecision({
+      search: IMMERSIVE_SEARCH,
+      createCanvas: canvasFactory,
+      getIsWebDriver: () => true,
     });
     expect(decision).toEqual({ shouldUseFallback: false });
   });


### PR DESCRIPTION
## Summary
- add navigator.webdriver detection to automated fallback routing
- document the webdriver heuristic in the roadmap
- cover webdriver scenarios with failover unit tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f1c664738c832f884b7408b5f3b728