### PR TITLE
Gate passive POI recommendations behind HUD layout & panel state

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1538,8 +1538,9 @@ function initializeImmersiveScene(
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
   const updatePassivePoiRecommendationPolicy = () => {
     const activeHudPanel = hudPanelCoordinator?.getActivePanel() ?? null;
-    const hudLayout = hudLayoutManager?.getLayout() ?? 'desktop';
-    const enabled = hudLayout !== 'mobile' && activeHudPanel === null;
+    const hudLayout = hudLayoutManager?.getLayout() ?? null;
+    const enabled =
+      hudLayout !== null && hudLayout !== 'mobile' && activeHudPanel === null;
     poiTooltipOverlay.setPassiveRecommendationsEnabled(enabled);
     poiWorldTooltip.setPassiveRecommendationsEnabled(enabled);
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1536,6 +1536,14 @@ function initializeImmersiveScene(
     interactionTimeline,
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const updatePassivePoiRecommendationPolicy = () => {
+    const activeHudPanel = hudPanelCoordinator?.getActivePanel() ?? null;
+    const hudLayout = hudLayoutManager?.getLayout() ?? 'desktop';
+    const enabled = hudLayout !== 'mobile' && activeHudPanel === null;
+    poiTooltipOverlay.setPassiveRecommendationsEnabled(enabled);
+    poiWorldTooltip.setPassiveRecommendationsEnabled(enabled);
+  };
+  updatePassivePoiRecommendationPolicy();
   idleMonitor = new IdleMonitor({
     windowTarget: window,
     elementTargets: [renderer.domElement],
@@ -2482,6 +2490,7 @@ function initializeImmersiveScene(
         strings: controlOverlayStrings,
         initialLayout: 'desktop',
         manageButtonClick: false,
+        onOpenChange: updatePassivePoiRecommendationPolicy,
       })
     : null;
   const updateControlsButtonLabel = () => {
@@ -2602,6 +2611,7 @@ function initializeImmersiveScene(
     helpButton,
     onOpen: showHudControlElements,
     onClose: hideHudControlElements,
+    onOpenChange: updatePassivePoiRecommendationPolicy,
     hudFocusAnnouncer,
     announcements: helpModalStrings.announcements,
   });
@@ -2700,6 +2710,7 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
+    onActivePanelChange: updatePassivePoiRecommendationPolicy,
   });
   let interactablePoi: PoiInstance | null = null;
 
@@ -3306,10 +3317,12 @@ function initializeImmersiveScene(
     windowTarget: window,
     onLayoutChange: (layout) => {
       responsiveControlOverlay?.setLayout(layout);
+      updatePassivePoiRecommendationPolicy();
     },
   });
   if (hudLayoutManager) {
     responsiveControlOverlay?.setLayout(hudLayoutManager.getLayout());
+    updatePassivePoiRecommendationPolicy();
   }
 
   composer = new EffectComposer(renderer);

--- a/src/main.ts
+++ b/src/main.ts
@@ -387,6 +387,7 @@ import {
 } from './ui/hud/hudPanelCoordinator';
 import {
   createHudLayoutManager,
+  type HudLayout,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
 import {
@@ -1536,11 +1537,13 @@ function initializeImmersiveScene(
     interactionTimeline,
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
-  const updatePassivePoiRecommendationPolicy = () => {
+  const updatePassivePoiRecommendationPolicy = (layoutOverride?: HudLayout) => {
     const activeHudPanel = hudPanelCoordinator?.getActivePanel() ?? null;
-    const hudLayout = hudLayoutManager?.getLayout() ?? null;
+    const hudLayout = layoutOverride ?? hudLayoutManager?.getLayout();
     const enabled =
-      hudLayout !== null && hudLayout !== 'mobile' && activeHudPanel === null;
+      hudLayout !== undefined &&
+      hudLayout !== 'mobile' &&
+      activeHudPanel === null;
     poiTooltipOverlay.setPassiveRecommendationsEnabled(enabled);
     poiWorldTooltip.setPassiveRecommendationsEnabled(enabled);
   };
@@ -2491,7 +2494,7 @@ function initializeImmersiveScene(
         strings: controlOverlayStrings,
         initialLayout: 'desktop',
         manageButtonClick: false,
-        onOpenChange: updatePassivePoiRecommendationPolicy,
+        onOpenChange: () => updatePassivePoiRecommendationPolicy(),
       })
     : null;
   const updateControlsButtonLabel = () => {
@@ -2612,7 +2615,7 @@ function initializeImmersiveScene(
     helpButton,
     onOpen: showHudControlElements,
     onClose: hideHudControlElements,
-    onOpenChange: updatePassivePoiRecommendationPolicy,
+    onOpenChange: () => updatePassivePoiRecommendationPolicy(),
     hudFocusAnnouncer,
     announcements: helpModalStrings.announcements,
   });
@@ -2711,7 +2714,7 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
-    onActivePanelChange: updatePassivePoiRecommendationPolicy,
+    onActivePanelChange: () => updatePassivePoiRecommendationPolicy(),
   });
   let interactablePoi: PoiInstance | null = null;
 
@@ -3318,12 +3321,13 @@ function initializeImmersiveScene(
     windowTarget: window,
     onLayoutChange: (layout) => {
       responsiveControlOverlay?.setLayout(layout);
-      updatePassivePoiRecommendationPolicy();
+      updatePassivePoiRecommendationPolicy(layout);
     },
   });
   if (hudLayoutManager) {
-    responsiveControlOverlay?.setLayout(hudLayoutManager.getLayout());
-    updatePassivePoiRecommendationPolicy();
+    const initialHudLayout = hudLayoutManager.getLayout();
+    responsiveControlOverlay?.setLayout(initialHudLayout);
+    updatePassivePoiRecommendationPolicy(initialHudLayout);
   }
 
   composer = new EffectComposer(renderer);

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -49,6 +49,7 @@ export class PoiTooltipOverlay {
   private renderState: RenderState = { poiId: null };
   private visitedPoiIds: ReadonlySet<string> = new Set();
   private guidedTourEnabled = true;
+  private passiveRecommendationsEnabled = true;
   private isIdle = false;
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
@@ -191,6 +192,14 @@ export class PoiTooltipOverlay {
     this.update();
   }
 
+  setPassiveRecommendationsEnabled(enabled: boolean): void {
+    if (this.passiveRecommendationsEnabled === enabled) {
+      return;
+    }
+    this.passiveRecommendationsEnabled = enabled;
+    this.update();
+  }
+
   setVisitedPoiIds(ids: ReadonlySet<string>) {
     this.visitedPoiIds = ids;
     ids.forEach((id) => this.discoveredPoiIds.add(id));
@@ -231,7 +240,11 @@ export class PoiTooltipOverlay {
 
     const recommendation = this.recommendation;
     const idleRecommendation =
-      this.guidedTourEnabled && this.isIdle ? recommendation : null;
+      this.guidedTourEnabled &&
+      this.passiveRecommendationsEnabled &&
+      this.isIdle
+        ? recommendation
+        : null;
     const poi = this.hovered ?? this.selected ?? idleRecommendation;
     if (!poi) {
       this.root.classList.remove('poi-tooltip-overlay--visible');

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -103,6 +103,8 @@ export class PoiWorldTooltip {
 
   private guidedTourEnabled = true;
 
+  private passiveRecommendationsEnabled = true;
+
   private idle = false;
 
   private unsubscribeGuidedTour: (() => void) | null = null;
@@ -196,6 +198,16 @@ export class PoiWorldTooltip {
     this.recommendation = target;
   }
 
+  setPassiveRecommendationsEnabled(enabled: boolean): void {
+    if (this.passiveRecommendationsEnabled === enabled) {
+      return;
+    }
+    this.passiveRecommendationsEnabled = enabled;
+    if (!enabled && !this.hovered && !this.selected) {
+      this.fadeOut(0);
+    }
+  }
+
   setIdleState(idle: boolean): void {
     if (this.idle === idle) {
       return;
@@ -211,7 +223,9 @@ export class PoiWorldTooltip {
       return;
     }
     const recommendation =
-      this.guidedTourEnabled && this.idle ? this.recommendation : null;
+      this.guidedTourEnabled && this.passiveRecommendationsEnabled && this.idle
+        ? this.recommendation
+        : null;
     const active = this.selected ?? this.hovered ?? recommendation;
     const mode: PoiWorldTooltipMode | null = this.selected
       ? 'selected'
@@ -290,7 +304,10 @@ export class PoiWorldTooltip {
     if (this.disposed) {
       return;
     }
-    const recommendation = this.guidedTourEnabled ? this.recommendation : null;
+    const recommendation =
+      this.guidedTourEnabled && this.passiveRecommendationsEnabled && this.idle
+        ? this.recommendation
+        : null;
     const activeTarget = this.selected ?? this.hovered ?? recommendation;
     const mode: PoiWorldTooltipMode | null = this.selected
       ? 'selected'

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -379,6 +379,32 @@ describe('PoiTooltipOverlay', () => {
     expect(badge.textContent).toBe('Next highlight');
   });
 
+  it('does not surface passive recommendations when disabled', () => {
+    overlay.setPassiveRecommendationsEnabled(false);
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.dataset.state).toBe('hidden');
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('keeps explicit selection visible when passive recommendations are disabled', () => {
+    overlay.setPassiveRecommendationsEnabled(false);
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+    overlay.setSelected(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+
+    const title = root.querySelector('.poi-tooltip-overlay__title');
+    expect(title?.textContent).toBe(basePoi.title);
+  });
+
   it('shows a badge when the recommended POI is selected', () => {
     overlay.setIdleState(true);
     overlay.setRecommendation(basePoi);

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -310,6 +310,48 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('does not render passive recommendations when disabled', () => {
+    const { tooltip, preference } = createTooltip();
+    const recommendedPoi = createPoiDefinition({
+      id: 'dspace-backyard-rocket',
+    });
+    tooltip.setPassiveRecommendationsEnabled(false);
+    tooltip.setIdleState(true);
+    tooltip.setRecommendation(
+      createTarget(recommendedPoi, new Vector3(-1, 0.5, 2))
+    );
+    tooltip.update(0.016);
+
+    const state = tooltip.getState();
+    expect(state.mode).toBeNull();
+    expect(state.poiId).toBeNull();
+    expect(state.visible).toBe(false);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
+  it('keeps selected world tooltips visible when passive recommendations are disabled', () => {
+    const { tooltip, preference } = createTooltip();
+    const poi = createPoiDefinition({
+      id: 'jobbot-studio-terminal',
+    });
+    const target = createTarget(poi, new Vector3(0, 1, 0));
+    tooltip.setPassiveRecommendationsEnabled(false);
+    tooltip.setIdleState(true);
+    tooltip.setRecommendation(target);
+    tooltip.setSelected(target);
+    tooltip.update(0.016);
+
+    const state = tooltip.getState();
+    expect(state.mode).toBe('selected');
+    expect(state.poiId).toBe(poi.id);
+    expect(state.visible).toBe(true);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('suppresses recommendation rendering when guided tour is disabled', () => {
     const { tooltip, preference } = createTooltip();
     const recommendedPoi = createPoiDefinition({

--- a/src/ui/hud/helpModalController.ts
+++ b/src/ui/hud/helpModalController.ts
@@ -12,6 +12,7 @@ export interface HelpModalControllerOptions {
   helpButton?: HTMLButtonElement | null;
   onOpen?: () => void;
   onClose?: () => void;
+  onOpenChange?: (open: boolean) => void;
   hudFocusAnnouncer?: Pick<HudFocusAnnouncerHandle, 'announce'> | null;
   announcements?: HelpModalAnnouncements | null;
 }
@@ -38,6 +39,7 @@ export function attachHelpModalController({
   helpButton,
   onOpen,
   onClose,
+  onOpenChange,
   hudFocusAnnouncer,
   announcements,
 }: HelpModalControllerOptions): HelpModalControllerHandle {
@@ -85,6 +87,7 @@ export function attachHelpModalController({
     onOpen?.();
     originalOpen.call(helpModal);
     const nextIsOpen = refreshState();
+    onOpenChange?.(nextIsOpen);
     if (!nextIsOpen) {
       onClose?.();
       return;
@@ -101,6 +104,7 @@ export function attachHelpModalController({
     }
     originalClose.call(helpModal);
     const nextIsOpen = refreshState();
+    onOpenChange?.(nextIsOpen);
     if (!nextIsOpen) {
       onClose?.();
       announce(activeAnnouncements.close);
@@ -115,6 +119,9 @@ export function attachHelpModalController({
     }
     originalToggle.call(helpModal, force);
     const nextIsOpen = refreshState();
+    if (wasOpen !== nextIsOpen) {
+      onOpenChange?.(nextIsOpen);
+    }
     if (!wasOpen && nextIsOpen) {
       announce(activeAnnouncements.open);
       return;

--- a/src/ui/hud/hudPanelCoordinator.ts
+++ b/src/ui/hud/hudPanelCoordinator.ts
@@ -14,6 +14,7 @@ export interface HudPanelCoordinatorOptions {
   settingsButton?: HTMLButtonElement | null;
   textButton?: HTMLButtonElement | null;
   onTextMode: () => void;
+  onActivePanelChange?: (panel: HudPanel | null) => void;
   documentTarget?: Document;
 }
 
@@ -47,12 +48,14 @@ export function createHudPanelCoordinator({
   settingsButton,
   textButton,
   onTextMode,
+  onActivePanelChange,
   documentTarget = typeof document !== 'undefined' ? document : undefined,
 }: HudPanelCoordinatorOptions): HudPanelCoordinatorHandle {
   let activePanel: HudPanel | null = null;
   let disposed = false;
 
   const syncState = () => {
+    const previousPanel = activePanel;
     if (controls.isOpen()) {
       activePanel = 'controls';
     } else if (settings.isOpen()) {
@@ -62,6 +65,9 @@ export function createHudPanelCoordinator({
     }
     updateButtonState(controlsButton, activePanel === 'controls');
     updateButtonState(settingsButton, activePanel === 'settings');
+    if (activePanel !== previousPanel) {
+      onActivePanelChange?.(activePanel);
+    }
   };
 
   const closeControls = () => {

--- a/src/ui/hud/responsiveControlOverlay.ts
+++ b/src/ui/hud/responsiveControlOverlay.ts
@@ -26,6 +26,7 @@ export interface ResponsiveControlOverlayOptions {
   initialLayout?: HudLayout;
   documentTarget?: Document;
   manageButtonClick?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const CONTROL_LIST_SELECTOR = '[data-role="control-list"]';
@@ -144,6 +145,7 @@ export function createResponsiveControlOverlay(
     initialLayout = 'desktop',
     documentTarget = typeof document !== 'undefined' ? document : undefined,
     manageButtonClick = true,
+    onOpenChange,
   } = options;
 
   const list = options.list ?? container.querySelector(CONTROL_LIST_SELECTOR);
@@ -240,6 +242,7 @@ export function createResponsiveControlOverlay(
     }
     open = false;
     update();
+    onOpenChange?.(open);
   };
 
   const openPopover = () => {
@@ -249,6 +252,7 @@ export function createResponsiveControlOverlay(
     }
     open = true;
     update();
+    onOpenChange?.(open);
   };
 
   const togglePopover = () => {


### PR DESCRIPTION
### Motivation
- Idle/passive POI recommendations could auto-open and replace the Controls HUD on mobile or while HUD panels (Controls/Settings) are open, causing a poor UX and unexpected UI swapping.  
- Introduce an explicit passive-recommendation policy so auto-opening rich POI tooltips only occur in allowed contexts while keeping explicit selection and hover behavior unchanged.

### Description
- Added a passive recommendation flag and public API `setPassiveRecommendationsEnabled(enabled: boolean)` to `PoiTooltipOverlay` and `PoiWorldTooltip` and gated the idle recommendation path on that flag.  
- When passive recommendations are disabled, in-world tooltips immediately fade out if no hover/selection is active; explicit selection and hover still render normally.  
- Wired a main-level policy computed in `src/main.ts` (`updatePassivePoiRecommendationPolicy`) that enables passive POI hints only when the HUD layout is not `mobile` and no HUD panel is active, and calls `setPassiveRecommendationsEnabled` on both tooltip implementations.  
- Added lightweight HUD hooks so Controls and Settings can notify policy changes: `onOpenChange` for `ResponsiveControlOverlay` and `HelpModalController`, and `onActivePanelChange` for the HUD panel coordinator; main wires these callbacks to refresh the passive policy when layout or panel state changes.  
- Tests updated: `src/tests/poiTooltipOverlay.test.ts` and `src/tests/poiWorldTooltip.test.ts` now cover passive-enabled behavior, passive-disabled suppression, and that explicit selection still shows tooltips when passive is off.

### Testing
- Ran formatting and linting: `npm run format:write` (succeeded) and `npm run lint` (succeeded).  
- Typecheck: `npm run typecheck` (failed — unrelated, pre-existing repository-wide TypeScript issues surfaced; these errors are not caused by this change).  
- Targeted unit tests for the changes: `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts` (passed).  
- World tooltip tests and updated overlay tests: `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts` (passed).  
- Full test suite: `npm run test:ci` (all tests passed in CI run).  
- Build and verification: `npm run build`, `npm run docs:check`, and `npm run smoke` (all succeeded).  

Residual risks & follow-ups: the repository has pre-existing TypeScript typecheck failures unrelated to this change; CI/unit runs and a production build succeeded, but the `tsc --noEmit` step surfaced other repo issues and should be triaged separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d34343820832f8f7b88e41d408147)