### PR TITLE
♿ : – Fortify help modal focus trapping

### DIFF
--- a/docs/guides/accessibility-overlays.md
+++ b/docs/guides/accessibility-overlays.md
@@ -22,7 +22,8 @@ screen-reader visitors receive the same metadata as 3D players.
    movement legend in DOM order and ensure `aria-haspopup="dialog"` is present.
 3. When a POI is selected, focus shifts to `.poi-tooltip-overlay`; the close
    button (if present) should be first in the overlay’s tab order.
-4. Trap focus inside modal dialogs (`help-modal`) until dismissed.
+4. Trap focus inside modal dialogs (`help-modal`) until dismissed, redirecting
+   any stray tabbing back into the dialog content.
 5. Announce help menu open/close transitions through the HUD focus announcer so
    assistive tech users know when the dialog state changes.
 

--- a/src/tests/helpModal.test.ts
+++ b/src/tests/helpModal.test.ts
@@ -179,6 +179,31 @@ describe('createHelpModal', () => {
     expect(document.activeElement).toBe(closeButton);
   });
 
+  it('returns focus to the modal when shift-tabbing from outside elements', () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+
+    const handle = createHelpModal({
+      container: document.body,
+      content: cloneContent(),
+    });
+    handle.open();
+
+    const closeButton =
+      document.querySelector<HTMLButtonElement>('.help-modal__close');
+    expect(closeButton).toBeTruthy();
+
+    outside.focus();
+    const shiftTabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+    });
+    document.dispatchEvent(shiftTabEvent);
+
+    expect(document.activeElement).toBe(closeButton);
+  });
+
   it('announces open and close states through a live region', () => {
     vi.useFakeTimers();
     const content = cloneContent();

--- a/src/tests/helpModal.test.ts
+++ b/src/tests/helpModal.test.ts
@@ -157,6 +157,28 @@ describe('createHelpModal', () => {
     expect(document.activeElement).toBe(before);
   });
 
+  it('returns focus to the modal when tabbing from outside elements', () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+
+    const handle = createHelpModal({
+      container: document.body,
+      content: cloneContent(),
+    });
+    handle.open();
+
+    const closeButton =
+      document.querySelector<HTMLButtonElement>('.help-modal__close');
+    expect(closeButton).toBeTruthy();
+
+    outside.focus();
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+    document.dispatchEvent(tabEvent);
+
+    expect(document.activeElement).toBe(closeButton);
+  });
+
   it('announces open and close states through a live region', () => {
     vi.useFakeTimers();
     const content = cloneContent();

--- a/src/ui/hud/helpModal.ts
+++ b/src/ui/hud/helpModal.ts
@@ -281,7 +281,7 @@ export function createHelpModal(options: HelpModalOptions): HelpModalHandle {
       }
       return;
     }
-    if (!active || active === last) {
+    if (!active || active === last || !modal.contains(active)) {
       event.preventDefault();
       first.focus();
     }


### PR DESCRIPTION
### Motivation

- Ensure the help modal maintains strict keyboard focus trapping even when tabbing from elements outside the dialog.  
- Improve keyboard-only HUD parity and avoid focus loss that can confuse screen reader users.  
- Add a regression test to prevent future regressions around tabbing behavior.  
- Document the expected modal focus behavior in the accessibility overlay checklist.  

### Description

- Tighten the focus trap in `src/ui/hud/helpModal.ts` so Tab and Shift+Tab redirect back into the dialog when focus leaves the modal.  
- Add a unit test `returns focus to the modal when tabbing from outside elements` in `src/tests/helpModal.test.ts` to cover the regression.  
- Update `docs/guides/accessibility-overlays.md` to spell out the modal focus rule and redirect behavior.  
- Ran `npm run format:write` to apply formatting changes.  

### Testing

- Ran `npm run format:write` and `npm run lint` and both completed successfully.  
- Executed `npm run docs:check` and `npm run smoke` and both checks passed.  
- Started `npm run test:ci`; the new `helpModal` tests passed, but the full test run was interrupted in this environment due to a hanging `resumeArtifacts.test.ts` `beforeAll`, so the CI run was not completed here.  
- Local verification: the new unit test confirms tabbing from outside returns focus to the modal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096d94ce4832f852c99e4396fe9e9)