### PR TITLE
Retint backyard sky dome with seasonal presets

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -112,7 +112,8 @@ Focus: expand the environment while keeping navigation smooth.
      with ambient lighting.
    - ✅ Dusk mist ribbons now drift above the greenhouse walkway with seasonal retints and
      calm-mode damping.
-   - ✨ Gradient dusk sky dome now envelopes the backyard and animates the horizon glow.
+   - ✅ Gradient dusk sky dome now envelopes the backyard, animates the horizon glow, and
+     retints with seasonal presets.
 
 ## Phase 2 – Points of Interest (POIs)
 


### PR DESCRIPTION
what: teach the backyard sky dome to accept seasonal tints and cycle scales.
why: keeps the dusk horizon aligned with seasonal lighting presets and docs.
how to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_690542371344832f92db7acd56b252ab