### PR TITLE
Add press kit headroom summary

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -462,6 +462,8 @@ Ideas to evaluate after the core experience is stable:
   - ✅ Live GitHub star counts now stream into POI metric panels via the repo stats service.
 - ✅ Exportable "press kit" mode now packages screenshots, POI blurbs, and metrics for media kits.
   - ✅ Press kit summary generator now exports POI metadata and performance budgets to JSON for packaging.
+  - ✅ Press kit performance report now surfaces headroom for materials, draw calls, and texture
+    memory so media snapshots communicate remaining rendering capacity.
 
 ## Delivery Principles
 

--- a/src/tests/pressKitSummary.test.ts
+++ b/src/tests/pressKitSummary.test.ts
@@ -29,18 +29,34 @@ describe('buildPressKitSummary', () => {
       { project: 0, environment: 0 }
     );
     const expectedRooms = new Set(definitions.map((poi) => poi.roomId)).size;
+    const expectedReport = createPerformanceBudgetReport(
+      IMMERSIVE_SCENE_BASELINE,
+      IMMERSIVE_PERFORMANCE_BUDGET
+    );
 
     const summary = buildPressKitSummary({ now: fixedNow });
 
     expect(summary.generatedAtIso).toBe('2024-06-01T12:34:56.000Z');
     expect(summary.performance.budget).toEqual(IMMERSIVE_PERFORMANCE_BUDGET);
     expect(summary.performance.baseline).toEqual(IMMERSIVE_SCENE_BASELINE);
-    expect(summary.performance.report).toEqual(
-      createPerformanceBudgetReport(
-        IMMERSIVE_SCENE_BASELINE,
-        IMMERSIVE_PERFORMANCE_BUDGET
-      )
-    );
+    expect(summary.performance.report).toEqual(expectedReport);
+    expect(summary.performance.headroom).toEqual({
+      materials: {
+        remaining: expectedReport.materials.remaining,
+        percentUsed: expectedReport.materials.percentUsed,
+        overBudgetBy: expectedReport.materials.overBudgetBy,
+      },
+      drawCalls: {
+        remaining: expectedReport.drawCalls.remaining,
+        percentUsed: expectedReport.drawCalls.percentUsed,
+        overBudgetBy: expectedReport.drawCalls.overBudgetBy,
+      },
+      textureBytes: {
+        remaining: expectedReport.textureBytes.remaining,
+        percentUsed: expectedReport.textureBytes.percentUsed,
+        overBudgetBy: expectedReport.textureBytes.overBudgetBy,
+      },
+    });
     expect(summary.poiCatalog).toHaveLength(definitions.length);
     expect(summary.totals.poiCount).toBe(definitions.length);
     expect(summary.totals.roomsRepresented).toBe(expectedRooms);


### PR DESCRIPTION
What:
- add headroom details to the press kit performance summary output
- document the press kit headroom expectation in the roadmap

Why:
- roadmap calls for press kit exports to surface rendering headroom

How to test:
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281cbfa728832f9b448e4ce5b1a95c)