### PR TITLE
Add koi pond ripple shader to greenhouse

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -146,8 +146,9 @@ Focus: anchor each highlighted project with an interactive artifact.
 3. **Backyard Exhibits**
    - ✅ Launch-ready model rocket for `DSPACE`, complete with illuminated launch pad, pulsing
      caution halo, countdown-ready stance, and an interactive POI that links to the mission log.
-   - ✨ Aluminum extrusion greenhouse inspired by `sugarkube`, complete with animated solar
-     trackers, pulsing grow lights, interior planter beds, and a koi pond plinth.
+   - ✅ Aluminum extrusion greenhouse inspired by `sugarkube`, complete with animated solar
+     trackers, pulsing grow lights, interior planter beds, and a koi pond plinth with shimmering
+     ripple shaders.
      - ✅ Sugarkube greenhouse POI now surfaces automation metrics and dual CTAs in the registry.
        - ✅ Ambient audio beds (crickets, greenhouse chimes) now use smoothstep falloff so volume
          eases in based on player proximity.

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -156,6 +156,12 @@ describe('createBackyardEnvironment', () => {
     );
     expect(walkway).toBeInstanceOf(Mesh);
 
+    const pondRipple = environment.group.getObjectByName(
+      'BackyardGreenhousePondRipple'
+    );
+    expect(pondRipple).toBeInstanceOf(Mesh);
+    expect((pondRipple as Mesh).material).toBeInstanceOf(ShaderMaterial);
+
     const solarPivot = (greenhouse as Group).getObjectByName(
       'BackyardGreenhouseSolarPanels'
     );


### PR DESCRIPTION
what:
- add shader-driven koi pond ripple overlay in the greenhouse exhibit
- extend greenhouse coverage for ripple animation and pulse scaling
- mark the roadmap greenhouse slice as delivered with ripple shaders

why:
- roadmap phase 2 backyard greenhouse calls for an animated koi pond plinth

how to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f48f5686dc832f91c0556704b8666e