### PR TITLE
Add top “Try immersive again” CTA and shared fallback recovery

### DIFF
--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -16,6 +16,13 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       intro: wrap(
         'The text portfolio keeps every exhibit accessible with quick summaries, outcomes, and metrics while immersive mode is unavailable.'
       ),
+      retryCta: {
+        title: wrap('Want the full 3D room?'),
+        description: wrap(
+          'Clear text-only mode and relaunch the immersive portfolio when your device is ready.'
+        ),
+        ariaLabel: wrap('Try immersive mode again'),
+      },
       roomHeadingTemplate: wrap('{roomName} exhibits'),
       metricsHeading: wrap('Key metrics'),
       linksHeading: wrap('Further reading'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -28,6 +28,12 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       heading: 'Explore the highlights',
       intro:
         'The text portfolio keeps every exhibit accessible with quick summaries, outcomes, and metrics while immersive mode is unavailable.',
+      retryCta: {
+        title: 'Want the full 3D room?',
+        description:
+          'Clear text-only mode and relaunch the immersive portfolio when your device is ready.',
+        ariaLabel: 'Try immersive mode again',
+      },
       roomHeadingTemplate: '{roomName} exhibits',
       metricsHeading: 'Key metrics',
       linksHeading: 'Further reading',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -221,6 +221,11 @@ export interface SiteStructuredDataStrings {
 export interface SiteTextFallbackStrings {
   heading: string;
   intro: string;
+  retryCta: {
+    title: string;
+    description: string;
+    ariaLabel: string;
+  };
   roomHeadingTemplate: string;
   metricsHeading: string;
   linksHeading: string;

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -9,6 +9,7 @@ import {
   getPoiCopy,
   getPoiNarrativeLogStrings,
   getSiteStrings,
+  type SiteTextFallbackStrings,
 } from '../../assets/i18n';
 import { getPoiDefinitions } from '../../scene/poi/registry';
 import type { PoiLink } from '../../scene/poi/types';
@@ -565,6 +566,25 @@ const clearStoredModePreference = () => {
   }
 };
 
+export const recoverFromTextFallback = (
+  windowTarget: Window,
+  immersiveUrl: string
+): void => {
+  clearStoredModePreference();
+  windowTarget.location.assign(immersiveUrl);
+};
+
+const createFallbackRecoveryHandler =
+  (documentTarget: Document, immersiveUrl: string) => (event: Event) => {
+    event.preventDefault();
+    const windowTarget = documentTarget.defaultView;
+    if (!windowTarget) {
+      clearStoredModePreference();
+      return;
+    }
+    recoverFromTextFallback(windowTarget, immersiveUrl);
+  };
+
 const installFallbackRecoveryShortcuts = (
   documentTarget: Document,
   immersiveUrl: string,
@@ -591,8 +611,7 @@ const installFallbackRecoveryShortcuts = (
       return;
     }
     event.preventDefault();
-    clearStoredModePreference();
-    windowTarget.location.assign(immersiveUrl);
+    recoverFromTextFallback(windowTarget, immersiveUrl);
   };
   windowTarget.addEventListener('keydown', handleKeydown);
   fallbackRecoveryCleanup.set(documentTarget, () => {
@@ -1020,6 +1039,41 @@ export function renderTextFallback(
     descriptionStrings[reason] ?? descriptionStrings.manual;
   section.appendChild(description);
 
+  const retryCta = documentTarget.createElement('section');
+  retryCta.className = 'text-fallback__retry';
+  retryCta.dataset.actionBlock = 'immersive-retry';
+  const retryTitleId = 'text-fallback-immersive-retry-title';
+  const retryDescriptionId = 'text-fallback-immersive-retry-description';
+  retryCta.setAttribute('aria-labelledby', retryTitleId);
+  retryCta.setAttribute('aria-describedby', retryDescriptionId);
+
+  const retryTitle = documentTarget.createElement('h2');
+  retryTitle.id = retryTitleId;
+  retryTitle.className = 'text-fallback__retry-title';
+  retryTitle.textContent = textFallbackStrings.retryCta.title;
+  retryCta.appendChild(retryTitle);
+
+  const retryDescription = documentTarget.createElement('p');
+  retryDescription.id = retryDescriptionId;
+  retryDescription.className = 'text-fallback__retry-description';
+  retryDescription.textContent = textFallbackStrings.retryCta.description;
+  retryCta.appendChild(retryDescription);
+
+  const retryLink = documentTarget.createElement('a');
+  retryLink.href = immersiveUrl;
+  retryLink.className = 'text-fallback__link text-fallback__primary-action';
+  retryLink.textContent = actionStrings.immersiveLink;
+  retryLink.rel = 'noopener';
+  retryLink.dataset.action = 'immersive';
+  retryLink.setAttribute('aria-label', textFallbackStrings.retryCta.ariaLabel);
+  retryLink.addEventListener(
+    'click',
+    createFallbackRecoveryHandler(documentTarget, immersiveUrl)
+  );
+  retryCta.appendChild(retryLink);
+
+  section.appendChild(retryCta);
+
   section.appendChild(createAboutSection(documentTarget, textFallbackStrings));
   section.appendChild(createSkillsSection(documentTarget, textFallbackStrings));
   section.appendChild(
@@ -1045,7 +1099,10 @@ export function renderTextFallback(
   immersiveLink.textContent = actionStrings.immersiveLink;
   immersiveLink.rel = 'noopener';
   immersiveLink.dataset.action = 'immersive';
-  immersiveLink.addEventListener('click', clearStoredModePreference);
+  immersiveLink.addEventListener(
+    'click',
+    createFallbackRecoveryHandler(documentTarget, immersiveUrl)
+  );
   immersiveItem.appendChild(immersiveLink);
   list.appendChild(immersiveItem);
 

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -9,6 +9,7 @@ import {
   type FallbackReason,
   type RenderTextFallbackOptions,
 } from '../systems/failover';
+import { MODE_PREFERENCE_KEY } from '../systems/failover/modePreference';
 import {
   createImmersiveModeUrl,
   createImmersiveRecoveryUrl,
@@ -858,6 +859,32 @@ describe('renderTextFallback', () => {
     expect(links.map((link) => link.href)).toContain('https://example.com/');
   });
 
+  it('renders a primary immersive retry CTA before profile content', () => {
+    const container = render('manual');
+    const retry = container.querySelector<HTMLElement>(
+      '[data-action-block="immersive-retry"]'
+    );
+    const retryLink = retry?.querySelector<HTMLAnchorElement>(
+      '[data-action="immersive"]'
+    );
+    const about = container.querySelector<HTMLElement>('.text-fallback__about');
+
+    expect(retry).toBeTruthy();
+    expect(retry?.textContent).toContain('Want the full 3D room?');
+    expect(retryLink?.textContent).toBe('Try immersive again');
+    expect(retryLink?.getAttribute('aria-label')).toBe(
+      'Try immersive mode again'
+    );
+    expect(
+      retry && about
+        ? Boolean(
+            retry.compareDocumentPosition(about) &
+              Node.DOCUMENT_POSITION_FOLLOWING
+          )
+        : false
+    ).toBe(true);
+  });
+
   it('defaults immersive link to the override-enforced URL when unspecified', () => {
     const container = render('manual');
     const immersiveLink = container.querySelector<HTMLAnchorElement>(
@@ -914,6 +941,28 @@ describe('renderTextFallback', () => {
     ).toBeNull();
   });
 
+  it('uses shared fallback recovery for the top CTA and stored text preference', () => {
+    const container = render('manual', { immersiveUrl: '/retry' });
+    const retryLink = container.querySelector<HTMLAnchorElement>(
+      '[data-action-block="immersive-retry"] [data-action="immersive"]'
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    window.sessionStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    retryLink?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it('replaces fallback T recovery handlers between repeated renders', () => {
     const container = document.createElement('div');
     const consoleErrorSpy = vi
@@ -933,6 +982,9 @@ describe('renderTextFallback', () => {
       githubUrl: 'https://example.com',
     });
 
+    window.localStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+    window.sessionStorage.setItem(MODE_PREFERENCE_KEY, 'text');
+
     const event = new KeyboardEvent('keydown', {
       key: 't',
       bubbles: true,
@@ -941,6 +993,8 @@ describe('renderTextFallback', () => {
     window.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(true);
+    expect(window.localStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(MODE_PREFERENCE_KEY)).toBeNull();
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
 
     consoleErrorSpy.mockRestore();

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -121,6 +121,86 @@ canvas {
   opacity: 0.88;
 }
 
+.text-fallback__retry {
+  position: relative;
+  margin-top: 0.25rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow: hidden;
+  border: 1px solid rgba(115, 225, 255, 0.36);
+  border-radius: 1rem;
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(94, 234, 212, 0.2),
+      transparent 45%
+    ),
+    linear-gradient(135deg, rgba(11, 27, 45, 0.95), rgba(9, 19, 34, 0.92));
+  box-shadow:
+    0 0 0 1px rgba(143, 214, 255, 0.1) inset,
+    0 18px 44px rgba(0, 8, 20, 0.45),
+    0 0 32px rgba(56, 189, 248, 0.16);
+}
+
+.text-fallback__retry::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    rgba(143, 214, 255, 0.18),
+    transparent 45%
+  );
+  opacity: 0.72;
+}
+
+.text-fallback__retry-title,
+.text-fallback__retry-description,
+.text-fallback__primary-action {
+  position: relative;
+}
+
+.text-fallback__retry-title {
+  margin: 0;
+  color: #dff7ff;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.text-fallback__retry-description {
+  margin: 0;
+  color: rgba(236, 244, 255, 0.9);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.text-fallback__primary-action {
+  width: fit-content;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(190, 242, 255, 0.58);
+  border-radius: 999px;
+  color: #03131f;
+  background: linear-gradient(135deg, #b6f3ff, #60d5ff 52%, #a78bfa);
+  box-shadow:
+    0 0 24px rgba(96, 213, 255, 0.34),
+    0 10px 26px rgba(8, 16, 28, 0.5);
+  text-decoration: none;
+}
+
+.text-fallback__primary-action:hover,
+.text-fallback__primary-action:focus {
+  color: #020817;
+  text-decoration: none;
+  box-shadow:
+    0 0 0 3px rgba(182, 243, 255, 0.22),
+    0 0 32px rgba(96, 213, 255, 0.48),
+    0 12px 30px rgba(8, 16, 28, 0.55);
+}
+
 .text-fallback__section-heading {
   margin: 0;
   font-size: 1.2rem;


### PR DESCRIPTION
### Motivation
- Make the text-only fallback clearly offer the immersive recovery action before the profile content and reuse existing T-key recovery behavior to avoid duplicated logic.
- Ensure the retry action clears any saved text-mode preference and navigates to the same immersive recovery URL while preserving the debug bypass link behavior.

### Description
- Add a shared recovery helper `recoverFromTextFallback(window, immersiveUrl)` and a `createFallbackRecoveryHandler` used by the T-key shortcut and immersive CTA/link in `src/systems/failover/index.ts`.
- Insert a prominent, accessible top CTA block (title, description, primary action link) immediately after the fallback heading/description in `renderTextFallback` and wire it to the shared recovery handler.
- Add new i18n keys and types (`retryCta` in `SiteTextFallbackStrings`) and provide English and pseudo-locale copy in `src/assets/i18n/locales/en.ts` and `en-x-pseudo.ts`.
- Style the CTA to match the dark neon HUD theme in `src/ui/styles.css` and update tests in `src/tests/failover.test.ts` to assert CTA presence and shared recovery behavior.

### Testing
- Ran formatting with `npm run format:write` (passed).
- Ran lint with `npm run lint` (passed).
- Ran focused unit tests with `npm run test:ci -- src/tests/failover.test.ts src/tests/textFallbackAccessibility.test.ts` (both files passed).
- Built production bundle with `npm run build` (passed) and ran `npm run smoke` (passed).
- Ran full test suite with `npm run test:ci` (all tests passed in CI run observed).
- Verified docs check with `npm run docs:check` (passed).
- Captured a visual verification via Playwright after installing browser dependencies; `npx playwright screenshot ... '?mode=text'` produced the fallback screenshot (succeeded after installing Playwright browsers and host deps).
- Note: `npm run typecheck` reports pre-existing repository-wide type errors unrelated to this change (failed), so typechecking was not fully green in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e9def5f00832fa1bc4c71c825a599)