### PR TITLE
Add calendar-aware seasonal lighting metadata

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -334,7 +334,8 @@ Focus: replace the placeholder sphere with a stylized protagonist.
 Ideas to evaluate after the core experience is stable:
 
 - Multiplayer showroom tours or live streams as ambient projections.
-- Seasonal lighting presets (e.g., aurora, holiday lights) scheduled via calendar.
+- ✅ Seasonal lighting presets (holiday dusk, spring bloom, summer aurora, autumn harvest)
+  now rotate via calendar and expose HUD dataset hooks for the upcoming transition window.
 - ✅ Seasonal lighting scheduler now retints LED strips and fill lights for holiday and spring
   windows, slowing or accelerating pulse programs according to the calendar.
   - ✨ Backyard lanterns now inherit seasonal palettes so the greenhouse walkway glow matches the

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,7 @@ import { createRoomLedStrips } from './scene/lighting/ledStrips';
 import {
   applySeasonalLightingPreset,
   createSeasonallyAdjustedPrograms,
-  resolveSeasonalLightingPreset,
+  resolveSeasonalLightingSchedule,
 } from './scene/lighting/seasonalPresets';
 import { createWindowPoiAnalytics } from './scene/poi/analytics';
 import {
@@ -857,7 +857,8 @@ function initializeImmersiveScene(
   scene.add(directionalLight);
   scene.add(directionalLight.target);
 
-  const seasonalPreset = resolveSeasonalLightingPreset();
+  const seasonalSchedule = resolveSeasonalLightingSchedule();
+  const seasonalPreset = seasonalSchedule.active;
 
   const defaultEnvironmentTint = new Color('#ffe4c9');
   let environmentTint = defaultEnvironmentTint.clone();
@@ -1249,6 +1250,8 @@ function initializeImmersiveScene(
 
     applySeasonalLightingPreset({
       preset: seasonalPreset,
+      nextPreset: seasonalSchedule.next,
+      nextPresetStart: seasonalSchedule.nextStartDate,
       targets: ledBuild.seasonalTargets,
       documentElement: document.documentElement,
     });
@@ -1273,6 +1276,14 @@ function initializeImmersiveScene(
 
     scene.add(ledBuild.group);
     scene.add(ledBuild.fillLightGroup);
+  } else {
+    applySeasonalLightingPreset({
+      preset: seasonalPreset,
+      nextPreset: seasonalSchedule.next,
+      nextPresetStart: seasonalSchedule.nextStartDate,
+      targets: [],
+      documentElement: document.documentElement,
+    });
   }
 
   const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides);


### PR DESCRIPTION
## Summary
- extend seasonal lighting presets with summer aurora and autumn harvest entries
- expose a schedule resolver that records the active and upcoming preset datasets
- add coverage for schedule normalization and next-season dataset handling, plus roadmap notes

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f87a2acd88832fa66717d12267b8b9