### PR TITLE
Add canonical Helm chart for danielsmith.io

### DIFF
--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: danielsmith
+description: Canonical Helm chart for danielsmith.io static web app
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{- define "danielsmith.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "danielsmith.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "danielsmith.name" . -}}
+{{- if eq .Release.Name $name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "danielsmith.labels" -}}
+helm.sh/chart: {{ include "danielsmith.chart" . }}
+app.kubernetes.io/name: {{ include "danielsmith.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "danielsmith.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "danielsmith.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "danielsmith.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "danielsmith.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else if .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "danielsmith.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      labels:
+        {{- include "danielsmith.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "danielsmith.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "danielsmith.name" . }}
+          image: {{ include "danielsmith.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+            {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/danielsmith/templates/ingress.yaml
+++ b/charts/danielsmith/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "danielsmith.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/danielsmith/templates/service.yaml
+++ b/charts/danielsmith/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "danielsmith.fullname" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "danielsmith.selectorLabels" . | nindent 4 }}

--- a/charts/danielsmith/templates/serviceaccount.yaml
+++ b/charts/danielsmith/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "danielsmith.serviceAccountName" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -1,0 +1,86 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+containerPort: 8080
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+env: []
+extraEnv: []
+envFrom: []
+
+extraVolumes:
+  - name: nginx-cache
+    emptyDir: {}
+  - name: nginx-run
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: nginx-cache
+    mountPath: /var/cache/nginx
+  - name: nginx-run
+    mountPath: /var/run


### PR DESCRIPTION
### Motivation
- Provide an app-owned canonical Helm chart that Sugarkube can install from GHCR OCI for the static danielsmith.io site. 
- Ensure a minimal, hardened static-web deployment with SPA-friendly ingress, correct probe paths, and Sugarkube-friendly labels.

### Description
- Add `charts/danielsmith/Chart.yaml` with `apiVersion: v2`, `name: danielsmith`, and `version/appVersion: 0.1.0`.
- Add `charts/danielsmith/values.yaml` containing DSPACE/token.place-style values for image (`repository/tag/digest/pullPolicy`), replicas, service/container port `8080`, ingress/TLS, serviceAccount, securityContext, resources, probes, and optional `env`/`extraEnv`/`envFrom`.
- Add templates `templates/_helpers.tpl`, `templates/deployment.yaml`, `templates/service.yaml`, `templates/ingress.yaml`, and `templates/serviceaccount.yaml` with helpers for canonical naming and an image resolution helper that prefers `digest` > `tag` > `Chart.AppVersion`.
- Deployment is hardened and SPA-ready: named `http` port `8080`, liveness `/livez`, readiness `/healthz`, non-root runtime, dropped capabilities, disallowed privilege escalation, read-only root FS support, and writable `emptyDir` mounts for nginx cache/run.

### Testing
- Ran `git diff --cached | ./scripts/scan-secrets.py` and it succeeded with no high-risk secrets detected.
- Attempted `helm lint charts/danielsmith` but could not run because `helm` was not available in the environment (`/bin/bash: line 1: helm: command not found`).
- Recommended acceptance verification to run locally or in CI when `helm` is available: `helm lint charts/danielsmith` and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee > /tmp/danielsmith-rendered.yaml` and then grep for the image and probe/host lines as in the prompt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13818f3d04832f8c61d669d9f09210)