### PR TITLE
Make POI details dismissible and intentional on mobile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1532,11 +1532,48 @@ function initializeImmersiveScene(
 
   const poiAnalytics = createWindowPoiAnalytics();
   const interactionTimeline = new InteractionTimeline();
+  let poiInteractionManager: PoiInteractionManager | null = null;
+  let currentPoiHover: PoiDefinition | null = null;
+  let currentPoiSelection: PoiDefinition | null = null;
+  const shouldShowPoiHoverPreview = () =>
+    hudLayoutManager?.getLayout() !== 'mobile' &&
+    (hudPanelCoordinator?.getActivePanel() ?? null) === null;
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    onDismiss: () => {
+      dismissPoiDetail();
+    },
   });
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const syncPoiTooltipHoverPreview = () => {
+    poiTooltipOverlay.setHovered(
+      shouldShowPoiHoverPreview() ? currentPoiHover : null
+    );
+  };
+  const dismissPoiDetail = ({
+    closeHudPanels = true,
+  }: { closeHudPanels?: boolean } = {}) => {
+    const selectedPoiId = currentPoiSelection?.id ?? null;
+    const hoveredPoiId = currentPoiHover?.id ?? null;
+    poiInteractionManager?.clearSelection();
+    poiInteractionManager?.clearHover();
+    currentPoiSelection = null;
+    currentPoiHover = null;
+    poiTooltipOverlay.setSelected(null);
+    poiTooltipOverlay.setHovered(null);
+    if (
+      selectedPoiId === null ||
+      hoveredPoiId === null ||
+      selectedPoiId === hoveredPoiId
+    ) {
+      poiWorldTooltip.setSelected(null);
+      poiWorldTooltip.setHovered(null);
+    }
+    if (closeHudPanels) {
+      hudPanelCoordinator?.closeAllPanels();
+    }
+  };
   const updatePassivePoiRecommendationPolicy = (layoutOverride?: HudLayout) => {
     const activeHudPanel = hudPanelCoordinator?.getActivePanel() ?? null;
     const hudLayout = layoutOverride ?? hudLayoutManager?.getLayout();
@@ -1994,18 +2031,23 @@ function initializeImmersiveScene(
     woveLoom = loom;
   }
 
-  const poiInteractionManager = new PoiInteractionManager(
+  poiInteractionManager = new PoiInteractionManager(
     renderer.domElement,
     camera,
     poiInstances,
     poiAnalytics
   );
   const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
-    poiTooltipOverlay.setHovered(poi);
+    currentPoiHover = poi;
+    syncPoiTooltipHoverPreview();
     poiWorldTooltip.setHovered(resolveWorldTooltipTarget(poi));
   });
   const removeSelectionStateListener =
     poiInteractionManager.addSelectionStateListener((poi, context) => {
+      currentPoiSelection = poi;
+      if (poi) {
+        hudPanelCoordinator?.closeAllPanels();
+      }
       poiTooltipOverlay.setSelected(poi, context);
       poiWorldTooltip.setSelected(resolveWorldTooltipTarget(poi));
     });
@@ -2678,6 +2720,22 @@ function initializeImmersiveScene(
           .some((binding) => normalizeBindingKey(binding) === normalizedKey)
     );
   };
+  const handlePoiDismissKeydown = (event: KeyboardEvent) => {
+    if (
+      event.key !== 'Escape' ||
+      event.defaultPrevented ||
+      !poiTooltipOverlay.getState().visible
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    dismissPoiDetail();
+  };
+  window.addEventListener('keydown', handlePoiDismissKeydown, {
+    capture: true,
+  });
+
   const handleControlsKeydown = (event: KeyboardEvent) => {
     if (event.defaultPrevented || event.repeat) {
       return;
@@ -2714,7 +2772,12 @@ function initializeImmersiveScene(
     settingsButton: helpButton,
     textButton: textModeButton,
     onTextMode: activateTextMode,
-    onActivePanelChange: () => updatePassivePoiRecommendationPolicy(),
+    onActivePanelChange: (panel) => {
+      if (panel !== null) {
+        dismissPoiDetail({ closeHudPanels: false });
+      }
+      updatePassivePoiRecommendationPolicy();
+    },
   });
   let interactablePoi: PoiInstance | null = null;
 
@@ -3322,6 +3385,7 @@ function initializeImmersiveScene(
     onLayoutChange: (layout) => {
       responsiveControlOverlay?.setLayout(layout);
       updatePassivePoiRecommendationPolicy(layout);
+      syncPoiTooltipHoverPreview();
     },
   });
   if (hudLayoutManager) {
@@ -4110,7 +4174,7 @@ function initializeImmersiveScene(
     const pressed = keyBindings.isActionActive('interact', keyPressSource);
     if (pressed && !interactKeyWasPressed && interactablePoi) {
       idleMonitor?.reportActivity();
-      poiInteractionManager.selectPoiById(interactablePoi.definition.id);
+      poiInteractionManager?.selectPoiById(interactablePoi.definition.id);
     }
     interactKeyWasPressed = pressed;
   }
@@ -4157,7 +4221,7 @@ function initializeImmersiveScene(
       avatarFootIkController.dispose();
       avatarFootIkController = null;
     }
-    poiInteractionManager.dispose();
+    poiInteractionManager?.dispose();
     removeHoverListener();
     removeSelectionStateListener();
     removeSelectionListener();
@@ -4243,6 +4307,9 @@ function initializeImmersiveScene(
       hudLayoutManager.dispose();
       hudLayoutManager = null;
     }
+    window.removeEventListener('keydown', handlePoiDismissKeydown, {
+      capture: true,
+    });
     window.removeEventListener('keydown', handleControlsKeydown);
     if (hudPanelCoordinator) {
       hudPanelCoordinator.dispose();

--- a/src/scene/poi/interactionManager.ts
+++ b/src/scene/poi/interactionManager.ts
@@ -156,6 +156,16 @@ export class PoiInteractionManager {
     };
   }
 
+  clearSelection(
+    inputMethod: PoiSelectionInputMethod = this.lastSelectionInput
+  ): void {
+    this.setSelected(null, inputMethod);
+  }
+
+  clearHover(inputMethod: PoiSelectionInputMethod = this.lastHoverInput): void {
+    this.setHovered(null, inputMethod);
+  }
+
   selectPoiById(poiId: string): void {
     const poi = this.poiInstances.find(
       (instance) => instance.definition.id === poiId

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -17,6 +17,7 @@ export interface PoiTooltipOverlayOptions {
   };
   interactionTimeline?: InteractionTimeline;
   guidedTourPreference?: GuidedTourPreference;
+  onDismiss?: () => void;
 }
 
 interface RenderState {
@@ -36,6 +37,7 @@ export class PoiTooltipOverlay {
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
   private readonly recommendationBadge: HTMLSpanElement;
+  private readonly closeButton: HTMLButtonElement;
   private readonly liveRegion: HTMLElement;
   private readonly interactionTimeline: InteractionTimeline | null;
   private readonly guidedTourPreference: GuidedTourPreference;
@@ -60,6 +62,7 @@ export class PoiTooltipOverlay {
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
+      onDismiss,
     } = options;
     const documentTarget = container.ownerDocument ?? document;
 
@@ -104,6 +107,16 @@ export class PoiTooltipOverlay {
     this.recommendationBadge.textContent = 'Next highlight';
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
+
+    this.closeButton = documentTarget.createElement('button');
+    this.closeButton.type = 'button';
+    this.closeButton.className = 'poi-tooltip-overlay__close';
+    this.closeButton.setAttribute('aria-label', 'Close POI details');
+    this.closeButton.textContent = '×';
+    this.closeButton.addEventListener('click', () => {
+      onDismiss?.();
+    });
+    headingRow.appendChild(this.closeButton);
 
     this.summary = documentTarget.createElement('p');
     this.summary.className = 'poi-tooltip-overlay__summary';

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -519,6 +519,35 @@ describe('PoiInteractionManager', () => {
     });
   });
 
+  it('clears selection through the public API and notifies listeners with null', () => {
+    const selectionState = vi.fn();
+    const selectionCleared = vi.fn();
+    manager.dispose();
+    manager = new PoiInteractionManager(
+      domElement,
+      camera,
+      [poi],
+      {},
+      { selectionCleared }
+    );
+    manager.addSelectionStateListener(selectionState);
+    manager.start();
+
+    domElement.dispatchEvent(
+      new MouseEvent('click', { clientX: 200, clientY: 200 })
+    );
+    expect(selectionState).toHaveBeenLastCalledWith(definition, {
+      inputMethod: 'pointer',
+    });
+
+    manager.clearSelection('keyboard');
+
+    expect(selectionState).toHaveBeenLastCalledWith(null, {
+      inputMethod: 'keyboard',
+    });
+    expect(selectionCleared).toHaveBeenCalledWith(definition);
+  });
+
   it('ignores keyboard input when disabled', () => {
     const disabledManager = new PoiInteractionManager(
       domElement,

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PoiTooltipOverlay } from '../scene/poi/tooltipOverlay';
 import type { PoiDefinition } from '../scene/poi/types';
@@ -223,6 +223,62 @@ describe('PoiTooltipOverlay', () => {
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
     expect(root.getAttribute('aria-hidden')).toBe('true');
     expect(root.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('emits a dismiss callback from the focusable close button', () => {
+    const onDismiss = vi.fn();
+    overlay.dispose();
+    timelineHarness.dispose();
+    preference.dispose();
+    timelineHarness = new TimelineHarness();
+    preference = createPreference();
+    overlay = new PoiTooltipOverlay({
+      container,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+      onDismiss,
+    });
+
+    overlay.setSelected(basePoi);
+
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '.poi-tooltip-overlay__close'
+    );
+    expect(closeButton).toBeTruthy();
+    expect(closeButton?.tagName).toBe('BUTTON');
+    expect(closeButton?.getAttribute('aria-label')).toBe('Close POI details');
+    expect(closeButton?.tabIndex).toBe(0);
+
+    closeButton?.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('can hide selected POI details after a dismiss callback clears state', () => {
+    const onDismiss = vi.fn(() => overlay.setSelected(null));
+    overlay.dispose();
+    timelineHarness.dispose();
+    preference.dispose();
+    timelineHarness = new TimelineHarness();
+    preference = createPreference();
+    overlay = new PoiTooltipOverlay({
+      container,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+      onDismiss,
+    });
+
+    overlay.setSelected(basePoi);
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+
+    container
+      .querySelector<HTMLButtonElement>('.poi-tooltip-overlay__close')
+      ?.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.getAttribute('aria-hidden')).toBe('true');
   });
 
   it('refreshes metric values when notified about updates', () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1509,11 +1509,15 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 }
 
 :root[data-hud-layout='mobile'] .poi-tooltip-overlay {
+  top: auto;
   bottom: calc(var(--hud-mobile-safe-zone) + 1rem);
-  left: 1rem;
-  right: 1rem;
+  left: max(0.75rem, env(safe-area-inset-left, 0px));
+  right: max(0.75rem, env(safe-area-inset-right, 0px));
   max-width: none;
+  max-height: min(52vh, calc(100vh - var(--hud-mobile-safe-zone) - 6rem));
   width: auto;
+  overflow: auto;
+  padding: 0.9rem 1rem;
 }
 
 :root[data-accessibility-motion='reduced'] .audio-hud,
@@ -1526,6 +1530,7 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .overlay__popover,
 :root[data-accessibility-motion='reduced'] .overlay__popover-close,
 :root[data-accessibility-motion='reduced'] .poi-tooltip-overlay,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay__close,
 :root[data-accessibility-motion='reduced'] .accessibility-presets {
   transition: none !important;
   animation: none !important;
@@ -1536,6 +1541,9 @@ html[data-hud-layout='mobile'] .audio-subtitles {
 :root[data-accessibility-motion='reduced'] .overlay__popover-close:hover,
 :root[data-accessibility-motion='reduced']
   .overlay__popover-close:focus-visible,
+:root[data-accessibility-motion='reduced'] .poi-tooltip-overlay__close:hover,
+:root[data-accessibility-motion='reduced']
+  .poi-tooltip-overlay__close:focus-visible,
 :root[data-accessibility-motion='reduced'] .overlay__menu-button:active {
   transform: none;
 }
@@ -1874,6 +1882,38 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   display: flex;
   align-items: center;
   gap: 0.6rem;
+}
+
+.poi-tooltip-overlay__close {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.85rem;
+  min-height: 1.85rem;
+  margin-left: auto;
+  border: 1px solid rgba(143, 214, 255, 0.36);
+  border-radius: 999px;
+  background: rgba(8, 19, 34, 0.72);
+  color: rgba(232, 248, 255, 0.94);
+  font: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease,
+    transform 120ms ease;
+}
+
+.poi-tooltip-overlay__close:hover,
+.poi-tooltip-overlay__close:focus-visible {
+  border-color: rgba(255, 219, 142, 0.72);
+  background: rgba(255, 205, 94, 0.18);
+  color: #fff7db;
+  outline: none;
+  transform: translateY(-1px);
 }
 
 .poi-tooltip-overlay__title {


### PR DESCRIPTION
### Motivation
- Make rich POI detail overlays intentional and dismissible, reducing accidental mobile hover/preview noise.
- Ensure POI detail, Controls, and Settings are mutually exclusive so only one HUD panel is visible at a time.
- Provide an accessible, keyboard-focusable close affordance and consistent selection-clearing API for POI interactions.

### Description
- Add a compact, keyboard-focusable close button and `onDismiss` option to `PoiTooltipOverlay` and wire its click to call the dismiss handler.
- Add public `clearSelection()` and `clearHover()` methods to `PoiInteractionManager` which reuse existing selection/hover lifecycle and analytics behavior.
- Wire dismissal and mobile/desktop semantics in `main.ts`: the overlay close button, `Escape` (capture), and opening other HUD panels dismiss POI detail; mobile hover previews are gated so rich 2D overlay only shows for intentional selection/tap.
- Update mobile overlay sizing and add `.poi-tooltip-overlay__close` CSS for a compact accessible close button; update unit tests to cover dismiss callback and public selection clearing.

### Testing
- Ran formatting: `npm run format:write` (passed).
- Lint: `npm run lint` (passed).
- Typecheck: `npm run typecheck` (passed in final verification; intermittent unrelated repo type errors were observed earlier during iteration but resolved for this change).
- Focused unit tests: `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts` and `npm run test:ci -- src/tests/poiInteractionManager.test.ts` (both passed).
- Full test suite: `npm run test:ci` (passed; 913 tests across suite in CI run reported passing).
- Build: `npm run build` (passed).
- Docs check: `npm run docs:check` (passed).
- Smoke: `npm run smoke` (passed).
- Playwright screenshot: `npm run screenshot -- screenshot.spec.ts` was attempted but blocked in this environment because Playwright browsers were not installed (error: run `npx playwright install`).
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).

Residual risks & follow-ups: Playwright e2e/screenshot requires `npx playwright install` in CI to run visual checks; no runtime dependencies were added; behavior change is scoped to POI overlay/interaction wiring and tests were added to validate dismissal and public API semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df576edc4832fbcf60d4d96e48a1d)