### PR TITLE
⚡ : – tune adaptive quality warmup

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -81,3 +81,22 @@ and the Vitest assertions when measurable changes land.
   overflow stays within a 1 px tolerance.
 - **Validation notes** – Run `npm run test:e2e -- --grep "text fallback"` alongside the standard
   format, lint, typecheck, Vitest, docs, and smoke checks before promoting the fallback layout.
+
+### 2026-05-30 adaptive quality warmup/recovery
+
+- **Symptoms** – Staging diagnostics showed a hardware-accelerated NVIDIA RTX path settling near
+  60 FPS with no monotonic memory growth, but adaptive quality could still demote the normal
+  renderer from balanced to performance after startup spikes.
+- **Impact** – Capable hardware could remain in the low-cost performance preset for the rest of
+  the session even after shader and asset warmup ended. The separate Microsoft Basic Render
+  Driver / software-renderer crash path remains intentionally conservative and needs dedicated
+  crash hardening.
+- **Root cause** – Adaptive quality treated short startup frame-time spikes the same as steady
+  overload and had no recovery path once performance mode was selected.
+- **Corrective action** – Normal renderers now get a bounded warmup grace period, downgrade only
+  after sustained low median/p95 frame windows, and recover from performance to balanced after a
+  sustained stable window. Software renderers keep the performance-first policy and do not
+  auto-upshift unless future explicit user controls choose otherwise.
+- **Diagnostics** – `window.portfolio.performance.getSnapshot().quality` now exposes adaptive
+  warmup, hysteresis, recovery counts, last action/reasons, source (`initial`, `manual`, or
+  `adaptive`), and renderer risk state via the nested `adaptivePolicy` payload.

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -24,6 +24,18 @@ interface PerformanceSnapshot {
   quality: {
     level: 'cinematic' | 'balanced' | 'performance';
     adaptiveDowngradeCount: number;
+    adaptiveRecoveryCount: number;
+    lastAdaptiveAction: 'downgrade' | 'recovery' | null;
+    lastAdaptiveReason: string | null;
+    adaptivePolicy: {
+      isWarmingUp: boolean;
+      warmupElapsedMs: number;
+      warmupDurationMs: number;
+      isRecoveryAllowed: boolean;
+      isSoftwareRenderer: boolean;
+      lastAdaptiveAction: 'downgrade' | 'recovery' | null;
+    } | null;
+    source: 'initial' | 'manual' | 'adaptive';
   };
   features: {
     bloomEnabled: boolean;
@@ -181,6 +193,14 @@ test.describe('immersive performance diagnostics', () => {
       expect(snapshot.lastFailoverReason).toBeNull();
       expect(snapshot.rendererSize.pixelRatio).toBeLessThanOrEqual(1.25);
       expect(snapshot.quality.level).not.toBe('cinematic');
+      expect(snapshot.quality.adaptivePolicy).toBeTruthy();
+      expect(
+        snapshot.quality.adaptivePolicy?.warmupDurationMs
+      ).toBeGreaterThanOrEqual(0);
+      expect(snapshot.quality.adaptivePolicy?.isSoftwareRenderer).toBe(
+        snapshot.renderer.isSoftwareRenderer
+      );
+      expect(snapshot.quality.adaptiveRecoveryCount).toBeGreaterThanOrEqual(0);
       expect(snapshot.features.mirrorRenderTargetSize).toBeLessThanOrEqual(320);
       if (snapshot.quality.level === 'performance') {
         expect(snapshot.features.bloomEnabled).toBe(false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -707,6 +707,7 @@ function initializeImmersiveScene(
   let ambientCaptionBridge: AmbientCaptionBridge | null = null;
   let graphicsQualityManager: GraphicsQualityManager | null = null;
   let graphicsQualityControl: GraphicsQualityControlHandle | null = null;
+  let graphicsQualitySource: 'initial' | 'manual' | 'adaptive' = 'initial';
   let adaptiveQualityController: ReturnType<
     typeof createAdaptiveQualityController
   > | null = null;
@@ -3080,6 +3081,10 @@ function initializeImmersiveScene(
     },
     storage: qualityStorage,
   });
+  graphicsQualitySource =
+    graphicsQualityManager.getInitialSource() === 'stored'
+      ? 'manual'
+      : 'initial';
   ledAnimator?.captureBaseline();
   environmentLightAnimator?.captureBaseline();
 
@@ -3091,8 +3096,17 @@ function initializeImmersiveScene(
       basePixelRatio = value;
     },
     fpsThreshold: PERFORMANCE_FAILOVER_FPS_THRESHOLD,
+    isSoftwareRenderer: rendererInfo.isSoftwareRenderer,
+    hasManualQualitySelection: () => graphicsQualitySource === 'manual',
     onDowngrade: (event) => {
+      graphicsQualitySource = 'adaptive';
       console.info('[performance] adaptive quality downgrade', event);
+      performanceFailover.resetLowFpsSamples();
+      graphicsQualityControl?.refresh();
+    },
+    onRecover: (event) => {
+      graphicsQualitySource = 'adaptive';
+      console.info('[performance] adaptive quality recovery', event);
       performanceFailover.resetLowFpsSamples();
       graphicsQualityControl?.refresh();
     },
@@ -3248,6 +3262,7 @@ function initializeImmersiveScene(
     getActiveLevel: () =>
       graphicsQualityManager?.getLevel() ?? GRAPHICS_QUALITY_PRESETS[0].id,
     setActiveLevel: (level) => {
+      graphicsQualitySource = 'manual';
       graphicsQualityManager?.setLevel(level);
     },
   });
@@ -3302,7 +3317,15 @@ function initializeImmersiveScene(
       level: graphicsQualityManager!.getLevel(),
       adaptiveDowngradeCount:
         adaptiveQualityController?.getDowngradeCount() ?? 0,
+      adaptiveRecoveryCount: adaptiveQualityController?.getRecoveryCount() ?? 0,
+      lastAdaptiveAction: adaptiveQualityController?.getLastAction() ?? null,
       lastAdaptiveReason: adaptiveQualityController?.getLastReason() ?? null,
+      lastAdaptiveDowngradeReason:
+        adaptiveQualityController?.getLastDowngradeReason() ?? null,
+      lastAdaptiveRecoveryReason:
+        adaptiveQualityController?.getLastRecoveryReason() ?? null,
+      adaptivePolicy: adaptiveQualityController?.getSnapshot() ?? null,
+      source: graphicsQualitySource,
     }),
     getFeatureState: () => {
       const mirrorState = selfieMirror?.getRenderState();
@@ -4057,8 +4080,8 @@ function initializeImmersiveScene(
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);
-      const adaptiveDowngrade = adaptiveQualityController?.update(delta);
-      if (adaptiveDowngrade) {
+      const adaptiveAction = adaptiveQualityController?.update(delta);
+      if (adaptiveAction) {
         applyFeaturePolicy();
       }
       performanceFailover.update(delta);

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -116,8 +116,11 @@ export interface GraphicsQualityManagerOptions {
   preferInitialLevel?: boolean;
 }
 
+export type GraphicsQualityInitialSource = 'initial' | 'stored';
+
 export interface GraphicsQualityManager {
   getLevel(): GraphicsQualityLevel;
+  getInitialSource(): GraphicsQualityInitialSource;
   setLevel(level: GraphicsQualityLevel): void;
   refresh(): void;
   setBasePixelRatio(pixelRatio: number): void;
@@ -179,11 +182,13 @@ export function createGraphicsQualityManager({
   let currentLevel: GraphicsQualityLevel = isGraphicsQualityLevel(initialLevel)
     ? initialLevel
     : 'balanced';
+  let initialSource: GraphicsQualityInitialSource = 'initial';
   if (!preferInitialLevel && storage?.getItem) {
     try {
       const stored = storage.getItem(storageKey);
       if (isGraphicsQualityLevel(stored)) {
         currentLevel = stored;
+        initialSource = 'stored';
       }
     } catch (error) {
       console.warn('Failed to read persisted graphics quality level:', error);
@@ -247,6 +252,9 @@ export function createGraphicsQualityManager({
   return {
     getLevel() {
       return currentLevel;
+    },
+    getInitialSource() {
+      return initialSource;
     },
     setLevel(level) {
       if (!isGraphicsQualityLevel(level)) {

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -1,5 +1,7 @@
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
+export type AdaptiveQualityAction = 'downgrade' | 'recovery';
+
 export interface AdaptiveQualityManagerLike {
   getLevel(): GraphicsQualityLevel;
   setLevel(level: GraphicsQualityLevel): void;
@@ -11,25 +13,98 @@ export interface AdaptiveQualityControllerOptions {
   getBasePixelRatio: () => number;
   setBasePixelRatio: (value: number) => void;
   fpsThreshold?: number;
+  recoveryFpsThreshold?: number;
   downgradeAfterMs?: number;
+  stableRecoveryAfterMs?: number;
+  warmupMs?: number;
+  sampleWindowMs?: number;
   cooldownMs?: number;
   minBasePixelRatio?: number;
-  onDowngrade?: (event: AdaptiveQualityDowngradeEvent) => void;
+  isSoftwareRenderer?: boolean;
+  hasManualQualitySelection?: () => boolean;
+  onDowngrade?: (event: AdaptiveQualityEvent) => void;
+  onRecover?: (event: AdaptiveQualityEvent) => void;
 }
 
-export interface AdaptiveQualityDowngradeEvent {
+export interface AdaptiveQualityEvent {
+  action: AdaptiveQualityAction;
   step: string;
   level: GraphicsQualityLevel;
   basePixelRatio: number;
   reason: string;
   downgradeCount: number;
+  recoveryCount: number;
+  warmupElapsedMs: number;
+}
+
+export type AdaptiveQualityDowngradeEvent = AdaptiveQualityEvent;
+
+export interface AdaptiveQualityPolicySnapshot {
+  warmupElapsedMs: number;
+  warmupDurationMs: number;
+  isWarmingUp: boolean;
+  lowFpsDurationMs: number;
+  stableDurationMs: number;
+  cooldownRemainingMs: number;
+  downgradeCount: number;
+  recoveryCount: number;
+  lastAdaptiveAction: AdaptiveQualityAction | null;
+  lastDowngradeReason: string | null;
+  lastRecoveryReason: string | null;
+  lastAdaptiveReason: string | null;
+  isRecoveryAllowed: boolean;
+  isSoftwareRenderer: boolean;
+  sampleCount: number;
+  medianFps: number;
+  p95FrameMs: number;
 }
 
 export interface AdaptiveQualityController {
-  update(deltaSeconds: number): AdaptiveQualityDowngradeEvent | null;
+  update(deltaSeconds: number): AdaptiveQualityEvent | null;
   getDowngradeCount(): number;
+  getRecoveryCount(): number;
   getLastReason(): string | null;
+  getLastDowngradeReason(): string | null;
+  getLastRecoveryReason(): string | null;
+  getLastAction(): AdaptiveQualityAction | null;
+  getSnapshot(): AdaptiveQualityPolicySnapshot;
   isExhausted(): boolean;
+}
+
+interface FrameSample {
+  elapsedMs: number;
+  frameMs: number;
+}
+
+function percentile(
+  sorted: readonly number[],
+  percentileValue: number
+): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1)
+  );
+  return sorted[index] ?? 0;
+}
+
+function summarizeFrameWindow(samples: readonly FrameSample[]) {
+  if (samples.length === 0) {
+    return { averageFps: 0, medianFps: 0, p95FrameMs: 0 };
+  }
+  const frameMsValues = samples.map((sample) => sample.frameMs);
+  const sorted = [...frameMsValues].sort((a, b) => a - b);
+  const averageMs =
+    frameMsValues.reduce((total, value) => total + value, 0) /
+    frameMsValues.length;
+  const medianMs = percentile(sorted, 50);
+  return {
+    averageFps: averageMs > 0 ? 1000 / averageMs : 0,
+    medianFps: medianMs > 0 ? 1000 / medianMs : 0,
+    p95FrameMs: percentile(sorted, 95),
+  };
 }
 
 export function createAdaptiveQualityController({
@@ -37,50 +112,83 @@ export function createAdaptiveQualityController({
   getBasePixelRatio,
   setBasePixelRatio,
   fpsThreshold = 30,
-  downgradeAfterMs = 1200,
-  cooldownMs = 2500,
+  recoveryFpsThreshold = 55,
+  downgradeAfterMs = 1800,
+  stableRecoveryAfterMs = 8000,
+  warmupMs,
+  sampleWindowMs = 2400,
+  cooldownMs = 3500,
   minBasePixelRatio = 0.75,
+  isSoftwareRenderer = false,
+  hasManualQualitySelection = () => false,
   onDowngrade,
+  onRecover,
 }: AdaptiveQualityControllerOptions): AdaptiveQualityController {
+  const effectiveWarmupMs = warmupMs ?? (isSoftwareRenderer ? 0 : 5000);
+  let elapsedMs = 0;
   let lowFpsDurationMs = 0;
+  let stableDurationMs = 0;
   let cooldownRemainingMs = 0;
   let downgradeCount = 0;
-  let lastReason: string | null = null;
+  let recoveryCount = 0;
+  let lastAdaptiveReason: string | null = null;
+  let lastDowngradeReason: string | null = null;
+  let lastRecoveryReason: string | null = null;
+  let lastAdaptiveAction: AdaptiveQualityAction | null = null;
   let pixelRatioStepApplied = false;
+  const frameSamples: FrameSample[] = [];
 
   const emit = (
+    action: AdaptiveQualityAction,
     step: string,
     reason: string
-  ): AdaptiveQualityDowngradeEvent => {
-    downgradeCount += 1;
-    lastReason = reason;
+  ): AdaptiveQualityEvent => {
+    if (action === 'downgrade') {
+      downgradeCount += 1;
+      lastDowngradeReason = reason;
+    } else {
+      recoveryCount += 1;
+      lastRecoveryReason = reason;
+    }
+    lastAdaptiveAction = action;
+    lastAdaptiveReason = reason;
     lowFpsDurationMs = 0;
+    stableDurationMs = 0;
     cooldownRemainingMs = cooldownMs;
     const event = {
+      action,
       step,
       level: qualityManager.getLevel(),
       basePixelRatio: getBasePixelRatio(),
       reason,
       downgradeCount,
+      recoveryCount,
+      warmupElapsedMs: Math.min(elapsedMs, effectiveWarmupMs),
     };
-    onDowngrade?.(event);
+    if (action === 'downgrade') {
+      onDowngrade?.(event);
+    } else {
+      onRecover?.(event);
+    }
     return event;
   };
 
-  const downgrade = (): AdaptiveQualityDowngradeEvent | null => {
+  const downgrade = (): AdaptiveQualityEvent | null => {
     const currentLevel = qualityManager.getLevel();
     if (currentLevel === 'cinematic') {
       qualityManager.setLevel('balanced');
       return emit(
+        'downgrade',
         'quality-balanced',
-        'low FPS downgraded cinematic to balanced'
+        'sustained low FPS downgraded cinematic to balanced'
       );
     }
     if (currentLevel === 'balanced') {
       qualityManager.setLevel('performance');
       return emit(
+        'downgrade',
         'quality-performance',
-        'low FPS downgraded balanced to performance'
+        'sustained low FPS downgraded balanced to performance'
       );
     }
 
@@ -90,30 +198,97 @@ export function createAdaptiveQualityController({
       setBasePixelRatio(Math.max(minBasePixelRatio, currentRatio * 0.8));
       qualityManager.setBasePixelRatio(getBasePixelRatio());
       return emit(
+        'downgrade',
         'pixel-ratio',
-        'low FPS reduced base DPR after performance preset'
+        'sustained low FPS reduced base DPR after performance preset'
       );
     }
 
     return null;
   };
 
-  return {
+  const recover = (): AdaptiveQualityEvent | null => {
+    if (isSoftwareRenderer || hasManualQualitySelection()) {
+      return null;
+    }
+    if (qualityManager.getLevel() !== 'performance') {
+      return null;
+    }
+    qualityManager.setLevel('balanced');
+    return emit(
+      'recovery',
+      'quality-balanced',
+      'sustained stable FPS recovered performance to balanced'
+    );
+  };
+
+  const updateSamples = (frameMs: number) => {
+    frameSamples.push({ elapsedMs, frameMs });
+    const oldestAllowedMs = elapsedMs - sampleWindowMs;
+    while (
+      frameSamples.length > 0 &&
+      (frameSamples[0]?.elapsedMs ?? 0) < oldestAllowedMs
+    ) {
+      frameSamples.shift();
+    }
+  };
+
+  const controller: AdaptiveQualityController = {
     update(deltaSeconds: number) {
       if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
         return null;
       }
       const frameMs = deltaSeconds * 1000;
+      elapsedMs += frameMs;
+      updateSamples(frameMs);
+
       if (cooldownRemainingMs > 0) {
         cooldownRemainingMs = Math.max(0, cooldownRemainingMs - frameMs);
         return null;
       }
-      const fps = frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
-      if (fps >= fpsThreshold) {
+
+      const summary = summarizeFrameWindow(frameSamples);
+      const currentFps =
+        frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
+      const hasEnoughSamples = frameSamples.length >= 8;
+      const lowFrameBudgetMs = 1000 / fpsThreshold;
+      const lowWindow =
+        hasEnoughSamples &&
+        currentFps < fpsThreshold &&
+        (summary.medianFps < fpsThreshold ||
+          (summary.p95FrameMs > lowFrameBudgetMs * 1.4 &&
+            summary.averageFps < fpsThreshold * 1.15));
+      const stableFrameBudgetMs = 1000 / recoveryFpsThreshold;
+      const stableWindow =
+        hasEnoughSamples &&
+        summary.medianFps >= recoveryFpsThreshold &&
+        summary.averageFps >= recoveryFpsThreshold &&
+        summary.p95FrameMs <= stableFrameBudgetMs * 1.25 &&
+        currentFps >= recoveryFpsThreshold * 0.9;
+
+      if (stableWindow) {
+        stableDurationMs += frameMs;
+      } else {
+        stableDurationMs = 0;
+      }
+
+      if (lowWindow) {
+        lowFpsDurationMs += frameMs;
+      } else {
         lowFpsDurationMs = 0;
+      }
+
+      if (
+        stableDurationMs >= stableRecoveryAfterMs &&
+        qualityManager.getLevel() === 'performance'
+      ) {
+        return recover();
+      }
+
+      if (elapsedMs < effectiveWarmupMs) {
         return null;
       }
-      lowFpsDurationMs += frameMs;
+
       if (lowFpsDurationMs < downgradeAfterMs) {
         return null;
       }
@@ -122,8 +297,42 @@ export function createAdaptiveQualityController({
     getDowngradeCount() {
       return downgradeCount;
     },
+    getRecoveryCount() {
+      return recoveryCount;
+    },
     getLastReason() {
-      return lastReason;
+      return lastAdaptiveReason;
+    },
+    getLastDowngradeReason() {
+      return lastDowngradeReason;
+    },
+    getLastRecoveryReason() {
+      return lastRecoveryReason;
+    },
+    getLastAction() {
+      return lastAdaptiveAction;
+    },
+    getSnapshot() {
+      const summary = summarizeFrameWindow(frameSamples);
+      return {
+        warmupElapsedMs: Math.min(elapsedMs, effectiveWarmupMs),
+        warmupDurationMs: effectiveWarmupMs,
+        isWarmingUp: elapsedMs < effectiveWarmupMs,
+        lowFpsDurationMs,
+        stableDurationMs,
+        cooldownRemainingMs,
+        downgradeCount,
+        recoveryCount,
+        lastAdaptiveAction,
+        lastDowngradeReason,
+        lastRecoveryReason,
+        lastAdaptiveReason,
+        isRecoveryAllowed: !isSoftwareRenderer && !hasManualQualitySelection(),
+        isSoftwareRenderer,
+        sampleCount: frameSamples.length,
+        medianFps: summary.medianFps,
+        p95FrameMs: summary.p95FrameMs,
+      };
     },
     isExhausted() {
       return (
@@ -131,4 +340,6 @@ export function createAdaptiveQualityController({
       );
     },
   };
+
+  return controller;
 }

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -1,5 +1,6 @@
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
+import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
 export type PhaseName =
@@ -20,7 +21,13 @@ export interface RendererSizeSnapshot {
 export interface QualityStateSnapshot {
   level: GraphicsQualityLevel;
   adaptiveDowngradeCount: number;
+  adaptiveRecoveryCount: number;
+  lastAdaptiveAction: 'downgrade' | 'recovery' | null;
   lastAdaptiveReason: string | null;
+  lastAdaptiveDowngradeReason: string | null;
+  lastAdaptiveRecoveryReason: string | null;
+  adaptivePolicy: AdaptiveQualityPolicySnapshot | null;
+  source: 'initial' | 'manual' | 'adaptive';
 }
 
 export interface FeatureStateSnapshot {

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -64,6 +64,7 @@ describe('createGraphicsQualityManager', () => {
     });
 
     expect(manager.getLevel()).toBe('balanced');
+    expect(manager.getInitialSource()).toBe('stored');
     expect(renderer.getPixelRatio()).toBeCloseTo(2 * 0.85, 3);
     expect(renderer.toneMappingExposure).toBeCloseTo(1.02, 3);
     expect(bloom.enabled).toBe(true);
@@ -131,6 +132,7 @@ describe('createGraphicsQualityManager', () => {
     });
 
     expect(manager.getLevel()).toBe('balanced');
+    expect(manager.getInitialSource()).toBe('initial');
     expect(renderer.getPixelRatio()).toBeCloseTo(0.85, 3);
 
     manager.setLevel('balanced');

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -22,7 +22,37 @@ describe('performance diagnostics', () => {
       getQualityState: () => ({
         level: 'balanced',
         adaptiveDowngradeCount: 1,
-        lastAdaptiveReason: 'low FPS downgraded cinematic to balanced',
+        adaptiveRecoveryCount: 1,
+        lastAdaptiveAction: 'recovery',
+        lastAdaptiveReason:
+          'sustained stable FPS recovered performance to balanced',
+        lastAdaptiveDowngradeReason:
+          'sustained low FPS downgraded cinematic to balanced',
+        lastAdaptiveRecoveryReason:
+          'sustained stable FPS recovered performance to balanced',
+        adaptivePolicy: {
+          warmupElapsedMs: 5000,
+          warmupDurationMs: 5000,
+          isWarmingUp: false,
+          lowFpsDurationMs: 0,
+          stableDurationMs: 8000,
+          cooldownRemainingMs: 0,
+          downgradeCount: 1,
+          recoveryCount: 1,
+          lastAdaptiveAction: 'recovery',
+          lastDowngradeReason:
+            'sustained low FPS downgraded cinematic to balanced',
+          lastRecoveryReason:
+            'sustained stable FPS recovered performance to balanced',
+          lastAdaptiveReason:
+            'sustained stable FPS recovered performance to balanced',
+          isRecoveryAllowed: true,
+          isSoftwareRenderer: false,
+          sampleCount: 120,
+          medianFps: 60,
+          p95FrameMs: 18,
+        },
+        source: 'adaptive',
       }),
       getFeatureState: () => ({
         bloomEnabled: true,
@@ -50,6 +80,10 @@ describe('performance diagnostics', () => {
     expect(snapshot.sampleCount).toBe(3);
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
     expect(snapshot.quality.level).toBe('balanced');
+    expect(snapshot.quality.adaptiveRecoveryCount).toBe(1);
+    expect(snapshot.quality.lastAdaptiveAction).toBe('recovery');
+    expect(snapshot.quality.adaptivePolicy?.isWarmingUp).toBe(false);
+    expect(snapshot.quality.source).toBe('adaptive');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
     expect(snapshot.phases.mainRender.sampleCount).toBe(2);
     expect(snapshot.phases.mirror.averageMs).toBe(4);
@@ -75,7 +109,13 @@ describe('performance diagnostics', () => {
       getQualityState: () => ({
         level: 'balanced',
         adaptiveDowngradeCount: 0,
+        adaptiveRecoveryCount: 0,
+        lastAdaptiveAction: null,
         lastAdaptiveReason: null,
+        lastAdaptiveDowngradeReason: null,
+        lastAdaptiveRecoveryReason: null,
+        adaptivePolicy: null,
+        source: 'initial',
       }),
       getFeatureState: () => ({
         bloomEnabled: false,

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -9,6 +9,71 @@ import {
   resolveResizedBasePixelRatio,
 } from '../scene/performance/qualityPolicy';
 import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
+
+function createTestAdaptiveController(
+  options: {
+    level?: GraphicsQualityLevel;
+    basePixelRatio?: number;
+    isSoftwareRenderer?: boolean;
+    hasManualQualitySelection?: () => boolean;
+    cooldownMs?: number;
+    warmupMs?: number;
+    downgradeAfterMs?: number;
+    stableRecoveryAfterMs?: number;
+  } = {}
+) {
+  let level: GraphicsQualityLevel = options.level ?? 'balanced';
+  let basePixelRatio = options.basePixelRatio ?? 1.25;
+  const onDowngrade = vi.fn();
+  const onRecover = vi.fn();
+  const controller = createAdaptiveQualityController({
+    qualityManager: {
+      getLevel: () => level,
+      setLevel: (next) => {
+        level = next;
+      },
+      setBasePixelRatio: (next) => {
+        basePixelRatio = next;
+      },
+    },
+    getBasePixelRatio: () => basePixelRatio,
+    setBasePixelRatio: (next) => {
+      basePixelRatio = next;
+    },
+    cooldownMs: options.cooldownMs ?? 0,
+    warmupMs: options.warmupMs,
+    downgradeAfterMs: options.downgradeAfterMs ?? 1000,
+    stableRecoveryAfterMs: options.stableRecoveryAfterMs ?? 1000,
+    isSoftwareRenderer: options.isSoftwareRenderer,
+    hasManualQualitySelection: options.hasManualQualitySelection,
+    onDowngrade,
+    onRecover,
+  });
+
+  return {
+    controller,
+    onDowngrade,
+    onRecover,
+    get level() {
+      return level;
+    },
+    get basePixelRatio() {
+      return basePixelRatio;
+    },
+  };
+}
+
+function runFrames(
+  controller: ReturnType<typeof createAdaptiveQualityController>,
+  frameSeconds: number,
+  count: number
+) {
+  let lastEvent: ReturnType<typeof controller.update> = null;
+  for (let index = 0; index < count; index += 1) {
+    lastEvent = lastEvent ?? controller.update(frameSeconds);
+  }
+  return lastEvent;
+}
 describe('immersive performance optimization policy', () => {
   it('classifies known software renderers as risky', () => {
     expect(
@@ -60,38 +125,123 @@ describe('immersive performance optimization policy', () => {
     expect(resolveResizedBasePixelRatio(0.9, 1.25, 1)).toBe(0.9);
   });
 
-  it('downgrades quality once per cooldown without flapping back upward', () => {
-    let level: GraphicsQualityLevel = 'cinematic';
-    let basePixelRatio = 1.25;
-    const onDowngrade = vi.fn();
-    const controller = createAdaptiveQualityController({
-      qualityManager: {
-        getLevel: () => level,
-        setLevel: (next) => {
-          level = next;
-        },
-        setBasePixelRatio: (next) => {
-          basePixelRatio = next;
-        },
-      },
-      getBasePixelRatio: () => basePixelRatio,
-      setBasePixelRatio: (next) => {
-        basePixelRatio = next;
-      },
-      cooldownMs: 0,
-      downgradeAfterMs: 1000,
-      onDowngrade,
+  it('ignores transient startup low FPS during normal renderer warmup', () => {
+    const test = createTestAdaptiveController({
+      level: 'balanced',
+      warmupMs: 5000,
     });
 
-    expect(controller.update(0.5)).toBeNull();
-    expect(controller.update(0.6)?.step).toBe('quality-balanced');
-    expect(level).toBe('balanced');
-    expect(controller.update(1.1)?.step).toBe('quality-performance');
-    expect(level).toBe('performance');
-    expect(controller.update(1.1)?.step).toBe('pixel-ratio');
-    expect(basePixelRatio).toBeCloseTo(1);
-    expect(controller.update(1.1)).toBeNull();
-    expect(controller.isExhausted()).toBe(true);
-    expect(onDowngrade).toHaveBeenCalledTimes(3);
+    runFrames(test.controller, 0.1, 30);
+
+    expect(test.level).toBe('balanced');
+    expect(test.controller.getSnapshot()).toMatchObject({
+      isWarmingUp: true,
+      downgradeCount: 0,
+    });
+    expect(test.onDowngrade).not.toHaveBeenCalled();
+  });
+
+  it('downgrades normal renderers only after sustained low FPS after warmup', () => {
+    const test = createTestAdaptiveController({
+      level: 'balanced',
+      warmupMs: 5000,
+      downgradeAfterMs: 1000,
+    });
+
+    runFrames(test.controller, 1 / 60, 310);
+    expect(test.level).toBe('balanced');
+
+    const downgrade = runFrames(test.controller, 0.05, 80);
+
+    expect(downgrade?.step).toBe('quality-performance');
+    expect(downgrade?.action).toBe('downgrade');
+    expect(test.level).toBe('performance');
+    expect(test.controller.getLastDowngradeReason()).toContain(
+      'sustained low FPS'
+    );
+  });
+
+  it('recovers normal hardware from performance to balanced after stable FPS', () => {
+    const test = createTestAdaptiveController({
+      level: 'performance',
+      warmupMs: 0,
+      stableRecoveryAfterMs: 1000,
+    });
+
+    const recovery = runFrames(test.controller, 1 / 60, 70);
+
+    expect(recovery?.step).toBe('quality-balanced');
+    expect(recovery?.action).toBe('recovery');
+    expect(test.level).toBe('balanced');
+    expect(test.controller.getRecoveryCount()).toBe(1);
+    expect(test.onRecover).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps software renderers conservative and does not auto-upshift', () => {
+    const test = createTestAdaptiveController({
+      level: 'performance',
+      isSoftwareRenderer: true,
+      warmupMs: 0,
+      stableRecoveryAfterMs: 1000,
+    });
+
+    runFrames(test.controller, 1 / 60, 80);
+
+    expect(test.level).toBe('performance');
+    expect(test.controller.getRecoveryCount()).toBe(0);
+    expect(test.controller.getSnapshot().isRecoveryAllowed).toBe(false);
+  });
+
+  it('does not auto-upshift over a user-selected performance preset', () => {
+    const test = createTestAdaptiveController({
+      level: 'performance',
+      warmupMs: 0,
+      stableRecoveryAfterMs: 1000,
+      hasManualQualitySelection: () => true,
+    });
+
+    runFrames(test.controller, 1 / 60, 80);
+
+    expect(test.level).toBe('performance');
+    expect(test.controller.getRecoveryCount()).toBe(0);
+    expect(test.controller.getSnapshot().isRecoveryAllowed).toBe(false);
+  });
+
+  it('requires hysteresis and avoids oscillating near the threshold', () => {
+    const test = createTestAdaptiveController({
+      level: 'balanced',
+      warmupMs: 0,
+      downgradeAfterMs: 1000,
+      stableRecoveryAfterMs: 1000,
+    });
+
+    for (let index = 0; index < 80; index += 1) {
+      test.controller.update(index % 2 === 0 ? 1 / 60 : 1 / 28);
+    }
+
+    expect(test.level).toBe('balanced');
+    expect(test.controller.getDowngradeCount()).toBe(0);
+    expect(test.controller.getRecoveryCount()).toBe(0);
+  });
+
+  it('downgrades quality once per cooldown and exhausts after the DPR step', () => {
+    const test = createTestAdaptiveController({
+      level: 'cinematic',
+      warmupMs: 0,
+      cooldownMs: 0,
+      downgradeAfterMs: 1000,
+    });
+
+    expect(runFrames(test.controller, 0.05, 28)?.step).toBe('quality-balanced');
+    expect(test.level).toBe('balanced');
+    expect(runFrames(test.controller, 0.05, 28)?.step).toBe(
+      'quality-performance'
+    );
+    expect(test.level).toBe('performance');
+    expect(runFrames(test.controller, 0.05, 28)?.step).toBe('pixel-ratio');
+    expect(test.basePixelRatio).toBeCloseTo(1);
+    expect(runFrames(test.controller, 0.05, 28)).toBeNull();
+    expect(test.controller.isExhausted()).toBe(true);
+    expect(test.onDowngrade).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent capable (hardware-accelerated) renderers from being permanently downgraded to `performance` due to transient startup/shader warmup spikes while keeping software renderers conservative.

### Description
- Added a new adaptive quality controller with warmup, rolling-window median/p95 hysteresis, and stable-FPS recovery logic in `src/scene/performance/adaptiveQuality.ts` so normal hardware gets a bounded warmup grace period and can recover from `performance`→`balanced` after sustained stability.
- Exposed richer diagnostics and policy snapshot (`adaptivePolicy`, warmup/recovery counts, last action/reasons, source) via `window.portfolio.performance.getSnapshot()` by extending `performanceDiagnostics` and wiring the adaptive controller in `src/main.ts`.
- Tracked graphics quality source (`initial` | `manual` | `adaptive`) and respected manual/stored selections so auto-upshift will not override user intent; added initial-source reporting in `src/scene/graphics/qualityManager.ts`.
- Hooked adaptive downgrade/recover callbacks to update source, log events, and refresh HUD controls; kept software renderer path conservative (no auto-recovery) and parameterized thresholds and windows.
- Added unit tests covering warmup, sustained downgrade, recovery on stable FPS, software renderer conservatism, manual-quality preservation, and hysteresis/flapping avoidance in `src/tests/performanceOptimization.test.ts` and updated diagnostics tests in `src/tests/performanceDiagnostics.test.ts` and Playwright expectations in `playwright/immersive-performance.spec.ts`.
- Documented the staging evidence and change summary in `docs/architecture/performance-budgets.md`.

### Testing
- Ran formatting and linting: `npm run format:write` (passed) and `npm run lint` (passed).
- Unit tests: `npm run test:ci` passed for the focused suites exercised (`performanceOptimization`, `performanceDiagnostics`, `graphicsQualityManager`) and full test run completed (128 files, 859 tests) in CI run in this environment.
- Playwright E2E: `npm run test:e2e -- --grep "adaptive|performance|immersive"` executed; browsers were installed and deps added during the run and the targeted Playwright suite passed (13 passed, 2 skipped) after installing Playwright executables and host deps.
- Type-check: `npm run typecheck` reported pre-existing repository TypeScript errors unrelated to this change (missing/shape issues elsewhere); these are not introduced by this patch.
- Docs check: `npm run docs:check` passed.
- Smoke/build: `npm run smoke` passed (production build and dist assertions succeeded).
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` found no high-risk secrets.

Notes and risks
- Typecheck uncovered unrelated repo-wide typing problems; this PR avoids touching those areas and focuses on adaptive quality policy and diagnostics.
- Playwright in CI required installing headless shell and host libraries during verification; the PR does not change CI infra but the run here performed the installs to execute the e2e tests.
- Follow-ups: software-renderer crash hardening and persistent crash breadcrumbs are planned in the next prompt as noted in the integration plan.

How to verify locally
- `npm run format:write`
- `npm run lint`
- `npm run test:ci`
- `npm run test:e2e -- --grep "adaptive|performance|immersive"` (ensure Playwright browsers are installed with `npx playwright install --with-deps` if needed)
- `npm run docs:check`
- `npm run smoke`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8719e5d0832fba5810fd8a5f6c11)