### PR TITLE
Add animated launch pad effects for DSPACE rocket

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -134,8 +134,8 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✨ Gitshelves living room array now tessellates commit shelves with streak-reactive glow
      columns and nightly sync signage.
 3. **Backyard Exhibits**
-   - ✨ Launch-ready model rocket for `DSPACE`, complete with illuminated launch pad, caution halo,
-     countdown-ready stance, and an interactive POI that links to the mission log.
+   - ✅ Launch-ready model rocket for `DSPACE`, complete with illuminated launch pad, pulsing
+     caution halo, countdown-ready stance, and an interactive POI that links to the mission log.
    - ✨ Aluminum extrusion greenhouse inspired by `sugarkube`, complete with animated solar
      trackers, pulsing grow lights, interior planter beds, and a koi pond plinth.
      - ✅ Sugarkube greenhouse POI now surfaces automation metrics and dual CTAs in the registry.

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -303,6 +303,7 @@ export function createBackyardEnvironment(
   });
   group.add(rocket.group);
   colliders.push(rocket.collider);
+  updates.push(rocket.update);
 
   const steppingStoneGeometry = new BoxGeometry(pathWidth * 0.32, 0.12, 0.9);
   const steppingStoneMaterial = new MeshStandardMaterial({

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -79,7 +79,8 @@ describe('createBackyardEnvironment', () => {
   });
 
   it('adds the model rocket installation and collider to the backyard', () => {
-    const { group, colliders } = createBackyardEnvironment(BACKYARD_BOUNDS);
+    const environment = createBackyardEnvironment(BACKYARD_BOUNDS);
+    const { group, colliders } = environment;
     const rocket = group.getObjectByName('BackyardModelRocket');
     expect(rocket).toBeInstanceOf(Group);
 
@@ -95,6 +96,54 @@ describe('createBackyardEnvironment', () => {
     expect(matchingCollider).toBeDefined();
     expect(matchingCollider?.maxX).toBeGreaterThan(matchingCollider!.minX);
     expect(matchingCollider?.maxZ).toBeGreaterThan(matchingCollider!.minZ);
+
+    const thruster = (rocket as Group).getObjectByName('ModelRocketThruster');
+    expect(thruster).toBeInstanceOf(Mesh);
+    const thrusterMaterial = (thruster as Mesh)
+      .material as MeshStandardMaterial;
+    const thrusterBaseline = thrusterMaterial.emissiveIntensity;
+
+    const flame = (rocket as Group).getObjectByName('ModelRocketThrusterFlame');
+    expect(flame).toBeInstanceOf(Mesh);
+    const flameMaterial = (flame as Mesh).material as MeshBasicMaterial;
+    const flameBaseline = flameMaterial.opacity;
+
+    const thrusterLight = (rocket as Group).getObjectByName(
+      'ModelRocketThrusterLight'
+    );
+    expect(thrusterLight).toBeInstanceOf(PointLight);
+    const lightBaseline = (thrusterLight as PointLight).intensity;
+
+    const safetyRing = (rocket as Group).getObjectByName(
+      'ModelRocketSafetyRing'
+    );
+    expect(safetyRing).toBeInstanceOf(Mesh);
+    const safetyMaterial = (safetyRing as Mesh).material as MeshBasicMaterial;
+    const safetyBaseline = safetyMaterial.opacity;
+
+    const countdownPanel = (rocket as Group).getObjectByName(
+      'ModelRocketCountdownPanel'
+    );
+    expect(countdownPanel).toBeInstanceOf(Mesh);
+    const countdownMaterial = (countdownPanel as Mesh)
+      .material as MeshBasicMaterial;
+    const countdownOpacityBaseline = countdownMaterial.opacity;
+    const countdownScaleBaseline = (countdownPanel as Mesh).scale.y;
+
+    environment.update({ elapsed: 1.25, delta: 0.016 });
+
+    expect(thrusterMaterial.emissiveIntensity).not.toBeCloseTo(
+      thrusterBaseline
+    );
+    expect(flameMaterial.opacity).not.toBeCloseTo(flameBaseline);
+    expect((thrusterLight as PointLight).intensity).not.toBeCloseTo(
+      lightBaseline
+    );
+    expect(safetyMaterial.opacity).not.toBeCloseTo(safetyBaseline);
+    expect(countdownMaterial.opacity).not.toBeCloseTo(countdownOpacityBaseline);
+    expect((countdownPanel as Mesh).scale.y).not.toBeCloseTo(
+      countdownScaleBaseline
+    );
   });
 
   it('installs the greenhouse exhibit with animated elements and collider', () => {

--- a/src/tests/modelRocket.test.ts
+++ b/src/tests/modelRocket.test.ts
@@ -1,9 +1,20 @@
-import { Vector3 } from 'three';
-import { describe, expect, it } from 'vitest';
+import {
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  PointLight,
+  Vector3,
+} from 'three';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createModelRocket } from '../scene/structures/modelRocket';
 
 describe('createModelRocket', () => {
+  const MIN_DELTA = 0.003;
+  afterEach(() => {
+    delete document.documentElement.dataset.accessibilityPulseScale;
+  });
+
   it('builds a rocket group with expected child components', () => {
     const basePosition = new Vector3(4.2, 0, -3.1);
     const orientation = Math.PI / 6;
@@ -31,11 +42,112 @@ describe('createModelRocket', () => {
     );
     expect(finNames.length).toBeGreaterThanOrEqual(3);
 
+    expect(childNames).toContain('ModelRocketThrusterFlame');
+    expect(childNames).toContain('ModelRocketThrusterLight');
+    expect(childNames).toContain('ModelRocketCountdownPanel');
+
     const footprintHalf = (collider.maxX - collider.minX) / 2;
     expect(footprintHalf).toBeGreaterThan(1);
     expect(collider.minX).toBeCloseTo(basePosition.x - footprintHalf);
     expect(collider.maxX).toBeCloseTo(basePosition.x + footprintHalf);
     expect(collider.minZ).toBeCloseTo(basePosition.z - footprintHalf);
     expect(collider.maxZ).toBeCloseTo(basePosition.z + footprintHalf);
+  });
+
+  it('pulses thruster glow, halo, and countdown indicator over time', () => {
+    const basePosition = new Vector3(0, 0, 0);
+    const build = createModelRocket({ basePosition });
+
+    const thruster = build.group.getObjectByName(
+      'ModelRocketThruster'
+    ) as Mesh<MeshStandardMaterial>;
+    const thrusterMaterial = thruster.material as MeshStandardMaterial;
+    const thrusterBaseline = thrusterMaterial.emissiveIntensity;
+
+    const flame = build.group.getObjectByName(
+      'ModelRocketThrusterFlame'
+    ) as Mesh<MeshBasicMaterial>;
+    const flameMaterial = flame.material as MeshBasicMaterial;
+    const flameOpacityBaseline = flameMaterial.opacity;
+
+    const thrusterLight = build.group.getObjectByName(
+      'ModelRocketThrusterLight'
+    ) as PointLight;
+    const lightIntensityBaseline = thrusterLight.intensity;
+
+    const safetyRing = build.group.getObjectByName(
+      'ModelRocketSafetyRing'
+    ) as Mesh<MeshBasicMaterial>;
+    const safetyMaterial = safetyRing.material as MeshBasicMaterial;
+    const safetyOpacityBaseline = safetyMaterial.opacity;
+
+    const countdownPanel = build.group.getObjectByName(
+      'ModelRocketCountdownPanel'
+    ) as Mesh<MeshBasicMaterial>;
+    const countdownMaterial = countdownPanel.material as MeshBasicMaterial;
+    const countdownOpacityBaseline = countdownMaterial.opacity;
+    const countdownScaleBaseline = countdownPanel.scale.y;
+
+    build.update({ elapsed: 1.6, delta: 0.016 });
+
+    expect(
+      Math.abs(thrusterMaterial.emissiveIntensity - thrusterBaseline)
+    ).toBeGreaterThan(MIN_DELTA);
+    expect(
+      Math.abs(flameMaterial.opacity - flameOpacityBaseline)
+    ).toBeGreaterThan(MIN_DELTA);
+    expect(
+      Math.abs(thrusterLight.intensity - lightIntensityBaseline)
+    ).toBeGreaterThan(MIN_DELTA);
+    expect(
+      Math.abs(safetyMaterial.opacity - safetyOpacityBaseline)
+    ).toBeGreaterThan(MIN_DELTA);
+    expect(
+      Math.abs(countdownMaterial.opacity - countdownOpacityBaseline)
+    ).toBeGreaterThan(MIN_DELTA);
+    expect(
+      Math.abs(countdownPanel.scale.y - countdownScaleBaseline)
+    ).toBeGreaterThan(MIN_DELTA);
+  });
+
+  it('honors reduced pulse scale accessibility preferences', () => {
+    const basePosition = new Vector3(0, 0, 0);
+
+    document.documentElement.dataset.accessibilityPulseScale = '1';
+    const fullPulse = createModelRocket({ basePosition });
+    fullPulse.update({ elapsed: 2.1, delta: 0.016 });
+    const fullLight = fullPulse.group.getObjectByName(
+      'ModelRocketThrusterLight'
+    ) as PointLight;
+    const fullFlame = fullPulse.group.getObjectByName(
+      'ModelRocketThrusterFlame'
+    ) as Mesh<MeshBasicMaterial>;
+    const fullCountdown = fullPulse.group.getObjectByName(
+      'ModelRocketCountdownPanel'
+    ) as Mesh<MeshBasicMaterial>;
+
+    document.documentElement.dataset.accessibilityPulseScale = '0';
+    const reducedPulse = createModelRocket({ basePosition });
+    reducedPulse.update({ elapsed: 2.1, delta: 0.016 });
+    const reducedLight = reducedPulse.group.getObjectByName(
+      'ModelRocketThrusterLight'
+    ) as PointLight;
+    const reducedFlame = reducedPulse.group.getObjectByName(
+      'ModelRocketThrusterFlame'
+    ) as Mesh<MeshBasicMaterial>;
+    const reducedCountdown = reducedPulse.group.getObjectByName(
+      'ModelRocketCountdownPanel'
+    ) as Mesh<MeshBasicMaterial>;
+
+    expect(reducedLight.intensity).toBeLessThanOrEqual(fullLight.intensity);
+    expect(
+      (reducedFlame.material as MeshBasicMaterial).opacity
+    ).toBeLessThanOrEqual((fullFlame.material as MeshBasicMaterial).opacity);
+    expect(
+      (reducedCountdown.material as MeshBasicMaterial).opacity
+    ).toBeLessThanOrEqual(
+      (fullCountdown.material as MeshBasicMaterial).opacity
+    );
+    expect(reducedCountdown.scale.y).toBeLessThanOrEqual(fullCountdown.scale.y);
   });
 });


### PR DESCRIPTION
## Summary
- animate the DSPACE model rocket with a pulsing thruster light, flame, and countdown halo that respect accessibility presets
- wire the backyard environment update loop to drive the rocket animation and mark the roadmap milestone as complete
- expand rocket-focused unit tests and backyard environment coverage for the new interactions

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f200dda4fc832f9d47e157087382e6