### PR TITLE
🛟 Repair fallback mode recovery

### DIFF
--- a/outages/2026-05-29-danielsmith-staging-performance-overview.json
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.json
@@ -8,7 +8,8 @@
     "2026-05-29-danielsmith-software-renderer-quality",
     "2026-05-29-danielsmith-postprocessing-pixel-cost",
     "2026-05-29-danielsmith-selfie-mirror-render-cost",
-    "2026-05-29-danielsmith-adaptive-quality-gap"
+    "2026-05-29-danielsmith-adaptive-quality-gap",
+    "2026-05-30-danielsmith-mode-fallback-recovery"
   ],
   "disprovenOrUnconfirmed": [
     {

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.md
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.md
@@ -14,6 +14,7 @@ software WebGL.
 - [Postprocessing and DPR multiplied full-screen pixel cost](./2026-05-29-danielsmith-postprocessing-pixel-cost.md).
 - [SelfieMirror rendered the full scene every frame](./2026-05-29-danielsmith-selfie-mirror-render-cost.md).
 - [Adaptive quality did not downgrade before text fallback](./2026-05-29-danielsmith-adaptive-quality-gap.md).
+- [Text fallback recovery trapped immersive debugging](./2026-05-30-danielsmith-mode-fallback-recovery.md).
 
 ## Disproven or unconfirmed theories
 

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-05-30-danielsmith-mode-fallback-recovery",
+  "date": "2026-05-30",
+  "overview": "2026-05-29-danielsmith-staging-performance-overview",
+  "title": "Text fallback recovery trapped immersive debugging",
+  "symptomSlice": "Text mode and runtime fallback blocked normal immersive recovery unless operators knew the force-immersive debug URL.",
+  "rootCause": "The manual mode toggle was one-way after fallback activation, and fallback links did not separate normal immersive recovery from advanced performance-failover bypass debugging.",
+  "fixSummary": "The T shortcut is bidirectional, text fallback exposes Try immersive again plus a debug force-immersive link for performance/runtime fallbacks, and users can clear saved mode preference from the fallback UI.",
+  "regressionTests": "Vitest covers URL helpers, mode persistence rules, fallback recovery links, and manual toggle active-state recovery; Playwright covers T round trips, text-mode recovery links, stored preference overrides, and the force-immersive debug URL.",
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"mode|fallback|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
@@ -10,10 +10,11 @@
   "validationCommands": [
     "npm run format:write",
     "npm run lint",
-    "npm run typecheck",
     "npm run test:ci",
     "npm run test:e2e -- --grep \"mode|fallback|immersive\"",
     "npm run docs:check",
     "npm run smoke"
-  ]
+  ],
+  "knownFailingValidationCommands": ["npm run typecheck"],
+  "knownFailingValidationNote": "Still reports pre-existing repo-wide TypeScript issues outside this fallback recovery fix."
 }

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
@@ -1,0 +1,55 @@
+# Text fallback recovery trapped immersive debugging
+
+[Back to performance overview](./2026-05-29-danielsmith-staging-performance-overview.md)
+
+## Symptom
+
+Text mode was too trapdoor-like during staging validation. A hard refresh could
+start in text mode because `danielsmith.io:mode-preference` stored `text`, the
+`T` shortcut only moved from immersive into text fallback, and runtime failover
+made the primary debugging path feel blocked unless the operator knew to open
+`?mode=immersive&disablePerformanceFailover=1` manually.
+
+## Root cause
+
+The mode toggle treated an active fallback as a terminal state: it disabled the
+control and ignored the `T` shortcut once text mode was active. The fallback UI
+also exposed one immersive link that always used the full debug bypass URL, so it
+did not distinguish normal recovery (`?mode=immersive`) from advanced collection
+(`?mode=immersive&disablePerformanceFailover=1`). Together with stored text
+preference, this made manual text mode and runtime fallback look sticky.
+
+## Fix summary
+
+- `T` is now a bidirectional toggle. In immersive mode it still enters text mode;
+  in fallback mode it clears saved mode preference and navigates to a clean
+  immersive recovery URL.
+- Text fallback now shows a visible **Try immersive again** action using
+  `?mode=immersive`, plus a **Debug: force immersive mode** link for performance
+  and runtime-error fallbacks that need
+  `?mode=immersive&disablePerformanceFailover=1`.
+- A **Clear saved mode preference** action removes stored mode preference without
+  requiring DevTools.
+- Runtime performance fallback remains active but does not persist a sticky text
+  preference; only explicit manual text-mode selection should write `text`.
+
+## Validation steps
+
+- Start at `/?mode=immersive&disablePerformanceFailover=1`, press `T`, confirm
+  text fallback appears, press `T` again, and confirm immersive mode returns.
+- Start at `/?mode=text`, activate **Try immersive again**, and confirm the URL
+  includes `mode=immersive` without the performance bypass.
+- Set `localStorage["danielsmith.io:mode-preference"] = "text"`, open
+  `/?mode=immersive`, and confirm immersive mode wins over storage.
+- For low-FPS or debug collection, use
+  `/?mode=immersive&disablePerformanceFailover=1` to keep runtime failover off.
+
+## Validation commands
+
+- `npm run format:write`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:ci`
+- `npm run test:e2e -- --grep "mode|fallback|immersive"`
+- `npm run docs:check`
+- `npm run smoke`

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
@@ -48,8 +48,12 @@ preference, this made manual text mode and runtime fallback look sticky.
 
 - `npm run format:write`
 - `npm run lint`
-- `npm run typecheck`
 - `npm run test:ci`
 - `npm run test:e2e -- --grep "mode|fallback|immersive"`
 - `npm run docs:check`
 - `npm run smoke`
+
+## Known failing validation
+
+- `npm run typecheck` still reports pre-existing repo-wide TypeScript issues
+  outside this fallback recovery fix.

--- a/playwright/mode-fallback-recovery.spec.ts
+++ b/playwright/mode-fallback-recovery.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const IMMERSIVE_DEBUG_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const TEXT_URL = '/?mode=text';
+
+async function waitForImmersive(page: Page) {
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+  await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+async function waitForTextFallback(page: Page) {
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'fallback'
+  );
+  await expect(
+    page.locator('#app[data-mode="text"] .text-fallback')
+  ).toBeVisible();
+}
+
+test.describe('mode fallback recovery', () => {
+  test('pressing T toggles from immersive to text and back to immersive', async ({
+    page,
+  }) => {
+    await page.goto(IMMERSIVE_DEBUG_URL, { waitUntil: 'domcontentloaded' });
+    await waitForImmersive(page);
+
+    await page.keyboard.press('T');
+    await waitForTextFallback(page);
+    await expect(page.locator('[data-action="immersive"]')).toContainText(
+      'Try immersive again'
+    );
+
+    await page.keyboard.press('T');
+    await waitForImmersive(page);
+  });
+
+  test('Try immersive again from explicit text mode returns to immersive', async ({
+    page,
+  }) => {
+    await page.goto(TEXT_URL, { waitUntil: 'domcontentloaded' });
+    await waitForTextFallback(page);
+
+    await page.getByRole('link', { name: 'Try immersive again' }).click();
+    await expect(page).toHaveURL(/mode=immersive/);
+    await waitForImmersive(page);
+  });
+
+  test('explicit immersive URL wins over stored text preference', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('danielsmith.io:mode-preference', 'text');
+    });
+
+    await page.goto('/?mode=immersive', { waitUntil: 'domcontentloaded' });
+    await waitForImmersive(page);
+  });
+
+  test('debug force-immersive URL remains valid for collection', async ({
+    page,
+  }) => {
+    await page.goto(IMMERSIVE_DEBUG_URL, { waitUntil: 'domcontentloaded' });
+    await waitForImmersive(page);
+
+    await expect(page).toHaveURL(/mode=immersive/);
+    await expect(page).toHaveURL(/disablePerformanceFailover=1/);
+  });
+});

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -95,7 +95,10 @@ export const AR_OVERRIDES: LocaleOverrides = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: 'تشغيل الوضع الغامر',
+        immersiveLink: 'جرّب الوضع الغامر مجددًا',
+        debugImmersiveLink: 'تصحيح: فرض الوضع الغامر',
+        clearPreferenceButton: 'مسح تفضيل الوضع المحفوظ',
+        clearPreferenceSuccess: 'تم مسح تفضيل الوضع المحفوظ',
         resumeLink: 'تحميل أحدث سيرة ذاتية',
         githubLink: 'استكشاف المشاريع على GitHub',
       },

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -101,7 +101,10 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         resumeUrl: wrap('docs/resume/2025-09/resume.pdf'),
       },
       actions: {
-        immersiveLink: wrap('Launch immersive mode'),
+        immersiveLink: wrap('Try immersive again'),
+        debugImmersiveLink: wrap('Debug: force immersive mode'),
+        clearPreferenceButton: wrap('Clear saved mode preference'),
+        clearPreferenceSuccess: wrap('Saved mode preference cleared'),
         resumeLink: wrap('Download the latest résumé'),
         githubLink: wrap('Explore projects on GitHub'),
       },
@@ -259,9 +262,11 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       pendingAnnouncementTemplate: wrap(
         'Switch to the text-only portfolio. Switching to text mode…'
       ),
-      activeLabelTemplate: wrap('Text mode active'),
-      activeDescriptionTemplate: wrap('Text mode already active.'),
-      activeAnnouncementTemplate: wrap('Text mode already active.'),
+      activeLabelTemplate: wrap('Try immersive again · Press {keyHint}'),
+      activeDescriptionTemplate: wrap('Return to the immersive portfolio.'),
+      activeAnnouncementTemplate: wrap(
+        'Text mode active. Press {keyHint} to try immersive again.'
+      ),
       errorLabelTemplate: wrap('Retry text mode · Press {keyHint}'),
       errorDescriptionTemplate: wrap(
         'Text mode toggle failed. Try again or use the immersive link.'

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -100,7 +100,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: 'Launch immersive mode',
+        immersiveLink: 'Try immersive again',
+        debugImmersiveLink: 'Debug: force immersive mode',
+        clearPreferenceButton: 'Clear saved mode preference',
+        clearPreferenceSuccess: 'Saved mode preference cleared',
         resumeLink: 'Download the latest résumé',
         githubLink: 'Explore projects on GitHub',
       },
@@ -265,9 +268,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       pendingLabelTemplate: 'Switching to text mode…',
       pendingAnnouncementTemplate:
         'Switch to the text-only portfolio. Switching to text mode…',
-      activeLabelTemplate: 'Text mode active',
-      activeDescriptionTemplate: 'Text mode already active.',
-      activeAnnouncementTemplate: 'Text mode already active.',
+      activeLabelTemplate: 'Try immersive again · Press {keyHint}',
+      activeDescriptionTemplate: 'Return to the immersive portfolio.',
+      activeAnnouncementTemplate:
+        'Text mode active. Press {keyHint} to try immersive again.',
       errorLabelTemplate: 'Retry text mode · Press {keyHint}',
       errorDescriptionTemplate:
         'Text mode toggle failed. Try again or use the immersive link.',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -95,7 +95,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: '没入モードを起動',
+        immersiveLink: '没入モードをもう一度試す',
+        debugImmersiveLink: 'デバッグ: 没入モードを強制',
+        clearPreferenceButton: '保存したモード設定を消去',
+        clearPreferenceSuccess: '保存したモード設定を消去しました',
         resumeLink: '最新の履歴書をダウンロード',
         githubLink: 'GitHubでプロジェクトを見る',
       },

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -246,6 +246,9 @@ export interface SiteTextFallbackStrings {
   };
   actions: {
     immersiveLink: string;
+    debugImmersiveLink: string;
+    clearPreferenceButton: string;
+    clearPreferenceSuccess: string;
     resumeLink: string;
     githubLink: string;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -303,7 +303,11 @@ import {
   createManualModeToggle,
   type ManualModeToggleHandle,
 } from './systems/failover/manualModeToggle';
-import { writeModePreference } from './systems/failover/modePreference';
+import {
+  clearModePreference,
+  shouldPersistTextPreferenceForFallback,
+  writeModePreference,
+} from './systems/failover/modePreference';
 import { createPerformanceFailoverHandler } from './systems/failover/performanceFailover';
 import { createGitHubRepoStatsService } from './systems/github/repoStats';
 import {
@@ -385,6 +389,7 @@ import {
 } from './ui/hud/responsiveControlOverlay';
 import {
   createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
   shouldDisablePerformanceFailover,
 } from './ui/immersiveUrl';
 import './ui/styles.css';
@@ -2983,10 +2988,15 @@ function initializeImmersiveScene(
       strings: modeToggleStrings,
       getIsFallbackActive: () => performanceFailover.hasTriggered(),
       onToggle: () => {
-        writeModePreference('text');
-        if (!performanceFailover.hasTriggered()) {
-          performanceFailover.triggerFallback('manual');
+        if (performanceFailover.hasTriggered()) {
+          clearModePreference();
+          window.location.assign(createImmersiveRecoveryUrl());
+          return;
         }
+        if (shouldPersistTextPreferenceForFallback('manual')) {
+          writeModePreference('text');
+        }
+        performanceFailover.triggerFallback('manual');
       },
     });
     registerHudControlElement(manualModeToggle?.element ?? null);

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -549,6 +549,8 @@ const isTextInputTarget = (target: EventTarget | null): boolean => {
   const tagName = target.tagName.toLowerCase();
   return (
     target.isContentEditable ||
+    target.hasAttribute('contenteditable') ||
+    target.closest('[contenteditable]') !== null ||
     tagName === 'input' ||
     tagName === 'textarea' ||
     tagName === 'select'
@@ -575,6 +577,9 @@ const installFallbackRecoveryShortcuts = (
   }
   const normalizedKey = keyHint.length === 1 ? keyHint.toLowerCase() : keyHint;
   const handleKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
     const eventKey = keyHint.length === 1 ? event.key.toLowerCase() : event.key;
     if (eventKey !== normalizedKey) {
       return;

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -4,6 +4,7 @@ import {
   getLocaleDirection,
   getLocaleScript,
   getModeAnnouncerStrings,
+  getModeToggleStrings,
   resolveLocale,
   getPoiCopy,
   getPoiNarrativeLogStrings,
@@ -18,6 +19,7 @@ import {
 } from '../../ui/accessibility/modeAnnouncer';
 import {
   createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
   getModeFromSearch,
   IMMERSIVE_MODE_VALUE,
   shouldDisablePerformanceFailover,
@@ -25,6 +27,7 @@ import {
 } from '../../ui/immersiveUrl';
 
 import {
+  clearModePreference,
   readModePreference as readStoredModePreference,
   type ModePreference,
 } from './modePreference';
@@ -523,9 +526,74 @@ export function evaluateFailoverDecision(
 export interface RenderTextFallbackOptions {
   reason: FallbackReason;
   immersiveUrl?: string;
+  debugImmersiveUrl?: string;
   resumeUrl?: string;
   githubUrl?: string;
 }
+
+const FALLBACK_REASONS_WITH_DEBUG_BYPASS = new Set<FallbackReason>([
+  'low-performance',
+  'low-memory',
+  'low-end-device',
+  'data-saver',
+  'immersive-init-error',
+  'console-error',
+]);
+
+const fallbackRecoveryCleanup = new WeakMap<Document, () => void>();
+
+const isTextInputTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return (
+    target.isContentEditable ||
+    tagName === 'input' ||
+    tagName === 'textarea' ||
+    tagName === 'select'
+  );
+};
+
+const clearStoredModePreference = () => {
+  try {
+    clearModePreference();
+  } catch {
+    // Ignore storage failures; explicit immersive URLs still override preference.
+  }
+};
+
+const installFallbackRecoveryShortcuts = (
+  documentTarget: Document,
+  immersiveUrl: string,
+  keyHint = 'T'
+) => {
+  fallbackRecoveryCleanup.get(documentTarget)?.();
+  const windowTarget = documentTarget.defaultView;
+  if (!windowTarget) {
+    return;
+  }
+  const normalizedKey = keyHint.length === 1 ? keyHint.toLowerCase() : keyHint;
+  const handleKeydown = (event: KeyboardEvent) => {
+    const eventKey = keyHint.length === 1 ? event.key.toLowerCase() : event.key;
+    if (eventKey !== normalizedKey) {
+      return;
+    }
+    if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+      return;
+    }
+    if (isTextInputTarget(event.target)) {
+      return;
+    }
+    event.preventDefault();
+    clearStoredModePreference();
+    windowTarget.location.assign(immersiveUrl);
+  };
+  windowTarget.addEventListener('keydown', handleKeydown);
+  fallbackRecoveryCleanup.set(documentTarget, () => {
+    windowTarget.removeEventListener('keydown', handleKeydown);
+  });
+};
 
 function buildTextPortfolioGroups(
   localeHint?: string
@@ -882,6 +950,7 @@ export function renderTextFallback(
     resumeUrl = 'docs/resume/2025-09/resume.pdf',
     githubUrl = 'https://github.com/futuroptimist',
     immersiveUrl: providedImmersiveUrl,
+    debugImmersiveUrl: providedDebugImmersiveUrl,
   } = options;
   const documentTarget = container.ownerDocument ?? document;
   const localeHint =
@@ -889,13 +958,20 @@ export function renderTextFallback(
     (typeof navigator !== 'undefined' ? navigator.language : undefined);
   const textFallbackStrings = getSiteStrings(localeHint).textFallback;
   const actionStrings = textFallbackStrings.actions;
+  const modeToggleStrings = getModeToggleStrings(localeHint);
   const resolvedResumeUrl =
     resumeUrl ??
     textFallbackStrings.contact.resumeUrl ??
     'docs/resume/2025-09/resume.pdf';
   const resolvedGithubUrl = githubUrl ?? textFallbackStrings.contact.githubUrl;
-  const immersiveUrl = createImmersiveModeUrl(
+  const immersiveUrl = createImmersiveRecoveryUrl(
     providedImmersiveUrl ?? documentTarget.defaultView?.location ?? undefined
+  );
+  const debugImmersiveUrl = createImmersiveModeUrl(
+    providedDebugImmersiveUrl ??
+      providedImmersiveUrl ??
+      documentTarget.defaultView?.location ??
+      undefined
   );
   const resolvedLocale = resolveLocale(localeHint);
   const langValue = resolvedLocale === 'en-x-pseudo' ? 'en' : resolvedLocale;
@@ -964,8 +1040,45 @@ export function renderTextFallback(
   immersiveLink.textContent = actionStrings.immersiveLink;
   immersiveLink.rel = 'noopener';
   immersiveLink.dataset.action = 'immersive';
+  immersiveLink.addEventListener('click', clearStoredModePreference);
   immersiveItem.appendChild(immersiveLink);
   list.appendChild(immersiveItem);
+
+  if (FALLBACK_REASONS_WITH_DEBUG_BYPASS.has(reason)) {
+    const debugItem = documentTarget.createElement('li');
+    debugItem.className = 'text-fallback__action';
+    const debugLink = documentTarget.createElement('a');
+    debugLink.href = debugImmersiveUrl;
+    debugLink.className = 'text-fallback__link';
+    debugLink.textContent = actionStrings.debugImmersiveLink;
+    debugLink.rel = 'noopener';
+    debugLink.dataset.action = 'debug-immersive';
+    debugLink.addEventListener('click', clearStoredModePreference);
+    debugItem.appendChild(debugLink);
+    list.appendChild(debugItem);
+  }
+
+  const clearPreferenceItem = documentTarget.createElement('li');
+  clearPreferenceItem.className = 'text-fallback__action';
+  const clearPreferenceButton = documentTarget.createElement('button');
+  clearPreferenceButton.type = 'button';
+  clearPreferenceButton.className = 'text-fallback__link text-fallback__button';
+  clearPreferenceButton.textContent = actionStrings.clearPreferenceButton;
+  clearPreferenceButton.dataset.action = 'clear-mode-preference';
+  clearPreferenceButton.addEventListener('click', () => {
+    clearStoredModePreference();
+    clearPreferenceButton.textContent =
+      actionStrings.clearPreferenceSuccess ??
+      actionStrings.clearPreferenceButton;
+  });
+  clearPreferenceItem.appendChild(clearPreferenceButton);
+  list.appendChild(clearPreferenceItem);
+
+  installFallbackRecoveryShortcuts(
+    documentTarget,
+    immersiveUrl,
+    modeToggleStrings.keyHint
+  );
 
   const resumeItem = documentTarget.createElement('li');
   resumeItem.className = 'text-fallback__action';

--- a/src/systems/failover/manualModeToggle.ts
+++ b/src/systems/failover/manualModeToggle.ts
@@ -31,6 +31,8 @@ function isTextEntryTarget(target: EventTarget | null): boolean {
   const tagName = target.tagName.toLowerCase();
   return (
     target.isContentEditable ||
+    target.hasAttribute('contenteditable') ||
+    target.closest('[contenteditable]') !== null ||
     tagName === 'input' ||
     tagName === 'textarea' ||
     tagName === 'select'

--- a/src/systems/failover/manualModeToggle.ts
+++ b/src/systems/failover/manualModeToggle.ts
@@ -24,6 +24,19 @@ function isPromiseLike(value: unknown): value is PromiseLike<void> {
   );
 }
 
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return (
+    target.isContentEditable ||
+    tagName === 'input' ||
+    tagName === 'textarea' ||
+    tagName === 'select'
+  );
+}
+
 export function createManualModeToggle({
   container,
   onToggle,
@@ -38,6 +51,7 @@ export function createManualModeToggle({
 
   let pending = false;
   let errored = false;
+  let shortcutActive = false;
 
   const DEFAULT_STRINGS = getModeToggleStrings();
 
@@ -102,6 +116,11 @@ export function createManualModeToggle({
 
   const refreshState = () => {
     const fallbackActive = getIsFallbackActive();
+    if (fallbackActive) {
+      removeShortcutListener();
+    } else {
+      addShortcutListener();
+    }
     if (pending && fallbackActive) {
       pending = false;
     }
@@ -254,6 +273,9 @@ export function createManualModeToggle({
 
   const handleKeydown = (event: KeyboardEvent) => {
     const keyHint = strings.keyHint;
+    if (event.defaultPrevented) {
+      return;
+    }
     if (event.key !== keyHint && event.key !== keyHint.toLowerCase()) {
       return;
     }
@@ -263,12 +285,31 @@ export function createManualModeToggle({
     if (pending) {
       return;
     }
+    if (getIsFallbackActive() || isTextEntryTarget(event.target)) {
+      return;
+    }
     event.preventDefault();
     activate();
   };
 
+  const addShortcutListener = () => {
+    if (shortcutActive) {
+      return;
+    }
+    windowTarget.addEventListener('keydown', handleKeydown);
+    shortcutActive = true;
+  };
+
+  const removeShortcutListener = () => {
+    if (!shortcutActive) {
+      return;
+    }
+    windowTarget.removeEventListener('keydown', handleKeydown);
+    shortcutActive = false;
+  };
+
   button.addEventListener('click', handleClick);
-  windowTarget.addEventListener('keydown', handleKeydown);
+  addShortcutListener();
   button.addEventListener('focus', refreshState);
   windowTarget.addEventListener(
     'performancefailover',
@@ -285,7 +326,7 @@ export function createManualModeToggle({
     },
     dispose() {
       button.removeEventListener('click', handleClick);
-      windowTarget.removeEventListener('keydown', handleKeydown);
+      removeShortcutListener();
       button.removeEventListener('focus', refreshState);
       windowTarget.removeEventListener(
         'performancefailover',

--- a/src/systems/failover/manualModeToggle.ts
+++ b/src/systems/failover/manualModeToggle.ts
@@ -136,7 +136,7 @@ export function createManualModeToggle({
     if (fallbackActive) {
       errored = false;
       setContainerState('active');
-      setDisabledState(true);
+      setDisabledState(false);
       button.dataset.state = 'active';
       button.removeAttribute('aria-busy');
       button.textContent = withFallback(
@@ -214,7 +214,7 @@ export function createManualModeToggle({
 
   const activate = () => {
     refreshState();
-    if (pending || getIsFallbackActive()) {
+    if (pending) {
       return;
     }
     clearErrorState();
@@ -260,7 +260,7 @@ export function createManualModeToggle({
     if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
       return;
     }
-    if (pending || getIsFallbackActive()) {
+    if (pending) {
       return;
     }
     event.preventDefault();

--- a/src/systems/failover/modePreference.ts
+++ b/src/systems/failover/modePreference.ts
@@ -1,3 +1,5 @@
+import type { FallbackReason } from '../../types/failover';
+
 export type ModePreference = 'immersive' | 'text';
 
 const MODE_PREFERENCE_STORAGE_KEY = 'danielsmith.io:mode-preference';
@@ -75,5 +77,9 @@ export const clearModePreference = (
 ): void => {
   writeModePreference(null, options);
 };
+
+export const shouldPersistTextPreferenceForFallback = (
+  reason: FallbackReason
+): boolean => reason === 'manual';
 
 export const MODE_PREFERENCE_KEY = MODE_PREFERENCE_STORAGE_KEY;

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -914,6 +914,62 @@ describe('renderTextFallback', () => {
     ).toBeNull();
   });
 
+  it('replaces fallback T recovery handlers between repeated renders', () => {
+    const container = document.createElement('div');
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderTextFallback(container, {
+      reason: 'low-performance',
+      immersiveUrl: '/first',
+      resumeUrl: '/resume.pdf',
+      githubUrl: 'https://example.com',
+    });
+    renderTextFallback(container, {
+      reason: 'low-performance',
+      immersiveUrl: '/second',
+      resumeUrl: '/resume.pdf',
+      githubUrl: 'https://example.com',
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      key: 't',
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('ignores fallback T recovery shortcuts from contenteditable text targets', () => {
+    const container = render('low-performance');
+    const editable = document.createElement('div');
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    editable.setAttribute('contenteditable', 'true');
+    document.body.appendChild(editable);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 't',
+      bubbles: true,
+      cancelable: true,
+    });
+    editable.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+    editable.remove();
+    container.remove();
+  });
+
   it('indicates WebGL unsupported reason', () => {
     const container = render('webgl-unsupported');
     const section = container.querySelector('.text-fallback');

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -9,7 +9,10 @@ import {
   type FallbackReason,
   type RenderTextFallbackOptions,
 } from '../systems/failover';
-import { createImmersiveModeUrl } from '../ui/immersiveUrl';
+import {
+  createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
+} from '../ui/immersiveUrl';
 
 const IMMERSIVE_URL = createImmersiveModeUrl({
   pathname: '/',
@@ -861,7 +864,7 @@ describe('renderTextFallback', () => {
       '[data-action="immersive"]'
     );
     expect(immersiveLink?.href).toBe(
-      new URL(createImmersiveModeUrl(), window.location.origin).toString()
+      new URL(createImmersiveRecoveryUrl(), window.location.origin).toString()
     );
   });
 
@@ -873,10 +876,42 @@ describe('renderTextFallback', () => {
     );
     expect(immersiveLink?.href).toBe(
       new URL(
+        createImmersiveRecoveryUrl(customUrl),
+        window.location.origin
+      ).toString()
+    );
+  });
+
+  it('adds a debug immersive bypass link for runtime performance fallbacks', () => {
+    const customUrl = 'https://portfolio.test/demo?mode=text';
+    const container = render('low-performance', { immersiveUrl: customUrl });
+    const immersiveLink = container.querySelector<HTMLAnchorElement>(
+      '[data-action="immersive"]'
+    );
+    const debugLink = container.querySelector<HTMLAnchorElement>(
+      '[data-action="debug-immersive"]'
+    );
+
+    expect(immersiveLink?.href).toBe(
+      new URL(
+        createImmersiveRecoveryUrl(customUrl),
+        window.location.origin
+      ).toString()
+    );
+    expect(debugLink?.href).toBe(
+      new URL(
         createImmersiveModeUrl(customUrl),
         window.location.origin
       ).toString()
     );
+  });
+
+  it('does not add a debug bypass link for manual text mode', () => {
+    const container = render('manual');
+
+    expect(
+      container.querySelector('[data-action="debug-immersive"]')
+    ).toBeNull();
   });
 
   it('indicates WebGL unsupported reason', () => {
@@ -1011,6 +1046,7 @@ describe('renderTextFallback', () => {
 
     expect(actionLinks.map((link) => link.textContent)).toEqual([
       actions.immersiveLink,
+      actions.clearPreferenceButton,
       actions.resumeLink,
       actions.githubLink,
     ]);

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -103,6 +103,10 @@ describe('i18n utilities', () => {
     expect(english.pendingHudAnnouncement).toBe(
       'Switch to the text-only portfolio. Switching to text mode…'
     );
+    expect(english.activeLabel).toBe('Try immersive again · Press T');
+    expect(english.activeHudAnnouncement).toBe(
+      'Text mode active. Press T to try immersive again.'
+    );
     expect(english.errorLabel).toBe('Retry text mode · Press T');
     expect(english.errorHudAnnouncement).toBe(
       'Text mode toggle failed. Press T to try again.'
@@ -119,6 +123,10 @@ describe('i18n utilities', () => {
     );
     expect(pseudo.pendingHudAnnouncement).toBe(
       '⟦Switch to the text-only portfolio. Switching to text mode…⟧'
+    );
+    expect(pseudo.activeLabel).toBe('⟦Try immersive again · Press T⟧');
+    expect(pseudo.activeHudAnnouncement).toBe(
+      '⟦Text mode active. Press T to try immersive again.⟧'
     );
     expect(pseudo.errorLabel).toBe('⟦Retry text mode · Press T⟧');
     expect(pseudo.errorHudAnnouncement).toBe(

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createImmersiveModeUrl,
   createImmersivePreviewUrl,
+  createImmersiveRecoveryUrl,
   createTextModeUrl,
   getModeFromSearch,
   hasImmersiveOverride,
@@ -115,6 +116,28 @@ describe('createImmersiveModeUrl', () => {
     expect(url).toBe(
       '/demo?foo=bar&feature=preview&mode=immersive&disablePerformanceFailover=1#scene'
     );
+  });
+});
+
+describe('createImmersiveRecoveryUrl', () => {
+  it('builds an immersive URL without disabling runtime failover', () => {
+    const url = createImmersiveRecoveryUrl({
+      pathname: '/portfolio',
+      search: '?mode=text&disablePerformanceFailover=1&debug=1',
+      hash: '#text',
+    });
+
+    expect(url).toBe('/portfolio?mode=immersive&debug=1#text');
+  });
+
+  it('keeps extra params from clobbering the immersive recovery mode', () => {
+    const url = createImmersiveRecoveryUrl('/?mode=text', {
+      mode: 'text',
+      disablePerformanceFailover: true,
+      source: 'fallback',
+    });
+
+    expect(url).toBe('/?mode=immersive&source=fallback');
   });
 });
 

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -66,15 +66,15 @@ describe('createManualModeToggle', () => {
 
     expect(handle.element.dataset.state).toBe('active');
     expect(container.dataset.modeToggleState).toBe('active');
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(container.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.textContent).toBe('Text mode active');
+    expect(handle.element.textContent).toBe('Try immersive again · Press T');
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Text mode already active.'
+      'Text mode active. Press T to try immersive again.'
     );
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     cleanupHandle(handle);
     container.remove();
@@ -145,12 +145,12 @@ describe('createManualModeToggle', () => {
 
     expect(container.dataset.modeToggleState).toBe('active');
     expect(container.getAttribute('aria-busy')).toBeNull();
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.state).toBe('active');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.getAttribute('aria-disabled')).toBe('true');
+    expect(handle.element.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     resolveToggle?.();
     await flushMicrotasks();
@@ -162,7 +162,7 @@ describe('createManualModeToggle', () => {
     container.remove();
   });
 
-  it('ignores activation when fallback already active', () => {
+  it('activates recovery when fallback already active', () => {
     const container = createContainer();
     const onToggle = vi.fn();
     const handle = createManualModeToggle({
@@ -171,23 +171,23 @@ describe('createManualModeToggle', () => {
       getIsFallbackActive: () => true,
     });
 
-    expect(handle.element.getAttribute('aria-disabled')).toBe('true');
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(handle.element.getAttribute('aria-disabled')).toBeNull();
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Text mode already active.'
+      'Text mode active. Press T to try immersive again.'
     );
     expect(container.dataset.modeToggleState).toBe('active');
     expect(container.getAttribute('aria-busy')).toBeNull();
     expect(handle.element.dataset.state).toBe('active');
-    expect(handle.element.textContent).toBe('Text mode active');
+    expect(handle.element.textContent).toBe('Try immersive again · Press T');
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     handle.element.click();
 
-    expect(onToggle).not.toHaveBeenCalled();
-    expect(handle.element.disabled).toBe(true);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(handle.element.disabled).toBe(false);
     expect(handle.element.dataset.state).toBe('active');
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
 
@@ -390,7 +390,7 @@ describe('createManualModeToggle', () => {
 
     expect(container.dataset.modeToggleState).toBe('active');
     expect(handle.element.dataset.state).toBe('active');
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     handle.dispose();
     fallbackActive = false;

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -264,7 +264,11 @@ describe('createManualModeToggle', () => {
     });
 
     input.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 't', bubbles: true })
+      new KeyboardEvent('keydown', {
+        key: 't',
+        bubbles: true,
+        cancelable: true,
+      })
     );
     await flushMicrotasks();
 
@@ -272,6 +276,34 @@ describe('createManualModeToggle', () => {
 
     cleanupHandle(handle);
     input.remove();
+    container.remove();
+  });
+
+  it('ignores contenteditable targets for the global keyboard shortcut', async () => {
+    const container = createContainer();
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    document.body.appendChild(editable);
+    const onToggle = vi.fn();
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => false,
+    });
+
+    editable.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 't',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushMicrotasks();
+
+    expect(onToggle).not.toHaveBeenCalled();
+
+    cleanupHandle(handle);
+    editable.remove();
     container.remove();
   });
 

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -252,6 +252,29 @@ describe('createManualModeToggle', () => {
     container.remove();
   });
 
+  it('ignores text entry targets for the global keyboard shortcut', async () => {
+    const container = createContainer();
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const onToggle = vi.fn();
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => false,
+    });
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 't', bubbles: true })
+    );
+    await flushMicrotasks();
+
+    expect(onToggle).not.toHaveBeenCalled();
+
+    cleanupHandle(handle);
+    input.remove();
+    container.remove();
+  });
+
   it('clears error state on retry and updates to active when fallback triggers', async () => {
     const container = createContainer();
     let fallbackActive = false;
@@ -399,6 +422,31 @@ describe('createManualModeToggle', () => {
     expect(container.dataset.modeToggleState).toBeUndefined();
     expect(handle.element.isConnected).toBe(false);
 
+    container.remove();
+  });
+
+  it('removes its keyboard shortcut after performance failover activates', () => {
+    const container = createContainer();
+    let fallbackActive = false;
+    const onToggle = vi.fn();
+    const handle = createManualModeToggle({
+      container,
+      onToggle,
+      getIsFallbackActive: () => fallbackActive,
+    });
+
+    fallbackActive = true;
+    window.dispatchEvent(new CustomEvent('performancefailover'));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 't' }));
+
+    expect(handle.element.dataset.state).toBe('active');
+    expect(onToggle).not.toHaveBeenCalled();
+
+    handle.element.click();
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    cleanupHandle(handle);
     container.remove();
   });
 

--- a/src/tests/modePreference.test.ts
+++ b/src/tests/modePreference.test.ts
@@ -4,6 +4,7 @@ import {
   MODE_PREFERENCE_KEY,
   clearModePreference,
   readModePreference,
+  shouldPersistTextPreferenceForFallback,
   writeModePreference,
 } from '../systems/failover/modePreference';
 
@@ -127,5 +128,29 @@ describe('clearModePreference', () => {
 
     expect(storage.removeItem).toHaveBeenCalledWith(MODE_PREFERENCE_KEY);
     expect(storage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+  });
+});
+
+describe('shouldPersistTextPreferenceForFallback', () => {
+  it('only persists explicit manual text-mode fallbacks', () => {
+    expect(shouldPersistTextPreferenceForFallback('manual')).toBe(true);
+    expect(shouldPersistTextPreferenceForFallback('low-performance')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('low-end-device')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('low-memory')).toBe(false);
+    expect(shouldPersistTextPreferenceForFallback('data-saver')).toBe(false);
+    expect(shouldPersistTextPreferenceForFallback('automated-client')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('webgl-unsupported')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('immersive-init-error')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('console-error')).toBe(false);
   });
 });

--- a/src/tests/textFallbackAccessibility.test.ts
+++ b/src/tests/textFallbackAccessibility.test.ts
@@ -104,7 +104,7 @@ describe('text fallback accessibility', () => {
     });
   }
 
-  it('normalizes provided immersive URLs to enforce preview overrides', () => {
+  it('normalizes provided immersive URLs without disabling failover for normal recovery', () => {
     const container = document.createElement('div');
 
     renderTextFallback(container, {
@@ -117,6 +117,23 @@ describe('text fallback accessibility', () => {
     ) as HTMLAnchorElement | null;
 
     expect(immersiveLink?.href).toBe(
+      'https://danielsmith.io/portfolio?mode=immersive'
+    );
+  });
+
+  it('exposes a force-immersive debug URL for low-performance fallback', () => {
+    const container = document.createElement('div');
+
+    renderTextFallback(container, {
+      reason: 'low-performance',
+      immersiveUrl: 'https://danielsmith.io/portfolio',
+    });
+
+    const debugLink = container.querySelector(
+      '[data-action="debug-immersive"]'
+    ) as HTMLAnchorElement | null;
+
+    expect(debugLink?.href).toBe(
       'https://danielsmith.io/portfolio?mode=immersive&disablePerformanceFailover=1'
     );
   });

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -173,6 +173,15 @@ export const createImmersiveModeUrl = (
     extraParams,
   });
 
+export const createImmersiveRecoveryUrl = (
+  input?: UrlLike,
+  extraParams?: ExtraParams
+) =>
+  buildModeUrl(input, IMMERSIVE_MODE_VALUE, {
+    includePerformanceBypass: false,
+    extraParams,
+  });
+
 export const createImmersivePreviewUrl = (
   baseUrl: UrlLike = IMMERSIVE_PREVIEW_BASE_URL,
   extraParams?: ExtraParams

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -204,6 +204,14 @@ canvas {
   font-weight: 600;
 }
 
+.text-fallback__button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
 .text-fallback__link:hover,
 .text-fallback__link:focus {
   text-decoration: underline;


### PR DESCRIPTION
### Motivation
- Text fallback became a one-way trap: `T` and the HUD disabled recovery and stored runtime failovers as sticky text preference, blocking immersive debugging.
- Operators needed a clear, discoverable path back into immersive mode without forcing performance-bypass every time (`?mode=immersive&disablePerformanceFailover=1`).
- The change aims to keep runtime failover protections while restoring safe, reversible developer and user recovery paths.

### Description
- Make `T` bidirectional and update the HUD toggle so an active fallback no longer disables recovery; when fallback is active the toggle navigates to a clean immersive recovery URL instead of being inert. (`src/systems/failover/manualModeToggle.ts`, `src/main.ts`)
- Add a normal immersive recovery URL helper `createImmersiveRecoveryUrl(...)` that preserves `mode=immersive` without disabling runtime failover while keeping `createImmersiveModeUrl(...)` as the debug bypass (`disablePerformanceFailover=1`). (`src/ui/immersiveUrl.ts`)
- Enhance the text fallback UI with: a visible “Try immersive again” action (normal recovery), a debug-only “Debug: force immersive mode” link (performance bypass) for selected fallback reasons, and a clear “Clear saved mode preference” control; also install a `T`-keydown recovery shortcut on the fallback document. (`src/systems/failover/index.ts`, `src/ui/styles.css`, i18n updates)
- Persist text-mode preference only for explicit manual fallbacks and avoid writing sticky preferences for runtime/performance-driven fallbacks; add `shouldPersistTextPreferenceForFallback(...)`. (`src/systems/failover/modePreference.ts`) and update tests and docs accordingly.

### Testing
- Ran formatting and linting: `npm run format:write` (succeeded) and `npm run lint` (succeeded).
- Unit tests: `npm run test:ci` (Vitest) completed successfully with 128 test files and 848 tests passing; targeted suites for the changes (`immersiveUrl`, `modePreference`, `manualModeToggle`, `failover`, `textFallbackAccessibility`, `i18n`) passed.
- End-to-end: `npx playwright install` + `npm run test:e2e -- --grep "mode|fallback|immersive"` ran (Chromium installed and deps resolved) with the mode/fallback e2e group passing (16 passed, 2 skipped for hardware-only cases); focused `playwright/mode-fallback-recovery.spec.ts` also passed (4 tests).
- Smoke and docs: `npm run docs:check` and `npm run smoke` both completed successfully; secret scan reported no high-risk secrets via `./scripts/scan-secrets.py`.

Notes/known limits: `npm run typecheck` still reports pre-existing, repo-wide TypeScript issues unrelated to this change; Playwright required installing browsers and host dependencies in the test container (commands used: `npx playwright install` and `npx playwright install-deps chromium`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a73f16040832f8ce1effdb61c8296)