### PR TITLE
Make audio and guided tour opt-in

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -327,6 +327,7 @@ import {
   createGitHubRepoStatsService,
   type GitHubRepoStatsDiagnostics,
 } from './systems/github/repoStats';
+import { defaultGuidedTourPreference } from './systems/guidedTour/preference';
 import {
   createAnalyticsGlowRhythm,
   type AnalyticsGlowRhythmHandle,
@@ -888,7 +889,7 @@ function initializeImmersiveScene(
     if (stored === 'true') {
       return true;
     }
-    return true;
+    return defaultGuidedTourPreference.isEnabled();
   };
 
   const writeGuidedTourEnabled = (enabled: boolean) => {
@@ -1889,6 +1890,7 @@ function initializeImmersiveScene(
   const removeVisitedSubscription =
     poiVisitedState.subscribe(handleVisitedUpdate);
   const initialGuidedTourEnabled = readGuidedTourEnabled();
+  defaultGuidedTourPreference.setEnabled(initialGuidedTourEnabled, 'api');
   guidedTourChannel = new GuidedTourChannel({
     source: poiTourGuide,
     enabled: initialGuidedTourEnabled,
@@ -1902,6 +1904,12 @@ function initializeImmersiveScene(
       syncPoiRecommendation();
     }
   );
+  const removeGuidedTourPreferenceSubscription =
+    defaultGuidedTourPreference.subscribe((enabled) => {
+      guidedTourChannel?.setEnabled(enabled);
+      tourGuideToggleControl?.setEnabled(enabled);
+      writeGuidedTourEnabled(enabled);
+    });
 
   const futuroptimistPoi = poiInstances.find(
     (poi) => poi.definition.id === 'futuroptimist-living-room-tv'
@@ -3512,8 +3520,7 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       initialEnabled: initialGuidedTourEnabled,
       onToggle: (enabled) => {
-        guidedTourChannel?.setEnabled(enabled);
-        writeGuidedTourEnabled(enabled);
+        defaultGuidedTourPreference.setEnabled(enabled, 'control');
       },
       strings: tourGuideToggleStrings,
     });
@@ -4400,6 +4407,7 @@ function initializeImmersiveScene(
       removeGuidedTourSubscription();
       removeGuidedTourSubscription = null;
     }
+    removeGuidedTourPreferenceSubscription();
     guidedTourChannel?.dispose();
     guidedTourChannel = null;
     if (githubRepoMetrics) {

--- a/src/scene/poi/guidedTourChannel.ts
+++ b/src/scene/poi/guidedTourChannel.ts
@@ -30,7 +30,7 @@ export class GuidedTourChannel {
 
   private lastBroadcast: PoiDefinition | null = null;
 
-  constructor({ source, enabled = true }: GuidedTourChannelOptions) {
+  constructor({ source, enabled = false }: GuidedTourChannelOptions) {
     this.source = source;
     this.enabled = enabled;
     this.unsubscribeSource = this.source.subscribe((recommendation) => {

--- a/src/systems/guidedTour/preference.ts
+++ b/src/systems/guidedTour/preference.ts
@@ -84,7 +84,7 @@ export class GuidedTourPreference {
         ? getDefaultStorage(this.windowTarget)
         : options.storage;
     this.storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
-    this.enabled = this.loadInitialState(options.defaultEnabled ?? true);
+    this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
 
     if (this.windowTarget) {
       this.windowTarget.addEventListener('storage', this.handleStorageEvent);

--- a/src/tests/ambientAudioPreferenceBinding.test.ts
+++ b/src/tests/ambientAudioPreferenceBinding.test.ts
@@ -32,6 +32,32 @@ class FakeAmbientAudioController {
 }
 
 describe('bindAmbientAudioPreference', () => {
+  it('does not enable ambient audio after a gesture when no preference is stored', async () => {
+    const windowStub = new EventTarget();
+    const preference = new AmbientAudioPreference({
+      windowTarget: windowStub as unknown as Window,
+      storage: null,
+    });
+    const controller = new FakeAmbientAudioController();
+
+    const binding = bindAmbientAudioPreference({
+      controller,
+      preference,
+      windowTarget: windowStub as unknown as Window,
+      logger: { warn: vi.fn() },
+    });
+
+    windowStub.dispatchEvent(new Event('pointerdown'));
+    windowStub.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));
+    await Promise.resolve();
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(controller.enableMock).not.toHaveBeenCalled();
+    expect(controller.isEnabled()).toBe(false);
+
+    binding.dispose();
+  });
+
   it('enables ambient audio after pointer interaction when preference is stored', async () => {
     const windowStub = new EventTarget();
     const preference = new AmbientAudioPreference({

--- a/src/tests/guidedTourChannel.test.ts
+++ b/src/tests/guidedTourChannel.test.ts
@@ -44,9 +44,24 @@ const createSource = () => {
 };
 
 describe('GuidedTourChannel', () => {
-  it('forwards recommendations when enabled', () => {
+  it('starts disabled by default', () => {
     const { source, emit } = createSource();
     const channel = new GuidedTourChannel({ source });
+    const listener = vi.fn();
+
+    channel.subscribe(listener);
+    emit(samplePoi(ids[1]));
+
+    expect(channel.getEnabled()).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(null);
+
+    channel.dispose();
+  });
+
+  it('forwards recommendations when enabled', () => {
+    const { source, emit } = createSource();
+    const channel = new GuidedTourChannel({ source, enabled: true });
     const updates: Array<string | null> = [];
 
     channel.subscribe((recommendation) => {
@@ -87,7 +102,7 @@ describe('GuidedTourChannel', () => {
 
   it('unsubscribes from the source on dispose', () => {
     const { source, emit, listeners } = createSource();
-    const channel = new GuidedTourChannel({ source });
+    const channel = new GuidedTourChannel({ source, enabled: true });
     const listener = vi.fn();
     channel.subscribe(listener);
 

--- a/src/tests/guidedTourPreference.test.ts
+++ b/src/tests/guidedTourPreference.test.ts
@@ -6,6 +6,60 @@ import {
 } from '../systems/guidedTour/preference';
 
 describe('GuidedTourPreference', () => {
+  it('defaults to disabled when no stored preference exists', () => {
+    const storage = new Map<string, string>();
+    const preference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      storageKey: 'test-guided-tour-default',
+      windowTarget: window,
+    });
+
+    expect(preference.isEnabled()).toBe(false);
+
+    preference.dispose();
+  });
+
+  it('restores explicit stored enabled and disabled preferences', () => {
+    const enabledStorage = new Map<string, string>([
+      ['test-guided-tour-enabled', '1'],
+    ]);
+    const disabledStorage = new Map<string, string>([
+      ['test-guided-tour-disabled', '0'],
+    ]);
+
+    const enabledPreference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => enabledStorage.get(key) ?? null,
+        setItem: (key, value) => {
+          enabledStorage.set(key, value);
+        },
+      },
+      storageKey: 'test-guided-tour-enabled',
+      windowTarget: window,
+    });
+    const disabledPreference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => disabledStorage.get(key) ?? null,
+        setItem: (key, value) => {
+          disabledStorage.set(key, value);
+        },
+      },
+      storageKey: 'test-guided-tour-disabled',
+      windowTarget: window,
+    });
+
+    expect(enabledPreference.isEnabled()).toBe(true);
+    expect(disabledPreference.isEnabled()).toBe(false);
+
+    enabledPreference.dispose();
+    disabledPreference.dispose();
+  });
+
   let storage: Map<string, string>;
   let preference: GuidedTourPreference;
   const storageKey = 'test-guided-tour';

--- a/src/tests/tourResetControl.test.ts
+++ b/src/tests/tourResetControl.test.ts
@@ -45,6 +45,34 @@ describe('createTourResetControl', () => {
       defaultEnabled: true,
     });
 
+  it('shows the guided tour toggle as off by default', () => {
+    const container = createContainer();
+    const subscription = createVisitedSubscription();
+    const preference = new GuidedTourPreference({
+      storage: null,
+      windowTarget: window,
+    });
+
+    const handle = createTourResetControl({
+      container,
+      subscribeVisited: subscription.subscribe,
+      onReset: vi.fn(),
+      guidedTourPreference: preference,
+    });
+
+    const toggle = handle.element.querySelector(
+      '.guided-tour-control__toggle'
+    ) as HTMLButtonElement;
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(toggle.dataset.state).toBe('off');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+
+    handle.dispose();
+    preference.dispose();
+    container.remove();
+  });
+
   it('renders disabled state until POIs are visited', () => {
     const container = createContainer();
     const subscription = createVisitedSubscription();


### PR DESCRIPTION
### Motivation
- Prevent fresh sessions from automatically starting ambient audio or showing guided-tour recommendations while preserving explicit stored preferences.
- Keep Settings/HUD controls and the runtime guided-tour channel in sync so user opt-ins persist and restore correctly.

### Description
- Default guided-tour preference to disabled by changing `GuidedTourPreference` to load `options.defaultEnabled ?? false` in `src/systems/guidedTour/preference.ts`.
- Initialize `GuidedTourChannel` disabled by default by changing its constructor default to `enabled = false` in `src/scene/poi/guidedTourChannel.ts`.
- Wire immersive startup to read the persisted guided-tour value and sync it into a shared `defaultGuidedTourPreference`, then subscribe to keep the channel, HUD toggle, and storage in sync in `src/main.ts`.
- Make the tour HUD toggle update the shared `defaultGuidedTourPreference` (instead of writing storage directly) so user control is the single source of truth.
- Add and update unit tests to cover fresh defaults and opt-in behaviour (tests touched/added: `src/tests/guidedTourPreference.test.ts`, `src/tests/guidedTourChannel.test.ts`, `src/tests/tourResetControl.test.ts`, `src/tests/ambientAudioPreferenceBinding.test.ts`, and `src/tests/ambientAudioPreference.test.ts`).

### Testing
- Ran formatting with `npm run format:write` (succeeded).
- Ran lint with `npm run lint` (succeeded; one import-order warning was fixed during edits).
- Ran type-check with `npm run typecheck` which surfaced existing repository-wide TypeScript issues unrelated to this change (status: failed; these are pre-existing and out of scope for this PR).
- Ran targeted unit tests with `npm run test:ci -- <tests>` (guided-tour / ambient-audio / POI tooltip/world tests) and full suite `npm run test:ci`, both completed successfully (all Vitest tests passed).
- Built the app with `npm run build` (succeeded) and verified smoke checks with `npm run smoke` (succeeded).
- Executed end-to-end Playwright checks `npm run test:e2e -- playwright/small-screen-hud.spec.ts` after downloading browsers and installing system deps; E2E specs passed after the environment installs (Playwright browser install and deps step required but was performed in the CI run).

Notes and risks: the change preserves explicit stored preferences and only changes defaults for fresh sessions; a repository-wide `tsc` noise exists (pre-existing) so `npm run typecheck` shows unrelated errors and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc36c8830832fbddd7f23439aa70f)