### PR TITLE
⚙️ Tune adaptive quality warmup and recovery

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -36,6 +36,29 @@ and the Vitest assertions when measurable changes land.
   run `renderer.info.render` and `renderer.info.memory` after the camera settles
   at launch. Update the snapshot date and notes when refreshing numbers.
 
+## Adaptive quality warmup and recovery
+
+Staging on May 29, 2026 showed two renderer classes that need different
+adaptive-quality behavior:
+
+- Hardware acceleration (`ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11)`)
+  stabilized near 60 FPS with main render time warming down toward roughly
+  1–2 ms after startup. The previous policy could still downgrade balanced
+  quality to performance during shader/asset warmup and leave capable hardware
+  permanently reduced.
+- Software rendering (`ANGLE (Microsoft Basic Render Driver)`) remained around
+  30–40 FPS with DPR reduced, bloom/composer and the mirror disabled, and still
+  needs the separate crash-hardening follow-up.
+
+Normal renderers now collect warmup metrics before adaptive downgrades, require
+sustained low FPS/high frame time hysteresis before stepping down, and recover
+from performance to balanced after a sustained stable window near 60 FPS. The
+recovery path is disabled for software renderers and for explicit user-selected
+quality so manual performance choices are not silently upshifted. Diagnostics
+from `window.portfolio.performance.getSnapshot()` include warmup state,
+selection source, downgrade/recovery counts, and the last adaptive action reason
+so staging can distinguish startup spikes from steady-state overload.
+
 ## Heavy assets & lazy loading
 
 | Asset                                                      | Size            | Strategy                                                                                                                                          |

--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -50,8 +50,10 @@ adaptive-quality behavior:
   30–40 FPS with DPR reduced, bloom/composer and the mirror disabled, and still
   needs the separate crash-hardening follow-up.
 
-Normal renderers now collect warmup metrics before adaptive downgrades, require
-sustained low FPS/high frame time hysteresis before stepping down, and recover
+Normal renderers now collect warmup metrics during a 2.5-second grace window
+before adaptive downgrades, leaving time for the sustained-low-FPS ladder to act
+before the 5-second text failover. They require sustained low FPS/high frame
+time hysteresis before stepping down, and recover
 from performance to balanced after a sustained stable window near 60 FPS. The
 recovery path is disabled for software renderers and for explicit user-selected
 quality so manual performance choices are not silently upshifted. Diagnostics

--- a/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
+++ b/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
@@ -4,11 +4,18 @@
 
 ## Symptom slice
 
-Performance failover watched sustained low FPS, but graphics quality did not automatically step down before text fallback.
+Performance failover originally watched sustained low FPS, but graphics quality did
+not automatically step down before text fallback. Follow-up staging on May 29,
+2026 showed the opposite edge case on good hardware: `ANGLE (NVIDIA, NVIDIA
+GeForce RTX 4090 ..., D3D11)` stabilized near 60 FPS after startup, while the
+adaptive ladder still reacted to warmup spikes and could leave the session in
+performance mode.
 
 ## Evidence
 
-Diagnostics expose adaptive downgrade count and last adaptive reason; unit coverage drives slow-frame updates without requiring real SwiftShader in CI.
+Diagnostics expose adaptive warmup state, selection source, downgrade/recovery
+counts, and the last adaptive action reason; unit coverage drives slow-frame and
+recovery updates without requiring real SwiftShader in CI.
 
 ## Impacted files
 
@@ -20,7 +27,11 @@ Diagnostics expose adaptive downgrade count and last adaptive reason; unit cover
 
 ## Fix summary
 
-An adaptive ladder now lowers quality from cinematic to balanced to performance, then reduces base DPR, resetting failover samples after each downgrade to prevent premature fallback or flapping.
+An adaptive ladder lowers quality from cinematic to balanced to performance,
+then reduces base DPR, resetting failover samples after each downgrade. Normal
+renderers now get a warmup grace period plus sustained-frame hysteresis before
+downgrades, and can recover from performance to balanced after a stable
+near-60-FPS window. Software renderers stay conservative and do not auto-upshift.
 
 ## Interaction with other fixes
 
@@ -31,7 +42,10 @@ last-failover reason.
 
 ## Regression tests
 
-src/tests/performanceOptimization.test.ts covers the downgrade ladder and no-flap behavior; performanceFailover reset support keeps fallback available after adaptive steps are exhausted.
+src/tests/performanceOptimization.test.ts covers warmup suppression, sustained
+downgrade, stable recovery, software-renderer conservatism, user-selected
+quality, and no-flap behavior; performanceFailover reset support keeps fallback
+available after adaptive steps are exhausted.
 
 ## Validation commands
 

--- a/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
+++ b/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
@@ -29,9 +29,11 @@ recovery updates without requiring real SwiftShader in CI.
 
 An adaptive ladder lowers quality from cinematic to balanced to performance,
 then reduces base DPR, resetting failover samples after each downgrade. Normal
-renderers now get a warmup grace period plus sustained-frame hysteresis before
-downgrades, and can recover from performance to balanced after a stable
-near-60-FPS window. Software renderers stay conservative and do not auto-upshift.
+renderers now get a 2.5-second warmup grace period plus sustained-frame
+hysteresis before downgrades, keeping the adaptive ladder ahead of the
+5-second low-FPS text failover. They can recover from performance to balanced
+after a stable near-60-FPS window. Software renderers stay conservative and do
+not auto-upshift.
 
 ## Interaction with other fixes
 

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.md
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.md
@@ -30,10 +30,10 @@ The fix starts risky software renderers in performance mode, defaults normal
 desktop rendering to balanced quality, caps DPR to an explicit lower bound, skips
 EffectComposer when bloom and motion blur are inactive, disables bloom in
 performance mode, throttles or disables SelfieMirror work by quality tier, and
-adds a warmup-aware, non-flapping adaptive downgrade ladder before low-FPS
-fallback. Hardware-accelerated staging evidence from `ANGLE (NVIDIA, NVIDIA
-GeForce RTX 4090 ..., D3D11)` showed stable near-60-FPS behavior after startup,
-so normal renderers now require sustained low-FPS/high-frame-time evidence
+adds a 2.5-second warmup-aware, non-flapping adaptive downgrade ladder before
+low-FPS fallback. Hardware-accelerated staging evidence from `ANGLE (NVIDIA,
+NVIDIA GeForce RTX 4090 ..., D3D11)` showed stable near-60-FPS behavior
+after startup, so normal renderers now require sustained low-FPS/high-frame-time evidence
 before downgrading and can recover from performance to balanced after a stable
 window. Software renderer crash hardening remains a separate follow-up.
 

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.md
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.md
@@ -13,7 +13,7 @@ software WebGL.
 - [Software renderer used the expensive default quality path](./2026-05-29-danielsmith-software-renderer-quality.md).
 - [Postprocessing and DPR multiplied full-screen pixel cost](./2026-05-29-danielsmith-postprocessing-pixel-cost.md).
 - [SelfieMirror rendered the full scene every frame](./2026-05-29-danielsmith-selfie-mirror-render-cost.md).
-- [Adaptive quality did not downgrade before text fallback](./2026-05-29-danielsmith-adaptive-quality-gap.md).
+- [Adaptive quality needed both pre-fallback downgrades and warmup-aware recovery](./2026-05-29-danielsmith-adaptive-quality-gap.md).
 - [Text fallback recovery trapped immersive debugging](./2026-05-30-danielsmith-mode-fallback-recovery.md).
 
 ## Disproven or unconfirmed theories
@@ -30,7 +30,12 @@ The fix starts risky software renderers in performance mode, defaults normal
 desktop rendering to balanced quality, caps DPR to an explicit lower bound, skips
 EffectComposer when bloom and motion blur are inactive, disables bloom in
 performance mode, throttles or disables SelfieMirror work by quality tier, and
-adds a non-flapping adaptive downgrade ladder before low-FPS fallback.
+adds a warmup-aware, non-flapping adaptive downgrade ladder before low-FPS
+fallback. Hardware-accelerated staging evidence from `ANGLE (NVIDIA, NVIDIA
+GeForce RTX 4090 ..., D3D11)` showed stable near-60-FPS behavior after startup,
+so normal renderers now require sustained low-FPS/high-frame-time evidence
+before downgrading and can recover from performance to balanced after a stable
+window. Software renderer crash hardening remains a separate follow-up.
 
 Diagnostics are available in DevTools at:
 

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -23,7 +23,20 @@ interface PerformanceSnapshot {
   };
   quality: {
     level: 'cinematic' | 'balanced' | 'performance';
+    selectionSource: 'initial' | 'adaptive' | 'user';
     adaptiveDowngradeCount: number;
+    adaptiveRecoveryCount: number;
+    lastAdaptiveReason: string | null;
+    lastAdaptiveDowngradeReason: string | null;
+    lastAdaptiveRecoveryReason: string | null;
+    adaptivePolicy: {
+      isWarmingUp: boolean;
+      warmupElapsedMs: number;
+      warmupRemainingMs: number;
+      autoRecoveryEnabled: boolean;
+      softwareRenderer: boolean;
+      lastAction: 'downgrade' | 'recover' | null;
+    } | null;
   };
   features: {
     bloomEnabled: boolean;
@@ -181,6 +194,10 @@ test.describe('immersive performance diagnostics', () => {
       expect(snapshot.lastFailoverReason).toBeNull();
       expect(snapshot.rendererSize.pixelRatio).toBeLessThanOrEqual(1.25);
       expect(snapshot.quality.level).not.toBe('cinematic');
+      expect(snapshot.quality.adaptivePolicy).toBeDefined();
+      expect(snapshot.quality.adaptivePolicy?.softwareRenderer).toBe(
+        snapshot.renderer.isSoftwareRenderer
+      );
       expect(snapshot.features.mirrorRenderTargetSize).toBeLessThanOrEqual(320);
       if (snapshot.quality.level === 'performance') {
         expect(snapshot.features.bloomEnabled).toBe(false);
@@ -207,6 +224,7 @@ test.describe('immersive performance diagnostics', () => {
         snapshot.features.activePostprocessingPassCount
       ).toBeGreaterThanOrEqual(0);
       expect(snapshot.quality.level).not.toBe('cinematic');
+      expect(snapshot.quality.adaptivePolicy).toBeDefined();
     } finally {
       await context.close();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3091,9 +3091,14 @@ function initializeImmersiveScene(
       basePixelRatio = value;
     },
     fpsThreshold: PERFORMANCE_FAILOVER_FPS_THRESHOLD,
-    onDowngrade: (event) => {
-      console.info('[performance] adaptive quality downgrade', event);
-      performanceFailover.resetLowFpsSamples();
+    isSoftwareRenderer: rendererInfo.isSoftwareRenderer,
+    getSelectionSource: () =>
+      graphicsQualityManager?.getSelectionSource() ?? 'initial',
+    onAction: (event) => {
+      console.info('[performance] adaptive quality action', event);
+      if (event.action === 'downgrade') {
+        performanceFailover.resetLowFpsSamples();
+      }
       graphicsQualityControl?.refresh();
     },
   });
@@ -3300,9 +3305,16 @@ function initializeImmersiveScene(
     }),
     getQualityState: () => ({
       level: graphicsQualityManager!.getLevel(),
+      selectionSource: graphicsQualityManager!.getSelectionSource(),
       adaptiveDowngradeCount:
         adaptiveQualityController?.getDowngradeCount() ?? 0,
+      adaptiveRecoveryCount: adaptiveQualityController?.getRecoveryCount() ?? 0,
       lastAdaptiveReason: adaptiveQualityController?.getLastReason() ?? null,
+      lastAdaptiveDowngradeReason:
+        adaptiveQualityController?.getLastDowngradeReason() ?? null,
+      lastAdaptiveRecoveryReason:
+        adaptiveQualityController?.getLastRecoveryReason() ?? null,
+      adaptivePolicy: adaptiveQualityController?.getSnapshot() ?? null,
     }),
     getFeatureState: () => {
       const mirrorState = selfieMirror?.getRenderState();
@@ -4057,8 +4069,8 @@ function initializeImmersiveScene(
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);
-      const adaptiveDowngrade = adaptiveQualityController?.update(delta);
-      if (adaptiveDowngrade) {
+      const adaptiveAction = adaptiveQualityController?.update(delta);
+      if (adaptiveAction) {
         applyFeaturePolicy();
       }
       performanceFailover.update(delta);

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -116,9 +116,15 @@ export interface GraphicsQualityManagerOptions {
   preferInitialLevel?: boolean;
 }
 
+export type GraphicsQualitySelectionSource = 'initial' | 'adaptive' | 'user';
+
 export interface GraphicsQualityManager {
   getLevel(): GraphicsQualityLevel;
-  setLevel(level: GraphicsQualityLevel): void;
+  getSelectionSource(): GraphicsQualitySelectionSource;
+  setLevel(
+    level: GraphicsQualityLevel,
+    options?: { source?: GraphicsQualitySelectionSource }
+  ): void;
   refresh(): void;
   setBasePixelRatio(pixelRatio: number): void;
   onChange(listener: (level: GraphicsQualityLevel) => void): () => void;
@@ -179,11 +185,13 @@ export function createGraphicsQualityManager({
   let currentLevel: GraphicsQualityLevel = isGraphicsQualityLevel(initialLevel)
     ? initialLevel
     : 'balanced';
+  let selectionSource: GraphicsQualitySelectionSource = 'initial';
   if (!preferInitialLevel && storage?.getItem) {
     try {
       const stored = storage.getItem(storageKey);
       if (isGraphicsQualityLevel(stored)) {
         currentLevel = stored;
+        selectionSource = 'user';
       }
     } catch (error) {
       console.warn('Failed to read persisted graphics quality level:', error);
@@ -248,16 +256,25 @@ export function createGraphicsQualityManager({
     getLevel() {
       return currentLevel;
     },
-    setLevel(level) {
+    getSelectionSource() {
+      return selectionSource;
+    },
+    setLevel(level, options = {}) {
       if (!isGraphicsQualityLevel(level)) {
         throw new Error(`Unsupported graphics quality level: ${level}`);
       }
+      const source = options.source ?? 'user';
+      selectionSource = source;
       if (level === currentLevel) {
-        persist(level);
+        if (source === 'user') {
+          persist(level);
+        }
         return;
       }
       currentLevel = level;
-      persist(level);
+      if (source === 'user') {
+        persist(level);
+      }
       applyPreset(level);
       notify();
     },

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -72,7 +72,7 @@ export interface AdaptiveQualityController {
   isExhausted(): boolean;
 }
 
-const DEFAULT_NORMAL_WARMUP_MS = 5000;
+const DEFAULT_NORMAL_WARMUP_MS = 2500;
 const FRAME_SAMPLE_WINDOW = 60;
 const RECOVERY_COOLDOWN_MULTIPLIER = 2;
 
@@ -242,6 +242,10 @@ export function createAdaptiveQualityController({
   };
 
   const shouldRecover = (frameMs: number) => {
+    if (qualityManager.getLevel() !== 'performance') {
+      stableDurationMs = 0;
+      return false;
+    }
     const fps = frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
     const { p95FrameMs } = summarizeFrameWindow(frameMsSamples);
     const isStable =

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -133,6 +133,11 @@ export function createAdaptiveQualityController({
   const isWarmingUp = () => getWarmupRemainingMs() > 0;
   const autoRecoveryEnabled = () =>
     !isSoftwareRenderer && getSelectionSource() !== 'user';
+  const canAccrueRecovery = () =>
+    qualityManager.getLevel() === 'performance' && autoRecoveryEnabled();
+  const resetRecoveryState = () => {
+    stableDurationMs = 0;
+  };
 
   const emit = (
     action: AdaptiveQualityAction,
@@ -143,13 +148,13 @@ export function createAdaptiveQualityController({
       downgradeCount += 1;
       lastDowngradeReason = reason;
       lowFpsDurationMs = 0;
-      stableDurationMs = 0;
+      resetRecoveryState();
       cooldownRemainingMs = cooldownMs;
       recoveryCooldownRemainingMs = cooldownMs * RECOVERY_COOLDOWN_MULTIPLIER;
     } else {
       recoveryCount += 1;
       lastRecoveryReason = reason;
-      stableDurationMs = 0;
+      resetRecoveryState();
       lowFpsDurationMs = 0;
       cooldownRemainingMs = cooldownMs;
       recoveryCooldownRemainingMs = cooldownMs;
@@ -210,7 +215,7 @@ export function createAdaptiveQualityController({
   };
 
   const recover = (): AdaptiveQualityEvent | null => {
-    if (!autoRecoveryEnabled() || qualityManager.getLevel() !== 'performance') {
+    if (!canAccrueRecovery()) {
       return null;
     }
     qualityManager.setLevel('balanced', { source: 'adaptive' });
@@ -242,16 +247,16 @@ export function createAdaptiveQualityController({
   };
 
   const shouldRecover = (frameMs: number) => {
-    if (qualityManager.getLevel() !== 'performance') {
-      stableDurationMs = 0;
+    if (!canAccrueRecovery()) {
+      resetRecoveryState();
       return false;
     }
     const fps = frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
     const { p95FrameMs } = summarizeFrameWindow(frameMsSamples);
     const isStable =
       fps >= recoveryFpsThreshold && p95FrameMs <= recoveryP95FrameMs;
-    if (!isStable || !autoRecoveryEnabled()) {
-      stableDurationMs = 0;
+    if (!isStable) {
+      resetRecoveryState();
       return false;
     }
     stableDurationMs += frameMs;
@@ -278,6 +283,9 @@ export function createAdaptiveQualityController({
           0,
           recoveryCooldownRemainingMs - frameMs
         );
+      }
+      if (recoveryCooldownRemainingMs > 0 || !canAccrueRecovery()) {
+        resetRecoveryState();
       }
 
       if (cooldownRemainingMs <= 0 && shouldDowngrade(frameMs)) {

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -1,8 +1,14 @@
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
+export type AdaptiveQualitySelectionSource = 'initial' | 'adaptive' | 'user';
+export type AdaptiveQualityAction = 'downgrade' | 'recover';
+
 export interface AdaptiveQualityManagerLike {
   getLevel(): GraphicsQualityLevel;
-  setLevel(level: GraphicsQualityLevel): void;
+  setLevel(
+    level: GraphicsQualityLevel,
+    options?: { source?: AdaptiveQualitySelectionSource }
+  ): void;
   setBasePixelRatio(pixelRatio: number): void;
 }
 
@@ -14,22 +20,82 @@ export interface AdaptiveQualityControllerOptions {
   downgradeAfterMs?: number;
   cooldownMs?: number;
   minBasePixelRatio?: number;
-  onDowngrade?: (event: AdaptiveQualityDowngradeEvent) => void;
+  isSoftwareRenderer?: boolean;
+  warmupMs?: number;
+  recoveryAfterMs?: number;
+  recoveryFpsThreshold?: number;
+  recoveryP95FrameMs?: number;
+  getSelectionSource?: () => AdaptiveQualitySelectionSource;
+  onAction?: (event: AdaptiveQualityEvent) => void;
+  onDowngrade?: (event: AdaptiveQualityEvent) => void;
 }
 
-export interface AdaptiveQualityDowngradeEvent {
+export interface AdaptiveQualityEvent {
+  action: AdaptiveQualityAction;
   step: string;
   level: GraphicsQualityLevel;
   basePixelRatio: number;
   reason: string;
   downgradeCount: number;
+  recoveryCount: number;
+  warmupElapsedMs: number;
+  stableDurationMs: number;
+  lowFpsDurationMs: number;
+}
+
+export interface AdaptiveQualityPolicySnapshot {
+  warmupElapsedMs: number;
+  warmupRemainingMs: number;
+  isWarmingUp: boolean;
+  lowFpsDurationMs: number;
+  stableDurationMs: number;
+  cooldownRemainingMs: number;
+  downgradeCount: number;
+  recoveryCount: number;
+  lastAction: AdaptiveQualityAction | null;
+  lastDowngradeReason: string | null;
+  lastRecoveryReason: string | null;
+  lastAdaptiveReason: string | null;
+  selectionSource: AdaptiveQualitySelectionSource;
+  autoRecoveryEnabled: boolean;
+  softwareRenderer: boolean;
 }
 
 export interface AdaptiveQualityController {
-  update(deltaSeconds: number): AdaptiveQualityDowngradeEvent | null;
+  update(deltaSeconds: number): AdaptiveQualityEvent | null;
   getDowngradeCount(): number;
+  getRecoveryCount(): number;
   getLastReason(): string | null;
+  getLastDowngradeReason(): string | null;
+  getLastRecoveryReason(): string | null;
+  getSnapshot(): AdaptiveQualityPolicySnapshot;
   isExhausted(): boolean;
+}
+
+const DEFAULT_NORMAL_WARMUP_MS = 5000;
+const FRAME_SAMPLE_WINDOW = 60;
+const RECOVERY_COOLDOWN_MULTIPLIER = 2;
+
+function percentile(sorted: readonly number[], percentileValue: number) {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1)
+  );
+  return sorted[index] ?? 0;
+}
+
+function summarizeFrameWindow(frameMsSamples: readonly number[]) {
+  if (frameMsSamples.length === 0) {
+    return { medianFrameMs: 0, p95FrameMs: 0 };
+  }
+  const sorted = [...frameMsSamples].sort((a, b) => a - b);
+  return {
+    medianFrameMs: percentile(sorted, 50),
+    p95FrameMs: percentile(sorted, 95),
+  };
 }
 
 export function createAdaptiveQualityController({
@@ -37,50 +103,94 @@ export function createAdaptiveQualityController({
   getBasePixelRatio,
   setBasePixelRatio,
   fpsThreshold = 30,
-  downgradeAfterMs = 1200,
+  downgradeAfterMs = 1600,
   cooldownMs = 2500,
   minBasePixelRatio = 0.75,
+  isSoftwareRenderer = false,
+  warmupMs = isSoftwareRenderer ? 0 : DEFAULT_NORMAL_WARMUP_MS,
+  recoveryAfterMs = 8000,
+  recoveryFpsThreshold = 55,
+  recoveryP95FrameMs = 22,
+  getSelectionSource = () => 'adaptive',
+  onAction,
   onDowngrade,
 }: AdaptiveQualityControllerOptions): AdaptiveQualityController {
+  let elapsedMs = 0;
   let lowFpsDurationMs = 0;
+  let stableDurationMs = 0;
   let cooldownRemainingMs = 0;
+  let recoveryCooldownRemainingMs = 0;
   let downgradeCount = 0;
-  let lastReason: string | null = null;
+  let recoveryCount = 0;
+  let lastAction: AdaptiveQualityAction | null = null;
+  let lastDowngradeReason: string | null = null;
+  let lastRecoveryReason: string | null = null;
+  let lastAdaptiveReason: string | null = null;
   let pixelRatioStepApplied = false;
+  const frameMsSamples: number[] = [];
+
+  const getWarmupRemainingMs = () => Math.max(0, warmupMs - elapsedMs);
+  const isWarmingUp = () => getWarmupRemainingMs() > 0;
+  const autoRecoveryEnabled = () =>
+    !isSoftwareRenderer && getSelectionSource() !== 'user';
 
   const emit = (
+    action: AdaptiveQualityAction,
     step: string,
     reason: string
-  ): AdaptiveQualityDowngradeEvent => {
-    downgradeCount += 1;
-    lastReason = reason;
-    lowFpsDurationMs = 0;
-    cooldownRemainingMs = cooldownMs;
+  ): AdaptiveQualityEvent => {
+    if (action === 'downgrade') {
+      downgradeCount += 1;
+      lastDowngradeReason = reason;
+      lowFpsDurationMs = 0;
+      stableDurationMs = 0;
+      cooldownRemainingMs = cooldownMs;
+      recoveryCooldownRemainingMs = cooldownMs * RECOVERY_COOLDOWN_MULTIPLIER;
+    } else {
+      recoveryCount += 1;
+      lastRecoveryReason = reason;
+      stableDurationMs = 0;
+      lowFpsDurationMs = 0;
+      cooldownRemainingMs = cooldownMs;
+      recoveryCooldownRemainingMs = cooldownMs;
+    }
+    lastAction = action;
+    lastAdaptiveReason = reason;
     const event = {
+      action,
       step,
       level: qualityManager.getLevel(),
       basePixelRatio: getBasePixelRatio(),
       reason,
       downgradeCount,
-    };
-    onDowngrade?.(event);
+      recoveryCount,
+      warmupElapsedMs: Math.min(elapsedMs, warmupMs),
+      stableDurationMs,
+      lowFpsDurationMs,
+    } satisfies AdaptiveQualityEvent;
+    onAction?.(event);
+    if (action === 'downgrade') {
+      onDowngrade?.(event);
+    }
     return event;
   };
 
-  const downgrade = (): AdaptiveQualityDowngradeEvent | null => {
+  const downgrade = (): AdaptiveQualityEvent | null => {
     const currentLevel = qualityManager.getLevel();
     if (currentLevel === 'cinematic') {
-      qualityManager.setLevel('balanced');
+      qualityManager.setLevel('balanced', { source: 'adaptive' });
       return emit(
+        'downgrade',
         'quality-balanced',
-        'low FPS downgraded cinematic to balanced'
+        'sustained low FPS downgraded cinematic to balanced'
       );
     }
     if (currentLevel === 'balanced') {
-      qualityManager.setLevel('performance');
+      qualityManager.setLevel('performance', { source: 'adaptive' });
       return emit(
+        'downgrade',
         'quality-performance',
-        'low FPS downgraded balanced to performance'
+        'sustained low FPS downgraded balanced to performance'
       );
     }
 
@@ -90,12 +200,58 @@ export function createAdaptiveQualityController({
       setBasePixelRatio(Math.max(minBasePixelRatio, currentRatio * 0.8));
       qualityManager.setBasePixelRatio(getBasePixelRatio());
       return emit(
+        'downgrade',
         'pixel-ratio',
-        'low FPS reduced base DPR after performance preset'
+        'sustained low FPS reduced base DPR after performance preset'
       );
     }
 
     return null;
+  };
+
+  const recover = (): AdaptiveQualityEvent | null => {
+    if (!autoRecoveryEnabled() || qualityManager.getLevel() !== 'performance') {
+      return null;
+    }
+    qualityManager.setLevel('balanced', { source: 'adaptive' });
+    return emit(
+      'recover',
+      'quality-balanced',
+      'sustained stable FPS recovered performance to balanced'
+    );
+  };
+
+  const shouldDowngrade = (frameMs: number) => {
+    if (isWarmingUp()) {
+      lowFpsDurationMs = 0;
+      return false;
+    }
+    const fps = frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
+    const { medianFrameMs, p95FrameMs } = summarizeFrameWindow(frameMsSamples);
+    const thresholdFrameMs = 1000 / fpsThreshold;
+    const sustainedWindowIsLow =
+      medianFrameMs > thresholdFrameMs || p95FrameMs > thresholdFrameMs * 1.5;
+
+    if (fps >= fpsThreshold || !sustainedWindowIsLow) {
+      lowFpsDurationMs = 0;
+      return false;
+    }
+
+    lowFpsDurationMs += frameMs;
+    return lowFpsDurationMs >= downgradeAfterMs;
+  };
+
+  const shouldRecover = (frameMs: number) => {
+    const fps = frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
+    const { p95FrameMs } = summarizeFrameWindow(frameMsSamples);
+    const isStable =
+      fps >= recoveryFpsThreshold && p95FrameMs <= recoveryP95FrameMs;
+    if (!isStable || !autoRecoveryEnabled()) {
+      stableDurationMs = 0;
+      return false;
+    }
+    stableDurationMs += frameMs;
+    return stableDurationMs >= recoveryAfterMs;
   };
 
   return {
@@ -104,26 +260,63 @@ export function createAdaptiveQualityController({
         return null;
       }
       const frameMs = deltaSeconds * 1000;
+      elapsedMs += frameMs;
+      frameMsSamples.push(frameMs);
+      if (frameMsSamples.length > FRAME_SAMPLE_WINDOW) {
+        frameMsSamples.shift();
+      }
+
       if (cooldownRemainingMs > 0) {
         cooldownRemainingMs = Math.max(0, cooldownRemainingMs - frameMs);
-        return null;
       }
-      const fps = frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
-      if (fps >= fpsThreshold) {
-        lowFpsDurationMs = 0;
-        return null;
+      if (recoveryCooldownRemainingMs > 0) {
+        recoveryCooldownRemainingMs = Math.max(
+          0,
+          recoveryCooldownRemainingMs - frameMs
+        );
       }
-      lowFpsDurationMs += frameMs;
-      if (lowFpsDurationMs < downgradeAfterMs) {
-        return null;
+
+      if (cooldownRemainingMs <= 0 && shouldDowngrade(frameMs)) {
+        return downgrade();
       }
-      return downgrade();
+      if (recoveryCooldownRemainingMs <= 0 && shouldRecover(frameMs)) {
+        return recover();
+      }
+      return null;
     },
     getDowngradeCount() {
       return downgradeCount;
     },
+    getRecoveryCount() {
+      return recoveryCount;
+    },
     getLastReason() {
-      return lastReason;
+      return lastAdaptiveReason;
+    },
+    getLastDowngradeReason() {
+      return lastDowngradeReason;
+    },
+    getLastRecoveryReason() {
+      return lastRecoveryReason;
+    },
+    getSnapshot() {
+      return {
+        warmupElapsedMs: Math.min(elapsedMs, warmupMs),
+        warmupRemainingMs: getWarmupRemainingMs(),
+        isWarmingUp: isWarmingUp(),
+        lowFpsDurationMs,
+        stableDurationMs,
+        cooldownRemainingMs,
+        downgradeCount,
+        recoveryCount,
+        lastAction,
+        lastDowngradeReason,
+        lastRecoveryReason,
+        lastAdaptiveReason,
+        selectionSource: getSelectionSource(),
+        autoRecoveryEnabled: autoRecoveryEnabled(),
+        softwareRenderer: isSoftwareRenderer,
+      };
     },
     isExhausted() {
       return (

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -1,5 +1,9 @@
-import type { GraphicsQualityLevel } from '../graphics/qualityManager';
+import type {
+  GraphicsQualityLevel,
+  GraphicsQualitySelectionSource,
+} from '../graphics/qualityManager';
 
+import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
 export type PhaseName =
@@ -19,8 +23,13 @@ export interface RendererSizeSnapshot {
 
 export interface QualityStateSnapshot {
   level: GraphicsQualityLevel;
+  selectionSource: GraphicsQualitySelectionSource;
   adaptiveDowngradeCount: number;
+  adaptiveRecoveryCount: number;
   lastAdaptiveReason: string | null;
+  lastAdaptiveDowngradeReason: string | null;
+  lastAdaptiveRecoveryReason: string | null;
+  adaptivePolicy: AdaptiveQualityPolicySnapshot | null;
 }
 
 export interface FeatureStateSnapshot {

--- a/src/tests/accessibilityPresetManager.test.ts
+++ b/src/tests/accessibilityPresetManager.test.ts
@@ -21,6 +21,7 @@ function createStubGraphicsQualityManager(
       applyBaseline();
     },
     setBasePixelRatio: vi.fn(),
+    getSelectionSource: () => 'initial',
     onChange: (listener: (level: GraphicsQualityLevel) => void) => {
       listeners.add(listener);
       return () => {

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -64,6 +64,7 @@ describe('createGraphicsQualityManager', () => {
     });
 
     expect(manager.getLevel()).toBe('balanced');
+    expect(manager.getSelectionSource()).toBe('user');
     expect(renderer.getPixelRatio()).toBeCloseTo(2 * 0.85, 3);
     expect(renderer.toneMappingExposure).toBeCloseTo(1.02, 3);
     expect(bloom.enabled).toBe(true);
@@ -80,6 +81,7 @@ describe('createGraphicsQualityManager', () => {
     const unsubscribe = manager.onChange(listener);
 
     manager.setLevel('performance');
+    expect(manager.getSelectionSource()).toBe('user');
     expect(listener).toHaveBeenCalledWith('performance');
     expect(renderer.getPixelRatio()).toBeCloseTo(2 * 0.7, 3);
     expect(renderer.toneMappingExposure).toBeCloseTo(0.96, 3);
@@ -108,6 +110,37 @@ describe('createGraphicsQualityManager', () => {
     expect(listener).not.toHaveBeenCalled();
     expect(renderer.getPixelRatio()).toBeCloseTo(2, 3);
     expect(renderer.toneMappingExposure).toBeCloseTo(1.1, 3);
+  });
+
+  it('applies adaptive selections without persisting over user choices', () => {
+    const { renderer } = createRenderer();
+    const storage = {
+      getItem: vi.fn<[], string | null>().mockReturnValue(null),
+      setItem: vi.fn<[string, string], void>(),
+    };
+
+    const manager = createGraphicsQualityManager({
+      renderer,
+      basePixelRatio: 1,
+      baseBloom,
+      baseLed,
+      storage,
+    });
+
+    expect(manager.getSelectionSource()).toBe('initial');
+    manager.setLevel('performance', { source: 'adaptive' });
+
+    expect(manager.getLevel()).toBe('performance');
+    expect(manager.getSelectionSource()).toBe('adaptive');
+    expect(storage.setItem).not.toHaveBeenCalled();
+
+    manager.setLevel('balanced');
+
+    expect(manager.getSelectionSource()).toBe('user');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'danielsmith:graphics-quality-level',
+      'balanced'
+    );
   });
 
   it('handles storage failures and optional bloom/lights gracefully', () => {

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -134,6 +134,11 @@ describe('createGraphicsQualityManager', () => {
     expect(manager.getSelectionSource()).toBe('adaptive');
     expect(storage.setItem).not.toHaveBeenCalled();
 
+    manager.setLevel('performance', { source: 'adaptive' });
+
+    expect(manager.getSelectionSource()).toBe('adaptive');
+    expect(storage.setItem).not.toHaveBeenCalled();
+
     manager.setLevel('balanced');
 
     expect(manager.getSelectionSource()).toBe('user');

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -21,8 +21,35 @@ describe('performance diagnostics', () => {
       }),
       getQualityState: () => ({
         level: 'balanced',
+        selectionSource: 'adaptive',
         adaptiveDowngradeCount: 1,
-        lastAdaptiveReason: 'low FPS downgraded cinematic to balanced',
+        adaptiveRecoveryCount: 1,
+        lastAdaptiveReason:
+          'sustained stable FPS recovered performance to balanced',
+        lastAdaptiveDowngradeReason:
+          'sustained low FPS downgraded cinematic to balanced',
+        lastAdaptiveRecoveryReason:
+          'sustained stable FPS recovered performance to balanced',
+        adaptivePolicy: {
+          warmupElapsedMs: 5000,
+          warmupRemainingMs: 0,
+          isWarmingUp: false,
+          lowFpsDurationMs: 0,
+          stableDurationMs: 1200,
+          cooldownRemainingMs: 0,
+          downgradeCount: 1,
+          recoveryCount: 1,
+          lastAction: 'recover',
+          lastDowngradeReason:
+            'sustained low FPS downgraded cinematic to balanced',
+          lastRecoveryReason:
+            'sustained stable FPS recovered performance to balanced',
+          lastAdaptiveReason:
+            'sustained stable FPS recovered performance to balanced',
+          selectionSource: 'adaptive',
+          autoRecoveryEnabled: true,
+          softwareRenderer: false,
+        },
       }),
       getFeatureState: () => ({
         bloomEnabled: true,
@@ -51,6 +78,13 @@ describe('performance diagnostics', () => {
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
+    expect(snapshot.quality.selectionSource).toBe('adaptive');
+    expect(snapshot.quality.adaptiveRecoveryCount).toBe(1);
+    expect(snapshot.quality.adaptivePolicy).toMatchObject({
+      isWarmingUp: false,
+      lastAction: 'recover',
+      autoRecoveryEnabled: true,
+    });
     expect(snapshot.phases.mainRender.sampleCount).toBe(2);
     expect(snapshot.phases.mirror.averageMs).toBe(4);
     expect(snapshot.phases.avatarIkAudio.averageMs).toBe(2);
@@ -74,8 +108,13 @@ describe('performance diagnostics', () => {
       }),
       getQualityState: () => ({
         level: 'balanced',
+        selectionSource: 'initial',
         adaptiveDowngradeCount: 0,
+        adaptiveRecoveryCount: 0,
         lastAdaptiveReason: null,
+        lastAdaptiveDowngradeReason: null,
+        lastAdaptiveRecoveryReason: null,
+        adaptivePolicy: null,
       }),
       getFeatureState: () => ({
         bloomEnabled: false,

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { GraphicsQualityLevel } from '../scene/graphics/qualityManager';
-import { createAdaptiveQualityController } from '../scene/performance/adaptiveQuality';
+import {
+  createAdaptiveQualityController,
+  type AdaptiveQualitySelectionSource,
+} from '../scene/performance/adaptiveQuality';
 import {
   clampDevicePixelRatio,
   getQualityFeaturePolicy,
@@ -9,6 +12,63 @@ import {
   resolveResizedBasePixelRatio,
 } from '../scene/performance/qualityPolicy';
 import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
+
+function createPolicyHarness({
+  level = 'balanced',
+  basePixelRatio = 1.25,
+  selectionSource = 'adaptive',
+  isSoftwareRenderer = false,
+}: {
+  level?: GraphicsQualityLevel;
+  basePixelRatio?: number;
+  selectionSource?: AdaptiveQualitySelectionSource;
+  isSoftwareRenderer?: boolean;
+} = {}) {
+  let currentLevel = level;
+  let currentBasePixelRatio = basePixelRatio;
+  let currentSelectionSource = selectionSource;
+  const onAction = vi.fn();
+  const controller = createAdaptiveQualityController({
+    qualityManager: {
+      getLevel: () => currentLevel,
+      setLevel: (next, options = {}) => {
+        currentLevel = next;
+        currentSelectionSource = options.source ?? 'user';
+      },
+      setBasePixelRatio: (next) => {
+        currentBasePixelRatio = next;
+      },
+    },
+    getBasePixelRatio: () => currentBasePixelRatio,
+    setBasePixelRatio: (next) => {
+      currentBasePixelRatio = next;
+    },
+    getSelectionSource: () => currentSelectionSource,
+    isSoftwareRenderer,
+    cooldownMs: 0,
+    downgradeAfterMs: 1000,
+    warmupMs: isSoftwareRenderer ? 0 : 3000,
+    recoveryAfterMs: 3000,
+    recoveryFpsThreshold: 55,
+    recoveryP95FrameMs: 22,
+    onAction,
+  });
+
+  return {
+    controller,
+    onAction,
+    get level() {
+      return currentLevel;
+    },
+    get basePixelRatio() {
+      return currentBasePixelRatio;
+    },
+    setSelectionSource(next: AdaptiveQualitySelectionSource) {
+      currentSelectionSource = next;
+    },
+  };
+}
+
 describe('immersive performance optimization policy', () => {
   it('classifies known software renderers as risky', () => {
     expect(
@@ -60,38 +120,106 @@ describe('immersive performance optimization policy', () => {
     expect(resolveResizedBasePixelRatio(0.9, 1.25, 1)).toBe(0.9);
   });
 
-  it('downgrades quality once per cooldown without flapping back upward', () => {
-    let level: GraphicsQualityLevel = 'cinematic';
-    let basePixelRatio = 1.25;
-    const onDowngrade = vi.fn();
-    const controller = createAdaptiveQualityController({
-      qualityManager: {
-        getLevel: () => level,
-        setLevel: (next) => {
-          level = next;
-        },
-        setBasePixelRatio: (next) => {
-          basePixelRatio = next;
-        },
-      },
-      getBasePixelRatio: () => basePixelRatio,
-      setBasePixelRatio: (next) => {
-        basePixelRatio = next;
-      },
-      cooldownMs: 0,
-      downgradeAfterMs: 1000,
-      onDowngrade,
+  it('does not downgrade normal renderers for transient startup warmup FPS', () => {
+    const harness = createPolicyHarness({ level: 'balanced' });
+
+    for (let index = 0; index < 6; index += 1) {
+      expect(harness.controller.update(0.4)).toBeNull();
+    }
+
+    expect(harness.level).toBe('balanced');
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      isWarmingUp: true,
+      downgradeCount: 0,
+    });
+  });
+
+  it('downgrades normal renderers after sustained low FPS beyond warmup', () => {
+    const harness = createPolicyHarness({ level: 'cinematic' });
+
+    for (let index = 0; index < 9; index += 1) {
+      harness.controller.update(0.4);
+    }
+    const event = harness.controller.update(0.4);
+
+    expect(event?.step).toBe('quality-balanced');
+    expect(event?.reason).toContain('sustained low FPS');
+    expect(harness.level).toBe('balanced');
+  });
+
+  it('recovers normal hardware from performance to balanced after stable FPS', () => {
+    const harness = createPolicyHarness({ level: 'performance' });
+
+    let event = null;
+    for (let index = 0; index < 380; index += 1) {
+      event = harness.controller.update(1 / 60) ?? event;
+    }
+
+    expect(event?.action).toBe('recover');
+    expect(event?.step).toBe('quality-balanced');
+    expect(harness.level).toBe('balanced');
+    expect(harness.controller.getRecoveryCount()).toBe(1);
+  });
+
+  it('keeps software renderers conservative and does not auto-upshift', () => {
+    const harness = createPolicyHarness({
+      level: 'performance',
+      isSoftwareRenderer: true,
     });
 
-    expect(controller.update(0.5)).toBeNull();
-    expect(controller.update(0.6)?.step).toBe('quality-balanced');
-    expect(level).toBe('balanced');
-    expect(controller.update(1.1)?.step).toBe('quality-performance');
-    expect(level).toBe('performance');
-    expect(controller.update(1.1)?.step).toBe('pixel-ratio');
-    expect(basePixelRatio).toBeCloseTo(1);
-    expect(controller.update(1.1)).toBeNull();
-    expect(controller.isExhausted()).toBe(true);
-    expect(onDowngrade).toHaveBeenCalledTimes(3);
+    for (let index = 0; index < 240; index += 1) {
+      harness.controller.update(1 / 60);
+    }
+
+    expect(harness.level).toBe('performance');
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      autoRecoveryEnabled: false,
+      softwareRenderer: true,
+      recoveryCount: 0,
+    });
+  });
+
+  it('does not override user-selected performance with auto-upshift', () => {
+    const harness = createPolicyHarness({
+      level: 'performance',
+      selectionSource: 'user',
+    });
+
+    for (let index = 0; index < 240; index += 1) {
+      harness.controller.update(1 / 60);
+    }
+
+    expect(harness.level).toBe('performance');
+    expect(harness.controller.getSnapshot().autoRecoveryEnabled).toBe(false);
+  });
+
+  it('requires hysteresis so boundary frames do not oscillate quality', () => {
+    const harness = createPolicyHarness({ level: 'balanced' });
+
+    for (let index = 0; index < 12; index += 1) {
+      harness.controller.update(index % 2 === 0 ? 1 / 29 : 1 / 60);
+    }
+
+    expect(harness.level).toBe('balanced');
+    expect(harness.controller.getDowngradeCount()).toBe(0);
+    expect(harness.onAction).not.toHaveBeenCalled();
+  });
+
+  it('downgrades quality and DPR once adaptive steps are exhausted', () => {
+    const harness = createPolicyHarness({
+      level: 'cinematic',
+      isSoftwareRenderer: true,
+    });
+
+    expect(harness.controller.update(0.5)).toBeNull();
+    expect(harness.controller.update(0.6)?.step).toBe('quality-balanced');
+    expect(harness.level).toBe('balanced');
+    expect(harness.controller.update(1.1)?.step).toBe('quality-performance');
+    expect(harness.level).toBe('performance');
+    expect(harness.controller.update(1.1)?.step).toBe('pixel-ratio');
+    expect(harness.basePixelRatio).toBeCloseTo(1);
+    expect(harness.controller.update(1.1)).toBeNull();
+    expect(harness.controller.isExhausted()).toBe(true);
+    expect(harness.onAction).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -63,6 +63,9 @@ function createPolicyHarness({
     get basePixelRatio() {
       return currentBasePixelRatio;
     },
+    setLevel(next: GraphicsQualityLevel) {
+      currentLevel = next;
+    },
     setSelectionSource(next: AdaptiveQualitySelectionSource) {
       currentSelectionSource = next;
     },
@@ -159,6 +162,29 @@ describe('immersive performance optimization policy', () => {
     expect(event?.step).toBe('quality-balanced');
     expect(harness.level).toBe('balanced');
     expect(harness.controller.getRecoveryCount()).toBe(1);
+  });
+
+  it('starts recovery hysteresis fresh after entering performance mode', () => {
+    const harness = createPolicyHarness({ level: 'balanced' });
+
+    for (let index = 0; index < 190; index += 1) {
+      harness.controller.update(1 / 60);
+    }
+
+    expect(harness.controller.getSnapshot().stableDurationMs).toBe(0);
+
+    harness.setLevel('performance');
+
+    expect(harness.controller.update(1 / 60)).toBeNull();
+    expect(harness.level).toBe('performance');
+
+    let event = null;
+    for (let index = 0; index < 180; index += 1) {
+      event = harness.controller.update(1 / 60) ?? event;
+    }
+
+    expect(event?.action).toBe('recover');
+    expect(harness.level).toBe('balanced');
   });
 
   it('keeps software renderers conservative and does not auto-upshift', () => {

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -164,26 +164,50 @@ describe('immersive performance optimization policy', () => {
     expect(harness.controller.getRecoveryCount()).toBe(1);
   });
 
-  it('starts recovery hysteresis fresh after entering performance mode', () => {
+  it('does not bank recovery time while balanced or cinematic', () => {
+    const balancedHarness = createPolicyHarness({ level: 'balanced' });
+    const cinematicHarness = createPolicyHarness({ level: 'cinematic' });
+
+    for (let index = 0; index < 240; index += 1) {
+      balancedHarness.controller.update(1 / 60);
+      cinematicHarness.controller.update(1 / 60);
+    }
+
+    expect(balancedHarness.controller.getSnapshot().stableDurationMs).toBe(0);
+    expect(cinematicHarness.controller.getSnapshot().stableDurationMs).toBe(0);
+  });
+
+  it('starts recovery hysteresis fresh after a balanced to performance downgrade', () => {
     const harness = createPolicyHarness({ level: 'balanced' });
 
-    for (let index = 0; index < 190; index += 1) {
+    for (let index = 0; index < 240; index += 1) {
       harness.controller.update(1 / 60);
     }
 
     expect(harness.controller.getSnapshot().stableDurationMs).toBe(0);
 
-    harness.setLevel('performance');
-
-    expect(harness.controller.update(1 / 60)).toBeNull();
-    expect(harness.level).toBe('performance');
-
-    let event = null;
-    for (let index = 0; index < 180; index += 1) {
-      event = harness.controller.update(1 / 60) ?? event;
+    let downgradeEvent = null;
+    for (let index = 0; index < 6; index += 1) {
+      downgradeEvent = harness.controller.update(0.4) ?? downgradeEvent;
     }
 
-    expect(event?.action).toBe('recover');
+    expect(downgradeEvent?.step).toBe('quality-performance');
+    expect(harness.level).toBe('performance');
+    expect(harness.controller.getSnapshot().stableDurationMs).toBe(0);
+
+    let recoveryEvent = null;
+    for (let index = 0; index < 179; index += 1) {
+      recoveryEvent = harness.controller.update(1 / 60) ?? recoveryEvent;
+    }
+
+    expect(recoveryEvent).toBeNull();
+    expect(harness.level).toBe('performance');
+
+    for (let index = 0; index < 180; index += 1) {
+      recoveryEvent = harness.controller.update(1 / 60) ?? recoveryEvent;
+    }
+
+    expect(recoveryEvent?.action).toBe('recover');
     expect(harness.level).toBe('balanced');
   });
 
@@ -216,7 +240,36 @@ describe('immersive performance optimization policy', () => {
     }
 
     expect(harness.level).toBe('performance');
-    expect(harness.controller.getSnapshot().autoRecoveryEnabled).toBe(false);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      autoRecoveryEnabled: false,
+      stableDurationMs: 0,
+    });
+  });
+
+  it('clears accrued recovery when the selection source switches to user', () => {
+    const harness = createPolicyHarness({ level: 'performance' });
+
+    for (let index = 0; index < 90; index += 1) {
+      harness.controller.update(1 / 60);
+    }
+
+    expect(harness.controller.getSnapshot().stableDurationMs).toBeGreaterThan(
+      0
+    );
+
+    harness.setSelectionSource('user');
+    expect(harness.controller.update(1 / 60)).toBeNull();
+
+    for (let index = 0; index < 240; index += 1) {
+      harness.controller.update(1 / 60);
+    }
+
+    expect(harness.level).toBe('performance');
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      autoRecoveryEnabled: false,
+      stableDurationMs: 0,
+      recoveryCount: 0,
+    });
   });
 
   it('requires hysteresis so boundary frames do not oscillate quality', () => {


### PR DESCRIPTION
### Motivation
- Prevent capable hardware from being permanently downgraded to `performance` due to transient startup/shader/asset warmup spikes while keeping software renderers conservative.
- Surface adaptive decisions and policy state in diagnostics so staging can distinguish warmup noise from sustained overload.

### Description
- Add a warmup grace window, sustained low‑FPS hysteresis, and a recovery path that can upshift `performance` → `balanced` on stable hardware while disabling auto-recovery for software/dangerous renderers; implemented in `src/scene/performance/adaptiveQuality.ts`.
- Track quality selection source (`initial|adaptive|user`) and avoid persisting adaptive selections so manual user choices are not silently overridden; changes in `src/scene/graphics/qualityManager.ts`.
- Expose adaptive metrics, warmup/recovery snapshot, last adaptive action/reasons, and selection source through the diagnostics API wired into `window.portfolio.performance.getSnapshot()` and integrated in `src/main.ts` and `src/scene/performance/performanceDiagnostics.ts`.
- Update tests and docs: expand unit tests covering warmup suppression, sustained downgrade, recovery, software-renderer conservatism, user-selected behavior and no-flap rules (`src/tests/performanceOptimization.test.ts`, `src/tests/performanceDiagnostics.test.ts`, `src/tests/graphicsQualityManager.test.ts`), update Playwright spec shape (`playwright/immersive-performance.spec.ts`), and record the change in performance docs/outage notes.

### Testing
- Ran formatting and linting: `npm run format:write` (passed) and `npm run lint` (passed).
- Unit suite: `npm run test:ci` completed successfully with all Vitest suites passing (`860` tests in the run reported as passing in CI output for the workspace run).
- E2E: installed Playwright browsers and deps (`npx playwright install chromium-headless-shell`, `npx playwright install-deps chromium-headless-shell`), then ran `npm run test:e2e -- --grep "adaptive|performance|immersive"`; tests passed (13 passed, 2 skipped due to software WebGL classification in the CI environment).
- Smoke & docs: `npm run docs:check` (passed) and `npm run smoke` (passed build + smoke checks).
- Type-check: `npm run typecheck` still fails due to unrelated, repo-wide TypeScript issues outside this change (i18n/POI imports, `PoiId` typing, and some test/mock typings), so typecheck remains red independent of the adaptive-quality changes.

Notes: Playwright required installing headless shell and host deps in the ephemeral environment before E2E succeeded; all changes were kept minimal to the adaptive-quality path, diagnostics, tests, and documentation as scoped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8719e5d0832fba5810fd8a5f6c11)