### PR TITLE
🐳 : – add production static nginx container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+.git
+.gitignore
+.github
+.vscode
+.idea
+
+.DS_Store
+*.swp
+*.swo
+
+coverage
+playwright-report
+test-results
+
+*.tgz
+
+# Build outputs generated locally
+dist
+
+# Local caches
+.eslintcache
+.prettier-cache
+.vite
+
+# Optional docs/media artifacts not required for docker build context
+screenshots

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run smoke
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist/ /usr/share/nginx/html/
+
+EXPOSE 8080

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,37 @@
+server {
+  listen 8080;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location = /healthz {
+    default_type application/json;
+    add_header Cache-Control "no-store" always;
+    return 200 '{"status":"ok"}';
+  }
+
+  location = /livez {
+    default_type application/json;
+    add_header Cache-Control "no-store" always;
+    return 200 '{"status":"ok"}';
+  }
+
+  location ~ /\.(?!well-known).* {
+    deny all;
+  }
+
+  location = /index.html {
+    add_header Cache-Control "no-store" always;
+    try_files $uri =404;
+  }
+
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a production container that serves only built static assets without running Node in the final image.
- Ensure Kubernetes-friendly health endpoints (`/healthz`, `/livez`) and SPA routing so the site is ready for deployment behind an ingress.
- Improve runtime security and caching by using an unprivileged static server and long-lived caching for hashed assets.

### Description
- Add a multi-stage `Dockerfile` that uses Node 20 for the build stage, runs `npm ci` and `npm run smoke`, and copies only `dist/` into an unprivileged `nginx` runtime exposing port `8080`.
- Add `.dockerignore` to reduce build-context noise by excluding `node_modules`, `dist`, `.git`, local caches, and test artifacts.
- Add `docker/nginx/default.conf` implementing `/healthz` and `/livez` JSON 200 responses, SPA fallback via `try_files ... /index.html`, hidden-file denial, long-lived `Cache-Control` for `/assets/`, and `no-store` for `index.html` and health endpoints.
- Keep the runtime image Node-free and non-root by using `nginxinc/nginx-unprivileged` and copying only production artifacts.

### Testing
- Ran `npm ci` successfully in the build environment.
- Ran `npm run smoke` successfully and the smoke check passed (smoke emitted a warning about a missing manual static PDF asset but did not fail the build).
- Ran `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.
- Attempted `docker build -t danielsmith-io:local .` but it failed in this runner due to `docker: command not found` so image build verification is blocked in CI-less environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1366680748832f98d29457aace19a1)