### PR TITLE
✨ : – soften POI pedestal fade-in

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,7 +114,7 @@ Focus: anchor each highlighted project with an interactive artifact.
      events, paving the path for gamepad + mid-air parity.
 
    - ✅ Data-driven registry now spawns holographic pedestals for Futuroptimist + Flywheel exhibits.
-   - ✨ Pedestals fade in tooltips and halo guides as players enter their interaction radii.
+   - ✅ Pedestals fade in tooltips and halo guides as players enter their interaction radii.
    - ✅ Desktop pointer interaction manager highlights POIs and emits selection events.
    - ✅ Analytics hooks emit hover and selection lifecycle events for instrumentation pipelines.
    - ✅ Interaction manager now normalizes analytics injection so instrumentation fires when

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,11 @@ import {
 } from './scene/lighting/seasonalPresets';
 import { createWindowPoiAnalytics } from './scene/poi/analytics';
 import {
+  computePoiEmphasis,
+  computePoiHaloOpacity,
+  computePoiLabelOpacity,
+} from './scene/poi/emphasis';
+import {
   wireGitHubRepoMetrics,
   type GitHubRepoMetricsController,
 } from './scene/poi/githubMetrics';
@@ -3122,7 +3127,7 @@ function initializeImmersiveScene(
         smoothing
       );
       poi.focus = MathUtils.lerp(poi.focus, poi.focusTarget, smoothing);
-      const emphasis = Math.max(poi.activation, poi.focus);
+      const emphasis = computePoiEmphasis(poi.activation, poi.focus);
       const visitedEmphasis = poi.visitedStrength;
 
       if (poi.activation > highestActivation) {
@@ -3131,8 +3136,7 @@ function initializeImmersiveScene(
       }
 
       if (poi.label && poi.labelMaterial) {
-        const baseOpacity = MathUtils.lerp(0.32, 0.52, visitedEmphasis);
-        const labelOpacity = MathUtils.lerp(baseOpacity, 1, emphasis);
+        const labelOpacity = computePoiLabelOpacity(emphasis, visitedEmphasis);
         poi.labelMaterial.opacity = labelOpacity;
         poi.label.visible = labelOpacity > 0.05;
       }
@@ -3213,8 +3217,7 @@ function initializeImmersiveScene(
           const haloScale =
             MathUtils.lerp(baseHaloScale, 1.18, emphasis) * haloPulse;
           poi.halo.scale.setScalar(haloScale);
-          const baseHaloOpacity = MathUtils.lerp(0.18, 0.32, visitedEmphasis);
-          const haloOpacity = MathUtils.lerp(baseHaloOpacity, 0.62, emphasis);
+          const haloOpacity = computePoiHaloOpacity(emphasis, visitedEmphasis);
           poi.haloMaterial.opacity = haloOpacity;
           poi.halo.visible = haloOpacity > 0.04;
           poi.haloMaterial.color.lerpColors(

--- a/src/scene/poi/emphasis.ts
+++ b/src/scene/poi/emphasis.ts
@@ -1,0 +1,38 @@
+import { MathUtils } from 'three';
+
+const ACTIVATION_FADE_IN_START = 0.18;
+const ACTIVATION_FADE_IN_END = 0.72;
+const LABEL_VISITED_BASE_MAX = 0.48;
+const HALO_VISITED_BASE_MAX = 0.3;
+const HALO_FOCUS_OPACITY = 0.62;
+
+export function computePoiEmphasis(activation: number, focus: number): number {
+  const activationClamped = MathUtils.clamp(activation, 0, 1);
+  const focusClamped = MathUtils.clamp(focus, 0, 1);
+  const activationFade = MathUtils.smoothstep(
+    activationClamped,
+    ACTIVATION_FADE_IN_START,
+    ACTIVATION_FADE_IN_END
+  );
+  return Math.max(activationFade, focusClamped);
+}
+
+export function computePoiLabelOpacity(
+  emphasis: number,
+  visitedStrength: number
+): number {
+  const emphasisClamped = MathUtils.clamp(emphasis, 0, 1);
+  const visitedClamped = MathUtils.clamp(visitedStrength, 0, 1);
+  const visitedBase = MathUtils.lerp(0, LABEL_VISITED_BASE_MAX, visitedClamped);
+  return MathUtils.lerp(visitedBase, 1, emphasisClamped);
+}
+
+export function computePoiHaloOpacity(
+  emphasis: number,
+  visitedStrength: number
+): number {
+  const emphasisClamped = MathUtils.clamp(emphasis, 0, 1);
+  const visitedClamped = MathUtils.clamp(visitedStrength, 0, 1);
+  const visitedBase = MathUtils.lerp(0, HALO_VISITED_BASE_MAX, visitedClamped);
+  return MathUtils.lerp(visitedBase, HALO_FOCUS_OPACITY, emphasisClamped);
+}

--- a/src/tests/poiEmphasis.test.ts
+++ b/src/tests/poiEmphasis.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computePoiEmphasis,
+  computePoiHaloOpacity,
+  computePoiLabelOpacity,
+} from '../scene/poi/emphasis';
+
+describe('computePoiEmphasis', () => {
+  it('keeps emphasis at zero until activation enters the fade window', () => {
+    expect(computePoiEmphasis(0.05, 0)).toBe(0);
+  });
+
+  it('ramps up with activation and smooths toward focus', () => {
+    const midActivation = computePoiEmphasis(0.5, 0);
+    expect(midActivation).toBeGreaterThan(0);
+    expect(midActivation).toBeLessThan(1);
+  });
+
+  it('prefers focus strength when larger than activation', () => {
+    expect(computePoiEmphasis(0, 0.7)).toBeCloseTo(0.7, 5);
+  });
+});
+
+describe('computePoiLabelOpacity', () => {
+  it('returns zero opacity when emphasis and visited strength are zero', () => {
+    expect(computePoiLabelOpacity(0, 0)).toBe(0);
+  });
+
+  it('scales with emphasis when no visited strength is present', () => {
+    expect(computePoiLabelOpacity(0.6, 0)).toBeCloseTo(0.6, 5);
+  });
+
+  it('maintains a visited baseline even when emphasis is zero', () => {
+    expect(computePoiLabelOpacity(0, 1)).toBeCloseTo(0.48, 5);
+  });
+
+  it('never exceeds full opacity', () => {
+    expect(computePoiLabelOpacity(1.2, 0.5)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('computePoiHaloOpacity', () => {
+  it('returns zero opacity when emphasis and visited strength are zero', () => {
+    expect(computePoiHaloOpacity(0, 0)).toBe(0);
+  });
+
+  it('lerps toward the focus opacity as emphasis increases', () => {
+    expect(computePoiHaloOpacity(0.5, 0)).toBeCloseTo(0.31, 5);
+  });
+
+  it('preserves a visited glow even when emphasis is zero', () => {
+    expect(computePoiHaloOpacity(0, 1)).toBeCloseTo(0.3, 5);
+  });
+
+  it('caps at the configured focus opacity', () => {
+    expect(computePoiHaloOpacity(10, 1)).toBeLessThanOrEqual(0.62);
+  });
+});


### PR DESCRIPTION
what: smooth POI emphasis curves to hide tooltips until activation.
why: pedestals should glow only as players enter the interaction radius.
how to test: npm run lint && npm run test:ci && npm run docs:check && npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f7128c4aa4832f8263172f9ff53fdf