### PR TITLE
Fix orthographic zoom afterimages and motion-blur semantics

### DIFF
--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -1,0 +1,35 @@
+{
+  "id": "2026-05-28-danielsmith-staging-zoom-fallback",
+  "title": "staging.danielsmith.io zoom afterimage and fallback incident",
+  "date": "2026-05-28",
+  "environment": "staging.danielsmith.io on Sugarkube",
+  "component": "immersive Three.js renderer and postprocessing chain",
+  "symptoms": [
+    "Mouse-wheel zoom caused visible frame persistence and duplicated scene geometry.",
+    "Old orthographic camera projections appeared stacked over the current scene."
+  ],
+  "impact": "Staging immersive zoom and pan interactions were visually corrupted and could make the experience appear broken.",
+  "detection": "A user reproduced the issue during normal staging zoom testing.",
+  "keyObservation": "Setting the in-app motion blur slider to zero did not eliminate the bug.",
+  "rootCause": "AfterimagePass remained in the default composer path and the controller mapped intensity 0 to damp 1. Three.js AfterimageShader preserves old frame pixels at higher damp values, so the zero setting kept stale feedback instead of clearing it.",
+  "correctiveActions": [
+    "Map zero intensity to damp 0 and disable the pass at zero.",
+    "Reset afterimage feedback history when disabling or re-enabling the effect.",
+    "Invalidate feedback history on camera zoom, pan, and projection changes.",
+    "Remove AfterimagePass from the default composer path while preserving bloom and the accessibility UI.",
+    "Default base motion blur intensity to 0 unless a persisted user preference says otherwise."
+  ],
+  "regressionTests": [
+    "src/tests/motionBlurController.test.ts verifies no-op zero intensity, clamping, damp mapping, and history resets.",
+    "playwright/immersive-zoom.spec.ts verifies immersive mode remains active during wheel zoom with disablePerformanceFailover=1 and zero motion blur stays clean."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"zoom\"",
+    "npm run smoke"
+  ],
+  "deploymentNotes": "Deploy the patch to staging, then validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 with repeated wheel zoom in/out and the motion blur slider at zero."
+}

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -1,0 +1,75 @@
+# staging.danielsmith.io zoom afterimage and fallback incident
+
+- **Date:** 2026-05-28
+- **Environment:** staging.danielsmith.io on Sugarkube
+- **Component:** immersive Three.js renderer and postprocessing chain
+- **Status:** Corrective patch prepared on 2026-05-29
+
+## Symptoms
+
+The immersive scene loaded normally at first, but mouse-wheel zooming caused previous
+full-scene orthographic frames to remain visible. Users saw stacked or duplicated room
+geometry, as if old camera projections were composited over the current frame.
+
+## Impact
+
+The corruption made normal zoom and pan interactions visually unreliable in staging and
+could make the immersive experience appear broken. The text fallback itself was not removed,
+but zoom-related rendering instability increased the risk of users interpreting the
+experience as failed.
+
+## Detection
+
+A user reproduced the issue on staging.danielsmith.io while exercising normal mouse-wheel
+zoom. The key observation was that setting the in-app motion blur slider to zero did **not**
+eliminate the duplicated-frame symptom, proving the issue was not just an overly aggressive
+default slider value.
+
+## Root cause
+
+The renderer always added Three.js `AfterimagePass` after the render and bloom passes. The
+motion blur controller inverted `AfterimagePass` semantics: intensity `0` mapped to damp `1`,
+but `AfterimageShader` multiplies the old frame by `damp` and composites `max(new, old)`, so
+`damp: 1` preserves old bright scene pixels instead of clearing them. The pass also remained
+active at zero intensity, so stale feedback buffers could continue participating after users
+turned motion blur off.
+
+Orthographic zoom and camera projection changes made the stale feedback obvious because old
+full-scene projections no longer aligned with the new camera scale.
+
+## Corrective action
+
+- Corrected motion blur damp mapping so intensity `0` maps to `damp: 0`.
+- Disabled the afterimage pass when effective intensity is zero.
+- Added feedback-history reset behavior for zero-intensity transitions and camera changes.
+- Removed the afterimage pass from the default `EffectComposer` path so the default immersive
+  renderer keeps bloom but does not apply scene-wide feedback by default.
+- Changed the accessibility preset manager's default base motion blur intensity to `0`, while
+  preserving persisted user preferences and the slider state.
+
+## Regression tests
+
+- Vitest coverage now verifies zero-intensity no-op behavior, finite clamping, corrected damp
+  mapping, history resets, and nonzero-to-zero toggles for `createMotionBlurController`.
+- Playwright coverage loads `/?mode=immersive&disablePerformanceFailover=1`, asserts the
+  immersive canvas remains active, dispatches repeated wheel zoom events, verifies the text
+  fallback is not exposed, and confirms zero motion blur stays disabled with `damp: 0`.
+
+## Deployment and validation notes
+
+Validate the staging deployment with the immersive override URL:
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "zoom"
+npm run smoke
+```
+
+Manual validation should load
+`https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1`, zoom in and
+out with the mouse wheel, set the motion blur slider to zero, and repeat the zoom sequence.
+Expected result: a single clean immersive canvas with no retained prior scene projections and
+no unintended text fallback.

--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+
+type MotionBlurState = {
+  intensity: number;
+  damp: number;
+  enabled: boolean;
+  resetCount: number;
+};
+
+type ZoomSnapshot = {
+  appMode?: string;
+  appDataMode?: string;
+  canvasCount: number;
+  motionBlur: MotionBlurState;
+};
+
+async function waitForImmersiveReady(page: Page) {
+  await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+}
+
+async function getMotionBlurState(page: Page): Promise<MotionBlurState> {
+  return await page.evaluate(() => {
+    const state = window.portfolio?.graphics?.getMotionBlurState?.();
+    if (!state) {
+      throw new Error('Motion blur graphics test hook unavailable');
+    }
+    return state;
+  });
+}
+
+async function setMotionBlurIntensity(page: Page, value: number) {
+  await page.evaluate((nextValue) => {
+    const input = document.querySelector<HTMLInputElement>(
+      '#motion-blur-slider'
+    );
+    if (!input) {
+      throw new Error('Motion blur slider unavailable');
+    }
+    input.value = String(nextValue);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }, value);
+}
+
+async function dispatchWheelZoomSnapshot(page: Page): Promise<ZoomSnapshot> {
+  return await page.evaluate(() => {
+    const canvas = document.querySelector('canvas');
+    if (!canvas) {
+      throw new Error('Immersive canvas unavailable');
+    }
+    for (const deltaY of [-240, -180, 220, 180, -120, 160]) {
+      canvas.dispatchEvent(
+        new WheelEvent('wheel', { deltaY, bubbles: true, cancelable: true })
+      );
+    }
+    const motionBlur = window.portfolio?.graphics?.getMotionBlurState?.();
+    if (!motionBlur) {
+      throw new Error('Motion blur graphics test hook unavailable');
+    }
+    return {
+      appMode: document.documentElement.dataset.appMode,
+      appDataMode:
+        document.querySelector('#app')?.getAttribute('data-mode') ?? undefined,
+      canvasCount: document.querySelectorAll('canvas').length,
+      motionBlur,
+    };
+  });
+}
+
+test.describe('immersive orthographic zoom', () => {
+  test('does not leave afterimage history or reveal text fallback while zooming', async ({
+    page,
+  }) => {
+    await waitForImmersiveReady(page);
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'immersive'
+    );
+    await expect(page.locator('canvas')).toHaveCount(1);
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+    await expect(page.locator('#app[data-mode="text"]')).toHaveCount(0);
+
+    await setMotionBlurIntensity(page, 0);
+    const disabledBeforeZoom = await getMotionBlurState(page);
+    expect(disabledBeforeZoom.intensity).toBe(0);
+    expect(disabledBeforeZoom.enabled).toBe(false);
+    expect(disabledBeforeZoom.damp).toBe(0);
+
+    const disabledZoomSnapshot = await dispatchWheelZoomSnapshot(page);
+    expect(disabledZoomSnapshot.appMode).toBe('immersive');
+    expect(disabledZoomSnapshot.appDataMode).not.toBe('text');
+    expect(disabledZoomSnapshot.canvasCount).toBe(1);
+    expect(disabledZoomSnapshot.motionBlur.intensity).toBe(0);
+    expect(disabledZoomSnapshot.motionBlur.enabled).toBe(false);
+    expect(disabledZoomSnapshot.motionBlur.damp).toBe(0);
+
+    await setMotionBlurIntensity(page, 0.6);
+    const reenabledBeforeZero = await getMotionBlurState(page);
+    expect(reenabledBeforeZero.damp).toBeGreaterThan(0);
+    expect(reenabledBeforeZero.damp).toBeLessThan(1);
+
+    await setMotionBlurIntensity(page, 0);
+    const clearedAfterToggle = await getMotionBlurState(page);
+    expect(clearedAfterToggle.intensity).toBe(0);
+    expect(clearedAfterToggle.enabled).toBe(false);
+    expect(clearedAfterToggle.damp).toBe(0);
+    expect(clearedAfterToggle.resetCount).toBeGreaterThan(
+      reenabledBeforeZero.resetCount
+    );
+
+    const clearedZoomSnapshot = await dispatchWheelZoomSnapshot(page);
+    expect(clearedZoomSnapshot.appMode).toBe('immersive');
+    expect(clearedZoomSnapshot.appDataMode).not.toBe('text');
+    expect(clearedZoomSnapshot.canvasCount).toBe(1);
+    expect(clearedZoomSnapshot.motionBlur.intensity).toBe(0);
+    expect(clearedZoomSnapshot.motionBlur.enabled).toBe(false);
+    expect(clearedZoomSnapshot.motionBlur.damp).toBe(0);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -410,6 +410,14 @@ declare global {
         }>;
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
+      graphics?: {
+        getMotionBlurState(): {
+          intensity: number;
+          damp: number;
+          enabled: boolean;
+          resetCount: number;
+        };
+      };
       world?: {
         getActiveFloor(): FloorId;
         setActiveFloor(next: FloorId): void;
@@ -2584,8 +2592,15 @@ function initializeImmersiveScene(
   updatePlayerVerticalPosition();
   document.documentElement.dataset.activeFloor = activeFloorId;
 
+  let resetMotionBlurHistoryForCameraChange = () => {};
+  let resumeMotionBlurAfterCameraChange = () => {};
+
   const setCameraZoomTarget = (next: number) => {
-    cameraZoomTarget = MathUtils.clamp(next, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM);
+    const clamped = MathUtils.clamp(next, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM);
+    if (Math.abs(clamped - cameraZoomTarget) > 1e-4) {
+      resetMotionBlurHistoryForCameraChange();
+    }
+    cameraZoomTarget = clamped;
   };
 
   const updateCameraPanLimits = (aspect: number) => {
@@ -2622,6 +2637,7 @@ function initializeImmersiveScene(
     camera.bottom = -baseCameraSize;
     camera.zoom = cameraZoom;
     camera.updateProjectionMatrix();
+    resetMotionBlurHistoryForCameraChange();
     updateCameraPanLimits(aspect);
   };
 
@@ -2995,9 +3011,47 @@ function initializeImmersiveScene(
     composer.addPass(bloomPass);
   }
 
-  motionBlurController = createMotionBlurController({ intensity: 0.6 });
-  composer.addPass(motionBlurController.pass);
-  motionBlurController.pass.renderToScreen = true;
+  motionBlurController = createMotionBlurController();
+  let motionBlurResumeDeadline = 0;
+  let lastCameraMotionBlurReset = 0;
+  resetMotionBlurHistoryForCameraChange = () => {
+    if (!motionBlurController || motionBlurController.getIntensity() <= 0) {
+      return;
+    }
+    const now = window.performance.now();
+    if (now - lastCameraMotionBlurReset > 120) {
+      motionBlurController.resetHistory();
+      lastCameraMotionBlurReset = now;
+    }
+    motionBlurController.pass.enabled = false;
+    motionBlurResumeDeadline = now + 180;
+  };
+  resumeMotionBlurAfterCameraChange = () => {
+    if (!motionBlurController || motionBlurController.getIntensity() <= 0) {
+      return;
+    }
+    if (motionBlurController.pass.enabled !== false) {
+      return;
+    }
+    if (window.performance.now() < motionBlurResumeDeadline) {
+      return;
+    }
+    motionBlurController.resetHistory();
+    motionBlurController.pass.enabled = true;
+  };
+  if (!window.portfolio) {
+    window.portfolio = {};
+  }
+  window.portfolio.graphics = {
+    getMotionBlurState() {
+      return {
+        intensity: motionBlurController?.getIntensity() ?? 0,
+        damp: motionBlurController?.pass.uniforms.damp.value ?? 0,
+        enabled: motionBlurController?.isEnabled() ?? false,
+        resetCount: motionBlurController?.getResetCount() ?? 0,
+      };
+    },
+  };
 
   let qualityStorage: Storage | undefined;
   try {
@@ -3353,6 +3407,9 @@ function initializeImmersiveScene(
       cameraInput.y * cameraPanLimitZ
     );
 
+    const previousPanX = cameraPan.x;
+    const previousPanZ = cameraPan.z;
+
     cameraPan.x = MathUtils.damp(
       cameraPan.x,
       cameraPanTarget.x,
@@ -3376,6 +3433,13 @@ function initializeImmersiveScene(
       -cameraPanLimitZ,
       cameraPanLimitZ
     );
+
+    if (
+      Math.abs(cameraPan.x - previousPanX) > 1e-4 ||
+      Math.abs(cameraPan.z - previousPanZ) > 1e-4
+    ) {
+      resetMotionBlurHistoryForCameraChange();
+    }
 
     cameraCenter.set(
       player.position.x + cameraPan.x,
@@ -3691,6 +3755,9 @@ function initializeImmersiveScene(
     if (motionBlurControl) {
       motionBlurControl.dispose();
       motionBlurControl = null;
+    }
+    if (window.portfolio?.graphics) {
+      delete window.portfolio.graphics;
     }
     if (footstepAudio) {
       if (footstepAudio.isPlaying) {
@@ -4021,6 +4088,7 @@ function initializeImmersiveScene(
       if (selfieMirror) {
         selfieMirror.render(renderer, scene);
       }
+      resumeMotionBlurAfterCameraChange();
       if (composer) {
         composer.render();
       } else {

--- a/src/scene/graphics/motionBlurController.ts
+++ b/src/scene/graphics/motionBlurController.ts
@@ -1,4 +1,4 @@
-import { MathUtils } from 'three';
+import { Color, MathUtils, WebGLRenderTarget, WebGLRenderer } from 'three';
 import { AfterimagePass } from 'three/examples/jsm/postprocessing/AfterimagePass.js';
 
 export interface MotionBlurControllerOptions {
@@ -12,14 +12,22 @@ export interface MotionBlurControllerOptions {
    * disable trails entirely.
    */
   readonly maxDamp?: number;
+  /** Renderer used to clear AfterimagePass feedback buffers when history is invalidated. */
+  readonly renderer?: WebGLRenderer;
 }
 
 export interface MotionBlurController {
   readonly pass: AfterimagePass;
   /** Returns the currently applied intensity between 0 and 1. */
   getIntensity(): number;
+  /** Returns whether the afterimage pass is active in the composer chain. */
+  isEnabled(): boolean;
+  /** Returns how many times the feedback buffers have been invalidated. */
+  getResetCount(): number;
   /** Updates the motion blur intensity and corresponding pass uniforms. */
   setIntensity(intensity: number): void;
+  /** Clears stale afterimage history after projection/camera changes. */
+  resetHistory(): void;
   /** Disposes the underlying pass resources. */
   dispose(): void;
 }
@@ -39,22 +47,65 @@ function clamp01(value: number): number {
   return value;
 }
 
+function resolveMaxDamp(value: number): number {
+  const clamped = clamp01(value);
+  return clamped > 0 ? clamped : DEFAULT_MAX_DAMP;
+}
+
 function resolveDampValue(intensity: number, maxDamp: number): number {
   const clamped = clamp01(intensity);
-  // Damp of 1 disables trails entirely; lower values extend the afterimage.
-  return MathUtils.lerp(1, maxDamp, clamped);
+  // AfterimageShader multiplies the old frame by damp before max(new, old).
+  // Damp 0 clears history, while higher damp values preserve longer trails.
+  return MathUtils.lerp(0, maxDamp, clamped);
+}
+
+function clearRenderTarget(renderer: WebGLRenderer, target: WebGLRenderTarget) {
+  const previousTarget = renderer.getRenderTarget();
+  const previousAlpha = renderer.getClearAlpha();
+  const previousColor = renderer.getClearColor(new Color());
+
+  renderer.setClearColor(0x000000, 0);
+  renderer.setRenderTarget(target);
+  renderer.clear(true, true, true);
+  renderer.setRenderTarget(previousTarget);
+  renderer.setClearColor(previousColor, previousAlpha);
 }
 
 export function createMotionBlurController({
-  intensity = 0.6,
+  intensity = 0,
   maxDamp = DEFAULT_MAX_DAMP,
+  renderer,
 }: MotionBlurControllerOptions = {}): MotionBlurController {
-  const pass = new AfterimagePass(maxDamp);
+  const resolvedMaxDamp = resolveMaxDamp(maxDamp);
+  const pass = new AfterimagePass(resolvedMaxDamp);
   let currentIntensity = 0;
+  let resetCount = 0;
+
+  const resetHistory = () => {
+    resetCount += 1;
+    pass.uniforms.tOld.value = null;
+    pass.uniforms.tNew.value = null;
+
+    if (!renderer) {
+      return;
+    }
+
+    clearRenderTarget(renderer, pass.textureOld);
+    clearRenderTarget(renderer, pass.textureComp);
+  };
 
   const applyIntensity = (value: number) => {
+    const previousIntensity = currentIntensity;
     currentIntensity = clamp01(value);
-    pass.uniforms.damp.value = resolveDampValue(currentIntensity, maxDamp);
+    pass.uniforms.damp.value = resolveDampValue(
+      currentIntensity,
+      resolvedMaxDamp
+    );
+    pass.enabled = currentIntensity > 0;
+
+    if (currentIntensity <= 0 || previousIntensity <= 0) {
+      resetHistory();
+    }
   };
 
   applyIntensity(intensity);
@@ -64,9 +115,16 @@ export function createMotionBlurController({
     getIntensity() {
       return currentIntensity;
     },
+    isEnabled() {
+      return pass.enabled !== false;
+    },
+    getResetCount() {
+      return resetCount;
+    },
     setIntensity(value) {
       applyIntensity(value);
     },
+    resetHistory,
     dispose() {
       pass.dispose();
     },

--- a/src/tests/accessibilityPresetManager.test.ts
+++ b/src/tests/accessibilityPresetManager.test.ts
@@ -35,9 +35,12 @@ function createMotionBlurStub(): MotionBlurController {
   return {
     pass: {} as MotionBlurController['pass'],
     getIntensity: vi.fn(() => intensity),
+    isEnabled: vi.fn(() => intensity > 0),
+    getResetCount: vi.fn(() => 0),
     setIntensity: vi.fn((value: number) => {
       intensity = value;
     }),
+    resetHistory: vi.fn(),
     dispose: vi.fn(),
   };
 }
@@ -114,9 +117,7 @@ describe('createAccessibilityPresetManager', () => {
     expect(document.documentElement.dataset.accessibilityFlickerScale).toBe(
       '0.55'
     );
-    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe(
-      '0.25'
-    );
+    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe('0');
     expect(bloomPass.enabled).toBe(true);
     expect(bloomPass.strength).toBeCloseTo(0.9, 5);
     expect(bloomPass.radius).toBeCloseTo(0.81, 5);
@@ -124,7 +125,7 @@ describe('createAccessibilityPresetManager', () => {
     expect(ledMaterial.emissiveIntensity).toBeCloseTo(0.75, 5);
     expect(ledLight.intensity).toBeCloseTo(0.8, 5);
     expect(masterVolume).toBeCloseTo(0.8, 5);
-    expect(motionBlur.setIntensity).toHaveBeenCalledWith(0.25);
+    expect(motionBlur.setIntensity).toHaveBeenCalledWith(0);
 
     manager.dispose();
     restoreDataset();
@@ -181,7 +182,7 @@ describe('createAccessibilityPresetManager', () => {
       JSON.stringify({
         presetId: 'photosensitive',
         baseAudioVolume: 0.5,
-        baseMotionBlurIntensity: 1,
+        baseMotionBlurIntensity: 0,
       })
     );
     expect(document.documentElement.dataset.accessibilityContrast).toBe('high');
@@ -204,7 +205,7 @@ describe('createAccessibilityPresetManager', () => {
       JSON.stringify({
         presetId: 'photosensitive',
         baseAudioVolume: 0.9,
-        baseMotionBlurIntensity: 1,
+        baseMotionBlurIntensity: 0,
       })
     );
 
@@ -264,9 +265,7 @@ describe('createAccessibilityPresetManager', () => {
     expect(document.documentElement.dataset.accessibilityFlickerScale).toBe(
       '1'
     );
-    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe(
-      '0.6'
-    );
+    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe('0');
     expect(bloomPass.enabled).toBe(true);
     expect(bloomPass.strength).toBeCloseTo(1.32, 5);
     expect(bloomPass.radius).toBeCloseTo(0.95, 5);

--- a/src/tests/motionBlurController.test.ts
+++ b/src/tests/motionBlurController.test.ts
@@ -1,33 +1,101 @@
+import { Color } from 'three';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createMotionBlurController } from '../scene/graphics/motionBlurController';
 
 describe('createMotionBlurController', () => {
-  it('applies the initial intensity and updates the damp uniform', () => {
-    const controller = createMotionBlurController({ intensity: 0.5 });
+  it('starts disabled at zero intensity with a clearing damp value', () => {
+    const controller = createMotionBlurController({ intensity: 0 });
 
-    expect(controller.getIntensity()).toBeCloseTo(0.5, 5);
-    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.96, 5);
-
-    controller.setIntensity(0.25);
-    expect(controller.getIntensity()).toBeCloseTo(0.25, 5);
-    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.98, 5);
+    expect(controller.getIntensity()).toBe(0);
+    expect(controller.isEnabled()).toBe(false);
+    expect(controller.pass.enabled).toBe(false);
+    expect(controller.pass.uniforms.damp.value).toBe(0);
+    expect(controller.getResetCount()).toBeGreaterThanOrEqual(1);
 
     controller.dispose();
   });
 
-  it('clamps out-of-range intensity values and respects max damp overrides', () => {
+  it('maps nonzero intensity to AfterimagePass damp without inverting semantics', () => {
+    const controller = createMotionBlurController({ intensity: 0.5 });
+
+    expect(controller.getIntensity()).toBeCloseTo(0.5, 5);
+    expect(controller.isEnabled()).toBe(true);
+    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.46, 5);
+
+    controller.setIntensity(0.25);
+    expect(controller.getIntensity()).toBeCloseTo(0.25, 5);
+    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.23, 5);
+
+    controller.dispose();
+  });
+
+  it('clamps invalid and out-of-range intensity values safely', () => {
     const controller = createMotionBlurController({
-      intensity: 2,
+      intensity: Number.POSITIVE_INFINITY,
       maxDamp: 0.8,
     });
 
+    expect(controller.getIntensity()).toBe(0);
+    expect(controller.isEnabled()).toBe(false);
+    expect(controller.pass.uniforms.damp.value).toBe(0);
+
+    controller.setIntensity(2);
     expect(controller.getIntensity()).toBe(1);
+    expect(controller.isEnabled()).toBe(true);
     expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.8, 5);
 
-    controller.setIntensity(-0.4);
+    controller.setIntensity(Number.NaN);
     expect(controller.getIntensity()).toBe(0);
-    expect(controller.pass.uniforms.damp.value).toBe(1);
+    expect(controller.isEnabled()).toBe(false);
+    expect(controller.pass.uniforms.damp.value).toBe(0);
+
+    controller.dispose();
+  });
+
+  it('clears feedback history when toggling from nonzero to zero', () => {
+    const renderer = {
+      clear: vi.fn(),
+      getClearAlpha: vi.fn(() => 1),
+      getClearColor: vi.fn((target: Color) => target.set(0xffffff)),
+      getRenderTarget: vi.fn(() => null),
+      setClearColor: vi.fn(),
+      setRenderTarget: vi.fn(),
+    };
+    const controller = createMotionBlurController({
+      intensity: 0.6,
+      renderer: renderer as never,
+    });
+    const resetsBeforeZero = controller.getResetCount();
+
+    controller.setIntensity(0);
+
+    expect(controller.getIntensity()).toBe(0);
+    expect(controller.isEnabled()).toBe(false);
+    expect(controller.pass.uniforms.tOld.value).toBeNull();
+    expect(controller.pass.uniforms.tNew.value).toBeNull();
+    expect(controller.getResetCount()).toBe(resetsBeforeZero + 1);
+    expect(renderer.clear).toHaveBeenCalledTimes(4);
+    expect(renderer.setRenderTarget).toHaveBeenCalledWith(
+      controller.pass.textureOld
+    );
+    expect(renderer.setRenderTarget).toHaveBeenCalledWith(
+      controller.pass.textureComp
+    );
+
+    controller.dispose();
+  });
+
+  it('clears stale history before re-enabling a previously disabled pass', () => {
+    const controller = createMotionBlurController({ intensity: 0.6 });
+
+    controller.setIntensity(0);
+    const resetsBeforeEnable = controller.getResetCount();
+    controller.setIntensity(0.4);
+
+    expect(controller.isEnabled()).toBe(true);
+    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.368, 5);
+    expect(controller.getResetCount()).toBe(resetsBeforeEnable + 1);
 
     controller.dispose();
   });

--- a/src/ui/accessibility/presetManager.ts
+++ b/src/ui/accessibility/presetManager.ts
@@ -352,7 +352,7 @@ export function createAccessibilityPresetManager({
   let baseAudioVolume = clamp01(
     ambientAudioController?.getMasterVolume?.() ?? 1
   );
-  let baseMotionBlurIntensity = 1;
+  let baseMotionBlurIntensity = 0;
   let presetId: AccessibilityPresetId = 'standard';
 
   if (storage?.getItem) {


### PR DESCRIPTION
### Motivation
- Zooming the orthographic immersive scene left prior full-scene frames visible because the AfterimagePass feedback was preserved when it should have been cleared. 
- The existing controller inverted damp semantics so intensity `0` preserved history, and the pass remained active at zero, exposing stale frames during camera zoom/pan. 
- The goal is to ensure zero motion blur is a true no-op, clear stale history on camera changes, and keep the immersive renderer clean by default. 

### Description
- Corrected `createMotionBlurController` to map intensity→damp properly (zero intensity → `damp: 0`), disable the pass at zero, clamp invalid values, and add `resetHistory()` and reset-count tracking; optionally clear GPU feedback textures using the renderer when provided (`src/scene/graphics/motionBlurController.ts`).
- Removed AfterimagePass from the default composer path and added camera-change/pan hooks that invalidate afterimage history and temporarily suspend/resume the pass around projection changes to avoid visible trails during zoom/pan (`src/main.ts`).
- Defaulted accessibility base motion-blur intensity to `0` while preserving persisted preferences and the accessibility slider contract (`src/ui/accessibility/presetManager.ts`).
- Added unit tests for the motion blur controller (Vitest) and expanded accessibility-preset tests to match the new default behavior (`src/tests/motionBlurController.test.ts`, `src/tests/accessibilityPresetManager.test.ts`).
- Added a Playwright zoom regression test that exercises `/?mode=immersive&disablePerformanceFailover=1`, asserts a single canvas/no text-fallback, toggles motion blur, dispatches wheel events, and validates that zero intensity remains clean (`playwright/immersive-zoom.spec.ts`).
- Created outage records documenting symptoms, root cause, corrective action, regression tests, and validation commands (`outages/2026-05-28-danielsmith-staging-zoom-fallback.md`, `.json`).

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed.
- `npm run typecheck` — failed due to pre-existing repository-wide TS issues unrelated to this patch (reported; not introduced by these changes).
- Unit tests: `npm run test:ci` and focused runs for `motionBlurController` and `accessibilityPresetManager` — all Vitest tests passed.
- E2E: `npm run test:e2e -- --grep "zoom"` — Playwright zoom spec passed after installing Playwright browsers and host deps (the run included `npx playwright install` and `npx playwright install-deps`).
- `npm run docs:check` — passed.
- `npm run smoke` (build + dist assertions) — passed.

Residual notes and follow-ups: Typechecking failures are present in the repo prior to this change and should be addressed separately; Playwright browser/dependency installs are required in CI workers that do not already provision browsers; the AfterimagePass remains available as an opt-in effect via the motion-blur controller API but is not applied by default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a191d160754832f82307602461ccf3b)