### PR TITLE
Add timeline-driven LED strip pulses

### DIFF
--- a/docs/prompts/codex/lighting.md
+++ b/docs/prompts/codex/lighting.md
@@ -35,8 +35,9 @@ Summarize the change, list tests run, highlight any visual review steps.
 
 - Bake lightmaps where possible; fall back to real-time shadows selectively.
 - Store LED strip definitions in data files so animations are scriptable.
-- LED pulse programs live in `src/scene/lighting/ledPulsePrograms.ts`; extend definitions there
-  when adding new rooms or effects.
+- LED pulse programs now derive from `ROOM_LED_TIMELINES` in
+  `src/scene/lighting/ledPulsePrograms.ts`; add or adjust timeline segments there when introducing
+  new rooms or effects.
 - Add comments explaining any tone-mapping adjustments or shader hacks.
 
 ## Upgrade Prompt

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,7 +68,9 @@ Focus: expand the environment while keeping navigation smooth.
        greenhouse-facing spans for a dusk-washed glow.
    - ✅ Shift+L toggles a debug lighting view that disables bloom/LEDs for side-by-side comparisons.
    - ✅ Emissive cove strips now emit via bloom-tuned LED meshes and corner fill lights.
-   - ⚙️ LED pulse programs now drive per-room emissive and fill intensities via data timelines.
+   - ✅ LED pulse programs now drive per-room emissive and fill intensities via data timelines.
+     - Timeline segments now live in `ROOM_LED_TIMELINES`, turning the LED animator into a
+       data-driven system that mirrors real durations per room.
    - ✨ Baked dusk lightmaps now bathe floors and walls in a gradient bounce wash that pairs with the LED strips.
    - ✨ Interior walls and fences now expose dedicated UV2 channels so future bakes stay artifact-free.
 2. **House Footprint Layout**


### PR DESCRIPTION
what: move LED pulse programs to data timelines and refresh docs/tests.
why: unlock roadmap milestone for data-driven lighting control.
how to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f7128c4aa4832f8263172f9ff53fdf