### PR TITLE
Add clearance halo for media wall POI emphasis

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,12 +167,14 @@ Focus: anchor each highlighted project with an interactive artifact.
      kitchen Wove POI with a tactile robotics vignette.
      - Warp ripples now sync to emphasis pulses while the shuttle projects a warm glow wash
        across the loom table as it slides.
-   - ✨ Wall-mounted Futuroptimist media wall now frames the living room POI with a branded
+   - ✅ Wall-mounted Futuroptimist media wall now frames the living room POI with a branded
      screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
      - ✅ Undershelf LED wash now breathes with POI emphasis while calm/photosensitive presets
        dampen pulses and flicker spikes.
      - ✅ Live GitHub star telemetry now feeds the media wall badge so the display mirrors the
        latest repo metrics alongside the POI overlays.
+     - ✅ Floor-level clearance halo now pulses with POI focus to keep walkable space obvious
+       while accessibility presets soften its bloom and tint transitions.
    - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
      orbitals, and an activation-driven tech stack + docs callout panel.
    - ✅ Studio Jobbot terminal desk now projects live automation telemetry via

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -89,11 +89,17 @@ describe('createLivingRoomMediaWall', () => {
     expect(build.poiBindings.futuroptimistTv.glow).toBeTruthy();
     expect(build.poiBindings.futuroptimistTv.halo).toBeTruthy();
     expect(build.poiBindings.futuroptimistTv.shelfLight).toBeTruthy();
+    expect(build.poiBindings.futuroptimistTv.clearance).toBeTruthy();
 
     const shelfLight = build.group.getObjectByName(
       'LivingRoomMediaWallShelfLight'
     );
     expect(shelfLight).toBeTruthy();
+
+    const clearance = build.group.getObjectByName(
+      'LivingRoomMediaWallClearance'
+    );
+    expect(clearance).toBeTruthy();
 
     const screenContext = contexts[0];
     expect(screenContext).toBeDefined();
@@ -108,6 +114,10 @@ describe('createLivingRoomMediaWall', () => {
       build.poiBindings.futuroptimistTv.shelfLightMaterial;
     const baseHaloIntensity = haloMaterial.emissiveIntensity;
     const baseShelfIntensity = shelfLightMaterial.emissiveIntensity;
+    const clearanceMaterial =
+      build.poiBindings.futuroptimistTv.clearanceMaterial;
+    const baseClearanceOpacity = clearanceMaterial.opacity;
+    const baseClearanceColor = clearanceMaterial.color.clone();
 
     build.controller.setStarCount(1536);
     const updatedTexts = screenContext.fillTextCalls.map((call) => call.text);
@@ -130,6 +140,8 @@ describe('createLivingRoomMediaWall', () => {
     expect(shelfLightMaterial.emissiveIntensity).toBeGreaterThan(
       baseShelfIntensity
     );
+    expect(clearanceMaterial.opacity).toBeGreaterThan(baseClearanceOpacity);
+    expect(clearanceMaterial.color.equals(baseClearanceColor)).toBe(false);
 
     document.documentElement.dataset.accessibilityPulseScale = '0';
     document.documentElement.dataset.accessibilityFlickerScale = '0';
@@ -146,6 +158,14 @@ describe('createLivingRoomMediaWall', () => {
     expect(
       Math.abs(shelfLightMaterial.emissiveIntensity - baseShelfIntensity)
     ).toBeLessThan(0.1);
+    expect(
+      Math.abs(clearanceMaterial.opacity - baseClearanceOpacity)
+    ).toBeLessThan(0.05);
+    const clearanceColorDelta =
+      Math.abs(clearanceMaterial.color.r - baseClearanceColor.r) +
+      Math.abs(clearanceMaterial.color.g - baseClearanceColor.g) +
+      Math.abs(clearanceMaterial.color.b - baseClearanceColor.b);
+    expect(clearanceColorDelta).toBeLessThan(0.12);
 
     expect(() => build.controller.dispose()).not.toThrow();
   });


### PR DESCRIPTION
## Summary
- add an animated floor-level clearance halo to the Futuroptimist media wall and drive its color/opacity from POI emphasis
- expose the clearance binding to tests and mark the roadmap slice as complete

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_6906ddb8a018832f9998c2204ef3b75c