### PR TITLE
Add GHCR OCI Helm chart publishing workflow for danielsmith

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,98 @@
+name: Publish Helm chart
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to publish
+        required: false
+        default: main
+
+jobs:
+  helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'write' || 'read' }}
+    env:
+      CHART_DIR: charts/danielsmith
+      OCI_REGISTRY: oci://ghcr.io/futuroptimist/charts
+      CHART_NAME: danielsmith
+    steps:
+      - name: Checkout triggering commit
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+
+      - name: Checkout selected ref
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies (if declared)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -q '^dependencies:' "${CHART_DIR}/Chart.yaml"; then
+            helm dependency build "${CHART_DIR}"
+          else
+            echo "No chart dependencies declared in ${CHART_DIR}/Chart.yaml"
+          fi
+
+      - name: Lint chart
+        run: helm lint "${CHART_DIR}"
+
+      - name: Render staging-like template smoke
+        run: |
+          helm template danielsmith "${CHART_DIR}" \
+            --namespace danielsmith \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.danielsmith.io \
+            --set image.tag=main-deadbee
+
+      - name: Package chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          helm package "${CHART_DIR}" --destination dist
+
+      - name: Capture package metadata
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkg="$(ls -1 dist/${CHART_NAME}-*.tgz | head -n 1)"
+          chart_version="$(helm show chart "${pkg}" | sed -n 's/^version: //p' | head -n 1)"
+          full_ref="${OCI_REGISTRY}/${CHART_NAME}:${chart_version}"
+
+          echo "package=${pkg}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "full_ref=${full_ref}" >> "$GITHUB_OUTPUT"
+
+          echo "Chart package: ${pkg}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Chart version: ${chart_version}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Chart reference: ${full_ref}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Authenticate to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push chart to GHCR OCI registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: helm push "${{ steps.package.outputs.package }}" "${{ env.OCI_REGISTRY }}"
+
+      - name: Print final chart reference
+        run: |
+          echo "Chart version: ${{ steps.package.outputs.chart_version }}"
+          echo "Chart reference: ${{ steps.package.outputs.full_ref }}"


### PR DESCRIPTION
### Motivation
- Add CI automation to validate and publish the canonical `danielsmith` Helm chart to GHCR as an OCI artifact matching existing DSPACE/token.place deployment patterns.
- Ensure PRs validate the chart (lint + template + package) without publishing, and main pushes publish the chart to the specified OCI registry.

### Description
- Added `.github/workflows/ci-helm.yml` named `Publish Helm chart` with triggers for `pull_request` (main), `push` (main), and `workflow_dispatch` with an optional `ref` checkout input.
- Workflow sets up Helm, conditionally runs `helm dependency build` when `dependencies:` is present, runs `helm lint`, and runs a staging-like `helm template` using release/namespace `danielsmith`, `ingress.host=staging.danielsmith.io`, and `image.tag=main-deadbee`.
- Packages the chart into `dist`, captures package path/version and builds the full OCI reference `oci://ghcr.io/futuroptimist/charts/danielsmith:<version>`, and prints these to the step summary.
- GHCR authentication and `helm push` to `oci://ghcr.io/futuroptimist/charts` are gated to `push` events on `main` only, with workflow permissions set to `contents: read` and `packages: write` only when publishing.

### Testing
- Ran formatting: `npm run format:write .github/workflows/ci-helm.yml` which completed successfully (Prettier applied/verified). 
- Secret scan: `./scripts/scan-secrets.py <(git diff -- .github/workflows/ci-helm.yml)` ran successfully with no secrets detected. 
- Helm commands attempted locally but failed because `helm` is not installed in the environment: `helm lint charts/danielsmith` — failed (`/bin/bash: line 1: helm: command not found`). 
- Template/package commands attempted but blocked for same reason: `helm template ...` and `helm package charts/danielsmith` — not run due to missing `helm` binary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d9790f50832faca3c1b2efe05fee)