### PR TITLE
Add Jobbot telemetry shards around automation terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ Keep pipelines deterministic by regenerating assets immediately after touching g
   live region announcements so discovery prompts never rapid-fire when players browse exhibits.
   Metadata is authored in TypeScript so future automations
   can extend exhibits by updating data alone, and the studio desk now hosts a Jobbot holographic
-  terminal that pulses in sync with the new automation POI. The living room's gitshelves array now
+  terminal with orbiting telemetry shards that pulse in sync with the automation POI. The living
+  room's gitshelves array now
   extrudes nightly commit streaks into illuminated shelving mosaics with sync signage overhead.
 - **Localization** – UI chrome and POI copy are centralized in `src/assets/i18n/index.ts`, letting future
   locales load structured strings while keeping Vitest coverage in

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,17 +116,19 @@ Focus: anchor each highlighted project with an interactive artifact.
      triggers a rich text popup with repo summary, star count, and CTA buttons.
    - Spinning flywheel centerpiece representing the `flywheel` repo; interaction spins faster,
      reveals tech stack, and links to docs.
-   - Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
-   - ✨ Wall-mounted Futuroptimist media wall now frames the living room POI with a branded
-     screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
-   - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
-     orbitals, and an activation-driven tech stack + docs callout panel.
-   - ✨ Studio Jobbot terminal desk projects live automation telemetry via a holographic console
-     and anchors the Jobbot3000 POI with reactive lighting and diagnostics beacons.
-   - ✨ Axel quest navigator tabletop now charts backlog quests with holographic rings and
-     momentum beacons around the studio tracker POI.
-   - ✨ Gitshelves living room array now tessellates commit shelves with streak-reactive glow
-     columns and nightly sync signage.
+
+- ✅ Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
+- ✨ Wall-mounted Futuroptimist media wall now frames the living room POI with a branded
+  screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
+- ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
+  orbitals, and an activation-driven tech stack + docs callout panel.
+- ✅ Studio Jobbot terminal desk now projects live automation telemetry via orbiting data
+  shards and anchors the Jobbot3000 POI with reactive lighting and diagnostics beacons.
+- ✨ Axel quest navigator tabletop now charts backlog quests with holographic rings and
+  momentum beacons around the studio tracker POI.
+- ✨ Gitshelves living room array now tessellates commit shelves with streak-reactive glow
+  columns and nightly sync signage.
+
 3. **Backyard Exhibits**
    - ✨ Launch-ready model rocket for `DSPACE`, complete with illuminated launch pad, caution halo,
      countdown-ready stance, and an interactive POI that links to the mission log.


### PR DESCRIPTION
## Summary
- add orbiting telemetry panels and aura animation to the Jobbot POI terminal
- guard telemetry visuals against reduced motion presets and extend coverage with new tests
- mark the roadmap slice complete and note the new telemetry orbit in the README

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke


------
https://chatgpt.com/codex/tasks/task_e_68f1de4dcad8832fa23050a7fdb0a14b