### PR TITLE
🛡️ Harden software renderer crash behavior

### DIFF
--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.json
@@ -1,0 +1,26 @@
+{
+  "id": "2026-05-30-danielsmith-software-renderer-crash-hardening",
+  "date": "2026-05-30",
+  "title": "Software renderer crash hardening",
+  "symptomSlice": "Chrome tabs crashed after several seconds when hardware acceleration was disabled and WebGL reported ANGLE Microsoft Basic Render Driver, while the hardware-accelerated NVIDIA path stayed stable near 60 FPS.",
+  "evidence": "Forced immersive debug runs showed performance mode, reduced DPR, disabled bloom/composer/mirror, small JS timings, mainRender-dominated frame cost, and no clear monotonic JS heap leak before the tab crash.",
+  "rootCauseClass": "Dangerous software renderer instability under continuous WebGL animation.",
+  "mitigation": "Dangerous software renderers use safe immersive guardrails by default, expose an explicit softwareRendererMode=continuous override, show a visible renderer warning, and persist bounded crash breadcrumbs with context-loss events.",
+  "manualValidation": [
+    "Open http://localhost:5173/?mode=immersive&disablePerformanceFailover=1 with Chrome hardware acceleration disabled.",
+    "Confirm the software-renderer warning and safe immersive mode are active.",
+    "Verify window.portfolio.performance.getSnapshot() reports dangerousRenderer and softwareSafeMode as true.",
+    "Verify window.portfolio.performance.exportCrashLogJson() returns bounded renderer-warning breadcrumbs.",
+    "Use softwareRendererMode=continuous only for explicit continuous-rendering debugging.",
+    "Re-enable hardware acceleration and confirm the NVIDIA path is not software-safe."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"software|crash|renderer|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
+++ b/outages/2026-05-30-danielsmith-software-renderer-crash-hardening.md
@@ -1,0 +1,44 @@
+# Software renderer crash hardening
+
+## Symptom slice
+
+Chrome tabs crashed after several seconds when hardware acceleration was disabled and WebGL reported `ANGLE (Microsoft, Microsoft Basic Render Driver ..., D3D11)`. The same scene stayed stable at about 60 FPS on `ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 ..., D3D11)` with hardware acceleration enabled.
+
+## Evidence
+
+Forced immersive debug runs showed the app correctly identified the Microsoft Basic Render Driver as software rendering. Adaptive quality reached performance mode, DPR dropped to about 0.56, bloom/composer and the selfie mirror were disabled, JS phase timings stayed small, and `mainRender` dominated the frame cost. JS heap readings fluctuated without a monotonic leak trend, pointing to software renderer instability under continuous WebGL animation rather than an application memory leak.
+
+## Root cause class
+
+Known CPU/software WebGL paths such as Microsoft Basic Render Driver, SwiftShader, WARP, and llvmpipe can be unstable under continuous immersive rendering even after expensive scene features are disabled.
+
+## Mitigation
+
+Dangerous software renderers now enter software-safe immersive guardrails by default: ultra-low DPR, no bloom/composer extras, no mirror rendering, and a capped render cadence that still paints the first frame and responds to user input. The forced debug URL `?mode=immersive&disablePerformanceFailover=1` still bypasses immediate text fallback, but it keeps these guardrails unless `softwareRendererMode=continuous` is added for explicit investigation.
+
+A visible warning explains that Chrome is using software rendering / Basic Render Driver, recommends enabling browser hardware acceleration, and offers safe immersive, continuous immersive, and text-mode choices. Crash breadcrumbs persist bounded renderer, quality, diagnostic, memory, warning, URL, and WebGL context-loss data to storage and are retrievable through `window.portfolio.performance.exportCrashLogJson()` or `copyCrashLog()`.
+
+## Manual validation steps
+
+1. Disable Chrome hardware acceleration and open `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`.
+2. Confirm the software-renderer warning appears and the scene remains in safe immersive mode.
+3. Run `window.portfolio.performance.getSnapshot()` and verify `dangerousRenderer` and `softwareSafeMode` are true.
+4. Run `window.portfolio.performance.exportCrashLogJson()` and verify bounded breadcrumbs include renderer warning details.
+5. Add `&softwareRendererMode=continuous` only when debugging continuous software rendering.
+6. Re-enable hardware acceleration and confirm the NVIDIA path does not enter software-safe mode.
+
+## Regression tests
+
+- Unit tests cover dangerous renderer classification, ultra-low safe policy, cadence override behavior, and bounded crash log serialization.
+- Diagnostics tests assert snapshots include dangerous-renderer and software-safe state.
+- Playwright mocks a Basic Render Driver classification to verify the warning, force-immersive safe path, and crash-log export helper without depending on CI hardware.
+
+## Validation commands
+
+- `npm run format:write`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:ci`
+- `npm run test:e2e -- --grep "software|crash|renderer|immersive"`
+- `npm run docs:check`
+- `npm run smoke`

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -4,6 +4,8 @@ const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 const IMMERSIVE_URL = '/?mode=immersive';
 const IMMERSIVE_DIAGNOSTICS_URL =
   '/?mode=immersive&disablePerformanceFailover=1';
+const SOFTWARE_SAFE_DEBUG_URL =
+  '/?mode=immersive&disablePerformanceFailover=1&mockRenderer=basic';
 const SOFTWARE_RENDERER_ZOOM_PAN_MS = 600;
 const HARDWARE_RENDERER_ZOOM_PAN_MS = 4_000;
 
@@ -49,7 +51,16 @@ interface PerformanceSnapshot {
   };
   renderer: {
     isSoftwareRenderer: boolean;
-    riskLevel: 'normal' | 'software' | 'unknown';
+    isDangerousSoftwareRenderer: boolean;
+    riskLevel: 'normal' | 'software' | 'dangerous-software' | 'unknown';
+  };
+  dangerousRenderer: boolean;
+  softwareSafeMode: boolean;
+  softwareRendererPolicy: {
+    softwareSafeMode: boolean;
+    continuousRendering: boolean;
+    renderCadenceFps: number | null;
+    pixelRatioCap: number | null;
   };
   lastFailoverReason: string | null;
 }
@@ -59,6 +70,8 @@ interface PortfolioWindow extends Window {
   portfolio?: {
     performance?: {
       getSnapshot(): PerformanceSnapshot;
+      exportCrashLog(): unknown;
+      exportCrashLogJson(): string;
     };
     graphics?: {
       setCameraPanForTest?(input: { x: number; y: number }): void;
@@ -139,6 +152,41 @@ async function exerciseZoomPan(
       x: 0,
       y: 0,
     });
+  });
+}
+
+async function installDangerousRendererMock(page: Page) {
+  await page.addInitScript(() => {
+    const rendererString =
+      'ANGLE (Microsoft, Microsoft Basic Render Driver Direct3D11 vs_5_0 ps_5_0)';
+    const patchPrototype = (prototype: WebGLRenderingContext) => {
+      const originalGetExtension = prototype.getExtension;
+      const originalGetParameter = prototype.getParameter;
+      prototype.getExtension = function getExtension(name: string) {
+        if (name === 'WEBGL_debug_renderer_info') {
+          return {
+            UNMASKED_VENDOR_WEBGL: 0x9245,
+            UNMASKED_RENDERER_WEBGL: 0x9246,
+          } as unknown as WEBGL_debug_renderer_info;
+        }
+        return originalGetExtension.call(this, name);
+      };
+      prototype.getParameter = function getParameter(parameter: number) {
+        if (parameter === 0x9245) {
+          return 'Microsoft';
+        }
+        if (parameter === 0x9246) {
+          return rendererString;
+        }
+        return originalGetParameter.call(this, parameter);
+      };
+    };
+    patchPrototype(WebGLRenderingContext.prototype);
+    if (typeof WebGL2RenderingContext !== 'undefined') {
+      patchPrototype(
+        WebGL2RenderingContext.prototype as unknown as WebGLRenderingContext
+      );
+    }
   });
 }
 
@@ -225,6 +273,36 @@ test.describe('immersive performance diagnostics', () => {
       ).toBeGreaterThanOrEqual(0);
       expect(snapshot.quality.level).not.toBe('cinematic');
       expect(snapshot.quality.adaptivePolicy).toBeDefined();
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('shows safe immersive warning for dangerous software renderers', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+    await installDangerousRendererMock(page);
+
+    try {
+      await waitForImmersive(page, SOFTWARE_SAFE_DEBUG_URL);
+      await expect(page.locator('.software-renderer-warning')).toContainText(
+        'Software renderer safe mode'
+      );
+      await expect(page.locator('.software-renderer-warning')).toContainText(
+        'Microsoft Basic Render Driver'
+      );
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.renderer.isDangerousSoftwareRenderer).toBe(true);
+      expect(snapshot.softwareSafeMode).toBe(true);
+      expect(snapshot.softwareRendererPolicy.renderCadenceFps).toBe(12);
+      expect(snapshot.rendererSize.pixelRatio).toBeLessThanOrEqual(0.5);
+      const crashLog = await page.evaluate(() =>
+        (window as PortfolioWindow).portfolio?.performance?.exportCrashLogJson()
+      );
+      expect(crashLog).toContain('renderer-warning');
     } finally {
       await context.close();
     }

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -118,6 +118,7 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'automated-client': wrap('Automated client detected'),
         'data-saver': wrap('Data-saver mode enabled'),
         'console-error': wrap('Runtime errors detected'),
+        'webgl-context-lost': wrap('WebGL context lost'),
       },
       reasonDescriptions: {
         manual: wrap(
@@ -146,6 +147,9 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         ),
         'data-saver': wrap(
           'Your browser requested a data-saver experience, so we launched the lightweight text tour to minimize bandwidth while keeping the highlights accessible.'
+        ),
+        'webgl-context-lost': wrap(
+          'The browser reported a lost WebGL context, so we preserved diagnostics and opened the recoverable text tour.'
         ),
       },
     },

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -117,6 +117,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'automated-client': 'Automated client detected',
         'data-saver': 'Data-saver mode enabled',
         'console-error': 'Runtime errors detected',
+        'webgl-context-lost': 'WebGL context lost',
       },
       reasonDescriptions: {
         manual:
@@ -137,6 +138,8 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'We detected a runtime error and switched to the resilient text tour while the immersive scene recovers.',
         'data-saver':
           'Your browser requested a data-saver experience, so we launched the lightweight text tour to minimize bandwidth while keeping the highlights accessible.',
+        'webgl-context-lost':
+          'The browser reported a lost WebGL context, so we preserved diagnostics and opened the recoverable text tour.',
       },
     },
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,7 @@ import {
   resolveSeasonalLightingSchedule,
 } from './scene/lighting/seasonalPresets';
 import { createAdaptiveQualityController } from './scene/performance/adaptiveQuality';
+import { createCrashBreadcrumbStore } from './scene/performance/crashBreadcrumbs';
 import {
   createPerformanceDiagnostics,
   type PerformanceDiagnosticsApi,
@@ -144,6 +145,12 @@ import {
   resolveInitialQualityPolicy,
 } from './scene/performance/qualityPolicy';
 import { getRendererInfo } from './scene/performance/rendererCapabilities';
+import {
+  SOFTWARE_RENDERER_CONTINUOUS_MODE,
+  SOFTWARE_RENDERER_MODE_PARAM,
+  resolveSoftwareRendererPolicy,
+  shouldRenderSoftwareSafeFrame,
+} from './scene/performance/softwareRendererMode';
 import { createWindowPoiAnalytics } from './scene/poi/analytics';
 import {
   computePoiEmphasis,
@@ -390,6 +397,7 @@ import {
 import {
   createImmersiveModeUrl,
   createImmersiveRecoveryUrl,
+  createTextModeUrl,
   shouldDisablePerformanceFailover,
 } from './ui/immersiveUrl';
 import './ui/styles.css';
@@ -426,7 +434,11 @@ declare global {
         }>;
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
-      performance?: PerformanceDiagnosticsApi;
+      performance?: PerformanceDiagnosticsApi & {
+        exportCrashLog(): unknown;
+        exportCrashLogJson(): string;
+        copyCrashLog(): Promise<string>;
+      };
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -676,13 +688,29 @@ function initializeImmersiveScene(
   renderer.toneMapping = ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.1;
   const rendererInfo = getRendererInfo(renderer);
+  const softwareRendererPolicy = resolveSoftwareRendererPolicy(
+    rendererInfo,
+    window.location.search
+  );
+  const crashBreadcrumbs = createCrashBreadcrumbStore();
+  crashBreadcrumbs.setRendererInfo(rendererInfo);
+  crashBreadcrumbs.setSoftwareRendererPolicy(softwareRendererPolicy);
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
     window.devicePixelRatio ?? 1
   );
-  const maxPolicyPixelRatioCap = rendererInfo.isSoftwareRenderer ? 1 : 1.25;
+  const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
+    ? 0.4
+    : rendererInfo.isSoftwareRenderer
+      ? 1
+      : 1.25;
   let adaptivePixelRatioCap = Number.POSITIVE_INFINITY;
-  let basePixelRatio = initialQualityPolicy.basePixelRatioCap;
+  let basePixelRatio = softwareRendererPolicy.pixelRatioCap
+    ? Math.min(
+        initialQualityPolicy.basePixelRatioCap,
+        softwareRendererPolicy.pixelRatioCap
+      )
+    : initialQualityPolicy.basePixelRatioCap;
   renderer.setPixelRatio(basePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setClearColor(new Color(0x0d121c));
@@ -886,6 +914,11 @@ function initializeImmersiveScene(
   });
 
   const handleFatalError = (error: unknown) => {
+    crashBreadcrumbs.record({
+      kind: 'fatal-error',
+      message: error instanceof Error ? error.message : String(error),
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+    });
     disposeImmersiveResources();
     onFatalError(error, { renderer });
   };
@@ -3092,6 +3125,7 @@ function initializeImmersiveScene(
     },
     fpsThreshold: PERFORMANCE_FAILOVER_FPS_THRESHOLD,
     isSoftwareRenderer: rendererInfo.isSoftwareRenderer,
+    minBasePixelRatio: rendererInfo.isDangerousSoftwareRenderer ? 0.35 : 0.75,
     getSelectionSource: () =>
       graphicsQualityManager?.getSelectionSource() ?? 'initial',
     onAction: (event) => {
@@ -3261,7 +3295,8 @@ function initializeImmersiveScene(
   const applyFeaturePolicy = () => {
     const policy = getQualityFeaturePolicy(
       graphicsQualityManager?.getLevel() ?? initialQualityPolicy.initialLevel,
-      rendererInfo.isSoftwareRenderer
+      rendererInfo.isSoftwareRenderer,
+      rendererInfo.isDangerousSoftwareRenderer
     );
     selfieMirror?.setRenderPolicy({
       enabled: policy.mirrorEnabled,
@@ -3328,13 +3363,77 @@ function initializeImmersiveScene(
         mirrorRenderCount: mirrorState?.renderCount ?? 0,
       };
     },
+    getSoftwareRendererPolicy: () => softwareRendererPolicy,
     getLastFailoverReason: () => lastFailoverReason,
   });
   const portfolioWindow = window as Window;
   if (!portfolioWindow.portfolio) {
     portfolioWindow.portfolio = {};
   }
-  portfolioWindow.portfolio.performance = performanceDiagnostics.methods;
+  portfolioWindow.portfolio.performance = {
+    ...performanceDiagnostics.methods,
+    exportCrashLog: crashBreadcrumbs.exportCrashLog,
+    exportCrashLogJson: crashBreadcrumbs.exportCrashLogJson,
+    copyCrashLog: crashBreadcrumbs.copyCrashLog,
+  };
+
+  let softwareRendererWarning: HTMLElement | null = null;
+  const showSoftwareRendererWarning = () => {
+    if (!softwareRendererPolicy.dangerousRenderer) {
+      return;
+    }
+    const warning = document.createElement('aside');
+    warning.className = 'software-renderer-warning';
+    warning.setAttribute('role', 'status');
+    warning.dataset.softwareSafeMode = String(
+      softwareRendererPolicy.softwareSafeMode
+    );
+    const rendererLabel =
+      rendererInfo.unmaskedRenderer ??
+      rendererInfo.renderer ??
+      'software renderer';
+    const message =
+      'Chrome is using software rendering (' +
+      rendererLabel +
+      '). Enable browser hardware acceleration for smooth immersive mode.';
+    warning.innerHTML = '';
+    const title = document.createElement('strong');
+    title.textContent = 'Software renderer safe mode';
+    const body = document.createElement('p');
+    body.textContent = message;
+    const actions = document.createElement('div');
+    actions.className = 'software-renderer-warning__actions';
+    const continueButton = document.createElement('button');
+    continueButton.type = 'button';
+    continueButton.textContent = 'Continue in safe immersive';
+    continueButton.addEventListener('click', () => {
+      warning.hidden = true;
+      softwareSafeRenderDirty = true;
+      crashBreadcrumbs.setLastUserVisibleMessage('continued in safe immersive');
+      crashBreadcrumbs.record({
+        kind: 'mode-change',
+        message: 'continued in safe immersive',
+      });
+    });
+    const continuousLink = document.createElement('a');
+    continuousLink.href = createImmersiveModeUrl(window.location, {
+      [SOFTWARE_RENDERER_MODE_PARAM]: SOFTWARE_RENDERER_CONTINUOUS_MODE,
+    });
+    continuousLink.textContent = 'Enable continuous immersive anyway';
+    continuousLink.rel = 'noopener';
+    const textLink = document.createElement('a');
+    textLink.href = createTextModeUrl(window.location);
+    textLink.textContent = 'Use text mode';
+    textLink.rel = 'noopener';
+    actions.append(continueButton, continuousLink, textLink);
+    warning.append(title, body, actions);
+    container.appendChild(warning);
+    softwareRendererWarning = warning;
+    crashBreadcrumbs.setLastUserVisibleMessage(message);
+    crashBreadcrumbs.record({ kind: 'renderer-warning', message });
+  };
+
+  showSoftwareRendererWarning();
 
   const lightingDebugController = createLightingDebugController({
     renderer,
@@ -3392,7 +3491,8 @@ function initializeImmersiveScene(
     basePixelRatio = resolveResizedBasePixelRatio(
       window.devicePixelRatio ?? 1,
       maxPolicyPixelRatioCap,
-      adaptivePixelRatioCap
+      adaptivePixelRatioCap,
+      rendererInfo.isDangerousSoftwareRenderer ? 0.35 : 0.75
     );
     if (graphicsQualityManager) {
       graphicsQualityManager.setBasePixelRatio(basePixelRatio);
@@ -3983,6 +4083,14 @@ function initializeImmersiveScene(
       window.removeEventListener('beforeunload', beforeUnloadHandler);
       beforeUnloadHandler = null;
     }
+    window.removeEventListener('keydown', markSoftwareSafeRenderDirty);
+    window.removeEventListener('pointerdown', markSoftwareSafeRenderDirty);
+    window.removeEventListener('pointermove', markSoftwareSafeRenderDirty);
+    window.removeEventListener('wheel', markSoftwareSafeRenderDirty);
+    if (softwareRendererWarning) {
+      softwareRendererWarning.remove();
+      softwareRendererWarning = null;
+    }
     while (keyBindingUnsubscribes.length > 0) {
       const unsubscribe = keyBindingUnsubscribes.pop();
       unsubscribe?.();
@@ -4063,12 +4171,52 @@ function initializeImmersiveScene(
   }
 
   let hasPresentedFirstFrame = false;
+  let softwareSafeLastRenderMs: number | null = null;
+  let softwareSafeRenderDirty = true;
+  let crashSnapshotFrameCount = 0;
+  function markSoftwareSafeRenderDirty() {
+    softwareSafeRenderDirty = true;
+  }
+  if (softwareRendererPolicy.softwareSafeMode) {
+    window.addEventListener('keydown', markSoftwareSafeRenderDirty, {
+      passive: true,
+    });
+    window.addEventListener('pointerdown', markSoftwareSafeRenderDirty, {
+      passive: true,
+    });
+    window.addEventListener('pointermove', markSoftwareSafeRenderDirty, {
+      passive: true,
+    });
+    window.addEventListener('wheel', markSoftwareSafeRenderDirty, {
+      passive: true,
+    });
+  }
 
   renderer.setAnimationLoop(() => {
     try {
-      const delta = clock.getDelta();
+      const nowMs = performance.now();
+      if (
+        !shouldRenderSoftwareSafeFrame({
+          nowMs,
+          lastRenderMs: softwareSafeLastRenderMs,
+          cadenceFps: softwareRendererPolicy.renderCadenceFps,
+          dirty: softwareSafeRenderDirty,
+        })
+      ) {
+        return;
+      }
+      softwareSafeLastRenderMs = nowMs;
+      softwareSafeRenderDirty = false;
+      const delta = Math.min(clock.getDelta(), 1 / 12);
       const elapsedTime = clock.elapsedTime;
       performanceDiagnostics?.recordFrame(delta);
+      crashSnapshotFrameCount += 1;
+      if (performanceDiagnostics && crashSnapshotFrameCount % 60 === 0) {
+        crashBreadcrumbs.record({
+          kind: 'performance-snapshot',
+          snapshot: performanceDiagnostics.methods.getSnapshot(),
+        });
+      }
       const adaptiveAction = adaptiveQualityController?.update(delta);
       if (adaptiveAction) {
         applyFeaturePolicy();
@@ -4305,6 +4453,12 @@ function initializeImmersiveScene(
 
   renderer.domElement.addEventListener('webglcontextlost', (event) => {
     event.preventDefault();
-    handleFatalError(new Error('WebGL context lost during initialization.'));
+    crashBreadcrumbs.record({
+      kind: 'webgl-context-lost',
+      message: 'WebGL context lost; switching to recoverable text fallback.',
+      snapshot: performanceDiagnostics?.methods.getSnapshot(),
+    });
+    lastFailoverReason = 'webgl-context-lost';
+    performanceFailover.triggerFallback('webgl-context-lost');
   });
 }

--- a/src/scene/performance/crashBreadcrumbs.ts
+++ b/src/scene/performance/crashBreadcrumbs.ts
@@ -1,0 +1,205 @@
+import type { PerformanceDiagnosticsSnapshot } from './performanceDiagnostics';
+import type { RendererInfoSnapshot } from './rendererCapabilities';
+import type { SoftwareRendererPolicyState } from './softwareRendererMode';
+
+export type CrashBreadcrumbKind =
+  | 'performance-snapshot'
+  | 'renderer-warning'
+  | 'mode-change'
+  | 'webgl-context-lost'
+  | 'fatal-error';
+
+export interface CrashBreadcrumb {
+  kind: CrashBreadcrumbKind;
+  timestamp: string;
+  url: string;
+  renderer?: RendererInfoSnapshot;
+  softwareRendererPolicy?: SoftwareRendererPolicyState;
+  snapshot?: PerformanceDiagnosticsSnapshot;
+  memory?: CrashMemorySnapshot | null;
+  message?: string;
+  detail?: unknown;
+}
+
+export interface CrashMemorySnapshot {
+  usedJSHeapSize?: number;
+  totalJSHeapSize?: number;
+  jsHeapSizeLimit?: number;
+}
+
+export interface CrashLogExport {
+  version: 1;
+  generatedAt: string;
+  pageUrl: string;
+  renderer: RendererInfoSnapshot | null;
+  softwareRendererPolicy: SoftwareRendererPolicyState | null;
+  lastUserVisibleMessage: string | null;
+  breadcrumbs: CrashBreadcrumb[];
+}
+
+interface CrashBreadcrumbStoreOptions {
+  storage?: Storage | null;
+  storageKey?: string;
+  maxEntries?: number;
+  maxSerializedBytes?: number;
+  getLocationHref?: () => string;
+  getMemory?: () => CrashMemorySnapshot | null;
+}
+
+const DEFAULT_STORAGE_KEY = 'danielsmith.io:immersive-crash-breadcrumbs';
+const DEFAULT_MAX_ENTRIES = 40;
+const DEFAULT_MAX_SERIALIZED_BYTES = 96_000;
+
+const safeNow = () => new Date().toISOString();
+
+function readMemory(): CrashMemorySnapshot | null {
+  const performanceMemory =
+    typeof performance === 'undefined'
+      ? undefined
+      : (
+          performance as Performance & {
+            memory?: CrashMemorySnapshot;
+          }
+        ).memory;
+  if (!performanceMemory) {
+    return null;
+  }
+  return {
+    usedJSHeapSize: performanceMemory.usedJSHeapSize,
+    totalJSHeapSize: performanceMemory.totalJSHeapSize,
+    jsHeapSizeLimit: performanceMemory.jsHeapSizeLimit,
+  };
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function safeHref(): string {
+  try {
+    return typeof window === 'undefined' ? '' : window.location.href;
+  } catch {
+    return '';
+  }
+}
+
+function parseStoredBreadcrumbs(raw: string | null): CrashBreadcrumb[] {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as
+      | Partial<CrashLogExport>
+      | CrashBreadcrumb[];
+    if (Array.isArray(parsed)) {
+      return parsed.filter((entry): entry is CrashBreadcrumb => !!entry?.kind);
+    }
+    return Array.isArray(parsed.breadcrumbs)
+      ? parsed.breadcrumbs.filter(
+          (entry): entry is CrashBreadcrumb => !!entry?.kind
+        )
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function createCrashBreadcrumbStore({
+  storage = safeStorage(),
+  storageKey = DEFAULT_STORAGE_KEY,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+  maxSerializedBytes = DEFAULT_MAX_SERIALIZED_BYTES,
+  getLocationHref = safeHref,
+  getMemory = readMemory,
+}: CrashBreadcrumbStoreOptions = {}) {
+  const boundedMaxEntries = Math.max(1, Math.floor(maxEntries));
+  const boundedMaxBytes = Math.max(4096, Math.floor(maxSerializedBytes));
+  const breadcrumbs = parseStoredBreadcrumbs(
+    storage?.getItem(storageKey) ?? null
+  ).slice(-boundedMaxEntries);
+  let renderer: RendererInfoSnapshot | null = null;
+  let softwareRendererPolicy: SoftwareRendererPolicyState | null = null;
+  let lastUserVisibleMessage: string | null = null;
+
+  const createExport = (): CrashLogExport => ({
+    version: 1,
+    generatedAt: safeNow(),
+    pageUrl: getLocationHref(),
+    renderer,
+    softwareRendererPolicy,
+    lastUserVisibleMessage,
+    breadcrumbs: breadcrumbs.slice(-boundedMaxEntries),
+  });
+
+  const persist = () => {
+    if (!storage) {
+      return;
+    }
+    const exportLog = createExport();
+    while (exportLog.breadcrumbs.length > 0) {
+      const serialized = JSON.stringify(exportLog);
+      if (serialized.length <= boundedMaxBytes) {
+        storage.setItem(storageKey, serialized);
+        return;
+      }
+      exportLog.breadcrumbs.shift();
+      breadcrumbs.shift();
+    }
+    storage.setItem(storageKey, JSON.stringify(exportLog));
+  };
+
+  return {
+    setRendererInfo(next: RendererInfoSnapshot) {
+      renderer = next;
+      persist();
+    },
+    setSoftwareRendererPolicy(next: SoftwareRendererPolicyState) {
+      softwareRendererPolicy = next;
+      persist();
+    },
+    setLastUserVisibleMessage(message: string | null) {
+      lastUserVisibleMessage = message;
+      persist();
+    },
+    record(entry: Omit<CrashBreadcrumb, 'timestamp' | 'url' | 'memory'>) {
+      breadcrumbs.push({
+        ...entry,
+        renderer: entry.renderer ?? renderer ?? undefined,
+        softwareRendererPolicy:
+          entry.softwareRendererPolicy ?? softwareRendererPolicy ?? undefined,
+        timestamp: safeNow(),
+        url: getLocationHref(),
+        memory: getMemory(),
+      });
+      while (breadcrumbs.length > boundedMaxEntries) {
+        breadcrumbs.shift();
+      }
+      persist();
+    },
+    exportCrashLog(): CrashLogExport {
+      return createExport();
+    },
+    exportCrashLogJson(space = 2): string {
+      return JSON.stringify(createExport(), null, space);
+    },
+    async copyCrashLog(): Promise<string> {
+      const json = JSON.stringify(createExport(), null, 2);
+      if (typeof navigator !== 'undefined') {
+        await navigator.clipboard?.writeText(json);
+      }
+      return json;
+    },
+    clear() {
+      breadcrumbs.length = 0;
+      storage?.removeItem(storageKey);
+    },
+  };
+}
+
+export type CrashBreadcrumbStore = ReturnType<
+  typeof createCrashBreadcrumbStore
+>;

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -5,6 +5,7 @@ import type {
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { RendererInfoSnapshot } from './rendererCapabilities';
+import type { SoftwareRendererPolicyState } from './softwareRendererMode';
 
 export type PhaseName =
   | 'inputMovementCamera'
@@ -59,6 +60,9 @@ export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   rendererSize: RendererSizeSnapshot;
   quality: QualityStateSnapshot;
   features: FeatureStateSnapshot;
+  softwareRendererPolicy: SoftwareRendererPolicyState;
+  dangerousRenderer: boolean;
+  softwareSafeMode: boolean;
   lastFailoverReason: string | null;
 }
 
@@ -68,6 +72,7 @@ export interface PerformanceDiagnosticsApi {
   getRendererInfo(): RendererInfoSnapshot;
   getQualityState(): QualityStateSnapshot;
   getFeatureState(): FeatureStateSnapshot;
+  getSoftwareRendererPolicy(): SoftwareRendererPolicyState;
   getLastFailoverReason(): string | null;
 }
 
@@ -76,6 +81,7 @@ interface PerformanceDiagnosticsOptions {
   getRendererSize: () => RendererSizeSnapshot;
   getQualityState: () => QualityStateSnapshot;
   getFeatureState: () => FeatureStateSnapshot;
+  getSoftwareRendererPolicy: () => SoftwareRendererPolicyState;
   getLastFailoverReason: () => string | null;
   maxSamples?: number;
 }
@@ -128,6 +134,7 @@ export function createPerformanceDiagnostics({
   getRendererSize,
   getQualityState,
   getFeatureState,
+  getSoftwareRendererPolicy,
   getLastFailoverReason,
   maxSamples = 180,
 }: PerformanceDiagnosticsOptions) {
@@ -153,6 +160,10 @@ export function createPerformanceDiagnostics({
         rendererSize: getRendererSize(),
         quality: diagnosticsMethods.getQualityState(),
         features: diagnosticsMethods.getFeatureState(),
+        softwareRendererPolicy: diagnosticsMethods.getSoftwareRendererPolicy(),
+        dangerousRenderer: rendererInfo.isDangerousSoftwareRenderer,
+        softwareSafeMode:
+          diagnosticsMethods.getSoftwareRendererPolicy().softwareSafeMode,
         lastFailoverReason: diagnosticsMethods.getLastFailoverReason(),
       };
     },
@@ -185,6 +196,9 @@ export function createPerformanceDiagnostics({
     },
     getFeatureState() {
       return getFeatureState();
+    },
+    getSoftwareRendererPolicy() {
+      return getSoftwareRendererPolicy();
     },
     getLastFailoverReason() {
       return getLastFailoverReason();

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -28,11 +28,13 @@ export function clampDevicePixelRatio(
 export function resolveResizedBasePixelRatio(
   devicePixelRatio: number,
   maxPolicyCap: number,
-  adaptivePixelRatioCap = Number.POSITIVE_INFINITY
+  adaptivePixelRatioCap = Number.POSITIVE_INFINITY,
+  floor = 0.75
 ): number {
   const resizedPixelRatio = clampDevicePixelRatio(
     devicePixelRatio,
-    maxPolicyCap
+    maxPolicyCap,
+    floor
   );
   const safeAdaptiveCap =
     Number.isFinite(adaptivePixelRatioCap) && adaptivePixelRatioCap > 0
@@ -42,9 +44,22 @@ export function resolveResizedBasePixelRatio(
 }
 
 export function resolveInitialQualityPolicy(
-  rendererInfo: Pick<RendererInfoSnapshot, 'isSoftwareRenderer'>,
+  rendererInfo: Pick<RendererInfoSnapshot, 'isSoftwareRenderer'> &
+    Partial<Pick<RendererInfoSnapshot, 'isDangerousSoftwareRenderer'>>,
   devicePixelRatio: number
 ): QualityPolicyState {
+  if (rendererInfo.isDangerousSoftwareRenderer) {
+    return {
+      initialLevel: 'performance',
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.4, 0.35),
+      mirrorEnabled: false,
+      mirrorTargetSize: 128,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 250,
+      reason: 'dangerous software renderer starts in ultra-low safe mode',
+    };
+  }
+
   if (rendererInfo.isSoftwareRenderer) {
     return {
       initialLevel: 'performance',
@@ -70,7 +85,8 @@ export function resolveInitialQualityPolicy(
 
 export function getQualityFeaturePolicy(
   level: GraphicsQualityLevel,
-  isSoftwareRenderer = false
+  isSoftwareRenderer = false,
+  isDangerousSoftwareRenderer = false
 ): Pick<
   QualityPolicyState,
   | 'mirrorEnabled'
@@ -78,6 +94,15 @@ export function getQualityFeaturePolicy(
   | 'mirrorUpdateRateFps'
   | 'ambientUpdateIntervalMs'
 > {
+  if (isDangerousSoftwareRenderer) {
+    return {
+      mirrorEnabled: false,
+      mirrorTargetSize: 128,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 250,
+    };
+  }
+
   if (isSoftwareRenderer || level === 'performance') {
     return {
       mirrorEnabled: false,

--- a/src/scene/performance/rendererCapabilities.ts
+++ b/src/scene/performance/rendererCapabilities.ts
@@ -1,6 +1,10 @@
 import type { WebGLRenderer } from 'three';
 
-export type RendererRiskLevel = 'normal' | 'software' | 'unknown';
+export type RendererRiskLevel =
+  | 'normal'
+  | 'software'
+  | 'dangerous-software'
+  | 'unknown';
 
 export interface RendererInfoSnapshot {
   vendor: string | null;
@@ -8,6 +12,7 @@ export interface RendererInfoSnapshot {
   unmaskedVendor: string | null;
   unmaskedRenderer: string | null;
   isSoftwareRenderer: boolean;
+  isDangerousSoftwareRenderer: boolean;
   riskLevel: RendererRiskLevel;
   reason: string;
 }
@@ -20,6 +25,17 @@ const SOFTWARE_RENDERER_PATTERNS = [
   /mesa offscreen/i,
   /warp/i,
   /microsoft basic render/i,
+  /angle.*(swiftshader|software|warp)/i,
+] as const;
+
+const DANGEROUS_SOFTWARE_RENDERER_PATTERNS = [
+  /microsoft basic render/i,
+  /swiftshader/i,
+  /\bwarp\b/i,
+  /llvmpipe/i,
+  /softpipe/i,
+  /mesa offscreen/i,
+  /software rasterizer/i,
   /angle.*(swiftshader|software|warp)/i,
 ] as const;
 
@@ -36,9 +52,12 @@ export function classifyRendererInfo(input: {
   const haystack = [vendor, renderer, unmaskedVendor, unmaskedRenderer]
     .filter((value): value is string => typeof value === 'string')
     .join(' ');
-  const matchedPattern = SOFTWARE_RENDERER_PATTERNS.find((pattern) =>
-    pattern.test(haystack)
+  const matchedDangerousPattern = DANGEROUS_SOFTWARE_RENDERER_PATTERNS.find(
+    (pattern) => pattern.test(haystack)
   );
+  const matchedPattern =
+    matchedDangerousPattern ??
+    SOFTWARE_RENDERER_PATTERNS.find((pattern) => pattern.test(haystack));
 
   if (matchedPattern) {
     return {
@@ -47,7 +66,11 @@ export function classifyRendererInfo(input: {
       unmaskedVendor,
       unmaskedRenderer,
       isSoftwareRenderer: true,
-      riskLevel: 'software',
+      isDangerousSoftwareRenderer: matchedDangerousPattern !== undefined,
+      riskLevel:
+        matchedDangerousPattern !== undefined
+          ? 'dangerous-software'
+          : 'software',
       reason: `matched ${matchedPattern.source}`,
     };
   }
@@ -58,6 +81,7 @@ export function classifyRendererInfo(input: {
     unmaskedVendor,
     unmaskedRenderer,
     isSoftwareRenderer: false,
+    isDangerousSoftwareRenderer: false,
     riskLevel: haystack.length > 0 ? 'normal' : 'unknown',
     reason:
       haystack.length > 0

--- a/src/scene/performance/softwareRendererMode.ts
+++ b/src/scene/performance/softwareRendererMode.ts
@@ -1,0 +1,102 @@
+import type { RendererInfoSnapshot } from './rendererCapabilities';
+
+export const SOFTWARE_RENDERER_MODE_PARAM = 'softwareRendererMode';
+export const SOFTWARE_RENDERER_SAFE_MODE = 'safe';
+export const SOFTWARE_RENDERER_CONTINUOUS_MODE = 'continuous';
+export const FORCE_CONTINUOUS_RENDERING_PARAM = 'forceContinuousRendering';
+export const FORCE_CONTINUOUS_RENDERING_VALUE = '1';
+export const SOFTWARE_SAFE_RENDER_FPS = 12;
+
+export type SoftwareRendererMode =
+  | typeof SOFTWARE_RENDERER_SAFE_MODE
+  | typeof SOFTWARE_RENDERER_CONTINUOUS_MODE;
+
+export interface SoftwareRendererPolicyState {
+  dangerousRenderer: boolean;
+  softwareSafeMode: boolean;
+  continuousRendering: boolean;
+  renderCadenceFps: number | null;
+  pixelRatioCap: number | null;
+  reason: string;
+}
+
+const normalizeParam = (value: string | null | undefined): string | null => {
+  const normalized = value?.trim().toLowerCase();
+  return normalized ? normalized : null;
+};
+
+export function resolveSoftwareRendererMode(
+  search: string | URLSearchParams = typeof window === 'undefined'
+    ? ''
+    : window.location.search
+): SoftwareRendererMode | null {
+  const params =
+    search instanceof URLSearchParams
+      ? search
+      : new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const explicitMode = normalizeParam(params.get(SOFTWARE_RENDERER_MODE_PARAM));
+  if (explicitMode === SOFTWARE_RENDERER_CONTINUOUS_MODE) {
+    return SOFTWARE_RENDERER_CONTINUOUS_MODE;
+  }
+  if (explicitMode === SOFTWARE_RENDERER_SAFE_MODE) {
+    return SOFTWARE_RENDERER_SAFE_MODE;
+  }
+  if (
+    normalizeParam(params.get(FORCE_CONTINUOUS_RENDERING_PARAM)) ===
+    FORCE_CONTINUOUS_RENDERING_VALUE
+  ) {
+    return SOFTWARE_RENDERER_CONTINUOUS_MODE;
+  }
+  return null;
+}
+
+export function resolveSoftwareRendererPolicy(
+  rendererInfo: Pick<
+    RendererInfoSnapshot,
+    'isSoftwareRenderer' | 'isDangerousSoftwareRenderer' | 'reason'
+  >,
+  search?: string | URLSearchParams
+): SoftwareRendererPolicyState {
+  const requestedMode = resolveSoftwareRendererMode(search);
+  const dangerousRenderer = rendererInfo.isDangerousSoftwareRenderer === true;
+  if (!dangerousRenderer) {
+    return {
+      dangerousRenderer: false,
+      softwareSafeMode: false,
+      continuousRendering: true,
+      renderCadenceFps: null,
+      pixelRatioCap: null,
+      reason: rendererInfo.isSoftwareRenderer
+        ? 'software renderer is not on the dangerous renderer list'
+        : 'hardware renderer path',
+    };
+  }
+
+  const continuousRendering =
+    requestedMode === SOFTWARE_RENDERER_CONTINUOUS_MODE;
+  return {
+    dangerousRenderer,
+    softwareSafeMode: !continuousRendering,
+    continuousRendering,
+    renderCadenceFps: continuousRendering ? null : SOFTWARE_SAFE_RENDER_FPS,
+    pixelRatioCap: continuousRendering ? null : 0.4,
+    reason: continuousRendering
+      ? 'explicit software renderer continuous rendering override'
+      : `dangerous software renderer guardrails active: ${rendererInfo.reason}`,
+  };
+}
+
+export function shouldRenderSoftwareSafeFrame(input: {
+  nowMs: number;
+  lastRenderMs: number | null;
+  cadenceFps: number | null;
+  dirty: boolean;
+}): boolean {
+  if (!input.cadenceFps || input.cadenceFps <= 0) {
+    return true;
+  }
+  if (input.lastRenderMs === null || input.dirty) {
+    return true;
+  }
+  return input.nowMs - input.lastRenderMs >= 1000 / input.cadenceFps;
+}

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -538,6 +538,7 @@ const FALLBACK_REASONS_WITH_DEBUG_BYPASS = new Set<FallbackReason>([
   'data-saver',
   'immersive-init-error',
   'console-error',
+  'webgl-context-lost',
 ]);
 
 const fallbackRecoveryCleanup = new WeakMap<Document, () => void>();

--- a/src/tests/crashBreadcrumbs.test.ts
+++ b/src/tests/crashBreadcrumbs.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCrashBreadcrumbStore } from '../scene/performance/crashBreadcrumbs';
+import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
+import { resolveSoftwareRendererPolicy } from '../scene/performance/softwareRendererMode';
+
+function createStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}
+
+describe('crash breadcrumb store', () => {
+  it('keeps a bounded serializable ring buffer with renderer info', () => {
+    const storage = createStorage();
+    const renderer = classifyRendererInfo({
+      unmaskedRenderer: 'ANGLE (Microsoft, Microsoft Basic Render Driver)',
+    });
+    const softwareRendererPolicy = resolveSoftwareRendererPolicy(renderer);
+    const store = createCrashBreadcrumbStore({
+      storage,
+      maxEntries: 3,
+      getLocationHref: () => 'https://example.test/?mode=immersive',
+      getMemory: () => ({ usedJSHeapSize: 1234 }),
+    });
+
+    store.setRendererInfo(renderer);
+    store.setSoftwareRendererPolicy(softwareRendererPolicy);
+    store.setLastUserVisibleMessage('software renderer safe mode');
+
+    for (let index = 0; index < 5; index += 1) {
+      store.record({
+        kind: 'performance-snapshot',
+        message: `snapshot ${index}`,
+      });
+    }
+
+    const exported = store.exportCrashLog();
+    expect(exported.renderer?.isDangerousSoftwareRenderer).toBe(true);
+    expect(exported.softwareRendererPolicy?.softwareSafeMode).toBe(true);
+    expect(exported.lastUserVisibleMessage).toBe('software renderer safe mode');
+    expect(exported.breadcrumbs).toHaveLength(3);
+    expect(exported.breadcrumbs[0]?.message).toBe('snapshot 2');
+    expect(exported.breadcrumbs[2]?.memory?.usedJSHeapSize).toBe(1234);
+    expect(() => JSON.parse(store.exportCrashLogJson())).not.toThrow();
+    expect(storage.setItem).toHaveBeenCalled();
+  });
+});

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -11,6 +11,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },
@@ -60,6 +61,14 @@ describe('performance diagnostics', () => {
         mirrorUpdateRateFps: 8,
         mirrorRenderCount: 3,
       }),
+      getSoftwareRendererPolicy: () => ({
+        dangerousRenderer: false,
+        softwareSafeMode: false,
+        continuousRendering: true,
+        renderCadenceFps: null,
+        pixelRatioCap: null,
+        reason: 'hardware renderer path',
+      }),
       getLastFailoverReason: () => null,
     });
 
@@ -78,6 +87,9 @@ describe('performance diagnostics', () => {
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
+    expect(snapshot.dangerousRenderer).toBe(false);
+    expect(snapshot.softwareSafeMode).toBe(false);
+    expect(snapshot.softwareRendererPolicy.continuousRendering).toBe(true);
     expect(snapshot.quality.selectionSource).toBe('adaptive');
     expect(snapshot.quality.adaptiveRecoveryCount).toBe(1);
     expect(snapshot.quality.adaptivePolicy).toMatchObject({
@@ -98,6 +110,7 @@ describe('performance diagnostics', () => {
         unmaskedVendor: 'NVIDIA',
         unmaskedRenderer: 'ANGLE NVIDIA',
         isSoftwareRenderer: false,
+        isDangerousSoftwareRenderer: false,
         riskLevel: 'normal',
         reason: 'test',
       },
@@ -124,6 +137,14 @@ describe('performance diagnostics', () => {
         mirrorRenderTargetSize: 192,
         mirrorUpdateRateFps: 0,
         mirrorRenderCount: 0,
+      }),
+      getSoftwareRendererPolicy: () => ({
+        dangerousRenderer: false,
+        softwareSafeMode: false,
+        continuousRendering: true,
+        renderCadenceFps: null,
+        pixelRatioCap: null,
+        reason: 'hardware renderer path',
       }),
       getLastFailoverReason: () => null,
     });

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -12,6 +12,10 @@ import {
   resolveResizedBasePixelRatio,
 } from '../scene/performance/qualityPolicy';
 import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
+import {
+  resolveSoftwareRendererPolicy,
+  shouldRenderSoftwareSafeFrame,
+} from '../scene/performance/softwareRendererMode';
 
 function createPolicyHarness({
   level = 'balanced',
@@ -300,5 +304,89 @@ describe('immersive performance optimization policy', () => {
     expect(harness.controller.update(1.1)).toBeNull();
     expect(harness.controller.isExhausted()).toBe(true);
     expect(harness.onAction).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('dangerous software renderer guardrails', () => {
+  it('classifies Basic Render Driver, SwiftShader, WARP, and llvmpipe as dangerous', () => {
+    const renderers = [
+      'ANGLE (Microsoft, Microsoft Basic Render Driver Direct3D11 vs_5_0 ps_5_0)',
+      'Google SwiftShader',
+      'ANGLE (Microsoft, WARP D3D11)',
+      'llvmpipe (LLVM 17.0.6, 256 bits)',
+    ];
+
+    for (const unmaskedRenderer of renderers) {
+      const info = classifyRendererInfo({ unmaskedRenderer });
+      expect(info.isSoftwareRenderer).toBe(true);
+      expect(info.isDangerousSoftwareRenderer).toBe(true);
+      expect(info.riskLevel).toBe('dangerous-software');
+    }
+
+    const nvidia = classifyRendererInfo({
+      unmaskedRenderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 4090, D3D11)',
+    });
+    expect(nvidia.isSoftwareRenderer).toBe(false);
+    expect(nvidia.isDangerousSoftwareRenderer).toBe(false);
+  });
+
+  it('uses ultra-low quality policy for dangerous software renderers', () => {
+    const policy = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: true, isDangerousSoftwareRenderer: true },
+      2
+    );
+    expect(policy.initialLevel).toBe('performance');
+    expect(policy.basePixelRatioCap).toBe(0.4);
+    expect(policy.mirrorEnabled).toBe(false);
+    expect(policy.mirrorTargetSize).toBe(128);
+
+    expect(getQualityFeaturePolicy('cinematic', true, true)).toMatchObject({
+      mirrorEnabled: false,
+      mirrorUpdateRateFps: 0,
+      mirrorTargetSize: 128,
+    });
+  });
+
+  it('caps render cadence unless continuous rendering is explicitly requested', () => {
+    const rendererInfo = classifyRendererInfo({
+      unmaskedRenderer: 'ANGLE (Microsoft, Microsoft Basic Render Driver)',
+    });
+    const safe = resolveSoftwareRendererPolicy(rendererInfo, '?mode=immersive');
+    expect(safe.softwareSafeMode).toBe(true);
+    expect(safe.renderCadenceFps).toBe(12);
+    expect(safe.pixelRatioCap).toBe(0.4);
+
+    const continuous = resolveSoftwareRendererPolicy(
+      rendererInfo,
+      '?mode=immersive&softwareRendererMode=continuous'
+    );
+    expect(continuous.softwareSafeMode).toBe(false);
+    expect(continuous.continuousRendering).toBe(true);
+    expect(continuous.renderCadenceFps).toBeNull();
+
+    expect(
+      shouldRenderSoftwareSafeFrame({
+        nowMs: 100,
+        lastRenderMs: null,
+        cadenceFps: safe.renderCadenceFps,
+        dirty: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldRenderSoftwareSafeFrame({
+        nowMs: 110,
+        lastRenderMs: 100,
+        cadenceFps: safe.renderCadenceFps,
+        dirty: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldRenderSoftwareSafeFrame({
+        nowMs: 110,
+        lastRenderMs: 100,
+        cadenceFps: safe.renderCadenceFps,
+        dirty: true,
+      })
+    ).toBe(true);
   });
 });

--- a/src/types/failover.ts
+++ b/src/types/failover.ts
@@ -7,4 +7,5 @@ export type FallbackReason =
   | 'automated-client'
   | 'low-end-device'
   | 'console-error'
-  | 'data-saver';
+  | 'data-saver'
+  | 'webgl-context-lost';

--- a/src/ui/accessibility/modeAnnouncer.ts
+++ b/src/ui/accessibility/modeAnnouncer.ts
@@ -45,6 +45,8 @@ const DEFAULT_FALLBACK_MESSAGES: Record<FallbackReason, string> = {
     'We detected a runtime error. Presenting the resilient text tour while the scene resets.',
   'data-saver':
     'Your browser requested a data-saver experience, so the lightweight text tour is active.',
+  'webgl-context-lost':
+    'WebGL context was lost. Showing the text tour with a link to try immersive again.',
 };
 
 const mergeFallbackMessages = (

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1927,3 +1927,50 @@ html[data-hudLayout='mobile'] .audio-subtitles {
 .poi-tooltip-overlay[data-state='recommended'] {
   border-color: rgba(255, 207, 129, 0.42);
 }
+
+.software-renderer-warning {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 40;
+  max-width: min(34rem, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid rgba(255, 198, 92, 0.72);
+  border-radius: 1rem;
+  background: rgba(13, 18, 28, 0.92);
+  color: #fff4d6;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(16px);
+}
+
+.software-renderer-warning p {
+  margin: 0.45rem 0 0.75rem;
+  line-height: 1.45;
+}
+
+.software-renderer-warning__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.software-renderer-warning button,
+.software-renderer-warning a {
+  border: 1px solid rgba(255, 244, 214, 0.45);
+  border-radius: 999px;
+  padding: 0.45rem 0.7rem;
+  background: rgba(255, 244, 214, 0.1);
+  color: inherit;
+  font: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.software-renderer-warning button:hover,
+.software-renderer-warning a:hover,
+.software-renderer-warning button:focus-visible,
+.software-renderer-warning a:focus-visible {
+  background: rgba(255, 244, 214, 0.18);
+  outline: 2px solid rgba(255, 244, 214, 0.45);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
### Motivation
- Software/CPU WebGL paths (Microsoft Basic Render Driver, SwiftShader, WARP, llvmpipe, etc.) were observed to crash browser tabs under continuous immersive rendering even after the existing low-cost fallbacks were applied.
- The goal is to make immersive mode safer and more diagnosable on those dangerous renderers while preserving debug/preview overrides and recoverable text fallbacks.

### Description
- Classify dangerous software renderers and propagate that into policy: added detection and a `dangerous-software` risk level in `src/scene/performance/rendererCapabilities.ts` and a `softwareRendererMode` policy in `src/scene/performance/softwareRendererMode.ts` with `safe` / `continuous` and `forceContinuousRendering` support.
- Implement software-safe immersive guardrails and a capped render cadence: integrate policy into startup and adaptive paths in `src/main.ts`, reduce DPR for dangerous renderers, disable heavy features (bloom/composer/mirror), and conditionally throttle continuous frames using `shouldRenderSoftwareSafeFrame`.
- Add bounded crash breadcrumbs and export helpers: new `src/scene/performance/crashBreadcrumbs.ts` persists a small ring buffer of recent performance snapshots, renderer info, policy state, context-loss/fatal events, and exposes `exportCrashLog()`, `exportCrashLogJson()` and `copyCrashLog()` on `window.portfolio.performance`.
- Surface a visible software-renderer warning UI and recoverable context-loss flow: add a warning overlay with actions (continue safe immersive, enable continuous, use text mode) and record breadcrumbs on user choice; listen for `webglcontextlost` to persist a breadcrumb and trigger a recoverable text fallback.
- Extend diagnostics and policies: include software-safe fields in `createPerformanceDiagnostics` and wire the software policy into `qualityPolicy` and adaptive warmup/cooldown decisions (ultra-low DPR and relaxed recovery for dangerous renderers).
- Tests and docs: add unit tests for classification/policy and crash breadcrumbs, add a Playwright mock for Basic Render Driver to verify the warning and crash-log export, and add outage docs under `outages/2026-05-30-danielsmith-software-renderer-crash-hardening.*`.

### Testing
- Ran formatting and linting: `npm run format:write` (success) and `npm run lint` (success).
- Ran typecheck: `npm run typecheck` reported pre-existing repository-wide TypeScript issues unrelated to these changes and did not block this PR.
- Unit tests: `npm run test:ci` passed overall and `npm run test:ci -- performanceOptimization performanceDiagnostics crashBreadcrumbs` ran the modified/added tests and all targeted tests passed.
- Playwright/End-to-end: initial `npm run test:e2e -- --grep

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1d82fbe8832faae66f2ccff57923)