### PR TITLE
Add Sugarkube deployment docs for danielsmith.io static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Avatar facing is computed from the camera-relative movement vector; see
   immersive links. It now accepts canonical URLs or `URL` instances and always injects
   `mode=immersive&disablePerformanceFailover=1` so manual previews keep both overrides even
   when you append debugging or UTM flags.
+- **Sugarkube deployment docs** – Static-site Sugarkube onboarding and runbooks live in
+  [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
+  [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and
+  [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).
 
 ## Map of the repo
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -26,8 +26,9 @@ Use:
 - `docs/examples/danielsmith.values.prod.yaml`
 
 Use only `docs/examples/danielsmith.values.prod.yaml` for production commands.
-Treat this production values file as standalone and complete for all required
-chart inputs before rollout so production does not inherit dev-only settings.
+Treat this production values file as standalone, present in the Sugarkube checkout,
+and complete for all required chart inputs (including shared/base settings) before
+rollout so production does not inherit dev-only settings or chart defaults.
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -23,7 +23,7 @@ This guide covers production deployment for `danielsmith.io` on Sugarkube.
 
 Use:
 
-- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+- `docs/examples/danielsmith.values.prod.yaml`
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.
@@ -37,21 +37,14 @@ before running the helpers below (or update `version_file`/`values` to existing 
 First install:
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
-
-
-> Note: This values list intentionally includes `docs/examples/danielsmith.values.dev.yaml`
-> first for the current Sugarkube helper convention required by this prompt. Ensure all
-> production-specific settings are overridden by `docs/examples/danielsmith.values.prod.yaml`.
-> Any future rename to a neutral common/base values file should be handled in a separate
-> Sugarkube follow-up PR.
 
 Sugarkube wrapper commands can be adopted after the Sugarkube onboarding prompt sequence lands.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -23,11 +23,11 @@ This guide covers production deployment for `danielsmith.io` on Sugarkube.
 
 Use:
 
-- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+- `docs/examples/danielsmith.values.prod.yaml`
 
-This prompt intentionally follows the current Sugarkube helper convention: use
-`docs/examples/danielsmith.values.dev.yaml` as the shared/base layer and
-`docs/examples/danielsmith.values.prod.yaml` as the production override. Ensure production host/TLS/debug/resource settings are explicitly overridden in the prod file before production rollout. If the current dev-base layer contains unsafe shared keys, treat that as a blocker and follow up in Sugarkube with a neutral production-safe common/base file rename in a separate PR.
+Use only `docs/examples/danielsmith.values.prod.yaml` for production commands.
+Treat this production values file as standalone and complete for all required
+chart inputs before rollout so production does not inherit dev-only settings.
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.
@@ -41,13 +41,13 @@ before running the helpers below (or update `version_file`/`values` to existing 
 First install:
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Sugarkube wrapper commands can be adopted after the Sugarkube onboarding prompt sequence lands.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -25,6 +25,10 @@ Use:
 
 - `docs/examples/danielsmith.values.prod.yaml`
 
+This production values file must be standalone and complete for required shared
+chart inputs. If shared defaults move to a neutral base/common file in Sugarkube,
+layer that base before the production override in a dedicated follow-up update.
+
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -27,11 +27,7 @@ Use:
 
 This prompt intentionally follows the current Sugarkube helper convention: use
 `docs/examples/danielsmith.values.dev.yaml` as the shared/base layer and
-`docs/examples/danielsmith.values.prod.yaml` as the production override. Ensure
-production host/TLS/debug/resource settings are overridden in the prod file. If any
-shared key is not safe from the dev base, make `docs/examples/danielsmith.values.prod.yaml`
-standalone and complete for production-required settings; any neutral common/base values
-rename belongs in a separate Sugarkube follow-up PR.
+`docs/examples/danielsmith.values.prod.yaml` as the production override. Ensure production host/TLS/debug/resource settings are explicitly overridden in the prod file before production rollout. If the current dev-base layer contains unsafe shared keys, treat that as a blocker and follow up in Sugarkube with a neutral production-safe common/base file rename in a separate PR.
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -28,8 +28,10 @@ Use:
 This prompt intentionally follows the current Sugarkube helper convention: use
 `docs/examples/danielsmith.values.dev.yaml` as the shared/base layer and
 `docs/examples/danielsmith.values.prod.yaml` as the production override. Ensure
-production host/TLS/debug/resource settings are overridden in the prod file; any
-neutral common/base values rename belongs in a separate Sugarkube follow-up PR.
+production host/TLS/debug/resource settings are overridden in the prod file. If any
+shared key is not safe from the dev base, make `docs/examples/danielsmith.values.prod.yaml`
+standalone and complete for production-required settings; any neutral common/base values
+rename belongs in a separate Sugarkube follow-up PR.
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -23,7 +23,7 @@ This guide covers production deployment for `danielsmith.io` on Sugarkube.
 
 Use:
 
-- `docs/examples/danielsmith.values.prod.yaml`
+- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.
@@ -33,14 +33,21 @@ non-signoff convenience.
 First install:
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+
+> Note: This values list intentionally includes `docs/examples/danielsmith.values.dev.yaml`
+> first for the current Sugarkube helper convention required by this prompt. Ensure all
+> production-specific settings are overridden by `docs/examples/danielsmith.values.prod.yaml`.
+> Any future rename to a neutral common/base values file should be handled in a separate
+> Sugarkube follow-up PR.
 
 Sugarkube wrapper commands can be adopted after the Sugarkube onboarding prompt sequence lands.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,0 +1,67 @@
+# K3s Sugarkube production runbook (danielsmith.io)
+
+This guide covers production deployment for `danielsmith.io` on Sugarkube.
+
+## Service profile
+
+`danielsmith.io` is deployed as static web serving only:
+
+- Static Vite + Three.js app.
+- No API/backend/database/queue/worker services.
+- Runtime: production container serving static files.
+- Health endpoints: `/livez` and `/healthz`.
+- SPA fallback is enabled for browser routes.
+
+## Canonical deployment coordinates
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+
+## Production values profile
+
+Use:
+
+- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+
+Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
+non-signoff convenience.
+
+## Command examples (run in Sugarkube repo)
+
+First install:
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube wrapper commands can be adopted after the Sugarkube onboarding prompt sequence lands.
+
+## Default production hostname
+
+- `https://danielsmith.io`
+
+Operators can override hostnames with Sugarkube values and Cloudflare routing updates.
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+- Redeploy the prior immutable `main-<shortsha>` image tag using Sugarkube Helm OCI helpers.
+- Keep previous known-good tags available and documented in deployment records.
+- Helm revision rollback remains an additional safety option on Sugarkube.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -23,11 +23,13 @@ This guide covers production deployment for `danielsmith.io` on Sugarkube.
 
 Use:
 
-- `docs/examples/danielsmith.values.prod.yaml`
+- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
 
-This production values file must be standalone and complete for required shared
-chart inputs. If shared defaults move to a neutral base/common file in Sugarkube,
-layer that base before the production override in a dedicated follow-up update.
+This prompt intentionally follows the current Sugarkube helper convention: use
+`docs/examples/danielsmith.values.dev.yaml` as the shared/base layer and
+`docs/examples/danielsmith.values.prod.yaml` as the production override. Ensure
+production host/TLS/debug/resource settings are overridden in the prod file; any
+neutral common/base values rename belongs in a separate Sugarkube follow-up PR.
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.
@@ -41,13 +43,13 @@ before running the helpers below (or update `version_file`/`values` to existing 
 First install:
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Sugarkube wrapper commands can be adopted after the Sugarkube onboarding prompt sequence lands.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -30,6 +30,10 @@ non-signoff convenience.
 
 ## Command examples (run in Sugarkube repo)
 
+Prerequisite: ensure the Sugarkube checkout contains
+`docs/apps/danielsmith.version` and the referenced values files under `docs/examples/`
+before running the helpers below (or update `version_file`/`values` to existing paths).
+
 First install:
 
 ```bash

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -23,7 +23,7 @@ This guide covers production deployment for `danielsmith.io` on Sugarkube.
 
 Use:
 
-- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+- `docs/examples/danielsmith.values.prod.yaml`
 
 Use immutable `main-<shortsha>` tags for rollout and sign-off. Reserve `main-latest` for
 non-signoff convenience.
@@ -33,13 +33,13 @@ non-signoff convenience.
 First install:
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Sugarkube wrapper commands can be adopted after the Sugarkube onboarding prompt sequence lands.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -24,6 +24,10 @@ This guide covers staging deployment of the static `danielsmith.io` site on Suga
 
 ## Install/upgrade commands (run in Sugarkube repo)
 
+Prerequisite: ensure the Sugarkube checkout contains `docs/apps/danielsmith.version`
+and the referenced values files under `docs/examples/` before running the
+helpers below (or update `version_file`/`values` to existing paths).
+
 First install:
 
 ```bash

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,0 +1,61 @@
+# K3s Sugarkube staging runbook (danielsmith.io)
+
+This guide covers staging deployment of the static `danielsmith.io` site on Sugarkube.
+
+## Service profile
+
+- Runtime type: static Vite + Three.js site served by a web server.
+- Stateful dependencies: none.
+- Backend/API components: none.
+- Health endpoints: `/livez` and `/healthz`.
+- Browser navigation supports SPA fallback.
+
+## Artifacts
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+
+## Preferred image tag strategy
+
+- Use immutable `main-<shortsha>` for validation and sign-off.
+- Use `main-latest` only for convenience checks.
+
+## Install/upgrade commands (run in Sugarkube repo)
+
+First install:
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube wrapper commands can replace these once onboarding tasks are complete.
+
+## Default staging hostname
+
+- `https://staging.danielsmith.io`
+
+Hostname/routing can be overridden through Sugarkube values and Cloudflare routes.
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+- Re-run `just helm-oci-upgrade ... default_tag=main-<previous-shortsha>` with the previous known-good immutable tag.
+- Keep known-good immutable tags recorded and available.
+- If needed, perform a Helm revision rollback from Sugarkube.

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -39,11 +39,17 @@ just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-### Production upgrade/install profile
+### First production install
 
-Use the same helper commands with production values:
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
 
-- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+### Existing production upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -46,20 +46,18 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 ### First production install
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 ### Existing production upgrade
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-> Note: The production values list intentionally includes
-> `docs/examples/danielsmith.values.dev.yaml` first for the current Sugarkube helper
-> convention required by this prompt. Production-specific settings must be overridden
-> by `docs/examples/danielsmith.values.prod.yaml`. If Sugarkube later renames the shared
-> values layer to a neutral common/base file, track that as a separate Sugarkube follow-up PR.
+> Note: Production commands intentionally use only
+> `docs/examples/danielsmith.values.prod.yaml` so production does not inherit
+> any settings from development values files.
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -46,19 +46,21 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 ### First production install
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 ### Existing production upgrade
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-> Note: Production commands intentionally use only
-> `docs/examples/danielsmith.values.prod.yaml` so production does not inherit
-> development settings. This production values file must be standalone and
-> complete for required shared chart inputs.
+> Note: This prompt intentionally follows the current Sugarkube helper
+> convention by layering `docs/examples/danielsmith.values.dev.yaml` as the
+> shared/base values file and
+> `docs/examples/danielsmith.values.prod.yaml` as the production override.
+> Production host/TLS/debug/resource settings must be overridden by the prod
+> file; a neutral common/base rename belongs in a separate Sugarkube follow-up.
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -59,8 +59,10 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 > convention by layering `docs/examples/danielsmith.values.dev.yaml` as the
 > shared/base values file and
 > `docs/examples/danielsmith.values.prod.yaml` as the production override.
-> Production host/TLS/debug/resource settings must be overridden by the prod
-> file; a neutral common/base rename belongs in a separate Sugarkube follow-up.
+> Production host/TLS/debug/resource settings must be explicitly overridden by
+> the prod file before rollout. If the current dev-base layer has unsafe shared
+> keys, treat that as a blocker and follow up in Sugarkube with a neutral
+> production-safe common/base rename in a separate PR.
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -1,0 +1,86 @@
+# Sugarkube onboarding (danielsmith.io)
+
+This runbook documents how to deploy `danielsmith.io` to Sugarkube as a static web app.
+
+## Architecture
+
+`danielsmith.io` is a static Vite + Three.js site:
+
+- No API service.
+- No backend workers.
+- No database, queue, or stateful compute.
+- Runtime is static file serving from the production container image.
+- The web-server layer exposes health endpoints:
+  - `/livez`
+  - `/healthz`
+- Browser routes are handled with SPA fallback.
+
+## Canonical artifacts
+
+- Container image: `ghcr.io/futuroptimist/danielsmith.io`
+- Helm chart (OCI): `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Preferred image tags:
+  - `main-<shortsha>` for immutable staging/prod validation and sign-off.
+  - `main-latest` only for convenience and non-signoff checks.
+
+## Sugarkube command flow
+
+Run the following commands from a Sugarkube repository checkout (not from this repo).
+
+### First staging install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+### Existing staging upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+### Production upgrade/install profile
+
+Use the same helper commands with production values:
+
+- `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`
+
+Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
+
+## Hostnames
+
+Default routes:
+
+- Staging: `https://staging.danielsmith.io`
+- Production: `https://danielsmith.io`
+
+Operators can override hostnames via Sugarkube values and Cloudflare routing.
+
+## Validation checks
+
+Staging:
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+Production:
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+- Redeploy the previous immutable `main-<shortsha>` image tag through Sugarkube Helm OCI
+  helpers.
+- Keep previously validated tags available so rollback is immediate.
+- Helm revision rollback is also available from the Sugarkube side when needed.

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -46,23 +46,19 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 ### First production install
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 ### Existing production upgrade
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-> Note: This prompt intentionally follows the current Sugarkube helper
-> convention by layering `docs/examples/danielsmith.values.dev.yaml` as the
-> shared/base values file and
-> `docs/examples/danielsmith.values.prod.yaml` as the production override.
-> Production host/TLS/debug/resource settings must be explicitly overridden by
-> the prod file before rollout. If the current dev-base layer has unsafe shared
-> keys, treat that as a blocker and follow up in Sugarkube with a neutral
-> production-safe common/base rename in a separate PR.
+> Note: Production commands intentionally use only
+> `docs/examples/danielsmith.values.prod.yaml`. Ensure this prod values file is
+> standalone and complete for required chart inputs before rollout so
+> production does not inherit dev-only settings.
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -42,14 +42,20 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 ### First production install
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 ### Existing production upgrade
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+> Note: The production values list intentionally includes
+> `docs/examples/danielsmith.values.dev.yaml` first for the current Sugarkube helper
+> convention required by this prompt. Production-specific settings must be overridden
+> by `docs/examples/danielsmith.values.prod.yaml`. If Sugarkube later renames the shared
+> values layer to a neutral common/base file, track that as a separate Sugarkube follow-up PR.
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -27,6 +27,10 @@ This runbook documents how to deploy `danielsmith.io` to Sugarkube as a static w
 
 Run the following commands from a Sugarkube repository checkout (not from this repo).
 
+Prerequisite: before running these commands, ensure the Sugarkube checkout contains
+`docs/apps/danielsmith.version` and the referenced values files under `docs/examples/`
+(or update `version_file`/`values` to paths that exist in that checkout).
+
 ### First staging install
 
 ```bash

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -57,7 +57,8 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 
 > Note: Production commands intentionally use only
 > `docs/examples/danielsmith.values.prod.yaml` so production does not inherit
-> any settings from development values files.
+> development settings. This production values file must be standalone and
+> complete for required shared chart inputs.
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -57,8 +57,9 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 
 > Note: Production commands intentionally use only
 > `docs/examples/danielsmith.values.prod.yaml`. Ensure this prod values file is
-> standalone and complete for required chart inputs before rollout so
-> production does not inherit dev-only settings.
+> present in the Sugarkube checkout and standalone/complete for required chart
+> inputs (including shared/base settings) before rollout so production does not
+> inherit dev-only settings or chart defaults.
 
 Sugarkube-specific wrapper commands are expected after Sugarkube onboarding prompts land.
 


### PR DESCRIPTION
### Motivation

- Document the app-owned static deployment contract for `danielsmith.io` so operators can deploy to Sugarkube with clear, copy/paste commands. 
- Surface canonical artifact coordinates (`ghcr.io/futuroptimist/danielsmith.io` and `oci://ghcr.io/futuroptimist/charts/danielsmith`) and immutable-tag guidance for safe rollouts and rollbacks.

### Description

- Add `docs/sugarkube_onboarding.md` describing the static-only architecture, health endpoints (`/livez`, `/healthz`), SPA fallback behavior, canonical image/chart references, and Sugarkube Helm OCI command examples. 
- Add `docs/k3s-sugarkube-staging.md` with staging runbook content including release/namespace defaults (`release=danielsmith`, `namespace=danielsmith`), install/upgrade examples, staging hostname, validation checks, and rollback guidance. 
- Add `docs/k3s-sugarkube-prod.md` with production runbook content, production values guidance, install/upgrade examples, production hostname, validation checks, and rollback guidance. 
- Update `README.md` Key Resources to link the new Sugarkube onboarding and runbook docs while preserving existing architecture and testing content.

### Testing

- Ran documentation lint/check with `npm run docs:check` which passed. 
- Ran formatting and lint with `npm run format:write` and `npm run lint` which completed successfully. 
- Executed the test suite with `npm run test:ci` (Vitest) which completed successfully with `826` tests passing. 
- Performed the production smoke build and static artifact validation with `npm run smoke` which succeeded and reported valid `dist/` references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13effb10b4832fb79cd5ac06578410)