### PR TITLE
Add POI dismiss UX and mobile intentional-tap semantics

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1532,9 +1532,13 @@ function initializeImmersiveScene(
 
   const poiAnalytics = createWindowPoiAnalytics();
   const interactionTimeline = new InteractionTimeline();
+  let dismissActivePoiDetail: (options?: {
+    closeHudPanels?: boolean;
+  }) => void = () => {};
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    onDismiss: () => dismissActivePoiDetail({ closeHudPanels: true }),
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
   const updatePassivePoiRecommendationPolicy = (layoutOverride?: HudLayout) => {
@@ -2000,15 +2004,49 @@ function initializeImmersiveScene(
     poiInstances,
     poiAnalytics
   );
+  dismissActivePoiDetail = ({ closeHudPanels = false } = {}) => {
+    poiInteractionManager.clearSelection();
+    poiInteractionManager.clearHover();
+    poiTooltipOverlay.setSelected(null);
+    poiTooltipOverlay.setHovered(null);
+    poiWorldTooltip.setSelected(null);
+    poiWorldTooltip.setHovered(null);
+    poiWorldTooltip.update(0);
+    if (closeHudPanels) {
+      hudPanelCoordinator?.closeAllPanels();
+    }
+  };
   const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
-    poiTooltipOverlay.setHovered(poi);
-    poiWorldTooltip.setHovered(resolveWorldTooltipTarget(poi));
+    const activeHudPanel = hudPanelCoordinator?.getActivePanel() ?? null;
+    const isMobileLayout = hudLayoutManager?.getLayout() === 'mobile';
+    poiTooltipOverlay.setHovered(
+      activeHudPanel === null && !isMobileLayout ? poi : null
+    );
+    poiWorldTooltip.setHovered(
+      activeHudPanel === null ? resolveWorldTooltipTarget(poi) : null
+    );
   });
   const removeSelectionStateListener =
     poiInteractionManager.addSelectionStateListener((poi, context) => {
+      if (poi) {
+        hudPanelCoordinator?.closeAllPanels();
+      }
       poiTooltipOverlay.setSelected(poi, context);
       poiWorldTooltip.setSelected(resolveWorldTooltipTarget(poi));
     });
+  const handlePoiDetailKeydown = (event: KeyboardEvent) => {
+    if (event.key !== 'Escape' || event.defaultPrevented) {
+      return;
+    }
+    if (!poiTooltipOverlay.getState().visible) {
+      return;
+    }
+    event.preventDefault();
+    dismissActivePoiDetail();
+  };
+  document.addEventListener('keydown', handlePoiDetailKeydown, {
+    capture: true,
+  });
   const removeSelectionListener = poiInteractionManager.addSelectionListener(
     (poi) => {
       idleMonitor?.reportActivity();
@@ -2714,7 +2752,12 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
-    onActivePanelChange: () => updatePassivePoiRecommendationPolicy(),
+    onActivePanelChange: (panel) => {
+      if (panel !== null) {
+        dismissActivePoiDetail();
+      }
+      updatePassivePoiRecommendationPolicy();
+    },
   });
   let interactablePoi: PoiInstance | null = null;
 
@@ -3321,6 +3364,9 @@ function initializeImmersiveScene(
     windowTarget: window,
     onLayoutChange: (layout) => {
       responsiveControlOverlay?.setLayout(layout);
+      if (layout === 'mobile') {
+        poiTooltipOverlay.setHovered(null);
+      }
       updatePassivePoiRecommendationPolicy(layout);
     },
   });
@@ -4244,6 +4290,9 @@ function initializeImmersiveScene(
       hudLayoutManager = null;
     }
     window.removeEventListener('keydown', handleControlsKeydown);
+    document.removeEventListener('keydown', handlePoiDetailKeydown, {
+      capture: true,
+    });
     if (hudPanelCoordinator) {
       hudPanelCoordinator.dispose();
       hudPanelCoordinator = null;

--- a/src/scene/poi/interactionManager.ts
+++ b/src/scene/poi/interactionManager.ts
@@ -156,6 +156,16 @@ export class PoiInteractionManager {
     };
   }
 
+  clearSelection(
+    inputMethod: PoiSelectionInputMethod = this.lastSelectionInput
+  ): void {
+    this.setSelected(null, inputMethod);
+  }
+
+  clearHover(inputMethod: PoiSelectionInputMethod = this.lastHoverInput): void {
+    this.setHovered(null, inputMethod);
+  }
+
   selectPoiById(poiId: string): void {
     const poi = this.poiInstances.find(
       (instance) => instance.definition.id === poiId

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -11,6 +11,7 @@ type DiscoveryFormatter = (poi: PoiDefinition) => string;
 
 export interface PoiTooltipOverlayOptions {
   container: HTMLElement;
+  onDismiss?: () => void;
   discoveryAnnouncer?: {
     format?: DiscoveryFormatter;
     politeness?: 'polite' | 'assertive';
@@ -36,6 +37,7 @@ export class PoiTooltipOverlay {
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
   private readonly recommendationBadge: HTMLSpanElement;
+  private readonly dismissButton: HTMLButtonElement;
   private readonly liveRegion: HTMLElement;
   private readonly interactionTimeline: InteractionTimeline | null;
   private readonly guidedTourPreference: GuidedTourPreference;
@@ -53,10 +55,12 @@ export class PoiTooltipOverlay {
   private isIdle = false;
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
+  private readonly onDismiss: (() => void) | null;
 
   constructor(options: PoiTooltipOverlayOptions) {
     const {
       container,
+      onDismiss,
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
@@ -67,6 +71,7 @@ export class PoiTooltipOverlay {
     this.discoveryFormatter =
       discoveryAnnouncer?.format ?? defaultDiscoveryFormatter;
     this.interactionTimeline = interactionTimeline ?? null;
+    this.onDismiss = onDismiss ?? null;
     this.guidedTourPreference = guidedTourPreference;
     this.instanceId = generateTooltipInstanceId();
 
@@ -78,6 +83,8 @@ export class PoiTooltipOverlay {
     this.root.setAttribute('aria-labelledby', `${this.instanceId}-title`);
     this.root.setAttribute('aria-hidden', 'true');
     this.root.tabIndex = -1;
+
+    this.handleDismissClick = this.handleDismissClick.bind(this);
 
     const headingRow = documentTarget.createElement('div');
     headingRow.className = 'poi-tooltip-overlay__heading-row';
@@ -104,6 +111,14 @@ export class PoiTooltipOverlay {
     this.recommendationBadge.textContent = 'Next highlight';
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
+
+    this.dismissButton = documentTarget.createElement('button');
+    this.dismissButton.type = 'button';
+    this.dismissButton.className = 'poi-tooltip-overlay__dismiss';
+    this.dismissButton.setAttribute('aria-label', 'Close POI details');
+    this.dismissButton.textContent = '×';
+    this.dismissButton.addEventListener('click', this.handleDismissClick);
+    headingRow.appendChild(this.dismissButton);
 
     this.summary = documentTarget.createElement('p');
     this.summary.className = 'poi-tooltip-overlay__summary';
@@ -225,12 +240,17 @@ export class PoiTooltipOverlay {
   }
 
   dispose() {
+    this.dismissButton.removeEventListener('click', this.handleDismissClick);
     this.root.remove();
     this.liveRegion.remove();
     if (this.unsubscribeGuidedTour) {
       this.unsubscribeGuidedTour();
       this.unsubscribeGuidedTour = null;
     }
+  }
+
+  private handleDismissClick() {
+    this.onDismiss?.();
   }
 
   private update() {

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -519,6 +519,35 @@ describe('PoiInteractionManager', () => {
     });
   });
 
+  it('clearSelection notifies state listeners and analytics with null state', () => {
+    const selectionCleared = vi.fn();
+    manager.dispose();
+    manager = new PoiInteractionManager(
+      domElement,
+      camera,
+      [poi],
+      {},
+      { selectionCleared }
+    );
+    manager.start();
+    const selectionState = vi.fn();
+    manager.addSelectionStateListener(selectionState);
+
+    domElement.dispatchEvent(
+      new MouseEvent('click', { clientX: 200, clientY: 200 })
+    );
+    expect(selectionState).toHaveBeenLastCalledWith(definition, {
+      inputMethod: 'pointer',
+    });
+
+    manager.clearSelection();
+
+    expect(selectionState).toHaveBeenLastCalledWith(null, {
+      inputMethod: 'pointer',
+    });
+    expect(selectionCleared).toHaveBeenCalledWith(definition);
+  });
+
   it('ignores keyboard input when disabled', () => {
     const disabledManager = new PoiInteractionManager(
       domElement,

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PoiTooltipOverlay } from '../scene/poi/tooltipOverlay';
 import type { PoiDefinition } from '../scene/poi/types';
@@ -223,6 +223,49 @@ describe('PoiTooltipOverlay', () => {
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
     expect(root.getAttribute('aria-hidden')).toBe('true');
     expect(root.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('renders selected POI details with a focusable dismiss button', () => {
+    overlay.setSelected(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const dismissButton = root.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__dismiss'
+    );
+
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      basePoi.title
+    );
+    expect(dismissButton).toBeTruthy();
+    expect(dismissButton?.type).toBe('button');
+    expect(dismissButton?.getAttribute('aria-label')).toBe('Close POI details');
+    dismissButton?.focus();
+    expect(document.activeElement).toBe(dismissButton);
+  });
+
+  it('emits a dismiss callback from the close button', () => {
+    const onDismiss = vi.fn();
+    overlay.dispose();
+    timelineHarness.dispose();
+    preference.dispose();
+    timelineHarness = new TimelineHarness();
+    preference = createPreference();
+    overlay = new PoiTooltipOverlay({
+      container,
+      onDismiss,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+    });
+
+    overlay.setSelected(basePoi);
+    const dismissButton = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__dismiss'
+    );
+
+    dismissButton?.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes metric values when notified about updates', () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1509,11 +1509,13 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 }
 
 :root[data-hud-layout='mobile'] .poi-tooltip-overlay {
-  bottom: calc(var(--hud-mobile-safe-zone) + 1rem);
-  left: 1rem;
-  right: 1rem;
+  bottom: calc(var(--hud-mobile-safe-zone) + 0.75rem);
+  left: 0.75rem;
+  right: 0.75rem;
   max-width: none;
+  max-height: min(22rem, calc(100vh - 7.5rem - var(--hud-mobile-safe-zone)));
   width: auto;
+  overflow: auto;
 }
 
 :root[data-accessibility-motion='reduced'] .audio-hud,
@@ -1536,6 +1538,9 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .overlay__popover-close:hover,
 :root[data-accessibility-motion='reduced']
   .overlay__popover-close:focus-visible,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay__dismiss:hover,
+:root[data-accessibility-motion='reduced']
+  .poi-tooltip-overlay__dismiss:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__menu-button:active {
   transform: none;
 }
@@ -1876,7 +1881,40 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   gap: 0.6rem;
 }
 
+.poi-tooltip-overlay__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.85rem;
+  height: 1.85rem;
+  margin-left: auto;
+  border-radius: 999px;
+  border: 1px solid rgba(154, 221, 255, 0.32);
+  background: rgba(8, 18, 34, 0.72);
+  color: rgba(234, 249, 255, 0.94);
+  font: inherit;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease,
+    transform 120ms ease;
+}
+
+.poi-tooltip-overlay__dismiss:hover,
+.poi-tooltip-overlay__dismiss:focus-visible {
+  background: rgba(27, 55, 87, 0.9);
+  border-color: rgba(212, 242, 255, 0.72);
+  color: #ffffff;
+  outline: none;
+  transform: translateY(-1px);
+}
+
 .poi-tooltip-overlay__title {
+  min-width: 0;
   margin: 0;
   font-size: 1.15rem;
   letter-spacing: 0.01em;


### PR DESCRIPTION
### Motivation
- Make rich POI detail overlays intentional on touch devices and dismissible across input modes so they don't compete with the HUD panels. 
- Ensure a single visible HUD surface at a time by clearing POI state when Controls/Settings open or when users explicitly dismiss POI details.

### Description
- Added an accessible, keyboard-focusable close button and optional `onDismiss` callback to `PoiTooltipOverlay` to allow explicit dismissal from the overlay UI. (see `src/scene/poi/tooltipOverlay.ts`)
- Added public `clearSelection()` and `clearHover()` APIs to `PoiInteractionManager` that reuse existing selection/hover clearing paths and preserve analytics hooks. (see `src/scene/poi/interactionManager.ts`)
- Wired dismiss behavior and mobile semantics in the immersive scene (`src/main.ts`) so that: selecting a POI closes Controls/Settings; opening a HUD panel dismisses the POI detail; the overlay dismiss (close button, Escape) clears selection/hover and hides both 2D overlay and in-world tooltip; mobile layout suppresses hover-only overlay updates so rich detail only appears on deliberate taps. 
- Updated overlay styling to add a compact close affordance and to constrain/scroll the overlay on mobile so it doesn't overlap the top-right HUD. (see `src/ui/styles.css`)
- Added unit tests for overlay dismiss and interaction-manager clearing behavior. (see `src/tests/poiTooltipOverlay.test.ts`, `src/tests/poiInteractionManager.test.ts`)

### Testing
- `npm run format:write` — ran (success).
- `npm run lint` — ran (success).
- `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts` — ran (20 tests passed).
- `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts src/tests/poiInteractionManager.test.ts` — ran (34 tests passed across the two files).
- `npm run test:ci` — ran (full suite; 913 tests passed in this environment).
- `npm run build` — ran (production build succeeded; dist produced).
- `npm run docs:check && npm run smoke` — ran (docs check and smoke/build validations passed).
- `git diff --cached | ./scripts/scan-secrets.py` — ran (no high-risk secrets detected).

Notes / residual risks
- `npm run typecheck` failed in this environment due to unrelated repo-wide TypeScript baseline errors (existing PoiId/string mismatches and a few missing type imports); these failures are outside the scope of this change and were present when the repo was previously built here.
- Playwright screenshot / e2e capture attempted in CI-like preview failed here because Playwright browsers are not installed in this environment (`npx playwright install` would be required); all unit tests and smoke checks ran successfully.

Files changed (high level)
- src/scene/poi/tooltipOverlay.ts — close button + `onDismiss` wiring and cleanup.
- src/scene/poi/interactionManager.ts — `clearSelection()` and `clearHover()` methods.
- src/main.ts — HUD coordination, mobile hover suppression, overlay dismiss wiring, Escape handling.
- src/ui/styles.css — close button styling and mobile overlay constraints.
- src/tests/poiTooltipOverlay.test.ts, src/tests/poiInteractionManager.test.ts — added/updated tests for new behaviors.

How to verify locally
- Run the repository quality gates:
  - `npm run format:write`
  - `npm run lint`
  - `npm run test:ci`
  - `npm run docs:check`
  - `npm run smoke`
- Optional: to verify Playwright e2e / mobile flows, run `npx playwright install` then `npm run test:e2e` or the relevant Playwright spec targeting mobile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df576edc4832fbcf60d4d96e48a1d)