### PR TITLE
Make Helm chart publishing safe for existing OCI versions

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -21,10 +21,13 @@ jobs:
       chart_version: ${{ steps.package.outputs.chart_version }}
       package_path: ${{ steps.package.outputs.package_path }}
       chart_ref: ${{ steps.chart_meta.outputs.chart_ref }}
+      chart_changed: ${{ steps.chart_changes.outputs.chart_changed }}
     steps:
       - name: Checkout triggering commit
         if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Checkout selected ref
         if: github.event_name == 'workflow_dispatch'
@@ -34,6 +37,39 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
+
+      - name: Detect chart-relevant changes
+        id: chart_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_changed=false
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            before="${{ github.event.before }}"
+            after="${{ github.sha }}"
+
+            if [[ "$before" =~ ^0+$ ]]; then
+              echo "Push has no previous commit; treating chart as changed."
+              chart_changed=true
+            else
+              git fetch --no-tags --depth=1 origin "$before" || true
+              changed_paths=$(git diff --name-only "$before" "$after" -- \
+                charts/danielsmith \
+                .github/workflows/ci-helm.yml)
+              if [ -n "$changed_paths" ]; then
+                chart_changed=true
+                echo "Chart-relevant changes detected:"
+                echo "$changed_paths"
+              else
+                echo "No chart-relevant changes detected."
+              fi
+            fi
+          else
+            echo "${{ github.event_name }} does not require push change detection."
+          fi
+
+          echo "chart_changed=$chart_changed" >> "$GITHUB_OUTPUT"
 
       - name: Set expected chart reference
         id: chart_meta
@@ -158,7 +194,7 @@ jobs:
             --username "${{ github.actor }}" \
             --password-stdin
 
-      - name: Publish OCI chart
+      - name: Publish or skip OCI chart
         id: publish
         shell: bash
         run: |
@@ -166,11 +202,48 @@ jobs:
           chart_ref="${{ needs.helm-validate.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
           chart_version="${{ needs.helm-validate.outputs.chart_version }}"
+          chart_changed="${{ needs.helm-validate.outputs.chart_changed }}"
+          event_name="${{ github.event_name }}"
+
+          echo "Chart reference: \`${chart_ref}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Chart version: \`${chart_version}\`" >> "$GITHUB_STEP_SUMMARY"
 
           if helm show chart "${chart_ref}" --version "${chart_version}" >/dev/null 2>&1; then
-            echo "Chart version already exists at ${chart_ref}:${chart_version}." >&2
-            echo "Please bump charts/danielsmith/Chart.yaml version before publishing again." >&2
-            exit 1
+            if [ "$event_name" = "push" ] && [ "$chart_changed" = "true" ]; then
+              echo "Chart publication failed." >> "$GITHUB_STEP_SUMMARY"
+              echo "Version \`${chart_version}\` already exists after chart-relevant changes." \
+                >> "$GITHUB_STEP_SUMMARY"
+              echo "Bump \`charts/danielsmith/Chart.yaml\` version before publishing." \
+                >> "$GITHUB_STEP_SUMMARY"
+              echo "Chart version already exists at ${chart_ref}:${chart_version}." >&2
+              echo "Please bump charts/danielsmith/Chart.yaml version before publishing again." >&2
+              exit 1
+            fi
+
+            echo "chart_status=skipped" >> "$GITHUB_OUTPUT"
+            echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+            echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
+            echo "Chart publication skipped." >> "$GITHUB_STEP_SUMMARY"
+            echo "Version \`${chart_version}\` already exists and will not be overwritten." \
+              >> "$GITHUB_STEP_SUMMARY"
+            if [ "$event_name" = "push" ]; then
+              echo "No chart-relevant changes were detected for this push." \
+                >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "Manual dispatch found an existing immutable chart version." \
+                >> "$GITHUB_STEP_SUMMARY"
+            fi
+            exit 0
+          fi
+
+          if [ "$event_name" = "push" ] && [ "$chart_changed" != "true" ]; then
+            echo "chart_status=skipped" >> "$GITHUB_OUTPUT"
+            echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+            echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
+            echo "Chart publication skipped." >> "$GITHUB_STEP_SUMMARY"
+            echo "No chart-relevant changes were detected for this push." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           mapfile -t packages < <(find . -maxdepth 2 -type f -name "danielsmith-*.tgz" | sort)
@@ -182,12 +255,8 @@ jobs:
           package_path="${packages[0]}"
           helm push "$package_path" "$chart_registry"
 
+          echo "chart_status=published" >> "$GITHUB_OUTPUT"
           echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
           echo "chart_ref=$chart_ref" >> "$GITHUB_OUTPUT"
-
-      - name: Summarize published chart
-        run: |
-          echo "Published chart reference:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`${{ steps.publish.outputs.chart_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "Published chart version:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`${{ steps.publish.outputs.chart_version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published chart reference: \`${chart_ref}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published chart version: \`${chart_version}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Prevent harmless pushes to `main` (docs/metadata only) from failing when the Helm chart version already exists in GHCR.
- Preserve OCI immutability by ensuring chart versions are never overwritten and authors must bump `charts/danielsmith/Chart.yaml` when chart content changes.
- Keep PR validation unchanged while allowing `workflow_dispatch` to validate and publish when appropriate.

### Description
- Add a `Detect chart-relevant changes` step that sets `chart_changed` for pushes by diffing `charts/danielsmith/**` and `.github/workflows/ci-helm.yml` and expose it as a `helm-validate` output (`chart_changed`).
- Use full-history checkout (`fetch-depth: 0`) for push change detection and wire `chart_changed` into the publish logic to gate publishing.
- Replace the publish step with `Publish or skip OCI chart` that branches into three outcomes: publish (missing version), skip (no chart changes or existing identical version), and fail (chart changed but chart version already exists), and emit clear GitHub step-summary messages for each path.
- Preserve existing `helm lint`, `helm template`, `helm package`, artifact upload, GHCR auth, and `packages: write` permission scope; do not change the chart registry path or write permissions.

### Testing
- Ran `npm run format:write` and it completed successfully. ✅
- Ran `npm run lint` and it completed successfully. ✅
- Ran `npm run test:ci` and all tests passed (`826 passed`). ✅
- Ran `npm run docs:check` and it passed. ✅
- Ran `npm run smoke` (build + `scripts/assert-dist.cjs`) and the smoke check passed. ✅
- Installed Helm and ran `helm lint charts/danielsmith` and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee`, both of which completed successfully. ✅
- Ran repository checks `git diff --check` and `git diff | ./scripts/scan-secrets.py` and no issues were found. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18c4c785a8832f8f2bc5bda002bbd1)