### PR TITLE
🐳 : – add production static nginx container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Dependencies and local build outputs
+node_modules
+dist
+
+# Git metadata
+.git
+.gitignore
+
+# Logs and caches
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.eslintcache
+.vite
+
+# Editor / OS files
+.DS_Store
+.vscode
+.idea
+
+# Test artifacts and screenshots
+playwright-report
+test-results
+coverage
+*.png
+*.jpg
+*.jpeg
+*.webp
+
+# Local env
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-bookworm-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run smoke
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,39 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /healthz {
+        default_type application/json;
+        add_header Cache-Control "no-store" always;
+        return 200 '{"status":"ok"}';
+    }
+
+    location = /livez {
+        default_type application/json;
+        add_header Cache-Control "no-store" always;
+        return 200 '{"status":"ok"}';
+    }
+
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-store" always;
+        try_files $uri =404;
+    }
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a production-grade container for serving the Vite-built static site without Node at runtime.
- Ensure Kubernetes-friendly behavior by exposing probes and stable cache semantics for hashed assets.

### Description
- Add a multi-stage `Dockerfile` using Node 20 for the build stage that runs `npm ci` and `npm run smoke`, and copies only `dist/` into an unprivileged nginx runtime image exposing port `8080`.
- Add `.dockerignore` to keep the Docker build context small while preserving required build inputs (`package.json`, lockfile, source, and build scripts).
- Add `docker/nginx/default.conf` implementing `/healthz` and `/livez` JSON probes, SPA fallback via `try_files ... /index.html`, long-lived caching for `/assets/`, `no-store` for `index.html` and probe endpoints, and hidden-file denial.

### Testing
- Ran `npm ci` successfully in the build environment.
- Ran `npm run smoke` successfully which includes `vite build` and the repository's `scripts/assert-dist.cjs` smoke checks.
- Ran `npm run format:write` and `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.
- Attempted `docker build -t danielsmith-io:local .` but the environment lacks Docker (`docker: command not found`), so the runtime image build/behavior was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1366680748832f98d29457aace19a1)