### PR TITLE
🛡️ Harden software renderer safe mode

### DIFF
--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
@@ -1,0 +1,31 @@
+{
+  "date": "2026-05-30",
+  "title": "Software renderer crash hardening",
+  "status": "mitigated",
+  "symptom": "Chrome tabs crashed after several seconds when immersive mode ran continuously on Microsoft Basic Render Driver with browser hardware acceleration disabled.",
+  "evidence": [
+    "Software path: ANGLE (Microsoft, Microsoft Basic Render Driver ..., D3D11) reached performance mode with reduced DPR and disabled bloom/composer/mirror before crashing.",
+    "Hardware path: ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11) stayed stable around 60 FPS."
+  ],
+  "rootCauseClass": "Dangerous software renderer instability under continuous WebGL animation.",
+  "dangerousRenderers": [
+    "Microsoft Basic Render Driver",
+    "SwiftShader",
+    "WARP",
+    "llvmpipe",
+    "softpipe",
+    "Mesa offscreen"
+  ],
+  "mitigations": [
+    "Default dangerous renderers to software-safe immersive mode with ultra-low DPR and 15 FPS render cadence.",
+    "Keep bloom, composer, and mirror disabled on dangerous software renderers.",
+    "Show visible warning with safe immersive, continuous override, and text mode choices.",
+    "Persist bounded crash breadcrumbs to localStorage/sessionStorage and expose export/copy helpers.",
+    "Capture WebGL context loss and switch to a recoverable text fallback."
+  ],
+  "debugOverrides": [
+    "softwareRendererMode=safe",
+    "softwareRendererMode=continuous",
+    "forceContinuousRendering=1"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -1,0 +1,51 @@
+# Software renderer crash hardening — 2026-05-30
+
+## Symptom
+
+Forced immersive validation with browser hardware acceleration disabled showed Chrome using
+`ANGLE (Microsoft, Microsoft Basic Render Driver ..., D3D11)`. The page correctly entered the
+software-renderer performance path, disabled bloom/composer/mirror, and reduced DPR, but the tab
+still crashed after several seconds of continuous WebGL rendering.
+
+The same scene on `ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11)` stayed near 60 FPS and did
+not crash.
+
+## Root cause class
+
+The evidence points to dangerous software renderer instability under continuous WebGL animation,
+not a normal hardware GPU leak or a monotonic JavaScript heap leak. Microsoft Basic Render Driver,
+SwiftShader, WARP, llvmpipe, softpipe, and Mesa offscreen renderer strings are treated as dangerous
+software renderers.
+
+## Mitigation
+
+- Dangerous renderers start in software-safe immersive mode instead of full continuous rendering.
+- Safe mode uses an ultra-low DPR cap, performance graphics, disabled bloom/composer/mirror, and a
+  capped render cadence (15 FPS by default).
+- The warning panel explains the software renderer risk and offers:
+  - continue in safe immersive;
+  - enable continuous immersive anyway;
+  - use text mode.
+- `?mode=immersive&disablePerformanceFailover=1` still loads immersive mode for debugging, but the
+  software-safe guardrails remain active.
+- Continuous rendering can be explicitly requested with
+  `?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous` or
+  `?mode=immersive&disablePerformanceFailover=1&forceContinuousRendering=1`.
+- Crash breadcrumbs persist bounded renderer, quality, feature, performance, context-loss, URL, and
+  timestamp snapshots in localStorage/sessionStorage. Export them from the console with
+  `window.portfolio.performance.exportCrashLog()` or copy them with
+  `window.portfolio.performance.copyCrashLog()`.
+
+## Manual validation
+
+1. Disable browser hardware acceleration and open
+   `/?mode=immersive&disablePerformanceFailover=1`.
+2. Confirm the warning panel names software rendering / Basic Render Driver and offers the three
+   actions.
+3. Confirm `window.portfolio.performance.getSnapshot().softwareRenderer.softwareSafeMode` is true
+   and the render cadence is capped.
+4. Reload with `&softwareRendererMode=continuous` and confirm the cadence cap is removed.
+5. Confirm `window.portfolio.performance.exportCrashLog()` returns bounded JSON with renderer info
+   and recent snapshots after reload.
+6. Re-enable browser hardware acceleration and confirm the NVIDIA path is not marked dangerous and
+   does not enter software-safe mode.

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -49,7 +49,14 @@ interface PerformanceSnapshot {
   };
   renderer: {
     isSoftwareRenderer: boolean;
-    riskLevel: 'normal' | 'software' | 'unknown';
+    riskLevel: 'normal' | 'software' | 'dangerous-software' | 'unknown';
+    isDangerousSoftwareRenderer: boolean;
+  };
+  softwareRenderer: {
+    dangerousRenderer: boolean;
+    softwareSafeMode: boolean;
+    renderCadenceFps: number | null;
+    lastRenderSkipped: boolean;
   };
   lastFailoverReason: string | null;
 }
@@ -59,6 +66,7 @@ interface PortfolioWindow extends Window {
   portfolio?: {
     performance?: {
       getSnapshot(): PerformanceSnapshot;
+      exportCrashLog?(): { events: unknown[]; renderer: unknown };
     };
     graphics?: {
       setCameraPanForTest?(input: { x: number; y: number }): void;
@@ -204,6 +212,68 @@ test.describe('immersive performance diagnostics', () => {
         expect(snapshot.features.composerEnabled).toBe(false);
         expect(snapshot.features.mirrorEnabled).toBe(false);
       }
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('shows warning and safe diagnostics for mocked dangerous software renderer', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+
+    try {
+      await waitForImmersive(
+        page,
+        `${IMMERSIVE_DIAGNOSTICS_URL}&debugRenderer=microsoft-basic-render-driver`
+      );
+      await expect(page.locator('.software-renderer-warning')).toBeVisible();
+      await expect(page.locator('.software-renderer-warning')).toContainText(
+        'software rendering'
+      );
+      await expect(page.locator('.software-renderer-warning')).toContainText(
+        'Basic Render Driver'
+      );
+
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.renderer.isDangerousSoftwareRenderer).toBe(true);
+      expect(snapshot.softwareRenderer).toMatchObject({
+        dangerousRenderer: true,
+        softwareSafeMode: true,
+        renderCadenceFps: 15,
+      });
+      expect(snapshot.features.bloomEnabled).toBe(false);
+      expect(snapshot.features.composerEnabled).toBe(false);
+      expect(snapshot.features.mirrorEnabled).toBe(false);
+
+      const crashLog = await page.evaluate(() =>
+        (window as PortfolioWindow).portfolio?.performance?.exportCrashLog?.()
+      );
+      expect(crashLog?.events.length).toBeGreaterThan(0);
+      expect(crashLog?.renderer).toBeDefined();
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('allows explicit continuous override for mocked dangerous renderer', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+
+    try {
+      await waitForImmersive(
+        page,
+        `${IMMERSIVE_DIAGNOSTICS_URL}&debugRenderer=microsoft-basic-render-driver&softwareRendererMode=continuous`
+      );
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.renderer.isDangerousSoftwareRenderer).toBe(true);
+      expect(snapshot.softwareRenderer.softwareSafeMode).toBe(false);
+      expect(snapshot.softwareRenderer.renderCadenceFps).toBeNull();
     } finally {
       await context.close();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,7 @@ import {
   resolveSeasonalLightingSchedule,
 } from './scene/lighting/seasonalPresets';
 import { createAdaptiveQualityController } from './scene/performance/adaptiveQuality';
+import { createCrashBreadcrumbStore } from './scene/performance/crashBreadcrumbs';
 import {
   createPerformanceDiagnostics,
   type PerformanceDiagnosticsApi,
@@ -143,7 +144,11 @@ import {
   resolveResizedBasePixelRatio,
   resolveInitialQualityPolicy,
 } from './scene/performance/qualityPolicy';
-import { getRendererInfo } from './scene/performance/rendererCapabilities';
+import {
+  classifyRendererInfo,
+  getRendererInfo,
+} from './scene/performance/rendererCapabilities';
+import { resolveSoftwareRendererMode } from './scene/performance/softwareRendererMode';
 import { createWindowPoiAnalytics } from './scene/poi/analytics';
 import {
   computePoiEmphasis,
@@ -390,6 +395,7 @@ import {
 import {
   createImmersiveModeUrl,
   createImmersiveRecoveryUrl,
+  createTextModeUrl,
   shouldDisablePerformanceFailover,
 } from './ui/immersiveUrl';
 import './ui/styles.css';
@@ -493,6 +499,66 @@ const markDocumentReady = (mode: AppMode, fallbackReason?: FallbackReason) => {
     delete root.dataset.fallbackReason;
   }
   root.removeAttribute('data-app-loading');
+};
+
+const createStorageSafe = (kind: 'localStorage' | 'sessionStorage') => {
+  try {
+    return window[kind];
+  } catch {
+    return undefined;
+  }
+};
+
+const showDangerousRendererWarning = ({
+  container,
+  rendererLabel,
+  onContinueSafe,
+  onContinuous,
+  onTextMode,
+}: {
+  container: HTMLElement;
+  rendererLabel: string;
+  onContinueSafe: () => void;
+  onContinuous: () => void;
+  onTextMode: () => void;
+}) => {
+  const documentTarget = container.ownerDocument;
+  const panel = documentTarget.createElement('section');
+  panel.className = 'software-renderer-warning';
+  panel.setAttribute('role', 'status');
+  panel.setAttribute('aria-live', 'polite');
+
+  const heading = documentTarget.createElement('h2');
+  heading.textContent = 'Software renderer safe mode';
+  panel.appendChild(heading);
+
+  const message = documentTarget.createElement('p');
+  message.textContent =
+    `Chrome is using software rendering (${rendererLabel}). ` +
+    'Enable browser hardware acceleration for smooth immersive mode. ' +
+    'Safe immersive keeps WebGL available for debugging and screenshots with a capped cadence.';
+  panel.appendChild(message);
+
+  const actions = documentTarget.createElement('div');
+  actions.className = 'software-renderer-warning__actions';
+
+  const addButton = (label: string, onClick: () => void) => {
+    const button = documentTarget.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.addEventListener('click', onClick);
+    actions.appendChild(button);
+  };
+
+  addButton('Continue in safe immersive', () => {
+    panel.remove();
+    onContinueSafe();
+  });
+  addButton('Enable continuous immersive anyway', onContinuous);
+  addButton('Use text mode', onTextMode);
+  panel.appendChild(actions);
+  container.appendChild(panel);
+  return panel;
 };
 
 let immersiveFailureHandled = false;
@@ -675,18 +741,84 @@ function initializeImmersiveScene(
   renderer.outputColorSpace = SRGBColorSpace;
   renderer.toneMapping = ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.1;
-  const rendererInfo = getRendererInfo(renderer);
+  const rendererInfo =
+    new URLSearchParams(window.location.search).get('debugRenderer') ===
+    'microsoft-basic-render-driver'
+      ? classifyRendererInfo({
+          vendor: 'Google Inc.',
+          renderer: 'WebGL',
+          unmaskedVendor: 'Microsoft',
+          unmaskedRenderer:
+            'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
+        })
+      : getRendererInfo(renderer);
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
     window.devicePixelRatio ?? 1
   );
-  const maxPolicyPixelRatioCap = rendererInfo.isSoftwareRenderer ? 1 : 1.25;
+  const softwareRendererMode = resolveSoftwareRendererMode(
+    window.location.search,
+    rendererInfo.isDangerousSoftwareRenderer,
+    initialQualityPolicy.renderCadenceFps ?? 15
+  );
+  const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
+    ? 0.5
+    : rendererInfo.isSoftwareRenderer
+      ? 1
+      : 1.25;
   let adaptivePixelRatioCap = Number.POSITIVE_INFINITY;
   let basePixelRatio = initialQualityPolicy.basePixelRatioCap;
+  const crashBreadcrumbs = createCrashBreadcrumbStore({
+    storage: createStorageSafe('localStorage'),
+    sessionStorage: createStorageSafe('sessionStorage'),
+  });
+  crashBreadcrumbs.record({
+    type: rendererInfo.isDangerousSoftwareRenderer
+      ? 'renderer-warning'
+      : 'snapshot',
+    renderer: rendererInfo,
+    message: rendererInfo.isDangerousSoftwareRenderer
+      ? 'Dangerous software renderer entered immersive safe-mode policy.'
+      : 'Immersive renderer initialized.',
+    detail: {
+      softwareSafeMode: softwareRendererMode.safeMode,
+      renderCadenceFps: softwareRendererMode.renderCadenceFps,
+      qualityPolicy: initialQualityPolicy.reason,
+    },
+  });
   renderer.setPixelRatio(basePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setClearColor(new Color(0x0d121c));
   container.appendChild(renderer.domElement);
+
+  let softwareRenderRequested = true;
+  let lastSoftwareRenderMs = 0;
+  let lastSoftwareRenderSkipped = false;
+  const requestSoftwareSafeRender = () => {
+    softwareRenderRequested = true;
+  };
+
+  if (rendererInfo.isDangerousSoftwareRenderer) {
+    const rendererLabel =
+      rendererInfo.unmaskedRenderer ??
+      rendererInfo.renderer ??
+      'a CPU-backed WebGL renderer';
+    showDangerousRendererWarning({
+      container,
+      rendererLabel,
+      onContinueSafe: requestSoftwareSafeRender,
+      onContinuous: () => {
+        window.location.assign(
+          createImmersiveModeUrl(undefined, {
+            softwareRendererMode: 'continuous',
+          })
+        );
+      },
+      onTextMode: () => {
+        window.location.assign(createTextModeUrl());
+      },
+    });
+  }
 
   ledStripMaterials.length = 0;
   ledFillLightsList.length = 0;
@@ -705,6 +837,12 @@ function initializeImmersiveScene(
   let motionBlurControl: MotionBlurControlHandle | null = null;
   let audioSubtitles: AudioSubtitlesHandle | null = null;
   let ambientCaptionBridge: AmbientCaptionBridge | null = null;
+  const softwareSafeInputEvents = ['keydown', 'pointerdown', 'wheel'] as const;
+  softwareSafeInputEvents.forEach((eventName) => {
+    window.addEventListener(eventName, requestSoftwareSafeRender, {
+      passive: true,
+    });
+  });
   let graphicsQualityManager: GraphicsQualityManager | null = null;
   let graphicsQualityControl: GraphicsQualityControlHandle | null = null;
   let adaptiveQualityController: ReturnType<
@@ -1848,6 +1986,12 @@ function initializeImmersiveScene(
   poiInteractionManager.start();
   beforeUnloadHandler = () => {
     inputLatencyTelemetry?.report('beforeunload');
+    crashBreadcrumbs.record({
+      type: 'snapshot',
+      renderer: rendererInfo,
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+      message: 'Page unloading while immersive scene was active.',
+    });
     disposeImmersiveResources();
   };
   window.addEventListener('beforeunload', beforeUnloadHandler);
@@ -3261,7 +3405,8 @@ function initializeImmersiveScene(
   const applyFeaturePolicy = () => {
     const policy = getQualityFeaturePolicy(
       graphicsQualityManager?.getLevel() ?? initialQualityPolicy.initialLevel,
-      rendererInfo.isSoftwareRenderer
+      rendererInfo.isSoftwareRenderer,
+      rendererInfo.isDangerousSoftwareRenderer
     );
     selfieMirror?.setRenderPolicy({
       enabled: policy.mirrorEnabled,
@@ -3329,6 +3474,22 @@ function initializeImmersiveScene(
       };
     },
     getLastFailoverReason: () => lastFailoverReason,
+    getSoftwareRendererState: () => ({
+      dangerousRenderer: rendererInfo.isDangerousSoftwareRenderer,
+      softwareSafeMode: softwareRendererMode.safeMode,
+      renderCadenceFps: softwareRendererMode.renderCadenceFps,
+      lastRenderSkipped: lastSoftwareRenderSkipped,
+    }),
+    exportCrashLog: () => crashBreadcrumbs.exportCrashLog(),
+    copyCrashLog: async () => {
+      const serialized = crashBreadcrumbs.serialize();
+      try {
+        await navigator.clipboard?.writeText(serialized);
+        return true;
+      } catch {
+        return false;
+      }
+    },
   });
   const portfolioWindow = window as Window;
   if (!portfolioWindow.portfolio) {
@@ -3983,6 +4144,9 @@ function initializeImmersiveScene(
       window.removeEventListener('beforeunload', beforeUnloadHandler);
       beforeUnloadHandler = null;
     }
+    softwareSafeInputEvents.forEach((eventName) => {
+      window.removeEventListener(eventName, requestSoftwareSafeRender);
+    });
     while (keyBindingUnsubscribes.length > 0) {
       const unsubscribe = keyBindingUnsubscribes.pop();
       unsubscribe?.();
@@ -4063,9 +4227,33 @@ function initializeImmersiveScene(
   }
 
   let hasPresentedFirstFrame = false;
+  let lastCrashBreadcrumbMs = 0;
+
+  const shouldSkipSoftwareSafeFrame = (nowMs: number) => {
+    if (
+      !softwareRendererMode.safeMode ||
+      !softwareRendererMode.renderCadenceFps
+    ) {
+      lastSoftwareRenderSkipped = false;
+      return false;
+    }
+    const minFrameSpacingMs = 1000 / softwareRendererMode.renderCadenceFps;
+    const shouldRender =
+      !hasPresentedFirstFrame ||
+      softwareRenderRequested ||
+      nowMs - lastSoftwareRenderMs >= minFrameSpacingMs;
+    lastSoftwareRenderSkipped = !shouldRender;
+    return !shouldRender;
+  };
 
   renderer.setAnimationLoop(() => {
     try {
+      const frameStartMs = performance.now();
+      if (shouldSkipSoftwareSafeFrame(frameStartMs)) {
+        return;
+      }
+      softwareRenderRequested = false;
+      lastSoftwareRenderMs = frameStartMs;
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);
@@ -4297,14 +4485,49 @@ function initializeImmersiveScene(
         hasPresentedFirstFrame = true;
         writeModePreference('immersive');
         markDocumentReady('immersive');
+        crashBreadcrumbs.record({
+          type: 'mode-change',
+          renderer: rendererInfo,
+          snapshot: performanceDiagnostics?.methods.getSnapshot(),
+          message: 'Immersive first frame presented.',
+          detail: { softwareSafeMode: softwareRendererMode.safeMode },
+        });
+      }
+      if (frameStartMs - lastCrashBreadcrumbMs >= 1000) {
+        lastCrashBreadcrumbMs = frameStartMs;
+        crashBreadcrumbs.record({
+          type: 'snapshot',
+          renderer: rendererInfo,
+          snapshot: performanceDiagnostics?.methods.getSnapshot(),
+          detail: {
+            jsHeapUsed: (
+              performance as Performance & {
+                memory?: { usedJSHeapSize?: number };
+              }
+            ).memory?.usedJSHeapSize,
+          },
+        });
       }
     } catch (error) {
+      crashBreadcrumbs.record({
+        type: 'fatal-error',
+        renderer: rendererInfo,
+        snapshot: performanceDiagnostics?.methods.getSnapshot(),
+        message: error instanceof Error ? error.message : String(error),
+      });
       handleFatalError(error);
     }
   });
 
   renderer.domElement.addEventListener('webglcontextlost', (event) => {
     event.preventDefault();
-    handleFatalError(new Error('WebGL context lost during initialization.'));
+    crashBreadcrumbs.record({
+      type: 'context-lost',
+      renderer: rendererInfo,
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+      message: 'WebGL context lost; switching to recoverable text fallback.',
+    });
+    lastFailoverReason = 'webgl-unsupported';
+    performanceFailover.triggerFallback('webgl-unsupported');
   });
 }

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -204,7 +204,7 @@ export function createGraphicsQualityManager({
     if (!Number.isFinite(value) || value <= 0) {
       return 1;
     }
-    return Math.max(0.5, Math.min(value, 3));
+    return Math.max(0.25, Math.min(value, 3));
   }
 
   function applyPreset(level: GraphicsQualityLevel) {

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -1,0 +1,144 @@
+import type { PerformanceDiagnosticsSnapshot } from './performanceDiagnostics';
+import type { RendererInfoSnapshot } from './rendererCapabilities';
+
+export type CrashBreadcrumbEventType =
+  | 'snapshot'
+  | 'renderer-warning'
+  | 'context-lost'
+  | 'mode-change'
+  | 'fatal-error';
+
+export interface CrashBreadcrumbEvent {
+  type: CrashBreadcrumbEventType;
+  timestamp: string;
+  url: string;
+  renderer?: RendererInfoSnapshot;
+  snapshot?: PerformanceDiagnosticsSnapshot;
+  message?: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface CrashLogExport {
+  version: 1;
+  exportedAt: string;
+  pageUrl: string;
+  renderer: RendererInfoSnapshot | null;
+  latestSnapshot: PerformanceDiagnosticsSnapshot | null;
+  events: CrashBreadcrumbEvent[];
+}
+
+export interface CrashBreadcrumbStoreOptions {
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  sessionStorage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  storageKey?: string;
+  maxEvents?: number;
+  maxSerializedBytes?: number;
+  now?: () => Date;
+  getUrl?: () => string;
+}
+
+export interface CrashBreadcrumbStore {
+  record(event: Omit<CrashBreadcrumbEvent, 'timestamp' | 'url'>): void;
+  exportCrashLog(): CrashLogExport;
+  serialize(): string;
+}
+
+export const CRASH_BREADCRUMB_STORAGE_KEY =
+  'danielsmith.io:immersive-crash-breadcrumbs';
+
+const DEFAULT_MAX_EVENTS = 24;
+const DEFAULT_MAX_SERIALIZED_BYTES = 80_000;
+
+const safeParseEvents = (serialized: string | null): CrashBreadcrumbEvent[] => {
+  if (!serialized) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(serialized) as Partial<CrashLogExport>;
+    if (!Array.isArray(parsed.events)) {
+      return [];
+    }
+    return parsed.events.filter(
+      (event): event is CrashBreadcrumbEvent =>
+        !!event &&
+        typeof event.type === 'string' &&
+        typeof event.timestamp === 'string'
+    );
+  } catch {
+    return [];
+  }
+};
+
+const writeBounded = (
+  storage: Pick<Storage, 'setItem'> | null | undefined,
+  storageKey: string,
+  serialized: string
+) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(storageKey, serialized);
+  } catch {
+    // Storage may be disabled or full; breadcrumbs are best-effort only.
+  }
+};
+
+export function createCrashBreadcrumbStore({
+  storage,
+  sessionStorage,
+  storageKey = CRASH_BREADCRUMB_STORAGE_KEY,
+  maxEvents = DEFAULT_MAX_EVENTS,
+  maxSerializedBytes = DEFAULT_MAX_SERIALIZED_BYTES,
+  now = () => new Date(),
+  getUrl = () => (typeof window !== 'undefined' ? window.location.href : ''),
+}: CrashBreadcrumbStoreOptions = {}): CrashBreadcrumbStore {
+  const boundedMaxEvents = Math.max(1, Math.floor(maxEvents));
+  const boundedMaxBytes = Math.max(2048, Math.floor(maxSerializedBytes));
+  const events = safeParseEvents(storage?.getItem(storageKey) ?? null).slice(
+    -boundedMaxEvents
+  );
+
+  const buildExport = (): CrashLogExport => {
+    const latestSnapshot = [...events]
+      .reverse()
+      .find((event) => event.snapshot)?.snapshot;
+    const latestRenderer = [...events]
+      .reverse()
+      .find((event) => event.renderer)?.renderer;
+    return {
+      version: 1,
+      exportedAt: now().toISOString(),
+      pageUrl: getUrl(),
+      renderer: latestRenderer ?? latestSnapshot?.renderer ?? null,
+      latestSnapshot: latestSnapshot ?? null,
+      events: [...events],
+    };
+  };
+
+  const persist = () => {
+    while (events.length > boundedMaxEvents) {
+      events.shift();
+    }
+    let serialized = JSON.stringify(buildExport());
+    while (serialized.length > boundedMaxBytes && events.length > 1) {
+      events.shift();
+      serialized = JSON.stringify(buildExport());
+    }
+    writeBounded(storage, storageKey, serialized);
+    writeBounded(sessionStorage, storageKey, serialized);
+  };
+
+  return {
+    record(event) {
+      events.push({ ...event, timestamp: now().toISOString(), url: getUrl() });
+      persist();
+    },
+    exportCrashLog() {
+      return buildExport();
+    },
+    serialize() {
+      return JSON.stringify(buildExport(), null, 2);
+    },
+  };
+}

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -4,6 +4,7 @@ import type {
 } from '../graphics/qualityManager';
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
+import type { CrashLogExport } from './crashBreadcrumbs';
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
 export type PhaseName =
@@ -42,6 +43,13 @@ export interface FeatureStateSnapshot {
   mirrorRenderCount: number;
 }
 
+export interface SoftwareRendererStateSnapshot {
+  dangerousRenderer: boolean;
+  softwareSafeMode: boolean;
+  renderCadenceFps: number | null;
+  lastRenderSkipped: boolean;
+}
+
 export interface FrameStatsSnapshot {
   averageFps: number;
   medianFps: number;
@@ -60,6 +68,7 @@ export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   quality: QualityStateSnapshot;
   features: FeatureStateSnapshot;
   lastFailoverReason: string | null;
+  softwareRenderer: SoftwareRendererStateSnapshot;
 }
 
 export interface PerformanceDiagnosticsApi {
@@ -69,6 +78,9 @@ export interface PerformanceDiagnosticsApi {
   getQualityState(): QualityStateSnapshot;
   getFeatureState(): FeatureStateSnapshot;
   getLastFailoverReason(): string | null;
+  getSoftwareRendererState(): SoftwareRendererStateSnapshot;
+  exportCrashLog?(): CrashLogExport;
+  copyCrashLog?(): Promise<boolean>;
 }
 
 interface PerformanceDiagnosticsOptions {
@@ -77,6 +89,9 @@ interface PerformanceDiagnosticsOptions {
   getQualityState: () => QualityStateSnapshot;
   getFeatureState: () => FeatureStateSnapshot;
   getLastFailoverReason: () => string | null;
+  getSoftwareRendererState?: () => SoftwareRendererStateSnapshot;
+  exportCrashLog?: () => CrashLogExport;
+  copyCrashLog?: () => Promise<boolean>;
   maxSamples?: number;
 }
 
@@ -129,6 +144,14 @@ export function createPerformanceDiagnostics({
   getQualityState,
   getFeatureState,
   getLastFailoverReason,
+  getSoftwareRendererState = () => ({
+    dangerousRenderer: rendererInfo.isDangerousSoftwareRenderer,
+    softwareSafeMode: false,
+    renderCadenceFps: null,
+    lastRenderSkipped: false,
+  }),
+  exportCrashLog,
+  copyCrashLog,
   maxSamples = 180,
 }: PerformanceDiagnosticsOptions) {
   const frameMsSamples: number[] = [];
@@ -154,6 +177,7 @@ export function createPerformanceDiagnostics({
         quality: diagnosticsMethods.getQualityState(),
         features: diagnosticsMethods.getFeatureState(),
         lastFailoverReason: diagnosticsMethods.getLastFailoverReason(),
+        softwareRenderer: diagnosticsMethods.getSoftwareRendererState(),
       };
     },
     getFrameStats() {
@@ -189,6 +213,11 @@ export function createPerformanceDiagnostics({
     getLastFailoverReason() {
       return getLastFailoverReason();
     },
+    getSoftwareRendererState() {
+      return getSoftwareRendererState();
+    },
+    exportCrashLog,
+    copyCrashLog,
   };
 
   return {

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -9,6 +9,8 @@ export interface QualityPolicyState {
   mirrorTargetSize: number;
   mirrorUpdateRateFps: number;
   ambientUpdateIntervalMs: number;
+  softwareSafeMode: boolean;
+  renderCadenceFps: number | null;
   reason: string;
 }
 
@@ -42,9 +44,25 @@ export function resolveResizedBasePixelRatio(
 }
 
 export function resolveInitialQualityPolicy(
-  rendererInfo: Pick<RendererInfoSnapshot, 'isSoftwareRenderer'>,
+  rendererInfo: Pick<RendererInfoSnapshot, 'isSoftwareRenderer'> &
+    Partial<Pick<RendererInfoSnapshot, 'isDangerousSoftwareRenderer'>>,
   devicePixelRatio: number
 ): QualityPolicyState {
+  if (rendererInfo.isDangerousSoftwareRenderer === true) {
+    return {
+      initialLevel: 'performance',
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.5, 0.35),
+      mirrorEnabled: false,
+      mirrorTargetSize: 128,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 250,
+      softwareSafeMode: true,
+      renderCadenceFps: 15,
+      reason:
+        'dangerous software renderer starts with software-safe guardrails',
+    };
+  }
+
   if (rendererInfo.isSoftwareRenderer) {
     return {
       initialLevel: 'performance',
@@ -53,6 +71,8 @@ export function resolveInitialQualityPolicy(
       mirrorTargetSize: 192,
       mirrorUpdateRateFps: 0,
       ambientUpdateIntervalMs: 100,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
       reason: 'software renderer starts in performance mode',
     };
   }
@@ -64,13 +84,16 @@ export function resolveInitialQualityPolicy(
     mirrorTargetSize: 320,
     mirrorUpdateRateFps: 8,
     ambientUpdateIntervalMs: 33,
+    softwareSafeMode: false,
+    renderCadenceFps: null,
     reason: 'default desktop path balances fidelity with pixel cost',
   };
 }
 
 export function getQualityFeaturePolicy(
   level: GraphicsQualityLevel,
-  isSoftwareRenderer = false
+  isSoftwareRenderer = false,
+  isDangerousSoftwareRenderer = false
 ): Pick<
   QualityPolicyState,
   | 'mirrorEnabled'
@@ -78,6 +101,14 @@ export function getQualityFeaturePolicy(
   | 'mirrorUpdateRateFps'
   | 'ambientUpdateIntervalMs'
 > {
+  if (isDangerousSoftwareRenderer) {
+    return {
+      mirrorEnabled: false,
+      mirrorTargetSize: 128,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 250,
+    };
+  }
   if (isSoftwareRenderer || level === 'performance') {
     return {
       mirrorEnabled: false,

--- a/src/scene/performance/rendererCapabilities.ts
+++ b/src/scene/performance/rendererCapabilities.ts
@@ -1,6 +1,10 @@
 import type { WebGLRenderer } from 'three';
 
-export type RendererRiskLevel = 'normal' | 'software' | 'unknown';
+export type RendererRiskLevel =
+  | 'normal'
+  | 'software'
+  | 'dangerous-software'
+  | 'unknown';
 
 export interface RendererInfoSnapshot {
   vendor: string | null;
@@ -8,20 +12,22 @@ export interface RendererInfoSnapshot {
   unmaskedVendor: string | null;
   unmaskedRenderer: string | null;
   isSoftwareRenderer: boolean;
+  isDangerousSoftwareRenderer: boolean;
   riskLevel: RendererRiskLevel;
   reason: string;
 }
 
-const SOFTWARE_RENDERER_PATTERNS = [
+const DANGEROUS_SOFTWARE_RENDERER_PATTERNS = [
+  /microsoft basic render(?:er| driver)?/i,
   /swiftshader/i,
-  /software/i,
+  /\bwarp\b/i,
   /llvmpipe/i,
   /softpipe/i,
   /mesa offscreen/i,
-  /warp/i,
-  /microsoft basic render/i,
-  /angle.*(swiftshader|software|warp)/i,
+  /angle.*(swiftshader|software|warp|microsoft basic render)/i,
 ] as const;
+
+const SOFTWARE_RENDERER_PATTERNS = [/software/i] as const;
 
 export function classifyRendererInfo(input: {
   vendor?: string | null;
@@ -36,9 +42,25 @@ export function classifyRendererInfo(input: {
   const haystack = [vendor, renderer, unmaskedVendor, unmaskedRenderer]
     .filter((value): value is string => typeof value === 'string')
     .join(' ');
-  const matchedPattern = SOFTWARE_RENDERER_PATTERNS.find((pattern) =>
-    pattern.test(haystack)
+  const matchedDangerousPattern = DANGEROUS_SOFTWARE_RENDERER_PATTERNS.find(
+    (pattern) => pattern.test(haystack)
   );
+  const matchedPattern =
+    matchedDangerousPattern ??
+    SOFTWARE_RENDERER_PATTERNS.find((pattern) => pattern.test(haystack));
+
+  if (matchedDangerousPattern) {
+    return {
+      vendor,
+      renderer,
+      unmaskedVendor,
+      unmaskedRenderer,
+      isSoftwareRenderer: true,
+      isDangerousSoftwareRenderer: true,
+      riskLevel: 'dangerous-software',
+      reason: `matched dangerous ${matchedDangerousPattern.source}`,
+    };
+  }
 
   if (matchedPattern) {
     return {
@@ -47,6 +69,7 @@ export function classifyRendererInfo(input: {
       unmaskedVendor,
       unmaskedRenderer,
       isSoftwareRenderer: true,
+      isDangerousSoftwareRenderer: false,
       riskLevel: 'software',
       reason: `matched ${matchedPattern.source}`,
     };
@@ -58,6 +81,7 @@ export function classifyRendererInfo(input: {
     unmaskedVendor,
     unmaskedRenderer,
     isSoftwareRenderer: false,
+    isDangerousSoftwareRenderer: false,
     riskLevel: haystack.length > 0 ? 'normal' : 'unknown',
     reason:
       haystack.length > 0

--- a/src/scene/performance/softwareRendererMode.ts
+++ b/src/scene/performance/softwareRendererMode.ts
@@ -1,0 +1,56 @@
+export type SoftwareRendererMode = 'safe' | 'continuous';
+
+export const SOFTWARE_RENDERER_MODE_PARAM = 'softwareRendererMode';
+export const FORCE_CONTINUOUS_RENDERING_PARAM = 'forceContinuousRendering';
+
+export interface SoftwareRendererModePolicy {
+  mode: SoftwareRendererMode;
+  safeMode: boolean;
+  renderCadenceFps: number | null;
+  reason: string;
+}
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+const normalize = (value: string | null | undefined) =>
+  value?.trim().toLowerCase() ?? null;
+
+export function resolveSoftwareRendererMode(
+  search: string | URLSearchParams,
+  isDangerousSoftwareRenderer: boolean,
+  defaultSafeCadenceFps = 15
+): SoftwareRendererModePolicy {
+  if (!isDangerousSoftwareRenderer) {
+    return {
+      mode: 'continuous',
+      safeMode: false,
+      renderCadenceFps: null,
+      reason: 'hardware or non-dangerous renderer uses normal cadence',
+    };
+  }
+
+  const params =
+    typeof search === 'string'
+      ? new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+      : search;
+  const explicitMode = normalize(params.get(SOFTWARE_RENDERER_MODE_PARAM));
+  const forceContinuous = TRUE_VALUES.has(
+    normalize(params.get(FORCE_CONTINUOUS_RENDERING_PARAM)) ?? ''
+  );
+
+  if (explicitMode === 'continuous' || forceContinuous) {
+    return {
+      mode: 'continuous',
+      safeMode: false,
+      renderCadenceFps: null,
+      reason: 'explicit software renderer continuous override requested',
+    };
+  }
+
+  return {
+    mode: 'safe',
+    safeMode: true,
+    renderCadenceFps: defaultSafeCadenceFps,
+    reason: 'dangerous software renderer defaults to capped safe cadence',
+  };
+}

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCrashBreadcrumbStore } from '../scene/performance/crashBreadcrumbs';
+
+function createMemoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+}
+
+describe('crash breadcrumb store', () => {
+  it('keeps a bounded serializable ring buffer', () => {
+    const storage = createMemoryStorage();
+    const now = vi.fn(() => new Date('2026-05-30T12:00:00.000Z'));
+    const store = createCrashBreadcrumbStore({
+      storage,
+      maxEvents: 3,
+      now,
+      getUrl: () => 'https://example.test/?mode=immersive',
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      store.record({ type: 'snapshot', message: `snapshot ${index}` });
+    }
+
+    const exported = store.exportCrashLog();
+    expect(exported.events).toHaveLength(3);
+    expect(exported.events.map((event) => event.message)).toEqual([
+      'snapshot 2',
+      'snapshot 3',
+      'snapshot 4',
+    ]);
+    expect(() => JSON.parse(store.serialize())).not.toThrow();
+  });
+
+  it('exports renderer info from recent events', () => {
+    const store = createCrashBreadcrumbStore({
+      storage: createMemoryStorage(),
+      getUrl: () => 'https://example.test/',
+      now: () => new Date('2026-05-30T12:00:00.000Z'),
+    });
+
+    store.record({
+      type: 'renderer-warning',
+      renderer: {
+        vendor: 'Google Inc.',
+        renderer: 'WebGL',
+        unmaskedVendor: 'Microsoft',
+        unmaskedRenderer: 'ANGLE (Microsoft Basic Render Driver)',
+        isSoftwareRenderer: true,
+        isDangerousSoftwareRenderer: true,
+        riskLevel: 'dangerous-software',
+        reason: 'matched dangerous microsoft basic render',
+      },
+    });
+
+    expect(store.exportCrashLog().renderer).toMatchObject({
+      isDangerousSoftwareRenderer: true,
+      riskLevel: 'dangerous-software',
+    });
+  });
+});

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -11,6 +11,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },
@@ -79,6 +80,11 @@ describe('performance diagnostics', () => {
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
     expect(snapshot.quality.selectionSource).toBe('adaptive');
+    expect(snapshot.softwareRenderer).toMatchObject({
+      dangerousRenderer: false,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
+    });
     expect(snapshot.quality.adaptiveRecoveryCount).toBe(1);
     expect(snapshot.quality.adaptivePolicy).toMatchObject({
       isWarmingUp: false,
@@ -98,6 +104,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -302,3 +302,47 @@ describe('immersive performance optimization policy', () => {
     expect(harness.onAction).toHaveBeenCalledTimes(3);
   });
 });
+
+describe('dangerous software renderer safe mode', () => {
+  it('classifies Basic Render Driver, SwiftShader, WARP, and llvmpipe as dangerous', () => {
+    for (const unmaskedRenderer of [
+      'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
+      'Google SwiftShader',
+      'ANGLE (Microsoft, WARP, D3D11)',
+      'Mesa llvmpipe (LLVM 17.0.6, 256 bits)',
+    ]) {
+      const snapshot = classifyRendererInfo({ unmaskedRenderer });
+      expect(snapshot.isSoftwareRenderer).toBe(true);
+      expect(snapshot.isDangerousSoftwareRenderer).toBe(true);
+      expect(snapshot.riskLevel).toBe('dangerous-software');
+    }
+  });
+
+  it('keeps hardware renderers out of dangerous safe mode', () => {
+    const snapshot = classifyRendererInfo({
+      unmaskedRenderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 4090, D3D11)',
+    });
+
+    expect(snapshot.isSoftwareRenderer).toBe(false);
+    expect(snapshot.isDangerousSoftwareRenderer).toBe(false);
+    expect(snapshot.riskLevel).toBe('normal');
+  });
+
+  it('chooses ultra-low DPR, no mirror, and capped cadence for dangerous renderers', () => {
+    const policy = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: true, isDangerousSoftwareRenderer: true },
+      2
+    );
+
+    expect(policy.initialLevel).toBe('performance');
+    expect(policy.basePixelRatioCap).toBe(0.5);
+    expect(policy.softwareSafeMode).toBe(true);
+    expect(policy.renderCadenceFps).toBe(15);
+    expect(policy.mirrorEnabled).toBe(false);
+    expect(getQualityFeaturePolicy('cinematic', true, true)).toMatchObject({
+      mirrorEnabled: false,
+      mirrorTargetSize: 128,
+      mirrorUpdateRateFps: 0,
+    });
+  });
+});

--- a/src/tests/softwareRendererMode.test.ts
+++ b/src/tests/softwareRendererMode.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSoftwareRendererMode } from '../scene/performance/softwareRendererMode';
+
+describe('software renderer mode URL policy', () => {
+  it('defaults dangerous renderers to safe capped cadence', () => {
+    expect(resolveSoftwareRendererMode('', true)).toMatchObject({
+      mode: 'safe',
+      safeMode: true,
+      renderCadenceFps: 15,
+    });
+  });
+
+  it('allows continuous rendering only with an explicit override', () => {
+    expect(
+      resolveSoftwareRendererMode('?softwareRendererMode=continuous', true)
+    ).toMatchObject({
+      mode: 'continuous',
+      safeMode: false,
+      renderCadenceFps: null,
+    });
+    expect(
+      resolveSoftwareRendererMode('?forceContinuousRendering=1', true)
+    ).toMatchObject({ safeMode: false, renderCadenceFps: null });
+  });
+
+  it('does not cap normal hardware renderers', () => {
+    expect(resolveSoftwareRendererMode('', false)).toMatchObject({
+      mode: 'continuous',
+      safeMode: false,
+      renderCadenceFps: null,
+    });
+  });
+});

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1927,3 +1927,48 @@ html[data-hudLayout='mobile'] .audio-subtitles {
 .poi-tooltip-overlay[data-state='recommended'] {
   border-color: rgba(255, 207, 129, 0.42);
 }
+
+.software-renderer-warning {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 30;
+  max-width: min(44rem, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid rgba(252, 211, 77, 0.5);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.35);
+}
+
+.software-renderer-warning h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.software-renderer-warning p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.software-renderer-warning__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
+.software-renderer-warning__actions button {
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 999px;
+  padding: 0.55rem 0.8rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  cursor: pointer;
+}
+
+.software-renderer-warning__actions button:first-child {
+  background: #facc15;
+  color: #111827;
+}


### PR DESCRIPTION
### Motivation
- Software/CPU-backed WebGL renderers (Microsoft Basic Render Driver, SwiftShader, WARP, llvmpipe, etc.) were unstable under continuous immersive animation and could crash the tab. 
- Safety and diagnosability are required: keep immersive available for debugging/screenshots while avoiding continuous high-cost animation on known dangerous renderers. 
- Preserve explicit debug/force-immersive flows while adding opt-in continuous rendering and persistent crash breadcrumbs for post-crash forensics.

### Description
- Add a "dangerous software renderer" classification and extend renderer detection patterns to include Microsoft Basic Render Driver, SwiftShader, WARP, llvmpipe, softpipe, Mesa offscreen, and ANGLE software strings (new logic in `src/scene/performance/rendererCapabilities.ts`).
- Introduce a software-safe quality policy that defaults dangerous renderers to ultra-low DPR, disables bloom/composer/mirror, and returns a capped render cadence (default 15 FPS); expose this from `src/scene/performance/qualityPolicy.ts` and wire into feature policy application. 
- Add URL/debug overrides and resolver `resolveSoftwareRendererMode` in `src/scene/performance/softwareRendererMode.ts` supporting `softwareRendererMode=safe|continuous` and `forceContinuousRendering=1`. 
- Wire immersive initialization (`src/main.ts`) to: detect dangerous renderer, record a breadcrumb, show a non-blocking warning panel with actions (continue safe immersive / force continuous / text mode), and enforce a software-safe render cadence (render on first frame, user input, or at the capped FPS). 
- Add bounded crash breadcrumbs persisted to `localStorage`/`sessionStorage` with a ring buffer, export/copy helpers, and a `createCrashBreadcrumbStore` API in `src/scene/performance/crashBreadcrumbs.ts`. 
- Extend diagnostics (`performanceDiagnostics`) to expose software-renderer state and crash export/copy hooks, and record breadcrumbs on first frame, periodic snapshots, fatal errors, and `webglcontextlost` events. 
- Add light-weight warning UI styles in `src/ui/styles.css` and Playwright + Vitest tests for classification, mode resolution, and breadcrumb behavior. 
- Add documentation/outage notes `outages/2026-05-30-danielsmith-software-renderer-crash-hardening.*` describing symptoms, mitigation, and debug overrides.

### Testing
- Ran formatting and lint: `npm run format:write` (passed) and `npm run lint` (passed). 
- Typecheck: `npm run typecheck` (failed with pre-existing repo-wide TypeScript issues unrelated to these changes). 
- Unit tests: ran targeted suites and new tests with Vitest: `npx vitest run src/tests/performanceOptimization.test.ts src/tests/performanceDiagnostics.test.ts src/tests/softwareRendererMode.test.ts src/tests/crashBreadcrumbs.test.ts` (all targeted tests passed). 
- Full test CI: `npm run test:ci` (Vitest run completed; existing suite passed: 871 tests passed). 
- Playwright e2e: `npm run test:e2e -- --grep "software|crash|renderer|immersive"` was executed (Playwright browsers installed during the run and host deps installed as needed); results for the software/renderer/immersive grep: integration run completed with the relevant Playwright scenarios passing (15 passed, 2 skipped) after installing browsers and system deps. 
- Docs & smoke: `npm run docs:check` (passed) and `npm run smoke` (build + smoke assertions passed). 
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).

Residual notes and follow-ups: address unrelated TypeScript errors reported by `npm run typecheck` in a separate PR; consider follow-ups to tune the default safe cadence or expose the cadence in HUD for advanced debugging if requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1d82fbe8832faae66f2ccff57923)