### PR TITLE
Harden performance-failover zoom coverage

### DIFF
--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -6,29 +6,35 @@
   "symptoms": [
     "Initial immersive render looked normal.",
     "Mouse-wheel orthographic zoom left prior full-scene frames visible as duplicated geometry/trails.",
+    "Normal zoom/pan could switch staging from immersive mode into the text fallback after roughly 5-10 seconds.",
     "Setting the in-app motion blur slider to zero on staging did not eliminate the bug."
   ],
-  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and risked confusion with performance-failover behavior.",
-  "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming; now covered by Playwright zoom regression tests.",
-  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. This confirmed the root cause was the AfterimagePass damp mapping and missing zero-intensity no-op/disable behavior, not a separate staging fallback.",
+  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and could become unavailable when runtime failover replaced the canvas with the text experience.",
+  "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming, plus production-like staging sessions that fell back to text after persistent zoom corruption; now covered by Playwright zoom and performance-failover regression tests.",
+  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. The text fallback was likely a secondary reaction to sustained low FPS caused by the rendering bug rather than a reason to remove or weaken genuine performance failover.",
   "correctiveAction": [
     "Default motion blur intensity changed to zero so scene-wide afterimage is not active by default.",
     "Intensity zero disables AfterimagePass, maps to damp 0, and schedules feedback-history reset.",
     "Nonzero intensity now maps upward toward max damp.",
     "History resets when toggling motion blur to/from zero, when camera zoom/projection changes, and at camera-pan start/release boundaries so continuous pan does not clear every frame.",
-    "A narrow window.portfolio.graphics hook supports production-safe browser regression tests."
+    "A narrow window.portfolio.graphics hook supports production-safe browser regression tests.",
+    "Production-like Playwright coverage loads /?mode=immersive without disablePerformanceFailover=1, drives wheel zoom longer than the low-FPS window, and fails on performancefailover, fallback mode, text mode, or duplicate canvases.",
+    "Runtime failover remains enabled for genuine low performance, unsupported WebGL, automated clients, and explicit text mode."
   ],
   "regressionTests": [
     "Vitest coverage for zero no-op/disable behavior, invalid clamping, corrected damp mapping, history resets, and disposal.",
-    "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling."
+    "src/tests/performanceFailover.test.ts proves normal FPS for more than five seconds never triggers, intermittent low FPS resets the timer, sustained very-low FPS triggers, and low-performance transitions dispatch performancefailover with reason low-performance.",
+    "playwright/performance-failover-zoom.spec.ts covers /?mode=immersive with runtime performance failover enabled, zoom in/out for longer than 5000 ms, no performancefailover event, no fallback/text mode, and exactly one canvas.",
+    "Existing Playwright immersive zoom coverage still validates one canvas, no text fallback, repeated wheel zoom, zero blur, reset telemetry, and nonzero-to-zero toggling."
   ],
   "validationCommands": [
     "npm run format:write",
     "npm run lint",
     "npm run typecheck",
     "npm run test:ci",
+    "npm run test:e2e -- --grep \"performance failover\"",
     "npm run test:e2e -- --grep \"zoom\"",
     "npm run smoke"
   ],
-  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero."
+  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive for clean wheel zoom with runtime failover enabled, no performancefailover event, no text fallback, and one canvas. Also validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero."
 }

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -9,7 +9,9 @@
 The immersive portfolio initially rendered normally, but mouse-wheel zooming the
 orthographic camera caused prior full-scene frames to remain visible. Visitors
 could see stacked or duplicated room geometry and trails from old camera
-projections instead of a clean scale change.
+projections instead of a clean scale change. After roughly 5-10 seconds of
+normal zoom/pan interaction, staging could also switch from immersive mode into
+the text fallback.
 
 A key field observation was that setting the in-app motion blur slider to zero
 did **not** eliminate the artifact on staging.
@@ -17,14 +19,18 @@ did **not** eliminate the artifact on staging.
 ## Impact
 
 The staging immersive experience looked corrupted during normal zoom/pan
-interactions. The issue risked confusing validation because graphics corruption
-could be mistaken for a broader WebGL or performance-failover problem.
+interactions and could become unavailable when runtime failover replaced the
+canvas with the text experience. The issue risked confusing validation because
+graphics corruption could be mistaken for unsupported WebGL or a broken
+failover policy.
 
 ## Detection
 
 The bug was detected by manual staging validation of
-`/?mode=immersive&disablePerformanceFailover=1` followed by mouse-wheel zooming.
-Regression coverage now exercises the same flow in Playwright.
+`/?mode=immersive&disablePerformanceFailover=1` followed by mouse-wheel zooming
+and by observing production-like staging sessions fall back to text after the
+zoom corruption persisted. Regression coverage now exercises both the bypassed
+zoom path and `/?mode=immersive` with runtime failover enabled in Playwright.
 
 ## Root cause
 
@@ -36,7 +42,9 @@ zero setting retained stale full-scene feedback instead of disabling motion
 blur. The pass also stayed enabled at zero intensity, so it could continue
 rendering stale feedback buffers across orthographic camera projection changes.
 This confirmed the root cause was the AfterimagePass `damp` mapping and the
-missing zero-intensity no-op/disable behavior, not a separate staging fallback.
+missing zero-intensity no-op/disable behavior. The text fallback was likely a
+secondary reaction to sustained low FPS caused by the rendering bug rather than
+a reason to remove or weaken genuine performance failover.
 
 ## Corrective action
 
@@ -50,16 +58,30 @@ missing zero-intensity no-op/disable behavior, not a separate staging fallback.
   boundaries so continuous pan does not clear every frame.
 - A narrow `window.portfolio.graphics` test hook exposes motion-blur state and a
   production-safe setter for browser regression tests.
+- Production-like regression coverage now loads `/?mode=immersive` without the
+  failover bypass, drives wheel zoom longer than the 5000 ms low-FPS window,
+  and fails on `performancefailover`, fallback mode, text mode, or duplicate
+  canvases.
+- Runtime failover remains enabled for genuine low performance, unsupported
+  WebGL, automated clients, and explicit text mode.
 
 ## Regression tests
 
 - Vitest covers disabled zero intensity, invalid/nonfinite clamping, corrected
   damp mapping, toggle-to-zero history clearing, explicit history reset, and
   disposal.
-- Playwright covers immersive startup with exactly one canvas, repeated wheel
-  zoom in/out with failover disabled, setting motion blur to zero, motion-blur
-  reset telemetry for the stale/duplicated-frame symptom, and toggling nonzero
-  blur back to zero without revealing the text fallback.
+- `src/tests/performanceFailover.test.ts` proves normal FPS for more than five
+  seconds never triggers failover, intermittent low FPS resets the timer,
+  sustained very-low FPS triggers fallback, and low-performance transitions
+  dispatch a `performancefailover` event with reason `low-performance`.
+- `playwright/performance-failover-zoom.spec.ts` covers immersive startup with
+  runtime performance failover enabled, zoom in/out for longer than the 5000 ms
+  failover window, no `performancefailover` event, no fallback/text mode, and
+  exactly one canvas.
+- Existing Playwright zoom coverage still checks repeated wheel zoom in/out with
+  failover disabled, setting motion blur to zero, motion-blur reset telemetry
+  for the stale/duplicated-frame symptom, and toggling nonzero blur back to zero
+  without revealing the text fallback.
 
 ## Deployment and validation notes
 
@@ -76,6 +98,7 @@ npm run format:write
 npm run lint
 npm run typecheck
 npm run test:ci
+npm run test:e2e -- --grep "performance failover"
 npm run test:e2e -- --grep "zoom"
 npm run smoke
 ```

--- a/playwright/performance-failover-zoom.spec.ts
+++ b/playwright/performance-failover-zoom.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const PRODUCTION_LIKE_IMMERSIVE_URL = '/?mode=immersive';
+const ZOOM_STRESS_DURATION_MS = 6_500;
+const ZOOM_STEP_DELAY_MS = 100;
+
+interface FailoverEventRecord {
+  reason: string;
+}
+
+interface PerformanceFailoverWindow extends Window {
+  __performanceFailoverEvents?: FailoverEventRecord[];
+}
+
+async function installFailoverListener(page: Page) {
+  await page.addInitScript(() => {
+    const portfolioWindow = window as PerformanceFailoverWindow;
+    portfolioWindow.__performanceFailoverEvents = [];
+    window.addEventListener('performancefailover', (event) => {
+      const detail = (event as CustomEvent<{ reason?: string }>).detail;
+      portfolioWindow.__performanceFailoverEvents?.push({
+        reason: detail?.reason ?? 'unknown',
+      });
+    });
+  });
+}
+
+async function readFailoverEvents(page: Page): Promise<FailoverEventRecord[]> {
+  return page.evaluate(
+    () =>
+      (window as PerformanceFailoverWindow).__performanceFailoverEvents ?? []
+  );
+}
+
+async function waitForImmersive(page: Page) {
+  await page.goto(PRODUCTION_LIKE_IMMERSIVE_URL, {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'immersive'
+  );
+  await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+async function dispatchWheelZoom(page: Page, deltaY: number) {
+  await page.evaluate((nextDeltaY) => {
+    const canvas = document.querySelector<HTMLCanvasElement>('#app canvas');
+    canvas?.dispatchEvent(
+      new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        deltaY: nextDeltaY,
+      })
+    );
+  }, deltaY);
+}
+
+test.describe('performance failover zoom regression', () => {
+  test.setTimeout(90_000);
+
+  test('keeps production-like immersive zoom active without text fallback', async ({
+    page,
+  }) => {
+    const fallbackWarnings: string[] = [];
+    page.on('console', (message) => {
+      if (message.text().includes('Switching to text fallback')) {
+        fallbackWarnings.push(message.text());
+      }
+    });
+
+    await installFailoverListener(page);
+    await waitForImmersive(page);
+
+    const startedAt = Date.now();
+    let step = 0;
+    while (Date.now() - startedAt < ZOOM_STRESS_DURATION_MS) {
+      const zoomingIn = step % 12 < 6;
+      await dispatchWheelZoom(page, zoomingIn ? -260 : 260);
+      await page.waitForTimeout(ZOOM_STEP_DELAY_MS);
+      await expect(page.locator('html')).toHaveAttribute(
+        'data-app-mode',
+        'immersive'
+      );
+      await expect(page.locator('#app')).not.toHaveAttribute(
+        'data-mode',
+        'text'
+      );
+      step += 1;
+    }
+
+    expect(await readFailoverEvents(page)).toEqual([]);
+    expect(fallbackWarnings).toEqual([]);
+    await expect(page.locator('html')).not.toHaveAttribute(
+      'data-app-mode',
+      'fallback'
+    );
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+    await expect(page.locator('#app canvas')).toHaveCount(1);
+  });
+});

--- a/src/tests/performanceFailover.test.ts
+++ b/src/tests/performanceFailover.test.ts
@@ -191,6 +191,65 @@ describe('createPerformanceFailoverHandler', () => {
     });
   });
 
+  it('keeps immersive active when normal FPS stays above threshold for more than five seconds', () => {
+    const { renderer } = createRenderer();
+    const container = createContainer();
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const eventTarget = new EventTarget();
+    const events = collectFailoverEvents(eventTarget);
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      eventTarget,
+    });
+
+    for (let i = 0; i < 390; i += 1) {
+      handler.update(1 / 60);
+    }
+
+    expect(handler.hasTriggered()).toBe(false);
+    expect(renderFallback).not.toHaveBeenCalled();
+    expect(markAppReady).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+  });
+
+  it('resets the low-FPS timer when intermittent slow frames recover', () => {
+    const { renderer } = createRenderer();
+    const container = createContainer();
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const eventTarget = new EventTarget();
+    const events = collectFailoverEvents(eventTarget);
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      eventTarget,
+    });
+
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      for (let i = 0; i < 50; i += 1) {
+        handler.update(1 / 20);
+      }
+      for (let i = 0; i < 15; i += 1) {
+        handler.update(1 / 60);
+      }
+    }
+
+    expect(handler.hasTriggered()).toBe(false);
+    expect(renderFallback).not.toHaveBeenCalled();
+    expect(markAppReady).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+  });
+
   it('ignores sporadic low FPS frames', () => {
     const { renderer } = createRenderer();
     const container = createContainer();


### PR DESCRIPTION
### Motivation
- Prevent ordinary production-like immersive zoom/pan from triggering the text fallback while preserving genuine low-performance failover paths.  
- Capture the staging symptom where zoom corruption could lead to a runtime failover and document corrective/validation steps.

### Description
- Add a Playwright regression test `playwright/performance-failover-zoom.spec.ts` that loads `/?mode=immersive` (no `disablePerformanceFailover`), subscribes to the `performancefailover` event, stress-zooms for >5s, and asserts no `performancefailover`, no fallback/text mode, and exactly one canvas.  
- Extend unit coverage in `src/tests/performanceFailover.test.ts` with tests that assert normal 60FPS for >5s does not trigger failover and that intermittent low-FPS cycles reset the low-FPS timer.  
- Update the incident report files `outages/2026-05-28-danielsmith-staging-zoom-fallback.md` and `outages/2026-05-28-danielsmith-staging-zoom-fallback.json` to record the failover relationship, corrective actions, and new validation/test commands.  
- Keep existing failover behavior unchanged; tests exercise automated and manual failover paths without weakening thresholds.

### Testing
- Ran formatting: `npm run format:write` — success.  
- Lint: `npm run lint` — success.  
- Unit tests: `npm run test:ci` — full Vitest suite passed (126 files, 832 tests passed).  
- Playwright: `npm run test:e2e -- --grep "performance failover"` — the new `playwright/performance-failover-zoom.spec.ts` passed (note: required `npx playwright install` and `npx playwright install-deps` during runs).  
- Docs check: `npm run docs:check` — success.  
- Smoke: `npm run smoke` — success.  
- Type-check: `npm run typecheck` — still failing due to pre-existing project-wide TypeScript issues unrelated to these changes.  
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19408bec10832fb802640add351291)