### PR TITLE
Responsive HUD overlay collapse for mobile

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,7 +172,7 @@ Focus: unify user controls and ensure graceful fallback experiences.
 - Lab run logs (Lighthouse CI) show text mode TTI <1.5 s and immersive mode LCP <2.5 s.
 
 1. **HUD Layer**
-   - Responsive overlay with movement legend, interaction prompt, and help modal.
+   - ✅ Responsive overlay with movement legend, interaction prompt, and help modal.
    - ✅ Movement legend now detects the last input method (keyboard, mouse, or touch) and
      refreshes the interact prompt copy so players always see the relevant control hint.
    - ✅ Contextual interact prompts now pull localized action copy into the HUD legend and

--- a/index.html
+++ b/index.html
@@ -57,6 +57,45 @@
           transform 200ms ease;
       }
 
+      .overlay__item[data-mobile-collapsed='true'] {
+        display: none;
+      }
+
+      html[data-hudLayout='mobile'] .overlay {
+        top: calc(env(safe-area-inset-top, 0) + 1rem);
+        bottom: auto;
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+        width: min(24rem, calc(100% - 2rem));
+        padding: 0.9rem 1.05rem;
+        font-size: 0.95rem;
+        line-height: 1.5;
+        z-index: 40;
+      }
+
+      html[data-hudLayout='mobile'] .overlay__heading {
+        margin-bottom: 0.6rem;
+        font-size: 0.7rem;
+      }
+
+      html[data-hudLayout='mobile'] .overlay__list {
+        gap: 0.35rem;
+      }
+
+      html[data-hudLayout='mobile'] .overlay__item {
+        padding: 0.35rem 0.45rem;
+        gap: 0.6rem;
+      }
+
+      html[data-hudLayout='mobile'] .overlay__keys {
+        min-width: 5.75rem;
+      }
+
+      html[data-hudLayout='mobile'] .overlay__help-button {
+        margin-top: 0.65rem;
+      }
+
       .overlay__heading {
         margin: 0 0 0.75rem;
         font-size: 0.75rem;
@@ -128,6 +167,42 @@
         .overlay__item--desktop {
           display: none;
         }
+      }
+
+      .overlay__collapse-toggle {
+        margin-top: 0.6rem;
+        width: 100%;
+        padding: 0.55rem 0.9rem;
+        border-radius: 0.6rem;
+        border: 1px solid rgba(123, 209, 255, 0.32);
+        background:
+          linear-gradient(
+            140deg,
+            rgba(12, 25, 39, 0.88),
+            rgba(16, 43, 70, 0.72)
+          ),
+          rgba(9, 18, 28, 0.82);
+        color: rgba(231, 244, 255, 0.95);
+        font-size: 0.82rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        cursor: pointer;
+        transition:
+          border-color 140ms ease,
+          box-shadow 140ms ease,
+          transform 120ms ease;
+      }
+
+      .overlay__collapse-toggle:hover,
+      .overlay__collapse-toggle:focus-visible {
+        border-color: rgba(158, 232, 255, 0.75);
+        box-shadow: 0 14px 32px rgba(8, 20, 32, 0.32);
+        outline: none;
+        transform: translateY(-1px);
+      }
+
+      .overlay__collapse-toggle:active {
+        transform: translateY(0);
       }
 
       .overlay__help-button {
@@ -392,7 +467,7 @@
     <div id="app"></div>
     <div class="overlay" id="control-overlay">
       <p class="overlay__heading" data-control-text="heading">Controls</p>
-      <ul class="overlay__list">
+      <ul class="overlay__list" data-role="control-list">
         <li
           class="overlay__item"
           data-input-methods="keyboard"
@@ -469,6 +544,14 @@
           </span>
         </li>
       </ul>
+      <button
+        class="overlay__collapse-toggle"
+        type="button"
+        data-role="control-toggle"
+        hidden
+      >
+        Show controls
+      </button>
       <button
         class="overlay__help-button"
         type="button"

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -63,6 +63,14 @@ export const AR_OVERRIDES: LocaleOverrides = {
           'افتح الإعدادات والمساعدة. اضغط {shortcut} لمراجعة الاختصارات والنصائح.',
         shortcutFallback: 'H',
       },
+      mobileToggle: {
+        expandLabel: 'إظهار كل عناصر التحكم',
+        collapseLabel: 'إخفاء عناصر التحكم الإضافية',
+        expandAnnouncement:
+          'يتم عرض قائمة عناصر التحكم الكاملة للأجهزة المحمولة.',
+        collapseAnnouncement:
+          'يتم إخفاء عناصر التحكم الإضافية للحفاظ على القائمة مضغوطة.',
+      },
     },
     movementLegend: {
       defaultDescription: 'تفاعل',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -31,6 +31,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         ),
         shortcutFallback: wrap('H'),
       },
+      mobileToggle: {
+        expandLabel: wrap('Show all controls'),
+        collapseLabel: wrap('Hide extra controls'),
+        expandAnnouncement: wrap(
+          'Showing the full controls list for mobile players.'
+        ),
+        collapseAnnouncement: wrap(
+          'Hiding extra controls to keep the list compact.'
+        ),
+      },
     },
     movementLegend: {
       defaultDescription: wrap('Interact'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -73,6 +73,13 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Open settings and help. Press {shortcut} to review controls and accessibility tips.',
         shortcutFallback: 'H',
       },
+      mobileToggle: {
+        expandLabel: 'Show all controls',
+        collapseLabel: 'Hide extra controls',
+        expandAnnouncement:
+          'Showing the full controls list for mobile players.',
+        collapseAnnouncement: 'Hiding extra controls to keep the list compact.',
+      },
     },
     movementLegend: {
       defaultDescription: 'Interact',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -63,6 +63,13 @@ export const JA_OVERRIDES: LocaleOverrides = {
           '設定とヘルプを開きます。ショートカット {shortcut} で操作方法とアクセシビリティのヒントを確認できます。',
         shortcutFallback: 'H',
       },
+      mobileToggle: {
+        expandLabel: 'すべての操作を表示',
+        collapseLabel: '追加の操作を隠す',
+        expandAnnouncement: 'モバイル向けの操作一覧を表示します。',
+        collapseAnnouncement:
+          '一覧をコンパクトに保つため追加の操作を隠します。',
+      },
     },
     movementLegend: {
       defaultDescription: 'インタラクト',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -31,6 +31,12 @@ export interface ControlOverlayStrings {
     announcementTemplate: string;
     shortcutFallback: string;
   };
+  mobileToggle: {
+    expandLabel: string;
+    collapseLabel: string;
+    expandAnnouncement: string;
+    collapseAnnouncement: string;
+  };
 }
 
 export interface MovementLegendStrings {

--- a/src/tests/controlOverlay.test.ts
+++ b/src/tests/controlOverlay.test.ts
@@ -8,7 +8,7 @@ describe('applyControlOverlayStrings', () => {
     const container = document.createElement('div');
     container.innerHTML = `
       <p class="overlay__heading" data-control-text="heading">Placeholder</p>
-      <ul class="overlay__list">
+      <ul class="overlay__list" data-role="control-list">
         <li class="overlay__item" data-control-item="keyboardMove">
           <span class="overlay__keys">Keys</span>
           <span class="overlay__description">Move</span>
@@ -27,6 +27,13 @@ describe('applyControlOverlayStrings', () => {
           </span>
         </li>
       </ul>
+      <button
+        class="overlay__collapse-toggle"
+        type="button"
+        data-role="control-toggle"
+      >
+        Toggle
+      </button>
     `;
     const strings = getControlOverlayStrings('en');
     applyControlOverlayStrings(container, strings);
@@ -47,5 +54,23 @@ describe('applyControlOverlayStrings', () => {
     );
     expect(interactLabel?.textContent).toBe(strings.interact.defaultLabel);
     expect(interactDescription?.textContent).toBe(strings.interact.description);
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-role="control-toggle"]'
+    );
+    expect(toggle?.textContent).toBe(strings.mobileToggle.expandLabel);
+    expect(toggle?.dataset.expandLabel).toBe(strings.mobileToggle.expandLabel);
+    expect(toggle?.dataset.collapseLabel).toBe(
+      strings.mobileToggle.collapseLabel
+    );
+    expect(toggle?.dataset.expandAnnouncement).toBe(
+      strings.mobileToggle.expandAnnouncement
+    );
+    expect(toggle?.dataset.collapseAnnouncement).toBe(
+      strings.mobileToggle.collapseAnnouncement
+    );
+    expect(toggle?.dataset.hudAnnounce).toBe(
+      strings.mobileToggle.expandAnnouncement
+    );
   });
 });

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { createResponsiveControlOverlay } from '../ui/hud/responsiveControlOverlay';
+
+const createStrings = () => ({
+  expandLabel: 'Show all controls',
+  collapseLabel: 'Hide extra controls',
+  expandAnnouncement: 'Showing the full controls list for mobile players.',
+  collapseAnnouncement: 'Hiding extra controls to keep the list compact.',
+});
+
+const flushMicrotasks = async () => {
+  await new Promise((resolve) => queueMicrotask(resolve));
+};
+
+describe('createResponsiveControlOverlay', () => {
+  it('collapses mobile controls and toggles expanded state', async () => {
+    const container = document.createElement('div');
+    container.dataset.activeInput = 'keyboard';
+    container.innerHTML = `
+      <ul class="overlay__list" data-role="control-list">
+        <li
+          class="overlay__item"
+          data-control-item="keyboardMove"
+          data-input-methods="keyboard"
+        ></li>
+        <li
+          class="overlay__item"
+          data-control-item="pointerDrag"
+          data-input-methods="pointer"
+        ></li>
+        <li
+          class="overlay__item"
+          data-control-item="interact"
+          data-input-methods="keyboard pointer"
+        ></li>
+      </ul>
+      <button type="button" data-role="control-toggle">Toggle</button>
+    `;
+
+    const list = container.querySelector('[data-role="control-list"]');
+    const toggle = container.querySelector('[data-role="control-toggle"]');
+    const handle = createResponsiveControlOverlay({
+      container,
+      list: list as HTMLElement,
+      toggle: toggle as HTMLButtonElement,
+      strings: createStrings(),
+      initialLayout: 'desktop',
+    });
+
+    const keyboardItem = container.querySelector<HTMLElement>(
+      '[data-control-item="keyboardMove"]'
+    );
+    const pointerItem = container.querySelector<HTMLElement>(
+      '[data-control-item="pointerDrag"]'
+    );
+    const interactItem = container.querySelector<HTMLElement>(
+      '[data-control-item="interact"]'
+    );
+
+    handle.setLayout('mobile');
+
+    expect(container.dataset.controlCollapsed).toBe('true');
+    expect(toggle?.hidden).toBe(false);
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(pointerItem?.dataset.mobileCollapsed).toBe('true');
+    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
+
+    container.dataset.activeInput = 'pointer';
+    await flushMicrotasks();
+
+    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(keyboardItem?.dataset.mobileCollapsed).toBe('true');
+
+    (toggle as HTMLButtonElement).click();
+
+    expect(container.dataset.controlCollapsed).toBe('false');
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
+
+    handle.setLayout('desktop');
+    expect(container.dataset.controlCollapsed).toBeUndefined();
+    expect(toggle?.hidden).toBe(true);
+    expect(toggle?.hasAttribute('aria-expanded')).toBe(false);
+    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
+  });
+
+  it('updates toggle labels when strings change', () => {
+    const container = document.createElement('div');
+    container.dataset.activeInput = 'keyboard';
+    container.innerHTML = `
+      <ul class="overlay__list" data-role="control-list"></ul>
+      <button type="button" data-role="control-toggle">Toggle</button>
+    `;
+
+    const list = container.querySelector('[data-role="control-list"]');
+    const toggle = container.querySelector('[data-role="control-toggle"]');
+    const handle = createResponsiveControlOverlay({
+      container,
+      list: list as HTMLElement,
+      toggle: toggle as HTMLButtonElement,
+      strings: createStrings(),
+      initialLayout: 'desktop',
+    });
+
+    handle.setLayout('mobile');
+
+    expect(toggle?.textContent).toBe('Show all controls');
+    expect(toggle?.dataset.hudAnnounce).toBe(
+      'Showing the full controls list for mobile players.'
+    );
+
+    handle.setStrings({
+      expandLabel: 'Expand',
+      collapseLabel: 'Collapse',
+      expandAnnouncement: 'Expand controls.',
+      collapseAnnouncement: 'Collapse controls.',
+    });
+
+    expect(toggle?.textContent).toBe('Expand');
+    expect(toggle?.dataset.hudAnnounce).toBe('Expand controls.');
+
+    handle.dispose();
+    expect(toggle?.hidden).toBe(true);
+    expect(toggle?.textContent).toBe('Expand');
+  });
+});

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -5,6 +5,7 @@ const CONTROL_KEYS_SELECTOR = '.overlay__keys';
 const CONTROL_DESCRIPTION_SELECTOR = '.overlay__description';
 const INTERACT_LABEL_SELECTOR = '[data-role="interact-label"]';
 const INTERACT_DESCRIPTION_SELECTOR = '[data-role="interact-description"]';
+const COLLAPSE_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
 
 function setTextContent(
   element: Element | null | undefined,
@@ -59,5 +60,23 @@ export function applyControlOverlayStrings(
       interactItem.querySelector(INTERACT_LABEL_SELECTOR),
       strings.interact.defaultLabel
     );
+  }
+
+  const collapseToggle = container.querySelector<HTMLButtonElement>(
+    COLLAPSE_TOGGLE_SELECTOR
+  );
+  if (collapseToggle) {
+    const {
+      expandLabel,
+      collapseLabel,
+      expandAnnouncement,
+      collapseAnnouncement,
+    } = strings.mobileToggle;
+    setTextContent(collapseToggle, expandLabel);
+    collapseToggle.dataset.expandLabel = expandLabel;
+    collapseToggle.dataset.collapseLabel = collapseLabel;
+    collapseToggle.dataset.expandAnnouncement = expandAnnouncement;
+    collapseToggle.dataset.collapseAnnouncement = collapseAnnouncement;
+    collapseToggle.dataset.hudAnnounce = expandAnnouncement;
   }
 }

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -1,0 +1,285 @@
+import type { ControlOverlayStrings } from '../../assets/i18n/types';
+
+import type { HudLayout } from './layoutManager';
+import type { InputMethod } from './movementLegend';
+
+export type ResponsiveControlOverlayStrings =
+  ControlOverlayStrings['mobileToggle'];
+
+export interface ResponsiveControlOverlayHandle {
+  setLayout(layout: HudLayout): void;
+  setStrings(strings: ResponsiveControlOverlayStrings): void;
+  refresh(): void;
+  dispose(): void;
+}
+
+export interface ResponsiveControlOverlayOptions {
+  container: HTMLElement;
+  list?: HTMLElement | null;
+  toggle?: HTMLButtonElement | null;
+  strings: ResponsiveControlOverlayStrings;
+  initialLayout?: HudLayout;
+  defaultCollapsed?: boolean;
+}
+
+const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
+const CONTROL_ITEM_SELECTOR = '[data-control-item]';
+const CONTROL_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
+const CONTROL_COLLAPSED_KEY = 'controlCollapsed';
+const MOBILE_COLLAPSED_KEY = 'mobileCollapsed';
+
+const INPUT_METHODS: ReadonlyArray<InputMethod> = [
+  'keyboard',
+  'pointer',
+  'touch',
+  'gamepad',
+];
+
+const isInputMethod = (
+  value: string | null | undefined
+): value is InputMethod => INPUT_METHODS.includes(value as InputMethod);
+
+const parseInputMethods = (
+  value: string | null | undefined
+): ReadonlyArray<InputMethod> => {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(/[\s,]+/)
+    .map((method) => method.trim())
+    .filter(isInputMethod);
+};
+
+const getActiveMethod = (container: HTMLElement): InputMethod | null => {
+  const value = container.dataset.activeInput;
+  return isInputMethod(value) ? value : null;
+};
+
+const matchActiveMethod = (
+  methods: ReadonlyArray<InputMethod>,
+  active: InputMethod | null
+): boolean => {
+  if (!active) {
+    return true;
+  }
+  if (methods.includes(active)) {
+    return true;
+  }
+  if (active === 'gamepad' && methods.includes('keyboard')) {
+    return true;
+  }
+  return false;
+};
+
+const applyAnnouncement = (
+  toggle: HTMLButtonElement,
+  strings: ResponsiveControlOverlayStrings,
+  collapsed: boolean
+) => {
+  toggle.dataset.hudAnnounce = collapsed
+    ? strings.expandAnnouncement
+    : strings.collapseAnnouncement;
+};
+
+const applyToggleLabel = (
+  toggle: HTMLButtonElement,
+  strings: ResponsiveControlOverlayStrings,
+  collapsed: boolean
+) => {
+  toggle.textContent = collapsed ? strings.expandLabel : strings.collapseLabel;
+  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+  applyAnnouncement(toggle, strings, collapsed);
+};
+
+const applyContainerState = (
+  container: HTMLElement,
+  layout: HudLayout,
+  collapsed: boolean
+) => {
+  if (layout !== 'mobile') {
+    delete (container.dataset as Record<string, string | undefined>)[
+      CONTROL_COLLAPSED_KEY
+    ];
+    return;
+  }
+  container.dataset[CONTROL_COLLAPSED_KEY] = collapsed ? 'true' : 'false';
+};
+
+const applyCollapsedState = (
+  container: HTMLElement,
+  list: HTMLElement,
+  layout: HudLayout,
+  collapsed: boolean
+) => {
+  const activeMethod = getActiveMethod(container);
+  const items = Array.from(
+    list.querySelectorAll<HTMLElement>(CONTROL_ITEM_SELECTOR)
+  );
+  const shouldCollapse = layout === 'mobile' && collapsed;
+
+  for (const item of items) {
+    if (!shouldCollapse) {
+      delete (item.dataset as Record<string, string | undefined>)[
+        MOBILE_COLLAPSED_KEY
+      ];
+      continue;
+    }
+    const controlId = item.dataset.controlItem ?? '';
+    if (controlId === 'interact') {
+      delete (item.dataset as Record<string, string | undefined>)[
+        MOBILE_COLLAPSED_KEY
+      ];
+      continue;
+    }
+    const methods = parseInputMethods(item.dataset.inputMethods);
+    if (matchActiveMethod(methods, activeMethod)) {
+      delete (item.dataset as Record<string, string | undefined>)[
+        MOBILE_COLLAPSED_KEY
+      ];
+      continue;
+    }
+    item.dataset[MOBILE_COLLAPSED_KEY] = 'true';
+  }
+};
+
+export function createResponsiveControlOverlay(
+  options: ResponsiveControlOverlayOptions
+): ResponsiveControlOverlayHandle {
+  const {
+    container,
+    strings,
+    initialLayout = 'desktop',
+    defaultCollapsed,
+  } = options;
+
+  const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
+  const toggle =
+    options.toggle ?? container.querySelector(CONTROL_TOGGLE_SELECTOR);
+
+  if (
+    !(list instanceof HTMLElement) ||
+    !(toggle instanceof HTMLButtonElement)
+  ) {
+    return {
+      setLayout() {
+        /* noop */
+      },
+      setStrings() {
+        /* noop */
+      },
+      refresh() {
+        /* noop */
+      },
+      dispose() {
+        /* noop */
+      },
+    };
+  }
+
+  let layout: HudLayout = initialLayout;
+  let collapsed = defaultCollapsed ?? layout === 'mobile';
+  let currentStrings: ResponsiveControlOverlayStrings = { ...strings };
+  let disposed = false;
+
+  const update = () => {
+    if (disposed) {
+      return;
+    }
+    applyContainerState(container, layout, collapsed);
+    applyCollapsedState(container, list, layout, collapsed);
+    if (layout === 'mobile') {
+      toggle.hidden = false;
+      applyToggleLabel(toggle, currentStrings, collapsed);
+    } else {
+      toggle.hidden = true;
+      toggle.removeAttribute('aria-expanded');
+      toggle.dataset.hudAnnounce = '';
+    }
+  };
+
+  const setCollapsed = (next: boolean) => {
+    const normalized = layout === 'mobile' ? next : false;
+    if (collapsed === normalized) {
+      return;
+    }
+    collapsed = normalized;
+    update();
+  };
+
+  const handleToggleClick = () => {
+    if (layout !== 'mobile') {
+      return;
+    }
+    setCollapsed(!collapsed);
+  };
+
+  toggle.addEventListener('click', handleToggleClick);
+
+  const observer = new MutationObserver((mutations) => {
+    if (
+      mutations.some(
+        (mutation) =>
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'data-active-input'
+      )
+    ) {
+      applyCollapsedState(container, list, layout, collapsed);
+    }
+  });
+
+  observer.observe(container, {
+    attributes: true,
+    attributeFilter: ['data-active-input'],
+  });
+
+  update();
+
+  return {
+    setLayout(nextLayout: HudLayout) {
+      if (layout === nextLayout) {
+        update();
+        return;
+      }
+      layout = nextLayout;
+      if (layout === 'mobile') {
+        collapsed = true;
+      } else {
+        collapsed = false;
+      }
+      update();
+    },
+    setStrings(nextStrings: ResponsiveControlOverlayStrings) {
+      currentStrings = { ...nextStrings };
+      if (layout === 'mobile') {
+        applyToggleLabel(toggle, currentStrings, collapsed);
+      }
+    },
+    refresh() {
+      update();
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      observer.disconnect();
+      toggle.removeEventListener('click', handleToggleClick);
+      toggle.hidden = true;
+      toggle.removeAttribute('aria-expanded');
+      toggle.dataset.hudAnnounce = '';
+      toggle.textContent = currentStrings.expandLabel;
+      delete (container.dataset as Record<string, string | undefined>)[
+        CONTROL_COLLAPSED_KEY
+      ];
+      const items = Array.from(
+        list.querySelectorAll<HTMLElement>(CONTROL_ITEM_SELECTOR)
+      );
+      for (const item of items) {
+        delete (item.dataset as Record<string, string | undefined>)[
+          MOBILE_COLLAPSED_KEY
+        ];
+      }
+    },
+  };
+}


### PR DESCRIPTION
what:
- add responsive HUD control overlay with mobile collapse toggle
- update control overlay strings/tests and mark roadmap item complete

why:
- keep controls legible on small screens while preserving access to help

how to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f5ef4d5210832fa31d657f6ec3b9e9