### PR TITLE
Add keyboard zoom shortcuts and tune trackpad/wheel zoom

### DIFF
--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -199,6 +199,40 @@ test.describe('immersive orthographic zoom', () => {
     await expect(page.locator('[data-role="hud-menu"]')).toBeVisible();
   });
 
+  test('supports keyboard zoom shortcuts without a mouse wheel', async ({
+    page,
+  }) => {
+    await waitForImmersive(page);
+
+    const initial = await getCameraZoomState(page);
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('-');
+    await page.keyboard.up('Shift');
+
+    const zoomedOut = await getCameraZoomState(page);
+    expect(zoomedOut.target).toBeLessThan(initial.target);
+
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('=');
+    await page.keyboard.up('Shift');
+
+    const zoomedIn = await getCameraZoomState(page);
+    expect(zoomedIn.target).toBeGreaterThan(zoomedOut.target);
+
+    await page.evaluate(() => {
+      const field = document.createElement('input');
+      field.setAttribute('aria-label', 'Zoom shortcut guard');
+      document.body.append(field);
+      field.focus();
+    });
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('-');
+    await page.keyboard.up('Shift');
+
+    const unchanged = await getCameraZoomState(page);
+    expect(unchanged.target).toBeCloseTo(zoomedIn.target, 6);
+  });
+
   test('keeps a single clean immersive canvas while zooming with motion blur disabled', async ({
     page,
   }) => {

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -170,7 +170,7 @@ export const AR_OVERRIDES: LocaleOverrides = {
           description: 'اسحب لتحريك الكاميرا',
         },
         pointerZoom: {
-          keys: 'عجلة التمرير',
+          keys: 'عجلة التمرير / Shift + + / Shift + -',
           description: 'تكبير أو تصغير',
         },
         touchDrag: {
@@ -336,6 +336,10 @@ export const AR_OVERRIDES: LocaleOverrides = {
               description: 'قم بتدوير الكاميرا متساوية القياس.',
             },
             { label: 'عجلة التمرير', description: 'اضبط مستوى التكبير.' },
+            {
+              label: 'Shift + + / Shift + -',
+              description: 'كبّر أو صغّر من دون عجلة فأرة.',
+            },
             {
               label: 'عصا اللمس',
               description: 'اسحب اليسار للحركة واليمين للدوران.',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -176,7 +176,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           description: 'Drag to pan',
         },
         pointerZoom: {
-          keys: 'Scroll wheel',
+          keys: 'Scroll wheel / Shift + + / Shift + -',
           description: 'Zoom',
         },
         touchDrag: {
@@ -455,6 +455,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             },
             { label: 'Mouse drag', description: 'Pan the isometric camera.' },
             { label: 'Scroll wheel', description: 'Adjust zoom level.' },
+            {
+              label: 'Shift + + / Shift + -',
+              description: 'Zoom without a mouse wheel.',
+            },
             {
               label: 'Touch joysticks',
               description:

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -171,7 +171,7 @@ export const JA_OVERRIDES: LocaleOverrides = {
           description: 'ドラッグして視点移動',
         },
         pointerZoom: {
-          keys: 'ホイール',
+          keys: 'ホイール / Shift + + / Shift + -',
           description: 'ズーム',
         },
         touchDrag: {
@@ -338,6 +338,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
               description: 'アイソメ視点をパンします。',
             },
             { label: 'ホイール', description: 'ズームレベルを調整します。' },
+            {
+              label: 'Shift + + / Shift + -',
+              description: 'マウスホイールなしでズームします。',
+            },
             {
               label: 'タッチジョイスティック',
               description: '左パッドで移動し、右パッドで視点をパンします。',

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -143,7 +143,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       items: {
         keyboardMove: { keys: 'WASD / 方向键', description: '移动' },
         pointerDrag: { keys: '鼠标左键', description: '拖动平移' },
-        pointerZoom: { keys: '滚轮', description: '缩放' },
+        pointerZoom: {
+          keys: '滚轮 / Shift + + / Shift + -',
+          description: '缩放',
+        },
         touchDrag: {
           keys: '触控',
           description: '左半屏拖动移动，右半屏拖动平移',
@@ -365,6 +368,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             { label: 'WASD / 方向键', description: '在家中移动探索者。' },
             { label: '鼠标拖动', description: '平移等距相机。' },
             { label: '滚轮', description: '调整缩放级别。' },
+            {
+              label: 'Shift + + / Shift + -',
+              description: '无需鼠标滚轮即可缩放。',
+            },
             { label: '触控摇杆', description: '拖动左垫移动，拖动右垫平移。' },
             { label: '捏合', description: '在触控设备上缩放。' },
           ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -318,6 +318,12 @@ import {
 } from './systems/controls/tourResetControl';
 import { VirtualJoystick } from './systems/controls/VirtualJoystick';
 import {
+  applyCameraZoomStep,
+  applyWheelCameraZoom,
+  isKeyboardZoomShortcut,
+  isTextEntryTarget,
+} from './systems/controls/zoomControls';
+import {
   evaluateFailoverDecision,
   renderTextFallback,
   type FallbackReason,
@@ -533,7 +539,6 @@ const CAMERA_ZOOM_SMOOTHING = 6;
 const CAMERA_MARGIN = 1.1;
 const MIN_CAMERA_ZOOM = 0.65;
 const MAX_CAMERA_ZOOM = 12;
-const CAMERA_ZOOM_WHEEL_SENSITIVITY = 0.0018;
 const MANNEQUIN_YAW_SMOOTHING = 8;
 const CEILING_COVE_OFFSET = 0.35;
 const BACKYARD_ROOM_ID = 'backyard';
@@ -2972,20 +2977,6 @@ function initializeImmersiveScene(
     }
     helpModal.toggle(force);
   };
-  const isTextEntryTarget = (target: EventTarget | null): boolean => {
-    if (!(target instanceof HTMLElement)) {
-      return false;
-    }
-    const tagName = target.tagName.toLowerCase();
-    return (
-      target.isContentEditable ||
-      target.hasAttribute('contenteditable') ||
-      target.closest('[contenteditable]') !== null ||
-      tagName === 'input' ||
-      tagName === 'textarea' ||
-      tagName === 'select'
-    );
-  };
   const normalizeKeyboardEventKey = (event: KeyboardEvent): string =>
     event.key.length === 1 ? event.key.toLowerCase() : event.key;
   const normalizeBindingKey = (binding: string): string =>
@@ -3012,6 +3003,16 @@ function initializeImmersiveScene(
           .some((binding) => normalizeBindingKey(binding) === normalizedKey)
     );
   };
+  const handleKeyboardZoomKeydown = (event: KeyboardEvent) => {
+    const direction = isKeyboardZoomShortcut(event);
+    if (direction === null) {
+      return;
+    }
+    event.preventDefault();
+    idleMonitor?.reportActivity();
+    applyCameraZoomStepToTarget(direction, 'keyboard');
+  };
+
   const handleControlsKeydown = (event: KeyboardEvent) => {
     if (event.defaultPrevented || event.repeat) {
       return;
@@ -3035,6 +3036,7 @@ function initializeImmersiveScene(
     }
     responsiveControlOverlay?.toggle();
   };
+  window.addEventListener('keydown', handleKeyboardZoomKeydown);
   window.addEventListener('keydown', handleControlsKeydown);
   hudPanelCoordinator = createHudPanelCoordinator({
     controls: responsiveControlOverlay ?? {
@@ -3320,6 +3322,23 @@ function initializeImmersiveScene(
     cameraZoomTarget = MathUtils.clamp(next, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM);
   };
 
+  function applyCameraZoomStepToTarget(
+    direction: 1 | -1,
+    source: 'keyboard' | 'wheel' | 'pinch',
+    magnitude = 1
+  ) {
+    setCameraZoomTarget(
+      applyCameraZoomStep({
+        currentTarget: cameraZoomTarget,
+        direction,
+        source,
+        magnitude,
+        minZoom: MIN_CAMERA_ZOOM,
+        maxZoom: MAX_CAMERA_ZOOM,
+      })
+    );
+  }
+
   const updateCameraPanLimits = (aspect: number) => {
     const effectiveHalfWidth = (baseCameraSize * aspect) / cameraZoom;
     const effectiveHalfHeight = baseCameraSize / cameraZoom;
@@ -3372,7 +3391,13 @@ function initializeImmersiveScene(
   const handleWheelZoom = (event: WheelEvent) => {
     event.preventDefault();
     setCameraZoomTarget(
-      cameraZoomTarget - event.deltaY * CAMERA_ZOOM_WHEEL_SENSITIVITY
+      applyWheelCameraZoom({
+        currentTarget: cameraZoomTarget,
+        deltaY: event.deltaY,
+        deltaMode: event.deltaMode,
+        minZoom: MIN_CAMERA_ZOOM,
+        maxZoom: MAX_CAMERA_ZOOM,
+      })
     );
   };
 
@@ -4661,6 +4686,7 @@ function initializeImmersiveScene(
       hudLayoutManager.dispose();
       hudLayoutManager = null;
     }
+    window.removeEventListener('keydown', handleKeyboardZoomKeydown);
     window.removeEventListener('keydown', handleControlsKeydown);
     if (hudPanelCoordinator) {
       hudPanelCoordinator.dispose();

--- a/src/systems/controls/zoomControls.test.ts
+++ b/src/systems/controls/zoomControls.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyCameraZoomStep,
+  applyWheelCameraZoom,
+  isKeyboardZoomShortcut,
+  normalizeWheelDeltaY,
+} from './zoomControls';
+
+const bounds = { minZoom: 0.65, maxZoom: 12 };
+
+function keyboardEvent(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+}
+
+describe('zoomControls', () => {
+  it('detects Shift+Equal and Shift+Minus by physical key code', () => {
+    expect(
+      isKeyboardZoomShortcut(
+        keyboardEvent({ code: 'Equal', key: '+', shiftKey: true })
+      )
+    ).toBe(1);
+    expect(
+      isKeyboardZoomShortcut(
+        keyboardEvent({ code: 'Minus', key: '_', shiftKey: true })
+      )
+    ).toBe(-1);
+  });
+
+  it('ignores keyboard zoom shortcuts for text entry and modified events', () => {
+    const input = document.createElement('input');
+    document.body.append(input);
+    input.focus();
+
+    expect(
+      isKeyboardZoomShortcut(
+        keyboardEvent({
+          code: 'Equal',
+          key: '+',
+          shiftKey: true,
+          ctrlKey: true,
+        })
+      )
+    ).toBeNull();
+
+    const textEntryEvent = keyboardEvent({
+      code: 'Equal',
+      key: '+',
+      shiftKey: true,
+    });
+    input.dispatchEvent(textEntryEvent);
+    expect(isKeyboardZoomShortcut(textEntryEvent)).toBeNull();
+
+    const prevented = keyboardEvent({
+      code: 'Equal',
+      key: '+',
+      shiftKey: true,
+    });
+    prevented.preventDefault();
+    expect(isKeyboardZoomShortcut(prevented)).toBeNull();
+  });
+
+  it('applies predictable keyboard zoom steps and clamps at bounds', () => {
+    const zoomedIn = applyCameraZoomStep({
+      currentTarget: 4,
+      direction: 1,
+      source: 'keyboard',
+      minZoom: bounds.minZoom,
+      maxZoom: bounds.maxZoom,
+    });
+    expect(zoomedIn).toBeGreaterThan(4);
+
+    const zoomedOut = applyCameraZoomStep({
+      currentTarget: zoomedIn,
+      direction: -1,
+      source: 'keyboard',
+      minZoom: bounds.minZoom,
+      maxZoom: bounds.maxZoom,
+    });
+    expect(zoomedOut).toBeCloseTo(4, 6);
+
+    expect(
+      applyCameraZoomStep({
+        currentTarget: 100,
+        direction: 1,
+        source: 'keyboard',
+        minZoom: bounds.minZoom,
+        maxZoom: bounds.maxZoom,
+      })
+    ).toBe(bounds.maxZoom);
+    expect(
+      applyCameraZoomStep({
+        currentTarget: 0.1,
+        direction: -1,
+        source: 'keyboard',
+        minZoom: bounds.minZoom,
+        maxZoom: bounds.maxZoom,
+      })
+    ).toBe(bounds.minZoom);
+  });
+
+  it('normalizes wheel delta modes and speeds high-resolution trackpad deltas', () => {
+    expect(normalizeWheelDeltaY(3, 1)).toBe(48);
+    expect(normalizeWheelDeltaY(1, 2)).toBe(800);
+
+    const previousAdditiveTarget = 4 - 40 * 0.0018;
+    const nextTarget = applyWheelCameraZoom({
+      currentTarget: 4,
+      deltaY: 40,
+      deltaMode: 0,
+      minZoom: bounds.minZoom,
+      maxZoom: bounds.maxZoom,
+    });
+
+    expect(nextTarget).toBeLessThan(previousAdditiveTarget);
+    expect(nextTarget).toBeGreaterThan(bounds.minZoom);
+  });
+
+  it('keeps wheel zoom bounded for large mouse-wheel deltas', () => {
+    expect(
+      applyWheelCameraZoom({
+        currentTarget: 4,
+        deltaY: 10_000,
+        deltaMode: 0,
+        minZoom: bounds.minZoom,
+        maxZoom: bounds.maxZoom,
+      })
+    ).toBe(bounds.minZoom);
+    expect(
+      applyWheelCameraZoom({
+        currentTarget: 4,
+        deltaY: -10_000,
+        deltaMode: 0,
+        minZoom: bounds.minZoom,
+        maxZoom: bounds.maxZoom,
+      })
+    ).toBe(bounds.maxZoom);
+  });
+
+  it('preserves multiplicative pinch-style scaling through clamped targets', () => {
+    expect(
+      applyCameraZoomStep({
+        currentTarget: 4,
+        direction: 1,
+        source: 'pinch',
+        magnitude: Math.log(1.5),
+        minZoom: bounds.minZoom,
+        maxZoom: bounds.maxZoom,
+      })
+    ).toBeCloseTo(6, 6);
+    expect(
+      applyCameraZoomStep({
+        currentTarget: 10,
+        direction: 1,
+        source: 'pinch',
+        magnitude: Math.log(2),
+        minZoom: bounds.minZoom,
+        maxZoom: bounds.maxZoom,
+      })
+    ).toBe(bounds.maxZoom);
+  });
+});

--- a/src/systems/controls/zoomControls.ts
+++ b/src/systems/controls/zoomControls.ts
@@ -1,0 +1,143 @@
+export type CameraZoomDirection = 1 | -1;
+
+export type CameraZoomSource = 'keyboard' | 'wheel' | 'pinch';
+
+export interface CameraZoomBounds {
+  minZoom: number;
+  maxZoom: number;
+}
+
+export interface CameraZoomStepOptions extends CameraZoomBounds {
+  currentTarget: number;
+  direction: CameraZoomDirection;
+  source: CameraZoomSource;
+  magnitude?: number;
+}
+
+export interface WheelZoomDeltaOptions extends CameraZoomBounds {
+  currentTarget: number;
+  deltaY: number;
+  deltaMode: number;
+}
+
+export const CAMERA_ZOOM_KEYBOARD_STEP = 0.12;
+const DOM_DELTA_PIXEL = 0;
+const DOM_DELTA_LINE = 1;
+const DOM_DELTA_PAGE = 2;
+const WHEEL_LINE_HEIGHT_PX = 16;
+const WHEEL_PAGE_HEIGHT_PX = 800;
+const WHEEL_TRACKPAD_SENSITIVITY = 0.0045;
+const WHEEL_MOUSE_SENSITIVITY = 0.0026;
+const WHEEL_DELTA_CLAMP_PX = 900;
+const MOUSE_WHEEL_DELTA_THRESHOLD_PX = 80;
+
+export function clampCameraZoom(
+  next: number,
+  { minZoom, maxZoom }: CameraZoomBounds
+): number {
+  const fallback = Number.isFinite(minZoom) ? minZoom : 1;
+  return Math.min(
+    Math.max(Number.isFinite(next) ? next : fallback, minZoom),
+    maxZoom
+  );
+}
+
+export function applyCameraZoomStep({
+  currentTarget,
+  direction,
+  source,
+  magnitude = 1,
+  minZoom,
+  maxZoom,
+}: CameraZoomStepOptions): number {
+  const safeMagnitude = Number.isFinite(magnitude) ? Math.max(0, magnitude) : 0;
+  if (safeMagnitude === 0) {
+    return clampCameraZoom(currentTarget, { minZoom, maxZoom });
+  }
+
+  const baseStep = source === 'keyboard' ? CAMERA_ZOOM_KEYBOARD_STEP : 1;
+  const scale = Math.exp(direction * baseStep * safeMagnitude);
+  return clampCameraZoom(currentTarget * scale, { minZoom, maxZoom });
+}
+
+export function normalizeWheelDeltaY(
+  deltaY: number,
+  deltaMode: number
+): number {
+  if (!Number.isFinite(deltaY)) {
+    return 0;
+  }
+  switch (deltaMode) {
+    case DOM_DELTA_LINE:
+      return deltaY * WHEEL_LINE_HEIGHT_PX;
+    case DOM_DELTA_PAGE:
+      return deltaY * WHEEL_PAGE_HEIGHT_PX;
+    case DOM_DELTA_PIXEL:
+    default:
+      return deltaY;
+  }
+}
+
+export function applyWheelCameraZoom({
+  currentTarget,
+  deltaY,
+  deltaMode,
+  minZoom,
+  maxZoom,
+}: WheelZoomDeltaOptions): number {
+  const normalizedDeltaY = normalizeWheelDeltaY(deltaY, deltaMode);
+  const clampedDeltaY = Math.max(
+    -WHEEL_DELTA_CLAMP_PX,
+    Math.min(WHEEL_DELTA_CLAMP_PX, normalizedDeltaY)
+  );
+  const sensitivity =
+    Math.abs(clampedDeltaY) >= MOUSE_WHEEL_DELTA_THRESHOLD_PX
+      ? WHEEL_MOUSE_SENSITIVITY
+      : WHEEL_TRACKPAD_SENSITIVITY;
+  return applyCameraZoomStep({
+    currentTarget,
+    direction: clampedDeltaY <= 0 ? 1 : -1,
+    source: 'wheel',
+    magnitude: Math.abs(clampedDeltaY) * sensitivity,
+    minZoom,
+    maxZoom,
+  });
+}
+
+export function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return (
+    target.isContentEditable ||
+    target.hasAttribute('contenteditable') ||
+    target.closest('[contenteditable]') !== null ||
+    tagName === 'input' ||
+    tagName === 'textarea' ||
+    tagName === 'select'
+  );
+}
+
+export function isKeyboardZoomShortcut(
+  event: KeyboardEvent
+): CameraZoomDirection | null {
+  if (
+    event.defaultPrevented ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey ||
+    !event.shiftKey ||
+    isTextEntryTarget(event.target)
+  ) {
+    return null;
+  }
+
+  if (event.code === 'Equal') {
+    return 1;
+  }
+  if (event.code === 'Minus') {
+    return -1;
+  }
+  return null;
+}

--- a/src/tests/helpModal.test.ts
+++ b/src/tests/helpModal.test.ts
@@ -64,6 +64,20 @@ describe('createHelpModal', () => {
     expect(document.activeElement).toBe(focusAnchor);
   });
 
+  it('documents keyboard zoom shortcuts in the movement section', () => {
+    const handle = createHelpModal({
+      container: document.body,
+      content: cloneContent(),
+    });
+
+    handle.open();
+
+    const labels = Array.from(
+      document.querySelectorAll('.help-modal__item-label')
+    ).map((label) => label.textContent);
+    expect(labels).toContain('Shift + + / Shift + -');
+  });
+
   it('supports custom headings and sections', () => {
     const handle = createHelpModal({
       container: document.body,

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -260,6 +260,21 @@ describe('i18n utilities', () => {
     expect(japaneseHelp.announcements.close).toBe(
       'ヘルプメニューを閉じました。'
     );
+
+    for (const locale of [
+      'en',
+      'en-x-pseudo',
+      'ar',
+      'ja',
+      'zh-Hans',
+    ] as const) {
+      const movementItems = getHelpModalStrings(locale).sections.find(
+        (section) => section.id === 'movement'
+      )?.items;
+      expect(
+        movementItems?.some((item) => item.label.includes('Shift + +'))
+      ).toBe(true);
+    }
   });
 
   it('returns localized POI overlay chrome strings', () => {

--- a/src/tests/keyBindings.test.ts
+++ b/src/tests/keyBindings.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { isKeyboardZoomShortcut } from '../systems/controls/zoomControls';
+
+describe('immersive keyboard zoom shortcuts', () => {
+  it('uses dedicated Shift+Equal and Shift+Minus shortcuts for zooming', () => {
+    expect(
+      isKeyboardZoomShortcut(
+        new KeyboardEvent('keydown', {
+          code: 'Equal',
+          key: '+',
+          shiftKey: true,
+        })
+      )
+    ).toBe(1);
+    expect(
+      isKeyboardZoomShortcut(
+        new KeyboardEvent('keydown', {
+          code: 'Minus',
+          key: '_',
+          shiftKey: true,
+        })
+      )
+    ).toBe(-1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide keyboard zoom for users without a mouse wheel and make MacBook trackpad/wheel zoom feel more responsive while preserving mobile pinch behavior.

### Description
- Add a shared `src/systems/controls/zoomControls.ts` implementing bounded multiplicative zoom steps, `deltaMode` normalization, trackpad vs mouse sensitivity, clamping, and `isKeyboardZoomShortcut` that checks `event.code` for `Equal`/`Minus` and ignores modified/text-entry events.
- Wire keyboard zoom into the immersive scene via a non-remappable handler (`handleKeyboardZoomKeydown`) and replace the additive wheel path with the normalized multiplicative wheel helper while keeping the touch/pinch distance-ratio path unchanged (`src/main.ts`).
- Update Help/Controls copy across locales to document `Shift + + / Shift + -` and add a help modal expectation, and add unit and integration tests covering keyboard shortcuts, wheel normalization, and help copy localization (`src/systems/controls/zoomControls.test.ts`, `src/tests/keyBindings.test.ts`, updates to `src/tests/helpModal.test.ts` and `src/tests/i18n.test.ts`).
- Add a Playwright smoke test for keyboard zoom in `playwright/immersive-zoom.spec.ts` to exercise the new shortcut end-to-end.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully (lint reported one import-order warning originally and was fixed). 
- Type checking with `npm run typecheck` reported failures due to pre-existing, unrelated repository-wide TypeScript issues (status: FAIL; unrelated to these changes). 
- Focused unit tests with `npm run test:ci -- src/tests/keyBindings.test.ts src/tests/controlOverlayAccessibility.test.ts src/tests/i18n.test.ts src/systems/controls/zoomControls.test.ts src/tests/helpModal.test.ts` passed (status: PASS). 
- Full test-suite with `npm run test:ci` completed successfully (status: PASS). 
- Built the site with `npm run build` and ran smoke checks `npm run docs:check` and `npm run smoke`, all passed (status: PASS). 
- Playwright E2E: initial run failed because Playwright browsers were not installed; after running `npx playwright install chromium` and `npx playwright install-deps chromium`, `npm run test:e2e -- playwright/immersive-zoom.spec.ts playwright/small-screen-hud.spec.ts` passed (status: PASS).

Notes: `tsc --noEmit` still surfaces unrelated baseline type errors in the repo; those are outside the scope of this change and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ebdef1ac832fa5c6157b7a41df8c)