### PR TITLE
Normalize text mode URL helpers

### DIFF
--- a/docs/prompts/codex/modes.md
+++ b/docs/prompts/codex/modes.md
@@ -38,6 +38,8 @@ Include summary, automated tests, and manual verification checklist.
 - Low-end detection now considers hardware concurrency ≤2 and legacy mobile user agents.
   Use `?mode=immersive&disablePerformanceFailover=1` when validating on constrained
   dev environments. A `<noscript>` text tour keeps scrapers and no-JS browsers covered.
+- Use `createImmersiveModeUrl(...)` and `createTextModeUrl(...)` helpers to add mode
+  overrides without clobbering existing query parameters or hashes.
 
 ## Upgrade Prompt
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -228,6 +228,8 @@ Focus: unify user controls and ensure graceful fallback experiences.
      crawlers understand language coverage and free access guarantees.
    - ✅ Text fallback links back to immersive mode with the override URL so returns bypass
      automatic failover heuristics.
+   - ✅ Text mode URL builder now normalizes canonical share links so `?mode=text` appends
+     cleanly even when queries or hash fragments already exist.
 3. **Progression & State**
    - Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
      - ✅ SessionStorage fallback now protects POI progress when localStorage is blocked.

--- a/src/scene/poi/structuredData.ts
+++ b/src/scene/poi/structuredData.ts
@@ -8,6 +8,7 @@ import {
   getSiteStrings,
   resolveLocale,
 } from '../../assets/i18n';
+import { createTextModeUrl } from '../../ui/immersiveUrl';
 
 import type { PoiDefinition } from './types';
 
@@ -17,7 +18,6 @@ const TEXT_SCRIPT_ELEMENT_ID = 'danielsmith-portfolio-text-structured-data';
 const ITEM_LIST_FRAGMENT = '#immersive-poi-list';
 const PAGE_FRAGMENT = '#immersive-poi-page';
 const TEXT_COLLECTION_FRAGMENT = '#text-tour';
-const TEXT_MODE_QUERY = '?mode=text';
 const IMMERSIVE_OVERRIDE_QUERY = '?mode=immersive&disablePerformanceFailover=1';
 
 const stripFragmentAndQuery = (value: string): string => {
@@ -204,10 +204,6 @@ const createSiteEntry = (
     inLanguage: locale,
     isAccessibleForFree: true,
   };
-};
-
-const createTextModeUrl = (canonical: string): string => {
-  return `${canonical}${TEXT_MODE_QUERY}`;
 };
 
 const createImmersiveOverrideUrl = (canonical: string): string => {
@@ -568,7 +564,6 @@ export const _testables = {
   ensureTrailingSlash,
   normalizeCanonicalUrl,
   createPoiUrl,
-  createTextModeUrl,
   createImmersiveOverrideUrl,
   SCRIPT_ELEMENT_ID,
   TEXT_SCRIPT_ELEMENT_ID,

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createImmersiveModeUrl,
+  createTextModeUrl,
   hasImmersiveOverride,
   hasPerformanceFailoverBypass,
   shouldDisablePerformanceFailover,
@@ -39,6 +40,42 @@ describe('createImmersiveModeUrl', () => {
     expect(url).toBe(
       '/space?mode=immersive&feature=preview&disablePerformanceFailover=1'
     );
+  });
+});
+
+describe('createTextModeUrl', () => {
+  it('appends mode=text to relative paths while preserving fragments', () => {
+    expect(
+      createTextModeUrl({
+        pathname: '/portfolio',
+        search: '',
+        hash: '#text',
+      })
+    ).toBe('/portfolio?mode=text#text');
+  });
+
+  it('replaces existing mode values and strips performance bypass flags', () => {
+    const url = createTextModeUrl({
+      pathname: '/portfolio',
+      search: '?mode=immersive&feature=demo&disablePerformanceFailover=1',
+      hash: '',
+    });
+    expect(url).toBe('/portfolio?mode=text&feature=demo');
+  });
+
+  it('supports absolute canonical URLs with existing query and hash', () => {
+    const url = createTextModeUrl('https://example.com/app?ref=promo#hero');
+    expect(url).toBe('https://example.com/app?ref=promo&mode=text#hero');
+  });
+
+  it('appends query separator when canonical URL lacks params', () => {
+    const url = createTextModeUrl('https://example.com/app/');
+    expect(url).toBe('https://example.com/app/?mode=text');
+  });
+
+  it('falls back to root path when pathname is empty', () => {
+    const url = createTextModeUrl({ pathname: '', search: '', hash: '' });
+    expect(url).toBe('/?mode=text');
   });
 });
 

--- a/src/tests/poiStructuredData.test.ts
+++ b/src/tests/poiStructuredData.test.ts
@@ -8,6 +8,7 @@ import {
   injectTextPortfolioStructuredData,
 } from '../scene/poi/structuredData';
 import type { PoiDefinition } from '../scene/poi/types';
+import { createTextModeUrl } from '../ui/immersiveUrl';
 
 const createPoi = (overrides: Partial<PoiDefinition> = {}): PoiDefinition => ({
   id: 'futuroptimist-living-room-tv',
@@ -33,7 +34,6 @@ const {
   ITEM_LIST_FRAGMENT,
   PAGE_FRAGMENT,
   TEXT_COLLECTION_FRAGMENT,
-  createTextModeUrl,
   createImmersiveOverrideUrl,
 } = _testables;
 

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -2,12 +2,15 @@ export const IMMERSIVE_MODE_PARAM = 'mode';
 export const IMMERSIVE_MODE_VALUE = 'immersive';
 export const DISABLE_PERFORMANCE_FAILOVER_PARAM = 'disablePerformanceFailover';
 export const DISABLE_PERFORMANCE_FAILOVER_VALUE = '1';
+export const TEXT_MODE_VALUE = 'text';
 
 interface LocationLike {
   pathname: string;
   search?: string;
   hash?: string | null;
 }
+
+type UrlLike = string | LocationLike | undefined;
 
 const normalizeLocation = (location?: LocationLike) => {
   if (location) {
@@ -29,17 +32,80 @@ const normalizeLocation = (location?: LocationLike) => {
   };
 };
 
-export const createImmersiveModeUrl = (location?: LocationLike) => {
-  const { pathname, search, hash } = normalizeLocation(location);
-  const params = new URLSearchParams(search);
-  params.set(IMMERSIVE_MODE_PARAM, IMMERSIVE_MODE_VALUE);
-  params.set(
-    DISABLE_PERFORMANCE_FAILOVER_PARAM,
-    DISABLE_PERFORMANCE_FAILOVER_VALUE
-  );
-  const query = params.toString();
-  return `${pathname}${query ? `?${query}` : ''}${hash}`;
+interface UrlParts {
+  base: string;
+  search: string;
+  hash: string;
+}
+
+const splitHash = (value: string): { withoutHash: string; hash: string } => {
+  const hashIndex = value.indexOf('#');
+  if (hashIndex === -1) {
+    return { withoutHash: value, hash: '' };
+  }
+  return {
+    withoutHash: value.slice(0, hashIndex),
+    hash: value.slice(hashIndex),
+  };
 };
+
+const splitSearch = (value: string): { base: string; search: string } => {
+  const queryIndex = value.indexOf('?');
+  if (queryIndex === -1) {
+    return { base: value, search: '' };
+  }
+  return {
+    base: value.slice(0, queryIndex),
+    search: value.slice(queryIndex),
+  };
+};
+
+const normalizeUrlParts = (input: UrlLike): UrlParts => {
+  if (typeof input === 'string') {
+    const { withoutHash, hash } = splitHash(input);
+    const { base, search } = splitSearch(withoutHash);
+    return { base, search, hash };
+  }
+  const { pathname, search, hash } = normalizeLocation(input);
+  const base = pathname && pathname.length > 0 ? pathname : '/';
+  return { base, search, hash };
+};
+
+const toParams = (search: string): URLSearchParams =>
+  new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+
+interface BuildModeUrlOptions {
+  includePerformanceBypass: boolean;
+}
+
+const buildModeUrl = (
+  input: UrlLike,
+  modeValue: string,
+  options: BuildModeUrlOptions
+) => {
+  const { base, search, hash } = normalizeUrlParts(input);
+  const params = toParams(search);
+  params.set(IMMERSIVE_MODE_PARAM, modeValue);
+  if (options.includePerformanceBypass) {
+    params.set(
+      DISABLE_PERFORMANCE_FAILOVER_PARAM,
+      DISABLE_PERFORMANCE_FAILOVER_VALUE
+    );
+  } else {
+    params.delete(DISABLE_PERFORMANCE_FAILOVER_PARAM);
+  }
+  const query = params.toString();
+  return `${base}${query ? `?${query}` : ''}${hash ?? ''}`;
+};
+
+export const createImmersiveModeUrl = (location?: LocationLike) => {
+  return buildModeUrl(location, IMMERSIVE_MODE_VALUE, {
+    includePerformanceBypass: true,
+  });
+};
+
+export const createTextModeUrl = (input?: UrlLike) =>
+  buildModeUrl(input, TEXT_MODE_VALUE, { includePerformanceBypass: false });
 
 const toSearchParams = (value: string | URLSearchParams): URLSearchParams =>
   typeof value === 'string' ? new URLSearchParams(value) : value;


### PR DESCRIPTION
## Summary
- normalize immersive/text mode URL builders so queries and hashes stay intact
- share createTextModeUrl across structured data usage and prompt guidance

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68fb207c7b94832fa9e95c409d2f93de