### PR TITLE
Add aggressive low-poly scene-detail policy and apply for Performance graphics mode

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -36,6 +36,29 @@ and the Vitest assertions when measurable changes land.
   run `renderer.info.render` and `renderer.info.memory` after the camera settles
   at launch. Update the snapshot date and notes when refreshing numbers.
 
+## Performance scene detail mode
+
+Performance graphics mode now applies a separate scene-detail policy in addition to DPR,
+bloom, mirror, and LED reductions. The intent is a roughly 10× theoretical workload cut on
+weak tablets and coarse-pointer mobile hardware; it is a budget target for shader/fill-rate,
+texture upload, draw-call, dynamic-light, and triangle pressure, not a guaranteed FPS multiplier
+on every browser or GPU.
+
+The policy is centralized in
+[`getSceneDetailPolicy(...)`](../../src/scene/graphics/sceneDetailPolicy.ts) and wired through
+[`createSceneDetailController(...)`](../../src/scene/graphics/sceneDetailController.ts). Balanced
+and Cinematic keep the original high-detail segment counts, shader effects, transparent auras,
+large canvas textures, and decorative update cadence. Performance mode lowers POI/avatar
+segments, uses smaller Jobbot/media wall canvases, disables backyard mist and greenhouse pond
+ripple shaders, swaps greenhouse transmission glass to cheaper material settings, hides
+nonessential glow/halo groups, disables nonessential point lights, and throttles decorative
+updates.
+
+Diagnostics from `window.portfolio.performance.getSnapshot()` include `rendererInfoCounters`
+for `renderer.info.render` and `renderer.info.memory` values when supported, plus the active
+`quality.sceneDetail` policy so field reports can compare balanced/cinematic complexity against
+Performance-mode budgets.
+
 ## Adaptive quality warmup and recovery
 
 Staging on May 29, 2026 showed two renderer classes that need different

--- a/playwright/immersive-performance.spec.ts
+++ b/playwright/immersive-performance.spec.ts
@@ -29,6 +29,20 @@ interface PerformanceSnapshot {
     lastAdaptiveReason: string | null;
     lastAdaptiveDowngradeReason: string | null;
     lastAdaptiveRecoveryReason: string | null;
+    sceneDetail?: {
+      level: 'cinematic' | 'balanced' | 'performance';
+      theoreticalWorkloadScale: number;
+      segments: { cylinder: number; ring: number; sphereWidth: number };
+      textures: {
+        jobbotScreen: { width: number; height: number };
+        mediaWallScreen: { width: number; height: number };
+      };
+      effects: {
+        shaderMist: boolean;
+        shaderPond: boolean;
+        dynamicPointLights: boolean;
+      };
+    };
     adaptivePolicy: {
       isWarmingUp: boolean;
       warmupElapsedMs: number;
@@ -211,6 +225,46 @@ test.describe('immersive performance diagnostics', () => {
         expect(snapshot.features.composerEnabled).toBe(false);
         expect(snapshot.features.mirrorEnabled).toBe(false);
       }
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('reports capped scene detail budgets when performance mode is forced', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installProductionLikeHints(page);
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'danielsmith:graphics-quality-level',
+        'performance'
+      );
+    });
+
+    try {
+      await waitForImmersive(page, IMMERSIVE_DIAGNOSTICS_URL);
+      const snapshot = await getSnapshot(page);
+      expect(snapshot.quality.level).toBe('performance');
+      expect(snapshot.quality.sceneDetail?.level).toBe('performance');
+      expect(
+        snapshot.quality.sceneDetail?.theoreticalWorkloadScale
+      ).toBeLessThanOrEqual(0.1);
+      expect(
+        snapshot.quality.sceneDetail?.segments.cylinder
+      ).toBeLessThanOrEqual(8);
+      expect(
+        snapshot.quality.sceneDetail?.textures.jobbotScreen.width
+      ).toBeLessThanOrEqual(512);
+      expect(
+        snapshot.quality.sceneDetail?.textures.mediaWallScreen.width
+      ).toBeLessThanOrEqual(512);
+      expect(snapshot.quality.sceneDetail?.effects.shaderMist).toBe(false);
+      expect(snapshot.quality.sceneDetail?.effects.shaderPond).toBe(false);
+      expect(snapshot.quality.sceneDetail?.effects.dynamicPointLights).toBe(
+        false
+      );
     } finally {
       await context.close();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,7 @@ import {
   createGraphicsQualityManager,
   type GraphicsQualityManager,
 } from './scene/graphics/qualityManager';
+import { createSceneDetailController } from './scene/graphics/sceneDetailController';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -733,7 +734,14 @@ function initializeImmersiveScene(
   const initialQualityPolicy = resolveInitialQualityPolicy(
     rendererInfo,
     window.devicePixelRatio ?? 1,
-    softwareRendererPolicy
+    softwareRendererPolicy,
+    {
+      coarsePointer: window.matchMedia?.('(pointer: coarse)').matches ?? false,
+      maxTouchPoints: navigator.maxTouchPoints ?? 0,
+      deviceMemory: (navigator as Navigator & { deviceMemory?: number })
+        .deviceMemory,
+      userAgent: navigator.userAgent,
+    }
   );
   const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
     ? initialQualityPolicy.basePixelRatioCap
@@ -786,6 +794,9 @@ function initializeImmersiveScene(
   let ambientCaptionBridge: AmbientCaptionBridge | null = null;
   let graphicsQualityManager: GraphicsQualityManager | null = null;
   let graphicsQualityControl: GraphicsQualityControlHandle | null = null;
+  const sceneDetailController = createSceneDetailController(
+    initialQualityPolicy.initialLevel
+  );
   let adaptiveQualityController: ReturnType<
     typeof createAdaptiveQualityController
   > | null = null;
@@ -1152,8 +1163,10 @@ function initializeImmersiveScene(
   if (backyardRoom) {
     backyardEnvironment = createBackyardEnvironment(backyardRoom.bounds, {
       seasonalPreset,
+      detailPolicy: sceneDetailController.getPolicy(),
     });
     scene.add(backyardEnvironment.group);
+    sceneDetailController.register(backyardEnvironment.group);
     // Remove the enclosing sky dome to avoid a bright circular spheroid.
     // We want a dark void beyond the property in runtime.
     const skyDome =
@@ -1244,8 +1257,11 @@ function initializeImmersiveScene(
 
   const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom');
   if (livingRoom) {
-    const mediaWall = createLivingRoomMediaWall(livingRoom.bounds);
+    const mediaWall = createLivingRoomMediaWall(livingRoom.bounds, {
+      detailPolicy: sceneDetailController.getPolicy(),
+    });
     scene.add(mediaWall.group);
+    sceneDetailController.register(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
@@ -1547,7 +1563,9 @@ function initializeImmersiveScene(
   });
   lightmapAnimator.captureBaseline();
 
-  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides);
+  const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
+    detailPolicy: sceneDetailController.getPolicy(),
+  });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
       scene.add(poi.group);
@@ -1926,8 +1944,10 @@ function initializeImmersiveScene(
       centerZ,
       roomBounds: studioRoom.bounds,
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
+      detailPolicy: sceneDetailController.getPolicy(),
     });
     scene.add(showpiece.group);
+    sceneDetailController.register(showpiece.group);
     showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     flywheelShowpiece = showpiece;
 
@@ -1945,8 +1965,10 @@ function initializeImmersiveScene(
     const terminal = createJobbotTerminal({
       position: { x: terminalX, y: 0, z: terminalZ },
       orientationRadians: terminalOrientation,
+      detailPolicy: sceneDetailController.getPolicy(),
     });
     scene.add(terminal.group);
+    sceneDetailController.register(terminal.group);
     terminal.colliders.forEach((collider) => groundColliders.push(collider));
     jobbotTerminal = terminal;
 
@@ -2176,6 +2198,7 @@ function initializeImmersiveScene(
 
   const mannequin = createPortfolioMannequin({
     collisionRadius: PLAYER_RADIUS,
+    detailPolicy: sceneDetailController.getPolicy(),
   });
   const player = mannequin.group;
   const mannequinHeight = mannequin.height;
@@ -3774,7 +3797,8 @@ function initializeImmersiveScene(
   const shouldUseComposer = () =>
     !softwareRendererPolicy.safeMode && getActivePostprocessingPassCount() > 0;
 
-  unsubscribeGraphicsQuality = graphicsQualityManager.onChange(() => {
+  unsubscribeGraphicsQuality = graphicsQualityManager.onChange((level) => {
+    sceneDetailController.setLevel(level);
     applyFeaturePolicy();
     composer?.setSize(window.innerWidth, window.innerHeight);
     bloomPass?.setSize(window.innerWidth, window.innerHeight);
@@ -3812,7 +3836,9 @@ function initializeImmersiveScene(
       lastAdaptiveRecoveryReason:
         adaptiveQualityController?.getLastRecoveryReason() ?? null,
       adaptivePolicy: adaptiveQualityController?.getSnapshot() ?? null,
+      sceneDetail: sceneDetailController.getPolicy(),
     }),
+    getRendererInfoCounters: () => renderer.info,
     getFeatureState: () => {
       const mirrorState = selfieMirror?.getRenderState();
       return {
@@ -4708,7 +4734,9 @@ function initializeImmersiveScene(
         performance.now() - phaseStart
       );
       phaseStart = performance.now();
-      if (livingRoomMediaWall) {
+      const runDecorativeUpdate =
+        sceneDetailController.shouldRunDecorativeUpdate(elapsedTime);
+      if (livingRoomMediaWall && runDecorativeUpdate) {
         const activation = futuroptimistPoi?.activation ?? 0;
         const focus = futuroptimistPoi?.focus ?? 0;
         livingRoomMediaWall.controller.update({
@@ -4717,7 +4745,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (flywheelShowpiece) {
+      if (flywheelShowpiece && runDecorativeUpdate) {
         const activation = flywheelPoi?.activation ?? 0;
         const focus = flywheelPoi?.focus ?? 0;
         flywheelShowpiece.update({
@@ -4753,7 +4781,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (jobbotTerminal) {
+      if (jobbotTerminal && runDecorativeUpdate) {
         const activation = jobbotPoi?.activation ?? 0;
         const focus = jobbotPoi?.focus ?? 0;
         jobbotTerminal.update({
@@ -4809,7 +4837,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
-      if (backyardEnvironment) {
+      if (backyardEnvironment && runDecorativeUpdate) {
         backyardEnvironment.update({ elapsed: elapsedTime, delta });
       }
       performanceDiagnostics?.recordPhase(

--- a/src/scene/avatar/mannequin.ts
+++ b/src/scene/avatar/mannequin.ts
@@ -12,6 +12,9 @@ import {
   TorusGeometry,
 } from 'three';
 
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+
 // Deterministic floor-to-crest height used by initial camera framing before assets load.
 export const PORTFOLIO_MANNEQUIN_VISUAL_HEIGHT = 2.6;
 
@@ -32,6 +35,7 @@ export interface PortfolioMannequinOptions {
    * Head and glove color used to suggest skin or fabric contrast.
    */
   trimColor?: string;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface PortfolioMannequinPalette {
@@ -85,6 +89,13 @@ export function createPortfolioMannequin(
   options: PortfolioMannequinOptions = {}
 ): PortfolioMannequinBuild {
   const collisionRadius = options.collisionRadius ?? 0.75;
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const cylinderSegments = detailPolicy.isPerformance ? 8 : 32;
+  const highCylinderSegments = detailPolicy.isPerformance ? 8 : 48;
+  const sphereWidth = detailPolicy.segments.sphereWidth;
+  const sphereHeight = detailPolicy.segments.sphereHeight;
+  const torusRadial = detailPolicy.segments.torusRadial;
+  const torusTubular = detailPolicy.isPerformance ? 12 : 48;
   const initialPalette: PortfolioMannequinPalette = {
     base: options.baseColor ?? '#283347',
     accent: options.accentColor ?? '#57d7ff',
@@ -95,7 +106,7 @@ export function createPortfolioMannequin(
   group.name = 'PortfolioMannequin';
 
   const collisionProxy = new Mesh(
-    new SphereGeometry(collisionRadius, 32, 32),
+    new SphereGeometry(collisionRadius, sphereWidth, sphereHeight),
     new MeshBasicMaterial({ color: 0xffffff })
   );
   collisionProxy.name = 'PortfolioMannequinCollisionProxy';
@@ -116,7 +127,7 @@ export function createPortfolioMannequin(
   );
   const platformHeight = 0.08;
   const platform = new Mesh(
-    new CylinderGeometry(0.58, 0.58, platformHeight, 48),
+    new CylinderGeometry(0.58, 0.58, platformHeight, highCylinderSegments),
     platformMaterial
   );
   platform.name = 'PortfolioMannequinPlatform';
@@ -128,7 +139,7 @@ export function createPortfolioMannequin(
   const legMaterial = createStandardMaterial(new Color(initialPalette.base));
   const legHeight = 0.92;
   const legs = new Mesh(
-    new CylinderGeometry(0.26, 0.3, legHeight, 32),
+    new CylinderGeometry(0.26, 0.3, legHeight, cylinderSegments),
     legMaterial
   );
   legs.name = 'PortfolioMannequinLegs';
@@ -170,7 +181,7 @@ export function createPortfolioMannequin(
   rightFoot.add(rightFootMesh);
 
   const accentBand = new Mesh(
-    new TorusGeometry(0.34, 0.05, 20, 48),
+    new TorusGeometry(0.34, 0.05, torusRadial, torusTubular),
     platformMaterial.clone()
   );
   accentBand.name = 'PortfolioMannequinWaistBand';
@@ -184,7 +195,7 @@ export function createPortfolioMannequin(
 
   const torsoMaterial = createStandardMaterial(new Color(initialPalette.base));
   const torso = new Mesh(
-    new CylinderGeometry(0.46, 0.36, 0.86, 32),
+    new CylinderGeometry(0.46, 0.36, 0.86, cylinderSegments),
     torsoMaterial
   );
   torso.name = 'PortfolioMannequinTorso';
@@ -196,7 +207,12 @@ export function createPortfolioMannequin(
   const shoulderMaterial = createStandardMaterial(
     new Color(initialPalette.base)
   );
-  const armGeometry = new CylinderGeometry(0.16, 0.18, 0.82, 24);
+  const armGeometry = new CylinderGeometry(
+    0.16,
+    0.18,
+    0.82,
+    detailPolicy.isPerformance ? 8 : 24
+  );
 
   const leftArm = new Mesh(armGeometry, shoulderMaterial);
   leftArm.name = 'PortfolioMannequinArmLeft';
@@ -222,7 +238,12 @@ export function createPortfolioMannequin(
     }
   );
   const leftCuff = new Mesh(
-    new TorusGeometry(0.16, 0.035, 14, 32),
+    new TorusGeometry(
+      0.16,
+      0.035,
+      detailPolicy.isPerformance ? 6 : 14,
+      detailPolicy.isPerformance ? 10 : 32
+    ),
     cuffMaterial
   );
   leftCuff.name = 'PortfolioMannequinCuffLeft';
@@ -236,7 +257,12 @@ export function createPortfolioMannequin(
   mannequinRoot.add(rightCuff);
 
   const trimMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const gloveGeometry = new CylinderGeometry(0.18, 0.18, 0.22, 18);
+  const gloveGeometry = new CylinderGeometry(
+    0.18,
+    0.18,
+    0.22,
+    detailPolicy.isPerformance ? 8 : 18
+  );
   const leftGlove = new Mesh(gloveGeometry, trimMaterial);
   leftGlove.name = 'PortfolioMannequinGloveLeft';
   leftGlove.position.set(
@@ -265,7 +291,12 @@ export function createPortfolioMannequin(
     }
   );
   const collar = new Mesh(
-    new TorusGeometry(0.3, 0.045, 16, 36),
+    new TorusGeometry(
+      0.3,
+      0.045,
+      detailPolicy.isPerformance ? 6 : 16,
+      detailPolicy.isPerformance ? 10 : 36
+    ),
     collarMaterial
   );
   collar.name = 'PortfolioMannequinCollar';
@@ -274,7 +305,10 @@ export function createPortfolioMannequin(
   mannequinRoot.add(collar);
 
   const headMaterial = createStandardMaterial(new Color(initialPalette.trim));
-  const head = new Mesh(new SphereGeometry(0.28, 32, 32), headMaterial);
+  const head = new Mesh(
+    new SphereGeometry(0.28, sphereWidth, sphereHeight),
+    headMaterial
+  );
   head.name = 'PortfolioMannequinHead';
   head.position.y = collar.position.y + 0.32;
   head.castShadow = true;
@@ -283,7 +317,11 @@ export function createPortfolioMannequin(
 
   // Add a simple smiley face marker to the front of the head for directionality.
   const faceMaterial = new MeshBasicMaterial({ color: 0x000000 });
-  const eyeGeometry = new SphereGeometry(0.03, 12, 12);
+  const eyeGeometry = new SphereGeometry(
+    0.03,
+    detailPolicy.isPerformance ? 6 : 12,
+    detailPolicy.isPerformance ? 4 : 12
+  );
   const leftEye = new Mesh(eyeGeometry, faceMaterial);
   leftEye.name = 'PortfolioMannequinFaceLeftEye';
   leftEye.position.set(-0.08, head.position.y + 0.06, 0.25);
@@ -296,7 +334,13 @@ export function createPortfolioMannequin(
 
   // Mouth as a thin torus segment to suggest a smile on the front side.
   const mouth = new Mesh(
-    new TorusGeometry(0.09, 0.012, 8, 24, Math.PI),
+    new TorusGeometry(
+      0.09,
+      0.012,
+      detailPolicy.isPerformance ? 4 : 8,
+      detailPolicy.isPerformance ? 8 : 24,
+      Math.PI
+    ),
     faceMaterial
   );
   mouth.name = 'PortfolioMannequinFaceMouth';
@@ -315,7 +359,7 @@ export function createPortfolioMannequin(
   visorMaterial.opacity = 0.72;
   visorMaterial.side = DoubleSide;
   const visor = new Mesh(
-    new CylinderGeometry(0.27, 0.27, 0.16, 32, 1, true),
+    new CylinderGeometry(0.27, 0.27, 0.16, cylinderSegments, 1, true),
     visorMaterial
   );
   visor.name = 'PortfolioMannequinVisor';
@@ -330,7 +374,10 @@ export function createPortfolioMannequin(
       emissiveIntensity: 0.5,
     }
   );
-  const crest = new Mesh(new ConeGeometry(0.12, 0.24, 24), crestMaterial);
+  const crest = new Mesh(
+    new ConeGeometry(0.12, 0.24, detailPolicy.isPerformance ? 8 : 24),
+    crestMaterial
+  );
   crest.name = 'PortfolioMannequinCrest';
   crest.position.y = head.position.y + 0.3;
   mannequinRoot.add(crest);

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -41,6 +41,8 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import {
   applySeasonalLightingPreset,
   type SeasonalLightingPreset,
@@ -299,11 +301,15 @@ function createDuskLightProbe(): LightProbe {
 
 export interface BackyardEnvironmentOptions {
   seasonalPreset?: SeasonalLightingPreset | null;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export function createBackyardEnvironment(
   bounds: Bounds2D,
-  { seasonalPreset = null }: BackyardEnvironmentOptions = {}
+  {
+    seasonalPreset = null,
+    detailPolicy = getSceneDetailPolicy('balanced'),
+  }: BackyardEnvironmentOptions = {}
 ): BackyardEnvironmentBuild {
   const group = new Group();
   group.name = 'BackyardEnvironment';
@@ -324,7 +330,11 @@ export function createBackyardEnvironment(
   group.add(duskLightProbe);
 
   const skyRadius = Math.max(width, depth) * 1.32;
-  const skyGeometry = new SphereGeometry(skyRadius, 48, 48);
+  const skyGeometry = new SphereGeometry(
+    skyRadius,
+    detailPolicy.isPerformance ? 12 : 48,
+    detailPolicy.isPerformance ? 8 : 48
+  );
   skyGeometry.scale(1, 0.62, 1);
   const verticalExtent = skyRadius * 0.62;
 
@@ -498,6 +508,7 @@ export function createBackyardEnvironment(
   const rocket = createModelRocket({
     basePosition: rocketBase,
     orientationRadians: -Math.PI / 10,
+    detailPolicy,
   });
   group.add(rocket.group);
   colliders.push(rocket.collider);
@@ -537,6 +548,7 @@ export function createBackyardEnvironment(
     depth: greenhouseDepth,
     environmentMap: duskReflectionMap,
     environmentIntensity: 0.62,
+    detailPolicy,
   });
   group.add(greenhouse.group);
   greenhouse.colliders.forEach((collider) => colliders.push(collider));
@@ -650,7 +662,7 @@ export function createBackyardEnvironment(
     1
   );
   walkwayMistGeometry.rotateX(-Math.PI / 2);
-  const walkwayMistLayerCount = 3;
+  const walkwayMistLayerCount = detailPolicy.effects.shaderMist ? 3 : 0;
   for (let i = 0; i < walkwayMistLayerCount; i += 1) {
     const ratio = (i + 1) / (walkwayMistLayerCount + 1);
     const baseOpacity = MathUtils.lerp(0.24, 0.38, ratio);
@@ -1591,9 +1603,23 @@ export function createBackyardEnvironment(
   const lanternGroup = new Group();
   lanternGroup.name = 'BackyardWalkwayLanterns';
 
-  const lanternPostGeometry = new CylinderGeometry(0.08, 0.12, 1.1, 12);
-  const lanternCapGeometry = new CylinderGeometry(0.22, 0.22, 0.14, 12);
-  const lanternGlassGeometry = new SphereGeometry(0.3, 16, 16);
+  const lanternPostGeometry = new CylinderGeometry(
+    0.08,
+    0.12,
+    1.1,
+    detailPolicy.isPerformance ? 6 : 12
+  );
+  const lanternCapGeometry = new CylinderGeometry(
+    0.22,
+    0.22,
+    0.14,
+    detailPolicy.isPerformance ? 6 : 12
+  );
+  const lanternGlassGeometry = new SphereGeometry(
+    0.3,
+    detailPolicy.isPerformance ? 8 : 16,
+    detailPolicy.isPerformance ? 6 : 16
+  );
   const lanternPostMaterial = new MeshStandardMaterial({
     color: 0x1b232b,
     roughness: 0.76,
@@ -1652,6 +1678,11 @@ export function createBackyardEnvironment(
       light.name = `BackyardWalkwayLanternLight-${lanternIndex}`;
       light.position.y = 1.05;
       light.color.copy(glassMaterial.emissive);
+      light.userData.sceneDetailDynamicLight = true;
+      if (!detailPolicy.effects.dynamicPointLights) {
+        light.intensity = 0;
+        light.visible = false;
+      }
       lantern.add(light);
 
       const haloMaterial = new MeshBasicMaterial({
@@ -1667,6 +1698,7 @@ export function createBackyardEnvironment(
       halo.position.set(0, 0.02, 0);
       halo.renderOrder = 6;
       halo.scale.setScalar(1);
+      halo.userData.sceneDetailRole = 'decorative-effect';
       lantern.add(halo);
 
       lanternGroup.add(lantern);
@@ -1951,6 +1983,11 @@ export function createBackyardEnvironment(
   );
   duskLight.position.set(centerX - width * 0.18, 2.6, centerZ + depth * 0.18);
   duskLight.castShadow = false;
+  duskLight.userData.sceneDetailDynamicLight = true;
+  if (!detailPolicy.effects.dynamicPointLights) {
+    duskLight.intensity = 0;
+    duskLight.visible = false;
+  }
   group.add(duskLight);
 
   const barrierWidth = Math.min(width * 0.68, 6.5);
@@ -2081,7 +2118,18 @@ export function createBackyardEnvironment(
     );
   });
 
+  let lastPerformanceUpdateMs = Number.NEGATIVE_INFINITY;
   const update = (context: { elapsed: number; delta: number }) => {
+    if (detailPolicy.update.decorativeThrottleMs > 0) {
+      const nowMs = context.elapsed * 1000;
+      if (
+        nowMs - lastPerformanceUpdateMs <
+        detailPolicy.update.decorativeThrottleMs
+      ) {
+        return;
+      }
+      lastPerformanceUpdateMs = nowMs;
+    }
     updates.forEach((fn) => fn(context));
   };
 

--- a/src/scene/graphics/sceneDetailController.ts
+++ b/src/scene/graphics/sceneDetailController.ts
@@ -1,0 +1,91 @@
+import {
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  Object3D,
+  PointLight,
+} from 'three';
+
+import type { GraphicsQualityLevel } from './qualityManager';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from './sceneDetailPolicy';
+
+export interface SceneDetailController {
+  getPolicy(): SceneDetailPolicy;
+  setLevel(level: GraphicsQualityLevel): void;
+  register(root: Object3D): void;
+  shouldRunDecorativeUpdate(elapsedSeconds: number): boolean;
+}
+
+export function createSceneDetailController(
+  initialLevel: GraphicsQualityLevel
+): SceneDetailController {
+  const roots = new Set<Object3D>();
+  let policy = getSceneDetailPolicy(initialLevel);
+  let lastDecorativeUpdateMs = Number.NEGATIVE_INFINITY;
+
+  const applyObject = (object: Object3D) => {
+    const detailRole = object.userData.sceneDetailRole;
+    if (detailRole === 'decorative-effect') {
+      object.visible = policy.effects.transparentAuras;
+    }
+    if (detailRole === 'performance-hidden') {
+      object.visible = !policy.isPerformance;
+    }
+    if (
+      object instanceof PointLight &&
+      object.userData.sceneDetailDynamicLight
+    ) {
+      const baseIntensity = Number(
+        object.userData.sceneDetailBaseIntensity ?? object.intensity
+      );
+      object.userData.sceneDetailBaseIntensity = baseIntensity;
+      object.intensity = policy.effects.dynamicPointLights ? baseIntensity : 0;
+      object.visible = policy.effects.dynamicPointLights;
+    }
+    if ('material' in object) {
+      const material = object.material;
+      const materials = Array.isArray(material) ? material : [material];
+      materials.forEach((entry) => {
+        if (
+          (entry instanceof MeshStandardMaterial ||
+            entry instanceof MeshBasicMaterial) &&
+          entry.userData.sceneDetailTransparentEffect
+        ) {
+          entry.opacity = policy.effects.transparentAuras
+            ? Number(entry.userData.sceneDetailBaseOpacity ?? entry.opacity)
+            : 0;
+          entry.needsUpdate = true;
+        }
+      });
+    }
+  };
+
+  const applyRoot = (root: Object3D) => root.traverse(applyObject);
+
+  return {
+    getPolicy() {
+      return policy;
+    },
+    setLevel(level) {
+      policy = getSceneDetailPolicy(level);
+      roots.forEach(applyRoot);
+    },
+    register(root) {
+      roots.add(root);
+      applyRoot(root);
+    },
+    shouldRunDecorativeUpdate(elapsedSeconds) {
+      if (policy.update.decorativeThrottleMs <= 0) {
+        return true;
+      }
+      const nowMs = elapsedSeconds * 1000;
+      if (nowMs - lastDecorativeUpdateMs < policy.update.decorativeThrottleMs) {
+        return false;
+      }
+      lastDecorativeUpdateMs = nowMs;
+      return true;
+    },
+  };
+}

--- a/src/scene/graphics/sceneDetailPolicy.ts
+++ b/src/scene/graphics/sceneDetailPolicy.ts
@@ -1,0 +1,120 @@
+import type { GraphicsQualityLevel } from './qualityManager';
+
+export type SceneDetailLevel = GraphicsQualityLevel;
+
+export interface SceneDetailPolicy {
+  level: SceneDetailLevel;
+  isPerformance: boolean;
+  /**
+   * Target is theoretical workload reduction, not a guaranteed FPS multiplier
+   * on every browser/GPU. These budgets guide builders and diagnostics.
+   */
+  theoreticalWorkloadScale: number;
+  segments: {
+    cylinder: number;
+    ring: number;
+    sphereWidth: number;
+    sphereHeight: number;
+    torusRadial: number;
+    torusTubular: number;
+    terrainSubdivisions: number;
+  };
+  textures: {
+    jobbotScreen: { width: number; height: number };
+    jobbotTelemetry: { width: number; height: number };
+    mediaWallScreen: { width: number; height: number };
+    mediaWallBadge: { width: number; height: number };
+    poiLabelScale: number;
+  };
+  effects: {
+    transparentAuras: boolean;
+    shaderMist: boolean;
+    shaderPond: boolean;
+    glassTransmission: boolean;
+    decorativeOrbiters: boolean;
+    decorativePanels: boolean;
+    dynamicPointLights: boolean;
+  };
+  update: {
+    decorativeThrottleMs: number;
+    canvasRedrawThrottleMs: number;
+  };
+}
+
+const HIGH_DETAIL_SEGMENTS = {
+  cylinder: 48,
+  ring: 64,
+  sphereWidth: 32,
+  sphereHeight: 32,
+  torusRadial: 24,
+  torusTubular: 64,
+  terrainSubdivisions: 24,
+} as const;
+
+export function getSceneDetailPolicy(
+  level: GraphicsQualityLevel
+): SceneDetailPolicy {
+  if (level === 'performance') {
+    return {
+      level,
+      isPerformance: true,
+      theoreticalWorkloadScale: 0.1,
+      segments: {
+        cylinder: 8,
+        ring: 8,
+        sphereWidth: 8,
+        sphereHeight: 6,
+        torusRadial: 6,
+        torusTubular: 12,
+        terrainSubdivisions: 2,
+      },
+      textures: {
+        jobbotScreen: { width: 512, height: 256 },
+        jobbotTelemetry: { width: 256, height: 128 },
+        mediaWallScreen: { width: 512, height: 256 },
+        mediaWallBadge: { width: 256, height: 128 },
+        poiLabelScale: 0.5,
+      },
+      effects: {
+        transparentAuras: false,
+        shaderMist: false,
+        shaderPond: false,
+        glassTransmission: false,
+        decorativeOrbiters: false,
+        decorativePanels: false,
+        dynamicPointLights: false,
+      },
+      update: {
+        decorativeThrottleMs: 250,
+        canvasRedrawThrottleMs: 1000,
+      },
+    };
+  }
+
+  return {
+    level,
+    isPerformance: false,
+    theoreticalWorkloadScale: level === 'balanced' ? 0.85 : 1,
+    segments: HIGH_DETAIL_SEGMENTS,
+    textures: {
+      jobbotScreen: { width: 2048, height: 1024 },
+      jobbotTelemetry: { width: 1024, height: 512 },
+      mediaWallScreen: { width: 2048, height: 1024 },
+      mediaWallBadge: { width: 512, height: 256 },
+      poiLabelScale: 1,
+    },
+    effects: {
+      transparentAuras: true,
+      shaderMist: true,
+      shaderPond: true,
+      glassTransmission: true,
+      decorativeOrbiters: true,
+      decorativePanels: true,
+      dynamicPointLights: true,
+    },
+    update: {
+      decorativeThrottleMs: 0,
+      canvasRedrawThrottleMs: 0,
+    },
+  };
+}

--- a/src/scene/performance/performanceDiagnostics.ts
+++ b/src/scene/performance/performanceDiagnostics.ts
@@ -2,6 +2,7 @@ import type {
   GraphicsQualityLevel,
   GraphicsQualitySelectionSource,
 } from '../graphics/qualityManager';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 import type { AdaptiveQualityPolicySnapshot } from './adaptiveQuality';
 import type { SoftwareRendererPolicyState } from './qualityPolicy';
@@ -22,6 +23,15 @@ export interface RendererSizeSnapshot {
   drawingBuffer: { width: number; height: number };
 }
 
+export interface RendererInfoCountersSnapshot {
+  calls: number | null;
+  triangles: number | null;
+  points: number | null;
+  lines: number | null;
+  geometries: number | null;
+  textures: number | null;
+}
+
 export interface QualityStateSnapshot {
   level: GraphicsQualityLevel;
   selectionSource: GraphicsQualitySelectionSource;
@@ -31,6 +41,7 @@ export interface QualityStateSnapshot {
   lastAdaptiveDowngradeReason: string | null;
   lastAdaptiveRecoveryReason: string | null;
   adaptivePolicy: AdaptiveQualityPolicySnapshot | null;
+  sceneDetail?: SceneDetailPolicy;
 }
 
 export interface FeatureStateSnapshot {
@@ -57,6 +68,7 @@ export interface FrameStatsSnapshot {
 
 export interface PerformanceDiagnosticsSnapshot extends FrameStatsSnapshot {
   renderer: RendererInfoSnapshot;
+  rendererInfoCounters: RendererInfoCountersSnapshot;
   softwareRendererPolicy: SoftwareRendererPolicyState;
   rendererSize: RendererSizeSnapshot;
   quality: QualityStateSnapshot;
@@ -88,6 +100,7 @@ export interface PerformanceDiagnosticsApi {
 interface PerformanceDiagnosticsOptions {
   rendererInfo: RendererInfoSnapshot;
   getRendererSize: () => RendererSizeSnapshot;
+  getRendererInfoCounters?: () => unknown;
   getQualityState: () => QualityStateSnapshot;
   getFeatureState: () => FeatureStateSnapshot;
   getLastFailoverReason: () => string | null;
@@ -96,6 +109,35 @@ interface PerformanceDiagnosticsOptions {
   copyCrashLog?: () => Promise<boolean>;
   recordSnapshot?: (snapshot: PerformanceDiagnosticsSnapshot) => void;
   maxSamples?: number;
+}
+
+function readCounter(input: unknown, key: string): number | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const value = (input as Record<string, unknown>)[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function getRendererInfoCountersSnapshot(
+  rendererInfoCounters: unknown
+): RendererInfoCountersSnapshot {
+  const render =
+    rendererInfoCounters && typeof rendererInfoCounters === 'object'
+      ? (rendererInfoCounters as { render?: unknown }).render
+      : null;
+  const memory =
+    rendererInfoCounters && typeof rendererInfoCounters === 'object'
+      ? (rendererInfoCounters as { memory?: unknown }).memory
+      : null;
+  return {
+    calls: readCounter(render, 'calls'),
+    triangles: readCounter(render, 'triangles'),
+    points: readCounter(render, 'points'),
+    lines: readCounter(render, 'lines'),
+    geometries: readCounter(memory, 'geometries'),
+    textures: readCounter(memory, 'textures'),
+  };
 }
 
 const PHASES: readonly PhaseName[] = [
@@ -144,6 +186,7 @@ function summarize(values: readonly number[]): {
 export function createPerformanceDiagnostics({
   rendererInfo,
   getRendererSize,
+  getRendererInfoCounters,
   getQualityState,
   getFeatureState,
   getLastFailoverReason,
@@ -177,6 +220,9 @@ export function createPerformanceDiagnostics({
       return {
         ...diagnosticsMethods.getFrameStats(),
         renderer: diagnosticsMethods.getRendererInfo(),
+        rendererInfoCounters: getRendererInfoCountersSnapshot(
+          getRendererInfoCounters?.()
+        ),
         softwareRendererPolicy: getSoftwareRendererPolicy(),
         rendererSize: getRendererSize(),
         quality: diagnosticsMethods.getQualityState(),

--- a/src/scene/performance/qualityPolicy.ts
+++ b/src/scene/performance/qualityPolicy.ts
@@ -160,6 +160,13 @@ export function resolveResizedBasePixelRatio(
   return Math.min(resizedPixelRatio, safeAdaptiveCap);
 }
 
+export interface InitialQualityDeviceHints {
+  coarsePointer?: boolean;
+  maxTouchPoints?: number;
+  deviceMemory?: number;
+  userAgent?: string;
+}
+
 export function resolveInitialQualityPolicy(
   rendererInfo: Pick<
     RendererInfoSnapshot,
@@ -168,7 +175,8 @@ export function resolveInitialQualityPolicy(
   devicePixelRatio: number,
   softwareRendererPolicy: SoftwareRendererPolicyState = resolveSoftwareRendererPolicy(
     rendererInfo
-  )
+  ),
+  deviceHints: InitialQualityDeviceHints = {}
 ): QualityPolicyState {
   if (
     rendererInfo.isDangerousSoftwareRenderer &&
@@ -199,6 +207,33 @@ export function resolveInitialQualityPolicy(
       softwareSafeMode: false,
       renderCadenceFps: null,
       reason: 'software renderer starts in performance mode',
+    };
+  }
+
+  const userAgent = deviceHints.userAgent ?? '';
+  const isTabletLike = /ipad|tablet|sm-t|galaxy tab|android(?!.*mobile)/i.test(
+    userAgent
+  );
+  const isTouchMobileLike =
+    deviceHints.coarsePointer === true ||
+    (deviceHints.maxTouchPoints ?? 0) >= 2 ||
+    /android|iphone|mobile/i.test(userAgent);
+  const hasConstrainedMemory =
+    typeof deviceHints.deviceMemory === 'number' &&
+    deviceHints.deviceMemory <= 4;
+
+  if (isTabletLike || (isTouchMobileLike && hasConstrainedMemory)) {
+    return {
+      initialLevel: 'performance',
+      basePixelRatioCap: clampDevicePixelRatio(devicePixelRatio, 0.85, 0.5),
+      mirrorEnabled: false,
+      mirrorTargetSize: 192,
+      mirrorUpdateRateFps: 0,
+      ambientUpdateIntervalMs: 100,
+      softwareSafeMode: false,
+      renderCadenceFps: null,
+      reason:
+        'coarse-pointer mobile/tablet hardware starts in performance mode',
     };
   }
 

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -17,6 +17,9 @@ import {
   Vector3,
 } from 'three';
 
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+
 import {
   scalePoiValue,
   POI_ORB_VERTICAL_OFFSET,
@@ -82,16 +85,26 @@ export interface PoiInstance {
   visitedBadge?: PoiVisitedBadge;
 }
 
+export interface PoiInstancesOptions {
+  detailPolicy?: SceneDetailPolicy;
+}
+
 export function createPoiInstances(
   definitions: PoiDefinition[],
-  overrides: PoiInstanceOverrides = {}
+  overrides: PoiInstanceOverrides = {},
+  options: PoiInstancesOptions = {}
 ): PoiInstance[] {
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
   return definitions.map((definition, index) => {
     const override = overrides[definition.id];
     if (override?.mode === 'display') {
       return createDisplayPoiInstance(definition, override);
     }
-    return createPedestalPoiInstance(definition, index * Math.PI * 0.37);
+    return createPedestalPoiInstance(
+      definition,
+      index * Math.PI * 0.37,
+      detailPolicy
+    );
   });
 }
 
@@ -110,7 +123,8 @@ export function updatePoiInstanceDefinition(
 
 function createPedestalPoiInstance(
   definition: PoiDefinition,
-  phaseOffset: number
+  phaseOffset: number,
+  detailPolicy: SceneDetailPolicy
 ): PoiInstance {
   const group = new Group();
   group.name = `POI:${definition.id}`;
@@ -139,7 +153,7 @@ function createPedestalPoiInstance(
   let accentBaseColor: Color | undefined;
   let accentFocusColor: Color | undefined;
 
-  if (pedestalHeight > 0 && pedestalRadius > 0) {
+  if (pedestalHeight > 0 && pedestalRadius > 0 && !detailPolicy.isPerformance) {
     const bodyMaterial = new MeshStandardMaterial({
       color: new Color(hologramConfig?.bodyColor ?? 0x101c2a),
       emissive: new Color(hologramConfig?.emissiveColor ?? 0x2f8aff),
@@ -233,7 +247,11 @@ function createPedestalPoiInstance(
 
   const orbRadius =
     Math.max(baseRadius, pedestalRadius) * 0.45 * POI_ORB_DIAMETER_MULTIPLIER;
-  const orbGeometry = new SphereGeometry(orbRadius, 32, 32);
+  const orbGeometry = new SphereGeometry(
+    orbRadius,
+    detailPolicy.segments.sphereWidth,
+    detailPolicy.segments.sphereHeight
+  );
   const orbColor = new Color(hologramConfig?.orbColor ?? 0xb8f3ff);
   const orbEmissiveBase = new Color(
     hologramConfig?.orbEmissiveColor ?? 0x3de1ff
@@ -256,7 +274,10 @@ function createPedestalPoiInstance(
   orb.position.y = orbBaseHeight;
   group.add(orb);
 
-  const labelTexture = createPoiLabelTexture(definition);
+  const labelTexture = createPoiLabelTexture(
+    definition,
+    detailPolicy.textures.poiLabelScale
+  );
   const labelMaterial = new MeshBasicMaterial({
     map: labelTexture,
     transparent: true,
@@ -287,7 +308,7 @@ function createPedestalPoiInstance(
   const haloGeometry = new RingGeometry(
     haloInnerRadius,
     haloOuterRadius,
-    48,
+    detailPolicy.isPerformance ? 8 : 48,
     1
   );
   const haloBaseColor = new Color(0x4bd8ff);
@@ -309,7 +330,7 @@ function createPedestalPoiInstance(
   const visitedRingGeometry = new RingGeometry(
     haloInnerRadius * 0.92,
     haloOuterRadius * 1.05,
-    60,
+    detailPolicy.isPerformance ? 8 : 60,
     1
   );
   const visitedRingMaterial = new MeshBasicMaterial({
@@ -334,7 +355,7 @@ function createPedestalPoiInstance(
     hitAreaRadius,
     hitAreaRadius,
     hitAreaHeight,
-    32
+    detailPolicy.isPerformance ? 8 : 32
   );
   const hitAreaMaterial = new MeshBasicMaterial({
     transparent: true,
@@ -456,11 +477,13 @@ function createDisplayPoiInstance(
 }
 
 export function createPoiLabelTexture(
-  definition: PoiDefinition
+  definition: PoiDefinition,
+  textureScale = 1
 ): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 640;
-  canvas.height = 192;
+  const scale = MathUtils.clamp(textureScale, 0.25, 1);
+  canvas.width = Math.round(640 * scale);
+  canvas.height = Math.round(192 * scale);
   const context = canvas.getContext('2d');
   if (!context) {
     throw new Error('Unable to acquire 2D context for POI label.');
@@ -492,7 +515,7 @@ export function createPoiLabelTexture(
   context.stroke();
 
   context.fillStyle = gradient;
-  context.font = 'bold 64px "Inter", "Segoe UI", sans-serif';
+  context.font = `bold ${Math.round(64 * scale)}px "Inter", "Segoe UI", sans-serif`;
   context.textAlign = 'center';
   context.textBaseline = 'middle';
   wrapText(
@@ -501,7 +524,7 @@ export function createPoiLabelTexture(
     canvas.width / 2,
     canvas.height / 2,
     canvas.width - padding * 3,
-    68,
+    68 * scale,
     2
   );
 

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -18,6 +18,8 @@ import {
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
 
@@ -32,6 +34,7 @@ export interface FlywheelShowpieceOptions {
   centerZ: number;
   roomBounds: Bounds2D;
   orientationRadians?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface AutomationPillar {
@@ -48,6 +51,7 @@ export function createFlywheelShowpiece(
   group.name = 'FlywheelShowpiece';
 
   const colliders: RectCollider[] = [];
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
 
   const selectionEventTarget = typeof window === 'undefined' ? null : window;
   let selectionTarget = 0;
@@ -102,6 +106,10 @@ export function createFlywheelShowpiece(
       group.removeEventListener('removed', handleRemoval);
     };
     group.addEventListener('removed', handleRemoval);
+  }
+
+  if (detailPolicy.isPerformance) {
+    return createPerformanceFlywheelProxy(options, group, colliders);
   }
 
   const daisRadius = 1.45;
@@ -870,4 +878,80 @@ function getPoiIdFromEvent(event: Event): string | null {
   }
   const poiId = detail.poi?.id;
   return typeof poiId === 'string' ? poiId : null;
+}
+
+function createPerformanceFlywheelProxy(
+  options: FlywheelShowpieceOptions,
+  group: Group,
+  colliders: RectCollider[]
+): FlywheelShowpieceBuild {
+  const detailPolicy =
+    options.detailPolicy ?? getSceneDetailPolicy('performance');
+  const daisRadius = 1.45;
+  const daisHeight = 0.14;
+  const base = new Mesh(
+    new CylinderGeometry(
+      daisRadius,
+      daisRadius,
+      daisHeight,
+      detailPolicy.segments.cylinder
+    ),
+    new MeshStandardMaterial({
+      color: new Color(0x14202c),
+      roughness: 0.58,
+      metalness: 0.12,
+    })
+  );
+  base.name = 'FlywheelPerformanceDais';
+  base.position.set(options.centerX, daisHeight / 2, options.centerZ);
+  group.add(base);
+
+  const rotorMaterial = new MeshStandardMaterial({
+    color: new Color(0x2c95ff),
+    emissive: new Color(0x4cbcff),
+    emissiveIntensity: 0.45,
+    roughness: 0.32,
+    metalness: 0.24,
+  });
+  const rotor = new Mesh(
+    new TorusGeometry(
+      0.74,
+      0.08,
+      detailPolicy.segments.torusRadial,
+      detailPolicy.segments.torusTubular
+    ),
+    rotorMaterial
+  );
+  rotor.name = 'FlywheelPerformanceRotor';
+  rotor.position.set(options.centerX, 0.9, options.centerZ);
+  rotor.rotation.x = Math.PI / 2;
+  group.add(rotor);
+
+  const hub = new Mesh(
+    new CylinderGeometry(0.18, 0.18, 0.24, detailPolicy.segments.cylinder),
+    rotorMaterial.clone()
+  );
+  hub.name = 'FlywheelPerformanceHub';
+  hub.position.set(options.centerX, 0.9, options.centerZ);
+  hub.rotation.x = Math.PI / 2;
+  group.add(hub);
+
+  colliders.push({
+    minX: options.centerX - daisRadius,
+    maxX: options.centerX + daisRadius,
+    minZ: options.centerZ - daisRadius,
+    maxZ: options.centerZ + daisRadius,
+  });
+
+  return {
+    group,
+    colliders,
+    update({ delta, emphasis }) {
+      if (emphasis < 0.05) {
+        return;
+      }
+      rotor.rotation.z += delta * MathUtils.lerp(0.3, 1.2, emphasis);
+      rotorMaterial.emissiveIntensity = MathUtils.lerp(0.35, 0.85, emphasis);
+    },
+  };
 }

--- a/src/scene/structures/greenhouse.ts
+++ b/src/scene/structures/greenhouse.ts
@@ -6,6 +6,7 @@ import {
   Group,
   MathUtils,
   Mesh,
+  MeshBasicMaterial,
   MeshPhysicalMaterial,
   MeshStandardMaterial,
   PlaneGeometry,
@@ -20,6 +21,8 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 export interface GreenhouseConfig {
   basePosition: Vector3;
@@ -28,6 +31,7 @@ export interface GreenhouseConfig {
   depth?: number;
   environmentMap?: Texture | null;
   environmentIntensity?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface GreenhouseBuild {
@@ -46,6 +50,8 @@ const BASE_HEIGHT = 0.18;
 const SOLAR_BASE_TILT = -MathUtils.degToRad(18);
 
 export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
+  const detailPolicy = config.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const cylinderSegments = detailPolicy.segments.cylinder;
   const width = config.width ?? DEFAULT_WIDTH;
   const depth = config.depth ?? DEFAULT_DEPTH;
   const orientation = config.orientationRadians ?? 0;
@@ -193,15 +199,23 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   roofBeamRight.rotation.z = -roofBeamLeft.rotation.z;
   frameGroup.add(roofBeamRight);
 
-  const glassMaterial = new MeshPhysicalMaterial({
-    color: new Color(0x9cd6ff),
-    transparent: true,
-    opacity: 0.28,
-    roughness: 0.1,
-    metalness: 0.0,
-    transmission: 0.86,
-    thickness: 0.18,
-  });
+  const glassMaterial = detailPolicy.effects.glassTransmission
+    ? new MeshPhysicalMaterial({
+        color: new Color(0x9cd6ff),
+        transparent: true,
+        opacity: 0.28,
+        roughness: 0.1,
+        metalness: 0.0,
+        transmission: 0.86,
+        thickness: 0.18,
+      })
+    : new MeshStandardMaterial({
+        color: new Color(0x8fcfff),
+        transparent: true,
+        opacity: 0.34,
+        roughness: 0.42,
+        metalness: 0.02,
+      });
   applyEnvironmentMap(glassMaterial);
 
   const wallGeometry = new PlaneGeometry(
@@ -282,7 +296,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     pondPlinthRadius,
     pondPlinthRadius,
     pondPlinthHeight,
-    40
+    cylinderSegments
   );
   const pondPlinthMaterial = new MeshStandardMaterial({
     color: new Color(0x2b343c),
@@ -303,7 +317,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     depth * 0.17,
     depth * 0.17,
     0.12,
-    32
+    cylinderSegments
   );
   const pondMaterial = new MeshStandardMaterial({
     color: new Color(0x1a4a5e),
@@ -337,12 +351,13 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     outerColor: { value: new Color(0x082b3e) },
   };
 
-  const pondRippleMaterial = new ShaderMaterial({
-    uniforms: pondRippleUniforms,
-    blending: AdditiveBlending,
-    transparent: true,
-    depthWrite: false,
-    vertexShader: `
+  const pondRippleMaterial = detailPolicy.effects.shaderPond
+    ? new ShaderMaterial({
+        uniforms: pondRippleUniforms,
+        blending: AdditiveBlending,
+        transparent: true,
+        depthWrite: false,
+        vertexShader: `
       varying vec2 vUv;
 
       void main() {
@@ -350,7 +365,7 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
-    fragmentShader: `
+        fragmentShader: `
       uniform float time;
       uniform float amplitude;
       uniform float brightness;
@@ -393,11 +408,12 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
         gl_FragColor = vec4(baseColor, alpha);
       }
     `,
-  });
+      })
+    : null;
 
   const pondRipple = new Mesh(
     new PlaneGeometry(depth * 0.36, depth * 0.36),
-    pondRippleMaterial
+    pondRippleMaterial ?? new MeshBasicMaterial({ visible: false })
   );
   pondRipple.name = 'BackyardGreenhousePondRipple';
   pondRipple.position.set(
@@ -407,6 +423,8 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   );
   pondRipple.rotation.x = -Math.PI / 2;
   pondRipple.renderOrder = 6;
+  pondRipple.visible = detailPolicy.effects.shaderPond;
+  pondRipple.userData.sceneDetailRole = 'performance-hidden';
   group.add(pondRipple);
 
   const solarPanelPivot = new Group();
@@ -446,7 +464,12 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
   });
 
   const growLightMaterials: MeshStandardMaterial[] = [];
-  const growLightGeometry = new CylinderGeometry(0.05, 0.05, width * 0.32, 12);
+  const growLightGeometry = new CylinderGeometry(
+    0.05,
+    0.05,
+    width * 0.32,
+    detailPolicy.isPerformance ? 6 : 12
+  );
   const growLightSpacing = depth * 0.38;
   [-growLightSpacing, 0, growLightSpacing].forEach((offsetZ, index) => {
     const lightMaterial = new MeshStandardMaterial({
@@ -488,6 +511,9 @@ export function createGreenhouse(config: GreenhouseConfig): GreenhouseBuild {
     // Minimum ripple speed lowered from 0.24 to 0.2 for smoother pond animation at rest.
     // This matches updated visual tests and improves perceived calmness in accessibility mode.
     const rippleSpeed = MathUtils.lerp(0.2, 0.52, pulseScale);
+    if (!detailPolicy.effects.shaderPond) {
+      return;
+    }
     pondRippleUniforms.time.value = elapsed * rippleSpeed;
     // The minimum amplitude for pond ripples is set to 0.18 (was previously 0.25).
     // This lower value was chosen after visual and accessibility testing to ensure

--- a/src/scene/structures/jobbotTerminal.ts
+++ b/src/scene/structures/jobbotTerminal.ts
@@ -15,6 +15,8 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 export interface JobbotTerminalBuild {
   group: Group;
@@ -35,6 +37,7 @@ export interface JobbotTerminalOptions {
     width?: number;
     depth?: number;
   };
+  detailPolicy?: SceneDetailPolicy;
 }
 
 interface DataShardState {
@@ -46,10 +49,12 @@ interface DataShardState {
   orbitSpeed: number;
 }
 
-function createTerminalScreenTexture(): CanvasTexture {
+function createTerminalScreenTexture(
+  detailPolicy: SceneDetailPolicy
+): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 2048;
-  canvas.height = 1024;
+  canvas.width = detailPolicy.textures.jobbotScreen.width;
+  canvas.height = detailPolicy.textures.jobbotScreen.height;
   const context = canvas.getContext('2d');
 
   if (context) {
@@ -69,12 +74,13 @@ function createTerminalScreenTexture(): CanvasTexture {
     context.fillRect(0, 0, canvas.width, canvas.height);
 
     context.fillStyle = '#7cf1ff';
-    context.font = 'bold 220px "Inter", "Segoe UI", sans-serif';
+    const scale = canvas.width / 2048;
+    context.font = `bold ${Math.round(220 * scale)}px "Inter", "Segoe UI", sans-serif`;
     context.textAlign = 'left';
     context.textBaseline = 'alphabetic';
     context.fillText('jobbot3000', canvas.width * 0.08, canvas.height * 0.46);
 
-    context.font = '64px "Inter", "Segoe UI", sans-serif';
+    context.font = `${Math.round(64 * scale)}px "Inter", "Segoe UI", sans-serif`;
     context.fillStyle = '#9ce9ff';
     context.fillText(
       'Automation orchestrator · live diagnostics stream',
@@ -82,7 +88,7 @@ function createTerminalScreenTexture(): CanvasTexture {
       canvas.height * 0.68
     );
 
-    context.font = '52px "Inter", "Segoe UI", sans-serif';
+    context.font = `${Math.round(52 * scale)}px "Inter", "Segoe UI", sans-serif`;
     context.fillStyle = '#fede72';
     context.fillText(
       'Status: nominal · queue depth 0 · SLA 99.98%',
@@ -91,11 +97,11 @@ function createTerminalScreenTexture(): CanvasTexture {
     );
 
     const rightColumnX = canvas.width * 0.7;
-    context.font = '600 56px "Inter", "Segoe UI", sans-serif';
+    context.font = `600 ${Math.round(56 * scale)}px "Inter", "Segoe UI", sans-serif`;
     context.fillStyle = '#ffffff';
     context.fillText('Ops timeline', rightColumnX, canvas.height * 0.32);
 
-    context.font = '42px "Inter", "Segoe UI", sans-serif';
+    context.font = `${Math.round(42 * scale)}px "Inter", "Segoe UI", sans-serif`;
     context.fillStyle = '#b6d8ff';
     const logLines = [
       '• 05:32 · cron sync complete',
@@ -116,11 +122,12 @@ function createTerminalScreenTexture(): CanvasTexture {
 function createTelemetryPanelTexture(
   heading: string,
   primary: string,
-  metrics: string[]
+  metrics: string[],
+  detailPolicy: SceneDetailPolicy
 ): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 1024;
-  canvas.height = 512;
+  canvas.width = detailPolicy.textures.jobbotTelemetry.width;
+  canvas.height = detailPolicy.textures.jobbotTelemetry.height;
   const context = canvas.getContext('2d');
 
   if (!context) {
@@ -139,14 +146,15 @@ function createTelemetryPanelTexture(
   context.textBaseline = 'alphabetic';
 
   context.fillStyle = '#7cf1ff';
-  context.font = 'bold 156px "Inter", "Segoe UI", sans-serif';
+  const scale = canvas.width / 1024;
+  context.font = `bold ${Math.round(156 * scale)}px "Inter", "Segoe UI", sans-serif`;
   context.fillText(heading, 88, 220);
 
-  context.font = '600 94px "Inter", "Segoe UI", sans-serif';
+  context.font = `600 ${Math.round(94 * scale)}px "Inter", "Segoe UI", sans-serif`;
   context.fillStyle = '#d9fbff';
   context.fillText(primary, 88, 320);
 
-  context.font = '52px "Inter", "Segoe UI", sans-serif';
+  context.font = `${Math.round(52 * scale)}px "Inter", "Segoe UI", sans-serif`;
   metrics.forEach((metric, index) => {
     const y = 380 + index * 64;
     context.fillStyle = 'rgba(124, 241, 255, 0.65)';
@@ -205,6 +213,8 @@ export function createJobbotTerminal(
   options: JobbotTerminalOptions
 ): JobbotTerminalBuild {
   const { position, orientationRadians = 0, desk } = options;
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const cylinderSegments = detailPolicy.segments.cylinder;
   const baseY = position.y ?? 0;
   const deskWidth = desk?.width ?? 3.6;
   const deskDepth = desk?.depth ?? 1.6;
@@ -283,7 +293,7 @@ export function createJobbotTerminal(
   );
   group.add(accent);
 
-  const screenTexture = createTerminalScreenTexture();
+  const screenTexture = createTerminalScreenTexture(detailPolicy);
   const screenMaterial = new MeshBasicMaterial({
     map: screenTexture,
     transparent: true,
@@ -315,6 +325,7 @@ export function createJobbotTerminal(
   screenGlow.position.copy(screen.position);
   screenGlow.position.z += 0.02;
   screenGlow.renderOrder = 5;
+  screenGlow.userData.sceneDetailRole = 'decorative-effect';
   group.add(screenGlow);
 
   const tickerHeight = 0.22;
@@ -335,7 +346,12 @@ export function createJobbotTerminal(
   ticker.renderOrder = 7;
   group.add(ticker);
 
-  const hologramBaseGeometry = new CylinderGeometry(0.42, 0.5, 0.18, 48);
+  const hologramBaseGeometry = new CylinderGeometry(
+    0.42,
+    0.5,
+    0.18,
+    cylinderSegments
+  );
   const hologramBaseMaterial = new MeshStandardMaterial({
     color: new Color(0x152335),
     emissive: new Color(0x1b5dff),
@@ -356,6 +372,9 @@ export function createJobbotTerminal(
   const hologramBaseHeight =
     hologramBase.position.y + hologramBaseGeometry.parameters.height / 2;
   hologramGroup.position.set(0, hologramBaseHeight + 0.06, 0);
+  hologramGroup.userData.sceneDetailRole = detailPolicy.isPerformance
+    ? 'performance-hidden'
+    : undefined;
   group.add(hologramGroup);
 
   const hologramMaterial = new MeshBasicMaterial({
@@ -365,7 +384,14 @@ export function createJobbotTerminal(
     depthWrite: false,
     toneMapped: false,
   });
-  const hologramGeometry = new CylinderGeometry(0.12, 0.4, 0.8, 36, 1, true);
+  const hologramGeometry = new CylinderGeometry(
+    0.12,
+    0.4,
+    0.8,
+    cylinderSegments,
+    1,
+    true
+  );
   const hologram = new Mesh(hologramGeometry, hologramMaterial);
   hologram.position.y = 0.3;
   hologramGroup.add(hologram);
@@ -377,7 +403,11 @@ export function createJobbotTerminal(
     roughness: 0.2,
     metalness: 0.45,
   });
-  const hologramCoreGeometry = new SphereGeometry(0.18, 32, 32);
+  const hologramCoreGeometry = new SphereGeometry(
+    0.18,
+    detailPolicy.segments.sphereWidth,
+    detailPolicy.segments.sphereHeight
+  );
   const hologramCore = new Mesh(hologramCoreGeometry, hologramCoreMaterial);
   hologramCore.name = 'JobbotTerminalCore';
   hologramCore.position.set(0, 0.55, 0);
@@ -399,6 +429,9 @@ export function createJobbotTerminal(
   const dataShardGroup = new Group();
   dataShardGroup.name = 'JobbotTerminalDataShards';
   dataShardGroup.position.set(0, hologramBaseHeight + 0.24, 0);
+  dataShardGroup.userData.sceneDetailRole = detailPolicy.isPerformance
+    ? 'performance-hidden'
+    : undefined;
   group.add(dataShardGroup);
 
   const shardGeometry = new BoxGeometry(0.12, 0.34, 0.04);
@@ -436,6 +469,9 @@ export function createJobbotTerminal(
   telemetryGroup.name = 'JobbotTerminalTelemetryGroup';
   const telemetryBaseHeight = deskHeight + deskThickness + 0.58;
   telemetryGroup.position.set(0, telemetryBaseHeight, 0);
+  telemetryGroup.userData.sceneDetailRole = detailPolicy.isPerformance
+    ? 'performance-hidden'
+    : undefined;
   group.add(telemetryGroup);
 
   const telemetryDescriptors = [
@@ -461,7 +497,8 @@ export function createJobbotTerminal(
     const texture = createTelemetryPanelTexture(
       descriptor.heading,
       descriptor.primary,
-      descriptor.metrics
+      descriptor.metrics,
+      detailPolicy
     );
     const material = new MeshBasicMaterial({
       map: texture,
@@ -499,7 +536,7 @@ export function createJobbotTerminal(
       telemetryRadius * 1.06,
       telemetryRadius * 1.06,
       0.04,
-      48
+      cylinderSegments
     ),
     telemetryAuraMaterial
   );
@@ -507,9 +544,14 @@ export function createJobbotTerminal(
   telemetryAura.rotation.x = Math.PI / 2;
   telemetryAura.position.set(0, telemetryBaseHeight - 0.16, 0);
   telemetryAura.renderOrder = 2;
+  telemetryAura.userData.sceneDetailRole = 'decorative-effect';
   group.add(telemetryAura);
 
-  const statusBeaconGeometry = new SphereGeometry(0.08, 24, 24);
+  const statusBeaconGeometry = new SphereGeometry(
+    0.08,
+    detailPolicy.isPerformance ? 8 : 24,
+    detailPolicy.isPerformance ? 6 : 24
+  );
   const statusBeaconMaterial = new MeshStandardMaterial({
     color: new Color(0x1a2f40),
     emissive: new Color(0x3cb6ff),
@@ -548,6 +590,10 @@ export function createJobbotTerminal(
     colliders,
     update({ elapsed, emphasis, analyticsGlow, analyticsWave }) {
       const delta = Math.max(0, elapsed - lastElapsed);
+      if (detailPolicy.isPerformance && emphasis < 0.05) {
+        lastElapsed = elapsed;
+        return;
+      }
       lastElapsed = elapsed;
       const smoothing = delta > 0 ? 1 - Math.exp(-delta * 3.8) : 1;
       const pulseScale = getPulseScale();

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -18,9 +18,10 @@ import {
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 const SCREEN_WIDTH = 2048;
-const SCREEN_HEIGHT = 1024;
 const BASE_GLOW_OPACITY = 0.18;
 const EMPHASISED_GLOW_OPACITY = 0.62;
 const CLEARANCE_BASE_OPACITY = 0.16;
@@ -30,6 +31,8 @@ const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
 
 interface MediaWallScreenRendererOptions {
   starCount: number;
+  size: { width: number; height: number };
+  redrawThrottleMs: number;
 }
 
 class MediaWallScreenRenderer {
@@ -38,11 +41,15 @@ class MediaWallScreenRenderer {
   private readonly texture: CanvasTexture;
   private highlight = 0;
   private starCount: number;
+  private readonly width: number;
+  private readonly height: number;
+  private readonly redrawThrottleMs: number;
+  private lastRenderMs = Number.NEGATIVE_INFINITY;
 
   constructor(options: MediaWallScreenRendererOptions) {
     const canvas = document.createElement('canvas');
-    canvas.width = SCREEN_WIDTH;
-    canvas.height = SCREEN_HEIGHT;
+    canvas.width = options.size.width;
+    canvas.height = options.size.height;
     const context = canvas.getContext('2d');
 
     if (!context) {
@@ -52,6 +59,9 @@ class MediaWallScreenRenderer {
     this.canvas = canvas;
     this.context = context;
     this.texture = new CanvasTexture(canvas);
+    this.width = canvas.width;
+    this.height = canvas.height;
+    this.redrawThrottleMs = options.redrawThrottleMs;
     this.texture.colorSpace = SRGBColorSpace;
     this.starCount = options.starCount;
 
@@ -76,6 +86,14 @@ class MediaWallScreenRenderer {
     if (Math.abs(clamped - this.highlight) < 1e-4) {
       return;
     }
+    const now = typeof performance !== 'undefined' ? performance.now() : 0;
+    if (
+      this.redrawThrottleMs > 0 &&
+      now - this.lastRenderMs < this.redrawThrottleMs
+    ) {
+      this.highlight = clamped;
+      return;
+    }
     this.highlight = clamped;
     this.render();
   }
@@ -86,65 +104,68 @@ class MediaWallScreenRenderer {
 
   private render() {
     this.context.save();
-    this.context.clearRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    this.context.clearRect(0, 0, this.width, this.height);
     this.drawBase();
     this.drawStarHighlight();
     this.context.restore();
     this.texture.needsUpdate = true;
+    this.lastRenderMs =
+      typeof performance !== 'undefined' ? performance.now() : 0;
   }
 
   private drawBase() {
     const ctx = this.context;
     ctx.save();
     ctx.fillStyle = '#0f1724';
-    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    ctx.fillRect(0, 0, this.width, this.height);
 
     const baseGradient = ctx.createLinearGradient(
       0,
       0,
-      SCREEN_WIDTH,
-      SCREEN_HEIGHT
+      this.width,
+      this.height
     );
     baseGradient.addColorStop(0, '#182a47');
     baseGradient.addColorStop(0.55, '#0f233c');
     baseGradient.addColorStop(1, '#192339');
     ctx.fillStyle = baseGradient;
-    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+    ctx.fillRect(0, 0, this.width, this.height);
 
     ctx.globalAlpha = 0.6;
-    const accentGradient = ctx.createLinearGradient(0, 0, SCREEN_WIDTH, 0);
+    const accentGradient = ctx.createLinearGradient(0, 0, this.width, 0);
     accentGradient.addColorStop(0, 'rgba(75, 217, 255, 0.8)');
     accentGradient.addColorStop(0.45, 'rgba(83, 146, 255, 0.35)');
     accentGradient.addColorStop(1, 'rgba(255, 82, 82, 0.6)');
     ctx.fillStyle = accentGradient;
 
-    const accentX = SCREEN_WIDTH * 0.05;
-    const accentY = SCREEN_HEIGHT * 0.16;
-    const accentWidth = SCREEN_WIDTH * 0.9;
-    const accentHeight = SCREEN_HEIGHT * 0.68;
+    const accentX = this.width * 0.05;
+    const accentY = this.height * 0.16;
+    const accentWidth = this.width * 0.9;
+    const accentHeight = this.height * 0.68;
     ctx.fillRect(accentX, accentY, accentWidth, accentHeight);
     ctx.globalAlpha = 1;
 
-    const leftTextAnchor = SCREEN_WIDTH * 0.08;
-    const headerY = SCREEN_HEIGHT * 0.44;
-    const platformY = SCREEN_HEIGHT * 0.62;
-    const taglineY = SCREEN_HEIGHT * 0.74;
-    const episodeY = SCREEN_HEIGHT * 0.84;
-    const rightTextAnchor = SCREEN_WIDTH * 0.92;
+    const scale = this.width / SCREEN_WIDTH;
+    const leftTextAnchor = this.width * 0.08;
+    const headerY = this.height * 0.44;
+    const platformY = this.height * 0.62;
+    const taglineY = this.height * 0.74;
+    const episodeY = this.height * 0.84;
+    const rightTextAnchor = this.width * 0.92;
 
     ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 180px "Inter", "Segoe UI", sans-serif';
+    ctx.font = `bold ${Math.round(180 * scale)}px "Inter", "Segoe UI", sans-serif`;
     ctx.textAlign = 'left';
     ctx.textBaseline = 'alphabetic';
     ctx.fillText('Futuroptimist', leftTextAnchor, headerY);
 
-    ctx.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
+    ctx.font = `bold ${Math.round(120 * scale)}px "Inter", "Segoe UI", sans-serif`;
     ctx.fillStyle = '#ff4c4c';
     ctx.fillText('YouTube', leftTextAnchor, platformY);
 
     const tagline =
       'Designing resilient automation, live devlogs, and deep dives.';
-    ctx.font = '48px "Inter", "Segoe UI", sans-serif';
+    ctx.font = `${Math.round(48 * scale)}px "Inter", "Segoe UI", sans-serif`;
     ctx.fillStyle = '#dbe7ff';
     ctx.fillText(tagline, leftTextAnchor, taglineY);
 
@@ -152,7 +173,7 @@ class MediaWallScreenRenderer {
     ctx.fillStyle = '#9ddcff';
     ctx.fillText(latestEpisode, leftTextAnchor, episodeY);
 
-    ctx.font = '600 72px "Inter", "Segoe UI", sans-serif';
+    ctx.font = `600 ${Math.round(72 * scale)}px "Inter", "Segoe UI", sans-serif`;
     ctx.fillStyle = '#ffffff';
     ctx.textAlign = 'right';
     ctx.fillText('Watch now →', rightTextAnchor, episodeY);
@@ -161,10 +182,11 @@ class MediaWallScreenRenderer {
 
   private drawStarHighlight() {
     const ctx = this.context;
-    const cardWidth = SCREEN_WIDTH * 0.26;
-    const cardHeight = SCREEN_HEIGHT * 0.32;
-    const cardX = SCREEN_WIDTH * 0.62;
-    const cardY = SCREEN_HEIGHT * 0.18;
+    const scale = this.width / SCREEN_WIDTH;
+    const cardWidth = this.width * 0.26;
+    const cardHeight = this.height * 0.32;
+    const cardX = this.width * 0.62;
+    const cardY = this.height * 0.18;
     const cardRadius = cardHeight * 0.16;
 
     ctx.save();
@@ -190,7 +212,7 @@ class MediaWallScreenRenderer {
 
     const glowStrength = 0.25 + this.highlight * 0.45;
     ctx.shadowColor = `rgba(74, 210, 255, ${glowStrength})`;
-    ctx.shadowBlur = 120 * (0.35 + this.highlight * 0.55);
+    ctx.shadowBlur = 120 * scale * (0.35 + this.highlight * 0.55);
     ctx.fillStyle = `rgba(74, 210, 255, ${glowStrength})`;
     ctx.fill();
     ctx.shadowColor = 'transparent';
@@ -203,16 +225,16 @@ class MediaWallScreenRenderer {
     const labelY = y + h * 0.86;
 
     ctx.fillStyle = '#ffdd63';
-    ctx.font = 'bold 92px "Inter", "Segoe UI", sans-serif';
+    ctx.font = `bold ${Math.round(92 * scale)}px "Inter", "Segoe UI", sans-serif`;
     ctx.textAlign = 'left';
     ctx.fillText('★', iconX, iconY);
 
     ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 160px "Inter", "Segoe UI", sans-serif';
+    ctx.font = `bold ${Math.round(160 * scale)}px "Inter", "Segoe UI", sans-serif`;
     ctx.fillText(this.formatStarCount(), valueX, valueY);
 
     ctx.fillStyle = '#a7c5ff';
-    ctx.font = '48px "Inter", "Segoe UI", sans-serif';
+    ctx.font = `${Math.round(48 * scale)}px "Inter", "Segoe UI", sans-serif`;
     ctx.fillText('GitHub stars', iconX, labelY);
 
     ctx.restore();
@@ -234,14 +256,20 @@ interface MediaWallTextures {
   badge: CanvasTexture;
 }
 
-function createScreenRenderer(): MediaWallScreenRenderer {
-  return new MediaWallScreenRenderer({ starCount: 1280 });
+function createScreenRenderer(
+  detailPolicy: SceneDetailPolicy
+): MediaWallScreenRenderer {
+  return new MediaWallScreenRenderer({
+    starCount: 1280,
+    size: detailPolicy.textures.mediaWallScreen,
+    redrawThrottleMs: detailPolicy.update.canvasRedrawThrottleMs,
+  });
 }
 
-function createBadgeTexture(): CanvasTexture {
+function createBadgeTexture(detailPolicy: SceneDetailPolicy): CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
+  canvas.width = detailPolicy.textures.mediaWallBadge.width;
+  canvas.height = detailPolicy.textures.mediaWallBadge.height;
   const context = canvas.getContext('2d');
 
   if (!context) {
@@ -288,10 +316,12 @@ function createBadgeTexture(): CanvasTexture {
   return texture;
 }
 
-function getMediaWallTextures(): MediaWallTextures {
+function getMediaWallTextures(
+  detailPolicy: SceneDetailPolicy
+): MediaWallTextures {
   return {
-    screen: createScreenRenderer(),
-    badge: createBadgeTexture(),
+    screen: createScreenRenderer(detailPolicy),
+    badge: createBadgeTexture(detailPolicy),
   };
 }
 
@@ -324,6 +354,7 @@ export interface LivingRoomMediaWallBuild {
 }
 
 interface MediaWallControllerOptions {
+  detailPolicy: SceneDetailPolicy;
   screenRenderer: MediaWallScreenRenderer;
   glowMaterial: MeshBasicMaterial;
   haloMaterial: MeshStandardMaterial;
@@ -334,6 +365,7 @@ interface MediaWallControllerOptions {
 }
 
 function createMediaWallController({
+  detailPolicy,
   screenRenderer,
   glowMaterial,
   haloMaterial,
@@ -353,6 +385,9 @@ function createMediaWallController({
   return {
     update({ elapsed, delta, emphasis }) {
       const target = MathUtils.clamp(emphasis, 0, 1);
+      if (detailPolicy.isPerformance && target < 0.05) {
+        return;
+      }
       highlight = MathUtils.damp(highlight, target, 5.5, delta);
       const opacity = MathUtils.lerp(
         BASE_GLOW_OPACITY,
@@ -445,8 +480,10 @@ function createMediaWallController({
 }
 
 export function createLivingRoomMediaWall(
-  bounds: Bounds2D
+  bounds: Bounds2D,
+  options: { detailPolicy?: SceneDetailPolicy } = {}
 ): LivingRoomMediaWallBuild {
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
   const colliders: RectCollider[] = [];
@@ -487,7 +524,7 @@ export function createLivingRoomMediaWall(
   );
   group.add(trim);
 
-  const { screen, badge } = getMediaWallTextures();
+  const { screen, badge } = getMediaWallTextures(detailPolicy);
 
   const screenMaterial = new MeshBasicMaterial({
     map: screen.getTexture(),
@@ -520,6 +557,7 @@ export function createLivingRoomMediaWall(
   screenGlow.position.set(wallInteriorX + boardDepth + 0.015, 2.36, anchorZ);
   screenGlow.rotation.y = Math.PI / 2;
   screenGlow.renderOrder = 9;
+  screenGlow.userData.sceneDetailRole = 'decorative-effect';
   group.add(screenGlow);
 
   const badgeMaterial = new MeshBasicMaterial({
@@ -597,6 +635,7 @@ export function createLivingRoomMediaWall(
   const haloGeometry = new BoxGeometry(0.06, 0.24, shelfWidth * 0.85);
   const halo = new Mesh(haloGeometry, haloMaterial);
   halo.position.set(wallInteriorX + boardDepth + 0.37, 1.02, anchorZ);
+  halo.userData.sceneDetailRole = 'performance-hidden';
   group.add(halo);
 
   const shelfLightMaterial = new MeshStandardMaterial({
@@ -662,6 +701,7 @@ export function createLivingRoomMediaWall(
     anchorZ
   );
   clearance.renderOrder = 4;
+  clearance.userData.sceneDetailRole = 'decorative-effect';
   group.add(clearance);
 
   colliders.push({
@@ -687,6 +727,7 @@ export function createLivingRoomMediaWall(
   };
 
   const controller = createMediaWallController({
+    detailPolicy,
     screenRenderer: screen,
     glowMaterial: screenGlowMaterial,
     haloMaterial,

--- a/src/scene/structures/modelRocket.ts
+++ b/src/scene/structures/modelRocket.ts
@@ -16,11 +16,14 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
 export interface ModelRocketConfig {
   basePosition: Vector3;
   orientationRadians?: number;
   scale?: number;
+  detailPolicy?: SceneDetailPolicy;
 }
 
 export interface ModelRocketBuild {
@@ -33,6 +36,8 @@ const DEFAULT_SCALE = 1;
 const FIN_COUNT = 3;
 
 export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
+  const detailPolicy = config.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const cylinderSegments = detailPolicy.segments.cylinder;
   const scale = config.scale ?? DEFAULT_SCALE;
   const orientation = config.orientationRadians ?? 0;
   const basePosition = config.basePosition.clone();
@@ -48,7 +53,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius,
     standRadius,
     standHeight,
-    32
+    cylinderSegments
   );
   const standMaterial = new MeshStandardMaterial({
     color: new Color(0x2c3442),
@@ -64,7 +69,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     standRadius * 0.98,
     standRadius * 1.04,
     standHeight * 0.38,
-    32
+    cylinderSegments
   );
   const standTrimMaterial = new MeshStandardMaterial({
     color: new Color(0x39475b),
@@ -84,7 +89,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.02,
     bodyRadius * 0.94,
     bodyHeight,
-    40
+    detailPolicy.isPerformance ? 8 : 40
   );
   const bodyMaterial = new MeshStandardMaterial({
     color: new Color(0xe7eefc),
@@ -103,7 +108,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 1.06,
     bodyRadius * 1.06,
     stripeHeight,
-    40
+    detailPolicy.isPerformance ? 8 : 40
   );
   const stripeMaterial = new MeshStandardMaterial({
     color: new Color(0xff6b6b),
@@ -118,7 +123,11 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   group.add(stripe);
 
   const noseHeight = 1.1 * scale;
-  const noseGeometry = new ConeGeometry(bodyRadius * 0.92, noseHeight, 40);
+  const noseGeometry = new ConeGeometry(
+    bodyRadius * 0.92,
+    noseHeight,
+    detailPolicy.isPerformance ? 8 : 40
+  );
   const noseMaterial = new MeshStandardMaterial({
     color: new Color(0xff8976),
     emissive: new Color(0xb33a2d),
@@ -136,7 +145,7 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
     bodyRadius * 0.78,
     bodyRadius * 0.62,
     thrusterHeight,
-    32
+    cylinderSegments
   );
   const thrusterMaterial = new MeshStandardMaterial({
     color: new Color(0x1f2734),
@@ -159,12 +168,17 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
   );
   thrusterLight.name = 'ModelRocketThrusterLight';
   thrusterLight.position.set(0, standHeight + thrusterHeight * 0.24, 0);
+  thrusterLight.userData.sceneDetailDynamicLight = true;
+  if (!detailPolicy.effects.dynamicPointLights) {
+    thrusterLight.intensity = 0;
+    thrusterLight.visible = false;
+  }
   group.add(thrusterLight);
 
   const flameGeometry = new ConeGeometry(
     bodyRadius * 0.42,
     0.88 * scale,
-    24,
+    detailPolicy.isPerformance ? 8 : 24,
     1,
     true
   );
@@ -280,8 +294,9 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
       haloPulse
     );
 
-    thrusterLight.intensity =
-      thrusterLightBaseIntensity * MathUtils.lerp(0.78, 1.62, thrusterPulse);
+    thrusterLight.intensity = detailPolicy.effects.dynamicPointLights
+      ? thrusterLightBaseIntensity * MathUtils.lerp(0.78, 1.62, thrusterPulse)
+      : 0;
     thrusterLight.distance =
       thrusterLightBaseDistance * MathUtils.lerp(0.82, 1.24, thrusterPulse);
 
@@ -297,6 +312,9 @@ export function createModelRocket(config: ModelRocketConfig): ModelRocketBuild {
       flameScale
     );
 
+    if (detailPolicy.isPerformance && pulseScale < 0.2) {
+      return;
+    }
     safetyRingMaterial.opacity = MathUtils.clamp(
       safetyRingBaseOpacity * (0.62 + haloPulse * 0.55),
       0.12,

--- a/src/tests/performanceDiagnostics.test.ts
+++ b/src/tests/performanceDiagnostics.test.ts
@@ -20,6 +20,10 @@ describe('performance diagnostics', () => {
         viewport: { width: 1280, height: 720 },
         drawingBuffer: { width: 1600, height: 900 },
       }),
+      getRendererInfoCounters: () => ({
+        render: { calls: 42, triangles: 1234, points: 7, lines: 9 },
+        memory: { geometries: 88, textures: 12 },
+      }),
       getQualityState: () => ({
         level: 'balanced',
         selectionSource: 'adaptive',
@@ -77,6 +81,14 @@ describe('performance diagnostics', () => {
     expect(snapshot.minFps).toBeCloseTo(10, 0);
     expect(snapshot.sampleCount).toBe(3);
     expect(snapshot.rendererSize.pixelRatio).toBe(1.25);
+    expect(snapshot.rendererInfoCounters).toEqual({
+      calls: 42,
+      triangles: 1234,
+      points: 7,
+      lines: 9,
+      geometries: 88,
+      textures: 12,
+    });
     expect(snapshot.softwareRendererPolicy.safeMode).toBe(false);
     expect(snapshot.quality.level).toBe('balanced');
     expect(snapshot.features.activePostprocessingPassCount).toBe(1);
@@ -108,6 +120,10 @@ describe('performance diagnostics', () => {
         pixelRatio: 1,
         viewport: { width: 1280, height: 720 },
         drawingBuffer: { width: 1280, height: 720 },
+      }),
+      getRendererInfoCounters: () => ({
+        render: { calls: 42, triangles: 1234, points: 7, lines: 9 },
+        memory: { geometries: 88, textures: 12 },
       }),
       getQualityState: () => ({
         level: 'balanced',

--- a/src/tests/performanceOptimization.test.ts
+++ b/src/tests/performanceOptimization.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { createPortfolioMannequin } from '../scene/avatar/mannequin';
 import type { GraphicsQualityLevel } from '../scene/graphics/qualityManager';
+import { createSceneDetailController } from '../scene/graphics/sceneDetailController';
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import {
   createAdaptiveQualityController,
   type AdaptiveQualitySelectionSource,
@@ -75,6 +78,87 @@ function createPolicyHarness({
 }
 
 describe('immersive performance optimization policy', () => {
+  it('maps performance graphics quality to aggressive scene detail budgets', () => {
+    const balanced = getSceneDetailPolicy('balanced');
+    const cinematic = getSceneDetailPolicy('cinematic');
+    const performance = getSceneDetailPolicy('performance');
+
+    expect(performance.isPerformance).toBe(true);
+    expect(performance.theoreticalWorkloadScale).toBeLessThanOrEqual(0.1);
+    expect(performance.segments.cylinder).toBeLessThanOrEqual(
+      balanced.segments.cylinder / 5
+    );
+    expect(performance.segments.sphereWidth).toBeLessThanOrEqual(
+      balanced.segments.sphereWidth / 4
+    );
+    expect(performance.textures.jobbotScreen.width).toBeLessThanOrEqual(
+      balanced.textures.jobbotScreen.width / 4
+    );
+    expect(performance.textures.mediaWallScreen.width).toBeLessThanOrEqual(
+      cinematic.textures.mediaWallScreen.width / 4
+    );
+    expect(performance.effects.shaderMist).toBe(false);
+    expect(performance.effects.shaderPond).toBe(false);
+    expect(performance.effects.glassTransmission).toBe(false);
+    expect(performance.effects.dynamicPointLights).toBe(false);
+    expect(balanced.effects.shaderMist).toBe(true);
+    expect(cinematic.effects.glassTransmission).toBe(true);
+  });
+
+  it('starts coarse pointer tablet-like sessions in performance without overriding desktops', () => {
+    const tablet = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      undefined,
+      {
+        coarsePointer: true,
+        maxTouchPoints: 5,
+        deviceMemory: 4,
+        userAgent: 'Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-T870)',
+      }
+    );
+    expect(tablet.initialLevel).toBe('performance');
+    expect(tablet.mirrorEnabled).toBe(false);
+
+    const desktop = resolveInitialQualityPolicy(
+      { isSoftwareRenderer: false, isDangerousSoftwareRenderer: false },
+      2,
+      undefined,
+      { coarsePointer: false, maxTouchPoints: 0, deviceMemory: 16 }
+    );
+    expect(desktop.initialLevel).toBe('balanced');
+  });
+
+  it('preserves mannequin dimensions while lowering performance-mode geometry detail', () => {
+    const balanced = createPortfolioMannequin({
+      collisionRadius: 0.75,
+      detailPolicy: getSceneDetailPolicy('balanced'),
+    });
+    const performance = createPortfolioMannequin({
+      collisionRadius: 0.75,
+      detailPolicy: getSceneDetailPolicy('performance'),
+    });
+    const balancedProxy = balanced.group.getObjectByName(
+      'PortfolioMannequinCollisionProxy'
+    );
+    const performanceProxy = performance.group.getObjectByName(
+      'PortfolioMannequinCollisionProxy'
+    );
+
+    expect(performance.height).toBe(balanced.height);
+    expect(performance.collisionRadius).toBe(balanced.collisionRadius);
+    expect(
+      (
+        performanceProxy as {
+          geometry: { parameters: { widthSegments: number } };
+        }
+      ).geometry.parameters.widthSegments
+    ).toBeLessThan(
+      (balancedProxy as { geometry: { parameters: { widthSegments: number } } })
+        .geometry.parameters.widthSegments
+    );
+  });
+
   it('classifies known dangerous software renderers separately from hardware', () => {
     const dangerousRenderers = [
       'ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11)',
@@ -446,5 +530,37 @@ describe('immersive performance optimization policy', () => {
     expect(harness.controller.update(1.1)).toBeNull();
     expect(harness.controller.isExhausted()).toBe(true);
     expect(harness.onAction).toHaveBeenCalledTimes(3);
+  });
+
+  it('applies scene detail performance policy when adaptive downgrade reaches performance', () => {
+    let currentLevel: GraphicsQualityLevel = 'balanced';
+    const detailController = createSceneDetailController(currentLevel);
+    const controller = createAdaptiveQualityController({
+      qualityManager: {
+        getLevel: () => currentLevel,
+        setLevel: (next) => {
+          currentLevel = next;
+          detailController.setLevel(next);
+        },
+        setBasePixelRatio: () => {
+          /* noop */
+        },
+      },
+      getBasePixelRatio: () => 1,
+      setBasePixelRatio: () => {
+        /* noop */
+      },
+      cooldownMs: 0,
+      downgradeAfterMs: 100,
+      warmupMs: 0,
+      getSelectionSource: () => 'adaptive',
+    });
+
+    for (let index = 0; index < 8; index += 1) {
+      controller.update(0.05);
+    }
+
+    expect(detailController.getPolicy().level).toBe('performance');
+    expect(detailController.getPolicy().effects.shaderMist).toBe(false);
   });
 });

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -1,6 +1,7 @@
 import { CylinderGeometry, MeshStandardMaterial, Color } from 'three';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import { scalePoiValue } from '../scene/poi/constants';
 import {
   createPoiInstances,
@@ -243,6 +244,50 @@ describe('createPoiInstances', () => {
     );
     expect(instance.orbBaseHeight).toBeGreaterThan(pedestalHeight);
     expect(instance.labelBaseHeight).toBeGreaterThan(instance.orbBaseHeight);
+  });
+
+  it('uses low-segment performance marker geometry while preserving hit collider behavior', () => {
+    const definition = createDefinition({
+      id: 'flywheel-studio-flywheel',
+      roomId: 'studio',
+      footprint: { width: 2.6, depth: 2.2 },
+      pedestal: {
+        type: 'hologram',
+        height: 1.6,
+      },
+    });
+
+    const [balanced] = createPoiInstances(
+      [definition],
+      {},
+      {
+        detailPolicy: getSceneDetailPolicy('balanced'),
+      }
+    );
+    const [performance] = createPoiInstances(
+      [definition],
+      {},
+      {
+        detailPolicy: getSceneDetailPolicy('performance'),
+      }
+    );
+
+    const balancedHitGeometry = balanced.hitArea.geometry as CylinderGeometry;
+    const performanceHitGeometry = performance.hitArea
+      .geometry as CylinderGeometry;
+
+    expect(
+      performanceHitGeometry.parameters.radialSegments
+    ).toBeLessThanOrEqual(balancedHitGeometry.parameters.radialSegments / 4);
+    expect(
+      performance.group.getObjectByName(`POI_PedestalBody:${definition.id}`)
+    ).toBeUndefined();
+    expect(performance.hitArea.name).toBe(balanced.hitArea.name);
+    expect(performance.collider).toEqual(balanced.collider);
+    expect(performance.orbBaseHeight).toBeCloseTo(
+      balanced.orbBaseHeight ?? 0,
+      5
+    );
   });
 
   it('keeps default pedestal styling when no hologram config is provided', () => {


### PR DESCRIPTION
### Motivation
- Performance mode was insufficiently aggressive on weak/tablet devices; need a centralized scene-level policy to cut shader/fill-rate, textures, draw calls, dynamic lights and triangle count for a ~10× theoretical workload reduction. 
- Centralize detail budgets so Balanced/Cinematic remain unchanged while Performance activates low-poly/low-effect fallbacks and throttles decorative work.

### Description
- Introduces a typed scene detail policy and controller: `src/scene/graphics/sceneDetailPolicy.ts` and `src/scene/graphics/sceneDetailController.ts` and `getSceneDetailPolicy(...)` to expose segment counts, texture sizes, effect toggles and update throttles for `'cinematic' | 'balanced' | 'performance'`.
- Wire the controller into scene bootstrap (`src/main.ts`) so Performance applies when selected, when adaptive quality downgrades to Performance, or on coarse-pointer / low-memory tablet-like sessions via enhanced `resolveInitialQualityPolicy` in `src/scene/performance/qualityPolicy.ts`.
- Apply low-detail buckets across expensive builders and update loops: POI markers, mannequin, flywheel, Jobbot terminal, media wall, greenhouse, backyard, model rocket and others now accept/consult `detailPolicy` and produce lower-segment geometry, smaller canvas textures, disabled shaders (mist/pond), reduced dynamic lights, and throttled decorative updates or performance proxies where appropriate.
- Make runtime behavior safe: `createSceneDetailController` toggles visibility/materials/lights without unsafe rebuilds, and `shouldRunDecorativeUpdate` centralizes decorative throttling.
- Extend diagnostics and public API: `src/scene/performance/performanceDiagnostics.ts` now exposes `renderer.info` counters (calls/triangles/points/lines/memory) and includes the active `sceneDetail` policy in snapshots under `window.portfolio.performance.getSnapshot()`; add test coverage and docs entry describing goals and tradeoffs.

### Testing
- Lint and formatting: ran `npm run format:write` and `npm run lint`; lint finished with only one non-blocking import-order warning that was fixed during the rollout, overall status: success (warnings addressed).
- Typecheck: ran `npm run typecheck` (TS `--noEmit`) after fixes; result: success (no type errors remaining in the final run).
- Unit tests: ran `npm run test:ci -- src/tests/graphicsQualityManager.test.ts src/tests/performanceOptimization.test.ts src/tests/performanceDiagnostics.test.ts src/tests/poiMarkers.test.ts`; targeted suites passed (all tests green) and the edited/added tests asserting Performance budgets and LOD behavior passed.
- Full test suite: ran `npm run test:ci` (Vitest full suite) and observed all tests passing (final run: 132 test files, 935 tests passed); status: success.
- E2E: ran Playwright specs `playwright/immersive-performance.spec.ts` and `playwright/small-screen-hud.spec.ts`; initial run required installing Playwright browsers and host deps (installed via `npx playwright install` and `npx playwright install-deps`), after which the Playwright runs completed successfully (4 passed, 1 skipped in staging as noted); status: success after installing required browser packages.
- Build/smoke: ran `npm run build` and `npm run smoke`; build succeeded and smoke validation passed (dist artifacts created). 

Notes and follow-ups: the policy targets theoretical workload reduction (not a guaranteed FPS multiplier on every device); Playwright required the platform browser dependencies during CI-like runs (`npx playwright install` / `npx playwright install-deps`) which the rollout executed to validate E2E; scene-detail files are added (`sceneDetailPolicy`, `sceneDetailController`)—these are marked new in the diff and are safe, centralized helpers to avoid scattering quality checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1face2e198832fa885ac5102919ab7)