### PR TITLE
Add HUD interact prompt announcements

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -170,6 +170,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - Responsive overlay with movement legend, interaction prompt, and help modal.
    - ✨ Movement legend now detects the last input method (keyboard, mouse, or touch) and
      refreshes the interact prompt copy so players always see the relevant control hint.
+   - ✅ Movement legend now updates HUD screen reader announcements whenever interact prompts
+     change, keeping keyboard and assistive tech guidance aligned with on-screen cues.
    - ✅ Help modal opens from the HUD button or `H`/`?` hotkeys and surfaces controls,
      accessibility tips, and failover guidance.
    - ✅ Accessibility HUD presets now expose Standard, Calm, and Photosensitive-safe modes

--- a/src/tests/movementLegend.test.ts
+++ b/src/tests/movementLegend.test.ts
@@ -166,16 +166,26 @@ describe('createMovementLegend', () => {
       'Interact with Futuroptimist'
     );
     expect(interactLabel?.textContent).toBe('F');
+    expect(interactItem?.dataset.hudAnnounce).toBe(
+      'F — Interact with Futuroptimist'
+    );
 
     legend.setActiveMethod('touch');
     expect(interactLabel?.textContent).toBe('Tap');
+    expect(interactItem?.dataset.hudAnnounce).toBe(
+      'Tap — Interact with Futuroptimist'
+    );
 
     legend.setActiveMethod('gamepad');
     expect(interactLabel?.textContent).toBe('A');
+    expect(interactItem?.dataset.hudAnnounce).toBe(
+      'A — Interact with Futuroptimist'
+    );
 
     legend.setInteractPrompt(null);
     expect(interactItem?.hidden).toBe(true);
     expect(interactDescription?.textContent).toBe('Interact');
+    expect(interactItem?.dataset.hudAnnounce).toBeUndefined();
 
     legend.dispose();
   });
@@ -306,6 +316,7 @@ describe('createMovementLegend', () => {
     );
     expect(interactItem?.hidden).toBe(true);
     expect(interactDescription?.textContent).toBe('Interact');
+    expect(interactItem?.dataset.hudAnnounce).toBeUndefined();
 
     dispatchPointerEvent(window, 'touch');
     expect(legend.getActiveMethod()).toBe('pointer');


### PR DESCRIPTION
## Summary
- add movement legend helpers to compose HUD announcements
- update unit tests for the interact legend dataset metadata
- document the screen reader upgrade on the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f47e5f4e78832f98c7adf9a71ed511