### PR TITLE
Keep POI world cues title-only

### DIFF
--- a/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.json
+++ b/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.json
@@ -1,0 +1,36 @@
+{
+  "title": "danielsmith.io duplicate POI tooltip cleanup",
+  "date": "2026-05-30",
+  "environment": "staging forced-immersive POI hover validation",
+  "status": "mitigation prepared for deployment validation",
+  "symptoms": [
+    "Hovering a POI could show the expected 2D viewport details card plus two overlapping in-world 3D cards above the POI.",
+    "The duplicate 3D cards repeated summary, outcome, metrics, status, and helper copy that should live only in the 2D overlay.",
+    "Gitshelves was a representative staging repro for the stacked in-world cards."
+  ],
+  "rootCauseClass": "Duplicate in-world POI information surfaces, with pedestal marker labels and the camera-facing world tooltip both carrying rich metadata while the 2D overlay also rendered details.",
+  "correctiveAction": [
+    "Preserve the bottom-right 2D POI overlay as the only rich details surface.",
+    "Simplify the camera-facing in-world POI cue to title-only copy.",
+    "Simplify pedestal marker textures to title-only copy for inactive nearby labels.",
+    "Hide the active POI pedestal label while the camera-facing world cue is active so only one active in-world POI surface remains.",
+    "Expose window.portfolio.poi.getTooltipState() as a read-only browser test hook for active in-world surface counts."
+  ],
+  "validation": [
+    "Open /?mode=immersive&disablePerformanceFailover=1.",
+    "Hover or keyboard-focus a POI such as Gitshelves.",
+    "Confirm the bottom-right 2D overlay remains visible and still contains title, status, summary, outcome, metrics, links, and badges.",
+    "Confirm exactly one in-world surface is visible for the active POI.",
+    "Confirm the in-world surface contains only the POI title and no summary, outcome, metrics, status, links, or helper copy.",
+    "Confirm selected and guided-tour recommendation states do not create duplicate in-world POI cards."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"tooltip|POI|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.md
+++ b/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.md
@@ -1,0 +1,58 @@
+# danielsmith.io duplicate POI tooltip cleanup
+
+- **Date:** 2026-05-30
+- **Environment:** staging forced-immersive POI hover validation
+- **Status:** Mitigation prepared for deployment validation
+
+## Symptoms
+
+Hovering a POI, including the Gitshelves living-room exhibit, could show three
+information surfaces at once: the expected 2D viewport details card plus two
+overlapping in-world 3D cards above the POI. The stacked 3D cards repeated
+summary, outcome, metrics, status, and helper copy that should live only in the
+2D overlay.
+
+## Root cause class
+
+Two in-world POI surface systems were carrying rich metadata: pedestal marker
+labels and the camera-facing world tooltip. When hover, selection, or guided-tour
+state emphasized a POI, those 3D surfaces could overlap while the accessible 2D
+overlay also rendered the same details.
+
+## Corrective action
+
+- Preserve the bottom-right 2D POI overlay as the only rich details surface for
+  title, status, summary, outcome, metrics, links, visited badges, and guided
+  recommendation badges.
+- Simplify the camera-facing in-world POI cue to title-only copy.
+- Simplify pedestal marker textures to title-only copy so inactive nearby labels
+  cannot duplicate details.
+- Hide the active POI pedestal label while the camera-facing world cue is active,
+  leaving exactly one active in-world POI surface.
+- Add a read-only Playwright hook at `window.portfolio.poi.getTooltipState()` so
+  browser coverage can verify the active in-world surface count without
+  inspecting WebGL internals.
+
+## Validation
+
+1. Open `/?mode=immersive&disablePerformanceFailover=1`.
+2. Hover or keyboard-focus a POI such as Gitshelves.
+3. Confirm the bottom-right 2D overlay remains visible and still contains rich
+   details.
+4. Confirm exactly one in-world surface is visible for the active POI.
+5. Confirm the in-world surface contains only the POI title, with no summary,
+   outcome, metrics, status, links, or helper copy.
+6. Confirm selected and guided-tour recommendation states do not create duplicate
+   in-world POI cards.
+
+## Expected validation commands
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "tooltip|POI|immersive"
+npm run docs:check
+npm run smoke
+```

--- a/playwright/poi-tooltips.spec.ts
+++ b/playwright/poi-tooltips.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+
+async function waitForImmersiveReady(page: import('@playwright/test').Page) {
+  await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+}
+
+test.describe('POI tooltip surfaces', () => {
+  test('keeps the 2D details overlay and one title-only in-world cue', async ({
+    page,
+  }) => {
+    await waitForImmersiveReady(page);
+
+    const tooltip = page.locator('.poi-tooltip-overlay');
+    await page.keyboard.press('KeyE');
+    await expect(tooltip).toHaveAttribute('aria-hidden', 'false');
+
+    const title = (
+      await tooltip.locator('.poi-tooltip-overlay__title').textContent()
+    )?.trim();
+    expect(title?.length).toBeGreaterThan(0);
+    await expect(
+      tooltip.locator('.poi-tooltip-overlay__summary')
+    ).not.toBeEmpty();
+    await expect(
+      tooltip.locator('.poi-tooltip-overlay__metrics')
+    ).toBeVisible();
+
+    await page.waitForFunction(
+      () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const state = (window as any).portfolio?.poi?.getTooltipState?.();
+        return (
+          state?.worldTooltipVisible && state?.activeInWorldTooltipCount === 1
+        );
+      },
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    const state = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).portfolio?.poi?.getTooltipState?.();
+    });
+
+    expect(state.overlayPoiId).toBeTruthy();
+    expect(state.worldTooltipPoiId).toBe(state.overlayPoiId);
+    expect(state.worldTooltipTitle).toBe(title);
+    expect(state.activeMarkerLabelVisible).toBe(false);
+    expect(state.activeInWorldTooltipCount).toBe(1);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -449,6 +449,16 @@ declare global {
         resetMotionBlurHistory(): void;
         setCameraPanForTest?(input: { x: number; y: number }): void;
       };
+      poi?: {
+        getTooltipState(): {
+          overlayPoiId: string | null;
+          worldTooltipVisible: boolean;
+          worldTooltipPoiId: string | null;
+          worldTooltipTitle: string | null;
+          activeMarkerLabelVisible: boolean;
+          activeInWorldTooltipCount: number;
+        };
+      };
       world?: {
         getActiveFloor(): FloorId;
         setActiveFloor(next: FloorId): void;
@@ -970,9 +980,6 @@ function initializeImmersiveScene(
 
   const poiOverrides: PoiInstanceOverrides = {};
   const poiDefinitions = getPoiDefinitions();
-  const poiDefinitionsById = new Map(
-    poiDefinitions.map((definition) => [definition.id, definition] as const)
-  );
   injectPoiStructuredData(poiDefinitions, {
     siteName: siteStrings.name,
     locale,
@@ -1585,6 +1592,60 @@ function initializeImmersiveScene(
     };
   };
 
+  const getPoiOverlayPoiId = () => {
+    const overlayRoot = container.querySelector<HTMLElement>(
+      '.poi-tooltip-overlay'
+    );
+    if (!overlayRoot || overlayRoot.getAttribute('aria-hidden') === 'true') {
+      return null;
+    }
+    const title = overlayRoot
+      .querySelector<HTMLElement>('.poi-tooltip-overlay__title')
+      ?.textContent?.trim();
+    return poiDefinitions.find((poi) => poi.title === title)?.id ?? null;
+  };
+
+  const getActiveWorldTooltipMarkerLabelState = () => {
+    const worldTooltipState = poiWorldTooltip.getState();
+    const activeInstance = worldTooltipState.poiId
+      ? poiInstances.find(
+          (poi) => poi.definition.id === worldTooltipState.poiId
+        )
+      : null;
+    const activeMarkerLabelVisible = Boolean(
+      activeInstance?.label?.visible &&
+        (activeInstance.labelMaterial?.opacity ?? 0) > 0.05
+    );
+    return { worldTooltipState, activeMarkerLabelVisible };
+  };
+
+  const poiPortfolioWindow = window as Window;
+  if (!poiPortfolioWindow.portfolio) {
+    poiPortfolioWindow.portfolio = {};
+  }
+  poiPortfolioWindow.portfolio.poi = {
+    getTooltipState: () => {
+      const { worldTooltipState, activeMarkerLabelVisible } =
+        getActiveWorldTooltipMarkerLabelState();
+      const worldTooltipVisible = Boolean(
+        worldTooltipState.visible && worldTooltipState.poiId
+      );
+      const worldTooltipPoi = worldTooltipState.poiId
+        ? poiDefinitions.find((poi) => poi.id === worldTooltipState.poiId)
+        : null;
+      return {
+        overlayPoiId: getPoiOverlayPoiId(),
+        worldTooltipVisible,
+        worldTooltipPoiId: worldTooltipState.poiId,
+        worldTooltipTitle:
+          worldTooltipVisible && worldTooltipPoi ? worldTooltipPoi.title : null,
+        activeMarkerLabelVisible,
+        activeInWorldTooltipCount:
+          (worldTooltipVisible ? 1 : 0) + (activeMarkerLabelVisible ? 1 : 0),
+      };
+    },
+  };
+
   let visitedInitialized = false;
   let previousVisited = new Set<string>();
 
@@ -1605,7 +1666,7 @@ function initializeImmersiveScene(
     }
     if (poiNarrativeLog) {
       const visitedDefinitions = Array.from(visited)
-        .map((id) => poiDefinitionsById.get(id))
+        .map((id) => poiDefinitions.find((poi) => poi.id === id))
         .filter((definition): definition is PoiDefinition =>
           Boolean(definition)
         );
@@ -1625,7 +1686,7 @@ function initializeImmersiveScene(
           if (previousVisited.has(id)) {
             continue;
           }
-          const definition = poiDefinitionsById.get(id);
+          const definition = poiDefinitions.find((poi) => poi.id === id);
           if (!definition) {
             continue;
           }
@@ -2612,7 +2673,7 @@ function initializeImmersiveScene(
 
     const visitedSnapshot = poiVisitedState.snapshot();
     const visitedDefinitions = Array.from(visitedSnapshot)
-      .map((id) => poiDefinitionsById.get(id))
+      .map((id) => poiDefinitions.find((poi) => poi.id === id))
       .filter((definition): definition is PoiDefinition => Boolean(definition));
     if (visitedDefinitions.length > 0 && poiNarrativeLog) {
       poiNarrativeLog.syncVisited(visitedDefinitions, {
@@ -3758,7 +3819,14 @@ function initializeImmersiveScene(
       }
 
       if (poi.label && poi.labelMaterial) {
-        const labelOpacity = computePoiLabelOpacity(emphasis, visitedEmphasis);
+        const { worldTooltipState } = getActiveWorldTooltipMarkerLabelState();
+        const hasActiveWorldCue =
+          (worldTooltipState.visible &&
+            worldTooltipState.poiId === poi.definition.id) ||
+          poi.focusTarget > 0;
+        const labelOpacity = hasActiveWorldCue
+          ? 0
+          : computePoiLabelOpacity(emphasis, visitedEmphasis);
         poi.labelMaterial.opacity = labelOpacity;
         poi.label.visible = labelOpacity > 0.05;
       }
@@ -4089,6 +4157,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
+    }
+    if (window.portfolio?.poi) {
+      delete window.portfolio.poi;
     }
     if (helpButton) {
       helpButton.textContent = buildHelpButtonText(helpLabelFallback);

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -250,7 +250,7 @@ function createPedestalPoiInstance(
     depthWrite: false,
   });
   labelMaterial.side = DoubleSide;
-  const labelHeight = scalePoiValue(1.2);
+  const labelHeight = scalePoiValue(0.76);
   const labelWidth = scalePoiValue(2.7);
   const labelGeometry = new PlaneGeometry(labelWidth, labelHeight, 1, 1);
   const label = new Mesh(labelGeometry, labelMaterial);
@@ -442,10 +442,12 @@ function createDisplayPoiInstance(
   };
 }
 
-function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
+export function createPoiLabelTexture(
+  definition: PoiDefinition
+): CanvasTexture {
   const canvas = document.createElement('canvas');
   canvas.width = 640;
-  canvas.height = 320;
+  canvas.height = 180;
   const context = canvas.getContext('2d');
   if (!context) {
     throw new Error('Unable to acquire 2D context for POI label.');
@@ -477,76 +479,14 @@ function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
   context.stroke();
 
   context.fillStyle = gradient;
-  context.font = 'bold 64px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'top';
-  context.fillText(definition.title, padding * 1.5, padding * 1.35);
-
-  const summaryY = padding * 1.35 + 84;
-  context.font = '28px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = 'rgba(220, 245, 255, 0.92)';
-  wrapText(
-    context,
-    definition.summary,
-    padding * 1.5,
-    summaryY,
-    canvas.width - padding * 3,
-    40
-  );
-
-  if (definition.metrics && definition.metrics.length > 0) {
-    const metricsY = canvas.height - padding * 2.1;
-    const metricText = definition.metrics
-      .slice(0, 2)
-      .map((metric) => `${metric.label}: ${metric.value}`)
-      .join('   •   ');
-    context.font = '26px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(160, 226, 255, 0.95)';
-    context.fillText(metricText, padding * 1.5, metricsY);
-  }
-
-  if (definition.status) {
-    const statusText = definition.status === 'prototype' ? 'Prototype' : 'Live';
-    context.font = '24px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(255, 255, 255, 0.75)';
-    const textWidth = context.measureText(statusText).width;
-    context.fillText(
-      statusText,
-      canvas.width - padding * 1.5 - textWidth,
-      padding * 1.4
-    );
-  }
+  context.font = 'bold 62px "Inter", "Segoe UI", sans-serif';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.fillText(definition.title, canvas.width / 2, canvas.height / 2);
 
   const texture = new CanvasTexture(canvas);
   texture.needsUpdate = true;
   return texture;
-}
-
-function wrapText(
-  context: CanvasRenderingContext2D,
-  text: string,
-  x: number,
-  y: number,
-  maxWidth: number,
-  lineHeight: number
-) {
-  const words = text.split(' ');
-  let line = '';
-  let cursorY = y;
-  for (const word of words) {
-    const nextLine = line ? `${line} ${word}` : word;
-    const metrics = context.measureText(nextLine);
-    if (metrics.width > maxWidth && line) {
-      context.fillText(line, x, cursorY);
-      line = word;
-      cursorY += lineHeight;
-    } else {
-      line = nextLine;
-    }
-  }
-  if (line) {
-    context.fillText(line, x, cursorY);
-  }
 }
 
 function roundRect(

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -53,9 +53,9 @@ interface TooltipStateSnapshot {
 }
 
 /**
- * Renders an in-world tooltip card that anchors to a POI and always faces the
- * active camera. The card mirrors the accessible overlay metadata while
- * keeping the content grounded inside the immersive scene.
+ * Renders a lightweight in-world title cue that anchors to a POI and always
+ * faces the active camera. Rich metadata stays in the accessible 2D overlay so
+ * the 3D scene never duplicates detailed tooltip cards.
  */
 export class PoiWorldTooltip {
   public readonly group: Group;
@@ -128,9 +128,9 @@ export class PoiWorldTooltip {
 
   constructor(options: PoiWorldTooltipOptions) {
     this.camera = options.camera;
-    this.cardWidth = options.width ?? 2.6;
-    this.cardHeight = options.height ?? 1.35;
-    this.verticalOffset = options.verticalOffset ?? 0.6;
+    this.cardWidth = options.width ?? 2.15;
+    this.cardHeight = options.height ?? 0.48;
+    this.verticalOffset = options.verticalOffset ?? 0.42;
     this.fadeResponse = options.fadeResponse ?? 10;
     this.positionResponse = options.positionResponse ?? 12;
     this.scaleDistance = options.scaleDistance ?? 14;
@@ -368,7 +368,7 @@ export class PoiWorldTooltip {
     context.clearRect(0, 0, width, height);
 
     const padding = 72;
-    const radius = 36;
+    const radius = 42;
     const outline =
       mode === 'selected'
         ? 'rgba(170, 255, 255, 0.95)'
@@ -377,7 +377,7 @@ export class PoiWorldTooltip {
           : 'rgba(114, 224, 255, 0.68)';
 
     this.drawCardBackground({
-      fill: 'rgba(8, 22, 38, 0.94)',
+      fill: 'rgba(8, 22, 38, 0.92)',
       outline,
       x: padding,
       y: padding,
@@ -387,98 +387,34 @@ export class PoiWorldTooltip {
     });
 
     const accentGradient = context.createLinearGradient(
-      0,
       padding,
-      0,
-      padding + 96
+      padding,
+      width - padding,
+      height - padding
     );
-    accentGradient.addColorStop(0, 'rgba(33, 116, 255, 0.75)');
-    accentGradient.addColorStop(1, 'rgba(21, 192, 255, 0.35)');
+    accentGradient.addColorStop(0, 'rgba(33, 116, 255, 0.68)');
+    accentGradient.addColorStop(1, 'rgba(21, 192, 255, 0.34)');
     context.fillStyle = accentGradient;
     this.drawRoundedRect(
-      padding + 4,
-      padding + 4,
-      width - padding * 2 - 8,
-      96,
-      radius * 0.6
+      padding + 10,
+      padding + 10,
+      width - padding * 2 - 20,
+      height - padding * 2 - 20,
+      radius * 0.82
     );
     context.fill();
 
-    context.fillStyle = 'rgba(223, 246, 255, 0.92)';
-    context.font = 'bold 88px "Inter", "Segoe UI", sans-serif';
-    context.textAlign = 'left';
-    context.textBaseline = 'alphabetic';
-    const titleX = padding + 48;
-    const titleY = padding + 96;
+    context.fillStyle = 'rgba(232, 249, 255, 0.96)';
+    const titleX = padding + 52;
+    const titleY = padding + 172;
     this.fillWrappedText(poi.title, {
       x: titleX,
       y: titleY,
       maxWidth: width - padding * 3,
-      lineHeight: 92,
+      lineHeight: 86,
       maxLines: 2,
-      font: 'bold 88px "Inter", "Segoe UI", sans-serif',
+      font: 'bold 78px "Inter", "Segoe UI", sans-serif',
     });
-
-    context.font = '36px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(210, 236, 255, 0.92)';
-    const summaryY = titleY + 96;
-    const summaryBottom = this.fillWrappedText(poi.summary, {
-      x: titleX,
-      y: summaryY,
-      maxWidth: width - padding * 3,
-      lineHeight: 54,
-      maxLines: 3,
-      font: '36px "Inter", "Segoe UI", sans-serif',
-    });
-
-    let contentBottom = summaryBottom;
-
-    if (poi.outcome && poi.outcome.value.trim()) {
-      const outcomeLabel = poi.outcome.label?.trim() || 'Outcome';
-      const outcomeText = `${outcomeLabel}: ${poi.outcome.value.trim()}`;
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.fillStyle = 'rgba(172, 234, 255, 0.96)';
-      contentBottom = this.fillWrappedText(outcomeText, {
-        x: titleX,
-        y: summaryBottom + 54,
-        maxWidth: width - padding * 3,
-        lineHeight: 48,
-        maxLines: 2,
-        font: '34px "Inter", "Segoe UI", sans-serif',
-      });
-    }
-
-    if (poi.metrics && poi.metrics.length > 0) {
-      const metricText = poi.metrics
-        .slice(0, 2)
-        .map((metric) => `${metric.label}: ${metric.value}`)
-        .join('   •   ');
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.fillStyle = 'rgba(164, 232, 255, 0.95)';
-      const metricsY = Math.max(contentBottom + 54, height - padding * 1.6);
-      context.fillText(metricText, titleX, metricsY);
-    }
-
-    if (poi.status) {
-      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.textAlign = 'right';
-      context.fillStyle = 'rgba(220, 242, 255, 0.88)';
-      const badgeX = width - padding - 32;
-      const badgeY = padding + 64;
-      context.fillText(statusLabel, badgeX, badgeY);
-      context.textAlign = 'left';
-    }
-
-    context.font = '28px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(148, 230, 255, 0.88)';
-    const modeLabel =
-      mode === 'selected'
-        ? 'Selected exhibit'
-        : mode === 'hovered'
-          ? 'Interact to inspect'
-          : 'Next highlight';
-    context.fillText(modeLabel, titleX, padding + 48);
 
     this.texture.needsUpdate = true;
   }

--- a/src/tests/poiMarkerLabels.test.ts
+++ b/src/tests/poiMarkerLabels.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPoiLabelTexture } from '../scene/poi/markers';
+import type { PoiDefinition } from '../scene/poi/types';
+
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+const mockContexts = new WeakMap<HTMLCanvasElement, CanvasRenderingContext2D>();
+
+beforeAll(() => {
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (this: HTMLCanvasElement) {
+    const existing = mockContexts.get(this);
+    if (existing) {
+      return existing;
+    }
+    const context = createMockCanvasContext(this);
+    mockContexts.set(this, context);
+    return context;
+  } as unknown as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+});
+
+function createMockCanvasContext(
+  canvas: HTMLCanvasElement
+): CanvasRenderingContext2D {
+  const fillTextLog: string[] = [];
+  const context = {
+    canvas,
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    clearRect: () => {},
+    beginPath: () => {},
+    closePath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    quadraticCurveTo: () => {},
+    fill: () => {},
+    stroke: () => {},
+    createLinearGradient: () => ({ addColorStop: () => {} }),
+    measureText: (text: string) => ({ width: text.length * 12 }),
+    fillText: (text: string) => {
+      fillTextLog.push(text);
+    },
+  };
+  (context as { __fillTextLog?: string[] }).__fillTextLog = fillTextLog;
+  return context as unknown as CanvasRenderingContext2D;
+}
+
+function createPoiDefinition(): PoiDefinition {
+  return {
+    id: 'gitshelves-living-room-installation',
+    title: 'Gitshelves Living Room Array',
+    summary: 'A detailed summary that should stay in the 2D overlay only.',
+    interactionPrompt: 'Inspect Gitshelves Living Room Array',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'livingRoom',
+    position: { x: 0, y: 0, z: 0 },
+    interactionRadius: 3,
+    footprint: { width: 2, depth: 2 },
+    outcome: { label: 'Outcome', value: 'Curated repo discovery' },
+    metrics: [{ label: 'Repos', value: '42' }],
+    links: [{ label: 'GitHub', href: 'https://github.com/futuroptimist' }],
+    status: 'live',
+  } as PoiDefinition;
+}
+
+describe('POI marker labels', () => {
+  it('renders title-only marker textures without rich details', () => {
+    const texture = createPoiLabelTexture(createPoiDefinition());
+    const canvas = texture.image as HTMLCanvasElement;
+    const context = canvas.getContext('2d') as CanvasRenderingContext2D & {
+      __fillTextLog: string[];
+    };
+
+    expect(canvas.width).toBe(640);
+    expect(canvas.height).toBe(180);
+    expect(context.__fillTextLog).toEqual(['Gitshelves Living Room Array']);
+    expect(context.__fillTextLog).not.toContain(
+      'A detailed summary that should stay in the 2D overlay only.'
+    );
+    expect(context.__fillTextLog.some((entry) => entry.includes('Repos'))).toBe(
+      false
+    );
+    expect(context.__fillTextLog).not.toContain('Live');
+  });
+});

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -203,14 +203,50 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
-  it('re-renders the active card when metrics change', () => {
+  it('renders only the POI title in the world cue', () => {
     const { tooltip, preference } = createTooltip();
     const poi = createPoiDefinition({
       id: 'flywheel-studio-flywheel',
+      title: 'Flywheel Kinetic Hub',
+      summary: 'Rich summary copy belongs in the 2D overlay.',
+      outcome: { label: 'Outcome', value: 'Accelerated deploys 24%' },
       metrics: [
         { label: 'Stars', value: 'Fallback' },
         { label: 'Impact', value: 'Launch-ready' },
       ],
+      status: 'prototype',
+    });
+    const target = createTarget(poi, new Vector3(0, 1, 0));
+
+    tooltip.setSelected(target);
+    tooltip.update(0.016);
+
+    const context = (
+      tooltip as unknown as {
+        context: CanvasRenderingContext2D & { __fillTextLog: string[] };
+      }
+    ).context;
+
+    expect(context.__fillTextLog).toContain(poi.title);
+    expect(context.__fillTextLog).not.toContain(poi.summary);
+    expect(
+      context.__fillTextLog.some((entry) => entry.includes('Accelerated'))
+    ).toBe(false);
+    expect(
+      context.__fillTextLog.some((entry) => entry.includes('Fallback'))
+    ).toBe(false);
+    expect(context.__fillTextLog).not.toContain('Prototype');
+    expect(context.__fillTextLog).not.toContain('Selected exhibit');
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
+  it('re-renders the active title cue when notified about POI updates', () => {
+    const { tooltip, preference } = createTooltip();
+    const poi = createPoiDefinition({
+      id: 'flywheel-studio-flywheel',
+      title: 'Flywheel',
     });
     const target = createTarget(poi, new Vector3(0, 1, 0));
 
@@ -224,19 +260,13 @@ describe('PoiWorldTooltip', () => {
     ).context;
     const initialLength = context.__fillTextLog.length;
 
-    if (poi.metrics?.[0]) {
-      poi.metrics[0].value = 'Live 2,000';
-    }
-
+    poi.title = 'Flywheel Updated';
     tooltip.notifyPoiUpdated(poi.id);
 
     expect(context.__fillTextLog.length).toBeGreaterThan(initialLength);
-    const newEntries = context.__fillTextLog.slice(initialLength);
-    const metricEntry = newEntries.find((entry) =>
-      entry.includes('Live 2,000')
+    expect(context.__fillTextLog.slice(initialLength)).toContain(
+      'Flywheel Updated'
     );
-    expect(metricEntry).toBeDefined();
-    expect(metricEntry).toContain('Impact');
 
     tooltip.dispose();
     preference.dispose();


### PR DESCRIPTION
### Motivation
- Hovered POIs were rendering duplicate rich details: the 2D viewport overlay plus two overlapping 3D/in-world cards, creating visual noise and redundancy.
- The intent is to keep rich metadata in the accessible 2D overlay and reduce in-world surfaces to a single, lightweight title-only cue.

### Description
- Simplified `PoiWorldTooltip` to a compact title-only in-world cue and removed summary/outcome/metrics/status/mode label drawing from its canvas renderer (`src/scene/poi/worldTooltip.ts`).
- Converted pedestal marker textures to title-only label textures and reduced marker plane height (`src/scene/poi/markers.ts`).
- Hid the active pedestal label whenever the camera-facing world cue is active and added a read-only browser test hook at `window.portfolio.poi.getTooltipState()` to report overlay/world state and active in-world tooltip counts (`src/main.ts`).
- Added/updated tests and e2e coverage: unit tests for world tooltip and marker labels (`src/tests/poiWorldTooltip.test.ts`, `src/tests/poiMarkerLabels.test.ts`), a Playwright spec to assert the 2D overlay + single in-world cue (`playwright/poi-tooltips.spec.ts`), and an outage bookkeeping entry describing the change (`outages/2026-05-30-danielsmith-duplicate-poi-tooltips.{md,json}`).

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both succeeded.
- Ran type-checking with `npm run typecheck`, which reported pre-existing repo-wide TypeScript issues unrelated to the POI changes (not introduced by this PR).
- Ran targeted unit tests: `npm run test:ci` for the POI suites and the full `npm run test:ci`, both succeeded (Vitest: unit suites passed).
- Executed Playwright e2e for tooltip/POI/immersive flows: initial run failed due to missing Playwright browsers, then `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell` were executed and the e2e run succeeded for the targeted grep (`npm run test:e2e -- --grep "tooltip|POI|immersive"` resulted in the POI tooltip spec passing and overall targeted e2e passing: 16 passed, 2 skipped).
- Documentation and smoke checks were run and passed with `npm run docs:check` and `npm run smoke`.
- Secrets scan `git diff --cached | ./scripts/scan-secrets.py` was run and found no high-risk secrets.

Residual notes: the repo contains unrelated TypeScript type errors revealed by `npm run typecheck`; these are pre-existing and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8bc90a38832fa776e34cb9d1c4c5)