### PR TITLE
Sync flywheel callout with POI selection gating

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -122,6 +122,8 @@ Focus: anchor each highlighted project with an interactive artifact.
      faster, reveals tech stack, and links to docs.
      - ✨ Orbiting tech-stack chips now fade in with POI emphasis and highlight automation
        pillars around the rotor.
+     - ✅ Docs callout glow now locks to POI selection, syncing rotor surges with interaction
+       intent and spotlighting the flywheel docs CTA.
    - ✅ Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
    - ✨ f2clipboard incident console now elevates the kitchen diagnostics POI with a
      holographic log ticker, clipboard callouts, and ambient halo lighting.


### PR DESCRIPTION
## Summary
- gate the flywheel showpiece rotor, docs callout, and tech stack chips to POI selection events
- subscribe to analytics events so the hologram glow fades when visitors disengage
- cover the new behaviour with flywheel showpiece tests and note the selection gating in the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f47e5f4e78832f98c7adf9a71ed511