### PR TITLE
Make immersive POIs locale-reactive

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -1,4 +1,4 @@
-import type { PoiId } from '../poi/types';
+import type { PoiId } from '../../scene/poi/types';
 
 import { AR_OVERRIDES } from './locales/ar';
 import { EN_LOCALE_STRINGS } from './locales/en';
@@ -21,6 +21,7 @@ import type {
   MovementLegendStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
+  PoiOverlayStrings,
   HudCustomizationStrings,
   SiteStrings,
 } from './types';
@@ -333,6 +334,10 @@ export function getPoiNarrativeLogStrings(
   input?: LocaleInput
 ): PoiNarrativeLogStrings {
   return getLocaleStrings(input).hud.narrativeLog;
+}
+
+export function getPoiOverlayStrings(input?: LocaleInput): PoiOverlayStrings {
+  return getLocaleStrings(input).hud.poiOverlay;
 }
 
 export function getSiteStrings(input?: LocaleInput): SiteStrings {

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -279,6 +279,18 @@ export const AR_OVERRIDES: LocaleOverrides = {
         },
       },
     },
+    poiOverlay: {
+      visited: 'تمت الزيارة',
+      nextHighlight: 'التمييز التالي',
+      status: {
+        prototype: 'نموذج أولي',
+        live: 'مباشر',
+      },
+      closeDetails: 'إغلاق تفاصيل نقطة الاهتمام',
+      relatedCaseStudies: 'دراسات حالة ذات صلة',
+      outcomeFallbackLabel: 'النتيجة',
+      discoveryAnnouncementTemplate: 'تم اكتشاف {title}. {summary}',
+    },
     helpModal: {
       heading: 'الإعدادات والمساعدة',
       description:

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -347,6 +347,18 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         },
       },
     },
+    poiOverlay: {
+      visited: wrap('Visited'),
+      nextHighlight: wrap('Next highlight'),
+      status: {
+        prototype: wrap('Prototype'),
+        live: wrap('Live'),
+      },
+      closeDetails: wrap('Close POI details'),
+      relatedCaseStudies: wrap('Related case studies'),
+      outcomeFallbackLabel: wrap('Outcome'),
+      discoveryAnnouncementTemplate: wrap('{title} discovered. {summary}'),
+    },
     helpModal: {
       heading: wrap('Settings & Help'),
       closeLabel: wrap('Close'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -345,6 +345,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         },
       },
     },
+    poiOverlay: {
+      visited: 'Visited',
+      nextHighlight: 'Next highlight',
+      status: {
+        prototype: 'Prototype',
+        live: 'Live',
+      },
+      closeDetails: 'Close POI details',
+      relatedCaseStudies: 'Related case studies',
+      outcomeFallbackLabel: 'Outcome',
+      discoveryAnnouncementTemplate: '{title} discovered. {summary}',
+    },
     helpModal: {
       heading: 'Settings & Help',
       description: [

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -280,6 +280,18 @@ export const JA_OVERRIDES: LocaleOverrides = {
         },
       },
     },
+    poiOverlay: {
+      visited: '訪問済み',
+      nextHighlight: '次のハイライト',
+      status: {
+        prototype: 'プロトタイプ',
+        live: '公開中',
+      },
+      closeDetails: 'POI 詳細を閉じる',
+      relatedCaseStudies: '関連ケーススタディ',
+      outcomeFallbackLabel: '成果',
+      discoveryAnnouncementTemplate: '{title} を発見しました。{summary}',
+    },
     helpModal: {
       heading: '設定とヘルプ',
       description:

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -1,12 +1,12 @@
-import type { FallbackReason } from '../../types/failover';
-import type { InputMethod } from '../../ui/hud/movementLegend';
 import type {
   PoiId,
   PoiInteraction,
   PoiMetricSource,
   PoiNarration,
   PoiOutcome,
-} from '../poi/types';
+} from '../../scene/poi/types';
+import type { FallbackReason } from '../../types/failover';
+import type { InputMethod } from '../../ui/hud/movementLegend';
 
 export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja';
 export type LocaleDirection = 'ltr' | 'rtl';
@@ -168,6 +168,19 @@ export interface HudCustomizationStrings {
   accessories: { title: string; description: string };
 }
 
+export interface PoiOverlayStrings {
+  visited: string;
+  nextHighlight: string;
+  status: {
+    prototype: string;
+    live: string;
+  };
+  closeDetails: string;
+  relatedCaseStudies: string;
+  outcomeFallbackLabel: string;
+  discoveryAnnouncementTemplate: string;
+}
+
 export interface PoiNarrativeLogStrings {
   heading: string;
   visitedHeading: string;
@@ -299,6 +312,7 @@ export interface LocaleStrings {
     helpModal: HelpModalStrings;
     customization: HudCustomizationStrings;
     narrativeLog: PoiNarrativeLogStrings;
+    poiOverlay: PoiOverlayStrings;
   };
   poi: Record<PoiId, PoiCopy>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ import {
   getModeAnnouncerStrings,
   getModeToggleStrings,
   getPoiNarrativeLogStrings,
+  getPoiOverlayStrings,
   getSiteStrings,
   resolveLocale,
   type Locale,
@@ -166,6 +167,7 @@ import { GuidedTourChannel } from './scene/poi/guidedTourChannel';
 import { PoiInteractionManager } from './scene/poi/interactionManager';
 import {
   createPoiInstances,
+  updatePoiInstanceDefinition,
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
@@ -176,7 +178,7 @@ import {
 } from './scene/poi/structuredData';
 import { PoiTooltipOverlay } from './scene/poi/tooltipOverlay';
 import { PoiTourGuide } from './scene/poi/tourGuide';
-import type { PoiDefinition } from './scene/poi/types';
+import type { PoiDefinition, PoiId } from './scene/poi/types';
 import { updateVisitedBadge } from './scene/poi/visitedBadge';
 import { PoiVisitedState } from './scene/poi/visitedState';
 import {
@@ -923,6 +925,7 @@ function initializeImmersiveScene(
   let modeToggleStrings = getModeToggleStrings(locale);
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+  let poiOverlayStrings = getPoiOverlayStrings(locale);
   let siteStrings = getSiteStrings(locale);
   const syncModeAnnouncerStrings = () => {
     const announcerStrings = getModeAnnouncerStrings(locale);
@@ -1010,8 +1013,8 @@ function initializeImmersiveScene(
   scene.background = createImmersiveGradientTexture();
 
   const poiOverrides: PoiInstanceOverrides = {};
-  const poiDefinitions = getPoiDefinitions();
-  const poiDefinitionsById = new Map(
+  let poiDefinitions = getPoiDefinitions(locale);
+  let poiDefinitionsById = new Map(
     poiDefinitions.map((definition) => [definition.id, definition] as const)
   );
   injectPoiStructuredData(poiDefinitions, {
@@ -1567,6 +1570,7 @@ function initializeImmersiveScene(
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    strings: poiOverlayStrings,
     onDismiss: () => {
       dismissActivePoiDetail();
     },
@@ -1806,7 +1810,7 @@ function initializeImmersiveScene(
     }
     if (poiNarrativeLog) {
       const visitedDefinitions = Array.from(visited)
-        .map((id) => poiDefinitionsById.get(id))
+        .map((id) => poiDefinitionsById.get(id as PoiId))
         .filter((definition): definition is PoiDefinition =>
           Boolean(definition)
         );
@@ -1826,7 +1830,7 @@ function initializeImmersiveScene(
           if (previousVisited.has(id)) {
             continue;
           }
-          const definition = poiDefinitionsById.get(id);
+          const definition = poiDefinitionsById.get(id as PoiId);
           if (!definition) {
             continue;
           }
@@ -2934,7 +2938,57 @@ function initializeImmersiveScene(
     audioHudStrings = getAudioHudControlStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+    poiOverlayStrings = getPoiOverlayStrings(locale);
     siteStrings = getSiteStrings(locale);
+    const nextPoiDefinitions = getPoiDefinitions(locale);
+    const nextPoiDefinitionsById = new Map(
+      nextPoiDefinitions.map(
+        (definition) => [definition.id, definition] as const
+      )
+    );
+    poiDefinitions = nextPoiDefinitions;
+    poiDefinitionsById = nextPoiDefinitionsById;
+    poiInstances.forEach((instance) => {
+      const localizedDefinition = poiDefinitionsById.get(
+        instance.definition.id
+      );
+      if (localizedDefinition) {
+        updatePoiInstanceDefinition(instance, localizedDefinition);
+      }
+    });
+    const remapPoi = (poi: PoiDefinition | null): PoiDefinition | null =>
+      poi ? (poiDefinitionsById.get(poi.id) ?? poi) : null;
+    currentHoveredPoi = remapPoi(currentHoveredPoi);
+    currentSelectedPoi = remapPoi(currentSelectedPoi);
+    currentGuidedTourRecommendation = remapPoi(currentGuidedTourRecommendation);
+    poiTourGuide.setDefinitions(poiDefinitions);
+    injectPoiStructuredData(poiDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
+    injectTextPortfolioStructuredData(poiDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
+    if (githubRepoMetrics) {
+      githubRepoMetrics.dispose();
+    }
+    githubRepoMetrics = wireGitHubRepoMetrics({
+      definitions: poiDefinitions,
+      service: githubRepoStatsService,
+      onMetricsUpdated: (poiId) => {
+        poiTooltipOverlay.notifyPoiUpdated(poiId);
+        poiWorldTooltip.notifyPoiUpdated(poiId);
+      },
+      onRepoStatsUpdated: ({ poiId, stats }) => {
+        if (poiId === 'futuroptimist-living-room-tv') {
+          mediaWallStarBridge.updateStarCount(stats.stars);
+        }
+      },
+    });
+    githubRepoMetrics.refreshAll().catch(() => {
+      /* GitHub may be unreachable; metrics will remain on fallback values. */
+    });
     syncModeAnnouncerStrings();
     narrativeTimeFormatter = new Intl.DateTimeFormat(
       locale === 'en-x-pseudo' ? 'en' : locale,
@@ -2956,6 +3010,13 @@ function initializeImmersiveScene(
         formatKeyLabel(keyBindings.getPrimaryBinding('interact')) ||
         interactLabelFallback;
       movementLegend.setKeyboardInteractLabel(keyboardLabel);
+      movementLegend.setInteractPrompt(
+        interactablePoi?.definition.interactionPrompt ?? null
+      );
+    }
+    if (interactablePoi && interactDescription) {
+      interactDescription.textContent =
+        interactablePoi.definition.interactionPrompt;
     }
     manualModeToggle?.setStrings(modeToggleStrings);
     audioHudHandle?.setStrings(audioHudStrings);
@@ -2963,18 +3024,22 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
+    poiTooltipOverlay.setStrings(poiOverlayStrings);
     updateHelpButtonLabel();
     localeToggleControl?.refresh();
 
     const visitedSnapshot = poiVisitedState.snapshot();
     const visitedDefinitions = Array.from(visitedSnapshot)
-      .map((id) => poiDefinitionsById.get(id))
+      .map((id) => poiDefinitionsById.get(id as PoiId))
       .filter((definition): definition is PoiDefinition => Boolean(definition));
     if (visitedDefinitions.length > 0 && poiNarrativeLog) {
       poiNarrativeLog.syncVisited(visitedDefinitions, {
         visitedLabel: narrativeLogStrings.defaultVisitedLabel,
       });
+      proceduralNarrator?.primeVisited(visitedDefinitions);
     }
+    syncPoiRecommendation();
+    syncPoiDetailOverlay();
   };
 
   const localeOptions: Array<{

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -442,6 +442,20 @@ function createDisplayPoiInstance(
   };
 }
 
+export function updatePoiInstanceDefinition(
+  instance: PoiInstance,
+  definition: PoiDefinition
+): void {
+  instance.definition = definition;
+  if (!instance.label || !instance.labelMaterial) {
+    return;
+  }
+  const previousTexture = instance.labelMaterial.map;
+  instance.labelMaterial.map = createPoiLabelTexture(definition);
+  instance.labelMaterial.needsUpdate = true;
+  previousTexture?.dispose();
+}
+
 export function createPoiLabelTexture(
   definition: PoiDefinition
 ): CanvasTexture {

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -3,6 +3,7 @@ import {
   formatMessage,
   getControlOverlayStrings,
   getPoiCopy,
+  type LocaleInput,
 } from '../../assets/i18n';
 
 import { scalePoiValue } from './constants';
@@ -27,6 +28,7 @@ type PoiStaticDefinition = Omit<
   | 'links'
   | 'narration'
   | 'pedestal'
+  | 'interactionPrompt'
 > & { pedestal?: PoiPedestalStaticConfig };
 
 const baseDefinitions: PoiStaticDefinition[] = [
@@ -225,57 +227,65 @@ const baseDefinitions: PoiStaticDefinition[] = [
   },
 ];
 
-const poiCopy = getPoiCopy();
-const controlOverlayStrings = getControlOverlayStrings();
+export function localizePoiDefinitions(input?: LocaleInput): PoiDefinition[] {
+  const poiCopy = getPoiCopy(input);
+  const controlOverlayStrings = getControlOverlayStrings(input);
+  const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
+    const copy = poiCopy[base.id];
+    if (!copy) {
+      throw new Error(`Missing localized POI copy for ${base.id}`);
+    }
+    const footprintWidth = scalePoiValue(base.footprint.width);
+    const footprintDepth = scalePoiValue(base.footprint.depth);
+    const baseMaxHalf =
+      Math.max(base.footprint.width, base.footprint.depth) / 2;
+    const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
+    const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
+    const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
+    const pedestal: PoiPedestalConfig | undefined = base.pedestal
+      ? {
+          ...base.pedestal,
+          height:
+            typeof base.pedestal.height === 'number'
+              ? scalePoiValue(base.pedestal.height)
+              : undefined,
+        }
+      : undefined;
+    const template =
+      copy.interactionPrompt ??
+      controlOverlayStrings.interact.promptTemplates[base.interaction] ??
+      controlOverlayStrings.interact.promptTemplates.default;
+    const interactionPrompt = formatMessage(template, { title: copy.title });
+    return {
+      ...base,
+      position: { ...base.position },
+      interactionRadius: scaledInteractionRadius,
+      footprint: {
+        width: footprintWidth,
+        depth: footprintDepth,
+      },
+      pedestal,
+      title: copy.title,
+      summary: copy.summary,
+      outcome: copy.outcome ? { ...copy.outcome } : undefined,
+      metrics: copy.metrics?.map((metric) => ({
+        ...metric,
+        source: metric.source ? { ...metric.source } : undefined,
+      })),
+      links: copy.links?.map((link) => ({ ...link })),
+      narration: copy.narration ? { ...copy.narration } : undefined,
+      interactionPrompt,
+    } satisfies PoiDefinition;
+  });
 
-const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
-  const copy = poiCopy[base.id];
-  if (!copy) {
-    throw new Error(`Missing localized POI copy for ${base.id}`);
-  }
-  const footprintWidth = scalePoiValue(base.footprint.width);
-  const footprintDepth = scalePoiValue(base.footprint.depth);
-  const baseMaxHalf = Math.max(base.footprint.width, base.footprint.depth) / 2;
-  const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
-  const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
-  const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
-  const pedestal: PoiPedestalConfig | undefined = base.pedestal
-    ? {
-        ...base.pedestal,
-        height:
-          typeof base.pedestal.height === 'number'
-            ? scalePoiValue(base.pedestal.height)
-            : undefined,
-      }
-    : undefined;
-  const template =
-    copy.interactionPrompt ??
-    controlOverlayStrings.interact.promptTemplates[base.interaction] ??
-    controlOverlayStrings.interact.promptTemplates.default;
-  const interactionPrompt = formatMessage(template, { title: copy.title });
-  return {
-    ...base,
-    interactionRadius: scaledInteractionRadius,
-    footprint: {
-      width: footprintWidth,
-      depth: footprintDepth,
-    },
-    pedestal,
-    title: copy.title,
-    summary: copy.summary,
-    outcome: copy.outcome ? { ...copy.outcome } : undefined,
-    metrics: copy.metrics?.map((metric) => ({ ...metric })),
-    links: copy.links?.map((link) => ({ ...link })),
-    narration: copy.narration ? { ...copy.narration } : undefined,
-    interactionPrompt,
-  } satisfies PoiDefinition;
-});
+  // Deterministically lay out indoor POIs across downstairs rooms.
+  // Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
+  const definitions = applyManualPoiPlacements(scaled).map(clonePoi);
+  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  return definitions;
+}
 
-// Deterministically lay out indoor POIs across downstairs rooms.
-// Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
-const definitions: PoiDefinition[] = applyManualPoiPlacements(scaled);
-
-assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+const definitions: PoiDefinition[] = localizePoiDefinitions();
 
 function clonePoi(definition: PoiDefinition): PoiDefinition {
   return {
@@ -283,7 +293,10 @@ function clonePoi(definition: PoiDefinition): PoiDefinition {
     position: { ...definition.position },
     footprint: { ...definition.footprint },
     outcome: definition.outcome ? { ...definition.outcome } : undefined,
-    metrics: definition.metrics?.map((metric) => ({ ...metric })),
+    metrics: definition.metrics?.map((metric) => ({
+      ...metric,
+      source: metric.source ? { ...metric.source } : undefined,
+    })),
     links: definition.links?.map((link) => ({ ...link })),
     narration: definition.narration ? { ...definition.narration } : undefined,
     pedestal: definition.pedestal ? { ...definition.pedestal } : undefined,
@@ -352,17 +365,31 @@ class StaticPoiRegistry implements PoiRegistry {
 
 export const poiRegistry: PoiRegistry = new StaticPoiRegistry(definitions);
 
-export function getPoiDefinitions(): PoiDefinition[] {
-  return poiRegistry.all();
+export function getPoiDefinitions(input?: LocaleInput): PoiDefinition[] {
+  return input === undefined
+    ? poiRegistry.all()
+    : localizePoiDefinitions(input);
 }
 
-export function getPoiDefinitionsByRoom(roomId: string): PoiDefinition[] {
+export function getPoiDefinitionsByRoom(
+  roomId: string,
+  input?: LocaleInput
+): PoiDefinition[] {
+  if (input !== undefined) {
+    return localizePoiDefinitions(input).filter((poi) => poi.roomId === roomId);
+  }
   return poiRegistry.getByRoom(roomId);
 }
 
 export function getPoiDefinitionsByCategory(
-  category: PoiCategory
+  category: PoiCategory,
+  input?: LocaleInput
 ): PoiDefinition[] {
+  if (input !== undefined) {
+    return localizePoiDefinitions(input).filter(
+      (poi) => poi.category === category
+    );
+  }
   return poiRegistry.getByCategory(category);
 }
 

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -1,4 +1,10 @@
 import {
+  formatMessage,
+  getPoiOverlayStrings,
+  type LocaleInput,
+  type PoiOverlayStrings,
+} from '../../assets/i18n';
+import {
   GuidedTourPreference,
   defaultGuidedTourPreference,
 } from '../../systems/guidedTour/preference';
@@ -18,6 +24,8 @@ export interface PoiTooltipOverlayOptions {
   };
   interactionTimeline?: InteractionTimeline;
   guidedTourPreference?: GuidedTourPreference;
+  locale?: LocaleInput;
+  strings?: PoiOverlayStrings;
 }
 
 interface RenderState {
@@ -55,6 +63,7 @@ export class PoiTooltipOverlay {
   private isIdle = false;
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
+  private strings: PoiOverlayStrings;
   private readonly onDismiss: (() => void) | null;
 
   constructor(options: PoiTooltipOverlayOptions) {
@@ -64,6 +73,8 @@ export class PoiTooltipOverlay {
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
+      locale,
+      strings,
     } = options;
     const documentTarget = container.ownerDocument ?? document;
 
@@ -73,6 +84,7 @@ export class PoiTooltipOverlay {
     this.interactionTimeline = interactionTimeline ?? null;
     this.guidedTourPreference = guidedTourPreference;
     this.onDismiss = onDismiss ?? null;
+    this.strings = strings ?? getPoiOverlayStrings(locale);
     this.instanceId = generateTooltipInstanceId();
 
     this.root = documentTarget.createElement('section');
@@ -100,20 +112,20 @@ export class PoiTooltipOverlay {
 
     this.visitedBadge = documentTarget.createElement('span');
     this.visitedBadge.className = 'poi-tooltip-overlay__visited';
-    this.visitedBadge.textContent = 'Visited';
+    this.visitedBadge.textContent = this.strings.visited;
     this.visitedBadge.hidden = true;
     headingRow.appendChild(this.visitedBadge);
 
     this.recommendationBadge = documentTarget.createElement('span');
     this.recommendationBadge.className = 'poi-tooltip-overlay__recommendation';
-    this.recommendationBadge.textContent = 'Next highlight';
+    this.recommendationBadge.textContent = this.strings.nextHighlight;
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
 
     this.closeButton = documentTarget.createElement('button');
     this.closeButton.className = 'poi-tooltip-overlay__close';
     this.closeButton.type = 'button';
-    this.closeButton.setAttribute('aria-label', 'Close POI details');
+    this.closeButton.setAttribute('aria-label', this.strings.closeDetails);
     this.closeButton.textContent = '×';
     this.closeButton.hidden = true;
     this.closeButton.disabled = true;
@@ -153,7 +165,7 @@ export class PoiTooltipOverlay {
     this.linksList = documentTarget.createElement('ul');
     this.linksList.className = 'poi-tooltip-overlay__links';
     this.linksList.id = `${this.instanceId}-links`;
-    this.linksList.setAttribute('aria-label', 'Related case studies');
+    this.linksList.setAttribute('aria-label', this.strings.relatedCaseStudies);
     this.root.appendChild(this.linksList);
 
     container.appendChild(this.root);
@@ -175,6 +187,20 @@ export class PoiTooltipOverlay {
         this.update();
       }
     );
+  }
+
+  setStrings(strings: PoiOverlayStrings): void {
+    this.strings = strings;
+    this.visitedBadge.textContent = strings.visited;
+    this.recommendationBadge.textContent = strings.nextHighlight;
+    this.closeButton.setAttribute('aria-label', strings.closeDetails);
+    this.linksList.setAttribute('aria-label', strings.relatedCaseStudies);
+    this.renderState.poiId = null;
+    this.update();
+  }
+
+  setLocale(locale: LocaleInput): void {
+    this.setStrings(getPoiOverlayStrings(locale));
   }
 
   setIdleState(idle: boolean) {
@@ -271,6 +297,7 @@ export class PoiTooltipOverlay {
       this.setFocusContainment(false);
       this.root.removeAttribute('aria-describedby');
       this.renderState.poiId = null;
+      this.syncCloseButtonState('hidden');
       this.visitedBadge.hidden = true;
       this.recommendationBadge.hidden = true;
       this.liveRegion.textContent = '';
@@ -297,16 +324,8 @@ export class PoiTooltipOverlay {
         recommendation?.id === poi.id);
     this.recommendationBadge.hidden = !showRecommendationBadge;
 
-    const previousPoiId = this.renderState.poiId;
-
-    if (previousPoiId !== poi.id) {
-      this.renderPoi(poi);
-      this.renderState.poiId = poi.id;
-    } else {
-      this.updateStatus(poi);
-      this.renderOutcome(poi);
-      this.renderMetrics(poi);
-    }
+    this.renderPoi(poi);
+    this.renderState.poiId = poi.id;
 
     const describedByIds = [this.summary.id];
     if (!this.outcome.hidden) {
@@ -387,7 +406,7 @@ export class PoiTooltipOverlay {
       return;
     }
 
-    const label = outcome.label?.trim() || 'Outcome';
+    const label = outcome.label?.trim() || this.strings.outcomeFallbackLabel;
     this.outcomeLabel.textContent = label;
     this.outcomeLabel.hidden = false;
     this.outcomeValue.textContent = outcome.value.trim();
@@ -397,7 +416,10 @@ export class PoiTooltipOverlay {
 
   private updateStatus(poi: PoiDefinition) {
     if (poi.status) {
-      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
+      const statusLabel =
+        poi.status === 'prototype'
+          ? this.strings.status.prototype
+          : this.strings.status.live;
       this.statusBadge.textContent = statusLabel;
       this.statusBadge.hidden = false;
     } else {
@@ -458,7 +480,10 @@ export class PoiTooltipOverlay {
   }
 
   private announceDiscovery(poi: PoiDefinition) {
-    const message = this.discoveryFormatter(poi).trim();
+    const message =
+      this.discoveryFormatter === defaultDiscoveryFormatter
+        ? defaultDiscoveryFormatter(poi, this.strings)
+        : this.discoveryFormatter(poi).trim();
     if (!message) {
       return;
     }
@@ -494,9 +519,14 @@ function applyVisuallyHiddenStyles(element: HTMLElement): void {
   element.style.pointerEvents = 'none';
 }
 
-function defaultDiscoveryFormatter(poi: PoiDefinition): string {
-  const summary = poi.summary ? ` ${poi.summary}` : '';
-  return `${poi.title} discovered.${summary}`;
+function defaultDiscoveryFormatter(
+  poi: PoiDefinition,
+  strings = getPoiOverlayStrings()
+): string {
+  return formatMessage(strings.discoveryAnnouncementTemplate, {
+    title: poi.title,
+    summary: poi.summary ?? '',
+  }).trim();
 }
 
 let tooltipInstanceCounter = 0;

--- a/src/scene/poi/tourGuide.ts
+++ b/src/scene/poi/tourGuide.ts
@@ -34,7 +34,7 @@ export class PoiTourGuide {
 
   constructor(options: PoiTourGuideOptions) {
     this.visitedState = options.visitedState;
-    this.setDefinitions(options.definitions);
+    this.replaceDefinitions(options.definitions);
     this.priorityOrder = this.normalizePriority(
       options.priorityOrder ??
         options.definitions.map((definition) => definition.id)
@@ -58,6 +58,13 @@ export class PoiTourGuide {
     };
   }
 
+  setDefinitions(definitions: PoiDefinition[]): void {
+    const previousRecommendationId = this.recommendation?.id ?? null;
+    this.replaceDefinitions(definitions);
+    this.priorityOrder = this.normalizePriority(this.priorityOrder);
+    this.refreshRecommendation({ forceEmitForId: previousRecommendationId });
+  }
+
   setPriorityOrder(order: PoiId[]): void {
     const normalized = this.normalizePriority(order);
     if (this.areOrdersEqual(normalized, this.priorityOrder)) {
@@ -75,7 +82,7 @@ export class PoiTourGuide {
     this.listeners.clear();
   }
 
-  private setDefinitions(definitions: PoiDefinition[]) {
+  private replaceDefinitions(definitions: PoiDefinition[]) {
     this.allDefinitions = definitions.slice();
     this.definitionsById.clear();
     for (const definition of definitions) {
@@ -96,10 +103,18 @@ export class PoiTourGuide {
     return unique;
   }
 
-  private refreshRecommendation() {
+  private refreshRecommendation(
+    options: { forceEmitForId?: PoiId | null } = {}
+  ) {
     const visited = this.visitedState.snapshot();
     const next = this.computeRecommendation(visited);
-    if (next?.id === this.recommendation?.id) {
+    const nextId = next?.id ?? null;
+    if (nextId === (this.recommendation?.id ?? null)) {
+      this.recommendation = next;
+      if (options.forceEmitForId !== nextId) {
+        return;
+      }
+      this.emit(next);
       return;
     }
     this.recommendation = next;

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -11,10 +11,12 @@ import {
   getModeToggleStrings,
   getLocaleScript,
   getPoiNarrativeLogStrings,
+  getPoiOverlayStrings,
   getPoiCopy,
   getSiteStrings,
   resolveLocale,
 } from '../assets/i18n';
+import { getPoiDefinitions } from '../scene/poi/registry';
 
 describe('i18n utilities', () => {
   it('exposes available locales including pseudo locale scaffolding', () => {
@@ -203,6 +205,28 @@ describe('i18n utilities', () => {
     ).toBe('15:30 に訪問');
   });
 
+  it('returns localized POI overlay chrome strings', () => {
+    const english = getPoiOverlayStrings('en');
+    expect(english.visited).toBe('Visited');
+    expect(english.status.prototype).toBe('Prototype');
+    expect(
+      formatMessage(english.discoveryAnnouncementTemplate, {
+        title: 'Flywheel',
+        summary: 'Automation lab.',
+      })
+    ).toBe('Flywheel discovered. Automation lab.');
+
+    const pseudo = getPoiOverlayStrings('en-x-pseudo');
+    expect(pseudo.visited).toBe('⟦Visited⟧');
+    expect(pseudo.closeDetails).toBe('⟦Close POI details⟧');
+
+    const arabic = getPoiOverlayStrings('ar');
+    expect(arabic.visited).toBe('تمت الزيارة');
+
+    const japanese = getPoiOverlayStrings('ja');
+    expect(japanese.relatedCaseStudies).toBe('関連ケーススタディ');
+  });
+
   it('provides localized copy for POIs with English fallback', () => {
     const copy = getPoiCopy();
     expect(copy['futuroptimist-living-room-tv'].title).toMatch(/Futuroptimist/);
@@ -218,6 +242,36 @@ describe('i18n utilities', () => {
     expect(pseudoCopy['tokenplace-studio-cluster'].title).toBe(
       copy['tokenplace-studio-cluster'].title
     );
+  });
+
+  it('localizes POI definitions per locale without mutating shared base data', () => {
+    const english = getPoiDefinitions('en');
+    const pseudo = getPoiDefinitions('en-x-pseudo');
+    const englishAgain = getPoiDefinitions('en');
+
+    const englishPoi = english.find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    const pseudoPoi = pseudo.find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    const englishAgainPoi = englishAgain.find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+
+    expect(englishPoi?.title).toBe('Futuroptimist');
+    expect(pseudoPoi?.title).toBe('⟦Futuroptimist⟧');
+    expect(pseudoPoi?.interactionPrompt).toContain('⟦Futuroptimist⟧');
+    expect(englishAgainPoi?.title).toBe('Futuroptimist');
+
+    if (pseudoPoi?.metrics?.[0]) {
+      pseudoPoi.metrics[0].value = 'mutated';
+    }
+
+    const freshPseudo = getPoiDefinitions('en-x-pseudo').find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    expect(freshPseudo?.metrics?.[0]?.value).not.toBe('mutated');
   });
 
   it('falls back to English site metadata when pseudo overrides omit values', () => {

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -5,6 +5,7 @@ import { scalePoiValue } from '../scene/poi/constants';
 import {
   createPoiInstances,
   createPoiLabelTexture,
+  updatePoiInstanceDefinition,
 } from '../scene/poi/markers';
 import type { PoiDefinition } from '../scene/poi/types';
 
@@ -155,6 +156,23 @@ describe('createPoiInstances', () => {
       expect(fillTextLog.join(' ')).toBe(title);
       expect(fillTextLog.join(' ')).not.toContain('…');
     }
+  });
+
+  it('refreshes existing marker label textures when definitions are localized', () => {
+    fillTextLog = [];
+    const [instance] = createPoiInstances([
+      createDefinition({ title: 'Gitshelves' }),
+    ]);
+    expect(fillTextLog).toContain('Gitshelves');
+
+    fillTextLog = [];
+    updatePoiInstanceDefinition(
+      instance,
+      createDefinition({ title: '⟦Gitshelves⟧' })
+    );
+
+    expect(instance.definition.title).toBe('⟦Gitshelves⟧');
+    expect(fillTextLog).toContain('⟦Gitshelves⟧');
   });
 
   it('adds an ellipsis when long marker titles exceed the two-line cap', () => {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getPoiOverlayStrings } from '../assets/i18n';
+import { getPoiDefinitions } from '../scene/poi/registry';
 import { PoiTooltipOverlay } from '../scene/poi/tooltipOverlay';
 import type { PoiDefinition } from '../scene/poi/types';
 import { GuidedTourPreference } from '../systems/guidedTour/preference';
@@ -404,6 +406,46 @@ describe('PoiTooltipOverlay', () => {
       container.querySelectorAll<HTMLSpanElement>(metricSelector)
     ).map((node) => node.textContent);
     expect(updatedValues).toContain('Updated workflow');
+  });
+
+  it('rerenders active POI copy and overlay chrome during runtime locale switching', () => {
+    const englishPoi = getPoiDefinitions('en').find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    const pseudoPoi = getPoiDefinitions('en-x-pseudo').find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    expect(englishPoi).toBeTruthy();
+    expect(pseudoPoi).toBeTruthy();
+
+    overlay.setSelected(englishPoi!);
+    overlay.setVisitedPoiIds(new Set([englishPoi!.id]));
+
+    overlay.setStrings(getPoiOverlayStrings('en-x-pseudo'));
+    overlay.setSelected(pseudoPoi!);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      '⟦Futuroptimist⟧'
+    );
+    expect(
+      root.querySelector('.poi-tooltip-overlay__summary')?.textContent
+    ).toContain('⟦Automated Futuroptimist');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-label')?.textContent
+    ).toBe('⟦Stars⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__visited')?.textContent
+    ).toBe('⟦Visited⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__status')?.textContent
+    ).toBe('⟦Prototype⟧');
+    expect(
+      root
+        .querySelector('.poi-tooltip-overlay__links')
+        ?.getAttribute('aria-label')
+    ).toBe('⟦Related case studies⟧');
   });
 
   it('hides the outcome row when a POI omits the outcome field', () => {

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -247,6 +247,30 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('rerenders the selected title when localized POI definitions are swapped in place', () => {
+    const { tooltip, preference } = createTooltip();
+    const poi = createPoiDefinition({
+      id: 'flywheel-studio-flywheel',
+      title: 'Flywheel',
+    });
+    const target = createTarget(poi, new Vector3(0, 1, 0));
+
+    tooltip.setSelected(target);
+    tooltip.update(0.016);
+    expect(latestFillTextLog).toEqual(['Flywheel']);
+
+    target.poi = createPoiDefinition({
+      id: 'flywheel-studio-flywheel',
+      title: '⟦Flywheel⟧',
+    });
+    tooltip.notifyPoiUpdated(target.poi.id);
+
+    expect(latestFillTextLog).toEqual(['Flywheel', '⟦Flywheel⟧']);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('renders only the POI title in the in-world card', () => {
     const { tooltip, preference } = createTooltip();
     const poi = createPoiDefinition({


### PR DESCRIPTION
### Motivation
- POI copy was being resolved at module load which left POI titles, summaries, metrics, and interaction prompts frozen when the user changed locale at runtime.
- Localization must update overlay chrome, in-world labels, structured data, metric wiring, and narrative/visited state without reloading the page.

### Description
- Split static POI placement from localized copy by introducing `localizePoiDefinitions(input?)` and a locale-aware `getPoiDefinitions(input?)`, keeping base geometry immutable and returning cloned, locale-specific `PoiDefinition` objects. (changes: `src/scene/poi/registry.ts`)
- Wire runtime locale refresh in the scene bootstrap so `applyLocaleUpdate` rebuilds localized POIs, remaps `poiDefinitionsById`, updates existing `PoiInstance`s (marker label textures) via `updatePoiInstanceDefinition`, and remaps selected/hovered/recommended POIs without recreating Three.js geometry. (changes: `src/main.ts`, `src/scene/poi/markers.ts`)
- Move POI overlay chrome strings into the i18n system (`poiOverlay`) and add API on `PoiTooltipOverlay` to update strings at runtime (`setStrings` / `setLocale`), plus use i18n for discovery announcement template and outcome/status labels. (changes: `src/assets/i18n/*`, `src/scene/poi/tooltipOverlay.ts`)
- Ensure GitHub metric wiring and structured data are re-injected with localized data on locale changes and keep POI tour recommendation identity stable by refreshing `PoiTourGuide` definitions. (changes: `src/scene/poi/githubMetrics.ts`, `src/scene/poi/structuredData.ts`, `src/scene/poi/tourGuide.ts`)
- Add tests that cover localized POI definitions without mutating base data, overlay chrome locale strings, runtime overlay re-render on locale switch, marker label refresh, and in-world tooltip title rerendering. (changes: `src/tests/i18n.test.ts`, `src/tests/poiTooltipOverlay.test.ts`, `src/tests/poiMarkers.test.ts`, `src/tests/poiWorldTooltip.test.ts`)

### Testing
- `npm run format:write` — ran and applied formatting (success).
- `npm run lint` — ran; no errors, one import-order warning was fixed (success).
- `npm run test:ci -- src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts src/tests/poiMarkers.test.ts` — ran Vitest for the focused suites; all tests passed (4 files, 61 tests passed).
- `npm run build` — ran Vite build; completed successfully (bundle created).
- `npm run typecheck` — attempted but failed due to existing unrelated TypeScript errors elsewhere in the repo (avatar/audio/collision/tests etc.); failures are pre-existing and outside the scope of this PR.
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — ran and returned no high-risk secrets.

Residual risks / follow-ups
- `tsc --noEmit` still surfaces unrelated repo-wide typing issues; those are pre-existing and not introduced by this change, but full CI typecheck remains blocked by them and should be addressed in a separate cleanup PR.
- The marker texture update reuses and disposes CanvasTextures; monitor for any rare GPU memory leak in long-lived sessions (no issues surfaced in tests or build).

How to verify locally
- `npm run format:write`
- `npm run lint`
- `npm run test:ci -- src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts src/tests/poiMarkers.test.ts`
- Start the app and change Settings locale; confirm POI overlay titles, summaries, metric labels, visited/recommendation badges, marker textures, and structured data update without reloading.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f954a7544832fa08e716da6499986)