### PR TITLE
✨ : – unify HUD menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,8 +76,19 @@
         transition: opacity 160ms ease;
       }
 
-      .overlay__controls-button,
-      .overlay__help-button {
+      .overlay__menu {
+        display: flex;
+        align-items: stretch;
+        justify-content: flex-end;
+        gap: 0.35rem;
+        padding: 0.25rem;
+        border: 1px solid rgba(123, 209, 255, 0.32);
+        border-radius: 999px;
+        background: rgba(5, 12, 22, 0.58);
+        box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+      }
+
+      .overlay__menu-button {
         width: auto;
         min-height: 2.45rem;
         padding: 0.65rem 0.9rem;
@@ -102,19 +113,44 @@
           transform 120ms ease;
       }
 
-      .overlay__controls-button:hover,
-      .overlay__controls-button:focus-visible,
-      .overlay__help-button:hover,
-      .overlay__help-button:focus-visible {
+      .overlay__menu-button:hover,
+      .overlay__menu-button:focus-visible {
         border-color: rgba(158, 232, 255, 0.8);
         box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
         outline: none;
         transform: translateY(-1px);
       }
 
-      .overlay__controls-button:active,
-      .overlay__help-button:active {
+      .overlay__menu-button:active {
         transform: translateY(0);
+      }
+
+      .overlay__menu-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.45rem;
+      }
+
+      .overlay__menu-button[aria-expanded='true'],
+      .overlay__menu-button[aria-pressed='true'] {
+        border-color: rgba(158, 232, 255, 0.88);
+      }
+
+      .overlay__menu-label {
+        white-space: nowrap;
+      }
+
+      .overlay__key-hint {
+        min-width: 1.35rem;
+        padding: 0.1rem 0.35rem;
+        border: 1px solid rgba(158, 232, 255, 0.36);
+        border-radius: 999px;
+        background: rgba(203, 239, 255, 0.1);
+        color: rgba(123, 209, 255, 0.95);
+        font-size: 0.72rem;
+        line-height: 1.2;
+        text-align: center;
       }
 
       .overlay__popover {
@@ -445,15 +481,46 @@
       </section>
     </noscript>
     <div id="app"></div>
-    <div class="overlay" id="control-overlay" aria-label="Controls">
-      <button
-        class="overlay__controls-button"
-        type="button"
-        data-role="controls-button"
-        aria-expanded="false"
+    <div class="overlay" id="control-overlay" aria-label="Portfolio HUD menu">
+      <div
+        class="overlay__menu"
+        data-role="hud-menu"
+        role="group"
+        aria-label="Portfolio HUD menu"
       >
-        Controls
-      </button>
+        <button
+          class="overlay__menu-button overlay__controls-button"
+          type="button"
+          data-role="controls-button"
+          aria-expanded="false"
+          title="Show controls. Press C."
+        >
+          <span class="overlay__menu-label" data-role="controls-button-label"
+            >Controls</span
+          >
+          <span class="overlay__key-hint" aria-hidden="true">C</span>
+        </button>
+        <button
+          class="overlay__menu-button overlay__text-button"
+          type="button"
+          data-role="text-mode-button"
+          aria-pressed="false"
+          title="Switch to text mode. Press T."
+        >
+          <span class="overlay__menu-label">Text</span>
+          <span class="overlay__key-hint" aria-hidden="true">T</span>
+        </button>
+        <button
+          class="overlay__menu-button overlay__help-button"
+          type="button"
+          data-control="help"
+          data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
+          title="Open settings and help. Press H."
+        >
+          <span class="overlay__menu-label">Settings</span>
+          <span class="overlay__key-hint" aria-hidden="true">H</span>
+        </button>
+      </div>
       <div class="overlay__popover" data-role="controls-popover" hidden>
         <div class="overlay__popover-header">
           <p class="overlay__heading" data-control-text="heading">Controls</p>
@@ -544,14 +611,6 @@
           </li>
         </ul>
       </div>
-      <button
-        class="overlay__help-button"
-        type="button"
-        data-control="help"
-        data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
-      >
-        Open menu · Press H
-      </button>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -178,6 +178,18 @@ export const AR_OVERRIDES: LocaleOverrides = {
           'افتح الإعدادات والمساعدة. اضغط {shortcut} لمراجعة الاختصارات والنصائح.',
         shortcutFallback: 'H',
       },
+      hudMenu: {
+        label: 'قائمة واجهة المحفظة',
+        controlsLabel: 'عناصر التحكم',
+        controlsTitleTemplate: 'إظهار عناصر التحكم. اضغط {shortcut}.',
+        controlsKeyHint: 'C',
+        textLabel: 'النص',
+        textTitleTemplate: 'التحويل إلى العرض النصي. اضغط {shortcut}.',
+        textKeyHint: 'T',
+        settingsLabel: 'الإعدادات',
+        settingsTitleTemplate: 'فتح الإعدادات والمساعدة. اضغط {shortcut}.',
+        settingsKeyHint: 'H',
+      },
       mobileToggle: {
         expandLabel: 'إظهار كل عناصر التحكم',
         collapseLabel: 'إخفاء عناصر التحكم الإضافية',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -169,6 +169,20 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         ),
         shortcutFallback: wrap('H'),
       },
+      hudMenu: {
+        label: wrap('Portfolio HUD menu'),
+        controlsLabel: wrap('Controls'),
+        controlsTitleTemplate: wrap('Show controls. Press {shortcut}.'),
+        controlsKeyHint: wrap('C'),
+        textLabel: wrap('Text'),
+        textTitleTemplate: wrap('Switch to text mode. Press {shortcut}.'),
+        textKeyHint: wrap('T'),
+        settingsLabel: wrap('Settings'),
+        settingsTitleTemplate: wrap(
+          'Open settings and help. Press {shortcut}.'
+        ),
+        settingsKeyHint: wrap('H'),
+      },
       mobileToggle: {
         expandLabel: wrap('Show all controls'),
         collapseLabel: wrap('Hide extra controls'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -188,6 +188,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Open settings and help. Press {shortcut} to review controls and accessibility tips.',
         shortcutFallback: 'H',
       },
+      hudMenu: {
+        label: 'Portfolio HUD menu',
+        controlsLabel: 'Controls',
+        controlsTitleTemplate: 'Show controls. Press {shortcut}.',
+        controlsKeyHint: 'C',
+        textLabel: 'Text',
+        textTitleTemplate: 'Switch to text mode. Press {shortcut}.',
+        textKeyHint: 'T',
+        settingsLabel: 'Settings',
+        settingsTitleTemplate: 'Open settings and help. Press {shortcut}.',
+        settingsKeyHint: 'H',
+      },
       mobileToggle: {
         expandLabel: 'Show all controls',
         collapseLabel: 'Hide extra controls',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -178,6 +178,20 @@ export const JA_OVERRIDES: LocaleOverrides = {
           '設定とヘルプを開きます。ショートカット {shortcut} で操作方法とアクセシビリティのヒントを確認できます。',
         shortcutFallback: 'H',
       },
+      hudMenu: {
+        label: 'ポートフォリオHUDメニュー',
+        controlsLabel: '操作',
+        controlsTitleTemplate: '操作を表示します。{shortcut} を押します。',
+        controlsKeyHint: 'C',
+        textLabel: 'テキスト',
+        textTitleTemplate:
+          'テキストモードに切り替えます。{shortcut} を押します。',
+        textKeyHint: 'T',
+        settingsLabel: '設定',
+        settingsTitleTemplate:
+          '設定とヘルプを開きます。{shortcut} を押します。',
+        settingsKeyHint: 'H',
+      },
       mobileToggle: {
         expandLabel: 'すべての操作を表示',
         collapseLabel: '追加の操作を隠す',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -38,6 +38,18 @@ export interface ControlOverlayStrings {
     announcementTemplate: string;
     shortcutFallback: string;
   };
+  hudMenu: {
+    label: string;
+    controlsLabel: string;
+    controlsTitleTemplate: string;
+    controlsKeyHint: string;
+    textLabel: string;
+    textTitleTemplate: string;
+    textKeyHint: string;
+    settingsLabel: string;
+    settingsTitleTemplate: string;
+    settingsKeyHint: string;
+  };
   mobileToggle: {
     expandLabel: string;
     collapseLabel: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -379,6 +379,10 @@ import {
   type HelpModalControllerHandle,
 } from './ui/hud/helpModalController';
 import {
+  createHudPanelCoordinator,
+  type HudPanelCoordinatorHandle,
+} from './ui/hud/hudPanelCoordinator';
+import {
   createHudLayoutManager,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
@@ -819,6 +823,7 @@ function initializeImmersiveScene(
   }
   let hudFocusAnnouncer: HudFocusAnnouncerHandle | null = null;
   let helpModalController: HelpModalControllerHandle | null = null;
+  let hudPanelCoordinator: HudPanelCoordinatorHandle | null = null;
   let poiNarrativeLog: PoiNarrativeLogHandle | null = null;
   let proceduralNarrator: ProceduralNarrator | null = null;
   let localeToggleControl: LocaleToggleControlHandle | null = null;
@@ -2429,6 +2434,9 @@ function initializeImmersiveScene(
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
+  const textModeButton = controlOverlay?.querySelector<HTMLButtonElement>(
+    '[data-role="text-mode-button"]'
+  );
   let interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
   const interactDescriptionFallback =
     controlOverlayStrings.interact.description;
@@ -2470,6 +2478,8 @@ function initializeImmersiveScene(
         ),
         strings: controlOverlayStrings,
         initialLayout: 'desktop',
+        onOpen: () => hudPanelCoordinator?.noteControlsOpen(),
+        onClose: () => hudPanelCoordinator?.noteControlsClosed(),
       })
     : null;
   const helpModal = createHelpModal({
@@ -2578,19 +2588,51 @@ function initializeImmersiveScene(
     documentTarget: document,
     container: document.body,
   });
+  const activateTextMode = () => {
+    if (performanceFailover.hasTriggered()) {
+      clearModePreference();
+      window.location.assign(createImmersiveRecoveryUrl());
+      return;
+    }
+    if (shouldPersistTextPreferenceForFallback('manual')) {
+      writeModePreference('text');
+    }
+    performanceFailover.triggerFallback('manual');
+  };
+
   helpModalController = attachHelpModalController({
     helpModal,
     helpButton,
-    onOpen: showHudControlElements,
-    onClose: hideHudControlElements,
+    onOpen: () => {
+      showHudControlElements();
+      hudPanelCoordinator?.noteSettingsOpen();
+    },
+    onClose: () => {
+      hideHudControlElements();
+      hudPanelCoordinator?.noteSettingsClosed();
+    },
     hudFocusAnnouncer,
     announcements: helpModalStrings.announcements,
   });
-  const openHelpMenu = () => {
-    helpModal.open();
-  };
+
+  hudPanelCoordinator = createHudPanelCoordinator({
+    controls: responsiveControlOverlay ?? {
+      open() {
+        /* noop */
+      },
+      close() {
+        /* noop */
+      },
+      isOpen() {
+        return false;
+      },
+    },
+    settings: helpModal,
+    onTextAction: activateTextMode,
+  });
+
   const toggleHelpMenu = (force?: boolean) => {
-    helpModal.toggle(force);
+    hudPanelCoordinator?.toggleSettings(force);
   };
   const isTextEntryTarget = (target: EventTarget | null): boolean => {
     if (!(target instanceof HTMLElement)) {
@@ -2649,13 +2691,45 @@ function initializeImmersiveScene(
       return;
     }
     event.preventDefault();
-    responsiveControlOverlay?.toggle();
+    hudPanelCoordinator?.toggleControls();
+  };
+  const handleTextModeKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || event.repeat) {
+      return;
+    }
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      return;
+    }
+    if (isTextEntryTarget(event.target)) {
+      return;
+    }
+    const keyHint = modeToggleStrings.keyHint;
+    if (event.key !== keyHint && event.key !== keyHint.toLowerCase()) {
+      return;
+    }
+    event.preventDefault();
+    hudPanelCoordinator?.activateText();
+  };
+  const handleHudEscapeKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || event.key !== 'Escape') {
+      return;
+    }
+    if (hudPanelCoordinator?.closeActivePanel()) {
+      event.preventDefault();
+    }
   };
   window.addEventListener('keydown', handleControlsKeydown);
+  window.addEventListener('keydown', handleTextModeKeydown);
+  window.addEventListener('keydown', handleHudEscapeKeydown);
   let helpButtonClickHandler: (() => void) | null = null;
   if (helpButton) {
-    helpButtonClickHandler = () => openHelpMenu();
+    helpButtonClickHandler = () => toggleHelpMenu();
     helpButton.addEventListener('click', helpButtonClickHandler);
+  }
+  let textModeButtonClickHandler: (() => void) | null = null;
+  if (textModeButton) {
+    textModeButtonClickHandler = () => hudPanelCoordinator?.activateText();
+    textModeButton.addEventListener('click', textModeButtonClickHandler);
   }
   let interactablePoi: PoiInstance | null = null;
 
@@ -2687,25 +2761,68 @@ function initializeImmersiveScene(
   let activeFloorId: FloorId = 'ground';
   let helpKeyWasPressed = false;
   let helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
-  const buildHelpButtonText = (shortcut: string) =>
-    formatMessage(controlOverlayStrings.helpButton.labelTemplate, {
-      shortcut,
-    });
   const buildHelpAnnouncement = (shortcut: string) =>
     formatMessage(controlOverlayStrings.helpButton.announcementTemplate, {
       shortcut,
     });
-  const updateHelpButtonLabel = () => {
-    if (!helpButton) {
-      return;
+  const setButtonLabel = (button: HTMLButtonElement, label: string) => {
+    const labelElement = button.querySelector<HTMLElement>(
+      '.overlay__menu-label'
+    );
+    if (labelElement) {
+      labelElement.textContent = label;
+    } else {
+      button.textContent = label;
     }
-    const label =
+  };
+  const setButtonKeyHint = (button: HTMLButtonElement, keyHint: string) => {
+    const keyHintElement =
+      button.querySelector<HTMLElement>('.overlay__key-hint');
+    if (keyHintElement) {
+      keyHintElement.textContent = keyHint;
+    }
+  };
+  const updateHudMenuLabels = () => {
+    const menuStrings = controlOverlayStrings.hudMenu;
+    const controlsShortcut =
+      formatKeyLabel(keyBindings.getPrimaryBinding('toggleControls')) ||
+      menuStrings.controlsKeyHint;
+    const textShortcut = modeToggleStrings.keyHint || menuStrings.textKeyHint;
+    const settingsShortcut =
       formatKeyLabel(keyBindings.getPrimaryBinding('help')) ||
       helpLabelFallback;
-    helpButton.textContent = buildHelpButtonText(label);
-    helpButton.dataset.hudAnnounce = buildHelpAnnouncement(label);
+
+    controlOverlay?.setAttribute('aria-label', menuStrings.label);
+    controlOverlay
+      ?.querySelector<HTMLElement>('[data-role="hud-menu"]')
+      ?.setAttribute('aria-label', menuStrings.label);
+
+    if (controlsButton) {
+      setButtonLabel(controlsButton, menuStrings.controlsLabel);
+      setButtonKeyHint(controlsButton, controlsShortcut);
+      controlsButton.title = formatMessage(menuStrings.controlsTitleTemplate, {
+        shortcut: controlsShortcut,
+      });
+    }
+    if (textModeButton) {
+      setButtonLabel(textModeButton, menuStrings.textLabel);
+      setButtonKeyHint(textModeButton, textShortcut);
+      textModeButton.setAttribute('aria-label', menuStrings.textLabel);
+      textModeButton.title = formatMessage(menuStrings.textTitleTemplate, {
+        shortcut: textShortcut,
+      });
+    }
+    if (helpButton) {
+      setButtonLabel(helpButton, menuStrings.settingsLabel);
+      setButtonKeyHint(helpButton, settingsShortcut);
+      helpButton.setAttribute('aria-label', menuStrings.settingsLabel);
+      helpButton.title = formatMessage(menuStrings.settingsTitleTemplate, {
+        shortcut: settingsShortcut,
+      });
+      helpButton.dataset.hudAnnounce = buildHelpAnnouncement(settingsShortcut);
+    }
   };
-  updateHelpButtonLabel();
+  updateHudMenuLabels();
 
   const applyLocaleUpdate = (nextLocale: Locale) => {
     if (locale === nextLocale) {
@@ -2760,7 +2877,7 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
-    updateHelpButtonLabel();
+    updateHudMenuLabels();
     localeToggleControl?.refresh();
 
     const visitedSnapshot = poiVisitedState.snapshot();
@@ -2804,7 +2921,7 @@ function initializeImmersiveScene(
         movementLegend.setKeyboardInteractLabel(label);
       }
       if (action === 'help') {
-        updateHelpButtonLabel();
+        updateHudMenuLabels();
       }
       saveKeyBindings();
     })
@@ -3216,15 +3333,7 @@ function initializeImmersiveScene(
       strings: modeToggleStrings,
       getIsFallbackActive: () => performanceFailover.hasTriggered(),
       onToggle: () => {
-        if (performanceFailover.hasTriggered()) {
-          clearModePreference();
-          window.location.assign(createImmersiveRecoveryUrl());
-          return;
-        }
-        if (shouldPersistTextPreferenceForFallback('manual')) {
-          writeModePreference('text');
-        }
-        performanceFailover.triggerFallback('manual');
+        activateTextMode();
       },
     });
     registerHudControlElement(manualModeToggle?.element ?? null);
@@ -4178,6 +4287,9 @@ function initializeImmersiveScene(
       hudLayoutManager = null;
     }
     window.removeEventListener('keydown', handleControlsKeydown);
+    window.removeEventListener('keydown', handleTextModeKeydown);
+    window.removeEventListener('keydown', handleHudEscapeKeydown);
+    hudPanelCoordinator = null;
     if (responsiveControlOverlay) {
       responsiveControlOverlay.dispose();
       responsiveControlOverlay = null;
@@ -4256,8 +4368,15 @@ function initializeImmersiveScene(
       window.portfolio.performance = crashLogAccess;
     }
     if (helpButton) {
-      helpButton.textContent = buildHelpButtonText(helpLabelFallback);
       helpButton.dataset.hudAnnounce = buildHelpAnnouncement(helpLabelFallback);
+      if (helpButtonClickHandler) {
+        helpButton.removeEventListener('click', helpButtonClickHandler);
+        helpButtonClickHandler = null;
+      }
+    }
+    if (textModeButton && textModeButtonClickHandler) {
+      textModeButton.removeEventListener('click', textModeButtonClickHandler);
+      textModeButtonClickHandler = null;
     }
     if (localeToggleControl) {
       localeToggleControl.dispose();

--- a/src/tests/hudPanelCoordinator.test.ts
+++ b/src/tests/hudPanelCoordinator.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createHudPanelCoordinator } from '../ui/hud/hudPanelCoordinator';
+
+const createPanel = () => {
+  let open = false;
+  return {
+    open: vi.fn(() => {
+      open = true;
+    }),
+    close: vi.fn(() => {
+      open = false;
+    }),
+    toggle: vi.fn((force?: boolean) => {
+      open = force ?? !open;
+    }),
+    isOpen: vi.fn(() => open),
+  };
+};
+
+describe('createHudPanelCoordinator', () => {
+  it('closes Controls before opening Settings', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextAction: vi.fn(),
+    });
+
+    coordinator.openControls();
+    expect(coordinator.getActivePanel()).toBe('controls');
+
+    coordinator.openSettings();
+
+    expect(controls.close).toHaveBeenCalledTimes(1);
+    expect(settings.open).toHaveBeenCalledTimes(1);
+    expect(controls.isOpen()).toBe(false);
+    expect(settings.isOpen()).toBe(true);
+    expect(coordinator.getActivePanel()).toBe('settings');
+  });
+
+  it('closes Settings before opening Controls', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextAction: vi.fn(),
+    });
+
+    coordinator.openSettings();
+    expect(coordinator.getActivePanel()).toBe('settings');
+
+    coordinator.openControls();
+
+    expect(settings.close).toHaveBeenCalledTimes(1);
+    expect(controls.open).toHaveBeenCalledTimes(1);
+    expect(settings.isOpen()).toBe(false);
+    expect(controls.isOpen()).toBe(true);
+    expect(coordinator.getActivePanel()).toBe('controls');
+  });
+
+  it('closes panels before triggering text mode', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const onTextAction = vi.fn();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextAction,
+    });
+
+    coordinator.openControls();
+    coordinator.activateText();
+
+    expect(controls.close).toHaveBeenCalled();
+    expect(settings.close).toHaveBeenCalled();
+    expect(onTextAction).toHaveBeenCalledTimes(1);
+    expect(coordinator.getActivePanel()).toBeNull();
+  });
+
+  it('mirrors direct controller open notifications for mutual exclusion', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextAction: vi.fn(),
+    });
+
+    settings.open();
+    coordinator.noteSettingsOpen();
+    controls.open();
+    coordinator.noteControlsOpen();
+
+    expect(settings.close).toHaveBeenCalledTimes(1);
+    expect(coordinator.getActivePanel()).toBe('controls');
+  });
+});

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -31,6 +31,18 @@ const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
     announcementTemplate: 'Open help with {shortcut}',
     shortcutFallback: 'H',
   },
+  hudMenu: {
+    label: 'Portfolio HUD menu',
+    controlsLabel: 'Controls',
+    controlsTitleTemplate: 'Show controls. Press {shortcut}.',
+    controlsKeyHint: 'C',
+    textLabel: 'Text',
+    textTitleTemplate: 'Switch to text mode. Press {shortcut}.',
+    textKeyHint: 'T',
+    settingsLabel: 'Settings',
+    settingsTitleTemplate: 'Open settings and help. Press {shortcut}.',
+    settingsKeyHint: 'H',
+  },
   mobileToggle: {
     expandLabel: 'Show all controls',
     collapseLabel: 'Close controls',
@@ -315,10 +327,10 @@ describe('createResponsiveControlOverlay', () => {
     const styles = readFileSync('src/ui/styles.css', 'utf8');
 
     expect(styles).toContain(
-      ":root[data-accessibility-motion='reduced'] .overlay__controls-button"
+      ":root[data-accessibility-motion='reduced'] .overlay__menu-button"
     );
     expect(styles).toContain(
-      ":root[data-accessibility-motion='reduced'] .overlay__help-button"
+      ":root[data-accessibility-motion='reduced'] .overlay__menu"
     );
     expect(styles).toContain(
       ":root[data-accessibility-motion='reduced'] .overlay__popover"

--- a/src/ui/hud/hudPanelCoordinator.ts
+++ b/src/ui/hud/hudPanelCoordinator.ts
@@ -1,0 +1,148 @@
+export type HudPanel = 'controls' | 'settings';
+
+export interface HudPanelCoordinatorHandle {
+  getActivePanel(): HudPanel | null;
+  openControls(): void;
+  closeControls(): void;
+  toggleControls(): void;
+  openSettings(): void;
+  closeSettings(): void;
+  toggleSettings(force?: boolean): void;
+  activateText(): void;
+  noteControlsOpen(): void;
+  noteControlsClosed(): void;
+  noteSettingsOpen(): void;
+  noteSettingsClosed(): void;
+  closeActivePanel(): boolean;
+}
+
+export interface HudPanelCoordinatorOptions {
+  controls: {
+    open(): void;
+    close(): void;
+    isOpen(): boolean;
+  };
+  settings: {
+    open(): void;
+    close(): void;
+    toggle(force?: boolean): void;
+    isOpen(): boolean;
+  };
+  onTextAction(): void;
+}
+
+export function createHudPanelCoordinator({
+  controls,
+  settings,
+  onTextAction,
+}: HudPanelCoordinatorOptions): HudPanelCoordinatorHandle {
+  let activePanel: HudPanel | null = null;
+
+  const refreshActivePanel = () => {
+    if (settings.isOpen()) {
+      activePanel = 'settings';
+      return activePanel;
+    }
+    if (controls.isOpen()) {
+      activePanel = 'controls';
+      return activePanel;
+    }
+    activePanel = null;
+    return activePanel;
+  };
+
+  const closeControls = () => {
+    controls.close();
+    if (activePanel === 'controls' && !controls.isOpen()) {
+      activePanel = null;
+    }
+  };
+
+  const closeSettings = () => {
+    settings.close();
+    if (activePanel === 'settings' && !settings.isOpen()) {
+      activePanel = null;
+    }
+  };
+
+  const openControls = () => {
+    if (settings.isOpen()) {
+      settings.close();
+    }
+    controls.open();
+    activePanel = controls.isOpen() ? 'controls' : null;
+  };
+
+  const openSettings = () => {
+    if (controls.isOpen()) {
+      controls.close();
+    }
+    settings.open();
+    activePanel = settings.isOpen() ? 'settings' : null;
+  };
+
+  return {
+    getActivePanel() {
+      return refreshActivePanel();
+    },
+    openControls,
+    closeControls,
+    toggleControls() {
+      if (controls.isOpen()) {
+        closeControls();
+        return;
+      }
+      openControls();
+    },
+    openSettings,
+    closeSettings,
+    toggleSettings(force?: boolean) {
+      const targetOpen = force ?? !settings.isOpen();
+      if (targetOpen) {
+        openSettings();
+        return;
+      }
+      closeSettings();
+    },
+    activateText() {
+      closeControls();
+      closeSettings();
+      activePanel = null;
+      onTextAction();
+    },
+    noteControlsOpen() {
+      if (settings.isOpen()) {
+        settings.close();
+      }
+      activePanel = controls.isOpen() ? 'controls' : null;
+    },
+    noteControlsClosed() {
+      if (activePanel === 'controls') {
+        activePanel = settings.isOpen() ? 'settings' : null;
+      }
+    },
+    noteSettingsOpen() {
+      if (controls.isOpen()) {
+        controls.close();
+      }
+      activePanel = settings.isOpen() ? 'settings' : null;
+    },
+    noteSettingsClosed() {
+      if (activePanel === 'settings') {
+        activePanel = controls.isOpen() ? 'controls' : null;
+      }
+    },
+    closeActivePanel() {
+      const panel = refreshActivePanel();
+      if (panel === 'controls') {
+        closeControls();
+        return true;
+      }
+      if (panel === 'settings') {
+        closeSettings();
+        return true;
+      }
+      return false;
+    },
+  };
+}

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -23,6 +23,8 @@ export interface ResponsiveControlOverlayOptions {
   strings: ControlOverlayStrings;
   initialLayout?: HudLayout;
   documentTarget?: Document;
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
@@ -136,6 +138,8 @@ export function createResponsiveControlOverlay(
     strings,
     initialLayout = 'desktop',
     documentTarget = typeof document !== 'undefined' ? document : undefined,
+    onOpen,
+    onClose,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
@@ -184,7 +188,14 @@ export function createResponsiveControlOverlay(
     if (ownsContainerLabel) {
       container.setAttribute('aria-label', currentStrings.heading);
     }
-    button.textContent = currentStrings.heading;
+    const labelTarget = button.querySelector<HTMLElement>(
+      '[data-role="controls-button-label"]'
+    );
+    if (labelTarget) {
+      labelTarget.textContent = currentStrings.heading;
+    } else {
+      button.textContent = currentStrings.heading;
+    }
     button.setAttribute('aria-label', currentStrings.heading);
     if (closeButton instanceof HTMLButtonElement) {
       closeButton.setAttribute(
@@ -221,6 +232,7 @@ export function createResponsiveControlOverlay(
     }
     open = false;
     update();
+    onClose?.();
   };
 
   const openPopover = () => {
@@ -230,6 +242,7 @@ export function createResponsiveControlOverlay(
     }
     open = true;
     update();
+    onOpen?.();
   };
 
   const togglePopover = () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1321,8 +1321,20 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   transition: opacity 160ms ease;
 }
 
-.overlay__controls-button,
-.overlay__help-button {
+.overlay__menu {
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border: 1px solid rgba(123, 209, 255, 0.32);
+  border-radius: 999px;
+  background: rgba(5, 12, 22, 0.58);
+  box-shadow: var(--hud-surface-shadow);
+  backdrop-filter: blur(14px);
+}
+
+.overlay__menu-button {
   width: auto;
   min-height: 2.45rem;
   padding: 0.65rem 0.9rem;
@@ -1344,19 +1356,47 @@ html[data-hud-layout='mobile'] .audio-subtitles {
     transform 120ms ease;
 }
 
-.overlay__controls-button:hover,
-.overlay__controls-button:focus-visible,
-.overlay__help-button:hover,
-.overlay__help-button:focus-visible {
+.overlay__menu-button:hover,
+.overlay__menu-button:focus-visible {
   border-color: rgba(158, 232, 255, 0.8);
   box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
   outline: none;
   transform: translateY(-1px);
 }
 
-.overlay__controls-button:active,
-.overlay__help-button:active {
+.overlay__menu-button:active {
   transform: translateY(0);
+}
+
+.overlay__menu-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+}
+
+.overlay__menu-button[aria-expanded='true'],
+.overlay__menu-button[aria-pressed='true'] {
+  border-color: rgba(158, 232, 255, 0.88);
+  background:
+    linear-gradient(140deg, rgba(18, 56, 86, 0.96), rgba(19, 72, 106, 0.84)),
+    rgba(9, 30, 46, 0.92);
+}
+
+.overlay__menu-label {
+  white-space: nowrap;
+}
+
+.overlay__key-hint {
+  min-width: 1.35rem;
+  padding: 0.1rem 0.35rem;
+  border: 1px solid rgba(158, 232, 255, 0.36);
+  border-radius: 999px;
+  background: rgba(203, 239, 255, 0.1);
+  color: var(--hud-surface-accent);
+  font-size: 0.72rem;
+  line-height: 1.2;
+  text-align: center;
 }
 
 .overlay__popover {
@@ -1461,6 +1501,21 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   line-height: 1.5;
 }
 
+:root[data-hud-layout='mobile'] .overlay__menu {
+  gap: 0.2rem;
+}
+
+:root[data-hud-layout='mobile'] .overlay__menu-button {
+  min-height: 2.6rem;
+  padding: 0.55rem 0.62rem;
+  font-size: 0.78rem;
+}
+
+:root[data-hud-layout='mobile'] .overlay__key-hint {
+  min-width: 1.15rem;
+  padding-inline: 0.25rem;
+}
+
 :root[data-hud-layout='mobile'] .overlay__popover {
   width: min(20rem, calc(100vw - 1.5rem));
   max-height: min(26rem, calc(100vh - 7rem - env(safe-area-inset-top, 0px)));
@@ -1484,8 +1539,8 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .mode-toggle,
 :root[data-accessibility-motion='reduced'] .overlay,
 :root[data-accessibility-motion='reduced'] .overlay::after,
-:root[data-accessibility-motion='reduced'] .overlay__controls-button,
-:root[data-accessibility-motion='reduced'] .overlay__help-button,
+:root[data-accessibility-motion='reduced'] .overlay__menu,
+:root[data-accessibility-motion='reduced'] .overlay__menu-button,
 :root[data-accessibility-motion='reduced'] .overlay__popover,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close,
 :root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
@@ -1494,16 +1549,12 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   animation: none !important;
 }
 
-:root[data-accessibility-motion='reduced'] .overlay__controls-button:hover,
-:root[data-accessibility-motion='reduced']
-  .overlay__controls-button:focus-visible,
-:root[data-accessibility-motion='reduced'] .overlay__help-button:hover,
-:root[data-accessibility-motion='reduced'] .overlay__help-button:focus-visible,
+:root[data-accessibility-motion='reduced'] .overlay__menu-button:hover,
+:root[data-accessibility-motion='reduced'] .overlay__menu-button:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close:hover,
 :root[data-accessibility-motion='reduced']
   .overlay__popover-close:focus-visible,
-:root[data-accessibility-motion='reduced'] .overlay__controls-button:active,
-:root[data-accessibility-motion='reduced'] .overlay__help-button:active {
+:root[data-accessibility-motion='reduced'] .overlay__menu-button:active {
   transform: none;
 }
 


### PR DESCRIPTION
### Motivation
- Provide a single, compact top-right HUD that exposes Controls, Text mode, and Settings so users can discover all HUD actions in one stable place without changing existing behavior.
- Ensure Controls and Settings are mutually exclusive and that triggering Text closes any open HUD panels and reuses the existing manual text-mode activation path.

### Description
- Add a compact HUD strip in the top-right with three actions (Controls C, Text T, Settings H) and accessible labels/key hints in `index.html` and `src/ui/styles.css`.
- Introduce a small `HudPanelCoordinator` (`src/ui/hud/hudPanelCoordinator.ts`) that enforces mutual exclusion, closes active panels on Escape, and routes the Text action to the existing manual text-mode activation path.
- Wire the coordinator into `src/main.ts`, update keydown handlers to call `toggleControls`, `activateText`, and `closeActivePanel`, and reuse `activateTextMode()` for both HUD Text and `ManualModeToggle` activation.
- Add HUD menu i18n strings and update `src/assets/i18n/*` and types; extend `createResponsiveControlOverlay` to accept `onOpen`/`onClose` callbacks and to update the controls-button label markup.
- Add unit tests for the coordinator behavior in `src/tests/hudPanelCoordinator.test.ts` and update responsive overlay tests to match the new markup.

### Testing
- Ran formatting: `npm run format:write` — succeeded.
- Lint: `npm run lint` — succeeded after minor import reorder fix.
- Unit test suite: `npm run test:ci` — succeeded (selected earlier runs showed full test pass: 899 tests / 899 passed in CI run for the baseline and focused suites passed locally for modified tests).
- Build: `npm run build` — succeeded and produced `dist/` artifacts.
- Docs check and smoke: `npm run docs:check` and `npm run smoke` — both succeeded (smoke ran the build and `scripts/assert-dist.cjs`).
- Typecheck: `npm run typecheck` — did not pass due to pre-existing repository-wide TypeScript issues unrelated to this HUD change (reported and left unchanged).
- Playwright screenshot attempt: `npx playwright screenshot 'http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1' docs/assets/unified-hud-menu.png` — failed in this environment because Playwright browsers are not installed; the preview served correctly.
- Secret scan for staged changes: `git diff --cached | ./scripts/scan-secrets.py` — passed.

Notes: The change is intentionally minimal and reuses existing text-mode logic (`manualModeToggle` onToggle) via `activateTextMode()` in `main.ts`; follow-ups may include visual polish and an optional Playwright visual spec after CI browser installation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf11a8390832fa10cb28f7e6cddd3)