### PR TITLE
Add GHCR OCI Helm chart publishing workflow for danielsmith chart

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,110 @@
+name: Publish Helm chart
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to publish
+        required: false
+        default: main
+
+env:
+  CHART_PATH: charts/danielsmith
+  CHART_NAME: danielsmith
+  OCI_REGISTRY: oci://ghcr.io/futuroptimist/charts
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_ref: ${{ steps.chart_meta.outputs.chart_ref }}
+      chart_version: ${{ steps.chart_meta.outputs.chart_version }}
+      package_file: ${{ steps.package.outputs.package_file }}
+    steps:
+      - name: Checkout triggering commit
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+
+      - name: Checkout selected ref
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies (if present)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f "${CHART_PATH}/Chart.lock" ] || grep -q '^dependencies:' "${CHART_PATH}/Chart.yaml"; then
+            helm dependency build "${CHART_PATH}"
+          else
+            echo "No chart dependencies declared; skipping helm dependency build."
+          fi
+
+      - name: Lint chart
+        run: helm lint "${CHART_PATH}"
+
+      - name: Template smoke render (staging-like values)
+        run: |
+          helm template danielsmith "${CHART_PATH}" \
+            --namespace danielsmith \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.danielsmith.io \
+            --set image.tag=main-deadbee
+
+      - name: Package chart
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          helm package "${CHART_PATH}" --destination dist
+          package_file="$(find dist -maxdepth 1 -type f -name '${CHART_NAME}-*.tgz' | head -n1)"
+          test -n "${package_file}"
+          echo "package_file=${package_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Export chart metadata
+        id: chart_meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version="$(sed -n 's/^version:[[:space:]]*//p' "${CHART_PATH}/Chart.yaml" | head -n1)"
+          chart_ref="${OCI_REGISTRY}/${CHART_NAME}"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
+          {
+            echo "Chart reference: ${chart_ref}"
+            echo "Chart version: ${chart_version}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push chart package to GHCR OCI
+        run: helm push "${{ needs.validate.outputs.package_file }}" "${OCI_REGISTRY}"
+
+      - name: Summarize published chart
+        run: |
+          {
+            echo "Published chart reference: ${{ needs.validate.outputs.chart_ref }}"
+            echo "Published chart version: ${{ needs.validate.outputs.chart_version }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Provide an automated, CI-driven validation and publish pipeline for the canonical `danielsmith` Helm chart so PRs can be validated without publishing and pushes to `main` can publish an OCI chart to GHCR. 
- Align chart publishing with the existing DSPACE/token.place pattern by targeting the GHCR OCI charts namespace `oci://ghcr.io/futuroptimist/charts` and preserving the chart identity as `danielsmith`.

### Description
- Add `.github/workflows/ci-helm.yml` which defines a `Publish Helm chart` workflow triggered on `pull_request` to `main`, `push` to `main`, and `workflow_dispatch` with an optional `ref` input. 
- Implement a `validate` job that sets up Helm, conditionally runs `helm dependency build` when dependencies exist, runs `helm lint`, performs a staging-like `helm template` smoke render, and packages the chart to `dist`; it exports `chart_ref`, `chart_version`, and the packaged file path as outputs. 
- Implement a `publish` job that runs only on pushes to `main`, logs in to GHCR using the `GITHUB_TOKEN`, and pushes the packaged chart to `oci://ghcr.io/futuroptimist/charts`, with `contents: read` and `packages: write` permissions scoped for publishing. 
- Chart configuration values are centralized via environment variables: `CHART_PATH=charts/danielsmith`, `CHART_NAME=danielsmith`, and `OCI_REGISTRY=oci://ghcr.io/futuroptimist/charts`.

### Testing
- Ran `helm lint charts/danielsmith` locally; it could not be executed because Helm is not installed in this environment (`helm: command not found`).
- Ran `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` locally; it could not be executed because Helm is not installed (`helm: command not found`).
- Ran `helm package charts/danielsmith` locally; it could not be executed because Helm is not installed (`helm: command not found`).
- Workflow-level validation (`helm` install, lint, template, package, and publish steps) is expected to run in CI where the `azure/setup-helm@v4` action will provide the Helm binary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d9790f50832faca3c1b2efe05fee)