### PR TITLE
Add prominent “Try immersive again” CTA and shared text-fallback recovery

### DIFF
--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -99,6 +99,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         resumeLabel: 'Résumé (PDF)',
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
+      recoveryCta: {
+        title: 'Ready for the full neon tour?',
+        description:
+          'Retry the immersive scene now. This clears the saved text-mode preference and uses the same recovery path as pressing T.',
+        actionLabel: 'Try immersive again',
+        ariaLabel:
+          'Try immersive mode again and clear the saved text-mode preference',
+      },
       actions: {
         immersiveLink: 'Try immersive again',
         debugImmersiveLink: 'Debug: force immersive mode',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -255,6 +255,12 @@ export interface SiteTextFallbackStrings {
     resumeLabel: string;
     resumeUrl: string;
   };
+  recoveryCta: {
+    title: string;
+    description: string;
+    actionLabel: string;
+    ariaLabel: string;
+  };
   actions: {
     immersiveLink: string;
     debugImmersiveLink: string;

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -10,6 +10,7 @@ import {
   getPoiNarrativeLogStrings,
   getSiteStrings,
 } from '../../assets/i18n';
+import type { SiteTextFallbackStrings } from '../../assets/i18n';
 import { getPoiDefinitions } from '../../scene/poi/registry';
 import type { PoiLink } from '../../scene/poi/types';
 import type { FallbackReason } from '../../types/failover';
@@ -565,6 +566,14 @@ const clearStoredModePreference = () => {
   }
 };
 
+export const recoverFromTextFallback = (
+  documentTarget: Document,
+  immersiveUrl: string
+): void => {
+  clearStoredModePreference();
+  documentTarget.defaultView?.location.assign(immersiveUrl);
+};
+
 const installFallbackRecoveryShortcuts = (
   documentTarget: Document,
   immersiveUrl: string,
@@ -591,8 +600,7 @@ const installFallbackRecoveryShortcuts = (
       return;
     }
     event.preventDefault();
-    clearStoredModePreference();
-    windowTarget.location.assign(immersiveUrl);
+    recoverFromTextFallback(documentTarget, immersiveUrl);
   };
   windowTarget.addEventListener('keydown', handleKeydown);
   fallbackRecoveryCleanup.set(documentTarget, () => {
@@ -883,6 +891,41 @@ function createTimelineSection(
   return section;
 }
 
+function createFallbackRecoveryCta(
+  documentTarget: Document,
+  textFallbackStrings: SiteTextFallbackStrings,
+  immersiveUrl: string
+): HTMLElement {
+  const cta = documentTarget.createElement('section');
+  cta.className = 'text-fallback__recovery-cta';
+  cta.setAttribute('aria-labelledby', 'text-fallback-recovery-title');
+
+  const title = documentTarget.createElement('h2');
+  title.id = 'text-fallback-recovery-title';
+  title.className = 'text-fallback__recovery-title';
+  title.textContent = textFallbackStrings.recoveryCta.title;
+  cta.appendChild(title);
+
+  const description = documentTarget.createElement('p');
+  description.className = 'text-fallback__recovery-description';
+  description.textContent = textFallbackStrings.recoveryCta.description;
+  cta.appendChild(description);
+
+  const action = documentTarget.createElement('a');
+  action.href = immersiveUrl;
+  action.className = 'text-fallback__primary-action';
+  action.textContent = textFallbackStrings.recoveryCta.actionLabel;
+  action.ariaLabel = textFallbackStrings.recoveryCta.ariaLabel;
+  action.dataset.action = 'top-immersive-recovery';
+  action.addEventListener('click', (event) => {
+    event.preventDefault();
+    recoverFromTextFallback(documentTarget, immersiveUrl);
+  });
+  cta.appendChild(action);
+
+  return cta;
+}
+
 function createContactSection(
   documentTarget: Document,
   textFallbackStrings: SiteTextFallbackStrings,
@@ -1019,6 +1062,9 @@ export function renderTextFallback(
   description.textContent =
     descriptionStrings[reason] ?? descriptionStrings.manual;
   section.appendChild(description);
+  section.appendChild(
+    createFallbackRecoveryCta(documentTarget, textFallbackStrings, immersiveUrl)
+  );
 
   section.appendChild(createAboutSection(documentTarget, textFallbackStrings));
   section.appendChild(createSkillsSection(documentTarget, textFallbackStrings));
@@ -1045,7 +1091,10 @@ export function renderTextFallback(
   immersiveLink.textContent = actionStrings.immersiveLink;
   immersiveLink.rel = 'noopener';
   immersiveLink.dataset.action = 'immersive';
-  immersiveLink.addEventListener('click', clearStoredModePreference);
+  immersiveLink.addEventListener('click', (event) => {
+    event.preventDefault();
+    recoverFromTextFallback(documentTarget, immersiveUrl);
+  });
   immersiveItem.appendChild(immersiveLink);
   list.appendChild(immersiveItem);
 

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -5,10 +5,12 @@ import { getPoiDefinitions } from '../scene/poi/registry';
 import {
   evaluateFailoverDecision,
   isWebglSupported,
+  recoverFromTextFallback,
   renderTextFallback,
   type FallbackReason,
   type RenderTextFallbackOptions,
 } from '../systems/failover';
+import { MODE_PREFERENCE_KEY } from '../systems/failover/modePreference';
 import {
   createImmersiveModeUrl,
   createImmersiveRecoveryUrl,
@@ -856,6 +858,61 @@ describe('renderTextFallback', () => {
       container.querySelectorAll<HTMLAnchorElement>('.text-fallback__link')
     );
     expect(links.map((link) => link.href)).toContain('https://example.com/');
+  });
+
+  it('renders an obvious recovery CTA before fallback body content', () => {
+    const container = render('manual');
+    const cta = container.querySelector<HTMLElement>(
+      '.text-fallback__description + .text-fallback__recovery-cta'
+    );
+    const action = cta?.querySelector<HTMLAnchorElement>(
+      '[data-action="top-immersive-recovery"]'
+    );
+
+    expect(cta).toBeTruthy();
+    expect(cta?.textContent).toContain('Ready for the full neon tour?');
+    expect(action?.textContent).toBe('Try immersive again');
+    expect(action?.ariaLabel).toBe(
+      'Try immersive mode again and clear the saved text-mode preference'
+    );
+  });
+
+  it('uses shared recovery behavior for the top CTA', () => {
+    const container = render('manual', {
+      immersiveUrl: '/portfolio?mode=text',
+    });
+    const action = container.querySelector<HTMLAnchorElement>(
+      '[data-action="top-immersive-recovery"]'
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    action?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('clears text preference before shared recovery navigation', () => {
+    const assign = vi.fn();
+    const fakeDocument = {
+      defaultView: { location: { assign } },
+    } as unknown as Document;
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+
+    recoverFromTextFallback(fakeDocument, '/?mode=immersive');
+
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(assign).toHaveBeenCalledWith('/?mode=immersive');
   });
 
   it('defaults immersive link to the override-enforced URL when unspecified', () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -121,6 +121,81 @@ canvas {
   opacity: 0.88;
 }
 
+.text-fallback__recovery-cta {
+  margin: 0.35rem 0 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(120, 212, 255, 0.42);
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(89, 215, 255, 0.18),
+      transparent 55%
+    ),
+    linear-gradient(135deg, rgba(10, 24, 42, 0.96), rgba(13, 41, 58, 0.78));
+  box-shadow:
+    inset 0 0 0 1px rgba(14, 222, 255, 0.08),
+    0 18px 42px rgba(0, 12, 28, 0.45),
+    0 0 28px rgba(58, 188, 255, 0.16);
+}
+
+.text-fallback__recovery-title {
+  margin: 0;
+  color: #d7f4ff;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.text-fallback__recovery-description {
+  margin: 0;
+  color: rgba(236, 247, 255, 0.9);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.text-fallback__primary-action {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(182, 243, 255, 0.72);
+  border-radius: 999px;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(88, 183, 255, 0.95),
+      rgba(120, 255, 214, 0.88)
+    ),
+    #58b7ff;
+  color: #03111f;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  box-shadow:
+    0 0 22px rgba(88, 183, 255, 0.36),
+    0 12px 24px rgba(0, 9, 20, 0.35);
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease,
+    border-color 120ms ease;
+}
+
+.text-fallback__primary-action:hover,
+.text-fallback__primary-action:focus-visible {
+  border-color: #ffffff;
+  outline: none;
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 30px rgba(120, 255, 214, 0.42),
+    0 14px 28px rgba(0, 9, 20, 0.4);
+}
+
 .text-fallback__section-heading {
   margin: 0;
   font-size: 1.2rem;


### PR DESCRIPTION
### Motivation
- Make the text-only fallback clearly offer a single, obvious path back to immersive mode that matches the existing T shortcut behavior and avoids duplicated recovery logic.
- Preserve accessibility and theme consistency by adding an aria-labelled, keyboard-accessible primary action styled as the neon HUD.
- Keep the recovery behavior shared so manual links, the top CTA, and the T shortcut all behave identically (clear stored preference then navigate).

### Description
- Exported a reusable `recoverFromTextFallback(documentTarget: Document, immersiveUrl: string)` that clears saved mode preference and navigates to the immersive recovery URL, and wired the existing T key handler to call it instead of duplicating logic (`src/systems/failover/index.ts`).
- Added `createFallbackRecoveryCta(...)` and inserted a themed recovery CTA immediately after the fallback description with `data-action="top-immersive-recovery"` and an accessible aria label, and updated the lower immersive action link to reuse the shared recover function (`src/systems/failover/index.ts`).
- Added typed English copy for the CTA and extended `SiteTextFallbackStrings` (`src/assets/i18n/types.ts`, `src/assets/i18n/locales/en.ts`).
- Styled the CTA to match the dark neon HUD look and added tests covering CTA presence and shared recovery behavior (`src/ui/styles.css`, `src/tests/failover.test.ts`).

### Testing
- Ran `npm run format:write` — passed.
- Ran `npm run lint` — passed.
- Ran `npm run typecheck` — failed due to pre-existing repository-wide TypeScript issues unrelated to this change (reported but not introduced by this PR).
- Ran the focused tests `npm run test:ci -- src/tests/failover.test.ts src/tests/textFallbackAccessibility.test.ts` — passed.
- Ran full test suite `npm run test:ci` — passed (test run completed successfully in CI environment used here).
- Built and verified artifacts with `npm run build`, `npm run docs:check`, and `npm run smoke` — all passed.
- Performed Playwright browser installation and headless screenshot of `http://localhost:5173/?mode=text` for visual verification; environment required downloading Playwright browsers and OS deps which were installed and the capture completed.

Residual risk / follow-ups: the repo shows unrelated TypeScript errors during `npm run typecheck` that pre-exist this change and should be addressed separately; accessibility tests and focused unit tests for failover passed under the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e9def5f00832fa1bc4c71c825a599)