### PR TITLE
Add HUD guided tour reset control

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,7 +193,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - ✅ Visited POI progress persists across reloads, powering halo highlights and tooltip badges.
    - ✅ Accessibility HUD now remembers ambient audio volume tweaks between play sessions.
    - ✅ Guided tour overlay surfaces the next recommended POI whenever the player is idle.
-   - ✨ Guided tour reset utility now lets the HUD restart the curated path on demand so
+   - ✅ Guided tour reset utility now lets the HUD restart the curated path on demand so
      visitors can replay the experience during sessions or demos.
 
 ## Phase 4 – Accessibility & Internationalization

--- a/src/main.ts
+++ b/src/main.ts
@@ -205,6 +205,10 @@ import {
   type KeyBindingConfig,
 } from './systems/controls/keyBindings';
 import { KeyboardControls } from './systems/controls/KeyboardControls';
+import {
+  createTourResetControl,
+  type TourResetControlHandle,
+} from './systems/controls/tourResetControl';
 import { VirtualJoystick } from './systems/controls/VirtualJoystick';
 import {
   evaluateFailoverDecision,
@@ -540,6 +544,7 @@ function initializeImmersiveScene(
   ledAnimator = null;
 
   let manualModeToggle: ManualModeToggleHandle | null = null;
+  let tourResetControl: TourResetControlHandle | null = null;
   let hudLayoutManager: HudLayoutManagerHandle | null = null;
   let immersiveDisposed = false;
   let beforeUnloadHandler: (() => void) | null = null;
@@ -2372,6 +2377,14 @@ function initializeImmersiveScene(
         }
       },
     });
+
+    tourResetControl = createTourResetControl({
+      container: hudSettingsStack,
+      subscribeVisited: (listener) => poiVisitedState.subscribe(listener),
+      onReset: () => {
+        poiVisitedState.reset();
+      },
+    });
   }
 
   let composer: EffectComposer | null = null;
@@ -2978,6 +2991,10 @@ function initializeImmersiveScene(
     if (manualModeToggle) {
       manualModeToggle.dispose();
       manualModeToggle = null;
+    }
+    if (tourResetControl) {
+      tourResetControl.dispose();
+      tourResetControl = null;
     }
     if (ambientAudioController) {
       ambientAudioController.dispose();

--- a/src/systems/controls/tourResetControl.ts
+++ b/src/systems/controls/tourResetControl.ts
@@ -1,0 +1,206 @@
+import type { PoiVisitedListener } from '../../scene/poi/visitedState';
+
+export interface TourResetControlOptions {
+  container: HTMLElement;
+  /**
+   * Subscribes to visited POI updates. The listener should receive an initial
+   * snapshot immediately. Returns an unsubscribe function.
+   */
+  subscribeVisited: (listener: PoiVisitedListener) => () => void;
+  /**
+   * Invoked when the control activates. May return a promise when reset work
+   * performs asynchronous tasks.
+   */
+  onReset: () => void | Promise<void>;
+  windowTarget?: Window;
+  /** Single-character shortcut hint. */
+  resetKey?: string;
+  label?: string;
+  description?: string;
+  emptyLabel?: string;
+  emptyDescription?: string;
+  pendingLabel?: string;
+}
+
+export interface TourResetControlHandle {
+  readonly element: HTMLButtonElement;
+  dispose(): void;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<void> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+const appendClause = (base: string, clause: string): string => {
+  const trimmedBase = base.trim();
+  const trimmedClause = clause.trim();
+  if (!trimmedClause) {
+    return trimmedBase;
+  }
+  if (!trimmedBase) {
+    return trimmedClause;
+  }
+  const separator = /[.!?]\s*$/.test(trimmedBase) ? ' ' : '. ';
+  return `${trimmedBase}${separator}${trimmedClause}`;
+};
+
+export function createTourResetControl({
+  container,
+  subscribeVisited,
+  onReset,
+  windowTarget = window,
+  resetKey = 'g',
+  label = 'Restart guided tour',
+  description = 'Clear visited POIs and replay the curated path.',
+  emptyLabel = 'Guided tour ready',
+  emptyDescription = 'Explore exhibits to unlock the guided tour reset.',
+  pendingLabel = 'Resetting tour…',
+}: TourResetControlOptions): TourResetControlHandle {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tour-reset';
+  button.dataset.state = 'empty';
+  button.setAttribute('aria-label', description);
+  container.appendChild(button);
+
+  const normalizeKey = (value: string | undefined) => {
+    if (!value) {
+      return '';
+    }
+    return value.length === 1 ? value.toUpperCase() : value;
+  };
+
+  const normalizedResetKey = normalizeKey(resetKey);
+
+  const idleTitle = normalizedResetKey
+    ? `${label} (${normalizedResetKey})`
+    : label;
+
+  let visitedCount = 0;
+  let pending = false;
+
+  const buildHudAnnouncement = (message: string, includePrompt: boolean) => {
+    if (!includePrompt || !normalizedResetKey) {
+      return message;
+    }
+    return appendClause(message, `Press ${normalizedResetKey} to restart.`);
+  };
+
+  const refreshState = () => {
+    const hasVisited = visitedCount > 0;
+    if (pending) {
+      button.disabled = true;
+      button.dataset.state = 'pending';
+      button.textContent = pendingLabel;
+      button.title = idleTitle;
+      button.setAttribute(
+        'aria-label',
+        appendClause(description, 'Resetting the guided tour…')
+      );
+      button.dataset.hudAnnounce = appendClause(
+        description,
+        'Resetting the guided tour…'
+      );
+      return;
+    }
+    if (!hasVisited) {
+      button.disabled = true;
+      button.dataset.state = 'empty';
+      button.textContent = emptyLabel;
+      button.title = emptyDescription;
+      button.setAttribute('aria-label', emptyDescription);
+      button.dataset.hudAnnounce = emptyDescription;
+      return;
+    }
+    button.disabled = false;
+    button.dataset.state = 'ready';
+    button.textContent = label;
+    button.title = idleTitle;
+    button.setAttribute('aria-label', description);
+    button.dataset.hudAnnounce = buildHudAnnouncement(description, true);
+  };
+
+  const finalizeReset = () => {
+    pending = false;
+    refreshState();
+  };
+
+  const activate = () => {
+    if (pending || visitedCount === 0) {
+      return;
+    }
+    pending = true;
+    refreshState();
+    try {
+      const result = onReset();
+      if (isPromiseLike(result)) {
+        result
+          .catch((error) => {
+            console.warn('Failed to reset guided tour state:', error);
+          })
+          .finally(() => {
+            finalizeReset();
+          });
+      } else {
+        finalizeReset();
+      }
+    } catch (error) {
+      console.warn('Failed to reset guided tour state:', error);
+      finalizeReset();
+    }
+  };
+
+  const handleClick = () => {
+    activate();
+  };
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (!resetKey) {
+      return;
+    }
+    const matchesKey =
+      event.key === resetKey || event.key === resetKey.toUpperCase();
+    if (!matchesKey) {
+      return;
+    }
+    if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+      return;
+    }
+    if (pending || visitedCount === 0) {
+      return;
+    }
+    event.preventDefault();
+    activate();
+  };
+
+  button.addEventListener('click', handleClick);
+  if (resetKey) {
+    windowTarget.addEventListener('keydown', handleKeydown);
+  }
+
+  const unsubscribeVisited = subscribeVisited((visited) => {
+    visitedCount = visited.size;
+    refreshState();
+  });
+
+  refreshState();
+
+  return {
+    element: button,
+    dispose() {
+      button.removeEventListener('click', handleClick);
+      if (resetKey) {
+        windowTarget.removeEventListener('keydown', handleKeydown);
+      }
+      unsubscribeVisited();
+      if (button.parentElement) {
+        button.remove();
+      }
+    },
+  };
+}

--- a/src/tests/tourResetControl.test.ts
+++ b/src/tests/tourResetControl.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createTourResetControl } from '../systems/controls/tourResetControl';
+
+describe('createTourResetControl', () => {
+  const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  const createContainer = () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    return container;
+  };
+
+  const createVisitedSubscription = () => {
+    let listener: ((visited: ReadonlySet<string>) => void) | null = null;
+    const unsubscribe = vi.fn(() => {
+      listener = null;
+    });
+    const subscribe = (
+      next: (visited: ReadonlySet<string>) => void
+    ): (() => void) => {
+      listener = next;
+      next(new Set());
+      return unsubscribe;
+    };
+    const emit = (ids: Iterable<string>) => {
+      listener?.(new Set(ids));
+    };
+    return { subscribe, emit, unsubscribe };
+  };
+
+  it('renders disabled state until POIs are visited', () => {
+    const container = createContainer();
+    const subscription = createVisitedSubscription();
+
+    const handle = createTourResetControl({
+      container,
+      subscribeVisited: subscription.subscribe,
+      onReset: vi.fn(),
+    });
+
+    const button = handle.element;
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect(button.disabled).toBe(true);
+    expect(button.dataset.state).toBe('empty');
+    expect(button.textContent).toBe('Guided tour ready');
+    expect(button.dataset.hudAnnounce).toBe(
+      'Explore exhibits to unlock the guided tour reset.'
+    );
+
+    subscription.emit(['a', 'b']);
+    expect(button.disabled).toBe(false);
+    expect(button.dataset.state).toBe('ready');
+    expect(button.textContent).toBe('Restart guided tour');
+    expect(button.dataset.hudAnnounce).toContain('Press G to restart.');
+
+    handle.dispose();
+    expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(container.contains(button)).toBe(false);
+    container.remove();
+  });
+
+  it('activates via click and keyboard, handling async completion', async () => {
+    const container = createContainer();
+    const subscription = createVisitedSubscription();
+    subscription.emit(['seed']);
+
+    const reset = vi.fn(() => Promise.resolve());
+    const handle = createTourResetControl({
+      container,
+      subscribeVisited: subscription.subscribe,
+      onReset: reset,
+      resetKey: 'r',
+      windowTarget: window,
+    });
+
+    const button = handle.element;
+    subscription.emit(['seed']);
+    expect(button.disabled).toBe(false);
+
+    button.click();
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(button.dataset.state).toBe('pending');
+    expect(button.disabled).toBe(true);
+
+    await flushPromises();
+    subscription.emit([]);
+    await flushPromises();
+    expect(button.dataset.state).toBe('empty');
+    expect(button.disabled).toBe(true);
+
+    subscription.emit(['next']);
+    const event = new KeyboardEvent('keydown', { key: 'r' });
+    window.dispatchEvent(event);
+    expect(reset).toHaveBeenCalledTimes(2);
+    await flushPromises();
+
+    handle.dispose();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'r' }));
+    expect(reset).toHaveBeenCalledTimes(2);
+    container.remove();
+  });
+
+  it('handles async rejections without leaving pending state', async () => {
+    const container = createContainer();
+    const subscription = createVisitedSubscription();
+    subscription.emit(['seed']);
+
+    const reset = vi.fn(() => Promise.reject(new Error('nope')));
+    const handle = createTourResetControl({
+      container,
+      subscribeVisited: subscription.subscribe,
+      onReset: reset,
+      resetKey: 'r',
+      windowTarget: window,
+    });
+
+    const button = handle.element;
+    subscription.emit(['seed']);
+    expect(button.disabled).toBe(false);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'r' }));
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(button.dataset.state).toBe('pending');
+    subscription.emit(['seed']);
+    await flushPromises();
+    await flushPromises();
+    expect(button.dataset.state).toBe('ready');
+    expect(button.disabled).toBe(false);
+
+    handle.dispose();
+    container.remove();
+  });
+
+  it('recovers from synchronous reset errors', () => {
+    const container = createContainer();
+    const subscription = createVisitedSubscription();
+    subscription.emit(['seed']);
+
+    const reset = vi.fn(() => {
+      throw new Error('boom');
+    });
+
+    const handle = createTourResetControl({
+      container,
+      subscribeVisited: subscription.subscribe,
+      onReset: reset,
+    });
+
+    subscription.emit(['seed']);
+    const button = handle.element;
+    button.click();
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(button.dataset.state).toBe('ready');
+    expect(button.disabled).toBe(false);
+
+    handle.dispose();
+    container.remove();
+  });
+});

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -548,7 +548,8 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   border: 0;
 }
 
-.mode-toggle {
+.mode-toggle,
+.tour-reset {
   width: 100%;
   padding: 0.6rem 0.9rem;
   border-radius: 0.5rem;
@@ -570,15 +571,27 @@ html[data-hudLayout='mobile'] .audio-subtitles {
     color 120ms ease;
 }
 
+.tour-reset {
+  font-weight: 600;
+}
+
 .mode-toggle:hover,
-.mode-toggle:focus-visible {
+.mode-toggle:focus-visible,
+.tour-reset:hover,
+.tour-reset:focus-visible {
   border-color: rgba(143, 214, 255, 0.75);
   outline: none;
 }
 
-.mode-toggle[data-state='pending'] {
+.mode-toggle[data-state='pending'],
+.tour-reset[data-state='pending'] {
   cursor: progress;
   opacity: 0.78;
+}
+
+.tour-reset[data-state='empty'] {
+  cursor: not-allowed;
+  opacity: 0.7;
 }
 
 .hud-settings {


### PR DESCRIPTION
## Summary
- add a HUD tour reset button wired to the visited POI state
- share styling with existing HUD buttons and update the roadmap entry
- cover the control with unit tests for async success and failure paths

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f1f565758c832fa4ca8aaf99549241