### PR TITLE
Align Helm default image tag with GHCR tags

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -119,8 +119,12 @@ jobs:
           ' charts/danielsmith/values.yaml)
           test -n "$default_image_tag"
           case "$default_image_tag" in
-            main|main-latest|main-*)
+            main-latest|main-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
               echo "Default image.tag is publish-eligible: $default_image_tag"
+              ;;
+            main)
+              echo "Default image.tag must not use the unpublished bare main tag." >&2
+              exit 1
               ;;
             *)
               echo "Default image.tag is not publish-eligible: $default_image_tag" >&2

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -2,11 +2,12 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/danielsmith.io
-  # Keep this non-empty so default `helm lint`/`helm template` work, while
-  # avoiding an implicit fallback to Chart.AppVersion (for example `0.1.0`),
-  # which may not exist as a published image tag. Sugarkube overlays should
-  # override this with an environment-specific tag or set image.digest.
-  tag: main
+  # Keep this non-empty so default `helm lint`/`helm template` work with
+  # a tag published by CI, while avoiding an implicit fallback to Chart.AppVersion
+  # (for example `0.1.0`), which may not exist as a published image tag.
+  # Sugarkube staging/prod sign-off must still override this convenience default
+  # with an immutable `main-<shortsha>` tag or set image.digest.
+  tag: main-latest
   digest: ''
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Motivation
- The chart default used the unpublished `main` tag, causing local `helm lint`/`helm template` to reference an image tag not produced by CI.
- Default renders should point at a plausible published tag while preserving the rule that Sugarkube staging/prod must use immutable `main-<shortsha>` tags or a digest for sign-off.

### Description
- Update `charts/danielsmith/values.yaml` to set `image.tag: main-latest` and clarify comments that this is a convenience default for local rendering and that staging/prod must still use immutable `main-<shortsha>` or an image digest.
- Tighten the default-image-tag guard in `.github/workflows/ci-helm.yml` to accept `main-latest` and `main-<shortsha>`-style tags while explicitly rejecting the bare `main` tag.
- No change to the canonical image repository or Sugarkube deployment commands, and explicit immutable overrides (for example `--set image.tag=main-deadbee`) continue to be supported.

### Testing
- Ran `npm run format:write` which completed successfully.
- Ran `npm run lint && npm run test:ci && npm run docs:check` where `eslint` returned no errors, `vitest` finished with `826 passed (826)` tests, and `node scripts/check-docs.cjs` reported "Docs check passed.".
- Ran `npm run smoke` (build + artifact assertion) and it passed with the smoke check reporting valid dist artifacts.
- Installed Helm and ran `helm lint charts/danielsmith` which passed, and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` which rendered successfully showing `ghcr.io/futuroptimist/danielsmith.io:main-deadbee`.
- Verified `grep -n "tag: main-latest" charts/danielsmith/values.yaml` returned the updated line, and a shell validation of the CI guard logic confirmed `main-latest` and `main-deadbee` style tags pass while bare `main` fails.
- Ran `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` with no high-risk secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bd52a2f0832fa272168bddd077a7)