### PR TITLE
Add lantern wave audio modulator for ambient chimes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,6 +100,8 @@ Focus: expand the environment while keeping navigation smooth.
        calm-mode damping.
      - ✅ Lantern chime ambient beds now trail the light wave so audio sweeps follow the
        greenhouse approach.
+       - ✅ Lantern wave volume modulator now mirrors the beacon pulse timings so audio
+         intensity glides down the path while honoring calm-mode damping.
    - ✨ Firefly swarms now orbit the greenhouse walkway with accessibility-aware twinkle damping.
      - ✅ Firefly calm-mode presets now ease orbital amplitude and glow for sensitive players.
    - ✅ Fiber-optic pathway guides now trace the greenhouse approach with seasonal-aware pulses

--- a/src/main.ts
+++ b/src/main.ts
@@ -3802,7 +3802,9 @@ function initializeImmersiveScene(
         avatarAccessorySuite.update({ elapsed: elapsedTime, delta });
       }
       if (ambientAudioController) {
-        ambientAudioController.update(player.position, delta);
+        ambientAudioController.update(player.position, delta, {
+          elapsed: elapsedTime,
+        });
         ambientCaptionBridge?.update();
       }
       if (livingRoomMediaWall) {

--- a/src/systems/audio/lanternWaveVolumeModulator.ts
+++ b/src/systems/audio/lanternWaveVolumeModulator.ts
@@ -1,0 +1,117 @@
+import { MathUtils } from 'three';
+
+import {
+  getFlickerScale,
+  getPulseScale,
+} from '../../ui/accessibility/animationPreferences';
+
+import type { AmbientAudioVolumeModulator } from './ambientAudio';
+
+export interface LanternWaveVolumeSample {
+  progression: number;
+  offset: number;
+}
+
+export interface LanternWaveVolumeModulatorOptions {
+  samples?: ReadonlyArray<LanternWaveVolumeSample | null | undefined> | null;
+  minimumScale?: number;
+  maximumScale?: number;
+}
+
+const DEFAULT_SAMPLE: LanternWaveVolumeSample = {
+  progression: 0.5,
+  offset: 0,
+};
+
+const DEFAULT_MIN_SCALE = 0.45;
+const DEFAULT_MAX_SCALE = 1.35;
+
+const sanitizeProgression = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0.5;
+  }
+  return MathUtils.euclideanModulo(value, 1);
+};
+
+const sanitizeOffset = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return value;
+};
+
+export function createLanternWaveVolumeModulator({
+  samples,
+  minimumScale = DEFAULT_MIN_SCALE,
+  maximumScale = DEFAULT_MAX_SCALE,
+}: LanternWaveVolumeModulatorOptions = {}): AmbientAudioVolumeModulator {
+  const sanitizedSamples = (samples ?? []).flatMap((sample) => {
+    if (!sample) {
+      return [];
+    }
+    return [
+      {
+        progression: sanitizeProgression(sample.progression),
+        offset: sanitizeOffset(sample.offset),
+      },
+    ];
+  });
+
+  if (sanitizedSamples.length === 0) {
+    sanitizedSamples.push({ ...DEFAULT_SAMPLE });
+  }
+
+  const clampedMinimum = Math.max(0, minimumScale);
+  const clampedMaximum = Math.max(clampedMinimum, maximumScale);
+
+  return ({ elapsed }) => {
+    const time = Number.isFinite(elapsed) ? elapsed : 0;
+    const pulseScale = MathUtils.clamp(getPulseScale(), 0, 1);
+    const flickerScale = MathUtils.clamp(getFlickerScale(), 0, 1);
+    const waveSpeed = MathUtils.lerp(0.12, 0.22, pulseScale);
+    const waveSharpness = MathUtils.lerp(2.6, 4.4, Math.max(pulseScale, 0.2));
+    const steadyBase = MathUtils.lerp(0.6, 1, flickerScale);
+    const waveProgress = MathUtils.euclideanModulo(time * waveSpeed, 1);
+    const baseWave = Math.sin(time * 0.9) * 0.12;
+
+    let flickerAccumulator = 0;
+    let beaconAccumulator = 0;
+
+    sanitizedSamples.forEach(({ progression, offset }) => {
+      let distance = Math.abs(progression - waveProgress);
+      if (distance > 0.5) {
+        distance = 1 - distance;
+      }
+      const beaconStrength = Math.max(0, 1 - distance * waveSharpness);
+      beaconAccumulator += beaconStrength;
+
+      const flicker =
+        0.84 +
+        baseWave +
+        Math.sin(time * 1.7 + offset) * 0.16 +
+        Math.sin(time * 2.4 + offset * 0.8) * 0.08;
+      flickerAccumulator += Math.max(0.4, flicker);
+    });
+
+    const sampleCount = sanitizedSamples.length;
+    const averageBeacon = beaconAccumulator / sampleCount;
+    const averageFlicker = flickerAccumulator / sampleCount;
+
+    const intensityBoost =
+      1 +
+      averageBeacon *
+        MathUtils.lerp(0.18, 0.6, Math.max(pulseScale, flickerScale));
+    const flickerBlend = MathUtils.lerp(
+      steadyBase,
+      averageFlicker,
+      flickerScale
+    );
+    const scale = MathUtils.clamp(
+      flickerBlend * intensityBoost,
+      clampedMinimum,
+      clampedMaximum
+    );
+
+    return scale;
+  };
+}

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -4,6 +4,7 @@ import {
   AmbientAudioController,
   type AmbientAudioBedDefinition,
   type AmbientAudioSource,
+  type AmbientAudioVolumeModulator,
   _computeAttenuation,
   _smoothingFactor,
 } from '../systems/audio/ambientAudio';
@@ -42,6 +43,7 @@ describe('AmbientAudioController', () => {
       captionThreshold: overrides.captionThreshold,
       captionPriority: overrides.captionPriority,
       source,
+      volumeModulator: overrides.volumeModulator,
     };
     return { bed, source };
   };
@@ -176,6 +178,15 @@ describe('AmbientAudioController', () => {
     expect(snapshot.targetVolume).toBeCloseTo(0.42, 5);
     snapshot.definition.center.x = 999;
     expect(controller.getBedSnapshots()[0].definition.center.x).not.toBe(999);
+  });
+
+  it('scales base volume using the configured volume modulator', () => {
+    const modulator: AmbientAudioVolumeModulator = () => 0.5;
+    const { bed, source } = createBed({ volumeModulator: modulator });
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+    controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1, { elapsed: 2 });
+    expect(source.volumes.at(-1)).toBeCloseTo(bed.baseVolume * 0.5, 5);
   });
 });
 

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -1545,6 +1545,15 @@ describe('createBackyardEnvironment', () => {
     );
     expect(lanternBed?.baseVolume).toBeGreaterThan(0);
     expect(lanternBed?.falloffCurve).toBe('smoothstep');
+    expect(typeof lanternBed?.volumeModulator).toBe('function');
+
+    const sampleScale = lanternBed?.volumeModulator?.({
+      elapsed: 1.2,
+      delta: 0.016,
+      listenerPosition: { x: walkway!.position.x, z: walkway!.position.z },
+      baseVolume: lanternBed!.baseVolume,
+    });
+    expect(sampleScale).toBeGreaterThan(0);
   });
 
   it('adds holographic walkway arrows that pulse toward the greenhouse and honor calm-mode damping', () => {

--- a/src/tests/lanternWaveVolumeModulator.test.ts
+++ b/src/tests/lanternWaveVolumeModulator.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createLanternWaveVolumeModulator } from '../systems/audio/lanternWaveVolumeModulator';
+
+const CONTEXT_BASE = {
+  delta: 0.016,
+  listenerPosition: { x: 0, z: 0 },
+  baseVolume: 0.34,
+} as const;
+
+describe('createLanternWaveVolumeModulator', () => {
+  beforeEach(() => {
+    document.documentElement.dataset.accessibilityPulseScale = '1';
+    document.documentElement.dataset.accessibilityFlickerScale = '1';
+  });
+
+  it('varies the returned scale as the lantern wave progresses', () => {
+    const modulator = createLanternWaveVolumeModulator();
+    const early = modulator({ ...CONTEXT_BASE, elapsed: 0 });
+    const later = modulator({ ...CONTEXT_BASE, elapsed: 3.1 });
+    expect(Math.abs(later - early)).toBeGreaterThan(0.01);
+  });
+
+  it('damps the returned scale when accessibility calm mode is enabled', () => {
+    const modulator = createLanternWaveVolumeModulator();
+    const energetic = modulator({ ...CONTEXT_BASE, elapsed: 2.4 });
+    document.documentElement.dataset.accessibilityPulseScale = '0.15';
+    document.documentElement.dataset.accessibilityFlickerScale = '0.25';
+    const calm = modulator({ ...CONTEXT_BASE, elapsed: 2.4 });
+    expect(calm).toBeLessThanOrEqual(energetic);
+  });
+
+  it('clamps results to the configured range even with extreme samples', () => {
+    const modulator = createLanternWaveVolumeModulator({
+      minimumScale: 0.8,
+      maximumScale: 0.9,
+      samples: [
+        { progression: 0.2, offset: 0 },
+        { progression: 0.4, offset: Math.PI / 2 },
+        { progression: 0.6, offset: Math.PI },
+      ],
+    });
+    document.documentElement.dataset.accessibilityPulseScale = '1';
+    document.documentElement.dataset.accessibilityFlickerScale = '1';
+    const scale = modulator({ ...CONTEXT_BASE, elapsed: 9.75 });
+    expect(scale).toBeGreaterThanOrEqual(0.8);
+    expect(scale).toBeLessThanOrEqual(0.9);
+  });
+});


### PR DESCRIPTION
## Summary
- add ambient audio volume modulator support for beds
- drive backyard lantern wave chime intensity from beacon pulses
- document the new modulator in the roadmap

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6906ddb8a018832f9998c2204ef3b75c