### PR TITLE
Gracefully back off GitHub repo metrics

### DIFF
--- a/outages/2026-05-30-danielsmith-github-api-403-noise.json
+++ b/outages/2026-05-30-danielsmith-github-api-403-noise.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-05-30-danielsmith-github-api-403-noise",
+  "date": "2026-05-30",
+  "title": "GitHub API 403 noise during repo metrics fetches",
+  "symptomSlice": "Unauthenticated GitHub repo metrics fanned out across POIs and produced repeated 403 noise during performance validation.",
+  "rootCause": "The static browser app treated live GitHub metrics as best-effort but still attempted every repo on each page load after unauthenticated API failures or rate-limit responses.",
+  "fixSummary": "Repo metrics now use stale cached or static fallback values, enter bounded backoff after 403/404/429/network failures, suppress additional requests during backoff, and expose one grouped diagnostic path without failover coupling.",
+  "regressionTests": "Vitest covers 403 and 429 backoff, stale cached success reuse, persisted backoff suppression, and grouped warnings. Playwright mocks GitHub 403s and verifies immersive mode, fallback UI, diagnostics, and absence of performance failover.",
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"github|metrics|fallback|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-github-api-403-noise.md
+++ b/outages/2026-05-30-danielsmith-github-api-403-noise.md
@@ -1,0 +1,53 @@
+# GitHub API 403 noise during repo metrics fetches
+
+## Symptom
+
+Hardware-accelerated staging validation showed repeated browser console/network
+entries for unauthenticated GitHub repository API requests. The noisy fan-out
+covered portfolio repos such as `gabriel`, `token.place`, `flywheel`,
+`danielsmith.io`, `pr-reaper`, `gitshelves`, `wove`, `sigma`, and
+`f2clipboard`, making performance investigations harder to read.
+
+## Root cause
+
+Live POI metrics requested GitHub stars directly from the static browser app.
+Unauthenticated GitHub API calls can hit rate-limit, forbidden, unavailable, or
+private-repo paths, and the old refresh path attempted every public repo bucket
+on each page load even after a first failure proved the session was already
+blocked.
+
+## Fix summary
+
+- GitHub repo metrics now stay optional: failed live fetches leave static POI
+  fallback values or stale cached successes in place.
+- Successful responses are cached in browser storage and reused before any live
+  request, so stale stars can render while the network is unavailable.
+- 403, 404, 429, timeout, and network failures enter bounded backoff; subsequent
+  repo requests are suppressed during that window instead of fanning out.
+- Failures emit at most one grouped session warning and expose concise
+  diagnostics through `window.portfolio.github.getRepoMetricsDiagnostics()`.
+- Repo metric availability is not connected to performance health or text-mode
+  failover decisions.
+
+## Validation steps
+
+- Mock `https://api.github.com/repos/**` to return 403, load
+  `/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1`, and
+  confirm immersive mode stays active.
+- Confirm only the first GitHub request is attempted before backoff suppresses
+  the rest of the repo fan-out.
+- Confirm project/POI UI still renders with static fallback metric labels.
+- Inspect `window.portfolio.github.getRepoMetricsDiagnostics()` and verify the
+  source is `static-fallback`, the last status is `403`, request counts are
+  bounded, and a backoff expiration is present.
+- Reload during the backoff TTL and confirm live GitHub requests are skipped.
+
+## Validation commands
+
+- `npm run format:write`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:ci`
+- `npm run test:e2e -- --grep "github|metrics|fallback|immersive"`
+- `npm run docs:check`
+- `npm run smoke`

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_GITHUB_METRICS_URL =
+  '/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+
+const collectConsoleMessages = (
+  page: Page,
+  type: 'error' | 'warning'
+): string[] => {
+  const messages: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === type) {
+      messages.push(message.text());
+    }
+  });
+  return messages;
+};
+
+test.describe('GitHub repo metrics fallback', () => {
+  test('keeps immersive usable and quiet when unauthenticated API calls return 403', async ({
+    page,
+  }) => {
+    const consoleErrors = collectConsoleMessages(page, 'error');
+    const consoleWarnings = collectConsoleMessages(page, 'warning');
+    const failoverEvents: string[] = [];
+    let githubRequestCount = 0;
+
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+      window.addEventListener('performancefailover', (event) => {
+        const customEvent = event as CustomEvent<{ reason?: string }>;
+        (
+          window as Window & { __githubMetricsFailovers?: string[] }
+        ).__githubMetricsFailovers ??= [];
+        (
+          window as Window & { __githubMetricsFailovers: string[] }
+        ).__githubMetricsFailovers.push(
+          customEvent.detail?.reason ?? 'unknown'
+        );
+      });
+    });
+
+    await page.route('https://api.github.com/repos/**', async (route) => {
+      githubRequestCount += 1;
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'API rate limit exceeded' }),
+      });
+    });
+
+    await page.goto(IMMERSIVE_GITHUB_METRICS_URL, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+    await expect(page.locator('#app canvas')).toHaveCount(1);
+    await expect(page.locator('#control-overlay')).toBeVisible();
+    await expect(page.locator('.poi-tooltip-overlay')).toHaveCount(1);
+
+    const diagnostics = await page.evaluate(() =>
+      window.portfolio?.github?.getRepoMetricsDiagnostics()
+    );
+    failoverEvents.push(
+      ...(await page.evaluate(
+        () =>
+          (window as Window & { __githubMetricsFailovers?: string[] })
+            .__githubMetricsFailovers ?? []
+      ))
+    );
+
+    expect(githubRequestCount).toBe(1);
+    expect(failoverEvents).toEqual([]);
+    const githubResourceErrors = consoleErrors.filter(
+      (message) =>
+        message.includes('api.github.com') ||
+        message.includes('Failed to load resource')
+    );
+    const appConsoleErrors = consoleErrors.filter(
+      (message) => !githubResourceErrors.includes(message)
+    );
+    expect(appConsoleErrors).toEqual([]);
+    expect(githubResourceErrors.length).toBeLessThanOrEqual(1);
+    expect(
+      consoleWarnings.filter((message) =>
+        message.includes('GitHub repository metrics')
+      )
+    ).toHaveLength(1);
+    expect(diagnostics).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 403,
+      requestCount: 1,
+      suppressedRequestCount: expect.any(Number),
+      warnedThisSession: true,
+    });
+    expect(diagnostics?.suppressedRequestCount ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -313,7 +313,10 @@ import {
   writeModePreference,
 } from './systems/failover/modePreference';
 import { createPerformanceFailoverHandler } from './systems/failover/performanceFailover';
-import { createGitHubRepoStatsService } from './systems/github/repoStats';
+import {
+  createGitHubRepoStatsService,
+  type GitHubRepoStatsDiagnostics,
+} from './systems/github/repoStats';
 import {
   createAnalyticsGlowRhythm,
   type AnalyticsGlowRhythmHandle,
@@ -435,6 +438,9 @@ declare global {
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
+      github?: {
+        getRepoMetricsDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -1516,6 +1522,13 @@ function initializeImmersiveScene(
     poiWorldTooltip.setIdleState(idle);
   });
   const githubRepoStatsService = createGitHubRepoStatsService();
+  const githubPortfolioWindow = window as Window;
+  if (!githubPortfolioWindow.portfolio) {
+    githubPortfolioWindow.portfolio = {};
+  }
+  githubPortfolioWindow.portfolio.github = {
+    getRepoMetricsDiagnostics: () => githubRepoStatsService.getDiagnostics(),
+  };
   githubRepoMetrics = wireGitHubRepoMetrics({
     definitions: poiDefinitions,
     service: githubRepoStatsService,
@@ -4089,6 +4102,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
+    }
+    if (window.portfolio?.github) {
+      delete window.portfolio.github;
     }
     if (helpButton) {
       helpButton.textContent = buildHelpButtonText(helpLabelFallback);

--- a/src/scene/poi/githubMetrics.ts
+++ b/src/scene/poi/githubMetrics.ts
@@ -146,11 +146,9 @@ export function wireGitHubRepoMetrics({
   });
 
   const refreshAll = async () => {
-    await Promise.all(
-      Array.from(repoMap.values()).map((bucket) =>
-        service.requestStats(bucket.identifier)
-      )
-    );
+    for (const bucket of repoMap.values()) {
+      await service.requestStats(bucket.identifier);
+    }
   };
 
   const dispose = () => {

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -11,6 +11,22 @@ export interface GitHubRepoStats {
   pushedAt: string | null;
 }
 
+export type GitHubRepoStatsSource = 'live' | 'cached' | 'static-fallback';
+export type GitHubRepoStatsErrorStatus =
+  | number
+  | 'network'
+  | 'timeout'
+  | 'storage';
+
+export interface GitHubRepoStatsDiagnostics {
+  source: GitHubRepoStatsSource;
+  lastErrorStatus: GitHubRepoStatsErrorStatus | null;
+  requestCount: number;
+  suppressedRequestCount: number;
+  backoffExpiresAt: number | null;
+  warnedThisSession: boolean;
+}
+
 export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
 
 export interface GitHubRepoStatsService {
@@ -22,12 +38,35 @@ export interface GitHubRepoStatsService {
     identifier: GitHubRepoIdentifier,
     listener: GitHubRepoStatsListener
   ): () => void;
+  getDiagnostics(): GitHubRepoStatsDiagnostics;
 }
 
 const DEFAULT_HEADERS = {
   Accept: 'application/vnd.github+json',
-  'User-Agent': 'danielsmith.io-github-metrics',
 } as const;
+
+const SUCCESS_CACHE_KEY_PREFIX = 'danielsmith.io:github-repo-stats:';
+const BACKOFF_CACHE_KEY = 'danielsmith.io:github-repo-stats:backoff';
+const WARNING_SESSION_KEY = 'danielsmith.io:github-repo-stats:warned';
+const DEFAULT_BACKOFF_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_NETWORK_BACKOFF_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_FETCH_TIMEOUT_MS = 4500;
+
+interface StoredStatsRecord {
+  stats: GitHubRepoStats;
+  fetchedAt: number;
+}
+
+interface StoredBackoffRecord {
+  expiresAt: number;
+  status: GitHubRepoStatsErrorStatus;
+}
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
 
 const sanitizeNumber = (value: unknown): number => {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -42,6 +81,70 @@ const sanitizeNumber = (value: unknown): number => {
 
 const makeCacheKey = ({ owner, repo }: GitHubRepoIdentifier): string =>
   `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+
+const makeStorageKey = (identifier: GitHubRepoIdentifier): string =>
+  `${SUCCESS_CACHE_KEY_PREFIX}${makeCacheKey(identifier)}`;
+
+const readStorageJson = <T>(
+  storage: StorageLike | undefined,
+  key: string
+): T | null => {
+  if (!storage) {
+    return null;
+  }
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
+const writeStorageJson = (
+  storage: StorageLike | undefined,
+  key: string,
+  value: unknown
+): void => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Storage may be unavailable in private browsing or test shims.
+  }
+};
+
+const removeStorageItem = (
+  storage: StorageLike | undefined,
+  key: string
+): void => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Ignore storage failures; live metrics are always optional.
+  }
+};
+
+const isGitHubRepoStats = (value: unknown): value is GitHubRepoStats => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as GitHubRepoStats;
+  return (
+    typeof candidate.stars === 'number' &&
+    typeof candidate.watchers === 'number' &&
+    typeof candidate.forks === 'number' &&
+    typeof candidate.openIssues === 'number' &&
+    (typeof candidate.pushedAt === 'string' || candidate.pushedAt === null)
+  );
+};
 
 const shouldAttemptLiveFetch = (() => {
   const globalScope = globalThis as Partial<
@@ -65,8 +168,39 @@ const shouldAttemptLiveFetch = (() => {
   return false;
 })();
 
+const getDefaultStorage = (
+  kind: 'localStorage' | 'sessionStorage'
+): StorageLike | undefined => {
+  try {
+    return globalThis[kind] as StorageLike | undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const createTimeoutSignal = (
+  timeoutMs: number
+): { signal?: AbortSignal; dispose(): void } => {
+  if (typeof AbortController === 'undefined') {
+    return { dispose: () => undefined };
+  }
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    dispose: () => globalThis.clearTimeout(timeout),
+  };
+};
+
 export interface GitHubRepoStatsServiceOptions {
   allowLiveFetch?: boolean;
+  backoffTtlMs?: number;
+  networkBackoffTtlMs?: number;
+  fetchTimeoutMs?: number;
+  now?: () => number;
+  localStorage?: StorageLike;
+  sessionStorage?: StorageLike;
+  warn?: (message: string, diagnostics: GitHubRepoStatsDiagnostics) => void;
 }
 
 export function createGitHubRepoStatsService(
@@ -74,9 +208,93 @@ export function createGitHubRepoStatsService(
   options: GitHubRepoStatsServiceOptions = {}
 ): GitHubRepoStatsService {
   const allowLiveFetch = options.allowLiveFetch ?? shouldAttemptLiveFetch;
+  const backoffTtlMs = options.backoffTtlMs ?? DEFAULT_BACKOFF_TTL_MS;
+  const networkBackoffTtlMs =
+    options.networkBackoffTtlMs ?? DEFAULT_NETWORK_BACKOFF_TTL_MS;
+  const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const now = options.now ?? (() => Date.now());
+  const localStorage =
+    options.localStorage ?? getDefaultStorage('localStorage');
+  const sessionStorage =
+    options.sessionStorage ?? getDefaultStorage('sessionStorage');
+  const warn =
+    options.warn ??
+    ((message: string, diagnostics: GitHubRepoStatsDiagnostics) => {
+      console.warn(message, diagnostics);
+    });
   const cache = new Map<string, GitHubRepoStats>();
   const listeners = new Map<string, Set<GitHubRepoStatsListener>>();
   const inFlight = new Map<string, Promise<GitHubRepoStats | null>>();
+  const diagnostics: GitHubRepoStatsDiagnostics = {
+    source: 'static-fallback',
+    lastErrorStatus: null,
+    requestCount: 0,
+    suppressedRequestCount: 0,
+    backoffExpiresAt: null,
+    warnedThisSession: sessionStorage?.getItem(WARNING_SESSION_KEY) === '1',
+  };
+
+  const readBackoff = (): StoredBackoffRecord | null => {
+    const record = readStorageJson<StoredBackoffRecord>(
+      localStorage,
+      BACKOFF_CACHE_KEY
+    );
+    if (!record || typeof record.expiresAt !== 'number') {
+      return null;
+    }
+    if (record.expiresAt <= now()) {
+      removeStorageItem(localStorage, BACKOFF_CACHE_KEY);
+      diagnostics.backoffExpiresAt = null;
+      return null;
+    }
+    diagnostics.backoffExpiresAt = record.expiresAt;
+    diagnostics.lastErrorStatus = record.status;
+    return record;
+  };
+
+  readBackoff();
+
+  const warnOnce = () => {
+    if (diagnostics.warnedThisSession) {
+      return;
+    }
+    diagnostics.warnedThisSession = true;
+    try {
+      sessionStorage?.setItem(WARNING_SESSION_KEY, '1');
+    } catch {
+      // Optional session marker only.
+    }
+    warn(
+      'GitHub repository metrics are unavailable; using cached or static values.',
+      {
+        ...diagnostics,
+      }
+    );
+  };
+
+  const enterBackoff = (status: GitHubRepoStatsErrorStatus, ttlMs: number) => {
+    const expiresAt = now() + ttlMs;
+    diagnostics.lastErrorStatus = status;
+    diagnostics.backoffExpiresAt = expiresAt;
+    writeStorageJson(localStorage, BACKOFF_CACHE_KEY, { expiresAt, status });
+    warnOnce();
+  };
+
+  const loadStoredStats = (
+    identifier: GitHubRepoIdentifier
+  ): GitHubRepoStats | null => {
+    const record = readStorageJson<StoredStatsRecord>(
+      localStorage,
+      makeStorageKey(identifier)
+    );
+    if (!record || !isGitHubRepoStats(record.stats)) {
+      return null;
+    }
+    const key = makeCacheKey(identifier);
+    cache.set(key, record.stats);
+    diagnostics.source = 'cached';
+    return record.stats;
+  };
 
   const notify = (key: string, stats: GitHubRepoStats) => {
     const repoListeners = listeners.get(key);
@@ -96,7 +314,12 @@ export function createGitHubRepoStatsService(
     identifier: GitHubRepoIdentifier
   ): GitHubRepoStats | null => {
     const key = makeCacheKey(identifier);
-    return cache.get(key) ?? null;
+    const memoryCached = cache.get(key);
+    if (memoryCached) {
+      diagnostics.source = 'cached';
+      return memoryCached;
+    }
+    return loadStoredStats(identifier);
   };
 
   const subscribe = (
@@ -111,7 +334,7 @@ export function createGitHubRepoStatsService(
     }
     repoListeners.add(listener);
 
-    const cached = cache.get(key);
+    const cached = getCachedStats(identifier);
     if (cached) {
       queueMicrotask(() => listener(cached));
     }
@@ -132,7 +355,7 @@ export function createGitHubRepoStatsService(
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null> => {
     const key = makeCacheKey(identifier);
-    const cached = cache.get(key);
+    const cached = getCachedStats(identifier);
     if (cached) {
       return cached;
     }
@@ -140,19 +363,34 @@ export function createGitHubRepoStatsService(
     if (existing) {
       return existing;
     }
-    if (!fetchImpl || !allowLiveFetch) {
+    if (!fetchImpl || !allowLiveFetch || readBackoff()) {
+      diagnostics.suppressedRequestCount += 1;
+      diagnostics.source = 'static-fallback';
       return null;
     }
 
     const promise = (async () => {
+      const timeout = createTimeoutSignal(fetchTimeoutMs);
+      diagnostics.requestCount += 1;
       try {
         const response = await fetchImpl(
           `https://api.github.com/repos/${identifier.owner}/${identifier.repo}`,
-          { headers: DEFAULT_HEADERS }
+          { headers: DEFAULT_HEADERS, signal: timeout.signal }
         );
         if (!response.ok) {
+          const status = response.status || 'network';
+          if (status === 403 || status === 404 || status === 429) {
+            enterBackoff(status, backoffTtlMs);
+          } else {
+            diagnostics.lastErrorStatus = status;
+            warnOnce();
+          }
+          diagnostics.source = 'static-fallback';
           return null;
         }
+        removeStorageItem(localStorage, BACKOFF_CACHE_KEY);
+        diagnostics.backoffExpiresAt = null;
+        diagnostics.lastErrorStatus = null;
         const data = (await response.json()) as Record<string, unknown>;
         const stats: GitHubRepoStats = {
           stars: sanitizeNumber(data.stargazers_count),
@@ -164,11 +402,23 @@ export function createGitHubRepoStatsService(
           pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
         };
         cache.set(key, stats);
+        writeStorageJson(localStorage, makeStorageKey(identifier), {
+          stats,
+          fetchedAt: now(),
+        });
+        diagnostics.source = 'live';
         notify(key, stats);
         return stats;
-      } catch {
+      } catch (error) {
+        const status =
+          error instanceof DOMException && error.name === 'AbortError'
+            ? 'timeout'
+            : 'network';
+        enterBackoff(status, networkBackoffTtlMs);
+        diagnostics.source = 'static-fallback';
         return null;
       } finally {
+        timeout.dispose();
         inFlight.delete(key);
       }
     })();
@@ -177,9 +427,15 @@ export function createGitHubRepoStatsService(
     return promise;
   };
 
+  const getDiagnostics = (): GitHubRepoStatsDiagnostics => ({
+    ...diagnostics,
+    backoffExpiresAt: readBackoff()?.expiresAt ?? diagnostics.backoffExpiresAt,
+  });
+
   return {
     getCachedStats,
     requestStats,
     subscribe,
+    getDiagnostics,
   };
 }

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -5,6 +5,7 @@ import type { PoiDefinition } from '../scene/poi/types';
 import type {
   GitHubRepoIdentifier,
   GitHubRepoStats,
+  GitHubRepoStatsDiagnostics,
   GitHubRepoStatsListener,
   GitHubRepoStatsService,
 } from '../systems/github/repoStats';
@@ -28,6 +29,17 @@ class MockRepoStatsService implements GitHubRepoStatsService {
     const key = this.key(identifier);
     this.requested.push(key);
     return Promise.resolve(this.cache.get(key) ?? null);
+  }
+
+  getDiagnostics(): GitHubRepoStatsDiagnostics {
+    return {
+      source: 'static-fallback',
+      lastErrorStatus: null,
+      requestCount: this.requested.length,
+      suppressedRequestCount: 0,
+      backoffExpiresAt: null,
+      warnedThisSession: false,
+    };
   }
 
   subscribe(

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -2,6 +2,39 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createGitHubRepoStatsService } from '../systems/github/repoStats';
 
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+const createServiceStorage = () => ({
+  localStorage: new MemoryStorage(),
+  sessionStorage: new MemoryStorage(),
+});
+
 describe('GitHub repo stats service', () => {
   it('fetches stats, caches results, and notifies subscribers', async () => {
     const fetch = vi.fn().mockResolvedValue({
@@ -14,10 +47,11 @@ describe('GitHub repo stats service', () => {
         pushed_at: '2024-06-01T00:00:00Z',
       }),
     });
+    const storage = createServiceStorage();
 
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, ...storage }
     );
 
     const listener = vi.fn();
@@ -45,18 +79,170 @@ describe('GitHub repo stats service', () => {
     });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(cached).toBe(stats);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'cached',
+      lastErrorStatus: null,
+      requestCount: 1,
+    });
   });
 
-  it('returns null without caching when fetch fails', async () => {
+  it('returns null and warns once when fetch fails', async () => {
     const fetch = vi.fn().mockRejectedValue(new Error('network unreachable'));
+    const warn = vi.fn();
+    const storage = createServiceStorage();
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, warn, ...storage }
     );
 
     const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
+    const suppressed = await service.requestStats({
+      owner: 'foo',
+      repo: 'baz',
+    });
+
     expect(stats).toBeNull();
+    expect(suppressed).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
     expect(service.getCachedStats({ owner: 'foo', repo: 'bar' })).toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 'network',
+      requestCount: 1,
+      suppressedRequestCount: 1,
+      warnedThisSession: true,
+    });
+  });
+
+  it('enters backoff and returns static fallback after a 403 response', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const warn = vi.fn();
+    const storage = createServiceStorage();
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffTtlMs: 60_000,
+        now: () => 1_000,
+        warn,
+        ...storage,
+      }
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'gabriel' })
+    ).resolves.toBeNull();
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 403,
+      requestCount: 1,
+      suppressedRequestCount: 1,
+      backoffExpiresAt: 61_000,
+    });
+  });
+
+  it('enters backoff and returns static fallback after a 429 response', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
+    const warn = vi.fn();
+    const storage = createServiceStorage();
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffTtlMs: 30_000,
+        now: () => 5_000,
+        warn,
+        ...storage,
+      }
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'token.place' })
+    ).resolves.toBeNull();
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'wove' })
+    ).resolves.toBeNull();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      lastErrorStatus: 429,
+      requestCount: 1,
+      suppressedRequestCount: 1,
+      backoffExpiresAt: 35_000,
+    });
+  });
+
+  it('uses stale cached success when live fetch fails', async () => {
+    const identifier = { owner: 'foo', repo: 'baz' };
+    const storage = createServiceStorage();
+    const firstFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        stargazers_count: 42,
+        watchers_count: 7,
+        forks_count: 0,
+        open_issues_count: 0,
+      }),
+    });
+    const firstService = createGitHubRepoStatsService(
+      firstFetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, ...storage }
+    );
+    await firstService.requestStats(identifier);
+
+    const secondFetch = vi.fn().mockRejectedValue(new Error('offline'));
+    const secondService = createGitHubRepoStatsService(
+      secondFetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, ...storage }
+    );
+
+    await expect(secondService.requestStats(identifier)).resolves.toEqual({
+      stars: 42,
+      watchers: 7,
+      forks: 0,
+      openIssues: 0,
+      pushedAt: null,
+    });
+    expect(secondFetch).not.toHaveBeenCalled();
+    expect(secondService.getDiagnostics().source).toBe('cached');
+  });
+
+  it('suppresses repeated repo metric fetch attempts during persisted backoff', async () => {
+    const storage = createServiceStorage();
+    const firstFetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const firstService = createGitHubRepoStatsService(
+      firstFetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, now: () => 10_000, warn: vi.fn(), ...storage }
+    );
+    await firstService.requestStats({
+      owner: 'futuroptimist',
+      repo: 'gabriel',
+    });
+
+    const secondFetch = vi.fn();
+    const secondService = createGitHubRepoStatsService(
+      secondFetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, now: () => 20_000, ...storage }
+    );
+    await secondService.requestStats({
+      owner: 'futuroptimist',
+      repo: 'flywheel',
+    });
+
+    expect(secondFetch).not.toHaveBeenCalled();
+    expect(secondService.getDiagnostics()).toMatchObject({
+      lastErrorStatus: 403,
+      suppressedRequestCount: 1,
+      warnedThisSession: true,
+    });
   });
 
   it('delivers cached stats to new subscribers immediately', async () => {
@@ -71,7 +257,7 @@ describe('GitHub repo stats service', () => {
     });
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, ...createServiceStorage() }
     );
 
     await service.requestStats({ owner: 'foo', repo: 'baz' });


### PR DESCRIPTION
### Motivation
- Unauthenticated GitHub API calls were fanning out across POIs and flooding the browser console with 403/429 errors during performance validation, which interfered with diagnostics and could interact with console-budget or failover heuristics. 
- Repo metrics should be best-effort and never drive immersive failover or noisy repeated errors in the client.

### Description
- Add a resilient GitHub repo stats service in `src/systems/github/repoStats.ts` that implements localStorage-backed success caching, bounded backoff on 403/404/429/network/timeout, fetch timeouts using `AbortController`, and a grouped once-per-session `warn` path with persisted backoff metadata and diagnostics types. 
- Stop parallel fan-out of live requests by switching POI refresh to sequential `service.requestStats(...)` in `src/scene/poi/githubMetrics.ts` so the first rate-limit/forbidden response can suppress the rest of the session's live requests. 
- Expose concise diagnostics via `window.portfolio.github.getRepoMetricsDiagnostics()` during immersive runtime and clean it up on teardown (changes in `src/main.ts`). 
- Add automated coverage: unit tests for backoff/cached-stale behavior and grouped warnings (`src/tests/githubRepoStatsService.test.ts`, `src/tests/githubPoiMetrics.test.ts`), a Playwright e2e that mocks GitHub 403 responses and validates quiet fallback (`playwright/github-metrics-fallback.spec.ts`), and a standalone outage record (`outages/2026-05-30-danielsmith-github-api-403-noise.{md,json}`).

### Testing
- Ran formatting and checks: `npm run format:write` (passed) and `npm run lint` (passed). 
- Unit tests: `npm run test:ci` ran the Vitest suite and passed (`vitest` summary: all unit suites executed; the focused GitHub-related tests passed). 
- End-to-end: `npm run test:e2e -- --grep "github|metrics|fallback|immersive"` (Playwright) validated the GitHub 403 fallback scenario and the immersive flows under the grep set (Playwright run: tests passed for the focused grep set; the dedicated `github-metrics-fallback` e2e passed). 
- Docs and build checks: `npm run docs:check` (passed) and `npm run smoke` (build + smoke checks passed). 
- Typecheck: `npm run typecheck` reports pre-existing repo-wide TypeScript issues unrelated to this change and therefore failed; these are known and outside the scope of this PR. 

If you want I can split the diagnostics API or shorten the backoff TTL defaults for a follow-up, but the current defaults are conservative and documented in the outage note.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8bad41f4832fb7e16e38323a02d1)