### PR TITLE
Add aggressive low‑poly LODs and scene detail policy for Performance graphics mode

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -36,6 +36,33 @@ and the Vitest assertions when measurable changes land.
   run `renderer.info.render` and `renderer.info.memory` after the camera settles
   at launch. Update the snapshot date and notes when refreshing numbers.
 
+## Performance scene detail mode
+
+Performance graphics quality now applies a centralized scene detail policy in
+addition to DPR, bloom, exposure, mirror, and LED reductions. The intent is a
+roughly 10× theoretical workload reduction on constrained tablets and mobile
+GPUs; real FPS gains still depend on browser, thermal, and driver behavior.
+Balanced and Cinematic continue to share the original high-detail scene policy.
+
+When Performance is selected or reached adaptively, the low-detail policy:
+
+- lowers procedural cylinder/sphere/ring/torus segments used by POI markers,
+  the avatar mannequin, and major decorative structures;
+- reduces Jobbot and media-wall canvas texture dimensions from 2048×1024 to
+  512×256, and throttles performance-mode canvas redraws;
+- disables nonessential transparent shader/overdraw effects such as backyard
+  walkway mist, greenhouse pond ripples, flywheel glass/halo details, Jobbot
+  data shards and telemetry panels, and media-wall glow planes;
+- disables or hides nonessential point lights and skips/throttles unfocused
+  decorative update loops;
+- exposes renderer counters (`calls`, `triangles`, `points`, `lines`,
+  `memory.geometries`, and `memory.textures`) plus the active scene-detail
+  budget through `window.portfolio.performance.getSnapshot()`.
+
+Fresh sessions on coarse-pointer, mobile/tablet-like, or constrained-memory/CPU
+hardware start in Performance when no explicit graphics-quality preference is
+persisted. Explicit user selections remain authoritative.
+
 ## Adaptive quality warmup and recovery
 
 Staging on May 29, 2026 showed two renderer classes that need different

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -29,6 +29,22 @@ interface PerformanceSnapshot {
     lastAdaptiveReason: string | null;
     lastAdaptiveDowngradeReason: string | null;
     lastAdaptiveRecoveryReason: string | null;
+    sceneDetail?: {
+      level: 'cinematic' | 'balanced' | 'performance';
+      theoreticalBudget: {
+        transparentShaderLayers: number;
+        dynamicPointLights: number;
+        decorativeDrawCalls: number;
+        poiTriangleScale: number;
+        structureTriangleScale: number;
+      };
+      policy: {
+        textures: {
+          jobbotScreen: { width: number; height: number };
+          mediaWallScreen: { width: number; height: number };
+        };
+      };
+    };
     adaptivePolicy: {
       isWarmingUp: boolean;
       warmupElapsedMs: number;
@@ -46,6 +62,14 @@ interface PerformanceSnapshot {
     mirrorRenderTargetSize: number;
     mirrorUpdateRateFps: number;
     mirrorRenderCount: number;
+  };
+  rendererCounters: {
+    calls: number;
+    triangles: number;
+    points: number;
+    lines: number;
+    memoryGeometries: number;
+    memoryTextures: number;
   };
   renderer: {
     isSoftwareRenderer: boolean;
@@ -211,6 +235,50 @@ test.describe('immersive performance diagnostics', () => {
         expect(snapshot.features.composerEnabled).toBe(false);
         expect(snapshot.features.mirrorEnabled).toBe(false);
       }
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('reports aggressive performance scene detail budgets when forced by user preference', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'danielsmith:graphics-quality-level',
+        'performance'
+      );
+    });
+
+    try {
+      await waitForImmersive(page, IMMERSIVE_DIAGNOSTICS_URL);
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.quality.level).toBe('performance');
+      expect(snapshot.quality.sceneDetail?.level).toBe('performance');
+      expect(snapshot.quality.sceneDetail?.theoreticalBudget).toMatchObject({
+        transparentShaderLayers: 0,
+        dynamicPointLights: 1,
+      });
+      expect(
+        snapshot.quality.sceneDetail?.theoreticalBudget.poiTriangleScale
+      ).toBeLessThanOrEqual(0.2);
+      expect(
+        snapshot.quality.sceneDetail?.theoreticalBudget.structureTriangleScale
+      ).toBeLessThanOrEqual(0.2);
+      expect(
+        snapshot.quality.sceneDetail?.policy.textures.jobbotScreen.width
+      ).toBeLessThanOrEqual(512);
+      expect(
+        snapshot.quality.sceneDetail?.policy.textures.mediaWallScreen.width
+      ).toBeLessThanOrEqual(512);
+      expect(snapshot.rendererCounters.calls).toBeGreaterThanOrEqual(0);
+      expect(snapshot.rendererCounters.triangles).toBeGreaterThanOrEqual(0);
+      expect(snapshot.rendererCounters.memoryGeometries).toBeGreaterThanOrEqual(
+        0
+      );
     } finally {
       await context.close();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -775,6 +775,9 @@ function initializeImmersiveScene(
   const navigatorWithMemory = navigator as Navigator & {
     deviceMemory?: number;
   };
+  const persistedQualityLevel = rendererInfo.isSoftwareRenderer
+    ? null
+    : resolvePersistedGraphicsQualityLevel(qualityStorage);
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
     window.devicePixelRatio ?? 1,
@@ -787,11 +790,9 @@ function initializeImmersiveScene(
         (coarsePointer && window.innerWidth >= 700),
       deviceMemoryGb: navigatorWithMemory.deviceMemory ?? null,
       hardwareConcurrency: navigator.hardwareConcurrency ?? null,
+      explicitGraphicsQualityLevel: persistedQualityLevel,
     }
   );
-  const persistedQualityLevel = rendererInfo.isSoftwareRenderer
-    ? null
-    : resolvePersistedGraphicsQualityLevel(qualityStorage);
   const sceneDetailReloadOverride = consumePendingSceneDetailReloadLevel();
   const effectiveInitialQualityLevel =
     sceneDetailReloadOverride ??

--- a/src/main.ts
+++ b/src/main.ts
@@ -532,6 +532,7 @@ const CEILING_COVE_OFFSET = 0.35;
 const BACKYARD_ROOM_ID = 'backyard';
 const PENDING_SCENE_DETAIL_RELOAD_KEY =
   'portfolio::pending-scene-detail-reload-level';
+const PENDING_SCENE_DETAIL_RELOAD_PARAM = 'sceneDetailReloadLevel';
 
 function consumePendingSceneDetailReloadLevel(): GraphicsQualityLevel | null {
   try {
@@ -539,6 +540,18 @@ function consumePendingSceneDetailReloadLevel(): GraphicsQualityLevel | null {
       PENDING_SCENE_DETAIL_RELOAD_KEY
     );
     window.sessionStorage.removeItem(PENDING_SCENE_DETAIL_RELOAD_KEY);
+    if (isGraphicsQualityLevel(stored)) {
+      return stored;
+    }
+  } catch {
+    // Fall through to the URL handoff used when sessionStorage is unavailable.
+  }
+
+  try {
+    const url = new URL(window.location.href);
+    const stored = url.searchParams.get(PENDING_SCENE_DETAIL_RELOAD_PARAM);
+    url.searchParams.delete(PENDING_SCENE_DETAIL_RELOAD_PARAM);
+    window.history.replaceState(window.history.state, '', url);
     return isGraphicsQualityLevel(stored) ? stored : null;
   } catch {
     return null;
@@ -547,12 +560,27 @@ function consumePendingSceneDetailReloadLevel(): GraphicsQualityLevel | null {
 
 function persistPendingSceneDetailReloadLevel(
   level: GraphicsQualityLevel
-): void {
+): boolean {
   try {
     window.sessionStorage.setItem(PENDING_SCENE_DETAIL_RELOAD_KEY, level);
+    return (
+      window.sessionStorage.getItem(PENDING_SCENE_DETAIL_RELOAD_KEY) === level
+    );
   } catch {
-    // If session storage is unavailable, reloading still rebuilds from persisted
-    // user quality or the device-derived initial policy.
+    return false;
+  }
+}
+
+function reloadWithPendingSceneDetailParam(
+  level: GraphicsQualityLevel
+): boolean {
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set(PENDING_SCENE_DETAIL_RELOAD_PARAM, level);
+    window.location.assign(url.toString());
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -815,9 +843,16 @@ function initializeImmersiveScene(
       return;
     }
     if (options.reloadScene) {
-      persistPendingSceneDetailReloadLevel(level);
-      window.location.reload();
-      return;
+      if (persistPendingSceneDetailReloadLevel(level)) {
+        window.location.reload();
+        return;
+      }
+      if (reloadWithPendingSceneDetailParam(level)) {
+        return;
+      }
+      console.warn(
+        '[performance] scene detail reload handoff unavailable; applying policy without reload'
+      );
     }
     sceneDetailController.setLevel(level);
     activeSceneDetailPolicy = sceneDetailController.getPolicy();

--- a/src/main.ts
+++ b/src/main.ts
@@ -532,16 +532,28 @@ const CEILING_COVE_OFFSET = 0.35;
 const BACKYARD_ROOM_ID = 'backyard';
 const PENDING_SCENE_DETAIL_RELOAD_KEY =
   'portfolio::pending-scene-detail-reload-level';
+const PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY =
+  'portfolio::pending-scene-detail-adaptive-lock';
 const PENDING_SCENE_DETAIL_RELOAD_PARAM = 'sceneDetailReloadLevel';
+const PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM = 'sceneDetailAdaptiveLock';
 
-function consumePendingSceneDetailReloadLevel(): GraphicsQualityLevel | null {
+interface PendingSceneDetailReload {
+  level: GraphicsQualityLevel;
+  adaptivePerformanceRecoveryLocked: boolean;
+}
+
+function consumePendingSceneDetailReload(): PendingSceneDetailReload | null {
   try {
     const stored = window.sessionStorage.getItem(
       PENDING_SCENE_DETAIL_RELOAD_KEY
     );
+    const adaptiveLock =
+      window.sessionStorage.getItem(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY) ===
+      '1';
     window.sessionStorage.removeItem(PENDING_SCENE_DETAIL_RELOAD_KEY);
+    window.sessionStorage.removeItem(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY);
     if (isGraphicsQualityLevel(stored)) {
-      return stored;
+      return { level: stored, adaptivePerformanceRecoveryLocked: adaptiveLock };
     }
   } catch {
     // Fall through to the URL handoff used when sessionStorage is unavailable.
@@ -550,21 +562,36 @@ function consumePendingSceneDetailReloadLevel(): GraphicsQualityLevel | null {
   try {
     const url = new URL(window.location.href);
     const stored = url.searchParams.get(PENDING_SCENE_DETAIL_RELOAD_PARAM);
+    const adaptiveLock =
+      url.searchParams.get(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM) === '1';
     url.searchParams.delete(PENDING_SCENE_DETAIL_RELOAD_PARAM);
+    url.searchParams.delete(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM);
     window.history.replaceState(window.history.state, '', url);
-    return isGraphicsQualityLevel(stored) ? stored : null;
+    return isGraphicsQualityLevel(stored)
+      ? { level: stored, adaptivePerformanceRecoveryLocked: adaptiveLock }
+      : null;
   } catch {
     return null;
   }
 }
 
-function persistPendingSceneDetailReloadLevel(
-  level: GraphicsQualityLevel
+function persistPendingSceneDetailReload(
+  pendingReload: PendingSceneDetailReload
 ): boolean {
   try {
-    window.sessionStorage.setItem(PENDING_SCENE_DETAIL_RELOAD_KEY, level);
+    window.sessionStorage.setItem(
+      PENDING_SCENE_DETAIL_RELOAD_KEY,
+      pendingReload.level
+    );
+    window.sessionStorage.setItem(
+      PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY,
+      pendingReload.adaptivePerformanceRecoveryLocked ? '1' : '0'
+    );
     return (
-      window.sessionStorage.getItem(PENDING_SCENE_DETAIL_RELOAD_KEY) === level
+      window.sessionStorage.getItem(PENDING_SCENE_DETAIL_RELOAD_KEY) ===
+        pendingReload.level &&
+      window.sessionStorage.getItem(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY) ===
+        (pendingReload.adaptivePerformanceRecoveryLocked ? '1' : '0')
     );
   } catch {
     return false;
@@ -572,11 +599,19 @@ function persistPendingSceneDetailReloadLevel(
 }
 
 function reloadWithPendingSceneDetailParam(
-  level: GraphicsQualityLevel
+  pendingReload: PendingSceneDetailReload
 ): boolean {
   try {
     const url = new URL(window.location.href);
-    url.searchParams.set(PENDING_SCENE_DETAIL_RELOAD_PARAM, level);
+    url.searchParams.set(
+      PENDING_SCENE_DETAIL_RELOAD_PARAM,
+      pendingReload.level
+    );
+    if (pendingReload.adaptivePerformanceRecoveryLocked) {
+      url.searchParams.set(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM, '1');
+    } else {
+      url.searchParams.delete(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM);
+    }
     window.location.assign(url.toString());
     return true;
   } catch {
@@ -821,13 +856,13 @@ function initializeImmersiveScene(
       explicitGraphicsQualityLevel: persistedQualityLevel,
     }
   );
-  const sceneDetailReloadOverride = consumePendingSceneDetailReloadLevel();
+  const sceneDetailReloadOverride = consumePendingSceneDetailReload();
   const effectiveInitialQualityLevel =
-    sceneDetailReloadOverride ??
+    sceneDetailReloadOverride?.level ??
     persistedQualityLevel ??
     initialQualityPolicy.initialLevel;
   const initialSceneDetailLevel =
-    sceneDetailReloadOverride ??
+    sceneDetailReloadOverride?.level ??
     persistedQualityLevel ??
     initialQualityPolicy.sceneDetailLevel;
   const sceneDetailController = createSceneDetailController(
@@ -836,18 +871,26 @@ function initializeImmersiveScene(
   let activeSceneDetailPolicy = getSceneDetailPolicy(initialSceneDetailLevel);
   const applySceneDetailLevel = (
     level: GraphicsQualityLevel,
-    options: { reloadScene?: boolean } = {}
+    options: {
+      reloadScene?: boolean;
+      adaptivePerformanceRecoveryLocked?: boolean;
+    } = {}
   ) => {
     if (level === sceneDetailController.getLevel()) {
       activeSceneDetailPolicy = sceneDetailController.getPolicy();
       return;
     }
     if (options.reloadScene) {
-      if (persistPendingSceneDetailReloadLevel(level)) {
+      const pendingReload = {
+        level,
+        adaptivePerformanceRecoveryLocked:
+          options.adaptivePerformanceRecoveryLocked === true,
+      } satisfies PendingSceneDetailReload;
+      if (persistPendingSceneDetailReload(pendingReload)) {
         window.location.reload();
         return;
       }
-      if (reloadWithPendingSceneDetailParam(level)) {
+      if (reloadWithPendingSceneDetailParam(pendingReload)) {
         return;
       }
       console.warn(
@@ -3700,8 +3743,13 @@ function initializeImmersiveScene(
     isSoftwareRenderer: rendererInfo.isSoftwareRenderer,
     getSelectionSource: () =>
       graphicsQualityManager?.getSelectionSource() ?? 'initial',
+    initialAdaptivePerformanceRecoveryLocked:
+      sceneDetailReloadOverride?.adaptivePerformanceRecoveryLocked === true,
     onSceneDetailLevelChange: (level) => {
-      applySceneDetailLevel(level, { reloadScene: true });
+      applySceneDetailLevel(level, {
+        reloadScene: true,
+        adaptivePerformanceRecoveryLocked: level === 'performance',
+      });
     },
     onAction: (event) => {
       console.info('[performance] adaptive quality action', event);

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,8 +112,13 @@ import {
 import {
   GRAPHICS_QUALITY_PRESETS,
   createGraphicsQualityManager,
+  resolvePersistedGraphicsQualityLevel,
   type GraphicsQualityManager,
 } from './scene/graphics/qualityManager';
+import {
+  createSceneDetailController,
+  getSceneDetailPolicy,
+} from './scene/graphics/sceneDetailPolicy';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -730,11 +735,41 @@ function initializeImmersiveScene(
     rendererInfo,
     window.location.search
   );
+  let qualityStorage: Storage | undefined;
+  try {
+    qualityStorage = window.localStorage;
+  } catch {
+    qualityStorage = undefined;
+  }
+  const coarsePointer =
+    window.matchMedia?.('(pointer: coarse)').matches ?? false;
+  const userAgent = navigator.userAgent.toLowerCase();
+  const navigatorWithMemory = navigator as Navigator & {
+    deviceMemory?: number;
+  };
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
     window.devicePixelRatio ?? 1,
-    softwareRendererPolicy
+    softwareRendererPolicy,
+    {
+      coarsePointer,
+      mobileLike: /android|iphone|ipod|mobile/.test(userAgent),
+      tabletLike:
+        /ipad|tablet/.test(userAgent) ||
+        (coarsePointer && window.innerWidth >= 700),
+      deviceMemoryGb: navigatorWithMemory.deviceMemory ?? null,
+      hardwareConcurrency: navigator.hardwareConcurrency ?? null,
+    }
   );
+  const persistedQualityLevel = rendererInfo.isSoftwareRenderer
+    ? null
+    : resolvePersistedGraphicsQualityLevel(qualityStorage);
+  const initialSceneDetailLevel =
+    persistedQualityLevel ?? initialQualityPolicy.initialLevel;
+  const sceneDetailController = createSceneDetailController(
+    initialSceneDetailLevel
+  );
+  let activeSceneDetailPolicy = getSceneDetailPolicy(initialSceneDetailLevel);
   const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
     ? initialQualityPolicy.basePixelRatioCap
     : rendererInfo.isSoftwareRenderer
@@ -1152,6 +1187,7 @@ function initializeImmersiveScene(
   if (backyardRoom) {
     backyardEnvironment = createBackyardEnvironment(backyardRoom.bounds, {
       seasonalPreset,
+      detailPolicy: activeSceneDetailPolicy,
     });
     scene.add(backyardEnvironment.group);
     // Remove the enclosing sky dome to avoid a bright circular spheroid.
@@ -1244,7 +1280,10 @@ function initializeImmersiveScene(
 
   const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom');
   if (livingRoom) {
-    const mediaWall = createLivingRoomMediaWall(livingRoom.bounds);
+    const mediaWall = createLivingRoomMediaWall(
+      livingRoom.bounds,
+      activeSceneDetailPolicy
+    );
     scene.add(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
@@ -1547,7 +1586,9 @@ function initializeImmersiveScene(
   });
   lightmapAnimator.captureBaseline();
 
-  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides);
+  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
+    detailPolicy: activeSceneDetailPolicy,
+  });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
       scene.add(poi.group);
@@ -1926,6 +1967,7 @@ function initializeImmersiveScene(
       centerZ,
       roomBounds: studioRoom.bounds,
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
+      detailPolicy: activeSceneDetailPolicy,
     });
     scene.add(showpiece.group);
     showpiece.colliders.forEach((collider) => groundColliders.push(collider));
@@ -1945,6 +1987,7 @@ function initializeImmersiveScene(
     const terminal = createJobbotTerminal({
       position: { x: terminalX, y: 0, z: terminalZ },
       orientationRadians: terminalOrientation,
+      detailPolicy: activeSceneDetailPolicy,
     });
     scene.add(terminal.group);
     terminal.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2176,6 +2219,7 @@ function initializeImmersiveScene(
 
   const mannequin = createPortfolioMannequin({
     collisionRadius: PLAYER_RADIUS,
+    detailPolicy: activeSceneDetailPolicy,
   });
   const player = mannequin.group;
   const mannequinHeight = mannequin.height;
@@ -3535,13 +3579,6 @@ function initializeImmersiveScene(
   resetMotionBlurHistory = () => motionBlurController?.resetHistory();
   composer.addPass(motionBlurController.pass);
 
-  let qualityStorage: Storage | undefined;
-  try {
-    qualityStorage = window.localStorage;
-  } catch {
-    qualityStorage = undefined;
-  }
-
   graphicsQualityManager = createGraphicsQualityManager({
     renderer,
     bloomPass: bloomPass ?? undefined,
@@ -3575,6 +3612,10 @@ function initializeImmersiveScene(
     isSoftwareRenderer: rendererInfo.isSoftwareRenderer,
     getSelectionSource: () =>
       graphicsQualityManager?.getSelectionSource() ?? 'initial',
+    onSceneDetailLevelChange: (level) => {
+      sceneDetailController.setLevel(level);
+      activeSceneDetailPolicy = sceneDetailController.getPolicy();
+    },
     onAction: (event) => {
       console.info('[performance] adaptive quality action', event);
       if (event.action === 'downgrade') {
@@ -3758,6 +3799,9 @@ function initializeImmersiveScene(
       updateRateFps: policy.mirrorUpdateRateFps,
       renderTargetSize: policy.mirrorTargetSize,
     });
+    const level = graphicsQualityManager?.getLevel() ?? initialSceneDetailLevel;
+    sceneDetailController.setLevel(level);
+    activeSceneDetailPolicy = sceneDetailController.getPolicy();
   };
 
   const getActivePostprocessingPassCount = () => {
@@ -3812,6 +3856,7 @@ function initializeImmersiveScene(
       lastAdaptiveRecoveryReason:
         adaptiveQualityController?.getLastRecoveryReason() ?? null,
       adaptivePolicy: adaptiveQualityController?.getSnapshot() ?? null,
+      sceneDetail: sceneDetailController.getSnapshot(),
     }),
     getFeatureState: () => {
       const mirrorState = selfieMirror?.getRenderState();
@@ -3827,6 +3872,14 @@ function initializeImmersiveScene(
     },
     getLastFailoverReason: () => lastFailoverReason,
     getSoftwareRendererPolicy: () => softwareRendererPolicy,
+    getRendererCounters: () => ({
+      calls: renderer.info.render.calls,
+      triangles: renderer.info.render.triangles,
+      points: renderer.info.render.points,
+      lines: renderer.info.render.lines,
+      memoryGeometries: renderer.info.memory.geometries,
+      memoryTextures: renderer.info.memory.textures,
+    }),
     exportCrashLog: crashLogAccess.exportCrashLog,
     copyCrashLog: crashLogAccess.copyCrashLog,
     recordSnapshot: crashLogAccess.recordSnapshot,
@@ -4711,20 +4764,34 @@ function initializeImmersiveScene(
       if (livingRoomMediaWall) {
         const activation = futuroptimistPoi?.activation ?? 0;
         const focus = futuroptimistPoi?.focus ?? 0;
-        livingRoomMediaWall.controller.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
+        if (
+          sceneDetailController.shouldRunDecorativeUpdate(
+            elapsedTime,
+            Math.max(activation, focus)
+          )
+        ) {
+          livingRoomMediaWall.controller.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
       }
       if (flywheelShowpiece) {
         const activation = flywheelPoi?.activation ?? 0;
         const focus = flywheelPoi?.focus ?? 0;
-        flywheelShowpiece.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-        });
+        if (
+          sceneDetailController.shouldRunDecorativeUpdate(
+            elapsedTime,
+            Math.max(activation, focus)
+          )
+        ) {
+          flywheelShowpiece.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
       }
       if (f2ClipboardConsole) {
         const activation = f2ClipboardPoi?.activation ?? 0;
@@ -4756,13 +4823,20 @@ function initializeImmersiveScene(
       if (jobbotTerminal) {
         const activation = jobbotPoi?.activation ?? 0;
         const focus = jobbotPoi?.focus ?? 0;
-        jobbotTerminal.update({
-          elapsed: elapsedTime,
-          delta,
-          emphasis: Math.max(activation, focus),
-          analyticsGlow: analyticsGlow.getValue(),
-          analyticsWave: analyticsGlow.getWave(),
-        });
+        if (
+          sceneDetailController.shouldRunDecorativeUpdate(
+            elapsedTime,
+            Math.max(activation, focus)
+          )
+        ) {
+          jobbotTerminal.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+            analyticsGlow: analyticsGlow.getValue(),
+            analyticsWave: analyticsGlow.getWave(),
+          });
+        }
       }
       if (axelNavigator) {
         const activation = axelPoi?.activation ?? 0;
@@ -4810,7 +4884,9 @@ function initializeImmersiveScene(
         });
       }
       if (backyardEnvironment) {
-        backyardEnvironment.update({ elapsed: elapsedTime, delta });
+        if (sceneDetailController.shouldRunDecorativeUpdate(elapsedTime, 1)) {
+          backyardEnvironment.update({ elapsed: elapsedTime, delta });
+        }
       }
       performanceDiagnostics?.recordPhase(
         'decorativeStructures',

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,7 +112,9 @@ import {
 import {
   GRAPHICS_QUALITY_PRESETS,
   createGraphicsQualityManager,
+  isGraphicsQualityLevel,
   resolvePersistedGraphicsQualityLevel,
+  type GraphicsQualityLevel,
   type GraphicsQualityManager,
 } from './scene/graphics/qualityManager';
 import {
@@ -528,6 +530,32 @@ const CAMERA_ZOOM_WHEEL_SENSITIVITY = 0.0018;
 const MANNEQUIN_YAW_SMOOTHING = 8;
 const CEILING_COVE_OFFSET = 0.35;
 const BACKYARD_ROOM_ID = 'backyard';
+const PENDING_SCENE_DETAIL_RELOAD_KEY =
+  'portfolio::pending-scene-detail-reload-level';
+
+function consumePendingSceneDetailReloadLevel(): GraphicsQualityLevel | null {
+  try {
+    const stored = window.sessionStorage.getItem(
+      PENDING_SCENE_DETAIL_RELOAD_KEY
+    );
+    window.sessionStorage.removeItem(PENDING_SCENE_DETAIL_RELOAD_KEY);
+    return isGraphicsQualityLevel(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistPendingSceneDetailReloadLevel(
+  level: GraphicsQualityLevel
+): void {
+  try {
+    window.sessionStorage.setItem(PENDING_SCENE_DETAIL_RELOAD_KEY, level);
+  } catch {
+    // If session storage is unavailable, reloading still rebuilds from persisted
+    // user quality or the device-derived initial policy.
+  }
+}
+
 const PERFORMANCE_FAILOVER_FPS_THRESHOLD = 30;
 const PERFORMANCE_FAILOVER_DURATION_MS = 5000;
 const INPUT_LATENCY_P95_BUDGET_MS = 200;
@@ -764,12 +792,35 @@ function initializeImmersiveScene(
   const persistedQualityLevel = rendererInfo.isSoftwareRenderer
     ? null
     : resolvePersistedGraphicsQualityLevel(qualityStorage);
+  const sceneDetailReloadOverride = consumePendingSceneDetailReloadLevel();
+  const effectiveInitialQualityLevel =
+    sceneDetailReloadOverride ??
+    persistedQualityLevel ??
+    initialQualityPolicy.initialLevel;
   const initialSceneDetailLevel =
-    persistedQualityLevel ?? initialQualityPolicy.initialLevel;
+    sceneDetailReloadOverride ??
+    persistedQualityLevel ??
+    initialQualityPolicy.sceneDetailLevel;
   const sceneDetailController = createSceneDetailController(
     initialSceneDetailLevel
   );
   let activeSceneDetailPolicy = getSceneDetailPolicy(initialSceneDetailLevel);
+  const applySceneDetailLevel = (
+    level: GraphicsQualityLevel,
+    options: { reloadScene?: boolean } = {}
+  ) => {
+    if (level === sceneDetailController.getLevel()) {
+      activeSceneDetailPolicy = sceneDetailController.getPolicy();
+      return;
+    }
+    if (options.reloadScene) {
+      persistPendingSceneDetailReloadLevel(level);
+      window.location.reload();
+      return;
+    }
+    sceneDetailController.setLevel(level);
+    activeSceneDetailPolicy = sceneDetailController.getPolicy();
+  };
   const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
     ? initialQualityPolicy.basePixelRatioCap
     : rendererInfo.isSoftwareRenderer
@@ -3585,8 +3636,9 @@ function initializeImmersiveScene(
     ledStripMaterials,
     ledFillLights: ledFillLightsList,
     basePixelRatio,
-    initialLevel: initialQualityPolicy.initialLevel,
-    preferInitialLevel: rendererInfo.isSoftwareRenderer,
+    initialLevel: effectiveInitialQualityLevel,
+    preferInitialLevel:
+      rendererInfo.isSoftwareRenderer || sceneDetailReloadOverride !== null,
     baseBloom: {
       strength: LIGHTING_OPTIONS.bloomStrength,
       radius: LIGHTING_OPTIONS.bloomRadius,
@@ -3613,8 +3665,7 @@ function initializeImmersiveScene(
     getSelectionSource: () =>
       graphicsQualityManager?.getSelectionSource() ?? 'initial',
     onSceneDetailLevelChange: (level) => {
-      sceneDetailController.setLevel(level);
-      activeSceneDetailPolicy = sceneDetailController.getPolicy();
+      applySceneDetailLevel(level, { reloadScene: true });
     },
     onAction: (event) => {
       console.info('[performance] adaptive quality action', event);
@@ -3800,8 +3851,7 @@ function initializeImmersiveScene(
       renderTargetSize: policy.mirrorTargetSize,
     });
     const level = graphicsQualityManager?.getLevel() ?? initialSceneDetailLevel;
-    sceneDetailController.setLevel(level);
-    activeSceneDetailPolicy = sceneDetailController.getPolicy();
+    applySceneDetailLevel(level, { reloadScene: true });
   };
 
   const getActivePostprocessingPassCount = () => {
@@ -4767,7 +4817,8 @@ function initializeImmersiveScene(
         if (
           sceneDetailController.shouldRunDecorativeUpdate(
             elapsedTime,
-            Math.max(activation, focus)
+            Math.max(activation, focus),
+            'media-wall'
           )
         ) {
           livingRoomMediaWall.controller.update({
@@ -4783,7 +4834,8 @@ function initializeImmersiveScene(
         if (
           sceneDetailController.shouldRunDecorativeUpdate(
             elapsedTime,
-            Math.max(activation, focus)
+            Math.max(activation, focus),
+            'flywheel'
           )
         ) {
           flywheelShowpiece.update({
@@ -4826,7 +4878,8 @@ function initializeImmersiveScene(
         if (
           sceneDetailController.shouldRunDecorativeUpdate(
             elapsedTime,
-            Math.max(activation, focus)
+            Math.max(activation, focus),
+            'jobbot'
           )
         ) {
           jobbotTerminal.update({
@@ -4884,7 +4937,13 @@ function initializeImmersiveScene(
         });
       }
       if (backyardEnvironment) {
-        if (sceneDetailController.shouldRunDecorativeUpdate(elapsedTime, 1)) {
+        if (
+          sceneDetailController.shouldRunDecorativeUpdate(
+            elapsedTime,
+            1,
+            'backyard'
+          )
+        ) {
           backyardEnvironment.update({ elapsed: elapsedTime, delta });
         }
       }

--- a/src/scene/avatar/mannequin.ts
+++ b/src/scene/avatar/mannequin.ts
@@ -12,6 +12,9 @@ import {
   TorusGeometry,
 } from 'three';
 
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+
 // Deterministic floor-to-crest height used by initial camera framing before assets load.
 export const PORTFOLIO_MANNEQUIN_VISUAL_HEIGHT = 2.6;
 
@@ -32,6 +35,7 @@ export interface PortfolioMannequinOptions {
    * Head and glove color used to suggest skin or fabric contrast.
    */
   trimColor?: string;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface PortfolioMannequinPalette {
@@ -85,6 +89,12 @@ export function createPortfolioMannequin(
   options: PortfolioMannequinOptions = {}
 ): PortfolioMannequinBuild {
   const collisionRadius = options.collisionRadius ?? 0.75;
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
+  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
+  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
+  const torusRadialSegments = detailPolicy.geometry.torusRadialSegments;
+  const torusTubularSegments = detailPolicy.geometry.torusTubularSegments;
   const initialPalette: PortfolioMannequinPalette = {
     base: options.baseColor ?? '#283347',
     accent: options.accentColor ?? '#57d7ff',
@@ -95,7 +105,11 @@ export function createPortfolioMannequin(
   group.name = 'PortfolioMannequin';
 
   const collisionProxy = new Mesh(
-    new SphereGeometry(collisionRadius, 32, 32),
+    new SphereGeometry(
+      collisionRadius,
+      sphereWidthSegments,
+      sphereHeightSegments
+    ),
     new MeshBasicMaterial({ color: 0xffffff })
   );
   collisionProxy.name = 'PortfolioMannequinCollisionProxy';
@@ -116,7 +130,7 @@ export function createPortfolioMannequin(
   );
   const platformHeight = 0.08;
   const platform = new Mesh(
-    new CylinderGeometry(0.58, 0.58, platformHeight, 48),
+    new CylinderGeometry(0.58, 0.58, platformHeight, cylinderSegments),
     platformMaterial
   );
   platform.name = 'PortfolioMannequinPlatform';
@@ -128,7 +142,7 @@ export function createPortfolioMannequin(
   const legMaterial = createStandardMaterial(new Color(initialPalette.base));
   const legHeight = 0.92;
   const legs = new Mesh(
-    new CylinderGeometry(0.26, 0.3, legHeight, 32),
+    new CylinderGeometry(0.26, 0.3, legHeight, cylinderSegments),
     legMaterial
   );
   legs.name = 'PortfolioMannequinLegs';
@@ -170,7 +184,7 @@ export function createPortfolioMannequin(
   rightFoot.add(rightFootMesh);
 
   const accentBand = new Mesh(
-    new TorusGeometry(0.34, 0.05, 20, 48),
+    new TorusGeometry(0.34, 0.05, torusRadialSegments, torusTubularSegments),
     platformMaterial.clone()
   );
   accentBand.name = 'PortfolioMannequinWaistBand';
@@ -184,7 +198,7 @@ export function createPortfolioMannequin(
 
   const torsoMaterial = createStandardMaterial(new Color(initialPalette.base));
   const torso = new Mesh(
-    new CylinderGeometry(0.46, 0.36, 0.86, 32),
+    new CylinderGeometry(0.46, 0.36, 0.86, cylinderSegments),
     torsoMaterial
   );
   torso.name = 'PortfolioMannequinTorso';
@@ -196,7 +210,7 @@ export function createPortfolioMannequin(
   const shoulderMaterial = createStandardMaterial(
     new Color(initialPalette.base)
   );
-  const armGeometry = new CylinderGeometry(0.16, 0.18, 0.82, 24);
+  const armGeometry = new CylinderGeometry(0.16, 0.18, 0.82, cylinderSegments);
 
   const leftArm = new Mesh(armGeometry, shoulderMaterial);
   leftArm.name = 'PortfolioMannequinArmLeft';
@@ -222,7 +236,7 @@ export function createPortfolioMannequin(
     }
   );
   const leftCuff = new Mesh(
-    new TorusGeometry(0.16, 0.035, 14, 32),
+    new TorusGeometry(0.16, 0.035, torusRadialSegments, torusTubularSegments),
     cuffMaterial
   );
   leftCuff.name = 'PortfolioMannequinCuffLeft';
@@ -236,7 +250,12 @@ export function createPortfolioMannequin(
   mannequinRoot.add(rightCuff);
 
   const trimMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const gloveGeometry = new CylinderGeometry(0.18, 0.18, 0.22, 18);
+  const gloveGeometry = new CylinderGeometry(
+    0.18,
+    0.18,
+    0.22,
+    cylinderSegments
+  );
   const leftGlove = new Mesh(gloveGeometry, trimMaterial);
   leftGlove.name = 'PortfolioMannequinGloveLeft';
   leftGlove.position.set(
@@ -265,7 +284,7 @@ export function createPortfolioMannequin(
     }
   );
   const collar = new Mesh(
-    new TorusGeometry(0.3, 0.045, 16, 36),
+    new TorusGeometry(0.3, 0.045, torusRadialSegments, torusTubularSegments),
     collarMaterial
   );
   collar.name = 'PortfolioMannequinCollar';
@@ -274,7 +293,10 @@ export function createPortfolioMannequin(
   mannequinRoot.add(collar);
 
   const headMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const head = new Mesh(new SphereGeometry(0.28, 32, 32), headMaterial);
+  const head = new Mesh(
+    new SphereGeometry(0.28, sphereWidthSegments, sphereHeightSegments),
+    headMaterial
+  );
   head.name = 'PortfolioMannequinHead';
   head.position.y = collar.position.y + 0.32;
   head.castShadow = true;
@@ -283,7 +305,11 @@ export function createPortfolioMannequin(
 
   // Add a simple smiley face marker to the front of the head for directionality.
   const faceMaterial = new MeshBasicMaterial({ color: 0x000000 });
-  const eyeGeometry = new SphereGeometry(0.03, 12, 12);
+  const eyeGeometry = new SphereGeometry(
+    0.03,
+    sphereWidthSegments,
+    sphereHeightSegments
+  );
   const leftEye = new Mesh(eyeGeometry, faceMaterial);
   leftEye.name = 'PortfolioMannequinFaceLeftEye';
   leftEye.position.set(-0.08, head.position.y + 0.06, 0.25);
@@ -296,7 +322,13 @@ export function createPortfolioMannequin(
 
   // Mouth as a thin torus segment to suggest a smile on the front side.
   const mouth = new Mesh(
-    new TorusGeometry(0.09, 0.012, 8, 24, Math.PI),
+    new TorusGeometry(
+      0.09,
+      0.012,
+      torusRadialSegments,
+      torusTubularSegments,
+      Math.PI
+    ),
     faceMaterial
   );
   mouth.name = 'PortfolioMannequinFaceMouth';
@@ -315,7 +347,7 @@ export function createPortfolioMannequin(
   visorMaterial.opacity = 0.72;
   visorMaterial.side = DoubleSide;
   const visor = new Mesh(
-    new CylinderGeometry(0.27, 0.27, 0.16, 32, 1, true),
+    new CylinderGeometry(0.27, 0.27, 0.16, cylinderSegments, 1, true),
     visorMaterial
   );
   visor.name = 'PortfolioMannequinVisor';
@@ -330,7 +362,10 @@ export function createPortfolioMannequin(
       emissiveIntensity: 0.5,
     }
   );
-  const crest = new Mesh(new ConeGeometry(0.12, 0.24, 24), crestMaterial);
+  const crest = new Mesh(
+    new ConeGeometry(0.12, 0.24, cylinderSegments),
+    crestMaterial
+  );
   crest.name = 'PortfolioMannequinCrest';
   crest.position.y = head.position.y + 0.3;
   mannequinRoot.add(crest);

--- a/src/scene/collision.ts
+++ b/src/scene/collision.ts
@@ -1,0 +1,1 @@
+export type { RectCollider } from '../systems/collision';

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -41,6 +41,8 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import {
   applySeasonalLightingPreset,
   type SeasonalLightingPreset,
@@ -106,7 +108,7 @@ interface WalkwayMistLayer {
 const HEX_COLOR_PATTERN = /^#?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
 const clampUnit = (value: number | undefined): number => {
-  if (!Number.isFinite(value)) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     return 0;
   }
   if (value <= 0) {
@@ -119,7 +121,7 @@ const clampUnit = (value: number | undefined): number => {
 };
 
 const resolveCycleScale = (value: number | undefined): number => {
-  if (!Number.isFinite(value)) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     return 1;
   }
   if (value <= 0) {
@@ -299,12 +301,17 @@ function createDuskLightProbe(): LightProbe {
 
 export interface BackyardEnvironmentOptions {
   seasonalPreset?: SeasonalLightingPreset | null;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export function createBackyardEnvironment(
   bounds: Bounds2D,
-  { seasonalPreset = null }: BackyardEnvironmentOptions = {}
+  {
+    seasonalPreset = null,
+    detailPolicy = getSceneDetailPolicy('balanced'),
+  }: BackyardEnvironmentOptions = {}
 ): BackyardEnvironmentBuild {
+  const isPerformance = detailPolicy.level === 'performance';
   const group = new Group();
   group.name = 'BackyardEnvironment';
   const colliders: RectCollider[] = [];
@@ -324,7 +331,11 @@ export function createBackyardEnvironment(
   group.add(duskLightProbe);
 
   const skyRadius = Math.max(width, depth) * 1.32;
-  const skyGeometry = new SphereGeometry(skyRadius, 48, 48);
+  const skyGeometry = new SphereGeometry(
+    skyRadius,
+    detailPolicy.geometry.sphereWidthSegments,
+    detailPolicy.geometry.sphereHeightSegments
+  );
   skyGeometry.scale(1, 0.62, 1);
   const verticalExtent = skyRadius * 0.62;
 
@@ -498,6 +509,7 @@ export function createBackyardEnvironment(
   const rocket = createModelRocket({
     basePosition: rocketBase,
     orientationRadians: -Math.PI / 10,
+    detailPolicy,
   });
   group.add(rocket.group);
   colliders.push(rocket.collider);
@@ -537,6 +549,7 @@ export function createBackyardEnvironment(
     depth: greenhouseDepth,
     environmentMap: duskReflectionMap,
     environmentIntensity: 0.62,
+    detailPolicy,
   });
   group.add(greenhouse.group);
   greenhouse.colliders.forEach((collider) => colliders.push(collider));
@@ -733,7 +746,7 @@ export function createBackyardEnvironment(
       baseFlowStrength,
     });
   }
-  if (walkwayMistGroup.children.length > 0) {
+  if (!isPerformance && walkwayMistGroup.children.length > 0) {
     group.add(walkwayMistGroup);
   }
 
@@ -1042,7 +1055,7 @@ export function createBackyardEnvironment(
     );
   });
 
-  if (walkwayMistLayers.length > 0) {
+  if (!isPerformance && walkwayMistLayers.length > 0) {
     updates.push(({ elapsed }) => {
       const pulseScale = MathUtils.clamp(getPulseScale(), 0, 1);
       const flickerScale = MathUtils.clamp(getFlickerScale(), 0, 1);
@@ -1652,6 +1665,7 @@ export function createBackyardEnvironment(
       light.name = `BackyardWalkwayLanternLight-${lanternIndex}`;
       light.position.y = 1.05;
       light.color.copy(glassMaterial.emissive);
+      light.visible = detailPolicy.effects.dynamicPointLights;
       lantern.add(light);
 
       const haloMaterial = new MeshBasicMaterial({
@@ -1951,6 +1965,7 @@ export function createBackyardEnvironment(
   );
   duskLight.position.set(centerX - width * 0.18, 2.6, centerZ + depth * 0.18);
   duskLight.castShadow = false;
+  duskLight.visible = detailPolicy.effects.dynamicPointLights;
   group.add(duskLight);
 
   const barrierWidth = Math.min(width * 0.68, 6.5);

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -130,13 +130,32 @@ export interface GraphicsQualityManager {
   onChange(listener: (level: GraphicsQualityLevel) => void): () => void;
 }
 
-const DEFAULT_STORAGE_KEY = 'danielsmith:graphics-quality-level';
+export const DEFAULT_GRAPHICS_QUALITY_STORAGE_KEY =
+  'danielsmith:graphics-quality-level';
 
-function isGraphicsQualityLevel(value: unknown): value is GraphicsQualityLevel {
+export function isGraphicsQualityLevel(
+  value: unknown
+): value is GraphicsQualityLevel {
   return (
     typeof value === 'string' &&
     GRAPHICS_QUALITY_PRESETS.some((preset) => preset.id === value)
   );
+}
+
+export function resolvePersistedGraphicsQualityLevel(
+  storage?: Pick<Storage, 'getItem'> | null,
+  storageKey = DEFAULT_GRAPHICS_QUALITY_STORAGE_KEY
+): GraphicsQualityLevel | null {
+  if (!storage?.getItem) {
+    return null;
+  }
+  try {
+    const stored = storage.getItem(storageKey);
+    return isGraphicsQualityLevel(stored) ? stored : null;
+  } catch (error) {
+    console.warn('Failed to read persisted graphics quality level:', error);
+    return null;
+  }
 }
 
 interface LedMaterialEntry {
@@ -158,7 +177,7 @@ export function createGraphicsQualityManager({
   baseBloom,
   baseLed,
   storage,
-  storageKey = DEFAULT_STORAGE_KEY,
+  storageKey = DEFAULT_GRAPHICS_QUALITY_STORAGE_KEY,
   initialLevel = 'balanced',
   preferInitialLevel = false,
 }: GraphicsQualityManagerOptions): GraphicsQualityManager {
@@ -186,15 +205,11 @@ export function createGraphicsQualityManager({
     ? initialLevel
     : 'balanced';
   let selectionSource: GraphicsQualitySelectionSource = 'initial';
-  if (!preferInitialLevel && storage?.getItem) {
-    try {
-      const stored = storage.getItem(storageKey);
-      if (isGraphicsQualityLevel(stored)) {
-        currentLevel = stored;
-        selectionSource = 'user';
-      }
-    } catch (error) {
-      console.warn('Failed to read persisted graphics quality level:', error);
+  if (!preferInitialLevel) {
+    const stored = resolvePersistedGraphicsQualityLevel(storage, storageKey);
+    if (stored) {
+      currentLevel = stored;
+      selectionSource = 'user';
     }
   }
 

--- a/src/scene/graphics/sceneDetailPolicy.ts
+++ b/src/scene/graphics/sceneDetailPolicy.ts
@@ -1,0 +1,223 @@
+import type { GraphicsQualityLevel } from './qualityManager';
+
+export type SceneDetailLevel = GraphicsQualityLevel;
+
+export interface SceneDetailPolicy {
+  level: SceneDetailLevel;
+  geometry: {
+    cylinderSegments: number;
+    sphereWidthSegments: number;
+    sphereHeightSegments: number;
+    ringSegments: number;
+    torusRadialSegments: number;
+    torusTubularSegments: number;
+    terrainSegments: number;
+  };
+  textures: {
+    canvasScale: number;
+    jobbotScreen: { width: number; height: number };
+    jobbotTelemetry: { width: number; height: number };
+    mediaWallScreen: { width: number; height: number };
+    mediaWallBadge: { width: number; height: number };
+  };
+  effects: {
+    transparentShaders: boolean;
+    mist: boolean;
+    pondRippleShader: boolean;
+    glassTransmission: boolean;
+    decorativeHalos: boolean;
+    telemetryPanels: boolean;
+    decorativeShards: boolean;
+    dynamicPointLights: boolean;
+  };
+  updates: {
+    decorativeThrottleMs: number;
+    canvasRedrawThrottleMs: number;
+    skipUnfocusedDecorations: boolean;
+  };
+  budgets: {
+    transparentShaderLayers: number;
+    dynamicPointLights: number;
+    decorativeDrawCalls: number;
+    poiTriangleScale: number;
+    structureTriangleScale: number;
+  };
+}
+
+const HIGH_DETAIL_GEOMETRY = {
+  cylinderSegments: 48,
+  sphereWidthSegments: 32,
+  sphereHeightSegments: 32,
+  ringSegments: 64,
+  torusRadialSegments: 24,
+  torusTubularSegments: 64,
+  terrainSegments: 24,
+} as const;
+
+const HIGH_DETAIL_TEXTURES = {
+  canvasScale: 1,
+  jobbotScreen: { width: 2048, height: 1024 },
+  jobbotTelemetry: { width: 1024, height: 512 },
+  mediaWallScreen: { width: 2048, height: 1024 },
+  mediaWallBadge: { width: 512, height: 256 },
+} as const;
+
+const HIGH_DETAIL_EFFECTS = {
+  transparentShaders: true,
+  mist: true,
+  pondRippleShader: true,
+  glassTransmission: true,
+  decorativeHalos: true,
+  telemetryPanels: true,
+  decorativeShards: true,
+  dynamicPointLights: true,
+} as const;
+
+export const SCENE_DETAIL_POLICIES: Record<
+  SceneDetailLevel,
+  SceneDetailPolicy
+> = {
+  cinematic: {
+    level: 'cinematic',
+    geometry: HIGH_DETAIL_GEOMETRY,
+    textures: HIGH_DETAIL_TEXTURES,
+    effects: HIGH_DETAIL_EFFECTS,
+    updates: {
+      decorativeThrottleMs: 0,
+      canvasRedrawThrottleMs: 0,
+      skipUnfocusedDecorations: false,
+    },
+    budgets: {
+      transparentShaderLayers: 8,
+      dynamicPointLights: 12,
+      decorativeDrawCalls: 160,
+      poiTriangleScale: 1,
+      structureTriangleScale: 1,
+    },
+  },
+  balanced: {
+    level: 'balanced',
+    geometry: HIGH_DETAIL_GEOMETRY,
+    textures: HIGH_DETAIL_TEXTURES,
+    effects: HIGH_DETAIL_EFFECTS,
+    updates: {
+      decorativeThrottleMs: 0,
+      canvasRedrawThrottleMs: 0,
+      skipUnfocusedDecorations: false,
+    },
+    budgets: {
+      transparentShaderLayers: 8,
+      dynamicPointLights: 12,
+      decorativeDrawCalls: 160,
+      poiTriangleScale: 1,
+      structureTriangleScale: 1,
+    },
+  },
+  performance: {
+    level: 'performance',
+    geometry: {
+      cylinderSegments: 8,
+      sphereWidthSegments: 8,
+      sphereHeightSegments: 6,
+      ringSegments: 10,
+      torusRadialSegments: 6,
+      torusTubularSegments: 12,
+      terrainSegments: 4,
+    },
+    textures: {
+      canvasScale: 0.25,
+      jobbotScreen: { width: 512, height: 256 },
+      jobbotTelemetry: { width: 256, height: 128 },
+      mediaWallScreen: { width: 512, height: 256 },
+      mediaWallBadge: { width: 256, height: 128 },
+    },
+    effects: {
+      transparentShaders: false,
+      mist: false,
+      pondRippleShader: false,
+      glassTransmission: false,
+      decorativeHalos: false,
+      telemetryPanels: false,
+      decorativeShards: false,
+      dynamicPointLights: false,
+    },
+    updates: {
+      decorativeThrottleMs: 250,
+      canvasRedrawThrottleMs: 1000,
+      skipUnfocusedDecorations: true,
+    },
+    budgets: {
+      transparentShaderLayers: 0,
+      dynamicPointLights: 1,
+      decorativeDrawCalls: 24,
+      poiTriangleScale: 0.12,
+      structureTriangleScale: 0.18,
+    },
+  },
+};
+
+export function getSceneDetailPolicy(
+  level: SceneDetailLevel
+): SceneDetailPolicy {
+  return SCENE_DETAIL_POLICIES[level] ?? SCENE_DETAIL_POLICIES.balanced;
+}
+
+export interface SceneDetailController {
+  getLevel(): SceneDetailLevel;
+  getPolicy(): SceneDetailPolicy;
+  setLevel(level: SceneDetailLevel): void;
+  shouldRunDecorativeUpdate(elapsedSeconds: number, emphasis?: number): boolean;
+  getSnapshot(): {
+    level: SceneDetailLevel;
+    policy: SceneDetailPolicy;
+    theoreticalBudget: SceneDetailPolicy['budgets'];
+  };
+}
+
+export function createSceneDetailController(
+  initialLevel: SceneDetailLevel = 'balanced'
+): SceneDetailController {
+  let level = initialLevel;
+  let policy = getSceneDetailPolicy(level);
+  let lastDecorativeUpdateMs = Number.NEGATIVE_INFINITY;
+
+  return {
+    getLevel() {
+      return level;
+    },
+    getPolicy() {
+      return policy;
+    },
+    setLevel(nextLevel) {
+      level = nextLevel;
+      policy = getSceneDetailPolicy(nextLevel);
+    },
+    shouldRunDecorativeUpdate(elapsedSeconds, emphasis = 0) {
+      if (policy.updates.decorativeThrottleMs <= 0) {
+        return true;
+      }
+      if (
+        policy.updates.skipUnfocusedDecorations &&
+        Math.max(0, emphasis) < 0.02
+      ) {
+        return false;
+      }
+      const elapsedMs = elapsedSeconds * 1000;
+      if (
+        elapsedMs - lastDecorativeUpdateMs <
+        policy.updates.decorativeThrottleMs
+      ) {
+        return false;
+      }
+      lastDecorativeUpdateMs = elapsedMs;
+      return true;
+    },
+    getSnapshot() {
+      return {
+        level,
+        policy,
+        theoreticalBudget: policy.budgets,
+      };
+    },
+  };
+}

--- a/src/scene/graphics/sceneDetailPolicy.ts
+++ b/src/scene/graphics/sceneDetailPolicy.ts
@@ -166,7 +166,11 @@ export interface SceneDetailController {
   getLevel(): SceneDetailLevel;
   getPolicy(): SceneDetailPolicy;
   setLevel(level: SceneDetailLevel): void;
-  shouldRunDecorativeUpdate(elapsedSeconds: number, emphasis?: number): boolean;
+  shouldRunDecorativeUpdate(
+    elapsedSeconds: number,
+    emphasis?: number,
+    channel?: string
+  ): boolean;
   getSnapshot(): {
     level: SceneDetailLevel;
     policy: SceneDetailPolicy;
@@ -179,7 +183,7 @@ export function createSceneDetailController(
 ): SceneDetailController {
   let level = initialLevel;
   let policy = getSceneDetailPolicy(level);
-  let lastDecorativeUpdateMs = Number.NEGATIVE_INFINITY;
+  const lastDecorativeUpdateMsByChannel = new Map<string, number>();
 
   return {
     getLevel() {
@@ -192,7 +196,11 @@ export function createSceneDetailController(
       level = nextLevel;
       policy = getSceneDetailPolicy(nextLevel);
     },
-    shouldRunDecorativeUpdate(elapsedSeconds, emphasis = 0) {
+    shouldRunDecorativeUpdate(
+      elapsedSeconds,
+      emphasis = 0,
+      channel = 'default'
+    ) {
       if (policy.updates.decorativeThrottleMs <= 0) {
         return true;
       }
@@ -203,13 +211,16 @@ export function createSceneDetailController(
         return false;
       }
       const elapsedMs = elapsedSeconds * 1000;
+      const lastDecorativeUpdateMs =
+        lastDecorativeUpdateMsByChannel.get(channel) ??
+        Number.NEGATIVE_INFINITY;
       if (
         elapsedMs - lastDecorativeUpdateMs <
         policy.updates.decorativeThrottleMs
       ) {
         return false;
       }
-      lastDecorativeUpdateMs = elapsedMs;
+      lastDecorativeUpdateMsByChannel.set(channel, elapsedMs);
       return true;
     },
     getSnapshot() {

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -29,6 +29,7 @@ export interface AdaptiveQualityControllerOptions {
   onAction?: (event: AdaptiveQualityEvent) => void;
   onDowngrade?: (event: AdaptiveQualityEvent) => void;
   onSceneDetailLevelChange?: (level: GraphicsQualityLevel) => void;
+  initialAdaptivePerformanceRecoveryLocked?: boolean;
 }
 
 export interface AdaptiveQualityEvent {
@@ -116,6 +117,7 @@ export function createAdaptiveQualityController({
   onAction,
   onDowngrade,
   onSceneDetailLevelChange,
+  initialAdaptivePerformanceRecoveryLocked = false,
 }: AdaptiveQualityControllerOptions): AdaptiveQualityController {
   let elapsedMs = 0;
   let lowFpsDurationMs = 0;
@@ -129,7 +131,9 @@ export function createAdaptiveQualityController({
   let lastRecoveryReason: string | null = null;
   let lastAdaptiveReason: string | null = null;
   let pixelRatioStepApplied = false;
-  let adaptivePerformanceRecoveryLocked = false;
+  let adaptivePerformanceRecoveryLocked =
+    initialAdaptivePerformanceRecoveryLocked &&
+    qualityManager.getLevel() === 'performance';
   const frameMsSamples: number[] = [];
 
   const getWarmupRemainingMs = () => Math.max(0, warmupMs - elapsedMs);
@@ -142,6 +146,16 @@ export function createAdaptiveQualityController({
     qualityManager.getLevel() === 'performance' && autoRecoveryEnabled();
   const resetRecoveryState = () => {
     stableDurationMs = 0;
+  };
+  const syncExplicitUserOverride = () => {
+    if (
+      adaptivePerformanceRecoveryLocked &&
+      getSelectionSource() === 'user' &&
+      qualityManager.getLevel() !== 'performance'
+    ) {
+      adaptivePerformanceRecoveryLocked = false;
+      resetRecoveryState();
+    }
   };
 
   const emit = (
@@ -277,6 +291,7 @@ export function createAdaptiveQualityController({
       if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
         return null;
       }
+      syncExplicitUserOverride();
       const frameMs = deltaSeconds * 1000;
       elapsedMs += frameMs;
       frameMsSamples.push(frameMs);

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -28,6 +28,7 @@ export interface AdaptiveQualityControllerOptions {
   getSelectionSource?: () => AdaptiveQualitySelectionSource;
   onAction?: (event: AdaptiveQualityEvent) => void;
   onDowngrade?: (event: AdaptiveQualityEvent) => void;
+  onSceneDetailLevelChange?: (level: GraphicsQualityLevel) => void;
 }
 
 export interface AdaptiveQualityEvent {
@@ -114,6 +115,7 @@ export function createAdaptiveQualityController({
   getSelectionSource = () => 'adaptive',
   onAction,
   onDowngrade,
+  onSceneDetailLevelChange,
 }: AdaptiveQualityControllerOptions): AdaptiveQualityController {
   let elapsedMs = 0;
   let lowFpsDurationMs = 0;
@@ -184,6 +186,7 @@ export function createAdaptiveQualityController({
     const currentLevel = qualityManager.getLevel();
     if (currentLevel === 'cinematic') {
       qualityManager.setLevel('balanced', { source: 'adaptive' });
+      onSceneDetailLevelChange?.('balanced');
       return emit(
         'downgrade',
         'quality-balanced',
@@ -192,6 +195,7 @@ export function createAdaptiveQualityController({
     }
     if (currentLevel === 'balanced') {
       qualityManager.setLevel('performance', { source: 'adaptive' });
+      onSceneDetailLevelChange?.('performance');
       return emit(
         'downgrade',
         'quality-performance',
@@ -219,6 +223,7 @@ export function createAdaptiveQualityController({
       return null;
     }
     qualityManager.setLevel('balanced', { source: 'adaptive' });
+    onSceneDetailLevelChange?.('balanced');
     return emit(
       'recover',
       'quality-balanced',

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -129,12 +129,15 @@ export function createAdaptiveQualityController({
   let lastRecoveryReason: string | null = null;
   let lastAdaptiveReason: string | null = null;
   let pixelRatioStepApplied = false;
+  let adaptivePerformanceRecoveryLocked = false;
   const frameMsSamples: number[] = [];
 
   const getWarmupRemainingMs = () => Math.max(0, warmupMs - elapsedMs);
   const isWarmingUp = () => getWarmupRemainingMs() > 0;
   const autoRecoveryEnabled = () =>
-    !isSoftwareRenderer && getSelectionSource() !== 'user';
+    !isSoftwareRenderer &&
+    getSelectionSource() !== 'user' &&
+    !adaptivePerformanceRecoveryLocked;
   const canAccrueRecovery = () =>
     qualityManager.getLevel() === 'performance' && autoRecoveryEnabled();
   const resetRecoveryState = () => {
@@ -194,6 +197,7 @@ export function createAdaptiveQualityController({
       );
     }
     if (currentLevel === 'balanced') {
+      adaptivePerformanceRecoveryLocked = true;
       qualityManager.setLevel('performance', { source: 'adaptive' });
       onSceneDetailLevelChange?.('performance');
       return emit(

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -2,6 +2,7 @@ import type {
   GraphicsQualityLevel,
   GraphicsQualitySelectionSource,
 } from '../graphics/qualityManager';
+import type { SceneDetailController } from '../graphics/sceneDetailPolicy';
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { SoftwareRendererPolicyState } from './qualityPolicy';
@@ -31,6 +32,7 @@ export interface QualityStateSnapshot {
   lastAdaptiveDowngradeReason: string | null;
   lastAdaptiveRecoveryReason: string | null;
   adaptivePolicy: AdaptiveQualityPolicySnapshot | null;
+  sceneDetail?: ReturnType<SceneDetailController['getSnapshot']>;
 }
 
 export interface FeatureStateSnapshot {
@@ -55,8 +57,18 @@ export interface FrameStatsSnapshot {
   >;
 }
 
+export interface RendererCountersSnapshot {
+  calls: number;
+  triangles: number;
+  points: number;
+  lines: number;
+  memoryGeometries: number;
+  memoryTextures: number;
+}
+
 export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   renderer: RendererInfoSnapshot;
+  rendererCounters: RendererCountersSnapshot;
   softwareRendererPolicy: SoftwareRendererPolicyState;
   rendererSize: RendererSizeSnapshot;
   quality: QualityStateSnapshot;
@@ -92,6 +104,7 @@ interface PerformanceDiagnosticsOptions {
   getFeatureState: () => FeatureStateSnapshot;
   getLastFailoverReason: () => string | null;
   getSoftwareRendererPolicy?: () => SoftwareRendererPolicyState;
+  getRendererCounters?: () => RendererCountersSnapshot;
   exportCrashLog?: () => string;
   copyCrashLog?: () => Promise<boolean>;
   recordSnapshot?: (snapshot: PerformanceDiagnosticsSnapshot) => void;
@@ -156,6 +169,14 @@ export function createPerformanceDiagnostics({
   exportCrashLog,
   copyCrashLog,
   recordSnapshot,
+  getRendererCounters = () => ({
+    calls: 0,
+    triangles: 0,
+    points: 0,
+    lines: 0,
+    memoryGeometries: 0,
+    memoryTextures: 0,
+  }),
   maxSamples = 180,
 }: PerformanceDiagnosticsOptions) {
   const frameMsSamples: number[] = [];
@@ -177,6 +198,7 @@ export function createPerformanceDiagnostics({
       return {
         ...diagnosticsMethods.getFrameStats(),
         renderer: diagnosticsMethods.getRendererInfo(),
+        rendererCounters: getRendererCounters(),
         softwareRendererPolicy: getSoftwareRendererPolicy(),
         rendererSize: getRendererSize(),
         quality: diagnosticsMethods.getQualityState(),

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -168,6 +168,7 @@ export interface InitialQualityDeviceHints {
   tabletLike?: boolean;
   deviceMemoryGb?: number | null;
   hardwareConcurrency?: number | null;
+  explicitGraphicsQualityLevel?: GraphicsQualityLevel | null;
 }
 
 function shouldStartInPerformanceFromDeviceHints(
@@ -233,6 +234,22 @@ export function resolveInitialQualityPolicy(
       softwareSafeMode: false,
       renderCadenceFps: null,
       reason: 'software renderer starts in performance mode',
+    };
+  }
+
+  if (deviceHints.explicitGraphicsQualityLevel) {
+    const featurePolicy = getQualityFeaturePolicy(
+      deviceHints.explicitGraphicsQualityLevel,
+      false
+    );
+    return {
+      initialLevel: deviceHints.explicitGraphicsQualityLevel,
+      sceneDetailLevel: deviceHints.explicitGraphicsQualityLevel,
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 1.25, 0.75),
+      ...featurePolicy,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
+      reason: 'explicit graphics quality preference controls initial policy',
     };
   }
 

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -4,6 +4,7 @@ import {
   SOFTWARE_RENDERER_MODE_PARAM,
 } from '../../ui/immersiveUrl';
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
@@ -128,6 +129,7 @@ export interface QualityPolicyState {
   ambientUpdateIntervalMs: number;
   softwareSafeMode: boolean;
   renderCadenceFps: number | null;
+  sceneDetailLevel: GraphicsQualityLevel;
   reason: string;
 }
 
@@ -160,6 +162,35 @@ export function resolveResizedBasePixelRatio(
   return Math.min(resizedPixelRatio, safeAdaptiveCap);
 }
 
+export interface InitialQualityDeviceHints {
+  coarsePointer?: boolean;
+  mobileLike?: boolean;
+  tabletLike?: boolean;
+  deviceMemoryGb?: number | null;
+  hardwareConcurrency?: number | null;
+}
+
+function shouldStartInPerformanceFromDeviceHints(
+  hints: InitialQualityDeviceHints = {}
+): boolean {
+  const constrainedMemory =
+    typeof hints.deviceMemoryGb === 'number' && hints.deviceMemoryGb > 0
+      ? hints.deviceMemoryGb <= 4
+      : false;
+  const constrainedCpu =
+    typeof hints.hardwareConcurrency === 'number' &&
+    hints.hardwareConcurrency > 0
+      ? hints.hardwareConcurrency <= 4
+      : false;
+  return Boolean(
+    hints.coarsePointer ||
+      hints.mobileLike ||
+      hints.tabletLike ||
+      constrainedMemory ||
+      constrainedCpu
+  );
+}
+
 export function resolveInitialQualityPolicy(
   rendererInfo: Pick<
     RendererInfoSnapshot,
@@ -168,7 +199,8 @@ export function resolveInitialQualityPolicy(
   devicePixelRatio: number,
   softwareRendererPolicy: SoftwareRendererPolicyState = resolveSoftwareRendererPolicy(
     rendererInfo
-  )
+  ),
+  deviceHints: InitialQualityDeviceHints = {}
 ): QualityPolicyState {
   if (
     rendererInfo.isDangerousSoftwareRenderer &&
@@ -176,6 +208,7 @@ export function resolveInitialQualityPolicy(
   ) {
     return {
       initialLevel: 'performance',
+      sceneDetailLevel: 'performance',
       basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.45, 0.35),
       mirrorEnabled: false,
       mirrorTargetSize: 128,
@@ -191,6 +224,7 @@ export function resolveInitialQualityPolicy(
   if (rendererInfo.isSoftwareRenderer) {
     return {
       initialLevel: 'performance',
+      sceneDetailLevel: 'performance',
       basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.75, 0.5),
       mirrorEnabled: false,
       mirrorTargetSize: 192,
@@ -202,8 +236,25 @@ export function resolveInitialQualityPolicy(
     };
   }
 
+  if (shouldStartInPerformanceFromDeviceHints(deviceHints)) {
+    return {
+      initialLevel: 'performance',
+      sceneDetailLevel: 'performance',
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.85, 0.5),
+      mirrorEnabled: false,
+      mirrorTargetSize: 192,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 100,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
+      reason:
+        'coarse-pointer or constrained mobile/tablet hardware starts in performance mode',
+    };
+  }
+
   return {
     initialLevel: 'balanced',
+    sceneDetailLevel: 'balanced',
     basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 1.25, 0.75),
     mirrorEnabled: true,
     mirrorTargetSize: 320,
@@ -247,4 +298,8 @@ export function getQualityFeaturePolicy(
     mirrorUpdateRateFps: 15,
     ambientUpdateIntervalMs: 16,
   };
+}
+
+export function getQualitySceneDetailPolicy(level: GraphicsQualityLevel) {
+  return getSceneDetailPolicy(level);
 }

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -158,7 +158,12 @@ function createPedestalPoiInstance(
   let accentBaseColor: Color | undefined;
   let accentFocusColor: Color | undefined;
 
-  if (!isPerformance && pedestalHeight > 0 && pedestalRadius > 0) {
+  const rendersPedestal =
+    !isPerformance && pedestalHeight > 0 && pedestalRadius > 0;
+  const effectivePedestalHeight = rendersPedestal ? pedestalHeight : 0;
+  const effectivePedestalRadius = rendersPedestal ? pedestalRadius : 0;
+
+  if (rendersPedestal) {
     const bodyMaterial = new MeshStandardMaterial({
       color: new Color(hologramConfig?.bodyColor ?? 0x101c2a),
       emissive: new Color(hologramConfig?.emissiveColor ?? 0x2f8aff),
@@ -251,7 +256,9 @@ function createPedestalPoiInstance(
   }
 
   const orbRadius =
-    Math.max(baseRadius, pedestalRadius) * 0.45 * POI_ORB_DIAMETER_MULTIPLIER;
+    Math.max(baseRadius, effectivePedestalRadius) *
+    0.45 *
+    POI_ORB_DIAMETER_MULTIPLIER;
   const orbGeometry = new SphereGeometry(
     orbRadius,
     sphereWidthSegments,
@@ -273,7 +280,7 @@ function createPedestalPoiInstance(
   });
   const orb = new Mesh(orbGeometry, orbMaterial);
   const orbBaseHeight =
-    pedestalHeight +
+    effectivePedestalHeight +
     (baseHeight + orbRadius + scalePoiValue(POI_ORB_VERTICAL_OFFSET)) *
       POI_ORB_HEIGHT_MULTIPLIER;
   orb.position.y = orbBaseHeight;
@@ -304,7 +311,7 @@ function createPedestalPoiInstance(
 
   // Size the ground ring proportionally to the underlying model footprint.
   // Use the smaller half-extent to keep a conservative footprint and avoid overlaps.
-  const modelRadius = Math.max(baseRadius, pedestalRadius);
+  const modelRadius = Math.max(baseRadius, effectivePedestalRadius);
   const haloInnerRadius = modelRadius * 0.62; // tighter than the platform base
   const haloOuterRadius = haloInnerRadius + scalePoiValue(0.22);
   const haloGeometry = new RingGeometry(
@@ -351,8 +358,9 @@ function createPedestalPoiInstance(
   visitedRing.scale.setScalar(1);
   group.add(visitedRing);
 
-  const hitAreaHeight = baseHeight + pedestalHeight + scalePoiValue(0.24);
-  const hitAreaRadius = Math.max(baseRadiusX, pedestalRadius);
+  const hitAreaHeight =
+    baseHeight + effectivePedestalHeight + scalePoiValue(0.24);
+  const hitAreaRadius = Math.max(baseRadiusX, effectivePedestalRadius);
   const hitAreaGeometry = new CylinderGeometry(
     hitAreaRadius,
     hitAreaRadius,
@@ -370,8 +378,8 @@ function createPedestalPoiInstance(
   hitArea.name = `POI_HIT:${definition.id}`;
   group.add(hitArea);
 
-  const colliderRadiusX = Math.max(baseRadiusX, pedestalRadius);
-  const colliderRadiusZ = Math.max(baseRadiusZ, pedestalRadius);
+  const colliderRadiusX = Math.max(baseRadiusX, effectivePedestalRadius);
+  const colliderRadiusZ = Math.max(baseRadiusZ, effectivePedestalRadius);
   const collider = {
     minX: definition.position.x - colliderRadiusX,
     maxX: definition.position.x + colliderRadiusX,

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -17,6 +17,9 @@ import {
   Vector3,
 } from 'three';
 
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+
 import {
   scalePoiValue,
   POI_ORB_VERTICAL_OFFSET,
@@ -42,6 +45,10 @@ export type PoiInstanceOverride = {
 };
 
 export type PoiInstanceOverrides = Partial<Record<PoiId, PoiInstanceOverride>>;
+
+export interface PoiInstanceOptions {
+  detailPolicy?: SceneDetailPolicy;
+}
 
 export interface PoiInstance {
   definition: PoiDefinition;
@@ -84,14 +91,19 @@ export interface PoiInstance {
 
 export function createPoiInstances(
   definitions: PoiDefinition[],
-  overrides: PoiInstanceOverrides = {}
+  overrides: PoiInstanceOverrides = {},
+  options: PoiInstanceOptions = {}
 ): PoiInstance[] {
   return definitions.map((definition, index) => {
     const override = overrides[definition.id];
     if (override?.mode === 'display') {
       return createDisplayPoiInstance(definition, override);
     }
-    return createPedestalPoiInstance(definition, index * Math.PI * 0.37);
+    return createPedestalPoiInstance(
+      definition,
+      index * Math.PI * 0.37,
+      options.detailPolicy
+    );
   });
 }
 
@@ -110,7 +122,8 @@ export function updatePoiInstanceDefinition(
 
 function createPedestalPoiInstance(
   definition: PoiDefinition,
-  phaseOffset: number
+  phaseOffset: number,
+  detailPolicy: SceneDetailPolicy = getSceneDetailPolicy('balanced')
 ): PoiInstance {
   const group = new Group();
   group.name = `POI:${definition.id}`;
@@ -135,11 +148,17 @@ function createPedestalPoiInstance(
         MathUtils.clamp(hologramConfig?.radiusScale ?? 0.75, 0.3, 1.25)
       : 0;
 
+  const isPerformance = detailPolicy.level === 'performance';
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
+  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
+  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
+  const ringSegments = detailPolicy.geometry.ringSegments;
+
   let accentMaterial: MeshStandardMaterial | undefined;
   let accentBaseColor: Color | undefined;
   let accentFocusColor: Color | undefined;
 
-  if (pedestalHeight > 0 && pedestalRadius > 0) {
+  if (!isPerformance && pedestalHeight > 0 && pedestalRadius > 0) {
     const bodyMaterial = new MeshStandardMaterial({
       color: new Color(hologramConfig?.bodyColor ?? 0x101c2a),
       emissive: new Color(hologramConfig?.emissiveColor ?? 0x2f8aff),
@@ -158,7 +177,7 @@ function createPedestalPoiInstance(
       pedestalRadius,
       pedestalRadius,
       pedestalHeight,
-      48,
+      cylinderSegments,
       1,
       true
     );
@@ -194,7 +213,7 @@ function createPedestalPoiInstance(
       pedestalRadius * 1.02,
       pedestalRadius * 1.02,
       accentHeight,
-      48,
+      cylinderSegments,
       1,
       true
     );
@@ -220,7 +239,7 @@ function createPedestalPoiInstance(
     const ringGeometry = new RingGeometry(
       pedestalRadius * 0.55,
       pedestalRadius * 1.08,
-      64,
+      ringSegments,
       1
     );
     const ring = new Mesh(ringGeometry, ringMaterial);
@@ -233,7 +252,11 @@ function createPedestalPoiInstance(
 
   const orbRadius =
     Math.max(baseRadius, pedestalRadius) * 0.45 * POI_ORB_DIAMETER_MULTIPLIER;
-  const orbGeometry = new SphereGeometry(orbRadius, 32, 32);
+  const orbGeometry = new SphereGeometry(
+    orbRadius,
+    sphereWidthSegments,
+    sphereHeightSegments
+  );
   const orbColor = new Color(hologramConfig?.orbColor ?? 0xb8f3ff);
   const orbEmissiveBase = new Color(
     hologramConfig?.orbEmissiveColor ?? 0x3de1ff
@@ -287,7 +310,7 @@ function createPedestalPoiInstance(
   const haloGeometry = new RingGeometry(
     haloInnerRadius,
     haloOuterRadius,
-    48,
+    ringSegments,
     1
   );
   const haloBaseColor = new Color(0x4bd8ff);
@@ -309,7 +332,7 @@ function createPedestalPoiInstance(
   const visitedRingGeometry = new RingGeometry(
     haloInnerRadius * 0.92,
     haloOuterRadius * 1.05,
-    60,
+    ringSegments,
     1
   );
   const visitedRingMaterial = new MeshBasicMaterial({
@@ -334,7 +357,7 @@ function createPedestalPoiInstance(
     hitAreaRadius,
     hitAreaRadius,
     hitAreaHeight,
-    32
+    cylinderSegments
   );
   const hitAreaMaterial = new MeshBasicMaterial({
     transparent: true,

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -18,6 +18,8 @@ import {
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
 
@@ -32,6 +34,7 @@ export interface FlywheelShowpieceOptions {
   centerZ: number;
   roomBounds: Bounds2D;
   orientationRadians?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface AutomationPillar {
@@ -44,6 +47,15 @@ interface AutomationPillar {
 export function createFlywheelShowpiece(
   options: FlywheelShowpieceOptions
 ): FlywheelShowpieceBuild {
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
+  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
+  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
+  const torusRadialSegments = detailPolicy.geometry.torusRadialSegments;
+  const torusTubularSegments = detailPolicy.geometry.torusTubularSegments;
+  const ringSegments = detailPolicy.geometry.ringSegments;
+
   const group = new Group();
   group.name = 'FlywheelShowpiece';
 
@@ -110,7 +122,7 @@ export function createFlywheelShowpiece(
     daisRadius,
     daisRadius,
     daisHeight,
-    32
+    cylinderSegments
   );
   const daisMaterial = new MeshStandardMaterial({
     color: new Color(0x14202c),
@@ -128,7 +140,7 @@ export function createFlywheelShowpiece(
     pedestalRadius,
     pedestalRadius,
     pedestalHeight,
-    48
+    cylinderSegments
   );
   const pedestalMaterial = new MeshStandardMaterial({
     color: new Color(0x182634),
@@ -149,7 +161,7 @@ export function createFlywheelShowpiece(
     pedestalRadius * 1.02,
     pedestalRadius * 1.02,
     accentHeight,
-    48
+    cylinderSegments
   );
   const accentMaterial = new MeshStandardMaterial({
     color: new Color(0x5ad1ff),
@@ -173,7 +185,7 @@ export function createFlywheelShowpiece(
     glassRadius,
     glassRadius,
     glassHeight,
-    32,
+    cylinderSegments,
     1,
     true
   );
@@ -191,6 +203,7 @@ export function createFlywheelShowpiece(
     daisHeight + pedestalHeight + glassHeight / 2,
     options.centerZ
   );
+  glass.visible = detailPolicy.effects.glassTransmission;
   group.add(glass);
 
   const rotorGroup = new Group();
@@ -207,8 +220,8 @@ export function createFlywheelShowpiece(
   const rotorRingGeometry = new TorusGeometry(
     rotorRingRadius,
     rotorRingTube,
-    24,
-    64
+    torusRadialSegments,
+    torusTubularSegments
   );
   const rotorRingMaterial = new MeshStandardMaterial({
     color: new Color(0x2c95ff),
@@ -222,7 +235,12 @@ export function createFlywheelShowpiece(
   rotorRing.rotation.x = Math.PI / 2;
   rotorGroup.add(rotorRing);
 
-  const innerDiscGeometry = new CylinderGeometry(0.38, 0.38, 0.06, 48);
+  const innerDiscGeometry = new CylinderGeometry(
+    0.38,
+    0.38,
+    0.06,
+    cylinderSegments
+  );
   const innerDiscMaterial = new MeshStandardMaterial({
     color: new Color(0x101822),
     roughness: 0.34,
@@ -264,8 +282,8 @@ export function createFlywheelShowpiece(
   const counterRingGeometry = new TorusGeometry(
     rotorRingRadius * 0.72,
     0.07,
-    20,
-    64
+    torusRadialSegments,
+    torusTubularSegments
   );
   const counterRingMaterial = new MeshStandardMaterial({
     color: new Color(0x1f88ff),
@@ -282,7 +300,7 @@ export function createFlywheelShowpiece(
   const glyphRingGeometry = new RingGeometry(
     rotorRingRadius * 0.58,
     rotorRingRadius * 0.72,
-    64,
+    ringSegments,
     1
   );
   const glyphRingMaterial = new MeshBasicMaterial({
@@ -300,18 +318,25 @@ export function createFlywheelShowpiece(
   const orbitGroup = new Group();
   orbitGroup.name = 'FlywheelOrbitGroup';
   orbitGroup.position.copy(rotorGroup.position);
+  orbitGroup.visible = !isPerformance;
   group.add(orbitGroup);
 
   const automationPillars: AutomationPillar[] = [];
   const automationPillarGroup = new Group();
   automationPillarGroup.name = 'FlywheelAutomationPillars';
   automationPillarGroup.position.copy(rotorGroup.position);
+  automationPillarGroup.visible = !isPerformance;
   group.add(automationPillarGroup);
 
   const pillarCount = 4;
   const pillarHeight = Math.min(1.05, pedestalHeight * 1.5);
   const pillarRadius = rotorRingRadius * 0.94;
-  const pillarGeometry = new CylinderGeometry(0.12, 0.18, pillarHeight, 18);
+  const pillarGeometry = new CylinderGeometry(
+    0.12,
+    0.18,
+    pillarHeight,
+    cylinderSegments
+  );
   for (let index = 0; index < pillarCount; index += 1) {
     const pillarMaterial = new MeshStandardMaterial({
       color: new Color(0x102133),
@@ -341,7 +366,11 @@ export function createFlywheelShowpiece(
   }
 
   const orbitRadius = rotorRingRadius * 1.12;
-  const orbitGeometry = new SphereGeometry(0.08, 24, 24);
+  const orbitGeometry = new SphereGeometry(
+    0.08,
+    sphereWidthSegments,
+    sphereHeightSegments
+  );
   const orbitMaterial = new MeshStandardMaterial({
     color: new Color(0xffffff),
     emissive: new Color(0x7be9ff),
@@ -362,6 +391,7 @@ export function createFlywheelShowpiece(
   const techStackGroup = new Group();
   techStackGroup.name = 'FlywheelTechStackGroup';
   techStackGroup.position.copy(rotorGroup.position);
+  techStackGroup.visible = !isPerformance;
   group.add(techStackGroup);
 
   const techStackItems = [
@@ -549,6 +579,13 @@ export function createFlywheelShowpiece(
       smoothing
     );
     const selectionInfluence = MathUtils.clamp(selectionStrength, 0, 1);
+    if (
+      isPerformance &&
+      Math.max(context.emphasis, selectionInfluence) < 0.02
+    ) {
+      rotorGroup.rotation.y += 0.12 * context.delta;
+      return;
+    }
     const targetVelocity =
       MathUtils.lerp(0.55, 2.4, context.emphasis) +
       MathUtils.lerp(0, 1.1, selectionInfluence);

--- a/src/scene/structures/greenhouse.ts
+++ b/src/scene/structures/greenhouse.ts
@@ -20,6 +20,8 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 export interface GreenhouseConfig {
   basePosition: Vector3;
@@ -28,6 +30,7 @@ export interface GreenhouseConfig {
   depth?: number;
   environmentMap?: Texture | null;
   environmentIntensity?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface GreenhouseBuild {
@@ -46,6 +49,9 @@ const BASE_HEIGHT = 0.18;
 const SOLAR_BASE_TILT = -MathUtils.degToRad(18);
 
 export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
+  const detailPolicy = config.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
   const width = config.width ?? DEFAULT_WIDTH;
   const depth = config.depth ?? DEFAULT_DEPTH;
   const orientation = config.orientationRadians ?? 0;
@@ -193,15 +199,23 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   roofBeamRight.rotation.z = -roofBeamLeft.rotation.z;
   frameGroup.add(roofBeamRight);
 
-  const glassMaterial = new MeshPhysicalMaterial({
-    color: new Color(0x9cd6ff),
-    transparent: true,
-    opacity: 0.28,
-    roughness: 0.1,
-    metalness: 0.0,
-    transmission: 0.86,
-    thickness: 0.18,
-  });
+  const glassMaterial = isPerformance
+    ? new MeshStandardMaterial({
+        color: new Color(0x6ba6c7),
+        transparent: true,
+        opacity: 0.38,
+        roughness: 0.42,
+        metalness: 0.05,
+      })
+    : new MeshPhysicalMaterial({
+        color: new Color(0x9cd6ff),
+        transparent: true,
+        opacity: 0.28,
+        roughness: 0.1,
+        metalness: 0.0,
+        transmission: 0.86,
+        thickness: 0.18,
+      });
   applyEnvironmentMap(glassMaterial);
 
   const wallGeometry = new PlaneGeometry(
@@ -282,7 +296,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     pondPlinthRadius,
     pondPlinthRadius,
     pondPlinthHeight,
-    40
+    cylinderSegments
   );
   const pondPlinthMaterial = new MeshStandardMaterial({
     color: new Color(0x2b343c),
@@ -303,7 +317,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     depth * 0.17,
     depth * 0.17,
     0.12,
-    32
+    cylinderSegments
   );
   const pondMaterial = new MeshStandardMaterial({
     color: new Color(0x1a4a5e),
@@ -407,6 +421,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   );
   pondRipple.rotation.x = -Math.PI / 2;
   pondRipple.renderOrder = 6;
+  pondRipple.visible = detailPolicy.effects.pondRippleShader;
   group.add(pondRipple);
 
   const solarPanelPivot = new Group();
@@ -446,7 +461,12 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   });
 
   const growLightMaterials: MeshStandardMaterial[] = [];
-  const growLightGeometry = new CylinderGeometry(0.05, 0.05, width * 0.32, 12);
+  const growLightGeometry = new CylinderGeometry(
+    0.05,
+    0.05,
+    width * 0.32,
+    cylinderSegments
+  );
   const growLightSpacing = depth * 0.38;
   [-growLightSpacing, 0, growLightSpacing].forEach((offsetZ, index) => {
     const lightMaterial = new MeshStandardMaterial({
@@ -465,6 +485,9 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   });
 
   const update = ({ elapsed }: { elapsed: number; delta: number }) => {
+    if (isPerformance) {
+      return;
+    }
     const pulseScale = MathUtils.clamp(getPulseScale(), 0, 1);
     const flickerScale = MathUtils.clamp(getFlickerScale(), 0, 1);
     const calmScale = Math.min(pulseScale, flickerScale);

--- a/src/scene/structures/jobbotTerminal.ts
+++ b/src/scene/structures/jobbotTerminal.ts
@@ -18,6 +18,11 @@ import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
+const JOBBOT_SCREEN_WIDTH = 2048;
+const JOBBOT_SCREEN_HEIGHT = 1024;
+const JOBBOT_TELEMETRY_WIDTH = 1024;
+const JOBBOT_TELEMETRY_HEIGHT = 512;
+
 export interface JobbotTerminalBuild {
   group: Group;
   colliders: RectCollider[];
@@ -58,47 +63,56 @@ function createTerminalScreenTexture(
   const context = canvas.getContext('2d');
 
   if (context) {
+    context.save();
+    context.scale?.(
+      canvas.width / JOBBOT_SCREEN_WIDTH,
+      canvas.height / JOBBOT_SCREEN_HEIGHT
+    );
     context.fillStyle = '#07111f';
-    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillRect(0, 0, JOBBOT_SCREEN_WIDTH, JOBBOT_SCREEN_HEIGHT);
 
     const background = context.createLinearGradient(
       0,
       0,
-      canvas.width,
-      canvas.height
+      JOBBOT_SCREEN_WIDTH,
+      JOBBOT_SCREEN_HEIGHT
     );
     background.addColorStop(0, '#0d253f');
     background.addColorStop(0.6, '#10203a');
     background.addColorStop(1, '#0c1728');
     context.fillStyle = background;
-    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillRect(0, 0, JOBBOT_SCREEN_WIDTH, JOBBOT_SCREEN_HEIGHT);
 
     context.fillStyle = '#7cf1ff';
     context.font = 'bold 220px "Inter", "Segoe UI", sans-serif';
     context.textAlign = 'left';
     context.textBaseline = 'alphabetic';
-    context.fillText('jobbot3000', canvas.width * 0.08, canvas.height * 0.46);
+    context.fillText(
+      'jobbot3000',
+      JOBBOT_SCREEN_WIDTH * 0.08,
+      JOBBOT_SCREEN_HEIGHT * 0.46
+    );
 
     context.font = '64px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#9ce9ff';
     context.fillText(
       'Automation orchestrator · live diagnostics stream',
-      canvas.width * 0.08,
-      canvas.height * 0.68
+      JOBBOT_SCREEN_WIDTH * 0.08,
+      JOBBOT_SCREEN_HEIGHT * 0.68
     );
 
     context.font = '52px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#fede72';
     context.fillText(
       'Status: nominal · queue depth 0 · SLA 99.98%',
-      canvas.width * 0.08,
-      canvas.height * 0.82
+      JOBBOT_SCREEN_WIDTH * 0.08,
+      JOBBOT_SCREEN_HEIGHT * 0.82
     );
 
-    const rightColumnX = canvas.width * 0.7;
+    const rightColumnX = JOBBOT_SCREEN_WIDTH * 0.7;
     context.font = '600 56px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#ffffff';
-    context.fillText('Ops timeline', rightColumnX, canvas.height * 0.32);
+    context.fillText('Ops timeline', rightColumnX, JOBBOT_SCREEN_HEIGHT * 0.32);
 
     context.font = '42px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#b6d8ff';
@@ -108,8 +122,13 @@ function createTerminalScreenTexture(
       '• 05:38 · queue drained',
     ];
     logLines.forEach((line, index) => {
-      context.fillText(line, rightColumnX, canvas.height * (0.4 + index * 0.1));
+      context.fillText(
+        line,
+        rightColumnX,
+        JOBBOT_SCREEN_HEIGHT * (0.4 + index * 0.1)
+      );
     });
+    context.restore();
   }
 
   const texture = new CanvasTexture(canvas);
@@ -134,12 +153,27 @@ function createTelemetryPanelTexture(
   }
 
   context.clearRect(0, 0, canvas.width, canvas.height);
+  context.save();
+  context.scale?.(
+    canvas.width / JOBBOT_TELEMETRY_WIDTH,
+    canvas.height / JOBBOT_TELEMETRY_HEIGHT
+  );
   context.fillStyle = 'rgba(5, 18, 32, 0.9)';
-  context.fillRect(48, 48, canvas.width - 96, canvas.height - 96);
+  context.fillRect(
+    48,
+    48,
+    JOBBOT_TELEMETRY_WIDTH - 96,
+    JOBBOT_TELEMETRY_HEIGHT - 96
+  );
 
   context.strokeStyle = 'rgba(124, 241, 255, 0.4)';
   context.lineWidth = 6;
-  context.strokeRect(48, 48, canvas.width - 96, canvas.height - 96);
+  context.strokeRect(
+    48,
+    48,
+    JOBBOT_TELEMETRY_WIDTH - 96,
+    JOBBOT_TELEMETRY_HEIGHT - 96
+  );
 
   context.textAlign = 'left';
   context.textBaseline = 'alphabetic';
@@ -160,6 +194,7 @@ function createTelemetryPanelTexture(
     context.fillStyle = '#f1fdff';
     context.fillText(metric, 136, y - 6);
   });
+  context.restore();
 
   const texture = new CanvasTexture(canvas);
   texture.colorSpace = SRGBColorSpace;

--- a/src/scene/structures/jobbotTerminal.ts
+++ b/src/scene/structures/jobbotTerminal.ts
@@ -15,6 +15,8 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 export interface JobbotTerminalBuild {
   group: Group;
@@ -35,6 +37,7 @@ export interface JobbotTerminalOptions {
     width?: number;
     depth?: number;
   };
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface DataShardState {
@@ -46,10 +49,12 @@ interface DataShardState {
   orbitSpeed: number;
 }
 
-function createTerminalScreenTexture(): CanvasTexture {
+function createTerminalScreenTexture(
+  size = getSceneDetailPolicy('balanced').textures.jobbotScreen
+): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 2048;
-  canvas.height = 1024;
+  canvas.width = size.width;
+  canvas.height = size.height;
   const context = canvas.getContext('2d');
 
   if (context) {
@@ -116,11 +121,12 @@ function createTerminalScreenTexture(): CanvasTexture {
 function createTelemetryPanelTexture(
   heading: string,
   primary: string,
-  metrics: string[]
+  metrics: string[],
+  size = getSceneDetailPolicy('balanced').textures.jobbotTelemetry
 ): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 1024;
-  canvas.height = 512;
+  canvas.width = size.width;
+  canvas.height = size.height;
   const context = canvas.getContext('2d');
 
   if (!context) {
@@ -205,6 +211,11 @@ export function createJobbotTerminal(
   options: JobbotTerminalOptions
 ): JobbotTerminalBuild {
   const { position, orientationRadians = 0, desk } = options;
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
+  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
+  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
   const baseY = position.y ?? 0;
   const deskWidth = desk?.width ?? 3.6;
   const deskDepth = desk?.depth ?? 1.6;
@@ -283,7 +294,9 @@ export function createJobbotTerminal(
   );
   group.add(accent);
 
-  const screenTexture = createTerminalScreenTexture();
+  const screenTexture = createTerminalScreenTexture(
+    detailPolicy.textures.jobbotScreen
+  );
   const screenMaterial = new MeshBasicMaterial({
     map: screenTexture,
     transparent: true,
@@ -335,7 +348,12 @@ export function createJobbotTerminal(
   ticker.renderOrder = 7;
   group.add(ticker);
 
-  const hologramBaseGeometry = new CylinderGeometry(0.42, 0.5, 0.18, 48);
+  const hologramBaseGeometry = new CylinderGeometry(
+    0.42,
+    0.5,
+    0.18,
+    cylinderSegments
+  );
   const hologramBaseMaterial = new MeshStandardMaterial({
     color: new Color(0x152335),
     emissive: new Color(0x1b5dff),
@@ -365,7 +383,14 @@ export function createJobbotTerminal(
     depthWrite: false,
     toneMapped: false,
   });
-  const hologramGeometry = new CylinderGeometry(0.12, 0.4, 0.8, 36, 1, true);
+  const hologramGeometry = new CylinderGeometry(
+    0.12,
+    0.4,
+    0.8,
+    cylinderSegments,
+    1,
+    true
+  );
   const hologram = new Mesh(hologramGeometry, hologramMaterial);
   hologram.position.y = 0.3;
   hologramGroup.add(hologram);
@@ -377,7 +402,11 @@ export function createJobbotTerminal(
     roughness: 0.2,
     metalness: 0.45,
   });
-  const hologramCoreGeometry = new SphereGeometry(0.18, 32, 32);
+  const hologramCoreGeometry = new SphereGeometry(
+    0.18,
+    sphereWidthSegments,
+    sphereHeightSegments
+  );
   const hologramCore = new Mesh(hologramCoreGeometry, hologramCoreMaterial);
   hologramCore.name = 'JobbotTerminalCore';
   hologramCore.position.set(0, 0.55, 0);
@@ -399,6 +428,7 @@ export function createJobbotTerminal(
   const dataShardGroup = new Group();
   dataShardGroup.name = 'JobbotTerminalDataShards';
   dataShardGroup.position.set(0, hologramBaseHeight + 0.24, 0);
+  dataShardGroup.visible = detailPolicy.effects.decorativeShards;
   group.add(dataShardGroup);
 
   const shardGeometry = new BoxGeometry(0.12, 0.34, 0.04);
@@ -412,7 +442,7 @@ export function createJobbotTerminal(
     opacity: 0.72,
   });
   const dataShards: DataShardState[] = [];
-  const shardCount = 6;
+  const shardCount = detailPolicy.effects.decorativeShards ? 6 : 0;
   for (let index = 0; index < shardCount; index += 1) {
     const mesh = new Mesh(shardGeometry, shardMaterial.clone());
     mesh.name = `JobbotTerminalDataShard-${index}`;
@@ -436,6 +466,7 @@ export function createJobbotTerminal(
   telemetryGroup.name = 'JobbotTerminalTelemetryGroup';
   const telemetryBaseHeight = deskHeight + deskThickness + 0.58;
   telemetryGroup.position.set(0, telemetryBaseHeight, 0);
+  telemetryGroup.visible = detailPolicy.effects.telemetryPanels;
   group.add(telemetryGroup);
 
   const telemetryDescriptors = [
@@ -461,7 +492,8 @@ export function createJobbotTerminal(
     const texture = createTelemetryPanelTexture(
       descriptor.heading,
       descriptor.primary,
-      descriptor.metrics
+      descriptor.metrics,
+      detailPolicy.textures.jobbotTelemetry
     );
     const material = new MeshBasicMaterial({
       map: texture,
@@ -499,7 +531,7 @@ export function createJobbotTerminal(
       telemetryRadius * 1.06,
       telemetryRadius * 1.06,
       0.04,
-      48
+      cylinderSegments
     ),
     telemetryAuraMaterial
   );
@@ -509,7 +541,11 @@ export function createJobbotTerminal(
   telemetryAura.renderOrder = 2;
   group.add(telemetryAura);
 
-  const statusBeaconGeometry = new SphereGeometry(0.08, 24, 24);
+  const statusBeaconGeometry = new SphereGeometry(
+    0.08,
+    sphereWidthSegments,
+    sphereHeightSegments
+  );
   const statusBeaconMaterial = new MeshStandardMaterial({
     color: new Color(0x1a2f40),
     emissive: new Color(0x3cb6ff),
@@ -562,6 +598,12 @@ export function createJobbotTerminal(
         pulseScale <= 0
           ? 0
           : Math.min(1, analyticsGlowValue * pulseScale * 0.85);
+
+      if (isPerformance && combinedEmphasis < 0.02) {
+        screenGlowMaterial.emissiveIntensity = 0.18;
+        tickerMaterial.opacity = 0.32;
+        return;
+      }
       const analyticsPhase = analyticsWaveValue * Math.PI * 2;
       const bobAmplitude = MathUtils.lerp(0.012, 0.08, pulseScale);
       const spinScale = MathUtils.lerp(0.15, 1, pulseScale);

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -23,6 +23,8 @@ import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
+const BADGE_WIDTH = 512;
+const BADGE_HEIGHT = 256;
 const BASE_GLOW_OPACITY = 0.18;
 const EMPHASISED_GLOW_OPACITY = 0.62;
 const CLEARANCE_BASE_OPACITY = 0.16;
@@ -67,7 +69,7 @@ class MediaWallScreenRenderer {
     this.texture.colorSpace = SRGBColorSpace;
     this.starCount = options.starCount;
 
-    this.render();
+    this.render({ force: true });
   }
 
   getTexture(): CanvasTexture {
@@ -80,7 +82,7 @@ class MediaWallScreenRenderer {
     } else {
       this.starCount = count;
     }
-    this.render();
+    this.render({ force: true });
   }
 
   updateHighlight(target: number) {
@@ -96,9 +98,10 @@ class MediaWallScreenRenderer {
     this.texture.dispose();
   }
 
-  private render() {
+  private render(options: { force?: boolean } = {}) {
     const now = typeof performance === 'undefined' ? 0 : performance.now();
     if (
+      !options.force &&
       this.redrawThrottleMs > 0 &&
       now - this.lastRenderMs < this.redrawThrottleMs
     ) {
@@ -107,6 +110,10 @@ class MediaWallScreenRenderer {
     this.lastRenderMs = now;
     this.context.save();
     this.context.clearRect(0, 0, this.width, this.height);
+    this.context.scale?.(
+      this.width / SCREEN_WIDTH,
+      this.height / SCREEN_HEIGHT
+    );
     this.drawBase();
     this.drawStarHighlight();
     this.context.restore();
@@ -117,40 +124,40 @@ class MediaWallScreenRenderer {
     const ctx = this.context;
     ctx.save();
     ctx.fillStyle = '#0f1724';
-    ctx.fillRect(0, 0, this.width, this.height);
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 
     const baseGradient = ctx.createLinearGradient(
       0,
       0,
-      this.width,
-      this.height
+      SCREEN_WIDTH,
+      SCREEN_HEIGHT
     );
     baseGradient.addColorStop(0, '#182a47');
     baseGradient.addColorStop(0.55, '#0f233c');
     baseGradient.addColorStop(1, '#192339');
     ctx.fillStyle = baseGradient;
-    ctx.fillRect(0, 0, this.width, this.height);
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 
     ctx.globalAlpha = 0.6;
-    const accentGradient = ctx.createLinearGradient(0, 0, this.width, 0);
+    const accentGradient = ctx.createLinearGradient(0, 0, SCREEN_WIDTH, 0);
     accentGradient.addColorStop(0, 'rgba(75, 217, 255, 0.8)');
     accentGradient.addColorStop(0.45, 'rgba(83, 146, 255, 0.35)');
     accentGradient.addColorStop(1, 'rgba(255, 82, 82, 0.6)');
     ctx.fillStyle = accentGradient;
 
-    const accentX = this.width * 0.05;
-    const accentY = this.height * 0.16;
-    const accentWidth = this.width * 0.9;
-    const accentHeight = this.height * 0.68;
+    const accentX = SCREEN_WIDTH * 0.05;
+    const accentY = SCREEN_HEIGHT * 0.16;
+    const accentWidth = SCREEN_WIDTH * 0.9;
+    const accentHeight = SCREEN_HEIGHT * 0.68;
     ctx.fillRect(accentX, accentY, accentWidth, accentHeight);
     ctx.globalAlpha = 1;
 
-    const leftTextAnchor = this.width * 0.08;
-    const headerY = this.height * 0.44;
-    const platformY = this.height * 0.62;
-    const taglineY = this.height * 0.74;
-    const episodeY = this.height * 0.84;
-    const rightTextAnchor = this.width * 0.92;
+    const leftTextAnchor = SCREEN_WIDTH * 0.08;
+    const headerY = SCREEN_HEIGHT * 0.44;
+    const platformY = SCREEN_HEIGHT * 0.62;
+    const taglineY = SCREEN_HEIGHT * 0.74;
+    const episodeY = SCREEN_HEIGHT * 0.84;
+    const rightTextAnchor = SCREEN_WIDTH * 0.92;
 
     ctx.fillStyle = '#ffffff';
     ctx.font = 'bold 180px "Inter", "Segoe UI", sans-serif';
@@ -181,10 +188,10 @@ class MediaWallScreenRenderer {
 
   private drawStarHighlight() {
     const ctx = this.context;
-    const cardWidth = this.width * 0.26;
-    const cardHeight = this.height * 0.32;
-    const cardX = this.width * 0.62;
-    const cardY = this.height * 0.18;
+    const cardWidth = SCREEN_WIDTH * 0.26;
+    const cardHeight = SCREEN_HEIGHT * 0.32;
+    const cardX = SCREEN_WIDTH * 0.62;
+    const cardY = SCREEN_HEIGHT * 0.18;
     const cardRadius = cardHeight * 0.16;
 
     ctx.save();
@@ -258,7 +265,7 @@ function createScreenRenderer(
   detailPolicy = getSceneDetailPolicy('balanced')
 ): MediaWallScreenRenderer {
   return new MediaWallScreenRenderer({
-    starCount: 1280,
+    starCount: detailPolicy.level === 'performance' ? 128 : 1280,
     width: detailPolicy.textures.mediaWallScreen.width,
     height: detailPolicy.textures.mediaWallScreen.height,
     redrawThrottleMs: detailPolicy.updates.canvasRedrawThrottleMs,
@@ -278,22 +285,24 @@ function createBadgeTexture(
   }
 
   context.clearRect(0, 0, canvas.width, canvas.height);
+  context.save();
+  context.scale?.(canvas.width / BADGE_WIDTH, canvas.height / BADGE_HEIGHT);
   const radius = 42;
   const badgeColor = '#ff0000';
   context.fillStyle = badgeColor;
   context.beginPath();
   context.moveTo(radius, 0);
-  context.lineTo(canvas.width - radius, 0);
-  context.quadraticCurveTo(canvas.width, 0, canvas.width, radius);
-  context.lineTo(canvas.width, canvas.height - radius);
+  context.lineTo(BADGE_WIDTH - radius, 0);
+  context.quadraticCurveTo(BADGE_WIDTH, 0, BADGE_WIDTH, radius);
+  context.lineTo(BADGE_WIDTH, BADGE_HEIGHT - radius);
   context.quadraticCurveTo(
-    canvas.width,
-    canvas.height,
-    canvas.width - radius,
-    canvas.height
+    BADGE_WIDTH,
+    BADGE_HEIGHT,
+    BADGE_WIDTH - radius,
+    BADGE_HEIGHT
   );
-  context.lineTo(radius, canvas.height);
-  context.quadraticCurveTo(0, canvas.height, 0, canvas.height - radius);
+  context.lineTo(radius, BADGE_HEIGHT);
+  context.quadraticCurveTo(0, BADGE_HEIGHT, 0, BADGE_HEIGHT - radius);
   context.lineTo(0, radius);
   context.quadraticCurveTo(0, 0, radius, 0);
   context.closePath();
@@ -301,15 +310,16 @@ function createBadgeTexture(
 
   const playWidth = 120;
   const playHeight = 120;
-  const playOriginX = canvas.width / 2 - playWidth / 4;
-  const playOriginY = canvas.height / 2 - playHeight / 2;
+  const playOriginX = BADGE_WIDTH / 2 - playWidth / 4;
+  const playOriginY = BADGE_HEIGHT / 2 - playHeight / 2;
   context.fillStyle = '#ffffff';
   context.beginPath();
   context.moveTo(playOriginX, playOriginY);
   context.lineTo(playOriginX, playOriginY + playHeight);
-  context.lineTo(canvas.width / 2 + playWidth / 2, canvas.height / 2);
+  context.lineTo(BADGE_WIDTH / 2 + playWidth / 2, BADGE_HEIGHT / 2);
   context.closePath();
   context.fill();
+  context.restore();
 
   const texture = new CanvasTexture(canvas);
   texture.colorSpace = SRGBColorSpace;
@@ -734,7 +744,6 @@ export function createLivingRoomMediaWall(
     clearanceHighlightColor,
     detailPolicy,
   });
-  controller.setStarCount(detailPolicy.level === 'performance' ? 128 : 1280);
 
   return { group, colliders, poiBindings, controller };
 }

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -18,6 +18,8 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
@@ -30,6 +32,9 @@ const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
 
 interface MediaWallScreenRendererOptions {
   starCount: number;
+  width?: number;
+  height?: number;
+  redrawThrottleMs?: number;
 }
 
 class MediaWallScreenRenderer {
@@ -38,11 +43,18 @@ class MediaWallScreenRenderer {
   private readonly texture: CanvasTexture;
   private highlight = 0;
   private starCount: number;
+  private width: number;
+  private height: number;
+  private redrawThrottleMs: number;
+  private lastRenderMs = Number.NEGATIVE_INFINITY;
 
   constructor(options: MediaWallScreenRendererOptions) {
     const canvas = document.createElement('canvas');
-    canvas.width = SCREEN_WIDTH;
-    canvas.height = SCREEN_HEIGHT;
+    this.width = options.width ?? SCREEN_WIDTH;
+    this.height = options.height ?? SCREEN_HEIGHT;
+    this.redrawThrottleMs = options.redrawThrottleMs ?? 0;
+    canvas.width = this.width;
+    canvas.height = this.height;
     const context = canvas.getContext('2d');
 
     if (!context) {
@@ -85,8 +97,16 @@ class MediaWallScreenRenderer {
   }
 
   private render() {
+    const now = typeof performance === 'undefined' ? 0 : performance.now();
+    if (
+      this.redrawThrottleMs > 0 &&
+      now - this.lastRenderMs < this.redrawThrottleMs
+    ) {
+      return;
+    }
+    this.lastRenderMs = now;
     this.context.save();
-    this.context.clearRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    this.context.clearRect(0, 0, this.width, this.height);
     this.drawBase();
     this.drawStarHighlight();
     this.context.restore();
@@ -97,40 +117,40 @@ class MediaWallScreenRenderer {
     const ctx = this.context;
     ctx.save();
     ctx.fillStyle = '#0f1724';
-    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    ctx.fillRect(0, 0, this.width, this.height);
 
     const baseGradient = ctx.createLinearGradient(
       0,
       0,
-      SCREEN_WIDTH,
-      SCREEN_HEIGHT
+      this.width,
+      this.height
     );
     baseGradient.addColorStop(0, '#182a47');
     baseGradient.addColorStop(0.55, '#0f233c');
     baseGradient.addColorStop(1, '#192339');
     ctx.fillStyle = baseGradient;
-    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    ctx.fillRect(0, 0, this.width, this.height);
 
     ctx.globalAlpha = 0.6;
-    const accentGradient = ctx.createLinearGradient(0, 0, SCREEN_WIDTH, 0);
+    const accentGradient = ctx.createLinearGradient(0, 0, this.width, 0);
     accentGradient.addColorStop(0, 'rgba(75, 217, 255, 0.8)');
     accentGradient.addColorStop(0.45, 'rgba(83, 146, 255, 0.35)');
     accentGradient.addColorStop(1, 'rgba(255, 82, 82, 0.6)');
     ctx.fillStyle = accentGradient;
 
-    const accentX = SCREEN_WIDTH * 0.05;
-    const accentY = SCREEN_HEIGHT * 0.16;
-    const accentWidth = SCREEN_WIDTH * 0.9;
-    const accentHeight = SCREEN_HEIGHT * 0.68;
+    const accentX = this.width * 0.05;
+    const accentY = this.height * 0.16;
+    const accentWidth = this.width * 0.9;
+    const accentHeight = this.height * 0.68;
     ctx.fillRect(accentX, accentY, accentWidth, accentHeight);
     ctx.globalAlpha = 1;
 
-    const leftTextAnchor = SCREEN_WIDTH * 0.08;
-    const headerY = SCREEN_HEIGHT * 0.44;
-    const platformY = SCREEN_HEIGHT * 0.62;
-    const taglineY = SCREEN_HEIGHT * 0.74;
-    const episodeY = SCREEN_HEIGHT * 0.84;
-    const rightTextAnchor = SCREEN_WIDTH * 0.92;
+    const leftTextAnchor = this.width * 0.08;
+    const headerY = this.height * 0.44;
+    const platformY = this.height * 0.62;
+    const taglineY = this.height * 0.74;
+    const episodeY = this.height * 0.84;
+    const rightTextAnchor = this.width * 0.92;
 
     ctx.fillStyle = '#ffffff';
     ctx.font = 'bold 180px "Inter", "Segoe UI", sans-serif';
@@ -161,10 +181,10 @@ class MediaWallScreenRenderer {
 
   private drawStarHighlight() {
     const ctx = this.context;
-    const cardWidth = SCREEN_WIDTH * 0.26;
-    const cardHeight = SCREEN_HEIGHT * 0.32;
-    const cardX = SCREEN_WIDTH * 0.62;
-    const cardY = SCREEN_HEIGHT * 0.18;
+    const cardWidth = this.width * 0.26;
+    const cardHeight = this.height * 0.32;
+    const cardX = this.width * 0.62;
+    const cardY = this.height * 0.18;
     const cardRadius = cardHeight * 0.16;
 
     ctx.save();
@@ -234,14 +254,23 @@ interface MediaWallTextures {
   badge: CanvasTexture;
 }
 
-function createScreenRenderer(): MediaWallScreenRenderer {
-  return new MediaWallScreenRenderer({ starCount: 1280 });
+function createScreenRenderer(
+  detailPolicy = getSceneDetailPolicy('balanced')
+): MediaWallScreenRenderer {
+  return new MediaWallScreenRenderer({
+    starCount: 1280,
+    width: detailPolicy.textures.mediaWallScreen.width,
+    height: detailPolicy.textures.mediaWallScreen.height,
+    redrawThrottleMs: detailPolicy.updates.canvasRedrawThrottleMs,
+  });
 }
 
-function createBadgeTexture(): CanvasTexture {
+function createBadgeTexture(
+  detailPolicy = getSceneDetailPolicy('balanced')
+): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
+  canvas.width = detailPolicy.textures.mediaWallBadge.width;
+  canvas.height = detailPolicy.textures.mediaWallBadge.height;
   const context = canvas.getContext('2d');
 
   if (!context) {
@@ -288,10 +317,12 @@ function createBadgeTexture(): CanvasTexture {
   return texture;
 }
 
-function getMediaWallTextures(): MediaWallTextures {
+function getMediaWallTextures(
+  detailPolicy = getSceneDetailPolicy('balanced')
+): MediaWallTextures {
   return {
-    screen: createScreenRenderer(),
-    badge: createBadgeTexture(),
+    screen: createScreenRenderer(detailPolicy),
+    badge: createBadgeTexture(detailPolicy),
   };
 }
 
@@ -331,6 +362,7 @@ interface MediaWallControllerOptions {
   clearanceMaterial: MeshBasicMaterial;
   clearanceBaseColor: Color;
   clearanceHighlightColor: Color;
+  detailPolicy: SceneDetailPolicy;
 }
 
 function createMediaWallController({
@@ -341,6 +373,7 @@ function createMediaWallController({
   clearanceMaterial,
   clearanceBaseColor,
   clearanceHighlightColor,
+  detailPolicy,
 }: MediaWallControllerOptions): LivingRoomMediaWallController {
   let highlight = 0;
   const baseHaloIntensity = haloMaterial.emissiveIntensity;
@@ -433,7 +466,9 @@ function createMediaWallController({
         clearanceMaterial.color.copy(clearanceColor);
         clearanceMaterial.needsUpdate = true;
       }
-      screenRenderer.updateHighlight(highlight);
+      if (detailPolicy.level !== 'performance' || highlight > 0.05) {
+        screenRenderer.updateHighlight(highlight);
+      }
     },
     setStarCount(count) {
       screenRenderer.setStarCount(count);
@@ -445,7 +480,8 @@ function createMediaWallController({
 }
 
 export function createLivingRoomMediaWall(
-  bounds: Bounds2D
+  bounds: Bounds2D,
+  detailPolicy: SceneDetailPolicy = getSceneDetailPolicy('balanced')
 ): LivingRoomMediaWallBuild {
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
@@ -487,7 +523,7 @@ export function createLivingRoomMediaWall(
   );
   group.add(trim);
 
-  const { screen, badge } = getMediaWallTextures();
+  const { screen, badge } = getMediaWallTextures(detailPolicy);
 
   const screenMaterial = new MeshBasicMaterial({
     map: screen.getTexture(),
@@ -520,6 +556,7 @@ export function createLivingRoomMediaWall(
   screenGlow.position.set(wallInteriorX + boardDepth + 0.015, 2.36, anchorZ);
   screenGlow.rotation.y = Math.PI / 2;
   screenGlow.renderOrder = 9;
+  screenGlow.visible = detailPolicy.effects.decorativeHalos;
   group.add(screenGlow);
 
   const badgeMaterial = new MeshBasicMaterial({
@@ -597,6 +634,7 @@ export function createLivingRoomMediaWall(
   const haloGeometry = new BoxGeometry(0.06, 0.24, shelfWidth * 0.85);
   const halo = new Mesh(haloGeometry, haloMaterial);
   halo.position.set(wallInteriorX + boardDepth + 0.37, 1.02, anchorZ);
+  halo.visible = detailPolicy.effects.decorativeHalos;
   group.add(halo);
 
   const shelfLightMaterial = new MeshStandardMaterial({
@@ -694,8 +732,9 @@ export function createLivingRoomMediaWall(
     clearanceMaterial,
     clearanceBaseColor,
     clearanceHighlightColor,
+    detailPolicy,
   });
-  controller.setStarCount(1280);
+  controller.setStarCount(detailPolicy.level === 'performance' ? 128 : 1280);
 
   return { group, colliders, poiBindings, controller };
 }

--- a/src/scene/structures/modelRocket.ts
+++ b/src/scene/structures/modelRocket.ts
@@ -16,11 +16,14 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 export interface ModelRocketConfig {
   basePosition: Vector3;
   orientationRadians?: number;
   scale?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface ModelRocketBuild {
@@ -33,6 +36,10 @@ const DEFAULT_SCALE = 1;
 const FIN_COUNT = 3;
 
 export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
+  const detailPolicy = config.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
+  const ringSegments = detailPolicy.geometry.ringSegments;
   const scale = config.scale ?? DEFAULT_SCALE;
   const orientation = config.orientationRadians ?? 0;
   const basePosition = config.basePosition.clone();
@@ -48,7 +55,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius,
     standRadius,
     standHeight,
-    32
+    cylinderSegments
   );
   const standMaterial = new MeshStandardMaterial({
     color: new Color(0x2c3442),
@@ -64,7 +71,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius * 0.98,
     standRadius * 1.04,
     standHeight * 0.38,
-    32
+    cylinderSegments
   );
   const standTrimMaterial = new MeshStandardMaterial({
     color: new Color(0x39475b),
@@ -84,7 +91,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.02,
     bodyRadius * 0.94,
     bodyHeight,
-    40
+    cylinderSegments
   );
   const bodyMaterial = new MeshStandardMaterial({
     color: new Color(0xe7eefc),
@@ -103,7 +110,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.06,
     bodyRadius * 1.06,
     stripeHeight,
-    40
+    cylinderSegments
   );
   const stripeMaterial = new MeshStandardMaterial({
     color: new Color(0xff6b6b),
@@ -118,7 +125,11 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   group.add(stripe);
 
   const noseHeight = 1.1 * scale;
-  const noseGeometry = new ConeGeometry(bodyRadius * 0.92, noseHeight, 40);
+  const noseGeometry = new ConeGeometry(
+    bodyRadius * 0.92,
+    noseHeight,
+    cylinderSegments
+  );
   const noseMaterial = new MeshStandardMaterial({
     color: new Color(0xff8976),
     emissive: new Color(0xb33a2d),
@@ -136,7 +147,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 0.78,
     bodyRadius * 0.62,
     thrusterHeight,
-    32
+    cylinderSegments
   );
   const thrusterMaterial = new MeshStandardMaterial({
     color: new Color(0x1f2734),
@@ -159,12 +170,13 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   );
   thrusterLight.name = 'ModelRocketThrusterLight';
   thrusterLight.position.set(0, standHeight + thrusterHeight * 0.24, 0);
+  thrusterLight.visible = detailPolicy.effects.dynamicPointLights;
   group.add(thrusterLight);
 
   const flameGeometry = new ConeGeometry(
     bodyRadius * 0.42,
     0.88 * scale,
-    24,
+    cylinderSegments,
     1,
     true
   );
@@ -179,6 +191,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   flame.position.set(0, standHeight - thrusterHeight * 0.32, 0);
   flame.rotation.x = Math.PI;
   flame.scale.set(0.75, 0.5, 0.75);
+  flame.visible = !isPerformance;
   group.add(flame);
 
   const finHeight = 0.78 * scale;
@@ -209,7 +222,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   const safetyRingGeometry = new RingGeometry(
     standRadius * 1.18,
     standRadius * 1.52,
-    48
+    ringSegments
   );
   const safetyRingMaterial = new MeshBasicMaterial({
     color: new Color(0xffd166),
@@ -221,6 +234,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   safetyRing.name = 'ModelRocketSafetyRing';
   safetyRing.rotation.x = -Math.PI / 2;
   safetyRing.position.y = 0.02 * scale;
+  safetyRing.visible = !isPerformance;
   group.add(safetyRing);
 
   const countdownPanelMaterial = new MeshBasicMaterial({
@@ -240,6 +254,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius + 0.12 * scale
   );
   countdownPanel.rotation.y = Math.PI;
+  countdownPanel.visible = !isPerformance;
   group.add(countdownPanel);
 
   const footprintRadius = standRadius * 1.45;
@@ -259,6 +274,9 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   const thrusterLightBaseDistance = thrusterLight.distance;
 
   const update = ({ elapsed }: { elapsed: number; delta: number }) => {
+    if (isPerformance) {
+      return;
+    }
     const pulseScale = MathUtils.clamp(getPulseScale(), 0, 1);
     const thrusterPulse =
       ((Math.sin(elapsed * 2.1) + 1) / 2) * MathUtils.lerp(0.45, 1, pulseScale);

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -4,13 +4,43 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const mainPath = resolve(currentDir, '../main.ts');
+const readMainSource = () => readFileSync(mainPath, 'utf-8');
+
 describe('main module imports', () => {
   it('keeps camera-relative yaw helpers wired in', () => {
-    const currentDir = dirname(fileURLToPath(import.meta.url));
-    const mainPath = resolve(currentDir, '../main.ts');
-    const source = readFileSync(mainPath, 'utf-8');
+    const source = readMainSource();
     expect(source).toMatch(
       /import\s*\{[^}]*\bcomputeCameraRelativeYaw\b[^}]*\}\s*from '\.\/systems\/movement\/facing';/
+    );
+  });
+
+  it('falls back to a URL scene-detail reload handoff when sessionStorage is blocked', () => {
+    const source = readMainSource();
+
+    expect(source).toContain(
+      "const PENDING_SCENE_DETAIL_RELOAD_PARAM = 'sceneDetailReloadLevel';"
+    );
+    expect(source).toContain('function reloadWithPendingSceneDetailParam');
+    expect(source).toContain(
+      'url.searchParams.set(PENDING_SCENE_DETAIL_RELOAD_PARAM, level);'
+    );
+    expect(source).toContain('window.location.assign(url.toString());');
+    expect(source).toContain('if (reloadWithPendingSceneDetailParam(level))');
+  });
+
+  it('does not reload when no scene-detail handoff can be persisted', () => {
+    const source = readMainSource();
+
+    expect(source).toContain(
+      'window.sessionStorage.getItem(PENDING_SCENE_DETAIL_RELOAD_KEY) === level'
+    );
+    expect(source).toMatch(
+      /if \(persistPendingSceneDetailReloadLevel\(level\)\) \{\s*window\.location\.reload\(\);\s*return;\s*\}/
+    );
+    expect(source).toContain(
+      '[performance] scene detail reload handoff unavailable; applying policy without reload'
     );
   });
 });

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -22,22 +22,47 @@ describe('main module imports', () => {
     expect(source).toContain(
       "const PENDING_SCENE_DETAIL_RELOAD_PARAM = 'sceneDetailReloadLevel';"
     );
-    expect(source).toContain('function reloadWithPendingSceneDetailParam');
     expect(source).toContain(
-      'url.searchParams.set(PENDING_SCENE_DETAIL_RELOAD_PARAM, level);'
+      "const PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM = 'sceneDetailAdaptiveLock';"
+    );
+    expect(source).toContain('function reloadWithPendingSceneDetailParam');
+    expect(source).toContain('url.searchParams.set(');
+    expect(source).toContain('PENDING_SCENE_DETAIL_RELOAD_PARAM,');
+    expect(source).toContain(
+      "url.searchParams.set(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM, '1');"
     );
     expect(source).toContain('window.location.assign(url.toString());');
-    expect(source).toContain('if (reloadWithPendingSceneDetailParam(level))');
+    expect(source).toContain(
+      'if (reloadWithPendingSceneDetailParam(pendingReload))'
+    );
+  });
+
+  it('carries the adaptive recovery lock through scene-detail reload handoffs', () => {
+    const source = readMainSource();
+
+    expect(source).toContain(
+      "adaptivePerformanceRecoveryLocked: level === 'performance'"
+    );
+    expect(source).toContain('initialAdaptivePerformanceRecoveryLocked:');
+    expect(source).toContain(
+      'sceneDetailReloadOverride?.adaptivePerformanceRecoveryLocked === true'
+    );
+    expect(source).toContain(
+      'return { level: stored, adaptivePerformanceRecoveryLocked: adaptiveLock };'
+    );
   });
 
   it('does not reload when no scene-detail handoff can be persisted', () => {
     const source = readMainSource();
 
     expect(source).toContain(
-      'window.sessionStorage.getItem(PENDING_SCENE_DETAIL_RELOAD_KEY) === level'
+      'window.sessionStorage.getItem(PENDING_SCENE_DETAIL_RELOAD_KEY) ==='
+    );
+    expect(source).toContain(
+      'window.sessionStorage.getItem(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY) ==='
     );
     expect(source).toMatch(
-      /if \(persistPendingSceneDetailReloadLevel\(level\)\) \{\s*window\.location\.reload\(\);\s*return;\s*\}/
+      /if \(persistPendingSceneDetailReload\(pendingReload\)\) \{\s*window\.location\.reload\(\);\s*return;\s*\}/
     );
     expect(source).toContain(
       '[performance] scene detail reload handoff unavailable; applying policy without reload'

--- a/src/tests/mannequinDetailPolicy.test.ts
+++ b/src/tests/mannequinDetailPolicy.test.ts
@@ -1,0 +1,44 @@
+import { Box3, Mesh } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createPortfolioMannequin } from '../scene/avatar/mannequin';
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
+
+describe('portfolio mannequin detail policy', () => {
+  it('preserves height and collision radius while lowering performance geometry segments', () => {
+    const balanced = createPortfolioMannequin({ collisionRadius: 0.75 });
+    const performance = createPortfolioMannequin({
+      collisionRadius: 0.75,
+      detailPolicy: getSceneDetailPolicy('performance'),
+    });
+
+    const balancedLegs = balanced.group.getObjectByName(
+      'PortfolioMannequinLegs'
+    ) as Mesh;
+    const performanceLegs = performance.group.getObjectByName(
+      'PortfolioMannequinLegs'
+    ) as Mesh;
+
+    expect(performance.height).toBe(balanced.height);
+    expect(performance.collisionRadius).toBe(balanced.collisionRadius);
+    expect(performance.group.userData.boundingRadius).toBe(0.75);
+    const balancedLegGeometry =
+      balancedLegs.geometry as typeof balancedLegs.geometry & {
+        parameters: { radialSegments: number };
+      };
+    const performanceLegGeometry =
+      performanceLegs.geometry as typeof performanceLegs.geometry & {
+        parameters: { radialSegments: number };
+      };
+    expect(performanceLegGeometry.parameters.radialSegments).toBeLessThan(
+      balancedLegGeometry.parameters.radialSegments / 3
+    );
+
+    const balancedBox = new Box3().setFromObject(balanced.group);
+    const performanceBox = new Box3().setFromObject(performance.group);
+    expect(performanceBox.max.y - performanceBox.min.y).toBeCloseTo(
+      balancedBox.max.y - balancedBox.min.y,
+      1
+    );
+  });
+});

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -62,6 +62,14 @@ describe('performance diagnostics', () => {
         mirrorRenderCount: 3,
       }),
       getLastFailoverReason: () => null,
+      getRendererCounters: () => ({
+        calls: 7,
+        triangles: 1234,
+        points: 2,
+        lines: 3,
+        memoryGeometries: 42,
+        memoryTextures: 9,
+      }),
     });
 
     diagnostics.recordFrame(1 / 60);
@@ -77,6 +85,12 @@ describe('performance diagnostics', () => {
     expect(snapshot.minFps).toBeCloseTo(10, 0);
     expect(snapshot.sampleCount).toBe(3);
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
+    expect(snapshot.rendererCounters).toMatchObject({
+      calls: 7,
+      triangles: 1234,
+      memoryGeometries: 42,
+      memoryTextures: 9,
+    });
     expect(snapshot.softwareRendererPolicy.safeMode).toBe(false);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -26,12 +26,14 @@ function createPolicyHarness({
   selectionSource = 'adaptive',
   isSoftwareRenderer = false,
   onSceneDetailLevelChange,
+  initialAdaptivePerformanceRecoveryLocked = false,
 }: {
   level?: GraphicsQualityLevel;
   basePixelRatio?: number;
   selectionSource?: AdaptiveQualitySelectionSource;
   isSoftwareRenderer?: boolean;
   onSceneDetailLevelChange?: (level: GraphicsQualityLevel) => void;
+  initialAdaptivePerformanceRecoveryLocked?: boolean;
 } = {}) {
   let currentLevel = level;
   let currentBasePixelRatio = basePixelRatio;
@@ -62,6 +64,7 @@ function createPolicyHarness({
     recoveryP95FrameMs: 22,
     onAction,
     onSceneDetailLevelChange,
+    initialAdaptivePerformanceRecoveryLocked,
   });
 
   return {
@@ -398,6 +401,40 @@ describe('immersive performance optimization policy', () => {
 
     expect(balancedHarness.controller.getSnapshot().stableDurationMs).toBe(0);
     expect(cinematicHarness.controller.getSnapshot().stableDurationMs).toBe(0);
+  });
+
+  it('keeps adaptive performance locked after a scene-detail reload handoff', () => {
+    const harness = createPolicyHarness({
+      level: 'performance',
+      selectionSource: 'initial',
+      initialAdaptivePerformanceRecoveryLocked: true,
+    });
+
+    let recoveryEvent = null;
+    for (let index = 0; index < 420; index += 1) {
+      recoveryEvent = harness.controller.update(1 / 60) ?? recoveryEvent;
+    }
+
+    expect(recoveryEvent).toBeNull();
+    expect(harness.level).toBe('performance');
+    expect(harness.controller.getRecoveryCount()).toBe(0);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      autoRecoveryEnabled: false,
+      stableDurationMs: 0,
+    });
+
+    harness.setLevel('balanced');
+    harness.setSelectionSource('user');
+    harness.controller.update(1 / 60);
+    harness.setLevel('performance');
+    harness.setSelectionSource('adaptive');
+
+    for (let index = 0; index < 420; index += 1) {
+      recoveryEvent = harness.controller.update(1 / 60) ?? recoveryEvent;
+    }
+
+    expect(recoveryEvent?.action).toBe('recover');
+    expect(harness.level).toBe('balanced');
   });
 
   it('does not auto-recover after adaptive downgrade to performance', () => {

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { GraphicsQualityLevel } from '../scene/graphics/qualityManager';
-import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
+import {
+  createSceneDetailController,
+  getSceneDetailPolicy,
+} from '../scene/graphics/sceneDetailPolicy';
 import {
   createAdaptiveQualityController,
   type AdaptiveQualitySelectionSource,
@@ -422,6 +425,19 @@ describe('immersive performance optimization policy', () => {
     expect(sceneDetailChanges).toContain('performance');
     expect(getSceneDetailPolicy(currentLevel).effects.dynamicPointLights).toBe(
       false
+    );
+  });
+
+  it('throttles decorative updates per subsystem channel', () => {
+    const controller = createSceneDetailController('performance');
+
+    expect(controller.shouldRunDecorativeUpdate(1, 1, 'media-wall')).toBe(true);
+    expect(controller.shouldRunDecorativeUpdate(1, 1, 'jobbot')).toBe(true);
+    expect(controller.shouldRunDecorativeUpdate(1.1, 1, 'media-wall')).toBe(
+      false
+    );
+    expect(controller.shouldRunDecorativeUpdate(1.3, 1, 'media-wall')).toBe(
+      true
     );
   });
 

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -25,11 +25,13 @@ function createPolicyHarness({
   basePixelRatio = 1.25,
   selectionSource = 'adaptive',
   isSoftwareRenderer = false,
+  onSceneDetailLevelChange,
 }: {
   level?: GraphicsQualityLevel;
   basePixelRatio?: number;
   selectionSource?: AdaptiveQualitySelectionSource;
   isSoftwareRenderer?: boolean;
+  onSceneDetailLevelChange?: (level: GraphicsQualityLevel) => void;
 } = {}) {
   let currentLevel = level;
   let currentBasePixelRatio = basePixelRatio;
@@ -59,6 +61,7 @@ function createPolicyHarness({
     recoveryFpsThreshold: 55,
     recoveryP95FrameMs: 22,
     onAction,
+    onSceneDetailLevelChange,
   });
 
   return {
@@ -304,6 +307,39 @@ describe('immersive performance optimization policy', () => {
     expect(policy.mirrorEnabled).toBe(false);
   });
 
+  it('respects persisted balanced quality on coarse-pointer hardware', () => {
+    const policy = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      resolveSoftwareRendererPolicy({ isDangerousSoftwareRenderer: false }),
+      {
+        coarsePointer: true,
+        mobileLike: true,
+        tabletLike: true,
+        explicitGraphicsQualityLevel: 'balanced',
+      }
+    );
+
+    expect(policy.initialLevel).toBe('balanced');
+    expect(policy.sceneDetailLevel).toBe('balanced');
+    expect(policy.mirrorEnabled).toBe(true);
+  });
+
+  it('resolves persisted performance scene detail before construction', () => {
+    const policy = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      resolveSoftwareRendererPolicy({ isDangerousSoftwareRenderer: false }),
+      { explicitGraphicsQualityLevel: 'performance' }
+    );
+
+    expect(policy.initialLevel).toBe('performance');
+    expect(policy.sceneDetailLevel).toBe('performance');
+    expect(getQualitySceneDetailPolicy(policy.sceneDetailLevel).level).toBe(
+      'performance'
+    );
+  });
+
   it('resizes DPR up to the device cap without undoing adaptive downgrades', () => {
     expect(resolveResizedBasePixelRatio(2, 1.25)).toBe(1.25);
     expect(resolveResizedBasePixelRatio(2, 1.25, 1)).toBe(1);
@@ -364,8 +400,13 @@ describe('immersive performance optimization policy', () => {
     expect(cinematicHarness.controller.getSnapshot().stableDurationMs).toBe(0);
   });
 
-  it('starts recovery hysteresis fresh after a balanced to performance downgrade', () => {
-    const harness = createPolicyHarness({ level: 'balanced' });
+  it('does not auto-recover after adaptive downgrade to performance', () => {
+    const sceneDetailChanges: GraphicsQualityLevel[] = [];
+    const harness = createPolicyHarness({
+      level: 'balanced',
+      selectionSource: 'adaptive',
+      onSceneDetailLevelChange: (level) => sceneDetailChanges.push(level),
+    });
 
     for (let index = 0; index < 240; index += 1) {
       harness.controller.update(1 / 60);
@@ -380,21 +421,24 @@ describe('immersive performance optimization policy', () => {
 
     expect(downgradeEvent?.step).toBe('quality-performance');
     expect(harness.level).toBe('performance');
-    expect(harness.controller.getSnapshot().stableDurationMs).toBe(0);
+    expect(sceneDetailChanges).toEqual(['performance']);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      autoRecoveryEnabled: false,
+      stableDurationMs: 0,
+    });
 
     let recoveryEvent = null;
-    for (let index = 0; index < 179; index += 1) {
+    for (let index = 0; index < 420; index += 1) {
       recoveryEvent = harness.controller.update(1 / 60) ?? recoveryEvent;
     }
 
     expect(recoveryEvent).toBeNull();
     expect(harness.level).toBe('performance');
+    expect(harness.controller.getRecoveryCount()).toBe(0);
 
-    for (let index = 0; index < 180; index += 1) {
-      recoveryEvent = harness.controller.update(1 / 60) ?? recoveryEvent;
-    }
+    harness.setLevel('balanced');
+    harness.setSelectionSource('user');
 
-    expect(recoveryEvent?.action).toBe('recover');
     expect(harness.level).toBe('balanced');
   });
 

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { GraphicsQualityLevel } from '../scene/graphics/qualityManager';
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import {
   createAdaptiveQualityController,
   type AdaptiveQualitySelectionSource,
@@ -12,6 +13,7 @@ import {
   resolveResizedBasePixelRatio,
   resolveSoftwareRendererPolicy,
   resolveSoftwareSafeRenderCadence,
+  getQualitySceneDetailPolicy,
 } from '../scene/performance/qualityPolicy';
 import { classifyRendererInfo } from '../scene/performance/rendererCapabilities';
 
@@ -263,6 +265,42 @@ describe('immersive performance optimization policy', () => {
     });
   });
 
+  it('maps graphics quality to centralized scene detail budgets', () => {
+    const balanced = getQualitySceneDetailPolicy('balanced');
+    const performance = getQualitySceneDetailPolicy('performance');
+
+    expect(performance.level).toBe('performance');
+    expect(performance.effects.mist).toBe(false);
+    expect(performance.effects.pondRippleShader).toBe(false);
+    expect(performance.effects.dynamicPointLights).toBe(false);
+    expect(performance.textures.jobbotScreen.width).toBeLessThanOrEqual(
+      balanced.textures.jobbotScreen.width / 4
+    );
+    expect(performance.geometry.cylinderSegments).toBeLessThanOrEqual(
+      balanced.geometry.cylinderSegments / 5
+    );
+    expect(performance.geometry.sphereWidthSegments).toBeLessThanOrEqual(
+      balanced.geometry.sphereWidthSegments / 4
+    );
+    expect(performance.budgets.transparentShaderLayers).toBe(0);
+    expect(performance.budgets.dynamicPointLights).toBeLessThan(
+      balanced.budgets.dynamicPointLights
+    );
+  });
+
+  it('starts coarse-pointer constrained hardware in performance without persisted preferences', () => {
+    const policy = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      resolveSoftwareRendererPolicy({ isDangerousSoftwareRenderer: false }),
+      { coarsePointer: true, tabletLike: true, deviceMemoryGb: 4 }
+    );
+
+    expect(policy.initialLevel).toBe('performance');
+    expect(policy.sceneDetailLevel).toBe('performance');
+    expect(policy.mirrorEnabled).toBe(false);
+  });
+
   it('resizes DPR up to the device cap without undoing adaptive downgrades', () => {
     expect(resolveResizedBasePixelRatio(2, 1.25)).toBe(1.25);
     expect(resolveResizedBasePixelRatio(2, 1.25, 1)).toBe(1);
@@ -355,6 +393,36 @@ describe('immersive performance optimization policy', () => {
 
     expect(recoveryEvent?.action).toBe('recover');
     expect(harness.level).toBe('balanced');
+  });
+
+  it('notifies scene detail policy when adaptive downgrade reaches performance', () => {
+    let currentLevel: GraphicsQualityLevel = 'balanced';
+    const sceneDetailChanges: GraphicsQualityLevel[] = [];
+    const controller = createAdaptiveQualityController({
+      qualityManager: {
+        getLevel: () => currentLevel,
+        setLevel: (next) => {
+          currentLevel = next;
+        },
+        setBasePixelRatio: () => undefined,
+      },
+      getBasePixelRatio: () => 1,
+      setBasePixelRatio: () => undefined,
+      cooldownMs: 0,
+      downgradeAfterMs: 1000,
+      warmupMs: 0,
+      onSceneDetailLevelChange: (level) => sceneDetailChanges.push(level),
+    });
+
+    for (let index = 0; index < 4; index += 1) {
+      controller.update(0.4);
+    }
+
+    expect(currentLevel).toBe('performance');
+    expect(sceneDetailChanges).toContain('performance');
+    expect(getSceneDetailPolicy(currentLevel).effects.dynamicPointLights).toBe(
+      false
+    );
   });
 
   it('keeps software renderers conservative and does not auto-upshift', () => {

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -1,6 +1,12 @@
-import { CylinderGeometry, MeshStandardMaterial, Color } from 'three';
+import {
+  Color,
+  CylinderGeometry,
+  MeshStandardMaterial,
+  SphereGeometry,
+} from 'three';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import { scalePoiValue } from '../scene/poi/constants';
 import {
   createPoiInstances,
@@ -13,13 +19,7 @@ describe('createPoiInstances', () => {
   const baseSummary = 'Automation-ready showcase artifact.';
   let fillTextLog: string[] = [];
 
-  let originalGetContext:
-    | ((
-        this: HTMLCanvasElement,
-        contextId: string,
-        ...args: unknown[]
-      ) => CanvasRenderingContext2D | null)
-    | undefined;
+  let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
 
   beforeAll(() => {
     originalGetContext = HTMLCanvasElement.prototype.getContext;
@@ -27,7 +27,7 @@ describe('createPoiInstances', () => {
       this: HTMLCanvasElement,
       contextId: string,
       ...args: unknown[]
-    ): CanvasRenderingContext2D | null {
+    ) {
       if (contextId === '2d') {
         const gradient = {
           addColorStop: () => {
@@ -69,7 +69,8 @@ describe('createPoiInstances', () => {
           fillText: (text: string) => {
             fillTextLog.push(text);
           },
-          measureText: (text: string) => ({ width: text.length * 10 }),
+          measureText: (text: string) =>
+            ({ width: text.length * 10 }) as TextMetrics,
           createLinearGradient: () => gradient as CanvasGradient,
           set lineWidth(_value: number) {
             /* noop */
@@ -92,22 +93,16 @@ describe('createPoiInstances', () => {
         };
         return context as CanvasRenderingContext2D;
       }
-      return originalGetContext
-        ? originalGetContext.call(this, contextId, ...args)
-        : null;
-    };
+      return originalGetContext.call(
+        this,
+        contextId as Parameters<typeof originalGetContext>[0],
+        ...(args as [])
+      );
+    } as typeof HTMLCanvasElement.prototype.getContext;
   });
 
   afterAll(() => {
-    if (originalGetContext) {
-      HTMLCanvasElement.prototype.getContext = originalGetContext;
-    } else {
-      delete (
-        HTMLCanvasElement.prototype as {
-          getContext?: typeof originalGetContext;
-        }
-      ).getContext;
-    }
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
   });
 
   const createDefinition = (
@@ -242,7 +237,9 @@ describe('createPoiInstances', () => {
       5
     );
     expect(instance.orbBaseHeight).toBeGreaterThan(pedestalHeight);
-    expect(instance.labelBaseHeight).toBeGreaterThan(instance.orbBaseHeight);
+    expect(instance.labelBaseHeight ?? 0).toBeGreaterThan(
+      instance.orbBaseHeight ?? 0
+    );
   });
 
   it('keeps default pedestal styling when no hologram config is provided', () => {
@@ -260,5 +257,40 @@ describe('createPoiInstances', () => {
       scalePoiValue(0.32) + scalePoiValue(0.24),
       5
     );
+  });
+
+  it('uses low-poly performance marker geometry without changing hit collider bounds', () => {
+    const definition = createDefinition({
+      id: 'flywheel-studio-flywheel',
+      footprint: { width: 2.6, depth: 2.2 },
+      pedestal: {
+        type: 'hologram',
+        height: 1.6,
+        radiusScale: 0.88,
+      },
+    });
+    const [balanced] = createPoiInstances([definition]);
+    const [performance] = createPoiInstances(
+      [definition],
+      {},
+      {
+        detailPolicy: getSceneDetailPolicy('performance'),
+      }
+    );
+
+    const balancedHitGeometry = balanced.hitArea.geometry as CylinderGeometry;
+    const performanceHitGeometry = performance.hitArea
+      .geometry as CylinderGeometry;
+    const balancedOrbGeometry = balanced.orb?.geometry as SphereGeometry;
+    const performanceOrbGeometry = performance.orb?.geometry as SphereGeometry;
+
+    expect(performanceHitGeometry.parameters.radialSegments).toBeLessThan(
+      balancedHitGeometry.parameters.radialSegments / 3
+    );
+    expect(performanceOrbGeometry.parameters.widthSegments).toBeLessThan(
+      balancedOrbGeometry.parameters.widthSegments / 3
+    );
+    expect(performance.collider).toEqual(balanced.collider);
+    expect(performance.hitArea.name).toBe(`POI_HIT:${definition.id}`);
   });
 });


### PR DESCRIPTION
### Motivation

- Provide a centralized, much more aggressive Performance graphics mode that reduces shader/fill-rate work, canvas uploads, draw calls, dynamic lights, per-frame decorative updates, and triangle count while preserving Balanced/Cinematic visuals.
- Make the adaptive quality and initial quality selection apply scene detail reductions (not just pixel ratio/postprocessing) and make device heuristics start weak/mobile sessions in Performance when no user preference exists.
- Centralize detail budgets so feature toggles and LODs are easy to audit and test.

### Description

- Add a typed scene detail policy and controller in `src/scene/graphics/sceneDetailPolicy.ts` exposing geometry segment counts, texture sizes, effect toggles, update throttles, and theoretical budgets for `cinematic|balanced|performance` levels and `getSceneDetailPolicy(level)`/`createSceneDetailController(...)` helpers.
- Wire scene detail policy into the performance stack: expose `sceneDetail` from `resolveInitialQualityPolicy` and notify `createAdaptiveQualityController` via `onSceneDetailLevelChange` so adaptive downgrades immediately apply low‑detail policies.
- Extend `GraphicsQualityManager` with persistent resolution helpers (`resolvePersistedGraphicsQualityLevel`) and expose storage key constant for clearer wiring.
- Apply performance policy at scene construction and runtime: pass `detailPolicy` into expensive builders and controllers from `src/main.ts` and add a `sceneDetailController` that throttles decorative updates via `shouldRunDecorativeUpdate(...)`.
- Implement low‑poly / low‑effect builds and runtime behavior for major expensive components: POI markers (`src/scene/poi/markers.ts`), mannequin (`src/scene/avatar/mannequin.ts`), Flywheel (`src/scene/structures/flywheel.ts`), Jobbot terminal (`src/scene/structures/jobbotTerminal.ts`), Media Wall (`src/scene/structures/mediaWall.ts`), Greenhouse (`src/scene/structures/greenhouse.ts`), Model Rocket (`src/scene/structures/modelRocket.ts`), Backyard (`src/scene/environments/backyard.ts`). Changes include using the policy geometry segment values, smaller canvas texture sizes for Jobbot/MediaWall, disabling or replacing expensive ShaderMaterial / MeshPhysicalMaterial features with cheaper materials in Performance, hiding/omitting decorative groups (or making them invisible), disabling or reducing PointLight visibility in Performance, and avoiding per-frame canvas redraws where throttled by the policy.
- Reduce per-frame work by gating update() paths when Performance is active; added cheap early returns or throttles where safe and preserved colliders/hit areas for correctness.
- Extend diagnostics: `src/scene/performance/performanceDiagnostics.ts` now includes `rendererCounters` (reads `renderer.info` where available) and the diagnostics API exposes scene/detail snapshot via `getSnapshot()`; `window.portfolio.performance` remains available.
- Add/adjust unit tests: extend `src/tests/performanceOptimization.test.ts` and `src/tests/performanceDiagnostics.test.ts`; add detail/LOD checks for POI markers and mannequin (`src/tests/poiMarkers.test.ts`, `src/tests/mannequinDetailPolicy.test.ts`) to assert reduced segment counts and preserved colliders/heights.
- Small supporting fixes: add `src/scene/collision.ts` re-export for `RectCollider`, adjust a few imports and test shims to keep the focused test run stable.

### Testing

- Ran focused unit tests: `npm run test:ci -- src/tests/graphicsQualityManager.test.ts src/tests/performanceOptimization.test.ts src/tests/performanceDiagnostics.test.ts src/tests/poiMarkers.test.ts` and then with the added mannequin test; the targeted suites passed locally (these files together exercised the graphics quality, adaptive downgrade, diagnostics and POI/mannequin LOD changes). (Passed)
- Ran extended unit+integration run: `npm run test:ci` (full test run) locally; the test runner completed and the modified tests (performance and POI related) passed; test logs include some non-critical stderr test helper logs and mocked failure traces surfaced by spies but no failing tests from the modified areas were observed. (Completed, no failing tests introduced by changes to performance/scene detail features)
- Type checking and build: ran `npm run typecheck` and iteratively addressed introduced typing issues tied to the new APIs and test helpers; `npm run build` completed successfully and produced a production build. (Build succeeded)

Commands run (representative): `npm run format:write`, `npm run lint`, `npm run typecheck`, `npm run test:ci -- src/tests/graphicsQualityManager.test.ts src/tests/performanceOptimization.test.ts src/tests/performanceDiagnostics.test.ts src/tests/poiMarkers.test.ts`, `npm run test:ci`, and `npm run build`.

Residual notes / follow-ups

- The change centralizes performance/detail policy and reduces per-frame cost across many structures; balanced and cinematic paths are left functionally unchanged where possible, but reviewers should visually validate Cinematic/Balanced scenes to confirm parity.
- The PR adds a small set of tests that assert theoretical budget reductions (segment counts, texture sizes, effect toggles); these are deterministic checks of policy application rather than absolute runtime FPS guarantees.
- A follow-up could add lazy-upgrade paths for objects that were fully elided in Performance mode (if a user explicitly changes back from Performance mid-session) to avoid a full reload when restoring high detail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1face2e198832fa885ac5102919ab7)