### PR TITLE
Align Helm default image tag

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -118,15 +118,14 @@ jobs:
             }
           ' charts/danielsmith/values.yaml)
           test -n "$default_image_tag"
-          case "$default_image_tag" in
-            main|main-latest|main-*)
-              echo "Default image.tag is publish-eligible: $default_image_tag"
-              ;;
-            *)
-              echo "Default image.tag is not publish-eligible: $default_image_tag" >&2
-              exit 1
-              ;;
-          esac
+          if [ "$default_image_tag" = "main-latest" ] || \
+            [[ "$default_image_tag" =~ ^main-[0-9a-f]{7,40}$ ]]; then
+            echo "Default image.tag is publish-eligible: $default_image_tag"
+          else
+            echo "Default image.tag is not publish-eligible: $default_image_tag" >&2
+            echo "Use main-latest for local defaults or main-<shortsha> for sign-off." >&2
+            exit 1
+          fi
       - name: Summarize validated chart
         run: |
           echo "Validated chart reference:" >> "$GITHUB_STEP_SUMMARY"

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -2,11 +2,11 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/danielsmith.io
-  # Keep this non-empty so default `helm lint`/`helm template` work, while
-  # avoiding an implicit fallback to Chart.AppVersion (for example `0.1.0`),
-  # which may not exist as a published image tag. Sugarkube overlays should
-  # override this with an environment-specific tag or set image.digest.
-  tag: main
+  # Keep this non-empty so default `helm lint`/`helm template` work against
+  # the mutable GHCR tag that CI publishes for local chart rendering. Sugarkube
+  # staging/prod sign-off must still override this with an immutable
+  # `main-<shortsha>` image tag or set image.digest.
+  tag: main-latest
   digest: ''
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Motivation
- Align the Helm chart default `image.tag` with the mutable GHCR tags CI actually publishes while preserving the requirement that Sugarkube staging/prod use immutable `main-<shortsha>` tags or digests for sign-off.

### Description
- Change `charts/danielsmith/values.yaml` to set `image.tag: main-latest` and update the comment to explain that this is a local rendering convenience and that Sugarkube must supply immutable `main-<shortsha>` tags or `image.digest`.
- Tighten the `.github/workflows/ci-helm.yml` default-image-tag guard to accept `main-latest` or an immutable `main-<shortsha>` matching `^main-[0-9a-f]{7,40}$`, and reject a bare `main`, with a helpful error message.

### Testing
- Ran `npm run format:write` and formatting completed successfully.
- Ran `npm run lint` and static linting completed successfully.
- Ran `npm run test:ci` which executed the test suite (`126` files, `826` tests) and all tests passed.
- Ran `npm run docs:check` and docs validation passed.
- Used a temporary Helm binary to run `helm lint charts/danielsmith` which passed, and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` which produced templates referencing `ghcr.io/futuroptimist/danielsmith.io:main-deadbee` as expected.
- Verified the CI guard logic locally with a small script that confirmed `main` is rejected while `main-latest` and `main-<shortsha>` are allowed.
- Confirmed `grep -n "tag: main-latest" charts/danielsmith/values.yaml` returns a match.
- Ran `npm run smoke` and the smoke/build checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bd52a2f0832fa272168bddd077a7)