### PR TITLE
Align avatar foot IK with stair landing height

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -369,6 +369,8 @@ Focus: replace the placeholder sphere with a stylized protagonist.
      responding to POI selections with a controller-synced gesture.
    - ✅ Footstep audio now syncs to avatar speed with subtle stereo sway.
    - ✅ IK adjustments to align feet with uneven terrain/stairs.
+     - ✅ Landing samples now respect the upper floor slab thickness so feet rest flush on the
+       loft landing.
 
 3. **Self-Representation Touches**
    - ✅ Selfie mirror kiosk now renders a live avatar preview on a holographic panel near the

--- a/src/main.ts
+++ b/src/main.ts
@@ -311,6 +311,7 @@ import { computeStairLayout } from './systems/movement/stairLayout';
 import {
   computeRampHeight as computeStairRampHeight,
   predictStairFloorId,
+  sampleStairSurfaceHeight,
   type FloorId,
   type StairBehavior,
   type StairGeometry,
@@ -3715,21 +3716,14 @@ function initializeImmersiveScene(
         avatarFootIkController.update({
           delta,
           sampleHeight({ x, y }) {
-            const rampHeight = computeRampHeight(x, y);
-            const predictedFloor = predictFloorId(x, y, activeFloorId);
-            if (predictedFloor === 'upper') {
-              if (rampHeight >= upperFloorElevation - 1e-3) {
-                return upperFloorElevation;
-              }
-              const withinStairWidth =
-                Math.abs(x - stairGeometry.centerX) <=
-                stairGeometry.halfWidth + stairBehavior.transitionMargin;
-              if (withinStairWidth) {
-                return Math.min(upperFloorElevation, Math.max(rampHeight, 0));
-              }
-              return upperFloorElevation;
-            }
-            return Math.min(Math.max(rampHeight, 0), upperFloorElevation);
+            return sampleStairSurfaceHeight({
+              geometry: stairGeometry,
+              behavior: stairBehavior,
+              x,
+              z: y,
+              currentFloor: activeFloorId,
+              upperFloorElevation,
+            });
           },
         });
       }

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -135,3 +135,44 @@ export const predictStairFloorId = (
 
   return 'ground';
 };
+
+export interface StairSurfaceSampleOptions {
+  geometry: StairGeometry;
+  behavior: StairBehavior;
+  x: number;
+  z: number;
+  currentFloor: FloorId;
+  upperFloorElevation: number;
+}
+
+export const sampleStairSurfaceHeight = ({
+  geometry,
+  behavior,
+  x,
+  z,
+  currentFloor,
+  upperFloorElevation,
+}: StairSurfaceSampleOptions): number => {
+  const rampHeight = computeRampHeight(geometry, behavior, x, z);
+  const clampedRamp = MathUtils.clamp(rampHeight, 0, upperFloorElevation);
+  const predictedFloor = predictStairFloorId(
+    geometry,
+    behavior,
+    x,
+    z,
+    currentFloor
+  );
+  if (predictedFloor === 'upper') {
+    const withinStairWidth = isWithinStairWidth(
+      geometry,
+      x,
+      behavior.transitionMargin
+    );
+    const onLanding = isWithinLanding(geometry, x, z);
+    if (!withinStairWidth || onLanding) {
+      return upperFloorElevation;
+    }
+  }
+
+  return clampedRamp;
+};

--- a/src/tests/movement/stairSurfaceHeight.test.ts
+++ b/src/tests/movement/stairSurfaceHeight.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import {
+  sampleStairSurfaceHeight,
+  type FloorId,
+  type StairBehavior,
+  type StairGeometry,
+} from '../../systems/movement/stairs';
+
+const toWorldUnits = (value: number) => value * FLOOR_PLAN_SCALE;
+
+const geometry: StairGeometry = {
+  centerX: 0,
+  halfWidth: toWorldUnits(3.1) / 2,
+  bottomZ: 0,
+  topZ: toWorldUnits(0.85) * 9,
+  landingMinZ: toWorldUnits(0.85) * 9,
+  landingMaxZ: toWorldUnits(0.85) * 9 + toWorldUnits(2.6),
+  totalRise: 0.42 * 9,
+  direction: 1,
+};
+
+const behavior: StairBehavior = {
+  transitionMargin: toWorldUnits(0.6),
+  landingTriggerMargin: toWorldUnits(0.2),
+  stepRise: 0.42,
+};
+
+const upperFloorElevation = geometry.totalRise + 0.38;
+
+const sample = (params: { x: number; z: number; currentFloor: FloorId }) =>
+  sampleStairSurfaceHeight({
+    geometry,
+    behavior,
+    upperFloorElevation,
+    ...params,
+  });
+
+describe('sampleStairSurfaceHeight', () => {
+  it('returns the interpolated ramp height along the stair run', () => {
+    const midRampZ = geometry.topZ / 2;
+    const height = sample({ x: 0, z: midRampZ, currentFloor: 'ground' });
+    expect(height).toBeCloseTo(geometry.totalRise / 2, 5);
+  });
+
+  it('retains ramp height when descending toward the top step', () => {
+    const nearTopStepZ = geometry.topZ - toWorldUnits(0.2);
+    const height = sample({ x: 0, z: nearTopStepZ, currentFloor: 'ground' });
+    expect(height).toBeGreaterThan(geometry.totalRise * 0.9);
+    expect(height).toBeLessThanOrEqual(geometry.totalRise);
+  });
+
+  it('returns upper floor elevation across the landing interior', () => {
+    const landingInteriorZ = (geometry.landingMinZ + geometry.landingMaxZ) / 2;
+    const height = sample({ x: 0, z: landingInteriorZ, currentFloor: 'upper' });
+    expect(height).toBeCloseTo(upperFloorElevation, 6);
+  });
+
+  it('returns upper floor elevation when outside the stair width above the void', () => {
+    const farEastX = geometry.centerX + geometry.halfWidth + toWorldUnits(0.8);
+    const landingMidZ = (geometry.landingMinZ + geometry.landingMaxZ) / 2;
+    const height = sample({
+      x: farEastX,
+      z: landingMidZ,
+      currentFloor: 'upper',
+    });
+    expect(height).toBeCloseTo(upperFloorElevation, 6);
+  });
+
+  it('clamps to ground level when outside the stair span', () => {
+    const farEastX = geometry.centerX + geometry.halfWidth + toWorldUnits(0.8);
+    const height = sample({
+      x: farEastX,
+      z: -toWorldUnits(0.4),
+      currentFloor: 'ground',
+    });
+    expect(height).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a stair surface sampler to align IK offsets with the loft landing
- update the immersive foot IK loop to reuse the sampler
- capture the landing behaviour in roadmap notes and unit tests

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_690687921e30832f9a3538b13d1c88ef