### PR TITLE
Gate passive POI recommendations by HUD context

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1536,6 +1536,13 @@ function initializeImmersiveScene(
     interactionTimeline,
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const refreshPassivePoiRecommendationPolicy = () => {
+    const isMobileLayout = hudLayoutManager?.getLayout() === 'mobile';
+    const hasOpenHudPanel = hudPanelCoordinator?.getActivePanel() !== null;
+    const enabled = !isMobileLayout && !hasOpenHudPanel;
+    poiTooltipOverlay.setPassiveRecommendationsEnabled(enabled);
+    poiWorldTooltip.setPassiveRecommendationsEnabled(enabled);
+  };
   idleMonitor = new IdleMonitor({
     windowTarget: window,
     elementTargets: [renderer.domElement],
@@ -2482,6 +2489,7 @@ function initializeImmersiveScene(
         strings: controlOverlayStrings,
         initialLayout: 'desktop',
         manageButtonClick: false,
+        onOpenChange: refreshPassivePoiRecommendationPolicy,
       })
     : null;
   const updateControlsButtonLabel = () => {
@@ -2600,8 +2608,14 @@ function initializeImmersiveScene(
   helpModalController = attachHelpModalController({
     helpModal,
     helpButton,
-    onOpen: showHudControlElements,
-    onClose: hideHudControlElements,
+    onOpen: () => {
+      showHudControlElements();
+      refreshPassivePoiRecommendationPolicy();
+    },
+    onClose: () => {
+      hideHudControlElements();
+      refreshPassivePoiRecommendationPolicy();
+    },
     hudFocusAnnouncer,
     announcements: helpModalStrings.announcements,
   });
@@ -2700,7 +2714,9 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
+    onPanelChange: refreshPassivePoiRecommendationPolicy,
   });
+  refreshPassivePoiRecommendationPolicy();
   let interactablePoi: PoiInstance | null = null;
 
   const controls = new KeyboardControls();
@@ -3306,10 +3322,12 @@ function initializeImmersiveScene(
     windowTarget: window,
     onLayoutChange: (layout) => {
       responsiveControlOverlay?.setLayout(layout);
+      refreshPassivePoiRecommendationPolicy();
     },
   });
   if (hudLayoutManager) {
     responsiveControlOverlay?.setLayout(hudLayoutManager.getLayout());
+    refreshPassivePoiRecommendationPolicy();
   }
 
   composer = new EffectComposer(renderer);

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -49,6 +49,7 @@ export class PoiTooltipOverlay {
   private renderState: RenderState = { poiId: null };
   private visitedPoiIds: ReadonlySet<string> = new Set();
   private guidedTourEnabled = true;
+  private passiveRecommendationsEnabled = true;
   private isIdle = false;
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
@@ -191,6 +192,14 @@ export class PoiTooltipOverlay {
     this.update();
   }
 
+  setPassiveRecommendationsEnabled(enabled: boolean): void {
+    if (this.passiveRecommendationsEnabled === enabled) {
+      return;
+    }
+    this.passiveRecommendationsEnabled = enabled;
+    this.update();
+  }
+
   setVisitedPoiIds(ids: ReadonlySet<string>) {
     this.visitedPoiIds = ids;
     ids.forEach((id) => this.discoveredPoiIds.add(id));
@@ -231,7 +240,11 @@ export class PoiTooltipOverlay {
 
     const recommendation = this.recommendation;
     const idleRecommendation =
-      this.guidedTourEnabled && this.isIdle ? recommendation : null;
+      this.guidedTourEnabled &&
+      this.passiveRecommendationsEnabled &&
+      this.isIdle
+        ? recommendation
+        : null;
     const poi = this.hovered ?? this.selected ?? idleRecommendation;
     if (!poi) {
       this.root.classList.remove('poi-tooltip-overlay--visible');

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -103,6 +103,8 @@ export class PoiWorldTooltip {
 
   private guidedTourEnabled = true;
 
+  private passiveRecommendationsEnabled = true;
+
   private idle = false;
 
   private unsubscribeGuidedTour: (() => void) | null = null;
@@ -196,6 +198,16 @@ export class PoiWorldTooltip {
     this.recommendation = target;
   }
 
+  setPassiveRecommendationsEnabled(enabled: boolean): void {
+    if (this.passiveRecommendationsEnabled === enabled) {
+      return;
+    }
+    this.passiveRecommendationsEnabled = enabled;
+    if (!enabled && !this.hovered && !this.selected) {
+      this.fadeOut(0);
+    }
+  }
+
   setIdleState(idle: boolean): void {
     if (this.idle === idle) {
       return;
@@ -211,7 +223,9 @@ export class PoiWorldTooltip {
       return;
     }
     const recommendation =
-      this.guidedTourEnabled && this.idle ? this.recommendation : null;
+      this.guidedTourEnabled && this.passiveRecommendationsEnabled && this.idle
+        ? this.recommendation
+        : null;
     const active = this.selected ?? this.hovered ?? recommendation;
     const mode: PoiWorldTooltipMode | null = this.selected
       ? 'selected'
@@ -290,7 +304,10 @@ export class PoiWorldTooltip {
     if (this.disposed) {
       return;
     }
-    const recommendation = this.guidedTourEnabled ? this.recommendation : null;
+    const recommendation =
+      this.guidedTourEnabled && this.passiveRecommendationsEnabled && this.idle
+        ? this.recommendation
+        : null;
     const activeTarget = this.selected ?? this.hovered ?? recommendation;
     const mode: PoiWorldTooltipMode | null = this.selected
       ? 'selected'

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -360,7 +360,7 @@ describe('PoiTooltipOverlay', () => {
     );
   });
 
-  it('surfaces the recommendation overlay when idle', () => {
+  it('surfaces the recommendation overlay when idle and passive recommendations are enabled', () => {
     overlay.setIdleState(true);
     overlay.setRecommendation(basePoi);
 
@@ -377,6 +377,32 @@ describe('PoiTooltipOverlay', () => {
     ) as HTMLSpanElement;
     expect(badge.hidden).toBe(false);
     expect(badge.textContent).toBe('Next highlight');
+  });
+
+  it('does not surface idle recommendations when passive recommendations are disabled', () => {
+    overlay.setPassiveRecommendationsEnabled(false);
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('hidden');
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('keeps explicit selected POIs visible when passive recommendations are disabled', () => {
+    overlay.setPassiveRecommendationsEnabled(false);
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+    overlay.setSelected(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      basePoi.title
+    );
   });
 
   it('shows a badge when the recommended POI is selected', () => {

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -310,6 +310,34 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('suppresses idle recommendation rendering when passive recommendations are disabled', () => {
+    const { tooltip, preference } = createTooltip();
+    const recommendedPoi = createPoiDefinition({
+      id: 'f2clipboard-kitchen-console',
+    });
+    tooltip.setIdleState(true);
+    tooltip.setPassiveRecommendationsEnabled(false);
+    tooltip.setRecommendation(
+      createTarget(recommendedPoi, new Vector3(-1, 0.5, 2))
+    );
+    tooltip.update(0.016);
+
+    const disabledState = tooltip.getState();
+    expect(disabledState.mode).toBeNull();
+    expect(disabledState.visible).toBe(false);
+
+    tooltip.setSelected(createTarget(recommendedPoi, new Vector3(-1, 0.5, 2)));
+    tooltip.update(0.016);
+
+    const selectedState = tooltip.getState();
+    expect(selectedState.mode).toBe('selected');
+    expect(selectedState.poiId).toBe(recommendedPoi.id);
+    expect(selectedState.visible).toBe(true);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('suppresses recommendation rendering when guided tour is disabled', () => {
     const { tooltip, preference } = createTooltip();
     const recommendedPoi = createPoiDefinition({

--- a/src/ui/hud/hudPanelCoordinator.ts
+++ b/src/ui/hud/hudPanelCoordinator.ts
@@ -14,6 +14,7 @@ export interface HudPanelCoordinatorOptions {
   settingsButton?: HTMLButtonElement | null;
   textButton?: HTMLButtonElement | null;
   onTextMode: () => void;
+  onPanelChange?: (activePanel: HudPanel | null) => void;
   documentTarget?: Document;
 }
 
@@ -47,12 +48,14 @@ export function createHudPanelCoordinator({
   settingsButton,
   textButton,
   onTextMode,
+  onPanelChange,
   documentTarget = typeof document !== 'undefined' ? document : undefined,
 }: HudPanelCoordinatorOptions): HudPanelCoordinatorHandle {
   let activePanel: HudPanel | null = null;
   let disposed = false;
 
   const syncState = () => {
+    const previousPanel = activePanel;
     if (controls.isOpen()) {
       activePanel = 'controls';
     } else if (settings.isOpen()) {
@@ -62,6 +65,9 @@ export function createHudPanelCoordinator({
     }
     updateButtonState(controlsButton, activePanel === 'controls');
     updateButtonState(settingsButton, activePanel === 'settings');
+    if (activePanel !== previousPanel) {
+      onPanelChange?.(activePanel);
+    }
   };
 
   const closeControls = () => {

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -26,6 +26,7 @@ export interface ResponsiveControlOverlayOptions {
   initialLayout?: HudLayout;
   documentTarget?: Document;
   manageButtonClick?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
@@ -144,6 +145,7 @@ export function createResponsiveControlOverlay(
     initialLayout = 'desktop',
     documentTarget = typeof document !== 'undefined' ? document : undefined,
     manageButtonClick = true,
+    onOpenChange,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
@@ -240,6 +242,7 @@ export function createResponsiveControlOverlay(
     }
     open = false;
     update();
+    onOpenChange?.(open);
   };
 
   const openPopover = () => {
@@ -249,6 +252,7 @@ export function createResponsiveControlOverlay(
     }
     open = true;
     update();
+    onOpenChange?.(open);
   };
 
   const togglePopover = () => {


### PR DESCRIPTION
### Motivation
- Mobile idle POI recommendations could replace the Controls UI and create a poor UX on small devices. 
- Passive POI hints should not open while a HUD panel (Controls / Settings) is active so the panel isn’t replaced by an auto-recommendation.

### Description
- Add `setPassiveRecommendationsEnabled(enabled: boolean)` to `PoiTooltipOverlay` and `PoiWorldTooltip` and gate the idle/recommendation path on this flag. 
- Wire a main-level policy (`refreshPassivePoiRecommendationPolicy`) in `src/main.ts` that disables passive recommendations when the HUD layout is `mobile` or when any HUD panel is open, and enable it only when layout is not mobile and no panel is active. 
- Refresh the policy from controls popover open/close (`responsiveControlOverlay` `onOpenChange`), Settings modal open/close (`helpModalController` hooks), HUD panel coordinator changes (`onPanelChange`), and HUD layout changes (`createHudLayoutManager` `onLayoutChange`). 
- Keep explicit selection and hover behavior unchanged so pointer/keyboard-driven POI selection still renders tooltips; guided tour recommendation data remains intact but is prevented from auto-opening in disallowed contexts. 
- Add unit tests in `src/tests/poiTooltipOverlay.test.ts` and `src/tests/poiWorldTooltip.test.ts` that cover passive-enabled recommendations, passive-disabled suppression, and explicit selected POIs remaining visible.

### Testing
- Ran formatting with `npm run format:write` and lint with `npm run lint`, both succeeded. 
- Ran type-check with `npm run typecheck`, which failed due to existing repository-wide TypeScript issues unrelated to this change. 
- Ran targeted unit tests with `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts` and `npm run test:ci -- src/tests/poiWorldTooltip.test.ts`, and both test files passed. 
- Ran full test suite with `npm run test:ci`, which completed successfully (`131` test files, `909` tests passed). 
- Built the production bundle with `npm run build` and ran docs and smoke checks with `npm run docs:check` and `npm run smoke`, all of which passed. 
- Ran secret scan `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets. 

Residual risk / follow-up: the global `npm run typecheck` failure is pre-existing and should be addressed separately; this PR only introduces a local API and wiring to gate passive POI behavior and includes tests validating the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d34343820832f8f7b88e41d408147)