### PR TITLE
Add top “Try immersive again” CTA and shared fallback recovery

### DIFF
--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -94,6 +94,13 @@ export const AR_OVERRIDES: LocaleOverrides = {
         resumeLabel: 'السيرة الذاتية (PDF)',
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
+      recoveryCta: {
+        title: 'هل أنت مستعد للجولة الغامرة الكاملة؟',
+        description:
+          'يمسح تفضيل العرض النصي المحفوظ ويعيد تشغيل مشهد WebGL عبر مسار الاسترداد المعتاد.',
+        actionLabel: 'جرّب الوضع الغامر مجددًا',
+        ariaLabel: 'جرّب الوضع الغامر مجددًا',
+      },
       actions: {
         immersiveLink: 'جرّب الوضع الغامر مجددًا',
         debugImmersiveLink: 'تصحيح: فرض الوضع الغامر',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -100,6 +100,14 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         resumeLabel: wrap('Résumé (PDF)'),
         resumeUrl: wrap('docs/resume/2025-09/resume.pdf'),
       },
+      recoveryCta: {
+        title: wrap('Ready for the full immersive tour?'),
+        description: wrap(
+          'Clear the saved text preference and relaunch the WebGL scene with the standard recovery path.'
+        ),
+        actionLabel: wrap('Try immersive again'),
+        ariaLabel: wrap('Try immersive mode again'),
+      },
       actions: {
         immersiveLink: wrap('Try immersive again'),
         debugImmersiveLink: wrap('Debug: force immersive mode'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -99,6 +99,13 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         resumeLabel: 'Résumé (PDF)',
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
+      recoveryCta: {
+        title: 'Ready for the full immersive tour?',
+        description:
+          'Clear the saved text preference and relaunch the WebGL scene with the standard recovery path.',
+        actionLabel: 'Try immersive again',
+        ariaLabel: 'Try immersive mode again',
+      },
       actions: {
         immersiveLink: 'Try immersive again',
         debugImmersiveLink: 'Debug: force immersive mode',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -94,6 +94,13 @@ export const JA_OVERRIDES: LocaleOverrides = {
         resumeLabel: '履歴書 (PDF)',
         resumeUrl: 'docs/resume/2025-09/resume.pdf',
       },
+      recoveryCta: {
+        title: '没入型ツアーをもう一度開きますか？',
+        description:
+          '保存済みのテキスト設定を消去し、標準の復帰パスで WebGL シーンを再起動します。',
+        actionLabel: '没入モードをもう一度試す',
+        ariaLabel: '没入モードをもう一度試す',
+      },
       actions: {
         immersiveLink: '没入モードをもう一度試す',
         debugImmersiveLink: 'デバッグ: 没入モードを強制',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -255,6 +255,12 @@ export interface SiteTextFallbackStrings {
     resumeLabel: string;
     resumeUrl: string;
   };
+  recoveryCta: {
+    title: string;
+    description: string;
+    actionLabel: string;
+    ariaLabel: string;
+  };
   actions: {
     immersiveLink: string;
     debugImmersiveLink: string;

--- a/src/systems/failover/index.ts
+++ b/src/systems/failover/index.ts
@@ -9,6 +9,7 @@ import {
   getPoiCopy,
   getPoiNarrativeLogStrings,
   getSiteStrings,
+  type SiteTextFallbackStrings,
 } from '../../assets/i18n';
 import { getPoiDefinitions } from '../../scene/poi/registry';
 import type { PoiLink } from '../../scene/poi/types';
@@ -565,6 +566,26 @@ const clearStoredModePreference = () => {
   }
 };
 
+export interface FallbackRecoveryOptions {
+  windowTarget?: Pick<Window, 'location'>;
+  clearPreference?: () => void;
+  navigate?: (immersiveUrl: string) => void;
+}
+
+export function recoverFromTextFallback(
+  immersiveUrl: string,
+  options: FallbackRecoveryOptions = {}
+): void {
+  const {
+    windowTarget = typeof window !== 'undefined' ? window : undefined,
+    clearPreference = clearStoredModePreference,
+    navigate = (targetUrl: string) => windowTarget?.location.assign(targetUrl),
+  } = options;
+
+  clearPreference();
+  navigate(immersiveUrl);
+}
+
 const installFallbackRecoveryShortcuts = (
   documentTarget: Document,
   immersiveUrl: string,
@@ -591,14 +612,64 @@ const installFallbackRecoveryShortcuts = (
       return;
     }
     event.preventDefault();
-    clearStoredModePreference();
-    windowTarget.location.assign(immersiveUrl);
+    recoverFromTextFallback(immersiveUrl, { windowTarget });
   };
   windowTarget.addEventListener('keydown', handleKeydown);
   fallbackRecoveryCleanup.set(documentTarget, () => {
     windowTarget.removeEventListener('keydown', handleKeydown);
   });
 };
+
+const handleFallbackRecoveryClick = (
+  event: MouseEvent,
+  immersiveUrl: string,
+  windowTarget: Window | null
+) => {
+  event.preventDefault();
+  recoverFromTextFallback(immersiveUrl, {
+    windowTarget: windowTarget ?? undefined,
+  });
+};
+
+function createRecoveryCta(
+  documentTarget: Document,
+  textFallbackStrings: SiteTextFallbackStrings,
+  immersiveUrl: string
+): HTMLElement {
+  const ctaStrings = textFallbackStrings.recoveryCta;
+  const section = documentTarget.createElement('section');
+  section.className = 'text-fallback__recovery-cta';
+  section.setAttribute('aria-labelledby', 'text-fallback-recovery-title');
+
+  const heading = documentTarget.createElement('h2');
+  heading.id = 'text-fallback-recovery-title';
+  heading.className = 'text-fallback__recovery-title';
+  heading.textContent = ctaStrings.title;
+  section.appendChild(heading);
+
+  const description = documentTarget.createElement('p');
+  description.className = 'text-fallback__recovery-description';
+  description.textContent = ctaStrings.description;
+  section.appendChild(description);
+
+  const link = documentTarget.createElement('a');
+  link.href = immersiveUrl;
+  link.className = 'text-fallback__primary-action';
+  link.textContent = ctaStrings.actionLabel;
+  link.setAttribute('aria-label', ctaStrings.ariaLabel);
+  link.rel = 'noopener';
+  link.dataset.action = 'immersive-recovery-cta';
+  link.addEventListener('click', (event) => {
+    handleFallbackRecoveryClick(
+      event,
+      immersiveUrl,
+      documentTarget.defaultView
+    );
+  });
+  section.appendChild(link);
+
+  return section;
+}
 
 function buildTextPortfolioGroups(
   localeHint?: string
@@ -1019,6 +1090,9 @@ export function renderTextFallback(
   description.textContent =
     descriptionStrings[reason] ?? descriptionStrings.manual;
   section.appendChild(description);
+  section.appendChild(
+    createRecoveryCta(documentTarget, textFallbackStrings, immersiveUrl)
+  );
 
   section.appendChild(createAboutSection(documentTarget, textFallbackStrings));
   section.appendChild(createSkillsSection(documentTarget, textFallbackStrings));
@@ -1041,11 +1115,18 @@ export function renderTextFallback(
   immersiveItem.className = 'text-fallback__action';
   const immersiveLink = documentTarget.createElement('a');
   immersiveLink.href = immersiveUrl;
-  immersiveLink.className = 'text-fallback__link';
+  immersiveLink.className =
+    'text-fallback__link text-fallback__link--secondary';
   immersiveLink.textContent = actionStrings.immersiveLink;
   immersiveLink.rel = 'noopener';
   immersiveLink.dataset.action = 'immersive';
-  immersiveLink.addEventListener('click', clearStoredModePreference);
+  immersiveLink.addEventListener('click', (event) => {
+    handleFallbackRecoveryClick(
+      event,
+      immersiveUrl,
+      documentTarget.defaultView
+    );
+  });
   immersiveItem.appendChild(immersiveLink);
   list.appendChild(immersiveItem);
 

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -5,6 +5,7 @@ import { getPoiDefinitions } from '../scene/poi/registry';
 import {
   evaluateFailoverDecision,
   isWebglSupported,
+  recoverFromTextFallback,
   renderTextFallback,
   type FallbackReason,
   type RenderTextFallbackOptions,
@@ -833,6 +834,19 @@ describe('evaluateFailoverDecision', () => {
 });
 
 describe('renderTextFallback', () => {
+  it('shares recovery behavior for clearing preference and navigation', () => {
+    const clearPreference = vi.fn();
+    const navigate = vi.fn();
+
+    recoverFromTextFallback('/portfolio?mode=immersive', {
+      clearPreference,
+      navigate,
+    });
+
+    expect(clearPreference).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/portfolio?mode=immersive');
+  });
+
   const render = (
     reason: FallbackReason,
     overrides: Partial<RenderTextFallbackOptions> = {}
@@ -856,6 +870,57 @@ describe('renderTextFallback', () => {
       container.querySelectorAll<HTMLAnchorElement>('.text-fallback__link')
     );
     expect(links.map((link) => link.href)).toContain('https://example.com/');
+  });
+
+  it('renders a primary recovery CTA before portfolio content', () => {
+    const container = render('manual');
+    const cta = container.querySelector<HTMLElement>(
+      '.text-fallback__recovery-cta'
+    );
+    const ctaLink = container.querySelector<HTMLAnchorElement>(
+      '[data-action="immersive-recovery-cta"]'
+    );
+    const about = container.querySelector('.text-fallback__about');
+
+    expect(cta).toBeTruthy();
+    expect(cta?.textContent).toContain('Try immersive again');
+    expect(ctaLink?.getAttribute('aria-label')).toBe(
+      'Try immersive mode again'
+    );
+    expect(ctaLink?.classList.contains('text-fallback__primary-action')).toBe(
+      true
+    );
+    expect(
+      cta && about
+        ? cta.compareDocumentPosition(about) & Node.DOCUMENT_POSITION_FOLLOWING
+        : 0
+    ).toBeTruthy();
+  });
+
+  it('uses shared recovery behavior when the top CTA is activated', () => {
+    const container = render('manual', { immersiveUrl: '/immersive' });
+    const ctaLink = container.querySelector<HTMLAnchorElement>(
+      '[data-action="immersive-recovery-cta"]'
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    localStorage.setItem('danielsmith.io:mode-preference', 'text');
+    sessionStorage.setItem('danielsmith.io:mode-preference', 'text');
+
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    ctaLink?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(localStorage.getItem('danielsmith.io:mode-preference')).toBeNull();
+    expect(sessionStorage.getItem('danielsmith.io:mode-preference')).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('defaults immersive link to the override-enforced URL when unspecified', () => {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -121,6 +121,85 @@ canvas {
   opacity: 0.88;
 }
 
+.text-fallback__recovery-cta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(120, 212, 168, 0.4);
+  background:
+    radial-gradient(
+      circle at 15% 0%,
+      rgba(120, 212, 168, 0.18),
+      transparent 45%
+    ),
+    linear-gradient(135deg, rgba(9, 24, 39, 0.92), rgba(8, 38, 48, 0.82));
+  box-shadow:
+    inset 0 0 0 1px rgba(143, 214, 255, 0.12),
+    0 18px 48px rgba(0, 12, 28, 0.45),
+    0 0 28px rgba(120, 212, 168, 0.16);
+}
+
+.text-fallback__recovery-title {
+  margin: 0;
+  color: #e7fff2;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.text-fallback__recovery-description {
+  margin: 0;
+  color: rgba(236, 244, 255, 0.86);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.text-fallback__primary-action {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.72rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(143, 214, 255, 0.58);
+  background:
+    linear-gradient(135deg, rgba(120, 212, 168, 0.95), rgba(72, 188, 255, 0.9)),
+    #78d4a8;
+  color: #03101a;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  text-transform: uppercase;
+  box-shadow:
+    0 0 0 1px rgba(236, 244, 255, 0.16),
+    0 10px 24px rgba(72, 188, 255, 0.24),
+    0 0 20px rgba(120, 212, 168, 0.22);
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.text-fallback__primary-action:hover,
+.text-fallback__primary-action:focus-visible {
+  border-color: rgba(236, 244, 255, 0.82);
+  box-shadow:
+    0 0 0 2px rgba(143, 214, 255, 0.2),
+    0 14px 32px rgba(72, 188, 255, 0.32),
+    0 0 26px rgba(120, 212, 168, 0.32);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.text-fallback__primary-action:focus-visible {
+  outline: 2px solid rgba(236, 244, 255, 0.95);
+  outline-offset: 3px;
+}
+
 .text-fallback__section-heading {
   margin: 0;
   font-size: 1.2rem;


### PR DESCRIPTION
### Motivation
- Provide an obvious, theme-matching primary action at the top of the text-only fallback so users can relaunch immersive mode without hunting for the lower link or relying on the `T` shortcut. 
- Reuse the same recovery behavior as the `T` keyboard shortcut to avoid duplicate logic and keep behavior consistent. 
- Make the CTA localizable and accessible, and style it to match the dark neon HUD theme.

### Description
- Add a shared recovery helper `recoverFromTextFallback(immersiveUrl, options)` in `src/systems/failover/index.ts` that clears stored mode preference and navigates to the immersive recovery URL, and wire the existing `T` shortcut to call it. 
- Create a top recovery block (`createRecoveryCta`) inserted immediately after the fallback heading/description and wire its click to the shared recovery handler; convert the lower immersive link to use the same handler for consistency. 
- Add `recoveryCta` fields to `SiteTextFallbackStrings` and provide English, Arabic, Japanese and pseudo-localized strings in `src/assets/i18n/locales/*`. 
- Add dark-neon HUD styling for the CTA in `src/ui/styles.css` (primary-action styles, focus-visible outline, container chrome). 
- Add unit tests in `src/tests/failover.test.ts` that verify the helper behavior, top CTA presence/order, aria-label, and that the CTA clears stored preferences when activated.

### Testing
- Ran formatting: `npm run format:write` — passed. 
- Lint: `npm run lint` — passed. 
- Typecheck: `npm run typecheck` — failed; failures are existing repository TypeScript issues unrelated to the changes (missing/ambient POI types and other pre-existing TS errors). 
- Focused tests: `npm run test:ci -- src/tests/failover.test.ts src/tests/textFallbackAccessibility.test.ts` — passed (these files passed). 
- Full test suite: `npm run test:ci` — passed (all tests in repo passed in CI run). 
- Build: `npm run build` — passed. 
- Smoke: `npm run smoke` — passed. 
- Docs check: `npm run docs:check` — passed. 
- Playwright: installed browsers and host deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, then captured a verification screenshot of `/?mode=text` (screenshot saved as `/tmp/text-fallback-cta.png`) — succeeded. 
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

Residual risks / follow-ups: the repo shows unrelated TypeScript errors under `npm run typecheck`; this change did not introduce those and tests/build succeeded despite them, but a separate follow-up to fix global type issues is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e9def5f00832fa1bc4c71c825a599)