### PR TITLE
Add Simplified Mandarin (zh‑Hans) locale and finish visible UI i18n coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,10 @@ Launch screenshot workflow refresh and commit it after merge.
   locales load structured strings while keeping Vitest coverage in
   `src/tests/i18n.test.ts` to guard against regressions. HUD overlays and the
   text fallback now tag their containers with locale direction metadata so RTL
-  languages flow correctly even before full translations land.
+  and CJK languages flow correctly. The public Settings language picker exposes
+  English, Japanese, Arabic, and Simplified Mandarin Chinese; the pseudo-locale
+  remains available only in development, with `?i18nDebug=1`, or after setting
+  `localStorage.setItem('danielsmith:i18n-debug', 'true')` for translation QA.
 - **Audio captions** – A subtitles overlay now calls out ambient beds and POI narration with
   cooldown-aware timing so visitors who mute audio or rely on captions still catch the
   story beats.

--- a/src/assets/i18n/debug.ts
+++ b/src/assets/i18n/debug.ts
@@ -1,0 +1,39 @@
+const I18N_DEBUG_PARAM = 'i18nDebug';
+export const I18N_DEBUG_STORAGE_KEY = 'danielsmith:i18n-debug';
+
+export interface I18nDebugOptions {
+  search?: string | URLSearchParams;
+  storage?: Pick<Storage, 'getItem'> | null;
+  isDev?: boolean;
+}
+
+const isTruthyFlag = (value: string | null | undefined) =>
+  value === '1' || value === 'true' || value === 'yes' || value === 'on';
+
+export function isI18nDebugEnabled({
+  search,
+  storage,
+  isDev = import.meta.env.DEV,
+}: I18nDebugOptions = {}): boolean {
+  if (isDev) {
+    return true;
+  }
+
+  const params =
+    typeof search === 'string'
+      ? new URLSearchParams(search)
+      : (search ??
+        (typeof window !== 'undefined'
+          ? new URLSearchParams(window.location.search)
+          : null));
+
+  if (params && isTruthyFlag(params.get(I18N_DEBUG_PARAM))) {
+    return true;
+  }
+
+  try {
+    return isTruthyFlag(storage?.getItem(I18N_DEBUG_STORAGE_KEY));
+  } catch {
+    return false;
+  }
+}

--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -4,6 +4,7 @@ import { AR_OVERRIDES } from './locales/ar';
 import { EN_LOCALE_STRINGS } from './locales/en';
 import { EN_X_PSEUDO_OVERRIDES } from './locales/en-x-pseudo';
 import { JA_OVERRIDES } from './locales/ja';
+import { ZH_HANS_OVERRIDES } from './locales/zh-Hans';
 import type {
   AudioHudControlStrings,
   ControlOverlayStrings,
@@ -29,6 +30,7 @@ import type {
 export type LocaleToggleResolvedStrings = LocaleToggleStrings;
 
 export * from './types';
+export { I18N_DEBUG_STORAGE_KEY, isI18nDebugEnabled } from './debug';
 
 function cloneValue<T>(value: T): T {
   if (Array.isArray(value)) {
@@ -103,12 +105,18 @@ const MERGED_PSEUDO = buildLocale(
 
 const AR_LOCALE = buildLocale(EN_LOCALE_STRINGS, AR_OVERRIDES, 'ar');
 const JA_LOCALE = buildLocale(EN_LOCALE_STRINGS, JA_OVERRIDES, 'ja');
+const ZH_HANS_LOCALE = buildLocale(
+  EN_LOCALE_STRINGS,
+  ZH_HANS_OVERRIDES,
+  'zh-Hans'
+);
 
 const localeCatalog: Record<Locale, LocaleStrings> = Object.freeze({
   en: Object.freeze(cloneValue(EN_LOCALE_STRINGS)),
   'en-x-pseudo': MERGED_PSEUDO,
   ar: AR_LOCALE,
   ja: JA_LOCALE,
+  'zh-Hans': ZH_HANS_LOCALE,
 });
 
 export const AVAILABLE_LOCALES = Object.freeze(
@@ -143,6 +151,14 @@ export function resolveLocale(input: LocaleInput): Locale {
 
   if (normalized.startsWith('ja')) {
     return 'ja';
+  }
+
+  if (
+    normalized === 'zh' ||
+    normalized.startsWith('zh-') ||
+    normalized.startsWith('cmn')
+  ) {
+    return 'zh-Hans';
   }
 
   return 'en';
@@ -274,6 +290,18 @@ export function getHudCustomizationStrings(
   input?: LocaleInput
 ): HudCustomizationStrings {
   return getLocaleStrings(input).hud.customization;
+}
+
+export function getTourGuideToggleStrings(input?: LocaleInput) {
+  return getLocaleStrings(input).hud.tourGuideToggle;
+}
+
+export function getTourResetControlStrings(input?: LocaleInput) {
+  return getLocaleStrings(input).hud.tourReset;
+}
+
+export function getSoftwareRendererWarningStrings(input?: LocaleInput) {
+  return getLocaleStrings(input).hud.softwareRendererWarning;
 }
 
 export function getModeToggleStrings(

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -286,6 +286,13 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
     localeToggle: {
       title: wrap('Language'),
       description: wrap('Switch the HUD language and direction.'),
+      options: {
+        en: wrap('English'),
+        ja: wrap('日本語'),
+        ar: wrap('العربية'),
+        'zh-Hans': wrap('简体中文'),
+        'en-x-pseudo': wrap('Pseudo'),
+      },
       switchingAnnouncementTemplate: wrap('Switching to {target} locale…'),
       selectedAnnouncementTemplate: wrap('{label} locale selected.'),
       failureAnnouncementTemplate: wrap(
@@ -319,6 +326,53 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       errorTitleTemplate: wrap(
         'Text mode toggle failed. Press {keyHint} to retry text mode.'
       ),
+    },
+    tourGuideToggle: {
+      labelEnabled: wrap('Guided tour on'),
+      labelDisabled: wrap('Guided tour off'),
+      descriptionEnabled: wrap(
+        'Highlights the next recommended exhibit in the immersive tour.'
+      ),
+      descriptionDisabled: wrap(
+        'Guided tour highlights are hidden until you turn them back on.'
+      ),
+    },
+    tourReset: {
+      heading: wrap('Guided tour'),
+      label: wrap('Restart guided tour'),
+      description: wrap('Clear visited POIs and replay the curated path.'),
+      emptyLabel: wrap('Guided tour ready'),
+      emptyDescription: wrap(
+        'Explore exhibits to unlock the guided tour reset.'
+      ),
+      pendingLabel: wrap('Resetting tour…'),
+      pendingDescription: wrap('Resetting the guided tour…'),
+      restartPromptTemplate: wrap('Press {key} to restart.'),
+      guidedTourDescription: wrap('Show recommended exhibits when idle.'),
+      guidedTourLabelOn: wrap('Guided tour highlights: On'),
+      guidedTourLabelOff: wrap('Guided tour highlights: Off'),
+      guidedTourAnnouncementOn: wrap(
+        'Guided tour highlights enabled. Activate to disable recommendations.'
+      ),
+      guidedTourAnnouncementOff: wrap(
+        'Guided tour highlights disabled. Activate to enable recommendations.'
+      ),
+      guidedTourTitleOn: wrap('Disable guided tour highlights'),
+      guidedTourTitleOff: wrap('Enable guided tour highlights'),
+    },
+    softwareRendererWarning: {
+      fallbackRendererLabel: wrap('software WebGL renderer'),
+      title: wrap('Software rendering detected'),
+      descriptionTemplate: wrap(
+        'Chrome is using {renderer} instead of hardware acceleration. Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.'
+      ),
+      recommendation: wrap(
+        'Enable browser hardware acceleration for the smooth immersive portfolio. Safe immersive mode keeps screenshots and debugging available at a capped frame rate.'
+      ),
+      continueSafeLabel: wrap('Continue in safe immersive'),
+      continuousLabel: wrap('Enable continuous immersive anyway'),
+      textModeLabel: wrap('Use text mode'),
+      safeUrlLabel: wrap('Reload this safe immersive URL'),
     },
     poiOverlay: {
       visited: wrap('Visited'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -293,6 +293,13 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     localeToggle: {
       title: 'Language',
       description: 'Switch the HUD language and direction.',
+      options: {
+        en: 'English',
+        ja: '日本語',
+        ar: 'العربية',
+        'zh-Hans': '简体中文',
+        'en-x-pseudo': 'Pseudo',
+      },
       switchingAnnouncementTemplate: 'Switching to {target} locale…',
       selectedAnnouncementTemplate: '{label} locale selected.',
       failureAnnouncementTemplate:
@@ -319,6 +326,45 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'Text mode toggle failed. Press {keyHint} to try again.',
       errorTitleTemplate:
         'Text mode toggle failed. Press {keyHint} to retry text mode.',
+    },
+    tourGuideToggle: {
+      labelEnabled: 'Guided tour on',
+      labelDisabled: 'Guided tour off',
+      descriptionEnabled:
+        'Highlights the next recommended exhibit in the immersive tour.',
+      descriptionDisabled:
+        'Guided tour highlights are hidden until you turn them back on.',
+    },
+    tourReset: {
+      heading: 'Guided tour',
+      label: 'Restart guided tour',
+      description: 'Clear visited POIs and replay the curated path.',
+      emptyLabel: 'Guided tour ready',
+      emptyDescription: 'Explore exhibits to unlock the guided tour reset.',
+      pendingLabel: 'Resetting tour…',
+      pendingDescription: 'Resetting the guided tour…',
+      restartPromptTemplate: 'Press {key} to restart.',
+      guidedTourDescription: 'Show recommended exhibits when idle.',
+      guidedTourLabelOn: 'Guided tour highlights: On',
+      guidedTourLabelOff: 'Guided tour highlights: Off',
+      guidedTourAnnouncementOn:
+        'Guided tour highlights enabled. Activate to disable recommendations.',
+      guidedTourAnnouncementOff:
+        'Guided tour highlights disabled. Activate to enable recommendations.',
+      guidedTourTitleOn: 'Disable guided tour highlights',
+      guidedTourTitleOff: 'Enable guided tour highlights',
+    },
+    softwareRendererWarning: {
+      fallbackRendererLabel: 'software WebGL renderer',
+      title: 'Software rendering detected',
+      descriptionTemplate:
+        'Chrome is using {renderer} instead of hardware acceleration. Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.',
+      recommendation:
+        'Enable browser hardware acceleration for the smooth immersive portfolio. Safe immersive mode keeps screenshots and debugging available at a capped frame rate.',
+      continueSafeLabel: 'Continue in safe immersive',
+      continuousLabel: 'Enable continuous immersive anyway',
+      textModeLabel: 'Use text mode',
+      safeUrlLabel: 'Reload this safe immersive URL',
     },
     poiOverlay: {
       visited: 'Visited',

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -1,0 +1,438 @@
+import type { LocaleOverrides } from '../types';
+
+export const ZH_HANS_OVERRIDES: LocaleOverrides = {
+  locale: 'zh-Hans',
+  site: {
+    name: 'Daniel Smith 沉浸式作品集',
+    structuredData: {
+      description: 'Daniel Smith 沉浸式作品集中的互动项目展品。',
+      listNameTemplate: '{siteName} 展品',
+      textCollectionNameTemplate: '{siteName} 文字作品集',
+      textCollectionDescription:
+        '每个沉浸式展品的快速摘要、成果和指标，便于无障碍阅读和搜索索引。',
+      immersiveActionName: '启动沉浸模式',
+      properties: {
+        labels: { category: '类别', outcome: '成果', status: '状态' },
+        categories: { project: '项目', environment: '环境' },
+        statuses: { prototype: '原型', live: '上线' },
+      },
+    },
+    textFallback: {
+      heading: '浏览亮点',
+      intro: '当沉浸模式不可用时，文字作品集仍提供每个展品的摘要、成果和指标。',
+      roomHeadingTemplate: '{roomName} 展品',
+      metricsHeading: '关键指标',
+      linksHeading: '延伸阅读',
+      about: {
+        heading: '关于 Daniel',
+        summary:
+          '站点可靠性工程师，曾在 YouTube 工作六年，专注自动化、可观测性和稳定发布。',
+        highlights: [
+          '构建开发者平台和智能体工具，让团队更安全地快速交付。',
+          '指导团队实践 SLO、事故响应和可靠性评审。',
+          '探索沉浸式 WebGL 叙事，并始终提供可访问的文字回退。',
+        ],
+      },
+      skills: {
+        heading: '技能概览',
+        items: [
+          {
+            label: '语言',
+            value:
+              'Python、Go、SQL、C++、TypeScript/JavaScript、Ruby、Objective-C',
+          },
+          {
+            label: '基础设施与工具',
+            value:
+              'Kubernetes、Docker、Google Cloud (BigQuery)、GitHub Actions、WebGL/Three.js、React/Next.js、Astro',
+          },
+          {
+            label: '实践',
+            value:
+              'SRE、SLO、事故响应、可观测性、CI/CD、测试、提示词文档与智能体编程',
+          },
+        ],
+      },
+      contact: {
+        heading: '联系',
+        emailLabel: '邮箱',
+        githubLabel: 'GitHub',
+        resumeLabel: '简历 (PDF)',
+      },
+      recoveryCta: {
+        title: '准备进入完整房间了吗？',
+        description: '清除保存的文字模式偏好，并从这里重新启动沉浸式作品集。',
+        actionLabel: '再次尝试沉浸模式',
+        ariaLabel: '再次尝试沉浸模式并清除已保存的文字模式偏好',
+      },
+      actions: {
+        immersiveLink: '再次尝试沉浸模式',
+        debugImmersiveLink: '调试：强制沉浸模式',
+        clearPreferenceButton: '清除保存的模式偏好',
+        clearPreferenceSuccess: '已清除保存的模式偏好',
+        resumeLink: '下载最新简历',
+        githubLink: '在 GitHub 上浏览项目',
+      },
+      reasonHeadings: {
+        manual: '已启用纯文字模式',
+        'webgl-unsupported': '此设备无法使用沉浸模式',
+        'low-memory': '检测到低内存设备',
+        'low-end-device': '检测到轻量设备',
+        'low-performance': '性能回退已启用',
+        'immersive-init-error': '沉浸式场景遇到错误',
+        'automated-client': '检测到自动化客户端',
+        'data-saver': '已启用省流模式',
+        'console-error': '检测到运行时错误',
+      },
+      reasonDescriptions: {
+        manual: '你请求了轻量作品集视图。沉浸式场景仍可一键返回。',
+        'webgl-unsupported':
+          '浏览器或设备无法启动 WebGL 渲染器，因此先展示快速文字概览。',
+        'low-memory': '设备报告内存有限，因此启动轻量文字导览以保持流畅。',
+        'low-end-device': '我们检测到轻量设备配置，因此优先提供快速文字体验。',
+        'low-performance': '持续帧率较低，因此切换到文字模式以保持内容可访问。',
+        'immersive-init-error':
+          '沉浸式场景启动失败。文字版本保留全部项目内容。',
+        'automated-client': '自动化客户端会收到稳定、可索引的文字作品集。',
+        'data-saver': '省流模式会跳过较重的实时 3D 场景。',
+        'console-error': '检测到运行时错误，因此展示稳定的文字版本。',
+      },
+    },
+  },
+  hud: {
+    controlOverlay: {
+      heading: '控制',
+      items: {
+        keyboardMove: { keys: 'WASD / 方向键', description: '移动探索者' },
+        pointerDrag: { keys: '拖动', description: '平移相机' },
+        pointerZoom: { keys: '滚轮', description: '缩放视图' },
+        touchDrag: { keys: '触控摇杆', description: '移动并平移' },
+        touchPinch: { keys: '双指捏合', description: '缩放' },
+        cyclePoi: { keys: 'Q / E', description: '切换兴趣点' },
+        toggleTextMode: { keys: 'T', description: '切换文字模式' },
+      },
+      interact: {
+        defaultLabel: '互动',
+        description: '打开当前展品',
+        promptTemplates: {
+          inspect: '查看 {title}',
+          activate: '启动 {title}',
+          default: '探索 {title}',
+        },
+      },
+      helpButton: {
+        labelTemplate: '帮助 · 按 {keyHint}',
+        announcementTemplate: '打开帮助和设置。按 {keyHint} 切换。',
+        shortcutFallback: '帮助',
+      },
+      menu: {
+        controls: { label: '控制', keyHint: 'C', title: '打开控制面板' },
+        text: { label: '文字', keyHint: 'T', title: '切换到文字作品集' },
+        settings: { label: '设置', keyHint: 'H', title: '打开设置和帮助' },
+      },
+      mobileToggle: {
+        expandLabel: '显示控制',
+        collapseLabel: '隐藏控制',
+        expandAnnouncement: '控制已展开。',
+        collapseAnnouncement: '控制已收起。',
+      },
+    },
+    movementLegend: {
+      defaultDescription: '互动',
+      labels: {
+        keyboard: 'Enter',
+        pointer: '点击',
+        touch: '轻触',
+        gamepad: 'A',
+      },
+      interactPromptTemplates: {
+        default: '{prompt}',
+        keyboard: '按 {label} {prompt}',
+        pointer: '{label}{prompt}',
+        touch: '{label}{prompt}',
+        gamepad: '按 {label} {prompt}',
+      },
+    },
+    customization: {
+      heading: '自定义',
+      description: '调整当前任务中的角色风格和随身装备。',
+      variants: { title: '角色风格', description: '切换探索者的服装。' },
+      accessories: {
+        title: '配件',
+        description: '切换腕部控制台或全息无人机伙伴。',
+      },
+    },
+    audioControl: {
+      keyHint: 'M',
+      groupLabel: '环境音控制',
+      toggle: {
+        onLabelTemplate: '音频：开 · 按 {keyHint} 静音',
+        offLabelTemplate: '音频：关 · 按 {keyHint} 取消静音',
+        titleTemplate: '切换环境音 ({keyHint})',
+        announcementOnTemplate: '环境音已开启。按 {keyHint} 切换。',
+        announcementOffTemplate: '环境音已关闭。按 {keyHint} 切换。',
+        pendingAnnouncementTemplate: '正在切换环境音，请稍候…',
+      },
+      slider: {
+        label: '环境音量',
+        ariaLabel: '环境音音量',
+        hudLabel: '环境音音量滑块。',
+        valueAnnouncementTemplate: '环境音量 {volume}。',
+        mutedAnnouncementTemplate: '环境音已静音。音量设为 {volume}。',
+        mutedValueTemplate: '已静音 · {volume}',
+        mutedAriaValueTemplate: '已静音 ({volume})',
+      },
+    },
+    localeToggle: {
+      title: '语言',
+      description: '切换 HUD 语言和文字方向。',
+      options: {
+        en: 'English',
+        ja: '日本語',
+        ar: 'العربية',
+        'zh-Hans': '简体中文',
+        'en-x-pseudo': 'Pseudo',
+      },
+      switchingAnnouncementTemplate: '正在切换到 {target}…',
+      selectedAnnouncementTemplate: '已选择 {label}。',
+      failureAnnouncementTemplate: '无法切换到 {target}，继续使用 {current}。',
+    },
+    modeToggle: {
+      keyHint: 'T',
+      idleLabelTemplate: '文字模式 · 按 {keyHint}',
+      idleDescriptionTemplate: '切换到纯文字作品集',
+      idleAnnouncementTemplate: '切换到纯文字作品集。按 {keyHint} 启用。',
+      idleTitleTemplate: '切换到纯文字作品集 ({keyHint})',
+      pendingLabelTemplate: '正在切换到文字模式…',
+      pendingAnnouncementTemplate: '切换到纯文字作品集。正在切换到文字模式…',
+      activeLabelTemplate: '再次尝试沉浸模式 · 按 {keyHint}',
+      activeDescriptionTemplate: '返回沉浸式作品集。',
+      activeAnnouncementTemplate:
+        '文字模式已启用。按 {keyHint} 再次尝试沉浸模式。',
+      errorLabelTemplate: '重试文字模式 · 按 {keyHint}',
+      errorDescriptionTemplate: '文字模式切换失败。请重试或使用沉浸链接。',
+      errorAnnouncementTemplate: '文字模式切换失败。按 {keyHint} 重试。',
+      errorTitleTemplate: '文字模式切换失败。按 {keyHint} 重试文字模式。',
+    },
+    tourGuideToggle: {
+      labelEnabled: '导览已开启',
+      labelDisabled: '导览已关闭',
+      descriptionEnabled: '在沉浸式导览中高亮下一个推荐展品。',
+      descriptionDisabled: '导览高亮已隐藏，直到你再次开启。',
+    },
+    tourReset: {
+      heading: '导览',
+      label: '重新开始导览',
+      description: '清除已访问的兴趣点并重播精选路线。',
+      emptyLabel: '导览已就绪',
+      emptyDescription: '浏览展品后即可解锁导览重置。',
+      pendingLabel: '正在重置导览…',
+      pendingDescription: '正在重置导览…',
+      restartPromptTemplate: '按 {key} 重新开始。',
+      guidedTourDescription: '空闲时显示推荐展品。',
+      guidedTourLabelOn: '导览高亮：开',
+      guidedTourLabelOff: '导览高亮：关',
+      guidedTourAnnouncementOn: '导览高亮已开启。激活可关闭推荐。',
+      guidedTourAnnouncementOff: '导览高亮已关闭。激活可开启推荐。',
+      guidedTourTitleOn: '关闭导览高亮',
+      guidedTourTitleOff: '开启导览高亮',
+    },
+    softwareRendererWarning: {
+      fallbackRendererLabel: '软件 WebGL 渲染器',
+      title: '检测到软件渲染',
+      descriptionTemplate:
+        'Chrome 正在使用 {renderer} 而不是硬件加速。Basic Render Driver、SwiftShader、WARP 和 llvmpipe 在连续 WebGL 动画下可能崩溃。',
+      recommendation:
+        '启用浏览器硬件加速可获得流畅的沉浸式作品集。安全沉浸模式会限制帧率，同时保留截图和调试能力。',
+      continueSafeLabel: '继续使用安全沉浸模式',
+      continuousLabel: '仍然启用连续沉浸模式',
+      textModeLabel: '使用文字模式',
+      safeUrlLabel: '重新加载此安全沉浸 URL',
+    },
+    poiOverlay: {
+      visited: '已访问',
+      nextHighlight: '下一个亮点',
+      prototype: '原型',
+      live: '上线',
+      closeDetails: '关闭兴趣点详情',
+      relatedCaseStudies: '相关案例研究',
+      outcomeFallbackLabel: '成果',
+      discoveryAnnouncementTemplate: '已发现 {title}。{summary}',
+    },
+    narrativeLog: {
+      heading: '创作者故事日志',
+      visitedHeading: '已访问展品',
+      empty: '访问展品即可解锁记录创作者展示的叙事条目。',
+      defaultVisitedLabel: '已访问',
+      visitedLabelTemplate: '{time} 访问',
+      liveAnnouncementTemplate: '{title} 已添加到创作者故事日志。',
+      journey: {
+        heading: '旅程节点',
+        empty: '探索新展品以编织旅程叙事。',
+        entryLabelTemplate: '{from} → {to}',
+        sameRoomTemplate:
+          '在{room}{descriptor}中，故事从 {fromPoi} 转向 {toPoi}。',
+        crossRoomTemplate:
+          '离开{fromRoom}{fromDescriptor}，旅程进入{toRoom}{toDescriptor}，聚焦 {toPoi}。',
+        crossSectionTemplate:
+          '向{direction}穿过门槛，路径流入{toRoom}{toDescriptor}，抵达 {toPoi}。',
+        fallbackTemplate: '叙事流向 {toPoi}。',
+        announcementTemplate: '旅程更新 — {label}: {story}',
+        directions: { indoors: '室内', outdoors: '户外' },
+      },
+      rooms: {
+        livingRoom: {
+          label: '客厅',
+          descriptor: '电影感休息区',
+          zone: 'interior',
+        },
+        studio: {
+          label: '工作室',
+          descriptor: '自动化实验室',
+          zone: 'interior',
+        },
+        kitchen: {
+          label: '厨房实验室',
+          descriptor: '烹饪机器人区域',
+          zone: 'interior',
+        },
+        backyard: {
+          label: '后院观测区',
+          descriptor: '暮色花园',
+          zone: 'exterior',
+        },
+      },
+    },
+    helpModal: {
+      heading: '设置与帮助',
+      description:
+        '调整无障碍预设、图形质量、音频，并查看快捷键。使用帮助快捷键（默认 H 或 ?）切换此面板。',
+      closeLabel: '关闭',
+      closeAriaLabel: '关闭帮助',
+      settings: {
+        heading: '体验设置',
+        description:
+          '调整音频、视频和无障碍偏好。即使通过快捷键关闭菜单，这些控件也会保持可用。',
+      },
+      sections: [
+        {
+          id: 'movement',
+          title: '移动与相机',
+          items: [
+            { label: 'WASD / 方向键', description: '让探索者在家中移动。' },
+            { label: '鼠标拖动', description: '平移等距相机。' },
+            { label: '滚轮', description: '调整缩放级别。' },
+            { label: '触控摇杆', description: '左侧移动，右侧平移。' },
+            { label: '捏合', description: '在触控设备上缩放。' },
+          ],
+        },
+        {
+          id: 'interactions',
+          title: '互动',
+          items: [
+            {
+              label: '靠近发光兴趣点',
+              description: '按互动键、轻触或点击以打开展品浮层。',
+            },
+            {
+              label: 'Q / E 或 ← / →',
+              description: '用键盘在兴趣点之间切换焦点。',
+            },
+            { label: 'T', description: '在沉浸模式和文字回退之间切换。' },
+            { label: 'Shift + L', description: '比较电影级灯光和调试通道。' },
+          ],
+        },
+        {
+          id: 'accessibility',
+          title: '无障碍与回退',
+          items: [
+            {
+              label: '低性能',
+              description: '场景低于 30 FPS 时会自动切换到文字模式。',
+            },
+            {
+              label: '手动切换',
+              description: '随时使用屏幕上的文字模式按钮或按 T。',
+            },
+            {
+              label: '运动模糊滑块',
+              description: '在设置中的运动模糊控件调节拖影强度。',
+            },
+            { label: '环境音', description: '使用音频按钮或按 M 切换。' },
+          ],
+        },
+      ],
+      announcements: {
+        open: '帮助菜单已打开。请查看控制和设置。',
+        close: '帮助菜单已关闭。',
+      },
+    },
+  },
+  poi: {
+    'futuroptimist-living-room-tv': {
+      title: 'Futuroptimist',
+      summary:
+        '自动化 Futuroptimist 脚本工作台，用于整理研究、提纲和可配音的视频草稿。',
+    },
+    'tokenplace-studio-cluster': {
+      title: 'token.place',
+      summary:
+        '安全的点对点生成式 AI 平台，运行在 Raspberry Pi 集群上，配有加密中继和服务器节点。',
+    },
+    'gabriel-studio-sentry': {
+      title: 'Gabriel',
+      summary: '用于监控、告警和可靠性讲解的哨兵式自动化项目。',
+    },
+    'flywheel-studio-flywheel': {
+      title: 'Flywheel',
+      summary: '把提示词、检查和发布节奏串联起来的自动化工作流。',
+    },
+    'jobbot-studio-terminal': {
+      title: 'Jobbot 3000',
+      summary: '面向求职流程的终端助手，整理机会、材料和后续行动。',
+    },
+    'axel-studio-tracker': {
+      title: 'Axel',
+      summary: '用于跟踪项目状态、反馈和持续改进的轻量工具。',
+    },
+    'gitshelves-living-room-installation': {
+      title: 'Gitshelves',
+      summary: '把 GitHub 仓库整理成可浏览书架的作品集装置。',
+    },
+    'danielsmith-portfolio-table': {
+      title: 'danielsmith.io',
+      summary:
+        '这个沉浸式作品集本身：将 Three.js 房间、无障碍文字回退和本地化 HUD 组合在一起。',
+    },
+    'f2clipboard-kitchen-console': {
+      title: 'f2clipboard',
+      summary: '把失败日志快速复制成 CLI、剪贴板和 Markdown 输出的开发者工具。',
+    },
+    'sigma-kitchen-workbench': {
+      title: 'Sigma',
+      summary:
+        'ESP32 “AI pin”，通过按键对讲把音频发送到 Whisper，并在 OpenSCAD 外壳中返回 TTS。',
+    },
+    'wove-kitchen-loom': {
+      title: 'Wove',
+      summary:
+        '学习针织和钩编的开源工具包，并逐步走向带 OpenSCAD 硬件的机器人织机。',
+    },
+    'dspace-backyard-rocket': {
+      title: 'DSPACE',
+      summary:
+        '私人 DSPACE 火箭项目的后院发射架，包含遥测引导倒计时提示和公开任务日志。',
+      interactionPrompt: '启动 {title} 倒计时',
+    },
+    'pr-reaper-backyard-console': {
+      title: 'PR Reaper',
+      summary:
+        'GitHub Actions 工作流，可批量关闭陈旧 PR，支持 dry-run 预览和可选分支清理。',
+    },
+    'sugarkube-backyard-greenhouse': {
+      title: 'Sugarkube',
+      summary:
+        'Raspberry Pi 上的 k3s 平台，结合离网太阳能立方体安装、CAD、Pi 镜像和现场指南。',
+    },
+  },
+};

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -8,7 +8,7 @@ import type {
 import type { FallbackReason } from '../../types/failover';
 import type { InputMethod } from '../../ui/hud/movementLegend';
 
-export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja';
+export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja' | 'zh-Hans';
 export type LocaleDirection = 'ltr' | 'rtl';
 export type LocaleScript = 'latin' | 'cjk' | 'rtl';
 
@@ -137,12 +137,13 @@ export interface HelpModalSectionStrings {
 
 export interface HelpModalSettingsStrings {
   heading: string;
-  description?: string;
+  description: string;
 }
 
 export interface LocaleToggleStrings {
   title: string;
   description: string;
+  options: Record<Locale, string>;
   switchingAnnouncementTemplate: string;
   selectedAnnouncementTemplate: string;
   failureAnnouncementTemplate: string;
@@ -163,9 +164,45 @@ export interface HelpModalStrings {
 
 export interface HudCustomizationStrings {
   heading: string;
-  description?: string;
+  description: string;
   variants: { title: string; description: string };
   accessories: { title: string; description: string };
+}
+
+export interface TourGuideToggleStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
+export interface TourResetControlStrings {
+  heading: string;
+  label: string;
+  description: string;
+  emptyLabel: string;
+  emptyDescription: string;
+  pendingLabel: string;
+  pendingDescription: string;
+  restartPromptTemplate: string;
+  guidedTourDescription: string;
+  guidedTourLabelOn: string;
+  guidedTourLabelOff: string;
+  guidedTourAnnouncementOn: string;
+  guidedTourAnnouncementOff: string;
+  guidedTourTitleOn: string;
+  guidedTourTitleOff: string;
+}
+
+export interface SoftwareRendererWarningStrings {
+  fallbackRendererLabel: string;
+  title: string;
+  descriptionTemplate: string;
+  recommendation: string;
+  continueSafeLabel: string;
+  continuousLabel: string;
+  textModeLabel: string;
+  safeUrlLabel: string;
 }
 
 export interface PoiOverlayChromeStrings {
@@ -325,6 +362,9 @@ export interface LocaleStrings {
     modeToggle: ModeToggleStrings;
     localeToggle: LocaleToggleStrings;
     helpModal: HelpModalStrings;
+    tourGuideToggle: TourGuideToggleStrings;
+    tourReset: TourResetControlStrings;
+    softwareRendererWarning: SoftwareRendererWarningStrings;
     customization: HudCustomizationStrings;
     narrativeLog: PoiNarrativeLogStrings;
     poiOverlay: PoiOverlayChromeStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,10 @@ import {
   getPoiNarrativeLogStrings,
   getPoiOverlayChromeStrings,
   getSiteStrings,
+  getSoftwareRendererWarningStrings,
+  getTourGuideToggleStrings,
+  getTourResetControlStrings,
+  isI18nDebugEnabled,
   resolveLocale,
   type Locale,
 } from './assets/i18n';
@@ -829,16 +833,6 @@ function initializeImmersiveScene(
       softwareRendererPolicy,
     });
   };
-  if (rendererInfo.isDangerousSoftwareRenderer) {
-    softwareRendererWarning = createSoftwareRendererWarning({
-      rendererInfo,
-      safeUrl: createSoftwareSafeImmersiveUrl(),
-      continuousUrl: createContinuousSoftwareImmersiveUrl(),
-      textUrl: createTextModeUrl(),
-      onContinueSafe: requestSoftwareSafeRender,
-      onVisible: recordRendererWarning,
-    });
-  }
   let hudFocusAnnouncer: HudFocusAnnouncerHandle | null = null;
   let helpModalController: HelpModalControllerHandle | null = null;
   let poiNarrativeLog: PoiNarrativeLogHandle | null = null;
@@ -926,7 +920,22 @@ function initializeImmersiveScene(
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
+  let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
+  let tourResetControlStrings = getTourResetControlStrings(locale);
+  let softwareRendererWarningStrings =
+    getSoftwareRendererWarningStrings(locale);
   let siteStrings = getSiteStrings(locale);
+  if (rendererInfo.isDangerousSoftwareRenderer) {
+    softwareRendererWarning = createSoftwareRendererWarning({
+      rendererInfo,
+      safeUrl: createSoftwareSafeImmersiveUrl(),
+      continuousUrl: createContinuousSoftwareImmersiveUrl(),
+      textUrl: createTextModeUrl(),
+      onContinueSafe: requestSoftwareSafeRender,
+      onVisible: recordRendererWarning,
+      strings: softwareRendererWarningStrings,
+    });
+  }
   const syncModeAnnouncerStrings = () => {
     const announcerStrings = getModeAnnouncerStrings(locale);
     getModeAnnouncer().setMessages(
@@ -2949,6 +2958,9 @@ function initializeImmersiveScene(
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
+    tourGuideToggleStrings = getTourGuideToggleStrings(locale);
+    tourResetControlStrings = getTourResetControlStrings(locale);
+    softwareRendererWarningStrings = getSoftwareRendererWarningStrings(locale);
     siteStrings = getSiteStrings(locale);
     syncModeAnnouncerStrings();
     narrativeTimeFormatter = new Intl.DateTimeFormat(
@@ -3012,6 +3024,9 @@ function initializeImmersiveScene(
     helpModal.setContent(helpModalStrings);
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
+    tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
+    tourResetControl?.setStrings(tourResetControlStrings);
+    softwareRendererWarning?.setStrings(softwareRendererWarningStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
     updateHelpButtonLabel();
@@ -3031,16 +3046,24 @@ function initializeImmersiveScene(
     }
   };
 
+  const localeOptionIds: Locale[] = ['en', 'ja', 'ar', 'zh-Hans'];
+  if (
+    isI18nDebugEnabled({
+      search: window.location.search,
+      storage: localeStorage,
+    })
+  ) {
+    localeOptionIds.push('en-x-pseudo');
+  }
   const localeOptions: Array<{
     id: Locale;
     label: string;
     direction: 'ltr' | 'rtl';
-  }> = [
-    { id: 'en', label: 'English', direction: 'ltr' },
-    { id: 'ja', label: '日本語', direction: 'ltr' },
-    { id: 'ar', label: 'العربية', direction: 'rtl' },
-    { id: 'en-x-pseudo', label: 'Pseudo', direction: 'ltr' },
-  ];
+  }> = localeOptionIds.map((id) => ({
+    id,
+    label: localeToggleStrings.options[id],
+    direction: getLocaleDirection(id),
+  }));
 
   localeToggleControl = createLocaleToggleControl({
     container: hudSettingsStack,
@@ -3482,6 +3505,7 @@ function initializeImmersiveScene(
     tourGuideToggleControl = createTourGuideToggleControl({
       container: hudSettingsStack,
       initialEnabled: initialGuidedTourEnabled,
+      strings: tourGuideToggleStrings,
       onToggle: (enabled) => {
         guidedTourChannel?.setEnabled(enabled);
         writeGuidedTourEnabled(enabled);
@@ -3491,6 +3515,7 @@ function initializeImmersiveScene(
 
     tourResetControl = createTourResetControl({
       container: hudSettingsStack,
+      strings: tourResetControlStrings,
       subscribeVisited: (listener) => poiVisitedState.subscribe(listener),
       onReset: () => {
         poiVisitedState.reset();

--- a/src/systems/controls/localeToggleControl.ts
+++ b/src/systems/controls/localeToggleControl.ts
@@ -17,6 +17,10 @@ export interface LocaleToggleControlOptions {
   getActiveLocale: () => Locale;
   setActiveLocale: (locale: Locale) => void | Promise<void>;
   strings?: LocaleToggleResolvedStrings;
+  /** @deprecated Pass strings.title instead. */
+  title?: string;
+  /** @deprecated Pass strings.description instead. */
+  description?: string;
 }
 
 export interface LocaleToggleControlHandle {
@@ -41,6 +45,8 @@ export function createLocaleToggleControl({
   getActiveLocale,
   setActiveLocale,
   strings: providedStrings,
+  title,
+  description,
 }: LocaleToggleControlOptions): LocaleToggleControlHandle {
   if (!options.length) {
     throw new Error('Locale toggle requires at least one option.');
@@ -50,6 +56,8 @@ export function createLocaleToggleControl({
   let strings: LocaleToggleResolvedStrings = {
     ...DEFAULT_STRINGS,
     ...providedStrings,
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
   };
 
   const wrapper = document.createElement('section');
@@ -196,6 +204,9 @@ export function createLocaleToggleControl({
       heading.textContent = strings.title;
       descriptionParagraph.textContent = strings.description;
       optionsList.setAttribute('aria-label', strings.title);
+      buttons.forEach((button, locale) => {
+        button.textContent = strings.options[locale];
+      });
       updateActiveState();
     },
     refresh: updateActiveState,

--- a/src/systems/controls/tourGuideToggleControl.ts
+++ b/src/systems/controls/tourGuideToggleControl.ts
@@ -1,35 +1,32 @@
+import type { TourGuideToggleStrings } from '../../assets/i18n';
+import { getLocaleStrings } from '../../assets/i18n';
+
 export interface TourGuideToggleControlOptions {
   container: HTMLElement;
   initialEnabled?: boolean;
   onToggle?: (enabled: boolean) => void;
-  labelEnabled?: string;
-  labelDisabled?: string;
-  descriptionEnabled?: string;
-  descriptionDisabled?: string;
+  strings?: TourGuideToggleStrings;
 }
 
 export interface TourGuideToggleControlHandle {
   readonly element: HTMLButtonElement;
   setEnabled(enabled: boolean): void;
+  setStrings(strings: TourGuideToggleStrings): void;
   dispose(): void;
 }
-
-const defaultEnabledLabel = 'Guided tour on';
-const defaultDisabledLabel = 'Guided tour off';
-const defaultEnabledDescription =
-  'Highlights the next recommended exhibit in the immersive tour.';
-const defaultDisabledDescription =
-  'Guided tour highlights are hidden until you turn them back on.';
 
 export function createTourGuideToggleControl({
   container,
   initialEnabled = true,
   onToggle,
-  labelEnabled = defaultEnabledLabel,
-  labelDisabled = defaultDisabledLabel,
-  descriptionEnabled = defaultEnabledDescription,
-  descriptionDisabled = defaultDisabledDescription,
+  strings: providedStrings,
 }: TourGuideToggleControlOptions): TourGuideToggleControlHandle {
+  const defaultStrings = getLocaleStrings().hud.tourGuideToggle;
+  let strings: TourGuideToggleStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+  };
+
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'tour-toggle';
@@ -37,9 +34,10 @@ export function createTourGuideToggleControl({
 
   let enabled = Boolean(initialEnabled);
 
-  const getLabel = () => (enabled ? labelEnabled : labelDisabled);
+  const getLabel = () =>
+    enabled ? strings.labelEnabled : strings.labelDisabled;
   const getDescription = () =>
-    enabled ? descriptionEnabled : descriptionDisabled;
+    enabled ? strings.descriptionEnabled : strings.descriptionDisabled;
 
   const refresh = () => {
     const label = getLabel();
@@ -68,6 +66,10 @@ export function createTourGuideToggleControl({
         return;
       }
       enabled = next;
+      refresh();
+    },
+    setStrings(nextStrings) {
+      strings = { ...defaultStrings, ...nextStrings };
       refresh();
     },
     dispose() {

--- a/src/systems/controls/tourResetControl.ts
+++ b/src/systems/controls/tourResetControl.ts
@@ -1,3 +1,5 @@
+import { formatMessage, getLocaleStrings } from '../../assets/i18n';
+import type { TourResetControlStrings } from '../../assets/i18n';
 import type { PoiVisitedListener } from '../../scene/poi/visitedState';
 import {
   GuidedTourPreference,
@@ -19,19 +21,13 @@ export interface TourResetControlOptions {
   windowTarget?: Window;
   /** Single-character shortcut hint. */
   resetKey?: string;
-  label?: string;
-  description?: string;
-  emptyLabel?: string;
-  emptyDescription?: string;
-  pendingLabel?: string;
   guidedTourPreference?: GuidedTourPreference;
-  guidedTourDescription?: string;
-  guidedTourLabelOn?: string;
-  guidedTourLabelOff?: string;
+  strings?: TourResetControlStrings;
 }
 
 export interface TourResetControlHandle {
   readonly element: HTMLElement;
+  setStrings(strings: TourResetControlStrings): void;
   dispose(): void;
 }
 
@@ -63,16 +59,15 @@ export function createTourResetControl({
   onReset,
   windowTarget = window,
   resetKey = 'g',
-  label = 'Restart guided tour',
-  description = 'Clear visited POIs and replay the curated path.',
-  emptyLabel = 'Guided tour ready',
-  emptyDescription = 'Explore exhibits to unlock the guided tour reset.',
-  pendingLabel = 'Resetting tour…',
   guidedTourPreference = defaultGuidedTourPreference,
-  guidedTourDescription = 'Show recommended exhibits when idle.',
-  guidedTourLabelOn = 'Guided tour highlights: On',
-  guidedTourLabelOff = 'Guided tour highlights: Off',
+  strings: providedStrings,
 }: TourResetControlOptions): TourResetControlHandle {
+  const defaultStrings = getLocaleStrings().hud.tourReset;
+  let strings: TourResetControlStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+  };
+
   const wrapper = document.createElement('section');
   wrapper.className = 'guided-tour-control';
   wrapper.dataset.pending = 'false';
@@ -80,12 +75,12 @@ export function createTourResetControl({
 
   const heading = document.createElement('h2');
   heading.className = 'guided-tour-control__title';
-  heading.textContent = 'Guided tour';
+  heading.textContent = strings.heading;
   wrapper.appendChild(heading);
 
   const descriptionParagraph = document.createElement('p');
   descriptionParagraph.className = 'guided-tour-control__description';
-  descriptionParagraph.textContent = guidedTourDescription;
+  descriptionParagraph.textContent = strings.guidedTourDescription;
   wrapper.appendChild(descriptionParagraph);
 
   const toggleButton = document.createElement('button');
@@ -99,7 +94,7 @@ export function createTourResetControl({
   resetButton.type = 'button';
   resetButton.className = 'tour-reset';
   resetButton.dataset.state = 'empty';
-  resetButton.setAttribute('aria-label', description);
+  resetButton.setAttribute('aria-label', strings.description);
   resetButton.setAttribute('aria-busy', 'false');
   wrapper.appendChild(resetButton);
 
@@ -114,27 +109,26 @@ export function createTourResetControl({
 
   const normalizedResetKey = normalizeKey(resetKey);
 
-  const idleTitle = normalizedResetKey
-    ? `${label} (${normalizedResetKey})`
-    : label;
+  const buildIdleTitle = () =>
+    normalizedResetKey
+      ? `${strings.label} (${normalizedResetKey})`
+      : strings.label;
 
   let visitedCount = 0;
   let pending = false;
   let guidedTourEnabled = guidedTourPreference.isEnabled();
 
-  const buildToggleAnnouncement = (enabled: boolean) => {
-    const stateLabel = enabled ? 'enabled' : 'disabled';
-    return `Guided tour highlights ${stateLabel}. Activate to ${
-      enabled ? 'disable' : 'enable'
-    } recommendations.`;
-  };
+  const buildToggleAnnouncement = (enabled: boolean) =>
+    enabled
+      ? strings.guidedTourAnnouncementOn
+      : strings.guidedTourAnnouncementOff;
 
   const refreshToggle = () => {
     guidedTourEnabled = guidedTourPreference.isEnabled();
     toggleButton.dataset.state = guidedTourEnabled ? 'on' : 'off';
     toggleButton.textContent = guidedTourEnabled
-      ? guidedTourLabelOn
-      : guidedTourLabelOff;
+      ? strings.guidedTourLabelOn
+      : strings.guidedTourLabelOff;
     toggleButton.setAttribute(
       'aria-pressed',
       guidedTourEnabled ? 'true' : 'false'
@@ -142,8 +136,8 @@ export function createTourResetControl({
     toggleButton.dataset.hudAnnounce =
       buildToggleAnnouncement(guidedTourEnabled);
     toggleButton.title = guidedTourEnabled
-      ? 'Disable guided tour highlights'
-      : 'Enable guided tour highlights';
+      ? strings.guidedTourTitleOn
+      : strings.guidedTourTitleOff;
     wrapper.dataset.guidedTour = guidedTourEnabled ? 'on' : 'off';
   };
 
@@ -151,7 +145,10 @@ export function createTourResetControl({
     if (!includePrompt || !normalizedResetKey) {
       return message;
     }
-    return appendClause(message, `Press ${normalizedResetKey} to restart.`);
+    return appendClause(
+      message,
+      formatMessage(strings.restartPromptTemplate, { key: normalizedResetKey })
+    );
   };
 
   const refreshState = () => {
@@ -159,15 +156,15 @@ export function createTourResetControl({
     if (pending) {
       resetButton.disabled = true;
       resetButton.dataset.state = 'pending';
-      resetButton.textContent = pendingLabel;
-      resetButton.title = idleTitle;
+      resetButton.textContent = strings.pendingLabel;
+      resetButton.title = buildIdleTitle();
       resetButton.setAttribute(
         'aria-label',
-        appendClause(description, 'Resetting the guided tour…')
+        appendClause(strings.description, strings.pendingDescription)
       );
       resetButton.dataset.hudAnnounce = appendClause(
-        description,
-        'Resetting the guided tour…'
+        strings.description,
+        strings.pendingDescription
       );
       wrapper.dataset.pending = 'true';
       wrapper.setAttribute('aria-busy', 'true');
@@ -177,10 +174,10 @@ export function createTourResetControl({
     if (!hasVisited) {
       resetButton.disabled = true;
       resetButton.dataset.state = 'empty';
-      resetButton.textContent = emptyLabel;
-      resetButton.title = emptyDescription;
-      resetButton.setAttribute('aria-label', emptyDescription);
-      resetButton.dataset.hudAnnounce = emptyDescription;
+      resetButton.textContent = strings.emptyLabel;
+      resetButton.title = strings.emptyDescription;
+      resetButton.setAttribute('aria-label', strings.emptyDescription);
+      resetButton.dataset.hudAnnounce = strings.emptyDescription;
       wrapper.dataset.pending = 'false';
       wrapper.setAttribute('aria-busy', 'false');
       resetButton.setAttribute('aria-busy', 'false');
@@ -188,10 +185,13 @@ export function createTourResetControl({
     }
     resetButton.disabled = false;
     resetButton.dataset.state = 'ready';
-    resetButton.textContent = label;
-    resetButton.title = idleTitle;
-    resetButton.setAttribute('aria-label', description);
-    resetButton.dataset.hudAnnounce = buildHudAnnouncement(description, true);
+    resetButton.textContent = strings.label;
+    resetButton.title = buildIdleTitle();
+    resetButton.setAttribute('aria-label', strings.description);
+    resetButton.dataset.hudAnnounce = buildHudAnnouncement(
+      strings.description,
+      true
+    );
     wrapper.dataset.pending = 'false';
     wrapper.setAttribute('aria-busy', 'false');
     resetButton.setAttribute('aria-busy', 'false');
@@ -275,6 +275,13 @@ export function createTourResetControl({
 
   return {
     element: wrapper,
+    setStrings(nextStrings) {
+      strings = { ...defaultStrings, ...nextStrings };
+      heading.textContent = strings.heading;
+      descriptionParagraph.textContent = strings.guidedTourDescription;
+      refreshToggle();
+      refreshState();
+    },
     dispose() {
       resetButton.removeEventListener('click', handleClick);
       if (resetKey) {

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -6,6 +6,7 @@ import {
   getControlOverlayStrings,
   getHelpModalStrings,
   getLocaleDirection,
+  getLocaleStrings,
   getLocaleToggleStrings,
   getModeAnnouncerStrings,
   getModeToggleStrings,
@@ -14,6 +15,7 @@ import {
   getPoiOverlayChromeStrings,
   getPoiCopy,
   getSiteStrings,
+  isI18nDebugEnabled,
   resolveLocale,
 } from '../assets/i18n';
 import { getPoiDefinitions } from '../scene/poi/registry';
@@ -24,6 +26,7 @@ describe('i18n utilities', () => {
     expect(AVAILABLE_LOCALES).toContain('en-x-pseudo');
     expect(AVAILABLE_LOCALES).toContain('ar');
     expect(AVAILABLE_LOCALES).toContain('ja');
+    expect(AVAILABLE_LOCALES).toContain('zh-Hans');
   });
 
   it('normalizes locale inputs with region modifiers and pseudo identifiers', () => {
@@ -34,6 +37,8 @@ describe('i18n utilities', () => {
     expect(resolveLocale('en_x_pseudo')).toBe('en-x-pseudo');
     expect(resolveLocale('ar-EG')).toBe('ar');
     expect(resolveLocale('ja-JP')).toBe('ja');
+    expect(resolveLocale('zh-CN')).toBe('zh-Hans');
+    expect(resolveLocale('zh-Hans')).toBe('zh-Hans');
   });
 
   it('detects locale direction for RTL and LTR language inputs', () => {
@@ -50,6 +55,7 @@ describe('i18n utilities', () => {
     expect(getLocaleScript('en')).toBe('latin');
     expect(getLocaleScript('en-x-pseudo')).toBe('latin');
     expect(getLocaleScript('zh-CN')).toBe('cjk');
+    expect(getLocaleScript('zh-Hans')).toBe('cjk');
     expect(getLocaleScript('ja')).toBe('cjk');
     expect(getLocaleScript('ko-KR')).toBe('cjk');
     expect(getLocaleScript('ar')).toBe('rtl');
@@ -117,10 +123,12 @@ describe('i18n utilities', () => {
     const pseudoOverlay = getControlOverlayStrings('en-x-pseudo');
     const arabicOverlay = getControlOverlayStrings('ar');
     const japaneseOverlay = getControlOverlayStrings('ja');
+    const chineseOverlay = getControlOverlayStrings('zh-Hans');
     expect(englishOverlay.heading).toBe('Controls');
     expect(pseudoOverlay.heading).toBe('⟦Controls⟧');
     expect(arabicOverlay.heading).toBe('عناصر التحكم');
     expect(japaneseOverlay.heading).toBe('操作');
+    expect(chineseOverlay.heading).toBe('控制');
     expect(pseudoOverlay.items.keyboardMove.keys).toBe(
       englishOverlay.items.keyboardMove.keys
     );
@@ -135,6 +143,11 @@ describe('i18n utilities', () => {
     expect(arabicHelp.announcements.open).toBe(
       'تم فتح قائمة المساعدة. راجع عناصر التحكم والإعدادات.'
     );
+    const chineseHelp = getHelpModalStrings('zh-Hans');
+    expect(chineseHelp.heading).toBe('设置与帮助');
+    expect(chineseHelp.announcements.open).toBe(
+      '帮助菜单已打开。请查看控制和设置。'
+    );
     const japaneseHelp = getHelpModalStrings('ja');
     expect(japaneseHelp.heading).toBe('設定とヘルプ');
     expect(japaneseHelp.announcements.close).toBe(
@@ -147,6 +160,7 @@ describe('i18n utilities', () => {
     const pseudo = getPoiOverlayChromeStrings('en-x-pseudo');
     const arabic = getPoiOverlayChromeStrings('ar');
     const japanese = getPoiOverlayChromeStrings('ja');
+    const chinese = getPoiOverlayChromeStrings('zh-Hans');
 
     expect(english.closeDetails).toBe('Close POI details');
     expect(english.discoveryAnnouncementTemplate).toContain('{title}');
@@ -154,6 +168,7 @@ describe('i18n utilities', () => {
     expect(pseudo.relatedCaseStudies).toBe('⟦Related case studies⟧');
     expect(arabic.prototype).toBe('نموذج أولي');
     expect(japanese.nextHighlight).toBe('次のハイライト');
+    expect(chinese.closeDetails).toBe('关闭兴趣点详情');
   });
 
   it('returns localized mode toggle strings with formatted key hints', () => {
@@ -215,6 +230,11 @@ describe('i18n utilities', () => {
       'Unable to switch to {target}. Staying on {current} locale.'
     );
 
+    const chinese = getLocaleToggleStrings('zh-Hans');
+    expect(chinese.title).toBe('语言');
+    expect(chinese.options['zh-Hans']).toBe('简体中文');
+    expect(chinese.options['en-x-pseudo']).toBe('Pseudo');
+
     const pseudo = getLocaleToggleStrings('en-x-pseudo');
     expect(pseudo.title).toBe('⟦Language⟧');
     expect(pseudo.switchingAnnouncementTemplate).toBe(
@@ -260,6 +280,12 @@ describe('i18n utilities', () => {
       'تمت الزيارة في ٣:٣٠ م'
     );
 
+    const chinese = getPoiNarrativeLogStrings('zh-Hans');
+    expect(chinese.heading).toBe('创作者故事日志');
+    expect(formatMessage(chinese.visitedLabelTemplate, { time: '15:30' })).toBe(
+      '15:30 访问'
+    );
+
     const japanese = getPoiNarrativeLogStrings('ja');
     expect(japanese.heading).toBe('クリエイターストーリーログ');
     expect(
@@ -272,6 +298,11 @@ describe('i18n utilities', () => {
     expect(copy['futuroptimist-living-room-tv'].title).toMatch(/Futuroptimist/);
     expect(copy['dspace-backyard-rocket'].metrics?.length).toBeGreaterThan(0);
 
+    const chineseCopy = getPoiCopy('zh-Hans');
+    expect(chineseCopy['futuroptimist-living-room-tv'].summary).toContain(
+      '脚本工作台'
+    );
+
     const pseudoCopy = getPoiCopy('en-x-pseudo');
     expect(pseudoCopy['futuroptimist-living-room-tv'].title).toBe(
       '⟦Futuroptimist⟧'
@@ -282,6 +313,64 @@ describe('i18n utilities', () => {
     expect(pseudoCopy['tokenplace-studio-cluster'].title).toBe(
       copy['tokenplace-studio-cluster'].title
     );
+  });
+
+  it('keeps visible locale catalogs structurally complete', () => {
+    const english = getLocaleStrings('en');
+    const assertNoMissingStrings = (value: unknown, path: string): void => {
+      if (typeof value === 'string') {
+        expect(value.trim(), path).not.toBe('');
+        return;
+      }
+      if (Array.isArray(value)) {
+        value.forEach((item, index) =>
+          assertNoMissingStrings(item, `${path}[${index}]`)
+        );
+        return;
+      }
+      if (value && typeof value === 'object') {
+        Object.entries(value as Record<string, unknown>).forEach(
+          ([key, nested]) => {
+            assertNoMissingStrings(nested, `${path}.${key}`);
+          }
+        );
+      }
+    };
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const strings = getLocaleStrings(locale);
+      expect(Object.keys(strings.poi).sort()).toEqual(
+        Object.keys(english.poi).sort()
+      );
+      assertNoMissingStrings(strings.hud, `${locale}.hud`);
+      assertNoMissingStrings(
+        strings.site.textFallback,
+        `${locale}.site.textFallback`
+      );
+    }
+  });
+
+  it('gates pseudo-locale visibility behind explicit i18n debug mode', () => {
+    expect(
+      isI18nDebugEnabled({ isDev: false, search: '', storage: null })
+    ).toBe(false);
+    expect(isI18nDebugEnabled({ isDev: true, search: '', storage: null })).toBe(
+      true
+    );
+    expect(
+      isI18nDebugEnabled({
+        isDev: false,
+        search: '?i18nDebug=1',
+        storage: null,
+      })
+    ).toBe(true);
+    expect(
+      isI18nDebugEnabled({
+        isDev: false,
+        search: '',
+        storage: { getItem: () => 'true' },
+      })
+    ).toBe(true);
   });
 
   it('falls back to English site metadata when pseudo overrides omit values', () => {

--- a/src/tests/textFallbackAccessibility.test.ts
+++ b/src/tests/textFallbackAccessibility.test.ts
@@ -104,6 +104,25 @@ describe('text fallback accessibility', () => {
     });
   }
 
+  it('renders Mandarin Chinese text fallback CTA and lang metadata', () => {
+    const container = document.createElement('div');
+    document.documentElement.lang = 'zh-Hans';
+
+    renderTextFallback(container, {
+      reason: 'manual',
+      immersiveUrl: 'https://danielsmith.io/immersive',
+    });
+
+    expect(document.documentElement.lang).toBe('zh-Hans');
+    expect(document.documentElement.dataset.localeScript).toBe('cjk');
+    expect(
+      container.querySelector('.text-fallback__recovery-title')?.textContent
+    ).toBe('准备进入完整房间了吗？');
+    expect(
+      container.querySelector('.text-fallback__primary-action')?.textContent
+    ).toBe('再次尝试沉浸模式');
+  });
+
   it('normalizes provided immersive URLs without disabling failover for normal recovery', () => {
     const container = document.createElement('div');
 

--- a/src/ui/softwareRendererWarning.ts
+++ b/src/ui/softwareRendererWarning.ts
@@ -1,3 +1,5 @@
+import { formatMessage, getLocaleStrings } from '../assets/i18n';
+import type { SoftwareRendererWarningStrings } from '../assets/i18n';
 import type { RendererInfoSnapshot } from '../scene/performance/rendererCapabilities';
 
 export interface SoftwareRendererWarningOptions {
@@ -7,17 +9,22 @@ export interface SoftwareRendererWarningOptions {
   textUrl: string;
   onContinueSafe?: () => void;
   onVisible?: (message: string) => void;
+  strings?: SoftwareRendererWarningStrings;
 }
 
 export interface SoftwareRendererWarningHandle {
   element: HTMLElement;
+  setStrings(strings: SoftwareRendererWarningStrings): void;
   dispose(): void;
 }
 
-const rendererLabel = (rendererInfo: RendererInfoSnapshot) =>
+const rendererLabel = (
+  rendererInfo: RendererInfoSnapshot,
+  fallbackRendererLabel: string
+) =>
   rendererInfo.unmaskedRenderer ??
   rendererInfo.renderer ??
-  'software WebGL renderer';
+  fallbackRendererLabel;
 
 export function createSoftwareRendererWarning({
   rendererInfo,
@@ -26,7 +33,12 @@ export function createSoftwareRendererWarning({
   textUrl,
   onContinueSafe,
   onVisible,
+  strings: providedStrings,
 }: SoftwareRendererWarningOptions): SoftwareRendererWarningHandle {
+  let strings = {
+    ...getLocaleStrings().hud.softwareRendererWarning,
+    ...providedStrings,
+  };
   const documentTarget = document;
   const element = documentTarget.createElement('aside');
   element.className = 'software-renderer-warning';
@@ -40,21 +52,19 @@ export function createSoftwareRendererWarning({
 
   const title = documentTarget.createElement('h2');
   title.className = 'software-renderer-warning__title';
-  title.textContent = 'Software rendering detected';
+  title.textContent = strings.title;
   element.appendChild(title);
 
   const description = documentTarget.createElement('p');
   description.className = 'software-renderer-warning__description';
-  description.textContent =
-    `Chrome is using ${rendererLabel(rendererInfo)} instead of hardware acceleration. ` +
-    'Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.';
+  description.textContent = formatMessage(strings.descriptionTemplate, {
+    renderer: rendererLabel(rendererInfo, strings.fallbackRendererLabel),
+  });
   element.appendChild(description);
 
   const recommendation = documentTarget.createElement('p');
   recommendation.className = 'software-renderer-warning__recommendation';
-  recommendation.textContent =
-    'Enable browser hardware acceleration for the smooth immersive portfolio. ' +
-    'Safe immersive mode keeps screenshots and debugging available at a capped frame rate.';
+  recommendation.textContent = strings.recommendation;
   element.appendChild(recommendation);
 
   const actions = documentTarget.createElement('div');
@@ -64,7 +74,7 @@ export function createSoftwareRendererWarning({
   safeButton.type = 'button';
   safeButton.className = 'software-renderer-warning__button';
   safeButton.dataset.action = 'continue-safe-immersive';
-  safeButton.textContent = 'Continue in safe immersive';
+  safeButton.textContent = strings.continueSafeLabel;
   safeButton.addEventListener('click', () => {
     dispose();
     onContinueSafe?.();
@@ -75,7 +85,7 @@ export function createSoftwareRendererWarning({
   continuousLink.className = 'software-renderer-warning__link';
   continuousLink.dataset.action = 'continuous-immersive';
   continuousLink.href = continuousUrl;
-  continuousLink.textContent = 'Enable continuous immersive anyway';
+  continuousLink.textContent = strings.continuousLabel;
   actions.appendChild(continuousLink);
 
   const textLink = documentTarget.createElement('a');
@@ -83,21 +93,41 @@ export function createSoftwareRendererWarning({
     'software-renderer-warning__link software-renderer-warning__link--muted';
   textLink.dataset.action = 'text-mode';
   textLink.href = textUrl;
-  textLink.textContent = 'Use text mode';
+  textLink.textContent = strings.textModeLabel;
   actions.appendChild(textLink);
 
   const safeLink = documentTarget.createElement('a');
   safeLink.className = 'software-renderer-warning__safe-link';
   safeLink.href = safeUrl;
-  safeLink.textContent = 'Reload this safe immersive URL';
+  safeLink.textContent = strings.safeUrlLabel;
   element.appendChild(actions);
   element.appendChild(safeLink);
 
+  const applyStrings = () => {
+    title.textContent = strings.title;
+    description.textContent = formatMessage(strings.descriptionTemplate, {
+      renderer: rendererLabel(rendererInfo, strings.fallbackRendererLabel),
+    });
+    recommendation.textContent = strings.recommendation;
+    safeButton.textContent = strings.continueSafeLabel;
+    continuousLink.textContent = strings.continuousLabel;
+    textLink.textContent = strings.textModeLabel;
+    safeLink.textContent = strings.safeUrlLabel;
+  };
+
+  applyStrings();
   documentTarget.body.appendChild(element);
-  onVisible?.(description.textContent ?? 'Software rendering detected');
+  onVisible?.(description.textContent ?? strings.title);
 
   return {
     element,
+    setStrings(nextStrings) {
+      strings = {
+        ...getLocaleStrings().hud.softwareRendererWarning,
+        ...nextStrings,
+      };
+      applyStrings();
+    },
     dispose,
   };
 }


### PR DESCRIPTION
### Motivation
- Treat English as the i18n baseline and add Simplified Mandarin (`zh-Hans`) as a first-class locale so the HUD, Settings, POIs, and text fallback are fully localizable.
- Remove visible hard-coded English strings from HUD, guided-tour, tour-reset, and software-renderer warning surfaces so runtime locale switches update every visible UI text.
- Keep the pseudo (`en-x-pseudo`) locale available for QA while hiding it from normal users behind an explicit i18n debug gate.

### Description
- Added `zh-Hans` to the `Locale` type, locale resolution, catalog, and a full `src/assets/i18n/locales/zh-Hans.ts` overrides file containing site text fallback, HUD, audio, mode/tour controls, POI copy, and software-renderer warning strings.
- Extended `LocaleStrings`/types with typed groups for `tourGuideToggle`, `tourReset`, and `softwareRendererWarning`, and updated English + pseudo locale entries accordingly.
- Refactored controls to consume typed locale strings and support runtime refresh via `setStrings(...)` for `tourGuideToggle`, `tourReset`, `localeToggle`, and `softwareRendererWarning` and wired `applyLocaleUpdate()` to refresh all affected components.
- Added an i18n debug gate (`isI18nDebugEnabled`) that exposes the pseudo-locale only in DEV, when `?i18nDebug=1` is present, or when `localStorage.getItem('danielsmith:i18n-debug')` is truthy; Settings language picker now shows `zh-Hans` and uses locale labels from locale files.

### Testing
- Ran formatting: `npm run format:write` — succeeded.
- Lint: `npm run lint` — succeeded (no lint errors reported).
- Focused tests: `npm run test:ci -- src/tests/i18n.test.ts src/tests/textFallbackAccessibility.test.ts src/tests/localeToggleControl.test.ts src/tests/tourGuideToggleControl.test.ts src/tests/tourResetControl.test.ts` — all specified tests passed.
- Full test suite: `npm run test:ci` — all tests passed (132 files, 933 tests in the environment where run).
- Build and sanity checks: `npm run build`, `npm run docs:check`, and `npm run smoke` — build and smoke checks succeeded and produced a valid `dist`.
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.
- Typecheck: `npm run typecheck` — did not pass; this exposed existing repository-wide type issues unrelated to this change (notably imports and test/mock type mismatches in areas outside the i18n work such as `src/scene/environments/backyard.ts` and several test stubs). This PR did not relax type rules; follow-ups should address those unrelated TS errors.

Notes / follow-ups: the PR focuses strictly on i18n/localization wiring, typed strings, and test coverage for visible UI copy; CI typecheck failures originate from pre-existing repository typing gaps and should be handled in a separate targeted cleanup change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1facbb991c832fbec68929cc82d057)