### PR TITLE
Add runtime seasonal hook for backyard lanterns

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -337,8 +337,8 @@ Ideas to evaluate after the core experience is stable:
 - Seasonal lighting presets (e.g., aurora, holiday lights) scheduled via calendar.
 - ✅ Seasonal lighting scheduler now retints LED strips and fill lights for holiday and spring
   windows, slowing or accelerating pulse programs according to the calendar.
-  - ✨ Backyard lanterns now inherit seasonal palettes so the greenhouse walkway glow matches the
-    active preset.
+  - ✅ Backyard lanterns now inherit seasonal palettes and expose a runtime retint hook so the
+    greenhouse walkway glow matches the active preset.
 - ✅ Procedural storytelling AI that narrates the journey between POIs.
   - ✅ Procedural narrator now weaves journey beats into the HUD story log whenever new exhibits are discovered.
 - ✅ Integration with GitHub API for live repo stats and contribution heatmaps.


### PR DESCRIPTION
what: expose seasonal preset hook on backyard lanterns and doc roadmap
why: keep greenhouse walkway glow aligned with active lighting palette
how to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68f87a2acd88832fa66717d12267b8b9