### PR TITLE
Align Sugarkube GHCR/Helm release contract and add runbook

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -44,6 +44,24 @@ jobs:
           echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
           echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      - name: Summarize build contract
+        shell: bash
+        run: |
+          deploy_tag="ghcr.io/futuroptimist/danielsmith.io:main-${{ steps.meta.outputs.short_sha }}"
+          {
+            echo "Sugarkube image contract:"
+            echo "- Immutable deploy tag: \`${deploy_tag}\`"
+            echo "- Event: \`${{ github.event_name }}\`"
+            if [ "${{ github.event_name }}" = "push" ] && \
+              [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              echo "- Publish behavior: multi-arch image publishes after smoke tests pass."
+            elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "- Publish behavior: manual dispatch builds and smokes only; no image publish."
+            else
+              echo "- Publish behavior: pull requests build and smoke only; no image publish."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Build local smoke-test image
         uses: docker/build-push-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   immersive links. It now accepts canonical URLs or `URL` instances and always injects
   `mode=immersive&disablePerformanceFailover=1` so manual previews keep both overrides even
   when you append debugging or UTM flags.
-- **Sugarkube deployment docs** – Static-site Sugarkube onboarding and runbooks live in
-  [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
+- **Sugarkube deployment docs** – The GHCR/Helm release runbook lives in
+  [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md), with legacy
+  static-site onboarding notes in [`docs/sugarkube_onboarding.md`](docs/sugarkube_onboarding.md),
   [`docs/k3s-sugarkube-staging.md`](docs/k3s-sugarkube-staging.md), and
   [`docs/k3s-sugarkube-prod.md`](docs/k3s-sugarkube-prod.md).
 

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,0 +1,139 @@
+# Sugarkube GHCR/Helm release runbook for danielsmith.io
+
+This runbook is the copy-pasteable release path for deploying `danielsmith.io` to
+Sugarkube. The app remains a static Vite + Three.js site served by unprivileged
+nginx on port `8080`; the runtime exposes `/livez` and `/healthz` and has no
+backend, database, API, queue, or compute-node dependency.
+
+## Release contract
+
+| Artifact              | Contract                                               |
+| --------------------- | ------------------------------------------------------ |
+| Image                 | `ghcr.io/futuroptimist/danielsmith.io`                 |
+| Immutable image tag   | `main-<shortsha>` from a successful `ci-image.yml` run |
+| Convenience image tag | `main-latest` for rendering/lint convenience only      |
+| Chart name            | `danielsmith`                                          |
+| Chart ref             | `oci://ghcr.io/futuroptimist/charts/danielsmith`       |
+| Chart version         | Immutable SemVer from `charts/danielsmith/Chart.yaml`  |
+
+GitHub Actions owns artifact publication. Operators should not use local Docker
+builds for Sugarkube releases; Sugarkube deploys the already-published GHCR image
+by immutable tag through the OCI Helm chart.
+
+## 1. Find the immutable image tag
+
+1. Open the `Build and publish GHCR image` workflow (`ci-image.yml`) in GitHub
+   Actions.
+2. Select the successful run for the commit you want to release.
+3. Confirm it is a `push` run on `main`. Pull requests and manual dispatches
+   build and smoke-test the image but do not publish it.
+4. Copy the immutable deploy tag from the workflow summary:
+
+```text
+ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA
+```
+
+Use only the tag portion with Sugarkube deploy commands:
+
+```text
+main-REPLACE_SHORTSHA
+```
+
+The image workflow also publishes these companion tags for `main` pushes:
+
+- `ghcr.io/futuroptimist/danielsmith.io:main-<shortsha>`
+- `ghcr.io/futuroptimist/danielsmith.io:main-latest`
+- `ghcr.io/futuroptimist/danielsmith.io:sha-<shortsha>`
+
+## 2. Confirm the chart is published
+
+1. Open the `Publish Helm chart` workflow (`ci-helm.yml`) in GitHub Actions.
+2. Confirm a successful run for the chart content you plan to deploy.
+3. Verify the workflow summary references:
+
+```text
+oci://ghcr.io/futuroptimist/charts/danielsmith
+```
+
+The chart publication step skips an already-published identical chart version. If
+changed chart content reuses an existing version, CI requires a version bump
+instead of overwriting the immutable OCI chart.
+
+## 3. Deploy staging from Sugarkube
+
+Run deployment commands from a Sugarkube checkout, not from this app repository.
+Replace `main-REPLACE_SHORTSHA` with the immutable image tag copied from
+`ci-image.yml`.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic app recipes land:
+
+```bash
+just app-deploy app=danielsmith env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## 4. Validate staging
+
+```bash
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+If the cluster is directly accessible, also check rollout state from the
+Sugarkube environment:
+
+```bash
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+kubectl -n danielsmith get deploy,po,svc,ingress
+```
+
+## 5. Promote production
+
+Promote the exact immutable tag that passed staging validation.
+
+Current app-specific command:
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+```
+
+Future generic command after the Sugarkube generic app recipes land:
+
+```bash
+just app-promote-prod app=danielsmith tag=main-REPLACE_SHORTSHA
+```
+
+## 6. Validate production
+
+```bash
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+If the cluster is directly accessible, also check rollout state from the
+Sugarkube environment:
+
+```bash
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+kubectl -n danielsmith get deploy,po,svc,ingress
+```
+
+## Cloudflare routes are separate
+
+Cloudflare tunnel DNS, hostnames, and route setup are operational prerequisites
+that remain separate from the Helm deployment. Configure or verify Cloudflare
+routing before rollout when introducing a new hostname, but do not couple route
+changes to the chart render or image publication steps.
+
+## Rollback
+
+Redeploy or promote the previous known-good immutable image tag through the same
+Sugarkube commands. Do not roll back to `main-latest`; it is mutable and intended
+only as a chart render convenience.


### PR DESCRIPTION
### Motivation
- Make the danielsmith.io Sugarkube release path obvious, copy-pasteable, and repeatable so operators do not fall back to local Docker builds.  
- Ensure CI-published GHCR image tags and OCI Helm chart usage follow the shared Sugarkube contract (immutable `main-<shortsha>` deploy tags and chart ref `oci://ghcr.io/futuroptimist/charts/danielsmith`).

### Description
- Add a copy-pasteable release runbook at `docs/ops/sugarkube-release.md` describing the image/chart contract, how to find the immutable image tag, staging deploys, prod promotion, validation commands, and rollback guidance.  
- Update the image workflow `/.github/workflows/ci-image.yml` to summarize the Sugarkube image contract and print the immutable deploy tag (``ghcr.io/futuroptimist/danielsmith.io:main-<shortsha>``) plus explicit PR / `workflow_dispatch` / `main` publish behavior into the workflow summary.  
- Link the new runbook from `README.md` alongside existing Sugarkube onboarding docs so the canonical release path is discoverable.

### Testing
- Project quality gates ran successfully: `npm run format:write`, `npm ci`, and `npm run check` (ESLint + `vitest run` + `node scripts/check-docs.cjs`), with the test suite passing (all Vitest tests passed).  
- Production smoke build succeeded via `npm run smoke` (Vite build + `scripts/assert-dist.cjs`) and validated the `dist/` artifact references.  
- Helm checks succeeded: `helm lint charts/danielsmith` passed and `helm template danielsmith charts/danielsmith --namespace danielsmith --set ingress.enabled=true --set ingress.host=staging.danielsmith.io --set image.tag=main-deadbee` rendered without error.  
- Documentation and safety checks passed: `grep -R "app-deploy app=danielsmith" docs README.md` found the future-generic command, `grep -R "docker build" docs README.md || true` returned nothing, and the secrets scan (`./scripts/scan-secrets.py`) reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb037e50832f8860c3b6d8d5b3bf)