### PR TITLE
Align danielsmith.io with Sugarkube release contract

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -110,22 +110,26 @@ jobs:
           image_tag="main-${{ steps.meta.outputs.short_sha }}"
           image_ref="ghcr.io/futuroptimist/danielsmith.io:${image_tag}"
 
-          echo "Immutable image tag:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`${image_ref}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "Sugarkube deploy tag:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`${image_tag}\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            printf '%s\n' \
+              "Image tag candidate:" \
+              "\`${image_ref}\`" \
+              "Sugarkube deploy tag candidate:" \
+              "\`${image_tag}\`" \
+              "Publish behavior:"
 
-          if [ "${{ github.event_name }}" = "push" ] && \
-            [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "Publish behavior:" >> "$GITHUB_STEP_SUMMARY"
-            echo "\`main-${{ steps.meta.outputs.short_sha }}\`, \`main-latest\`, and " \
-              "\`sha-${{ steps.meta.outputs.short_sha }}\` will be published by the publish job." \
-              >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Publish behavior:" >> "$GITHUB_STEP_SUMMARY"
-            echo "\`${{ github.event_name }}\` runs build and smoke-test only; no GHCR tags are published." \
-              >> "$GITHUB_STEP_SUMMARY"
-          fi
+            if [ "${{ github.event_name }}" = "push" ] && \
+              [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              printf \
+                '`main-%s`, `main-latest`, and `sha-%s` will be published by the publish job.\n' \
+                "${{ steps.meta.outputs.short_sha }}" \
+                "${{ steps.meta.outputs.short_sha }}"
+            else
+              printf \
+                '`%s` runs build and smoke-test only; no GHCR tags are published.\n' \
+                "${{ github.event_name }}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -168,8 +172,11 @@ jobs:
 
       - name: Summarize published immutable tag
         run: |
-          echo "Published immutable image tag:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`ghcr.io/futuroptimist/danielsmith.io:main-${{ needs.build-and-smoke.outputs.short_sha }}\`" \
-            >> "$GITHUB_STEP_SUMMARY"
-          echo "Sugarkube deploy tag:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`main-${{ needs.build-and-smoke.outputs.short_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          image_tag="main-${{ needs.build-and-smoke.outputs.short_sha }}"
+          image_ref="ghcr.io/futuroptimist/danielsmith.io:${image_tag}"
+
+          printf '%s\n' \
+            "Published immutable image tag:" \
+            "\`${image_ref}\`" \
+            "Sugarkube deploy tag:" \
+            "\`${image_tag}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -103,6 +103,30 @@ jobs:
           test -n "${asset_path}"
           curl -fsS "http://127.0.0.1:8080${asset_path}" >/dev/null
 
+      - name: Summarize image build contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_tag="main-${{ steps.meta.outputs.short_sha }}"
+          image_ref="ghcr.io/futuroptimist/danielsmith.io:${image_tag}"
+
+          echo "Immutable image tag:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${image_ref}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Sugarkube deploy tag:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${image_tag}\`" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ github.event_name }}" = "push" ] && \
+            [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "Publish behavior:" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`main-${{ steps.meta.outputs.short_sha }}\`, \`main-latest\`, and " \
+              "\`sha-${{ steps.meta.outputs.short_sha }}\` will be published by the publish job." \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Publish behavior:" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`${{ github.event_name }}\` runs build and smoke-test only; no GHCR tags are published." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -147,3 +171,5 @@ jobs:
           echo "Published immutable image tag:" >> "$GITHUB_STEP_SUMMARY"
           echo "\`ghcr.io/futuroptimist/danielsmith.io:main-${{ needs.build-and-smoke.outputs.short_sha }}\`" \
             >> "$GITHUB_STEP_SUMMARY"
+          echo "Sugarkube deploy tag:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`main-${{ needs.build-and-smoke.outputs.short_sha }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   immersive links. It now accepts canonical URLs or `URL` instances and always injects
   `mode=immersive&disablePerformanceFailover=1` so manual previews keep both overrides even
   when you append debugging or UTM flags.
-- **Sugarkube deployment docs** – Static-site Sugarkube onboarding and runbooks live in
+- **Sugarkube release docs** – Copy-paste the GHCR/Helm release flow from
+  [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md). Static-site Sugarkube
+  onboarding and environment runbooks live in
   [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
   [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and
   [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,0 +1,116 @@
+# Sugarkube GHCR/Helm release runbook for danielsmith.io
+
+Use this runbook to release `danielsmith.io` to Sugarkube without local image builds. The
+application remains a static Vite/Three.js site served by nginx on port `8080`; it exposes
+`/livez` and `/healthz` and does not include any backend, database, API, queue, or compute-node
+components.
+
+## Release contract
+
+- Image repository: `ghcr.io/futuroptimist/danielsmith.io`
+- Deploy image tag: immutable `main-<shortsha>` from GitHub Actions
+- Convenience image tag: `main-latest` for rendering and ad hoc checks only
+- SHA alias: `sha-<shortsha>`
+- Helm chart: `danielsmith`
+- Helm chart reference: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Helm chart version: immutable; bump `charts/danielsmith/Chart.yaml` when chart content changes
+- Runtime: nginx static-site container listening on port `8080`
+- Health endpoints: `/livez` and `/healthz`
+
+Cloudflare DNS, tunnel, and route setup are separate from Helm deployment. Confirm those routes
+outside this app repo before expecting the public hostnames to resolve.
+
+## 1. Pick the immutable image tag
+
+1. Open the GitHub Actions workflow **Build and publish GHCR image** (`ci-image.yml`).
+2. Choose a successful run on `main` for the commit you want to release.
+3. In the workflow summary, copy the published immutable tag:
+
+   ```text
+   ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA
+   ```
+
+4. Use only the tag suffix in Sugarkube commands:
+
+   ```text
+   main-REPLACE_SHORTSHA
+   ```
+
+`pull_request` and `workflow_dispatch` runs build and smoke-test the static image but do not publish
+deployable tags. Only `push` runs on `main` publish `main-<shortsha>`, `main-latest`, and
+`sha-<shortsha>`.
+
+## 2. Confirm the chart is available
+
+1. Open the GitHub Actions workflow **Publish Helm chart** (`ci-helm.yml`).
+2. Confirm the matching `main` run validates the chart named `danielsmith`.
+3. Confirm the workflow summary reports the chart reference:
+
+   ```text
+   oci://ghcr.io/futuroptimist/charts/danielsmith
+   ```
+
+The chart publisher skips unchanged chart content when the same version already exists. If chart
+content changes and the existing version differs, bump `charts/danielsmith/Chart.yaml` before
+publishing. Manual `workflow_dispatch` chart runs validate the selected ref and publish only when
+that ref is `main`/`refs/heads/main`.
+
+## 3. Deploy staging from Sugarkube
+
+Run deployment commands from the Sugarkube repository checkout, not from this app repository.
+Replace `main-REPLACE_SHORTSHA` with the immutable tag copied from `ci-image.yml`.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic app recipes land:
+
+```bash
+just app-deploy app=danielsmith env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## 4. Validate staging
+
+```bash
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+If these fail, first check the Sugarkube release status and ingress/Cloudflare routing separately.
+Do not rebuild images locally as a release workaround; pick a known-good immutable GitHub Actions
+tag and redeploy it.
+
+## 5. Promote production
+
+After staging sign-off, promote the same immutable image tag to production from the Sugarkube
+repository checkout.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic app recipes land:
+
+```bash
+just app-promote-prod app=danielsmith tag=main-REPLACE_SHORTSHA
+```
+
+## 6. Validate production
+
+```bash
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+Redeploy or promote the previous known-good immutable `main-<shortsha>` tag from Sugarkube. Helm
+revision rollback remains available on the cluster side, but the preferred app-level rollback is to
+return to a previously published immutable GHCR image tag.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -36,7 +36,7 @@ outside this app repo before expecting the public hostnames to resolve.
    main-REPLACE_SHORTSHA
    ```
 
-`pull_request` and `workflow_dispatch` runs build and smoke-test the static image but do not publish
+`pull_request` and `workflow_dispatch` run build and smoke-test the static image but do not publish
 deployable tags. Only `push` runs on `main` publish `main-<shortsha>`, `main-latest`, and
 `sha-<shortsha>`.
 
@@ -60,16 +60,32 @@ that ref is `main`/`refs/heads/main`.
 Run deployment commands from the Sugarkube repository checkout, not from this app repository.
 Replace `main-REPLACE_SHORTSHA` with the immutable tag copied from `ci-image.yml`.
 
-Current app-specific command:
+Prerequisite: ensure the Sugarkube checkout contains `docs/apps/danielsmith.version` and the
+referenced values files under `docs/examples/` before running the helpers below. If that checkout
+uses different paths, update `version_file` and `values` to match the files present there.
+
+First install:
 
 ```bash
-just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+just helm-oci-install \
+  release=danielsmith \
+  namespace=danielsmith \
+  chart=oci://ghcr.io/futuroptimist/charts/danielsmith \
+  values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml \
+  version_file=docs/apps/danielsmith.version \
+  default_tag=main-REPLACE_SHORTSHA
 ```
 
-Future generic command after the Sugarkube generic app recipes land:
+Upgrade an existing release:
 
 ```bash
-just app-deploy app=danielsmith env=staging tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade \
+  release=danielsmith \
+  namespace=danielsmith \
+  chart=oci://ghcr.io/futuroptimist/charts/danielsmith \
+  values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml \
+  version_file=docs/apps/danielsmith.version \
+  default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## 4. Validate staging
@@ -89,16 +105,18 @@ tag and redeploy it.
 After staging sign-off, promote the same immutable image tag to production from the Sugarkube
 repository checkout.
 
-Current app-specific command:
+Use only the production values file for production promotion so production does not inherit
+dev-only settings or chart defaults. If the production release has not been installed yet, run the
+same command with `helm-oci-install` instead of `helm-oci-upgrade`.
 
 ```bash
-just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
-```
-
-Future generic command after the Sugarkube generic app recipes land:
-
-```bash
-just app-promote-prod app=danielsmith tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade \
+  release=danielsmith \
+  namespace=danielsmith \
+  chart=oci://ghcr.io/futuroptimist/charts/danielsmith \
+  values=docs/examples/danielsmith.values.prod.yaml \
+  version_file=docs/apps/danielsmith.version \
+  default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## 6. Validate production

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -60,9 +60,24 @@ that ref is `main`/`refs/heads/main`.
 Run deployment commands from the Sugarkube repository checkout, not from this app repository.
 Replace `main-REPLACE_SHORTSHA` with the immutable tag copied from `ci-image.yml`.
 
-Prerequisite: ensure the Sugarkube checkout contains `docs/apps/danielsmith.version` and the
-referenced values files under `docs/examples/` before running the helpers below. If that checkout
-uses different paths, update `version_file` and `values` to match the files present there.
+Current app-specific staging command:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Future generic staging command:
+
+```bash
+just app-deploy app=danielsmith env=staging tag=main-REPLACE_SHORTSHA
+```
+
+### Legacy staging helper fallback
+
+Older Sugarkube checkouts that do not yet include the wrapper recipes can use the explicit Helm
+OCI helper flow. Ensure the checkout contains `docs/apps/danielsmith.version` and the referenced
+values files under `docs/examples/` before running these helpers. If that checkout uses different
+paths, update `version_file` and `values` to match the files present there.
 
 First install:
 
@@ -105,9 +120,24 @@ tag and redeploy it.
 After staging sign-off, promote the same immutable image tag to production from the Sugarkube
 repository checkout.
 
-Use only the production values file for production promotion so production does not inherit
-dev-only settings or chart defaults. If the production release has not been installed yet, run the
-same command with `helm-oci-install` instead of `helm-oci-upgrade`.
+Current app-specific production promotion command:
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+```
+
+Future generic production promotion command:
+
+```bash
+just app-promote-prod app=danielsmith tag=main-REPLACE_SHORTSHA
+```
+
+### Legacy production helper fallback
+
+Older Sugarkube checkouts that do not yet include the promotion wrapper recipes can use the
+explicit Helm OCI helper flow. Use only the production values file for production promotion so
+production does not inherit dev-only settings or chart defaults. If the production release has not
+been installed yet, run the same command with `helm-oci-install` instead of `helm-oci-upgrade`.
 
 ```bash
 just helm-oci-upgrade \


### PR DESCRIPTION
### Motivation
- Make releasing `danielsmith.io` to Sugarkube obvious and reproducible by documenting the GHCR/OCI Helm contract and avoiding ad-hoc local Docker rebuilds.
- Surface the immutable `main-<shortsha>` tag produced by CI so operators can deploy the exact image published by GitHub Actions.

### Description
- Add `docs/ops/sugarkube-release.md` containing copy-pasteable release steps, immutable tag guidance, chart ref `oci://ghcr.io/futuroptimist/charts/danielsmith`, staging/prod commands, validation curls, and rollback notes.
- Update `.github/workflows/ci-image.yml` to append a `Summarize image build contract` step that prints the immutable image ref, the Sugarkube deploy tag, and publish behavior to the workflow summary for every build.
- Extend the `publish` job summary to also print the `Sugarkube deploy tag` after publishing on `main`.
- Link the new release runbook from `README.md` alongside the existing Sugarkube onboarding/runbooks.

### Testing
- Ran formatting with `npm run format:write` and checked `git diff --check`, both passed.
- Installed dependencies with `npm ci` and ran repo checks with `npm run check`, which executed `npm run lint`, `npm run test:ci`, and `npm run docs:check` and completed successfully.
- Built and validated the production bundle with `npm run smoke`, which succeeded and reported valid `dist/` references.
- Installed Helm and ran `helm lint charts/danielsmith` and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee >/tmp/danielsmith-render.yaml`, both of which succeeded.
- Verified docs/searchability with `grep -R "app-deploy app=danielsmith" docs README.md` and `grep -R "docker build" docs README.md || true`, and ran `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb037e50832f8860c3b6d8d5b3bf)