### PR TITLE
Highlight flywheel docs CTA in POI overlay

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,21 +114,23 @@ Focus: anchor each highlighted project with an interactive artifact.
 2. **Interior Showpieces**
    - ✅ Wall-mounted TV with YouTube branding for the `futuroptimist` repo; approaching
      triggers a rich text popup with repo summary, star count, and CTA buttons.
-   - Spinning flywheel centerpiece representing the `flywheel` repo; interaction spins faster,
-     reveals tech stack, and links to docs.
-   - ✅ Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
-   - ✨ f2clipboard incident console now elevates the kitchen diagnostics POI with a
-     holographic log ticker, clipboard callouts, and ambient halo lighting.
-   - ✨ Wall-mounted Futuroptimist media wall now frames the living room POI with a branded
-     screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
-   - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
-     orbitals, and an activation-driven tech stack + docs callout panel.
-   - ✅ Studio Jobbot terminal desk now projects live automation telemetry via orbiting data
-     shards and anchors the Jobbot3000 POI with reactive lighting and diagnostics beacons.
-   - ✨ Axel quest navigator tabletop now charts backlog quests with holographic rings and
-     momentum beacons around the studio tracker POI.
-   - ✨ Gitshelves living room array now tessellates commit shelves with streak-reactive glow
-     columns and nightly sync signage.
+
+- ✅ Spinning flywheel centerpiece representing the `flywheel` repo; interaction spins faster,
+  reveals tech stack, and spotlights the docs CTA inside the HUD tooltip.
+- ✅ Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
+- ✨ f2clipboard incident console now elevates the kitchen diagnostics POI with a
+  holographic log ticker, clipboard callouts, and ambient halo lighting.
+- ✨ Wall-mounted Futuroptimist media wall now frames the living room POI with a branded
+  screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
+- ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
+  orbitals, and an activation-driven tech stack + docs callout panel.
+- ✅ Studio Jobbot terminal desk now projects live automation telemetry via orbiting data
+  shards and anchors the Jobbot3000 POI with reactive lighting and diagnostics beacons.
+- ✨ Axel quest navigator tabletop now charts backlog quests with holographic rings and
+  momentum beacons around the studio tracker POI.
+- ✨ Gitshelves living room array now tessellates commit shelves with streak-reactive glow
+  columns and nightly sync signage.
+
 3. **Backyard Exhibits**
    - ✨ Launch-ready model rocket for `DSPACE`, complete with illuminated launch pad, caution halo,
      countdown-ready stance, and an interactive POI that links to the mission log.

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -221,7 +221,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           label: 'Flywheel Repo',
           href: 'https://github.com/futuroptimist/flywheel',
         },
-        { label: 'Docs', href: 'https://flywheel.futuroptimist.dev' },
+        {
+          label: 'Docs',
+          href: 'https://flywheel.futuroptimist.dev',
+          featured: true,
+        },
       ],
       narration: {
         caption:

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -1,5 +1,5 @@
 import type { InputMethod } from '../../ui/hud/movementLegend';
-import type { PoiId, PoiNarration } from '../poi/types';
+import type { PoiId, PoiLink, PoiNarration } from '../poi/types';
 
 export type Locale = 'en' | 'en-x-pseudo';
 export type LocaleDirection = 'ltr' | 'rtl';
@@ -79,11 +79,13 @@ export interface SiteStrings {
   structuredData: SiteStructuredDataStrings;
 }
 
+type PoiLinkCopy = Pick<PoiLink, 'label' | 'href' | 'featured'>;
+
 export interface PoiCopy {
   title: string;
   summary: string;
   metrics?: ReadonlyArray<{ label: string; value: string }>;
-  links?: ReadonlyArray<{ label: string; href: string }>;
+  links?: ReadonlyArray<PoiLinkCopy>;
   narration?: PoiNarration;
 }
 

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -239,6 +239,13 @@ export class PoiTooltipOverlay {
       anchor.rel = 'noopener noreferrer';
       anchor.textContent = link.label;
 
+      if (link.featured) {
+        anchor.classList.add('poi-tooltip-overlay__link--featured');
+        anchor.setAttribute('aria-current', 'page');
+        anchor.dataset.featuredLink = 'true';
+        item.dataset.featuredLink = 'true';
+      }
+
       item.appendChild(anchor);
       this.linksList.appendChild(item);
     }

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -26,6 +26,11 @@ export interface PoiMetric {
 export interface PoiLink {
   label: string;
   href: string;
+  /**
+   * Flag primary call-to-action links so overlays can spotlight critical CTAs
+   * (e.g., repo docs) with additional styling and accessibility affordances.
+   */
+  featured?: boolean;
 }
 
 export interface PoiNarration {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -216,6 +216,48 @@ describe('PoiTooltipOverlay', () => {
     expect(liveRegion.textContent).toContain(`${nextPoi.title} discovered.`);
   });
 
+  it('spotlights featured links with CTA styling and aria-current metadata', () => {
+    const poiWithFeaturedLink: PoiDefinition = {
+      ...basePoi,
+      id: 'flywheel-studio-flywheel',
+      links: [
+        {
+          label: 'Flywheel Repo',
+          href: 'https://github.com/futuroptimist/flywheel',
+        },
+        {
+          label: 'Docs',
+          href: 'https://flywheel.futuroptimist.dev',
+          featured: true,
+        },
+      ],
+    };
+
+    overlay.setSelected(poiWithFeaturedLink);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const links = root.querySelectorAll<HTMLAnchorElement>(
+      '.poi-tooltip-overlay__link'
+    );
+
+    expect(links).toHaveLength(2);
+    const featuredLink = Array.from(links).find(
+      (anchor) => anchor.dataset.featuredLink === 'true'
+    );
+    expect(
+      featuredLink?.classList.contains('poi-tooltip-overlay__link--featured')
+    ).toBe(true);
+    expect(featuredLink?.getAttribute('aria-current')).toBe('page');
+
+    const nonFeaturedLink = Array.from(links).find(
+      (anchor) => anchor.dataset.featuredLink !== 'true'
+    );
+    expect(
+      nonFeaturedLink?.classList.contains('poi-tooltip-overlay__link--featured')
+    ).toBe(false);
+    expect(nonFeaturedLink?.hasAttribute('aria-current')).toBe(false);
+  });
+
   it('supports custom discovery formatter and politeness levels', () => {
     overlay.dispose();
     timelineHarness.dispose();

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1137,6 +1137,27 @@ html[data-hudLayout='mobile'] .audio-subtitles {
     border-color 120ms ease;
 }
 
+.poi-tooltip-overlay__link--featured {
+  color: #e6f7ff;
+  border-bottom-color: rgba(230, 247, 255, 0.7);
+  font-weight: 600;
+  text-shadow: 0 0 6px rgba(92, 202, 255, 0.5);
+}
+
+.poi-tooltip-overlay__link--featured::after {
+  content: 'Primary';
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.4rem;
+  background: rgba(76, 200, 255, 0.18);
+  border: 1px solid rgba(76, 200, 255, 0.42);
+  color: rgba(214, 244, 255, 0.95);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .poi-tooltip-overlay__link:focus,
 .poi-tooltip-overlay__link:hover {
   color: #d4f2ff;


### PR DESCRIPTION
## Summary
- spotlight the flywheel docs CTA with featured HUD tooltip styling
- extend POI link metadata/types so exhibits can flag primary CTAs
- mark the roadmap flywheel centerpiece milestone as completed

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f1eaeddc04832fa018eedc0e45ac8c