### PR TITLE
Document CI-owned `game-launch.png` and forbid manual binary edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,15 @@ Run targeted scripts (e.g., `npm run floorplan:diagram`,
 ## Documentation & assets
 
 - Update the relevant files in `docs/` whenever behavior, prompts, or workflows change.
-- Store generated images as SVG or PNG in `docs/assets/`.
+- Store generated images as SVG or PNG in `docs/assets/`, except for CI-owned outputs noted
+  below.
+- Never manually create, edit, replace, stage, or commit `docs/assets/game-launch.png`. The
+  launch screenshot workflow regenerates it automatically after every merge, and Codex Cloud
+  cannot create or commit binary files.
 - Avoid committing large binaries elsewhere in the repo.
-- For front-end tweaks, capture an updated screenshot via the CI workflow.
-- Use the manual command noted in the README when you need a local capture.
+- For front-end tweaks, capture an updated screenshot via the CI workflow instead of touching
+  `docs/assets/game-launch.png` locally.
+- Use the manual command noted in the README when you need a local capture for review only.
 
 ## Tooling & automation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,9 @@ npm run smoke
 - Never share preview links without those overrides—headless and low-FPS heuristics will otherwise
   fall back to the text mode.
 
-Run targeted scripts (e.g., `npm run floorplan:diagram`,
-`npm run launch:screenshot`) only when your changes impact the related assets.
+Run targeted scripts (e.g., `npm run floorplan:diagram`) only when your changes impact
+the related assets. `npm run launch:screenshot` is review-only because
+`docs/assets/game-launch.png` is CI-owned.
 
 ## Documentation & assets
 

--- a/README.md
+++ b/README.md
@@ -172,11 +172,14 @@ lightweight.
 | Script                      | Output                        | Refresh trigger                                                                                     |
 | --------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------- |
 | `npm run floorplan:diagram` | `docs/assets/floorplan-*.svg` | Run after editing layout data in `src/assets/floorplan/**`. CI regenerates diagrams after merges.   |
-| `npm run launch:screenshot` | `docs/assets/game-launch.png` | Run whenever lighting, camera, or HUD composition shifts. CI captures a fresh image post-merge.     |
+| `npm run launch:screenshot` | `docs/assets/game-launch.png` | Review-only local capture for lighting, camera, or HUD shifts; do not commit this CI-owned output.  |
 | `npm run smoke`             | `dist/index.html` + assets    | Verifies built JS/CSS references resolve and reports missing manual binary runtime assets.          |
 | `npm run press-kit`         | `docs/assets/press-kit.json`  | Refresh after updating POI copy, performance budgets, or media listings to keep the export current. |
 
-Keep pipelines deterministic by regenerating assets immediately after touching geometry, lighting, or HUD composition so CI diffs stay tidy.
+Keep pipelines deterministic by regenerating committable assets immediately after touching geometry
+or layout data. `docs/assets/game-launch.png` is the exception: use
+`npm run launch:screenshot` only for local review, leave the PNG unstaged, and let the
+Launch screenshot workflow refresh and commit it after merge.
 
 ## Performance guardrails
 

--- a/docs/architecture/testing-assets.md
+++ b/docs/architecture/testing-assets.md
@@ -36,13 +36,15 @@ coverage remains comprehensive.
 
 ## Auto-generated assets
 
-| Script                      | Output path                   | Trigger                                                                                             |
-| --------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------- |
-| `npm run floorplan:diagram` | `docs/assets/floorplan-*.svg` | Run after floor geometry or labels change. CI refreshes the diagrams post-merge.                    |
-| `npm run launch:screenshot` | `docs/assets/game-launch.png` | Run after lighting, HUD, or camera framing changes. CI captures a fresh launch pose on every merge. |
+| Script                      | Output path                   | Trigger                                                                                              |
+| --------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `npm run floorplan:diagram` | `docs/assets/floorplan-*.svg` | Run after floor geometry or labels change. CI refreshes the diagrams post-merge.                     |
+| `npm run launch:screenshot` | `docs/assets/game-launch.png` | Review-only local capture after lighting, HUD, or camera framing changes; CI owns the committed PNG. |
 
-Regenerate affected assets locally before committing so diffs stay deterministic.
-Document the update in commit messages when budgets or captures shift.
+Regenerate affected committable assets locally before committing so diffs stay deterministic.
+Do not stage or commit `docs/assets/game-launch.png`; use local launch captures only for review,
+then let the Launch screenshot workflow refresh the committed PNG after merge. Document the
+update in commit messages when budgets or captures shift.
 
 ## Manual binary runtime assets
 


### PR DESCRIPTION
### Motivation
- Prevent Codex tasks and contributors from creating or editing `docs/assets/game-launch.png` because the file is auto-generated by CI and Codex Cloud cannot create or commit binary files.

### Description
- Update `AGENTS.md` to mark `docs/assets/game-launch.png` as a CI-owned output and add an explicit prohibition against manually creating, editing, replacing, staging, or committing it.
- Clarify that generated images are normally stored as SVG/PNG but `game-launch.png` is an exception and front-end screenshot updates should rely on the CI workflow or local captures for review only.

### Testing
- Ran formatting with `npm run format:write` and the formatter completed successfully.
- Ran lint with `npm run lint` and no lint errors were reported.
- Ran the full test suite with `npm run test:ci` and all tests passed (`Test Files 131 passed, Tests 917 passed`).
- Ran docs validation with `npm run docs:check` and it passed.
- Ran the build/smoke with `npm run smoke` and the smoke check passed.
- Ran the secret scan `git diff --cached | ./scripts/scan-secrets.py` and no high-risk secrets were detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f10fe927c832fb63c9d7d556224af)