### PR TITLE
Add accessibility flags to JSON-LD feeds

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -207,7 +207,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
      unless immersive mode is explicitly forced.
    - ✅ Manual mode toggle now exposes an active state with aria-pressed so assistive tech
      announces when the text tour is engaged.
-   - ✨ JSON-LD exhibit feeds now include `inLanguage` and `isAccessibleForFree` metadata so
+   - ✅ JSON-LD exhibit feeds now include `inLanguage` and `isAccessibleForFree` metadata so
      crawlers understand language coverage and free access guarantees.
    - ✅ Text fallback links back to immersive mode with the override URL so returns bypass
      automatic failover heuristics.

--- a/src/scene/poi/structuredData.ts
+++ b/src/scene/poi/structuredData.ts
@@ -202,6 +202,7 @@ const createSiteEntry = (
     name: siteName,
     url: canonical,
     inLanguage: locale,
+    isAccessibleForFree: true,
   };
 };
 
@@ -253,6 +254,7 @@ export const buildPoiStructuredData = (
     name: siteName,
     url: canonical,
     inLanguage: locale,
+    isAccessibleForFree: true,
     description,
   };
 
@@ -420,6 +422,8 @@ export const buildTextPortfolioStructuredData = (
   const hasPart = pois.map((poi) => ({
     '@type': 'CreativeWork',
     '@id': createPoiUrl(canonical, poi.id),
+    inLanguage: locale,
+    isAccessibleForFree: true,
   }));
 
   const structuredData: Record<string, unknown> = {

--- a/src/tests/poiStructuredData.test.ts
+++ b/src/tests/poiStructuredData.test.ts
@@ -122,6 +122,7 @@ describe('buildPoiStructuredData', () => {
       name: 'Immersive Portfolio',
       url: 'https://portfolio.example/immersive/',
       inLanguage: 'en',
+      isAccessibleForFree: true,
       description:
         'Interactive exhibits within the Daniel Smith immersive portfolio experience.',
       mainEntity: { '@id': expectedPageId },
@@ -273,6 +274,7 @@ describe('buildTextPortfolioStructuredData', () => {
       name: 'Immersive Portfolio',
       url: canonicalBase,
       inLanguage: 'en',
+      isAccessibleForFree: true,
     });
     expect(data.mainEntity).toEqual({
       '@type': 'ItemList',
@@ -286,10 +288,14 @@ describe('buildTextPortfolioStructuredData', () => {
       {
         '@type': 'CreativeWork',
         '@id': `${canonicalBase}#poi-tokenplace-studio-cluster`,
+        inLanguage: 'en',
+        isAccessibleForFree: true,
       },
       {
         '@type': 'CreativeWork',
         '@id': `${canonicalBase}#poi-gabriel-studio-sentry`,
+        inLanguage: 'en',
+        isAccessibleForFree: true,
       },
     ]);
     expect(data.potentialAction).toEqual({
@@ -383,6 +389,7 @@ describe('injectPoiStructuredData', () => {
       name: 'Immersive Portfolio',
       url: 'https://example.com/portfolio/',
       inLanguage: 'en',
+      isAccessibleForFree: true,
       description:
         'Interactive exhibits within the Daniel Smith immersive portfolio experience.',
       mainEntity: { '@id': expectedPageId },


### PR DESCRIPTION
## Summary
- mark roadmap milestone for JSON-LD access metadata as complete
- add isAccessibleForFree to immersive site structured data and text hasPart entries
- extend structured data tests to assert new language and access flags

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f5e0740e58832fa319e63d37e62f5d