### PR TITLE
Add canonical publisher metadata to POI structured data

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -183,6 +183,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - Mode switch between immersive 3D view and a fast-loading text portfolio.
    - ✅ Detect low-end/no-JS/scraper clients and auto-route to static mode.
    - Share canonical content via structured data (JSON-LD) for SEO and bots.
+   - ✅ JSON-LD ItemList now advertises canonical site URLs plus publisher/author metadata.
+     Logo references ensure search surfaces attribute exhibits correctly.
    - ✅ JSON-LD structured data now mirrors the POI registry so bots and scrapers receive the
      same exhibit catalog as players.
    - ✅ HUD toggle + `T` keybinding now trigger the text portfolio without a page reload.

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -8,6 +8,17 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       description:
         'Interactive exhibits within the Daniel Smith immersive portfolio experience.',
       listNameTemplate: '{siteName} Exhibits',
+      publisher: {
+        name: 'Daniel Smith',
+        url: 'https://danielsmith.io/',
+        type: 'Person',
+        logoUrl: 'https://danielsmith.io/favicon.ico',
+      },
+      author: {
+        name: 'Daniel Smith',
+        url: 'https://danielsmith.io/',
+        type: 'Person',
+      },
     },
   },
   hud: {

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -69,9 +69,20 @@ export interface PoiNarrativeLogStrings {
   liveAnnouncementTemplate: string;
 }
 
+export type StructuredDataEntityType = 'Person' | 'Organization';
+
+export interface SiteStructuredDataEntityStrings {
+  name: string;
+  url?: string;
+  type?: StructuredDataEntityType;
+  logoUrl?: string;
+}
+
 export interface SiteStructuredDataStrings {
   description: string;
   listNameTemplate: string;
+  publisher: SiteStructuredDataEntityStrings;
+  author: SiteStructuredDataEntityStrings;
 }
 
 export interface SiteStrings {

--- a/src/scene/poi/structuredData.ts
+++ b/src/scene/poi/structuredData.ts
@@ -1,4 +1,8 @@
-import type { LocaleInput } from '../../assets/i18n';
+import type {
+  LocaleInput,
+  SiteStructuredDataEntityStrings,
+  StructuredDataEntityType,
+} from '../../assets/i18n';
 import {
   formatMessage,
   getSiteStrings,
@@ -9,11 +13,25 @@ import type { PoiDefinition } from './types';
 
 const DEFAULT_CANONICAL_URL = 'https://danielsmith.io/';
 const SCRIPT_ELEMENT_ID = 'danielsmith-portfolio-pois-structured-data';
+const ITEM_LIST_FRAGMENT = '#immersive-poi-list';
+
+const stripFragmentAndQuery = (value: string): string => {
+  return value.replace(/[#?].*$/, '');
+};
+
+const stripIndexDocument = (value: string): string => {
+  return value.replace(/index\.html?\/?$/i, '');
+};
+
+export interface StructuredDataEntityOverride
+  extends Partial<SiteStructuredDataEntityStrings> {}
 
 export interface PoiStructuredDataOptions {
   canonicalUrl?: string;
   siteName?: string;
   locale?: LocaleInput;
+  publisher?: StructuredDataEntityOverride;
+  author?: StructuredDataEntityOverride;
 }
 
 export interface InjectPoiStructuredDataOptions
@@ -46,22 +64,112 @@ const normalizeCanonicalUrl = (
   fallback: string
 ): string => {
   const base = fallback || DEFAULT_CANONICAL_URL;
+  const sanitize = (value: string): string => {
+    return ensureTrailingSlash(stripIndexDocument(value));
+  };
   if (!canonicalUrl) {
-    return ensureTrailingSlash(base.replace(/[#?].*$/, ''));
+    return sanitize(stripFragmentAndQuery(base));
   }
   try {
     const parsed = new URL(canonicalUrl, base);
     parsed.hash = '';
     parsed.search = '';
-    return ensureTrailingSlash(parsed.toString());
+    return sanitize(parsed.toString());
   } catch (error) {
     console.warn('Invalid canonical URL provided for structured data.', error);
-    return ensureTrailingSlash(base.replace(/[#?].*$/, ''));
+    return sanitize(stripFragmentAndQuery(base));
   }
 };
 
 const createPoiUrl = (canonical: string, poiId: string): string => {
   return `${canonical}#poi-${poiId}`;
+};
+
+const isNonEmptyString = (value: unknown): value is string => {
+  return typeof value === 'string' && value.trim().length > 0;
+};
+
+const normalizeEntityType = (
+  type: StructuredDataEntityType | string | undefined
+): StructuredDataEntityType => {
+  return type === 'Organization' ? 'Organization' : 'Person';
+};
+
+const sanitizeOptionalString = (
+  value: string | undefined
+): string | undefined => {
+  if (!isNonEmptyString(value)) {
+    return undefined;
+  }
+  return value.trim();
+};
+
+const mergeEntityDefinition = (
+  base: SiteStructuredDataEntityStrings | undefined,
+  override?: StructuredDataEntityOverride
+): SiteStructuredDataEntityStrings | null => {
+  const name =
+    sanitizeOptionalString(override?.name) ??
+    sanitizeOptionalString(base?.name);
+  if (!name) {
+    return null;
+  }
+
+  const url =
+    sanitizeOptionalString(override?.url) ?? sanitizeOptionalString(base?.url);
+  const logoUrl =
+    sanitizeOptionalString(override?.logoUrl) ??
+    sanitizeOptionalString(base?.logoUrl);
+  const type = normalizeEntityType(override?.type ?? base?.type);
+
+  return { name, url, logoUrl, type };
+};
+
+type EntitySchema = {
+  '@type': StructuredDataEntityType;
+  name: string;
+  url?: string;
+  '@id'?: string;
+  logo?: { '@type': 'ImageObject'; url: string };
+};
+
+const createEntitySchema = (
+  definition: SiteStructuredDataEntityStrings
+): EntitySchema => {
+  const entity: EntitySchema = {
+    '@type': normalizeEntityType(definition.type),
+    name: definition.name,
+  };
+  if (definition.url) {
+    entity.url = definition.url;
+    entity['@id'] = definition.url;
+  }
+  if (definition.logoUrl) {
+    entity.logo = {
+      '@type': 'ImageObject',
+      url: definition.logoUrl,
+    };
+  }
+  return entity;
+};
+
+const createEntityReference = (
+  entity: EntitySchema | null
+): Record<string, string> | undefined => {
+  if (!entity) {
+    return undefined;
+  }
+  const id = entity['@id'];
+  if (isNonEmptyString(id)) {
+    return { '@id': id };
+  }
+  if (isNonEmptyString(entity.name)) {
+    return {
+      '@type': entity['@type'],
+      name: entity.name,
+    };
+  }
+  return undefined;
 };
 
 export const buildPoiStructuredData = (
@@ -79,6 +187,32 @@ export const buildPoiStructuredData = (
     siteName,
   });
   const description = siteStrings.structuredData.description;
+  const listId = `${canonical}${ITEM_LIST_FRAGMENT}`;
+
+  const publisherDefinition = mergeEntityDefinition(
+    siteStrings.structuredData.publisher,
+    options.publisher
+  );
+  const authorDefinition = mergeEntityDefinition(
+    siteStrings.structuredData.author,
+    options.author
+  );
+  const publisherEntity = publisherDefinition
+    ? createEntitySchema(publisherDefinition)
+    : null;
+  const authorEntity = authorDefinition
+    ? createEntitySchema(authorDefinition)
+    : null;
+  const publisherReference = createEntityReference(publisherEntity);
+  const authorReference = createEntityReference(authorEntity);
+
+  const siteEntry: Record<string, unknown> = {
+    '@type': 'WebSite',
+    '@id': canonical,
+    name: siteName,
+    url: canonical,
+    inLanguage: locale,
+  };
 
   const itemListElement: ListItem[] = pois.map((poi, index) => {
     const poiUrl = createPoiUrl(canonical, poi.id);
@@ -127,6 +261,16 @@ export const buildPoiStructuredData = (
       item.sameAs = sameAs;
     }
 
+    if (publisherReference) {
+      item.publisher = publisherReference;
+      item.provider = publisherReference;
+    }
+    if (authorReference) {
+      item.author = authorReference;
+      item.creator = authorReference;
+    }
+    item.isPartOf = { '@type': 'ItemList', '@id': listId };
+
     return {
       '@type': 'ListItem',
       position: index + 1,
@@ -135,16 +279,29 @@ export const buildPoiStructuredData = (
     } satisfies ListItem;
   });
 
-  return {
+  const structuredData: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
+    '@id': listId,
+    url: canonical,
     name: listName,
     description,
     inLanguage: locale,
     isAccessibleForFree: true,
     itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    isPartOf: siteEntry,
     itemListElement,
   };
+  if (publisherEntity) {
+    structuredData.publisher = publisherEntity;
+    structuredData.provider = publisherEntity;
+  }
+  if (authorEntity) {
+    structuredData.author = authorEntity;
+    structuredData.creator = authorEntity;
+  }
+
+  return structuredData;
 };
 
 export const injectPoiStructuredData = (
@@ -172,6 +329,8 @@ export const injectPoiStructuredData = (
     canonicalUrl: canonical,
     siteName: options.siteName,
     locale: options.locale,
+    publisher: options.publisher,
+    author: options.author,
   });
 
   const existing = documentTarget.getElementById(SCRIPT_ELEMENT_ID);
@@ -193,4 +352,5 @@ export const _testables = {
   normalizeCanonicalUrl,
   createPoiUrl,
   SCRIPT_ELEMENT_ID,
+  ITEM_LIST_FRAGMENT,
 };

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -93,5 +93,14 @@ describe('i18n utilities', () => {
     expect(pseudoSite.structuredData.description).toBe(
       '⟦Interactive exhibits within the Daniel Smith immersive portfolio experience.⟧'
     );
+    expect(pseudoSite.structuredData.publisher.name).toBe(
+      englishSite.structuredData.publisher.name
+    );
+    expect(pseudoSite.structuredData.publisher.url).toBe(
+      englishSite.structuredData.publisher.url
+    );
+    expect(pseudoSite.structuredData.author.name).toBe(
+      englishSite.structuredData.author.name
+    );
   });
 });


### PR DESCRIPTION
## Summary
- extend the structured data builder to expose canonical site, publisher, and author metadata with logo references
- add locale strings, tests, and roadmap note covering the enhanced JSON-LD feed

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f47e5f4e78832f98c7adf9a71ed511