### PR TITLE
🚀 : – Align Sugarkube release contract

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -103,6 +103,26 @@ jobs:
           test -n "${asset_path}"
           curl -fsS "http://127.0.0.1:8080${asset_path}" >/dev/null
 
+      - name: Summarize image contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          immutable_tag="ghcr.io/futuroptimist/danielsmith.io:main-${{ steps.meta.outputs.short_sha }}"
+          echo "Immutable deploy tag:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${immutable_tag}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Publish behavior:" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "push" ] && \
+            [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "\`push to main publishes main-<shortsha>, main-latest, and sha-<shortsha>.\`" \
+              >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "\`workflow_dispatch validates the selected ref without publishing image tags.\`" \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "\`pull_request builds and smoke-tests without publishing image tags.\`" \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   immersive links. It now accepts canonical URLs or `URL` instances and always injects
   `mode=immersive&disablePerformanceFailover=1` so manual previews keep both overrides even
   when you append debugging or UTM flags.
-- **Sugarkube deployment docs** – Static-site Sugarkube onboarding and runbooks live in
-  [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
+- **Sugarkube release runbook** – Release via GitHub-published GHCR image tags and the
+  OCI Helm chart using [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md).
+  Legacy environment notes remain in [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
   [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and
   [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,5 +1,9 @@
 # K3s Sugarkube production runbook (danielsmith.io)
 
+> Current production promotion commands live in
+> [docs/ops/sugarkube-release.md](ops/sugarkube-release.md). Keep this page for
+> production service profile and legacy Helm helper context.
+
 This guide covers production deployment for `danielsmith.io` on Sugarkube.
 
 ## Service profile

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,5 +1,9 @@
 # K3s Sugarkube staging runbook (danielsmith.io)
 
+> Current staging release commands live in
+> [docs/ops/sugarkube-release.md](ops/sugarkube-release.md). Keep this page for
+> staging service profile and legacy Helm helper context.
+
 This guide covers staging deployment of the static `danielsmith.io` site on Sugarkube.
 
 ## Service profile

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,0 +1,107 @@
+# Sugarkube GHCR/Helm release runbook (danielsmith.io)
+
+Use this runbook to release the static `danielsmith.io` site to Sugarkube without
+local container builds. GitHub Actions publishes the image and OCI Helm chart;
+Sugarkube deploys an immutable image tag.
+
+## Static-site contract
+
+`danielsmith.io` stays within the static-site-only deployment profile:
+
+- Runtime: nginx serving the built Vite + Three.js assets on port `8080`.
+- Health endpoints: `/livez` and `/healthz`.
+- No backend service, API server, database, queue, worker, or compute-node dependency.
+- Browser routes use the static container's SPA fallback.
+
+## Canonical artifacts
+
+- Image repository: `ghcr.io/futuroptimist/danielsmith.io`
+- Immutable deploy tag format: `main-<shortsha>`
+- Convenience tag: `main-latest` (rendering and quick checks only; do not use for sign-off)
+- Extra SHA tag: `sha-<shortsha>`
+- Helm chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Chart name: `danielsmith`
+
+## GitHub Actions release sources
+
+1. Open the `Build and publish GHCR image` workflow for the commit you want to deploy:
+   <https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml>
+2. Choose a successful run from `main`. Pull requests only build and smoke-test; they do
+   not publish GHCR tags. Manual `workflow_dispatch` runs validate a selected ref but also
+   do not publish image tags.
+3. Copy the immutable deploy tag from the workflow summary:
+
+   ```text
+   ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA
+   ```
+
+4. Confirm the `Publish Helm chart` workflow for the same commit succeeded:
+   <https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml>
+5. In the chart workflow summary, confirm the chart reference is:
+
+   ```text
+   oci://ghcr.io/futuroptimist/charts/danielsmith
+   ```
+
+   Chart publishing skips unchanged chart content. If chart content changed and the existing
+   immutable chart version has different content, bump `charts/danielsmith/Chart.yaml` and
+   rerun CI.
+
+## Deploy staging from Sugarkube
+
+Run commands from a Sugarkube repository checkout, not from this app repo.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic app recipes land:
+
+```bash
+just app-deploy app=danielsmith env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validate staging
+
+```bash
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Promote production
+
+Promote only after the same immutable tag passes staging validation.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic app recipes land:
+
+```bash
+just app-promote-prod app=danielsmith tag=main-REPLACE_SHORTSHA
+```
+
+## Validate production
+
+```bash
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback
+
+Redeploy or promote the previous known-good immutable `main-<shortsha>` tag from the
+Sugarkube checkout. Avoid mutable tags for rollback sign-off.
+
+## Cloudflare routing
+
+Keep Cloudflare Tunnel, DNS, and route setup separate from Helm deployment. Helm rollout
+selects the image tag and Kubernetes resources; Cloudflare route changes should be handled
+by the Sugarkube networking/runbook process for the target environment.

--- a/docs/sugarkube_onboarding.md
+++ b/docs/sugarkube_onboarding.md
@@ -1,5 +1,9 @@
 # Sugarkube onboarding (danielsmith.io)
 
+> Current copy-paste release commands live in
+> [docs/ops/sugarkube-release.md](ops/sugarkube-release.md). Keep this page for
+> static-site service profile and legacy Helm helper context.
+
 This runbook documents how to deploy `danielsmith.io` to Sugarkube as a static web app.
 
 ## Architecture


### PR DESCRIPTION
### Motivation
- Make the danielsmith.io release path explicit and copy-pasteable so operators deploy immutable GHCR image tags and OCI charts via Sugarkube without local Docker builds. 
- Align the repo with the Sugarkube GHCR/Helm release contract (immutable `main-<shortsha>` tags, chart OCI ref) while preserving the static-site-only runtime assumptions. 
- Surface the immutable deploy tag directly in CI so humans can easily copy the exact tag to roll out via Sugarkube.

### Description
- Added a runbook at `docs/ops/sugarkube-release.md` that documents the static-site contract, canonical GHCR image and OCI chart coordinates, copy-paste staging deploy and prod promote commands, validation `curl` checks, rollback guidance, and Cloudflare routing separation. 
- Updated the image CI workflow `.github/workflows/ci-image.yml` to append a `Summarize image contract` step which prints the immutable deploy tag (`ghcr.io/futuroptimist/danielsmith.io:main-<shortsha>`) to the workflow summary and explains `push` vs `pull_request` vs `workflow_dispatch` behavior. 
- Linked the new runbook from `README.md` and added pointer notes to `docs/sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, and `docs/k3s-sugarkube-prod.md` so legacy onboarding pages remain but refer to the canonical release flow. 
- No runtime or site behavior changes were made (Dockerfile, nginx config, health endpoints, and Helm chart defaults remain unchanged). 

### Testing
- Ran `git diff --check` with no issues. 
- Ran `npm ci` which completed successfully. 
- Ran `npm run check` (calls `eslint`, `vitest run`, and `node scripts/check-docs.cjs`) and it completed successfully with `Test Files 131 passed` and `Tests 910 passed`. 
- Ran `npm run smoke` and build/smoke validations passed (dist build generated and smoke check passed). 
- Ran `helm lint charts/danielsmith` and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` which both succeeded (note: Helm was installed in the test environment to run these checks). 
- Verified docs and grep checks: `grep -R "app-deploy app=danielsmith" docs README.md` found the future-generic command, and `grep -R "docker build" docs README.md || true` returned none as expected. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` with no high-risk secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb037e50832f8860c3b6d8d5b3bf)