### PR TITLE
Make immersive POIs locale-reactive

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -1,4 +1,4 @@
-import type { PoiId } from '../poi/types';
+import type { PoiId } from '../../scene/poi/types';
 
 import { AR_OVERRIDES } from './locales/ar';
 import { EN_LOCALE_STRINGS } from './locales/en';
@@ -21,6 +21,7 @@ import type {
   MovementLegendStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
+  PoiTooltipOverlayStrings,
   HudCustomizationStrings,
   SiteStrings,
 } from './types';
@@ -327,6 +328,12 @@ export function getModeAnnouncerStrings(
       localeStrings.site.textFallback.reasonDescriptions
     ),
   } satisfies ModeAnnouncerStrings;
+}
+
+export function getPoiTooltipOverlayStrings(
+  input?: LocaleInput
+): PoiTooltipOverlayStrings {
+  return getLocaleStrings(input).hud.poiTooltipOverlay;
 }
 
 export function getPoiNarrativeLogStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -232,6 +232,18 @@ export const AR_OVERRIDES: LocaleOverrides = {
         description: 'فعّل سوار المعصم أو الطائرة الهولوغرافية.',
       },
     },
+    poiTooltipOverlay: {
+      visited: 'تمت الزيارة',
+      nextHighlight: 'المحطة التالية',
+      status: {
+        prototype: 'نموذج أولي',
+        live: 'متاح',
+      },
+      closeDetailsLabel: 'إغلاق تفاصيل نقطة الاهتمام',
+      relatedCaseStudiesLabel: 'دراسات حالة مرتبطة',
+      outcomeFallbackLabel: 'النتيجة',
+      discoveryAnnouncementTemplate: 'تم اكتشاف {title}. {summary}',
+    },
     narrativeLog: {
       heading: 'سجل القصة',
       visitedHeading: 'المعارض التي تمت زيارتها',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -295,6 +295,18 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Text mode toggle failed. Press {keyHint} to retry text mode.'
       ),
     },
+    poiTooltipOverlay: {
+      visited: wrap('Visited'),
+      nextHighlight: wrap('Next highlight'),
+      status: {
+        prototype: wrap('Prototype'),
+        live: wrap('Live'),
+      },
+      closeDetailsLabel: wrap('Close POI details'),
+      relatedCaseStudiesLabel: wrap('Related case studies'),
+      outcomeFallbackLabel: wrap('Outcome'),
+      discoveryAnnouncementTemplate: wrap('{title} discovered. {summary}'),
+    },
     narrativeLog: {
       heading: wrap('Creator story log'),
       visitedHeading: wrap('Visited exhibits'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -297,6 +297,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       errorTitleTemplate:
         'Text mode toggle failed. Press {keyHint} to retry text mode.',
     },
+    poiTooltipOverlay: {
+      visited: 'Visited',
+      nextHighlight: 'Next highlight',
+      status: {
+        prototype: 'Prototype',
+        live: 'Live',
+      },
+      closeDetailsLabel: 'Close POI details',
+      relatedCaseStudiesLabel: 'Related case studies',
+      outcomeFallbackLabel: 'Outcome',
+      discoveryAnnouncementTemplate: '{title} discovered. {summary}',
+    },
     narrativeLog: {
       heading: 'Creator story log',
       visitedHeading: 'Visited exhibits',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -232,6 +232,18 @@ export const JA_OVERRIDES: LocaleOverrides = {
           'リストコンソールやホログラフィックドローンを切り替えます。',
       },
     },
+    poiTooltipOverlay: {
+      visited: '訪問済み',
+      nextHighlight: '次のハイライト',
+      status: {
+        prototype: 'プロトタイプ',
+        live: '公開中',
+      },
+      closeDetailsLabel: 'POI 詳細を閉じる',
+      relatedCaseStudiesLabel: '関連ケーススタディ',
+      outcomeFallbackLabel: '成果',
+      discoveryAnnouncementTemplate: '{title} を発見しました。{summary}',
+    },
     narrativeLog: {
       heading: 'クリエイターストーリーログ',
       visitedHeading: '訪問した展示',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -1,12 +1,12 @@
-import type { FallbackReason } from '../../types/failover';
-import type { InputMethod } from '../../ui/hud/movementLegend';
 import type {
   PoiId,
   PoiInteraction,
   PoiMetricSource,
   PoiNarration,
   PoiOutcome,
-} from '../poi/types';
+} from '../../scene/poi/types';
+import type { FallbackReason } from '../../types/failover';
+import type { InputMethod } from '../../ui/hud/movementLegend';
 
 export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja';
 export type LocaleDirection = 'ltr' | 'rtl';
@@ -168,6 +168,16 @@ export interface HudCustomizationStrings {
   accessories: { title: string; description: string };
 }
 
+export interface PoiTooltipOverlayStrings {
+  visited: string;
+  nextHighlight: string;
+  status: Record<'prototype' | 'live', string>;
+  closeDetailsLabel: string;
+  relatedCaseStudiesLabel: string;
+  outcomeFallbackLabel: string;
+  discoveryAnnouncementTemplate: string;
+}
+
 export interface PoiNarrativeLogStrings {
   heading: string;
   visitedHeading: string;
@@ -298,6 +308,7 @@ export interface LocaleStrings {
     localeToggle: LocaleToggleStrings;
     helpModal: HelpModalStrings;
     customization: HudCustomizationStrings;
+    poiTooltipOverlay: PoiTooltipOverlayStrings;
     narrativeLog: PoiNarrativeLogStrings;
   };
   poi: Record<PoiId, PoiCopy>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ import {
   getModeAnnouncerStrings,
   getModeToggleStrings,
   getPoiNarrativeLogStrings,
+  getPoiTooltipOverlayStrings,
   getSiteStrings,
   resolveLocale,
   type Locale,
@@ -166,6 +167,7 @@ import { GuidedTourChannel } from './scene/poi/guidedTourChannel';
 import { PoiInteractionManager } from './scene/poi/interactionManager';
 import {
   createPoiInstances,
+  updatePoiInstanceDefinition,
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
@@ -176,7 +178,7 @@ import {
 } from './scene/poi/structuredData';
 import { PoiTooltipOverlay } from './scene/poi/tooltipOverlay';
 import { PoiTourGuide } from './scene/poi/tourGuide';
-import type { PoiDefinition } from './scene/poi/types';
+import type { PoiDefinition, PoiId } from './scene/poi/types';
 import { updateVisitedBadge } from './scene/poi/visitedBadge';
 import { PoiVisitedState } from './scene/poi/visitedState';
 import {
@@ -923,6 +925,7 @@ function initializeImmersiveScene(
   let modeToggleStrings = getModeToggleStrings(locale);
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+  let poiTooltipOverlayStrings = getPoiTooltipOverlayStrings(locale);
   let siteStrings = getSiteStrings(locale);
   const syncModeAnnouncerStrings = () => {
     const announcerStrings = getModeAnnouncerStrings(locale);
@@ -1010,8 +1013,8 @@ function initializeImmersiveScene(
   scene.background = createImmersiveGradientTexture();
 
   const poiOverrides: PoiInstanceOverrides = {};
-  const poiDefinitions = getPoiDefinitions();
-  const poiDefinitionsById = new Map(
+  let poiDefinitions = getPoiDefinitions(locale);
+  let poiDefinitionsById = new Map(
     poiDefinitions.map((definition) => [definition.id, definition] as const)
   );
   injectPoiStructuredData(poiDefinitions, {
@@ -1567,6 +1570,7 @@ function initializeImmersiveScene(
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    strings: poiTooltipOverlayStrings,
     onDismiss: () => {
       dismissActivePoiDetail();
     },
@@ -1787,9 +1791,9 @@ function initializeImmersiveScene(
   ensurePoiApi();
 
   let visitedInitialized = false;
-  let previousVisited = new Set<string>();
+  let previousVisited = new Set<PoiId>();
 
-  const handleVisitedUpdate = (visited: ReadonlySet<string>) => {
+  const handleVisitedUpdate = (visited: ReadonlySet<PoiId>) => {
     for (const poi of poiInstances) {
       const isVisited = visited.has(poi.definition.id);
       if (poi.visited !== isVisited) {
@@ -2934,6 +2938,7 @@ function initializeImmersiveScene(
     audioHudStrings = getAudioHudControlStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+    poiTooltipOverlayStrings = getPoiTooltipOverlayStrings(locale);
     siteStrings = getSiteStrings(locale);
     syncModeAnnouncerStrings();
     narrativeTimeFormatter = new Intl.DateTimeFormat(
@@ -2962,9 +2967,67 @@ function initializeImmersiveScene(
     helpModal.setContent(helpModalStrings);
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
+    poiTooltipOverlay.setStrings(poiTooltipOverlayStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
     updateHelpButtonLabel();
     localeToggleControl?.refresh();
+
+    const localizedDefinitions = getPoiDefinitions(locale);
+    poiDefinitions = localizedDefinitions;
+    poiDefinitionsById = new Map(
+      localizedDefinitions.map(
+        (definition) => [definition.id, definition] as const
+      )
+    );
+    for (const instance of poiInstances) {
+      const localizedDefinition = poiDefinitionsById.get(
+        instance.definition.id
+      );
+      if (localizedDefinition) {
+        updatePoiInstanceDefinition(instance, localizedDefinition);
+      }
+    }
+    currentHoveredPoi = currentHoveredPoi
+      ? (poiDefinitionsById.get(currentHoveredPoi.id) ?? null)
+      : null;
+    currentSelectedPoi = currentSelectedPoi
+      ? (poiDefinitionsById.get(currentSelectedPoi.id) ?? null)
+      : null;
+    currentGuidedTourRecommendation = currentGuidedTourRecommendation
+      ? (poiDefinitionsById.get(currentGuidedTourRecommendation.id) ?? null)
+      : null;
+    poiTourGuide.setDefinitions(localizedDefinitions);
+    proceduralNarrator?.setDefinitions(localizedDefinitions);
+    githubRepoMetrics?.dispose();
+    githubRepoMetrics = wireGitHubRepoMetrics({
+      definitions: localizedDefinitions,
+      service: githubRepoStatsService,
+      onMetricsUpdated: (poiId) => {
+        poiTooltipOverlay.notifyPoiUpdated(poiId);
+        poiWorldTooltip.notifyPoiUpdated(poiId);
+      },
+      onRepoStatsUpdated: ({ poiId, stats }) => {
+        if (poiId === 'futuroptimist-living-room-tv') {
+          mediaWallStarBridge.updateStarCount(stats.stars);
+        }
+      },
+    });
+    githubRepoMetrics.refreshAll().catch(() => {
+      /* GitHub may be unreachable; metrics will remain on fallback values. */
+    });
+    injectPoiStructuredData(localizedDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
+    injectTextPortfolioStructuredData(localizedDefinitions, {
+      siteName: siteStrings.name,
+      locale,
+    });
+    syncPoiRecommendation();
+    syncPoiDetailOverlay();
+    const activeInteractablePoi = interactablePoi;
+    interactablePoi = null;
+    setInteractablePoi(activeInteractablePoi);
 
     const visitedSnapshot = poiVisitedState.snapshot();
     const visitedDefinitions = Array.from(visitedSnapshot)

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -95,6 +95,20 @@ export function createPoiInstances(
   });
 }
 
+export function updatePoiInstanceDefinition(
+  instance: PoiInstance,
+  definition: PoiDefinition
+): void {
+  instance.definition = definition;
+  if (!instance.labelMaterial) {
+    return;
+  }
+  const previousTexture = instance.labelMaterial.map;
+  instance.labelMaterial.map = createPoiLabelTexture(definition);
+  instance.labelMaterial.needsUpdate = true;
+  previousTexture?.dispose();
+}
+
 function createPedestalPoiInstance(
   definition: PoiDefinition,
   phaseOffset: number

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -3,6 +3,7 @@ import {
   formatMessage,
   getControlOverlayStrings,
   getPoiCopy,
+  type LocaleInput,
 } from '../../assets/i18n';
 
 import { scalePoiValue } from './constants';
@@ -27,6 +28,7 @@ type PoiStaticDefinition = Omit<
   | 'links'
   | 'narration'
   | 'pedestal'
+  | 'interactionPrompt'
 > & { pedestal?: PoiPedestalStaticConfig };
 
 const baseDefinitions: PoiStaticDefinition[] = [
@@ -225,57 +227,60 @@ const baseDefinitions: PoiStaticDefinition[] = [
   },
 ];
 
-const poiCopy = getPoiCopy();
-const controlOverlayStrings = getControlOverlayStrings();
+function buildLocalizedDefinitions(locale?: LocaleInput): PoiDefinition[] {
+  const poiCopy = getPoiCopy(locale);
+  const controlOverlayStrings = getControlOverlayStrings(locale);
+  const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
+    const copy = poiCopy[base.id];
+    if (!copy) {
+      throw new Error(`Missing localized POI copy for ${base.id}`);
+    }
+    const footprintWidth = scalePoiValue(base.footprint.width);
+    const footprintDepth = scalePoiValue(base.footprint.depth);
+    const baseMaxHalf =
+      Math.max(base.footprint.width, base.footprint.depth) / 2;
+    const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
+    const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
+    const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
+    const pedestal: PoiPedestalConfig | undefined = base.pedestal
+      ? {
+          ...base.pedestal,
+          height:
+            typeof base.pedestal.height === 'number'
+              ? scalePoiValue(base.pedestal.height)
+              : undefined,
+        }
+      : undefined;
+    const template =
+      copy.interactionPrompt ??
+      controlOverlayStrings.interact.promptTemplates[base.interaction] ??
+      controlOverlayStrings.interact.promptTemplates.default;
+    const interactionPrompt = formatMessage(template, { title: copy.title });
+    return {
+      ...base,
+      interactionRadius: scaledInteractionRadius,
+      footprint: {
+        width: footprintWidth,
+        depth: footprintDepth,
+      },
+      pedestal,
+      title: copy.title,
+      summary: copy.summary,
+      outcome: copy.outcome ? { ...copy.outcome } : undefined,
+      metrics: copy.metrics?.map((metric) => ({
+        ...metric,
+        source: metric.source ? { ...metric.source } : undefined,
+      })),
+      links: copy.links?.map((link) => ({ ...link })),
+      narration: copy.narration ? { ...copy.narration } : undefined,
+      interactionPrompt,
+    } satisfies PoiDefinition;
+  });
 
-const scaled: PoiDefinition[] = baseDefinitions.map((base) => {
-  const copy = poiCopy[base.id];
-  if (!copy) {
-    throw new Error(`Missing localized POI copy for ${base.id}`);
-  }
-  const footprintWidth = scalePoiValue(base.footprint.width);
-  const footprintDepth = scalePoiValue(base.footprint.depth);
-  const baseMaxHalf = Math.max(base.footprint.width, base.footprint.depth) / 2;
-  const scaledMaxHalf = Math.max(footprintWidth, footprintDepth) / 2;
-  const preservedMargin = Math.max(0, base.interactionRadius - baseMaxHalf);
-  const scaledInteractionRadius = scaledMaxHalf + preservedMargin;
-  const pedestal: PoiPedestalConfig | undefined = base.pedestal
-    ? {
-        ...base.pedestal,
-        height:
-          typeof base.pedestal.height === 'number'
-            ? scalePoiValue(base.pedestal.height)
-            : undefined,
-      }
-    : undefined;
-  const template =
-    copy.interactionPrompt ??
-    controlOverlayStrings.interact.promptTemplates[base.interaction] ??
-    controlOverlayStrings.interact.promptTemplates.default;
-  const interactionPrompt = formatMessage(template, { title: copy.title });
-  return {
-    ...base,
-    interactionRadius: scaledInteractionRadius,
-    footprint: {
-      width: footprintWidth,
-      depth: footprintDepth,
-    },
-    pedestal,
-    title: copy.title,
-    summary: copy.summary,
-    outcome: copy.outcome ? { ...copy.outcome } : undefined,
-    metrics: copy.metrics?.map((metric) => ({ ...metric })),
-    links: copy.links?.map((link) => ({ ...link })),
-    narration: copy.narration ? { ...copy.narration } : undefined,
-    interactionPrompt,
-  } satisfies PoiDefinition;
-});
-
-// Deterministically lay out indoor POIs across downstairs rooms.
-// Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
-const definitions: PoiDefinition[] = applyManualPoiPlacements(scaled);
-
-assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  const definitions = applyManualPoiPlacements(scaled);
+  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  return definitions.map((definition) => clonePoi(definition));
+}
 
 function clonePoi(definition: PoiDefinition): PoiDefinition {
   return {
@@ -283,7 +288,10 @@ function clonePoi(definition: PoiDefinition): PoiDefinition {
     position: { ...definition.position },
     footprint: { ...definition.footprint },
     outcome: definition.outcome ? { ...definition.outcome } : undefined,
-    metrics: definition.metrics?.map((metric) => ({ ...metric })),
+    metrics: definition.metrics?.map((metric) => ({
+      ...metric,
+      source: metric.source ? { ...metric.source } : undefined,
+    })),
     links: definition.links?.map((link) => ({ ...link })),
     narration: definition.narration ? { ...definition.narration } : undefined,
     pedestal: definition.pedestal ? { ...definition.pedestal } : undefined,
@@ -350,20 +358,30 @@ class StaticPoiRegistry implements PoiRegistry {
   }
 }
 
-export const poiRegistry: PoiRegistry = new StaticPoiRegistry(definitions);
-
-export function getPoiDefinitions(): PoiDefinition[] {
-  return poiRegistry.all();
+export function createPoiRegistry(locale?: LocaleInput): PoiRegistry {
+  return new StaticPoiRegistry(buildLocalizedDefinitions(locale));
 }
 
-export function getPoiDefinitionsByRoom(roomId: string): PoiDefinition[] {
-  return poiRegistry.getByRoom(roomId);
+export const poiRegistry: PoiRegistry = createPoiRegistry();
+
+export function getPoiDefinitions(locale?: LocaleInput): PoiDefinition[] {
+  return buildLocalizedDefinitions(locale);
+}
+
+export const localizePoiDefinitions = getPoiDefinitions;
+
+export function getPoiDefinitionsByRoom(
+  roomId: string,
+  locale?: LocaleInput
+): PoiDefinition[] {
+  return createPoiRegistry(locale).getByRoom(roomId);
 }
 
 export function getPoiDefinitionsByCategory(
-  category: PoiCategory
+  category: PoiCategory,
+  locale?: LocaleInput
 ): PoiDefinition[] {
-  return poiRegistry.getByCategory(category);
+  return createPoiRegistry(locale).getByCategory(category);
 }
 
 export function isPoiInsideRoom(poi: PoiDefinition): boolean {

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -1,4 +1,10 @@
 import {
+  formatMessage,
+  getPoiTooltipOverlayStrings,
+  type LocaleInput,
+  type PoiTooltipOverlayStrings,
+} from '../../assets/i18n';
+import {
   GuidedTourPreference,
   defaultGuidedTourPreference,
 } from '../../systems/guidedTour/preference';
@@ -18,6 +24,8 @@ export interface PoiTooltipOverlayOptions {
   };
   interactionTimeline?: InteractionTimeline;
   guidedTourPreference?: GuidedTourPreference;
+  locale?: LocaleInput;
+  strings?: PoiTooltipOverlayStrings;
 }
 
 interface RenderState {
@@ -42,6 +50,7 @@ export class PoiTooltipOverlay {
   private readonly interactionTimeline: InteractionTimeline | null;
   private readonly guidedTourPreference: GuidedTourPreference;
   private readonly instanceId: string;
+  private strings: PoiTooltipOverlayStrings;
   private discoveryFormatter: DiscoveryFormatter;
   private discoveryPoliteness: 'polite' | 'assertive';
   private readonly discoveredPoiIds = new Set<string>();
@@ -64,12 +73,15 @@ export class PoiTooltipOverlay {
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
+      locale,
+      strings,
     } = options;
     const documentTarget = container.ownerDocument ?? document;
 
+    this.strings = strings ?? getPoiTooltipOverlayStrings(locale);
     this.discoveryPoliteness = discoveryAnnouncer?.politeness ?? 'polite';
     this.discoveryFormatter =
-      discoveryAnnouncer?.format ?? defaultDiscoveryFormatter;
+      discoveryAnnouncer?.format ?? this.formatDefaultDiscovery.bind(this);
     this.interactionTimeline = interactionTimeline ?? null;
     this.guidedTourPreference = guidedTourPreference;
     this.onDismiss = onDismiss ?? null;
@@ -100,20 +112,20 @@ export class PoiTooltipOverlay {
 
     this.visitedBadge = documentTarget.createElement('span');
     this.visitedBadge.className = 'poi-tooltip-overlay__visited';
-    this.visitedBadge.textContent = 'Visited';
+    this.visitedBadge.textContent = this.strings.visited;
     this.visitedBadge.hidden = true;
     headingRow.appendChild(this.visitedBadge);
 
     this.recommendationBadge = documentTarget.createElement('span');
     this.recommendationBadge.className = 'poi-tooltip-overlay__recommendation';
-    this.recommendationBadge.textContent = 'Next highlight';
+    this.recommendationBadge.textContent = this.strings.nextHighlight;
     this.recommendationBadge.hidden = true;
     headingRow.appendChild(this.recommendationBadge);
 
     this.closeButton = documentTarget.createElement('button');
     this.closeButton.className = 'poi-tooltip-overlay__close';
     this.closeButton.type = 'button';
-    this.closeButton.setAttribute('aria-label', 'Close POI details');
+    this.closeButton.setAttribute('aria-label', this.strings.closeDetailsLabel);
     this.closeButton.textContent = '×';
     this.closeButton.hidden = true;
     this.closeButton.disabled = true;
@@ -153,7 +165,10 @@ export class PoiTooltipOverlay {
     this.linksList = documentTarget.createElement('ul');
     this.linksList.className = 'poi-tooltip-overlay__links';
     this.linksList.id = `${this.instanceId}-links`;
-    this.linksList.setAttribute('aria-label', 'Related case studies');
+    this.linksList.setAttribute(
+      'aria-label',
+      this.strings.relatedCaseStudiesLabel
+    );
     this.root.appendChild(this.linksList);
 
     container.appendChild(this.root);
@@ -175,6 +190,20 @@ export class PoiTooltipOverlay {
         this.update();
       }
     );
+  }
+
+  setStrings(strings: PoiTooltipOverlayStrings): void {
+    this.strings = strings;
+    this.visitedBadge.textContent = strings.visited;
+    this.recommendationBadge.textContent = strings.nextHighlight;
+    this.closeButton.setAttribute('aria-label', strings.closeDetailsLabel);
+    this.linksList.setAttribute('aria-label', strings.relatedCaseStudiesLabel);
+    this.renderState.poiId = null;
+    this.update();
+  }
+
+  setLocale(locale: LocaleInput): void {
+    this.setStrings(getPoiTooltipOverlayStrings(locale));
   }
 
   setIdleState(idle: boolean) {
@@ -300,13 +329,9 @@ export class PoiTooltipOverlay {
     const previousPoiId = this.renderState.poiId;
 
     if (previousPoiId !== poi.id) {
-      this.renderPoi(poi);
       this.renderState.poiId = poi.id;
-    } else {
-      this.updateStatus(poi);
-      this.renderOutcome(poi);
-      this.renderMetrics(poi);
     }
+    this.renderPoi(poi);
 
     const describedByIds = [this.summary.id];
     if (!this.outcome.hidden) {
@@ -387,7 +412,7 @@ export class PoiTooltipOverlay {
       return;
     }
 
-    const label = outcome.label?.trim() || 'Outcome';
+    const label = outcome.label?.trim() || this.strings.outcomeFallbackLabel;
     this.outcomeLabel.textContent = label;
     this.outcomeLabel.hidden = false;
     this.outcomeValue.textContent = outcome.value.trim();
@@ -397,7 +422,7 @@ export class PoiTooltipOverlay {
 
   private updateStatus(poi: PoiDefinition) {
     if (poi.status) {
-      const statusLabel = poi.status === 'prototype' ? 'Prototype' : 'Live';
+      const statusLabel = this.strings.status[poi.status];
       this.statusBadge.textContent = statusLabel;
       this.statusBadge.hidden = false;
     } else {
@@ -478,6 +503,12 @@ export class PoiTooltipOverlay {
       announce();
     }
   }
+  private formatDefaultDiscovery(poi: PoiDefinition): string {
+    return formatMessage(this.strings.discoveryAnnouncementTemplate, {
+      title: poi.title,
+      summary: poi.summary,
+    });
+  }
 }
 
 function applyVisuallyHiddenStyles(element: HTMLElement): void {
@@ -492,11 +523,6 @@ function applyVisuallyHiddenStyles(element: HTMLElement): void {
   element.style.clipPath = 'inset(50%)';
   element.style.whiteSpace = 'nowrap';
   element.style.pointerEvents = 'none';
-}
-
-function defaultDiscoveryFormatter(poi: PoiDefinition): string {
-  const summary = poi.summary ? ` ${poi.summary}` : '';
-  return `${poi.title} discovered.${summary}`;
 }
 
 let tooltipInstanceCounter = 0;

--- a/src/scene/poi/tourGuide.ts
+++ b/src/scene/poi/tourGuide.ts
@@ -34,7 +34,7 @@ export class PoiTourGuide {
 
   constructor(options: PoiTourGuideOptions) {
     this.visitedState = options.visitedState;
-    this.setDefinitions(options.definitions);
+    this.storeDefinitions(options.definitions);
     this.priorityOrder = this.normalizePriority(
       options.priorityOrder ??
         options.definitions.map((definition) => definition.id)
@@ -75,7 +75,13 @@ export class PoiTourGuide {
     this.listeners.clear();
   }
 
-  private setDefinitions(definitions: PoiDefinition[]) {
+  setDefinitions(definitions: PoiDefinition[]): void {
+    const previousRecommendationId = this.recommendation?.id ?? null;
+    this.storeDefinitions(definitions);
+    this.refreshRecommendation({ forceEmit: true, previousRecommendationId });
+  }
+
+  private storeDefinitions(definitions: PoiDefinition[]) {
     this.allDefinitions = definitions.slice();
     this.definitionsById.clear();
     for (const definition of definitions) {
@@ -96,10 +102,17 @@ export class PoiTourGuide {
     return unique;
   }
 
-  private refreshRecommendation() {
+  private refreshRecommendation(
+    options: {
+      forceEmit?: boolean;
+      previousRecommendationId?: PoiId | null;
+    } = {}
+  ) {
     const visited = this.visitedState.snapshot();
     const next = this.computeRecommendation(visited);
-    if (next?.id === this.recommendation?.id) {
+    const previousId =
+      options.previousRecommendationId ?? this.recommendation?.id;
+    if (!options.forceEmit && next?.id === previousId) {
       return;
     }
     this.recommendation = next;

--- a/src/systems/narrative/proceduralNarrator.ts
+++ b/src/systems/narrative/proceduralNarrator.ts
@@ -30,6 +30,10 @@ export class ProceduralNarrator {
     this.lastVisitedId = last.id;
   }
 
+  setDefinitions(definitions: ReadonlyArray<PoiDefinition>): void {
+    definitions.forEach((definition) => this.storeDefinition(definition));
+  }
+
   handleVisit(poi: PoiDefinition): void {
     this.storeDefinition(poi);
     const previousId = this.lastVisitedId;

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -11,10 +11,12 @@ import {
   getModeToggleStrings,
   getLocaleScript,
   getPoiNarrativeLogStrings,
+  getPoiTooltipOverlayStrings,
   getPoiCopy,
   getSiteStrings,
   resolveLocale,
 } from '../assets/i18n';
+import { getPoiDefinitions } from '../scene/poi/registry';
 
 describe('i18n utilities', () => {
   it('exposes available locales including pseudo locale scaffolding', () => {
@@ -218,6 +220,50 @@ describe('i18n utilities', () => {
     expect(pseudoCopy['tokenplace-studio-cluster'].title).toBe(
       copy['tokenplace-studio-cluster'].title
     );
+  });
+
+  it('localizes POI definitions without mutating shared base data', () => {
+    const englishDefinitions = getPoiDefinitions('en');
+    const pseudoDefinitions = getPoiDefinitions('en-x-pseudo');
+    const englishFuturoptimist = englishDefinitions.find(
+      (definition) => definition.id === 'futuroptimist-living-room-tv'
+    );
+    const pseudoFuturoptimist = pseudoDefinitions.find(
+      (definition) => definition.id === 'futuroptimist-living-room-tv'
+    );
+
+    expect(englishFuturoptimist?.title).toBe('Futuroptimist');
+    expect(pseudoFuturoptimist?.title).toBe('⟦Futuroptimist⟧');
+    expect(pseudoFuturoptimist?.summary).toContain('⟦Automated');
+    expect(pseudoFuturoptimist?.interactionPrompt).toBe(
+      '⟦Inspect ⟦Futuroptimist⟧⟧'
+    );
+
+    if (!englishFuturoptimist?.metrics?.[0]) {
+      throw new Error('Expected Futuroptimist metric fixture.');
+    }
+    englishFuturoptimist.metrics[0].value = 'Mutated metric';
+    expect(
+      getPoiDefinitions('en').find(
+        (definition) => definition.id === 'futuroptimist-living-room-tv'
+      )?.metrics?.[0]?.value
+    ).toBe('1,280+');
+  });
+
+  it('returns localized POI tooltip overlay chrome strings', () => {
+    const english = getPoiTooltipOverlayStrings('en');
+    expect(english.visited).toBe('Visited');
+    expect(english.status.prototype).toBe('Prototype');
+    expect(
+      formatMessage(english.discoveryAnnouncementTemplate, {
+        title: 'Flywheel',
+        summary: 'Automation hub.',
+      })
+    ).toBe('Flywheel discovered. Automation hub.');
+
+    const pseudo = getPoiTooltipOverlayStrings('en-x-pseudo');
+    expect(pseudo.visited).toBe('⟦Visited⟧');
+    expect(pseudo.relatedCaseStudiesLabel).toBe('⟦Related case studies⟧');
   });
 
   it('falls back to English site metadata when pseudo overrides omit values', () => {

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -5,6 +5,7 @@ import { scalePoiValue } from '../scene/poi/constants';
 import {
   createPoiInstances,
   createPoiLabelTexture,
+  updatePoiInstanceDefinition,
 } from '../scene/poi/markers';
 import type { PoiDefinition } from '../scene/poi/types';
 
@@ -145,6 +146,22 @@ describe('createPoiInstances', () => {
     expect(renderedText).not.toContain('Reduced shelf drift');
     expect(renderedText).not.toContain('Cataloged 200 repos');
     expect(renderedText).not.toContain('Prototype');
+  });
+
+  it('updates existing marker label textures when definitions are localized', () => {
+    fillTextLog = [];
+    const [instance] = createPoiInstances([
+      createDefinition({ title: 'Futuroptimist' }),
+    ]);
+    expect(fillTextLog).toEqual(['Futuroptimist']);
+
+    updatePoiInstanceDefinition(
+      instance,
+      createDefinition({ title: '⟦Futuroptimist⟧' })
+    );
+
+    expect(instance.definition.title).toBe('⟦Futuroptimist⟧');
+    expect(fillTextLog).toEqual(['Futuroptimist', '⟦Futuroptimist⟧']);
   });
 
   it('preserves existing title-only marker labels without ellipsizing them', () => {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -406,6 +406,68 @@ describe('PoiTooltipOverlay', () => {
     expect(updatedValues).toContain('Updated workflow');
   });
 
+  it('refreshes selected POI copy and chrome strings at runtime', () => {
+    overlay.setSelected(basePoi);
+    overlay.setVisitedPoiIds(new Set([basePoi.id]));
+
+    const localizedPoi: PoiDefinition = {
+      ...basePoi,
+      title: '⟦Futuroptimist⟧',
+      summary: '⟦Localized immersive summary.⟧',
+      outcome: { label: '', value: '⟦Localized outcome.⟧' },
+      metrics: [{ label: '⟦Workflow⟧', value: '⟦Localized metric.⟧' }],
+      links: [{ label: '⟦Docs⟧', href: 'https://futuroptimist.dev' }],
+    };
+
+    overlay.setStrings({
+      visited: '⟦Visited⟧',
+      nextHighlight: '⟦Next highlight⟧',
+      status: {
+        prototype: '⟦Prototype⟧',
+        live: '⟦Live⟧',
+      },
+      closeDetailsLabel: '⟦Close POI details⟧',
+      relatedCaseStudiesLabel: '⟦Related case studies⟧',
+      outcomeFallbackLabel: '⟦Outcome⟧',
+      discoveryAnnouncementTemplate: '⟦{title} discovered. {summary}⟧',
+    });
+    overlay.setSelected(localizedPoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('.poi-tooltip-overlay__title')?.textContent).toBe(
+      '⟦Futuroptimist⟧'
+    );
+    expect(
+      root.querySelector('.poi-tooltip-overlay__summary')?.textContent
+    ).toBe('⟦Localized immersive summary.⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__outcome-label')?.textContent
+    ).toBe('⟦Outcome⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-label')?.textContent
+    ).toBe('⟦Workflow⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-value')?.textContent
+    ).toBe('⟦Localized metric.⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__visited')?.textContent
+    ).toBe('⟦Visited⟧');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__status')?.textContent
+    ).toBe('⟦Prototype⟧');
+    expect(
+      root
+        .querySelector('.poi-tooltip-overlay__links')
+        ?.getAttribute('aria-label')
+    ).toBe('⟦Related case studies⟧');
+    expect(
+      root
+        .querySelector('.poi-tooltip-overlay__close')
+        ?.getAttribute('aria-label')
+    ).toBe('⟦Close POI details⟧');
+  });
+
   it('hides the outcome row when a POI omits the outcome field', () => {
     const poiWithoutOutcome: PoiDefinition = {
       ...basePoi,


### PR DESCRIPTION
### Motivation
- POI copy was captured at module load which froze immersive POI titles/metrics/tooltips to the initial locale and prevented Settings-driven updates.
- The UX requires runtime locale switching to update POI titles, summaries, outcomes, metrics, links, interaction prompts, marker labels, tooltips, narrative log entries, and structured data without a page reload.

### Description
- Split static placement from localized copy by adding `buildLocalizedDefinitions(locale)` and `getPoiDefinitions(locale)` and a `createPoiRegistry(locale)` so localized POI definitions are generated at runtime and do not mutate shared base data. (`src/scene/poi/registry.ts`).
- Add `updatePoiInstanceDefinition(instance, definition)` to `markers.ts` and call it on locale switches to refresh marker label textures without recreating Three.js objects. (`src/scene/poi/markers.ts`).
- Move POI overlay chrome strings into the i18n system (`PoiTooltipOverlayStrings`) and provide `setStrings`/`setLocale` on `PoiTooltipOverlay` so badges, close aria-labels, recommendation labels, status labels, outcome fallback, and discovery announcement templates are localized at runtime. (`src/assets/i18n/*`, `src/scene/poi/tooltipOverlay.ts`).
- Wire runtime locale refresh in `applyLocaleUpdate` to rebuild localized definitions and update: `poiDefinitionsById`, existing POI instances, selected/hovered/recommended POI references, `PoiTourGuide`/`ProceduralNarrator` definitions, GitHub metrics wiring (`wireGitHubRepoMetrics`), structured data injection, and overlay/world tooltip strings so the UI updates in-place. (`src/main.ts`).
- Ensure narrative/tour state and visited state are preserved and re-bound to localized definitions; added minor tour/narrator APIs (`setDefinitions`) to accept updated localized definitions. (`src/scene/poi/tourGuide.ts`, `src/systems/narrative/proceduralNarrator.ts`).
- Tests: added/updated tests that cover non-mutating localized POI definitions, overlay chrome localization, runtime refresh of an active selected POI, and marker label texture updates. (`src/tests/i18n.test.ts`, `src/tests/poiTooltipOverlay.test.ts`, `src/tests/poiMarkers.test.ts`).

### Testing
- `npm run format:write` — succeeded (files formatted).
- `npm run lint` — succeeded (0 errors, 2 warnings reported and left unchanged).
- Targeted unit tests: `npm run test:ci -- src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts src/tests/poiMarkers.test.ts` — all targeted tests passed (4 files, 60 tests).
- Full unit test suite: `npm run test:ci` — all tests passed (132 files, 923 tests) in CI run.
- `npm run build` — succeeded and produced `dist/` artifacts.
- `npm run docs:check` — succeeded.
- `npm run smoke` — succeeded (build + smoke assertions passed).
- `npm run typecheck` — currently failing in the workspace due to unrelated, pre-existing project-wide TypeScript issues (examples: `AudioNode` nullability in `src/main.ts`, missing `../collision` declarations across environment/structure files, and some test typing mismatches); these are out-of-scope for this POI i18n change.

Notes / residual risks
- The change avoids recreating Three.js geometry/materials for POI instances and updates label textures in-place, but any downstream code that assumes object identity for definition objects should instead use `definition.id` as a stable key; tests were added to guard label refresh behavior.
- `typecheck` failures observed are unrelated to the POI i18n refactor and should be addressed separately; functional tests, build, and smoke checks passed for this change.
- Manual verification: switch locale in Settings during an immersive session and confirm selected POI remains selected and its overlay/world labels update immediately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f954a7544832fa08e716da6499986)