### PR TITLE
🧭 Repair reversible fallback recovery

### DIFF
--- a/outages/2026-05-29-danielsmith-staging-performance-overview.json
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.json
@@ -32,5 +32,6 @@
     "2026-05-30: docs:check and smoke completed successfully after updating validation evidence.",
     "2026-05-30: npm run typecheck still fails before targeted immersive performance files, with representative repo-wide errors in i18n ../poi/types imports, src/main.ts PoiId/audio/API typing, GLTF loader typing, backyard/LED sample guards, POI registry interactionPrompt requirements, and existing DOM/Canvas/PoiId test mocks.",
     "2026-05-30: git fetch origin main failed because this checkout has no origin remote, so base comparison could not run."
-  ]
+  ],
+  "followUps": ["2026-05-30-danielsmith-mode-fallback-recovery"]
 }

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.md
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.md
@@ -23,6 +23,10 @@ software WebGL.
   main render so future captures can confirm or disprove specific JS buckets.
   The targeted changes focused on confirmed render/pixel/mirror waste.
 
+## Related follow-up
+
+- [Mode fallback recovery UX made text mode reversible and debug-friendly](./2026-05-30-danielsmith-mode-fallback-recovery.md).
+
 ## Optimization summary
 
 The fix starts risky software renderers in performance mode, defaults normal

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
@@ -1,0 +1,27 @@
+{
+  "id": "2026-05-30-danielsmith-mode-fallback-recovery",
+  "date": "2026-05-30",
+  "status": "mitigated",
+  "symptom": "Text mode and runtime fallback could block immersive debugging or recovery without the force-immersive debug URL.",
+  "rootCause": "The T shortcut was one-way and fallback UI conflated normal immersive recovery with the performance-failover bypass URL.",
+  "fixes": [
+    "Make T a bidirectional mode toggle that navigates from fallback to a clean immersive URL.",
+    "Add Try immersive again and clear-preference recovery actions to the text fallback.",
+    "Expose disablePerformanceFailover=1 only as an advanced debug fallback link for runtime fallback reasons.",
+    "Keep runtime low-performance fallback from writing sticky text-mode preference."
+  ],
+  "debugUrls": [
+    "/?mode=immersive",
+    "/?mode=immersive&disablePerformanceFailover=1",
+    "/?mode=text"
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"mode|fallback|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
@@ -1,0 +1,54 @@
+# danielsmith.io mode fallback recovery UX
+
+## Symptom
+
+Staging validation needed the force-immersive debug URL
+`?mode=immersive&disablePerformanceFailover=1` because visitors and debuggers
+could get stuck in the text fallback. A hard refresh could honor a stored
+`danielsmith.io:mode-preference=text`, the `T` shortcut only moved from
+immersive to text mode, and runtime performance fallback did not present an
+obvious recovery path.
+
+## Root cause
+
+The mode toggle treated fallback as an active, disabled state instead of a
+bidirectional control. Text fallback links also reused the force-debug immersive
+URL as the only escape hatch, so normal recovery, preference clearing, and
+advanced failover bypass were conflated.
+
+## Fix
+
+- `T` now acts as a two-way toggle: immersive mode still moves to the text
+  portfolio, while text/fallback mode clears the saved mode preference and
+  navigates to a clean `?mode=immersive` recovery URL.
+- The text fallback now shows a visible “Try immersive again” action and a
+  separate “Clear saved mode preference” recovery action.
+- Runtime fallback reasons expose an advanced debug link using
+  `?mode=immersive&disablePerformanceFailover=1` without making that bypass the
+  default recovery route.
+- Runtime failover remains available, but low-FPS/runtime fallback does not
+  write a sticky text-mode preference. Only the explicit manual text toggle is
+  eligible to persist the text preference.
+
+## Validation steps
+
+1. Open `/?mode=immersive&disablePerformanceFailover=1`, press `T`, and confirm
+   text mode appears.
+2. Press `T` from text mode and confirm the app returns to immersive mode via a
+   clean `?mode=immersive` URL.
+3. Open `/?mode=text`, click “Try immersive again,” and confirm immersive mode
+   starts even when a stored text preference exists.
+4. Store `localStorage["danielsmith.io:mode-preference"] = "text"`, open
+   `/?mode=immersive`, and confirm the explicit URL overrides the preference.
+5. Open `/?mode=immersive&disablePerformanceFailover=1` and confirm the debug
+   URL still disables runtime performance failover for collection.
+
+## Verification commands
+
+- `npm run format:write`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:ci`
+- `npm run test:e2e -- --grep "mode|fallback|immersive"`
+- `npm run docs:check`
+- `npm run smoke`

--- a/playwright/immersive-mode.spec.ts
+++ b/playwright/immersive-mode.spec.ts
@@ -47,6 +47,75 @@ test.describe('immersive experience', () => {
     expect.soft(pageErrors).toHaveLength(0);
   });
 
+  test('toggles between immersive and text mode with the T shortcut', async ({
+    page,
+  }) => {
+    await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    await page.keyboard.press('t');
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'fallback'
+    );
+    await expect(
+      page.locator('#app[data-mode="text"] .text-fallback')
+    ).toBeVisible();
+
+    await page.keyboard.press('t');
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+  });
+
+  test('text fallback recovery controls bypass stored text preference', async ({
+    page,
+  }) => {
+    await page.goto('/?mode=text', { waitUntil: 'domcontentloaded' });
+    await expect(
+      page.locator('#app[data-mode="text"] .text-fallback')
+    ).toBeVisible();
+
+    await page.getByRole('link', { name: /try immersive again/i }).click();
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    await page.evaluate(() => {
+      window.localStorage.setItem('danielsmith.io:mode-preference', 'text');
+    });
+    await page.goto('/?mode=immersive', { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+  });
+
+  test('debug immersive URL remains valid for forced collection', async ({
+    page,
+  }) => {
+    await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    expect(
+      new URL(page.url()).searchParams.get('disablePerformanceFailover')
+    ).toBe('1');
+  });
+
   test('upper floor shows only when ascending stairs; ceilings are translucent', async ({
     page,
   }) => {

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -95,7 +95,9 @@ export const AR_OVERRIDES: LocaleOverrides = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: 'تشغيل الوضع الغامر',
+        immersiveLink: 'تجربة الوضع الغامر مرة أخرى',
+        immersiveDebugLink: 'تصحيح: فرض الوضع الغامر بدون تحويل الأداء',
+        clearPreferenceLink: 'مسح تفضيل الوضع المحفوظ',
         resumeLink: 'تحميل أحدث سيرة ذاتية',
         githubLink: 'استكشاف المشاريع على GitHub',
       },

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -101,7 +101,11 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         resumeUrl: wrap('docs/resume/2025-09/resume.pdf'),
       },
       actions: {
-        immersiveLink: wrap('Launch immersive mode'),
+        immersiveLink: wrap('Try immersive again'),
+        immersiveDebugLink: wrap(
+          'Debug: force immersive without performance failover'
+        ),
+        clearPreferenceLink: wrap('Clear saved mode preference'),
         resumeLink: wrap('Download the latest résumé'),
         githubLink: wrap('Explore projects on GitHub'),
       },
@@ -250,18 +254,26 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
     modeToggle: {
       keyHint: 'T',
       idleLabelTemplate: wrap('Text mode · Press {keyHint}'),
-      idleDescriptionTemplate: wrap('Switch to the text-only portfolio'),
+      idleDescriptionTemplate: wrap(
+        'Toggle to the text-only portfolio. Press again from text mode to try immersive.'
+      ),
       idleAnnouncementTemplate: wrap(
-        'Switch to the text-only portfolio. Press {keyHint} to activate.'
+        'Toggle to the text-only portfolio. Press {keyHint} to activate.'
       ),
-      idleTitleTemplate: wrap('Switch to the text-only portfolio ({keyHint})'),
-      pendingLabelTemplate: wrap('Switching to text mode…'),
+      idleTitleTemplate: wrap(
+        'Toggle between immersive and text mode ({keyHint})'
+      ),
+      pendingLabelTemplate: wrap('Switching modes…'),
       pendingAnnouncementTemplate: wrap(
-        'Switch to the text-only portfolio. Switching to text mode…'
+        'Mode toggle requested. Switching modes…'
       ),
-      activeLabelTemplate: wrap('Text mode active'),
-      activeDescriptionTemplate: wrap('Text mode already active.'),
-      activeAnnouncementTemplate: wrap('Text mode already active.'),
+      activeLabelTemplate: wrap('Try immersive again · Press {keyHint}'),
+      activeDescriptionTemplate: wrap(
+        'Text mode is active. Activate to try immersive mode again.'
+      ),
+      activeAnnouncementTemplate: wrap(
+        'Text mode is active. Press {keyHint} to try immersive mode again.'
+      ),
       errorLabelTemplate: wrap('Retry text mode · Press {keyHint}'),
       errorDescriptionTemplate: wrap(
         'Text mode toggle failed. Try again or use the immersive link.'

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -100,7 +100,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: 'Launch immersive mode',
+        immersiveLink: 'Try immersive again',
+        immersiveDebugLink:
+          'Debug: force immersive without performance failover',
+        clearPreferenceLink: 'Clear saved mode preference',
         resumeLink: 'Download the latest résumé',
         githubLink: 'Explore projects on GitHub',
       },
@@ -258,16 +261,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     modeToggle: {
       keyHint: 'T',
       idleLabelTemplate: 'Text mode · Press {keyHint}',
-      idleDescriptionTemplate: 'Switch to the text-only portfolio',
+      idleDescriptionTemplate:
+        'Toggle to the text-only portfolio. Press again from text mode to try immersive.',
       idleAnnouncementTemplate:
-        'Switch to the text-only portfolio. Press {keyHint} to activate.',
-      idleTitleTemplate: 'Switch to the text-only portfolio ({keyHint})',
-      pendingLabelTemplate: 'Switching to text mode…',
-      pendingAnnouncementTemplate:
-        'Switch to the text-only portfolio. Switching to text mode…',
-      activeLabelTemplate: 'Text mode active',
-      activeDescriptionTemplate: 'Text mode already active.',
-      activeAnnouncementTemplate: 'Text mode already active.',
+        'Toggle to the text-only portfolio. Press {keyHint} to activate.',
+      idleTitleTemplate: 'Toggle between immersive and text mode ({keyHint})',
+      pendingLabelTemplate: 'Switching modes…',
+      pendingAnnouncementTemplate: 'Mode toggle requested. Switching modes…',
+      activeLabelTemplate: 'Try immersive again · Press {keyHint}',
+      activeDescriptionTemplate:
+        'Text mode is active. Activate to try immersive mode again.',
+      activeAnnouncementTemplate:
+        'Text mode is active. Press {keyHint} to try immersive mode again.',
       errorLabelTemplate: 'Retry text mode · Press {keyHint}',
       errorDescriptionTemplate:
         'Text mode toggle failed. Try again or use the immersive link.',
@@ -375,7 +380,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             {
               label: 'T',
               description:
-                'Toggle between immersive mode and the text fallback.',
+                'Toggle between immersive mode and the text fallback; from text mode, T tries immersive again.',
             },
             {
               label: 'Shift + L',
@@ -395,7 +400,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             {
               label: 'Manual toggle',
               description:
-                'Use the on-screen Text mode button or press T at any time.',
+                'Use the on-screen mode button or press T at any time to switch both ways.',
             },
             {
               label: 'Motion blur slider',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -95,7 +95,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: '没入モードを起動',
+        immersiveLink: '没入モードをもう一度試す',
+        immersiveDebugLink:
+          'デバッグ: パフォーマンス切替なしで没入モードを強制',
+        clearPreferenceLink: '保存済みモード設定をクリア',
         resumeLink: '最新の履歴書をダウンロード',
         githubLink: 'GitHubでプロジェクトを見る',
       },

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -246,6 +246,8 @@ export interface SiteTextFallbackStrings {
   };
   actions: {
     immersiveLink: string;
+    immersiveDebugLink: string;
+    clearPreferenceLink: string;
     resumeLink: string;
     githubLink: string;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -303,7 +303,10 @@ import {
   createManualModeToggle,
   type ManualModeToggleHandle,
 } from './systems/failover/manualModeToggle';
-import { writeModePreference } from './systems/failover/modePreference';
+import {
+  clearModePreference,
+  writeModePreference,
+} from './systems/failover/modePreference';
 import { createPerformanceFailoverHandler } from './systems/failover/performanceFailover';
 import { createGitHubRepoStatsService } from './systems/github/repoStats';
 import {
@@ -384,7 +387,7 @@ import {
   type ResponsiveControlOverlayHandle,
 } from './ui/hud/responsiveControlOverlay';
 import {
-  createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
   shouldDisablePerformanceFailover,
 } from './ui/immersiveUrl';
 import './ui/styles.css';
@@ -531,7 +534,7 @@ const handleImmersiveFailure = (
   try {
     renderTextFallback(container, {
       reason: 'immersive-init-error',
-      immersiveUrl: createImmersiveModeUrl(),
+      immersiveUrl: createImmersiveRecoveryUrl(),
     });
   } catch (fallbackError) {
     console.error('Failed to render fallback experience:', fallbackError);
@@ -642,7 +645,7 @@ if (!container) {
 const failoverDecision = evaluateFailoverDecision();
 
 if (failoverDecision.shouldUseFallback) {
-  const immersiveUrl = createImmersiveModeUrl();
+  const immersiveUrl = createImmersiveRecoveryUrl();
   renderTextFallback(container, {
     reason: failoverDecision.reason ?? 'manual',
     immersiveUrl,
@@ -665,7 +668,7 @@ function initializeImmersiveScene(
   container: HTMLElement,
   onFatalError: (error: unknown, options: { renderer?: WebGLRenderer }) => void
 ) {
-  const immersiveUrl = createImmersiveModeUrl();
+  const immersiveUrl = createImmersiveRecoveryUrl();
   const renderer = new WebGLRenderer({ antialias: true });
   renderer.outputColorSpace = SRGBColorSpace;
   renderer.toneMapping = ACESFilmicToneMapping;
@@ -2983,10 +2986,13 @@ function initializeImmersiveScene(
       strings: modeToggleStrings,
       getIsFallbackActive: () => performanceFailover.hasTriggered(),
       onToggle: () => {
-        writeModePreference('text');
-        if (!performanceFailover.hasTriggered()) {
-          performanceFailover.triggerFallback('manual');
+        if (performanceFailover.hasTriggered()) {
+          clearModePreference();
+          window.location.assign(createImmersiveRecoveryUrl(window.location));
+          return;
         }
+        writeModePreference('text');
+        performanceFailover.triggerFallback('manual');
       },
     });
     registerHudControlElement(manualModeToggle?.element ?? null);

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -18,6 +18,7 @@ import {
 } from '../../ui/accessibility/modeAnnouncer';
 import {
   createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
   getModeFromSearch,
   IMMERSIVE_MODE_VALUE,
   shouldDisablePerformanceFailover,
@@ -25,6 +26,7 @@ import {
 } from '../../ui/immersiveUrl';
 
 import {
+  clearModePreference,
   readModePreference as readStoredModePreference,
   type ModePreference,
 } from './modePreference';
@@ -894,7 +896,10 @@ export function renderTextFallback(
     textFallbackStrings.contact.resumeUrl ??
     'docs/resume/2025-09/resume.pdf';
   const resolvedGithubUrl = githubUrl ?? textFallbackStrings.contact.githubUrl;
-  const immersiveUrl = createImmersiveModeUrl(
+  const immersiveUrl = createImmersiveRecoveryUrl(
+    providedImmersiveUrl ?? documentTarget.defaultView?.location ?? undefined
+  );
+  const debugImmersiveUrl = createImmersiveModeUrl(
     providedImmersiveUrl ?? documentTarget.defaultView?.location ?? undefined
   );
   const resolvedLocale = resolveLocale(localeHint);
@@ -956,6 +961,15 @@ export function renderTextFallback(
   const list = documentTarget.createElement('ul');
   list.className = 'text-fallback__actions';
 
+  const navigateToImmersive = (url: string) => {
+    clearModePreference();
+    const view = documentTarget.defaultView;
+    if (!view) {
+      return;
+    }
+    view.location.assign(url);
+  };
+
   const immersiveItem = documentTarget.createElement('li');
   immersiveItem.className = 'text-fallback__action';
   const immersiveLink = documentTarget.createElement('a');
@@ -964,8 +978,53 @@ export function renderTextFallback(
   immersiveLink.textContent = actionStrings.immersiveLink;
   immersiveLink.rel = 'noopener';
   immersiveLink.dataset.action = 'immersive';
+  immersiveLink.addEventListener('click', () => {
+    clearModePreference();
+  });
   immersiveItem.appendChild(immersiveLink);
   list.appendChild(immersiveItem);
+
+  if (reason !== 'manual') {
+    const debugItem = documentTarget.createElement('li');
+    debugItem.className = 'text-fallback__action';
+    const debugLink = documentTarget.createElement('a');
+    debugLink.href = debugImmersiveUrl;
+    debugLink.className = 'text-fallback__link';
+    debugLink.textContent = actionStrings.immersiveDebugLink;
+    debugLink.rel = 'noopener';
+    debugLink.dataset.action = 'immersive-debug';
+    debugLink.addEventListener('click', () => {
+      clearModePreference();
+    });
+    debugItem.appendChild(debugLink);
+    list.appendChild(debugItem);
+  }
+
+  const clearPreferenceItem = documentTarget.createElement('li');
+  clearPreferenceItem.className = 'text-fallback__action';
+  const clearPreferenceLink = documentTarget.createElement('a');
+  clearPreferenceLink.href = immersiveUrl;
+  clearPreferenceLink.className = 'text-fallback__link';
+  clearPreferenceLink.textContent = actionStrings.clearPreferenceLink;
+  clearPreferenceLink.rel = 'noopener';
+  clearPreferenceLink.dataset.action = 'clear-mode-preference';
+  clearPreferenceLink.addEventListener('click', () => {
+    clearModePreference();
+  });
+  clearPreferenceItem.appendChild(clearPreferenceLink);
+  list.appendChild(clearPreferenceItem);
+
+  const view = documentTarget.defaultView;
+  view?.addEventListener('keydown', (event) => {
+    if (event.key !== 'T' && event.key !== 't') {
+      return;
+    }
+    if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+      return;
+    }
+    event.preventDefault();
+    navigateToImmersive(immersiveUrl);
+  });
 
   const resumeItem = documentTarget.createElement('li');
   resumeItem.className = 'text-fallback__action';

--- a/src/systems/failover/manualModeToggle.ts
+++ b/src/systems/failover/manualModeToggle.ts
@@ -136,7 +136,7 @@ export function createManualModeToggle({
     if (fallbackActive) {
       errored = false;
       setContainerState('active');
-      setDisabledState(true);
+      setDisabledState(false);
       button.dataset.state = 'active';
       button.removeAttribute('aria-busy');
       button.textContent = withFallback(
@@ -214,7 +214,7 @@ export function createManualModeToggle({
 
   const activate = () => {
     refreshState();
-    if (pending || getIsFallbackActive()) {
+    if (pending) {
       return;
     }
     clearErrorState();
@@ -260,7 +260,7 @@ export function createManualModeToggle({
     if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
       return;
     }
-    if (pending || getIsFallbackActive()) {
+    if (pending) {
       return;
     }
     event.preventDefault();

--- a/src/systems/failover/modePreference.ts
+++ b/src/systems/failover/modePreference.ts
@@ -76,4 +76,8 @@ export const clearModePreference = (
   writeModePreference(null, options);
 };
 
+export const shouldPersistTextPreferenceForFallbackReason = (
+  reason: string | null | undefined
+): boolean => reason === 'manual';
+
 export const MODE_PREFERENCE_KEY = MODE_PREFERENCE_STORAGE_KEY;

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -9,7 +9,16 @@ import {
   type FallbackReason,
   type RenderTextFallbackOptions,
 } from '../systems/failover';
-import { createImmersiveModeUrl } from '../ui/immersiveUrl';
+import {
+  clearModePreference,
+  readModePreference,
+  shouldPersistTextPreferenceForFallbackReason,
+  writeModePreference,
+} from '../systems/failover/modePreference';
+import {
+  createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
+} from '../ui/immersiveUrl';
 
 const IMMERSIVE_URL = createImmersiveModeUrl({
   pathname: '/',
@@ -829,6 +838,19 @@ describe('evaluateFailoverDecision', () => {
   });
 });
 
+describe('mode preference persistence rules', () => {
+  it('persists explicit manual text preference only', () => {
+    expect(shouldPersistTextPreferenceForFallbackReason('manual')).toBe(true);
+    expect(
+      shouldPersistTextPreferenceForFallbackReason('low-performance')
+    ).toBe(false);
+    expect(shouldPersistTextPreferenceForFallbackReason('console-error')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallbackReason(undefined)).toBe(false);
+  });
+});
+
 describe('renderTextFallback', () => {
   const render = (
     reason: FallbackReason,
@@ -861,7 +883,7 @@ describe('renderTextFallback', () => {
       '[data-action="immersive"]'
     );
     expect(immersiveLink?.href).toBe(
-      new URL(createImmersiveModeUrl(), window.location.origin).toString()
+      new URL(createImmersiveRecoveryUrl(), window.location.origin).toString()
     );
   });
 
@@ -873,10 +895,44 @@ describe('renderTextFallback', () => {
     );
     expect(immersiveLink?.href).toBe(
       new URL(
-        createImmersiveModeUrl(customUrl),
+        createImmersiveRecoveryUrl(customUrl),
         window.location.origin
       ).toString()
     );
+  });
+
+  it('adds a debug immersive link for runtime fallback reasons', () => {
+    const container = render('low-performance');
+    const debugLink = container.querySelector<HTMLAnchorElement>(
+      '[data-action="immersive-debug"]'
+    );
+    expect(debugLink?.href).toContain('mode=immersive');
+    expect(debugLink?.href).toContain('disablePerformanceFailover=1');
+  });
+
+  it('omits the debug immersive link for manual text mode', () => {
+    const container = render('manual');
+    expect(
+      container.querySelector('[data-action="immersive-debug"]')
+    ).toBeNull();
+  });
+
+  it('clears the saved mode preference before retrying immersive mode', () => {
+    writeModePreference('text');
+    const container = render('manual');
+    const retryLink = container.querySelector<HTMLAnchorElement>(
+      '[data-action="immersive"]'
+    );
+
+    retryLink?.addEventListener('click', (event) => event.preventDefault(), {
+      once: true,
+    });
+    retryLink?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+
+    expect(readModePreference()).toBeNull();
+    clearModePreference();
   });
 
   it('indicates WebGL unsupported reason', () => {
@@ -1011,6 +1067,7 @@ describe('renderTextFallback', () => {
 
     expect(actionLinks.map((link) => link.textContent)).toEqual([
       actions.immersiveLink,
+      actions.clearPreferenceLink,
       actions.resumeLink,
       actions.githubLink,
     ]);

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -97,11 +97,13 @@ describe('i18n utilities', () => {
     expect(english.keyHint).toBe('T');
     expect(english.idleLabel).toBe('Text mode · Press T');
     expect(english.idleHudAnnouncement).toBe(
-      'Switch to the text-only portfolio. Press T to activate.'
+      'Toggle to the text-only portfolio. Press T to activate.'
     );
-    expect(english.idleTitle).toBe('Switch to the text-only portfolio (T)');
+    expect(english.idleTitle).toBe(
+      'Toggle between immersive and text mode (T)'
+    );
     expect(english.pendingHudAnnouncement).toBe(
-      'Switch to the text-only portfolio. Switching to text mode…'
+      'Mode toggle requested. Switching modes…'
     );
     expect(english.errorLabel).toBe('Retry text mode · Press T');
     expect(english.errorHudAnnouncement).toBe(
@@ -115,10 +117,10 @@ describe('i18n utilities', () => {
     expect(pseudo.keyHint).toBe('T');
     expect(pseudo.idleLabel).toBe('⟦Text mode · Press T⟧');
     expect(pseudo.idleHudAnnouncement).toBe(
-      '⟦Switch to the text-only portfolio. Press T to activate.⟧'
+      '⟦Toggle to the text-only portfolio. Press T to activate.⟧'
     );
     expect(pseudo.pendingHudAnnouncement).toBe(
-      '⟦Switch to the text-only portfolio. Switching to text mode…⟧'
+      '⟦Mode toggle requested. Switching modes…⟧'
     );
     expect(pseudo.errorLabel).toBe('⟦Retry text mode · Press T⟧');
     expect(pseudo.errorHudAnnouncement).toBe(
@@ -153,7 +155,7 @@ describe('i18n utilities', () => {
   it('builds mode announcer messages from localized HUD and fallback copy', () => {
     const english = getModeAnnouncerStrings('en');
     expect(english.immersiveReady).toBe(
-      'Switch to the text-only portfolio. Press T to activate.'
+      'Toggle to the text-only portfolio. Press T to activate.'
     );
     expect(english.fallbackReasons['data-saver']).toContain('data-saver');
 

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createImmersiveModeUrl,
   createImmersivePreviewUrl,
+  createImmersiveRecoveryUrl,
   createTextModeUrl,
   getModeFromSearch,
   hasImmersiveOverride,
@@ -115,6 +116,27 @@ describe('createImmersiveModeUrl', () => {
     expect(url).toBe(
       '/demo?foo=bar&feature=preview&mode=immersive&disablePerformanceFailover=1#scene'
     );
+  });
+});
+
+describe('createImmersiveRecoveryUrl', () => {
+  it('forces immersive mode without disabling runtime failover', () => {
+    const url = createImmersiveRecoveryUrl({
+      pathname: '/',
+      search: '?mode=text&disablePerformanceFailover=1&foo=bar',
+      hash: '#view',
+    });
+
+    expect(url).toBe('/?mode=immersive&foo=bar#view');
+  });
+
+  it('prevents extra params from clobbering the recovery mode', () => {
+    const url = createImmersiveRecoveryUrl('/portfolio?mode=text', {
+      mode: 'text',
+      disablePerformanceFailover: true,
+    });
+
+    expect(url).toBe('/portfolio?mode=immersive');
   });
 });
 

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -38,7 +38,7 @@ describe('createManualModeToggle', () => {
     expect(handle.element.getAttribute('aria-disabled')).toBeNull();
     expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Switch to the text-only portfolio. Press T to activate.'
+      'Toggle to the text-only portfolio. Press T to activate.'
     );
     expect(container.dataset.modeToggleState).toBe('idle');
     expect(container.getAttribute('aria-busy')).toBeNull();
@@ -57,7 +57,7 @@ describe('createManualModeToggle', () => {
     expect(container.getAttribute('aria-busy')).toBe('true');
     expect(handle.element.dataset.state).toBe('pending');
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Switch to the text-only portfolio. Switching to text mode…'
+      'Mode toggle requested. Switching modes…'
     );
     expect(handle.element.getAttribute('aria-pressed')).toBe('false');
     expect(handle.element.getAttribute('aria-busy')).toBe('true');
@@ -66,15 +66,15 @@ describe('createManualModeToggle', () => {
 
     expect(handle.element.dataset.state).toBe('active');
     expect(container.dataset.modeToggleState).toBe('active');
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(container.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.textContent).toBe('Text mode active');
+    expect(handle.element.textContent).toBe('Try immersive again · Press T');
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Text mode already active.'
+      'Text mode is active. Press T to try immersive mode again.'
     );
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     cleanupHandle(handle);
     container.remove();
@@ -145,12 +145,12 @@ describe('createManualModeToggle', () => {
 
     expect(container.dataset.modeToggleState).toBe('active');
     expect(container.getAttribute('aria-busy')).toBeNull();
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.state).toBe('active');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.getAttribute('aria-disabled')).toBe('true');
+    expect(handle.element.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     resolveToggle?.();
     await flushMicrotasks();
@@ -162,7 +162,7 @@ describe('createManualModeToggle', () => {
     container.remove();
   });
 
-  it('ignores activation when fallback already active', () => {
+  it('activates recovery when fallback already active', async () => {
     const container = createContainer();
     const onToggle = vi.fn();
     const handle = createManualModeToggle({
@@ -171,23 +171,28 @@ describe('createManualModeToggle', () => {
       getIsFallbackActive: () => true,
     });
 
-    expect(handle.element.getAttribute('aria-disabled')).toBe('true');
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(handle.element.getAttribute('aria-disabled')).toBeNull();
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Text mode already active.'
+      'Text mode is active. Press T to try immersive mode again.'
     );
     expect(container.dataset.modeToggleState).toBe('active');
     expect(container.getAttribute('aria-busy')).toBeNull();
     expect(handle.element.dataset.state).toBe('active');
-    expect(handle.element.textContent).toBe('Text mode active');
+    expect(handle.element.textContent).toBe('Try immersive again · Press T');
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     handle.element.click();
 
-    expect(onToggle).not.toHaveBeenCalled();
-    expect(handle.element.disabled).toBe(true);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(handle.element.disabled).toBe(false);
+    expect(handle.element.dataset.state).toBe('active');
+
+    await flushMicrotasks();
+
+    expect(handle.element.disabled).toBe(false);
     expect(handle.element.dataset.state).toBe('active');
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
 
@@ -390,7 +395,7 @@ describe('createManualModeToggle', () => {
 
     expect(container.dataset.modeToggleState).toBe('active');
     expect(handle.element.dataset.state).toBe('active');
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     handle.dispose();
     fallbackActive = false;

--- a/src/tests/textFallbackAccessibility.test.ts
+++ b/src/tests/textFallbackAccessibility.test.ts
@@ -104,7 +104,7 @@ describe('text fallback accessibility', () => {
     });
   }
 
-  it('normalizes provided immersive URLs to enforce preview overrides', () => {
+  it('normalizes provided immersive URLs for clean recovery', () => {
     const container = document.createElement('div');
 
     renderTextFallback(container, {
@@ -117,7 +117,7 @@ describe('text fallback accessibility', () => {
     ) as HTMLAnchorElement | null;
 
     expect(immersiveLink?.href).toBe(
-      'https://danielsmith.io/portfolio?mode=immersive&disablePerformanceFailover=1'
+      'https://danielsmith.io/portfolio?mode=immersive'
     );
   });
 

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -164,6 +164,15 @@ const buildModeUrl = (
   return `${base}${query ? `?${query}` : ''}${hash ?? ''}`;
 };
 
+export const createImmersiveRecoveryUrl = (
+  input?: UrlLike,
+  extraParams?: ExtraParams
+) =>
+  buildModeUrl(input, IMMERSIVE_MODE_VALUE, {
+    includePerformanceBypass: false,
+    extraParams,
+  });
+
 export const createImmersiveModeUrl = (
   input?: UrlLike,
   extraParams?: ExtraParams


### PR DESCRIPTION
### Motivation
- The text-only/fallback UX could become an unrecoverable trap (stored `danielsmith.io:mode-preference` or a runtime performance failover), making immersive debugging difficult; the debugger URL `?mode=immersive&disablePerformanceFailover=1` was used as a last-resort escape hatch.
- Make the `T` shortcut and on-screen controls bidirectional and make runtime-triggered fallbacks non-sticky while preserving explicit user preference and the advanced debug bypass URL.

### Description
- Add a clean recovery URL helper `createImmersiveRecoveryUrl(...)` that enforces `mode=immersive` but does NOT include the performance-bypass flag, and keep the existing `createImmersiveModeUrl(...)` as the debug/collection URL that includes `disablePerformanceFailover=1` (`src/ui/immersiveUrl.ts`).
- Update the text fallback UI to expose: a visible “Try immersive again” recovery link, an advanced debug link when the fallback reason is runtime/performance, and a “Clear saved mode preference” action that clears stored preference before navigating (`src/systems/failover/index.ts`).
- Make the HUD/manual `T` toggle bidirectional: when fallback is active the control remains enabled and pressing it from fallback clears the preference and navigates to a clean immersive recovery URL (navigation used rather than trying to resurrect disposed WebGL resources) (`src/systems/failover/manualModeToggle.ts`, `src/main.ts`).
- Add `clearModePreference()` and `shouldPersistTextPreferenceForFallbackReason(...)` so only explicit/manual fallbacks persist a sticky text preference (`src/systems/failover/modePreference.ts`).
- Update localized HUD/help/copy to reflect two-way behavior and add new i18n strings for the debug and clear-preference actions (`src/assets/i18n/locales/*`, `src/assets/i18n/types.ts`).
- Tests and docs: add/update Vitest and Playwright tests covering URL helpers, preference rules, fallback links, clearing preference, `T` toggling and stored-preference override; add outage notes and link from the performance overview (`src/tests/**`, `playwright/immersive-mode.spec.ts`, `outages/2026-05-30-danielsmith-mode-fallback-recovery.*`).

### Testing
- `npm run format:write` — passed (no unexpected format changes beyond the PR edits).
- `npm run lint` — passed after import ordering and small adjustments.
- `npm run typecheck` — not fully green; failed with existing repo-wide TypeScript issues unrelated to this change (not introduced by this PR); noted as a known repo-wide limitation.
- `npm run test:ci` (Vitest) — passed: full suite ran and all tests passed (848 tests in CI run reported passing).
- `npx playwright install --with-deps chromium` — run and browsers installed successfully to enable e2e.
- `npm run test:e2e -- --grep "mode|fallback|immersive"` (Playwright) — passed for the targeted scenarios (15 passed, 2 skipped in this environment); included added tests for `T` toggling and recovery links.
- `npm run docs:check` — passed.
- `npm run smoke` (build + dist checks) — passed.
- Secret scan `git diff --cached | ./scripts/scan-secrets.py` — passed (no high-risk secrets).

Residual notes and follow-ups:
- Type checking still surfaces existing unrelated repo-wide errors (imports/typing in many tests and scene code); this PR did not introduce those issues and they remain on the repo TODO list.
- The recovery path intentionally navigates to a clean immersive URL (rather than resurrecting disposed renderer state) to keep the runtime transition robust.
- Playwright e2e coverage depends on the local Playwright browser install (the PR includes the `npx playwright install --with-deps chromium` step used during verification).

Files touched (high level): `src/ui/immersiveUrl.ts`, `src/systems/failover/index.ts`, `src/systems/failover/manualModeToggle.ts`, `src/systems/failover/modePreference.ts`, `src/main.ts`, i18n locale bundles, Vitest tests in `src/tests/`, Playwright spec updates, and outage docs in `outages/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a73f16040832f8ce1effdb61c8296)