### PR TITLE
Add POI category registry queries

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -175,6 +175,8 @@ Focus: anchor each highlighted project with an interactive artifact.
 1. **POI Framework**
    - ✅ Create a data-driven registry for POIs (id, asset, interaction type, metadata).
      - ✅ Room-aware registry queries now expose `getByRoom(...)` for pedestals and HUD overlays.
+     - ✅ Category queries now expose `getByCategory(...)` so HUD filters can separate project and
+       environment exhibits cleanly.
    - ✅ 3D tooltip cards anchor POIs in world space, billboard to the camera, and reuse overlay copy.
      - ✅ World-space POI tooltips now cull when anchored behind the camera to reduce overdraw.
    - ✅ Desktop pointer + keyboard selection loops share accessible focus targets and emit POI

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -286,6 +286,7 @@ function clonePoi(definition: PoiDefinition): PoiDefinition {
     metrics: definition.metrics?.map((metric) => ({ ...metric })),
     links: definition.links?.map((link) => ({ ...link })),
     narration: definition.narration ? { ...definition.narration } : undefined,
+    pedestal: definition.pedestal ? { ...definition.pedestal } : undefined,
   } satisfies PoiDefinition;
 }
 

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -8,6 +8,7 @@ import {
 import { scalePoiValue } from './constants';
 import { applyManualPoiPlacements } from './placements';
 import type {
+  PoiCategory,
   PoiDefinition,
   PoiId,
   PoiPedestalConfig,
@@ -293,9 +294,12 @@ class StaticPoiRegistry implements PoiRegistry {
 
   private readonly roomIndex: Map<string, PoiId[]>;
 
+  private readonly categoryIndex: Map<string, PoiId[]>;
+
   constructor(initial: PoiDefinition[]) {
     this.pois = new Map();
     this.roomIndex = new Map();
+    this.categoryIndex = new Map();
 
     initial.forEach((definition) => {
       const stored = clonePoi(definition);
@@ -305,6 +309,12 @@ class StaticPoiRegistry implements PoiRegistry {
         ids.push(stored.id);
       } else {
         this.roomIndex.set(stored.roomId, [stored.id]);
+      }
+      const categoryIds = this.categoryIndex.get(stored.category);
+      if (categoryIds) {
+        categoryIds.push(stored.id);
+      } else {
+        this.categoryIndex.set(stored.category, [stored.id]);
       }
     });
   }
@@ -329,6 +339,14 @@ class StaticPoiRegistry implements PoiRegistry {
     }
     return ids.map((id) => this.clone(this.pois.get(id)!));
   }
+
+  getByCategory(category: PoiCategory): PoiDefinition[] {
+    const ids = this.categoryIndex.get(category);
+    if (!ids) {
+      return [];
+    }
+    return ids.map((id) => this.clone(this.pois.get(id)!));
+  }
 }
 
 export const poiRegistry: PoiRegistry = new StaticPoiRegistry(definitions);
@@ -339,6 +357,12 @@ export function getPoiDefinitions(): PoiDefinition[] {
 
 export function getPoiDefinitionsByRoom(roomId: string): PoiDefinition[] {
   return poiRegistry.getByRoom(roomId);
+}
+
+export function getPoiDefinitionsByCategory(
+  category: PoiCategory
+): PoiDefinition[] {
+  return poiRegistry.getByCategory(category);
 }
 
 export function isPoiInsideRoom(poi: PoiDefinition): boolean {

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -135,4 +135,5 @@ export interface PoiRegistry {
   all(): PoiDefinition[];
   getById(id: PoiId): PoiDefinition | undefined;
   getByRoom(roomId: string): PoiDefinition[];
+  getByCategory(category: PoiCategory): PoiDefinition[];
 }

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { FLOOR_PLAN } from '../assets/floorPlan';
 import {
   getPoiDefinitions,
+  getPoiDefinitionsByCategory,
   getPoiDefinitionsByRoom,
   isPoiInsideRoom,
 } from '../scene/poi/registry';
@@ -183,5 +184,26 @@ describe('POI registry', () => {
 
   it('returns an empty array when a room has no registered POIs', () => {
     expect(getPoiDefinitionsByRoom('loft')).toEqual([]);
+  });
+
+  it('exposes category-level ordering with defensive copies', () => {
+    const firstCall = getPoiDefinitionsByCategory('project');
+    const secondCall = getPoiDefinitionsByCategory('project');
+
+    expect(firstCall.length).toBe(pois.length);
+    expect(firstCall.every((poi) => poi.category === 'project')).toBe(true);
+
+    expect(firstCall).not.toBe(secondCall);
+    expect(firstCall[0]).not.toBe(secondCall[0]);
+
+    const originalTitle = secondCall[0].title;
+    firstCall[0].title = 'Mutated';
+
+    const refreshed = getPoiDefinitionsByCategory('project');
+    expect(refreshed[0].title).toBe(originalTitle);
+  });
+
+  it('returns an empty array when a category has no registered POIs', () => {
+    expect(getPoiDefinitionsByCategory('environment')).toEqual([]);
   });
 });


### PR DESCRIPTION
### Motivation
- Enable category-level POI lookups so HUDs and text views can filter exhibits by `project` vs `environment`.
- Provide a stable, defensive API surface for category queries that mirrors existing room-level helpers.
- Make it easy for UI and tooling to group or filter POIs without re-scanning the full registry.

### Description
- Add `getByCategory(...)` to the `PoiRegistry` interface and `getPoiDefinitionsByCategory(...)` helper that return defensive copies for callers.
- Index POIs by category with a `categoryIndex: Map<string, PoiId[]>` and populate it during `StaticPoiRegistry` construction.
- Update types in `src/scene/poi/types.ts`, implement registry changes in `src/scene/poi/registry.ts`, add tests in `src/tests/poiRegistry.test.ts`, and document the capability in `docs/roadmap.md`.

### Testing
- Ran `npm run format:write` and `npm run lint` with no reported issues.
- Ran `npm run test:ci` where the test suite completed successfully with `823` tests passing across the project.
- Ran `npm run docs:check` which passed, and `npm run smoke` (build + dist assertions) which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096d94ce4832f852c99e4396fe9e9)