### PR TITLE
Add traveling wave beacons to greenhouse walkway

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -96,6 +96,8 @@ Focus: expand the environment while keeping navigation smooth.
    - ✅ Sculpted dusk backyard terrain with terraced pathing, perimeter fencing, and a gradient skybox.
    - ✅ Installed hologram barrier and signage to stage future backyard exhibits.
    - ✨ Lantern-lined walkway now guides the greenhouse approach with pulsing dusk beacons.
+     - Lantern beacons now ripple toward the greenhouse in a traveling wave that honors
+       calm-mode damping.
    - ✨ Firefly swarms now orbit the greenhouse walkway with accessibility-aware twinkle damping.
      - ✅ Firefly calm-mode presets now ease orbital amplitude and glow for sensitive players.
    - ✅ Fiber-optic pathway guides now trace the greenhouse approach with seasonal-aware pulses


### PR DESCRIPTION
## Summary
- animate the greenhouse walkway lanterns with traveling wave pulses that respect seasonal tinting and accessibility damping
- modulate lantern light colors and intensity scaling from refreshed accent targets
- extend backyard environment tests and roadmap notes to cover the new ripple behavior

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6903133ef984832fa4c42a9951654c18