### PR TITLE
Add danielsmith.io Sugarkube deployment docs and k3s runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Avatar facing is computed from the camera-relative movement vector; see
 - **Tests** – [`src/tests/`](src/tests/) (Vitest) and [`playwright/`](playwright/) capture unit and end-to-end coverage, including the keyboard traversal macro.
 - **Docs & planning** – [`docs/roadmap.md`](docs/roadmap.md), [`docs/backlog.md`](docs/backlog.md), and the prompt library in [`docs/prompts/`](docs/prompts/) track longer-term intent.
 - **Architecture notes** – See [`docs/architecture/scene-stack.md`](docs/architecture/scene-stack.md) for a visual of the data → systems → scene → UI flow.
+- **Sugarkube deployment docs** – Static-site deployment onboarding and runbooks live in
+  [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
+  [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and
+  [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).
 
 ### Scene module composition & state flow
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,0 +1,59 @@
+# k3s Sugarkube production runbook: danielsmith.io
+
+## Purpose
+
+Deploy `danielsmith.io` to production with immutable static-site artifacts.
+
+## Deployment model
+
+- Static Vite + Three.js web serving only.
+- No API, backend, database, queue, worker, or other stateful runtime service.
+- Runtime container serves static assets plus SPA fallback routes.
+- Health endpoints are served by the web server:
+  - `/livez`
+  - `/healthz`
+
+## Artifact references
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Default hostname: `https://danielsmith.io`
+
+Preferred tags:
+
+- Signoff: immutable `main-<shortsha>`
+- Convenience/non-signoff only: `main-latest`
+
+## Commands (run from Sugarkube repo)
+
+Production install/upgrade uses prod values:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+(For first-time cluster bootstrap, use `helm-oci-install` with the same prod values set.)
+
+Sugarkube wrappers are expected after the Sugarkube onboarding prompt sequence lands.
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+- Redeploy a previous known-good immutable image tag via Sugarkube Helm OCI helper commands.
+- Keep previous known-good `main-<shortsha>` tags available.
+- Use Helm revision rollback from Sugarkube when revision history rollback is preferred.
+
+## Hostname overrides
+
+Operators may override production hostnames using Sugarkube values and Cloudflare routes.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,0 +1,54 @@
+# k3s Sugarkube staging runbook: danielsmith.io
+
+## Purpose
+
+Deploy the static `danielsmith.io` web app into the staging k3s/Sugarkube environment.
+
+## Deployment model
+
+- Static web app only (Vite + Three.js).
+- No API/backend/database/queue/worker/stateful service.
+- Runtime is static container serving with SPA fallback.
+- Health checks are served by the web-server layer at `/livez` and `/healthz`.
+
+## Artifact references
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Hostname default: `https://staging.danielsmith.io`
+
+Use immutable `main-<shortsha>` tags for validation and signoff. Use `main-latest` only for convenience.
+
+## Commands (run from Sugarkube repo)
+
+First install:
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade existing release:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube wrappers for danielsmith are expected after the Sugarkube onboarding sequence completes.
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+1. Identify previous known-good immutable tag (`main-<shortsha>`).
+2. Re-run staging upgrade with that tag as `default_tag`.
+3. Optionally use Helm revision rollback from Sugarkube tooling.

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -1,0 +1,72 @@
+# Sugarkube onboarding for danielsmith.io
+
+This document describes the canonical Sugarkube deployment flow for `danielsmith.io`.
+
+## Architecture summary
+
+- `danielsmith.io` is a **static Vite + Three.js web app**.
+- It has **no API, backend, database, queue, worker, or stateful runtime service**.
+- Runtime delivery is static web serving from the production container image.
+- The web server layer serves health endpoints at:
+  - `/livez`
+  - `/healthz`
+- Browser route navigation uses SPA fallback.
+
+## Canonical deploy artifacts
+
+- Container image: `ghcr.io/futuroptimist/danielsmith.io`
+- OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Preferred image tags:
+  - Immutable signoff tags: `main-<shortsha>`
+  - Convenience-only tag: `main-latest` (not for signoff)
+
+## Sugarkube command examples
+
+> Run the following commands from a **Sugarkube checkout**, not from this app repo.
+
+First staging install:
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Existing staging upgrade:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Production deploys use the same helpers, swapping staging values for prod values:
+
+```text
+docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml
+```
+
+Sugarkube-specific wrappers are expected after the Sugarkube onboarding prompts land.
+
+## Default hostnames
+
+- Staging default hostname: `https://staging.danielsmith.io`
+- Production default hostname: `https://danielsmith.io`
+
+Operators can override hostnames through Sugarkube values and Cloudflare routes.
+
+## Post-deploy validation
+
+Staging examples:
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+Production equivalents use `https://danielsmith.io`.
+
+## Rollback
+
+- Redeploy a previously known-good immutable image tag (`main-<shortsha>`) with Sugarkube Helm OCI helpers.
+- Keep prior known-good immutable tags available for quick rollback.
+- Helm revision rollback can also be used from Sugarkube when appropriate.


### PR DESCRIPTION
### Motivation
- Provide canonical operator-facing docs that describe how `danielsmith.io` is deployed as a static site to Sugarkube.
- Make artifact references, Helm OCI install/upgrade examples, hostnames, validation, and rollback guidance explicit for staging and production.
- Keep the app repo as the single source for deployment runbooks so Sugarkube onboarding and app owners share the same expectations.

### Description
- Add `docs/sugarkube_onboarding.md` that summarizes architecture, canonical artifacts (`ghcr.io/futuroptimist/danielsmith.io` and `oci://ghcr.io/futuroptimist/charts/danielsmith`), Sugarkube command examples, hostnames, validation, and rollback guidance. 
- Add `docs/k3s-sugarkube-staging.md` containing the staging k3s/Sugarkube runbook with `just helm-oci-install`/`just helm-oci-upgrade` examples, validation (`/livez`, `/healthz`, `/`), and immutable-tag rollback steps. 
- Add `docs/k3s-sugarkube-prod.md` containing the production runbook with prod values usage, validation commands, preferred tagging policy, and rollback guidance. 
- Update `README.md` Key resources to link the three new deployment/runbook documents.

### Testing
- Ran docs validation with `npm run docs:check`, which passed. 
- Verified artifact and command references with: `grep -R "oci://ghcr.io/futuroptimist/charts/danielsmith" README.md docs`, `grep -R "ghcr.io/futuroptimist/danielsmith.io" README.md docs`, and `grep -R "release=danielsmith namespace=danielsmith" README.md docs`, all of which returned the expected entries. 
- Scanned staged changes for secrets via `git diff --cached | ./scripts/scan-secrets.py`, which reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13effb10b4832fb79cd5ac06578410)