### PR TITLE
Add compact dismissible Controls popover

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,24 +42,89 @@
 
       .overlay {
         position: fixed;
-        bottom: 1.5rem;
-        left: 1.5rem;
-        padding: 1rem 1.25rem;
-        border-radius: 0.75rem;
-        background: rgba(8, 12, 20, 0.78);
-        color: inherit;
-        border: 1px solid rgba(86, 184, 255, 0.28);
-        box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+        top: calc(env(safe-area-inset-top, 0px) + 1rem);
+        right: calc(env(safe-area-inset-right, 0px) + 1rem);
+        z-index: 40;
+        color: var(--hud-surface-text);
         font-size: 0.9rem;
         line-height: 1.4;
-        max-width: 20rem;
-        transition:
-          opacity 200ms ease,
-          transform 200ms ease;
-        overflow: visible;
       }
 
-      .overlay::after {
+      .overlay__actions {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+
+      .overlay__controls-button,
+      .overlay__help-button,
+      .overlay__close {
+        border: 1px solid rgba(123, 209, 255, 0.4);
+        background:
+          linear-gradient(
+            140deg,
+            rgba(12, 25, 39, 0.92),
+            rgba(16, 43, 70, 0.78)
+          ),
+          rgba(9, 18, 28, 0.88);
+        color: #e7f4ff;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        cursor: pointer;
+        transition:
+          border-color 140ms ease,
+          box-shadow 140ms ease,
+          transform 120ms ease;
+      }
+
+      .overlay__controls-button:hover,
+      .overlay__controls-button:focus-visible,
+      .overlay__help-button:hover,
+      .overlay__help-button:focus-visible,
+      .overlay__close:hover,
+      .overlay__close:focus-visible {
+        border-color: rgba(158, 232, 255, 0.8);
+        box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
+        outline: none;
+        transform: translateY(-1px);
+      }
+
+      .overlay__controls-button:active,
+      .overlay__help-button:active,
+      .overlay__close:active {
+        transform: translateY(0);
+      }
+
+      .overlay__controls-button,
+      .overlay__help-button {
+        padding: 0.65rem 0.9rem;
+        border-radius: 999px;
+        backdrop-filter: blur(12px);
+      }
+
+      .overlay__popover {
+        position: absolute;
+        top: calc(100% + 0.7rem);
+        right: 0;
+        width: min(22rem, calc(100vw - 2rem - env(safe-area-inset-left, 0px)));
+        max-height: min(70vh, 32rem);
+        padding: 1rem 1.05rem;
+        overflow: auto;
+        overscroll-behavior: contain;
+        border-radius: 0.9rem;
+        background: var(--hud-surface-bg);
+        border: 1px solid var(--hud-surface-border);
+        box-shadow: var(--hud-surface-shadow);
+        backdrop-filter: blur(12px);
+      }
+
+      .overlay__popover[hidden] {
+        display: none;
+      }
+
+      .overlay__popover::after {
         content: '';
         position: absolute;
         inset: -0.9rem;
@@ -76,52 +141,28 @@
         transition: opacity 160ms ease;
       }
 
-      .overlay__item[data-mobile-collapsed='true'] {
-        display: none;
-      }
-
-      html[data-hudLayout='mobile'] .overlay {
-        top: calc(env(safe-area-inset-top, 0) + 1rem);
-        bottom: auto;
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-        width: min(24rem, calc(100% - 2rem));
-        padding: 0.9rem 1.05rem;
-        font-size: 0.95rem;
-        line-height: 1.5;
-        z-index: 40;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__heading {
-        margin-bottom: 0.6rem;
-        font-size: 0.7rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__list {
-        gap: 0.35rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__item {
-        padding: 0.35rem 0.45rem;
-        gap: 0.6rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__keys {
-        min-width: 5.75rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__help-button {
-        margin-top: 0.65rem;
+      .overlay__popover-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 0.75rem;
       }
 
       .overlay__heading {
-        margin: 0 0 0.75rem;
+        margin: 0;
         font-size: 0.75rem;
         font-weight: 600;
-        letter-spacing: 0.12em;
         text-transform: uppercase;
-        color: rgba(196, 228, 255, 0.82);
+        letter-spacing: 0.12em;
+        color: var(--hud-surface-heading);
+      }
+
+      .overlay__close {
+        flex: none;
+        padding: 0.4rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.76rem;
       }
 
       .overlay__list {
@@ -155,10 +196,11 @@
       }
 
       .overlay__keys {
+        display: inline-block;
         min-width: 7rem;
         font-weight: 600;
         letter-spacing: 0.02em;
-        color: rgba(143, 214, 255, 0.9);
+        color: var(--hud-surface-accent);
       }
 
       .overlay__item[data-state='active'] .overlay__keys {
@@ -167,7 +209,7 @@
 
       .overlay__description {
         flex: 1;
-        color: rgba(239, 245, 255, 0.88);
+        color: var(--hud-surface-muted-text);
       }
 
       .overlay__item[data-state='active'] .overlay__description {
@@ -188,76 +230,44 @@
         }
       }
 
-      .overlay__collapse-toggle {
-        margin-top: 0.6rem;
-        width: 100%;
-        padding: 0.55rem 0.9rem;
-        border-radius: 0.6rem;
-        border: 1px solid rgba(123, 209, 255, 0.32);
-        background:
-          linear-gradient(
-            140deg,
-            rgba(12, 25, 39, 0.88),
-            rgba(16, 43, 70, 0.72)
-          ),
-          rgba(9, 18, 28, 0.82);
-        color: rgba(231, 244, 255, 0.95);
-        font-size: 0.82rem;
-        font-weight: 600;
-        letter-spacing: 0.01em;
-        cursor: pointer;
-        transition:
-          border-color 140ms ease,
-          box-shadow 140ms ease,
-          transform 120ms ease;
+      :root[data-hud-layout='mobile'],
+      :root[data-hudLayout='mobile'] {
+        --hud-mobile-safe-zone: calc(8.5rem + env(safe-area-inset-bottom, 0px));
       }
 
-      .overlay__collapse-toggle:hover,
-      .overlay__collapse-toggle:focus-visible {
-        border-color: rgba(158, 232, 255, 0.75);
-        box-shadow: 0 14px 32px rgba(8, 20, 32, 0.32);
-        outline: none;
-        transform: translateY(-1px);
+      :root[data-hud-layout='mobile'] .overlay,
+      :root[data-hudLayout='mobile'] .overlay {
+        top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
+        right: calc(env(safe-area-inset-right, 0px) + 0.75rem);
+        left: calc(env(safe-area-inset-left, 0px) + 0.75rem);
+        font-size: 0.85rem;
       }
 
-      .overlay__collapse-toggle:active {
-        transform: translateY(0);
+      :root[data-hud-layout='mobile'] .overlay__actions,
+      :root[data-hudLayout='mobile'] .overlay__actions {
+        flex-wrap: wrap;
       }
 
-      .overlay__help-button {
-        margin-top: 0.85rem;
-        width: 100%;
-        padding: 0.65rem 0.9rem;
-        border-radius: 0.6rem;
-        border: 1px solid rgba(123, 209, 255, 0.4);
-        background:
-          linear-gradient(
-            140deg,
-            rgba(12, 25, 39, 0.92),
-            rgba(16, 43, 70, 0.78)
-          ),
-          rgba(9, 18, 28, 0.88);
-        color: #e7f4ff;
-        font-size: 0.86rem;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        cursor: pointer;
-        transition:
-          border-color 140ms ease,
-          box-shadow 140ms ease,
-          transform 120ms ease;
+      :root[data-hud-layout='mobile'] .overlay__popover,
+      :root[data-hudLayout='mobile'] .overlay__popover {
+        width: auto;
+        left: 0;
+        max-height: min(62vh, 28rem);
+        padding: 0.85rem 0.9rem;
       }
 
-      .overlay__help-button:hover,
-      .overlay__help-button:focus-visible {
-        border-color: rgba(158, 232, 255, 0.8);
-        box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
-        outline: none;
-        transform: translateY(-1px);
+      :root[data-hud-layout='mobile'] .overlay__keys,
+      :root[data-hudLayout='mobile'] .overlay__keys {
+        min-width: 5.75rem;
       }
 
-      .overlay__help-button:active {
-        transform: translateY(0);
+      :root[data-hud-layout='mobile'] .poi-tooltip-overlay,
+      :root[data-hudLayout='mobile'] .poi-tooltip-overlay {
+        bottom: calc(var(--hud-mobile-safe-zone) + 1rem);
+        left: 1rem;
+        right: 1rem;
+        max-width: none;
+        width: auto;
       }
 
       .help-modal-backdrop {
@@ -488,100 +498,126 @@
     </noscript>
     <div id="app"></div>
     <div class="overlay" id="control-overlay">
-      <p class="overlay__heading" data-control-text="heading">Controls</p>
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-input-methods="keyboard"
-          data-control-item="keyboardMove"
+      <div class="overlay__actions">
+        <button
+          class="overlay__controls-button"
+          type="button"
+          data-role="control-toggle"
+          data-control-text="toggle"
         >
-          <span class="overlay__keys">WASD / Arrow keys</span>
-          <span class="overlay__description">Move</span>
-        </li>
-        <li
-          class="overlay__item overlay__item--desktop"
-          data-input-methods="pointer"
-          data-control-item="pointerDrag"
+          Controls
+        </button>
+        <button
+          class="overlay__help-button"
+          type="button"
+          data-control="help"
+          data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
         >
-          <span class="overlay__keys">Left mouse button</span>
-          <span class="overlay__description">Drag to pan</span>
-        </li>
-        <li
-          class="overlay__item overlay__item--desktop"
-          data-input-methods="pointer"
-          data-control-item="pointerZoom"
-        >
-          <span class="overlay__keys">Scroll wheel</span>
-          <span class="overlay__description">Zoom</span>
-        </li>
-        <li
-          class="overlay__item overlay__item--touch"
-          data-input-methods="touch"
-          data-control-item="touchDrag"
-        >
-          <span class="overlay__keys">Touch</span>
-          <span class="overlay__description">
-            Drag the left half to move and the right half to pan
-          </span>
-        </li>
-        <li
-          class="overlay__item overlay__item--touch"
-          data-input-methods="touch"
-          data-control-item="touchPinch"
-        >
-          <span class="overlay__keys">Pinch</span>
-          <span class="overlay__description">Zoom</span>
-        </li>
-        <li
-          class="overlay__item"
-          data-input-methods="keyboard"
-          data-control-item="cyclePoi"
-        >
-          <span class="overlay__keys">Q / E</span>
-          <span class="overlay__description">Cycle POIs</span>
-        </li>
-        <li
-          class="overlay__item"
-          data-input-methods="keyboard"
-          data-control-item="toggleTextMode"
-        >
-          <span class="overlay__keys">T</span>
-          <span class="overlay__description">Switch to text mode</span>
-        </li>
-        <li
-          class="overlay__item"
-          data-control="interact"
-          data-role="interact"
-          data-input-methods="keyboard pointer touch"
-          data-control-item="interact"
-          hidden
-        >
-          <span class="overlay__keys" data-role="interact-label">F</span>
-          <span
-            class="overlay__description"
-            data-control="interact-description"
-            data-role="interact-description"
-          >
-            Interact
-          </span>
-        </li>
-      </ul>
-      <button
-        class="overlay__collapse-toggle"
-        type="button"
-        data-role="control-toggle"
+          Open menu · Press H
+        </button>
+      </div>
+      <div
+        class="overlay__popover"
+        data-role="control-popover"
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby="control-overlay-heading"
         hidden
       >
-        Show controls
-      </button>
-      <button
-        class="overlay__help-button"
-        type="button"
-        data-control="help"
-        data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
-      >
-        Open menu · Press H
-      </button>
+        <div class="overlay__popover-header">
+          <p
+            class="overlay__heading"
+            data-control-text="heading"
+            id="control-overlay-heading"
+          >
+            Controls
+          </p>
+          <button
+            class="overlay__close"
+            type="button"
+            data-role="control-close"
+          >
+            Close
+          </button>
+        </div>
+        <ul class="overlay__list" data-role="control-list">
+          <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="keyboardMove"
+          >
+            <span class="overlay__keys">WASD / Arrow keys</span>
+            <span class="overlay__description">Move</span>
+          </li>
+          <li
+            class="overlay__item overlay__item--desktop"
+            data-input-methods="pointer"
+            data-control-item="pointerDrag"
+          >
+            <span class="overlay__keys">Left mouse button</span>
+            <span class="overlay__description">Drag to pan</span>
+          </li>
+          <li
+            class="overlay__item overlay__item--desktop"
+            data-input-methods="pointer"
+            data-control-item="pointerZoom"
+          >
+            <span class="overlay__keys">Scroll wheel</span>
+            <span class="overlay__description">Zoom</span>
+          </li>
+          <li
+            class="overlay__item overlay__item--touch"
+            data-input-methods="touch"
+            data-control-item="touchDrag"
+          >
+            <span class="overlay__keys">Touch</span>
+            <span class="overlay__description">
+              Drag the left half to move and the right half to pan
+            </span>
+          </li>
+          <li
+            class="overlay__item overlay__item--touch"
+            data-input-methods="touch"
+            data-control-item="touchPinch"
+          >
+            <span class="overlay__keys">Pinch</span>
+            <span class="overlay__description">Zoom</span>
+          </li>
+          <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="cyclePoi"
+          >
+            <span class="overlay__keys">Q / E</span>
+            <span class="overlay__description">Cycle POIs</span>
+          </li>
+          <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="toggleTextMode"
+          >
+            <span class="overlay__keys">T</span>
+            <span class="overlay__description">Switch to text mode</span>
+          </li>
+          <li
+            class="overlay__item"
+            data-control="interact"
+            data-role="interact"
+            data-input-methods="keyboard pointer touch"
+            data-control-item="interact"
+            hidden
+          >
+            <span class="overlay__keys" data-role="interact-label">F</span>
+            <span
+              class="overlay__description"
+              data-control="interact-description"
+              data-role="interact-description"
+            >
+              Interact
+            </span>
+          </li>
+        </ul>
+      </div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -277,6 +277,7 @@ import {
   KeyBindings,
   createKeyBindingAwareSource,
   formatKeyLabel,
+  shouldIgnoreShortcutEvent,
   type KeyBindingAction,
   type KeyBindingConfig,
 } from './systems/controls/keyBindings';
@@ -2207,6 +2208,7 @@ function initializeImmersiveScene(
     'moveRight',
     'interact',
     'help',
+    'toggleControls',
   ];
   const bindingActionSet = new Set<KeyBindingAction>(bindingActions);
 
@@ -2463,6 +2465,22 @@ function initializeImmersiveScene(
         initialLayout: 'desktop',
       })
     : null;
+  const normalizeShortcutKey = (key: string) =>
+    key.length === 1 ? key.toLowerCase() : key;
+  const controlsToggleKeydownHandler = (event: KeyboardEvent) => {
+    if (
+      event.repeat ||
+      shouldIgnoreShortcutEvent(event) ||
+      !keyBindings
+        .getBindings('toggleControls')
+        .includes(normalizeShortcutKey(event.key))
+    ) {
+      return;
+    }
+    event.preventDefault();
+    responsiveControlOverlay?.toggle();
+  };
+  window.addEventListener('keydown', controlsToggleKeydownHandler);
   const helpModal = createHelpModal({
     container: document.body,
     content: helpModalStrings,
@@ -4159,6 +4177,7 @@ function initializeImmersiveScene(
       unsubscribeGraphicsQuality = null;
     }
     graphicsQualityManager = null;
+    window.removeEventListener('keydown', controlsToggleKeydownHandler);
     if (beforeUnloadHandler) {
       window.removeEventListener('beforeunload', beforeUnloadHandler);
       beforeUnloadHandler = null;

--- a/src/systems/controls/keyBindings.ts
+++ b/src/systems/controls/keyBindings.ts
@@ -6,7 +6,8 @@ export type KeyBindingAction =
   | 'moveLeft'
   | 'moveRight'
   | 'interact'
-  | 'help';
+  | 'help'
+  | 'toggleControls';
 
 export type KeyBindingConfig = Partial<
   Record<KeyBindingAction, readonly string[]>
@@ -29,6 +30,7 @@ export const DEFAULT_KEY_BINDINGS: Record<KeyBindingAction, readonly string[]> =
     moveRight: ['d', 'ArrowRight'],
     interact: ['Enter', 'f', ' '],
     help: ['h', '?'],
+    toggleControls: ['c'],
   };
 
 type ActionEntries = [KeyBindingAction, readonly string[]];
@@ -184,6 +186,49 @@ export function formatKeyLabel(key: string | null | undefined): string {
     return `Arrow ${direction}`;
   }
   return key;
+}
+
+export function isTextEntryKeyEventTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === 'textarea' || tagName === 'select') {
+    return true;
+  }
+  if (tagName !== 'input') {
+    return Boolean(
+      target.closest(
+        '[contenteditable="true"], [data-keybinding-editing="true"]'
+      )
+    );
+  }
+  const input = target as HTMLInputElement;
+  const type = input.type.toLowerCase();
+  return ![
+    'button',
+    'checkbox',
+    'color',
+    'file',
+    'radio',
+    'range',
+    'reset',
+    'submit',
+  ].includes(type);
+}
+
+export function shouldIgnoreShortcutEvent(event: KeyboardEvent): boolean {
+  return (
+    event.defaultPrevented ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey ||
+    isTextEntryKeyEventTarget(event.target)
+  );
 }
 
 export function createKeyBindingAwareSource(

--- a/src/tests/controlOverlay.test.ts
+++ b/src/tests/controlOverlay.test.ts
@@ -28,12 +28,13 @@ describe('applyControlOverlayStrings', () => {
         </li>
       </ul>
       <button
-        class="overlay__collapse-toggle"
+        class="overlay__controls-button"
         type="button"
         data-role="control-toggle"
       >
         Toggle
       </button>
+      <button type="button" data-role="control-close">Close</button>
     `;
     const strings = getControlOverlayStrings('en');
     applyControlOverlayStrings(container, strings);
@@ -58,11 +59,7 @@ describe('applyControlOverlayStrings', () => {
     const toggle = container.querySelector<HTMLButtonElement>(
       '[data-role="control-toggle"]'
     );
-    expect(toggle?.textContent).toBe(strings.mobileToggle.expandLabel);
-    expect(toggle?.dataset.expandLabel).toBe(strings.mobileToggle.expandLabel);
-    expect(toggle?.dataset.collapseLabel).toBe(
-      strings.mobileToggle.collapseLabel
-    );
+    expect(toggle?.textContent).toBe(strings.heading);
     expect(toggle?.dataset.expandAnnouncement).toBe(
       strings.mobileToggle.expandAnnouncement
     );
@@ -71,6 +68,14 @@ describe('applyControlOverlayStrings', () => {
     );
     expect(toggle?.dataset.hudAnnounce).toBe(
       strings.mobileToggle.expandAnnouncement
+    );
+
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '[data-role="control-close"]'
+    );
+    expect(closeButton?.textContent).toBe(strings.mobileToggle.collapseLabel);
+    expect(closeButton?.dataset.hudAnnounce).toBe(
+      strings.mobileToggle.collapseAnnouncement
     );
   });
 });

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -1,29 +1,29 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import {
+  shouldIgnoreShortcutEvent,
+  DEFAULT_KEY_BINDINGS,
+} from '../systems/controls/keyBindings';
 import { createResponsiveControlOverlay } from '../ui/hud/responsiveControlOverlay';
 
 const createStrings = () => ({
   expandLabel: 'Show all controls',
-  collapseLabel: 'Hide extra controls',
-  expandAnnouncement: 'Showing the full controls list for mobile players.',
-  collapseAnnouncement: 'Hiding extra controls to keep the list compact.',
+  collapseLabel: 'Hide controls',
+  expandAnnouncement: 'Controls opened.',
+  collapseAnnouncement: 'Controls closed.',
 });
 
 const flushMicrotasks = async () => {
-  await new Promise((resolve) => queueMicrotask(resolve));
+  await Promise.resolve();
 };
 
-const COLLAPSE_STORAGE_KEY = 'hud:control-overlay-collapsed';
-
-beforeEach(() => {
-  localStorage.removeItem(COLLAPSE_STORAGE_KEY);
-});
-
-describe('createResponsiveControlOverlay', () => {
-  it('collapses mobile controls and toggles expanded state', async () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
+const createFixture = () => {
+  const container = document.createElement('div');
+  container.dataset.activeInput = 'keyboard';
+  container.innerHTML = `
+    <button type="button" data-role="control-toggle">Controls</button>
+    <section data-role="control-popover" hidden>
+      <button type="button" data-role="control-close">Close</button>
       <ul class="overlay__list" data-role="control-list">
         <li
           class="overlay__item"
@@ -37,24 +37,177 @@ describe('createResponsiveControlOverlay', () => {
         ></li>
         <li
           class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
+          data-control-item="touchDrag"
+          data-input-methods="touch"
         ></li>
       </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
+    </section>
+  `;
+  document.body.append(container);
 
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
+  const toggle = container.querySelector<HTMLButtonElement>(
+    '[data-role="control-toggle"]'
+  );
+  const popover = container.querySelector<HTMLElement>(
+    '[data-role="control-popover"]'
+  );
+  const closeButton = container.querySelector<HTMLButtonElement>(
+    '[data-role="control-close"]'
+  );
+  const list = container.querySelector<HTMLElement>(
+    '[data-role="control-list"]'
+  );
+
+  if (!toggle || !popover || !closeButton || !list) {
+    throw new Error('Fixture failed to render controls overlay elements.');
+  }
+
+  return { container, toggle, popover, closeButton, list };
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('createResponsiveControlOverlay', () => {
+  it('starts closed with a compact toggle and opens through the handle', () => {
+    const { container, toggle, popover, list } = createFixture();
     const handle = createResponsiveControlOverlay({
       container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
+      list,
+      toggle,
+      popover,
       strings: createStrings(),
       initialLayout: 'desktop',
     });
 
-    expect(toggle?.getAttribute('aria-controls')).toBe('control-overlay-list');
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+    expect(toggle.hidden).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.getAttribute('aria-controls')).toBe(
+      'control-overlay-popover'
+    );
+    expect(container.dataset.controlsOpen).toBe('false');
+
+    handle.open();
+
+    expect(handle.isOpen()).toBe(true);
+    expect(popover.hidden).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(container.dataset.controlsOpen).toBe('true');
+
+    handle.dispose();
+  });
+
+  it('toggles with the Controls button and closes with the close affordance', () => {
+    const { container, toggle, popover, closeButton, list } = createFixture();
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      toggle,
+      popover,
+      closeButton,
+      strings: createStrings(),
+    });
+
+    toggle.click();
+
+    expect(handle.isOpen()).toBe(true);
+    expect(popover.hidden).toBe(false);
+
+    closeButton.click();
+
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+    expect(document.activeElement).toBe(toggle);
+
+    handle.dispose();
+  });
+
+  it('closes on Escape while open', () => {
+    const { container, toggle, popover, list } = createFixture();
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      toggle,
+      popover,
+      strings: createStrings(),
+    });
+
+    handle.open();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+    expect(document.activeElement).toBe(toggle);
+
+    handle.dispose();
+  });
+
+  it('closes on outside pointer down but ignores interactions inside the popover', () => {
+    const { container, toggle, popover, list } = createFixture();
+    const outside = document.createElement('button');
+    document.body.append(outside);
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      toggle,
+      popover,
+      strings: createStrings(),
+    });
+
+    handle.open();
+    popover.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    expect(handle.isOpen()).toBe(true);
+
+    outside.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+
+    handle.dispose();
+  });
+
+  it('closes when switching to mobile layout and remains available', () => {
+    const { container, toggle, popover, list } = createFixture();
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      toggle,
+      popover,
+      strings: createStrings(),
+      initialLayout: 'desktop',
+      defaultOpen: true,
+    });
+
+    expect(handle.isOpen()).toBe(true);
+
+    handle.setLayout('mobile');
+
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+    expect(toggle.hidden).toBe(false);
+    expect(container.dataset.hudLayout).toBe('mobile');
+
+    toggle.click();
+
+    expect(handle.isOpen()).toBe(true);
+    expect(popover.hidden).toBe(false);
+
+    handle.dispose();
+  });
+
+  it('refreshes active input highlighting without hiding other input methods', async () => {
+    const { container, toggle, popover, list } = createFixture();
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      toggle,
+      popover,
+      strings: createStrings(),
+    });
 
     const keyboardItem = container.querySelector<HTMLElement>(
       '[data-control-item="keyboardMove"]'
@@ -62,443 +215,88 @@ describe('createResponsiveControlOverlay', () => {
     const pointerItem = container.querySelector<HTMLElement>(
       '[data-control-item="pointerDrag"]'
     );
-    const interactItem = container.querySelector<HTMLElement>(
-      '[data-control-item="interact"]'
-    );
 
-    handle.setLayout('mobile');
-
-    expect(container.dataset.controlCollapsed).toBe('true');
-    expect(toggle?.hidden).toBe(false);
-    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(pointerItem?.hidden).toBe(true);
-    expect(pointerItem?.dataset.mobileCollapsed).toBe('true');
-    expect(interactItem?.hidden).toBe(false);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(keyboardItem?.dataset.state).toBe('active');
+    expect(pointerItem?.hidden).toBe(false);
 
     container.dataset.activeInput = 'pointer';
     await flushMicrotasks();
 
-    expect(pointerItem?.hidden).toBe(false);
-    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(keyboardItem?.hidden).toBe(true);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBe('true');
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
-    expect(pointerItem?.hidden).toBe(false);
-    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(keyboardItem?.dataset.state).toBeUndefined();
     expect(keyboardItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
-
-    handle.setLayout('desktop');
-    expect(container.dataset.controlCollapsed).toBeUndefined();
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.hasAttribute('aria-expanded')).toBe(false);
+    expect(pointerItem?.dataset.state).toBe('active');
     expect(pointerItem?.hidden).toBe(false);
-    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
+
+    handle.dispose();
   });
 
-  it('updates toggle labels when strings change', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="pointerDrag"
-          data-input-methods="pointer"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
+  it('updates announcements when strings refresh', () => {
+    const { container, toggle, popover, closeButton, list } = createFixture();
     const handle = createResponsiveControlOverlay({
       container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
+      list,
+      toggle,
+      popover,
+      closeButton,
       strings: createStrings(),
-      initialLayout: 'desktop',
     });
-
-    handle.setLayout('mobile');
-
-    expect(toggle?.textContent).toBe('Show all controls');
-    expect(toggle?.dataset.hudAnnounce).toBe(
-      'Showing the full controls list for mobile players.'
-    );
 
     handle.setStrings({
-      expandLabel: 'Expand',
-      collapseLabel: 'Collapse',
-      expandAnnouncement: 'Expand controls.',
-      collapseAnnouncement: 'Collapse controls.',
+      expandLabel: 'Afficher les commandes',
+      collapseLabel: 'Masquer les commandes',
+      expandAnnouncement: 'Commandes ouvertes.',
+      collapseAnnouncement: 'Commandes fermées.',
     });
 
-    expect(toggle?.textContent).toBe('Expand');
-    expect(toggle?.dataset.hudAnnounce).toBe('Expand controls.');
+    expect(toggle.dataset.hudAnnounce).toBe('Commandes fermées.');
+    expect(closeButton.dataset.hudAnnounce).toBe('Commandes fermées.');
 
-    handle.dispose();
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.textContent).toBe('Expand');
-  });
+    handle.open();
 
-  it('respects baseline hidden states while collapsing and disposing', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'pointer';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
-          hidden
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-    });
-
-    const keyboardItem = container.querySelector<HTMLElement>(
-      '[data-control-item="keyboardMove"]'
-    );
-    const interactItem = container.querySelector<HTMLElement>(
-      '[data-control-item="interact"]'
-    );
-
-    expect(keyboardItem?.hidden).toBe(true);
-    expect(interactItem?.hidden).toBe(true);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(interactItem?.hidden).toBe(true);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-
-    handle.dispose();
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(interactItem?.hidden).toBe(true);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-  });
-
-  it('preserves runtime visibility for interact prompt after collapsing', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'pointer';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
-          hidden
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-    });
-
-    const interactItem = container.querySelector<HTMLElement>(
-      '[data-control-item="interact"]'
-    );
-
-    expect(interactItem?.hidden).toBe(true);
-
-    if (interactItem) {
-      interactItem.hidden = false;
-    }
-
-    handle.refresh();
-
-    expect(interactItem?.hidden).toBe(false);
-    expect(container.dataset.controlCollapsed).toBe('true');
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(interactItem?.hidden).toBe(false);
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(container.dataset.controlCollapsed).toBe('true');
-    expect(interactItem?.hidden).toBe(false);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(toggle.dataset.hudAnnounce).toBe('Commandes ouvertes.');
 
     handle.dispose();
   });
 
-  it('persists mobile collapse preference across layout changes', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="pointerDrag"
-          data-input-methods="pointer"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const store = new Map<string, string>([
-      ['hud:control-overlay-collapsed', 'false'],
-    ]);
-    const storage = {
-      getItem: vi.fn((key: string) => store.get(key) ?? null),
-      setItem: vi.fn((key: string, value: string) => {
-        store.set(key, value);
-      }),
-    };
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
+  it('removes listeners and restores initial state on dispose', () => {
+    const { container, toggle, popover, list } = createFixture();
     const handle = createResponsiveControlOverlay({
       container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
+      list,
+      toggle,
+      popover,
       strings: createStrings(),
-      initialLayout: 'mobile',
-      storage,
-      defaultCollapsed: true,
-      windowTarget: undefined,
     });
 
-    expect(storage.getItem).toHaveBeenCalledWith(
-      'hud:control-overlay-collapsed'
-    );
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(storage.setItem).toHaveBeenCalledWith(
-      'hud:control-overlay-collapsed',
-      'true'
-    );
-    expect(container.dataset.controlCollapsed).toBe('true');
-
-    handle.setLayout('desktop');
-    expect(container.dataset.controlCollapsed).toBeUndefined();
-
-    handle.setLayout('mobile');
-    expect(container.dataset.controlCollapsed).toBe('true');
-    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
-
+    handle.open();
     handle.dispose();
+
+    expect(popover.hidden).toBe(true);
+    expect(toggle.getAttribute('aria-expanded')).toBeNull();
+    expect(container.dataset.controlsOpen).toBeUndefined();
+
+    toggle.click();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(popover.hidden).toBe(true);
   });
 
-  it('ignores storage access errors while updating collapse state', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
+  it('keeps C in the key binding model and ignores editing or modified C shortcuts', () => {
+    expect(DEFAULT_KEY_BINDINGS.toggleControls).toEqual(['c']);
 
-    const storageError = new Error('denied');
-    const storage = {
-      getItem: vi.fn(() => {
-        throw storageError;
-      }),
-      setItem: vi.fn(() => {
-        throw storageError;
-      }),
-    };
+    const input = document.createElement('input');
+    document.body.append(input);
+    const inputEvent = new KeyboardEvent('keydown', { key: 'c' });
+    Object.defineProperty(inputEvent, 'target', { value: input });
 
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-      storage,
-    });
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.getAttribute('aria-expanded')).toBeNull();
-
-    expect(() => (toggle as HTMLButtonElement).click()).not.toThrow();
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(storage.setItem).not.toHaveBeenCalled();
-
-    handle.dispose();
-  });
-
-  it('falls back gracefully when localStorage is unavailable', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const windowTarget = Object.defineProperty({}, 'localStorage', {
-      get() {
-        throw new Error('blocked');
-      },
-    });
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-      storage: null,
-      windowTarget: windowTarget as unknown as Window,
-    });
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.getAttribute('aria-expanded')).toBeNull();
-    expect(() => (toggle as HTMLButtonElement).click()).not.toThrow();
-    expect(container.dataset.controlCollapsed).toBe('false');
-
-    handle.dispose();
-  });
-
-  it('initializes when no storage or window target are available', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-      windowTarget: undefined,
-    });
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.getAttribute('aria-expanded')).toBeNull();
-    expect(() => (toggle as HTMLButtonElement).click()).not.toThrow();
-    expect(container.dataset.controlCollapsed).toBe('false');
-
-    handle.dispose();
-  });
-
-  it('hides the collapse toggle when no controls need collapsing', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-    });
-
-    const keyboardItem = container.querySelector<HTMLElement>(
-      '[data-control-item="keyboardMove"]'
-    );
-    const interactItem = container.querySelector<HTMLElement>(
-      '[data-control-item="interact"]'
-    );
-
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.hasAttribute('aria-expanded')).toBe(false);
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(interactItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-
-    handle.dispose();
+    expect(shouldIgnoreShortcutEvent(inputEvent)).toBe(true);
+    expect(
+      shouldIgnoreShortcutEvent(new KeyboardEvent('keydown', { key: 'c' }))
+    ).toBe(false);
+    expect(
+      shouldIgnoreShortcutEvent(
+        new KeyboardEvent('keydown', { key: 'c', ctrlKey: true })
+      )
+    ).toBe(true);
   });
 });

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -5,7 +5,8 @@ const CONTROL_KEYS_SELECTOR = '.overlay__keys';
 const CONTROL_DESCRIPTION_SELECTOR = '.overlay__description';
 const INTERACT_LABEL_SELECTOR = '[data-role="interact-label"]';
 const INTERACT_DESCRIPTION_SELECTOR = '[data-role="interact-description"]';
-const COLLAPSE_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
+const CONTROL_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
+const CONTROL_CLOSE_SELECTOR = '[data-role="control-close"]';
 
 function setTextContent(
   element: Element | null | undefined,
@@ -62,21 +63,22 @@ export function applyControlOverlayStrings(
     );
   }
 
-  const collapseToggle = container.querySelector<HTMLButtonElement>(
-    COLLAPSE_TOGGLE_SELECTOR
+  const controlToggle = container.querySelector<HTMLButtonElement>(
+    CONTROL_TOGGLE_SELECTOR
   );
-  if (collapseToggle) {
-    const {
-      expandLabel,
-      collapseLabel,
-      expandAnnouncement,
-      collapseAnnouncement,
-    } = strings.mobileToggle;
-    setTextContent(collapseToggle, expandLabel);
-    collapseToggle.dataset.expandLabel = expandLabel;
-    collapseToggle.dataset.collapseLabel = collapseLabel;
-    collapseToggle.dataset.expandAnnouncement = expandAnnouncement;
-    collapseToggle.dataset.collapseAnnouncement = collapseAnnouncement;
-    collapseToggle.dataset.hudAnnounce = expandAnnouncement;
+  if (controlToggle) {
+    const { expandAnnouncement, collapseAnnouncement } = strings.mobileToggle;
+    setTextContent(controlToggle, strings.heading);
+    controlToggle.dataset.expandAnnouncement = expandAnnouncement;
+    controlToggle.dataset.collapseAnnouncement = collapseAnnouncement;
+    controlToggle.dataset.hudAnnounce = expandAnnouncement;
+  }
+
+  const closeButton = container.querySelector<HTMLButtonElement>(
+    CONTROL_CLOSE_SELECTOR
+  );
+  if (closeButton) {
+    setTextContent(closeButton, strings.mobileToggle.collapseLabel);
+    closeButton.dataset.hudAnnounce = strings.mobileToggle.collapseAnnouncement;
   }
 }

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -7,6 +7,10 @@ export type ResponsiveControlOverlayStrings =
   ControlOverlayStrings['mobileToggle'];
 
 export interface ResponsiveControlOverlayHandle {
+  open(): void;
+  close(): void;
+  toggle(): void;
+  isOpen(): boolean;
   setLayout(layout: HudLayout): void;
   setStrings(strings: ResponsiveControlOverlayStrings): void;
   refresh(): void;
@@ -17,9 +21,14 @@ export interface ResponsiveControlOverlayOptions {
   container: HTMLElement;
   list?: HTMLElement | null;
   toggle?: HTMLButtonElement | null;
+  popover?: HTMLElement | null;
+  closeButton?: HTMLButtonElement | null;
   strings: ResponsiveControlOverlayStrings;
   initialLayout?: HudLayout;
+  defaultOpen?: boolean;
+  /** @deprecated kept for compatibility with the previous mobile collapse API. */
   defaultCollapsed?: boolean;
+  /** @deprecated kept for compatibility with the previous mobile collapse API. */
   storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
   windowTarget?: Window;
 }
@@ -27,10 +36,11 @@ export interface ResponsiveControlOverlayOptions {
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
 const CONTROL_ITEM_SELECTOR = '[data-control-item]';
 const CONTROL_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
-const CONTROL_COLLAPSED_KEY = 'controlCollapsed';
-const MOBILE_COLLAPSED_KEY = 'mobileCollapsed';
-const CONTROL_LIST_ID = 'control-overlay-list';
-const COLLAPSE_STORAGE_KEY = 'hud:control-overlay-collapsed';
+const CONTROL_POPOVER_SELECTOR = '[data-role="control-popover"]';
+const CONTROL_CLOSE_SELECTOR = '[data-role="control-close"]';
+const CONTROL_OPEN_KEY = 'controlsOpen';
+const ACTIVE_STATE = 'active';
+const CONTROL_POPOVER_ID = 'control-overlay-popover';
 
 const INPUT_METHODS: ReadonlyArray<InputMethod> = [
   'keyboard',
@@ -65,168 +75,102 @@ const matchActiveMethod = (
   active: InputMethod | null
 ): boolean => {
   if (!active) {
-    return true;
+    return false;
   }
   if (methods.includes(active)) {
     return true;
   }
-  if (active === 'gamepad' && methods.includes('keyboard')) {
-    return true;
-  }
-  return false;
+  return active === 'gamepad' && methods.includes('keyboard');
 };
 
-const applyAnnouncement = (
+const ensurePopoverId = (popover: HTMLElement): string => {
+  if (popover.id) {
+    return popover.id;
+  }
+  popover.id = CONTROL_POPOVER_ID;
+  return popover.id;
+};
+
+const setAnnouncement = (
   toggle: HTMLButtonElement,
   strings: ResponsiveControlOverlayStrings,
-  collapsed: boolean
+  open: boolean
 ) => {
-  toggle.dataset.hudAnnounce = collapsed
+  toggle.dataset.hudAnnounce = open
     ? strings.expandAnnouncement
     : strings.collapseAnnouncement;
 };
 
-const applyToggleLabel = (
+const syncExpandedState = (
+  container: HTMLElement,
+  popover: HTMLElement,
   toggle: HTMLButtonElement,
+  closeButton: HTMLButtonElement | null,
   strings: ResponsiveControlOverlayStrings,
-  collapsed: boolean
+  open: boolean
 ) => {
-  toggle.textContent = collapsed ? strings.expandLabel : strings.collapseLabel;
-  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
-  applyAnnouncement(toggle, strings, collapsed);
-};
-
-const applyContainerState = (
-  container: HTMLElement,
-  layout: HudLayout,
-  collapsed: boolean
-) => {
-  if (layout !== 'mobile') {
-    delete (container.dataset as Record<string, string | undefined>)[
-      CONTROL_COLLAPSED_KEY
-    ];
-    return;
-  }
-  container.dataset[CONTROL_COLLAPSED_KEY] = collapsed ? 'true' : 'false';
-};
-
-const applyCollapsedState = (
-  container: HTMLElement,
-  items: ReadonlyArray<HTMLElement>,
-  collapsedHiddenStates: WeakMap<HTMLElement, boolean>,
-  layout: HudLayout,
-  collapsed: boolean,
-  collapsibleTargets: ReadonlyArray<HTMLElement>
-) => {
-  const collapsibleSet =
-    collapsibleTargets.length > 0 ? new Set(collapsibleTargets) : null;
-  const shouldCollapse =
-    layout === 'mobile' && collapsed && collapsibleTargets.length > 0;
-
-  const restoreCollapsedState = (item: HTMLElement) => {
-    delete (item.dataset as Record<string, string | undefined>)[
-      MOBILE_COLLAPSED_KEY
-    ];
-    if (!collapsedHiddenStates.has(item)) {
-      return;
-    }
-    const previousHidden = collapsedHiddenStates.get(item);
-    collapsedHiddenStates.delete(item);
-    if (previousHidden !== undefined) {
-      item.hidden = previousHidden;
-    }
-  };
-
-  for (const item of items) {
-    if (!shouldCollapse || !collapsibleSet?.has(item)) {
-      restoreCollapsedState(item);
-      continue;
-    }
-
-    if (!collapsedHiddenStates.has(item)) {
-      collapsedHiddenStates.set(item, item.hidden);
-    }
-    item.dataset[MOBILE_COLLAPSED_KEY] = 'true';
-    item.hidden = true;
+  popover.hidden = !open;
+  toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  container.dataset[CONTROL_OPEN_KEY] = open ? 'true' : 'false';
+  setAnnouncement(toggle, strings, open);
+  if (closeButton) {
+    closeButton.dataset.hudAnnounce = strings.collapseAnnouncement;
   }
 };
 
-const getCollapsibleItems = (
+const applyActiveInputState = (
   container: HTMLElement,
   items: ReadonlyArray<HTMLElement>
-): ReadonlyArray<HTMLElement> => {
-  const activeMethod = getActiveMethod(container);
-  return items.filter((item) => {
-    const methods = parseInputMethods(item.dataset.inputMethods);
-    const controlId = item.dataset.controlItem ?? '';
-    if (controlId === 'interact') {
-      return false;
-    }
-    return !matchActiveMethod(methods, activeMethod);
-  });
-};
-
-const ensureControlListId = (list: HTMLElement): string => {
-  if (list.id) {
-    return list.id;
-  }
-  list.id = CONTROL_LIST_ID;
-  return list.id;
-};
-
-const getStorage = (
-  windowTarget?: Window,
-  storage?: Pick<Storage, 'getItem' | 'setItem'> | null
-): Pick<Storage, 'getItem' | 'setItem'> | null => {
-  if (storage === null) {
-    return null;
-  }
-  if (storage) {
-    return storage;
-  }
-  if (!windowTarget) {
-    return null;
-  }
-  try {
-    return windowTarget.localStorage ?? null;
-  } catch {
-    return null;
-  }
-};
-
-const readPersistedCollapsed = (
-  storage: Pick<Storage, 'getItem'> | null
-): boolean | null => {
-  if (!storage) {
-    return null;
-  }
-  try {
-    const value = storage.getItem(COLLAPSE_STORAGE_KEY);
-    if (value === 'true') {
-      return true;
-    }
-    if (value === 'false') {
-      return false;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-};
-
-const persistCollapsed = (
-  storage: Pick<Storage, 'setItem'> | null,
-  collapsed: boolean
 ) => {
-  if (!storage) {
-    return;
-  }
-  try {
-    storage.setItem(COLLAPSE_STORAGE_KEY, collapsed ? 'true' : 'false');
-  } catch {
-    /* ignore storage errors */
+  const active = getActiveMethod(container);
+  for (const item of items) {
+    const methods = parseInputMethods(item.dataset.inputMethods);
+    if (matchActiveMethod(methods, active)) {
+      item.dataset.state = ACTIVE_STATE;
+    } else if (item.dataset.state === ACTIVE_STATE) {
+      delete item.dataset.state;
+    }
   }
 };
+
+const getEventTargetNode = (event: Event): Node | null => {
+  const target = event.target;
+  return target instanceof Node ? target : null;
+};
+
+const isEventInside = (event: Event, elements: ReadonlyArray<HTMLElement>) => {
+  const target = getEventTargetNode(event);
+  return Boolean(
+    target && elements.some((element) => element.contains(target))
+  );
+};
+
+const noopHandle = (): ResponsiveControlOverlayHandle => ({
+  open() {
+    /* noop */
+  },
+  close() {
+    /* noop */
+  },
+  toggle() {
+    /* noop */
+  },
+  isOpen() {
+    return false;
+  },
+  setLayout() {
+    /* noop */
+  },
+  setStrings() {
+    /* noop */
+  },
+  refresh() {
+    /* noop */
+  },
+  dispose() {
+    /* noop */
+  },
+});
 
 export function createResponsiveControlOverlay(
   options: ResponsiveControlOverlayOptions
@@ -235,104 +179,106 @@ export function createResponsiveControlOverlay(
     container,
     strings,
     initialLayout = 'desktop',
-    defaultCollapsed,
+    defaultOpen = false,
     windowTarget = typeof window !== 'undefined' ? window : undefined,
-    storage: providedStorage,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
   const toggle =
     options.toggle ?? container.querySelector(CONTROL_TOGGLE_SELECTOR);
+  const popover =
+    options.popover ?? container.querySelector(CONTROL_POPOVER_SELECTOR);
+  const closeButton =
+    options.closeButton ?? container.querySelector(CONTROL_CLOSE_SELECTOR);
 
   if (
     !(list instanceof HTMLElement) ||
-    !(toggle instanceof HTMLButtonElement)
+    !(toggle instanceof HTMLButtonElement) ||
+    !(popover instanceof HTMLElement)
   ) {
-    return {
-      setLayout() {
-        /* noop */
-      },
-      setStrings() {
-        /* noop */
-      },
-      refresh() {
-        /* noop */
-      },
-      dispose() {
-        /* noop */
-      },
-    };
+    return noopHandle();
   }
 
+  const resolvedCloseButton =
+    closeButton instanceof HTMLButtonElement ? closeButton : null;
   const controlItems = Array.from(
     list.querySelectorAll<HTMLElement>(CONTROL_ITEM_SELECTOR)
   );
-  const initialHiddenStates = new WeakMap<HTMLElement, boolean>();
-  const collapsedHiddenStates = new WeakMap<HTMLElement, boolean>();
-
-  controlItems.forEach((item) => {
-    initialHiddenStates.set(item, item.hidden);
-  });
-
-  const listId = ensureControlListId(list);
-  toggle.setAttribute('aria-controls', listId);
-
-  const storage = getStorage(windowTarget, providedStorage);
-  const readStoredCollapsed = () => readPersistedCollapsed(storage);
-
-  const resolveMobileCollapsed = () =>
-    readStoredCollapsed() ?? defaultCollapsed ?? true;
+  const initialOpen = defaultOpen && initialLayout !== 'mobile';
+  const initialPopoverHidden = popover.hidden;
+  const initialToggleText = toggle.textContent ?? '';
+  const initialCloseText = resolvedCloseButton?.textContent ?? '';
+  const popoverId = ensurePopoverId(popover);
 
   let layout: HudLayout = initialLayout;
-  let collapsed = layout === 'mobile' ? resolveMobileCollapsed() : false;
   let currentStrings: ResponsiveControlOverlayStrings = { ...strings };
+  let open = initialOpen;
   let disposed = false;
+
+  toggle.hidden = false;
+  toggle.setAttribute('aria-controls', popoverId);
+  toggle.setAttribute('aria-haspopup', 'dialog');
+  if (resolvedCloseButton) {
+    resolvedCloseButton.setAttribute('aria-controls', popoverId);
+  }
 
   const update = () => {
     if (disposed) {
       return;
     }
-    const collapsibleItems = getCollapsibleItems(container, controlItems);
-    const canCollapse = layout === 'mobile' && collapsibleItems.length > 0;
-    const effectiveCollapsed = canCollapse ? collapsed : false;
-
-    applyContainerState(container, layout, effectiveCollapsed);
-    applyCollapsedState(
+    applyActiveInputState(container, controlItems);
+    syncExpandedState(
       container,
-      controlItems,
-      collapsedHiddenStates,
-      layout,
-      effectiveCollapsed,
-      collapsibleItems
+      popover,
+      toggle,
+      resolvedCloseButton,
+      currentStrings,
+      open
     );
-    if (layout === 'mobile' && canCollapse) {
-      persistCollapsed(storage, collapsed);
-      toggle.hidden = false;
-      applyToggleLabel(toggle, currentStrings, effectiveCollapsed);
-    } else {
-      toggle.hidden = true;
-      toggle.removeAttribute('aria-expanded');
-      toggle.dataset.hudAnnounce = '';
-    }
+    container.dataset.hudLayout = layout;
   };
 
-  const setCollapsed = (next: boolean) => {
-    const normalized = layout === 'mobile' ? next : false;
-    if (collapsed === normalized) {
+  const setOpen = (nextOpen: boolean) => {
+    if (open === nextOpen) {
+      update();
       return;
     }
-    collapsed = normalized;
+    open = nextOpen;
     update();
   };
 
   const handleToggleClick = () => {
-    if (layout !== 'mobile') {
+    setOpen(!open);
+  };
+
+  const handleCloseClick = () => {
+    setOpen(false);
+    toggle.focus({ preventScroll: true });
+  };
+
+  const handleDocumentPointerDown = (event: PointerEvent) => {
+    if (!open || isEventInside(event, [popover, toggle])) {
       return;
     }
-    setCollapsed(!collapsed);
+    setOpen(false);
+  };
+
+  const handleDocumentKeyDown = (event: KeyboardEvent) => {
+    if (!open || event.key !== 'Escape') {
+      return;
+    }
+    event.preventDefault();
+    setOpen(false);
+    toggle.focus({ preventScroll: true });
   };
 
   toggle.addEventListener('click', handleToggleClick);
+  resolvedCloseButton?.addEventListener('click', handleCloseClick);
+  windowTarget?.document.addEventListener(
+    'pointerdown',
+    handleDocumentPointerDown
+  );
+  windowTarget?.document.addEventListener('keydown', handleDocumentKeyDown);
 
   const observer = new MutationObserver((mutations) => {
     if (
@@ -354,24 +300,28 @@ export function createResponsiveControlOverlay(
   update();
 
   return {
+    open() {
+      setOpen(true);
+    },
+    close() {
+      setOpen(false);
+    },
+    toggle() {
+      setOpen(!open);
+    },
+    isOpen() {
+      return open;
+    },
     setLayout(nextLayout: HudLayout) {
-      if (layout === nextLayout) {
-        update();
-        return;
-      }
       layout = nextLayout;
       if (layout === 'mobile') {
-        collapsed = resolveMobileCollapsed();
-      } else {
-        collapsed = false;
+        open = false;
       }
       update();
     },
     setStrings(nextStrings: ResponsiveControlOverlayStrings) {
       currentStrings = { ...nextStrings };
-      if (layout === 'mobile') {
-        applyToggleLabel(toggle, currentStrings, collapsed);
-      }
+      update();
     },
     refresh() {
       update();
@@ -383,18 +333,34 @@ export function createResponsiveControlOverlay(
       disposed = true;
       observer.disconnect();
       toggle.removeEventListener('click', handleToggleClick);
-      toggle.hidden = true;
+      resolvedCloseButton?.removeEventListener('click', handleCloseClick);
+      windowTarget?.document.removeEventListener(
+        'pointerdown',
+        handleDocumentPointerDown
+      );
+      windowTarget?.document.removeEventListener(
+        'keydown',
+        handleDocumentKeyDown
+      );
+      popover.hidden = initialPopoverHidden;
       toggle.removeAttribute('aria-expanded');
+      toggle.removeAttribute('aria-controls');
+      toggle.removeAttribute('aria-haspopup');
       toggle.dataset.hudAnnounce = '';
-      toggle.textContent = currentStrings.expandLabel;
+      toggle.textContent = initialToggleText;
+      if (resolvedCloseButton) {
+        resolvedCloseButton.removeAttribute('aria-controls');
+        resolvedCloseButton.dataset.hudAnnounce = '';
+        resolvedCloseButton.textContent = initialCloseText;
+      }
       delete (container.dataset as Record<string, string | undefined>)[
-        CONTROL_COLLAPSED_KEY
+        CONTROL_OPEN_KEY
       ];
+      delete container.dataset.hudLayout;
       for (const item of controlItems) {
-        delete (item.dataset as Record<string, string | undefined>)[
-          MOBILE_COLLAPSED_KEY
-        ];
-        item.hidden = initialHiddenStates.get(item) ?? false;
+        if (item.dataset.state === ACTIVE_STATE) {
+          delete item.dataset.state;
+        }
       }
     },
   };

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -535,7 +535,8 @@ canvas {
   overflow: hidden;
 }
 
-html[data-hudLayout='mobile'] .audio-subtitles {
+:root[data-hud-layout='mobile'] .audio-subtitles,
+:root[data-hudLayout='mobile'] .audio-subtitles {
   bottom: 6.5rem;
   padding: 0.85rem 1.05rem;
   font-size: 0.95rem;
@@ -1287,22 +1288,85 @@ html[data-hudLayout='mobile'] .audio-subtitles {
 
 .overlay {
   position: fixed;
-  bottom: 1.5rem;
-  left: 1.5rem;
-  padding: 1rem 1.25rem;
-  border-radius: 0.75rem;
-  background: var(--hud-surface-bg);
+  top: calc(env(safe-area-inset-top, 0px) + 1rem);
+  right: calc(env(safe-area-inset-right, 0px) + 1rem);
+  z-index: 40;
   color: var(--hud-surface-text);
-  backdrop-filter: blur(12px);
   font-size: 0.9rem;
   line-height: 1.4;
-  max-width: 20rem;
-  border: 1px solid var(--hud-surface-border);
-  box-shadow: var(--hud-surface-shadow);
-  overflow: visible;
 }
 
-.overlay::after {
+.overlay__actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.overlay__controls-button,
+.overlay__help-button,
+.overlay__close {
+  border: 1px solid rgba(123, 209, 255, 0.4);
+  background:
+    linear-gradient(140deg, rgba(12, 25, 39, 0.92), rgba(16, 43, 70, 0.78)),
+    rgba(9, 18, 28, 0.88);
+  color: #e7f4ff;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 120ms ease;
+}
+
+.overlay__controls-button:hover,
+.overlay__controls-button:focus-visible,
+.overlay__help-button:hover,
+.overlay__help-button:focus-visible,
+.overlay__close:hover,
+.overlay__close:focus-visible {
+  border-color: rgba(158, 232, 255, 0.8);
+  box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.overlay__controls-button:active,
+.overlay__help-button:active,
+.overlay__close:active {
+  transform: translateY(0);
+}
+
+.overlay__controls-button,
+.overlay__help-button {
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  backdrop-filter: blur(12px);
+}
+
+.overlay__popover {
+  position: absolute;
+  top: calc(100% + 0.7rem);
+  right: 0;
+  width: min(22rem, calc(100vw - 2rem - env(safe-area-inset-left, 0px)));
+  max-height: min(70vh, 32rem);
+  padding: 1rem 1.05rem;
+  overflow: auto;
+  overscroll-behavior: contain;
+  border-radius: 0.9rem;
+  background: var(--hud-surface-bg);
+  border: 1px solid var(--hud-surface-border);
+  box-shadow: var(--hud-surface-shadow);
+  backdrop-filter: blur(12px);
+}
+
+.overlay__popover[hidden] {
+  display: none;
+}
+
+.overlay__popover::after {
   content: '';
   position: absolute;
   inset: -0.9rem;
@@ -1319,13 +1383,28 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   transition: opacity 160ms ease;
 }
 
+.overlay__popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
 .overlay__heading {
-  margin: 0 0 0.75rem;
+  margin: 0;
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--hud-surface-heading);
+}
+
+.overlay__close {
+  flex: none;
+  padding: 0.4rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.76rem;
 }
 
 .overlay__list {
@@ -1341,23 +1420,42 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
+  border-radius: 0.6rem;
+  padding: 0.25rem 0.35rem;
+  transition:
+    background-color 180ms ease,
+    box-shadow 180ms ease,
+    color 180ms ease;
 }
 
 .overlay__item[hidden] {
   display: none;
 }
 
+.overlay__item[data-state='active'] {
+  background: rgba(32, 82, 128, 0.28);
+  box-shadow: 0 0 0 1px rgba(114, 210, 255, 0.28);
+}
+
 .overlay__keys {
   display: inline-block;
-  width: 11rem;
+  min-width: 7rem;
   font-weight: 600;
-  color: var(--hud-surface-accent);
   letter-spacing: 0.02em;
+  color: var(--hud-surface-accent);
+}
+
+.overlay__item[data-state='active'] .overlay__keys {
+  color: rgba(173, 236, 255, 0.96);
 }
 
 .overlay__description {
   flex: 1;
   color: var(--hud-surface-muted-text);
+}
+
+.overlay__item[data-state='active'] .overlay__description {
+  color: rgba(244, 250, 255, 0.96);
 }
 
 .overlay__item--touch {
@@ -1374,86 +1472,44 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   }
 }
 
-:root[data-hud-layout='mobile'] {
+:root[data-hud-layout='mobile'],
+:root[data-hudLayout='mobile'] {
   --hud-mobile-safe-zone: calc(8.5rem + env(safe-area-inset-bottom, 0px));
 }
 
-:root[data-hud-layout='mobile'] .overlay {
-  bottom: var(--hud-mobile-safe-zone);
-  left: 1rem;
-  right: 1rem;
-  max-width: none;
-  width: auto;
-  padding: 0.9rem 1rem;
+:root[data-hud-layout='mobile'] .overlay,
+:root[data-hudLayout='mobile'] .overlay {
+  top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
+  right: calc(env(safe-area-inset-right, 0px) + 0.75rem);
+  left: calc(env(safe-area-inset-left, 0px) + 0.75rem);
   font-size: 0.85rem;
-  line-height: 1.5;
 }
 
-:root[data-hud-layout='mobile'] .overlay__keys {
-  width: 8.5rem;
+:root[data-hud-layout='mobile'] .overlay__actions,
+:root[data-hudLayout='mobile'] .overlay__actions {
+  flex-wrap: wrap;
 }
 
-:root[data-hud-layout='mobile'] .poi-tooltip-overlay {
+:root[data-hud-layout='mobile'] .overlay__popover,
+:root[data-hudLayout='mobile'] .overlay__popover {
+  width: auto;
+  left: 0;
+  max-height: min(62vh, 28rem);
+  padding: 0.85rem 0.9rem;
+}
+
+:root[data-hud-layout='mobile'] .overlay__keys,
+:root[data-hudLayout='mobile'] .overlay__keys {
+  min-width: 5.75rem;
+}
+
+:root[data-hud-layout='mobile'] .poi-tooltip-overlay,
+:root[data-hudLayout='mobile'] .poi-tooltip-overlay {
   bottom: calc(var(--hud-mobile-safe-zone) + 1rem);
   left: 1rem;
   right: 1rem;
   max-width: none;
   width: auto;
-}
-
-:root[data-accessibility-motion='reduced'] .audio-hud,
-:root[data-accessibility-motion='reduced'] .motion-blur-control,
-:root[data-accessibility-motion='reduced'] .graphics-quality,
-:root[data-accessibility-motion='reduced'] .mode-toggle,
-:root[data-accessibility-motion='reduced'] .overlay,
-:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
-:root[data-accessibility-motion='reduced'] .accessibility-presets {
-  transition: none !important;
-  animation: none !important;
-}
-
-:root[data-accessibility-contrast='high'] {
-  --hud-surface-bg: rgba(4, 10, 18, 0.92);
-  --hud-surface-raised-bg: rgba(10, 18, 30, 0.96);
-  --hud-surface-border: rgba(214, 238, 255, 0.5);
-  --hud-surface-raised-border: rgba(174, 238, 255, 0.6);
-  --hud-surface-text: #f5f9ff;
-  --hud-surface-muted-text: rgba(240, 250, 255, 0.9);
-  --hud-surface-heading: #f4fbff;
-  --hud-surface-accent: rgba(174, 238, 255, 0.7);
-  --hud-surface-shadow: 0 14px 36px rgba(2, 6, 12, 0.7);
-}
-
-.overlay__help-button {
-  margin-top: 0.85rem;
-  width: 100%;
-  padding: 0.65rem 0.9rem;
-  border-radius: 0.6rem;
-  border: 1px solid rgba(123, 209, 255, 0.4);
-  background:
-    linear-gradient(140deg, rgba(12, 25, 39, 0.92), rgba(16, 43, 70, 0.78)),
-    rgba(9, 18, 28, 0.88);
-  color: #e7f4ff;
-  font-size: 0.86rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  transition:
-    border-color 140ms ease,
-    box-shadow 140ms ease,
-    transform 120ms ease;
-}
-
-.overlay__help-button:hover,
-.overlay__help-button:focus-visible {
-  border-color: rgba(158, 232, 255, 0.8);
-  box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
-  outline: none;
-  transform: translateY(-1px);
-}
-
-.overlay__help-button:active {
-  transform: translateY(0);
 }
 
 .help-modal-backdrop {


### PR DESCRIPTION
### Motivation
- Replace the large, always-visible Controls card with a compact, top-right Controls entry that opens a bounded, dismissible popover to reduce HUD footprint while keeping controls discoverable.
- Keep existing localized strings and data attributes (e.g., `data-control-item`, `data-input-methods`) and preserve touch/keyboard/gamepad discoverability.

### Description
- Add a compact Controls button and popover markup in `index.html` and move help button into a shared top-right HUD actions area; include a close affordance inside the popover.
- Replace/refactor `createResponsiveControlOverlay` to a popover controller exposing `open()`, `close()`, `toggle()`, `isOpen()`, `setLayout()`, `setStrings()`, `refresh()`, and `dispose()` with Escape-to-close and outside-click behavior, mobile default-closed behavior, and active-input highlighting (`src/ui/hud/responsiveControlOverlay.ts`).
- Add `toggleControls` key binding defaulting to `C`, helper guards to ignore text-entry or modified shortcuts, and wire a rising-edge handler in `src/main.ts` to toggle the popover.
- Update `applyControlOverlayStrings` to populate the new Controls entry and the close button; preserve localized `mobileToggle` strings (`src/ui/hud/controlOverlay.ts`).
- Update HUD CSS to position the compact Controls entry at the top-right, provide a bounded scrollable popover with safe-area handling, and normalize selectors for both `data-hud-layout` and `data-hudLayout` (`src/ui/styles.css`).
- Replace and extend unit tests to cover default closed/open state, button toggle, close affordance, Escape close, outside-click close, layout transitions, active-input refresh, string refresh, dispose cleanup, and C shortcut semantics (`src/tests/responsiveControlOverlay.test.ts`, `src/tests/controlOverlay.test.ts`, `src/systems/controls/keyBindings.test.ts`).

### Testing
- `npm run format:write` — succeeded.
- `npm run lint` — succeeded.
- `npm run test:ci -- src/tests/responsiveControlOverlay.test.ts` — succeeded (9 tests passed).
- `npm run test:ci -- src/tests/controlOverlay.test.ts src/systems/controls/keyBindings.test.ts src/tests/responsiveControlOverlay.test.ts` — succeeded (18 tests passed across the three files).
- `npm run build` — succeeded (Vite build produced `dist/`).
- `npm run docs:check` — succeeded.
- `npm run smoke` — succeeded (build + distribution assertions passed).
- `npm run typecheck` — failed with pre-existing, repo-wide TypeScript issues unrelated to this change (many POI/type errors already present); this PR did not introduce these errors.
- Playwright screenshot attempt was attempted but blocked in this environment because Playwright browser binaries are not installed (local `npx playwright install` required).

Branch: `codex/controls-popover`, commit: `bba2fde`.

Residual risks / follow-ups: repo-wide `tsc --noEmit` errors remain and should be fixed separately; consider adding Playwright browser install in CI environment if e2e screenshots are required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ccaa79c78832fa0311593dc0a9f94)