### PR TITLE
Quiet GitHub repo metric failures — cache/backoff & graceful fallback

### DIFF
--- a/outages/2026-05-30-danielsmith-github-api-403-noise.json
+++ b/outages/2026-05-30-danielsmith-github-api-403-noise.json
@@ -1,0 +1,38 @@
+{
+  "title": "danielsmith.io GitHub API 403 metrics noise",
+  "date": "2026-05-30",
+  "environment": "hardware-accelerated staging validation with live GitHub repo metrics enabled",
+  "status": "mitigation prepared for deployment validation",
+  "symptoms": [
+    "Repeated browser console/network entries appeared for unauthenticated api.github.com/repos/futuroptimist/* requests during performance validation.",
+    "Affected repositories included gabriel, token.place, flywheel, danielsmith.io, pr-reaper, gitshelves, wove, sigma, and f2clipboard.",
+    "The messages were not the primary FPS bottleneck, but they made performance investigations noisy and could be confused with console-budget or runtime failover signals."
+  ],
+  "rootCauseClass": "Unauthenticated browser GitHub REST API fan-out encountering rate-limit, forbidden, or access-policy behavior while fetching optional project-card metrics.",
+  "mitigation": [
+    "GitHub repo metrics remain optional browser-only enhancements with no token, secret, proxy, or backend.",
+    "Successful live metrics are cached in browser storage and reused as stale values on later loads.",
+    "403 and 429 responses enter bounded browser-storage backoff so remaining repo requests are suppressed during the TTL.",
+    "Network failures and timeouts also enter bounded backoff to avoid repeated unavailable API attempts during a session.",
+    "Project cards continue rendering static fallback metrics when live metrics are unavailable.",
+    "Diagnostics expose metrics source, last error status, request count, suppressed request count, and backoff expiration.",
+    "App-level logging is grouped into at most one console.warn per metrics service instance and never uses console.error, keeping GitHub metric failures independent of performance failover."
+  ],
+  "validationSteps": [
+    "Open /?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1 with GitHub API requests mocked to return 403.",
+    "Confirm immersive mode loads and no performancefailover event fires.",
+    "Confirm only the first GitHub repo request is attempted before backoff suppresses remaining fan-out.",
+    "Confirm POI overlay/project content still shows fallback metric values.",
+    "Inspect window.portfolio.github.getRepoMetricsDiagnostics() for static-fallback source, lastErrorStatus 403, one request, and a backoff expiration.",
+    "Repeat with a successful GitHub API response and confirm live values cache and render."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"github|metrics|fallback|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-github-api-403-noise.md
+++ b/outages/2026-05-30-danielsmith-github-api-403-noise.md
@@ -1,0 +1,71 @@
+# danielsmith.io GitHub API 403 metrics noise
+
+- **Date:** 2026-05-30
+- **Environment:** hardware-accelerated staging validation with live GitHub repo metrics enabled
+- **Status:** Mitigation prepared for deployment validation
+
+## Symptoms
+
+Hardware-accelerated immersive validation showed repeated browser console/network
+entries for unauthenticated GitHub repository API requests, including
+`api.github.com/repos/futuroptimist/gabriel`, `token.place`, `flywheel`,
+`danielsmith.io`, `pr-reaper`, `gitshelves`, `wove`, `sigma`, and
+`f2clipboard`. The scene itself could continue rendering, but the repeated 403
+resource messages made performance investigations noisy and risked confusion
+with console-budget or runtime failover signals.
+
+## Root cause class
+
+The live project-card metrics used unauthenticated browser requests to the
+GitHub REST API. When GitHub rejected the first request because of rate limits,
+access policy, or unauthenticated quota behavior, the existing refresh path could
+fan out across the remaining repositories on the same page load. Those failures
+were not required for core portfolio content because every project already ships
+with static fallback copy and metric labels.
+
+## Mitigation
+
+- GitHub repo metrics remain optional browser-only enhancements; no token,
+  secret, proxy, or backend was introduced.
+- Successful live responses are cached in browser storage and reused as stale
+  project metrics on later loads.
+- A 403 or 429 response enters a bounded browser-storage backoff so later repo
+  requests are suppressed during the TTL instead of fanning out through the full
+  project list.
+- Network failures and timeouts also enter the same bounded backoff to avoid
+  repeated unavailable API attempts during a session.
+- Project cards keep rendering static fallback metric values when live metrics
+  are unavailable.
+- The metrics service exposes concise diagnostics: source (`live`, `cached`, or
+  `static-fallback`), last error status, request count, suppressed request count,
+  and backoff expiration.
+- App-level logging is grouped into at most one `console.warn` per metrics
+  service instance and never uses `console.error`, keeping repo metric failures
+  out of performance-failover and console-budget criteria.
+
+## Validation steps
+
+1. Open `/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1`
+   with GitHub API requests mocked to return 403.
+2. Confirm the immersive scene reaches `document.documentElement.dataset.appMode
+=== 'immersive'` and no `performancefailover` event fires.
+3. Confirm only the first GitHub repo request is attempted before backoff
+   suppresses the remaining repo fan-out.
+4. Confirm the POI overlay/project content still shows fallback metric values.
+5. Inspect `window.portfolio.github.getRepoMetricsDiagnostics()` and confirm it
+   reports `source: 'static-fallback'`, `lastErrorStatus: 403`, one live request,
+   and a backoff expiration timestamp.
+6. Repeat with a successful GitHub API response and confirm live values cache and
+   render.
+
+## Expected validation commands
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "github|metrics|fallback|immersive"
+npm run docs:check
+npm run smoke
+```

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const LIVE_METRICS_PREVIEW_URL =
+  '/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1';
+
+async function waitForImmersive(page: Page) {
+  await page.goto(LIVE_METRICS_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+}
+
+test.describe('GitHub metrics fallback', () => {
+  test('keeps immersive stable and suppresses fan-out when GitHub returns 403', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    const githubWarnings: string[] = [];
+    let githubApiRequests = 0;
+
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+      if (
+        message.type() === 'warning' &&
+        message.text().includes('[github-metrics]')
+      ) {
+        githubWarnings.push(message.text());
+      }
+    });
+
+    await page.route('https://api.github.com/repos/**', async (route) => {
+      githubApiRequests += 1;
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'API rate limit exceeded' }),
+      });
+    });
+
+    await page.addInitScript(() => {
+      window.addEventListener('performancefailover', () => {
+        document.documentElement.dataset.githubMetricsPerformanceFailover = '1';
+      });
+    });
+
+    await waitForImmersive(page);
+
+    await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
+    await expect(page.locator('#app canvas')).toHaveCount(1);
+
+    await page.keyboard.press('KeyE');
+    const tooltip = page.locator('.poi-tooltip-overlay');
+    await expect(tooltip).toHaveAttribute('aria-hidden', 'false');
+    await expect(tooltip.locator('.poi-tooltip-overlay__title')).not.toHaveText(
+      ''
+    );
+    await expect(
+      tooltip.locator('.poi-tooltip-overlay__metric-value').first()
+    ).not.toHaveText('');
+
+    const diagnostics = await page.evaluate(() =>
+      window.portfolio?.github?.getRepoMetricsDiagnostics()
+    );
+
+    expect(githubApiRequests).toBeLessThanOrEqual(1);
+    expect(githubWarnings.length).toBeLessThanOrEqual(1);
+    expect(
+      consoleErrors.filter((message) => message.includes('[github-metrics]'))
+    ).toEqual([]);
+    await expect(page.locator('html')).not.toHaveAttribute(
+      'data-github-metrics-performance-failover',
+      '1'
+    );
+    expect(diagnostics).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 403,
+      requestCount: 1,
+    });
+    expect(diagnostics?.backoffExpiresAt).toEqual(expect.any(Number));
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -435,6 +435,11 @@ declare global {
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
+      github?: {
+        getRepoMetricsDiagnostics(): ReturnType<
+          GitHubRepoMetricsController['getDiagnostics']
+        >;
+      };
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -1532,6 +1537,13 @@ function initializeImmersiveScene(
   githubRepoMetrics.refreshAll().catch(() => {
     /* GitHub may be unreachable; metrics will remain on fallback values. */
   });
+  const githubPortfolioWindow = window as Window;
+  if (!githubPortfolioWindow.portfolio) {
+    githubPortfolioWindow.portfolio = {};
+  }
+  githubPortfolioWindow.portfolio.github = {
+    getRepoMetricsDiagnostics: () => githubRepoStatsService.getDiagnostics(),
+  };
   const poiVisitedState = new PoiVisitedState();
   if (avatarAccessoryManager) {
     avatarAccessoryProgression = createAvatarAccessoryProgression({
@@ -4086,6 +4098,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.graphics) {
       delete window.portfolio.graphics;
+    }
+    if (window.portfolio?.github) {
+      delete window.portfolio.github;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/scene/poi/githubMetrics.ts
+++ b/src/scene/poi/githubMetrics.ts
@@ -1,5 +1,6 @@
 import type {
   GitHubRepoStats,
+  GitHubRepoStatsDiagnostics,
   GitHubRepoStatsService,
 } from '../../systems/github/repoStats';
 
@@ -35,6 +36,7 @@ export interface WireGitHubRepoMetricsOptions {
 }
 
 export interface GitHubRepoMetricsController {
+  getDiagnostics(): GitHubRepoStatsDiagnostics;
   refreshAll(): Promise<void>;
   dispose(): void;
 }
@@ -146,12 +148,12 @@ export function wireGitHubRepoMetrics({
   });
 
   const refreshAll = async () => {
-    await Promise.all(
-      Array.from(repoMap.values()).map((bucket) =>
-        service.requestStats(bucket.identifier)
-      )
-    );
+    for (const bucket of repoMap.values()) {
+      await service.requestStats(bucket.identifier);
+    }
   };
+
+  const getDiagnostics = () => service.getDiagnostics();
 
   const dispose = () => {
     disposables.splice(0).forEach((fn) => {
@@ -164,6 +166,7 @@ export function wireGitHubRepoMetrics({
   };
 
   return {
+    getDiagnostics,
     refreshAll,
     dispose,
   };

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -11,10 +11,21 @@ export interface GitHubRepoStats {
   pushedAt: string | null;
 }
 
+export type GitHubRepoMetricsSource = 'live' | 'cached' | 'static-fallback';
+
+export interface GitHubRepoStatsDiagnostics {
+  source: GitHubRepoMetricsSource;
+  lastErrorStatus: number | 'network' | 'timeout' | 'backoff' | null;
+  requestCount: number;
+  backoffExpiresAt: number | null;
+  suppressedRequestCount: number;
+}
+
 export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
 
 export interface GitHubRepoStatsService {
   getCachedStats(identifier: GitHubRepoIdentifier): GitHubRepoStats | null;
+  getDiagnostics(): GitHubRepoStatsDiagnostics;
   requestStats(
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null>;
@@ -29,6 +40,38 @@ const DEFAULT_HEADERS = {
   'User-Agent': 'danielsmith.io-github-metrics',
 } as const;
 
+const CACHE_STORAGE_PREFIX = 'danielsmith.io:github-repo-stats:';
+const BACKOFF_STORAGE_KEY = 'danielsmith.io:github-repo-stats:backoff';
+const DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 3500;
+const DEFAULT_MAX_LIVE_REQUESTS = 16;
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+interface CacheRecord {
+  stats: GitHubRepoStats;
+  cachedAt: number;
+}
+
+interface BackoffRecord {
+  expiresAt: number;
+  status: number | 'network' | 'timeout' | 'backoff';
+}
+
+export interface GitHubRepoStatsServiceOptions {
+  allowLiveFetch?: boolean;
+  backoffMs?: number;
+  maxLiveRequests?: number;
+  now?: () => number;
+  storage?: StorageLike | null;
+  timeoutMs?: number;
+  warn?: Pick<Console, 'warn'> | null;
+}
+
 const sanitizeNumber = (value: unknown): number => {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -42,6 +85,102 @@ const sanitizeNumber = (value: unknown): number => {
 
 const makeCacheKey = ({ owner, repo }: GitHubRepoIdentifier): string =>
   `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+
+const makeStorageKey = (identifier: GitHubRepoIdentifier): string =>
+  `${CACHE_STORAGE_PREFIX}${makeCacheKey(identifier)}`;
+
+const isStorageLike = (value: unknown): value is StorageLike => {
+  const candidate = value as Partial<StorageLike> | null | undefined;
+  return (
+    !!candidate &&
+    typeof candidate.getItem === 'function' &&
+    typeof candidate.setItem === 'function' &&
+    typeof candidate.removeItem === 'function'
+  );
+};
+
+const getDefaultStorage = (): StorageLike | null => {
+  try {
+    if (isStorageLike(globalThis.localStorage)) {
+      return globalThis.localStorage;
+    }
+  } catch {
+    // Browser storage can be disabled; metrics remain best-effort.
+  }
+  return null;
+};
+
+const readJson = <T>(storage: StorageLike | null, key: string): T | null => {
+  if (!storage) {
+    return null;
+  }
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
+const writeJson = (
+  storage: StorageLike | null,
+  key: string,
+  value: unknown
+) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Cache writes are optional and must never affect the immersive scene.
+  }
+};
+
+const removeStorageItem = (storage: StorageLike | null, key: string) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Cache cleanup is optional.
+  }
+};
+
+const parseCachedStats = (
+  record: CacheRecord | null
+): GitHubRepoStats | null => {
+  const stats = record?.stats;
+  if (!stats) {
+    return null;
+  }
+  return {
+    stars: sanitizeNumber(stats.stars),
+    watchers: sanitizeNumber(stats.watchers),
+    forks: sanitizeNumber(stats.forks),
+    openIssues: sanitizeNumber(stats.openIssues),
+    pushedAt: typeof stats.pushedAt === 'string' ? stats.pushedAt : null,
+  };
+};
+
+const readBackoff = (
+  storage: StorageLike | null,
+  now: number
+): BackoffRecord | null => {
+  const record = readJson<BackoffRecord>(storage, BACKOFF_STORAGE_KEY);
+  if (!record || !Number.isFinite(record.expiresAt)) {
+    return null;
+  }
+  if (record.expiresAt <= now) {
+    removeStorageItem(storage, BACKOFF_STORAGE_KEY);
+    return null;
+  }
+  return record;
+};
 
 const shouldAttemptLiveFetch = (() => {
   const globalScope = globalThis as Partial<
@@ -65,18 +204,110 @@ const shouldAttemptLiveFetch = (() => {
   return false;
 })();
 
-export interface GitHubRepoStatsServiceOptions {
-  allowLiveFetch?: boolean;
-}
+const createTimeoutSignal = (
+  timeoutMs: number
+): { signal?: AbortSignal; dispose(): void; timedOut(): boolean } => {
+  if (typeof AbortController !== 'function' || timeoutMs <= 0) {
+    return { dispose() {}, timedOut: () => false };
+  }
+  const controller = new AbortController();
+  let didTimeOut = false;
+  const timeout = globalThis.setTimeout(() => {
+    didTimeOut = true;
+    controller.abort();
+  }, timeoutMs);
+  return {
+    signal: controller.signal,
+    dispose() {
+      globalThis.clearTimeout(timeout);
+    },
+    timedOut: () => didTimeOut,
+  };
+};
+
+const statusEntersBackoff = (status: number | 'network' | 'timeout'): boolean =>
+  status === 403 ||
+  status === 429 ||
+  status === 'network' ||
+  status === 'timeout';
 
 export function createGitHubRepoStatsService(
   fetchImpl: typeof fetch | undefined = globalThis.fetch,
   options: GitHubRepoStatsServiceOptions = {}
 ): GitHubRepoStatsService {
   const allowLiveFetch = options.allowLiveFetch ?? shouldAttemptLiveFetch;
+  const backoffMs = options.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const maxLiveRequests = options.maxLiveRequests ?? DEFAULT_MAX_LIVE_REQUESTS;
+  const now = options.now ?? Date.now;
+  const storage =
+    options.storage === undefined ? getDefaultStorage() : options.storage;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const warnTarget = options.warn === undefined ? console : options.warn;
   const cache = new Map<string, GitHubRepoStats>();
   const listeners = new Map<string, Set<GitHubRepoStatsListener>>();
   const inFlight = new Map<string, Promise<GitHubRepoStats | null>>();
+  let requestCount = 0;
+  let suppressedRequestCount = 0;
+  let warned = false;
+  let diagnostics: GitHubRepoStatsDiagnostics = {
+    source: 'static-fallback',
+    lastErrorStatus: null,
+    requestCount,
+    backoffExpiresAt: readBackoff(storage, now())?.expiresAt ?? null,
+    suppressedRequestCount,
+  };
+
+  const updateDiagnostics = (
+    patch: Partial<GitHubRepoStatsDiagnostics>
+  ): GitHubRepoStatsDiagnostics => {
+    diagnostics = {
+      ...diagnostics,
+      requestCount,
+      suppressedRequestCount,
+      ...patch,
+    };
+    return diagnostics;
+  };
+
+  const warnOnce = (status: GitHubRepoStatsDiagnostics['lastErrorStatus']) => {
+    if (warned || !warnTarget) {
+      return;
+    }
+    warned = true;
+    warnTarget.warn(
+      '[github-metrics] Live GitHub repo metrics are unavailable; using cached/static fallback values.',
+      { status, diagnostics: getDiagnostics() }
+    );
+  };
+
+  const enterBackoff = (
+    status: Exclude<BackoffRecord['status'], 'backoff'>
+  ) => {
+    const expiresAt = now() + backoffMs;
+    writeJson(storage, BACKOFF_STORAGE_KEY, { expiresAt, status });
+    updateDiagnostics({
+      source: diagnostics.source === 'cached' ? 'cached' : 'static-fallback',
+      lastErrorStatus: status,
+      backoffExpiresAt: expiresAt,
+    });
+    warnOnce(status);
+  };
+
+  const getStoredStats = (
+    identifier: GitHubRepoIdentifier
+  ): GitHubRepoStats | null =>
+    parseCachedStats(
+      readJson<CacheRecord>(storage, makeStorageKey(identifier))
+    );
+
+  const cacheStats = (
+    identifier: GitHubRepoIdentifier,
+    stats: GitHubRepoStats
+  ) => {
+    const key = makeCacheKey(identifier);
+    cache.set(key, stats);
+    writeJson(storage, makeStorageKey(identifier), { stats, cachedAt: now() });
+  };
 
   const notify = (key: string, stats: GitHubRepoStats) => {
     const repoListeners = listeners.get(key);
@@ -96,7 +327,19 @@ export function createGitHubRepoStatsService(
     identifier: GitHubRepoIdentifier
   ): GitHubRepoStats | null => {
     const key = makeCacheKey(identifier);
-    return cache.get(key) ?? null;
+    const cached = cache.get(key) ?? getStoredStats(identifier);
+    if (cached) {
+      cache.set(key, cached);
+      updateDiagnostics({ source: 'cached' });
+    }
+    return cached ?? null;
+  };
+
+  const getDiagnostics = (): GitHubRepoStatsDiagnostics => {
+    const backoff = readBackoff(storage, now());
+    return updateDiagnostics({
+      backoffExpiresAt: backoff?.expiresAt ?? null,
+    });
   };
 
   const subscribe = (
@@ -111,7 +354,7 @@ export function createGitHubRepoStatsService(
     }
     repoListeners.add(listener);
 
-    const cached = cache.get(key);
+    const cached = getCachedStats(identifier);
     if (cached) {
       queueMicrotask(() => listener(cached));
     }
@@ -132,7 +375,7 @@ export function createGitHubRepoStatsService(
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null> => {
     const key = makeCacheKey(identifier);
-    const cached = cache.get(key);
+    const cached = getCachedStats(identifier);
     if (cached) {
       return cached;
     }
@@ -141,17 +384,48 @@ export function createGitHubRepoStatsService(
       return existing;
     }
     if (!fetchImpl || !allowLiveFetch) {
+      updateDiagnostics({ source: 'static-fallback' });
+      return null;
+    }
+    const backoff = readBackoff(storage, now());
+    if (backoff) {
+      suppressedRequestCount += 1;
+      updateDiagnostics({
+        source: 'static-fallback',
+        lastErrorStatus: backoff.status,
+        backoffExpiresAt: backoff.expiresAt,
+      });
+      return null;
+    }
+    if (requestCount >= maxLiveRequests) {
+      suppressedRequestCount += 1;
+      updateDiagnostics({ source: 'static-fallback' });
       return null;
     }
 
     const promise = (async () => {
+      const timeout = createTimeoutSignal(timeoutMs);
+      requestCount += 1;
+      updateDiagnostics({});
       try {
         const response = await fetchImpl(
           `https://api.github.com/repos/${identifier.owner}/${identifier.repo}`,
-          { headers: DEFAULT_HEADERS }
+          { headers: DEFAULT_HEADERS, signal: timeout.signal }
         );
         if (!response.ok) {
-          return null;
+          const status = response.status;
+          if (statusEntersBackoff(status)) {
+            enterBackoff(status);
+          } else {
+            updateDiagnostics({
+              source: 'static-fallback',
+              lastErrorStatus: status,
+            });
+            if (status === 404) {
+              warnOnce(status);
+            }
+          }
+          return getCachedStats(identifier);
         }
         const data = (await response.json()) as Record<string, unknown>;
         const stats: GitHubRepoStats = {
@@ -163,12 +437,21 @@ export function createGitHubRepoStatsService(
           openIssues: sanitizeNumber(data.open_issues_count),
           pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
         };
-        cache.set(key, stats);
+        cacheStats(identifier, stats);
+        removeStorageItem(storage, BACKOFF_STORAGE_KEY);
+        updateDiagnostics({
+          source: 'live',
+          lastErrorStatus: null,
+          backoffExpiresAt: null,
+        });
         notify(key, stats);
         return stats;
       } catch {
-        return null;
+        const status = timeout.timedOut() ? 'timeout' : 'network';
+        enterBackoff(status);
+        return getCachedStats(identifier);
       } finally {
+        timeout.dispose();
         inFlight.delete(key);
       }
     })();
@@ -179,6 +462,7 @@ export function createGitHubRepoStatsService(
 
   return {
     getCachedStats,
+    getDiagnostics,
     requestStats,
     subscribe,
   };

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -5,6 +5,7 @@ import type { PoiDefinition } from '../scene/poi/types';
 import type {
   GitHubRepoIdentifier,
   GitHubRepoStats,
+  GitHubRepoStatsDiagnostics,
   GitHubRepoStatsListener,
   GitHubRepoStatsService,
 } from '../systems/github/repoStats';
@@ -20,6 +21,16 @@ class MockRepoStatsService implements GitHubRepoStatsService {
 
   getCachedStats(identifier: GitHubRepoIdentifier): GitHubRepoStats | null {
     return this.cache.get(this.key(identifier)) ?? null;
+  }
+
+  getDiagnostics(): GitHubRepoStatsDiagnostics {
+    return {
+      source: 'static-fallback',
+      lastErrorStatus: null,
+      requestCount: this.requested.length,
+      backoffExpiresAt: null,
+      suppressedRequestCount: 0,
+    };
   }
 
   requestStats(

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -2,6 +2,34 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createGitHubRepoStatsService } from '../systems/github/repoStats';
 
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+  length = 0;
+
+  clear(): void {
+    this.values.clear();
+    this.length = 0;
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+    this.length = this.values.size;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+    this.length = this.values.size;
+  }
+}
+
 describe('GitHub repo stats service', () => {
   it('fetches stats, caches results, and notifies subscribers', async () => {
     const fetch = vi.fn().mockResolvedValue({
@@ -17,7 +45,7 @@ describe('GitHub repo stats service', () => {
 
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, storage: new MemoryStorage() }
     );
 
     const listener = vi.fn();
@@ -38,6 +66,11 @@ describe('GitHub repo stats service', () => {
     });
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0][0]).toEqual(stats);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'live',
+      lastErrorStatus: null,
+      requestCount: 1,
+    });
 
     const cached = await service.requestStats({
       owner: 'futuroptimist',
@@ -45,18 +78,26 @@ describe('GitHub repo stats service', () => {
     });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(cached).toBe(stats);
+    expect(service.getDiagnostics().source).toBe('cached');
   });
 
   it('returns null without caching when fetch fails', async () => {
     const fetch = vi.fn().mockRejectedValue(new Error('network unreachable'));
+    const warn = { warn: vi.fn() };
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, storage: new MemoryStorage(), warn }
     );
 
     const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
     expect(stats).toBeNull();
     expect(service.getCachedStats({ owner: 'foo', repo: 'bar' })).toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 'network',
+      requestCount: 1,
+    });
+    expect(warn.warn).toHaveBeenCalledTimes(1);
   });
 
   it('delivers cached stats to new subscribers immediately', async () => {
@@ -71,7 +112,7 @@ describe('GitHub repo stats service', () => {
     });
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, storage: new MemoryStorage() }
     );
 
     await service.requestStats({ owner: 'foo', repo: 'baz' });
@@ -88,5 +129,139 @@ describe('GitHub repo stats service', () => {
       openIssues: 0,
       pushedAt: null,
     });
+  });
+
+  it('enters backoff and returns static fallback after a 403', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const warn = { warn: vi.fn() };
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffMs: 10_000,
+        now: () => 1_000,
+        storage: new MemoryStorage(),
+        warn,
+      }
+    );
+
+    const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
+
+    expect(stats).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(warn.warn).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 403,
+      requestCount: 1,
+      backoffExpiresAt: 11_000,
+    });
+  });
+
+  it('enters backoff and returns static fallback after a 429', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffMs: 20_000,
+        now: () => 1_000,
+        storage: new MemoryStorage(),
+        warn: null,
+      }
+    );
+
+    await expect(
+      service.requestStats({ owner: 'foo', repo: 'ratelimited' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      lastErrorStatus: 429,
+      backoffExpiresAt: 21_000,
+    });
+  });
+
+  it('uses stale cached success when live fetches are backed off', async () => {
+    const storage = new MemoryStorage();
+    const fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        stargazers_count: 99,
+        subscribers_count: 4,
+        forks_count: 5,
+        open_issues_count: 6,
+      }),
+    });
+    const firstService = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, storage }
+    );
+    await firstService.requestStats({ owner: 'foo', repo: 'cached' });
+
+    const failingFetch = vi.fn().mockRejectedValue(new Error('offline'));
+    const secondService = createGitHubRepoStatsService(
+      failingFetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, storage }
+    );
+
+    const stats = await secondService.requestStats({
+      owner: 'foo',
+      repo: 'cached',
+    });
+
+    expect(stats).toEqual({
+      stars: 99,
+      watchers: 4,
+      forks: 5,
+      openIssues: 6,
+      pushedAt: null,
+    });
+    expect(failingFetch).not.toHaveBeenCalled();
+    expect(secondService.getDiagnostics().source).toBe('cached');
+  });
+
+  it('suppresses repeated repo metric attempts during backoff', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffMs: 30_000,
+        now: () => 5_000,
+        storage: new MemoryStorage(),
+        warn: null,
+      }
+    );
+
+    await service.requestStats({ owner: 'foo', repo: 'one' });
+    await service.requestStats({ owner: 'foo', repo: 'two' });
+    await service.requestStats({ owner: 'foo', repo: 'three' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      lastErrorStatus: 403,
+      requestCount: 1,
+      suppressedRequestCount: 2,
+      backoffExpiresAt: 35_000,
+    });
+  });
+
+  it('groups failures into one warning path', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const warn = { warn: vi.fn() };
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffMs: 30_000,
+        now: () => 5_000,
+        storage: new MemoryStorage(),
+        warn,
+      }
+    );
+
+    await service.requestStats({ owner: 'foo', repo: 'one' });
+    await service.requestStats({ owner: 'foo', repo: 'two' });
+
+    expect(warn.warn).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Motivation
- Unauthenticated GitHub REST API failures were creating noisy browser console/network 403/429 messages and could fan out across many repo metric requests during immersive performance validation.
- Repo metrics are optional UI enrichments so failures must not trigger performance failover or console-budget logic and should fall back quietly to static/stale data.

### Description
- Replace the bare fetch path with a metrics service that implements browser-storage caching, a bounded backoff (403/429/network/timeout), request count limits, and AbortController timeouts in `src/systems/github/repoStats.ts`.
- Stop fan-out by refreshing repo buckets sequentially (instead of Promise.all) and expose a diagnostics snapshot from the controller via `getDiagnostics()` in `src/scene/poi/githubMetrics.ts` and `window.portfolio.github.getRepoMetricsDiagnostics()` in `src/main.ts`.
- Ensure failures do not spam `console.error` and emit at most one grouped `console.warn` per service instance while continuing to render static/fallback metric values for POI cards.
- Add unit tests for cache/backoff/diagnostics and a Playwright e2e spec `playwright/github-metrics-fallback.spec.ts` that mocks 403 responses and verifies immersive stability and suppressed fan-out, plus standalone outage docs `outages/2026-05-30-danielsmith-github-api-403-noise.{md,json}`.

### Testing
- Ran format and lint: `npm run format:write` (passed) and `npm run lint` (passed).
- Ran typecheck: `npm run typecheck` which surfaced pre-existing repo-wide TypeScript baseline issues and did not indicate new GitHub-metrics type errors (typecheck: failed due to existing baseline issues).
- Unit tests: `npm run test:ci` ran Vitest and completed successfully with the added suites; unit coverage for the metrics service passed (Vitest: 884 tests passed across the suite in this run).
- Playwright e2e: targeted `playwright/github-metrics-fallback.spec.ts` passed and verified backoff, single warning, suppressed fan-out, and that immersive did not failover; a full `npm run test:e2e` run reproduced a pre-existing flaky mode-toggle timeout unrelated to these changes (not introduced by this PR).
- Docs & smoke: `npm run docs:check` (passed) and `npm run smoke` (build/smoke passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8bad41f4832fb7e16e38323a02d1)