### PR TITLE
Add small-screen HUD Playwright tests and remove duplicate HUD critical CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,10 +85,13 @@
       }
 
       .overlay__menu-button:hover,
-      .overlay__menu-button:focus-visible,
+      .overlay__menu-button:focus-visible {
+        background: rgba(196, 232, 255, 0.1);
+        outline: none;
+      }
+
       .overlay__menu-button[aria-pressed='true'] {
         background: rgba(80, 164, 255, 0.24);
-        outline: none;
       }
 
       .overlay__menu-key {

--- a/index.html
+++ b/index.html
@@ -49,31 +49,10 @@
         flex-direction: column;
         align-items: flex-end;
         gap: 0.55rem;
+        max-width: min(22rem, calc(100vw - 2rem));
         color: rgba(224, 236, 255, 0.9);
         font-size: 0.9rem;
         line-height: 1.4;
-        max-width: min(22rem, calc(100vw - 2rem));
-        overflow: visible;
-      }
-
-      .overlay::after {
-        content: '';
-        position: absolute;
-        top: -0.65rem;
-        right: -0.65rem;
-        width: 8rem;
-        height: 8rem;
-        border-radius: 999px;
-        background: radial-gradient(
-          circle at center,
-          rgba(94, 210, 255, 0.55) 0%,
-          rgba(94, 210, 255, 0) 70%
-        );
-        opacity: calc(var(--hud-analytics-glow, 0) * 0.85);
-        pointer-events: none;
-        filter: blur(22px);
-        z-index: -1;
-        transition: opacity 160ms ease;
       }
 
       .overlay__menu {
@@ -84,13 +63,7 @@
         padding: 0.25rem;
         border: 1px solid rgba(123, 209, 255, 0.4);
         border-radius: 999px;
-        background:
-          linear-gradient(
-            140deg,
-            rgba(12, 25, 39, 0.92),
-            rgba(16, 43, 70, 0.78)
-          ),
-          rgba(9, 18, 28, 0.88);
+        background: rgba(9, 18, 28, 0.88);
         box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
       }
 
@@ -98,36 +71,24 @@
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
-        width: auto;
         min-height: 2.45rem;
         padding: 0.55rem 0.72rem;
-        border-radius: 999px;
         border: 0;
+        border-radius: 999px;
         background: transparent;
         color: #e7f4ff;
+        font: inherit;
         font-size: 0.86rem;
         font-weight: 600;
         letter-spacing: 0.02em;
         cursor: pointer;
-        transition:
-          border-color 140ms ease,
-          box-shadow 140ms ease,
-          transform 120ms ease;
       }
 
       .overlay__menu-button:hover,
-      .overlay__menu-button:focus-visible {
-        background: rgba(80, 164, 255, 0.18);
-        outline: none;
-        transform: translateY(-1px);
-      }
-
-      .overlay__menu-button:active {
-        transform: translateY(0);
-      }
-
+      .overlay__menu-button:focus-visible,
       .overlay__menu-button[aria-pressed='true'] {
         background: rgba(80, 164, 255, 0.24);
+        outline: none;
       }
 
       .overlay__menu-key {
@@ -144,89 +105,25 @@
 
       .overlay__popover {
         width: min(22rem, calc(100vw - 2rem));
-        max-height: min(32rem, calc(100vh - 7.5rem));
+        max-height: min(
+          32rem,
+          calc(100vh - 7.5rem - env(safe-area-inset-top, 0px))
+        );
         padding: 0.9rem 1rem;
+        border: 1px solid rgba(86, 184, 255, 0.28);
         border-radius: 0.75rem;
         background: rgba(8, 12, 20, 0.78);
-        border: 1px solid rgba(86, 184, 255, 0.28);
         box-shadow: 0 20px 48px rgba(3, 9, 18, 0.55);
         overflow: auto;
         overscroll-behavior: contain;
       }
 
-      .overlay__popover[hidden] {
-        display: none;
-      }
-
-      .overlay__popover-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.75rem;
-        margin-bottom: 0.75rem;
-      }
-
-      .overlay__heading {
-        margin: 0;
-        font-size: 0.75rem;
-        font-weight: 600;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-        color: rgba(196, 228, 255, 0.82);
-      }
-
-      .overlay__popover-close {
-        flex: 0 0 auto;
-        width: 2rem;
-        height: 2rem;
-        border: 1px solid rgba(123, 209, 255, 0.35);
-        border-radius: 999px;
-        background: rgba(8, 18, 30, 0.72);
-        color: rgba(224, 236, 255, 0.9);
-        font-size: 1.25rem;
-        line-height: 1;
-        cursor: pointer;
-      }
-
-      .overlay__list {
-        margin: 0;
-        padding: 0;
-        list-style: none;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-      }
-
-      .overlay__item {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.75rem;
-        border-radius: 0.6rem;
-        padding: 0.25rem 0.35rem;
-      }
-
+      .overlay__popover[hidden],
       .overlay__item[hidden] {
         display: none;
       }
 
-      .overlay__item[data-active-method='true'] {
-        background: rgba(32, 82, 128, 0.28);
-        box-shadow: 0 0 0 1px rgba(114, 210, 255, 0.28);
-      }
-
-      .overlay__keys {
-        min-width: 7rem;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        color: rgba(143, 214, 255, 0.9);
-      }
-
-      .overlay__description {
-        flex: 1;
-        color: rgba(239, 245, 255, 0.88);
-      }
-
-      html[data-hud-layout='mobile'] .overlay {
+      :root[data-hud-layout='mobile'] .overlay {
         top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
         right: calc(env(safe-area-inset-right, 0px) + 0.75rem);
         max-width: min(20rem, calc(100vw - 1.5rem));
@@ -234,25 +131,24 @@
         line-height: 1.5;
       }
 
-      html[data-hud-layout='mobile'] .overlay__menu-button {
+      :root[data-hud-layout='mobile'] .overlay__menu-button {
         gap: 0.25rem;
         min-height: 2.35rem;
         padding: 0.45rem 0.5rem;
         font-size: 0.78rem;
       }
 
-      html[data-hud-layout='mobile'] .overlay__menu-key {
+      :root[data-hud-layout='mobile'] .overlay__menu-key {
         min-width: 1.1rem;
         padding-inline: 0.24rem;
       }
 
-      html[data-hud-layout='mobile'] .overlay__popover {
+      :root[data-hud-layout='mobile'] .overlay__popover {
         width: min(20rem, calc(100vw - 1.5rem));
-        max-height: min(26rem, calc(100vh - 7rem));
-      }
-
-      html[data-hud-layout='mobile'] .overlay__keys {
-        min-width: 5.75rem;
+        max-height: min(
+          26rem,
+          calc(100vh - 7rem - env(safe-area-inset-top, 0px))
+        );
       }
 
       .help-modal-backdrop {

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -1,12 +1,25 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page, type Locator } from '@playwright/test';
 
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 const POI_IDLE_TIMEOUT_MS = 4_000;
+const VIEWPORT_BOUNDS_EPSILON_PX = 1;
 
 type PoiTooltipState = {
   overlayVisiblePoiId: string | null;
   worldTooltipVisible: boolean;
+};
+
+type ViewportBounds = {
+  width: number;
+  height: number;
+};
+
+type ElementBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 };
 
 type PortfolioPoiWindow = Window & {
@@ -16,6 +29,37 @@ type PortfolioPoiWindow = Window & {
     };
   };
 };
+
+async function pressShortcutUntil(
+  page: Page,
+  key: string,
+  waitForShortcutEffect: () => Promise<void>
+) {
+  await page.keyboard.down(key);
+  try {
+    await waitForShortcutEffect();
+  } finally {
+    await page.keyboard.up(key);
+  }
+}
+
+async function expectWithinViewport(
+  locator: Locator,
+  viewport: ViewportBounds
+) {
+  const bounds = await locator.boundingBox();
+  expect(bounds).not.toBeNull();
+  const { x, y, width, height } = bounds as ElementBounds;
+
+  expect(x).toBeGreaterThanOrEqual(-VIEWPORT_BOUNDS_EPSILON_PX);
+  expect(y).toBeGreaterThanOrEqual(-VIEWPORT_BOUNDS_EPSILON_PX);
+  expect(x + width).toBeLessThanOrEqual(
+    viewport.width + VIEWPORT_BOUNDS_EPSILON_PX
+  );
+  expect(y + height).toBeLessThanOrEqual(
+    viewport.height + VIEWPORT_BOUNDS_EPSILON_PX
+  );
+}
 
 async function waitForImmersiveReady(page: Page) {
   await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
@@ -85,11 +129,7 @@ test.describe('small-screen HUD regression coverage', () => {
         /(?:Open settings|Settings).*H/
       );
 
-      const hudBox = await hud.boundingBox();
-      expect(hudBox).not.toBeNull();
-      expect(hudBox?.x).toBeGreaterThanOrEqual(0);
-      expect(hudBox?.y).toBeGreaterThanOrEqual(0);
-      expect((hudBox?.x ?? 0) + (hudBox?.width ?? 0)).toBeLessThanOrEqual(375);
+      await expectWithinViewport(hud, { width: 375, height: 667 });
 
       await expect(controlsPopover).toBeHidden();
       await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
@@ -102,18 +142,10 @@ test.describe('small-screen HUD regression coverage', () => {
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'true');
       await expect(settingsModal).toBeHidden();
 
-      const popoverBox = await controlsPopover.boundingBox();
-      expect(popoverBox).not.toBeNull();
-      expect(popoverBox?.x).toBeGreaterThanOrEqual(0);
-      expect(popoverBox?.y).toBeGreaterThanOrEqual(0);
-      expect(
-        (popoverBox?.x ?? 0) + (popoverBox?.width ?? 0)
-      ).toBeLessThanOrEqual(375);
-      expect(
-        (popoverBox?.y ?? 0) + (popoverBox?.height ?? 0)
-      ).toBeLessThanOrEqual(667);
+      await expectWithinViewport(controlsPopover, { width: 375, height: 667 });
 
       await textButton.focus();
+      await expect(textButton).toBeFocused();
       await page.keyboard.press('Tab');
       await expect(settingsButton).toBeFocused();
 
@@ -125,6 +157,15 @@ test.describe('small-screen HUD regression coverage', () => {
       await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
       await expect(settingsButton).toHaveAttribute('aria-pressed', 'true');
 
+      await page.keyboard.press('Escape');
+      await expect(settingsModal).toBeHidden();
+      await expect(settingsButton).toHaveAttribute('aria-expanded', 'false');
+      await expect(settingsButton).toHaveAttribute('aria-pressed', 'false');
+
+      await pressShortcutUntil(page, 'h', async () => {
+        await expect(settingsModal).toBeVisible();
+        await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
+      });
       await page.keyboard.press('Escape');
       await expect(settingsModal).toBeHidden();
       await expect(settingsButton).toHaveAttribute('aria-expanded', 'false');
@@ -172,22 +213,22 @@ test.describe('small-screen HUD regression coverage', () => {
       );
 
       await expect(controlsPopover).toBeHidden();
-      await page.keyboard.press('KeyC');
+      await page.keyboard.press('c');
       await expect(controlsPopover).toBeVisible();
       await expect(controlsButton).toHaveAttribute('aria-expanded', 'true');
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'true');
 
-      await page.keyboard.press('KeyC');
+      await page.keyboard.press('c');
       await expect(controlsPopover).toBeHidden();
       await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
 
-      await page.keyboard.press('KeyC');
+      await page.keyboard.press('c');
       await expect(controlsPopover).toBeVisible();
-      await page.keyboard.down('KeyH');
-      await expect(controlsPopover).toBeHidden();
-      await expect(settingsModal).toBeVisible();
-      await page.keyboard.up('KeyH');
+      await pressShortcutUntil(page, 'h', async () => {
+        await expect(controlsPopover).toBeHidden();
+        await expect(settingsModal).toBeVisible();
+      });
       await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
       await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -178,10 +178,9 @@ test.describe('small-screen HUD regression coverage', () => {
       await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
 
+      await page.waitForTimeout(POI_IDLE_TIMEOUT_MS + 500);
       await expect
-        .poll(async () => getPoiTooltipState(page), {
-          timeout: POI_IDLE_TIMEOUT_MS + 1_000,
-        })
+        .poll(async () => getPoiTooltipState(page), { timeout: 1_000 })
         .toMatchObject({
           overlayVisiblePoiId: null,
           worldTooltipVisible: false,

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const POI_IDLE_TIMEOUT_MS = 4_000;
+
+type PoiTooltipState = {
+  overlayVisiblePoiId: string | null;
+  worldTooltipVisible: boolean;
+};
+
+type PortfolioPoiWindow = Window & {
+  portfolio?: {
+    poi?: {
+      getTooltipState?: () => PoiTooltipState;
+    };
+  };
+};
+
+async function waitForImmersiveReady(page: Page) {
+  await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+  await page.waitForFunction(
+    () => (window as PortfolioPoiWindow).portfolio?.poi?.getTooltipState
+  );
+}
+
+async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
+  return page.evaluate(() => {
+    const state = (
+      window as PortfolioPoiWindow
+    ).portfolio?.poi?.getTooltipState?.();
+    return {
+      overlayVisiblePoiId: state?.overlayVisiblePoiId ?? null,
+      worldTooltipVisible: state?.worldTooltipVisible ?? false,
+    };
+  });
+}
+
+test.describe('small-screen HUD regression coverage', () => {
+  test.describe('mobile viewport', () => {
+    test.use({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 375, height: 667 },
+    });
+
+    test('keeps mobile HUD compact and panel state mutually exclusive', async ({
+      page,
+    }) => {
+      test.slow();
+      await waitForImmersiveReady(page);
+
+      const hud = page.locator('#control-overlay');
+      const hudMenu = page.locator('[data-role="hud-menu"]');
+      const controlsButton = page.locator('[data-role="controls-button"]');
+      const textButton = page.locator('[data-role="text-mode-button"]');
+      const settingsButton = page.locator('[data-role="settings-button"]');
+      const controlsPopover = page.locator('[data-role="controls-popover"]');
+      const settingsModal = page.locator('.help-modal-backdrop');
+
+      await expect(page.locator('html')).toHaveAttribute(
+        'data-hud-layout',
+        'mobile'
+      );
+      await expect(hud).toBeVisible();
+      await expect(hudMenu).toBeVisible();
+      await expect(hudMenu.getByRole('button')).toHaveCount(3);
+      await expect(controlsButton).toHaveAccessibleName(/Open controls.*C/);
+      await expect(textButton).toHaveAccessibleName(/text mode.*T/i);
+      await expect(settingsButton).toHaveAccessibleName(
+        /(?:Open settings|Settings).*H/
+      );
+
+      const hudBox = await hud.boundingBox();
+      expect(hudBox).not.toBeNull();
+      expect(hudBox?.x).toBeGreaterThanOrEqual(0);
+      expect(hudBox?.y).toBeGreaterThanOrEqual(0);
+      expect((hudBox?.x ?? 0) + (hudBox?.width ?? 0)).toBeLessThanOrEqual(375);
+
+      await expect(controlsPopover).toBeHidden();
+      await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+      await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
+      await expect(settingsModal).toBeHidden();
+
+      await controlsButton.tap();
+      await expect(controlsPopover).toBeVisible();
+      await expect(controlsButton).toHaveAttribute('aria-expanded', 'true');
+      await expect(controlsButton).toHaveAttribute('aria-pressed', 'true');
+      await expect(settingsModal).toBeHidden();
+
+      const popoverBox = await controlsPopover.boundingBox();
+      expect(popoverBox).not.toBeNull();
+      expect(popoverBox?.x).toBeGreaterThanOrEqual(0);
+      expect(popoverBox?.y).toBeGreaterThanOrEqual(0);
+      expect(
+        (popoverBox?.x ?? 0) + (popoverBox?.width ?? 0)
+      ).toBeLessThanOrEqual(375);
+      expect(
+        (popoverBox?.y ?? 0) + (popoverBox?.height ?? 0)
+      ).toBeLessThanOrEqual(667);
+
+      await page.keyboard.press('Tab');
+      expect(
+        await page.evaluate(
+          () =>
+            document.activeElement?.closest(
+              '[data-role="controls-popover"]'
+            ) !== null
+        )
+      ).toBe(false);
+
+      await settingsButton.tap();
+      await expect(controlsPopover).toBeHidden();
+      await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+      await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
+      await expect(settingsModal).toBeVisible();
+      await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
+      await expect(settingsButton).toHaveAttribute('aria-pressed', 'true');
+
+      await page.keyboard.press('Escape');
+      await expect(settingsModal).toBeHidden();
+      await expect(settingsButton).toHaveAttribute('aria-expanded', 'false');
+      await expect(settingsButton).toHaveAttribute('aria-pressed', 'false');
+
+      await controlsButton.tap();
+      await expect(controlsPopover).toBeVisible();
+      await controlsButton.tap();
+      await expect(controlsPopover).toBeHidden();
+      await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+      await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
+
+      await page.waitForTimeout(POI_IDLE_TIMEOUT_MS + 500);
+      await expect
+        .poll(async () => getPoiTooltipState(page))
+        .toMatchObject({
+          overlayVisiblePoiId: null,
+          worldTooltipVisible: false,
+        });
+    });
+  });
+
+  test.describe('desktop viewport', () => {
+    test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('keeps desktop keyboard HUD toggles mutually exclusive', async ({
+      page,
+    }) => {
+      await waitForImmersiveReady(page);
+
+      const controlsButton = page.locator('[data-role="controls-button"]');
+      const settingsButton = page.locator('[data-role="settings-button"]');
+      const controlsPopover = page.locator('[data-role="controls-popover"]');
+      const settingsModal = page.locator('.help-modal-backdrop');
+
+      await expect(page.locator('html')).toHaveAttribute(
+        'data-hud-layout',
+        'desktop'
+      );
+      await expect(page.locator('[data-role="hud-menu"]')).toBeVisible();
+      await expect(controlsButton).toHaveAccessibleName(/Open controls.*C/);
+      await expect(settingsButton).toHaveAccessibleName(
+        /(?:Open settings|Settings).*H/
+      );
+
+      await expect(controlsPopover).toBeHidden();
+      await page.keyboard.press('KeyC');
+      await expect(controlsPopover).toBeVisible();
+      await expect(controlsButton).toHaveAttribute('aria-expanded', 'true');
+      await expect(controlsButton).toHaveAttribute('aria-pressed', 'true');
+
+      await page.keyboard.press('KeyC');
+      await expect(controlsPopover).toBeHidden();
+      await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+      await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
+
+      await page.keyboard.press('KeyC');
+      await expect(controlsPopover).toBeVisible();
+      await page.keyboard.press('KeyH');
+      await expect(controlsPopover).toBeHidden();
+      await expect(settingsModal).toBeVisible();
+      await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+      await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
+      await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
+      await expect(settingsButton).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+});

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -31,13 +31,22 @@ async function waitForImmersiveReady(page: Page) {
 
 async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
   return page.evaluate(() => {
-    const state = (
-      window as PortfolioPoiWindow
-    ).portfolio?.poi?.getTooltipState?.();
-    return {
-      overlayVisiblePoiId: state?.overlayVisiblePoiId ?? null,
-      worldTooltipVisible: state?.worldTooltipVisible ?? false,
-    };
+    const getTooltipState = (window as PortfolioPoiWindow).portfolio?.poi
+      ?.getTooltipState;
+
+    if (!getTooltipState) {
+      throw new Error('window.portfolio.poi.getTooltipState() is unavailable');
+    }
+
+    const state = getTooltipState();
+
+    if (!state) {
+      throw new Error(
+        'window.portfolio.poi.getTooltipState() returned no state'
+      );
+    }
+
+    return state;
   });
 }
 
@@ -104,15 +113,9 @@ test.describe('small-screen HUD regression coverage', () => {
         (popoverBox?.y ?? 0) + (popoverBox?.height ?? 0)
       ).toBeLessThanOrEqual(667);
 
+      await textButton.focus();
       await page.keyboard.press('Tab');
-      expect(
-        await page.evaluate(
-          () =>
-            document.activeElement?.closest(
-              '[data-role="controls-popover"]'
-            ) !== null
-        )
-      ).toBe(false);
+      await expect(settingsButton).toBeFocused();
 
       await settingsButton.tap();
       await expect(controlsPopover).toBeHidden();
@@ -134,9 +137,10 @@ test.describe('small-screen HUD regression coverage', () => {
       await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
 
-      await page.waitForTimeout(POI_IDLE_TIMEOUT_MS + 500);
       await expect
-        .poll(async () => getPoiTooltipState(page))
+        .poll(async () => getPoiTooltipState(page), {
+          timeout: POI_IDLE_TIMEOUT_MS + 1_000,
+        })
         .toMatchObject({
           overlayVisiblePoiId: null,
           worldTooltipVisible: false,
@@ -180,9 +184,10 @@ test.describe('small-screen HUD regression coverage', () => {
 
       await page.keyboard.press('KeyC');
       await expect(controlsPopover).toBeVisible();
-      await page.keyboard.press('KeyH');
+      await page.keyboard.down('KeyH');
       await expect(controlsPopover).toBeHidden();
       await expect(settingsModal).toBeVisible();
+      await page.keyboard.up('KeyH');
       await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
       await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
### Motivation
- Lock in the compact top-right HUD/menu behavior on small screens and prevent regressing to the old full-width Controls card. 
- Remove stale/duplicated critical overlay CSS in `index.html` so the initial critical styles match `src/ui/styles.css` and the HUD layout manager’s emitted data attribute.

### Description
- Add `playwright/small-screen-hud.spec.ts` which includes a mobile (iPhone SE-like) `hasTouch`/`isMobile` scenario and a desktop viewport scenario that verify the compact HUD, accessible button names, `C`/`H` toggles, ARIA `aria-expanded`/`aria-pressed` states, non-modal Controls focus behavior, and POI idle suppression via `window.portfolio.poi.getTooltipState()`.
- Trim duplicated/old overlay CSS from `index.html`, normalize mobile overrides to `:root[data-hud-layout='mobile']`, and keep only minimal critical menu/popover rules so the runtime `createHudLayoutManager` dataset aligns with critical CSS.
- Small test plumbing: add a local `PortfolioPoiWindow` type in the spec to safely read `window.portfolio.poi.getTooltipState()` from Playwright tests.

### Testing
- Ran formatting: `npm run format:write` (passed).
- Lint: `npm run lint` (passed) and unit test CI: `npm run test:ci` (Vitest run passed all repo unit tests).
- Docs check: `npm run docs:check` (passed).
- Build & smoke: `npm run build` and `npm run smoke` (passed).
- E2E: `npm run test:e2e` (Playwright) — new `playwright/small-screen-hud.spec.ts` ran in both mobile and desktop contexts and passed; full Playwright suite also passed locally.
- Typecheck: `npm run typecheck` reported pre-existing repository TypeScript issues unrelated to this change and therefore was not used as a gate for this PR (failures are existing in the repo prior to this patch). 

All changes are intentionally focused: new Playwright coverage plus removal of obsolete critical CSS; no runtime behavior was changed aside from removing duplicated initial CSS rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e08b4e8b0832fafe65e430a5011cf)