### PR TITLE
🛠️ : – strengthen static smoke artifact checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Each floor has its own auto-generated diagram (regenerated locally with
 | `npm run test` / `npm run test:ci`              | Execute the Vitest suite (CI uses `:ci`).                              |
 | `npm run typecheck`                             | Type-check with TypeScript without emitting files.                     |
 | `npm run docs:check`                            | Ensure required docs (including Codex prompts) exist.                  |
-| `npm run smoke`                                 | Build and assert that `dist/index.html` exists.                        |
+| `npm run smoke`                                 | Build and verify dist bundles + runtime static path references.        |
 | `npm run check`                                 | Convenience command chaining lint, test:ci, and docs:check.            |
 | `npm run press-kit`                             | Emit `docs/assets/press-kit.json` with POI and media manifest details. |
 
@@ -146,7 +146,8 @@ lightweight.
 - **Keyboard traversal macro** – [`playwright/keyboard-traversal.spec.ts`](playwright/keyboard-traversal.spec.ts) touches every POI and HUD overlay using keyboard-only input. Use `npm run test:e2e -- --grep traversal` to run just that macro when iterating.
 - **Animation QA checklist** – [`docs/media/animation-qa.md`](docs/media/animation-qa.md) links the IK contact/footstep sync tests and describes how to capture fresh clips when polishing locomotion.
 - **Docs validation** – `npm run docs:check` enforces prompt, roadmap, and architecture coverage.
-- **Launch smoke** – `npm run smoke` builds the project once and asserts `dist/index.html` exists before heavier suites run.
+- **Launch smoke** – `npm run smoke` builds once, validates bundled JS/CSS references, and
+  reports runtime absolute static paths (manual binary assets warn by default, fail in strict mode).
 - **Link preview heuristics** – Automated user-agent checks steer social/chat crawlers
   (Facebook, Twitter, Slack, Discord, LinkedIn, Telegram, WhatsApp, Skype, GPTBot,
   ClaudeBot, ByteSpider, and others) to the text tour so share cards render without
@@ -159,12 +160,24 @@ lightweight.
 
 ## Auto-generated assets
 
-| Script                      | Output                        | Refresh trigger                                                                                     |
-| --------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------- |
-| `npm run floorplan:diagram` | `docs/assets/floorplan-*.svg` | Run after editing layout data in `src/assets/floorplan/**`. CI regenerates diagrams after merges.   |
-| `npm run launch:screenshot` | `docs/assets/game-launch.png` | Run whenever lighting, camera, or HUD composition shifts. CI captures a fresh image post-merge.     |
-| `npm run smoke`             | `dist/index.html` (assert)    | Ensures the production build succeeds before visual diffs or E2E suites rely on generated assets.   |
+| Script                      | Output                        | Refresh trigger                                                                                        |
+| --------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `npm run floorplan:diagram` | `docs/assets/floorplan-*.svg` | Run after editing layout data in `src/assets/floorplan/**`. CI regenerates diagrams after merges.      |
+| `npm run launch:screenshot` | `docs/assets/game-launch.png` | Run whenever lighting, camera, or HUD composition shifts. CI captures a fresh image post-merge.        |
+| `npm run smoke`             | `dist/**` runtime checks      | Ensures production bundle refs resolve and absolute static paths are reviewed before downstream tests. |
 | `npm run press-kit`         | `docs/assets/press-kit.json`  | Refresh after updating POI copy, performance budgets, or media listings to keep the export current. |
+
+### Manual static binaries for deployment
+
+Some runtime absolute links depend on manually managed binary assets (for
+example `/favicon.ico` and `/docs/resume/2025-09/resume.pdf`).
+
+- Default smoke mode warns for missing manual binaries but does not fail.
+- Strict smoke mode fails if manual binaries are missing from source or `dist/`:
+
+```bash
+REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke
+```
 
 Keep pipelines deterministic by regenerating assets immediately after touching geometry, lighting, or HUD composition so CI diffs stay tidy.
 

--- a/docs/architecture/testing-assets.md
+++ b/docs/architecture/testing-assets.md
@@ -9,7 +9,7 @@ auto-generated artifacts stay up to date.
 | ------------------------ | ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | Unit & integration tests | `src/tests/` (Vitest)        | `npm run test:ci`                   | Run with `CI=1` locally to mirror pipeline timeouts and disable watch mode.                                        |
 | End-to-end + visual      | `playwright/` (Playwright)   | `npm run test:e2e`                  | Uses the same immersive URL overrides as production. Set `CI=1` to lock workers to 1 for deterministic WebGL boot. |
-| Smoke build check        | Vite production build output | `npm run smoke`                     | Ensures `npm run build` succeeds and that `dist/index.html` exists.                                                |
+| Smoke build check        | Vite production build output | `npm run smoke`                     | Ensures `npm run build` succeeds, bundled refs resolve in `dist/`, and runtime absolute static paths are reported. |
 | Linting & types          | Source TypeScript            | `npm run lint`, `npm run typecheck` | Linting runs ESLint; `npm run check` chains lint, tests, and docs validation.                                      |
 
 ### Visual diff budgets
@@ -43,6 +43,18 @@ coverage remains comprehensive.
 
 Regenerate affected assets locally before committing so diffs stay deterministic.
 Document the update in commit messages when budgets or captures shift.
+
+## Manual binary runtime assets
+
+Smoke checks track first-party absolute runtime paths such as `/favicon.ico`
+and `/docs/resume/2025-09/resume.pdf`.
+
+- Default mode warns when those manual binary assets are missing.
+- Strict mode enforces their presence in source and built artifacts:
+
+```bash
+REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke
+```
 
 `npm run press-kit` now emits a `performance.report` payload that mirrors the
 headroom calculations from `createPerformanceBudgetReport(...)`, including

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -1,15 +1,186 @@
 #!/usr/bin/env node
-const { access } = require('fs/promises');
+const { access, readFile } = require('fs/promises');
 const path = require('path');
+const {
+  manualBinaryExtensions,
+  runtimeAbsolutePaths,
+} = require('./static-asset-expectations.cjs');
 
-const artifact = path.join(__dirname, '..', 'dist', 'index.html');
+const repoRoot = path.join(__dirname, '..');
+const distRoot = path.join(repoRoot, 'dist');
+const distIndex = path.join(distRoot, 'index.html');
+const requireManual = process.env.REQUIRE_MANUAL_STATIC_ASSETS === '1';
+
+const bundledAssetPattern =
+  /<(?:script|link)\b[^>]*\b(?:src|href)=['"]([^'"]+)['"][^>]*>/gi;
+const absolutePathPattern = /\b(?:src|href)=['"](\/[^'"]+)['"]/gi;
+
+const toDistPath = (urlPath) =>
+  path.join(distRoot, urlPath.replace(/^\/+/, ''));
+const toSourcePath = (urlPath) =>
+  path.join(repoRoot, urlPath.replace(/^\/+/, ''));
+const isHttpUrl = (value) => /^https?:\/\//i.test(value);
+
+const gatherMatches = (html, pattern, predicate = () => true) => {
+  const values = new Set();
+  let match = pattern.exec(html);
+
+  while (match) {
+    const candidate = match[1];
+
+    if (predicate(candidate)) {
+      values.add(candidate);
+    }
+
+    match = pattern.exec(html);
+  }
+
+  return [...values].sort();
+};
+
+const hasManualExtension = (urlPath) => {
+  const extension = path.extname(urlPath.split(/[?#]/)[0]).toLowerCase();
+  return manualBinaryExtensions.has(extension);
+};
+
+const assertPathExists = async (filePath, message) => {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    if (message) {
+      console.error(message);
+    }
+    return false;
+  }
+};
 
 (async () => {
-  try {
-    await access(artifact);
-    console.log(`Smoke check passed: ${artifact} exists.`);
-  } catch (error) {
-    console.error('Smoke check failed: dist/index.html missing.');
+  let hasFailures = false;
+
+  if (
+    !(await assertPathExists(
+      distIndex,
+      'Smoke check failed: dist/index.html missing.'
+    ))
+  ) {
     process.exitCode = 1;
+    return;
   }
+
+  const distHtml = await readFile(distIndex, 'utf8');
+
+  const bundledRefs = gatherMatches(
+    distHtml,
+    bundledAssetPattern,
+    (value) => !isHttpUrl(value) && !value.startsWith('data:')
+  );
+
+  if (bundledRefs.length === 0) {
+    console.error(
+      'Smoke check failed: dist/index.html has no script/link bundle references.'
+    );
+    hasFailures = true;
+  }
+
+  for (const ref of bundledRefs) {
+    const normalized = ref.startsWith('/') ? ref : `/${ref}`;
+    const candidate = toDistPath(normalized);
+
+    if (
+      !(await assertPathExists(
+        candidate,
+        `Smoke check failed: built asset missing at ${normalized}`
+      ))
+    ) {
+      hasFailures = true;
+    }
+  }
+
+  const absoluteRefs = new Set(runtimeAbsolutePaths);
+  for (const urlPath of gatherMatches(
+    distHtml,
+    absolutePathPattern,
+    (value) => !isHttpUrl(value)
+  )) {
+    absoluteRefs.add(urlPath);
+  }
+
+  const report = [];
+  for (const urlPath of [...absoluteRefs].sort()) {
+    if (urlPath.includes('?') || urlPath.includes('#')) {
+      report.push(
+        `- ${urlPath} (route/query reference ignored for static file checks)`
+      );
+      continue;
+    }
+
+    if (urlPath === '/src/main.ts') {
+      report.push(
+        `- ${urlPath} (dev-only Vite source entry ignored in production checks)`
+      );
+      continue;
+    }
+
+    const sourcePath = toSourcePath(urlPath);
+    const distPath = toDistPath(urlPath);
+    const sourceExists = await assertPathExists(sourcePath, '');
+    const distExists = await assertPathExists(distPath, '');
+    const manualBinary = hasManualExtension(urlPath);
+
+    if (!sourceExists && !distExists) {
+      const status = manualBinary && !requireManual ? 'WARN' : 'FAIL';
+      report.push(`- ${urlPath} (${status}: missing in source and dist)`);
+      if (status === 'FAIL') {
+        hasFailures = true;
+      }
+      continue;
+    }
+
+    if (sourceExists && !distExists) {
+      const status = manualBinary && !requireManual ? 'WARN' : 'FAIL';
+      report.push(
+        `- ${urlPath} (${status}: present in source but missing from dist)`
+      );
+      if (status === 'FAIL') {
+        hasFailures = true;
+      }
+      continue;
+    }
+
+    if (!sourceExists && distExists) {
+      report.push(`- ${urlPath} (OK: present in dist only)`);
+      continue;
+    }
+
+    report.push(`- ${urlPath} (OK: present in source and dist)`);
+  }
+
+  console.log('\nStatic runtime path summary:');
+  for (const line of report) {
+    console.log(line);
+  }
+
+  if (hasFailures) {
+    if (requireManual) {
+      console.error(
+        '\nSmoke check failed in strict manual-asset mode. Fix missing runtime assets and rerun:\n' +
+          'REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke'
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!requireManual && report.some((line) => line.includes('(WARN:'))) {
+    console.warn(
+      '\nSmoke check passed with warnings for manual binary assets.\n' +
+        'After adding them, verify strictly with:\n' +
+        'REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke'
+    );
+  }
+
+  console.log(
+    '\nSmoke check passed: dist artifact and static runtime references look valid.'
+  );
 })();

--- a/scripts/static-asset-expectations.cjs
+++ b/scripts/static-asset-expectations.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  manualBinaryExtensions: new Set([
+    '.pdf',
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.ico',
+    '.webp',
+  ]),
+  runtimeAbsolutePaths: ['/favicon.ico', '/docs/resume/2025-09/resume.pdf'],
+};


### PR DESCRIPTION
### Motivation
- Prepare production static artifact checks to catch broken builds and surface missing first-party runtime assets while keeping manually managed binary files non-blocking by default.

### Description
- Update `scripts/assert-dist.cjs` to parse `dist/index.html`, validate built `script`/`link` bundle references, and summarize first-party absolute runtime paths while ignoring dev-only entries and route/query references.
- Add `scripts/static-asset-expectations.cjs` to declare manual binary extensions and canonical runtime absolute paths (for example `/favicon.ico` and `/docs/resume/2025-09/resume.pdf`).
- Implement manual-binary-aware behavior so the default `npm run smoke` warns for missing manual binaries and the opt-in strict mode `REQUIRE_MANUAL_STATIC_ASSETS=1` fails when such assets are missing.
- Update `README.md` and `docs/architecture/testing-assets.md` to document the enhanced smoke checks and the strict verification command.

### Testing
- Ran `npm ci`, `npm run format:write`, `npm run lint`, `npm run test:ci`, and `npm run docs:check`, with the Vitest suite completing successfully (`126 files` / `826 tests`).
- Ran `npm run smoke` which performed a production `vite build`, validated bundled JS/CSS references in `dist/`, and printed a readable static runtime path summary with warnings for missing manual binaries.
- Verified strict behavior using `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` which fails as expected when the manual runtime asset `/docs/resume/2025-09/resume.pdf` is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ae6e0314832f890723262ed18af0)