### PR TITLE
Fix text fallback scrolling

### DIFF
--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -7,12 +7,14 @@
     "Initial immersive render looked normal.",
     "Mouse-wheel orthographic zoom left prior full-scene frames visible as duplicated geometry/trails.",
     "Production-like staging sessions with runtime performance failover enabled switched from immersive mode to text fallback after roughly 5-10 seconds of normal zooming.",
-    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug."
+    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug.",
+    "Text fallback content could start mid-page with the title clipped above the viewport and no way to scroll upward to it."
   ],
-  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and could exit to the text fallback during ordinary browser input, risking confusion with broader WebGL or performance-failover behavior.",
+  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and could exit to the text fallback during ordinary browser input. When fallback appeared, visitors could miss the opening context because the text card was clipped above the scrollable viewport, risking confusion with broader WebGL or performance-failover behavior.",
   "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming, then production-like /?mode=immersive validation where only preflight routing is bypassed and runtime failover remains enabled; now covered by Playwright zoom and performance failover regression tests.",
-  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. The observed text fallback was likely a secondary reaction to sustained low FPS caused by the rendering bug, not evidence that runtime failover should be removed or weakened.",
+  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. The observed text fallback was likely a secondary reaction to sustained low FPS caused by the rendering bug, not evidence that runtime failover should be removed or weakened. The fallback clipping had a separate layout root cause: fixed-height #app plus vertical flex centering of a .text-fallback card taller than the viewport produced negative-Y overflow outside the scrollable range.",
   "correctiveAction": [
+    "Text mode now uses a normal document-flow fallback layout: height-auto shell, min-viewport-height, top-aligned scrolling, safe-area-aware padding, and a horizontally centered card.",
     "Default motion blur intensity changed to zero so scene-wide afterimage is not active by default.",
     "Intensity zero disables AfterimagePass, maps to damp 0, and schedules feedback-history reset.",
     "Nonzero intensity now maps upward toward max damp.",
@@ -25,7 +27,8 @@
     "Vitest coverage for zero no-op/disable behavior, invalid clamping, corrected damp mapping, history resets, and disposal.",
     "Vitest performance-failover coverage proves normal FPS for more than five seconds never triggers, intermittent low FPS resets when performance recovers, sustained very-low FPS triggers, and low-performance transitions dispatch a performancefailover event with reason low-performance.",
     "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling.",
-    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active."
+    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active.",
+    "Playwright text fallback layout coverage loads /?mode=text at 1280x720 and 390x844, then asserts the title is visible at scroll position zero, the final fallback POI is reachable after scrolling, and horizontal overflow is absent."
   ],
   "validationCommands": [
     "npm run format:write",
@@ -34,7 +37,8 @@
     "npm run test:ci",
     "npm run test:e2e -- --grep \"zoom\"",
     "npm run test:e2e -- --grep \"performance failover\"",
+    "npm run test:e2e -- --grep \"text fallback\"",
     "npm run smoke"
   ],
-  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases."
+  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases. Also validate /?mode=text at desktop and mobile widths to confirm the title is visible at scroll position zero and the last fallback POI is reachable by normal scrolling."
 }

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -14,14 +14,18 @@ with runtime performance failover enabled, normal zoom eventually switched the
 immersive scene into the text fallback after roughly 5–10 seconds.
 
 A key field observation was that setting the in-app motion blur slider to zero
-did **not** eliminate the artifact on staging.
+did **not** eliminate the artifact on staging. When fallback did appear, the
+text page started mid-content: its title and introductory copy were clipped
+above the viewport, and normal scrolling could not move farther upward.
 
 ## Impact
 
 The staging immersive experience looked corrupted during normal zoom/pan
 interactions and could exit to the text fallback during otherwise ordinary
-browser input. The issue risked confusing validation because graphics corruption
-could be mistaken for a broader WebGL or performance-failover problem.
+browser input. When fallback appeared, visitors could miss the opening context
+and start the portfolio in the middle of the exhibit list. The issue risked
+confusing validation because graphics corruption and fallback layout clipping
+could be mistaken for broader WebGL or performance-failover problems.
 
 ## Detection
 
@@ -48,8 +52,16 @@ missing zero-intensity no-op/disable behavior. The observed text fallback was
 likely a secondary reaction to sustained low FPS caused by the rendering bug,
 not evidence that the runtime failover feature should be removed or weakened.
 
+The fallback clipping had a separate layout root cause: the fallback reused the
+full-height `#app` shell and centered `.text-fallback` as a flex item. Once the
+full portfolio/exhibit card became taller than the viewport, vertical centering
+produced negative-Y overflow outside the scrollable range.
+
 ## Corrective action
 
+- Text mode now uses a normal document-flow layout: the fallback shell is
+  height-auto, min-viewport-height, top-aligned, and padded with safe-area-aware
+  spacing while the card remains horizontally centered.
 - Default immersive rendering now creates the motion blur controller at zero
   intensity so scene-wide afterimage is not active by default.
 - Intensity zero now disables the `AfterimagePass`, maps to clearing damp `0`,
@@ -86,6 +98,9 @@ not evidence that the runtime failover feature should be removed or weakened.
   production-like `/?mode=immersive` session, which bypasses only preflight
   routing heuristics while leaving runtime failover enabled, and asserts normal
   wheel zoom/pan remains immersive for longer than the 5-second low-FPS window.
+- Playwright `text fallback layout` covers `/?mode=text` at 1280×720 and
+  390×844, asserting title visibility at scroll position zero, reachability of
+  the final fallback POI after scrolling, and no horizontal overflow.
 
 ## Deployment and validation notes
 
@@ -95,7 +110,10 @@ and `https://staging.danielsmith.io/?mode=immersive`. Confirm the initial
 render is clean, wheel zooming does not stack previous camera projections, the
 motion blur slider at zero remains clean, returning from nonzero blur to zero
 clears residual trails, and normal zoom does not reveal the text fallback while
-runtime failover remains available for genuine low-performance cases.
+runtime failover remains available for genuine low-performance cases. Also
+validate `/?mode=text` at desktop and mobile widths to confirm the title is
+visible at scroll position zero and the last fallback POI is reachable by normal
+scrolling.
 
 Expected validation commands:
 
@@ -106,5 +124,6 @@ npm run typecheck
 npm run test:ci
 npm run test:e2e -- --grep "zoom"
 npm run test:e2e -- --grep "performance failover"
+npm run test:e2e -- --grep "text fallback"
 npm run smoke
 ```

--- a/playwright/text-fallback-layout.spec.ts
+++ b/playwright/text-fallback-layout.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const TEXT_FALLBACK_URL = '/?mode=text';
+const VIEWPORTS = [
+  { name: 'desktop', width: 1280, height: 720 },
+  { name: 'mobile', width: 390, height: 844 },
+] as const;
+
+async function waitForTextFallback(page: Page) {
+  await page.goto(TEXT_FALLBACK_URL, { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'fallback'
+  );
+  await expect(
+    page.locator('#app[data-mode="text"] .text-fallback')
+  ).toBeVisible();
+}
+
+async function assertIntroStartsInsideViewport(page: Page) {
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const viewportHeight = page.viewportSize()?.height ?? 0;
+  for (const selector of [
+    '.text-fallback__title',
+    '.text-fallback__description',
+  ]) {
+    const box = await page.locator(selector).boundingBox();
+    expect(box).not.toBeNull();
+    expect(box?.y).toBeGreaterThanOrEqual(0);
+    expect((box?.y ?? 0) + (box?.height ?? 0)).toBeLessThanOrEqual(
+      viewportHeight
+    );
+  }
+}
+
+async function assertDocumentScrollsToFinalFallbackContent(page: Page) {
+  const scrollMetrics = await page.evaluate(() => ({
+    clientHeight: document.documentElement.clientHeight,
+    scrollHeight: document.documentElement.scrollHeight,
+  }));
+  expect(scrollMetrics.scrollHeight).toBeGreaterThan(
+    scrollMetrics.clientHeight
+  );
+
+  await page.evaluate(() =>
+    window.scrollTo(0, document.documentElement.scrollHeight)
+  );
+  const finalPoi = page.locator('.text-fallback__poi').last();
+  await expect(finalPoi).toBeInViewport();
+}
+
+async function assertNoHorizontalOverflow(page: Page) {
+  const overflowMetrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(overflowMetrics.scrollWidth).toBeLessThanOrEqual(
+    overflowMetrics.clientWidth + 1
+  );
+}
+
+test.describe('text fallback layout', () => {
+  for (const viewport of VIEWPORTS) {
+    test(`${viewport.name} starts at the title and scrolls through all content`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await waitForTextFallback(page);
+
+      await assertIntroStartsInsideViewport(page);
+      await assertDocumentScrollsToFinalFallbackContent(page);
+      await assertNoHorizontalOverflow(page);
+    });
+  }
+});

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -47,16 +47,30 @@ body {
   background: #04070d;
 }
 
+html[data-app-mode='fallback'],
+html[data-app-mode='fallback'] body {
+  min-height: 100%;
+  height: auto;
+  overflow-y: auto;
+}
+
 #app {
   width: 100%;
   height: 100%;
 }
 
 #app[data-mode='text'] {
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: auto;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 2rem;
+  justify-content: flex-start;
+  padding: calc(2rem + env(safe-area-inset-top, 0px))
+    calc(clamp(1rem, 4vw, 2rem) + env(safe-area-inset-right, 0px))
+    calc(2rem + env(safe-area-inset-bottom, 0px))
+    calc(clamp(1rem, 4vw, 2rem) + env(safe-area-inset-left, 0px));
+  overflow: visible;
 }
 
 canvas {
@@ -68,6 +82,7 @@ canvas {
 }
 
 .text-fallback {
+  width: min(32rem, 100%);
   margin: 0 auto;
   padding: 3rem 1.75rem;
   max-width: 32rem;


### PR DESCRIPTION
### Motivation
- Fix a staging bug where the text-only fallback was vertically centered inside a fixed-height shell, causing the fallback title/intro to be clipped above the viewport and unreachable by normal scrolling.
- Add deterministic regression coverage so future changes cannot reintroduce clipped fallback content on desktop or mobile viewports.

### Description
- Adjusted fallback layout in `src/ui/styles.css` to make fallback/page surfaces use normal document flow: added `html[data-app-mode='fallback']` rules, made `#app[data-mode='text']` auto-height/top-aligned with safe-area-aware padding, and constrained `.text-fallback` to `width: min(32rem, 100%)` so the card remains horizontally centered without negative-Y overflow.
- Added an end-to-end Playwright spec `playwright/text-fallback-layout.spec.ts` that verifies at 1280×720 and 390×844 the title/description are visible at scroll position 0, the page scrolls to the final fallback POI, and there is no horizontal overflow.
- Updated the existing outage entry `outages/2026-05-28-danielsmith-staging-zoom-fallback.{md,json}` to record the fallback-clipping symptom, identify the fixed-height + flex-centering root cause, list the corrective action, and reference the new Playwright coverage.

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed.
- `npm run typecheck` — failed due to pre-existing TypeScript errors unrelated to this change (these errors were present in the repo before this patch).
- `npm run test:ci` (Vitest) — passed (unit test suite run completed successfully).
- `npm run test:e2e -- --grep "text fallback"` (Playwright) — passed (desktop and mobile text-fallback layout checks).
- `npm run docs:check` — passed.
- `npm run smoke` — passed (build + dist assertions).
- `git diff --cached | ./scripts/scan-secrets.py` — passed (no high-risk secrets detected).

Notes: Typecheck failures are from unrelated, pre-existing repository type issues; the CSS and Playwright changes were validated end-to-end and the Playwright suite required installing browser deps during the run to execute in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f3ffb5b8832fb8d7657bd7440b16)