### PR TITLE
Add procedural narrator journey logging

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -321,7 +321,8 @@ Ideas to evaluate after the core experience is stable:
   windows, slowing or accelerating pulse programs according to the calendar.
   - ✨ Backyard lanterns now inherit seasonal palettes so the greenhouse walkway glow matches the
     active preset.
-- Procedural storytelling AI that narrates the journey between POIs.
+- ✅ Procedural storytelling AI that narrates the journey between POIs.
+  - ✅ Procedural narrator now weaves journey beats into the HUD story log whenever new exhibits are discovered.
 - Integration with GitHub API for live repo stats and contribution heatmaps.
 - Exportable "press kit" mode that packages screenshots, POI blurbs, and metrics.
   - ✅ Press kit summary generator now exports POI metadata and performance budgets to JSON for packaging.

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -75,10 +75,50 @@ export const AR_OVERRIDES: LocaleOverrides = {
     },
     narrativeLog: {
       heading: 'سجل القصة',
+      visitedHeading: 'المعارض التي تمت زيارتها',
       empty: 'قم بزيارة المعارض لفتح مدخلات جديدة تحكي قصة صانع المحتوى.',
       defaultVisitedLabel: 'تمت الزيارة',
       visitedLabelTemplate: 'تمت الزيارة في {time}',
       liveAnnouncementTemplate: '{title} أضيف إلى سجل القصة.',
+      journey: {
+        heading: 'محطات الرحلة',
+        empty: 'استكشف معارض جديدة لنسج سرد الرحلة.',
+        entryLabelTemplate: '{from} → {to}',
+        sameRoomTemplate:
+          'داخل {room} {descriptor}، ينتقل السرد من {fromPoi} نحو {toPoi}.',
+        crossRoomTemplate:
+          'مغادرًا {fromRoom} {fromDescriptor}، تنساب الرحلة إلى {toRoom} {toDescriptor} لإبراز {toPoi}.',
+        crossSectionTemplate:
+          'عند العبور {direction} عبر العتبة، يتجه المسار إلى {toRoom} {toDescriptor} للوصول إلى {toPoi}.',
+        fallbackTemplate: 'يتجه السرد نحو {toPoi}.',
+        announcementTemplate: 'تحديث الرحلة — {label}: {story}',
+        directions: {
+          indoors: 'إلى الداخل',
+          outdoors: 'إلى الخارج',
+        },
+      },
+      rooms: {
+        livingRoom: {
+          label: 'غرفة المعيشة',
+          descriptor: 'صالة سينمائية',
+          zone: 'interior',
+        },
+        studio: {
+          label: 'الاستوديو',
+          descriptor: 'مختبر الأتمتة',
+          zone: 'interior',
+        },
+        kitchen: {
+          label: 'مختبر المطبخ',
+          descriptor: 'جناح الروبوتات الطهوية',
+          zone: 'interior',
+        },
+        backyard: {
+          label: 'الفناء الخلفي',
+          descriptor: 'حديقة مضاءة عند الغسق',
+          zone: 'exterior',
+        },
+      },
     },
     helpModal: {
       heading: 'الإعدادات والمساعدة',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -43,12 +43,55 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
     },
     narrativeLog: {
       heading: wrap('Creator story log'),
+      visitedHeading: wrap('Visited exhibits'),
       empty: wrap(
         'Visit exhibits to unlock narrative entries chronicling the creator showcase.'
       ),
       defaultVisitedLabel: wrap('Visited'),
       visitedLabelTemplate: wrap('Visited at {time}'),
       liveAnnouncementTemplate: wrap('{title} added to the creator story log.'),
+      journey: {
+        heading: wrap('Journey beats'),
+        empty: wrap('Explore new exhibits to weave journey narration.'),
+        entryLabelTemplate: wrap('{from} → {to}'),
+        sameRoomTemplate: wrap(
+          'Within the {room} {descriptor}, the story shifts from {fromPoi} toward {toPoi}.'
+        ),
+        crossRoomTemplate: wrap(
+          'Leaving the {fromRoom} {fromDescriptor}, the journey drifts into the {toRoom} {toDescriptor} to spotlight {toPoi}.'
+        ),
+        crossSectionTemplate: wrap(
+          'Stepping {direction} through the threshold, the path flows into the {toRoom} {toDescriptor} to reach {toPoi}.'
+        ),
+        fallbackTemplate: wrap('The narrative flows toward {toPoi}.'),
+        announcementTemplate: wrap('Journey update — {label}: {story}'),
+        directions: {
+          indoors: wrap('back inside'),
+          outdoors: wrap('outdoors'),
+        },
+      },
+      rooms: {
+        livingRoom: {
+          label: wrap('living room'),
+          descriptor: wrap('cinematic lounge'),
+          zone: 'interior',
+        },
+        studio: {
+          label: wrap('studio'),
+          descriptor: wrap('automation lab'),
+          zone: 'interior',
+        },
+        kitchen: {
+          label: wrap('kitchen lab'),
+          descriptor: wrap('culinary robotics wing'),
+          zone: 'interior',
+        },
+        backyard: {
+          label: wrap('backyard observatory'),
+          descriptor: wrap('dusk-lit garden'),
+          zone: 'exterior',
+        },
+      },
     },
     helpModal: {
       heading: wrap('Settings & Help'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -85,11 +85,51 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     },
     narrativeLog: {
       heading: 'Creator story log',
+      visitedHeading: 'Visited exhibits',
       empty:
         'Visit exhibits to unlock narrative entries chronicling the creator showcase.',
       defaultVisitedLabel: 'Visited',
       visitedLabelTemplate: 'Visited at {time}',
       liveAnnouncementTemplate: '{title} added to the creator story log.',
+      journey: {
+        heading: 'Journey beats',
+        empty: 'Explore new exhibits to weave journey narration.',
+        entryLabelTemplate: '{from} → {to}',
+        sameRoomTemplate:
+          'Within the {room} {descriptor}, the story shifts from {fromPoi} toward {toPoi}.',
+        crossRoomTemplate:
+          'Leaving the {fromRoom} {fromDescriptor}, the journey drifts into the {toRoom} {toDescriptor} to spotlight {toPoi}.',
+        crossSectionTemplate:
+          'Stepping {direction} through the threshold, the path flows into the {toRoom} {toDescriptor} to reach {toPoi}.',
+        fallbackTemplate: 'The narrative flows toward {toPoi}.',
+        announcementTemplate: 'Journey update — {label}: {story}',
+        directions: {
+          indoors: 'back inside',
+          outdoors: 'outdoors',
+        },
+      },
+      rooms: {
+        livingRoom: {
+          label: 'living room',
+          descriptor: 'cinematic lounge',
+          zone: 'interior',
+        },
+        studio: {
+          label: 'studio',
+          descriptor: 'automation lab',
+          zone: 'interior',
+        },
+        kitchen: {
+          label: 'kitchen lab',
+          descriptor: 'culinary robotics wing',
+          zone: 'interior',
+        },
+        backyard: {
+          label: 'backyard observatory',
+          descriptor: 'dusk-lit garden',
+          zone: 'exterior',
+        },
+      },
     },
     helpModal: {
       heading: 'Settings & Help',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -75,11 +75,51 @@ export const JA_OVERRIDES: LocaleOverrides = {
     },
     narrativeLog: {
       heading: 'クリエイターストーリーログ',
+      visitedHeading: '訪問した展示',
       empty: '展示を訪問するとショーケースの記録がアンロックされます。',
       defaultVisitedLabel: '訪問済み',
       visitedLabelTemplate: '{time} に訪問',
       liveAnnouncementTemplate:
         '{title} をクリエイターストーリーログに追加しました。',
+      journey: {
+        heading: '旅のハイライト',
+        empty: '新しい展示を巡ると旅の語りが生成されます。',
+        entryLabelTemplate: '{from} → {to}',
+        sameRoomTemplate:
+          '{room}{descriptor}の中で物語は{fromPoi}から{toPoi}へ滑らかに移り変わります。',
+        crossRoomTemplate:
+          '{fromRoom}{fromDescriptor}を後にして、{toRoom}{toDescriptor}へ進み{toPoi}をクローズアップします。',
+        crossSectionTemplate:
+          '閾値を{direction}にくぐり、{toRoom}{toDescriptor}へ向かって{toPoi}に到達します。',
+        fallbackTemplate: '物語は{toPoi}へ向かって進みます。',
+        announcementTemplate: '旅の更新 — {label}: {story}',
+        directions: {
+          indoors: '屋内へ',
+          outdoors: '屋外へ',
+        },
+      },
+      rooms: {
+        livingRoom: {
+          label: 'リビング',
+          descriptor: 'のシネマラウンジ',
+          zone: 'interior',
+        },
+        studio: {
+          label: 'スタジオ',
+          descriptor: 'のオートメーションラボ',
+          zone: 'interior',
+        },
+        kitchen: {
+          label: 'キッチンラボ',
+          descriptor: 'のフードロボティクスウィング',
+          zone: 'interior',
+        },
+        backyard: {
+          label: 'バックヤード',
+          descriptor: 'の黄昏ガーデン',
+          zone: 'exterior',
+        },
+      },
     },
     helpModal: {
       heading: '設定とヘルプ',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -65,10 +65,33 @@ export interface HelpModalStrings {
 
 export interface PoiNarrativeLogStrings {
   heading: string;
+  visitedHeading: string;
   empty: string;
   defaultVisitedLabel: string;
   visitedLabelTemplate: string;
   liveAnnouncementTemplate: string;
+  journey: {
+    heading: string;
+    empty: string;
+    entryLabelTemplate: string;
+    sameRoomTemplate: string;
+    crossRoomTemplate: string;
+    crossSectionTemplate: string;
+    fallbackTemplate: string;
+    announcementTemplate: string;
+    directions: {
+      indoors: string;
+      outdoors: string;
+    };
+  };
+  rooms: Record<
+    string,
+    {
+      label: string;
+      descriptor: string;
+      zone: 'interior' | 'exterior';
+    }
+  >;
 }
 
 export type StructuredDataEntityType = 'Person' | 'Organization';

--- a/src/systems/narrative/proceduralNarrator.ts
+++ b/src/systems/narrative/proceduralNarrator.ts
@@ -1,0 +1,59 @@
+import type { PoiDefinition, PoiId } from '../../scene/poi/types';
+import type { PoiNarrativeLogHandle } from '../../ui/hud/poiNarrativeLog';
+
+export interface ProceduralNarratorOptions {
+  log: PoiNarrativeLogHandle;
+  definitions: ReadonlyArray<PoiDefinition>;
+}
+
+export class ProceduralNarrator {
+  private readonly log: PoiNarrativeLogHandle;
+
+  private readonly definitionsById = new Map<PoiId, PoiDefinition>();
+
+  private lastVisitedId: PoiId | null = null;
+
+  constructor(options: ProceduralNarratorOptions) {
+    this.log = options.log;
+    options.definitions.forEach((definition) =>
+      this.storeDefinition(definition)
+    );
+  }
+
+  primeVisited(pois: ReadonlyArray<PoiDefinition>): void {
+    if (pois.length === 0) {
+      this.lastVisitedId = null;
+      return;
+    }
+    pois.forEach((poi) => this.storeDefinition(poi));
+    const last = pois[pois.length - 1];
+    this.lastVisitedId = last.id;
+  }
+
+  handleVisit(poi: PoiDefinition): void {
+    this.storeDefinition(poi);
+    const previousId = this.lastVisitedId;
+    this.lastVisitedId = poi.id;
+    if (!previousId || previousId === poi.id) {
+      return;
+    }
+    const previous = this.definitionsById.get(previousId);
+    if (!previous) {
+      return;
+    }
+    this.log.recordJourney(previous, poi);
+  }
+
+  reset(): void {
+    this.lastVisitedId = null;
+  }
+
+  dispose(): void {
+    this.definitionsById.clear();
+    this.lastVisitedId = null;
+  }
+
+  private storeDefinition(poi: PoiDefinition): void {
+    this.definitionsById.set(poi.id, poi);
+  }
+}

--- a/src/tests/poiNarrativeLog.test.ts
+++ b/src/tests/poiNarrativeLog.test.ts
@@ -1,23 +1,83 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { formatMessage } from '../assets/i18n';
 import type { PoiNarrativeLogStrings } from '../assets/i18n';
 import type { PoiDefinition } from '../scene/poi/types';
 import { createPoiNarrativeLog } from '../ui/hud/poiNarrativeLog';
 
 const STRINGS: PoiNarrativeLogStrings = {
   heading: 'Story log',
+  visitedHeading: 'Visited exhibits',
   empty: 'Visit exhibits to unlock story entries.',
   defaultVisitedLabel: 'Visited',
   visitedLabelTemplate: 'Visited at {time}',
   liveAnnouncementTemplate: '{title} logged.',
+  journey: {
+    heading: 'Journey beats',
+    empty: 'Explore new exhibits to unlock journey narration.',
+    entryLabelTemplate: '{from} -> {to}',
+    sameRoomTemplate: '{room} {descriptor}: {fromPoi} to {toPoi}.',
+    crossRoomTemplate:
+      'From {fromRoom} {fromDescriptor} to {toRoom} {toDescriptor} for {toPoi}.',
+    crossSectionTemplate:
+      'Stepping {direction}, the story moves to {toRoom} {toDescriptor} for {toPoi}.',
+    fallbackTemplate: 'Heading toward {toPoi}.',
+    announcementTemplate: 'Journey — {label}: {story}',
+    directions: {
+      indoors: 'indoors',
+      outdoors: 'outdoors',
+    },
+  },
+  rooms: {
+    livingRoom: {
+      label: 'Living room',
+      descriptor: 'lounge',
+      zone: 'interior',
+    },
+    studio: { label: 'Studio', descriptor: 'lab', zone: 'interior' },
+    kitchen: { label: 'Kitchen', descriptor: 'lab', zone: 'interior' },
+    backyard: { label: 'Backyard', descriptor: 'garden', zone: 'exterior' },
+  },
 };
 
 const AR_STRINGS: PoiNarrativeLogStrings = {
   heading: 'سجل القصة',
+  visitedHeading: 'المعارض التي تمت زيارتها',
   empty: 'قم بزيارة المعارض لفتح إدخالات جديدة.',
   defaultVisitedLabel: 'تمت الزيارة',
   visitedLabelTemplate: 'تمت الزيارة في {time}',
   liveAnnouncementTemplate: '{title} أضيف.',
+  journey: {
+    heading: 'محطات الرحلة',
+    empty: 'استكشف معارض جديدة لنسج سرد الرحلة.',
+    entryLabelTemplate: '{from} → {to}',
+    sameRoomTemplate:
+      '{room} {descriptor}: ينتقل السرد من {fromPoi} إلى {toPoi}.',
+    crossRoomTemplate:
+      'من {fromRoom} {fromDescriptor} إلى {toRoom} {toDescriptor} لإبراز {toPoi}.',
+    crossSectionTemplate:
+      'بالعبور {direction} يصل المسار إلى {toRoom} {toDescriptor} نحو {toPoi}.',
+    fallbackTemplate: 'يتجه السرد نحو {toPoi}.',
+    announcementTemplate: 'تحديث الرحلة — {label}: {story}',
+    directions: {
+      indoors: 'إلى الداخل',
+      outdoors: 'إلى الخارج',
+    },
+  },
+  rooms: {
+    livingRoom: {
+      label: 'غرفة المعيشة',
+      descriptor: 'الاستراحة',
+      zone: 'interior',
+    },
+    studio: { label: 'الاستوديو', descriptor: 'المختبر', zone: 'interior' },
+    kitchen: { label: 'مختبر المطبخ', descriptor: 'الجناح', zone: 'interior' },
+    backyard: {
+      label: 'الفناء الخلفي',
+      descriptor: 'الحديقة',
+      zone: 'exterior',
+    },
+  },
 };
 
 const createPoi = (overrides: Partial<PoiDefinition> = {}): PoiDefinition => ({
@@ -46,15 +106,26 @@ describe('createPoiNarrativeLog', () => {
     setup();
 
     const section = document.querySelector('.poi-narrative-log');
-    const empty = document.querySelector('.poi-narrative-log__empty');
-    const list = document.querySelector('.poi-narrative-log__list');
+    const journeyEmpty = document.querySelector(
+      '.poi-narrative-log__journey-empty'
+    );
+    const journeyList = document.querySelector(
+      '.poi-narrative-log__journey-list'
+    );
+    const visitedEmpty = document.querySelector('.poi-narrative-log__empty');
+    const visitedList = document.querySelector('.poi-narrative-log__list');
 
     expect(section).toBeInstanceOf(HTMLElement);
-    expect(empty).toBeInstanceOf(HTMLElement);
-    expect(empty?.textContent).toBe(STRINGS.empty);
-    expect(empty?.getAttribute('hidden')).toBeNull();
-    expect(list).toBeInstanceOf(HTMLElement);
-    expect(list?.getAttribute('hidden')).toBe('');
+    expect(journeyEmpty).toBeInstanceOf(HTMLElement);
+    expect(journeyEmpty?.textContent).toBe(STRINGS.journey.empty);
+    expect(journeyEmpty?.getAttribute('hidden')).toBeNull();
+    expect(journeyList).toBeInstanceOf(HTMLElement);
+    expect(journeyList?.getAttribute('hidden')).toBe('');
+    expect(visitedEmpty).toBeInstanceOf(HTMLElement);
+    expect(visitedEmpty?.textContent).toBe(STRINGS.empty);
+    expect(visitedEmpty?.getAttribute('hidden')).toBeNull();
+    expect(visitedList).toBeInstanceOf(HTMLElement);
+    expect(visitedList?.getAttribute('hidden')).toBe('');
   });
 
   it('records narrative entries and announces new visits', () => {
@@ -70,8 +141,14 @@ describe('createPoiNarrativeLog', () => {
     const title = entry?.querySelector('.poi-narrative-log__entry-title');
     const caption = entry?.querySelector('.poi-narrative-log__entry-caption');
     const visited = entry?.querySelector('.poi-narrative-log__entry-visited');
-    const empty = document.querySelector('.poi-narrative-log__empty');
-    const list = document.querySelector('.poi-narrative-log__list');
+    const visitedEmpty = document.querySelector('.poi-narrative-log__empty');
+    const visitedList = document.querySelector('.poi-narrative-log__list');
+    const journeyEmpty = document.querySelector(
+      '.poi-narrative-log__journey-empty'
+    );
+    const journeyList = document.querySelector(
+      '.poi-narrative-log__journey-list'
+    );
     const liveRegion = document.querySelector(
       '.poi-narrative-log__live-region'
     );
@@ -80,9 +157,71 @@ describe('createPoiNarrativeLog', () => {
     expect(title?.textContent).toBe(poi.title);
     expect(caption?.textContent).toBe('Narrative caption');
     expect(visited?.textContent).toBe('Visited just now');
-    expect(empty?.hidden).toBe(true);
-    expect(list?.hidden).toBe(false);
+    expect(visitedEmpty?.hidden).toBe(true);
+    expect(visitedList?.hidden).toBe(false);
+    expect(journeyEmpty?.hidden).toBe(false);
+    expect(journeyList?.hidden).toBe(true);
     expect(liveRegion?.textContent).toBe(`${poi.title} logged.`);
+  });
+
+  it('records journey beats with contextual narration', () => {
+    const log = setup();
+
+    const fromPoi = createPoi({
+      id: 'futuroptimist-living-room-tv',
+      title: 'Futuroptimist Creator Desk',
+      roomId: 'livingRoom',
+    });
+    const toPoi = createPoi({
+      id: 'flywheel-studio-flywheel',
+      title: 'Flywheel Kinetic Hub',
+      roomId: 'studio',
+    });
+
+    log.recordJourney(fromPoi, toPoi);
+
+    const journeyEntry = document.querySelector(
+      '.poi-narrative-log__journey-entry'
+    );
+    const journeyLabel = journeyEntry?.querySelector(
+      '.poi-narrative-log__journey-label'
+    );
+    const journeyCaption = journeyEntry?.querySelector(
+      '.poi-narrative-log__journey-caption'
+    );
+    const journeyEmpty = document.querySelector(
+      '.poi-narrative-log__journey-empty'
+    );
+    const journeyList = document.querySelector(
+      '.poi-narrative-log__journey-list'
+    );
+    const liveRegion = document.querySelector(
+      '.poi-narrative-log__live-region'
+    );
+
+    const expectedLabel = formatMessage(STRINGS.journey.entryLabelTemplate, {
+      from: STRINGS.rooms.livingRoom.label,
+      to: STRINGS.rooms.studio.label,
+    });
+    const expectedStory = formatMessage(STRINGS.journey.crossRoomTemplate, {
+      fromRoom: STRINGS.rooms.livingRoom.label,
+      fromDescriptor: STRINGS.rooms.livingRoom.descriptor,
+      toRoom: STRINGS.rooms.studio.label,
+      toDescriptor: STRINGS.rooms.studio.descriptor,
+      toPoi: toPoi.title,
+    });
+
+    expect(journeyEntry).toBeInstanceOf(HTMLElement);
+    expect(journeyLabel?.textContent).toBe(expectedLabel);
+    expect(journeyCaption?.textContent).toBe(expectedStory);
+    expect(journeyEmpty?.hidden).toBe(true);
+    expect(journeyList?.hidden).toBe(false);
+    expect(liveRegion?.textContent).toBe(
+      formatMessage(STRINGS.journey.announcementTemplate, {
+        label: expectedLabel,
+        story: expectedStory,
+      })
+    );
   });
 
   it('supports silent entries and summary fallbacks when narration is missing', () => {
@@ -133,6 +272,44 @@ describe('createPoiNarrativeLog', () => {
     log.recordVisit(silent, { visitedLabel: 'Revisited' });
     expect(visited?.textContent).toBe('Revisited');
     expect(liveRegion?.textContent).toBe('');
+  });
+
+  it('enforces the journey history limit and clears entries', () => {
+    const log = setup();
+
+    const makePoi = (index: number, overrides: Partial<PoiDefinition> = {}) =>
+      createPoi({
+        id: `poi-${index}`,
+        title: `POI ${index}`,
+        ...overrides,
+      });
+
+    for (let i = 0; i < 7; i += 1) {
+      const fromPoi = makePoi(i, {
+        roomId: i % 2 === 0 ? 'livingRoom' : 'studio',
+        title: `From ${i}`,
+      });
+      const toPoi = makePoi(i + 20, {
+        roomId: i % 3 === 0 ? 'backyard' : 'studio',
+        title: `To ${i}`,
+      });
+      log.recordJourney(fromPoi, toPoi);
+    }
+
+    const journeyEntries = document.querySelectorAll(
+      '.poi-narrative-log__journey-entry'
+    );
+    expect(journeyEntries).toHaveLength(6);
+
+    log.clearJourneys();
+    const journeyEmpty = document.querySelector(
+      '.poi-narrative-log__journey-empty'
+    );
+    const journeyList = document.querySelector(
+      '.poi-narrative-log__journey-list'
+    );
+    expect(journeyEmpty?.hidden).toBe(false);
+    expect(journeyList?.hidden).toBe(true);
   });
 
   it('synchronizes visited entries and removes stale items', () => {
@@ -187,6 +364,42 @@ describe('createPoiNarrativeLog', () => {
     expect(liveRegion?.textContent).toBe('');
   });
 
+  it('re-renders journey narration when strings change', () => {
+    const log = setup();
+    const fromPoi = createPoi();
+    const toPoi = createPoi({
+      id: 'flywheel-studio-flywheel',
+      title: 'Flywheel Kinetic Hub',
+      roomId: 'studio',
+    });
+
+    log.recordJourney(fromPoi, toPoi);
+
+    log.setStrings(AR_STRINGS);
+
+    const journeyLabel = document.querySelector(
+      '.poi-narrative-log__journey-label'
+    );
+    const journeyCaption = document.querySelector(
+      '.poi-narrative-log__journey-caption'
+    );
+
+    const expectedLabel = formatMessage(AR_STRINGS.journey.entryLabelTemplate, {
+      from: AR_STRINGS.rooms.livingRoom.label,
+      to: AR_STRINGS.rooms.studio.label,
+    });
+    const expectedStory = formatMessage(AR_STRINGS.journey.crossRoomTemplate, {
+      fromRoom: AR_STRINGS.rooms.livingRoom.label,
+      fromDescriptor: AR_STRINGS.rooms.livingRoom.descriptor,
+      toRoom: AR_STRINGS.rooms.studio.label,
+      toDescriptor: AR_STRINGS.rooms.studio.descriptor,
+      toPoi: toPoi.title,
+    });
+
+    expect(journeyLabel?.textContent).toBe(expectedLabel);
+    expect(journeyCaption?.textContent).toBe(expectedStory);
+  });
+
   it('disposes the log and removes elements from the DOM', () => {
     const log = setup();
     log.dispose();
@@ -205,12 +418,24 @@ describe('createPoiNarrativeLog', () => {
     const sectionHeading = section?.querySelector(
       '.help-modal__section-heading'
     );
+    const journeyHeading = section?.querySelector(
+      '.poi-narrative-log__journey-heading'
+    );
+    const visitedHeading = section?.querySelector(
+      '.poi-narrative-log__visited-heading'
+    );
     const empty = document.querySelector('.poi-narrative-log__empty');
+    const journeyEmpty = document.querySelector(
+      '.poi-narrative-log__journey-empty'
+    );
     const visited = document.querySelector('.poi-narrative-log__entry-visited');
     const region = section;
 
     expect(sectionHeading?.textContent).toBe(AR_STRINGS.heading);
+    expect(journeyHeading?.textContent).toBe(AR_STRINGS.journey.heading);
+    expect(visitedHeading?.textContent).toBe(AR_STRINGS.visitedHeading);
     expect(empty?.textContent).toBe(AR_STRINGS.empty);
+    expect(journeyEmpty?.textContent).toBe(AR_STRINGS.journey.empty);
     expect(visited?.textContent).toBe(AR_STRINGS.defaultVisitedLabel);
     expect(region?.getAttribute('aria-label')).toBe(AR_STRINGS.heading);
   });

--- a/src/tests/proceduralNarrator.test.ts
+++ b/src/tests/proceduralNarrator.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PoiDefinition } from '../scene/poi/types';
+import { ProceduralNarrator } from '../systems/narrative/proceduralNarrator';
+import type { PoiNarrativeLogHandle } from '../ui/hud/poiNarrativeLog';
+
+const createPoi = (overrides: Partial<PoiDefinition> = {}): PoiDefinition => {
+  const title = overrides.title ?? 'Test POI';
+  return {
+    id: 'futuroptimist-living-room-tv',
+    title,
+    summary: overrides.summary ?? 'Summary',
+    interactionPrompt: overrides.interactionPrompt ?? `Inspect ${title}`,
+    category: 'project',
+    interaction: 'inspect',
+    roomId: overrides.roomId ?? 'livingRoom',
+    position: overrides.position ?? { x: 0, y: 0, z: 0 },
+    interactionRadius: overrides.interactionRadius ?? 2,
+    footprint: overrides.footprint ?? { width: 1, depth: 1 },
+    metrics: overrides.metrics,
+    links: overrides.links,
+    narration: overrides.narration,
+    ...overrides,
+  };
+};
+
+const createLogStub = () => {
+  const element = document.createElement('section');
+  const stub: PoiNarrativeLogHandle = {
+    element,
+    recordVisit: vi.fn(),
+    recordJourney: vi.fn(),
+    clearJourneys: vi.fn(),
+    syncVisited: vi.fn(),
+    setStrings: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return stub;
+};
+
+describe('ProceduralNarrator', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('emits a journey after a prior visit is known', () => {
+    const fromPoi = createPoi({
+      id: 'futuroptimist-living-room-tv',
+      title: 'From',
+      roomId: 'livingRoom',
+    });
+    const toPoi = createPoi({
+      id: 'flywheel-studio-flywheel',
+      title: 'To',
+      roomId: 'studio',
+    });
+    const log = createLogStub();
+    const narrator = new ProceduralNarrator({
+      log,
+      definitions: [fromPoi, toPoi],
+    });
+
+    narrator.handleVisit(fromPoi);
+    const internals = narrator as unknown as {
+      lastVisitedId: string | null;
+      definitionsById: Map<string, PoiDefinition>;
+    };
+    expect(internals.lastVisitedId).toBe(fromPoi.id);
+    expect(Array.from(internals.definitionsById.keys())).toEqual([
+      fromPoi.id,
+      toPoi.id,
+    ]);
+    expect(log.recordJourney).not.toHaveBeenCalled();
+
+    narrator.handleVisit(toPoi);
+    expect(internals.lastVisitedId).toBe(toPoi.id);
+    expect(log.recordJourney).toHaveBeenCalledTimes(1);
+    expect(log.recordJourney).toHaveBeenCalledTimes(1);
+    expect(log.recordJourney).toHaveBeenCalledWith(fromPoi, toPoi);
+  });
+
+  it('ignores repeat visits to the same exhibit', () => {
+    const poi = createPoi({
+      id: 'futuroptimist-living-room-tv',
+      title: 'Loop',
+      roomId: 'livingRoom',
+    });
+    const log = createLogStub();
+    const narrator = new ProceduralNarrator({ log, definitions: [poi] });
+
+    narrator.primeVisited([poi]);
+    narrator.handleVisit(poi);
+
+    expect(log.recordJourney).not.toHaveBeenCalled();
+  });
+
+  it('primes previously visited exhibits and resets gracefully', () => {
+    const firstPoi = createPoi({
+      id: 'futuroptimist-living-room-tv',
+      title: 'Alpha',
+      roomId: 'livingRoom',
+    });
+    const secondPoi = createPoi({
+      id: 'flywheel-studio-flywheel',
+      title: 'Beta',
+      roomId: 'studio',
+    });
+    const thirdPoi = createPoi({
+      id: 'jobbot-studio-terminal',
+      title: 'Gamma',
+      roomId: 'backyard',
+    });
+    const log = createLogStub();
+    const narrator = new ProceduralNarrator({
+      log,
+      definitions: [firstPoi, secondPoi, thirdPoi],
+    });
+
+    narrator.primeVisited([firstPoi, secondPoi]);
+    narrator.handleVisit(thirdPoi);
+    expect(log.recordJourney).toHaveBeenLastCalledWith(secondPoi, thirdPoi);
+
+    narrator.reset();
+    log.recordJourney.mockClear();
+    narrator.handleVisit(firstPoi);
+    expect(log.recordJourney).not.toHaveBeenCalled();
+
+    narrator.primeVisited([]);
+    narrator.handleVisit(secondPoi);
+    expect(log.recordJourney).not.toHaveBeenCalled();
+  });
+
+  it('does not emit journeys when the previous definition cannot be resolved', () => {
+    const orphanPoi = createPoi({
+      id: 'sugarkube-backyard-greenhouse',
+      title: 'Orphan',
+    });
+    const toPoi = createPoi({
+      id: 'tokenplace-studio-cluster',
+      title: 'Next stop',
+      roomId: 'studio',
+    });
+    const log = createLogStub();
+    const narrator = new ProceduralNarrator({ log, definitions: [] });
+
+    (narrator as unknown as { lastVisitedId: string | null }).lastVisitedId =
+      orphanPoi.id;
+
+    narrator.handleVisit(toPoi);
+    expect(log.recordJourney).not.toHaveBeenCalled();
+  });
+
+  it('clears stored state on dispose', () => {
+    const firstPoi = createPoi({
+      id: 'futuroptimist-living-room-tv',
+      title: 'Alpha',
+    });
+    const secondPoi = createPoi({
+      id: 'flywheel-studio-flywheel',
+      title: 'Beta',
+    });
+    const log = createLogStub();
+    const narrator = new ProceduralNarrator({
+      log,
+      definitions: [firstPoi, secondPoi],
+    });
+
+    narrator.handleVisit(firstPoi);
+    narrator.dispose();
+
+    log.recordJourney.mockClear();
+    narrator.handleVisit(secondPoi);
+
+    expect(log.recordJourney).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1075,6 +1075,55 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   border-top: 1px solid rgba(86, 184, 255, 0.12);
 }
 
+.poi-narrative-log__journey-heading,
+.poi-narrative-log__visited-heading {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(158, 225, 255, 0.82);
+}
+
+.poi-narrative-log__journey-empty {
+  margin: 0.35rem 0 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: rgba(210, 236, 255, 0.68);
+}
+
+.poi-narrative-log__journey-list {
+  margin: 0.6rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.poi-narrative-log__journey-entry {
+  background: rgba(4, 12, 22, 0.72);
+  border: 1px solid rgba(86, 184, 255, 0.16);
+  border-radius: 0.7rem;
+  padding: 0.6rem 0.75rem;
+  box-shadow: 0 10px 24px rgba(3, 10, 20, 0.32);
+}
+
+.poi-narrative-log__journey-label {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(144, 219, 255, 0.78);
+}
+
+.poi-narrative-log__journey-caption {
+  margin: 0.35rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: rgba(214, 236, 255, 0.82);
+}
+
 .poi-narrative-log__empty {
   margin: 0.75rem 0 0;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- add a procedural narrator system that records journeys between POI visits and integrate it with the immersive scene lifecycle
- expand the HUD narrative log to render localized journey beats with styling updates and new i18n copy
- cover the narrator and enhanced log with vitest suites to maintain full patch coverage and document the roadmap milestone completion

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f5e0740e58832fa319e63d37e62f5d