### PR TITLE
Add GHCR image build/publish workflow for danielsmith.io

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,143 @@
+name: Build and publish GHCR image
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to build
+        required: false
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'write' || 'read' }}
+    env:
+      IMAGE_NAME: ghcr.io/futuroptimist/danielsmith.io
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
+
+      - name: Compute tags and OCI labels
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          created="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+          {
+            echo "short_sha=${short_sha}"
+            echo "immutable_tag=main-${short_sha}"
+            echo "compat_tag=sha-${short_sha}"
+            echo "created=${created}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build local smoke-test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: danielsmith-io:smoke
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test container
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          container_name="danielsmith-io-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker logs "${container_name}" || true
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          docker run -d --name "${container_name}" -p 127.0.0.1:8080:8080 danielsmith-io:smoke
+
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/ >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/healthz >/dev/null && \
+              curl -fsS http://127.0.0.1:8080/livez >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          test "${ready}" = 1
+
+          curl -fsS http://127.0.0.1:8080/studio | grep -qi '<html'
+
+          asset_path="$({
+            curl -fsS http://127.0.0.1:8080/ | sed -n 's/.*src="\(\/assets\/[^"]*\)".*/\1/p' | head -n 1
+          } || true)"
+
+          if [ -z "${asset_path}"; then
+            asset_path="$(docker exec "${container_name}" sh -lc \
+              "find /usr/share/nginx/html/assets -maxdepth 1 -type f ! -name '*.map' | head -n 1 | sed 's#^/usr/share/nginx/html##'")"
+          fi
+
+          test -n "${asset_path}"
+          curl -fsS "http://127.0.0.1:8080${asset_path}" >/dev/null
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.immutable_tag }}
+            ${{ env.IMAGE_NAME }}:main-latest
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.compat_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Publish image tag summary
+        run: |
+          {
+            echo "## GHCR image"
+            echo "- Immutable tag: \
+            \\`${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.immutable_tag }}\\`"
+            echo "- Mutable tag: \
+            \\`${{ env.IMAGE_NAME }}:main-latest\\`"
+            echo "- Compatibility tag: \
+            \\`${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.compat_tag }}\\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Provide a dedicated GitHub Actions workflow to build, smoke-test, and publish the static-site container to GHCR with deterministic immutable tags for reproducible deploys.
- Align image publishing behavior with existing DSPACE/token.place patterns while keeping the flow static-site appropriate (no backend/runtime changes).

### Description
- Added `.github/workflows/ci-image.yml` which triggers on `pull_request` to `main` (build + smoke tests), `push` to `main` (build + smoke tests + publish), and `workflow_dispatch` with an optional `ref` input.
- Workflow computes deterministic tags (`main-<shortsha>`, `sha-<shortsha>`) and prints the immutable tag to the workflow summary, and sets OCI labels `org.opencontainers.image.source`, `org.opencontainers.image.revision`, and `org.opencontainers.image.created`.
- Uses Docker Buildx with a local `linux/amd64` load for PR/manual runs and a multi-arch `linux/amd64,linux/arm64` push on `main` pushes, with GitHub Actions cache configured.
- Performs runtime smoke checks against the built container validating `/`, `/healthz`, `/livez`, a SPA route `/studio` returning HTML, and that at least one `/assets/...` file is served, and conditionally logs and cleans up the container on failures.

### Testing
- Ran formatting and fixed style with `npx prettier --write .github/workflows/ci-image.yml` which succeeded.
- Verified formatting with `npx prettier --check .github/workflows/ci-image.yml` which succeeded.
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.
- Attempted local image build `docker build -t danielsmith-io:local .` which could not be executed in this environment because `docker` is not available (error: `docker: command not found`), so full smoke-run verification is expected to be exercised by CI on GitHub Actions where Docker is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cc81582c832f9137c86b7ae4e38a)