### PR TITLE
Align Helm default image tag with GHCR tags

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -118,15 +118,14 @@ jobs:
             }
           ' charts/danielsmith/values.yaml)
           test -n "$default_image_tag"
-          case "$default_image_tag" in
-            main|main-latest|main-*)
-              echo "Default image.tag is publish-eligible: $default_image_tag"
-              ;;
-            *)
-              echo "Default image.tag is not publish-eligible: $default_image_tag" >&2
-              exit 1
-              ;;
-          esac
+          if [[ "$default_image_tag" == "main-latest" ]] || \
+             [[ "$default_image_tag" =~ ^main-[0-9a-f]{7,40}$ ]]; then
+            echo "Default image.tag is publish-eligible: $default_image_tag"
+          else
+            echo "Default image.tag is not publish-eligible: $default_image_tag" >&2
+            echo "Use main-latest for local rendering or main-<shortsha> for releases." >&2
+            exit 1
+          fi
       - name: Summarize validated chart
         run: |
           echo "Validated chart reference:" >> "$GITHUB_STEP_SUMMARY"

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -4,9 +4,10 @@ image:
   repository: ghcr.io/futuroptimist/danielsmith.io
   # Keep this non-empty so default `helm lint`/`helm template` work, while
   # avoiding an implicit fallback to Chart.AppVersion (for example `0.1.0`),
-  # which may not exist as a published image tag. Sugarkube overlays should
-  # override this with an environment-specific tag or set image.digest.
-  tag: main
+  # which may not exist as a published image tag. `main-latest` is a mutable
+  # rendering/linting convenience only; Sugarkube staging/prod sign-off must
+  # still pass an immutable `main-<shortsha>` tag or set image.digest.
+  tag: main-latest
   digest: ''
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Motivation
- Make the chart default image tag refer to a tag actually published by the image CI workflow so `helm lint`/`helm template` produce plausible image references.
- Preserve the rule that Sugarkube staging/prod sign-off must use immutable `main-<shortsha>` tags (or an image digest) rather than a mutable `main` tag.

### Description
- Change `charts/danielsmith/values.yaml` default `image.tag` from `main` to `main-latest` and update the nearby comment to describe that `main-latest` is a mutable rendering/linting convenience while production sign-off requires an immutable `main-<shortsha>` or `image.digest`.
- Update `.github/workflows/ci-helm.yml` guard to accept `main-latest` and only `main-<shortsha>` values that match a hex suffix, while rejecting a bare `main` and emitting guidance on allowed values.
- Preserve the canonical image repository and leave Sugarkube deployment commands and explicit overrides (e.g. `--set image.tag=main-deadbee`) unchanged.

### Testing
- Ran formatting with `npm run format:write` and static checks with `npm run lint`, all completed successfully.
- Ran unit/integration tests with `npm run test:ci` and saw `Test Files  126 passed (126)` and `Tests  826 passed (826)` indicating full success.
- Ran docs validation and smoke build with `npm run docs:check` and `npm run smoke`, both passed.
- Installed Helm locally and ran `helm lint charts/danielsmith` and `helm template ... --set image.tag=main-deadbee`, which succeeded and produced the rendered template at `/tmp/danielsmith-helm-template.yaml`.
- Verified `charts/danielsmith/values.yaml` contains `tag: main-latest` via `grep -n "tag: main-latest" charts/danielsmith/values.yaml` and exercised guard semantics smoke checks showing `main-latest` accepted, `main-deadbee` accepted, and `main` rejected.
- Ran the repository secret scan with `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bd52a2f0832fa272168bddd077a7)