### PR TITLE
🛡️ Harden software-renderer crash behavior

### DIFF
--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
@@ -26,7 +26,7 @@
     "Software-safe immersive starts with ultra-low DPR, disables expensive post-processing and mirror rendering, and caps render cadence to 12 FPS while keeping first-frame and input-driven rendering available.",
     "Visible warning UI explains software rendering / Basic Render Driver risk and offers safe immersive, explicit continuous immersive, and text-mode choices.",
     "Continuous software rendering requires ?softwareRendererMode=continuous or ?forceContinuousRendering=1.",
-    "Bounded crash breadcrumbs persist to browser localStorage with sessionStorage fallback, including renderer info, performance snapshots, quality/adaptive state, memory when available, warning/mode events, URL, and timestamps.",
+    "Bounded crash breadcrumbs persist to browser localStorage with sessionStorage fallback when local writes fail, including renderer info, performance snapshots, quality/adaptive state, memory when available, warning/mode events, URL, and timestamps.",
     "window.portfolio.performance.exportCrashLog() and copyCrashLog() expose the bounded crash log.",
     "webglcontextlost records an immediate breadcrumb and switches to recoverable fallback UI while preserving the crash-log export helper."
   ],

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
@@ -26,7 +26,7 @@
     "Software-safe immersive starts with ultra-low DPR, disables expensive post-processing and mirror rendering, and caps render cadence to 12 FPS while keeping first-frame and input-driven rendering available.",
     "Visible warning UI explains software rendering / Basic Render Driver risk and offers safe immersive, explicit continuous immersive, and text-mode choices.",
     "Continuous software rendering requires ?softwareRendererMode=continuous or ?forceContinuousRendering=1.",
-    "Bounded crash breadcrumbs persist to browser localStorage with sessionStorage fallback when local writes fail, including renderer info, performance snapshots, quality/adaptive state, memory when available, warning/mode events, URL, and timestamps.",
+    "Bounded crash breadcrumbs persist to browser localStorage with sessionStorage fallback when local writes fail, and exports choose the newest readable provider so stale local entries cannot hide newer fallback writes.",
     "window.portfolio.performance.exportCrashLog() and copyCrashLog() expose the bounded crash log.",
     "webglcontextlost records an immediate breadcrumb and switches to recoverable fallback UI while preserving the crash-log export helper."
   ],

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
@@ -1,0 +1,49 @@
+{
+  "title": "danielsmith.io software-renderer crash hardening",
+  "date": "2026-05-30",
+  "environment": "local forced-immersive Chrome with hardware acceleration off",
+  "status": "mitigation prepared for deployment validation",
+  "symptoms": [
+    "Chrome with hardware acceleration disabled selected ANGLE (Microsoft, Microsoft Basic Render Driver ..., D3D11).",
+    "The app classified the renderer as software and reduced cost through performance quality, lower DPR, disabled bloom/composer, and disabled mirror rendering.",
+    "JavaScript timings and heap movement did not indicate a clear application memory leak.",
+    "The tab still crashed after several seconds on Basic Render Driver.",
+    "The same machine with ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11) stayed near 60 FPS and did not crash."
+  ],
+  "rootCauseClass": "Dangerous software/CPU WebGL renderer instability under continuous animation, not a general memory leak or normal hardware GPU path bug.",
+  "dangerousRendererClass": [
+    "Microsoft Basic Render Driver",
+    "SwiftShader",
+    "WARP",
+    "llvmpipe",
+    "softpipe",
+    "Mesa offscreen",
+    "other existing software/CPU WebGL classifier matches"
+  ],
+  "mitigation": [
+    "Dangerous software renderers are classified separately from hardware and unknown renderers.",
+    "Forced immersive debug URLs still load immersive mode but apply software-safe guardrails by default on dangerous renderers.",
+    "Software-safe immersive starts with ultra-low DPR, disables expensive post-processing and mirror rendering, and caps render cadence to 12 FPS while keeping first-frame and input-driven rendering available.",
+    "Visible warning UI explains software rendering / Basic Render Driver risk and offers safe immersive, explicit continuous immersive, and text-mode choices.",
+    "Continuous software rendering requires ?softwareRendererMode=continuous or ?forceContinuousRendering=1.",
+    "Bounded crash breadcrumbs persist renderer info, performance snapshots, quality/adaptive state, memory when available, warning/mode events, URL, and timestamps.",
+    "window.portfolio.performance.exportCrashLog() and copyCrashLog() expose the bounded crash log.",
+    "webglcontextlost records an immediate breadcrumb and switches to recoverable fallback UI."
+  ],
+  "manualValidation": [
+    "Disable browser hardware acceleration and open /?mode=immersive&disablePerformanceFailover=1.",
+    "Confirm immersive mode remains active, warning UI is visible, and getSnapshot().softwareRendererPolicy.safeMode is true.",
+    "Export window.portfolio.performance.exportCrashLog() and verify renderer info, software-safe state, snapshots, URL, and timestamps.",
+    "Open /?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous only for short debugging runs and verify continuous mode is reported.",
+    "Re-enable hardware acceleration and verify the NVIDIA path remains continuous and is not forced into software-safe mode."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"software|crash|renderer|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
@@ -18,7 +18,7 @@
     "llvmpipe",
     "softpipe",
     "Mesa offscreen",
-    "other existing software/CPU WebGL classifier matches"
+    "software/CPU WebGL strings that match the dangerous classifier only"
   ],
   "mitigation": [
     "Dangerous software renderers are classified separately from hardware and unknown renderers.",
@@ -26,14 +26,14 @@
     "Software-safe immersive starts with ultra-low DPR, disables expensive post-processing and mirror rendering, and caps render cadence to 12 FPS while keeping first-frame and input-driven rendering available.",
     "Visible warning UI explains software rendering / Basic Render Driver risk and offers safe immersive, explicit continuous immersive, and text-mode choices.",
     "Continuous software rendering requires ?softwareRendererMode=continuous or ?forceContinuousRendering=1.",
-    "Bounded crash breadcrumbs persist renderer info, performance snapshots, quality/adaptive state, memory when available, warning/mode events, URL, and timestamps.",
+    "Bounded crash breadcrumbs persist to browser localStorage with sessionStorage fallback, including renderer info, performance snapshots, quality/adaptive state, memory when available, warning/mode events, URL, and timestamps.",
     "window.portfolio.performance.exportCrashLog() and copyCrashLog() expose the bounded crash log.",
-    "webglcontextlost records an immediate breadcrumb and switches to recoverable fallback UI."
+    "webglcontextlost records an immediate breadcrumb and switches to recoverable fallback UI while preserving the crash-log export helper."
   ],
   "manualValidation": [
     "Disable browser hardware acceleration and open /?mode=immersive&disablePerformanceFailover=1.",
     "Confirm immersive mode remains active, warning UI is visible, and getSnapshot().softwareRendererPolicy.safeMode is true.",
-    "Export window.portfolio.performance.exportCrashLog() and verify renderer info, software-safe state, snapshots, URL, and timestamps.",
+    "Export window.portfolio.performance.exportCrashLog(), verify renderer info, software-safe state, snapshots, URL, and timestamps, then reload and confirm the bounded browser-storage log remains available.",
     "Open /?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous only for short debugging runs and verify continuous mode is reported.",
     "Re-enable hardware acceleration and verify the NVIDIA path remains continuous and is not forced into software-safe mode."
   ],

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -45,9 +45,10 @@ covered by the software-renderer classifier.
   override: `?softwareRendererMode=continuous` or `?forceContinuousRendering=1`.
 - Crash breadcrumbs persist to bounded browser storage (`localStorage`, with
   `sessionStorage` as the browser fallback when local writes fail, even when
-  `localStorage` is passed explicitly) and are exported from
-  `window.portfolio.performance.exportCrashLog()`; `copyCrashLog()` copies the
-  same bounded JSON when Clipboard API access is available.
+  `localStorage` is passed explicitly). Exports choose the newest readable log
+  across providers so stale local entries cannot hide newer fallback writes.
+  `window.portfolio.performance.exportCrashLog()` exports that bounded JSON;
+  `copyCrashLog()` copies it when Clipboard API access is available.
 - `webglcontextlost` records an immediate breadcrumb before switching to the
   recoverable text fallback, while preserving the existing “Try immersive
   again” path and crash-log export helper after cleanup.

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -43,11 +43,13 @@ covered by the software-renderer classifier.
   text mode.
 - Continuous software rendering is available only through an explicit debug
   override: `?softwareRendererMode=continuous` or `?forceContinuousRendering=1`.
-- Crash breadcrumbs persist to bounded storage and are exported from
+- Crash breadcrumbs persist to bounded browser storage (`localStorage`, with
+  `sessionStorage` as the browser fallback) and are exported from
   `window.portfolio.performance.exportCrashLog()`; `copyCrashLog()` copies the
   same bounded JSON when Clipboard API access is available.
 - `webglcontextlost` records an immediate breadcrumb before switching to the
-  recoverable text fallback with the existing “Try immersive again” path.
+  recoverable text fallback, while preserving the existing “Try immersive
+  again” path and crash-log export helper after cleanup.
 
 ## Manual validation
 
@@ -57,7 +59,8 @@ covered by the software-renderer classifier.
    reports `softwareRendererPolicy.safeMode === true` from
    `window.portfolio.performance.getSnapshot()`.
 4. Export `window.portfolio.performance.exportCrashLog()` and confirm it includes
-   renderer info, software-safe state, snapshots, URL, and timestamps.
+   renderer info, software-safe state, snapshots, URL, and timestamps; reload and
+   confirm the bounded log can still be exported from browser storage.
 5. Open `/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous`
    only for short debugging runs and confirm the snapshot reports continuous
    mode.

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -44,7 +44,8 @@ covered by the software-renderer classifier.
 - Continuous software rendering is available only through an explicit debug
   override: `?softwareRendererMode=continuous` or `?forceContinuousRendering=1`.
 - Crash breadcrumbs persist to bounded browser storage (`localStorage`, with
-  `sessionStorage` as the browser fallback when local writes fail) and are exported from
+  `sessionStorage` as the browser fallback when local writes fail, even when
+  `localStorage` is passed explicitly) and are exported from
   `window.portfolio.performance.exportCrashLog()`; `copyCrashLog()` copies the
   same bounded JSON when Clipboard API access is available.
 - `webglcontextlost` records an immediate breadcrumb before switching to the

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -44,7 +44,7 @@ covered by the software-renderer classifier.
 - Continuous software rendering is available only through an explicit debug
   override: `?softwareRendererMode=continuous` or `?forceContinuousRendering=1`.
 - Crash breadcrumbs persist to bounded browser storage (`localStorage`, with
-  `sessionStorage` as the browser fallback) and are exported from
+  `sessionStorage` as the browser fallback when local writes fail) and are exported from
   `window.portfolio.performance.exportCrashLog()`; `copyCrashLog()` copies the
   same bounded JSON when Clipboard API access is available.
 - `webglcontextlost` records an immediate breadcrumb before switching to the

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -1,0 +1,78 @@
+# danielsmith.io software-renderer crash hardening
+
+- **Date:** 2026-05-30
+- **Environment:** local forced-immersive Chrome with hardware acceleration off
+- **Status:** Mitigation prepared for deployment validation
+
+## Symptoms
+
+Forced immersive validation with Chrome hardware acceleration disabled selected
+`ANGLE (Microsoft, Microsoft Basic Render Driver ..., D3D11)`. The app correctly
+identified a software renderer, downgraded to performance quality, reduced DPR
+to roughly 0.56, disabled bloom/composer/mirror work, and kept runtime text
+failover disabled for the debug run. JavaScript phase timings stayed tiny while
+`mainRender` dominated the frame budget, and JS heap movement did not show a
+clear monotonic leak. Even with those reductions, the Chrome tab crashed after
+several seconds.
+
+The same machine with hardware acceleration enabled selected
+`ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11)`, stayed near 60 FPS, and
+did not crash.
+
+## Root cause class
+
+The evidence points to dangerous software/CPU WebGL renderer instability under
+continuous animation rather than a general memory leak or a normal hardware GPU
+path bug. The risky class now includes Microsoft Basic Render Driver,
+SwiftShader, WARP, llvmpipe, softpipe, Mesa offscreen, and other strings already
+covered by the software-renderer classifier.
+
+## Mitigation
+
+- Dangerous software renderers are classified separately from ordinary hardware
+  and unknown renderers.
+- Forced immersive debug URLs still load the immersive scene, but dangerous
+  software renderers start in software-safe immersive mode by default.
+- Software-safe immersive mode starts at ultra-low DPR, disables expensive
+  post-processing and mirror rendering, and caps render cadence to 12 FPS while
+  still rendering the first frame and responding to user input for screenshots
+  and debugging.
+- A visible warning explains that Chrome is using software rendering / Basic
+  Render Driver, recommends enabling browser hardware acceleration, and offers
+  actions to continue safely, opt into continuous rendering anyway, or switch to
+  text mode.
+- Continuous software rendering is available only through an explicit debug
+  override: `?softwareRendererMode=continuous` or `?forceContinuousRendering=1`.
+- Crash breadcrumbs persist to bounded storage and are exported from
+  `window.portfolio.performance.exportCrashLog()`; `copyCrashLog()` copies the
+  same bounded JSON when Clipboard API access is available.
+- `webglcontextlost` records an immediate breadcrumb before switching to the
+  recoverable text fallback with the existing “Try immersive again” path.
+
+## Manual validation
+
+1. Disable browser hardware acceleration and launch Chrome.
+2. Open `/?mode=immersive&disablePerformanceFailover=1`.
+3. Confirm the page remains immersive, shows the software-renderer warning, and
+   reports `softwareRendererPolicy.safeMode === true` from
+   `window.portfolio.performance.getSnapshot()`.
+4. Export `window.portfolio.performance.exportCrashLog()` and confirm it includes
+   renderer info, software-safe state, snapshots, URL, and timestamps.
+5. Open `/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous`
+   only for short debugging runs and confirm the snapshot reports continuous
+   mode.
+6. Re-enable browser hardware acceleration, open the normal forced-immersive URL,
+   and confirm the NVIDIA path remains continuous and is not forced into
+   software-safe mode.
+
+## Expected validation commands
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "software|crash|renderer|immersive"
+npm run docs:check
+npm run smoke
+```

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -49,7 +49,14 @@ interface PerformanceSnapshot {
   };
   renderer: {
     isSoftwareRenderer: boolean;
-    riskLevel: 'normal' | 'software' | 'unknown';
+    isDangerousSoftwareRenderer: boolean;
+    riskLevel: 'normal' | 'software' | 'dangerous-software' | 'unknown';
+  };
+  softwareRendererPolicy: {
+    mode: 'safe' | 'continuous';
+    safeMode: boolean;
+    renderCadenceFps: number | null;
+    reason: string;
   };
   lastFailoverReason: string | null;
 }

--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
-const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_PREVIEW_URL =
+  '/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous';
 
 interface MotionBlurState {
   enabled: boolean;

--- a/playwright/software-renderer-crash.spec.ts
+++ b/playwright/software-renderer-crash.spec.ts
@@ -74,10 +74,19 @@ test.describe('software renderer crash hardening', () => {
       page.locator('[data-action="continuous-immersive"]')
     ).toHaveAttribute('href', /softwareRendererMode=continuous/);
 
-    const crashLog = await page.evaluate(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).portfolio.performance.exportCrashLog()
-    );
+    const crashLog = await page.evaluate(() => {
+      const performanceDiagnostics =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).portfolio.performance;
+      for (let index = 0; index < 80; index += 1) {
+        performanceDiagnostics.recordSnapshot?.(
+          performanceDiagnostics.getSnapshot()
+        );
+      }
+      return performanceDiagnostics.exportCrashLog();
+    });
+    const parsedCrashLog = JSON.parse(crashLog) as { entries: unknown[] };
+    expect(parsedCrashLog.entries.length).toBeLessThanOrEqual(40);
     expect(crashLog.length).toBeLessThan(100_000);
     expect(crashLog).toContain('renderer-warning');
     expect(crashLog).toContain('Basic Render Driver');

--- a/playwright/software-renderer-crash.spec.ts
+++ b/playwright/software-renderer-crash.spec.ts
@@ -92,6 +92,33 @@ test.describe('software renderer crash hardening', () => {
     expect(crashLog).toContain('Basic Render Driver');
   });
 
+  test('context loss records a breadcrumb before recoverable fallback', async ({
+    page,
+  }) => {
+    await mockDangerousRenderer(page);
+    await page.goto('/?mode=immersive&disablePerformanceFailover=1', {
+      waitUntil: 'domcontentloaded',
+    });
+    await waitForImmersive(page);
+
+    await page.locator('#app canvas').dispatchEvent('webglcontextlost');
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-app-mode',
+      'fallback'
+    );
+    await expect(
+      page.getByRole('link', { name: 'Try immersive again' })
+    ).toBeVisible();
+
+    const crashLog = await page.evaluate(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).portfolio.performance.exportCrashLog()
+    );
+    expect(crashLog).toContain('webgl-context-lost');
+    expect(crashLog).toContain('recoverable fallback');
+  });
+
   test('explicit continuous override bypasses the safe cadence cap', async ({
     page,
   }) => {

--- a/playwright/software-renderer-crash.spec.ts
+++ b/playwright/software-renderer-crash.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const BASIC_RENDERER =
+  'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)';
+
+async function mockDangerousRenderer(page: Page) {
+  await page.addInitScript((rendererName) => {
+    const patchGetParameter = (
+      prototype: WebGLRenderingContext | WebGL2RenderingContext
+    ) => {
+      const original = prototype.getParameter;
+      Object.defineProperty(prototype, 'getParameter', {
+        configurable: true,
+        value(parameter: number) {
+          if (parameter === this.RENDERER) {
+            return 'WebGL';
+          }
+          if (parameter === this.VENDOR) {
+            return 'Google Inc.';
+          }
+          if (parameter === 0x9246) {
+            return rendererName;
+          }
+          if (parameter === 0x9245) {
+            return 'Microsoft';
+          }
+          return original.call(this, parameter);
+        },
+      });
+    };
+    patchGetParameter(WebGLRenderingContext.prototype);
+    if (typeof WebGL2RenderingContext !== 'undefined') {
+      patchGetParameter(WebGL2RenderingContext.prototype);
+    }
+  }, BASIC_RENDERER);
+}
+
+async function waitForImmersive(page: Page) {
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'immersive',
+    {
+      timeout: IMMERSIVE_READY_TIMEOUT_MS,
+    }
+  );
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+test.describe('software renderer crash hardening', () => {
+  test('dangerous renderer shows warning choices and keeps force immersive in safe mode', async ({
+    page,
+  }) => {
+    await mockDangerousRenderer(page);
+    await page.goto('/?mode=immersive&disablePerformanceFailover=1', {
+      waitUntil: 'domcontentloaded',
+    });
+    await waitForImmersive(page);
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-dangerous-renderer',
+      'true'
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-software-renderer-mode',
+      'safe'
+    );
+    await expect(page.locator('.software-renderer-warning')).toBeVisible();
+    await expect(page.getByText('Software rendering detected')).toBeVisible();
+    await expect(
+      page.locator('[data-action="continue-safe-immersive"]')
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-action="continuous-immersive"]')
+    ).toHaveAttribute('href', /softwareRendererMode=continuous/);
+
+    const crashLog = await page.evaluate(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).portfolio.performance.exportCrashLog()
+    );
+    expect(crashLog.length).toBeLessThan(100_000);
+    expect(crashLog).toContain('renderer-warning');
+    expect(crashLog).toContain('Basic Render Driver');
+  });
+
+  test('explicit continuous override bypasses the safe cadence cap', async ({
+    page,
+  }) => {
+    await mockDangerousRenderer(page);
+    await page.goto(
+      '/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous',
+      { waitUntil: 'domcontentloaded' }
+    );
+    await waitForImmersive(page);
+
+    const policy = await page.evaluate(
+      () =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).portfolio.performance.getSnapshot()
+          .softwareRendererPolicy
+    );
+    expect(policy).toMatchObject({ mode: 'continuous', safeMode: false });
+  });
+});

--- a/playwright/software-renderer-crash.spec.ts
+++ b/playwright/software-renderer-crash.spec.ts
@@ -87,7 +87,7 @@ test.describe('software renderer crash hardening', () => {
     });
     const parsedCrashLog = JSON.parse(crashLog) as { entries: unknown[] };
     expect(parsedCrashLog.entries.length).toBeLessThanOrEqual(40);
-    expect(crashLog.length).toBeLessThan(100_000);
+    expect(new Blob([crashLog]).size).toBeLessThan(100_000);
     expect(crashLog).toContain('renderer-warning');
     expect(crashLog).toContain('Basic Render Driver');
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,7 @@ import { createAdaptiveQualityController } from './scene/performance/adaptiveQua
 import { createCrashBreadcrumbStore } from './scene/performance/crashBreadcrumbs';
 import {
   createPerformanceDiagnostics,
+  type PerformanceCrashBreadcrumbApi,
   type PerformanceDiagnosticsApi,
 } from './scene/performance/performanceDiagnostics';
 import {
@@ -432,7 +433,7 @@ declare global {
         }>;
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
-      performance?: PerformanceDiagnosticsApi;
+      performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -3367,6 +3368,12 @@ function initializeImmersiveScene(
   });
   applyFeaturePolicy();
 
+  const crashLogAccess: PerformanceCrashBreadcrumbApi = {
+    exportCrashLog: () => crashBreadcrumbs.exportCrashLog(),
+    copyCrashLog: () => crashBreadcrumbs.copyCrashLog(),
+    recordSnapshot: (snapshot) => crashBreadcrumbs.recordSnapshot(snapshot),
+  };
+
   performanceDiagnostics = createPerformanceDiagnostics({
     rendererInfo,
     getRendererSize: () => ({
@@ -3404,8 +3411,9 @@ function initializeImmersiveScene(
     },
     getLastFailoverReason: () => lastFailoverReason,
     getSoftwareRendererPolicy: () => softwareRendererPolicy,
-    exportCrashLog: () => crashBreadcrumbs.exportCrashLog(),
-    copyCrashLog: () => crashBreadcrumbs.copyCrashLog(),
+    exportCrashLog: crashLogAccess.exportCrashLog,
+    copyCrashLog: crashLogAccess.copyCrashLog,
+    recordSnapshot: crashLogAccess.recordSnapshot,
   });
   const portfolioWindow = window as Window;
   if (!portfolioWindow.portfolio) {
@@ -4079,7 +4087,7 @@ function initializeImmersiveScene(
       delete window.portfolio.graphics;
     }
     if (window.portfolio?.performance) {
-      delete window.portfolio.performance;
+      window.portfolio.performance = crashLogAccess;
     }
     if (helpButton) {
       helpButton.textContent = buildHelpButtonText(helpLabelFallback);

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,6 +145,7 @@ import {
   resolveResizedBasePixelRatio,
   resolveInitialQualityPolicy,
   resolveSoftwareRendererPolicy,
+  resolveSoftwareSafeRenderCadence,
 } from './scene/performance/qualityPolicy';
 import { getRendererInfo } from './scene/performance/rendererCapabilities';
 import { createWindowPoiAnalytics } from './scene/poi/analytics';
@@ -4167,17 +4168,19 @@ function initializeImmersiveScene(
   renderer.setAnimationLoop(() => {
     try {
       const frameStartMs = performance.now();
-      if (softwareRendererPolicy.safeMode && hasPresentedFirstFrame) {
-        const hasCadenceElapsed =
-          softwareSafeRenderIntervalMs > 0 &&
-          frameStartMs - lastSoftwareSafeRenderMs >=
-            softwareSafeRenderIntervalMs;
-        if (!softwareSafeRenderRequested && !hasCadenceElapsed) {
-          return;
-        }
+      const cadenceDecision = resolveSoftwareSafeRenderCadence({
+        safeMode: softwareRendererPolicy.safeMode,
+        hasPresentedFirstFrame,
+        renderRequested: softwareSafeRenderRequested,
+        lastRenderMs: lastSoftwareSafeRenderMs,
+        nowMs: frameStartMs,
+        renderIntervalMs: softwareSafeRenderIntervalMs,
+      });
+      if (!cadenceDecision.shouldRender) {
+        return;
       }
-      softwareSafeRenderRequested = false;
-      lastSoftwareSafeRenderMs = frameStartMs;
+      softwareSafeRenderRequested = cadenceDecision.renderRequested;
+      lastSoftwareSafeRenderMs = cadenceDecision.lastRenderMs;
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,7 @@ import {
   resolveSeasonalLightingSchedule,
 } from './scene/lighting/seasonalPresets';
 import { createAdaptiveQualityController } from './scene/performance/adaptiveQuality';
+import { createCrashBreadcrumbStore } from './scene/performance/crashBreadcrumbs';
 import {
   createPerformanceDiagnostics,
   type PerformanceDiagnosticsApi,
@@ -142,6 +143,7 @@ import {
   getQualityFeaturePolicy,
   resolveResizedBasePixelRatio,
   resolveInitialQualityPolicy,
+  resolveSoftwareRendererPolicy,
 } from './scene/performance/qualityPolicy';
 import { getRendererInfo } from './scene/performance/rendererCapabilities';
 import { createWindowPoiAnalytics } from './scene/poi/analytics';
@@ -388,10 +390,14 @@ import {
   type ResponsiveControlOverlayHandle,
 } from './ui/hud/responsiveControlOverlay';
 import {
+  createContinuousSoftwareImmersiveUrl,
   createImmersiveModeUrl,
+  createSoftwareSafeImmersiveUrl,
   createImmersiveRecoveryUrl,
+  createTextModeUrl,
   shouldDisablePerformanceFailover,
 } from './ui/immersiveUrl';
+import { createSoftwareRendererWarning } from './ui/softwareRendererWarning';
 import './ui/styles.css';
 
 const WALL_HEIGHT = 6;
@@ -676,11 +682,39 @@ function initializeImmersiveScene(
   renderer.toneMapping = ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.1;
   const rendererInfo = getRendererInfo(renderer);
+  const softwareRendererPolicy = resolveSoftwareRendererPolicy(
+    rendererInfo,
+    window.location.search
+  );
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
-    window.devicePixelRatio ?? 1
+    window.devicePixelRatio ?? 1,
+    softwareRendererPolicy
   );
-  const maxPolicyPixelRatioCap = rendererInfo.isSoftwareRenderer ? 1 : 1.25;
+  const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
+    ? initialQualityPolicy.basePixelRatioCap
+    : rendererInfo.isSoftwareRenderer
+      ? 0.75
+      : 1.25;
+  document.documentElement.dataset.softwareRendererMode =
+    softwareRendererPolicy.mode;
+  document.documentElement.dataset.dangerousRenderer = String(
+    rendererInfo.isDangerousSoftwareRenderer
+  );
+
+  const crashBreadcrumbs = createCrashBreadcrumbStore({
+    storage: (() => {
+      try {
+        return window.localStorage;
+      } catch {
+        try {
+          return window.sessionStorage;
+        } catch {
+          return undefined;
+        }
+      }
+    })(),
+  });
   let adaptivePixelRatioCap = Number.POSITIVE_INFINITY;
   let basePixelRatio = initialQualityPolicy.basePixelRatioCap;
   renderer.setPixelRatio(basePixelRatio);
@@ -728,6 +762,38 @@ function initializeImmersiveScene(
   let avatarAccessoryProgression: AvatarAccessoryProgressionHandle | null =
     null;
   let avatarAssetPipeline: AvatarAssetPipeline | null = null;
+  let softwareRendererWarning: ReturnType<
+    typeof createSoftwareRendererWarning
+  > | null = null;
+  let softwareSafeRenderRequested = true;
+  const softwareSafeRenderEvents = [
+    'keydown',
+    'pointerdown',
+    'pointermove',
+    'wheel',
+    'resize',
+  ] as const;
+  const requestSoftwareSafeRender = () => {
+    softwareSafeRenderRequested = true;
+  };
+  const recordRendererWarning = (message: string) => {
+    crashBreadcrumbs.record({
+      type: 'renderer-warning',
+      message,
+      renderer: rendererInfo,
+      softwareRendererPolicy,
+    });
+  };
+  if (rendererInfo.isDangerousSoftwareRenderer) {
+    softwareRendererWarning = createSoftwareRendererWarning({
+      rendererInfo,
+      safeUrl: createSoftwareSafeImmersiveUrl(),
+      continuousUrl: createContinuousSoftwareImmersiveUrl(),
+      textUrl: createTextModeUrl(),
+      onContinueSafe: requestSoftwareSafeRender,
+      onVisible: recordRendererWarning,
+    });
+  }
   let hudFocusAnnouncer: HudFocusAnnouncerHandle | null = null;
   let helpModalController: HelpModalControllerHandle | null = null;
   let poiNarrativeLog: PoiNarrativeLogHandle | null = null;
@@ -886,6 +952,13 @@ function initializeImmersiveScene(
   });
 
   const handleFatalError = (error: unknown) => {
+    crashBreadcrumbs.record({
+      type: 'fatal-error',
+      message: error instanceof Error ? error.message : String(error),
+      renderer: rendererInfo,
+      softwareRendererPolicy,
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+    });
     disposeImmersiveResources();
     onFatalError(error, { renderer });
   };
@@ -3281,7 +3354,8 @@ function initializeImmersiveScene(
     return count;
   };
 
-  const shouldUseComposer = () => getActivePostprocessingPassCount() > 0;
+  const shouldUseComposer = () =>
+    !softwareRendererPolicy.safeMode && getActivePostprocessingPassCount() > 0;
 
   unsubscribeGraphicsQuality = graphicsQualityManager.onChange(() => {
     applyFeaturePolicy();
@@ -3329,6 +3403,9 @@ function initializeImmersiveScene(
       };
     },
     getLastFailoverReason: () => lastFailoverReason,
+    getSoftwareRendererPolicy: () => softwareRendererPolicy,
+    exportCrashLog: () => crashBreadcrumbs.exportCrashLog(),
+    copyCrashLog: () => crashBreadcrumbs.copyCrashLog(),
   });
   const portfolioWindow = window as Window;
   if (!portfolioWindow.portfolio) {
@@ -3826,6 +3903,11 @@ function initializeImmersiveScene(
       inputLatencyTelemetry.dispose();
       inputLatencyTelemetry = null;
     }
+    softwareSafeRenderEvents.forEach((eventName) => {
+      window.removeEventListener(eventName, requestSoftwareSafeRender);
+    });
+    softwareRendererWarning?.dispose();
+    softwareRendererWarning = null;
     immersiveDisposed = true;
     ledAnimator = null;
     lightmapAnimator = null;
@@ -4062,13 +4144,44 @@ function initializeImmersiveScene(
     gitshelvesInstallation = null;
   }
 
+  const softwareSafeRenderIntervalMs = softwareRendererPolicy.renderCadenceFps
+    ? 1000 / softwareRendererPolicy.renderCadenceFps
+    : 0;
   let hasPresentedFirstFrame = false;
+  let lastSoftwareSafeRenderMs = 0;
+  let lastCrashBreadcrumbSnapshotMs = 0;
+  softwareSafeRenderEvents.forEach((eventName) => {
+    window.addEventListener(eventName, requestSoftwareSafeRender, {
+      passive: true,
+    });
+  });
 
   renderer.setAnimationLoop(() => {
     try {
+      const frameStartMs = performance.now();
+      if (softwareRendererPolicy.safeMode && hasPresentedFirstFrame) {
+        const hasCadenceElapsed =
+          softwareSafeRenderIntervalMs > 0 &&
+          frameStartMs - lastSoftwareSafeRenderMs >=
+            softwareSafeRenderIntervalMs;
+        if (!softwareSafeRenderRequested && !hasCadenceElapsed) {
+          return;
+        }
+      }
+      softwareSafeRenderRequested = false;
+      lastSoftwareSafeRenderMs = frameStartMs;
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);
+      if (
+        performanceDiagnostics &&
+        frameStartMs - lastCrashBreadcrumbSnapshotMs >= 1000
+      ) {
+        lastCrashBreadcrumbSnapshotMs = frameStartMs;
+        crashBreadcrumbs.recordSnapshot(
+          performanceDiagnostics.methods.getSnapshot()
+        );
+      }
       const adaptiveAction = adaptiveQualityController?.update(delta);
       if (adaptiveAction) {
         applyFeaturePolicy();
@@ -4305,6 +4418,15 @@ function initializeImmersiveScene(
 
   renderer.domElement.addEventListener('webglcontextlost', (event) => {
     event.preventDefault();
-    handleFatalError(new Error('WebGL context lost during initialization.'));
+    crashBreadcrumbs.record({
+      type: 'webgl-context-lost',
+      message: 'WebGL context lost; switching to a recoverable fallback.',
+      renderer: rendererInfo,
+      softwareRendererPolicy,
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+    });
+    handleFatalError(
+      new Error('WebGL context lost; try immersive again after recovery.')
+    );
   });
 }

--- a/src/scene/graphics/motionBlurController.ts
+++ b/src/scene/graphics/motionBlurController.ts
@@ -95,6 +95,7 @@ export function createMotionBlurController({
     } finally {
       pass.uniforms.damp.value = previousDamp;
       shouldResetHistory = false;
+      pass.enabled = currentIntensity > 0;
     }
   };
 
@@ -111,7 +112,9 @@ export function createMotionBlurController({
       currentIntensity,
       resolvedMaxDamp
     );
-    pass.enabled = currentIntensity > 0;
+    const transitionedAcrossDisabledState =
+      (currentIntensity === 0) !== (previousIntensity === 0);
+    pass.enabled = currentIntensity > 0 || transitionedAcrossDisabledState;
 
     if (currentIntensity === 0 || previousIntensity === 0) {
       resetHistory();

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -1,0 +1,196 @@
+import type { PerformanceDiagnosticsSnapshot } from './performanceDiagnostics';
+import type { SoftwareRendererPolicyState } from './qualityPolicy';
+import type { RendererInfoSnapshot } from './rendererCapabilities';
+
+export type CrashBreadcrumbEventType =
+  | 'snapshot'
+  | 'renderer-warning'
+  | 'mode-change'
+  | 'webgl-context-lost'
+  | 'fatal-error';
+
+export interface CrashBreadcrumbEntry {
+  type: CrashBreadcrumbEventType;
+  timestamp: string;
+  pageUrl: string;
+  message?: string;
+  snapshot?: PerformanceDiagnosticsSnapshot;
+  renderer?: RendererInfoSnapshot;
+  softwareRendererPolicy?: SoftwareRendererPolicyState;
+  memory?: {
+    usedJSHeapSize: number;
+    totalJSHeapSize: number;
+    jsHeapSizeLimit: number;
+  } | null;
+}
+
+export interface CrashBreadcrumbLog {
+  version: 1;
+  updatedAt: string;
+  entries: CrashBreadcrumbEntry[];
+}
+
+export interface CrashBreadcrumbStore {
+  record(
+    entry: Omit<CrashBreadcrumbEntry, 'timestamp' | 'pageUrl' | 'memory'>
+  ): void;
+  recordSnapshot(snapshot: PerformanceDiagnosticsSnapshot): void;
+  exportCrashLog(): string;
+  copyCrashLog(): Promise<boolean>;
+  read(): CrashBreadcrumbLog;
+  clear(): void;
+}
+
+const CRASH_LOG_KEY = 'danielsmith.io:immersive-crash-breadcrumbs';
+const DEFAULT_MAX_ENTRIES = 40;
+const DEFAULT_MAX_SERIALIZED_BYTES = 96_000;
+
+type StorageProvider = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+type MemoryLike = {
+  usedJSHeapSize?: number;
+  totalJSHeapSize?: number;
+  jsHeapSizeLimit?: number;
+};
+
+const emptyLog = (): CrashBreadcrumbLog => ({
+  version: 1,
+  updatedAt: new Date(0).toISOString(),
+  entries: [],
+});
+
+const getPageUrl = () =>
+  typeof window === 'undefined' ? 'about:blank' : window.location.href;
+
+const getMemorySnapshot = () => {
+  const performanceWithMemory = (
+    typeof performance === 'undefined' ? undefined : performance
+  ) as (Performance & { memory?: MemoryLike }) | undefined;
+  const memory = performanceWithMemory?.memory;
+  if (!memory || typeof memory.usedJSHeapSize !== 'number') {
+    return null;
+  }
+  return {
+    usedJSHeapSize: memory.usedJSHeapSize ?? 0,
+    totalJSHeapSize: memory.totalJSHeapSize ?? 0,
+    jsHeapSizeLimit: memory.jsHeapSizeLimit ?? 0,
+  };
+};
+
+const safeParse = (value: string | null): CrashBreadcrumbLog => {
+  if (!value) {
+    return emptyLog();
+  }
+  try {
+    const parsed = JSON.parse(value) as Partial<CrashBreadcrumbLog>;
+    if (parsed.version === 1 && Array.isArray(parsed.entries)) {
+      return {
+        version: 1,
+        updatedAt:
+          typeof parsed.updatedAt === 'string'
+            ? parsed.updatedAt
+            : new Date(0).toISOString(),
+        entries: parsed.entries.filter(
+          (entry): entry is CrashBreadcrumbEntry =>
+            typeof entry === 'object' &&
+            entry !== null &&
+            typeof entry.type === 'string'
+        ),
+      };
+    }
+  } catch {
+    // Corrupt breadcrumbs should not block the page.
+  }
+  return emptyLog();
+};
+
+const serializeBounded = (
+  log: CrashBreadcrumbLog,
+  maxEntries: number,
+  maxSerializedBytes: number
+): string => {
+  let bounded: CrashBreadcrumbLog = {
+    ...log,
+    entries: log.entries.slice(-maxEntries),
+  };
+  let serialized = JSON.stringify(bounded);
+  while (serialized.length > maxSerializedBytes && bounded.entries.length > 1) {
+    bounded = { ...bounded, entries: bounded.entries.slice(1) };
+    serialized = JSON.stringify(bounded);
+  }
+  return serialized;
+};
+
+export function createCrashBreadcrumbStore({
+  storage,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+  maxSerializedBytes = DEFAULT_MAX_SERIALIZED_BYTES,
+}: {
+  storage?: StorageProvider;
+  maxEntries?: number;
+  maxSerializedBytes?: number;
+} = {}): CrashBreadcrumbStore {
+  const fallbackStorage = new Map<string, string>();
+  const safeStorage: StorageProvider = storage ?? {
+    getItem: (key) => fallbackStorage.get(key) ?? null,
+    setItem: (key, value) => {
+      fallbackStorage.set(key, value);
+    },
+    removeItem: (key) => {
+      fallbackStorage.delete(key);
+    },
+  };
+
+  const read = () => safeParse(safeStorage.getItem(CRASH_LOG_KEY));
+  const write = (log: CrashBreadcrumbLog) => {
+    safeStorage.setItem(
+      CRASH_LOG_KEY,
+      serializeBounded(log, maxEntries, maxSerializedBytes)
+    );
+  };
+
+  return {
+    record(entry) {
+      const timestamp = new Date().toISOString();
+      const log = read();
+      write({
+        version: 1,
+        updatedAt: timestamp,
+        entries: [
+          ...log.entries,
+          {
+            ...entry,
+            timestamp,
+            pageUrl: getPageUrl(),
+            memory: getMemorySnapshot(),
+          },
+        ],
+      });
+    },
+    recordSnapshot(snapshot) {
+      this.record({
+        type: 'snapshot',
+        snapshot,
+        renderer: snapshot.renderer,
+        softwareRendererPolicy: snapshot.softwareRendererPolicy,
+      });
+    },
+    exportCrashLog() {
+      return JSON.stringify(read(), null, 2);
+    },
+    async copyCrashLog() {
+      const text = this.exportCrashLog();
+      if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+        return false;
+      }
+      await navigator.clipboard.writeText(text);
+      return true;
+    },
+    read,
+    clear() {
+      safeStorage.removeItem(CRASH_LOG_KEY);
+    },
+  };
+}
+
+export { CRASH_LOG_KEY };

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -128,18 +128,40 @@ const safeParse = (value: string | null): CrashBreadcrumbLog => {
   return emptyLog();
 };
 
+const removeOldestSnapshotOrEntry = (
+  entries: CrashBreadcrumbEntry[]
+): CrashBreadcrumbEntry[] => {
+  if (entries.length <= 1) {
+    return entries;
+  }
+
+  const oldestSnapshotIndex = entries.findIndex(
+    (entry, index) => entry.type === 'snapshot' && index < entries.length - 1
+  );
+  const removeIndex = oldestSnapshotIndex >= 0 ? oldestSnapshotIndex : 0;
+  return entries.filter((_, index) => index !== removeIndex);
+};
+
 const serializeBounded = (
   log: CrashBreadcrumbLog,
   maxEntries: number,
   maxSerializedBytes: number
 ): string => {
+  let entries = [...log.entries];
+  while (entries.length > maxEntries) {
+    entries = removeOldestSnapshotOrEntry(entries);
+  }
+
   let bounded: CrashBreadcrumbLog = {
     ...log,
-    entries: log.entries.slice(-maxEntries),
+    entries,
   };
   let serialized = JSON.stringify(bounded);
   while (serialized.length > maxSerializedBytes && bounded.entries.length > 1) {
-    bounded = { ...bounded, entries: bounded.entries.slice(1) };
+    bounded = {
+      ...bounded,
+      entries: removeOldestSnapshotOrEntry(bounded.entries),
+    };
     serialized = JSON.stringify(bounded);
   }
   return serialized;
@@ -225,7 +247,8 @@ export function createCrashBreadcrumbStore({
       softwareRendererPolicy: snapshot.softwareRendererPolicy,
     });
   };
-  const exportCrashLog = () => JSON.stringify(read(), null, 2);
+  const exportCrashLog = () =>
+    serializeBounded(read(), maxEntries, maxSerializedBytes);
 
   return {
     record,

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -77,20 +77,28 @@ const getMemorySnapshot = () => {
   };
 };
 
-const getDefaultBrowserStorage = (): StorageProvider | undefined => {
+const getDefaultBrowserStorageCandidates = (): StorageProvider[] => {
   if (typeof window === 'undefined') {
-    return undefined;
+    return [];
+  }
+
+  const candidates: StorageProvider[] = [];
+  try {
+    candidates.push(window.localStorage);
+  } catch {
+    // Fall through to sessionStorage when localStorage access is blocked.
   }
 
   try {
-    return window.localStorage;
-  } catch {
-    try {
-      return window.sessionStorage;
-    } catch {
-      return undefined;
+    const sessionStorage = window.sessionStorage;
+    if (!candidates.includes(sessionStorage)) {
+      candidates.push(sessionStorage);
     }
+  } catch {
+    // Storage access can throw in private or locked-down browser contexts.
   }
+
+  return candidates;
 };
 
 const safeParse = (value: string | null): CrashBreadcrumbLog => {
@@ -156,24 +164,40 @@ export function createCrashBreadcrumbStore({
       fallbackStorage.delete(key);
     },
   };
-  const safeStorage: StorageProvider =
-    storage ?? getDefaultBrowserStorage() ?? memoryStorage;
+  const storageCandidates = storage
+    ? [storage]
+    : [...getDefaultBrowserStorageCandidates(), memoryStorage];
+  let activeStorageIndex = 0;
+
+  const candidateOrder = () => [
+    ...storageCandidates.slice(activeStorageIndex),
+    ...storageCandidates.slice(0, activeStorageIndex),
+  ];
 
   const read = () => {
-    try {
-      return safeParse(safeStorage.getItem(CRASH_LOG_KEY));
-    } catch {
-      return emptyLog();
+    for (const candidate of candidateOrder()) {
+      try {
+        const serializedLog = candidate.getItem(CRASH_LOG_KEY);
+        if (serializedLog) {
+          activeStorageIndex = storageCandidates.indexOf(candidate);
+          return safeParse(serializedLog);
+        }
+      } catch {
+        // Try the next storage provider before dropping to an empty log.
+      }
     }
+    return emptyLog();
   };
   const write = (log: CrashBreadcrumbLog) => {
-    try {
-      safeStorage.setItem(
-        CRASH_LOG_KEY,
-        serializeBounded(log, maxEntries, maxSerializedBytes)
-      );
-    } catch {
-      // Breadcrumbs are best-effort diagnostics and must never break rendering.
+    const serializedLog = serializeBounded(log, maxEntries, maxSerializedBytes);
+    for (const candidate of candidateOrder()) {
+      try {
+        candidate.setItem(CRASH_LOG_KEY, serializedLog);
+        activeStorageIndex = storageCandidates.indexOf(candidate);
+        return;
+      } catch {
+        // Retry the next provider so sessionStorage can back up localStorage.
+      }
     }
   };
   const record: CrashBreadcrumbStore['record'] = (entry) => {
@@ -220,10 +244,12 @@ export function createCrashBreadcrumbStore({
     },
     read,
     clear() {
-      try {
-        safeStorage.removeItem(CRASH_LOG_KEY);
-      } catch {
-        // Ignore storage failures when clearing best-effort breadcrumbs.
+      for (const candidate of storageCandidates) {
+        try {
+          candidate.removeItem(CRASH_LOG_KEY);
+        } catch {
+          // Ignore storage failures when clearing best-effort breadcrumbs.
+        }
       }
     },
   };

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -77,6 +77,22 @@ const getMemorySnapshot = () => {
   };
 };
 
+const getDefaultBrowserStorage = (): StorageProvider | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    try {
+      return window.sessionStorage;
+    } catch {
+      return undefined;
+    }
+  }
+};
+
 const safeParse = (value: string | null): CrashBreadcrumbLog => {
   if (!value) {
     return emptyLog();
@@ -131,7 +147,7 @@ export function createCrashBreadcrumbStore({
   maxSerializedBytes?: number;
 } = {}): CrashBreadcrumbStore {
   const fallbackStorage = new Map<string, string>();
-  const safeStorage: StorageProvider = storage ?? {
+  const memoryStorage: StorageProvider = {
     getItem: (key) => fallbackStorage.get(key) ?? null,
     setItem: (key, value) => {
       fallbackStorage.set(key, value);
@@ -140,6 +156,8 @@ export function createCrashBreadcrumbStore({
       fallbackStorage.delete(key);
     },
   };
+  const safeStorage: StorageProvider =
+    storage ?? getDefaultBrowserStorage() ?? memoryStorage;
 
   const read = () => {
     try {

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -141,54 +141,72 @@ export function createCrashBreadcrumbStore({
     },
   };
 
-  const read = () => safeParse(safeStorage.getItem(CRASH_LOG_KEY));
-  const write = (log: CrashBreadcrumbLog) => {
-    safeStorage.setItem(
-      CRASH_LOG_KEY,
-      serializeBounded(log, maxEntries, maxSerializedBytes)
-    );
+  const read = () => {
+    try {
+      return safeParse(safeStorage.getItem(CRASH_LOG_KEY));
+    } catch {
+      return emptyLog();
+    }
   };
+  const write = (log: CrashBreadcrumbLog) => {
+    try {
+      safeStorage.setItem(
+        CRASH_LOG_KEY,
+        serializeBounded(log, maxEntries, maxSerializedBytes)
+      );
+    } catch {
+      // Breadcrumbs are best-effort diagnostics and must never break rendering.
+    }
+  };
+  const record: CrashBreadcrumbStore['record'] = (entry) => {
+    const timestamp = new Date().toISOString();
+    const log = read();
+    write({
+      version: 1,
+      updatedAt: timestamp,
+      entries: [
+        ...log.entries,
+        {
+          ...entry,
+          timestamp,
+          pageUrl: getPageUrl(),
+          memory: getMemorySnapshot(),
+        },
+      ],
+    });
+  };
+  const recordSnapshot: CrashBreadcrumbStore['recordSnapshot'] = (snapshot) => {
+    record({
+      type: 'snapshot',
+      snapshot,
+      renderer: snapshot.renderer,
+      softwareRendererPolicy: snapshot.softwareRendererPolicy,
+    });
+  };
+  const exportCrashLog = () => JSON.stringify(read(), null, 2);
 
   return {
-    record(entry) {
-      const timestamp = new Date().toISOString();
-      const log = read();
-      write({
-        version: 1,
-        updatedAt: timestamp,
-        entries: [
-          ...log.entries,
-          {
-            ...entry,
-            timestamp,
-            pageUrl: getPageUrl(),
-            memory: getMemorySnapshot(),
-          },
-        ],
-      });
-    },
-    recordSnapshot(snapshot) {
-      this.record({
-        type: 'snapshot',
-        snapshot,
-        renderer: snapshot.renderer,
-        softwareRendererPolicy: snapshot.softwareRendererPolicy,
-      });
-    },
-    exportCrashLog() {
-      return JSON.stringify(read(), null, 2);
-    },
+    record,
+    recordSnapshot,
+    exportCrashLog,
     async copyCrashLog() {
-      const text = this.exportCrashLog();
       if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
         return false;
       }
-      await navigator.clipboard.writeText(text);
-      return true;
+      try {
+        await navigator.clipboard.writeText(exportCrashLog());
+        return true;
+      } catch {
+        return false;
+      }
     },
     read,
     clear() {
-      safeStorage.removeItem(CRASH_LOG_KEY);
+      try {
+        safeStorage.removeItem(CRASH_LOG_KEY);
+      } catch {
+        // Ignore storage failures when clearing best-effort breadcrumbs.
+      }
     },
   };
 }

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -101,6 +101,13 @@ const getDefaultBrowserStorageCandidates = (): StorageProvider[] => {
   return candidates;
 };
 
+const getLogUpdatedAtMs = (log: CrashBreadcrumbLog) => {
+  const updatedAtMs = Date.parse(log.updatedAt);
+  return Number.isFinite(updatedAtMs) ? updatedAtMs : 0;
+};
+
+const hasEntries = (log: CrashBreadcrumbLog) => log.entries.length > 0;
+
 const safeParse = (value: string | null): CrashBreadcrumbLog => {
   if (!value) {
     return emptyLog();
@@ -201,16 +208,29 @@ export function createCrashBreadcrumbStore({
   ];
 
   const read = () => {
+    let newestReadableLog: CrashBreadcrumbLog | null = null;
+    let newestReadableStorageIndex = -1;
+
     for (const candidate of candidateOrder()) {
       try {
         const serializedLog = candidate.getItem(CRASH_LOG_KEY);
-        if (serializedLog) {
-          activeStorageIndex = storageCandidates.indexOf(candidate);
-          return safeParse(serializedLog);
+        const parsedLog = safeParse(serializedLog);
+        if (
+          hasEntries(parsedLog) &&
+          (!newestReadableLog ||
+            getLogUpdatedAtMs(parsedLog) > getLogUpdatedAtMs(newestReadableLog))
+        ) {
+          newestReadableLog = parsedLog;
+          newestReadableStorageIndex = storageCandidates.indexOf(candidate);
         }
       } catch {
         // Try the next storage provider before dropping to an empty log.
       }
+    }
+
+    if (newestReadableLog) {
+      activeStorageIndex = newestReadableStorageIndex;
+      return newestReadableLog;
     }
     return emptyLog();
   };

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -186,9 +186,13 @@ export function createCrashBreadcrumbStore({
       fallbackStorage.delete(key);
     },
   };
-  const storageCandidates = storage
-    ? [storage]
-    : [...getDefaultBrowserStorageCandidates(), memoryStorage];
+  const storageCandidates = [
+    ...(storage ? [storage] : []),
+    ...getDefaultBrowserStorageCandidates(),
+    memoryStorage,
+  ].filter(
+    (candidate, index, candidates) => candidates.indexOf(candidate) === index
+  );
   let activeStorageIndex = 0;
 
   const candidateOrder = () => [

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -4,6 +4,7 @@ import type {
 } from '../graphics/qualityManager';
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
+import type { SoftwareRendererPolicyState } from './qualityPolicy';
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
 export type PhaseName =
@@ -56,6 +57,7 @@ export interface FrameStatsSnapshot {
 
 export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   renderer: RendererInfoSnapshot;
+  softwareRendererPolicy: SoftwareRendererPolicyState;
   rendererSize: RendererSizeSnapshot;
   quality: QualityStateSnapshot;
   features: FeatureStateSnapshot;
@@ -69,6 +71,8 @@ export interface PerformanceDiagnosticsApi {
   getQualityState(): QualityStateSnapshot;
   getFeatureState(): FeatureStateSnapshot;
   getLastFailoverReason(): string | null;
+  exportCrashLog?(): string;
+  copyCrashLog?(): Promise<boolean>;
 }
 
 interface PerformanceDiagnosticsOptions {
@@ -77,6 +81,9 @@ interface PerformanceDiagnosticsOptions {
   getQualityState: () => QualityStateSnapshot;
   getFeatureState: () => FeatureStateSnapshot;
   getLastFailoverReason: () => string | null;
+  getSoftwareRendererPolicy?: () => SoftwareRendererPolicyState;
+  exportCrashLog?: () => string;
+  copyCrashLog?: () => Promise<boolean>;
   maxSamples?: number;
 }
 
@@ -129,6 +136,14 @@ export function createPerformanceDiagnostics({
   getQualityState,
   getFeatureState,
   getLastFailoverReason,
+  getSoftwareRendererPolicy = () => ({
+    mode: 'continuous',
+    safeMode: false,
+    renderCadenceFps: null,
+    reason: 'software renderer policy unavailable',
+  }),
+  exportCrashLog,
+  copyCrashLog,
   maxSamples = 180,
 }: PerformanceDiagnosticsOptions) {
   const frameMsSamples: number[] = [];
@@ -150,6 +165,7 @@ export function createPerformanceDiagnostics({
       return {
         ...diagnosticsMethods.getFrameStats(),
         renderer: diagnosticsMethods.getRendererInfo(),
+        softwareRendererPolicy: getSoftwareRendererPolicy(),
         rendererSize: getRendererSize(),
         quality: diagnosticsMethods.getQualityState(),
         features: diagnosticsMethods.getFeatureState(),
@@ -189,6 +205,8 @@ export function createPerformanceDiagnostics({
     getLastFailoverReason() {
       return getLastFailoverReason();
     },
+    exportCrashLog,
+    copyCrashLog,
   };
 
   return {

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -64,6 +64,15 @@ export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   lastFailoverReason: string | null;
 }
 
+export interface PerformanceCrashLogApi {
+  exportCrashLog(): string;
+  copyCrashLog(): Promise<boolean>;
+}
+
+export interface PerformanceCrashBreadcrumbApi extends PerformanceCrashLogApi {
+  recordSnapshot(snapshot: PerformanceDiagnosticsSnapshot): void;
+}
+
 export interface PerformanceDiagnosticsApi {
   getSnapshot(): PerformanceDiagnosticsSnapshot;
   getFrameStats(): FrameStatsSnapshot;
@@ -73,6 +82,7 @@ export interface PerformanceDiagnosticsApi {
   getLastFailoverReason(): string | null;
   exportCrashLog?(): string;
   copyCrashLog?(): Promise<boolean>;
+  recordSnapshot?(snapshot: PerformanceDiagnosticsSnapshot): void;
 }
 
 interface PerformanceDiagnosticsOptions {
@@ -84,6 +94,7 @@ interface PerformanceDiagnosticsOptions {
   getSoftwareRendererPolicy?: () => SoftwareRendererPolicyState;
   exportCrashLog?: () => string;
   copyCrashLog?: () => Promise<boolean>;
+  recordSnapshot?: (snapshot: PerformanceDiagnosticsSnapshot) => void;
   maxSamples?: number;
 }
 
@@ -144,6 +155,7 @@ export function createPerformanceDiagnostics({
   }),
   exportCrashLog,
   copyCrashLog,
+  recordSnapshot,
   maxSamples = 180,
 }: PerformanceDiagnosticsOptions) {
   const frameMsSamples: number[] = [];
@@ -207,6 +219,7 @@ export function createPerformanceDiagnostics({
     },
     exportCrashLog,
     copyCrashLog,
+    recordSnapshot,
   };
 
   return {

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -1,3 +1,8 @@
+import {
+  FORCE_CONTINUOUS_RENDERING_PARAM,
+  SOFTWARE_RENDERER_CONTINUOUS_VALUE,
+  SOFTWARE_RENDERER_MODE_PARAM,
+} from '../../ui/immersiveUrl';
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
 import type { RendererInfoSnapshot } from './rendererCapabilities';
@@ -11,8 +16,6 @@ export interface SoftwareRendererPolicyState {
   reason: string;
 }
 
-const SOFTWARE_RENDERER_MODE_PARAM = 'softwareRendererMode';
-const FORCE_CONTINUOUS_RENDERING_PARAM = 'forceContinuousRendering';
 const SOFTWARE_SAFE_RENDER_CADENCE_FPS = 12;
 
 const isTruthyParam = (value: string | null): boolean => {
@@ -40,7 +43,7 @@ export function resolveSoftwareRendererPolicy(
 
   if (
     rendererInfo.isDangerousSoftwareRenderer &&
-    (requestedMode === 'continuous' || forceContinuous)
+    (requestedMode === SOFTWARE_RENDERER_CONTINUOUS_VALUE || forceContinuous)
   ) {
     return {
       mode: 'continuous',

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -71,6 +71,54 @@ export function resolveSoftwareRendererPolicy(
   };
 }
 
+export interface SoftwareSafeRenderCadenceInput {
+  safeMode: boolean;
+  hasPresentedFirstFrame: boolean;
+  renderRequested: boolean;
+  lastRenderMs: number;
+  nowMs: number;
+  renderIntervalMs: number;
+}
+
+export interface SoftwareSafeRenderCadenceDecision {
+  shouldRender: boolean;
+  renderRequested: boolean;
+  lastRenderMs: number;
+}
+
+export function resolveSoftwareSafeRenderCadence({
+  safeMode,
+  hasPresentedFirstFrame,
+  renderRequested,
+  lastRenderMs,
+  nowMs,
+  renderIntervalMs,
+}: SoftwareSafeRenderCadenceInput): SoftwareSafeRenderCadenceDecision {
+  if (!safeMode || !hasPresentedFirstFrame) {
+    return {
+      shouldRender: true,
+      renderRequested: false,
+      lastRenderMs: nowMs,
+    };
+  }
+
+  const hasCadenceElapsed =
+    renderIntervalMs > 0 && nowMs - lastRenderMs >= renderIntervalMs;
+  if (!renderRequested && !hasCadenceElapsed) {
+    return {
+      shouldRender: false,
+      renderRequested,
+      lastRenderMs,
+    };
+  }
+
+  return {
+    shouldRender: true,
+    renderRequested: false,
+    lastRenderMs: nowMs,
+  };
+}
+
 export interface QualityPolicyState {
   initialLevel: GraphicsQualityLevel;
   basePixelRatioCap: number;

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -2,6 +2,72 @@ import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
+export type SoftwareRendererMode = 'safe' | 'continuous';
+
+export interface SoftwareRendererPolicyState {
+  mode: SoftwareRendererMode;
+  safeMode: boolean;
+  renderCadenceFps: number | null;
+  reason: string;
+}
+
+const SOFTWARE_RENDERER_MODE_PARAM = 'softwareRendererMode';
+const FORCE_CONTINUOUS_RENDERING_PARAM = 'forceContinuousRendering';
+const SOFTWARE_SAFE_RENDER_CADENCE_FPS = 12;
+
+const isTruthyParam = (value: string | null): boolean => {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+};
+
+export function resolveSoftwareRendererPolicy(
+  rendererInfo: Pick<RendererInfoSnapshot, 'isDangerousSoftwareRenderer'>,
+  search: string | URLSearchParams = typeof window !== 'undefined'
+    ? window.location.search
+    : ''
+): SoftwareRendererPolicyState {
+  const params =
+    search instanceof URLSearchParams
+      ? search
+      : new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const requestedMode = params
+    .get(SOFTWARE_RENDERER_MODE_PARAM)
+    ?.trim()
+    .toLowerCase();
+  const forceContinuous = isTruthyParam(
+    params.get(FORCE_CONTINUOUS_RENDERING_PARAM)
+  );
+
+  if (
+    rendererInfo.isDangerousSoftwareRenderer &&
+    (requestedMode === 'continuous' || forceContinuous)
+  ) {
+    return {
+      mode: 'continuous',
+      safeMode: false,
+      renderCadenceFps: null,
+      reason:
+        'dangerous software renderer continuous rendering override requested',
+    };
+  }
+
+  if (rendererInfo.isDangerousSoftwareRenderer) {
+    return {
+      mode: 'safe',
+      safeMode: true,
+      renderCadenceFps: SOFTWARE_SAFE_RENDER_CADENCE_FPS,
+      reason: 'dangerous software renderer uses software-safe capped rendering',
+    };
+  }
+
+  return {
+    mode: 'continuous',
+    safeMode: false,
+    renderCadenceFps: null,
+    reason: 'hardware renderer uses continuous rendering',
+  };
+}
+
 export interface QualityPolicyState {
   initialLevel: GraphicsQualityLevel;
   basePixelRatioCap: number;
@@ -9,6 +75,8 @@ export interface QualityPolicyState {
   mirrorTargetSize: number;
   mirrorUpdateRateFps: number;
   ambientUpdateIntervalMs: number;
+  softwareSafeMode: boolean;
+  renderCadenceFps: number | null;
   reason: string;
 }
 
@@ -42,17 +110,43 @@ export function resolveResizedBasePixelRatio(
 }
 
 export function resolveInitialQualityPolicy(
-  rendererInfo: Pick<RendererInfoSnapshot, 'isSoftwareRenderer'>,
-  devicePixelRatio: number
+  rendererInfo: Pick<
+    RendererInfoSnapshot,
+    'isSoftwareRenderer' | 'isDangerousSoftwareRenderer'
+  >,
+  devicePixelRatio: number,
+  softwareRendererPolicy: SoftwareRendererPolicyState = resolveSoftwareRendererPolicy(
+    rendererInfo
+  )
 ): QualityPolicyState {
+  if (
+    rendererInfo.isDangerousSoftwareRenderer &&
+    softwareRendererPolicy.safeMode
+  ) {
+    return {
+      initialLevel: 'performance',
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.45, 0.35),
+      mirrorEnabled: false,
+      mirrorTargetSize: 128,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 250,
+      softwareSafeMode: true,
+      renderCadenceFps: softwareRendererPolicy.renderCadenceFps,
+      reason:
+        'dangerous software renderer starts in software-safe performance mode',
+    };
+  }
+
   if (rendererInfo.isSoftwareRenderer) {
     return {
       initialLevel: 'performance',
-      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 1, 0.75),
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.75, 0.5),
       mirrorEnabled: false,
       mirrorTargetSize: 192,
       mirrorUpdateRateFps: 0,
       ambientUpdateIntervalMs: 100,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
       reason: 'software renderer starts in performance mode',
     };
   }
@@ -64,6 +158,8 @@ export function resolveInitialQualityPolicy(
     mirrorTargetSize: 320,
     mirrorUpdateRateFps: 8,
     ambientUpdateIntervalMs: 33,
+    softwareSafeMode: false,
+    renderCadenceFps: null,
     reason: 'default desktop path balances fidelity with pixel cost',
   };
 }

--- a/src/scene/performance/rendererCapabilities.ts
+++ b/src/scene/performance/rendererCapabilities.ts
@@ -74,8 +74,8 @@ export function classifyRendererInfo(input: {
       unmaskedVendor,
       unmaskedRenderer,
       isSoftwareRenderer: true,
-      isDangerousSoftwareRenderer: true,
-      riskLevel: 'dangerous-software',
+      isDangerousSoftwareRenderer: false,
+      riskLevel: 'software',
       reason: `matched software renderer pattern ${matchedSoftwarePattern.source}`,
     };
   }

--- a/src/scene/performance/rendererCapabilities.ts
+++ b/src/scene/performance/rendererCapabilities.ts
@@ -24,7 +24,7 @@ const DANGEROUS_SOFTWARE_RENDERER_PATTERNS = [
   /llvmpipe/i,
   /softpipe/i,
   /mesa offscreen/i,
-  /angle.*(swiftshader|software|warp|microsoft basic render)/i,
+  /angle.*(swiftshader|warp|microsoft basic render)/i,
 ] as const;
 
 const SOFTWARE_RENDERER_PATTERNS = [

--- a/src/scene/performance/rendererCapabilities.ts
+++ b/src/scene/performance/rendererCapabilities.ts
@@ -1,6 +1,10 @@
 import type { WebGLRenderer } from 'three';
 
-export type RendererRiskLevel = 'normal' | 'software' | 'unknown';
+export type RendererRiskLevel =
+  | 'normal'
+  | 'software'
+  | 'dangerous-software'
+  | 'unknown';
 
 export interface RendererInfoSnapshot {
   vendor: string | null;
@@ -8,19 +12,26 @@ export interface RendererInfoSnapshot {
   unmaskedVendor: string | null;
   unmaskedRenderer: string | null;
   isSoftwareRenderer: boolean;
+  isDangerousSoftwareRenderer: boolean;
   riskLevel: RendererRiskLevel;
   reason: string;
 }
 
-const SOFTWARE_RENDERER_PATTERNS = [
+const DANGEROUS_SOFTWARE_RENDERER_PATTERNS = [
+  /microsoft basic render(?:er| driver)?/i,
   /swiftshader/i,
-  /software/i,
+  /\bwarp\b/i,
   /llvmpipe/i,
   /softpipe/i,
   /mesa offscreen/i,
-  /warp/i,
-  /microsoft basic render/i,
-  /angle.*(swiftshader|software|warp)/i,
+  /angle.*(swiftshader|software|warp|microsoft basic render)/i,
+] as const;
+
+const SOFTWARE_RENDERER_PATTERNS = [
+  ...DANGEROUS_SOFTWARE_RENDERER_PATTERNS,
+  /software/i,
+  /cpu raster/i,
+  /chromium.*software/i,
 ] as const;
 
 export function classifyRendererInfo(input: {
@@ -36,19 +47,36 @@ export function classifyRendererInfo(input: {
   const haystack = [vendor, renderer, unmaskedVendor, unmaskedRenderer]
     .filter((value): value is string => typeof value === 'string')
     .join(' ');
-  const matchedPattern = SOFTWARE_RENDERER_PATTERNS.find((pattern) =>
-    pattern.test(haystack)
+  const matchedDangerousPattern = DANGEROUS_SOFTWARE_RENDERER_PATTERNS.find(
+    (pattern) => pattern.test(haystack)
   );
+  const matchedSoftwarePattern =
+    matchedDangerousPattern ??
+    SOFTWARE_RENDERER_PATTERNS.find((pattern) => pattern.test(haystack));
 
-  if (matchedPattern) {
+  if (matchedDangerousPattern) {
     return {
       vendor,
       renderer,
       unmaskedVendor,
       unmaskedRenderer,
       isSoftwareRenderer: true,
-      riskLevel: 'software',
-      reason: `matched ${matchedPattern.source}`,
+      isDangerousSoftwareRenderer: true,
+      riskLevel: 'dangerous-software',
+      reason: `matched dangerous software renderer pattern ${matchedDangerousPattern.source}`,
+    };
+  }
+
+  if (matchedSoftwarePattern) {
+    return {
+      vendor,
+      renderer,
+      unmaskedVendor,
+      unmaskedRenderer,
+      isSoftwareRenderer: true,
+      isDangerousSoftwareRenderer: true,
+      riskLevel: 'dangerous-software',
+      reason: `matched software renderer pattern ${matchedSoftwarePattern.source}`,
     };
   }
 
@@ -58,6 +86,7 @@ export function classifyRendererInfo(input: {
     unmaskedVendor,
     unmaskedRenderer,
     isSoftwareRenderer: false,
+    isDangerousSoftwareRenderer: false,
     riskLevel: haystack.length > 0 ? 'normal' : 'unknown',
     reason:
       haystack.length > 0

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createCrashBreadcrumbStore } from '../scene/performance/crashBreadcrumbs';
+import {
+  CRASH_LOG_KEY,
+  createCrashBreadcrumbStore,
+} from '../scene/performance/crashBreadcrumbs';
 
 function createMemoryStorage() {
   const values = new Map<string, string>();
@@ -72,6 +75,64 @@ describe('crash breadcrumbs', () => {
         Object.defineProperty(window, 'localStorage', originalLocalStorage);
       } else {
         Reflect.deleteProperty(window, 'localStorage');
+      }
+    }
+  });
+
+  it('retries sessionStorage when localStorage writes fail', () => {
+    const localFallbackStorage = createMemoryStorage();
+    const sessionFallbackStorage = createMemoryStorage();
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(
+      window,
+      'localStorage'
+    );
+    const originalSessionStorage = Object.getOwnPropertyDescriptor(
+      window,
+      'sessionStorage'
+    );
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: () => ({
+        ...localFallbackStorage,
+        setItem: () => {
+          throw new Error('quota exceeded');
+        },
+      }),
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get: () => sessionFallbackStorage,
+    });
+
+    try {
+      createCrashBreadcrumbStore().record({
+        type: 'mode-change',
+        message: 'persisted in session fallback',
+      });
+      const reloadedStore = createCrashBreadcrumbStore();
+      const exported = JSON.parse(reloadedStore.exportCrashLog()) as ReturnType<
+        typeof reloadedStore.read
+      >;
+
+      expect(exported.entries).toHaveLength(1);
+      expect(exported.entries[0]).toMatchObject({
+        type: 'mode-change',
+        message: 'persisted in session fallback',
+      });
+      expect(localFallbackStorage.getItem(CRASH_LOG_KEY)).toBeNull();
+      expect(sessionFallbackStorage.getItem(CRASH_LOG_KEY)).toContain(
+        'persisted in session fallback'
+      );
+    } finally {
+      if (originalLocalStorage) {
+        Object.defineProperty(window, 'localStorage', originalLocalStorage);
+      } else {
+        Reflect.deleteProperty(window, 'localStorage');
+      }
+      if (originalSessionStorage) {
+        Object.defineProperty(window, 'sessionStorage', originalSessionStorage);
+      } else {
+        Reflect.deleteProperty(window, 'sessionStorage');
       }
     }
   });

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCrashBreadcrumbStore } from '../scene/performance/crashBreadcrumbs';
+
+function createMemoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+  };
+}
+
+describe('crash breadcrumbs', () => {
+  it('keeps a bounded serializable ring buffer', () => {
+    const store = createCrashBreadcrumbStore({
+      storage: createMemoryStorage(),
+      maxEntries: 3,
+      maxSerializedBytes: 20_000,
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      store.record({ type: 'mode-change', message: `entry-${index}` });
+    }
+
+    const exported = JSON.parse(store.exportCrashLog()) as ReturnType<
+      typeof store.read
+    >;
+    expect(exported.entries).toHaveLength(3);
+    expect(exported.entries.map((entry) => entry.message)).toEqual([
+      'entry-2',
+      'entry-3',
+      'entry-4',
+    ]);
+    expect(() => JSON.stringify(exported)).not.toThrow();
+  });
+
+  it('exports recent snapshots with renderer and software-safe state', () => {
+    const store = createCrashBreadcrumbStore({
+      storage: createMemoryStorage(),
+    });
+    store.recordSnapshot({
+      averageFps: 12,
+      medianFps: 12,
+      p95FrameMs: 90,
+      minFps: 8,
+      sampleCount: 5,
+      phases: {
+        inputMovementCamera: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        avatarIkAudio: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        poiHudTooltips: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        decorativeStructures: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        lightingLedLightmap: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        mirror: { averageMs: 0, p95Ms: 0, sampleCount: 0 },
+        mainRender: { averageMs: 80, p95Ms: 90, sampleCount: 5 },
+      },
+      renderer: {
+        vendor: 'Google Inc.',
+        renderer: 'WebGL',
+        unmaskedVendor: 'Microsoft',
+        unmaskedRenderer:
+          'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
+        isSoftwareRenderer: true,
+        isDangerousSoftwareRenderer: true,
+        riskLevel: 'dangerous-software',
+        reason: 'test',
+      },
+      softwareRendererPolicy: {
+        mode: 'safe',
+        safeMode: true,
+        renderCadenceFps: 12,
+        reason: 'test',
+      },
+      rendererSize: {
+        pixelRatio: 0.5,
+        viewport: { width: 1280, height: 720 },
+        drawingBuffer: { width: 640, height: 360 },
+      },
+      quality: {
+        level: 'performance',
+        selectionSource: 'initial',
+        adaptiveDowngradeCount: 0,
+        adaptiveRecoveryCount: 0,
+        lastAdaptiveReason: null,
+        lastAdaptiveDowngradeReason: null,
+        lastAdaptiveRecoveryReason: null,
+        adaptivePolicy: null,
+      },
+      features: {
+        bloomEnabled: false,
+        composerEnabled: false,
+        activePostprocessingPassCount: 0,
+        mirrorEnabled: false,
+        mirrorRenderTargetSize: 0,
+        mirrorUpdateRateFps: 0,
+        mirrorRenderCount: 0,
+      },
+      lastFailoverReason: null,
+    });
+
+    const exported = JSON.parse(store.exportCrashLog()) as ReturnType<
+      typeof store.read
+    >;
+    expect(exported.entries[0]).toMatchObject({
+      type: 'snapshot',
+      renderer: { isDangerousSoftwareRenderer: true },
+      softwareRendererPolicy: { safeMode: true, renderCadenceFps: 12 },
+    });
+  });
+});

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -40,6 +40,12 @@ describe('crash breadcrumbs', () => {
     expect(() =>
       store.record({ type: 'mode-change', message: 'should not throw' })
     ).not.toThrow();
+    expect(store.read().entries).toContainEqual(
+      expect.objectContaining({
+        type: 'mode-change',
+        message: 'should not throw',
+      })
+    );
     expect(() => store.clear()).not.toThrow();
     expect(store.read().entries).toEqual([]);
   });
@@ -122,6 +128,65 @@ describe('crash breadcrumbs', () => {
       expect(localFallbackStorage.getItem(CRASH_LOG_KEY)).toBeNull();
       expect(sessionFallbackStorage.getItem(CRASH_LOG_KEY)).toContain(
         'persisted in session fallback'
+      );
+    } finally {
+      if (originalLocalStorage) {
+        Object.defineProperty(window, 'localStorage', originalLocalStorage);
+      } else {
+        Reflect.deleteProperty(window, 'localStorage');
+      }
+      if (originalSessionStorage) {
+        Object.defineProperty(window, 'sessionStorage', originalSessionStorage);
+      } else {
+        Reflect.deleteProperty(window, 'sessionStorage');
+      }
+    }
+  });
+
+  it('retries sessionStorage when an explicit localStorage provider cannot write', () => {
+    const localFallbackStorage = createMemoryStorage();
+    const sessionFallbackStorage = createMemoryStorage();
+    const explicitLocalStorage = {
+      ...localFallbackStorage,
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+    };
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(
+      window,
+      'localStorage'
+    );
+    const originalSessionStorage = Object.getOwnPropertyDescriptor(
+      window,
+      'sessionStorage'
+    );
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: () => explicitLocalStorage,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get: () => sessionFallbackStorage,
+    });
+
+    try {
+      createCrashBreadcrumbStore({ storage: explicitLocalStorage }).record({
+        type: 'mode-change',
+        message: 'explicit local falls back to session',
+      });
+      const reloadedStore = createCrashBreadcrumbStore();
+      const exported = JSON.parse(reloadedStore.exportCrashLog()) as ReturnType<
+        typeof reloadedStore.read
+      >;
+
+      expect(exported.entries).toHaveLength(1);
+      expect(exported.entries[0]).toMatchObject({
+        type: 'mode-change',
+        message: 'explicit local falls back to session',
+      });
+      expect(localFallbackStorage.getItem(CRASH_LOG_KEY)).toBeNull();
+      expect(sessionFallbackStorage.getItem(CRASH_LOG_KEY)).toContain(
+        'explicit local falls back to session'
       );
     } finally {
       if (originalLocalStorage) {

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -143,6 +143,80 @@ describe('crash breadcrumbs', () => {
     }
   });
 
+  it('exports the newest fallback log when stale localStorage remains readable', () => {
+    const localFallbackStorage = createMemoryStorage();
+    const sessionFallbackStorage = createMemoryStorage();
+    const oldTimestamp = '2026-05-30T20:00:00.000Z';
+    localFallbackStorage.setItem(
+      CRASH_LOG_KEY,
+      JSON.stringify({
+        version: 1,
+        updatedAt: oldTimestamp,
+        entries: [
+          {
+            type: 'mode-change',
+            timestamp: oldTimestamp,
+            pageUrl: 'https://example.test/?mode=immersive',
+            message: 'stale local breadcrumb',
+            memory: null,
+          },
+        ],
+      })
+    );
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(
+      window,
+      'localStorage'
+    );
+    const originalSessionStorage = Object.getOwnPropertyDescriptor(
+      window,
+      'sessionStorage'
+    );
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: () => ({
+        ...localFallbackStorage,
+        setItem: () => {
+          throw new Error('quota exceeded');
+        },
+      }),
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get: () => sessionFallbackStorage,
+    });
+
+    try {
+      createCrashBreadcrumbStore().record({
+        type: 'mode-change',
+        message: 'newer session fallback breadcrumb',
+      });
+      const reloadedStore = createCrashBreadcrumbStore();
+      const exported = JSON.parse(reloadedStore.exportCrashLog()) as ReturnType<
+        typeof reloadedStore.read
+      >;
+
+      expect(exported.entries).toHaveLength(2);
+      expect(exported.entries.map((entry) => entry.message)).toEqual([
+        'stale local breadcrumb',
+        'newer session fallback breadcrumb',
+      ]);
+      expect(sessionFallbackStorage.getItem(CRASH_LOG_KEY)).toContain(
+        'newer session fallback breadcrumb'
+      );
+    } finally {
+      if (originalLocalStorage) {
+        Object.defineProperty(window, 'localStorage', originalLocalStorage);
+      } else {
+        Reflect.deleteProperty(window, 'localStorage');
+      }
+      if (originalSessionStorage) {
+        Object.defineProperty(window, 'sessionStorage', originalSessionStorage);
+      } else {
+        Reflect.deleteProperty(window, 'sessionStorage');
+      }
+    }
+  });
+
   it('retries sessionStorage when an explicit localStorage provider cannot write', () => {
     const localFallbackStorage = createMemoryStorage();
     const sessionFallbackStorage = createMemoryStorage();

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -271,6 +271,50 @@ describe('crash breadcrumbs', () => {
     expect(() => JSON.stringify(exported)).not.toThrow();
   });
 
+  it('keeps exported crash logs under the serialized byte budget', () => {
+    const store = createCrashBreadcrumbStore({
+      storage: createMemoryStorage(),
+      maxEntries: 40,
+      maxSerializedBytes: 1_200,
+    });
+
+    for (let index = 0; index < 12; index += 1) {
+      store.record({
+        type: 'mode-change',
+        message: `entry-${index}-${'x'.repeat(400)}`,
+      });
+    }
+
+    const exported = store.exportCrashLog();
+    const parsed = JSON.parse(exported) as ReturnType<typeof store.read>;
+    expect(new Blob([exported]).size).toBeLessThanOrEqual(1_200);
+    expect(parsed.entries.at(-1)?.message).toContain('entry-11');
+  });
+
+  it('preserves critical warning breadcrumbs before trimming old snapshots', () => {
+    const store = createCrashBreadcrumbStore({
+      storage: createMemoryStorage(),
+      maxEntries: 5,
+      maxSerializedBytes: 1_800,
+    });
+
+    store.record({ type: 'renderer-warning', message: 'Basic Render Driver' });
+    for (let index = 0; index < 12; index += 1) {
+      store.record({ type: 'snapshot', message: `snapshot-${index}` });
+    }
+
+    const exported = store.exportCrashLog();
+    const parsed = JSON.parse(exported) as ReturnType<typeof store.read>;
+    expect(new Blob([exported]).size).toBeLessThanOrEqual(1_800);
+    expect(parsed.entries).toContainEqual(
+      expect.objectContaining({
+        type: 'renderer-warning',
+        message: 'Basic Render Driver',
+      })
+    );
+    expect(parsed.entries.at(-1)).toMatchObject({ message: 'snapshot-11' });
+  });
+
   it('exports recent snapshots with renderer and software-safe state', () => {
     const store = createCrashBreadcrumbStore({
       storage: createMemoryStorage(),

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -41,6 +41,81 @@ describe('crash breadcrumbs', () => {
     expect(store.read().entries).toEqual([]);
   });
 
+  it('defaults to browser storage so exports survive a reload', () => {
+    const storage = createMemoryStorage();
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(
+      window,
+      'localStorage'
+    );
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: () => storage,
+    });
+
+    try {
+      createCrashBreadcrumbStore().record({
+        type: 'mode-change',
+        message: 'persisted in browser storage',
+      });
+      const reloadedStore = createCrashBreadcrumbStore();
+      const exported = JSON.parse(reloadedStore.exportCrashLog()) as ReturnType<
+        typeof reloadedStore.read
+      >;
+
+      expect(exported.entries).toHaveLength(1);
+      expect(exported.entries[0]).toMatchObject({
+        type: 'mode-change',
+        message: 'persisted in browser storage',
+      });
+    } finally {
+      if (originalLocalStorage) {
+        Object.defineProperty(window, 'localStorage', originalLocalStorage);
+      } else {
+        Reflect.deleteProperty(window, 'localStorage');
+      }
+    }
+  });
+
+  it('persists breadcrumbs across fresh stores on the same browser storage', () => {
+    const storage = createMemoryStorage();
+    const firstStore = createCrashBreadcrumbStore({ storage });
+
+    firstStore.record({
+      type: 'webgl-context-lost',
+      message: 'simulated context loss before reload',
+      renderer: {
+        vendor: 'Google Inc.',
+        renderer: 'WebGL',
+        unmaskedVendor: 'Microsoft',
+        unmaskedRenderer:
+          'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
+        isSoftwareRenderer: true,
+        isDangerousSoftwareRenderer: true,
+        riskLevel: 'dangerous-software',
+        reason: 'test',
+      },
+      softwareRendererPolicy: {
+        mode: 'safe',
+        safeMode: true,
+        renderCadenceFps: 12,
+        reason: 'test',
+      },
+    });
+
+    const reloadedStore = createCrashBreadcrumbStore({ storage });
+    const exported = JSON.parse(reloadedStore.exportCrashLog()) as ReturnType<
+      typeof reloadedStore.read
+    >;
+
+    expect(exported.entries).toHaveLength(1);
+    expect(exported.entries[0]).toMatchObject({
+      type: 'webgl-context-lost',
+      message: 'simulated context loss before reload',
+      renderer: { isDangerousSoftwareRenderer: true },
+      softwareRendererPolicy: { safeMode: true, renderCadenceFps: 12 },
+    });
+  });
+
   it('keeps snapshot recording and clipboard copy destructure-safe', async () => {
     const store = createCrashBreadcrumbStore({
       storage: createMemoryStorage(),

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createCrashBreadcrumbStore } from '../scene/performance/crashBreadcrumbs';
 
@@ -16,6 +16,102 @@ function createMemoryStorage() {
 }
 
 describe('crash breadcrumbs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('treats storage failures as best-effort diagnostics', () => {
+    const failingStorage = {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+      removeItem: () => {
+        throw new Error('blocked');
+      },
+    };
+    const store = createCrashBreadcrumbStore({ storage: failingStorage });
+
+    expect(() =>
+      store.record({ type: 'mode-change', message: 'should not throw' })
+    ).not.toThrow();
+    expect(() => store.clear()).not.toThrow();
+    expect(store.read().entries).toEqual([]);
+  });
+
+  it('keeps snapshot recording and clipboard copy destructure-safe', async () => {
+    const store = createCrashBreadcrumbStore({
+      storage: createMemoryStorage(),
+    });
+    const { copyCrashLog, recordSnapshot } = store;
+    const writeText = vi.fn().mockRejectedValue(new Error('not focused'));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    recordSnapshot({
+      averageFps: 12,
+      medianFps: 12,
+      p95FrameMs: 90,
+      minFps: 8,
+      sampleCount: 5,
+      phases: {
+        inputMovementCamera: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        avatarIkAudio: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        poiHudTooltips: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        decorativeStructures: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        lightingLedLightmap: { averageMs: 1, p95Ms: 2, sampleCount: 1 },
+        mirror: { averageMs: 0, p95Ms: 0, sampleCount: 0 },
+        mainRender: { averageMs: 80, p95Ms: 90, sampleCount: 5 },
+      },
+      renderer: {
+        vendor: 'Google Inc.',
+        renderer: 'WebGL',
+        unmaskedVendor: 'Microsoft',
+        unmaskedRenderer: 'ANGLE (Microsoft, WARP, D3D11)',
+        isSoftwareRenderer: true,
+        isDangerousSoftwareRenderer: true,
+        riskLevel: 'dangerous-software',
+        reason: 'test',
+      },
+      softwareRendererPolicy: {
+        mode: 'safe',
+        safeMode: true,
+        renderCadenceFps: 12,
+        reason: 'test',
+      },
+      rendererSize: {
+        pixelRatio: 0.5,
+        viewport: { width: 1280, height: 720 },
+        drawingBuffer: { width: 640, height: 360 },
+      },
+      quality: {
+        level: 'performance',
+        selectionSource: 'initial',
+        adaptiveDowngradeCount: 0,
+        adaptiveRecoveryCount: 0,
+        lastAdaptiveReason: null,
+        lastAdaptiveDowngradeReason: null,
+        lastAdaptiveRecoveryReason: null,
+        adaptivePolicy: null,
+      },
+      features: {
+        bloomEnabled: false,
+        composerEnabled: false,
+        activePostprocessingPassCount: 0,
+        mirrorEnabled: false,
+        mirrorRenderTargetSize: 0,
+        mirrorUpdateRateFps: 0,
+        mirrorRenderCount: 0,
+      },
+      lastFailoverReason: null,
+    });
+
+    expect(store.read().entries).toHaveLength(1);
+    await expect(copyCrashLog()).resolves.toBe(false);
+    expect(writeText).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps a bounded serializable ring buffer', () => {
     const store = createCrashBreadcrumbStore({
       storage: createMemoryStorage(),

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -331,3 +331,19 @@ describe('immersive flag helpers', () => {
     ).toBe(false);
   });
 });
+
+describe('software renderer immersive URLs', () => {
+  it('adds explicit safe and continuous software renderer modes', async () => {
+    const {
+      createSoftwareSafeImmersiveUrl,
+      createContinuousSoftwareImmersiveUrl,
+    } = await import('../ui/immersiveUrl');
+
+    expect(createSoftwareSafeImmersiveUrl('/debug?foo=bar')).toBe(
+      '/debug?foo=bar&mode=immersive&disablePerformanceFailover=1&softwareRendererMode=safe'
+    );
+    expect(createContinuousSoftwareImmersiveUrl('/debug')).toBe(
+      '/debug?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous&forceContinuousRendering=1'
+    );
+  });
+});

--- a/src/tests/motionBlurController.test.ts
+++ b/src/tests/motionBlurController.test.ts
@@ -15,12 +15,27 @@ describe('createMotionBlurController', () => {
 
     controller.setIntensity(0);
     expect(controller.getIntensity()).toBe(0);
-    expect(controller.pass.enabled).toBe(false);
+    expect(controller.pass.enabled).toBe(true);
     expect(controller.pass.uniforms.damp.value).toBe(0);
     expect(controller.getHistoryState()).toMatchObject({
       pendingReset: true,
       lastResetDamp: 0,
     });
+
+    const renderer = {
+      setRenderTarget: vi.fn(),
+      render: vi.fn(),
+      clear: vi.fn(),
+    };
+    const buffer = { texture: {} };
+    controller.pass.render(
+      renderer as never,
+      buffer as never,
+      buffer as never,
+      0,
+      false
+    );
+    expect(controller.pass.enabled).toBe(false);
 
     controller.dispose();
   });
@@ -56,8 +71,23 @@ describe('createMotionBlurController', () => {
 
     controller.setIntensity(Number.NEGATIVE_INFINITY);
     expect(controller.getIntensity()).toBe(0);
-    expect(controller.pass.enabled).toBe(false);
+    expect(controller.pass.enabled).toBe(true);
     expect(controller.pass.uniforms.damp.value).toBe(0);
+
+    const renderer = {
+      setRenderTarget: vi.fn(),
+      render: vi.fn(),
+      clear: vi.fn(),
+    };
+    const buffer = { texture: {} };
+    controller.pass.render(
+      renderer as never,
+      buffer as never,
+      buffer as never,
+      0,
+      false
+    );
+    expect(controller.pass.enabled).toBe(false);
 
     controller.setIntensity(Number.POSITIVE_INFINITY);
     expect(controller.getIntensity()).toBe(0);

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -11,6 +11,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },
@@ -76,6 +77,7 @@ describe('performance diagnostics', () => {
     expect(snapshot.minFps).toBeCloseTo(10, 0);
     expect(snapshot.sampleCount).toBe(3);
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
+    expect(snapshot.softwareRendererPolicy.safeMode).toBe(false);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
     expect(snapshot.quality.selectionSource).toBe('adaptive');
@@ -98,6 +100,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -10,6 +10,7 @@ import {
   getQualityFeaturePolicy,
   resolveInitialQualityPolicy,
   resolveResizedBasePixelRatio,
+  resolveSoftwareRendererPolicy,
 } from '../scene/performance/qualityPolicy';
 import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
 
@@ -73,33 +74,97 @@ function createPolicyHarness({
 }
 
 describe('immersive performance optimization policy', () => {
-  it('classifies known software renderers as risky', () => {
-    expect(
-      classifyRendererInfo({ unmaskedRenderer: 'Google SwiftShader' })
-        .isSoftwareRenderer
-    ).toBe(true);
+  it('classifies known dangerous software renderers separately from hardware', () => {
+    const dangerousRenderers = [
+      'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
+      'Google SwiftShader',
+      'ANGLE (Microsoft, WARP, D3D11)',
+      'llvmpipe (LLVM 17.0.0, 256 bits)',
+    ];
+
+    dangerousRenderers.forEach((renderer) => {
+      expect(
+        classifyRendererInfo({ unmaskedRenderer: renderer })
+      ).toMatchObject({
+        isSoftwareRenderer: true,
+        isDangerousSoftwareRenderer: true,
+        riskLevel: 'dangerous-software',
+      });
+    });
+
     expect(
       classifyRendererInfo({ renderer: 'ANGLE (NVIDIA GeForce RTX)' })
-        .isSoftwareRenderer
-    ).toBe(false);
+    ).toMatchObject({
+      isSoftwareRenderer: false,
+      isDangerousSoftwareRenderer: false,
+      riskLevel: 'normal',
+    });
   });
 
   it('starts software renderers in low-cost performance mode', () => {
     const software = resolveInitialQualityPolicy(
-      { isSoftwareRenderer: true },
+      { isSoftwareRenderer: true, isDangerousSoftwareRenderer: false },
       2
     );
     expect(software.initialLevel).toBe('performance');
-    expect(software.basePixelRatioCap).toBe(1);
+    expect(software.basePixelRatioCap).toBe(0.75);
     expect(software.mirrorEnabled).toBe(false);
 
     const normal = resolveInitialQualityPolicy(
-      { isSoftwareRenderer: false },
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
       2
     );
     expect(normal.initialLevel).toBe('balanced');
     expect(normal.basePixelRatioCap).toBe(1.25);
     expect(normal.mirrorEnabled).toBe(true);
+  });
+
+  it('chooses ultra-low DPR and capped cadence for dangerous software safe mode', () => {
+    const policy = resolveSoftwareRendererPolicy(
+      { isDangerousSoftwareRenderer: true },
+      '?mode=immersive&disablePerformanceFailover=1'
+    );
+    const quality = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: true, isDangerousSoftwareRenderer: true },
+      2,
+      policy
+    );
+
+    expect(policy).toMatchObject({
+      safeMode: true,
+      mode: 'safe',
+      renderCadenceFps: 12,
+    });
+    expect(quality).toMatchObject({
+      initialLevel: 'performance',
+      basePixelRatioCap: 0.45,
+      mirrorEnabled: false,
+      softwareSafeMode: true,
+      renderCadenceFps: 12,
+    });
+  });
+
+  it('allows continuous rendering only with an explicit software override', () => {
+    expect(
+      resolveSoftwareRendererPolicy(
+        { isDangerousSoftwareRenderer: true },
+        '?softwareRendererMode=continuous'
+      )
+    ).toMatchObject({
+      safeMode: false,
+      mode: 'continuous',
+      renderCadenceFps: null,
+    });
+    expect(
+      resolveSoftwareRendererPolicy(
+        { isDangerousSoftwareRenderer: true },
+        '?forceContinuousRendering=1'
+      )
+    ).toMatchObject({
+      safeMode: false,
+      mode: 'continuous',
+      renderCadenceFps: null,
+    });
   });
 
   it('clamps DPR and disables expensive features in performance mode', () => {

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -101,6 +101,22 @@ describe('immersive performance optimization policy', () => {
     });
   });
 
+  it('keeps generic software renderers out of dangerous safe mode', () => {
+    const genericSoftwareRenderers = [
+      'Generic Software Renderer',
+      'CPU Rasterizer',
+      'Chromium Software Compositor',
+    ];
+
+    genericSoftwareRenderers.forEach((renderer) => {
+      expect(classifyRendererInfo({ renderer })).toMatchObject({
+        isSoftwareRenderer: true,
+        isDangerousSoftwareRenderer: false,
+        riskLevel: 'software',
+      });
+    });
+  });
+
   it('starts software renderers in low-cost performance mode', () => {
     const software = resolveInitialQualityPolicy(
       { isSoftwareRenderer: true, isDangerousSoftwareRenderer: false },

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -11,6 +11,7 @@ import {
   resolveInitialQualityPolicy,
   resolveResizedBasePixelRatio,
   resolveSoftwareRendererPolicy,
+  resolveSoftwareSafeRenderCadence,
 } from '../scene/performance/qualityPolicy';
 import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
 
@@ -181,6 +182,69 @@ describe('immersive performance optimization policy', () => {
       mode: 'continuous',
       renderCadenceFps: null,
     });
+  });
+
+  it('enforces the dangerous software safe render cadence deterministically', () => {
+    const intervalMs = 1000 / 12;
+
+    expect(
+      resolveSoftwareSafeRenderCadence({
+        safeMode: true,
+        hasPresentedFirstFrame: false,
+        renderRequested: false,
+        lastRenderMs: 0,
+        nowMs: 0,
+        renderIntervalMs: intervalMs,
+      })
+    ).toMatchObject({ shouldRender: true, lastRenderMs: 0 });
+
+    expect(
+      resolveSoftwareSafeRenderCadence({
+        safeMode: true,
+        hasPresentedFirstFrame: true,
+        renderRequested: false,
+        lastRenderMs: 0,
+        nowMs: 16,
+        renderIntervalMs: intervalMs,
+      })
+    ).toMatchObject({ shouldRender: false, lastRenderMs: 0 });
+
+    expect(
+      resolveSoftwareSafeRenderCadence({
+        safeMode: true,
+        hasPresentedFirstFrame: true,
+        renderRequested: true,
+        lastRenderMs: 0,
+        nowMs: 20,
+        renderIntervalMs: intervalMs,
+      })
+    ).toMatchObject({
+      shouldRender: true,
+      renderRequested: false,
+      lastRenderMs: 20,
+    });
+
+    expect(
+      resolveSoftwareSafeRenderCadence({
+        safeMode: true,
+        hasPresentedFirstFrame: true,
+        renderRequested: false,
+        lastRenderMs: 0,
+        nowMs: intervalMs,
+        renderIntervalMs: intervalMs,
+      })
+    ).toMatchObject({ shouldRender: true, lastRenderMs: intervalMs });
+
+    expect(
+      resolveSoftwareSafeRenderCadence({
+        safeMode: false,
+        hasPresentedFirstFrame: true,
+        renderRequested: false,
+        lastRenderMs: 20,
+        nowMs: 32,
+        renderIntervalMs: intervalMs,
+      })
+    ).toMatchObject({ shouldRender: true, lastRenderMs: 32 });
   });
 
   it('clamps DPR and disables expensive features in performance mode', () => {

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -107,6 +107,7 @@ describe('immersive performance optimization policy', () => {
       'Generic Software Renderer',
       'CPU Rasterizer',
       'Chromium Software Compositor',
+      'ANGLE (Generic, Software Renderer, D3D11)',
     ];
 
     genericSoftwareRenderers.forEach((renderer) => {

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -3,6 +3,10 @@ export const IMMERSIVE_MODE_VALUE = 'immersive';
 export const DISABLE_PERFORMANCE_FAILOVER_PARAM = 'disablePerformanceFailover';
 export const DISABLE_PERFORMANCE_FAILOVER_VALUE = '1';
 export const TEXT_MODE_VALUE = 'text';
+export const SOFTWARE_RENDERER_MODE_PARAM = 'softwareRendererMode';
+export const SOFTWARE_RENDERER_SAFE_VALUE = 'safe';
+export const SOFTWARE_RENDERER_CONTINUOUS_VALUE = 'continuous';
+export const FORCE_CONTINUOUS_RENDERING_PARAM = 'forceContinuousRendering';
 export const IMMERSIVE_PREVIEW_BASE_URL = 'http://localhost:5173/';
 export type ModeSelection =
   | typeof IMMERSIVE_MODE_VALUE
@@ -186,6 +190,26 @@ export const createImmersivePreviewUrl = (
   baseUrl: UrlLike = IMMERSIVE_PREVIEW_BASE_URL,
   extraParams?: ExtraParams
 ): string => createImmersiveModeUrl(baseUrl, extraParams);
+
+export const createSoftwareSafeImmersiveUrl = (
+  input?: UrlLike,
+  extraParams?: ExtraParams
+) =>
+  createImmersiveModeUrl(input, {
+    ...extraParams,
+    [SOFTWARE_RENDERER_MODE_PARAM]: SOFTWARE_RENDERER_SAFE_VALUE,
+    [FORCE_CONTINUOUS_RENDERING_PARAM]: null,
+  });
+
+export const createContinuousSoftwareImmersiveUrl = (
+  input?: UrlLike,
+  extraParams?: ExtraParams
+) =>
+  createImmersiveModeUrl(input, {
+    ...extraParams,
+    [SOFTWARE_RENDERER_MODE_PARAM]: SOFTWARE_RENDERER_CONTINUOUS_VALUE,
+    [FORCE_CONTINUOUS_RENDERING_PARAM]: DISABLE_PERFORMANCE_FAILOVER_VALUE,
+  });
 
 export const createTextModeUrl = (input?: UrlLike, extraParams?: ExtraParams) =>
   buildModeUrl(input, TEXT_MODE_VALUE, {

--- a/src/ui/softwareRendererWarning.ts
+++ b/src/ui/softwareRendererWarning.ts
@@ -1,0 +1,101 @@
+import type { RendererInfoSnapshot } from '../scene/performance/rendererCapabilities';
+
+export interface SoftwareRendererWarningOptions {
+  rendererInfo: RendererInfoSnapshot;
+  safeUrl: string;
+  continuousUrl: string;
+  textUrl: string;
+  onContinueSafe?: () => void;
+  onVisible?: (message: string) => void;
+}
+
+export interface SoftwareRendererWarningHandle {
+  element: HTMLElement;
+  dispose(): void;
+}
+
+const rendererLabel = (rendererInfo: RendererInfoSnapshot) =>
+  rendererInfo.unmaskedRenderer ??
+  rendererInfo.renderer ??
+  'software WebGL renderer';
+
+export function createSoftwareRendererWarning({
+  rendererInfo,
+  safeUrl,
+  continuousUrl,
+  textUrl,
+  onContinueSafe,
+  onVisible,
+}: SoftwareRendererWarningOptions): SoftwareRendererWarningHandle {
+  const documentTarget = document;
+  const element = documentTarget.createElement('aside');
+  element.className = 'software-renderer-warning';
+  element.setAttribute('role', 'alertdialog');
+  element.setAttribute('aria-live', 'assertive');
+  element.dataset.softwareRendererWarning = 'true';
+
+  const title = documentTarget.createElement('h2');
+  title.className = 'software-renderer-warning__title';
+  title.textContent = 'Software rendering detected';
+  element.appendChild(title);
+
+  const description = documentTarget.createElement('p');
+  description.className = 'software-renderer-warning__description';
+  description.textContent =
+    `Chrome is using ${rendererLabel(rendererInfo)} instead of hardware acceleration. ` +
+    'Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.';
+  element.appendChild(description);
+
+  const recommendation = documentTarget.createElement('p');
+  recommendation.className = 'software-renderer-warning__recommendation';
+  recommendation.textContent =
+    'Enable browser hardware acceleration for the smooth immersive portfolio. ' +
+    'Safe immersive mode keeps screenshots and debugging available at a capped frame rate.';
+  element.appendChild(recommendation);
+
+  const actions = documentTarget.createElement('div');
+  actions.className = 'software-renderer-warning__actions';
+
+  const safeButton = documentTarget.createElement('button');
+  safeButton.type = 'button';
+  safeButton.className = 'software-renderer-warning__button';
+  safeButton.dataset.action = 'continue-safe-immersive';
+  safeButton.textContent = 'Continue in safe immersive';
+  safeButton.addEventListener('click', () => {
+    element.remove();
+    onContinueSafe?.();
+  });
+  actions.appendChild(safeButton);
+
+  const continuousLink = documentTarget.createElement('a');
+  continuousLink.className = 'software-renderer-warning__link';
+  continuousLink.dataset.action = 'continuous-immersive';
+  continuousLink.href = continuousUrl;
+  continuousLink.textContent = 'Enable continuous immersive anyway';
+  actions.appendChild(continuousLink);
+
+  const textLink = documentTarget.createElement('a');
+  textLink.className =
+    'software-renderer-warning__link software-renderer-warning__link--muted';
+  textLink.dataset.action = 'text-mode';
+  textLink.href = textUrl;
+  textLink.textContent = 'Use text mode';
+  actions.appendChild(textLink);
+
+  const safeLink = documentTarget.createElement('a');
+  safeLink.className = 'software-renderer-warning__safe-link';
+  safeLink.href = safeUrl;
+  safeLink.textContent = 'Reload this safe immersive URL';
+  element.appendChild(actions);
+  element.appendChild(safeLink);
+
+  documentTarget.body.appendChild(element);
+  onVisible?.(description.textContent ?? 'Software rendering detected');
+
+  return {
+    element,
+    dispose() {
+      element.remove();
+    },
+  };
+}

--- a/src/ui/softwareRendererWarning.ts
+++ b/src/ui/softwareRendererWarning.ts
@@ -30,9 +30,13 @@ export function createSoftwareRendererWarning({
   const documentTarget = document;
   const element = documentTarget.createElement('aside');
   element.className = 'software-renderer-warning';
-  element.setAttribute('role', 'alertdialog');
-  element.setAttribute('aria-live', 'assertive');
+  element.setAttribute('role', 'alert');
+  element.setAttribute('aria-atomic', 'true');
   element.dataset.softwareRendererWarning = 'true';
+
+  const dispose = () => {
+    element.remove();
+  };
 
   const title = documentTarget.createElement('h2');
   title.className = 'software-renderer-warning__title';
@@ -62,7 +66,7 @@ export function createSoftwareRendererWarning({
   safeButton.dataset.action = 'continue-safe-immersive';
   safeButton.textContent = 'Continue in safe immersive';
   safeButton.addEventListener('click', () => {
-    element.remove();
+    dispose();
     onContinueSafe?.();
   });
   actions.appendChild(safeButton);
@@ -94,8 +98,6 @@ export function createSoftwareRendererWarning({
 
   return {
     element,
-    dispose() {
-      element.remove();
-    },
+    dispose,
   };
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1927,3 +1927,66 @@ html[data-hudLayout='mobile'] .audio-subtitles {
 .poi-tooltip-overlay[data-state='recommended'] {
   border-color: rgba(255, 207, 129, 0.42);
 }
+
+.software-renderer-warning {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  max-width: min(34rem, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid rgb(255 207 115 / 0.8);
+  border-radius: 1rem;
+  background: rgb(13 18 28 / 0.94);
+  color: #f8fbff;
+  box-shadow: 0 1.2rem 3rem rgb(0 0 0 / 0.38);
+  backdrop-filter: blur(14px);
+}
+
+.software-renderer-warning__title {
+  margin: 0 0 0.45rem;
+  font-size: 1rem;
+}
+
+.software-renderer-warning__description,
+.software-renderer-warning__recommendation {
+  margin: 0 0 0.75rem;
+  color: rgb(248 251 255 / 0.86);
+  line-height: 1.45;
+}
+
+.software-renderer-warning__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.software-renderer-warning__button,
+.software-renderer-warning__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgb(146 204 255 / 0.7);
+  border-radius: 999px;
+  background: rgb(94 166 255 / 0.2);
+  color: #f8fbff;
+  font: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.software-renderer-warning__link--muted,
+.software-renderer-warning__safe-link {
+  border-color: rgb(248 251 255 / 0.24);
+  background: transparent;
+  color: rgb(248 251 255 / 0.78);
+}
+
+.software-renderer-warning__safe-link {
+  display: inline-block;
+  margin-top: 0.65rem;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
### Motivation
- Forced-immersive runs on software WebGL (Microsoft Basic Render Driver / SwiftShader / WARP / llvmpipe) crashed browser tabs despite conservative quality reductions, so dangerous software renderers must be treated more conservatively. 
- Keep `?mode=immersive&disablePerformanceFailover=1` useful for debugging while applying safe-mode guardrails instead of forcing text fallback. 
- Preserve diagnostic evidence by persisting bounded crash breadcrumbs so operators can inspect renderer, quality and recent performance snapshots after a crash. 

### Description
- Add a dangerous-software classification and extended renderer snapshot fields in `src/scene/performance/rendererCapabilities.ts`. 
- Introduce a `resolveSoftwareRendererPolicy` + URL overrides (`softwareRendererMode` / `forceContinuousRendering`) and wire it into the initial quality policy in `src/scene/performance/qualityPolicy.ts` to pick ultra-low DPR and capped safe render cadence for dangerous renderers. 
- Implement a software-renderer warning UI with action links for safe immersive, explicit continuous immersive, and text mode in `src/ui/softwareRendererWarning.ts` and styles in `src/ui/styles.css`. 
- Add bounded crash breadcrumb storage and helpers in `src/scene/performance/crashBreadcrumbs.ts` with `exportCrashLog()` / `copyCrashLog()` and integrate periodic snapshot recording, context-loss and fatal-error breadcrumbs in `src/main.ts`, which also exposes the helpers via `window.portfolio.performance`. 
- Prevent heavy postprocessing in safe mode by gating composer usage and capping render cadence (input-driven / low-FPS cadence) in the renderer loop; add Playwright and unit tests and outage docs for the change. 

### Testing
- Ran formatting and linting: `npm run format:write` (success) and `npm run lint` (success; 3 warnings fixed). 
- Unit tests: `npm run test:ci` executed Vitest suite and the focused performance tests including `src/tests/performanceOptimization.test.ts`, `src/tests/performanceDiagnostics.test.ts`, and `src/tests/crashBreadcrumbs.test.ts` all passed. 
- End-to-end: attempted `npm run test:e2e -- --grep "software|crash|renderer|immersive"` but Playwright could not complete in this environment due to missing host browser libraries (Playwright requested `npx playwright install-deps` / system libs), so full Playwright coverage was not run here; a dedicated CI runner with Playwright deps is required to exercise the new Playwright specs (`playwright/software-renderer-crash.spec.ts` and related). 
- Smoke/build/docs: `npm run smoke` (build + smoke) passed and `npm run docs:check` passed. 

Notes / residual risks: `npm run typecheck` shows pre-existing repository TypeScript issues independent of this change; Playwright e2e requires host browser dependencies to run in this environment and should be validated on CI or a developer machine with `npx playwright install` and required OS libs installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1d82fbe8832faae66f2ccff57923)