### PR TITLE
Harden performance failover zoom coverage

### DIFF
--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -6,29 +6,34 @@
   "symptoms": [
     "Initial immersive render looked normal.",
     "Mouse-wheel orthographic zoom left prior full-scene frames visible as duplicated geometry/trails.",
-    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug."
+    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug.",
+    "Normal zoom eventually switched immersive mode into text fallback after roughly 5-10 seconds."
   ],
-  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and risked confusion with performance-failover behavior.",
-  "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming; now covered by Playwright zoom regression tests.",
-  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. This confirmed the root cause was the AfterimagePass damp mapping and missing zero-intensity no-op/disable behavior, not a separate staging fallback.",
+  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and later text fallback during an ordinary zoom session, risking confusion with genuine unsupported or low-performance failover behavior.",
+  "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming; now covered by Playwright zoom and production-like performance-failover regression tests.",
+  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. The text fallback was likely a secondary reaction to sustained low FPS caused by the rendering bug, not a reason to remove or weaken genuine low-performance failover.",
   "correctiveAction": [
     "Default motion blur intensity changed to zero so scene-wide afterimage is not active by default.",
     "Intensity zero disables AfterimagePass, maps to damp 0, and schedules feedback-history reset.",
     "Nonzero intensity now maps upward toward max damp.",
     "History resets when toggling motion blur to/from zero, when camera zoom/projection changes, and at camera-pan start/release boundaries so continuous pan does not clear every frame.",
-    "A narrow window.portfolio.graphics hook supports production-safe browser regression tests."
+    "A narrow window.portfolio.graphics hook supports production-safe browser regression tests.",
+    "Production-like Playwright coverage loads /?mode=immersive without disablePerformanceFailover=1 and verifies ordinary wheel zoom stays immersive beyond the 5000ms low-FPS window.",
+    "Runtime performance failover remains enabled for genuine sustained low FPS, unsupported WebGL, automated clients/scrapers, explicit text mode, and other supported fallback paths."
   ],
   "regressionTests": [
     "Vitest coverage for zero no-op/disable behavior, invalid clamping, corrected damp mapping, history resets, and disposal.",
-    "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling."
+    "Vitest performance-failover coverage for normal FPS beyond five seconds, intermittent low-FPS recovery resetting the timer, sustained very-low FPS triggering, and performancefailover events with reason low-performance.",
+    "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling.",
+    "Playwright performance-failover coverage for a production-like /?mode=immersive session that subscribes to performancefailover, watches Switching to text fallback warnings, drives wheel zoom in/out for longer than 6500ms, and asserts no fallback plus exactly one canvas."
   ],
   "validationCommands": [
     "npm run format:write",
     "npm run lint",
     "npm run typecheck",
     "npm run test:ci",
-    "npm run test:e2e -- --grep \"zoom\"",
+    "npm run test:e2e -- --grep \"performance failover\"",
     "npm run smoke"
   ],
-  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero."
+  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive without the failover bypass to confirm ordinary wheel zoom does not dispatch performancefailover or reveal text fallback while real unsupported/low-performance fallback paths remain covered."
 }

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -17,14 +17,18 @@ did **not** eliminate the artifact on staging.
 ## Impact
 
 The staging immersive experience looked corrupted during normal zoom/pan
-interactions. The issue risked confusing validation because graphics corruption
+interactions. After roughly 5-10 seconds of the degraded zoom session, the
+runtime performance monitor switched the app from immersive mode into the text
+fallback. The issue risked confusing validation because graphics corruption
 could be mistaken for a broader WebGL or performance-failover problem.
 
 ## Detection
 
 The bug was detected by manual staging validation of
 `/?mode=immersive&disablePerformanceFailover=1` followed by mouse-wheel zooming.
-Regression coverage now exercises the same flow in Playwright.
+Regression coverage now exercises the same flow in Playwright, including a
+production-like `/?mode=immersive` session where runtime performance failover
+remains enabled.
 
 ## Root cause
 
@@ -36,7 +40,9 @@ zero setting retained stale full-scene feedback instead of disabling motion
 blur. The pass also stayed enabled at zero intensity, so it could continue
 rendering stale feedback buffers across orthographic camera projection changes.
 This confirmed the root cause was the AfterimagePass `damp` mapping and the
-missing zero-intensity no-op/disable behavior, not a separate staging fallback.
+missing zero-intensity no-op/disable behavior. The text fallback was likely a
+secondary reaction to sustained low FPS caused by that rendering bug, not a
+reason to remove or weaken genuine low-performance failover.
 
 ## Corrective action
 
@@ -50,6 +56,12 @@ missing zero-intensity no-op/disable behavior, not a separate staging fallback.
   boundaries so continuous pan does not clear every frame.
 - A narrow `window.portfolio.graphics` test hook exposes motion-blur state and a
   production-safe setter for browser regression tests.
+- Production-like regression coverage now loads `/?mode=immersive` without the
+  failover bypass and verifies normal wheel zoom stays immersive for longer
+  than the 5000ms low-FPS window.
+- Runtime performance failover remains enabled for genuine sustained low FPS,
+  unsupported WebGL, automated clients/scrapers, explicit text mode, and other
+  supported fallback paths.
 
 ## Regression tests
 
@@ -60,14 +72,25 @@ missing zero-intensity no-op/disable behavior, not a separate staging fallback.
   zoom in/out with failover disabled, setting motion blur to zero, motion-blur
   reset telemetry for the stale/duplicated-frame symptom, and toggling nonzero
   blur back to zero without revealing the text fallback.
+- `playwright/performance-failover-zoom.spec.ts` covers a production-like
+  immersive session at `/?mode=immersive`, subscribes to the
+  `performancefailover` event and fallback console warnings, drives wheel zoom
+  in/out for longer than 6500ms, and asserts no text fallback plus exactly one
+  canvas.
+- `src/tests/performanceFailover.test.ts` covers normal FPS for more than five
+  seconds, intermittent low FPS recovery resetting the timer, sustained very-low
+  FPS triggering, and the `performancefailover` event reason
+  `low-performance`.
 
 ## Deployment and validation notes
 
 Validate the deployed staging build at
 `https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1`.
 Confirm the initial render is clean, wheel zooming does not stack previous
-camera projections, the motion blur slider at zero remains clean, and returning
-from nonzero blur to zero clears residual trails.
+camera projections, the motion blur slider at zero remains clean, returning
+from nonzero blur to zero clears residual trails, and ordinary wheel zoom at
+`/?mode=immersive` does not dispatch `performancefailover` or reveal text
+fallback while real unsupported/low-performance fallback paths remain covered.
 
 Expected validation commands:
 
@@ -76,6 +99,6 @@ npm run format:write
 npm run lint
 npm run typecheck
 npm run test:ci
-npm run test:e2e -- --grep "zoom"
+npm run test:e2e -- --grep "performance failover"
 npm run smoke
 ```

--- a/playwright/performance-failover-zoom.spec.ts
+++ b/playwright/performance-failover-zoom.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const PERFORMANCE_FAILOVER_WINDOW_MS = 5_000;
+const ZOOM_STRESS_DURATION_MS = PERFORMANCE_FAILOVER_WINDOW_MS + 1_500;
+const ZOOM_STEP_INTERVAL_MS = 100;
+const PRODUCTION_LIKE_IMMERSIVE_URL = '/?mode=immersive';
+const FAILOVER_WARNING_PATTERN = /Switching to text fallback/i;
+
+declare global {
+  interface Window {
+    __performanceFailoverEvents?: unknown[];
+  }
+}
+
+async function installFailoverEventProbe(page: Page) {
+  await page.addInitScript(() => {
+    window.__performanceFailoverEvents = [];
+    window.addEventListener('performancefailover', (event) => {
+      window.__performanceFailoverEvents?.push(
+        (event as CustomEvent<unknown>).detail ?? null
+      );
+    });
+  });
+}
+
+async function expectImmersiveMode(page: Page) {
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'immersive'
+  );
+  await expect(page.locator('html')).not.toHaveAttribute(
+    'data-app-mode',
+    'fallback'
+  );
+  await expect(page.locator('#app[data-mode="text"]')).toHaveCount(0);
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+async function assertNoRuntimeFailover(page: Page) {
+  const failoverEvents = await page.evaluate(
+    () => window.__performanceFailoverEvents ?? []
+  );
+
+  expect(failoverEvents).toEqual([]);
+  await expectImmersiveMode(page);
+}
+
+async function dispatchWheelZoom(page: Page, deltaY: number) {
+  await page.evaluate((nextDeltaY) => {
+    const canvas = document.querySelector<HTMLCanvasElement>('#app canvas');
+    if (!canvas) {
+      throw new Error('Expected immersive canvas before wheel zoom.');
+    }
+    canvas.dispatchEvent(
+      new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        deltaY: nextDeltaY,
+      })
+    );
+  }, deltaY);
+}
+
+test.describe('performance failover', () => {
+  test.setTimeout(120_000);
+
+  test('keeps production-like immersive zoom above the runtime failover path', async ({
+    page,
+  }) => {
+    const failoverWarnings: string[] = [];
+    page.on('console', (message) => {
+      const text = message.text();
+      if (message.type() === 'warning' && FAILOVER_WARNING_PATTERN.test(text)) {
+        failoverWarnings.push(text);
+      }
+    });
+
+    await installFailoverEventProbe(page);
+    await page.goto(PRODUCTION_LIKE_IMMERSIVE_URL, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+    await expectImmersiveMode(page);
+
+    const startedAt = Date.now();
+    let step = 0;
+    while (Date.now() - startedAt < ZOOM_STRESS_DURATION_MS) {
+      const zoomingIn = Date.now() - startedAt < ZOOM_STRESS_DURATION_MS / 2;
+      const deltaY = zoomingIn ? -360 : 360;
+      await dispatchWheelZoom(page, deltaY);
+      await page.waitForTimeout(ZOOM_STEP_INTERVAL_MS);
+
+      step += 1;
+      if (step % 10 === 0) {
+        await assertNoRuntimeFailover(page);
+      }
+    }
+
+    expect(failoverWarnings).toEqual([]);
+    await assertNoRuntimeFailover(page);
+  });
+});

--- a/src/tests/performanceFailover.test.ts
+++ b/src/tests/performanceFailover.test.ts
@@ -67,6 +67,102 @@ describe('createPerformanceFailoverHandler', () => {
     return events;
   };
 
+  it('keeps normal FPS immersive beyond the low-performance window', () => {
+    const { renderer } = createRenderer();
+    const container = createContainer();
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const eventTarget = new EventTarget();
+    const events = collectFailoverEvents(eventTarget);
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      eventTarget,
+    });
+
+    for (let i = 0; i < 390; i += 1) {
+      handler.update(1 / 60);
+    }
+
+    expect(handler.hasTriggered()).toBe(false);
+    expect(events).toEqual([]);
+    expect(renderFallback).not.toHaveBeenCalled();
+    expect(markAppReady).not.toHaveBeenCalled();
+  });
+
+  it('resets the low-FPS timer after intermittent recovery', () => {
+    const { renderer } = createRenderer();
+    const container = createContainer();
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+    });
+
+    for (let i = 0; i < 40; i += 1) {
+      handler.update(1 / 20);
+    }
+    for (let i = 0; i < 60; i += 1) {
+      handler.update(1 / 60);
+    }
+    for (let i = 0; i < 80; i += 1) {
+      handler.update(1 / 20);
+    }
+
+    expect(handler.hasTriggered()).toBe(false);
+    expect(renderFallback).not.toHaveBeenCalled();
+    expect(markAppReady).not.toHaveBeenCalled();
+  });
+
+  it('emits a low-performance event after sustained very-low FPS', () => {
+    const { renderer, canvas } = createRenderer();
+    const container = createContainer();
+    container.appendChild(canvas);
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const eventTarget = new EventTarget();
+    const events = collectFailoverEvents(eventTarget);
+    const onTrigger = vi.fn();
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      eventTarget,
+      onTrigger,
+    });
+
+    for (let i = 0; i < 61; i += 1) {
+      handler.update(1 / 10);
+    }
+
+    expect(handler.hasTriggered()).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0].detail.reason).toBe('low-performance');
+    expect(events[0].detail.context).toMatchObject({
+      averageFps: expect.any(Number),
+      durationMs: expect.any(Number),
+      sampleCount: expect.any(Number),
+    });
+    expect(renderFallback).toHaveBeenCalledWith(container, {
+      reason: 'low-performance',
+      immersiveUrl: IMMERSIVE_URL,
+      resumeUrl: undefined,
+      githubUrl: undefined,
+    });
+  });
+
   it('triggers fallback after sustained low FPS and cleans up renderer', () => {
     const { renderer, canvas, setAnimationLoop, dispose } = createRenderer();
     const removeSpy = vi.spyOn(canvas, 'remove');


### PR DESCRIPTION
### Motivation
- Ordinary user wheel-zoom/pan in a production-like immersive session must not trigger the runtime performance failover; staging showed zoom-induced afterimages that later caused the app to flip to text fallback. 
- Add regression coverage that exercises runtime failover (enabled) so the system continues to fall back only for genuine low-performance/unsupported conditions while preserving explicit `?mode=text` and automated-client heuristics.

### Description
- Add a Playwright E2E test `playwright/performance-failover-zoom.spec.ts` that loads `/?mode=immersive` (no bypass), subscribes to the `performancefailover` event, captures fallback console warnings, drives repeated wheel zoom for longer than the 5000ms window, and asserts immersive mode remains active and exactly one canvas remains. 
- Extend Vitest performance tests in `src/tests/performanceFailover.test.ts` with cases asserting that sustained normal FPS (>5s) does not trigger failover, intermittent low-FPS resets the low-FPS timer, and sustained very-low FPS triggers a `performancefailover` event with reason `low-performance` and renders fallback.
- Update the shared outage docs `outages/2026-05-28-danielsmith-staging-zoom-fallback.md` and the machine-readable JSON to record symptoms (including the observed text fallback after ~5–10s), root cause summary, corrective action, and the new regression/validation commands.

### Testing
- Ran formatting: `npm run format:write` — passed. 
- Lint: `npm run lint` — passed. 
- Typecheck: `npm run typecheck` — failed due to pre-existing, unrelated TypeScript errors across the codebase (these errors were present before this change and are outside the scope of this PR). 
- Unit tests: `npm run test:ci` — passed (full Vitest suite; the added `performanceFailover` unit tests passed). 
- Playwright E2E: `npm run test:e2e -- --grep "performance failover"` — passed after installing Playwright browsers and host deps (`npx playwright install` and `npx playwright install-deps chromium`) in the test environment; the new browser test validated no `performancefailover` event, no fallback markup, and exactly one canvas during the stress zoom scenario. 
- Docs and smoke: `npm run docs:check` and `npm run smoke` — passed. 

Note: Playwright execution required downloading browsers and installing host dependencies in the environment where tests ran; this was performed as part of the test run. Type-check failures are pre-existing and unrelated to the added tests and docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19408bec10832fb802640add351291)