### PR TITLE
Ensure manual mode toggle recovers on failover

### DIFF
--- a/src/systems/failover/manualModeToggle.ts
+++ b/src/systems/failover/manualModeToggle.ts
@@ -102,6 +102,9 @@ export function createManualModeToggle({
 
   const refreshState = () => {
     const fallbackActive = getIsFallbackActive();
+    if (pending && fallbackActive) {
+      pending = false;
+    }
     const setContainerState = (
       state: 'idle' | 'pending' | 'active' | 'error'
     ) => {

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -119,6 +119,46 @@ describe('createManualModeToggle', () => {
     container.remove();
   });
 
+  it('promotes pending toggles to active when failover fires mid-transition', async () => {
+    const container = createContainer();
+    let fallbackActive = false;
+    let resolveToggle: (() => void) | null = null;
+    const onToggle = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveToggle = resolve;
+        })
+    );
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => fallbackActive,
+    });
+
+    handle.element.click();
+    expect(container.dataset.modeToggleState).toBe('pending');
+    expect(handle.element.getAttribute('aria-busy')).toBe('true');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('false');
+
+    fallbackActive = true;
+    window.dispatchEvent(new CustomEvent('performancefailover'));
+
+    expect(container.dataset.modeToggleState).toBe('active');
+    expect(container.getAttribute('aria-busy')).toBeNull();
+    expect(handle.element.dataset.state).toBe('active');
+    expect(handle.element.getAttribute('aria-busy')).toBeNull();
+    expect(handle.element.disabled).toBe(true);
+
+    resolveToggle?.();
+    await flushMicrotasks();
+
+    expect(container.dataset.modeToggleState).toBe('active');
+    expect(handle.element.dataset.state).toBe('active');
+
+    cleanupHandle(handle);
+    container.remove();
+  });
+
   it('ignores activation when fallback already active', () => {
     const container = createContainer();
     const onToggle = vi.fn();

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -145,8 +145,11 @@ describe('createManualModeToggle', () => {
 
     expect(container.dataset.modeToggleState).toBe('active');
     expect(container.getAttribute('aria-busy')).toBeNull();
+    expect(container.getAttribute('aria-disabled')).toBe('true');
     expect(handle.element.dataset.state).toBe('active');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
+    expect(handle.element.getAttribute('aria-disabled')).toBe('true');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('true');
     expect(handle.element.disabled).toBe(true);
 
     resolveToggle?.();


### PR DESCRIPTION
## Summary
- clear pending manual mode toggle state when a failover is already active
- add regression coverage to confirm HUD toggle becomes active after failover events

## Testing
- npm run format:write
- npm run lint
- npm run test:ci
- npm run docs:check
- npm run smoke

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f299a53c832faa20df309b2f37fc)