### PR TITLE
Remove duplicate in-world POI tooltips and make in-world cue title-only

### DIFF
--- a/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.json
+++ b/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.json
@@ -1,0 +1,35 @@
+{
+  "title": "danielsmith.io duplicate POI tooltip surfaces",
+  "date": "2026-05-30",
+  "environment": "staging forced-immersive preview",
+  "status": "mitigation prepared for deployment validation",
+  "symptoms": [
+    "Hovering a POI could show the intended bottom-right 2D overlay plus two overlapping in-world POI cards.",
+    "The duplicate 3D surfaces repeated details that were already present in the 2D overlay.",
+    "The stacked cards were especially noisy on exhibits such as Gitshelves."
+  ],
+  "rootCauseClass": "Duplicate in-world POI information surfaces rendered rich metadata that should be reserved for the viewport overlay.",
+  "correctiveAction": [
+    "Keep the 2D POI overlay as the only rich detail surface.",
+    "Render PoiWorldTooltip as a compact title-only in-world cue.",
+    "Render pedestal marker label textures as title-only copy.",
+    "Suppress the active POI pedestal marker label while the world tooltip owns the active hovered, selected, or guided recommendation cue.",
+    "Expose window.portfolio.poi.getTooltipState() as a narrow read-only validation hook for active overlay and in-world tooltip counts."
+  ],
+  "manualValidation": [
+    "Open https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1.",
+    "Hover Gitshelves or cycle to it with keyboard traversal.",
+    "Confirm the bottom-right 2D overlay remains rich and visible.",
+    "Confirm exactly one in-world surface appears near the active POI.",
+    "Confirm the in-world surface contains only the POI title and no summary, outcome, metrics, status, links, or helper copy."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"tooltip|POI|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.md
+++ b/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.md
@@ -1,0 +1,58 @@
+# danielsmith.io duplicate POI tooltip surfaces
+
+- **Date:** 2026-05-30
+- **Environment:** staging forced-immersive preview
+- **Status:** Mitigation prepared for deployment validation
+
+## Symptoms
+
+Hovering a POI in immersive mode could show three information surfaces at once:
+
+1. The intended bottom-right 2D viewport overlay with full POI details.
+2. A rich in-world POI tooltip card above the hovered exhibit.
+3. A second in-world marker label with overlapping POI detail copy.
+
+The stacked 3D cards were most visible on exhibits such as Gitshelves and made
+the scene feel noisy even though the rich details were already available in the
+accessible overlay.
+
+## Root cause class
+
+Two separate in-world POI systems rendered overlapping metadata surfaces. The
+world tooltip and pedestal marker labels both included rich details such as
+summaries, outcomes, metrics, status text, or helper copy that should be
+reserved for the 2D viewport overlay.
+
+## Corrective action
+
+- Keep the 2D POI overlay as the only rich detail surface.
+- Reduce `PoiWorldTooltip` to a compact title-only in-world cue.
+- Reduce pedestal marker label textures to title-only copy.
+- Suppress the pedestal marker label for the active hovered, selected, or guided
+  recommendation POI while the world tooltip is responsible for that active cue.
+- Expose a narrow read-only `window.portfolio.poi.getTooltipState()` validation
+  hook so browser tests can verify the active in-world tooltip count without
+  inspecting WebGL internals.
+
+## Manual validation
+
+1. Open `https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1`.
+2. Hover Gitshelves or cycle to it with keyboard traversal.
+3. Confirm the bottom-right 2D overlay remains visible and includes title,
+   status, summary, outcome, metrics, links, and visited/recommended badges when
+   applicable.
+4. Confirm exactly one in-world surface appears near the active POI.
+5. Confirm the in-world surface contains only the POI title and does not include
+   summary, outcome, metrics, status, links, or helper copy.
+
+## Expected validation commands
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "tooltip|POI|immersive"
+npm run docs:check
+npm run smoke
+```

--- a/playwright/poi-tooltips.spec.ts
+++ b/playwright/poi-tooltips.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+
+test.describe('POI tooltip surfaces', () => {
+  test('keeps rich details in the overlay and one title-only in-world cue', async ({
+    page,
+  }) => {
+    await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    await page.keyboard.press('E');
+
+    const overlay = page.locator('.poi-tooltip-overlay');
+    await expect(overlay).toHaveAttribute('aria-hidden', 'false');
+    await expect(overlay).toHaveAttribute('data-state', 'hovered');
+    await expect(
+      overlay.locator('.poi-tooltip-overlay__title')
+    ).not.toBeEmpty();
+    await expect(
+      overlay.locator('.poi-tooltip-overlay__summary')
+    ).not.toBeEmpty();
+    await expect(
+      overlay.locator('.poi-tooltip-overlay__metrics')
+    ).toBeVisible();
+
+    await page.waitForFunction(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const state = (window as any).portfolio?.poi?.getTooltipState?.();
+      return state?.activeInWorldTooltipCount === 1;
+    });
+
+    const tooltipState = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).portfolio?.poi?.getTooltipState?.();
+    });
+    const overlayTitle =
+      (
+        await overlay.locator('.poi-tooltip-overlay__title').textContent()
+      )?.trim() ?? '';
+
+    expect(tooltipState.overlayPoiId).toBeTruthy();
+    expect(tooltipState.worldTooltipVisible).toBe(true);
+    expect(tooltipState.markerLabelVisible).toBe(false);
+    expect(tooltipState.activeInWorldTooltipCount).toBe(1);
+    expect(tooltipState.worldTooltipPoiId).toBe(tooltipState.overlayPoiId);
+    expect(tooltipState.worldTooltipTitle).toBe(overlayTitle);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -172,7 +172,7 @@ import {
 } from './scene/poi/structuredData';
 import { PoiTooltipOverlay } from './scene/poi/tooltipOverlay';
 import { PoiTourGuide } from './scene/poi/tourGuide';
-import type { PoiDefinition } from './scene/poi/types';
+import type { PoiDefinition, PoiId } from './scene/poi/types';
 import { updateVisitedBadge } from './scene/poi/visitedBadge';
 import { PoiVisitedState } from './scene/poi/visitedState';
 import {
@@ -435,6 +435,17 @@ declare global {
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
+      poi?: {
+        getTooltipState(): {
+          overlayPoiId: string | null;
+          worldTooltipVisible: boolean;
+          worldTooltipPoiId: string | null;
+          worldTooltipTitle: string | null;
+          markerLabelVisible: boolean;
+          markerLabelPoiId: string | null;
+          activeInWorldTooltipCount: number;
+        };
+      };
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -1507,11 +1518,26 @@ function initializeImmersiveScene(
     interactionTimeline,
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+
+  let hoveredPoiId: PoiId | null = null;
+  let selectedPoiId: PoiId | null = null;
+  let recommendedPoiId: PoiId | null = null;
+  let poiTooltipIdle = false;
+  let activeWorldTooltipPoiId: PoiId | null = null;
+
+  const syncActiveWorldTooltipPoiId = () => {
+    activeWorldTooltipPoiId =
+      selectedPoiId ??
+      hoveredPoiId ??
+      (poiTooltipIdle ? recommendedPoiId : null);
+  };
   idleMonitor = new IdleMonitor({
     windowTarget: window,
     elementTargets: [renderer.domElement],
   });
   removeIdleSubscription = idleMonitor.subscribe((idle) => {
+    poiTooltipIdle = idle;
+    syncActiveWorldTooltipPoiId();
     poiTooltipOverlay.setIdleState(idle);
     poiWorldTooltip.setIdleState(idle);
   });
@@ -1654,6 +1680,8 @@ function initializeImmersiveScene(
   });
   removeGuidedTourSubscription = guidedTourChannel.subscribe(
     (recommendation) => {
+      recommendedPoiId = recommendation?.id ?? null;
+      syncActiveWorldTooltipPoiId();
       poiTooltipOverlay.setRecommendation(recommendation);
       poiWorldTooltip.setRecommendation(
         resolveWorldTooltipTarget(recommendation)
@@ -1897,11 +1925,15 @@ function initializeImmersiveScene(
     poiAnalytics
   );
   const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
+    hoveredPoiId = poi?.id ?? null;
+    syncActiveWorldTooltipPoiId();
     poiTooltipOverlay.setHovered(poi);
     poiWorldTooltip.setHovered(resolveWorldTooltipTarget(poi));
   });
   const removeSelectionStateListener =
     poiInteractionManager.addSelectionStateListener((poi, context) => {
+      selectedPoiId = poi?.id ?? null;
+      syncActiveWorldTooltipPoiId();
       poiTooltipOverlay.setSelected(poi, context);
       poiWorldTooltip.setSelected(resolveWorldTooltipTarget(poi));
     });
@@ -2256,6 +2288,47 @@ function initializeImmersiveScene(
     };
   };
   ensureWorldApi();
+  const ensurePoiTooltipApi = () => {
+    const portfolioWindow = window as Window;
+    if (!portfolioWindow.portfolio) {
+      portfolioWindow.portfolio = {};
+    }
+    portfolioWindow.portfolio.poi = {
+      getTooltipState: () => {
+        const overlayRoot = container.querySelector<HTMLElement>(
+          '.poi-tooltip-overlay'
+        );
+        const overlayPoiId = overlayRoot?.getAttribute('data-poi-id') ?? null;
+        const worldState = poiWorldTooltip.getState();
+        const activeMarker = activeWorldTooltipPoiId
+          ? (poiInstances.find(
+              (poi) => poi.definition.id === activeWorldTooltipPoiId
+            ) ?? null)
+          : null;
+        const markerLabelVisible = Boolean(activeMarker?.label?.visible);
+        const markerLabelPoiId = markerLabelVisible
+          ? (activeMarker?.definition.id ?? null)
+          : null;
+        const worldTooltipVisible = worldState.visible;
+        return {
+          overlayPoiId,
+          worldTooltipVisible,
+          worldTooltipPoiId: worldTooltipVisible ? worldState.poiId : null,
+          worldTooltipTitle:
+            worldTooltipVisible && worldState.poiId
+              ? (poiDefinitionsById.get(worldState.poiId as PoiId)?.title ??
+                null)
+              : null,
+          markerLabelVisible,
+          markerLabelPoiId,
+          activeInWorldTooltipCount:
+            Number(worldTooltipVisible) + Number(markerLabelVisible),
+        };
+      },
+    };
+  };
+  ensurePoiTooltipApi();
+
   const getAvatarAssetPipeline = () => {
     if (!avatarAssetPipeline) {
       avatarAssetPipeline = createAvatarAssetPipeline({
@@ -3758,7 +3831,11 @@ function initializeImmersiveScene(
       }
 
       if (poi.label && poi.labelMaterial) {
-        const labelOpacity = computePoiLabelOpacity(emphasis, visitedEmphasis);
+        const isActiveWorldTooltipPoi =
+          activeWorldTooltipPoiId === poi.definition.id;
+        const labelOpacity = isActiveWorldTooltipPoi
+          ? 0
+          : computePoiLabelOpacity(emphasis, visitedEmphasis);
         poi.labelMaterial.opacity = labelOpacity;
         poi.label.visible = labelOpacity > 0.05;
       }
@@ -4089,6 +4166,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
+    }
+    if (window.portfolio?.poi) {
+      delete window.portfolio.poi;
     }
     if (helpButton) {
       helpButton.textContent = buildHelpButtonText(helpLabelFallback);

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -250,7 +250,7 @@ function createPedestalPoiInstance(
     depthWrite: false,
   });
   labelMaterial.side = DoubleSide;
-  const labelHeight = scalePoiValue(1.2);
+  const labelHeight = scalePoiValue(0.62);
   const labelWidth = scalePoiValue(2.7);
   const labelGeometry = new PlaneGeometry(labelWidth, labelHeight, 1, 1);
   const label = new Mesh(labelGeometry, labelMaterial);
@@ -442,10 +442,12 @@ function createDisplayPoiInstance(
   };
 }
 
-function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
+export function createPoiLabelTexture(
+  definition: PoiDefinition
+): CanvasTexture {
   const canvas = document.createElement('canvas');
   canvas.width = 640;
-  canvas.height = 320;
+  canvas.height = 160;
   const context = canvas.getContext('2d');
   if (!context) {
     throw new Error('Unable to acquire 2D context for POI label.');
@@ -464,7 +466,7 @@ function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
   context.fillStyle = 'rgba(6, 20, 32, 0.84)';
   context.strokeStyle = 'rgba(112, 214, 255, 0.68)';
   context.lineWidth = 4;
-  const padding = 24;
+  const padding = 20;
   roundRect(
     context,
     padding,
@@ -477,45 +479,18 @@ function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
   context.stroke();
 
   context.fillStyle = gradient;
-  context.font = 'bold 64px "Inter", "Segoe UI", sans-serif';
+  context.font = 'bold 54px "Inter", "Segoe UI", sans-serif';
   context.textAlign = 'left';
   context.textBaseline = 'top';
-  context.fillText(definition.title, padding * 1.5, padding * 1.35);
-
-  const summaryY = padding * 1.35 + 84;
-  context.font = '28px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = 'rgba(220, 245, 255, 0.92)';
   wrapText(
     context,
-    definition.summary,
+    definition.title,
     padding * 1.5,
-    summaryY,
+    padding * 1.35,
     canvas.width - padding * 3,
-    40
+    58,
+    2
   );
-
-  if (definition.metrics && definition.metrics.length > 0) {
-    const metricsY = canvas.height - padding * 2.1;
-    const metricText = definition.metrics
-      .slice(0, 2)
-      .map((metric) => `${metric.label}: ${metric.value}`)
-      .join('   •   ');
-    context.font = '26px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(160, 226, 255, 0.95)';
-    context.fillText(metricText, padding * 1.5, metricsY);
-  }
-
-  if (definition.status) {
-    const statusText = definition.status === 'prototype' ? 'Prototype' : 'Live';
-    context.font = '24px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(255, 255, 255, 0.75)';
-    const textWidth = context.measureText(statusText).width;
-    context.fillText(
-      statusText,
-      canvas.width - padding * 1.5 - textWidth,
-      padding * 1.4
-    );
-  }
 
   const texture = new CanvasTexture(canvas);
   texture.needsUpdate = true;
@@ -528,7 +503,8 @@ function wrapText(
   x: number,
   y: number,
   maxWidth: number,
-  lineHeight: number
+  lineHeight: number,
+  maxLines = Number.POSITIVE_INFINITY
 ) {
   const words = text.split(' ');
   let line = '';
@@ -540,6 +516,10 @@ function wrapText(
       context.fillText(line, x, cursorY);
       line = word;
       cursorY += lineHeight;
+      if (cursorY >= y + lineHeight * maxLines) {
+        line = '';
+        break;
+      }
     } else {
       line = nextLine;
     }

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -228,6 +228,7 @@ export class PoiTooltipOverlay {
     if (!poi) {
       this.root.classList.remove('poi-tooltip-overlay--visible');
       this.root.dataset.state = 'hidden';
+      delete this.root.dataset.poiId;
       this.root.setAttribute('aria-hidden', 'true');
       this.root.removeAttribute('aria-describedby');
       this.renderState.poiId = null;
@@ -244,6 +245,7 @@ export class PoiTooltipOverlay {
         ? 'selected'
         : 'recommended';
     this.root.dataset.state = state;
+    this.root.dataset.poiId = poi.id;
     this.root.classList.add('poi-tooltip-overlay--visible');
     this.root.setAttribute('aria-hidden', 'false');
 

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -53,9 +53,10 @@ interface TooltipStateSnapshot {
 }
 
 /**
- * Renders an in-world tooltip card that anchors to a POI and always faces the
- * active camera. The card mirrors the accessible overlay metadata while
- * keeping the content grounded inside the immersive scene.
+ * Renders a lightweight in-world POI cue that anchors to a POI and always
+ * faces the active camera. Rich POI metadata stays in PoiTooltipOverlay; this
+ * surface intentionally renders the title only to avoid duplicate detail cards
+ * in the WebGL scene.
  */
 export class PoiWorldTooltip {
   public readonly group: Group;
@@ -128,8 +129,8 @@ export class PoiWorldTooltip {
 
   constructor(options: PoiWorldTooltipOptions) {
     this.camera = options.camera;
-    this.cardWidth = options.width ?? 2.6;
-    this.cardHeight = options.height ?? 1.35;
+    this.cardWidth = options.width ?? 2.4;
+    this.cardHeight = options.height ?? 0.58;
     this.verticalOffset = options.verticalOffset ?? 0.6;
     this.fadeResponse = options.fadeResponse ?? 10;
     this.positionResponse = options.positionResponse ?? 12;
@@ -142,7 +143,7 @@ export class PoiWorldTooltip {
 
     this.canvas = document.createElement('canvas');
     this.canvas.width = 1024;
-    this.canvas.height = 576;
+    this.canvas.height = 256;
     const context = this.canvas.getContext('2d');
     if (!context) {
       throw new Error('Unable to acquire 2D context for POI world tooltip.');
@@ -367,8 +368,8 @@ export class PoiWorldTooltip {
 
     context.clearRect(0, 0, width, height);
 
-    const padding = 72;
-    const radius = 36;
+    const padding = 40;
+    const radius = 34;
     const outline =
       mode === 'selected'
         ? 'rgba(170, 255, 255, 0.95)'
@@ -376,8 +377,16 @@ export class PoiWorldTooltip {
           ? 'rgba(132, 238, 255, 0.85)'
           : 'rgba(114, 224, 255, 0.68)';
 
+    const fillGradient = context.createLinearGradient(
+      0,
+      padding,
+      width,
+      height
+    );
+    fillGradient.addColorStop(0, 'rgba(9, 25, 42, 0.94)');
+    fillGradient.addColorStop(1, 'rgba(11, 45, 68, 0.88)');
     this.drawCardBackground({
-      fill: 'rgba(8, 22, 38, 0.94)',
+      fill: fillGradient,
       outline,
       x: padding,
       y: padding,
@@ -386,99 +395,20 @@ export class PoiWorldTooltip {
       radius,
     });
 
-    const accentGradient = context.createLinearGradient(
-      0,
-      padding,
-      0,
-      padding + 96
-    );
-    accentGradient.addColorStop(0, 'rgba(33, 116, 255, 0.75)');
-    accentGradient.addColorStop(1, 'rgba(21, 192, 255, 0.35)');
-    context.fillStyle = accentGradient;
-    this.drawRoundedRect(
-      padding + 4,
-      padding + 4,
-      width - padding * 2 - 8,
-      96,
-      radius * 0.6
-    );
-    context.fill();
-
-    context.fillStyle = 'rgba(223, 246, 255, 0.92)';
-    context.font = 'bold 88px "Inter", "Segoe UI", sans-serif';
+    const titleX = padding + 48;
+    const titleY = padding + 88;
+    context.fillStyle = 'rgba(229, 249, 255, 0.96)';
+    context.font = 'bold 76px "Inter", "Segoe UI", sans-serif';
     context.textAlign = 'left';
     context.textBaseline = 'alphabetic';
-    const titleX = padding + 48;
-    const titleY = padding + 96;
     this.fillWrappedText(poi.title, {
       x: titleX,
       y: titleY,
-      maxWidth: width - padding * 3,
-      lineHeight: 92,
+      maxWidth: width - padding * 3.2,
+      lineHeight: 78,
       maxLines: 2,
-      font: 'bold 88px "Inter", "Segoe UI", sans-serif',
+      font: 'bold 76px "Inter", "Segoe UI", sans-serif',
     });
-
-    context.font = '36px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(210, 236, 255, 0.92)';
-    const summaryY = titleY + 96;
-    const summaryBottom = this.fillWrappedText(poi.summary, {
-      x: titleX,
-      y: summaryY,
-      maxWidth: width - padding * 3,
-      lineHeight: 54,
-      maxLines: 3,
-      font: '36px "Inter", "Segoe UI", sans-serif',
-    });
-
-    let contentBottom = summaryBottom;
-
-    if (poi.outcome && poi.outcome.value.trim()) {
-      const outcomeLabel = poi.outcome.label?.trim() || 'Outcome';
-      const outcomeText = `${outcomeLabel}: ${poi.outcome.value.trim()}`;
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.fillStyle = 'rgba(172, 234, 255, 0.96)';
-      contentBottom = this.fillWrappedText(outcomeText, {
-        x: titleX,
-        y: summaryBottom + 54,
-        maxWidth: width - padding * 3,
-        lineHeight: 48,
-        maxLines: 2,
-        font: '34px "Inter", "Segoe UI", sans-serif',
-      });
-    }
-
-    if (poi.metrics && poi.metrics.length > 0) {
-      const metricText = poi.metrics
-        .slice(0, 2)
-        .map((metric) => `${metric.label}: ${metric.value}`)
-        .join('   •   ');
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.fillStyle = 'rgba(164, 232, 255, 0.95)';
-      const metricsY = Math.max(contentBottom + 54, height - padding * 1.6);
-      context.fillText(metricText, titleX, metricsY);
-    }
-
-    if (poi.status) {
-      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.textAlign = 'right';
-      context.fillStyle = 'rgba(220, 242, 255, 0.88)';
-      const badgeX = width - padding - 32;
-      const badgeY = padding + 64;
-      context.fillText(statusLabel, badgeX, badgeY);
-      context.textAlign = 'left';
-    }
-
-    context.font = '28px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(148, 230, 255, 0.88)';
-    const modeLabel =
-      mode === 'selected'
-        ? 'Selected exhibit'
-        : mode === 'hovered'
-          ? 'Interact to inspect'
-          : 'Next highlight';
-    context.fillText(modeLabel, titleX, padding + 48);
 
     this.texture.needsUpdate = true;
   }

--- a/src/tests/poiMarkerLabels.test.ts
+++ b/src/tests/poiMarkerLabels.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPoiLabelTexture } from '../scene/poi/markers';
+import type { PoiDefinition } from '../scene/poi/types';
+
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+const createdContexts: Array<
+  CanvasRenderingContext2D & { __fillTextLog: string[] }
+> = [];
+
+beforeAll(() => {
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function () {
+    const context = createMockCanvasContext() as CanvasRenderingContext2D & {
+      __fillTextLog: string[];
+    };
+    createdContexts.push(context);
+    return context;
+  };
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+});
+
+function createMockCanvasContext(): CanvasRenderingContext2D {
+  const fillTextLog: string[] = [];
+  const context = {
+    canvas: document.createElement('canvas'),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    clearRect: () => {},
+    beginPath: () => {},
+    closePath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    quadraticCurveTo: () => {},
+    fill: () => {},
+    stroke: () => {},
+    createLinearGradient: () => ({ addColorStop: () => {} }),
+    measureText: (text: string) => ({ width: text.length * 12 }),
+    fillText: (text: string) => {
+      fillTextLog.push(text);
+    },
+  };
+  (context as { __fillTextLog?: string[] }).__fillTextLog = fillTextLog;
+  return context as unknown as CanvasRenderingContext2D;
+}
+
+function createPoiDefinition(): PoiDefinition {
+  return {
+    id: 'gitshelves-living-room-installation',
+    title: 'Gitshelves Living Room Array',
+    summary: 'Rich summary copy remains reserved for the viewport overlay.',
+    interactionPrompt: 'Inspect Gitshelves Living Room Array',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'livingRoom',
+    position: { x: 0, y: 0, z: 0 },
+    interactionRadius: 3,
+    footprint: { width: 2, depth: 2 },
+    outcome: { label: 'Outcome', value: 'Curated repos faster' },
+    metrics: [{ label: 'Repos', value: '42' }],
+    links: [{ label: 'GitHub', href: 'https://github.com/futuroptimist' }],
+    status: 'live',
+  } as PoiDefinition;
+}
+
+describe('createPoiLabelTexture', () => {
+  it('draws title-only marker labels without rich detail copy', () => {
+    const poi = createPoiDefinition();
+    const texture = createPoiLabelTexture(poi);
+    const renderedText = createdContexts.at(-1)?.__fillTextLog.join(' ') ?? '';
+
+    expect(renderedText).toContain(poi.title);
+    expect(renderedText).not.toContain('Rich summary');
+    expect(renderedText).not.toContain('Curated repos');
+    expect(renderedText).not.toContain('Repos');
+    expect(renderedText).not.toContain('Live');
+
+    texture.dispose();
+  });
+});

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -135,6 +135,7 @@ describe('PoiTooltipOverlay', () => {
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
     expect(root.getAttribute('aria-hidden')).toBe('false');
     expect(root.dataset.state).toBe('hovered');
+    expect(root.dataset.poiId).toBe(basePoi.id);
 
     const title = root.querySelector(
       '.poi-tooltip-overlay__title'
@@ -223,6 +224,7 @@ describe('PoiTooltipOverlay', () => {
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
     expect(root.getAttribute('aria-hidden')).toBe('true');
     expect(root.getAttribute('aria-describedby')).toBeNull();
+    expect(root.dataset.poiId).toBeUndefined();
   });
 
   it('refreshes metric values when notified about updates', () => {

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -203,7 +203,42 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
-  it('re-renders the active card when metrics change', () => {
+  it('renders only the POI title in the in-world canvas', () => {
+    const { tooltip, preference } = createTooltip();
+    const poi = createPoiDefinition({
+      id: 'flywheel-studio-flywheel',
+      title: 'Flywheel Kinetic Hub',
+      summary: 'Summary copy belongs in the viewport overlay only.',
+      outcome: { label: 'Outcome', value: 'Accelerated deploys 24%' },
+      metrics: [
+        { label: 'Stars', value: 'Fallback' },
+        { label: 'Impact', value: 'Launch-ready' },
+      ],
+      status: 'prototype',
+    });
+    const target = createTarget(poi, new Vector3(0, 1, 0));
+
+    tooltip.setSelected(target);
+    tooltip.update(0.016);
+
+    const context = (
+      tooltip as unknown as {
+        context: CanvasRenderingContext2D & { __fillTextLog: string[] };
+      }
+    ).context;
+
+    expect(context.__fillTextLog).toContain('Flywheel Kinetic Hub');
+    expect(context.__fillTextLog.join(' ')).not.toContain('Summary copy');
+    expect(context.__fillTextLog.join(' ')).not.toContain('Accelerated');
+    expect(context.__fillTextLog.join(' ')).not.toContain('Stars');
+    expect(context.__fillTextLog.join(' ')).not.toContain('Prototype');
+    expect(context.__fillTextLog.join(' ')).not.toContain('Selected exhibit');
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
+  it('re-renders title-only content when active POI metrics change', () => {
     const { tooltip, preference } = createTooltip();
     const poi = createPoiDefinition({
       id: 'flywheel-studio-flywheel',
@@ -232,11 +267,9 @@ describe('PoiWorldTooltip', () => {
 
     expect(context.__fillTextLog.length).toBeGreaterThan(initialLength);
     const newEntries = context.__fillTextLog.slice(initialLength);
-    const metricEntry = newEntries.find((entry) =>
-      entry.includes('Live 2,000')
-    );
-    expect(metricEntry).toBeDefined();
-    expect(metricEntry).toContain('Impact');
+    expect(newEntries).toContain(poi.title);
+    expect(newEntries.join(' ')).not.toContain('Live 2,000');
+    expect(newEntries.join(' ')).not.toContain('Impact');
 
     tooltip.dispose();
     preference.dispose();


### PR DESCRIPTION
### Motivation
- Hovering POIs could surface the 2D overlay plus two overlapping in-world 3D cards, duplicating rich detail and adding visual noise. 
- The 2D overlay should remain the single rich-details surface while in-world cues stay lightweight and readable.

### Description
- Render the world tooltip as a compact, title-only in-world card by reducing canvas/card dimensions and removing summary/outcome/metrics/status/mode drawing in `src/scene/poi/worldTooltip.ts`.
- Produce title-only pedestal marker textures via `createPoiLabelTexture()` and smaller label geometry in `src/scene/poi/markers.ts` so marker labels no longer duplicate overlay details.
- Track the active POI cue in `src/main.ts` and suppress the pedestal marker label when the world tooltip is the active in-world cue, by gating `labelOpacity` when `activeWorldTooltipPoiId` matches the POI.
- Add a narrow read-only test hook `window.portfolio.poi.getTooltipState()` plus `data-poi-id` on the overlay to let Playwright assert overlay/world-tooltip/marker state without inspecting WebGL internals, and add Vitest + Playwright tests and a standalone outage bookkeeping entry under `outages/`.

### Testing
- Ran formatting with `npm run format:write` and it completed successfully.
- Ran lint with `npm run lint` and it completed successfully.
- Ran type check with `npm run typecheck` and it reported existing repo-wide TypeScript issues unrelated to these changes (status: failed; these issues pre-existed and were not introduced by this PR).
- Ran focused unit tests with `npx vitest run src/tests/poiWorldTooltip.test.ts src/tests/poiMarkerLabels.test.ts src/tests/poiTooltipOverlay.test.ts` and they passed.
- Ran full CI unit suite with `npm run test:ci` and it completed successfully (many tests; existing repo warnings/errors were unrelated to this change and are pre-existing in the tree).
- Ran Playwright end-to-end checks filtered for tooltip/POI/immersive with `npm run test:e2e -- --grep "tooltip|POI|immersive"` and the new `playwright/poi-tooltips.spec.ts` passed as part of the suite (16 passed, 2 skipped in this filtered run after browser setup), confirming the overlay retains rich details and exactly one in-world title-only cue is active.
- Ran `npm run docs:check` and `npm run smoke` and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8bc90a38832fa776e34cb9d1c4c5)