### PR TITLE
Retint walkway motes with seasonal presets

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,6 +98,8 @@ Focus: expand the environment while keeping navigation smooth.
      that honor accessibility damping scales.
    - ✨ Dusk pollen motes now drift along the greenhouse walkway with accessibility-aware swirl
      damping for calm-mode visitors.
+   - ✅ Seasonal presets now retint the dusk pollen motes so backyard event palettes stay in sync
+     with ambient lighting.
    - ✨ Gradient dusk sky dome now envelopes the backyard and animates the horizon glow.
 
 ## Phase 2 – Points of Interest (POIs)


### PR DESCRIPTION
## Summary
- add seasonal tint application for backyard walkway motes driven by seasonal presets
- cover tint, fallback, and saturation behaviors with backyard environment tests
- note the pollen mote palette sync in the roadmap outdoor transition section

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68fe9d23248c832f8f9f0601a8319466