### PR TITLE
🧪 : – harden static smoke checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Each floor has its own auto-generated diagram (regenerated locally with
 | `npm run test` / `npm run test:ci`              | Execute the Vitest suite (CI uses `:ci`).                              |
 | `npm run typecheck`                             | Type-check with TypeScript without emitting files.                     |
 | `npm run docs:check`                            | Ensure required docs (including Codex prompts) exist.                  |
-| `npm run smoke`                                 | Build and assert that `dist/index.html` exists.                        |
+| `npm run smoke`                                 | Build and validate `dist/index.html`, bundled assets, and static refs. |
 | `npm run check`                                 | Convenience command chaining lint, test:ci, and docs:check.            |
 | `npm run press-kit`                             | Emit `docs/assets/press-kit.json` with POI and media manifest details. |
 
@@ -146,7 +146,11 @@ lightweight.
 - **Keyboard traversal macro** – [`playwright/keyboard-traversal.spec.ts`](playwright/keyboard-traversal.spec.ts) touches every POI and HUD overlay using keyboard-only input. Use `npm run test:e2e -- --grep traversal` to run just that macro when iterating.
 - **Animation QA checklist** – [`docs/media/animation-qa.md`](docs/media/animation-qa.md) links the IK contact/footstep sync tests and describes how to capture fresh clips when polishing locomotion.
 - **Docs validation** – `npm run docs:check` enforces prompt, roadmap, and architecture coverage.
-- **Launch smoke** – `npm run smoke` builds the project once and asserts `dist/index.html` exists before heavier suites run.
+- **Launch smoke** – `npm run smoke` builds once, validates bundled output references, and reports
+  manual static binary assets (resume/favicon) as warnings by default.
+- **Strict manual static verification** – run `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` after
+  Daniel manually adds binary assets (for example `favicon.ico` and resume PDFs) so missing source
+  or `dist/` artifacts fail fast.
 - **Link preview heuristics** – Automated user-agent checks steer social/chat crawlers
   (Facebook, Twitter, Slack, Discord, LinkedIn, Telegram, WhatsApp, Skype, GPTBot,
   ClaudeBot, ByteSpider, and others) to the text tour so share cards render without
@@ -163,7 +167,7 @@ lightweight.
 | --------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------- |
 | `npm run floorplan:diagram` | `docs/assets/floorplan-*.svg` | Run after editing layout data in `src/assets/floorplan/**`. CI regenerates diagrams after merges.   |
 | `npm run launch:screenshot` | `docs/assets/game-launch.png` | Run whenever lighting, camera, or HUD composition shifts. CI captures a fresh image post-merge.     |
-| `npm run smoke`             | `dist/index.html` (assert)    | Ensures the production build succeeds before visual diffs or E2E suites rely on generated assets.   |
+| `npm run smoke`             | `dist/index.html` + assets    | Verifies built JS/CSS references resolve and reports missing manual binary runtime assets.          |
 | `npm run press-kit`         | `docs/assets/press-kit.json`  | Refresh after updating POI copy, performance budgets, or media listings to keep the export current. |
 
 Keep pipelines deterministic by regenerating assets immediately after touching geometry, lighting, or HUD composition so CI diffs stay tidy.

--- a/docs/architecture/testing-assets.md
+++ b/docs/architecture/testing-assets.md
@@ -9,7 +9,7 @@ auto-generated artifacts stay up to date.
 | ------------------------ | ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | Unit & integration tests | `src/tests/` (Vitest)        | `npm run test:ci`                   | Run with `CI=1` locally to mirror pipeline timeouts and disable watch mode.                                        |
 | End-to-end + visual      | `playwright/` (Playwright)   | `npm run test:e2e`                  | Uses the same immersive URL overrides as production. Set `CI=1` to lock workers to 1 for deterministic WebGL boot. |
-| Smoke build check        | Vite production build output | `npm run smoke`                     | Ensures `npm run build` succeeds and that `dist/index.html` exists.                                                |
+| Smoke build check        | Vite production build output | `npm run smoke`                     | Ensures `npm run build` succeeds, `dist/index.html` exists, and built JS/CSS references resolve in `dist/`.        |
 | Linting & types          | Source TypeScript            | `npm run lint`, `npm run typecheck` | Linting runs ESLint; `npm run check` chains lint, tests, and docs validation.                                      |
 
 ### Visual diff budgets
@@ -43,6 +43,22 @@ coverage remains comprehensive.
 
 Regenerate affected assets locally before committing so diffs stay deterministic.
 Document the update in commit messages when budgets or captures shift.
+
+## Manual binary runtime assets
+
+Static runtime binaries (for example `favicon.ico`, resume PDFs, and similar
+media artifacts) are Daniel-managed and may be absent during automation updates.
+`npm run smoke` reports missing manual binaries as warnings by default so
+text/code-only changes stay unblocked.
+
+After those binary assets are added manually, run:
+
+```bash
+REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke
+```
+
+Strict mode fails when required binary runtime assets are missing from either
+the source path or final `dist/` artifact.
 
 `npm run press-kit` now emits a `performance.report` payload that mirrors the
 headroom calculations from `createPerformanceBudgetReport(...)`, including

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -26,6 +26,13 @@ const normalizeToRuntimeAbsolute = (value) => {
   }
   return cleaned.startsWith('/') ? cleaned : `/${cleaned}`;
 };
+const normalizeRuntimePathForBase = (runtimePath, basePrefix) => {
+  if (!basePrefix || !runtimePath.startsWith(`${basePrefix}/`)) {
+    return runtimePath;
+  }
+  const withoutBase = runtimePath.slice(basePrefix.length);
+  return withoutBase.startsWith('/') ? withoutBase : `/${withoutBase}`;
+};
 const toRelativeFromRoot = (absolutePath) =>
   stripQuery(absolutePath).replace(/^\//, '');
 const hasStaticFileExtension = (runtimePath) =>
@@ -62,6 +69,7 @@ const formatPaths = (paths) =>
 
   const distIndexHtml = await readFile(distIndexPath, 'utf8');
   const bundledAssetReferences = new Set();
+  const bundledAssetBasePrefixes = new Set();
   for (const match of distIndexHtml.matchAll(assetReferenceRegex)) {
     const reference = match[3];
     if (!reference || isHttpUrl(reference)) {
@@ -71,6 +79,10 @@ const formatPaths = (paths) =>
     const normalizedReference = normalizeToRuntimeAbsolute(reference);
     if (normalizedReference.includes('/assets/')) {
       const assetsIndex = normalizedReference.indexOf('/assets/');
+      const basePrefix = normalizedReference.slice(0, assetsIndex);
+      if (basePrefix) {
+        bundledAssetBasePrefixes.add(basePrefix);
+      }
       bundledAssetReferences.add(normalizedReference.slice(assetsIndex));
     }
   }
@@ -99,12 +111,20 @@ const formatPaths = (paths) =>
   }
 
   const runtimeAbsoluteReferences = new Set();
+  const bundledBasePrefixesByLength = [...bundledAssetBasePrefixes].sort(
+    (a, b) => b.length - a.length
+  );
   for (const match of distIndexHtml.matchAll(absolutePathRegex)) {
     const reference = stripQuery(match[1]);
     if (!reference || isHttpUrl(reference) || reference === '/src/main.ts') {
       continue;
     }
-    runtimeAbsoluteReferences.add(reference);
+    const normalizedReference = bundledBasePrefixesByLength.reduce(
+      (currentPath, basePrefix) =>
+        normalizeRuntimePathForBase(currentPath, basePrefix),
+      reference
+    );
+    runtimeAbsoluteReferences.add(normalizedReference);
   }
 
   for (const expectation of runtimeAssetExpectations) {

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -165,7 +165,7 @@ const formatPaths = (paths) =>
     if (
       !manualBinary &&
       hasStaticFileExtension(runtimePath) &&
-      !runtimePath.startsWith('/assets/')
+      !runtimePath.includes('/assets/')
     ) {
       if (!sourceExists || !distExists) {
         failures.push(

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -1,15 +1,163 @@
 #!/usr/bin/env node
-const { access } = require('fs/promises');
+const { access, readFile } = require('fs/promises');
 const path = require('path');
+const {
+  manualBinaryExtensions,
+  runtimeAssetExpectations,
+} = require('./static-asset-expectations.cjs');
 
-const artifact = path.join(__dirname, '..', 'dist', 'index.html');
+const projectRoot = path.join(__dirname, '..');
+const distRoot = path.join(projectRoot, 'dist');
+const distIndexPath = path.join(distRoot, 'index.html');
+const strictManualAssetMode = process.env.REQUIRE_MANUAL_STATIC_ASSETS === '1';
+
+const assetReferenceRegex =
+  /<(script|link)\b[^>]*(src|href)=['\"]([^'\"]+)['\"][^>]*>/gi;
+const absolutePathRegex =
+  /(?:href|src)=['\"](\/(?!\/)[^'\"?#]+(?:\?[^'\"]*)?)['\"]/gi;
+
+const isHttpUrl = (value) => /^(?:https?:)?\/\//i.test(value);
+const stripQuery = (value) => value.split('?')[0].split('#')[0];
+const toRelativeFromRoot = (absolutePath) =>
+  stripQuery(absolutePath).replace(/^\//, '');
+
+const isManualBinaryAsset = (assetPath) => {
+  const extension = path.extname(stripQuery(assetPath)).toLowerCase();
+  return manualBinaryExtensions.has(extension);
+};
+
+const formatPaths = (paths) =>
+  paths.length > 0
+    ? paths.map((assetPath) => `  - ${assetPath}`).join('\n')
+    : '  - none';
 
 (async () => {
+  const failures = [];
+  const warnings = [];
+
   try {
-    await access(artifact);
-    console.log(`Smoke check passed: ${artifact} exists.`);
-  } catch (error) {
-    console.error('Smoke check failed: dist/index.html missing.');
-    process.exitCode = 1;
+    await access(distIndexPath);
+  } catch {
+    failures.push('Missing dist/index.html.');
   }
+
+  if (failures.length > 0) {
+    console.error('Smoke check failed.');
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const distIndexHtml = await readFile(distIndexPath, 'utf8');
+  const bundledAssetReferences = new Set();
+  for (const match of distIndexHtml.matchAll(assetReferenceRegex)) {
+    const reference = match[3];
+    if (!reference || isHttpUrl(reference)) {
+      continue;
+    }
+
+    const cleanedReference = stripQuery(reference);
+    if (
+      cleanedReference.startsWith('/assets/') ||
+      cleanedReference.startsWith('./assets/')
+    ) {
+      bundledAssetReferences.add(cleanedReference.replace(/^\.\//, '/'));
+    }
+  }
+
+  if (bundledAssetReferences.size === 0) {
+    failures.push(
+      'No bundled /assets references found in dist/index.html. Vite output may be broken.'
+    );
+  }
+
+  const missingBundledAssets = [];
+  for (const bundledPath of bundledAssetReferences) {
+    const relativePath = toRelativeFromRoot(bundledPath);
+    const distAssetPath = path.join(distRoot, relativePath);
+    try {
+      await access(distAssetPath);
+    } catch {
+      missingBundledAssets.push(bundledPath);
+    }
+  }
+
+  if (missingBundledAssets.length > 0) {
+    failures.push(
+      `Missing generated assets referenced by dist/index.html:\n${formatPaths(missingBundledAssets)}`
+    );
+  }
+
+  const runtimeAbsoluteReferences = new Set();
+  for (const match of distIndexHtml.matchAll(absolutePathRegex)) {
+    const reference = stripQuery(match[1]);
+    if (!reference || isHttpUrl(reference) || reference === '/src/main.ts') {
+      continue;
+    }
+    runtimeAbsoluteReferences.add(reference);
+  }
+
+  for (const expectation of runtimeAssetExpectations) {
+    runtimeAbsoluteReferences.add(expectation.path);
+  }
+
+  const runtimeChecks = [];
+  for (const runtimePath of [...runtimeAbsoluteReferences].sort()) {
+    const relativePath = toRelativeFromRoot(runtimePath);
+    const sourcePath = path.join(projectRoot, relativePath);
+    const distPath = path.join(distRoot, relativePath);
+
+    const sourceExists = await access(sourcePath)
+      .then(() => true)
+      .catch(() => false);
+    const distExists = await access(distPath)
+      .then(() => true)
+      .catch(() => false);
+    const manualBinary = isManualBinaryAsset(runtimePath);
+
+    runtimeChecks.push({ runtimePath, sourceExists, distExists, manualBinary });
+
+    if (manualBinary && (!sourceExists || !distExists)) {
+      const message =
+        `Manual static asset missing for ${runtimePath} ` +
+        `(source: ${sourceExists ? 'present' : 'missing'}, dist: ${distExists ? 'present' : 'missing'}).`;
+      if (strictManualAssetMode) {
+        failures.push(message);
+      } else {
+        warnings.push(
+          `${message} Run REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke after adding it.`
+        );
+      }
+    }
+  }
+
+  console.log('Runtime static references summary:');
+  for (const check of runtimeChecks) {
+    const type = check.manualBinary ? 'manual-binary' : 'text/static';
+    console.log(
+      `- ${check.runtimePath} [${type}] source=${check.sourceExists ? 'yes' : 'no'} dist=${check.distExists ? 'yes' : 'no'}`
+    );
+  }
+
+  if (warnings.length > 0) {
+    console.warn('\nSmoke check warnings:');
+    for (const warning of warnings) {
+      console.warn(`- ${warning}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('\nSmoke check failed.');
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    '\nSmoke check passed: dist build artifact references look valid.'
+  );
 })();

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -150,7 +150,7 @@ const formatPaths = (paths) =>
     if (manualBinary && (!sourceExists || !distExists)) {
       const message =
         `Manual static asset missing for ${runtimePath} ` +
-        `(source: ${sourceExists ? 'present' : 'missing'}: ${relativePath}, ` +
+        `(source: ${sourceExists ? 'present' : 'missing'}: public/${relativePath}, ` +
         `dist: ${distExists ? 'present' : 'missing'}: dist/${relativePath}).`;
       if (strictManualAssetMode) {
         failures.push(message);
@@ -170,7 +170,7 @@ const formatPaths = (paths) =>
       if (!sourceExists || !distExists) {
         failures.push(
           `Missing first-party runtime static asset for ${runtimePath} ` +
-            `(source: ${sourceExists ? 'present' : 'missing'}: ${relativePath}, ` +
+            `(source: ${sourceExists ? 'present' : 'missing'}: public/${relativePath}, ` +
             `dist: ${distExists ? 'present' : 'missing'}: dist/${relativePath}).`
         );
       }

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -28,6 +28,8 @@ const normalizeToRuntimeAbsolute = (value) => {
 };
 const toRelativeFromRoot = (absolutePath) =>
   stripQuery(absolutePath).replace(/^\//, '');
+const hasStaticFileExtension = (runtimePath) =>
+  Boolean(path.extname(stripQuery(runtimePath)));
 
 const isManualBinaryAsset = (assetPath) => {
   const extension = path.extname(stripQuery(assetPath)).toLowerCase();
@@ -128,12 +130,28 @@ const formatPaths = (paths) =>
     if (manualBinary && (!sourceExists || !distExists)) {
       const message =
         `Manual static asset missing for ${runtimePath} ` +
-        `(source: ${sourceExists ? 'present' : 'missing'}, dist: ${distExists ? 'present' : 'missing'}).`;
+        `(source: ${sourceExists ? 'present' : 'missing'}: ${relativePath}, ` +
+        `dist: ${distExists ? 'present' : 'missing'}: dist/${relativePath}).`;
       if (strictManualAssetMode) {
         failures.push(message);
       } else {
         warnings.push(
           `${message} Run REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke after adding it.`
+        );
+      }
+      continue;
+    }
+
+    if (
+      !manualBinary &&
+      hasStaticFileExtension(runtimePath) &&
+      !runtimePath.startsWith('/assets/')
+    ) {
+      if (!sourceExists || !distExists) {
+        failures.push(
+          `Missing first-party runtime static asset for ${runtimePath} ` +
+            `(source: ${sourceExists ? 'present' : 'missing'}: ${relativePath}, ` +
+            `dist: ${distExists ? 'present' : 'missing'}: dist/${relativePath}).`
         );
       }
     }

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -7,6 +7,7 @@ const {
 } = require('./static-asset-expectations.cjs');
 
 const projectRoot = path.join(__dirname, '..');
+const publicRoot = path.join(projectRoot, 'public');
 const distRoot = path.join(projectRoot, 'dist');
 const distIndexPath = path.join(distRoot, 'index.html');
 const strictManualAssetMode = process.env.REQUIRE_MANUAL_STATIC_ASSETS === '1';
@@ -18,6 +19,13 @@ const absolutePathRegex =
 
 const isHttpUrl = (value) => /^(?:https?:)?\/\//i.test(value);
 const stripQuery = (value) => value.split('?')[0].split('#')[0];
+const normalizeToRuntimeAbsolute = (value) => {
+  const cleaned = stripQuery(value);
+  if (cleaned.startsWith('./')) {
+    return `/${cleaned.slice(2)}`;
+  }
+  return cleaned.startsWith('/') ? cleaned : `/${cleaned}`;
+};
 const toRelativeFromRoot = (absolutePath) =>
   stripQuery(absolutePath).replace(/^\//, '');
 
@@ -58,12 +66,10 @@ const formatPaths = (paths) =>
       continue;
     }
 
-    const cleanedReference = stripQuery(reference);
-    if (
-      cleanedReference.startsWith('/assets/') ||
-      cleanedReference.startsWith('./assets/')
-    ) {
-      bundledAssetReferences.add(cleanedReference.replace(/^\.\//, '/'));
+    const normalizedReference = normalizeToRuntimeAbsolute(reference);
+    if (normalizedReference.includes('/assets/')) {
+      const assetsIndex = normalizedReference.indexOf('/assets/');
+      bundledAssetReferences.add(normalizedReference.slice(assetsIndex));
     }
   }
 
@@ -106,7 +112,7 @@ const formatPaths = (paths) =>
   const runtimeChecks = [];
   for (const runtimePath of [...runtimeAbsoluteReferences].sort()) {
     const relativePath = toRelativeFromRoot(runtimePath);
-    const sourcePath = path.join(projectRoot, relativePath);
+    const sourcePath = path.join(publicRoot, relativePath);
     const distPath = path.join(distRoot, relativePath);
 
     const sourceExists = await access(sourcePath)

--- a/scripts/static-asset-expectations.cjs
+++ b/scripts/static-asset-expectations.cjs
@@ -1,0 +1,26 @@
+const manualBinaryExtensions = new Set([
+  '.pdf',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.ico',
+  '.webp',
+  '.avif',
+  '.gif',
+]);
+
+const runtimeAssetExpectations = [
+  {
+    path: '/favicon.ico',
+    reason: 'Tab/favicon metadata in index.html.',
+  },
+  {
+    path: '/docs/resume/2025-09/resume.pdf',
+    reason: 'No-script fallback resume link in index.html.',
+  },
+];
+
+module.exports = {
+  manualBinaryExtensions,
+  runtimeAssetExpectations,
+};

--- a/scripts/static-asset-expectations.cjs
+++ b/scripts/static-asset-expectations.cjs
@@ -1,5 +1,6 @@
 const manualBinaryExtensions = new Set([
   '.pdf',
+  '.docx',
   '.png',
   '.jpg',
   '.jpeg',


### PR DESCRIPTION
### Motivation

- Improve the existing smoke check so production Vite artifacts are validated beyond the mere presence of `dist/index.html` without adding or changing any binary assets.
- Ensure manually-managed runtime binaries (favicon, resume PDFs, etc.) do not block normal code/doc iterations while providing an opt-in strict check for deploy prep.

### Description

- Update `scripts/assert-dist.cjs` to parse `dist/index.html`, validate built `/assets/*` JS/CSS references exist in `dist/`, enumerate absolute runtime references, and emit a readable summary with warnings or failures depending on mode.
- Add a text-only manifest `scripts/static-asset-expectations.cjs` that lists manual-binary extensions and explicit runtime expectations such as `/favicon.ico` and `/docs/resume/2025-09/resume.pdf`.
- Update docs and README (`README.md` and `docs/architecture/testing-assets.md`) to document the new smoke behavior and the strict verification command `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` for after manual asset addition.
- No binary files were created, modified, or committed; changes are limited to smoke/build checks and docs only.

### Testing

- Ran `npm run lint` and it completed successfully.
- Ran `npm run test:ci` and the Vitest suite passed (all tests reported as passed during the run).
- Ran `npm run docs:check` and it passed.
- Ran `npm run smoke` (default) which builds the site and passed the smoke check while printing actionable warnings for missing manual binaries.
- Ran `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` which correctly failed when manual binary assets were missing, demonstrating strict-mode behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ae6e0314832f890723262ed18af0)