### PR TITLE
Add orbiting tech stack chips to flywheel showpiece

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,8 +114,10 @@ Focus: anchor each highlighted project with an interactive artifact.
 2. **Interior Showpieces**
    - ✅ Wall-mounted TV with YouTube branding for the `futuroptimist` repo; approaching
      triggers a rich text popup with repo summary, star count, and CTA buttons.
-   - Spinning flywheel centerpiece representing the `flywheel` repo; interaction spins faster,
-     reveals tech stack, and links to docs.
+   - ✅ Spinning flywheel centerpiece representing the `flywheel` repo; interaction spins
+     faster, reveals tech stack, and links to docs.
+     - ✨ Orbiting tech-stack chips now fade in with POI emphasis and highlight automation
+       pillars around the rotor.
    - ✅ Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
    - ✨ f2clipboard incident console now elevates the kitchen diagnostics POI with a
      holographic log ticker, clipboard callouts, and ambient halo lighting.

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -86,6 +86,12 @@ describe('createFlywheelShowpiece', () => {
     expect(capturedText).toContain('Flywheel Automation');
     expect(capturedText).toContain('Docs');
     expect(capturedText).toContain('flywheel.futuroptimist.dev');
+    expect(capturedText).toContain('CI templates');
+    expect(capturedText).toContain('Typed prompts');
+    expect(capturedText).toContain('Scaffolds');
+    expect(capturedText).toContain('lint · test · deploy');
+    expect(capturedText).toContain('codex-driven flows');
+    expect(capturedText).toContain('vite · playwright');
   });
 
   it('reveals docs callout and accelerates the rotor under emphasis', () => {
@@ -138,5 +144,45 @@ describe('createFlywheelShowpiece', () => {
 
     expect(calloutMaterial.opacity).toBe(0);
     expect(callout.visible).toBe(false);
+  });
+
+  it('reveals tech stack chips and animates their orbit with emphasis', () => {
+    const build = createFlywheelShowpiece({
+      centerX: 0,
+      centerZ: 0,
+      roomBounds,
+    });
+
+    const techStackGroup = build.group.getObjectByName(
+      'FlywheelTechStackGroup'
+    ) as Group;
+    expect(techStackGroup).toBeInstanceOf(Group);
+
+    const wrappers = techStackGroup.children as Group[];
+    expect(wrappers).toHaveLength(3);
+
+    const initialRotations = wrappers.map((wrapper) => wrapper.rotation.y);
+    const materials = wrappers.map((wrapper) => {
+      const chip = wrapper.children[0] as Mesh;
+      return chip.material as MeshBasicMaterial;
+    });
+
+    build.update({ elapsed: 0.25, delta: 0.25, emphasis: 0 });
+    materials.forEach((material) => {
+      expect(material.opacity).toBeLessThan(0.05);
+    });
+
+    build.update({ elapsed: 0.75, delta: 0.5, emphasis: 1 });
+    build.update({ elapsed: 1.4, delta: 0.65, emphasis: 1 });
+
+    wrappers.forEach((wrapper, index) => {
+      expect(wrapper.rotation.y).not.toBeCloseTo(initialRotations[index]);
+      const chip = wrapper.children[0] as Mesh;
+      expect(chip.visible).toBe(true);
+    });
+
+    materials.forEach((material) => {
+      expect(material.opacity).toBeGreaterThan(0.25);
+    });
   });
 });


### PR DESCRIPTION
what: add orbiting tech stack chips and emphasis-driven fades to the flywheel showpiece
why: surface automation pillars when players focus or activate the flywheel poi
how to test: npm run lint && npm run test:ci && npm run docs:check && npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f1eaeddc04832fa018eedc0e45ac8c