### PR TITLE
Make audio and guided tour opt-in by default

### DIFF
--- a/playwright/immersive-mode.spec.ts
+++ b/playwright/immersive-mode.spec.ts
@@ -116,9 +116,9 @@ test.describe('immersive experience', () => {
     const poiOverlay = page.locator('.poi-tooltip-overlay');
     const lightingIndicator = page.locator('.lighting-debug-indicator');
 
-    // When guided tour is enabled and idle, overlay shows recommendations
-    await expect(poiOverlay).toHaveAttribute('data-state', 'recommended');
-    await expect(poiOverlay).toHaveAttribute('aria-hidden', 'false');
+    // Guided tour is opt-in by default, so idle recommendations stay hidden.
+    await expect(poiOverlay).toHaveAttribute('data-state', 'hidden');
+    await expect(poiOverlay).toHaveAttribute('aria-hidden', 'true');
     await expect(lightingIndicator).toBeHidden();
 
     await expect(audioHud).toHaveCount(1);
@@ -150,7 +150,7 @@ test.describe('immersive experience', () => {
     await expect(graphicsControl).toBeHidden();
     await expect(accessibilityControl).toBeHidden();
     await expect(modeToggle).toBeHidden();
-    // After closing help modal, overlay returns to recommended state
-    await expect(poiOverlay).toHaveAttribute('data-state', 'recommended');
+    // After closing help modal, overlay remains hidden until the tour is enabled.
+    await expect(poiOverlay).toHaveAttribute('data-state', 'hidden');
   });
 });

--- a/playwright/keyboard-traversal.spec.ts
+++ b/playwright/keyboard-traversal.spec.ts
@@ -25,8 +25,8 @@ test.describe('keyboard traversal macro', () => {
     const helpButton = page.locator('[data-control="help"]');
     const helpBackdrop = page.locator('.help-modal-backdrop');
 
-    // When guided tour is enabled and idle, tooltip shows recommendations
-    await expect(tooltip).toHaveAttribute('data-state', 'recommended');
+    // Guided tour is opt-in by default, so idle recommendations stay hidden.
+    await expect(tooltip).toHaveAttribute('data-state', 'hidden');
 
     // Cycle to the first POI using the keyboard-only binding (E).
     await page.keyboard.press('KeyE');

--- a/src/main.ts
+++ b/src/main.ts
@@ -327,6 +327,7 @@ import {
   createGitHubRepoStatsService,
   type GitHubRepoStatsDiagnostics,
 } from './systems/github/repoStats';
+import { GuidedTourPreference } from './systems/guidedTour/preference';
 import {
   createAnalyticsGlowRhythm,
   type AnalyticsGlowRhythmHandle,
@@ -842,6 +843,7 @@ function initializeImmersiveScene(
   let idleMonitor: IdleMonitor | null = null;
   let removeIdleSubscription: (() => void) | null = null;
   let removeGuidedTourSubscription: (() => void) | null = null;
+  let removeGuidedTourPreferenceSubscription: (() => void) | null = null;
   let githubRepoMetrics: GitHubRepoMetricsController | null = null;
   let getAmbientAudioVolume = () =>
     ambientAudioController?.getMasterVolume() ?? 1;
@@ -882,25 +884,29 @@ function initializeImmersiveScene(
 
   const readGuidedTourEnabled = (): boolean => {
     const stored = guidedTourStorage?.getItem(GUIDED_TOUR_STORAGE_KEY);
-    if (stored === 'false') {
+    if (stored === 'false' || stored === '0') {
       return false;
     }
-    if (stored === 'true') {
+    if (stored === 'true' || stored === '1') {
       return true;
     }
-    return true;
+    return false;
   };
 
   const writeGuidedTourEnabled = (enabled: boolean) => {
     try {
-      guidedTourStorage?.setItem(
-        GUIDED_TOUR_STORAGE_KEY,
-        enabled ? 'true' : 'false'
-      );
+      guidedTourStorage?.setItem(GUIDED_TOUR_STORAGE_KEY, enabled ? '1' : '0');
     } catch {
       /* ignore storage write failures */
     }
   };
+
+  const guidedTourPreference = new GuidedTourPreference({
+    storage: guidedTourStorage ?? null,
+    storageKey: GUIDED_TOUR_STORAGE_KEY,
+    windowTarget: window,
+    defaultEnabled: false,
+  });
 
   const detectedLanguage =
     typeof navigator !== 'undefined' && navigator.language
@@ -1595,6 +1601,7 @@ function initializeImmersiveScene(
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
     interactionTimeline,
+    guidedTourPreference,
     discoveryAnnouncer: {
       format: (poi, strings) =>
         formatMessage(strings.discoveryAnnouncementTemplate, {
@@ -1607,7 +1614,11 @@ function initializeImmersiveScene(
     },
   });
   poiTooltipOverlay.setStrings(poiOverlayStrings);
-  const poiWorldTooltip = new PoiWorldTooltip({ parent: scene, camera });
+  const poiWorldTooltip = new PoiWorldTooltip({
+    parent: scene,
+    camera,
+    guidedTourPreference,
+  });
   const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
     (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
     (!isMobilePoiLayout(layoutOverride) || currentSelectedPoi !== null);
@@ -1889,10 +1900,24 @@ function initializeImmersiveScene(
   const removeVisitedSubscription =
     poiVisitedState.subscribe(handleVisitedUpdate);
   const initialGuidedTourEnabled = readGuidedTourEnabled();
+  if (guidedTourPreference.isEnabled() !== initialGuidedTourEnabled) {
+    guidedTourPreference.setEnabled(initialGuidedTourEnabled, 'storage');
+  }
   guidedTourChannel = new GuidedTourChannel({
     source: poiTourGuide,
     enabled: initialGuidedTourEnabled,
   });
+  let guidedTourPreferenceInitialized = false;
+  removeGuidedTourPreferenceSubscription = guidedTourPreference.subscribe(
+    (enabled) => {
+      guidedTourChannel?.setEnabled(enabled);
+      tourGuideToggleControl?.setEnabled(enabled);
+      if (guidedTourPreferenceInitialized) {
+        writeGuidedTourEnabled(enabled);
+      }
+      guidedTourPreferenceInitialized = true;
+    }
+  );
   removeGuidedTourSubscription = guidedTourChannel.subscribe(
     (recommendation) => {
       if (recommendation?.id !== dismissedPassiveRecommendationPoiId) {
@@ -3512,8 +3537,7 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       initialEnabled: initialGuidedTourEnabled,
       onToggle: (enabled) => {
-        guidedTourChannel?.setEnabled(enabled);
-        writeGuidedTourEnabled(enabled);
+        guidedTourPreference.setEnabled(enabled, 'control');
       },
       strings: tourGuideToggleStrings,
     });
@@ -3526,6 +3550,7 @@ function initializeImmersiveScene(
         poiVisitedState.reset();
       },
       strings: tourResetControlStrings,
+      guidedTourPreference,
     });
     registerHudControlElement(tourResetControl?.element ?? null);
   }
@@ -4400,8 +4425,13 @@ function initializeImmersiveScene(
       removeGuidedTourSubscription();
       removeGuidedTourSubscription = null;
     }
+    if (removeGuidedTourPreferenceSubscription) {
+      removeGuidedTourPreferenceSubscription();
+      removeGuidedTourPreferenceSubscription = null;
+    }
     guidedTourChannel?.dispose();
     guidedTourChannel = null;
+    guidedTourPreference.dispose();
     if (githubRepoMetrics) {
       githubRepoMetrics.dispose();
       githubRepoMetrics = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -882,25 +882,6 @@ function initializeImmersiveScene(
     budgetMs: INPUT_LATENCY_P95_BUDGET_MS,
   });
 
-  const readGuidedTourEnabled = (): boolean => {
-    const stored = guidedTourStorage?.getItem(GUIDED_TOUR_STORAGE_KEY);
-    if (stored === 'false' || stored === '0') {
-      return false;
-    }
-    if (stored === 'true' || stored === '1') {
-      return true;
-    }
-    return false;
-  };
-
-  const writeGuidedTourEnabled = (enabled: boolean) => {
-    try {
-      guidedTourStorage?.setItem(GUIDED_TOUR_STORAGE_KEY, enabled ? '1' : '0');
-    } catch {
-      /* ignore storage write failures */
-    }
-  };
-
   const guidedTourPreference = new GuidedTourPreference({
     storage: guidedTourStorage ?? null,
     storageKey: GUIDED_TOUR_STORAGE_KEY,
@@ -1899,23 +1880,15 @@ function initializeImmersiveScene(
 
   const removeVisitedSubscription =
     poiVisitedState.subscribe(handleVisitedUpdate);
-  const initialGuidedTourEnabled = readGuidedTourEnabled();
-  if (guidedTourPreference.isEnabled() !== initialGuidedTourEnabled) {
-    guidedTourPreference.setEnabled(initialGuidedTourEnabled, 'storage');
-  }
+  const initialGuidedTourEnabled = guidedTourPreference.isEnabled();
   guidedTourChannel = new GuidedTourChannel({
     source: poiTourGuide,
     enabled: initialGuidedTourEnabled,
   });
-  let guidedTourPreferenceInitialized = false;
   removeGuidedTourPreferenceSubscription = guidedTourPreference.subscribe(
     (enabled) => {
       guidedTourChannel?.setEnabled(enabled);
       tourGuideToggleControl?.setEnabled(enabled);
-      if (guidedTourPreferenceInitialized) {
-        writeGuidedTourEnabled(enabled);
-      }
-      guidedTourPreferenceInitialized = true;
     }
   );
   removeGuidedTourSubscription = guidedTourChannel.subscribe(

--- a/src/main.ts
+++ b/src/main.ts
@@ -858,13 +858,6 @@ function initializeImmersiveScene(
     localeStorage = undefined;
   }
 
-  let guidedTourStorage: Storage | undefined;
-  try {
-    guidedTourStorage = window.localStorage;
-  } catch {
-    guidedTourStorage = undefined;
-  }
-
   let ambientAudioStorage: Storage | undefined;
   try {
     ambientAudioStorage = window.localStorage;
@@ -883,7 +876,6 @@ function initializeImmersiveScene(
   });
 
   const guidedTourPreference = new GuidedTourPreference({
-    storage: guidedTourStorage ?? null,
     storageKey: GUIDED_TOUR_STORAGE_KEY,
     windowTarget: window,
     defaultEnabled: false,
@@ -3508,7 +3500,7 @@ function initializeImmersiveScene(
 
     tourGuideToggleControl = createTourGuideToggleControl({
       container: hudSettingsStack,
-      initialEnabled: initialGuidedTourEnabled,
+      initialEnabled: guidedTourPreference.isEnabled(),
       onToggle: (enabled) => {
         guidedTourPreference.setEnabled(enabled, 'control');
       },

--- a/src/scene/poi/guidedTourChannel.ts
+++ b/src/scene/poi/guidedTourChannel.ts
@@ -30,7 +30,7 @@ export class GuidedTourChannel {
 
   private lastBroadcast: PoiDefinition | null = null;
 
-  constructor({ source, enabled = true }: GuidedTourChannelOptions) {
+  constructor({ source, enabled = false }: GuidedTourChannelOptions) {
     this.source = source;
     this.enabled = enabled;
     this.unsubscribeSource = this.source.subscribe((recommendation) => {

--- a/src/systems/controls/tourGuideToggleControl.ts
+++ b/src/systems/controls/tourGuideToggleControl.ts
@@ -17,7 +17,7 @@ export interface TourGuideToggleControlHandle {
 
 export function createTourGuideToggleControl({
   container,
-  initialEnabled = true,
+  initialEnabled = false,
   onToggle,
   strings: providedStrings,
 }: TourGuideToggleControlOptions): TourGuideToggleControlHandle {

--- a/src/systems/guidedTour/preference.ts
+++ b/src/systems/guidedTour/preference.ts
@@ -57,10 +57,10 @@ const getDefaultStorage = (target: Window | null): Storage | null => {
 };
 
 const parseStoredValue = (value: string | null): boolean | null => {
-  if (value === '1') {
+  if (value === '1' || value === 'true') {
     return true;
   }
-  if (value === '0') {
+  if (value === '0' || value === 'false') {
     return false;
   }
   return null;
@@ -84,7 +84,7 @@ export class GuidedTourPreference {
         ? getDefaultStorage(this.windowTarget)
         : options.storage;
     this.storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
-    this.enabled = this.loadInitialState(options.defaultEnabled ?? true);
+    this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
 
     if (this.windowTarget) {
       this.windowTarget.addEventListener('storage', this.handleStorageEvent);

--- a/src/systems/guidedTour/preference.ts
+++ b/src/systems/guidedTour/preference.ts
@@ -174,10 +174,11 @@ export class GuidedTourPreference {
   }
 
   private handleStorageEvent = (event: StorageEvent) => {
-    if (!event.key || event.key !== this.storageKey) {
+    if (event.key !== null && event.key !== this.storageKey) {
       return;
     }
-    const parsed = parseStoredValue(event.newValue ?? null);
+    const parsed =
+      event.newValue === null ? false : parseStoredValue(event.newValue);
     if (parsed === null || parsed === this.enabled) {
       return;
     }

--- a/src/tests/ambientAudioPreferenceBinding.test.ts
+++ b/src/tests/ambientAudioPreferenceBinding.test.ts
@@ -32,6 +32,31 @@ class FakeAmbientAudioController {
 }
 
 describe('bindAmbientAudioPreference', () => {
+  it('does not enable ambient audio on first gesture without explicit opt-in', async () => {
+    const windowStub = new EventTarget();
+    const preference = new AmbientAudioPreference({
+      windowTarget: windowStub as unknown as Window,
+      storage: null,
+    });
+    const controller = new FakeAmbientAudioController();
+
+    const binding = bindAmbientAudioPreference({
+      controller,
+      preference,
+      windowTarget: windowStub as unknown as Window,
+      logger: { warn: vi.fn() },
+    });
+
+    windowStub.dispatchEvent(new Event('pointerdown'));
+    windowStub.dispatchEvent(new KeyboardEvent('keydown', { key: 'x' }));
+    await Promise.resolve();
+
+    expect(controller.enableMock).not.toHaveBeenCalled();
+    expect(controller.isEnabled()).toBe(false);
+
+    binding.dispose();
+  });
+
   it('enables ambient audio after pointer interaction when preference is stored', async () => {
     const windowStub = new EventTarget();
     const preference = new AmbientAudioPreference({

--- a/src/tests/guidedTourChannel.test.ts
+++ b/src/tests/guidedTourChannel.test.ts
@@ -44,9 +44,24 @@ const createSource = () => {
 };
 
 describe('GuidedTourChannel', () => {
-  it('forwards recommendations when enabled', () => {
+  it('starts disabled unless explicitly enabled', () => {
     const { source, emit } = createSource();
     const channel = new GuidedTourChannel({ source });
+    const updates: Array<string | null> = [];
+
+    channel.subscribe((recommendation) => {
+      updates.push(recommendation?.id ?? null);
+    });
+
+    emit(samplePoi(ids[1]));
+
+    expect(updates).toEqual([null]);
+    channel.dispose();
+  });
+
+  it('forwards recommendations when enabled', () => {
+    const { source, emit } = createSource();
+    const channel = new GuidedTourChannel({ source, enabled: true });
     const updates: Array<string | null> = [];
 
     channel.subscribe((recommendation) => {
@@ -87,7 +102,7 @@ describe('GuidedTourChannel', () => {
 
   it('unsubscribes from the source on dispose', () => {
     const { source, emit, listeners } = createSource();
-    const channel = new GuidedTourChannel({ source });
+    const channel = new GuidedTourChannel({ source, enabled: true });
     const listener = vi.fn();
     channel.subscribe(listener);
 

--- a/src/tests/guidedTourPreference.test.ts
+++ b/src/tests/guidedTourPreference.test.ts
@@ -21,7 +21,6 @@ describe('GuidedTourPreference', () => {
       },
       storageKey,
       windowTarget: window,
-      defaultEnabled: true,
     });
   });
 
@@ -29,23 +28,28 @@ describe('GuidedTourPreference', () => {
     preference.dispose();
   });
 
+  it('defaults to off when no stored preference exists', () => {
+    expect(preference.isEnabled()).toBe(false);
+    expect(storage.get(storageKey)).toBeUndefined();
+  });
+
   it('toggles state, persists, and notifies listeners', () => {
     const listener = vi.fn();
     preference.subscribe(listener);
 
-    expect(preference.isEnabled()).toBe(true);
+    expect(preference.isEnabled()).toBe(false);
     expect(storage.get(storageKey)).toBeUndefined();
 
-    preference.setEnabled(false, 'control');
+    preference.setEnabled(true, 'control');
 
-    expect(preference.isEnabled()).toBe(false);
-    expect(storage.get(storageKey)).toBe('0');
-    expect(listener).toHaveBeenCalledTimes(2);
-    expect(listener).toHaveBeenLastCalledWith(false);
-
-    preference.toggle();
     expect(preference.isEnabled()).toBe(true);
     expect(storage.get(storageKey)).toBe('1');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    preference.toggle();
+    expect(preference.isEnabled()).toBe(false);
+    expect(storage.get(storageKey)).toBe('0');
   });
 
   it('dispatches custom events when state changes', () => {
@@ -55,16 +59,44 @@ describe('GuidedTourPreference', () => {
       handler as EventListener
     );
 
-    preference.setEnabled(false, 'api');
+    preference.setEnabled(true, 'api');
 
     expect(handler).toHaveBeenCalledTimes(1);
     const event = handler.mock.calls[0][0] as CustomEvent;
-    expect(event.detail).toEqual({ enabled: false, source: 'api' });
+    expect(event.detail).toEqual({ enabled: true, source: 'api' });
 
     window.removeEventListener(
       GUIDED_TOUR_PREFERENCE_EVENT,
       handler as EventListener
     );
+  });
+
+  it('preserves stored explicit enabled and disabled states', () => {
+    storage.set(storageKey, 'true');
+    const enabledPreference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      storageKey,
+      windowTarget: null,
+    });
+    expect(enabledPreference.isEnabled()).toBe(true);
+
+    storage.set(storageKey, 'false');
+    const disabledPreference = new GuidedTourPreference({
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      storageKey,
+      windowTarget: null,
+    });
+    expect(disabledPreference.isEnabled()).toBe(false);
   });
 
   it('reacts to storage events from other contexts', () => {
@@ -74,12 +106,12 @@ describe('GuidedTourPreference', () => {
 
     const storageEvent = new StorageEvent('storage', {
       key: storageKey,
-      newValue: '0',
+      newValue: '1',
     });
 
     window.dispatchEvent(storageEvent);
 
-    expect(preference.isEnabled()).toBe(false);
-    expect(listener).toHaveBeenCalledWith(false);
+    expect(preference.isEnabled()).toBe(true);
+    expect(listener).toHaveBeenCalledWith(true);
   });
 });

--- a/src/tests/guidedTourPreference.test.ts
+++ b/src/tests/guidedTourPreference.test.ts
@@ -99,6 +99,39 @@ describe('GuidedTourPreference', () => {
     expect(disabledPreference.isEnabled()).toBe(false);
   });
 
+  it('falls back to sessionStorage when localStorage is blocked', () => {
+    const sessionStorage = new Map<string, string>();
+    const sessionStorageLike = {
+      getItem: (key: string) => sessionStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        sessionStorage.set(key, value);
+      },
+    };
+    const windowTarget = {
+      get localStorage() {
+        throw new Error('localStorage unavailable');
+      },
+      get sessionStorage() {
+        return sessionStorageLike;
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as Window;
+    const fallbackPreference = new GuidedTourPreference({
+      storageKey,
+      windowTarget,
+    });
+
+    expect(fallbackPreference.isEnabled()).toBe(false);
+
+    fallbackPreference.setEnabled(true, 'control');
+
+    expect(sessionStorage.get(storageKey)).toBe('1');
+
+    fallbackPreference.dispose();
+  });
+
   it('reacts to storage events from other contexts', () => {
     const listener = vi.fn();
     preference.subscribe(listener);

--- a/src/tests/guidedTourPreference.test.ts
+++ b/src/tests/guidedTourPreference.test.ts
@@ -114,4 +114,38 @@ describe('GuidedTourPreference', () => {
     expect(preference.isEnabled()).toBe(true);
     expect(listener).toHaveBeenCalledWith(true);
   });
+
+  it('treats removed stored values as disabled across contexts', () => {
+    preference.setEnabled(true, 'control');
+    const listener = vi.fn();
+    preference.subscribe(listener);
+    listener.mockClear();
+
+    const storageEvent = new StorageEvent('storage', {
+      key: storageKey,
+      newValue: null,
+    });
+
+    window.dispatchEvent(storageEvent);
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(listener).toHaveBeenCalledWith(false);
+  });
+
+  it('treats cleared storage as disabled across contexts', () => {
+    preference.setEnabled(true, 'control');
+    const listener = vi.fn();
+    preference.subscribe(listener);
+    listener.mockClear();
+
+    const storageEvent = new StorageEvent('storage', {
+      key: null,
+      newValue: null,
+    });
+
+    window.dispatchEvent(storageEvent);
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(listener).toHaveBeenCalledWith(false);
+  });
 });

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -691,6 +691,37 @@ describe('PoiTooltipOverlay', () => {
     expect(badge.textContent).toBe('Next highlight');
   });
 
+  it('keeps fresh idle sessions hidden until guided tour is enabled', () => {
+    overlay.dispose();
+    preference.dispose();
+    preference = new GuidedTourPreference({
+      storage: {
+        getItem: () => null,
+        setItem: () => {
+          /* noop */
+        },
+      },
+      windowTarget: window,
+    });
+    overlay = new PoiTooltipOverlay({
+      container,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+    });
+
+    overlay.setIdleState(true);
+    overlay.setRecommendation(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(preference.isEnabled()).toBe(false);
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
+    expect(root.dataset.state).toBe('hidden');
+
+    preference.setEnabled(true, 'api');
+    expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(true);
+    expect(root.dataset.state).toBe('recommended');
+  });
+
   it('does not surface passive recommendations when disabled', () => {
     overlay.setPassiveRecommendationsEnabled(false);
     overlay.setIdleState(true);

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -290,6 +290,48 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('does not render fresh idle recommendations until guided tour is enabled', () => {
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-10, 10, 10, -10, 0.1, 100);
+    camera.position.set(12, 14, 16);
+    camera.lookAt(0, 0, 0);
+    camera.updateProjectionMatrix();
+    const preference = new GuidedTourPreference({
+      storage: {
+        getItem: () => null,
+        setItem: () => {
+          /* noop */
+        },
+      },
+      windowTarget: window,
+    });
+    const tooltip = new PoiWorldTooltip({
+      parent: scene,
+      camera,
+      guidedTourPreference: preference,
+      minimumFacingDot: -1,
+    });
+    const recommendedPoi = createPoiDefinition({
+      id: 'sugarkube-backyard-greenhouse',
+    });
+
+    tooltip.setIdleState(true);
+    tooltip.setRecommendation(
+      createTarget(recommendedPoi, new Vector3(-1, 0.5, 2))
+    );
+    tooltip.update(0.016);
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(tooltip.getState().mode).toBeNull();
+
+    preference.setEnabled(true, 'api');
+    tooltip.update(0.016);
+    expect(tooltip.getState().mode).toBe('recommended');
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('falls back to the recommendation when no hover or selection is active', () => {
     const { tooltip, preference } = createTooltip();
     const recommendedPoi = createPoiDefinition({

--- a/src/tests/tourGuideToggleControl.test.ts
+++ b/src/tests/tourGuideToggleControl.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { createTourGuideToggleControl } from '../systems/controls/tourGuideToggleControl';
 
 describe('tourGuideToggleControl', () => {
-  it('renders an enabled toggle by default', () => {
+  it('renders a disabled toggle by default', () => {
     const container = document.createElement('div');
     const handle = createTourGuideToggleControl({ container });
 
     expect(container.querySelector('.tour-toggle')).toBe(handle.element);
-    expect(handle.element.dataset.state).toBe('enabled');
-    expect(handle.element.getAttribute('aria-pressed')).toBe('true');
-    expect(handle.element.dataset.hudAnnounce).toContain('Guided tour on');
+    expect(handle.element.dataset.state).toBe('disabled');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('false');
+    expect(handle.element.dataset.hudAnnounce).toContain('Guided tour off');
 
     handle.dispose();
   });
@@ -67,6 +67,6 @@ describe('tourGuideToggleControl', () => {
     expect(container.contains(button)).toBe(false);
 
     button.click();
-    expect(button.dataset.state).toBe('enabled');
+    expect(button.dataset.state).toBe('disabled');
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent unexpected ambient audio and passive guided-tour recommendations from starting in fresh immersive sessions by making both features opt-in. 
- Preserve users' explicit stored on/off choices across reloads while making new sessions start with both features off. 
- Keep HUD, world tooltips, and reset controls synchronized with a single guided-tour preference so toggles and idle recommendations behave consistently.

### Description
- Change guided-tour preference default to off by making `GuidedTourPreference` default `defaultEnabled` to `false` and parsing stored values as either `"1"/"0"` or `"true"/"false"` in `src/systems/guidedTour/preference.ts`.
- Make `GuidedTourChannel` and the Settings `TourGuideToggleControl` start disabled by default (`enabled = false` / `initialEnabled = false`).
- Wire a shared `GuidedTourPreference` into the immersive scene (`src/main.ts`) and use it to initialize and synchronize `GuidedTourChannel`, the HUD toggle, `TourResetControl`, `PoiTooltipOverlay`, and `PoiWorldTooltip`, while persisting writes as compact `"1"/"0"` for compatibility.
- Add tests and small behavioral guards: ensure ambient audio does not auto-enable on first gesture without explicit opt-in, ensure fresh idle POI recommendations are suppressed until guided tour is explicitly enabled, and add coverage asserting stored enabled/disabled values are preserved.

### Testing
- Ran formatting and linting: `npm run format:write` (pass) and `npm run lint` (pass; one import ordering warning auto-fixed). 
- Type check: `npm run typecheck` failed due to pre-existing repository-wide TS issues unrelated to this change (reported and left unmodified). 
- Targeted unit tests: `npm run test:ci -- src/tests/ambientAudioPreference.test.ts src/tests/ambientAudioPreferenceBinding.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/poiWorldTooltip.test.ts` (pass). 
- Full test suite: `npm run test:ci` (pass; all tests green). 
- Build and docs: `npm run build` (pass) and `npm run docs:check` (pass) and `npm run smoke` (pass). 
- Playwright E2E: installed browsers and deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, then ran `npm run test:e2e -- playwright/small-screen-hud.spec.ts` (pass after installing browsers/deps). 

Note: The change preserves legacy stored values and migrates display/storage to a compact `1`/`0` format while treating absent storage as opt-out; repository typecheck failures observed are pre-existing and unrelated to this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc36c8830832fbddd7f23439aa70f)