### PR TITLE
Ensure text fallback immersive link uses override URL

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -194,6 +194,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
      announces when the text tour is engaged.
    - ✨ JSON-LD exhibit feeds now include `inLanguage` and `isAccessibleForFree` metadata so
      crawlers understand language coverage and free access guarantees.
+   - ✅ Text fallback links back to immersive mode with the override URL so returns bypass
+     automatic failover heuristics.
 3. **Progression & State**
    - Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
      - ✅ SessionStorage fallback now protects POI progress when localStorage is blocked.

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -1,5 +1,6 @@
 import { getLocaleDirection } from '../../assets/i18n';
 import { initializeModeAnnouncementObserver } from '../../ui/accessibility/modeAnnouncer';
+import { createImmersiveModeUrl } from '../../ui/immersiveUrl';
 
 if (
   typeof document !== 'undefined' &&
@@ -309,14 +310,18 @@ export interface RenderTextFallbackOptions {
 
 export function renderTextFallback(
   container: HTMLElement,
-  {
+  options: RenderTextFallbackOptions
+): void {
+  const {
     reason,
-    immersiveUrl = window.location.pathname,
     resumeUrl = 'docs/resume/2025-09/resume.pdf',
     githubUrl = 'https://github.com/futuroptimist',
-  }: RenderTextFallbackOptions
-): void {
+    immersiveUrl: providedImmersiveUrl,
+  } = options;
   const documentTarget = container.ownerDocument ?? document;
+  const immersiveUrl =
+    providedImmersiveUrl ??
+    createImmersiveModeUrl(documentTarget.defaultView?.location ?? undefined);
   const localeHint =
     documentTarget.documentElement.lang ||
     (typeof navigator !== 'undefined' ? navigator.language : undefined);


### PR DESCRIPTION
## Summary
- default the text fallback immersive link to use createImmersiveModeUrl so return visits force immersive mode
- document the experience toggle milestone with the new fallback behavior
- cover the default and override link cases in renderTextFallback tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f3394b23e4832f9b781a54ea47d69b