### PR TITLE
Add GHCR OCI Helm chart publishing workflow for danielsmith chart

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,127 @@
+name: Publish Helm chart
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to publish from
+        required: false
+        default: main
+
+jobs:
+  helm-validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.chart_meta.outputs.chart_version }}
+      package_path: ${{ steps.package.outputs.package_path }}
+    steps:
+      - name: Checkout triggering commit
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+
+      - name: Checkout selected ref
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies when present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -q '^dependencies:' charts/danielsmith/Chart.yaml; then
+            helm dependency build charts/danielsmith
+          else
+            echo "No chart dependencies detected; skipping helm dependency build."
+          fi
+
+      - name: Helm lint
+        run: helm lint charts/danielsmith
+
+      - name: Template smoke render (staging-like)
+        run: |
+          helm template danielsmith charts/danielsmith \
+            --namespace danielsmith \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.danielsmith.io \
+            --set image.tag=main-deadbee
+
+      - name: Read chart version
+        id: chart_meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version=$(sed -n 's/^version:[[:space:]]*//p' charts/danielsmith/Chart.yaml | head -n1)
+          test -n "$chart_version"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+
+      - name: Package Helm chart
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          helm package charts/danielsmith --destination dist
+          package_path="dist/danielsmith-${{ steps.chart_meta.outputs.chart_version }}.tgz"
+          test -f "$package_path"
+          echo "package_path=$package_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload chart artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: danielsmith-chart
+          path: ${{ steps.package.outputs.package_path }}
+
+  publish-chart:
+    if: |
+      github.event_name == 'push' && github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: helm-validate
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download packaged chart
+        uses: actions/download-artifact@v4
+        with:
+          name: danielsmith-chart
+          path: dist
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Authenticate to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Publish OCI chart
+        id: publish
+        shell: bash
+        env:
+          HELM_REGISTRY: oci://ghcr.io/futuroptimist/charts
+        run: |
+          set -euo pipefail
+          package_path="${{ needs.helm-validate.outputs.package_path }}"
+          helm push "$package_path" "$HELM_REGISTRY"
+
+          chart_ref="oci://ghcr.io/futuroptimist/charts/danielsmith"
+          echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize published chart
+        run: |
+          echo "Published chart reference:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${{ steps.publish.outputs.chart_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published chart version:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${{ needs.helm-validate.outputs.chart_version }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Git ref (branch, tag, or SHA) to publish from
+        description: Git ref to validate (publishing allowed only for main)
         required: false
         default: main
 
@@ -52,8 +52,7 @@ jobs:
           helm template danielsmith charts/danielsmith \
             --namespace danielsmith \
             --set ingress.enabled=true \
-            --set ingress.host=staging.danielsmith.io \
-            --set image.tag=main-deadbee
+            --set ingress.host=staging.danielsmith.io
 
       - name: Read chart version
         id: chart_meta
@@ -79,12 +78,28 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: danielsmith-chart
-          path: ${{ steps.package.outputs.package_path }}
+          path: dist/
+
+      - name: Enforce publish-eligible default image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          default_image_tag=$(sed -n 's/^tag:[[:space:]]*//p' charts/danielsmith/values.yaml | head -n1)
+          test -n "$default_image_tag"
+          case "$default_image_tag" in
+            main-latest|main-*)
+              echo "Default image.tag is publish-eligible: $default_image_tag"
+              ;;
+            *)
+              echo "Default image.tag is not publish-eligible: $default_image_tag" >&2
+              exit 1
+              ;;
+          esac
 
   publish-chart:
     if: |
       github.event_name == 'push' && github.ref == 'refs/heads/main' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     needs: helm-validate
     permissions:
@@ -95,7 +110,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: danielsmith-chart
-          path: dist
+          path: .
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -114,6 +129,10 @@ jobs:
         run: |
           set -euo pipefail
           package_path="${{ needs.helm-validate.outputs.package_path }}"
+          if [ ! -f "$package_path" ]; then
+            echo "Expected chart package not found at: $package_path" >&2
+            exit 1
+          fi
           helm push "$package_path" "$HELM_REGISTRY"
 
           chart_ref="oci://ghcr.io/futuroptimist/charts/danielsmith"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -18,8 +18,9 @@ jobs:
     permissions:
       contents: read
     outputs:
-      chart_version: ${{ steps.chart_meta.outputs.chart_version }}
+      chart_version: ${{ steps.package.outputs.chart_version }}
       package_path: ${{ steps.package.outputs.package_path }}
+      chart_ref: ${{ steps.chart_meta.outputs.chart_ref }}
     steps:
       - name: Checkout triggering commit
         if: github.event_name != 'workflow_dispatch'
@@ -33,6 +34,26 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
+
+      - name: Set expected chart reference
+        id: chart_meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_ref="oci://ghcr.io/futuroptimist/charts/danielsmith"
+          chart_version="${{ needs.helm-validate.outputs.chart_version }}"
+          echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+
+      - name: Guard chart identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_name=$(helm show chart charts/danielsmith | sed -n "s/^name:[[:space:]]*//p" | head -n1)
+          if [ "$chart_name" != "danielsmith" ]; then
+            echo "Chart name must be danielsmith, got: $chart_name" >&2
+            exit 1
+          fi
 
       - name: Build chart dependencies when present
         shell: bash
@@ -54,14 +75,6 @@ jobs:
             --set ingress.enabled=true \
             --set ingress.host=staging.danielsmith.io
 
-      - name: Read chart version
-        id: chart_meta
-        shell: bash
-        run: |
-          set -euo pipefail
-          chart_version=$(sed -n 's/^version:[[:space:]]*//p' charts/danielsmith/Chart.yaml | head -n1)
-          test -n "$chart_version"
-          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
 
       - name: Package Helm chart
         id: package
@@ -70,9 +83,20 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           helm package charts/danielsmith --destination dist
-          package_path="dist/danielsmith-${{ steps.chart_meta.outputs.chart_version }}.tgz"
-          test -f "$package_path"
+
+          mapfile -t packages < <(find dist -maxdepth 1 -type f -name "danielsmith-*.tgz" | sort)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "Expected exactly one chart package, found ${#packages[@]}" >&2
+            printf "- %s\n" "${packages[@]}" >&2
+            exit 1
+          fi
+
+          package_path="${packages[0]}"
+          chart_version=$(helm show chart "$package_path" | sed -n "s/^version:[[:space:]]*//p" | head -n1)
+          test -n "$chart_version"
+
           echo "package_path=$package_path" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
 
       - name: Upload chart artifact
         uses: actions/upload-artifact@v4
@@ -103,11 +127,18 @@ jobs:
               exit 1
               ;;
           esac
+      - name: Summarize validated chart
+        run: |
+          echo "Validated chart reference:" >> "$GITHUB_STEP_SUMMARY"
+          echo "`${{ steps.chart_meta.outputs.chart_ref }}`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Validated chart version:" >> "$GITHUB_STEP_SUMMARY"
+          echo "`${{ steps.package.outputs.chart_version }}`" >> "$GITHUB_STEP_SUMMARY"
+
 
   publish-chart:
     if: |
-      github.event_name == 'push' && github.ref == 'refs/heads/main' ||
-      github.event_name == 'workflow_dispatch' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main'))
     runs-on: ubuntu-latest
     needs: helm-validate
     permissions:
@@ -144,11 +175,13 @@ jobs:
           helm push "$package_path" "$HELM_REGISTRY"
 
           chart_ref="oci://ghcr.io/futuroptimist/charts/danielsmith"
+          chart_version="${{ needs.helm-validate.outputs.chart_version }}"
           echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
 
       - name: Summarize published chart
         run: |
           echo "Published chart reference:" >> "$GITHUB_STEP_SUMMARY"
           echo "\`${{ steps.publish.outputs.chart_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "Published chart version:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`${{ needs.helm-validate.outputs.chart_version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${{ steps.publish.outputs.chart_version }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -117,7 +117,7 @@ jobs:
           ' charts/danielsmith/values.yaml)
           test -n "$default_image_tag"
           case "$default_image_tag" in
-            main-latest|main-*)
+            main|main-latest|main-*)
               echo "Default image.tag is publish-eligible: $default_image_tag"
               ;;
             *)

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -41,9 +41,7 @@ jobs:
         run: |
           set -euo pipefail
           chart_ref="oci://ghcr.io/futuroptimist/charts/danielsmith"
-          chart_version="${{ needs.helm-validate.outputs.chart_version }}"
           echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
-          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
 
       - name: Guard chart identity
         shell: bash
@@ -176,8 +174,8 @@ jobs:
 
           chart_ref="oci://ghcr.io/futuroptimist/charts/danielsmith"
           chart_version="${{ needs.helm-validate.outputs.chart_version }}"
-          echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
           echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
 
       - name: Summarize published chart
         run: |

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -117,7 +117,7 @@ jobs:
           ' charts/danielsmith/values.yaml)
           test -n "$default_image_tag"
           case "$default_image_tag" in
-            main|main-latest|main-*)
+            main-latest|main-*)
               echo "Default image.tag is publish-eligible: $default_image_tag"
               ;;
             *)
@@ -166,6 +166,7 @@ jobs:
         run: |
           set -euo pipefail
           package_path="${{ needs.helm-validate.outputs.package_path }}"
+          package_path="${package_path#dist/}"
           if [ ! -f "$package_path" ]; then
             echo "Expected chart package not found at: $package_path" >&2
             exit 1

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -84,7 +84,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          default_image_tag=$(sed -n 's/^tag:[[:space:]]*//p' charts/danielsmith/values.yaml | head -n1)
+          default_image_tag=$(awk '
+            /^image:[[:space:]]*$/ { in_image=1; next }
+            in_image && /^[^[:space:]]/ { in_image=0 }
+            in_image && /^[[:space:]]+tag:[[:space:]]*/ {
+              sub(/^[[:space:]]+tag:[[:space:]]*/, "")
+              print
+              exit
+            }
+          ' charts/danielsmith/values.yaml)
           test -n "$default_image_tag"
           case "$default_image_tag" in
             main-latest|main-*)

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -71,7 +71,8 @@ jobs:
           helm template danielsmith charts/danielsmith \
             --namespace danielsmith \
             --set ingress.enabled=true \
-            --set ingress.host=staging.danielsmith.io
+            --set ingress.host=staging.danielsmith.io \
+            --set image.tag=main-deadbee
 
       - name: Package Helm chart
         id: package
@@ -105,6 +106,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Smoke render intentionally uses a staging-like image.tag override per
+          # prompt requirements; this separate guard validates default image.tag.
           default_image_tag=$(awk '
             /^image:[[:space:]]*$/ { in_image=1; next }
             in_image && /^[^[:space:]]/ { in_image=0 }
@@ -159,20 +162,27 @@ jobs:
       - name: Publish OCI chart
         id: publish
         shell: bash
-        env:
-          HELM_REGISTRY: oci://ghcr.io/futuroptimist/charts
         run: |
           set -euo pipefail
-          package_path="${{ needs.helm-validate.outputs.package_path }}"
-          package_path="${package_path#dist/}"
-          if [ ! -f "$package_path" ]; then
-            echo "Expected chart package not found at: $package_path" >&2
+          chart_ref="${{ needs.helm-validate.outputs.chart_ref }}"
+          chart_registry="${chart_ref%/*}"
+          chart_version="${{ needs.helm-validate.outputs.chart_version }}"
+
+          if helm show chart "${chart_ref}" --version "${chart_version}" >/dev/null 2>&1; then
+            echo "Chart version already exists at ${chart_ref}:${chart_version}." >&2
+            echo "Please bump charts/danielsmith/Chart.yaml version before publishing again." >&2
             exit 1
           fi
-          helm push "$package_path" "$HELM_REGISTRY"
 
-          chart_ref="oci://ghcr.io/futuroptimist/charts/danielsmith"
-          chart_version="${{ needs.helm-validate.outputs.chart_version }}"
+          mapfile -t packages < <(find . -maxdepth 2 -type f -name "danielsmith-*.tgz" | sort)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "Expected exactly one downloaded chart package, found ${#packages[@]}." >&2
+            printf -- "- %s\n" "${packages[@]}" >&2
+            exit 1
+          fi
+          package_path="${packages[0]}"
+          helm push "$package_path" "$chart_registry"
+
           echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
           echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -73,7 +73,6 @@ jobs:
             --set ingress.enabled=true \
             --set ingress.host=staging.danielsmith.io
 
-
       - name: Package Helm chart
         id: package
         shell: bash
@@ -131,7 +130,6 @@ jobs:
           echo "`${{ steps.chart_meta.outputs.chart_ref }}`" >> "$GITHUB_STEP_SUMMARY"
           echo "Validated chart version:" >> "$GITHUB_STEP_SUMMARY"
           echo "`${{ steps.package.outputs.chart_version }}`" >> "$GITHUB_STEP_SUMMARY"
-
 
   publish-chart:
     if: |


### PR DESCRIPTION
### Motivation
- Add CI automation to validate and publish the canonical `charts/danielsmith` Helm chart to GHCR as an OCI chart so deployments can follow the same DSPACE/token.place model.

### Description
- Add `.github/workflows/ci-helm.yml` which validates `charts/danielsmith` on `pull_request` (checkout, `azure/setup-helm`, conditional `helm dependency build`, `helm lint`, a staging-like `helm template`, package and upload artifact) and publishes the packaged chart to `oci://ghcr.io/futuroptimist/charts/danielsmith` on `push` to `main` or `workflow_dispatch` (downloads artifact, logs in to GHCR with `GITHUB_TOKEN`, runs `helm push`, and prints the chart reference/version), while using `contents: read` and `packages: write` permissions only where required.

### Testing
- Ran `npm run format:write` (passed), `npm run lint` (passed), `npm run test:ci` (passed — 826 tests), `npm run docs:check` (passed), `npm run smoke` (passed — Vite production build and static artifact smoke checks), and `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets), and note that local `helm` verification commands (`helm lint`, `helm template`, `helm package`) could not be executed here because `helm` was not installed in the environment (the workflow uses `azure/setup-helm@v4` in CI to run those steps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d9790f50832faca3c1b2efe05fee)