### PR TITLE
Improve avatar importer skeleton validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ Keep pipelines deterministic by regenerating assets immediately after touching g
 - **Backyard installations** – The dusk courtyard now features a DSPACE-inspired model rocket on a
   lit launch pad with a safety halo, tying the exterior exhibits into the narrative while the nav
   colliders keep players clear of the ignition zone.
-- **Avatar pipeline** – `createAvatarImporter` validates GLTF bone and animation requirements and can
-  attach a DRACO decoder path so future mannequins load consistently, and a stylized emissive
-  mannequin now rides on the controller collider so the space feels inhabited even before the hero
-  avatar lands.
+- **Avatar pipeline** – `createAvatarImporter` validates GLTF bone and animation requirements,
+  insists required bones are bound to active skeletons, and can attach a DRACO decoder path so
+  future mannequins load consistently. A stylized emissive mannequin now rides on the controller
+  collider so the space feels inhabited even before the hero avatar lands.
 - **Backlog** – Future scene work is tracked in [`docs/backlog.md`](docs/backlog.md).
 
 ## Controls

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -300,7 +300,9 @@ Focus: replace the placeholder sphere with a stylized protagonist.
 
 1. **Character Import**
    - Set up GLTF/GLB ingestion pipeline with unit tests for bone/animation integrity.
-     - ⚙️ Avatar importer now validates required bones and animation clips before controller wiring.
+   - ✅ Avatar importer now validates required bones and animation clips before controller wiring.
+     - Required bones must be bound to an active skeleton so stray rig helpers cannot bypass
+       validation.
 
 - ✅ Stylized mannequin placeholder now replaces the golden sphere, aligning with the controller
   collider while showcasing emissive visor accents and HUD-ready trim palettes.

--- a/src/scene/avatar/importer.ts
+++ b/src/scene/avatar/importer.ts
@@ -145,6 +145,18 @@ function scanScene(root: Object3D): SceneScanResult {
   };
 }
 
+function collectSkeletonBoneNames(skeletons: Skeleton[]): Set<string> {
+  const names = new Set<string>();
+  for (const skeleton of skeletons) {
+    for (const bone of skeleton.bones) {
+      if (bone.name) {
+        names.add(bone.name);
+      }
+    }
+  }
+  return names;
+}
+
 function ensureRequirements(
   scan: SceneScanResult,
   animations: AnimationClip[],
@@ -162,6 +174,17 @@ function ensureRequirements(
   if (missingBones.length > 0) {
     throw new Error(
       `Avatar model is missing required bones: ${missingBones.join(', ')}`
+    );
+  }
+
+  const skeletonBoneNames = collectSkeletonBoneNames(scan.skeletons);
+  const missingBoundBones = requirements.bones.filter(
+    (bone) => !skeletonBoneNames.has(bone)
+  );
+  if (missingBoundBones.length > 0) {
+    const missingList = missingBoundBones.join(', ');
+    throw new Error(
+      `Avatar model is missing required skeleton bindings for bones: ${missingList}`
     );
   }
 

--- a/src/tests/avatarImporter.test.ts
+++ b/src/tests/avatarImporter.test.ts
@@ -144,6 +144,32 @@ describe('createAvatarImporter', () => {
     );
   });
 
+  it('throws when a required bone is not bound to a skeleton', async () => {
+    const hips = new Bone();
+    hips.name = 'Hips';
+    const spine = new Bone();
+    spine.name = 'Spine';
+    const geometry = createGeometry();
+    const material = new MeshBasicMaterial();
+    const mesh = new SkinnedMesh(geometry, material);
+    mesh.add(spine);
+    mesh.add(hips);
+    const skeleton = new Skeleton([spine]);
+    mesh.bind(skeleton);
+    const group = new Group();
+    group.add(mesh);
+    const gltf = createGltf({ group, animations: [] });
+
+    const importer = createAvatarImporter({
+      createLoader: () => ({ loadAsync: vi.fn().mockResolvedValue(gltf) }),
+      requiredBones: ['Hips'],
+    });
+
+    await expect(
+      importer.load({ url: '/missing-skeleton-binding.glb' })
+    ).rejects.toThrow(/missing required skeleton bindings/i);
+  });
+
   it('throws when a required animation clip is missing', async () => {
     const { group, idle } = createAvatarScene();
     const gltf = createGltf({ group, animations: [idle] });


### PR DESCRIPTION
## Summary
- ensure avatar importer requires required bones to be bound to active skeletons
- add coverage for skeleton-binding failures and document the stronger contract
- refresh roadmap and README notes about the avatar pipeline safeguards

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f7322943e0832f81bf98e359dbff54