### PR TITLE
⚙️ Tune adaptive quality warmup and recovery

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -36,6 +36,26 @@ and the Vitest assertions when measurable changes land.
   run `renderer.info.render` and `renderer.info.memory` after the camera settles
   at launch. Update the snapshot date and notes when refreshing numbers.
 
+### 2026-05-30 adaptive quality warmup tuning
+
+- **Evidence** – Staging compared two renderer classes: the software path reported
+  `ANGLE (Microsoft, Microsoft Basic Render Driver ..., D3D11)` and stayed near
+  30–40 FPS before later tab instability, while the hardware path reported
+  `ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11)` and settled near 60 FPS with
+  main render time warming down toward 1–2 ms.
+- **Bug** – The adaptive quality controller treated startup shader/asset warmup spikes like
+  steady-state overload. Normal hardware could be downgraded from balanced to performance and
+  remain there even after the frame budget recovered.
+- **Corrective action** – Normal renderers now get a finite warmup grace period, rolling-window
+  median/p95 hysteresis before downgrades, and stable-FPS recovery from performance back to
+  balanced. Software or unknown-risk renderers skip warmup optimism and do not auto-upshift.
+- **Diagnostics** – `window.portfolio.performance.getSnapshot().quality` now exposes adaptive
+  warmup, recovery, source, renderer risk, and last-action state so captures can distinguish
+  transient startup behavior from sustained overload.
+- **Follow-up** – Software renderer crash-hardening remains separate: the Basic Render Driver,
+  SwiftShader, WARP, and llvmpipe paths still need safer immersive/debug handling and persisted
+  crash breadcrumbs.
+
 ## Heavy assets & lazy loading
 
 | Asset                                                      | Size            | Strategy                                                                                                                                          |

--- a/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
+++ b/outages/2026-05-29-danielsmith-adaptive-quality-gap.md
@@ -4,11 +4,11 @@
 
 ## Symptom slice
 
-Performance failover watched sustained low FPS, but graphics quality did not automatically step down before text fallback.
+Performance failover watched sustained low FPS, but graphics quality did not automatically step down before text fallback. A later staging capture showed the opposite edge case on capable hardware: startup shader/asset warmup could downgrade a normal NVIDIA RTX path from balanced to performance even though it later stabilized near 60 FPS.
 
 ## Evidence
 
-Diagnostics expose adaptive downgrade count and last adaptive reason; unit coverage drives slow-frame updates without requiring real SwiftShader in CI.
+Diagnostics expose adaptive downgrade count, recovery count, warmup state, renderer risk, quality source, and last adaptive reasons; unit coverage drives slow-frame and stable-frame updates without requiring real SwiftShader in CI.
 
 ## Impacted files
 
@@ -20,7 +20,7 @@ Diagnostics expose adaptive downgrade count and last adaptive reason; unit cover
 
 ## Fix summary
 
-An adaptive ladder now lowers quality from cinematic to balanced to performance, then reduces base DPR, resetting failover samples after each downgrade to prevent premature fallback or flapping.
+An adaptive ladder now lowers quality from cinematic to balanced to performance, then reduces base DPR, resetting failover samples after each adaptive action to prevent premature fallback or flapping. Normal renderers get a finite warmup grace period and rolling median/p95 hysteresis before downgrade; if they remain stable near 60 FPS after an adaptive downgrade, they can recover from performance back to balanced. Software and unknown-risk renderers stay conservative and do not auto-upshift.
 
 ## Interaction with other fixes
 
@@ -31,7 +31,7 @@ last-failover reason.
 
 ## Regression tests
 
-src/tests/performanceOptimization.test.ts covers the downgrade ladder and no-flap behavior; performanceFailover reset support keeps fallback available after adaptive steps are exhausted.
+src/tests/performanceOptimization.test.ts covers warmup grace, sustained low-FPS downgrade, stable-FPS recovery, software-renderer no-upshift behavior, manual performance selection, the downgrade ladder, and no-flap behavior. performanceFailover reset support keeps fallback available after adaptive steps are exhausted.
 
 ## Validation commands
 

--- a/outages/2026-05-29-danielsmith-staging-performance-overview.md
+++ b/outages/2026-05-29-danielsmith-staging-performance-overview.md
@@ -30,7 +30,12 @@ The fix starts risky software renderers in performance mode, defaults normal
 desktop rendering to balanced quality, caps DPR to an explicit lower bound, skips
 EffectComposer when bloom and motion blur are inactive, disables bloom in
 performance mode, throttles or disables SelfieMirror work by quality tier, and
-adds a non-flapping adaptive downgrade ladder before low-FPS fallback.
+adds a warmup-aware adaptive downgrade ladder before low-FPS fallback. Normal
+hardware evidence now includes an NVIDIA RTX 4090 path that settled near 60 FPS
+after startup warmup; adaptive quality therefore requires sustained rolling
+median/p95 pressure before downgrading and can recover performance back to
+balanced after sustained stable FPS. Software-renderer crash-hardening remains a
+separate follow-up.
 
 Diagnostics are available in DevTools at:
 

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -24,6 +24,21 @@ interface PerformanceSnapshot {
   quality: {
     level: 'cinematic' | 'balanced' | 'performance';
     adaptiveDowngradeCount: number;
+    adaptiveRecoveryCount: number;
+    lastAdaptiveReason: string | null;
+    lastAdaptiveDowngradeReason: string | null;
+    lastAdaptiveRecoveryReason: string | null;
+    adaptivePolicy: {
+      rendererRiskLevel: 'normal' | 'software' | 'unknown';
+      qualitySource: 'initial' | 'adaptive' | 'manual';
+      inWarmup: boolean;
+      warmupElapsedMs: number;
+      warmupGraceMs: number;
+      lowFpsDurationMs: number;
+      stableDurationMs: number;
+      lastAction: 'downgrade' | 'recovery' | null;
+      canAutoRecover: boolean;
+    } | null;
   };
   features: {
     bloomEnabled: boolean;
@@ -181,6 +196,15 @@ test.describe('immersive performance diagnostics', () => {
       expect(snapshot.lastFailoverReason).toBeNull();
       expect(snapshot.rendererSize.pixelRatio).toBeLessThanOrEqual(1.25);
       expect(snapshot.quality.level).not.toBe('cinematic');
+      expect(snapshot.quality.adaptivePolicy).toBeDefined();
+      expect(snapshot.quality.adaptivePolicy).toMatchObject({
+        rendererRiskLevel: snapshot.renderer.riskLevel,
+      });
+      if (!snapshot.renderer.isSoftwareRenderer) {
+        expect(
+          snapshot.quality.adaptivePolicy?.warmupGraceMs ?? 0
+        ).toBeGreaterThan(0);
+      }
       expect(snapshot.features.mirrorRenderTargetSize).toBeLessThanOrEqual(320);
       if (snapshot.quality.level === 'performance') {
         expect(snapshot.features.bloomEnabled).toBe(false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3091,8 +3091,9 @@ function initializeImmersiveScene(
       basePixelRatio = value;
     },
     fpsThreshold: PERFORMANCE_FAILOVER_FPS_THRESHOLD,
-    onDowngrade: (event) => {
-      console.info('[performance] adaptive quality downgrade', event);
+    rendererRiskLevel: rendererInfo.riskLevel,
+    onAction: (event) => {
+      console.info(`[performance] adaptive quality ${event.action}`, event);
       performanceFailover.resetLowFpsSamples();
       graphicsQualityControl?.refresh();
     },
@@ -3249,6 +3250,7 @@ function initializeImmersiveScene(
       graphicsQualityManager?.getLevel() ?? GRAPHICS_QUALITY_PRESETS[0].id,
     setActiveLevel: (level) => {
       graphicsQualityManager?.setLevel(level);
+      adaptiveQualityController?.markUserSelectedLevel(level);
     },
   });
   registerHudControlElement(graphicsQualityControl?.element ?? null);
@@ -3302,7 +3304,13 @@ function initializeImmersiveScene(
       level: graphicsQualityManager!.getLevel(),
       adaptiveDowngradeCount:
         adaptiveQualityController?.getDowngradeCount() ?? 0,
+      adaptiveRecoveryCount: adaptiveQualityController?.getRecoveryCount() ?? 0,
       lastAdaptiveReason: adaptiveQualityController?.getLastReason() ?? null,
+      lastAdaptiveDowngradeReason:
+        adaptiveQualityController?.getLastDowngradeReason() ?? null,
+      lastAdaptiveRecoveryReason:
+        adaptiveQualityController?.getLastRecoveryReason() ?? null,
+      adaptivePolicy: adaptiveQualityController?.getSnapshot() ?? null,
     }),
     getFeatureState: () => {
       const mirrorState = selfieMirror?.getRenderState();
@@ -4057,8 +4065,8 @@ function initializeImmersiveScene(
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);
-      const adaptiveDowngrade = adaptiveQualityController?.update(delta);
-      if (adaptiveDowngrade) {
+      const adaptiveQualityEvent = adaptiveQualityController?.update(delta);
+      if (adaptiveQualityEvent) {
         applyFeaturePolicy();
       }
       performanceFailover.update(delta);

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -1,10 +1,15 @@
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
+import type { RendererRiskLevel } from './rendererCapabilities';
+
 export interface AdaptiveQualityManagerLike {
   getLevel(): GraphicsQualityLevel;
   setLevel(level: GraphicsQualityLevel): void;
   setBasePixelRatio(pixelRatio: number): void;
 }
+
+export type AdaptiveQualityAction = 'downgrade' | 'recovery';
+export type AdaptiveQualitySource = 'initial' | 'adaptive' | 'manual';
 
 export interface AdaptiveQualityControllerOptions {
   qualityManager: AdaptiveQualityManagerLike;
@@ -14,22 +19,125 @@ export interface AdaptiveQualityControllerOptions {
   downgradeAfterMs?: number;
   cooldownMs?: number;
   minBasePixelRatio?: number;
+  rendererRiskLevel?: RendererRiskLevel;
+  warmupGraceMs?: number;
+  evaluationWindowMs?: number;
+  recoveryAfterMs?: number;
+  recoveryFpsThreshold?: number;
+  recoveryP95FrameMs?: number;
+  initialQualitySource?: AdaptiveQualitySource;
   onDowngrade?: (event: AdaptiveQualityDowngradeEvent) => void;
+  onRecovery?: (event: AdaptiveQualityRecoveryEvent) => void;
+  onAction?: (event: AdaptiveQualityEvent) => void;
 }
 
-export interface AdaptiveQualityDowngradeEvent {
+export interface AdaptiveQualityEvent {
+  action: AdaptiveQualityAction;
   step: string;
   level: GraphicsQualityLevel;
   basePixelRatio: number;
   reason: string;
   downgradeCount: number;
+  recoveryCount: number;
+  elapsedMs: number;
+  warmupElapsedMs: number;
+  warmupGraceMs: number;
+  inWarmup: boolean;
+  lowFpsDurationMs: number;
+  stableDurationMs: number;
+  medianFps: number;
+  p95FrameMs: number;
+  minFps: number;
+  sampleCount: number;
+  qualitySource: AdaptiveQualitySource;
+  rendererRiskLevel: RendererRiskLevel;
+}
+
+export type AdaptiveQualityDowngradeEvent = AdaptiveQualityEvent & {
+  action: 'downgrade';
+};
+
+export type AdaptiveQualityRecoveryEvent = AdaptiveQualityEvent & {
+  action: 'recovery';
+};
+
+export interface AdaptiveQualityPolicySnapshot {
+  rendererRiskLevel: RendererRiskLevel;
+  qualitySource: AdaptiveQualitySource;
+  inWarmup: boolean;
+  warmupElapsedMs: number;
+  warmupGraceMs: number;
+  lowFpsDurationMs: number;
+  stableDurationMs: number;
+  cooldownRemainingMs: number;
+  downgradeCount: number;
+  recoveryCount: number;
+  lastAction: AdaptiveQualityAction | null;
+  lastDowngradeReason: string | null;
+  lastRecoveryReason: string | null;
+  lastAdaptiveReason: string | null;
+  medianFps: number;
+  p95FrameMs: number;
+  minFps: number;
+  sampleCount: number;
+  canAutoRecover: boolean;
 }
 
 export interface AdaptiveQualityController {
-  update(deltaSeconds: number): AdaptiveQualityDowngradeEvent | null;
+  update(deltaSeconds: number): AdaptiveQualityEvent | null;
   getDowngradeCount(): number;
+  getRecoveryCount(): number;
   getLastReason(): string | null;
+  getLastDowngradeReason(): string | null;
+  getLastRecoveryReason(): string | null;
+  getSnapshot(): AdaptiveQualityPolicySnapshot;
+  markUserSelectedLevel(level: GraphicsQualityLevel): void;
   isExhausted(): boolean;
+}
+
+const NORMAL_WARMUP_GRACE_MS = 5000;
+const LOW_FPS_P95_MULTIPLIER = 1.5;
+
+interface FrameSample {
+  frameMs: number;
+  elapsedMs: number;
+}
+
+function percentile(
+  sorted: readonly number[],
+  percentileValue: number
+): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1)
+  );
+  return sorted[index] ?? 0;
+}
+
+function summarizeFrameSamples(samples: readonly FrameSample[]): {
+  medianFps: number;
+  p95FrameMs: number;
+  minFps: number;
+  sampleCount: number;
+} {
+  if (samples.length === 0) {
+    return { medianFps: 0, p95FrameMs: 0, minFps: 0, sampleCount: 0 };
+  }
+  const sortedFrameMs = samples
+    .map((sample) => sample.frameMs)
+    .sort((a, b) => a - b);
+  const medianFrameMs = percentile(sortedFrameMs, 50);
+  const p95FrameMs = percentile(sortedFrameMs, 95);
+  const maxFrameMs = sortedFrameMs[sortedFrameMs.length - 1] ?? 0;
+  return {
+    medianFps: medianFrameMs > 0 ? 1000 / medianFrameMs : 0,
+    p95FrameMs,
+    minFps: maxFrameMs > 0 ? 1000 / maxFrameMs : 0,
+    sampleCount: sortedFrameMs.length,
+  };
 }
 
 export function createAdaptiveQualityController({
@@ -37,33 +145,99 @@ export function createAdaptiveQualityController({
   getBasePixelRatio,
   setBasePixelRatio,
   fpsThreshold = 30,
-  downgradeAfterMs = 1200,
-  cooldownMs = 2500,
+  downgradeAfterMs = 1600,
+  cooldownMs = 3500,
   minBasePixelRatio = 0.75,
+  rendererRiskLevel = 'normal',
+  warmupGraceMs,
+  evaluationWindowMs = 2200,
+  recoveryAfterMs = 8000,
+  recoveryFpsThreshold = 55,
+  recoveryP95FrameMs = 24,
+  initialQualitySource = 'initial',
   onDowngrade,
+  onRecovery,
+  onAction,
 }: AdaptiveQualityControllerOptions): AdaptiveQualityController {
+  const isConservativeRenderer = rendererRiskLevel !== 'normal';
+  const resolvedWarmupGraceMs =
+    warmupGraceMs ?? (isConservativeRenderer ? 0 : NORMAL_WARMUP_GRACE_MS);
+  let elapsedMs = 0;
   let lowFpsDurationMs = 0;
+  let stableDurationMs = 0;
   let cooldownRemainingMs = 0;
   let downgradeCount = 0;
-  let lastReason: string | null = null;
+  let recoveryCount = 0;
+  let lastAction: AdaptiveQualityAction | null = null;
+  let lastDowngradeReason: string | null = null;
+  let lastRecoveryReason: string | null = null;
+  let lastAdaptiveReason: string | null = null;
   let pixelRatioStepApplied = false;
+  let qualitySource = initialQualitySource;
+  let manualLevel: GraphicsQualityLevel | null =
+    initialQualitySource === 'manual' ? qualityManager.getLevel() : null;
+  const samples: FrameSample[] = [];
+
+  const getWarmupElapsedMs = () => Math.min(elapsedMs, resolvedWarmupGraceMs);
+  const isInWarmup = () => elapsedMs < resolvedWarmupGraceMs;
+  const getStats = () => summarizeFrameSamples(samples);
+  const canAutoRecover = () =>
+    !isConservativeRenderer && manualLevel !== 'performance';
+
+  const pushSample = (frameMs: number) => {
+    samples.push({ frameMs, elapsedMs });
+    const oldestAllowedElapsedMs = elapsedMs - evaluationWindowMs;
+    while (
+      samples.length > 0 &&
+      (samples[0]?.elapsedMs ?? 0) < oldestAllowedElapsedMs
+    ) {
+      samples.shift();
+    }
+  };
 
   const emit = (
+    action: AdaptiveQualityAction,
     step: string,
     reason: string
-  ): AdaptiveQualityDowngradeEvent => {
-    downgradeCount += 1;
-    lastReason = reason;
-    lowFpsDurationMs = 0;
+  ): AdaptiveQualityEvent => {
+    const stats = getStats();
+    lastAction = action;
+    lastAdaptiveReason = reason;
+    if (action === 'downgrade') {
+      downgradeCount += 1;
+      lastDowngradeReason = reason;
+      lowFpsDurationMs = 0;
+    } else {
+      recoveryCount += 1;
+      lastRecoveryReason = reason;
+      stableDurationMs = 0;
+    }
     cooldownRemainingMs = cooldownMs;
+    qualitySource = 'adaptive';
     const event = {
+      action,
       step,
       level: qualityManager.getLevel(),
       basePixelRatio: getBasePixelRatio(),
       reason,
       downgradeCount,
+      recoveryCount,
+      elapsedMs,
+      warmupElapsedMs: getWarmupElapsedMs(),
+      warmupGraceMs: resolvedWarmupGraceMs,
+      inWarmup: isInWarmup(),
+      lowFpsDurationMs,
+      stableDurationMs,
+      ...stats,
+      qualitySource,
+      rendererRiskLevel,
     };
-    onDowngrade?.(event);
+    if (action === 'downgrade') {
+      onDowngrade?.(event as AdaptiveQualityDowngradeEvent);
+    } else {
+      onRecovery?.(event as AdaptiveQualityRecoveryEvent);
+    }
+    onAction?.(event);
     return event;
   };
 
@@ -72,16 +246,18 @@ export function createAdaptiveQualityController({
     if (currentLevel === 'cinematic') {
       qualityManager.setLevel('balanced');
       return emit(
+        'downgrade',
         'quality-balanced',
-        'low FPS downgraded cinematic to balanced'
-      );
+        'sustained low FPS downgraded cinematic to balanced'
+      ) as AdaptiveQualityDowngradeEvent;
     }
     if (currentLevel === 'balanced') {
       qualityManager.setLevel('performance');
       return emit(
+        'downgrade',
         'quality-performance',
-        'low FPS downgraded balanced to performance'
-      );
+        'sustained low FPS downgraded balanced to performance'
+      ) as AdaptiveQualityDowngradeEvent;
     }
 
     const currentRatio = getBasePixelRatio();
@@ -90,12 +266,25 @@ export function createAdaptiveQualityController({
       setBasePixelRatio(Math.max(minBasePixelRatio, currentRatio * 0.8));
       qualityManager.setBasePixelRatio(getBasePixelRatio());
       return emit(
+        'downgrade',
         'pixel-ratio',
-        'low FPS reduced base DPR after performance preset'
-      );
+        'sustained low FPS reduced base DPR after performance preset'
+      ) as AdaptiveQualityDowngradeEvent;
     }
 
     return null;
+  };
+
+  const recover = (): AdaptiveQualityRecoveryEvent | null => {
+    if (!canAutoRecover() || qualityManager.getLevel() !== 'performance') {
+      return null;
+    }
+    qualityManager.setLevel('balanced');
+    return emit(
+      'recovery',
+      'quality-balanced',
+      'sustained stable FPS recovered performance to balanced'
+    ) as AdaptiveQualityRecoveryEvent;
   };
 
   return {
@@ -104,26 +293,94 @@ export function createAdaptiveQualityController({
         return null;
       }
       const frameMs = deltaSeconds * 1000;
+      elapsedMs += frameMs;
+      pushSample(frameMs);
+
       if (cooldownRemainingMs > 0) {
         cooldownRemainingMs = Math.max(0, cooldownRemainingMs - frameMs);
         return null;
       }
-      const fps = frameMs > 0 ? 1000 / frameMs : Number.POSITIVE_INFINITY;
-      if (fps >= fpsThreshold) {
+
+      const stats = getStats();
+      const hasEvaluationWindow =
+        samples.length > 1 &&
+        elapsedMs - (samples[0]?.elapsedMs ?? elapsedMs) >=
+          Math.min(evaluationWindowMs, downgradeAfterMs);
+      const lowFpsThresholdFrameMs = 1000 / fpsThreshold;
+      const isSustainedLow =
+        hasEvaluationWindow &&
+        (stats.medianFps < fpsThreshold ||
+          stats.p95FrameMs > lowFpsThresholdFrameMs * LOW_FPS_P95_MULTIPLIER);
+      const isStable =
+        stats.medianFps >= recoveryFpsThreshold &&
+        stats.p95FrameMs > 0 &&
+        stats.p95FrameMs <= recoveryP95FrameMs;
+
+      if (isInWarmup() && !isConservativeRenderer) {
+        lowFpsDurationMs = isSustainedLow ? lowFpsDurationMs + frameMs : 0;
+        stableDurationMs = isStable ? stableDurationMs + frameMs : 0;
+        return null;
+      }
+
+      if (isSustainedLow) {
+        lowFpsDurationMs += frameMs;
+        stableDurationMs = 0;
+      } else {
         lowFpsDurationMs = 0;
-        return null;
+        stableDurationMs = isStable ? stableDurationMs + frameMs : 0;
       }
-      lowFpsDurationMs += frameMs;
-      if (lowFpsDurationMs < downgradeAfterMs) {
-        return null;
+
+      if (lowFpsDurationMs >= downgradeAfterMs) {
+        return downgrade();
       }
-      return downgrade();
+
+      if (stableDurationMs >= recoveryAfterMs) {
+        return recover();
+      }
+
+      return null;
     },
     getDowngradeCount() {
       return downgradeCount;
     },
+    getRecoveryCount() {
+      return recoveryCount;
+    },
     getLastReason() {
-      return lastReason;
+      return lastAdaptiveReason;
+    },
+    getLastDowngradeReason() {
+      return lastDowngradeReason;
+    },
+    getLastRecoveryReason() {
+      return lastRecoveryReason;
+    },
+    getSnapshot() {
+      return {
+        rendererRiskLevel,
+        qualitySource,
+        inWarmup: isInWarmup(),
+        warmupElapsedMs: getWarmupElapsedMs(),
+        warmupGraceMs: resolvedWarmupGraceMs,
+        lowFpsDurationMs,
+        stableDurationMs,
+        cooldownRemainingMs,
+        downgradeCount,
+        recoveryCount,
+        lastAction,
+        lastDowngradeReason,
+        lastRecoveryReason,
+        lastAdaptiveReason,
+        ...getStats(),
+        canAutoRecover: canAutoRecover(),
+      };
+    },
+    markUserSelectedLevel(level) {
+      manualLevel = level;
+      qualitySource = 'manual';
+      stableDurationMs = 0;
+      lowFpsDurationMs = 0;
+      cooldownRemainingMs = cooldownMs;
     },
     isExhausted() {
       return (

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -1,5 +1,6 @@
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
+import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
 export type PhaseName =
@@ -20,7 +21,11 @@ export interface RendererSizeSnapshot {
 export interface QualityStateSnapshot {
   level: GraphicsQualityLevel;
   adaptiveDowngradeCount: number;
+  adaptiveRecoveryCount: number;
   lastAdaptiveReason: string | null;
+  lastAdaptiveDowngradeReason: string | null;
+  lastAdaptiveRecoveryReason: string | null;
+  adaptivePolicy: AdaptiveQualityPolicySnapshot | null;
 }
 
 export interface FeatureStateSnapshot {

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -22,7 +22,37 @@ describe('performance diagnostics', () => {
       getQualityState: () => ({
         level: 'balanced',
         adaptiveDowngradeCount: 1,
-        lastAdaptiveReason: 'low FPS downgraded cinematic to balanced',
+        adaptiveRecoveryCount: 1,
+        lastAdaptiveReason:
+          'sustained stable FPS recovered performance to balanced',
+        lastAdaptiveDowngradeReason:
+          'sustained low FPS downgraded cinematic to balanced',
+        lastAdaptiveRecoveryReason:
+          'sustained stable FPS recovered performance to balanced',
+        adaptivePolicy: {
+          rendererRiskLevel: 'normal',
+          qualitySource: 'adaptive',
+          inWarmup: false,
+          warmupElapsedMs: 5000,
+          warmupGraceMs: 5000,
+          lowFpsDurationMs: 0,
+          stableDurationMs: 1200,
+          cooldownRemainingMs: 0,
+          downgradeCount: 1,
+          recoveryCount: 1,
+          lastAction: 'recovery',
+          lastDowngradeReason:
+            'sustained low FPS downgraded cinematic to balanced',
+          lastRecoveryReason:
+            'sustained stable FPS recovered performance to balanced',
+          lastAdaptiveReason:
+            'sustained stable FPS recovered performance to balanced',
+          medianFps: 60,
+          p95FrameMs: 18,
+          minFps: 55,
+          sampleCount: 120,
+          canAutoRecover: true,
+        },
       }),
       getFeatureState: () => ({
         bloomEnabled: true,
@@ -50,6 +80,12 @@ describe('performance diagnostics', () => {
     expect(snapshot.sampleCount).toBe(3);
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
     expect(snapshot.quality.level).toBe('balanced');
+    expect(snapshot.quality.adaptivePolicy).toMatchObject({
+      warmupGraceMs: 5000,
+      recoveryCount: 1,
+      lastAction: 'recovery',
+      qualitySource: 'adaptive',
+    });
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
     expect(snapshot.phases.mainRender.sampleCount).toBe(2);
     expect(snapshot.phases.mirror.averageMs).toBe(4);
@@ -75,7 +111,11 @@ describe('performance diagnostics', () => {
       getQualityState: () => ({
         level: 'balanced',
         adaptiveDowngradeCount: 0,
+        adaptiveRecoveryCount: 0,
         lastAdaptiveReason: null,
+        lastAdaptiveDowngradeReason: null,
+        lastAdaptiveRecoveryReason: null,
+        adaptivePolicy: null,
       }),
       getFeatureState: () => ({
         bloomEnabled: false,

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -60,10 +60,20 @@ describe('immersive performance optimization policy', () => {
     expect(resolveResizedBasePixelRatio(0.9, 1.25, 1)).toBe(0.9);
   });
 
-  it('downgrades quality once per cooldown without flapping back upward', () => {
-    let level: GraphicsQualityLevel = 'cinematic';
+  function createTestController(
+    options: {
+      initialLevel?: GraphicsQualityLevel;
+      rendererRiskLevel?: 'normal' | 'software' | 'unknown';
+      warmupGraceMs?: number;
+      cooldownMs?: number;
+      downgradeAfterMs?: number;
+      recoveryAfterMs?: number;
+      evaluationWindowMs?: number;
+      onAction?: ReturnType<typeof vi.fn>;
+    } = {}
+  ) {
+    let level: GraphicsQualityLevel = options.initialLevel ?? 'balanced';
     let basePixelRatio = 1.25;
-    const onDowngrade = vi.fn();
     const controller = createAdaptiveQualityController({
       qualityManager: {
         getLevel: () => level,
@@ -78,20 +88,160 @@ describe('immersive performance optimization policy', () => {
       setBasePixelRatio: (next) => {
         basePixelRatio = next;
       },
-      cooldownMs: 0,
-      downgradeAfterMs: 1000,
-      onDowngrade,
+      rendererRiskLevel: options.rendererRiskLevel ?? 'normal',
+      warmupGraceMs: options.warmupGraceMs ?? 0,
+      cooldownMs: options.cooldownMs ?? 0,
+      downgradeAfterMs: options.downgradeAfterMs ?? 1000,
+      recoveryAfterMs: options.recoveryAfterMs ?? 2000,
+      evaluationWindowMs: options.evaluationWindowMs ?? 2200,
+      onAction: options.onAction,
     });
 
-    expect(controller.update(0.5)).toBeNull();
-    expect(controller.update(0.6)?.step).toBe('quality-balanced');
-    expect(level).toBe('balanced');
-    expect(controller.update(1.1)?.step).toBe('quality-performance');
-    expect(level).toBe('performance');
-    expect(controller.update(1.1)?.step).toBe('pixel-ratio');
-    expect(basePixelRatio).toBeCloseTo(1);
-    expect(controller.update(1.1)).toBeNull();
-    expect(controller.isExhausted()).toBe(true);
-    expect(onDowngrade).toHaveBeenCalledTimes(3);
+    return {
+      controller,
+      get level() {
+        return level;
+      },
+      get basePixelRatio() {
+        return basePixelRatio;
+      },
+    };
+  }
+
+  it('ignores transient startup low FPS during normal-renderer warmup', () => {
+    const test = createTestController({ warmupGraceMs: 5000 });
+
+    for (let index = 0; index < 20; index += 1) {
+      expect(test.controller.update(0.1)).toBeNull();
+    }
+
+    expect(test.level).toBe('balanced');
+    expect(test.controller.getSnapshot()).toMatchObject({
+      inWarmup: true,
+      downgradeCount: 0,
+    });
+  });
+
+  it('downgrades normal renderers after sustained low FPS past warmup', () => {
+    const test = createTestController({ warmupGraceMs: 1000 });
+
+    for (let index = 0; index < 10; index += 1) {
+      expect(test.controller.update(0.1)).toBeNull();
+    }
+
+    let event = null;
+    for (let index = 0; index < 40; index += 1) {
+      event = event ?? test.controller.update(0.1);
+    }
+
+    expect(event).toMatchObject({
+      action: 'downgrade',
+      step: 'quality-performance',
+    });
+    expect(test.level).toBe('performance');
+  });
+
+  it('recovers normal hardware from performance to balanced after stable FPS', () => {
+    const test = createTestController({
+      initialLevel: 'performance',
+      recoveryAfterMs: 1000,
+    });
+
+    let event = null;
+    for (let index = 0; index < 70; index += 1) {
+      event = event ?? test.controller.update(1 / 60);
+    }
+
+    expect(event).toMatchObject({
+      action: 'recovery',
+      step: 'quality-balanced',
+    });
+    expect(test.level).toBe('balanced');
+    expect(test.controller.getSnapshot().lastRecoveryReason).toContain(
+      'recovered performance to balanced'
+    );
+  });
+
+  it('starts software renderers conservatively and does not auto-upshift', () => {
+    const test = createTestController({
+      initialLevel: 'performance',
+      rendererRiskLevel: 'software',
+      recoveryAfterMs: 1000,
+    });
+
+    for (let index = 0; index < 90; index += 1) {
+      expect(test.controller.update(1 / 60)).toBeNull();
+    }
+
+    expect(test.level).toBe('performance');
+    expect(test.controller.getSnapshot()).toMatchObject({
+      canAutoRecover: false,
+      recoveryCount: 0,
+    });
+  });
+
+  it('does not override an explicit user-selected performance level', () => {
+    const test = createTestController({
+      initialLevel: 'performance',
+      recoveryAfterMs: 1000,
+    });
+    test.controller.markUserSelectedLevel('performance');
+
+    for (let index = 0; index < 90; index += 1) {
+      expect(test.controller.update(1 / 60)).toBeNull();
+    }
+
+    expect(test.level).toBe('performance');
+    expect(test.controller.getSnapshot()).toMatchObject({
+      qualitySource: 'manual',
+      canAutoRecover: false,
+    });
+  });
+
+  it('requires sustained window health and avoids flapping at boundaries', () => {
+    const onAction = vi.fn();
+    const test = createTestController({ onAction });
+
+    for (let index = 0; index < 40; index += 1) {
+      const delta = index % 8 === 0 ? 1 / 20 : 1 / 60;
+      expect(test.controller.update(delta)).toBeNull();
+    }
+
+    expect(test.level).toBe('balanced');
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('downgrades quality once per cooldown without flapping back upward', () => {
+    const onAction = vi.fn();
+    const test = createTestController({
+      initialLevel: 'cinematic',
+      onAction,
+      recoveryAfterMs: 10000,
+      evaluationWindowMs: 1200,
+    });
+
+    let firstEvent = null;
+    for (let index = 0; index < 22; index += 1) {
+      firstEvent = firstEvent ?? test.controller.update(0.1);
+    }
+    expect(firstEvent?.step).toBe('quality-balanced');
+    expect(test.level).toBe('balanced');
+
+    let secondEvent = null;
+    for (let index = 0; index < 22; index += 1) {
+      secondEvent = secondEvent ?? test.controller.update(0.1);
+    }
+    expect(secondEvent?.step).toBe('quality-performance');
+    expect(test.level).toBe('performance');
+
+    let thirdEvent = null;
+    for (let index = 0; index < 22; index += 1) {
+      thirdEvent = thirdEvent ?? test.controller.update(0.1);
+    }
+    expect(thirdEvent?.step).toBe('pixel-ratio');
+    expect(test.basePixelRatio).toBeCloseTo(1);
+    expect(test.controller.update(1.1)).toBeNull();
+    expect(test.controller.isExhausted()).toBe(true);
+    expect(onAction).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent capable hardware from being permanently downgraded to `performance` due to startup/shader/asset warmup spikes while keeping conservative behavior for software/unknown-risk renderers.
- Make adaptive decisions more robust by adding warmup grace, rolling-window median/p95 hysteresis, and a safe recovery path when steady-state FPS returns.
- Surface adaptive policy state in diagnostics so captures can distinguish transient warmup behavior from sustained overload.

### Description
- Implement a warmup-aware adaptive controller in `src/scene/performance/adaptiveQuality.ts` that collects rolling frame samples, applies a warmup grace period for normal renderers, uses median/p95 hysteresis for downgrade decisions, supports cooldowns, and can recover `performance` → `balanced` after sustained stable FPS.
- Track renderer risk (`rendererInfo.riskLevel`) and preserve manual user selections via `markUserSelectedLevel`; wire an `onAction` hook to reset failover samples and refresh feature policy from `src/main.ts` when adaptive actions occur.
- Expand diagnostics so `window.portfolio.performance.getSnapshot().quality` exposes recovery counts, last downgrade/recovery reasons, adaptive policy snapshot (warmup, durations, source, renderer risk, last action), and add corresponding typings and Playwright/Unit assertions.
- Add/adjust Vitest tests in `src/tests/performanceOptimization.test.ts` and `src/tests/performanceDiagnostics.test.ts`, update Playwright expectations in `playwright/immersive-performance.spec.ts`, and document the change in `docs/` and `outages/` notes.

### Testing
- Ran formatting and lint: `npm run format:write` ✅ and `npm run lint` ✅.
- Unit tests: `npm run test:ci` executed full suite and reported all tests passing (128 files, 859 tests) ✅, and focused tests for adaptive policy passed (`src/tests/performanceOptimization.test.ts` & `src/tests/performanceDiagnostics.test.ts`) ✅.
- E2E: `npm run test:e2e -- --grep "adaptive|performance|immersive"` run (Playwright required `npx playwright install` / deps), resulting in the immersive/performance E2E checks passing with hardware-only assertions skipped where appropriate (Playwright run: 13 passed, 2 skipped) ✅.
- Docs & smoke: `npm run docs:check` ✅ and `npm run smoke` (build + artifact assertions) ✅.
- Typecheck: `npm run typecheck` reported failures unrelated to this change (pre-existing repository-wide TS issues), so typecheck is intentionally marked as not-red here (see notes) ❌.

Note: Playwright required browser installation in this environment (`npx playwright install` and host deps) which was performed during verification; `typecheck` failures are from existing repo typing issues outside the adaptive-quality scope and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8719e5d0832fba5810fd8a5f6c11)