### PR TITLE
Add GHCR image build and publish workflow for danielsmith.io

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -19,12 +19,18 @@ jobs:
       contents: read
     outputs:
       short_sha: ${{ steps.meta.outputs.short_sha }}
+      revision: ${{ steps.meta.outputs.revision }}
       created: ${{ steps.meta.outputs.created }}
     steps:
+      - name: Checkout triggering commit
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+
       - name: Checkout selected ref
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -34,7 +40,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Build local smoke-test image
@@ -50,7 +57,7 @@ jobs:
           cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.meta.outputs.revision }}
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
 
       - name: Smoke test local image
@@ -132,7 +139,7 @@ jobs:
           cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ needs.build-and-smoke.outputs.revision }}
             org.opencontainers.image.created=${{ needs.build-and-smoke.outputs.created }}
 
       - name: Summarize published immutable tag

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,142 @@
+name: Build and publish GHCR image
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to build
+        required: false
+        default: main
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      short_sha: ${{ steps.meta.outputs.short_sha }}
+      created: ${{ steps.meta.outputs.created }}
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Build local smoke-test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          push: false
+          tags: danielsmith-io:smoke
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+
+      - name: Smoke test local image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          container_name="danielsmith-io-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker logs "${container_name}" || true
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          docker run -d --name "${container_name}" \
+            -p 127.0.0.1:8080:8080 \
+            danielsmith-io:smoke
+
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/ >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/healthz >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/livez >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          test "${ready}" = 1
+
+          curl -fsS http://127.0.0.1:8080/studio | grep -qi '<html'
+
+          asset_path="$(docker exec "${container_name}" sh -lc \
+            "sed -n 's/.*\\(\\/assets\\/[^\" ]*\\).*/\\1/p' /usr/share/nginx/html/index.html \
+            | head -n 1")"
+
+          if [ -z "${asset_path}" ]; then
+            asset_path="$(docker exec "${container_name}" sh -lc \
+              "find /usr/share/nginx/html/assets -maxdepth 1 -type f ! -name '*.map' \
+              | head -n 1 | sed 's#^/usr/share/nginx/html##'")"
+          fi
+
+          test -n "${asset_path}"
+          curl -fsS "http://127.0.0.1:8080${asset_path}" >/dev/null
+
+  publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-and-smoke
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/futuroptimist/danielsmith.io:main-${{ needs.build-and-smoke.outputs.short_sha }}
+            ghcr.io/futuroptimist/danielsmith.io:main-latest
+            ghcr.io/futuroptimist/danielsmith.io:sha-${{ needs.build-and-smoke.outputs.short_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ needs.build-and-smoke.outputs.created }}
+
+      - name: Summarize published immutable tag
+        run: |
+          echo "Published immutable image tag:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`ghcr.io/futuroptimist/danielsmith.io:main-${{ needs.build-and-smoke.outputs.short_sha }}\`" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     outputs:
       short_sha: ${{ steps.meta.outputs.short_sha }}
-      revision: ${{ steps.meta.outputs.revision }}
+      full_sha: ${{ steps.meta.outputs.full_sha }}
       created: ${{ steps.meta.outputs.created }}
     steps:
       - name: Checkout triggering commit
@@ -40,8 +40,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
-          echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "full_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
           echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Build local smoke-test image
@@ -57,7 +57,7 @@ jobs:
           cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.meta.outputs.revision }}
+            org.opencontainers.image.revision=${{ steps.meta.outputs.full_sha }}
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
 
       - name: Smoke test local image
@@ -139,7 +139,7 @@ jobs:
           cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.build-and-smoke.outputs.revision }}
+            org.opencontainers.image.revision=${{ needs.build-and-smoke.outputs.full_sha }}
             org.opencontainers.image.created=${{ needs.build-and-smoke.outputs.created }}
 
       - name: Summarize published immutable tag


### PR DESCRIPTION
### Motivation
- Provide a CI workflow to build, smoke-test, and publish the static-site Docker image to GHCR for `danielsmith.io` without changing Helm/Sugarkube artifacts.
- Ensure PRs validate a runnable container (no push) and `main` pushes produce immutable and convenience image tags for deployments.

### Description
- Add `.github/workflows/ci-image.yml` with `pull_request`, `push` to `main`, and `workflow_dispatch` triggers and separate `build-and-smoke` and `publish` jobs.
- Implement `build-and-smoke` to build a local amd64 image with Buildx, load it, and smoke-test HTTP endpoints `/`, `/healthz`, `/livez`, a SPA route like `/studio`, and at least one ` /assets/...` file discovered from the served `index.html`.
- Implement `publish` to log in to GHCR and push a multi-arch image (`linux/amd64,linux/arm64`) only on `push` to `main`, publishing `ghcr.io/futuroptimist/danielsmith.io:main-<shortsha>`, `main-latest`, and `sha-<shortsha>` and writing the immutable tag to the workflow summary.
- Use scoped permissions so smoke job has `contents: read` and the publish job adds `packages: write`, include OCI labels `org.opencontainers.image.source`, `org.opencontainers.image.revision`, and `org.opencontainers.image.created`, and use GitHub Actions build cache where safe.

### Testing
- Ran `npm run format:write` (Prettier) and it completed successfully against the repo files.
- Ran `./scripts/scan-secrets.py` on the staged diff and it reported no high-risk secrets.
- Attempted a local `docker build -t danielsmith-io:local .` to validate the Dockerfile but the environment lacks the `docker` binary so the local build was not run here; CI workflow contains the smoke tests that will run in Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cc81582c832f9137c86b7ae4e38a)