### PR TITLE
Refine POI copy and Sigma signage; update i18n, press-kit, and tests

### DIFF
--- a/docs/assets/press-kit.json
+++ b/docs/assets/press-kit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtIso": "2026-06-02T09:18:49.290Z",
+  "generatedAtIso": "2026-06-02T17:25:49.601Z",
   "performance": {
     "budget": {
       "maxMaterials": 36,
@@ -293,6 +293,18 @@
       },
       "metrics": [
         {
+          "label": "Stars",
+          "value": "Syncing from GitHub…",
+          "source": {
+            "type": "githubStars",
+            "owner": "futuroptimist",
+            "repo": "jobbot3000",
+            "format": "compact",
+            "template": "{value} stars",
+            "fallback": "Syncing from GitHub…"
+          }
+        },
+        {
           "label": "Status",
           "value": "Local-first CLI with preview web UI"
         },
@@ -523,11 +535,11 @@
         },
         {
           "label": "Hardware",
-          "value": "ESP32 · on-device speech stack"
+          "value": "ESP32 · OpenSCAD enclosure"
         },
         {
           "label": "Modes",
-          "value": "Push-to-talk · local inference loops"
+          "value": "Push-to-talk · Whisper + TTS relay"
         }
       ],
       "links": [

--- a/docs/assets/press-kit.json
+++ b/docs/assets/press-kit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtIso": "2025-12-06T08:41:16.687Z",
+  "generatedAtIso": "2026-06-02T09:18:49.290Z",
   "performance": {
     "budget": {
       "maxMaterials": 36,
@@ -53,7 +53,9 @@
         "remainingPercent": 0.2222222222222222,
         "overBudgetBy": 0,
         "status": "within-budget",
-        "label": "Within budget · 78% used · 22% remaining."
+        "label": "Within budget · 78% used · 22% remaining (8 materials headroom).",
+        "statusLabel": "Within budget",
+        "remainingPercentLabel": "22% remaining"
       },
       "drawCalls": {
         "remaining": 18,
@@ -61,7 +63,9 @@
         "remainingPercent": 0.12,
         "overBudgetBy": 0,
         "status": "within-budget",
-        "label": "Within budget · 88% used · 12% remaining."
+        "label": "Within budget · 88% used · 12% remaining (18 draw calls headroom).",
+        "statusLabel": "Within budget",
+        "remainingPercentLabel": "12% remaining"
       },
       "textureBytes": {
         "remaining": 6291456,
@@ -69,7 +73,9 @@
         "remainingPercent": 0.25,
         "overBudgetBy": 0,
         "status": "within-budget",
-        "label": "Within budget · 75% used · 25% remaining."
+        "label": "Within budget · 75% used · 25% remaining (6,291,456 bytes headroom).",
+        "statusLabel": "Within budget",
+        "remainingPercentLabel": "25% remaining"
       }
     }
   },
@@ -84,8 +90,8 @@
   "poiCatalog": [
     {
       "id": "futuroptimist-living-room-tv",
-      "title": "Futuroptimist Creator Desk",
-      "summary": "Triple-monitor editing bay capturing Futuroptimist releases with a live showreel, timeline, and automation overlays.",
+      "title": "Futuroptimist",
+      "summary": "Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -133,8 +139,8 @@
     },
     {
       "id": "tokenplace-studio-cluster",
-      "title": "token.place Compute Rack",
-      "summary": "3D-printed Raspberry Pi lattice orchestrating the token.place volunteer compute mesh with pulsing status beacons.",
+      "title": "token.place",
+      "summary": "Secure peer-to-peer generative AI platform running on a Raspberry Pi lattice with encrypted relay and server nodes.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -182,8 +188,8 @@
     },
     {
       "id": "gabriel-studio-sentry",
-      "title": "Gabriel Sentinel Rover",
-      "summary": "Autonomous sentry robot with a rotating scanner that sweeps the studio and fires a red perimeter pulse every second.",
+      "title": "Gabriel",
+      "summary": "Privacy-first \"guardian angel\" LLM that delivers local security coaching and integrates with token.place or offline inference.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -227,8 +233,8 @@
     },
     {
       "id": "flywheel-studio-flywheel",
-      "title": "Flywheel Kinetic Hub",
-      "summary": "Kinetic automation hub that accelerates with approach, revealing tech stack glow and docs callouts.",
+      "title": "Flywheel",
+      "summary": "GitHub template and automation hub that bundles linting, tests, docs, and Codex prompts for fast repo bootstrapping.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -276,8 +282,8 @@
     },
     {
       "id": "jobbot-studio-terminal",
-      "title": "Jobbot Holographic Terminal",
-      "summary": "Holographic command desk broadcasting live telemetry from the Jobbot3000 automation mesh.",
+      "title": "Jobbot3000",
+      "summary": "Self-hosted job search copilot with CLI and experimental web UI for ingesting outreach and tracking applications.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -287,24 +293,16 @@
       },
       "metrics": [
         {
-          "label": "Stars",
-          "value": "Syncing from GitHub…",
-          "source": {
-            "type": "githubStars",
-            "owner": "futuroptimist",
-            "repo": "jobbot3000",
-            "format": "compact",
-            "template": "{value} stars",
-            "fallback": "Syncing from GitHub…"
-          }
+          "label": "Status",
+          "value": "Local-first CLI with preview web UI"
         },
         {
-          "label": "Ops savings",
-          "value": "Recovered 6h weekly toil"
+          "label": "Stack",
+          "value": "Node.js 20+ · npm scripts · Playwright preview"
         },
         {
-          "label": "Reliability",
-          "value": "99.98% SLA self-healing loops"
+          "label": "Flows",
+          "value": "Recruiter outreach ingestion and lifecycle tracking"
         }
       ],
       "links": [
@@ -325,8 +323,8 @@
     },
     {
       "id": "axel-studio-tracker",
-      "title": "Axel Quest Navigator",
-      "summary": "Tabletop command slate where Axel curates next-step quests, projecting repo insights and backlog momentum rings.",
+      "title": "Axel",
+      "summary": "Goal and quest tracker that organizes repos with agentic LLMs, analytics helpers, and a pipx-friendly CLI.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -336,24 +334,16 @@
       },
       "metrics": [
         {
-          "label": "Stars",
-          "value": "Syncing from GitHub…",
-          "source": {
-            "type": "githubStars",
-            "owner": "futuroptimist",
-            "repo": "axel",
-            "format": "compact",
-            "template": "{value} stars",
-            "fallback": "Syncing from GitHub…"
-          }
+          "label": "Status",
+          "value": "Alpha · pipx install axel"
         },
         {
-          "label": "Guidance",
-          "value": "Auto-prioritised quests from repo scans"
+          "label": "Repo analytics",
+          "value": "Quest planning from repo lists and scans"
         },
         {
-          "label": "Modes",
-          "value": "Focus · explore toggles per sprint"
+          "label": "Docs",
+          "value": "FAQ · known issues · threat model kept with tests"
         }
       ],
       "links": [
@@ -370,8 +360,8 @@
     },
     {
       "id": "gitshelves-living-room-installation",
-      "title": "Gitshelves Living Room Array",
-      "summary": "Modular wall of 3D-printed commit blocks that transform GitHub streaks into physical shelving mosaics.",
+      "title": "Gitshelves",
+      "summary": "CLI that turns GitHub contribution data into OpenSCAD and STL models for 3D-printed Gridfinity shelves.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -415,8 +405,8 @@
     },
     {
       "id": "danielsmith-portfolio-table",
-      "title": "danielsmith.io Holographic Map",
-      "summary": "Holotable overview of danielsmith.io with layered navigation routes, accessibility presets, and deploy targets.",
+      "title": "danielsmith.io",
+      "summary": "Orthographic Three.js/WebGL portfolio with keyboard navigation and a resilient text fallback for accessibility.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -464,8 +454,8 @@
     },
     {
       "id": "f2clipboard-kitchen-console",
-      "title": "f2clipboard Incident Console",
-      "summary": "Kitchen-side diagnostics station where f2clipboard parses Codex logs and pipes concise summaries straight to the clipboard.",
+      "title": "f2clipboard",
+      "summary": "CLI that ingests Codex task pages and GitHub logs, redacts secrets, and emits ready-to-paste Markdown summaries.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -509,8 +499,8 @@
     },
     {
       "id": "sigma-kitchen-workbench",
-      "title": "Sigma Fabrication Bench",
-      "summary": "Workbench showcasing the Sigma ESP32 AI pin with on-device speech, local inference, and 3D-printed shells.",
+      "title": "Sigma",
+      "summary": "ESP32 \"AI pin\" that streams push-to-talk audio to Whisper and returns TTS in a 3D-printed OpenSCAD enclosure.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -554,8 +544,8 @@
     },
     {
       "id": "wove-kitchen-loom",
-      "title": "Wove Loom Atelier",
-      "summary": "Soft robotics loom where Wove bridges CAD workflows with textiles while teaching knit and crochet fundamentals.",
+      "title": "Wove",
+      "summary": "Open-source toolkit for learning knitting and crochet while building toward a robotic loom with OpenSCAD hardware.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -599,8 +589,8 @@
     },
     {
       "id": "dspace-backyard-rocket",
-      "title": "DSPACE Launch Pad",
-      "summary": "Backyard launch gantry staging the DSPACE model rocket with telemetry-guided countdown cues.",
+      "title": "DSPACE",
+      "summary": "Backyard launch gantry for the private DSPACE rocket project with telemetry-guided countdown cues and a public mission log.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -649,8 +639,8 @@
     },
     {
       "id": "pr-reaper-backyard-console",
-      "title": "PR Reaper Automation Gate",
-      "summary": "Backyard control gate that visualises pr-reaper sweeping stale pull requests with safe dry-runs and audit logs.",
+      "title": "PR Reaper",
+      "summary": "GitHub Actions workflow that bulk-closes stale pull requests with dry-run previews and optional branch cleanup.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -694,8 +684,8 @@
     },
     {
       "id": "sugarkube-backyard-greenhouse",
-      "title": "Sugarkube Solar Greenhouse",
-      "summary": "Adaptive greenhouse showcasing Sugarkube automation with responsive grow lights and solar tracking.",
+      "title": "Sugarkube",
+      "summary": "k3s-on-Raspberry-Pi platform paired with an off-grid solar cube installation documented with CAD, Pi images, and field guides.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -705,24 +695,16 @@
       },
       "metrics": [
         {
-          "label": "Stars",
-          "value": "Syncing from GitHub…",
-          "source": {
-            "type": "githubStars",
-            "owner": "futuroptimist",
-            "repo": "sugarkube",
-            "format": "compact",
-            "template": "{value} stars",
-            "fallback": "Syncing from GitHub…"
-          }
+          "label": "Platform",
+          "value": "k3s, Kubernetes helpers, Cloudflare tunnels, and solar tilt/irrigation notes"
         },
         {
-          "label": "Automation",
-          "value": "Sugarkube schedules solar tilt + irrigation"
+          "label": "Hardware",
+          "value": "Solar cube CAD, Pi carrier plates, electronics docs"
         },
         {
-          "label": "Throughput",
-          "value": "3× daily harvest cadence maintained"
+          "label": "Guides",
+          "value": "Field guides for Pi images and headless provisioning"
         }
       ],
       "links": [

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -368,7 +368,7 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
   },
   poi: {
     'futuroptimist-living-room-tv': {
-      title: wrap('Futuroptimist Creator Desk'),
+      title: wrap('Futuroptimist'),
       summary: wrap(
         'Triple-monitor editing bay capturing Futuroptimist releases with a live showreel, timeline, and automation overlays.'
       ),

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -370,7 +370,7 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
     'futuroptimist-living-room-tv': {
       title: wrap('Futuroptimist'),
       summary: wrap(
-        'Triple-monitor editing bay capturing Futuroptimist releases with a live showreel, timeline, and automation overlays.'
+        'Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.'
       ),
       metrics: [
         { label: wrap('Stars'), value: wrap('1,280+') },

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -588,7 +588,22 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'End-to-end workflows mirror docs and tests so recruiter outreach flows stay covered.',
       },
       metrics: [
-        { label: 'Status', value: 'Local-first CLI with preview web UI' },
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'jobbot3000',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
+        {
+          label: 'Status',
+          value: 'Local-first CLI with preview web UI',
+        },
         {
           label: 'Stack',
           value: 'Node.js 20+ · npm scripts · Playwright preview',
@@ -755,8 +770,8 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             fallback: 'Syncing from GitHub…',
           },
         },
-        { label: 'Hardware', value: 'ESP32 · on-device speech stack' },
-        { label: 'Modes', value: 'Push-to-talk · local inference loops' },
+        { label: 'Hardware', value: 'ESP32 · OpenSCAD enclosure' },
+        { label: 'Modes', value: 'Push-to-talk · Whisper + TTS relay' },
       ],
       links: [
         { label: 'GitHub', href: 'https://github.com/futuroptimist/sigma' },

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -438,7 +438,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
   },
   poi: {
     'futuroptimist-living-room-tv': {
-      title: 'Futuroptimist Creator Desk',
+      title: 'Futuroptimist',
       summary:
         'Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.',
       outcome: {
@@ -475,7 +475,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       },
     },
     'tokenplace-studio-cluster': {
-      title: 'token.place Compute Rack',
+      title: 'token.place',
       summary:
         'Secure peer-to-peer generative AI platform running on a Raspberry Pi lattice with encrypted relay and server nodes.',
       outcome: {
@@ -508,7 +508,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'gabriel-studio-sentry': {
-      title: 'Gabriel Sentinel Rover',
+      title: 'Gabriel',
       summary:
         'Privacy-first "guardian angel" LLM that delivers local security coaching and integrates with token.place or offline inference.',
       outcome: {
@@ -537,7 +537,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'flywheel-studio-flywheel': {
-      title: 'Flywheel Kinetic Hub',
+      title: 'Flywheel',
       summary: [
         'GitHub template and automation hub that bundles linting, tests, docs, and Codex prompts for fast repo bootstrapping.',
       ].join(' '),
@@ -579,7 +579,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       interactionPrompt: 'Engage {title} systems',
     },
     'jobbot-studio-terminal': {
-      title: 'Jobbot Holographic Terminal',
+      title: 'Jobbot3000',
       summary:
         'Self-hosted job search copilot with CLI and experimental web UI for ingesting outreach and tracking applications.',
       outcome: {
@@ -614,7 +614,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       },
     },
     'axel-studio-tracker': {
-      title: 'Axel Quest Navigator',
+      title: 'Axel',
       summary:
         'Goal and quest tracker that organizes repos with agentic LLMs, analytics helpers, and a pipx-friendly CLI.',
       outcome: {
@@ -638,7 +638,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'gitshelves-living-room-installation': {
-      title: 'Gitshelves Living Room Array',
+      title: 'Gitshelves',
       summary:
         'CLI that turns GitHub contribution data into OpenSCAD and STL models for 3D-printed Gridfinity shelves.',
       outcome: {
@@ -670,7 +670,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'danielsmith-portfolio-table': {
-      title: 'danielsmith.io Holographic Map',
+      title: 'danielsmith.io',
       summary:
         'Orthographic Three.js/WebGL portfolio with keyboard navigation and a resilient text fallback for accessibility.',
       outcome: {
@@ -702,7 +702,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'f2clipboard-kitchen-console': {
-      title: 'f2clipboard Incident Console',
+      title: 'f2clipboard',
       summary:
         'CLI that ingests Codex task pages and GitHub logs, redacts secrets, and emits ready-to-paste Markdown summaries.',
       outcome: {
@@ -734,7 +734,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'sigma-kitchen-workbench': {
-      title: 'Sigma Fabrication Bench',
+      title: 'Sigma',
       summary:
         'ESP32 "AI pin" that streams push-to-talk audio to Whisper and returns TTS in a 3D-printed OpenSCAD enclosure.',
       outcome: {
@@ -763,7 +763,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'wove-kitchen-loom': {
-      title: 'Wove Fiber Loom',
+      title: 'Wove',
       summary:
         'Open-source toolkit for learning knitting and crochet while building toward a robotic loom with OpenSCAD hardware.',
       outcome: {
@@ -792,7 +792,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'dspace-backyard-rocket': {
-      title: 'DSPACE Launch Pad',
+      title: 'DSPACE',
       summary:
         'Backyard launch gantry for the private DSPACE rocket project with telemetry-guided countdown cues and a public mission log.',
       outcome: {
@@ -832,7 +832,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       interactionPrompt: 'Launch {title} countdown',
     },
     'pr-reaper-backyard-console': {
-      title: 'PR Reaper Automation Gate',
+      title: 'PR Reaper',
       summary:
         'GitHub Actions workflow that bulk-closes stale pull requests with dry-run previews and optional branch cleanup.',
       outcome: {
@@ -861,7 +861,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
     },
     'sugarkube-backyard-greenhouse': {
-      title: 'Sugarkube Solar Greenhouse',
+      title: 'Sugarkube',
       summary:
         'k3s-on-Raspberry-Pi platform paired with an off-grid solar cube installation documented with CAD, Pi images, and field guides.',
       outcome: {

--- a/src/scene/structures/sigmaWorkbench.ts
+++ b/src/scene/structures/sigmaWorkbench.ts
@@ -443,7 +443,7 @@ function createWorkSurfaceTexture(): CanvasTexture {
   context.save();
   context.fillStyle = '#8fe9ff';
   context.font = '700 120px "Inter", "Segoe UI", sans-serif';
-  context.fillText('Sigma Fabrication Bench', 96, 200);
+  context.fillText('Sigma', 96, 200);
   context.font = '500 60px "Inter", "Segoe UI", sans-serif';
   context.fillText('ESP32 AI Pin · Local inference demos', 96, 290);
   context.font = '48px "JetBrains Mono", monospace';

--- a/src/scene/structures/sigmaWorkbench.ts
+++ b/src/scene/structures/sigmaWorkbench.ts
@@ -445,9 +445,9 @@ function createWorkSurfaceTexture(): CanvasTexture {
   context.font = '700 120px "Inter", "Segoe UI", sans-serif';
   context.fillText('Sigma', 96, 200);
   context.font = '500 60px "Inter", "Segoe UI", sans-serif';
-  context.fillText('ESP32 AI Pin · Local inference demos', 96, 290);
+  context.fillText('ESP32 AI Pin · Whisper + TTS relay', 96, 290);
   context.font = '48px "JetBrains Mono", monospace';
-  context.fillText('Modes: push-to-talk · offline voice agent', 96, 360);
+  context.fillText('Modes: push-to-talk · printed enclosure', 96, 360);
   context.restore();
 
   const texture = new CanvasTexture(canvas);

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -212,6 +212,9 @@ describe('i18n utilities', () => {
     expect(pseudoCopy['futuroptimist-living-room-tv'].title).toBe(
       '⟦Futuroptimist⟧'
     );
+    expect(pseudoCopy['futuroptimist-living-room-tv'].summary).toBe(
+      '⟦Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.⟧'
+    );
     expect(pseudoCopy['tokenplace-studio-cluster'].title).toBe(
       copy['tokenplace-studio-cluster'].title
     );

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -210,7 +210,7 @@ describe('i18n utilities', () => {
 
     const pseudoCopy = getPoiCopy('en-x-pseudo');
     expect(pseudoCopy['futuroptimist-living-room-tv'].title).toBe(
-      '⟦Futuroptimist Creator Desk⟧'
+      '⟦Futuroptimist⟧'
     );
     expect(pseudoCopy['tokenplace-studio-cluster'].title).toBe(
       copy['tokenplace-studio-cluster'].title

--- a/src/tests/poiAnalytics.test.ts
+++ b/src/tests/poiAnalytics.test.ts
@@ -9,10 +9,10 @@ describe('createWindowPoiAnalytics', () => {
   beforeEach(() => {
     poi = {
       id: 'futuroptimist-living-room-tv',
-      title: 'Futuroptimist Creator Desk',
+      title: 'Futuroptimist',
       summary:
         'Triple-monitor editing suite showcasing Futuroptimist workflows.',
-      interactionPrompt: 'Inspect Futuroptimist Creator Desk',
+      interactionPrompt: 'Inspect Futuroptimist',
       category: 'project',
       interaction: 'inspect',
       roomId: 'livingRoom',

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -174,9 +174,9 @@ function dispatchTouchEvent(
 describe('PoiInteractionManager', () => {
   const definition: PoiDefinition = {
     id: 'futuroptimist-living-room-tv',
-    title: 'Futuroptimist Creator Desk',
+    title: 'Futuroptimist',
     summary: 'Triple-monitor editing suite showcasing Futuroptimist workflows.',
-    interactionPrompt: 'Inspect Futuroptimist Creator Desk',
+    interactionPrompt: 'Inspect Futuroptimist',
     category: 'project',
     interaction: 'inspect',
     roomId: 'livingRoom',

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -147,7 +147,7 @@ describe('createPoiInstances', () => {
     expect(renderedText).not.toContain('Prototype');
   });
 
-  it('fits existing long title-only labels without ellipsizing them', () => {
+  it('preserves existing title-only marker labels without ellipsizing them', () => {
     for (const title of ['Gitshelves', 'danielsmith.io']) {
       fillTextLog = [];
       createPoiLabelTexture(createDefinition({ title }));

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -131,7 +131,7 @@ describe('createPoiInstances', () => {
   it('draws marker label textures as title-only in-world cues', () => {
     fillTextLog = [];
     const definition = createDefinition({
-      title: 'Gitshelves Living Room Array',
+      title: 'Gitshelves',
       summary: 'Dense implementation notes remain in the 2D overlay.',
       status: 'prototype',
       outcome: { label: 'Outcome', value: 'Reduced shelf drift 42%' },
@@ -139,7 +139,7 @@ describe('createPoiInstances', () => {
     });
 
     createPoiLabelTexture(definition);
-    expect(fillTextLog).toEqual(['Gitshelves Living Room Array']);
+    expect(fillTextLog).toEqual(['Gitshelves']);
     const renderedText = fillTextLog.join(' ');
     expect(renderedText).not.toContain(definition.summary);
     expect(renderedText).not.toContain('Reduced shelf drift');
@@ -148,10 +148,7 @@ describe('createPoiInstances', () => {
   });
 
   it('fits existing long title-only labels without ellipsizing them', () => {
-    for (const title of [
-      'Gitshelves Living Room Array',
-      'danielsmith.io Holographic Map',
-    ]) {
+    for (const title of ['Gitshelves', 'danielsmith.io']) {
       fillTextLog = [];
       createPoiLabelTexture(createDefinition({ title }));
 

--- a/src/tests/poiNarrativeLog.test.ts
+++ b/src/tests/poiNarrativeLog.test.ts
@@ -82,9 +82,9 @@ const AR_STRINGS: PoiNarrativeLogStrings = {
 
 const createPoi = (overrides: Partial<PoiDefinition> = {}): PoiDefinition => ({
   id: 'futuroptimist-living-room-tv',
-  title: 'Futuroptimist Creator Desk',
+  title: 'Futuroptimist',
   summary: 'Default summary',
-  interactionPrompt: `Inspect ${overrides.title ?? 'Futuroptimist Creator Desk'}`,
+  interactionPrompt: `Inspect ${overrides.title ?? 'Futuroptimist'}`,
   category: 'project',
   interaction: 'inspect',
   roomId: 'livingRoom',
@@ -169,12 +169,12 @@ describe('createPoiNarrativeLog', () => {
 
     const fromPoi = createPoi({
       id: 'futuroptimist-living-room-tv',
-      title: 'Futuroptimist Creator Desk',
+      title: 'Futuroptimist',
       roomId: 'livingRoom',
     });
     const toPoi = createPoi({
       id: 'flywheel-studio-flywheel',
-      title: 'Flywheel Kinetic Hub',
+      title: 'Flywheel',
       roomId: 'studio',
     });
 
@@ -232,12 +232,12 @@ describe('createPoiNarrativeLog', () => {
 
     const narrated = createPoi({
       id: 'flywheel-studio-flywheel',
-      title: 'Flywheel Kinetic Hub',
+      title: 'Flywheel',
       narration: { caption: 'Flywheel narration' },
     });
 
     log.recordVisit(narrated);
-    expect(liveRegion?.textContent).toBe('Flywheel Kinetic Hub logged.');
+    expect(liveRegion?.textContent).toBe('Flywheel logged.');
 
     const silent = createPoi({
       id: 'jobbot-studio-terminal',
@@ -369,7 +369,7 @@ describe('createPoiNarrativeLog', () => {
     const fromPoi = createPoi();
     const toPoi = createPoi({
       id: 'flywheel-studio-flywheel',
-      title: 'Flywheel Kinetic Hub',
+      title: 'Flywheel',
       roomId: 'studio',
     });
 

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -102,21 +102,15 @@ describe('POI registry', () => {
 
   it('derives localized interaction prompts for exhibits', () => {
     const flywheel = pois.find((poi) => poi.id === 'flywheel-studio-flywheel');
-    expect(flywheel?.interactionPrompt).toBe(
-      'Engage Flywheel Kinetic Hub systems'
-    );
+    expect(flywheel?.interactionPrompt).toBe('Engage Flywheel systems');
 
     const rocket = pois.find((poi) => poi.id === 'dspace-backyard-rocket');
-    expect(rocket?.interactionPrompt).toBe(
-      'Launch DSPACE Launch Pad countdown'
-    );
+    expect(rocket?.interactionPrompt).toBe('Launch DSPACE countdown');
 
     const gitshelves = pois.find(
       (poi) => poi.id === 'gitshelves-living-room-installation'
     );
-    expect(gitshelves?.interactionPrompt).toBe(
-      'Inspect Gitshelves Living Room Array'
-    );
+    expect(gitshelves?.interactionPrompt).toBe('Inspect Gitshelves');
   });
 
   it('exposes stable room-level ordering with defensive copies', () => {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -75,10 +75,10 @@ describe('PoiTooltipOverlay', () => {
 
   const basePoi: PoiDefinition = {
     id: 'futuroptimist-living-room-tv',
-    title: 'Futuroptimist Creator Desk',
+    title: 'Futuroptimist',
     summary:
       'Triple-monitor editing bay capturing Futuroptimist releases with live timeline overlays.',
-    interactionPrompt: 'Inspect Futuroptimist Creator Desk',
+    interactionPrompt: 'Inspect Futuroptimist',
     category: 'project',
     interaction: 'inspect',
     roomId: 'livingRoom',
@@ -351,14 +351,14 @@ describe('PoiTooltipOverlay', () => {
     const selectedPoi: PoiDefinition = {
       ...basePoi,
       id: 'flywheel-studio-flywheel',
-      title: 'Flywheel Kinetic Hub',
+      title: 'Flywheel',
       position: { x: 2, y: 0, z: 4 },
       metrics: [{ label: 'Automation', value: 'CI-ready prompts' }],
       links: [
         { label: 'Flywheel', href: 'https://flywheel.futuroptimist.dev' },
       ],
       status: undefined,
-      interactionPrompt: 'Engage Flywheel Kinetic Hub systems',
+      interactionPrompt: 'Engage Flywheel systems',
     };
 
     overlay.setSelected(selectedPoi);
@@ -410,9 +410,9 @@ describe('PoiTooltipOverlay', () => {
     const poiWithoutOutcome: PoiDefinition = {
       ...basePoi,
       id: 'tokenplace-studio-cluster',
-      title: 'token.place Compute Rack',
+      title: 'token.place',
       outcome: undefined,
-      interactionPrompt: 'Inspect token.place Compute Rack',
+      interactionPrompt: 'Inspect token.place',
     };
 
     overlay.setSelected(poiWithoutOutcome);
@@ -459,8 +459,8 @@ describe('PoiTooltipOverlay', () => {
     const nextPoi: PoiDefinition = {
       ...basePoi,
       id: 'futuroptimist-living-room-tv-variant',
-      title: 'Futuroptimist Creator Desk Alt',
-      interactionPrompt: 'Inspect Futuroptimist Creator Desk Alt',
+      title: 'Futuroptimist Alt',
+      interactionPrompt: 'Inspect Futuroptimist Alt',
     };
 
     overlay.setSelected(nextPoi);

--- a/src/tests/poiTourGuide.test.ts
+++ b/src/tests/poiTourGuide.test.ts
@@ -7,10 +7,10 @@ import { PoiVisitedState } from '../scene/poi/visitedState';
 const DEFINITIONS: PoiDefinition[] = [
   {
     id: 'futuroptimist-living-room-tv',
-    title: 'Futuroptimist Creator Desk',
+    title: 'Futuroptimist',
     summary:
       'Triple-monitor editing bay capturing Futuroptimist releases with live timeline overlays.',
-    interactionPrompt: 'Inspect Futuroptimist Creator Desk',
+    interactionPrompt: 'Inspect Futuroptimist',
     category: 'project',
     interaction: 'inspect',
     roomId: 'livingRoom',
@@ -20,9 +20,9 @@ const DEFINITIONS: PoiDefinition[] = [
   },
   {
     id: 'flywheel-studio-flywheel',
-    title: 'Flywheel Kinetic Hub',
+    title: 'Flywheel',
     summary: 'Automation centerpiece with responsive rotation.',
-    interactionPrompt: 'Engage Flywheel Kinetic Hub systems',
+    interactionPrompt: 'Engage Flywheel systems',
     category: 'project',
     interaction: 'inspect',
     roomId: 'studio',
@@ -32,9 +32,9 @@ const DEFINITIONS: PoiDefinition[] = [
   },
   {
     id: 'jobbot-studio-terminal',
-    title: 'Jobbot Holographic Terminal',
+    title: 'Jobbot3000',
     summary: 'Telemetry console broadcasting automation metrics.',
-    interactionPrompt: 'Inspect Jobbot Holographic Terminal',
+    interactionPrompt: 'Inspect Jobbot3000',
     category: 'project',
     interaction: 'inspect',
     roomId: 'studio',
@@ -44,9 +44,9 @@ const DEFINITIONS: PoiDefinition[] = [
   },
   {
     id: 'dspace-backyard-rocket',
-    title: 'DSPACE Launch Pad',
+    title: 'DSPACE',
     summary: 'Backyard launch gantry staging the DSPACE model rocket.',
-    interactionPrompt: 'Launch DSPACE Launch Pad countdown',
+    interactionPrompt: 'Launch DSPACE countdown',
     category: 'project',
     interaction: 'inspect',
     roomId: 'backyard',

--- a/src/tests/sigmaWorkbench.test.ts
+++ b/src/tests/sigmaWorkbench.test.ts
@@ -76,7 +76,7 @@ describe('createSigmaWorkbench', () => {
     expect(hologram).toBeInstanceOf(Mesh);
 
     const printedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
-    expect(printedText).toContain('Sigma Fabrication Bench');
+    expect(printedText).toContain('Sigma');
     expect(printedText).toContain('Sigma AI Pin');
   });
 

--- a/src/tests/sigmaWorkbench.test.ts
+++ b/src/tests/sigmaWorkbench.test.ts
@@ -77,6 +77,8 @@ describe('createSigmaWorkbench', () => {
 
     const printedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
     expect(printedText).toContain('Sigma');
+    expect(printedText).toContain('ESP32 AI Pin · Whisper + TTS relay');
+    expect(printedText).toContain('Modes: push-to-talk · printed enclosure');
     expect(printedText).toContain('Sigma AI Pin');
   });
 


### PR DESCRIPTION
### Motivation
- Standardize and shorten POI titles and summaries for clearer in-app labels and localized fallbacks. 
- Make press-kit headroom labels more descriptive and add explicit label fields for UI consumption. 
- Tighten signage on the Sigma fabrication bench to match branding and updated narrative copy. 

### Description
- Renamed and rewrote multiple POI titles, summaries, metrics, links, and `interactionPrompt` values across the POI catalog and English locale overrides in `src/assets/i18n/locales/en.ts` and `src/assets/i18n/locales/en-x-pseudo.ts`. 
- Updated `docs/assets/press-kit.json` with a new `generatedAtIso` timestamp and expanded `headroom` entries to include more descriptive `label`, plus `statusLabel` and `remainingPercentLabel` fields. 
- Shortened the Sigma workbench canvas text in `src/scene/structures/sigmaWorkbench.ts` (from "Sigma Fabrication Bench" to "Sigma") and adjusted supporting lines to reflect the new messaging. 
- Updated many unit tests in `src/tests/*` to match the revised strings and interaction prompts so expected snapshots/assertions align with the new copy. 

### Testing
- Ran the unit test suite with `vitest` (via `npm test`) after applying copy changes and test updates, and all tests completed successfully. 
- Executed the i18n-specific tests in `src/tests/i18n.test.ts` to verify fallbacks and pseudo-locales, and they passed. 
- Executed POI-focused tests in `src/tests/poi*.test.ts` to validate labels, tooltips, interactions, and analytics, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e9e49ab7c832fb4e027d76433f867)