### PR TITLE
Link help HUD button to modal aria state

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2331,6 +2331,7 @@ function initializeImmersiveScene(
   });
   helpModalController = attachHelpModalController({
     helpModal,
+    helpButton,
     onOpen: showHudControlElements,
     onClose: hideHudControlElements,
     hudFocusAnnouncer,

--- a/src/tests/helpModalController.test.ts
+++ b/src/tests/helpModalController.test.ts
@@ -146,6 +146,35 @@ describe('attachHelpModalController', () => {
     controller.dispose();
   });
 
+  it('syncs help button aria state with modal visibility', () => {
+    const context = createHelpModalStub();
+    const button = document.createElement('button');
+
+    const controller = attachHelpModalController({
+      helpModal: context.handle,
+      helpButton: button,
+    });
+
+    expect(button.getAttribute('aria-controls')).toBe(
+      context.handle.element.id
+    );
+    expect(button.getAttribute('aria-haspopup')).toBe('dialog');
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+
+    context.handle.open();
+
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+
+    context.handle.close();
+
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+
+    controller.dispose();
+  });
+
   it('avoids duplicate announcements when state is unchanged', () => {
     const events: string[] = [];
     const context = createHelpModalStub();

--- a/src/ui/hud/helpModal.ts
+++ b/src/ui/hud/helpModal.ts
@@ -138,6 +138,9 @@ export function createHelpModal(options: HelpModalOptions): HelpModalHandle {
   modal.setAttribute('role', 'dialog');
   modal.setAttribute('aria-modal', 'true');
   modal.tabIndex = -1;
+  if (!modal.id) {
+    modal.id = 'help-modal';
+  }
 
   const titleId = 'help-modal-title';
   modal.setAttribute('aria-labelledby', titleId);

--- a/src/ui/hud/helpModalController.ts
+++ b/src/ui/hud/helpModalController.ts
@@ -9,6 +9,7 @@ export interface HelpModalAnnouncements {
 
 export interface HelpModalControllerOptions {
   helpModal: HelpModalHandle;
+  helpButton?: HTMLButtonElement | null;
   onOpen?: () => void;
   onClose?: () => void;
   hudFocusAnnouncer?: Pick<HudFocusAnnouncerHandle, 'announce'> | null;
@@ -34,6 +35,7 @@ const sanitizeAnnouncements = (
 
 export function attachHelpModalController({
   helpModal,
+  helpButton,
   onOpen,
   onClose,
   hudFocusAnnouncer,
@@ -46,8 +48,23 @@ export function attachHelpModalController({
   let activeAnnouncements = sanitizeAnnouncements(announcements);
   let isOpen = helpModal.isOpen();
 
+  const applyButtonState = () => {
+    if (!helpButton) {
+      return;
+    }
+    const modalId = helpModal.element.id || 'help-modal';
+    helpModal.element.id = modalId;
+    helpButton.setAttribute('aria-controls', modalId);
+    helpButton.setAttribute('aria-haspopup', 'dialog');
+    helpButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    helpButton.setAttribute('aria-pressed', isOpen ? 'true' : 'false');
+  };
+
+  applyButtonState();
+
   const refreshState = () => {
     isOpen = helpModal.isOpen();
+    applyButtonState();
     return isOpen;
   };
 


### PR DESCRIPTION
What:
- assign a stable id to the help modal and wire the HUD help button aria attributes
- keep the help modal controller in sync with the button state in tests

Why:
- improve accessibility so the help control announces its relationship to the dialog

How to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281cbfa728832f9b448e4ce5b1a95c)