### PR TITLE
🧪 Static smoke checks for Vite artifacts and manual binary assets

### DIFF
--- a/docs/architecture/testing-assets.md
+++ b/docs/architecture/testing-assets.md
@@ -5,12 +5,12 @@ auto-generated artifacts stay up to date.
 
 ## Test suites
 
-| Suite                    | Location                     | Command                             | Notes                                                                                                              |
-| ------------------------ | ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Unit & integration tests | `src/tests/` (Vitest)        | `npm run test:ci`                   | Run with `CI=1` locally to mirror pipeline timeouts and disable watch mode.                                        |
-| End-to-end + visual      | `playwright/` (Playwright)   | `npm run test:e2e`                  | Uses the same immersive URL overrides as production. Set `CI=1` to lock workers to 1 for deterministic WebGL boot. |
-| Smoke build check        | Vite production build output | `npm run smoke`                     | Ensures `npm run build` succeeds and that `dist/index.html` exists.                                                |
-| Linting & types          | Source TypeScript            | `npm run lint`, `npm run typecheck` | Linting runs ESLint; `npm run check` chains lint, tests, and docs validation.                                      |
+| Suite                    | Location                     | Command                             | Notes                                                                                                                                                  |
+| ------------------------ | ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Unit & integration tests | `src/tests/` (Vitest)        | `npm run test:ci`                   | Run with `CI=1` locally to mirror pipeline timeouts and disable watch mode.                                                                            |
+| End-to-end + visual      | `playwright/` (Playwright)   | `npm run test:e2e`                  | Uses the same immersive URL overrides as production. Set `CI=1` to lock workers to 1 for deterministic WebGL boot.                                     |
+| Smoke build check        | Vite production build output | `npm run smoke`                     | Ensures `npm run build` succeeds, `dist/index.html` exists, generated `/assets/*` bundles resolve, and first-party root-relative links are summarized. |
+| Linting & types          | Source TypeScript            | `npm run lint`, `npm run typecheck` | Linting runs ESLint; `npm run check` chains lint, tests, and docs validation.                                                                          |
 
 ### Visual diff budgets
 
@@ -48,3 +48,19 @@ Document the update in commit messages when budgets or captures shift.
 headroom calculations from `createPerformanceBudgetReport(...)`, including
 `status` labels and clamped `remainingPercent` values so distribution artifacts
 call out budget health at a glance.
+
+## Static deployment binary preconditions
+
+`npm run smoke` reports first-party root-relative references found in `dist/index.html`.
+Manual binaries (for example `favicon.ico`, résumé PDFs, and image formats such as
+PNG/JPG/WEBP) are warning-only in default mode so container/static preparation can continue
+without committing binaries from automation.
+
+After Daniel manually adds or updates these assets, run strict verification:
+
+```bash
+REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke
+```
+
+Strict mode fails when a manual binary asset referenced by the app is missing from source or
+from the built `dist/` artifact.

--- a/scripts/assert-dist.cjs
+++ b/scripts/assert-dist.cjs
@@ -1,15 +1,183 @@
 #!/usr/bin/env node
-const { access } = require('fs/promises');
+const fs = require('fs');
 const path = require('path');
 
-const artifact = path.join(__dirname, '..', 'dist', 'index.html');
+const PROJECT_ROOT = path.join(__dirname, '..');
+const DIST_ROOT = path.join(PROJECT_ROOT, 'dist');
+const DIST_INDEX = path.join(DIST_ROOT, 'index.html');
+const REQUIRE_MANUAL_STATIC_ASSETS =
+  process.env.REQUIRE_MANUAL_STATIC_ASSETS === '1';
 
-(async () => {
+const MANUAL_BINARY_EXTENSIONS = new Set([
+  '.pdf',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.ico',
+  '.webp',
+]);
+
+const EXIT = {
+  OK: 0,
+  FAIL: 1,
+};
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function fileExists(filePath) {
+  return fs.existsSync(filePath);
+}
+
+function normalizePathname(raw) {
+  if (!raw || !raw.startsWith('/')) {
+    return null;
+  }
+
+  const withoutHash = raw.split('#')[0];
+  const withoutQuery = withoutHash.split('?')[0];
+  return withoutQuery || '/';
+}
+
+function extractRootRelativeReferences(html) {
+  const refs = new Set();
+  const attrRegex = /(?:href|src)=(["'])(.*?)\1/g;
+
+  for (const match of html.matchAll(attrRegex)) {
+    const normalized = normalizePathname(match[2]);
+    if (normalized) {
+      refs.add(normalized);
+    }
+  }
+
+  return [...refs].sort();
+}
+
+function isManualBinaryPath(pathname) {
+  const extension = path.extname(pathname).toLowerCase();
+  return MANUAL_BINARY_EXTENSIONS.has(extension);
+}
+
+function checkDistIndex() {
+  if (!fileExists(DIST_INDEX)) {
+    throw new Error(
+      'Smoke check failed: dist/index.html is missing. Run npm run build first.'
+    );
+  }
+}
+
+function checkViteBuiltAssets(indexHtml) {
+  const missing = [];
+  const refs = extractRootRelativeReferences(indexHtml).filter((pathname) =>
+    pathname.startsWith('/assets/')
+  );
+
+  for (const pathname of refs) {
+    const distTarget = path.join(DIST_ROOT, pathname.slice(1));
+    if (!fileExists(distTarget)) {
+      missing.push(pathname);
+    }
+  }
+
+  return { refs, missing };
+}
+
+function checkFirstPartyStaticReferences(indexHtml) {
+  const refs = extractRootRelativeReferences(indexHtml).filter(
+    (pathname) => !pathname.startsWith('/assets/')
+  );
+
+  const report = refs.map((pathname) => {
+    const sourcePath = path.join(PROJECT_ROOT, pathname.slice(1));
+    const distPath = path.join(DIST_ROOT, pathname.slice(1));
+    const manualBinary = isManualBinaryPath(pathname);
+
+    return {
+      pathname,
+      sourceExists: fileExists(sourcePath),
+      distExists: fileExists(distPath),
+      manualBinary,
+    };
+  });
+
+  return report;
+}
+
+function printStaticReferenceSummary(report) {
+  if (report.length === 0) {
+    console.log(
+      'No first-party root-relative static references found in dist/index.html.'
+    );
+    return;
+  }
+
+  console.log(
+    'First-party root-relative static references from dist/index.html:'
+  );
+  for (const item of report) {
+    const kind = item.manualBinary ? 'manual-binary' : 'text/static';
+    const source = item.sourceExists ? 'source:ok' : 'source:missing';
+    const dist = item.distExists ? 'dist:ok' : 'dist:missing';
+    console.log(` - ${item.pathname} [${kind}] (${source}, ${dist})`);
+  }
+}
+
+(function main() {
   try {
-    await access(artifact);
-    console.log(`Smoke check passed: ${artifact} exists.`);
+    checkDistIndex();
+    const indexHtml = readText(DIST_INDEX);
+
+    const viteAssets = checkViteBuiltAssets(indexHtml);
+    if (viteAssets.refs.length === 0) {
+      throw new Error(
+        'Smoke check failed: no /assets/* references found in dist/index.html.'
+      );
+    }
+
+    if (viteAssets.missing.length > 0) {
+      throw new Error(
+        `Smoke check failed: missing built Vite assets:\n${viteAssets.missing
+          .map((asset) => ` - ${asset}`)
+          .join('\n')}`
+      );
+    }
+
+    const staticRefs = checkFirstPartyStaticReferences(indexHtml);
+    printStaticReferenceSummary(staticRefs);
+
+    const missingManual = staticRefs.filter(
+      (item) => item.manualBinary && (!item.sourceExists || !item.distExists)
+    );
+
+    if (missingManual.length > 0) {
+      const message = [
+        'Manual static binary asset checks:',
+        ...missingManual.map(
+          (item) =>
+            ` - ${item.pathname} (source:${item.sourceExists ? 'ok' : 'missing'}, dist:${
+              item.distExists ? 'ok' : 'missing'
+            })`
+        ),
+      ].join('\n');
+
+      if (REQUIRE_MANUAL_STATIC_ASSETS) {
+        throw new Error(
+          `${message}\nFailing because REQUIRE_MANUAL_STATIC_ASSETS=1 is enabled.`
+        );
+      }
+
+      console.warn(
+        `${message}\nWarning only (default mode). Set REQUIRE_MANUAL_STATIC_ASSETS=1 to fail on these.`
+      );
+    }
+
+    console.log(
+      'Smoke check passed: dist artifact references look consistent.'
+    );
+    process.exitCode = EXIT.OK;
   } catch (error) {
-    console.error('Smoke check failed: dist/index.html missing.');
-    process.exitCode = 1;
+    console.error(error.message);
+    process.exitCode = EXIT.FAIL;
   }
 })();


### PR DESCRIPTION
### Motivation
- Improve the production smoke check to catch broken Vite outputs and surface missing first-party static references before containerized hosting work. 
- Keep binary assets (favicon, résumé PDFs, images) as manual, Daniel-owned artifacts and avoid committing or generating binaries from automation. 
- Provide an opt-in strict verification mode for deployment readiness while preserving default non-blocking behavior. 

### Description
- Replace the simple existence check with `scripts/assert-dist.cjs` that verifies `dist/index.html`, ensures `/assets/*` bundle references exist in `dist/`, and extracts root-relative first-party references from the built HTML. 
- Add manual-binary awareness for `.pdf`, `.png`, `.jpg`, `.jpeg`, `.ico`, and `.webp` paths and report their `source`/`dist` presence. 
- Default mode prints actionable warnings for missing manual binaries, and strict mode (`REQUIRE_MANUAL_STATIC_ASSETS=1`) makes the smoke check fail on missing manual binaries. 
- Update `docs/architecture/testing-assets.md` to document the stricter smoke guarantees, the manual-binary precondition, and the strict verification command `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke`. 

### Testing
- Ran `npm ci`, `npm run format:write`, `npm run lint`, `npm run test:ci`, and `npm run docs:check`, and all of those commands completed successfully. 
- Ran `npm run smoke` which builds the app, validated `/assets/*` bundles exist, printed a summary of first-party root-relative references, and passed in default (warning) mode. 
- Ran strict verification `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` which failed as expected and reported missing manual binaries (actionable paths shown). 
- Verified no binary files were added or modified via `git diff --name-only -- '*.pdf' '*.png' '*.jpg' '*.jpeg' '*.ico' '*.webp'` prior to commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ae6e0314832f890723262ed18af0)