### PR TITLE
Add keyboard zoom shortcuts and improve trackpad/wheel zoom responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,6 +452,14 @@
             <span class="overlay__description">Zoom</span>
           </li>
           <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="keyboardZoom"
+          >
+            <span class="overlay__keys">Shift + = / Shift + -</span>
+            <span class="overlay__description">Zoom</span>
+          </li>
+          <li
             class="overlay__item overlay__item--touch"
             data-input-methods="touch"
             data-control-item="touchDrag"

--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -199,6 +199,122 @@ test.describe('immersive orthographic zoom', () => {
     await expect(page.locator('[data-role="hud-menu"]')).toBeVisible();
   });
 
+  test('zooms with keyboard shortcuts and ignores text-entry targets', async ({
+    page,
+  }) => {
+    await waitForImmersive(page);
+
+    const initial = await getCameraZoomState(page);
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          code: 'Minus',
+          key: '_',
+          shiftKey: true,
+        })
+      );
+    });
+    const zoomedOut = await getCameraZoomState(page);
+    expect(zoomedOut.target).toBeLessThan(initial.target);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          code: 'Equal',
+          key: '+',
+          shiftKey: true,
+        })
+      );
+    });
+    const zoomedIn = await getCameraZoomState(page);
+    expect(zoomedIn.target).toBeGreaterThan(zoomedOut.target);
+
+    const beforeInput = await getCameraZoomState(page);
+    const inputEventPrevented = await page.evaluate(() => {
+      const input = document.createElement('input');
+      document.body.append(input);
+      input.focus();
+      const event = new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        code: 'Equal',
+        key: '+',
+        shiftKey: true,
+      });
+      input.dispatchEvent(event);
+      input.remove();
+      return event.defaultPrevented;
+    });
+    const afterInput = await getCameraZoomState(page);
+    expect(inputEventPrevented).toBe(false);
+    expect(afterInput.target).toBeCloseTo(beforeInput.target, 6);
+  });
+
+  test('keeps touch pinch zoom multiplicative and bounded', async ({
+    page,
+  }) => {
+    await waitForImmersive(page);
+    const framing = await getInitialCameraFraming(page);
+    const initial = await getCameraZoomState(page);
+
+    await page.evaluate(() => {
+      const canvas = document.querySelector<HTMLCanvasElement>('#app canvas');
+      canvas?.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 100,
+          clientY: 100,
+          pointerId: 1,
+          pointerType: 'touch',
+        })
+      );
+      canvas?.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 200,
+          clientY: 100,
+          pointerId: 2,
+          pointerType: 'touch',
+        })
+      );
+      window.dispatchEvent(
+        new PointerEvent('pointermove', {
+          bubbles: true,
+          clientX: 300,
+          clientY: 100,
+          pointerId: 2,
+          pointerType: 'touch',
+        })
+      );
+    });
+
+    const pinched = await getCameraZoomState(page);
+    expect(pinched.target).toBeCloseTo(
+      Math.min(initial.target * 2, framing.maxZoom),
+      5
+    );
+    expect(pinched.target).toBeGreaterThanOrEqual(framing.minZoom);
+    expect(pinched.target).toBeLessThanOrEqual(framing.maxZoom);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', {
+          bubbles: true,
+          clientX: 10_000,
+          clientY: 100,
+          pointerId: 2,
+          pointerType: 'touch',
+        })
+      );
+    });
+    const clamped = await getCameraZoomState(page);
+    expect(clamped.target).toBe(framing.maxZoom);
+  });
+
   test('keeps a single clean immersive canvas while zooming with motion blur disabled', async ({
     page,
   }) => {

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -337,6 +337,10 @@ export const AR_OVERRIDES: LocaleOverrides = {
             },
             { label: 'عجلة التمرير', description: 'اضبط مستوى التكبير.' },
             {
+              label: 'Shift + = / Shift + -',
+              description: 'كبّر أو صغّر دون عجلة فأرة.',
+            },
+            {
               label: 'عصا اللمس',
               description: 'اسحب اليسار للحركة واليمين للدوران.',
             },

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -179,6 +179,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           keys: 'Scroll wheel',
           description: 'Zoom',
         },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: 'Zoom',
+        },
         touchDrag: {
           keys: 'Touch',
           description: 'Drag the left half to move and the right half to pan',
@@ -455,6 +459,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             },
             { label: 'Mouse drag', description: 'Pan the isometric camera.' },
             { label: 'Scroll wheel', description: 'Adjust zoom level.' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'Zoom in or out without a mouse wheel.',
+            },
             {
               label: 'Touch joysticks',
               description:

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -174,6 +174,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
           keys: 'ホイール',
           description: 'ズーム',
         },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: 'ズーム',
+        },
         touchDrag: {
           keys: 'タッチ',
           description: '左側で移動・右側で視点をドラッグ',
@@ -338,6 +342,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
               description: 'アイソメ視点をパンします。',
             },
             { label: 'ホイール', description: 'ズームレベルを調整します。' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'マウスホイールなしでズームします。',
+            },
             {
               label: 'タッチジョイスティック',
               description: '左パッドで移動し、右パッドで視点をパンします。',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -67,6 +67,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: string;
     keyboardMove: string;
     pointerDrag: string;
+    keyboardZoom: string;
     touchDrag: string;
     cyclePoi: string;
     interactDefault: string;
@@ -111,6 +112,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: 'Exhibiciones de {roomName}',
     keyboardMove: 'Mover',
     pointerDrag: 'Arrastrar para panorámica',
+    keyboardZoom: 'Zoom',
     touchDrag:
       'Arrastra a la izquierda para mover y a la derecha para panorámica',
     cyclePoi: 'Recorrer POI',
@@ -159,6 +161,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: 'Exibições de {roomName}',
     keyboardMove: 'Mover',
     pointerDrag: 'Arrastar para panorâmica',
+    keyboardZoom: 'Zoom',
     touchDrag: 'Arraste à esquerda para mover e à direita para panorâmica',
     cyclePoi: 'Percorrer POIs',
     interactDefault: 'Entrar',
@@ -207,6 +210,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: '{roomName}-Exponate',
     keyboardMove: 'Bewegen',
     pointerDrag: 'Ziehen zum Schwenken',
+    keyboardZoom: 'Zoom',
     touchDrag: 'Links bewegen, rechts schwenken',
     cyclePoi: 'POIs wechseln',
     interactDefault: 'Öffnen',
@@ -254,6 +258,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: '{roomName} kiállításai',
     keyboardMove: 'Mozgás',
     pointerDrag: 'Húzás a pásztázáshoz',
+    keyboardZoom: 'Nagyítás',
     touchDrag: 'Bal oldalon mozgás, jobb oldalon pásztázás',
     cyclePoi: 'POI-k váltása',
     interactDefault: 'Megnyitás',
@@ -447,6 +452,7 @@ export function buildLatinLocaleOverrides(
             description: templates.pointerDrag,
           },
           pointerZoom: { description: 'Zoom' },
+          keyboardZoom: { description: templates.keyboardZoom },
           touchDrag: {
             description: templates.touchDrag,
           },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -144,6 +144,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         keyboardMove: { keys: 'WASD / 方向键', description: '移动' },
         pointerDrag: { keys: '鼠标左键', description: '拖动平移' },
         pointerZoom: { keys: '滚轮', description: '缩放' },
+        keyboardZoom: { keys: 'Shift + = / Shift + -', description: '缩放' },
         touchDrag: {
           keys: '触控',
           description: '左半屏拖动移动，右半屏拖动平移',
@@ -365,6 +366,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             { label: 'WASD / 方向键', description: '在家中移动探索者。' },
             { label: '鼠标拖动', description: '平移等距相机。' },
             { label: '滚轮', description: '调整缩放级别。' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: '无需鼠标滚轮即可放大或缩小。',
+            },
             { label: '触控摇杆', description: '拖动左垫移动，拖动右垫平移。' },
             { label: '捏合', description: '在触控设备上缩放。' },
           ],

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -38,6 +38,7 @@ export interface ControlOverlayStrings {
     keyboardMove: ControlOverlayItemStrings;
     pointerDrag: ControlOverlayItemStrings;
     pointerZoom: ControlOverlayItemStrings;
+    keyboardZoom: ControlOverlayItemStrings;
     touchDrag: ControlOverlayItemStrings;
     touchPinch: ControlOverlayItemStrings;
     cyclePoi: ControlOverlayItemStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -318,6 +318,11 @@ import {
 } from './systems/controls/tourResetControl';
 import { VirtualJoystick } from './systems/controls/VirtualJoystick';
 import {
+  applyCameraZoomStep,
+  computeWheelZoomTarget,
+  isKeyboardZoomShortcut,
+} from './systems/controls/zoomControls';
+import {
   evaluateFailoverDecision,
   renderTextFallback,
   type FallbackReason,
@@ -533,7 +538,6 @@ const CAMERA_ZOOM_SMOOTHING = 6;
 const CAMERA_MARGIN = 1.1;
 const MIN_CAMERA_ZOOM = 0.65;
 const MAX_CAMERA_ZOOM = 12;
-const CAMERA_ZOOM_WHEEL_SENSITIVITY = 0.0018;
 const MANNEQUIN_YAW_SMOOTHING = 8;
 const CEILING_COVE_OFFSET = 0.35;
 const BACKYARD_ROOM_ID = 'backyard';
@@ -3320,6 +3324,17 @@ function initializeImmersiveScene(
     cameraZoomTarget = MathUtils.clamp(next, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM);
   };
 
+  const zoomCameraByStep = (direction: 'in' | 'out') => {
+    setCameraZoomTarget(
+      applyCameraZoomStep(
+        cameraZoomTarget,
+        direction,
+        MIN_CAMERA_ZOOM,
+        MAX_CAMERA_ZOOM
+      )
+    );
+  };
+
   const updateCameraPanLimits = (aspect: number) => {
     const effectiveHalfWidth = (baseCameraSize * aspect) / cameraZoom;
     const effectiveHalfHeight = baseCameraSize / cameraZoom;
@@ -3372,8 +3387,25 @@ function initializeImmersiveScene(
   const handleWheelZoom = (event: WheelEvent) => {
     event.preventDefault();
     setCameraZoomTarget(
-      cameraZoomTarget - event.deltaY * CAMERA_ZOOM_WHEEL_SENSITIVITY
+      computeWheelZoomTarget(
+        cameraZoomTarget,
+        event,
+        MIN_CAMERA_ZOOM,
+        MAX_CAMERA_ZOOM
+      )
     );
+  };
+
+  const handleKeyboardZoom = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || isTextEntryTarget(event.target)) {
+      return;
+    }
+    const direction = isKeyboardZoomShortcut(event);
+    if (!direction) {
+      return;
+    }
+    event.preventDefault();
+    zoomCameraByStep(direction);
   };
 
   const handlePointerDownForZoom = (event: PointerEvent) => {
@@ -3499,6 +3531,7 @@ function initializeImmersiveScene(
   renderer.domElement.addEventListener('wheel', handleWheelZoom, {
     passive: false,
   });
+  window.addEventListener('keydown', handleKeyboardZoom);
   renderer.domElement.addEventListener('pointerdown', handlePointerDownForZoom);
   renderer.domElement.addEventListener(
     'pointerdown',
@@ -4619,6 +4652,7 @@ function initializeImmersiveScene(
       footstepAudioController = null;
     }
     renderer.domElement.removeEventListener('wheel', handleWheelZoom);
+    window.removeEventListener('keydown', handleKeyboardZoom);
     renderer.domElement.removeEventListener(
       'pointerdown',
       handlePointerDownForZoom

--- a/src/systems/controls/zoomControls.test.ts
+++ b/src/systems/controls/zoomControls.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyCameraZoomStep,
+  computeWheelZoomTarget,
+  isKeyboardZoomShortcut,
+  normalizeWheelDeltaY,
+} from './zoomControls';
+
+describe('zoomControls', () => {
+  it('matches keyboard zoom shortcuts by physical key code and Shift state', () => {
+    expect(
+      isKeyboardZoomShortcut(
+        new KeyboardEvent('keydown', {
+          code: 'Equal',
+          key: '+',
+          shiftKey: true,
+        })
+      )
+    ).toBe('in');
+    expect(
+      isKeyboardZoomShortcut(
+        new KeyboardEvent('keydown', {
+          code: 'Minus',
+          key: '_',
+          shiftKey: true,
+        })
+      )
+    ).toBe('out');
+    expect(
+      isKeyboardZoomShortcut(
+        new KeyboardEvent('keydown', {
+          code: 'Equal',
+          key: '=',
+          shiftKey: false,
+        })
+      )
+    ).toBeNull();
+    expect(
+      isKeyboardZoomShortcut(
+        new KeyboardEvent('keydown', {
+          altKey: true,
+          code: 'Equal',
+          key: '+',
+          shiftKey: true,
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('applies repeatable multiplicative keyboard steps within bounds', () => {
+    expect(applyCameraZoomStep(4, 'in', 0.65, 12)).toBeCloseTo(4.48);
+    expect(applyCameraZoomStep(4, 'out', 0.65, 12)).toBeCloseTo(3.5714, 4);
+    expect(applyCameraZoomStep(11.8, 'in', 0.65, 12)).toBe(12);
+    expect(applyCameraZoomStep(0.7, 'out', 0.65, 12)).toBe(0.65);
+  });
+
+  it('normalizes wheel delta modes before exponential zoom scaling', () => {
+    const lineEvent = new WheelEvent('wheel', {
+      deltaMode: WheelEvent.DOM_DELTA_LINE,
+      deltaY: 3,
+    });
+    const pageEvent = new WheelEvent('wheel', {
+      deltaMode: WheelEvent.DOM_DELTA_PAGE,
+      deltaY: 1,
+    });
+
+    expect(normalizeWheelDeltaY(lineEvent)).toBe(48);
+    expect(normalizeWheelDeltaY(pageEvent)).toBe(800);
+
+    const lineTarget = computeWheelZoomTarget(4, lineEvent, 0.65, 12);
+    expect(lineTarget).toBeLessThan(4);
+    expect(lineTarget).toBeGreaterThan(0.65);
+  });
+
+  it('makes high-resolution trackpad deltas materially responsive without exceeding bounds', () => {
+    const trackpadZoomIn = computeWheelZoomTarget(
+      4,
+      new WheelEvent('wheel', {
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+        deltaY: -5,
+      }),
+      0.65,
+      12
+    );
+    const oldAdditiveZoomIn = 4 - -5 * 0.0018;
+
+    expect(trackpadZoomIn - 4).toBeGreaterThan(oldAdditiveZoomIn - 4);
+    expect(
+      computeWheelZoomTarget(
+        11.8,
+        new WheelEvent('wheel', { deltaY: -10_000 }),
+        0.65,
+        12
+      )
+    ).toBe(12);
+    expect(
+      computeWheelZoomTarget(
+        0.7,
+        new WheelEvent('wheel', { deltaY: 10_000 }),
+        0.65,
+        12
+      )
+    ).toBe(0.65);
+  });
+});

--- a/src/systems/controls/zoomControls.ts
+++ b/src/systems/controls/zoomControls.ts
@@ -1,0 +1,75 @@
+export type CameraZoomDirection = 'in' | 'out';
+export type CameraZoomSource = 'keyboard' | 'wheel' | 'pinch';
+
+export const CAMERA_ZOOM_KEYBOARD_STEP = 1.12;
+export const CAMERA_ZOOM_WHEEL_PIXEL_SENSITIVITY = 0.0035;
+export const CAMERA_ZOOM_TRACKPAD_PIXEL_SENSITIVITY = 0.014;
+export const CAMERA_ZOOM_WHEEL_LINE_HEIGHT = 16;
+export const CAMERA_ZOOM_WHEEL_PAGE_HEIGHT = 800;
+export const CAMERA_ZOOM_TRACKPAD_DELTA_THRESHOLD = 50;
+
+export function clampCameraZoomTarget(
+  next: number,
+  minZoom: number,
+  maxZoom: number
+): number {
+  if (!Number.isFinite(next)) {
+    return minZoom;
+  }
+  return Math.min(Math.max(next, minZoom), maxZoom);
+}
+
+export function normalizeWheelDeltaY(event: WheelEvent): number {
+  const deltaY = Number.isFinite(event.deltaY) ? event.deltaY : 0;
+  switch (event.deltaMode) {
+    case WheelEvent.DOM_DELTA_LINE:
+      return deltaY * CAMERA_ZOOM_WHEEL_LINE_HEIGHT;
+    case WheelEvent.DOM_DELTA_PAGE:
+      return deltaY * CAMERA_ZOOM_WHEEL_PAGE_HEIGHT;
+    case WheelEvent.DOM_DELTA_PIXEL:
+    default:
+      return deltaY;
+  }
+}
+
+export function computeWheelZoomTarget(
+  currentZoom: number,
+  event: WheelEvent,
+  minZoom: number,
+  maxZoom: number
+): number {
+  const normalizedDeltaY = normalizeWheelDeltaY(event);
+  const sensitivity =
+    event.deltaMode === WheelEvent.DOM_DELTA_PIXEL &&
+    Math.abs(normalizedDeltaY) < CAMERA_ZOOM_TRACKPAD_DELTA_THRESHOLD
+      ? CAMERA_ZOOM_TRACKPAD_PIXEL_SENSITIVITY
+      : CAMERA_ZOOM_WHEEL_PIXEL_SENSITIVITY;
+  const nextZoom = currentZoom * Math.exp(-normalizedDeltaY * sensitivity);
+  return clampCameraZoomTarget(nextZoom, minZoom, maxZoom);
+}
+
+export function applyCameraZoomStep(
+  currentZoom: number,
+  direction: CameraZoomDirection,
+  minZoom: number,
+  maxZoom: number,
+  step = CAMERA_ZOOM_KEYBOARD_STEP
+): number {
+  const multiplier = direction === 'in' ? step : 1 / step;
+  return clampCameraZoomTarget(currentZoom * multiplier, minZoom, maxZoom);
+}
+
+export function isKeyboardZoomShortcut(
+  event: KeyboardEvent
+): CameraZoomDirection | null {
+  if (!event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+    return null;
+  }
+  if (event.code === 'Equal') {
+    return 'in';
+  }
+  if (event.code === 'Minus') {
+    return 'out';
+  }
+  return null;
+}

--- a/src/tests/controlOverlay.test.ts
+++ b/src/tests/controlOverlay.test.ts
@@ -13,6 +13,10 @@ describe('applyControlOverlayStrings', () => {
           <span class="overlay__keys">Keys</span>
           <span class="overlay__description">Move</span>
         </li>
+        <li class="overlay__item" data-control-item="keyboardZoom">
+          <span class="overlay__keys">Keys</span>
+          <span class="overlay__description">Zoom</span>
+        </li>
         <li
           class="overlay__item"
           data-control-item="interact"
@@ -45,6 +49,11 @@ describe('applyControlOverlayStrings', () => {
       '[data-control-item="keyboardMove"] .overlay__keys'
     );
     expect(keyboardItem?.textContent).toBe(strings.items.keyboardMove.keys);
+
+    const keyboardZoomItem = container.querySelector(
+      '[data-control-item="keyboardZoom"] .overlay__keys'
+    );
+    expect(keyboardZoomItem?.textContent).toBe(strings.items.keyboardZoom.keys);
 
     const interactLabel = container.querySelector(
       '[data-role="interact-label"]'

--- a/src/tests/helpModal.test.ts
+++ b/src/tests/helpModal.test.ts
@@ -64,6 +64,20 @@ describe('createHelpModal', () => {
     expect(document.activeElement).toBe(focusAnchor);
   });
 
+  it('documents keyboard zoom shortcuts in the default movement section', () => {
+    const handle = createHelpModal({
+      container: document.body,
+      content: cloneContent(),
+    });
+
+    handle.open();
+
+    expect(document.body.textContent).toContain('Shift + = / Shift + -');
+    expect(document.body.textContent).toContain(
+      'Zoom in or out without a mouse wheel.'
+    );
+  });
+
   it('supports custom headings and sections', () => {
     const handle = createHelpModal({
       container: document.body,

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -244,6 +244,18 @@ describe('i18n utilities', () => {
     expect(pseudoOverlay.items.keyboardMove.keys).toBe(
       englishOverlay.items.keyboardMove.keys
     );
+    expect(englishOverlay.items.keyboardZoom.keys).toBe(
+      'Shift + = / Shift + -'
+    );
+    expect(pseudoOverlay.items.keyboardZoom.keys).toBe(
+      englishOverlay.items.keyboardZoom.keys
+    );
+    const englishHelp = getHelpModalStrings('en');
+    expect(
+      englishHelp.sections
+        .find((section) => section.id === 'movement')
+        ?.items.some((item) => item.label === 'Shift + = / Shift + -')
+    ).toBe(true);
     const helpModal = getHelpModalStrings('en-x-pseudo');
     expect(helpModal.closeLabel).toBe('⟦Close⟧');
     expect(helpModal.announcements.open).toBe(

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -13,6 +13,7 @@ const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
     keyboardMove: { keys: 'WASD / Arrow keys', description: 'Move' },
     pointerDrag: { keys: 'Left mouse button', description: 'Drag to pan' },
     pointerZoom: { keys: 'Scroll wheel', description: 'Zoom' },
+    keyboardZoom: { keys: 'Shift + = / Shift + -', description: 'Zoom' },
     touchDrag: { keys: 'Touch', description: 'Drag to move and pan' },
     touchPinch: { keys: 'Pinch', description: 'Zoom' },
     cyclePoi: { keys: 'Q / E', description: 'Cycle POIs' },

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -65,6 +65,7 @@ export function applyControlOverlayStrings(
   applyItem('keyboardMove');
   applyItem('pointerDrag');
   applyItem('pointerZoom');
+  applyItem('keyboardZoom');
   applyItem('touchDrag');
   applyItem('touchPinch');
   applyItem('cyclePoi');


### PR DESCRIPTION
### Motivation
- Improve zoom ergonomics for users who don't have a mouse wheel by adding keyboard shortcuts for zoom in/out.  
- Make MacBook trackpad (high-resolution) wheel zoom feel materially faster and more consistent without making mouse-wheel zoom comically fast.  
- Preserve existing mobile pinch-to-zoom behavior (multiplicative distance-ratio path) and document the new shortcuts in HUD/Settings across locales.

### Description
- Add a small zoom helper module `src/systems/controls/zoomControls.ts` that normalizes `WheelEvent.deltaMode`, applies exponential/multiplicative scaling for wheel/trackpad deltas, and exposes `applyCameraZoomStep`, `computeWheelZoomTarget`, and `isKeyboardZoomShortcut`.  
- Wire keyboard zoom handling into the immersive lifecycle in `src/main.ts`: ignore text-entry targets and modifier/meta combos, detect physical keys via `event.code` (`Equal` / `Minus`) with `Shift`, and apply repeatable multiplicative steps; register/remove the listener with scene init/dispose.  
- Replace the old additive wheel handling with `computeWheelZoomTarget(...)` to normalize delta modes and apply separate sensitivities for trackpads vs wheels while clamping to min/max zoom.  
- Add HUD/Help copy and i18n updates to document the shortcuts (`Shift + = / Shift + -`) across supported locales and add the compact Controls overlay entry (`keyboardZoom`) in `index.html`, `src/ui/hud/controlOverlay.ts`, and locale files.  
- Add tests: unit tests at `src/systems/controls/zoomControls.test.ts` covering keyboard detection, keyboard steps, wheel normalization, and trackpad responsiveness; updated UI/i18n tests and a Playwright e2e test `playwright/immersive-zoom.spec.ts` to cover keyboard zoom behavior and pinch preservation.

### Testing
- `npm run format:write` — passed.  
- `npm run lint` — passed (no blocking errors; ordering warning was addressed).  
- `npm run typecheck` (`tsc --noEmit`) — passed.  
- `npm run test:ci` — passed (unit/integration suite; all Vitest tests passed).  
- `npm run build` — passed (`vite build` produced `dist` successfully).  
- `npm run test:e2e -- playwright/immersive-zoom.spec.ts playwright/small-screen-hud.spec.ts` — passed after installing Playwright browsers and host deps in the test environment (all Playwright checks in the targeted specs passed).  
- `npm run docs:check` — passed.  
- `npm run smoke` — passed (build + artifact assertions).  

Residual risks & follow-ups: keyboard zoom is implemented as a focused, non-remappable handler integrated into the immersive scene (preferred for minimal surface change); follow-up could expose remappable actions in the `KeyBindings` model if a persisted user mapping is desired.  Zoom sensitivity constants (`CAMERA_ZOOM_TRACKPAD_PIXEL_SENSITIVITY`, etc.) are tuned conservatively and may be iterated from UX feedback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ebdef1ac832fa5c6157b7a41df8c)