### PR TITLE
Add production Dockerfile and nginx static serving config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.git
+.gitignore
+.vscode
+*.log
+npm-debug.log*
+playwright-report
+test-results
+coverage
+.DS_Store
+*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run smoke
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 8080

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,42 @@
+server {
+  listen 8080;
+  listen [::]:8080;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  gzip on;
+  gzip_types text/css application/javascript application/json image/svg+xml;
+
+  location = /healthz {
+    add_header Content-Type application/json;
+    add_header Cache-Control 'no-store';
+    return 200 '{"status":"ok"}';
+  }
+
+  location = /livez {
+    add_header Content-Type application/json;
+    add_header Cache-Control 'no-store';
+    return 200 '{"status":"ok"}';
+  }
+
+  location ~ /\.
+  {
+    deny all;
+  }
+
+  location = /index.html {
+    add_header Cache-Control 'no-store';
+    try_files $uri =404;
+  }
+
+  location /assets/ {
+    add_header Cache-Control 'public, max-age=31536000, immutable';
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a production container for the built Vite static site that does not run Node at runtime and is Kubernetes-friendly.
- Ensure the runtime serves SPA routes, exposes health endpoints, and applies sensible cache policies for hashed assets.

### Description
- Add a multi-stage `Dockerfile` that uses Node 20 for the build stage, runs `npm ci` and `npm run smoke`, and copies only `dist/` into an unprivileged nginx runtime image that exposes port `8080`.
- Add `docker/nginx/default.conf` which sets the static root to `/usr/share/nginx/html`, implements SPA fallback via `try_files ... /index.html`, provides `/healthz` and `/livez` JSON 200 endpoints with `no-store` caching, denies access to hidden files, enables gzip, and sets long-lived immutable cache headers for `/assets/` while keeping `index.html` and health endpoints `no-store`.
- Add a `.dockerignore` to keep `node_modules`, `dist`, VCS metadata, logs, test artifacts, and other local files out of the Docker build context.

### Testing
- Ran `npm ci` successfully in the build environment.
- Ran `npm run smoke` (which runs `npm run build` and `scripts/assert-dist.cjs`) and it passed, validating referenced static artifacts.
- Attempted `docker build -t danielsmith-io:local .` but the environment lacks Docker (`docker: command not found`), so the image build could not be executed here.
- Ran the repository secret scan via `./scripts/scan-secrets.py` on the staged changes and it reported no high-risk secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1366680748832f98d29457aace19a1)