### PR TITLE
Add top “Try immersive again” CTA and shared fallback recovery

### DIFF
--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -94,6 +94,13 @@ export const AR_OVERRIDES: LocaleOverrides = {
         resumeLabel: 'السيرة الذاتية (PDF)',
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
+      recoveryCta: {
+        title: 'هل أنت جاهز للغرفة الكاملة؟',
+        description:
+          'امسح تفضيل النص المحفوظ وأعد تشغيل المحفظة الغامرة من هنا.',
+        actionLabel: 'جرّب الوضع الغامر مرة أخرى',
+        ariaLabel: 'جرّب الوضع الغامر مرة أخرى وامسح تفضيل وضع النص المحفوظ',
+      },
       actions: {
         immersiveLink: 'جرّب الوضع الغامر مجددًا',
         debugImmersiveLink: 'تصحيح: فرض الوضع الغامر',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -100,6 +100,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         resumeLabel: wrap('Résumé (PDF)'),
         resumeUrl: wrap('docs/resume/2025-09/resume.pdf'),
       },
+      recoveryCta: {
+        title: wrap('Ready for the full room?'),
+        description: wrap(
+          'Clear the saved text preference and relaunch the immersive portfolio from here.'
+        ),
+        actionLabel: wrap('Try immersive again'),
+        ariaLabel: wrap(
+          'Try immersive mode again and clear the saved text mode preference'
+        ),
+      },
       actions: {
         immersiveLink: wrap('Try immersive again'),
         debugImmersiveLink: wrap('Debug: force immersive mode'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -99,6 +99,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         resumeLabel: 'Résumé (PDF)',
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
+      recoveryCta: {
+        title: 'Ready for the full room?',
+        description:
+          'Clear the saved text preference and relaunch the immersive portfolio from here.',
+        actionLabel: 'Try immersive again',
+        ariaLabel:
+          'Try immersive mode again and clear the saved text mode preference',
+      },
       actions: {
         immersiveLink: 'Try immersive again',
         debugImmersiveLink: 'Debug: force immersive mode',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -94,6 +94,14 @@ export const JA_OVERRIDES: LocaleOverrides = {
         resumeLabel: '履歴書 (PDF)',
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
+      recoveryCta: {
+        title: 'フルルームに戻りますか？',
+        description:
+          '保存されたテキスト設定を消去して、ここから没入ポートフォリオを再起動します。',
+        actionLabel: '没入モードをもう一度試す',
+        ariaLabel:
+          '没入モードをもう一度試して、保存されたテキストモード設定を消去',
+      },
       actions: {
         immersiveLink: '没入モードをもう一度試す',
         debugImmersiveLink: 'デバッグ: 没入モードを強制',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -255,6 +255,12 @@ export interface SiteTextFallbackStrings {
     resumeLabel: string;
     resumeUrl: string;
   };
+  recoveryCta: {
+    title: string;
+    description: string;
+    actionLabel: string;
+    ariaLabel: string;
+  };
   actions: {
     immersiveLink: string;
     debugImmersiveLink: string;

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -565,6 +565,23 @@ const clearStoredModePreference = () => {
   }
 };
 
+export const recoverFromTextFallback = (
+  documentTarget: Document,
+  immersiveUrl: string
+): void => {
+  clearStoredModePreference();
+  documentTarget.defaultView?.location.assign(immersiveUrl);
+};
+
+const handleFallbackRecoveryClick = (
+  event: MouseEvent,
+  documentTarget: Document,
+  immersiveUrl: string
+): void => {
+  event.preventDefault();
+  recoverFromTextFallback(documentTarget, immersiveUrl);
+};
+
 const installFallbackRecoveryShortcuts = (
   documentTarget: Document,
   immersiveUrl: string,
@@ -591,8 +608,7 @@ const installFallbackRecoveryShortcuts = (
       return;
     }
     event.preventDefault();
-    clearStoredModePreference();
-    windowTarget.location.assign(immersiveUrl);
+    recoverFromTextFallback(documentTarget, immersiveUrl);
   };
   windowTarget.addEventListener('keydown', handleKeydown);
   fallbackRecoveryCleanup.set(documentTarget, () => {
@@ -771,6 +787,45 @@ function createTextPortfolioSection(
   });
 
   return section;
+}
+
+function createRecoveryCta(
+  documentTarget: Document,
+  textFallbackStrings: SiteTextFallbackStrings,
+  immersiveUrl: string
+): HTMLElement {
+  const cta = documentTarget.createElement('aside');
+  cta.className = 'text-fallback__recovery-cta';
+  cta.setAttribute('aria-labelledby', 'text-fallback-recovery-title');
+
+  const copy = documentTarget.createElement('div');
+  copy.className = 'text-fallback__recovery-copy';
+
+  const title = documentTarget.createElement('h2');
+  title.id = 'text-fallback-recovery-title';
+  title.className = 'text-fallback__recovery-title';
+  title.textContent = textFallbackStrings.recoveryCta.title;
+  copy.appendChild(title);
+
+  const description = documentTarget.createElement('p');
+  description.className = 'text-fallback__recovery-description';
+  description.textContent = textFallbackStrings.recoveryCta.description;
+  copy.appendChild(description);
+
+  cta.appendChild(copy);
+
+  const action = documentTarget.createElement('a');
+  action.href = immersiveUrl;
+  action.className = 'text-fallback__primary-action';
+  action.textContent = textFallbackStrings.recoveryCta.actionLabel;
+  action.setAttribute('aria-label', textFallbackStrings.recoveryCta.ariaLabel);
+  action.dataset.action = 'top-immersive-recovery';
+  action.addEventListener('click', (event) => {
+    handleFallbackRecoveryClick(event, documentTarget, immersiveUrl);
+  });
+  cta.appendChild(action);
+
+  return cta;
 }
 
 function createAboutSection(
@@ -1019,6 +1074,9 @@ export function renderTextFallback(
   description.textContent =
     descriptionStrings[reason] ?? descriptionStrings.manual;
   section.appendChild(description);
+  section.appendChild(
+    createRecoveryCta(documentTarget, textFallbackStrings, immersiveUrl)
+  );
 
   section.appendChild(createAboutSection(documentTarget, textFallbackStrings));
   section.appendChild(createSkillsSection(documentTarget, textFallbackStrings));
@@ -1045,7 +1103,9 @@ export function renderTextFallback(
   immersiveLink.textContent = actionStrings.immersiveLink;
   immersiveLink.rel = 'noopener';
   immersiveLink.dataset.action = 'immersive';
-  immersiveLink.addEventListener('click', clearStoredModePreference);
+  immersiveLink.addEventListener('click', (event) => {
+    handleFallbackRecoveryClick(event, documentTarget, immersiveUrl);
+  });
   immersiveItem.appendChild(immersiveLink);
   list.appendChild(immersiveItem);
 

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -578,8 +578,19 @@ const handleFallbackRecoveryClick = (
   documentTarget: Document,
   immersiveUrl: string
 ): void => {
+  clearStoredModePreference();
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey
+  ) {
+    return;
+  }
   event.preventDefault();
-  recoverFromTextFallback(documentTarget, immersiveUrl);
+  documentTarget.defaultView?.location.assign(immersiveUrl);
 };
 
 const installFallbackRecoveryShortcuts = (

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -898,7 +898,7 @@ describe('renderTextFallback', () => {
     );
   });
 
-  it('uses shared recovery behavior for top and lower immersive actions', () => {
+  it('uses shared recovery behavior for top and lower immersive actions', async () => {
     const container = render('manual', {
       immersiveUrl: '/portfolio?mode=text',
     });
@@ -942,7 +942,21 @@ describe('renderTextFallback', () => {
     expect(lowerEvent.defaultPrevented).toBe(true);
     expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
     expect(window.sessionStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    window.sessionStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    const modifiedEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+    });
+    topAction?.dispatchEvent(modifiedEvent);
+
+    expect(modifiedEvent.defaultPrevented).toBe(false);
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
 
     consoleErrorSpy.mockRestore();
   });

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -9,6 +9,7 @@ import {
   type FallbackReason,
   type RenderTextFallbackOptions,
 } from '../systems/failover';
+import { MODE_PREFERENCE_KEY } from '../systems/failover/modePreference';
 import {
   createImmersiveModeUrl,
   createImmersiveRecoveryUrl,
@@ -868,6 +869,84 @@ describe('renderTextFallback', () => {
     );
   });
 
+  it('renders a prominent top immersive recovery CTA before text content', () => {
+    const container = render('manual');
+    const section = container.querySelector('.text-fallback');
+    const description = container.querySelector('.text-fallback__description');
+    const cta = container.querySelector('.text-fallback__recovery-cta');
+    const action = container.querySelector<HTMLAnchorElement>(
+      '[data-action="top-immersive-recovery"]'
+    );
+    const about = container.querySelector('[data-section="about"]');
+    const strings = getSiteStrings(container.lang).textFallback.recoveryCta;
+
+    expect(cta).toBeTruthy();
+    expect(action?.classList.contains('text-fallback__primary-action')).toBe(
+      true
+    );
+    expect(action?.textContent).toBe(strings.actionLabel);
+    expect(action?.getAttribute('aria-label')).toBe(strings.ariaLabel);
+    expect(
+      Array.from(section?.children ?? []).indexOf(cta as Element)
+    ).toBeGreaterThan(
+      Array.from(section?.children ?? []).indexOf(description as Element)
+    );
+    expect(
+      Array.from(section?.children ?? []).indexOf(cta as Element)
+    ).toBeLessThan(
+      Array.from(section?.children ?? []).indexOf(about as Element)
+    );
+  });
+
+  it('uses shared recovery behavior for top and lower immersive actions', () => {
+    const container = render('manual', {
+      immersiveUrl: '/portfolio?mode=text',
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const expectedHref = new URL(
+      createImmersiveRecoveryUrl('/portfolio?mode=text'),
+      window.location.origin
+    ).toString();
+    const topAction = container.querySelector<HTMLAnchorElement>(
+      '[data-action="top-immersive-recovery"]'
+    );
+    const lowerAction = container.querySelector<HTMLAnchorElement>(
+      '[data-action="immersive"]'
+    );
+
+    expect(topAction?.href).toBe(expectedHref);
+    expect(lowerAction?.href).toBe(expectedHref);
+
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    window.sessionStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    const topEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    topAction?.dispatchEvent(topEvent);
+
+    expect(topEvent.defaultPrevented).toBe(true);
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    window.sessionStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    const lowerEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    lowerAction?.dispatchEvent(lowerEvent);
+
+    expect(lowerEvent.defaultPrevented).toBe(true);
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it('respects custom immersive links when provided', () => {
     const customUrl = 'https://portfolio.test/demo?force=immersive';
     const container = render('manual', { immersiveUrl: customUrl });
@@ -933,6 +1012,8 @@ describe('renderTextFallback', () => {
       githubUrl: 'https://example.com',
     });
 
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    window.sessionStorage.setItem(MODE_PREFERENCE_KEY, 'text');
     const event = new KeyboardEvent('keydown', {
       key: 't',
       bubbles: true,
@@ -941,6 +1022,8 @@ describe('renderTextFallback', () => {
     window.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(true);
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
 
     consoleErrorSpy.mockRestore();

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -121,6 +121,84 @@ canvas {
   opacity: 0.88;
 }
 
+.text-fallback__recovery-cta {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0.25rem 0 0.75rem;
+  padding: 1rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(34, 211, 238, 0.18),
+      rgba(129, 140, 248, 0.16)
+    ),
+    rgba(7, 17, 31, 0.82);
+  border: 1px solid rgba(125, 211, 252, 0.45);
+  border-radius: 1rem;
+  box-shadow:
+    inset 0 0 24px rgba(45, 212, 191, 0.08),
+    0 18px 48px rgba(2, 12, 27, 0.42),
+    0 0 28px rgba(56, 189, 248, 0.16);
+}
+
+.text-fallback__recovery-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.text-fallback__recovery-title {
+  margin: 0;
+  color: #f8fdff;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.text-fallback__recovery-description {
+  margin: 0;
+  color: rgba(236, 244, 255, 0.86);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.text-fallback__primary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+  color: #03111f;
+  background: linear-gradient(135deg, #7dd3fc, #34d399 58%, #fde68a);
+  border: 1px solid rgba(224, 242, 254, 0.75);
+  border-radius: 999px;
+  box-shadow:
+    0 0 22px rgba(52, 211, 153, 0.35),
+    0 10px 28px rgba(14, 165, 233, 0.24);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.text-fallback__primary-action:hover,
+.text-fallback__primary-action:focus {
+  color: #020617;
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 30px rgba(125, 211, 252, 0.48),
+    0 14px 34px rgba(14, 165, 233, 0.3);
+}
+
+.text-fallback__primary-action:focus-visible {
+  outline: 3px solid #fef08a;
+  outline-offset: 3px;
+}
+
 .text-fallback__section-heading {
   margin: 0;
   font-size: 1.2rem;
@@ -2128,4 +2206,16 @@ html[data-hud-layout='mobile'] .audio-subtitles {
   display: inline-block;
   margin-top: 0.65rem;
   font-size: 0.85rem;
+}
+
+@media (min-width: 640px) {
+  .text-fallback__recovery-cta {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .text-fallback__primary-action {
+    flex: 0 0 auto;
+  }
 }


### PR DESCRIPTION
### Motivation
- Make the text-only fallback clearly offer an obvious, themed path back into immersive mode before the long text content. 
- Reuse existing recovery behavior (the `T` shortcut) to avoid duplicating preference-clearing and navigation logic. 
- Provide localized copy and accessible labels so the CTA works across locales and with assistive tech. 

### Description
- Added a shared recovery helper `recoverFromTextFallback(documentTarget, immersiveUrl)` and `handleFallbackRecoveryClick(...)` and wired `installFallbackRecoveryShortcuts` and immersive action links to call it so all retry paths clear stored mode preference and navigate to the same recovery URL. 
- Inserted a prominent top CTA block via `createRecoveryCta(...)` immediately after the fallback heading/description and before About/Skills/Contact content, with `data-action="top-immersive-recovery"` and proper ARIA labeling. 
- Introduced localized copy for the CTA and updated types by adding `recoveryCta` to `SiteTextFallbackStrings`, and added translations in `en`, `en-x-pseudo`, `ar`, and `ja`. 
- Added themed styling in `src/ui/styles.css` for `.text-fallback__recovery-cta` and `.text-fallback__primary-action` including focus-visible and a desktop layout media rule. 
- Updated tests in `src/tests/failover.test.ts` to assert CTA placement, URL parity, and that clicking top/lower CTA or pressing `T` clears stored preferences and reuses shared recovery behaviour. 

### Testing
- Ran formatting with `npm run format:write` (succeeded) and lint with `npm run lint` (succeeded). 
- Ran typecheck with `npm run typecheck` which failed due to pre-existing, broad repo type errors unrelated to this change (first error: missing module `../poi/types`). 
- Ran the focused test set with `npm run test:ci -- src/tests/failover.test.ts src/tests/textFallbackAccessibility.test.ts` and both files passed (total 94 tests passed). 
- Built and validated artifacts with `npm run build`, `npm run docs:check`, and `npm run smoke` which all completed successfully. 
- Captured a preview screenshot of `/?mode=text` using Playwright after installing required browser binaries and host deps (`npx playwright install` and `npx playwright install-deps chromium`), confirming the CTA renders visually. 

Notes: typechecking the entire repository surfaces existing unrelated type errors; the changes here are limited to the failover path, i18n entries, styles, and tests and do not modify immersive HUD behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e9def5f00832fa1bc4c71c825a599)