### PR TITLE
🌐 : – Add Mandarin (zh-Hans) locale and finish visible UI i18n coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ Launch screenshot workflow refresh and commit it after merge.
   Screen readers now announce each switch so assistive technology users
   know which mode is active.
 
+## i18n debug mode
+
+The public Settings language picker hides the internal pseudo-locale by default.
+For translation QA, expose it in development, append `?i18nDebug=1`, or set
+`localStorage.setItem('danielsmith.io:i18n-debug', '1')` before loading the
+immersive portfolio.
+
 ## Automation prompts
 
 The canonical Codex automation prompt lives at

--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -4,6 +4,7 @@ import { AR_OVERRIDES } from './locales/ar';
 import { EN_LOCALE_STRINGS } from './locales/en';
 import { EN_X_PSEUDO_OVERRIDES } from './locales/en-x-pseudo';
 import { JA_OVERRIDES } from './locales/ja';
+import { ZH_HANS_OVERRIDES } from './locales/zh-Hans';
 import type {
   AudioHudControlStrings,
   ControlOverlayStrings,
@@ -23,6 +24,8 @@ import type {
   PoiNarrativeLogStrings,
   PoiOverlayChromeStrings,
   HudCustomizationStrings,
+  GuidedTourControlStrings,
+  SoftwareRendererWarningStrings,
   SiteStrings,
 } from './types';
 
@@ -103,17 +106,71 @@ const MERGED_PSEUDO = buildLocale(
 
 const AR_LOCALE = buildLocale(EN_LOCALE_STRINGS, AR_OVERRIDES, 'ar');
 const JA_LOCALE = buildLocale(EN_LOCALE_STRINGS, JA_OVERRIDES, 'ja');
+const ZH_HANS_LOCALE = buildLocale(
+  EN_LOCALE_STRINGS,
+  ZH_HANS_OVERRIDES,
+  'zh-Hans'
+);
 
 const localeCatalog: Record<Locale, LocaleStrings> = Object.freeze({
   en: Object.freeze(cloneValue(EN_LOCALE_STRINGS)),
   'en-x-pseudo': MERGED_PSEUDO,
   ar: AR_LOCALE,
   ja: JA_LOCALE,
+  'zh-Hans': ZH_HANS_LOCALE,
 });
 
 export const AVAILABLE_LOCALES = Object.freeze(
   Object.keys(localeCatalog) as ReadonlyArray<Locale>
 );
+
+export interface LocaleOption {
+  id: Locale;
+  label: string;
+  direction: LocaleDirection;
+  internal?: boolean;
+}
+
+const LOCALE_OPTIONS: ReadonlyArray<LocaleOption> = Object.freeze([
+  { id: 'en', label: 'English', direction: 'ltr' },
+  { id: 'zh-Hans', label: '简体中文', direction: 'ltr' },
+  { id: 'ja', label: '日本語', direction: 'ltr' },
+  { id: 'ar', label: 'العربية', direction: 'rtl' },
+  { id: 'en-x-pseudo', label: 'Pseudo', direction: 'ltr', internal: true },
+]);
+
+export const I18N_DEBUG_STORAGE_KEY = 'danielsmith.io:i18n-debug';
+
+export function isI18nDebugEnabled({
+  dev = false,
+  search = '',
+  storage,
+}: {
+  dev?: boolean;
+  search?: string;
+  storage?: Pick<Storage, 'getItem'> | null;
+} = {}): boolean {
+  const params = new URLSearchParams(
+    search.startsWith('?') ? search : `?${search}`
+  );
+  if (params.get('i18nDebug') === '1') {
+    return true;
+  }
+  if (dev) {
+    return true;
+  }
+  try {
+    return storage?.getItem(I18N_DEBUG_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function getLocaleOptions({
+  includeInternal = false,
+}: { includeInternal?: boolean } = {}): ReadonlyArray<LocaleOption> {
+  return LOCALE_OPTIONS.filter((option) => includeInternal || !option.internal);
+}
 
 function normalizeLocaleInput(input: LocaleInput): string {
   if (!input) {
@@ -143,6 +200,14 @@ export function resolveLocale(input: LocaleInput): Locale {
 
   if (normalized.startsWith('ja')) {
     return 'ja';
+  }
+
+  if (
+    normalized === 'zh' ||
+    normalized.startsWith('zh-') ||
+    normalized.startsWith('cmn')
+  ) {
+    return 'zh-Hans';
   }
 
   return 'en';
@@ -274,6 +339,18 @@ export function getHudCustomizationStrings(
   input?: LocaleInput
 ): HudCustomizationStrings {
   return getLocaleStrings(input).hud.customization;
+}
+
+export function getGuidedTourControlStrings(
+  input?: LocaleInput
+): GuidedTourControlStrings {
+  return getLocaleStrings(input).hud.guidedTour;
+}
+
+export function getSoftwareRendererWarningStrings(
+  input?: LocaleInput
+): SoftwareRendererWarningStrings {
+  return getLocaleStrings(input).hud.softwareRendererWarning;
 }
 
 export function getModeToggleStrings(

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -283,6 +283,43 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         mutedAriaValueTemplate: wrap('Muted ({volume})'),
       },
     },
+    guidedTour: {
+      heading: wrap('Guided tour'),
+      description: wrap('Show recommended exhibits when idle.'),
+      toggleLabelOn: wrap('Guided tour highlights: On'),
+      toggleLabelOff: wrap('Guided tour highlights: Off'),
+      toggleTitleOn: wrap('Disable guided tour highlights'),
+      toggleTitleOff: wrap('Enable guided tour highlights'),
+      toggleAnnouncementOn: wrap(
+        'Guided tour highlights enabled. Activate to disable recommendations.'
+      ),
+      toggleAnnouncementOff: wrap(
+        'Guided tour highlights disabled. Activate to enable recommendations.'
+      ),
+      resetLabel: wrap('Restart guided tour'),
+      resetDescription: wrap('Clear visited POIs and replay the curated path.'),
+      resetEmptyLabel: wrap('Guided tour ready'),
+      resetEmptyDescription: wrap(
+        'Explore exhibits to unlock the guided tour reset.'
+      ),
+      resetPendingLabel: wrap('Resetting tour…'),
+      resetPendingDescription: wrap('Resetting the guided tour…'),
+      resetShortcutTemplate: wrap('Press {key} to restart.'),
+    },
+    softwareRendererWarning: {
+      title: wrap('Software rendering detected'),
+      rendererFallbackLabel: wrap('software WebGL renderer'),
+      descriptionTemplate: wrap(
+        'Chrome is using {renderer} instead of hardware acceleration. Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.'
+      ),
+      recommendation: wrap(
+        'Enable browser hardware acceleration for the smooth immersive portfolio. Safe immersive mode keeps screenshots and debugging available at a capped frame rate.'
+      ),
+      continueSafeLabel: wrap('Continue in safe immersive'),
+      continuousLabel: wrap('Enable continuous immersive anyway'),
+      textModeLabel: wrap('Use text mode'),
+      safeUrlLabel: wrap('Reload this safe immersive URL'),
+    },
     localeToggle: {
       title: wrap('Language'),
       description: wrap('Switch the HUD language and direction.'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -266,6 +266,38 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Toggle the wrist console or holographic drone companions.',
       },
     },
+    guidedTour: {
+      heading: 'Guided tour',
+      description: 'Show recommended exhibits when idle.',
+      toggleLabelOn: 'Guided tour highlights: On',
+      toggleLabelOff: 'Guided tour highlights: Off',
+      toggleTitleOn: 'Disable guided tour highlights',
+      toggleTitleOff: 'Enable guided tour highlights',
+      toggleAnnouncementOn:
+        'Guided tour highlights enabled. Activate to disable recommendations.',
+      toggleAnnouncementOff:
+        'Guided tour highlights disabled. Activate to enable recommendations.',
+      resetLabel: 'Restart guided tour',
+      resetDescription: 'Clear visited POIs and replay the curated path.',
+      resetEmptyLabel: 'Guided tour ready',
+      resetEmptyDescription:
+        'Explore exhibits to unlock the guided tour reset.',
+      resetPendingLabel: 'Resetting tour…',
+      resetPendingDescription: 'Resetting the guided tour…',
+      resetShortcutTemplate: 'Press {key} to restart.',
+    },
+    softwareRendererWarning: {
+      title: 'Software rendering detected',
+      rendererFallbackLabel: 'software WebGL renderer',
+      descriptionTemplate:
+        'Chrome is using {renderer} instead of hardware acceleration. Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.',
+      recommendation:
+        'Enable browser hardware acceleration for the smooth immersive portfolio. Safe immersive mode keeps screenshots and debugging available at a capped frame rate.',
+      continueSafeLabel: 'Continue in safe immersive',
+      continuousLabel: 'Enable continuous immersive anyway',
+      textModeLabel: 'Use text mode',
+      safeUrlLabel: 'Reload this safe immersive URL',
+    },
     audioControl: {
       keyHint: 'M',
       groupLabel: 'Ambient audio controls',

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -1,0 +1,688 @@
+import type { LocaleOverrides } from '../types';
+
+export const ZH_HANS_OVERRIDES: LocaleOverrides = {
+  locale: 'zh-Hans',
+  site: {
+    name: 'Daniel Smith 沉浸式作品集',
+    structuredData: {
+      description:
+        '在 Daniel Smith 的沉浸式作品集中探索交互式项目展品、成果和叙事。',
+      listNameTemplate: '{siteName} 展品',
+      textCollectionNameTemplate: '{siteName} 文字作品集',
+      textCollectionDescription:
+        '为无障碍阅读和搜索爬虫优化的快速摘要，覆盖每个沉浸式展品。',
+      immersiveActionName: '启动沉浸模式',
+      properties: {
+        labels: {
+          category: '类别',
+          outcome: '成果',
+          status: '状态',
+        },
+        categories: {
+          project: '项目',
+          environment: '环境',
+        },
+        statuses: {
+          prototype: '原型',
+          live: '已上线',
+        },
+      },
+      publisher: { name: 'Daniel Smith' },
+      author: { name: 'Daniel Smith' },
+    },
+    textFallback: {
+      heading: '浏览亮点',
+      intro:
+        '当沉浸模式不可用时，文字作品集会以简短摘要、成果和指标保持每个展品可访问。',
+      roomHeadingTemplate: '{roomName}展品',
+      metricsHeading: '关键指标',
+      linksHeading: '延伸阅读',
+      about: {
+        heading: '关于 Daniel',
+        summary:
+          '曾在 YouTube 担任六年网站可靠性工程师，专注自动化、可观测性和稳定发布。',
+        highlights: [
+          '构建开发者平台和智能代理工具，让团队更快且更安全地交付。',
+          '辅导团队开展 SLO、事故响应和可靠性评审。',
+          '探索沉浸式 WebGL 叙事，并始终提供可访问的文字备用体验。',
+        ],
+      },
+      skills: {
+        heading: '技能概览',
+        items: [
+          {
+            label: '语言',
+            value:
+              'Python、Go、SQL、C++、TypeScript/JavaScript、Ruby、Objective-C',
+          },
+          {
+            label: '基础设施与工具',
+            value:
+              'Kubernetes、Docker、Google Cloud (BigQuery)、GitHub Actions、WebGL/Three.js、React/Next.js、Astro',
+          },
+          {
+            label: '实践',
+            value:
+              'SRE（SLO、事故响应、容量）、可观测性、CI/CD、测试、提示词文档与代理式编码',
+          },
+        ],
+      },
+      timeline: {
+        heading: '工作时间线',
+        entries: [
+          {
+            period: '2018年9月 — 2025年5月',
+            location: '加州圣布鲁诺',
+            role: '网站可靠性工程师 (L4)',
+            org: 'YouTube (Google)',
+            summary:
+              '负责多个产品面的值班，使用 Python/Go/SQL/C++ 自动化监控，并推动面向领导层的可靠性评审。',
+          },
+          {
+            period: '2017年1月 — 2018年9月',
+            location: '密西西比州斯坦尼斯航天中心',
+            role: '软件工程师',
+            org: 'Naval Research Laboratory',
+            summary: '在 Scrum 节奏中交付 C++/Qt 数据处理应用和远程演示。',
+          },
+          {
+            period: '2014年3月 — 2016年12月',
+            location: '密西西比州哈蒂斯堡',
+            role: '软件开发者',
+            org: '南密西西比大学',
+            summary: '为大学 iOS 应用构建 Objective-C 实时内容投放框架。',
+          },
+        ],
+      },
+      contact: {
+        heading: '联系方式',
+        emailLabel: '邮箱',
+        email: 'daniel@danielsmith.io',
+        githubLabel: 'GitHub',
+        githubUrl: 'https://github.com/futuroptimist',
+        resumeLabel: '简历 (PDF)',
+        resumeUrl: 'docs/resume/2025-09/resume.pdf',
+      },
+      recoveryCta: {
+        title: '准备进入完整房间了吗？',
+        description: '清除已保存的文字偏好，并从这里重新启动沉浸式作品集。',
+        actionLabel: '再次尝试沉浸模式',
+        ariaLabel: '再次尝试沉浸模式并清除已保存的文字模式偏好',
+      },
+      actions: {
+        immersiveLink: '再次尝试沉浸模式',
+        debugImmersiveLink: '调试：强制沉浸模式',
+        clearPreferenceButton: '清除已保存的模式偏好',
+        clearPreferenceSuccess: '已清除保存的模式偏好',
+        resumeLink: '下载最新版简历',
+        githubLink: '在 GitHub 上浏览项目',
+      },
+      reasonHeadings: {
+        manual: '已启用纯文字模式',
+        'webgl-unsupported': '此设备无法使用沉浸模式',
+        'low-memory': '检测到低内存设备',
+        'low-end-device': '检测到轻量设备',
+        'low-performance': '性能备用模式已启用',
+        'immersive-init-error': '沉浸式场景遇到错误',
+        'automated-client': '检测到自动化客户端',
+        'data-saver': '已启用省流量模式',
+        'console-error': '检测到运行时错误',
+      },
+      reasonDescriptions: {
+        manual: '你请求了轻量作品集视图。沉浸式场景仍可一键返回。',
+        'webgl-unsupported':
+          '你的浏览器或设备无法启动 WebGL 渲染器。请先使用快速文字概览。',
+        'low-memory':
+          '设备报告内存有限，因此我们启动了轻量文字导览以保持流畅。',
+        'low-end-device':
+          '我们检测到轻量设备配置，因此加载快速文字导览以保持导航响应。',
+        'low-performance':
+          '我们检测到持续低帧率，因此切换到响应更快的文字导览。',
+        'immersive-init-error':
+          '启动沉浸式场景时出现问题，因此先为你显示文字概览。',
+        'automated-client':
+          '检测到自动化客户端，因此展示快速加载的文字作品集以便预览和爬虫访问。',
+        'console-error':
+          '检测到运行时错误，已切换到稳健的文字导览，同时沉浸式场景恢复。',
+        'data-saver':
+          '浏览器请求省流量体验，因此我们启动轻量文字导览以减少带宽并保留重点内容。',
+      },
+    },
+  },
+  hud: {
+    controlOverlay: {
+      heading: '控制',
+      items: {
+        keyboardMove: { keys: 'WASD / 方向键', description: '移动' },
+        pointerDrag: { keys: '鼠标左键', description: '拖动平移' },
+        pointerZoom: { keys: '滚轮', description: '缩放' },
+        touchDrag: {
+          keys: '触摸',
+          description: '拖动左半屏移动，拖动右半屏平移',
+        },
+        touchPinch: { keys: '双指捏合', description: '缩放' },
+        cyclePoi: { keys: 'Q / E', description: '切换兴趣点' },
+        toggleTextMode: { keys: 'T', description: '切换到文字模式' },
+      },
+      interact: {
+        defaultLabel: 'Enter',
+        description: '互动',
+        promptTemplates: {
+          default: '与 {title} 互动',
+          inspect: '查看 {title}',
+          activate: '启动 {title}',
+        },
+      },
+      helpButton: {
+        labelTemplate: '打开菜单 · 按 {shortcut}',
+        announcementTemplate:
+          '打开设置和帮助。按 {shortcut} 查看控制方式和无障碍提示。',
+        shortcutFallback: 'H',
+      },
+      menu: {
+        controls: { label: '控制', keyHint: 'C', title: '打开控制 (C)' },
+        text: { label: '文字', keyHint: 'T', title: '切换到文字模式 (T)' },
+        settings: { label: '设置', keyHint: 'H', title: '打开设置和帮助 (H)' },
+      },
+      mobileToggle: {
+        expandLabel: '显示全部控制',
+        collapseLabel: '隐藏额外控制',
+        expandAnnouncement: '正在显示移动端玩家的完整控制列表。',
+        collapseAnnouncement: '正在隐藏额外控制，使列表保持紧凑。',
+      },
+    },
+    movementLegend: {
+      defaultDescription: '互动',
+      labels: {
+        keyboard: 'Enter',
+        pointer: '点击',
+        touch: '轻点',
+        gamepad: 'A',
+      },
+      interactPromptTemplates: {
+        default: '{prompt}',
+        keyboard: '按 {label} {prompt}',
+        pointer: '{label}以{prompt}',
+        touch: '{label}以{prompt}',
+        gamepad: '按 {label} {prompt}',
+      },
+    },
+    customization: {
+      heading: '自定义',
+      description: '调整当前任务中的角色样式和随身装备。',
+      variants: {
+        title: '角色样式',
+        description: '切换人体模型探索者的装束。',
+      },
+      accessories: {
+        title: '配件',
+        description: '切换腕部控制台或全息无人机伙伴。',
+      },
+    },
+    guidedTour: {
+      heading: '引导游览',
+      description: '空闲时显示推荐展品。',
+      toggleLabelOn: '引导游览高亮：开启',
+      toggleLabelOff: '引导游览高亮：关闭',
+      toggleTitleOn: '关闭引导游览高亮',
+      toggleTitleOff: '开启引导游览高亮',
+      toggleAnnouncementOn: '引导游览高亮已开启。激活可关闭推荐。',
+      toggleAnnouncementOff: '引导游览高亮已关闭。激活可开启推荐。',
+      resetLabel: '重新开始引导游览',
+      resetDescription: '清除已访问的兴趣点并重新播放精选路线。',
+      resetEmptyLabel: '引导游览已准备好',
+      resetEmptyDescription: '探索展品以解锁引导游览重置。',
+      resetPendingLabel: '正在重置游览…',
+      resetPendingDescription: '正在重置引导游览…',
+      resetShortcutTemplate: '按 {key} 重新开始。',
+    },
+    softwareRendererWarning: {
+      title: '检测到软件渲染',
+      rendererFallbackLabel: '软件 WebGL 渲染器',
+      descriptionTemplate:
+        'Chrome 正在使用 {renderer}，而不是硬件加速。Basic Render Driver、SwiftShader、WARP 和 llvmpipe 在连续 WebGL 动画中可能崩溃。',
+      recommendation:
+        '请启用浏览器硬件加速以获得流畅的沉浸式作品集。安全沉浸模式会限制帧率，同时保留截图和调试能力。',
+      continueSafeLabel: '继续使用安全沉浸模式',
+      continuousLabel: '仍然启用连续沉浸模式',
+      textModeLabel: '使用文字模式',
+      safeUrlLabel: '重新加载此安全沉浸 URL',
+    },
+    audioControl: {
+      keyHint: 'M',
+      groupLabel: '环境音频控制',
+      toggle: {
+        onLabelTemplate: '音频：开 · 按 {keyHint} 静音',
+        offLabelTemplate: '音频：关 · 按 {keyHint} 取消静音',
+        titleTemplate: '切换环境音频 ({keyHint})',
+        announcementOnTemplate: '环境音频已开启。按 {keyHint} 切换。',
+        announcementOffTemplate: '环境音频已关闭。按 {keyHint} 切换。',
+        pendingAnnouncementTemplate: '正在切换环境音频状态，请稍候…',
+      },
+      slider: {
+        label: '环境音量',
+        ariaLabel: '环境音频音量',
+        hudLabel: '环境音频音量滑块。',
+        valueAnnouncementTemplate: '环境音频音量 {volume}。',
+        mutedAnnouncementTemplate: '环境音频已静音。音量设为 {volume}。',
+        mutedValueTemplate: '已静音 · {volume}',
+        mutedAriaValueTemplate: '已静音 ({volume})',
+      },
+    },
+    localeToggle: {
+      title: '语言',
+      description: '切换 HUD 语言和方向。',
+      switchingAnnouncementTemplate: '正在切换到 {target} 语言…',
+      selectedAnnouncementTemplate: '已选择 {label} 语言。',
+      failureAnnouncementTemplate:
+        '无法切换到 {target}。继续使用 {current} 语言。',
+    },
+    modeToggle: {
+      keyHint: 'T',
+      idleLabelTemplate: '文字模式 · 按 {keyHint}',
+      idleDescriptionTemplate: '切换到纯文字作品集',
+      idleAnnouncementTemplate: '切换到纯文字作品集。按 {keyHint} 激活。',
+      idleTitleTemplate: '切换到纯文字作品集 ({keyHint})',
+      pendingLabelTemplate: '正在切换到文字模式…',
+      pendingAnnouncementTemplate: '切换到纯文字作品集。正在切换到文字模式…',
+      activeLabelTemplate: '再次尝试沉浸模式 · 按 {keyHint}',
+      activeDescriptionTemplate: '返回沉浸式作品集。',
+      activeAnnouncementTemplate:
+        '文字模式已激活。按 {keyHint} 再次尝试沉浸模式。',
+      errorLabelTemplate: '重试文字模式 · 按 {keyHint}',
+      errorDescriptionTemplate: '文字模式切换失败。请重试或使用沉浸链接。',
+      errorAnnouncementTemplate: '文字模式切换失败。按 {keyHint} 重试。',
+      errorTitleTemplate: '文字模式切换失败。按 {keyHint} 重试文字模式。',
+    },
+    poiOverlay: {
+      visited: '已访问',
+      nextHighlight: '下一个亮点',
+      prototype: '原型',
+      live: '已上线',
+      closeDetails: '关闭兴趣点详情',
+      relatedCaseStudies: '相关案例研究',
+      outcomeFallbackLabel: '成果',
+      discoveryAnnouncementTemplate: '发现 {title}。{summary}',
+    },
+    narrativeLog: {
+      heading: '创作者故事日志',
+      visitedHeading: '已访问展品',
+      empty: '访问展品即可解锁记录创作者展示的叙事条目。',
+      defaultVisitedLabel: '已访问',
+      visitedLabelTemplate: '访问时间 {time}',
+      liveAnnouncementTemplate: '{title} 已加入创作者故事日志。',
+      journey: {
+        heading: '旅程节点',
+        empty: '探索新展品以编织旅程叙事。',
+        entryLabelTemplate: '{from} → {to}',
+        sameRoomTemplate:
+          '在{room}的{descriptor}中，故事从 {fromPoi} 转向 {toPoi}。',
+        crossRoomTemplate:
+          '离开{fromRoom}的{fromDescriptor}，旅程进入{toRoom}的{toDescriptor}，突出 {toPoi}。',
+        crossSectionTemplate:
+          '向{direction}穿过门槛，路径流入{toRoom}的{toDescriptor}并抵达 {toPoi}。',
+        fallbackTemplate: '叙事流向 {toPoi}。',
+        announcementTemplate: '旅程更新 — {label}：{story}',
+        directions: { indoors: '回到室内', outdoors: '走向户外' },
+      },
+      rooms: {
+        livingRoom: {
+          label: '客厅',
+          descriptor: '电影感休息区',
+          zone: 'interior',
+        },
+        studio: {
+          label: '工作室',
+          descriptor: '自动化实验室',
+          zone: 'interior',
+        },
+        kitchen: {
+          label: '厨房实验室',
+          descriptor: '烹饪机器人区',
+          zone: 'interior',
+        },
+        backyard: {
+          label: '后院观测台',
+          descriptor: '暮色花园',
+          zone: 'exterior',
+        },
+      },
+    },
+    helpModal: {
+      heading: '设置与帮助',
+      description:
+        '调整无障碍预设、图形质量、音频，并查看快捷键。使用帮助快捷键（默认 H 或 ?）切换此面板。',
+      closeLabel: '关闭',
+      closeAriaLabel: '关闭帮助',
+      settings: {
+        heading: '体验设置',
+        description:
+          '调整音频、视频和无障碍偏好。即使通过键盘快捷键关闭菜单，这些控制仍可使用。',
+      },
+      sections: [
+        {
+          id: 'movement',
+          title: '移动与相机',
+          items: [
+            { label: 'WASD / 方向键', description: '在房间中移动探索者。' },
+            { label: '鼠标拖动', description: '平移等距相机。' },
+            { label: '滚轮', description: '调整缩放级别。' },
+            {
+              label: '触摸摇杆',
+              description: '拖动左侧触控板移动，拖动右侧触控板平移。',
+            },
+            { label: '双指捏合', description: '在触摸设备上缩放。' },
+          ],
+        },
+        {
+          id: 'interactions',
+          title: '互动',
+          items: [
+            {
+              label: '靠近发光兴趣点',
+              description:
+                '按互动键（Enter/Space/F）、轻点或点击以打开展品覆盖层。',
+            },
+            {
+              label: 'Q / E 或 ← / →',
+              description: '用键盘在兴趣点之间循环焦点。',
+            },
+            { label: 'T', description: '在沉浸模式和文字备用模式之间切换。' },
+            { label: 'Shift + L', description: '比较电影灯光和调试渲染通道。' },
+          ],
+        },
+        {
+          id: 'accessibility',
+          title: '无障碍与故障切换',
+          items: [
+            {
+              label: '低性能',
+              description: '当场景低于 30 FPS 时会自动切换到文字模式。',
+            },
+            {
+              label: '手动切换',
+              description: '可随时使用屏幕上的文字模式按钮或按 T。',
+            },
+            {
+              label: '运动模糊滑块',
+              description: '在“设置 → 运动模糊”中调整拖尾强度。',
+            },
+            { label: '环境音频', description: '使用音频按钮或按 M 切换。' },
+          ],
+        },
+      ],
+      announcements: {
+        open: '帮助菜单已打开。请查看控制和设置。',
+        close: '帮助菜单已关闭。',
+      },
+    },
+  },
+  poi: {
+    'futuroptimist-living-room-tv': {
+      title: 'Futuroptimist',
+      summary: '自动化视频脚本工作台，将研究、提纲和可旁白草稿串联成新视频。',
+      outcome: {
+        label: '成果',
+        value: '让每周亮点脚本持续从自动化流水线产出，无需手动格式化。',
+      },
+      metrics: [
+        { label: '星标', value: '1,280+' },
+        { label: '工作流', value: 'Resolve 风格剪辑台 · 三屏显示' },
+        { label: '重点', value: 'Futuroptimist 生态短片制作中' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist' },
+        { label: '文档', href: 'https://futuroptimist.dev' },
+      ],
+      narration: { caption: 'Futuroptimist 媒体墙在客厅中投射高光视频。' },
+    },
+    'tokenplace-studio-cluster': {
+      title: 'token.place',
+      summary:
+        '运行在 Raspberry Pi 阵列上的安全点对点生成式 AI 平台，带加密中继和服务器节点。',
+      outcome: {
+        label: '成果',
+        value: '快速启动脚本可在本地拉起中继、服务器和模拟 LLM 栈用于测试。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '集群', value: '12 个 Pi 5 节点置于模块化舱位' },
+        { label: '网络', value: '临时令牌 · 加密突发传输' },
+      ],
+      links: [
+        { label: '网站', href: 'https://token.place' },
+        {
+          label: 'GitHub',
+          href: 'https://github.com/futuroptimist/token.place',
+        },
+      ],
+    },
+    'gabriel-studio-sentry': {
+      title: 'Gabriel',
+      summary:
+        '隐私优先的“守护天使”LLM，提供本地安全指导，并可接入 token.place 或离线推理。',
+      outcome: {
+        label: '成果',
+        value: '摄取、分析、通知和 UI 栈通过类型化接口保持一致。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '重点', value: '360° 激光雷达扫描 + 本地启发式' },
+        { label: '节奏', value: '红色警报每 1.0 秒闪烁' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/gabriel' },
+      ],
+    },
+    'flywheel-studio-flywheel': {
+      title: 'Flywheel',
+      summary:
+        'GitHub 模板和自动化中枢，打包 lint、测试、文档和 Codex 提示以快速启动仓库。',
+      outcome: {
+        label: '成果',
+        value: '交付可重复 CI 和提示库，让新仓库从一开始保持健康。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '自动化', value: 'CI 脚手架 · 类型化提示 · QA 循环' },
+        { label: '文档 CTA', value: 'flywheel.futuroptimist.dev →' },
+      ],
+      links: [
+        {
+          label: 'Flywheel 仓库',
+          href: 'https://github.com/futuroptimist/flywheel',
+        },
+        { label: '文档', href: 'https://flywheel.futuroptimist.dev' },
+      ],
+      narration: { caption: 'Flywheel 动能枢纽启动，聚焦自动化提示和工具。' },
+      interactionPrompt: '启动 {title} 系统',
+    },
+    'jobbot-studio-terminal': {
+      title: 'Jobbot3000',
+      summary:
+        '自托管求职副驾驶，带 CLI 和实验性 Web UI，用于摄取外联并跟踪申请。',
+      outcome: {
+        label: '成果',
+        value: '端到端流程与文档和测试保持一致，覆盖招聘外联流。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '状态', value: '本地优先 CLI，带预览 Web UI' },
+        { label: '技术栈', value: 'Node.js 20+ · npm 脚本 · Playwright 预览' },
+        { label: '流程', value: '招聘外联摄取和生命周期跟踪' },
+      ],
+      links: [
+        {
+          label: 'GitHub',
+          href: 'https://github.com/futuroptimist/jobbot3000',
+        },
+        { label: '自动化日志', href: 'https://futuroptimist.dev/automation' },
+      ],
+      narration: { caption: 'Jobbot 全息终端以闪烁覆盖层流式展示自动化遥测。' },
+    },
+    'axel-studio-tracker': {
+      title: 'Axel',
+      summary:
+        '目标和任务追踪器，使用代理式 LLM、分析助手和 pipx 友好 CLI 组织仓库。',
+      outcome: {
+        label: '成果',
+        value: 'Alpha 发布让 README、FAQ 和威胁模型与 pytest 套件同步。',
+      },
+      metrics: [
+        { label: '状态', value: 'Alpha · pipx install axel' },
+        { label: '仓库分析', value: '根据仓库列表和扫描进行任务规划' },
+        { label: '文档', value: 'FAQ · 已知问题 · 威胁模型随测试维护' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/axel' },
+      ],
+    },
+    'gitshelves-living-room-installation': {
+      title: 'Gitshelves',
+      summary:
+        'CLI 将 GitHub 贡献数据转换为 OpenSCAD 和 STL 模型，用于 3D 打印 Gridfinity 书架。',
+      outcome: {
+        label: '成果',
+        value: '导出带元数据的 SCAD/STL 对，让打印书架映射贡献时间线。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '输出', value: 'OpenSCAD · STL · GitHub 贡献元数据' },
+        { label: '形态', value: 'Gridfinity 兼容展示架' },
+      ],
+      links: [
+        {
+          label: 'GitHub',
+          href: 'https://github.com/futuroptimist/gitshelves',
+        },
+      ],
+    },
+    'f2clipboard-kitchen-console': {
+      title: 'f2clipboard',
+      summary:
+        '开发者工具，可把失败日志、命令和上下文快速复制成可分享的 Markdown。',
+      outcome: {
+        label: '成果',
+        value: '让调试片段更容易粘贴到 PR、issue 和代理提示中。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '速度', value: '3 秒内复制失败日志' },
+        { label: '格式', value: 'CLI + 剪贴板 + Markdown 输出' },
+      ],
+      links: [
+        {
+          label: 'GitHub',
+          href: 'https://github.com/futuroptimist/f2clipboard',
+        },
+      ],
+    },
+    'sigma-kitchen-workbench': {
+      title: 'Sigma',
+      summary:
+        'ESP32 “AI pin”，将按键通话音频流式发送到 Whisper，并在 3D 打印 OpenSCAD 外壳中返回 TTS。',
+      outcome: {
+        label: '成果',
+        value: '包含固件、外壳 CAD、STL 导出和由 CI 保持更新的装配文档。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '硬件', value: 'ESP32 · OpenSCAD 外壳' },
+        { label: '模式', value: '按键通话 · Whisper + TTS 中继' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/sigma' },
+      ],
+    },
+    'wove-kitchen-loom': {
+      title: 'Wove',
+      summary:
+        '开源工具包，用于学习针织和钩针，并逐步构建带 OpenSCAD 硬件的机器人织机。',
+      outcome: {
+        label: '成果',
+        value: '文档覆盖密度计算器、计划导出和跨纱线重量的张力配置。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '手工艺', value: '织机根据 CAD 针脚图校准' },
+        { label: '路线图', value: '迈向机器人编织实验室' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/wove' },
+      ],
+    },
+    'dspace-backyard-rocket': {
+      title: 'DSPACE',
+      summary:
+        '私人 DSPACE 火箭项目的后院发射架，带遥测倒计时提示和公开任务日志。',
+      outcome: {
+        label: '成果',
+        value:
+          '在仓库仍为私有时，维护倒计时编排说明以及 GitHub 和任务日志链接。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '倒计时', value: '自主 T-0 编排' },
+        { label: '技术栈', value: 'Three.js 特效 · 空间音频' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/dspace' },
+        {
+          label: '任务日志',
+          href: 'https://futuroptimist.dev/projects/dspace',
+        },
+      ],
+      narration: {
+        caption: 'dSpace 发射台在后院小径旁迸发倒计时能量。',
+        durationMs: 6000,
+      },
+      interactionPrompt: '启动 {title} 倒计时',
+    },
+    'pr-reaper-backyard-console': {
+      title: 'PR Reaper',
+      summary:
+        'GitHub Actions 工作流，可批量关闭陈旧 PR，支持 dry-run 预览和可选分支清理。',
+      outcome: {
+        label: '成果',
+        value: '一键工作流在 README 中记录输入、安全模型和审计输出。',
+      },
+      metrics: [
+        { label: '星标', value: '正在从 GitHub 同步…' },
+        { label: '清扫', value: '用预览模式批量关闭陈旧 PR' },
+        { label: '节奏', value: 'Cron 触发 + 手动 dry-run' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/pr-reaper' },
+      ],
+    },
+    'sugarkube-backyard-greenhouse': {
+      title: 'Sugarkube',
+      summary:
+        'Raspberry Pi 上的 k3s 平台，配套离网太阳能方块装置，并以 CAD、Pi 镜像和现场指南记录。',
+      outcome: {
+        label: '成果',
+        value:
+          '分步文档覆盖太阳能硬件、Pi 配置和用于韧性 homelab 的 Kubernetes 助手。',
+      },
+      metrics: [
+        {
+          label: '平台',
+          value: 'k3s、Kubernetes 助手、Cloudflare 隧道和太阳能倾角/灌溉笔记',
+        },
+        { label: '硬件', value: '太阳能方块 CAD、Pi 托板、电子文档' },
+        { label: '指南', value: 'Pi 镜像和无头配置现场指南' },
+      ],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/sugarkube' },
+        {
+          label: '温室日志',
+          href: 'https://futuroptimist.dev/projects/sugarkube',
+        },
+      ],
+      narration: {
+        caption: 'Sugarkube 温室柔和生长灯与锦鲤池氛围同步循环。',
+        durationMs: 6500,
+      },
+    },
+  },
+};

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -8,7 +8,7 @@ import type {
 import type { FallbackReason } from '../../types/failover';
 import type { InputMethod } from '../../ui/hud/movementLegend';
 
-export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja';
+export type Locale = 'en' | 'en-x-pseudo' | 'ar' | 'ja' | 'zh-Hans';
 export type LocaleDirection = 'ltr' | 'rtl';
 export type LocaleScript = 'latin' | 'cjk' | 'rtl';
 
@@ -137,7 +137,7 @@ export interface HelpModalSectionStrings {
 
 export interface HelpModalSettingsStrings {
   heading: string;
-  description?: string;
+  description: string;
 }
 
 export interface LocaleToggleStrings {
@@ -146,6 +146,35 @@ export interface LocaleToggleStrings {
   switchingAnnouncementTemplate: string;
   selectedAnnouncementTemplate: string;
   failureAnnouncementTemplate: string;
+}
+
+export interface GuidedTourControlStrings {
+  heading: string;
+  description: string;
+  toggleLabelOn: string;
+  toggleLabelOff: string;
+  toggleTitleOn: string;
+  toggleTitleOff: string;
+  toggleAnnouncementOn: string;
+  toggleAnnouncementOff: string;
+  resetLabel: string;
+  resetDescription: string;
+  resetEmptyLabel: string;
+  resetEmptyDescription: string;
+  resetPendingLabel: string;
+  resetPendingDescription: string;
+  resetShortcutTemplate: string;
+}
+
+export interface SoftwareRendererWarningStrings {
+  title: string;
+  rendererFallbackLabel: string;
+  descriptionTemplate: string;
+  recommendation: string;
+  continueSafeLabel: string;
+  continuousLabel: string;
+  textModeLabel: string;
+  safeUrlLabel: string;
 }
 
 export interface HelpModalStrings {
@@ -163,7 +192,7 @@ export interface HelpModalStrings {
 
 export interface HudCustomizationStrings {
   heading: string;
-  description?: string;
+  description: string;
   variants: { title: string; description: string };
   accessories: { title: string; description: string };
 }
@@ -326,6 +355,8 @@ export interface LocaleStrings {
     localeToggle: LocaleToggleStrings;
     helpModal: HelpModalStrings;
     customization: HudCustomizationStrings;
+    guidedTour: GuidedTourControlStrings;
+    softwareRendererWarning: SoftwareRendererWarningStrings;
     narrativeLog: PoiNarrativeLogStrings;
     poiOverlay: PoiOverlayChromeStrings;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,12 +46,16 @@ import {
   getHelpModalStrings,
   getHudCustomizationStrings,
   getLocaleDirection,
+  getLocaleOptions,
   getLocaleToggleStrings,
   getModeAnnouncerStrings,
   getModeToggleStrings,
   getPoiNarrativeLogStrings,
   getPoiOverlayChromeStrings,
   getSiteStrings,
+  getGuidedTourControlStrings,
+  getSoftwareRendererWarningStrings,
+  isI18nDebugEnabled,
   resolveLocale,
   type Locale,
 } from './assets/i18n';
@@ -837,6 +841,9 @@ function initializeImmersiveScene(
       textUrl: createTextModeUrl(),
       onContinueSafe: requestSoftwareSafeRender,
       onVisible: recordRendererWarning,
+      strings: getSoftwareRendererWarningStrings(
+        document.documentElement.lang || navigator.language
+      ),
     });
   }
   let hudFocusAnnouncer: HudFocusAnnouncerHandle | null = null;
@@ -925,6 +932,9 @@ function initializeImmersiveScene(
   let modeToggleStrings = getModeToggleStrings(locale);
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
+  let guidedTourStrings = getGuidedTourControlStrings(locale);
+  let softwareRendererWarningStrings =
+    getSoftwareRendererWarningStrings(locale);
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
   let siteStrings = getSiteStrings(locale);
   const syncModeAnnouncerStrings = () => {
@@ -2946,6 +2956,8 @@ function initializeImmersiveScene(
     localeToggleStrings = getLocaleToggleStrings(locale);
     modeToggleStrings = getModeToggleStrings(locale);
     audioHudStrings = getAudioHudControlStrings(locale);
+    guidedTourStrings = getGuidedTourControlStrings(locale);
+    softwareRendererWarningStrings = getSoftwareRendererWarningStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
@@ -3009,6 +3021,9 @@ function initializeImmersiveScene(
     }
     manualModeToggle?.setStrings(modeToggleStrings);
     audioHudHandle?.setStrings(audioHudStrings);
+    tourGuideToggleControl?.setStrings(guidedTourStrings);
+    tourResetControl?.setStrings(guidedTourStrings);
+    softwareRendererWarning?.setStrings(softwareRendererWarningStrings);
     helpModal.setContent(helpModalStrings);
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
@@ -3031,16 +3046,13 @@ function initializeImmersiveScene(
     }
   };
 
-  const localeOptions: Array<{
-    id: Locale;
-    label: string;
-    direction: 'ltr' | 'rtl';
-  }> = [
-    { id: 'en', label: 'English', direction: 'ltr' },
-    { id: 'ja', label: '日本語', direction: 'ltr' },
-    { id: 'ar', label: 'العربية', direction: 'rtl' },
-    { id: 'en-x-pseudo', label: 'Pseudo', direction: 'ltr' },
-  ];
+  const localeOptions = getLocaleOptions({
+    includeInternal: isI18nDebugEnabled({
+      dev: import.meta.env.DEV,
+      search: window.location.search,
+      storage: localeStorage,
+    }),
+  });
 
   localeToggleControl = createLocaleToggleControl({
     container: hudSettingsStack,
@@ -3486,6 +3498,7 @@ function initializeImmersiveScene(
         guidedTourChannel?.setEnabled(enabled);
         writeGuidedTourEnabled(enabled);
       },
+      strings: guidedTourStrings,
     });
     registerHudControlElement(tourGuideToggleControl?.element ?? null);
 
@@ -3495,6 +3508,7 @@ function initializeImmersiveScene(
       onReset: () => {
         poiVisitedState.reset();
       },
+      strings: guidedTourStrings,
     });
     registerHudControlElement(tourResetControl?.element ?? null);
   }

--- a/src/systems/controls/tourGuideToggleControl.ts
+++ b/src/systems/controls/tourGuideToggleControl.ts
@@ -1,34 +1,32 @@
+import type { GuidedTourControlStrings } from '../../assets/i18n/types';
+
 export interface TourGuideToggleControlOptions {
   container: HTMLElement;
   initialEnabled?: boolean;
   onToggle?: (enabled: boolean) => void;
-  labelEnabled?: string;
-  labelDisabled?: string;
-  descriptionEnabled?: string;
-  descriptionDisabled?: string;
+  strings: Pick<
+    GuidedTourControlStrings,
+    | 'toggleLabelOn'
+    | 'toggleLabelOff'
+    | 'toggleTitleOn'
+    | 'toggleTitleOff'
+    | 'toggleAnnouncementOn'
+    | 'toggleAnnouncementOff'
+  >;
 }
 
 export interface TourGuideToggleControlHandle {
   readonly element: HTMLButtonElement;
   setEnabled(enabled: boolean): void;
+  setStrings(strings: TourGuideToggleControlOptions['strings']): void;
   dispose(): void;
 }
-
-const defaultEnabledLabel = 'Guided tour on';
-const defaultDisabledLabel = 'Guided tour off';
-const defaultEnabledDescription =
-  'Highlights the next recommended exhibit in the immersive tour.';
-const defaultDisabledDescription =
-  'Guided tour highlights are hidden until you turn them back on.';
 
 export function createTourGuideToggleControl({
   container,
   initialEnabled = true,
   onToggle,
-  labelEnabled = defaultEnabledLabel,
-  labelDisabled = defaultDisabledLabel,
-  descriptionEnabled = defaultEnabledDescription,
-  descriptionDisabled = defaultDisabledDescription,
+  strings: initialStrings,
 }: TourGuideToggleControlOptions): TourGuideToggleControlHandle {
   const button = document.createElement('button');
   button.type = 'button';
@@ -36,10 +34,14 @@ export function createTourGuideToggleControl({
   container.appendChild(button);
 
   let enabled = Boolean(initialEnabled);
+  let strings = initialStrings;
 
-  const getLabel = () => (enabled ? labelEnabled : labelDisabled);
+  const getLabel = () =>
+    enabled ? strings.toggleLabelOn : strings.toggleLabelOff;
   const getDescription = () =>
-    enabled ? descriptionEnabled : descriptionDisabled;
+    enabled ? strings.toggleTitleOn : strings.toggleTitleOff;
+  const getAnnouncement = () =>
+    enabled ? strings.toggleAnnouncementOn : strings.toggleAnnouncementOff;
 
   const refresh = () => {
     const label = getLabel();
@@ -49,7 +51,7 @@ export function createTourGuideToggleControl({
     button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
     button.setAttribute('aria-label', description);
     button.title = description;
-    button.dataset.hudAnnounce = `${label}. ${description}`;
+    button.dataset.hudAnnounce = getAnnouncement();
   };
 
   const toggle = () => {
@@ -68,6 +70,10 @@ export function createTourGuideToggleControl({
         return;
       }
       enabled = next;
+      refresh();
+    },
+    setStrings(nextStrings) {
+      strings = nextStrings;
       refresh();
     },
     dispose() {

--- a/src/systems/controls/tourResetControl.ts
+++ b/src/systems/controls/tourResetControl.ts
@@ -1,3 +1,5 @@
+import { formatMessage } from '../../assets/i18n';
+import type { GuidedTourControlStrings } from '../../assets/i18n/types';
 import type { PoiVisitedListener } from '../../scene/poi/visitedState';
 import {
   GuidedTourPreference,
@@ -19,19 +21,13 @@ export interface TourResetControlOptions {
   windowTarget?: Window;
   /** Single-character shortcut hint. */
   resetKey?: string;
-  label?: string;
-  description?: string;
-  emptyLabel?: string;
-  emptyDescription?: string;
-  pendingLabel?: string;
+  strings: GuidedTourControlStrings;
   guidedTourPreference?: GuidedTourPreference;
-  guidedTourDescription?: string;
-  guidedTourLabelOn?: string;
-  guidedTourLabelOff?: string;
 }
 
 export interface TourResetControlHandle {
   readonly element: HTMLElement;
+  setStrings(strings: GuidedTourControlStrings): void;
   dispose(): void;
 }
 
@@ -63,16 +59,11 @@ export function createTourResetControl({
   onReset,
   windowTarget = window,
   resetKey = 'g',
-  label = 'Restart guided tour',
-  description = 'Clear visited POIs and replay the curated path.',
-  emptyLabel = 'Guided tour ready',
-  emptyDescription = 'Explore exhibits to unlock the guided tour reset.',
-  pendingLabel = 'Resetting tour…',
+  strings: initialStrings,
   guidedTourPreference = defaultGuidedTourPreference,
-  guidedTourDescription = 'Show recommended exhibits when idle.',
-  guidedTourLabelOn = 'Guided tour highlights: On',
-  guidedTourLabelOff = 'Guided tour highlights: Off',
 }: TourResetControlOptions): TourResetControlHandle {
+  let strings = initialStrings;
+
   const wrapper = document.createElement('section');
   wrapper.className = 'guided-tour-control';
   wrapper.dataset.pending = 'false';
@@ -80,12 +71,12 @@ export function createTourResetControl({
 
   const heading = document.createElement('h2');
   heading.className = 'guided-tour-control__title';
-  heading.textContent = 'Guided tour';
+  heading.textContent = strings.heading;
   wrapper.appendChild(heading);
 
   const descriptionParagraph = document.createElement('p');
   descriptionParagraph.className = 'guided-tour-control__description';
-  descriptionParagraph.textContent = guidedTourDescription;
+  descriptionParagraph.textContent = strings.description;
   wrapper.appendChild(descriptionParagraph);
 
   const toggleButton = document.createElement('button');
@@ -99,7 +90,7 @@ export function createTourResetControl({
   resetButton.type = 'button';
   resetButton.className = 'tour-reset';
   resetButton.dataset.state = 'empty';
-  resetButton.setAttribute('aria-label', description);
+  resetButton.setAttribute('aria-label', strings.resetDescription);
   resetButton.setAttribute('aria-busy', 'false');
   wrapper.appendChild(resetButton);
 
@@ -114,27 +105,24 @@ export function createTourResetControl({
 
   const normalizedResetKey = normalizeKey(resetKey);
 
-  const idleTitle = normalizedResetKey
-    ? `${label} (${normalizedResetKey})`
-    : label;
+  const getIdleTitle = () =>
+    normalizedResetKey
+      ? `${strings.resetLabel} (${normalizedResetKey})`
+      : strings.resetLabel;
 
   let visitedCount = 0;
   let pending = false;
   let guidedTourEnabled = guidedTourPreference.isEnabled();
 
-  const buildToggleAnnouncement = (enabled: boolean) => {
-    const stateLabel = enabled ? 'enabled' : 'disabled';
-    return `Guided tour highlights ${stateLabel}. Activate to ${
-      enabled ? 'disable' : 'enable'
-    } recommendations.`;
-  };
+  const buildToggleAnnouncement = (enabled: boolean) =>
+    enabled ? strings.toggleAnnouncementOn : strings.toggleAnnouncementOff;
 
   const refreshToggle = () => {
     guidedTourEnabled = guidedTourPreference.isEnabled();
     toggleButton.dataset.state = guidedTourEnabled ? 'on' : 'off';
     toggleButton.textContent = guidedTourEnabled
-      ? guidedTourLabelOn
-      : guidedTourLabelOff;
+      ? strings.toggleLabelOn
+      : strings.toggleLabelOff;
     toggleButton.setAttribute(
       'aria-pressed',
       guidedTourEnabled ? 'true' : 'false'
@@ -142,8 +130,8 @@ export function createTourResetControl({
     toggleButton.dataset.hudAnnounce =
       buildToggleAnnouncement(guidedTourEnabled);
     toggleButton.title = guidedTourEnabled
-      ? 'Disable guided tour highlights'
-      : 'Enable guided tour highlights';
+      ? strings.toggleTitleOn
+      : strings.toggleTitleOff;
     wrapper.dataset.guidedTour = guidedTourEnabled ? 'on' : 'off';
   };
 
@@ -151,7 +139,10 @@ export function createTourResetControl({
     if (!includePrompt || !normalizedResetKey) {
       return message;
     }
-    return appendClause(message, `Press ${normalizedResetKey} to restart.`);
+    return appendClause(
+      message,
+      formatMessage(strings.resetShortcutTemplate, { key: normalizedResetKey })
+    );
   };
 
   const refreshState = () => {
@@ -159,15 +150,15 @@ export function createTourResetControl({
     if (pending) {
       resetButton.disabled = true;
       resetButton.dataset.state = 'pending';
-      resetButton.textContent = pendingLabel;
-      resetButton.title = idleTitle;
+      resetButton.textContent = strings.resetPendingLabel;
+      resetButton.title = getIdleTitle();
       resetButton.setAttribute(
         'aria-label',
-        appendClause(description, 'Resetting the guided tour…')
+        appendClause(strings.resetDescription, strings.resetPendingDescription)
       );
       resetButton.dataset.hudAnnounce = appendClause(
-        description,
-        'Resetting the guided tour…'
+        strings.resetDescription,
+        strings.resetPendingDescription
       );
       wrapper.dataset.pending = 'true';
       wrapper.setAttribute('aria-busy', 'true');
@@ -177,10 +168,10 @@ export function createTourResetControl({
     if (!hasVisited) {
       resetButton.disabled = true;
       resetButton.dataset.state = 'empty';
-      resetButton.textContent = emptyLabel;
-      resetButton.title = emptyDescription;
-      resetButton.setAttribute('aria-label', emptyDescription);
-      resetButton.dataset.hudAnnounce = emptyDescription;
+      resetButton.textContent = strings.resetEmptyLabel;
+      resetButton.title = strings.resetEmptyDescription;
+      resetButton.setAttribute('aria-label', strings.resetEmptyDescription);
+      resetButton.dataset.hudAnnounce = strings.resetEmptyDescription;
       wrapper.dataset.pending = 'false';
       wrapper.setAttribute('aria-busy', 'false');
       resetButton.setAttribute('aria-busy', 'false');
@@ -188,10 +179,13 @@ export function createTourResetControl({
     }
     resetButton.disabled = false;
     resetButton.dataset.state = 'ready';
-    resetButton.textContent = label;
-    resetButton.title = idleTitle;
-    resetButton.setAttribute('aria-label', description);
-    resetButton.dataset.hudAnnounce = buildHudAnnouncement(description, true);
+    resetButton.textContent = strings.resetLabel;
+    resetButton.title = getIdleTitle();
+    resetButton.setAttribute('aria-label', strings.resetDescription);
+    resetButton.dataset.hudAnnounce = buildHudAnnouncement(
+      strings.resetDescription,
+      true
+    );
     wrapper.dataset.pending = 'false';
     wrapper.setAttribute('aria-busy', 'false');
     resetButton.setAttribute('aria-busy', 'false');
@@ -275,6 +269,13 @@ export function createTourResetControl({
 
   return {
     element: wrapper,
+    setStrings(nextStrings) {
+      strings = nextStrings;
+      heading.textContent = strings.heading;
+      descriptionParagraph.textContent = strings.description;
+      refreshToggle();
+      refreshState();
+    },
     dispose() {
       resetButton.removeEventListener('click', handleClick);
       if (resetKey) {

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   AVAILABLE_LOCALES,
+  I18N_DEBUG_STORAGE_KEY,
   formatMessage,
   getControlOverlayStrings,
+  getGuidedTourControlStrings,
   getHelpModalStrings,
   getLocaleDirection,
+  getLocaleOptions,
   getLocaleToggleStrings,
   getModeAnnouncerStrings,
   getModeToggleStrings,
@@ -14,6 +17,7 @@ import {
   getPoiOverlayChromeStrings,
   getPoiCopy,
   getSiteStrings,
+  isI18nDebugEnabled,
   resolveLocale,
 } from '../assets/i18n';
 import { getPoiDefinitions } from '../scene/poi/registry';
@@ -24,6 +28,7 @@ describe('i18n utilities', () => {
     expect(AVAILABLE_LOCALES).toContain('en-x-pseudo');
     expect(AVAILABLE_LOCALES).toContain('ar');
     expect(AVAILABLE_LOCALES).toContain('ja');
+    expect(AVAILABLE_LOCALES).toContain('zh-Hans');
   });
 
   it('normalizes locale inputs with region modifiers and pseudo identifiers', () => {
@@ -34,6 +39,8 @@ describe('i18n utilities', () => {
     expect(resolveLocale('en_x_pseudo')).toBe('en-x-pseudo');
     expect(resolveLocale('ar-EG')).toBe('ar');
     expect(resolveLocale('ja-JP')).toBe('ja');
+    expect(resolveLocale('zh-CN')).toBe('zh-Hans');
+    expect(resolveLocale('zh_Hans')).toBe('zh-Hans');
   });
 
   it('detects locale direction for RTL and LTR language inputs', () => {
@@ -43,6 +50,7 @@ describe('i18n utilities', () => {
     expect(getLocaleDirection('AR_EG')).toBe('rtl');
     expect(getLocaleDirection('fa-IR')).toBe('rtl');
     expect(getLocaleDirection('ja-JP')).toBe('ltr');
+    expect(getLocaleDirection('zh-Hans')).toBe('ltr');
     expect(getLocaleDirection(undefined)).toBe('ltr');
   });
 
@@ -50,10 +58,39 @@ describe('i18n utilities', () => {
     expect(getLocaleScript('en')).toBe('latin');
     expect(getLocaleScript('en-x-pseudo')).toBe('latin');
     expect(getLocaleScript('zh-CN')).toBe('cjk');
+    expect(getLocaleScript('zh-Hans')).toBe('cjk');
     expect(getLocaleScript('ja')).toBe('cjk');
     expect(getLocaleScript('ko-KR')).toBe('cjk');
     expect(getLocaleScript('ar')).toBe('rtl');
     expect(getLocaleScript(undefined)).toBe('latin');
+  });
+
+  it('exposes public locale options while hiding pseudo without i18n debug', () => {
+    const publicOptions = getLocaleOptions();
+    expect(publicOptions.map((option) => option.id)).toEqual([
+      'en',
+      'zh-Hans',
+      'ja',
+      'ar',
+    ]);
+    expect(publicOptions.find((option) => option.id === 'zh-Hans')?.label).toBe(
+      '简体中文'
+    );
+    expect(publicOptions).not.toContainEqual(
+      expect.objectContaining({ id: 'en-x-pseudo' })
+    );
+
+    expect(
+      getLocaleOptions({ includeInternal: true }).map((option) => option.id)
+    ).toContain('en-x-pseudo');
+    expect(isI18nDebugEnabled({ search: '?i18nDebug=1' })).toBe(true);
+    expect(
+      isI18nDebugEnabled({
+        storage: {
+          getItem: (key) => (key === I18N_DEBUG_STORAGE_KEY ? '1' : null),
+        },
+      })
+    ).toBe(true);
   });
 
   it('formats template strings with provided values', () => {
@@ -265,6 +302,77 @@ describe('i18n utilities', () => {
     expect(
       formatMessage(japanese.visitedLabelTemplate, { time: '15:30' })
     ).toBe('15:30 に訪問');
+  });
+
+  it('provides Mandarin Chinese strings for primary visible UI surfaces', () => {
+    expect(getSiteStrings('zh-Hans').textFallback.recoveryCta.actionLabel).toBe(
+      '再次尝试沉浸模式'
+    );
+    expect(getHelpModalStrings('zh-Hans').heading).toBe('设置与帮助');
+    expect(getControlOverlayStrings('zh-Hans').menu.settings.label).toBe(
+      '设置'
+    );
+    expect(getGuidedTourControlStrings('zh-Hans').heading).toBe('引导游览');
+    expect(getPoiOverlayChromeStrings('zh-Hans').nextHighlight).toBe(
+      '下一个亮点'
+    );
+    expect(
+      getPoiCopy('zh-Hans')['futuroptimist-living-room-tv'].summary
+    ).toContain('自动化视频脚本工作台');
+    expect(getPoiDefinitions('zh-Hans')[0].title).toBe('Futuroptimist');
+  });
+
+  it('keeps every locale aligned with the required visible string schema', () => {
+    const assertNoMissingStrings = (value: unknown, path: string) => {
+      if (typeof value === 'string') {
+        expect(value.trim(), path).not.toHaveLength(0);
+        return;
+      }
+      if (Array.isArray(value)) {
+        expect(value.length, path).toBeGreaterThan(0);
+        value.forEach((item, index) =>
+          assertNoMissingStrings(item, `${path}[${index}]`)
+        );
+        return;
+      }
+      if (value && typeof value === 'object') {
+        Object.entries(value).forEach(([key, nested]) => {
+          if (
+            key === 'source' ||
+            key === 'href' ||
+            key === 'url' ||
+            key === 'logoUrl'
+          ) {
+            return;
+          }
+          assertNoMissingStrings(nested, `${path}.${key}`);
+        });
+      }
+    };
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const strings = getSiteStrings(locale);
+      assertNoMissingStrings(
+        strings.textFallback,
+        `${locale}.site.textFallback`
+      );
+      assertNoMissingStrings(
+        getControlOverlayStrings(locale),
+        `${locale}.hud.controlOverlay`
+      );
+      assertNoMissingStrings(
+        getHelpModalStrings(locale),
+        `${locale}.hud.helpModal`
+      );
+      assertNoMissingStrings(
+        getGuidedTourControlStrings(locale),
+        `${locale}.hud.guidedTour`
+      );
+      assertNoMissingStrings(
+        getPoiOverlayChromeStrings(locale),
+        `${locale}.hud.poiOverlay`
+      );
+    }
   });
 
   it('provides localized copy for POIs with English fallback', () => {

--- a/src/tests/textFallbackAccessibility.test.ts
+++ b/src/tests/textFallbackAccessibility.test.ts
@@ -104,6 +104,22 @@ describe('text fallback accessibility', () => {
     });
   }
 
+  it('renders Mandarin Chinese fallback CTA and lang metadata', () => {
+    const container = document.createElement('div');
+    document.documentElement.lang = 'zh-CN';
+
+    renderTextFallback(container, {
+      reason: 'manual',
+      immersiveUrl: 'https://danielsmith.io/portfolio',
+    });
+
+    expect(document.documentElement.lang).toBe('zh-Hans');
+    expect(container.lang).toBe('zh-Hans');
+    expect(container.dataset.localeScript).toBe('cjk');
+    expect(container.textContent).toContain('再次尝试沉浸模式');
+    expect(container.textContent).toContain('浏览亮点');
+  });
+
   it('normalizes provided immersive URLs without disabling failover for normal recovery', () => {
     const container = document.createElement('div');
 

--- a/src/tests/tourGuideToggleControl.test.ts
+++ b/src/tests/tourGuideToggleControl.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getGuidedTourControlStrings } from '../assets/i18n';
 import { createTourGuideToggleControl } from '../systems/controls/tourGuideToggleControl';
 
 describe('tourGuideToggleControl', () => {
   it('renders an enabled toggle by default', () => {
     const container = document.createElement('div');
-    const handle = createTourGuideToggleControl({ container });
+    const handle = createTourGuideToggleControl({
+      container,
+      strings: getGuidedTourControlStrings('en'),
+    });
 
     expect(container.querySelector('.tour-toggle')).toBe(handle.element);
     expect(handle.element.dataset.state).toBe('enabled');
     expect(handle.element.getAttribute('aria-pressed')).toBe('true');
-    expect(handle.element.dataset.hudAnnounce).toContain('Guided tour on');
+    expect(handle.element.dataset.hudAnnounce).toContain(
+      'Guided tour highlights enabled'
+    );
 
     handle.dispose();
   });
@@ -22,6 +28,7 @@ describe('tourGuideToggleControl', () => {
       container,
       initialEnabled: true,
       onToggle,
+      strings: getGuidedTourControlStrings('en'),
     });
 
     handle.element.click();
@@ -44,6 +51,7 @@ describe('tourGuideToggleControl', () => {
       container,
       initialEnabled: false,
       onToggle,
+      strings: getGuidedTourControlStrings('en'),
     });
 
     handle.setEnabled(true);
@@ -59,7 +67,10 @@ describe('tourGuideToggleControl', () => {
 
   it('cleans up DOM and listeners on dispose', () => {
     const container = document.createElement('div');
-    const handle = createTourGuideToggleControl({ container });
+    const handle = createTourGuideToggleControl({
+      container,
+      strings: getGuidedTourControlStrings('en'),
+    });
 
     const button = handle.element;
     handle.dispose();

--- a/src/tests/tourResetControl.test.ts
+++ b/src/tests/tourResetControl.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getGuidedTourControlStrings } from '../assets/i18n';
+import type { PoiId } from '../scene/poi/types';
 import { createTourResetControl } from '../systems/controls/tourResetControl';
 import { GuidedTourPreference } from '../systems/guidedTour/preference';
 
@@ -16,19 +18,19 @@ describe('createTourResetControl', () => {
   };
 
   const createVisitedSubscription = () => {
-    let listener: ((visited: ReadonlySet<string>) => void) | null = null;
+    let listener: ((visited: ReadonlySet<PoiId>) => void) | null = null;
     const unsubscribe = vi.fn(() => {
       listener = null;
     });
     const subscribe = (
-      next: (visited: ReadonlySet<string>) => void
+      next: (visited: ReadonlySet<PoiId>) => void
     ): (() => void) => {
       listener = next;
       next(new Set());
       return unsubscribe;
     };
     const emit = (ids: Iterable<string>) => {
-      listener?.(new Set(ids));
+      listener?.(new Set(ids as Iterable<PoiId>));
     };
     return { subscribe, emit, unsubscribe };
   };
@@ -55,6 +57,7 @@ describe('createTourResetControl', () => {
       subscribeVisited: subscription.subscribe,
       onReset: vi.fn(),
       guidedTourPreference: preference,
+      strings: getGuidedTourControlStrings('en'),
     });
 
     const wrapper = handle.element;
@@ -72,7 +75,10 @@ describe('createTourResetControl', () => {
       'Explore exhibits to unlock the guided tour reset.'
     );
 
-    subscription.emit(['a', 'b']);
+    subscription.emit([
+      'futuroptimist-living-room-tv',
+      'tokenplace-studio-cluster',
+    ]);
     expect(resetButton.disabled).toBe(false);
     expect(resetButton.dataset.state).toBe('ready');
     expect(resetButton.textContent).toBe('Restart guided tour');
@@ -90,7 +96,7 @@ describe('createTourResetControl', () => {
   it('activates via click and keyboard, handling async completion', async () => {
     const container = createContainer();
     const subscription = createVisitedSubscription();
-    subscription.emit(['seed']);
+    subscription.emit(['futuroptimist-living-room-tv']);
     const preference = createPreference();
 
     const reset = vi.fn(() => Promise.resolve());
@@ -101,12 +107,13 @@ describe('createTourResetControl', () => {
       resetKey: 'r',
       windowTarget: window,
       guidedTourPreference: preference,
+      strings: getGuidedTourControlStrings('en'),
     });
 
     const resetButton = handle.element.querySelector(
       '.tour-reset'
     ) as HTMLButtonElement;
-    subscription.emit(['seed']);
+    subscription.emit(['futuroptimist-living-room-tv']);
     expect(resetButton.disabled).toBe(false);
 
     resetButton.click();
@@ -124,7 +131,7 @@ describe('createTourResetControl', () => {
     expect(handle.element.getAttribute('aria-busy')).toBe('false');
     expect(resetButton.getAttribute('aria-busy')).toBe('false');
 
-    subscription.emit(['next']);
+    subscription.emit(['tokenplace-studio-cluster']);
     const event = new KeyboardEvent('keydown', { key: 'r' });
     window.dispatchEvent(event);
     expect(reset).toHaveBeenCalledTimes(2);
@@ -143,7 +150,7 @@ describe('createTourResetControl', () => {
   it('handles async rejections without leaving pending state', async () => {
     const container = createContainer();
     const subscription = createVisitedSubscription();
-    subscription.emit(['seed']);
+    subscription.emit(['futuroptimist-living-room-tv']);
     const preference = createPreference();
 
     const reset = vi.fn(() => Promise.reject(new Error('nope')));
@@ -154,18 +161,19 @@ describe('createTourResetControl', () => {
       resetKey: 'r',
       windowTarget: window,
       guidedTourPreference: preference,
+      strings: getGuidedTourControlStrings('en'),
     });
 
     const resetButton = handle.element.querySelector(
       '.tour-reset'
     ) as HTMLButtonElement;
-    subscription.emit(['seed']);
+    subscription.emit(['futuroptimist-living-room-tv']);
     expect(resetButton.disabled).toBe(false);
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'r' }));
     expect(reset).toHaveBeenCalledTimes(1);
     expect(resetButton.dataset.state).toBe('pending');
-    subscription.emit(['seed']);
+    subscription.emit(['futuroptimist-living-room-tv']);
     await flushPromises();
     await flushPromises();
     expect(resetButton.dataset.state).toBe('ready');
@@ -181,7 +189,7 @@ describe('createTourResetControl', () => {
   it('recovers from synchronous reset errors', () => {
     const container = createContainer();
     const subscription = createVisitedSubscription();
-    subscription.emit(['seed']);
+    subscription.emit(['futuroptimist-living-room-tv']);
     const preference = createPreference();
 
     const reset = vi.fn(() => {
@@ -193,9 +201,10 @@ describe('createTourResetControl', () => {
       subscribeVisited: subscription.subscribe,
       onReset: reset,
       guidedTourPreference: preference,
+      strings: getGuidedTourControlStrings('en'),
     });
 
-    subscription.emit(['seed']);
+    subscription.emit(['futuroptimist-living-room-tv']);
     const resetButton = handle.element.querySelector(
       '.tour-reset'
     ) as HTMLButtonElement;
@@ -219,6 +228,7 @@ describe('createTourResetControl', () => {
       subscribeVisited: subscription.subscribe,
       onReset: vi.fn(),
       guidedTourPreference: preference,
+      strings: getGuidedTourControlStrings('en'),
     });
 
     const wrapper = handle.element;

--- a/src/ui/softwareRendererWarning.ts
+++ b/src/ui/softwareRendererWarning.ts
@@ -1,3 +1,5 @@
+import { formatMessage } from '../assets/i18n';
+import type { SoftwareRendererWarningStrings } from '../assets/i18n/types';
 import type { RendererInfoSnapshot } from '../scene/performance/rendererCapabilities';
 
 export interface SoftwareRendererWarningOptions {
@@ -7,17 +9,22 @@ export interface SoftwareRendererWarningOptions {
   textUrl: string;
   onContinueSafe?: () => void;
   onVisible?: (message: string) => void;
+  strings: SoftwareRendererWarningStrings;
 }
 
 export interface SoftwareRendererWarningHandle {
   element: HTMLElement;
+  setStrings(strings: SoftwareRendererWarningStrings): void;
   dispose(): void;
 }
 
-const rendererLabel = (rendererInfo: RendererInfoSnapshot) =>
+const rendererLabel = (
+  rendererInfo: RendererInfoSnapshot,
+  strings: SoftwareRendererWarningStrings
+) =>
   rendererInfo.unmaskedRenderer ??
   rendererInfo.renderer ??
-  'software WebGL renderer';
+  strings.rendererFallbackLabel;
 
 export function createSoftwareRendererWarning({
   rendererInfo,
@@ -26,8 +33,10 @@ export function createSoftwareRendererWarning({
   textUrl,
   onContinueSafe,
   onVisible,
+  strings: initialStrings,
 }: SoftwareRendererWarningOptions): SoftwareRendererWarningHandle {
   const documentTarget = document;
+  let strings = initialStrings;
   const element = documentTarget.createElement('aside');
   element.className = 'software-renderer-warning';
   element.setAttribute('role', 'alert');
@@ -40,21 +49,22 @@ export function createSoftwareRendererWarning({
 
   const title = documentTarget.createElement('h2');
   title.className = 'software-renderer-warning__title';
-  title.textContent = 'Software rendering detected';
+  title.textContent = strings.title;
   element.appendChild(title);
 
   const description = documentTarget.createElement('p');
   description.className = 'software-renderer-warning__description';
-  description.textContent =
-    `Chrome is using ${rendererLabel(rendererInfo)} instead of hardware acceleration. ` +
-    'Basic Render Driver, SwiftShader, WARP, and llvmpipe can crash under continuous WebGL animation.';
+  const updateDescription = () => {
+    description.textContent = formatMessage(strings.descriptionTemplate, {
+      renderer: rendererLabel(rendererInfo, strings),
+    });
+  };
+  updateDescription();
   element.appendChild(description);
 
   const recommendation = documentTarget.createElement('p');
   recommendation.className = 'software-renderer-warning__recommendation';
-  recommendation.textContent =
-    'Enable browser hardware acceleration for the smooth immersive portfolio. ' +
-    'Safe immersive mode keeps screenshots and debugging available at a capped frame rate.';
+  recommendation.textContent = strings.recommendation;
   element.appendChild(recommendation);
 
   const actions = documentTarget.createElement('div');
@@ -64,7 +74,7 @@ export function createSoftwareRendererWarning({
   safeButton.type = 'button';
   safeButton.className = 'software-renderer-warning__button';
   safeButton.dataset.action = 'continue-safe-immersive';
-  safeButton.textContent = 'Continue in safe immersive';
+  safeButton.textContent = strings.continueSafeLabel;
   safeButton.addEventListener('click', () => {
     dispose();
     onContinueSafe?.();
@@ -75,7 +85,7 @@ export function createSoftwareRendererWarning({
   continuousLink.className = 'software-renderer-warning__link';
   continuousLink.dataset.action = 'continuous-immersive';
   continuousLink.href = continuousUrl;
-  continuousLink.textContent = 'Enable continuous immersive anyway';
+  continuousLink.textContent = strings.continuousLabel;
   actions.appendChild(continuousLink);
 
   const textLink = documentTarget.createElement('a');
@@ -83,21 +93,31 @@ export function createSoftwareRendererWarning({
     'software-renderer-warning__link software-renderer-warning__link--muted';
   textLink.dataset.action = 'text-mode';
   textLink.href = textUrl;
-  textLink.textContent = 'Use text mode';
+  textLink.textContent = strings.textModeLabel;
   actions.appendChild(textLink);
 
   const safeLink = documentTarget.createElement('a');
   safeLink.className = 'software-renderer-warning__safe-link';
   safeLink.href = safeUrl;
-  safeLink.textContent = 'Reload this safe immersive URL';
+  safeLink.textContent = strings.safeUrlLabel;
   element.appendChild(actions);
   element.appendChild(safeLink);
 
   documentTarget.body.appendChild(element);
-  onVisible?.(description.textContent ?? 'Software rendering detected');
+  onVisible?.(description.textContent ?? strings.title);
 
   return {
     element,
+    setStrings(nextStrings) {
+      strings = nextStrings;
+      title.textContent = strings.title;
+      updateDescription();
+      recommendation.textContent = strings.recommendation;
+      safeButton.textContent = strings.continueSafeLabel;
+      continuousLink.textContent = strings.continuousLabel;
+      textLink.textContent = strings.textModeLabel;
+      safeLink.textContent = strings.safeUrlLabel;
+    },
     dispose,
   };
 }


### PR DESCRIPTION
### Motivation
- Add first-class Simplified Mandarin (`zh-Hans`) support so the visible UI (HUD, text fallback, POIs) is fully localizable. 
- Ensure all user-visible strings are typed, come from locale data, and refresh at runtime when the active locale changes. 
- Keep the pseudo-locale available for QA but hidden from normal Settings unless i18n debug mode is explicitly enabled.

### Description
- Added `zh-Hans` as a new `Locale` and a full `src/assets/i18n/locales/zh-Hans.ts` override with translations for site text fallback, HUD, movement legend, audio controls, mode/locale toggles, help modal, customization, guided tour, software-renderer warning, narrative log, and POI copy. 
- Expanded `LocaleStrings` and related types with `GuidedTourControlStrings` and `SoftwareRendererWarningStrings`, and exposed `getGuidedTourControlStrings` and `getSoftwareRendererWarningStrings` accessor helpers. 
- Introduced `getLocaleOptions` and `isI18nDebugEnabled` utilities to provide Settings options and to hide `en-x-pseudo` unless debug is enabled via `import.meta.env.DEV`, `?i18nDebug=1`, or `localStorage` flag. 
- Refactored guided-tour controls and software-renderer UI to accept typed strings, support `setStrings(...)` for runtime updates, and removed hard-coded user-facing English from those components. 
- Wired `applyLocaleUpdate(...)` in `src/main.ts` to refresh all HUD/help/POI/guided-tour/software-renderer strings and metadata (lang/dir/script) when the locale changes. 
- Added tests that assert locale options, `zh-Hans` presence, document `lang` resolution, Mandarin text in the text-fallback CTA and help headings, and a schema check that fails when visible strings are missing. 
- Documented the i18n debug gate in `README.md`.

### Testing
- `npm run format:write` — passed. 
- `npm run lint` — passed (one pre-existing lint warning fixed). 
- `npm run typecheck` — produced many pre-existing repo type errors unrelated to these i18n/local changes; filtered review showed no type errors introduced by the touched i18n/tour/software-renderer files. 
- Focused unit tests: `npm run test:ci -- src/tests/i18n.test.ts src/tests/textFallbackAccessibility.test.ts src/tests/tourGuideToggleControl.test.ts src/tests/tourResetControl.test.ts` — all tests passed. 
- Full test suite: `npm run test:ci` — all tests passed (reported 934 tests passing in CI run). 
- Build and smoke: `npm run build` and `npm run docs:check` and `node scripts/assert-dist.cjs` — build and smoke checks passed. 
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected. 
- Playwright capture: installed browsers and deps (`npx playwright install` / `npx playwright install-deps`) and produced a settings screenshot at `/tmp/mandarin-i18n-settings.png` during a preview run (Playwright host deps installed in the environment). 

Residual notes and follow-ups: the repo has baseline TypeScript errors unrelated to this change; this PR limits its type surface to i18n/schema, control wiring, and tests only. The pseudo-locale remains available for QA via the documented debug gate. Please review `src/assets/i18n/locales/zh-Hans.ts` for copy edits or community translation adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1facbb991c832fbec68929cc82d057)