### PR TITLE
Add keyboard zoom shortcuts and tune trackpad/wheel zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,8 +448,16 @@
             data-input-methods="pointer"
             data-control-item="pointerZoom"
           >
-            <span class="overlay__keys">Scroll wheel</span>
+            <span class="overlay__keys">Scroll wheel / trackpad</span>
             <span class="overlay__description">Zoom</span>
+          </li>
+          <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="keyboardZoom"
+          >
+            <span class="overlay__keys">Shift + = / Shift + -</span>
+            <span class="overlay__description">Keyboard zoom</span>
           </li>
           <li
             class="overlay__item overlay__item--touch"

--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -199,6 +199,41 @@ test.describe('immersive orthographic zoom', () => {
     await expect(page.locator('[data-role="hud-menu"]')).toBeVisible();
   });
 
+  test('zooms with Shift plus keyboard shortcuts while ignoring text entry targets', async ({
+    page,
+  }) => {
+    await waitForImmersive(page);
+
+    const initial = await getCameraZoomState(page);
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Minus');
+    await page.keyboard.up('Shift');
+
+    const zoomedOut = await getCameraZoomState(page);
+    expect(zoomedOut.target).toBeLessThan(initial.target);
+
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Equal');
+    await page.keyboard.up('Shift');
+
+    const zoomedIn = await getCameraZoomState(page);
+    expect(zoomedIn.target).toBeGreaterThan(zoomedOut.target);
+
+    await page.evaluate(() => {
+      const input = document.createElement('input');
+      input.id = 'zoom-shortcut-input';
+      document.body.appendChild(input);
+      input.focus();
+    });
+    const beforeTextEntry = await getCameraZoomState(page);
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Equal');
+    await page.keyboard.up('Shift');
+
+    const afterTextEntry = await getCameraZoomState(page);
+    expect(afterTextEntry.target).toBeCloseTo(beforeTextEntry.target, 6);
+  });
+
   test('keeps a single clean immersive canvas while zooming with motion blur disabled', async ({
     page,
   }) => {

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -335,7 +335,14 @@ export const AR_OVERRIDES: LocaleOverrides = {
               label: 'سحب الفأرة',
               description: 'قم بتدوير الكاميرا متساوية القياس.',
             },
-            { label: 'عجلة التمرير', description: 'اضبط مستوى التكبير.' },
+            {
+              label: 'عجلة التمرير / لوحة التتبع',
+              description: 'اضبط مستوى التكبير.',
+            },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'كبّر أو صغّر باستخدام لوحة المفاتيح.',
+            },
             {
               label: 'عصا اللمس',
               description: 'اسحب اليسار للحركة واليمين للدوران.',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -178,6 +178,40 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
   hud: {
     controlOverlay: {
       heading: wrap('Controls'),
+      items: {
+        keyboardMove: {
+          keys: 'WASD / Arrow keys',
+          description: wrap('Move'),
+        },
+        pointerDrag: {
+          keys: wrap('Left mouse button'),
+          description: wrap('Drag to pan'),
+        },
+        pointerZoom: {
+          keys: wrap('Scroll wheel / trackpad'),
+          description: wrap('Zoom'),
+        },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: wrap('Keyboard zoom'),
+        },
+        touchDrag: {
+          keys: wrap('Touch'),
+          description: wrap('Left pad to move · right pad to pan'),
+        },
+        touchPinch: {
+          keys: wrap('Pinch'),
+          description: wrap('Zoom'),
+        },
+        cyclePoi: {
+          keys: 'Q / E',
+          description: wrap('Cycle POIs'),
+        },
+        toggleTextMode: {
+          keys: 'T',
+          description: wrap('Switch to text mode'),
+        },
+      },
       interact: {
         defaultLabel: wrap('Enter'),
         description: wrap('Interact'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -176,8 +176,12 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           description: 'Drag to pan',
         },
         pointerZoom: {
-          keys: 'Scroll wheel',
+          keys: 'Scroll wheel / trackpad',
           description: 'Zoom',
+        },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: 'Keyboard zoom',
         },
         touchDrag: {
           keys: 'Touch',
@@ -454,7 +458,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
               description: 'Roll the explorer around the home.',
             },
             { label: 'Mouse drag', description: 'Pan the isometric camera.' },
-            { label: 'Scroll wheel', description: 'Adjust zoom level.' },
+            {
+              label: 'Scroll wheel / trackpad',
+              description: 'Adjust zoom level.',
+            },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'Zoom in or out from the keyboard.',
+            },
             {
               label: 'Touch joysticks',
               description:

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -171,8 +171,12 @@ export const JA_OVERRIDES: LocaleOverrides = {
           description: 'ドラッグして視点移動',
         },
         pointerZoom: {
-          keys: 'ホイール',
+          keys: 'ホイール / トラックパッド',
           description: 'ズーム',
+        },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: 'キーボードでズーム',
         },
         touchDrag: {
           keys: 'タッチ',
@@ -337,7 +341,14 @@ export const JA_OVERRIDES: LocaleOverrides = {
               label: 'マウスドラッグ',
               description: 'アイソメ視点をパンします。',
             },
-            { label: 'ホイール', description: 'ズームレベルを調整します。' },
+            {
+              label: 'ホイール / トラックパッド',
+              description: 'ズームレベルを調整します。',
+            },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'キーボードでズームインまたはズームアウトします。',
+            },
             {
               label: 'タッチジョイスティック',
               description: '左パッドで移動し、右パッドで視点をパンします。',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -446,7 +446,11 @@ export function buildLatinLocaleOverrides(
           pointerDrag: {
             description: templates.pointerDrag,
           },
-          pointerZoom: { description: 'Zoom' },
+          pointerZoom: { keys: 'Scroll / trackpad', description: 'Zoom' },
+          keyboardZoom: {
+            keys: 'Shift + = / Shift + -',
+            description: 'Keyboard zoom',
+          },
           touchDrag: {
             description: templates.touchDrag,
           },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -143,7 +143,11 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       items: {
         keyboardMove: { keys: 'WASD / 方向键', description: '移动' },
         pointerDrag: { keys: '鼠标左键', description: '拖动平移' },
-        pointerZoom: { keys: '滚轮', description: '缩放' },
+        pointerZoom: { keys: '滚轮 / 触控板', description: '缩放' },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: '键盘缩放',
+        },
         touchDrag: {
           keys: '触控',
           description: '左半屏拖动移动，右半屏拖动平移',
@@ -364,7 +368,11 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
           items: [
             { label: 'WASD / 方向键', description: '在家中移动探索者。' },
             { label: '鼠标拖动', description: '平移等距相机。' },
-            { label: '滚轮', description: '调整缩放级别。' },
+            { label: '滚轮 / 触控板', description: '调整缩放级别。' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: '用键盘放大或缩小。',
+            },
             { label: '触控摇杆', description: '拖动左垫移动，拖动右垫平移。' },
             { label: '捏合', description: '在触控设备上缩放。' },
           ],

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -38,6 +38,7 @@ export interface ControlOverlayStrings {
     keyboardMove: ControlOverlayItemStrings;
     pointerDrag: ControlOverlayItemStrings;
     pointerZoom: ControlOverlayItemStrings;
+    keyboardZoom: ControlOverlayItemStrings;
     touchDrag: ControlOverlayItemStrings;
     touchPinch: ControlOverlayItemStrings;
     cyclePoi: ControlOverlayItemStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,6 +108,13 @@ import {
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
 import {
+  applyCameraPinchZoom,
+  applyCameraWheelZoom,
+  applyCameraZoomStep,
+  clampCameraZoomTarget,
+  type CameraZoomSource,
+} from './scene/camera/zoomControls';
+import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
@@ -533,7 +540,6 @@ const CAMERA_ZOOM_SMOOTHING = 6;
 const CAMERA_MARGIN = 1.1;
 const MIN_CAMERA_ZOOM = 0.65;
 const MAX_CAMERA_ZOOM = 12;
-const CAMERA_ZOOM_WHEEL_SENSITIVITY = 0.0018;
 const MANNEQUIN_YAW_SMOOTHING = 8;
 const CEILING_COVE_OFFSET = 0.35;
 const BACKYARD_ROOM_ID = 'backyard';
@@ -2563,6 +2569,8 @@ function initializeImmersiveScene(
     'interact',
     'help',
     'toggleControls',
+    'zoomIn',
+    'zoomOut',
   ];
   const bindingActionSet = new Set<KeyBindingAction>(bindingActions);
 
@@ -3316,8 +3324,25 @@ function initializeImmersiveScene(
   updatePlayerVerticalPosition();
   document.documentElement.dataset.activeFloor = activeFloorId;
 
+  const cameraZoomBounds = {
+    minZoom: MIN_CAMERA_ZOOM,
+    maxZoom: MAX_CAMERA_ZOOM,
+  };
+
   const setCameraZoomTarget = (next: number) => {
-    cameraZoomTarget = MathUtils.clamp(next, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM);
+    cameraZoomTarget = clampCameraZoomTarget(next, cameraZoomBounds);
+  };
+
+  const applyCameraZoomStepTarget = (
+    direction: 1 | -1,
+    source: CameraZoomSource
+  ) => {
+    void source;
+    cameraZoomTarget = applyCameraZoomStep(
+      cameraZoomTarget,
+      direction,
+      cameraZoomBounds
+    );
   };
 
   const updateCameraPanLimits = (aspect: number) => {
@@ -3371,9 +3396,34 @@ function initializeImmersiveScene(
 
   const handleWheelZoom = (event: WheelEvent) => {
     event.preventDefault();
-    setCameraZoomTarget(
-      cameraZoomTarget - event.deltaY * CAMERA_ZOOM_WHEEL_SENSITIVITY
+    cameraZoomTarget = applyCameraWheelZoom(
+      cameraZoomTarget,
+      event,
+      cameraZoomBounds
     );
+  };
+
+  const handleKeyboardZoom = (event: KeyboardEvent) => {
+    if (
+      event.defaultPrevented ||
+      !event.shiftKey ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      isTextEntryTarget(event.target)
+    ) {
+      return;
+    }
+
+    const direction =
+      event.code === 'Equal' ? 1 : event.code === 'Minus' ? -1 : 0;
+    if (direction === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    idleMonitor?.reportActivity();
+    applyCameraZoomStepTarget(direction, 'keyboard');
   };
 
   const handlePointerDownForZoom = (event: PointerEvent) => {
@@ -3416,11 +3466,14 @@ function initializeImmersiveScene(
       pinchStartZoomTarget = cameraZoomTarget;
       return;
     }
-    const scale = distance / pinchStartDistance;
-    if (!isFinite(scale) || scale <= 0) {
-      return;
-    }
-    setCameraZoomTarget(pinchStartZoomTarget * scale);
+    setCameraZoomTarget(
+      applyCameraPinchZoom(
+        pinchStartZoomTarget,
+        pinchStartDistance,
+        distance,
+        cameraZoomBounds
+      )
+    );
   };
 
   const handlePointerEndForZoom = (event: PointerEvent) => {
@@ -3499,6 +3552,7 @@ function initializeImmersiveScene(
   renderer.domElement.addEventListener('wheel', handleWheelZoom, {
     passive: false,
   });
+  window.addEventListener('keydown', handleKeyboardZoom);
   renderer.domElement.addEventListener('pointerdown', handlePointerDownForZoom);
   renderer.domElement.addEventListener(
     'pointerdown',
@@ -4619,6 +4673,7 @@ function initializeImmersiveScene(
       footstepAudioController = null;
     }
     renderer.domElement.removeEventListener('wheel', handleWheelZoom);
+    window.removeEventListener('keydown', handleKeyboardZoom);
     renderer.domElement.removeEventListener(
       'pointerdown',
       handlePointerDownForZoom

--- a/src/scene/camera/zoomControls.test.ts
+++ b/src/scene/camera/zoomControls.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyCameraPinchZoom,
+  applyCameraWheelZoom,
+  applyCameraZoomStep,
+  WHEEL_DELTA_LINE,
+  WHEEL_DELTA_PAGE,
+  WHEEL_DELTA_PIXEL,
+  normalizeWheelDeltaY,
+} from './zoomControls';
+
+const bounds = { minZoom: 0.65, maxZoom: 12 };
+
+describe('camera zoom controls', () => {
+  it('steps keyboard zoom multiplicatively and clamps to camera bounds', () => {
+    expect(applyCameraZoomStep(4, 1, bounds)).toBeCloseTo(4.48, 6);
+    expect(applyCameraZoomStep(4, -1, bounds)).toBeCloseTo(4 / 1.12, 6);
+    expect(applyCameraZoomStep(11.9, 1, bounds)).toBe(12);
+    expect(applyCameraZoomStep(0.66, -1, bounds)).toBe(0.65);
+  });
+
+  it('normalizes wheel delta modes before applying exponential zoom', () => {
+    expect(
+      normalizeWheelDeltaY({ deltaY: 3, deltaMode: WHEEL_DELTA_LINE })
+    ).toBe(48);
+    expect(
+      normalizeWheelDeltaY({ deltaY: 1, deltaMode: WHEEL_DELTA_PAGE })
+    ).toBe(800);
+    expect(
+      normalizeWheelDeltaY({
+        deltaY: 24,
+        deltaMode: WHEEL_DELTA_PIXEL,
+      })
+    ).toBe(24);
+
+    const lineModeTarget = applyCameraWheelZoom(
+      4,
+      { deltaY: -3, deltaMode: WHEEL_DELTA_LINE },
+      bounds
+    );
+    expect(lineModeTarget).toBeGreaterThan(4);
+  });
+
+  it('makes high-resolution trackpad deltas materially more responsive than old additive zoom', () => {
+    const previousAdditiveTarget = 4 - -10 * 0.0018;
+    const nextTarget = applyCameraWheelZoom(
+      4,
+      { deltaY: -10, deltaMode: WHEEL_DELTA_PIXEL },
+      bounds
+    );
+
+    expect(nextTarget - 4).toBeGreaterThan((previousAdditiveTarget - 4) * 3);
+    expect(nextTarget).toBeLessThan(4.25);
+  });
+
+  it('keeps large mouse-wheel deltas controlled and bounded', () => {
+    const nextTarget = applyCameraWheelZoom(
+      4,
+      { deltaY: -120, deltaMode: WHEEL_DELTA_PIXEL },
+      bounds
+    );
+
+    expect(nextTarget).toBeGreaterThan(4);
+    expect(nextTarget).toBeLessThan(5);
+    expect(applyCameraWheelZoom(11, { deltaY: -10_000 }, bounds)).toBe(12);
+    expect(applyCameraWheelZoom(1, { deltaY: 10_000 }, bounds)).toBe(0.65);
+  });
+
+  it('keeps touch pinch multiplicative and bounded by min/max zoom', () => {
+    expect(applyCameraPinchZoom(3, 100, 150, bounds)).toBeCloseTo(4.5, 6);
+    expect(applyCameraPinchZoom(3, 100, 50, bounds)).toBeCloseTo(1.5, 6);
+    expect(applyCameraPinchZoom(10, 100, 300, bounds)).toBe(12);
+    expect(applyCameraPinchZoom(1, 100, 10, bounds)).toBe(0.65);
+  });
+});

--- a/src/scene/camera/zoomControls.ts
+++ b/src/scene/camera/zoomControls.ts
@@ -1,0 +1,98 @@
+import { MathUtils } from 'three';
+
+export const CAMERA_ZOOM_KEYBOARD_STEP = 0.12;
+export const CAMERA_ZOOM_WHEEL_PIXEL_SENSITIVITY = 0.00125;
+export const CAMERA_ZOOM_TRACKPAD_MULTIPLIER = 3.5;
+export const CAMERA_ZOOM_LINE_HEIGHT_PX = 16;
+export const CAMERA_ZOOM_PAGE_HEIGHT_PX = 800;
+export const WHEEL_DELTA_PIXEL = 0;
+export const WHEEL_DELTA_LINE = 1;
+export const WHEEL_DELTA_PAGE = 2;
+
+export type CameraZoomStepDirection = 1 | -1;
+export type CameraZoomSource = 'keyboard' | 'wheel' | 'pinch';
+
+export interface CameraZoomBounds {
+  minZoom: number;
+  maxZoom: number;
+}
+
+export interface WheelZoomInput {
+  deltaY: number;
+  deltaMode?: number;
+}
+
+export function clampCameraZoomTarget(
+  next: number,
+  { minZoom, maxZoom }: CameraZoomBounds
+): number {
+  return MathUtils.clamp(next, minZoom, maxZoom);
+}
+
+export function applyCameraZoomStep(
+  currentTarget: number,
+  direction: CameraZoomStepDirection,
+  bounds: CameraZoomBounds,
+  step = CAMERA_ZOOM_KEYBOARD_STEP
+): number {
+  const factor = 1 + Math.max(0, step);
+  const next = direction > 0 ? currentTarget * factor : currentTarget / factor;
+  return clampCameraZoomTarget(next, bounds);
+}
+
+export function normalizeWheelDeltaY(event: WheelZoomInput): number {
+  if (!Number.isFinite(event.deltaY)) {
+    return 0;
+  }
+  switch (event.deltaMode) {
+    case WHEEL_DELTA_LINE:
+      return event.deltaY * CAMERA_ZOOM_LINE_HEIGHT_PX;
+    case WHEEL_DELTA_PAGE:
+      return event.deltaY * CAMERA_ZOOM_PAGE_HEIGHT_PX;
+    case WHEEL_DELTA_PIXEL:
+    default:
+      return event.deltaY;
+  }
+}
+
+function getWheelDeltaMultiplier(deltaY: number): number {
+  return Math.abs(deltaY) > 0 && Math.abs(deltaY) < 40
+    ? CAMERA_ZOOM_TRACKPAD_MULTIPLIER
+    : 1;
+}
+
+export function applyCameraWheelZoom(
+  currentTarget: number,
+  event: WheelZoomInput,
+  bounds: CameraZoomBounds
+): number {
+  const normalizedDeltaY = normalizeWheelDeltaY(event);
+  if (normalizedDeltaY === 0) {
+    return clampCameraZoomTarget(currentTarget, bounds);
+  }
+  const multiplier = getWheelDeltaMultiplier(normalizedDeltaY);
+  const exponent =
+    -normalizedDeltaY * CAMERA_ZOOM_WHEEL_PIXEL_SENSITIVITY * multiplier;
+  return clampCameraZoomTarget(currentTarget * Math.exp(exponent), bounds);
+}
+
+export function applyCameraPinchZoom(
+  pinchStartZoomTarget: number,
+  pinchStartDistance: number,
+  currentDistance: number,
+  bounds: CameraZoomBounds
+): number {
+  if (
+    !Number.isFinite(pinchStartZoomTarget) ||
+    !Number.isFinite(pinchStartDistance) ||
+    !Number.isFinite(currentDistance) ||
+    pinchStartDistance <= 0 ||
+    currentDistance <= 0
+  ) {
+    return clampCameraZoomTarget(pinchStartZoomTarget, bounds);
+  }
+  return clampCameraZoomTarget(
+    pinchStartZoomTarget * (currentDistance / pinchStartDistance),
+    bounds
+  );
+}

--- a/src/systems/controls/keyBindings.test.ts
+++ b/src/systems/controls/keyBindings.test.ts
@@ -15,10 +15,12 @@ describe('KeyBindings', () => {
     expect(bindings.getBindings('interact')).toEqual(['f', ' ']);
   });
 
-  it('surfaces multi-key defaults for the interact binding', () => {
+  it('surfaces multi-key defaults for the interact and zoom bindings', () => {
     const bindings = new KeyBindings();
 
     expect(bindings.getBindings('interact')).toEqual(['Enter', 'f', ' ']);
+    expect(bindings.getBindings('zoomIn')).toEqual(['Shift+Equal']);
+    expect(bindings.getBindings('zoomOut')).toEqual(['Shift+Minus']);
     expect(bindings.getPrimaryBinding('interact')).toBe('Enter');
 
     bindings.reset('interact');
@@ -93,6 +95,8 @@ describe('formatKeyLabel', () => {
     expect(formatKeyLabel('ArrowUp')).toBe('Arrow Up');
     expect(formatKeyLabel(' ')).toBe('Space');
     expect(formatKeyLabel('Shift')).toBe('Shift');
+    expect(formatKeyLabel('Shift+Equal')).toBe('Shift + = / +');
+    expect(formatKeyLabel('Shift+Minus')).toBe('Shift + - / _');
     expect(formatKeyLabel(undefined)).toBe('');
   });
 });

--- a/src/systems/controls/keyBindings.ts
+++ b/src/systems/controls/keyBindings.ts
@@ -7,7 +7,9 @@ export type KeyBindingAction =
   | 'moveRight'
   | 'interact'
   | 'help'
-  | 'toggleControls';
+  | 'toggleControls'
+  | 'zoomIn'
+  | 'zoomOut';
 
 export type KeyBindingConfig = Partial<
   Record<KeyBindingAction, readonly string[]>
@@ -31,6 +33,8 @@ export const DEFAULT_KEY_BINDINGS: Record<KeyBindingAction, readonly string[]> =
     interact: ['Enter', 'f', ' '],
     help: ['h', '?'],
     toggleControls: ['c'],
+    zoomIn: ['Shift+Equal'],
+    zoomOut: ['Shift+Minus'],
   };
 
 type ActionEntries = [KeyBindingAction, readonly string[]];
@@ -180,6 +184,12 @@ export function formatKeyLabel(key: string | null | undefined): string {
   }
   if (key.length === 1) {
     return key.toUpperCase();
+  }
+  if (key === 'Shift+Equal') {
+    return 'Shift + = / +';
+  }
+  if (key === 'Shift+Minus') {
+    return 'Shift + - / _';
   }
   if (key.startsWith('Arrow')) {
     const direction = key.slice('Arrow'.length);

--- a/src/tests/controlOverlay.test.ts
+++ b/src/tests/controlOverlay.test.ts
@@ -13,6 +13,10 @@ describe('applyControlOverlayStrings', () => {
           <span class="overlay__keys">Keys</span>
           <span class="overlay__description">Move</span>
         </li>
+        <li class="overlay__item" data-control-item="keyboardZoom">
+          <span class="overlay__keys">Keys</span>
+          <span class="overlay__description">Zoom</span>
+        </li>
         <li
           class="overlay__item"
           data-control-item="interact"
@@ -45,6 +49,11 @@ describe('applyControlOverlayStrings', () => {
       '[data-control-item="keyboardMove"] .overlay__keys'
     );
     expect(keyboardItem?.textContent).toBe(strings.items.keyboardMove.keys);
+
+    const keyboardZoomItem = container.querySelector(
+      '[data-control-item="keyboardZoom"] .overlay__keys'
+    );
+    expect(keyboardZoomItem?.textContent).toBe(strings.items.keyboardZoom.keys);
 
     const interactLabel = container.querySelector(
       '[data-role="interact-label"]'

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -244,6 +244,19 @@ describe('i18n utilities', () => {
     expect(pseudoOverlay.items.keyboardMove.keys).toBe(
       englishOverlay.items.keyboardMove.keys
     );
+    expect(englishOverlay.items.keyboardZoom.keys).toBe(
+      'Shift + = / Shift + -'
+    );
+    expect(pseudoOverlay.items.keyboardZoom.description).toBe(
+      '⟦Keyboard zoom⟧'
+    );
+    const englishHelp = getHelpModalStrings('en');
+    expect(
+      englishHelp.sections
+        .find((section) => section.id === 'movement')
+        ?.items.some((item) => item.label === 'Shift + = / Shift + -')
+    ).toBe(true);
+
     const helpModal = getHelpModalStrings('en-x-pseudo');
     expect(helpModal.closeLabel).toBe('⟦Close⟧');
     expect(helpModal.announcements.open).toBe(

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -13,6 +13,10 @@ const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
     keyboardMove: { keys: 'WASD / Arrow keys', description: 'Move' },
     pointerDrag: { keys: 'Left mouse button', description: 'Drag to pan' },
     pointerZoom: { keys: 'Scroll wheel', description: 'Zoom' },
+    keyboardZoom: {
+      keys: 'Shift + = / Shift + -',
+      description: 'Keyboard zoom',
+    },
     touchDrag: { keys: 'Touch', description: 'Drag to move and pan' },
     touchPinch: { keys: 'Pinch', description: 'Zoom' },
     cyclePoi: { keys: 'Q / E', description: 'Cycle POIs' },
@@ -439,5 +443,7 @@ describe('createResponsiveControlOverlay', () => {
 
   it('represents the controls popover shortcut in the key binding model', () => {
     expect(DEFAULT_KEY_BINDINGS.toggleControls).toEqual(['c']);
+    expect(DEFAULT_KEY_BINDINGS.zoomIn).toEqual(['Shift+Equal']);
+    expect(DEFAULT_KEY_BINDINGS.zoomOut).toEqual(['Shift+Minus']);
   });
 });

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -65,6 +65,7 @@ export function applyControlOverlayStrings(
   applyItem('keyboardMove');
   applyItem('pointerDrag');
   applyItem('pointerZoom');
+  applyItem('keyboardZoom');
   applyItem('touchDrag');
   applyItem('touchPinch');
   applyItem('cyclePoi');


### PR DESCRIPTION
### Motivation
- Improve zoom ergonomics for users without a mouse wheel and make MacBook trackpad/wheel zoom feel responsive while preserving existing pinch behavior on touch devices.
- Provide keyboard discoverability by documenting shortcuts in the Controls HUD and localized Settings help.

### Description
- Added a shared camera zoom helper module `src/scene/camera/zoomControls.ts` with bounded zoom steps, wheel normalization (`deltaMode`), exponential wheel scaling (trackpad multiplier), and pinch math for reuse across input sources.
- Wired wheel zoom to use `applyCameraWheelZoom(...)`, kept touch pinch multiplicative via `applyCameraPinchZoom(...)`, and added `applyCameraZoomStep(...)` for keyboard stepping; all paths clamp to `MIN_CAMERA_ZOOM` / `MAX_CAMERA_ZOOM`.
- Implemented non-remappable keyboard shortcuts using `KeyboardEvent.code` for robust layout handling: `Shift + Equal` (zoom in) and `Shift + Minus` (zoom out), ignoring events when the target is text input, modifier keys (meta/ctrl/alt) are active, or the event was defaultPrevented; held-shift repeats apply multiplicative steps.
- Integrated keyboard shortcuts into the keybinding model by adding `zoomIn`/`zoomOut` defaults and display labels, and added `applyCameraZoomStepTarget(...)` in `src/main.ts` to centralize behavior.
- Updated HUD/Help copy and i18n across locales to document the new keyboard zoom controls and added a compact keyboard entry in the Controls popover and Settings help.
- Added unit tests for zoom helpers (`src/scene/camera/zoomControls.test.ts`) and updated existing tests to cover the new labels and defaults, and added a Playwright integration test for keyboard zoom and text-entry ignoring (`playwright/immersive-zoom.spec.ts`).

### Testing
- Ran formatter: `npm run format:write` — succeeded.
- Lint: `npm run lint` — succeeded with fix applied for unused var.
- Unit tests (focused): `npm run test:ci -- src/scene/camera/zoomControls.test.ts src/systems/controls/keyBindings.test.ts src/tests/controlOverlay.test.ts src/tests/controlOverlayAccessibility.test.ts src/tests/i18n.test.ts` — all passed.
- Full unit test suite: `npm run test:ci` — all tests passed (980 tests in CI run observed passing in this rollout).
- Build: `npm run build` — succeeded and produced `dist` artifacts.
- Docs check and smoke: `npm run docs:check` and `npm run smoke` — succeeded.
- Playwright setup: `npx playwright install chromium` and `npx playwright install-deps chromium` were run as needed to install browsers/deps in the environment.
- End-to-end tests: `npm run test:e2e -- playwright/immersive-zoom.spec.ts playwright/small-screen-hud.spec.ts` — after installing Playwright browsers and host deps the E2E runs for the updated zoom flows passed (Playwright tests covering keyboard zoom and small-screen HUD passed in the final run).
- Typecheck: `npm run typecheck` — not fully green; this command surfaced unrelated existing TypeScript issues elsewhere in the repo (audio/Avatar importer/failover/test mocks); these are pre-existing and out of scope for this change.

Notes
- Branch: `codex/keyboard-zoom-shortcuts`.
- Residual risks: tuning constants (trackpad multiplier, pixel sensitivity, keyboard step) may require future user feedback to refine ergonomics across devices; behavior preserves current pinch path to avoid mobile regressions.
- Follow-ups: if more remappable shortcut UX is desired, we can expose `zoomIn`/`zoomOut` bindings in the Settings UI for user remapping in a follow-up PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ebdef1ac832fa5c6157b7a41df8c)