### PR TITLE
Unify top-right HUD menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,19 @@
         overflow: visible;
       }
 
+      .overlay__menu-strip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.35rem;
+        padding: 0.25rem;
+        border: 1px solid rgba(123, 209, 255, 0.28);
+        border-radius: 999px;
+        background: rgba(8, 16, 28, 0.58);
+        box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+        backdrop-filter: blur(12px);
+      }
+
       .overlay::after {
         content: '';
         position: absolute;
@@ -76,11 +89,13 @@
         transition: opacity 160ms ease;
       }
 
-      .overlay__controls-button,
-      .overlay__help-button {
+      .overlay__menu-button {
         width: auto;
         min-height: 2.45rem;
-        padding: 0.65rem 0.9rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.55rem 0.72rem;
         border-radius: 999px;
         border: 1px solid rgba(123, 209, 255, 0.4);
         background:
@@ -102,19 +117,28 @@
           transform 120ms ease;
       }
 
-      .overlay__controls-button:hover,
-      .overlay__controls-button:focus-visible,
-      .overlay__help-button:hover,
-      .overlay__help-button:focus-visible {
+      .overlay__menu-button:hover,
+      .overlay__menu-button:focus-visible {
         border-color: rgba(158, 232, 255, 0.8);
         box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
         outline: none;
         transform: translateY(-1px);
       }
 
-      .overlay__controls-button:active,
-      .overlay__help-button:active {
+      .overlay__menu-button:active {
         transform: translateY(0);
+      }
+
+      .overlay__menu-key {
+        min-width: 1.35rem;
+        padding: 0.1rem 0.35rem;
+        border-radius: 999px;
+        background: rgba(143, 214, 255, 0.16);
+        color: rgba(143, 214, 255, 0.75);
+        font: inherit;
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-align: center;
       }
 
       .overlay__popover {
@@ -207,6 +231,16 @@
         max-width: min(20rem, calc(100vw - 1.5rem));
         font-size: 0.85rem;
         line-height: 1.5;
+      }
+
+      html[data-hud-layout='mobile'] .overlay__menu-strip {
+        gap: 0.25rem;
+      }
+
+      html[data-hud-layout='mobile'] .overlay__menu-button {
+        min-height: 2.75rem;
+        padding: 0.55rem 0.6rem;
+        font-size: 0.8rem;
       }
 
       html[data-hud-layout='mobile'] .overlay__popover {
@@ -446,14 +480,42 @@
     </noscript>
     <div id="app"></div>
     <div class="overlay" id="control-overlay" aria-label="Controls">
-      <button
-        class="overlay__controls-button"
-        type="button"
-        data-role="controls-button"
-        aria-expanded="false"
+      <div
+        class="overlay__menu-strip"
+        data-role="hud-menu"
+        aria-label="HUD menu"
       >
-        Controls
-      </button>
+        <button
+          class="overlay__menu-button overlay__controls-button"
+          type="button"
+          data-role="controls-button"
+          aria-expanded="false"
+          aria-pressed="false"
+        >
+          <span data-role="controls-label">Controls</span>
+          <kbd class="overlay__menu-key" data-role="controls-key-hint">C</kbd>
+        </button>
+        <button
+          class="overlay__menu-button"
+          type="button"
+          data-control="text-mode"
+          data-hud-announce="Switch to text mode. Press T to activate."
+        >
+          <span data-role="menu-label">Text</span>
+          <kbd class="overlay__menu-key" data-role="menu-key-hint">T</kbd>
+        </button>
+        <button
+          class="overlay__menu-button overlay__help-button"
+          type="button"
+          data-control="help"
+          data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
+          aria-expanded="false"
+          aria-pressed="false"
+        >
+          <span data-role="menu-label">Settings</span>
+          <kbd class="overlay__menu-key" data-role="menu-key-hint">H</kbd>
+        </button>
+      </div>
       <div class="overlay__popover" data-role="controls-popover" hidden>
         <div class="overlay__popover-header">
           <p class="overlay__heading" data-control-text="heading">Controls</p>
@@ -544,14 +606,6 @@
           </li>
         </ul>
       </div>
-      <button
-        class="overlay__help-button"
-        type="button"
-        data-control="help"
-        data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
-      >
-        Open menu · Press H
-      </button>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -138,6 +138,14 @@ export const AR_OVERRIDES: LocaleOverrides = {
   hud: {
     controlOverlay: {
       heading: 'عناصر التحكم',
+      menu: {
+        controlsLabel: 'التحكم',
+        controlsKeyHint: 'C',
+        textLabel: 'النص',
+        textKeyHint: 'T',
+        settingsLabel: 'الإعدادات',
+        settingsKeyHint: 'H',
+      },
       items: {
         keyboardMove: {
           keys: 'WASD / الأسهم',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -153,6 +153,14 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
   hud: {
     controlOverlay: {
       heading: wrap('Controls'),
+      menu: {
+        controlsLabel: wrap('Controls'),
+        controlsKeyHint: 'C',
+        textLabel: wrap('Text'),
+        textKeyHint: 'T',
+        settingsLabel: wrap('Settings'),
+        settingsKeyHint: 'H',
+      },
       interact: {
         defaultLabel: wrap('Enter'),
         description: wrap('Interact'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -143,6 +143,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
   hud: {
     controlOverlay: {
       heading: 'Controls',
+      menu: {
+        controlsLabel: 'Controls',
+        controlsKeyHint: 'C',
+        textLabel: 'Text',
+        textKeyHint: 'T',
+        settingsLabel: 'Settings',
+        settingsKeyHint: 'H',
+      },
       items: {
         keyboardMove: {
           keys: 'WASD / Arrow keys',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -138,6 +138,14 @@ export const JA_OVERRIDES: LocaleOverrides = {
   hud: {
     controlOverlay: {
       heading: '操作',
+      menu: {
+        controlsLabel: '操作',
+        controlsKeyHint: 'C',
+        textLabel: 'テキスト',
+        textKeyHint: 'T',
+        settingsLabel: '設定',
+        settingsKeyHint: 'H',
+      },
       items: {
         keyboardMove: {
           keys: 'WASD / 矢印キー',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -19,6 +19,14 @@ export interface ControlOverlayItemStrings {
 
 export interface ControlOverlayStrings {
   heading: string;
+  menu: {
+    controlsLabel: string;
+    controlsKeyHint: string;
+    textLabel: string;
+    textKeyHint: string;
+    settingsLabel: string;
+    settingsKeyHint: string;
+  };
   items: {
     keyboardMove: ControlOverlayItemStrings;
     pointerDrag: ControlOverlayItemStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -379,6 +379,10 @@ import {
   type HelpModalControllerHandle,
 } from './ui/hud/helpModalController';
 import {
+  createHudPanelCoordinator,
+  type HudPanelCoordinatorHandle,
+} from './ui/hud/hudPanelCoordinator';
+import {
   createHudLayoutManager,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
@@ -2429,6 +2433,9 @@ function initializeImmersiveScene(
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
+  const textModeButton = controlOverlay?.querySelector<HTMLButtonElement>(
+    '[data-control="text-mode"]'
+  );
   let interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
   const interactDescriptionFallback =
     controlOverlayStrings.interact.description;
@@ -2455,6 +2462,7 @@ function initializeImmersiveScene(
       focusOnInit: true,
     });
   }
+  let hudPanelCoordinator: HudPanelCoordinatorHandle | null = null;
   responsiveControlOverlay = controlOverlay
     ? createResponsiveControlOverlay({
         container: controlOverlay,
@@ -2470,6 +2478,9 @@ function initializeImmersiveScene(
         ),
         strings: controlOverlayStrings,
         initialLayout: 'desktop',
+        onBeforeOpen: () => hudPanelCoordinator?.closePanel('settings'),
+        onOpen: () => hudPanelCoordinator?.notifyOpened('controls'),
+        onClose: () => hudPanelCoordinator?.notifyClosed('controls'),
       })
     : null;
   const helpModal = createHelpModal({
@@ -2578,19 +2589,46 @@ function initializeImmersiveScene(
     documentTarget: document,
     container: document.body,
   });
+  const activateTextMode = () => {
+    if (performanceFailover.hasTriggered()) {
+      clearModePreference();
+      window.location.assign(createImmersiveRecoveryUrl());
+      return;
+    }
+    if (shouldPersistTextPreferenceForFallback('manual')) {
+      writeModePreference('text');
+    }
+    performanceFailover.triggerFallback('manual');
+  };
+
+  const settingsPanelHandle = {
+    open: () => helpModal.open(),
+    close: () => helpModal.close(),
+    toggle: (force?: boolean) => helpModal.toggle(force),
+    isOpen: () => helpModal.isOpen(),
+  };
+  hudPanelCoordinator = createHudPanelCoordinator({
+    controls: responsiveControlOverlay,
+    settings: settingsPanelHandle,
+    onTextAction: activateTextMode,
+  });
+
   helpModalController = attachHelpModalController({
     helpModal,
     helpButton,
-    onOpen: showHudControlElements,
-    onClose: hideHudControlElements,
+    onOpen: () => {
+      showHudControlElements();
+      hudPanelCoordinator?.notifyOpened('settings');
+    },
+    onClose: () => {
+      hideHudControlElements();
+      hudPanelCoordinator?.notifyClosed('settings');
+    },
     hudFocusAnnouncer,
     announcements: helpModalStrings.announcements,
   });
-  const openHelpMenu = () => {
-    helpModal.open();
-  };
-  const toggleHelpMenu = (force?: boolean) => {
-    helpModal.toggle(force);
+  const toggleHelpMenu = () => {
+    hudPanelCoordinator?.toggleSettings();
   };
   const isTextEntryTarget = (target: EventTarget | null): boolean => {
     if (!(target instanceof HTMLElement)) {
@@ -2649,13 +2687,29 @@ function initializeImmersiveScene(
       return;
     }
     event.preventDefault();
-    responsiveControlOverlay?.toggle();
+    hudPanelCoordinator?.toggleControls();
   };
   window.addEventListener('keydown', handleControlsKeydown);
+  const handleHudEscapeKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || event.key !== 'Escape') {
+      return;
+    }
+    if (!hudPanelCoordinator?.closeActivePanel()) {
+      return;
+    }
+    event.preventDefault();
+  };
+  window.addEventListener('keydown', handleHudEscapeKeydown, true);
   let helpButtonClickHandler: (() => void) | null = null;
   if (helpButton) {
-    helpButtonClickHandler = () => openHelpMenu();
+    helpButtonClickHandler = () => toggleHelpMenu();
     helpButton.addEventListener('click', helpButtonClickHandler);
+  }
+  let textModeButtonClickHandler: (() => void) | null = null;
+  if (textModeButton) {
+    textModeButtonClickHandler = () =>
+      hudPanelCoordinator?.activateTextAction();
+    textModeButton.addEventListener('click', textModeButtonClickHandler);
   }
   let interactablePoi: PoiInstance | null = null;
 
@@ -2702,7 +2756,23 @@ function initializeImmersiveScene(
     const label =
       formatKeyLabel(keyBindings.getPrimaryBinding('help')) ||
       helpLabelFallback;
-    helpButton.textContent = buildHelpButtonText(label);
+    const labelElement = helpButton.querySelector<HTMLElement>(
+      '[data-role="menu-label"]'
+    );
+    const keyHintElement = helpButton.querySelector<HTMLElement>(
+      '[data-role="menu-key-hint"]'
+    );
+    if (labelElement) {
+      labelElement.textContent = controlOverlayStrings.menu.settingsLabel;
+    } else {
+      helpButton.textContent = buildHelpButtonText(label);
+    }
+    if (keyHintElement) {
+      keyHintElement.textContent = label;
+    }
+    const ariaLabel = `${controlOverlayStrings.menu.settingsLabel} (${label})`;
+    helpButton.setAttribute('aria-label', ariaLabel);
+    helpButton.title = ariaLabel;
     helpButton.dataset.hudAnnounce = buildHelpAnnouncement(label);
   };
   updateHelpButtonLabel();
@@ -3215,17 +3285,7 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       strings: modeToggleStrings,
       getIsFallbackActive: () => performanceFailover.hasTriggered(),
-      onToggle: () => {
-        if (performanceFailover.hasTriggered()) {
-          clearModePreference();
-          window.location.assign(createImmersiveRecoveryUrl());
-          return;
-        }
-        if (shouldPersistTextPreferenceForFallback('manual')) {
-          writeModePreference('text');
-        }
-        performanceFailover.triggerFallback('manual');
-      },
+      onToggle: activateTextMode,
     });
     registerHudControlElement(manualModeToggle?.element ?? null);
 
@@ -4178,6 +4238,15 @@ function initializeImmersiveScene(
       hudLayoutManager = null;
     }
     window.removeEventListener('keydown', handleControlsKeydown);
+    window.removeEventListener('keydown', handleHudEscapeKeydown, true);
+    if (helpButton && helpButtonClickHandler) {
+      helpButton.removeEventListener('click', helpButtonClickHandler);
+      helpButtonClickHandler = null;
+    }
+    if (textModeButton && textModeButtonClickHandler) {
+      textModeButton.removeEventListener('click', textModeButtonClickHandler);
+      textModeButtonClickHandler = null;
+    }
     if (responsiveControlOverlay) {
       responsiveControlOverlay.dispose();
       responsiveControlOverlay = null;

--- a/src/tests/hudPanelCoordinator.test.ts
+++ b/src/tests/hudPanelCoordinator.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createHudPanelCoordinator,
+  type HudPanelHandle,
+} from '../ui/hud/hudPanelCoordinator';
+
+function createPanelHandle(): HudPanelHandle & {
+  openMock: ReturnType<typeof vi.fn>;
+  closeMock: ReturnType<typeof vi.fn>;
+} {
+  let open = false;
+  const openMock = vi.fn(() => {
+    open = true;
+  });
+  const closeMock = vi.fn(() => {
+    open = false;
+  });
+  return {
+    open: openMock,
+    close: closeMock,
+    toggle: vi.fn(() => {
+      open = !open;
+    }),
+    isOpen: () => open,
+    openMock,
+    closeMock,
+  };
+}
+
+describe('createHudPanelCoordinator', () => {
+  it('closes Controls before opening Settings', () => {
+    const controls = createPanelHandle();
+    const settings = createPanelHandle();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextAction: vi.fn(),
+    });
+
+    coordinator.openControls();
+    coordinator.openSettings();
+
+    expect(controls.closeMock).toHaveBeenCalledTimes(1);
+    expect(settings.openMock).toHaveBeenCalledTimes(1);
+    expect(coordinator.getActivePanel()).toBe('settings');
+  });
+
+  it('closes Settings before opening Controls', () => {
+    const controls = createPanelHandle();
+    const settings = createPanelHandle();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextAction: vi.fn(),
+    });
+
+    coordinator.openSettings();
+    coordinator.openControls();
+
+    expect(settings.closeMock).toHaveBeenCalled();
+    expect(controls.openMock).toHaveBeenCalledTimes(1);
+    expect(coordinator.getActivePanel()).toBe('controls');
+  });
+
+  it('closes open panels before triggering the Text action', () => {
+    const controls = createPanelHandle();
+    const settings = createPanelHandle();
+    const onTextAction = vi.fn();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextAction,
+    });
+
+    coordinator.openControls();
+    coordinator.activateTextAction();
+
+    expect(controls.closeMock).toHaveBeenCalledTimes(1);
+    expect(settings.closeMock).toHaveBeenCalled();
+    expect(onTextAction).toHaveBeenCalledTimes(1);
+    expect(coordinator.getActivePanel()).toBeNull();
+  });
+});

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -8,6 +8,14 @@ import { createResponsiveControlOverlay } from '../ui/hud/responsiveControlOverl
 
 const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
   heading,
+  menu: {
+    controlsLabel: heading,
+    controlsKeyHint: 'C',
+    textLabel: 'Text',
+    textKeyHint: 'T',
+    settingsLabel: 'Settings',
+    settingsKeyHint: 'H',
+  },
   items: {
     keyboardMove: { keys: 'WASD / Arrow keys', description: 'Move' },
     pointerDrag: { keys: 'Left mouse button', description: 'Drag to pan' },
@@ -43,7 +51,10 @@ const createOverlay = () => {
   const container = document.createElement('div');
   container.dataset.activeInput = 'keyboard';
   container.innerHTML = `
-    <button type="button" data-role="controls-button">Controls</button>
+    <button type="button" data-role="controls-button">
+      <span data-role="controls-label">Controls</span>
+      <kbd data-role="controls-key-hint">C</kbd>
+    </button>
     <div data-role="controls-popover">
       <div>
         <p data-control-text="heading">Controls</p>
@@ -96,7 +107,7 @@ describe('createResponsiveControlOverlay', () => {
 
     expect(handle.isOpen()).toBe(false);
     expect(popover.hidden).toBe(true);
-    expect(button.textContent).toBe('Controls');
+    expect(button.textContent?.replace(/\s+/g, ' ').trim()).toBe('Controls C');
     expect(button.getAttribute('aria-expanded')).toBe('false');
     expect(button.getAttribute('aria-controls')).toBe(popover.id);
     expect(container.dataset.controlsOpen).toBe('false');
@@ -230,8 +241,10 @@ describe('createResponsiveControlOverlay', () => {
 
     handle.setStrings(createStrings('Controls menu'));
 
-    expect(button.textContent).toBe('Controls menu');
-    expect(button.getAttribute('aria-label')).toBe('Controls menu');
+    expect(button.textContent?.replace(/\s+/g, ' ').trim()).toBe(
+      'Controls menu C'
+    );
+    expect(button.getAttribute('aria-label')).toBe('Controls menu (C)');
     expect(closeButton.getAttribute('aria-label')).toBe('Close controls');
 
     handle.dispose();
@@ -256,6 +269,7 @@ describe('createResponsiveControlOverlay', () => {
 
     expect(popover.hidden).toBe(true);
     expect(button.getAttribute('aria-expanded')).toBeNull();
+    expect(button.getAttribute('aria-pressed')).toBeNull();
     expect(container.dataset.controlsOpen).toBeUndefined();
     expect(interact?.hidden).toBe(true);
 

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -6,6 +6,8 @@ const CONTROL_DESCRIPTION_SELECTOR = '.overlay__description';
 const INTERACT_LABEL_SELECTOR = '[data-role="interact-label"]';
 const INTERACT_DESCRIPTION_SELECTOR = '[data-role="interact-description"]';
 const CONTROLS_BUTTON_SELECTOR = '[data-role="controls-button"]';
+const TEXT_BUTTON_SELECTOR = '[data-control="text-mode"]';
+const HELP_BUTTON_SELECTOR = '[data-control="help"]';
 const LEGACY_COLLAPSE_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
 
 function setTextContent(
@@ -15,6 +17,33 @@ function setTextContent(
   if (element instanceof HTMLElement) {
     element.textContent = value;
   }
+}
+
+function setMenuButtonContent(
+  button: HTMLButtonElement | null,
+  label: string,
+  keyHint: string
+): void {
+  if (!button) {
+    return;
+  }
+  const labelElement = button.querySelector<HTMLElement>(
+    '[data-role="menu-label"], [data-role="controls-label"]'
+  );
+  const keyHintElement = button.querySelector<HTMLElement>(
+    '[data-role="menu-key-hint"], [data-role="controls-key-hint"]'
+  );
+  if (labelElement) {
+    labelElement.textContent = label;
+  } else {
+    button.textContent = label;
+  }
+  if (keyHintElement) {
+    keyHintElement.textContent = keyHint;
+  }
+  const ariaLabel = `${label} (${keyHint})`;
+  button.setAttribute('aria-label', ariaLabel);
+  button.title = ariaLabel;
 }
 
 export function applyControlOverlayStrings(
@@ -67,10 +96,25 @@ export function applyControlOverlayStrings(
     CONTROLS_BUTTON_SELECTOR
   );
   if (controlsButton) {
-    setTextContent(controlsButton, strings.heading);
+    setMenuButtonContent(
+      controlsButton,
+      strings.menu.controlsLabel,
+      strings.menu.controlsKeyHint
+    );
     controlsButton.dataset.hudAnnounce =
       strings.mobileToggle.expandAnnouncement;
   }
+
+  setMenuButtonContent(
+    container.querySelector<HTMLButtonElement>(TEXT_BUTTON_SELECTOR),
+    strings.menu.textLabel,
+    strings.menu.textKeyHint
+  );
+  setMenuButtonContent(
+    container.querySelector<HTMLButtonElement>(HELP_BUTTON_SELECTOR),
+    strings.menu.settingsLabel,
+    strings.menu.settingsKeyHint
+  );
 
   const legacyCollapseToggle = container.querySelector<HTMLButtonElement>(
     LEGACY_COLLAPSE_TOGGLE_SELECTOR

--- a/src/ui/hud/hudPanelCoordinator.ts
+++ b/src/ui/hud/hudPanelCoordinator.ts
@@ -1,0 +1,109 @@
+export type HudPanel = 'controls' | 'settings';
+
+export interface HudPanelHandle {
+  open(): void;
+  close(): void;
+  toggle(): void;
+  isOpen(): boolean;
+}
+
+export interface HudPanelCoordinatorOptions {
+  controls: HudPanelHandle | null;
+  settings: HudPanelHandle | null;
+  onTextAction: () => void;
+}
+
+export interface HudPanelCoordinatorHandle {
+  getActivePanel(): HudPanel | null;
+  openControls(): void;
+  toggleControls(): void;
+  openSettings(): void;
+  toggleSettings(): void;
+  closeActivePanel(): boolean;
+  closePanel(panel: HudPanel): void;
+  notifyOpened(panel: HudPanel): void;
+  notifyClosed(panel: HudPanel): void;
+  activateTextAction(): void;
+}
+
+export function createHudPanelCoordinator({
+  controls,
+  settings,
+  onTextAction,
+}: HudPanelCoordinatorOptions): HudPanelCoordinatorHandle {
+  let activePanel: HudPanel | null = null;
+
+  const getHandle = (panel: HudPanel): HudPanelHandle | null =>
+    panel === 'controls' ? controls : settings;
+
+  const oppositePanel = (panel: HudPanel): HudPanel =>
+    panel === 'controls' ? 'settings' : 'controls';
+
+  const closePanel = (panel: HudPanel): void => {
+    getHandle(panel)?.close();
+    if (activePanel === panel) {
+      activePanel = null;
+    }
+  };
+
+  const openPanel = (panel: HudPanel): void => {
+    closePanel(oppositePanel(panel));
+    getHandle(panel)?.open();
+    activePanel = panel;
+  };
+
+  const togglePanel = (panel: HudPanel): void => {
+    const handle = getHandle(panel);
+    if (!handle) {
+      return;
+    }
+    if (activePanel === panel || handle.isOpen()) {
+      handle.close();
+      if (activePanel === panel) {
+        activePanel = null;
+      }
+      return;
+    }
+    openPanel(panel);
+  };
+
+  return {
+    getActivePanel() {
+      return activePanel;
+    },
+    openControls() {
+      openPanel('controls');
+    },
+    toggleControls() {
+      togglePanel('controls');
+    },
+    openSettings() {
+      openPanel('settings');
+    },
+    toggleSettings() {
+      togglePanel('settings');
+    },
+    closeActivePanel() {
+      if (!activePanel) {
+        return false;
+      }
+      closePanel(activePanel);
+      return true;
+    },
+    closePanel,
+    notifyOpened(panel) {
+      closePanel(oppositePanel(panel));
+      activePanel = panel;
+    },
+    notifyClosed(panel) {
+      if (activePanel === panel) {
+        activePanel = null;
+      }
+    },
+    activateTextAction() {
+      closePanel('controls');
+      closePanel('settings');
+      onTextAction();
+    },
+  };
+}

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -23,6 +23,9 @@ export interface ResponsiveControlOverlayOptions {
   strings: ControlOverlayStrings;
   initialLayout?: HudLayout;
   documentTarget?: Document;
+  onBeforeOpen?: () => void;
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
@@ -123,6 +126,7 @@ const setOpenState = (
   popover.hidden = !open;
   container.dataset[CONTROL_OPEN_KEY] = open ? 'true' : 'false';
   button.setAttribute('aria-expanded', open ? 'true' : 'false');
+  button.setAttribute('aria-pressed', open ? 'true' : 'false');
   button.dataset.hudAnnounce = open
     ? strings.mobileToggle.collapseAnnouncement
     : strings.mobileToggle.expandAnnouncement;
@@ -136,6 +140,9 @@ export function createResponsiveControlOverlay(
     strings,
     initialLayout = 'desktop',
     documentTarget = typeof document !== 'undefined' ? document : undefined,
+    onBeforeOpen,
+    onOpen,
+    onClose,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
@@ -184,8 +191,23 @@ export function createResponsiveControlOverlay(
     if (ownsContainerLabel) {
       container.setAttribute('aria-label', currentStrings.heading);
     }
-    button.textContent = currentStrings.heading;
-    button.setAttribute('aria-label', currentStrings.heading);
+    const label = button.querySelector<HTMLElement>(
+      '[data-role="controls-label"]'
+    );
+    const keyHint = button.querySelector<HTMLElement>(
+      '[data-role="controls-key-hint"]'
+    );
+    if (label) {
+      label.textContent = currentStrings.menu.controlsLabel;
+    } else {
+      button.textContent = currentStrings.menu.controlsLabel;
+    }
+    if (keyHint) {
+      keyHint.textContent = currentStrings.menu.controlsKeyHint;
+    }
+    const buttonLabel = `${currentStrings.menu.controlsLabel} (${currentStrings.menu.controlsKeyHint})`;
+    button.setAttribute('aria-label', buttonLabel);
+    button.title = buttonLabel;
     if (closeButton instanceof HTMLButtonElement) {
       closeButton.setAttribute(
         'aria-label',
@@ -221,6 +243,7 @@ export function createResponsiveControlOverlay(
     }
     open = false;
     update();
+    onClose?.();
   };
 
   const openPopover = () => {
@@ -228,8 +251,10 @@ export function createResponsiveControlOverlay(
       update();
       return;
     }
+    onBeforeOpen?.();
     open = true;
     update();
+    onOpen?.();
   };
 
   const togglePopover = () => {
@@ -329,6 +354,7 @@ export function createResponsiveControlOverlay(
       documentTarget?.removeEventListener('keydown', handleDocumentKeydown);
       popover.hidden = true;
       button.removeAttribute('aria-expanded');
+      button.removeAttribute('aria-pressed');
       button.removeAttribute('aria-controls');
       button.removeAttribute('aria-haspopup');
       button.dataset.hudAnnounce = '';

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1301,6 +1301,19 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   overflow: visible;
 }
 
+.overlay__menu-strip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border: 1px solid rgba(123, 209, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(8, 16, 28, 0.58);
+  box-shadow: var(--hud-surface-shadow);
+  backdrop-filter: blur(12px);
+}
+
 .overlay::after {
   content: '';
   position: absolute;
@@ -1321,11 +1334,13 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   transition: opacity 160ms ease;
 }
 
-.overlay__controls-button,
-.overlay__help-button {
+.overlay__menu-button {
   width: auto;
   min-height: 2.45rem;
-  padding: 0.65rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.72rem;
   border-radius: 999px;
   border: 1px solid rgba(123, 209, 255, 0.4);
   background:
@@ -1344,19 +1359,28 @@ html[data-hud-layout='mobile'] .audio-subtitles {
     transform 120ms ease;
 }
 
-.overlay__controls-button:hover,
-.overlay__controls-button:focus-visible,
-.overlay__help-button:hover,
-.overlay__help-button:focus-visible {
+.overlay__menu-button:hover,
+.overlay__menu-button:focus-visible {
   border-color: rgba(158, 232, 255, 0.8);
   box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
   outline: none;
   transform: translateY(-1px);
 }
 
-.overlay__controls-button:active,
-.overlay__help-button:active {
+.overlay__menu-button:active {
   transform: translateY(0);
+}
+
+.overlay__menu-key {
+  min-width: 1.35rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 999px;
+  background: rgba(143, 214, 255, 0.16);
+  color: var(--hud-surface-accent);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-align: center;
 }
 
 .overlay__popover {
@@ -1459,6 +1483,16 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   max-width: min(20rem, calc(100vw - 1.5rem));
   font-size: 0.85rem;
   line-height: 1.5;
+}
+
+:root[data-hud-layout='mobile'] .overlay__menu-strip {
+  gap: 0.25rem;
+}
+
+:root[data-hud-layout='mobile'] .overlay__menu-button {
+  min-height: 2.75rem;
+  padding: 0.55rem 0.6rem;
+  font-size: 0.8rem;
 }
 
 :root[data-hud-layout='mobile'] .overlay__popover {


### PR DESCRIPTION
### Motivation
- Consolidate Controls, Text mode, and Settings/help into a single compact top-right HUD so users discover actions from one stable location.
- Prevent overlapping HUD panels by making Controls and Settings mutually exclusive and ensure Text activation always closes panels first.
- Reuse the existing text-mode/manual fallback path to avoid duplicating logic and preserve current keyboard shortcuts (`C`, `T`, `H`).

### Description
- Add a compact HUD menu strip (Controls / Text / Settings) with visible key hints and accessible labels in `index.html` and styles in `src/ui/styles.css` and wire localized labels via `src/assets/i18n/*`.
- Introduce a small coordinator `createHudPanelCoordinator` in `src/ui/hud/hudPanelCoordinator.ts` that enforces mutual exclusion, closes the opposite panel before opening, supports Escape to close the active panel, and exposes `activateTextAction()` to close panels then run the text-mode path.
- Wire `responsiveControlOverlay` to new open/close callbacks and `aria-pressed` so it participates in central coordination and update `applyControlOverlayStrings` to populate menu labels/key-hints (no behavioral duplication of `ManualModeToggle`).
- Add tests: `src/tests/hudPanelCoordinator.test.ts` for mutual exclusion and updated `src/tests/responsiveControlOverlay.test.ts` for menu key-hint behavior and overlay state.

### Testing
- `npm run format:write` — passed. 
- `npm run lint` — passed after minor cleanup. 
- `npm run typecheck` — failed due to pre-existing repository-wide TypeScript issues unrelated to the HUD change (reported as existing missing/typing issues); HUD changes did not introduce new type failures.
- `npm run test:ci` — full test suite run completed successfully (`vitest`), focused new/updated tests passed (`src/tests/hudPanelCoordinator.test.ts`, updated `responsiveControlOverlay` tests included). 
- `npm run build` — passed and produced `dist/` artifacts (note: bundle warning about large chunk size only). 
- `npm run docs:check` — passed. 
- `npm run smoke` — passed. 
- Playwright screenshot (`npm run screenshot -- --grep "capture launch state screenshot"`) — could not be run in this environment because Playwright browsers are not installed (error: run `npx playwright install`).

Notes: The implementation is intentionally minimal and avoids adding runtime dependencies or a new state framework; follow-ups could add Playwright e2e coverage for mobile interactions and a small accessibility test sweep if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf11a8390832fa10cb28f7e6cddd3)