### PR TITLE
Add LED pulse timeline compiler and tests

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,7 +68,8 @@ Focus: expand the environment while keeping navigation smooth.
        greenhouse-facing spans for a dusk-washed glow.
    - ✅ Shift+L toggles a debug lighting view that disables bloom/LEDs for side-by-side comparisons.
    - ✅ Emissive cove strips now emit via bloom-tuned LED meshes and corner fill lights.
-   - ⚙️ LED pulse programs now drive per-room emissive and fill intensities via data timelines.
+   - ✅ LED pulse programs now drive per-room emissive and fill intensities via data timelines.
+     - Timeline data in `ROOM_LED_TIMELINES` powers the animator so lighting palettes stay editable without code changes.
    - ✨ Baked dusk lightmaps now bathe floors and walls in a gradient bounce wash that pairs with the LED strips.
    - ✨ Interior walls and fences now expose dedicated UV2 channels so future bakes stay artifact-free.
 2. **House Footprint Layout**

--- a/src/tests/ledPulsePrograms.test.ts
+++ b/src/tests/ledPulsePrograms.test.ts
@@ -2,6 +2,9 @@ import { MeshStandardMaterial, PointLight } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ROOM_LED_PULSE_PROGRAMS,
+  ROOM_LED_TIMELINES,
+  compileLedTimeline,
   createLedAnimator,
   createLedProgramSampler,
   type LedPulseProgram,
@@ -73,6 +76,82 @@ describe('createLedProgramSampler', () => {
   });
 });
 
+describe('compileLedTimeline', () => {
+  it('normalizes timeline points and preserves easing assignments', () => {
+    const program = compileLedTimeline({
+      roomId: 'timeline-test',
+      cycleSeconds: 12,
+      points: [
+        {
+          timeSeconds: 4,
+          stripMultiplier: 1.2,
+          fillMultiplier: 1.1,
+          ease: 'sine-in-out',
+        },
+        { timeSeconds: -3, stripMultiplier: 0.8 },
+        { timeSeconds: 6, stripMultiplier: 1.04, fillMultiplier: 0.96 },
+        { timeSeconds: 6, stripMultiplier: 1.05, fillMultiplier: 0.98 },
+        {
+          timeSeconds: 18,
+          stripMultiplier: 0.6,
+          fillMultiplier: 0.55,
+          ease: 'linear',
+        },
+      ],
+    });
+
+    expect(program.roomId).toBe('timeline-test');
+    expect(program.cycleSeconds).toBeCloseTo(12);
+    expect(program.keyframes).toEqual([
+      {
+        time: 0,
+        stripMultiplier: 0.8,
+        fillMultiplier: 0.8,
+        ease: undefined,
+      },
+      {
+        time: 4 / 12,
+        stripMultiplier: 1.2,
+        fillMultiplier: 1.1,
+        ease: 'sine-in-out',
+      },
+      {
+        time: 6 / 12,
+        stripMultiplier: 1.05,
+        fillMultiplier: 0.98,
+        ease: undefined,
+      },
+      {
+        time: 1,
+        stripMultiplier: 0.6,
+        fillMultiplier: 0.55,
+        ease: 'linear',
+      },
+    ]);
+  });
+
+  it('duplicates lone timeline points to cover an entire cycle', () => {
+    const program = compileLedTimeline({
+      roomId: 'single',
+      cycleSeconds: 0,
+      points: [{ timeSeconds: 0, stripMultiplier: 0.7 }],
+    });
+
+    expect(program.cycleSeconds).toBeCloseTo(1e-6);
+    expect(program.keyframes).toHaveLength(2);
+    expect(program.keyframes[0]).toMatchObject({
+      time: 0,
+      stripMultiplier: 0.7,
+      fillMultiplier: 0.7,
+    });
+    expect(program.keyframes[1]).toMatchObject({
+      time: 1,
+      stripMultiplier: 0.7,
+      fillMultiplier: 0.7,
+    });
+  });
+});
+
 describe('createLedAnimator', () => {
   it('scales intensities relative to the captured baseline', () => {
     const material = new MeshStandardMaterial({ emissiveIntensity: 2 });
@@ -109,5 +188,21 @@ describe('createLedAnimator', () => {
     animator.update(2.5);
     expect(material.emissiveIntensity).toBeCloseTo(3, 5);
     expect(light.intensity).toBeCloseTo(4.2, 5);
+  });
+});
+
+describe('ROOM_LED_TIMELINES', () => {
+  it('compile into the exported pulse programs without altering sequence order', () => {
+    ROOM_LED_TIMELINES.forEach((timeline, index) => {
+      const program = compileLedTimeline(timeline);
+      expect(program.roomId).toBe(timeline.roomId);
+      expect(program.cycleSeconds).toBeCloseTo(timeline.cycleSeconds);
+      expect(program.keyframes[0]?.time).toBe(0);
+      expect(program.keyframes.at(-1)?.time).toBe(1);
+      expect(program.keyframes.length).toBeGreaterThanOrEqual(2);
+
+      const exportedProgram = ROOM_LED_PULSE_PROGRAMS[index];
+      expect(exportedProgram.keyframes).toEqual(program.keyframes);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add data-driven LED pulse timelines and a compiler to normalize room cycles
- ensure exports assemble existing programs from timeline data with new tests
- update the roadmap to note the timeline-driven LED animation milestone

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f7128c4aa4832f8263172f9ff53fdf