### PR TITLE
Make POI copy & overlay chrome locale-reactive

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -1,4 +1,4 @@
-import type { PoiId } from '../poi/types';
+import type { PoiId } from '../../scene/poi/types';
 
 import { AR_OVERRIDES } from './locales/ar';
 import { EN_LOCALE_STRINGS } from './locales/en';
@@ -21,6 +21,7 @@ import type {
   MovementLegendStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
+  PoiOverlayChromeStrings,
   HudCustomizationStrings,
   SiteStrings,
 } from './types';
@@ -333,6 +334,12 @@ export function getPoiNarrativeLogStrings(
   input?: LocaleInput
 ): PoiNarrativeLogStrings {
   return getLocaleStrings(input).hud.narrativeLog;
+}
+
+export function getPoiOverlayChromeStrings(
+  input?: LocaleInput
+): PoiOverlayChromeStrings {
+  return getLocaleStrings(input).hud.poiOverlay;
 }
 
 export function getSiteStrings(input?: LocaleInput): SiteStrings {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -295,6 +295,18 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Text mode toggle failed. Press {keyHint} to retry text mode.'
       ),
     },
+    poiOverlay: {
+      visited: wrap('Visited'),
+      nextHighlight: wrap('Next highlight'),
+      status: {
+        prototype: wrap('Prototype'),
+        live: wrap('Live'),
+      },
+      closeLabel: wrap('Close POI details'),
+      relatedCaseStudiesLabel: wrap('Related case studies'),
+      outcomeFallbackLabel: wrap('Outcome'),
+      discoveryAnnouncementTemplate: wrap('{title} discovered.{summary}'),
+    },
     narrativeLog: {
       heading: wrap('Creator story log'),
       visitedHeading: wrap('Visited exhibits'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -297,6 +297,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       errorTitleTemplate:
         'Text mode toggle failed. Press {keyHint} to retry text mode.',
     },
+    poiOverlay: {
+      visited: 'Visited',
+      nextHighlight: 'Next highlight',
+      status: {
+        prototype: 'Prototype',
+        live: 'Live',
+      },
+      closeLabel: 'Close POI details',
+      relatedCaseStudiesLabel: 'Related case studies',
+      outcomeFallbackLabel: 'Outcome',
+      discoveryAnnouncementTemplate: '{title} discovered.{summary}',
+    },
     narrativeLog: {
       heading: 'Creator story log',
       visitedHeading: 'Visited exhibits',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -1,12 +1,12 @@
-import type { FallbackReason } from '../../types/failover';
-import type { InputMethod } from '../../ui/hud/movementLegend';
 import type {
   PoiId,
   PoiInteraction,
   PoiMetricSource,
   PoiNarration,
   PoiOutcome,
-} from '../poi/types';
+} from '../../scene/poi/types';
+import type { FallbackReason } from '../../types/failover';
+import type { InputMethod } from '../../ui/hud/movementLegend';
 
 export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja';
 export type LocaleDirection = 'ltr' | 'rtl';
@@ -168,6 +168,19 @@ export interface HudCustomizationStrings {
   accessories: { title: string; description: string };
 }
 
+export interface PoiOverlayChromeStrings {
+  visited: string;
+  nextHighlight: string;
+  status: {
+    prototype: string;
+    live: string;
+  };
+  closeLabel: string;
+  relatedCaseStudiesLabel: string;
+  outcomeFallbackLabel: string;
+  discoveryAnnouncementTemplate: string;
+}
+
 export interface PoiNarrativeLogStrings {
   heading: string;
   visitedHeading: string;
@@ -299,6 +312,7 @@ export interface LocaleStrings {
     helpModal: HelpModalStrings;
     customization: HudCustomizationStrings;
     narrativeLog: PoiNarrativeLogStrings;
+    poiOverlay: PoiOverlayChromeStrings;
   };
   poi: Record<PoiId, PoiCopy>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ import {
   getModeAnnouncerStrings,
   getModeToggleStrings,
   getPoiNarrativeLogStrings,
+  getPoiOverlayChromeStrings,
   getSiteStrings,
   resolveLocale,
   type Locale,
@@ -166,6 +167,7 @@ import { GuidedTourChannel } from './scene/poi/guidedTourChannel';
 import { PoiInteractionManager } from './scene/poi/interactionManager';
 import {
   createPoiInstances,
+  updatePoiInstanceDefinition,
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
@@ -923,6 +925,7 @@ function initializeImmersiveScene(
   let modeToggleStrings = getModeToggleStrings(locale);
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+  let poiOverlayChromeStrings = getPoiOverlayChromeStrings(locale);
   let siteStrings = getSiteStrings(locale);
   const syncModeAnnouncerStrings = () => {
     const announcerStrings = getModeAnnouncerStrings(locale);
@@ -1010,8 +1013,8 @@ function initializeImmersiveScene(
   scene.background = createImmersiveGradientTexture();
 
   const poiOverrides: PoiInstanceOverrides = {};
-  const poiDefinitions = getPoiDefinitions();
-  const poiDefinitionsById = new Map(
+  let poiDefinitions = getPoiDefinitions(locale);
+  let poiDefinitionsById = new Map(
     poiDefinitions.map((definition) => [definition.id, definition] as const)
   );
   injectPoiStructuredData(poiDefinitions, {
@@ -1566,6 +1569,7 @@ function initializeImmersiveScene(
     (layoutOverride ?? hudLayoutManager?.getLayout()) === 'mobile';
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
+    strings: poiOverlayChromeStrings,
     interactionTimeline,
     onDismiss: () => {
       dismissActivePoiDetail();
@@ -1658,20 +1662,27 @@ function initializeImmersiveScene(
   window.portfolio.githubMetrics = {
     getDiagnostics: () => githubRepoStatsService.getDiagnostics(),
   };
-  githubRepoMetrics = wireGitHubRepoMetrics({
-    definitions: poiDefinitions,
-    service: githubRepoStatsService,
-    onMetricsUpdated: (poiId) => {
-      poiTooltipOverlay.notifyPoiUpdated(poiId);
-      poiWorldTooltip.notifyPoiUpdated(poiId);
-    },
-    onRepoStatsUpdated: ({ poiId, stats }) => {
-      if (poiId === 'futuroptimist-living-room-tv') {
-        mediaWallStarBridge.updateStarCount(stats.stars);
-      }
-    },
-  });
-  githubRepoMetrics.refreshAll().catch(() => {
+  const rewireGitHubMetrics = (): GitHubRepoMetricsController => {
+    githubRepoMetrics?.dispose();
+    const controller = wireGitHubRepoMetrics({
+      definitions: poiDefinitions,
+      service: githubRepoStatsService,
+      onMetricsUpdated: (poiId) => {
+        poiTooltipOverlay.notifyPoiUpdated(poiId);
+        poiWorldTooltip.notifyPoiUpdated(poiId);
+      },
+      onRepoStatsUpdated: ({ poiId, stats }) => {
+        if (poiId === 'futuroptimist-living-room-tv') {
+          mediaWallStarBridge.updateStarCount(stats.stars);
+        }
+      },
+    });
+    githubRepoMetrics = controller;
+    return controller;
+  };
+
+  const initialGithubRepoMetrics = rewireGitHubMetrics();
+  initialGithubRepoMetrics?.refreshAll().catch(() => {
     /* GitHub may be unreachable; metrics will remain on fallback values. */
   });
   const poiVisitedState = new PoiVisitedState();
@@ -1748,9 +1759,8 @@ function initializeImmersiveScene(
           (poi) => poi.definition.id
         );
         const worldTooltipTitle =
-          poiDefinitions.find(
-            (definition) => definition.id === worldState.poiId
-          )?.title ?? null;
+          poiDefinitionsById.get(worldState.poiId as PoiDefinition['id'])
+            ?.title ?? null;
         const activePoiId = worldState.visible
           ? worldState.poiId
           : overlayState.visible
@@ -1806,7 +1816,7 @@ function initializeImmersiveScene(
     }
     if (poiNarrativeLog) {
       const visitedDefinitions = Array.from(visited)
-        .map((id) => poiDefinitionsById.get(id))
+        .map((id) => poiDefinitionsById.get(id as PoiDefinition['id']))
         .filter((definition): definition is PoiDefinition =>
           Boolean(definition)
         );
@@ -1826,7 +1836,7 @@ function initializeImmersiveScene(
           if (previousVisited.has(id)) {
             continue;
           }
-          const definition = poiDefinitionsById.get(id);
+          const definition = poiDefinitionsById.get(id as PoiDefinition['id']);
           if (!definition) {
             continue;
           }
@@ -2909,6 +2919,61 @@ function initializeImmersiveScene(
   };
   updateHelpButtonLabel();
 
+  const refreshLocalizedPoiDefinitions = () => {
+    const nextDefinitions = getPoiDefinitions(locale);
+    const nextDefinitionsById = new Map(
+      nextDefinitions.map((definition) => [definition.id, definition] as const)
+    );
+    poiDefinitions = nextDefinitions;
+    poiDefinitionsById = nextDefinitionsById;
+
+    poiInstances.forEach((instance) => {
+      const localized = nextDefinitionsById.get(instance.definition.id);
+      if (localized) {
+        updatePoiInstanceDefinition(instance, localized);
+      }
+    });
+
+    currentHoveredPoi = currentHoveredPoi
+      ? (nextDefinitionsById.get(currentHoveredPoi.id) ?? null)
+      : null;
+    currentSelectedPoi = currentSelectedPoi
+      ? (nextDefinitionsById.get(currentSelectedPoi.id) ?? null)
+      : null;
+    currentGuidedTourRecommendation = currentGuidedTourRecommendation
+      ? (nextDefinitionsById.get(currentGuidedTourRecommendation.id) ?? null)
+      : null;
+
+    poiTourGuide.setDefinitions(nextDefinitions);
+    proceduralNarrator?.primeVisited(
+      Array.from(poiVisitedState.snapshot())
+        .map((id) => nextDefinitionsById.get(id))
+        .filter((definition): definition is PoiDefinition =>
+          Boolean(definition)
+        )
+    );
+    syncPoiDetailOverlay();
+    syncPoiRecommendation();
+    [currentHoveredPoi, currentSelectedPoi, currentGuidedTourRecommendation]
+      .filter((poi): poi is PoiDefinition => Boolean(poi))
+      .forEach((poi) => {
+        poiTooltipOverlay.notifyPoiUpdated(poi.id);
+        poiWorldTooltip.notifyPoiUpdated(poi.id);
+      });
+    const localizedGithubRepoMetrics = rewireGitHubMetrics();
+    localizedGithubRepoMetrics.refreshAll().catch(() => {
+      /* GitHub may be unreachable; metrics will remain on fallback values. */
+    });
+    injectPoiStructuredData(nextDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
+    injectTextPortfolioStructuredData(nextDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
+  };
+
   const applyLocaleUpdate = (nextLocale: Locale) => {
     if (locale === nextLocale) {
       return;
@@ -2934,6 +2999,7 @@ function initializeImmersiveScene(
     audioHudStrings = getAudioHudControlStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+    poiOverlayChromeStrings = getPoiOverlayChromeStrings(locale);
     siteStrings = getSiteStrings(locale);
     syncModeAnnouncerStrings();
     narrativeTimeFormatter = new Intl.DateTimeFormat(
@@ -2963,12 +3029,14 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
+    refreshLocalizedPoiDefinitions();
+    poiTooltipOverlay.setStrings(poiOverlayChromeStrings);
     updateHelpButtonLabel();
     localeToggleControl?.refresh();
 
     const visitedSnapshot = poiVisitedState.snapshot();
     const visitedDefinitions = Array.from(visitedSnapshot)
-      .map((id) => poiDefinitionsById.get(id))
+      .map((id) => poiDefinitionsById.get(id as PoiDefinition['id']))
       .filter((definition): definition is PoiDefinition => Boolean(definition));
     if (visitedDefinitions.length > 0 && poiNarrativeLog) {
       poiNarrativeLog.syncVisited(visitedDefinitions, {

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -442,6 +442,20 @@ function createDisplayPoiInstance(
   };
 }
 
+export function updatePoiInstanceDefinition(
+  instance: PoiInstance,
+  definition: PoiDefinition
+): void {
+  instance.definition = definition;
+  if (!instance.labelMaterial) {
+    return;
+  }
+  const previousTexture = instance.labelMaterial.map;
+  instance.labelMaterial.map = createPoiLabelTexture(definition);
+  instance.labelMaterial.needsUpdate = true;
+  previousTexture?.dispose();
+}
+
 export function createPoiLabelTexture(
   definition: PoiDefinition
 ): CanvasTexture {

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -3,6 +3,7 @@ import {
   formatMessage,
   getControlOverlayStrings,
   getPoiCopy,
+  type LocaleInput,
 } from '../../assets/i18n';
 
 import { scalePoiValue } from './constants';
@@ -27,6 +28,7 @@ type PoiStaticDefinition = Omit<
   | 'links'
   | 'narration'
   | 'pedestal'
+  | 'interactionPrompt'
 > & { pedestal?: PoiPedestalStaticConfig };
 
 const baseDefinitions: PoiStaticDefinition[] = [
@@ -225,57 +227,67 @@ const baseDefinitions: PoiStaticDefinition[] = [
   },
 ];
 
-const poiCopy = getPoiCopy();
-const controlOverlayStrings = getControlOverlayStrings();
+function buildScaledDefinitions(locale?: LocaleInput): PoiDefinition[] {
+  const poiCopy = getPoiCopy(locale);
+  const controlOverlayStrings = getControlOverlayStrings(locale);
 
-const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
-  const copy = poiCopy[base.id];
-  if (!copy) {
-    throw new Error(`Missing localized POI copy for ${base.id}`);
-  }
-  const footprintWidth = scalePoiValue(base.footprint.width);
-  const footprintDepth = scalePoiValue(base.footprint.depth);
-  const baseMaxHalf = Math.max(base.footprint.width, base.footprint.depth) / 2;
-  const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
-  const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
-  const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
-  const pedestal: PoiPedestalConfig | undefined = base.pedestal
-    ? {
-        ...base.pedestal,
-        height:
-          typeof base.pedestal.height === 'number'
-            ? scalePoiValue(base.pedestal.height)
-            : undefined,
-      }
-    : undefined;
-  const template =
-    copy.interactionPrompt ??
-    controlOverlayStrings.interact.promptTemplates[base.interaction] ??
-    controlOverlayStrings.interact.promptTemplates.default;
-  const interactionPrompt = formatMessage(template, { title: copy.title });
-  return {
-    ...base,
-    interactionRadius: scaledInteractionRadius,
-    footprint: {
-      width: footprintWidth,
-      depth: footprintDepth,
-    },
-    pedestal,
-    title: copy.title,
-    summary: copy.summary,
-    outcome: copy.outcome ? { ...copy.outcome } : undefined,
-    metrics: copy.metrics?.map((metric) => ({ ...metric })),
-    links: copy.links?.map((link) => ({ ...link })),
-    narration: copy.narration ? { ...copy.narration } : undefined,
-    interactionPrompt,
-  } satisfies PoiDefinition;
-});
+  return baseDefinitions.map((base) => {
+    const copy = poiCopy[base.id];
+    if (!copy) {
+      throw new Error(`Missing localized POI copy for ${base.id}`);
+    }
+    const footprintWidth = scalePoiValue(base.footprint.width);
+    const footprintDepth = scalePoiValue(base.footprint.depth);
+    const baseMaxHalf =
+      Math.max(base.footprint.width, base.footprint.depth) / 2;
+    const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
+    const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
+    const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
+    const pedestal: PoiPedestalConfig | undefined = base.pedestal
+      ? {
+          ...base.pedestal,
+          height:
+            typeof base.pedestal.height === 'number'
+              ? scalePoiValue(base.pedestal.height)
+              : undefined,
+        }
+      : undefined;
+    const template =
+      copy.interactionPrompt ??
+      controlOverlayStrings.interact.promptTemplates[base.interaction] ??
+      controlOverlayStrings.interact.promptTemplates.default;
+    const interactionPrompt = formatMessage(template, { title: copy.title });
+    return {
+      ...base,
+      position: { ...base.position },
+      footprint: {
+        width: footprintWidth,
+        depth: footprintDepth,
+      },
+      interactionRadius: scaledInteractionRadius,
+      pedestal,
+      title: copy.title,
+      summary: copy.summary,
+      outcome: copy.outcome ? { ...copy.outcome } : undefined,
+      metrics: copy.metrics?.map((metric) => ({
+        ...metric,
+        source: metric.source ? { ...metric.source } : undefined,
+      })),
+      links: copy.links?.map((link) => ({ ...link })),
+      narration: copy.narration ? { ...copy.narration } : undefined,
+      interactionPrompt,
+    } satisfies PoiDefinition;
+  });
+}
 
-// Deterministically lay out indoor POIs across downstairs rooms.
-// Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
-const definitions: PoiDefinition[] = applyManualPoiPlacements(scaled);
-
-assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+function buildDefinitions(locale?: LocaleInput): PoiDefinition[] {
+  const scaled = buildScaledDefinitions(locale);
+  // Deterministically lay out indoor POIs across downstairs rooms. Apply only
+  // manual placements for downstairs. Simple, explicit, and easy to tweak.
+  const definitions = applyManualPoiPlacements(scaled);
+  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  return definitions;
+}
 
 function clonePoi(definition: PoiDefinition): PoiDefinition {
   return {
@@ -283,7 +295,10 @@ function clonePoi(definition: PoiDefinition): PoiDefinition {
     position: { ...definition.position },
     footprint: { ...definition.footprint },
     outcome: definition.outcome ? { ...definition.outcome } : undefined,
-    metrics: definition.metrics?.map((metric) => ({ ...metric })),
+    metrics: definition.metrics?.map((metric) => ({
+      ...metric,
+      source: metric.source ? { ...metric.source } : undefined,
+    })),
     links: definition.links?.map((link) => ({ ...link })),
     narration: definition.narration ? { ...definition.narration } : undefined,
     pedestal: definition.pedestal ? { ...definition.pedestal } : undefined,
@@ -350,20 +365,39 @@ class StaticPoiRegistry implements PoiRegistry {
   }
 }
 
-export const poiRegistry: PoiRegistry = new StaticPoiRegistry(definitions);
+export const poiRegistry: PoiRegistry = new StaticPoiRegistry(
+  buildDefinitions()
+);
 
-export function getPoiDefinitions(): PoiDefinition[] {
-  return poiRegistry.all();
+export function getPoiDefinitions(locale?: LocaleInput): PoiDefinition[] {
+  if (locale === undefined) {
+    return poiRegistry.all();
+  }
+  return buildDefinitions(locale).map((definition) => clonePoi(definition));
 }
 
-export function getPoiDefinitionsByRoom(roomId: string): PoiDefinition[] {
-  return poiRegistry.getByRoom(roomId);
+export function localizePoiDefinitions(locale?: LocaleInput): PoiDefinition[] {
+  return getPoiDefinitions(locale);
+}
+
+export function getPoiDefinitionsByRoom(
+  roomId: string,
+  locale?: LocaleInput
+): PoiDefinition[] {
+  if (locale === undefined) {
+    return poiRegistry.getByRoom(roomId);
+  }
+  return getPoiDefinitions(locale).filter((poi) => poi.roomId === roomId);
 }
 
 export function getPoiDefinitionsByCategory(
-  category: PoiCategory
+  category: PoiCategory,
+  locale?: LocaleInput
 ): PoiDefinition[] {
-  return poiRegistry.getByCategory(category);
+  if (locale === undefined) {
+    return poiRegistry.getByCategory(category);
+  }
+  return getPoiDefinitions(locale).filter((poi) => poi.category === category);
 }
 
 export function isPoiInsideRoom(poi: PoiDefinition): boolean {

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -1,4 +1,9 @@
 import {
+  formatMessage,
+  getPoiOverlayChromeStrings,
+  type PoiOverlayChromeStrings,
+} from '../../assets/i18n';
+import {
   GuidedTourPreference,
   defaultGuidedTourPreference,
 } from '../../systems/guidedTour/preference';
@@ -12,6 +17,7 @@ type DiscoveryFormatter = (poi: PoiDefinition) => string;
 export interface PoiTooltipOverlayOptions {
   container: HTMLElement;
   onDismiss?: () => void;
+  strings?: PoiOverlayChromeStrings;
   discoveryAnnouncer?: {
     format?: DiscoveryFormatter;
     politeness?: 'polite' | 'assertive';
@@ -42,6 +48,7 @@ export class PoiTooltipOverlay {
   private readonly interactionTimeline: InteractionTimeline | null;
   private readonly guidedTourPreference: GuidedTourPreference;
   private readonly instanceId: string;
+  private strings: PoiOverlayChromeStrings;
   private discoveryFormatter: DiscoveryFormatter;
   private discoveryPoliteness: 'polite' | 'assertive';
   private readonly discoveredPoiIds = new Set<string>();
@@ -61,15 +68,17 @@ export class PoiTooltipOverlay {
     const {
       container,
       onDismiss,
+      strings,
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
     } = options;
     const documentTarget = container.ownerDocument ?? document;
 
+    this.strings = strings ?? getPoiOverlayChromeStrings();
     this.discoveryPoliteness = discoveryAnnouncer?.politeness ?? 'polite';
     this.discoveryFormatter =
-      discoveryAnnouncer?.format ?? defaultDiscoveryFormatter;
+      discoveryAnnouncer?.format ?? this.formatDiscoveryAnnouncement;
     this.interactionTimeline = interactionTimeline ?? null;
     this.guidedTourPreference = guidedTourPreference;
     this.onDismiss = onDismiss ?? null;
@@ -100,20 +109,20 @@ export class PoiTooltipOverlay {
 
     this.visitedBadge = documentTarget.createElement('span');
     this.visitedBadge.className = 'poi-tooltip-overlay__visited';
-    this.visitedBadge.textContent = 'Visited';
+    this.visitedBadge.textContent = this.strings.visited;
     this.visitedBadge.hidden = true;
     headingRow.appendChild(this.visitedBadge);
 
     this.recommendationBadge = documentTarget.createElement('span');
     this.recommendationBadge.className = 'poi-tooltip-overlay__recommendation';
-    this.recommendationBadge.textContent = 'Next highlight';
+    this.recommendationBadge.textContent = this.strings.nextHighlight;
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
 
     this.closeButton = documentTarget.createElement('button');
     this.closeButton.className = 'poi-tooltip-overlay__close';
     this.closeButton.type = 'button';
-    this.closeButton.setAttribute('aria-label', 'Close POI details');
+    this.closeButton.setAttribute('aria-label', this.strings.closeLabel);
     this.closeButton.textContent = '×';
     this.closeButton.hidden = true;
     this.closeButton.disabled = true;
@@ -153,7 +162,10 @@ export class PoiTooltipOverlay {
     this.linksList = documentTarget.createElement('ul');
     this.linksList.className = 'poi-tooltip-overlay__links';
     this.linksList.id = `${this.instanceId}-links`;
-    this.linksList.setAttribute('aria-label', 'Related case studies');
+    this.linksList.setAttribute(
+      'aria-label',
+      this.strings.relatedCaseStudiesLabel
+    );
     this.root.appendChild(this.linksList);
 
     container.appendChild(this.root);
@@ -175,6 +187,19 @@ export class PoiTooltipOverlay {
         this.update();
       }
     );
+  }
+
+  setStrings(strings: PoiOverlayChromeStrings) {
+    this.strings = strings;
+    this.visitedBadge.textContent = strings.visited;
+    this.recommendationBadge.textContent = strings.nextHighlight;
+    this.closeButton.setAttribute('aria-label', strings.closeLabel);
+    this.linksList.setAttribute('aria-label', strings.relatedCaseStudiesLabel);
+    if (this.discoveryFormatter === this.formatDiscoveryAnnouncement) {
+      this.discoveryFormatter = this.formatDiscoveryAnnouncement;
+    }
+    this.renderState.poiId = null;
+    this.update();
   }
 
   setIdleState(idle: boolean) {
@@ -387,7 +412,7 @@ export class PoiTooltipOverlay {
       return;
     }
 
-    const label = outcome.label?.trim() || 'Outcome';
+    const label = outcome.label?.trim() || this.strings.outcomeFallbackLabel;
     this.outcomeLabel.textContent = label;
     this.outcomeLabel.hidden = false;
     this.outcomeValue.textContent = outcome.value.trim();
@@ -397,7 +422,10 @@ export class PoiTooltipOverlay {
 
   private updateStatus(poi: PoiDefinition) {
     if (poi.status) {
-      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
+      const statusLabel =
+        poi.status === 'prototype'
+          ? this.strings.status.prototype
+          : this.strings.status.live;
       this.statusBadge.textContent = statusLabel;
       this.statusBadge.hidden = false;
     } else {
@@ -457,6 +485,14 @@ export class PoiTooltipOverlay {
     }
   }
 
+  private formatDiscoveryAnnouncement = (poi: PoiDefinition): string => {
+    const summary = poi.summary ? ` ${poi.summary}` : '';
+    return formatMessage(this.strings.discoveryAnnouncementTemplate, {
+      title: poi.title,
+      summary,
+    });
+  };
+
   private announceDiscovery(poi: PoiDefinition) {
     const message = this.discoveryFormatter(poi).trim();
     if (!message) {
@@ -492,11 +528,6 @@ function applyVisuallyHiddenStyles(element: HTMLElement): void {
   element.style.clipPath = 'inset(50%)';
   element.style.whiteSpace = 'nowrap';
   element.style.pointerEvents = 'none';
-}
-
-function defaultDiscoveryFormatter(poi: PoiDefinition): string {
-  const summary = poi.summary ? ` ${poi.summary}` : '';
-  return `${poi.title} discovered.${summary}`;
 }
 
 let tooltipInstanceCounter = 0;

--- a/src/scene/poi/tourGuide.ts
+++ b/src/scene/poi/tourGuide.ts
@@ -75,7 +75,7 @@ export class PoiTourGuide {
     this.listeners.clear();
   }
 
-  private setDefinitions(definitions: PoiDefinition[]) {
+  setDefinitions(definitions: PoiDefinition[]) {
     this.allDefinitions = definitions.slice();
     this.definitionsById.clear();
     for (const definition of definitions) {

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -11,6 +11,7 @@ import {
   getModeToggleStrings,
   getLocaleScript,
   getPoiNarrativeLogStrings,
+  getPoiOverlayChromeStrings,
   getPoiCopy,
   getSiteStrings,
   resolveLocale,
@@ -174,6 +175,28 @@ describe('i18n utilities', () => {
     expect(
       getSiteStrings('en').textFallback.reasonDescriptions.manual
     ).not.toBe('Mutated');
+  });
+
+  it('exposes localized POI overlay chrome strings', () => {
+    const english = getPoiOverlayChromeStrings('en');
+    expect(english.visited).toBe('Visited');
+    expect(english.nextHighlight).toBe('Next highlight');
+    expect(english.status.prototype).toBe('Prototype');
+    expect(english.status.live).toBe('Live');
+    expect(english.closeLabel).toBe('Close POI details');
+    expect(english.relatedCaseStudiesLabel).toBe('Related case studies');
+    expect(english.outcomeFallbackLabel).toBe('Outcome');
+    expect(
+      formatMessage(english.discoveryAnnouncementTemplate, {
+        title: 'Flywheel',
+        summary: ' Automation showcase.',
+      })
+    ).toBe('Flywheel discovered. Automation showcase.');
+
+    const pseudo = getPoiOverlayChromeStrings('en-x-pseudo');
+    expect(pseudo.visited).toBe('⟦Visited⟧');
+    expect(pseudo.status.prototype).toBe('⟦Prototype⟧');
+    expect(pseudo.closeLabel).toBe('⟦Close POI details⟧');
   });
 
   it('exposes narrative log strings with localized announcements', () => {

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -5,6 +5,7 @@ import { scalePoiValue } from '../scene/poi/constants';
 import {
   createPoiInstances,
   createPoiLabelTexture,
+  updatePoiInstanceDefinition,
 } from '../scene/poi/markers';
 import type { PoiDefinition } from '../scene/poi/types';
 
@@ -145,6 +146,21 @@ describe('createPoiInstances', () => {
     expect(renderedText).not.toContain('Reduced shelf drift');
     expect(renderedText).not.toContain('Cataloged 200 repos');
     expect(renderedText).not.toContain('Prototype');
+  });
+
+  it('updates an existing marker label texture when localized copy changes', () => {
+    const [instance] = createPoiInstances([
+      createDefinition({ title: 'Gitshelves' }),
+    ]);
+    fillTextLog = [];
+
+    updatePoiInstanceDefinition(
+      instance,
+      createDefinition({ title: '⟦Gitshelves⟧' })
+    );
+
+    expect(instance.definition.title).toBe('⟦Gitshelves⟧');
+    expect(fillTextLog.join(' ')).toBe('⟦Gitshelves⟧');
   });
 
   it('preserves existing title-only marker labels without ellipsizing them', () => {

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -11,6 +11,35 @@ import {
 describe('POI registry', () => {
   const pois = getPoiDefinitions();
 
+  it('returns locale-specific defensive copies without mutating English definitions', () => {
+    const english = getPoiDefinitions('en').find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    const pseudo = getPoiDefinitions('en-x-pseudo').find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+
+    expect(english?.title).toBe('Futuroptimist');
+    expect(pseudo?.title).toBe('⟦Futuroptimist⟧');
+    expect(pseudo?.interactionPrompt).toBe('⟦Inspect ⟦Futuroptimist⟧⟧');
+
+    if (pseudo?.metrics?.[0]) {
+      pseudo.metrics[0].value = 'Mutated pseudo metric';
+    }
+
+    const refreshedPseudo = getPoiDefinitions('en-x-pseudo').find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    const refreshedEnglish = getPoiDefinitions('en').find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+
+    expect(refreshedPseudo?.metrics?.[0]?.value).not.toBe(
+      'Mutated pseudo metric'
+    );
+    expect(refreshedEnglish?.title).toBe('Futuroptimist');
+  });
+
   it('uses unique identifiers', () => {
     const ids = pois.map((poi) => poi.id);
     const uniqueIds = new Set(ids);

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -186,6 +186,53 @@ describe('PoiTooltipOverlay', () => {
     expect(describedIds).toContain(linksList.id);
   });
 
+  it('updates selected POI copy and chrome when runtime locale strings change', () => {
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+
+    const localizedPoi: PoiDefinition = {
+      ...basePoi,
+      title: '⟦Futuroptimist⟧',
+      summary: '⟦Localized immersive exhibit summary.⟧',
+      outcome: { label: '', value: '⟦Localized outcome value.⟧' },
+      metrics: [{ label: '⟦Workflow⟧', value: '⟦Localized metric⟧' }],
+      links: [{ label: '⟦Case study⟧', href: 'https://example.com/case' }],
+    };
+
+    overlay.setSelected(localizedPoi, { inputMethod: 'pointer' });
+    overlay.setStrings({
+      visited: '⟦Visited⟧',
+      nextHighlight: '⟦Next highlight⟧',
+      status: { prototype: '⟦Prototype⟧', live: '⟦Live⟧' },
+      closeLabel: '⟦Close POI details⟧',
+      relatedCaseStudiesLabel: '⟦Related case studies⟧',
+      outcomeFallbackLabel: '⟦Outcome⟧',
+      discoveryAnnouncementTemplate: '⟦{title} discovered.{summary}⟧',
+    });
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      '⟦Futuroptimist⟧'
+    );
+    expect(
+      root.querySelector('.poi-tooltip-overlay__summary')?.textContent
+    ).toBe('⟦Localized immersive exhibit summary.⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric')?.textContent
+    ).toContain('⟦Localized metric⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__status')?.textContent
+    ).toBe('⟦Prototype⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__outcome-label')?.textContent
+    ).toBe('⟦Outcome⟧');
+    expect(
+      root
+        .querySelector<HTMLUListElement>('.poi-tooltip-overlay__links')
+        ?.getAttribute('aria-label')
+    ).toBe('⟦Related case studies⟧');
+  });
+
   it('renders selected POI metadata without a hover target', () => {
     overlay.setSelected(basePoi, { inputMethod: 'pointer' });
 

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -170,6 +170,26 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('redraws the active title when POI copy changes at runtime', () => {
+    const { tooltip, preference } = createTooltip();
+    const poi = createPoiDefinition({ title: 'Flywheel' });
+    tooltip.setSelected(createTarget(poi, new Vector3(0, 1, 0)));
+    tooltip.update(0.016);
+    expect(latestFillTextLog.join(' ')).toContain('Flywheel');
+
+    const localized = createPoiDefinition({
+      ...poi,
+      title: '⟦Flywheel⟧',
+    });
+    tooltip.setSelected(createTarget(localized, new Vector3(0, 1, 0)));
+    tooltip.notifyPoiUpdated(localized.id);
+
+    expect(latestFillTextLog.join(' ')).toContain('⟦Flywheel⟧');
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('shows hovered tooltip anchored to the provided world position', () => {
     const { tooltip, camera, preference } = createTooltip();
     const poi = createPoiDefinition({ status: 'prototype' });


### PR DESCRIPTION
### Motivation
- Locale changes were updating HUD strings but POI definitions and in-world/overlay copy were frozen at module load because `getPoiCopy()` was called once and baked into static definitions.
- The immersive POI overlay, marker labels, tour recommendation, visited narrative entries, metrics wiring, and structured data must reflect the active locale without a page reload.

### Description
- Split static POI placement (geometry/position/pedestal) from localized copy and implemented `buildDefinitions(locale?)` / `getPoiDefinitions(locale?)` that returns defensive localized clones instead of mutating shared state (changes in `src/scene/poi/registry.ts`).
- Added `updatePoiInstanceDefinition` to refresh an existing marker's label texture and wired it into the runtime refresh so marker labels update in-place (changes in `src/scene/poi/markers.ts`).
- Moved POI overlay chrome strings into the i18n catalog and added a `setStrings` API plus localized discovery announcement formatting to `PoiTooltipOverlay` so badges, status labels, close aria-label, links aria-label, outcome fallback label, and discovery announcements are locale-driven (changes in `src/scene/poi/tooltipOverlay.ts` and i18n files).
- Updated `main.ts` locale update flow to rebuild localized POI definitions and then refresh: marker labels, world tooltip canvases, tooltip overlay state, guided-tour definitions, visited narrative sync, GitHub metrics wiring, and structured data injection; preserved hovered/selected/recommendation state by POI id and avoided recreating Three.js objects where possible.
- Added/updated unit tests to cover runtime locale switching for POI definitions, overlay chrome, marker texture refresh, and world tooltip redraw (`src/tests/*` modifications).

### Testing
- `npm run format:write` — ran and applied formatting.
- `npm run lint` — ran; lint run completed (minor import-order warning addressed).
- `npm run typecheck` — ran; no new type errors were introduced by this change (repo has unrelated historical TS issues outside this patch surface that were not introduced here).
- Focused unit tests: `npm run test:ci -- src/tests/poiRegistry.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts src/tests/poiMarkers.test.ts` — all targeted tests passed.
- Full test suite: `npm run test:ci` — Vitest run completed; all tests in the repository passed in CI environment when exercised in this branch.
- Build & smoke: `npm run build`, `npm run docs:check`, `npm run smoke` — all succeeded and produced expected artifacts.

All acceptance criteria were validated by the added tests and runtime checks: changing locale updates POI overlay title/summary/metrics/links in-place, selected POI remains selected and renders in the new locale, marker labels/world tooltips update, and structured data is re-injected for the active locale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f954a7544832fa08e716da6499986)