### PR TITLE
Add text portfolio structured data feed

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
 2. **Experience Toggle**
    - Mode switch between immersive 3D view and a fast-loading text portfolio.
    - ✅ Detect low-end/no-JS/scraper clients and auto-route to static mode.
-   - Share canonical content via structured data (JSON-LD) for SEO and bots.
+   - ✅ Share canonical content via structured data (JSON-LD) for SEO and bots.
    - ✅ JSON-LD ItemList now advertises canonical site URLs plus publisher/author metadata.
      Logo references ensure search surfaces attribute exhibits correctly.
    - ✅ JSON-LD structured data now mirrors the POI registry so bots and scrapers receive the

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -8,6 +8,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       description:
         'Interactive exhibits within the Daniel Smith immersive portfolio experience.',
       listNameTemplate: '{siteName} Exhibits',
+      textCollectionNameTemplate: '{siteName} Text Portfolio',
+      textCollectionDescription:
+        'Fast-loading summaries of every immersive exhibit tuned for accessible and crawler-friendly reading.',
+      immersiveActionName: 'Launch immersive mode',
       publisher: {
         name: 'Daniel Smith',
         url: 'https://danielsmith.io/',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -81,6 +81,9 @@ export interface SiteStructuredDataEntityStrings {
 export interface SiteStructuredDataStrings {
   description: string;
   listNameTemplate: string;
+  textCollectionNameTemplate: string;
+  textCollectionDescription: string;
+  immersiveActionName: string;
   publisher: SiteStructuredDataEntityStrings;
   author: SiteStructuredDataEntityStrings;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,10 @@ import {
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
 import { getPoiDefinitions } from './scene/poi/registry';
-import { injectPoiStructuredData } from './scene/poi/structuredData';
+import {
+  injectPoiStructuredData,
+  injectTextPortfolioStructuredData,
+} from './scene/poi/structuredData';
 import { PoiTooltipOverlay } from './scene/poi/tooltipOverlay';
 import { PoiTourGuide } from './scene/poi/tourGuide';
 import type { PoiDefinition } from './scene/poi/types';
@@ -656,6 +659,10 @@ function initializeImmersiveScene(
     poiDefinitions.map((definition) => [definition.id, definition] as const)
   );
   injectPoiStructuredData(poiDefinitions, {
+    siteName: siteStrings.name,
+    locale,
+  });
+  injectTextPortfolioStructuredData(poiDefinitions, {
     siteName: siteStrings.name,
     locale,
   });

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -102,5 +102,14 @@ describe('i18n utilities', () => {
     expect(pseudoSite.structuredData.author.name).toBe(
       englishSite.structuredData.author.name
     );
+    expect(pseudoSite.structuredData.textCollectionNameTemplate).toBe(
+      englishSite.structuredData.textCollectionNameTemplate
+    );
+    expect(pseudoSite.structuredData.textCollectionDescription).toBe(
+      englishSite.structuredData.textCollectionDescription
+    );
+    expect(pseudoSite.structuredData.immersiveActionName).toBe(
+      englishSite.structuredData.immersiveActionName
+    );
   });
 });


### PR DESCRIPTION
## Summary
- inject a CollectionPage JSON-LD feed for the text portfolio alongside the POI ItemList
- add localized strings for the text collection metadata and immersive action label
- expand vitest coverage for structured data builders/injectors and document the completed roadmap item

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f485536048832f8faeebef85cffdf1