### PR TITLE
Add median FPS telemetry to performance failover logs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,7 +37,7 @@ captures; keep artifacts in `docs/metrics/`.
     to the text experience while honoring `?mode=immersive&disablePerformanceFailover=1`
     overrides.
   - ✅ Runtime performance monitor now auto-switches to text mode after 5 s below 30 FPS.
-  - ✅ Low-performance failover logs now surface min/p95 FPS and sample counts for telemetry handoff.
+  - ✅ Low-performance failover logs now surface min/median/p95 FPS and sample counts for telemetry handoff.
 
 ## Phase 0 – Foundations (Shipped)
 
@@ -154,8 +154,11 @@ Focus: anchor each highlighted project with an interactive artifact.
    - ✅ Docs callout glow now locks to POI selection, syncing rotor surges with interaction
      intent and spotlighting the flywheel docs CTA.
    - ✅ Studio desk with holographic terminal referencing `jobbot3000` automation lineage.
-   - ✨ f2clipboard incident console now elevates the kitchen diagnostics POI with a
+
+   - ✅ f2clipboard incident console now elevates the kitchen diagnostics POI with a
      holographic log ticker, clipboard callouts, and ambient halo lighting.
+     - Clipboard panel now floats animated summary cards that glow brighter with POI
+       emphasis so diagnostics feel alive as triage intensity climbs.
    - ✅ Sigma fabrication bench now anchors the kitchen Sigma POI with a glowing ESP32 AI pin,
      holographic spec sheet, and animated print arm choreography.
    - ✨ Wove tactile loom now weaves animated warp threads and a glowing shuttle to anchor the
@@ -177,6 +180,7 @@ Focus: anchor each highlighted project with an interactive artifact.
        sprints accelerate toward completion.
    - ✅ Gitshelves living room array now tessellates commit shelves with streak-reactive glow
      columns and nightly sync signage.
+
 3. **Backyard Exhibits**
    - ✅ Launch-ready model rocket for `DSPACE`, complete with illuminated launch pad, pulsing
      caution halo, countdown-ready stance, and an interactive POI that links to the mission log.

--- a/src/main.ts
+++ b/src/main.ts
@@ -757,15 +757,24 @@ function initializeImmersiveScene(
     markAppReady: markDocumentReady,
     fpsThreshold: PERFORMANCE_FAILOVER_FPS_THRESHOLD,
     minimumDurationMs: PERFORMANCE_FAILOVER_DURATION_MS,
-    onTrigger: ({ averageFps, durationMs, p95Fps, sampleCount, minFps }) => {
+    onTrigger: ({
+      averageFps,
+      durationMs,
+      p95Fps,
+      sampleCount,
+      minFps,
+      medianFps,
+    }) => {
       const roundedDuration = Math.round(durationMs);
       const averaged = averageFps.toFixed(1);
       const percentile = p95Fps.toFixed(1);
       const floor = minFps.toFixed(1);
+      const median = medianFps.toFixed(1);
       console.warn(
         `Switching to text fallback after ${roundedDuration}ms below ` +
           `${PERFORMANCE_FAILOVER_FPS_THRESHOLD} FPS (avg ${averaged} FPS, ` +
-          `p95 ${percentile} FPS, min ${floor} FPS across ${sampleCount} samples).`
+          `median ${median} FPS, p95 ${percentile} FPS, min ${floor} FPS across ` +
+          `${sampleCount} samples).`
       );
     },
     onBeforeFallback: () => {

--- a/src/systems/failover/performanceFailover.ts
+++ b/src/systems/failover/performanceFailover.ts
@@ -24,6 +24,7 @@ export interface PerformanceFailoverTriggerContext {
   minFps: number;
   maxFps: number;
   p95Fps: number;
+  medianFps: number;
 }
 
 export interface PerformanceFailoverHandlerOptions {
@@ -110,6 +111,7 @@ class PerformanceFailoverMonitor {
           minFps: summary?.minFps ?? fps,
           maxFps: summary?.maxFps ?? fps,
           p95Fps: summary?.p95Fps ?? fps,
+          medianFps: summary?.medianFps ?? fps,
         });
       }
       return;

--- a/src/systems/performance/fpsAccumulator.ts
+++ b/src/systems/performance/fpsAccumulator.ts
@@ -4,6 +4,7 @@ export interface FpsSampleSummary {
   minFps: number;
   maxFps: number;
   p95Fps: number;
+  medianFps: number;
 }
 
 export interface FpsAccumulator {
@@ -61,6 +62,11 @@ export function createFpsAccumulator(): FpsAccumulator {
       Math.max(0, Math.ceil(sorted.length * 0.95) - 1)
     );
     const p95Fps = sorted[percentileIndex];
+    const midIndex = Math.floor(sorted.length / 2);
+    const medianFps =
+      sorted.length % 2 === 0
+        ? (sorted[midIndex - 1] + sorted[midIndex]) / 2
+        : sorted[midIndex];
     return {
       count: samples.length,
       averageFps,
@@ -68,6 +74,7 @@ export function createFpsAccumulator(): FpsAccumulator {
       maxFps:
         max === Number.NEGATIVE_INFINITY ? sorted[sorted.length - 1] : max,
       p95Fps,
+      medianFps,
     } satisfies FpsSampleSummary;
   };
 

--- a/src/tests/fpsAccumulator.test.ts
+++ b/src/tests/fpsAccumulator.test.ts
@@ -19,6 +19,7 @@ describe('createFpsAccumulator', () => {
     expect(summary?.maxFps).toBeCloseTo(24);
     expect(summary?.averageFps).toBeCloseTo((0 + 12 + 18 + 24) / 4, 5);
     expect(summary?.p95Fps).toBeCloseTo(24);
+    expect(summary?.medianFps).toBeCloseTo((12 + 18) / 2, 5);
   });
 
   it('computes percentile using ceiling semantics and resets state', () => {
@@ -30,6 +31,7 @@ describe('createFpsAccumulator', () => {
 
     const summaryBeforeReset = accumulator.getSummary();
     expect(summaryBeforeReset?.p95Fps).toBeCloseTo(30);
+    expect(summaryBeforeReset?.medianFps).toBeCloseTo((20 + 28) / 2, 5);
 
     accumulator.reset();
     expect(accumulator.getSummary()).toBeNull();
@@ -43,5 +45,6 @@ describe('createFpsAccumulator', () => {
     expect(summaryAfterReset?.maxFps).toBeCloseTo(26);
     expect(summaryAfterReset?.averageFps).toBeCloseTo((22 + 26 + 24) / 3, 5);
     expect(summaryAfterReset?.p95Fps).toBeCloseTo(26);
+    expect(summaryAfterReset?.medianFps).toBeCloseTo(24);
   });
 });

--- a/src/tests/performanceFailover.test.ts
+++ b/src/tests/performanceFailover.test.ts
@@ -98,6 +98,8 @@ describe('createPerformanceFailoverHandler', () => {
     expect(context.sampleCount).toBeGreaterThan(0);
     expect(context.minFps).toBeLessThanOrEqual(context.p95Fps);
     expect(context.maxFps).toBeGreaterThanOrEqual(context.p95Fps);
+    expect(context.medianFps).toBeGreaterThanOrEqual(context.minFps);
+    expect(context.medianFps).toBeLessThanOrEqual(context.maxFps);
   });
 
   it('ignores sporadic low FPS frames', () => {


### PR DESCRIPTION
what:
- add median computation to the fps accumulator and failover context
- include the metric in fallback console logging and roadmap docs

why:
- provide richer telemetry to understand frame pacing when failover fires

how to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6905a6f56bd8832fbb2735e3bb8254f7