### PR TITLE
🧪 : – Cover performance failover zoom

### DIFF
--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -6,29 +6,34 @@
   "symptoms": [
     "Initial immersive render looked normal.",
     "Mouse-wheel orthographic zoom left prior full-scene frames visible as duplicated geometry/trails.",
-    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug."
+    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug.",
+    "With runtime performance failover enabled, normal zoom could switch immersive mode into the text fallback after about 5-10 seconds."
   ],
-  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and risked confusion with performance-failover behavior.",
-  "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming; now covered by Playwright zoom regression tests.",
-  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. This confirmed the root cause was the AfterimagePass damp mapping and missing zero-intensity no-op/disable behavior, not a separate staging fallback.",
+  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and a production-like runtime failover could move normal visitors into text fallback after sustained low FPS.",
+  "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming; production-like /?mode=immersive regression coverage now exercises normal zoom beyond the 5000 ms low-FPS window with runtime failover enabled.",
+  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. The text fallback was likely reacting correctly to sustained low FPS caused by that rendering bug, so failover remains enabled for genuine low-performance conditions.",
   "correctiveAction": [
     "Default motion blur intensity changed to zero so scene-wide afterimage is not active by default.",
     "Intensity zero disables AfterimagePass, maps to damp 0, and schedules feedback-history reset.",
     "Nonzero intensity now maps upward toward max damp.",
     "History resets when toggling motion blur to/from zero, when camera zoom/projection changes, and at camera-pan start/release boundaries so continuous pan does not clear every frame.",
-    "A narrow window.portfolio.graphics hook supports production-safe browser regression tests."
+    "A narrow window.portfolio.graphics hook supports production-safe browser regression tests.",
+    "Production-like failover coverage loads /?mode=immersive without disablePerformanceFailover=1, records performancefailover events, zooms beyond the low-FPS window, and asserts the page remains immersive with one canvas.",
+    "Runtime failover remains enabled for genuine low-performance, explicit text mode, unsupported WebGL, automated clients, and scraper/data-saver routes."
   ],
   "regressionTests": [
     "Vitest coverage for zero no-op/disable behavior, invalid clamping, corrected damp mapping, history resets, and disposal.",
-    "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling."
+    "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling.",
+    "playwright/performance-failover-zoom.spec.ts verifies normal zoom stays immersive with runtime performance failover enabled and no performancefailover event.",
+    "src/tests/performanceFailover.test.ts verifies normal FPS for more than 5 seconds, intermittent low-FPS recovery, sustained very-low-FPS fallback, and low-performance event dispatch."
   ],
   "validationCommands": [
     "npm run format:write",
     "npm run lint",
     "npm run typecheck",
     "npm run test:ci",
-    "npm run test:e2e -- --grep \"zoom\"",
+    "npm run test:e2e -- --grep \"performance failover\"",
     "npm run smoke"
   ],
-  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero."
+  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean zoom rendering, then validate https://staging.danielsmith.io/?mode=immersive without the bypass to confirm normal zoom/pan remains immersive while runtime failover stays available for real low-performance sessions."
 }

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -18,13 +18,18 @@ did **not** eliminate the artifact on staging.
 
 The staging immersive experience looked corrupted during normal zoom/pan
 interactions. The issue risked confusing validation because graphics corruption
-could be mistaken for a broader WebGL or performance-failover problem.
+could be mistaken for a broader WebGL or performance-failover problem. In a
+production-like session with runtime performance failover enabled, the sustained
+rendering slowdown could also switch the visitor into the text fallback after
+roughly 5-10 seconds of normal zooming.
 
 ## Detection
 
 The bug was detected by manual staging validation of
 `/?mode=immersive&disablePerformanceFailover=1` followed by mouse-wheel zooming.
-Regression coverage now exercises the same flow in Playwright.
+A related production-like check uses `/?mode=immersive` without the failover
+bypass so runtime performance failover remains active while zoom/pan behavior is
+exercised beyond the 5,000 ms low-FPS window.
 
 ## Root cause
 
@@ -36,7 +41,9 @@ zero setting retained stale full-scene feedback instead of disabling motion
 blur. The pass also stayed enabled at zero intensity, so it could continue
 rendering stale feedback buffers across orthographic camera projection changes.
 This confirmed the root cause was the AfterimagePass `damp` mapping and the
-missing zero-intensity no-op/disable behavior, not a separate staging fallback.
+missing zero-intensity no-op/disable behavior. The text fallback was likely
+reacting correctly to sustained low FPS caused by that rendering bug, so the
+failover feature remains enabled for genuine low-performance conditions.
 
 ## Corrective action
 
@@ -50,6 +57,13 @@ missing zero-intensity no-op/disable behavior, not a separate staging fallback.
   boundaries so continuous pan does not clear every frame.
 - A narrow `window.portfolio.graphics` test hook exposes motion-blur state and a
   production-safe setter for browser regression tests.
+- Production-like performance-failover coverage now loads `/?mode=immersive`
+  without `disablePerformanceFailover=1`, records `performancefailover` events,
+  zooms beyond the low-FPS window, and asserts the page remains immersive with a
+  single canvas.
+- The runtime failover path remains active for real low-performance sessions,
+  explicit text mode, unsupported WebGL, automated clients, and scraper/data
+  saver routes.
 
 ## Regression tests
 
@@ -60,6 +74,13 @@ missing zero-intensity no-op/disable behavior, not a separate staging fallback.
   zoom in/out with failover disabled, setting motion blur to zero, motion-blur
   reset telemetry for the stale/duplicated-frame symptom, and toggling nonzero
   blur back to zero without revealing the text fallback.
+- `playwright/performance-failover-zoom.spec.ts` covers a production-like
+  immersive session with runtime failover enabled and fails on a
+  `performancefailover` event, text fallback, fallback app mode, or extra
+  canvases while normal wheel zoom runs for more than 5,000 ms.
+- `src/tests/performanceFailover.test.ts` covers normal FPS beyond the failover
+  window, intermittent low FPS recovery, sustained very-low-FPS fallback, and
+  the `performancefailover` event reason `low-performance`.
 
 ## Deployment and validation notes
 
@@ -67,7 +88,10 @@ Validate the deployed staging build at
 `https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1`.
 Confirm the initial render is clean, wheel zooming does not stack previous
 camera projections, the motion blur slider at zero remains clean, and returning
-from nonzero blur to zero clears residual trails.
+from nonzero blur to zero clears residual trails. Then validate
+`https://staging.danielsmith.io/?mode=immersive` without the bypass to confirm
+normal zoom/pan remains immersive while runtime failover is still available for
+real low-performance sessions.
 
 Expected validation commands:
 
@@ -76,6 +100,6 @@ npm run format:write
 npm run lint
 npm run typecheck
 npm run test:ci
-npm run test:e2e -- --grep "zoom"
+npm run test:e2e -- --grep "performance failover"
 npm run smoke
 ```

--- a/playwright/performance-failover-zoom.spec.ts
+++ b/playwright/performance-failover-zoom.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const PRODUCTION_LIKE_IMMERSIVE_URL = '/?mode=immersive';
+const RUNTIME_FAILOVER_WINDOW_MS = 5_000;
+const ZOOM_EXERCISE_DURATION_MS = RUNTIME_FAILOVER_WINDOW_MS + 1_500;
+
+interface PerformanceFailoverEventLog {
+  reason: string;
+  context?: unknown;
+}
+
+interface FailoverTestWindow extends Window {
+  __performanceFailoverEvents?: PerformanceFailoverEventLog[];
+}
+
+const getFailoverEvents = async (
+  page: Page
+): Promise<PerformanceFailoverEventLog[]> =>
+  page.evaluate(
+    () =>
+      (window as FailoverTestWindow).__performanceFailoverEvents?.slice() ?? []
+  );
+
+async function installFailoverEventRecorder(page: Page) {
+  await page.addInitScript(() => {
+    const failoverWindow = window as FailoverTestWindow;
+    failoverWindow.__performanceFailoverEvents = [];
+    window.addEventListener('performancefailover', (event) => {
+      const detail = (event as CustomEvent<PerformanceFailoverEventLog>).detail;
+      failoverWindow.__performanceFailoverEvents?.push({
+        reason: detail.reason,
+        context: detail.context,
+      });
+    });
+  });
+}
+
+async function assertImmersiveCanvas(page: Page) {
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'immersive'
+  );
+  await expect(page.locator('html')).not.toHaveAttribute(
+    'data-app-mode',
+    'fallback'
+  );
+  await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+async function wheelZoomForFailoverWindow(page: Page) {
+  const deltas = [-360, -240, -180, 180, 240, 360];
+  const startedAt = Date.now();
+  let index = 0;
+
+  while (Date.now() - startedAt < ZOOM_EXERCISE_DURATION_MS) {
+    await page.evaluate(
+      (deltaY) => {
+        const canvas = document.querySelector<HTMLCanvasElement>('#app canvas');
+        canvas?.dispatchEvent(
+          new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaY,
+          })
+        );
+      },
+      deltas[index % deltas.length]
+    );
+    index += 1;
+    await page.waitForTimeout(75);
+  }
+}
+
+test.describe('performance failover', () => {
+  test.setTimeout(90_000);
+
+  test('keeps normal zoom immersive while runtime failover remains enabled', async ({
+    page,
+  }) => {
+    const failoverWarnings: string[] = [];
+    page.on('console', (message) => {
+      const text = message.text();
+      if (
+        message.type() === 'warning' &&
+        text.includes('Switching to text fallback')
+      ) {
+        failoverWarnings.push(text);
+      }
+    });
+    await installFailoverEventRecorder(page);
+
+    await page.goto(PRODUCTION_LIKE_IMMERSIVE_URL, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+    await assertImmersiveCanvas(page);
+
+    await wheelZoomForFailoverWindow(page);
+    await assertImmersiveCanvas(page);
+
+    expect(await getFailoverEvents(page)).toEqual([]);
+    expect(failoverWarnings).toEqual([]);
+  });
+});

--- a/src/tests/performanceFailover.test.ts
+++ b/src/tests/performanceFailover.test.ts
@@ -240,6 +240,103 @@ describe('createPerformanceFailoverHandler', () => {
     expect(renderFallback).not.toHaveBeenCalled();
   });
 
+  it('does not trigger during normal FPS for longer than the fallback window', () => {
+    const { renderer } = createRenderer();
+    const container = createContainer();
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const eventTarget = new EventTarget();
+    const events = collectFailoverEvents(eventTarget);
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      eventTarget,
+    });
+
+    for (let i = 0; i < 360; i += 1) {
+      handler.update(1 / 60);
+    }
+
+    expect(handler.hasTriggered()).toBe(false);
+    expect(renderFallback).not.toHaveBeenCalled();
+    expect(markAppReady).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it('resets the low-FPS timer when intermittent low FPS recovers', () => {
+    const { renderer } = createRenderer();
+    const container = createContainer();
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const eventTarget = new EventTarget();
+    const events = collectFailoverEvents(eventTarget);
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      eventTarget,
+    });
+
+    for (let i = 0; i < 80; i += 1) {
+      handler.update(1 / 20);
+    }
+    handler.update(1 / 60);
+    for (let i = 0; i < 80; i += 1) {
+      handler.update(1 / 20);
+    }
+
+    expect(handler.hasTriggered()).toBe(false);
+    expect(renderFallback).not.toHaveBeenCalled();
+    expect(markAppReady).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it('dispatches a low-performance event after sustained very low FPS', () => {
+    const { renderer, canvas } = createRenderer();
+    const container = createContainer();
+    container.appendChild(canvas);
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const eventTarget = new EventTarget();
+    const events = collectFailoverEvents(eventTarget);
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      eventTarget,
+    });
+
+    for (let i = 0; i < 31; i += 1) {
+      handler.update(1 / 5);
+    }
+
+    expect(handler.hasTriggered()).toBe(true);
+    expect(renderFallback).toHaveBeenCalledWith(container, {
+      reason: 'low-performance',
+      immersiveUrl: IMMERSIVE_URL,
+      resumeUrl: undefined,
+      githubUrl: undefined,
+    });
+    expect(markAppReady).toHaveBeenCalledWith('fallback', 'low-performance');
+    expect(events).toHaveLength(1);
+    expect(events[0].detail.reason).toBe('low-performance');
+    expect(events[0].detail.context).toMatchObject({
+      averageFps: 5,
+      durationMs: expect.any(Number),
+      sampleCount: expect.any(Number),
+    });
+  });
+
   it('allows manual fallback triggering with preparation hooks', () => {
     const { renderer, canvas, setAnimationLoop, dispose } = createRenderer();
     const removeSpy = vi.spyOn(canvas, 'remove');


### PR DESCRIPTION
### Motivation
- Ensure normal user zoom/pan on modern browsers does not spuriously trigger the runtime performance failover while retaining real low-performance fallback behavior.
- Add production-like regression coverage that exercises `/?mode=immersive` with failover enabled so the zoom bug (and failover sensitivity) are validated end-to-end.
- Record the incident and test/validation steps in the outage notes so staging and post-deploy validation are repeatable.

### Description
- Add `playwright/performance-failover-zoom.spec.ts`, a Playwright spec that loads `/?mode=immersive`, records `performancefailover` events, performs wheel zoom for longer than the 5s window, and fails if any `performancefailover`, text fallback, or extra canvases appear.
- Extend `src/tests/performanceFailover.test.ts` with unit cases that assert: sustained normal FPS does not trigger failover, intermittent low-FPS resets the timer, and sustained very-low FPS triggers a `low-performance` failover event and dispatch.
- Update `outages/2026-05-28-danielsmith-staging-zoom-fallback.md` and `outages/2026-05-28-danielsmith-staging-zoom-fallback.json` to document the production-like failover symptom, corrective scope, regression tests, and validation commands.

### Testing
- Ran `npm run format:write` and it succeeded.
- Ran `npm run lint` and it succeeded.
- Ran `npm run typecheck` which failed due to pre-existing, unrelated TypeScript issues (baseline errors outside this change set).
- Ran unit suite with `npm run test:ci` and targeted `src/tests/performanceFailover.test.ts`; all added unit tests passed.
- Ran Playwright e2e for the new test with `npm run test:e2e -- --grep "performance failover"`; browsers/deps were installed in the test environment and the spec passed.
- Ran `npm run docs:check` and `npm run smoke` and both succeeded.
- Ran the repository secret scan (`git diff --cached | ./scripts/scan-secrets.py`) and it reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19408bec10832fb802640add351291)