### PR TITLE
🌐 : – cover Mandarin POI nested fallback copy

### DIFF
--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -438,14 +438,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       outcome: { label: '成果', value: '保持中继只看到密文和安全路由元数据。' },
       metrics: [
         {
-          label: 'Stars',
+          label: '星标',
           value: '正在从 GitHub 同步…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'token.place',
             format: 'compact',
-            template: '{value} stars',
+            template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
           },
         },
@@ -486,14 +486,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       },
       metrics: [
         {
-          label: 'Stars',
+          label: '星标',
           value: '正在从 GitHub 同步…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'flywheel',
             format: 'compact',
-            template: '{value} stars',
+            template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
           },
         },
@@ -520,14 +520,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       },
       metrics: [
         {
-          label: 'Stars',
+          label: '星标',
           value: '正在从 GitHub 同步…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'jobbot3000',
             format: 'compact',
-            template: '{value} stars',
+            template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
           },
         },
@@ -571,14 +571,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       },
       metrics: [
         {
-          label: 'Stars',
+          label: '星标',
           value: '正在从 GitHub 同步…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'gitshelves',
             format: 'compact',
-            template: '{value} stars',
+            template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
           },
         },
@@ -602,14 +602,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       },
       metrics: [
         {
-          label: 'Stars',
+          label: '星标',
           value: '1,280+',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'danielsmith.io',
             format: 'compact',
-            template: '{value} stars',
+            template: '{value} 个星标',
             fallback: '1,280+',
           },
         },

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -122,6 +122,27 @@ describe('i18n utilities', () => {
     expect(englishPoi).not.toBe(pseudoPoi);
   });
 
+  it('localizes zh-Hans GitHub star metric copy without English fallback', () => {
+    const definitions = getPoiDefinitions('zh-Hans');
+    const poi = definitions.find((definition) =>
+      definition.metrics?.some(
+        (metric) => metric.source?.type === 'githubStars'
+      )
+    );
+    const starMetric = poi?.metrics?.find(
+      (metric) => metric.source?.type === 'githubStars'
+    );
+
+    expect(poi?.id).toBe('tokenplace-studio-cluster');
+    expect(starMetric?.label).toBe('星标');
+    expect(starMetric?.value).toBe('正在从 GitHub 同步…');
+    expect(starMetric?.source).toMatchObject({
+      type: 'githubStars',
+      template: '{value} 个星标',
+      fallback: '正在从 GitHub 同步…',
+    });
+  });
+
   it('deep-clones localized POI metric sources per call', () => {
     const firstDefinitions = getPoiDefinitions('en-x-pseudo');
     const firstPoi = firstDefinitions.find(

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getPoiOverlayChromeStrings } from '../assets/i18n';
+import { getPoiDefinitions } from '../scene/poi/registry';
 import { PoiTooltipOverlay } from '../scene/poi/tooltipOverlay';
 import type { PoiDefinition } from '../scene/poi/types';
 import { GuidedTourPreference } from '../systems/guidedTour/preference';
@@ -435,6 +437,51 @@ describe('PoiTooltipOverlay', () => {
         .querySelector('.poi-tooltip-overlay__links')
         ?.getAttribute('aria-label')
     ).toBe('⟦Related case studies⟧');
+  });
+
+  it('renders zh-Hans POI detail copy and overlay chrome without English fallback', () => {
+    const poi = getPoiDefinitions('zh-Hans').find(
+      (definition) => definition.id === 'tokenplace-studio-cluster'
+    );
+    expect(poi).toBeDefined();
+
+    const zhPoi = poi!;
+    overlay.setStrings(getPoiOverlayChromeStrings('zh-Hans'));
+    overlay.setVisitedPoiIds(new Set([zhPoi.id]));
+    overlay.setRecommendation(zhPoi);
+    overlay.setSelected(zhPoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__summary')?.textContent
+    ).toBe('中继盲的端到端加密令牌中转站，用于安全共享敏感短文本。');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__outcome-label')?.textContent
+    ).toBe('成果');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__outcome-value')?.textContent
+    ).toBe('保持中继只看到密文和安全路由元数据。');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__status')?.textContent
+    ).toBe('原型');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__visited')?.textContent
+    ).toBe('已访问');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__recommendation')?.textContent
+    ).toBe('下一个亮点');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-label')?.textContent
+    ).toBe('星标');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-value')?.textContent
+    ).toBe('正在从 GitHub 同步…');
+    expect(
+      root
+        .querySelector('.poi-tooltip-overlay__links')
+        ?.getAttribute('aria-label')
+    ).toBe('相关案例研究');
   });
 
   it('skips rebuilding active POI content when updates do not change copy', () => {


### PR DESCRIPTION
### Motivation
- Ensure Simplified Chinese (`zh-Hans`) POI metric chrome and nested POI detail fields do not silently fall back to English by localizing remaining visible English metric labels/templates used in POI copy. 
- Add deterministic unit coverage that will fail if `zh-Hans` POI details rely on English fallback for nested metric fields or overlay chrome.

### Description
- Translated visible GitHub star metric labels and templates from `Stars` / `'{value} stars'` to Chinese `星标` / `'{value} 个星标'` in `src/assets/i18n/locales/zh-Hans.ts` without changing URLs, repo names, or code identifiers. 
- Added a focused i18n unit test asserting a `zh-Hans` POI with a `githubStars` metric exposes Chinese `label`, `template`, and `fallback` in `src/tests/i18n.test.ts`. 
- Extended the existing POI tooltip overlay test to render a `zh-Hans` POI and assert Chinese overlay chrome, summary, outcome, status, visited/recommendation badges, metric label/value, and related-case aria label in `src/tests/poiTooltipOverlay.test.ts`. 
- Kept the change small and limited to the requested files: `src/assets/i18n/locales/zh-Hans.ts`, `src/tests/i18n.test.ts`, and `src/tests/poiTooltipOverlay.test.ts`.

### Testing
- Ran formatting with `npm run format:write` and lint with `npm run lint`, both succeeded. 
- Ran `npm run typecheck`, which surfaced pre-existing unrelated TypeScript errors in the repo and did not fail due to the scoped changes. 
- Ran targeted tests `npm run test:ci -- src/tests/i18n.test.ts src/tests/textFallbackAccessibility.test.ts src/tests/localeToggleControl.test.ts` and `npm run test:ci -- src/tests/poiTooltipOverlay.test.ts`, and those tests passed. 
- Ran full test suite with `npm run test:ci` which passed (all Vitest tests green), and built production bundle with `npm run build` which succeeded. 
- Ran the repository secret scan script and found no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb6210840832f9d2e7f90be841a26)