### PR TITLE
Add focus and landmark semantics to text fallback

### DIFF
--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -921,6 +921,8 @@ export function renderTextFallback(
   section.dataset.localeDirection = direction;
   section.dataset.localeScript = script;
   section.style.textAlign = direction === 'rtl' ? 'right' : 'left';
+  section.role = 'main';
+  section.tabIndex = -1;
 
   const heading = documentTarget.createElement('h1');
   heading.className = 'text-fallback__title';
@@ -994,6 +996,7 @@ export function renderTextFallback(
     section.appendChild(portfolioSection);
   }
   container.appendChild(section);
+  section.focus({ preventScroll: true });
 
   try {
     const announcerStrings = getModeAnnouncerStrings(resolvedLocale);

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -921,7 +921,7 @@ export function renderTextFallback(
   section.dataset.localeDirection = direction;
   section.dataset.localeScript = script;
   section.style.textAlign = direction === 'rtl' ? 'right' : 'left';
-  section.role = 'main';
+  section.setAttribute('role', 'main');
   section.tabIndex = -1;
 
   const heading = documentTarget.createElement('h1');

--- a/src/tests/textFallbackAccessibility.test.ts
+++ b/src/tests/textFallbackAccessibility.test.ts
@@ -137,4 +137,21 @@ describe('text fallback accessibility', () => {
       false
     );
   });
+
+  it('focuses the fallback content and marks it as the main landmark', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    renderTextFallback(container, {
+      reason: 'manual',
+      immersiveUrl: 'https://danielsmith.io/immersive',
+    });
+
+    const section = container.querySelector(
+      '.text-fallback'
+    ) as HTMLElement | null;
+    expect(section?.getAttribute('role')).toBe('main');
+    expect(section?.tabIndex).toBe(-1);
+    expect(document.activeElement).toBe(section);
+  });
 });


### PR DESCRIPTION
## Summary
- focus the rendered text fallback section and mark it as the main landmark for keyboard users
- add regression coverage to verify the fallback view focuses itself and exposes the main role

## Testing
- npm run format:write
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f299a53c832faa20df309b2f37fc)