### PR TITLE
Compact dismissible Controls popover

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ Keep pipelines deterministic by regenerating assets immediately after touching g
 - **Movement** – Use `WASD` or arrow keys to guide the mannequin.
 - **Key remapping** – Use `portfolio.input.keyBindings.setBinding('interact', ['e'])`
   in the browser console to try alternate bindings. HUD prompts update instantly and
-  the mapping persists locally.
+  the mapping persists locally. The controls popover shortcut defaults to `C`; if you
+  bind that key to another action, the popover shortcut yields to the action binding.
 - **Touch** – Drag the on-screen joysticks (left: movement, right: camera pan) on touch devices.
 - **Lighting debug** – Press `Shift` + `L` to toggle bloom and LED strips for comparison captures.
 - **Mode toggle** – Press `T` or select the "Text mode" overlay button to jump into the

--- a/index.html
+++ b/index.html
@@ -42,28 +42,28 @@
 
       .overlay {
         position: fixed;
-        bottom: 1.5rem;
-        left: 1.5rem;
-        padding: 1rem 1.25rem;
-        border-radius: 0.75rem;
-        background: rgba(8, 12, 20, 0.78);
-        color: inherit;
-        border: 1px solid rgba(86, 184, 255, 0.28);
-        box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+        top: calc(env(safe-area-inset-top, 0px) + 1rem);
+        right: calc(env(safe-area-inset-right, 0px) + 1rem);
+        z-index: 40;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.55rem;
+        color: rgba(224, 236, 255, 0.9);
         font-size: 0.9rem;
         line-height: 1.4;
-        max-width: 20rem;
-        transition:
-          opacity 200ms ease,
-          transform 200ms ease;
+        max-width: min(22rem, calc(100vw - 2rem));
         overflow: visible;
       }
 
       .overlay::after {
         content: '';
         position: absolute;
-        inset: -0.9rem;
-        border-radius: inherit;
+        top: -0.65rem;
+        right: -0.65rem;
+        width: 8rem;
+        height: 8rem;
+        border-radius: 999px;
         background: radial-gradient(
           circle at center,
           rgba(94, 210, 255, 0.55) 0%,
@@ -76,52 +76,91 @@
         transition: opacity 160ms ease;
       }
 
-      .overlay__item[data-mobile-collapsed='true'] {
+      .overlay__controls-button,
+      .overlay__help-button {
+        width: auto;
+        min-height: 2.45rem;
+        padding: 0.65rem 0.9rem;
+        border-radius: 999px;
+        border: 1px solid rgba(123, 209, 255, 0.4);
+        background:
+          linear-gradient(
+            140deg,
+            rgba(12, 25, 39, 0.92),
+            rgba(16, 43, 70, 0.78)
+          ),
+          rgba(9, 18, 28, 0.88);
+        color: #e7f4ff;
+        box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+        font-size: 0.86rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        cursor: pointer;
+        transition:
+          border-color 140ms ease,
+          box-shadow 140ms ease,
+          transform 120ms ease;
+      }
+
+      .overlay__controls-button:hover,
+      .overlay__controls-button:focus-visible,
+      .overlay__help-button:hover,
+      .overlay__help-button:focus-visible {
+        border-color: rgba(158, 232, 255, 0.8);
+        box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
+        outline: none;
+        transform: translateY(-1px);
+      }
+
+      .overlay__controls-button:active,
+      .overlay__help-button:active {
+        transform: translateY(0);
+      }
+
+      .overlay__popover {
+        width: min(22rem, calc(100vw - 2rem));
+        max-height: min(32rem, calc(100vh - 7.5rem));
+        padding: 0.9rem 1rem;
+        border-radius: 0.75rem;
+        background: rgba(8, 12, 20, 0.78);
+        border: 1px solid rgba(86, 184, 255, 0.28);
+        box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+        overflow: auto;
+        overscroll-behavior: contain;
+      }
+
+      .overlay__popover[hidden] {
         display: none;
       }
 
-      html[data-hudLayout='mobile'] .overlay {
-        top: calc(env(safe-area-inset-top, 0) + 1rem);
-        bottom: auto;
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-        width: min(24rem, calc(100% - 2rem));
-        padding: 0.9rem 1.05rem;
-        font-size: 0.95rem;
-        line-height: 1.5;
-        z-index: 40;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__heading {
-        margin-bottom: 0.6rem;
-        font-size: 0.7rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__list {
-        gap: 0.35rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__item {
-        padding: 0.35rem 0.45rem;
-        gap: 0.6rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__keys {
-        min-width: 5.75rem;
-      }
-
-      html[data-hudLayout='mobile'] .overlay__help-button {
-        margin-top: 0.65rem;
+      .overlay__popover-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        margin-bottom: 0.75rem;
       }
 
       .overlay__heading {
-        margin: 0 0 0.75rem;
+        margin: 0;
         font-size: 0.75rem;
         font-weight: 600;
         letter-spacing: 0.12em;
         text-transform: uppercase;
         color: rgba(196, 228, 255, 0.82);
+      }
+
+      .overlay__popover-close {
+        flex: 0 0 auto;
+        width: 2rem;
+        height: 2rem;
+        border: 1px solid rgba(123, 209, 255, 0.35);
+        border-radius: 999px;
+        background: rgba(8, 18, 30, 0.72);
+        color: rgba(224, 236, 255, 0.9);
+        font-size: 1.25rem;
+        line-height: 1;
+        cursor: pointer;
       }
 
       .overlay__list {
@@ -139,17 +178,13 @@
         gap: 0.75rem;
         border-radius: 0.6rem;
         padding: 0.25rem 0.35rem;
-        transition:
-          background-color 180ms ease,
-          box-shadow 180ms ease,
-          color 180ms ease;
       }
 
       .overlay__item[hidden] {
         display: none;
       }
 
-      .overlay__item[data-state='active'] {
+      .overlay__item[data-active-method='true'] {
         background: rgba(32, 82, 128, 0.28);
         box-shadow: 0 0 0 1px rgba(114, 210, 255, 0.28);
       }
@@ -161,103 +196,26 @@
         color: rgba(143, 214, 255, 0.9);
       }
 
-      .overlay__item[data-state='active'] .overlay__keys {
-        color: rgba(173, 236, 255, 0.96);
-      }
-
       .overlay__description {
         flex: 1;
         color: rgba(239, 245, 255, 0.88);
       }
 
-      .overlay__item[data-state='active'] .overlay__description {
-        color: rgba(244, 250, 255, 0.96);
+      html[data-hud-layout='mobile'] .overlay {
+        top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
+        right: calc(env(safe-area-inset-right, 0px) + 0.75rem);
+        max-width: min(20rem, calc(100vw - 1.5rem));
+        font-size: 0.85rem;
+        line-height: 1.5;
       }
 
-      .overlay__item--touch {
-        display: none;
+      html[data-hud-layout='mobile'] .overlay__popover {
+        width: min(20rem, calc(100vw - 1.5rem));
+        max-height: min(26rem, calc(100vh - 7rem));
       }
 
-      @media (hover: none) and (pointer: coarse) {
-        .overlay__item--touch {
-          display: flex;
-        }
-
-        .overlay__item--desktop {
-          display: none;
-        }
-      }
-
-      .overlay__collapse-toggle {
-        margin-top: 0.6rem;
-        width: 100%;
-        padding: 0.55rem 0.9rem;
-        border-radius: 0.6rem;
-        border: 1px solid rgba(123, 209, 255, 0.32);
-        background:
-          linear-gradient(
-            140deg,
-            rgba(12, 25, 39, 0.88),
-            rgba(16, 43, 70, 0.72)
-          ),
-          rgba(9, 18, 28, 0.82);
-        color: rgba(231, 244, 255, 0.95);
-        font-size: 0.82rem;
-        font-weight: 600;
-        letter-spacing: 0.01em;
-        cursor: pointer;
-        transition:
-          border-color 140ms ease,
-          box-shadow 140ms ease,
-          transform 120ms ease;
-      }
-
-      .overlay__collapse-toggle:hover,
-      .overlay__collapse-toggle:focus-visible {
-        border-color: rgba(158, 232, 255, 0.75);
-        box-shadow: 0 14px 32px rgba(8, 20, 32, 0.32);
-        outline: none;
-        transform: translateY(-1px);
-      }
-
-      .overlay__collapse-toggle:active {
-        transform: translateY(0);
-      }
-
-      .overlay__help-button {
-        margin-top: 0.85rem;
-        width: 100%;
-        padding: 0.65rem 0.9rem;
-        border-radius: 0.6rem;
-        border: 1px solid rgba(123, 209, 255, 0.4);
-        background:
-          linear-gradient(
-            140deg,
-            rgba(12, 25, 39, 0.92),
-            rgba(16, 43, 70, 0.78)
-          ),
-          rgba(9, 18, 28, 0.88);
-        color: #e7f4ff;
-        font-size: 0.86rem;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        cursor: pointer;
-        transition:
-          border-color 140ms ease,
-          box-shadow 140ms ease,
-          transform 120ms ease;
-      }
-
-      .overlay__help-button:hover,
-      .overlay__help-button:focus-visible {
-        border-color: rgba(158, 232, 255, 0.8);
-        box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
-        outline: none;
-        transform: translateY(-1px);
-      }
-
-      .overlay__help-button:active {
-        transform: translateY(0);
+      html[data-hud-layout='mobile'] .overlay__keys {
+        min-width: 5.75rem;
       }
 
       .help-modal-backdrop {
@@ -488,92 +446,104 @@
     </noscript>
     <div id="app"></div>
     <div class="overlay" id="control-overlay">
-      <p class="overlay__heading" data-control-text="heading">Controls</p>
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-input-methods="keyboard"
-          data-control-item="keyboardMove"
-        >
-          <span class="overlay__keys">WASD / Arrow keys</span>
-          <span class="overlay__description">Move</span>
-        </li>
-        <li
-          class="overlay__item overlay__item--desktop"
-          data-input-methods="pointer"
-          data-control-item="pointerDrag"
-        >
-          <span class="overlay__keys">Left mouse button</span>
-          <span class="overlay__description">Drag to pan</span>
-        </li>
-        <li
-          class="overlay__item overlay__item--desktop"
-          data-input-methods="pointer"
-          data-control-item="pointerZoom"
-        >
-          <span class="overlay__keys">Scroll wheel</span>
-          <span class="overlay__description">Zoom</span>
-        </li>
-        <li
-          class="overlay__item overlay__item--touch"
-          data-input-methods="touch"
-          data-control-item="touchDrag"
-        >
-          <span class="overlay__keys">Touch</span>
-          <span class="overlay__description">
-            Drag the left half to move and the right half to pan
-          </span>
-        </li>
-        <li
-          class="overlay__item overlay__item--touch"
-          data-input-methods="touch"
-          data-control-item="touchPinch"
-        >
-          <span class="overlay__keys">Pinch</span>
-          <span class="overlay__description">Zoom</span>
-        </li>
-        <li
-          class="overlay__item"
-          data-input-methods="keyboard"
-          data-control-item="cyclePoi"
-        >
-          <span class="overlay__keys">Q / E</span>
-          <span class="overlay__description">Cycle POIs</span>
-        </li>
-        <li
-          class="overlay__item"
-          data-input-methods="keyboard"
-          data-control-item="toggleTextMode"
-        >
-          <span class="overlay__keys">T</span>
-          <span class="overlay__description">Switch to text mode</span>
-        </li>
-        <li
-          class="overlay__item"
-          data-control="interact"
-          data-role="interact"
-          data-input-methods="keyboard pointer touch"
-          data-control-item="interact"
-          hidden
-        >
-          <span class="overlay__keys" data-role="interact-label">F</span>
-          <span
-            class="overlay__description"
-            data-control="interact-description"
-            data-role="interact-description"
-          >
-            Interact
-          </span>
-        </li>
-      </ul>
       <button
-        class="overlay__collapse-toggle"
+        class="overlay__controls-button"
         type="button"
-        data-role="control-toggle"
-        hidden
+        data-role="controls-button"
+        aria-expanded="false"
       >
-        Show controls
+        Controls
       </button>
+      <div class="overlay__popover" data-role="controls-popover" hidden>
+        <div class="overlay__popover-header">
+          <p class="overlay__heading" data-control-text="heading">Controls</p>
+          <button
+            class="overlay__popover-close"
+            type="button"
+            data-role="controls-close"
+            aria-label="Close controls"
+          >
+            ×
+          </button>
+        </div>
+        <ul class="overlay__list" data-role="control-list">
+          <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="keyboardMove"
+          >
+            <span class="overlay__keys">WASD / Arrow keys</span>
+            <span class="overlay__description">Move</span>
+          </li>
+          <li
+            class="overlay__item overlay__item--desktop"
+            data-input-methods="pointer"
+            data-control-item="pointerDrag"
+          >
+            <span class="overlay__keys">Left mouse button</span>
+            <span class="overlay__description">Drag to pan</span>
+          </li>
+          <li
+            class="overlay__item overlay__item--desktop"
+            data-input-methods="pointer"
+            data-control-item="pointerZoom"
+          >
+            <span class="overlay__keys">Scroll wheel</span>
+            <span class="overlay__description">Zoom</span>
+          </li>
+          <li
+            class="overlay__item overlay__item--touch"
+            data-input-methods="touch"
+            data-control-item="touchDrag"
+          >
+            <span class="overlay__keys">Touch</span>
+            <span class="overlay__description">
+              Drag the left half to move and the right half to pan
+            </span>
+          </li>
+          <li
+            class="overlay__item overlay__item--touch"
+            data-input-methods="touch"
+            data-control-item="touchPinch"
+          >
+            <span class="overlay__keys">Pinch</span>
+            <span class="overlay__description">Zoom</span>
+          </li>
+          <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="cyclePoi"
+          >
+            <span class="overlay__keys">Q / E</span>
+            <span class="overlay__description">Cycle POIs</span>
+          </li>
+          <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="toggleTextMode"
+          >
+            <span class="overlay__keys">T</span>
+            <span class="overlay__description">Switch to text mode</span>
+          </li>
+          <li
+            class="overlay__item"
+            data-control="interact"
+            data-role="interact"
+            data-input-methods="keyboard pointer touch"
+            data-control-item="interact"
+            hidden
+          >
+            <span class="overlay__keys" data-role="interact-label">F</span>
+            <span
+              class="overlay__description"
+              data-control="interact-description"
+              data-role="interact-description"
+            >
+              Interact
+            </span>
+          </li>
+        </ul>
+      </div>
       <button
         class="overlay__help-button"
         type="button"

--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@
       </section>
     </noscript>
     <div id="app"></div>
-    <div class="overlay" id="control-overlay">
+    <div class="overlay" id="control-overlay" aria-label="Controls">
       <button
         class="overlay__controls-button"
         type="button"

--- a/src/main.ts
+++ b/src/main.ts
@@ -2207,6 +2207,7 @@ function initializeImmersiveScene(
     'moveRight',
     'interact',
     'help',
+    'toggleControls',
   ];
   const bindingActionSet = new Set<KeyBindingAction>(bindingActions);
 
@@ -2456,10 +2457,16 @@ function initializeImmersiveScene(
         list: controlOverlay.querySelector<HTMLElement>(
           '[data-role="control-list"]'
         ),
-        toggle: controlOverlay.querySelector<HTMLButtonElement>(
-          '[data-role="control-toggle"]'
+        button: controlOverlay.querySelector<HTMLButtonElement>(
+          '[data-role="controls-button"]'
         ),
-        strings: controlOverlayStrings.mobileToggle,
+        popover: controlOverlay.querySelector<HTMLElement>(
+          '[data-role="controls-popover"]'
+        ),
+        closeButton: controlOverlay.querySelector<HTMLButtonElement>(
+          '[data-role="controls-close"]'
+        ),
+        strings: controlOverlayStrings,
         initialLayout: 'desktop',
       })
     : null;
@@ -2583,6 +2590,49 @@ function initializeImmersiveScene(
   const toggleHelpMenu = (force?: boolean) => {
     helpModal.toggle(force);
   };
+  const isTextEntryTarget = (target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+    const tagName = target.tagName.toLowerCase();
+    return (
+      target.isContentEditable ||
+      target.hasAttribute('contenteditable') ||
+      target.closest('[contenteditable]') !== null ||
+      tagName === 'input' ||
+      tagName === 'textarea' ||
+      tagName === 'select'
+    );
+  };
+  const matchesKeyBinding = (
+    event: KeyboardEvent,
+    action: KeyBindingAction
+  ): boolean => {
+    const normalizedKey =
+      event.key.length === 1 ? event.key.toLowerCase() : event.key;
+    return keyBindings.getBindings(action).some((binding) => {
+      const normalizedBinding =
+        binding.length === 1 ? binding.toLowerCase() : binding;
+      return normalizedBinding === normalizedKey;
+    });
+  };
+  const handleControlsKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || event.repeat) {
+      return;
+    }
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      return;
+    }
+    if (isTextEntryTarget(event.target)) {
+      return;
+    }
+    if (!matchesKeyBinding(event, 'toggleControls')) {
+      return;
+    }
+    event.preventDefault();
+    responsiveControlOverlay?.toggle();
+  };
+  window.addEventListener('keydown', handleControlsKeydown);
   let helpButtonClickHandler: (() => void) | null = null;
   if (helpButton) {
     helpButtonClickHandler = () => openHelpMenu();
@@ -2676,7 +2726,7 @@ function initializeImmersiveScene(
       applyControlOverlayStrings(controlOverlay, controlOverlayStrings);
     }
     analyticsGlow.setElement(controlOverlay ?? null);
-    responsiveControlOverlay?.setStrings(controlOverlayStrings.mobileToggle);
+    responsiveControlOverlay?.setStrings(controlOverlayStrings);
     responsiveControlOverlay?.refresh();
     movementLegend?.setLocale(locale);
     if (movementLegend) {
@@ -4108,6 +4158,7 @@ function initializeImmersiveScene(
       hudLayoutManager.dispose();
       hudLayoutManager = null;
     }
+    window.removeEventListener('keydown', handleControlsKeydown);
     if (responsiveControlOverlay) {
       responsiveControlOverlay.dispose();
       responsiveControlOverlay = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2423,6 +2423,9 @@ function initializeImmersiveScene(
   const controlOverlayHeading = controlOverlay?.querySelector<HTMLElement>(
     '[data-control-text="heading"]'
   );
+  const controlsButton = controlOverlay?.querySelector<HTMLButtonElement>(
+    '[data-role="controls-button"]'
+  );
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
@@ -2446,6 +2449,7 @@ function initializeImmersiveScene(
     applyControlOverlayAccessibility({
       container: controlOverlay,
       heading: controlOverlayHeading,
+      controlsButton,
       helpButton,
       documentTarget: document,
       focusOnInit: true,
@@ -2457,9 +2461,7 @@ function initializeImmersiveScene(
         list: controlOverlay.querySelector<HTMLElement>(
           '[data-role="control-list"]'
         ),
-        button: controlOverlay.querySelector<HTMLButtonElement>(
-          '[data-role="controls-button"]'
-        ),
+        button: controlsButton,
         popover: controlOverlay.querySelector<HTMLElement>(
           '[data-role="controls-popover"]'
         ),
@@ -2604,17 +2606,31 @@ function initializeImmersiveScene(
       tagName === 'select'
     );
   };
+  const normalizeKeyboardEventKey = (event: KeyboardEvent): string =>
+    event.key.length === 1 ? event.key.toLowerCase() : event.key;
+  const normalizeBindingKey = (binding: string): string =>
+    binding.length === 1 ? binding.toLowerCase() : binding;
   const matchesKeyBinding = (
     event: KeyboardEvent,
     action: KeyBindingAction
   ): boolean => {
-    const normalizedKey =
-      event.key.length === 1 ? event.key.toLowerCase() : event.key;
-    return keyBindings.getBindings(action).some((binding) => {
-      const normalizedBinding =
-        binding.length === 1 ? binding.toLowerCase() : binding;
-      return normalizedBinding === normalizedKey;
-    });
+    const normalizedKey = normalizeKeyboardEventKey(event);
+    return keyBindings
+      .getBindings(action)
+      .some((binding) => normalizeBindingKey(binding) === normalizedKey);
+  };
+  const hasConflictingKeyBinding = (
+    event: KeyboardEvent,
+    action: KeyBindingAction
+  ): boolean => {
+    const normalizedKey = normalizeKeyboardEventKey(event);
+    return bindingActions.some(
+      (candidate) =>
+        candidate !== action &&
+        keyBindings
+          .getBindings(candidate)
+          .some((binding) => normalizeBindingKey(binding) === normalizedKey)
+    );
   };
   const handleControlsKeydown = (event: KeyboardEvent) => {
     if (event.defaultPrevented || event.repeat) {
@@ -2626,7 +2642,10 @@ function initializeImmersiveScene(
     if (isTextEntryTarget(event.target)) {
       return;
     }
-    if (!matchesKeyBinding(event, 'toggleControls')) {
+    if (
+      !matchesKeyBinding(event, 'toggleControls') ||
+      hasConflictingKeyBinding(event, 'toggleControls')
+    ) {
       return;
     }
     event.preventDefault();

--- a/src/systems/controls/keyBindings.ts
+++ b/src/systems/controls/keyBindings.ts
@@ -6,7 +6,8 @@ export type KeyBindingAction =
   | 'moveLeft'
   | 'moveRight'
   | 'interact'
-  | 'help';
+  | 'help'
+  | 'toggleControls';
 
 export type KeyBindingConfig = Partial<
   Record<KeyBindingAction, readonly string[]>
@@ -29,6 +30,7 @@ export const DEFAULT_KEY_BINDINGS: Record<KeyBindingAction, readonly string[]> =
     moveRight: ['d', 'ArrowRight'],
     interact: ['Enter', 'f', ' '],
     help: ['h', '?'],
+    toggleControls: ['c'],
   };
 
 type ActionEntries = [KeyBindingAction, readonly string[]];

--- a/src/tests/controlOverlayAccessibility.test.ts
+++ b/src/tests/controlOverlayAccessibility.test.ts
@@ -52,6 +52,21 @@ describe('applyControlOverlayAccessibility', () => {
     expect(document.activeElement).toBe(preFocused);
   });
 
+  it('uses the visible controls button as the overlay region label when available', () => {
+    const container = document.createElement('div');
+    const heading = document.createElement('p');
+    heading.id = 'hidden-heading';
+    const controlsButton = document.createElement('button');
+    controlsButton.textContent = 'Controls';
+
+    applyControlOverlayAccessibility({ container, heading, controlsButton });
+
+    expect(container.getAttribute('aria-labelledby')).toBe(
+      'control-overlay-controls'
+    );
+    expect(controlsButton.id).toBe('control-overlay-controls');
+  });
+
   it('appends the help button id to existing aria-describedby content', () => {
     const container = document.createElement('div');
     container.setAttribute('aria-describedby', 'existing-id');

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -255,6 +255,57 @@ describe('createResponsiveControlOverlay', () => {
     expect(popover.hidden).toBe(true);
   });
 
+  it('keeps legacy mobile collapse behavior when no popover is present', () => {
+    const container = document.createElement('div');
+    container.dataset.activeInput = 'keyboard';
+    container.innerHTML = `
+      <button type="button" data-role="control-toggle">Show all controls</button>
+      <ul data-role="control-list">
+        <li data-control-item="keyboardMove" data-input-methods="keyboard"></li>
+        <li data-control-item="pointerDrag" data-input-methods="pointer"></li>
+        <li data-control-item="interact" data-input-methods="keyboard pointer touch" hidden></li>
+      </ul>
+    `;
+    document.body.append(container);
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-role="control-toggle"]'
+    );
+    const list = container.querySelector<HTMLElement>(
+      '[data-role="control-list"]'
+    );
+    const pointer = container.querySelector<HTMLElement>(
+      '[data-control-item="pointerDrag"]'
+    );
+
+    if (!toggle || !list || !pointer) {
+      throw new Error('Failed to create legacy control overlay fixture.');
+    }
+
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      toggle,
+      strings: createStrings(),
+      initialLayout: 'mobile',
+      storage: null,
+    });
+
+    expect(handle.isOpen()).toBe(false);
+    expect(toggle.hidden).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(pointer.hidden).toBe(true);
+    expect(pointer.dataset.mobileCollapsed).toBe('true');
+
+    toggle.click();
+
+    expect(handle.isOpen()).toBe(true);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(pointer.hidden).toBe(false);
+    expect(pointer.dataset.mobileCollapsed).toBeUndefined();
+
+    handle.dispose();
+  });
+
   it('represents the controls popover shortcut in the key binding model', () => {
     expect(DEFAULT_KEY_BINDINGS.toggleControls).toEqual(['c']);
   });

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -1,504 +1,261 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import type { ControlOverlayStrings } from '../assets/i18n/types';
+import { DEFAULT_KEY_BINDINGS } from '../systems/controls/keyBindings';
 import { createResponsiveControlOverlay } from '../ui/hud/responsiveControlOverlay';
 
-const createStrings = () => ({
-  expandLabel: 'Show all controls',
-  collapseLabel: 'Hide extra controls',
-  expandAnnouncement: 'Showing the full controls list for mobile players.',
-  collapseAnnouncement: 'Hiding extra controls to keep the list compact.',
+const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
+  heading,
+  items: {
+    keyboardMove: { keys: 'WASD / Arrow keys', description: 'Move' },
+    pointerDrag: { keys: 'Left mouse button', description: 'Drag to pan' },
+    pointerZoom: { keys: 'Scroll wheel', description: 'Zoom' },
+    touchDrag: { keys: 'Touch', description: 'Drag to move and pan' },
+    touchPinch: { keys: 'Pinch', description: 'Zoom' },
+    cyclePoi: { keys: 'Q / E', description: 'Cycle POIs' },
+    toggleTextMode: { keys: 'T', description: 'Switch to text mode' },
+  },
+  interact: {
+    defaultLabel: 'F',
+    description: 'Interact',
+    promptTemplates: {
+      default: 'Interact with {title}',
+      inspect: 'Inspect {title}',
+      activate: 'Activate {title}',
+    },
+  },
+  helpButton: {
+    labelTemplate: 'Open menu · Press {shortcut}',
+    announcementTemplate: 'Open help with {shortcut}',
+    shortcutFallback: 'H',
+  },
+  mobileToggle: {
+    expandLabel: 'Show all controls',
+    collapseLabel: 'Close controls',
+    expandAnnouncement: 'Controls closed.',
+    collapseAnnouncement: 'Controls open.',
+  },
 });
 
-const flushMicrotasks = async () => {
-  await new Promise((resolve) => queueMicrotask(resolve));
+const createOverlay = () => {
+  const container = document.createElement('div');
+  container.dataset.activeInput = 'keyboard';
+  container.innerHTML = `
+    <button type="button" data-role="controls-button">Controls</button>
+    <div data-role="controls-popover">
+      <div>
+        <p data-control-text="heading">Controls</p>
+        <button type="button" data-role="controls-close">Close</button>
+      </div>
+      <ul data-role="control-list">
+        <li data-control-item="keyboardMove" data-input-methods="keyboard"></li>
+        <li data-control-item="pointerDrag" data-input-methods="pointer"></li>
+        <li data-control-item="touchDrag" data-input-methods="touch"></li>
+        <li data-control-item="interact" data-input-methods="keyboard pointer touch" hidden></li>
+      </ul>
+    </div>
+  `;
+  document.body.append(container);
+  const button = container.querySelector<HTMLButtonElement>(
+    '[data-role="controls-button"]'
+  );
+  const popover = container.querySelector<HTMLElement>(
+    '[data-role="controls-popover"]'
+  );
+  const closeButton = container.querySelector<HTMLButtonElement>(
+    '[data-role="controls-close"]'
+  );
+  const list = container.querySelector<HTMLElement>(
+    '[data-role="control-list"]'
+  );
+
+  if (!button || !popover || !closeButton || !list) {
+    throw new Error('Failed to create control overlay fixture.');
+  }
+
+  return { container, button, popover, closeButton, list };
 };
 
-const COLLAPSE_STORAGE_KEY = 'hud:control-overlay-collapsed';
-
 beforeEach(() => {
-  localStorage.removeItem(COLLAPSE_STORAGE_KEY);
+  document.body.innerHTML = '';
 });
 
 describe('createResponsiveControlOverlay', () => {
-  it('collapses mobile controls and toggles expanded state', async () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="pointerDrag"
-          data-input-methods="pointer"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
+  it('starts closed with a compact controls button', () => {
+    const { container, button, popover, list } = createOverlay();
     const handle = createResponsiveControlOverlay({
       container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
+      list,
+      button,
+      popover,
       strings: createStrings(),
-      initialLayout: 'desktop',
+      initialLayout: 'mobile',
     });
 
-    expect(toggle?.getAttribute('aria-controls')).toBe('control-overlay-list');
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+    expect(button.textContent).toBe('Controls');
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(button.getAttribute('aria-controls')).toBe(popover.id);
+    expect(container.dataset.controlsOpen).toBe('false');
+    expect(container.dataset.hudLayout).toBe('mobile');
 
-    const keyboardItem = container.querySelector<HTMLElement>(
+    handle.dispose();
+  });
+
+  it('opens and closes through the button, handle, and close affordance', () => {
+    const { container, button, popover, closeButton, list } = createOverlay();
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      button,
+      popover,
+      closeButton,
+      strings: createStrings(),
+    });
+
+    button.click();
+    expect(handle.isOpen()).toBe(true);
+    expect(popover.hidden).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+
+    handle.toggle();
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+
+    handle.open();
+    closeButton.click();
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+
+    handle.dispose();
+  });
+
+  it('closes with Escape when the popover is open', () => {
+    const { container, button, popover, list } = createOverlay();
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      button,
+      popover,
+      strings: createStrings(),
+    });
+
+    handle.open();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(handle.isOpen()).toBe(false);
+    expect(popover.hidden).toBe(true);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    handle.dispose();
+  });
+
+  it('closes on outside pointer input but ignores pointer input in the popover or button', () => {
+    const { container, button, popover, list } = createOverlay();
+    const outside = document.createElement('button');
+    document.body.append(outside);
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      button,
+      popover,
+      strings: createStrings(),
+    });
+
+    handle.open();
+    popover.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(handle.isOpen()).toBe(true);
+
+    button.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(handle.isOpen()).toBe(true);
+
+    outside.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(handle.isOpen()).toBe(false);
+
+    handle.dispose();
+  });
+
+  it('refreshes highlighted input methods without hiding other controls', () => {
+    const { container, button, popover, list } = createOverlay();
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      button,
+      popover,
+      strings: createStrings(),
+    });
+    const keyboard = container.querySelector<HTMLElement>(
       '[data-control-item="keyboardMove"]'
     );
-    const pointerItem = container.querySelector<HTMLElement>(
+    const pointer = container.querySelector<HTMLElement>(
       '[data-control-item="pointerDrag"]'
     );
-    const interactItem = container.querySelector<HTMLElement>(
-      '[data-control-item="interact"]'
-    );
 
-    handle.setLayout('mobile');
-
-    expect(container.dataset.controlCollapsed).toBe('true');
-    expect(toggle?.hidden).toBe(false);
-    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(pointerItem?.hidden).toBe(true);
-    expect(pointerItem?.dataset.mobileCollapsed).toBe('true');
-    expect(interactItem?.hidden).toBe(false);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(keyboard?.hidden).toBe(false);
+    expect(pointer?.hidden).toBe(false);
+    expect(keyboard?.dataset.activeMethod).toBe('true');
+    expect(pointer?.dataset.activeMethod).toBe('false');
 
     container.dataset.activeInput = 'pointer';
-    await flushMicrotasks();
-
-    expect(pointerItem?.hidden).toBe(false);
-    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(keyboardItem?.hidden).toBe(true);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBe('true');
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
-    expect(pointerItem?.hidden).toBe(false);
-    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
-
-    handle.setLayout('desktop');
-    expect(container.dataset.controlCollapsed).toBeUndefined();
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.hasAttribute('aria-expanded')).toBe(false);
-    expect(pointerItem?.hidden).toBe(false);
-    expect(pointerItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
-  });
-
-  it('updates toggle labels when strings change', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="pointerDrag"
-          data-input-methods="pointer"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'desktop',
-    });
-
-    handle.setLayout('mobile');
-
-    expect(toggle?.textContent).toBe('Show all controls');
-    expect(toggle?.dataset.hudAnnounce).toBe(
-      'Showing the full controls list for mobile players.'
-    );
-
-    handle.setStrings({
-      expandLabel: 'Expand',
-      collapseLabel: 'Collapse',
-      expandAnnouncement: 'Expand controls.',
-      collapseAnnouncement: 'Collapse controls.',
-    });
-
-    expect(toggle?.textContent).toBe('Expand');
-    expect(toggle?.dataset.hudAnnounce).toBe('Expand controls.');
-
-    handle.dispose();
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.textContent).toBe('Expand');
-  });
-
-  it('respects baseline hidden states while collapsing and disposing', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'pointer';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
-          hidden
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-    });
-
-    const keyboardItem = container.querySelector<HTMLElement>(
-      '[data-control-item="keyboardMove"]'
-    );
-    const interactItem = container.querySelector<HTMLElement>(
-      '[data-control-item="interact"]'
-    );
-
-    expect(keyboardItem?.hidden).toBe(true);
-    expect(interactItem?.hidden).toBe(true);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(interactItem?.hidden).toBe(true);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-
-    handle.dispose();
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(interactItem?.hidden).toBe(true);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-  });
-
-  it('preserves runtime visibility for interact prompt after collapsing', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'pointer';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
-          hidden
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-    });
-
-    const interactItem = container.querySelector<HTMLElement>(
-      '[data-control-item="interact"]'
-    );
-
-    expect(interactItem?.hidden).toBe(true);
-
-    if (interactItem) {
-      interactItem.hidden = false;
-    }
-
     handle.refresh();
 
-    expect(interactItem?.hidden).toBe(false);
-    expect(container.dataset.controlCollapsed).toBe('true');
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(interactItem?.hidden).toBe(false);
-
-    (toggle as HTMLButtonElement).click();
-
-    expect(container.dataset.controlCollapsed).toBe('true');
-    expect(interactItem?.hidden).toBe(false);
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
+    expect(keyboard?.hidden).toBe(false);
+    expect(pointer?.hidden).toBe(false);
+    expect(keyboard?.dataset.activeMethod).toBe('false');
+    expect(pointer?.dataset.activeMethod).toBe('true');
 
     handle.dispose();
   });
 
-  it('persists mobile collapse preference across layout changes', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="pointerDrag"
-          data-input-methods="pointer"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const store = new Map<string, string>([
-      ['hud:control-overlay-collapsed', 'false'],
-    ]);
-    const storage = {
-      getItem: vi.fn((key: string) => store.get(key) ?? null),
-      setItem: vi.fn((key: string, value: string) => {
-        store.set(key, value);
-      }),
-    };
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
+  it('updates button and close labels when strings refresh', () => {
+    const { container, button, popover, closeButton, list } = createOverlay();
     const handle = createResponsiveControlOverlay({
       container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
+      list,
+      button,
+      popover,
+      closeButton,
       strings: createStrings(),
-      initialLayout: 'mobile',
-      storage,
-      defaultCollapsed: true,
-      windowTarget: undefined,
     });
 
-    expect(storage.getItem).toHaveBeenCalledWith(
-      'hud:control-overlay-collapsed'
-    );
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    handle.setStrings(createStrings('Controls menu'));
 
-    (toggle as HTMLButtonElement).click();
-
-    expect(storage.setItem).toHaveBeenCalledWith(
-      'hud:control-overlay-collapsed',
-      'true'
-    );
-    expect(container.dataset.controlCollapsed).toBe('true');
-
-    handle.setLayout('desktop');
-    expect(container.dataset.controlCollapsed).toBeUndefined();
-
-    handle.setLayout('mobile');
-    expect(container.dataset.controlCollapsed).toBe('true');
-    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(button.textContent).toBe('Controls menu');
+    expect(button.getAttribute('aria-label')).toBe('Controls menu');
+    expect(closeButton.getAttribute('aria-label')).toBe('Close controls');
 
     handle.dispose();
   });
 
-  it('ignores storage access errors while updating collapse state', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const storageError = new Error('denied');
-    const storage = {
-      getItem: vi.fn(() => {
-        throw storageError;
-      }),
-      setItem: vi.fn(() => {
-        throw storageError;
-      }),
-    };
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-      storage,
-    });
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.getAttribute('aria-expanded')).toBeNull();
-
-    expect(() => (toggle as HTMLButtonElement).click()).not.toThrow();
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(storage.setItem).not.toHaveBeenCalled();
-
-    handle.dispose();
-  });
-
-  it('falls back gracefully when localStorage is unavailable', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const windowTarget = Object.defineProperty({}, 'localStorage', {
-      get() {
-        throw new Error('blocked');
-      },
-    });
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-      storage: null,
-      windowTarget: windowTarget as unknown as Window,
-    });
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.getAttribute('aria-expanded')).toBeNull();
-    expect(() => (toggle as HTMLButtonElement).click()).not.toThrow();
-    expect(container.dataset.controlCollapsed).toBe('false');
-
-    handle.dispose();
-  });
-
-  it('initializes when no storage or window target are available', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-      windowTarget: undefined,
-    });
-
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.getAttribute('aria-expanded')).toBeNull();
-    expect(() => (toggle as HTMLButtonElement).click()).not.toThrow();
-    expect(container.dataset.controlCollapsed).toBe('false');
-
-    handle.dispose();
-  });
-
-  it('hides the collapse toggle when no controls need collapsing', () => {
-    const container = document.createElement('div');
-    container.dataset.activeInput = 'keyboard';
-    container.innerHTML = `
-      <ul class="overlay__list" data-role="control-list">
-        <li
-          class="overlay__item"
-          data-control-item="keyboardMove"
-          data-input-methods="keyboard"
-        ></li>
-        <li
-          class="overlay__item"
-          data-control-item="interact"
-          data-input-methods="keyboard pointer"
-        ></li>
-      </ul>
-      <button type="button" data-role="control-toggle">Toggle</button>
-    `;
-
-    const list = container.querySelector('[data-role="control-list"]');
-    const toggle = container.querySelector('[data-role="control-toggle"]');
-    const handle = createResponsiveControlOverlay({
-      container,
-      list: list as HTMLElement,
-      toggle: toggle as HTMLButtonElement,
-      strings: createStrings(),
-      initialLayout: 'mobile',
-    });
-
-    const keyboardItem = container.querySelector<HTMLElement>(
-      '[data-control-item="keyboardMove"]'
-    );
-    const interactItem = container.querySelector<HTMLElement>(
+  it('removes listeners and restores initial hidden state on dispose', () => {
+    const { container, button, popover, list } = createOverlay();
+    const interact = container.querySelector<HTMLElement>(
       '[data-control-item="interact"]'
     );
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      button,
+      popover,
+      strings: createStrings(),
+    });
 
-    expect(toggle?.hidden).toBe(true);
-    expect(toggle?.hasAttribute('aria-expanded')).toBe(false);
-    expect(container.dataset.controlCollapsed).toBe('false');
-    expect(keyboardItem?.hidden).toBe(false);
-    expect(interactItem?.hidden).toBe(false);
-    expect(keyboardItem?.dataset.mobileCollapsed).toBeUndefined();
-    expect(interactItem?.dataset.mobileCollapsed).toBeUndefined();
-
+    handle.open();
+    expect(popover.hidden).toBe(false);
     handle.dispose();
+
+    expect(popover.hidden).toBe(true);
+    expect(button.getAttribute('aria-expanded')).toBeNull();
+    expect(container.dataset.controlsOpen).toBeUndefined();
+    expect(interact?.hidden).toBe(true);
+
+    button.click();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(popover.hidden).toBe(true);
+  });
+
+  it('represents the controls popover shortcut in the key binding model', () => {
+    expect(DEFAULT_KEY_BINDINGS.toggleControls).toEqual(['c']);
   });
 });

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { ControlOverlayStrings } from '../assets/i18n/types';
@@ -99,6 +101,11 @@ describe('createResponsiveControlOverlay', () => {
     expect(button.getAttribute('aria-controls')).toBe(popover.id);
     expect(container.dataset.controlsOpen).toBe('false');
     expect(container.dataset.hudLayout).toBe('mobile');
+    expect(container.getAttribute('aria-label')).toBe('Controls');
+    expect(container.getAttribute('aria-labelledby')).toBeNull();
+    expect(popover.getAttribute('aria-labelledby')).toBe(
+      container.querySelector('[data-control-text="heading"]')?.id
+    );
 
     handle.dispose();
   });
@@ -127,6 +134,7 @@ describe('createResponsiveControlOverlay', () => {
     closeButton.click();
     expect(handle.isOpen()).toBe(false);
     expect(popover.hidden).toBe(true);
+    expect(document.activeElement).toBe(button);
 
     handle.dispose();
   });
@@ -147,6 +155,7 @@ describe('createResponsiveControlOverlay', () => {
     expect(handle.isOpen()).toBe(false);
     expect(popover.hidden).toBe(true);
     expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(button);
 
     handle.dispose();
   });
@@ -255,7 +264,7 @@ describe('createResponsiveControlOverlay', () => {
     expect(popover.hidden).toBe(true);
   });
 
-  it('keeps legacy mobile collapse behavior when no popover is present', () => {
+  it('requires the popover contract instead of reviving legacy collapse markup', () => {
     const container = document.createElement('div');
     container.dataset.activeInput = 'keyboard';
     container.innerHTML = `
@@ -263,7 +272,6 @@ describe('createResponsiveControlOverlay', () => {
       <ul data-role="control-list">
         <li data-control-item="keyboardMove" data-input-methods="keyboard"></li>
         <li data-control-item="pointerDrag" data-input-methods="pointer"></li>
-        <li data-control-item="interact" data-input-methods="keyboard pointer touch" hidden></li>
       </ul>
     `;
     document.body.append(container);
@@ -284,26 +292,41 @@ describe('createResponsiveControlOverlay', () => {
     const handle = createResponsiveControlOverlay({
       container,
       list,
-      toggle,
       strings: createStrings(),
       initialLayout: 'mobile',
-      storage: null,
     });
 
     expect(handle.isOpen()).toBe(false);
-    expect(toggle.hidden).toBe(false);
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-    expect(pointer.hidden).toBe(true);
-    expect(pointer.dataset.mobileCollapsed).toBe('true');
-
-    toggle.click();
-
-    expect(handle.isOpen()).toBe(true);
-    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle.getAttribute('aria-expanded')).toBeNull();
     expect(pointer.hidden).toBe(false);
     expect(pointer.dataset.mobileCollapsed).toBeUndefined();
 
+    toggle.click();
+    handle.toggle();
+
+    expect(handle.isOpen()).toBe(false);
+    expect(pointer.hidden).toBe(false);
+    expect(container.dataset.controlCollapsed).toBeUndefined();
+
     handle.dispose();
+  });
+
+  it('keeps reduced-motion HUD selectors wired for popover controls', () => {
+    const styles = readFileSync('src/ui/styles.css', 'utf8');
+
+    expect(styles).toContain(
+      ":root[data-accessibility-motion='reduced'] .overlay__controls-button"
+    );
+    expect(styles).toContain(
+      ":root[data-accessibility-motion='reduced'] .overlay__help-button"
+    );
+    expect(styles).toContain(
+      ":root[data-accessibility-motion='reduced'] .overlay__popover"
+    );
+    expect(styles).toContain(
+      ":root[data-accessibility-motion='reduced'] .overlay__popover-close"
+    );
+    expect(styles).toContain('transform: none;');
   });
 
   it('represents the controls popover shortcut in the key binding model', () => {

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -5,7 +5,8 @@ const CONTROL_KEYS_SELECTOR = '.overlay__keys';
 const CONTROL_DESCRIPTION_SELECTOR = '.overlay__description';
 const INTERACT_LABEL_SELECTOR = '[data-role="interact-label"]';
 const INTERACT_DESCRIPTION_SELECTOR = '[data-role="interact-description"]';
-const COLLAPSE_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
+const CONTROLS_BUTTON_SELECTOR = '[data-role="controls-button"]';
+const LEGACY_COLLAPSE_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
 
 function setTextContent(
   element: Element | null | undefined,
@@ -62,21 +63,30 @@ export function applyControlOverlayStrings(
     );
   }
 
-  const collapseToggle = container.querySelector<HTMLButtonElement>(
-    COLLAPSE_TOGGLE_SELECTOR
+  const controlsButton = container.querySelector<HTMLButtonElement>(
+    CONTROLS_BUTTON_SELECTOR
   );
-  if (collapseToggle) {
+  if (controlsButton) {
+    setTextContent(controlsButton, strings.heading);
+    controlsButton.dataset.hudAnnounce =
+      strings.mobileToggle.expandAnnouncement;
+  }
+
+  const legacyCollapseToggle = container.querySelector<HTMLButtonElement>(
+    LEGACY_COLLAPSE_TOGGLE_SELECTOR
+  );
+  if (legacyCollapseToggle) {
     const {
       expandLabel,
       collapseLabel,
       expandAnnouncement,
       collapseAnnouncement,
     } = strings.mobileToggle;
-    setTextContent(collapseToggle, expandLabel);
-    collapseToggle.dataset.expandLabel = expandLabel;
-    collapseToggle.dataset.collapseLabel = collapseLabel;
-    collapseToggle.dataset.expandAnnouncement = expandAnnouncement;
-    collapseToggle.dataset.collapseAnnouncement = collapseAnnouncement;
-    collapseToggle.dataset.hudAnnounce = expandAnnouncement;
+    setTextContent(legacyCollapseToggle, expandLabel);
+    legacyCollapseToggle.dataset.expandLabel = expandLabel;
+    legacyCollapseToggle.dataset.collapseLabel = collapseLabel;
+    legacyCollapseToggle.dataset.expandAnnouncement = expandAnnouncement;
+    legacyCollapseToggle.dataset.collapseAnnouncement = collapseAnnouncement;
+    legacyCollapseToggle.dataset.hudAnnounce = expandAnnouncement;
   }
 }

--- a/src/ui/hud/controlOverlayAccessibility.ts
+++ b/src/ui/hud/controlOverlayAccessibility.ts
@@ -1,12 +1,14 @@
 interface ControlOverlayAccessibilityOptions {
   container: HTMLElement;
   heading?: HTMLElement | null;
+  controlsButton?: HTMLButtonElement | null;
   helpButton?: HTMLButtonElement | null;
   documentTarget?: Document;
   focusOnInit?: boolean;
 }
 
 const DEFAULT_HEADING_ID = 'control-overlay-heading';
+const DEFAULT_CONTROLS_BUTTON_ID = 'control-overlay-controls';
 const DEFAULT_HELP_BUTTON_ID = 'control-overlay-help';
 
 const ensureHeadingId = (heading: HTMLElement, fallbackId: string) => {
@@ -16,10 +18,7 @@ const ensureHeadingId = (heading: HTMLElement, fallbackId: string) => {
   return heading.id;
 };
 
-const ensureHelpButtonId = (
-  helpButton: HTMLButtonElement,
-  fallbackId: string
-) => {
+const ensureButtonId = (helpButton: HTMLButtonElement, fallbackId: string) => {
   if (!helpButton.id) {
     helpButton.id = fallbackId;
   }
@@ -41,6 +40,7 @@ const appendDescribedBy = (element: HTMLElement, id: string) => {
 export const applyControlOverlayAccessibility = ({
   container,
   heading,
+  controlsButton,
   helpButton,
   documentTarget = document,
   focusOnInit = false,
@@ -50,14 +50,20 @@ export const applyControlOverlayAccessibility = ({
     container.tabIndex = -1;
   }
 
-  if (heading) {
+  if (controlsButton) {
+    const controlsButtonId = ensureButtonId(
+      controlsButton,
+      DEFAULT_CONTROLS_BUTTON_ID
+    );
+    container.setAttribute('aria-labelledby', controlsButtonId);
+  } else if (heading) {
     const headingId = ensureHeadingId(heading, DEFAULT_HEADING_ID);
     container.setAttribute('aria-labelledby', headingId);
   }
 
   if (helpButton) {
     helpButton.setAttribute('aria-haspopup', 'dialog');
-    const helpId = ensureHelpButtonId(helpButton, DEFAULT_HELP_BUTTON_ID);
+    const helpId = ensureButtonId(helpButton, DEFAULT_HELP_BUTTON_ID);
     appendDescribedBy(container, helpId);
   }
 

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -3,19 +3,13 @@ import type { ControlOverlayStrings } from '../../assets/i18n/types';
 import type { HudLayout } from './layoutManager';
 import type { InputMethod } from './movementLegend';
 
-export type LegacyResponsiveControlOverlayStrings =
-  ControlOverlayStrings['mobileToggle'];
-export type ResponsiveControlOverlayStrings =
-  | ControlOverlayStrings
-  | LegacyResponsiveControlOverlayStrings;
-
 export interface ResponsiveControlOverlayHandle {
   open(): void;
   close(): void;
   toggle(): void;
   isOpen(): boolean;
   setLayout(layout: HudLayout): void;
-  setStrings(strings: ResponsiveControlOverlayStrings): void;
+  setStrings(strings: ControlOverlayStrings): void;
   refresh(): void;
   dispose(): void;
 }
@@ -24,30 +18,21 @@ export interface ResponsiveControlOverlayOptions {
   container: HTMLElement;
   list?: HTMLElement | null;
   button?: HTMLButtonElement | null;
-  toggle?: HTMLButtonElement | null;
   popover?: HTMLElement | null;
   closeButton?: HTMLButtonElement | null;
-  strings: ResponsiveControlOverlayStrings;
+  strings: ControlOverlayStrings;
   initialLayout?: HudLayout;
-  defaultCollapsed?: boolean;
-  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
   documentTarget?: Document;
-  windowTarget?: Window;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
 const CONTROL_ITEM_SELECTOR = '[data-control-item]';
 const CONTROL_BUTTON_SELECTOR = '[data-role="controls-button"]';
-const LEGACY_CONTROL_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
 const CONTROL_POPOVER_SELECTOR = '[data-role="controls-popover"]';
 const CONTROL_CLOSE_SELECTOR = '[data-role="controls-close"]';
 const CONTROL_HEADING_SELECTOR = '[data-control-text="heading"]';
-const CONTROL_LIST_ID = 'control-overlay-list';
 const CONTROL_POPOVER_ID = 'control-overlay-popover';
 const CONTROL_OPEN_KEY = 'controlsOpen';
-const CONTROL_COLLAPSED_KEY = 'controlCollapsed';
-const MOBILE_COLLAPSED_KEY = 'mobileCollapsed';
-const COLLAPSE_STORAGE_KEY = 'hud:control-overlay-collapsed';
 const ACTIVE_INPUT_KEY = 'activeInput';
 const ACTIVE_METHOD_KEY = 'activeMethod';
 
@@ -100,318 +85,40 @@ const ensureId = (element: HTMLElement, fallback: string): string => {
   return element.id;
 };
 
-const getToggleStrings = (
-  strings: ResponsiveControlOverlayStrings
-): LegacyResponsiveControlOverlayStrings =>
-  'mobileToggle' in strings ? strings.mobileToggle : strings;
-
-const legacyMatchActiveMethod = (
-  methods: ReadonlyArray<InputMethod>,
-  active: InputMethod | null
-): boolean => !active || matchActiveMethod(methods, active);
-
-const getLegacyCollapsibleItems = (
-  container: HTMLElement,
-  items: ReadonlyArray<HTMLElement>
-): ReadonlyArray<HTMLElement> => {
-  const activeMethod = getActiveMethod(container);
-  return items.filter((item) => {
-    const methods = parseInputMethods(item.dataset.inputMethods);
-    const controlId = item.dataset.controlItem ?? '';
-    if (controlId === 'interact') {
-      return false;
-    }
-    return !legacyMatchActiveMethod(methods, activeMethod);
-  });
-};
-
-const applyLegacyToggleLabel = (
-  toggle: HTMLButtonElement,
-  strings: LegacyResponsiveControlOverlayStrings,
-  collapsed: boolean
-) => {
-  toggle.textContent = collapsed ? strings.expandLabel : strings.collapseLabel;
-  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
-  toggle.dataset.hudAnnounce = collapsed
-    ? strings.expandAnnouncement
-    : strings.collapseAnnouncement;
-};
-
-const applyLegacyContainerState = (
-  container: HTMLElement,
-  layout: HudLayout,
-  collapsed: boolean
-) => {
-  if (layout !== 'mobile') {
-    delete (container.dataset as Record<string, string | undefined>)[
-      CONTROL_COLLAPSED_KEY
-    ];
-    return;
-  }
-  container.dataset[CONTROL_COLLAPSED_KEY] = collapsed ? 'true' : 'false';
-};
-
-const applyLegacyCollapsedState = (
-  items: ReadonlyArray<HTMLElement>,
-  collapsedHiddenStates: WeakMap<HTMLElement, boolean>,
-  layout: HudLayout,
-  collapsed: boolean,
-  collapsibleTargets: ReadonlyArray<HTMLElement>
-) => {
-  const collapsibleSet =
-    collapsibleTargets.length > 0 ? new Set(collapsibleTargets) : null;
-  const shouldCollapse =
-    layout === 'mobile' && collapsed && collapsibleTargets.length > 0;
-
-  const restoreCollapsedState = (item: HTMLElement) => {
-    delete (item.dataset as Record<string, string | undefined>)[
-      MOBILE_COLLAPSED_KEY
-    ];
-    if (!collapsedHiddenStates.has(item)) {
-      return;
-    }
-    const previousHidden = collapsedHiddenStates.get(item);
-    collapsedHiddenStates.delete(item);
-    if (previousHidden !== undefined) {
-      item.hidden = previousHidden;
-    }
-  };
-
-  for (const item of items) {
-    if (!shouldCollapse || !collapsibleSet?.has(item)) {
-      restoreCollapsedState(item);
-      continue;
-    }
-
-    if (!collapsedHiddenStates.has(item)) {
-      collapsedHiddenStates.set(item, item.hidden);
-    }
-    item.dataset[MOBILE_COLLAPSED_KEY] = 'true';
-    item.hidden = true;
-  }
-};
-
-const getStorage = (
-  windowTarget?: Window,
-  storage?: Pick<Storage, 'getItem' | 'setItem'> | null
-): Pick<Storage, 'getItem' | 'setItem'> | null => {
-  if (storage === null) {
-    return null;
-  }
-  if (storage) {
-    return storage;
-  }
-  if (!windowTarget) {
-    return null;
-  }
-  try {
-    return windowTarget.localStorage ?? null;
-  } catch {
-    return null;
-  }
-};
-
-const readPersistedCollapsed = (
-  storage: Pick<Storage, 'getItem'> | null
-): boolean | null => {
-  if (!storage) {
-    return null;
-  }
-  try {
-    const value = storage.getItem(COLLAPSE_STORAGE_KEY);
-    if (value === 'true') {
-      return true;
-    }
-    if (value === 'false') {
-      return false;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-};
-
-const persistCollapsed = (
-  storage: Pick<Storage, 'setItem'> | null,
-  collapsed: boolean
-) => {
-  if (!storage) {
-    return;
-  }
-  try {
-    storage.setItem(COLLAPSE_STORAGE_KEY, collapsed ? 'true' : 'false');
-  } catch {
-    /* ignore storage errors */
-  }
-};
-
-const createLegacyResponsiveControlOverlay = (
-  options: ResponsiveControlOverlayOptions,
-  list: HTMLElement,
-  toggle: HTMLButtonElement
-): ResponsiveControlOverlayHandle => {
-  const {
-    container,
-    strings,
-    initialLayout = 'desktop',
-    defaultCollapsed,
-    windowTarget = typeof window !== 'undefined' ? window : undefined,
-    storage: providedStorage,
-  } = options;
-  const controlItems = Array.from(
-    list.querySelectorAll<HTMLElement>(CONTROL_ITEM_SELECTOR)
-  );
-  const initialHiddenStates = new WeakMap<HTMLElement, boolean>();
-  const collapsedHiddenStates = new WeakMap<HTMLElement, boolean>();
-  controlItems.forEach((item) => {
-    initialHiddenStates.set(item, item.hidden);
-  });
-
-  const listId = ensureId(list, CONTROL_LIST_ID);
-  toggle.setAttribute('aria-controls', listId);
-
-  const storage = getStorage(windowTarget, providedStorage);
-  const readStoredCollapsed = () => readPersistedCollapsed(storage);
-  const resolveMobileCollapsed = () =>
-    readStoredCollapsed() ?? defaultCollapsed ?? true;
-
-  let layout: HudLayout = initialLayout;
-  let collapsed = layout === 'mobile' ? resolveMobileCollapsed() : false;
-  let currentStrings = getToggleStrings(strings);
-  let disposed = false;
-  let canCollapse = false;
-
-  const update = () => {
-    if (disposed) {
-      return;
-    }
-    const collapsibleItems = getLegacyCollapsibleItems(container, controlItems);
-    canCollapse = layout === 'mobile' && collapsibleItems.length > 0;
-    const effectiveCollapsed = canCollapse ? collapsed : false;
-
-    applyLegacyContainerState(container, layout, effectiveCollapsed);
-    applyLegacyCollapsedState(
-      controlItems,
-      collapsedHiddenStates,
-      layout,
-      effectiveCollapsed,
-      collapsibleItems
-    );
-    if (layout === 'mobile' && canCollapse) {
-      persistCollapsed(storage, collapsed);
-      toggle.hidden = false;
-      applyLegacyToggleLabel(toggle, currentStrings, effectiveCollapsed);
-    } else {
-      toggle.hidden = true;
-      toggle.removeAttribute('aria-expanded');
-      toggle.dataset.hudAnnounce = '';
-    }
-  };
-
-  const setCollapsed = (next: boolean) => {
-    const normalized = layout === 'mobile' ? next : false;
-    if (collapsed === normalized) {
-      update();
-      return;
-    }
-    collapsed = normalized;
-    update();
-  };
-
-  const handleToggleClick = () => {
-    if (layout !== 'mobile') {
-      return;
-    }
-    setCollapsed(!collapsed);
-  };
-
-  toggle.addEventListener('click', handleToggleClick);
-
-  const observer = new MutationObserver((mutations) => {
-    if (
-      mutations.some(
-        (mutation) =>
-          mutation.type === 'attributes' &&
-          mutation.attributeName === 'data-active-input'
-      )
-    ) {
-      update();
-    }
-  });
-
-  observer.observe(container, {
-    attributes: true,
-    attributeFilter: ['data-active-input'],
-  });
-
-  update();
-
-  return {
+const createNoopResponsiveControlOverlay =
+  (): ResponsiveControlOverlayHandle => ({
     open() {
-      setCollapsed(false);
+      /* noop */
     },
     close() {
-      setCollapsed(true);
+      /* noop */
     },
     toggle() {
-      handleToggleClick();
+      /* noop */
     },
     isOpen() {
-      return layout === 'mobile' && canCollapse ? !collapsed : false;
+      return false;
     },
-    setLayout(nextLayout: HudLayout) {
-      if (layout === nextLayout) {
-        update();
-        return;
-      }
-      layout = nextLayout;
-      if (layout === 'mobile') {
-        collapsed = resolveMobileCollapsed();
-      } else {
-        collapsed = false;
-      }
-      update();
+    setLayout() {
+      /* noop */
     },
-    setStrings(nextStrings: ResponsiveControlOverlayStrings) {
-      currentStrings = getToggleStrings(nextStrings);
-      if (layout === 'mobile') {
-        applyLegacyToggleLabel(toggle, currentStrings, collapsed);
-      }
+    setStrings() {
+      /* noop */
     },
     refresh() {
-      update();
+      /* noop */
     },
     dispose() {
-      if (disposed) {
-        return;
-      }
-      disposed = true;
-      observer.disconnect();
-      toggle.removeEventListener('click', handleToggleClick);
-      toggle.hidden = true;
-      toggle.removeAttribute('aria-expanded');
-      toggle.removeAttribute('aria-controls');
-      toggle.dataset.hudAnnounce = '';
-      toggle.textContent = currentStrings.expandLabel;
-      delete (container.dataset as Record<string, string | undefined>)[
-        CONTROL_COLLAPSED_KEY
-      ];
-      for (const item of controlItems) {
-        delete (item.dataset as Record<string, string | undefined>)[
-          MOBILE_COLLAPSED_KEY
-        ];
-        item.hidden = initialHiddenStates.get(item) ?? false;
-      }
+      /* noop */
     },
-  };
-};
+  });
 
 const setOpenState = (
   container: HTMLElement,
   popover: HTMLElement,
   button: HTMLButtonElement,
   open: boolean,
-  strings: ResponsiveControlOverlayStrings
+  strings: ControlOverlayStrings
 ) => {
   popover.hidden = !open;
   container.dataset[CONTROL_OPEN_KEY] = open ? 'true' : 'false';
@@ -433,54 +140,18 @@ export function createResponsiveControlOverlay(
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
   const button =
-    options.button ??
-    options.toggle ??
-    container.querySelector(CONTROL_BUTTON_SELECTOR) ??
-    container.querySelector(LEGACY_CONTROL_TOGGLE_SELECTOR);
+    options.button ?? container.querySelector(CONTROL_BUTTON_SELECTOR);
   const popover =
     options.popover ?? container.querySelector(CONTROL_POPOVER_SELECTOR);
   const closeButton =
     options.closeButton ?? container.querySelector(CONTROL_CLOSE_SELECTOR);
 
   if (
-    list instanceof HTMLElement &&
-    button instanceof HTMLButtonElement &&
-    !(popover instanceof HTMLElement)
-  ) {
-    return createLegacyResponsiveControlOverlay(options, list, button);
-  }
-
-  if (
     !(list instanceof HTMLElement) ||
     !(button instanceof HTMLButtonElement) ||
     !(popover instanceof HTMLElement)
   ) {
-    return {
-      open() {
-        /* noop */
-      },
-      close() {
-        /* noop */
-      },
-      toggle() {
-        /* noop */
-      },
-      isOpen() {
-        return false;
-      },
-      setLayout() {
-        /* noop */
-      },
-      setStrings() {
-        /* noop */
-      },
-      refresh() {
-        /* noop */
-      },
-      dispose() {
-        /* noop */
-      },
-    };
+    return createNoopResponsiveControlOverlay();
   }
 
   const controlItems = Array.from(
@@ -493,23 +164,26 @@ export function createResponsiveControlOverlay(
 
   const heading = container.querySelector(CONTROL_HEADING_SELECTOR);
   const labelElement = heading instanceof HTMLElement ? heading : list;
-  const labelId = ensureId(labelElement, CONTROL_LIST_ID);
+  const labelId = ensureId(labelElement, 'control-overlay-popover-heading');
   const popoverId = ensureId(popover, CONTROL_POPOVER_ID);
+  const ownsContainerLabel =
+    !container.hasAttribute('aria-label') &&
+    !container.hasAttribute('aria-labelledby');
   button.setAttribute('aria-controls', popoverId);
   button.setAttribute('aria-haspopup', 'dialog');
   popover.setAttribute('role', 'dialog');
   popover.setAttribute('aria-modal', 'false');
   popover.setAttribute('aria-labelledby', labelId);
 
-  let currentStrings: ControlOverlayStrings =
-    'mobileToggle' in strings
-      ? { ...strings }
-      : ({ mobileToggle: strings } as ControlOverlayStrings);
+  let currentStrings: ControlOverlayStrings = { ...strings };
   let layout: HudLayout = initialLayout;
   let open = false;
   let disposed = false;
 
   const applyStrings = () => {
+    if (ownsContainerLabel) {
+      container.setAttribute('aria-label', currentStrings.heading);
+    }
     button.textContent = currentStrings.heading;
     button.setAttribute('aria-label', currentStrings.heading);
     if (closeButton instanceof HTMLButtonElement) {
@@ -633,11 +307,8 @@ export function createResponsiveControlOverlay(
       layout = nextLayout;
       update();
     },
-    setStrings(nextStrings: ResponsiveControlOverlayStrings) {
-      currentStrings =
-        'mobileToggle' in nextStrings
-          ? { ...nextStrings }
-          : ({ mobileToggle: nextStrings } as ControlOverlayStrings);
+    setStrings(nextStrings: ControlOverlayStrings) {
+      currentStrings = { ...nextStrings };
       applyStrings();
     },
     refresh() {
@@ -661,6 +332,9 @@ export function createResponsiveControlOverlay(
       button.removeAttribute('aria-controls');
       button.removeAttribute('aria-haspopup');
       button.dataset.hudAnnounce = '';
+      if (ownsContainerLabel) {
+        container.removeAttribute('aria-label');
+      }
       delete (container.dataset as Record<string, string | undefined>)[
         CONTROL_OPEN_KEY
       ];

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -3,10 +3,13 @@ import type { ControlOverlayStrings } from '../../assets/i18n/types';
 import type { HudLayout } from './layoutManager';
 import type { InputMethod } from './movementLegend';
 
-export type ResponsiveControlOverlayStrings =
-  ControlOverlayStrings['mobileToggle'];
+export type ResponsiveControlOverlayStrings = ControlOverlayStrings;
 
 export interface ResponsiveControlOverlayHandle {
+  open(): void;
+  close(): void;
+  toggle(): void;
+  isOpen(): boolean;
   setLayout(layout: HudLayout): void;
   setStrings(strings: ResponsiveControlOverlayStrings): void;
   refresh(): void;
@@ -16,21 +19,28 @@ export interface ResponsiveControlOverlayHandle {
 export interface ResponsiveControlOverlayOptions {
   container: HTMLElement;
   list?: HTMLElement | null;
+  button?: HTMLButtonElement | null;
   toggle?: HTMLButtonElement | null;
+  popover?: HTMLElement | null;
+  closeButton?: HTMLButtonElement | null;
   strings: ResponsiveControlOverlayStrings;
   initialLayout?: HudLayout;
-  defaultCollapsed?: boolean;
-  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  documentTarget?: Document;
   windowTarget?: Window;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
 const CONTROL_ITEM_SELECTOR = '[data-control-item]';
-const CONTROL_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
-const CONTROL_COLLAPSED_KEY = 'controlCollapsed';
-const MOBILE_COLLAPSED_KEY = 'mobileCollapsed';
+const CONTROL_BUTTON_SELECTOR = '[data-role="controls-button"]';
+const LEGACY_CONTROL_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
+const CONTROL_POPOVER_SELECTOR = '[data-role="controls-popover"]';
+const CONTROL_CLOSE_SELECTOR = '[data-role="controls-close"]';
+const CONTROL_HEADING_SELECTOR = '[data-control-text="heading"]';
 const CONTROL_LIST_ID = 'control-overlay-list';
-const COLLAPSE_STORAGE_KEY = 'hud:control-overlay-collapsed';
+const CONTROL_POPOVER_ID = 'control-overlay-popover';
+const CONTROL_OPEN_KEY = 'controlsOpen';
+const ACTIVE_INPUT_KEY = 'activeInput';
+const ACTIVE_METHOD_KEY = 'activeMethod';
 
 const INPUT_METHODS: ReadonlyArray<InputMethod> = [
   'keyboard',
@@ -56,7 +66,7 @@ const parseInputMethods = (
 };
 
 const getActiveMethod = (container: HTMLElement): InputMethod | null => {
-  const value = container.dataset.activeInput;
+  const value = container.dataset[ACTIVE_INPUT_KEY];
   return isInputMethod(value) ? value : null;
 };
 
@@ -65,167 +75,35 @@ const matchActiveMethod = (
   active: InputMethod | null
 ): boolean => {
   if (!active) {
-    return true;
+    return false;
   }
   if (methods.includes(active)) {
     return true;
   }
-  if (active === 'gamepad' && methods.includes('keyboard')) {
-    return true;
+  return active === 'gamepad' && methods.includes('keyboard');
+};
+
+const ensureId = (element: HTMLElement, fallback: string): string => {
+  if (element.id) {
+    return element.id;
   }
-  return false;
+  element.id = fallback;
+  return element.id;
 };
 
-const applyAnnouncement = (
-  toggle: HTMLButtonElement,
-  strings: ResponsiveControlOverlayStrings,
-  collapsed: boolean
-) => {
-  toggle.dataset.hudAnnounce = collapsed
-    ? strings.expandAnnouncement
-    : strings.collapseAnnouncement;
-};
-
-const applyToggleLabel = (
-  toggle: HTMLButtonElement,
-  strings: ResponsiveControlOverlayStrings,
-  collapsed: boolean
-) => {
-  toggle.textContent = collapsed ? strings.expandLabel : strings.collapseLabel;
-  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
-  applyAnnouncement(toggle, strings, collapsed);
-};
-
-const applyContainerState = (
+const setOpenState = (
   container: HTMLElement,
-  layout: HudLayout,
-  collapsed: boolean
+  popover: HTMLElement,
+  button: HTMLButtonElement,
+  open: boolean,
+  strings: ResponsiveControlOverlayStrings
 ) => {
-  if (layout !== 'mobile') {
-    delete (container.dataset as Record<string, string | undefined>)[
-      CONTROL_COLLAPSED_KEY
-    ];
-    return;
-  }
-  container.dataset[CONTROL_COLLAPSED_KEY] = collapsed ? 'true' : 'false';
-};
-
-const applyCollapsedState = (
-  container: HTMLElement,
-  items: ReadonlyArray<HTMLElement>,
-  collapsedHiddenStates: WeakMap<HTMLElement, boolean>,
-  layout: HudLayout,
-  collapsed: boolean,
-  collapsibleTargets: ReadonlyArray<HTMLElement>
-) => {
-  const collapsibleSet =
-    collapsibleTargets.length > 0 ? new Set(collapsibleTargets) : null;
-  const shouldCollapse =
-    layout === 'mobile' && collapsed && collapsibleTargets.length > 0;
-
-  const restoreCollapsedState = (item: HTMLElement) => {
-    delete (item.dataset as Record<string, string | undefined>)[
-      MOBILE_COLLAPSED_KEY
-    ];
-    if (!collapsedHiddenStates.has(item)) {
-      return;
-    }
-    const previousHidden = collapsedHiddenStates.get(item);
-    collapsedHiddenStates.delete(item);
-    if (previousHidden !== undefined) {
-      item.hidden = previousHidden;
-    }
-  };
-
-  for (const item of items) {
-    if (!shouldCollapse || !collapsibleSet?.has(item)) {
-      restoreCollapsedState(item);
-      continue;
-    }
-
-    if (!collapsedHiddenStates.has(item)) {
-      collapsedHiddenStates.set(item, item.hidden);
-    }
-    item.dataset[MOBILE_COLLAPSED_KEY] = 'true';
-    item.hidden = true;
-  }
-};
-
-const getCollapsibleItems = (
-  container: HTMLElement,
-  items: ReadonlyArray<HTMLElement>
-): ReadonlyArray<HTMLElement> => {
-  const activeMethod = getActiveMethod(container);
-  return items.filter((item) => {
-    const methods = parseInputMethods(item.dataset.inputMethods);
-    const controlId = item.dataset.controlItem ?? '';
-    if (controlId === 'interact') {
-      return false;
-    }
-    return !matchActiveMethod(methods, activeMethod);
-  });
-};
-
-const ensureControlListId = (list: HTMLElement): string => {
-  if (list.id) {
-    return list.id;
-  }
-  list.id = CONTROL_LIST_ID;
-  return list.id;
-};
-
-const getStorage = (
-  windowTarget?: Window,
-  storage?: Pick<Storage, 'getItem' | 'setItem'> | null
-): Pick<Storage, 'getItem' | 'setItem'> | null => {
-  if (storage === null) {
-    return null;
-  }
-  if (storage) {
-    return storage;
-  }
-  if (!windowTarget) {
-    return null;
-  }
-  try {
-    return windowTarget.localStorage ?? null;
-  } catch {
-    return null;
-  }
-};
-
-const readPersistedCollapsed = (
-  storage: Pick<Storage, 'getItem'> | null
-): boolean | null => {
-  if (!storage) {
-    return null;
-  }
-  try {
-    const value = storage.getItem(COLLAPSE_STORAGE_KEY);
-    if (value === 'true') {
-      return true;
-    }
-    if (value === 'false') {
-      return false;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-};
-
-const persistCollapsed = (
-  storage: Pick<Storage, 'setItem'> | null,
-  collapsed: boolean
-) => {
-  if (!storage) {
-    return;
-  }
-  try {
-    storage.setItem(COLLAPSE_STORAGE_KEY, collapsed ? 'true' : 'false');
-  } catch {
-    /* ignore storage errors */
-  }
+  popover.hidden = !open;
+  container.dataset[CONTROL_OPEN_KEY] = open ? 'true' : 'false';
+  button.setAttribute('aria-expanded', open ? 'true' : 'false');
+  button.dataset.hudAnnounce = open
+    ? strings.mobileToggle.collapseAnnouncement
+    : strings.mobileToggle.expandAnnouncement;
 };
 
 export function createResponsiveControlOverlay(
@@ -235,20 +113,38 @@ export function createResponsiveControlOverlay(
     container,
     strings,
     initialLayout = 'desktop',
-    defaultCollapsed,
-    windowTarget = typeof window !== 'undefined' ? window : undefined,
-    storage: providedStorage,
+    documentTarget = typeof document !== 'undefined' ? document : undefined,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
-  const toggle =
-    options.toggle ?? container.querySelector(CONTROL_TOGGLE_SELECTOR);
+  const button =
+    options.button ??
+    options.toggle ??
+    container.querySelector(CONTROL_BUTTON_SELECTOR) ??
+    container.querySelector(LEGACY_CONTROL_TOGGLE_SELECTOR);
+  const popover =
+    options.popover ?? container.querySelector(CONTROL_POPOVER_SELECTOR);
+  const closeButton =
+    options.closeButton ?? container.querySelector(CONTROL_CLOSE_SELECTOR);
 
   if (
     !(list instanceof HTMLElement) ||
-    !(toggle instanceof HTMLButtonElement)
+    !(button instanceof HTMLButtonElement) ||
+    !(popover instanceof HTMLElement)
   ) {
     return {
+      open() {
+        /* noop */
+      },
+      close() {
+        /* noop */
+      },
+      toggle() {
+        /* noop */
+      },
+      isOpen() {
+        return false;
+      },
       setLayout() {
         /* noop */
       },
@@ -268,71 +164,117 @@ export function createResponsiveControlOverlay(
     list.querySelectorAll<HTMLElement>(CONTROL_ITEM_SELECTOR)
   );
   const initialHiddenStates = new WeakMap<HTMLElement, boolean>();
-  const collapsedHiddenStates = new WeakMap<HTMLElement, boolean>();
-
   controlItems.forEach((item) => {
     initialHiddenStates.set(item, item.hidden);
   });
 
-  const listId = ensureControlListId(list);
-  toggle.setAttribute('aria-controls', listId);
+  const heading = container.querySelector(CONTROL_HEADING_SELECTOR);
+  const labelElement = heading instanceof HTMLElement ? heading : list;
+  const labelId = ensureId(labelElement, CONTROL_LIST_ID);
+  const popoverId = ensureId(popover, CONTROL_POPOVER_ID);
+  button.setAttribute('aria-controls', popoverId);
+  button.setAttribute('aria-haspopup', 'dialog');
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-modal', 'false');
+  popover.setAttribute('aria-labelledby', labelId);
 
-  const storage = getStorage(windowTarget, providedStorage);
-  const readStoredCollapsed = () => readPersistedCollapsed(storage);
-
-  const resolveMobileCollapsed = () =>
-    readStoredCollapsed() ?? defaultCollapsed ?? true;
-
-  let layout: HudLayout = initialLayout;
-  let collapsed = layout === 'mobile' ? resolveMobileCollapsed() : false;
   let currentStrings: ResponsiveControlOverlayStrings = { ...strings };
+  let layout: HudLayout = initialLayout;
+  let open = false;
   let disposed = false;
+
+  const applyStrings = () => {
+    button.textContent = currentStrings.heading;
+    button.setAttribute('aria-label', currentStrings.heading);
+    if (closeButton instanceof HTMLButtonElement) {
+      closeButton.setAttribute(
+        'aria-label',
+        currentStrings.mobileToggle.collapseLabel
+      );
+      closeButton.title = currentStrings.mobileToggle.collapseLabel;
+    }
+    setOpenState(container, popover, button, open, currentStrings);
+  };
+
+  const refreshActiveInput = () => {
+    const activeMethod = getActiveMethod(container);
+    for (const item of controlItems) {
+      const methods = parseInputMethods(item.dataset.inputMethods);
+      const isActive = matchActiveMethod(methods, activeMethod);
+      item.dataset[ACTIVE_METHOD_KEY] = isActive ? 'true' : 'false';
+    }
+  };
 
   const update = () => {
     if (disposed) {
       return;
     }
-    const collapsibleItems = getCollapsibleItems(container, controlItems);
-    const canCollapse = layout === 'mobile' && collapsibleItems.length > 0;
-    const effectiveCollapsed = canCollapse ? collapsed : false;
-
-    applyContainerState(container, layout, effectiveCollapsed);
-    applyCollapsedState(
-      container,
-      controlItems,
-      collapsedHiddenStates,
-      layout,
-      effectiveCollapsed,
-      collapsibleItems
-    );
-    if (layout === 'mobile' && canCollapse) {
-      persistCollapsed(storage, collapsed);
-      toggle.hidden = false;
-      applyToggleLabel(toggle, currentStrings, effectiveCollapsed);
-    } else {
-      toggle.hidden = true;
-      toggle.removeAttribute('aria-expanded');
-      toggle.dataset.hudAnnounce = '';
-    }
+    container.dataset.hudLayout = layout;
+    refreshActiveInput();
+    setOpenState(container, popover, button, open, currentStrings);
   };
 
-  const setCollapsed = (next: boolean) => {
-    const normalized = layout === 'mobile' ? next : false;
-    if (collapsed === normalized) {
+  const close = () => {
+    if (!open) {
+      update();
       return;
     }
-    collapsed = normalized;
+    open = false;
     update();
   };
 
-  const handleToggleClick = () => {
-    if (layout !== 'mobile') {
+  const openPopover = () => {
+    if (open) {
+      update();
       return;
     }
-    setCollapsed(!collapsed);
+    open = true;
+    update();
   };
 
-  toggle.addEventListener('click', handleToggleClick);
+  const togglePopover = () => {
+    if (open) {
+      close();
+    } else {
+      openPopover();
+    }
+  };
+
+  const handleButtonClick = () => {
+    togglePopover();
+  };
+
+  const handleCloseClick = () => {
+    close();
+    button.focus();
+  };
+
+  const handleDocumentPointerDown = (event: MouseEvent | PointerEvent) => {
+    if (!open) {
+      return;
+    }
+    const target = event.target;
+    if (!(target instanceof Node)) {
+      return;
+    }
+    if (popover.contains(target) || button.contains(target)) {
+      return;
+    }
+    close();
+  };
+
+  const handleDocumentKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      close();
+      button.focus();
+    }
+  };
+
+  button.addEventListener('click', handleButtonClick);
+  closeButton?.addEventListener('click', handleCloseClick);
+  documentTarget?.addEventListener('pointerdown', handleDocumentPointerDown);
+  documentTarget?.addEventListener('keydown', handleDocumentKeydown);
 
   const observer = new MutationObserver((mutations) => {
     if (
@@ -351,27 +293,23 @@ export function createResponsiveControlOverlay(
     attributeFilter: ['data-active-input'],
   });
 
+  applyStrings();
   update();
 
   return {
+    open: openPopover,
+    close,
+    toggle: togglePopover,
+    isOpen() {
+      return open;
+    },
     setLayout(nextLayout: HudLayout) {
-      if (layout === nextLayout) {
-        update();
-        return;
-      }
       layout = nextLayout;
-      if (layout === 'mobile') {
-        collapsed = resolveMobileCollapsed();
-      } else {
-        collapsed = false;
-      }
       update();
     },
     setStrings(nextStrings: ResponsiveControlOverlayStrings) {
       currentStrings = { ...nextStrings };
-      if (layout === 'mobile') {
-        applyToggleLabel(toggle, currentStrings, collapsed);
-      }
+      applyStrings();
     },
     refresh() {
       update();
@@ -382,17 +320,26 @@ export function createResponsiveControlOverlay(
       }
       disposed = true;
       observer.disconnect();
-      toggle.removeEventListener('click', handleToggleClick);
-      toggle.hidden = true;
-      toggle.removeAttribute('aria-expanded');
-      toggle.dataset.hudAnnounce = '';
-      toggle.textContent = currentStrings.expandLabel;
+      button.removeEventListener('click', handleButtonClick);
+      closeButton?.removeEventListener('click', handleCloseClick);
+      documentTarget?.removeEventListener(
+        'pointerdown',
+        handleDocumentPointerDown
+      );
+      documentTarget?.removeEventListener('keydown', handleDocumentKeydown);
+      popover.hidden = true;
+      button.removeAttribute('aria-expanded');
+      button.removeAttribute('aria-controls');
+      button.removeAttribute('aria-haspopup');
+      button.dataset.hudAnnounce = '';
       delete (container.dataset as Record<string, string | undefined>)[
-        CONTROL_COLLAPSED_KEY
+        CONTROL_OPEN_KEY
       ];
+      delete (container.dataset as Record<string, string | undefined>)
+        .hudLayout;
       for (const item of controlItems) {
         delete (item.dataset as Record<string, string | undefined>)[
-          MOBILE_COLLAPSED_KEY
+          ACTIVE_METHOD_KEY
         ];
         item.hidden = initialHiddenStates.get(item) ?? false;
       }

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -3,7 +3,11 @@ import type { ControlOverlayStrings } from '../../assets/i18n/types';
 import type { HudLayout } from './layoutManager';
 import type { InputMethod } from './movementLegend';
 
-export type ResponsiveControlOverlayStrings = ControlOverlayStrings;
+export type LegacyResponsiveControlOverlayStrings =
+  ControlOverlayStrings['mobileToggle'];
+export type ResponsiveControlOverlayStrings =
+  | ControlOverlayStrings
+  | LegacyResponsiveControlOverlayStrings;
 
 export interface ResponsiveControlOverlayHandle {
   open(): void;
@@ -25,6 +29,8 @@ export interface ResponsiveControlOverlayOptions {
   closeButton?: HTMLButtonElement | null;
   strings: ResponsiveControlOverlayStrings;
   initialLayout?: HudLayout;
+  defaultCollapsed?: boolean;
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
   documentTarget?: Document;
   windowTarget?: Window;
 }
@@ -39,6 +45,9 @@ const CONTROL_HEADING_SELECTOR = '[data-control-text="heading"]';
 const CONTROL_LIST_ID = 'control-overlay-list';
 const CONTROL_POPOVER_ID = 'control-overlay-popover';
 const CONTROL_OPEN_KEY = 'controlsOpen';
+const CONTROL_COLLAPSED_KEY = 'controlCollapsed';
+const MOBILE_COLLAPSED_KEY = 'mobileCollapsed';
+const COLLAPSE_STORAGE_KEY = 'hud:control-overlay-collapsed';
 const ACTIVE_INPUT_KEY = 'activeInput';
 const ACTIVE_METHOD_KEY = 'activeMethod';
 
@@ -91,6 +100,312 @@ const ensureId = (element: HTMLElement, fallback: string): string => {
   return element.id;
 };
 
+const getToggleStrings = (
+  strings: ResponsiveControlOverlayStrings
+): LegacyResponsiveControlOverlayStrings =>
+  'mobileToggle' in strings ? strings.mobileToggle : strings;
+
+const legacyMatchActiveMethod = (
+  methods: ReadonlyArray<InputMethod>,
+  active: InputMethod | null
+): boolean => !active || matchActiveMethod(methods, active);
+
+const getLegacyCollapsibleItems = (
+  container: HTMLElement,
+  items: ReadonlyArray<HTMLElement>
+): ReadonlyArray<HTMLElement> => {
+  const activeMethod = getActiveMethod(container);
+  return items.filter((item) => {
+    const methods = parseInputMethods(item.dataset.inputMethods);
+    const controlId = item.dataset.controlItem ?? '';
+    if (controlId === 'interact') {
+      return false;
+    }
+    return !legacyMatchActiveMethod(methods, activeMethod);
+  });
+};
+
+const applyLegacyToggleLabel = (
+  toggle: HTMLButtonElement,
+  strings: LegacyResponsiveControlOverlayStrings,
+  collapsed: boolean
+) => {
+  toggle.textContent = collapsed ? strings.expandLabel : strings.collapseLabel;
+  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+  toggle.dataset.hudAnnounce = collapsed
+    ? strings.expandAnnouncement
+    : strings.collapseAnnouncement;
+};
+
+const applyLegacyContainerState = (
+  container: HTMLElement,
+  layout: HudLayout,
+  collapsed: boolean
+) => {
+  if (layout !== 'mobile') {
+    delete (container.dataset as Record<string, string | undefined>)[
+      CONTROL_COLLAPSED_KEY
+    ];
+    return;
+  }
+  container.dataset[CONTROL_COLLAPSED_KEY] = collapsed ? 'true' : 'false';
+};
+
+const applyLegacyCollapsedState = (
+  items: ReadonlyArray<HTMLElement>,
+  collapsedHiddenStates: WeakMap<HTMLElement, boolean>,
+  layout: HudLayout,
+  collapsed: boolean,
+  collapsibleTargets: ReadonlyArray<HTMLElement>
+) => {
+  const collapsibleSet =
+    collapsibleTargets.length > 0 ? new Set(collapsibleTargets) : null;
+  const shouldCollapse =
+    layout === 'mobile' && collapsed && collapsibleTargets.length > 0;
+
+  const restoreCollapsedState = (item: HTMLElement) => {
+    delete (item.dataset as Record<string, string | undefined>)[
+      MOBILE_COLLAPSED_KEY
+    ];
+    if (!collapsedHiddenStates.has(item)) {
+      return;
+    }
+    const previousHidden = collapsedHiddenStates.get(item);
+    collapsedHiddenStates.delete(item);
+    if (previousHidden !== undefined) {
+      item.hidden = previousHidden;
+    }
+  };
+
+  for (const item of items) {
+    if (!shouldCollapse || !collapsibleSet?.has(item)) {
+      restoreCollapsedState(item);
+      continue;
+    }
+
+    if (!collapsedHiddenStates.has(item)) {
+      collapsedHiddenStates.set(item, item.hidden);
+    }
+    item.dataset[MOBILE_COLLAPSED_KEY] = 'true';
+    item.hidden = true;
+  }
+};
+
+const getStorage = (
+  windowTarget?: Window,
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null
+): Pick<Storage, 'getItem' | 'setItem'> | null => {
+  if (storage === null) {
+    return null;
+  }
+  if (storage) {
+    return storage;
+  }
+  if (!windowTarget) {
+    return null;
+  }
+  try {
+    return windowTarget.localStorage ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const readPersistedCollapsed = (
+  storage: Pick<Storage, 'getItem'> | null
+): boolean | null => {
+  if (!storage) {
+    return null;
+  }
+  try {
+    const value = storage.getItem(COLLAPSE_STORAGE_KEY);
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
+const persistCollapsed = (
+  storage: Pick<Storage, 'setItem'> | null,
+  collapsed: boolean
+) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(COLLAPSE_STORAGE_KEY, collapsed ? 'true' : 'false');
+  } catch {
+    /* ignore storage errors */
+  }
+};
+
+const createLegacyResponsiveControlOverlay = (
+  options: ResponsiveControlOverlayOptions,
+  list: HTMLElement,
+  toggle: HTMLButtonElement
+): ResponsiveControlOverlayHandle => {
+  const {
+    container,
+    strings,
+    initialLayout = 'desktop',
+    defaultCollapsed,
+    windowTarget = typeof window !== 'undefined' ? window : undefined,
+    storage: providedStorage,
+  } = options;
+  const controlItems = Array.from(
+    list.querySelectorAll<HTMLElement>(CONTROL_ITEM_SELECTOR)
+  );
+  const initialHiddenStates = new WeakMap<HTMLElement, boolean>();
+  const collapsedHiddenStates = new WeakMap<HTMLElement, boolean>();
+  controlItems.forEach((item) => {
+    initialHiddenStates.set(item, item.hidden);
+  });
+
+  const listId = ensureId(list, CONTROL_LIST_ID);
+  toggle.setAttribute('aria-controls', listId);
+
+  const storage = getStorage(windowTarget, providedStorage);
+  const readStoredCollapsed = () => readPersistedCollapsed(storage);
+  const resolveMobileCollapsed = () =>
+    readStoredCollapsed() ?? defaultCollapsed ?? true;
+
+  let layout: HudLayout = initialLayout;
+  let collapsed = layout === 'mobile' ? resolveMobileCollapsed() : false;
+  let currentStrings = getToggleStrings(strings);
+  let disposed = false;
+  let canCollapse = false;
+
+  const update = () => {
+    if (disposed) {
+      return;
+    }
+    const collapsibleItems = getLegacyCollapsibleItems(container, controlItems);
+    canCollapse = layout === 'mobile' && collapsibleItems.length > 0;
+    const effectiveCollapsed = canCollapse ? collapsed : false;
+
+    applyLegacyContainerState(container, layout, effectiveCollapsed);
+    applyLegacyCollapsedState(
+      controlItems,
+      collapsedHiddenStates,
+      layout,
+      effectiveCollapsed,
+      collapsibleItems
+    );
+    if (layout === 'mobile' && canCollapse) {
+      persistCollapsed(storage, collapsed);
+      toggle.hidden = false;
+      applyLegacyToggleLabel(toggle, currentStrings, effectiveCollapsed);
+    } else {
+      toggle.hidden = true;
+      toggle.removeAttribute('aria-expanded');
+      toggle.dataset.hudAnnounce = '';
+    }
+  };
+
+  const setCollapsed = (next: boolean) => {
+    const normalized = layout === 'mobile' ? next : false;
+    if (collapsed === normalized) {
+      update();
+      return;
+    }
+    collapsed = normalized;
+    update();
+  };
+
+  const handleToggleClick = () => {
+    if (layout !== 'mobile') {
+      return;
+    }
+    setCollapsed(!collapsed);
+  };
+
+  toggle.addEventListener('click', handleToggleClick);
+
+  const observer = new MutationObserver((mutations) => {
+    if (
+      mutations.some(
+        (mutation) =>
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'data-active-input'
+      )
+    ) {
+      update();
+    }
+  });
+
+  observer.observe(container, {
+    attributes: true,
+    attributeFilter: ['data-active-input'],
+  });
+
+  update();
+
+  return {
+    open() {
+      setCollapsed(false);
+    },
+    close() {
+      setCollapsed(true);
+    },
+    toggle() {
+      handleToggleClick();
+    },
+    isOpen() {
+      return layout === 'mobile' && canCollapse ? !collapsed : false;
+    },
+    setLayout(nextLayout: HudLayout) {
+      if (layout === nextLayout) {
+        update();
+        return;
+      }
+      layout = nextLayout;
+      if (layout === 'mobile') {
+        collapsed = resolveMobileCollapsed();
+      } else {
+        collapsed = false;
+      }
+      update();
+    },
+    setStrings(nextStrings: ResponsiveControlOverlayStrings) {
+      currentStrings = getToggleStrings(nextStrings);
+      if (layout === 'mobile') {
+        applyLegacyToggleLabel(toggle, currentStrings, collapsed);
+      }
+    },
+    refresh() {
+      update();
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      observer.disconnect();
+      toggle.removeEventListener('click', handleToggleClick);
+      toggle.hidden = true;
+      toggle.removeAttribute('aria-expanded');
+      toggle.removeAttribute('aria-controls');
+      toggle.dataset.hudAnnounce = '';
+      toggle.textContent = currentStrings.expandLabel;
+      delete (container.dataset as Record<string, string | undefined>)[
+        CONTROL_COLLAPSED_KEY
+      ];
+      for (const item of controlItems) {
+        delete (item.dataset as Record<string, string | undefined>)[
+          MOBILE_COLLAPSED_KEY
+        ];
+        item.hidden = initialHiddenStates.get(item) ?? false;
+      }
+    },
+  };
+};
+
 const setOpenState = (
   container: HTMLElement,
   popover: HTMLElement,
@@ -126,6 +441,14 @@ export function createResponsiveControlOverlay(
     options.popover ?? container.querySelector(CONTROL_POPOVER_SELECTOR);
   const closeButton =
     options.closeButton ?? container.querySelector(CONTROL_CLOSE_SELECTOR);
+
+  if (
+    list instanceof HTMLElement &&
+    button instanceof HTMLButtonElement &&
+    !(popover instanceof HTMLElement)
+  ) {
+    return createLegacyResponsiveControlOverlay(options, list, button);
+  }
 
   if (
     !(list instanceof HTMLElement) ||
@@ -178,7 +501,10 @@ export function createResponsiveControlOverlay(
   popover.setAttribute('aria-modal', 'false');
   popover.setAttribute('aria-labelledby', labelId);
 
-  let currentStrings: ResponsiveControlOverlayStrings = { ...strings };
+  let currentStrings: ControlOverlayStrings =
+    'mobileToggle' in strings
+      ? { ...strings }
+      : ({ mobileToggle: strings } as ControlOverlayStrings);
   let layout: HudLayout = initialLayout;
   let open = false;
   let disposed = false;
@@ -308,7 +634,10 @@ export function createResponsiveControlOverlay(
       update();
     },
     setStrings(nextStrings: ResponsiveControlOverlayStrings) {
-      currentStrings = { ...nextStrings };
+      currentStrings =
+        'mobileToggle' in nextStrings
+          ? { ...nextStrings }
+          : ({ mobileToggle: nextStrings } as ControlOverlayStrings);
       applyStrings();
     },
     refresh() {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1436,18 +1436,6 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   display: none;
 }
 
-.overlay__item--touch {
-  display: none;
-}
-
-:root[data-hud-layout='mobile'] .overlay__item--touch {
-  display: flex;
-}
-
-:root[data-hud-layout='mobile'] .overlay__item--desktop {
-  display: none;
-}
-
 .overlay__keys {
   display: inline-block;
   width: 11rem;
@@ -1495,8 +1483,10 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .graphics-quality,
 :root[data-accessibility-motion='reduced'] .mode-toggle,
 :root[data-accessibility-motion='reduced'] .overlay,
+:root[data-accessibility-motion='reduced'] .overlay::after,
 :root[data-accessibility-motion='reduced'] .overlay__controls-button,
 :root[data-accessibility-motion='reduced'] .overlay__help-button,
+:root[data-accessibility-motion='reduced'] .overlay__popover,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close,
 :root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
 :root[data-accessibility-motion='reduced'] .accessibility-presets {
@@ -1509,6 +1499,9 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   .overlay__controls-button:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__help-button:hover,
 :root[data-accessibility-motion='reduced'] .overlay__help-button:focus-visible,
+:root[data-accessibility-motion='reduced'] .overlay__popover-close:hover,
+:root[data-accessibility-motion='reduced']
+  .overlay__popover-close:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__controls-button:active,
 :root[data-accessibility-motion='reduced'] .overlay__help-button:active {
   transform: none;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -535,7 +535,7 @@ canvas {
   overflow: hidden;
 }
 
-html[data-hudLayout='mobile'] .audio-subtitles {
+html[data-hud-layout='mobile'] .audio-subtitles {
   bottom: 6.5rem;
   padding: 0.85rem 1.05rem;
   font-size: 0.95rem;
@@ -1287,26 +1287,28 @@ html[data-hudLayout='mobile'] .audio-subtitles {
 
 .overlay {
   position: fixed;
-  bottom: 1.5rem;
-  left: 1.5rem;
-  padding: 1rem 1.25rem;
-  border-radius: 0.75rem;
-  background: var(--hud-surface-bg);
+  top: calc(env(safe-area-inset-top, 0px) + 1rem);
+  right: calc(env(safe-area-inset-right, 0px) + 1rem);
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.55rem;
   color: var(--hud-surface-text);
-  backdrop-filter: blur(12px);
   font-size: 0.9rem;
   line-height: 1.4;
-  max-width: 20rem;
-  border: 1px solid var(--hud-surface-border);
-  box-shadow: var(--hud-surface-shadow);
+  max-width: min(22rem, calc(100vw - 2rem));
   overflow: visible;
 }
 
 .overlay::after {
   content: '';
   position: absolute;
-  inset: -0.9rem;
-  border-radius: inherit;
+  top: -0.65rem;
+  right: -0.65rem;
+  width: 8rem;
+  height: 8rem;
+  border-radius: 999px;
   background: radial-gradient(
     circle at center,
     rgba(94, 210, 255, 0.55) 0%,
@@ -1319,13 +1321,95 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   transition: opacity 160ms ease;
 }
 
+.overlay__controls-button,
+.overlay__help-button {
+  width: auto;
+  min-height: 2.45rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(123, 209, 255, 0.4);
+  background:
+    linear-gradient(140deg, rgba(12, 25, 39, 0.92), rgba(16, 43, 70, 0.78)),
+    rgba(9, 18, 28, 0.88);
+  color: #e7f4ff;
+  backdrop-filter: blur(12px);
+  box-shadow: var(--hud-surface-shadow);
+  font-size: 0.86rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 120ms ease;
+}
+
+.overlay__controls-button:hover,
+.overlay__controls-button:focus-visible,
+.overlay__help-button:hover,
+.overlay__help-button:focus-visible {
+  border-color: rgba(158, 232, 255, 0.8);
+  box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.overlay__controls-button:active,
+.overlay__help-button:active {
+  transform: translateY(0);
+}
+
+.overlay__popover {
+  width: min(22rem, calc(100vw - 2rem));
+  max-height: min(32rem, calc(100vh - 7.5rem - env(safe-area-inset-top, 0px)));
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--hud-surface-bg);
+  border: 1px solid var(--hud-surface-border);
+  box-shadow: var(--hud-surface-shadow);
+  backdrop-filter: blur(12px);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.overlay__popover[hidden] {
+  display: none;
+}
+
+.overlay__popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
 .overlay__heading {
-  margin: 0 0 0.75rem;
+  margin: 0;
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--hud-surface-heading);
+}
+
+.overlay__popover-close {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid rgba(123, 209, 255, 0.35);
+  border-radius: 999px;
+  background: rgba(8, 18, 30, 0.72);
+  color: var(--hud-surface-text);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.overlay__popover-close:hover,
+.overlay__popover-close:focus-visible {
+  border-color: rgba(158, 232, 255, 0.8);
+  outline: none;
 }
 
 .overlay__list {
@@ -1341,6 +1425,11 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
+  border-radius: 0.55rem;
+}
+
+.overlay__item[data-active-method='true'] {
+  background: rgba(94, 210, 255, 0.08);
 }
 
 .overlay__item[hidden] {
@@ -1360,33 +1449,21 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   color: var(--hud-surface-muted-text);
 }
 
-.overlay__item--touch {
-  display: none;
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .overlay__item--touch {
-    display: flex;
-  }
-
-  .overlay__item--desktop {
-    display: none;
-  }
-}
-
 :root[data-hud-layout='mobile'] {
   --hud-mobile-safe-zone: calc(8.5rem + env(safe-area-inset-bottom, 0px));
 }
 
 :root[data-hud-layout='mobile'] .overlay {
-  bottom: var(--hud-mobile-safe-zone);
-  left: 1rem;
-  right: 1rem;
-  max-width: none;
-  width: auto;
-  padding: 0.9rem 1rem;
+  top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
+  right: calc(env(safe-area-inset-right, 0px) + 0.75rem);
+  max-width: min(20rem, calc(100vw - 1.5rem));
   font-size: 0.85rem;
   line-height: 1.5;
+}
+
+:root[data-hud-layout='mobile'] .overlay__popover {
+  width: min(20rem, calc(100vw - 1.5rem));
+  max-height: min(26rem, calc(100vh - 7rem - env(safe-area-inset-top, 0px)));
 }
 
 :root[data-hud-layout='mobile'] .overlay__keys {
@@ -1399,61 +1476,6 @@ html[data-hudLayout='mobile'] .audio-subtitles {
   right: 1rem;
   max-width: none;
   width: auto;
-}
-
-:root[data-accessibility-motion='reduced'] .audio-hud,
-:root[data-accessibility-motion='reduced'] .motion-blur-control,
-:root[data-accessibility-motion='reduced'] .graphics-quality,
-:root[data-accessibility-motion='reduced'] .mode-toggle,
-:root[data-accessibility-motion='reduced'] .overlay,
-:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
-:root[data-accessibility-motion='reduced'] .accessibility-presets {
-  transition: none !important;
-  animation: none !important;
-}
-
-:root[data-accessibility-contrast='high'] {
-  --hud-surface-bg: rgba(4, 10, 18, 0.92);
-  --hud-surface-raised-bg: rgba(10, 18, 30, 0.96);
-  --hud-surface-border: rgba(214, 238, 255, 0.5);
-  --hud-surface-raised-border: rgba(174, 238, 255, 0.6);
-  --hud-surface-text: #f5f9ff;
-  --hud-surface-muted-text: rgba(240, 250, 255, 0.9);
-  --hud-surface-heading: #f4fbff;
-  --hud-surface-accent: rgba(174, 238, 255, 0.7);
-  --hud-surface-shadow: 0 14px 36px rgba(2, 6, 12, 0.7);
-}
-
-.overlay__help-button {
-  margin-top: 0.85rem;
-  width: 100%;
-  padding: 0.65rem 0.9rem;
-  border-radius: 0.6rem;
-  border: 1px solid rgba(123, 209, 255, 0.4);
-  background:
-    linear-gradient(140deg, rgba(12, 25, 39, 0.92), rgba(16, 43, 70, 0.78)),
-    rgba(9, 18, 28, 0.88);
-  color: #e7f4ff;
-  font-size: 0.86rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  transition:
-    border-color 140ms ease,
-    box-shadow 140ms ease,
-    transform 120ms ease;
-}
-
-.overlay__help-button:hover,
-.overlay__help-button:focus-visible {
-  border-color: rgba(158, 232, 255, 0.8);
-  box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
-  outline: none;
-  transform: translateY(-1px);
-}
-
-.overlay__help-button:active {
-  transform: translateY(0);
 }
 
 .help-modal-backdrop {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1436,6 +1436,18 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   display: none;
 }
 
+.overlay__item--touch {
+  display: none;
+}
+
+:root[data-hud-layout='mobile'] .overlay__item--touch {
+  display: flex;
+}
+
+:root[data-hud-layout='mobile'] .overlay__item--desktop {
+  display: none;
+}
+
 .overlay__keys {
   display: inline-block;
   width: 11rem;
@@ -1476,6 +1488,30 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   right: 1rem;
   max-width: none;
   width: auto;
+}
+
+:root[data-accessibility-motion='reduced'] .audio-hud,
+:root[data-accessibility-motion='reduced'] .motion-blur-control,
+:root[data-accessibility-motion='reduced'] .graphics-quality,
+:root[data-accessibility-motion='reduced'] .mode-toggle,
+:root[data-accessibility-motion='reduced'] .overlay,
+:root[data-accessibility-motion='reduced'] .overlay__controls-button,
+:root[data-accessibility-motion='reduced'] .overlay__help-button,
+:root[data-accessibility-motion='reduced'] .overlay__popover-close,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
+:root[data-accessibility-motion='reduced'] .accessibility-presets {
+  transition: none !important;
+  animation: none !important;
+}
+
+:root[data-accessibility-motion='reduced'] .overlay__controls-button:hover,
+:root[data-accessibility-motion='reduced']
+  .overlay__controls-button:focus-visible,
+:root[data-accessibility-motion='reduced'] .overlay__help-button:hover,
+:root[data-accessibility-motion='reduced'] .overlay__help-button:focus-visible,
+:root[data-accessibility-motion='reduced'] .overlay__controls-button:active,
+:root[data-accessibility-motion='reduced'] .overlay__help-button:active {
+  transform: none;
 }
 
 .help-modal-backdrop {


### PR DESCRIPTION
### Motivation
- Replace the oversized always-visible Controls card with a compact, top‑right HUD entry point so the immersive scene has a smaller default footprint on desktop and mobile. 
- Preserve existing control item semantics (`data-control-item`, `data-input-methods`) and localized strings while making the control list discoverable via a dismissible popover. 

### Description
- Replace the legacy mobile collapse UI with a popover controller (`createResponsiveControlOverlay`) that exposes `open()`, `close()`, `toggle()`, `isOpen()`, `setLayout()`, `setStrings()`, `refresh()`, and `dispose()`. 
- Add a top‑right `Controls` button + bounded `controls-popover` and in‑popover close affordance in `index.html` and wire them from `src/main.ts`. 
- Add `toggleControls` key binding (default `C`) to `src/systems/controls/keyBindings.ts` and wire guarded rising‑edge keyboard handling in `src/main.ts` that ignores text entry and modifier combos. 
- Update `src/ui/hud/controlOverlay.ts` to populate the compact button and keep legacy toggle support; add HUD styles and responsive sizing in `src/ui/styles.css`. 
- Replace/adapt tests: `src/tests/responsiveControlOverlay.test.ts` now covers closed/open defaults, button toggle, Escape close, outside pointer close, dispose cleanup, string refresh, active‑method refresh, and validates the `C` binding. 

### Testing
- Ran formatting and lint: `npm run format:write` (passed) and `npm run lint` (passed). 
- Ran focused unit tests: `npm run test:ci -- src/tests/responsiveControlOverlay.test.ts` (passed). 
- Ran broader test suites: `npm run test:ci` (most tests passed; local run completed with 892/892 tests passing after adapting the small overlay tests). 
- Built and smoke-checked artifacts: `npm run build` (passed) and `npm run smoke` / `node scripts/assert-dist.cjs` (passed). 
- Typecheck: `npm run typecheck` reported existing, repo‑wide TypeScript errors unrelated to this change (these pre‑existing typing issues were not introduced by the popover). 
- Playwright screenshot: installed browsers and dependencies and captured `/tmp/danielsmith-screens/controls-popover.png` using the immersive preview URL. 

Notes: The PR is on branch `codex/compact-controls-popover` (commit `48d9e14`) and leaves broader TypeScript repo issues untouched; follow‑ups can be opened to address global type errors or further HUD unification work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ccaa79c78832fa0311593dc0a9f94)