### PR TITLE
Fix text-fallback top clipping and scrolling

### DIFF
--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.json
@@ -7,11 +7,12 @@
     "Initial immersive render looked normal.",
     "Mouse-wheel orthographic zoom left prior full-scene frames visible as duplicated geometry/trails.",
     "Production-like staging sessions with runtime performance failover enabled switched from immersive mode to text fallback after roughly 5-10 seconds of normal zooming.",
-    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug."
+    "Setting the in-app motion blur slider to zero on staging did not eliminate the bug.",
+    "Text fallback content could be clipped above the viewport, leaving the title and introductory copy unreachable by upward scrolling."
   ],
-  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and could exit to the text fallback during ordinary browser input, risking confusion with broader WebGL or performance-failover behavior.",
+  "impact": "Staging immersive validation showed corrupted zoom/pan rendering and could exit to the text fallback during ordinary browser input, risking confusion with broader WebGL or performance-failover behavior. The clipping also made the accessible text-only portfolio incomplete for visitors in explicit text mode or supported fallback paths.",
   "detection": "Manual staging validation of /?mode=immersive&disablePerformanceFailover=1 followed by wheel zooming, then production-like /?mode=immersive validation where only preflight routing is bypassed and runtime failover remains enabled; now covered by Playwright zoom and performance failover regression tests.",
-  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. The observed text fallback was likely a secondary reaction to sustained low FPS caused by the rendering bug, not evidence that runtime failover should be removed or weakened.",
+  "rootCause": "The postprocessing chain always ran Three.js AfterimagePass. The controller mapped intensity 0 to damp 1 even though AfterimagePass preserves more old pixels as damp approaches 1 and clears history at damp 0. The pass also remained enabled at zero, allowing stale feedback buffers across orthographic projection changes. The observed text fallback was likely a secondary reaction to sustained low FPS caused by the rendering bug, not evidence that runtime failover should be removed or weakened. The fallback clipping was a separate layout bug caused by fixed-height html/body/#app containers plus vertical flex centering of a fallback card that can be taller than the viewport.",
   "correctiveAction": [
     "Default motion blur intensity changed to zero so scene-wide afterimage is not active by default.",
     "Intensity zero disables AfterimagePass, maps to damp 0, and schedules feedback-history reset.",
@@ -19,13 +20,15 @@
     "History resets when toggling motion blur to/from zero, when camera zoom/projection changes, and at camera-pan start/release boundaries so continuous pan does not clear every frame.",
     "A narrow window.portfolio.graphics hook supports production-safe browser regression tests.",
     "Production-like /?mode=immersive Playwright coverage now omits the explicit disablePerformanceFailover=1 bypass, keeps runtime failover enabled during wheel zoom for longer than the 5-second low-FPS window, and fails on performancefailover events, fallback mode, text mode, console fallback warnings, or duplicate canvases.",
-    "Runtime performance failover remains enabled for genuine sustained low FPS, unsupported WebGL, automated clients, explicit text mode, and related low-capability cases."
+    "Runtime performance failover remains enabled for genuine sustained low FPS, unsupported WebGL, automated clients, explicit text mode, and related low-capability cases.",
+    "Text fallback mode now uses normal document-flow scrolling with a top-aligned, horizontally centered card, safe-area-aware padding, and long-content wrapping to prevent horizontal overflow."
   ],
   "regressionTests": [
     "Vitest coverage for zero no-op/disable behavior, invalid clamping, corrected damp mapping, history resets, and disposal.",
     "Vitest performance-failover coverage proves normal FPS for more than five seconds never triggers, intermittent low FPS resets when performance recovers, sustained very-low FPS triggers, and low-performance transitions dispatch a performancefailover event with reason low-performance.",
     "Playwright immersive zoom coverage for one canvas, no text fallback, repeated wheel zoom, zero blur, motion-blur reset telemetry for stale/duplicated-frame symptoms, and nonzero-to-zero toggling.",
-    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active."
+    "Playwright performance failover runtime zoom coverage loads /?mode=immersive, which bypasses only preflight routing heuristics and omits disablePerformanceFailover=1, then asserts ordinary zoom remains immersive while runtime failover is active.",
+    "Playwright text fallback layout coverage verifies explicit /?mode=text at 1280x720 and 390x844 plus automated-client fallback at 1280x720: title visible at scroll top, final portfolio POI reachable at scroll bottom, and no horizontal overflow."
   ],
   "validationCommands": [
     "npm run format:write",
@@ -34,7 +37,8 @@
     "npm run test:ci",
     "npm run test:e2e -- --grep \"zoom\"",
     "npm run test:e2e -- --grep \"performance failover\"",
+    "npm run test:e2e -- --grep \"text fallback\"",
     "npm run smoke"
   ],
-  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases."
+  "deploymentValidation": "After deployment, validate https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1 for clean initial render, clean wheel zoom, clean zero motion blur, and cleared trails after toggling nonzero blur back to zero. Also validate https://staging.danielsmith.io/?mode=immersive to confirm normal zoom does not reveal the text fallback while runtime failover remains available for genuine low-performance cases. Also validate https://staging.danielsmith.io/?mode=text at desktop and mobile-ish viewport widths for a visible title at scroll position 0 and reachable final fallback portfolio content."
 }

--- a/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
+++ b/outages/2026-05-28-danielsmith-staging-zoom-fallback.md
@@ -11,7 +11,9 @@ orthographic camera caused prior full-scene frames to remain visible. Visitors
 could see stacked or duplicated room geometry and trails from old camera
 projections instead of a clean scale change. In production-like staging sessions
 with runtime performance failover enabled, normal zoom eventually switched the
-immersive scene into the text fallback after roughly 5–10 seconds.
+immersive scene into the text fallback after roughly 5–10 seconds. When the text
+fallback rendered, its content could be clipped above the viewport and visitors
+could not scroll upward to reach the title or introductory description.
 
 A key field observation was that setting the in-app motion blur slider to zero
 did **not** eliminate the artifact on staging.
@@ -21,7 +23,10 @@ did **not** eliminate the artifact on staging.
 The staging immersive experience looked corrupted during normal zoom/pan
 interactions and could exit to the text fallback during otherwise ordinary
 browser input. The issue risked confusing validation because graphics corruption
-could be mistaken for a broader WebGL or performance-failover problem.
+could be mistaken for a broader WebGL or performance-failover problem. The
+fallback clipping also made the accessible, text-only portfolio incomplete for
+visitors who intentionally selected text mode or were routed there by supported
+failover paths.
 
 ## Detection
 
@@ -48,6 +53,12 @@ missing zero-intensity no-op/disable behavior. The observed text fallback was
 likely a secondary reaction to sustained low FPS caused by the rendering bug,
 not evidence that the runtime failover feature should be removed or weakened.
 
+The fallback clipping was a separate layout bug: `html`, `body`, and `#app`
+used fixed `height: 100%`, while `#app[data-mode='text']` vertically centered
+the fallback card with flexbox. Once the portfolio/exhibits card grew taller
+than the viewport, centering placed the top of that flex item above the
+scrollable range.
+
 ## Corrective action
 
 - Default immersive rendering now creates the motion blur controller at zero
@@ -68,6 +79,10 @@ not evidence that the runtime failover feature should be removed or weakened.
 - Runtime performance failover remains enabled for genuine sustained low FPS,
   unsupported WebGL, automated clients, explicit text mode, and related
   low-capability cases.
+- Text fallback mode now opts `html`, `body`, and `#app[data-mode='text']` into
+  normal document-flow scrolling, top-aligns the fallback card, preserves the
+  horizontally centered card width, respects safe-area padding, and wraps long
+  fallback links/metrics to prevent horizontal overflow.
 
 ## Regression tests
 
@@ -86,6 +101,10 @@ not evidence that the runtime failover feature should be removed or weakened.
   production-like `/?mode=immersive` session, which bypasses only preflight
   routing heuristics while leaving runtime failover enabled, and asserts normal
   wheel zoom/pan remains immersive for longer than the 5-second low-FPS window.
+- Playwright `text fallback layout` covers explicit `/?mode=text` at 1280×720
+  and 390×844, plus automated-client fallback at 1280×720. It asserts the title
+  starts inside the viewport at scroll position 0, the document scrolls to the
+  final portfolio POI, and the document has no horizontal overflow.
 
 ## Deployment and validation notes
 
@@ -95,7 +114,10 @@ and `https://staging.danielsmith.io/?mode=immersive`. Confirm the initial
 render is clean, wheel zooming does not stack previous camera projections, the
 motion blur slider at zero remains clean, returning from nonzero blur to zero
 clears residual trails, and normal zoom does not reveal the text fallback while
-runtime failover remains available for genuine low-performance cases.
+runtime failover remains available for genuine low-performance cases. Also
+validate `https://staging.danielsmith.io/?mode=text` at desktop and mobile-ish
+viewport widths to confirm the title is visible at scroll position 0 and the
+last fallback portfolio content is reachable by normal scrolling.
 
 Expected validation commands:
 
@@ -106,5 +128,6 @@ npm run typecheck
 npm run test:ci
 npm run test:e2e -- --grep "zoom"
 npm run test:e2e -- --grep "performance failover"
+npm run test:e2e -- --grep "text fallback"
 npm run smoke
 ```

--- a/playwright/text-fallback-layout.spec.ts
+++ b/playwright/text-fallback-layout.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const TEXT_FALLBACK_URL = '/?mode=text';
+
+async function waitForTextFallback(page: Page) {
+  await page.goto(TEXT_FALLBACK_URL, { waitUntil: 'domcontentloaded' });
+  await expect(
+    page.locator('#app[data-mode="text"] .text-fallback')
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'fallback'
+  );
+}
+
+async function assertTitleStartsInViewport(page: Page) {
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const titleBounds = await page.locator('.text-fallback__title').boundingBox();
+
+  expect(titleBounds).not.toBeNull();
+  expect(titleBounds?.y ?? Number.NEGATIVE_INFINITY).toBeGreaterThanOrEqual(0);
+  expect(
+    (titleBounds?.y ?? 0) + (titleBounds?.height ?? 0)
+  ).toBeLessThanOrEqual(page.viewportSize()?.height ?? 0);
+}
+
+async function assertScrollableToFinalContent(page: Page) {
+  const dimensions = await page.evaluate(() => {
+    const scrollingElement =
+      document.scrollingElement ?? document.documentElement;
+
+    return {
+      clientHeight: scrollingElement.clientHeight,
+      scrollHeight: scrollingElement.scrollHeight,
+    };
+  });
+
+  expect(dimensions.scrollHeight).toBeGreaterThan(dimensions.clientHeight);
+
+  await page.evaluate(() => {
+    const scrollingElement =
+      document.scrollingElement ?? document.documentElement;
+    scrollingElement.scrollTo(0, scrollingElement.scrollHeight);
+  });
+
+  await expect(page.locator('.text-fallback__poi').last()).toBeInViewport();
+}
+
+async function assertNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => {
+    const scrollingElement =
+      document.scrollingElement ?? document.documentElement;
+
+    return {
+      clientWidth: scrollingElement.clientWidth,
+      scrollWidth: scrollingElement.scrollWidth,
+    };
+  });
+
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(
+    dimensions.clientWidth + 1
+  );
+}
+
+async function assertTextFallbackLayout(page: Page) {
+  await assertTitleStartsInViewport(page);
+  await assertScrollableToFinalContent(page);
+  await assertNoHorizontalOverflow(page);
+}
+
+test.describe('text fallback layout', () => {
+  test('keeps the title visible and content scrollable on desktop', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await waitForTextFallback(page);
+
+    await assertTextFallbackLayout(page);
+  });
+
+  test('keeps the title visible and content scrollable on mobile', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForTextFallback(page);
+
+    await assertTextFallbackLayout(page);
+  });
+
+  test('uses the same scrollable layout for automated-client fallback', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(
+      page.locator('#app[data-mode="text"] .text-fallback')
+    ).toBeVisible();
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'fallback'
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-fallback-reason',
+      'automated-client'
+    );
+
+    await assertTextFallbackLayout(page);
+  });
+});

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -47,16 +47,31 @@ body {
   background: #04070d;
 }
 
+html[data-app-mode='fallback'],
+html[data-app-mode='fallback'] body {
+  min-height: 100%;
+  height: auto;
+  overflow-x: clip;
+  overflow-y: auto;
+}
+
 #app {
   width: 100%;
   height: 100%;
 }
 
 #app[data-mode='text'] {
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: auto;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 2rem;
+  justify-content: flex-start;
+  padding: calc(2rem + env(safe-area-inset-top, 0px))
+    calc(2rem + env(safe-area-inset-right, 0px))
+    calc(2rem + env(safe-area-inset-bottom, 0px))
+    calc(2rem + env(safe-area-inset-left, 0px));
+  overflow: visible;
 }
 
 canvas {
@@ -68,14 +83,16 @@ canvas {
 }
 
 .text-fallback {
-  margin: 0 auto;
+  width: min(32rem, 100%);
+  margin-inline: auto;
   padding: 3rem 1.75rem;
-  max-width: 32rem;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   gap: 1rem;
   color: #ecf4ff;
   text-align: left;
+  overflow-wrap: anywhere;
   background:
     linear-gradient(140deg, rgba(11, 18, 30, 0.95), rgba(13, 31, 46, 0.85)),
     rgba(6, 12, 22, 0.9);
@@ -87,6 +104,19 @@ canvas {
 
 .text-fallback[data-locale-script='cjk'] {
   letter-spacing: 0.02em;
+}
+
+@media (max-width: 480px) {
+  #app[data-mode='text'] {
+    padding: calc(1rem + env(safe-area-inset-top, 0px))
+      calc(1rem + env(safe-area-inset-right, 0px))
+      calc(1rem + env(safe-area-inset-bottom, 0px))
+      calc(1rem + env(safe-area-inset-left, 0px));
+  }
+
+  .text-fallback {
+    padding: 2rem 1.1rem;
+  }
 }
 
 .text-fallback__title {
@@ -182,6 +212,7 @@ canvas {
 
 .text-fallback__link {
   color: #8fd6ff;
+  overflow-wrap: anywhere;
   text-decoration: none;
   font-weight: 600;
 }
@@ -272,7 +303,7 @@ canvas {
 .text-fallback__poi-metrics {
   margin: 0;
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   column-gap: 0.75rem;
   row-gap: 0.3rem;
   font-size: 0.88rem;


### PR DESCRIPTION
### Motivation
- The text-only fallback could be vertically centered inside a fixed-height app container so a tall fallback card was clipped above the viewport and unreachable by scrolling.
- Visitors routed to text mode (manual, automated-client, or runtime failover) must see the fallback title at scroll position 0 and be able to scroll to the final portfolio content without horizontal overflow.

### Description
- Stop vertically centering the fallback and opt fallback pages into normal document-flow scrolling by adding `html[data-app-mode='fallback']` and changing `#app[data-mode='text']` to `min-height`/`height:auto`, top-aligned flow, safe-area-aware padding, and `overflow: visible` (edit: `src/ui/styles.css`).
- Preserve the centered card feel while preventing overflow by bounding `.text-fallback` with `width: min(32rem,100%)`, `margin-inline: auto`, long-content wrapping, and a safer metric grid (`minmax(0, 1fr`) to avoid horizontal scroll.
- Add end-to-end Playwright tests that assert title visibility at scroll top, page scrollability to the final POI, and no horizontal overflow on desktop and mobile (`playwright/text-fallback-layout.spec.ts`).
- Update the staging outage notes to record the fallback clipping symptom, root cause, corrective action, and the new regression coverage (`outages/2026-05-28-danielsmith-staging-zoom-fallback.*`).

### Testing
- Ran formatting and lint: `npm run format:write` (passed) and `npm run lint` (passed).
- Ran type-check: `npm run typecheck` (failed due to existing repo-wide TypeScript issues unrelated to this change; failure reported rather than caused by the CSS/test additions).
- Unit suite: `npm run test:ci` (Vitest) completed successfully (all repository Vitest tests passed).
- Playwright e2e: `npm run test:e2e -- --grep "text fallback"` (new text-fallback spec) passed after installing Playwright browsers and host deps; tests verify desktop (1280×720), mobile (390×844), and automated-client fallback scenarios.
- Docs and smoke: `npm run docs:check` (passed) and `npm run smoke` (build + smoke) (passed).
- Notes and follow-ups: the patch is scoped to layout and tests; `typecheck` failures are pre-existing and require a separate cleanup PR, and CI Playwright runs require browsers/deps (installation steps are documented and were run in the validation session).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f3ffb5b8832fb8d7657bd7440b16)