### PR TITLE
Add canonical danielsmith Helm chart for Sugarkube

### DIFF
--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: danielsmith
+description: Helm chart for danielsmith.io static web app
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{- define "danielsmith.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "danielsmith.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "danielsmith.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: danielsmith
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "danielsmith.selectorLabels" -}}
+app.kubernetes.io/name: danielsmith
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "danielsmith.image" -}}
+{{- if .Values.image.digest -}}
+{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else if .Values.image.tag -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "danielsmith.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "danielsmith.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "danielsmith.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "danielsmith.name" . }}
+          image: {{ include "danielsmith.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: var-cache-nginx
+              mountPath: /var/cache/nginx
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: var-cache-nginx
+          emptyDir: {}

--- a/charts/danielsmith/templates/ingress.yaml
+++ b/charts/danielsmith/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "danielsmith.fullname" . }}
+                port:
+                  name: http
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/danielsmith/templates/service.yaml
+++ b/charts/danielsmith/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "danielsmith.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/danielsmith/templates/serviceaccount.yaml
+++ b/charts/danielsmith/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "danielsmith.serviceAccountName" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -1,0 +1,73 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+containerPort: 8080
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  automountServiceAccountToken: false
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+env: []
+extraEnv: []
+envFrom: []


### PR DESCRIPTION
### Motivation
- Provide an app-owned, minimal Helm chart that Sugarkube can install from GHCR OCI for the static danielsmith.io site using DSPACE/token.place-style values and safe defaults.
- Ensure the chart exposes a single static web Deployment, Service, optional Ingress, and health probes so platform rollout tooling can discover and manage the app.

### Description
- Added `charts/danielsmith/Chart.yaml` with `apiVersion: v2`, `type: application`, and `version/appVersion: 0.1.0`.
- Added `charts/danielsmith/values.yaml` with DSPACE-style keys including `image.repository`, `image.tag`, `image.digest`, `image.pullPolicy`, `replicaCount`, `service.port: 8080`, `containerPort: 8080`, `ingress.*`, `serviceAccount.*`, pod/container security contexts, resources, probes, and optional `env`, `extraEnv`, and `envFrom` hooks.
- Added templates: `_helpers.tpl` for naming/labels/image resolution, `deployment.yaml` with named port `http`, liveness `/livez`, readiness `/healthz`, non-root/security restrictions, and writable `/tmp` + `/var/cache/nginx` volumes, `service.yaml`, `ingress.yaml` (host-driven, TLS optional, Traefik-compatible), and `serviceaccount.yaml`.
- Labels include `app.kubernetes.io/name: danielsmith` and `app.kubernetes.io/instance: <release>` so a Helm release named `danielsmith` renders resources as `danielsmith`.

### Testing
- `git diff --cached | ./scripts/scan-secrets.py` ran and found no high-risk secrets (passed).
- `helm lint charts/danielsmith` was not run in this environment because `helm` is not installed here; to verify run: `helm lint charts/danielsmith` locally (not run).
- Template rendering checks were not run due to missing `helm`; to verify locally run: `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee > /tmp/danielsmith-rendered.yaml` and then confirm the rendered output contains `ghcr.io/futuroptimist/danielsmith.io:main-deadbee`, `path: /healthz`, `path: /livez`, and `host: staging.danielsmith.io` (not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13818f3d04832f8c61d669d9f09210)