### PR TITLE
🚀 Align Sugarkube release docs and CI image summary

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -103,6 +103,28 @@ jobs:
           test -n "${asset_path}"
           curl -fsS "http://127.0.0.1:8080${asset_path}" >/dev/null
 
+      - name: Summarize image contract
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          SHORT_SHA: ${{ steps.meta.outputs.short_sha }}
+        run: |
+          {
+            echo "Image workflow contract:"
+            echo "- Event: \`${EVENT_NAME}\`"
+            echo "- Candidate immutable deploy tag:"
+            echo "  \`ghcr.io/futuroptimist/danielsmith.io:main-${SHORT_SHA}\`"
+            if [ "${EVENT_NAME}" = "push" ] && [ "${GIT_REF}" = "refs/heads/main" ]; then
+              publish_behavior="this run publishes main-<shortsha>, main-latest, and sha-<shortsha>."
+            elif [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+              publish_behavior="workflow_dispatch validates the selected ref only; it does not publish image tags."
+            else
+              publish_behavior="pull requests build and smoke-test only; they do not publish image tags."
+            fi
+            echo "- Publish behavior: ${publish_behavior}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   immersive links. It now accepts canonical URLs or `URL` instances and always injects
   `mode=immersive&disablePerformanceFailover=1` so manual previews keep both overrides even
   when you append debugging or UTM flags.
-- **Sugarkube deployment docs** – Static-site Sugarkube onboarding and runbooks live in
+- **Sugarkube deployment docs** – The copy-paste GHCR/Helm release flow lives in
+  [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md), with supporting
+  static-site onboarding and environment runbooks in
   [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
   [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and
   [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,0 +1,132 @@
+# Sugarkube release runbook for danielsmith.io
+
+Use this runbook to release the static `danielsmith.io` site through the shared Sugarkube
+GHCR/Helm contract. The application remains static-site only: the runtime image serves the
+Vite build with nginx on port `8080`, exposes `/livez` and `/healthz`, and does not require a
+backend, database, queue, worker, API, or compute-node service.
+
+## Contract summary
+
+| Artifact                   | Canonical value                                  |
+| -------------------------- | ------------------------------------------------ |
+| Image repository           | `ghcr.io/futuroptimist/danielsmith.io`           |
+| Immutable deploy image tag | `main-<shortsha>`                                |
+| Convenience image tag      | `main-latest`                                    |
+| SHA alias                  | `sha-<shortsha>`                                 |
+| Helm chart name            | `danielsmith`                                    |
+| Helm chart ref             | `oci://ghcr.io/futuroptimist/charts/danielsmith` |
+| Release and namespace      | `danielsmith`                                    |
+| Runtime port               | `8080`                                           |
+| Health endpoints           | `/livez`, `/healthz`                             |
+
+GitHub Actions owns publishing. Operators should not build or tag images locally for Sugarkube
+rollouts.
+
+## 1. Find the published immutable image tag
+
+1. Open the `Build and publish GHCR image` workflow (`ci-image.yml`) for the commit you want to
+   release.
+2. Confirm the run succeeded on `main`.
+3. Copy the immutable deploy tag from the workflow summary:
+
+   ```text
+   ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA
+   ```
+
+Pushes to `main` publish all three image tags:
+
+- `ghcr.io/futuroptimist/danielsmith.io:main-<shortsha>`
+- `ghcr.io/futuroptimist/danielsmith.io:main-latest`
+- `ghcr.io/futuroptimist/danielsmith.io:sha-<shortsha>`
+
+Pull requests build and smoke-test the image without publishing. Manual `workflow_dispatch` runs
+also build and smoke-test the selected ref; they are validation-only for the image workflow and do
+not publish GHCR image tags.
+
+## 2. Confirm the OCI chart is available
+
+1. Open the `Publish Helm chart` workflow (`ci-helm.yml`) for the same commit or the current chart
+   version.
+2. Confirm the workflow succeeded and the summary references:
+
+   ```text
+   oci://ghcr.io/futuroptimist/charts/danielsmith
+   ```
+
+The chart workflow lints, renders a staging-like template with `image.tag=main-deadbee`, packages
+`charts/danielsmith`, and publishes the immutable chart version to GHCR when needed. If an
+identical chart version already exists, publication may be skipped; if chart content changed under
+an existing version, bump `charts/danielsmith/Chart.yaml` before publishing.
+
+## 3. Deploy staging from the Sugarkube checkout
+
+Run deployment commands from a Sugarkube repository checkout, not from this app repo.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic recipes land:
+
+```bash
+just app-deploy app=danielsmith env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## 4. Validate staging
+
+```bash
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+If you also need cluster-side confirmation from Sugarkube, use the standard namespace checks:
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+```
+
+## 5. Promote production
+
+After staging sign-off, promote the same immutable image tag to production.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic recipes land:
+
+```bash
+just app-promote-prod app=danielsmith tag=main-REPLACE_SHORTSHA
+```
+
+## 6. Validate production
+
+```bash
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+Optional cluster-side confirmation:
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+```
+
+## Cloudflare routing is separate
+
+Helm deployment should only install or upgrade the Kubernetes release. Keep Cloudflare DNS, tunnel,
+and route setup in the Sugarkube/network runbooks so application release steps remain repeatable and
+can be re-run without changing public routing.
+
+## Rollback
+
+Redeploy or promote the previous known-good immutable `main-<shortsha>` image tag from the
+Sugarkube checkout. Do not roll back by using mutable tags for sign-off.


### PR DESCRIPTION
### Motivation
- Make the GHCR image + OCI Helm chart release flow obvious and copy-pasteable for Sugarkube operators while preserving the existing static-site runtime contract (nginx on port `8080`, `/livez` and `/healthz`, no backend). 
- Avoid operator guesswork or local Docker builds by surfacing the immutable image tag and workflow dispatch behavior in CI and a dedicated runbook.
- Keep runtime code unchanged and avoid Sugarkube-specific implementation in the app itself.

### Description
- Add `docs/ops/sugarkube-release.md`, a copy-pasteable runbook that documents the canonical image repo, immutable `main-<shortsha>` tag, chart ref `oci://ghcr.io/futuroptimist/charts/danielsmith`, staging/prod deploy and promote commands, validation curls, Cloudflare separation, and rollback guidance. 
- Link the new runbook from the README so operators can discover the release flow quickly. 
- Add a `Summarize image contract` step to `.github/workflows/ci-image.yml` that writes the candidate immutable deploy tag (`ghcr.io/futuroptimist/danielsmith.io:main-<shortsha>`) and explains push/PR/`workflow_dispatch` publish behavior into the GitHub Actions step summary. 

### Testing
- Ran formatting: `npm run format:write` (succeeded). 
- Verified repository checks: `git diff --check` (no issues) and `git add`/`git commit` flow; secret scan `./scripts/scan-secrets.py` reported no high-risk secrets. 
- Installed deps and ran CI checks: `npm ci` (succeeded; reported existing dependency vulnerabilities from upstream packages), `npm run check` which ran `eslint`, the full `vitest` suite (all tests passed: 131 files, 910 tests), and `node scripts/check-docs.cjs` (docs check passed). 
- Built and smoke-tested the site: `npm run smoke` (build + smoke assertions passed). 
- Helm checks: installed Helm locally in the environment and ran `helm lint charts/danielsmith` (lint passed) and `helm template ... --set image.tag=main-deadbee` (template render passed). 
- Grep checks: `grep -R "app-deploy app=danielsmith" docs README.md` and `grep -R "docker build" docs README.md || true` (found expected entries / no problematic references). 

All automated checks listed above completed successfully; `npm ci` noted dependency vulnerabilities (existing, not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb037e50832f8860c3b6d8d5b3bf)