### PR TITLE
Normalize mode override parsing for full URLs

### DIFF
--- a/docs/prompts/codex/modes.md
+++ b/docs/prompts/codex/modes.md
@@ -41,9 +41,9 @@ Include summary, automated tests, and manual verification checklist.
 - Network throttling heuristics treat Save-Data, slow-2g/2g/3g effective types,
   low downlink, and high RTT (≥800 ms) as triggers for text mode unless immersive overrides
   or performance bypass flags are present.
-- `evaluateFailoverDecision` accepts `URLSearchParams` or raw search strings so SSR hooks
-  and client-side routers can share the same mode detection logic without manual
-  serialization.
+- `evaluateFailoverDecision` accepts `URLSearchParams`, raw search strings, or full URLs
+  so SSR hooks and client-side routers can share the same mode detection logic without
+  manual serialization.
 - Use `createImmersiveModeUrl(...)` and `createTextModeUrl(...)` helpers to add mode
   overrides without clobbering existing query parameters or hashes.
   - Both helpers now accept an optional extra params map so you can append UTM/debug flags

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -219,6 +219,16 @@ describe('immersive flag helpers', () => {
     expect(getModeFromSearch('mode=unknown')).toBeNull();
   });
 
+  it('parses mode overrides from full URLs or paths with query strings', () => {
+    expect(getModeFromSearch('https://example.com/app?mode=text#hero')).toBe(
+      'text'
+    );
+    expect(getModeFromSearch('/scene?mode=immersive&debug=1')).toBe(
+      'immersive'
+    );
+    expect(getModeFromSearch('https://example.com/app#hero')).toBeNull();
+  });
+
   it('treats mode selections as case-insensitive and trims extra spacing', () => {
     expect(getModeFromSearch('mode=IMMERSIVE')).toBe('immersive');
     expect(getModeFromSearch('mode= text ')).toBe('text');

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -184,7 +184,7 @@ export const createTextModeUrl = (input?: UrlLike, extraParams?: ExtraParams) =>
     extraParams,
   });
 
-const stripHash = (value: string): string => value.split('#')[0] ?? '';
+const stripHash = (value: string): string => splitHash(value).withoutHash;
 
 const normalizeSearchInput = (value: string): string => {
   const trimmed = value.trim();

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -184,8 +184,31 @@ export const createTextModeUrl = (input?: UrlLike, extraParams?: ExtraParams) =>
     extraParams,
   });
 
+const stripHash = (value: string): string => value.split('#')[0] ?? '';
+
+const normalizeSearchInput = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const withoutHash = stripHash(trimmed);
+  const queryIndex = withoutHash.indexOf('?');
+  if (queryIndex >= 0) {
+    return withoutHash.slice(queryIndex);
+  }
+
+  if (withoutHash.includes('://') || withoutHash.startsWith('/')) {
+    return '';
+  }
+
+  return withoutHash;
+};
+
 const toSearchParams = (value: string | URLSearchParams): URLSearchParams =>
-  typeof value === 'string' ? new URLSearchParams(value) : value;
+  typeof value === 'string'
+    ? new URLSearchParams(normalizeSearchInput(value))
+    : value;
 
 const isImmersiveMode = (value: string | null) =>
   normalizeParamValue(value) === IMMERSIVE_MODE_VALUE;


### PR DESCRIPTION
### Motivation

- Mode helpers should accept full URLs and path inputs so server-side and client-side callers can share the same detection logic.
- Parsing raw search strings currently misinterprets full URLs and hash fragments, causing mode flags to be missed in some inputs.
- Tests and prompts need to reflect that helpers accept canonical URLs as well as `URLSearchParams` and raw searches.

### Description

- Add `normalizeSearchInput` and `stripHash` helpers to extract query segments from full URLs and paths in `src/ui/immersiveUrl.ts`.
- Update `toSearchParams(...)` to normalize string inputs before constructing `URLSearchParams` so `getModeFromSearch` and related helpers accept full URLs and path strings.
- Add unit tests in `src/tests/immersiveUrl.test.ts` to cover full URL and path inputs when reading `mode` overrides.
- Update prompt docs in `docs/prompts/codex/modes.md` to document that `evaluateFailoverDecision` accepts full URLs in addition to `URLSearchParams` and raw search strings.

### Testing

- Ran `npm run format:write` and `npm run lint`, both completed successfully.
- Executed `npm run test:ci` (Vitest) and all tests passed (`126 files, 822 tests` reported as passed).
- Ran `npm run docs:check` and the docs check passed.
- Performed the smoke flow `npm run smoke` which builds the site and verified the dist artifact exists, and the smoke check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096d94ce4832f852c99e4396fe9e9)