### PR TITLE
Add GHCR image build/publish workflow for danielsmith.io

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,160 @@
+name: Build and publish GHCR image
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to build
+        required: false
+        default: main
+
+jobs:
+  build-smoke:
+    name: Build and smoke test image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute OCI created timestamp
+        id: created
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "value=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >>"$GITHUB_OUTPUT"
+
+      - name: Build local smoke-test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: danielsmith-io:smoke
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.value }}
+
+      - name: Smoke test local image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          container_name="danielsmith-io-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          logs_file="${RUNNER_TEMP}/danielsmith-io-smoke.log"
+
+          cleanup() {
+            docker logs "${container_name}" >"${logs_file}" 2>&1 || true
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          docker run -d --name "${container_name}" -p 127.0.0.1:8080:8080 danielsmith-io:smoke
+
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/ >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/healthz >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/livez >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          test "${ready}" = 1
+
+          curl -fsS http://127.0.0.1:8080/studio | grep -qi '<html'
+
+          asset_path="$(
+            docker exec "${container_name}" sh -lc \
+              "find /usr/share/nginx/html/assets -maxdepth 1 -type f | head -n 1" | \
+              sed 's#^/usr/share/nginx/html##'
+          )"
+          test -n "${asset_path}"
+          curl -fsS "http://127.0.0.1:8080${asset_path}" >/dev/null
+
+          docker logs "${container_name}"
+
+  publish:
+    name: Publish multi-arch image to GHCR
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build-smoke
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Derive image metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          echo "short_sha=${short_sha}" >>"$GITHUB_OUTPUT"
+          echo "image=ghcr.io/futuroptimist/danielsmith.io" >>"$GITHUB_OUTPUT"
+          echo "tag_immutable=main-${short_sha}" >>"$GITHUB_OUTPUT"
+          echo "tag_mutable=main-latest" >>"$GITHUB_OUTPUT"
+          echo "tag_compat=sha-${short_sha}" >>"$GITHUB_OUTPUT"
+
+      - name: Compute OCI created timestamp
+        id: created
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "value=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >>"$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag_immutable }}
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag_mutable }}
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag_compat }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.value }}
+
+      - name: Append published tag summary
+        shell: bash
+        run: |
+          {
+            echo "### Published image"
+            echo
+            echo "- Immutable tag: \`${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag_immutable }}\`"
+            echo "- Mutable tag: \`${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag_mutable }}\`"
+            echo "- Compatibility tag: \`${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag_compat }}\`"
+          } >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Provide a canonical GitHub Actions pipeline to build, smoke-test, and publish the static-site container to GHCR for `danielsmith.io` while keeping PR validation fast. 
- Ensure published images are immutable and traceable with short-SHA tags and a convenience `main-latest` tag, and ensure the container serves all static assets referenced by the app.

### Description
- Add `.github/workflows/ci-image.yml` which triggers on `pull_request` (targeting `main`), `push` to `main`, and `workflow_dispatch` with an optional `ref` input. 
- Implement a `build-smoke` job that uses Docker Buildx to build a local `linux/amd64` image, loads it, and runs smoke checks against `/`, `/healthz`, `/livez`, an SPA route (`/studio`), and at least one discovered `/assets/...` file. 
- Implement a `publish` job gated to non-PR events that logs into GHCR, builds & pushes multi-arch images (`linux/amd64,linux/arm64`), and publishes tags: `main-<shortsha>` (immutable), `main-latest` (mutable), and `sha-<shortsha>` (compat). 
- Scope permissions so `packages: write` is used only in the publish job, add OCI labels (`org.opencontainers.image.source`, `org.opencontainers.image.revision`, `org.opencontainers.image.created`), and append the immutable published tag to the GitHub Actions step summary.

### Testing
- Ran secret scan with `git diff --cached | ./scripts/scan-secrets.py` which completed with no high-risk secrets detected. 
- Attempted local image build with `docker build -t danielsmith-io:local .` which failed in this environment with `docker: command not found`, so full local smoke-run could not be executed here. 
- The workflow includes automated smoke assertions and will run in CI for PRs (build + smoke) and pushes (build, smoke, publish) to verify runtime behavior; publish step will be exercised by a `main` push in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cc81582c832f9137c86b7ae4e38a)