### PR TITLE
Make POI copy and overlay chrome locale-reactive

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -1,4 +1,4 @@
-import type { PoiId } from '../poi/types';
+import type { PoiId } from '../../scene/poi/types';
 
 import { AR_OVERRIDES } from './locales/ar';
 import { EN_LOCALE_STRINGS } from './locales/en';
@@ -21,6 +21,7 @@ import type {
   MovementLegendStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
+  PoiOverlayChromeStrings,
   HudCustomizationStrings,
   SiteStrings,
 } from './types';
@@ -222,6 +223,12 @@ export function getPoiCopy(
   input?: LocaleInput
 ): Readonly<Record<PoiId, PoiCopy>> {
   return getLocaleStrings(input).poi;
+}
+
+export function getPoiOverlayChromeStrings(
+  input?: LocaleInput
+): PoiOverlayChromeStrings {
+  return getLocaleStrings(input).hud.poiOverlay;
 }
 
 export function formatMessage(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -232,6 +232,16 @@ export const AR_OVERRIDES: LocaleOverrides = {
         description: 'فعّل سوار المعصم أو الطائرة الهولوغرافية.',
       },
     },
+    poiOverlay: {
+      visited: 'تمت الزيارة',
+      nextHighlight: 'المحطة التالية',
+      prototype: 'نموذج أولي',
+      live: 'مباشر',
+      closeDetails: 'إغلاق تفاصيل نقطة الاهتمام',
+      relatedCaseStudies: 'دراسات حالة ذات صلة',
+      outcomeFallbackLabel: 'النتيجة',
+      discoveryAnnouncementTemplate: 'تم اكتشاف {title}. {summary}',
+    },
     narrativeLog: {
       heading: 'سجل القصة',
       visitedHeading: 'المعارض التي تمت زيارتها',

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -12,6 +12,21 @@ export const AR_OVERRIDES: LocaleOverrides = {
       textCollectionDescription:
         'ملخصات سريعة قابلة للوصول لكل معرض مع الحفاظ على سرعة التصفح.',
       immersiveActionName: 'تشغيل الوضع الغامر',
+      properties: {
+        labels: {
+          category: 'الفئة',
+          outcome: 'النتيجة',
+          status: 'الحالة',
+        },
+        categories: {
+          project: 'مشروع',
+          environment: 'بيئة',
+        },
+        statuses: {
+          prototype: 'نموذج أولي',
+          live: 'مباشر',
+        },
+      },
       publisher: {
         name: 'Daniel Smith',
       },

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -10,6 +10,21 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       description: wrap(
         'Interactive exhibits within the Daniel Smith immersive portfolio experience.'
       ),
+      properties: {
+        labels: {
+          category: wrap('Category'),
+          outcome: wrap('Outcome'),
+          status: wrap('Status'),
+        },
+        categories: {
+          project: wrap('Project'),
+          environment: wrap('Environment'),
+        },
+        statuses: {
+          prototype: wrap('Prototype'),
+          live: wrap('Live'),
+        },
+      },
     },
     textFallback: {
       heading: wrap('Explore the highlights'),

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -295,6 +295,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Text mode toggle failed. Press {keyHint} to retry text mode.'
       ),
     },
+    poiOverlay: {
+      visited: wrap('Visited'),
+      nextHighlight: wrap('Next highlight'),
+      prototype: wrap('Prototype'),
+      live: wrap('Live'),
+      closeDetails: wrap('Close POI details'),
+      relatedCaseStudies: wrap('Related case studies'),
+      outcomeFallbackLabel: wrap('Outcome'),
+      discoveryAnnouncementTemplate: wrap('{title} discovered. {summary}'),
+    },
     narrativeLog: {
       heading: wrap('Creator story log'),
       visitedHeading: wrap('Visited exhibits'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -12,6 +12,21 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       textCollectionDescription:
         'Fast-loading summaries of every immersive exhibit tuned for accessible and crawler-friendly reading.',
       immersiveActionName: 'Launch immersive mode',
+      properties: {
+        labels: {
+          category: 'Category',
+          outcome: 'Outcome',
+          status: 'Status',
+        },
+        categories: {
+          project: 'Project',
+          environment: 'Environment',
+        },
+        statuses: {
+          prototype: 'Prototype',
+          live: 'Live',
+        },
+      },
       publisher: {
         name: 'Daniel Smith',
         url: 'https://danielsmith.io/',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -297,6 +297,16 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       errorTitleTemplate:
         'Text mode toggle failed. Press {keyHint} to retry text mode.',
     },
+    poiOverlay: {
+      visited: 'Visited',
+      nextHighlight: 'Next highlight',
+      prototype: 'Prototype',
+      live: 'Live',
+      closeDetails: 'Close POI details',
+      relatedCaseStudies: 'Related case studies',
+      outcomeFallbackLabel: 'Outcome',
+      discoveryAnnouncementTemplate: '{title} discovered. {summary}',
+    },
     narrativeLog: {
       heading: 'Creator story log',
       visitedHeading: 'Visited exhibits',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -232,6 +232,16 @@ export const JA_OVERRIDES: LocaleOverrides = {
           'リストコンソールやホログラフィックドローンを切り替えます。',
       },
     },
+    poiOverlay: {
+      visited: '訪問済み',
+      nextHighlight: '次のハイライト',
+      prototype: 'プロトタイプ',
+      live: '公開中',
+      closeDetails: 'POI の詳細を閉じる',
+      relatedCaseStudies: '関連ケーススタディ',
+      outcomeFallbackLabel: '成果',
+      discoveryAnnouncementTemplate: '{title} を発見しました。{summary}',
+    },
     narrativeLog: {
       heading: 'クリエイターストーリーログ',
       visitedHeading: '訪問した展示',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -12,6 +12,21 @@ export const JA_OVERRIDES: LocaleOverrides = {
       textCollectionDescription:
         '没入型展示の内容を高速に読めるよう最適化した要約を提供します。',
       immersiveActionName: '没入モードを起動',
+      properties: {
+        labels: {
+          category: 'カテゴリー',
+          outcome: '成果',
+          status: 'ステータス',
+        },
+        categories: {
+          project: 'プロジェクト',
+          environment: '環境',
+        },
+        statuses: {
+          prototype: 'プロトタイプ',
+          live: '公開中',
+        },
+      },
       publisher: {
         name: 'Daniel Smith',
       },

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -1,12 +1,12 @@
-import type { FallbackReason } from '../../types/failover';
-import type { InputMethod } from '../../ui/hud/movementLegend';
 import type {
   PoiId,
   PoiInteraction,
   PoiMetricSource,
   PoiNarration,
   PoiOutcome,
-} from '../poi/types';
+} from '../../scene/poi/types';
+import type { FallbackReason } from '../../types/failover';
+import type { InputMethod } from '../../ui/hud/movementLegend';
 
 export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja';
 export type LocaleDirection = 'ltr' | 'rtl';
@@ -168,6 +168,17 @@ export interface HudCustomizationStrings {
   accessories: { title: string; description: string };
 }
 
+export interface PoiOverlayChromeStrings {
+  visited: string;
+  nextHighlight: string;
+  prototype: string;
+  live: string;
+  closeDetails: string;
+  relatedCaseStudies: string;
+  outcomeFallbackLabel: string;
+  discoveryAnnouncementTemplate: string;
+}
+
 export interface PoiNarrativeLogStrings {
   heading: string;
   visitedHeading: string;
@@ -299,6 +310,7 @@ export interface LocaleStrings {
     helpModal: HelpModalStrings;
     customization: HudCustomizationStrings;
     narrativeLog: PoiNarrativeLogStrings;
+    poiOverlay: PoiOverlayChromeStrings;
   };
   poi: Record<PoiId, PoiCopy>;
 }

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -219,12 +219,23 @@ export interface SiteStructuredDataEntityStrings {
   logoUrl?: string;
 }
 
+export interface SiteStructuredDataPropertyStrings {
+  labels: {
+    category: string;
+    outcome: string;
+    status: string;
+  };
+  categories: Record<'project' | 'environment', string>;
+  statuses: Record<'prototype' | 'live', string>;
+}
+
 export interface SiteStructuredDataStrings {
   description: string;
   listNameTemplate: string;
   textCollectionNameTemplate: string;
   textCollectionDescription: string;
   immersiveActionName: string;
+  properties: SiteStructuredDataPropertyStrings;
   publisher: SiteStructuredDataEntityStrings;
   author: SiteStructuredDataEntityStrings;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ import {
   getModeAnnouncerStrings,
   getModeToggleStrings,
   getPoiNarrativeLogStrings,
+  getPoiOverlayChromeStrings,
   getSiteStrings,
   resolveLocale,
   type Locale,
@@ -166,6 +167,7 @@ import { GuidedTourChannel } from './scene/poi/guidedTourChannel';
 import { PoiInteractionManager } from './scene/poi/interactionManager';
 import {
   createPoiInstances,
+  updatePoiInstanceDefinition,
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
@@ -176,7 +178,7 @@ import {
 } from './scene/poi/structuredData';
 import { PoiTooltipOverlay } from './scene/poi/tooltipOverlay';
 import { PoiTourGuide } from './scene/poi/tourGuide';
-import type { PoiDefinition } from './scene/poi/types';
+import type { PoiDefinition, PoiId } from './scene/poi/types';
 import { updateVisitedBadge } from './scene/poi/visitedBadge';
 import { PoiVisitedState } from './scene/poi/visitedState';
 import {
@@ -923,6 +925,7 @@ function initializeImmersiveScene(
   let modeToggleStrings = getModeToggleStrings(locale);
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+  let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
   let siteStrings = getSiteStrings(locale);
   const syncModeAnnouncerStrings = () => {
     const announcerStrings = getModeAnnouncerStrings(locale);
@@ -1010,8 +1013,8 @@ function initializeImmersiveScene(
   scene.background = createImmersiveGradientTexture();
 
   const poiOverrides: PoiInstanceOverrides = {};
-  const poiDefinitions = getPoiDefinitions();
-  const poiDefinitionsById = new Map(
+  let poiDefinitions = getPoiDefinitions(locale);
+  let poiDefinitionsById = new Map(
     poiDefinitions.map((definition) => [definition.id, definition] as const)
   );
   injectPoiStructuredData(poiDefinitions, {
@@ -1567,10 +1570,18 @@ function initializeImmersiveScene(
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    discoveryAnnouncer: {
+      format: (poi, strings) =>
+        formatMessage(strings.discoveryAnnouncementTemplate, {
+          title: poi.title,
+          summary: poi.summary ?? '',
+        }),
+    },
     onDismiss: () => {
       dismissActivePoiDetail();
     },
   });
+  poiTooltipOverlay.setStrings(poiOverlayStrings);
   const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
   const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
     (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
@@ -1658,22 +1669,26 @@ function initializeImmersiveScene(
   window.portfolio.githubMetrics = {
     getDiagnostics: () => githubRepoStatsService.getDiagnostics(),
   };
-  githubRepoMetrics = wireGitHubRepoMetrics({
-    definitions: poiDefinitions,
-    service: githubRepoStatsService,
-    onMetricsUpdated: (poiId) => {
-      poiTooltipOverlay.notifyPoiUpdated(poiId);
-      poiWorldTooltip.notifyPoiUpdated(poiId);
-    },
-    onRepoStatsUpdated: ({ poiId, stats }) => {
-      if (poiId === 'futuroptimist-living-room-tv') {
-        mediaWallStarBridge.updateStarCount(stats.stars);
-      }
-    },
-  });
-  githubRepoMetrics.refreshAll().catch(() => {
-    /* GitHub may be unreachable; metrics will remain on fallback values. */
-  });
+  const wirePoiGitHubMetrics = () => {
+    githubRepoMetrics?.dispose();
+    githubRepoMetrics = wireGitHubRepoMetrics({
+      definitions: poiDefinitions,
+      service: githubRepoStatsService,
+      onMetricsUpdated: (poiId) => {
+        poiTooltipOverlay.notifyPoiUpdated(poiId);
+        poiWorldTooltip.notifyPoiUpdated(poiId);
+      },
+      onRepoStatsUpdated: ({ poiId, stats }) => {
+        if (poiId === 'futuroptimist-living-room-tv') {
+          mediaWallStarBridge.updateStarCount(stats.stars);
+        }
+      },
+    });
+    githubRepoMetrics.refreshAll().catch(() => {
+      /* GitHub may be unreachable; metrics will remain on fallback values. */
+    });
+  };
+  wirePoiGitHubMetrics();
   const poiVisitedState = new PoiVisitedState();
   if (avatarAccessoryManager) {
     avatarAccessoryProgression = createAvatarAccessoryProgression({
@@ -1806,7 +1821,7 @@ function initializeImmersiveScene(
     }
     if (poiNarrativeLog) {
       const visitedDefinitions = Array.from(visited)
-        .map((id) => poiDefinitionsById.get(id))
+        .map((id) => poiDefinitionsById.get(id as PoiId))
         .filter((definition): definition is PoiDefinition =>
           Boolean(definition)
         );
@@ -1826,7 +1841,7 @@ function initializeImmersiveScene(
           if (previousVisited.has(id)) {
             continue;
           }
-          const definition = poiDefinitionsById.get(id);
+          const definition = poiDefinitionsById.get(id as PoiId);
           if (!definition) {
             continue;
           }
@@ -2934,6 +2949,7 @@ function initializeImmersiveScene(
     audioHudStrings = getAudioHudControlStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+    poiOverlayStrings = getPoiOverlayChromeStrings(locale);
     siteStrings = getSiteStrings(locale);
     syncModeAnnouncerStrings();
     narrativeTimeFormatter = new Intl.DateTimeFormat(
@@ -2942,6 +2958,40 @@ function initializeImmersiveScene(
     );
     interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
     helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
+
+    const selectedId = currentSelectedPoi?.id ?? null;
+    const hoveredId = currentHoveredPoi?.id ?? null;
+    const recommendationId = currentGuidedTourRecommendation?.id ?? null;
+    poiDefinitions = getPoiDefinitions(locale);
+    poiDefinitionsById = new Map(
+      poiDefinitions.map((definition) => [definition.id, definition] as const)
+    );
+    for (const poi of poiInstances) {
+      const nextDefinition = poiDefinitionsById.get(poi.definition.id);
+      if (nextDefinition) {
+        updatePoiInstanceDefinition(poi, nextDefinition);
+      }
+    }
+    currentSelectedPoi = selectedId
+      ? (poiDefinitionsById.get(selectedId) ?? null)
+      : null;
+    currentHoveredPoi = hoveredId
+      ? (poiDefinitionsById.get(hoveredId) ?? null)
+      : null;
+    currentGuidedTourRecommendation = recommendationId
+      ? (poiDefinitionsById.get(recommendationId) ?? null)
+      : null;
+    poiTourGuide.setDefinitions(poiDefinitions);
+    proceduralNarrator?.setDefinitions(poiDefinitions);
+    wirePoiGitHubMetrics();
+    injectPoiStructuredData(poiDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
+    injectTextPortfolioStructuredData(poiDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
 
     if (controlOverlay) {
       applyControlOverlayStrings(controlOverlay, controlOverlayStrings);
@@ -2963,12 +3013,18 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
+    poiTooltipOverlay.setStrings(poiOverlayStrings);
     updateHelpButtonLabel();
     localeToggleControl?.refresh();
+    syncPoiRecommendation();
+    syncPoiDetailOverlay();
+    if (interactablePoi) {
+      setInteractablePoi(interactablePoi);
+    }
 
     const visitedSnapshot = poiVisitedState.snapshot();
     const visitedDefinitions = Array.from(visitedSnapshot)
-      .map((id) => poiDefinitionsById.get(id))
+      .map((id) => poiDefinitionsById.get(id as PoiId))
       .filter((definition): definition is PoiDefinition => Boolean(definition));
     if (visitedDefinitions.length > 0 && poiNarrativeLog) {
       poiNarrativeLog.syncVisited(visitedDefinitions, {
@@ -4225,10 +4281,11 @@ function initializeImmersiveScene(
   }
 
   function setInteractablePoi(poi: PoiInstance | null) {
-    if (interactablePoi === poi) {
+    const samePoi = interactablePoi === poi;
+    interactablePoi = poi;
+    if (samePoi && !poi) {
       return;
     }
-    interactablePoi = poi;
     if (movementLegend) {
       if (poi) {
         movementLegend.setInteractPrompt(poi.definition.interactionPrompt);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2596,8 +2596,7 @@ function initializeImmersiveScene(
     '[data-role="text-mode-button"]'
   );
   let interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
-  const interactDescriptionFallback =
-    controlOverlayStrings.interact.description;
+  let interactDescriptionFallback = controlOverlayStrings.interact.description;
   const movementLegend: MovementLegendHandle | null = controlOverlay
     ? createMovementLegend({
         container: controlOverlay,
@@ -2957,6 +2956,7 @@ function initializeImmersiveScene(
       { hour: 'numeric', minute: '2-digit' }
     );
     interactLabelFallback = controlOverlayStrings.interact.defaultLabel;
+    interactDescriptionFallback = controlOverlayStrings.interact.description;
     helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
 
     const selectedId = currentSelectedPoi?.id ?? null;
@@ -3018,9 +3018,7 @@ function initializeImmersiveScene(
     localeToggleControl?.refresh();
     syncPoiRecommendation();
     syncPoiDetailOverlay();
-    if (interactablePoi) {
-      setInteractablePoi(interactablePoi);
-    }
+    refreshInteractablePoiPrompt();
 
     const visitedSnapshot = poiVisitedState.snapshot();
     const visitedDefinitions = Array.from(visitedSnapshot)
@@ -4280,29 +4278,31 @@ function initializeImmersiveScene(
     }
   }
 
-  function setInteractablePoi(poi: PoiInstance | null) {
-    const samePoi = interactablePoi === poi;
-    interactablePoi = poi;
-    if (samePoi && !poi) {
-      return;
-    }
+  function refreshInteractablePoiPrompt() {
     if (movementLegend) {
-      if (poi) {
-        movementLegend.setInteractPrompt(poi.definition.interactionPrompt);
-      } else {
-        movementLegend.setInteractPrompt(null);
-      }
+      movementLegend.setInteractPrompt(
+        interactablePoi?.definition.interactionPrompt ?? null
+      );
     }
     if (!interactControl || !interactDescription) {
       return;
     }
-    if (poi) {
+    if (interactablePoi) {
       interactControl.hidden = false;
-      interactDescription.textContent = poi.definition.interactionPrompt;
+      interactDescription.textContent =
+        interactablePoi.definition.interactionPrompt;
     } else {
       interactControl.hidden = true;
       interactDescription.textContent = interactDescriptionFallback;
     }
+  }
+
+  function setInteractablePoi(poi: PoiInstance | null) {
+    if (interactablePoi === poi) {
+      return;
+    }
+    interactablePoi = poi;
+    refreshInteractablePoiPrompt();
   }
 
   function handleInteractionInput() {

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -95,6 +95,19 @@ export function createPoiInstances(
   });
 }
 
+export function updatePoiInstanceDefinition(
+  instance: PoiInstance,
+  definition: PoiDefinition
+): void {
+  instance.definition = definition;
+  if (instance.labelMaterial) {
+    const previousTexture = instance.labelMaterial.map;
+    instance.labelMaterial.map = createPoiLabelTexture(definition);
+    instance.labelMaterial.needsUpdate = true;
+    previousTexture?.dispose();
+  }
+}
+
 function createPedestalPoiInstance(
   definition: PoiDefinition,
   phaseOffset: number

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -3,6 +3,7 @@ import {
   formatMessage,
   getControlOverlayStrings,
   getPoiCopy,
+  type LocaleInput,
 } from '../../assets/i18n';
 
 import { scalePoiValue } from './constants';
@@ -27,6 +28,7 @@ type PoiStaticDefinition = Omit<
   | 'links'
   | 'narration'
   | 'pedestal'
+  | 'interactionPrompt'
 > & { pedestal?: PoiPedestalStaticConfig };
 
 const baseDefinitions: PoiStaticDefinition[] = [
@@ -225,57 +227,65 @@ const baseDefinitions: PoiStaticDefinition[] = [
   },
 ];
 
-const poiCopy = getPoiCopy();
-const controlOverlayStrings = getControlOverlayStrings();
+function localizeBaseDefinitions(input?: LocaleInput): PoiDefinition[] {
+  const poiCopy = getPoiCopy(input);
+  const controlOverlayStrings = getControlOverlayStrings(input);
 
-const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
-  const copy = poiCopy[base.id];
-  if (!copy) {
-    throw new Error(`Missing localized POI copy for ${base.id}`);
-  }
-  const footprintWidth = scalePoiValue(base.footprint.width);
-  const footprintDepth = scalePoiValue(base.footprint.depth);
-  const baseMaxHalf = Math.max(base.footprint.width, base.footprint.depth) / 2;
-  const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
-  const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
-  const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
-  const pedestal: PoiPedestalConfig | undefined = base.pedestal
-    ? {
-        ...base.pedestal,
-        height:
-          typeof base.pedestal.height === 'number'
-            ? scalePoiValue(base.pedestal.height)
-            : undefined,
-      }
-    : undefined;
-  const template =
-    copy.interactionPrompt ??
-    controlOverlayStrings.interact.promptTemplates[base.interaction] ??
-    controlOverlayStrings.interact.promptTemplates.default;
-  const interactionPrompt = formatMessage(template, { title: copy.title });
-  return {
-    ...base,
-    interactionRadius: scaledInteractionRadius,
-    footprint: {
-      width: footprintWidth,
-      depth: footprintDepth,
-    },
-    pedestal,
-    title: copy.title,
-    summary: copy.summary,
-    outcome: copy.outcome ? { ...copy.outcome } : undefined,
-    metrics: copy.metrics?.map((metric) => ({ ...metric })),
-    links: copy.links?.map((link) => ({ ...link })),
-    narration: copy.narration ? { ...copy.narration } : undefined,
-    interactionPrompt,
-  } satisfies PoiDefinition;
-});
+  return baseDefinitions.map((base) => {
+    const copy = poiCopy[base.id];
+    if (!copy) {
+      throw new Error(`Missing localized POI copy for ${base.id}`);
+    }
+    const footprintWidth = scalePoiValue(base.footprint.width);
+    const footprintDepth = scalePoiValue(base.footprint.depth);
+    const baseMaxHalf =
+      Math.max(base.footprint.width, base.footprint.depth) / 2;
+    const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
+    const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
+    const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
+    const pedestal: PoiPedestalConfig | undefined = base.pedestal
+      ? {
+          ...base.pedestal,
+          height:
+            typeof base.pedestal.height === 'number'
+              ? scalePoiValue(base.pedestal.height)
+              : undefined,
+        }
+      : undefined;
+    const template =
+      copy.interactionPrompt ??
+      controlOverlayStrings.interact.promptTemplates[base.interaction] ??
+      controlOverlayStrings.interact.promptTemplates.default;
+    const interactionPrompt = formatMessage(template, { title: copy.title });
+    return {
+      ...base,
+      interactionRadius: scaledInteractionRadius,
+      footprint: {
+        width: footprintWidth,
+        depth: footprintDepth,
+      },
+      pedestal,
+      title: copy.title,
+      summary: copy.summary,
+      outcome: copy.outcome ? { ...copy.outcome } : undefined,
+      metrics: copy.metrics?.map((metric) => ({ ...metric })),
+      links: copy.links?.map((link) => ({ ...link })),
+      narration: copy.narration ? { ...copy.narration } : undefined,
+      interactionPrompt,
+    } satisfies PoiDefinition;
+  });
+}
 
-// Deterministically lay out indoor POIs across downstairs rooms.
-// Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
-const definitions: PoiDefinition[] = applyManualPoiPlacements(scaled);
+export function localizePoiDefinitions(input?: LocaleInput): PoiDefinition[] {
+  const localized = localizeBaseDefinitions(input);
+  // Deterministically lay out indoor POIs across downstairs rooms.
+  // Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
+  const definitions = applyManualPoiPlacements(localized);
+  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  return definitions.map((definition) => clonePoi(definition));
+}
 
-assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+const definitions: PoiDefinition[] = localizePoiDefinitions();
 
 function clonePoi(definition: PoiDefinition): PoiDefinition {
   return {
@@ -352,17 +362,34 @@ class StaticPoiRegistry implements PoiRegistry {
 
 export const poiRegistry: PoiRegistry = new StaticPoiRegistry(definitions);
 
-export function getPoiDefinitions(): PoiDefinition[] {
+export function getPoiDefinitions(input?: LocaleInput): PoiDefinition[] {
+  if (input !== undefined) {
+    return localizePoiDefinitions(input);
+  }
   return poiRegistry.all();
 }
 
-export function getPoiDefinitionsByRoom(roomId: string): PoiDefinition[] {
+export function getPoiDefinitionsByRoom(
+  roomId: string,
+  input?: LocaleInput
+): PoiDefinition[] {
+  if (input !== undefined) {
+    return localizePoiDefinitions(input).filter(
+      (definition) => definition.roomId === roomId
+    );
+  }
   return poiRegistry.getByRoom(roomId);
 }
 
 export function getPoiDefinitionsByCategory(
-  category: PoiCategory
+  category: PoiCategory,
+  input?: LocaleInput
 ): PoiDefinition[] {
+  if (input !== undefined) {
+    return localizePoiDefinitions(input).filter(
+      (definition) => definition.category === category
+    );
+  }
   return poiRegistry.getByCategory(category);
 }
 

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -268,7 +268,10 @@ function localizeBaseDefinitions(input?: LocaleInput): PoiDefinition[] {
       title: copy.title,
       summary: copy.summary,
       outcome: copy.outcome ? { ...copy.outcome } : undefined,
-      metrics: copy.metrics?.map((metric) => ({ ...metric })),
+      metrics: copy.metrics?.map((metric) => ({
+        ...metric,
+        source: metric.source ? { ...metric.source } : undefined,
+      })),
       links: copy.links?.map((link) => ({ ...link })),
       narration: copy.narration ? { ...copy.narration } : undefined,
       interactionPrompt,
@@ -293,7 +296,10 @@ function clonePoi(definition: PoiDefinition): PoiDefinition {
     position: { ...definition.position },
     footprint: { ...definition.footprint },
     outcome: definition.outcome ? { ...definition.outcome } : undefined,
-    metrics: definition.metrics?.map((metric) => ({ ...metric })),
+    metrics: definition.metrics?.map((metric) => ({
+      ...metric,
+      source: metric.source ? { ...metric.source } : undefined,
+    })),
     links: definition.links?.map((link) => ({ ...link })),
     narration: definition.narration ? { ...definition.narration } : undefined,
     pedestal: definition.pedestal ? { ...definition.pedestal } : undefined,

--- a/src/scene/poi/structuredData.ts
+++ b/src/scene/poi/structuredData.ts
@@ -1,6 +1,7 @@
 import type {
   LocaleInput,
   SiteStructuredDataEntityStrings,
+  SiteStructuredDataPropertyStrings,
   StructuredDataEntityType,
 } from '../../assets/i18n';
 import {
@@ -192,20 +193,21 @@ const createEntityReference = (
 };
 
 const createAdditionalProperties = (
-  poi: PoiDefinition
+  poi: PoiDefinition,
+  strings: SiteStructuredDataPropertyStrings
 ): ReadonlyArray<PropertyValue> => {
   const additionalProperty: PropertyValue[] = [
     {
       '@type': 'PropertyValue',
-      name: 'Category',
-      value: poi.category,
+      name: strings.labels.category,
+      value: strings.categories[poi.category],
     },
   ];
 
   if (poi.outcome && poi.outcome.value.trim()) {
     additionalProperty.push({
       '@type': 'PropertyValue',
-      name: poi.outcome.label?.trim() || 'Outcome',
+      name: poi.outcome.label?.trim() || strings.labels.outcome,
       value: poi.outcome.value.trim(),
     });
   }
@@ -223,8 +225,8 @@ const createAdditionalProperties = (
   if (poi.status) {
     additionalProperty.push({
       '@type': 'PropertyValue',
-      name: 'Status',
-      value: poi.status,
+      name: strings.labels.status,
+      value: strings.statuses[poi.status],
     });
   }
 
@@ -256,6 +258,7 @@ interface PoiCreativeWorkOptions {
   listId: string;
   publisherReference?: Record<string, string>;
   authorReference?: Record<string, string>;
+  propertyStrings: SiteStructuredDataPropertyStrings;
 }
 
 const createPoiCreativeWork = (
@@ -263,7 +266,10 @@ const createPoiCreativeWork = (
   options: PoiCreativeWorkOptions
 ): Record<string, unknown> => {
   const poiUrl = createPoiUrl(options.canonical, poi.id);
-  const additionalProperty = createAdditionalProperties(poi);
+  const additionalProperty = createAdditionalProperties(
+    poi,
+    options.propertyStrings
+  );
   const sameAs = poi.links?.map((link) => link.href).filter(Boolean) ?? [];
 
   const item: Record<string, unknown> = {
@@ -360,6 +366,7 @@ export const buildPoiStructuredData = (
       listId,
       publisherReference,
       authorReference,
+      propertyStrings: siteStrings.structuredData.properties,
     });
 
     return {
@@ -459,6 +466,7 @@ export const buildTextPortfolioStructuredData = (
       listId,
       publisherReference,
       authorReference,
+      propertyStrings: siteStrings.structuredData.properties,
     })
   );
 

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -30,7 +30,19 @@ export interface PoiTooltipOverlayOptions {
 
 interface RenderState {
   poiId: string | null;
+  poiRef: PoiDefinition | null;
+  contentKey: string | null;
 }
+
+const getPoiRenderContentKey = (poi: PoiDefinition): string =>
+  JSON.stringify({
+    title: poi.title,
+    summary: poi.summary,
+    status: poi.status ?? null,
+    outcome: poi.outcome ?? null,
+    metrics: poi.metrics ?? [],
+    links: poi.links ?? [],
+  });
 
 export class PoiTooltipOverlay {
   private readonly root: HTMLElement;
@@ -56,7 +68,11 @@ export class PoiTooltipOverlay {
   private hovered: PoiDefinition | null = null;
   private selected: PoiDefinition | null = null;
   private recommendation: PoiDefinition | null = null;
-  private renderState: RenderState = { poiId: null };
+  private renderState: RenderState = {
+    poiId: null,
+    poiRef: null,
+    contentKey: null,
+  };
   private visitedPoiIds: ReadonlySet<string> = new Set();
   private guidedTourEnabled = true;
   private passiveRecommendationsEnabled = true;
@@ -193,7 +209,7 @@ export class PoiTooltipOverlay {
     this.recommendationBadge.textContent = strings.nextHighlight;
     this.closeButton.setAttribute('aria-label', strings.closeDetails);
     this.linksList.setAttribute('aria-label', strings.relatedCaseStudies);
-    this.renderState.poiId = null;
+    this.renderState = { poiId: null, poiRef: null, contentKey: null };
     this.update();
   }
 
@@ -290,7 +306,7 @@ export class PoiTooltipOverlay {
       this.root.dataset.state = 'hidden';
       this.setFocusContainment(false);
       this.root.removeAttribute('aria-describedby');
-      this.renderState.poiId = null;
+      this.renderState = { poiId: null, poiRef: null, contentKey: null };
       this.visitedBadge.hidden = true;
       this.recommendationBadge.hidden = true;
       this.liveRegion.textContent = '';
@@ -317,12 +333,20 @@ export class PoiTooltipOverlay {
         recommendation?.id === poi.id);
     this.recommendationBadge.hidden = !showRecommendationBadge;
 
-    const previousPoiId = this.renderState.poiId;
+    const nextContentKey = getPoiRenderContentKey(poi);
+    const shouldRenderPoi =
+      this.renderState.poiId !== poi.id ||
+      this.renderState.poiRef !== poi ||
+      this.renderState.contentKey !== nextContentKey;
 
-    if (previousPoiId !== poi.id) {
-      this.renderState.poiId = poi.id;
+    if (shouldRenderPoi) {
+      this.renderState = {
+        poiId: poi.id,
+        poiRef: poi,
+        contentKey: nextContentKey,
+      };
+      this.renderPoi(poi);
     }
-    this.renderPoi(poi);
 
     const describedByIds = [this.summary.id];
     if (!this.outcome.hidden) {

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -1,4 +1,9 @@
 import {
+  formatMessage,
+  getPoiOverlayChromeStrings,
+  type PoiOverlayChromeStrings,
+} from '../../assets/i18n';
+import {
   GuidedTourPreference,
   defaultGuidedTourPreference,
 } from '../../systems/guidedTour/preference';
@@ -7,7 +12,10 @@ import type { InteractionTimeline } from '../../ui/accessibility/interactionTime
 import type { PoiSelectionContext } from './interactionManager';
 import type { PoiDefinition } from './types';
 
-type DiscoveryFormatter = (poi: PoiDefinition) => string;
+type DiscoveryFormatter = (
+  poi: PoiDefinition,
+  strings: PoiOverlayChromeStrings
+) => string;
 
 export interface PoiTooltipOverlayOptions {
   container: HTMLElement;
@@ -56,6 +64,7 @@ export class PoiTooltipOverlay {
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
   private readonly onDismiss: (() => void) | null;
+  private strings: PoiOverlayChromeStrings;
 
   constructor(options: PoiTooltipOverlayOptions) {
     const {
@@ -67,6 +76,7 @@ export class PoiTooltipOverlay {
     } = options;
     const documentTarget = container.ownerDocument ?? document;
 
+    this.strings = getPoiOverlayChromeStrings();
     this.discoveryPoliteness = discoveryAnnouncer?.politeness ?? 'polite';
     this.discoveryFormatter =
       discoveryAnnouncer?.format ?? defaultDiscoveryFormatter;
@@ -100,20 +110,20 @@ export class PoiTooltipOverlay {
 
     this.visitedBadge = documentTarget.createElement('span');
     this.visitedBadge.className = 'poi-tooltip-overlay__visited';
-    this.visitedBadge.textContent = 'Visited';
+    this.visitedBadge.textContent = this.strings.visited;
     this.visitedBadge.hidden = true;
     headingRow.appendChild(this.visitedBadge);
 
     this.recommendationBadge = documentTarget.createElement('span');
     this.recommendationBadge.className = 'poi-tooltip-overlay__recommendation';
-    this.recommendationBadge.textContent = 'Next highlight';
+    this.recommendationBadge.textContent = this.strings.nextHighlight;
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
 
     this.closeButton = documentTarget.createElement('button');
     this.closeButton.className = 'poi-tooltip-overlay__close';
     this.closeButton.type = 'button';
-    this.closeButton.setAttribute('aria-label', 'Close POI details');
+    this.closeButton.setAttribute('aria-label', this.strings.closeDetails);
     this.closeButton.textContent = '×';
     this.closeButton.hidden = true;
     this.closeButton.disabled = true;
@@ -153,7 +163,7 @@ export class PoiTooltipOverlay {
     this.linksList = documentTarget.createElement('ul');
     this.linksList.className = 'poi-tooltip-overlay__links';
     this.linksList.id = `${this.instanceId}-links`;
-    this.linksList.setAttribute('aria-label', 'Related case studies');
+    this.linksList.setAttribute('aria-label', this.strings.relatedCaseStudies);
     this.root.appendChild(this.linksList);
 
     container.appendChild(this.root);
@@ -175,6 +185,16 @@ export class PoiTooltipOverlay {
         this.update();
       }
     );
+  }
+
+  setStrings(strings: PoiOverlayChromeStrings): void {
+    this.strings = strings;
+    this.visitedBadge.textContent = strings.visited;
+    this.recommendationBadge.textContent = strings.nextHighlight;
+    this.closeButton.setAttribute('aria-label', strings.closeDetails);
+    this.linksList.setAttribute('aria-label', strings.relatedCaseStudies);
+    this.renderState.poiId = null;
+    this.update();
   }
 
   setIdleState(idle: boolean) {
@@ -300,13 +320,9 @@ export class PoiTooltipOverlay {
     const previousPoiId = this.renderState.poiId;
 
     if (previousPoiId !== poi.id) {
-      this.renderPoi(poi);
       this.renderState.poiId = poi.id;
-    } else {
-      this.updateStatus(poi);
-      this.renderOutcome(poi);
-      this.renderMetrics(poi);
     }
+    this.renderPoi(poi);
 
     const describedByIds = [this.summary.id];
     if (!this.outcome.hidden) {
@@ -387,7 +403,7 @@ export class PoiTooltipOverlay {
       return;
     }
 
-    const label = outcome.label?.trim() || 'Outcome';
+    const label = outcome.label?.trim() || this.strings.outcomeFallbackLabel;
     this.outcomeLabel.textContent = label;
     this.outcomeLabel.hidden = false;
     this.outcomeValue.textContent = outcome.value.trim();
@@ -397,7 +413,8 @@ export class PoiTooltipOverlay {
 
   private updateStatus(poi: PoiDefinition) {
     if (poi.status) {
-      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
+      const statusLabel =
+        poi.status === 'prototype' ? this.strings.prototype : this.strings.live;
       this.statusBadge.textContent = statusLabel;
       this.statusBadge.hidden = false;
     } else {
@@ -458,7 +475,7 @@ export class PoiTooltipOverlay {
   }
 
   private announceDiscovery(poi: PoiDefinition) {
-    const message = this.discoveryFormatter(poi).trim();
+    const message = this.discoveryFormatter(poi, this.strings).trim();
     if (!message) {
       return;
     }
@@ -494,9 +511,14 @@ function applyVisuallyHiddenStyles(element: HTMLElement): void {
   element.style.pointerEvents = 'none';
 }
 
-function defaultDiscoveryFormatter(poi: PoiDefinition): string {
-  const summary = poi.summary ? ` ${poi.summary}` : '';
-  return `${poi.title} discovered.${summary}`;
+function defaultDiscoveryFormatter(
+  poi: PoiDefinition,
+  strings: PoiOverlayChromeStrings
+): string {
+  return formatMessage(strings.discoveryAnnouncementTemplate, {
+    title: poi.title,
+    summary: poi.summary ?? '',
+  }).trim();
 }
 
 let tooltipInstanceCounter = 0;

--- a/src/scene/poi/tourGuide.ts
+++ b/src/scene/poi/tourGuide.ts
@@ -34,7 +34,7 @@ export class PoiTourGuide {
 
   constructor(options: PoiTourGuideOptions) {
     this.visitedState = options.visitedState;
-    this.setDefinitions(options.definitions);
+    this.storeDefinitions(options.definitions);
     this.priorityOrder = this.normalizePriority(
       options.priorityOrder ??
         options.definitions.map((definition) => definition.id)
@@ -75,7 +75,17 @@ export class PoiTourGuide {
     this.listeners.clear();
   }
 
-  private setDefinitions(definitions: PoiDefinition[]) {
+  setDefinitions(definitions: PoiDefinition[]) {
+    this.allDefinitions = definitions.slice();
+    this.definitionsById.clear();
+    for (const definition of definitions) {
+      this.definitionsById.set(definition.id, definition);
+    }
+    this.priorityOrder = this.normalizePriority(this.priorityOrder);
+    this.refreshRecommendation();
+  }
+
+  private storeDefinitions(definitions: PoiDefinition[]) {
     this.allDefinitions = definitions.slice();
     this.definitionsById.clear();
     for (const definition of definitions) {
@@ -99,7 +109,7 @@ export class PoiTourGuide {
   private refreshRecommendation() {
     const visited = this.visitedState.snapshot();
     const next = this.computeRecommendation(visited);
-    if (next?.id === this.recommendation?.id) {
+    if (next?.id === this.recommendation?.id && next === this.recommendation) {
       return;
     }
     this.recommendation = next;

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -42,8 +42,12 @@ export interface PoiWorldTooltipOptions {
 
 interface RenderState {
   poiId: string | null;
+  poiRef: PoiDefinition | null;
   mode: PoiWorldTooltipMode | null;
+  contentKey: string | null;
 }
+
+const getPoiRenderContentKey = (poi: PoiDefinition): string => poi.title;
 
 interface TooltipStateSnapshot {
   poiId: string | null;
@@ -123,7 +127,12 @@ export class PoiWorldTooltip {
 
   private opacity = 0;
 
-  private renderState: RenderState = { poiId: null, mode: null };
+  private renderState: RenderState = {
+    poiId: null,
+    poiRef: null,
+    mode: null,
+    contentKey: null,
+  };
 
   private disposed = false;
 
@@ -240,9 +249,12 @@ export class PoiWorldTooltip {
       return;
     }
 
+    const contentKey = getPoiRenderContentKey(active.poi);
     const targetChanged =
       this.renderState.poiId !== active.poi.id ||
-      this.renderState.mode !== mode;
+      this.renderState.poiRef !== active.poi ||
+      this.renderState.mode !== mode ||
+      this.renderState.contentKey !== contentKey;
 
     const anchor = active.getAnchorPosition(this.anchorScratch);
     this.targetPosition.copy(anchor);
@@ -261,7 +273,12 @@ export class PoiWorldTooltip {
       this.opacity = 0;
       this.mesh.material.opacity = 0;
       this.group.visible = false;
-      this.renderState = { poiId: null, mode: null };
+      this.renderState = {
+        poiId: null,
+        poiRef: null,
+        mode: null,
+        contentKey: null,
+      };
       return;
     }
 
@@ -296,7 +313,12 @@ export class PoiWorldTooltip {
 
     if (targetChanged) {
       this.renderTooltip(active.poi, mode);
-      this.renderState = { poiId: active.poi.id, mode };
+      this.renderState = {
+        poiId: active.poi.id,
+        poiRef: active.poi,
+        mode,
+        contentKey,
+      };
     }
   }
 
@@ -317,7 +339,14 @@ export class PoiWorldTooltip {
           ? 'recommended'
           : null;
     if (activeTarget && mode && activeTarget.poi.id === poiId) {
+      const contentKey = getPoiRenderContentKey(activeTarget.poi);
       this.renderTooltip(activeTarget.poi, mode);
+      this.renderState = {
+        poiId: activeTarget.poi.id,
+        poiRef: activeTarget.poi,
+        mode,
+        contentKey,
+      };
     }
   }
 
@@ -375,7 +404,12 @@ export class PoiWorldTooltip {
     this.mesh.material.opacity = this.opacity;
     if (this.opacity <= 0.01) {
       this.group.visible = false;
-      this.renderState = { poiId: null, mode: null };
+      this.renderState = {
+        poiId: null,
+        poiRef: null,
+        mode: null,
+        contentKey: null,
+      };
     }
   }
 

--- a/src/systems/narrative/proceduralNarrator.ts
+++ b/src/systems/narrative/proceduralNarrator.ts
@@ -30,6 +30,11 @@ export class ProceduralNarrator {
     this.lastVisitedId = last.id;
   }
 
+  setDefinitions(definitions: ReadonlyArray<PoiDefinition>): void {
+    this.definitionsById.clear();
+    definitions.forEach((definition) => this.storeDefinition(definition));
+  }
+
   handleVisit(poi: PoiDefinition): void {
     this.storeDefinition(poi);
     const previousId = this.lastVisitedId;

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -11,10 +11,12 @@ import {
   getModeToggleStrings,
   getLocaleScript,
   getPoiNarrativeLogStrings,
+  getPoiOverlayChromeStrings,
   getPoiCopy,
   getSiteStrings,
   resolveLocale,
 } from '../assets/i18n';
+import { getPoiDefinitions } from '../scene/poi/registry';
 
 describe('i18n utilities', () => {
   it('exposes available locales including pseudo locale scaffolding', () => {
@@ -62,6 +64,24 @@ describe('i18n utilities', () => {
     expect(formatMessage('Hold {missing}', {})).toBe('Hold {missing}');
   });
 
+  it('localizes POI definitions per call without mutating previous copies', () => {
+    const englishDefinitions = getPoiDefinitions('en');
+    const pseudoDefinitions = getPoiDefinitions('en-x-pseudo');
+    const englishPoi = englishDefinitions.find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+    const pseudoPoi = pseudoDefinitions.find(
+      (poi) => poi.id === 'futuroptimist-living-room-tv'
+    );
+
+    expect(englishPoi?.title).toBe('Futuroptimist');
+    expect(pseudoPoi?.title).toBe('⟦Futuroptimist⟧');
+    expect(pseudoPoi?.interactionPrompt).toBe('⟦Inspect ⟦Futuroptimist⟧⟧');
+    expect(englishPoi?.title).toBe('Futuroptimist');
+    expect(englishDefinitions).not.toBe(pseudoDefinitions);
+    expect(englishPoi).not.toBe(pseudoPoi);
+  });
+
   it('returns localized HUD strings and applies pseudo locale overrides', () => {
     const englishOverlay = getControlOverlayStrings('en');
     const pseudoOverlay = getControlOverlayStrings('en-x-pseudo');
@@ -90,6 +110,20 @@ describe('i18n utilities', () => {
     expect(japaneseHelp.announcements.close).toBe(
       'ヘルプメニューを閉じました。'
     );
+  });
+
+  it('returns localized POI overlay chrome strings', () => {
+    const english = getPoiOverlayChromeStrings('en');
+    const pseudo = getPoiOverlayChromeStrings('en-x-pseudo');
+    const arabic = getPoiOverlayChromeStrings('ar');
+    const japanese = getPoiOverlayChromeStrings('ja');
+
+    expect(english.closeDetails).toBe('Close POI details');
+    expect(english.discoveryAnnouncementTemplate).toContain('{title}');
+    expect(pseudo.closeDetails).toBe('⟦Close POI details⟧');
+    expect(pseudo.relatedCaseStudies).toBe('⟦Related case studies⟧');
+    expect(arabic.prototype).toBe('نموذج أولي');
+    expect(japanese.nextHighlight).toBe('次のハイライト');
   });
 
   it('returns localized mode toggle strings with formatted key hints', () => {

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -82,6 +82,36 @@ describe('i18n utilities', () => {
     expect(englishPoi).not.toBe(pseudoPoi);
   });
 
+  it('deep-clones localized POI metric sources per call', () => {
+    const firstDefinitions = getPoiDefinitions('en-x-pseudo');
+    const firstPoi = firstDefinitions.find(
+      (poi) => poi.id === 'tokenplace-studio-cluster'
+    );
+    const firstSource = firstPoi?.metrics?.[0]?.source;
+
+    expect(firstSource).toMatchObject({
+      type: 'githubStars',
+      owner: 'futuroptimist',
+      repo: 'token.place',
+    });
+
+    if (firstSource) {
+      firstSource.owner = 'mutated-owner';
+      firstSource.repo = 'mutated-repo';
+    }
+
+    const freshDefinitions = getPoiDefinitions('en-x-pseudo');
+    const freshPoi = freshDefinitions.find(
+      (poi) => poi.id === 'tokenplace-studio-cluster'
+    );
+
+    expect(freshPoi?.metrics?.[0]?.source).toMatchObject({
+      type: 'githubStars',
+      owner: 'futuroptimist',
+      repo: 'token.place',
+    });
+  });
+
   it('returns localized HUD strings and applies pseudo locale overrides', () => {
     const englishOverlay = getControlOverlayStrings('en');
     const pseudoOverlay = getControlOverlayStrings('en-x-pseudo');

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -5,6 +5,7 @@ import { scalePoiValue } from '../scene/poi/constants';
 import {
   createPoiInstances,
   createPoiLabelTexture,
+  updatePoiInstanceDefinition,
 } from '../scene/poi/markers';
 import type { PoiDefinition } from '../scene/poi/types';
 
@@ -145,6 +146,23 @@ describe('createPoiInstances', () => {
     expect(renderedText).not.toContain('Reduced shelf drift');
     expect(renderedText).not.toContain('Cataloged 200 repos');
     expect(renderedText).not.toContain('Prototype');
+  });
+
+  it('updates existing marker label textures when localized definitions change', () => {
+    fillTextLog = [];
+    const [instance] = createPoiInstances([
+      createDefinition({ title: 'Gitshelves' }),
+    ]);
+    expect(fillTextLog.join(' ')).toBe('Gitshelves');
+
+    fillTextLog = [];
+    updatePoiInstanceDefinition(
+      instance,
+      createDefinition({ title: '⟦Gitshelves⟧' })
+    );
+
+    expect(instance.definition.title).toBe('⟦Gitshelves⟧');
+    expect(fillTextLog.join(' ')).toBe('⟦Gitshelves⟧');
   });
 
   it('preserves existing title-only marker labels without ellipsizing them', () => {

--- a/src/tests/poiStructuredData.test.ts
+++ b/src/tests/poiStructuredData.test.ts
@@ -183,7 +183,7 @@ describe('buildPoiStructuredData', () => {
       Record<string, unknown>
     >;
     expect(additionalProperty).toEqual([
-      { '@type': 'PropertyValue', name: 'Category', value: 'project' },
+      { '@type': 'PropertyValue', name: 'Category', value: 'Project' },
       { '@type': 'PropertyValue', name: 'Outcome', value: 'Reduced toil 42%' },
       { '@type': 'PropertyValue', name: 'Impact', value: 'Reduced toil 42%' },
       {
@@ -191,7 +191,7 @@ describe('buildPoiStructuredData', () => {
         name: 'Stack',
         value: 'TypeScript · Three.js',
       },
-      { '@type': 'PropertyValue', name: 'Status', value: 'prototype' },
+      { '@type': 'PropertyValue', name: 'Status', value: 'Prototype' },
     ]);
 
     expect(firstItem.isPartOf).toEqual({
@@ -220,7 +220,7 @@ describe('buildPoiStructuredData', () => {
       isAccessibleForFree: true,
     });
     expect(secondItem.additionalProperty).toEqual([
-      { '@type': 'PropertyValue', name: 'Category', value: 'project' },
+      { '@type': 'PropertyValue', name: 'Category', value: 'Project' },
     ]);
     expect(secondItem.isPartOf).toEqual({
       '@type': 'ItemList',
@@ -234,6 +234,28 @@ describe('buildPoiStructuredData', () => {
       '@id': 'https://danielsmith.io/',
     });
     expect(secondItem.creator).toEqual(secondItem.author);
+  });
+
+  it('localizes additional property labels and enum values', () => {
+    const data = buildPoiStructuredData(
+      [
+        createPoi({
+          category: 'environment',
+          outcome: { label: '', value: 'حافظ على السياق' },
+          status: 'live',
+        }),
+      ],
+      { locale: 'ar' }
+    );
+
+    const items = data.itemListElement as Array<Record<string, unknown>>;
+    const item = items[0]?.item as Record<string, unknown>;
+
+    expect(item.additionalProperty).toEqual([
+      { '@type': 'PropertyValue', name: 'الفئة', value: 'بيئة' },
+      { '@type': 'PropertyValue', name: 'النتيجة', value: 'حافظ على السياق' },
+      { '@type': 'PropertyValue', name: 'الحالة', value: 'مباشر' },
+    ]);
   });
 
   it('honors locale overrides when emitting language metadata', () => {
@@ -324,7 +346,7 @@ describe('buildTextPortfolioStructuredData', () => {
       creator: { '@id': 'https://danielsmith.io/' },
     });
     expect(hasPart[0]?.additionalProperty).toEqual([
-      { '@type': 'PropertyValue', name: 'Category', value: 'project' },
+      { '@type': 'PropertyValue', name: 'Category', value: 'Project' },
       { '@type': 'PropertyValue', name: 'Outcome', value: 'Reduced toil 42%' },
       { '@type': 'PropertyValue', name: 'Impact', value: 'Reduced toil 42%' },
       {
@@ -353,8 +375,8 @@ describe('buildTextPortfolioStructuredData', () => {
       creator: { '@id': 'https://danielsmith.io/' },
     });
     expect(hasPart[1]?.additionalProperty).toEqual([
-      { '@type': 'PropertyValue', name: 'Category', value: 'project' },
-      { '@type': 'PropertyValue', name: 'Status', value: 'prototype' },
+      { '@type': 'PropertyValue', name: 'Category', value: 'Project' },
+      { '@type': 'PropertyValue', name: 'Status', value: 'Prototype' },
     ]);
     expect(data.potentialAction).toEqual({
       '@type': 'Action',

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -437,6 +437,16 @@ describe('PoiTooltipOverlay', () => {
     ).toBe('⟦Related case studies⟧');
   });
 
+  it('skips rebuilding active POI content when updates do not change copy', () => {
+    overlay.setHovered(basePoi);
+    const metricSelector = '.poi-tooltip-overlay__metric';
+    const initialMetric = container.querySelector(metricSelector);
+
+    overlay.notifyPoiUpdated(basePoi.id);
+
+    expect(container.querySelector(metricSelector)).toBe(initialMetric);
+  });
+
   it('refreshes metric values when notified about updates', () => {
     overlay.setHovered(basePoi);
     const metricSelector = '.poi-tooltip-overlay__metric-value';

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -386,6 +386,57 @@ describe('PoiTooltipOverlay', () => {
     expect(root.getAttribute('aria-describedby')).toBeNull();
   });
 
+  it('refreshes active selected POI copy and chrome when locale strings change', () => {
+    overlay.setSelected(basePoi);
+
+    const localizedPoi: PoiDefinition = {
+      ...basePoi,
+      title: '⟦Futuroptimist⟧',
+      summary: '⟦Localized summary for the active exhibit.⟧',
+      outcome: { label: '', value: '⟦Localized outcome.⟧' },
+      metrics: [{ label: '⟦Workflow⟧', value: '⟦Localized metric.⟧' }],
+      links: [{ label: '⟦Docs⟧', href: 'https://futuroptimist.dev' }],
+    };
+
+    overlay.setStrings({
+      visited: '⟦Visited⟧',
+      nextHighlight: '⟦Next highlight⟧',
+      prototype: '⟦Prototype⟧',
+      live: '⟦Live⟧',
+      closeDetails: '⟦Close POI details⟧',
+      relatedCaseStudies: '⟦Related case studies⟧',
+      outcomeFallbackLabel: '⟦Outcome⟧',
+      discoveryAnnouncementTemplate: '⟦{title} discovered. {summary}⟧',
+    });
+    overlay.setSelected(localizedPoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      localizedPoi.title
+    );
+    expect(
+      root.querySelector('.poi-tooltip-overlay__summary')?.textContent
+    ).toBe(localizedPoi.summary);
+    expect(
+      root.querySelector('.poi-tooltip-overlay__outcome-label')?.textContent
+    ).toBe('⟦Outcome⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-label')?.textContent
+    ).toBe('⟦Workflow⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-value')?.textContent
+    ).toBe('⟦Localized metric.⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__status')?.textContent
+    ).toBe('⟦Prototype⟧');
+    expect(
+      root
+        .querySelector('.poi-tooltip-overlay__links')
+        ?.getAttribute('aria-label')
+    ).toBe('⟦Related case studies⟧');
+  });
+
   it('refreshes metric values when notified about updates', () => {
     overlay.setHovered(basePoi);
     const metricSelector = '.poi-tooltip-overlay__metric-value';

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -331,6 +331,27 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('redraws when active POI definitions are swapped for localized copies', () => {
+    const { tooltip } = createTooltip();
+    const poi = createPoiDefinition({ title: 'Flywheel' });
+    const localizedPoi = createPoiDefinition({
+      id: poi.id,
+      title: '⟦Flywheel⟧',
+    });
+
+    tooltip.setSelected(createTarget(poi, new Vector3(0, 0, 0)));
+    tooltip.update(0.016);
+    expect(latestFillTextLog).toContain('Flywheel');
+
+    latestFillTextLog.length = 0;
+    tooltip.setSelected(createTarget(localizedPoi, new Vector3(0, 0, 0)));
+    tooltip.update(0.016);
+
+    expect(latestFillTextLog).toContain('⟦Flywheel⟧');
+    expect(tooltip.getState().poiId).toBe(poi.id);
+    tooltip.dispose();
+  });
+
   it('redraws the active world tooltip when POI copy is localized', () => {
     const { tooltip } = createTooltip();
     const poi = createPoiDefinition({ title: 'Flywheel' });

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -331,6 +331,24 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('redraws the active world tooltip when POI copy is localized', () => {
+    const { tooltip } = createTooltip();
+    const poi = createPoiDefinition({ title: 'Flywheel' });
+    const target = createTarget(poi, new Vector3(0, 0, 0));
+
+    tooltip.setSelected(target);
+    tooltip.update(0.016);
+    expect(latestFillTextLog).toContain('Flywheel');
+
+    poi.title = '⟦Flywheel⟧';
+    latestFillTextLog.length = 0;
+    tooltip.notifyPoiUpdated(poi.id);
+
+    expect(latestFillTextLog).toContain('⟦Flywheel⟧');
+    expect(tooltip.getState().poiId).toBe(poi.id);
+    tooltip.dispose();
+  });
+
   it('keeps selected world tooltips visible when passive recommendations are disabled', () => {
     const { tooltip, preference } = createTooltip();
     const poi = createPoiDefinition({


### PR DESCRIPTION
### Motivation
- POI titles/summaries/metrics were frozen at module load because `getPoiCopy()` was called once, causing HUD locale switches to leave POI UI stuck in the old language.
- Locale changes must update POI overlay chrome, in-world labels, structured data, and guided-tour state without a page reload.

### Description
- Separate static POI placement from localized copy by adding `localizeBaseDefinitions(input?)` and `localizePoiDefinitions(input?)` and exposing `getPoiDefinitions(input?)`, so callers can request localized POI definitions without mutating shared base data (`src/scene/poi/registry.ts`).
- Refresh runtime POI data on locale changes: main scene `applyLocaleUpdate(...)` now rebuilds `poiDefinitions`/`poiDefinitionsById`, updates `poiInstances` via `updatePoiInstanceDefinition(...)`, re-sets tour/narrator definitions, re-wires GitHub metrics, and reinjects structured data (`src/main.ts`, `src/scene/poi/markers.ts`, `src/scene/poi/tourGuide.ts`, `src/systems/narrative/proceduralNarrator.ts`).
- Move all POI overlay chrome strings into i18n and add a `PoiOverlayChromeStrings` shape with translations (including pseudo, Arabic, and Japanese scaffolding) and getter `getPoiOverlayChromeStrings(...)` (`src/assets/i18n/*`).
- Add `setStrings(...)` API to `PoiTooltipOverlay` so overlay chrome (Visited, Next highlight, Prototype/Live, Close label, Related label, Outcome fallback, discovery announcement template) can be updated at runtime, and use localized discovery announcement formatting (`src/scene/poi/tooltipOverlay.ts`).
- Add `updatePoiInstanceDefinition(instance, definition)` to update a POI instance's definition and redraw its label texture without recreating the whole Three.js object (`src/scene/poi/markers.ts`).
- Preserve visited state, current selected/hovered/recommended POI ids across locale switches and reapply them to the refreshed localized definitions (`src/main.ts`).
- Tests: add/extend unit tests to cover per-call localized POI defs, overlay chrome localization, marker label texture update, and world-tooltip redraw on localized copy changes (`src/tests/*`).

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed (1 minor import-order warning fixed during changes).
- Focused unit suites: `npm run test:ci -- src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts src/tests/poiMarkers.test.ts` — all tests passed.
- `npm run build` — production build succeeded (bundle produced; chunk size warning only).
- `npm run docs:check` — passed.
- `npm run smoke` — passed (build + dist assertions).
- Full test suite: `npm run test:ci` — all Vitest tests passed (recorded run: 132 files, 924 tests passing).
- `npm run typecheck` — left as a repo-wide known issue; the change does not introduce new type regressions but `tsc --noEmit` surfaced unrelated existing typing issues in other areas (not caused by the POI i18n changes).

Residual risks / follow-ups
- `tsc` still reports unrelated repo-wide type errors that preexisted these changes; follow-up maintenance may be needed to fully satisfy `npm run typecheck` in CI.
- Pseudo-locale is intentionally aggressive for QA; reviewers may want to review the AI-assisted translations in `src/assets/i18n/locales/*`.

Files touched (high level)
- src/scene/poi/registry.ts, markers.ts, tooltipOverlay.ts, worldTooltip.ts, tourGuide.ts
- src/assets/i18n/{types.ts,index.ts,locales/*}
- src/main.ts wiring for runtime locale refresh
- small API/tests updated under src/tests/*

Verification commands run (examples)
- `npm run format:write`
- `npm run lint`
- `npm run test:ci -- src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts src/tests/poiMarkers.test.ts`
- `npm run build`
- `npm run docs:check`
- `npm run smoke`
- `npm run test:ci`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f954a7544832fa08e716da6499986)