### PR TITLE
Add language metadata to POI structured data

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -188,6 +188,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
      browsers to the text experience unless the immersive override is set.
    - ✅ Manual mode toggle now exposes an active state with aria-pressed so assistive tech
      announces when the text tour is engaged.
+   - ✨ JSON-LD exhibit feeds now include `inLanguage` and `isAccessibleForFree` metadata so
+     crawlers understand language coverage and free access guarantees.
 3. **Progression & State**
    - Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
      - ✅ SessionStorage fallback now protects POI progress when localStorage is blocked.

--- a/src/scene/poi/structuredData.ts
+++ b/src/scene/poi/structuredData.ts
@@ -118,6 +118,8 @@ export const buildPoiStructuredData = (
       description: poi.summary,
       identifier: poi.id,
       keywords: [poi.category, poi.roomId],
+      inLanguage: locale,
+      isAccessibleForFree: true,
       additionalProperty,
     };
 
@@ -138,6 +140,8 @@ export const buildPoiStructuredData = (
     '@type': 'ItemList',
     name: listName,
     description,
+    inLanguage: locale,
+    isAccessibleForFree: true,
     itemListOrder: 'https://schema.org/ItemListOrderAscending',
     itemListElement,
   };

--- a/src/tests/poiStructuredData.test.ts
+++ b/src/tests/poiStructuredData.test.ts
@@ -55,6 +55,8 @@ describe('buildPoiStructuredData', () => {
       name: 'Immersive Portfolio Exhibits',
       description:
         'Interactive exhibits within the Daniel Smith immersive portfolio experience.',
+      inLanguage: 'en',
+      isAccessibleForFree: true,
       itemListOrder: 'https://schema.org/ItemListOrderAscending',
     });
 
@@ -79,6 +81,8 @@ describe('buildPoiStructuredData', () => {
       identifier: 'tokenplace-studio-cluster',
       keywords: ['project', 'studio'],
       sameAs: ['https://example.com/repo'],
+      inLanguage: 'en',
+      isAccessibleForFree: true,
     });
 
     const additionalProperty = firstItem.additionalProperty as Array<
@@ -103,9 +107,23 @@ describe('buildPoiStructuredData', () => {
     });
     const secondItem = second.item as Record<string, unknown>;
     expect(secondItem).not.toHaveProperty('sameAs');
+    expect(secondItem).toMatchObject({
+      inLanguage: 'en',
+      isAccessibleForFree: true,
+    });
     expect(secondItem.additionalProperty).toEqual([
       { '@type': 'PropertyValue', name: 'Category', value: 'project' },
     ]);
+  });
+
+  it('honors locale overrides when emitting language metadata', () => {
+    const data = buildPoiStructuredData([createPoi()], {
+      locale: 'en-x-pseudo',
+    });
+
+    expect(data.inLanguage).toBe('en-x-pseudo');
+    const items = data.itemListElement as Array<Record<string, unknown>>;
+    expect(items[0]?.item).toMatchObject({ inLanguage: 'en-x-pseudo' });
   });
 });
 
@@ -129,6 +147,8 @@ describe('injectPoiStructuredData', () => {
 
     const parsed = JSON.parse(firstScript.textContent ?? '{}');
     expect(parsed.name).toBe('Immersive Portfolio Exhibits');
+    expect(parsed.inLanguage).toBe('en');
+    expect(parsed.isAccessibleForFree).toBe(true);
 
     const secondScript = injectPoiStructuredData(pois, {
       documentTarget,


### PR DESCRIPTION
what: Tag POI structured data with language/access metadata.
why: Improve SEO clarity for crawlers reading the exhibit feed.
how to test: npm run lint && npm run test:ci
  npm run docs:check && npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f32fd50b9c832f875aaff5c7b29419