### PR TITLE
Sync walkway arrow holograms with seasonal palettes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,6 +106,8 @@ Focus: expand the environment while keeping navigation smooth.
      that sweep toward the greenhouse while honoring accessibility damping scales.
    - ✅ Holographic walkway arrows now sweep visitors toward the greenhouse while calm-mode
      pulses keep motion gentle for sensitive players.
+     - ✅ Seasonal retints now sync the walkway arrow holograms with the dusk mote palette so
+       backyard lighting presets keep signage, mist, and pollen in the same tint family.
    - ✅ Dusk pollen motes now drift along the greenhouse walkway with accessibility-aware swirl
      damping for calm-mode visitors.
    - ✅ Seasonal presets now retint the dusk pollen motes so backyard event palettes stay in sync

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -69,6 +69,11 @@ interface WalkwayArrowTarget {
   phase: number;
 }
 
+interface WalkwayArrowSeasonalTarget {
+  material: MeshBasicMaterial;
+  baseColor: Color;
+}
+
 interface WalkwayMistLayer {
   mesh: Mesh;
   uniforms: {
@@ -583,6 +588,7 @@ export function createBackyardEnvironment(
   const walkwayArrowGroup = new Group();
   walkwayArrowGroup.name = 'BackyardWalkwayArrows';
   const walkwayArrowTargets: WalkwayArrowTarget[] = [];
+  const walkwayArrowSeasonalTargets: WalkwayArrowSeasonalTarget[] = [];
   const walkwayArrowCount = 3;
   const arrowBaseWidth = walkwayWidth * 0.26;
   const arrowBaseLength = walkwayDepth * 0.28;
@@ -609,6 +615,10 @@ export function createBackyardEnvironment(
       arrowBaseLength * (0.84 + Math.cos(ratio * Math.PI) * 0.12);
     arrow.scale.set(widthScale, 1, lengthScale);
     walkwayArrowGroup.add(arrow);
+    walkwayArrowSeasonalTargets.push({
+      material,
+      baseColor: material.color.clone(),
+    });
     walkwayArrowTargets.push({
       mesh: arrow,
       baseOpacity: material.opacity ?? 0.68,
@@ -870,6 +880,10 @@ export function createBackyardEnvironment(
     walkwayMistLayers.forEach((layer) => {
       layer.uniforms.color.value.copy(layer.baseColor);
     });
+    walkwayArrowSeasonalTargets.forEach((target) => {
+      target.material.color.copy(target.baseColor);
+      target.material.needsUpdate = true;
+    });
     if (!preset) {
       walkwayMoteMaterial.needsUpdate = true;
       pollenMaterial.needsUpdate = true;
@@ -912,6 +926,14 @@ export function createBackyardEnvironment(
         walkwayMoteTintColor,
         tintStrength
       );
+    });
+    walkwayArrowSeasonalTargets.forEach((target) => {
+      target.material.color.lerpColors(
+        target.baseColor,
+        walkwayMoteTintColor,
+        tintStrength
+      );
+      target.material.needsUpdate = true;
     });
     walkwayMoteMaterial.needsUpdate = true;
     pollenMaterial.needsUpdate = true;

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -545,6 +545,17 @@ describe('createBackyardEnvironment', () => {
     const baselinePollenMaterial = (baselinePollen as Points)
       .material as PointsMaterial;
     const basePollenColor = baselinePollenMaterial.color.clone();
+    const baselineArrowGroup = baseline.group.getObjectByName(
+      'BackyardWalkwayArrows'
+    );
+    expect(baselineArrowGroup).toBeInstanceOf(Group);
+    const baselineArrow = (baselineArrowGroup as Group).children.find((child) =>
+      child.name.startsWith('BackyardWalkwayArrow-')
+    ) as Mesh | undefined;
+    expect(baselineArrow).toBeInstanceOf(Mesh);
+    const baselineArrowMaterial = (baselineArrow!
+      .material as MeshBasicMaterial)!;
+    const baseArrowColor = baselineArrowMaterial.color.clone();
 
     const preset: SeasonalLightingPreset = {
       id: 'backyard-festival',
@@ -573,6 +584,22 @@ describe('createBackyardEnvironment', () => {
     expect(material.color.g).toBeCloseTo(expectedTint.g, 5);
     expect(material.color.b).toBeCloseTo(expectedTint.b, 5);
 
+    const arrowGroup = environment.group.getObjectByName(
+      'BackyardWalkwayArrows'
+    );
+    expect(arrowGroup).toBeInstanceOf(Group);
+    const tintedArrow = (arrowGroup as Group).children.find((child) =>
+      child.name.startsWith('BackyardWalkwayArrow-')
+    ) as Mesh | undefined;
+    expect(tintedArrow).toBeInstanceOf(Mesh);
+    const tintedArrowMaterial = (tintedArrow!.material as MeshBasicMaterial)!;
+    const expectedArrowTint = baseArrowColor
+      .clone()
+      .lerp(new Color('#ff88cc'), 0.65);
+    expect(tintedArrowMaterial.color.r).toBeCloseTo(expectedArrowTint.r, 5);
+    expect(tintedArrowMaterial.color.g).toBeCloseTo(expectedArrowTint.g, 5);
+    expect(tintedArrowMaterial.color.b).toBeCloseTo(expectedArrowTint.b, 5);
+
     const pollen = environment.group.getObjectByName('BackyardPollenMotes');
     expect(pollen).toBeInstanceOf(Points);
     const pollenMaterial = (pollen as Points).material as PointsMaterial;
@@ -590,6 +617,9 @@ describe('createBackyardEnvironment', () => {
     expect(pollenMaterial.color.r).toBeCloseTo(basePollenColor.r, 5);
     expect(pollenMaterial.color.g).toBeCloseTo(basePollenColor.g, 5);
     expect(pollenMaterial.color.b).toBeCloseTo(basePollenColor.b, 5);
+    expect(tintedArrowMaterial.color.r).toBeCloseTo(baseArrowColor.r, 5);
+    expect(tintedArrowMaterial.color.g).toBeCloseTo(baseArrowColor.g, 5);
+    expect(tintedArrowMaterial.color.b).toBeCloseTo(baseArrowColor.b, 5);
 
     const zeroStrengthPreset: SeasonalLightingPreset = {
       ...preset,
@@ -606,6 +636,9 @@ describe('createBackyardEnvironment', () => {
     expect(pollenMaterial.color.r).toBeCloseTo(basePollenColor.r, 5);
     expect(pollenMaterial.color.g).toBeCloseTo(basePollenColor.g, 5);
     expect(pollenMaterial.color.b).toBeCloseTo(basePollenColor.b, 5);
+    expect(tintedArrowMaterial.color.r).toBeCloseTo(baseArrowColor.r, 5);
+    expect(tintedArrowMaterial.color.g).toBeCloseTo(baseArrowColor.g, 5);
+    expect(tintedArrowMaterial.color.b).toBeCloseTo(baseArrowColor.b, 5);
 
     const invalidTintPreset: SeasonalLightingPreset = {
       ...preset,
@@ -630,6 +663,9 @@ describe('createBackyardEnvironment', () => {
     expect(pollenMaterial.color.r).toBeCloseTo(expectedPollenTint.r, 5);
     expect(pollenMaterial.color.g).toBeCloseTo(expectedPollenTint.g, 5);
     expect(pollenMaterial.color.b).toBeCloseTo(expectedPollenTint.b, 5);
+    expect(tintedArrowMaterial.color.r).toBeCloseTo(expectedArrowTint.r, 5);
+    expect(tintedArrowMaterial.color.g).toBeCloseTo(expectedArrowTint.g, 5);
+    expect(tintedArrowMaterial.color.b).toBeCloseTo(expectedArrowTint.b, 5);
 
     const highStrengthPreset: SeasonalLightingPreset = {
       ...preset,
@@ -648,6 +684,12 @@ describe('createBackyardEnvironment', () => {
     expect(pollenMaterial.color.r).toBeCloseTo(saturatedPollenTint.r, 5);
     expect(pollenMaterial.color.g).toBeCloseTo(saturatedPollenTint.g, 5);
     expect(pollenMaterial.color.b).toBeCloseTo(saturatedPollenTint.b, 5);
+    const saturatedArrowTint = baseArrowColor
+      .clone()
+      .lerp(new Color('#ff88cc'), 1);
+    expect(tintedArrowMaterial.color.r).toBeCloseTo(saturatedArrowTint.r, 5);
+    expect(tintedArrowMaterial.color.g).toBeCloseTo(saturatedArrowTint.g, 5);
+    expect(tintedArrowMaterial.color.b).toBeCloseTo(saturatedArrowTint.b, 5);
   });
 
   it('retints walkway lanterns and preserves seasonal baselines', () => {


### PR DESCRIPTION
## Summary
- tint greenhouse walkway arrow holograms with seasonal presets
- extend backyard seasonal tint tests to cover arrow signage
- note the seasonal retint behaviour in the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6905a6f56bd8832fbb2735e3bb8254f7