### PR TITLE
Make ambient audio and guided tour opt-in by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ Launch screenshot workflow refresh and commit it after merge.
   languages flow correctly even before full translations land. Mandarin Chinese (`zh-Hans`) is available in the public language picker; the pseudo locale remains internal and only appears in development, with `?i18nDebug=1`, or after setting `localStorage['danielsmith.io:i18nDebug']='true'` for translation QA.
 - **Audio captions** – A subtitles overlay now calls out ambient beds and POI narration with
   cooldown-aware timing so visitors who mute audio or rely on captions still catch the
-  story beats.
+  story beats. Ambient audio remains off for fresh sessions until visitors explicitly
+  opt in from the HUD, and that preference persists across reloads.
 - **Backyard installations** – The dusk courtyard now features a DSPACE-inspired model rocket on a
   lit launch pad with a safety halo, tying the exterior exhibits into the narrative while the nav
   colliders keep players clear of the ignition zone.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -358,15 +358,15 @@ Focus: unify user controls and ensure graceful fallback experiences.
    - ✅ Lightweight save of visited POIs and toggled settings (localStorage w/ fallbacks).
      - ✅ SessionStorage fallback now protects POI progress when localStorage is blocked.
      - ✅ Ambient audio mute preference now persists with localStorage + sessionStorage fallback
-       and auto-resumes after the next pointer/key interaction to respect autoplay policies.
+       and only auto-resumes after the next pointer/key interaction when a visitor explicitly opted in, preventing fresh-session autoplay surprises.
    - ✅ In-world visual cues for discovered content (e.g., glowing trims, checkmarks).
      - ✅ Visited POIs now reveal holographic checkmark badges that hover above each pedestal.
-   - ✅ Guided tour toggle lets players pause highlight recommendations while keeping reset tools.
+   - ✅ Guided tour toggle lets players opt into or pause highlight recommendations while keeping reset tools.
      - ✅ Idle monitor now waits roughly four seconds of inactivity before surfacing the next
        highlight so overlays stay quiet while the player is actively moving or interacting.
    - ✅ Visited POI progress persists across reloads, powering halo highlights and tooltip badges.
    - ✅ Accessibility HUD now remembers ambient audio volume tweaks between play sessions.
-   - ✅ Guided tour overlay surfaces the next recommended POI whenever the player is idle.
+   - ✅ Guided tour overlay surfaces the next recommended POI whenever an opted-in player is idle.
    - ✅ Guided tour reset utility now lets the HUD restart the curated path on demand so
      visitors can replay the experience during sessions or demos.
      - ✅ Guided tour reset control now flags pending resets with `aria-busy` so screen readers

--- a/src/main.ts
+++ b/src/main.ts
@@ -327,6 +327,7 @@ import {
   createGitHubRepoStatsService,
   type GitHubRepoStatsDiagnostics,
 } from './systems/github/repoStats';
+import { GuidedTourPreference } from './systems/guidedTour/preference';
 import {
   createAnalyticsGlowRhythm,
   type AnalyticsGlowRhythmHandle,
@@ -839,6 +840,7 @@ function initializeImmersiveScene(
   let proceduralNarrator: ProceduralNarrator | null = null;
   let localeToggleControl: LocaleToggleControlHandle | null = null;
   let guidedTourChannel: GuidedTourChannel | null = null;
+  let removeGuidedTourPreferenceSubscription: (() => void) | null = null;
   let idleMonitor: IdleMonitor | null = null;
   let removeIdleSubscription: (() => void) | null = null;
   let removeGuidedTourSubscription: (() => void) | null = null;
@@ -881,14 +883,18 @@ function initializeImmersiveScene(
   });
 
   const readGuidedTourEnabled = (): boolean => {
-    const stored = guidedTourStorage?.getItem(GUIDED_TOUR_STORAGE_KEY);
-    if (stored === 'false') {
-      return false;
+    try {
+      const stored = guidedTourStorage?.getItem(GUIDED_TOUR_STORAGE_KEY);
+      if (stored === 'false' || stored === '0') {
+        return false;
+      }
+      if (stored === 'true' || stored === '1') {
+        return true;
+      }
+    } catch {
+      /* ignore storage read failures */
     }
-    if (stored === 'true') {
-      return true;
-    }
-    return true;
+    return false;
   };
 
   const writeGuidedTourEnabled = (enabled: boolean) => {
@@ -901,6 +907,13 @@ function initializeImmersiveScene(
       /* ignore storage write failures */
     }
   };
+
+  const guidedTourPreference = new GuidedTourPreference({
+    storage: guidedTourStorage ?? null,
+    storageKey: GUIDED_TOUR_STORAGE_KEY,
+    windowTarget: window,
+    defaultEnabled: readGuidedTourEnabled(),
+  });
 
   const detectedLanguage =
     typeof navigator !== 'undefined' && navigator.language
@@ -1595,6 +1608,7 @@ function initializeImmersiveScene(
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    guidedTourPreference,
     discoveryAnnouncer: {
       format: (poi, strings) =>
         formatMessage(strings.discoveryAnnouncementTemplate, {
@@ -1607,7 +1621,11 @@ function initializeImmersiveScene(
     },
   });
   poiTooltipOverlay.setStrings(poiOverlayStrings);
-  const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const poiWorldTooltip = new PoiWorldTooltip({
+    parent: scene,
+    camera,
+    guidedTourPreference,
+  });
   const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
     (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
     (!isMobilePoiLayout(layoutOverride) || currentSelectedPoi !== null);
@@ -1893,6 +1911,12 @@ function initializeImmersiveScene(
     source: poiTourGuide,
     enabled: initialGuidedTourEnabled,
   });
+  removeGuidedTourPreferenceSubscription = guidedTourPreference.subscribe(
+    (enabled) => {
+      guidedTourChannel?.setEnabled(enabled);
+      tourGuideToggleControl?.setEnabled(enabled);
+    }
+  );
   removeGuidedTourSubscription = guidedTourChannel.subscribe(
     (recommendation) => {
       if (recommendation?.id !== dismissedPassiveRecommendationPoiId) {
@@ -3512,7 +3536,7 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       initialEnabled: initialGuidedTourEnabled,
       onToggle: (enabled) => {
-        guidedTourChannel?.setEnabled(enabled);
+        guidedTourPreference.setEnabled(enabled, 'control');
         writeGuidedTourEnabled(enabled);
       },
       strings: tourGuideToggleStrings,
@@ -3526,6 +3550,7 @@ function initializeImmersiveScene(
         poiVisitedState.reset();
       },
       strings: tourResetControlStrings,
+      guidedTourPreference,
     });
     registerHudControlElement(tourResetControl?.element ?? null);
   }
@@ -4400,6 +4425,10 @@ function initializeImmersiveScene(
       removeGuidedTourSubscription();
       removeGuidedTourSubscription = null;
     }
+    if (removeGuidedTourPreferenceSubscription) {
+      removeGuidedTourPreferenceSubscription();
+      removeGuidedTourPreferenceSubscription = null;
+    }
     guidedTourChannel?.dispose();
     guidedTourChannel = null;
     if (githubRepoMetrics) {
@@ -4410,6 +4439,7 @@ function initializeImmersiveScene(
     poiTooltipOverlay.dispose();
     poiWorldTooltip.dispose();
     poiTourGuide.dispose();
+    guidedTourPreference.dispose();
     if (manualModeToggle) {
       manualModeToggle.dispose();
       manualModeToggle = null;

--- a/src/scene/poi/guidedTourChannel.ts
+++ b/src/scene/poi/guidedTourChannel.ts
@@ -30,7 +30,7 @@ export class GuidedTourChannel {
 
   private lastBroadcast: PoiDefinition | null = null;
 
-  constructor({ source, enabled = true }: GuidedTourChannelOptions) {
+  constructor({ source, enabled = false }: GuidedTourChannelOptions) {
     this.source = source;
     this.enabled = enabled;
     this.unsubscribeSource = this.source.subscribe((recommendation) => {

--- a/src/systems/controls/tourGuideToggleControl.ts
+++ b/src/systems/controls/tourGuideToggleControl.ts
@@ -17,7 +17,7 @@ export interface TourGuideToggleControlHandle {
 
 export function createTourGuideToggleControl({
   container,
-  initialEnabled = true,
+  initialEnabled = false,
   onToggle,
   strings: providedStrings,
 }: TourGuideToggleControlOptions): TourGuideToggleControlHandle {

--- a/src/systems/guidedTour/preference.ts
+++ b/src/systems/guidedTour/preference.ts
@@ -57,10 +57,10 @@ const getDefaultStorage = (target: Window | null): Storage | null => {
 };
 
 const parseStoredValue = (value: string | null): boolean | null => {
-  if (value === '1') {
+  if (value === '1' || value === 'true') {
     return true;
   }
-  if (value === '0') {
+  if (value === '0' || value === 'false') {
     return false;
   }
   return null;
@@ -84,7 +84,7 @@ export class GuidedTourPreference {
         ? getDefaultStorage(this.windowTarget)
         : options.storage;
     this.storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
-    this.enabled = this.loadInitialState(options.defaultEnabled ?? true);
+    this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
 
     if (this.windowTarget) {
       this.windowTarget.addEventListener('storage', this.handleStorageEvent);

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -69,6 +69,19 @@ describe('AmbientAudioPreference', () => {
     expect(preference.isEnabled()).toBe(true);
   });
 
+  it('loads a persisted disabled state even if a caller supplies a true fallback', () => {
+    const storage = new MemoryStorage();
+    storage.setItem('test::preference', '0');
+
+    const preference = new AmbientAudioPreference({
+      storage,
+      storageKey: 'test::preference',
+      defaultEnabled: true,
+    });
+
+    expect(preference.isEnabled()).toBe(false);
+  });
+
   it('persists toggled states back to storage', () => {
     const storage = new MemoryStorage();
     const preference = new AmbientAudioPreference({

--- a/src/tests/ambientAudioPreferenceBinding.test.ts
+++ b/src/tests/ambientAudioPreferenceBinding.test.ts
@@ -32,6 +32,31 @@ class FakeAmbientAudioController {
 }
 
 describe('bindAmbientAudioPreference', () => {
+  it('does not enable ambient audio on gestures when preference is unset', async () => {
+    const windowStub = new EventTarget();
+    const preference = new AmbientAudioPreference({
+      windowTarget: windowStub as unknown as Window,
+      storage: null,
+    });
+    const controller = new FakeAmbientAudioController();
+
+    const binding = bindAmbientAudioPreference({
+      controller,
+      preference,
+      windowTarget: windowStub as unknown as Window,
+      logger: { warn: vi.fn() },
+    });
+
+    windowStub.dispatchEvent(new Event('pointerdown'));
+    windowStub.dispatchEvent(new KeyboardEvent('keydown', { key: 'x' }));
+    await Promise.resolve();
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(controller.enableMock).not.toHaveBeenCalled();
+    expect(controller.isEnabled()).toBe(false);
+
+    binding.dispose();
+  });
   it('enables ambient audio after pointer interaction when preference is stored', async () => {
     const windowStub = new EventTarget();
     const preference = new AmbientAudioPreference({

--- a/src/tests/guidedTourChannel.test.ts
+++ b/src/tests/guidedTourChannel.test.ts
@@ -44,9 +44,21 @@ const createSource = () => {
 };
 
 describe('GuidedTourChannel', () => {
+  it('starts disabled by default', () => {
+    const { source } = createSource();
+    const channel = new GuidedTourChannel({ source });
+    const listener = vi.fn();
+
+    channel.subscribe(listener);
+
+    expect(channel.getEnabled()).toBe(false);
+    expect(listener).toHaveBeenLastCalledWith(null);
+    channel.dispose();
+  });
+
   it('forwards recommendations when enabled', () => {
     const { source, emit } = createSource();
-    const channel = new GuidedTourChannel({ source });
+    const channel = new GuidedTourChannel({ source, enabled: true });
     const updates: Array<string | null> = [];
 
     channel.subscribe((recommendation) => {
@@ -87,7 +99,7 @@ describe('GuidedTourChannel', () => {
 
   it('unsubscribes from the source on dispose', () => {
     const { source, emit, listeners } = createSource();
-    const channel = new GuidedTourChannel({ source });
+    const channel = new GuidedTourChannel({ source, enabled: true });
     const listener = vi.fn();
     channel.subscribe(listener);
 

--- a/src/tests/guidedTourPreference.test.ts
+++ b/src/tests/guidedTourPreference.test.ts
@@ -21,7 +21,6 @@ describe('GuidedTourPreference', () => {
       },
       storageKey,
       windowTarget: window,
-      defaultEnabled: true,
     });
   });
 
@@ -29,23 +28,71 @@ describe('GuidedTourPreference', () => {
     preference.dispose();
   });
 
+  it('defaults to disabled when no stored preference exists', () => {
+    expect(preference.isEnabled()).toBe(false);
+    expect(storage.get(storageKey)).toBeUndefined();
+  });
+
+  it('loads persisted enabled and disabled states from storage', () => {
+    preference.dispose();
+    storage.set(storageKey, '1');
+    preference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      storageKey,
+      windowTarget: window,
+    });
+    expect(preference.isEnabled()).toBe(true);
+
+    preference.dispose();
+    storage.set(storageKey, '0');
+    preference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      storageKey,
+      windowTarget: window,
+    });
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('accepts legacy boolean payloads for compatibility', () => {
+    preference.dispose();
+    storage.set(storageKey, 'true');
+    preference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      storageKey,
+      windowTarget: window,
+    });
+    expect(preference.isEnabled()).toBe(true);
+  });
+
   it('toggles state, persists, and notifies listeners', () => {
     const listener = vi.fn();
     preference.subscribe(listener);
 
-    expect(preference.isEnabled()).toBe(true);
-    expect(storage.get(storageKey)).toBeUndefined();
+    preference.setEnabled(true, 'control');
 
-    preference.setEnabled(false, 'control');
-
-    expect(preference.isEnabled()).toBe(false);
-    expect(storage.get(storageKey)).toBe('0');
-    expect(listener).toHaveBeenCalledTimes(2);
-    expect(listener).toHaveBeenLastCalledWith(false);
-
-    preference.toggle();
     expect(preference.isEnabled()).toBe(true);
     expect(storage.get(storageKey)).toBe('1');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    preference.toggle();
+    expect(preference.isEnabled()).toBe(false);
+    expect(storage.get(storageKey)).toBe('0');
   });
 
   it('dispatches custom events when state changes', () => {
@@ -55,11 +102,11 @@ describe('GuidedTourPreference', () => {
       handler as EventListener
     );
 
-    preference.setEnabled(false, 'api');
+    preference.setEnabled(true, 'api');
 
     expect(handler).toHaveBeenCalledTimes(1);
     const event = handler.mock.calls[0][0] as CustomEvent;
-    expect(event.detail).toEqual({ enabled: false, source: 'api' });
+    expect(event.detail).toEqual({ enabled: true, source: 'api' });
 
     window.removeEventListener(
       GUIDED_TOUR_PREFERENCE_EVENT,
@@ -74,12 +121,12 @@ describe('GuidedTourPreference', () => {
 
     const storageEvent = new StorageEvent('storage', {
       key: storageKey,
-      newValue: '0',
+      newValue: '1',
     });
 
     window.dispatchEvent(storageEvent);
 
-    expect(preference.isEnabled()).toBe(false);
-    expect(listener).toHaveBeenCalledWith(false);
+    expect(preference.isEnabled()).toBe(true);
+    expect(listener).toHaveBeenCalledWith(true);
   });
 });

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -702,6 +702,33 @@ describe('PoiTooltipOverlay', () => {
     expect(root.getAttribute('aria-hidden')).toBe('true');
   });
 
+  it('does not surface idle recommendations for a fresh opt-in preference', () => {
+    overlay.dispose();
+    preference.dispose();
+    preference = new GuidedTourPreference({
+      storage: {
+        getItem: () => null,
+        setItem: () => {
+          /* noop */
+        },
+      },
+      windowTarget: window,
+    });
+    overlay = new PoiTooltipOverlay({
+      container,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+    });
+
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.dataset.state).toBe('hidden');
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+  });
+
   it('keeps explicit selection visible when passive recommendations are disabled', () => {
     overlay.setPassiveRecommendationsEnabled(false);
     overlay.setIdleState(true);
@@ -739,7 +766,7 @@ describe('PoiTooltipOverlay', () => {
 
   it('hides recommendation badges when guided tour mode is disabled', () => {
     overlay.setIdleState(true);
-    preference.setEnabled(false, 'test');
+    preference.setEnabled(false, 'api');
     overlay.setRecommendation(basePoi);
     const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
@@ -752,7 +779,7 @@ describe('PoiTooltipOverlay', () => {
     ) as HTMLSpanElement;
     expect(badge.hidden).toBe(true);
 
-    preference.setEnabled(true, 'test');
+    preference.setEnabled(true, 'api');
     expect(root.dataset.guidedTour).toBe('on');
     expect(badge.hidden).toBe(false);
   });

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -95,7 +95,7 @@ function createPoiDefinition(
   } as PoiDefinition;
 }
 
-function createTooltip() {
+function createTooltip(defaultEnabled = true) {
   const scene = new Scene();
   const camera = new OrthographicCamera(-10, 10, 10, -10, 0.1, 100);
   camera.position.set(12, 14, 16);
@@ -109,7 +109,7 @@ function createTooltip() {
       },
     },
     windowTarget: window,
-    defaultEnabled: true,
+    defaultEnabled,
   });
   const tooltip = new PoiWorldTooltip({
     parent: scene,
@@ -397,7 +397,7 @@ describe('PoiWorldTooltip', () => {
       id: 'pr-reaper-backyard-console',
     });
     tooltip.setIdleState(true);
-    preference.setEnabled(false, 'test');
+    preference.setEnabled(false, 'api');
     tooltip.setRecommendation(
       createTarget(recommendedPoi, new Vector3(-1, 0.5, 2))
     );
@@ -407,10 +407,30 @@ describe('PoiWorldTooltip', () => {
     expect(disabledState.mode).toBeNull();
     expect(disabledState.visible).toBe(false);
 
-    preference.setEnabled(true, 'test');
+    preference.setEnabled(true, 'api');
     tooltip.update(0.016);
     const enabledState = tooltip.getState();
     expect(enabledState.mode).toBe('recommended');
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
+  it('does not render idle recommendations before guided tour opt-in', () => {
+    const { tooltip, preference } = createTooltip(false);
+    const recommendedPoi = createPoiDefinition({
+      id: 'dspace-backyard-rocket',
+    });
+
+    tooltip.setIdleState(true);
+    tooltip.setRecommendation(
+      createTarget(recommendedPoi, new Vector3(-1, 0.5, 2))
+    );
+    tooltip.update(0.016);
+
+    const state = tooltip.getState();
+    expect(state.mode).toBeNull();
+    expect(state.visible).toBe(false);
 
     tooltip.dispose();
     preference.dispose();

--- a/src/tests/tourGuideToggleControl.test.ts
+++ b/src/tests/tourGuideToggleControl.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { createTourGuideToggleControl } from '../systems/controls/tourGuideToggleControl';
 
 describe('tourGuideToggleControl', () => {
-  it('renders an enabled toggle by default', () => {
+  it('renders a disabled toggle by default', () => {
     const container = document.createElement('div');
     const handle = createTourGuideToggleControl({ container });
 
     expect(container.querySelector('.tour-toggle')).toBe(handle.element);
-    expect(handle.element.dataset.state).toBe('enabled');
-    expect(handle.element.getAttribute('aria-pressed')).toBe('true');
-    expect(handle.element.dataset.hudAnnounce).toContain('Guided tour on');
+    expect(handle.element.dataset.state).toBe('disabled');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('false');
+    expect(handle.element.dataset.hudAnnounce).toContain('Guided tour off');
 
     handle.dispose();
   });
@@ -67,6 +67,6 @@ describe('tourGuideToggleControl', () => {
     expect(container.contains(button)).toBe(false);
 
     button.click();
-    expect(button.dataset.state).toBe('enabled');
+    expect(button.dataset.state).toBe('disabled');
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent fresh sessions from auto-starting ambient audio or surfacing guided-tour recommendations unless a visitor explicitly opts in. 
- Preserve and honor any previously stored explicit preferences while making the safe default for new sessions be Off. 
- Ensure HUD controls and tooltip/channel plumbing consistently reflect and persist the opt-in state.

### Description
- Default guided-tour preference to false by changing `GuidedTourPreference` to load with `defaultEnabled ?? false` and accept legacy storage payloads (`'1'|'0'` and `'true'|'false'`).
- Initialize a single `GuidedTourPreference` in `src/main.ts` and wire it into `PoiTooltipOverlay`, `PoiWorldTooltip`, `GuidedTourChannel`, the HUD `tourResetControl`, and the HUD toggle so UI and channel enable/disable flow through the shared preference.
- Make `GuidedTourChannel` and the HUD `tourGuideToggleControl` start disabled by default (`enabled = false` / `initialEnabled = false`) and update the HUD toggle to call `guidedTourPreference.setEnabled(..., 'control')` (plus write storage when appropriate).
- Ensure `readGuidedTourEnabled()` falls back to `false` for fresh sessions while accepting legacy stored values and handling storage read errors safely.
- Add/adjust tests to cover fresh-session suppression and persisted opt-in behaviors for both ambient audio and guided-tour recommendations (updates in `src/tests/*` covering `AmbientAudioPreference`, `bindAmbientAudioPreference`, `GuidedTourPreference`, `GuidedTourChannel`, `PoiTooltipOverlay`, `PoiWorldTooltip`, and HUD toggle control).

### Testing
- Ran formatting and linting: `npm run format:write` (passed) and `npm run lint` (passed; one import-order warning fixed). 
- Ran typecheck: `npm run typecheck` — reported existing, repo-wide TS errors unrelated to this change (status: failed; these are pre-existing in the codebase). 
- Unit tests: `npm run test:ci` (full suite) — all tests passed in CI run (950 tests passed). 
- Focused tests: `npm run test:ci -- src/tests/ambientAudioPreference.test.ts src/tests/ambientAudioPreferenceBinding.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts` — passed. 
- End-to-end: `npm run test:e2e -- playwright/small-screen-hud.spec.ts` — passed after installing Playwright browsers and host deps (download + `npx playwright install` / `npx playwright install-deps chromium`). 
- Build & docs: `npm run build`, `npm run docs:check`, and `npm run smoke` — all passed. 

Notes/risks: `tsc --noEmit` still reports unrelated existing type errors elsewhere in the repo; this PR avoids broad refactors and focuses only on opt-in behavior and tests. The guided-tour storage compatibility accepts both numeric (`'1'/'0'`) and boolean (`'true'/'false'`) payloads to cover prior releases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc36c8830832fbddd7f23439aa70f)