### PR TITLE
Fix text-fallback top clipping and add Playwright layout tests

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -56,3 +56,28 @@ and the Vitest assertions when measurable changes land.
 4. Verify in the immersive build by launching
    `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1` and
    toggling `Shift+L` to compare debug vs. cinematic passes.
+
+## Outage notes
+
+### 2026-05-29 text fallback clipping
+
+- **Symptoms** – Staging visitors who were routed to text mode saw the fallback content start
+  mid-page. The title and description were clipped above the viewport, and scrolling could not
+  reach them.
+- **Impact** – Explicit `?mode=text`, runtime performance failover, automated-client failover,
+  and other fallback paths could hide the page introduction whenever the full portfolio/exhibits
+  copy made the fallback card taller than the viewport.
+- **Root cause** – The document and `#app` were fixed to `height: 100%`, while
+  `#app[data-mode='text']` vertically centered the tall `.text-fallback` flex item. Once the
+  card exceeded the viewport height, flex centering pushed the top into negative-Y overflow that
+  was outside the scroll range.
+- **Corrective action** – Text mode now switches the fallback document back to normal top-aligned
+  flow: the fallback root uses `min-height: 100dvh`, `height: auto`, visible overflow, centered
+  inline card sizing, and safe-area-aware padding so all content begins within the scrollable
+  range.
+- **Regression tests** – `playwright/text-fallback-layout.spec.ts` covers 1280×720 desktop,
+  390×844 mobile, and automated-client runtime fallback. Each path asserts the title/description
+  are visible at scroll position 0, the page scrolls to the final portfolio POI, and horizontal
+  overflow stays within a 1 px tolerance.
+- **Validation notes** – Run `npm run test:e2e -- --grep "text fallback"` alongside the standard
+  format, lint, typecheck, Vitest, docs, and smoke checks before promoting the fallback layout.

--- a/index.html
+++ b/index.html
@@ -404,10 +404,13 @@
 
         .noscript-fallback {
           min-height: 100vh;
+          min-height: 100dvh;
           display: flex;
           flex-direction: column;
-          justify-content: center;
-          padding: 3rem clamp(1.5rem, 4vw, 4rem);
+          justify-content: flex-start;
+          padding-block-start: max(3rem, env(safe-area-inset-top));
+          padding-block-end: max(3rem, env(safe-area-inset-bottom));
+          padding-inline: clamp(1.5rem, 4vw, 4rem);
           gap: 1.5rem;
           background: linear-gradient(180deg, #0a111c 0%, #020408 100%);
           color: rgba(224, 236, 255, 0.9);

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -7,7 +7,8 @@
     "Initial immersive render looked normal.",
     "Mouse-wheel orthographic zoom left prior full-scene frames visible as duplicated geometry/trails.",
     "Production-like staging sessions with runtime performance failover enabled switched from immersive mode to text fallback after roughly 5-10 seconds of normal zooming.",
-    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug."
+    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug.",
+    "Text fallback content could start mid-page with the title and description clipped above the viewport; scrolling could not reach the missing top content."
   ],
   "impact": "Staging immersive validation showed corrupted zoom/pan rendering and could exit to the text fallback during ordinary browser input, risking confusion with broader WebGL or performance-failover behavior.",
   "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming, then production-like /?mode=immersive validation where only preflight routing is bypassed and runtime failover remains enabled; now covered by Playwright zoom and performance failover regression tests.",
@@ -19,13 +20,15 @@
     "History resets when toggling motion blur to/from zero, when camera zoom/projection changes, and at camera-pan start/release boundaries so continuous pan does not clear every frame.",
     "A narrow window.portfolio.graphics hook supports production-safe browser regression tests.",
     "Production-like /?mode=immersive Playwright coverage now omits the explicit disablePerformanceFailover=1 bypass, keeps runtime failover enabled during wheel zoom for longer than the 5-second low-FPS window, and fails on performancefailover events, fallback mode, text mode, console fallback warnings, or duplicate canvases.",
-    "Runtime performance failover remains enabled for genuine sustained low FPS, unsupported WebGL, automated clients, explicit text mode, and related low-capability cases."
+    "Runtime performance failover remains enabled for genuine sustained low FPS, unsupported WebGL, automated clients, explicit text mode, and related low-capability cases.",
+    "Text fallback layout now uses normal top-aligned document-flow scrolling with min-height: 100dvh, height: auto, visible overflow, centered inline card sizing, and safe-area-aware padding."
   ],
   "regressionTests": [
     "Vitest coverage for zero no-op/disable behavior, invalid clamping, corrected damp mapping, history resets, and disposal.",
     "Vitest performance-failover coverage proves normal FPS for more than five seconds never triggers, intermittent low FPS resets when performance recovers, sustained very-low FPS triggers, and low-performance transitions dispatch a performancefailover event with reason low-performance.",
     "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling.",
-    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active."
+    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active.",
+    "Playwright text fallback layout coverage verifies 1280x720 desktop, 390x844 mobile, and automated-client runtime fallback paths show the title/description at scroll position 0, scroll to the final portfolio POI, and avoid horizontal overflow."
   ],
   "validationCommands": [
     "npm run format:write",
@@ -34,7 +37,17 @@
     "npm run test:ci",
     "npm run test:e2e -- --grep \"zoom\"",
     "npm run test:e2e -- --grep \"performance failover\"",
-    "npm run smoke"
+    "npm run smoke",
+    "npm run test:e2e -- --grep \"text fallback\""
   ],
-  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases."
+  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases.",
+  "relatedFollowUps": [
+    {
+      "date": "2026-05-29",
+      "issue": "Text fallback clipping",
+      "rootCause": "Fixed-height #app plus vertically centered tall .text-fallback card pushed the top of the card into negative-Y overflow outside the scroll range.",
+      "impact": "Explicit text mode, runtime performance fallback, automated-client fallback, and related fallback routes could hide the page introduction once portfolio/exhibits content exceeded the viewport height.",
+      "validation": "Covered by playwright/text-fallback-layout.spec.ts across desktop, mobile, and automated-client runtime fallback."
+    }
+  ]
 }

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -87,6 +87,21 @@ not evidence that the runtime failover feature should be removed or weakened.
   routing heuristics while leaving runtime failover enabled, and asserts normal
   wheel zoom/pan remains immersive for longer than the 5-second low-FPS window.
 
+### Text fallback clipping follow-up (2026-05-29)
+
+When the same staging fallback paths rendered the full text portfolio, the card
+could start mid-page with the title and description clipped above the viewport.
+Visitors could scroll down, but could not scroll upward to the missing top
+content. The root cause was the fixed-height `#app` combined with vertical flex
+centering of a `.text-fallback` card that had grown taller than the viewport.
+Text mode now restores normal document-flow scrolling with a top-aligned
+`min-height: 100dvh` fallback root, visible overflow, centered inline card
+sizing, and safe-area-aware padding. Regression coverage in
+`playwright/text-fallback-layout.spec.ts` verifies 1280×720 desktop, 390×844
+mobile, and automated-client runtime fallback paths keep the title/description
+visible at scroll position 0, scroll to the final portfolio POI, and avoid
+horizontal overflow.
+
 ## Deployment and validation notes
 
 Validate the deployed staging build at

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -121,5 +121,6 @@ npm run typecheck
 npm run test:ci
 npm run test:e2e -- --grep "zoom"
 npm run test:e2e -- --grep "performance failover"
+npm run test:e2e -- --grep "text fallback"
 npm run smoke
 ```

--- a/playwright/text-fallback-layout.spec.ts
+++ b/playwright/text-fallback-layout.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const TEXT_FALLBACK_URL = '/?mode=text';
+const FALLBACK_READY_SELECTOR = '#app[data-mode="text"] .text-fallback';
+const OVERFLOW_TOLERANCE_PX = 1;
+
+async function waitForTextFallback(page: Page) {
+  await page.goto(TEXT_FALLBACK_URL, { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'fallback'
+  );
+  await expect(page.locator(FALLBACK_READY_SELECTOR)).toBeVisible();
+}
+
+async function assertTopCopyVisible(page: Page) {
+  await page.evaluate(() => window.scrollTo(0, 0));
+
+  const topCopyBounds = await page.evaluate(() => {
+    const title = document.querySelector('.text-fallback__title');
+    const description = document.querySelector('.text-fallback__description');
+
+    if (!title || !description) {
+      throw new Error('Missing text fallback title or description.');
+    }
+
+    const titleRect = title.getBoundingClientRect();
+    const descriptionRect = description.getBoundingClientRect();
+
+    return {
+      descriptionBottom: descriptionRect.bottom,
+      descriptionTop: descriptionRect.top,
+      titleBottom: titleRect.bottom,
+      titleTop: titleRect.top,
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(topCopyBounds.titleTop).toBeGreaterThanOrEqual(0);
+  expect(topCopyBounds.titleBottom).toBeLessThanOrEqual(
+    topCopyBounds.viewportHeight
+  );
+  expect(topCopyBounds.descriptionTop).toBeGreaterThanOrEqual(0);
+  expect(topCopyBounds.descriptionBottom).toBeLessThanOrEqual(
+    topCopyBounds.viewportHeight
+  );
+}
+
+async function assertPageScrollsToFinalContent(page: Page) {
+  const scrollMetrics = await page.evaluate(() => ({
+    clientHeight: document.documentElement.clientHeight,
+    scrollHeight: document.documentElement.scrollHeight,
+  }));
+
+  expect(scrollMetrics.scrollHeight).toBeGreaterThan(
+    scrollMetrics.clientHeight
+  );
+
+  await page.evaluate(() =>
+    window.scrollTo(0, document.documentElement.scrollHeight)
+  );
+
+  const finalPoiBounds = await page.evaluate(() => {
+    const finalPoi = Array.from(
+      document.querySelectorAll('.text-fallback__poi')
+    ).at(-1);
+
+    if (!finalPoi) {
+      throw new Error('Missing final text fallback POI.');
+    }
+
+    const rect = finalPoi.getBoundingClientRect();
+
+    return {
+      bottom: rect.bottom,
+      top: rect.top,
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(finalPoiBounds.top).toBeLessThan(finalPoiBounds.viewportHeight);
+  expect(finalPoiBounds.bottom).toBeGreaterThan(0);
+}
+
+async function assertNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+
+  expect(overflow.scrollWidth).toBeLessThanOrEqual(
+    overflow.clientWidth + OVERFLOW_TOLERANCE_PX
+  );
+}
+
+async function assertScrollableFallbackLayout(page: Page) {
+  await assertTopCopyVisible(page);
+  await assertPageScrollsToFinalContent(page);
+  await assertNoHorizontalOverflow(page);
+}
+
+test.describe('text fallback layout', () => {
+  test('keeps the desktop fallback top-aligned, scrollable, and horizontally contained', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await waitForTextFallback(page);
+
+    await assertScrollableFallbackLayout(page);
+  });
+
+  test('keeps the mobile fallback top-aligned, scrollable, and horizontally contained', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForTextFallback(page);
+
+    await assertScrollableFallbackLayout(page);
+  });
+
+  test('uses the same scrollable layout for automated-client runtime fallback', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.removeItem('danielsmith.io:mode-preference');
+        window.sessionStorage.removeItem('danielsmith.io:mode-preference');
+      } catch {
+        // Ignore inaccessible storage in hardened browser contexts.
+      }
+
+      try {
+        Object.defineProperty(Navigator.prototype, 'webdriver', {
+          configurable: true,
+          get: () => true,
+        });
+      } catch {
+        // Ignore browser contexts that do not allow webdriver overrides.
+      }
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-fallback-reason',
+      'automated-client'
+    );
+    await expect(page.locator(FALLBACK_READY_SELECTOR)).toBeVisible();
+
+    await assertScrollableFallbackLayout(page);
+  });
+});

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -47,16 +47,34 @@ body {
   background: #04070d;
 }
 
+html[data-app-mode='fallback'],
+html[data-app-mode='fallback'] body {
+  min-height: 100%;
+  height: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 #app {
   width: 100%;
   height: 100%;
 }
 
 #app[data-mode='text'] {
+  min-height: 100dvh;
+  height: auto;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 2rem;
+  justify-content: flex-start;
+  overflow: visible;
+  padding-block-start: max(clamp(1.25rem, 4vw, 2rem), env(safe-area-inset-top));
+  padding-block-end: max(
+    clamp(1.25rem, 4vw, 2rem),
+    env(safe-area-inset-bottom)
+  );
+  padding-inline-start: max(clamp(1rem, 4vw, 2rem), env(safe-area-inset-left));
+  padding-inline-end: max(clamp(1rem, 4vw, 2rem), env(safe-area-inset-right));
 }
 
 canvas {
@@ -68,9 +86,9 @@ canvas {
 }
 
 .text-fallback {
+  width: min(32rem, 100%);
   margin: 0 auto;
   padding: 3rem 1.75rem;
-  max-width: 32rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;


### PR DESCRIPTION
### Motivation
- The text-only fallback could be vertically centered inside a fixed-height app root so a tall `.text-fallback` card started mid-page and the top (title/description) was clipped outside the scrollable range. 
- Root cause: `#app` and `html, body` were fixed to `height: 100%` while `#app[data-mode='text']` used flex centering, which pushes tall children into negative Y overflow when they exceed viewport height.

### Description
- Restore document-flow scrolling for fallback by making `html[data-app-mode='fallback']` / `body` and `#app[data-mode='text']` top-aligned, `height: auto` / `min-height: 100dvh`, visible overflow, and safe-area-aware padding in `src/ui/styles.css`.
- Keep the centered card feel by constraining the card with `width: min(32rem, 100%)` and centering inline in `.text-fallback` and align the no-JS fallback in `index.html` to the same top-first layout.
- Add Playwright regression tests at `playwright/text-fallback-layout.spec.ts` to assert top-copy visibility at scroll 0, full-page scrollability to the final POI, and no horizontal overflow across desktop (1280×720), mobile (390×844), and automated-client runtime fallback.
- Update documentation and outage bookkeeping: add a short entry to `docs/architecture/performance-budgets.md` and append a follow-up section to `outages/2026-05-28-danielsmith-staging-zoom-fallback.{md,json}` describing symptoms, root cause, corrective action, and the new regression coverage.

### Testing
- Ran formatting with `npm run format:write` which completed successfully.
- Ran lint with `npm run lint` which completed successfully.
- Ran type-check with `npm run typecheck` which failed due to existing unrelated TypeScript errors elsewhere in the repo (these pre-existed and are outside this focused layout change).
- Ran unit CI tests with `npm run test:ci` (Vitest) which passed (`833 tests, 833 passed` reported by the run).
- Ran docs validation with `npm run docs:check` which passed.
- Built and verified the production bundle with `npm run smoke` which passed.
- Executed Playwright E2E for the new layout checks with `npm run test:e2e -- --grep "text fallback"` after installing Playwright browser dependencies and system deps, and the three new tests passed.
- Captured a runtime screenshot via Playwright (`npx playwright screenshot --viewport-size=1280,720 'http://127.0.0.1:5173/?mode=text' /tmp/text-fallback-layout.png`) to verify visual layout.

Notes: the change is intentionally scoped to fallback layout, no runtime failover heuristics or rendering pipeline were modified here; the unrelated TypeScript errors surfaced by `npm run typecheck` pre-exist and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f3ffb5b8832fb8d7657bd7440b16)