### PR TITLE
Gate passive POI recommendations behind HUD policy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -387,6 +387,7 @@ import {
 } from './ui/hud/hudPanelCoordinator';
 import {
   createHudLayoutManager,
+  type HudLayout,
   type HudLayoutManagerHandle,
 } from './ui/hud/layoutManager';
 import {
@@ -1536,6 +1537,14 @@ function initializeImmersiveScene(
     interactionTimeline,
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const refreshPassivePoiRecommendationPolicy = (layout?: HudLayout): void => {
+    const currentLayout = layout ?? hudLayoutManager?.getLayout() ?? 'desktop';
+    const hudPanelOpen = hudPanelCoordinator?.getActivePanel() !== null;
+    const enabled = currentLayout !== 'mobile' && !hudPanelOpen;
+    poiTooltipOverlay.setPassiveRecommendationsEnabled(enabled);
+    poiWorldTooltip.setPassiveRecommendationsEnabled(enabled);
+  };
+  refreshPassivePoiRecommendationPolicy();
   idleMonitor = new IdleMonitor({
     windowTarget: window,
     elementTargets: [renderer.domElement],
@@ -2700,7 +2709,11 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
+    onActivePanelChange: () => {
+      refreshPassivePoiRecommendationPolicy();
+    },
   });
+  refreshPassivePoiRecommendationPolicy();
   let interactablePoi: PoiInstance | null = null;
 
   const controls = new KeyboardControls();
@@ -3306,10 +3319,13 @@ function initializeImmersiveScene(
     windowTarget: window,
     onLayoutChange: (layout) => {
       responsiveControlOverlay?.setLayout(layout);
+      refreshPassivePoiRecommendationPolicy(layout);
     },
   });
   if (hudLayoutManager) {
-    responsiveControlOverlay?.setLayout(hudLayoutManager.getLayout());
+    const layout = hudLayoutManager.getLayout();
+    responsiveControlOverlay?.setLayout(layout);
+    refreshPassivePoiRecommendationPolicy(layout);
   }
 
   composer = new EffectComposer(renderer);

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -49,6 +49,7 @@ export class PoiTooltipOverlay {
   private renderState: RenderState = { poiId: null };
   private visitedPoiIds: ReadonlySet<string> = new Set();
   private guidedTourEnabled = true;
+  private passiveRecommendationsEnabled = true;
   private isIdle = false;
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
@@ -191,6 +192,14 @@ export class PoiTooltipOverlay {
     this.update();
   }
 
+  setPassiveRecommendationsEnabled(enabled: boolean): void {
+    if (this.passiveRecommendationsEnabled === enabled) {
+      return;
+    }
+    this.passiveRecommendationsEnabled = enabled;
+    this.update();
+  }
+
   setVisitedPoiIds(ids: ReadonlySet<string>) {
     this.visitedPoiIds = ids;
     ids.forEach((id) => this.discoveredPoiIds.add(id));
@@ -231,7 +240,11 @@ export class PoiTooltipOverlay {
 
     const recommendation = this.recommendation;
     const idleRecommendation =
-      this.guidedTourEnabled && this.isIdle ? recommendation : null;
+      this.guidedTourEnabled &&
+      this.passiveRecommendationsEnabled &&
+      this.isIdle
+        ? recommendation
+        : null;
     const poi = this.hovered ?? this.selected ?? idleRecommendation;
     if (!poi) {
       this.root.classList.remove('poi-tooltip-overlay--visible');

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -103,6 +103,8 @@ export class PoiWorldTooltip {
 
   private guidedTourEnabled = true;
 
+  private passiveRecommendationsEnabled = true;
+
   private idle = false;
 
   private unsubscribeGuidedTour: (() => void) | null = null;
@@ -196,6 +198,16 @@ export class PoiWorldTooltip {
     this.recommendation = target;
   }
 
+  setPassiveRecommendationsEnabled(enabled: boolean): void {
+    if (this.passiveRecommendationsEnabled === enabled) {
+      return;
+    }
+    this.passiveRecommendationsEnabled = enabled;
+    if (!enabled && !this.hovered && !this.selected) {
+      this.fadeOut(0);
+    }
+  }
+
   setIdleState(idle: boolean): void {
     if (this.idle === idle) {
       return;
@@ -210,8 +222,9 @@ export class PoiWorldTooltip {
     if (this.disposed) {
       return;
     }
-    const recommendation =
-      this.guidedTourEnabled && this.idle ? this.recommendation : null;
+    const recommendation = this.shouldRenderPassiveRecommendation()
+      ? this.recommendation
+      : null;
     const active = this.selected ?? this.hovered ?? recommendation;
     const mode: PoiWorldTooltipMode | null = this.selected
       ? 'selected'
@@ -290,7 +303,9 @@ export class PoiWorldTooltip {
     if (this.disposed) {
       return;
     }
-    const recommendation = this.guidedTourEnabled ? this.recommendation : null;
+    const recommendation = this.shouldRenderPassiveRecommendation()
+      ? this.recommendation
+      : null;
     const activeTarget = this.selected ?? this.hovered ?? recommendation;
     const mode: PoiWorldTooltipMode | null = this.selected
       ? 'selected'
@@ -329,6 +344,12 @@ export class PoiWorldTooltip {
       visible: this.group.visible,
       opacity: this.mesh.material.opacity,
     };
+  }
+
+  private shouldRenderPassiveRecommendation(): boolean {
+    return (
+      this.guidedTourEnabled && this.passiveRecommendationsEnabled && this.idle
+    );
   }
 
   private isFacingCamera(target: Vector3): boolean {

--- a/src/tests/hudPanelCoordinator.test.ts
+++ b/src/tests/hudPanelCoordinator.test.ts
@@ -147,4 +147,26 @@ describe('createHudPanelCoordinator', () => {
 
     coordinator.dispose();
   });
+
+  it('notifies when the active HUD panel changes', () => {
+    const controls = createPanel();
+    const settings = createPanel();
+    const onActivePanelChange = vi.fn();
+    const coordinator = createHudPanelCoordinator({
+      controls,
+      settings,
+      onTextMode: vi.fn(),
+      onActivePanelChange,
+    });
+
+    coordinator.openControls();
+    coordinator.openSettings();
+    coordinator.closeActivePanel();
+
+    expect(onActivePanelChange).toHaveBeenNthCalledWith(1, 'controls');
+    expect(onActivePanelChange).toHaveBeenNthCalledWith(2, 'settings');
+    expect(onActivePanelChange).toHaveBeenNthCalledWith(3, null);
+
+    coordinator.dispose();
+  });
 });

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -379,6 +379,36 @@ describe('PoiTooltipOverlay', () => {
     expect(badge.textContent).toBe('Next highlight');
   });
 
+  it('does not surface idle recommendations when passive hints are disabled', () => {
+    overlay.setIdleState(true);
+    overlay.setPassiveRecommendationsEnabled(false);
+    overlay.setRecommendation(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.dataset.state).toBe('hidden');
+    expect(overlay.getState()).toEqual({
+      poiId: null,
+      state: 'hidden',
+      visible: false,
+    });
+  });
+
+  it('keeps explicit POI selections visible when passive hints are disabled', () => {
+    overlay.setIdleState(true);
+    overlay.setPassiveRecommendationsEnabled(false);
+    overlay.setRecommendation(basePoi);
+    overlay.setSelected(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      basePoi.title
+    );
+  });
+
   it('shows a badge when the recommended POI is selected', () => {
     overlay.setIdleState(true);
     overlay.setRecommendation(basePoi);

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -310,6 +310,54 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('does not render idle recommendations when passive hints are disabled', () => {
+    const { tooltip, preference } = createTooltip();
+    const recommendedPoi = createPoiDefinition({
+      id: 'sugarkube-backyard-greenhouse',
+    });
+
+    tooltip.setIdleState(true);
+    tooltip.setPassiveRecommendationsEnabled(false);
+    tooltip.setRecommendation(
+      createTarget(recommendedPoi, new Vector3(-1, 0.5, 2))
+    );
+    tooltip.update(0.016);
+
+    const state = tooltip.getState();
+    expect(state.mode).toBeNull();
+    expect(state.poiId).toBeNull();
+    expect(state.visible).toBe(false);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
+  it('keeps selected world tooltips visible when passive hints are disabled', () => {
+    const { tooltip, preference } = createTooltip();
+    const selectedPoi = createPoiDefinition({
+      id: 'jobbot-studio-terminal',
+    });
+
+    tooltip.setIdleState(true);
+    tooltip.setPassiveRecommendationsEnabled(false);
+    tooltip.setRecommendation(
+      createTarget(
+        createPoiDefinition({ id: 'axel-studio-tracker' }),
+        new Vector3(1, 0.5, 2)
+      )
+    );
+    tooltip.setSelected(createTarget(selectedPoi, new Vector3(0, 1, 0)));
+    tooltip.update(0.016);
+
+    const state = tooltip.getState();
+    expect(state.mode).toBe('selected');
+    expect(state.poiId).toBe(selectedPoi.id);
+    expect(state.visible).toBe(true);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('suppresses recommendation rendering when guided tour is disabled', () => {
     const { tooltip, preference } = createTooltip();
     const recommendedPoi = createPoiDefinition({

--- a/src/ui/hud/hudPanelCoordinator.ts
+++ b/src/ui/hud/hudPanelCoordinator.ts
@@ -14,6 +14,7 @@ export interface HudPanelCoordinatorOptions {
   settingsButton?: HTMLButtonElement | null;
   textButton?: HTMLButtonElement | null;
   onTextMode: () => void;
+  onActivePanelChange?: (panel: HudPanel | null) => void;
   documentTarget?: Document;
 }
 
@@ -47,12 +48,14 @@ export function createHudPanelCoordinator({
   settingsButton,
   textButton,
   onTextMode,
+  onActivePanelChange,
   documentTarget = typeof document !== 'undefined' ? document : undefined,
 }: HudPanelCoordinatorOptions): HudPanelCoordinatorHandle {
   let activePanel: HudPanel | null = null;
   let disposed = false;
 
   const syncState = () => {
+    const previousPanel = activePanel;
     if (controls.isOpen()) {
       activePanel = 'controls';
     } else if (settings.isOpen()) {
@@ -62,6 +65,9 @@ export function createHudPanelCoordinator({
     }
     updateButtonState(controlsButton, activePanel === 'controls');
     updateButtonState(settingsButton, activePanel === 'settings');
+    if (previousPanel !== activePanel) {
+      onActivePanelChange?.(activePanel);
+    }
   };
 
   const closeControls = () => {


### PR DESCRIPTION
### Motivation
- Prevent passive/idle POI recommendations from auto-opening the top-right HUD on mobile or while any HUD panel (Controls/Settings) is open.
- Preserve existing guided-tour recommendation data while avoiding unsolicited rich tooltip takeover in disallowed contexts.
- Keep explicit POI selection and desktop hover behavior unchanged.

### Description
- Added a passive recommendation flag and API to the 2D overlay: `PoiTooltipOverlay#setPassiveRecommendationsEnabled(enabled: boolean)` and gated idle recommendation rendering behind it. (file: `src/scene/poi/tooltipOverlay.ts`).
- Added the same API and gating to the in-world tooltip: `PoiWorldTooltip#setPassiveRecommendationsEnabled(enabled: boolean)` and a helper `shouldRenderPassiveRecommendation()` so world tooltips only auto-render when allowed. (file: `src/scene/poi/worldTooltip.ts`).
- Extended the HUD panel coordinator to notify callers when the active panel changes via `onActivePanelChange?: (panel: HudPanel | null) => void`, so the app can react when Controls/Settings open/close. (file: `src/ui/hud/hudPanelCoordinator.ts`).
- Wired a policy in the main immersive initialization that computes whether passive POI hints are allowed (disabled on mobile layout and whenever a HUD panel is open) and refreshes that policy on layout and active-panel changes; the policy toggles both overlay and world tooltip passive flags. (file: `src/main.ts`).
- Added tests covering passive-enabled vs passive-disabled idle recommendations, and ensured explicit selection still shows tooltips when passive hints are disabled; added a HUD coordinator notification test. (files: `src/tests/poiTooltipOverlay.test.ts`, `src/tests/poiWorldTooltip.test.ts`, `src/tests/hudPanelCoordinator.test.ts`).

### Testing
- Ran formatter: `npm run format:write -- <changed-files>` — succeeded.
- Lint: `npm run lint` — succeeded.
- Focused unit tests: `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts` — passed.
- Added world tooltip and HUD tests and ran: `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts src/tests/hudPanelCoordinator.test.ts` — passed.
- Full test suite: `npm run test:ci` — all tests passed in CI run (131 files, 911 tests in this environment).
- Build: `npm run build` — succeeded and produced `dist/` artifacts.
- Docs check: `npm run docs:check` — succeeded.
- Smoke (build + dist assertions): `npm run smoke` — succeeded.
- Typecheck: `npm run typecheck` — failed due to pre-existing, repo-wide TypeScript issues unrelated to this change (missing imports and test typing mismatches); these failures predate and are outside the scope of this PR.

Notes: The change only gates passive/idle recommendation rendering; explicit selections (`setSelected`) and hover-driven behavior remain unchanged and fully supported on all layouts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d34343820832f8f7b88e41d408147)