### PR TITLE
Harden software-renderer crash behavior; add safe immersive mode and crash breadcrumbs

### DIFF
--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
@@ -1,0 +1,39 @@
+{
+  "id": "2026-05-30-danielsmith-software-renderer-crash-hardening",
+  "date": "2026-05-30",
+  "title": "Software renderer crash hardening",
+  "severity": "medium",
+  "status": "mitigated",
+  "symptom": "Chrome tab crashed after several seconds on Microsoft Basic Render Driver with hardware acceleration disabled.",
+  "evidence": [
+    "Software renderer path reached performance quality with DPR around 0.56 and expensive effects disabled.",
+    "mainRender dominated frame time while JavaScript phase timings were small.",
+    "NVIDIA hardware renderer on the same machine remained stable near 60 FPS."
+  ],
+  "rootCauseClass": "Dangerous software-renderer instability under continuous WebGL animation.",
+  "dangerousRenderers": [
+    "Microsoft Basic Render Driver",
+    "SwiftShader",
+    "WARP",
+    "llvmpipe",
+    "softpipe",
+    "Mesa offscreen"
+  ],
+  "mitigations": [
+    "Classify dangerous software renderers separately from normal software renderer risk.",
+    "Start dangerous renderers in software-safe immersive mode with ultra-low DPR and no expensive effects.",
+    "Cap safe-mode rendering cadence unless softwareRendererMode=continuous is explicitly present.",
+    "Persist bounded crash breadcrumbs to localStorage/sessionStorage and expose export/copy helpers.",
+    "Record WebGL context loss and transition to a recoverable fallback when possible."
+  ],
+  "debugOptions": {
+    "safe": "?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=safe",
+    "continuous": "?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous"
+  },
+  "manualValidation": [
+    "Open forced immersive with Chrome hardware acceleration disabled and confirm the safe-mode warning.",
+    "Confirm exportCrashLog() contains renderer-warning and snapshot events.",
+    "Append softwareRendererMode=continuous only for deliberate high-risk debugging.",
+    "Re-enable hardware acceleration and confirm NVIDIA is not marked dangerous."
+  ]
+}

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -1,0 +1,69 @@
+# Software renderer crash hardening
+
+## Symptom
+
+On May 30, 2026, forced immersive testing with Chrome hardware acceleration
+disabled showed the renderer string
+`ANGLE (Microsoft, Microsoft Basic Render Driver ..., D3D11)`. The app correctly
+identified the path as software rendered, lowered quality to performance mode,
+reduced DPR to roughly `0.56`, disabled bloom/composer work, and disabled the
+mirror, yet the Chrome tab still crashed after several seconds.
+
+The same scene on the same workstation with browser hardware acceleration
+enabled reported `ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11)`, held
+near 60 FPS, and did not crash.
+
+## Evidence
+
+- Software-renderer logs showed low JavaScript phase timings while `mainRender`
+  dominated frame cost.
+- JS heap readings fluctuated but did not show a clear monotonic leak.
+- The crash reproduced only on the Microsoft Basic Render Driver path, not the
+  NVIDIA hardware path.
+
+## Root cause class
+
+The failure is treated as dangerous software-renderer instability under
+continuous WebGL animation. Microsoft Basic Render Driver, SwiftShader, WARP,
+llvmpipe, softpipe, and Mesa offscreen strings are classified as dangerous
+software renderers.
+
+## Mitigation
+
+Dangerous renderers now enter software-safe immersive mode unless the URL
+explicitly opts into continuous rendering:
+
+- `?mode=immersive&disablePerformanceFailover=1` still loads immersive mode for
+  debugging, but applies software-safe guardrails.
+- `softwareRendererMode=safe` keeps ultra-low DPR, disables expensive features,
+  and caps the render cadence.
+- `softwareRendererMode=continuous` is the explicit debugging override for full
+  continuous animation on dangerous software renderers.
+
+The warning UI explains that Chrome is using a software renderer / Basic Render
+Driver, recommends enabling browser hardware acceleration, and offers safe
+immersive, continuous immersive, or text mode choices.
+
+Crash breadcrumbs are persisted to localStorage/sessionStorage with bounded ring
+buffers. Use `window.portfolio.performance.exportCrashLog()` to retrieve JSON or
+`window.portfolio.performance.copyCrashLog()` to copy it when clipboard access is
+available. Breadcrumbs include recent diagnostics snapshots, renderer info,
+quality/adaptive state, WebGL context loss events, JS memory when available, the
+page URL, timestamps, and the last renderer warning.
+
+## Manual validation
+
+1. Disable Chrome hardware acceleration and open
+   `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`.
+2. Confirm the software-renderer warning is visible and the scene reaches first
+   frame without immediate text fallback.
+3. Run `window.portfolio.performance.getSnapshot()` and confirm
+   `dangerousRenderer: true`, `softwareSafeMode: "safe"`, no mirror, no bloom,
+   and a capped render cadence.
+4. Run `window.portfolio.performance.exportCrashLog()` and confirm the renderer
+   warning and snapshots are present after reload.
+5. For a deliberate high-risk debug run, append
+   `&softwareRendererMode=continuous` and confirm the snapshot reports
+   `softwareSafeMode: "continuous"`.
+6. Re-enable hardware acceleration and confirm the NVIDIA path reports
+   `dangerousRenderer: false` and is not forced into software-safe mode.

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -49,9 +49,14 @@ interface PerformanceSnapshot {
   };
   renderer: {
     isSoftwareRenderer: boolean;
-    riskLevel: 'normal' | 'software' | 'unknown';
+    riskLevel: 'normal' | 'software' | 'dangerous-software' | 'unknown';
+    isDangerousSoftwareRenderer: boolean;
   };
   lastFailoverReason: string | null;
+  dangerousRenderer: boolean;
+  softwareSafeMode: 'off' | 'safe' | 'continuous';
+  continuousRendering: boolean;
+  maxRenderFps: number | null;
 }
 
 interface PortfolioWindow extends Window {
@@ -59,6 +64,7 @@ interface PortfolioWindow extends Window {
   portfolio?: {
     performance?: {
       getSnapshot(): PerformanceSnapshot;
+      exportCrashLog(): string;
     };
     graphics?: {
       setCameraPanForTest?(input: { x: number; y: number }): void;
@@ -101,6 +107,41 @@ async function installProductionLikeHints(page: Page) {
     defineNavigatorGetter('webdriver', false);
     defineNavigatorGetter('hardwareConcurrency', 8);
     defineNavigatorGetter('deviceMemory', 8);
+  });
+}
+
+async function mockDangerousRenderer(page: Page) {
+  await page.addInitScript(() => {
+    const dangerousRenderer =
+      'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)';
+    const patchPrototype = (prototype: WebGLRenderingContext) => {
+      const originalGetExtension = prototype.getExtension;
+      const originalGetParameter = prototype.getParameter;
+      prototype.getExtension = function getExtension(name: string) {
+        if (name === 'WEBGL_debug_renderer_info') {
+          return {
+            UNMASKED_VENDOR_WEBGL: 0x9245,
+            UNMASKED_RENDERER_WEBGL: 0x9246,
+          } as WEBGL_debug_renderer_info;
+        }
+        return originalGetExtension.call(this, name);
+      };
+      prototype.getParameter = function getParameter(parameter: number) {
+        if (parameter === 0x9245) {
+          return 'Microsoft';
+        }
+        if (parameter === 0x9246) {
+          return dangerousRenderer;
+        }
+        return originalGetParameter.call(this, parameter);
+      };
+    };
+    patchPrototype(WebGLRenderingContext.prototype);
+    if (typeof WebGL2RenderingContext !== 'undefined') {
+      patchPrototype(
+        WebGL2RenderingContext.prototype as unknown as WebGLRenderingContext
+      );
+    }
   });
 }
 
@@ -225,6 +266,35 @@ test.describe('immersive performance diagnostics', () => {
       ).toBeGreaterThanOrEqual(0);
       expect(snapshot.quality.level).not.toBe('cinematic');
       expect(snapshot.quality.adaptivePolicy).toBeDefined();
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('shows safe-mode warning for mocked dangerous software renderer', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+    await mockDangerousRenderer(page);
+
+    try {
+      await waitForImmersive(page, IMMERSIVE_DIAGNOSTICS_URL);
+      await expect(page.locator('.software-renderer-warning')).toContainText(
+        'Software renderer safe mode'
+      );
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.renderer.isDangerousSoftwareRenderer).toBe(true);
+      expect(snapshot.dangerousRenderer).toBe(true);
+      expect(snapshot.softwareSafeMode).toBe('safe');
+      expect(snapshot.maxRenderFps).toBe(15);
+      expect(snapshot.rendererSize.pixelRatio).toBeLessThanOrEqual(0.5);
+      const crashLog = await page.evaluate(() =>
+        (window as PortfolioWindow).portfolio?.performance?.exportCrashLog()
+      );
+      expect(crashLog).toContain('renderer-warning');
+      expect(crashLog?.length ?? 0).toBeLessThan(70_000);
     } finally {
       await context.close();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,7 @@ import {
   resolveSeasonalLightingSchedule,
 } from './scene/lighting/seasonalPresets';
 import { createAdaptiveQualityController } from './scene/performance/adaptiveQuality';
+import { createCrashBreadcrumbStore } from './scene/performance/crashBreadcrumbs';
 import {
   createPerformanceDiagnostics,
   type PerformanceDiagnosticsApi,
@@ -144,6 +145,7 @@ import {
   resolveInitialQualityPolicy,
 } from './scene/performance/qualityPolicy';
 import { getRendererInfo } from './scene/performance/rendererCapabilities';
+import { resolveSoftwareRendererModeState } from './scene/performance/softwareRendererMode';
 import { createWindowPoiAnalytics } from './scene/poi/analytics';
 import {
   computePoiEmphasis,
@@ -390,6 +392,8 @@ import {
 import {
   createImmersiveModeUrl,
   createImmersiveRecoveryUrl,
+  createTextModeUrl,
+  getSoftwareRendererModeFromSearch,
   shouldDisablePerformanceFailover,
 } from './ui/immersiveUrl';
 import './ui/styles.css';
@@ -676,11 +680,19 @@ function initializeImmersiveScene(
   renderer.toneMapping = ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.1;
   const rendererInfo = getRendererInfo(renderer);
+  const requestedSoftwareRendererMode = getSoftwareRendererModeFromSearch(
+    window.location.search
+  );
+  const softwareRendererMode = resolveSoftwareRendererModeState(
+    rendererInfo,
+    requestedSoftwareRendererMode
+  );
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
-    window.devicePixelRatio ?? 1
+    window.devicePixelRatio ?? 1,
+    softwareRendererMode
   );
-  const maxPolicyPixelRatioCap = rendererInfo.isSoftwareRenderer ? 1 : 1.25;
+  const maxPolicyPixelRatioCap = initialQualityPolicy.basePixelRatioCap;
   let adaptivePixelRatioCap = Number.POSITIVE_INFINITY;
   let basePixelRatio = initialQualityPolicy.basePixelRatioCap;
   renderer.setPixelRatio(basePixelRatio);
@@ -713,6 +725,10 @@ function initializeImmersiveScene(
   let performanceDiagnostics: ReturnType<
     typeof createPerformanceDiagnostics
   > | null = null;
+  const crashBreadcrumbs = createCrashBreadcrumbStore();
+  let lastRendererWarning: string | null = null;
+  let removeSoftwareSafeRenderListeners: (() => void) | null = null;
+  let removeContextLostListener: (() => void) | null = null;
   let unsubscribeGraphicsQuality: (() => void) | null = null;
   let accessibilityPresetManager: AccessibilityPresetManager | null = null;
   let accessibilityControlHandle: AccessibilityPresetControlHandle | null =
@@ -873,7 +889,8 @@ function initializeImmersiveScene(
       lastFailoverReason = reason;
       inputLatencyTelemetry?.report(`failover-${reason}`);
     },
-    disabled: disablePerformanceFailover,
+    disabled:
+      disablePerformanceFailover || softwareRendererMode.maxRenderFps !== null,
     consoleFailover: {
       budget: 0,
       onExceeded: ({ source, count }) => {
@@ -1848,6 +1865,13 @@ function initializeImmersiveScene(
   poiInteractionManager.start();
   beforeUnloadHandler = () => {
     inputLatencyTelemetry?.report('beforeunload');
+    crashBreadcrumbs.record({
+      type: 'beforeunload',
+      renderer: rendererInfo,
+      softwareRenderer: softwareRendererMode,
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+      message: lastRendererWarning ?? initialQualityPolicy.reason,
+    });
     disposeImmersiveResources();
   };
   window.addEventListener('beforeunload', beforeUnloadHandler);
@@ -3329,12 +3353,92 @@ function initializeImmersiveScene(
       };
     },
     getLastFailoverReason: () => lastFailoverReason,
+    getSoftwareRendererState: () => softwareRendererMode,
   });
   const portfolioWindow = window as Window;
   if (!portfolioWindow.portfolio) {
     portfolioWindow.portfolio = {};
   }
-  portfolioWindow.portfolio.performance = performanceDiagnostics.methods;
+  portfolioWindow.portfolio.performance = {
+    ...performanceDiagnostics.methods,
+    exportCrashLog: () => crashBreadcrumbs.exportJson(),
+    copyCrashLog: () => crashBreadcrumbs.copyLog(),
+  };
+
+  crashBreadcrumbs.record({
+    type: 'mode',
+    renderer: rendererInfo,
+    softwareRenderer: softwareRendererMode,
+    snapshot: performanceDiagnostics.methods.getSnapshot(),
+    message: initialQualityPolicy.reason,
+  });
+
+  const showDangerousRendererWarning = () => {
+    if (!softwareRendererMode.dangerousRenderer) {
+      return;
+    }
+    const warning = document.createElement('section');
+    warning.className = 'software-renderer-warning';
+    warning.setAttribute('role', 'status');
+    warning.setAttribute('aria-live', 'polite');
+    const rendererLabel =
+      rendererInfo.unmaskedRenderer ??
+      rendererInfo.renderer ??
+      'software WebGL renderer';
+    lastRendererWarning =
+      `Chrome is using ${rendererLabel}; safe immersive mode is active. ` +
+      'Enable browser hardware acceleration for smooth immersive mode.';
+
+    const title = document.createElement('h2');
+    title.textContent = 'Software renderer safe mode';
+    warning.appendChild(title);
+
+    const description = document.createElement('p');
+    description.textContent = lastRendererWarning;
+    warning.appendChild(description);
+
+    const actions = document.createElement('div');
+    actions.className = 'software-renderer-warning__actions';
+
+    const safeButton = document.createElement('button');
+    safeButton.type = 'button';
+    safeButton.textContent = 'Continue in safe immersive';
+    safeButton.addEventListener('click', () => {
+      warning.remove();
+      crashBreadcrumbs.record({
+        type: 'renderer-warning',
+        renderer: rendererInfo,
+        softwareRenderer: softwareRendererMode,
+        snapshot: performanceDiagnostics?.methods.getSnapshot(),
+        message: 'dismissed safe immersive warning',
+      });
+    });
+    actions.appendChild(safeButton);
+
+    const continuousLink = document.createElement('a');
+    continuousLink.href = createImmersiveModeUrl(undefined, {
+      softwareRendererMode: 'continuous',
+    });
+    continuousLink.textContent = 'Enable continuous immersive anyway';
+    actions.appendChild(continuousLink);
+
+    const textLink = document.createElement('a');
+    textLink.href = createTextModeUrl();
+    textLink.textContent = 'Use text mode';
+    actions.appendChild(textLink);
+
+    warning.appendChild(actions);
+    container.appendChild(warning);
+    crashBreadcrumbs.record({
+      type: 'renderer-warning',
+      renderer: rendererInfo,
+      softwareRenderer: softwareRendererMode,
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+      message: lastRendererWarning,
+    });
+  };
+
+  showDangerousRendererWarning();
 
   const lightingDebugController = createLightingDebugController({
     renderer,
@@ -3392,7 +3496,8 @@ function initializeImmersiveScene(
     basePixelRatio = resolveResizedBasePixelRatio(
       window.devicePixelRatio ?? 1,
       maxPolicyPixelRatioCap,
-      adaptivePixelRatioCap
+      adaptivePixelRatioCap,
+      initialQualityPolicy.pixelRatioFloor
     );
     if (graphicsQualityManager) {
       graphicsQualityManager.setBasePixelRatio(basePixelRatio);
@@ -3885,6 +3990,14 @@ function initializeImmersiveScene(
       footstepAudioController.dispose();
       footstepAudioController = null;
     }
+    if (removeContextLostListener) {
+      removeContextLostListener();
+      removeContextLostListener = null;
+    }
+    if (removeSoftwareSafeRenderListeners) {
+      removeSoftwareSafeRenderListeners();
+      removeSoftwareSafeRenderListeners = null;
+    }
     renderer.domElement.removeEventListener('wheel', handleWheelZoom);
     renderer.domElement.removeEventListener(
       'pointerdown',
@@ -4063,12 +4176,52 @@ function initializeImmersiveScene(
   }
 
   let hasPresentedFirstFrame = false;
+  let lastSafeRenderAt = 0;
+  let lastCrashSnapshotAt = 0;
+  let safeRenderRequested = true;
+  const requestSafeRender = () => {
+    safeRenderRequested = true;
+  };
+  if (softwareRendererMode.maxRenderFps !== null) {
+    window.addEventListener('keydown', requestSafeRender);
+    window.addEventListener('pointerdown', requestSafeRender);
+    window.addEventListener('pointermove', requestSafeRender);
+    window.addEventListener('wheel', requestSafeRender, { passive: true });
+    removeSoftwareSafeRenderListeners = () => {
+      window.removeEventListener('keydown', requestSafeRender);
+      window.removeEventListener('pointerdown', requestSafeRender);
+      window.removeEventListener('pointermove', requestSafeRender);
+      window.removeEventListener('wheel', requestSafeRender);
+    };
+  }
 
   renderer.setAnimationLoop(() => {
     try {
+      const now = performance.now();
+      const maxRenderFps = softwareRendererMode.maxRenderFps;
+      if (maxRenderFps !== null && hasPresentedFirstFrame) {
+        const minFrameMs = 1000 / maxRenderFps;
+        if (!safeRenderRequested && now - lastSafeRenderAt < minFrameMs) {
+          return;
+        }
+        if (safeRenderRequested || now - lastSafeRenderAt >= minFrameMs) {
+          safeRenderRequested = false;
+        }
+      }
+      lastSafeRenderAt = now;
       const delta = clock.getDelta();
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);
+      if (performanceDiagnostics && now - lastCrashSnapshotAt > 1000) {
+        lastCrashSnapshotAt = now;
+        crashBreadcrumbs.record({
+          type: 'snapshot',
+          renderer: rendererInfo,
+          softwareRenderer: softwareRendererMode,
+          snapshot: performanceDiagnostics.methods.getSnapshot(),
+          message: lastRendererWarning ?? initialQualityPolicy.reason,
+        });
+      }
       const adaptiveAction = adaptiveQualityController?.update(delta);
       if (adaptiveAction) {
         applyFeaturePolicy();
@@ -4299,12 +4452,34 @@ function initializeImmersiveScene(
         markDocumentReady('immersive');
       }
     } catch (error) {
+      crashBreadcrumbs.record({
+        type: 'fatal-error',
+        renderer: rendererInfo,
+        softwareRenderer: softwareRendererMode,
+        snapshot: performanceDiagnostics?.methods.getSnapshot(),
+        message: error instanceof Error ? error.message : String(error),
+      });
       handleFatalError(error);
     }
   });
 
-  renderer.domElement.addEventListener('webglcontextlost', (event) => {
+  const handleContextLost = (event: Event) => {
     event.preventDefault();
-    handleFatalError(new Error('WebGL context lost during initialization.'));
-  });
+    crashBreadcrumbs.record({
+      type: 'webgl-context-lost',
+      renderer: rendererInfo,
+      softwareRenderer: softwareRendererMode,
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+      message: 'WebGL context lost; switching to recoverable fallback.',
+    });
+    lastFailoverReason = 'immersive-init-error';
+    performanceFailover.triggerFallback('immersive-init-error');
+  };
+  renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
+  removeContextLostListener = () => {
+    renderer.domElement.removeEventListener(
+      'webglcontextlost',
+      handleContextLost
+    );
+  };
 }

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -1,0 +1,197 @@
+import type { PerformanceDiagnosticsSnapshot } from './performanceDiagnostics';
+import type { RendererInfoSnapshot } from './rendererCapabilities';
+import type { SoftwareRendererModeState } from './softwareRendererMode';
+
+export const CRASH_BREADCRUMB_STORAGE_KEY =
+  'danielsmith.io:immersive-crash-breadcrumbs';
+export const CRASH_BREADCRUMB_SESSION_KEY =
+  'danielsmith.io:immersive-crash-breadcrumbs:session';
+
+const DEFAULT_MAX_EVENTS = 24;
+const DEFAULT_MAX_SERIALIZED_BYTES = 64_000;
+
+type BreadcrumbType =
+  | 'snapshot'
+  | 'renderer-warning'
+  | 'webgl-context-lost'
+  | 'mode'
+  | 'fatal-error'
+  | 'beforeunload';
+
+export interface CrashBreadcrumbEvent {
+  type: BreadcrumbType;
+  timestamp: string;
+  pageUrl: string;
+  renderer?: RendererInfoSnapshot;
+  softwareRenderer?: SoftwareRendererModeState;
+  snapshot?: PerformanceDiagnosticsSnapshot;
+  message?: string;
+  memory?: {
+    usedJSHeapSize: number;
+    totalJSHeapSize: number;
+    jsHeapSizeLimit: number;
+  };
+}
+
+export interface CrashBreadcrumbLog {
+  version: 1;
+  updatedAt: string;
+  events: CrashBreadcrumbEvent[];
+}
+
+interface CrashBreadcrumbStoreOptions {
+  maxEvents?: number;
+  maxSerializedBytes?: number;
+  localStorage?: Storage;
+  sessionStorage?: Storage;
+  now?: () => Date;
+  getPageUrl?: () => string;
+}
+
+const getStorage = (
+  kind: 'localStorage' | 'sessionStorage'
+): Storage | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  try {
+    return window[kind];
+  } catch {
+    return undefined;
+  }
+};
+
+const getMemorySnapshot = (): CrashBreadcrumbEvent['memory'] => {
+  if (typeof performance === 'undefined') {
+    return undefined;
+  }
+  const memory = (
+    performance as Performance & {
+      memory?: CrashBreadcrumbEvent['memory'];
+    }
+  ).memory;
+  if (!memory) {
+    return undefined;
+  }
+  return {
+    usedJSHeapSize: memory.usedJSHeapSize,
+    totalJSHeapSize: memory.totalJSHeapSize,
+    jsHeapSizeLimit: memory.jsHeapSizeLimit,
+  };
+};
+
+export class CrashBreadcrumbStore {
+  private readonly maxEvents: number;
+
+  private readonly maxSerializedBytes: number;
+
+  private readonly localStorage?: Storage;
+
+  private readonly sessionStorage?: Storage;
+
+  private readonly now: () => Date;
+
+  private readonly getPageUrl: () => string;
+
+  private events: CrashBreadcrumbEvent[] = [];
+
+  constructor(options: CrashBreadcrumbStoreOptions = {}) {
+    this.maxEvents = Math.max(1, options.maxEvents ?? DEFAULT_MAX_EVENTS);
+    this.maxSerializedBytes = Math.max(
+      1_024,
+      options.maxSerializedBytes ?? DEFAULT_MAX_SERIALIZED_BYTES
+    );
+    this.localStorage = options.localStorage ?? getStorage('localStorage');
+    this.sessionStorage =
+      options.sessionStorage ?? getStorage('sessionStorage');
+    this.now = options.now ?? (() => new Date());
+    this.getPageUrl =
+      options.getPageUrl ??
+      (() => (typeof window === 'undefined' ? '' : window.location.href));
+    this.events = this.readStoredEvents();
+  }
+
+  record(
+    event: Omit<CrashBreadcrumbEvent, 'timestamp' | 'pageUrl' | 'memory'>
+  ) {
+    this.events.push({
+      ...event,
+      timestamp: this.now().toISOString(),
+      pageUrl: this.getPageUrl(),
+      memory: getMemorySnapshot(),
+    });
+    this.trimToBounds();
+    this.persist();
+  }
+
+  exportLog(): CrashBreadcrumbLog {
+    return {
+      version: 1,
+      updatedAt: this.now().toISOString(),
+      events: [...this.events],
+    };
+  }
+
+  exportJson(): string {
+    this.trimToBounds();
+    return JSON.stringify(this.exportLog(), null, 2);
+  }
+
+  async copyLog(): Promise<boolean> {
+    const json = this.exportJson();
+    const clipboard =
+      typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+    if (!clipboard?.writeText) {
+      return false;
+    }
+    await clipboard.writeText(json);
+    return true;
+  }
+
+  private readStoredEvents(): CrashBreadcrumbEvent[] {
+    const stored =
+      this.sessionStorage?.getItem(CRASH_BREADCRUMB_SESSION_KEY) ??
+      this.localStorage?.getItem(CRASH_BREADCRUMB_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(stored) as Partial<CrashBreadcrumbLog>;
+      return Array.isArray(parsed.events)
+        ? parsed.events.slice(-this.maxEvents)
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private trimToBounds() {
+    while (this.events.length > this.maxEvents) {
+      this.events.shift();
+    }
+    while (JSON.stringify(this.exportLog()).length > this.maxSerializedBytes) {
+      if (this.events.length <= 1) {
+        break;
+      }
+      this.events.shift();
+    }
+  }
+
+  private persist() {
+    const serialized = JSON.stringify(this.exportLog());
+    try {
+      this.sessionStorage?.setItem(CRASH_BREADCRUMB_SESSION_KEY, serialized);
+    } catch {
+      // Storage can be unavailable in private or hardened browser contexts.
+    }
+    try {
+      this.localStorage?.setItem(CRASH_BREADCRUMB_STORAGE_KEY, serialized);
+    } catch {
+      // Best effort only; sessionStorage usually keeps the latest breadcrumb.
+    }
+  }
+}
+
+export const createCrashBreadcrumbStore = (
+  options?: CrashBreadcrumbStoreOptions
+) => new CrashBreadcrumbStore(options);

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -5,6 +5,7 @@ import type {
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { RendererInfoSnapshot } from './rendererCapabilities';
+import type { SoftwareRendererModeState } from './softwareRendererMode';
 
 export type PhaseName =
   | 'inputMovementCamera'
@@ -60,6 +61,10 @@ export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   quality: QualityStateSnapshot;
   features: FeatureStateSnapshot;
   lastFailoverReason: string | null;
+  dangerousRenderer: boolean;
+  softwareSafeMode: SoftwareRendererModeState['softwareSafeMode'];
+  continuousRendering: boolean;
+  maxRenderFps: number | null;
 }
 
 export interface PerformanceDiagnosticsApi {
@@ -69,6 +74,9 @@ export interface PerformanceDiagnosticsApi {
   getQualityState(): QualityStateSnapshot;
   getFeatureState(): FeatureStateSnapshot;
   getLastFailoverReason(): string | null;
+  getSoftwareRendererState(): SoftwareRendererModeState;
+  exportCrashLog?(): string;
+  copyCrashLog?(): Promise<boolean>;
 }
 
 interface PerformanceDiagnosticsOptions {
@@ -77,6 +85,7 @@ interface PerformanceDiagnosticsOptions {
   getQualityState: () => QualityStateSnapshot;
   getFeatureState: () => FeatureStateSnapshot;
   getLastFailoverReason: () => string | null;
+  getSoftwareRendererState: () => SoftwareRendererModeState;
   maxSamples?: number;
 }
 
@@ -129,6 +138,7 @@ export function createPerformanceDiagnostics({
   getQualityState,
   getFeatureState,
   getLastFailoverReason,
+  getSoftwareRendererState,
   maxSamples = 180,
 }: PerformanceDiagnosticsOptions) {
   const frameMsSamples: number[] = [];
@@ -154,6 +164,14 @@ export function createPerformanceDiagnostics({
         quality: diagnosticsMethods.getQualityState(),
         features: diagnosticsMethods.getFeatureState(),
         lastFailoverReason: diagnosticsMethods.getLastFailoverReason(),
+        dangerousRenderer:
+          diagnosticsMethods.getSoftwareRendererState().dangerousRenderer,
+        softwareSafeMode:
+          diagnosticsMethods.getSoftwareRendererState().softwareSafeMode,
+        continuousRendering:
+          diagnosticsMethods.getSoftwareRendererState().continuousRendering,
+        maxRenderFps:
+          diagnosticsMethods.getSoftwareRendererState().maxRenderFps,
       };
     },
     getFrameStats() {
@@ -188,6 +206,9 @@ export function createPerformanceDiagnostics({
     },
     getLastFailoverReason() {
       return getLastFailoverReason();
+    },
+    getSoftwareRendererState() {
+      return getSoftwareRendererState();
     },
   };
 

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -1,6 +1,7 @@
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
 
 import type { RendererInfoSnapshot } from './rendererCapabilities';
+import type { SoftwareRendererModeState } from './softwareRendererMode';
 
 export interface QualityPolicyState {
   initialLevel: GraphicsQualityLevel;
@@ -9,6 +10,9 @@ export interface QualityPolicyState {
   mirrorTargetSize: number;
   mirrorUpdateRateFps: number;
   ambientUpdateIntervalMs: number;
+  pixelRatioFloor: number;
+  maxRenderFps: number | null;
+  softwareSafeMode: SoftwareRendererModeState['softwareSafeMode'];
   reason: string;
 }
 
@@ -28,11 +32,13 @@ export function clampDevicePixelRatio(
 export function resolveResizedBasePixelRatio(
   devicePixelRatio: number,
   maxPolicyCap: number,
-  adaptivePixelRatioCap = Number.POSITIVE_INFINITY
+  adaptivePixelRatioCap = Number.POSITIVE_INFINITY,
+  floor = 0.75
 ): number {
   const resizedPixelRatio = clampDevicePixelRatio(
     devicePixelRatio,
-    maxPolicyCap
+    maxPolicyCap,
+    floor
   );
   const safeAdaptiveCap =
     Number.isFinite(adaptivePixelRatioCap) && adaptivePixelRatioCap > 0
@@ -42,9 +48,31 @@ export function resolveResizedBasePixelRatio(
 }
 
 export function resolveInitialQualityPolicy(
-  rendererInfo: Pick<RendererInfoSnapshot, 'isSoftwareRenderer'>,
-  devicePixelRatio: number
+  rendererInfo: Pick<RendererInfoSnapshot, 'isSoftwareRenderer'> &
+    Partial<Pick<RendererInfoSnapshot, 'isDangerousSoftwareRenderer'>>,
+  devicePixelRatio: number,
+  softwareRendererMode?: SoftwareRendererModeState
 ): QualityPolicyState {
+  if (softwareRendererMode?.dangerousRenderer) {
+    const continuous = softwareRendererMode.continuousRendering;
+    return {
+      initialLevel: 'performance',
+      basePixelRatioCap: clampDevicePixelRatio(
+        devicePixelRatio,
+        continuous ? 0.5 : 0.35,
+        0.35
+      ),
+      mirrorEnabled: false,
+      mirrorTargetSize: 128,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 150,
+      pixelRatioFloor: 0.35,
+      maxRenderFps: softwareRendererMode.maxRenderFps,
+      softwareSafeMode: softwareRendererMode.softwareSafeMode,
+      reason: softwareRendererMode.reason,
+    };
+  }
+
   if (rendererInfo.isSoftwareRenderer) {
     return {
       initialLevel: 'performance',
@@ -53,6 +81,9 @@ export function resolveInitialQualityPolicy(
       mirrorTargetSize: 192,
       mirrorUpdateRateFps: 0,
       ambientUpdateIntervalMs: 100,
+      pixelRatioFloor: 0.75,
+      maxRenderFps: null,
+      softwareSafeMode: 'off',
       reason: 'software renderer starts in performance mode',
     };
   }
@@ -64,6 +95,9 @@ export function resolveInitialQualityPolicy(
     mirrorTargetSize: 320,
     mirrorUpdateRateFps: 8,
     ambientUpdateIntervalMs: 33,
+    pixelRatioFloor: 0.75,
+    maxRenderFps: null,
+    softwareSafeMode: 'off',
     reason: 'default desktop path balances fidelity with pixel cost',
   };
 }

--- a/src/scene/performance/rendererCapabilities.ts
+++ b/src/scene/performance/rendererCapabilities.ts
@@ -1,6 +1,10 @@
 import type { WebGLRenderer } from 'three';
 
-export type RendererRiskLevel = 'normal' | 'software' | 'unknown';
+export type RendererRiskLevel =
+  | 'normal'
+  | 'software'
+  | 'dangerous-software'
+  | 'unknown';
 
 export interface RendererInfoSnapshot {
   vendor: string | null;
@@ -8,9 +12,20 @@ export interface RendererInfoSnapshot {
   unmaskedVendor: string | null;
   unmaskedRenderer: string | null;
   isSoftwareRenderer: boolean;
+  isDangerousSoftwareRenderer: boolean;
   riskLevel: RendererRiskLevel;
   reason: string;
 }
+
+const DANGEROUS_SOFTWARE_RENDERER_PATTERNS = [
+  /microsoft basic render(?:er| driver)?/i,
+  /swiftshader/i,
+  /\bwarp\b/i,
+  /llvmpipe/i,
+  /softpipe/i,
+  /mesa offscreen/i,
+  /angle.*(swiftshader|software|warp|microsoft basic render)/i,
+] as const;
 
 const SOFTWARE_RENDERER_PATTERNS = [
   /swiftshader/i,
@@ -36,9 +51,12 @@ export function classifyRendererInfo(input: {
   const haystack = [vendor, renderer, unmaskedVendor, unmaskedRenderer]
     .filter((value): value is string => typeof value === 'string')
     .join(' ');
-  const matchedPattern = SOFTWARE_RENDERER_PATTERNS.find((pattern) =>
-    pattern.test(haystack)
+  const dangerousPattern = DANGEROUS_SOFTWARE_RENDERER_PATTERNS.find(
+    (pattern) => pattern.test(haystack)
   );
+  const matchedPattern =
+    dangerousPattern ??
+    SOFTWARE_RENDERER_PATTERNS.find((pattern) => pattern.test(haystack));
 
   if (matchedPattern) {
     return {
@@ -47,7 +65,8 @@ export function classifyRendererInfo(input: {
       unmaskedVendor,
       unmaskedRenderer,
       isSoftwareRenderer: true,
-      riskLevel: 'software',
+      isDangerousSoftwareRenderer: dangerousPattern !== undefined,
+      riskLevel: dangerousPattern ? 'dangerous-software' : 'software',
       reason: `matched ${matchedPattern.source}`,
     };
   }
@@ -58,6 +77,7 @@ export function classifyRendererInfo(input: {
     unmaskedVendor,
     unmaskedRenderer,
     isSoftwareRenderer: false,
+    isDangerousSoftwareRenderer: false,
     riskLevel: haystack.length > 0 ? 'normal' : 'unknown',
     reason:
       haystack.length > 0

--- a/src/scene/performance/softwareRendererMode.ts
+++ b/src/scene/performance/softwareRendererMode.ts
@@ -1,0 +1,68 @@
+import type { RendererInfoSnapshot } from './rendererCapabilities';
+
+export const SOFTWARE_RENDERER_MODE_PARAM = 'softwareRendererMode';
+export const SOFTWARE_RENDERER_MODE_SAFE = 'safe';
+export const SOFTWARE_RENDERER_MODE_CONTINUOUS = 'continuous';
+
+export type SoftwareRendererMode =
+  | typeof SOFTWARE_RENDERER_MODE_SAFE
+  | typeof SOFTWARE_RENDERER_MODE_CONTINUOUS;
+
+export interface SoftwareRendererModeState {
+  dangerousRenderer: boolean;
+  softwareSafeMode: SoftwareRendererMode | 'off';
+  continuousRendering: boolean;
+  maxRenderFps: number | null;
+  reason: string;
+}
+
+const normalizeMode = (value: string | null): SoftwareRendererMode | null => {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === SOFTWARE_RENDERER_MODE_CONTINUOUS) {
+    return SOFTWARE_RENDERER_MODE_CONTINUOUS;
+  }
+  if (normalized === SOFTWARE_RENDERER_MODE_SAFE) {
+    return SOFTWARE_RENDERER_MODE_SAFE;
+  }
+  return null;
+};
+
+export function getSoftwareRendererModeFromSearch(
+  value: string | URLSearchParams
+): SoftwareRendererMode | null {
+  const params = typeof value === 'string' ? new URLSearchParams(value) : value;
+  return normalizeMode(params.get(SOFTWARE_RENDERER_MODE_PARAM));
+}
+
+export function resolveSoftwareRendererModeState(
+  rendererInfo: Pick<RendererInfoSnapshot, 'isDangerousSoftwareRenderer'>,
+  requestedMode: SoftwareRendererMode | null
+): SoftwareRendererModeState {
+  if (!rendererInfo.isDangerousSoftwareRenderer) {
+    return {
+      dangerousRenderer: false,
+      softwareSafeMode: 'off',
+      continuousRendering: true,
+      maxRenderFps: null,
+      reason: 'hardware renderer or non-dangerous renderer uses normal cadence',
+    };
+  }
+
+  if (requestedMode === SOFTWARE_RENDERER_MODE_CONTINUOUS) {
+    return {
+      dangerousRenderer: true,
+      softwareSafeMode: SOFTWARE_RENDERER_MODE_CONTINUOUS,
+      continuousRendering: true,
+      maxRenderFps: null,
+      reason: 'explicit software renderer continuous rendering override',
+    };
+  }
+
+  return {
+    dangerousRenderer: true,
+    softwareSafeMode: SOFTWARE_RENDERER_MODE_SAFE,
+    continuousRendering: false,
+    maxRenderFps: 15,
+    reason: 'dangerous software renderer capped to safe immersive cadence',
+  };
+}

--- a/src/tests/immersiveUrl.test.ts
+++ b/src/tests/immersiveUrl.test.ts
@@ -6,6 +6,7 @@ import {
   createImmersiveRecoveryUrl,
   createTextModeUrl,
   getModeFromSearch,
+  getSoftwareRendererModeFromSearch,
   hasImmersiveOverride,
   hasPerformanceFailoverBypass,
   IMMERSIVE_PREVIEW_BASE_URL,
@@ -64,6 +65,24 @@ describe('createImmersiveModeUrl', () => {
     expect(url).toBe(
       '/demo?foo=bar&mode=immersive&disablePerformanceFailover=1&utm_campaign=launch'
     );
+  });
+
+  it('preserves explicit software renderer debug modes as extra params', () => {
+    const safeUrl = createImmersiveModeUrl(baseLocation, {
+      softwareRendererMode: 'safe',
+    });
+    const continuousUrl = createImmersiveModeUrl(baseLocation, {
+      softwareRendererMode: 'continuous',
+    });
+
+    expect(safeUrl).toBe(
+      '/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=safe'
+    );
+    expect(continuousUrl).toBe(
+      '/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=continuous'
+    );
+    expect(getSoftwareRendererModeFromSearch(safeUrl)).toBe('safe');
+    expect(getSoftwareRendererModeFromSearch(continuousUrl)).toBe('continuous');
   });
 
   it('normalizes canonical URLs passed as strings while enforcing overrides', () => {

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -11,6 +11,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },
@@ -61,6 +62,13 @@ describe('performance diagnostics', () => {
         mirrorRenderCount: 3,
       }),
       getLastFailoverReason: () => null,
+      getSoftwareRendererState: () => ({
+        dangerousRenderer: false,
+        softwareSafeMode: 'off',
+        continuousRendering: true,
+        maxRenderFps: null,
+        reason: 'test',
+      }),
     });
 
     diagnostics.recordFrame(1 / 60);
@@ -78,6 +86,8 @@ describe('performance diagnostics', () => {
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
+    expect(snapshot.dangerousRenderer).toBe(false);
+    expect(snapshot.softwareSafeMode).toBe('off');
     expect(snapshot.quality.selectionSource).toBe('adaptive');
     expect(snapshot.quality.adaptiveRecoveryCount).toBe(1);
     expect(snapshot.quality.adaptivePolicy).toMatchObject({
@@ -98,6 +108,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },
@@ -126,6 +137,13 @@ describe('performance diagnostics', () => {
         mirrorRenderCount: 0,
       }),
       getLastFailoverReason: () => null,
+      getSoftwareRendererState: () => ({
+        dangerousRenderer: false,
+        softwareSafeMode: 'off',
+        continuousRendering: true,
+        maxRenderFps: null,
+        reason: 'test',
+      }),
     });
 
     for (let index = 0; index < 19; index += 1) {

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -5,6 +5,7 @@ import {
   createAdaptiveQualityController,
   type AdaptiveQualitySelectionSource,
 } from '../scene/performance/adaptiveQuality';
+import { createCrashBreadcrumbStore } from '../scene/performance/crashBreadcrumbs';
 import {
   clampDevicePixelRatio,
   getQualityFeaturePolicy,
@@ -12,6 +13,7 @@ import {
   resolveResizedBasePixelRatio,
 } from '../scene/performance/qualityPolicy';
 import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
+import { resolveSoftwareRendererModeState } from '../scene/performance/softwareRendererMode';
 
 function createPolicyHarness({
   level = 'balanced',
@@ -73,15 +75,29 @@ function createPolicyHarness({
 }
 
 describe('immersive performance optimization policy', () => {
-  it('classifies known software renderers as risky', () => {
-    expect(
-      classifyRendererInfo({ unmaskedRenderer: 'Google SwiftShader' })
-        .isSoftwareRenderer
-    ).toBe(true);
+  it('classifies known dangerous software renderers as high risk', () => {
+    for (const renderer of [
+      'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
+      'Google SwiftShader',
+      'ANGLE (Microsoft, WARP, D3D11)',
+      'llvmpipe (LLVM 15.0.7, 256 bits)',
+    ]) {
+      expect(
+        classifyRendererInfo({ unmaskedRenderer: renderer })
+      ).toMatchObject({
+        isSoftwareRenderer: true,
+        isDangerousSoftwareRenderer: true,
+        riskLevel: 'dangerous-software',
+      });
+    }
+
     expect(
       classifyRendererInfo({ renderer: 'ANGLE (NVIDIA GeForce RTX)' })
-        .isSoftwareRenderer
-    ).toBe(false);
+    ).toMatchObject({
+      isSoftwareRenderer: false,
+      isDangerousSoftwareRenderer: false,
+      riskLevel: 'normal',
+    });
   });
 
   it('starts software renderers in low-cost performance mode', () => {
@@ -100,6 +116,81 @@ describe('immersive performance optimization policy', () => {
     expect(normal.initialLevel).toBe('balanced');
     expect(normal.basePixelRatioCap).toBe(1.25);
     expect(normal.mirrorEnabled).toBe(true);
+  });
+
+  it('uses ultra-low DPR and capped cadence for dangerous software safe mode', () => {
+    const mode = resolveSoftwareRendererModeState(
+      { isDangerousSoftwareRenderer: true },
+      null
+    );
+    const policy = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: true, isDangerousSoftwareRenderer: true },
+      2,
+      mode
+    );
+
+    expect(mode).toMatchObject({
+      dangerousRenderer: true,
+      softwareSafeMode: 'safe',
+      continuousRendering: false,
+      maxRenderFps: 15,
+    });
+    expect(policy).toMatchObject({
+      initialLevel: 'performance',
+      basePixelRatioCap: 0.35,
+      mirrorEnabled: false,
+      mirrorUpdateRateFps: 0,
+      maxRenderFps: 15,
+      softwareSafeMode: 'safe',
+    });
+  });
+
+  it('allows continuous software rendering only with explicit override', () => {
+    const safe = resolveSoftwareRendererModeState(
+      { isDangerousSoftwareRenderer: true },
+      'safe'
+    );
+    const continuous = resolveSoftwareRendererModeState(
+      { isDangerousSoftwareRenderer: true },
+      'continuous'
+    );
+
+    expect(safe.maxRenderFps).toBe(15);
+    expect(safe.continuousRendering).toBe(false);
+    expect(continuous.maxRenderFps).toBeNull();
+    expect(continuous.continuousRendering).toBe(true);
+  });
+
+  it('keeps crash breadcrumb logs bounded and serializable', () => {
+    const storage = new Map<string, string>();
+    const fakeStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+      key: (index: number) => Array.from(storage.keys())[index] ?? null,
+      get length() {
+        return storage.size;
+      },
+    } as Storage;
+    const store = createCrashBreadcrumbStore({
+      maxEvents: 3,
+      localStorage: fakeStorage,
+      sessionStorage: fakeStorage,
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+      getPageUrl: () => 'https://example.test/?mode=immersive',
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      store.record({ type: 'snapshot', message: `snapshot ${index}` });
+    }
+
+    const parsed = JSON.parse(store.exportJson()) as {
+      events: Array<{ message?: string }>;
+    };
+    expect(parsed.events).toHaveLength(3);
+    expect(parsed.events[0]?.message).toBe('snapshot 2');
+    expect(store.exportJson()).toContain('https://example.test/');
   });
 
   it('clamps DPR and disables expensive features in performance mode', () => {

--- a/src/ui/immersiveUrl.ts
+++ b/src/ui/immersiveUrl.ts
@@ -2,11 +2,18 @@ export const IMMERSIVE_MODE_PARAM = 'mode';
 export const IMMERSIVE_MODE_VALUE = 'immersive';
 export const DISABLE_PERFORMANCE_FAILOVER_PARAM = 'disablePerformanceFailover';
 export const DISABLE_PERFORMANCE_FAILOVER_VALUE = '1';
+export const SOFTWARE_RENDERER_MODE_PARAM = 'softwareRendererMode';
+export const SOFTWARE_RENDERER_MODE_SAFE = 'safe';
+export const SOFTWARE_RENDERER_MODE_CONTINUOUS = 'continuous';
 export const TEXT_MODE_VALUE = 'text';
 export const IMMERSIVE_PREVIEW_BASE_URL = 'http://localhost:5173/';
 export type ModeSelection =
   | typeof IMMERSIVE_MODE_VALUE
   | typeof TEXT_MODE_VALUE
+  | null;
+export type SoftwareRendererUrlMode =
+  | typeof SOFTWARE_RENDERER_MODE_SAFE
+  | typeof SOFTWARE_RENDERER_MODE_CONTINUOUS
   | null;
 
 type QueryParamValue = string | number | boolean | null | undefined;
@@ -256,6 +263,22 @@ export const hasPerformanceFailoverBypass = (
 ) => {
   const params = toSearchParams(value);
   return isPerformanceBypass(params.get(DISABLE_PERFORMANCE_FAILOVER_PARAM));
+};
+
+export const getSoftwareRendererModeFromSearch = (
+  value: string | URLSearchParams
+): SoftwareRendererUrlMode => {
+  const params = toSearchParams(value);
+  const normalized = normalizeParamValue(
+    params.get(SOFTWARE_RENDERER_MODE_PARAM)
+  );
+  if (normalized === SOFTWARE_RENDERER_MODE_SAFE) {
+    return SOFTWARE_RENDERER_MODE_SAFE;
+  }
+  if (normalized === SOFTWARE_RENDERER_MODE_CONTINUOUS) {
+    return SOFTWARE_RENDERER_MODE_CONTINUOUS;
+  }
+  return null;
 };
 
 export const shouldDisablePerformanceFailover = (

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1927,3 +1927,59 @@ html[data-hudLayout='mobile'] .audio-subtitles {
 .poi-tooltip-overlay[data-state='recommended'] {
   border-color: rgba(255, 207, 129, 0.42);
 }
+
+.software-renderer-warning {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 30;
+  max-width: min(28rem, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid rgba(255, 205, 111, 0.6);
+  border-radius: 1rem;
+  background: rgba(13, 18, 28, 0.92);
+  color: #f8fafc;
+  box-shadow: 0 1.25rem 3rem rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.software-renderer-warning h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+
+.software-renderer-warning p {
+  margin: 0 0 0.85rem;
+  color: rgba(248, 250, 252, 0.86);
+  line-height: 1.45;
+}
+
+.software-renderer-warning__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.software-renderer-warning button,
+.software-renderer-warning a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  font: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.software-renderer-warning button:hover,
+.software-renderer-warning a:hover,
+.software-renderer-warning button:focus-visible,
+.software-renderer-warning a:focus-visible {
+  border-color: rgba(255, 205, 111, 0.85);
+  background: rgba(255, 205, 111, 0.18);
+  outline: none;
+}


### PR DESCRIPTION
### Motivation

- Chrome/ANGLE software renderers (Microsoft Basic Render Driver, SwiftShader, WARP, llvmpipe, etc.) can crash under continuous WebGL animation even when the app aggressively reduces quality, so safer defaults and diagnostic breadcrumbs are required.

### Description

- Classify dangerous software renderers separately by extending `rendererCapabilities` to mark `dangerous-software` and expose `isDangerousSoftwareRenderer` for policy decisions.
- Add `softwareRendererMode` helpers and `resolveSoftwareRendererModeState` (`src/scene/performance/softwareRendererMode.ts`) to support URL/debug overrides (`softwareRendererMode=safe|continuous`) and to resolve a safe-mode state for dangerous renderers.
- Make quality policy aware of dangerous software mode by extending `resolveInitialQualityPolicy` to return ultra-low DPR floors, disabled bloom/composer/mirror, and optional `maxRenderFps` when in safe mode (`src/scene/performance/qualityPolicy.ts`).
- Introduce bounded crash breadcrumb storage and helpers in `src/scene/performance/crashBreadcrumbs.ts` with `exportCrashLog()`/`copyCrashLog()` semantics and session/localStorage persistence.
- Wire breadcrumbs + software-safe behavior into the immersive lifecycle (`src/main.ts`) to:
  - pick the software mode from URL params, apply safe policy, and cap render cadence (first frame + user input or low FPS cap) for dangerous renderers,
  - record periodic snapshots and events (snapshots, renderer warnings, context loss, fatal errors, beforeunload),
  - expose `window.portfolio.performance.exportCrashLog()` and `copyCrashLog()`.
- Add an in-UI dismissible safety warning for dangerous renderers offering `Continue in safe immersive`, explicit continuous override link, and `Use text mode` (styles in `src/ui/styles.css`).
- Extend diagnostics API (`performanceDiagnostics`) to include `dangerousRenderer`, `softwareSafeMode`, `continuousRendering`, and `maxRenderFps` so snapshots include the software-safe state.
- Keep `?mode=immersive&disablePerformanceFailover=1` behavior but apply software-safe guardrails unless `softwareRendererMode=continuous` is explicitly present.
- Tests and docs: update/add unit tests and Playwright spec for the dangerous renderer path, and add outage notes (`outages/2026-05-30-danielsmith-software-renderer-crash-hardening.*`). Files changed include performance modules, `main.ts`, a Playwright spec, tests, and CSS.

### Testing

- Ran formatting and lint: `npm run format:write` and `npm run lint` (lint had a single import-order warning which was corrected). Both completed successfully.
- Unit/CI tests: `npm run test:ci` (Vitest full suite) was executed locally and the test suite passed; targeted runs also passed for the modified performance tests (e.g. `src/tests/performanceOptimization.test.ts`, `src/tests/performanceDiagnostics.test.ts`, `src/tests/immersiveUrl.test.ts`).
- Playwright: added `playwright/immersive-performance.spec.ts` which includes a mocked dangerous-renderer smoke test; Playwright e2e runs were not executed in this environment (CI should run e2e with browser runners).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1d82fbe8832faae66f2ccff57923)