### PR TITLE
Add GHCR image build/publish workflow (ci-image.yml)

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,150 @@
+name: Build and publish GHCR image
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to build
+        required: false
+        default: main
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: futuroptimist/danielsmith.io
+
+jobs:
+  build-smoke-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: ${{ github.event_name == 'push' && 'write' || 'none' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          immutable_tag="main-${short_sha}"
+          compat_tag="sha-${short_sha}"
+          image="${REGISTRY}/${IMAGE_NAME}"
+          created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "immutable_tag=${immutable_tag}" >> "$GITHUB_OUTPUT"
+          echo "compat_tag=${compat_tag}" >> "$GITHUB_OUTPUT"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "created=${created}" >> "$GITHUB_OUTPUT"
+
+      - name: Build local image for smoke tests
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: danielsmith-io:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+
+      - name: Smoke test container runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          container_name="danielsmith-io-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker logs "${container_name}" >/dev/null 2>&1 || true
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          docker run -d --name "${container_name}" \
+            -p 127.0.0.1:8080:8080 \
+            danielsmith-io:smoke
+
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/ >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/healthz >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/livez >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "${ready}" != "1" ]; then
+            echo "Container failed readiness checks"
+            docker logs "${container_name}" || true
+            exit 1
+          fi
+
+          curl -fsS http://127.0.0.1:8080/studio | grep -qi '<html'
+
+          asset="$(
+            docker exec "${container_name}" sh -lc \
+              "find /usr/share/nginx/html/assets -maxdepth 1 -type f | head -n 1" | \
+              sed 's#^/usr/share/nginx/html##'
+          )"
+          test -n "${asset}"
+          curl -fsS "http://127.0.0.1:8080${asset}" >/dev/null
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.immutable_tag }}
+            ${{ steps.meta.outputs.image }}:main-latest
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.compat_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+
+      - name: Publish image summary
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          {
+            echo "## GHCR image publish"
+            echo
+            echo "- Immutable tag: \
+              \\`${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.immutable_tag }}\\`"
+            echo "- Convenience tag: \
+              \\`${{ steps.meta.outputs.image }}:main-latest\\`"
+            echo "- Compatibility tag: \
+              \\`${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.compat_tag }}\\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Provide a GitHub Actions pipeline that builds, smoke-tests, and publishes the static-site container to GHCR while ensuring the container serves the app and static assets before any publish.

### Description
- Add ` .github/workflows/ci-image.yml` which triggers on `pull_request` to `main`, `push` to `main`, and `workflow_dispatch` with an optional `ref` input.
- Use Docker Buildx to produce a local `linux/amd64` image for smoke tests and push a multi-arch (`linux/amd64,linux/arm64`) image on `push` events, using GitHub Actions caching and `docker/login-action` for GHCR authentication.
- Run runtime smoke checks against the container validating `/`, `/healthz`, `/livez`, a plausible SPA route (`/studio`), and that at least one built `/assets/*` file is served, and print container logs on failure.
- Publish images to `ghcr.io/futuroptimist/danielsmith.io` with tags `main-<shortsha>`, `main-latest`, and `sha-<shortsha>` and emit the immutable tag details into the job summary, while adding OCI labels including `org.opencontainers.image.created`.

### Testing
- No automated tests were executed locally for this change; the new workflow defines the automated smoke tests that will run on PRs (build + smoke) and on pushes to `main` (build + smoke + push).
- The commit and PR payload were created successfully and the workflow file was linted via a repository checkout before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cc81582c832f9137c86b7ae4e38a)