### PR TITLE
Add PR Reaper walkway beacons

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -196,8 +196,8 @@ Focus: anchor each highlighted project with an interactive artifact.
      - ✅ Sugarkube greenhouse POI now surfaces automation metrics and dual CTAs in the registry.
        - ✅ Ambient audio beds (crickets, greenhouse chimes) now use smoothstep falloff so volume
          eases in based on player proximity.
-   - ✨ PR Reaper triage console now anchors the backyard ops POI with holographic sweeps,
-     caution-lit walkways, and log review surfaces.
+   - ✅ PR Reaper triage console now anchors the backyard ops POI with holographic sweeps,
+     caution-lit walkways, beaconed approaches, and log review surfaces.
      - ✅ Caution-lit walkway now pulses with triage emphasis cues and honors accessibility
        motion dampening scales.
    - ✅ Incident console log displays now stream Codex triage updates with emphasis-aware

--- a/src/tests/prReaperConsole.test.ts
+++ b/src/tests/prReaperConsole.test.ts
@@ -88,6 +88,12 @@ describe('createPrReaperConsole', () => {
     expect(
       console.group.getObjectByName('PrReaperConsoleLogTicker')
     ).toBeInstanceOf(Mesh);
+    expect(
+      console.group.getObjectByName('PrReaperConsoleBeacon-0')
+    ).toBeInstanceOf(Mesh);
+    expect(
+      console.group.getObjectByName('PrReaperConsoleBeaconHalo-0')
+    ).toBeInstanceOf(Mesh);
 
     expect(console.colliders).toHaveLength(2);
     const [deckCollider, walkwayCollider] = console.colliders;
@@ -106,6 +112,46 @@ describe('createPrReaperConsole', () => {
     expect(walkwayCenterZ).toBeCloseTo(expectedWalkwayZ, 6);
     expect(walkwayCenterX).not.toBeCloseTo(deckCenterX, 6);
     expect(walkwayCenterZ).not.toBeCloseTo(deckCenterZ, 6);
+  });
+
+  it('elevates walkway beacons with emphasis pulses and calm-mode damping', () => {
+    const console = createPrReaperConsole({ position: { x: 0, z: 0 } });
+    const beacon = console.group.getObjectByName(
+      'PrReaperConsoleBeacon-0'
+    ) as Mesh;
+    const halo = console.group.getObjectByName(
+      'PrReaperConsoleBeaconHalo-0'
+    ) as Mesh;
+
+    expect(beacon).toBeInstanceOf(Mesh);
+    expect(halo).toBeInstanceOf(Mesh);
+
+    const beaconMaterial = beacon.material as MeshStandardMaterial;
+    const haloMaterial = halo.material as MeshBasicMaterial;
+    const baseIntensity = beaconMaterial.emissiveIntensity;
+    const baseOpacity = haloMaterial.opacity;
+    const baseScale = halo.scale.x;
+
+    console.update({ elapsed: 0.4, delta: 0.016, emphasis: 0.75 });
+    const activeIntensity = beaconMaterial.emissiveIntensity;
+    const activeOpacity = haloMaterial.opacity;
+    const activeScale = halo.scale.x;
+    const activeRotation = halo.rotation.z;
+
+    expect(activeIntensity).toBeGreaterThan(baseIntensity);
+    expect(activeOpacity).toBeGreaterThan(baseOpacity);
+    expect(activeScale).toBeGreaterThan(baseScale);
+    expect(activeRotation).toBeGreaterThan(0);
+
+    document.documentElement.dataset.accessibilityPulseScale = '0';
+    console.update({ elapsed: 1.4, delta: 0.016, emphasis: 0.75 });
+
+    expect(beaconMaterial.emissiveIntensity).toBeLessThanOrEqual(
+      activeIntensity
+    );
+    expect(haloMaterial.opacity).toBeLessThanOrEqual(activeOpacity);
+    expect(halo.scale.x).toBeLessThanOrEqual(activeScale);
+    expect(halo.rotation.z).toBeGreaterThan(activeRotation);
   });
 
   it('animates hologram elements and emissive surfaces based on emphasis', () => {


### PR DESCRIPTION
## Summary
- add holographic caution beacons to the PR Reaper console walkway with emphasis-aware pulses
- drive the new beacons through the existing update loop and calm-mode damping utilities
- document the roadmap slice as complete now that the beaconed approach is live

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6906ddb8a018832f9998c2204ef3b75c