### PR TITLE
Control overlay: accessibility fixes, legacy mobile collapse, and key-binding normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ Keep pipelines deterministic by regenerating assets immediately after touching g
 - **Movement** – Use `WASD` or arrow keys to guide the mannequin.
 - **Key remapping** – Use `portfolio.input.keyBindings.setBinding('interact', ['e'])`
   in the browser console to try alternate bindings. HUD prompts update instantly and
-  the mapping persists locally.
+  the mapping persists locally. The controls popover shortcut defaults to `C`; if you
+  bind that key to another action, the popover shortcut yields to the action binding.
 - **Touch** – Drag the on-screen joysticks (left: movement, right: camera pan) on touch devices.
 - **Lighting debug** – Press `Shift` + `L` to toggle bloom and LED strips for comparison captures.
 - **Mode toggle** – Press `T` or select the "Text mode" overlay button to jump into the

--- a/src/main.ts
+++ b/src/main.ts
@@ -2423,6 +2423,9 @@ function initializeImmersiveScene(
   const controlOverlayHeading = controlOverlay?.querySelector<HTMLElement>(
     '[data-control-text="heading"]'
   );
+  const controlsButton = controlOverlay?.querySelector<HTMLButtonElement>(
+    '[data-role="controls-button"]'
+  );
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
@@ -2446,6 +2449,7 @@ function initializeImmersiveScene(
     applyControlOverlayAccessibility({
       container: controlOverlay,
       heading: controlOverlayHeading,
+      controlsButton,
       helpButton,
       documentTarget: document,
       focusOnInit: true,
@@ -2457,9 +2461,7 @@ function initializeImmersiveScene(
         list: controlOverlay.querySelector<HTMLElement>(
           '[data-role="control-list"]'
         ),
-        button: controlOverlay.querySelector<HTMLButtonElement>(
-          '[data-role="controls-button"]'
-        ),
+        button: controlsButton,
         popover: controlOverlay.querySelector<HTMLElement>(
           '[data-role="controls-popover"]'
         ),
@@ -2604,17 +2606,31 @@ function initializeImmersiveScene(
       tagName === 'select'
     );
   };
+  const normalizeKeyboardEventKey = (event: KeyboardEvent): string =>
+    event.key.length === 1 ? event.key.toLowerCase() : event.key;
+  const normalizeBindingKey = (binding: string): string =>
+    binding.length === 1 ? binding.toLowerCase() : binding;
   const matchesKeyBinding = (
     event: KeyboardEvent,
     action: KeyBindingAction
   ): boolean => {
-    const normalizedKey =
-      event.key.length === 1 ? event.key.toLowerCase() : event.key;
-    return keyBindings.getBindings(action).some((binding) => {
-      const normalizedBinding =
-        binding.length === 1 ? binding.toLowerCase() : binding;
-      return normalizedBinding === normalizedKey;
-    });
+    const normalizedKey = normalizeKeyboardEventKey(event);
+    return keyBindings
+      .getBindings(action)
+      .some((binding) => normalizeBindingKey(binding) === normalizedKey);
+  };
+  const hasConflictingKeyBinding = (
+    event: KeyboardEvent,
+    action: KeyBindingAction
+  ): boolean => {
+    const normalizedKey = normalizeKeyboardEventKey(event);
+    return bindingActions.some(
+      (candidate) =>
+        candidate !== action &&
+        keyBindings
+          .getBindings(candidate)
+          .some((binding) => normalizeBindingKey(binding) === normalizedKey)
+    );
   };
   const handleControlsKeydown = (event: KeyboardEvent) => {
     if (event.defaultPrevented || event.repeat) {
@@ -2626,7 +2642,10 @@ function initializeImmersiveScene(
     if (isTextEntryTarget(event.target)) {
       return;
     }
-    if (!matchesKeyBinding(event, 'toggleControls')) {
+    if (
+      !matchesKeyBinding(event, 'toggleControls') ||
+      hasConflictingKeyBinding(event, 'toggleControls')
+    ) {
       return;
     }
     event.preventDefault();

--- a/src/tests/controlOverlayAccessibility.test.ts
+++ b/src/tests/controlOverlayAccessibility.test.ts
@@ -52,6 +52,21 @@ describe('applyControlOverlayAccessibility', () => {
     expect(document.activeElement).toBe(preFocused);
   });
 
+  it('uses the visible controls button as the overlay region label when available', () => {
+    const container = document.createElement('div');
+    const heading = document.createElement('p');
+    heading.id = 'hidden-heading';
+    const controlsButton = document.createElement('button');
+    controlsButton.textContent = 'Controls';
+
+    applyControlOverlayAccessibility({ container, heading, controlsButton });
+
+    expect(container.getAttribute('aria-labelledby')).toBe(
+      'control-overlay-controls'
+    );
+    expect(controlsButton.id).toBe('control-overlay-controls');
+  });
+
   it('appends the help button id to existing aria-describedby content', () => {
     const container = document.createElement('div');
     container.setAttribute('aria-describedby', 'existing-id');

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -255,6 +255,57 @@ describe('createResponsiveControlOverlay', () => {
     expect(popover.hidden).toBe(true);
   });
 
+  it('keeps legacy mobile collapse behavior when no popover is present', () => {
+    const container = document.createElement('div');
+    container.dataset.activeInput = 'keyboard';
+    container.innerHTML = `
+      <button type="button" data-role="control-toggle">Show all controls</button>
+      <ul data-role="control-list">
+        <li data-control-item="keyboardMove" data-input-methods="keyboard"></li>
+        <li data-control-item="pointerDrag" data-input-methods="pointer"></li>
+        <li data-control-item="interact" data-input-methods="keyboard pointer touch" hidden></li>
+      </ul>
+    `;
+    document.body.append(container);
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-role="control-toggle"]'
+    );
+    const list = container.querySelector<HTMLElement>(
+      '[data-role="control-list"]'
+    );
+    const pointer = container.querySelector<HTMLElement>(
+      '[data-control-item="pointerDrag"]'
+    );
+
+    if (!toggle || !list || !pointer) {
+      throw new Error('Failed to create legacy control overlay fixture.');
+    }
+
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      toggle,
+      strings: createStrings(),
+      initialLayout: 'mobile',
+      storage: null,
+    });
+
+    expect(handle.isOpen()).toBe(false);
+    expect(toggle.hidden).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(pointer.hidden).toBe(true);
+    expect(pointer.dataset.mobileCollapsed).toBe('true');
+
+    toggle.click();
+
+    expect(handle.isOpen()).toBe(true);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(pointer.hidden).toBe(false);
+    expect(pointer.dataset.mobileCollapsed).toBeUndefined();
+
+    handle.dispose();
+  });
+
   it('represents the controls popover shortcut in the key binding model', () => {
     expect(DEFAULT_KEY_BINDINGS.toggleControls).toEqual(['c']);
   });

--- a/src/ui/hud/controlOverlayAccessibility.ts
+++ b/src/ui/hud/controlOverlayAccessibility.ts
@@ -1,12 +1,14 @@
 interface ControlOverlayAccessibilityOptions {
   container: HTMLElement;
   heading?: HTMLElement | null;
+  controlsButton?: HTMLButtonElement | null;
   helpButton?: HTMLButtonElement | null;
   documentTarget?: Document;
   focusOnInit?: boolean;
 }
 
 const DEFAULT_HEADING_ID = 'control-overlay-heading';
+const DEFAULT_CONTROLS_BUTTON_ID = 'control-overlay-controls';
 const DEFAULT_HELP_BUTTON_ID = 'control-overlay-help';
 
 const ensureHeadingId = (heading: HTMLElement, fallbackId: string) => {
@@ -16,10 +18,7 @@ const ensureHeadingId = (heading: HTMLElement, fallbackId: string) => {
   return heading.id;
 };
 
-const ensureHelpButtonId = (
-  helpButton: HTMLButtonElement,
-  fallbackId: string
-) => {
+const ensureButtonId = (helpButton: HTMLButtonElement, fallbackId: string) => {
   if (!helpButton.id) {
     helpButton.id = fallbackId;
   }
@@ -41,6 +40,7 @@ const appendDescribedBy = (element: HTMLElement, id: string) => {
 export const applyControlOverlayAccessibility = ({
   container,
   heading,
+  controlsButton,
   helpButton,
   documentTarget = document,
   focusOnInit = false,
@@ -50,14 +50,20 @@ export const applyControlOverlayAccessibility = ({
     container.tabIndex = -1;
   }
 
-  if (heading) {
+  if (controlsButton) {
+    const controlsButtonId = ensureButtonId(
+      controlsButton,
+      DEFAULT_CONTROLS_BUTTON_ID
+    );
+    container.setAttribute('aria-labelledby', controlsButtonId);
+  } else if (heading) {
     const headingId = ensureHeadingId(heading, DEFAULT_HEADING_ID);
     container.setAttribute('aria-labelledby', headingId);
   }
 
   if (helpButton) {
     helpButton.setAttribute('aria-haspopup', 'dialog');
-    const helpId = ensureHelpButtonId(helpButton, DEFAULT_HELP_BUTTON_ID);
+    const helpId = ensureButtonId(helpButton, DEFAULT_HELP_BUTTON_ID);
     appendDescribedBy(container, helpId);
   }
 

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -3,7 +3,11 @@ import type { ControlOverlayStrings } from '../../assets/i18n/types';
 import type { HudLayout } from './layoutManager';
 import type { InputMethod } from './movementLegend';
 
-export type ResponsiveControlOverlayStrings = ControlOverlayStrings;
+export type LegacyResponsiveControlOverlayStrings =
+  ControlOverlayStrings['mobileToggle'];
+export type ResponsiveControlOverlayStrings =
+  | ControlOverlayStrings
+  | LegacyResponsiveControlOverlayStrings;
 
 export interface ResponsiveControlOverlayHandle {
   open(): void;
@@ -25,6 +29,8 @@ export interface ResponsiveControlOverlayOptions {
   closeButton?: HTMLButtonElement | null;
   strings: ResponsiveControlOverlayStrings;
   initialLayout?: HudLayout;
+  defaultCollapsed?: boolean;
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
   documentTarget?: Document;
   windowTarget?: Window;
 }
@@ -39,6 +45,9 @@ const CONTROL_HEADING_SELECTOR = '[data-control-text="heading"]';
 const CONTROL_LIST_ID = 'control-overlay-list';
 const CONTROL_POPOVER_ID = 'control-overlay-popover';
 const CONTROL_OPEN_KEY = 'controlsOpen';
+const CONTROL_COLLAPSED_KEY = 'controlCollapsed';
+const MOBILE_COLLAPSED_KEY = 'mobileCollapsed';
+const COLLAPSE_STORAGE_KEY = 'hud:control-overlay-collapsed';
 const ACTIVE_INPUT_KEY = 'activeInput';
 const ACTIVE_METHOD_KEY = 'activeMethod';
 
@@ -91,6 +100,312 @@ const ensureId = (element: HTMLElement, fallback: string): string => {
   return element.id;
 };
 
+const getToggleStrings = (
+  strings: ResponsiveControlOverlayStrings
+): LegacyResponsiveControlOverlayStrings =>
+  'mobileToggle' in strings ? strings.mobileToggle : strings;
+
+const legacyMatchActiveMethod = (
+  methods: ReadonlyArray<InputMethod>,
+  active: InputMethod | null
+): boolean => !active || matchActiveMethod(methods, active);
+
+const getLegacyCollapsibleItems = (
+  container: HTMLElement,
+  items: ReadonlyArray<HTMLElement>
+): ReadonlyArray<HTMLElement> => {
+  const activeMethod = getActiveMethod(container);
+  return items.filter((item) => {
+    const methods = parseInputMethods(item.dataset.inputMethods);
+    const controlId = item.dataset.controlItem ?? '';
+    if (controlId === 'interact') {
+      return false;
+    }
+    return !legacyMatchActiveMethod(methods, activeMethod);
+  });
+};
+
+const applyLegacyToggleLabel = (
+  toggle: HTMLButtonElement,
+  strings: LegacyResponsiveControlOverlayStrings,
+  collapsed: boolean
+) => {
+  toggle.textContent = collapsed ? strings.expandLabel : strings.collapseLabel;
+  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+  toggle.dataset.hudAnnounce = collapsed
+    ? strings.expandAnnouncement
+    : strings.collapseAnnouncement;
+};
+
+const applyLegacyContainerState = (
+  container: HTMLElement,
+  layout: HudLayout,
+  collapsed: boolean
+) => {
+  if (layout !== 'mobile') {
+    delete (container.dataset as Record<string, string | undefined>)[
+      CONTROL_COLLAPSED_KEY
+    ];
+    return;
+  }
+  container.dataset[CONTROL_COLLAPSED_KEY] = collapsed ? 'true' : 'false';
+};
+
+const applyLegacyCollapsedState = (
+  items: ReadonlyArray<HTMLElement>,
+  collapsedHiddenStates: WeakMap<HTMLElement, boolean>,
+  layout: HudLayout,
+  collapsed: boolean,
+  collapsibleTargets: ReadonlyArray<HTMLElement>
+) => {
+  const collapsibleSet =
+    collapsibleTargets.length > 0 ? new Set(collapsibleTargets) : null;
+  const shouldCollapse =
+    layout === 'mobile' && collapsed && collapsibleTargets.length > 0;
+
+  const restoreCollapsedState = (item: HTMLElement) => {
+    delete (item.dataset as Record<string, string | undefined>)[
+      MOBILE_COLLAPSED_KEY
+    ];
+    if (!collapsedHiddenStates.has(item)) {
+      return;
+    }
+    const previousHidden = collapsedHiddenStates.get(item);
+    collapsedHiddenStates.delete(item);
+    if (previousHidden !== undefined) {
+      item.hidden = previousHidden;
+    }
+  };
+
+  for (const item of items) {
+    if (!shouldCollapse || !collapsibleSet?.has(item)) {
+      restoreCollapsedState(item);
+      continue;
+    }
+
+    if (!collapsedHiddenStates.has(item)) {
+      collapsedHiddenStates.set(item, item.hidden);
+    }
+    item.dataset[MOBILE_COLLAPSED_KEY] = 'true';
+    item.hidden = true;
+  }
+};
+
+const getStorage = (
+  windowTarget?: Window,
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null
+): Pick<Storage, 'getItem' | 'setItem'> | null => {
+  if (storage === null) {
+    return null;
+  }
+  if (storage) {
+    return storage;
+  }
+  if (!windowTarget) {
+    return null;
+  }
+  try {
+    return windowTarget.localStorage ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const readPersistedCollapsed = (
+  storage: Pick<Storage, 'getItem'> | null
+): boolean | null => {
+  if (!storage) {
+    return null;
+  }
+  try {
+    const value = storage.getItem(COLLAPSE_STORAGE_KEY);
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
+const persistCollapsed = (
+  storage: Pick<Storage, 'setItem'> | null,
+  collapsed: boolean
+) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(COLLAPSE_STORAGE_KEY, collapsed ? 'true' : 'false');
+  } catch {
+    /* ignore storage errors */
+  }
+};
+
+const createLegacyResponsiveControlOverlay = (
+  options: ResponsiveControlOverlayOptions,
+  list: HTMLElement,
+  toggle: HTMLButtonElement
+): ResponsiveControlOverlayHandle => {
+  const {
+    container,
+    strings,
+    initialLayout = 'desktop',
+    defaultCollapsed,
+    windowTarget = typeof window !== 'undefined' ? window : undefined,
+    storage: providedStorage,
+  } = options;
+  const controlItems = Array.from(
+    list.querySelectorAll<HTMLElement>(CONTROL_ITEM_SELECTOR)
+  );
+  const initialHiddenStates = new WeakMap<HTMLElement, boolean>();
+  const collapsedHiddenStates = new WeakMap<HTMLElement, boolean>();
+  controlItems.forEach((item) => {
+    initialHiddenStates.set(item, item.hidden);
+  });
+
+  const listId = ensureId(list, CONTROL_LIST_ID);
+  toggle.setAttribute('aria-controls', listId);
+
+  const storage = getStorage(windowTarget, providedStorage);
+  const readStoredCollapsed = () => readPersistedCollapsed(storage);
+  const resolveMobileCollapsed = () =>
+    readStoredCollapsed() ?? defaultCollapsed ?? true;
+
+  let layout: HudLayout = initialLayout;
+  let collapsed = layout === 'mobile' ? resolveMobileCollapsed() : false;
+  let currentStrings = getToggleStrings(strings);
+  let disposed = false;
+  let canCollapse = false;
+
+  const update = () => {
+    if (disposed) {
+      return;
+    }
+    const collapsibleItems = getLegacyCollapsibleItems(container, controlItems);
+    canCollapse = layout === 'mobile' && collapsibleItems.length > 0;
+    const effectiveCollapsed = canCollapse ? collapsed : false;
+
+    applyLegacyContainerState(container, layout, effectiveCollapsed);
+    applyLegacyCollapsedState(
+      controlItems,
+      collapsedHiddenStates,
+      layout,
+      effectiveCollapsed,
+      collapsibleItems
+    );
+    if (layout === 'mobile' && canCollapse) {
+      persistCollapsed(storage, collapsed);
+      toggle.hidden = false;
+      applyLegacyToggleLabel(toggle, currentStrings, effectiveCollapsed);
+    } else {
+      toggle.hidden = true;
+      toggle.removeAttribute('aria-expanded');
+      toggle.dataset.hudAnnounce = '';
+    }
+  };
+
+  const setCollapsed = (next: boolean) => {
+    const normalized = layout === 'mobile' ? next : false;
+    if (collapsed === normalized) {
+      update();
+      return;
+    }
+    collapsed = normalized;
+    update();
+  };
+
+  const handleToggleClick = () => {
+    if (layout !== 'mobile') {
+      return;
+    }
+    setCollapsed(!collapsed);
+  };
+
+  toggle.addEventListener('click', handleToggleClick);
+
+  const observer = new MutationObserver((mutations) => {
+    if (
+      mutations.some(
+        (mutation) =>
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'data-active-input'
+      )
+    ) {
+      update();
+    }
+  });
+
+  observer.observe(container, {
+    attributes: true,
+    attributeFilter: ['data-active-input'],
+  });
+
+  update();
+
+  return {
+    open() {
+      setCollapsed(false);
+    },
+    close() {
+      setCollapsed(true);
+    },
+    toggle() {
+      handleToggleClick();
+    },
+    isOpen() {
+      return layout === 'mobile' && canCollapse ? !collapsed : false;
+    },
+    setLayout(nextLayout: HudLayout) {
+      if (layout === nextLayout) {
+        update();
+        return;
+      }
+      layout = nextLayout;
+      if (layout === 'mobile') {
+        collapsed = resolveMobileCollapsed();
+      } else {
+        collapsed = false;
+      }
+      update();
+    },
+    setStrings(nextStrings: ResponsiveControlOverlayStrings) {
+      currentStrings = getToggleStrings(nextStrings);
+      if (layout === 'mobile') {
+        applyLegacyToggleLabel(toggle, currentStrings, collapsed);
+      }
+    },
+    refresh() {
+      update();
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      observer.disconnect();
+      toggle.removeEventListener('click', handleToggleClick);
+      toggle.hidden = true;
+      toggle.removeAttribute('aria-expanded');
+      toggle.removeAttribute('aria-controls');
+      toggle.dataset.hudAnnounce = '';
+      toggle.textContent = currentStrings.expandLabel;
+      delete (container.dataset as Record<string, string | undefined>)[
+        CONTROL_COLLAPSED_KEY
+      ];
+      for (const item of controlItems) {
+        delete (item.dataset as Record<string, string | undefined>)[
+          MOBILE_COLLAPSED_KEY
+        ];
+        item.hidden = initialHiddenStates.get(item) ?? false;
+      }
+    },
+  };
+};
+
 const setOpenState = (
   container: HTMLElement,
   popover: HTMLElement,
@@ -126,6 +441,14 @@ export function createResponsiveControlOverlay(
     options.popover ?? container.querySelector(CONTROL_POPOVER_SELECTOR);
   const closeButton =
     options.closeButton ?? container.querySelector(CONTROL_CLOSE_SELECTOR);
+
+  if (
+    list instanceof HTMLElement &&
+    button instanceof HTMLButtonElement &&
+    !(popover instanceof HTMLElement)
+  ) {
+    return createLegacyResponsiveControlOverlay(options, list, button);
+  }
 
   if (
     !(list instanceof HTMLElement) ||
@@ -178,7 +501,10 @@ export function createResponsiveControlOverlay(
   popover.setAttribute('aria-modal', 'false');
   popover.setAttribute('aria-labelledby', labelId);
 
-  let currentStrings: ResponsiveControlOverlayStrings = { ...strings };
+  let currentStrings: ControlOverlayStrings =
+    'mobileToggle' in strings
+      ? { ...strings }
+      : ({ mobileToggle: strings } as ControlOverlayStrings);
   let layout: HudLayout = initialLayout;
   let open = false;
   let disposed = false;
@@ -308,7 +634,10 @@ export function createResponsiveControlOverlay(
       update();
     },
     setStrings(nextStrings: ResponsiveControlOverlayStrings) {
-      currentStrings = { ...nextStrings };
+      currentStrings =
+        'mobileToggle' in nextStrings
+          ? { ...nextStrings }
+          : ({ mobileToggle: nextStrings } as ControlOverlayStrings);
       applyStrings();
     },
     refresh() {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1436,6 +1436,18 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   display: none;
 }
 
+.overlay__item--touch {
+  display: none;
+}
+
+:root[data-hud-layout='mobile'] .overlay__item--touch {
+  display: flex;
+}
+
+:root[data-hud-layout='mobile'] .overlay__item--desktop {
+  display: none;
+}
+
 .overlay__keys {
   display: inline-block;
   width: 11rem;
@@ -1476,6 +1488,30 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   right: 1rem;
   max-width: none;
   width: auto;
+}
+
+:root[data-accessibility-motion='reduced'] .audio-hud,
+:root[data-accessibility-motion='reduced'] .motion-blur-control,
+:root[data-accessibility-motion='reduced'] .graphics-quality,
+:root[data-accessibility-motion='reduced'] .mode-toggle,
+:root[data-accessibility-motion='reduced'] .overlay,
+:root[data-accessibility-motion='reduced'] .overlay__controls-button,
+:root[data-accessibility-motion='reduced'] .overlay__help-button,
+:root[data-accessibility-motion='reduced'] .overlay__popover-close,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
+:root[data-accessibility-motion='reduced'] .accessibility-presets {
+  transition: none !important;
+  animation: none !important;
+}
+
+:root[data-accessibility-motion='reduced'] .overlay__controls-button:hover,
+:root[data-accessibility-motion='reduced']
+  .overlay__controls-button:focus-visible,
+:root[data-accessibility-motion='reduced'] .overlay__help-button:hover,
+:root[data-accessibility-motion='reduced'] .overlay__help-button:focus-visible,
+:root[data-accessibility-motion='reduced'] .overlay__controls-button:active,
+:root[data-accessibility-motion='reduced'] .overlay__help-button:active {
+  transform: none;
 }
 
 .help-modal-backdrop {


### PR DESCRIPTION
### Motivation

- Ensure the control overlay is properly announced and usable when a visible controls button exists, and preserve legacy mobile collapse behavior for older markup patterns.  
- Make keyboard handling for the controls popover robust by normalizing single-character keys and refusing to toggle the popover when the key conflicts with another bound action.  
- Improve mobile/touch styling and respect reduced-motion accessibility settings for overlay controls.

### Description

- Prefer a visible `controlsButton` as the overlay region label in `applyControlOverlayAccessibility` and consolidate button id handling into `ensureButtonId`.  
- Query and pass `controlsButton` from `src/main.ts` into accessibility setup and wire up updated key-binding helpers: `normalizeKeyboardEventKey`, `normalizeBindingKey`, `matchesKeyBinding`, and `hasConflictingKeyBinding` to avoid shortcut conflicts.  
- Add a legacy implementation `createLegacyResponsiveControlOverlay` for the control list toggle when no popover is present, with options for `defaultCollapsed` and pluggable `storage`, persistent collapsed state under `hud:control-overlay-collapsed`, and logic to collapse non-matching input-method items on mobile.  
- Extend `ResponsiveControlOverlayStrings` typing to accept legacy `mobileToggle` shapes and adapt existing popover logic to a unified `mobileToggle` representation.  
- Update CSS to support touch-specific control items (`.overlay__item--touch`), hide desktop items on mobile, and disable transitions/animations for reduced-motion via `data-accessibility-motion='reduced'`.  
- Add tests covering the new accessibility behavior and legacy mobile collapse flow, and update README docs to clarify the controls popover shortcut semantics when keys are rebound.

### Testing

- Ran the unit tests with `vitest`; all tests completed successfully.  
- Added `src/tests/controlOverlayAccessibility.test.ts` case to assert the controls button becomes the region label and updated assertions for appended `aria-describedby`, and the new test passed.  
- Added `src/tests/responsiveControlOverlay.test.ts` case to verify legacy mobile collapse behavior when no popover exists, which passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd72c201c832f9df45135b3a0d2ea)