### PR TITLE
Improve immersive rendering performance: renderer classification, DPR policy, mirror throttling, adaptive downgrades, and diagnostics

### DIFF
--- a/outages/2026-05-29-danielsmith-adaptive-quality-gap.json
+++ b/outages/2026-05-29-danielsmith-adaptive-quality-gap.json
@@ -1,0 +1,24 @@
+{
+  "title": "adaptive quality gap root cause",
+  "date": "2026-05-29",
+  "overview": "outages/2026-05-29-danielsmith-staging-performance-overview.md",
+  "symptomSlice": "Sustained low FPS could go straight to text fallback without first trying cheaper quality settings.",
+  "evidence": "The failover monitor previously only accumulated low-FPS samples and transitioned to fallback; diagnostics lacked downgrade count/reason.",
+  "impactedFiles": [
+    "src/systems/failover/performanceFailover.ts",
+    "src/systems/performance/performanceDiagnostics.ts",
+    "src/main.ts",
+    "src/tests/performanceFailover.test.ts",
+    "src/tests/performanceDiagnostics.test.ts"
+  ],
+  "fixSummary": "Added a pre-fallback adaptive callback and non-flapping downgrade ladder to performance quality, then additional DPR reductions, before fallback.",
+  "interactionWithOtherFixes": "The ladder reuses the cheaper DPR, postprocessing, and mirror policies introduced by the other root-cause fixes.",
+  "regressionTests": [
+    "Performance-failover adaptive callback tests",
+    "diagnostics adaptive state tests"
+  ],
+  "validationCommands": [
+    "npm run test:ci -- src/tests/performanceFailover.test.ts src/tests/performanceDiagnostics.test.ts",
+    "npm run test:e2e -- --grep \"adaptive\""
+  ]
+}

--- a/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
+++ b/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
@@ -1,0 +1,53 @@
+# Adaptive quality gap root cause
+
+- **Date:** 2026-05-29
+- **Overview:** [staging performance overview](./2026-05-29-danielsmith-staging-performance-overview.md)
+
+## Symptom slice
+
+Runtime performance failover could switch directly to text fallback after
+sustained low FPS. It did not first force cheaper rendering settings for sessions
+that might recover with reduced DPR, disabled bloom/composer, and disabled mirror
+renders.
+
+## Evidence
+
+The failover monitor only accumulated low-FPS samples and transitioned to
+fallback when the duration threshold was reached. There was no pre-fallback
+quality callback, downgrade count, or last downgrade reason in diagnostics.
+
+## Impacted files
+
+- `src/systems/failover/performanceFailover.ts`
+- `src/systems/performance/performanceDiagnostics.ts`
+- `src/main.ts`
+- `src/tests/performanceFailover.test.ts`
+- `src/tests/performanceDiagnostics.test.ts`
+
+## Fix summary
+
+The low-FPS monitor now supports a pre-fallback adaptive callback. The immersive
+scene uses it as a non-flapping ladder: downgrade to performance first, then
+apply additional DPR reductions on later sustained low-FPS windows, while
+recording downgrade count and reason. Text fallback remains enabled once the
+adaptive budget is exhausted.
+
+## Interaction with other fixes
+
+The adaptive ladder reuses the concrete cheaper paths introduced by the other
+fixes: performance quality disables bloom, composer skipping removes no-op
+passes, DPR policy lowers drawing-buffer cost, and mirror policy disables the
+extra render.
+
+## Regression tests
+
+Performance-failover tests assert the adaptive callback can consume a low-FPS
+window without triggering fallback and that recovery/reset avoids immediate
+flapping. Diagnostics tests assert adaptive state is observable.
+
+## Validation commands
+
+```bash
+npm run test:ci -- src/tests/performanceFailover.test.ts src/tests/performanceDiagnostics.test.ts
+npm run test:e2e -- --grep "adaptive"
+```

--- a/outages/2026-05-29-danielsmith-postprocessing-pixel-cost.json
+++ b/outages/2026-05-29-danielsmith-postprocessing-pixel-cost.json
@@ -1,0 +1,25 @@
+{
+  "title": "postprocessing and DPR pixel-cost root cause",
+  "date": "2026-05-29",
+  "overview": "outages/2026-05-29-danielsmith-staging-performance-overview.md",
+  "symptomSlice": "DPR up to 2 plus composer and bloom multiplied full-screen pixel work.",
+  "evidence": "Code inspection showed a fixed DPR cap of 2 and composer creation/rendering even when passes were inactive; diagnostics now expose DPR, drawing buffer, bloom, composer, and pass count.",
+  "impactedFiles": [
+    "src/scene/graphics/performancePolicy.ts",
+    "src/scene/graphics/qualityManager.ts",
+    "src/systems/performance/performanceDiagnostics.ts",
+    "src/main.ts",
+    "src/tests/rendererPerformancePolicy.test.ts",
+    "src/tests/performanceDiagnostics.test.ts"
+  ],
+  "fixSummary": "Default hardware quality is balanced; DPR caps are explicit; composer is skipped entirely when no postprocessing pass is active.",
+  "interactionWithOtherFixes": "Lower DPR and composer skipping amplify software and adaptive downgrade savings.",
+  "regressionTests": [
+    "DPR clamping and composer decision unit tests",
+    "diagnostics aggregation tests"
+  ],
+  "validationCommands": [
+    "npm run test:ci -- src/tests/rendererPerformancePolicy.test.ts src/tests/performanceDiagnostics.test.ts",
+    "npm run test:e2e -- --grep \"immersive performance diagnostics\""
+  ]
+}

--- a/outages/2026-05-29-danielsmith-postprocessing-pixel-cost.md
+++ b/outages/2026-05-29-danielsmith-postprocessing-pixel-cost.md
@@ -1,0 +1,52 @@
+# Postprocessing and DPR pixel-cost root cause
+
+- **Date:** 2026-05-29
+- **Overview:** [staging performance overview](./2026-05-29-danielsmith-staging-performance-overview.md)
+
+## Symptom slice
+
+The scene was visually simple but could still spend too much time in full-screen
+work. DPR up to 2 plus composer and bloom multiplied every frame's pixel cost,
+which is especially harmful on software renderers.
+
+## Evidence
+
+The previous renderer setup used `Math.min(devicePixelRatio, 2)` and always
+created/rendered an EffectComposer chain even when motion blur was disabled and
+performance quality disabled bloom. New diagnostics expose DPR, viewport,
+drawing-buffer size, bloom state, composer state, and active pass count.
+
+## Impacted files
+
+- `src/scene/graphics/performancePolicy.ts`
+- `src/scene/graphics/qualityManager.ts`
+- `src/systems/performance/performanceDiagnostics.ts`
+- `src/main.ts`
+- `src/tests/rendererPerformancePolicy.test.ts`
+- `src/tests/performanceDiagnostics.test.ts`
+
+## Fix summary
+
+Default quality is balanced on normal hardware. DPR caps are explicit by quality
+and renderer tier. Rendering now bypasses EffectComposer entirely when bloom and
+motion blur are inactive, so performance/software mode renders the scene directly
+instead of paying for no-op full-screen passes.
+
+## Interaction with other fixes
+
+Lower DPR reduces both the main render and any remaining render-target work.
+Composer skipping depends on the quality preset and motion-blur state; it also
+makes software and adaptive performance downgrades immediately cheaper.
+
+## Regression tests
+
+Unit tests cover DPR clamping and composer enable/disable decisions. Diagnostics
+tests verify snapshots include frame stats, quality/DPR, renderer data, and
+feature state.
+
+## Validation commands
+
+```bash
+npm run test:ci -- src/tests/rendererPerformancePolicy.test.ts src/tests/performanceDiagnostics.test.ts
+npm run test:e2e -- --grep "immersive performance diagnostics"
+```

--- a/outages/2026-05-29-danielsmith-selfie-mirror-render-cost.json
+++ b/outages/2026-05-29-danielsmith-selfie-mirror-render-cost.json
@@ -1,0 +1,25 @@
+{
+  "title": "SelfieMirror render-cost root cause",
+  "date": "2026-05-29",
+  "overview": "outages/2026-05-29-danielsmith-staging-performance-overview.md",
+  "symptomSlice": "SelfieMirror rendered the full scene to a 512x512 target every animation frame before the main render.",
+  "evidence": "Code inspection confirmed per-frame mirror.render; diagnostics expose mirror target size, update rate, enabled state, and render count.",
+  "impactedFiles": [
+    "src/scene/structures/selfieMirror.ts",
+    "src/scene/graphics/performancePolicy.ts",
+    "src/systems/performance/performanceDiagnostics.ts",
+    "src/main.ts",
+    "src/tests/selfieMirror.test.ts",
+    "src/tests/rendererPerformancePolicy.test.ts"
+  ],
+  "fixSummary": "Mirror updates are throttled in cinematic/balanced, disabled in performance/software, lower resolution outside cinematic, and skipped when distant.",
+  "interactionWithOtherFixes": "Quality and renderer policies drive mirror cost, and adaptive performance downgrades disable the extra render.",
+  "regressionTests": [
+    "SelfieMirror diagnostics tests",
+    "mirror policy unit tests"
+  ],
+  "validationCommands": [
+    "npm run test:ci -- src/tests/selfieMirror.test.ts src/tests/rendererPerformancePolicy.test.ts",
+    "npm run test:e2e -- --grep \"performance|adaptive\""
+  ]
+}

--- a/outages/2026-05-29-danielsmith-selfie-mirror-render-cost.md
+++ b/outages/2026-05-29-danielsmith-selfie-mirror-render-cost.md
@@ -1,0 +1,52 @@
+# SelfieMirror render-cost root cause
+
+- **Date:** 2026-05-29
+- **Overview:** [staging performance overview](./2026-05-29-danielsmith-staging-performance-overview.md)
+
+## Symptom slice
+
+The SelfieMirror rendered the whole scene into a 512x512 render target every
+animation frame, then the main camera rendered the scene again. That hidden second
+scene render is disproportionate in software mode and wasteful when the mirror is
+not near/important.
+
+## Evidence
+
+Code inspection confirmed `selfieMirror.render(renderer, scene)` ran every frame
+with a fixed 512x512 target. New diagnostics expose mirror enabled/disabled
+state, target size, update rate, and render count.
+
+## Impacted files
+
+- `src/scene/structures/selfieMirror.ts`
+- `src/scene/graphics/performancePolicy.ts`
+- `src/systems/performance/performanceDiagnostics.ts`
+- `src/main.ts`
+- `src/tests/selfieMirror.test.ts`
+- `src/tests/rendererPerformancePolicy.test.ts`
+
+## Fix summary
+
+Mirror rendering is now policy-driven. Cinematic mode throttles to 15 FPS at
+512px, balanced throttles to 8 FPS at 256px, performance mode disables mirror
+renders at a 128px target, software renderers disable mirror renders, and distant
+players do not update the mirror until they are back in range.
+
+## Interaction with other fixes
+
+The mirror policy consumes the same renderer classification and quality level as
+DPR/postprocessing. Adaptive downgrades to performance also disable mirror work,
+removing an entire extra scene render before text fallback is considered.
+
+## Regression tests
+
+Unit tests cover mirror policy for cinematic, balanced, performance, software,
+and distance states. SelfieMirror tests verify render-target resizing and render
+count diagnostics.
+
+## Validation commands
+
+```bash
+npm run test:ci -- src/tests/selfieMirror.test.ts src/tests/rendererPerformancePolicy.test.ts
+npm run test:e2e -- --grep "performance|adaptive"
+```

--- a/outages/2026-05-29-danielsmith-software-renderer-quality.json
+++ b/outages/2026-05-29-danielsmith-software-renderer-quality.json
@@ -1,0 +1,24 @@
+{
+  "title": "software renderer quality root cause",
+  "date": "2026-05-29",
+  "overview": "outages/2026-05-29-danielsmith-staging-performance-overview.md",
+  "symptomSlice": "Hardware acceleration disabled routes WebGL through software paths where expensive default quality is catastrophic.",
+  "evidence": "Renderer diagnostics classify WEBGL_debug_renderer_info strings such as SwiftShader and llvmpipe; Playwright software override verifies performance policy.",
+  "impactedFiles": [
+    "src/scene/graphics/rendererCapabilities.ts",
+    "src/scene/graphics/performancePolicy.ts",
+    "src/main.ts",
+    "src/tests/rendererPerformancePolicy.test.ts",
+    "playwright/adaptive-quality.spec.ts"
+  ],
+  "fixSummary": "Known software renderers start in performance quality with aggressive DPR, no bloom/composer extras, and disabled mirror rendering.",
+  "interactionWithOtherFixes": "Renderer tier feeds DPR, postprocessing, mirror, and adaptive policies.",
+  "regressionTests": [
+    "renderer performance policy unit tests",
+    "adaptive quality Playwright software override"
+  ],
+  "validationCommands": [
+    "npm run test:ci -- src/tests/rendererPerformancePolicy.test.ts",
+    "npm run test:e2e -- --grep \"adaptive quality\""
+  ]
+}

--- a/outages/2026-05-29-danielsmith-software-renderer-quality.md
+++ b/outages/2026-05-29-danielsmith-software-renderer-quality.md
@@ -1,0 +1,51 @@
+# Software renderer quality root cause
+
+- **Date:** 2026-05-29
+- **Overview:** [staging performance overview](./2026-05-29-danielsmith-staging-performance-overview.md)
+
+## Symptom slice
+
+The reported 5 FPS reproduction used Chrome with hardware acceleration disabled.
+That makes software WebGL a likely path, where full-resolution postprocessing and
+extra scene renders are much more expensive than on a GPU-backed desktop.
+
+## Evidence
+
+The app previously had no WebGL vendor/renderer diagnostics and always began from
+the persisted/default quality path. New diagnostics read
+`WEBGL_debug_renderer_info` when available and classify SwiftShader, llvmpipe,
+softpipe, software, WARP, and related renderer strings as software.
+
+## Impacted files
+
+- `src/scene/graphics/rendererCapabilities.ts`
+- `src/scene/graphics/performancePolicy.ts`
+- `src/main.ts`
+- `src/tests/rendererPerformancePolicy.test.ts`
+- `playwright/adaptive-quality.spec.ts`
+
+## Fix summary
+
+Known software renderers now start in performance quality before the render loop
+begins. Their DPR is capped aggressively, bloom is disabled by the performance
+preset, composer work is skipped when no passes are active, and mirror rendering
+is disabled.
+
+## Interaction with other fixes
+
+Software classification feeds the DPR policy, postprocessing policy, mirror
+policy, and adaptive downgrade ladder. It prevents expensive software-only frames
+instead of waiting for failover to observe low FPS after the fact.
+
+## Regression tests
+
+Unit tests cover renderer classification and initial quality selection. A
+Playwright software override verifies performance quality, low DPR,
+software-tier diagnostics, no bloom/composer, and disabled mirror state.
+
+## Validation commands
+
+```bash
+npm run test:ci -- src/tests/rendererPerformancePolicy.test.ts
+npm run test:e2e -- --grep "adaptive quality"
+```

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.json
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.json
@@ -1,0 +1,42 @@
+{
+  "title": "staging.danielsmith.io immersive performance overview",
+  "date": "2026-05-29",
+  "environment": "staging.danielsmith.io; Chrome desktop including hardware-acceleration-disabled software WebGL",
+  "status": "corrective patch prepared for deployment validation",
+  "symptoms": [
+    "After zoom trails were fixed, immersive staging still showed roughly 5 FPS by user observation and fell back after a few seconds.",
+    "Reproduction included Chrome with hardware acceleration disabled."
+  ],
+  "relatedIncidents": [
+    "outages/2026-05-28-danielsmith-staging-zoom-fallback.md"
+  ],
+  "confirmedRootCauses": [
+    "outages/2026-05-29-danielsmith-software-renderer-quality.md",
+    "outages/2026-05-29-danielsmith-postprocessing-pixel-cost.md",
+    "outages/2026-05-29-danielsmith-selfie-mirror-render-cost.md",
+    "outages/2026-05-29-danielsmith-adaptive-quality-gap.md"
+  ],
+  "disprovenOrUnconfirmed": [
+    "Per-frame JS update work was not confirmed as the primary root cause in this patch; broad phase diagnostics were added for future evidence."
+  ],
+  "correctiveAction": [
+    "Added window.portfolio.performance diagnostics.",
+    "Classified software renderers and started them in performance quality.",
+    "Made DPR caps explicit by renderer tier and quality.",
+    "Skipped composer when bloom and motion blur are inactive.",
+    "Throttled or disabled SelfieMirror rendering by quality, renderer tier, and distance.",
+    "Added an adaptive downgrade ladder before text fallback."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"performance|adaptive|immersive\"",
+    "npm run smoke"
+  ],
+  "manualBenchmark": [
+    "Chrome hardware acceleration enabled: open /?mode=immersive, inspect window.portfolio.performance.getSnapshot(), zoom and pan for 10 seconds, confirm immersive remains active.",
+    "Chrome hardware acceleration disabled: repeat and confirm software/performance policy reduces DPR/postprocessing/mirror work before fallback."
+  ]
+}

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.md
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.md
@@ -1,0 +1,80 @@
+# staging.danielsmith.io immersive performance overview
+
+- **Date:** 2026-05-29
+- **Environment:** staging.danielsmith.io; Chrome desktop, including a hardware-acceleration-disabled software WebGL path
+- **Status:** Corrective patch prepared for deployment validation
+- **Related incident:** [2026-05-28 zoom afterimage and fallback](./2026-05-28-danielsmith-staging-zoom-fallback.md)
+
+## Symptom
+
+After the zoom afterimage/trails fix, staging no longer showed stacked prior
+frames during zoom/pan. The immersive scene still performed extremely poorly in
+one reported environment: roughly 5 FPS by user observation, then automatic
+switching to the text fallback after a few seconds. The most important field
+clue was that the reproduction used Chrome with hardware acceleration disabled,
+which routes WebGL through a software renderer such as SwiftShader on many
+systems.
+
+## Confirmed root causes
+
+- [Software renderer started on expensive quality](./2026-05-29-danielsmith-software-renderer-quality.md)
+- [Postprocessing and DPR multiplied pixel cost](./2026-05-29-danielsmith-postprocessing-pixel-cost.md)
+- [SelfieMirror rendered an extra full scene every frame](./2026-05-29-danielsmith-selfie-mirror-render-cost.md)
+- [Adaptive quality did not run before failover](./2026-05-29-danielsmith-adaptive-quality-gap.md)
+
+## Disproven or unconfirmed theories
+
+- **Per-frame JS work as the primary root cause:** not confirmed in this patch.
+  The scene does update many systems every frame, so diagnostics now record broad
+  phase timings for input/camera, avatar/audio, POI/HUD, decorative structures,
+  lighting, mirror, and main render. The targeted fixes addressed confirmed
+  renderer/pixel/mirror/adaptive waste first. If future snapshots show
+  decorative or POI/HUD buckets dominating after the render-side fixes, that
+  should become a separate incident rather than being conflated here.
+
+## Fix summary and interaction
+
+The patch adds `window.portfolio.performance` diagnostics with renderer/vendor
+classification, DPR, drawing-buffer size, quality state, postprocessing state,
+mirror policy, adaptive downgrade count, rolling frame stats, sampled phase
+timings, and last failover reason. Diagnostics are available even when
+`disablePerformanceFailover=1` is used for preview validation.
+
+The default quality path now starts balanced on normal hardware and performance
+on known software renderers. DPR caps are explicit and visible: cinematic caps
+at 1.5, balanced at 1.25, performance at 1.0, and software renderers at 0.75
+before any additional adaptive reductions. Performance/software mode disables
+bloom, skips the composer entirely when no postprocessing pass is active, and
+turns off the SelfieMirror render.
+
+The fixes compound intentionally: early software classification avoids the first
+expensive frames, DPR policy reduces all full-screen work, composer skipping
+removes no-op postprocessing overhead, mirror policy removes the hidden second
+scene render, and adaptive downgrade gives overloaded sessions a cheaper path
+before text fallback remains available for truly incapable environments.
+
+## Manual benchmark steps
+
+1. Open Chrome with hardware acceleration enabled.
+2. Visit `https://staging.danielsmith.io/?mode=immersive`.
+3. In DevTools, run `window.portfolio.performance.getSnapshot()`.
+4. Zoom in/out and pan/move for at least 10 seconds.
+5. Confirm the app remains immersive, only one canvas exists, average FPS stays
+   above the failover threshold on normal desktop hardware, and no
+   `performancefailover` event fires.
+6. Repeat with Chrome hardware acceleration disabled.
+7. Confirm diagnostics classify the renderer as software where the browser
+   exposes that string, quality starts or drops to performance, DPR is capped,
+   bloom/composer extras are off, mirror rendering is disabled, and fallback only
+   occurs after those reductions still cannot sustain the threshold.
+
+## Validation commands
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "performance|adaptive|immersive"
+npm run smoke
+```

--- a/playwright/adaptive-quality.spec.ts
+++ b/playwright/adaptive-quality.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const IMMERSIVE_URL = '/?mode=immersive&disablePerformanceFailover=1';
+
+async function installSoftwareRendererOverride(page: Page) {
+  await page.addInitScript(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__portfolioRendererInfoOverride = {
+      vendor: 'Google Inc.',
+      renderer: 'WebGL',
+      unmaskedVendor: 'Google Inc. (Google)',
+      unmaskedRenderer: 'ANGLE (Google, Vulkan SwiftShader Device)',
+      tier: 'software',
+      reason: 'playwright software override',
+    };
+  });
+}
+
+test.describe('adaptive quality', () => {
+  test('starts software-classified renderers in performance quality', async ({
+    page,
+  }) => {
+    await installSoftwareRendererOverride(page);
+    await page.goto(IMMERSIVE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'immersive',
+      {
+        timeout: IMMERSIVE_READY_TIMEOUT_MS,
+      }
+    );
+
+    const snapshot = await page.evaluate(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).portfolio?.performance?.getSnapshot?.()
+    );
+
+    expect(snapshot.quality.level).toBe('performance');
+    expect(snapshot.quality.dpr).toBeLessThanOrEqual(0.75);
+    expect(snapshot.renderer.tier).toBe('software');
+    expect(snapshot.features.bloomEnabled).toBe(false);
+    expect(snapshot.features.composerEnabled).toBe(false);
+    expect(snapshot.features.mirrorEnabled).toBe(false);
+  });
+});

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const PRODUCTION_LIKE_IMMERSIVE_URL =
+  '/?mode=immersive&disablePerformanceFailover=1';
+
+type PerformanceSnapshot = {
+  averageFps: number;
+  p95FrameMs: number;
+  sampleCount: number;
+  quality: { level: string; dpr: number; downgradeCount: number };
+  features: {
+    composerEnabled: boolean;
+    bloomEnabled: boolean;
+    activePostprocessingPassCount: number;
+    mirrorEnabled: boolean;
+    mirrorRenderTargetSize: number;
+    mirrorUpdateRateFps: number;
+  };
+};
+
+async function waitForImmersive(page: Page) {
+  await page.goto(PRODUCTION_LIKE_IMMERSIVE_URL, {
+    waitUntil: 'domcontentloaded',
+  });
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'immersive',
+    {
+      timeout: IMMERSIVE_READY_TIMEOUT_MS,
+    }
+  );
+  await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+async function exerciseZoomAndMovement(page: Page) {
+  await page.locator('#app canvas').hover();
+  for (let index = 0; index < 24; index += 1) {
+    await page.mouse.wheel(0, index % 2 === 0 ? -320 : 260);
+    await page.keyboard.down(index % 2 === 0 ? 'w' : 'd');
+    await page.waitForTimeout(80);
+    await page.keyboard.up(index % 2 === 0 ? 'w' : 'd');
+  }
+  await page.waitForTimeout(500);
+}
+
+async function readSnapshot(page: Page): Promise<PerformanceSnapshot> {
+  const snapshot = await page.evaluate(() =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).portfolio?.performance?.getSnapshot?.()
+  );
+  expect(snapshot).toBeDefined();
+  return snapshot as PerformanceSnapshot;
+}
+
+test.describe('immersive performance diagnostics', () => {
+  test.setTimeout(150_000);
+
+  test('keeps normal interaction immersive and exposes diagnostics with failover disabled', async ({
+    page,
+  }) => {
+    const failoverEvents: unknown[] = [];
+    await page.addInitScript(() => {
+      window.addEventListener('performancefailover', (event) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).__failoverEvents = [
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...((window as any).__failoverEvents ?? []),
+          (event as CustomEvent).detail,
+        ];
+      });
+    });
+
+    await waitForImmersive(page);
+    await exerciseZoomAndMovement(page);
+
+    const browserEvents = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).__failoverEvents ?? []
+    );
+    failoverEvents.push(...browserEvents);
+    const snapshot = await readSnapshot(page);
+
+    expect(failoverEvents).toEqual([]);
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'immersive'
+    );
+    await expect(page.locator('#app canvas')).toHaveCount(1);
+    expect(snapshot.sampleCount).toBeGreaterThan(10);
+    expect(snapshot.averageFps).toBeGreaterThan(1);
+    expect(snapshot.p95FrameMs).toBeLessThan(2_000);
+    expect(['balanced', 'performance', 'cinematic']).toContain(
+      snapshot.quality.level
+    );
+    expect(
+      snapshot.features.activePostprocessingPassCount
+    ).toBeGreaterThanOrEqual(0);
+    if (snapshot.quality.level === 'performance') {
+      expect(snapshot.features.bloomEnabled).toBe(false);
+      expect(snapshot.features.composerEnabled).toBe(false);
+      expect(snapshot.features.mirrorEnabled).toBe(false);
+    }
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,10 +105,22 @@ import {
   type MotionBlurController,
 } from './scene/graphics/motionBlurController';
 import {
+  clampDpr,
+  getActivePostprocessingPassCount,
+  selectInitialGraphicsQuality,
+  selectMirrorPolicy,
+  shouldUseComposer,
+} from './scene/graphics/performancePolicy';
+import {
   GRAPHICS_QUALITY_PRESETS,
   createGraphicsQualityManager,
+  type GraphicsQualityLevel,
   type GraphicsQualityManager,
 } from './scene/graphics/qualityManager';
+import {
+  readRendererInfo,
+  type RendererInfoSnapshot,
+} from './scene/graphics/rendererCapabilities';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -326,6 +338,11 @@ import {
   type InputLatencyTelemetryHandle,
 } from './systems/performance/inputLatencyTelemetry';
 import {
+  createPerformanceDiagnostics,
+  type PerformanceDiagnostics,
+  type PerformancePhase,
+} from './systems/performance/performanceDiagnostics';
+import {
   createAvatarAccessoryProgression,
   type AvatarAccessoryProgressionHandle,
 } from './systems/progression/avatarAccessoryProgression';
@@ -410,6 +427,7 @@ declare global {
         }>;
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
+      performance?: PerformanceDiagnostics;
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -445,6 +463,7 @@ declare global {
         getPlayerYaw?(): number;
       };
     };
+    __portfolioRendererInfoOverride?: RendererInfoSnapshot;
   }
 }
 
@@ -655,10 +674,19 @@ function initializeImmersiveScene(
 ) {
   const immersiveUrl = createImmersiveModeUrl();
   const renderer = new WebGLRenderer({ antialias: true });
+  const rendererInfo =
+    window.__portfolioRendererInfoOverride ??
+    readRendererInfo(renderer.getContext());
+  const initialQuality = selectInitialGraphicsQuality(rendererInfo);
+  const initialDpr = clampDpr({
+    devicePixelRatio: window.devicePixelRatio ?? 1,
+    rendererTier: rendererInfo.tier,
+    quality: initialQuality,
+  });
   renderer.outputColorSpace = SRGBColorSpace;
   renderer.toneMapping = ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.1;
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setPixelRatio(initialDpr);
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setClearColor(new Color(0x0d121c));
   container.appendChild(renderer.domElement);
@@ -834,10 +862,13 @@ function initializeImmersiveScene(
           `${sampleCount} samples).`
       );
     },
-    onBeforeFallback: () => {
+    onLowFpsBeforeFallback: () => applyAdaptiveDowngrade('sustained low FPS'),
+    onBeforeFallback: (reason) => {
+      lastFailoverReason = reason;
       disposeImmersiveResources();
     },
     onFallback: (reason) => {
+      lastFailoverReason = reason;
       inputLatencyTelemetry?.report(`failover-${reason}`);
     },
     disabled: disablePerformanceFailover,
@@ -2986,6 +3017,14 @@ function initializeImmersiveScene(
   let composer: EffectComposer | null = null;
   let bloomPass: UnrealBloomPass | null = null;
   let motionBlurController: MotionBlurController | null = null;
+  let performanceDiagnostics: PerformanceDiagnostics | null = null;
+  let adaptiveDowngradeCount = 0;
+  let adaptiveDprStep = 0;
+  let lastAdaptiveDowngradeReason: string | null = null;
+  let lastFailoverReason: string | null = null;
+  let mirrorUpdateRateFps = 0;
+  let mirrorEnabled = false;
+  let lastMirrorRenderAtMs = 0;
 
   hudLayoutManager = createHudLayoutManager({
     root: document.documentElement,
@@ -3016,9 +3055,16 @@ function initializeImmersiveScene(
   resetMotionBlurHistory = () => motionBlurController?.resetHistory();
   composer.addPass(motionBlurController.pass);
 
-  let qualityStorage: Storage | undefined;
+  let qualityStorage: Pick<Storage, 'getItem' | 'setItem'> | undefined;
   try {
-    qualityStorage = window.localStorage;
+    const localQualityStorage = window.localStorage;
+    qualityStorage =
+      rendererInfo.tier === 'software'
+        ? {
+            getItem: () => null,
+            setItem: (key, value) => localQualityStorage.setItem(key, value),
+          }
+        : localQualityStorage;
   } catch {
     qualityStorage = undefined;
   }
@@ -3028,7 +3074,7 @@ function initializeImmersiveScene(
     bloomPass: bloomPass ?? undefined,
     ledStripMaterials,
     ledFillLights: ledFillLightsList,
-    basePixelRatio: Math.min(window.devicePixelRatio ?? 1, 2),
+    basePixelRatio: initialDpr,
     baseBloom: {
       strength: LIGHTING_OPTIONS.bloomStrength,
       radius: LIGHTING_OPTIONS.bloomRadius,
@@ -3039,7 +3085,107 @@ function initializeImmersiveScene(
       lightIntensity: LIGHTING_OPTIONS.ledLightIntensity,
     },
     storage: qualityStorage,
+    defaultLevel: initialQuality,
   });
+
+  const applyDprPolicy = () => {
+    if (!graphicsQualityManager) {
+      return;
+    }
+    graphicsQualityManager.setBasePixelRatio(
+      clampDpr({
+        devicePixelRatio: window.devicePixelRatio ?? 1,
+        rendererTier: rendererInfo.tier,
+        quality: graphicsQualityManager.getLevel(),
+        adaptiveStep: adaptiveDprStep,
+      })
+    );
+  };
+
+  const getPostprocessingState = () => ({
+    bloomEnabled: bloomPass?.enabled === true,
+    motionBlurEnabled: motionBlurController?.pass.enabled === true,
+  });
+
+  const shouldRenderWithComposer = () =>
+    shouldUseComposer(getPostprocessingState());
+
+  const refreshMirrorPolicy = () => {
+    const mirrorState = selfieMirror?.getState();
+    const policy = selectMirrorPolicy({
+      quality: graphicsQualityManager?.getLevel() ?? initialQuality,
+      rendererTier: rendererInfo.tier,
+      playerDistance: mirrorState?.playerDistance,
+    });
+    mirrorEnabled = policy.enabled;
+    mirrorUpdateRateFps = policy.updateRateFps;
+    selfieMirror?.setRenderTargetSize(policy.targetSize);
+    return policy;
+  };
+
+  function applyAdaptiveDowngrade(reason: string): boolean {
+    if (!graphicsQualityManager) {
+      return false;
+    }
+    if (adaptiveDowngradeCount >= 6) {
+      return false;
+    }
+    const currentLevel = graphicsQualityManager.getLevel();
+    if (currentLevel !== 'performance') {
+      graphicsQualityManager.setLevel('performance');
+    } else {
+      adaptiveDprStep += 1;
+      applyDprPolicy();
+    }
+    adaptiveDowngradeCount += 1;
+    lastAdaptiveDowngradeReason = reason;
+    refreshMirrorPolicy();
+    return true;
+  }
+
+  applyDprPolicy();
+  refreshMirrorPolicy();
+
+  performanceDiagnostics = createPerformanceDiagnostics({
+    rendererInfo,
+    getQualityLevel: () =>
+      graphicsQualityManager?.getLevel() ??
+      (initialQuality as GraphicsQualityLevel),
+    getDpr: () => renderer.getPixelRatio(),
+    getViewport: () => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }),
+    getDrawingBuffer: () => ({
+      width: renderer.getContext().drawingBufferWidth,
+      height: renderer.getContext().drawingBufferHeight,
+    }),
+    getFeatureState: () => {
+      const postprocessingState = getPostprocessingState();
+      const mirrorState = selfieMirror?.getState();
+      return {
+        bloomEnabled: postprocessingState.bloomEnabled,
+        composerEnabled: shouldRenderWithComposer(),
+        activePostprocessingPassCount:
+          getActivePostprocessingPassCount(postprocessingState),
+        mirrorEnabled,
+        mirrorRenderTargetSize: mirrorState?.renderTargetSize ?? 0,
+        mirrorUpdateRateFps,
+        mirrorRenderCount: mirrorState?.renderCount ?? 0,
+      };
+    },
+    getAdaptiveState: () => ({
+      downgradeCount: adaptiveDowngradeCount,
+      lastDowngradeReason: lastAdaptiveDowngradeReason,
+      lastFailoverReason,
+    }),
+  });
+
+  const portfolioWindow = window as Window;
+  if (!portfolioWindow.portfolio) {
+    portfolioWindow.portfolio = {};
+  }
+  portfolioWindow.portfolio.performance = performanceDiagnostics;
   ledAnimator?.captureBaseline();
   environmentLightAnimator?.captureBaseline();
 
@@ -3199,6 +3345,8 @@ function initializeImmersiveScene(
   registerHudControlElement(graphicsQualityControl?.element ?? null);
 
   unsubscribeGraphicsQuality = graphicsQualityManager.onChange(() => {
+    applyDprPolicy();
+    refreshMirrorPolicy();
     graphicsQualityControl?.refresh();
     ledAnimator?.captureBaseline();
     environmentLightAnimator?.captureBaseline();
@@ -3259,9 +3407,15 @@ function initializeImmersiveScene(
     renderer.setSize(window.innerWidth, window.innerHeight);
     const nextPixelRatio = Math.min(window.devicePixelRatio ?? 1, 2);
     if (graphicsQualityManager) {
-      graphicsQualityManager.setBasePixelRatio(nextPixelRatio);
+      applyDprPolicy();
     } else {
-      renderer.setPixelRatio(nextPixelRatio);
+      renderer.setPixelRatio(
+        clampDpr({
+          devicePixelRatio: nextPixelRatio,
+          rendererTier: rendererInfo.tier,
+          quality: initialQuality,
+        })
+      );
     }
 
     if (composer) {
@@ -3860,6 +4014,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.graphics) {
       delete window.portfolio.graphics;
     }
+    if (window.portfolio?.performance) {
+      delete window.portfolio.performance;
+    }
     if (helpButton) {
       helpButton.textContent = buildHelpButtonText(helpLabelFallback);
       helpButton.dataset.hudAnnounce = buildHelpAnnouncement(helpLabelFallback);
@@ -3925,190 +4082,220 @@ function initializeImmersiveScene(
 
   let hasPresentedFirstFrame = false;
 
+  const measurePhase = (phase: PerformancePhase, work: () => void) => {
+    const startedAt = performance.now();
+    work();
+    performanceDiagnostics?.recordPhase(phase, performance.now() - startedAt);
+  };
+
   renderer.setAnimationLoop(() => {
     try {
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
+      performanceDiagnostics?.recordFrame(delta);
       performanceFailover.update(delta);
       if (performanceFailover.hasTriggered()) {
         return;
       }
-      updateMovement(delta);
-      if (locomotionAnimator) {
-        locomotionAnimator.update({
-          delta,
-          linearSpeed: locomotionLinearSpeed,
-          angularSpeed: locomotionAngularSpeed,
-        });
-      }
-      if (avatarFootIkController) {
-        avatarFootIkController.update({
-          delta,
-          sampleHeight({ x, y }) {
-            return sampleStairSurfaceHeight({
-              geometry: stairGeometry,
-              behavior: stairBehavior,
-              x,
-              z: y,
-              currentFloor: activeFloorId,
-              upperFloorElevation,
-            });
-          },
-        });
-      }
-      if (footstepAudioController) {
-        footstepAudioController.update({
-          delta,
-          linearSpeed: locomotionLinearSpeed,
-          masterVolume: getAmbientAudioVolume(),
-        });
-      }
-      updateCamera(delta);
-      if (selfieMirror) {
-        selfieMirror.update({
-          playerPosition: player.position,
-          playerRotationY: player.rotation.y,
-          playerHeight: mannequinHeight,
-        });
-      }
-      updatePois(elapsedTime, delta);
-      analyticsGlow.update(delta);
-      poiWorldTooltip.update(delta);
-      handleInteractionInput();
-      handleHelpInput();
-      if (avatarAccessorySuite) {
-        avatarAccessorySuite.update({ elapsed: elapsedTime, delta });
-      }
-      if (ambientAudioController) {
-        ambientAudioController.update(player.position, delta, {
-          elapsed: elapsedTime,
-        });
-        ambientCaptionBridge?.update();
-      }
-      if (livingRoomMediaWall) {
-        const activation = futuroptimistPoi?.activation ?? 0;
-        const focus = futuroptimistPoi?.focus ?? 0;
-        livingRoomMediaWall.controller.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (flywheelShowpiece) {
-        const activation = flywheelPoi?.activation ?? 0;
-        const focus = flywheelPoi?.focus ?? 0;
-        flywheelShowpiece.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (f2ClipboardConsole) {
-        const activation = f2ClipboardPoi?.activation ?? 0;
-        const focus = f2ClipboardPoi?.focus ?? 0;
-        f2ClipboardConsole.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (sigmaWorkbench) {
-        const activation = sigmaPoi?.activation ?? 0;
-        const focus = sigmaPoi?.focus ?? 0;
-        sigmaWorkbench.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (woveLoom) {
-        const activation = wovePoi?.activation ?? 0;
-        const focus = wovePoi?.focus ?? 0;
-        woveLoom.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (jobbotTerminal) {
-        const activation = jobbotPoi?.activation ?? 0;
-        const focus = jobbotPoi?.focus ?? 0;
-        jobbotTerminal.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-          analyticsGlow: analyticsGlow.getValue(),
-          analyticsWave: analyticsGlow.getWave(),
-        });
-      }
-      if (axelNavigator) {
-        const activation = axelPoi?.activation ?? 0;
-        const focus = axelPoi?.focus ?? 0;
-        axelNavigator.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (tokenPlaceRack) {
-        const activation = tokenPlacePoi?.activation ?? 0;
-        const focus = tokenPlacePoi?.focus ?? 0;
-        tokenPlaceRack.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (gabrielSentry) {
-        const activation = gabrielPoi?.activation ?? 0;
-        const focus = gabrielPoi?.focus ?? 0;
-        gabrielSentry.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (gitshelvesInstallation) {
-        const activation = gitshelvesPoi?.activation ?? 0;
-        const focus = gitshelvesPoi?.focus ?? 0;
-        gitshelvesInstallation.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (prReaperConsole) {
-        const activation = prReaperPoi?.activation ?? 0;
-        const focus = prReaperPoi?.focus ?? 0;
-        prReaperConsole.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
-      }
-      if (backyardEnvironment) {
-        backyardEnvironment.update({ elapsed: elapsedTime, delta });
-      }
-      if (
-        environmentLightAnimator &&
-        lightingDebugController.getMode() === 'cinematic'
-      ) {
-        environmentLightAnimator.update(elapsedTime);
-      }
-      if (ledAnimator) {
-        ledAnimator.update(elapsedTime);
-      }
-      if (lightmapAnimator) {
-        lightmapAnimator.update(elapsedTime);
-      }
-      if (selfieMirror) {
-        selfieMirror.render(renderer, scene);
-      }
-      if (composer) {
-        composer.render();
-      } else {
-        renderer.render(scene, camera);
-      }
+      measurePhase('inputMovementCamera', () => {
+        updateMovement(delta);
+        updateCamera(delta);
+        if (selfieMirror) {
+          selfieMirror.update({
+            playerPosition: player.position,
+            playerRotationY: player.rotation.y,
+            playerHeight: mannequinHeight,
+          });
+        }
+      });
+      measurePhase('avatarIkAudio', () => {
+        if (locomotionAnimator) {
+          locomotionAnimator.update({
+            delta,
+            linearSpeed: locomotionLinearSpeed,
+            angularSpeed: locomotionAngularSpeed,
+          });
+        }
+        if (avatarFootIkController) {
+          avatarFootIkController.update({
+            delta,
+            sampleHeight({ x, y }) {
+              return sampleStairSurfaceHeight({
+                geometry: stairGeometry,
+                behavior: stairBehavior,
+                x,
+                z: y,
+                currentFloor: activeFloorId,
+                upperFloorElevation,
+              });
+            },
+          });
+        }
+        if (footstepAudioController) {
+          footstepAudioController.update({
+            delta,
+            linearSpeed: locomotionLinearSpeed,
+            masterVolume: getAmbientAudioVolume(),
+          });
+        }
+        if (avatarAccessorySuite) {
+          avatarAccessorySuite.update({ elapsed: elapsedTime, delta });
+        }
+        if (ambientAudioController) {
+          ambientAudioController.update(player.position, delta, {
+            elapsed: elapsedTime,
+          });
+          ambientCaptionBridge?.update();
+        }
+      });
+      measurePhase('poiHudTooltips', () => {
+        updatePois(elapsedTime, delta);
+        analyticsGlow.update(delta);
+        poiWorldTooltip.update(delta);
+        handleInteractionInput();
+        handleHelpInput();
+      });
+      measurePhase('decorativeStructures', () => {
+        if (livingRoomMediaWall) {
+          const activation = futuroptimistPoi?.activation ?? 0;
+          const focus = futuroptimistPoi?.focus ?? 0;
+          livingRoomMediaWall.controller.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (flywheelShowpiece) {
+          const activation = flywheelPoi?.activation ?? 0;
+          const focus = flywheelPoi?.focus ?? 0;
+          flywheelShowpiece.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (f2ClipboardConsole) {
+          const activation = f2ClipboardPoi?.activation ?? 0;
+          const focus = f2ClipboardPoi?.focus ?? 0;
+          f2ClipboardConsole.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (sigmaWorkbench) {
+          const activation = sigmaPoi?.activation ?? 0;
+          const focus = sigmaPoi?.focus ?? 0;
+          sigmaWorkbench.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (woveLoom) {
+          const activation = wovePoi?.activation ?? 0;
+          const focus = wovePoi?.focus ?? 0;
+          woveLoom.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (jobbotTerminal) {
+          const activation = jobbotPoi?.activation ?? 0;
+          const focus = jobbotPoi?.focus ?? 0;
+          jobbotTerminal.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+            analyticsGlow: analyticsGlow.getValue(),
+            analyticsWave: analyticsGlow.getWave(),
+          });
+        }
+        if (axelNavigator) {
+          const activation = axelPoi?.activation ?? 0;
+          const focus = axelPoi?.focus ?? 0;
+          axelNavigator.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (tokenPlaceRack) {
+          const activation = tokenPlacePoi?.activation ?? 0;
+          const focus = tokenPlacePoi?.focus ?? 0;
+          tokenPlaceRack.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (gabrielSentry) {
+          const activation = gabrielPoi?.activation ?? 0;
+          const focus = gabrielPoi?.focus ?? 0;
+          gabrielSentry.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (gitshelvesInstallation) {
+          const activation = gitshelvesPoi?.activation ?? 0;
+          const focus = gitshelvesPoi?.focus ?? 0;
+          gitshelvesInstallation.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+        if (prReaperConsole) {
+          const activation = prReaperPoi?.activation ?? 0;
+          const focus = prReaperPoi?.focus ?? 0;
+          prReaperConsole.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
+      });
+      measurePhase('lightingLedLightmap', () => {
+        if (backyardEnvironment) {
+          backyardEnvironment.update({ elapsed: elapsedTime, delta });
+        }
+        if (
+          environmentLightAnimator &&
+          lightingDebugController.getMode() === 'cinematic'
+        ) {
+          environmentLightAnimator.update(elapsedTime);
+        }
+        if (ledAnimator) {
+          ledAnimator.update(elapsedTime);
+        }
+        if (lightmapAnimator) {
+          lightmapAnimator.update(elapsedTime);
+        }
+      });
+      measurePhase('mirror', () => {
+        const policy = refreshMirrorPolicy();
+        const now = performance.now();
+        const intervalMs =
+          policy.updateRateFps > 0 ? 1000 / policy.updateRateFps : Infinity;
+        if (
+          selfieMirror &&
+          policy.enabled &&
+          now - lastMirrorRenderAtMs >= intervalMs
+        ) {
+          selfieMirror.render(renderer, scene);
+          lastMirrorRenderAtMs = now;
+        }
+      });
+      measurePhase('mainRenderComposer', () => {
+        if (composer && shouldRenderWithComposer()) {
+          composer.render();
+        } else {
+          renderer.render(scene, camera);
+        }
+      });
       if (!hasPresentedFirstFrame) {
         hasPresentedFirstFrame = true;
         writeModePreference('immersive');

--- a/src/scene/graphics/performancePolicy.ts
+++ b/src/scene/graphics/performancePolicy.ts
@@ -1,0 +1,107 @@
+import type { GraphicsQualityLevel } from './qualityManager';
+import type { RendererInfoSnapshot } from './rendererCapabilities';
+
+export interface DprPolicyInput {
+  devicePixelRatio: number;
+  rendererTier: RendererInfoSnapshot['tier'];
+  quality: GraphicsQualityLevel;
+  adaptiveStep?: number;
+}
+
+export interface MirrorPolicy {
+  enabled: boolean;
+  targetSize: number;
+  updateRateFps: number;
+  reason: string;
+}
+
+export function selectInitialGraphicsQuality(
+  rendererInfo: Pick<RendererInfoSnapshot, 'tier'>,
+  storedLevel?: GraphicsQualityLevel | null
+): GraphicsQualityLevel {
+  if (rendererInfo.tier === 'software') {
+    return 'performance';
+  }
+  return storedLevel ?? 'balanced';
+}
+
+export function clampDpr({
+  devicePixelRatio,
+  rendererTier,
+  quality,
+  adaptiveStep = 0,
+}: DprPolicyInput): number {
+  const safeDeviceDpr =
+    Number.isFinite(devicePixelRatio) && devicePixelRatio > 0
+      ? devicePixelRatio
+      : 1;
+  const qualityCap: Record<GraphicsQualityLevel, number> = {
+    cinematic: 1.5,
+    balanced: 1.25,
+    performance: 1,
+  };
+  const tierCap = rendererTier === 'software' ? 0.75 : qualityCap[quality];
+  const adaptiveReduction = Math.max(0, adaptiveStep) * 0.15;
+  const cap = Math.max(0.5, tierCap - adaptiveReduction);
+  return Math.max(0.5, Math.min(safeDeviceDpr, cap));
+}
+
+export function shouldUseComposer(input: {
+  bloomEnabled: boolean;
+  motionBlurEnabled: boolean;
+}): boolean {
+  return input.bloomEnabled || input.motionBlurEnabled;
+}
+
+export function getActivePostprocessingPassCount(input: {
+  bloomEnabled: boolean;
+  motionBlurEnabled: boolean;
+}): number {
+  return Number(input.bloomEnabled) + Number(input.motionBlurEnabled);
+}
+
+export function selectMirrorPolicy(input: {
+  quality: GraphicsQualityLevel;
+  rendererTier: RendererInfoSnapshot['tier'];
+  playerDistance?: number;
+}): MirrorPolicy {
+  if (input.rendererTier === 'software') {
+    return {
+      enabled: false,
+      targetSize: 128,
+      updateRateFps: 0,
+      reason: 'disabled for software renderer',
+    };
+  }
+  if (input.quality === 'performance') {
+    return {
+      enabled: false,
+      targetSize: 128,
+      updateRateFps: 0,
+      reason: 'disabled in performance quality',
+    };
+  }
+  const distance = input.playerDistance ?? 0;
+  if (distance > 18) {
+    return {
+      enabled: false,
+      targetSize: input.quality === 'cinematic' ? 512 : 256,
+      updateRateFps: 0,
+      reason: 'player outside mirror update radius',
+    };
+  }
+  if (input.quality === 'balanced') {
+    return {
+      enabled: true,
+      targetSize: 256,
+      updateRateFps: 8,
+      reason: 'balanced throttle',
+    };
+  }
+  return {
+    enabled: true,
+    targetSize: 512,
+    updateRateFps: 15,
+    reason: 'cinematic throttle',
+  };
+}

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -112,6 +112,7 @@ export interface GraphicsQualityManagerOptions {
   };
   storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
   storageKey?: string;
+  defaultLevel?: GraphicsQualityLevel;
 }
 
 export interface GraphicsQualityManager {
@@ -151,6 +152,7 @@ export function createGraphicsQualityManager({
   baseLed,
   storage,
   storageKey = DEFAULT_STORAGE_KEY,
+  defaultLevel = 'balanced',
 }: GraphicsQualityManagerOptions): GraphicsQualityManager {
   let currentBasePixelRatio = sanitizePixelRatio(basePixelRatio);
   const ledMaterialEntries: LedMaterialEntry[] = ledStripMaterials
@@ -172,7 +174,9 @@ export function createGraphicsQualityManager({
 
   const listeners = new Set<(level: GraphicsQualityLevel) => void>();
 
-  let currentLevel: GraphicsQualityLevel = 'cinematic';
+  let currentLevel: GraphicsQualityLevel = isGraphicsQualityLevel(defaultLevel)
+    ? defaultLevel
+    : 'balanced';
   if (storage?.getItem) {
     try {
       const stored = storage.getItem(storageKey);

--- a/src/scene/graphics/rendererCapabilities.ts
+++ b/src/scene/graphics/rendererCapabilities.ts
@@ -1,0 +1,145 @@
+export type RendererTier = 'hardware' | 'software' | 'unknown';
+
+export interface RendererInfoSnapshot {
+  vendor: string | null;
+  renderer: string | null;
+  unmaskedVendor: string | null;
+  unmaskedRenderer: string | null;
+  tier: RendererTier;
+  reason: string;
+}
+
+export interface WebGLDebugRendererInfoLike {
+  UNMASKED_VENDOR_WEBGL: number;
+  UNMASKED_RENDERER_WEBGL: number;
+}
+
+export interface WebGLContextLike {
+  getParameter(parameter: number): unknown;
+  getExtension(
+    name: 'WEBGL_debug_renderer_info'
+  ): WebGLDebugRendererInfoLike | null;
+  VENDOR?: number;
+  RENDERER?: number;
+}
+
+const SOFTWARE_RENDERER_PATTERNS = [
+  /swiftshader/i,
+  /software/i,
+  /llvmpipe/i,
+  /softpipe/i,
+  /mesa offscreen/i,
+  /google inc\. \(google\)/i,
+  /angle.*warp/i,
+  /microsoft basic render/i,
+];
+
+const HARDWARE_RENDERER_PATTERNS = [
+  /nvidia/i,
+  /amd/i,
+  /radeon/i,
+  /intel/i,
+  /apple/i,
+  /adreno/i,
+  /mali/i,
+  /powervr/i,
+];
+
+function normalizeParameter(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+export function classifyRendererInfo(input: {
+  vendor?: string | null;
+  renderer?: string | null;
+  unmaskedVendor?: string | null;
+  unmaskedRenderer?: string | null;
+}): Pick<RendererInfoSnapshot, 'tier' | 'reason'> {
+  const haystack = [
+    input.vendor,
+    input.renderer,
+    input.unmaskedVendor,
+    input.unmaskedRenderer,
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' | ');
+
+  const softwareMatch = SOFTWARE_RENDERER_PATTERNS.find((pattern) =>
+    pattern.test(haystack)
+  );
+  if (softwareMatch) {
+    return {
+      tier: 'software',
+      reason: `matched software renderer pattern ${softwareMatch}`,
+    };
+  }
+
+  const hardwareMatch = HARDWARE_RENDERER_PATTERNS.find((pattern) =>
+    pattern.test(haystack)
+  );
+  if (hardwareMatch) {
+    return {
+      tier: 'hardware',
+      reason: `matched hardware renderer pattern ${hardwareMatch}`,
+    };
+  }
+
+  return {
+    tier: 'unknown',
+    reason:
+      haystack.length > 0
+        ? 'no renderer pattern matched'
+        : 'renderer unavailable',
+  };
+}
+
+export function readRendererInfo(gl: WebGLContextLike): RendererInfoSnapshot {
+  let vendor: string | null = null;
+  let renderer: string | null = null;
+  let unmaskedVendor: string | null = null;
+  let unmaskedRenderer: string | null = null;
+
+  try {
+    if (typeof gl.VENDOR === 'number') {
+      vendor = normalizeParameter(gl.getParameter(gl.VENDOR));
+    }
+    if (typeof gl.RENDERER === 'number') {
+      renderer = normalizeParameter(gl.getParameter(gl.RENDERER));
+    }
+  } catch {
+    vendor = null;
+    renderer = null;
+  }
+
+  try {
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+    if (debugInfo) {
+      unmaskedVendor = normalizeParameter(
+        gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL)
+      );
+      unmaskedRenderer = normalizeParameter(
+        gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+      );
+    }
+  } catch {
+    unmaskedVendor = null;
+    unmaskedRenderer = null;
+  }
+
+  const classification = classifyRendererInfo({
+    vendor,
+    renderer,
+    unmaskedVendor,
+    unmaskedRenderer,
+  });
+
+  return {
+    vendor,
+    renderer,
+    unmaskedVendor,
+    unmaskedRenderer,
+    ...classification,
+  };
+}

--- a/src/scene/structures/selfieMirror.ts
+++ b/src/scene/structures/selfieMirror.ts
@@ -39,6 +39,12 @@ export interface SelfieMirrorBuild {
   renderTarget: WebGLRenderTarget;
   update(context: SelfieMirrorUpdateContext): void;
   render(renderer: WebGLRenderer, scene: Scene): void;
+  setRenderTargetSize(size: number): void;
+  getState(): {
+    playerDistance: number;
+    renderTargetSize: number;
+    renderCount: number;
+  };
   dispose(): void;
 }
 
@@ -160,9 +166,17 @@ export function createSelfieMirror(
   accent.position.set(0, BASE_HEIGHT + height - 0.28, depth * -0.08);
   group.add(accent);
 
-  const renderTarget = new WebGLRenderTarget(512, 512, {
-    generateMipmaps: false,
-  });
+  let renderTargetSize = 512;
+  let renderCount = 0;
+  let lastPlayerDistance = Number.POSITIVE_INFINITY;
+
+  const renderTarget = new WebGLRenderTarget(
+    renderTargetSize,
+    renderTargetSize,
+    {
+      generateMipmaps: false,
+    }
+  );
   renderTarget.texture.colorSpace = SRGBColorSpace;
 
   const displayMaterial = new MeshBasicMaterial({
@@ -247,6 +261,7 @@ export function createSelfieMirror(
       playerPosition.z - basePosition.z
     );
     const planarDistance = planarOffset.length();
+    lastPlayerDistance = planarDistance;
     const emphasis = MathUtils.clamp(1 - planarDistance / GLOW_RADIUS, 0, 1);
     glowMaterial.opacity = MathUtils.lerp(
       GLOW_BASE_OPACITY,
@@ -272,7 +287,23 @@ export function createSelfieMirror(
     glow.visible = previousGlowVisible;
     renderer.setRenderTarget(previousTarget);
     renderer.autoClear = previousAutoClear;
+    renderCount += 1;
   };
+
+  const setRenderTargetSize = (size: number) => {
+    const nextSize = Math.max(64, Math.min(512, Math.round(size)));
+    if (nextSize === renderTargetSize) {
+      return;
+    }
+    renderTargetSize = nextSize;
+    renderTarget.setSize(nextSize, nextSize);
+  };
+
+  const getState = () => ({
+    playerDistance: lastPlayerDistance,
+    renderTargetSize,
+    renderCount,
+  });
 
   const dispose = () => {
     renderTarget.dispose();
@@ -295,6 +326,8 @@ export function createSelfieMirror(
     renderTarget,
     update,
     render,
+    setRenderTargetSize,
+    getState,
     dispose,
   };
 }

--- a/src/systems/failover/performanceFailover.ts
+++ b/src/systems/failover/performanceFailover.ts
@@ -43,6 +43,9 @@ export interface PerformanceFailoverHandlerOptions {
   minimumDurationMs?: number;
   maxFrameDeltaMs?: number;
   onTrigger?: (context: PerformanceFailoverTriggerContext) => void;
+  onLowFpsBeforeFallback?: (
+    context: PerformanceFailoverTriggerContext
+  ) => boolean;
   renderFallback?: (
     container: HTMLElement,
     options: RenderTextFallbackOptions
@@ -74,7 +77,7 @@ interface PerformanceFailoverMonitorOptions {
   fpsThreshold: number;
   minimumDurationMs: number;
   maxFrameDeltaMs: number;
-  onTrigger: (context: PerformanceFailoverTriggerContext) => void;
+  onTrigger: (context: PerformanceFailoverTriggerContext) => boolean | void;
 }
 
 const logPerformanceFailover = (
@@ -108,7 +111,7 @@ class PerformanceFailoverMonitor {
 
   private readonly onTrigger: (
     context: PerformanceFailoverTriggerContext
-  ) => void;
+  ) => boolean | void;
 
   private lowFpsDurationMs = 0;
 
@@ -143,7 +146,7 @@ class PerformanceFailoverMonitor {
         this.triggered = true;
         const summary = this.fpsAccumulator.getSummary();
         const averageFps = summary?.averageFps ?? fps;
-        this.onTrigger({
+        const handled = this.onTrigger({
           averageFps,
           durationMs: this.lowFpsDurationMs,
           sampleCount: summary?.count ?? 1,
@@ -152,6 +155,10 @@ class PerformanceFailoverMonitor {
           p95Fps: summary?.p95Fps ?? fps,
           medianFps: summary?.medianFps ?? fps,
         });
+        if (handled === true) {
+          this.triggered = false;
+          this.resetLowFpsSamples();
+        }
       }
       return;
     }
@@ -186,6 +193,7 @@ export function createPerformanceFailoverHandler(
     minimumDurationMs = 5000,
     maxFrameDeltaMs = 1000,
     onTrigger,
+    onLowFpsBeforeFallback,
     renderFallback: render = renderTextFallback,
     fallbackLinks,
     onBeforeFallback,
@@ -287,7 +295,11 @@ export function createPerformanceFailoverHandler(
         minimumDurationMs,
         maxFrameDeltaMs,
         onTrigger: (context) => {
+          if (onLowFpsBeforeFallback?.(context) === true) {
+            return true;
+          }
           transitionToFallback('low-performance', context);
+          return false;
         },
       });
 

--- a/src/systems/performance/performanceDiagnostics.ts
+++ b/src/systems/performance/performanceDiagnostics.ts
@@ -1,0 +1,170 @@
+import type { GraphicsQualityLevel } from '../../scene/graphics/qualityManager';
+import type { RendererInfoSnapshot } from '../../scene/graphics/rendererCapabilities';
+
+export type PerformancePhase =
+  | 'inputMovementCamera'
+  | 'avatarIkAudio'
+  | 'poiHudTooltips'
+  | 'decorativeStructures'
+  | 'lightingLedLightmap'
+  | 'mirror'
+  | 'mainRenderComposer';
+
+export interface PhaseTimingSnapshot {
+  averageMs: number;
+  p95Ms: number;
+  sampleCount: number;
+}
+
+export interface PerformanceDiagnosticsState {
+  rendererInfo: RendererInfoSnapshot;
+  getQualityLevel(): GraphicsQualityLevel;
+  getDpr(): number;
+  getViewport(): { width: number; height: number };
+  getDrawingBuffer(): { width: number; height: number };
+  getFeatureState(): {
+    bloomEnabled: boolean;
+    composerEnabled: boolean;
+    activePostprocessingPassCount: number;
+    mirrorEnabled: boolean;
+    mirrorRenderTargetSize: number;
+    mirrorUpdateRateFps: number;
+    mirrorRenderCount: number;
+  };
+  getAdaptiveState(): {
+    downgradeCount: number;
+    lastDowngradeReason: string | null;
+    lastFailoverReason: string | null;
+  };
+}
+
+const MAX_FRAME_SAMPLES = 240;
+const MAX_PHASE_SAMPLES = 160;
+
+function percentile(sortedValues: readonly number[], ratio: number): number {
+  if (sortedValues.length === 0) {
+    return 0;
+  }
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil(sortedValues.length * ratio) - 1)
+  );
+  return sortedValues[index];
+}
+
+function summarize(values: readonly number[]) {
+  if (values.length === 0) {
+    return { average: 0, median: 0, p95: 0, min: 0, count: 0 };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    average: total / values.length,
+    median: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+    min: sorted[0],
+    count: values.length,
+  };
+}
+
+export function createPerformanceDiagnostics(
+  state: PerformanceDiagnosticsState
+) {
+  const frameMsSamples: number[] = [];
+  const phaseSamples = new Map<PerformancePhase, number[]>();
+
+  function pushSample(samples: number[], value: number, maxSamples: number) {
+    if (!Number.isFinite(value) || value < 0) {
+      return;
+    }
+    samples.push(value);
+    if (samples.length > maxSamples) {
+      samples.splice(0, samples.length - maxSamples);
+    }
+  }
+
+  function getFrameStats() {
+    const summary = summarize(frameMsSamples);
+    const fpsSamples = frameMsSamples.map((frameMs) =>
+      frameMs > 0 ? 1000 / frameMs : 0
+    );
+    const fpsSummary = summarize(fpsSamples);
+    return {
+      averageFps: fpsSummary.average,
+      medianFps: fpsSummary.median,
+      p95FrameMs: summary.p95,
+      minFps: fpsSummary.min,
+      sampleCount: summary.count,
+    };
+  }
+
+  function getPhaseTimings(): Record<PerformancePhase, PhaseTimingSnapshot> {
+    const phases: PerformancePhase[] = [
+      'inputMovementCamera',
+      'avatarIkAudio',
+      'poiHudTooltips',
+      'decorativeStructures',
+      'lightingLedLightmap',
+      'mirror',
+      'mainRenderComposer',
+    ];
+    return Object.fromEntries(
+      phases.map((phase) => {
+        const summary = summarize(phaseSamples.get(phase) ?? []);
+        return [
+          phase,
+          {
+            averageMs: summary.average,
+            p95Ms: summary.p95,
+            sampleCount: summary.count,
+          },
+        ];
+      })
+    ) as Record<PerformancePhase, PhaseTimingSnapshot>;
+  }
+
+  return {
+    recordFrame(deltaSeconds: number) {
+      pushSample(frameMsSamples, deltaSeconds * 1000, MAX_FRAME_SAMPLES);
+    },
+    recordPhase(phase: PerformancePhase, durationMs: number) {
+      const samples = phaseSamples.get(phase) ?? [];
+      pushSample(samples, durationMs, MAX_PHASE_SAMPLES);
+      phaseSamples.set(phase, samples);
+    },
+    getFrameStats,
+    getRendererInfo() {
+      return { ...state.rendererInfo };
+    },
+    getQualityState() {
+      return {
+        level: state.getQualityLevel(),
+        dpr: state.getDpr(),
+        ...state.getAdaptiveState(),
+      };
+    },
+    getFeatureState() {
+      return state.getFeatureState();
+    },
+    getLastFailoverReason() {
+      return state.getAdaptiveState().lastFailoverReason;
+    },
+    getSnapshot() {
+      return {
+        ...getFrameStats(),
+        dpr: state.getDpr(),
+        viewport: state.getViewport(),
+        drawingBuffer: state.getDrawingBuffer(),
+        quality: this.getQualityState(),
+        features: state.getFeatureState(),
+        renderer: this.getRendererInfo(),
+        phaseTimings: getPhaseTimings(),
+        lastFailoverReason: state.getAdaptiveState().lastFailoverReason,
+      };
+    },
+  };
+}
+
+export type PerformanceDiagnostics = ReturnType<
+  typeof createPerformanceDiagnostics
+>;

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -130,8 +130,8 @@ describe('createGraphicsQualityManager', () => {
       storage,
     });
 
-    expect(manager.getLevel()).toBe('cinematic');
-    expect(renderer.getPixelRatio()).toBeCloseTo(1, 3);
+    expect(manager.getLevel()).toBe('balanced');
+    expect(renderer.getPixelRatio()).toBeCloseTo(0.85, 3);
 
     manager.setLevel('balanced');
     expect(renderer.getPixelRatio()).toBeCloseTo(0.85, 3);
@@ -162,7 +162,7 @@ describe('createGraphicsQualityManager', () => {
       storage,
     });
 
-    expect(manager.getLevel()).toBe('cinematic');
+    expect(manager.getLevel()).toBe('balanced');
     expect(storage.getItem).toHaveBeenCalledWith(
       'danielsmith:graphics-quality-level'
     );

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPerformanceDiagnostics } from '../systems/performance/performanceDiagnostics';
+
+describe('performance diagnostics', () => {
+  it('aggregates frame and phase snapshots without mutating feature state', () => {
+    const diagnostics = createPerformanceDiagnostics({
+      rendererInfo: {
+        vendor: 'Google Inc.',
+        renderer: 'WebGL',
+        unmaskedVendor: 'NVIDIA',
+        unmaskedRenderer: 'NVIDIA GeForce',
+        tier: 'hardware',
+        reason: 'test',
+      },
+      getQualityLevel: () => 'balanced',
+      getDpr: () => 1.25,
+      getViewport: () => ({ width: 1280, height: 720 }),
+      getDrawingBuffer: () => ({ width: 1600, height: 900 }),
+      getFeatureState: () => ({
+        bloomEnabled: true,
+        composerEnabled: true,
+        activePostprocessingPassCount: 1,
+        mirrorEnabled: true,
+        mirrorRenderTargetSize: 256,
+        mirrorUpdateRateFps: 8,
+        mirrorRenderCount: 3,
+      }),
+      getAdaptiveState: () => ({
+        downgradeCount: 1,
+        lastDowngradeReason: 'test downgrade',
+        lastFailoverReason: null,
+      }),
+    });
+
+    diagnostics.recordFrame(1 / 60);
+    diagnostics.recordFrame(1 / 30);
+    diagnostics.recordPhase('mainRenderComposer', 4);
+    diagnostics.recordPhase('mainRenderComposer', 12);
+
+    const snapshot = diagnostics.getSnapshot();
+    expect(snapshot.averageFps).toBeGreaterThan(40);
+    expect(snapshot.p95FrameMs).toBeGreaterThan(16);
+    expect(snapshot.quality).toMatchObject({
+      level: 'balanced',
+      dpr: 1.25,
+      downgradeCount: 1,
+    });
+    expect(snapshot.features).toMatchObject({
+      composerEnabled: true,
+      mirrorUpdateRateFps: 8,
+    });
+    expect(snapshot.phaseTimings.mainRenderComposer.sampleCount).toBe(2);
+    expect(snapshot.renderer.tier).toBe('hardware');
+  });
+});

--- a/src/tests/performanceFailover.test.ts
+++ b/src/tests/performanceFailover.test.ts
@@ -511,4 +511,40 @@ describe('createPerformanceFailoverHandler', () => {
     expect(failoverEvents[0].detail.context).toEqual(consoleDetail);
     expect(consoleTarget.error).toBe(originalError);
   });
+
+  it('runs adaptive downgrade callback before falling back and does not flap immediately', () => {
+    const { renderer } = createRenderer();
+    const container = createContainer();
+    const markAppReady = vi.fn();
+    const renderFallback = vi.fn();
+    const onLowFpsBeforeFallback = vi.fn(() => true);
+
+    const handler = createPerformanceFailoverHandler({
+      renderer,
+      container,
+      immersiveUrl: IMMERSIVE_URL,
+      markAppReady,
+      renderFallback,
+      minimumDurationMs: 1000,
+      onLowFpsBeforeFallback,
+    });
+
+    for (let i = 0; i < 25; i += 1) {
+      handler.update(1 / 20);
+    }
+
+    expect(onLowFpsBeforeFallback).toHaveBeenCalledTimes(1);
+    expect(handler.hasTriggered()).toBe(false);
+    expect(renderFallback).not.toHaveBeenCalled();
+
+    for (let i = 0; i < 10; i += 1) {
+      handler.update(1 / 60);
+    }
+    for (let i = 0; i < 25; i += 1) {
+      handler.update(1 / 20);
+    }
+
+    expect(onLowFpsBeforeFallback).toHaveBeenCalledTimes(2);
+    expect(handler.hasTriggered()).toBe(false);
+  });
 });

--- a/src/tests/rendererPerformancePolicy.test.ts
+++ b/src/tests/rendererPerformancePolicy.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clampDpr,
+  selectInitialGraphicsQuality,
+  selectMirrorPolicy,
+  shouldUseComposer,
+} from '../scene/graphics/performancePolicy';
+import { classifyRendererInfo } from '../scene/graphics/rendererCapabilities';
+
+const softwareRenderer = {
+  tier: 'software' as const,
+};
+
+const hardwareRenderer = {
+  tier: 'hardware' as const,
+};
+
+describe('renderer performance policy', () => {
+  it('classifies common software renderer strings', () => {
+    expect(
+      classifyRendererInfo({
+        unmaskedRenderer: 'ANGLE (Google, Vulkan SwiftShader)',
+      }).tier
+    ).toBe('software');
+    expect(
+      classifyRendererInfo({ unmaskedRenderer: 'llvmpipe (LLVM 17.0)' }).tier
+    ).toBe('software');
+  });
+
+  it('classifies common hardware renderer strings', () => {
+    expect(
+      classifyRendererInfo({ unmaskedRenderer: 'NVIDIA GeForce RTX 4090' }).tier
+    ).toBe('hardware');
+    expect(
+      classifyRendererInfo({ unmaskedRenderer: 'Apple M3 Pro' }).tier
+    ).toBe('hardware');
+  });
+
+  it('selects performance quality for software and balanced for normal defaults', () => {
+    expect(selectInitialGraphicsQuality(softwareRenderer, 'cinematic')).toBe(
+      'performance'
+    );
+    expect(selectInitialGraphicsQuality(hardwareRenderer, null)).toBe(
+      'balanced'
+    );
+    expect(selectInitialGraphicsQuality(hardwareRenderer, 'cinematic')).toBe(
+      'cinematic'
+    );
+  });
+
+  it('clamps DPR by quality tier and adaptive downgrade step', () => {
+    expect(
+      clampDpr({
+        devicePixelRatio: 3,
+        rendererTier: 'hardware',
+        quality: 'cinematic',
+      })
+    ).toBe(1.5);
+    expect(
+      clampDpr({
+        devicePixelRatio: 3,
+        rendererTier: 'hardware',
+        quality: 'balanced',
+      })
+    ).toBe(1.25);
+    expect(
+      clampDpr({
+        devicePixelRatio: 2,
+        rendererTier: 'software',
+        quality: 'cinematic',
+      })
+    ).toBe(0.75);
+    expect(
+      clampDpr({
+        devicePixelRatio: 2,
+        rendererTier: 'hardware',
+        quality: 'performance',
+        adaptiveStep: 2,
+      })
+    ).toBe(0.7);
+  });
+
+  it('skips composer when postprocessing passes are disabled', () => {
+    expect(
+      shouldUseComposer({ bloomEnabled: false, motionBlurEnabled: false })
+    ).toBe(false);
+    expect(
+      shouldUseComposer({ bloomEnabled: true, motionBlurEnabled: false })
+    ).toBe(true);
+  });
+
+  it('throttles or disables selfie mirror by quality and renderer tier', () => {
+    expect(
+      selectMirrorPolicy({
+        quality: 'performance',
+        rendererTier: 'hardware',
+        playerDistance: 1,
+      })
+    ).toMatchObject({ enabled: false, targetSize: 128, updateRateFps: 0 });
+    expect(
+      selectMirrorPolicy({
+        quality: 'balanced',
+        rendererTier: 'hardware',
+        playerDistance: 1,
+      })
+    ).toMatchObject({ enabled: true, targetSize: 256, updateRateFps: 8 });
+    expect(
+      selectMirrorPolicy({
+        quality: 'cinematic',
+        rendererTier: 'hardware',
+        playerDistance: 1,
+      })
+    ).toMatchObject({ enabled: true, targetSize: 512, updateRateFps: 15 });
+    expect(
+      selectMirrorPolicy({
+        quality: 'cinematic',
+        rendererTier: 'software',
+        playerDistance: 1,
+      })
+    ).toMatchObject({ enabled: false, targetSize: 128, updateRateFps: 0 });
+  });
+});

--- a/src/tests/selfieMirror.test.ts
+++ b/src/tests/selfieMirror.test.ts
@@ -106,3 +106,30 @@ describe('SelfieMirror structure', () => {
     mirror.dispose();
   });
 });
+
+it('tracks render target size and render count for diagnostics', () => {
+  const mirror = createSelfieMirror({ position: { x: 0, z: 0 } });
+  const scene = new Scene();
+  const renderer = {
+    autoClear: false,
+    getRenderTarget: vi.fn(() => null),
+    setRenderTarget: vi.fn(),
+    render: vi.fn(),
+  } as unknown as WebGLRenderer;
+
+  mirror.setRenderTargetSize(256);
+  mirror.update({
+    playerPosition: { x: 1, y: 0, z: 1 },
+    playerRotationY: 0,
+    playerHeight: 1.8,
+  });
+  mirror.render(renderer, scene);
+
+  expect(mirror.getState()).toMatchObject({
+    renderTargetSize: 256,
+    renderCount: 1,
+  });
+  expect(mirror.getState().playerDistance).toBeGreaterThan(0);
+
+  mirror.dispose();
+});


### PR DESCRIPTION
### Motivation

- Address severe immersive slowdowns observed on staging (≈5 FPS) and ensure modern desktop paths remain immersive while software paths degrade gracefully before text fallback.
- Prevent expensive full-screen postprocessing and redundant scene renders (SelfieMirror) from causing unnecessary frame cost, and surface cheap, production-safe diagnostics to validate fixes.

### Description

- Add renderer capability detection and classification in `src/scene/graphics/rendererCapabilities.ts` and a performance policy in `src/scene/graphics/performancePolicy.ts` to choose initial quality and clamp DPR by renderer tier.
- Wire adaptive DPR/quality policy and lightweight diagnostics into `src/main.ts`: detect renderer info early, select initial quality/DPR, skip composer when no passes are active, add an adaptive downgrade ladder (non-flapping) before failover, and expose `window.portfolio.performance` via `src/systems/performance/performanceDiagnostics.ts`.
- Throttle / disable the SelfieMirror render by policy and make the mirror resizable and observable (`setRenderTargetSize`, `getState`) in `src/scene/structures/selfieMirror.ts` so mirror updates no longer render the full scene every frame.
- Extend the performance-failover monitor (`src/systems/failover/performanceFailover.ts`) with a pre-fallback callback so adaptive downgrades run before committing to the text fallback.
- Add unit tests for the new policies and diagnostics and extend existing tests to cover mirror state and the adaptive pre-fallback behavior (`src/tests/rendererPerformancePolicy.test.ts`, `src/tests/performanceDiagnostics.test.ts`, updates to `src/tests/performanceFailover.test.ts`, `src/tests/selfieMirror.test.ts`).
- Add Playwright specs to validate runtime behavior and adaptive quality (`playwright/immersive-performance.spec.ts`, `playwright/adaptive-quality.spec.ts`) and create outage bookkeeping markdown/JSON entries documenting the overview and confirmed root causes under `outages/2026-05-29-*`.

### Testing

- Ran formatting and linting: `npm run format:write` completed and `npm run lint` produced and then had import-order warnings which were addressed as part of the change; lint now reports no blocking errors (only initial warnings were resolved).
- Ran targeted Vitest unit suites for the new/modified tests: `src/tests/rendererPerformancePolicy.test.ts`, `src/tests/performanceDiagnostics.test.ts`, `src/tests/performanceFailover.test.ts`, and `src/tests/selfieMirror.test.ts`; the targeted run completed with all tests passing (4 files, 24 tests passed).
- `npm run typecheck` was executed but the repository contains pre-existing, unrelated TypeScript errors that surfaced during a full typecheck run; those errors are outside the narrow change surface and were not introduced by this patch (recommend follow-up to address repo-wide type noise before a full typecheck pass).
- Playwright E2E specs for adaptive and immersive performance were added but not executed in this environment (CI/browser runs expected in pipeline); they are included under `playwright/` and referenced in outage validation commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a034eac64832fb9e59fe78a350aa1)