### PR TITLE
Improve POI tooltip accessibility focus handling

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,7 +113,7 @@ Focus: anchor each highlighted project with an interactive artifact.
 
 - ✅ Each POI card includes a one-line outcome metric (e.g., "Reduced p95 render 28%"), backed by
   links in `docs/case-studies/`.
-- Tooltips overlay passes axe CI and keyboard focus audit.
+- ✅ Tooltips overlay passes axe CI and keyboard focus audit.
 - Release tag `phase-2-pois` ships with gallery screenshots + metrics table entry.
 
 1. **POI Framework**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1698,8 +1698,8 @@ function initializeImmersiveScene(
     poiWorldTooltip.setHovered(resolveWorldTooltipTarget(poi));
   });
   const removeSelectionStateListener =
-    poiInteractionManager.addSelectionStateListener((poi) => {
-      poiTooltipOverlay.setSelected(poi);
+    poiInteractionManager.addSelectionStateListener((poi, context) => {
+      poiTooltipOverlay.setSelected(poi, context);
       poiWorldTooltip.setSelected(resolveWorldTooltipTarget(poi));
     });
   const removeSelectionListener = poiInteractionManager.addSelectionListener(

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -236,10 +236,19 @@ describe('PoiInteractionManager', () => {
       new MouseEvent('click', { clientX: 200, clientY: 200 })
     );
 
-    expect(listener).toHaveBeenCalledWith(definition);
+    expect(listener).toHaveBeenCalledWith(definition, {
+      inputMethod: 'pointer',
+    });
     expect(customEventHandler).toHaveBeenCalledTimes(1);
+    const customEvent = customEventHandler.mock.calls[0]?.[0] as CustomEvent;
+    expect(customEvent.detail).toEqual({
+      poi: definition,
+      inputMethod: 'pointer',
+    });
     expect(poi.focusTarget).toBe(1);
-    expect(selectionState).toHaveBeenLastCalledWith(definition);
+    expect(selectionState).toHaveBeenLastCalledWith(definition, {
+      inputMethod: 'pointer',
+    });
 
     domElement.dispatchEvent(new MouseEvent('mouseleave'));
     expect(poi.focusTarget).toBe(1);
@@ -275,7 +284,9 @@ describe('PoiInteractionManager', () => {
     dispatchTouchEvent(domElement, 'touchend', [
       { clientX: 210, clientY: 210, identifier: 42 },
     ]);
-    expect(selection).toHaveBeenCalledWith(definition);
+    expect(selection).toHaveBeenCalledWith(definition, {
+      inputMethod: 'touch',
+    });
     expect(poi.focusTarget).toBe(1);
 
     dispatchTouchEvent(domElement, 'touchend', []);
@@ -386,8 +397,13 @@ describe('PoiInteractionManager', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
-    expect(listener).toHaveBeenCalledWith(definition);
+    expect(listener).toHaveBeenNthCalledWith(1, definition, {
+      inputMethod: 'keyboard',
+    });
     expect(customEventHandler).toHaveBeenCalledTimes(1);
+    const keyboardSelectionEvent = customEventHandler.mock
+      .calls[0]?.[0] as CustomEvent;
+    expect(keyboardSelectionEvent.detail.inputMethod).toBe('keyboard');
     expect(poi.focusTarget).toBe(1);
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
@@ -395,6 +411,9 @@ describe('PoiInteractionManager', () => {
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
     expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenNthCalledWith(2, definition, {
+      inputMethod: 'keyboard',
+    });
 
     window.removeEventListener('poi:selected', customEventHandler);
   });
@@ -406,7 +425,9 @@ describe('PoiInteractionManager', () => {
 
     manager.selectPoiById(definition.id);
 
-    expect(listener).toHaveBeenCalledWith(definition);
+    expect(listener).toHaveBeenCalledWith(definition, {
+      inputMethod: 'keyboard',
+    });
     expect(poi.focusTarget).toBe(1);
   });
 
@@ -418,10 +439,14 @@ describe('PoiInteractionManager', () => {
     domElement.dispatchEvent(
       new MouseEvent('click', { clientX: 200, clientY: 200 })
     );
-    expect(selectionState).toHaveBeenLastCalledWith(definition);
+    expect(selectionState).toHaveBeenLastCalledWith(definition, {
+      inputMethod: 'pointer',
+    });
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-    expect(selectionState).toHaveBeenLastCalledWith(null);
+    expect(selectionState).toHaveBeenLastCalledWith(null, {
+      inputMethod: 'keyboard',
+    });
   });
 
   it('ignores keyboard input when disabled', () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1520,6 +1520,14 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   z-index: 30;
 }
 
+.poi-tooltip-overlay:focus-visible {
+  outline: none;
+  border-color: rgba(143, 214, 255, 0.75);
+  box-shadow:
+    0 36px 92px rgba(3, 8, 18, 0.7),
+    0 0 0 3px rgba(143, 214, 255, 0.75);
+}
+
 .poi-tooltip-overlay--visible {
   opacity: 1;
   transform: translateY(0);


### PR DESCRIPTION
What:
- add input method context to POI selection events
- focus tooltip overlay for keyboard use and expand aria metadata

Why:
- satisfy the roadmap axe/focus audit for POI overlays

How to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6902b18e5600832f8b21a5a2cb2f4b7a