### PR TITLE
Add production Dockerfile and nginx static-serving config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,13 @@ yarn-error.log*
 .idea
 *.swp
 *.swo
+.env
+.env.*
+*.env
+*.pem
+*.key
+*.p12
+*.crt
 
 # Docs and generated artifacts not needed for image build context
 README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,8 +18,8 @@ yarn-error.log*
 *.swp
 *.swo
 .env
-.env.local
-.env.*.local
+.env.*
+*.env
 *.pem
 *.key
 *.p12

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+.git
+.gitignore
+node_modules
+dist
+coverage
+playwright-report
+test-results
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store
+.npm
+.cache
+.DS_Store
+.vscode
+.idea
+*.swp
+*.swo
+
+# Docs and generated artifacts not needed for image build context
+README.md
+docs/assets/**/*.png
+docs/assets/**/*.jpg
+docs/assets/**/*.jpeg
+docs/assets/**/*.webp
+docs/assets/**/*.gif

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,8 +18,8 @@ yarn-error.log*
 *.swp
 *.swo
 .env
-.env.*
-*.env
+.env.local
+.env.*.local
 *.pem
 *.key
 *.p12

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -22,3 +22,67 @@ jobs:
         run: npm run test:ci
       - name: Smoke test
         run: npm run smoke
+
+  docker-runtime-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t danielsmith-io:local .
+
+      - name: Smoke test Docker runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          container_name="danielsmith-io-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          docker run -d --name "${container_name}" \
+            -p 127.0.0.1:8080:8080 \
+            danielsmith-io:local
+
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/ >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/healthz >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/livez >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          test "${ready}" = 1
+
+          curl -fsSI http://127.0.0.1:8080/healthz | \
+            grep -i 'content-type: application/json'
+          curl -fsSI http://127.0.0.1:8080/healthz | \
+            grep -i 'cache-control: no-store'
+          curl -fsS http://127.0.0.1:8080/studio | grep -qi '<html'
+
+          test "$(curl -s -o /dev/null -w '%{http_code}' \
+            http://127.0.0.1:8080/definitely-missing.pdf)" = "404"
+
+          test "$(curl -s -o /dev/null -w '%{http_code}' \
+            http://127.0.0.1:8080/assets/definitely-missing.js.map)" = "404"
+
+          docker exec "${container_name}" sh -lc '! command -v node'
+          docker exec "${container_name}" sh -lc \
+            '! find /usr/share/nginx/html -type f -name "*.map" -print -quit | grep .'
+
+          asset="$(
+            docker exec "${container_name}" sh -lc \
+              "find /usr/share/nginx/html/assets -maxdepth 1 -type f ! -name '*.map' | head -n 1" | \
+              sed 's#^/usr/share/nginx/html##'
+          )"
+          test -n "${asset}"
+
+          curl -fsSI "http://127.0.0.1:8080${asset}" | \
+            grep -i 'cache-control: public, max-age=31536000, immutable'
+
+          docker logs "${container_name}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,12 @@ RUN find dist -type f -name '*.map' -delete
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
 WORKDIR /usr/share/nginx/html
 
+USER root
+RUN rm -rf /usr/share/nginx/html/*
+
 COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist/ /usr/share/nginx/html/
+
+USER nginx
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
-RUN npm run smoke
+RUN REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke
+RUN find dist -type f -name '*.map' -delete
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
 WORKDIR /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-bookworm-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run smoke
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+WORKDIR /usr/share/nginx/html
+
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist/ /usr/share/nginx/html/
+
+EXPOSE 8080

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -32,7 +32,11 @@ server {
     }
 
     location / {
+        try_files $uri $uri/ @spa_fallback;
+    }
+
+    location @spa_fallback {
         add_header Cache-Control "no-store" always;
-        try_files $uri $uri/ /index.html;
+        try_files /index.html =404;
     }
 }

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -26,11 +26,15 @@ server {
         try_files $uri =404;
     }
 
+    location ~* ^/assets/.*\.map$ {
+        return 404;
+    }
+
     location ~* \.map$ {
         return 404;
     }
 
-    location /assets/ {
+    location ~* ^/assets/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         try_files $uri =404;
     }

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -26,8 +26,16 @@ server {
         try_files $uri =404;
     }
 
+    location ~* \.map$ {
+        return 404;
+    }
+
     location /assets/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    location ~* \.[^/]+$ {
         try_files $uri =404;
     }
 

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,38 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /healthz {
+        default_type application/json;
+        add_header Cache-Control "no-store" always;
+        return 200 '{"status":"ok"}';
+    }
+
+    location = /livez {
+        default_type application/json;
+        add_header Cache-Control "no-store" always;
+        return 200 '{"status":"ok"}';
+    }
+
+    location ~ /\.|/\. {
+        return 404;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-store" always;
+        try_files $uri =404;
+    }
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    location / {
+        add_header Cache-Control "no-store" always;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a production-ready container image that serves only the built Vite static site without Node at runtime and exposes Kubernetes-friendly health endpoints.
- Ensure the image build runs the repo smoke checks (`npm run smoke`) so the container contains all referenced static artifacts.
- Use an unprivileged runtime and sensible cache/SPA behavior to make the image safe and performant in clusters.

### Description
- Add a multi-stage `Dockerfile` that uses Node 20 for the build stage, runs `npm ci` and `npm run smoke`, and copies only `dist/` into an `nginx` unprivileged runtime on port `8080`.
- Add `docker/nginx/default.conf` with `try_files` SPA fallback to `/index.html`, `/healthz` and `/livez` JSON 200 endpoints, hidden-file blocking, long-lived `Cache-Control` for `/assets/*`, and `no-store` for `index.html` and route fallbacks.
- Add a focused `.dockerignore` to reduce build context by excluding `node_modules`, `dist`, test artifacts, logs, and large doc assets while keeping files required by `npm ci` and the build.
- Keep runtime image free of Node and runtime source, and avoid adding Helm/GHCR/Sugarkube changes in this PR.

### Testing
- Ran `npm run format:write` successfully. 
- Ran `npm run lint && npm run test:ci && npm run docs:check` and all automated tests completed successfully (`vitest` run showed 826 tests passed) and docs check passed. 
- Ran `npm run smoke` which builds the production bundle and the smoke assertions in `scripts/assert-dist.cjs` passed. 
- Performed a staged secret scan with `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets. 
- Attempted `docker build -t danielsmith-io:local .` but it failed in this environment because `docker` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1366680748832f98d29457aace19a1)