### PR TITLE
Fix text fallback scrolling layout

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -56,3 +56,27 @@ and the Vitest assertions when measurable changes land.
 4. Verify in the immersive build by launching
    `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1` and
    toggling `Shift+L` to compare debug vs. cinematic passes.
+
+## 2026-05-29 text fallback clipping incident
+
+- **Symptoms** – When staging switched to the text fallback, the portfolio card started
+  mid-page with its heading clipped above the viewport. Users could scroll down through
+  content, but scroll position `0` could not reveal the missing title or introductory copy.
+- **Impact** – Explicit `?mode=text`, runtime performance failover, automated-client
+  fallback, and other rendered text-mode paths could hide the first fallback content on
+  short desktop viewports once the full exhibit list made the card taller than the window.
+- **Root cause** – `html`, `body`, and `#app` used fixed `height: 100%` sizing while
+  `#app[data-mode='text']` vertically centered the tall `.text-fallback` flex item.
+  Centering a flex child taller than its fixed-height container created negative-Y overflow
+  above the document scroll range.
+- **Corrective action** – Fallback mode now lets `html`/`body` grow in normal document
+  flow, top-aligns the text-mode app container, preserves the centered card width with
+  logical/safe-area padding, and keeps vertical overflow on the document rather than inside
+  a clipped fixed-height parent.
+- **Regression tests** – `playwright/text-fallback-layout.spec.ts` covers 1280×720 and
+  390×844 viewports, asserting the title is fully visible at scroll top, the document can
+  scroll to the final exhibit card, and horizontal overflow stays within a one-pixel
+  rounding tolerance.
+- **Validation notes** – Run `npm run test:e2e -- --grep "text fallback"` alongside the
+  normal lint, typecheck, unit, docs, and smoke checks after layout changes touching the
+  fallback experience.

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -7,7 +7,8 @@
     "Initial immersive render looked normal.",
     "Mouse-wheel orthographic zoom left prior full-scene frames visible as duplicated geometry/trails.",
     "Production-like staging sessions with runtime performance failover enabled switched from immersive mode to text fallback after roughly 5-10 seconds of normal zooming.",
-    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug."
+    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug.",
+    "Related 2026-05-29 follow-up: text fallback content was clipped above the viewport and impossible to scroll back to the title when the fallback card exceeded viewport height."
   ],
   "impact": "Staging immersive validation showed corrupted zoom/pan rendering and could exit to the text fallback during ordinary browser input, risking confusion with broader WebGL or performance-failover behavior.",
   "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming, then production-like /?mode=immersive validation where only preflight routing is bypassed and runtime failover remains enabled; now covered by Playwright zoom and performance failover regression tests.",
@@ -19,13 +20,15 @@
     "History resets when toggling motion blur to/from zero, when camera zoom/projection changes, and at camera-pan start/release boundaries so continuous pan does not clear every frame.",
     "A narrow window.portfolio.graphics hook supports production-safe browser regression tests.",
     "Production-like /?mode=immersive Playwright coverage now omits the explicit disablePerformanceFailover=1 bypass, keeps runtime failover enabled during wheel zoom for longer than the 5-second low-FPS window, and fails on performancefailover events, fallback mode, text mode, console fallback warnings, or duplicate canvases.",
-    "Runtime performance failover remains enabled for genuine sustained low FPS, unsupported WebGL, automated clients, explicit text mode, and related low-capability cases."
+    "Runtime performance failover remains enabled for genuine sustained low FPS, unsupported WebGL, automated clients, explicit text mode, and related low-capability cases.",
+    "Text fallback layout now uses top-aligned normal document flow with root document scrolling, centered card width, and safe-area-aware padding instead of vertically centering a tall card inside fixed-height #app."
   ],
   "regressionTests": [
     "Vitest coverage for zero no-op/disable behavior, invalid clamping, corrected damp mapping, history resets, and disposal.",
     "Vitest performance-failover coverage proves normal FPS for more than five seconds never triggers, intermittent low FPS resets when performance recovers, sustained very-low FPS triggers, and low-performance transitions dispatch a performancefailover event with reason low-performance.",
     "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling.",
-    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active."
+    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active.",
+    "Playwright text fallback layout coverage verifies 1280x720 and 390x844 viewports keep the title visible at scroll top, scroll to the final exhibit card, and avoid horizontal overflow."
   ],
   "validationCommands": [
     "npm run format:write",
@@ -34,7 +37,20 @@
     "npm run test:ci",
     "npm run test:e2e -- --grep \"zoom\"",
     "npm run test:e2e -- --grep \"performance failover\"",
+    "npm run test:e2e -- --grep \"text fallback\"",
     "npm run smoke"
   ],
-  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases."
+  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases.",
+  "textFallbackClippingFollowUp": {
+    "date": "2026-05-29",
+    "symptom": "Text fallback content was clipped above the viewport and impossible to scroll to the title/description at document scroll position 0.",
+    "impact": "Explicit text mode, runtime performance fallback, automated-client fallback, and related rendered fallback paths could hide the beginning of the recovery content on short viewports.",
+    "rootCause": "Fixed-height html/body/#app shell plus vertically centered #app[data-mode=text] flex layout placed a tall .text-fallback card partly above the document scroll range.",
+    "correctiveAction": "Allow fallback html/body and #app[data-mode=text] to grow in normal document flow, top-align the card, preserve horizontal centering, and use safe-area-aware padding with document-level scrolling.",
+    "regressionTests": [
+      "playwright/text-fallback-layout.spec.ts at 1280x720",
+      "playwright/text-fallback-layout.spec.ts at 390x844"
+    ],
+    "validation": "npm run test:e2e -- --grep \"text fallback\""
+  }
 }

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -87,6 +87,27 @@ not evidence that the runtime failover feature should be removed or weakened.
   routing heuristics while leaving runtime failover enabled, and asserts normal
   wheel zoom/pan remains immersive for longer than the 5-second low-FPS window.
 
+## Related text fallback clipping follow-up (2026-05-29)
+
+When the staging session fell through to text mode, the fallback page itself had
+a separate layout defect: the top of the text card was clipped above the
+viewport and normal scrolling could not reach the title or introductory copy.
+The impact was limited to rendered text fallback paths (`?mode=text`, runtime
+performance fallback, automated-client fallback, and related low-capability
+routes), but it made the recovery experience feel broken when the prior zoom
+incident exposed fallback mode.
+
+The root cause was the fixed-height document/app shell combined with
+`#app[data-mode='text']` vertically centering a `.text-fallback` card that can
+be taller than short viewports. The corrective action top-aligns text mode in
+normal document flow, allows fallback pages to grow and scroll from the
+document root, preserves the centered card width, and applies logical/safe-area
+padding to avoid horizontal overflow. Playwright regression coverage now checks
+1280×720 and 390×844 viewports for a visible title at scroll top, scrollability
+to the final exhibit card, and no horizontal overflow. Validate with
+`npm run test:e2e -- --grep "text fallback"` in addition to the existing zoom
+and performance-failover checks.
+
 ## Deployment and validation notes
 
 Validate the deployed staging build at
@@ -106,5 +127,6 @@ npm run typecheck
 npm run test:ci
 npm run test:e2e -- --grep "zoom"
 npm run test:e2e -- --grep "performance failover"
+npm run test:e2e -- --grep "text fallback"
 npm run smoke
 ```

--- a/playwright/text-fallback-layout.spec.ts
+++ b/playwright/text-fallback-layout.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const TEXT_FALLBACK_URL = '/?mode=text';
+
+async function expectScrollableTextFallback(page: Page) {
+  await page.goto(TEXT_FALLBACK_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#app[data-mode="text"] .text-fallback');
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+
+  const titleRect = await page.locator('.text-fallback__title').boundingBox();
+  expect(titleRect).not.toBeNull();
+  expect(titleRect?.y ?? -1).toBeGreaterThanOrEqual(0);
+  expect((titleRect?.y ?? 0) + (titleRect?.height ?? 0)).toBeLessThanOrEqual(
+    page.viewportSize()?.height ?? 0
+  );
+
+  const initialMetrics = await page.evaluate(() => ({
+    clientHeight: document.documentElement.clientHeight,
+    scrollHeight: document.documentElement.scrollHeight,
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+
+  expect(initialMetrics.scrollHeight).toBeGreaterThan(
+    initialMetrics.clientHeight
+  );
+  expect(initialMetrics.scrollWidth).toBeLessThanOrEqual(
+    initialMetrics.clientWidth + 1
+  );
+
+  await page.evaluate(() =>
+    window.scrollTo(0, document.documentElement.scrollHeight)
+  );
+
+  const finalPoi = page.locator('.text-fallback__poi').last();
+  await expect(finalPoi).toBeVisible();
+
+  const bottomMetrics = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(bottomMetrics.scrollWidth).toBeLessThanOrEqual(
+    bottomMetrics.clientWidth + 1
+  );
+}
+
+test.describe('text fallback layout', () => {
+  test('keeps the title visible and scrolls through the final exhibit on desktop', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await expectScrollableTextFallback(page);
+  });
+
+  test('keeps the title visible and avoids horizontal overflow on mobile', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await expectScrollableTextFallback(page);
+  });
+});

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -47,16 +47,31 @@ body {
   background: #04070d;
 }
 
+html[data-app-mode='fallback'],
+html[data-app-mode='fallback'] body {
+  min-height: 100%;
+  height: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 #app {
   width: 100%;
   height: 100%;
 }
 
 #app[data-mode='text'] {
+  min-height: 100dvh;
+  height: auto;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 2rem;
+  justify-content: flex-start;
+  padding-block: max(2rem, env(safe-area-inset-top))
+    max(2rem, env(safe-area-inset-bottom));
+  padding-inline: max(1rem, env(safe-area-inset-left))
+    max(1rem, env(safe-area-inset-right));
+  overflow: visible;
 }
 
 canvas {
@@ -68,6 +83,7 @@ canvas {
 }
 
 .text-fallback {
+  width: min(32rem, 100%);
   margin: 0 auto;
   padding: 3rem 1.75rem;
   max-width: 32rem;


### PR DESCRIPTION
### Motivation
- The text-only fallback could render its centered `.text-fallback` card taller than a fixed-height `#app`, causing the title to be clipped above the viewport and unreachable at scroll position 0.
- The change ensures fallback pages use normal document-flow scrolling so the title and intro are visible at the top and the page can scroll to the final content while preserving a centered card feel and safe-area insets.

### Description
- Stop vertically centering the fallback card and allow document-level scrolling by updating `html`/`body` and `#app[data-mode='text']` sizing/padding in `src/ui/styles.css`, including safe-area-aware logical padding and `min-height: 100dvh` for text mode.
- Keep the horizontally centered card look and prevent horizontal overflow by constraining `.text-fallback` to `width: min(32rem, 100%)` and adding `overflow-x: hidden` protections.
- Add end-to-end coverage: `playwright/text-fallback-layout.spec.ts` verifies title visibility at scroll top, document scrollability to the final exhibit, and no horizontal overflow at both 1280×720 and 390×844 viewports.
- Document the follow-up in the performance overview and update the existing 2026-05-28 outage entry with symptoms, root cause, corrective action, regression tests, and validation commands.

### Testing
- Ran formatting and linting via `npm run format:write` and `npm run lint`, both succeeded.
- Ran unit/test suite via `npm run test:ci` (Vitest) which completed successfully (`126 files / 833 tests passed`).
- Ran Playwright e2e specifically for the new checks via `npm run test:e2e -- --grep "text fallback"` after installing Playwright browsers and host deps, and the two new tests passed (2 passed).
- Additional checks: `npm run docs:check` and `npm run smoke` passed; `npm run typecheck` failed due to pre-existing repository TypeScript errors unrelated to this layout change (reported and left unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f3ffb5b8832fb8d7657bd7440b16)