### PR TITLE
Add help modal announcements for HUD accessibility

### DIFF
--- a/docs/guides/accessibility-overlays.md
+++ b/docs/guides/accessibility-overlays.md
@@ -23,6 +23,8 @@ screen-reader visitors receive the same metadata as 3D players.
 3. When a POI is selected, focus shifts to `.poi-tooltip-overlay`; the close
    button (if present) should be first in the overlay’s tab order.
 4. Trap focus inside modal dialogs (`help-modal`) until dismissed.
+5. Announce help menu open/close transitions through the HUD focus announcer so
+   assistive tech users know when the dialog state changes.
 
 ## Text alternatives
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -181,6 +181,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
      change, keeping keyboard and assistive tech guidance aligned with on-screen cues.
    - ✅ Help modal opens from the HUD button or `H`/`?` hotkeys and surfaces controls,
      accessibility tips, and failover guidance.
+   - ✅ Help modal open and close events now announce their state to screen readers so
+     keyboard visitors know when the panel is active.
    - ✅ Accessibility HUD presets now expose Standard, Calm, and Photosensitive-safe modes
      that soften bloom, ease emissives, duck ambient audio, and boost HUD contrast.
      - ✅ Graphics HUD presets let players choose Cinematic, Balanced, or Performance modes

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -161,6 +161,10 @@ export const AR_OVERRIDES: LocaleOverrides = {
           ],
         },
       ],
+      announcements: {
+        open: 'تم فتح قائمة المساعدة. راجع عناصر التحكم والإعدادات.',
+        close: 'تم إغلاق قائمة المساعدة.',
+      },
     },
   },
 };

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -63,6 +63,10 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
           ].join(' ')
         ),
       },
+      announcements: {
+        open: wrap('Help menu opened. Review controls and settings.'),
+        close: wrap('Help menu closed.'),
+      },
     },
   },
   poi: {

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -176,6 +176,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           ],
         },
       ],
+      announcements: {
+        open: 'Help menu opened. Review controls and settings.',
+        close: 'Help menu closed.',
+      },
     },
   },
   poi: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -161,6 +161,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
           ],
         },
       ],
+      announcements: {
+        open: 'ヘルプメニューを開きました。操作方法と設定を確認できます。',
+        close: 'ヘルプメニューを閉じました。',
+      },
     },
   },
 };

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -61,6 +61,10 @@ export interface HelpModalStrings {
   closeAriaLabel: string;
   settings: HelpModalSettingsStrings;
   sections: readonly HelpModalSectionStrings[];
+  announcements: {
+    open: string;
+    close: string;
+  };
 }
 
 export interface PoiNarrativeLogStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -282,6 +282,10 @@ import {
 import { applyControlOverlayStrings } from './ui/hud/controlOverlay';
 import { createHelpModal } from './ui/hud/helpModal';
 import {
+  attachHelpModalController,
+  type HelpModalControllerHandle,
+} from './ui/hud/helpModalController';
+import {
   createHudLayoutManager,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
@@ -594,6 +598,7 @@ function initializeImmersiveScene(
   let avatarVariantControl: AvatarVariantControlHandle | null = null;
   let unsubscribeAvatarVariant: (() => void) | null = null;
   let hudFocusAnnouncer: HudFocusAnnouncerHandle | null = null;
+  let helpModalController: HelpModalControllerHandle | null = null;
   let poiNarrativeLog: PoiNarrativeLogHandle | null = null;
   let localeToggleControl: LocaleToggleControlHandle | null = null;
   let getAmbientAudioVolume = () =>
@@ -2010,7 +2015,7 @@ function initializeImmersiveScene(
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
-  const interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
+  let interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
   const interactDescriptionFallback =
     controlOverlayStrings.interact.description;
   const movementLegend: MovementLegendHandle | null = controlOverlay
@@ -2058,34 +2063,6 @@ function initializeImmersiveScene(
     });
   };
 
-  const originalHelpModalOpen = helpModal.open.bind(helpModal);
-  const originalHelpModalClose = helpModal.close.bind(helpModal);
-  const originalHelpModalToggle = helpModal.toggle.bind(helpModal);
-
-  helpModal.open = () => {
-    showHudControlElements();
-    originalHelpModalOpen();
-  };
-  helpModal.close = () => {
-    originalHelpModalClose();
-    hideHudControlElements();
-  };
-  helpModal.toggle = (force?: boolean) => {
-    const shouldOpen = force ?? !helpModal.isOpen();
-    if (shouldOpen) {
-      showHudControlElements();
-    } else {
-      hideHudControlElements();
-    }
-    originalHelpModalToggle(force);
-  };
-
-  const openHelpMenu = () => {
-    helpModal.open();
-  };
-  const toggleHelpMenu = (force?: boolean) => {
-    helpModal.toggle(force);
-  };
   poiNarrativeLog = createPoiNarrativeLog({
     container: helpModal.element,
     strings: narrativeLogStrings,
@@ -2108,6 +2085,19 @@ function initializeImmersiveScene(
     documentTarget: document,
     container: document.body,
   });
+  helpModalController = attachHelpModalController({
+    helpModal,
+    onOpen: showHudControlElements,
+    onClose: hideHudControlElements,
+    hudFocusAnnouncer,
+    announcements: helpModalStrings.announcements,
+  });
+  const openHelpMenu = () => {
+    helpModal.open();
+  };
+  const toggleHelpMenu = (force?: boolean) => {
+    helpModal.toggle(force);
+  };
   let helpButtonClickHandler: (() => void) | null = null;
   if (helpButton) {
     helpButtonClickHandler = () => openHelpMenu();
@@ -2181,6 +2171,7 @@ function initializeImmersiveScene(
 
     controlOverlayStrings = getControlOverlayStrings(locale);
     helpModalStrings = getHelpModalStrings(locale);
+    helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     siteStrings = getSiteStrings(locale);
     narrativeTimeFormatter = new Intl.DateTimeFormat(
@@ -3404,6 +3395,10 @@ function initializeImmersiveScene(
     if (poiNarrativeLog) {
       poiNarrativeLog.dispose();
       poiNarrativeLog = null;
+    }
+    if (helpModalController) {
+      helpModalController.dispose();
+      helpModalController = null;
     }
     helpModal.dispose();
     if (hudFocusAnnouncer) {

--- a/src/tests/helpModal.test.ts
+++ b/src/tests/helpModal.test.ts
@@ -22,6 +22,10 @@ function cloneContent() {
         description: item.description,
       })),
     })),
+    announcements: {
+      open: content.announcements.open,
+      close: content.announcements.close,
+    },
   };
 }
 

--- a/src/tests/helpModalController.test.ts
+++ b/src/tests/helpModalController.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import type { HelpModalHandle } from '../ui/hud/helpModal';
+import { attachHelpModalController } from '../ui/hud/helpModalController';
+
+interface StubContext {
+  handle: HelpModalHandle;
+  getOpenState(): boolean;
+  setOpenState(value: boolean): void;
+  openSpy: ReturnType<typeof vi.fn>;
+  closeSpy: ReturnType<typeof vi.fn>;
+  toggleSpy: ReturnType<typeof vi.fn>;
+}
+
+const createHelpModalStub = (): StubContext => {
+  const element = document.createElement('div');
+  let openState = false;
+  const openSpy = vi.fn(() => {
+    openState = true;
+  });
+  const closeSpy = vi.fn(() => {
+    openState = false;
+  });
+  const toggleSpy = vi.fn((force?: boolean) => {
+    const shouldOpen = force ?? !openState;
+    openState = shouldOpen;
+  });
+  const handle: HelpModalHandle = {
+    element,
+    settingsContainer: null,
+    open: openSpy,
+    close: closeSpy,
+    toggle: toggleSpy,
+    isOpen: () => openState,
+    setContent: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return {
+    handle,
+    getOpenState: () => openState,
+    setOpenState: (value: boolean) => {
+      openState = value;
+    },
+    openSpy,
+    closeSpy,
+    toggleSpy,
+  } satisfies StubContext;
+};
+
+describe('attachHelpModalController', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  it('invokes open/close hooks and announces state changes', () => {
+    const events: string[] = [];
+    const context = createHelpModalStub();
+    const announcer = {
+      announce: vi.fn((message: string) => events.push(`announce:${message}`)),
+    };
+    const controller = attachHelpModalController({
+      helpModal: context.handle,
+      onOpen: () => events.push('onOpen'),
+      onClose: () => events.push('onClose'),
+      hudFocusAnnouncer: announcer,
+      announcements: { open: 'opened', close: 'closed' },
+    });
+
+    context.openSpy.mockImplementationOnce(() => {
+      events.push('open');
+      context.setOpenState(true);
+    });
+    context.closeSpy.mockImplementationOnce(() => {
+      events.push('close');
+      context.setOpenState(false);
+    });
+
+    context.handle.open();
+    expect(events).toEqual(['onOpen', 'open', 'announce:opened']);
+    expect(announcer.announce).toHaveBeenCalledWith('opened');
+
+    events.length = 0;
+    context.handle.close();
+    expect(events).toEqual(['close', 'onClose', 'announce:closed']);
+    expect(announcer.announce).toHaveBeenLastCalledWith('closed');
+
+    controller.dispose();
+  });
+
+  it('wraps toggle to emit announcements for inferred state changes', () => {
+    const events: string[] = [];
+    const context = createHelpModalStub();
+    context.toggleSpy.mockImplementation((force?: boolean) => {
+      const shouldOpen = force ?? !context.getOpenState();
+      events.push(`toggle:${shouldOpen ? 'open' : 'close'}`);
+      context.setOpenState(shouldOpen);
+    });
+    const controller = attachHelpModalController({
+      helpModal: context.handle,
+      onOpen: () => events.push('onOpen'),
+      onClose: () => events.push('onClose'),
+      hudFocusAnnouncer: {
+        announce: (message: string) => events.push(`announce:${message}`),
+      },
+      announcements: { open: 'opened', close: 'closed' },
+    });
+
+    context.handle.toggle();
+    expect(events).toEqual(['onOpen', 'toggle:open', 'announce:opened']);
+
+    events.length = 0;
+    context.setOpenState(true);
+    context.handle.toggle();
+    expect(events).toEqual(['onClose', 'toggle:close', 'announce:closed']);
+
+    events.length = 0;
+    context.setOpenState(true);
+    context.handle.toggle(false);
+    expect(events).toEqual(['onClose', 'toggle:close', 'announce:closed']);
+
+    controller.dispose();
+  });
+
+  it('updates announcements dynamically and ignores empty strings', () => {
+    const context = createHelpModalStub();
+    const announcer = { announce: vi.fn() };
+    const controller = attachHelpModalController({
+      helpModal: context.handle,
+      hudFocusAnnouncer: announcer,
+      announcements: { open: 'first open', close: 'first close' },
+    });
+
+    context.handle.open();
+    expect(announcer.announce).toHaveBeenCalledWith('first open');
+
+    controller.setAnnouncements({ open: '', close: 'updated close' });
+    context.handle.open();
+    expect(announcer.announce).not.toHaveBeenCalledWith('');
+
+    context.handle.close();
+    expect(announcer.announce).toHaveBeenLastCalledWith('updated close');
+
+    controller.setAnnouncements(null);
+    context.handle.open();
+    expect(announcer.announce).not.toHaveBeenLastCalledWith('first open');
+
+    controller.dispose();
+  });
+
+  it('restores original handlers on dispose', () => {
+    const context = createHelpModalStub();
+    const controller = attachHelpModalController({
+      helpModal: context.handle,
+      hudFocusAnnouncer: null,
+    });
+
+    expect(context.handle.open).not.toBe(context.openSpy);
+    expect(context.handle.close).not.toBe(context.closeSpy);
+    expect(context.handle.toggle).not.toBe(context.toggleSpy);
+
+    controller.dispose();
+
+    expect(context.handle.open).toBe(context.openSpy);
+    expect(context.handle.close).toBe(context.closeSpy);
+    expect(context.handle.toggle).toBe(context.toggleSpy);
+  });
+});

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -73,10 +73,20 @@ describe('i18n utilities', () => {
     );
     const helpModal = getHelpModalStrings('en-x-pseudo');
     expect(helpModal.closeLabel).toBe('⟦Close⟧');
+    expect(helpModal.announcements.open).toBe(
+      '⟦Help menu opened. Review controls and settings.⟧'
+    );
+    expect(helpModal.announcements.close).toBe('⟦Help menu closed.⟧');
     const arabicHelp = getHelpModalStrings('ar');
     expect(arabicHelp.heading).toBe('الإعدادات والمساعدة');
+    expect(arabicHelp.announcements.open).toBe(
+      'تم فتح قائمة المساعدة. راجع عناصر التحكم والإعدادات.'
+    );
     const japaneseHelp = getHelpModalStrings('ja');
     expect(japaneseHelp.heading).toBe('設定とヘルプ');
+    expect(japaneseHelp.announcements.close).toBe(
+      'ヘルプメニューを閉じました。'
+    );
   });
 
   it('exposes narrative log strings with localized announcements', () => {

--- a/src/ui/hud/helpModal.ts
+++ b/src/ui/hud/helpModal.ts
@@ -19,6 +19,10 @@ export interface HelpModalContent {
     description?: string;
   };
   sections: ReadonlyArray<HelpModalSection>;
+  announcements?: {
+    open: string;
+    close: string;
+  };
 }
 
 export interface HelpModalOptions {

--- a/src/ui/hud/helpModalController.ts
+++ b/src/ui/hud/helpModalController.ts
@@ -1,0 +1,88 @@
+import type { HudFocusAnnouncerHandle } from '../accessibility/hudFocusAnnouncer';
+
+import type { HelpModalHandle } from './helpModal';
+
+export interface HelpModalAnnouncements {
+  open?: string | null;
+  close?: string | null;
+}
+
+export interface HelpModalControllerOptions {
+  helpModal: HelpModalHandle;
+  onOpen?: () => void;
+  onClose?: () => void;
+  hudFocusAnnouncer?: Pick<HudFocusAnnouncerHandle, 'announce'> | null;
+  announcements?: HelpModalAnnouncements | null;
+}
+
+export interface HelpModalControllerHandle {
+  setAnnouncements(announcements?: HelpModalAnnouncements | null): void;
+  dispose(): void;
+}
+
+const sanitizeAnnouncement = (value?: string | null): string | null => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+};
+
+const sanitizeAnnouncements = (
+  value?: HelpModalAnnouncements | null
+): { open: string | null; close: string | null } => ({
+  open: sanitizeAnnouncement(value?.open),
+  close: sanitizeAnnouncement(value?.close),
+});
+
+export function attachHelpModalController({
+  helpModal,
+  onOpen,
+  onClose,
+  hudFocusAnnouncer,
+  announcements,
+}: HelpModalControllerOptions): HelpModalControllerHandle {
+  const originalOpen = helpModal.open;
+  const originalClose = helpModal.close;
+  const originalToggle = helpModal.toggle;
+
+  let activeAnnouncements = sanitizeAnnouncements(announcements);
+
+  const announce = (message: string | null) => {
+    if (!message) {
+      return;
+    }
+    hudFocusAnnouncer?.announce(message);
+  };
+
+  helpModal.open = () => {
+    onOpen?.();
+    originalOpen.call(helpModal);
+    announce(activeAnnouncements.open);
+  };
+
+  helpModal.close = () => {
+    originalClose.call(helpModal);
+    onClose?.();
+    announce(activeAnnouncements.close);
+  };
+
+  helpModal.toggle = (force?: boolean) => {
+    const shouldOpen = force ?? !helpModal.isOpen();
+    if (shouldOpen) {
+      onOpen?.();
+    } else {
+      onClose?.();
+    }
+    originalToggle.call(helpModal, force);
+    announce(shouldOpen ? activeAnnouncements.open : activeAnnouncements.close);
+  };
+
+  return {
+    setAnnouncements(nextAnnouncements) {
+      activeAnnouncements = sanitizeAnnouncements(nextAnnouncements);
+    },
+    dispose() {
+      helpModal.open = originalOpen;
+      helpModal.close = originalClose;
+      helpModal.toggle = originalToggle;
+    },
+  } satisfies HelpModalControllerHandle;
+}


### PR DESCRIPTION
## Summary
- add a help modal controller that wraps open/close/toggle and announces state changes
- localize help menu announcement strings and document the new screen reader behavior

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f5e0740e58832fa319e63d37e62f5d