### PR TITLE
Make ambient audio and guided tour opt-in by default

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -357,11 +357,11 @@ Focus: unify user controls and ensure graceful fallback experiences.
 3. **Progression & State**
    - ✅ Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
      - ✅ SessionStorage fallback now protects POI progress when localStorage is blocked.
-     - ✅ Ambient audio mute preference now persists with localStorage + sessionStorage fallback
-       and auto-resumes after the next pointer/key interaction to respect autoplay policies.
+     - ✅ Ambient audio is opt-in by default; explicit on/off choices persist with localStorage +
+       sessionStorage fallback and only resume after pointer/key interaction when enabled.
    - ✅ In-world visual cues for discovered content (e.g., glowing trims, checkmarks).
      - ✅ Visited POIs now reveal holographic checkmark badges that hover above each pedestal.
-   - ✅ Guided tour toggle lets players pause highlight recommendations while keeping reset tools.
+   - ✅ Guided tour toggle keeps highlight recommendations opt-in while preserving reset tools.
      - ✅ Idle monitor now waits roughly four seconds of inactivity before surfacing the next
        highlight so overlays stay quiet while the player is actively moving or interacting.
    - ✅ Visited POI progress persists across reloads, powering halo highlights and tooltip badges.

--- a/src/main.ts
+++ b/src/main.ts
@@ -327,6 +327,7 @@ import {
   createGitHubRepoStatsService,
   type GitHubRepoStatsDiagnostics,
 } from './systems/github/repoStats';
+import { GuidedTourPreference } from './systems/guidedTour/preference';
 import {
   createAnalyticsGlowRhythm,
   type AnalyticsGlowRhythmHandle,
@@ -882,25 +883,29 @@ function initializeImmersiveScene(
 
   const readGuidedTourEnabled = (): boolean => {
     const stored = guidedTourStorage?.getItem(GUIDED_TOUR_STORAGE_KEY);
-    if (stored === 'false') {
-      return false;
-    }
-    if (stored === 'true') {
+    if (stored === 'true' || stored === '1') {
       return true;
     }
-    return true;
+    if (stored === 'false' || stored === '0') {
+      return false;
+    }
+    return false;
   };
 
   const writeGuidedTourEnabled = (enabled: boolean) => {
     try {
-      guidedTourStorage?.setItem(
-        GUIDED_TOUR_STORAGE_KEY,
-        enabled ? 'true' : 'false'
-      );
+      guidedTourStorage?.setItem(GUIDED_TOUR_STORAGE_KEY, enabled ? '1' : '0');
     } catch {
       /* ignore storage write failures */
     }
   };
+
+  const guidedTourPreference = new GuidedTourPreference({
+    storage: guidedTourStorage ?? null,
+    storageKey: GUIDED_TOUR_STORAGE_KEY,
+    windowTarget: window,
+    defaultEnabled: false,
+  });
 
   const detectedLanguage =
     typeof navigator !== 'undefined' && navigator.language
@@ -1595,6 +1600,7 @@ function initializeImmersiveScene(
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    guidedTourPreference,
     discoveryAnnouncer: {
       format: (poi, strings) =>
         formatMessage(strings.discoveryAnnouncementTemplate, {
@@ -1607,7 +1613,11 @@ function initializeImmersiveScene(
     },
   });
   poiTooltipOverlay.setStrings(poiOverlayStrings);
-  const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const poiWorldTooltip = new PoiWorldTooltip({
+    parent: scene,
+    camera,
+    guidedTourPreference,
+  });
   const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
     (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
     (!isMobilePoiLayout(layoutOverride) || currentSelectedPoi !== null);
@@ -1900,6 +1910,12 @@ function initializeImmersiveScene(
       }
       currentGuidedTourRecommendation = recommendation;
       syncPoiRecommendation();
+    }
+  );
+  const unsubscribeGuidedTourPreference = guidedTourPreference.subscribe(
+    (enabled) => {
+      guidedTourChannel?.setEnabled(enabled);
+      tourGuideToggleControl?.setEnabled(enabled);
     }
   );
 
@@ -3512,7 +3528,7 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       initialEnabled: initialGuidedTourEnabled,
       onToggle: (enabled) => {
-        guidedTourChannel?.setEnabled(enabled);
+        guidedTourPreference.setEnabled(enabled, 'control');
         writeGuidedTourEnabled(enabled);
       },
       strings: tourGuideToggleStrings,
@@ -3526,6 +3542,7 @@ function initializeImmersiveScene(
         poiVisitedState.reset();
       },
       strings: tourResetControlStrings,
+      guidedTourPreference,
     });
     registerHudControlElement(tourResetControl?.element ?? null);
   }
@@ -4400,6 +4417,8 @@ function initializeImmersiveScene(
       removeGuidedTourSubscription();
       removeGuidedTourSubscription = null;
     }
+    unsubscribeGuidedTourPreference();
+    guidedTourPreference.dispose();
     guidedTourChannel?.dispose();
     guidedTourChannel = null;
     if (githubRepoMetrics) {

--- a/src/scene/poi/guidedTourChannel.ts
+++ b/src/scene/poi/guidedTourChannel.ts
@@ -30,7 +30,7 @@ export class GuidedTourChannel {
 
   private lastBroadcast: PoiDefinition | null = null;
 
-  constructor({ source, enabled = true }: GuidedTourChannelOptions) {
+  constructor({ source, enabled = false }: GuidedTourChannelOptions) {
     this.source = source;
     this.enabled = enabled;
     this.unsubscribeSource = this.source.subscribe((recommendation) => {

--- a/src/systems/controls/tourGuideToggleControl.ts
+++ b/src/systems/controls/tourGuideToggleControl.ts
@@ -17,7 +17,7 @@ export interface TourGuideToggleControlHandle {
 
 export function createTourGuideToggleControl({
   container,
-  initialEnabled = true,
+  initialEnabled = false,
   onToggle,
   strings: providedStrings,
 }: TourGuideToggleControlOptions): TourGuideToggleControlHandle {

--- a/src/systems/guidedTour/preference.ts
+++ b/src/systems/guidedTour/preference.ts
@@ -57,10 +57,10 @@ const getDefaultStorage = (target: Window | null): Storage | null => {
 };
 
 const parseStoredValue = (value: string | null): boolean | null => {
-  if (value === '1') {
+  if (value === '1' || value === 'true') {
     return true;
   }
-  if (value === '0') {
+  if (value === '0' || value === 'false') {
     return false;
   }
   return null;
@@ -84,7 +84,7 @@ export class GuidedTourPreference {
         ? getDefaultStorage(this.windowTarget)
         : options.storage;
     this.storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
-    this.enabled = this.loadInitialState(options.defaultEnabled ?? true);
+    this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
 
     if (this.windowTarget) {
       this.windowTarget.addEventListener('storage', this.handleStorageEvent);

--- a/src/tests/ambientAudioPreferenceBinding.test.ts
+++ b/src/tests/ambientAudioPreferenceBinding.test.ts
@@ -32,6 +32,31 @@ class FakeAmbientAudioController {
 }
 
 describe('bindAmbientAudioPreference', () => {
+  it('does not enable ambient audio on fresh gestures without an explicit opt-in', async () => {
+    const windowStub = new EventTarget();
+    const preference = new AmbientAudioPreference({
+      windowTarget: windowStub as unknown as Window,
+      storage: null,
+    });
+    const controller = new FakeAmbientAudioController();
+
+    const binding = bindAmbientAudioPreference({
+      controller,
+      preference,
+      windowTarget: windowStub as unknown as Window,
+      logger: { warn: vi.fn() },
+    });
+
+    windowStub.dispatchEvent(new Event('pointerdown'));
+    windowStub.dispatchEvent(new KeyboardEvent('keydown', { key: 'x' }));
+    await Promise.resolve();
+
+    expect(controller.enableMock).not.toHaveBeenCalled();
+    expect(controller.isEnabled()).toBe(false);
+
+    binding.dispose();
+  });
+
   it('enables ambient audio after pointer interaction when preference is stored', async () => {
     const windowStub = new EventTarget();
     const preference = new AmbientAudioPreference({

--- a/src/tests/guidedTourChannel.test.ts
+++ b/src/tests/guidedTourChannel.test.ts
@@ -44,9 +44,22 @@ const createSource = () => {
 };
 
 describe('GuidedTourChannel', () => {
+  it('defaults to suppressing recommendations until explicitly enabled', () => {
+    const { source } = createSource();
+    const channel = new GuidedTourChannel({ source });
+    const listener = vi.fn();
+
+    channel.subscribe(listener);
+
+    expect(channel.getEnabled()).toBe(false);
+    expect(listener).toHaveBeenLastCalledWith(null);
+
+    channel.dispose();
+  });
+
   it('forwards recommendations when enabled', () => {
     const { source, emit } = createSource();
-    const channel = new GuidedTourChannel({ source });
+    const channel = new GuidedTourChannel({ source, enabled: true });
     const updates: Array<string | null> = [];
 
     channel.subscribe((recommendation) => {

--- a/src/tests/guidedTourPreference.test.ts
+++ b/src/tests/guidedTourPreference.test.ts
@@ -21,7 +21,6 @@ describe('GuidedTourPreference', () => {
       },
       storageKey,
       windowTarget: window,
-      defaultEnabled: true,
     });
   });
 
@@ -29,23 +28,43 @@ describe('GuidedTourPreference', () => {
     preference.dispose();
   });
 
+  it('defaults to false when no stored preference exists', () => {
+    expect(preference.isEnabled()).toBe(false);
+    expect(storage.get(storageKey)).toBeUndefined();
+  });
+
+  it('loads persisted enabled states from legacy and current storage payloads', () => {
+    preference.dispose();
+    storage.set(storageKey, 'true');
+
+    preference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      storageKey,
+      windowTarget: window,
+    });
+
+    expect(preference.isEnabled()).toBe(true);
+  });
+
   it('toggles state, persists, and notifies listeners', () => {
     const listener = vi.fn();
     preference.subscribe(listener);
 
-    expect(preference.isEnabled()).toBe(true);
-    expect(storage.get(storageKey)).toBeUndefined();
+    preference.setEnabled(true, 'control');
 
-    preference.setEnabled(false, 'control');
-
-    expect(preference.isEnabled()).toBe(false);
-    expect(storage.get(storageKey)).toBe('0');
-    expect(listener).toHaveBeenCalledTimes(2);
-    expect(listener).toHaveBeenLastCalledWith(false);
-
-    preference.toggle();
     expect(preference.isEnabled()).toBe(true);
     expect(storage.get(storageKey)).toBe('1');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    preference.toggle();
+    expect(preference.isEnabled()).toBe(false);
+    expect(storage.get(storageKey)).toBe('0');
   });
 
   it('dispatches custom events when state changes', () => {
@@ -55,11 +74,11 @@ describe('GuidedTourPreference', () => {
       handler as EventListener
     );
 
-    preference.setEnabled(false, 'api');
+    preference.setEnabled(true, 'api');
 
     expect(handler).toHaveBeenCalledTimes(1);
     const event = handler.mock.calls[0][0] as CustomEvent;
-    expect(event.detail).toEqual({ enabled: false, source: 'api' });
+    expect(event.detail).toEqual({ enabled: true, source: 'api' });
 
     window.removeEventListener(
       GUIDED_TOUR_PREFERENCE_EVENT,
@@ -74,12 +93,12 @@ describe('GuidedTourPreference', () => {
 
     const storageEvent = new StorageEvent('storage', {
       key: storageKey,
-      newValue: '0',
+      newValue: '1',
     });
 
     window.dispatchEvent(storageEvent);
 
-    expect(preference.isEnabled()).toBe(false);
-    expect(listener).toHaveBeenCalledWith(false);
+    expect(preference.isEnabled()).toBe(true);
+    expect(listener).toHaveBeenCalledWith(true);
   });
 });

--- a/src/tests/tourGuideToggleControl.test.ts
+++ b/src/tests/tourGuideToggleControl.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { createTourGuideToggleControl } from '../systems/controls/tourGuideToggleControl';
 
 describe('tourGuideToggleControl', () => {
-  it('renders an enabled toggle by default', () => {
+  it('renders a disabled toggle by default', () => {
     const container = document.createElement('div');
     const handle = createTourGuideToggleControl({ container });
 
     expect(container.querySelector('.tour-toggle')).toBe(handle.element);
-    expect(handle.element.dataset.state).toBe('enabled');
-    expect(handle.element.getAttribute('aria-pressed')).toBe('true');
-    expect(handle.element.dataset.hudAnnounce).toContain('Guided tour on');
+    expect(handle.element.dataset.state).toBe('disabled');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('false');
+    expect(handle.element.dataset.hudAnnounce).toContain('Guided tour off');
 
     handle.dispose();
   });
@@ -67,6 +67,6 @@ describe('tourGuideToggleControl', () => {
     expect(container.contains(button)).toBe(false);
 
     button.click();
-    expect(button.dataset.state).toBe('enabled');
+    expect(button.dataset.state).toBe('disabled');
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent fresh sessions from automatically starting ambient audio or surfacing guided-tour recommendations so users are not surprised by autoplay or unsolicited highlights.
- Preserve explicit user choices (on/off) across reloads while making new sessions start with both features off unless the user previously opted in.
- Keep the UI, POI overlays, and channel logic synchronized with a single preference instance so Settings toggles, HUD controls, and world overlays remain consistent.

### Description
- Change guided-tour defaults to opt-out by default by making `GuidedTourPreference` default to `false`, the `GuidedTourChannel` constructor default `enabled` to `false`, and the tour toggle control default `initialEnabled` to `false` so fresh UI shows Off. (files: `src/systems/guidedTour/preference.ts`, `src/scene/poi/guidedTourChannel.ts`, `src/systems/controls/tourGuideToggleControl.ts`).
- Centralize and share a `GuidedTourPreference` instance in `src/main.ts`, wire it into `PoiTooltipOverlay` / `PoiWorldTooltip` / tour toggle / reset controls, and subscribe/unsubscribe lifecycle to keep settings synchronized and persisted. (file: `src/main.ts`).
- Accept both legacy (`true` / `false`) and numeric (`1` / `0`) payloads when reading stored guided-tour state and migrate writes to the numeric `1`/`0` format so previous installs that wrote `true`/`false` remain compatible. (files: `src/systems/guidedTour/preference.ts`, `src/main.ts`).
- Ensure ambient audio remains opt-in: `AmbientAudioPreference` already defaults to `false` and added a unit test to guard that fresh pointer/keyboard gestures do not enable ambient audio unless the stored preference explicitly requested it. (files: `src/systems/audio/ambientAudioPreference.ts`, `src/tests/ambientAudioPreferenceBinding.test.ts`).
- Add and update unit tests covering: guided-tour preference defaults & storage compatibility, guided-tour channel suppression when disabled, tour toggle default state, and ambient audio gesture suppression before explicit opt-in. (files: `src/tests/guidedTourPreference.test.ts`, `src/tests/guidedTourChannel.test.ts`, `src/tests/tourGuideToggleControl.test.ts`, `src/tests/ambientAudioPreferenceBinding.test.ts`).
- Document the opt-in behavior in `docs/roadmap.md` to reflect the change in UX expectations.

### Testing
- `npm run format:write` — succeeded (applied formatting to touched files).
- `npm run lint` — succeeded (one import-order warning fixed during edits; no blocking ESLint errors).
- `npm run typecheck` — failed (repo-wide TypeScript errors unrelated to this change remain in upstream code; these are pre-existing and not introduced by this PR). Exact failures reported by `tsc` are in the run log and are not caused by the guided-audio/tour changes.
- Focused unit tests: `npm run test:ci -- src/tests/ambientAudioPreference.test.ts src/tests/ambientAudioPreferenceBinding.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts` — all tests passed.
- Full unit test suite: `npm run test:ci` — all tests passed locally (133 files, 946 tests succeeded in the run log).
- Build: `npm run build` — succeeded and produced `dist` artifacts.
- Playwright e2e: `npm run test:e2e -- playwright/small-screen-hud.spec.ts` — initially failed due to missing Playwright browser binaries, then passed after installing Playwright browsers and system deps (`npx playwright install` / `npx playwright install-deps`), resulting in the spec passing locally.
- Docs check: `npm run docs:check` — passed.
- Smoke: `npm run smoke` (build + dist assert) — passed.

Residual notes and compatibility
- Stored legacy values of `true`/`false` are still recognized, and new writes use `1`/`0`; this provides backward compatibility while normalizing persisted payloads going forward.
- `tsc` currently reports many unrelated type errors in the repo; those pre-existed and were not introduced by these changes (the unit and e2e suites passed locally).
- No user-facing removal of functionality: users can still enable/disable ambient audio and guided tour in Settings; enabling persists and restores across reloads; disabling also persists.

Branch and commit
- Changes are on branch `codex/opt-in-audio-guided-tour` and committed with message "🔇 : – Make audio and tours opt-in".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc36c8830832fbddd7f23439aa70f)