### PR TITLE
Fix zoom afterimage frame persistence

### DIFF
--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -1,0 +1,37 @@
+{
+  "title": "staging.danielsmith.io zoom afterimage and fallback incident",
+  "date": "2026-05-28",
+  "environment": "staging.danielsmith.io on Sugarkube",
+  "status": "corrective patch prepared",
+  "symptoms": [
+    "Initial immersive render looked normal.",
+    "Mouse-wheel zoom or camera pan left prior full-scene frames visible as duplicated geometry/trails."
+  ],
+  "impact": "Staging visitors could not reliably validate normal immersive zoom/pan navigation.",
+  "detection": "Manual staging validation reproduced the corruption during wheel zoom.",
+  "keyObservation": "Setting the in-app motion blur slider to zero did not eliminate the bug.",
+  "rootCause": "The postprocessing chain kept AfterimagePass enabled and mapped intensity 0 to damp 1. Three's AfterimageShader retains more previous-frame history as damp increases, so zero intensity preserved stale feedback buffers across orthographic zoom/projection changes.",
+  "correctiveActions": [
+    "Map intensity 0 to damp 0 and disable AfterimagePass at zero intensity.",
+    "Reset/clear afterimage history when toggling intensity to or from zero.",
+    "Reset/clear afterimage history on camera zoom/projection/pan changes when the optional pass is active.",
+    "Start the default immersive experience with motion blur off while preserving the slider as opt-in."
+  ],
+  "regressionTests": [
+    "Vitest coverage for damp mapping, zero no-op behavior, invalid input clamping, and history clearing.",
+    "Playwright zoom test for immersive mode, single canvas, repeated wheel zoom, motion blur zero toggle, and no text fallback."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"zoom\"",
+    "npm run smoke"
+  ],
+  "deploymentValidation": [
+    "Open https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 after deployment.",
+    "Wheel zoom in and out and confirm no duplicated scene geometry remains visible.",
+    "Set motion blur to zero and repeat zooming while confirming the app stays immersive."
+  ]
+}

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -1,0 +1,72 @@
+# staging.danielsmith.io zoom afterimage and fallback incident
+
+- **Date:** 2026-05-28
+- **Environment:** staging.danielsmith.io on Sugarkube
+- **Status:** corrective patch prepared
+
+## Symptoms
+
+The immersive scene rendered cleanly on first load, but mouse-wheel zooming or
+camera panning caused previous full-scene projections to remain visible. The
+result looked like stacked or duplicated room geometry and broad afterimage
+trails instead of a clean orthographic zoom.
+
+## Impact
+
+Visitors testing the staging immersive experience could not reliably inspect the
+3D home. The visual corruption made normal zoom/pan navigation appear broken and
+risked being mistaken for a renderer, asset, or deployment failure.
+
+## Detection
+
+The issue was reported from staging during manual validation. A key observation
+was that setting the in-app motion blur slider to zero did **not** eliminate the
+corruption, which ruled out a simple default-slider-value fix.
+
+## Root cause
+
+The postprocessing chain always appended Three.js `AfterimagePass` after render
+and bloom. The controller treated `damp = 1` as disabled, but Three's
+`AfterimageShader` multiplies the previous frame by `damp` and combines it with
+the new frame, so larger damp values preserve more history. Intensity zero was
+therefore mapped to maximum history retention, and the pass remained enabled with
+stale feedback render targets. Orthographic zoom/projection changes then mixed
+old full-scene projections with the new camera frame.
+
+## Corrective action
+
+- Remapped motion blur intensity so zero maps to `damp = 0` and nonzero values
+  scale upward toward the configured maximum damp.
+- Disabled `AfterimagePass` entirely at intensity zero so it is a true no-op.
+- Added afterimage history reset support and clear retained feedback buffers when
+  intensity changes to/from zero or when camera zoom/projection/pan changes.
+- Started the default immersive experience with motion blur off while preserving
+  the slider as an opt-in trail effect.
+
+## Regression tests
+
+- Vitest coverage now verifies zero intensity disables the pass, invalid values
+  clamp safely, damp mapping follows Three's retention semantics, and history
+  reset clears retained render targets.
+- Playwright zoom coverage loads
+  `/?mode=immersive&disablePerformanceFailover=1`, confirms immersive mode stays
+  active with a single canvas, performs repeated zoom in/out, toggles motion blur
+  from nonzero back to zero, and verifies the afterimage pass is disabled.
+
+## Deployment and validation notes
+
+Validate the patch on staging with:
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "zoom"
+npm run smoke
+```
+
+After deployment, manually open
+`https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1`,
+zoom in and out with the mouse wheel, set motion blur to zero, and repeat zooming
+to confirm clean frames without duplicated geometry or text fallback.

--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_PREVIEW_URL =
+  '/?mode=immersive&disablePerformanceFailover=1&pauseImmersiveAnimationForTests=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+
+type PortfolioWorldApi = {
+  getCameraZoom?: () => number;
+  getCameraZoomTarget?: () => number;
+  getMotionBlurIntensity?: () => number;
+  getMotionBlurPassEnabled?: () => boolean;
+  setMotionBlurIntensity?: (intensity: number) => void;
+};
+
+declare global {
+  interface Window {
+    portfolio?: {
+      world?: PortfolioWorldApi;
+    };
+  }
+}
+
+async function waitForImmersiveReady(page: Page) {
+  await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+}
+
+async function wheelZoom(page: Page, deltaY: number, repetitions = 6) {
+  const canvas = page.locator('#app canvas').first();
+  await expect(canvas).toBeVisible();
+  await page.evaluate(
+    ({ wheelDeltaY, count }) => {
+      const target = document.querySelector<HTMLCanvasElement>('#app canvas');
+      for (let index = 0; index < count; index += 1) {
+        target?.dispatchEvent(
+          new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaY: wheelDeltaY,
+          })
+        );
+      }
+    },
+    { wheelDeltaY: deltaY, count: repetitions }
+  );
+}
+
+test.describe('immersive zoom rendering', () => {
+  test('zooms without fallback or retained afterimage buffers', async ({
+    page,
+  }) => {
+    await waitForImmersiveReady(page);
+
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+    await expect(page.locator('#app[data-mode="text"]')).toHaveCount(0);
+    await expect(page.locator('#app canvas')).toHaveCount(1);
+
+    await page.waitForFunction(() =>
+      Boolean(window.portfolio?.world?.getCameraZoom)
+    );
+
+    const initialState = await page.evaluate(() => ({
+      motionBlurEnabled:
+        window.portfolio?.world?.getMotionBlurPassEnabled?.() ?? true,
+      motionBlurIntensity:
+        window.portfolio?.world?.getMotionBlurIntensity?.() ?? 1,
+      zoom: window.portfolio?.world?.getCameraZoomTarget?.() ?? 0,
+    }));
+    expect(initialState.motionBlurIntensity).toBe(0);
+    expect(initialState.motionBlurEnabled).toBe(false);
+
+    await wheelZoom(page, -240);
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'immersive'
+    );
+    await expect(page.locator('#app[data-mode="text"]')).toHaveCount(0);
+
+    const zoomedIn = await page.evaluate(
+      () => window.portfolio?.world?.getCameraZoomTarget?.() ?? 0
+    );
+    expect(zoomedIn).toBeGreaterThan(initialState.zoom);
+
+    await page.evaluate(() =>
+      window.portfolio?.world?.setMotionBlurIntensity?.(0.7)
+    );
+    await page.waitForFunction(
+      () => window.portfolio?.world?.getMotionBlurPassEnabled?.() === true
+    );
+
+    await page.evaluate(() =>
+      window.portfolio?.world?.setMotionBlurIntensity?.(0)
+    );
+    await page.waitForFunction(
+      () => window.portfolio?.world?.getMotionBlurPassEnabled?.() === false
+    );
+
+    await wheelZoom(page, 240);
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'immersive'
+    );
+    await expect(page.locator('#app[data-mode="text"]')).toHaveCount(0);
+    await expect(page.locator('#app canvas')).toHaveCount(1);
+
+    const finalState = await page.evaluate(() => ({
+      motionBlurEnabled:
+        window.portfolio?.world?.getMotionBlurPassEnabled?.() ?? true,
+      motionBlurIntensity:
+        window.portfolio?.world?.getMotionBlurIntensity?.() ?? 1,
+      zoom: window.portfolio?.world?.getCameraZoomTarget?.() ?? 0,
+    }));
+    expect(finalState.motionBlurIntensity).toBe(0);
+    expect(finalState.motionBlurEnabled).toBe(false);
+    expect(finalState.zoom).toBeLessThan(zoomedIn);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -427,6 +427,11 @@ declare global {
           upperFloorElevation: number;
         };
         getCeilingOpacities(): number[];
+        getCameraZoom(): number;
+        getCameraZoomTarget(): number;
+        getMotionBlurIntensity(): number;
+        getMotionBlurPassEnabled(): boolean;
+        setMotionBlurIntensity(intensity: number): void;
         // Test-only helper: current player yaw in radians
         getPlayerYaw?(): number;
       };
@@ -667,6 +672,9 @@ function initializeImmersiveScene(
   let audioSubtitles: AudioSubtitlesHandle | null = null;
   let ambientCaptionBridge: AmbientCaptionBridge | null = null;
   let graphicsQualityManager: GraphicsQualityManager | null = null;
+  let composer: EffectComposer | null = null;
+  let bloomPass: UnrealBloomPass | null = null;
+  let motionBlurController: MotionBlurController | null = null;
   let graphicsQualityControl: GraphicsQualityControlHandle | null = null;
   let unsubscribeGraphicsQuality: (() => void) | null = null;
   let accessibilityPresetManager: AccessibilityPresetManager | null = null;
@@ -2130,6 +2138,26 @@ function initializeImmersiveScene(
           return material.opacity;
         });
       },
+      getCameraZoom() {
+        return cameraZoom;
+      },
+      getCameraZoomTarget() {
+        return cameraZoomTarget;
+      },
+      getMotionBlurIntensity() {
+        return motionBlurController?.getIntensity() ?? 0;
+      },
+      getMotionBlurPassEnabled() {
+        return motionBlurController?.pass.enabled ?? false;
+      },
+      setMotionBlurIntensity(intensity: number) {
+        if (accessibilityPresetManager) {
+          accessibilityPresetManager.setBaseMotionBlurIntensity(intensity);
+        } else {
+          motionBlurController?.setIntensity(intensity);
+        }
+        motionBlurControl?.refresh();
+      },
     };
   };
   ensureWorldApi();
@@ -2623,6 +2651,7 @@ function initializeImmersiveScene(
     camera.zoom = cameraZoom;
     camera.updateProjectionMatrix();
     updateCameraPanLimits(aspect);
+    motionBlurController?.resetHistory(renderer);
   };
 
   const getPinchDistance = () => {
@@ -2966,10 +2995,6 @@ function initializeImmersiveScene(
     registerHudControlElement(tourResetControl?.element ?? null);
   }
 
-  let composer: EffectComposer | null = null;
-  let bloomPass: UnrealBloomPass | null = null;
-  let motionBlurController: MotionBlurController | null = null;
-
   hudLayoutManager = createHudLayoutManager({
     root: document.documentElement,
     windowTarget: window,
@@ -2995,7 +3020,7 @@ function initializeImmersiveScene(
     composer.addPass(bloomPass);
   }
 
-  motionBlurController = createMotionBlurController({ intensity: 0.6 });
+  motionBlurController = createMotionBlurController({ intensity: 0 });
   composer.addPass(motionBlurController.pass);
   motionBlurController.pass.renderToScreen = true;
 
@@ -3063,7 +3088,6 @@ function initializeImmersiveScene(
     ledAnimator?.captureBaseline();
     environmentLightAnimator?.captureBaseline();
     audioHudHandle?.refresh();
-    motionBlurControl?.refresh();
   }
 
   motionBlurControl = createMotionBlurControl({
@@ -3108,7 +3132,6 @@ function initializeImmersiveScene(
   unsubscribeAccessibility = accessibilityPresetManager.onChange(() => {
     accessibilityControlHandle?.refresh();
     audioHudHandle?.refresh();
-    motionBlurControl?.refresh();
     ledAnimator?.captureBaseline();
     environmentLightAnimator?.captureBaseline();
   });
@@ -3353,6 +3376,9 @@ function initializeImmersiveScene(
       cameraInput.y * cameraPanLimitZ
     );
 
+    const previousPanX = cameraPan.x;
+    const previousPanZ = cameraPan.z;
+
     cameraPan.x = MathUtils.damp(
       cameraPan.x,
       cameraPanTarget.x,
@@ -3376,6 +3402,13 @@ function initializeImmersiveScene(
       -cameraPanLimitZ,
       cameraPanLimitZ
     );
+
+    if (
+      Math.abs(cameraPan.x - previousPanX) > 1e-4 ||
+      Math.abs(cameraPan.z - previousPanZ) > 1e-4
+    ) {
+      motionBlurController?.resetHistory(renderer);
+    }
 
     cameraCenter.set(
       player.position.x + cameraPan.x,
@@ -3840,6 +3873,10 @@ function initializeImmersiveScene(
     gitshelvesInstallation = null;
   }
 
+  const pauseAnimationAfterFirstFrameForTests =
+    new URLSearchParams(window.location.search).get(
+      'pauseImmersiveAnimationForTests'
+    ) === '1';
   let hasPresentedFirstFrame = false;
 
   renderer.setAnimationLoop(() => {
@@ -4030,6 +4067,9 @@ function initializeImmersiveScene(
         hasPresentedFirstFrame = true;
         writeModePreference('immersive');
         markDocumentReady('immersive');
+        if (pauseAnimationAfterFirstFrameForTests) {
+          renderer.setAnimationLoop(null);
+        }
       }
     } catch (error) {
       handleFatalError(error);

--- a/src/scene/graphics/motionBlurController.ts
+++ b/src/scene/graphics/motionBlurController.ts
@@ -1,4 +1,5 @@
-import { MathUtils } from 'three';
+import { Color, MathUtils } from 'three';
+import type { WebGLRenderer, WebGLRenderTarget } from 'three';
 import { AfterimagePass } from 'three/examples/jsm/postprocessing/AfterimagePass.js';
 
 export interface MotionBlurControllerOptions {
@@ -8,8 +9,8 @@ export interface MotionBlurControllerOptions {
   readonly intensity?: number;
   /**
    * Upper bound for the Afterimage dampening uniform. Defaults to 0.92 which
-   * matches the effect's stock configuration while leaving room for presets to
-   * disable trails entirely.
+   * keeps optional trails visible without letting old frames dominate camera
+   * changes. Three's AfterimagePass preserves more history as damp increases.
    */
   readonly maxDamp?: number;
 }
@@ -20,11 +21,25 @@ export interface MotionBlurController {
   getIntensity(): number;
   /** Updates the motion blur intensity and corresponding pass uniforms. */
   setIntensity(intensity: number): void;
+  /** Clears retained afterimage history before the next active render. */
+  resetHistory(renderer?: WebGLRenderer): void;
   /** Disposes the underlying pass resources. */
   dispose(): void;
 }
 
 const DEFAULT_MAX_DAMP = 0.92;
+const DISABLED_DAMP = 0;
+const CLEAR_COLOR = new Color(0, 0, 0);
+
+type RenderTargetRenderer = Pick<
+  WebGLRenderer,
+  | 'clear'
+  | 'getClearAlpha'
+  | 'getClearColor'
+  | 'getRenderTarget'
+  | 'setClearColor'
+  | 'setRenderTarget'
+>;
 
 function clamp01(value: number): number {
   if (!Number.isFinite(value)) {
@@ -39,22 +54,76 @@ function clamp01(value: number): number {
   return value;
 }
 
-function resolveDampValue(intensity: number, maxDamp: number): number {
+function resolveMaxDamp(maxDamp: number): number {
+  return clamp01(maxDamp);
+}
+
+export function resolveDampValue(intensity: number, maxDamp: number): number {
   const clamped = clamp01(intensity);
-  // Damp of 1 disables trails entirely; lower values extend the afterimage.
-  return MathUtils.lerp(1, maxDamp, clamped);
+  if (clamped <= 0) {
+    return DISABLED_DAMP;
+  }
+  // AfterimagePass multiplies the previous frame by damp; higher values keep
+  // more history. Keep intensity 0 as a true no-op and scale upward from there.
+  return MathUtils.lerp(DISABLED_DAMP, resolveMaxDamp(maxDamp), clamped);
+}
+
+function clearRenderTargetHistory(
+  renderer: RenderTargetRenderer,
+  targets: readonly WebGLRenderTarget[]
+) {
+  const previousTarget = renderer.getRenderTarget();
+  const previousColor = renderer.getClearColor(new Color());
+  const previousAlpha = renderer.getClearAlpha();
+
+  renderer.setClearColor(CLEAR_COLOR, 0);
+  for (const target of targets) {
+    renderer.setRenderTarget(target);
+    renderer.clear(true, true, true);
+  }
+  renderer.setClearColor(previousColor, previousAlpha);
+  renderer.setRenderTarget(previousTarget);
 }
 
 export function createMotionBlurController({
-  intensity = 0.6,
+  intensity = 0,
   maxDamp = DEFAULT_MAX_DAMP,
 }: MotionBlurControllerOptions = {}): MotionBlurController {
-  const pass = new AfterimagePass(maxDamp);
+  const resolvedMaxDamp = resolveMaxDamp(maxDamp);
+  const pass = new AfterimagePass(DISABLED_DAMP);
+  const render = pass.render.bind(pass);
   let currentIntensity = 0;
+  let resetPending = true;
+
+  const resetHistory = (renderer?: WebGLRenderer) => {
+    resetPending = true;
+    if (renderer) {
+      clearRenderTargetHistory(renderer, [pass.textureOld, pass.textureComp]);
+      resetPending = false;
+    }
+  };
+
+  pass.render = (renderer, writeBuffer, readBuffer, deltaTime, maskActive) => {
+    if (resetPending) {
+      clearRenderTargetHistory(renderer, [pass.textureOld, pass.textureComp]);
+      resetPending = false;
+    }
+    render(renderer, writeBuffer, readBuffer, deltaTime, maskActive);
+  };
 
   const applyIntensity = (value: number) => {
-    currentIntensity = clamp01(value);
-    pass.uniforms.damp.value = resolveDampValue(currentIntensity, maxDamp);
+    const nextIntensity = clamp01(value);
+    const wasEnabled = pass.enabled;
+    currentIntensity = nextIntensity;
+    pass.uniforms.damp.value = resolveDampValue(
+      currentIntensity,
+      resolvedMaxDamp
+    );
+    pass.enabled = currentIntensity > 0;
+
+    if (!pass.enabled || !wasEnabled) {
+      resetHistory();
+    }
   };
 
   applyIntensity(intensity);
@@ -67,6 +136,7 @@ export function createMotionBlurController({
     setIntensity(value) {
       applyIntensity(value);
     },
+    resetHistory,
     dispose() {
       pass.dispose();
     },

--- a/src/tests/accessibilityPresetManager.test.ts
+++ b/src/tests/accessibilityPresetManager.test.ts
@@ -114,9 +114,7 @@ describe('createAccessibilityPresetManager', () => {
     expect(document.documentElement.dataset.accessibilityFlickerScale).toBe(
       '0.55'
     );
-    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe(
-      '0.25'
-    );
+    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe('0');
     expect(bloomPass.enabled).toBe(true);
     expect(bloomPass.strength).toBeCloseTo(0.9, 5);
     expect(bloomPass.radius).toBeCloseTo(0.81, 5);
@@ -124,7 +122,7 @@ describe('createAccessibilityPresetManager', () => {
     expect(ledMaterial.emissiveIntensity).toBeCloseTo(0.75, 5);
     expect(ledLight.intensity).toBeCloseTo(0.8, 5);
     expect(masterVolume).toBeCloseTo(0.8, 5);
-    expect(motionBlur.setIntensity).toHaveBeenCalledWith(0.25);
+    expect(motionBlur.setIntensity).toHaveBeenCalledWith(0);
 
     manager.dispose();
     restoreDataset();
@@ -181,7 +179,7 @@ describe('createAccessibilityPresetManager', () => {
       JSON.stringify({
         presetId: 'photosensitive',
         baseAudioVolume: 0.5,
-        baseMotionBlurIntensity: 1,
+        baseMotionBlurIntensity: 0,
       })
     );
     expect(document.documentElement.dataset.accessibilityContrast).toBe('high');
@@ -204,7 +202,7 @@ describe('createAccessibilityPresetManager', () => {
       JSON.stringify({
         presetId: 'photosensitive',
         baseAudioVolume: 0.9,
-        baseMotionBlurIntensity: 1,
+        baseMotionBlurIntensity: 0,
       })
     );
 
@@ -264,9 +262,7 @@ describe('createAccessibilityPresetManager', () => {
     expect(document.documentElement.dataset.accessibilityFlickerScale).toBe(
       '1'
     );
-    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe(
-      '0.6'
-    );
+    expect(document.documentElement.dataset.accessibilityMotionBlur).toBe('0');
     expect(bloomPass.enabled).toBe(true);
     expect(bloomPass.strength).toBeCloseTo(1.32, 5);
     expect(bloomPass.radius).toBeCloseTo(0.95, 5);

--- a/src/tests/motionBlurController.test.ts
+++ b/src/tests/motionBlurController.test.ts
@@ -1,33 +1,116 @@
+import { WebGLRenderTarget } from 'three';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createMotionBlurController } from '../scene/graphics/motionBlurController';
+import {
+  createMotionBlurController,
+  resolveDampValue,
+} from '../scene/graphics/motionBlurController';
 
 describe('createMotionBlurController', () => {
-  it('applies the initial intensity and updates the damp uniform', () => {
-    const controller = createMotionBlurController({ intensity: 0.5 });
+  it('disables the AfterimagePass and clears damp at zero intensity', () => {
+    const controller = createMotionBlurController({ intensity: 0 });
 
-    expect(controller.getIntensity()).toBeCloseTo(0.5, 5);
-    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.96, 5);
-
-    controller.setIntensity(0.25);
-    expect(controller.getIntensity()).toBeCloseTo(0.25, 5);
-    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.98, 5);
+    expect(controller.getIntensity()).toBe(0);
+    expect(controller.pass.enabled).toBe(false);
+    expect(controller.pass.uniforms.damp.value).toBe(0);
 
     controller.dispose();
   });
 
-  it('clamps out-of-range intensity values and respects max damp overrides', () => {
+  it('maps intensity upward because larger damp values retain more history', () => {
+    const controller = createMotionBlurController({ intensity: 0.5 });
+
+    expect(controller.getIntensity()).toBeCloseTo(0.5, 5);
+    expect(controller.pass.enabled).toBe(true);
+    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.46, 5);
+
+    controller.setIntensity(0.25);
+    expect(controller.getIntensity()).toBeCloseTo(0.25, 5);
+    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.23, 5);
+
+    controller.dispose();
+  });
+
+  it('clamps out-of-range, invalid intensity values and max damp overrides', () => {
     const controller = createMotionBlurController({
-      intensity: 2,
+      intensity: Number.POSITIVE_INFINITY,
       maxDamp: 0.8,
     });
 
+    expect(controller.getIntensity()).toBe(0);
+    expect(controller.pass.enabled).toBe(false);
+    expect(controller.pass.uniforms.damp.value).toBe(0);
+
+    controller.setIntensity(2);
     expect(controller.getIntensity()).toBe(1);
+    expect(controller.pass.enabled).toBe(true);
     expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.8, 5);
 
-    controller.setIntensity(-0.4);
+    controller.setIntensity(Number.NaN);
     expect(controller.getIntensity()).toBe(0);
-    expect(controller.pass.uniforms.damp.value).toBe(1);
+    expect(controller.pass.enabled).toBe(false);
+    expect(controller.pass.uniforms.damp.value).toBe(0);
+
+    controller.dispose();
+  });
+
+  it('explicitly resolves zero damp for invalid inputs and clamps max damp', () => {
+    expect(resolveDampValue(0, 0.92)).toBe(0);
+    expect(resolveDampValue(Number.NaN, 0.92)).toBe(0);
+    expect(resolveDampValue(1, 2)).toBe(1);
+    expect(resolveDampValue(1, -1)).toBe(0);
+  });
+
+  it('clears retained render targets when history is reset', () => {
+    const controller = createMotionBlurController({ intensity: 0.6 });
+    const previousTarget = new WebGLRenderTarget(1, 1);
+    const renderer = {
+      clear: vi.fn(),
+      getClearAlpha: vi.fn(() => 0.75),
+      getClearColor: vi.fn(
+        (color: { setRGB: (r: number, g: number, b: number) => void }) => {
+          color.setRGB(0.1, 0.2, 0.3);
+          return color;
+        }
+      ),
+      getRenderTarget: vi.fn(() => previousTarget),
+      setClearColor: vi.fn(),
+      setRenderTarget: vi.fn(),
+    };
+
+    controller.resetHistory(renderer as never);
+
+    expect(renderer.setRenderTarget).toHaveBeenCalledWith(
+      controller.pass.textureOld
+    );
+    expect(renderer.setRenderTarget).toHaveBeenCalledWith(
+      controller.pass.textureComp
+    );
+    expect(renderer.clear).toHaveBeenCalledTimes(2);
+    expect(renderer.setRenderTarget).toHaveBeenLastCalledWith(previousTarget);
+    expect(renderer.setClearColor).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isColor: true }),
+      0.75
+    );
+
+    previousTarget.dispose();
+    controller.dispose();
+  });
+
+  it('disables and clears stale feedback when toggling from nonzero to zero', () => {
+    const controller = createMotionBlurController({ intensity: 0.7 });
+
+    expect(controller.pass.enabled).toBe(true);
+
+    controller.setIntensity(0);
+
+    expect(controller.getIntensity()).toBe(0);
+    expect(controller.pass.enabled).toBe(false);
+    expect(controller.pass.uniforms.damp.value).toBe(0);
+
+    controller.setIntensity(0.4);
+    expect(controller.pass.enabled).toBe(true);
+    expect(controller.pass.uniforms.damp.value).toBeCloseTo(0.368, 5);
 
     controller.dispose();
   });

--- a/src/ui/accessibility/presetManager.ts
+++ b/src/ui/accessibility/presetManager.ts
@@ -352,7 +352,7 @@ export function createAccessibilityPresetManager({
   let baseAudioVolume = clamp01(
     ambientAudioController?.getMasterVolume?.() ?? 1
   );
-  let baseMotionBlurIntensity = 1;
+  let baseMotionBlurIntensity = 0;
   let presetId: AccessibilityPresetId = 'standard';
 
   if (storage?.getItem) {


### PR DESCRIPTION
### Motivation
- Wheel zoom/pan left prior full-scene frames visible (stacked/duplicated geometry) because the Afterimage feedback pass retained stale history.  
- The in-app motion-blur slider could be set to zero but did not make the effect a true no-op due to an inverted damp mapping and active feedback render targets.
- Make zero intensity a true no-op, clear retained history on relevant camera changes, and add regression coverage to prevent regressions.

### Description
- Remap intensity→damp semantics and make intensity `0` a true no-op by disabling `AfterimagePass` and mapping to `damp = 0`, and clamp/validate inputs; add `resetHistory` to clear retained render targets. (`src/scene/graphics/motionBlurController.ts`)
- Default the immersive startup to motion blur off and clear afterimage history on projection, zoom, and camera-pan changes so old projections are not blended into new frames. (`src/main.ts`)
- Add test-only world hooks and a query param `pauseImmersiveAnimationForTests=1` to stabilize the E2E regression. (`src/main.ts`, `playwright/immersive-zoom.spec.ts`)
- Set accessibility preset base motion-blur default/stored behavior to preserve opt-in semantics while not enabling trails by default. (`src/ui/accessibility/presetManager.ts`)
- Add/modify Vitest unit coverage for `createMotionBlurController` to assert zero disables pass, clamp behavior, damp mapping, history reset, and disposal. (`src/tests/motionBlurController.test.ts`)
- Add Playwright coverage to exercise immersive mode zoom-in/out, motion-blur toggle to/from zero, and ensure the app remains immersive with a single canvas and no text fallback. (`playwright/immersive-zoom.spec.ts`)
- Document the incident with md + machine-readable json outage records. (`outages/2026-05-28-danielsmith-staging-zoom-fallback.md`, `.json`)

### Testing
- Ran formatting and linting: `npm run format:write` ✅, `npm run lint` ✅.
- Typecheck: `npm run typecheck` — known repository-wide unrelated TypeScript baseline errors remain, so typecheck is not green (pre-existing failures). ❌
- Unit tests: `npm run test:ci` (Vitest) — full suite passed locally (`126` test files, `830` tests reported in run). ✅
- E2E: `npm run test:e2e -- --grep "zoom"` — Playwright zoom spec added and executed (browsers installed and host deps added during run); the `immersive-zoom` test passed after setup. ✅
- Docs and smoke: `npm run docs:check` ✅, `npm run smoke` (build + dist checks) ✅.
- Secrets scan: `git diff | ./scripts/scan-secrets.py` and staged diff scan returned no high-risk secrets. ✅

Notes and residual risks
- Type errors reported by `tsc` are pre-existing in the repository and were not introduced by this patch; they remain out of scope for this fix.  
- Playwright test execution required installing browser binaries and host libraries inside the test runner environment; CI runners must provide Playwright browsers or run `npx playwright install` and required OS packages.  
- The Afterimage pass is now opt-in (disabled by default) to minimize risk; enabling it restores expected trail behavior but will clear history when toggled to avoid visual corruption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a191d160754832f82307602461ccf3b)