### PR TITLE
Add dismissible POI detail UX

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1534,6 +1534,8 @@ function initializeImmersiveScene(
   const interactionTimeline = new InteractionTimeline();
   let currentHoveredPoi: PoiDefinition | null = null;
   let currentSelectedPoi: PoiDefinition | null = null;
+  let currentGuidedTourRecommendation: PoiDefinition | null = null;
+  let dismissedPassiveRecommendationPoiId: string | null = null;
   let poiInteractionManager: PoiInteractionManager | null = null;
   const isMobilePoiLayout = (layoutOverride?: HudLayout): boolean =>
     (layoutOverride ?? hudLayoutManager?.getLayout()) === 'mobile';
@@ -1548,6 +1550,33 @@ function initializeImmersiveScene(
   const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
     (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
     (!isMobilePoiLayout(layoutOverride) || currentSelectedPoi !== null);
+  const getVisiblePoiRecommendation = (): PoiDefinition | null => {
+    if (
+      currentGuidedTourRecommendation &&
+      currentGuidedTourRecommendation.id !== dismissedPassiveRecommendationPoiId
+    ) {
+      return currentGuidedTourRecommendation;
+    }
+    return null;
+  };
+  const syncPoiRecommendation = () => {
+    const visibleRecommendation = getVisiblePoiRecommendation();
+    poiTooltipOverlay.setRecommendation(visibleRecommendation);
+    poiWorldTooltip.setRecommendation(
+      resolveWorldTooltipTarget(visibleRecommendation)
+    );
+  };
+  const suppressActivePoiRecommendation = (poi: PoiDefinition | null) => {
+    if (
+      poi === null ||
+      currentGuidedTourRecommendation === null ||
+      currentGuidedTourRecommendation.id !== poi.id
+    ) {
+      return;
+    }
+    dismissedPassiveRecommendationPoiId = poi.id;
+    syncPoiRecommendation();
+  };
   const syncPoiDetailOverlay = (layoutOverride?: HudLayout) => {
     const canShowDetail = canShowPoiDetailOverlay(layoutOverride);
     const showHover =
@@ -1572,6 +1601,9 @@ function initializeImmersiveScene(
   const dismissActivePoiDetail = (
     inputMethod: 'keyboard' | 'pointer' | 'touch' = 'pointer'
   ) => {
+    const activePoi =
+      currentSelectedPoi ?? currentHoveredPoi ?? getVisiblePoiRecommendation();
+    suppressActivePoiRecommendation(activePoi);
     clearPoiDetailState(inputMethod);
     hudPanelCoordinator?.closeAllPanels();
   };
@@ -1798,10 +1830,11 @@ function initializeImmersiveScene(
   });
   removeGuidedTourSubscription = guidedTourChannel.subscribe(
     (recommendation) => {
-      poiTooltipOverlay.setRecommendation(recommendation);
-      poiWorldTooltip.setRecommendation(
-        resolveWorldTooltipTarget(recommendation)
-      );
+      if (recommendation?.id !== dismissedPassiveRecommendationPoiId) {
+        dismissedPassiveRecommendationPoiId = null;
+      }
+      currentGuidedTourRecommendation = recommendation;
+      syncPoiRecommendation();
     }
   );
 
@@ -2081,7 +2114,6 @@ function initializeImmersiveScene(
     if (
       event.key !== 'Escape' ||
       event.defaultPrevented ||
-      currentSelectedPoi === null ||
       !poiTooltipOverlay.getState().visible
     ) {
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2081,6 +2081,7 @@ function initializeImmersiveScene(
     if (
       event.key !== 'Escape' ||
       event.defaultPrevented ||
+      currentSelectedPoi === null ||
       !poiTooltipOverlay.getState().visible
     ) {
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2118,6 +2118,9 @@ function initializeImmersiveScene(
     ) {
       return;
     }
+    // Escape intentionally dismisses any visible POI detail state—selected, hovered,
+    // or recommended—because HUD panel opens clear/hide POI detail before their own
+    // Escape handlers run, so this capture listener should not swallow panel Escape.
     event.preventDefault();
     event.stopImmediatePropagation();
     dismissActivePoiDetail('keyboard');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1532,11 +1532,49 @@ function initializeImmersiveScene(
 
   const poiAnalytics = createWindowPoiAnalytics();
   const interactionTimeline = new InteractionTimeline();
+  let currentHoveredPoi: PoiDefinition | null = null;
+  let currentSelectedPoi: PoiDefinition | null = null;
+  let poiInteractionManager: PoiInteractionManager | null = null;
+  const isMobilePoiLayout = (layoutOverride?: HudLayout): boolean =>
+    (layoutOverride ?? hudLayoutManager?.getLayout()) === 'mobile';
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    onDismiss: () => {
+      dismissActivePoiDetail();
+    },
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
+    (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
+    (!isMobilePoiLayout(layoutOverride) || currentSelectedPoi !== null);
+  const syncPoiDetailOverlay = (layoutOverride?: HudLayout) => {
+    const canShowDetail = canShowPoiDetailOverlay(layoutOverride);
+    const showHover =
+      canShowDetail && !isMobilePoiLayout(layoutOverride)
+        ? currentHoveredPoi
+        : null;
+    const showSelected = canShowDetail ? currentSelectedPoi : null;
+    poiTooltipOverlay.setHovered(showHover);
+    poiTooltipOverlay.setSelected(showSelected);
+    poiWorldTooltip.setHovered(resolveWorldTooltipTarget(showHover));
+    poiWorldTooltip.setSelected(resolveWorldTooltipTarget(showSelected));
+  };
+  const clearPoiDetailState = (
+    inputMethod: 'keyboard' | 'pointer' | 'touch' = 'pointer'
+  ) => {
+    currentHoveredPoi = null;
+    currentSelectedPoi = null;
+    poiInteractionManager?.clearHover(inputMethod);
+    poiInteractionManager?.clearSelection(inputMethod);
+    syncPoiDetailOverlay();
+  };
+  const dismissActivePoiDetail = (
+    inputMethod: 'keyboard' | 'pointer' | 'touch' = 'pointer'
+  ) => {
+    clearPoiDetailState(inputMethod);
+    hudPanelCoordinator?.closeAllPanels();
+  };
   const updatePassivePoiRecommendationPolicy = (layoutOverride?: HudLayout) => {
     const activeHudPanel = hudPanelCoordinator?.getActivePanel() ?? null;
     const hudLayout = layoutOverride ?? hudLayoutManager?.getLayout();
@@ -1546,8 +1584,8 @@ function initializeImmersiveScene(
       activeHudPanel === null;
     poiTooltipOverlay.setPassiveRecommendationsEnabled(enabled);
     poiWorldTooltip.setPassiveRecommendationsEnabled(enabled);
+    syncPoiDetailOverlay(layoutOverride);
   };
-  updatePassivePoiRecommendationPolicy();
   idleMonitor = new IdleMonitor({
     windowTarget: window,
     elementTargets: [renderer.domElement],
@@ -1631,6 +1669,8 @@ function initializeImmersiveScene(
       },
     };
   };
+
+  updatePassivePoiRecommendationPolicy();
 
   const ensurePoiApi = () => {
     const portfolioWindow = window as Window;
@@ -1994,20 +2034,32 @@ function initializeImmersiveScene(
     woveLoom = loom;
   }
 
-  const poiInteractionManager = new PoiInteractionManager(
+  poiInteractionManager = new PoiInteractionManager(
     renderer.domElement,
     camera,
     poiInstances,
     poiAnalytics
   );
   const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
-    poiTooltipOverlay.setHovered(poi);
-    poiWorldTooltip.setHovered(resolveWorldTooltipTarget(poi));
+    currentHoveredPoi = poi;
+    syncPoiDetailOverlay();
   });
   const removeSelectionStateListener =
     poiInteractionManager.addSelectionStateListener((poi, context) => {
-      poiTooltipOverlay.setSelected(poi, context);
-      poiWorldTooltip.setSelected(resolveWorldTooltipTarget(poi));
+      currentSelectedPoi = poi;
+      if (poi) {
+        hudPanelCoordinator?.closeAllPanels();
+      }
+      poiTooltipOverlay.setSelected(
+        canShowPoiDetailOverlay() ? currentSelectedPoi : null,
+        context
+      );
+      poiWorldTooltip.setSelected(
+        resolveWorldTooltipTarget(
+          canShowPoiDetailOverlay() ? currentSelectedPoi : null
+        )
+      );
+      syncPoiDetailOverlay();
     });
   const removeSelectionListener = poiInteractionManager.addSelectionListener(
     (poi) => {
@@ -2025,6 +2077,21 @@ function initializeImmersiveScene(
     }
   );
   poiInteractionManager.start();
+  const handlePoiDetailEscape = (event: KeyboardEvent) => {
+    if (
+      event.key !== 'Escape' ||
+      event.defaultPrevented ||
+      !poiTooltipOverlay.getState().visible
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    dismissActivePoiDetail('keyboard');
+  };
+  document.addEventListener('keydown', handlePoiDetailEscape, {
+    capture: true,
+  });
   beforeUnloadHandler = () => {
     inputLatencyTelemetry?.report('beforeunload');
     disposeImmersiveResources();
@@ -2714,7 +2781,12 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
-    onActivePanelChange: () => updatePassivePoiRecommendationPolicy(),
+    onActivePanelChange: (panel) => {
+      if (panel !== null) {
+        clearPoiDetailState();
+      }
+      updatePassivePoiRecommendationPolicy();
+    },
   });
   let interactablePoi: PoiInstance | null = null;
 
@@ -4110,7 +4182,7 @@ function initializeImmersiveScene(
     const pressed = keyBindings.isActionActive('interact', keyPressSource);
     if (pressed && !interactKeyWasPressed && interactablePoi) {
       idleMonitor?.reportActivity();
-      poiInteractionManager.selectPoiById(interactablePoi.definition.id);
+      poiInteractionManager?.selectPoiById(interactablePoi.definition.id);
     }
     interactKeyWasPressed = pressed;
   }
@@ -4157,7 +4229,11 @@ function initializeImmersiveScene(
       avatarFootIkController.dispose();
       avatarFootIkController = null;
     }
-    poiInteractionManager.dispose();
+    document.removeEventListener('keydown', handlePoiDetailEscape, {
+      capture: true,
+    });
+    poiInteractionManager?.dispose();
+    poiInteractionManager = null;
     removeHoverListener();
     removeSelectionStateListener();
     removeSelectionListener();

--- a/src/scene/poi/interactionManager.ts
+++ b/src/scene/poi/interactionManager.ts
@@ -156,6 +156,14 @@ export class PoiInteractionManager {
     };
   }
 
+  clearSelection(inputMethod: PoiSelectionInputMethod = 'pointer'): void {
+    this.setSelected(null, inputMethod);
+  }
+
+  clearHover(inputMethod: PoiSelectionInputMethod = 'pointer'): void {
+    this.setHovered(null, inputMethod);
+  }
+
   selectPoiById(poiId: string): void {
     const poi = this.poiInstances.find(
       (instance) => instance.definition.id === poiId

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -11,6 +11,7 @@ type DiscoveryFormatter = (poi: PoiDefinition) => string;
 
 export interface PoiTooltipOverlayOptions {
   container: HTMLElement;
+  onDismiss?: () => void;
   discoveryAnnouncer?: {
     format?: DiscoveryFormatter;
     politeness?: 'polite' | 'assertive';
@@ -36,6 +37,7 @@ export class PoiTooltipOverlay {
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
   private readonly recommendationBadge: HTMLSpanElement;
+  private readonly closeButton: HTMLButtonElement;
   private readonly liveRegion: HTMLElement;
   private readonly interactionTimeline: InteractionTimeline | null;
   private readonly guidedTourPreference: GuidedTourPreference;
@@ -53,10 +55,12 @@ export class PoiTooltipOverlay {
   private isIdle = false;
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
+  private readonly onDismiss: (() => void) | null;
 
   constructor(options: PoiTooltipOverlayOptions) {
     const {
       container,
+      onDismiss,
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
@@ -68,6 +72,7 @@ export class PoiTooltipOverlay {
       discoveryAnnouncer?.format ?? defaultDiscoveryFormatter;
     this.interactionTimeline = interactionTimeline ?? null;
     this.guidedTourPreference = guidedTourPreference;
+    this.onDismiss = onDismiss ?? null;
     this.instanceId = generateTooltipInstanceId();
 
     this.root = documentTarget.createElement('section');
@@ -104,6 +109,16 @@ export class PoiTooltipOverlay {
     this.recommendationBadge.textContent = 'Next highlight';
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
+
+    this.closeButton = documentTarget.createElement('button');
+    this.closeButton.className = 'poi-tooltip-overlay__close';
+    this.closeButton.type = 'button';
+    this.closeButton.setAttribute('aria-label', 'Close POI details');
+    this.closeButton.textContent = '×';
+    this.closeButton.addEventListener('click', () => {
+      this.onDismiss?.();
+    });
+    headingRow.appendChild(this.closeButton);
 
     this.summary = documentTarget.createElement('p');
     this.summary.className = 'poi-tooltip-overlay__summary';

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -343,7 +343,7 @@ export class PoiTooltipOverlay {
   private syncCloseButtonState(
     state: 'hovered' | 'selected' | 'recommended' | 'hidden'
   ) {
-    const canDismiss = state === 'selected' && this.onDismiss !== null;
+    const canDismiss = state !== 'hidden' && this.onDismiss !== null;
     this.closeButton.hidden = !canDismiss;
     this.closeButton.disabled = !canDismiss;
     this.closeButton.tabIndex = canDismiss ? 0 : -1;

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -115,6 +115,9 @@ export class PoiTooltipOverlay {
     this.closeButton.type = 'button';
     this.closeButton.setAttribute('aria-label', 'Close POI details');
     this.closeButton.textContent = '×';
+    this.closeButton.hidden = true;
+    this.closeButton.disabled = true;
+    this.closeButton.tabIndex = -1;
     this.closeButton.addEventListener('click', () => {
       this.onDismiss?.();
     });
@@ -163,6 +166,7 @@ export class PoiTooltipOverlay {
     this.liveRegion.dataset.poiAnnouncement = 'discovery';
     applyVisuallyHiddenStyles(this.liveRegion);
     container.appendChild(this.liveRegion);
+    this.setFocusContainment(false);
 
     this.unsubscribeGuidedTour = this.guidedTourPreference.subscribe(
       (enabled) => {
@@ -264,7 +268,7 @@ export class PoiTooltipOverlay {
     if (!poi) {
       this.root.classList.remove('poi-tooltip-overlay--visible');
       this.root.dataset.state = 'hidden';
-      this.root.setAttribute('aria-hidden', 'true');
+      this.setFocusContainment(false);
       this.root.removeAttribute('aria-describedby');
       this.renderState.poiId = null;
       this.visitedBadge.hidden = true;
@@ -281,7 +285,8 @@ export class PoiTooltipOverlay {
         : 'recommended';
     this.root.dataset.state = state;
     this.root.classList.add('poi-tooltip-overlay--visible');
-    this.root.setAttribute('aria-hidden', 'false');
+    this.setFocusContainment(true);
+    this.syncCloseButtonState(state);
 
     const visited = this.visitedPoiIds.has(poi.id);
     this.visitedBadge.hidden = !visited;
@@ -325,6 +330,23 @@ export class PoiTooltipOverlay {
     } else if (state !== 'selected') {
       this.focusOnNextUpdate = false;
     }
+  }
+
+  private setFocusContainment(visible: boolean) {
+    this.root.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    this.root.toggleAttribute('inert', !visible);
+    if (!visible) {
+      this.syncCloseButtonState('hidden');
+    }
+  }
+
+  private syncCloseButtonState(
+    state: 'hovered' | 'selected' | 'recommended' | 'hidden'
+  ) {
+    const canDismiss = state === 'selected' && this.onDismiss !== null;
+    this.closeButton.hidden = !canDismiss;
+    this.closeButton.disabled = !canDismiss;
+    this.closeButton.tabIndex = canDismiss ? 0 : -1;
   }
 
   private focusRoot() {

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -501,6 +501,25 @@ describe('PoiInteractionManager', () => {
     expect(poi.focusTarget).toBe(1);
   });
 
+  it('clearSelection notifies selection state listeners with null', () => {
+    manager.start();
+    const selectionState = vi.fn();
+    manager.addSelectionStateListener(selectionState);
+
+    domElement.dispatchEvent(
+      new MouseEvent('click', { clientX: 200, clientY: 200 })
+    );
+    expect(selectionState).toHaveBeenLastCalledWith(definition, {
+      inputMethod: 'pointer',
+    });
+
+    manager.clearSelection('touch');
+
+    expect(selectionState).toHaveBeenLastCalledWith(null, {
+      inputMethod: 'touch',
+    });
+  });
+
   it('notifies selection state listeners when selection clears', () => {
     manager.start();
     const selectionState = vi.fn();

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -248,6 +248,7 @@ describe('PoiTooltipOverlay', () => {
     const closeButton = container.querySelector<HTMLButtonElement>(
       '.poi-tooltip-overlay__close'
     );
+    expect(root.getAttribute('aria-hidden')).toBe('true');
     expect(root.hasAttribute('inert')).toBe(true);
     expect(closeButton?.hidden).toBe(true);
     expect(closeButton?.disabled).toBe(true);
@@ -256,6 +257,7 @@ describe('PoiTooltipOverlay', () => {
     overlay.setSelected(basePoi, { inputMethod: 'pointer' });
 
     expect(root.dataset.state).toBe('selected');
+    expect(root.getAttribute('aria-hidden')).toBe('false');
     expect(root.hasAttribute('inert')).toBe(false);
     expect(closeButton?.hidden).toBe(false);
     expect(closeButton?.disabled).toBe(false);
@@ -267,6 +269,7 @@ describe('PoiTooltipOverlay', () => {
     overlay.setSelected(null, { inputMethod: 'pointer' });
 
     expect(root.dataset.state).toBe('hidden');
+    expect(root.getAttribute('aria-hidden')).toBe('true');
     expect(root.hasAttribute('inert')).toBe(true);
     expect(closeButton?.hidden).toBe(true);
     expect(closeButton?.disabled).toBe(true);
@@ -282,6 +285,7 @@ describe('PoiTooltipOverlay', () => {
     overlay.setSelected(basePoi, { inputMethod: 'pointer' });
 
     expect(root.dataset.state).toBe('selected');
+    expect(root.getAttribute('aria-hidden')).toBe('false');
     expect(root.hasAttribute('inert')).toBe(false);
     expect(closeButton?.hidden).toBe(true);
     expect(closeButton?.disabled).toBe(true);

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -230,32 +230,7 @@ describe('PoiTooltipOverlay', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the close button inert unless selected dismissal is available', () => {
-    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
-    const closeButton = container.querySelector<HTMLButtonElement>(
-      '.poi-tooltip-overlay__close'
-    );
-    expect(root.hasAttribute('inert')).toBe(true);
-    expect(closeButton?.hidden).toBe(true);
-    expect(closeButton?.disabled).toBe(true);
-    expect(closeButton?.tabIndex).toBe(-1);
-
-    overlay.setHovered(basePoi);
-
-    expect(root.hasAttribute('inert')).toBe(false);
-    expect(closeButton?.hidden).toBe(true);
-    expect(closeButton?.disabled).toBe(true);
-    expect(closeButton?.tabIndex).toBe(-1);
-
-    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
-
-    expect(root.dataset.state).toBe('hovered');
-    expect(closeButton?.hidden).toBe(true);
-    expect(closeButton?.disabled).toBe(true);
-    expect(closeButton?.tabIndex).toBe(-1);
-  });
-
-  it('hides the close button for passive recommendations', () => {
+  it('removes the hidden close button from keyboard navigation', () => {
     const onDismiss = vi.fn();
     overlay.dispose();
     timelineHarness.dispose();
@@ -269,17 +244,92 @@ describe('PoiTooltipOverlay', () => {
       guidedTourPreference: preference,
     });
 
-    overlay.setIdleState(true);
-    overlay.setRecommendation(basePoi);
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__close'
+    );
+    expect(root.hasAttribute('inert')).toBe(true);
+    expect(closeButton?.hidden).toBe(true);
+    expect(closeButton?.disabled).toBe(true);
+    expect(closeButton?.tabIndex).toBe(-1);
+
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+
+    expect(root.dataset.state).toBe('selected');
+    expect(root.hasAttribute('inert')).toBe(false);
+    expect(closeButton?.hidden).toBe(false);
+    expect(closeButton?.disabled).toBe(false);
+    expect(closeButton?.tabIndex).toBe(0);
+
+    closeButton?.focus();
+    expect(document.activeElement).toBe(closeButton);
+
+    overlay.setSelected(null, { inputMethod: 'pointer' });
+
+    expect(root.dataset.state).toBe('hidden');
+    expect(root.hasAttribute('inert')).toBe(true);
+    expect(closeButton?.hidden).toBe(true);
+    expect(closeButton?.disabled).toBe(true);
+    expect(closeButton?.tabIndex).toBe(-1);
+  });
+
+  it('keeps the close button inert when no dismiss handler is available', () => {
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__close'
+    );
+
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+
+    expect(root.dataset.state).toBe('selected');
+    expect(root.hasAttribute('inert')).toBe(false);
+    expect(closeButton?.hidden).toBe(true);
+    expect(closeButton?.disabled).toBe(true);
+    expect(closeButton?.tabIndex).toBe(-1);
+  });
+
+  it('enables the close button for hovered and passive recommendations', () => {
+    const onDismiss = vi.fn();
+    overlay.dispose();
+    timelineHarness.dispose();
+    preference.dispose();
+    timelineHarness = new TimelineHarness();
+    preference = createPreference();
+    overlay = new PoiTooltipOverlay({
+      container,
+      onDismiss,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+    });
 
     const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
     const closeButton = container.querySelector<HTMLButtonElement>(
       '.poi-tooltip-overlay__close'
     );
+
+    overlay.setHovered(basePoi);
+
+    expect(root.dataset.state).toBe('hovered');
+    expect(closeButton?.hidden).toBe(false);
+    expect(closeButton?.disabled).toBe(false);
+    expect(closeButton?.tabIndex).toBe(0);
+
+    closeButton?.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    overlay.setHovered(null);
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+
     expect(root.dataset.state).toBe('recommended');
-    expect(closeButton?.hidden).toBe(true);
-    expect(closeButton?.disabled).toBe(true);
-    expect(closeButton?.tabIndex).toBe(-1);
+    expect(closeButton?.hidden).toBe(false);
+    expect(closeButton?.disabled).toBe(false);
+    expect(closeButton?.tabIndex).toBe(0);
+
+    closeButton?.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(2);
   });
 
   it('can hide after dismiss clears selected state through the public API', () => {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PoiTooltipOverlay } from '../scene/poi/tooltipOverlay';
 import type { PoiDefinition } from '../scene/poi/types';
@@ -184,6 +184,58 @@ describe('PoiTooltipOverlay', () => {
       '.poi-tooltip-overlay__links'
     ) as HTMLElement;
     expect(describedIds).toContain(linksList.id);
+  });
+
+  it('renders selected POI metadata without a hover target', () => {
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      basePoi.title
+    );
+  });
+
+  it('emits a dismiss callback from a keyboard-focusable close button', () => {
+    const onDismiss = vi.fn();
+    overlay.dispose();
+    timelineHarness.dispose();
+    preference.dispose();
+    timelineHarness = new TimelineHarness();
+    preference = createPreference();
+    overlay = new PoiTooltipOverlay({
+      container,
+      onDismiss,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+    });
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__close'
+    );
+    expect(closeButton).toBeTruthy();
+    expect(closeButton?.tagName).toBe('BUTTON');
+    expect(closeButton?.type).toBe('button');
+    expect(closeButton?.getAttribute('aria-label')).toBe('Close POI details');
+
+    closeButton?.focus();
+    expect(document.activeElement).toBe(closeButton);
+    closeButton?.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('can hide after dismiss clears selected state through the public API', () => {
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+
+    overlay.setSelected(null, { inputMethod: 'pointer' });
+
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.dataset.state).toBe('hidden');
   });
 
   it('prefers hovered metadata over selected and hides when cleared', () => {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -219,12 +219,67 @@ describe('PoiTooltipOverlay', () => {
     expect(closeButton?.tagName).toBe('BUTTON');
     expect(closeButton?.type).toBe('button');
     expect(closeButton?.getAttribute('aria-label')).toBe('Close POI details');
+    expect(closeButton?.hidden).toBe(false);
+    expect(closeButton?.disabled).toBe(false);
+    expect(closeButton?.tabIndex).toBe(0);
 
     closeButton?.focus();
     expect(document.activeElement).toBe(closeButton);
     closeButton?.click();
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the close button inert unless selected dismissal is available', () => {
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__close'
+    );
+    expect(root.hasAttribute('inert')).toBe(true);
+    expect(closeButton?.hidden).toBe(true);
+    expect(closeButton?.disabled).toBe(true);
+    expect(closeButton?.tabIndex).toBe(-1);
+
+    overlay.setHovered(basePoi);
+
+    expect(root.hasAttribute('inert')).toBe(false);
+    expect(closeButton?.hidden).toBe(true);
+    expect(closeButton?.disabled).toBe(true);
+    expect(closeButton?.tabIndex).toBe(-1);
+
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+
+    expect(root.dataset.state).toBe('hovered');
+    expect(closeButton?.hidden).toBe(true);
+    expect(closeButton?.disabled).toBe(true);
+    expect(closeButton?.tabIndex).toBe(-1);
+  });
+
+  it('hides the close button for passive recommendations', () => {
+    const onDismiss = vi.fn();
+    overlay.dispose();
+    timelineHarness.dispose();
+    preference.dispose();
+    timelineHarness = new TimelineHarness();
+    preference = createPreference();
+    overlay = new PoiTooltipOverlay({
+      container,
+      onDismiss,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+    });
+
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__close'
+    );
+    expect(root.dataset.state).toBe('recommended');
+    expect(closeButton?.hidden).toBe(true);
+    expect(closeButton?.disabled).toBe(true);
+    expect(closeButton?.tabIndex).toBe(-1);
   });
 
   it('can hide after dismiss clears selected state through the public API', () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1514,6 +1514,16 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   right: 1rem;
   max-width: none;
   width: auto;
+  max-height: min(24rem, calc(100vh - 7rem - var(--hud-mobile-safe-zone)));
+  overflow-y: auto;
+}
+
+:root[data-hud-layout='mobile'] .poi-tooltip-overlay__heading-row {
+  align-items: flex-start;
+}
+
+:root[data-hud-layout='mobile'] .poi-tooltip-overlay__close {
+  margin-block-start: -0.2rem;
 }
 
 :root[data-accessibility-motion='reduced'] .audio-hud,
@@ -1526,6 +1536,7 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .overlay__popover,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close,
 :root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay__close,
 :root[data-accessibility-motion='reduced'] .accessibility-presets {
   transition: none !important;
   animation: none !important;
@@ -1536,6 +1547,9 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .overlay__popover-close:hover,
 :root[data-accessibility-motion='reduced']
   .overlay__popover-close:focus-visible,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay__close:hover,
+:root[data-accessibility-motion='reduced']
+  .poi-tooltip-overlay__close:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__menu-button:active {
   transform: none;
 }
@@ -1874,6 +1888,43 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   display: flex;
   align-items: center;
   gap: 0.6rem;
+}
+
+.poi-tooltip-overlay__close {
+  appearance: none;
+  margin: -0.35rem -0.55rem -0.35rem auto;
+  width: 1.85rem;
+  height: 1.85rem;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(143, 214, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(9, 18, 33, 0.62);
+  color: rgba(222, 245, 255, 0.92);
+  font: inherit;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease,
+    transform 120ms ease;
+}
+
+.poi-tooltip-overlay__close:hover,
+.poi-tooltip-overlay__close:focus-visible {
+  border-color: rgba(212, 242, 255, 0.7);
+  background: rgba(61, 201, 255, 0.18);
+  color: #ffffff;
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.poi-tooltip-overlay__close:focus-visible {
+  box-shadow: 0 0 0 3px rgba(143, 214, 255, 0.55);
 }
 
 .poi-tooltip-overlay__title {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1862,11 +1862,13 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   border: 1px solid var(--hud-surface-border);
   backdrop-filter: blur(16px);
   opacity: 0;
+  visibility: hidden;
   transform: translateY(12px);
   pointer-events: none;
   transition:
     opacity 160ms ease,
-    transform 180ms ease;
+    transform 180ms ease,
+    visibility 0s linear 180ms;
   z-index: 30;
 }
 
@@ -1880,8 +1882,10 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 
 .poi-tooltip-overlay--visible {
   opacity: 1;
+  visibility: visible;
   transform: translateY(0);
   pointer-events: auto;
+  transition-delay: 0s;
 }
 
 .poi-tooltip-overlay__heading-row {


### PR DESCRIPTION
### Motivation
- Make rich POI detail tooltips intentional on mobile so hover/idle doesn’t surface large cards unexpectedly.
- Ensure only one top-right HUD panel (Controls, Settings, or POI detail) is visible at a time and opening a HUD panel dismisses POI detail.
- Provide an accessible, keyboard-focusable close affordance and a programmatic API to clear POI selection/hover for coordinated dismiss behavior.

### Description
- Add a compact, keyboard-focusable close button to the POI overlay and surface an optional `onDismiss` callback in `PoiTooltipOverlayOptions` so callers can react when the overlay is dismissed (`src/scene/poi/tooltipOverlay.ts`).
- Add public `clearSelection()` and `clearHover()` methods to `PoiInteractionManager` that clear state and notify selection/hover listeners consistent with existing analytics hooks (`src/scene/poi/interactionManager.ts`).
- Wire overlay dismissal and mobile-intent semantics in the scene bootstrap (`src/main.ts`): track current hovered/selected POI, only show hover previews on non-mobile layouts, require explicit selection/tap to show full details on mobile, close HUD panels on POI selection, dismiss POI detail when opening a HUD panel, and handle Escape to dismiss POI detail first.
- Style the close button and constrain the mobile overlay to fit the viewport while preserving reduced-motion behavior (`src/ui/styles.css`).
- Add focused unit tests covering the close-button dismiss callback, selected-only rendering, and that `clearSelection()` notifies listeners (`src/tests/poiTooltipOverlay.test.ts`, `src/tests/poiInteractionManager.test.ts`).

### Testing
- Ran formatting: `npm run format:write` — passed.
- Lint: `npm run lint` — passed.
- Typecheck: `npm run typecheck` — failed due to pre-existing, repo-wide TypeScript issues unrelated to this change (reported missing imports/typing errors outside the touched files).
- Focused unit tests: `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts src/tests/poiInteractionManager.test.ts` — passed (both test files green).
- Full test suite: `npm run test:ci` — passed (all tests in repo ran green in this environment).
- Build: `npm run build` — passed (production build produced dist artifacts).
- Docs check & smoke: `npm run docs:check` and `npm run smoke` — passed.
- Playwright screenshot: `npm run screenshot -- playwright/screenshot.spec.ts` — failed in this environment because Playwright browsers are not installed (run `npx playwright install` to provision browsers in CI/local runner).
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — passed (no high-risk secrets detected).

Residual notes and follow-ups: typecheck failures are pre-existing and not introduced by this PR; Playwright E2E screenshot is blocked in this environment by missing browser binaries and should be rerun in CI where browsers are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df576edc4832fbcf60d4d96e48a1d)