### PR TITLE
Sync media wall stars with GitHub metrics

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -171,6 +171,8 @@ Focus: anchor each highlighted project with an interactive artifact.
      screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
      - ✅ Undershelf LED wash now breathes with POI emphasis while calm/photosensitive presets
        dampen pulses and flicker spikes.
+     - ✅ Live GitHub star telemetry now feeds the media wall badge so the display mirrors the
+       latest repo metrics alongside the POI overlays.
    - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
      orbitals, and an activation-driven tech stack + docs callout panel.
    - ✅ Studio Jobbot terminal desk now projects live automation telemetry via

--- a/src/main.ts
+++ b/src/main.ts
@@ -196,6 +196,7 @@ import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
 } from './scene/structures/mediaWall';
+import { createMediaWallStarBridge } from './scene/structures/mediaWallStarBridge';
 import {
   createPrReaperConsole,
   type PrReaperConsoleBuild,
@@ -559,6 +560,7 @@ let tokenPlaceRack: TokenPlaceRackBuild | null = null;
 let prReaperConsole: PrReaperConsoleBuild | null = null;
 let gabrielSentry: GabrielSentryBuild | null = null;
 let gitshelvesInstallation: GitshelvesInstallationBuild | null = null;
+const mediaWallStarBridge = createMediaWallStarBridge();
 let livingRoomMediaWall: LivingRoomMediaWallBuild | null = null;
 let selfieMirror: SelfieMirrorBuild | null = null;
 let ledStripGroup: Group | null = null;
@@ -1027,6 +1029,7 @@ function initializeImmersiveScene(
     scene.add(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
+    mediaWallStarBridge.attach(mediaWall.controller);
 
     const tvBinding = mediaWall.poiBindings.futuroptimistTv;
     const tvHitArea = tvBinding.screen.clone();
@@ -1338,6 +1341,11 @@ function initializeImmersiveScene(
     onMetricsUpdated: (poiId) => {
       poiTooltipOverlay.notifyPoiUpdated(poiId);
       poiWorldTooltip.notifyPoiUpdated(poiId);
+    },
+    onRepoStatsUpdated: ({ poiId, stats }) => {
+      if (poiId === 'futuroptimist-living-room-tv') {
+        mediaWallStarBridge.updateStarCount(stats.stars);
+      }
     },
   });
   githubRepoMetrics.refreshAll().catch(() => {
@@ -3675,6 +3683,7 @@ function initializeImmersiveScene(
     controls.dispose();
     if (livingRoomMediaWall) {
       livingRoomMediaWall.controller.dispose();
+      mediaWallStarBridge.detach();
       livingRoomMediaWall = null;
     }
     if (selfieMirror) {

--- a/src/scene/structures/mediaWallStarBridge.ts
+++ b/src/scene/structures/mediaWallStarBridge.ts
@@ -1,0 +1,46 @@
+import type { LivingRoomMediaWallController } from './mediaWall';
+
+const sanitizeStarCount = (value: number | null | undefined): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value));
+};
+
+export interface MediaWallStarBridge {
+  attach(controller: LivingRoomMediaWallController): void;
+  detach(): void;
+  updateStarCount(stars: number | null | undefined): void;
+  getStarCount(): number;
+}
+
+export const createMediaWallStarBridge = (
+  initialStars = 1280
+): MediaWallStarBridge => {
+  let starCount = sanitizeStarCount(initialStars);
+  let controller: LivingRoomMediaWallController | null = null;
+
+  const apply = () => {
+    if (!controller) {
+      return;
+    }
+    controller.setStarCount(starCount);
+  };
+
+  return {
+    attach(nextController) {
+      controller = nextController;
+      apply();
+    },
+    detach() {
+      controller = null;
+    },
+    updateStarCount(nextStars) {
+      starCount = sanitizeStarCount(nextStars);
+      apply();
+    },
+    getStarCount() {
+      return starCount;
+    },
+  };
+};

--- a/src/tests/mediaWallStarBridge.test.ts
+++ b/src/tests/mediaWallStarBridge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LivingRoomMediaWallController } from '../scene/structures/mediaWall';
+import { createMediaWallStarBridge } from '../scene/structures/mediaWallStarBridge';
+
+describe('createMediaWallStarBridge', () => {
+  const createController = () => {
+    const controller: LivingRoomMediaWallController = {
+      update: vi.fn(),
+      setStarCount: vi.fn(),
+      dispose: vi.fn(),
+    };
+    return controller;
+  };
+
+  it('applies the initial star count when attaching a controller', () => {
+    const bridge = createMediaWallStarBridge(1280);
+    const controller = createController();
+
+    bridge.attach(controller);
+
+    expect(controller.setStarCount).toHaveBeenCalledTimes(1);
+    expect(controller.setStarCount).toHaveBeenCalledWith(1280);
+    expect(bridge.getStarCount()).toBe(1280);
+  });
+
+  it('updates the controller when live star counts arrive', () => {
+    const bridge = createMediaWallStarBridge(1280);
+    const controller = createController();
+    bridge.attach(controller);
+
+    bridge.updateStarCount(1536.4);
+
+    expect(controller.setStarCount).toHaveBeenLastCalledWith(1536);
+    expect(bridge.getStarCount()).toBe(1536);
+  });
+
+  it('retains the latest star count across detaches and reattaches', () => {
+    const bridge = createMediaWallStarBridge(1000);
+    const firstController = createController();
+    bridge.attach(firstController);
+
+    bridge.updateStarCount(2048);
+    expect(bridge.getStarCount()).toBe(2048);
+
+    bridge.detach();
+    bridge.updateStarCount(4096);
+
+    const secondController = createController();
+    bridge.attach(secondController);
+
+    expect(secondController.setStarCount).toHaveBeenCalledWith(4096);
+    expect(firstController.setStarCount).toHaveBeenCalledTimes(2);
+  });
+
+  it('sanitizes invalid star counts to zero', () => {
+    const bridge = createMediaWallStarBridge();
+    const controller = createController();
+    bridge.attach(controller);
+
+    bridge.updateStarCount(Number.NaN);
+    expect(bridge.getStarCount()).toBe(0);
+    expect(controller.setStarCount).toHaveBeenLastCalledWith(0);
+
+    bridge.updateStarCount(-42);
+    expect(bridge.getStarCount()).toBe(0);
+    expect(controller.setStarCount).toHaveBeenLastCalledWith(0);
+  });
+});


### PR DESCRIPTION
## Summary
- stream GitHub repo star updates into the media wall badge and roadmap
- expose GitHub repo stats callbacks and hook the media wall star bridge
- add unit tests covering the star bridge and repo metrics notifications

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_690687921e30832f9a3538b13d1c88ef