### PR TITLE
Keep POI tooltips title-only in world

### DIFF
--- a/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.json
+++ b/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-05-30-danielsmith-duplicate-poi-tooltips",
+  "date": "2026-05-30",
+  "title": "Duplicate POI tooltips cluttered immersive hover states",
+  "symptomSlice": "The bottom-right 2D overlay appeared alongside two overlapping in-world POI detail cards on hover.",
+  "rootCause": "Pedestal marker labels and PoiWorldTooltip both rendered rich in-world metadata for the same active POI.",
+  "fixSummary": "Reserve rich POI details for the 2D overlay, render only title text in in-world canvases, and hide the active marker label while the anchored world tooltip is visible.",
+  "regressionTests": "Vitest covers title-only world tooltip and marker label canvases plus rich overlay details; Playwright covers one active in-world tooltip count with rich overlay content in immersive mode.",
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"tooltip|POI|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.md
+++ b/outages/2026-05-30-danielsmith-duplicate-poi-tooltips.md
@@ -1,0 +1,45 @@
+# Duplicate POI tooltips cluttered immersive hover states
+
+## Symptom
+
+Staging screenshots showed three POI information surfaces at the same time: the
+bottom-right 2D viewport overlay plus two overlapping in-world cards above the
+hovered POI. Gitshelves was especially noisy because both in-world surfaces
+repeated rich details that belonged in the overlay.
+
+## Root cause
+
+Pedestal POI marker labels and `PoiWorldTooltip` both rendered in-world cards,
+and both surfaces included rich metadata such as summaries, outcomes, metrics,
+status, or helper copy. Hover and recommendation emphasis made the marker label
+visible while the world tooltip also appeared, creating duplicate 3D detail
+layers for the same POI.
+
+## Fix summary
+
+- The 2D viewport overlay remains the only rich-details surface for title,
+  status, summary, outcome, metrics, links, and visited/recommended badges.
+- In-world POI canvases now render title-only cues.
+- The active POI marker label yields while the anchored world tooltip is visible,
+  leaving exactly one in-world cue for hovered, selected, and recommended POIs.
+- A narrow read-only Playwright hook exposes overlay/world tooltip state and the
+  active in-world tooltip count for regression coverage.
+
+## Validation steps
+
+- Open `/?mode=immersive&disablePerformanceFailover=1`.
+- Hover or focus Gitshelves.
+- Confirm the bottom-right 2D overlay still shows full details.
+- Confirm the scene shows one title-only in-world cue near the POI.
+- Confirm the in-world cue does not include summary, outcome, metrics, status,
+  links, or helper copy such as “Interact to inspect” or “Next highlight”.
+
+## Validation commands
+
+- `npm run format:write`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:ci`
+- `npm run test:e2e -- --grep "tooltip|POI|immersive"`
+- `npm run docs:check`
+- `npm run smoke`

--- a/playwright/poi-tooltips.spec.ts
+++ b/playwright/poi-tooltips.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+
+interface PoiTooltipStateApi {
+  getTooltipState(): {
+    overlayPoiId: string | null;
+    overlayVisible: boolean;
+    overlayTitle: string;
+    overlaySummary: string;
+    overlayOutcome: string;
+    overlayMetrics: string[];
+    worldTooltipPoiId: string | null;
+    worldTooltipVisible: boolean;
+    worldTooltipTitle: string | null;
+    activeMarkerLabelVisible: boolean;
+    activeInWorldTooltipCount: number;
+  };
+}
+
+interface PortfolioWindow extends Window {
+  portfolio?: {
+    poi?: PoiTooltipStateApi;
+  };
+}
+
+test.describe('POI tooltips', () => {
+  test('keeps rich details in the overlay and one title-only in-world cue', async ({
+    page,
+  }) => {
+    await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    const overlay = page.locator('.poi-tooltip-overlay');
+    await expect(overlay).toHaveAttribute(
+      'data-state',
+      /recommended|hovered|selected/
+    );
+    await expect(overlay).toHaveAttribute('aria-hidden', 'false');
+
+    await page.waitForFunction(
+      () =>
+        (window as PortfolioWindow).portfolio?.poi?.getTooltipState()
+          .activeInWorldTooltipCount === 1,
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    const state = await page.evaluate(() =>
+      (window as PortfolioWindow).portfolio?.poi?.getTooltipState()
+    );
+    expect(state).toBeTruthy();
+    expect(state?.overlayVisible).toBe(true);
+    expect(state?.overlayPoiId).toBe(state?.worldTooltipPoiId);
+    expect(state?.worldTooltipVisible).toBe(true);
+    expect(state?.worldTooltipTitle).toBe(state?.overlayTitle);
+    expect(state?.activeMarkerLabelVisible).toBe(false);
+    expect(state?.activeInWorldTooltipCount).toBe(1);
+    expect(state?.overlaySummary.length).toBeGreaterThan(0);
+    expect(
+      state?.overlayOutcome.length || state?.overlayMetrics.join('').length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -435,6 +435,23 @@ declare global {
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
+      poi?: {
+        getTooltipState(): {
+          overlayPoiId: string | null;
+          overlayVisible: boolean;
+          overlayState: string | null;
+          overlayTitle: string;
+          overlaySummary: string;
+          overlayOutcome: string;
+          overlayMetrics: string[];
+          worldTooltipPoiId: string | null;
+          worldTooltipVisible: boolean;
+          worldTooltipMode: string | null;
+          worldTooltipTitle: string | null;
+          activeMarkerLabelVisible: boolean;
+          activeInWorldTooltipCount: number;
+        };
+      };
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -1507,11 +1524,20 @@ function initializeImmersiveScene(
     interactionTimeline,
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  let currentHoveredPoi: PoiDefinition | null = null;
+  let currentSelectedPoi: PoiDefinition | null = null;
+  let currentRecommendedPoi: PoiDefinition | null = null;
+  let poiIdle = false;
+  const getActiveWorldTooltipPoi = () =>
+    currentSelectedPoi ??
+    currentHoveredPoi ??
+    (poiIdle ? currentRecommendedPoi : null);
   idleMonitor = new IdleMonitor({
     windowTarget: window,
     elementTargets: [renderer.domElement],
   });
   removeIdleSubscription = idleMonitor.subscribe((idle) => {
+    poiIdle = idle;
     poiTooltipOverlay.setIdleState(idle);
     poiWorldTooltip.setIdleState(idle);
   });
@@ -1654,6 +1680,7 @@ function initializeImmersiveScene(
   });
   removeGuidedTourSubscription = guidedTourChannel.subscribe(
     (recommendation) => {
+      currentRecommendedPoi = recommendation;
       poiTooltipOverlay.setRecommendation(recommendation);
       poiWorldTooltip.setRecommendation(
         resolveWorldTooltipTarget(recommendation)
@@ -1897,11 +1924,13 @@ function initializeImmersiveScene(
     poiAnalytics
   );
   const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
+    currentHoveredPoi = poi;
     poiTooltipOverlay.setHovered(poi);
     poiWorldTooltip.setHovered(resolveWorldTooltipTarget(poi));
   });
   const removeSelectionStateListener =
     poiInteractionManager.addSelectionStateListener((poi, context) => {
+      currentSelectedPoi = poi;
       poiTooltipOverlay.setSelected(poi, context);
       poiWorldTooltip.setSelected(resolveWorldTooltipTarget(poi));
     });
@@ -2256,6 +2285,56 @@ function initializeImmersiveScene(
     };
   };
   ensureWorldApi();
+  const ensurePoiApi = () => {
+    const portfolioWindow = window as Window;
+    if (!portfolioWindow.portfolio) {
+      portfolioWindow.portfolio = {};
+    }
+    portfolioWindow.portfolio.poi = {
+      getTooltipState() {
+        const overlayRoot = container.querySelector<HTMLElement>(
+          '.poi-tooltip-overlay'
+        );
+        const worldState = poiWorldTooltip.getState();
+        const activePoi = getActiveWorldTooltipPoi();
+        const activeMarkerLabelVisible = poiInstances.some(
+          (poi) =>
+            poi.definition.id === activePoi?.id && poi.label?.visible === true
+        );
+        const overlayMetrics = Array.from(
+          container.querySelectorAll<HTMLElement>(
+            '.poi-tooltip-overlay__metric'
+          )
+        ).map((metric) => metric.textContent?.trim() ?? '');
+        const overlayOutcome = container
+          .querySelector<HTMLElement>('.poi-tooltip-overlay__outcome-value')
+          ?.textContent?.trim();
+        return {
+          overlayPoiId: overlayRoot?.dataset.poiId ?? null,
+          overlayVisible: overlayRoot?.dataset.state !== 'hidden',
+          overlayState: overlayRoot?.dataset.state ?? null,
+          overlayTitle:
+            container
+              .querySelector<HTMLElement>('.poi-tooltip-overlay__title')
+              ?.textContent?.trim() ?? '',
+          overlaySummary:
+            container
+              .querySelector<HTMLElement>('.poi-tooltip-overlay__summary')
+              ?.textContent?.trim() ?? '',
+          overlayOutcome: overlayOutcome ?? '',
+          overlayMetrics,
+          worldTooltipPoiId: worldState.poiId,
+          worldTooltipVisible: worldState.visible,
+          worldTooltipMode: worldState.mode,
+          worldTooltipTitle: worldState.title,
+          activeMarkerLabelVisible,
+          activeInWorldTooltipCount:
+            (worldState.visible ? 1 : 0) + (activeMarkerLabelVisible ? 1 : 0),
+        };
+      },
+    };
+  };
+  ensurePoiApi();
   const getAvatarAssetPipeline = () => {
     if (!avatarAssetPipeline) {
       avatarAssetPipeline = createAvatarAssetPipeline({
@@ -3758,7 +3837,12 @@ function initializeImmersiveScene(
       }
 
       if (poi.label && poi.labelMaterial) {
-        const labelOpacity = computePoiLabelOpacity(emphasis, visitedEmphasis);
+        const activeWorldTooltipPoi = getActiveWorldTooltipPoi();
+        const shouldYieldToWorldTooltip =
+          activeWorldTooltipPoi?.id === poi.definition.id;
+        const labelOpacity = shouldYieldToWorldTooltip
+          ? 0
+          : computePoiLabelOpacity(emphasis, visitedEmphasis);
         poi.labelMaterial.opacity = labelOpacity;
         poi.label.visible = labelOpacity > 0.05;
       }

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -250,8 +250,8 @@ function createPedestalPoiInstance(
     depthWrite: false,
   });
   labelMaterial.side = DoubleSide;
-  const labelHeight = scalePoiValue(1.2);
-  const labelWidth = scalePoiValue(2.7);
+  const labelHeight = scalePoiValue(0.75);
+  const labelWidth = scalePoiValue(2.35);
   const labelGeometry = new PlaneGeometry(labelWidth, labelHeight, 1, 1);
   const label = new Mesh(labelGeometry, labelMaterial);
   const labelBaseHeight = orbBaseHeight + orbRadius + scalePoiValue(0.4);
@@ -442,10 +442,12 @@ function createDisplayPoiInstance(
   };
 }
 
-function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
+export function createPoiLabelTexture(
+  definition: PoiDefinition
+): CanvasTexture {
   const canvas = document.createElement('canvas');
   canvas.width = 640;
-  canvas.height = 320;
+  canvas.height = 180;
   const context = canvas.getContext('2d');
   if (!context) {
     throw new Error('Unable to acquire 2D context for POI label.');
@@ -461,7 +463,7 @@ function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
   gradient.addColorStop(0, 'rgba(33, 108, 255, 0.92)');
   gradient.addColorStop(1, 'rgba(20, 188, 255, 0.55)');
 
-  context.fillStyle = 'rgba(6, 20, 32, 0.84)';
+  context.fillStyle = 'rgba(6, 20, 32, 0.82)';
   context.strokeStyle = 'rgba(112, 214, 255, 0.68)';
   context.lineWidth = 4;
   const padding = 24;
@@ -477,76 +479,14 @@ function createPoiLabelTexture(definition: PoiDefinition): CanvasTexture {
   context.stroke();
 
   context.fillStyle = gradient;
-  context.font = 'bold 64px "Inter", "Segoe UI", sans-serif';
+  context.font = 'bold 58px "Inter", "Segoe UI", sans-serif';
   context.textAlign = 'left';
-  context.textBaseline = 'top';
-  context.fillText(definition.title, padding * 1.5, padding * 1.35);
-
-  const summaryY = padding * 1.35 + 84;
-  context.font = '28px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = 'rgba(220, 245, 255, 0.92)';
-  wrapText(
-    context,
-    definition.summary,
-    padding * 1.5,
-    summaryY,
-    canvas.width - padding * 3,
-    40
-  );
-
-  if (definition.metrics && definition.metrics.length > 0) {
-    const metricsY = canvas.height - padding * 2.1;
-    const metricText = definition.metrics
-      .slice(0, 2)
-      .map((metric) => `${metric.label}: ${metric.value}`)
-      .join('   •   ');
-    context.font = '26px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(160, 226, 255, 0.95)';
-    context.fillText(metricText, padding * 1.5, metricsY);
-  }
-
-  if (definition.status) {
-    const statusText = definition.status === 'prototype' ? 'Prototype' : 'Live';
-    context.font = '24px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(255, 255, 255, 0.75)';
-    const textWidth = context.measureText(statusText).width;
-    context.fillText(
-      statusText,
-      canvas.width - padding * 1.5 - textWidth,
-      padding * 1.4
-    );
-  }
+  context.textBaseline = 'middle';
+  context.fillText(definition.title, padding * 1.5, canvas.height / 2);
 
   const texture = new CanvasTexture(canvas);
   texture.needsUpdate = true;
   return texture;
-}
-
-function wrapText(
-  context: CanvasRenderingContext2D,
-  text: string,
-  x: number,
-  y: number,
-  maxWidth: number,
-  lineHeight: number
-) {
-  const words = text.split(' ');
-  let line = '';
-  let cursorY = y;
-  for (const word of words) {
-    const nextLine = line ? `${line} ${word}` : word;
-    const metrics = context.measureText(nextLine);
-    if (metrics.width > maxWidth && line) {
-      context.fillText(line, x, cursorY);
-      line = word;
-      cursorY += lineHeight;
-    } else {
-      line = nextLine;
-    }
-  }
-  if (line) {
-    context.fillText(line, x, cursorY);
-  }
 }
 
 function roundRect(

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -230,6 +230,7 @@ export class PoiTooltipOverlay {
       this.root.dataset.state = 'hidden';
       this.root.setAttribute('aria-hidden', 'true');
       this.root.removeAttribute('aria-describedby');
+      delete this.root.dataset.poiId;
       this.renderState.poiId = null;
       this.visitedBadge.hidden = true;
       this.recommendationBadge.hidden = true;
@@ -244,6 +245,7 @@ export class PoiTooltipOverlay {
         ? 'selected'
         : 'recommended';
     this.root.dataset.state = state;
+    this.root.dataset.poiId = poi.id;
     this.root.classList.add('poi-tooltip-overlay--visible');
     this.root.setAttribute('aria-hidden', 'false');
 

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -43,6 +43,7 @@ export interface PoiWorldTooltipOptions {
 interface RenderState {
   poiId: string | null;
   mode: PoiWorldTooltipMode | null;
+  title: string | null;
 }
 
 interface TooltipStateSnapshot {
@@ -50,12 +51,13 @@ interface TooltipStateSnapshot {
   mode: PoiWorldTooltipMode | null;
   visible: boolean;
   opacity: number;
+  title: string | null;
 }
 
 /**
- * Renders an in-world tooltip card that anchors to a POI and always faces the
- * active camera. The card mirrors the accessible overlay metadata while
- * keeping the content grounded inside the immersive scene.
+ * Renders a compact in-world title cue that anchors to a POI and always faces
+ * the active camera. Rich details stay in the accessible viewport overlay so
+ * the immersive scene only has one lightweight POI surface.
  */
 export class PoiWorldTooltip {
   public readonly group: Group;
@@ -122,15 +124,15 @@ export class PoiWorldTooltip {
 
   private opacity = 0;
 
-  private renderState: RenderState = { poiId: null, mode: null };
+  private renderState: RenderState = { poiId: null, mode: null, title: null };
 
   private disposed = false;
 
   constructor(options: PoiWorldTooltipOptions) {
     this.camera = options.camera;
-    this.cardWidth = options.width ?? 2.6;
-    this.cardHeight = options.height ?? 1.35;
-    this.verticalOffset = options.verticalOffset ?? 0.6;
+    this.cardWidth = options.width ?? 2.15;
+    this.cardHeight = options.height ?? 0.58;
+    this.verticalOffset = options.verticalOffset ?? 0.45;
     this.fadeResponse = options.fadeResponse ?? 10;
     this.positionResponse = options.positionResponse ?? 12;
     this.scaleDistance = options.scaleDistance ?? 14;
@@ -246,7 +248,7 @@ export class PoiWorldTooltip {
       this.opacity = 0;
       this.mesh.material.opacity = 0;
       this.group.visible = false;
-      this.renderState = { poiId: null, mode: null };
+      this.renderState = { poiId: null, mode: null, title: null };
       return;
     }
 
@@ -281,7 +283,11 @@ export class PoiWorldTooltip {
 
     if (targetChanged) {
       this.renderTooltip(active.poi, mode);
-      this.renderState = { poiId: active.poi.id, mode };
+      this.renderState = {
+        poiId: active.poi.id,
+        mode,
+        title: active.poi.title,
+      };
     }
   }
 
@@ -327,6 +333,7 @@ export class PoiWorldTooltip {
       mode: this.renderState.mode,
       visible: this.group.visible,
       opacity: this.mesh.material.opacity,
+      title: this.renderState.title,
     };
   }
 
@@ -357,7 +364,7 @@ export class PoiWorldTooltip {
     this.mesh.material.opacity = this.opacity;
     if (this.opacity <= 0.01) {
       this.group.visible = false;
-      this.renderState = { poiId: null, mode: null };
+      this.renderState = { poiId: null, mode: null, title: null };
     }
   }
 
@@ -367,8 +374,8 @@ export class PoiWorldTooltip {
 
     context.clearRect(0, 0, width, height);
 
-    const padding = 72;
-    const radius = 36;
+    const padding = 80;
+    const radius = 42;
     const outline =
       mode === 'selected'
         ? 'rgba(170, 255, 255, 0.95)'
@@ -377,7 +384,7 @@ export class PoiWorldTooltip {
           : 'rgba(114, 224, 255, 0.68)';
 
     this.drawCardBackground({
-      fill: 'rgba(8, 22, 38, 0.94)',
+      fill: 'rgba(8, 22, 38, 0.92)',
       outline,
       x: padding,
       y: padding,
@@ -386,99 +393,24 @@ export class PoiWorldTooltip {
       radius,
     });
 
-    const accentGradient = context.createLinearGradient(
-      0,
+    const titleGradient = context.createLinearGradient(
       padding,
-      0,
-      padding + 96
+      height / 2,
+      width - padding,
+      height / 2
     );
-    accentGradient.addColorStop(0, 'rgba(33, 116, 255, 0.75)');
-    accentGradient.addColorStop(1, 'rgba(21, 192, 255, 0.35)');
-    context.fillStyle = accentGradient;
-    this.drawRoundedRect(
-      padding + 4,
-      padding + 4,
-      width - padding * 2 - 8,
-      96,
-      radius * 0.6
-    );
-    context.fill();
+    titleGradient.addColorStop(0, 'rgba(223, 246, 255, 0.98)');
+    titleGradient.addColorStop(1, 'rgba(139, 232, 255, 0.95)');
 
-    context.fillStyle = 'rgba(223, 246, 255, 0.92)';
-    context.font = 'bold 88px "Inter", "Segoe UI", sans-serif';
-    context.textAlign = 'left';
-    context.textBaseline = 'alphabetic';
-    const titleX = padding + 48;
-    const titleY = padding + 96;
+    context.fillStyle = titleGradient;
     this.fillWrappedText(poi.title, {
-      x: titleX,
-      y: titleY,
-      maxWidth: width - padding * 3,
-      lineHeight: 92,
+      x: padding + 54,
+      y: height / 2 - 18,
+      maxWidth: width - padding * 2 - 108,
+      lineHeight: 82,
       maxLines: 2,
-      font: 'bold 88px "Inter", "Segoe UI", sans-serif',
+      font: 'bold 76px "Inter", "Segoe UI", sans-serif',
     });
-
-    context.font = '36px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(210, 236, 255, 0.92)';
-    const summaryY = titleY + 96;
-    const summaryBottom = this.fillWrappedText(poi.summary, {
-      x: titleX,
-      y: summaryY,
-      maxWidth: width - padding * 3,
-      lineHeight: 54,
-      maxLines: 3,
-      font: '36px "Inter", "Segoe UI", sans-serif',
-    });
-
-    let contentBottom = summaryBottom;
-
-    if (poi.outcome && poi.outcome.value.trim()) {
-      const outcomeLabel = poi.outcome.label?.trim() || 'Outcome';
-      const outcomeText = `${outcomeLabel}: ${poi.outcome.value.trim()}`;
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.fillStyle = 'rgba(172, 234, 255, 0.96)';
-      contentBottom = this.fillWrappedText(outcomeText, {
-        x: titleX,
-        y: summaryBottom + 54,
-        maxWidth: width - padding * 3,
-        lineHeight: 48,
-        maxLines: 2,
-        font: '34px "Inter", "Segoe UI", sans-serif',
-      });
-    }
-
-    if (poi.metrics && poi.metrics.length > 0) {
-      const metricText = poi.metrics
-        .slice(0, 2)
-        .map((metric) => `${metric.label}: ${metric.value}`)
-        .join('   •   ');
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.fillStyle = 'rgba(164, 232, 255, 0.95)';
-      const metricsY = Math.max(contentBottom + 54, height - padding * 1.6);
-      context.fillText(metricText, titleX, metricsY);
-    }
-
-    if (poi.status) {
-      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
-      context.font = '34px "Inter", "Segoe UI", sans-serif';
-      context.textAlign = 'right';
-      context.fillStyle = 'rgba(220, 242, 255, 0.88)';
-      const badgeX = width - padding - 32;
-      const badgeY = padding + 64;
-      context.fillText(statusLabel, badgeX, badgeY);
-      context.textAlign = 'left';
-    }
-
-    context.font = '28px "Inter", "Segoe UI", sans-serif';
-    context.fillStyle = 'rgba(148, 230, 255, 0.88)';
-    const modeLabel =
-      mode === 'selected'
-        ? 'Selected exhibit'
-        : mode === 'hovered'
-          ? 'Interact to inspect'
-          : 'Next highlight';
-    context.fillText(modeLabel, titleX, padding + 48);
 
     this.texture.needsUpdate = true;
   }

--- a/src/tests/poiMarkerLabels.test.ts
+++ b/src/tests/poiMarkerLabels.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPoiLabelTexture } from '../scene/poi/markers';
+import type { PoiDefinition } from '../scene/poi/types';
+
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+beforeAll(() => {
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function () {
+    const context = createMockCanvasContext();
+    (
+      this as HTMLCanvasElement & { __mockContext?: CanvasRenderingContext2D }
+    ).__mockContext = context;
+    return context;
+  };
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+});
+
+function createMockCanvasContext(): CanvasRenderingContext2D {
+  const fillTextLog: string[] = [];
+  const context = {
+    canvas: document.createElement('canvas'),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    clearRect: () => {},
+    beginPath: () => {},
+    closePath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    quadraticCurveTo: () => {},
+    fill: () => {},
+    stroke: () => {},
+    createLinearGradient: () => ({ addColorStop: () => {} }),
+    fillText: (text: string) => {
+      fillTextLog.push(text);
+    },
+  };
+  (context as { __fillTextLog?: string[] }).__fillTextLog = fillTextLog;
+  return context as unknown as CanvasRenderingContext2D;
+}
+
+function createPoiDefinition(): PoiDefinition {
+  return {
+    id: 'gitshelves-living-room-installation',
+    title: 'Gitshelves Living Room Array',
+    summary: 'A rich shelving summary that should only appear in the overlay.',
+    interactionPrompt: 'Inspect Gitshelves Living Room Array',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'livingRoom',
+    position: { x: 0, y: 0, z: 0 },
+    interactionRadius: 3,
+    footprint: { width: 2, depth: 2 },
+    outcome: { label: 'Outcome', value: 'Mapped a personal library' },
+    metrics: [{ label: 'Shelves', value: '200+' }],
+    links: [{ label: 'Read more', href: '#' }],
+    status: 'live',
+  } as PoiDefinition;
+}
+
+describe('createPoiLabelTexture', () => {
+  it('draws a compact title-only marker label', () => {
+    const poi = createPoiDefinition();
+    const texture = createPoiLabelTexture(poi);
+    const context = (
+      texture.image as HTMLCanvasElement & {
+        __mockContext: CanvasRenderingContext2D & { __fillTextLog: string[] };
+      }
+    ).__mockContext;
+
+    expect(context.__fillTextLog).toContain(poi.title);
+    expect(context.__fillTextLog).not.toContain(poi.summary);
+    expect(context.__fillTextLog).not.toContain('Shelves: 200+');
+    expect(context.__fillTextLog).not.toContain('Live');
+  });
+});

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -158,6 +158,39 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('renders only the POI title in the in-world canvas', () => {
+    const { tooltip, preference } = createTooltip();
+    const poi = createPoiDefinition({
+      title: 'Gitshelves Living Room Array',
+      summary: 'Full detail summary belongs in the viewport overlay.',
+      outcome: { label: 'Outcome', value: 'Catalogued 200 shelves' },
+      metrics: [{ label: 'Impact', value: 'Title-only cue' }],
+      status: 'prototype',
+    });
+
+    tooltip.setHovered(createTarget(poi, new Vector3(0, 1, 0)));
+    tooltip.update(0.016);
+
+    const context = (
+      tooltip as unknown as {
+        context: CanvasRenderingContext2D & { __fillTextLog: string[] };
+      }
+    ).context;
+
+    expect(context.__fillTextLog).toContain(poi.title);
+    expect(context.__fillTextLog).not.toContain(poi.summary);
+    expect(context.__fillTextLog).not.toContain(
+      'Outcome: Catalogued 200 shelves'
+    );
+    expect(context.__fillTextLog).not.toContain('Impact: Title-only cue');
+    expect(context.__fillTextLog).not.toContain('Prototype');
+    expect(context.__fillTextLog).not.toContain('Interact to inspect');
+    expect(tooltip.getState().title).toBe(poi.title);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('culls tooltips positioned behind the camera view', () => {
     const { tooltip, preference } = createTooltip();
     const poi = createPoiDefinition({ id: 'behind-camera-poi' });
@@ -203,7 +236,7 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
-  it('re-renders the active card when metrics change', () => {
+  it('re-renders the active title cue without drawing changed metrics', () => {
     const { tooltip, preference } = createTooltip();
     const poi = createPoiDefinition({
       id: 'flywheel-studio-flywheel',
@@ -232,11 +265,11 @@ describe('PoiWorldTooltip', () => {
 
     expect(context.__fillTextLog.length).toBeGreaterThan(initialLength);
     const newEntries = context.__fillTextLog.slice(initialLength);
-    const metricEntry = newEntries.find((entry) =>
-      entry.includes('Live 2,000')
+    expect(newEntries).toContain(poi.title);
+    expect(newEntries.some((entry) => entry.includes('Live 2,000'))).toBe(
+      false
     );
-    expect(metricEntry).toBeDefined();
-    expect(metricEntry).toContain('Impact');
+    expect(newEntries.some((entry) => entry.includes('Impact'))).toBe(false);
 
     tooltip.dispose();
     preference.dispose();


### PR DESCRIPTION
### Motivation
- Remove duplicate in-world POI detail cards so the immersive scene shows a single lightweight title-only cue while the rich details remain in the viewport overlay.

### Description
- Simplified `PoiWorldTooltip` to render a compact title-only in-world card and reduced its card dimensions and canvas content (removed summary/outcome/metrics/status/mode label). (`src/scene/poi/worldTooltip.ts`)
- Simplified pedestal POI marker label textures to title-only and reduced label plane size. (`src/scene/poi/markers.ts`)
- Make active marker labels yield to the anchored world tooltip by tracking current hover/selection/recommendation and setting marker label opacity to zero when that POI is the active world tooltip. (`src/main.ts`)
- Expose a narrow, read-only test hook `window.portfolio.poi.getTooltipState()` that reports overlay/world tooltip state, marker-label visibility, and an active in-world tooltip count for Playwright assertions. (`src/main.ts`)
- Add `data-poi-id` to the 2D overlay DOM state so tests can confirm overlay ↔ world tooltip consistency. (`src/scene/poi/tooltipOverlay.ts`)
- Add/update tests: Vitest tests verifying the world tooltip and marker label canvases render title-only and overlay retains full details, and a Playwright spec asserting exactly one in-world tooltip plus rich overlay content. (`src/tests/poiWorldTooltip.test.ts`, `src/tests/poiMarkerLabels.test.ts`, `playwright/poi-tooltips.spec.ts`)
- Add a standalone outage bookkeeping entry documenting the issue and validation steps. (`outages/2026-05-30-danielsmith-duplicate-poi-tooltips.md`, `.json`)

### Testing
- Ran code formatting: `npm run format:write` — success.
- Ran linter: `npm run lint` — success.
- Ran typecheck: `npm run typecheck` — known repo-wide TypeScript errors remain unrelated to this change (reported and intentionally out-of-scope for this focused UI fix).
- Ran unit tests: `npm run test:ci` — all Vitest suites passed (including updated POI tests).
- Ran Playwright e2e: `npm run test:e2e -- --grep "tooltip|POI|immersive"` — Playwright suites passed for the targeted immersive/tooltip specs after installing browser deps; the new `poi-tooltips` spec asserts one active in-world tooltip and rich overlay content.
- Docs and smoke: `npm run docs:check` and `npm run smoke` — success.

All changes are limited to POI tooltip/marker overlay code, tests, Playwright spec, and a standalone outage note; no renderer/adaptive-quality or GitHub metrics behavior was modified beyond minimal test hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8bc90a38832fa776e34cb9d1c4c5)