### PR TITLE
Broadcast performance failover telemetry events

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -48,6 +48,8 @@ captures; keep artifacts in `docs/metrics/`.
   - ✅ Runtime performance monitor now auto-switches to text mode after 5 s below 30 FPS.
   - ✅ Low-performance failover logs now surface min/median/p95 FPS and sample counts for telemetry
     handoff, with a default console summary emitted whenever low-FPS fallback triggers.
+    - ✅ A `performancefailover` CustomEvent now broadcasts the fallback reason and FPS summary so
+      analytics hooks can forward the telemetry payload without coupling to the renderer.
   - ✅ Data-saver and console-error failovers now narrate their reason through the mode announcer
     so assistive tech users understand why the text tour launched.
   - ✅ Social and chat link preview scrapers now force the text portfolio via user-agent


### PR DESCRIPTION
## Summary
- emit a performancefailover CustomEvent carrying fallback reason and FPS context
- guard event dispatch failures and document the telemetry hook in the roadmap
- extend performance failover tests to cover the new event and failure cases

## Testing
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281cbfa728832f9b448e4ce5b1a95c)