### PR TITLE
📝 Add danielsmith.io Sugarkube deployment docs and runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Avatar facing is computed from the camera-relative movement vector; see
 - **Prompt library** – Automation-ready Codex prompts are summarized in
   [`summary.md`][prompt-summary] and expanded across topical files in
   `docs/prompts/codex/` (automation, lighting, avatar, HUD, POIs, accessibility, and more).
+- **Sugarkube deployment docs** – Static-site deployment onboarding and runbooks live in
+  [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
+  [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and
+  [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).
 - **Preview overrides** – Use [`createImmersiveModeUrl`](src/ui/immersiveUrl.ts) to build
   immersive links. It now accepts canonical URLs or `URL` instances and always injects
   `mode=immersive&disablePerformanceFailover=1` so manual previews keep both overrides even

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,0 +1,50 @@
+# danielsmith.io on k3s Sugarkube production
+
+This runbook covers production deployment of the static **danielsmith.io** web app.
+
+## Production architecture summary
+
+- Static Vite + Three.js application.
+- Runtime serves static assets from `ghcr.io/futuroptimist/danielsmith.io`.
+- No API/backend/database/queue/worker/stateful components.
+- Health probes are web-server endpoints: `/livez` and `/healthz`.
+- SPA fallback supports browser route refresh/deep links.
+
+## Production defaults
+
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Hostname: `https://danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Tag policy: prefer immutable `main-<shortsha>`; avoid signoff on `main-latest`.
+
+Operators can override hostnames via Sugarkube values and Cloudflare routes.
+
+## Commands (run from Sugarkube checkout)
+
+Upgrade using prod values:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+(If you need an initial bootstrap flow, use the equivalent `helm-oci-install` pattern with the
+same release, namespace, chart, and prod values files.)
+
+Sugarkube-specific wrapper commands may be added later; these generic helpers remain canonical.
+
+## Validation checklist
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+- Redeploy last known-good immutable tag: `main-<shortsha>`.
+- Keep prior good tags available to avoid blocked restores.
+- Optional: use Helm revision rollback in Sugarkube for chart revision reverts.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,0 +1,51 @@
+# danielsmith.io on k3s Sugarkube staging
+
+This runbook covers staging deployment of the static **danielsmith.io** web app.
+
+## Staging architecture summary
+
+- Static Vite + Three.js application.
+- Runtime serves static assets from `ghcr.io/futuroptimist/danielsmith.io`.
+- No API/backend/database/queue/worker/stateful components.
+- Health probes are web-server endpoints: `/livez` and `/healthz`.
+- SPA fallback supports browser route refresh/deep links.
+
+## Staging defaults
+
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Hostname: `https://staging.danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Tag policy: prefer immutable `main-<shortsha>`; avoid signoff on `main-latest`.
+
+## Commands (run from Sugarkube checkout)
+
+First install:
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific wrapper commands may be added later; these generic helpers remain canonical.
+
+## Validation checklist
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+- Redeploy last known-good immutable tag: `main-<shortsha>`.
+- Keep prior good tags available to avoid blocked restores.
+- Optional: use Helm revision rollback in Sugarkube for chart revision reverts.

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -1,0 +1,103 @@
+# danielsmith.io Sugarkube onboarding
+
+This guide documents the **danielsmith.io** deployment model used by Sugarkube.
+
+## Architecture
+
+`danielsmith.io` is a static web application built with Vite + Three.js.
+
+- No API service.
+- No backend service.
+- No database.
+- No queue or worker tier.
+- No stateful runtime component.
+
+Runtime delivery is a production container that serves static web assets.
+
+The web server layer exposes health endpoints and SPA routing support:
+
+- `GET /livez`
+- `GET /healthz`
+- SPA fallback for browser routes to the app entrypoint.
+
+## Artifacts
+
+Sugarkube deploys the app using these app-owned artifacts:
+
+- Container image: `ghcr.io/futuroptimist/danielsmith.io`
+- OCI chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+
+Preferred image tags:
+
+- `main-<shortsha>` for immutable staging/prod validation and signoff.
+- `main-latest` for convenience only (non-signoff workflows).
+
+## Release/namespace defaults
+
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+
+Default hostnames:
+
+- Staging: `https://staging.danielsmith.io`
+- Production: `https://danielsmith.io`
+
+Operators can override hostnames through Sugarkube values and Cloudflare routing.
+
+## Deploy from Sugarkube checkout
+
+Run deployment commands from a **Sugarkube repository checkout**, not from this repo.
+
+### First staging install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+### Existing staging upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+### Production upgrade
+
+Use prod values while keeping the same release/chart/tag pattern:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+> Sugarkube convenience wrappers for danielsmith.io can be layered on top of these generic Helm
+> OCI helper commands after Sugarkube onboarding prompts are completed.
+
+## Validation
+
+Staging validation:
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+Production validation (host swap only):
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+Rollback options are operationally simple because the app is static web serving:
+
+1. Redeploy a previous known-good immutable image tag (`main-<shortsha>`) via the Sugarkube Helm
+   OCI helper.
+2. Keep at least one prior known-good immutable tag available for fast restore.
+3. Use Helm revision rollback from Sugarkube if a chart/app revision revert is preferred.


### PR DESCRIPTION
### Motivation

- Provide operators a clear, canonical Sugarkube onboarding and runbook for deploying the static `danielsmith.io` Vite + Three.js site.  
- Clarify that the app is static-only with no API/backend/database/queue/worker/stateful services and that health endpoints and SPA fallback are served by the web server.  
- Surface the app-owned artifacts and tag policy so Sugarkube installs use the correct image and OCI chart.  

### Description

- Added `docs/sugarkube_onboarding.md` documenting architecture, artifacts (`ghcr.io/futuroptimist/danielsmith.io` and `oci://ghcr.io/futuroptimist/charts/danielsmith`), health endpoints, SPA fallback, deployment examples, validation, and rollback guidance.  
- Added staging runbook `docs/k3s-sugarkube-staging.md` with staging defaults, first-install/upgrade `just` command examples using `release=danielsmith namespace=danielsmith`, validation checks, and rollback notes.  
- Added production runbook `docs/k3s-sugarkube-prod.md` with production defaults, prod `just` upgrade example, validation checks, and rollback notes.  
- Linked the new Sugarkube docs from the README under Key resources for operator discoverability.  

### Testing

- Ran `npm run format:write` and the formatting step completed successfully.  
- Ran `npm run docs:check` and the docs check passed.  
- Ran repository searches with `rg` for the canonical image and chart references and the expected occurrences were found in `README.md` and `docs`.  
- Ran the secrets scan `git diff --cached | ./scripts/scan-secrets.py` and it reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13effb10b4832fb79cd5ac06578410)