### PR TITLE
Add Simplified Chinese (zh-Hans) locale and complete UI i18n coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,10 @@ Launch screenshot workflow refresh and commit it after merge.
 - **Localization** – UI chrome and POI copy are centralized in `src/assets/i18n/index.ts`, letting future
   locales load structured strings while keeping Vitest coverage in
   `src/tests/i18n.test.ts` to guard against regressions. HUD overlays and the
-  text fallback now tag their containers with locale direction metadata so RTL
-  languages flow correctly even before full translations land.
+  text fallback now tag their containers with locale direction/script metadata so RTL
+  and CJK languages flow correctly. The internal pseudo-locale stays hidden from
+  public settings unless Vite dev mode, `?i18nDebug=1`, or
+  `localStorage['danielsmith.io:i18n-debug']='true'` explicitly enables i18n debug mode.
 - **Audio captions** – A subtitles overlay now calls out ambient beds and POI narration with
   cooldown-aware timing so visitors who mute audio or rely on captions still catch the
   story beats.

--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -4,6 +4,7 @@ import { AR_OVERRIDES } from './locales/ar';
 import { EN_LOCALE_STRINGS } from './locales/en';
 import { EN_X_PSEUDO_OVERRIDES } from './locales/en-x-pseudo';
 import { JA_OVERRIDES } from './locales/ja';
+import { ZH_HANS_OVERRIDES } from './locales/zh-Hans';
 import type {
   AudioHudControlStrings,
   ControlOverlayStrings,
@@ -24,6 +25,9 @@ import type {
   PoiOverlayChromeStrings,
   HudCustomizationStrings,
   SiteStrings,
+  SoftwareRendererWarningStrings,
+  TourGuideToggleStrings,
+  TourResetStrings,
 } from './types';
 
 export type LocaleToggleResolvedStrings = LocaleToggleStrings;
@@ -103,17 +107,51 @@ const MERGED_PSEUDO = buildLocale(
 
 const AR_LOCALE = buildLocale(EN_LOCALE_STRINGS, AR_OVERRIDES, 'ar');
 const JA_LOCALE = buildLocale(EN_LOCALE_STRINGS, JA_OVERRIDES, 'ja');
+const ZH_HANS_LOCALE = buildLocale(
+  EN_LOCALE_STRINGS,
+  ZH_HANS_OVERRIDES,
+  'zh-Hans'
+);
 
 const localeCatalog: Record<Locale, LocaleStrings> = Object.freeze({
   en: Object.freeze(cloneValue(EN_LOCALE_STRINGS)),
   'en-x-pseudo': MERGED_PSEUDO,
   ar: AR_LOCALE,
   ja: JA_LOCALE,
+  'zh-Hans': ZH_HANS_LOCALE,
 });
 
 export const AVAILABLE_LOCALES = Object.freeze(
   Object.keys(localeCatalog) as ReadonlyArray<Locale>
 );
+
+export const I18N_DEBUG_STORAGE_KEY = 'danielsmith.io:i18n-debug';
+
+export function isI18nDebugEnabled({
+  dev = false,
+  search = '',
+  storage,
+}: {
+  dev?: boolean;
+  search?: string;
+  storage?: Pick<Storage, 'getItem'> | null;
+} = {}): boolean {
+  if (dev) {
+    return true;
+  }
+  const params = new URLSearchParams(
+    search.startsWith('?') ? search : `?${search}`
+  );
+  if (params.get('i18nDebug') === '1') {
+    return true;
+  }
+  try {
+    const stored = storage?.getItem(I18N_DEBUG_STORAGE_KEY);
+    return stored === '1' || stored === 'true';
+  } catch {
+    return false;
+  }
+}
 
 function normalizeLocaleInput(input: LocaleInput): string {
   if (!input) {
@@ -143,6 +181,15 @@ export function resolveLocale(input: LocaleInput): Locale {
 
   if (normalized.startsWith('ja')) {
     return 'ja';
+  }
+
+  if (
+    normalized === 'zh-hans' ||
+    normalized === 'zh-cn' ||
+    normalized === 'zh-sg' ||
+    normalized.startsWith('zh')
+  ) {
+    return 'zh-Hans';
   }
 
   return 'en';
@@ -274,6 +321,22 @@ export function getHudCustomizationStrings(
   input?: LocaleInput
 ): HudCustomizationStrings {
   return getLocaleStrings(input).hud.customization;
+}
+
+export function getTourGuideToggleStrings(
+  input?: LocaleInput
+): TourGuideToggleStrings {
+  return getLocaleStrings(input).hud.tourGuideToggle;
+}
+
+export function getTourResetStrings(input?: LocaleInput): TourResetStrings {
+  return getLocaleStrings(input).hud.tourReset;
+}
+
+export function getSoftwareRendererWarningStrings(
+  input?: LocaleInput
+): SoftwareRendererWarningStrings {
+  return getLocaleStrings(input).hud.softwareRendererWarning;
 }
 
 export function getModeToggleStrings(

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -292,6 +292,54 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Unable to switch to {target}. Staying on {current} locale.'
       ),
     },
+    tourGuideToggle: {
+      labelEnabled: wrap('Guided tour on'),
+      labelDisabled: wrap('Guided tour off'),
+      descriptionEnabled: wrap(
+        'Highlights the next recommended exhibit in the immersive tour.'
+      ),
+      descriptionDisabled: wrap(
+        'Guided tour highlights are hidden until you turn them back on.'
+      ),
+    },
+    tourReset: {
+      heading: wrap('Guided tour'),
+      resetKey: 'g',
+      label: wrap('Restart guided tour'),
+      description: wrap('Clear visited POIs and replay the curated path.'),
+      emptyLabel: wrap('Guided tour ready'),
+      emptyDescription: wrap(
+        'Explore exhibits to unlock the guided tour reset.'
+      ),
+      pendingLabel: wrap('Resetting tour…'),
+      pendingDescription: wrap('Resetting the guided tour…'),
+      restartPromptTemplate: wrap('Press {key} to restart.'),
+      guidedTourDescription: wrap('Show recommended exhibits when idle.'),
+      guidedTourLabelOn: wrap('Guided tour highlights: On'),
+      guidedTourLabelOff: wrap('Guided tour highlights: Off'),
+      toggleAnnouncementOn: wrap(
+        'Guided tour highlights enabled. Activate to disable recommendations.'
+      ),
+      toggleAnnouncementOff: wrap(
+        'Guided tour highlights disabled. Activate to enable recommendations.'
+      ),
+      toggleTitleOn: wrap('Disable guided tour highlights'),
+      toggleTitleOff: wrap('Enable guided tour highlights'),
+    },
+    softwareRendererWarning: {
+      title: wrap('Software rendering detected'),
+      rendererFallbackLabel: wrap('software WebGL renderer'),
+      descriptionTemplate: wrap(
+        'Chrome is using {renderer} instead of hardware acceleration. Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.'
+      ),
+      recommendation: wrap(
+        'Enable browser hardware acceleration for the smooth immersive portfolio. Safe immersive mode keeps screenshots and debugging available at a capped frame rate.'
+      ),
+      continueSafeLabel: wrap('Continue in safe immersive'),
+      continuousLabel: wrap('Enable continuous immersive anyway'),
+      textModeLabel: wrap('Use text mode'),
+      safeUrlLabel: wrap('Reload this safe immersive URL'),
+    },
     modeToggle: {
       keyHint: 'T',
       idleLabelTemplate: wrap('Text mode · Press {keyHint}'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -298,6 +298,46 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       failureAnnouncementTemplate:
         'Unable to switch to {target}. Staying on {current} locale.',
     },
+    tourGuideToggle: {
+      labelEnabled: 'Guided tour on',
+      labelDisabled: 'Guided tour off',
+      descriptionEnabled:
+        'Highlights the next recommended exhibit in the immersive tour.',
+      descriptionDisabled:
+        'Guided tour highlights are hidden until you turn them back on.',
+    },
+    tourReset: {
+      heading: 'Guided tour',
+      resetKey: 'g',
+      label: 'Restart guided tour',
+      description: 'Clear visited POIs and replay the curated path.',
+      emptyLabel: 'Guided tour ready',
+      emptyDescription: 'Explore exhibits to unlock the guided tour reset.',
+      pendingLabel: 'Resetting tour…',
+      pendingDescription: 'Resetting the guided tour…',
+      restartPromptTemplate: 'Press {key} to restart.',
+      guidedTourDescription: 'Show recommended exhibits when idle.',
+      guidedTourLabelOn: 'Guided tour highlights: On',
+      guidedTourLabelOff: 'Guided tour highlights: Off',
+      toggleAnnouncementOn:
+        'Guided tour highlights enabled. Activate to disable recommendations.',
+      toggleAnnouncementOff:
+        'Guided tour highlights disabled. Activate to enable recommendations.',
+      toggleTitleOn: 'Disable guided tour highlights',
+      toggleTitleOff: 'Enable guided tour highlights',
+    },
+    softwareRendererWarning: {
+      title: 'Software rendering detected',
+      rendererFallbackLabel: 'software WebGL renderer',
+      descriptionTemplate:
+        'Chrome is using {renderer} instead of hardware acceleration. Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.',
+      recommendation:
+        'Enable browser hardware acceleration for the smooth immersive portfolio. Safe immersive mode keeps screenshots and debugging available at a capped frame rate.',
+      continueSafeLabel: 'Continue in safe immersive',
+      continuousLabel: 'Enable continuous immersive anyway',
+      textModeLabel: 'Use text mode',
+      safeUrlLabel: 'Reload this safe immersive URL',
+    },
     modeToggle: {
       keyHint: 'T',
       idleLabelTemplate: 'Text mode · Press {keyHint}',

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -1,0 +1,496 @@
+import type { LocaleOverrides } from '../types';
+
+export const ZH_HANS_OVERRIDES: LocaleOverrides = {
+  locale: 'zh-Hans',
+  site: {
+    name: 'Daniel Smith 沉浸式作品集',
+    structuredData: {
+      description: 'Daniel Smith 沉浸式作品集中的互动项目展品。',
+      listNameTemplate: '{siteName} 展品',
+      textCollectionNameTemplate: '{siteName} 文字作品集',
+      textCollectionDescription:
+        '快速加载每个沉浸式展品的摘要、成果和指标，便于无障碍阅读和爬虫预览。',
+      immersiveActionName: '启动沉浸模式',
+      properties: {
+        labels: { category: '类别', outcome: '成果', status: '状态' },
+        categories: { project: '项目', environment: '环境' },
+        statuses: { prototype: '原型', live: '已上线' },
+      },
+    },
+    textFallback: {
+      heading: '浏览亮点',
+      intro: '当沉浸模式不可用时，文字作品集仍提供每个展品的摘要、成果和指标。',
+      roomHeadingTemplate: '{roomName} 展品',
+      metricsHeading: '关键指标',
+      linksHeading: '继续阅读',
+      about: {
+        heading: '关于 Daniel',
+        summary:
+          '网站可靠性工程师，曾在 YouTube 工作六年，专注自动化、可观测性和稳定发布。',
+        highlights: [
+          '构建开发者平台和智能体工具，让团队更安全、更快速地交付。',
+          '指导团队实践 SLO、事故响应和可靠性评审。',
+          '探索沉浸式 WebGL 叙事，并始终保留无障碍文字回退。',
+        ],
+      },
+      skills: {
+        heading: '技能概览',
+        items: [
+          {
+            label: '语言',
+            value:
+              'Python、Go、SQL、C++、TypeScript/JavaScript、Ruby、Objective-C',
+          },
+          {
+            label: '基础设施与工具',
+            value:
+              'Kubernetes、Docker、Google Cloud (BigQuery)、GitHub Actions、WebGL/Three.js、React/Next.js、Astro',
+          },
+          {
+            label: '实践',
+            value:
+              'SRE（SLO、事故响应、容量）、可观测性、CI/CD、测试、提示文档和智能体编程',
+          },
+        ],
+      },
+      timeline: {
+        heading: '工作时间线',
+        entries: [
+          {
+            period: '2018 年 9 月 — 2025 年 5 月',
+            location: '加州圣布鲁诺',
+            role: '网站可靠性工程师（L4）',
+            org: 'YouTube (Google)',
+            summary:
+              '负责多个产品面的值班，用 Python/Go/SQL/C++ 自动化监控，并为领导层推动可靠性评审。',
+          },
+          {
+            period: '2017 年 1 月 — 2018 年 9 月',
+            location: '密西西比州斯坦尼斯航天中心',
+            role: '软件工程师',
+            org: '海军研究实验室',
+            summary: '在 Scrum 冲刺中交付 C++/Qt 数据处理应用和远程演示。',
+          },
+          {
+            period: '2014 年 3 月 — 2016 年 12 月',
+            location: '密西西比州哈蒂斯堡',
+            role: '软件开发者',
+            org: '南密西西比大学',
+            summary: '为大学 iOS 应用构建实时内容投放的 Objective-C 框架。',
+          },
+        ],
+      },
+      contact: {
+        heading: '联系',
+        emailLabel: '邮箱',
+        githubLabel: 'GitHub',
+        resumeLabel: '简历（PDF）',
+      },
+      recoveryCta: {
+        title: '准备进入完整房间？',
+        description: '清除已保存的文字模式偏好，并从这里重新启动沉浸式作品集。',
+        actionLabel: '再次尝试沉浸模式',
+        ariaLabel: '再次尝试沉浸模式，并清除已保存的文字模式偏好',
+      },
+      actions: {
+        immersiveLink: '再次尝试沉浸模式',
+        debugImmersiveLink: '调试：强制沉浸模式',
+        clearPreferenceButton: '清除已保存的模式偏好',
+        clearPreferenceSuccess: '已清除保存的模式偏好',
+        resumeLink: '下载最新简历',
+        githubLink: '在 GitHub 浏览项目',
+      },
+      reasonHeadings: {
+        manual: '已启用纯文字模式',
+        'webgl-unsupported': '此设备无法使用沉浸模式',
+        'low-memory': '检测到低内存设备',
+        'low-end-device': '检测到轻量设备',
+        'low-performance': '性能回退已启用',
+        'immersive-init-error': '沉浸式场景遇到错误',
+        'automated-client': '检测到自动化客户端',
+        'data-saver': '已启用省流量模式',
+        'console-error': '检测到运行时错误',
+      },
+      reasonDescriptions: {
+        manual: '你选择了轻量作品集视图。沉浸式场景仍可一键返回。',
+        'webgl-unsupported':
+          '你的浏览器或设备无法启动 WebGL 渲染器。请先阅读快速文字概览。',
+        'low-memory': '设备报告内存有限，因此已启动轻量文字导览以保持流畅。',
+        'low-end-device': '检测到轻量设备配置，因此已加载快速文字导览。',
+        'low-performance': '检测到持续低帧率，因此切换到响应更快的文字导览。',
+        'immersive-init-error': '启动沉浸式场景时出错，因此改为显示文字概览。',
+        'automated-client':
+          '检测到自动化客户端，因此显示便于预览和爬虫读取的文字作品集。',
+        'data-saver': '浏览器请求省流量体验，因此加载轻量文字导览以降低带宽。',
+        'console-error':
+          '检测到运行时错误，已切换到稳定的文字导览等待沉浸场景恢复。',
+      },
+    },
+  },
+  hud: {
+    controlOverlay: {
+      heading: '控制',
+      items: {
+        keyboardMove: { keys: 'WASD / 方向键', description: '移动' },
+        pointerDrag: { keys: '鼠标左键', description: '拖动平移' },
+        pointerZoom: { keys: '滚轮', description: '缩放' },
+        touchDrag: { keys: '触控', description: '左半区移动，右半区平移' },
+        touchPinch: { keys: '双指捏合', description: '缩放' },
+        cyclePoi: { keys: 'Q / E', description: '切换兴趣点' },
+        toggleTextMode: { keys: 'T', description: '切换到文字模式' },
+      },
+      interact: {
+        defaultLabel: 'Enter',
+        description: '互动',
+        promptTemplates: {
+          default: '与 {title} 互动',
+          inspect: '查看 {title}',
+          activate: '启动 {title}',
+        },
+      },
+      helpButton: {
+        labelTemplate: '打开菜单 · 按 {shortcut}',
+        announcementTemplate:
+          '打开设置和帮助。按 {shortcut} 查看控制和无障碍提示。',
+        shortcutFallback: 'H',
+      },
+      menu: {
+        controls: { label: '控制', keyHint: 'C', title: '打开控制（C）' },
+        text: { label: '文字', keyHint: 'T', title: '切换到文字模式（T）' },
+        settings: { label: '设置', keyHint: 'H', title: '打开设置和帮助（H）' },
+      },
+      mobileToggle: {
+        expandLabel: '显示全部控制',
+        collapseLabel: '隐藏额外控制',
+        expandAnnouncement: '正在为移动玩家显示完整控制列表。',
+        collapseAnnouncement: '正在隐藏额外控制，让列表保持简洁。',
+      },
+    },
+    movementLegend: {
+      defaultDescription: '互动',
+      labels: {
+        keyboard: 'Enter',
+        pointer: '点击',
+        touch: '轻点',
+        gamepad: 'A',
+      },
+      interactPromptTemplates: {
+        default: '{prompt}',
+        keyboard: '按 {label} {prompt}',
+        pointer: '{label}{prompt}',
+        touch: '{label}{prompt}',
+        gamepad: '按 {label} {prompt}',
+      },
+    },
+    customization: {
+      heading: '自定义',
+      description: '为当前任务调整人偶风格和伙伴装备。',
+      variants: { title: '头像风格', description: '切换探索者人偶的服装。' },
+      accessories: {
+        title: '配件',
+        description: '切换腕部控制台或全息无人机伙伴。',
+      },
+    },
+    audioControl: {
+      keyHint: 'M',
+      groupLabel: '环境音频控制',
+      toggle: {
+        onLabelTemplate: '音频：开 · 按 {keyHint} 静音',
+        offLabelTemplate: '音频：关 · 按 {keyHint} 取消静音',
+        titleTemplate: '切换环境音频（{keyHint}）',
+        announcementOnTemplate: '环境音频已开启。按 {keyHint} 切换。',
+        announcementOffTemplate: '环境音频已关闭。按 {keyHint} 切换。',
+        pendingAnnouncementTemplate: '正在切换环境音频状态，请稍候…',
+      },
+      slider: {
+        label: '环境音量',
+        ariaLabel: '环境音频音量',
+        hudLabel: '环境音频音量滑块。',
+        valueAnnouncementTemplate: '环境音频音量 {volume}。',
+        mutedAnnouncementTemplate: '环境音频已静音。音量设为 {volume}。',
+        mutedValueTemplate: '已静音 · {volume}',
+        mutedAriaValueTemplate: '已静音（{volume}）',
+      },
+    },
+    localeToggle: {
+      title: '语言',
+      description: '切换 HUD 语言和文字方向。',
+      switchingAnnouncementTemplate: '正在切换到 {target} 语言…',
+      selectedAnnouncementTemplate: '已选择 {label}。',
+      failureAnnouncementTemplate: '无法切换到 {target}。仍停留在 {current}。',
+    },
+    tourGuideToggle: {
+      labelEnabled: '导览已开启',
+      labelDisabled: '导览已关闭',
+      descriptionEnabled: '在沉浸式导览中高亮下一个推荐展品。',
+      descriptionDisabled: '导览高亮已隐藏，直到你重新开启。',
+    },
+    tourReset: {
+      heading: '引导导览',
+      resetKey: 'g',
+      label: '重新开始引导导览',
+      description: '清除已访问的兴趣点并重播精选路径。',
+      emptyLabel: '引导导览已就绪',
+      emptyDescription: '探索展品后即可解锁导览重置。',
+      pendingLabel: '正在重置导览…',
+      pendingDescription: '正在重置引导导览…',
+      restartPromptTemplate: '按 {key} 重新开始。',
+      guidedTourDescription: '空闲时显示推荐展品。',
+      guidedTourLabelOn: '导览高亮：开',
+      guidedTourLabelOff: '导览高亮：关',
+      toggleAnnouncementOn: '导览高亮已启用。激活可关闭推荐。',
+      toggleAnnouncementOff: '导览高亮已停用。激活可启用推荐。',
+      toggleTitleOn: '关闭导览高亮',
+      toggleTitleOff: '开启导览高亮',
+    },
+    softwareRendererWarning: {
+      title: '检测到软件渲染',
+      rendererFallbackLabel: '软件 WebGL 渲染器',
+      descriptionTemplate:
+        'Chrome 正在使用 {renderer}，而不是硬件加速。Basic Render Driver、SwiftShader、WARP 和 llvmpipe 可能会在连续 WebGL 动画下崩溃。',
+      recommendation:
+        '请启用浏览器硬件加速以获得流畅的沉浸式作品集。安全沉浸模式会限制帧率，同时保留截图和调试能力。',
+      continueSafeLabel: '继续使用安全沉浸模式',
+      continuousLabel: '仍然启用连续沉浸模式',
+      textModeLabel: '使用文字模式',
+      safeUrlLabel: '重新加载此安全沉浸链接',
+    },
+    modeToggle: {
+      keyHint: 'T',
+      idleLabelTemplate: '文字模式 · 按 {keyHint}',
+      idleDescriptionTemplate: '切换到纯文字作品集',
+      idleAnnouncementTemplate: '切换到纯文字作品集。按 {keyHint} 激活。',
+      idleTitleTemplate: '切换到纯文字作品集（{keyHint}）',
+      pendingLabelTemplate: '正在切换到文字模式…',
+      pendingAnnouncementTemplate: '切换到纯文字作品集。正在切换到文字模式…',
+      activeLabelTemplate: '再次尝试沉浸模式 · 按 {keyHint}',
+      activeDescriptionTemplate: '返回沉浸式作品集。',
+      activeAnnouncementTemplate:
+        '文字模式已启用。按 {keyHint} 再次尝试沉浸模式。',
+      errorLabelTemplate: '重试文字模式 · 按 {keyHint}',
+      errorDescriptionTemplate: '文字模式切换失败。请重试或使用沉浸链接。',
+      errorAnnouncementTemplate: '文字模式切换失败。按 {keyHint} 重试。',
+      errorTitleTemplate: '文字模式切换失败。按 {keyHint} 重试文字模式。',
+    },
+    poiOverlay: {
+      visited: '已访问',
+      nextHighlight: '下一个亮点',
+      prototype: '原型',
+      live: '已上线',
+      closeDetails: '关闭兴趣点详情',
+      relatedCaseStudies: '相关案例研究',
+      outcomeFallbackLabel: '成果',
+      discoveryAnnouncementTemplate: '已发现 {title}。{summary}',
+    },
+    narrativeLog: {
+      heading: '创作者故事日志',
+      visitedHeading: '已访问展品',
+      empty: '靠近展品即可把它们加入故事日志。',
+      defaultVisitedLabel: '已访问',
+      visitedLabelTemplate: '访问时间 {time}',
+      liveAnnouncementTemplate: '{title} 已加入创作者故事日志。',
+      journey: {
+        heading: '旅程提示',
+        empty: '探索新的展品来编织旅程叙事。',
+        entryLabelTemplate: '{from} 到 {to}',
+        sameRoomTemplate: '继续在 {room} 内探索，从 {from} 前往 {to}。',
+        crossRoomTemplate: '从 {fromRoom} 的 {from} 前往 {toRoom} 的 {to}。',
+        crossSectionTemplate:
+          '从{direction}的 {fromRoom} 前往{nextDirection}的 {toRoom}，连接 {from} 和 {to}。',
+        fallbackTemplate: '从 {from} 继续前往 {to}。',
+        announcementTemplate: '下一段旅程：{summary}',
+        directions: { indoors: '室内', outdoors: '室外' },
+      },
+      rooms: {
+        living: { label: '客厅', descriptor: '客厅展区', zone: 'interior' },
+        studio: { label: '工作室', descriptor: '工作室展区', zone: 'interior' },
+        kitchen: { label: '厨房', descriptor: '厨房展区', zone: 'interior' },
+        backyard: { label: '后院', descriptor: '后院展区', zone: 'exterior' },
+      },
+    },
+    helpModal: {
+      heading: '帮助与设置',
+      description:
+        '查看控制、无障碍选项，以及体验从沉浸模式回退到文字模式的方式。',
+      closeLabel: '关闭',
+      closeAriaLabel: '关闭帮助与设置',
+      settings: {
+        heading: '设置',
+        description: '调整语言、音频、外观和导览控件。',
+      },
+      announcements: {
+        open: '帮助菜单已打开。请查看控制和设置。',
+        close: '帮助菜单已关闭。',
+      },
+      sections: [
+        {
+          id: 'movement',
+          title: '移动与相机',
+          items: [
+            { label: '移动', description: '使用 WASD 或方向键相对相机移动。' },
+            { label: '平移', description: '用鼠标拖动或触控右半区平移相机。' },
+            { label: '缩放', description: '使用滚轮或双指捏合缩放视图。' },
+          ],
+        },
+        {
+          id: 'interaction',
+          title: '互动',
+          items: [
+            {
+              label: '兴趣点',
+              description: '靠近发光展品并按 Enter、点击或轻点查看详情。',
+            },
+            {
+              label: '切换展品',
+              description: '按 Q 或 E 在可见兴趣点之间切换。',
+            },
+            { label: '文字模式', description: '按 T 打开可访问的文字作品集。' },
+          ],
+        },
+        {
+          id: 'accessibility',
+          title: '无障碍与回退',
+          items: [
+            {
+              label: '语言',
+              description: '在设置中切换语言；阿拉伯语保持从右到左。',
+            },
+            {
+              label: '性能',
+              description: '低性能或省流量环境会自动显示文字导览。',
+            },
+            { label: '音频', description: '环境音频可静音并调整音量。' },
+          ],
+        },
+      ],
+    },
+  },
+  poi: {
+    'futuroptimist-living-room-tv': {
+      title: 'Futuroptimist',
+      summary:
+        '自动化 Futuroptimist 脚本工作台，把研究、提纲和可配音草稿串成新视频。',
+      outcome: {
+        label: '成果',
+        value: '把创意流水线、提示文档和发布检查集中到一个可复用系统。',
+      },
+      interactionPrompt: '查看 {title}',
+    },
+    'tokenplace-studio-cluster': {
+      title: 'token.place',
+      summary: '端到端加密剪贴板与令牌中继系统，把敏感内容保留在用户设备上。',
+      outcome: {
+        label: '成果',
+        value: '提供加密、盲中继和安全诊断，支持隐私优先的共享流程。',
+      },
+    },
+    'gabriel-studio-sentry': {
+      title: 'Gabriel',
+      summary:
+        '面向创作者的智能体助手，把研究、写作和任务编排放进可审阅的工作流。',
+      outcome: {
+        label: '成果',
+        value: '将提示、工具和审查清单组织成可重复的自动化体验。',
+      },
+    },
+    'flywheel-studio-flywheel': {
+      title: 'Flywheel',
+      summary:
+        '可靠性和发布节奏工作台，帮助团队把提示、检查和 CI 信号接入同一个循环。',
+      outcome: {
+        label: '成果',
+        value: '把自动化开发、测试和文档检查连接成可持续的交付飞轮。',
+      },
+      interactionPrompt: '启动 {title} 系统',
+    },
+    'jobbot-studio-terminal': {
+      title: 'Jobbot3000',
+      summary: '求职自动化终端，整理机会、申请资料和跟进任务。',
+      outcome: {
+        label: '成果',
+        value: '把求职流水线拆成可追踪、可审阅、可自动化的步骤。',
+      },
+    },
+    'axel-studio-tracker': {
+      title: 'Axel',
+      summary: '自行车与出行实验，把路线、维护和小型硬件记录成可分享项目。',
+      outcome: {
+        label: '成果',
+        value: '把现实世界的骑行数据和维护提醒组织进轻量工具。',
+      },
+    },
+    'gitshelves-living-room-installation': {
+      title: 'Gitshelves',
+      summary: 'GitHub 活动书架，把提交节奏和项目历史变成发光的室内陈列。',
+      outcome: {
+        label: '成果',
+        value: '把代码活动可视化成可浏览、可讲故事的空间装置。',
+      },
+    },
+    'danielsmith-portfolio-table': {
+      title: 'danielsmith.io',
+      summary:
+        '本站的沉浸式作品集，将 Three.js 房间、HUD、POI 和文字回退组合在一起。',
+      outcome: {
+        label: '成果',
+        value: '同时服务沉浸访问者、键盘用户、爬虫和低性能设备。',
+      },
+    },
+    'f2clipboard-kitchen-console': {
+      title: 'f2clipboard',
+      summary:
+        '快速复制失败日志的 CLI/剪贴板工具，便于把调试上下文发给智能体或队友。',
+      outcome: {
+        label: '成果',
+        value: '把失败输出转成可粘贴的 Markdown 和剪贴板内容。',
+      },
+    },
+    'sigma-kitchen-workbench': {
+      title: 'Sigma',
+      summary:
+        'ESP32 “AI pin”，把按键通话音频发往 Whisper，并在 OpenSCAD 外壳中返回 TTS。',
+      outcome: {
+        label: '成果',
+        value: '包含固件、外壳 CAD、STL 导出和由 CI 保持更新的装配文档。',
+      },
+    },
+    'wove-kitchen-loom': {
+      title: 'Wove',
+      summary:
+        '学习针织和钩针的开源工具包，并朝着带 OpenSCAD 硬件的机器人织机推进。',
+      outcome: {
+        label: '成果',
+        value: '文档覆盖密度计算、规划导出和不同线材重量的张力曲线。',
+      },
+    },
+    'dspace-backyard-rocket': {
+      title: 'DSPACE',
+      summary:
+        '私人 DSPACE 火箭项目的后院发射架，带遥测倒计时提示和公开任务日志。',
+      outcome: {
+        label: '成果',
+        value: '在仓库保持私有时，维护倒计时编排笔记、GitHub 链接和任务日志。',
+      },
+      interactionPrompt: '启动 {title} 倒计时',
+    },
+    'pr-reaper-backyard-console': {
+      title: 'PR Reaper',
+      summary:
+        'GitHub Actions 工作流，可批量关闭陈旧拉取请求，支持预演和可选分支清理。',
+      outcome: {
+        label: '成果',
+        value: 'README 记录一键工作流的输入、安全模型和审计输出。',
+      },
+    },
+    'sugarkube-backyard-greenhouse': {
+      title: 'Sugarkube',
+      summary:
+        '树莓派 k3s 平台搭配离网太阳能方块装置，配有 CAD、Pi 镜像和现场指南。',
+      outcome: {
+        label: '成果',
+        value:
+          '逐步文档覆盖太阳能硬件、Pi 配置和韧性 homelab 的 Kubernetes 辅助工具。',
+      },
+    },
+  },
+};

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -8,7 +8,7 @@ import type {
 import type { FallbackReason } from '../../types/failover';
 import type { InputMethod } from '../../ui/hud/movementLegend';
 
-export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja';
+export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja' | 'zh-Hans';
 export type LocaleDirection = 'ltr' | 'rtl';
 export type LocaleScript = 'latin' | 'cjk' | 'rtl';
 
@@ -122,6 +122,43 @@ export interface ModeToggleResolvedStrings {
 export interface ModeAnnouncerStrings {
   immersiveReady: string;
   fallbackReasons: Record<FallbackReason, string>;
+}
+
+export interface TourGuideToggleStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
+export interface TourResetStrings {
+  heading: string;
+  resetKey: string;
+  label: string;
+  description: string;
+  emptyLabel: string;
+  emptyDescription: string;
+  pendingLabel: string;
+  pendingDescription: string;
+  restartPromptTemplate: string;
+  guidedTourDescription: string;
+  guidedTourLabelOn: string;
+  guidedTourLabelOff: string;
+  toggleAnnouncementOn: string;
+  toggleAnnouncementOff: string;
+  toggleTitleOn: string;
+  toggleTitleOff: string;
+}
+
+export interface SoftwareRendererWarningStrings {
+  title: string;
+  rendererFallbackLabel: string;
+  descriptionTemplate: string;
+  recommendation: string;
+  continueSafeLabel: string;
+  continuousLabel: string;
+  textModeLabel: string;
+  safeUrlLabel: string;
 }
 
 export interface HelpModalItemStrings {
@@ -324,6 +361,9 @@ export interface LocaleStrings {
     audioControl: AudioHudControlStrings;
     modeToggle: ModeToggleStrings;
     localeToggle: LocaleToggleStrings;
+    tourGuideToggle: TourGuideToggleStrings;
+    tourReset: TourResetStrings;
+    softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;
     customization: HudCustomizationStrings;
     narrativeLog: PoiNarrativeLogStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,13 +45,18 @@ import {
   getControlOverlayStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
+  isI18nDebugEnabled,
   getLocaleDirection,
+  getLocaleScript,
   getLocaleToggleStrings,
   getModeAnnouncerStrings,
   getModeToggleStrings,
   getPoiNarrativeLogStrings,
   getPoiOverlayChromeStrings,
   getSiteStrings,
+  getSoftwareRendererWarningStrings,
+  getTourGuideToggleStrings,
+  getTourResetStrings,
   resolveLocale,
   type Locale,
 } from './assets/i18n';
@@ -918,6 +923,7 @@ function initializeImmersiveScene(
   const htmlDirection = getLocaleDirection(locale);
   document.documentElement.dir = htmlDirection;
   document.documentElement.dataset.localeDirection = htmlDirection;
+  document.documentElement.dataset.localeScript = getLocaleScript(locale);
   let controlOverlayStrings = getControlOverlayStrings(locale);
   let helpModalStrings = getHelpModalStrings(locale);
   let hudCustomizationStrings = getHudCustomizationStrings(locale);
@@ -926,6 +932,10 @@ function initializeImmersiveScene(
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
+  let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
+  let tourResetStrings = getTourResetStrings(locale);
+  let softwareRendererWarningStrings =
+    getSoftwareRendererWarningStrings(locale);
   let siteStrings = getSiteStrings(locale);
   const syncModeAnnouncerStrings = () => {
     const announcerStrings = getModeAnnouncerStrings(locale);
@@ -2938,6 +2948,7 @@ function initializeImmersiveScene(
     const direction = getLocaleDirection(locale);
     document.documentElement.dir = direction;
     document.documentElement.dataset.localeDirection = direction;
+    document.documentElement.dataset.localeScript = getLocaleScript(locale);
     document.documentElement.lang = locale === 'en-x-pseudo' ? 'en' : locale;
 
     controlOverlayStrings = getControlOverlayStrings(locale);
@@ -2949,6 +2960,9 @@ function initializeImmersiveScene(
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
+    tourGuideToggleStrings = getTourGuideToggleStrings(locale);
+    tourResetStrings = getTourResetStrings(locale);
+    softwareRendererWarningStrings = getSoftwareRendererWarningStrings(locale);
     siteStrings = getSiteStrings(locale);
     syncModeAnnouncerStrings();
     narrativeTimeFormatter = new Intl.DateTimeFormat(
@@ -3014,6 +3028,9 @@ function initializeImmersiveScene(
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
+    tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
+    tourResetControl?.setStrings(tourResetStrings);
+    softwareRendererWarning?.setStrings(softwareRendererWarningStrings);
     updateHelpButtonLabel();
     localeToggleControl?.refresh();
     syncPoiRecommendation();
@@ -3037,10 +3054,24 @@ function initializeImmersiveScene(
     direction: 'ltr' | 'rtl';
   }> = [
     { id: 'en', label: 'English', direction: 'ltr' },
+    { id: 'zh-Hans', label: '简体中文', direction: 'ltr' },
     { id: 'ja', label: '日本語', direction: 'ltr' },
     { id: 'ar', label: 'العربية', direction: 'rtl' },
-    { id: 'en-x-pseudo', label: 'Pseudo', direction: 'ltr' },
   ];
+
+  if (
+    isI18nDebugEnabled({
+      dev: import.meta.env.DEV,
+      search: window.location.search,
+      storage: localeStorage,
+    })
+  ) {
+    localeOptions.push({
+      id: 'en-x-pseudo',
+      label: 'Pseudo',
+      direction: 'ltr',
+    });
+  }
 
   localeToggleControl = createLocaleToggleControl({
     container: hudSettingsStack,
@@ -3486,6 +3517,7 @@ function initializeImmersiveScene(
         guidedTourChannel?.setEnabled(enabled);
         writeGuidedTourEnabled(enabled);
       },
+      strings: tourGuideToggleStrings,
     });
     registerHudControlElement(tourGuideToggleControl?.element ?? null);
 
@@ -3495,6 +3527,7 @@ function initializeImmersiveScene(
       onReset: () => {
         poiVisitedState.reset();
       },
+      strings: tourResetStrings,
     });
     registerHudControlElement(tourResetControl?.element ?? null);
   }

--- a/src/systems/controls/tourGuideToggleControl.ts
+++ b/src/systems/controls/tourGuideToggleControl.ts
@@ -1,35 +1,34 @@
+import {
+  getTourGuideToggleStrings,
+  type TourGuideToggleStrings,
+} from '../../assets/i18n';
+
 export interface TourGuideToggleControlOptions {
   container: HTMLElement;
   initialEnabled?: boolean;
   onToggle?: (enabled: boolean) => void;
-  labelEnabled?: string;
-  labelDisabled?: string;
-  descriptionEnabled?: string;
-  descriptionDisabled?: string;
+  strings?: TourGuideToggleStrings;
 }
 
 export interface TourGuideToggleControlHandle {
   readonly element: HTMLButtonElement;
   setEnabled(enabled: boolean): void;
+  setStrings(strings: TourGuideToggleStrings): void;
   dispose(): void;
 }
-
-const defaultEnabledLabel = 'Guided tour on';
-const defaultDisabledLabel = 'Guided tour off';
-const defaultEnabledDescription =
-  'Highlights the next recommended exhibit in the immersive tour.';
-const defaultDisabledDescription =
-  'Guided tour highlights are hidden until you turn them back on.';
 
 export function createTourGuideToggleControl({
   container,
   initialEnabled = true,
   onToggle,
-  labelEnabled = defaultEnabledLabel,
-  labelDisabled = defaultDisabledLabel,
-  descriptionEnabled = defaultEnabledDescription,
-  descriptionDisabled = defaultDisabledDescription,
+  strings: providedStrings,
 }: TourGuideToggleControlOptions): TourGuideToggleControlHandle {
+  const defaultStrings = getTourGuideToggleStrings();
+  let strings: TourGuideToggleStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+  };
+
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'tour-toggle';
@@ -37,9 +36,10 @@ export function createTourGuideToggleControl({
 
   let enabled = Boolean(initialEnabled);
 
-  const getLabel = () => (enabled ? labelEnabled : labelDisabled);
+  const getLabel = () =>
+    enabled ? strings.labelEnabled : strings.labelDisabled;
   const getDescription = () =>
-    enabled ? descriptionEnabled : descriptionDisabled;
+    enabled ? strings.descriptionEnabled : strings.descriptionDisabled;
 
   const refresh = () => {
     const label = getLabel();
@@ -68,6 +68,10 @@ export function createTourGuideToggleControl({
         return;
       }
       enabled = next;
+      refresh();
+    },
+    setStrings(nextStrings) {
+      strings = { ...defaultStrings, ...nextStrings };
       refresh();
     },
     dispose() {

--- a/src/systems/controls/tourResetControl.ts
+++ b/src/systems/controls/tourResetControl.ts
@@ -1,3 +1,8 @@
+import {
+  formatMessage,
+  getTourResetStrings,
+  type TourResetStrings,
+} from '../../assets/i18n';
 import type { PoiVisitedListener } from '../../scene/poi/visitedState';
 import {
   GuidedTourPreference,
@@ -17,21 +22,16 @@ export interface TourResetControlOptions {
    */
   onReset: () => void | Promise<void>;
   windowTarget?: Window;
-  /** Single-character shortcut hint. */
+  /** Locale-sourced copy for visible guided tour controls. */
+  strings?: TourResetStrings;
+  /** Single-character shortcut hint override for tests or remapped controls. */
   resetKey?: string;
-  label?: string;
-  description?: string;
-  emptyLabel?: string;
-  emptyDescription?: string;
-  pendingLabel?: string;
   guidedTourPreference?: GuidedTourPreference;
-  guidedTourDescription?: string;
-  guidedTourLabelOn?: string;
-  guidedTourLabelOff?: string;
 }
 
 export interface TourResetControlHandle {
   readonly element: HTMLElement;
+  setStrings(strings: TourResetStrings): void;
   dispose(): void;
 }
 
@@ -62,17 +62,16 @@ export function createTourResetControl({
   subscribeVisited,
   onReset,
   windowTarget = window,
-  resetKey = 'g',
-  label = 'Restart guided tour',
-  description = 'Clear visited POIs and replay the curated path.',
-  emptyLabel = 'Guided tour ready',
-  emptyDescription = 'Explore exhibits to unlock the guided tour reset.',
-  pendingLabel = 'Resetting tour…',
+  strings: providedStrings,
+  resetKey,
   guidedTourPreference = defaultGuidedTourPreference,
-  guidedTourDescription = 'Show recommended exhibits when idle.',
-  guidedTourLabelOn = 'Guided tour highlights: On',
-  guidedTourLabelOff = 'Guided tour highlights: Off',
 }: TourResetControlOptions): TourResetControlHandle {
+  const defaultStrings = getTourResetStrings();
+  let strings: TourResetStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+    ...(resetKey ? { resetKey } : {}),
+  };
   const wrapper = document.createElement('section');
   wrapper.className = 'guided-tour-control';
   wrapper.dataset.pending = 'false';
@@ -80,12 +79,12 @@ export function createTourResetControl({
 
   const heading = document.createElement('h2');
   heading.className = 'guided-tour-control__title';
-  heading.textContent = 'Guided tour';
+  heading.textContent = strings.heading;
   wrapper.appendChild(heading);
 
   const descriptionParagraph = document.createElement('p');
   descriptionParagraph.className = 'guided-tour-control__description';
-  descriptionParagraph.textContent = guidedTourDescription;
+  descriptionParagraph.textContent = strings.guidedTourDescription;
   wrapper.appendChild(descriptionParagraph);
 
   const toggleButton = document.createElement('button');
@@ -99,7 +98,7 @@ export function createTourResetControl({
   resetButton.type = 'button';
   resetButton.className = 'tour-reset';
   resetButton.dataset.state = 'empty';
-  resetButton.setAttribute('aria-label', description);
+  resetButton.setAttribute('aria-label', strings.description);
   resetButton.setAttribute('aria-busy', 'false');
   wrapper.appendChild(resetButton);
 
@@ -112,29 +111,27 @@ export function createTourResetControl({
     return value.length === 1 ? value.toUpperCase() : value;
   };
 
-  const normalizedResetKey = normalizeKey(resetKey);
-
-  const idleTitle = normalizedResetKey
-    ? `${label} (${normalizedResetKey})`
-    : label;
+  const getNormalizedResetKey = () => normalizeKey(strings.resetKey);
+  const getIdleTitle = () => {
+    const normalizedResetKey = getNormalizedResetKey();
+    return normalizedResetKey
+      ? `${strings.label} (${normalizedResetKey})`
+      : strings.label;
+  };
 
   let visitedCount = 0;
   let pending = false;
   let guidedTourEnabled = guidedTourPreference.isEnabled();
 
-  const buildToggleAnnouncement = (enabled: boolean) => {
-    const stateLabel = enabled ? 'enabled' : 'disabled';
-    return `Guided tour highlights ${stateLabel}. Activate to ${
-      enabled ? 'disable' : 'enable'
-    } recommendations.`;
-  };
+  const buildToggleAnnouncement = (enabled: boolean) =>
+    enabled ? strings.toggleAnnouncementOn : strings.toggleAnnouncementOff;
 
   const refreshToggle = () => {
     guidedTourEnabled = guidedTourPreference.isEnabled();
     toggleButton.dataset.state = guidedTourEnabled ? 'on' : 'off';
     toggleButton.textContent = guidedTourEnabled
-      ? guidedTourLabelOn
-      : guidedTourLabelOff;
+      ? strings.guidedTourLabelOn
+      : strings.guidedTourLabelOff;
     toggleButton.setAttribute(
       'aria-pressed',
       guidedTourEnabled ? 'true' : 'false'
@@ -142,16 +139,20 @@ export function createTourResetControl({
     toggleButton.dataset.hudAnnounce =
       buildToggleAnnouncement(guidedTourEnabled);
     toggleButton.title = guidedTourEnabled
-      ? 'Disable guided tour highlights'
-      : 'Enable guided tour highlights';
+      ? strings.toggleTitleOn
+      : strings.toggleTitleOff;
     wrapper.dataset.guidedTour = guidedTourEnabled ? 'on' : 'off';
   };
 
   const buildHudAnnouncement = (message: string, includePrompt: boolean) => {
+    const normalizedResetKey = getNormalizedResetKey();
     if (!includePrompt || !normalizedResetKey) {
       return message;
     }
-    return appendClause(message, `Press ${normalizedResetKey} to restart.`);
+    return appendClause(
+      message,
+      formatMessage(strings.restartPromptTemplate, { key: normalizedResetKey })
+    );
   };
 
   const refreshState = () => {
@@ -159,15 +160,15 @@ export function createTourResetControl({
     if (pending) {
       resetButton.disabled = true;
       resetButton.dataset.state = 'pending';
-      resetButton.textContent = pendingLabel;
-      resetButton.title = idleTitle;
+      resetButton.textContent = strings.pendingLabel;
+      resetButton.title = getIdleTitle();
       resetButton.setAttribute(
         'aria-label',
-        appendClause(description, 'Resetting the guided tour…')
+        appendClause(strings.description, strings.pendingDescription)
       );
       resetButton.dataset.hudAnnounce = appendClause(
-        description,
-        'Resetting the guided tour…'
+        strings.description,
+        strings.pendingDescription
       );
       wrapper.dataset.pending = 'true';
       wrapper.setAttribute('aria-busy', 'true');
@@ -177,10 +178,10 @@ export function createTourResetControl({
     if (!hasVisited) {
       resetButton.disabled = true;
       resetButton.dataset.state = 'empty';
-      resetButton.textContent = emptyLabel;
-      resetButton.title = emptyDescription;
-      resetButton.setAttribute('aria-label', emptyDescription);
-      resetButton.dataset.hudAnnounce = emptyDescription;
+      resetButton.textContent = strings.emptyLabel;
+      resetButton.title = strings.emptyDescription;
+      resetButton.setAttribute('aria-label', strings.emptyDescription);
+      resetButton.dataset.hudAnnounce = strings.emptyDescription;
       wrapper.dataset.pending = 'false';
       wrapper.setAttribute('aria-busy', 'false');
       resetButton.setAttribute('aria-busy', 'false');
@@ -188,10 +189,13 @@ export function createTourResetControl({
     }
     resetButton.disabled = false;
     resetButton.dataset.state = 'ready';
-    resetButton.textContent = label;
-    resetButton.title = idleTitle;
-    resetButton.setAttribute('aria-label', description);
-    resetButton.dataset.hudAnnounce = buildHudAnnouncement(description, true);
+    resetButton.textContent = strings.label;
+    resetButton.title = getIdleTitle();
+    resetButton.setAttribute('aria-label', strings.description);
+    resetButton.dataset.hudAnnounce = buildHudAnnouncement(
+      strings.description,
+      true
+    );
     wrapper.dataset.pending = 'false';
     wrapper.setAttribute('aria-busy', 'false');
     resetButton.setAttribute('aria-busy', 'false');
@@ -232,11 +236,12 @@ export function createTourResetControl({
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
-    if (!resetKey) {
+    if (!strings.resetKey) {
       return;
     }
     const matchesKey =
-      event.key === resetKey || event.key === resetKey.toUpperCase();
+      event.key === strings.resetKey ||
+      event.key === strings.resetKey.toUpperCase();
     if (!matchesKey) {
       return;
     }
@@ -262,9 +267,7 @@ export function createTourResetControl({
   refreshToggle();
 
   resetButton.addEventListener('click', handleClick);
-  if (resetKey) {
-    windowTarget.addEventListener('keydown', handleKeydown);
-  }
+  windowTarget.addEventListener('keydown', handleKeydown);
 
   const unsubscribeVisited = subscribeVisited((visited) => {
     visitedCount = visited.size;
@@ -275,11 +278,20 @@ export function createTourResetControl({
 
   return {
     element: wrapper,
+    setStrings(nextStrings) {
+      strings = {
+        ...defaultStrings,
+        ...nextStrings,
+        ...(resetKey ? { resetKey } : {}),
+      };
+      heading.textContent = strings.heading;
+      descriptionParagraph.textContent = strings.guidedTourDescription;
+      refreshToggle();
+      refreshState();
+    },
     dispose() {
       resetButton.removeEventListener('click', handleClick);
-      if (resetKey) {
-        windowTarget.removeEventListener('keydown', handleKeydown);
-      }
+      windowTarget.removeEventListener('keydown', handleKeydown);
       unsubscribeVisited();
       unsubscribePreference();
       toggleButton.removeEventListener('click', handleToggleClick);

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -10,9 +10,13 @@ import {
   getModeAnnouncerStrings,
   getModeToggleStrings,
   getLocaleScript,
+  getTourGuideToggleStrings,
+  getTourResetStrings,
+  isI18nDebugEnabled,
   getPoiNarrativeLogStrings,
   getPoiOverlayChromeStrings,
   getPoiCopy,
+  getLocaleStrings,
   getSiteStrings,
   resolveLocale,
 } from '../assets/i18n';
@@ -24,6 +28,7 @@ describe('i18n utilities', () => {
     expect(AVAILABLE_LOCALES).toContain('en-x-pseudo');
     expect(AVAILABLE_LOCALES).toContain('ar');
     expect(AVAILABLE_LOCALES).toContain('ja');
+    expect(AVAILABLE_LOCALES).toContain('zh-Hans');
   });
 
   it('normalizes locale inputs with region modifiers and pseudo identifiers', () => {
@@ -34,6 +39,8 @@ describe('i18n utilities', () => {
     expect(resolveLocale('en_x_pseudo')).toBe('en-x-pseudo');
     expect(resolveLocale('ar-EG')).toBe('ar');
     expect(resolveLocale('ja-JP')).toBe('ja');
+    expect(resolveLocale('zh-CN')).toBe('zh-Hans');
+    expect(resolveLocale('zh_Hans')).toBe('zh-Hans');
   });
 
   it('detects locale direction for RTL and LTR language inputs', () => {
@@ -43,6 +50,7 @@ describe('i18n utilities', () => {
     expect(getLocaleDirection('AR_EG')).toBe('rtl');
     expect(getLocaleDirection('fa-IR')).toBe('rtl');
     expect(getLocaleDirection('ja-JP')).toBe('ltr');
+    expect(getLocaleDirection('zh-Hans')).toBe('ltr');
     expect(getLocaleDirection(undefined)).toBe('ltr');
   });
 
@@ -50,10 +58,75 @@ describe('i18n utilities', () => {
     expect(getLocaleScript('en')).toBe('latin');
     expect(getLocaleScript('en-x-pseudo')).toBe('latin');
     expect(getLocaleScript('zh-CN')).toBe('cjk');
+    expect(getLocaleScript('zh-Hans')).toBe('cjk');
     expect(getLocaleScript('ja')).toBe('cjk');
     expect(getLocaleScript('ko-KR')).toBe('cjk');
     expect(getLocaleScript('ar')).toBe('rtl');
     expect(getLocaleScript(undefined)).toBe('latin');
+  });
+
+  it('keeps every available locale populated with required visible strings', () => {
+    const assertNonEmptyStrings = (value: unknown, path: string): void => {
+      if (typeof value === 'string') {
+        expect(value.trim(), path).not.toBe('');
+        return;
+      }
+      if (Array.isArray(value)) {
+        expect(value.length, path).toBeGreaterThan(0);
+        value.forEach((item, index) =>
+          assertNonEmptyStrings(item, `${path}[${index}]`)
+        );
+        return;
+      }
+      if (value && typeof value === 'object') {
+        const entries = Object.entries(value);
+        expect(entries.length, path).toBeGreaterThan(0);
+        entries.forEach(([key, nested]) =>
+          assertNonEmptyStrings(nested, `${path}.${key}`)
+        );
+      }
+    };
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const strings = getLocaleStrings(locale);
+      assertNonEmptyStrings(strings.site, `${locale}.site`);
+      assertNonEmptyStrings(strings.hud, `${locale}.hud`);
+      assertNonEmptyStrings(strings.poi, `${locale}.poi`);
+    }
+  });
+
+  it('gates pseudo locale visibility behind explicit i18n debug settings', () => {
+    expect(isI18nDebugEnabled()).toBe(false);
+    expect(isI18nDebugEnabled({ search: '?i18nDebug=1' })).toBe(true);
+    expect(isI18nDebugEnabled({ dev: true })).toBe(true);
+    expect(
+      isI18nDebugEnabled({
+        storage: { getItem: () => 'true' } as Pick<Storage, 'getItem'>,
+      })
+    ).toBe(true);
+  });
+
+  it('provides Mandarin Chinese UI, tour, fallback, and POI strings', () => {
+    const overlay = getControlOverlayStrings('zh-Hans');
+    expect(overlay.heading).toBe('控制');
+    expect(overlay.items.toggleTextMode.description).toBe('切换到文字模式');
+
+    const helpModal = getHelpModalStrings('zh-Hans');
+    expect(helpModal.heading).toBe('帮助与设置');
+    expect(helpModal.sections[0]?.title).toBe('移动与相机');
+
+    const tourToggle = getTourGuideToggleStrings('zh-Hans');
+    expect(tourToggle.labelEnabled).toBe('导览已开启');
+    const tourReset = getTourResetStrings('zh-Hans');
+    expect(tourReset.heading).toBe('引导导览');
+    expect(tourReset.pendingDescription).toContain('重置');
+
+    const site = getSiteStrings('zh-Hans');
+    expect(site.textFallback.recoveryCta.actionLabel).toBe('再次尝试沉浸模式');
+
+    const poi = getPoiCopy('zh-Hans');
+    expect(poi['futuroptimist-living-room-tv'].summary).toContain('脚本工作台');
+    expect(poi['dspace-backyard-rocket'].interactionPrompt).toContain('倒计时');
   });
 
   it('formats template strings with provided values', () => {

--- a/src/tests/localeToggleControl.test.ts
+++ b/src/tests/localeToggleControl.test.ts
@@ -43,6 +43,34 @@ describe('createLocaleToggleControl', () => {
     handle.dispose();
   });
 
+  it('renders Mandarin as a public option without pseudo by default', () => {
+    const container = document.createElement('div');
+    const handle = createLocaleToggleControl({
+      container,
+      options: [
+        { id: 'en', label: 'English' },
+        { id: 'zh-Hans', label: '简体中文' },
+        { id: 'ja', label: '日本語' },
+        { id: 'ar', label: 'العربية', direction: 'rtl' },
+      ],
+      getActiveLocale: () => 'en',
+      setActiveLocale: () => {},
+      strings,
+    });
+
+    expect(
+      container.querySelector('.locale-toggle__option[data-locale="zh-Hans"]')
+        ?.textContent
+    ).toBe('简体中文');
+    expect(
+      container.querySelector(
+        '.locale-toggle__option[data-locale="en-x-pseudo"]'
+      )
+    ).toBeNull();
+
+    handle.dispose();
+  });
+
   it('announces switching and failures with localized templates', async () => {
     const container = document.createElement('div');
     const failingToggle = vi.fn(async () => {

--- a/src/tests/textFallbackAccessibility.test.ts
+++ b/src/tests/textFallbackAccessibility.test.ts
@@ -104,6 +104,24 @@ describe('text fallback accessibility', () => {
     });
   }
 
+  it('renders Mandarin text fallback copy and document metadata', () => {
+    const container = document.createElement('div');
+    document.documentElement.lang = 'zh-CN';
+
+    renderTextFallback(container, {
+      reason: 'manual',
+      immersiveUrl: 'https://danielsmith.io/immersive',
+    });
+
+    expect(document.documentElement.lang).toBe('zh-Hans');
+    expect(document.documentElement.dataset.localeScript).toBe('cjk');
+    expect(
+      container.querySelector('.text-fallback__recovery-title')?.textContent
+    ).toBe('准备进入完整房间？');
+    expect(container.textContent).toContain('Futuroptimist');
+    expect(container.textContent).toContain('脚本工作台');
+  });
+
   it('normalizes provided immersive URLs without disabling failover for normal recovery', () => {
     const container = document.createElement('div');
 

--- a/src/ui/softwareRendererWarning.ts
+++ b/src/ui/softwareRendererWarning.ts
@@ -1,3 +1,8 @@
+import {
+  formatMessage,
+  getSoftwareRendererWarningStrings,
+  type SoftwareRendererWarningStrings,
+} from '../assets/i18n';
 import type { RendererInfoSnapshot } from '../scene/performance/rendererCapabilities';
 
 export interface SoftwareRendererWarningOptions {
@@ -7,17 +12,17 @@ export interface SoftwareRendererWarningOptions {
   textUrl: string;
   onContinueSafe?: () => void;
   onVisible?: (message: string) => void;
+  strings?: SoftwareRendererWarningStrings;
 }
 
 export interface SoftwareRendererWarningHandle {
   element: HTMLElement;
+  setStrings(strings: SoftwareRendererWarningStrings): void;
   dispose(): void;
 }
 
 const rendererLabel = (rendererInfo: RendererInfoSnapshot) =>
-  rendererInfo.unmaskedRenderer ??
-  rendererInfo.renderer ??
-  'software WebGL renderer';
+  rendererInfo.unmaskedRenderer ?? rendererInfo.renderer;
 
 export function createSoftwareRendererWarning({
   rendererInfo,
@@ -26,7 +31,12 @@ export function createSoftwareRendererWarning({
   textUrl,
   onContinueSafe,
   onVisible,
+  strings: providedStrings,
 }: SoftwareRendererWarningOptions): SoftwareRendererWarningHandle {
+  let strings = {
+    ...getSoftwareRendererWarningStrings(),
+    ...providedStrings,
+  };
   const documentTarget = document;
   const element = documentTarget.createElement('aside');
   element.className = 'software-renderer-warning';
@@ -40,21 +50,31 @@ export function createSoftwareRendererWarning({
 
   const title = documentTarget.createElement('h2');
   title.className = 'software-renderer-warning__title';
-  title.textContent = 'Software rendering detected';
+  const applyStrings = () => {
+    title.textContent = strings.title;
+    description.textContent = formatMessage(strings.descriptionTemplate, {
+      renderer: rendererLabel(rendererInfo) ?? strings.rendererFallbackLabel,
+    });
+    recommendation.textContent = strings.recommendation;
+    safeButton.textContent = strings.continueSafeLabel;
+    continuousLink.textContent = strings.continuousLabel;
+    textLink.textContent = strings.textModeLabel;
+    safeLink.textContent = strings.safeUrlLabel;
+  };
+
+  title.textContent = strings.title;
   element.appendChild(title);
 
   const description = documentTarget.createElement('p');
   description.className = 'software-renderer-warning__description';
-  description.textContent =
-    `Chrome is using ${rendererLabel(rendererInfo)} instead of hardware acceleration. ` +
-    'Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.';
+  description.textContent = formatMessage(strings.descriptionTemplate, {
+    renderer: rendererLabel(rendererInfo) ?? strings.rendererFallbackLabel,
+  });
   element.appendChild(description);
 
   const recommendation = documentTarget.createElement('p');
   recommendation.className = 'software-renderer-warning__recommendation';
-  recommendation.textContent =
-    'Enable browser hardware acceleration for the smooth immersive portfolio. ' +
-    'Safe immersive mode keeps screenshots and debugging available at a capped frame rate.';
+  recommendation.textContent = strings.recommendation;
   element.appendChild(recommendation);
 
   const actions = documentTarget.createElement('div');
@@ -64,7 +84,7 @@ export function createSoftwareRendererWarning({
   safeButton.type = 'button';
   safeButton.className = 'software-renderer-warning__button';
   safeButton.dataset.action = 'continue-safe-immersive';
-  safeButton.textContent = 'Continue in safe immersive';
+  safeButton.textContent = strings.continueSafeLabel;
   safeButton.addEventListener('click', () => {
     dispose();
     onContinueSafe?.();
@@ -75,7 +95,7 @@ export function createSoftwareRendererWarning({
   continuousLink.className = 'software-renderer-warning__link';
   continuousLink.dataset.action = 'continuous-immersive';
   continuousLink.href = continuousUrl;
-  continuousLink.textContent = 'Enable continuous immersive anyway';
+  continuousLink.textContent = strings.continuousLabel;
   actions.appendChild(continuousLink);
 
   const textLink = documentTarget.createElement('a');
@@ -83,21 +103,26 @@ export function createSoftwareRendererWarning({
     'software-renderer-warning__link software-renderer-warning__link--muted';
   textLink.dataset.action = 'text-mode';
   textLink.href = textUrl;
-  textLink.textContent = 'Use text mode';
+  textLink.textContent = strings.textModeLabel;
   actions.appendChild(textLink);
 
   const safeLink = documentTarget.createElement('a');
   safeLink.className = 'software-renderer-warning__safe-link';
   safeLink.href = safeUrl;
-  safeLink.textContent = 'Reload this safe immersive URL';
+  safeLink.textContent = strings.safeUrlLabel;
   element.appendChild(actions);
   element.appendChild(safeLink);
 
+  applyStrings();
   documentTarget.body.appendChild(element);
-  onVisible?.(description.textContent ?? 'Software rendering detected');
+  onVisible?.(description.textContent ?? strings.title);
 
   return {
     element,
+    setStrings(nextStrings) {
+      strings = { ...getSoftwareRendererWarningStrings(), ...nextStrings };
+      applyStrings();
+    },
     dispose,
   };
 }


### PR DESCRIPTION
### Motivation
- Provide first-class Simplified Mandarin (zh-Hans) support and remove hardcoded English UI by routing all visible UI strings (HUD, POIs, text fallback, guided tour, and software-renderer warning) through the typed i18n catalog.
- Make locale state live-updatable so switching locales refreshes HUD overlays, POI copy, guided-tour controls, and warnings without module-load time freezes.
- Keep the pseudo-test locale internal by default and expose it only during explicit i18n debugging to help catch missed strings in CI and dev without confusing end users.

### Description
- Added `zh-Hans` to the `Locale` union, resolver, catalog, and CJK script detection and registered the locale in `AVAILABLE_LOCALES`. (files: `src/assets/i18n/types.ts`, `src/assets/i18n/index.ts`)
- Added `src/assets/i18n/locales/zh-Hans.ts` containing Simplified Chinese strings for site text-fallback, HUD controls, movement legend, audio controls, mode toggle, locale toggle, help/settings modal, customization, guided-tour toggle & reset, software renderer warning, narrative log, POI copy, and POI overlay chrome.
- Extended `LocaleStrings` types with typed surfaces for `tourGuideToggle`, `tourReset`, and `softwareRendererWarning` and exposed typed getters: `getTourGuideToggleStrings`, `getTourResetStrings`, and `getSoftwareRendererWarningStrings`.
- Refactored `createTourGuideToggleControl`, `createTourResetControl`, and `createSoftwareRendererWarning` to consume typed i18n strings and support runtime `setStrings(...)` for refreshing UI copy when the active locale changes.
- Updated runtime locale plumbing in `src/main.ts` to: set `document.documentElement.lang/dir/dataset.localeScript`, refresh all HUD components (control overlay, movement legend, help modal, POI overlays, guided-tour controls, and software renderer warning) when `applyLocaleUpdate()` runs, and add `zh-Hans` to the Settings picker.
- Added an i18n debug gate (`isI18nDebugEnabled`) and hid `en-x-pseudo` from public settings unless explicitly enabled via `import.meta.env.DEV`, `?i18nDebug=1`, or `localStorage['danielsmith.io:i18n-debug']`.
- Documented the pseudo-locale debug behavior in `README.md` and added tests asserting locale option visibility rules.

### Testing
- Formatting: `npm run format:write` — passed.
- Lint: `npm run lint` — passed.
- Type-check: `npm run typecheck` — failed with pre-existing repository-wide TypeScript issues unrelated to these changes (reported errors in various scene/tests import and typing locations); the i18n changes are typed and the new typed surfaces compile locally where exercised by tests, but a full repo `tsc` surfaces unrelated legacy/coverage typing issues.
- Focused unit tests: `npm run test:ci -- src/tests/i18n.test.ts src/tests/textFallbackAccessibility.test.ts src/tests/localeToggleControl.test.ts src/tests/tourGuideToggleControl.test.ts src/tests/tourResetControl.test.ts` — passed.
- Full test suite: `npm run test:ci` — all Vitest tests passed (132 files, 934 tests in this run passed); test output shows additional unrelated runtime warnings but no failing tests.
- Build: `npm run build` — succeeded and `dist` produced; `npm run smoke` passed.
- Docs validation: `npm run docs:check` — passed.

Notes and residual risks
- `tsc --noEmit` still reports unrelated, pre-existing type errors elsewhere in the repo (these predated this change); consider addressing repository-wide typing issues in a separate follow-up.
- Translations in `zh-Hans` were authored to provide coverage for every visible UI string; translations may be AI-assisted and should be reviewed by native speakers for tone and accuracy.
- Pseudo-locale remains available for dev/test when the debug gate is enabled to help surface any missed copy coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1facbb991c832fbec68929cc82d057)