### PR TITLE
Add doorway trim for ground-floor openings

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,7 +67,8 @@ Focus: expand the environment while keeping navigation smooth.
 2. **House Footprint Layout**
    - Block out multiple rooms on the ground floor using modular wall/floor/ceiling pieces.
      - ✅ Modular ceiling panels now cap each ground-floor room with LED-friendly insets.
-   - Cut simple doorway openings (no doors yet) between rooms and toward the backyard.
+   - ✅ Cut simple doorway openings (no doors yet) between rooms and toward the backyard.
+     - Doorway trim now frames each threshold.
    - ✅ Stub staircase volumes that connect to a placeholder second-floor landing.
    - Ensure navmesh/character controller handles slopes and doorway thresholds.
      - ✅ Wall segment builder now reserves doorway openings and keeps player colliders clear.

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,6 +133,7 @@ import {
   type AxelNavigatorBuild,
 } from './scene/structures/axelNavigator';
 import { createRoomCeilingPanels } from './scene/structures/ceilingPanels';
+import { createDoorwayOpenings } from './scene/structures/doorwayOpenings';
 import {
   createF2ClipboardConsole,
   type F2ClipboardConsoleBuild,
@@ -768,6 +769,13 @@ function initializeImmersiveScene(
 
   const wallMaterial = new MeshStandardMaterial({ color: 0x3d4a63 });
   const fenceMaterial = new MeshStandardMaterial({ color: 0x4a5668 });
+  const doorwayTrimMaterial = new MeshStandardMaterial({
+    color: new Color(0x556278),
+    emissive: new Color(0x111b29),
+    emissiveIntensity: 0.12,
+    roughness: 0.46,
+    metalness: 0.3,
+  });
 
   const interiorLightmaps = createInteriorLightmapTextures({
     floorSize: {
@@ -810,6 +818,17 @@ function initializeImmersiveScene(
   });
 
   scene.add(wallGroup);
+
+  const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
+    wallHeight: WALL_HEIGHT,
+    baseElevation: 0,
+    doorHeight: WALL_HEIGHT * 0.72,
+    jambThickness: WALL_THICKNESS * 0.76,
+    lintelThickness: 0.26,
+    trimDepth: WALL_THICKNESS * 0.92,
+    material: doorwayTrimMaterial,
+  });
+  scene.add(doorwayOpenings.group);
 
   const ceilings = createRoomCeilingPanels(FLOOR_PLAN.rooms, {
     height: WALL_HEIGHT - 0.15,

--- a/src/scene/structures/__tests__/doorwayOpenings.test.ts
+++ b/src/scene/structures/__tests__/doorwayOpenings.test.ts
@@ -1,0 +1,121 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN } from '../../../assets/floorPlan';
+import { createDoorwayOpenings } from '../../structures/doorwayOpenings';
+
+const HORIZONTAL_DOOR_KEYS = {
+  livingToKitchen: { x: -18, z: -8 },
+  livingToStudio: { x: 15, z: -8 },
+  kitchenToBackyard: { x: -18, z: 16 },
+  studioToBackyard: { x: 15, z: 16 },
+};
+
+const VERTICAL_DOOR_KEY = { x: -4, z: 4 };
+
+const EPSILON = 1e-5;
+
+const findDoorwayGroup = (
+  children: readonly THREE.Object3D[],
+  position: { x: number; z: number }
+) => {
+  return children.find(
+    (child) =>
+      Math.abs(child.position.x - position.x) < EPSILON &&
+      Math.abs(child.position.z - position.z) < EPSILON
+  );
+};
+
+describe('createDoorwayOpenings', () => {
+  it('creates doorway trim for each unique opening on the ground floor', () => {
+    const { group } = createDoorwayOpenings(FLOOR_PLAN, {
+      wallHeight: 6,
+      doorHeight: 4.4,
+      jambThickness: 0.32,
+      lintelThickness: 0.2,
+      trimDepth: 0.42,
+    });
+
+    expect(group.name).toBe('DoorwayOpenings');
+    expect(group.children).toHaveLength(5);
+
+    const livingKitchen = findDoorwayGroup(
+      group.children,
+      HORIZONTAL_DOOR_KEYS.livingToKitchen
+    );
+    expect(livingKitchen?.children).toHaveLength(3);
+
+    const lintel = livingKitchen?.children.find((child) =>
+      child.name.includes('Lintel')
+    );
+    expect(lintel).toBeDefined();
+    if (lintel) {
+      const lintelMesh = lintel as THREE.Mesh;
+      const geometry = lintelMesh.geometry as THREE.BoxGeometry;
+      expect(geometry.parameters.height).toBeCloseTo(0.2, 5);
+      expect(lintel.position.y).toBeCloseTo(4.4 + 0.1, 5);
+    }
+
+    const leftJamb = livingKitchen?.children.find((child) =>
+      child.name.includes('JambLeft')
+    );
+    const rightJamb = livingKitchen?.children.find((child) =>
+      child.name.includes('JambRight')
+    );
+    expect(leftJamb).toBeDefined();
+    expect(rightJamb).toBeDefined();
+    if (leftJamb && rightJamb) {
+      const leftMesh = leftJamb as THREE.Mesh;
+      const rightMesh = rightJamb as THREE.Mesh;
+      const leftGeometry = leftMesh.geometry as THREE.BoxGeometry;
+      const rightGeometry = rightMesh.geometry as THREE.BoxGeometry;
+      expect(leftGeometry.parameters.width).toBeCloseTo(0.32, 5);
+      expect(rightGeometry.parameters.width).toBeCloseTo(0.32, 5);
+      expect(leftMesh.position.x).toBeCloseTo(-3.84, 2);
+      expect(rightMesh.position.x).toBeCloseTo(3.84, 2);
+      expect(leftMesh.position.y).toBeCloseTo(2.2, 5);
+      expect(rightMesh.position.y).toBeCloseTo(2.2, 5);
+    }
+
+    const verticalDoor = findDoorwayGroup(group.children, VERTICAL_DOOR_KEY);
+    expect(verticalDoor?.children).toHaveLength(3);
+    if (verticalDoor) {
+      const near = verticalDoor.children.find((child) =>
+        child.name.includes('JambNear')
+      ) as THREE.Mesh | undefined;
+      const far = verticalDoor.children.find((child) =>
+        child.name.includes('JambFar')
+      ) as THREE.Mesh | undefined;
+      expect(near).toBeDefined();
+      expect(far).toBeDefined();
+      if (near && far) {
+        const geometry = near.geometry as THREE.BoxGeometry;
+        expect(geometry.parameters.depth).toBeCloseTo(0.32, 5);
+        expect(near.position.z).toBeCloseTo(-3.84, 2);
+        expect(far.position.z).toBeCloseTo(3.84, 2);
+      }
+    }
+
+    const backyardDoor = findDoorwayGroup(
+      group.children,
+      HORIZONTAL_DOOR_KEYS.kitchenToBackyard
+    );
+    expect(backyardDoor?.children).toHaveLength(3);
+  });
+
+  it('derives doorway height from the wall height when unspecified', () => {
+    const { group } = createDoorwayOpenings(FLOOR_PLAN, {
+      wallHeight: 6,
+    });
+
+    expect(group.children.length).toBeGreaterThan(0);
+    const firstDoor = group.children[0];
+    const lintel = firstDoor.children.find((child) =>
+      child.name.includes('Lintel')
+    ) as THREE.Mesh | undefined;
+    expect(lintel).toBeDefined();
+    if (lintel) {
+      expect(lintel.position.y).toBeCloseTo(6 * 0.72 + 0.11, 5);
+    }
+  });
+});

--- a/src/scene/structures/doorwayOpenings.ts
+++ b/src/scene/structures/doorwayOpenings.ts
@@ -1,0 +1,214 @@
+import { BoxGeometry, Color, Group, Mesh, MeshStandardMaterial } from 'three';
+
+import {
+  type DoorwayDefinition,
+  type FloorPlanDefinition,
+  type RoomWall,
+} from '../../assets/floorPlan';
+
+type DoorAxis = 'horizontal' | 'vertical';
+
+interface DoorwayInstance {
+  axis: DoorAxis;
+  width: number;
+  center: { x: number; z: number };
+}
+
+export interface DoorwayOpeningsOptions {
+  wallHeight: number;
+  baseElevation?: number;
+  doorHeight?: number;
+  jambThickness?: number;
+  lintelThickness?: number;
+  trimDepth?: number;
+  material?: MeshStandardMaterial;
+}
+
+export interface DoorwayOpeningsBuild {
+  group: Group;
+}
+
+const AXIS_FROM_WALL: Record<RoomWall, DoorAxis> = {
+  north: 'horizontal',
+  south: 'horizontal',
+  east: 'vertical',
+  west: 'vertical',
+};
+
+const DEFAULT_DOOR_HEIGHT_RATIO = 0.72;
+const DEFAULT_JAMB_THICKNESS = 0.36;
+const DEFAULT_LINTEL_THICKNESS = 0.22;
+const DEFAULT_TRIM_DEPTH = 0.36;
+
+const DOOR_NAME = 'DoorwayOpenings';
+
+const createDefaultMaterial = () =>
+  new MeshStandardMaterial({
+    color: new Color(0x52657d),
+    emissive: new Color(0x111d2a),
+    emissiveIntensity: 0.14,
+    roughness: 0.44,
+    metalness: 0.28,
+  });
+
+function normalizeDoorway(
+  roomBounds: FloorPlanDefinition['rooms'][number]['bounds'],
+  doorway: DoorwayDefinition
+): DoorwayInstance {
+  const axis = AXIS_FROM_WALL[doorway.wall];
+  const width = Math.abs(doorway.end - doorway.start);
+
+  if (axis === 'horizontal') {
+    const centerX = (doorway.start + doorway.end) / 2;
+    const centerZ =
+      doorway.wall === 'north' ? roomBounds.maxZ : roomBounds.minZ;
+    return {
+      axis,
+      width,
+      center: { x: centerX, z: centerZ },
+    };
+  }
+
+  const centerZ = (doorway.start + doorway.end) / 2;
+  const centerX = doorway.wall === 'east' ? roomBounds.maxX : roomBounds.minX;
+  return {
+    axis,
+    width,
+    center: { x: centerX, z: centerZ },
+  };
+}
+
+const getAccumulatorKey = ({ axis, center, width }: DoorwayInstance): string =>
+  `${axis}|${center.x.toFixed(3)}|${center.z.toFixed(3)}|${width.toFixed(3)}`;
+
+const sortDoorways = (doorways: DoorwayInstance[]): DoorwayInstance[] => {
+  return [...doorways].sort((a, b) => {
+    if (a.axis !== b.axis) {
+      return a.axis === 'horizontal' ? -1 : 1;
+    }
+    if (a.center.z !== b.center.z) {
+      return a.center.z - b.center.z;
+    }
+    if (a.center.x !== b.center.x) {
+      return a.center.x - b.center.x;
+    }
+    return a.width - b.width;
+  });
+};
+
+export function createDoorwayOpenings(
+  plan: FloorPlanDefinition,
+  {
+    wallHeight,
+    baseElevation = 0,
+    doorHeight: providedDoorHeight,
+    jambThickness = DEFAULT_JAMB_THICKNESS,
+    lintelThickness = DEFAULT_LINTEL_THICKNESS,
+    trimDepth = DEFAULT_TRIM_DEPTH,
+    material: providedMaterial,
+  }: DoorwayOpeningsOptions
+): DoorwayOpeningsBuild {
+  const doorHeight =
+    typeof providedDoorHeight === 'number'
+      ? providedDoorHeight
+      : wallHeight * DEFAULT_DOOR_HEIGHT_RATIO;
+  const material = providedMaterial ?? createDefaultMaterial();
+
+  const accumulator = new Map<string, DoorwayInstance>();
+
+  plan.rooms.forEach((room) => {
+    room.doorways?.forEach((doorway) => {
+      const instance = normalizeDoorway(room.bounds, doorway);
+      const key = getAccumulatorKey(instance);
+      if (!accumulator.has(key)) {
+        accumulator.set(key, instance);
+      }
+    });
+  });
+
+  const uniqueDoorways = sortDoorways(Array.from(accumulator.values()));
+
+  const root = new Group();
+  root.name = DOOR_NAME;
+
+  uniqueDoorways.forEach((doorway, index) => {
+    const doorGroup = new Group();
+    doorGroup.name = `${DOOR_NAME}-${doorway.axis}-${index}`;
+    doorGroup.position.set(doorway.center.x, baseElevation, doorway.center.z);
+
+    const lintelSpan = Math.max(
+      doorway.width - jambThickness * 0.6,
+      jambThickness
+    );
+    const lintelHeight = doorHeight + lintelThickness / 2;
+
+    if (doorway.axis === 'horizontal') {
+      const halfWidth = doorway.width / 2;
+      const jambOffset = Math.max(halfWidth - jambThickness / 2, 0);
+      const jambGeometry = new BoxGeometry(
+        jambThickness,
+        doorHeight,
+        trimDepth
+      );
+
+      const leftJamb = new Mesh(jambGeometry, material);
+      leftJamb.name = `${DOOR_NAME}-JambLeft-${index}`;
+      leftJamb.position.set(-jambOffset, doorHeight / 2, 0);
+      doorGroup.add(leftJamb);
+
+      const rightJamb = new Mesh(jambGeometry, material);
+      rightJamb.name = `${DOOR_NAME}-JambRight-${index}`;
+      rightJamb.position.set(jambOffset, doorHeight / 2, 0);
+      doorGroup.add(rightJamb);
+
+      const lintelGeometry = new BoxGeometry(
+        lintelSpan,
+        lintelThickness,
+        trimDepth
+      );
+      const lintel = new Mesh(lintelGeometry, material);
+      lintel.name = `${DOOR_NAME}-Lintel-${index}`;
+      lintel.position.set(0, lintelHeight, 0);
+      doorGroup.add(lintel);
+    } else {
+      const halfWidth = doorway.width / 2;
+      const jambOffset = Math.max(halfWidth - jambThickness / 2, 0);
+      const jambGeometry = new BoxGeometry(
+        trimDepth,
+        doorHeight,
+        jambThickness
+      );
+
+      const nearJamb = new Mesh(jambGeometry, material);
+      nearJamb.name = `${DOOR_NAME}-JambNear-${index}`;
+      nearJamb.position.set(0, doorHeight / 2, -jambOffset);
+      doorGroup.add(nearJamb);
+
+      const farJamb = new Mesh(jambGeometry, material);
+      farJamb.name = `${DOOR_NAME}-JambFar-${index}`;
+      farJamb.position.set(0, doorHeight / 2, jambOffset);
+      doorGroup.add(farJamb);
+
+      const lintelGeometry = new BoxGeometry(
+        trimDepth,
+        lintelThickness,
+        lintelSpan
+      );
+      const lintel = new Mesh(lintelGeometry, material);
+      lintel.name = `${DOOR_NAME}-Lintel-${index}`;
+      lintel.position.set(0, lintelHeight, 0);
+      doorGroup.add(lintel);
+    }
+
+    root.add(doorGroup);
+  });
+
+  return { group: root };
+}
+
+export const _testables = {
+  createDefaultMaterial,
+  normalizeDoorway,
+  getAccumulatorKey,
+  sortDoorways,
+};


### PR DESCRIPTION
## Summary
- add a doorway trim builder that converts floor plan doorways into shared geometry
- render the new trim in the ground-floor scene material pass
- record the roadmap milestone and cover the builder with unit tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke


------
https://chatgpt.com/codex/tasks/task_e_68f48f5686dc832f91c0556704b8666e