### PR TITLE
Unify Controls, Text, and Settings HUD menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,13 +76,14 @@
         transition: opacity 160ms ease;
       }
 
-      .overlay__controls-button,
-      .overlay__help-button {
-        width: auto;
-        min-height: 2.45rem;
-        padding: 0.65rem 0.9rem;
-        border-radius: 999px;
+      .overlay__menu {
+        display: flex;
+        align-items: stretch;
+        justify-content: flex-end;
+        gap: 0.25rem;
+        padding: 0.25rem;
         border: 1px solid rgba(123, 209, 255, 0.4);
+        border-radius: 999px;
         background:
           linear-gradient(
             140deg,
@@ -90,8 +91,20 @@
             rgba(16, 43, 70, 0.78)
           ),
           rgba(9, 18, 28, 0.88);
-        color: #e7f4ff;
         box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
+      }
+
+      .overlay__menu-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        width: auto;
+        min-height: 2.45rem;
+        padding: 0.55rem 0.72rem;
+        border-radius: 999px;
+        border: 0;
+        background: transparent;
+        color: #e7f4ff;
         font-size: 0.86rem;
         font-weight: 600;
         letter-spacing: 0.02em;
@@ -102,19 +115,31 @@
           transform 120ms ease;
       }
 
-      .overlay__controls-button:hover,
-      .overlay__controls-button:focus-visible,
-      .overlay__help-button:hover,
-      .overlay__help-button:focus-visible {
-        border-color: rgba(158, 232, 255, 0.8);
-        box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
+      .overlay__menu-button:hover,
+      .overlay__menu-button:focus-visible {
+        background: rgba(80, 164, 255, 0.18);
         outline: none;
         transform: translateY(-1px);
       }
 
-      .overlay__controls-button:active,
-      .overlay__help-button:active {
+      .overlay__menu-button:active {
         transform: translateY(0);
+      }
+
+      .overlay__menu-button[aria-pressed='true'] {
+        background: rgba(80, 164, 255, 0.24);
+      }
+
+      .overlay__menu-key {
+        min-width: 1.35rem;
+        padding: 0.1rem 0.32rem;
+        border-radius: 999px;
+        background: rgba(196, 232, 255, 0.14);
+        color: rgba(228, 244, 255, 0.92);
+        font: inherit;
+        font-size: 0.74rem;
+        font-weight: 700;
+        text-align: center;
       }
 
       .overlay__popover {
@@ -207,6 +232,18 @@
         max-width: min(20rem, calc(100vw - 1.5rem));
         font-size: 0.85rem;
         line-height: 1.5;
+      }
+
+      html[data-hud-layout='mobile'] .overlay__menu-button {
+        gap: 0.25rem;
+        min-height: 2.35rem;
+        padding: 0.45rem 0.5rem;
+        font-size: 0.78rem;
+      }
+
+      html[data-hud-layout='mobile'] .overlay__menu-key {
+        min-width: 1.1rem;
+        padding-inline: 0.24rem;
       }
 
       html[data-hud-layout='mobile'] .overlay__popover {
@@ -445,15 +482,39 @@
       </section>
     </noscript>
     <div id="app"></div>
-    <div class="overlay" id="control-overlay" aria-label="Controls">
-      <button
-        class="overlay__controls-button"
-        type="button"
-        data-role="controls-button"
-        aria-expanded="false"
-      >
-        Controls
-      </button>
+    <div class="overlay" id="control-overlay" aria-label="HUD menu">
+      <div class="overlay__menu" data-role="hud-menu" aria-label="HUD menu">
+        <button
+          class="overlay__menu-button"
+          type="button"
+          data-role="controls-button"
+          aria-expanded="false"
+          aria-pressed="false"
+        >
+          <span data-hud-menu-label="controls">Controls</span>
+          <kbd class="overlay__menu-key" data-hud-menu-key="controls">C</kbd>
+        </button>
+        <button
+          class="overlay__menu-button"
+          type="button"
+          data-role="text-mode-button"
+        >
+          <span data-hud-menu-label="text">Text</span>
+          <kbd class="overlay__menu-key" data-hud-menu-key="text">T</kbd>
+        </button>
+        <button
+          class="overlay__menu-button"
+          type="button"
+          data-control="help"
+          data-role="settings-button"
+          aria-expanded="false"
+          aria-pressed="false"
+          data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
+        >
+          <span data-hud-menu-label="settings">Settings</span>
+          <kbd class="overlay__menu-key" data-hud-menu-key="settings">H</kbd>
+        </button>
+      </div>
       <div class="overlay__popover" data-role="controls-popover" hidden>
         <div class="overlay__popover-header">
           <p class="overlay__heading" data-control-text="heading">Controls</p>
@@ -544,14 +605,6 @@
           </li>
         </ul>
       </div>
-      <button
-        class="overlay__help-button"
-        type="button"
-        data-control="help"
-        data-hud-announce="Open settings and help. Press H to review controls and accessibility tips."
-      >
-        Open menu · Press H
-      </button>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -178,6 +178,23 @@ export const AR_OVERRIDES: LocaleOverrides = {
           'افتح الإعدادات والمساعدة. اضغط {shortcut} لمراجعة الاختصارات والنصائح.',
         shortcutFallback: 'H',
       },
+      menu: {
+        controls: {
+          label: 'التحكم',
+          keyHint: 'C',
+          title: 'فتح عناصر التحكم (C)',
+        },
+        text: {
+          label: 'النص',
+          keyHint: 'T',
+          title: 'التحويل إلى العرض النصي (T)',
+        },
+        settings: {
+          label: 'الإعدادات',
+          keyHint: 'H',
+          title: 'فتح الإعدادات والمساعدة (H)',
+        },
+      },
       mobileToggle: {
         expandLabel: 'إظهار كل عناصر التحكم',
         collapseLabel: 'إخفاء عناصر التحكم الإضافية',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -169,6 +169,23 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         ),
         shortcutFallback: wrap('H'),
       },
+      menu: {
+        controls: {
+          label: wrap('Controls'),
+          keyHint: wrap('C'),
+          title: wrap('Open controls (C)'),
+        },
+        text: {
+          label: wrap('Text'),
+          keyHint: wrap('T'),
+          title: wrap('Switch to text mode (T)'),
+        },
+        settings: {
+          label: wrap('Settings'),
+          keyHint: wrap('H'),
+          title: wrap('Open settings and help (H)'),
+        },
+      },
       mobileToggle: {
         expandLabel: wrap('Show all controls'),
         collapseLabel: wrap('Hide extra controls'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -188,6 +188,23 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Open settings and help. Press {shortcut} to review controls and accessibility tips.',
         shortcutFallback: 'H',
       },
+      menu: {
+        controls: {
+          label: 'Controls',
+          keyHint: 'C',
+          title: 'Open controls (C)',
+        },
+        text: {
+          label: 'Text',
+          keyHint: 'T',
+          title: 'Switch to text mode (T)',
+        },
+        settings: {
+          label: 'Settings',
+          keyHint: 'H',
+          title: 'Open settings and help (H)',
+        },
+      },
       mobileToggle: {
         expandLabel: 'Show all controls',
         collapseLabel: 'Hide extra controls',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -178,6 +178,23 @@ export const JA_OVERRIDES: LocaleOverrides = {
           '設定とヘルプを開きます。ショートカット {shortcut} で操作方法とアクセシビリティのヒントを確認できます。',
         shortcutFallback: 'H',
       },
+      menu: {
+        controls: {
+          label: '操作',
+          keyHint: 'C',
+          title: '操作を開く (C)',
+        },
+        text: {
+          label: 'テキスト',
+          keyHint: 'T',
+          title: 'テキストモードに切り替え (T)',
+        },
+        settings: {
+          label: '設定',
+          keyHint: 'H',
+          title: '設定とヘルプを開く (H)',
+        },
+      },
       mobileToggle: {
         expandLabel: 'すべての操作を表示',
         collapseLabel: '追加の操作を隠す',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -17,6 +17,12 @@ export interface ControlOverlayItemStrings {
   description: string;
 }
 
+export interface ControlOverlayMenuItemStrings {
+  label: string;
+  keyHint: string;
+  title: string;
+}
+
 export interface ControlOverlayStrings {
   heading: string;
   items: {
@@ -37,6 +43,11 @@ export interface ControlOverlayStrings {
     labelTemplate: string;
     announcementTemplate: string;
     shortcutFallback: string;
+  };
+  menu: {
+    controls: ControlOverlayMenuItemStrings;
+    text: ControlOverlayMenuItemStrings;
+    settings: ControlOverlayMenuItemStrings;
   };
   mobileToggle: {
     expandLabel: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2481,6 +2481,18 @@ function initializeImmersiveScene(
         manageButtonClick: false,
       })
     : null;
+  const formatMenuButtonTitle = (
+    item: { keyHint: string; title: string },
+    shortcut: string
+  ): string =>
+    item.keyHint ? item.title.split(item.keyHint).join(shortcut) : item.title;
+  const updateControlsButtonLabel = () => {
+    const label =
+      formatKeyLabel(keyBindings.getPrimaryBinding('toggleControls')) ||
+      controlOverlayStrings.menu.controls.keyHint;
+    responsiveControlOverlay?.setControlsShortcutLabel(label);
+  };
+  updateControlsButtonLabel();
   const helpModal = createHelpModal({
     container: document.body,
     content: helpModalStrings,
@@ -2742,6 +2754,12 @@ function initializeImmersiveScene(
     if (settingsKey instanceof HTMLElement) {
       settingsKey.textContent = label;
     }
+    const title = formatMenuButtonTitle(
+      controlOverlayStrings.menu.settings,
+      label
+    );
+    helpButton.setAttribute('aria-label', title);
+    helpButton.title = title;
     helpButton.dataset.hudAnnounce = buildHelpAnnouncement(label);
   };
   updateHelpButtonLabel();
@@ -2785,6 +2803,7 @@ function initializeImmersiveScene(
     }
     analyticsGlow.setElement(controlOverlay ?? null);
     responsiveControlOverlay?.setStrings(controlOverlayStrings);
+    updateControlsButtonLabel();
     responsiveControlOverlay?.refresh();
     movementLegend?.setLocale(locale);
     if (movementLegend) {
@@ -2844,6 +2863,9 @@ function initializeImmersiveScene(
       }
       if (action === 'help') {
         updateHelpButtonLabel();
+      }
+      if (action === 'toggleControls') {
+        updateControlsButtonLabel();
       }
       saveKeyBindings();
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -2620,7 +2620,11 @@ function initializeImmersiveScene(
     performanceFailover.triggerFallback('manual');
   };
   const toggleHelpMenu = (force?: boolean) => {
-    hudPanelCoordinator?.toggleSettings(force) ?? helpModal.toggle(force);
+    if (hudPanelCoordinator) {
+      hudPanelCoordinator.toggleSettings(force);
+      return;
+    }
+    helpModal.toggle(force);
   };
   const isTextEntryTarget = (target: EventTarget | null): boolean => {
     if (!(target instanceof HTMLElement)) {
@@ -2679,7 +2683,11 @@ function initializeImmersiveScene(
       return;
     }
     event.preventDefault();
-    hudPanelCoordinator?.toggleControls() ?? responsiveControlOverlay?.toggle();
+    if (hudPanelCoordinator) {
+      hudPanelCoordinator.toggleControls();
+      return;
+    }
+    responsiveControlOverlay?.toggle();
   };
   window.addEventListener('keydown', handleControlsKeydown);
   hudPanelCoordinator = createHudPanelCoordinator({

--- a/src/main.ts
+++ b/src/main.ts
@@ -379,6 +379,10 @@ import {
   type HelpModalControllerHandle,
 } from './ui/hud/helpModalController';
 import {
+  createHudPanelCoordinator,
+  type HudPanelCoordinatorHandle,
+} from './ui/hud/hudPanelCoordinator';
+import {
   createHudLayoutManager,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
@@ -756,6 +760,7 @@ function initializeImmersiveScene(
   let tourResetControl: TourResetControlHandle | null = null;
   let hudLayoutManager: HudLayoutManagerHandle | null = null;
   let responsiveControlOverlay: ResponsiveControlOverlayHandle | null = null;
+  let hudPanelCoordinator: HudPanelCoordinatorHandle | null = null;
   let immersiveDisposed = false;
   let beforeUnloadHandler: (() => void) | null = null;
   let audioHudHandle: AudioHudControlHandle | null = null;
@@ -2429,6 +2434,9 @@ function initializeImmersiveScene(
   const helpButton = controlOverlay?.querySelector<HTMLButtonElement>(
     '[data-control="help"]'
   );
+  const textModeButton = controlOverlay?.querySelector<HTMLButtonElement>(
+    '[data-role="text-mode-button"]'
+  );
   let interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
   const interactDescriptionFallback =
     controlOverlayStrings.interact.description;
@@ -2470,6 +2478,7 @@ function initializeImmersiveScene(
         ),
         strings: controlOverlayStrings,
         initialLayout: 'desktop',
+        manageButtonClick: false,
       })
     : null;
   const helpModal = createHelpModal({
@@ -2586,11 +2595,20 @@ function initializeImmersiveScene(
     hudFocusAnnouncer,
     announcements: helpModalStrings.announcements,
   });
-  const openHelpMenu = () => {
-    helpModal.open();
+  const activateTextMode = () => {
+    hudPanelCoordinator?.closeAllPanels();
+    if (performanceFailover.hasTriggered()) {
+      clearModePreference();
+      window.location.assign(createImmersiveRecoveryUrl());
+      return;
+    }
+    if (shouldPersistTextPreferenceForFallback('manual')) {
+      writeModePreference('text');
+    }
+    performanceFailover.triggerFallback('manual');
   };
   const toggleHelpMenu = (force?: boolean) => {
-    helpModal.toggle(force);
+    hudPanelCoordinator?.toggleSettings(force) ?? helpModal.toggle(force);
   };
   const isTextEntryTarget = (target: EventTarget | null): boolean => {
     if (!(target instanceof HTMLElement)) {
@@ -2649,14 +2667,22 @@ function initializeImmersiveScene(
       return;
     }
     event.preventDefault();
-    responsiveControlOverlay?.toggle();
+    hudPanelCoordinator?.toggleControls() ?? responsiveControlOverlay?.toggle();
   };
   window.addEventListener('keydown', handleControlsKeydown);
-  let helpButtonClickHandler: (() => void) | null = null;
-  if (helpButton) {
-    helpButtonClickHandler = () => openHelpMenu();
-    helpButton.addEventListener('click', helpButtonClickHandler);
-  }
+  hudPanelCoordinator = createHudPanelCoordinator({
+    controls: responsiveControlOverlay ?? {
+      open() {},
+      close() {},
+      toggle() {},
+      isOpen: () => false,
+    },
+    settings: helpModal,
+    controlsButton,
+    settingsButton: helpButton,
+    textButton: textModeButton,
+    onTextMode: activateTextMode,
+  });
   let interactablePoi: PoiInstance | null = null;
 
   const controls = new KeyboardControls();
@@ -2702,7 +2728,20 @@ function initializeImmersiveScene(
     const label =
       formatKeyLabel(keyBindings.getPrimaryBinding('help')) ||
       helpLabelFallback;
-    helpButton.textContent = buildHelpButtonText(label);
+    const settingsLabel = helpButton.querySelector(
+      '[data-hud-menu-label="settings"]'
+    );
+    const settingsKey = helpButton.querySelector(
+      '[data-hud-menu-key="settings"]'
+    );
+    if (settingsLabel instanceof HTMLElement) {
+      settingsLabel.textContent = controlOverlayStrings.menu.settings.label;
+    } else {
+      helpButton.textContent = buildHelpButtonText(label);
+    }
+    if (settingsKey instanceof HTMLElement) {
+      settingsKey.textContent = label;
+    }
     helpButton.dataset.hudAnnounce = buildHelpAnnouncement(label);
   };
   updateHelpButtonLabel();
@@ -3215,17 +3254,7 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       strings: modeToggleStrings,
       getIsFallbackActive: () => performanceFailover.hasTriggered(),
-      onToggle: () => {
-        if (performanceFailover.hasTriggered()) {
-          clearModePreference();
-          window.location.assign(createImmersiveRecoveryUrl());
-          return;
-        }
-        if (shouldPersistTextPreferenceForFallback('manual')) {
-          writeModePreference('text');
-        }
-        performanceFailover.triggerFallback('manual');
-      },
+      onToggle: activateTextMode,
     });
     registerHudControlElement(manualModeToggle?.element ?? null);
 
@@ -4178,6 +4207,10 @@ function initializeImmersiveScene(
       hudLayoutManager = null;
     }
     window.removeEventListener('keydown', handleControlsKeydown);
+    if (hudPanelCoordinator) {
+      hudPanelCoordinator.dispose();
+      hudPanelCoordinator = null;
+    }
     if (responsiveControlOverlay) {
       responsiveControlOverlay.dispose();
       responsiveControlOverlay = null;
@@ -4254,10 +4287,6 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
-    }
-    if (helpButton) {
-      helpButton.textContent = buildHelpButtonText(helpLabelFallback);
-      helpButton.dataset.hudAnnounce = buildHelpAnnouncement(helpLabelFallback);
     }
     if (localeToggleControl) {
       localeToggleControl.dispose();

--- a/src/main.ts
+++ b/src/main.ts
@@ -386,6 +386,7 @@ import {
   createHudLayoutManager,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
+import { formatMenuButtonTitle } from './ui/hud/menuButtonTitle';
 import {
   createMovementLegend,
   type MovementLegendHandle,
@@ -2481,11 +2482,6 @@ function initializeImmersiveScene(
         manageButtonClick: false,
       })
     : null;
-  const formatMenuButtonTitle = (
-    item: { keyHint: string; title: string },
-    shortcut: string
-  ): string =>
-    item.keyHint ? item.title.split(item.keyHint).join(shortcut) : item.title;
   const updateControlsButtonLabel = () => {
     const label =
       formatKeyLabel(keyBindings.getPrimaryBinding('toggleControls')) ||

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,7 +367,10 @@ import {
   createAudioSubtitles,
   type AudioSubtitlesHandle,
 } from './ui/hud/audioSubtitles';
-import { applyControlOverlayStrings } from './ui/hud/controlOverlay';
+import {
+  applyControlOverlayStrings,
+  applyHudMenuButtonMetadata,
+} from './ui/hud/controlOverlay';
 import { applyControlOverlayAccessibility } from './ui/hud/controlOverlayAccessibility';
 import {
   createHudCustomizationSection,
@@ -386,7 +389,6 @@ import {
   createHudLayoutManager,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
-import { formatMenuButtonTitle } from './ui/hud/menuButtonTitle';
 import {
   createMovementLegend,
   type MovementLegendHandle,
@@ -2747,24 +2749,15 @@ function initializeImmersiveScene(
     const settingsLabel = helpButton.querySelector(
       '[data-hud-menu-label="settings"]'
     );
-    const settingsKey = helpButton.querySelector(
-      '[data-hud-menu-key="settings"]'
-    );
-    if (settingsLabel instanceof HTMLElement) {
-      settingsLabel.textContent = controlOverlayStrings.menu.settings.label;
-    } else {
+    if (!(settingsLabel instanceof HTMLElement)) {
       helpButton.textContent = buildHelpButtonText(label);
     }
-    if (settingsKey instanceof HTMLElement) {
-      settingsKey.textContent = label;
-    }
-    const title = formatMenuButtonTitle(
+    applyHudMenuButtonMetadata(
+      helpButton,
       controlOverlayStrings.menu.settings,
-      label
+      label,
+      buildHelpAnnouncement(label)
     );
-    helpButton.setAttribute('aria-label', title);
-    helpButton.title = title;
-    helpButton.dataset.hudAnnounce = buildHelpAnnouncement(label);
   };
   updateHelpButtonLabel();
 

--- a/src/tests/hudMenuButtonTitle.test.ts
+++ b/src/tests/hudMenuButtonTitle.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatMenuButtonTitle } from '../ui/hud/menuButtonTitle';
+
+describe('formatMenuButtonTitle', () => {
+  it('updates the parenthesized default shortcut in regular locale titles', () => {
+    expect(
+      formatMenuButtonTitle(
+        { keyHint: 'H', title: 'Open settings and help (H)' },
+        'K'
+      )
+    ).toBe('Open settings and help (K)');
+  });
+
+  it('updates raw parenthesized shortcuts in pseudo-locale titles', () => {
+    expect(
+      formatMenuButtonTitle(
+        { keyHint: '⟦C⟧', title: '⟦Open controls (C)⟧' },
+        'K'
+      )
+    ).toBe('⟦Open controls (K)⟧');
+  });
+
+  it('updates pseudo-locale settings titles after help remaps', () => {
+    expect(
+      formatMenuButtonTitle(
+        { keyHint: '⟦H⟧', title: '⟦Open settings and help (H)⟧' },
+        'F1'
+      )
+    ).toBe('⟦Open settings and help (F1)⟧');
+  });
+});

--- a/src/tests/hudPanelCoordinator.test.ts
+++ b/src/tests/hudPanelCoordinator.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createHudPanelCoordinator } from '../ui/hud/hudPanelCoordinator';
+
+const createPanel = () => {
+  let open = false;
+  return {
+    open: vi.fn(() => {
+      open = true;
+    }),
+    close: vi.fn(() => {
+      open = false;
+    }),
+    toggle: vi.fn((force?: boolean) => {
+      open = force ?? !open;
+    }),
+    isOpen: () => open,
+  };
+};
+
+describe('createHudPanelCoordinator', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('closes Settings when Controls opens', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextMode: vi.fn(),
+    });
+
+    coordinator.openSettings();
+    expect(settings.isOpen()).toBe(true);
+
+    coordinator.openControls();
+
+    expect(settings.close).toHaveBeenCalled();
+    expect(settings.isOpen()).toBe(false);
+    expect(controls.isOpen()).toBe(true);
+    expect(coordinator.getActivePanel()).toBe('controls');
+
+    coordinator.dispose();
+  });
+
+  it('closes Controls when Settings opens', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextMode: vi.fn(),
+    });
+
+    coordinator.openControls();
+    expect(controls.isOpen()).toBe(true);
+
+    coordinator.openSettings();
+
+    expect(controls.close).toHaveBeenCalled();
+    expect(controls.isOpen()).toBe(false);
+    expect(settings.isOpen()).toBe(true);
+    expect(coordinator.getActivePanel()).toBe('settings');
+
+    coordinator.dispose();
+  });
+
+  it('closes panels before triggering the Text action', () => {
+    const events: string[] = [];
+    let controlsOpen = false;
+    let settingsOpen = false;
+    const controls = {
+      open: vi.fn(() => {
+        controlsOpen = true;
+      }),
+      close: vi.fn(() => {
+        events.push('controls:close');
+        controlsOpen = false;
+      }),
+      toggle: vi.fn(),
+      isOpen: () => controlsOpen,
+    };
+    const settings = {
+      open: vi.fn(() => {
+        settingsOpen = true;
+      }),
+      close: vi.fn(() => {
+        events.push('settings:close');
+        settingsOpen = false;
+      }),
+      toggle: vi.fn(),
+      isOpen: () => settingsOpen,
+    };
+    const onTextMode = vi.fn(() => {
+      events.push('text');
+    });
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextMode,
+    });
+
+    coordinator.openControls();
+    events.length = 0;
+    coordinator.activateTextMode();
+
+    expect(events).toEqual(['controls:close', 'settings:close', 'text']);
+    expect(onTextMode).toHaveBeenCalledTimes(1);
+    expect(coordinator.getActivePanel()).toBeNull();
+
+    coordinator.dispose();
+  });
+
+  it('wires HUD buttons and Escape to panel actions', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const controlsButton = document.createElement('button');
+    const settingsButton = document.createElement('button');
+    const textButton = document.createElement('button');
+    const onTextMode = vi.fn();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      controlsButton,
+      settingsButton,
+      textButton,
+      onTextMode,
+    });
+
+    controlsButton.click();
+    expect(controls.isOpen()).toBe(true);
+    expect(controlsButton.getAttribute('aria-pressed')).toBe('true');
+
+    settingsButton.click();
+    expect(controls.isOpen()).toBe(false);
+    expect(settings.isOpen()).toBe(true);
+    expect(settingsButton.getAttribute('aria-pressed')).toBe('true');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(settings.isOpen()).toBe(false);
+    expect(settingsButton.getAttribute('aria-pressed')).toBe('false');
+
+    textButton.click();
+    expect(onTextMode).toHaveBeenCalledTimes(1);
+
+    coordinator.dispose();
+  });
+});

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -31,6 +31,11 @@ const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
     announcementTemplate: 'Open help with {shortcut}',
     shortcutFallback: 'H',
   },
+  menu: {
+    controls: { label: 'Controls', keyHint: 'C', title: 'Open controls (C)' },
+    text: { label: 'Text', keyHint: 'T', title: 'Switch to text mode (T)' },
+    settings: { label: 'Settings', keyHint: 'H', title: 'Open settings (H)' },
+  },
   mobileToggle: {
     expandLabel: 'Show all controls',
     collapseLabel: 'Close controls',
@@ -315,10 +320,7 @@ describe('createResponsiveControlOverlay', () => {
     const styles = readFileSync('src/ui/styles.css', 'utf8');
 
     expect(styles).toContain(
-      ":root[data-accessibility-motion='reduced'] .overlay__controls-button"
-    );
-    expect(styles).toContain(
-      ":root[data-accessibility-motion='reduced'] .overlay__help-button"
+      ":root[data-accessibility-motion='reduced'] .overlay__menu-button"
     );
     expect(styles).toContain(
       ":root[data-accessibility-motion='reduced'] .overlay__popover"

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { ControlOverlayStrings } from '../assets/i18n/types';
 import { DEFAULT_KEY_BINDINGS } from '../systems/controls/keyBindings';
+import { applyHudMenuButtonMetadata } from '../ui/hud/controlOverlay';
 import { createResponsiveControlOverlay } from '../ui/hud/responsiveControlOverlay';
 
 const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
@@ -246,6 +247,85 @@ describe('createResponsiveControlOverlay', () => {
     expect(button.title).toBe('Open controls (K)');
 
     handle.dispose();
+  });
+
+  it('keeps pseudo-locale Controls titles aligned with remapped bindings', () => {
+    const { container, button, popover, list } = createOverlay();
+    button.innerHTML = `
+      <span data-hud-menu-label="controls">⟦Controls⟧</span>
+      <kbd data-hud-menu-key="controls">⟦C⟧</kbd>
+    `;
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      button,
+      popover,
+      strings: {
+        ...createStrings('⟦Controls⟧'),
+        menu: {
+          ...createStrings().menu,
+          controls: {
+            label: '⟦Controls⟧',
+            keyHint: '⟦C⟧',
+            title: '⟦Open controls (C)⟧',
+          },
+        },
+      },
+    });
+
+    handle.setControlsShortcutLabel('K');
+
+    expect(button.querySelector('[data-hud-menu-key]')?.textContent).toBe('K');
+    expect(button.getAttribute('aria-label')).toBe('⟦Open controls (K)⟧');
+    expect(button.title).toBe('⟦Open controls (K)⟧');
+
+    handle.dispose();
+  });
+
+  it('keeps Settings shortcut metadata aligned with remapped Help bindings', () => {
+    const button = document.createElement('button');
+    button.innerHTML = `
+      <span data-hud-menu-label="settings">Settings</span>
+      <kbd data-hud-menu-key="settings">H</kbd>
+    `;
+
+    applyHudMenuButtonMetadata(
+      button,
+      createStrings().menu.settings,
+      '?',
+      'Open help with ?'
+    );
+
+    expect(button.querySelector('[data-hud-menu-key]')?.textContent).toBe('?');
+    expect(button.getAttribute('aria-label')).toBe('Open settings (?)');
+    expect(button.title).toBe('Open settings (?)');
+    expect(button.dataset.hudAnnounce).toBe('Open help with ?');
+  });
+
+  it('keeps pseudo-locale Settings titles aligned with remapped Help bindings', () => {
+    const button = document.createElement('button');
+    button.innerHTML = `
+      <span data-hud-menu-label="settings">⟦Settings⟧</span>
+      <kbd data-hud-menu-key="settings">⟦H⟧</kbd>
+    `;
+
+    applyHudMenuButtonMetadata(
+      button,
+      {
+        label: '⟦Settings⟧',
+        keyHint: '⟦H⟧',
+        title: '⟦Open settings and help (H)⟧',
+      },
+      '?',
+      '⟦Open help with ?⟧'
+    );
+
+    expect(button.querySelector('[data-hud-menu-key]')?.textContent).toBe('?');
+    expect(button.getAttribute('aria-label')).toBe(
+      '⟦Open settings and help (?)⟧'
+    );
+    expect(button.title).toBe('⟦Open settings and help (?)⟧');
+    expect(button.dataset.hudAnnounce).toBe('⟦Open help with ?⟧');
   });
 
   it('updates button and close labels when strings refresh', () => {

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -130,15 +130,18 @@ describe('createResponsiveControlOverlay', () => {
     expect(handle.isOpen()).toBe(true);
     expect(popover.hidden).toBe(false);
     expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(button.getAttribute('aria-pressed')).toBe('true');
 
     handle.toggle();
     expect(handle.isOpen()).toBe(false);
     expect(popover.hidden).toBe(true);
+    expect(button.getAttribute('aria-pressed')).toBe('false');
 
     handle.open();
     closeButton.click();
     expect(handle.isOpen()).toBe(false);
     expect(popover.hidden).toBe(true);
+    expect(button.getAttribute('aria-pressed')).toBe('false');
     expect(document.activeElement).toBe(button);
 
     handle.dispose();
@@ -218,6 +221,29 @@ describe('createResponsiveControlOverlay', () => {
     expect(pointer?.hidden).toBe(false);
     expect(keyboard?.dataset.activeMethod).toBe('false');
     expect(pointer?.dataset.activeMethod).toBe('true');
+
+    handle.dispose();
+  });
+
+  it('keeps menu shortcut metadata aligned with remapped Controls bindings', () => {
+    const { container, button, popover, list } = createOverlay();
+    button.innerHTML = `
+      <span data-hud-menu-label="controls">Controls</span>
+      <kbd data-hud-menu-key="controls">C</kbd>
+    `;
+    const handle = createResponsiveControlOverlay({
+      container,
+      list,
+      button,
+      popover,
+      strings: createStrings(),
+    });
+
+    handle.setControlsShortcutLabel('K');
+
+    expect(button.querySelector('[data-hud-menu-key]')?.textContent).toBe('K');
+    expect(button.getAttribute('aria-label')).toBe('Open controls (K)');
+    expect(button.title).toBe('Open controls (K)');
 
     handle.dispose();
   });

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -1,5 +1,7 @@
 import type { ControlOverlayStrings } from '../../assets/i18n';
 
+import { formatMenuButtonTitle } from './menuButtonTitle';
+
 const CONTROL_HEADING_SELECTOR = '[data-control-text="heading"]';
 const CONTROL_KEYS_SELECTOR = '.overlay__keys';
 const CONTROL_DESCRIPTION_SELECTOR = '.overlay__description';
@@ -16,6 +18,23 @@ function setTextContent(
 ): void {
   if (element instanceof HTMLElement) {
     element.textContent = value;
+  }
+}
+
+export function applyHudMenuButtonMetadata(
+  button: HTMLButtonElement,
+  item: ControlOverlayStrings['menu'][keyof ControlOverlayStrings['menu']],
+  shortcutLabel: string,
+  announcement?: string
+): void {
+  setTextContent(button.querySelector('[data-hud-menu-label]'), item.label);
+  setTextContent(button.querySelector('[data-hud-menu-key]'), shortcutLabel);
+
+  const title = formatMenuButtonTitle(item, shortcutLabel);
+  button.setAttribute('aria-label', title);
+  button.title = title;
+  if (announcement !== undefined) {
+    button.dataset.hudAnnounce = announcement;
   }
 }
 
@@ -74,10 +93,7 @@ export function applyControlOverlayStrings(
       return;
     }
     const item = strings.menu[key];
-    setTextContent(button.querySelector('[data-hud-menu-label]'), item.label);
-    setTextContent(button.querySelector('[data-hud-menu-key]'), item.keyHint);
-    button.setAttribute('aria-label', item.title);
-    button.title = item.title;
+    applyHudMenuButtonMetadata(button, item, item.keyHint);
   };
 
   applyMenuButton(CONTROLS_BUTTON_SELECTOR, 'controls');

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -6,6 +6,8 @@ const CONTROL_DESCRIPTION_SELECTOR = '.overlay__description';
 const INTERACT_LABEL_SELECTOR = '[data-role="interact-label"]';
 const INTERACT_DESCRIPTION_SELECTOR = '[data-role="interact-description"]';
 const CONTROLS_BUTTON_SELECTOR = '[data-role="controls-button"]';
+const TEXT_MODE_BUTTON_SELECTOR = '[data-role="text-mode-button"]';
+const SETTINGS_BUTTON_SELECTOR = '[data-role="settings-button"]';
 const LEGACY_COLLAPSE_TOGGLE_SELECTOR = '[data-role="control-toggle"]';
 
 function setTextContent(
@@ -63,11 +65,29 @@ export function applyControlOverlayStrings(
     );
   }
 
+  const applyMenuButton = (
+    selector: string,
+    key: keyof ControlOverlayStrings['menu']
+  ) => {
+    const button = container.querySelector<HTMLButtonElement>(selector);
+    if (!button) {
+      return;
+    }
+    const item = strings.menu[key];
+    setTextContent(button.querySelector('[data-hud-menu-label]'), item.label);
+    setTextContent(button.querySelector('[data-hud-menu-key]'), item.keyHint);
+    button.setAttribute('aria-label', item.title);
+    button.title = item.title;
+  };
+
+  applyMenuButton(CONTROLS_BUTTON_SELECTOR, 'controls');
+  applyMenuButton(TEXT_MODE_BUTTON_SELECTOR, 'text');
+  applyMenuButton(SETTINGS_BUTTON_SELECTOR, 'settings');
+
   const controlsButton = container.querySelector<HTMLButtonElement>(
     CONTROLS_BUTTON_SELECTOR
   );
   if (controlsButton) {
-    setTextContent(controlsButton, strings.heading);
     controlsButton.dataset.hudAnnounce =
       strings.mobileToggle.expandAnnouncement;
   }

--- a/src/ui/hud/hudPanelCoordinator.ts
+++ b/src/ui/hud/hudPanelCoordinator.ts
@@ -1,0 +1,179 @@
+export type HudPanel = 'controls' | 'settings';
+
+interface TogglePanelHandle {
+  open(): void;
+  close(): void;
+  toggle(force?: boolean): void;
+  isOpen(): boolean;
+}
+
+export interface HudPanelCoordinatorOptions {
+  controls: TogglePanelHandle;
+  settings: TogglePanelHandle;
+  controlsButton?: HTMLButtonElement | null;
+  settingsButton?: HTMLButtonElement | null;
+  textButton?: HTMLButtonElement | null;
+  onTextMode: () => void;
+  documentTarget?: Document;
+}
+
+export interface HudPanelCoordinatorHandle {
+  getActivePanel(): HudPanel | null;
+  openControls(): void;
+  toggleControls(): void;
+  openSettings(): void;
+  toggleSettings(force?: boolean): void;
+  activateTextMode(): void;
+  closeActivePanel(): void;
+  closeAllPanels(): void;
+  dispose(): void;
+}
+
+const updateButtonState = (
+  button: HTMLButtonElement | null | undefined,
+  active: boolean
+) => {
+  if (!button) {
+    return;
+  }
+  button.setAttribute('aria-expanded', active ? 'true' : 'false');
+  button.setAttribute('aria-pressed', active ? 'true' : 'false');
+};
+
+export function createHudPanelCoordinator({
+  controls,
+  settings,
+  controlsButton,
+  settingsButton,
+  textButton,
+  onTextMode,
+  documentTarget = typeof document !== 'undefined' ? document : undefined,
+}: HudPanelCoordinatorOptions): HudPanelCoordinatorHandle {
+  let activePanel: HudPanel | null = null;
+  let disposed = false;
+
+  const syncState = () => {
+    if (controls.isOpen()) {
+      activePanel = 'controls';
+    } else if (settings.isOpen()) {
+      activePanel = 'settings';
+    } else {
+      activePanel = null;
+    }
+    updateButtonState(controlsButton, activePanel === 'controls');
+    updateButtonState(settingsButton, activePanel === 'settings');
+  };
+
+  const closeControls = () => {
+    controls.close();
+  };
+
+  const closeSettings = () => {
+    settings.close();
+  };
+
+  const openControls = () => {
+    closeSettings();
+    controls.open();
+    syncState();
+  };
+
+  const toggleControls = () => {
+    if (controls.isOpen()) {
+      closeControls();
+      syncState();
+      return;
+    }
+    openControls();
+  };
+
+  const openSettings = () => {
+    closeControls();
+    settings.open();
+    syncState();
+  };
+
+  const toggleSettings = (force?: boolean) => {
+    const shouldOpen = force ?? !settings.isOpen();
+    if (shouldOpen) {
+      openSettings();
+      return;
+    }
+    closeSettings();
+    syncState();
+  };
+
+  const closeAllPanels = () => {
+    closeControls();
+    closeSettings();
+    syncState();
+  };
+
+  const closeActivePanel = () => {
+    if (activePanel === 'controls') {
+      closeControls();
+    } else if (activePanel === 'settings') {
+      closeSettings();
+    }
+    syncState();
+  };
+
+  const activateTextMode = () => {
+    closeAllPanels();
+    onTextMode();
+  };
+
+  const handleControlsClick = () => {
+    toggleControls();
+  };
+
+  const handleSettingsClick = () => {
+    toggleSettings();
+  };
+
+  const handleTextClick = () => {
+    activateTextMode();
+  };
+
+  const handleDocumentKeydown = (event: KeyboardEvent) => {
+    if (
+      event.key !== 'Escape' ||
+      event.defaultPrevented ||
+      activePanel === null
+    ) {
+      return;
+    }
+    event.preventDefault();
+    closeActivePanel();
+  };
+
+  controlsButton?.addEventListener('click', handleControlsClick);
+  settingsButton?.addEventListener('click', handleSettingsClick);
+  textButton?.addEventListener('click', handleTextClick);
+  documentTarget?.addEventListener('keydown', handleDocumentKeydown);
+  syncState();
+
+  return {
+    getActivePanel() {
+      syncState();
+      return activePanel;
+    },
+    openControls,
+    toggleControls,
+    openSettings,
+    toggleSettings,
+    activateTextMode,
+    closeActivePanel,
+    closeAllPanels,
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      controlsButton?.removeEventListener('click', handleControlsClick);
+      settingsButton?.removeEventListener('click', handleSettingsClick);
+      textButton?.removeEventListener('click', handleTextClick);
+      documentTarget?.removeEventListener('keydown', handleDocumentKeydown);
+    },
+  } satisfies HudPanelCoordinatorHandle;
+}

--- a/src/ui/hud/menuButtonTitle.ts
+++ b/src/ui/hud/menuButtonTitle.ts
@@ -1,0 +1,46 @@
+export interface HudMenuTitleItem {
+  keyHint: string;
+  title: string;
+}
+
+const PSEUDO_LOCALE_WRAPPER_PATTERN = /[⟦⟧]/g;
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const uniqueCandidates = (keyHint: string): ReadonlyArray<string> => {
+  const candidates = [
+    keyHint,
+    keyHint.replace(PSEUDO_LOCALE_WRAPPER_PATTERN, ''),
+  ]
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate.length > 0);
+  return Array.from(new Set(candidates));
+};
+
+export const formatMenuButtonTitle = (
+  item: HudMenuTitleItem,
+  shortcutLabel: string
+): string => {
+  for (const candidate of uniqueCandidates(item.keyHint)) {
+    const parenthesizedCandidate = new RegExp(
+      `\\(${escapeRegExp(candidate)}\\)`,
+      'g'
+    );
+    if (parenthesizedCandidate.test(item.title)) {
+      return item.title.replace(
+        parenthesizedCandidate,
+        () => `(${shortcutLabel})`
+      );
+    }
+  }
+
+  for (const candidate of uniqueCandidates(item.keyHint)) {
+    const candidatePattern = new RegExp(escapeRegExp(candidate), 'g');
+    if (candidatePattern.test(item.title)) {
+      return item.title.replace(candidatePattern, () => shortcutLabel);
+    }
+  }
+
+  return item.title;
+};

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -1,7 +1,7 @@
 import type { ControlOverlayStrings } from '../../assets/i18n/types';
 
+import { applyHudMenuButtonMetadata } from './controlOverlay';
 import type { HudLayout } from './layoutManager';
-import { formatMenuButtonTitle } from './menuButtonTitle';
 import type { InputMethod } from './movementLegend';
 
 export interface ResponsiveControlOverlayHandle {
@@ -196,16 +196,11 @@ export function createResponsiveControlOverlay(
     const menuLabel = button.querySelector('[data-hud-menu-label]');
     if (menuLabel instanceof HTMLElement) {
       menuLabel.textContent = currentStrings.menu.controls.label;
-      const menuKey = button.querySelector('[data-hud-menu-key]');
-      if (menuKey instanceof HTMLElement) {
-        menuKey.textContent = controlsShortcutLabel;
-      }
-      const title = formatMenuButtonTitle(
+      applyHudMenuButtonMetadata(
+        button,
         currentStrings.menu.controls,
         controlsShortcutLabel
       );
-      button.setAttribute('aria-label', title);
-      button.title = title;
     } else {
       button.textContent = currentStrings.heading;
       button.setAttribute('aria-label', currentStrings.heading);

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -10,6 +10,7 @@ export interface ResponsiveControlOverlayHandle {
   isOpen(): boolean;
   setLayout(layout: HudLayout): void;
   setStrings(strings: ControlOverlayStrings): void;
+  setControlsShortcutLabel(label: string): void;
   refresh(): void;
   dispose(): void;
 }
@@ -36,6 +37,14 @@ const CONTROL_POPOVER_ID = 'control-overlay-popover';
 const CONTROL_OPEN_KEY = 'controlsOpen';
 const ACTIVE_INPUT_KEY = 'activeInput';
 const ACTIVE_METHOD_KEY = 'activeMethod';
+
+const formatMenuButtonTitle = (
+  item: ControlOverlayStrings['menu']['controls'],
+  shortcutLabel: string
+): string =>
+  item.keyHint
+    ? item.title.split(item.keyHint).join(shortcutLabel)
+    : item.title;
 
 const INPUT_METHODS: ReadonlyArray<InputMethod> = [
   'keyboard',
@@ -106,6 +115,9 @@ const createNoopResponsiveControlOverlay =
     setStrings() {
       /* noop */
     },
+    setControlsShortcutLabel() {
+      /* noop */
+    },
     refresh() {
       /* noop */
     },
@@ -124,6 +136,7 @@ const setOpenState = (
   popover.hidden = !open;
   container.dataset[CONTROL_OPEN_KEY] = open ? 'true' : 'false';
   button.setAttribute('aria-expanded', open ? 'true' : 'false');
+  button.setAttribute('aria-pressed', open ? 'true' : 'false');
   button.dataset.hudAnnounce = open
     ? strings.mobileToggle.collapseAnnouncement
     : strings.mobileToggle.expandAnnouncement;
@@ -178,6 +191,7 @@ export function createResponsiveControlOverlay(
   popover.setAttribute('aria-labelledby', labelId);
 
   let currentStrings: ControlOverlayStrings = { ...strings };
+  let controlsShortcutLabel = currentStrings.menu.controls.keyHint;
   let layout: HudLayout = initialLayout;
   let open = false;
   let disposed = false;
@@ -191,10 +205,14 @@ export function createResponsiveControlOverlay(
       menuLabel.textContent = currentStrings.menu.controls.label;
       const menuKey = button.querySelector('[data-hud-menu-key]');
       if (menuKey instanceof HTMLElement) {
-        menuKey.textContent = currentStrings.menu.controls.keyHint;
+        menuKey.textContent = controlsShortcutLabel;
       }
-      button.setAttribute('aria-label', currentStrings.menu.controls.title);
-      button.title = currentStrings.menu.controls.title;
+      const title = formatMenuButtonTitle(
+        currentStrings.menu.controls,
+        controlsShortcutLabel
+      );
+      button.setAttribute('aria-label', title);
+      button.title = title;
     } else {
       button.textContent = currentStrings.heading;
       button.setAttribute('aria-label', currentStrings.heading);
@@ -323,7 +341,15 @@ export function createResponsiveControlOverlay(
       update();
     },
     setStrings(nextStrings: ControlOverlayStrings) {
+      const previousDefaultShortcut = currentStrings.menu.controls.keyHint;
       currentStrings = { ...nextStrings };
+      if (controlsShortcutLabel === previousDefaultShortcut) {
+        controlsShortcutLabel = currentStrings.menu.controls.keyHint;
+      }
+      applyStrings();
+    },
+    setControlsShortcutLabel(label: string) {
+      controlsShortcutLabel = label || currentStrings.menu.controls.keyHint;
       applyStrings();
     },
     refresh() {
@@ -346,6 +372,7 @@ export function createResponsiveControlOverlay(
       documentTarget?.removeEventListener('keydown', handleDocumentKeydown);
       popover.hidden = true;
       button.removeAttribute('aria-expanded');
+      button.removeAttribute('aria-pressed');
       button.removeAttribute('aria-controls');
       button.removeAttribute('aria-haspopup');
       button.dataset.hudAnnounce = '';

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -1,6 +1,7 @@
 import type { ControlOverlayStrings } from '../../assets/i18n/types';
 
 import type { HudLayout } from './layoutManager';
+import { formatMenuButtonTitle } from './menuButtonTitle';
 import type { InputMethod } from './movementLegend';
 
 export interface ResponsiveControlOverlayHandle {
@@ -37,14 +38,6 @@ const CONTROL_POPOVER_ID = 'control-overlay-popover';
 const CONTROL_OPEN_KEY = 'controlsOpen';
 const ACTIVE_INPUT_KEY = 'activeInput';
 const ACTIVE_METHOD_KEY = 'activeMethod';
-
-const formatMenuButtonTitle = (
-  item: ControlOverlayStrings['menu']['controls'],
-  shortcutLabel: string
-): string =>
-  item.keyHint
-    ? item.title.split(item.keyHint).join(shortcutLabel)
-    : item.title;
 
 const INPUT_METHODS: ReadonlyArray<InputMethod> = [
   'keyboard',

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -23,6 +23,7 @@ export interface ResponsiveControlOverlayOptions {
   strings: ControlOverlayStrings;
   initialLayout?: HudLayout;
   documentTarget?: Document;
+  manageButtonClick?: boolean;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
@@ -136,6 +137,7 @@ export function createResponsiveControlOverlay(
     strings,
     initialLayout = 'desktop',
     documentTarget = typeof document !== 'undefined' ? document : undefined,
+    manageButtonClick = true,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
@@ -184,8 +186,19 @@ export function createResponsiveControlOverlay(
     if (ownsContainerLabel) {
       container.setAttribute('aria-label', currentStrings.heading);
     }
-    button.textContent = currentStrings.heading;
-    button.setAttribute('aria-label', currentStrings.heading);
+    const menuLabel = button.querySelector('[data-hud-menu-label]');
+    if (menuLabel instanceof HTMLElement) {
+      menuLabel.textContent = currentStrings.menu.controls.label;
+      const menuKey = button.querySelector('[data-hud-menu-key]');
+      if (menuKey instanceof HTMLElement) {
+        menuKey.textContent = currentStrings.menu.controls.keyHint;
+      }
+      button.setAttribute('aria-label', currentStrings.menu.controls.title);
+      button.title = currentStrings.menu.controls.title;
+    } else {
+      button.textContent = currentStrings.heading;
+      button.setAttribute('aria-label', currentStrings.heading);
+    }
     if (closeButton instanceof HTMLButtonElement) {
       closeButton.setAttribute(
         'aria-label',
@@ -271,7 +284,9 @@ export function createResponsiveControlOverlay(
     }
   };
 
-  button.addEventListener('click', handleButtonClick);
+  if (manageButtonClick) {
+    button.addEventListener('click', handleButtonClick);
+  }
   closeButton?.addEventListener('click', handleCloseClick);
   documentTarget?.addEventListener('pointerdown', handleDocumentPointerDown);
   documentTarget?.addEventListener('keydown', handleDocumentKeydown);
@@ -320,7 +335,9 @@ export function createResponsiveControlOverlay(
       }
       disposed = true;
       observer.disconnect();
-      button.removeEventListener('click', handleButtonClick);
+      if (manageButtonClick) {
+        button.removeEventListener('click', handleButtonClick);
+      }
       closeButton?.removeEventListener('click', handleCloseClick);
       documentTarget?.removeEventListener(
         'pointerdown',

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1321,19 +1321,32 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   transition: opacity 160ms ease;
 }
 
-.overlay__controls-button,
-.overlay__help-button {
-  width: auto;
-  min-height: 2.45rem;
-  padding: 0.65rem 0.9rem;
-  border-radius: 999px;
+.overlay__menu {
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  padding: 0.25rem;
   border: 1px solid rgba(123, 209, 255, 0.4);
+  border-radius: 999px;
   background:
     linear-gradient(140deg, rgba(12, 25, 39, 0.92), rgba(16, 43, 70, 0.78)),
     rgba(9, 18, 28, 0.88);
-  color: #e7f4ff;
+  box-shadow: var(--hud-surface-shadow, 0 20px 48px rgba(3, 9, 18, 0.55));
   backdrop-filter: blur(12px);
-  box-shadow: var(--hud-surface-shadow);
+}
+
+.overlay__menu-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: auto;
+  min-height: 2.45rem;
+  padding: 0.55rem 0.72rem;
+  border-radius: 999px;
+  border: 0;
+  background: transparent;
+  color: #e7f4ff;
   font-size: 0.86rem;
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -1344,19 +1357,32 @@ html[data-hud-layout='mobile'] .audio-subtitles {
     transform 120ms ease;
 }
 
-.overlay__controls-button:hover,
-.overlay__controls-button:focus-visible,
-.overlay__help-button:hover,
-.overlay__help-button:focus-visible {
+.overlay__menu-button:hover,
+.overlay__menu-button:focus-visible {
   border-color: rgba(158, 232, 255, 0.8);
   box-shadow: 0 18px 38px rgba(8, 20, 32, 0.35);
   outline: none;
   transform: translateY(-1px);
 }
 
-.overlay__controls-button:active,
-.overlay__help-button:active {
+.overlay__menu-button:active {
   transform: translateY(0);
+}
+
+.overlay__menu-button[aria-pressed='true'] {
+  background: rgba(80, 164, 255, 0.24);
+}
+
+.overlay__menu-key {
+  min-width: 1.35rem;
+  padding: 0.1rem 0.32rem;
+  border-radius: 999px;
+  background: rgba(196, 232, 255, 0.14);
+  color: rgba(228, 244, 255, 0.92);
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-align: center;
 }
 
 .overlay__popover {
@@ -1461,6 +1487,18 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   line-height: 1.5;
 }
 
+:root[data-hud-layout='mobile'] .overlay__menu-button {
+  gap: 0.25rem;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.5rem;
+  font-size: 0.78rem;
+}
+
+:root[data-hud-layout='mobile'] .overlay__menu-key {
+  min-width: 1.1rem;
+  padding-inline: 0.24rem;
+}
+
 :root[data-hud-layout='mobile'] .overlay__popover {
   width: min(20rem, calc(100vw - 1.5rem));
   max-height: min(26rem, calc(100vh - 7rem - env(safe-area-inset-top, 0px)));
@@ -1484,8 +1522,7 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .mode-toggle,
 :root[data-accessibility-motion='reduced'] .overlay,
 :root[data-accessibility-motion='reduced'] .overlay::after,
-:root[data-accessibility-motion='reduced'] .overlay__controls-button,
-:root[data-accessibility-motion='reduced'] .overlay__help-button,
+:root[data-accessibility-motion='reduced'] .overlay__menu-button,
 :root[data-accessibility-motion='reduced'] .overlay__popover,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close,
 :root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
@@ -1494,16 +1531,12 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   animation: none !important;
 }
 
-:root[data-accessibility-motion='reduced'] .overlay__controls-button:hover,
-:root[data-accessibility-motion='reduced']
-  .overlay__controls-button:focus-visible,
-:root[data-accessibility-motion='reduced'] .overlay__help-button:hover,
-:root[data-accessibility-motion='reduced'] .overlay__help-button:focus-visible,
+:root[data-accessibility-motion='reduced'] .overlay__menu-button:hover,
+:root[data-accessibility-motion='reduced'] .overlay__menu-button:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close:hover,
 :root[data-accessibility-motion='reduced']
   .overlay__popover-close:focus-visible,
-:root[data-accessibility-motion='reduced'] .overlay__controls-button:active,
-:root[data-accessibility-motion='reduced'] .overlay__help-button:active {
+:root[data-accessibility-motion='reduced'] .overlay__menu-button:active {
   transform: none;
 }
 


### PR DESCRIPTION
### Motivation
- Replace separate Controls / Text / Settings affordances with a single compact top-right HUD menu so users can discover all primary HUD actions from one place.
- Ensure Controls and Settings remain mutually exclusive, Text activation reuses the existing manual toggle path, and accessibility/keyboard hints are preserved.

### Description
- Add a three‑button HUD strip in `index.html` with Controls (C), Text (T), and Settings (H) and visible key hints; keep accessible attributes (`aria-expanded`, `aria-pressed`, labels, titles). (see `index.html`, `src/ui/styles.css`).
- Introduce `src/ui/hud/hudPanelCoordinator.ts` to coordinate HUD panels so opening one closes the other, Escape closes the active panel, and activating Text closes all panels first.
- Wire the coordinator into `src/main.ts`: the Controls key/button uses the coordinator, Settings still uses the existing `helpModal` (now routed through the coordinator), and the Text action reuses the `manualModeToggle` activation logic via a shared `activateTextMode` function.
- Update `createResponsiveControlOverlay` to allow the coordinator to manage the Controls button click (`manageButtonClick` option) and adapt string/application code so menu labels and key hints come from i18n strings.
- Extend i18n types and locales with a lightweight `menu` block and update `applyControlOverlayStrings` to populate menu labels/keys/titles.
- Add a small unit test suite for the coordinator and adjust an existing responsive overlay test to account for the new menu naming.

### Testing
- Ran formatting: `npm run format:write` — passed.
- Lint: `npm run lint` — passed (one import-order warning fixed during changes).
- Unit tests: `npm run test:ci` — passed (Vitest: 899 tests passed, included new `src/tests/hudPanelCoordinator.test.ts` and updated overlay test).
- Build: `npm run build` — passed (Vite build produced `dist`).
- Docs check: `npm run docs:check` — passed.
- Smoke: `npm run smoke` (build + `scripts/assert-dist.cjs`) — passed.
- Playwright / visual verification: launched a local preview and captured a screenshot of the HUD at `http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1`; created `/tmp/danielsmith-hud-menu.png` after installing Playwright browsers and host deps (commands run: `npx playwright install` and `npx playwright install-deps chromium`); screenshot saved successfully.
- Typecheck: `npm run typecheck` — not green and was not used as a gate for this change; the repository currently has pre-existing type errors unrelated to this HUD change (unresolved/POI typing and other legacy issues), so full `tsc --noEmit` reported many existing errors.

Follow-ups / notes: keep an eye on repository type issues when doing broader refactors; the coordinator and menu changes are intentionally minimal and localized to HUD files and `main.ts` to keep the change reviewable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf11a8390832fa10cb28f7e6cddd3)