### PR TITLE
Add data-saver heuristics to mode failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ Keep pipelines deterministic by regenerating assets immediately after touching g
 - **Help** – Use the help key (default `H` or `?`), or tap the HUD Help button to
   open a modal with controls, accessibility tips, and failover guidance.
 - **Failover** – Append `?mode=text` to the URL to load the lightweight text view.
-  Automatic detection now covers missing WebGL support and sustained frame rates below 30 FPS;
+  Automatic detection now covers missing WebGL support, sustained frame rates below 30 FPS,
+  data-saver preferences, and slow 2G network hints;
   share preview links as `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`
   (swap host/port as needed) to force the full scene even on throttled preview clients.
   Screen readers now announce each switch so assistive technology users know which mode is active.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,6 +186,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
      portfolio while honoring manual immersive overrides.
    - ✅ WebDriver automation heuristics now check `navigator.webdriver` and steer scripted
      browsers to the text experience unless the immersive override is set.
+   - ✅ Data-saver detection now honors Save-Data and slow 2G hints by launching the text tour
+     unless immersive mode is explicitly forced.
    - ✅ Manual mode toggle now exposes an active state with aria-pressed so assistive tech
      announces when the text tour is engaged.
 3. **Progression & State**

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -15,6 +15,15 @@ type WebglContextName = (typeof WEBGL_CONTEXT_NAMES)[number];
 type DeviceMemoryReader = () => number | undefined;
 type UserAgentReader = () => string | undefined;
 type WebDriverReader = () => boolean | undefined;
+type NetworkInformationReader = () =>
+  | NetworkInformationSnapshot
+  | null
+  | undefined;
+
+interface NetworkInformationSnapshot {
+  saveData?: boolean;
+  effectiveType?: string | null;
+}
 
 export type FallbackReason =
   | 'webgl-unsupported'
@@ -23,7 +32,8 @@ export type FallbackReason =
   | 'low-performance'
   | 'immersive-init-error'
   | 'automated-client'
-  | 'console-error';
+  | 'console-error'
+  | 'data-saver';
 
 export interface WebglSupportOptions {
   createCanvas?: () => HTMLCanvasElement;
@@ -68,6 +78,7 @@ export interface FailoverDecisionOptions extends WebglSupportOptions {
   minimumDeviceMemory?: number;
   getUserAgent?: UserAgentReader;
   getIsWebDriver?: WebDriverReader;
+  getNetworkInformation?: NetworkInformationReader;
 }
 
 export interface FailoverDecision {
@@ -81,6 +92,16 @@ interface NavigatorWithDeviceMemory extends Navigator {
 
 type NavigatorWithUserAgent = Navigator & { userAgent?: string };
 type NavigatorWithWebDriver = Navigator & { webdriver?: boolean };
+type NavigatorWithConnection = Navigator & {
+  connection?: NetworkInformationLike;
+  mozConnection?: NetworkInformationLike;
+  webkitConnection?: NetworkInformationLike;
+};
+
+type NetworkInformationLike = {
+  saveData?: boolean;
+  effectiveType?: string | null;
+} | null;
 
 function getNavigatorDeviceMemory(): number | undefined {
   if (typeof navigator === 'undefined') {
@@ -108,6 +129,40 @@ function getNavigatorWebDriver(): boolean | undefined {
   }
   const reported = (navigator as NavigatorWithWebDriver).webdriver;
   return typeof reported === 'boolean' ? reported : undefined;
+}
+
+function normalizeNetworkInformation(
+  info: NetworkInformationLike
+): NetworkInformationSnapshot | undefined {
+  if (!info || typeof info !== 'object') {
+    return undefined;
+  }
+  const saveData = info.saveData === true;
+  const effectiveType =
+    typeof info.effectiveType === 'string' && info.effectiveType.length > 0
+      ? info.effectiveType
+      : undefined;
+  if (!saveData && !effectiveType) {
+    return undefined;
+  }
+  return {
+    saveData,
+    effectiveType,
+  } satisfies NetworkInformationSnapshot;
+}
+
+function getNavigatorNetworkInformation():
+  | NetworkInformationSnapshot
+  | undefined {
+  if (typeof navigator === 'undefined') {
+    return undefined;
+  }
+  const candidate =
+    (navigator as NavigatorWithConnection).connection ??
+    (navigator as NavigatorWithConnection).mozConnection ??
+    (navigator as NavigatorWithConnection).webkitConnection ??
+    null;
+  return normalizeNetworkInformation(candidate);
 }
 
 const AUTOMATED_CLIENT_PATTERNS: ReadonlyArray<RegExp> = [
@@ -158,6 +213,16 @@ export function evaluateFailoverDecision(
   const automatedByUserAgent =
     !!userAgent && shouldForceTextModeForUserAgent(userAgent);
 
+  const readNetworkInformation =
+    options.getNetworkInformation ?? getNavigatorNetworkInformation;
+  const networkInformation = readNetworkInformation() ?? undefined;
+  const prefersReducedData = networkInformation?.saveData === true;
+  const effectiveType = networkInformation?.effectiveType;
+  const normalizedEffectiveType =
+    typeof effectiveType === 'string' ? effectiveType.toLowerCase() : undefined;
+  const hasSlowConnection =
+    normalizedEffectiveType === 'slow-2g' || normalizedEffectiveType === '2g';
+
   if (mode === 'text') {
     return { shouldUseFallback: true, reason: 'manual' };
   }
@@ -178,6 +243,13 @@ export function evaluateFailoverDecision(
 
   if (hasLowMemory) {
     return { shouldUseFallback: true, reason: 'low-memory' };
+  }
+
+  if (
+    (!mode || mode.length === 0) &&
+    (prefersReducedData || hasSlowConnection)
+  ) {
+    return { shouldUseFallback: true, reason: 'data-saver' };
   }
 
   return { shouldUseFallback: false };
@@ -242,6 +314,8 @@ export function renderTextFallback(
         return 'We detected an automated client, so we surfaced the fast-loading text portfolio for reliable previews and crawlers.';
       case 'console-error':
         return 'We detected a runtime error and switched to the resilient text tour while the immersive scene recovers.';
+      case 'data-saver':
+        return 'Your browser requested a data-saver experience, so we launched the lightweight text tour to minimize bandwidth while keeping the highlights accessible.';
       default:
         return 'You requested the lightweight portfolio view. The immersive scene stays just a click away.';
     }

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -100,12 +100,94 @@ describe('evaluateFailoverDecision', () => {
     });
   });
 
+  it('routes data-saver clients to text mode when mode is not forced', () => {
+    const decision = evaluateFailoverDecision({
+      createCanvas: canvasFactory,
+      getNetworkInformation: () => ({ saveData: true }),
+    });
+    expect(decision).toEqual({
+      shouldUseFallback: true,
+      reason: 'data-saver',
+    });
+  });
+
+  it('reads save-data hints from navigator.connection when available', () => {
+    const original = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      'connection'
+    );
+    Object.defineProperty(window.navigator, 'connection', {
+      configurable: true,
+      value: { saveData: true },
+    });
+
+    const decision = evaluateFailoverDecision({
+      createCanvas: canvasFactory,
+    });
+
+    expect(decision).toEqual({
+      shouldUseFallback: true,
+      reason: 'data-saver',
+    });
+
+    if (original) {
+      Object.defineProperty(window.navigator, 'connection', original);
+    } else {
+      delete (window.navigator as Navigator & { connection?: unknown })
+        .connection;
+    }
+  });
+
+  it('ignores navigator.connection when no data-saver hints are present', () => {
+    const original = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      'connection'
+    );
+    Object.defineProperty(window.navigator, 'connection', {
+      configurable: true,
+      value: {},
+    });
+
+    const decision = evaluateFailoverDecision({
+      createCanvas: canvasFactory,
+    });
+
+    expect(decision).toEqual({ shouldUseFallback: false });
+
+    if (original) {
+      Object.defineProperty(window.navigator, 'connection', original);
+    } else {
+      delete (window.navigator as Navigator & { connection?: unknown })
+        .connection;
+    }
+  });
+
+  it('routes slow connections to text mode when mode is not forced', () => {
+    const decision = evaluateFailoverDecision({
+      createCanvas: canvasFactory,
+      getNetworkInformation: () => ({ effectiveType: 'slow-2g' }),
+    });
+    expect(decision).toEqual({
+      shouldUseFallback: true,
+      reason: 'data-saver',
+    });
+  });
+
   it('allows immersive override when memory is low but WebGL works', () => {
     const decision = evaluateFailoverDecision({
       search: IMMERSIVE_SEARCH,
       createCanvas: canvasFactory,
       getDeviceMemory: () => 0.25,
       minimumDeviceMemory: 1,
+    });
+    expect(decision).toEqual({ shouldUseFallback: false });
+  });
+
+  it('respects immersive override even when data-saver is active', () => {
+    const decision = evaluateFailoverDecision({
+      search: IMMERSIVE_SEARCH,
+      createCanvas: canvasFactory,
+      getNetworkInformation: () => ({ saveData: true }),
     });
     expect(decision).toEqual({ shouldUseFallback: false });
   });
@@ -214,6 +296,14 @@ describe('renderTextFallback', () => {
     expect(section?.getAttribute('data-reason')).toBe('low-performance');
     const description = container.querySelector('.text-fallback__description');
     expect(description?.textContent).toMatch(/frame/);
+  });
+
+  it('highlights data-saver fallback messaging', () => {
+    const container = render('data-saver');
+    const section = container.querySelector('.text-fallback');
+    expect(section?.getAttribute('data-reason')).toBe('data-saver');
+    const description = container.querySelector('.text-fallback__description');
+    expect(description?.textContent).toMatch(/data-saver|bandwidth/i);
   });
 
   it('describes automated client fallback messaging', () => {


### PR DESCRIPTION
## Summary
- route Save-Data and slow-2G clients to the text tour when no override is set
- surface data-saver messaging in the fallback view and document the roadmap win
- cover the heuristics with vitest cases, including navigator.connection shims

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f32fd50b9c832f875aaff5c7b29419