### PR TITLE
Add dismissible POI detail UX and mobile intentional-tap semantics

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1532,11 +1532,35 @@ function initializeImmersiveScene(
 
   const poiAnalytics = createWindowPoiAnalytics();
   const interactionTimeline = new InteractionTimeline();
+  const poiInteractionManager = new PoiInteractionManager(
+    renderer.domElement,
+    camera,
+    poiInstances,
+    poiAnalytics
+  );
+  const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const isMobileHudLayout = (layoutOverride?: HudLayout) =>
+    (layoutOverride ?? hudLayoutManager?.getLayout()) === 'mobile';
+  const shouldShowPoiHoverDetail = (layoutOverride?: HudLayout) =>
+    !isMobileHudLayout(layoutOverride) &&
+    (hudPanelCoordinator?.getActivePanel() ?? null) === null;
+  const clearActivePoiDetail = () => {
+    poiInteractionManager?.clearHover();
+    poiInteractionManager?.clearSelection();
+    poiTooltipOverlay.setHovered(null);
+    poiTooltipOverlay.setSelected(null);
+    poiWorldTooltip.setHovered(null);
+    poiWorldTooltip.setSelected(null);
+  };
+  const dismissActivePoiDetail = () => {
+    hudPanelCoordinator?.closeAllPanels();
+    clearActivePoiDetail();
+  };
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    onDismiss: dismissActivePoiDetail,
   });
-  const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
   const updatePassivePoiRecommendationPolicy = (layoutOverride?: HudLayout) => {
     const activeHudPanel = hudPanelCoordinator?.getActivePanel() ?? null;
     const hudLayout = layoutOverride ?? hudLayoutManager?.getLayout();
@@ -1544,6 +1568,10 @@ function initializeImmersiveScene(
       hudLayout !== undefined &&
       hudLayout !== 'mobile' &&
       activeHudPanel === null;
+    if (!shouldShowPoiHoverDetail(hudLayout)) {
+      poiTooltipOverlay.setHovered(null);
+      poiWorldTooltip.setHovered(null);
+    }
     poiTooltipOverlay.setPassiveRecommendationsEnabled(enabled);
     poiWorldTooltip.setPassiveRecommendationsEnabled(enabled);
   };
@@ -1994,13 +2022,12 @@ function initializeImmersiveScene(
     woveLoom = loom;
   }
 
-  const poiInteractionManager = new PoiInteractionManager(
-    renderer.domElement,
-    camera,
-    poiInstances,
-    poiAnalytics
-  );
   const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
+    if (!shouldShowPoiHoverDetail()) {
+      poiTooltipOverlay.setHovered(null);
+      poiWorldTooltip.setHovered(null);
+      return;
+    }
     poiTooltipOverlay.setHovered(poi);
     poiWorldTooltip.setHovered(resolveWorldTooltipTarget(poi));
   });
@@ -2011,6 +2038,7 @@ function initializeImmersiveScene(
     });
   const removeSelectionListener = poiInteractionManager.addSelectionListener(
     (poi) => {
+      hudPanelCoordinator?.closeAllPanels();
       idleMonitor?.reportActivity();
       poiVisitedState.markVisited(poi.id);
       if (poi.narration?.caption && audioSubtitles) {
@@ -2025,6 +2053,17 @@ function initializeImmersiveScene(
     }
   );
   poiInteractionManager.start();
+  const handlePoiDetailEscape = (event: KeyboardEvent) => {
+    if (event.key !== 'Escape' || event.defaultPrevented) {
+      return;
+    }
+    if (!poiTooltipOverlay.getState().visible) {
+      return;
+    }
+    event.preventDefault();
+    dismissActivePoiDetail();
+  };
+  document.addEventListener('keydown', handlePoiDetailEscape);
   beforeUnloadHandler = () => {
     inputLatencyTelemetry?.report('beforeunload');
     disposeImmersiveResources();
@@ -2714,7 +2753,12 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
-    onActivePanelChange: () => updatePassivePoiRecommendationPolicy(),
+    onActivePanelChange: (panel) => {
+      if (panel !== null) {
+        clearActivePoiDetail();
+      }
+      updatePassivePoiRecommendationPolicy();
+    },
   });
   let interactablePoi: PoiInstance | null = null;
 
@@ -4243,6 +4287,7 @@ function initializeImmersiveScene(
       hudLayoutManager.dispose();
       hudLayoutManager = null;
     }
+    document.removeEventListener('keydown', handlePoiDetailEscape);
     window.removeEventListener('keydown', handleControlsKeydown);
     if (hudPanelCoordinator) {
       hudPanelCoordinator.dispose();

--- a/src/scene/poi/interactionManager.ts
+++ b/src/scene/poi/interactionManager.ts
@@ -156,6 +156,14 @@ export class PoiInteractionManager {
     };
   }
 
+  clearHover(): void {
+    this.setHovered(null, this.lastHoverInput);
+  }
+
+  clearSelection(): void {
+    this.setSelected(null, this.lastSelectionInput);
+  }
+
   selectPoiById(poiId: string): void {
     const poi = this.poiInstances.find(
       (instance) => instance.definition.id === poiId

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -11,6 +11,7 @@ type DiscoveryFormatter = (poi: PoiDefinition) => string;
 
 export interface PoiTooltipOverlayOptions {
   container: HTMLElement;
+  onDismiss?: () => void;
   discoveryAnnouncer?: {
     format?: DiscoveryFormatter;
     politeness?: 'polite' | 'assertive';
@@ -36,6 +37,7 @@ export class PoiTooltipOverlay {
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
   private readonly recommendationBadge: HTMLSpanElement;
+  private readonly dismissButton: HTMLButtonElement;
   private readonly liveRegion: HTMLElement;
   private readonly interactionTimeline: InteractionTimeline | null;
   private readonly guidedTourPreference: GuidedTourPreference;
@@ -57,6 +59,7 @@ export class PoiTooltipOverlay {
   constructor(options: PoiTooltipOverlayOptions) {
     const {
       container,
+      onDismiss,
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
@@ -104,6 +107,17 @@ export class PoiTooltipOverlay {
     this.recommendationBadge.textContent = 'Next highlight';
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
+
+    this.dismissButton = documentTarget.createElement('button');
+    this.dismissButton.type = 'button';
+    this.dismissButton.className = 'poi-tooltip-overlay__dismiss';
+    this.dismissButton.setAttribute('aria-label', 'Close POI details');
+    this.dismissButton.title = 'Close POI details';
+    this.dismissButton.textContent = '×';
+    this.dismissButton.addEventListener('click', () => {
+      onDismiss?.();
+    });
+    headingRow.appendChild(this.dismissButton);
 
     this.summary = documentTarget.createElement('p');
     this.summary.className = 'poi-tooltip-overlay__summary';

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -537,6 +537,25 @@ describe('PoiInteractionManager', () => {
     disabledManager.dispose();
   });
 
+  it('clearSelection notifies selection state listeners with null', () => {
+    const selectionState = vi.fn();
+    manager.addSelectionStateListener(selectionState);
+    manager.start();
+
+    domElement.dispatchEvent(
+      new MouseEvent('click', { clientX: 200, clientY: 200 })
+    );
+    expect(selectionState).toHaveBeenLastCalledWith(definition, {
+      inputMethod: 'pointer',
+    });
+
+    manager.clearSelection();
+    expect(selectionState).toHaveBeenLastCalledWith(null, {
+      inputMethod: 'pointer',
+    });
+    expect(poi.focusTarget).toBe(0);
+  });
+
   it('notifies analytics hooks for hover and selection transitions', () => {
     const hoverStarted = vi.fn();
     const hoverEnded = vi.fn();

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PoiTooltipOverlay } from '../scene/poi/tooltipOverlay';
 import type { PoiDefinition } from '../scene/poi/types';
@@ -184,6 +184,43 @@ describe('PoiTooltipOverlay', () => {
       '.poi-tooltip-overlay__links'
     ) as HTMLElement;
     expect(describedIds).toContain(linksList.id);
+  });
+
+  it('renders selected POI metadata with an accessible dismiss button', () => {
+    overlay.setSelected(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      basePoi.title
+    );
+
+    const dismiss = root.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__dismiss'
+    );
+    expect(dismiss).toBeTruthy();
+    expect(dismiss?.type).toBe('button');
+    expect(dismiss?.getAttribute('aria-label')).toBe('Close POI details');
+  });
+
+  it('emits the dismiss callback when the close button is clicked', () => {
+    const onDismiss = vi.fn();
+    overlay.dispose();
+    overlay = new PoiTooltipOverlay({
+      container,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+      onDismiss,
+    });
+    overlay.setSelected(basePoi);
+
+    const dismiss = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__dismiss'
+    );
+    dismiss?.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   it('prefers hovered metadata over selected and hides when cleared', () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1510,10 +1510,23 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 
 :root[data-hud-layout='mobile'] .poi-tooltip-overlay {
   bottom: calc(var(--hud-mobile-safe-zone) + 1rem);
-  left: 1rem;
-  right: 1rem;
+  left: 0.75rem;
+  right: 0.75rem;
   max-width: none;
+  max-height: min(52vh, calc(100vh - 8rem - var(--hud-mobile-safe-zone)));
   width: auto;
+  overflow: auto;
+  padding: 0.95rem 1rem;
+}
+
+:root[data-hud-layout='mobile'] .poi-tooltip-overlay__heading-row {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+:root[data-hud-layout='mobile'] .poi-tooltip-overlay__dismiss {
+  position: sticky;
+  top: 0;
 }
 
 :root[data-accessibility-motion='reduced'] .audio-hud,
@@ -1526,6 +1539,7 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .overlay__popover,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close,
 :root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay__dismiss,
 :root[data-accessibility-motion='reduced'] .accessibility-presets {
   transition: none !important;
   animation: none !important;
@@ -1536,6 +1550,9 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .overlay__popover-close:hover,
 :root[data-accessibility-motion='reduced']
   .overlay__popover-close:focus-visible,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay__dismiss:hover,
+:root[data-accessibility-motion='reduced']
+  .poi-tooltip-overlay__dismiss:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__menu-button:active {
   transform: none;
 }
@@ -1874,6 +1891,40 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   display: flex;
   align-items: center;
   gap: 0.6rem;
+}
+
+.poi-tooltip-overlay__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.75rem;
+  height: 1.75rem;
+  margin-left: auto;
+  border: 1px solid rgba(143, 214, 255, 0.32);
+  border-radius: 999px;
+  background: rgba(7, 15, 26, 0.72);
+  color: rgba(236, 248, 255, 0.92);
+  font: inherit;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    transform 120ms ease;
+}
+
+.poi-tooltip-overlay__dismiss:hover,
+.poi-tooltip-overlay__dismiss:focus-visible {
+  border-color: rgba(212, 242, 255, 0.68);
+  background: rgba(24, 61, 92, 0.82);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.poi-tooltip-overlay__dismiss:active {
+  transform: translateY(0);
 }
 
 .poi-tooltip-overlay__title {


### PR DESCRIPTION
### Motivation
- Make rich POI detail intentional and dismissible, especially on mobile where hover is unreliable. 
- Ensure only one top-right HUD panel (Controls/Settings) or POI detail is visible at a time and provide a clear close affordance. 

### Description
- Added an accessible dismiss button to the 2D POI overlay with an `onDismiss` option so app code can clear selection state (`src/scene/poi/tooltipOverlay.ts`).
- Exposed `clearHover()` and `clearSelection()` on `PoiInteractionManager` and used those APIs to consistently clear selection/hover/analytics state (`src/scene/poi/interactionManager.ts`).
- Wired overlay dismiss behavior in `main.ts` so the close button, `Escape`, and opening Controls/Settings dismiss POI detail, hide the 2D overlay, and clear the in-world tooltip; on mobile the overlay ignores hover-only updates and shows rich detail only on deliberate tap/selection (`src/main.ts`).
- Adjusted mobile HUD styles so the POI overlay fits and the dismiss control is compact and keyboard-focusable, while preserving reduced-motion rules (`src/ui/styles.css`).
- Added focused tests for the new dismiss button behavior and for `clearSelection()` notifying listeners (`src/tests/poiTooltipOverlay.test.ts`, `src/tests/poiInteractionManager.test.ts`).

### Testing
- Ran formatting: `npm run format:write` (applied to modified files) — succeeded.
- Ran unit tests for changed areas: `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts src/tests/poiInteractionManager.test.ts` — both test files passed.
- Ran the repo test suite: `npm run test:ci` — full test suite completed successfully (all tests passed in run reported).
- Lint: `npm run lint` — succeeded (ESLint clean after a small const fix).
- Build: `npm run build` — succeeded, produced `dist/` artifacts (build warning about large chunk size only).
- Docs & smoke: `npm run docs:check` and `npm run smoke` — both succeeded.
- Typecheck: `npm run typecheck` — failed due to pre-existing, unrelated project-wide TypeScript issues (import/type mismatches outside this change); these failures were present before this PR and are not caused by the changes here.

Known follow-ups / risks
- Type-check currently fails on unrelated, existing typing issues in the repo; this PR is minimal and confined to POI UX and tests.
- Playwright/visual mobile regression coverage is recommended as a follow-up for end-to-end validation in real device scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df576edc4832fbcf60d4d96e48a1d)