### PR TITLE
Unify top-right HUD: Controls, Text, and Settings into one menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,21 @@
         transition: opacity 160ms ease;
       }
 
+      .overlay__menu {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.35rem;
+        padding: 0.25rem;
+        border: 1px solid rgba(123, 209, 255, 0.28);
+        border-radius: 999px;
+        background: rgba(8, 18, 30, 0.52);
+        box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+      }
+
+      .overlay__menu-button,
       .overlay__controls-button,
+      .overlay__text-button,
       .overlay__help-button {
         width: auto;
         min-height: 2.45rem;
@@ -102,8 +116,12 @@
           transform 120ms ease;
       }
 
+      .overlay__menu-button:hover,
+      .overlay__menu-button:focus-visible,
       .overlay__controls-button:hover,
       .overlay__controls-button:focus-visible,
+      .overlay__text-button:hover,
+      .overlay__text-button:focus-visible,
       .overlay__help-button:hover,
       .overlay__help-button:focus-visible {
         border-color: rgba(158, 232, 255, 0.8);
@@ -112,9 +130,46 @@
         transform: translateY(-1px);
       }
 
+      .overlay__menu-button:active,
       .overlay__controls-button:active,
+      .overlay__text-button:active,
       .overlay__help-button:active {
         transform: translateY(0);
+      }
+
+      .overlay__menu-button::after {
+        content: attr(data-key-hint);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 1.25rem;
+        min-height: 1.25rem;
+        margin-left: 0.45rem;
+        padding: 0 0.28rem;
+        border-radius: 0.38rem;
+        border: 1px solid rgba(158, 232, 255, 0.36);
+        background: rgba(3, 9, 18, 0.38);
+        color: var(--hud-surface-accent);
+        font-size: 0.72rem;
+        line-height: 1;
+      }
+
+      :root[data-hud-layout='mobile'] .overlay__menu {
+        gap: 0.25rem;
+        max-width: calc(100vw - 1.5rem);
+      }
+
+      :root[data-hud-layout='mobile'] .overlay__menu-button {
+        min-height: 2.6rem;
+        padding: 0.55rem 0.62rem;
+        font-size: 0.78rem;
+      }
+
+      :root[data-hud-layout='mobile'] .overlay__menu-button::after {
+        min-width: 1.1rem;
+        min-height: 1.1rem;
+        margin-left: 0.28rem;
+        font-size: 0.68rem;
       }
 
       .overlay__popover {
@@ -446,14 +501,38 @@
     </noscript>
     <div id="app"></div>
     <div class="overlay" id="control-overlay" aria-label="Controls">
-      <button
-        class="overlay__controls-button"
-        type="button"
-        data-role="controls-button"
-        aria-expanded="false"
-      >
-        Controls
-      </button>
+      <div class="overlay__menu" data-role="hud-menu" aria-label="HUD menu">
+        <button
+          class="overlay__menu-button overlay__controls-button"
+          type="button"
+          data-role="controls-button"
+          data-key-hint="C"
+          aria-expanded="false"
+          title="Controls (C)"
+        >
+          Controls
+        </button>
+        <button
+          class="overlay__menu-button overlay__text-button"
+          type="button"
+          data-role="text-mode-button"
+          data-key-hint="T"
+          aria-pressed="false"
+          title="Switch to text mode (T)"
+        >
+          Text
+        </button>
+        <button
+          class="overlay__menu-button overlay__help-button"
+          type="button"
+          data-control="help"
+          data-key-hint="H"
+          data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
+          title="Settings and help (H)"
+        >
+          Settings
+        </button>
+      </div>
       <div class="overlay__popover" data-role="controls-popover" hidden>
         <div class="overlay__popover-header">
           <p class="overlay__heading" data-control-text="heading">Controls</p>
@@ -544,14 +623,6 @@
           </li>
         </ul>
       </div>
-      <button
-        class="overlay__help-button"
-        type="button"
-        data-control="help"
-        data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
-      >
-        Open menu · Press H
-      </button>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -138,6 +138,14 @@ export const AR_OVERRIDES: LocaleOverrides = {
   hud: {
     controlOverlay: {
       heading: 'عناصر التحكم',
+      menu: {
+        controlsLabel: 'التحكم',
+        controlsTitleTemplate: 'عناصر التحكم ({keyHint})',
+        textLabel: 'النص',
+        textTitleTemplate: 'التبديل إلى العرض النصي ({keyHint})',
+        settingsLabel: 'الإعدادات',
+        settingsTitleTemplate: 'الإعدادات والمساعدة ({keyHint})',
+      },
       items: {
         keyboardMove: {
           keys: 'WASD / الأسهم',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -153,6 +153,14 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
   hud: {
     controlOverlay: {
       heading: wrap('Controls'),
+      menu: {
+        controlsLabel: wrap('Controls'),
+        controlsTitleTemplate: wrap('Controls ({keyHint})'),
+        textLabel: wrap('Text'),
+        textTitleTemplate: wrap('Switch to text mode ({keyHint})'),
+        settingsLabel: wrap('Settings'),
+        settingsTitleTemplate: wrap('Settings and help ({keyHint})'),
+      },
       interact: {
         defaultLabel: wrap('Enter'),
         description: wrap('Interact'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -143,6 +143,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
   hud: {
     controlOverlay: {
       heading: 'Controls',
+      menu: {
+        controlsLabel: 'Controls',
+        controlsTitleTemplate: 'Controls ({keyHint})',
+        textLabel: 'Text',
+        textTitleTemplate: 'Switch to text mode ({keyHint})',
+        settingsLabel: 'Settings',
+        settingsTitleTemplate: 'Settings and help ({keyHint})',
+      },
       items: {
         keyboardMove: {
           keys: 'WASD / Arrow keys',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -138,6 +138,14 @@ export const JA_OVERRIDES: LocaleOverrides = {
   hud: {
     controlOverlay: {
       heading: '操作',
+      menu: {
+        controlsLabel: '操作',
+        controlsTitleTemplate: '操作（{keyHint}）',
+        textLabel: 'テキスト',
+        textTitleTemplate: 'テキストモードに切り替え（{keyHint}）',
+        settingsLabel: '設定',
+        settingsTitleTemplate: '設定とヘルプ（{keyHint}）',
+      },
       items: {
         keyboardMove: {
           keys: 'WASD / 矢印キー',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -19,6 +19,14 @@ export interface ControlOverlayItemStrings {
 
 export interface ControlOverlayStrings {
   heading: string;
+  menu: {
+    controlsLabel: string;
+    controlsTitleTemplate: string;
+    textLabel: string;
+    textTitleTemplate: string;
+    settingsLabel: string;
+    settingsTitleTemplate: string;
+  };
   items: {
     keyboardMove: ControlOverlayItemStrings;
     pointerDrag: ControlOverlayItemStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -378,6 +378,7 @@ import {
   attachHelpModalController,
   type HelpModalControllerHandle,
 } from './ui/hud/helpModalController';
+import { createHudPanelCoordinator } from './ui/hud/hudPanelCoordinator';
 import {
   createHudLayoutManager,
   type HudLayoutManagerHandle,
@@ -2426,6 +2427,9 @@ function initializeImmersiveScene(
   const controlsButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-role="controls-button"]'
   );
+  const textModeButton = controlOverlay?.querySelector<HTMLButtonElement>(
+    '[data-role="text-mode-button"]'
+  );
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
@@ -2455,6 +2459,12 @@ function initializeImmersiveScene(
       focusOnInit: true,
     });
   }
+  let closeSettingsFromHudMenu = () => {
+    /* assigned after the help modal is created */
+  };
+  let hudPanelCoordinator: ReturnType<typeof createHudPanelCoordinator> | null =
+    null;
+
   responsiveControlOverlay = controlOverlay
     ? createResponsiveControlOverlay({
         container: controlOverlay,
@@ -2470,6 +2480,13 @@ function initializeImmersiveScene(
         ),
         strings: controlOverlayStrings,
         initialLayout: 'desktop',
+        onOpen: () => {
+          closeSettingsFromHudMenu();
+          hudPanelCoordinator?.sync();
+        },
+        onClose: () => {
+          hudPanelCoordinator?.sync();
+        },
       })
     : null;
   const helpModal = createHelpModal({
@@ -2578,19 +2595,49 @@ function initializeImmersiveScene(
     documentTarget: document,
     container: document.body,
   });
+  const activateTextMode = () => {
+    if (performanceFailover.hasTriggered()) {
+      clearModePreference();
+      window.location.assign(createImmersiveRecoveryUrl());
+      return;
+    }
+    if (shouldPersistTextPreferenceForFallback('manual')) {
+      writeModePreference('text');
+    }
+    performanceFailover.triggerFallback('manual');
+  };
+
+  closeSettingsFromHudMenu = () => {
+    helpModal.close();
+  };
+
+  hudPanelCoordinator = createHudPanelCoordinator({
+    isControlsOpen: () => responsiveControlOverlay?.isOpen() ?? false,
+    openControls: () => responsiveControlOverlay?.open(),
+    closeControls: () => responsiveControlOverlay?.close(),
+    isSettingsOpen: () => helpModal.isOpen(),
+    openSettings: () => helpModal.open(),
+    closeSettings: () => helpModal.close(),
+    activateTextMode,
+  });
+
   helpModalController = attachHelpModalController({
     helpModal,
     helpButton,
-    onOpen: showHudControlElements,
-    onClose: hideHudControlElements,
+    onOpen: () => {
+      responsiveControlOverlay?.close();
+      showHudControlElements();
+      hudPanelCoordinator?.sync();
+    },
+    onClose: () => {
+      hideHudControlElements();
+      hudPanelCoordinator?.sync();
+    },
     hudFocusAnnouncer,
     announcements: helpModalStrings.announcements,
   });
-  const openHelpMenu = () => {
-    helpModal.open();
-  };
   const toggleHelpMenu = (force?: boolean) => {
-    helpModal.toggle(force);
+    hudPanelCoordinator?.toggleSettings(force);
   };
   const isTextEntryTarget = (target: EventTarget | null): boolean => {
     if (!(target instanceof HTMLElement)) {
@@ -2633,6 +2680,12 @@ function initializeImmersiveScene(
     );
   };
   const handleControlsKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && !event.defaultPrevented) {
+      if (hudPanelCoordinator?.closeActivePanel()) {
+        event.preventDefault();
+      }
+      return;
+    }
     if (event.defaultPrevented || event.repeat) {
       return;
     }
@@ -2649,12 +2702,17 @@ function initializeImmersiveScene(
       return;
     }
     event.preventDefault();
-    responsiveControlOverlay?.toggle();
+    hudPanelCoordinator?.toggleControls();
   };
   window.addEventListener('keydown', handleControlsKeydown);
+  let textModeButtonClickHandler: (() => void) | null = null;
+  if (textModeButton) {
+    textModeButtonClickHandler = () => hudPanelCoordinator?.activateTextMode();
+    textModeButton.addEventListener('click', textModeButtonClickHandler);
+  }
   let helpButtonClickHandler: (() => void) | null = null;
   if (helpButton) {
-    helpButtonClickHandler = () => openHelpMenu();
+    helpButtonClickHandler = () => toggleHelpMenu();
     helpButton.addEventListener('click', helpButtonClickHandler);
   }
   let interactablePoi: PoiInstance | null = null;
@@ -2687,25 +2745,54 @@ function initializeImmersiveScene(
   let activeFloorId: FloorId = 'ground';
   let helpKeyWasPressed = false;
   let helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
-  const buildHelpButtonText = (shortcut: string) =>
-    formatMessage(controlOverlayStrings.helpButton.labelTemplate, {
-      shortcut,
-    });
+  const buildMenuTitle = (template: string, keyHint: string) =>
+    formatMessage(template, { keyHint });
   const buildHelpAnnouncement = (shortcut: string) =>
     formatMessage(controlOverlayStrings.helpButton.announcementTemplate, {
       shortcut,
     });
-  const updateHelpButtonLabel = () => {
+  const updateHudMenuLabels = () => {
+    const controlsLabel =
+      formatKeyLabel(keyBindings.getPrimaryBinding('toggleControls')) || 'C';
+    if (controlsButton) {
+      controlsButton.dataset.keyHint = controlsLabel;
+      controlsButton.title = buildMenuTitle(
+        controlOverlayStrings.menu.controlsTitleTemplate,
+        controlsLabel
+      );
+    }
+    const textLabel = modeToggleStrings.keyHint || 'T';
+    if (textModeButton) {
+      textModeButton.textContent = controlOverlayStrings.menu.textLabel;
+      textModeButton.dataset.keyHint = textLabel;
+      textModeButton.setAttribute(
+        'aria-label',
+        controlOverlayStrings.menu.textLabel
+      );
+      textModeButton.title = buildMenuTitle(
+        controlOverlayStrings.menu.textTitleTemplate,
+        textLabel
+      );
+    }
     if (!helpButton) {
       return;
     }
     const label =
       formatKeyLabel(keyBindings.getPrimaryBinding('help')) ||
       helpLabelFallback;
-    helpButton.textContent = buildHelpButtonText(label);
+    helpButton.textContent = controlOverlayStrings.menu.settingsLabel;
+    helpButton.dataset.keyHint = label;
+    helpButton.setAttribute(
+      'aria-label',
+      controlOverlayStrings.menu.settingsLabel
+    );
+    helpButton.title = buildMenuTitle(
+      controlOverlayStrings.menu.settingsTitleTemplate,
+      label
+    );
     helpButton.dataset.hudAnnounce = buildHelpAnnouncement(label);
   };
-  updateHelpButtonLabel();
+  updateHudMenuLabels();
 
   const applyLocaleUpdate = (nextLocale: Locale) => {
     if (locale === nextLocale) {
@@ -2760,7 +2847,7 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
-    updateHelpButtonLabel();
+    updateHudMenuLabels();
     localeToggleControl?.refresh();
 
     const visitedSnapshot = poiVisitedState.snapshot();
@@ -2804,7 +2891,7 @@ function initializeImmersiveScene(
         movementLegend.setKeyboardInteractLabel(label);
       }
       if (action === 'help') {
-        updateHelpButtonLabel();
+        updateHudMenuLabels();
       }
       saveKeyBindings();
     })
@@ -3215,17 +3302,7 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       strings: modeToggleStrings,
       getIsFallbackActive: () => performanceFailover.hasTriggered(),
-      onToggle: () => {
-        if (performanceFailover.hasTriggered()) {
-          clearModePreference();
-          window.location.assign(createImmersiveRecoveryUrl());
-          return;
-        }
-        if (shouldPersistTextPreferenceForFallback('manual')) {
-          writeModePreference('text');
-        }
-        performanceFailover.triggerFallback('manual');
-      },
+      onToggle: activateTextMode,
     });
     registerHudControlElement(manualModeToggle?.element ?? null);
 
@@ -4178,6 +4255,14 @@ function initializeImmersiveScene(
       hudLayoutManager = null;
     }
     window.removeEventListener('keydown', handleControlsKeydown);
+    if (textModeButton && textModeButtonClickHandler) {
+      textModeButton.removeEventListener('click', textModeButtonClickHandler);
+      textModeButtonClickHandler = null;
+    }
+    if (helpButton && helpButtonClickHandler) {
+      helpButton.removeEventListener('click', helpButtonClickHandler);
+      helpButtonClickHandler = null;
+    }
     if (responsiveControlOverlay) {
       responsiveControlOverlay.dispose();
       responsiveControlOverlay = null;
@@ -4256,7 +4341,7 @@ function initializeImmersiveScene(
       window.portfolio.performance = crashLogAccess;
     }
     if (helpButton) {
-      helpButton.textContent = buildHelpButtonText(helpLabelFallback);
+      helpButton.textContent = controlOverlayStrings.menu.settingsLabel;
       helpButton.dataset.hudAnnounce = buildHelpAnnouncement(helpLabelFallback);
     }
     if (localeToggleControl) {

--- a/src/tests/hudPanelCoordinator.test.ts
+++ b/src/tests/hudPanelCoordinator.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createHudPanelCoordinator } from '../ui/hud/hudPanelCoordinator';
+
+const createFixture = () => {
+  let controlsOpen = false;
+  let settingsOpen = false;
+  const calls: string[] = [];
+
+  const coordinator = createHudPanelCoordinator({
+    isControlsOpen: () => controlsOpen,
+    openControls: vi.fn(() => {
+      calls.push('openControls');
+      controlsOpen = true;
+    }),
+    closeControls: vi.fn(() => {
+      calls.push('closeControls');
+      controlsOpen = false;
+    }),
+    isSettingsOpen: () => settingsOpen,
+    openSettings: vi.fn(() => {
+      calls.push('openSettings');
+      settingsOpen = true;
+    }),
+    closeSettings: vi.fn(() => {
+      calls.push('closeSettings');
+      settingsOpen = false;
+    }),
+    activateTextMode: vi.fn(() => {
+      calls.push('activateTextMode');
+    }),
+  });
+
+  return {
+    coordinator,
+    calls,
+    get controlsOpen() {
+      return controlsOpen;
+    },
+    get settingsOpen() {
+      return settingsOpen;
+    },
+  };
+};
+
+describe('createHudPanelCoordinator', () => {
+  it('closes Controls before opening Settings', () => {
+    const fixture = createFixture();
+
+    fixture.coordinator.openControls();
+    fixture.coordinator.openSettings();
+
+    expect(fixture.controlsOpen).toBe(false);
+    expect(fixture.settingsOpen).toBe(true);
+    expect(fixture.coordinator.getActivePanel()).toBe('settings');
+    expect(fixture.calls).toEqual([
+      'openControls',
+      'closeControls',
+      'openSettings',
+    ]);
+  });
+
+  it('closes Settings before opening Controls', () => {
+    const fixture = createFixture();
+
+    fixture.coordinator.openSettings();
+    fixture.coordinator.openControls();
+
+    expect(fixture.controlsOpen).toBe(true);
+    expect(fixture.settingsOpen).toBe(false);
+    expect(fixture.coordinator.getActivePanel()).toBe('controls');
+    expect(fixture.calls).toEqual([
+      'openSettings',
+      'closeSettings',
+      'openControls',
+    ]);
+  });
+
+  it('closes panels before activating text mode', () => {
+    const fixture = createFixture();
+
+    fixture.coordinator.openControls();
+    fixture.coordinator.activateTextMode();
+
+    expect(fixture.controlsOpen).toBe(false);
+    expect(fixture.settingsOpen).toBe(false);
+    expect(fixture.coordinator.getActivePanel()).toBeNull();
+    expect(fixture.calls).toEqual([
+      'openControls',
+      'closeControls',
+      'activateTextMode',
+    ]);
+  });
+});

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -8,6 +8,14 @@ import { createResponsiveControlOverlay } from '../ui/hud/responsiveControlOverl
 
 const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
   heading,
+  menu: {
+    controlsLabel: heading,
+    controlsTitleTemplate: 'Controls ({keyHint})',
+    textLabel: 'Text',
+    textTitleTemplate: 'Switch to text mode ({keyHint})',
+    settingsLabel: 'Settings',
+    settingsTitleTemplate: 'Settings and help ({keyHint})',
+  },
   items: {
     keyboardMove: { keys: 'WASD / Arrow keys', description: 'Move' },
     pointerDrag: { keys: 'Left mouse button', description: 'Drag to pan' },

--- a/src/ui/hud/hudPanelCoordinator.ts
+++ b/src/ui/hud/hudPanelCoordinator.ts
@@ -1,0 +1,124 @@
+export type HudPanel = 'controls' | 'settings';
+
+export interface HudPanelCoordinatorOptions {
+  isControlsOpen: () => boolean;
+  openControls: () => void;
+  closeControls: () => void;
+  isSettingsOpen: () => boolean;
+  openSettings: () => void;
+  closeSettings: () => void;
+  activateTextMode: () => void;
+}
+
+export interface HudPanelCoordinatorHandle {
+  getActivePanel(): HudPanel | null;
+  openControls(): void;
+  toggleControls(): void;
+  openSettings(): void;
+  toggleSettings(force?: boolean): void;
+  activateTextMode(): void;
+  closeActivePanel(): boolean;
+  sync(): HudPanel | null;
+}
+
+export function createHudPanelCoordinator({
+  isControlsOpen,
+  openControls,
+  closeControls,
+  isSettingsOpen,
+  openSettings,
+  closeSettings,
+  activateTextMode,
+}: HudPanelCoordinatorOptions): HudPanelCoordinatorHandle {
+  let activePanel: HudPanel | null = null;
+
+  const sync = () => {
+    if (isControlsOpen()) {
+      activePanel = 'controls';
+      return activePanel;
+    }
+    if (isSettingsOpen()) {
+      activePanel = 'settings';
+      return activePanel;
+    }
+    activePanel = null;
+    return activePanel;
+  };
+
+  const closeControlsPanel = () => {
+    if (isControlsOpen()) {
+      closeControls();
+    }
+  };
+
+  const closeSettingsPanel = () => {
+    if (isSettingsOpen()) {
+      closeSettings();
+    }
+  };
+
+  const showControls = () => {
+    closeSettingsPanel();
+    openControls();
+    activePanel = 'controls';
+    sync();
+  };
+
+  const showSettings = () => {
+    closeControlsPanel();
+    openSettings();
+    activePanel = 'settings';
+    sync();
+  };
+
+  return {
+    getActivePanel() {
+      return sync();
+    },
+    openControls: showControls,
+    toggleControls() {
+      if (isControlsOpen()) {
+        closeControls();
+        activePanel = null;
+        sync();
+        return;
+      }
+      showControls();
+    },
+    openSettings: showSettings,
+    toggleSettings(force?: boolean) {
+      const shouldOpen = force ?? !isSettingsOpen();
+      if (shouldOpen) {
+        showSettings();
+        return;
+      }
+      closeSettingsPanel();
+      activePanel = null;
+      sync();
+    },
+    activateTextMode() {
+      closeControlsPanel();
+      closeSettingsPanel();
+      activePanel = null;
+      activateTextMode();
+      sync();
+    },
+    closeActivePanel() {
+      sync();
+      if (activePanel === 'controls') {
+        closeControlsPanel();
+        activePanel = null;
+        sync();
+        return true;
+      }
+      if (activePanel === 'settings') {
+        closeSettingsPanel();
+        activePanel = null;
+        sync();
+        return true;
+      }
+      return false;
+    },
+    sync,
+  };
+}

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -23,6 +23,8 @@ export interface ResponsiveControlOverlayOptions {
   strings: ControlOverlayStrings;
   initialLayout?: HudLayout;
   documentTarget?: Document;
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
@@ -136,6 +138,8 @@ export function createResponsiveControlOverlay(
     strings,
     initialLayout = 'desktop',
     documentTarget = typeof document !== 'undefined' ? document : undefined,
+    onOpen,
+    onClose,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
@@ -184,8 +188,8 @@ export function createResponsiveControlOverlay(
     if (ownsContainerLabel) {
       container.setAttribute('aria-label', currentStrings.heading);
     }
-    button.textContent = currentStrings.heading;
-    button.setAttribute('aria-label', currentStrings.heading);
+    button.textContent = currentStrings.menu.controlsLabel;
+    button.setAttribute('aria-label', currentStrings.menu.controlsLabel);
     if (closeButton instanceof HTMLButtonElement) {
       closeButton.setAttribute(
         'aria-label',
@@ -221,6 +225,7 @@ export function createResponsiveControlOverlay(
     }
     open = false;
     update();
+    onClose?.();
   };
 
   const openPopover = () => {
@@ -230,6 +235,7 @@ export function createResponsiveControlOverlay(
     }
     open = true;
     update();
+    onOpen?.();
   };
 
   const togglePopover = () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1321,7 +1321,22 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   transition: opacity 160ms ease;
 }
 
+.overlay__menu {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border: 1px solid rgba(123, 209, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(8, 18, 30, 0.52);
+  box-shadow: var(--hud-surface-shadow);
+  backdrop-filter: blur(12px);
+}
+
+.overlay__menu-button,
 .overlay__controls-button,
+.overlay__text-button,
 .overlay__help-button {
   width: auto;
   min-height: 2.45rem;
@@ -1344,8 +1359,12 @@ html[data-hud-layout='mobile'] .audio-subtitles {
     transform 120ms ease;
 }
 
+.overlay__menu-button:hover,
+.overlay__menu-button:focus-visible,
 .overlay__controls-button:hover,
 .overlay__controls-button:focus-visible,
+.overlay__text-button:hover,
+.overlay__text-button:focus-visible,
 .overlay__help-button:hover,
 .overlay__help-button:focus-visible {
   border-color: rgba(158, 232, 255, 0.8);
@@ -1354,9 +1373,46 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   transform: translateY(-1px);
 }
 
+.overlay__menu-button:active,
 .overlay__controls-button:active,
+.overlay__text-button:active,
 .overlay__help-button:active {
   transform: translateY(0);
+}
+
+.overlay__menu-button::after {
+  content: attr(data-key-hint);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
+  margin-left: 0.45rem;
+  padding: 0 0.28rem;
+  border-radius: 0.38rem;
+  border: 1px solid rgba(158, 232, 255, 0.36);
+  background: rgba(3, 9, 18, 0.38);
+  color: var(--hud-surface-accent);
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
+:root[data-hud-layout='mobile'] .overlay__menu {
+  gap: 0.25rem;
+  max-width: calc(100vw - 1.5rem);
+}
+
+:root[data-hud-layout='mobile'] .overlay__menu-button {
+  min-height: 2.6rem;
+  padding: 0.55rem 0.62rem;
+  font-size: 0.78rem;
+}
+
+:root[data-hud-layout='mobile'] .overlay__menu-button::after {
+  min-width: 1.1rem;
+  min-height: 1.1rem;
+  margin-left: 0.28rem;
+  font-size: 0.68rem;
 }
 
 .overlay__popover {


### PR DESCRIPTION
### Motivation
- Provide a single compact, discoverable top-right HUD that surfaces Controls, Text mode, and Settings/help so users can find all HUD actions in one place.
- Ensure Controls and Settings are mutually exclusive and that text-mode activation reuses the existing manual toggle path to avoid duplicating logic.

### Description
- Add a new HUD menu strip in `index.html` with three buttons (Controls `C`, Text `T`, Settings `H`) and visible key-hint badges, and add responsive styling in `src/ui/styles.css` so the strip stays compact and tap-friendly across layouts.
- Introduce a lightweight `HudPanelCoordinator` (`src/ui/hud/hudPanelCoordinator.ts`) that centralizes panel state, enforces mutual exclusion between Controls and Settings, closes active panels on `Escape`, and runs the shared text-mode activation path.
- Wire the coordinator in `src/main.ts`, expose `onOpen`/`onClose` hooks on `createResponsiveControlOverlay`, and reuse `createManualModeToggle`’s behavior for the HUD Text action by calling the same activation routine.
- Extend i18n types and locale overrides to add `controlOverlay.menu` labels/templates and update tests and overlay code to use the new shared menu strings.
- Add unit tests `src/tests/hudPanelCoordinator.test.ts` and adjust `responsiveControlOverlay` tests to cover label refresh behavior.

### Testing
- Ran formatting with `npm run format:write` and fixed whitespace/style changes (passed).
- Ran lint with `npm run lint` after fixes and resolved a single unused variable; lint passed.
- Ran type check with `npm run typecheck` (noted existing baseline TypeScript issues unrelated to this change; typecheck reported pre-existing errors in the repo and was not used as a gating failure for this PR).
- Ran unit tests with `npm run test:ci` and verified the new coordinator tests plus existing HUD tests passed (`src/tests/hudPanelCoordinator.test.ts` and updated overlay tests included); test suite passed.
- Built and smoke-checked artifacts with `npm run build` and `npm run smoke` and validated the production build artifacts; build and smoke passed.
- Ran `npm run docs:check` and `git diff --cached | ./scripts/scan-secrets.py`; docs check and secret scan passed.
- Attempted a local Playwright screenshot against `vite preview`, but Playwright browser binaries were not installed in the environment so the headless capture could not run (install with `npx playwright install` to enable screenshot verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf11a8390832fa10cb28f7e6cddd3)