### PR TITLE
Add orbiting data shards around Jobbot terminal

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,6 +133,8 @@ Focus: anchor each highlighted project with an interactive artifact.
      orbitals, and an activation-driven tech stack + docs callout panel.
    - ✅ Studio Jobbot terminal desk now projects live automation telemetry via orbiting data
      shards and anchors the Jobbot3000 POI with reactive lighting and diagnostics beacons.
+     - ✨ Orbiting data shards now sync their emissive sweeps with visitor emphasis pulses,
+       echoing the HUD analytics glow rhythm.
    - ✨ Axel quest navigator tabletop now charts backlog quests with holographic rings and
      momentum beacons around the studio tracker POI.
    - ✨ Gitshelves living room array now tessellates commit shelves with streak-reactive glow

--- a/src/tests/jobbotTerminal.test.ts
+++ b/src/tests/jobbotTerminal.test.ts
@@ -77,6 +77,15 @@ describe('JobbotTerminal structure', () => {
       build.group.getObjectByName('JobbotTerminalHologram')
     ).toBeInstanceOf(Group);
 
+    const shardGroup = build.group.getObjectByName(
+      'JobbotTerminalDataShards'
+    ) as Group;
+    expect(shardGroup).toBeInstanceOf(Group);
+    expect(shardGroup.children).toHaveLength(6);
+    shardGroup.children.forEach((child) => {
+      expect(child).toBeInstanceOf(Mesh);
+    });
+
     const telemetryGroup = build.group.getObjectByName(
       'JobbotTerminalTelemetryGroup'
     ) as Group;
@@ -103,11 +112,15 @@ describe('JobbotTerminal structure', () => {
     const telemetryPanel = build.group.getObjectByName(
       'JobbotTerminalTelemetry-0'
     ) as Mesh;
+    const shard = build.group.getObjectByName(
+      'JobbotTerminalDataShard-0'
+    ) as Mesh;
 
     const screenMaterial = screen.material as MeshBasicMaterial;
     const coreMaterial = hologramCore.material as MeshStandardMaterial;
     const tickerMaterial = ticker.material as MeshBasicMaterial;
     const telemetryMaterial = telemetryPanel.material as MeshBasicMaterial;
+    const shardMaterial = shard.material as MeshStandardMaterial;
 
     build.update({ elapsed: 0, delta: 0.016, emphasis: 0 });
     const initialScreenOpacity = screenMaterial.opacity;
@@ -115,6 +128,9 @@ describe('JobbotTerminal structure', () => {
     const initialTickerOpacity = tickerMaterial.opacity;
     const initialTelemetryOpacity = telemetryMaterial.opacity;
     const initialTelemetryRotation = telemetryGroup.rotation.y;
+    const initialShardPosition = shard.position.clone();
+    const initialShardIntensity = shardMaterial.emissiveIntensity;
+    const initialShardOpacity = shardMaterial.opacity;
 
     build.update({ elapsed: 1.5, delta: 0.016, emphasis: 1 });
     expect(screenMaterial.opacity).toBeGreaterThanOrEqual(initialScreenOpacity);
@@ -126,6 +142,13 @@ describe('JobbotTerminal structure', () => {
       initialTelemetryOpacity
     );
     expect(telemetryGroup.rotation.y).toBeGreaterThan(initialTelemetryRotation);
+    expect(shard.position.distanceTo(initialShardPosition)).toBeGreaterThan(
+      0.001
+    );
+    expect(shardMaterial.emissiveIntensity).toBeGreaterThan(
+      initialShardIntensity
+    );
+    expect(shardMaterial.opacity).toBeGreaterThanOrEqual(initialShardOpacity);
   });
 
   it('reduces hologram flicker when pulse scale is disabled', () => {
@@ -137,14 +160,19 @@ describe('JobbotTerminal structure', () => {
     const telemetryPanel = build.group.getObjectByName(
       'JobbotTerminalTelemetry-1'
     ) as Mesh;
+    const shard = build.group.getObjectByName(
+      'JobbotTerminalDataShard-1'
+    ) as Mesh;
 
     expect(ticker).toBeInstanceOf(Mesh);
     expect(beacon).toBeInstanceOf(Mesh);
     expect(telemetryPanel).toBeInstanceOf(Mesh);
+    expect(shard).toBeInstanceOf(Mesh);
 
     const tickerMaterial = ticker.material as MeshBasicMaterial;
     const beaconMaterial = (beacon!.material as MeshStandardMaterial)!;
     const telemetryMaterial = telemetryPanel.material as MeshBasicMaterial;
+    const shardMaterial = shard.material as MeshStandardMaterial;
 
     document.documentElement.dataset.accessibilityPulseScale = '0';
 
@@ -153,6 +181,9 @@ describe('JobbotTerminal structure', () => {
     const steadyBeacon = beaconMaterial.emissiveIntensity;
     const steadyHeight = beacon!.position.y;
     const steadyTelemetry = telemetryMaterial.opacity;
+    const steadyShardPosition = shard.position.clone();
+    const steadyShardIntensity = shardMaterial.emissiveIntensity;
+    const steadyShardOpacity = shardMaterial.opacity;
 
     build.update({ elapsed: 1.6, delta: 0.016, emphasis: 0.6 });
 
@@ -160,5 +191,11 @@ describe('JobbotTerminal structure', () => {
     expect(beaconMaterial.emissiveIntensity).toBeCloseTo(steadyBeacon, 5);
     expect(beacon!.position.y).toBeCloseTo(steadyHeight, 5);
     expect(telemetryMaterial.opacity).toBeCloseTo(steadyTelemetry, 5);
+    expect(shard.position.distanceTo(steadyShardPosition)).toBeLessThan(0.002);
+    expect(shardMaterial.emissiveIntensity).toBeCloseTo(
+      steadyShardIntensity,
+      5
+    );
+    expect(shardMaterial.opacity).toBeCloseTo(steadyShardOpacity, 5);
   });
 });


### PR DESCRIPTION
## Summary
- add emissive data shards around the Jobbot terminal hologram with emphasis-driven animation curves
- pause shard orbit and bobbing when accessibility pulse scale disables motion and cover the new behaviour in unit tests
- note the synced shard sweep in the roadmap slice for the Jobbot POI

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f32fd50b9c832f875aaff5c7b29419