### PR TITLE
Add orbiting quest backlog indicators to Axel navigator

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -166,8 +166,10 @@ Focus: anchor each highlighted project with an interactive artifact.
      and diagnostics beacons.
    - ✅ Orbiting data shards now sync their emissive sweeps with visitor
      emphasis pulses, echoing the HUD analytics glow rhythm.
-   - ✨ Axel quest navigator tabletop now charts backlog quests with holographic rings and
+   - ✅ Axel quest navigator tabletop now charts backlog quests with holographic rings and
      momentum beacons around the studio tracker POI.
+     - Quest backlog indicators now orbit the hologram in real time, pulsing halo beacons as
+       sprints accelerate toward completion.
    - ✅ Gitshelves living room array now tessellates commit shelves with streak-reactive glow
      columns and nightly sync signage.
 3. **Backyard Exhibits**


### PR DESCRIPTION
## Summary
- add quest momentum presets to the Axel navigator with emissive orbiting indicators and halos
- animate quest backlog beacons to pulse and orbit with emphasis-driven pacing
- document the roadmap update reflecting the completed navigator tabletop feature

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_69045c15e3c8832f826ff03cb7b71677