### PR TITLE
Add canonical danielsmith Helm chart

### DIFF
--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: danielsmith
+description: Canonical Helm chart for danielsmith.io static web deployment
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{- define "danielsmith.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "danielsmith.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: danielsmith
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "danielsmith.selectorLabels" -}}
+app.kubernetes.io/name: danielsmith
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "danielsmith.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "danielsmith.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else if .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "danielsmith.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "danielsmith.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "danielsmith.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "danielsmith.name" . }}
+          image: {{ include "danielsmith.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- $envAll := concat .Values.env .Values.extraEnv }}
+          {{- with $envAll }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/danielsmith/templates/ingress.yaml
+++ b/charts/danielsmith/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "danielsmith.fullname" . }}
+                port:
+                  name: http
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/danielsmith/templates/service.yaml
+++ b/charts/danielsmith/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "danielsmith.selectorLabels" . | nindent 4 }}

--- a/charts/danielsmith/templates/serviceaccount.yaml
+++ b/charts/danielsmith/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "danielsmith.serviceAccountName" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -1,0 +1,83 @@
+replicaCount: 1
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+containerPort: 8080
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+probes:
+  liveness:
+    path: /livez
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+env: []
+extraEnv: []
+envFrom: []
+
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+  - name: nginx-cache
+    mountPath: /var/cache/nginx
+
+volumes:
+  - name: tmp
+    emptyDir: {}
+  - name: nginx-cache
+    emptyDir: {}


### PR DESCRIPTION
### Motivation
- Provide an app-owned, canonical Helm chart for Sugarkube to install the static `danielsmith.io` site from GHCR OCI with DSPACE/token.place-style values and secure defaults.

### Description
- Add `charts/danielsmith/Chart.yaml` (`apiVersion: v2`, `name: danielsmith`, `type: application`, `version: 0.1.0`, `appVersion: "0.1.0"`).
- Add `charts/danielsmith/values.yaml` with DSPACE-style keys including `replicaCount`, `image.{repository,tag,digest,pullPolicy}`, `service`, `containerPort`, `ingress` toggles, `serviceAccount` options, `podSecurityContext` / `securityContext`, resource requests/limits, `probes` (`/livez` and `/healthz`), and optional `env`, `extraEnv`, and `envFrom` hooks.
- Add templates: `_helpers.tpl` (canonical naming, label helpers, and image rendering logic preferring `digest` then `tag` then `Chart.AppVersion`), `deployment.yaml` (named `http` port 8080, liveness `/livez`, readiness `/healthz`, non-root, drop all capabilities, no privilege escalation, read-only root fs with writable `/tmp` and `/var/cache/nginx`), `service.yaml`, `ingress.yaml` (optional host/class/annotations/TLS, Traefik-compatible), and `serviceaccount.yaml` gated by `serviceAccount.create`.
- Ensure labels include `app.kubernetes.io/name: danielsmith` and `app.kubernetes.io/instance: {{ .Release.Name }}` so resources render as `danielsmith` for the default release/namespace.

### Testing
- Attempted `helm lint charts/danielsmith` but it could not run because the `helm` binary is not available in this environment (`/bin/bash: line 1: helm: command not found`).
- Attempted `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` but it was blocked locally for the same reason (missing `helm`).
- Planned verification commands to run in an environment with Helm are: `helm lint charts/danielsmith`, `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee > /tmp/danielsmith-rendered.yaml`, and the greps: `grep -q 'ghcr.io/futuroptimist/danielsmith.io:main-deadbee' /tmp/danielsmith-rendered.yaml`, `grep -q 'path: /healthz' /tmp/danielsmith-rendered.yaml`, `grep -q 'path: /livez' /tmp/danielsmith-rendered.yaml`, `grep -q 'host: staging.danielsmith.io' /tmp/danielsmith-rendered.yaml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13818f3d04832f8c61d669d9f09210)