### PR TITLE
Add canonical Helm chart (charts/danielsmith)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs/prompts/codex/automation.md
+charts/danielsmith/templates/*.yaml

--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -3,4 +3,4 @@ name: danielsmith
 description: Canonical Helm chart for deploying the danielsmith.io static web app.
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: '0.1.0'

--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: danielsmith
+description: Canonical Helm chart for deploying the danielsmith.io static web app.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -44,6 +44,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.image.digest -}}
 {{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
 {{- else -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository (required "image.tag is required when image.digest is not set" .Values.image.tag) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -40,6 +40,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{/*
+Resolve the container image. Digest wins for immutable deploys. Otherwise a tag
+is required; values.yaml intentionally supplies `main` so default lint/template
+commands work without falling back to Chart.AppVersion, which is the chart/app
+version and may not correspond to a published container tag.
+*/}}
 {{- define "danielsmith.image" -}}
 {{- if .Values.image.digest -}}
 {{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -44,6 +44,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.image.digest -}}
 {{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
 {{- else -}}
-{{- printf "%s:%s" .Values.image.repository (required "image.tag is required when image.digest is not set" .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{- define "danielsmith.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "danielsmith.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "danielsmith.labels" -}}
+helm.sh/chart: {{ include "danielsmith.chart" . }}
+app.kubernetes.io/name: danielsmith
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "danielsmith.selectorLabels" -}}
+app.kubernetes.io/name: danielsmith
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "danielsmith.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "danielsmith.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -62,9 +62,16 @@ spec:
               mountPath: /var/run
           {{- if or (gt (len .Values.env) 0) (gt (len .Values.extraEnv) 0) }}
           env:
+            {{- if kindIs "map" .Values.env }}
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- else }}
             {{- range .Values.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
+            {{- end }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "danielsmith.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "danielsmith.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "danielsmith.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "danielsmith.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: var-cache-nginx
+              mountPath: /var/cache/nginx
+            - name: var-run
+              mountPath: /var/run
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: var-cache-nginx
+          emptyDir: {}
+        - name: var-run
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -12,10 +12,10 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "danielsmith.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+{{ toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "danielsmith.selectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -60,6 +60,7 @@ spec:
               mountPath: /var/cache/nginx
             - name: var-run
               mountPath: /var/run
+          {{- if or .Values.env .Values.extraEnv }}
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
@@ -68,6 +69,7 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           {{- with .Values.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -37,20 +37,20 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.path }}
+              path: {{ .Values.probes.liveness.path }}
               port: http
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.path }}
+              path: {{ .Values.probes.readiness.path }}
               port: http
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -60,11 +60,11 @@ spec:
               mountPath: /var/cache/nginx
             - name: var-run
               mountPath: /var/run
-          {{- if or .Values.env .Values.extraEnv }}
+          {{- if or (gt (len .Values.env) 0) (gt (len .Values.extraEnv) 0) }}
           env:
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/danielsmith/templates/ingress.yaml
+++ b/charts/danielsmith/templates/ingress.yaml
@@ -14,7 +14,7 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host | quote }}
+    - host: {{ required "ingress.host is required when ingress.enabled=true" .Values.ingress.host | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}
@@ -25,9 +25,9 @@ spec:
                 port:
                   number: {{ .Values.service.port }}
   {{- if .Values.ingress.tls.enabled }}
-  tls:
+    tls:
     - hosts:
-        - {{ .Values.ingress.host | quote }}
-      secretName: {{ .Values.ingress.tls.secretName | quote }}
+        - {{ required "ingress.host is required when ingress.enabled=true" .Values.ingress.host | quote }}
+      secretName: {{ required "ingress.tls.secretName is required when ingress.tls.enabled=true" .Values.ingress.tls.secretName | quote }}
   {{- end }}
 {{- end }}

--- a/charts/danielsmith/templates/ingress.yaml
+++ b/charts/danielsmith/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "danielsmith.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/danielsmith/templates/ingress.yaml
+++ b/charts/danielsmith/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
                 port:
                   number: {{ .Values.service.port }}
   {{- if .Values.ingress.tls.enabled }}
-    tls:
+  tls:
     - hosts:
         - {{ required "ingress.host is required when ingress.enabled=true" .Values.ingress.host | quote }}
       secretName: {{ required "ingress.tls.secretName is required when ingress.tls.enabled=true" .Values.ingress.tls.secretName | quote }}

--- a/charts/danielsmith/templates/service.yaml
+++ b/charts/danielsmith/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "danielsmith.selectorLabels" . | nindent 4 }}

--- a/charts/danielsmith/templates/serviceaccount.yaml
+++ b/charts/danielsmith/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "danielsmith.serviceAccountName" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/danielsmith.io
-  tag: ''
+  tag: main
   digest: ''
   pullPolicy: IfNotPresent
 

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -2,7 +2,11 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/danielsmith.io
-  tag: ''
+  # Keep this non-empty so default `helm lint`/`helm template` work, while
+  # avoiding an implicit fallback to Chart.AppVersion (for example `0.1.0`),
+  # which may not exist as a published image tag. Sugarkube overlays should
+  # override this with an environment-specific tag or set image.digest.
+  tag: main
   digest: ''
   pullPolicy: IfNotPresent
 

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/danielsmith.io
-  tag: main
+  tag: ''
   digest: ''
   pullPolicy: IfNotPresent
 

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -1,0 +1,78 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+containerPort: 8080
+
+service:
+  type: ClusterIP
+  port: 8080
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+livenessProbe:
+  path: /livez
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+readinessProbe:
+  path: /healthz
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+env: {}
+extraEnv: []
+envFrom: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: ""
+  path: /
+  pathType: Prefix
+  tls:
+    enabled: false
+    secretName: ""
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/danielsmith.io
-  tag: ""
-  digest: ""
+  tag: ''
+  digest: ''
   pullPolicy: IfNotPresent
 
 containerPort: 8080
@@ -16,7 +16,7 @@ serviceAccount:
   create: true
   automountServiceAccountToken: false
   annotations: {}
-  name: ""
+  name: ''
 
 podAnnotations: {}
 podLabels: {}
@@ -44,34 +44,34 @@ resources:
     cpu: 250m
     memory: 256Mi
 
-livenessProbe:
-  path: /livez
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  timeoutSeconds: 2
-  failureThreshold: 3
+probes:
+  liveness:
+    path: /livez
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
 
-readinessProbe:
-  path: /healthz
-  initialDelaySeconds: 5
-  periodSeconds: 10
-  timeoutSeconds: 2
-  failureThreshold: 3
-
-env: {}
+env: []
 extraEnv: []
 envFrom: []
 
 ingress:
   enabled: false
-  className: ""
+  className: ''
   annotations: {}
-  host: ""
+  host: ''
   path: /
   pathType: Prefix
   tls:
     enabled: false
-    secretName: ""
+    secretName: ''
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
### Motivation
- Provide an app-owned, Sugarkube-installable Helm chart for the static `danielsmith.io` site with DSPACE/token.place-style values so deployments can be published and managed via GHCR OCI. 
- Keep the chart minimal (static web Deployment + Service + optional Ingress) with standard health probes and hardened runtime defaults for production use.

### Description
- Add `charts/danielsmith/Chart.yaml` and `charts/danielsmith/values.yaml` with DSPACE-style keys for `image.repository`, `image.tag`/`digest`, `replicaCount`, `service`, `ingress`, probes, security contexts, `env`/`envFrom`, and resource defaults. 
- Add `_helpers.tpl` to render names, labels (including `app.kubernetes.io/name: danielsmith` and `app.kubernetes.io/instance: <release>`), and image selection that supports tag or digest. 
- Add `deployment.yaml` implementing a single static web container exposing named port `http` (8080), liveness `/livez`, readiness `/healthz`, non-root/read-only defaults, dropped capabilities, disallowed privilege escalation, and `emptyDir` mounts for nginx temp/cache paths. 
- Add `service.yaml`, `ingress.yaml` (host-driven, no hard-coded domain, optional TLS, Traefik-compatible), and `serviceaccount.yaml` (optional creation) templates. 

### Testing
- Run secret scan with `git diff --cached | ./scripts/scan-secrets.py` which completed with no high-risk secrets found. 
- Attempted `helm lint charts/danielsmith` but it was not run in this environment because `helm` is not installed (`helm: command not found`). 
- Attempted `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` but templating was not executed here for the same `helm` availability reason. 
- Local verification commands to run where `helm` is available: `helm lint charts/danielsmith` and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` (expected to render `ghcr.io/futuroptimist/danielsmith.io:main-deadbee` and probe paths `/livez` and `/healthz`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13818f3d04832f8c61d669d9f09210)