### PR TITLE
Align Helm default image tag to published GHCR tag

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -118,15 +118,14 @@ jobs:
             }
           ' charts/danielsmith/values.yaml)
           test -n "$default_image_tag"
-          case "$default_image_tag" in
-            main|main-latest|main-*)
-              echo "Default image.tag is publish-eligible: $default_image_tag"
-              ;;
-            *)
-              echo "Default image.tag is not publish-eligible: $default_image_tag" >&2
-              exit 1
-              ;;
-          esac
+          if [ "$default_image_tag" = "main-latest" ] || \
+            [[ "$default_image_tag" =~ ^main-[0-9a-f]{7,40}$ ]]; then
+            echo "Default image.tag is publish-eligible: $default_image_tag"
+          else
+            echo "Default image.tag is not publish-eligible: $default_image_tag" >&2
+            echo "Use main-latest or an immutable main-<shortsha> tag; bare main is not published." >&2
+            exit 1
+          fi
       - name: Summarize validated chart
         run: |
           echo "Validated chart reference:" >> "$GITHUB_STEP_SUMMARY"

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -42,9 +42,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/*
 Resolve the container image. Digest wins for immutable deploys. Otherwise a tag
-is required; values.yaml intentionally supplies `main` so default lint/template
-commands work without falling back to Chart.AppVersion, which is the chart/app
-version and may not correspond to a published container tag.
+is required; values.yaml intentionally supplies `main-latest` as a mutable
+convenience default for local lint/template rendering without falling back to
+Chart.AppVersion, which is the chart/app version and may not correspond to a
+published container tag. Sugarkube staging/prod sign-off must still use an
+immutable `main-<shortsha>` tag or `image.digest`.
 */}}
 {{- define "danielsmith.image" -}}
 {{- if .Values.image.digest -}}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -2,11 +2,11 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/danielsmith.io
-  # Keep this non-empty so default `helm lint`/`helm template` work, while
-  # avoiding an implicit fallback to Chart.AppVersion (for example `0.1.0`),
-  # which may not exist as a published image tag. Sugarkube overlays should
-  # override this with an environment-specific tag or set image.digest.
-  tag: main
+  # Keep this non-empty so default `helm lint`/`helm template` work with a
+  # tag published by CI. `main-latest` is only a local rendering/linting
+  # convenience; Sugarkube staging/prod sign-off must override it with an
+  # immutable `main-<shortsha>` tag or set image.digest.
+  tag: main-latest
   digest: ''
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Motivation
- The chart default `image.tag` was `main` but CI publishes `main-latest` and immutable `main-<shortsha>` tags, causing default `helm lint`/`helm template` to reference a non-published tag.
- Default local rendering should use a plausible published tag while preserving the rule that staging/prod sign-off must use immutable `main-<shortsha>` tags or digests.

### Description
- Change `charts/danielsmith/values.yaml` to set `image.tag: main-latest` and update the adjacent comment to explain `main-latest` is only a local rendering/linting convenience and that Sugarkube staging/prod must provide an immutable `main-<shortsha>` or `image.digest` override.
- Tighten the Helm CI guard in `.github/workflows/ci-helm.yml` to allow `main-latest` or `main-<shortsha>` (regex `^main-[0-9a-f]{7,40}$`) and explicitly reject bare `main` with a helpful error message.
- Files changed: `charts/danielsmith/values.yaml` and `.github/workflows/ci-helm.yml`.

### Testing
- Ran formatting and repo checks: `npm run format:write` (passed), `npm run lint` (passed), `npm run docs:check` (passed), and `npm run smoke` (passed).
- Ran unit tests: `npm run test:ci` (Vitest: 126 test files, 826 tests — all passed).
- Helm validations: installed Helm, `helm lint charts/danielsmith` (passed) and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` (rendered successfully), and verified `grep -n "tag: main-latest" charts/danielsmith/values.yaml` shows the new default.
- Guard smoke tests: evaluated candidates and observed `main` -> rejected, `main-latest` -> allowed, `main-deadbee` -> allowed, confirming the CI guard behavior.
- Secret scans: `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bd52a2f0832fa272168bddd077a7)