### PR TITLE
Ground POI copy and add link validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Each floor has its own auto-generated diagram (regenerated locally with
 | `npm run format:check` / `npm run format:write` | Check or apply Prettier formatting.                                    |
 | `npm run test` / `npm run test:ci`              | Execute the Vitest suite (CI uses `:ci`).                              |
 | `npm run typecheck`                             | Type-check with TypeScript without emitting files.                     |
-| `npm run docs:check`                            | Ensure required docs (including Codex prompts) exist.                  |
+| `npm run docs:check`                            | Ensure required docs exist and run the link checker.                   |
+| `npm run links:check`                           | Validate POI and README/docs links, failing clear 404/410 targets.     |
 | `npm run smoke`                                 | Build and validate `dist/index.html`, bundled assets, and static refs. |
 | `npm run check`                                 | Convenience command chaining lint, test:ci, and docs:check.            |
 | `npm run press-kit`                             | Emit `docs/assets/press-kit.json` with POI and media manifest details. |
@@ -151,7 +152,7 @@ lightweight.
 - **Visual smoke thresholds** – [`playwright.config.ts`](playwright.config.ts) loads [`VISUAL_SMOKE_DIFF_BUDGET`](src/assets/performance.ts#L37-L45) so `expect().toHaveScreenshot` allows at most a 0.015 diff ratio or 1,200 differing pixels.
 - **Keyboard traversal macro** – [`playwright/keyboard-traversal.spec.ts`](playwright/keyboard-traversal.spec.ts) touches every POI and HUD overlay using keyboard-only input. Use `npm run test:e2e -- --grep traversal` to run just that macro when iterating.
 - **Animation QA checklist** – [`docs/media/animation-qa.md`](docs/media/animation-qa.md) links the IK contact/footstep sync tests and describes how to capture fresh clips when polishing locomotion.
-- **Docs validation** – `npm run docs:check` enforces prompt, roadmap, and architecture coverage.
+- **Docs validation** – `npm run docs:check` enforces prompt, roadmap, and architecture coverage, then runs `npm run links:check`. The link checker collects POI locale links plus README/docs Markdown links, validates URL syntax, checks local targets, and probes external HTTP(S) targets with HEAD plus GET fallback while treating private, rate-limited, or unreachable hosts as warnings instead of clear broken-link failures.
 - **Launch smoke** – `npm run smoke` builds once, validates bundled output references, and reports
   manual static binary assets (resume/favicon) as warnings by default.
 - **Strict manual static verification** – run `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` after

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -61,26 +61,27 @@ layer without guessing where functionality lives.
 
 ### State surfaces & consumers
 
-| Source handle / data surface | Origin                                                                                                   | Consumed by                                                                                         | Notes                                                             |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `FLOOR_PLAN` + POI metadata  | [`src/assets/floorPlan/index.ts`](../../src/assets/floorPlan/index.ts)                                   | Scene POI builders, keyboard traversal macro, HUD tooltip overlay                                   | Canonical IDs power collision bounds and DOM aria-label text.     |
-| `KeyBindingRegistry`         | [`src/systems/controls/keyBindings.ts`](../../src/systems/controls/keyBindings.ts)                       | HUD legend (`src/ui/hud/movementLegend.tsx`), help modal, Playwright macro                          | Emits observable binding changes so overlays update instantly.    |
-| `MovementControllerHandle`   | [`src/systems/movement/cameraRelativeMovement.ts`](../../src/systems/movement/cameraRelativeMovement.ts) | Scene avatar rig (`src/scene/avatar/createAvatarRig.ts`), debug helpers on `window.portfolio.world` | Provides camera-relative vectors and collision-clamped positions. |
-| `PoiVisitedState`            | [`src/scene/poi/visitedState.ts`](../../src/scene/poi/visitedState.ts)                                   | Scene halo/material toggles, DOM overlay badges, accessibility announcers                           | Persists visited state between HUD and Three.js meshes.           |
-| `HudFocusAnnouncerHandle`    | [`src/ui/accessibility/hudFocusAnnouncer.ts`](../../src/ui/accessibility/hudFocusAnnouncer.ts)           | HUD overlays, subtitles bridge, Playwright assertions                                               | Centralises live-region announcements and aria-live priorities.   |
-| Performance budgets          | [`src/assets/performance.ts`](../../src/assets/performance.ts)                                           | Vitest assertions (`src/tests/performanceBudget.test.ts`), Playwright diff budget, docs             | Keeps render metrics and screenshot tolerances in sync.           |
+| Source handle / data surface      | Origin                                                                                                   | Consumed by                                                                             | Notes                                                           |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `FLOOR_PLAN` + POI metadata       | [`src/assets/floorPlan/index.ts`](../../src/assets/floorPlan/index.ts)                                   | Scene POI builders, keyboard traversal macro, HUD tooltip overlay                       | Canonical IDs power collision bounds and DOM aria-label text.   |
+| `KeyBindingRegistry`              | [`src/systems/controls/keyBindings.ts`](../../src/systems/controls/keyBindings.ts)                       | HUD legend (`src/ui/hud/movementLegend.tsx`), help modal, Playwright macro              | Emits observable binding changes so overlays update instantly.  |
+| `getCameraRelativeMovementVector` | [`src/systems/movement/cameraRelativeMovement.ts`](../../src/systems/movement/cameraRelativeMovement.ts) | `src/main.ts` avatar update loop and movement/facing tests                              | Provides camera-relative planar vectors for movement and yaw.   |
+| `PoiVisitedState`                 | [`src/scene/poi/visitedState.ts`](../../src/scene/poi/visitedState.ts)                                   | Scene halo/material toggles, DOM overlay badges, accessibility announcers               | Persists visited state between HUD and Three.js meshes.         |
+| `HudFocusAnnouncerHandle`         | [`src/ui/accessibility/hudFocusAnnouncer.ts`](../../src/ui/accessibility/hudFocusAnnouncer.ts)           | HUD overlays, subtitles bridge, Playwright assertions                                   | Centralises live-region announcements and aria-live priorities. |
+| Performance budgets               | [`src/assets/performance.ts`](../../src/assets/performance.ts)                                           | Vitest assertions (`src/tests/performanceBudget.test.ts`), Playwright diff budget, docs | Keeps render metrics and screenshot tolerances in sync.         |
 
 ### Data flow callouts
 
-- **Camera rig** – `src/main.ts` composes `createCameraRig` from
-  [`src/scene/camera/initialFraming.ts`](../../src/scene/camera/initialFraming.ts)
-  with the movement controller. The rig reads camera-relative vectors from the
-  system handle and exposes `updateCameraOnResize` for UI resize observers.
-- **Avatar loop** – `createMovementController` emits frame-by-frame velocity
-  updates. `createAvatarRig` listens and applies yaw derived from
-  [`getCameraRelativeMovementVector`](../../src/systems/movement/facing.ts).
-  HUD overlays subscribe to the same controller so WASD prompts highlight the
-  active axis without touching Three.js meshes.
+- **Camera framing** – `src/main.ts` resolves the initial orthographic zoom with
+  [`resolveInitialAvatarCameraFraming`](../../src/scene/camera/initialFraming.ts)
+  after constructing the camera. Resize behavior stays in `src/main.ts` through
+  the local `onResize` handler, which refreshes projection, renderer, and
+  postprocessing dimensions.
+- **Avatar loop** – `src/main.ts` samples key bindings and joystick input each
+  frame, then derives movement via
+  [`getCameraRelativeMovementVector`](../../src/systems/movement/cameraRelativeMovement.ts).
+  The same loop applies velocity, collision clamping, and yaw so HUD prompts can
+  reflect active WASD axes without owning Three.js meshes.
 - **POI orchestration** – The registry
   (`src/scene/poi/registry.ts`) hydrates data from
   [`src/assets/i18n/locales/en.ts`](../../src/assets/i18n/locales/en.ts) and now exposes

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -61,19 +61,19 @@ layer without guessing where functionality lives.
 
 ### State surfaces & consumers
 
-| Source handle / data surface | Origin                                                                                                       | Consumed by                                                                                         | Notes                                                             |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `FLOOR_PLAN` + POI metadata  | [`src/assets/floorPlan.ts`](../../src/assets/floorPlan.ts)                                                   | Scene POI builders, keyboard traversal macro, HUD tooltip overlay                                   | Canonical IDs power collision bounds and DOM aria-label text.     |
-| `KeyBindingRegistry`         | [`src/systems/controls/keyBindings.ts`](../../src/systems/controls/keyBindings.ts)                           | HUD legend (`src/ui/hud/movementLegend.tsx`), help modal, Playwright macro                          | Emits observable binding changes so overlays update instantly.    |
-| `MovementControllerHandle`   | [`src/systems/movement/createMovementController.ts`](../../src/systems/movement/createMovementController.ts) | Scene avatar rig (`src/scene/avatar/createAvatarRig.ts`), debug helpers on `window.portfolio.world` | Provides camera-relative vectors and collision-clamped positions. |
-| `PoiVisitedState`            | [`src/systems/poi/poiVisitedState.ts`](../../src/systems/poi/poiVisitedState.ts)                             | Scene halo/material toggles, DOM overlay badges, accessibility announcers                           | Persists visited state between HUD and Three.js meshes.           |
-| `HudFocusAnnouncerHandle`    | [`src/systems/accessibility/hudFocusAnnouncer.ts`](../../src/systems/accessibility/hudFocusAnnouncer.ts)     | HUD overlays, subtitles bridge, Playwright assertions                                               | Centralises live-region announcements and aria-live priorities.   |
-| Performance budgets          | [`src/assets/performance.ts`](../../src/assets/performance.ts)                                               | Vitest assertions (`src/tests/performanceBudget.test.ts`), Playwright diff budget, docs             | Keeps render metrics and screenshot tolerances in sync.           |
+| Source handle / data surface | Origin                                                                                                   | Consumed by                                                                                         | Notes                                                             |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `FLOOR_PLAN` + POI metadata  | [`src/assets/floorPlan/index.ts`](../../src/assets/floorPlan/index.ts)                                   | Scene POI builders, keyboard traversal macro, HUD tooltip overlay                                   | Canonical IDs power collision bounds and DOM aria-label text.     |
+| `KeyBindingRegistry`         | [`src/systems/controls/keyBindings.ts`](../../src/systems/controls/keyBindings.ts)                       | HUD legend (`src/ui/hud/movementLegend.tsx`), help modal, Playwright macro                          | Emits observable binding changes so overlays update instantly.    |
+| `MovementControllerHandle`   | [`src/systems/movement/cameraRelativeMovement.ts`](../../src/systems/movement/cameraRelativeMovement.ts) | Scene avatar rig (`src/scene/avatar/createAvatarRig.ts`), debug helpers on `window.portfolio.world` | Provides camera-relative vectors and collision-clamped positions. |
+| `PoiVisitedState`            | [`src/scene/poi/visitedState.ts`](../../src/scene/poi/visitedState.ts)                                   | Scene halo/material toggles, DOM overlay badges, accessibility announcers                           | Persists visited state between HUD and Three.js meshes.           |
+| `HudFocusAnnouncerHandle`    | [`src/ui/accessibility/hudFocusAnnouncer.ts`](../../src/ui/accessibility/hudFocusAnnouncer.ts)           | HUD overlays, subtitles bridge, Playwright assertions                                               | Centralises live-region announcements and aria-live priorities.   |
+| Performance budgets          | [`src/assets/performance.ts`](../../src/assets/performance.ts)                                           | Vitest assertions (`src/tests/performanceBudget.test.ts`), Playwright diff budget, docs             | Keeps render metrics and screenshot tolerances in sync.           |
 
 ### Data flow callouts
 
 - **Camera rig** – `src/main.ts` composes `createCameraRig` from
-  [`src/scene/camera/createCameraRig.ts`](../../src/scene/camera/createCameraRig.ts)
+  [`src/scene/camera/initialFraming.ts`](../../src/scene/camera/initialFraming.ts)
   with the movement controller. The rig reads camera-relative vectors from the
   system handle and exposes `updateCameraOnResize` for UI resize observers.
 - **Avatar loop** – `createMovementController` emits frame-by-frame velocity
@@ -83,11 +83,11 @@ layer without guessing where functionality lives.
   active axis without touching Three.js meshes.
 - **POI orchestration** – The registry
   (`src/scene/poi/registry.ts`) hydrates data from
-  [`src/assets/poi/index.ts`](../../src/assets/poi/index.ts) and now exposes
+  [`src/assets/i18n/locales/en.ts`](../../src/assets/i18n/locales/en.ts) and now exposes
   room-aware lookups via `poiRegistry.getByRoom(...)`. Interaction handlers in
   `src/scene/poi/interactionManager.ts` emit POI selection events. UI layers
   listen via the shared observable to mirror selection state in
-  [`src/ui/poi/tooltipOverlay.tsx`](../../src/ui/poi/tooltipOverlay.tsx), while
+  [`src/scene/poi/tooltipOverlay.ts`](../../src/scene/poi/tooltipOverlay.ts), while
   [`src/scene/poi/githubMetrics.ts`](../../src/scene/poi/githubMetrics.ts)
   wires GitHub star counts into both the in-world tooltip and HUD overlay.
 - **Accessibility overlays** – `HudFocusAnnouncerHandle` flows from systems
@@ -112,9 +112,8 @@ layer without guessing where functionality lives.
   [`keyBindings.ts`](../../src/systems/controls/keyBindings.ts) emit movement
   vectors plus action events. Key bindings drive HUD prompts and focus
   announcers.
-- **HUD overlays** – [`src/ui/hud`](../../src/ui/hud),
-  [`src/ui/accessibility`](../../src/ui/accessibility), and
-  [`src/ui/help`](../../src/ui/help) subscribe to key binding, accessibility
+- **HUD overlays** – [`src/ui/hud`](../../src/ui/hud) and
+  [`src/ui/accessibility`](../../src/ui/accessibility) subscribe to key binding, accessibility
   preset, and POI selection handles. Each overlay follows the
   [accessibility checklist](../guides/accessibility-overlays.md).
 - **POI orchestration** – The registry at

--- a/docs/assets/press-kit.json
+++ b/docs/assets/press-kit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtIso": "2026-06-02T17:25:49.601Z",
+  "generatedAtIso": "2026-06-04T03:26:52.636Z",
   "performance": {
     "budget": {
       "maxMaterials": 36,
@@ -91,7 +91,7 @@
     {
       "id": "futuroptimist-living-room-tv",
       "title": "Futuroptimist",
-      "summary": "Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.",
+      "summary": "Futuroptimist hub for open-source scripts, data pipelines, tests, and YouTube-oriented automation metadata.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -102,23 +102,23 @@
       "metrics": [
         {
           "label": "Stars",
-          "value": "1,280+",
+          "value": "Syncing from GitHub…",
           "source": {
             "type": "githubStars",
             "owner": "futuroptimist",
             "repo": "danielsmith.io",
             "format": "compact",
             "template": "{value} stars",
-            "fallback": "1,280+"
+            "fallback": "Syncing from GitHub…"
           }
         },
         {
           "label": "Workflow",
-          "value": "Resolve-style edit suite · triple display"
+          "value": "uv, Make targets, pytest, and GitHub Actions"
         },
         {
           "label": "Focus",
-          "value": "Futuroptimist ecosystem reels in progress"
+          "value": "Scripts, prompt docs, related-project status"
         }
       ],
       "links": [
@@ -127,8 +127,8 @@
           "href": "https://github.com/futuroptimist"
         },
         {
-          "label": "Docs",
-          "href": "https://futuroptimist.dev"
+          "label": "YouTube",
+          "href": "https://www.youtube.com/@futuroptimist"
         }
       ],
       "footprint": {
@@ -140,7 +140,7 @@
     {
       "id": "tokenplace-studio-cluster",
       "title": "token.place",
-      "summary": "Secure peer-to-peer generative AI platform running on a Raspberry Pi lattice with encrypted relay and server nodes.",
+      "summary": "Secure peer-to-peer generative AI platform with relay and compute-node paths for sharing idle compute as a public-good network.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -162,12 +162,12 @@
           }
         },
         {
-          "label": "Cluster",
-          "value": "12× Pi 5 nodes in modular bays"
+          "label": "Runtime",
+          "value": "Python relay.py and server.py entrypoints"
         },
         {
-          "label": "Network",
-          "value": "Ephemeral tokens · encrypted bursts"
+          "label": "Security",
+          "value": "API v1 relay-blind E2EE baseline"
         }
       ],
       "links": [
@@ -189,7 +189,7 @@
     {
       "id": "gabriel-studio-sentry",
       "title": "Gabriel",
-      "summary": "Privacy-first \"guardian angel\" LLM that delivers local security coaching and integrates with token.place or offline inference.",
+      "summary": "Open-source \"guardian angel\" LLM focused on private, local security advice and optional local AI-assisted monitoring.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -212,11 +212,11 @@
         },
         {
           "label": "Focus",
-          "value": "360° lidar sweep + local heuristics"
+          "value": "Privacy-first digital security coaching"
         },
         {
-          "label": "Cadence",
-          "value": "Red alert flash every 1.0 s"
+          "label": "Docs",
+          "value": "FAQ and project docs in-repo"
         }
       ],
       "links": [
@@ -234,7 +234,7 @@
     {
       "id": "flywheel-studio-flywheel",
       "title": "Flywheel",
-      "summary": "GitHub template and automation hub that bundles linting, tests, docs, and Codex prompts for fast repo bootstrapping.",
+      "summary": "Opinionated boilerplate and CLI for reproducible CI, code quality, docs, prompts, and repo audits.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -257,21 +257,17 @@
         },
         {
           "label": "Automation",
-          "value": "CI scaffolds · typed prompts · QA loops"
+          "value": "init/update CLI · checks · prompt docs"
         },
         {
-          "label": "Docs CTA",
-          "value": "flywheel.futuroptimist.dev →"
+          "label": "CAD",
+          "value": "Flywheel stand, shaft, adapter, and physics docs"
         }
       ],
       "links": [
         {
           "label": "Flywheel Repo",
           "href": "https://github.com/futuroptimist/flywheel"
-        },
-        {
-          "label": "Docs",
-          "href": "https://flywheel.futuroptimist.dev"
         }
       ],
       "footprint": {
@@ -283,7 +279,7 @@
     {
       "id": "jobbot-studio-terminal",
       "title": "Jobbot3000",
-      "summary": "Self-hosted job search copilot with CLI and experimental web UI for ingesting outreach and tracking applications.",
+      "summary": "Self-hosted, open-source job search copilot with a local experimental web interface and documented setup.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -306,25 +302,21 @@
         },
         {
           "label": "Status",
-          "value": "Local-first CLI with preview web UI"
+          "value": "Self-hosted copilot with local web preview"
         },
         {
           "label": "Stack",
-          "value": "Node.js 20+ · npm scripts · Playwright preview"
+          "value": "Node.js 20+ · npm scripts"
         },
         {
-          "label": "Flows",
-          "value": "Recruiter outreach ingestion and lifecycle tracking"
+          "label": "Safety",
+          "value": "Local-only warning for secrets and PII"
         }
       ],
       "links": [
         {
           "label": "GitHub",
           "href": "https://github.com/futuroptimist/jobbot3000"
-        },
-        {
-          "label": "Automation Log",
-          "href": "https://futuroptimist.dev/automation"
         }
       ],
       "footprint": {
@@ -429,14 +421,14 @@
       "metrics": [
         {
           "label": "Stars",
-          "value": "1,280+",
+          "value": "Syncing from GitHub…",
           "source": {
             "type": "githubStars",
             "owner": "futuroptimist",
             "repo": "danielsmith.io",
             "format": "compact",
             "template": "{value} stars",
-            "fallback": "1,280+"
+            "fallback": "Syncing from GitHub…"
           }
         },
         {
@@ -489,12 +481,12 @@
           }
         },
         {
-          "label": "Speed",
-          "value": "Copy failing logs in under 3 s"
+          "label": "Flow",
+          "value": "Codex task → GitHub PR checks → Markdown"
         },
         {
-          "label": "Formats",
-          "value": "CLI + clipboard + Markdown output"
+          "label": "Safety",
+          "value": "Secret redaction before summaries or output"
         }
       ],
       "links": [
@@ -557,7 +549,7 @@
     {
       "id": "wove-kitchen-loom",
       "title": "Wove",
-      "summary": "Open-source toolkit for learning knitting and crochet while building toward a robotic loom with OpenSCAD hardware.",
+      "summary": "Open-source toolkit for learning knitting and crochet while building toward robotic knitting hardware with OpenSCAD parts.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -580,11 +572,11 @@
         },
         {
           "label": "Craft",
-          "value": "Loom calibrates from CAD stitch maps"
+          "value": "Knitting and crochet learning docs"
         },
         {
-          "label": "Roadmap",
-          "value": "Path toward robotic weaving labs"
+          "label": "Automation",
+          "value": "Pattern CLI, planner exports, OpenSCAD hardware"
         }
       ],
       "links": [
@@ -602,7 +594,7 @@
     {
       "id": "dspace-backyard-rocket",
       "title": "DSPACE",
-      "summary": "Backyard launch gantry for the private DSPACE rocket project with telemetry-guided countdown cues and a public mission log.",
+      "summary": "Public DSPACE exhibit for the Democratized Space web idle game, focused on quests, resources, exploration, and launch-to-orbit progression.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -616,31 +608,30 @@
           "value": "Syncing from GitHub…",
           "source": {
             "type": "githubStars",
-            "owner": "futuroptimist",
+            "owner": "democratizedspace",
             "repo": "dspace",
-            "visibility": "private",
             "format": "compact",
             "template": "{value} stars",
             "fallback": "Syncing from GitHub…"
           }
         },
         {
-          "label": "Countdown",
-          "value": "Autonomous T-0 sequencing"
+          "label": "Game",
+          "value": "Resource management · quests · exploration"
         },
         {
-          "label": "Stack",
-          "value": "Three.js FX · Spatial audio"
+          "label": "Docs",
+          "value": "Public docs and developer guide"
         }
       ],
       "links": [
         {
           "label": "GitHub",
-          "href": "https://github.com/futuroptimist/dspace"
+          "href": "https://github.com/democratizedspace/dspace"
         },
         {
-          "label": "Mission Log",
-          "href": "https://futuroptimist.dev/projects/dspace"
+          "label": "Docs",
+          "href": "https://democratized.space/docs"
         }
       ],
       "footprint": {
@@ -652,7 +643,7 @@
     {
       "id": "pr-reaper-backyard-console",
       "title": "PR Reaper",
-      "summary": "GitHub Actions workflow that bulk-closes stale pull requests with dry-run previews and optional branch cleanup.",
+      "summary": "One-button GitHub Action that closes open pull requests authored by you, with a dry-run preview before reaping.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -675,11 +666,11 @@
         },
         {
           "label": "Sweep",
-          "value": "Bulk-close stale PRs with preview mode"
+          "value": "Close your own open PRs in bulk"
         },
         {
-          "label": "Cadence",
-          "value": "Cron triggers + manual dry-runs"
+          "label": "Safety",
+          "value": "dry_run=true preview and step summary"
         }
       ],
       "links": [
@@ -697,7 +688,7 @@
     {
       "id": "sugarkube-backyard-greenhouse",
       "title": "Sugarkube",
-      "summary": "k3s-on-Raspberry-Pi platform paired with an off-grid solar cube installation documented with CAD, Pi images, and field guides.",
+      "summary": "Accessible k3s platform for Raspberry Pis and SBCs integrated with an off-grid solar cube installation.",
       "category": "project",
       "interaction": "inspect",
       "status": "prototype",
@@ -723,10 +714,6 @@
         {
           "label": "GitHub",
           "href": "https://github.com/futuroptimist/sugarkube"
-        },
-        {
-          "label": "Greenhouse Log",
-          "href": "https://futuroptimist.dev/projects/sugarkube"
         }
       ],
       "footprint": {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -240,7 +240,7 @@ Focus: anchor each highlighted project with an interactive artifact.
 
 3. **Backyard Exhibits**
    - ✅ Launch-ready model rocket for `DSPACE`, complete with illuminated launch pad, pulsing
-     caution halo, countdown-ready stance, and an interactive POI that links to the mission log.
+     caution halo, countdown-ready stance, and an interactive POI that links to the public DSPACE repo and docs.
    - ✅ Aluminum extrusion greenhouse inspired by `sugarkube`, complete with animated solar
      trackers, pulsing grow lights, interior planter beds, and a koi pond plinth with shimmering
      ripple shaders.

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "test": "vitest",
     "test:ci": "vitest run",
     "typecheck": "tsc --noEmit",
-    "docs:check": "node scripts/check-docs.cjs",
+    "docs:check": "node scripts/check-docs.cjs && npm run links:check",
     "smoke": "npm run build && node scripts/assert-dist.cjs",
     "press-kit": "tsx scripts/generate-press-kit.ts",
     "check": "npm run lint && npm run test:ci && npm run docs:check",
     "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
     "favicon": "tsx scripts/generate-favicon.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "links:check": "node scripts/check-links.cjs"
   },
   "dependencies": {
     "three": "^0.161.0"

--- a/scripts/check-links.cjs
+++ b/scripts/check-links.cjs
@@ -353,6 +353,10 @@ async function checkExternalUrl(
           continue;
         }
         if ([404, 410].includes(response.status)) {
+          if (method === 'HEAD') {
+            lastError = new Error(`${target} returned ${response.status}`);
+            continue;
+          }
           return {
             ok: false,
             message: `${target} returned ${response.status}`,

--- a/scripts/check-links.cjs
+++ b/scripts/check-links.cjs
@@ -416,7 +416,10 @@ async function validateLink(link, options) {
 function dedupeLinks(links) {
   const seen = new Map();
   for (const link of links) {
-    const key = `${link.kind}:${link.target}`;
+    const { url } = parseTarget(link.target);
+    const key = url
+      ? `${link.kind}:${link.target}`
+      : `${link.kind}:${link.source}:${link.target}`;
     const existing = seen.get(key);
     if (existing) {
       existing.sources.push(link.source);

--- a/scripts/check-links.cjs
+++ b/scripts/check-links.cjs
@@ -55,7 +55,7 @@ async function listFiles(dir, predicate) {
 
 function addLink(links, source, target, kind) {
   const trimmed = target.trim();
-  if (!trimmed || trimmed.startsWith('#')) {
+  if (!trimmed || trimmed === '#') {
     return;
   }
   links.push({
@@ -65,15 +65,87 @@ function addLink(links, source, target, kind) {
   });
 }
 
-function extractMarkdownLinks(source, text) {
+function findInlineMarkdownDestinationEnd(text, startIndex) {
+  let depth = 0;
+  let escaped = false;
+  let quote = null;
+
+  for (let index = startIndex; index < text.length; index += 1) {
+    const char = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+    if (char === ')') {
+      if (depth === 0) {
+        return index;
+      }
+      depth -= 1;
+    }
+  }
+
+  return -1;
+}
+
+function extractDestination(rawDestination) {
+  const trimmed = rawDestination.trim();
+  if (trimmed.startsWith('<')) {
+    const closingIndex = trimmed.indexOf('>');
+    return closingIndex > 0 ? trimmed.slice(1, closingIndex) : null;
+  }
+
+  const titleMatch = trimmed.match(/^(\S+)(?:\s+['"(].*)?$/s);
+  return titleMatch?.[1] ?? null;
+}
+
+function extractInlineMarkdownLinks(source, text) {
   const links = [];
-  const markdownLinkPattern = /!?(?:\[[^\]]*\])\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  const linkOpenPattern = /!?\[[^\]]*\]\(/g;
+
+  for (const match of text.matchAll(linkOpenPattern)) {
+    const destinationStart = match.index + match[0].length;
+    const destinationEnd = findInlineMarkdownDestinationEnd(
+      text,
+      destinationStart
+    );
+    if (destinationEnd === -1) {
+      continue;
+    }
+
+    const destination = extractDestination(
+      text.slice(destinationStart, destinationEnd)
+    );
+    if (destination) {
+      addLink(links, source, destination, 'docs');
+    }
+  }
+
+  return links;
+}
+
+function extractMarkdownLinks(source, text) {
+  const links = extractInlineMarkdownLinks(source, text);
   const referenceDefinitionPattern = /^\s*\[[^\]]+\]:\s+(\S+)/gm;
   const autolinkPattern = /<((?:https?:|mailto:)[^>\s]+)>/g;
 
-  for (const match of text.matchAll(markdownLinkPattern)) {
-    addLink(links, source, match[1], 'docs');
-  }
   for (const match of text.matchAll(referenceDefinitionPattern)) {
     addLink(links, source, match[1], 'docs');
   }
@@ -149,27 +221,106 @@ function parseTarget(target) {
   }
 }
 
-async function validateLocalLink(link, cleanTarget) {
-  const sourcePath = path.join(repoRoot, link.source);
-  const [withoutHash] = cleanTarget.split('#', 1);
-  const [withoutQuery] = withoutHash.split('?', 1);
-  if (!withoutQuery) {
+function parseLocalTarget(cleanTarget) {
+  const hashIndex = cleanTarget.indexOf('#');
+  const beforeHash =
+    hashIndex === -1 ? cleanTarget : cleanTarget.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : cleanTarget.slice(hashIndex + 1);
+  const queryIndex = beforeHash.indexOf('?');
+  const fileTarget =
+    queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+  return { fileTarget, hash };
+}
+
+function slugifyHeading(value) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[`*_~[\]()]/g, '')
+    .replace(/&/g, '')
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+function collectMarkdownAnchors(text) {
+  const anchors = new Set();
+  const headingCounts = new Map();
+  const headingPattern = /^#{1,6}\s+(.+?)\s*#*\s*$/gm;
+  const explicitAnchorPattern =
+    /<a\s+[^>]*(?:id|name)=["']([^"']+)["'][^>]*>/gi;
+
+  for (const match of text.matchAll(headingPattern)) {
+    const baseSlug = slugifyHeading(match[1]);
+    if (!baseSlug) {
+      continue;
+    }
+    const count = headingCounts.get(baseSlug) ?? 0;
+    headingCounts.set(baseSlug, count + 1);
+    anchors.add(count === 0 ? baseSlug : `${baseSlug}-${count}`);
+  }
+  for (const match of text.matchAll(explicitAnchorPattern)) {
+    anchors.add(match[1]);
+  }
+
+  return anchors;
+}
+
+async function validateLocalAnchor(link, resolvedPath, hash) {
+  if (!hash) {
     return { ok: true };
   }
-  const resolvedPath = path.resolve(path.dirname(sourcePath), withoutQuery);
-  if (!resolvedPath.startsWith(repoRoot)) {
+  let decodedHash = hash;
+  try {
+    decodedHash = decodeURIComponent(hash);
+  } catch {
+    return {
+      ok: false,
+      message: `${link.source}: invalid local anchor #${hash} in ${link.target}`,
+    };
+  }
+  const text = await fs.readFile(resolvedPath, 'utf8');
+  const anchors = collectMarkdownAnchors(text);
+  if (anchors.has(decodedHash)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    message: `${link.source}: missing local anchor #${hash} in ${link.target}`,
+  };
+}
+
+async function validateLocalLink(link, cleanTarget) {
+  const sourcePath = path.join(repoRoot, link.source);
+  const { fileTarget, hash } = parseLocalTarget(cleanTarget);
+  const targetPath = fileTarget || link.source;
+  const resolvedPath = path.resolve(path.dirname(sourcePath), targetPath);
+  const repoRootWithSeparator = `${repoRoot}${path.sep}`;
+  if (
+    resolvedPath !== repoRoot &&
+    !resolvedPath.startsWith(repoRootWithSeparator)
+  ) {
     return {
       ok: false,
       message: `${link.source}: local link escapes repo: ${link.target}`,
     };
   }
-  if (await fileExists(resolvedPath)) {
-    return { ok: true };
+  if (!(await fileExists(resolvedPath))) {
+    return {
+      ok: false,
+      message: `${link.source}: missing local link target: ${link.target}`,
+    };
   }
-  return {
-    ok: false,
-    message: `${link.source}: missing local link target: ${link.target}`,
-  };
+  if (!resolvedPath.endsWith('.md')) {
+    return hash
+      ? {
+          ok: true,
+          warning: true,
+          message: `${link.source}: skipped non-Markdown anchor ${link.target}`,
+        }
+      : { ok: true };
+  }
+  return validateLocalAnchor(link, resolvedPath, hash);
 }
 
 async function fetchWithTimeout(url, method, timeoutMs) {
@@ -262,28 +413,56 @@ async function validateLink(link, options) {
   return validateLocalLink(link, cleanTarget);
 }
 
+function dedupeLinks(links) {
+  const seen = new Map();
+  for (const link of links) {
+    const key = `${link.kind}:${link.target}`;
+    const existing = seen.get(key);
+    if (existing) {
+      existing.sources.push(link.source);
+    } else {
+      seen.set(key, { ...link, sources: [link.source] });
+    }
+  }
+  return [...seen.values()];
+}
+
 async function validateLinks(links, options = {}) {
   const failures = [];
   const warnings = [];
   let skipped = 0;
-  for (const link of links) {
-    const result = await validateLink(link, options);
-    if (!result.ok) {
-      failures.push(result.message);
-    } else if (result.warning) {
-      warnings.push(result.message);
-    } else if (result.skipped) {
-      skipped += 1;
+  const concurrency = Math.max(1, options.concurrency ?? 6);
+  const queue = dedupeLinks(links);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < queue.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const link = queue[index];
+      const result = await validateLink(link, options);
+      if (!result.ok) {
+        failures.push(result.message);
+      } else if (result.warning) {
+        warnings.push(result.message);
+      } else if (result.skipped) {
+        skipped += 1;
+      }
     }
   }
-  return { failures, warnings, skipped };
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, queue.length) }, () => worker())
+  );
+
+  return { failures, warnings, skipped, checked: queue.length };
 }
 
 async function main() {
   const links = await collectLinks();
   const poiCount = links.filter((link) => link.kind === 'poi').length;
   const docsCount = links.filter((link) => link.kind === 'docs').length;
-  const { failures, warnings, skipped } = await validateLinks(links);
+  const { failures, warnings, skipped, checked } = await validateLinks(links);
 
   for (const warning of warnings) {
     console.warn(`Warning: ${warning}`);
@@ -296,8 +475,10 @@ async function main() {
     process.exitCode = 1;
     return;
   }
+  const checkedSummary =
+    checked === links.length ? `${links.length}` : `${checked}/${links.length}`;
   console.log(
-    `Link check passed: ${links.length} links (${poiCount} POI, ${docsCount} docs, ${skipped} allowlisted).`
+    `Link check passed: ${checkedSummary} links checked (${poiCount} POI, ${docsCount} docs, ${skipped} allowlisted).`
   );
 }
 
@@ -319,4 +500,5 @@ module.exports = {
   extractMarkdownLinks,
   extractPoiLinks,
   validateLinks,
+  collectMarkdownAnchors,
 };

--- a/scripts/check-links.cjs
+++ b/scripts/check-links.cjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+const fs = require('fs/promises');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_RETRIES = 2;
+
+const allowedSchemes = new Set(['http:', 'https:', 'mailto:']);
+const externalAllowlist = [
+  {
+    pattern: /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?(?:\/|$)/i,
+    reason: 'local preview URLs are environment-specific',
+  },
+  {
+    pattern: /^https?:\/\/chatgpt\.com\/codex\/tasks\/task_123(?:\b|$)/i,
+    reason: 'illustrative Codex task placeholder in docs',
+  },
+  {
+    pattern: /^https?:\/\/chatgpt\.com\/share\/abcdefg(?:\b|$)/i,
+    reason: 'illustrative shared-chat placeholder in docs',
+  },
+  {
+    pattern: /^https?:\/\/relay\.cloudflare\.workers\.dev\/api\/v1(?:\b|$)/i,
+    reason: 'example Cloudflare Worker relay URL from upstream docs',
+  },
+];
+
+function normalizeSlashes(value) {
+  return value.replace(/\\/g, '/');
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listFiles(dir, predicate) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const results = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await listFiles(fullPath, predicate)));
+    } else if (predicate(fullPath)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function addLink(links, source, target, kind) {
+  const trimmed = target.trim();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return;
+  }
+  links.push({
+    source: normalizeSlashes(path.relative(repoRoot, source)),
+    target: trimmed,
+    kind,
+  });
+}
+
+function extractMarkdownLinks(source, text) {
+  const links = [];
+  const markdownLinkPattern = /!?(?:\[[^\]]*\])\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  const referenceDefinitionPattern = /^\s*\[[^\]]+\]:\s+(\S+)/gm;
+  const autolinkPattern = /<((?:https?:|mailto:)[^>\s]+)>/g;
+
+  for (const match of text.matchAll(markdownLinkPattern)) {
+    addLink(links, source, match[1], 'docs');
+  }
+  for (const match of text.matchAll(referenceDefinitionPattern)) {
+    addLink(links, source, match[1], 'docs');
+  }
+  for (const match of text.matchAll(autolinkPattern)) {
+    addLink(links, source, match[1], 'docs');
+  }
+  return links;
+}
+
+function extractPoiLinks(source, text) {
+  const links = [];
+  const hrefPattern = /href:\s*['"]([^'"]+)['"]/g;
+  for (const match of text.matchAll(hrefPattern)) {
+    addLink(links, source, match[1], 'poi');
+  }
+  return links;
+}
+
+async function collectMarkdownLinks() {
+  const docsDir = path.join(repoRoot, 'docs');
+  const files = [path.join(repoRoot, 'README.md')];
+  if (await fileExists(docsDir)) {
+    files.push(
+      ...(await listFiles(docsDir, (filePath) => filePath.endsWith('.md')))
+    );
+  }
+  const links = [];
+  for (const filePath of files) {
+    const text = await fs.readFile(filePath, 'utf8');
+    links.push(...extractMarkdownLinks(filePath, text));
+  }
+  return links;
+}
+
+async function collectPoiLinks() {
+  const localeDir = path.join(repoRoot, 'src', 'assets', 'i18n', 'locales');
+  const files = await listFiles(localeDir, (filePath) =>
+    filePath.endsWith('.ts')
+  );
+  const links = [];
+  for (const filePath of files) {
+    const text = await fs.readFile(filePath, 'utf8');
+    links.push(...extractPoiLinks(filePath, text));
+  }
+  return links;
+}
+
+async function collectLinks() {
+  const [poiLinks, docsLinks] = await Promise.all([
+    collectPoiLinks(),
+    collectMarkdownLinks(),
+  ]);
+  return [...poiLinks, ...docsLinks];
+}
+
+function stripTrailingPunctuation(target) {
+  return target.replace(/[.,;:]+$/g, '');
+}
+
+function allowlistReason(target) {
+  return (
+    externalAllowlist.find((entry) => entry.pattern.test(target))?.reason ??
+    null
+  );
+}
+
+function parseTarget(target) {
+  const cleanTarget = stripTrailingPunctuation(target);
+  try {
+    return { cleanTarget, url: new URL(cleanTarget) };
+  } catch {
+    return { cleanTarget, url: null };
+  }
+}
+
+async function validateLocalLink(link, cleanTarget) {
+  const sourcePath = path.join(repoRoot, link.source);
+  const [withoutHash] = cleanTarget.split('#', 1);
+  const [withoutQuery] = withoutHash.split('?', 1);
+  if (!withoutQuery) {
+    return { ok: true };
+  }
+  const resolvedPath = path.resolve(path.dirname(sourcePath), withoutQuery);
+  if (!resolvedPath.startsWith(repoRoot)) {
+    return {
+      ok: false,
+      message: `${link.source}: local link escapes repo: ${link.target}`,
+    };
+  }
+  if (await fileExists(resolvedPath)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    message: `${link.source}: missing local link target: ${link.target}`,
+  };
+}
+
+async function fetchWithTimeout(url, method, timeoutMs) {
+  return fetch(url, {
+    method,
+    redirect: 'follow',
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: {
+      'User-Agent': 'danielsmith-io-link-check/1.0',
+      Accept: '*/*',
+    },
+  });
+}
+
+async function checkExternalUrl(
+  target,
+  { retries = DEFAULT_RETRIES, timeoutMs = DEFAULT_TIMEOUT_MS } = {}
+) {
+  const reason = allowlistReason(target);
+  if (reason) {
+    return { ok: true, skipped: true, message: `${target} (${reason})` };
+  }
+
+  let lastError = null;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    for (const method of ['HEAD', 'GET']) {
+      try {
+        const response = await fetchWithTimeout(target, method, timeoutMs);
+        if (response.status === 405 && method === 'HEAD') {
+          continue;
+        }
+        if ([404, 410].includes(response.status)) {
+          return {
+            ok: false,
+            message: `${target} returned ${response.status}`,
+          };
+        }
+        if (response.status >= 200 && response.status < 400) {
+          return { ok: true };
+        }
+        if ([401, 403, 429].includes(response.status)) {
+          return {
+            ok: true,
+            warning: true,
+            message: `${target} returned ${response.status}; treated as private/rate-limited`,
+          };
+        }
+        lastError = new Error(`${target} returned ${response.status}`);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+  }
+  return {
+    ok: true,
+    warning: true,
+    message: `${target} could not be reached: ${lastError?.message ?? 'unknown error'}`,
+  };
+}
+
+async function validateLink(link, options) {
+  const { cleanTarget, url } = parseTarget(link.target);
+  if (url) {
+    if (!allowedSchemes.has(url.protocol)) {
+      return {
+        ok: false,
+        message: `${link.source}: unsupported scheme in ${link.target}`,
+      };
+    }
+    if (url.protocol === 'mailto:') {
+      return { ok: true };
+    }
+    const external = await checkExternalUrl(cleanTarget, options);
+    return external.ok
+      ? {
+          ...external,
+          message: external.message
+            ? `${link.source}: ${external.message}`
+            : undefined,
+        }
+      : { ok: false, message: `${link.source}: ${external.message}` };
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(cleanTarget)) {
+    return {
+      ok: false,
+      message: `${link.source}: invalid or unsupported URL: ${link.target}`,
+    };
+  }
+  return validateLocalLink(link, cleanTarget);
+}
+
+async function validateLinks(links, options = {}) {
+  const failures = [];
+  const warnings = [];
+  let skipped = 0;
+  for (const link of links) {
+    const result = await validateLink(link, options);
+    if (!result.ok) {
+      failures.push(result.message);
+    } else if (result.warning) {
+      warnings.push(result.message);
+    } else if (result.skipped) {
+      skipped += 1;
+    }
+  }
+  return { failures, warnings, skipped };
+}
+
+async function main() {
+  const links = await collectLinks();
+  const poiCount = links.filter((link) => link.kind === 'poi').length;
+  const docsCount = links.filter((link) => link.kind === 'docs').length;
+  const { failures, warnings, skipped } = await validateLinks(links);
+
+  for (const warning of warnings) {
+    console.warn(`Warning: ${warning}`);
+  }
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`Error: ${failure}`);
+    }
+    console.error(`Link check failed: ${failures.length} failure(s).`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `Link check passed: ${links.length} links (${poiCount} POI, ${docsCount} docs, ${skipped} allowlisted).`
+  );
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(
+      'Link check failed:',
+      error instanceof Error ? error.message : error
+    );
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  allowedSchemes,
+  collectLinks,
+  collectMarkdownLinks,
+  collectPoiLinks,
+  extractMarkdownLinks,
+  extractPoiLinks,
+  validateLinks,
+};

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -182,9 +182,9 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
       outcome:
         'Verlinkt das öffentliche Repository democratizedspace/dspace und die offiziellen Spieldokumente statt ungeprüfter Missionslogs.',
       metrics: [
-        'Countdown',
+        'Spiel',
         'Ressourcenverwaltung · Quests · Erkundung',
-        'Stack',
+        'Docs',
         'Öffentliche Docs und Entwicklerleitfaden',
       ],
     },

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -55,12 +55,12 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
     },
     tokenplace: {
       summary:
-        'Sichere Peer-to-Peer-Plattform für generative KI auf einem Raspberry-Pi-Gitter mit verschlüsseltem Relay und Serverknoten.',
+        'Sichere Peer-to-Peer-Plattform für generative KI mit Relay- und Compute-Node-Pfaden, um ungenutzte Rechenleistung als Gemeingut zu teilen.',
       outcome:
         'Quickstart-Skripte starten Relay, Server und Mock-LLM-Stack lokal zum Testen.',
       metrics: [
         'Cluster',
-        '12× Pi-5-Knoten in modularen Einschüben',
+        'Python-Einstiege relay.py und server.py',
         'Netzwerk',
         'Ephemere Tokens · verschlüsselte Bursts',
       ],
@@ -74,7 +74,7 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
         'Fokus',
         '360°-Lidar-Scan + lokale Heuristiken',
         'Takt',
-        'Roter Alarmblitz alle 1,0 s',
+        'FAQ und Repo-Dokumentation',
       ],
     },
     flywheel: {
@@ -86,7 +86,7 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
         'Automatisierung',
         'CI-Scaffolds · typisierte Prompts · QA-Schleifen',
         'Docs CTA',
-        'flywheel.futuroptimist.dev →',
+        'Stand, Welle, Adapter und Physik-Dokumente',
       ],
     },
     jobbot: {
@@ -147,9 +147,9 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
         'Automatisiert CI-Log-Sammlung und Zusammenfassung für schnelle Debug-Handoffs.',
       metrics: [
         'Geschwindigkeit',
-        'Fehlerlogs in unter 3 s kopieren',
+        'Codex-Task → GitHub-PR-Checks → Markdown',
         'Formate',
-        'CLI + Zwischenablage + Markdown-Ausgabe',
+        'Secret-Redaktion vor Zusammenfassung oder Ausgabe',
       ],
     },
     sigma: {
@@ -178,14 +178,14 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
     },
     dspace: {
       summary:
-        'Startgerüst im Garten für DSPACE mit telemetriegeführten Countdown-Hinweisen und öffentlichem Missionslog.',
+        'DSPACE-Exponat für das Web-Idle-Game Democratized Space mit Ressourcen, Quests, Erkundung und Orbitstarts.',
       outcome:
-        'Pflegt Countdown-Notizen neben GitHub- und Missionslog-Links, während das Repo privat bleibt.',
+        'Verlinkt das öffentliche Repository democratizedspace/dspace und die offiziellen Spieldokumente statt ungeprüfter Missionslogs.',
       metrics: [
         'Countdown',
-        'Autonome T-0-Sequenzierung',
+        'Ressourcenverwaltung · Quests · Erkundung',
         'Stack',
-        'Three.js FX · Spatial Audio',
+        'Öffentliche Docs und Entwicklerleitfaden',
       ],
     },
     prReaper: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -460,17 +460,17 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
     'futuroptimist-living-room-tv': {
       title: wrap('Futuroptimist'),
       summary: wrap(
-        'Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.'
+        'Futuroptimist hub for open-source scripts, data pipelines, tests, and YouTube-oriented automation metadata.'
       ),
       metrics: [
-        { label: wrap('Stars'), value: wrap('1,280+') },
+        { label: wrap('Stars'), value: wrap('Syncing from GitHub…') },
         {
           label: wrap('Workflow'),
-          value: wrap('Resolve-style edit suite · triple display'),
+          value: wrap('uv, Make targets, pytest, and GitHub Actions'),
         },
         {
           label: wrap('Focus'),
-          value: wrap('Futuroptimist ecosystem reels in progress'),
+          value: wrap('Scripts, prompt docs, related-project status'),
         },
       ],
     },

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -524,34 +524,37 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'futuroptimist-living-room-tv': {
       title: 'Futuroptimist',
       summary:
-        'Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.',
+        'Futuroptimist hub for open-source scripts, data pipelines, tests, and YouTube-oriented automation metadata.',
       outcome: {
         label: 'Outcome',
         value:
-          'Keeps weekly highlight scripts flowing from the automation pipeline without manual formatting.',
+          'Documents setup, tests, prompt automation, and related projects for the Futuroptimist ecosystem.',
       },
       metrics: [
         {
           label: 'Stars',
-          value: '1,280+',
+          value: 'Syncing from GitHub…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'danielsmith.io',
             format: 'compact',
             template: '{value} stars',
-            fallback: '1,280+',
+            fallback: 'Syncing from GitHub…',
           },
         },
         {
           label: 'Workflow',
-          value: 'Resolve-style edit suite · triple display',
+          value: 'uv, Make targets, pytest, and GitHub Actions',
         },
-        { label: 'Focus', value: 'Futuroptimist ecosystem reels in progress' },
+        {
+          label: 'Focus',
+          value: 'Scripts, prompt docs, related-project status',
+        },
       ],
       links: [
         { label: 'GitHub', href: 'https://github.com/futuroptimist' },
-        { label: 'Docs', href: 'https://futuroptimist.dev' },
+        { label: 'YouTube', href: 'https://www.youtube.com/@futuroptimist' },
       ],
       narration: {
         caption:
@@ -561,11 +564,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'tokenplace-studio-cluster': {
       title: 'token.place',
       summary:
-        'Secure peer-to-peer generative AI platform running on a Raspberry Pi lattice with encrypted relay and server nodes.',
+        'Secure peer-to-peer generative AI platform with relay and compute-node paths for sharing idle compute as a public-good network.',
       outcome: {
         label: 'Outcome',
         value:
-          'Quickstart scripts bring up the relay, server, and mock LLM stack locally for testing.',
+          'Quickstart docs cover the Python relay, compute server, Docker Compose, tests, and E2EE API v1 guardrails.',
       },
       metrics: [
         {
@@ -580,8 +583,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             fallback: 'Syncing from GitHub…',
           },
         },
-        { label: 'Cluster', value: '12× Pi 5 nodes in modular bays' },
-        { label: 'Network', value: 'Ephemeral tokens · encrypted bursts' },
+        {
+          label: 'Runtime',
+          value: 'Python relay.py and server.py entrypoints',
+        },
+        { label: 'Security', value: 'API v1 relay-blind E2EE baseline' },
       ],
       links: [
         { label: 'Site', href: 'https://token.place' },
@@ -594,11 +600,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'gabriel-studio-sentry': {
       title: 'Gabriel',
       summary:
-        'Privacy-first "guardian angel" LLM that delivers local security coaching and integrates with token.place or offline inference.',
+        'Open-source "guardian angel" LLM focused on private, local security advice and optional local AI-assisted monitoring.',
       outcome: {
         label: 'Outcome',
         value:
-          'Modular ingestion, analysis, notification, and UI stacks stay aligned through typed interfaces.',
+          'The README emphasizes consent, local inference, personal environment knowledge, and actionable security coaching.',
       },
       metrics: [
         {
@@ -613,8 +619,8 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             fallback: 'Syncing from GitHub…',
           },
         },
-        { label: 'Focus', value: '360° lidar sweep + local heuristics' },
-        { label: 'Cadence', value: 'Red alert flash every 1.0 s' },
+        { label: 'Focus', value: 'Privacy-first digital security coaching' },
+        { label: 'Docs', value: 'FAQ and project docs in-repo' },
       ],
       links: [
         { label: 'GitHub', href: 'https://github.com/futuroptimist/gabriel' },
@@ -623,12 +629,12 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'flywheel-studio-flywheel': {
       title: 'Flywheel',
       summary: [
-        'GitHub template and automation hub that bundles linting, tests, docs, and Codex prompts for fast repo bootstrapping.',
+        'Opinionated boilerplate and CLI for reproducible CI, code quality, docs, prompts, and repo audits.',
       ].join(' '),
       outcome: {
         label: 'Outcome',
         value:
-          'Ships repeatable CI (lint, tests, docs) and prompt libraries so new repos start healthy.',
+          'Provides init/update commands, checks, Codex prompt docs, audits, and dry-run improvement suggestions.',
       },
       metrics: [
         {
@@ -645,16 +651,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         },
         {
           label: 'Automation',
-          value: 'CI scaffolds · typed prompts · QA loops',
+          value: 'init/update CLI · checks · prompt docs',
         },
-        { label: 'Docs CTA', value: 'flywheel.futuroptimist.dev →' },
+        {
+          label: 'CAD',
+          value: 'Flywheel stand, shaft, adapter, and physics docs',
+        },
       ],
       links: [
         {
           label: 'Flywheel Repo',
           href: 'https://github.com/futuroptimist/flywheel',
         },
-        { label: 'Docs', href: 'https://flywheel.futuroptimist.dev' },
       ],
       narration: {
         caption:
@@ -665,11 +673,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'jobbot-studio-terminal': {
       title: 'Jobbot3000',
       summary:
-        'Self-hosted job search copilot with CLI and experimental web UI for ingesting outreach and tracking applications.',
+        'Self-hosted, open-source job search copilot with a local experimental web interface and documented setup.',
       outcome: {
         label: 'Outcome',
         value:
-          'End-to-end workflows mirror docs and tests so recruiter outreach flows stay covered.',
+          'The README warns the web UI is local-only while docs cover setup, architecture, configuration, and tests.',
       },
       metrics: [
         {
@@ -686,25 +694,15 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         },
         {
           label: 'Status',
-          value: 'Local-first CLI with preview web UI',
+          value: 'Self-hosted copilot with local web preview',
         },
-        {
-          label: 'Stack',
-          value: 'Node.js 20+ · npm scripts · Playwright preview',
-        },
-        {
-          label: 'Flows',
-          value: 'Recruiter outreach ingestion and lifecycle tracking',
-        },
+        { label: 'Stack', value: 'Node.js 20+ · npm scripts' },
+        { label: 'Safety', value: 'Local-only warning for secrets and PII' },
       ],
       links: [
         {
           label: 'GitHub',
           href: 'https://github.com/futuroptimist/jobbot3000',
-        },
-        {
-          label: 'Automation Log',
-          href: 'https://futuroptimist.dev/automation',
         },
       ],
       narration: {
@@ -779,14 +777,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       metrics: [
         {
           label: 'Stars',
-          value: '1,280+',
+          value: 'Syncing from GitHub…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'danielsmith.io',
             format: 'compact',
             template: '{value} stars',
-            fallback: '1,280+',
+            fallback: 'Syncing from GitHub…',
           },
         },
         { label: 'Stack', value: 'Vite · Three.js · accessibility HUD' },
@@ -822,8 +820,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             fallback: 'Syncing from GitHub…',
           },
         },
-        { label: 'Speed', value: 'Copy failing logs in under 3 s' },
-        { label: 'Formats', value: 'CLI + clipboard + Markdown output' },
+        { label: 'Flow', value: 'Codex task → GitHub PR checks → Markdown' },
+        {
+          label: 'Safety',
+          value: 'Secret redaction before summaries or output',
+        },
       ],
       links: [
         {
@@ -864,11 +865,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'wove-kitchen-loom': {
       title: 'Wove',
       summary:
-        'Open-source toolkit for learning knitting and crochet while building toward a robotic loom with OpenSCAD hardware.',
+        'Open-source toolkit for learning knitting and crochet while building toward robotic knitting hardware with OpenSCAD parts.',
       outcome: {
         label: 'Outcome',
         value:
-          'Docs cover gauge calculators, planner exports, and tension profiles across yarn weights.',
+          'Docs cover hand-craft basics, gauge calculators, pattern translation, and tension profiles.',
       },
       metrics: [
         {
@@ -883,8 +884,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             fallback: 'Syncing from GitHub…',
           },
         },
-        { label: 'Craft', value: 'Loom calibrates from CAD stitch maps' },
-        { label: 'Roadmap', value: 'Path toward robotic weaving labs' },
+        { label: 'Craft', value: 'Knitting and crochet learning docs' },
+        {
+          label: 'Automation',
+          value: 'Pattern CLI, planner exports, OpenSCAD hardware',
+        },
       ],
       links: [
         { label: 'GitHub', href: 'https://github.com/futuroptimist/wove' },
@@ -893,11 +897,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'dspace-backyard-rocket': {
       title: 'DSPACE',
       summary:
-        'Backyard launch gantry for the private DSPACE rocket project with telemetry-guided countdown cues and a public mission log.',
+        'Public DSPACE exhibit for the Democratized Space web idle game, focused on quests, resources, exploration, and launch-to-orbit progression.',
       outcome: {
         label: 'Outcome',
         value:
-          'Maintains countdown sequencing notes alongside GitHub and mission log links while the repo remains private.',
+          'Links to the public democratizedspace/dspace repository and official game documentation instead of an unverified mission log.',
       },
       metrics: [
         {
@@ -905,23 +909,22 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           value: 'Syncing from GitHub…',
           source: {
             type: 'githubStars',
-            owner: 'futuroptimist',
+            owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',
           },
         },
-        { label: 'Countdown', value: 'Autonomous T-0 sequencing' },
-        { label: 'Stack', value: 'Three.js FX · Spatial audio' },
+        { label: 'Game', value: 'Resource management · quests · exploration' },
+        { label: 'Docs', value: 'Public docs and developer guide' },
       ],
       links: [
-        { label: 'GitHub', href: 'https://github.com/futuroptimist/dspace' },
         {
-          label: 'Mission Log',
-          href: 'https://futuroptimist.dev/projects/dspace',
+          label: 'GitHub',
+          href: 'https://github.com/democratizedspace/dspace',
         },
+        { label: 'Docs', href: 'https://democratized.space/docs' },
       ],
       narration: {
         caption:
@@ -933,11 +936,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'pr-reaper-backyard-console': {
       title: 'PR Reaper',
       summary:
-        'GitHub Actions workflow that bulk-closes stale pull requests with dry-run previews and optional branch cleanup.',
+        'One-button GitHub Action that closes open pull requests authored by you, with a dry-run preview before reaping.',
       outcome: {
         label: 'Outcome',
         value:
-          'One-button workflow documents inputs, safety model, and audit outputs in the README.',
+          'README documents token setup, workflow dispatch, dry-run summaries, and the gh-powered lookup.',
       },
       metrics: [
         {
@@ -952,8 +955,8 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             fallback: 'Syncing from GitHub…',
           },
         },
-        { label: 'Sweep', value: 'Bulk-close stale PRs with preview mode' },
-        { label: 'Cadence', value: 'Cron triggers + manual dry-runs' },
+        { label: 'Sweep', value: 'Close your own open PRs in bulk' },
+        { label: 'Safety', value: 'dry_run=true preview and step summary' },
       ],
       links: [
         { label: 'GitHub', href: 'https://github.com/futuroptimist/pr-reaper' },
@@ -962,11 +965,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
     'sugarkube-backyard-greenhouse': {
       title: 'Sugarkube',
       summary:
-        'k3s-on-Raspberry-Pi platform paired with an off-grid solar cube installation documented with CAD, Pi images, and field guides.',
+        'Accessible k3s platform for Raspberry Pis and SBCs integrated with an off-grid solar cube installation.',
       outcome: {
         label: 'Outcome',
         value:
-          'Step-by-step docs cover solar hardware, Pi provisioning, and Kubernetes helpers for resilient homelabs.',
+          'Docs cover the 3-node HA k3s happy path, Raspberry Pi imaging, flashing, verification, and solar hardware notes.',
       },
       metrics: [
         {
@@ -985,10 +988,6 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       ],
       links: [
         { label: 'GitHub', href: 'https://github.com/futuroptimist/sugarkube' },
-        {
-          label: 'Greenhouse Log',
-          href: 'https://futuroptimist.dev/projects/sugarkube',
-        },
       ],
       narration: {
         caption:

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -55,52 +55,52 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
     },
     tokenplace: {
       summary:
-        'Plataforma segura de IA generativa peer-to-peer sobre una malla Raspberry Pi con relay cifrado y nodos de servidor.',
+        'Plataforma segura de IA generativa peer-to-peer con rutas de relay y nodo de cómputo para compartir capacidad ociosa como bien público.',
       outcome:
-        'Los scripts de inicio levantan localmente el relay, el servidor y la pila de LLM simulado para pruebas.',
+        'La guía rápida cubre relay Python, servidor de cómputo, Docker Compose, pruebas y guardas E2EE de API v1.',
       metrics: [
         'Clúster',
-        '12× nodos Pi 5 en bahías modulares',
+        'Entrypoints Python relay.py y server.py',
         'Red',
-        'Tokens efímeros · ráfagas cifradas',
+        'Línea base API v1 con E2EE ciego al relay',
       ],
     },
     gabriel: {
       summary:
-        'LLM “ángel guardián” con privacidad primero para coaching local de seguridad e integración con token.place o inferencia offline.',
+        'LLM “ángel guardián” open source centrado en consejos de seguridad privados, locales y monitoreo asistido opcional.',
       outcome:
-        'Las pilas de ingesta, análisis, notificación e interfaz se mantienen alineadas mediante interfaces tipadas.',
+        'El README enfatiza consentimiento, inferencia local, conocimiento del entorno personal y coaching accionable.',
       metrics: [
         'Enfoque',
-        'Barrido lidar 360° + heurísticas locales',
+        'Coaching de seguridad digital con privacidad primero',
         'Cadencia',
-        'Destello rojo cada 1,0 s',
+        'FAQ y documentación en el repositorio',
       ],
     },
     flywheel: {
       summary:
-        'Plantilla de GitHub y centro de automatización con lint, pruebas, docs y prompts de Codex para iniciar repos rápido.',
+        'Boilerplate y CLI opinados para CI reproducible, calidad de código, docs, prompts y auditorías de repos.',
       outcome:
-        'Incluye CI repetible y bibliotecas de prompts para que los repos nuevos arranquen saludables.',
+        'Ofrece comandos init/update, checks, docs de prompts de Codex, auditorías y sugerencias dry-run.',
       metrics: [
         'Automatización',
-        'Andamios CI · prompts tipados · bucles QA',
+        'CLI init/update · checks · docs de prompts',
         'Docs CTA',
-        'flywheel.futuroptimist.dev →',
+        'Soporte, eje, adaptador y docs de física',
       ],
     },
     jobbot: {
       summary:
-        'Copiloto autoalojado de búsqueda laboral con CLI e interfaz web experimental para ingestar contactos y seguir postulaciones.',
+        'Copiloto open source autoalojado de búsqueda laboral con interfaz web local experimental y setup documentado.',
       outcome:
-        'Los flujos de punta a punta reflejan docs y pruebas para cubrir el contacto con recruiters.',
+        'El README advierte que la UI web es solo local mientras las docs cubren setup, arquitectura, configuración y pruebas.',
       metrics: [
         'Estado',
-        'CLI local-first con UI web previa',
+        'Copiloto autoalojado con vista web local',
         'Stack',
-        'Node.js 20+ · scripts npm · vista Playwright',
+        'Node.js 20+ · scripts npm',
         'Flujos',
-        'Ingesta de contactos y seguimiento del ciclo',
+        'Advertencia local sobre secretos y PII',
       ],
     },
     axel: {
@@ -148,9 +148,9 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
         'Automatiza la recolección y síntesis de logs CI para traspasos de depuración rápidos.',
       metrics: [
         'Velocidad',
-        'Copia logs fallidos en menos de 3 s',
+        'Codex task → checks de PR GitHub → Markdown',
         'Formatos',
-        'CLI + portapapeles + salida Markdown',
+        'Redacción de secretos antes de resumir o emitir',
       ],
     },
     sigma: {
@@ -179,14 +179,14 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
     },
     dspace: {
       summary:
-        'Pórtico de lanzamiento de patio para DSPACE con señales de cuenta atrás guiadas por telemetría y bitácora pública.',
+        'Exhibición DSPACE para el juego web idle Democratized Space, enfocada en recursos, quests, exploración y lanzamientos a órbita.',
       outcome:
-        'Mantiene notas de secuencia de cuenta atrás junto a enlaces de GitHub y bitácora mientras el repo sigue privado.',
+        'Enlaza el repositorio público democratizedspace/dspace y la documentación oficial, sin bitácoras no verificadas.',
       metrics: [
         'Cuenta atrás',
-        'Secuencia T-0 autónoma',
+        'Gestión de recursos · quests · exploración',
         'Stack',
-        'Three.js FX · audio espacial',
+        'Docs públicos y guía de desarrollo',
       ],
     },
     prReaper: {

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -85,7 +85,7 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
       metrics: [
         'Automatización',
         'CLI init/update · checks · docs de prompts',
-        'Docs CTA',
+        'CAD',
         'Soporte, eje, adaptador y docs de física',
       ],
     },

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -183,9 +183,9 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
       outcome:
         'Enlaza el repositorio público democratizedspace/dspace y la documentación oficial, sin bitácoras no verificadas.',
       metrics: [
-        'Cuenta atrás',
+        'Juego',
         'Gestión de recursos · quests · exploración',
-        'Stack',
+        'Docs',
         'Docs públicos y guía de desarrollo',
       ],
     },

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -183,9 +183,9 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
       outcome:
         'A nyilvános democratizedspace/dspace repót és a hivatalos játékdokumentációt linkeli, ellenőrizetlen napló nélkül.',
       metrics: [
-        'Visszaszámlálás',
+        'Játék',
         'Erőforrás-kezelés · questek · felfedezés',
-        'Stack',
+        'Docs',
         'Nyilvános docs és fejlesztői útmutató',
       ],
     },

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -50,7 +50,7 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
         'Munkafolyamat',
         'Resolve-stílusú vágócsomag · három kijelző',
         'Fókusz',
-        'Futuroptimist ökoszisztéma-reels folyamatban',
+        'Szkriptek, prompt-dokumentumok, kapcsolódó projektek állapota',
       ],
     },
     tokenplace: {
@@ -60,9 +60,9 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
         'A quickstart scriptek helyben indítják a relayt, szervert és mock LLM stacket teszteléshez.',
       metrics: [
         'Klaszter',
-        '12× Pi 5 csomópont moduláris rekeszekben',
+        'Python belépési pontok: relay.py és server.py',
         'Hálózat',
-        'Efemer tokenek · titkosított burstök',
+        'API v1 relay-vak E2EE alapvonal',
       ],
     },
     gabriel: {
@@ -72,7 +72,7 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
         'A beviteli, elemzési, értesítési és UI stackek típusos interfészekkel maradnak összhangban.',
       metrics: [
         'Fókusz',
-        '360° lidar pásztázás + helyi heurisztikák',
+        'Adatvédelem-központú digitális biztonsági coaching',
         'Ütem',
         'Piros riasztásvillanás 1,0 s-enként',
       ],
@@ -86,7 +86,7 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
         'Automatizáció',
         'CI scaffoldok · típusos promptok · QA ciklusok',
         'Docs CTA',
-        'flywheel.futuroptimist.dev →',
+        'Állvány, tengely, adapter és fizika dokumentumok',
       ],
     },
     jobbot: {
@@ -150,7 +150,7 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
         'Sebesség',
         'Hibás logok másolása 3 s alatt',
         'Formátumok',
-        'CLI + vágólap + Markdown kimenet',
+        'Titkok redakciója összegzés vagy kimenet előtt',
       ],
     },
     sigma: {
@@ -179,14 +179,14 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
     },
     dspace: {
       summary:
-        'Hátsókerti indítóállvány a DSPACE projekthez telemetria-vezérelt visszaszámlálási jelzésekkel és nyilvános missziónaplóval.',
+        'DSPACE kiállítás a Democratized Space webes idle játékhoz, erőforrásokra, questekre, felfedezésre és orbitális indításokra fókuszálva.',
       outcome:
-        'Visszaszámlálási jegyzeteket tart GitHub és missziónapló linkek mellett, miközben a repo privát.',
+        'A nyilvános democratizedspace/dspace repót és a hivatalos játékdokumentációt linkeli, ellenőrizetlen napló nélkül.',
       metrics: [
         'Visszaszámlálás',
-        'Autonóm T-0 szekvencia',
+        'Erőforrás-kezelés · questek · felfedezés',
         'Stack',
-        'Three.js FX · térbeli hang',
+        'Nyilvános docs és fejlesztői útmutató',
       ],
     },
     prReaper: {

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -685,9 +685,13 @@ function buildPoi(
     fallback: string;
   }
 ): LocaleOverrides['poi'] {
-  const starSource = (repo: string, visibility?: 'private') => ({
+  const starSource = (
+    repo: string,
+    visibility?: 'private',
+    owner = 'futuroptimist'
+  ) => ({
     type: 'githubStars' as const,
-    owner: 'futuroptimist',
+    owner,
     repo,
     ...(visibility ? { visibility } : {}),
     format: 'compact' as const,
@@ -706,8 +710,8 @@ function buildPoi(
       metrics: [
         {
           label: githubStars.label,
-          value: '1,280+',
-          source: { ...starSource('danielsmith.io'), fallback: '1,280+' },
+          value: githubStars.value,
+          source: starSource('danielsmith.io'),
         },
         {
           label: poi.futuroptimist.metrics[0],
@@ -809,8 +813,8 @@ function buildPoi(
       metrics: [
         {
           label: githubStars.label,
-          value: '1,280+',
-          source: { ...starSource('danielsmith.io'), fallback: '1,280+' },
+          value: githubStars.value,
+          source: starSource('danielsmith.io'),
         },
         { label: poi.portfolio.metrics[0], value: poi.portfolio.metrics[1] },
         { label: poi.portfolio.metrics[2], value: poi.portfolio.metrics[3] },
@@ -872,7 +876,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', 'private'),
+          source: starSource('dspace', undefined, 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -178,13 +178,13 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
     },
     dspace: {
       summary:
-        'Pórtico de lançamento no quintal para DSPACE com sinais de contagem regressiva guiados por telemetria e log público.',
+        'Exposição DSPACE para o jogo idle web Democratized Space, com recursos, missões, exploração e lançamentos orbitais.',
       outcome:
-        'Aponta para o repositório público democratizedspace/dspace e a documentação oficial, sem logs não verificados.',
+        'Aponta para o repositório público democratizedspace/dspace e a documentação oficial do jogo, sem logs não verificados.',
       metrics: [
-        'Contagem',
-        'Sequenciamento T-0 autônomo',
-        'Stack',
+        'Jogo',
+        'Gestão de recursos · missões · exploração',
+        'Docs',
         'Docs públicos e guia de desenvolvimento',
       ],
     },

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -60,9 +60,9 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
         'Scripts de início sobem localmente o relay, o servidor e a pilha de LLM simulado para testes.',
       metrics: [
         'Cluster',
-        '12× nós Pi 5 em baias modulares',
+        'Entrypoints Python relay.py e server.py',
         'Rede',
-        'Tokens efêmeros · rajadas criptografadas',
+        'Linha de base API v1 com E2EE cega ao relay',
       ],
     },
     gabriel: {
@@ -72,9 +72,9 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
         'Pilhas de ingestão, análise, notificação e UI permanecem alinhadas por interfaces tipadas.',
       metrics: [
         'Foco',
-        'Varredura lidar 360° + heurísticas locais',
+        'Coaching de segurança digital com privacidade primeiro',
         'Cadência',
-        'Flash vermelho a cada 1,0 s',
+        'FAQ e docs no repositório',
       ],
     },
     flywheel: {
@@ -86,7 +86,7 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
         'Automação',
         'Scaffolds CI · prompts tipados · ciclos QA',
         'CTA docs',
-        'flywheel.futuroptimist.dev →',
+        'Suporte, eixo, adaptador e docs de física',
       ],
     },
     jobbot: {
@@ -147,7 +147,7 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
         'Automatiza coleta e resumo de logs CI para handoff rápido de depuração.',
       metrics: [
         'Velocidade',
-        'Copia logs com falha em menos de 3 s',
+        'Codex task → checks de PR GitHub → Markdown',
         'Formatos',
         'CLI + área de transferência + Markdown',
       ],
@@ -180,12 +180,12 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
       summary:
         'Pórtico de lançamento no quintal para DSPACE com sinais de contagem regressiva guiados por telemetria e log público.',
       outcome:
-        'Mantém notas de sequência junto a links GitHub e log de missão enquanto o repo segue privado.',
+        'Aponta para o repositório público democratizedspace/dspace e a documentação oficial, sem logs não verificados.',
       metrics: [
         'Contagem',
         'Sequenciamento T-0 autônomo',
         'Stack',
-        'Three.js FX · áudio espacial',
+        'Docs públicos e guia de desenvolvimento',
       ],
     },
     prReaper: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -425,14 +425,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         { label: '状态', value: '自动化内容工作流' },
         {
           label: '星标',
-          value: '1,280+',
+          value: '正在从 GitHub 同步…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'danielsmith.io',
             format: 'compact',
             template: '{value} 个星标',
-            fallback: '1,280+',
+            fallback: '正在从 GitHub 同步…',
           },
         },
         { label: '节奏', value: '研究 → 提纲 → 旁白草稿' },
@@ -497,7 +497,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         { label: '模式', value: '可审计代理循环' },
       ],
       links: [
-        { label: 'GitHub', href: 'https://github.com/futuroptimist/Gabriel' },
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/gabriel' },
       ],
     },
     'flywheel-studio-flywheel': {
@@ -521,15 +521,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             fallback: '正在从 GitHub 同步…',
           },
         },
-        { label: '自动化', value: 'CI 脚手架 · 类型化提示 · QA 循环' },
-        { label: '文档入口', value: 'flywheel.futuroptimist.dev →' },
+        { label: '自动化', value: 'init/update CLI · 检查 · 提示文档' },
+        { label: 'CAD', value: '飞轮支架、轴、适配器和物理文档' },
       ],
       links: [
         {
           label: 'Flywheel 仓库',
           href: 'https://github.com/futuroptimist/flywheel',
         },
-        { label: '文档', href: 'https://flywheel.futuroptimist.dev' },
       ],
       narration: { caption: 'Flywheel 动能中枢启动，聚焦自动化提示和工具链。' },
       interactionPrompt: '启动 {title} 系统',
@@ -564,7 +563,6 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
           label: 'GitHub',
           href: 'https://github.com/futuroptimist/jobbot3000',
         },
-        { label: '自动化日志', href: 'https://futuroptimist.dev/automation' },
       ],
       narration: { caption: 'Jobbot 全息终端以闪烁覆盖层流式展示自动化遥测。' },
     },
@@ -627,14 +625,14 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       metrics: [
         {
           label: '星标',
-          value: '1,280+',
+          value: '正在从 GitHub 同步…',
           source: {
             type: 'githubStars',
             owner: 'futuroptimist',
             repo: 'danielsmith.io',
             format: 'compact',
             template: '{value} 个星标',
-            fallback: '1,280+',
+            fallback: '正在从 GitHub 同步…',
           },
         },
         { label: '技术栈', value: 'Vite · Three.js · 无障碍 HUD' },
@@ -733,36 +731,37 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
     },
     'dspace-backyard-rocket': {
       title: 'Dspace',
-      summary: '民主化空间项目资料与任务体验，围绕探索、技能和路线图组织内容。',
+      summary:
+        'DSPACE 展示 Democratized Space 网页放置游戏，聚焦资源管理、任务、探索和发射入轨进程。',
       outcome: {
         label: '成果',
-        value: '让任务 JSON、技能文档和发布说明保持耦合，便于可靠迭代。',
+        value:
+          '链接到公开的 democratizedspace/dspace 仓库和官方游戏文档，避免未经验证的任务日志。',
       },
       metrics: [
-        { label: '状态', value: '任务验证和文档门禁' },
+        { label: '游戏', value: '资源管理 · 任务 · 探索' },
         {
           label: '星标',
           value: '正在从 GitHub 同步…',
           source: {
             type: 'githubStars',
-            owner: 'futuroptimist',
+            owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
           },
         },
-        { label: '重点', value: '探索路线图 · 技能 · 发布文档' },
-        { label: 'QA', value: '链接检查和任务验证' },
+        { label: '文档', value: '公开文档和开发者指南' },
       ],
       links: [
         {
           label: 'GitHub',
           href: 'https://github.com/democratizedspace/dspace',
         },
+        { label: '文档', href: 'https://democratized.space/docs' },
       ],
-      narration: { caption: '后院火箭投射 Dspace 路线图轨迹。' },
+      narration: { caption: '后院火箭投射 DSPACE 探索路线。' },
     },
     'pr-reaper-backyard-console': {
       title: 'pr-reaper',

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -730,7 +730,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       ],
     },
     'dspace-backyard-rocket': {
-      title: 'Dspace',
+      title: 'DSPACE',
       summary:
         'DSPACE 展示 Democratized Space 网页放置游戏，聚焦资源管理、任务、探索和发射入轨进程。',
       outcome: {

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -812,11 +812,15 @@ function createFlywheelDocsCalloutTexture(): CanvasTexture {
   context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
   context.textAlign = 'left';
   context.textBaseline = 'alphabetic';
-  context.fillText('Docs', 64, canvas.height * 0.56);
+  context.fillText('README', 64, canvas.height * 0.56);
 
   context.font = '600 56px "Inter", "Segoe UI", sans-serif';
   context.fillStyle = '#a8eeff';
-  context.fillText('flywheel.futuroptimist.dev', 64, canvas.height * 0.78);
+  context.fillText(
+    'github.com/futuroptimist/flywheel',
+    64,
+    canvas.height * 0.78
+  );
 
   context.textAlign = 'right';
   context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -84,8 +84,8 @@ describe('createFlywheelShowpiece', () => {
 
     const capturedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
     expect(capturedText).toContain('Flywheel Automation');
-    expect(capturedText).toContain('Docs');
-    expect(capturedText).toContain('flywheel.futuroptimist.dev');
+    expect(capturedText).toContain('README');
+    expect(capturedText).toContain('github.com/futuroptimist/flywheel');
     expect(capturedText).toContain('CI templates');
     expect(capturedText).toContain('Typed prompts');
     expect(capturedText).toContain('Scaffolds');

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -218,6 +218,28 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('keeps localized DSPACE game and docs metric labels current', () => {
+    const staleDspaceMetricLabelPattern =
+      /^(countdown|cuenta atrás|visszaszámlálás|contagem|stack)$/i;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const dspace = getPoiDefinitions(locale).find(
+        (poi) => poi.id === 'dspace-backyard-rocket'
+      );
+      const groundedMetricLabels =
+        dspace?.metrics
+          ?.filter((metric) => metric.source?.type !== 'githubStars')
+          .map((metric) => metric.label) ?? [];
+
+      expect(groundedMetricLabels, locale).toHaveLength(2);
+      expect(groundedMetricLabels, locale).toEqual(
+        expect.not.arrayContaining([
+          expect.stringMatching(staleDspaceMetricLabelPattern),
+        ])
+      );
+    }
+  });
+
   it('deep-clones localized POI metric sources per call', () => {
     const firstDefinitions = getPoiDefinitions('en-x-pseudo');
     const firstPoi = firstDefinitions.find(

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -200,6 +200,24 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('removes the invalid DSPACE Mission Log link from every locale', () => {
+    for (const locale of AVAILABLE_LOCALES) {
+      const dspace = getPoiDefinitions(locale).find(
+        (poi) => poi.id === 'dspace-backyard-rocket'
+      );
+      const links = dspace?.links ?? [];
+
+      expect(links).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            href: 'https://futuroptimist.dev/projects/dspace',
+          }),
+        ])
+      );
+      expect(links.some((link) => /mission log/i.test(link.label))).toBe(false);
+    }
+  });
+
   it('deep-clones localized POI metric sources per call', () => {
     const firstDefinitions = getPoiDefinitions('en-x-pseudo');
     const firstPoi = firstDefinitions.find(
@@ -673,7 +691,7 @@ describe('i18n utilities', () => {
       '⟦Futuroptimist⟧'
     );
     expect(pseudoCopy['futuroptimist-living-room-tv'].summary).toBe(
-      '⟦Automated Futuroptimist scripting desk that stitches research, outlines, and narration-ready drafts for new videos.⟧'
+      '⟦Futuroptimist hub for open-source scripts, data pipelines, tests, and YouTube-oriented automation metadata.⟧'
     );
     expect(pseudoCopy['tokenplace-studio-cluster'].title).toBe(
       copy['tokenplace-studio-cluster'].title

--- a/src/tests/linkChecker.test.ts
+++ b/src/tests/linkChecker.test.ts
@@ -6,10 +6,15 @@ import { AVAILABLE_LOCALES } from '../assets/i18n';
 import { getPoiDefinitions } from '../scene/poi/registry';
 
 const require = createRequire(import.meta.url);
+type CollectedLink = { kind: 'poi' | 'docs'; source: string; target: string };
+
 const linkChecker = require('../../scripts/check-links.cjs') as {
-  collectLinks: () => Promise<
-    Array<{ kind: 'poi' | 'docs'; source: string; target: string }>
-  >;
+  collectLinks: () => Promise<CollectedLink[]>;
+  extractMarkdownLinks: (source: string, text: string) => CollectedLink[];
+  validateLinks: (
+    links: CollectedLink[],
+    options?: { concurrency?: number; retries?: number; timeoutMs?: number }
+  ) => Promise<{ failures: string[]; warnings: string[]; skipped: number }>;
 };
 
 const allowedPoiSchemes = new Set(['http:', 'https:', 'mailto:']);
@@ -37,7 +42,7 @@ describe('POI link validation', () => {
     for (const locale of AVAILABLE_LOCALES) {
       for (const poi of getPoiDefinitions(locale)) {
         for (const link of poi.links ?? []) {
-          const url = new URL(link.href, 'https://danielsmith.io/');
+          const url = new URL(link.href);
           expect(
             allowedPoiSchemes.has(url.protocol),
             `${locale} ${poi.id} ${link.href} uses an allowed scheme`
@@ -45,6 +50,10 @@ describe('POI link validation', () => {
         }
       }
     }
+  });
+
+  it('requires localized POI links to be absolute URLs', () => {
+    expect(() => new URL('/docs/foo')).toThrow(TypeError);
   });
 });
 
@@ -64,5 +73,49 @@ describe('link checker collection', () => {
     expect(
       links.some((link) => link.kind === 'docs' && link.source === 'README.md')
     ).toBe(true);
+  });
+});
+
+describe('Markdown link extraction', () => {
+  it('keeps balanced parentheses in inline Markdown link destinations', () => {
+    const links = linkChecker.extractMarkdownLinks(
+      'docs/example.md',
+      '[API](https://example.com/a_(b))'
+    );
+
+    expect(links).toEqual([
+      {
+        kind: 'docs',
+        source: 'docs/example.md',
+        target: 'https://example.com/a_(b)',
+      },
+    ]);
+  });
+
+  it('validates local Markdown anchors when hashes are present', async () => {
+    const results = await linkChecker.validateLinks(
+      [
+        {
+          kind: 'docs',
+          source: 'README.md',
+          target: 'README.md#local-quality-gates',
+        },
+        {
+          kind: 'docs',
+          source: 'README.md',
+          target: '#key-resources',
+        },
+        {
+          kind: 'docs',
+          source: 'README.md',
+          target: 'README.md#missing-section-for-test',
+        },
+      ],
+      { concurrency: 1 }
+    );
+
+    expect(results.failures).toHaveLength(1);
+    expect(results.failures[0]).toContain('missing local anchor');
+    expect(results.failures[0]).toContain('README.md#missing-section-for-test');
   });
 });

--- a/src/tests/linkChecker.test.ts
+++ b/src/tests/linkChecker.test.ts
@@ -92,6 +92,28 @@ describe('Markdown link extraction', () => {
     ]);
   });
 
+  it('validates repeated local targets relative to each source file', async () => {
+    const results = await linkChecker.validateLinks(
+      [
+        {
+          kind: 'docs',
+          source: 'README.md',
+          target: 'docs/roadmap.md',
+        },
+        {
+          kind: 'docs',
+          source: 'docs/architecture/scene-stack.md',
+          target: 'docs/roadmap.md',
+        },
+      ],
+      { concurrency: 1 }
+    );
+
+    expect(results.failures).toHaveLength(1);
+    expect(results.failures[0]).toContain('missing local link target');
+    expect(results.failures[0]).toContain('docs/architecture/scene-stack.md');
+  });
+
   it('validates local Markdown anchors when hashes are present', async () => {
     const results = await linkChecker.validateLinks(
       [

--- a/src/tests/linkChecker.test.ts
+++ b/src/tests/linkChecker.test.ts
@@ -1,0 +1,68 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+import { AVAILABLE_LOCALES } from '../assets/i18n';
+import { getPoiDefinitions } from '../scene/poi/registry';
+
+const require = createRequire(import.meta.url);
+const linkChecker = require('../../scripts/check-links.cjs') as {
+  collectLinks: () => Promise<
+    Array<{ kind: 'poi' | 'docs'; source: string; target: string }>
+  >;
+};
+
+const allowedPoiSchemes = new Set(['http:', 'https:', 'mailto:']);
+
+describe('POI link validation', () => {
+  it('does not expose the removed DSPACE Mission Log link in any locale', () => {
+    for (const locale of AVAILABLE_LOCALES) {
+      const dspace = getPoiDefinitions(locale).find(
+        (poi) => poi.id === 'dspace-backyard-rocket'
+      );
+      const links = dspace?.links ?? [];
+
+      expect(links, `${locale} keeps DSPACE links`).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            href: 'https://futuroptimist.dev/projects/dspace',
+          }),
+        ])
+      );
+      expect(links.some((link) => /mission log/i.test(link.label))).toBe(false);
+    }
+  });
+
+  it('keeps all localized POI links on supported schemes with valid syntax', () => {
+    for (const locale of AVAILABLE_LOCALES) {
+      for (const poi of getPoiDefinitions(locale)) {
+        for (const link of poi.links ?? []) {
+          const url = new URL(link.href, 'https://danielsmith.io/');
+          expect(
+            allowedPoiSchemes.has(url.protocol),
+            `${locale} ${poi.id} ${link.href} uses an allowed scheme`
+          ).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe('link checker collection', () => {
+  it('collects both POI locale links and README/docs Markdown links', async () => {
+    const links = await linkChecker.collectLinks();
+
+    expect(links.some((link) => link.kind === 'poi')).toBe(true);
+    expect(links.some((link) => link.kind === 'docs')).toBe(true);
+    expect(
+      links.some(
+        (link) =>
+          link.kind === 'poi' &&
+          link.target === 'https://github.com/democratizedspace/dspace'
+      )
+    ).toBe(true);
+    expect(
+      links.some((link) => link.kind === 'docs' && link.source === 'README.md')
+    ).toBe(true);
+  });
+});

--- a/src/tests/linkChecker.test.ts
+++ b/src/tests/linkChecker.test.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AVAILABLE_LOCALES } from '../assets/i18n';
 import { getPoiDefinitions } from '../scene/poi/registry';
@@ -73,6 +73,38 @@ describe('link checker collection', () => {
     expect(
       links.some((link) => link.kind === 'docs' && link.source === 'README.md')
     ).toBe(true);
+  });
+});
+
+describe('external link validation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to GET when HEAD reports a missing external URL', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await linkChecker.validateLinks(
+      [
+        {
+          kind: 'docs',
+          source: 'README.md',
+          target: 'https://example.org/head-404-get-ok',
+        },
+      ],
+      { concurrency: 1, retries: 0 }
+    );
+
+    expect(results.failures).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([, init]) => init?.method)).toEqual([
+      'HEAD',
+      'GET',
+    ]);
   });
 });
 

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -77,9 +77,9 @@ describe('POI registry', () => {
     expect(rocket?.interactionRadius).toBeGreaterThan(2);
     expect(rocket?.footprint.width).toBeGreaterThan(3);
     expect(rocket?.links?.[0]?.href).toContain('dspace');
-    expect(
-      rocket?.metrics?.some((metric) => metric.label === 'Countdown')
-    ).toBe(true);
+    expect(rocket?.metrics?.some((metric) => metric.label === 'Game')).toBe(
+      true
+    );
   });
 
   it('registers the greenhouse POI with Sugarkube storytelling hooks', () => {

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -357,7 +357,10 @@ describe('PoiTooltipOverlay', () => {
       position: { x: 2, y: 0, z: 4 },
       metrics: [{ label: 'Automation', value: 'CI-ready prompts' }],
       links: [
-        { label: 'Flywheel', href: 'https://flywheel.futuroptimist.dev' },
+        {
+          label: 'Flywheel',
+          href: 'https://github.com/futuroptimist/flywheel',
+        },
       ],
       status: undefined,
       interactionPrompt: 'Engage Flywheel systems',


### PR DESCRIPTION
### Motivation
- Ground POI copy and links in real public README/docs facts and remove an unverified DSPACE "Mission Log" link that was not publicly valid.
- Prevent future regressions by adding CI-level link validation that scans POI locale data and README/docs Markdown links.
- Ensure locale parity so non-English locales reflect the same grounded facts and star/metric sources remain neutral when live data is unavailable.

### Description
- Rewrote POI copy for several projects in `src/assets/i18n/locales/*` (notably `en.ts`, `en-x-pseudo.ts`, `zh-Hans.ts`, `latinLocaleOverrides.ts`, and other Latin locales) to align with public README/docs and removed the `https://futuroptimist.dev/projects/dspace` Mission Log link in favor of `democratizedspace/dspace` + official docs.
- Replaced static/fake star fallbacks with neutral "Syncing from GitHub…" placeholders and adjusted the Latin-locale star helpers to emit owner overrides for private/public repo mappings.
- Added a link checker script `scripts/check-links.cjs` and a test `src/tests/linkChecker.test.ts` that collect POI `href:` entries and Markdown links, validate URL syntax, check local targets, probe external HTTP(S) targets with HEAD→GET fallback, apply an allowlist for known examples, and fail CI on clear 404/410 results.
- Wired `links:check` into `package.json` and into `npm run docs:check`, updated README/docs references, and refreshed the press-kit output to reflect the updated POI data.

### Testing
- Ran `npm run format:write` and formatting completed successfully.
- Ran `npm run lint` and ESLint completed with no new errors.
- Ran `npm run typecheck` which surfaced pre-existing unrelated TypeScript errors in the codebase and therefore failed; these errors were present prior to the link validation work and were not introduced by this change.
- Ran `npm run links:check` which executed `scripts/check-links.cjs`; the checker collected POI and docs links and passed, emitting network reachability warnings in this environment for external hosts but no 404/410 failures.
- Ran `npm run docs:check` (which now invokes `links:check`) and it passed; link-check warnings about unreachable external hosts were logged but treated as warnings per the allowlist/timeout policy.
- Ran `npm run test:ci` (full Vitest suite) and the test suite passed locally: all tests passed in CI run snapshot (final run: 135 files, 979 tests passed).
- Ran `npm run build` and `npm run smoke` and both completed successfully; `dist` artifacts were generated and smoke validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ec072918832fa8e7e5ef839881a8)