### PR TITLE
Add aggressive low‑poly SceneDetailPolicy and apply Performance LOD/effect budgets

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -291,7 +291,9 @@ Focus: unify user controls and ensure graceful fallback experiences.
 - ✅ Accessibility HUD presets now expose Standard, Calm, and Photosensitive-safe modes
   that soften bloom, ease emissives, duck ambient audio, and boost HUD contrast.
   - ✅ Graphics HUD presets let players choose Cinematic, Balanced, or Performance modes
-    that retune bloom, LED lighting, and pixel ratio for their device.
+    that retune bloom, LED lighting, and pixel ratio for their device. Performance
+    also activates aggressive low-poly/low-effect scene detail budgets that target
+    theoretical workload reduction rather than a guaranteed FPS multiplier on every GPU.
 - ✅ Ambient audio HUD now exposes a mute toggle and keyboard-friendly volume slider.
 - ✅ Mobile HUD layout now lifts instructional overlays above the joystick
   safe zone so touch movement remains unobstructed.

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -29,6 +29,12 @@ interface PerformanceSnapshot {
     lastAdaptiveReason: string | null;
     lastAdaptiveDowngradeReason: string | null;
     lastAdaptiveRecoveryReason: string | null;
+    sceneDetail?: {
+      level: 'cinematic' | 'balanced' | 'performance';
+      textures: { canvasScale: number };
+      effects: { transparentShaders: boolean; dynamicPointLights: boolean };
+      budget: { texturePixels: number; shaderEffectWeight: number };
+    };
     adaptivePolicy: {
       isWarmingUp: boolean;
       warmupElapsedMs: number;
@@ -46,6 +52,13 @@ interface PerformanceSnapshot {
     mirrorRenderTargetSize: number;
     mirrorUpdateRateFps: number;
     mirrorRenderCount: number;
+  };
+  rendererRuntime?: {
+    calls: number;
+    triangles: number;
+    points: number;
+    lines: number;
+    memory: { geometries: number; textures: number };
   };
   renderer: {
     isSoftwareRenderer: boolean;
@@ -232,6 +245,56 @@ test.describe('immersive performance diagnostics', () => {
       ).toBeGreaterThanOrEqual(0);
       expect(snapshot.quality.level).not.toBe('cinematic');
       expect(snapshot.quality.adaptivePolicy).toBeDefined();
+      expect(snapshot.rendererRuntime?.calls).toBeGreaterThanOrEqual(0);
+      expect(snapshot.rendererRuntime?.triangles).toBeGreaterThanOrEqual(0);
+      expect(
+        snapshot.rendererRuntime?.memory.geometries
+      ).toBeGreaterThanOrEqual(0);
+      expect(snapshot.quality.sceneDetail).toBeDefined();
+      expect(
+        snapshot.quality.sceneDetail?.budget.texturePixels
+      ).toBeGreaterThan(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('caps scene detail budgets when performance quality is persisted', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem(
+          'danielsmith:graphics-quality-level',
+          'performance'
+        );
+      } catch {
+        // Ignore inaccessible storage in hardened browser contexts.
+      }
+    });
+
+    try {
+      await waitForImmersive(page, IMMERSIVE_DIAGNOSTICS_URL);
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.quality.level).toBe('performance');
+      expect(snapshot.quality.sceneDetail?.level).toBe('performance');
+      expect(
+        snapshot.quality.sceneDetail?.textures.canvasScale
+      ).toBeLessThanOrEqual(0.25);
+      expect(snapshot.quality.sceneDetail?.effects.transparentShaders).toBe(
+        false
+      );
+      expect(snapshot.quality.sceneDetail?.effects.dynamicPointLights).toBe(
+        false
+      );
+      expect(
+        snapshot.quality.sceneDetail?.budget.texturePixels
+      ).toBeLessThanOrEqual(512 * 256);
+      expect(snapshot.rendererRuntime?.calls).toBeGreaterThanOrEqual(0);
+      expect(snapshot.rendererRuntime?.triangles).toBeGreaterThanOrEqual(0);
     } finally {
       await context.close();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,11 @@ import {
   createGraphicsQualityManager,
   type GraphicsQualityManager,
 } from './scene/graphics/qualityManager';
+import {
+  createSceneDetailController,
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+} from './scene/graphics/sceneDetailPolicy';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -733,8 +738,41 @@ function initializeImmersiveScene(
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
     window.devicePixelRatio ?? 1,
-    softwareRendererPolicy
+    softwareRendererPolicy,
+    {
+      coarsePointer: window.matchMedia?.('(pointer: coarse)').matches ?? false,
+      mobileLike: /Android|iPhone|iPod|Mobile/i.test(navigator.userAgent),
+      tabletLike: /iPad|Tablet|SM-T|Galaxy Tab/i.test(navigator.userAgent),
+      deviceMemoryGb:
+        typeof (navigator as Navigator & { deviceMemory?: number })
+          .deviceMemory === 'number'
+          ? (navigator as Navigator & { deviceMemory?: number }).deviceMemory
+          : null,
+      hardwareConcurrency:
+        typeof navigator.hardwareConcurrency === 'number'
+          ? navigator.hardwareConcurrency
+          : null,
+    }
   );
+  let qualityStorage: Storage | undefined;
+  try {
+    qualityStorage = window.localStorage;
+  } catch {
+    qualityStorage = undefined;
+  }
+  const storedInitialSceneLevel = qualityStorage?.getItem(
+    'danielsmith:graphics-quality-level'
+  );
+  const initialSceneDetailLevel: SceneDetailLevel =
+    GRAPHICS_QUALITY_PRESETS.some(
+      (preset) => preset.id === storedInitialSceneLevel
+    )
+      ? (storedInitialSceneLevel as SceneDetailLevel)
+      : initialQualityPolicy.initialLevel;
+  const sceneDetailController = createSceneDetailController(
+    initialSceneDetailLevel
+  );
+  const sceneDetailPolicy = getSceneDetailPolicy(initialSceneDetailLevel);
   const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
     ? initialQualityPolicy.basePixelRatioCap
     : rendererInfo.isSoftwareRenderer
@@ -1152,6 +1190,7 @@ function initializeImmersiveScene(
   if (backyardRoom) {
     backyardEnvironment = createBackyardEnvironment(backyardRoom.bounds, {
       seasonalPreset,
+      detailPolicy: sceneDetailPolicy,
     });
     scene.add(backyardEnvironment.group);
     // Remove the enclosing sky dome to avoid a bright circular spheroid.
@@ -1244,7 +1283,9 @@ function initializeImmersiveScene(
 
   const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom');
   if (livingRoom) {
-    const mediaWall = createLivingRoomMediaWall(livingRoom.bounds);
+    const mediaWall = createLivingRoomMediaWall(livingRoom.bounds, {
+      detailPolicy: sceneDetailPolicy,
+    });
     scene.add(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
@@ -1547,7 +1588,9 @@ function initializeImmersiveScene(
   });
   lightmapAnimator.captureBaseline();
 
-  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides);
+  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
+    detailPolicy: sceneDetailPolicy,
+  });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
       scene.add(poi.group);
@@ -1926,6 +1969,7 @@ function initializeImmersiveScene(
       centerZ,
       roomBounds: studioRoom.bounds,
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
+      detailPolicy: sceneDetailPolicy,
     });
     scene.add(showpiece.group);
     showpiece.colliders.forEach((collider) => groundColliders.push(collider));
@@ -1945,6 +1989,7 @@ function initializeImmersiveScene(
     const terminal = createJobbotTerminal({
       position: { x: terminalX, y: 0, z: terminalZ },
       orientationRadians: terminalOrientation,
+      detailPolicy: sceneDetailPolicy,
     });
     scene.add(terminal.group);
     terminal.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2176,6 +2221,7 @@ function initializeImmersiveScene(
 
   const mannequin = createPortfolioMannequin({
     collisionRadius: PLAYER_RADIUS,
+    detailPolicy: sceneDetailPolicy,
   });
   const player = mannequin.group;
   const mannequinHeight = mannequin.height;
@@ -3535,13 +3581,6 @@ function initializeImmersiveScene(
   resetMotionBlurHistory = () => motionBlurController?.resetHistory();
   composer.addPass(motionBlurController.pass);
 
-  let qualityStorage: Storage | undefined;
-  try {
-    qualityStorage = window.localStorage;
-  } catch {
-    qualityStorage = undefined;
-  }
-
   graphicsQualityManager = createGraphicsQualityManager({
     renderer,
     bloomPass: bloomPass ?? undefined,
@@ -3774,7 +3813,8 @@ function initializeImmersiveScene(
   const shouldUseComposer = () =>
     !softwareRendererPolicy.safeMode && getActivePostprocessingPassCount() > 0;
 
-  unsubscribeGraphicsQuality = graphicsQualityManager.onChange(() => {
+  unsubscribeGraphicsQuality = graphicsQualityManager.onChange((level) => {
+    sceneDetailController.setLevel(level);
     applyFeaturePolicy();
     composer?.setSize(window.innerWidth, window.innerHeight);
     bloomPass?.setSize(window.innerWidth, window.innerHeight);
@@ -3800,6 +3840,16 @@ function initializeImmersiveScene(
         height: renderer.getContext().drawingBufferHeight,
       },
     }),
+    getRendererRuntimeInfo: () => ({
+      calls: renderer.info.render.calls,
+      triangles: renderer.info.render.triangles,
+      points: renderer.info.render.points,
+      lines: renderer.info.render.lines,
+      memory: {
+        geometries: renderer.info.memory.geometries,
+        textures: renderer.info.memory.textures,
+      },
+    }),
     getQualityState: () => ({
       level: graphicsQualityManager!.getLevel(),
       selectionSource: graphicsQualityManager!.getSelectionSource(),
@@ -3812,6 +3862,7 @@ function initializeImmersiveScene(
       lastAdaptiveRecoveryReason:
         adaptiveQualityController?.getLastRecoveryReason() ?? null,
       adaptivePolicy: adaptiveQualityController?.getSnapshot() ?? null,
+      sceneDetail: sceneDetailController.getPolicy(),
     }),
     getFeatureState: () => {
       const mirrorState = selfieMirror?.getRenderState();
@@ -4708,7 +4759,9 @@ function initializeImmersiveScene(
         performance.now() - phaseStart
       );
       phaseStart = performance.now();
-      if (livingRoomMediaWall) {
+      const shouldRunDecorativeUpdate =
+        sceneDetailController.shouldRunDecorativeUpdate(elapsedTime);
+      if (livingRoomMediaWall && shouldRunDecorativeUpdate) {
         const activation = futuroptimistPoi?.activation ?? 0;
         const focus = futuroptimistPoi?.focus ?? 0;
         livingRoomMediaWall.controller.update({
@@ -4717,7 +4770,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (flywheelShowpiece) {
+      if (flywheelShowpiece && shouldRunDecorativeUpdate) {
         const activation = flywheelPoi?.activation ?? 0;
         const focus = flywheelPoi?.focus ?? 0;
         flywheelShowpiece.update({
@@ -4753,7 +4806,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (jobbotTerminal) {
+      if (jobbotTerminal && shouldRunDecorativeUpdate) {
         const activation = jobbotPoi?.activation ?? 0;
         const focus = jobbotPoi?.focus ?? 0;
         jobbotTerminal.update({
@@ -4809,7 +4862,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (backyardEnvironment) {
+      if (backyardEnvironment && shouldRunDecorativeUpdate) {
         backyardEnvironment.update({ elapsed: elapsedTime, delta });
       }
       performanceDiagnostics?.recordPhase(

--- a/src/scene/avatar/mannequin.ts
+++ b/src/scene/avatar/mannequin.ts
@@ -12,6 +12,12 @@ import {
   TorusGeometry,
 } from 'three';
 
+import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+
 // Deterministic floor-to-crest height used by initial camera framing before assets load.
 export const PORTFOLIO_MANNEQUIN_VISUAL_HEIGHT = 2.6;
 
@@ -32,6 +38,8 @@ export interface PortfolioMannequinOptions {
    * Head and glove color used to suggest skin or fabric contrast.
    */
   trimColor?: string;
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface PortfolioMannequinPalette {
@@ -84,6 +92,14 @@ function createStandardMaterial(
 export function createPortfolioMannequin(
   options: PortfolioMannequinOptions = {}
 ): PortfolioMannequinBuild {
+  const detailPolicy =
+    options.detailPolicy ??
+    getSceneDetailPolicy(options.detailLevel ?? 'balanced');
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
+  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
+  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
+  const torusRadialSegments = detailPolicy.geometry.torusRadialSegments;
+  const torusTubularSegments = detailPolicy.geometry.torusTubularSegments;
   const collisionRadius = options.collisionRadius ?? 0.75;
   const initialPalette: PortfolioMannequinPalette = {
     base: options.baseColor ?? '#283347',
@@ -95,7 +111,11 @@ export function createPortfolioMannequin(
   group.name = 'PortfolioMannequin';
 
   const collisionProxy = new Mesh(
-    new SphereGeometry(collisionRadius, 32, 32),
+    new SphereGeometry(
+      collisionRadius,
+      sphereWidthSegments,
+      sphereHeightSegments
+    ),
     new MeshBasicMaterial({ color: 0xffffff })
   );
   collisionProxy.name = 'PortfolioMannequinCollisionProxy';
@@ -116,7 +136,7 @@ export function createPortfolioMannequin(
   );
   const platformHeight = 0.08;
   const platform = new Mesh(
-    new CylinderGeometry(0.58, 0.58, platformHeight, 48),
+    new CylinderGeometry(0.58, 0.58, platformHeight, cylinderSegments),
     platformMaterial
   );
   platform.name = 'PortfolioMannequinPlatform';
@@ -128,7 +148,7 @@ export function createPortfolioMannequin(
   const legMaterial = createStandardMaterial(new Color(initialPalette.base));
   const legHeight = 0.92;
   const legs = new Mesh(
-    new CylinderGeometry(0.26, 0.3, legHeight, 32),
+    new CylinderGeometry(0.26, 0.3, legHeight, cylinderSegments),
     legMaterial
   );
   legs.name = 'PortfolioMannequinLegs';
@@ -170,7 +190,7 @@ export function createPortfolioMannequin(
   rightFoot.add(rightFootMesh);
 
   const accentBand = new Mesh(
-    new TorusGeometry(0.34, 0.05, 20, 48),
+    new TorusGeometry(0.34, 0.05, torusRadialSegments, torusTubularSegments),
     platformMaterial.clone()
   );
   accentBand.name = 'PortfolioMannequinWaistBand';
@@ -184,7 +204,7 @@ export function createPortfolioMannequin(
 
   const torsoMaterial = createStandardMaterial(new Color(initialPalette.base));
   const torso = new Mesh(
-    new CylinderGeometry(0.46, 0.36, 0.86, 32),
+    new CylinderGeometry(0.46, 0.36, 0.86, cylinderSegments),
     torsoMaterial
   );
   torso.name = 'PortfolioMannequinTorso';
@@ -196,7 +216,7 @@ export function createPortfolioMannequin(
   const shoulderMaterial = createStandardMaterial(
     new Color(initialPalette.base)
   );
-  const armGeometry = new CylinderGeometry(0.16, 0.18, 0.82, 24);
+  const armGeometry = new CylinderGeometry(0.16, 0.18, 0.82, cylinderSegments);
 
   const leftArm = new Mesh(armGeometry, shoulderMaterial);
   leftArm.name = 'PortfolioMannequinArmLeft';
@@ -222,7 +242,7 @@ export function createPortfolioMannequin(
     }
   );
   const leftCuff = new Mesh(
-    new TorusGeometry(0.16, 0.035, 14, 32),
+    new TorusGeometry(0.16, 0.035, torusRadialSegments, torusTubularSegments),
     cuffMaterial
   );
   leftCuff.name = 'PortfolioMannequinCuffLeft';
@@ -236,7 +256,12 @@ export function createPortfolioMannequin(
   mannequinRoot.add(rightCuff);
 
   const trimMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const gloveGeometry = new CylinderGeometry(0.18, 0.18, 0.22, 18);
+  const gloveGeometry = new CylinderGeometry(
+    0.18,
+    0.18,
+    0.22,
+    cylinderSegments
+  );
   const leftGlove = new Mesh(gloveGeometry, trimMaterial);
   leftGlove.name = 'PortfolioMannequinGloveLeft';
   leftGlove.position.set(
@@ -265,7 +290,7 @@ export function createPortfolioMannequin(
     }
   );
   const collar = new Mesh(
-    new TorusGeometry(0.3, 0.045, 16, 36),
+    new TorusGeometry(0.3, 0.045, torusRadialSegments, torusTubularSegments),
     collarMaterial
   );
   collar.name = 'PortfolioMannequinCollar';
@@ -274,7 +299,10 @@ export function createPortfolioMannequin(
   mannequinRoot.add(collar);
 
   const headMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const head = new Mesh(new SphereGeometry(0.28, 32, 32), headMaterial);
+  const head = new Mesh(
+    new SphereGeometry(0.28, sphereWidthSegments, sphereHeightSegments),
+    headMaterial
+  );
   head.name = 'PortfolioMannequinHead';
   head.position.y = collar.position.y + 0.32;
   head.castShadow = true;
@@ -283,7 +311,11 @@ export function createPortfolioMannequin(
 
   // Add a simple smiley face marker to the front of the head for directionality.
   const faceMaterial = new MeshBasicMaterial({ color: 0x000000 });
-  const eyeGeometry = new SphereGeometry(0.03, 12, 12);
+  const eyeGeometry = new SphereGeometry(
+    0.03,
+    Math.min(12, sphereWidthSegments),
+    Math.min(12, sphereHeightSegments)
+  );
   const leftEye = new Mesh(eyeGeometry, faceMaterial);
   leftEye.name = 'PortfolioMannequinFaceLeftEye';
   leftEye.position.set(-0.08, head.position.y + 0.06, 0.25);
@@ -296,7 +328,13 @@ export function createPortfolioMannequin(
 
   // Mouth as a thin torus segment to suggest a smile on the front side.
   const mouth = new Mesh(
-    new TorusGeometry(0.09, 0.012, 8, 24, Math.PI),
+    new TorusGeometry(
+      0.09,
+      0.012,
+      Math.min(8, torusRadialSegments),
+      torusTubularSegments,
+      Math.PI
+    ),
     faceMaterial
   );
   mouth.name = 'PortfolioMannequinFaceMouth';
@@ -315,7 +353,7 @@ export function createPortfolioMannequin(
   visorMaterial.opacity = 0.72;
   visorMaterial.side = DoubleSide;
   const visor = new Mesh(
-    new CylinderGeometry(0.27, 0.27, 0.16, 32, 1, true),
+    new CylinderGeometry(0.27, 0.27, 0.16, cylinderSegments, 1, true),
     visorMaterial
   );
   visor.name = 'PortfolioMannequinVisor';

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -42,6 +42,11 @@ import {
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
 import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+import {
   applySeasonalLightingPreset,
   type SeasonalLightingPreset,
   type SeasonalLightingTarget,
@@ -79,6 +84,12 @@ interface WalkwayArrowTarget {
 interface WalkwayArrowSeasonalTarget {
   material: MeshBasicMaterial;
   baseColor: Color;
+}
+
+export interface BackyardEnvironmentOptions {
+  seasonalPreset?: SeasonalLightingPreset | null;
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface WalkwayMistLayer {
@@ -297,14 +308,16 @@ function createDuskLightProbe(): LightProbe {
   return probe;
 }
 
-export interface BackyardEnvironmentOptions {
-  seasonalPreset?: SeasonalLightingPreset | null;
-}
-
 export function createBackyardEnvironment(
   bounds: Bounds2D,
-  { seasonalPreset = null }: BackyardEnvironmentOptions = {}
+  {
+    seasonalPreset = null,
+    detailLevel = 'balanced',
+    detailPolicy,
+  }: BackyardEnvironmentOptions = {}
 ): BackyardEnvironmentBuild {
+  const sceneDetail = detailPolicy ?? getSceneDetailPolicy(detailLevel);
+  const isPerformance = sceneDetail.level === 'performance';
   const group = new Group();
   group.name = 'BackyardEnvironment';
   const colliders: RectCollider[] = [];
@@ -324,7 +337,11 @@ export function createBackyardEnvironment(
   group.add(duskLightProbe);
 
   const skyRadius = Math.max(width, depth) * 1.32;
-  const skyGeometry = new SphereGeometry(skyRadius, 48, 48);
+  const skyGeometry = new SphereGeometry(
+    skyRadius,
+    sceneDetail.geometry.sphereWidthSegments,
+    sceneDetail.geometry.sphereHeightSegments
+  );
   skyGeometry.scale(1, 0.62, 1);
   const verticalExtent = skyRadius * 0.62;
 
@@ -440,7 +457,7 @@ export function createBackyardEnvironment(
     );
   });
 
-  const terrainSegments = 32;
+  const terrainSegments = sceneDetail.geometry.terrainSegments;
   const terrainGeometry = new PlaneGeometry(
     width,
     depth,
@@ -498,6 +515,7 @@ export function createBackyardEnvironment(
   const rocket = createModelRocket({
     basePosition: rocketBase,
     orientationRadians: -Math.PI / 10,
+    detailPolicy: sceneDetail,
   });
   group.add(rocket.group);
   colliders.push(rocket.collider);
@@ -537,6 +555,7 @@ export function createBackyardEnvironment(
     depth: greenhouseDepth,
     environmentMap: duskReflectionMap,
     environmentIntensity: 0.62,
+    detailPolicy: sceneDetail,
   });
   group.add(greenhouse.group);
   greenhouse.colliders.forEach((collider) => colliders.push(collider));
@@ -650,7 +669,7 @@ export function createBackyardEnvironment(
     1
   );
   walkwayMistGeometry.rotateX(-Math.PI / 2);
-  const walkwayMistLayerCount = 3;
+  const walkwayMistLayerCount = sceneDetail.effects.transparentShaders ? 3 : 0;
   for (let i = 0; i < walkwayMistLayerCount; i += 1) {
     const ratio = (i + 1) / (walkwayMistLayerCount + 1);
     const baseOpacity = MathUtils.lerp(0.24, 0.38, ratio);
@@ -1648,7 +1667,12 @@ export function createBackyardEnvironment(
       glass.position.y = 1.05;
       lantern.add(glass);
 
-      const light = new PointLight(0xffd9a2, 0.85, 4.4, 2.6);
+      const light = new PointLight(
+        0xffd9a2,
+        sceneDetail.effects.dynamicPointLights ? 0.85 : 0,
+        4.4,
+        2.6
+      );
       light.name = `BackyardWalkwayLanternLight-${lanternIndex}`;
       light.position.y = 1.05;
       light.color.copy(glassMaterial.emissive);
@@ -1945,7 +1969,7 @@ export function createBackyardEnvironment(
 
   const duskLight = new PointLight(
     0x8fb8ff,
-    0.065,
+    sceneDetail.effects.dynamicPointLights ? 0.065 : 0,
     Math.max(width, depth) * 0.9,
     2.4
   );
@@ -2082,6 +2106,9 @@ export function createBackyardEnvironment(
   });
 
   const update = (context: { elapsed: number; delta: number }) => {
+    if (isPerformance) {
+      return;
+    }
     updates.forEach((fn) => fn(context));
   };
 

--- a/src/scene/graphics/sceneDetailPolicy.ts
+++ b/src/scene/graphics/sceneDetailPolicy.ts
@@ -1,0 +1,183 @@
+import type { GraphicsQualityLevel } from './qualityManager';
+
+export type SceneDetailLevel = GraphicsQualityLevel;
+
+export interface SceneDetailPolicy {
+  level: SceneDetailLevel;
+  geometry: {
+    cylinderSegments: number;
+    sphereWidthSegments: number;
+    sphereHeightSegments: number;
+    ringSegments: number;
+    torusRadialSegments: number;
+    torusTubularSegments: number;
+    terrainSegments: number;
+  };
+  textures: {
+    canvasScale: number;
+    poiLabelScale: number;
+    maxStaticUploadFps: number;
+  };
+  effects: {
+    transparentShaders: boolean;
+    decorativeHalos: boolean;
+    decorativeOrbiters: boolean;
+    dynamicPointLights: boolean;
+    physicalGlass: boolean;
+  };
+  updates: {
+    decorativeThrottleMs: number;
+    canvasRedrawThrottleMs: number;
+  };
+  budget: {
+    shaderEffectWeight: number;
+    texturePixels: number;
+    transparentLayerWeight: number;
+    dynamicLightWeight: number;
+    decorativeUpdateWeight: number;
+    geometrySegmentWeight: number;
+  };
+}
+
+const DETAIL_POLICIES: Record<SceneDetailLevel, SceneDetailPolicy> = {
+  cinematic: {
+    level: 'cinematic',
+    geometry: {
+      cylinderSegments: 48,
+      sphereWidthSegments: 32,
+      sphereHeightSegments: 32,
+      ringSegments: 64,
+      torusRadialSegments: 20,
+      torusTubularSegments: 64,
+      terrainSegments: 32,
+    },
+    textures: { canvasScale: 1, poiLabelScale: 1, maxStaticUploadFps: 60 },
+    effects: {
+      transparentShaders: true,
+      decorativeHalos: true,
+      decorativeOrbiters: true,
+      dynamicPointLights: true,
+      physicalGlass: true,
+    },
+    updates: { decorativeThrottleMs: 0, canvasRedrawThrottleMs: 0 },
+    budget: {
+      shaderEffectWeight: 1,
+      texturePixels: 2048 * 1024,
+      transparentLayerWeight: 1,
+      dynamicLightWeight: 1,
+      decorativeUpdateWeight: 1,
+      geometrySegmentWeight: 1,
+    },
+  },
+  balanced: {
+    level: 'balanced',
+    geometry: {
+      cylinderSegments: 48,
+      sphereWidthSegments: 32,
+      sphereHeightSegments: 32,
+      ringSegments: 64,
+      torusRadialSegments: 20,
+      torusTubularSegments: 64,
+      terrainSegments: 32,
+    },
+    textures: { canvasScale: 1, poiLabelScale: 1, maxStaticUploadFps: 60 },
+    effects: {
+      transparentShaders: true,
+      decorativeHalos: true,
+      decorativeOrbiters: true,
+      dynamicPointLights: true,
+      physicalGlass: true,
+    },
+    updates: { decorativeThrottleMs: 0, canvasRedrawThrottleMs: 0 },
+    budget: {
+      shaderEffectWeight: 1,
+      texturePixels: 2048 * 1024,
+      transparentLayerWeight: 1,
+      dynamicLightWeight: 1,
+      decorativeUpdateWeight: 1,
+      geometrySegmentWeight: 1,
+    },
+  },
+  performance: {
+    level: 'performance',
+    geometry: {
+      cylinderSegments: 8,
+      sphereWidthSegments: 8,
+      sphereHeightSegments: 6,
+      ringSegments: 12,
+      torusRadialSegments: 6,
+      torusTubularSegments: 12,
+      terrainSegments: 4,
+    },
+    textures: { canvasScale: 0.25, poiLabelScale: 0.5, maxStaticUploadFps: 2 },
+    effects: {
+      transparentShaders: false,
+      decorativeHalos: false,
+      decorativeOrbiters: false,
+      dynamicPointLights: false,
+      physicalGlass: false,
+    },
+    updates: { decorativeThrottleMs: 250, canvasRedrawThrottleMs: 500 },
+    budget: {
+      // This is a theoretical workload budget for policy tests/diagnostics;
+      // actual FPS gains still depend on browser, GPU, thermals, and drivers.
+      shaderEffectWeight: 0.05,
+      texturePixels: 512 * 256,
+      transparentLayerWeight: 0.08,
+      dynamicLightWeight: 0.05,
+      decorativeUpdateWeight: 0.1,
+      geometrySegmentWeight: 0.12,
+    },
+  },
+};
+
+export function getSceneDetailPolicy(
+  level: GraphicsQualityLevel
+): SceneDetailPolicy {
+  return DETAIL_POLICIES[level] ?? DETAIL_POLICIES.balanced;
+}
+
+export interface SceneDetailRuntimeTarget {
+  setSceneDetailLevel?(
+    level: SceneDetailLevel,
+    policy: SceneDetailPolicy
+  ): void;
+}
+
+export interface SceneDetailController {
+  getLevel(): SceneDetailLevel;
+  getPolicy(): SceneDetailPolicy;
+  setLevel(level: SceneDetailLevel): void;
+  shouldRunDecorativeUpdate(elapsedSeconds: number): boolean;
+}
+
+export function createSceneDetailController(
+  initialLevel: SceneDetailLevel
+): SceneDetailController {
+  let level = initialLevel;
+  let policy = getSceneDetailPolicy(level);
+  let lastDecorativeUpdateMs = Number.NEGATIVE_INFINITY;
+  return {
+    getLevel: () => level,
+    getPolicy: () => policy,
+    setLevel(nextLevel) {
+      if (nextLevel === level) {
+        return;
+      }
+      level = nextLevel;
+      policy = getSceneDetailPolicy(level);
+    },
+    shouldRunDecorativeUpdate(elapsedSeconds) {
+      const throttleMs = policy.updates.decorativeThrottleMs;
+      if (throttleMs <= 0) {
+        return true;
+      }
+      const nowMs = elapsedSeconds * 1000;
+      if (nowMs - lastDecorativeUpdateMs < throttleMs) {
+        return false;
+      }
+      lastDecorativeUpdateMs = nowMs;
+      return true;
+    },
+  };
+}

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -2,6 +2,7 @@ import type {
   GraphicsQualityLevel,
   GraphicsQualitySelectionSource,
 } from '../graphics/qualityManager';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { SoftwareRendererPolicyState } from './qualityPolicy';
@@ -15,6 +16,14 @@ export type PhaseName =
   | 'lightingLedLightmap'
   | 'mirror'
   | 'mainRender';
+
+export interface RendererRuntimeInfoSnapshot {
+  calls: number;
+  triangles: number;
+  points: number;
+  lines: number;
+  memory: { geometries: number; textures: number };
+}
 
 export interface RendererSizeSnapshot {
   pixelRatio: number;
@@ -31,6 +40,7 @@ export interface QualityStateSnapshot {
   lastAdaptiveDowngradeReason: string | null;
   lastAdaptiveRecoveryReason: string | null;
   adaptivePolicy: AdaptiveQualityPolicySnapshot | null;
+  sceneDetail?: SceneDetailPolicy;
 }
 
 export interface FeatureStateSnapshot {
@@ -59,6 +69,7 @@ export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   renderer: RendererInfoSnapshot;
   softwareRendererPolicy: SoftwareRendererPolicyState;
   rendererSize: RendererSizeSnapshot;
+  rendererRuntime: RendererRuntimeInfoSnapshot;
   quality: QualityStateSnapshot;
   features: FeatureStateSnapshot;
   lastFailoverReason: string | null;
@@ -88,6 +99,7 @@ export interface PerformanceDiagnosticsApi {
 interface PerformanceDiagnosticsOptions {
   rendererInfo: RendererInfoSnapshot;
   getRendererSize: () => RendererSizeSnapshot;
+  getRendererRuntimeInfo?: () => RendererRuntimeInfoSnapshot;
   getQualityState: () => QualityStateSnapshot;
   getFeatureState: () => FeatureStateSnapshot;
   getLastFailoverReason: () => string | null;
@@ -144,6 +156,13 @@ function summarize(values: readonly number[]): {
 export function createPerformanceDiagnostics({
   rendererInfo,
   getRendererSize,
+  getRendererRuntimeInfo = () => ({
+    calls: 0,
+    triangles: 0,
+    points: 0,
+    lines: 0,
+    memory: { geometries: 0, textures: 0 },
+  }),
   getQualityState,
   getFeatureState,
   getLastFailoverReason,
@@ -179,6 +198,7 @@ export function createPerformanceDiagnostics({
         renderer: diagnosticsMethods.getRendererInfo(),
         softwareRendererPolicy: getSoftwareRendererPolicy(),
         rendererSize: getRendererSize(),
+        rendererRuntime: getRendererRuntimeInfo(),
         quality: diagnosticsMethods.getQualityState(),
         features: diagnosticsMethods.getFeatureState(),
         lastFailoverReason: diagnosticsMethods.getLastFailoverReason(),

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -119,6 +119,14 @@ export function resolveSoftwareSafeRenderCadence({
   };
 }
 
+export interface QualityPolicyDeviceHints {
+  coarsePointer?: boolean;
+  mobileLike?: boolean;
+  tabletLike?: boolean;
+  deviceMemoryGb?: number | null;
+  hardwareConcurrency?: number | null;
+}
+
 export interface QualityPolicyState {
   initialLevel: GraphicsQualityLevel;
   basePixelRatioCap: number;
@@ -168,7 +176,8 @@ export function resolveInitialQualityPolicy(
   devicePixelRatio: number,
   softwareRendererPolicy: SoftwareRendererPolicyState = resolveSoftwareRendererPolicy(
     rendererInfo
-  )
+  ),
+  deviceHints: QualityPolicyDeviceHints = {}
 ): QualityPolicyState {
   if (
     rendererInfo.isDangerousSoftwareRenderer &&
@@ -199,6 +208,34 @@ export function resolveInitialQualityPolicy(
       softwareSafeMode: false,
       renderCadenceFps: null,
       reason: 'software renderer starts in performance mode',
+    };
+  }
+
+  const isConstrainedMobileOrTablet =
+    Boolean(
+      deviceHints.coarsePointer ||
+        deviceHints.mobileLike ||
+        deviceHints.tabletLike
+    ) ||
+    (typeof deviceHints.deviceMemoryGb === 'number' &&
+      deviceHints.deviceMemoryGb > 0 &&
+      deviceHints.deviceMemoryGb <= 4) ||
+    (typeof deviceHints.hardwareConcurrency === 'number' &&
+      deviceHints.hardwareConcurrency > 0 &&
+      deviceHints.hardwareConcurrency <= 4);
+
+  if (isConstrainedMobileOrTablet) {
+    return {
+      initialLevel: 'performance',
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.9, 0.6),
+      mirrorEnabled: false,
+      mirrorTargetSize: 192,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 100,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
+      reason:
+        'coarse-pointer or constrained mobile/tablet hardware starts in performance mode',
     };
   }
 

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -18,6 +18,12 @@ import {
 } from 'three';
 
 import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+
+import {
   scalePoiValue,
   POI_ORB_VERTICAL_OFFSET,
   POI_ORB_HEIGHT_MULTIPLIER,
@@ -82,16 +88,29 @@ export interface PoiInstance {
   visitedBadge?: PoiVisitedBadge;
 }
 
+export interface PoiInstanceDetailOptions {
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
+}
+
 export function createPoiInstances(
   definitions: PoiDefinition[],
-  overrides: PoiInstanceOverrides = {}
+  overrides: PoiInstanceOverrides = {},
+  detailOptions: PoiInstanceDetailOptions = {}
 ): PoiInstance[] {
+  const detailPolicy =
+    detailOptions.detailPolicy ??
+    getSceneDetailPolicy(detailOptions.detailLevel ?? 'balanced');
   return definitions.map((definition, index) => {
     const override = overrides[definition.id];
     if (override?.mode === 'display') {
       return createDisplayPoiInstance(definition, override);
     }
-    return createPedestalPoiInstance(definition, index * Math.PI * 0.37);
+    return createPedestalPoiInstance(
+      definition,
+      index * Math.PI * 0.37,
+      detailPolicy
+    );
   });
 }
 
@@ -110,8 +129,10 @@ export function updatePoiInstanceDefinition(
 
 function createPedestalPoiInstance(
   definition: PoiDefinition,
-  phaseOffset: number
+  phaseOffset: number,
+  detailPolicy: SceneDetailPolicy
 ): PoiInstance {
+  const isPerformance = detailPolicy.level === 'performance';
   const group = new Group();
   group.name = `POI:${definition.id}`;
   group.position.set(
@@ -158,7 +179,7 @@ function createPedestalPoiInstance(
       pedestalRadius,
       pedestalRadius,
       pedestalHeight,
-      48,
+      detailPolicy.geometry.cylinderSegments,
       1,
       true
     );
@@ -194,7 +215,7 @@ function createPedestalPoiInstance(
       pedestalRadius * 1.02,
       pedestalRadius * 1.02,
       accentHeight,
-      48,
+      detailPolicy.geometry.cylinderSegments,
       1,
       true
     );
@@ -220,7 +241,7 @@ function createPedestalPoiInstance(
     const ringGeometry = new RingGeometry(
       pedestalRadius * 0.55,
       pedestalRadius * 1.08,
-      64,
+      detailPolicy.geometry.ringSegments,
       1
     );
     const ring = new Mesh(ringGeometry, ringMaterial);
@@ -228,12 +249,18 @@ function createPedestalPoiInstance(
     ring.rotation.x = -Math.PI / 2;
     ring.position.y = pedestalHeight + scalePoiValue(0.02);
     ring.renderOrder = 12;
-    group.add(ring);
+    if (detailPolicy.effects.decorativeHalos) {
+      group.add(ring);
+    }
   }
 
   const orbRadius =
     Math.max(baseRadius, pedestalRadius) * 0.45 * POI_ORB_DIAMETER_MULTIPLIER;
-  const orbGeometry = new SphereGeometry(orbRadius, 32, 32);
+  const orbGeometry = new SphereGeometry(
+    orbRadius,
+    detailPolicy.geometry.sphereWidthSegments,
+    detailPolicy.geometry.sphereHeightSegments
+  );
   const orbColor = new Color(hologramConfig?.orbColor ?? 0xb8f3ff);
   const orbEmissiveBase = new Color(
     hologramConfig?.orbEmissiveColor ?? 0x3de1ff
@@ -256,7 +283,9 @@ function createPedestalPoiInstance(
   orb.position.y = orbBaseHeight;
   group.add(orb);
 
-  const labelTexture = createPoiLabelTexture(definition);
+  const labelTexture = createPoiLabelTexture(definition, {
+    textureScale: detailPolicy.textures.poiLabelScale,
+  });
   const labelMaterial = new MeshBasicMaterial({
     map: labelTexture,
     transparent: true,
@@ -287,7 +316,7 @@ function createPedestalPoiInstance(
   const haloGeometry = new RingGeometry(
     haloInnerRadius,
     haloOuterRadius,
-    48,
+    detailPolicy.geometry.ringSegments,
     1
   );
   const haloBaseColor = new Color(0x4bd8ff);
@@ -304,12 +333,14 @@ function createPedestalPoiInstance(
   halo.rotation.x = -Math.PI / 2;
   halo.position.y = scalePoiValue(0.08);
   halo.renderOrder = 11;
-  group.add(halo);
+  if (detailPolicy.effects.decorativeHalos) {
+    group.add(halo);
+  }
 
   const visitedRingGeometry = new RingGeometry(
     haloInnerRadius * 0.92,
     haloOuterRadius * 1.05,
-    60,
+    detailPolicy.geometry.ringSegments,
     1
   );
   const visitedRingMaterial = new MeshBasicMaterial({
@@ -326,7 +357,9 @@ function createPedestalPoiInstance(
   visitedRing.renderOrder = 10;
   visitedRing.visible = false;
   visitedRing.scale.setScalar(1);
-  group.add(visitedRing);
+  if (detailPolicy.effects.decorativeHalos) {
+    group.add(visitedRing);
+  }
 
   const hitAreaHeight = baseHeight + pedestalHeight + scalePoiValue(0.24);
   const hitAreaRadius = Math.max(baseRadiusX, pedestalRadius);
@@ -334,7 +367,7 @@ function createPedestalPoiInstance(
     hitAreaRadius,
     hitAreaRadius,
     hitAreaHeight,
-    32
+    Math.max(8, detailPolicy.geometry.cylinderSegments)
   );
   const hitAreaMaterial = new MeshBasicMaterial({
     transparent: true,
@@ -367,8 +400,10 @@ function createPedestalPoiInstance(
     labelBaseHeight,
     labelWorldPosition: new Vector3(),
     floatPhase: phaseOffset,
-    floatSpeed: MathUtils.randFloat(0.8, 1.1),
-    floatAmplitude: MathUtils.randFloat(0.12, 0.18) * scalePoiValue(1),
+    floatSpeed: isPerformance ? 0 : MathUtils.randFloat(0.8, 1.1),
+    floatAmplitude: isPerformance
+      ? 0
+      : MathUtils.randFloat(0.12, 0.18) * scalePoiValue(1),
     halo,
     haloMaterial,
     accentMaterial,
@@ -456,22 +491,29 @@ function createDisplayPoiInstance(
 }
 
 export function createPoiLabelTexture(
-  definition: PoiDefinition
+  definition: PoiDefinition,
+  options: { textureScale?: number } = {}
 ): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 640;
-  canvas.height = 192;
+  const textureScale = MathUtils.clamp(options.textureScale ?? 1, 0.25, 1);
+  const logicalWidth = 640;
+  const logicalHeight = 192;
+  canvas.width = Math.round(logicalWidth * textureScale);
+  canvas.height = Math.round(logicalHeight * textureScale);
   const context = canvas.getContext('2d');
   if (!context) {
     throw new Error('Unable to acquire 2D context for POI label.');
   }
 
-  context.clearRect(0, 0, canvas.width, canvas.height);
+  if (typeof context.scale === 'function') {
+    context.scale(textureScale, textureScale);
+  }
+  context.clearRect(0, 0, logicalWidth, logicalHeight);
   const gradient = context.createLinearGradient(
     0,
     0,
-    canvas.width,
-    canvas.height
+    logicalWidth,
+    logicalHeight
   );
   gradient.addColorStop(0, 'rgba(33, 108, 255, 0.92)');
   gradient.addColorStop(1, 'rgba(20, 188, 255, 0.55)');
@@ -484,8 +526,8 @@ export function createPoiLabelTexture(
     context,
     padding,
     padding,
-    canvas.width - padding * 2,
-    canvas.height - padding * 2,
+    logicalWidth - padding * 2,
+    logicalHeight - padding * 2,
     18
   );
   context.fill();
@@ -498,9 +540,9 @@ export function createPoiLabelTexture(
   wrapText(
     context,
     definition.title,
-    canvas.width / 2,
-    canvas.height / 2,
-    canvas.width - padding * 3,
+    logicalWidth / 2,
+    logicalHeight / 2,
+    logicalWidth - padding * 3,
     68,
     2
   );

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -18,6 +18,11 @@ import {
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
 
@@ -32,6 +37,8 @@ export interface FlywheelShowpieceOptions {
   centerZ: number;
   roomBounds: Bounds2D;
   orientationRadians?: number;
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface AutomationPillar {
@@ -44,6 +51,9 @@ interface AutomationPillar {
 export function createFlywheelShowpiece(
   options: FlywheelShowpieceOptions
 ): FlywheelShowpieceBuild {
+  const detailPolicy =
+    options.detailPolicy ??
+    getSceneDetailPolicy(options.detailLevel ?? 'balanced');
   const group = new Group();
   group.name = 'FlywheelShowpiece';
 
@@ -102,6 +112,71 @@ export function createFlywheelShowpiece(
       group.removeEventListener('removed', handleRemoval);
     };
     group.addEventListener('removed', handleRemoval);
+  }
+
+  if (detailPolicy.level === 'performance') {
+    const proxyRadius = 1.1;
+    const proxyHeight = 0.2;
+    const proxy = new Mesh(
+      new CylinderGeometry(
+        proxyRadius,
+        proxyRadius,
+        proxyHeight,
+        detailPolicy.geometry.cylinderSegments
+      ),
+      new MeshStandardMaterial({
+        color: new Color(0x14202c),
+        emissive: new Color(0x153a4f),
+        emissiveIntensity: 0.35,
+        roughness: 0.62,
+        metalness: 0.12,
+      })
+    );
+    proxy.name = 'FlywheelPerformanceProxy';
+    proxy.position.set(options.centerX, proxyHeight / 2, options.centerZ);
+    proxy.rotation.y = options.orientationRadians ?? 0;
+    group.add(proxy);
+    const rotor = new Mesh(
+      new TorusGeometry(
+        0.56,
+        0.04,
+        detailPolicy.geometry.torusRadialSegments,
+        detailPolicy.geometry.torusTubularSegments
+      ),
+      new MeshStandardMaterial({
+        color: new Color(0x4cd0ff),
+        emissive: new Color(0x1a8bb5),
+        emissiveIntensity: 0.55,
+        roughness: 0.34,
+        metalness: 0.38,
+      })
+    );
+    rotor.name = 'FlywheelPerformanceRotor';
+    rotor.position.set(options.centerX, 0.72, options.centerZ);
+    rotor.rotation.x = Math.PI / 2;
+    group.add(rotor);
+    colliders.push({
+      minX: options.centerX - proxyRadius,
+      maxX: options.centerX + proxyRadius,
+      minZ: options.centerZ - proxyRadius,
+      maxZ: options.centerZ + proxyRadius,
+    });
+    return {
+      group,
+      colliders,
+      update(context) {
+        const smoothing =
+          context.delta > 0 ? 1 - Math.exp(-context.delta * 3.8) : 1;
+        selectionStrength = MathUtils.lerp(
+          selectionStrength,
+          selectionTarget,
+          smoothing
+        );
+        if (Math.max(context.emphasis, selectionStrength) > 0.4) {
+          rotor.rotation.z += context.delta * 0.4;
+        }
+      },
+    } satisfies FlywheelShowpieceBuild;
   }
 
   const daisRadius = 1.45;

--- a/src/scene/structures/greenhouse.ts
+++ b/src/scene/structures/greenhouse.ts
@@ -6,6 +6,7 @@ import {
   Group,
   MathUtils,
   Mesh,
+  MeshBasicMaterial,
   MeshPhysicalMaterial,
   MeshStandardMaterial,
   PlaneGeometry,
@@ -20,6 +21,11 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 export interface GreenhouseConfig {
   basePosition: Vector3;
@@ -28,6 +34,8 @@ export interface GreenhouseConfig {
   depth?: number;
   environmentMap?: Texture | null;
   environmentIntensity?: number;
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface GreenhouseBuild {
@@ -46,6 +54,10 @@ const BASE_HEIGHT = 0.18;
 const SOLAR_BASE_TILT = -MathUtils.degToRad(18);
 
 export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
+  const detailPolicy =
+    config.detailPolicy ??
+    getSceneDetailPolicy(config.detailLevel ?? 'balanced');
+  const isPerformance = detailPolicy.level === 'performance';
   const width = config.width ?? DEFAULT_WIDTH;
   const depth = config.depth ?? DEFAULT_DEPTH;
   const orientation = config.orientationRadians ?? 0;
@@ -193,15 +205,23 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   roofBeamRight.rotation.z = -roofBeamLeft.rotation.z;
   frameGroup.add(roofBeamRight);
 
-  const glassMaterial = new MeshPhysicalMaterial({
-    color: new Color(0x9cd6ff),
-    transparent: true,
-    opacity: 0.28,
-    roughness: 0.1,
-    metalness: 0.0,
-    transmission: 0.86,
-    thickness: 0.18,
-  });
+  const glassMaterial = detailPolicy.effects.physicalGlass
+    ? new MeshPhysicalMaterial({
+        color: new Color(0x9cd6ff),
+        transparent: true,
+        opacity: 0.28,
+        roughness: 0.1,
+        metalness: 0.0,
+        transmission: 0.86,
+        thickness: 0.18,
+      })
+    : new MeshStandardMaterial({
+        color: new Color(0x9cd6ff),
+        transparent: true,
+        opacity: 0.18,
+        roughness: 0.55,
+        metalness: 0.0,
+      });
   applyEnvironmentMap(glassMaterial);
 
   const wallGeometry = new PlaneGeometry(
@@ -337,12 +357,13 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     outerColor: { value: new Color(0x082b3e) },
   };
 
-  const pondRippleMaterial = new ShaderMaterial({
-    uniforms: pondRippleUniforms,
-    blending: AdditiveBlending,
-    transparent: true,
-    depthWrite: false,
-    vertexShader: `
+  const pondRippleMaterial = detailPolicy.effects.transparentShaders
+    ? new ShaderMaterial({
+        uniforms: pondRippleUniforms,
+        blending: AdditiveBlending,
+        transparent: true,
+        depthWrite: false,
+        vertexShader: `
       varying vec2 vUv;
 
       void main() {
@@ -350,7 +371,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
-    fragmentShader: `
+        fragmentShader: `
       uniform float time;
       uniform float amplitude;
       uniform float brightness;
@@ -393,7 +414,13 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
         gl_FragColor = vec4(baseColor, alpha);
       }
     `,
-  });
+      })
+    : new MeshBasicMaterial({
+        color: new Color(0x155266),
+        transparent: true,
+        opacity: 0.28,
+        depthWrite: false,
+      });
 
   const pondRipple = new Mesh(
     new PlaneGeometry(depth * 0.36, depth * 0.36),
@@ -446,7 +473,12 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   });
 
   const growLightMaterials: MeshStandardMaterial[] = [];
-  const growLightGeometry = new CylinderGeometry(0.05, 0.05, width * 0.32, 12);
+  const growLightGeometry = new CylinderGeometry(
+    0.05,
+    0.05,
+    width * 0.32,
+    detailPolicy.geometry.cylinderSegments
+  );
   const growLightSpacing = depth * 0.38;
   [-growLightSpacing, 0, growLightSpacing].forEach((offsetZ, index) => {
     const lightMaterial = new MeshStandardMaterial({
@@ -465,6 +497,9 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   });
 
   const update = ({ elapsed }: { elapsed: number; delta: number }) => {
+    if (isPerformance) {
+      return;
+    }
     const pulseScale = MathUtils.clamp(getPulseScale(), 0, 1);
     const flickerScale = MathUtils.clamp(getFlickerScale(), 0, 1);
     const calmScale = Math.min(pulseScale, flickerScale);

--- a/src/scene/structures/jobbotTerminal.ts
+++ b/src/scene/structures/jobbotTerminal.ts
@@ -15,6 +15,11 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 export interface JobbotTerminalBuild {
   group: Group;
@@ -35,6 +40,8 @@ export interface JobbotTerminalOptions {
     width?: number;
     depth?: number;
   };
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface DataShardState {
@@ -46,54 +53,59 @@ interface DataShardState {
   orbitSpeed: number;
 }
 
-function createTerminalScreenTexture(): CanvasTexture {
+function createTerminalScreenTexture(textureScale = 1): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 2048;
-  canvas.height = 1024;
+  const logicalWidth = 2048;
+  const logicalHeight = 1024;
+  canvas.width = Math.round(logicalWidth * textureScale);
+  canvas.height = Math.round(logicalHeight * textureScale);
   const context = canvas.getContext('2d');
 
   if (context) {
+    if (typeof context.scale === 'function') {
+      context.scale(textureScale, textureScale);
+    }
     context.fillStyle = '#07111f';
-    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillRect(0, 0, logicalWidth, logicalHeight);
 
     const background = context.createLinearGradient(
       0,
       0,
-      canvas.width,
-      canvas.height
+      logicalWidth,
+      logicalHeight
     );
     background.addColorStop(0, '#0d253f');
     background.addColorStop(0.6, '#10203a');
     background.addColorStop(1, '#0c1728');
     context.fillStyle = background;
-    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillRect(0, 0, logicalWidth, logicalHeight);
 
     context.fillStyle = '#7cf1ff';
     context.font = 'bold 220px "Inter", "Segoe UI", sans-serif';
     context.textAlign = 'left';
     context.textBaseline = 'alphabetic';
-    context.fillText('jobbot3000', canvas.width * 0.08, canvas.height * 0.46);
+    context.fillText('jobbot3000', logicalWidth * 0.08, logicalHeight * 0.46);
 
     context.font = '64px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#9ce9ff';
     context.fillText(
       'Automation orchestrator · live diagnostics stream',
-      canvas.width * 0.08,
-      canvas.height * 0.68
+      logicalWidth * 0.08,
+      logicalHeight * 0.68
     );
 
     context.font = '52px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#fede72';
     context.fillText(
       'Status: nominal · queue depth 0 · SLA 99.98%',
-      canvas.width * 0.08,
-      canvas.height * 0.82
+      logicalWidth * 0.08,
+      logicalHeight * 0.82
     );
 
-    const rightColumnX = canvas.width * 0.7;
+    const rightColumnX = logicalWidth * 0.7;
     context.font = '600 56px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#ffffff';
-    context.fillText('Ops timeline', rightColumnX, canvas.height * 0.32);
+    context.fillText('Ops timeline', rightColumnX, logicalHeight * 0.32);
 
     context.font = '42px "Inter", "Segoe UI", sans-serif';
     context.fillStyle = '#b6d8ff';
@@ -103,7 +115,7 @@ function createTerminalScreenTexture(): CanvasTexture {
       '• 05:38 · queue drained',
     ];
     logLines.forEach((line, index) => {
-      context.fillText(line, rightColumnX, canvas.height * (0.4 + index * 0.1));
+      context.fillText(line, rightColumnX, logicalHeight * (0.4 + index * 0.1));
     });
   }
 
@@ -116,18 +128,24 @@ function createTerminalScreenTexture(): CanvasTexture {
 function createTelemetryPanelTexture(
   heading: string,
   primary: string,
-  metrics: string[]
+  metrics: string[],
+  textureScale = 1
 ): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 1024;
-  canvas.height = 512;
+  const logicalWidth = 1024;
+  const logicalHeight = 512;
+  canvas.width = Math.round(logicalWidth * textureScale);
+  canvas.height = Math.round(logicalHeight * textureScale);
   const context = canvas.getContext('2d');
 
   if (!context) {
     throw new Error('Unable to create telemetry panel canvas.');
   }
 
-  context.clearRect(0, 0, canvas.width, canvas.height);
+  if (typeof context.scale === 'function') {
+    context.scale(textureScale, textureScale);
+  }
+  context.clearRect(0, 0, logicalWidth, logicalHeight);
   context.fillStyle = 'rgba(5, 18, 32, 0.9)';
   context.fillRect(48, 48, canvas.width - 96, canvas.height - 96);
 
@@ -205,6 +223,14 @@ export function createJobbotTerminal(
   options: JobbotTerminalOptions
 ): JobbotTerminalBuild {
   const { position, orientationRadians = 0, desk } = options;
+  const detailPolicy =
+    options.detailPolicy ??
+    getSceneDetailPolicy(options.detailLevel ?? 'balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
+  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
+  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
+  const textureScale = detailPolicy.textures.canvasScale;
   const baseY = position.y ?? 0;
   const deskWidth = desk?.width ?? 3.6;
   const deskDepth = desk?.depth ?? 1.6;
@@ -283,7 +309,7 @@ export function createJobbotTerminal(
   );
   group.add(accent);
 
-  const screenTexture = createTerminalScreenTexture();
+  const screenTexture = createTerminalScreenTexture(textureScale);
   const screenMaterial = new MeshBasicMaterial({
     map: screenTexture,
     transparent: true,
@@ -335,7 +361,12 @@ export function createJobbotTerminal(
   ticker.renderOrder = 7;
   group.add(ticker);
 
-  const hologramBaseGeometry = new CylinderGeometry(0.42, 0.5, 0.18, 48);
+  const hologramBaseGeometry = new CylinderGeometry(
+    0.42,
+    0.5,
+    0.18,
+    cylinderSegments
+  );
   const hologramBaseMaterial = new MeshStandardMaterial({
     color: new Color(0x152335),
     emissive: new Color(0x1b5dff),
@@ -365,7 +396,14 @@ export function createJobbotTerminal(
     depthWrite: false,
     toneMapped: false,
   });
-  const hologramGeometry = new CylinderGeometry(0.12, 0.4, 0.8, 36, 1, true);
+  const hologramGeometry = new CylinderGeometry(
+    0.12,
+    0.4,
+    0.8,
+    cylinderSegments,
+    1,
+    true
+  );
   const hologram = new Mesh(hologramGeometry, hologramMaterial);
   hologram.position.y = 0.3;
   hologramGroup.add(hologram);
@@ -377,7 +415,11 @@ export function createJobbotTerminal(
     roughness: 0.2,
     metalness: 0.45,
   });
-  const hologramCoreGeometry = new SphereGeometry(0.18, 32, 32);
+  const hologramCoreGeometry = new SphereGeometry(
+    0.18,
+    sphereWidthSegments,
+    sphereHeightSegments
+  );
   const hologramCore = new Mesh(hologramCoreGeometry, hologramCoreMaterial);
   hologramCore.name = 'JobbotTerminalCore';
   hologramCore.position.set(0, 0.55, 0);
@@ -461,7 +503,8 @@ export function createJobbotTerminal(
     const texture = createTelemetryPanelTexture(
       descriptor.heading,
       descriptor.primary,
-      descriptor.metrics
+      descriptor.metrics,
+      textureScale
     );
     const material = new MeshBasicMaterial({
       map: texture,
@@ -509,7 +552,11 @@ export function createJobbotTerminal(
   telemetryAura.renderOrder = 2;
   group.add(telemetryAura);
 
-  const statusBeaconGeometry = new SphereGeometry(0.08, 24, 24);
+  const statusBeaconGeometry = new SphereGeometry(
+    0.08,
+    sphereWidthSegments,
+    sphereHeightSegments
+  );
   const statusBeaconMaterial = new MeshStandardMaterial({
     color: new Color(0x1a2f40),
     emissive: new Color(0x3cb6ff),
@@ -630,6 +677,9 @@ export function createJobbotTerminal(
       const shardSpinScale = pulseScale <= 0 ? 0 : Math.max(spinScale, 0.15);
       const shardAmplitudeScale =
         pulseScale <= 0 ? 0 : MathUtils.lerp(0.4, 1, combinedEmphasis);
+      if (isPerformance && combinedEmphasis < 0.35) {
+        return;
+      }
       dataShards.forEach((shard, index) => {
         shard.orbitAngle +=
           delta * shard.orbitSpeed * shardOrbitDriver * shardSpinScale;
@@ -689,6 +739,9 @@ export function createJobbotTerminal(
       telemetryGroup.position.y =
         telemetryBaseHeight + bob * MathUtils.lerp(0.26, 0.6, pulseScale);
 
+      if (isPerformance && combinedEmphasis < 0.35) {
+        return;
+      }
       telemetryPanelMaterials.forEach((material, index) => {
         const wave = (Math.sin(elapsed * 2.6 + index) + 1) / 2;
         const driver = MathUtils.lerp(

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -18,6 +18,11 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
@@ -30,6 +35,8 @@ const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
 
 interface MediaWallScreenRendererOptions {
   starCount: number;
+  textureScale?: number;
+  redrawThrottleMs?: number;
 }
 
 class MediaWallScreenRenderer {
@@ -38,11 +45,18 @@ class MediaWallScreenRenderer {
   private readonly texture: CanvasTexture;
   private highlight = 0;
   private starCount: number;
+  private readonly logicalWidth = SCREEN_WIDTH;
+  private readonly logicalHeight = SCREEN_HEIGHT;
+  private readonly textureScale: number;
+  private readonly redrawThrottleMs: number;
+  private lastRenderMs = Number.NEGATIVE_INFINITY;
 
   constructor(options: MediaWallScreenRendererOptions) {
     const canvas = document.createElement('canvas');
-    canvas.width = SCREEN_WIDTH;
-    canvas.height = SCREEN_HEIGHT;
+    this.textureScale = MathUtils.clamp(options.textureScale ?? 1, 0.25, 1);
+    this.redrawThrottleMs = Math.max(0, options.redrawThrottleMs ?? 0);
+    canvas.width = Math.round(SCREEN_WIDTH * this.textureScale);
+    canvas.height = Math.round(SCREEN_HEIGHT * this.textureScale);
     const context = canvas.getContext('2d');
 
     if (!context) {
@@ -55,7 +69,7 @@ class MediaWallScreenRenderer {
     this.texture.colorSpace = SRGBColorSpace;
     this.starCount = options.starCount;
 
-    this.render();
+    this.render(true);
   }
 
   getTexture(): CanvasTexture {
@@ -68,7 +82,7 @@ class MediaWallScreenRenderer {
     } else {
       this.starCount = count;
     }
-    this.render();
+    this.render(true);
   }
 
   updateHighlight(target: number) {
@@ -77,16 +91,24 @@ class MediaWallScreenRenderer {
       return;
     }
     this.highlight = clamped;
-    this.render();
+    this.render(true);
   }
 
   dispose() {
     this.texture.dispose();
   }
 
-  private render() {
+  private render(force = false) {
+    const now = typeof performance === 'undefined' ? 0 : performance.now();
+    if (!force && now - this.lastRenderMs < this.redrawThrottleMs) {
+      return;
+    }
+    this.lastRenderMs = now;
     this.context.save();
-    this.context.clearRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    if (typeof this.context.scale === 'function') {
+      this.context.scale(this.textureScale, this.textureScale);
+    }
+    this.context.clearRect(0, 0, this.logicalWidth, this.logicalHeight);
     this.drawBase();
     this.drawStarHighlight();
     this.context.restore();
@@ -444,9 +466,18 @@ function createMediaWallController({
   };
 }
 
+export interface LivingRoomMediaWallOptions {
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
+}
+
 export function createLivingRoomMediaWall(
-  bounds: Bounds2D
+  bounds: Bounds2D,
+  options: LivingRoomMediaWallOptions = {}
 ): LivingRoomMediaWallBuild {
+  const detailPolicy =
+    options.detailPolicy ??
+    getSceneDetailPolicy(options.detailLevel ?? 'balanced');
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
   const colliders: RectCollider[] = [];
@@ -695,7 +726,7 @@ export function createLivingRoomMediaWall(
     clearanceBaseColor,
     clearanceHighlightColor,
   });
-  controller.setStarCount(1280);
+  controller.setStarCount(detailPolicy.level === 'performance' ? 160 : 1280);
 
   return { group, colliders, poiBindings, controller };
 }

--- a/src/scene/structures/modelRocket.ts
+++ b/src/scene/structures/modelRocket.ts
@@ -16,11 +16,18 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
 
 export interface ModelRocketConfig {
   basePosition: Vector3;
   orientationRadians?: number;
   scale?: number;
+  detailLevel?: SceneDetailLevel;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface ModelRocketBuild {
@@ -33,6 +40,11 @@ const DEFAULT_SCALE = 1;
 const FIN_COUNT = 3;
 
 export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
+  const detailPolicy =
+    config.detailPolicy ??
+    getSceneDetailPolicy(config.detailLevel ?? 'balanced');
+  const isPerformance = detailPolicy.level === 'performance';
+  const segments = detailPolicy.geometry.cylinderSegments;
   const scale = config.scale ?? DEFAULT_SCALE;
   const orientation = config.orientationRadians ?? 0;
   const basePosition = config.basePosition.clone();
@@ -48,7 +60,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius,
     standRadius,
     standHeight,
-    32
+    segments
   );
   const standMaterial = new MeshStandardMaterial({
     color: new Color(0x2c3442),
@@ -64,7 +76,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius * 0.98,
     standRadius * 1.04,
     standHeight * 0.38,
-    32
+    segments
   );
   const standTrimMaterial = new MeshStandardMaterial({
     color: new Color(0x39475b),
@@ -84,7 +96,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.02,
     bodyRadius * 0.94,
     bodyHeight,
-    40
+    segments
   );
   const bodyMaterial = new MeshStandardMaterial({
     color: new Color(0xe7eefc),
@@ -103,7 +115,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.06,
     bodyRadius * 1.06,
     stripeHeight,
-    40
+    segments
   );
   const stripeMaterial = new MeshStandardMaterial({
     color: new Color(0xff6b6b),
@@ -118,7 +130,11 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   group.add(stripe);
 
   const noseHeight = 1.1 * scale;
-  const noseGeometry = new ConeGeometry(bodyRadius * 0.92, noseHeight, 40);
+  const noseGeometry = new ConeGeometry(
+    bodyRadius * 0.92,
+    noseHeight,
+    segments
+  );
   const noseMaterial = new MeshStandardMaterial({
     color: new Color(0xff8976),
     emissive: new Color(0xb33a2d),
@@ -159,7 +175,9 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   );
   thrusterLight.name = 'ModelRocketThrusterLight';
   thrusterLight.position.set(0, standHeight + thrusterHeight * 0.24, 0);
-  group.add(thrusterLight);
+  if (detailPolicy.effects.dynamicPointLights) {
+    group.add(thrusterLight);
+  }
 
   const flameGeometry = new ConeGeometry(
     bodyRadius * 0.42,
@@ -259,6 +277,9 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   const thrusterLightBaseDistance = thrusterLight.distance;
 
   const update = ({ elapsed }: { elapsed: number; delta: number }) => {
+    if (isPerformance) {
+      return;
+    }
     const pulseScale = MathUtils.clamp(getPulseScale(), 0, 1);
     const thrusterPulse =
       ((Math.sin(elapsed * 2.1) + 1) / 2) * MathUtils.lerp(0.45, 1, pulseScale);

--- a/src/tests/mannequinDetail.test.ts
+++ b/src/tests/mannequinDetail.test.ts
@@ -1,0 +1,60 @@
+import { Box3, CylinderGeometry, Mesh, SphereGeometry, Vector3 } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  PORTFOLIO_MANNEQUIN_VISUAL_HEIGHT,
+  createPortfolioMannequin,
+} from '../scene/avatar/mannequin';
+
+function findFirstGeometry<T extends CylinderGeometry | SphereGeometry>(
+  root: Mesh | import('three').Object3D,
+  predicate: (geometry: unknown) => geometry is T
+): T | null {
+  let found: T | null = null;
+  root.traverse((object) => {
+    if (found || !(object instanceof Mesh)) {
+      return;
+    }
+    const geometry = object.geometry;
+    if (predicate(geometry)) {
+      found = geometry;
+    }
+  });
+  return found;
+}
+
+describe('portfolio mannequin scene detail', () => {
+  it('keeps collision radius and visual height stable in performance detail', () => {
+    const balanced = createPortfolioMannequin({
+      collisionRadius: 0.75,
+      detailLevel: 'balanced',
+    });
+    const performance = createPortfolioMannequin({
+      collisionRadius: 0.75,
+      detailLevel: 'performance',
+    });
+
+    const balancedSphere = findFirstGeometry(
+      balanced.group,
+      (geometry): geometry is SphereGeometry =>
+        geometry instanceof SphereGeometry
+    );
+    const performanceSphere = findFirstGeometry(
+      performance.group,
+      (geometry): geometry is SphereGeometry =>
+        geometry instanceof SphereGeometry
+    );
+    const balancedBounds = new Box3().setFromObject(balanced.group);
+    const performanceBounds = new Box3().setFromObject(performance.group);
+
+    expect(performance.collisionRadius).toBe(balanced.collisionRadius);
+    expect(performance.height).toBe(PORTFOLIO_MANNEQUIN_VISUAL_HEIGHT);
+    expect(performanceBounds.getSize(new Vector3()).y).toBeCloseTo(
+      balancedBounds.getSize(new Vector3()).y,
+      1
+    );
+    expect(performanceSphere?.parameters.widthSegments).toBeLessThan(
+      balancedSphere?.parameters.widthSegments ?? 0
+    );
+  });
+});

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -20,6 +20,13 @@ describe('performance diagnostics', () => {
         viewport: { width: 1280, height: 720 },
         drawingBuffer: { width: 1600, height: 900 },
       }),
+      getRendererRuntimeInfo: () => ({
+        calls: 42,
+        triangles: 12000,
+        points: 128,
+        lines: 16,
+        memory: { geometries: 70, textures: 12 },
+      }),
       getQualityState: () => ({
         level: 'balanced',
         selectionSource: 'adaptive',
@@ -77,6 +84,13 @@ describe('performance diagnostics', () => {
     expect(snapshot.minFps).toBeCloseTo(10, 0);
     expect(snapshot.sampleCount).toBe(3);
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
+    expect(snapshot.rendererRuntime).toMatchObject({
+      calls: 42,
+      triangles: 12000,
+      points: 128,
+      lines: 16,
+      memory: { geometries: 70, textures: 12 },
+    });
     expect(snapshot.softwareRendererPolicy.safeMode).toBe(false);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { GraphicsQualityLevel } from '../scene/graphics/qualityManager';
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import {
   createAdaptiveQualityController,
   type AdaptiveQualitySelectionSource,
@@ -137,6 +138,19 @@ describe('immersive performance optimization policy', () => {
     expect(normal.mirrorEnabled).toBe(true);
   });
 
+  it('starts constrained coarse-pointer tablet sessions in performance when no preference exists', () => {
+    const policy = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      resolveSoftwareRendererPolicy({ isDangerousSoftwareRenderer: false }, ''),
+      { coarsePointer: true, tabletLike: true, deviceMemoryGb: 4 }
+    );
+
+    expect(policy.initialLevel).toBe('performance');
+    expect(policy.mirrorEnabled).toBe(false);
+    expect(policy.reason).toContain('mobile/tablet');
+  });
+
   it('chooses ultra-low DPR and capped cadence for dangerous software safe mode', () => {
     const policy = resolveSoftwareRendererPolicy(
       { isDangerousSoftwareRenderer: true },
@@ -261,6 +275,28 @@ describe('immersive performance optimization policy', () => {
       mirrorUpdateRateFps: 15,
       mirrorTargetSize: 512,
     });
+  });
+
+  it('maps graphics quality levels to centralized scene detail budgets', () => {
+    const balanced = getSceneDetailPolicy('balanced');
+    const performance = getSceneDetailPolicy('performance');
+
+    expect(performance.level).toBe('performance');
+    expect(performance.effects.transparentShaders).toBe(false);
+    expect(performance.effects.dynamicPointLights).toBe(false);
+    expect(performance.textures.canvasScale).toBeLessThanOrEqual(0.25);
+    expect(performance.budget.texturePixels).toBeLessThanOrEqual(
+      balanced.budget.texturePixels / 16
+    );
+    expect(performance.budget.shaderEffectWeight).toBeLessThan(
+      balanced.budget.shaderEffectWeight / 10
+    );
+    expect(performance.geometry.cylinderSegments).toBeLessThanOrEqual(
+      balanced.geometry.cylinderSegments / 5
+    );
+    expect(performance.geometry.sphereWidthSegments).toBeLessThanOrEqual(
+      balanced.geometry.sphereWidthSegments / 4
+    );
   });
 
   it('resizes DPR up to the device cap without undoing adaptive downgrades', () => {

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -14,11 +14,7 @@ describe('createPoiInstances', () => {
   let fillTextLog: string[] = [];
 
   let originalGetContext:
-    | ((
-        this: HTMLCanvasElement,
-        contextId: string,
-        ...args: unknown[]
-      ) => CanvasRenderingContext2D | null)
+    | typeof HTMLCanvasElement.prototype.getContext
     | undefined;
 
   beforeAll(() => {
@@ -27,7 +23,7 @@ describe('createPoiInstances', () => {
       this: HTMLCanvasElement,
       contextId: string,
       ...args: unknown[]
-    ): CanvasRenderingContext2D | null {
+    ) {
       if (contextId === '2d') {
         const gradient = {
           addColorStop: () => {
@@ -69,8 +65,9 @@ describe('createPoiInstances', () => {
           fillText: (text: string) => {
             fillTextLog.push(text);
           },
-          measureText: (text: string) => ({ width: text.length * 10 }),
-          createLinearGradient: () => gradient as CanvasGradient,
+          measureText: (text: string) =>
+            ({ width: text.length * 10 }) as TextMetrics,
+          createLinearGradient: () => gradient as unknown as CanvasGradient,
           set lineWidth(_value: number) {
             /* noop */
           },
@@ -93,9 +90,13 @@ describe('createPoiInstances', () => {
         return context as CanvasRenderingContext2D;
       }
       return originalGetContext
-        ? originalGetContext.call(this, contextId, ...args)
+        ? originalGetContext.call(
+            this,
+            contextId as Parameters<typeof originalGetContext>[0],
+            ...(args as [])
+          )
         : null;
-    };
+    } as typeof HTMLCanvasElement.prototype.getContext;
   });
 
   afterAll(() => {
@@ -103,9 +104,7 @@ describe('createPoiInstances', () => {
       HTMLCanvasElement.prototype.getContext = originalGetContext;
     } else {
       delete (
-        HTMLCanvasElement.prototype as {
-          getContext?: typeof originalGetContext;
-        }
+        HTMLCanvasElement.prototype as unknown as { getContext?: unknown }
       ).getContext;
     }
   });
@@ -242,7 +241,7 @@ describe('createPoiInstances', () => {
       5
     );
     expect(instance.orbBaseHeight).toBeGreaterThan(pedestalHeight);
-    expect(instance.labelBaseHeight).toBeGreaterThan(instance.orbBaseHeight);
+    expect(instance.labelBaseHeight).toBeGreaterThan(instance.orbBaseHeight!);
   });
 
   it('keeps default pedestal styling when no hologram config is provided', () => {
@@ -258,6 +257,40 @@ describe('createPoiInstances', () => {
     const hitGeometry = instance.hitArea.geometry as CylinderGeometry;
     expect(hitGeometry.parameters.height).toBeCloseTo(
       scalePoiValue(0.32) + scalePoiValue(0.24),
+      5
+    );
+  });
+  it('uses low-segment performance geometry while preserving hit area colliders', () => {
+    const definition = createDefinition({
+      id: 'flywheel-studio-flywheel',
+      footprint: { width: 2.8, depth: 2.2 },
+      pedestal: {
+        type: 'hologram',
+        height: 1.6,
+        radiusScale: 0.88,
+      },
+    });
+
+    const [balanced] = createPoiInstances(
+      [definition],
+      {},
+      { detailLevel: 'balanced' }
+    );
+    const [performance] = createPoiInstances(
+      [definition],
+      {},
+      { detailLevel: 'performance' }
+    );
+    const balancedHit = balanced.hitArea.geometry as CylinderGeometry;
+    const performanceHit = performance.hitArea.geometry as CylinderGeometry;
+
+    expect(performanceHit.parameters.radialSegments).toBeLessThanOrEqual(8);
+    expect(performanceHit.parameters.radialSegments).toBeLessThan(
+      balancedHit.parameters.radialSegments / 3
+    );
+    expect(performance.collider).toEqual(balanced.collider);
+    expect(performance.hitArea.position.y).toBeCloseTo(
+      balanced.hitArea.position.y,
       5
     );
   });


### PR DESCRIPTION
### Motivation
- Provide a centralized, typed scene detail policy for aggressively lowering geometry, shader, texture, light, and per‑frame decorative costs when `Performance` graphics quality is selected or adaptively reached. 
- Ensure balanced/cinematic modes are unchanged while making Performance mode reach substantially lower theoretical render workload on weak/mobile devices.

### Description
- Add a central scene detail policy and controller in `src/scene/graphics/sceneDetailPolicy.ts` exposing `getSceneDetailPolicy(...)`, `SceneDetailPolicy`, and `createSceneDetailController(...)` to centralize segment counts, texture scales, effect toggles, and update throttles. 
- Wire the scene detail controller into runtime in `src/main.ts`: initial scene detail chosen from device hints (coarse pointer / mobile / tablet / deviceMemory / concurrency), persisted user preference respected, and controller updated on graphics quality changes and adaptive downgrades. 
- Apply `detailPolicy` across expensive builders so `performance` uses low‑poly/low‑effect variants: `src/scene/poi/markers.ts` (much lower cylinder/sphere/ring segments + scaled POI label canvases and throttled uploads), `src/scene/avatar/mannequin.ts` (segment-driven geometries), `src/scene/structures/flywheel.ts` (performance proxy with minimal meshes), `src/scene/structures/jobbotTerminal.ts` (smaller canvases, skip shards/telemetry when cheap), `src/scene/structures/mediaWall.ts` (scaled canvas + redraw throttling), `src/scene/structures/greenhouse.ts`, `src/scene/structures/modelRocket.ts`, and `src/scene/environments/backyard.ts` (disable mist/pond shader layers, simplify glass to cheaper materials, reduce point light intensities). 
- Reduce per‑frame decorative updates by honoring the scene detail controller’s `shouldRunDecorativeUpdate(...)` throttle inside the main update loop. 
- Extend diagnostics in `src/scene/performance/performanceDiagnostics.ts` to include renderer runtime counters (`calls`, `triangles`, `points`, `lines`, `memory.geometries/textures`) and surface them via the existing diagnostics API so `window.portfolio.performance.getSnapshot()` reports scene/detail metrics. 
- Improve `resolveInitialQualityPolicy` in `src/scene/performance/qualityPolicy.ts` to start constrained coarse‑pointer/mobile/tablet sessions in `performance` when no explicit user preference exists. 
- Preserve backward compatibility: Balanced/Cinematic remain visually unchanged except for the small, internal policy-based refactor; where needed, high‑detail builds are created lazily or guarded by policy to avoid regressions. 

### Testing
- Lint and format: ran `npm run format:write` and `npm run lint` (warnings fixed where applicable) and no blocking ESLint errors remained. 
- Typecheck: ran `npm run typecheck` and TypeScript checks passed. 
- Unit tests: ran `npm run test:ci` and focused suites: `npm run test:ci -- src/tests/graphicsQualityManager.test.ts src/tests/performanceOptimization.test.ts src/tests/performanceDiagnostics.test.ts src/tests/poiMarkers.test.ts src/tests/mannequinDetail.test.ts`; Vitest full run succeeded (all unit/integration tests passed locally: 133 files, 934 tests passed). 
- Build & smoke: ran `npm run build` and `npm run smoke`; production build and smoke checks passed. 
- E2E: attempted `npm run test:e2e` (Playwright); initial runs required Playwright browsers and host deps so I installed browsers via `npx playwright install` and host deps via `npx playwright install-deps`; Playwright environment in this runner still reported missing host libraries in some attempts—recommend CI to run `npx playwright install --with-deps` or `npx playwright install-deps` on the runner before e2e to ensure deterministic E2E runs. 

Notes / follow-ups: 
- The change centralizes quality/detail policy to avoid scattering checks; please review `sceneDetailPolicy.ts` for target budget numbers (values chosen to hit the aggressive budget goals but remain adjustable). 
- E2E failures seen were environment/dependency related (Playwright browsers/host libs) and not functional regressions in tests run under Vitest; ensure CI Playwright setup includes browser + OS deps before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1face2e198832fa885ac5102919ab7)