### PR TITLE
🧹 Gracefully back off GitHub repo metrics

### DIFF
--- a/outages/2026-05-30-danielsmith-github-api-403-noise.json
+++ b/outages/2026-05-30-danielsmith-github-api-403-noise.json
@@ -1,0 +1,38 @@
+{
+  "title": "danielsmith.io GitHub API 403 console-noise cleanup",
+  "date": "2026-05-30",
+  "environment": "hardware-accelerated staging performance validation",
+  "status": "mitigation prepared for deployment validation",
+  "symptoms": [
+    "Hardware-accelerated immersive validation showed repeated api.github.com/repos/futuroptimist/* HTTP 403 entries in the browser Network panel.",
+    "Affected repos included gabriel, token.place, flywheel, danielsmith.io, pr-reaper, gitshelves, wove, sigma, and f2clipboard.",
+    "The failures were not the main FPS bottleneck but made performance-investigation logs noisy and could confuse fallback triage."
+  ],
+  "rootCauseClass": "Unauthenticated client-side GitHub API fan-out for optional repo metrics can hit rate-limit, forbidden, unavailable, or access responses in a static browser app.",
+  "mitigation": [
+    "Project metric cards keep static fallback values unless live GitHub stats are available.",
+    "Successful live stats are cached in browser storage and reused as stale data when later live requests fail.",
+    "HTTP 403 and 429 responses enter bounded backoff and suppress subsequent repo metric requests.",
+    "Persisted backoff prevents repeated hard refreshes from immediately retrying unauthenticated fan-out.",
+    "Metric failures use one concise warning/diagnostic path per app session and never console.error.",
+    "window.portfolio.githubMetrics.getDiagnostics() exposes source, last status, request count, suppressed count, and backoff expiry.",
+    "GitHub metric availability is not coupled to renderer health, adaptive quality, or performance/text failover policy."
+  ],
+  "validationSteps": [
+    "Open /?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1.",
+    "Mock or reproduce GitHub API HTTP 403/429 for api.github.com/repos/**.",
+    "Confirm immersive mode remains active and no performancefailover event is emitted.",
+    "Confirm project cards and POIs keep static or cached metric text.",
+    "Confirm diagnostics report static-fallback or cached source, last status, counts, and backoff expiration.",
+    "Hard-refresh during the backoff TTL and confirm the app does not fan out to every repo again."
+  ],
+  "validationCommands": [
+    "npm run format:write",
+    "npm run lint",
+    "npm run typecheck",
+    "npm run test:ci",
+    "npm run test:e2e -- --grep \"github|metrics|fallback|immersive\"",
+    "npm run docs:check",
+    "npm run smoke"
+  ]
+}

--- a/outages/2026-05-30-danielsmith-github-api-403-noise.md
+++ b/outages/2026-05-30-danielsmith-github-api-403-noise.md
@@ -1,0 +1,69 @@
+# danielsmith.io GitHub API 403 console-noise cleanup
+
+- **Date:** 2026-05-30
+- **Environment:** hardware-accelerated staging performance validation
+- **Status:** Mitigation prepared for deployment validation
+
+## Symptoms
+
+Hardware-accelerated immersive validation showed repeated browser Network panel
+entries for unauthenticated GitHub REST API requests such as
+`api.github.com/repos/futuroptimist/gabriel` returning HTTP 403. Similar entries
+appeared for token.place, flywheel, danielsmith.io, pr-reaper, gitshelves,
+wove, sigma, and f2clipboard while project cards still had static fallback copy.
+
+The failures were not the primary FPS bottleneck, but the fan-out made
+performance-investigation logs noisy and risked confusing console-budget and
+fallback triage with unrelated repo metric availability.
+
+## Root cause class
+
+Project POI cards attempted unauthenticated client-side GitHub API requests for
+live star counts. When GitHub rate-limited, forbade, or otherwise rejected the
+anonymous requests, every repo could still be requested during page load. A
+static site cannot safely ship credentials in the browser, so live metrics must
+remain optional and best-effort.
+
+## Mitigation
+
+- GitHub repo metrics now keep project cards on their static metric fallback
+  values unless live stats are available.
+- Successful live metrics are cached in browser storage and reused as stale data
+  when a later live request fails.
+- HTTP 403 and 429 responses enter bounded backoff so subsequent repo metric
+  requests are suppressed instead of fanning out across every project.
+- Persisted backoff prevents repeated hard refreshes from immediately retrying
+  the same unauthenticated fan-out.
+- GitHub metric failures are reported through one concise warning/diagnostic path
+  per app session, never through `console.error`.
+- Diagnostics expose metric source (`live`, `cached`, or `static-fallback`), last
+  error status, request count, suppressed request count, and backoff expiry via
+  `window.portfolio.githubMetrics.getDiagnostics()`.
+- GitHub metrics remain independent of renderer health, adaptive quality, and
+  performance/text failover policy.
+
+## Validation steps
+
+1. Launch the immersive debug URL:
+   `/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1`.
+2. Mock or reproduce GitHub API HTTP 403/429 for `api.github.com/repos/**`.
+3. Confirm immersive mode remains active and no `performancefailover` event is
+   emitted.
+4. Confirm project cards/POIs still render their static or cached metric text.
+5. Confirm diagnostics report `source: "static-fallback"` or `source: "cached"`,
+   the last HTTP status, request count, suppressed request count, and backoff
+   expiration.
+6. Hard-refresh during the backoff TTL and confirm the app does not fan out to
+   every GitHub repo again.
+
+## Expected validation commands
+
+```bash
+npm run format:write
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run test:e2e -- --grep "github|metrics|fallback|immersive"
+npm run docs:check
+npm run smoke
+```

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_GITHUB_METRICS_URL =
+  '/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+
+const collectConsoleMessages = (
+  page: Page,
+  type: 'error' | 'warning'
+): string[] => {
+  const messages: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === type) {
+      messages.push(message.text());
+    }
+  });
+  return messages;
+};
+
+test.describe('GitHub repo metrics fallback', () => {
+  test('keeps immersive stable and suppresses repo fan-out after GitHub 403', async ({
+    page,
+  }) => {
+    const consoleErrors = collectConsoleMessages(page, 'error');
+    const consoleWarnings = collectConsoleMessages(page, 'warning');
+    const performanceFailovers: unknown[] = [];
+    let githubRequestCount = 0;
+
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.addEventListener('performancefailover', (event) => {
+        (
+          window as unknown as { __githubMetricsFailovers: unknown[] }
+        ).__githubMetricsFailovers.push((event as CustomEvent).detail);
+      });
+      (
+        window as unknown as { __githubMetricsFailovers: unknown[] }
+      ).__githubMetricsFailovers = [];
+    });
+    await page.route('https://api.github.com/repos/**', async (route) => {
+      githubRequestCount += 1;
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'API rate limit exceeded' }),
+      });
+    });
+
+    await page.goto(IMMERSIVE_GITHUB_METRICS_URL, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    const diagnostics = await page.waitForFunction(() => {
+      const snapshot = window.portfolio?.githubMetrics?.getDiagnostics?.();
+      return snapshot?.lastErrorStatus === 403 ? snapshot : null;
+    });
+    const diagnosticsValue = await diagnostics.jsonValue();
+    performanceFailovers.push(
+      ...(await page.evaluate(
+        () =>
+          (window as unknown as { __githubMetricsFailovers: unknown[] })
+            .__githubMetricsFailovers
+      ))
+    );
+
+    expect(githubRequestCount).toBe(1);
+    expect(diagnosticsValue).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 403,
+      requestCount: 1,
+      warningCount: 1,
+    });
+    expect(performanceFailovers).toEqual([]);
+    expect(
+      consoleErrors.filter(
+        (message) => !message.includes('Failed to load resource')
+      )
+    ).toEqual([]);
+    expect(
+      consoleWarnings.filter((message) =>
+        message.includes('GitHub repo metrics are temporarily unavailable')
+      )
+    ).toHaveLength(1);
+    await expect(page.locator('#control-overlay')).toBeVisible();
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -313,7 +313,10 @@ import {
   writeModePreference,
 } from './systems/failover/modePreference';
 import { createPerformanceFailoverHandler } from './systems/failover/performanceFailover';
-import { createGitHubRepoStatsService } from './systems/github/repoStats';
+import {
+  createGitHubRepoStatsService,
+  type GitHubRepoStatsDiagnostics,
+} from './systems/github/repoStats';
 import {
   createAnalyticsGlowRhythm,
   type AnalyticsGlowRhythmHandle,
@@ -435,6 +438,9 @@ declare global {
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
+      githubMetrics?: {
+        getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
       graphics?: {
         getMotionBlurIntensity(): number;
         setMotionBlurIntensity(intensity: number): void;
@@ -1529,6 +1535,15 @@ function initializeImmersiveScene(
       }
     },
   });
+  const githubMetricsWindow = window as Window;
+  if (!githubMetricsWindow.portfolio) {
+    githubMetricsWindow.portfolio = {};
+  }
+  githubMetricsWindow.portfolio.githubMetrics = {
+    getDiagnostics: () =>
+      githubRepoMetrics?.getDiagnostics() ??
+      githubRepoStatsService.getDiagnostics(),
+  };
   githubRepoMetrics.refreshAll().catch(() => {
     /* GitHub may be unreachable; metrics will remain on fallback values. */
   });
@@ -4086,6 +4101,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.graphics) {
       delete window.portfolio.graphics;
+    }
+    if (window.portfolio?.githubMetrics) {
+      delete window.portfolio.githubMetrics;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/scene/poi/githubMetrics.ts
+++ b/src/scene/poi/githubMetrics.ts
@@ -1,5 +1,6 @@
 import type {
   GitHubRepoStats,
+  GitHubRepoStatsDiagnostics,
   GitHubRepoStatsService,
 } from '../../systems/github/repoStats';
 
@@ -36,6 +37,7 @@ export interface WireGitHubRepoMetricsOptions {
 
 export interface GitHubRepoMetricsController {
   refreshAll(): Promise<void>;
+  getDiagnostics(): GitHubRepoStatsDiagnostics;
   dispose(): void;
 }
 
@@ -146,12 +148,12 @@ export function wireGitHubRepoMetrics({
   });
 
   const refreshAll = async () => {
-    await Promise.all(
-      Array.from(repoMap.values()).map((bucket) =>
-        service.requestStats(bucket.identifier)
-      )
-    );
+    for (const bucket of repoMap.values()) {
+      await service.requestStats(bucket.identifier);
+    }
   };
+
+  const getDiagnostics = () => service.getDiagnostics();
 
   const dispose = () => {
     disposables.splice(0).forEach((fn) => {
@@ -165,6 +167,7 @@ export function wireGitHubRepoMetrics({
 
   return {
     refreshAll,
+    getDiagnostics,
     dispose,
   };
 }

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -13,6 +13,19 @@ export interface GitHubRepoStats {
 
 export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
 
+export type GitHubRepoMetricsSource = 'live' | 'cached' | 'static-fallback';
+
+export interface GitHubRepoStatsDiagnostics {
+  source: GitHubRepoMetricsSource;
+  lastErrorStatus: number | null;
+  lastErrorMessage: string | null;
+  requestCount: number;
+  suppressedRequestCount: number;
+  backoffUntil: number | null;
+  backoffReason: string | null;
+  warningCount: number;
+}
+
 export interface GitHubRepoStatsService {
   getCachedStats(identifier: GitHubRepoIdentifier): GitHubRepoStats | null;
   requestStats(
@@ -22,12 +35,40 @@ export interface GitHubRepoStatsService {
     identifier: GitHubRepoIdentifier,
     listener: GitHubRepoStatsListener
   ): () => void;
+  getDiagnostics(): GitHubRepoStatsDiagnostics;
 }
 
 const DEFAULT_HEADERS = {
   Accept: 'application/vnd.github+json',
   'User-Agent': 'danielsmith.io-github-metrics',
 } as const;
+
+const CACHE_STORAGE_KEY = 'danielsmith.io:github-repo-stats-cache:v1';
+const BACKOFF_STORAGE_KEY = 'danielsmith.io:github-repo-stats-backoff:v1';
+const DEFAULT_SUCCESS_CACHE_TTL_MS = 1000 * 60 * 60 * 6;
+const DEFAULT_BACKOFF_TTL_MS = 1000 * 60 * 60;
+const DEFAULT_FETCH_TIMEOUT_MS = 3500;
+const DEFAULT_MAX_LIVE_REQUESTS_PER_SESSION = 24;
+const BACKOFF_STATUSES = new Set([403, 429]);
+
+interface StoredStatsEntry {
+  stats: GitHubRepoStats;
+  storedAt: number;
+}
+
+interface StoredBackoffEntry {
+  until: number;
+  reason: string;
+  status: number | null;
+}
+
+interface CacheEntry extends StoredStatsEntry {
+  source: 'live' | 'cached';
+}
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+type GitHubMetricsLogger = Pick<Console, 'warn'>;
 
 const sanitizeNumber = (value: unknown): number => {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -65,8 +106,106 @@ const shouldAttemptLiveFetch = (() => {
   return false;
 })();
 
+const getDefaultStorage = (): StorageLike | undefined => {
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+const parseStoredStats = (
+  value: string | null
+): Map<string, StoredStatsEntry> => {
+  if (!value) {
+    return new Map();
+  }
+  try {
+    const parsed = JSON.parse(value) as Record<string, StoredStatsEntry>;
+    return new Map(
+      Object.entries(parsed).filter(([, entry]) => isStoredStatsEntry(entry))
+    );
+  } catch {
+    return new Map();
+  }
+};
+
+const isStoredStatsEntry = (value: unknown): value is StoredStatsEntry => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const entry = value as Partial<StoredStatsEntry>;
+  return (
+    typeof entry.storedAt === 'number' &&
+    Number.isFinite(entry.storedAt) &&
+    !!entry.stats &&
+    typeof entry.stats === 'object'
+  );
+};
+
+const readBackoff = (
+  storage: StorageLike | undefined,
+  now: number
+): StoredBackoffEntry | null => {
+  if (!storage) {
+    return null;
+  }
+  try {
+    const raw = storage.getItem(BACKOFF_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<StoredBackoffEntry>;
+    if (
+      typeof parsed.until !== 'number' ||
+      !Number.isFinite(parsed.until) ||
+      parsed.until <= now
+    ) {
+      storage.removeItem(BACKOFF_STORAGE_KEY);
+      return null;
+    }
+    return {
+      until: parsed.until,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : 'unavailable',
+      status: typeof parsed.status === 'number' ? parsed.status : null,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const readStoredStats = (
+  storage: StorageLike | undefined
+): Map<string, StoredStatsEntry> => {
+  if (!storage) {
+    return new Map();
+  }
+  try {
+    return parseStoredStats(storage.getItem(CACHE_STORAGE_KEY));
+  } catch {
+    return new Map();
+  }
+};
+
+const serializeCache = (cache: Map<string, CacheEntry>): string =>
+  JSON.stringify(
+    Object.fromEntries(
+      Array.from(cache.entries()).map(([key, entry]) => [
+        key,
+        { stats: entry.stats, storedAt: entry.storedAt },
+      ])
+    )
+  );
+
 export interface GitHubRepoStatsServiceOptions {
   allowLiveFetch?: boolean;
+  storage?: StorageLike;
+  now?: () => number;
+  logger?: GitHubMetricsLogger;
+  successCacheTtlMs?: number;
+  backoffTtlMs?: number;
+  fetchTimeoutMs?: number;
+  maxLiveRequestsPerSession?: number;
 }
 
 export function createGitHubRepoStatsService(
@@ -74,9 +213,47 @@ export function createGitHubRepoStatsService(
   options: GitHubRepoStatsServiceOptions = {}
 ): GitHubRepoStatsService {
   const allowLiveFetch = options.allowLiveFetch ?? shouldAttemptLiveFetch;
-  const cache = new Map<string, GitHubRepoStats>();
+  const storage = options.storage ?? getDefaultStorage();
+  const now = options.now ?? (() => Date.now());
+  const logger = options.logger ?? console;
+  const successCacheTtlMs =
+    options.successCacheTtlMs ?? DEFAULT_SUCCESS_CACHE_TTL_MS;
+  const backoffTtlMs = options.backoffTtlMs ?? DEFAULT_BACKOFF_TTL_MS;
+  const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const maxLiveRequestsPerSession =
+    options.maxLiveRequestsPerSession ?? DEFAULT_MAX_LIVE_REQUESTS_PER_SESSION;
+  const cache = new Map<string, CacheEntry>();
   const listeners = new Map<string, Set<GitHubRepoStatsListener>>();
   const inFlight = new Map<string, Promise<GitHubRepoStats | null>>();
+  let requestCount = 0;
+  let suppressedRequestCount = 0;
+  let warningCount = 0;
+  let hasWarnedUnavailable = false;
+  let lastErrorStatus: number | null = null;
+  let lastErrorMessage: string | null = null;
+  let currentSource: GitHubRepoMetricsSource = 'static-fallback';
+  let backoff = readBackoff(storage, now());
+
+  readStoredStats(storage).forEach((entry, key) => {
+    cache.set(key, { ...entry, source: 'cached' });
+    currentSource = 'cached';
+  });
+
+  if (backoff) {
+    lastErrorStatus = backoff.status;
+    lastErrorMessage = backoff.reason;
+  }
+
+  const persistCache = () => {
+    if (!storage) {
+      return;
+    }
+    try {
+      storage.setItem(CACHE_STORAGE_KEY, serializeCache(cache));
+    } catch {
+      // Cache persistence is best effort and must not affect rendering.
+    }
+  };
 
   const notify = (key: string, stats: GitHubRepoStats) => {
     const repoListeners = listeners.get(key);
@@ -92,11 +269,57 @@ export function createGitHubRepoStatsService(
     }
   };
 
+  const warnUnavailableOnce = () => {
+    if (hasWarnedUnavailable) {
+      return;
+    }
+    hasWarnedUnavailable = true;
+    warningCount += 1;
+    logger.warn(
+      'GitHub repo metrics are temporarily unavailable; using cached or static project metrics.',
+      {
+        status: lastErrorStatus,
+        reason: lastErrorMessage,
+        backoffUntil: backoff?.until ?? null,
+      }
+    );
+  };
+
+  const enterBackoff = (status: number | null, reason: string) => {
+    lastErrorStatus = status;
+    lastErrorMessage = reason;
+    backoff = {
+      until: now() + backoffTtlMs,
+      reason,
+      status,
+    };
+    if (storage) {
+      try {
+        storage.setItem(BACKOFF_STORAGE_KEY, JSON.stringify(backoff));
+      } catch {
+        // Failure metadata is best effort.
+      }
+    }
+    warnUnavailableOnce();
+  };
+
+  const getFreshCachedEntry = (key: string): CacheEntry | null => {
+    const cached = cache.get(key);
+    if (!cached) {
+      return null;
+    }
+    if (now() - cached.storedAt <= successCacheTtlMs) {
+      return cached;
+    }
+    return null;
+  };
+
   const getCachedStats = (
     identifier: GitHubRepoIdentifier
   ): GitHubRepoStats | null => {
     const key = makeCacheKey(identifier);
-    return cache.get(key) ?? null;
+    const cached = cache.get(key);
+    return cached?.stats ?? null;
   };
 
   const subscribe = (
@@ -113,7 +336,7 @@ export function createGitHubRepoStatsService(
 
     const cached = cache.get(key);
     if (cached) {
-      queueMicrotask(() => listener(cached));
+      queueMicrotask(() => listener(cached.stats));
     }
 
     return () => {
@@ -128,29 +351,68 @@ export function createGitHubRepoStatsService(
     };
   };
 
+  const shouldSuppressLiveRequest = () => {
+    if (!fetchImpl || !allowLiveFetch) {
+      return true;
+    }
+    if (backoff && backoff.until > now()) {
+      return true;
+    }
+    if (requestCount >= maxLiveRequestsPerSession) {
+      return true;
+    }
+    return false;
+  };
+
   const requestStats = async (
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null> => {
     const key = makeCacheKey(identifier);
-    const cached = cache.get(key);
-    if (cached) {
-      return cached;
+    const freshCached = getFreshCachedEntry(key);
+    if (freshCached) {
+      currentSource = freshCached.source === 'live' ? 'live' : 'cached';
+      return freshCached.stats;
     }
     const existing = inFlight.get(key);
     if (existing) {
       return existing;
     }
-    if (!fetchImpl || !allowLiveFetch) {
+    if (shouldSuppressLiveRequest()) {
+      suppressedRequestCount += 1;
+      const stale = cache.get(key);
+      if (stale) {
+        currentSource = 'cached';
+        return stale.stats;
+      }
+      currentSource = 'static-fallback';
       return null;
     }
 
     const promise = (async () => {
+      const controller =
+        typeof AbortController === 'function' ? new AbortController() : null;
+      const timeout = controller
+        ? setTimeout(() => controller.abort(), fetchTimeoutMs)
+        : null;
       try {
+        requestCount += 1;
         const response = await fetchImpl(
           `https://api.github.com/repos/${identifier.owner}/${identifier.repo}`,
-          { headers: DEFAULT_HEADERS }
+          { headers: DEFAULT_HEADERS, signal: controller?.signal }
         );
         if (!response.ok) {
+          const reason = `GitHub API returned ${response.status}`;
+          lastErrorStatus = response.status;
+          lastErrorMessage = reason;
+          if (BACKOFF_STATUSES.has(response.status)) {
+            enterBackoff(response.status, reason);
+          }
+          const stale = cache.get(key);
+          if (stale) {
+            currentSource = 'cached';
+            return stale.stats;
+          }
+          currentSource = 'static-fallback';
           return null;
         }
         const data = (await response.json()) as Record<string, unknown>;
@@ -163,12 +425,31 @@ export function createGitHubRepoStatsService(
           openIssues: sanitizeNumber(data.open_issues_count),
           pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
         };
-        cache.set(key, stats);
+        cache.set(key, { stats, storedAt: now(), source: 'live' });
+        currentSource = 'live';
+        persistCache();
         notify(key, stats);
         return stats;
-      } catch {
+      } catch (error) {
+        const isAbort =
+          typeof DOMException === 'function' &&
+          error instanceof DOMException &&
+          error.name === 'AbortError';
+        lastErrorStatus = null;
+        lastErrorMessage = isAbort
+          ? 'GitHub API request timed out'
+          : 'GitHub API request failed';
+        const stale = cache.get(key);
+        if (stale) {
+          currentSource = 'cached';
+          return stale.stats;
+        }
+        currentSource = 'static-fallback';
         return null;
       } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
         inFlight.delete(key);
       }
     })();
@@ -177,9 +458,24 @@ export function createGitHubRepoStatsService(
     return promise;
   };
 
+  const getDiagnostics = (): GitHubRepoStatsDiagnostics => {
+    const activeBackoff = backoff && backoff.until > now() ? backoff : null;
+    return {
+      source: currentSource,
+      lastErrorStatus,
+      lastErrorMessage,
+      requestCount,
+      suppressedRequestCount,
+      backoffUntil: activeBackoff?.until ?? null,
+      backoffReason: activeBackoff?.reason ?? null,
+      warningCount,
+    };
+  };
+
   return {
     getCachedStats,
     requestStats,
     subscribe,
+    getDiagnostics,
   };
 }

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -5,6 +5,7 @@ import type { PoiDefinition } from '../scene/poi/types';
 import type {
   GitHubRepoIdentifier,
   GitHubRepoStats,
+  GitHubRepoStatsDiagnostics,
   GitHubRepoStatsListener,
   GitHubRepoStatsService,
 } from '../systems/github/repoStats';
@@ -28,6 +29,19 @@ class MockRepoStatsService implements GitHubRepoStatsService {
     const key = this.key(identifier);
     this.requested.push(key);
     return Promise.resolve(this.cache.get(key) ?? null);
+  }
+
+  getDiagnostics(): GitHubRepoStatsDiagnostics {
+    return {
+      source: 'static-fallback',
+      lastErrorStatus: null,
+      lastErrorMessage: null,
+      requestCount: this.requested.length,
+      suppressedRequestCount: 0,
+      backoffUntil: null,
+      backoffReason: null,
+      warningCount: 0,
+    };
   }
 
   subscribe(

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -2,6 +2,34 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createGitHubRepoStatsService } from '../systems/github/repoStats';
 
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+  length = 0;
+
+  clear(): void {
+    this.values.clear();
+    this.length = 0;
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+    this.length = this.values.size;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+    this.length = this.values.size;
+  }
+}
+
 describe('GitHub repo stats service', () => {
   it('fetches stats, caches results, and notifies subscribers', async () => {
     const fetch = vi.fn().mockResolvedValue({
@@ -17,7 +45,7 @@ describe('GitHub repo stats service', () => {
 
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, storage: new MemoryStorage() }
     );
 
     const listener = vi.fn();
@@ -38,6 +66,7 @@ describe('GitHub repo stats service', () => {
     });
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0][0]).toEqual(stats);
+    expect(service.getDiagnostics().source).toBe('live');
 
     const cached = await service.requestStats({
       owner: 'futuroptimist',
@@ -51,12 +80,16 @@ describe('GitHub repo stats service', () => {
     const fetch = vi.fn().mockRejectedValue(new Error('network unreachable'));
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, storage: new MemoryStorage() }
     );
 
     const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
     expect(stats).toBeNull();
     expect(service.getCachedStats({ owner: 'foo', repo: 'bar' })).toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-fallback',
+      lastErrorMessage: 'GitHub API request failed',
+    });
   });
 
   it('delivers cached stats to new subscribers immediately', async () => {
@@ -71,7 +104,7 @@ describe('GitHub repo stats service', () => {
     });
     const service = createGitHubRepoStatsService(
       fetch as unknown as typeof globalThis.fetch,
-      { allowLiveFetch: true }
+      { allowLiveFetch: true, storage: new MemoryStorage() }
     );
 
     await service.requestStats({ owner: 'foo', repo: 'baz' });
@@ -88,5 +121,154 @@ describe('GitHub repo stats service', () => {
       openIssues: 0,
       pushedAt: null,
     });
+  });
+
+  it('enters backoff and returns static fallback after a 403 response', async () => {
+    let now = 1_000;
+    const storage = new MemoryStorage();
+    const logger = { warn: vi.fn() };
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffTtlMs: 60_000,
+        logger,
+        now: () => now,
+        storage,
+      }
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'gabriel' })
+    ).resolves.toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 403,
+      requestCount: 1,
+      warningCount: 1,
+      backoffUntil: 61_000,
+    });
+
+    now += 1_000;
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics().suppressedRequestCount).toBe(1);
+  });
+
+  it('enters backoff and returns static fallback after a 429 response', async () => {
+    const logger = { warn: vi.fn() };
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffTtlMs: 10_000,
+        logger,
+        now: () => 5_000,
+        storage: new MemoryStorage(),
+      }
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'token.place' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-fallback',
+      lastErrorStatus: 429,
+      backoffUntil: 15_000,
+    });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses stale cached success when live fetch fails', async () => {
+    let now = 1_000;
+    const storage = new MemoryStorage();
+    const successFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        stargazers_count: 86,
+        subscribers_count: 5,
+        forks_count: 2,
+        open_issues_count: 1,
+      }),
+    });
+    const warmService = createGitHubRepoStatsService(
+      successFetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, now: () => now, storage, successCacheTtlMs: 1 }
+    );
+    await warmService.requestStats({ owner: 'futuroptimist', repo: 'axel' });
+
+    now = 2_000;
+    const failingFetch = vi.fn().mockRejectedValue(new Error('offline'));
+    const service = createGitHubRepoStatsService(
+      failingFetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, now: () => now, storage, successCacheTtlMs: 1 }
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'axel' })
+    ).resolves.toEqual({
+      stars: 86,
+      watchers: 5,
+      forks: 2,
+      openIssues: 1,
+      pushedAt: null,
+    });
+    expect(failingFetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({ source: 'cached' });
+  });
+
+  it('suppresses repeated repo metric fetches during persisted backoff', async () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      'danielsmith.io:github-repo-stats-backoff:v1',
+      JSON.stringify({
+        until: 30_000,
+        reason: 'GitHub API returned 403',
+        status: 403,
+      })
+    );
+    const fetch = vi.fn();
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      { allowLiveFetch: true, now: () => 20_000, storage }
+    );
+
+    await service.requestStats({ owner: 'futuroptimist', repo: 'gabriel' });
+    await service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(service.getDiagnostics()).toMatchObject({
+      lastErrorStatus: 403,
+      suppressedRequestCount: 2,
+      backoffUntil: 30_000,
+    });
+  });
+
+  it('groups unavailable warnings into one diagnostic path', async () => {
+    const logger = { warn: vi.fn() };
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: true,
+        backoffTtlMs: 60_000,
+        logger,
+        now: () => 1_000,
+        storage: new MemoryStorage(),
+      }
+    );
+
+    await service.requestStats({ owner: 'futuroptimist', repo: 'gabriel' });
+    await service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' });
+    await service.requestStats({ owner: 'futuroptimist', repo: 'wove' });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics().warningCount).toBe(1);
   });
 });


### PR DESCRIPTION
### Motivation
- Reduce noisy unauthenticated GitHub REST API 403/429 fan-out during immersive performance validation and avoid polluting console/console-budget failover logic.
- Keep project/POI displays usable without requiring tokens or a backend proxy by falling back to static or cached metrics.
- Provide a concise diagnostics surface so integrators can inspect metrics source/backoff state without coupling metrics to renderer health or failover.

### Description
- Implement a cache/backoff-aware metrics service in `src/systems/github/repoStats.ts` that adds: persistent success cache, persisted 403/429 backoff, request timeout via `AbortController`, max live requests per session, stale-cache fallback, grouped single-session `console.warn` and a `getDiagnostics()` API returning `{ source, lastErrorStatus, lastErrorMessage, requestCount, suppressedRequestCount, backoffUntil, backoffReason, warningCount }`.
- Update POI wiring in `src/scene/poi/githubMetrics.ts` to subscribe and refresh repo metrics sequentially (stop fan-out after the first failing backoff), and expose `getDiagnostics()` on the returned controller.
- Surface diagnostics to the test/dev API as `window.portfolio.githubMetrics.getDiagnostics()` from `src/main.ts` so e2e/debug tooling can query metric state without changing app behavior.
- Add unit tests and a Playwright regression: new/updated tests in `src/tests/githubRepoStatsService.test.ts` and `src/tests/githubPoiMetrics.test.ts` cover 403/429 backoff, stale-cache use, persisted backoff suppression, and grouped warnings; `playwright/github-metrics-fallback.spec.ts` mocks 403 responses and verifies single-request fan-out, no `performancefailover`, one grouped warning, and diagnostics state.
- Add standalone outage documentation in `outages/2026-05-30-danielsmith-github-api-403-noise.{md,json}` describing symptoms, root cause, mitigation, and validation steps.

### Testing
- Ran `npm run format:write` and `npm run lint` successfully.
- Ran `npm run test:ci` (Vitest) and the full unit suite completed successfully (`129 files, 884 tests passed`).
- Ran focused unit tests `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts` and they passed.
- Installed Playwright browsers and deps (`npx playwright install chromium-headless-shell` and `npx playwright install-deps`), then ran the focused e2e `npx playwright test playwright/github-metrics-fallback.spec.ts` and the new GitHub metrics fallback test passed.
- Ran broader Playwright grep `npm run test:e2e -- --grep "github|metrics|fallback|immersive"`; the GitHub-metrics-focused scenarios passed but some unrelated browser tests experienced environment/timeouts in this runner (host dependency and occasional timing/flaky HUD tests) and are out-of-scope for this change.
- Ran `npm run docs:check` and `npm run smoke` (build + dist checks) and they passed.

Notes and residuals: `npm run typecheck` still fails on pre-existing repo-wide TypeScript issues unrelated to this change; Playwright full e2e requires host browser deps (see logs) and may time out on unrelated flaky specs in this environment. The metrics changes do not introduce credentials or backend proxies and intentionally avoid coupling metrics availability to performance/failover heuristics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8bad41f4832fb7e16e38323a02d1)