### PR TITLE
Add Wove loom weaving animation and shuttle glow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,8 +158,10 @@ Focus: anchor each highlighted project with an interactive artifact.
      holographic log ticker, clipboard callouts, and ambient halo lighting.
    - ✅ Sigma fabrication bench now anchors the kitchen Sigma POI with a glowing ESP32 AI pin,
      holographic spec sheet, and animated print arm choreography.
-   - ✨ Wove tactile loom now weaves animated warp threads and a glowing shuttle to anchor the
+   - ✅ Wove tactile loom now weaves animated warp threads and a glowing shuttle to anchor the
      kitchen Wove POI with a tactile robotics vignette.
+     - Warp ripples now sync to emphasis pulses while the shuttle projects a warm glow wash
+       across the loom table as it slides.
    - ✨ Wall-mounted Futuroptimist media wall now frames the living room POI with a branded
      screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
      - ✅ Undershelf LED wash now breathes with POI emphasis while calm/photosensitive presets

--- a/src/scene/structures/__tests__/woveLoom.test.ts
+++ b/src/scene/structures/__tests__/woveLoom.test.ts
@@ -1,4 +1,4 @@
-import { Mesh, MeshStandardMaterial } from 'three';
+import { Mesh, MeshBasicMaterial, MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { createWoveLoom } from '../woveLoom';
@@ -27,7 +27,7 @@ describe('createWoveLoom', () => {
     );
   });
 
-  it('animates spool rotation, thread glow, and shuttle motion', () => {
+  it('animates spool rotation, warp weaving, glow intensity, and shuttle motion', () => {
     const build = createWoveLoom({ position: { x: 0, z: 0 } });
     const spool = build.group.getObjectByName('WoveLoomSpool') as Mesh | null;
     const thread = build.group.getObjectByName(
@@ -36,23 +36,33 @@ describe('createWoveLoom', () => {
     const shuttle = build.group.getObjectByName(
       'WoveLoomShuttle'
     ) as Mesh | null;
+    const shuttleGlow = build.group.getObjectByName(
+      'WoveLoomShuttleGlow'
+    ) as Mesh | null;
 
-    if (!spool || !thread || !shuttle) {
+    if (!spool || !thread || !shuttle || !shuttleGlow) {
       throw new Error('Expected loom components to be present.');
     }
 
     const threadMaterial = thread.material as MeshStandardMaterial;
+    const shuttleGlowMaterial = shuttleGlow.material as MeshBasicMaterial;
     const initialRotation = spool.rotation.x;
 
     build.update({ elapsed: 0.6, delta: 0.12, emphasis: 0.1 });
     const rotationAfterLow = spool.rotation.x;
     const intensityAfterLow = threadMaterial.emissiveIntensity;
     const shuttleAfterLow = shuttle.position.x;
+    const threadWeaveLow = thread.position.x;
+    const threadScaleLow = thread.scale.y;
+    const glowOpacityLow = shuttleGlowMaterial.opacity;
 
     build.update({ elapsed: 1.2, delta: 0.12, emphasis: 0.95 });
     const rotationAfterHigh = spool.rotation.x;
     const intensityAfterHigh = threadMaterial.emissiveIntensity;
     const shuttleAfterHigh = shuttle.position.x;
+    const threadWeaveHigh = thread.position.x;
+    const threadScaleHigh = thread.scale.y;
+    const glowOpacityHigh = shuttleGlowMaterial.opacity;
 
     const lowDelta = rotationAfterLow - initialRotation;
     const highDelta = rotationAfterHigh - rotationAfterLow;
@@ -61,5 +71,8 @@ describe('createWoveLoom', () => {
     expect(highDelta).toBeGreaterThan(lowDelta);
     expect(intensityAfterHigh).toBeGreaterThan(intensityAfterLow);
     expect(shuttleAfterHigh).not.toBe(shuttleAfterLow);
+    expect(Math.abs(threadWeaveHigh - threadWeaveLow)).toBeGreaterThan(1e-4);
+    expect(threadScaleHigh).not.toBe(threadScaleLow);
+    expect(glowOpacityHigh).toBeGreaterThan(glowOpacityLow);
   });
 });


### PR DESCRIPTION
## Summary
- animate the Wove loom warp threads and shuttle glow using emphasis-driven pulses
- cover the new weaving behavior with unit tests and mark the roadmap slice complete

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6905a6f56bd8832fbb2735e3bb8254f7