### PR TITLE
Add small-screen HUD regression coverage

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,10 @@
 
       .overlay__popover {
         width: min(22rem, calc(100vw - 2rem));
-        max-height: min(32rem, calc(100vh - 7.5rem));
+        max-height: min(
+          32rem,
+          calc(100vh - 7.5rem - env(safe-area-inset-top, 0px))
+        );
         padding: 0.9rem 1rem;
         border-radius: 0.75rem;
         background: rgba(8, 12, 20, 0.78);
@@ -248,11 +251,14 @@
 
       html[data-hud-layout='mobile'] .overlay__popover {
         width: min(20rem, calc(100vw - 1.5rem));
-        max-height: min(26rem, calc(100vh - 7rem));
+        max-height: min(
+          26rem,
+          calc(100vh - 7rem - env(safe-area-inset-top, 0px))
+        );
       }
 
       html[data-hud-layout='mobile'] .overlay__keys {
-        min-width: 5.75rem;
+        width: 8.5rem;
       }
 
       .help-modal-backdrop {

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const IDLE_THRESHOLD_BUFFER_MS = 4_500;
+
+async function waitForImmersiveReady(page: Page) {
+  await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+}
+
+async function getPoiTooltipState(page: Page) {
+  return page.evaluate(() => window.portfolio?.poi?.getTooltipState?.());
+}
+
+test.describe('small-screen HUD regressions', () => {
+  test.use({
+    viewport: { width: 375, height: 667 },
+    hasTouch: true,
+    isMobile: true,
+  });
+
+  test('keeps the iPhone SE HUD compact and panel states exclusive', async ({
+    page,
+  }) => {
+    test.slow();
+    await waitForImmersiveReady(page);
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-hud-layout',
+      'mobile'
+    );
+
+    const hud = page.locator('#control-overlay');
+    const menu = page.locator('[data-role="hud-menu"]');
+    const controlsButton = page.locator('[data-role="controls-button"]');
+    const settingsButton = page.locator('[data-role="settings-button"]');
+    const controlsPopover = page.locator('[data-role="controls-popover"]');
+    const settingsModal = page.locator('.help-modal-backdrop');
+
+    await expect(hud).toBeVisible();
+    await expect(menu).toBeVisible();
+    await expect(controlsButton).toBeVisible();
+    await expect(controlsButton).toHaveAccessibleName(/Controls/i);
+    await expect(settingsButton).toBeVisible();
+    await expect(settingsButton).toHaveAccessibleName(/Settings/i);
+    await expect(controlsPopover).toBeHidden();
+    await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
+
+    await controlsButton.tap();
+    await expect(controlsPopover).toBeVisible();
+    await expect(controlsButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(controlsButton).toHaveAttribute('aria-pressed', 'true');
+
+    const popoverBounds = await controlsPopover.boundingBox();
+    expect(popoverBounds).not.toBeNull();
+    expect(popoverBounds?.x).toBeGreaterThanOrEqual(0);
+    expect(popoverBounds?.y).toBeGreaterThanOrEqual(0);
+    expect(
+      (popoverBounds?.x ?? 0) + (popoverBounds?.width ?? 0)
+    ).toBeLessThanOrEqual(375);
+    expect(
+      (popoverBounds?.y ?? 0) + (popoverBounds?.height ?? 0)
+    ).toBeLessThanOrEqual(667);
+
+    await settingsButton.tap();
+    await expect(controlsPopover).toBeHidden();
+    await expect(settingsModal).toBeVisible();
+    await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(settingsButton).toHaveAttribute('aria-pressed', 'true');
+
+    await page.getByRole('button', { name: /Close help/i }).click();
+    await expect(settingsModal).toBeHidden();
+    await expect(settingsButton).toHaveAttribute('aria-expanded', 'false');
+
+    await controlsButton.tap();
+    await expect(controlsPopover).toBeVisible();
+    await controlsButton.tap();
+    await expect(controlsPopover).toBeHidden();
+    await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
+
+    await page.waitForTimeout(IDLE_THRESHOLD_BUFFER_MS);
+    const tooltipState = await getPoiTooltipState(page);
+    expect(tooltipState).toMatchObject({
+      overlayVisiblePoiId: null,
+      worldTooltipVisible: false,
+      visibleMarkerLabelCount: 0,
+      activeInWorldTooltipCount: 0,
+      totalInWorldTooltipCount: 0,
+    });
+    await expect(page.locator('.poi-tooltip-overlay')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
+});
+
+test.describe('desktop HUD regressions', () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test('keeps keyboard shortcuts mutually exclusive across HUD panels', async ({
+    page,
+  }) => {
+    test.slow();
+    await waitForImmersiveReady(page);
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-hud-layout',
+      'desktop'
+    );
+
+    const menu = page.locator('[data-role="hud-menu"]');
+    const controlsButton = page.locator('[data-role="controls-button"]');
+    const settingsButton = page.locator('[data-role="settings-button"]');
+    const controlsPopover = page.locator('[data-role="controls-popover"]');
+    const settingsModal = page.locator('.help-modal-backdrop');
+
+    await expect(menu).toBeVisible();
+    await expect(controlsButton).toBeVisible();
+    await expect(controlsButton).toHaveAccessibleName(/Controls/i);
+    await expect(settingsButton).toBeVisible();
+    await expect(settingsButton).toHaveAccessibleName(/Settings/i);
+    await expect(controlsPopover).toBeHidden();
+    await expect(settingsModal).toBeHidden();
+
+    await page.keyboard.press('KeyC');
+    await expect(controlsPopover).toBeVisible();
+    await expect(controlsButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(controlsButton).toHaveAttribute('aria-pressed', 'true');
+
+    await page.keyboard.press('KeyH');
+    await expect(controlsPopover).toBeHidden();
+    await expect(settingsModal).toBeVisible();
+    await expect(controlsButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(settingsButton).toHaveAttribute('aria-pressed', 'true');
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent regressions that re-introduce the old full-width mobile Controls card and passive POI tooltips on small screens. 
- Ensure Controls, Text, and Settings remain mutually exclusive and accessible across mobile and desktop viewports. 
- Keep the critical inline CSS in `index.html` consistent with `src/ui/styles.css` to avoid divergent responsive rules.

### Description
- Added a Playwright e2e spec `playwright/small-screen-hud.spec.ts` that covers an iPhone SE-like viewport and a desktop viewport validating compact HUD presence, Controls/Settings exclusivity, accessible names/ARIA states, bounded mobile popover geometry, Controls toggle behavior, and suppression of passive POI recommendations via `window.portfolio.poi.getTooltipState()`. 
- Cleaned up and normalized critical HUD popover CSS in `index.html` (safe-area-aware `max-height` and mobile keys sizing) so it matches `src/ui/styles.css` and avoids stale duplicate rules. 
- Formatted the new test and updated HTML with Prettier to match repo style.

### Testing
- Ran `npm run format:write -- playwright/small-screen-hud.spec.ts index.html` (succeeded). 
- Ran `npm run lint` (succeeded). 
- Ran `npm run test:ci` (Vitest unit suite) which completed successfully (existing suite: 917 tests passed). 
- Installed Playwright browsers with `npx playwright install` and host deps with `npx playwright install-deps chromium` to enable headful/headless E2E runs (succeeded). 
- Ran targeted e2e: `npm run test:e2e -- playwright/small-screen-hud.spec.ts` and the new spec passed locally. 
- Ran full Playwright suite `npm run test:e2e` which completed (Playwright e2e run: 26 passed, 2 skipped in this environment). 
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke` (succeeded). 
- Note: `npm run typecheck` reports pre-existing TypeScript errors unrelated to these changes; typecheck failures are present in the repository prior to this PR and were not caused by these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e08b4e8b0832fafe65e430a5011cf)