### PR TITLE
Add Sugarkube deployment docs and k3s runbooks for danielsmith.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Avatar facing is computed from the camera-relative movement vector; see
 - **Tests** – [`src/tests/`](src/tests/) (Vitest) and [`playwright/`](playwright/) capture unit and end-to-end coverage, including the keyboard traversal macro.
 - **Docs & planning** – [`docs/roadmap.md`](docs/roadmap.md), [`docs/backlog.md`](docs/backlog.md), and the prompt library in [`docs/prompts/`](docs/prompts/) track longer-term intent.
 - **Architecture notes** – See [`docs/architecture/scene-stack.md`](docs/architecture/scene-stack.md) for a visual of the data → systems → scene → UI flow.
+- **Sugarkube deployment docs** – Static-site deployment/onboarding and k3s runbooks live in [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md), [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).
 
 ### Scene module composition & state flow
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,0 +1,62 @@
+# k3s Sugarkube production runbook (danielsmith.io)
+
+This runbook covers production deployments for danielsmith.io on Sugarkube.
+
+## Service model
+
+danielsmith.io is a static site deployment:
+
+- Static Vite + Three.js assets
+- No API/backend/database/queue/worker/stateful service
+- Web-server-owned health endpoints:
+  - `/livez`
+  - `/healthz`
+- SPA fallback for browser routes
+
+## Artifacts and release identity
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+
+Tag policy:
+
+- Preferred: immutable `main-<shortsha>`
+- Convenience only: `main-latest`
+
+## Production deploy command (from Sugarkube checkout)
+
+Production uses dev + prod values:
+
+- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+
+Example command:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube wrappers for this app are planned in the follow-up Sugarkube prompts.
+
+## Production hostname
+
+Default production URL: `https://danielsmith.io`
+
+Operators can override hostname through Sugarkube values and Cloudflare routing rules.
+
+## Post-deploy validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+- Redeploy a previous immutable `main-<shortsha>` with Sugarkube Helm OCI helpers.
+- Keep previously known-good tags available for fast rollback.
+- Use Helm revision rollback from Sugarkube when revision restore is preferred.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,0 +1,59 @@
+# k3s Sugarkube staging runbook (danielsmith.io)
+
+This runbook covers staging deployments for danielsmith.io on Sugarkube.
+
+## Service model
+
+danielsmith.io is deployed as static web serving only:
+
+- Static Vite + Three.js assets
+- No API/backend/database/queue/worker/stateful tier
+- Health endpoints from the web server:
+  - `/livez`
+  - `/healthz`
+- SPA browser route fallback enabled
+
+## Artifacts
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+
+Use immutable `main-<shortsha>` tags for staging sign-off. Use `main-latest` only for convenience.
+
+## First install (from Sugarkube checkout)
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+## Upgrade (from Sugarkube checkout)
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific wrapper shortcuts are expected in later Sugarkube onboarding work.
+
+## Staging hostname
+
+Default staging URL: `https://staging.danielsmith.io`
+
+Operators may override hostname via Sugarkube values and Cloudflare route configuration.
+
+## Post-deploy validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+- Redeploy a prior immutable `main-<shortsha>` tag with `just helm-oci-upgrade ... default_tag=...`.
+- Keep previous known-good tags available.
+- If needed, run a Helm revision rollback from Sugarkube.

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -1,0 +1,88 @@
+# Sugarkube onboarding for danielsmith.io
+
+This guide documents how to onboard **danielsmith.io** to Sugarkube as a static web app.
+
+## Architecture summary
+
+- danielsmith.io is a **static Vite + Three.js site**.
+- It has **no API, backend, database, queue, worker, or other stateful service**.
+- Runtime delivery is static web serving from the production container image.
+- Health checks are exposed by the web-server layer at:
+  - `/livez`
+  - `/healthz`
+- Browser routes are supported via SPA fallback.
+
+## Canonical deployment artifacts
+
+- Container image: `ghcr.io/futuroptimist/danielsmith.io`
+- Helm chart (OCI): `oci://ghcr.io/futuroptimist/charts/danielsmith`
+
+Preferred image-tag policy:
+
+- Use immutable `main-<shortsha>` tags for staging/prod validation and sign-off.
+- Use `main-latest` only for convenience or non-signoff testing.
+
+## Sugarkube Helm OCI commands
+
+> Run these commands from a **Sugarkube checkout**, not from this repository.
+
+### First staging install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+### Existing staging upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+### Production upgrade pattern
+
+Production uses the same release/chart flow with prod values:
+
+- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+
+Sugarkube-specific wrapper commands will be added in Sugarkube onboarding follow-up prompts.
+
+## Hostnames
+
+Default endpoints:
+
+- Staging: `https://staging.danielsmith.io`
+- Production: `https://danielsmith.io`
+
+Operators can override hostnames through Sugarkube values and Cloudflare routing.
+
+## Validation checklist
+
+After install/upgrade, validate rollout and HTTP endpoints.
+
+### Staging
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+### Production
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+If a release needs to be reverted:
+
+1. Redeploy a previous immutable `main-<shortsha>` image tag via Sugarkube Helm OCI helper.
+2. Keep at least one previously known-good immutable tag available for fast recovery.
+3. Optionally use Helm revision rollback from Sugarkube if you need to restore a prior Helm state.


### PR DESCRIPTION
### Motivation

- Provide clear operator-facing documentation for deploying the static `danielsmith.io` site to Sugarkube using the app-owned GHCR image and OCI Helm chart. 
- Capture canonical artifact identifiers, tag policy, health endpoints, SPA fallback behavior, and simple rollback guidance so on-call and infra operators can validate and recover production/staging. 

### Description

- Add `docs/sugarkube_onboarding.md` describing the static-site architecture, canonical image `ghcr.io/futuroptimist/danielsmith.io`, chart `oci://ghcr.io/futuroptimist/charts/danielsmith`, preferred tag pattern, Helm OCI example commands, hostnames, validation steps, and rollback notes. 
- Add `docs/k3s-sugarkube-staging.md` with a staging runbook including release/namespace identity (`release=danielsmith`, `namespace=danielsmith`), first-install and upgrade `just` command examples, staging hostname, validation, and rollback steps. 
- Add `docs/k3s-sugarkube-prod.md` with the production runbook showing the prod `just` upgrade pattern using dev+prod values, production hostname, validation checks, and rollback guidance. 
- Update `README.md` to link the new Sugarkube deployment docs under the repo key resources without altering existing architecture/testing content. 

### Testing

- Ran formatting with `npm run format:write` and doc validation with `npm run docs:check`, both of which completed successfully. 
- Ran lint via `npm run lint` and the full unit test suite via `npm run test:ci`, with `vitest` reporting `126 files` and `826 tests` passing. 
- Built and validated the production artifacts via `npm run smoke` (which runs `vite build` + `scripts/assert-dist.cjs`) and it passed the smoke checks. 
- Verified documentation references with `rg` commands for the chart, image, and release/namespace strings and confirmed the expected entries are present in `README.md` and `docs/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13effb10b4832fb79cd5ac06578410)