### PR TITLE
Add CI workflow to validate and publish danielsmith Helm chart to GHCR OCI

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,110 @@
+name: Publish Helm chart
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - charts/danielsmith/**
+      - .github/workflows/ci-helm.yml
+  push:
+    branches:
+      - main
+    paths:
+      - charts/danielsmith/**
+      - .github/workflows/ci-helm.yml
+  workflow_dispatch:
+
+jobs:
+  helm-validate:
+    name: Helm validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.chart_meta.outputs.chart_version }}
+      package_name: ${{ steps.package.outputs.package_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build dependencies (if defined)
+        run: |
+          if grep -Eq '^dependencies:' charts/danielsmith/Chart.yaml; then
+            helm dependency build charts/danielsmith
+          else
+            echo "No chart dependencies defined; skipping helm dependency build."
+          fi
+
+      - name: Lint chart
+        run: helm lint charts/danielsmith
+
+      - name: Template smoke render
+        run: |
+          helm template danielsmith charts/danielsmith \
+            --namespace danielsmith \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.danielsmith.io \
+            --set image.tag=main-deadbee
+
+      - name: Read chart metadata
+        id: chart_meta
+        run: |
+          CHART_VERSION="$(awk '/^version:/ {print $2}' charts/danielsmith/Chart.yaml)"
+          echo "chart_version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Chart version: ${CHART_VERSION}"
+
+      - name: Package chart
+        id: package
+        run: |
+          mkdir -p dist/charts
+          helm package charts/danielsmith --destination dist/charts
+          PACKAGE_NAME="$(basename dist/charts/danielsmith-${{ steps.chart_meta.outputs.chart_version }}.tgz)"
+          echo "package_name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
+          ls -lah dist/charts
+
+      - name: Upload packaged chart artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: danielsmith-chart
+          path: dist/charts/${{ steps.package.outputs.package_name }}
+
+  helm-publish:
+    name: Helm publish
+    runs-on: ubuntu-latest
+    needs: helm-validate
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download packaged chart artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: danielsmith-chart
+          path: dist/charts
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Authenticate to GHCR
+        run: |
+          echo "${{ github.token }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push chart to GHCR OCI registry
+        run: |
+          helm push "dist/charts/${{ needs.helm-validate.outputs.package_name }}" \
+            oci://ghcr.io/futuroptimist/charts
+
+      - name: Export chart reference
+        run: |
+          CHART_REF="oci://ghcr.io/futuroptimist/charts/danielsmith"
+          CHART_VERSION="${{ needs.helm-validate.outputs.chart_version }}"
+          echo "chart_ref=${CHART_REF}" >> "$GITHUB_ENV"
+          echo "chart_version=${CHART_VERSION}" >> "$GITHUB_ENV"
+          echo "Published chart: ${CHART_REF}:${CHART_VERSION}"


### PR DESCRIPTION
### Motivation
- Add automated chart validation on PRs and automated OCI publishing on `main` so `charts/danielsmith` is released to GHCR consistently with the repository's canonical deployment model.
- Ensure chart identity and registry match expectations (`name: danielsmith` and `oci://ghcr.io/futuroptimist/charts/danielsmith`).

### Description
- Add `.github/workflows/ci-helm.yml` named `Publish Helm chart` with triggers for `pull_request` (validation only), `push` to `main` (validate + publish), and `workflow_dispatch` (manual publish). 
- Implement `helm-validate` job that checks out code, sets up Helm, conditionally runs `helm dependency build` when `dependencies:` exists in `Chart.yaml`, runs `helm lint`, performs a staging-like `helm template` smoke render, reads `version` from `Chart.yaml`, packages the chart to `dist/charts`, and uploads the packaged chart as an artifact. 
- Implement `helm-publish` job gated to `push`/`workflow_dispatch` that downloads the packaged artifact, logs into GHCR using `GITHUB_TOKEN`, pushes the package to `oci://ghcr.io/futuroptimist/charts`, and exports the final chart reference and version as environment outputs. 
- Permissions are scoped to `contents: read` for validation and `packages: write` only for the publish job so publishing is restricted to the intended events. 

### Testing
- Attempted local verification commands `helm lint charts/danielsmith`, `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee`, and `helm package charts/danielsmith` but they could not be run locally due to `helm: command not found`.
- The workflow will run `helm lint` and the template smoke render in CI and will fail the run if either `helm lint` or `helm template` fails, satisfying the acceptance criteria that PRs validate without publishing and `main` pushes publish.
- Packaged chart is uploaded as an artifact by the `helm-validate` job and used by `helm-publish` to ensure the exact package pushed to GHCR is the validated artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d9790f50832faca3c1b2efe05fee)