### PR TITLE
Make text-mode reversible and add recovery/debug links for immersive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,10 @@ Keep pipelines deterministic by regenerating assets immediately after touching g
   the mapping persists locally.
 - **Touch** – Drag the on-screen joysticks (left: movement, right: camera pan) on touch devices.
 - **Lighting debug** – Press `Shift` + `L` to toggle bloom and LED strips for comparison captures.
-- **Mode toggle** – Press `T` or select the "Text mode" overlay button to jump into the
-  lightweight portfolio view at any time.
+- **Mode toggle** – Press `T` or select the mode overlay button to move between the
+  immersive scene and the lightweight portfolio view. Text fallback pages also include
+  a "Try immersive again" action plus a clear-preference control so saved text-mode
+  choices never become traps.
 - **Accessibility presets** – Pick Standard, Calm, High contrast, or Photosensitive-safe modes
   from the HUD to soften bloom, boost readability, reduce motion cues, and tune emissive
   lighting. The Photosensitive-safe preset now also smooths greenhouse grow lights, walkway
@@ -243,7 +245,9 @@ Keep pipelines deterministic by regenerating assets immediately after touching g
 - **Help** – Use the help key (default `H` or `?`), or tap the HUD Help button to
   open a modal with controls, accessibility tips, and failover guidance.
 - **Failover** – Append `?mode=text` to the URL to load the lightweight text view.
-  Automatic detection now covers missing WebGL support, sustained frame rates below 30 FPS,
+  Append `?mode=immersive` to bypass a saved text preference, or use
+  `?mode=immersive&disablePerformanceFailover=1` when collecting debug evidence and
+  runtime low-FPS fallback must stay disabled. Automatic detection now covers missing WebGL support, sustained frame rates below 30 FPS,
   low-memory and low-core devices, data-saver preferences, slow 2G network hints,
   high-latency connections, and automated crawlers. A `<noscript>` fallback now routes no-JS
   clients and scrapers to the static tour immediately. Share preview links as

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.json
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.json
@@ -32,5 +32,6 @@
     "2026-05-30: docs:check and smoke completed successfully after updating validation evidence.",
     "2026-05-30: npm run typecheck still fails before targeted immersive performance files, with representative repo-wide errors in i18n ../poi/types imports, src/main.ts PoiId/audio/API typing, GLTF loader typing, backyard/LED sample guards, POI registry interactionPrompt requirements, and existing DOM/Canvas/PoiId test mocks.",
     "2026-05-30: git fetch origin main failed because this checkout has no origin remote, so base comparison could not run."
-  ]
+  ],
+  "relatedOutages": ["2026-05-30-danielsmith-mode-fallback-recovery"]
 }

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.md
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.md
@@ -14,6 +14,7 @@ software WebGL.
 - [Postprocessing and DPR multiplied full-screen pixel cost](./2026-05-29-danielsmith-postprocessing-pixel-cost.md).
 - [SelfieMirror rendered the full scene every frame](./2026-05-29-danielsmith-selfie-mirror-render-cost.md).
 - [Adaptive quality did not downgrade before text fallback](./2026-05-29-danielsmith-adaptive-quality-gap.md).
+- [Text fallback recovery was one-way and sticky](./2026-05-30-danielsmith-mode-fallback-recovery.md).
 
 ## Disproven or unconfirmed theories
 

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-05-30-danielsmith-mode-fallback-recovery",
+  "date": "2026-05-30",
+  "overview": "2026-05-29-danielsmith-staging-performance-overview",
+  "title": "Text fallback recovery was one-way and sticky",
+  "symptomSlice": "Text mode and runtime fallback could block immersive debugging because T only entered fallback and stored text preference could win on refresh.",
+  "rootCause": "The mode toggle disabled itself while fallback was active, and recovery UI did not clearly separate explicit text preference from runtime failover.",
+  "fixSummary": "Mode toggling is bidirectional, fallback pages include Try immersive again, debug force links remain available, and runtime failover no longer writes sticky text preference.",
+  "regressionTests": "Vitest covers recovery URL helpers and persistence rules; Playwright covers T toggling, text recovery links, immersive override precedence, and debug URL validity."
+}

--- a/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
+++ b/outages/2026-05-30-danielsmith-mode-fallback-recovery.md
@@ -1,0 +1,41 @@
+# Mode fallback recovery UX
+
+[Back to performance overview](./2026-05-29-danielsmith-staging-performance-overview.md)
+
+## Symptoms
+
+Staging validation could get stuck in the text portfolio after a hard refresh when
+`danielsmith.io:mode-preference` stored `text`, or after runtime failover disposed
+immersive resources. Pressing `T` only entered text mode, so engineers needed the
+force URL `?mode=immersive&disablePerformanceFailover=1` to escape and keep
+collecting debug data.
+
+## Root cause
+
+The manual mode toggle treated fallback as an active, disabled state. Combined
+with sticky mode preference writes, text mode behaved like a trapdoor: explicit
+text choices and runtime fallback both looked similar to the recovery path even
+though only explicit user text choices should persist.
+
+## Fix
+
+- `T` is now bidirectional: immersive sessions switch to text mode, while text or
+  fallback sessions navigate to a clean `?mode=immersive` recovery URL.
+- Text fallback renders a visible “Try immersive again” action that clears the
+  saved mode preference before navigation.
+- Performance and error fallbacks expose an advanced
+  `?mode=immersive&disablePerformanceFailover=1` debug link.
+- A “Clear saved mode preference” control is available inside fallback UI.
+- Runtime failover remains enabled but no longer writes sticky text preference;
+  only explicit manual text-mode choices persist.
+
+## Validation
+
+- Load `/?mode=immersive&disablePerformanceFailover=1`, press `T`, confirm text
+  mode appears, press `T` again, and confirm immersive mode returns.
+- Load `/?mode=text`, click “Try immersive again”, and confirm immersive mode
+  returns on `?mode=immersive`.
+- Seed `localStorage["danielsmith.io:mode-preference"] = "text"`, then load
+  `/?mode=immersive` and confirm immersive routing wins.
+- Keep `/?mode=immersive&disablePerformanceFailover=1` available for debug
+  captures that must bypass runtime low-FPS failover.

--- a/playwright/mode-fallback-recovery.spec.ts
+++ b/playwright/mode-fallback-recovery.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const DEBUG_IMMERSIVE_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const TEXT_FALLBACK_SELECTOR = '#app[data-mode="text"] .text-fallback';
+
+async function waitForImmersive(page: import('@playwright/test').Page) {
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+async function waitForTextFallback(page: import('@playwright/test').Page) {
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'fallback'
+  );
+  await expect(page.locator(TEXT_FALLBACK_SELECTOR)).toBeVisible();
+}
+
+test.describe('mode and fallback recovery', () => {
+  test('T toggles from forced immersive to text mode and back to immersive', async ({
+    page,
+  }) => {
+    await page.goto(DEBUG_IMMERSIVE_URL, { waitUntil: 'domcontentloaded' });
+    await waitForImmersive(page);
+
+    await page.keyboard.press('T');
+    await waitForTextFallback(page);
+
+    await page.keyboard.press('T');
+    await waitForImmersive(page);
+    await expect(page).toHaveURL(/mode=immersive/);
+  });
+
+  test('manual text mode exposes a recovery link back to immersive', async ({
+    page,
+  }) => {
+    await page.goto('/?mode=text', { waitUntil: 'domcontentloaded' });
+    await waitForTextFallback(page);
+
+    await page.getByRole('link', { name: /try immersive again/i }).click();
+    await waitForImmersive(page);
+    await expect(page).toHaveURL(/mode=immersive/);
+  });
+
+  test('immersive query override wins over saved text preference', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('danielsmith.io:mode-preference', 'text');
+    });
+
+    await page.goto('/?mode=immersive', { waitUntil: 'domcontentloaded' });
+    await waitForImmersive(page);
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+  });
+
+  test('debug immersive URL remains valid for collection', async ({ page }) => {
+    await page.goto(DEBUG_IMMERSIVE_URL, { waitUntil: 'domcontentloaded' });
+    await waitForImmersive(page);
+    await expect(page).toHaveURL(/mode=immersive/);
+    await expect(page).toHaveURL(/disablePerformanceFailover=1/);
+  });
+});

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -95,7 +95,9 @@ export const AR_OVERRIDES: LocaleOverrides = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: 'تشغيل الوضع الغامر',
+        immersiveLink: 'حاول تشغيل الوضع الغامر مرة أخرى',
+        immersiveDebugLink: 'فرض وضع التصحيح الغامر',
+        clearModePreference: 'مسح تفضيل الوضع المحفوظ',
         resumeLink: 'تحميل أحدث سيرة ذاتية',
         githubLink: 'استكشاف المشاريع على GitHub',
       },

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -101,7 +101,9 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         resumeUrl: wrap('docs/resume/2025-09/resume.pdf'),
       },
       actions: {
-        immersiveLink: wrap('Launch immersive mode'),
+        immersiveLink: wrap('Try immersive again'),
+        immersiveDebugLink: wrap('Force immersive debug mode'),
+        clearModePreference: wrap('Clear saved mode preference'),
         resumeLink: wrap('Download the latest résumé'),
         githubLink: wrap('Explore projects on GitHub'),
       },
@@ -252,26 +254,26 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       idleLabelTemplate: wrap('Text mode · Press {keyHint}'),
       idleDescriptionTemplate: wrap('Switch to the text-only portfolio'),
       idleAnnouncementTemplate: wrap(
-        'Switch to the text-only portfolio. Press {keyHint} to activate.'
+        'Switch between immersive mode and the text portfolio. Press {keyHint} to activate.'
       ),
       idleTitleTemplate: wrap('Switch to the text-only portfolio ({keyHint})'),
-      pendingLabelTemplate: wrap('Switching to text mode…'),
+      pendingLabelTemplate: wrap('Switching modes…'),
       pendingAnnouncementTemplate: wrap(
-        'Switch to the text-only portfolio. Switching to text mode…'
+        'Switching between immersive mode and the text portfolio…'
       ),
-      activeLabelTemplate: wrap('Text mode active'),
-      activeDescriptionTemplate: wrap('Text mode already active.'),
-      activeAnnouncementTemplate: wrap('Text mode already active.'),
-      errorLabelTemplate: wrap('Retry text mode · Press {keyHint}'),
+      activeLabelTemplate: wrap('Try immersive · Press {keyHint}'),
+      activeDescriptionTemplate: wrap('Return to immersive mode'),
+      activeAnnouncementTemplate: wrap(
+        'Return to immersive mode. Press {keyHint} to activate.'
+      ),
+      errorLabelTemplate: wrap('Retry mode switch · Press {keyHint}'),
       errorDescriptionTemplate: wrap(
-        'Text mode toggle failed. Try again or use the immersive link.'
+        'Mode switch failed. Try again or use the recovery link.'
       ),
       errorAnnouncementTemplate: wrap(
-        'Text mode toggle failed. Press {keyHint} to try again.'
+        'Mode switch failed. Press {keyHint} to try again.'
       ),
-      errorTitleTemplate: wrap(
-        'Text mode toggle failed. Press {keyHint} to retry text mode.'
-      ),
+      errorTitleTemplate: wrap('Mode switch failed. Press {keyHint} to retry.'),
     },
     narrativeLog: {
       heading: wrap('Creator story log'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -100,7 +100,9 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: 'Launch immersive mode',
+        immersiveLink: 'Try immersive again',
+        immersiveDebugLink: 'Force immersive debug mode',
+        clearModePreference: 'Clear saved mode preference',
         resumeLink: 'Download the latest résumé',
         githubLink: 'Explore projects on GitHub',
       },
@@ -260,21 +262,21 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       idleLabelTemplate: 'Text mode · Press {keyHint}',
       idleDescriptionTemplate: 'Switch to the text-only portfolio',
       idleAnnouncementTemplate:
-        'Switch to the text-only portfolio. Press {keyHint} to activate.',
+        'Switch between immersive mode and the text portfolio. Press {keyHint} to activate.',
       idleTitleTemplate: 'Switch to the text-only portfolio ({keyHint})',
-      pendingLabelTemplate: 'Switching to text mode…',
+      pendingLabelTemplate: 'Switching modes…',
       pendingAnnouncementTemplate:
-        'Switch to the text-only portfolio. Switching to text mode…',
-      activeLabelTemplate: 'Text mode active',
-      activeDescriptionTemplate: 'Text mode already active.',
-      activeAnnouncementTemplate: 'Text mode already active.',
-      errorLabelTemplate: 'Retry text mode · Press {keyHint}',
+        'Switching between immersive mode and the text portfolio…',
+      activeLabelTemplate: 'Try immersive · Press {keyHint}',
+      activeDescriptionTemplate: 'Return to immersive mode',
+      activeAnnouncementTemplate:
+        'Return to immersive mode. Press {keyHint} to activate.',
+      errorLabelTemplate: 'Retry mode switch · Press {keyHint}',
       errorDescriptionTemplate:
-        'Text mode toggle failed. Try again or use the immersive link.',
+        'Mode switch failed. Try again or use the recovery link.',
       errorAnnouncementTemplate:
-        'Text mode toggle failed. Press {keyHint} to try again.',
-      errorTitleTemplate:
-        'Text mode toggle failed. Press {keyHint} to retry text mode.',
+        'Mode switch failed. Press {keyHint} to try again.',
+      errorTitleTemplate: 'Mode switch failed. Press {keyHint} to retry.',
     },
     narrativeLog: {
       heading: 'Creator story log',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -95,7 +95,9 @@ export const JA_OVERRIDES: LocaleOverrides = {
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
       actions: {
-        immersiveLink: '没入モードを起動',
+        immersiveLink: 'もう一度没入モードを試す',
+        immersiveDebugLink: '没入デバッグモードを強制',
+        clearModePreference: '保存済みモード設定をクリア',
         resumeLink: '最新の履歴書をダウンロード',
         githubLink: 'GitHubでプロジェクトを見る',
       },

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -246,6 +246,8 @@ export interface SiteTextFallbackStrings {
   };
   actions: {
     immersiveLink: string;
+    immersiveDebugLink: string;
+    clearModePreference: string;
     resumeLink: string;
     githubLink: string;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -303,7 +303,11 @@ import {
   createManualModeToggle,
   type ManualModeToggleHandle,
 } from './systems/failover/manualModeToggle';
-import { writeModePreference } from './systems/failover/modePreference';
+import {
+  clearModePreference,
+  shouldPersistTextPreferenceForFallback,
+  writeModePreference,
+} from './systems/failover/modePreference';
 import { createPerformanceFailoverHandler } from './systems/failover/performanceFailover';
 import { createGitHubRepoStatsService } from './systems/github/repoStats';
 import {
@@ -385,6 +389,7 @@ import {
 } from './ui/hud/responsiveControlOverlay';
 import {
   createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
   shouldDisablePerformanceFailover,
 } from './ui/immersiveUrl';
 import './ui/styles.css';
@@ -2983,10 +2988,15 @@ function initializeImmersiveScene(
       strings: modeToggleStrings,
       getIsFallbackActive: () => performanceFailover.hasTriggered(),
       onToggle: () => {
-        writeModePreference('text');
-        if (!performanceFailover.hasTriggered()) {
-          performanceFailover.triggerFallback('manual');
+        if (performanceFailover.hasTriggered()) {
+          clearModePreference();
+          window.location.assign(createImmersiveRecoveryUrl(window.location));
+          return;
         }
+        if (shouldPersistTextPreferenceForFallback('manual')) {
+          writeModePreference('text');
+        }
+        performanceFailover.triggerFallback('manual');
       },
     });
     registerHudControlElement(manualModeToggle?.element ?? null);

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -18,6 +18,7 @@ import {
 } from '../../ui/accessibility/modeAnnouncer';
 import {
   createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
   getModeFromSearch,
   IMMERSIVE_MODE_VALUE,
   shouldDisablePerformanceFailover,
@@ -25,6 +26,7 @@ import {
 } from '../../ui/immersiveUrl';
 
 import {
+  clearModePreference,
   readModePreference as readStoredModePreference,
   type ModePreference,
 } from './modePreference';
@@ -873,6 +875,66 @@ function createContactSection(
   return section;
 }
 
+const ADVANCED_IMMERSIVE_DEBUG_REASONS = new Set<FallbackReason>([
+  'low-performance',
+  'low-end-device',
+  'low-memory',
+  'console-error',
+  'immersive-init-error',
+]);
+
+const shouldShowAdvancedImmersiveDebugLink = (
+  reason: FallbackReason
+): boolean => ADVANCED_IMMERSIVE_DEBUG_REASONS.has(reason);
+
+const installTextFallbackRecoveryHandlers = (
+  section: HTMLElement,
+  options: {
+    immersiveUrl: string;
+    documentTarget: Document;
+  }
+): void => {
+  const { immersiveUrl, documentTarget } = options;
+  const windowTarget = documentTarget.defaultView;
+  const clearPreference = () => {
+    clearModePreference();
+  };
+  const navigateToImmersive = () => {
+    clearPreference();
+    if (windowTarget) {
+      windowTarget.location.assign(immersiveUrl);
+    }
+  };
+
+  section.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    const action = target.closest<HTMLElement>('[data-action]')?.dataset.action;
+    if (action === 'immersive') {
+      clearPreference();
+      return;
+    }
+    if (action === 'clear-mode-preference') {
+      event.preventDefault();
+      clearPreference();
+      target.setAttribute('aria-pressed', 'true');
+    }
+  });
+
+  windowTarget?.addEventListener('keydown', (event) => {
+    if (event.key !== 'T' && event.key !== 't') {
+      return;
+    }
+    if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+      return;
+    }
+    event.preventDefault();
+    navigateToImmersive();
+  });
+};
+
 export function renderTextFallback(
   container: HTMLElement,
   options: RenderTextFallbackOptions
@@ -894,9 +956,10 @@ export function renderTextFallback(
     textFallbackStrings.contact.resumeUrl ??
     'docs/resume/2025-09/resume.pdf';
   const resolvedGithubUrl = githubUrl ?? textFallbackStrings.contact.githubUrl;
-  const immersiveUrl = createImmersiveModeUrl(
-    providedImmersiveUrl ?? documentTarget.defaultView?.location ?? undefined
-  );
+  const recoveryUrlInput =
+    providedImmersiveUrl ?? documentTarget.defaultView?.location ?? undefined;
+  const immersiveUrl = createImmersiveRecoveryUrl(recoveryUrlInput);
+  const immersiveDebugUrl = createImmersiveModeUrl(recoveryUrlInput);
   const resolvedLocale = resolveLocale(localeHint);
   const langValue = resolvedLocale === 'en-x-pseudo' ? 'en' : resolvedLocale;
   const direction = getLocaleDirection(localeHint);
@@ -967,6 +1030,30 @@ export function renderTextFallback(
   immersiveItem.appendChild(immersiveLink);
   list.appendChild(immersiveItem);
 
+  if (shouldShowAdvancedImmersiveDebugLink(reason)) {
+    const debugItem = documentTarget.createElement('li');
+    debugItem.className = 'text-fallback__action';
+    const debugLink = documentTarget.createElement('a');
+    debugLink.href = immersiveDebugUrl;
+    debugLink.className = 'text-fallback__link';
+    debugLink.textContent = actionStrings.immersiveDebugLink;
+    debugLink.rel = 'noopener';
+    debugLink.dataset.action = 'immersive-debug';
+    debugItem.appendChild(debugLink);
+    list.appendChild(debugItem);
+  }
+
+  const clearPreferenceItem = documentTarget.createElement('li');
+  clearPreferenceItem.className = 'text-fallback__action';
+  const clearPreferenceButton = documentTarget.createElement('button');
+  clearPreferenceButton.type = 'button';
+  clearPreferenceButton.className = 'text-fallback__link text-fallback__button';
+  clearPreferenceButton.textContent = actionStrings.clearModePreference;
+  clearPreferenceButton.dataset.action = 'clear-mode-preference';
+  clearPreferenceButton.setAttribute('aria-pressed', 'false');
+  clearPreferenceItem.appendChild(clearPreferenceButton);
+  list.appendChild(clearPreferenceItem);
+
   const resumeItem = documentTarget.createElement('li');
   resumeItem.className = 'text-fallback__action';
   const resumeLink = documentTarget.createElement('a');
@@ -998,6 +1085,10 @@ export function renderTextFallback(
     section.appendChild(portfolioSection);
   }
   container.appendChild(section);
+  installTextFallbackRecoveryHandlers(section, {
+    immersiveUrl,
+    documentTarget,
+  });
   section.focus({ preventScroll: true });
 
   try {

--- a/src/systems/failover/manualModeToggle.ts
+++ b/src/systems/failover/manualModeToggle.ts
@@ -136,7 +136,7 @@ export function createManualModeToggle({
     if (fallbackActive) {
       errored = false;
       setContainerState('active');
-      setDisabledState(true);
+      setDisabledState(false);
       button.dataset.state = 'active';
       button.removeAttribute('aria-busy');
       button.textContent = withFallback(
@@ -214,7 +214,7 @@ export function createManualModeToggle({
 
   const activate = () => {
     refreshState();
-    if (pending || getIsFallbackActive()) {
+    if (pending) {
       return;
     }
     clearErrorState();
@@ -260,7 +260,7 @@ export function createManualModeToggle({
     if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
       return;
     }
-    if (pending || getIsFallbackActive()) {
+    if (pending) {
       return;
     }
     event.preventDefault();

--- a/src/systems/failover/modePreference.ts
+++ b/src/systems/failover/modePreference.ts
@@ -1,3 +1,5 @@
+import type { FallbackReason } from '../../types/failover';
+
 export type ModePreference = 'immersive' | 'text';
 
 const MODE_PREFERENCE_STORAGE_KEY = 'danielsmith.io:mode-preference';
@@ -75,5 +77,9 @@ export const clearModePreference = (
 ): void => {
   writeModePreference(null, options);
 };
+
+export const shouldPersistTextPreferenceForFallback = (
+  reason: FallbackReason
+): boolean => reason === 'manual';
 
 export const MODE_PREFERENCE_KEY = MODE_PREFERENCE_STORAGE_KEY;

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -9,7 +9,10 @@ import {
   type FallbackReason,
   type RenderTextFallbackOptions,
 } from '../systems/failover';
-import { createImmersiveModeUrl } from '../ui/immersiveUrl';
+import {
+  createImmersiveModeUrl,
+  createImmersiveRecoveryUrl,
+} from '../ui/immersiveUrl';
 
 const IMMERSIVE_URL = createImmersiveModeUrl({
   pathname: '/',
@@ -861,7 +864,7 @@ describe('renderTextFallback', () => {
       '[data-action="immersive"]'
     );
     expect(immersiveLink?.href).toBe(
-      new URL(createImmersiveModeUrl(), window.location.origin).toString()
+      new URL(createImmersiveRecoveryUrl(), window.location.origin).toString()
     );
   });
 
@@ -873,7 +876,7 @@ describe('renderTextFallback', () => {
     );
     expect(immersiveLink?.href).toBe(
       new URL(
-        createImmersiveModeUrl(customUrl),
+        createImmersiveRecoveryUrl(customUrl),
         window.location.origin
       ).toString()
     );
@@ -951,6 +954,19 @@ describe('renderTextFallback', () => {
     expect(section?.getAttribute('data-reason')).toBe('low-performance');
     const description = container.querySelector('.text-fallback__description');
     expect(description?.textContent).toMatch(/frame/);
+    expect(
+      container.querySelector<HTMLAnchorElement>('[data-action="immersive"]')
+        ?.href
+    ).toBe(
+      new URL(createImmersiveRecoveryUrl(), window.location.origin).toString()
+    );
+    expect(
+      container.querySelector<HTMLAnchorElement>(
+        '[data-action="immersive-debug"]'
+      )?.href
+    ).toBe(
+      new URL(createImmersiveModeUrl(), window.location.origin).toString()
+    );
   });
 
   it('highlights data-saver fallback messaging', () => {
@@ -1011,6 +1027,7 @@ describe('renderTextFallback', () => {
 
     expect(actionLinks.map((link) => link.textContent)).toEqual([
       actions.immersiveLink,
+      actions.clearModePreference,
       actions.resumeLink,
       actions.githubLink,
     ]);

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -97,36 +97,34 @@ describe('i18n utilities', () => {
     expect(english.keyHint).toBe('T');
     expect(english.idleLabel).toBe('Text mode · Press T');
     expect(english.idleHudAnnouncement).toBe(
-      'Switch to the text-only portfolio. Press T to activate.'
+      'Switch between immersive mode and the text portfolio. Press T to activate.'
     );
     expect(english.idleTitle).toBe('Switch to the text-only portfolio (T)');
     expect(english.pendingHudAnnouncement).toBe(
-      'Switch to the text-only portfolio. Switching to text mode…'
+      'Switching between immersive mode and the text portfolio…'
     );
-    expect(english.errorLabel).toBe('Retry text mode · Press T');
+    expect(english.activeLabel).toBe('Try immersive · Press T');
+    expect(english.activeDescription).toBe('Return to immersive mode');
+    expect(english.errorLabel).toBe('Retry mode switch · Press T');
     expect(english.errorHudAnnouncement).toBe(
-      'Text mode toggle failed. Press T to try again.'
+      'Mode switch failed. Press T to try again.'
     );
-    expect(english.errorTitle).toBe(
-      'Text mode toggle failed. Press T to retry text mode.'
-    );
+    expect(english.errorTitle).toBe('Mode switch failed. Press T to retry.');
 
     const pseudo = getModeToggleStrings('en-x-pseudo');
     expect(pseudo.keyHint).toBe('T');
     expect(pseudo.idleLabel).toBe('⟦Text mode · Press T⟧');
     expect(pseudo.idleHudAnnouncement).toBe(
-      '⟦Switch to the text-only portfolio. Press T to activate.⟧'
+      '⟦Switch between immersive mode and the text portfolio. Press T to activate.⟧'
     );
     expect(pseudo.pendingHudAnnouncement).toBe(
-      '⟦Switch to the text-only portfolio. Switching to text mode…⟧'
+      '⟦Switching between immersive mode and the text portfolio…⟧'
     );
-    expect(pseudo.errorLabel).toBe('⟦Retry text mode · Press T⟧');
+    expect(pseudo.errorLabel).toBe('⟦Retry mode switch · Press T⟧');
     expect(pseudo.errorHudAnnouncement).toBe(
-      '⟦Text mode toggle failed. Press T to try again.⟧'
+      '⟦Mode switch failed. Press T to try again.⟧'
     );
-    expect(pseudo.errorTitle).toBe(
-      '⟦Text mode toggle failed. Press T to retry text mode.⟧'
-    );
+    expect(pseudo.errorTitle).toBe('⟦Mode switch failed. Press T to retry.⟧');
   });
 
   it('returns localized locale toggle strings for HUD controls', () => {
@@ -153,7 +151,7 @@ describe('i18n utilities', () => {
   it('builds mode announcer messages from localized HUD and fallback copy', () => {
     const english = getModeAnnouncerStrings('en');
     expect(english.immersiveReady).toBe(
-      'Switch to the text-only portfolio. Press T to activate.'
+      'Switch between immersive mode and the text portfolio. Press T to activate.'
     );
     expect(english.fallbackReasons['data-saver']).toContain('data-saver');
 

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createImmersiveModeUrl,
   createImmersivePreviewUrl,
+  createImmersiveRecoveryUrl,
   createTextModeUrl,
   getModeFromSearch,
   hasImmersiveOverride,
@@ -115,6 +116,23 @@ describe('createImmersiveModeUrl', () => {
     expect(url).toBe(
       '/demo?foo=bar&feature=preview&mode=immersive&disablePerformanceFailover=1#scene'
     );
+  });
+});
+
+describe('createImmersiveRecoveryUrl', () => {
+  it('forces immersive mode without disabling runtime performance failover', () => {
+    const url = createImmersiveRecoveryUrl({
+      pathname: '/',
+      search: '?mode=text&disablePerformanceFailover=1',
+      hash: '',
+    });
+
+    expect(url).toBe('/?mode=immersive');
+  });
+
+  it('preserves unrelated recovery query params and hash fragments', () => {
+    const url = createImmersiveRecoveryUrl('/portfolio?ref=fallback#studio');
+    expect(url).toBe('/portfolio?ref=fallback&mode=immersive#studio');
   });
 });
 

--- a/src/tests/manualModeToggle.test.ts
+++ b/src/tests/manualModeToggle.test.ts
@@ -38,7 +38,7 @@ describe('createManualModeToggle', () => {
     expect(handle.element.getAttribute('aria-disabled')).toBeNull();
     expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Switch to the text-only portfolio. Press T to activate.'
+      'Switch between immersive mode and the text portfolio. Press T to activate.'
     );
     expect(container.dataset.modeToggleState).toBe('idle');
     expect(container.getAttribute('aria-busy')).toBeNull();
@@ -57,7 +57,7 @@ describe('createManualModeToggle', () => {
     expect(container.getAttribute('aria-busy')).toBe('true');
     expect(handle.element.dataset.state).toBe('pending');
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Switch to the text-only portfolio. Switching to text mode…'
+      'Switching between immersive mode and the text portfolio…'
     );
     expect(handle.element.getAttribute('aria-pressed')).toBe('false');
     expect(handle.element.getAttribute('aria-busy')).toBe('true');
@@ -66,15 +66,15 @@ describe('createManualModeToggle', () => {
 
     expect(handle.element.dataset.state).toBe('active');
     expect(container.dataset.modeToggleState).toBe('active');
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(container.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.textContent).toBe('Text mode active');
+    expect(handle.element.textContent).toBe('Try immersive · Press T');
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Text mode already active.'
+      'Return to immersive mode. Press T to activate.'
     );
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     cleanupHandle(handle);
     container.remove();
@@ -145,12 +145,12 @@ describe('createManualModeToggle', () => {
 
     expect(container.dataset.modeToggleState).toBe('active');
     expect(container.getAttribute('aria-busy')).toBeNull();
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.state).toBe('active');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.getAttribute('aria-disabled')).toBe('true');
+    expect(handle.element.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     resolveToggle?.();
     await flushMicrotasks();
@@ -162,7 +162,7 @@ describe('createManualModeToggle', () => {
     container.remove();
   });
 
-  it('ignores activation when fallback already active', () => {
+  it('activates recovery when fallback already active', async () => {
     const container = createContainer();
     const onToggle = vi.fn();
     const handle = createManualModeToggle({
@@ -171,23 +171,24 @@ describe('createManualModeToggle', () => {
       getIsFallbackActive: () => true,
     });
 
-    expect(handle.element.getAttribute('aria-disabled')).toBe('true');
-    expect(container.getAttribute('aria-disabled')).toBe('true');
+    expect(handle.element.getAttribute('aria-disabled')).toBeNull();
+    expect(container.getAttribute('aria-disabled')).toBeNull();
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Text mode already active.'
+      'Return to immersive mode. Press T to activate.'
     );
     expect(container.dataset.modeToggleState).toBe('active');
     expect(container.getAttribute('aria-busy')).toBeNull();
     expect(handle.element.dataset.state).toBe('active');
-    expect(handle.element.textContent).toBe('Text mode active');
+    expect(handle.element.textContent).toBe('Try immersive · Press T');
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     handle.element.click();
+    await flushMicrotasks();
 
-    expect(onToggle).not.toHaveBeenCalled();
-    expect(handle.element.disabled).toBe(true);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(handle.element.disabled).toBe(false);
     expect(handle.element.dataset.state).toBe('active');
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
 
@@ -219,12 +220,12 @@ describe('createManualModeToggle', () => {
     expect(container.dataset.modeToggleState).toBe('error');
     expect(container.getAttribute('aria-busy')).toBeNull();
     expect(handle.element.dataset.state).toBe('error');
-    expect(handle.element.textContent).toBe('Retry text mode · Press T');
+    expect(handle.element.textContent).toBe('Retry mode switch · Press T');
     expect(handle.element.dataset.hudAnnounce).toBe(
-      'Text mode toggle failed. Press T to try again.'
+      'Mode switch failed. Press T to try again.'
     );
     expect(handle.element.getAttribute('aria-label')).toBe(
-      'Text mode toggle failed. Try again or use the immersive link.'
+      'Mode switch failed. Try again or use the recovery link.'
     );
     expect(handle.element.getAttribute('aria-pressed')).toBe('false');
     expect(handle.element.getAttribute('aria-busy')).toBeNull();
@@ -390,7 +391,7 @@ describe('createManualModeToggle', () => {
 
     expect(container.dataset.modeToggleState).toBe('active');
     expect(handle.element.dataset.state).toBe('active');
-    expect(handle.element.disabled).toBe(true);
+    expect(handle.element.disabled).toBe(false);
 
     handle.dispose();
     fallbackActive = false;

--- a/src/tests/modePreference.test.ts
+++ b/src/tests/modePreference.test.ts
@@ -4,6 +4,7 @@ import {
   MODE_PREFERENCE_KEY,
   clearModePreference,
   readModePreference,
+  shouldPersistTextPreferenceForFallback,
   writeModePreference,
 } from '../systems/failover/modePreference';
 
@@ -127,5 +128,29 @@ describe('clearModePreference', () => {
 
     expect(storage.removeItem).toHaveBeenCalledWith(MODE_PREFERENCE_KEY);
     expect(storage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+  });
+});
+
+describe('shouldPersistTextPreferenceForFallback', () => {
+  it('persists only explicit manual text-mode choices', () => {
+    expect(shouldPersistTextPreferenceForFallback('manual')).toBe(true);
+    expect(shouldPersistTextPreferenceForFallback('low-performance')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('low-end-device')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('low-memory')).toBe(false);
+    expect(shouldPersistTextPreferenceForFallback('webgl-unsupported')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('automated-client')).toBe(
+      false
+    );
+    expect(shouldPersistTextPreferenceForFallback('data-saver')).toBe(false);
+    expect(shouldPersistTextPreferenceForFallback('console-error')).toBe(false);
+    expect(shouldPersistTextPreferenceForFallback('immersive-init-error')).toBe(
+      false
+    );
   });
 });

--- a/src/tests/textFallbackAccessibility.test.ts
+++ b/src/tests/textFallbackAccessibility.test.ts
@@ -117,7 +117,7 @@ describe('text fallback accessibility', () => {
     ) as HTMLAnchorElement | null;
 
     expect(immersiveLink?.href).toBe(
-      'https://danielsmith.io/portfolio?mode=immersive&disablePerformanceFailover=1'
+      'https://danielsmith.io/portfolio?mode=immersive'
     );
   });
 

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -173,6 +173,15 @@ export const createImmersiveModeUrl = (
     extraParams,
   });
 
+export const createImmersiveRecoveryUrl = (
+  input?: UrlLike,
+  extraParams?: ExtraParams
+) =>
+  buildModeUrl(input, IMMERSIVE_MODE_VALUE, {
+    includePerformanceBypass: false,
+    extraParams,
+  });
+
 export const createImmersivePreviewUrl = (
   baseUrl: UrlLike = IMMERSIVE_PREVIEW_BASE_URL,
   extraParams?: ExtraParams

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -204,6 +204,15 @@ canvas {
   font-weight: 600;
 }
 
+.text-fallback__button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
 .text-fallback__link:hover,
 .text-fallback__link:focus {
   text-decoration: underline;


### PR DESCRIPTION
### Motivation

- Fix a trapdoor UX where entering text/fallback could become irreversible and block immersive debugging, while preserving runtime failover and crawler behavior.
- Expose a clear debug escape hatch for engineers (`?mode=immersive&disablePerformanceFailover=1`) and provide a non-sticky recovery path for runtime-triggered fallbacks.

### Description

- Add `createImmersiveRecoveryUrl(...)` and keep `createImmersiveModeUrl(...)` for the debug bypass; update URL helpers in `src/ui/immersiveUrl.ts`.
- Render new recovery actions in the text fallback UI: a visible “Try immersive again” link, an advanced debug link (when appropriate) to `?mode=immersive&disablePerformanceFailover=1`, and a `Clear saved mode preference` control; wired via `installTextFallbackRecoveryHandlers(...)` inside `src/systems/failover/index.ts` and rendered by `renderTextFallback`.
- Make the HUD/manual `T` control genuinely bidirectional by updating `createManualModeToggle` to allow recovery from fallback and by changing its enabled/ARIA states so it can navigate back to immersive instead of being a one-way disabled control (`src/systems/failover/manualModeToggle.ts`).
- Prevent runtime failover from writing a sticky text preference: add `shouldPersistTextPreferenceForFallback` in `modePreference.ts` and only persist when the reason is an explicit manual choice; wire the check where manual toggles trigger persistence (`src/main.ts`).
- Add localized strings for the new actions and update HUD copy / ARIA announcements to reflect two-way behavior in `src/assets/i18n/locales/*` and `src/assets/i18n/types.ts`.
- Add a Playwright spec `playwright/mode-fallback-recovery.spec.ts` exercising `T` toggling and recovery links, and an outage note plus JSON `outages/2026-05-30-danielsmith-mode-fallback-recovery.{md,json}` documenting the change.

### Testing

- Updated and ran Vitest unit suites covering URL helpers, mode persistence, and fallback rendering (`npm run test:ci`); targeted suites and the full Vitest run passed (updated expectations and new tests included). — PASS
- Added a Playwright e2e spec (`playwright/mode-fallback-recovery.spec.ts`) to validate keyboard `T` toggling and recovery links, included for CI e2e runs but not executed locally in this patch set. — (spec added)
- Ran linters and formatting: `npm run format:write` and `npm run lint` were executed and completed; formatting applied where needed. — PASS

Notes and follow-ups

- The recovery path navigates to a clean immersive URL rather than attempting in-place WebGL resurrection to avoid fragile renderer/state teardown.
- Playwright e2e should be included in CI runs (`npm run test:e2e -- --grep "mode|fallback|immersive"`) for full integration verification in the browser environment.
- No runtime dependencies were added; changes were limited to URL helpers, failover logic, HUD toggle behavior, i18n strings, tests, and outage docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a73f16040832f8ce1effdb61c8296)