### PR TITLE
Add hologram pedestal config for Futuroptimist and Flywheel exhibits

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,8 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✅ 3D tooltip cards anchor POIs in world space, billboard to the camera, and reuse overlay copy.
    - ✅ Desktop pointer + keyboard selection loops share accessible focus targets and emit POI
      events, paving the path for gamepad + mid-air parity.
-   - ⚙️ Data-driven registry now spawns holographic pedestals for Futuroptimist + Flywheel exhibits.
+
+   - ✅ Data-driven registry now spawns holographic pedestals for Futuroptimist + Flywheel exhibits.
    - ✨ Pedestals fade in tooltips and halo guides as players enter their interaction radii.
    - ✅ Desktop pointer interaction manager highlights POIs and emits selection events.
    - ✅ Analytics hooks emit hover and selection lifecycle events for instrumentation pipelines.
@@ -111,6 +112,7 @@ Focus: anchor each highlighted project with an interactive artifact.
      hover/selection state.
    - ✅ Registry validation enforces room bounds, unique ids, and safe spacing at build time.
    - ✅ Touch interactions now share the pointer pipeline so mobile taps mirror desktop focus.
+
 2. **Interior Showpieces**
    - ✅ Wall-mounted TV with YouTube branding for the `futuroptimist` repo; approaching
      triggers a rich text popup with repo summary, star count, and CTA buttons.

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -3,13 +3,20 @@ import { getPoiCopy } from '../../assets/i18n';
 
 import { scalePoiValue } from './constants';
 import { applyManualPoiPlacements } from './placements';
-import type { PoiDefinition, PoiId, PoiRegistry } from './types';
+import type {
+  PoiDefinition,
+  PoiId,
+  PoiPedestalConfig,
+  PoiRegistry,
+} from './types';
 import { assertValidPoiDefinitions } from './validation';
+
+type PoiPedestalStaticConfig = PoiPedestalConfig;
 
 type PoiStaticDefinition = Omit<
   PoiDefinition,
-  'title' | 'summary' | 'metrics' | 'links' | 'narration'
->;
+  'title' | 'summary' | 'metrics' | 'links' | 'narration' | 'pedestal'
+> & { pedestal?: PoiPedestalStaticConfig };
 
 const baseDefinitions: PoiStaticDefinition[] = [
   {
@@ -23,6 +30,25 @@ const baseDefinitions: PoiStaticDefinition[] = [
     interactionRadius: 2.6,
     footprint: { width: 3.4, depth: 3.2 },
     status: 'prototype',
+    pedestal: {
+      type: 'hologram',
+      height: 0.86,
+      radiusScale: 0.76,
+      bodyColor: 0x122036,
+      bodyOpacity: 0.58,
+      emissiveColor: 0x1f77ff,
+      emissiveIntensity: 0.82,
+      accentColor: 0x5acbff,
+      accentEmissiveColor: 0x8fe3ff,
+      accentEmissiveIntensity: 1.08,
+      accentOpacity: 0.88,
+      ringColor: 0x7ff2ff,
+      ringOpacity: 0.62,
+      orbColor: 0xc7f3ff,
+      orbEmissiveColor: 0x4de6ff,
+      orbHighlightColor: 0x9bfbff,
+      orbEmissiveIntensity: 1.05,
+    },
   },
   {
     id: 'tokenplace-studio-cluster',
@@ -56,6 +82,25 @@ const baseDefinitions: PoiStaticDefinition[] = [
     interactionRadius: 2.2,
     footprint: { width: 2, depth: 2 },
     status: 'prototype',
+    pedestal: {
+      type: 'hologram',
+      height: 0.96,
+      radiusScale: 0.82,
+      bodyColor: 0x101a28,
+      bodyOpacity: 0.54,
+      emissiveColor: 0x1cc7a3,
+      emissiveIntensity: 0.9,
+      accentColor: 0x48ffd4,
+      accentEmissiveColor: 0x96ffe9,
+      accentEmissiveIntensity: 1.12,
+      accentOpacity: 0.92,
+      ringColor: 0x6affdf,
+      ringOpacity: 0.65,
+      orbColor: 0xbefde4,
+      orbEmissiveColor: 0x36f7c5,
+      orbHighlightColor: 0x9ffff3,
+      orbEmissiveIntensity: 1.08,
+    },
   },
   {
     id: 'jobbot-studio-terminal',
@@ -182,6 +227,15 @@ const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
   const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
   const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
   const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
+  const pedestal: PoiPedestalConfig | undefined = base.pedestal
+    ? {
+        ...base.pedestal,
+        height:
+          typeof base.pedestal.height === 'number'
+            ? scalePoiValue(base.pedestal.height)
+            : undefined,
+      }
+    : undefined;
   return {
     ...base,
     interactionRadius: scaledInteractionRadius,
@@ -189,6 +243,7 @@ const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
       width: footprintWidth,
       depth: footprintDepth,
     },
+    pedestal,
     title: copy.title,
     summary: copy.summary,
     metrics: copy.metrics?.map((metric) => ({ ...metric })),

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -40,6 +40,44 @@ export interface PoiFootprint {
   depth: number;
 }
 
+export interface PoiHologramPedestalConfig {
+  type: 'hologram';
+  /** Optional height of the holographic pedestal shell, in world units. */
+  height?: number;
+  /** Scale applied to the pedestal radius relative to the POI footprint. */
+  radiusScale?: number;
+  /** Base color tint applied to the holographic shell. */
+  bodyColor?: number;
+  /** Opacity applied to the holographic shell material. */
+  bodyOpacity?: number;
+  /** Emissive color for the holographic shell glow. */
+  emissiveColor?: number;
+  /** Emissive intensity multiplier for the holographic shell glow. */
+  emissiveIntensity?: number;
+  /** Accent band color used near the top of the pedestal. */
+  accentColor?: number;
+  /** Accent band emissive tint. */
+  accentEmissiveColor?: number;
+  /** Accent band emissive intensity. */
+  accentEmissiveIntensity?: number;
+  /** Accent band opacity. */
+  accentOpacity?: number;
+  /** Color applied to the floating holographic top ring. */
+  ringColor?: number;
+  /** Opacity for the floating holographic top ring. */
+  ringOpacity?: number;
+  /** Base albedo color for the interaction orb. */
+  orbColor?: number;
+  /** Emissive color for the interaction orb. */
+  orbEmissiveColor?: number;
+  /** Highlight emissive color when the orb is focused. */
+  orbHighlightColor?: number;
+  /** Emissive intensity applied to the interaction orb. */
+  orbEmissiveIntensity?: number;
+}
+
+export type PoiPedestalConfig = PoiHologramPedestalConfig;
+
 export interface PoiDefinition {
   id: PoiId;
   title: string;
@@ -56,6 +94,7 @@ export interface PoiDefinition {
   /** Optional note to surface prototype status in tooltips. */
   status?: 'prototype' | 'live';
   narration?: PoiNarration;
+  pedestal?: PoiPedestalConfig;
 }
 
 export interface PoiAnalytics {

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -1,0 +1,197 @@
+import { CylinderGeometry, MeshStandardMaterial, Color } from 'three';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { scalePoiValue } from '../scene/poi/constants';
+import { createPoiInstances } from '../scene/poi/markers';
+import type { PoiDefinition } from '../scene/poi/types';
+
+describe('createPoiInstances', () => {
+  const baseSummary = 'Automation-ready showcase artifact.';
+
+  let originalGetContext:
+    | ((
+        this: HTMLCanvasElement,
+        contextId: string,
+        ...args: unknown[]
+      ) => CanvasRenderingContext2D | null)
+    | undefined;
+
+  beforeAll(() => {
+    originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function getContextShim(
+      this: HTMLCanvasElement,
+      contextId: string,
+      ...args: unknown[]
+    ): CanvasRenderingContext2D | null {
+      if (contextId === '2d') {
+        const gradient = {
+          addColorStop: () => {
+            /* noop */
+          },
+        };
+        const context: Partial<CanvasRenderingContext2D> = {
+          canvas: this,
+          clearRect: () => {
+            /* noop */
+          },
+          fillRect: () => {
+            /* noop */
+          },
+          beginPath: () => {
+            /* noop */
+          },
+          arc: () => {
+            /* noop */
+          },
+          closePath: () => {
+            /* noop */
+          },
+          moveTo: () => {
+            /* noop */
+          },
+          lineTo: () => {
+            /* noop */
+          },
+          quadraticCurveTo: () => {
+            /* noop */
+          },
+          fill: () => {
+            /* noop */
+          },
+          stroke: () => {
+            /* noop */
+          },
+          fillText: () => {
+            /* noop */
+          },
+          measureText: (text: string) => ({ width: text.length * 10 }),
+          createLinearGradient: () => gradient as CanvasGradient,
+          set lineWidth(_value: number) {
+            /* noop */
+          },
+          set font(_value: string) {
+            /* noop */
+          },
+          set textAlign(_value: CanvasTextAlign) {
+            /* noop */
+          },
+          set textBaseline(_value: CanvasTextBaseline) {
+            /* noop */
+          },
+          set fillStyle(_value: string | CanvasGradient | CanvasPattern) {
+            /* noop */
+          },
+          set strokeStyle(_value: string | CanvasGradient | CanvasPattern) {
+            /* noop */
+          },
+        };
+        return context as CanvasRenderingContext2D;
+      }
+      return originalGetContext
+        ? originalGetContext.call(this, contextId, ...args)
+        : null;
+    };
+  });
+
+  afterAll(() => {
+    if (originalGetContext) {
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+    } else {
+      delete (
+        HTMLCanvasElement.prototype as {
+          getContext?: typeof originalGetContext;
+        }
+      ).getContext;
+    }
+  });
+
+  const createDefinition = (
+    definition: Partial<PoiDefinition>
+  ): PoiDefinition => ({
+    id: 'gitshelves-living-room-installation',
+    title: 'Gitshelves Installation',
+    summary: baseSummary,
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'livingRoom',
+    position: { x: 0, y: 0, z: 0 },
+    headingRadians: 0,
+    interactionRadius: 2.4,
+    footprint: { width: 2.8, depth: 2.2 },
+    ...definition,
+  });
+
+  it('applies hologram pedestal styling when configured', () => {
+    const pedestalHeight = 1.6;
+    const orbColorHex = 0x1355aa;
+    const orbEmissiveHex = 0x1be3ff;
+    const orbHighlightHex = 0xa7fbff;
+    const accentColorHex = 0x44f3c7;
+
+    const hologramDefinition = createDefinition({
+      id: 'flywheel-studio-flywheel',
+      roomId: 'studio',
+      footprint: { width: 2.6, depth: 2.2 },
+      pedestal: {
+        type: 'hologram',
+        height: pedestalHeight,
+        radiusScale: 0.88,
+        bodyColor: 0x0f1a2a,
+        bodyOpacity: 0.6,
+        emissiveColor: 0x17b8ff,
+        emissiveIntensity: 0.86,
+        accentColor: accentColorHex,
+        accentEmissiveColor: 0x8efff0,
+        accentEmissiveIntensity: 1.1,
+        accentOpacity: 0.9,
+        ringColor: 0x6df4ff,
+        ringOpacity: 0.64,
+        orbColor: orbColorHex,
+        orbEmissiveColor: orbEmissiveHex,
+        orbHighlightColor: orbHighlightHex,
+        orbEmissiveIntensity: 1.18,
+      },
+    });
+
+    const [instance] = createPoiInstances([hologramDefinition]);
+
+    expect(instance.accentMaterial).toBeInstanceOf(MeshStandardMaterial);
+    expect(instance.accentBaseColor?.getHex()).toBe(accentColorHex);
+    const expectedFocus = new Color(accentColorHex)
+      .lerp(new Color(0xffffff), 0.35)
+      .getHex();
+    expect(instance.accentFocusColor?.getHex()).toBe(expectedFocus);
+
+    expect(instance.orbMaterial).toBeInstanceOf(MeshStandardMaterial);
+    expect(instance.orbMaterial?.color.getHex()).toBe(orbColorHex);
+    expect(instance.orbMaterial?.emissive.getHex()).toBe(orbEmissiveHex);
+    expect(instance.orbMaterial?.emissiveIntensity).toBeCloseTo(1.18, 5);
+    expect(instance.orbEmissiveBase?.getHex()).toBe(orbEmissiveHex);
+    expect(instance.orbEmissiveHighlight?.getHex()).toBe(orbHighlightHex);
+
+    const hitGeometry = instance.hitArea.geometry as CylinderGeometry;
+    expect(hitGeometry.parameters.height).toBeCloseTo(
+      scalePoiValue(0.32) + pedestalHeight + scalePoiValue(0.24),
+      5
+    );
+    expect(instance.orbBaseHeight).toBeGreaterThan(pedestalHeight);
+    expect(instance.labelBaseHeight).toBeGreaterThan(instance.orbBaseHeight);
+  });
+
+  it('keeps default pedestal styling when no hologram config is provided', () => {
+    const defaultDefinition = createDefinition({
+      id: 'gitshelves-living-room-installation',
+    });
+
+    const [instance] = createPoiInstances([defaultDefinition]);
+    expect(instance.accentMaterial).toBeUndefined();
+    expect(instance.accentBaseColor).toBeUndefined();
+    expect(instance.accentFocusColor).toBeUndefined();
+
+    const hitGeometry = instance.hitArea.geometry as CylinderGeometry;
+    expect(hitGeometry.parameters.height).toBeCloseTo(
+      scalePoiValue(0.32) + scalePoiValue(0.24),
+      5
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add data-driven pedestal configuration for Futuroptimist and Flywheel POIs
- update pedestal builder to render hologram shells, accent bands, and adjust heights from config
- cover pedestal sampling with new unit tests and mark roadmap milestone complete

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f200dda4fc832f9d47e157087382e6