### PR TITLE
Guard help modal announcements when state is unchanged

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -210,6 +210,9 @@ Focus: unify user controls and ensure graceful fallback experiences.
      accessibility tips, and failover guidance.
    - ✅ Help modal open and close events now announce their state to screen readers so
      keyboard visitors know when the panel is active.
+   - ✅ Help modal controller now suppresses duplicate announcements and restores HUD
+     visibility if an open attempt fails, preventing repeated screen reader chatter and
+     keeping the settings stack in sync with modal state.
    - ✅ Accessibility HUD presets now expose Standard, Calm, and Photosensitive-safe modes
      that soften bloom, ease emissives, duck ambient audio, and boost HUD contrast.
      - ✅ Graphics HUD presets let players choose Cinematic, Balanced, or Performance modes


### PR DESCRIPTION
## Summary
- guard the help modal controller so redundant open/close requests no longer emit duplicate announcements
- revert HUD visibility when an open attempt fails and document the roadmap entry for the controller safeguards
- add regression coverage to ensure duplicate and failed openings stay quiet and restore HUD state

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_69045c15e3c8832f826ff03cb7b71677