### PR TITLE
Aggressive Performance scene detail policy + low‑poly LODs and effect budgets

### DIFF
--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -29,6 +29,13 @@ interface PerformanceSnapshot {
     lastAdaptiveReason: string | null;
     lastAdaptiveDowngradeReason: string | null;
     lastAdaptiveRecoveryReason: string | null;
+    sceneDetailLevel?: 'cinematic' | 'balanced' | 'performance';
+    sceneDetailMetrics?: {
+      theoreticalWorkScale: number;
+      texturePixelBudget: number;
+      poiTriangleBudget: number;
+      shaderEffectsEnabled: number;
+    };
     adaptivePolicy: {
       isWarmingUp: boolean;
       warmupElapsedMs: number;
@@ -211,6 +218,35 @@ test.describe('immersive performance diagnostics', () => {
         expect(snapshot.features.composerEnabled).toBe(false);
         expect(snapshot.features.mirrorEnabled).toBe(false);
       }
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('caps theoretical scene work when performance graphics mode is selected', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'danielsmith:graphics-quality-level',
+        'performance'
+      );
+    });
+
+    try {
+      await waitForImmersive(page, IMMERSIVE_DIAGNOSTICS_URL);
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.quality.level).toBe('performance');
+      expect(snapshot.quality.sceneDetailLevel).toBe('performance');
+      expect(
+        snapshot.quality.sceneDetailMetrics?.theoreticalWorkScale
+      ).toBeLessThanOrEqual(0.1);
+      expect(snapshot.quality.sceneDetailMetrics?.shaderEffectsEnabled).toBe(0);
+      expect(snapshot.features.bloomEnabled).toBe(false);
+      expect(snapshot.features.mirrorEnabled).toBe(false);
     } finally {
       await context.close();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,11 @@ import {
   createGraphicsQualityManager,
   type GraphicsQualityManager,
 } from './scene/graphics/qualityManager';
+import {
+  getSceneDetailMetrics,
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from './scene/graphics/sceneDetailPolicy';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -730,11 +735,36 @@ function initializeImmersiveScene(
     rendererInfo,
     window.location.search
   );
+  const qualityStorageHasPreference = (() => {
+    try {
+      return (
+        window.localStorage.getItem('danielsmith:graphics-quality-level') !==
+        null
+      );
+    } catch {
+      return false;
+    }
+  })();
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
     window.devicePixelRatio ?? 1,
-    softwareRendererPolicy
+    softwareRendererPolicy,
+    {
+      coarsePointer: window.matchMedia?.('(pointer: coarse)').matches ?? false,
+      mobileLike: /Android|iPad|iPhone|Mobile|Tablet/i.test(
+        navigator.userAgent
+      ),
+      deviceMemoryGb: (navigator as Navigator & { deviceMemory?: number })
+        .deviceMemory,
+      hardwareConcurrency: navigator.hardwareConcurrency,
+      hasExplicitPreference: qualityStorageHasPreference,
+    }
   );
+  let activeSceneDetailPolicy: SceneDetailPolicy = getSceneDetailPolicy(
+    initialQualityPolicy.sceneDetailLevel
+  );
+  document.documentElement.dataset.sceneDetailLevel =
+    activeSceneDetailPolicy.level;
   const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
     ? initialQualityPolicy.basePixelRatioCap
     : rendererInfo.isSoftwareRenderer
@@ -1152,6 +1182,7 @@ function initializeImmersiveScene(
   if (backyardRoom) {
     backyardEnvironment = createBackyardEnvironment(backyardRoom.bounds, {
       seasonalPreset,
+      detailPolicy: activeSceneDetailPolicy,
     });
     scene.add(backyardEnvironment.group);
     // Remove the enclosing sky dome to avoid a bright circular spheroid.
@@ -1244,7 +1275,9 @@ function initializeImmersiveScene(
 
   const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom');
   if (livingRoom) {
-    const mediaWall = createLivingRoomMediaWall(livingRoom.bounds);
+    const mediaWall = createLivingRoomMediaWall(livingRoom.bounds, {
+      detailPolicy: activeSceneDetailPolicy,
+    });
     scene.add(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
@@ -1547,7 +1580,9 @@ function initializeImmersiveScene(
   });
   lightmapAnimator.captureBaseline();
 
-  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides);
+  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
+    detailPolicy: activeSceneDetailPolicy,
+  });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
       scene.add(poi.group);
@@ -1922,6 +1957,7 @@ function initializeImmersiveScene(
       flywheelPoi?.group.position.z ??
       (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2;
     const showpiece = createFlywheelShowpiece({
+      detailPolicy: activeSceneDetailPolicy,
       centerX,
       centerZ,
       roomBounds: studioRoom.bounds,
@@ -1943,6 +1979,7 @@ function initializeImmersiveScene(
       studioRoom.bounds.maxZ - 1.1
     );
     const terminal = createJobbotTerminal({
+      detailPolicy: activeSceneDetailPolicy,
       position: { x: terminalX, y: 0, z: terminalZ },
       orientationRadians: terminalOrientation,
     });
@@ -2175,6 +2212,7 @@ function initializeImmersiveScene(
   window.addEventListener('beforeunload', beforeUnloadHandler);
 
   const mannequin = createPortfolioMannequin({
+    detailPolicy: activeSceneDetailPolicy,
     collisionRadius: PLAYER_RADIUS,
   });
   const player = mannequin.group;
@@ -3573,6 +3611,7 @@ function initializeImmersiveScene(
     },
     fpsThreshold: PERFORMANCE_FAILOVER_FPS_THRESHOLD,
     isSoftwareRenderer: rendererInfo.isSoftwareRenderer,
+    lockRecoveryAfterPerformanceDowngrade: true,
     getSelectionSource: () =>
       graphicsQualityManager?.getSelectionSource() ?? 'initial',
     onAction: (event) => {
@@ -3748,6 +3787,39 @@ function initializeImmersiveScene(
   });
   registerHudControlElement(graphicsQualityControl?.element ?? null);
 
+  const applySceneDetailPolicy = () => {
+    activeSceneDetailPolicy = getSceneDetailPolicy(
+      graphicsQualityManager?.getLevel() ??
+        initialQualityPolicy.sceneDetailLevel
+    );
+    document.documentElement.dataset.sceneDetailLevel =
+      activeSceneDetailPolicy.level;
+    if (
+      initialQualityPolicy.sceneDetailLevel === 'performance' &&
+      activeSceneDetailPolicy.level !== 'performance'
+    ) {
+      document.documentElement.dataset.sceneDetailReloadRecommended = 'true';
+    } else {
+      delete document.documentElement.dataset.sceneDetailReloadRecommended;
+    }
+    const lowDetail = activeSceneDetailPolicy.level === 'performance';
+    scene.traverse((object) => {
+      const name = object.name.toLowerCase();
+      if (
+        name.includes('mist') ||
+        name.includes('aura') ||
+        name.includes('halo') ||
+        name.includes('glow') ||
+        name.includes('telemetry')
+      ) {
+        object.visible = !lowDetail;
+      }
+      if (object.type === 'PointLight') {
+        object.visible = !lowDetail;
+      }
+    });
+  };
+
   const applyFeaturePolicy = () => {
     const policy = getQualityFeaturePolicy(
       graphicsQualityManager?.getLevel() ?? initialQualityPolicy.initialLevel,
@@ -3776,6 +3848,7 @@ function initializeImmersiveScene(
 
   unsubscribeGraphicsQuality = graphicsQualityManager.onChange(() => {
     applyFeaturePolicy();
+    applySceneDetailPolicy();
     composer?.setSize(window.innerWidth, window.innerHeight);
     bloomPass?.setSize(window.innerWidth, window.innerHeight);
     graphicsQualityControl?.refresh();
@@ -3783,6 +3856,7 @@ function initializeImmersiveScene(
     environmentLightAnimator?.captureBaseline();
   });
   applyFeaturePolicy();
+  applySceneDetailPolicy();
 
   const crashLogAccess: PerformanceCrashBreadcrumbApi = {
     exportCrashLog: () => crashBreadcrumbs.exportCrashLog(),
@@ -3800,6 +3874,14 @@ function initializeImmersiveScene(
         height: renderer.getContext().drawingBufferHeight,
       },
     }),
+    getRendererRuntimeInfo: () => ({
+      calls: renderer.info.render.calls,
+      triangles: renderer.info.render.triangles,
+      points: renderer.info.render.points,
+      lines: renderer.info.render.lines,
+      geometries: renderer.info.memory.geometries,
+      textures: renderer.info.memory.textures,
+    }),
     getQualityState: () => ({
       level: graphicsQualityManager!.getLevel(),
       selectionSource: graphicsQualityManager!.getSelectionSource(),
@@ -3812,6 +3894,8 @@ function initializeImmersiveScene(
       lastAdaptiveRecoveryReason:
         adaptiveQualityController?.getLastRecoveryReason() ?? null,
       adaptivePolicy: adaptiveQualityController?.getSnapshot() ?? null,
+      sceneDetailLevel: activeSceneDetailPolicy.level,
+      sceneDetailMetrics: getSceneDetailMetrics(activeSceneDetailPolicy.level),
     }),
     getFeatureState: () => {
       const mirrorState = selfieMirror?.getRenderState();
@@ -4630,6 +4714,7 @@ function initializeImmersiveScene(
       const adaptiveAction = adaptiveQualityController?.update(delta);
       if (adaptiveAction) {
         applyFeaturePolicy();
+        applySceneDetailPolicy();
       }
       performanceFailover.update(delta);
       if (performanceFailover.hasTriggered()) {
@@ -4708,7 +4793,10 @@ function initializeImmersiveScene(
         performance.now() - phaseStart
       );
       phaseStart = performance.now();
-      if (livingRoomMediaWall) {
+      const shouldRunDecorativeUpdate =
+        activeSceneDetailPolicy.level !== 'performance' ||
+        Math.floor(elapsedTime * 4) !== Math.floor((elapsedTime - delta) * 4);
+      if (livingRoomMediaWall && shouldRunDecorativeUpdate) {
         const activation = futuroptimistPoi?.activation ?? 0;
         const focus = futuroptimistPoi?.focus ?? 0;
         livingRoomMediaWall.controller.update({
@@ -4717,7 +4805,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (flywheelShowpiece) {
+      if (flywheelShowpiece && shouldRunDecorativeUpdate) {
         const activation = flywheelPoi?.activation ?? 0;
         const focus = flywheelPoi?.focus ?? 0;
         flywheelShowpiece.update({
@@ -4753,7 +4841,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (jobbotTerminal) {
+      if (jobbotTerminal && shouldRunDecorativeUpdate) {
         const activation = jobbotPoi?.activation ?? 0;
         const focus = jobbotPoi?.focus ?? 0;
         jobbotTerminal.update({
@@ -4809,7 +4897,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (backyardEnvironment) {
+      if (backyardEnvironment && shouldRunDecorativeUpdate) {
         backyardEnvironment.update({ elapsed: elapsedTime, delta });
       }
       performanceDiagnostics?.recordPhase(

--- a/src/scene/avatar/mannequin.ts
+++ b/src/scene/avatar/mannequin.ts
@@ -12,6 +12,11 @@ import {
   TorusGeometry,
 } from 'three';
 
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+
 // Deterministic floor-to-crest height used by initial camera framing before assets load.
 export const PORTFOLIO_MANNEQUIN_VISUAL_HEIGHT = 2.6;
 
@@ -32,6 +37,7 @@ export interface PortfolioMannequinOptions {
    * Head and glove color used to suggest skin or fabric contrast.
    */
   trimColor?: string;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface PortfolioMannequinPalette {
@@ -85,6 +91,16 @@ export function createPortfolioMannequin(
   options: PortfolioMannequinOptions = {}
 ): PortfolioMannequinBuild {
   const collisionRadius = options.collisionRadius ?? 0.75;
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const cylinderSegments = detailPolicy.geometry.mannequinCylinderSegments;
+  const sphereWidthSegments =
+    detailPolicy.geometry.mannequinSphereWidthSegments;
+  const sphereHeightSegments =
+    detailPolicy.geometry.mannequinSphereHeightSegments;
+  const torusRadialSegments =
+    detailPolicy.geometry.mannequinTorusRadialSegments;
+  const torusTubularSegments =
+    detailPolicy.geometry.mannequinTorusTubularSegments;
   const initialPalette: PortfolioMannequinPalette = {
     base: options.baseColor ?? '#283347',
     accent: options.accentColor ?? '#57d7ff',
@@ -95,7 +111,11 @@ export function createPortfolioMannequin(
   group.name = 'PortfolioMannequin';
 
   const collisionProxy = new Mesh(
-    new SphereGeometry(collisionRadius, 32, 32),
+    new SphereGeometry(
+      collisionRadius,
+      sphereWidthSegments,
+      sphereHeightSegments
+    ),
     new MeshBasicMaterial({ color: 0xffffff })
   );
   collisionProxy.name = 'PortfolioMannequinCollisionProxy';
@@ -116,7 +136,7 @@ export function createPortfolioMannequin(
   );
   const platformHeight = 0.08;
   const platform = new Mesh(
-    new CylinderGeometry(0.58, 0.58, platformHeight, 48),
+    new CylinderGeometry(0.58, 0.58, platformHeight, cylinderSegments),
     platformMaterial
   );
   platform.name = 'PortfolioMannequinPlatform';
@@ -128,7 +148,7 @@ export function createPortfolioMannequin(
   const legMaterial = createStandardMaterial(new Color(initialPalette.base));
   const legHeight = 0.92;
   const legs = new Mesh(
-    new CylinderGeometry(0.26, 0.3, legHeight, 32),
+    new CylinderGeometry(0.26, 0.3, legHeight, cylinderSegments),
     legMaterial
   );
   legs.name = 'PortfolioMannequinLegs';
@@ -170,7 +190,7 @@ export function createPortfolioMannequin(
   rightFoot.add(rightFootMesh);
 
   const accentBand = new Mesh(
-    new TorusGeometry(0.34, 0.05, 20, 48),
+    new TorusGeometry(0.34, 0.05, torusRadialSegments, torusTubularSegments),
     platformMaterial.clone()
   );
   accentBand.name = 'PortfolioMannequinWaistBand';
@@ -184,7 +204,7 @@ export function createPortfolioMannequin(
 
   const torsoMaterial = createStandardMaterial(new Color(initialPalette.base));
   const torso = new Mesh(
-    new CylinderGeometry(0.46, 0.36, 0.86, 32),
+    new CylinderGeometry(0.46, 0.36, 0.86, cylinderSegments),
     torsoMaterial
   );
   torso.name = 'PortfolioMannequinTorso';
@@ -196,7 +216,7 @@ export function createPortfolioMannequin(
   const shoulderMaterial = createStandardMaterial(
     new Color(initialPalette.base)
   );
-  const armGeometry = new CylinderGeometry(0.16, 0.18, 0.82, 24);
+  const armGeometry = new CylinderGeometry(0.16, 0.18, 0.82, cylinderSegments);
 
   const leftArm = new Mesh(armGeometry, shoulderMaterial);
   leftArm.name = 'PortfolioMannequinArmLeft';
@@ -222,7 +242,7 @@ export function createPortfolioMannequin(
     }
   );
   const leftCuff = new Mesh(
-    new TorusGeometry(0.16, 0.035, 14, 32),
+    new TorusGeometry(0.16, 0.035, torusRadialSegments, torusTubularSegments),
     cuffMaterial
   );
   leftCuff.name = 'PortfolioMannequinCuffLeft';
@@ -236,7 +256,12 @@ export function createPortfolioMannequin(
   mannequinRoot.add(rightCuff);
 
   const trimMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const gloveGeometry = new CylinderGeometry(0.18, 0.18, 0.22, 18);
+  const gloveGeometry = new CylinderGeometry(
+    0.18,
+    0.18,
+    0.22,
+    cylinderSegments
+  );
   const leftGlove = new Mesh(gloveGeometry, trimMaterial);
   leftGlove.name = 'PortfolioMannequinGloveLeft';
   leftGlove.position.set(
@@ -265,7 +290,7 @@ export function createPortfolioMannequin(
     }
   );
   const collar = new Mesh(
-    new TorusGeometry(0.3, 0.045, 16, 36),
+    new TorusGeometry(0.3, 0.045, torusRadialSegments, torusTubularSegments),
     collarMaterial
   );
   collar.name = 'PortfolioMannequinCollar';
@@ -274,7 +299,10 @@ export function createPortfolioMannequin(
   mannequinRoot.add(collar);
 
   const headMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const head = new Mesh(new SphereGeometry(0.28, 32, 32), headMaterial);
+  const head = new Mesh(
+    new SphereGeometry(0.28, sphereWidthSegments, sphereHeightSegments),
+    headMaterial
+  );
   head.name = 'PortfolioMannequinHead';
   head.position.y = collar.position.y + 0.32;
   head.castShadow = true;
@@ -283,7 +311,11 @@ export function createPortfolioMannequin(
 
   // Add a simple smiley face marker to the front of the head for directionality.
   const faceMaterial = new MeshBasicMaterial({ color: 0x000000 });
-  const eyeGeometry = new SphereGeometry(0.03, 12, 12);
+  const eyeGeometry = new SphereGeometry(
+    0.03,
+    Math.max(6, sphereWidthSegments),
+    Math.max(4, sphereHeightSegments)
+  );
   const leftEye = new Mesh(eyeGeometry, faceMaterial);
   leftEye.name = 'PortfolioMannequinFaceLeftEye';
   leftEye.position.set(-0.08, head.position.y + 0.06, 0.25);
@@ -296,7 +328,13 @@ export function createPortfolioMannequin(
 
   // Mouth as a thin torus segment to suggest a smile on the front side.
   const mouth = new Mesh(
-    new TorusGeometry(0.09, 0.012, 8, 24, Math.PI),
+    new TorusGeometry(
+      0.09,
+      0.012,
+      torusRadialSegments,
+      torusTubularSegments,
+      Math.PI
+    ),
     faceMaterial
   );
   mouth.name = 'PortfolioMannequinFaceMouth';
@@ -315,7 +353,7 @@ export function createPortfolioMannequin(
   visorMaterial.opacity = 0.72;
   visorMaterial.side = DoubleSide;
   const visor = new Mesh(
-    new CylinderGeometry(0.27, 0.27, 0.16, 32, 1, true),
+    new CylinderGeometry(0.27, 0.27, 0.16, cylinderSegments, 1, true),
     visorMaterial
   );
   visor.name = 'PortfolioMannequinVisor';
@@ -330,7 +368,10 @@ export function createPortfolioMannequin(
       emissiveIntensity: 0.5,
     }
   );
-  const crest = new Mesh(new ConeGeometry(0.12, 0.24, 24), crestMaterial);
+  const crest = new Mesh(
+    new ConeGeometry(0.12, 0.24, cylinderSegments),
+    crestMaterial
+  );
   crest.name = 'PortfolioMannequinCrest';
   crest.position.y = head.position.y + 0.3;
   mannequinRoot.add(crest);

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -42,6 +42,10 @@ import {
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
 import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+import {
   applySeasonalLightingPreset,
   type SeasonalLightingPreset,
   type SeasonalLightingTarget,
@@ -299,12 +303,17 @@ function createDuskLightProbe(): LightProbe {
 
 export interface BackyardEnvironmentOptions {
   seasonalPreset?: SeasonalLightingPreset | null;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export function createBackyardEnvironment(
   bounds: Bounds2D,
-  { seasonalPreset = null }: BackyardEnvironmentOptions = {}
+  {
+    seasonalPreset = null,
+    detailPolicy = getSceneDetailPolicy('balanced'),
+  }: BackyardEnvironmentOptions = {}
 ): BackyardEnvironmentBuild {
+  const isPerformance = detailPolicy.level === 'performance';
   const group = new Group();
   group.name = 'BackyardEnvironment';
   const colliders: RectCollider[] = [];
@@ -324,7 +333,11 @@ export function createBackyardEnvironment(
   group.add(duskLightProbe);
 
   const skyRadius = Math.max(width, depth) * 1.32;
-  const skyGeometry = new SphereGeometry(skyRadius, 48, 48);
+  const skyGeometry = new SphereGeometry(
+    skyRadius,
+    detailPolicy.geometry.structureCylinderSegments,
+    detailPolicy.geometry.structureCylinderSegments
+  );
   skyGeometry.scale(1, 0.62, 1);
   const verticalExtent = skyRadius * 0.62;
 
@@ -498,10 +511,13 @@ export function createBackyardEnvironment(
   const rocket = createModelRocket({
     basePosition: rocketBase,
     orientationRadians: -Math.PI / 10,
+    detailPolicy,
   });
   group.add(rocket.group);
   colliders.push(rocket.collider);
-  updates.push(rocket.update);
+  if (!isPerformance) {
+    updates.push(rocket.update);
+  }
 
   const steppingStoneGeometry = new BoxGeometry(pathWidth * 0.32, 0.12, 0.9);
   const steppingStoneMaterial = new MeshStandardMaterial({
@@ -537,10 +553,13 @@ export function createBackyardEnvironment(
     depth: greenhouseDepth,
     environmentMap: duskReflectionMap,
     environmentIntensity: 0.62,
+    detailPolicy,
   });
   group.add(greenhouse.group);
   greenhouse.colliders.forEach((collider) => colliders.push(collider));
-  updates.push(greenhouse.update);
+  if (!isPerformance) {
+    updates.push(greenhouse.update);
+  }
 
   const walkwayWidth = greenhouseWidth * 0.68;
   const walkwayDepth = greenhouseDepth * 0.72;
@@ -650,7 +669,7 @@ export function createBackyardEnvironment(
     1
   );
   walkwayMistGeometry.rotateX(-Math.PI / 2);
-  const walkwayMistLayerCount = 3;
+  const walkwayMistLayerCount = isPerformance ? 0 : 3;
   for (let i = 0; i < walkwayMistLayerCount; i += 1) {
     const ratio = (i + 1) / (walkwayMistLayerCount + 1);
     const baseOpacity = MathUtils.lerp(0.24, 0.38, ratio);

--- a/src/scene/graphics/sceneDetailPolicy.ts
+++ b/src/scene/graphics/sceneDetailPolicy.ts
@@ -1,0 +1,205 @@
+import type { GraphicsQualityLevel } from './qualityManager';
+
+export type SceneDetailLevel = GraphicsQualityLevel;
+
+export interface SceneDetailPolicy {
+  level: SceneDetailLevel;
+  geometry: {
+    poiCylinderSegments: number;
+    poiRingSegments: number;
+    poiOrbWidthSegments: number;
+    poiOrbHeightSegments: number;
+    poiHitSegments: number;
+    mannequinCylinderSegments: number;
+    mannequinSphereWidthSegments: number;
+    mannequinSphereHeightSegments: number;
+    mannequinTorusRadialSegments: number;
+    mannequinTorusTubularSegments: number;
+    structureCylinderSegments: number;
+    structureRingSegments: number;
+    terrainSegments: number;
+  };
+  textures: {
+    canvasScale: number;
+    jobbotScreenWidth: number;
+    jobbotScreenHeight: number;
+    jobbotTelemetryWidth: number;
+    jobbotTelemetryHeight: number;
+    mediaWallWidth: number;
+    mediaWallHeight: number;
+    redrawThrottleMs: number;
+  };
+  effects: {
+    shaderMist: boolean;
+    shaderPond: boolean;
+    transparentGlow: boolean;
+    hologramAura: boolean;
+    decorativeParticles: boolean;
+    dynamicPointLights: boolean;
+    physicalGlass: boolean;
+  };
+  updates: {
+    decorativeThrottleMs: number;
+    canvasRedrawThrottleMs: number;
+    skipUnemphasizedDecorations: boolean;
+  };
+  budgets: {
+    theoreticalWorkScale: number;
+    maxTransparentLayers: number;
+    maxDynamicPointLights: number;
+  };
+}
+
+const CINEMATIC_AND_BALANCED_SHARED = {
+  geometry: {
+    poiCylinderSegments: 48,
+    poiRingSegments: 64,
+    poiOrbWidthSegments: 32,
+    poiOrbHeightSegments: 32,
+    poiHitSegments: 32,
+    mannequinCylinderSegments: 48,
+    mannequinSphereWidthSegments: 32,
+    mannequinSphereHeightSegments: 32,
+    mannequinTorusRadialSegments: 20,
+    mannequinTorusTubularSegments: 48,
+    structureCylinderSegments: 48,
+    structureRingSegments: 64,
+    terrainSegments: 32,
+  },
+  textures: {
+    canvasScale: 1,
+    jobbotScreenWidth: 2048,
+    jobbotScreenHeight: 1024,
+    jobbotTelemetryWidth: 1024,
+    jobbotTelemetryHeight: 512,
+    mediaWallWidth: 2048,
+    mediaWallHeight: 1024,
+    redrawThrottleMs: 0,
+  },
+  effects: {
+    shaderMist: true,
+    shaderPond: true,
+    transparentGlow: true,
+    hologramAura: true,
+    decorativeParticles: true,
+    dynamicPointLights: true,
+    physicalGlass: true,
+  },
+  updates: {
+    decorativeThrottleMs: 0,
+    canvasRedrawThrottleMs: 0,
+    skipUnemphasizedDecorations: false,
+  },
+  budgets: {
+    theoreticalWorkScale: 1,
+    maxTransparentLayers: Number.POSITIVE_INFINITY,
+    maxDynamicPointLights: Number.POSITIVE_INFINITY,
+  },
+} as const;
+
+const PERFORMANCE_POLICY: SceneDetailPolicy = {
+  level: 'performance',
+  geometry: {
+    poiCylinderSegments: 8,
+    poiRingSegments: 8,
+    poiOrbWidthSegments: 8,
+    poiOrbHeightSegments: 6,
+    poiHitSegments: 8,
+    mannequinCylinderSegments: 10,
+    mannequinSphereWidthSegments: 10,
+    mannequinSphereHeightSegments: 8,
+    mannequinTorusRadialSegments: 6,
+    mannequinTorusTubularSegments: 12,
+    structureCylinderSegments: 10,
+    structureRingSegments: 12,
+    terrainSegments: 4,
+  },
+  textures: {
+    canvasScale: 0.25,
+    jobbotScreenWidth: 512,
+    jobbotScreenHeight: 256,
+    jobbotTelemetryWidth: 256,
+    jobbotTelemetryHeight: 128,
+    mediaWallWidth: 512,
+    mediaWallHeight: 256,
+    redrawThrottleMs: 750,
+  },
+  effects: {
+    shaderMist: false,
+    shaderPond: false,
+    transparentGlow: false,
+    hologramAura: false,
+    decorativeParticles: false,
+    dynamicPointLights: false,
+    physicalGlass: false,
+  },
+  updates: {
+    decorativeThrottleMs: 250,
+    canvasRedrawThrottleMs: 750,
+    skipUnemphasizedDecorations: true,
+  },
+  budgets: {
+    theoreticalWorkScale: 0.1,
+    maxTransparentLayers: 1,
+    maxDynamicPointLights: 0,
+  },
+};
+
+const BALANCED_POLICY: SceneDetailPolicy = {
+  level: 'balanced',
+  ...CINEMATIC_AND_BALANCED_SHARED,
+};
+
+const CINEMATIC_POLICY: SceneDetailPolicy = {
+  level: 'cinematic',
+  ...CINEMATIC_AND_BALANCED_SHARED,
+};
+
+export function getSceneDetailPolicy(
+  level: GraphicsQualityLevel
+): SceneDetailPolicy {
+  if (level === 'performance') {
+    return PERFORMANCE_POLICY;
+  }
+  return level === 'cinematic' ? CINEMATIC_POLICY : BALANCED_POLICY;
+}
+
+export interface SceneDetailMetrics {
+  theoreticalWorkScale: number;
+  texturePixelBudget: number;
+  poiTriangleBudget: number;
+  dynamicPointLightBudget: number;
+  transparentLayerBudget: number;
+  shaderEffectsEnabled: number;
+}
+
+export function getSceneDetailMetrics(
+  level: GraphicsQualityLevel
+): SceneDetailMetrics {
+  const policy = getSceneDetailPolicy(level);
+  const shaderEffectsEnabled = [
+    policy.effects.shaderMist,
+    policy.effects.shaderPond,
+    policy.effects.transparentGlow,
+    policy.effects.hologramAura,
+    policy.effects.decorativeParticles,
+    policy.effects.physicalGlass,
+  ].filter(Boolean).length;
+  return {
+    theoreticalWorkScale: policy.budgets.theoreticalWorkScale,
+    texturePixelBudget:
+      policy.textures.jobbotScreenWidth * policy.textures.jobbotScreenHeight +
+      policy.textures.jobbotTelemetryWidth *
+        policy.textures.jobbotTelemetryHeight +
+      policy.textures.mediaWallWidth * policy.textures.mediaWallHeight,
+    poiTriangleBudget:
+      policy.geometry.poiCylinderSegments * 4 +
+      policy.geometry.poiRingSegments * 4 +
+      policy.geometry.poiOrbWidthSegments *
+        policy.geometry.poiOrbHeightSegments *
+        2,
+    dynamicPointLightBudget: policy.budgets.maxDynamicPointLights,
+    transparentLayerBudget: policy.budgets.maxTransparentLayers,
+    shaderEffectsEnabled,
+  };
+}

--- a/src/scene/performance/adaptiveQuality.ts
+++ b/src/scene/performance/adaptiveQuality.ts
@@ -28,6 +28,7 @@ export interface AdaptiveQualityControllerOptions {
   getSelectionSource?: () => AdaptiveQualitySelectionSource;
   onAction?: (event: AdaptiveQualityEvent) => void;
   onDowngrade?: (event: AdaptiveQualityEvent) => void;
+  lockRecoveryAfterPerformanceDowngrade?: boolean;
 }
 
 export interface AdaptiveQualityEvent {
@@ -114,6 +115,7 @@ export function createAdaptiveQualityController({
   getSelectionSource = () => 'adaptive',
   onAction,
   onDowngrade,
+  lockRecoveryAfterPerformanceDowngrade = false,
 }: AdaptiveQualityControllerOptions): AdaptiveQualityController {
   let elapsedMs = 0;
   let lowFpsDurationMs = 0;
@@ -127,6 +129,7 @@ export function createAdaptiveQualityController({
   let lastRecoveryReason: string | null = null;
   let lastAdaptiveReason: string | null = null;
   let pixelRatioStepApplied = false;
+  let lockedInPerformanceByDowngrade = false;
   const frameMsSamples: number[] = [];
 
   const getWarmupRemainingMs = () => Math.max(0, warmupMs - elapsedMs);
@@ -134,7 +137,9 @@ export function createAdaptiveQualityController({
   const autoRecoveryEnabled = () =>
     !isSoftwareRenderer && getSelectionSource() !== 'user';
   const canAccrueRecovery = () =>
-    qualityManager.getLevel() === 'performance' && autoRecoveryEnabled();
+    qualityManager.getLevel() === 'performance' &&
+    autoRecoveryEnabled() &&
+    (!lockedInPerformanceByDowngrade || !lockRecoveryAfterPerformanceDowngrade);
   const resetRecoveryState = () => {
     stableDurationMs = 0;
   };
@@ -192,6 +197,7 @@ export function createAdaptiveQualityController({
     }
     if (currentLevel === 'balanced') {
       qualityManager.setLevel('performance', { source: 'adaptive' });
+      lockedInPerformanceByDowngrade = true;
       return emit(
         'downgrade',
         'quality-performance',

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -2,6 +2,10 @@ import type {
   GraphicsQualityLevel,
   GraphicsQualitySelectionSource,
 } from '../graphics/qualityManager';
+import type {
+  SceneDetailLevel,
+  SceneDetailMetrics,
+} from '../graphics/sceneDetailPolicy';
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { SoftwareRendererPolicyState } from './qualityPolicy';
@@ -15,6 +19,15 @@ export type PhaseName =
   | 'lightingLedLightmap'
   | 'mirror'
   | 'mainRender';
+
+export interface RendererRuntimeInfoSnapshot {
+  calls: number;
+  triangles: number;
+  points: number;
+  lines: number;
+  geometries: number;
+  textures: number;
+}
 
 export interface RendererSizeSnapshot {
   pixelRatio: number;
@@ -31,6 +44,8 @@ export interface QualityStateSnapshot {
   lastAdaptiveDowngradeReason: string | null;
   lastAdaptiveRecoveryReason: string | null;
   adaptivePolicy: AdaptiveQualityPolicySnapshot | null;
+  sceneDetailLevel?: SceneDetailLevel;
+  sceneDetailMetrics?: SceneDetailMetrics;
 }
 
 export interface FeatureStateSnapshot {
@@ -57,6 +72,7 @@ export interface FrameStatsSnapshot {
 
 export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   renderer: RendererInfoSnapshot;
+  rendererRuntime: RendererRuntimeInfoSnapshot;
   softwareRendererPolicy: SoftwareRendererPolicyState;
   rendererSize: RendererSizeSnapshot;
   quality: QualityStateSnapshot;
@@ -88,6 +104,7 @@ export interface PerformanceDiagnosticsApi {
 interface PerformanceDiagnosticsOptions {
   rendererInfo: RendererInfoSnapshot;
   getRendererSize: () => RendererSizeSnapshot;
+  getRendererRuntimeInfo?: () => RendererRuntimeInfoSnapshot;
   getQualityState: () => QualityStateSnapshot;
   getFeatureState: () => FeatureStateSnapshot;
   getLastFailoverReason: () => string | null;
@@ -144,6 +161,14 @@ function summarize(values: readonly number[]): {
 export function createPerformanceDiagnostics({
   rendererInfo,
   getRendererSize,
+  getRendererRuntimeInfo = () => ({
+    calls: 0,
+    triangles: 0,
+    points: 0,
+    lines: 0,
+    geometries: 0,
+    textures: 0,
+  }),
   getQualityState,
   getFeatureState,
   getLastFailoverReason,
@@ -177,6 +202,7 @@ export function createPerformanceDiagnostics({
       return {
         ...diagnosticsMethods.getFrameStats(),
         renderer: diagnosticsMethods.getRendererInfo(),
+        rendererRuntime: getRendererRuntimeInfo(),
         softwareRendererPolicy: getSoftwareRendererPolicy(),
         rendererSize: getRendererSize(),
         quality: diagnosticsMethods.getQualityState(),

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -4,6 +4,7 @@ import {
   SOFTWARE_RENDERER_MODE_PARAM,
 } from '../../ui/immersiveUrl';
 import type { GraphicsQualityLevel } from '../graphics/qualityManager';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 import type { RendererInfoSnapshot } from './rendererCapabilities';
 
@@ -119,8 +120,17 @@ export function resolveSoftwareSafeRenderCadence({
   };
 }
 
+export interface InitialDeviceQualityHints {
+  coarsePointer?: boolean;
+  mobileLike?: boolean;
+  deviceMemoryGb?: number;
+  hardwareConcurrency?: number;
+  hasExplicitPreference?: boolean;
+}
+
 export interface QualityPolicyState {
   initialLevel: GraphicsQualityLevel;
+  sceneDetailLevel: GraphicsQualityLevel;
   basePixelRatioCap: number;
   mirrorEnabled: boolean;
   mirrorTargetSize: number;
@@ -168,7 +178,8 @@ export function resolveInitialQualityPolicy(
   devicePixelRatio: number,
   softwareRendererPolicy: SoftwareRendererPolicyState = resolveSoftwareRendererPolicy(
     rendererInfo
-  )
+  ),
+  deviceHints: InitialDeviceQualityHints = {}
 ): QualityPolicyState {
   if (
     rendererInfo.isDangerousSoftwareRenderer &&
@@ -176,6 +187,7 @@ export function resolveInitialQualityPolicy(
   ) {
     return {
       initialLevel: 'performance',
+      sceneDetailLevel: getSceneDetailPolicy('performance').level,
       basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.45, 0.35),
       mirrorEnabled: false,
       mirrorTargetSize: 128,
@@ -191,6 +203,7 @@ export function resolveInitialQualityPolicy(
   if (rendererInfo.isSoftwareRenderer) {
     return {
       initialLevel: 'performance',
+      sceneDetailLevel: getSceneDetailPolicy('performance').level,
       basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.75, 0.5),
       mirrorEnabled: false,
       mirrorTargetSize: 192,
@@ -202,8 +215,32 @@ export function resolveInitialQualityPolicy(
     };
   }
 
+  const isConstrainedMobile =
+    !deviceHints.hasExplicitPreference &&
+    (deviceHints.coarsePointer || deviceHints.mobileLike) &&
+    ((deviceHints.deviceMemoryGb ?? Number.POSITIVE_INFINITY) <= 4 ||
+      (deviceHints.hardwareConcurrency ?? Number.POSITIVE_INFINITY) <= 4 ||
+      devicePixelRatio >= 1.5);
+
+  if (isConstrainedMobile) {
+    return {
+      initialLevel: 'performance',
+      sceneDetailLevel: getSceneDetailPolicy('performance').level,
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.85, 0.5),
+      mirrorEnabled: false,
+      mirrorTargetSize: 192,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 100,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
+      reason:
+        'coarse-pointer mobile/tablet hardware starts in performance mode',
+    };
+  }
+
   return {
     initialLevel: 'balanced',
+    sceneDetailLevel: getSceneDetailPolicy('balanced').level,
     basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 1.25, 0.75),
     mirrorEnabled: true,
     mirrorTargetSize: 320,

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -18,6 +18,11 @@ import {
 } from 'three';
 
 import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+
+import {
   scalePoiValue,
   POI_ORB_VERTICAL_OFFSET,
   POI_ORB_HEIGHT_MULTIPLIER,
@@ -82,16 +87,26 @@ export interface PoiInstance {
   visitedBadge?: PoiVisitedBadge;
 }
 
+export interface PoiInstanceDetailOptions {
+  detailPolicy?: SceneDetailPolicy;
+}
+
 export function createPoiInstances(
   definitions: PoiDefinition[],
-  overrides: PoiInstanceOverrides = {}
+  overrides: PoiInstanceOverrides = {},
+  options: PoiInstanceDetailOptions = {}
 ): PoiInstance[] {
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
   return definitions.map((definition, index) => {
     const override = overrides[definition.id];
     if (override?.mode === 'display') {
       return createDisplayPoiInstance(definition, override);
     }
-    return createPedestalPoiInstance(definition, index * Math.PI * 0.37);
+    return createPedestalPoiInstance(
+      definition,
+      index * Math.PI * 0.37,
+      detailPolicy
+    );
   });
 }
 
@@ -110,8 +125,10 @@ export function updatePoiInstanceDefinition(
 
 function createPedestalPoiInstance(
   definition: PoiDefinition,
-  phaseOffset: number
+  phaseOffset: number,
+  detailPolicy: SceneDetailPolicy
 ): PoiInstance {
+  const isPerformance = detailPolicy.level === 'performance';
   const group = new Group();
   group.name = `POI:${definition.id}`;
   group.position.set(
@@ -158,7 +175,7 @@ function createPedestalPoiInstance(
       pedestalRadius,
       pedestalRadius,
       pedestalHeight,
-      48,
+      detailPolicy.geometry.poiCylinderSegments,
       1,
       true
     );
@@ -194,7 +211,7 @@ function createPedestalPoiInstance(
       pedestalRadius * 1.02,
       pedestalRadius * 1.02,
       accentHeight,
-      48,
+      detailPolicy.geometry.poiCylinderSegments,
       1,
       true
     );
@@ -220,7 +237,7 @@ function createPedestalPoiInstance(
     const ringGeometry = new RingGeometry(
       pedestalRadius * 0.55,
       pedestalRadius * 1.08,
-      64,
+      detailPolicy.geometry.poiRingSegments,
       1
     );
     const ring = new Mesh(ringGeometry, ringMaterial);
@@ -228,12 +245,17 @@ function createPedestalPoiInstance(
     ring.rotation.x = -Math.PI / 2;
     ring.position.y = pedestalHeight + scalePoiValue(0.02);
     ring.renderOrder = 12;
+    ring.visible = !isPerformance;
     group.add(ring);
   }
 
   const orbRadius =
     Math.max(baseRadius, pedestalRadius) * 0.45 * POI_ORB_DIAMETER_MULTIPLIER;
-  const orbGeometry = new SphereGeometry(orbRadius, 32, 32);
+  const orbGeometry = new SphereGeometry(
+    orbRadius,
+    detailPolicy.geometry.poiOrbWidthSegments,
+    detailPolicy.geometry.poiOrbHeightSegments
+  );
   const orbColor = new Color(hologramConfig?.orbColor ?? 0xb8f3ff);
   const orbEmissiveBase = new Color(
     hologramConfig?.orbEmissiveColor ?? 0x3de1ff
@@ -287,7 +309,7 @@ function createPedestalPoiInstance(
   const haloGeometry = new RingGeometry(
     haloInnerRadius,
     haloOuterRadius,
-    48,
+    detailPolicy.geometry.poiRingSegments,
     1
   );
   const haloBaseColor = new Color(0x4bd8ff);
@@ -304,12 +326,13 @@ function createPedestalPoiInstance(
   halo.rotation.x = -Math.PI / 2;
   halo.position.y = scalePoiValue(0.08);
   halo.renderOrder = 11;
+  halo.visible = !isPerformance;
   group.add(halo);
 
   const visitedRingGeometry = new RingGeometry(
     haloInnerRadius * 0.92,
     haloOuterRadius * 1.05,
-    60,
+    detailPolicy.geometry.poiRingSegments,
     1
   );
   const visitedRingMaterial = new MeshBasicMaterial({
@@ -326,6 +349,7 @@ function createPedestalPoiInstance(
   visitedRing.renderOrder = 10;
   visitedRing.visible = false;
   visitedRing.scale.setScalar(1);
+  visitedRing.visible = false;
   group.add(visitedRing);
 
   const hitAreaHeight = baseHeight + pedestalHeight + scalePoiValue(0.24);
@@ -334,7 +358,7 @@ function createPedestalPoiInstance(
     hitAreaRadius,
     hitAreaRadius,
     hitAreaHeight,
-    32
+    detailPolicy.geometry.poiHitSegments
   );
   const hitAreaMaterial = new MeshBasicMaterial({
     transparent: true,

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -18,6 +18,10 @@ import {
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
 
@@ -32,6 +36,7 @@ export interface FlywheelShowpieceOptions {
   centerZ: number;
   roomBounds: Bounds2D;
   orientationRadians?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface AutomationPillar {
@@ -44,6 +49,8 @@ interface AutomationPillar {
 export function createFlywheelShowpiece(
   options: FlywheelShowpieceOptions
 ): FlywheelShowpieceBuild {
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
   const group = new Group();
   group.name = 'FlywheelShowpiece';
 
@@ -110,7 +117,7 @@ export function createFlywheelShowpiece(
     daisRadius,
     daisRadius,
     daisHeight,
-    32
+    detailPolicy.geometry.structureCylinderSegments
   );
   const daisMaterial = new MeshStandardMaterial({
     color: new Color(0x14202c),
@@ -128,7 +135,7 @@ export function createFlywheelShowpiece(
     pedestalRadius,
     pedestalRadius,
     pedestalHeight,
-    48
+    detailPolicy.geometry.structureCylinderSegments
   );
   const pedestalMaterial = new MeshStandardMaterial({
     color: new Color(0x182634),
@@ -143,6 +150,18 @@ export function createFlywheelShowpiece(
     options.centerZ
   );
   group.add(pedestal);
+
+  if (isPerformance) {
+    colliders.push({
+      minX: options.centerX - daisRadius,
+      maxX: options.centerX + daisRadius,
+      minZ: options.centerZ - daisRadius,
+      maxZ: options.centerZ + daisRadius,
+    });
+    // Performance mode intentionally keeps only the interaction silhouette.
+    // This targets theoretical workload reduction, not guaranteed 10x FPS on every GPU.
+    return { group, colliders, update() {} };
+  }
 
   const accentHeight = 0.12;
   const accentGeometry = new CylinderGeometry(

--- a/src/scene/structures/greenhouse.ts
+++ b/src/scene/structures/greenhouse.ts
@@ -20,6 +20,10 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 export interface GreenhouseConfig {
   basePosition: Vector3;
@@ -28,6 +32,7 @@ export interface GreenhouseConfig {
   depth?: number;
   environmentMap?: Texture | null;
   environmentIntensity?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface GreenhouseBuild {
@@ -52,6 +57,9 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   const basePosition = config.basePosition.clone();
   const environmentMap = config.environmentMap ?? null;
   const environmentIntensity = config.environmentIntensity ?? 0.5;
+  const detailPolicy = config.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const structureSegments = detailPolicy.geometry.structureCylinderSegments;
 
   const applyEnvironmentMap = (
     material: MeshStandardMaterial | MeshPhysicalMaterial
@@ -193,15 +201,23 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   roofBeamRight.rotation.z = -roofBeamLeft.rotation.z;
   frameGroup.add(roofBeamRight);
 
-  const glassMaterial = new MeshPhysicalMaterial({
-    color: new Color(0x9cd6ff),
-    transparent: true,
-    opacity: 0.28,
-    roughness: 0.1,
-    metalness: 0.0,
-    transmission: 0.86,
-    thickness: 0.18,
-  });
+  const glassMaterial = isPerformance
+    ? new MeshStandardMaterial({
+        color: new Color(0x8bcfff),
+        roughness: 0.5,
+        metalness: 0.05,
+        transparent: true,
+        opacity: 0.34,
+      })
+    : new MeshPhysicalMaterial({
+        color: new Color(0x9cd6ff),
+        transparent: true,
+        opacity: 0.28,
+        roughness: 0.1,
+        metalness: 0.0,
+        transmission: 0.86,
+        thickness: 0.18,
+      });
   applyEnvironmentMap(glassMaterial);
 
   const wallGeometry = new PlaneGeometry(
@@ -282,7 +298,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     pondPlinthRadius,
     pondPlinthRadius,
     pondPlinthHeight,
-    40
+    structureSegments
   );
   const pondPlinthMaterial = new MeshStandardMaterial({
     color: new Color(0x2b343c),
@@ -303,7 +319,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     depth * 0.17,
     depth * 0.17,
     0.12,
-    32
+    structureSegments
   );
   const pondMaterial = new MeshStandardMaterial({
     color: new Color(0x1a4a5e),
@@ -407,6 +423,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   );
   pondRipple.rotation.x = -Math.PI / 2;
   pondRipple.renderOrder = 6;
+  pondRipple.visible = !isPerformance;
   group.add(pondRipple);
 
   const solarPanelPivot = new Group();
@@ -446,7 +463,12 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   });
 
   const growLightMaterials: MeshStandardMaterial[] = [];
-  const growLightGeometry = new CylinderGeometry(0.05, 0.05, width * 0.32, 12);
+  const growLightGeometry = new CylinderGeometry(
+    0.05,
+    0.05,
+    width * 0.32,
+    structureSegments
+  );
   const growLightSpacing = depth * 0.38;
   [-growLightSpacing, 0, growLightSpacing].forEach((offsetZ, index) => {
     const lightMaterial = new MeshStandardMaterial({

--- a/src/scene/structures/jobbotTerminal.ts
+++ b/src/scene/structures/jobbotTerminal.ts
@@ -15,6 +15,10 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 export interface JobbotTerminalBuild {
   group: Group;
@@ -35,6 +39,7 @@ export interface JobbotTerminalOptions {
     width?: number;
     depth?: number;
   };
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface DataShardState {
@@ -46,10 +51,21 @@ interface DataShardState {
   orbitSpeed: number;
 }
 
-function createTerminalScreenTexture(): CanvasTexture {
+function canvasFont(
+  canvas: HTMLCanvasElement,
+  baselineWidth: number,
+  size: number,
+  weight = ''
+) {
+  return `${weight}${Math.max(10, size * (canvas.width / baselineWidth))}px "Inter", "Segoe UI", sans-serif`;
+}
+
+function createTerminalScreenTexture(
+  detailPolicy: SceneDetailPolicy
+): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 2048;
-  canvas.height = 1024;
+  canvas.width = detailPolicy.textures.jobbotScreenWidth;
+  canvas.height = detailPolicy.textures.jobbotScreenHeight;
   const context = canvas.getContext('2d');
 
   if (context) {
@@ -69,12 +85,12 @@ function createTerminalScreenTexture(): CanvasTexture {
     context.fillRect(0, 0, canvas.width, canvas.height);
 
     context.fillStyle = '#7cf1ff';
-    context.font = 'bold 220px "Inter", "Segoe UI", sans-serif';
+    context.font = canvasFont(canvas, 2048, 220, 'bold ');
     context.textAlign = 'left';
     context.textBaseline = 'alphabetic';
     context.fillText('jobbot3000', canvas.width * 0.08, canvas.height * 0.46);
 
-    context.font = '64px "Inter", "Segoe UI", sans-serif';
+    context.font = canvasFont(canvas, 2048, 64, '');
     context.fillStyle = '#9ce9ff';
     context.fillText(
       'Automation orchestrator · live diagnostics stream',
@@ -82,7 +98,7 @@ function createTerminalScreenTexture(): CanvasTexture {
       canvas.height * 0.68
     );
 
-    context.font = '52px "Inter", "Segoe UI", sans-serif';
+    context.font = canvasFont(canvas, 2048, 52, '');
     context.fillStyle = '#fede72';
     context.fillText(
       'Status: nominal · queue depth 0 · SLA 99.98%',
@@ -91,11 +107,11 @@ function createTerminalScreenTexture(): CanvasTexture {
     );
 
     const rightColumnX = canvas.width * 0.7;
-    context.font = '600 56px "Inter", "Segoe UI", sans-serif';
+    context.font = canvasFont(canvas, 2048, 56, '600 ');
     context.fillStyle = '#ffffff';
     context.fillText('Ops timeline', rightColumnX, canvas.height * 0.32);
 
-    context.font = '42px "Inter", "Segoe UI", sans-serif';
+    context.font = canvasFont(canvas, 2048, 42, '');
     context.fillStyle = '#b6d8ff';
     const logLines = [
       '• 05:32 · cron sync complete',
@@ -116,11 +132,12 @@ function createTerminalScreenTexture(): CanvasTexture {
 function createTelemetryPanelTexture(
   heading: string,
   primary: string,
-  metrics: string[]
+  metrics: string[],
+  detailPolicy: SceneDetailPolicy
 ): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 1024;
-  canvas.height = 512;
+  canvas.width = detailPolicy.textures.jobbotTelemetryWidth;
+  canvas.height = detailPolicy.textures.jobbotTelemetryHeight;
   const context = canvas.getContext('2d');
 
   if (!context) {
@@ -139,14 +156,14 @@ function createTelemetryPanelTexture(
   context.textBaseline = 'alphabetic';
 
   context.fillStyle = '#7cf1ff';
-  context.font = 'bold 156px "Inter", "Segoe UI", sans-serif';
+  context.font = canvasFont(canvas, 1024, 156, 'bold ');
   context.fillText(heading, 88, 220);
 
-  context.font = '600 94px "Inter", "Segoe UI", sans-serif';
+  context.font = canvasFont(canvas, 1024, 94, '600 ');
   context.fillStyle = '#d9fbff';
   context.fillText(primary, 88, 320);
 
-  context.font = '52px "Inter", "Segoe UI", sans-serif';
+  context.font = canvasFont(canvas, 2048, 52, '');
   metrics.forEach((metric, index) => {
     const y = 380 + index * 64;
     context.fillStyle = 'rgba(124, 241, 255, 0.65)';
@@ -205,6 +222,8 @@ export function createJobbotTerminal(
   options: JobbotTerminalOptions
 ): JobbotTerminalBuild {
   const { position, orientationRadians = 0, desk } = options;
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
   const baseY = position.y ?? 0;
   const deskWidth = desk?.width ?? 3.6;
   const deskDepth = desk?.depth ?? 1.6;
@@ -283,7 +302,7 @@ export function createJobbotTerminal(
   );
   group.add(accent);
 
-  const screenTexture = createTerminalScreenTexture();
+  const screenTexture = createTerminalScreenTexture(detailPolicy);
   const screenMaterial = new MeshBasicMaterial({
     map: screenTexture,
     transparent: true,
@@ -436,6 +455,7 @@ export function createJobbotTerminal(
   telemetryGroup.name = 'JobbotTerminalTelemetryGroup';
   const telemetryBaseHeight = deskHeight + deskThickness + 0.58;
   telemetryGroup.position.set(0, telemetryBaseHeight, 0);
+  telemetryGroup.visible = !isPerformance;
   group.add(telemetryGroup);
 
   const telemetryDescriptors = [
@@ -461,7 +481,8 @@ export function createJobbotTerminal(
     const texture = createTelemetryPanelTexture(
       descriptor.heading,
       descriptor.primary,
-      descriptor.metrics
+      descriptor.metrics,
+      detailPolicy
     );
     const material = new MeshBasicMaterial({
       map: texture,
@@ -499,7 +520,7 @@ export function createJobbotTerminal(
       telemetryRadius * 1.06,
       telemetryRadius * 1.06,
       0.04,
-      48
+      detailPolicy.geometry.structureCylinderSegments
     ),
     telemetryAuraMaterial
   );
@@ -507,9 +528,14 @@ export function createJobbotTerminal(
   telemetryAura.rotation.x = Math.PI / 2;
   telemetryAura.position.set(0, telemetryBaseHeight - 0.16, 0);
   telemetryAura.renderOrder = 2;
+  telemetryAura.visible = !isPerformance;
   group.add(telemetryAura);
 
-  const statusBeaconGeometry = new SphereGeometry(0.08, 24, 24);
+  const statusBeaconGeometry = new SphereGeometry(
+    0.08,
+    detailPolicy.geometry.structureCylinderSegments,
+    Math.max(6, detailPolicy.geometry.structureCylinderSegments / 2)
+  );
   const statusBeaconMaterial = new MeshStandardMaterial({
     color: new Color(0x1a2f40),
     emissive: new Color(0x3cb6ff),
@@ -558,6 +584,10 @@ export function createJobbotTerminal(
         1
       );
       const combinedEmphasis = Math.max(emphasis, analyticsGlowValue);
+      if (isPerformance && combinedEmphasis < 0.05) {
+        screenGlowMaterial.emissiveIntensity = 0.24;
+        return;
+      }
       const analyticsBlend =
         pulseScale <= 0
           ? 0

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -18,9 +18,11 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
-const SCREEN_WIDTH = 2048;
-const SCREEN_HEIGHT = 1024;
 const BASE_GLOW_OPACITY = 0.18;
 const EMPHASISED_GLOW_OPACITY = 0.62;
 const CLEARANCE_BASE_OPACITY = 0.16;
@@ -30,6 +32,7 @@ const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
 
 interface MediaWallScreenRendererOptions {
   starCount: number;
+  detailPolicy: SceneDetailPolicy;
 }
 
 class MediaWallScreenRenderer {
@@ -38,11 +41,18 @@ class MediaWallScreenRenderer {
   private readonly texture: CanvasTexture;
   private highlight = 0;
   private starCount: number;
+  private readonly width: number;
+  private readonly height: number;
+  private readonly redrawThrottleMs: number;
+  private lastRenderMs = -Number.POSITIVE_INFINITY;
 
   constructor(options: MediaWallScreenRendererOptions) {
     const canvas = document.createElement('canvas');
-    canvas.width = SCREEN_WIDTH;
-    canvas.height = SCREEN_HEIGHT;
+    this.width = options.detailPolicy.textures.mediaWallWidth;
+    this.height = options.detailPolicy.textures.mediaWallHeight;
+    this.redrawThrottleMs = options.detailPolicy.textures.redrawThrottleMs;
+    canvas.width = this.width;
+    canvas.height = this.height;
     const context = canvas.getContext('2d');
 
     if (!context) {
@@ -55,7 +65,7 @@ class MediaWallScreenRenderer {
     this.texture.colorSpace = SRGBColorSpace;
     this.starCount = options.starCount;
 
-    this.render();
+    this.render(true);
   }
 
   getTexture(): CanvasTexture {
@@ -68,7 +78,7 @@ class MediaWallScreenRenderer {
     } else {
       this.starCount = count;
     }
-    this.render();
+    this.render(true);
   }
 
   updateHighlight(target: number) {
@@ -77,74 +87,87 @@ class MediaWallScreenRenderer {
       return;
     }
     this.highlight = clamped;
-    this.render();
+    this.render(false);
   }
 
   dispose() {
     this.texture.dispose();
   }
 
-  private render() {
+  private render(force = false) {
+    const now = typeof performance === 'undefined' ? 0 : performance.now();
+    if (!force && now - this.lastRenderMs < this.redrawThrottleMs) {
+      return;
+    }
+    this.lastRenderMs = now;
     this.context.save();
-    this.context.clearRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    this.context.clearRect(0, 0, this.width, this.height);
     this.drawBase();
     this.drawStarHighlight();
     this.context.restore();
     this.texture.needsUpdate = true;
   }
 
+  private get textScale() {
+    return this.width / 2048;
+  }
+
+  private font(size: number, weight = '') {
+    return `${weight}${Math.max(10, size * this.textScale)}px "Inter", "Segoe UI", sans-serif`;
+  }
+
   private drawBase() {
     const ctx = this.context;
     ctx.save();
     ctx.fillStyle = '#0f1724';
-    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    ctx.fillRect(0, 0, this.width, this.height);
 
     const baseGradient = ctx.createLinearGradient(
       0,
       0,
-      SCREEN_WIDTH,
-      SCREEN_HEIGHT
+      this.width,
+      this.height
     );
     baseGradient.addColorStop(0, '#182a47');
     baseGradient.addColorStop(0.55, '#0f233c');
     baseGradient.addColorStop(1, '#192339');
     ctx.fillStyle = baseGradient;
-    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    ctx.fillRect(0, 0, this.width, this.height);
 
     ctx.globalAlpha = 0.6;
-    const accentGradient = ctx.createLinearGradient(0, 0, SCREEN_WIDTH, 0);
+    const accentGradient = ctx.createLinearGradient(0, 0, this.width, 0);
     accentGradient.addColorStop(0, 'rgba(75, 217, 255, 0.8)');
     accentGradient.addColorStop(0.45, 'rgba(83, 146, 255, 0.35)');
     accentGradient.addColorStop(1, 'rgba(255, 82, 82, 0.6)');
     ctx.fillStyle = accentGradient;
 
-    const accentX = SCREEN_WIDTH * 0.05;
-    const accentY = SCREEN_HEIGHT * 0.16;
-    const accentWidth = SCREEN_WIDTH * 0.9;
-    const accentHeight = SCREEN_HEIGHT * 0.68;
+    const accentX = this.width * 0.05;
+    const accentY = this.height * 0.16;
+    const accentWidth = this.width * 0.9;
+    const accentHeight = this.height * 0.68;
     ctx.fillRect(accentX, accentY, accentWidth, accentHeight);
     ctx.globalAlpha = 1;
 
-    const leftTextAnchor = SCREEN_WIDTH * 0.08;
-    const headerY = SCREEN_HEIGHT * 0.44;
-    const platformY = SCREEN_HEIGHT * 0.62;
-    const taglineY = SCREEN_HEIGHT * 0.74;
-    const episodeY = SCREEN_HEIGHT * 0.84;
-    const rightTextAnchor = SCREEN_WIDTH * 0.92;
+    const leftTextAnchor = this.width * 0.08;
+    const headerY = this.height * 0.44;
+    const platformY = this.height * 0.62;
+    const taglineY = this.height * 0.74;
+    const episodeY = this.height * 0.84;
+    const rightTextAnchor = this.width * 0.92;
 
     ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 180px "Inter", "Segoe UI", sans-serif';
+    ctx.font = this.font(180, 'bold ');
     ctx.textAlign = 'left';
     ctx.textBaseline = 'alphabetic';
     ctx.fillText('Futuroptimist', leftTextAnchor, headerY);
 
-    ctx.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
+    ctx.font = this.font(120, 'bold ');
     ctx.fillStyle = '#ff4c4c';
     ctx.fillText('YouTube', leftTextAnchor, platformY);
 
     const tagline =
       'Designing resilient automation, live devlogs, and deep dives.';
-    ctx.font = '48px "Inter", "Segoe UI", sans-serif';
+    ctx.font = this.font(48);
     ctx.fillStyle = '#dbe7ff';
     ctx.fillText(tagline, leftTextAnchor, taglineY);
 
@@ -152,7 +175,7 @@ class MediaWallScreenRenderer {
     ctx.fillStyle = '#9ddcff';
     ctx.fillText(latestEpisode, leftTextAnchor, episodeY);
 
-    ctx.font = '600 72px "Inter", "Segoe UI", sans-serif';
+    ctx.font = this.font(72, '600 ');
     ctx.fillStyle = '#ffffff';
     ctx.textAlign = 'right';
     ctx.fillText('Watch now →', rightTextAnchor, episodeY);
@@ -161,10 +184,10 @@ class MediaWallScreenRenderer {
 
   private drawStarHighlight() {
     const ctx = this.context;
-    const cardWidth = SCREEN_WIDTH * 0.26;
-    const cardHeight = SCREEN_HEIGHT * 0.32;
-    const cardX = SCREEN_WIDTH * 0.62;
-    const cardY = SCREEN_HEIGHT * 0.18;
+    const cardWidth = this.width * 0.26;
+    const cardHeight = this.height * 0.32;
+    const cardX = this.width * 0.62;
+    const cardY = this.height * 0.18;
     const cardRadius = cardHeight * 0.16;
 
     ctx.save();
@@ -190,7 +213,7 @@ class MediaWallScreenRenderer {
 
     const glowStrength = 0.25 + this.highlight * 0.45;
     ctx.shadowColor = `rgba(74, 210, 255, ${glowStrength})`;
-    ctx.shadowBlur = 120 * (0.35 + this.highlight * 0.55);
+    ctx.shadowBlur = 120 * this.textScale * (0.35 + this.highlight * 0.55);
     ctx.fillStyle = `rgba(74, 210, 255, ${glowStrength})`;
     ctx.fill();
     ctx.shadowColor = 'transparent';
@@ -203,16 +226,16 @@ class MediaWallScreenRenderer {
     const labelY = y + h * 0.86;
 
     ctx.fillStyle = '#ffdd63';
-    ctx.font = 'bold 92px "Inter", "Segoe UI", sans-serif';
+    ctx.font = this.font(92, 'bold ');
     ctx.textAlign = 'left';
     ctx.fillText('★', iconX, iconY);
 
     ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 160px "Inter", "Segoe UI", sans-serif';
+    ctx.font = this.font(160, 'bold ');
     ctx.fillText(this.formatStarCount(), valueX, valueY);
 
     ctx.fillStyle = '#a7c5ff';
-    ctx.font = '48px "Inter", "Segoe UI", sans-serif';
+    ctx.font = this.font(48);
     ctx.fillText('GitHub stars', iconX, labelY);
 
     ctx.restore();
@@ -234,8 +257,10 @@ interface MediaWallTextures {
   badge: CanvasTexture;
 }
 
-function createScreenRenderer(): MediaWallScreenRenderer {
-  return new MediaWallScreenRenderer({ starCount: 1280 });
+function createScreenRenderer(
+  detailPolicy: SceneDetailPolicy
+): MediaWallScreenRenderer {
+  return new MediaWallScreenRenderer({ starCount: 1280, detailPolicy });
 }
 
 function createBadgeTexture(): CanvasTexture {
@@ -288,9 +313,11 @@ function createBadgeTexture(): CanvasTexture {
   return texture;
 }
 
-function getMediaWallTextures(): MediaWallTextures {
+function getMediaWallTextures(
+  detailPolicy: SceneDetailPolicy
+): MediaWallTextures {
   return {
-    screen: createScreenRenderer(),
+    screen: createScreenRenderer(detailPolicy),
     badge: createBadgeTexture(),
   };
 }
@@ -445,8 +472,11 @@ function createMediaWallController({
 }
 
 export function createLivingRoomMediaWall(
-  bounds: Bounds2D
+  bounds: Bounds2D,
+  options: { detailPolicy?: SceneDetailPolicy } = {}
 ): LivingRoomMediaWallBuild {
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
   const colliders: RectCollider[] = [];
@@ -487,7 +517,7 @@ export function createLivingRoomMediaWall(
   );
   group.add(trim);
 
-  const { screen, badge } = getMediaWallTextures();
+  const { screen, badge } = getMediaWallTextures(detailPolicy);
 
   const screenMaterial = new MeshBasicMaterial({
     map: screen.getTexture(),
@@ -520,6 +550,7 @@ export function createLivingRoomMediaWall(
   screenGlow.position.set(wallInteriorX + boardDepth + 0.015, 2.36, anchorZ);
   screenGlow.rotation.y = Math.PI / 2;
   screenGlow.renderOrder = 9;
+  screenGlow.visible = !isPerformance;
   group.add(screenGlow);
 
   const badgeMaterial = new MeshBasicMaterial({
@@ -597,6 +628,7 @@ export function createLivingRoomMediaWall(
   const haloGeometry = new BoxGeometry(0.06, 0.24, shelfWidth * 0.85);
   const halo = new Mesh(haloGeometry, haloMaterial);
   halo.position.set(wallInteriorX + boardDepth + 0.37, 1.02, anchorZ);
+  halo.visible = !isPerformance;
   group.add(halo);
 
   const shelfLightMaterial = new MeshStandardMaterial({
@@ -662,6 +694,7 @@ export function createLivingRoomMediaWall(
     anchorZ
   );
   clearance.renderOrder = 4;
+  clearance.visible = !isPerformance;
   group.add(clearance);
 
   colliders.push({

--- a/src/scene/structures/modelRocket.ts
+++ b/src/scene/structures/modelRocket.ts
@@ -16,11 +16,16 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 export interface ModelRocketConfig {
   basePosition: Vector3;
   orientationRadians?: number;
   scale?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface ModelRocketBuild {
@@ -36,6 +41,9 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   const scale = config.scale ?? DEFAULT_SCALE;
   const orientation = config.orientationRadians ?? 0;
   const basePosition = config.basePosition.clone();
+  const detailPolicy = config.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const structureSegments = detailPolicy.geometry.structureCylinderSegments;
 
   const group = new Group();
   group.name = 'BackyardModelRocket';
@@ -48,7 +56,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius,
     standRadius,
     standHeight,
-    32
+    structureSegments
   );
   const standMaterial = new MeshStandardMaterial({
     color: new Color(0x2c3442),
@@ -64,7 +72,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius * 0.98,
     standRadius * 1.04,
     standHeight * 0.38,
-    32
+    structureSegments
   );
   const standTrimMaterial = new MeshStandardMaterial({
     color: new Color(0x39475b),
@@ -84,7 +92,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.02,
     bodyRadius * 0.94,
     bodyHeight,
-    40
+    structureSegments
   );
   const bodyMaterial = new MeshStandardMaterial({
     color: new Color(0xe7eefc),
@@ -103,7 +111,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.06,
     bodyRadius * 1.06,
     stripeHeight,
-    40
+    structureSegments
   );
   const stripeMaterial = new MeshStandardMaterial({
     color: new Color(0xff6b6b),
@@ -118,7 +126,11 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   group.add(stripe);
 
   const noseHeight = 1.1 * scale;
-  const noseGeometry = new ConeGeometry(bodyRadius * 0.92, noseHeight, 40);
+  const noseGeometry = new ConeGeometry(
+    bodyRadius * 0.92,
+    noseHeight,
+    structureSegments
+  );
   const noseMaterial = new MeshStandardMaterial({
     color: new Color(0xff8976),
     emissive: new Color(0xb33a2d),
@@ -136,7 +148,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 0.78,
     bodyRadius * 0.62,
     thrusterHeight,
-    32
+    structureSegments
   );
   const thrusterMaterial = new MeshStandardMaterial({
     color: new Color(0x1f2734),
@@ -159,6 +171,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   );
   thrusterLight.name = 'ModelRocketThrusterLight';
   thrusterLight.position.set(0, standHeight + thrusterHeight * 0.24, 0);
+  thrusterLight.visible = !isPerformance;
   group.add(thrusterLight);
 
   const flameGeometry = new ConeGeometry(
@@ -209,7 +222,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   const safetyRingGeometry = new RingGeometry(
     standRadius * 1.18,
     standRadius * 1.52,
-    48
+    detailPolicy.geometry.structureRingSegments
   );
   const safetyRingMaterial = new MeshBasicMaterial({
     color: new Color(0xffd166),
@@ -221,6 +234,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   safetyRing.name = 'ModelRocketSafetyRing';
   safetyRing.rotation.x = -Math.PI / 2;
   safetyRing.position.y = 0.02 * scale;
+  safetyRing.visible = !isPerformance;
   group.add(safetyRing);
 
   const countdownPanelMaterial = new MeshBasicMaterial({

--- a/src/tests/avatarMannequin.test.ts
+++ b/src/tests/avatarMannequin.test.ts
@@ -2,6 +2,7 @@ import { Color, DoubleSide, Group, Mesh, MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { createPortfolioMannequin } from '../scene/avatar/mannequin';
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 
 describe('createPortfolioMannequin', () => {
   it('creates a mannequin with a hidden collision proxy aligned to the controller radius', () => {
@@ -99,6 +100,33 @@ describe('createPortfolioMannequin', () => {
       trim.getHSL(trimHsl);
       expect(headHsl.h).toBeCloseTo(trimHsl.h, 1);
       expect(headHsl.l).toBeGreaterThan(trimHsl.l);
+    }
+  });
+
+  it('lowers performance geometry detail without changing controller dimensions', () => {
+    const balanced = createPortfolioMannequin({
+      detailPolicy: getSceneDetailPolicy('balanced'),
+    });
+    const performance = createPortfolioMannequin({
+      detailPolicy: getSceneDetailPolicy('performance'),
+    });
+    const balancedHead = balanced.group.getObjectByName(
+      'PortfolioMannequinHead'
+    );
+    const performanceHead = performance.group.getObjectByName(
+      'PortfolioMannequinHead'
+    );
+    expect(performance.collisionRadius).toBeCloseTo(balanced.collisionRadius);
+    expect(performance.height).toBeCloseTo(balanced.height);
+    expect(performance.group.userData.boundingRadius).toBeCloseTo(
+      balanced.group.userData.boundingRadius
+    );
+    expect(balancedHead).toBeInstanceOf(Mesh);
+    expect(performanceHead).toBeInstanceOf(Mesh);
+    if (balancedHead instanceof Mesh && performanceHead instanceof Mesh) {
+      expect(performanceHead.geometry.attributes.position.count).toBeLessThan(
+        balancedHead.geometry.attributes.position.count / 5
+      );
     }
   });
 

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -20,6 +20,14 @@ describe('performance diagnostics', () => {
         viewport: { width: 1280, height: 720 },
         drawingBuffer: { width: 1600, height: 900 },
       }),
+      getRendererRuntimeInfo: () => ({
+        calls: 12,
+        triangles: 3456,
+        points: 7,
+        lines: 8,
+        geometries: 9,
+        textures: 10,
+      }),
       getQualityState: () => ({
         level: 'balanced',
         selectionSource: 'adaptive',
@@ -77,6 +85,14 @@ describe('performance diagnostics', () => {
     expect(snapshot.minFps).toBeCloseTo(10, 0);
     expect(snapshot.sampleCount).toBe(3);
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
+    expect(snapshot.rendererRuntime).toMatchObject({
+      calls: 12,
+      triangles: 3456,
+      points: 7,
+      lines: 8,
+      geometries: 9,
+      textures: 10,
+    });
     expect(snapshot.softwareRendererPolicy.safeMode).toBe(false);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { GraphicsQualityLevel } from '../scene/graphics/qualityManager';
 import {
+  getSceneDetailMetrics,
+  getSceneDetailPolicy,
+} from '../scene/graphics/sceneDetailPolicy';
+import {
   createAdaptiveQualityController,
   type AdaptiveQualitySelectionSource,
 } from '../scene/performance/adaptiveQuality';
@@ -75,6 +79,43 @@ function createPolicyHarness({
 }
 
 describe('immersive performance optimization policy', () => {
+  it('maps performance quality to aggressive low-effect scene detail budgets', () => {
+    const balanced = getSceneDetailPolicy('balanced');
+    const performance = getSceneDetailPolicy('performance');
+
+    expect(performance.level).toBe('performance');
+    expect(performance.effects.shaderMist).toBe(false);
+    expect(performance.effects.shaderPond).toBe(false);
+    expect(performance.effects.dynamicPointLights).toBe(false);
+    expect(
+      performance.textures.jobbotScreenWidth *
+        performance.textures.jobbotScreenHeight
+    ).toBeLessThanOrEqual(
+      (balanced.textures.jobbotScreenWidth *
+        balanced.textures.jobbotScreenHeight) /
+        16
+    );
+    expect(performance.geometry.poiCylinderSegments).toBeLessThanOrEqual(
+      balanced.geometry.poiCylinderSegments / 5
+    );
+  });
+
+  it('reports a roughly 10x theoretical workload target for performance detail', () => {
+    const balanced = getSceneDetailMetrics('balanced');
+    const performance = getSceneDetailMetrics('performance');
+
+    expect(performance.theoreticalWorkScale).toBeLessThanOrEqual(0.1);
+    expect(performance.texturePixelBudget).toBeLessThanOrEqual(
+      balanced.texturePixelBudget / 16
+    );
+    expect(performance.poiTriangleBudget).toBeLessThan(
+      balanced.poiTriangleBudget / 5
+    );
+    expect(performance.shaderEffectsEnabled).toBeLessThan(
+      balanced.shaderEffectsEnabled
+    );
+  });
+
   it('classifies known dangerous software renderers separately from hardware', () => {
     const dangerousRenderers = [
       'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
@@ -135,6 +176,35 @@ describe('immersive performance optimization policy', () => {
     expect(normal.initialLevel).toBe('balanced');
     expect(normal.basePixelRatioCap).toBe(1.25);
     expect(normal.mirrorEnabled).toBe(true);
+  });
+
+  it('starts constrained coarse-pointer mobile hardware in performance without overriding explicit preferences', () => {
+    const constrained = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      undefined,
+      {
+        coarsePointer: true,
+        mobileLike: true,
+        deviceMemoryGb: 4,
+        hasExplicitPreference: false,
+      }
+    );
+    expect(constrained.initialLevel).toBe('performance');
+    expect(constrained.sceneDetailLevel).toBe('performance');
+
+    const explicitPreference = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      undefined,
+      {
+        coarsePointer: true,
+        mobileLike: true,
+        deviceMemoryGb: 4,
+        hasExplicitPreference: true,
+      }
+    );
+    expect(explicitPreference.initialLevel).toBe('balanced');
   });
 
   it('chooses ultra-low DPR and capped cadence for dangerous software safe mode', () => {

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -1,6 +1,12 @@
-import { CylinderGeometry, MeshStandardMaterial, Color } from 'three';
+import {
+  Color,
+  CylinderGeometry,
+  MeshStandardMaterial,
+  SphereGeometry,
+} from 'three';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import { scalePoiValue } from '../scene/poi/constants';
 import {
   createPoiInstances,
@@ -243,6 +249,46 @@ describe('createPoiInstances', () => {
     );
     expect(instance.orbBaseHeight).toBeGreaterThan(pedestalHeight);
     expect(instance.labelBaseHeight).toBeGreaterThan(instance.orbBaseHeight);
+  });
+
+  it('uses low-segment performance geometry while preserving hit area dimensions', () => {
+    const definition = createDefinition({
+      id: 'flywheel-studio-flywheel',
+      roomId: 'studio',
+      pedestal: { type: 'hologram', height: 1.6, radiusScale: 0.88 },
+    });
+    const [balanced] = createPoiInstances(
+      [definition],
+      {},
+      {
+        detailPolicy: getSceneDetailPolicy('balanced'),
+      }
+    );
+    const [performance] = createPoiInstances(
+      [definition],
+      {},
+      {
+        detailPolicy: getSceneDetailPolicy('performance'),
+      }
+    );
+
+    const balancedOrb = balanced.orb?.geometry as SphereGeometry;
+    const performanceOrb = performance.orb?.geometry as SphereGeometry;
+    const balancedHit = balanced.hitArea.geometry as CylinderGeometry;
+    const performanceHit = performance.hitArea.geometry as CylinderGeometry;
+
+    expect(performanceOrb.parameters.widthSegments).toBeLessThanOrEqual(8);
+    expect(performanceOrb.parameters.widthSegments).toBeLessThan(
+      balancedOrb.parameters.widthSegments / 3
+    );
+    expect(performanceHit.parameters.radialSegments).toBeLessThan(
+      balancedHit.parameters.radialSegments / 3
+    );
+    expect(performanceHit.parameters.height).toBeCloseTo(
+      balancedHit.parameters.height,
+      5
+    );
+    expect(performance.collider).toEqual(balanced.collider);
   });
 
   it('keeps default pedestal styling when no hologram config is provided', () => {


### PR DESCRIPTION
### Motivation
- Provide a centralized, much more aggressive Performance detail policy that meaningfully reduces shader/overdraw work, canvas upload cost, draw calls, dynamic lights, per‑frame decorative updates, and triangle counts for low‑end/mobile/tablet devices. Balanced/Cinematic visuals remain unchanged.
- Make adaptive and initial quality decisions apply scene detail reductions (not just pixel ratio/postprocessing) and expose richer diagnostics for verifying theoretical render budgets.

### Description
- Added a typed scene detail policy and helper `getSceneDetailPolicy` / `getSceneDetailMetrics` in `src/scene/graphics/sceneDetailPolicy.ts` that encodes geometry segments, texture scales, effect toggles, update throttles, and theoretical budgets for `cinematic | balanced | performance`.
- Integrated the scene detail policy across the scene: POI markers (`src/scene/poi/markers.ts`), mannequin (`src/scene/avatar/mannequin.ts`), flywheel (`src/scene/structures/flywheel.ts`), jobbot terminal (`src/scene/structures/jobbotTerminal.ts`), media wall (`src/scene/structures/mediaWall.ts`), greenhouse/model rocket/backyard environments, and other heavy structures to use low‑poly builders or hide expensive decorations when `performance` detail is active.
- Performance‑mode specific optimizations: disable walkway mist and pond ripple shaders, replace physical/transmission glass with cheaper materials, hide nonessential halos/glows/auras, remove or greatly reduce dynamic `PointLight` visibility/intensity, reduce canvas texture sizes (Jobbot/media wall) and throttle per‑frame canvas redraws, and skip/short‑circuit decorative update work for unemphasized objects.
- Adaptive quality and initial policy: `resolveInitialQualityPolicy` now considers coarse‑pointer/mobile hints to start in Performance when appropriate and `createAdaptiveQualityController` now locks recovery after an adaptive downgrade to Performance to avoid flip‑flopping; switching into Performance applies the scene detail policy immediately via a small controller added in `src/main.ts` (`applySceneDetailPolicy`).
- Diagnostics: extended performance diagnostics (`src/scene/performance/performanceDiagnostics.ts`) and main wiring so snapshots include `renderer.info.render` counters and scene detail metrics; `getSceneDetailMetrics` exposes theoretical budgets. Added low‑risk test helpers that assert performance budgets/segment reductions.
- Tests and small helpers: updated/added unit tests to cover mapping from GraphicsQuality to scene detail policy, geometry segment reductions for POIs and mannequin, texture budget reductions, and diagnostics exposure; updated tests in `src/tests/*` accordingly.

### Testing
- Formatting/lint/typecheck: ran `npm run format:write`, `npm run lint`, and `npm run typecheck`; formatting and lint warnings were fixed where safe and `tsc --noEmit` passed after changes.
- Unit tests: ran focused tests (`npm run test:ci -- src/tests/graphicsQualityManager.test.ts src/tests/performanceOptimization.test.ts src/tests/performanceDiagnostics.test.ts src/tests/poiMarkers.test.ts src/tests/avatarMannequin.test.ts`) then the full suite (`npm run test:ci`); final result: all unit/integration tests passed locally (132 test files, 935 tests passed).
- Build: ran `npm run build` and a production build completed successfully (`vite build` completed, `dist/` produced).
- Playwright / E2E: attempted `npm run test:e2e`; initial run failed due to missing Playwright browsers, then `npx playwright install` and `npx playwright install-deps` were executed to provision browsers and host deps; e2e could not be fully executed before environment constraints, so reviewers should re-run the playwright specs in CI or a developer machine (commands: `npx playwright install && npm run test:e2e playwright/immersive-performance.spec.ts playwright/small-screen-hud.spec.ts`).

Notes and followups
- The Performance policy targets a roughly 10x theoretical workload reduction (budget fields in `sceneDetailPolicy`), not a guaranteed FPS multiplier on every device; comments in code clarify this tradeoff and the lazy creation/reload policy for high‑detail geometry.
- Branch created as `codex/performance-detail-lods`; changes focused to scene detail policy, scene structures, diagnostics, and adaptive/initial quality wiring to keep the refactor surface minimal and reviewable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1face2e198832fa885ac5102919ab7)