### PR TITLE
Add keyboard zoom shortcuts and improve trackpad/mouse zoom ergonomics

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,6 +452,14 @@
             <span class="overlay__description">Zoom</span>
           </li>
           <li
+            class="overlay__item"
+            data-input-methods="keyboard"
+            data-control-item="keyboardZoom"
+          >
+            <span class="overlay__keys">Shift + = / Shift + -</span>
+            <span class="overlay__description">Zoom in or out</span>
+          </li>
+          <li
             class="overlay__item overlay__item--touch"
             data-input-methods="touch"
             data-control-item="touchDrag"

--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -199,6 +199,41 @@ test.describe('immersive orthographic zoom', () => {
     await expect(page.locator('[data-role="hud-menu"]')).toBeVisible();
   });
 
+  test('zooms with keyboard shortcuts and ignores text-entry focus', async ({
+    page,
+  }) => {
+    await waitForImmersive(page);
+
+    const initialState = await getCameraZoomState(page);
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Minus');
+    await page.keyboard.up('Shift');
+    const zoomedOutState = await getCameraZoomState(page);
+    expect(zoomedOutState.target).toBeLessThan(initialState.target);
+
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Equal');
+    await page.keyboard.up('Shift');
+    const zoomedInState = await getCameraZoomState(page);
+    expect(zoomedInState.target).toBeGreaterThan(zoomedOutState.target);
+
+    await page.evaluate(() => {
+      const input = document.createElement('input');
+      input.setAttribute('aria-label', 'Zoom shortcut test input');
+      document.body.appendChild(input);
+      input.focus();
+    });
+    const beforeTextEntryShortcut = await getCameraZoomState(page);
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Equal');
+    await page.keyboard.up('Shift');
+    const afterTextEntryShortcut = await getCameraZoomState(page);
+    expect(afterTextEntryShortcut.target).toBeCloseTo(
+      beforeTextEntryShortcut.target,
+      6
+    );
+  });
+
   test('keeps a single clean immersive canvas while zooming with motion blur disabled', async ({
     page,
   }) => {

--- a/playwright/immersive-zoom.spec.ts
+++ b/playwright/immersive-zoom.spec.ts
@@ -232,6 +232,26 @@ test.describe('immersive orthographic zoom', () => {
       beforeTextEntryShortcut.target,
       6
     );
+
+    await page.evaluate(() => {
+      document
+        .querySelector<HTMLInputElement>(
+          '[aria-label="Zoom shortcut test input"]'
+        )
+        ?.remove();
+      document.body.focus();
+    });
+    await page.keyboard.press('c');
+    await expect(page.locator('[data-role="controls-popover"]')).toBeVisible();
+    const beforePanelShortcut = await getCameraZoomState(page);
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Equal');
+    await page.keyboard.up('Shift');
+    const afterPanelShortcut = await getCameraZoomState(page);
+    expect(afterPanelShortcut.target).toBeCloseTo(
+      beforePanelShortcut.target,
+      6
+    );
   });
 
   test('keeps a single clean immersive canvas while zooming with motion blur disabled', async ({

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -173,6 +173,10 @@ export const AR_OVERRIDES: LocaleOverrides = {
           keys: 'عجلة التمرير',
           description: 'تكبير أو تصغير',
         },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: 'تكبير أو تصغير بلوحة المفاتيح',
+        },
         touchDrag: {
           keys: 'المس',
           description: 'اسحب اليسار للحركة واليمين للدوران',
@@ -336,6 +340,10 @@ export const AR_OVERRIDES: LocaleOverrides = {
               description: 'قم بتدوير الكاميرا متساوية القياس.',
             },
             { label: 'عجلة التمرير', description: 'اضبط مستوى التكبير.' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'كبّر أو صغّر من دون عجلة فأرة.',
+            },
             {
               label: 'عصا اللمس',
               description: 'اسحب اليسار للحركة واليمين للدوران.',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -439,6 +439,12 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
     },
     helpModal: {
       heading: wrap('Settings & Help'),
+      description: wrap(
+        [
+          'Adjust accessibility presets, graphics quality, audio, and review shortcuts.',
+          'Use the help shortcut (default H or ?) to toggle this panel.',
+        ].join(' ')
+      ),
       closeLabel: wrap('Close'),
       closeAriaLabel: wrap('Close help'),
       settings: {
@@ -450,6 +456,98 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
           ].join(' ')
         ),
       },
+      sections: [
+        {
+          id: 'movement',
+          title: wrap('Movement & Camera'),
+          items: [
+            {
+              label: wrap('WASD / Arrow keys'),
+              description: wrap('Roll the explorer around the home.'),
+            },
+            {
+              label: wrap('Mouse drag'),
+              description: wrap('Pan the isometric camera.'),
+            },
+            {
+              label: wrap('Scroll wheel'),
+              description: wrap('Adjust zoom level.'),
+            },
+            {
+              label: wrap('Shift + = / Shift + -'),
+              description: wrap('Zoom in or out without a mouse wheel.'),
+            },
+            {
+              label: wrap('Touch joysticks'),
+              description: wrap(
+                'Drag the left pad to move and the right pad to pan.'
+              ),
+            },
+            {
+              label: wrap('Pinch'),
+              description: wrap('Zoom on touch devices.'),
+            },
+          ],
+        },
+        {
+          id: 'interactions',
+          title: wrap('Interactions'),
+          items: [
+            {
+              label: wrap('Approach glowing POIs'),
+              description: wrap(
+                'Press your interact key (Enter/Space/F), tap, or click to open the exhibit overlay.'
+              ),
+            },
+            {
+              label: wrap('Q / E or ← / →'),
+              description: wrap(
+                'Cycle focus between points of interest with the keyboard.'
+              ),
+            },
+            {
+              label: wrap('T'),
+              description: wrap(
+                'Toggle between immersive mode and the text fallback.'
+              ),
+            },
+            {
+              label: wrap('Shift + L'),
+              description: wrap(
+                'Compare cinematic lighting with the debug pass.'
+              ),
+            },
+          ],
+        },
+        {
+          id: 'accessibility',
+          title: wrap('Accessibility & Failover'),
+          items: [
+            {
+              label: wrap('Low performance'),
+              description: wrap(
+                'The scene automatically switches to text mode below 30 FPS.'
+              ),
+            },
+            {
+              label: wrap('Manual toggle'),
+              description: wrap(
+                'Use the on-screen Text mode button or press T at any time.'
+              ),
+            },
+            {
+              label: wrap('Motion blur slider'),
+              description: wrap(
+                'Adjust trail strength with the Settings → Motion blur control.'
+              ),
+            },
+            {
+              label: wrap('Ambient audio'),
+              description: wrap('Toggle with the Audio button or press M.'),
+            },
+          ],
+        },
+      ],
       announcements: {
         open: wrap('Help menu opened. Review controls and settings.'),
         close: wrap('Help menu closed.'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -179,6 +179,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           keys: 'Scroll wheel',
           description: 'Zoom',
         },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: 'Zoom in or out',
+        },
         touchDrag: {
           keys: 'Touch',
           description: 'Drag the left half to move and the right half to pan',
@@ -455,6 +459,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             },
             { label: 'Mouse drag', description: 'Pan the isometric camera.' },
             { label: 'Scroll wheel', description: 'Adjust zoom level.' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'Zoom in or out without a mouse wheel.',
+            },
             {
               label: 'Touch joysticks',
               description:

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -174,6 +174,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
           keys: 'ホイール',
           description: 'ズーム',
         },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: 'キーボードでズームイン／アウト',
+        },
         touchDrag: {
           keys: 'タッチ',
           description: '左側で移動・右側で視点をドラッグ',
@@ -338,6 +342,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
               description: 'アイソメ視点をパンします。',
             },
             { label: 'ホイール', description: 'ズームレベルを調整します。' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: 'マウスホイールなしでズームします。',
+            },
             {
               label: 'タッチジョイスティック',
               description: '左パッドで移動し、右パッドで視点をパンします。',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -1,4 +1,8 @@
-import type { Locale, LocaleOverrides } from '../types';
+import type {
+  HelpModalSectionStrings,
+  Locale,
+  LocaleOverrides,
+} from '../types';
 
 type LatinLocale = Extract<Locale, 'es' | 'pt' | 'de' | 'hu'>;
 
@@ -297,6 +301,149 @@ const localizedTemplates: Record<
     dspaceInteractionPrompt: '{title} visszaszámlálás indítása',
   },
 };
+
+function buildLatinHelpSections(
+  locale: LatinLocale
+): readonly HelpModalSectionStrings[] {
+  const copy = {
+    es: {
+      movementTitle: 'Movimiento y cámara',
+      move: 'Mueve al explorador por la casa.',
+      drag: 'Desplaza la cámara isométrica.',
+      wheel: 'Ajusta el nivel de zoom.',
+      keyboardZoom: 'Acerca o aleja sin rueda de ratón.',
+      touch:
+        'Arrastra el pad izquierdo para mover y el derecho para panorámica.',
+      pinch: 'Haz zoom en dispositivos táctiles.',
+      interactionsTitle: 'Interacciones',
+      poi: 'Acércate a los POI luminosos',
+      poiDescription:
+        'Pulsa la tecla de interacción (Enter/Espacio/F), toca o haz clic para abrir la exhibición.',
+      cycle: 'Cambia el foco entre puntos de interés con el teclado.',
+      textMode: 'Alterna entre el modo inmersivo y el respaldo de texto.',
+      lighting:
+        'Compara la iluminación cinematográfica con el pase de depuración.',
+      accessibilityTitle: 'Accesibilidad y respaldo',
+      lowPerformance:
+        'La escena cambia automáticamente al modo texto por debajo de 30 FPS.',
+      manualToggle:
+        'Usa el botón Modo texto en pantalla o pulsa T en cualquier momento.',
+      motionBlur:
+        'Ajusta la intensidad de estelas con Ajustes → Desenfoque de movimiento.',
+      ambientAudio: 'Alterna con el botón Audio o pulsa M.',
+    },
+    pt: {
+      movementTitle: 'Movimento e câmera',
+      move: 'Mova o explorador pela casa.',
+      drag: 'Desloque a câmera isométrica.',
+      wheel: 'Ajuste o nível de zoom.',
+      keyboardZoom: 'Aproxime ou afaste sem roda do mouse.',
+      touch: 'Arraste o pad esquerdo para mover e o direito para panorâmica.',
+      pinch: 'Aplique zoom em dispositivos de toque.',
+      interactionsTitle: 'Interações',
+      poi: 'Aproxime-se dos POIs brilhantes',
+      poiDescription:
+        'Pressione sua tecla de interação (Enter/Espaço/F), toque ou clique para abrir a exibição.',
+      cycle: 'Alterne o foco entre pontos de interesse pelo teclado.',
+      textMode: 'Alterne entre o modo imersivo e o fallback em texto.',
+      lighting:
+        'Compare a iluminação cinematográfica com a passagem de depuração.',
+      accessibilityTitle: 'Acessibilidade e fallback',
+      lowPerformance:
+        'A cena muda automaticamente para o modo texto abaixo de 30 FPS.',
+      manualToggle:
+        'Use o botão Modo texto na tela ou pressione T a qualquer momento.',
+      motionBlur:
+        'Ajuste a força dos rastros em Configurações → Desfoque de movimento.',
+      ambientAudio: 'Alterne com o botão Áudio ou pressione M.',
+    },
+    de: {
+      movementTitle: 'Bewegung & Kamera',
+      move: 'Bewege den Explorer durch das Zuhause.',
+      drag: 'Schwenke die isometrische Kamera.',
+      wheel: 'Passe die Zoomstufe an.',
+      keyboardZoom: 'Zoome ohne Mausrad hinein oder heraus.',
+      touch: 'Ziehe links zum Bewegen und rechts zum Schwenken.',
+      pinch: 'Zoome auf Touch-Geräten per Pinch-Geste.',
+      interactionsTitle: 'Interaktionen',
+      poi: 'Leuchtenden POIs nähern',
+      poiDescription:
+        'Drücke die Interaktionstaste (Enter/Leertaste/F), tippe oder klicke, um das Exponat zu öffnen.',
+      cycle: 'Wechsle den Fokus per Tastatur zwischen Points of Interest.',
+      textMode: 'Wechsle zwischen immersivem Modus und Text-Fallback.',
+      lighting: 'Vergleiche filmische Beleuchtung mit dem Debug-Pass.',
+      accessibilityTitle: 'Barrierefreiheit & Fallback',
+      lowPerformance:
+        'Die Szene wechselt unter 30 FPS automatisch in den Textmodus.',
+      manualToggle: 'Nutze die Schaltfläche Textmodus oder drücke jederzeit T.',
+      motionBlur:
+        'Passe die Spur-Stärke unter Einstellungen → Bewegungsunschärfe an.',
+      ambientAudio: 'Schalte mit der Audio-Schaltfläche um oder drücke M.',
+    },
+    hu: {
+      movementTitle: 'Mozgás és kamera',
+      move: 'Mozgasd a felfedezőt az otthonban.',
+      drag: 'Pásztázd az izometrikus kamerát.',
+      wheel: 'Állítsd a nagyítási szintet.',
+      keyboardZoom: 'Nagyíts vagy kicsinyíts egérgörgő nélkül.',
+      touch: 'A bal paddal mozogj, a jobb paddal pásztázz.',
+      pinch: 'Érintős eszközön csippentéssel nagyíts.',
+      interactionsTitle: 'Interakciók',
+      poi: 'Közelíts a világító POI-khoz',
+      poiDescription:
+        'Nyomd meg az interakciós billentyűt (Enter/Szóköz/F), koppints vagy kattints a kiállítás megnyitásához.',
+      cycle: 'Billentyűzettel válts fókuszt az érdekes pontok között.',
+      textMode: 'Válts az immerzív mód és a szöveges tartalék között.',
+      lighting: 'Hasonlítsd össze a filmes világítást a hibakereső nézettel.',
+      accessibilityTitle: 'Akadálymentesség és tartalék',
+      lowPerformance:
+        'A jelenet 30 FPS alatt automatikusan szöveges módra vált.',
+      manualToggle:
+        'Használd a képernyőn látható Szöveges mód gombot, vagy nyomj T-t.',
+      motionBlur:
+        'Állítsd a csóvák erősségét a Beállítások → Mozgáselmosás vezérlővel.',
+      ambientAudio: 'Kapcsold az Audio gombbal, vagy nyomj M-et.',
+    },
+  }[locale];
+
+  return [
+    {
+      id: 'movement',
+      title: copy.movementTitle,
+      items: [
+        { label: 'WASD / Arrow keys', description: copy.move },
+        { label: 'Mouse drag', description: copy.drag },
+        { label: 'Scroll wheel', description: copy.wheel },
+        {
+          label: 'Shift + = / Shift + -',
+          description: copy.keyboardZoom,
+        },
+        { label: 'Touch joysticks', description: copy.touch },
+        { label: 'Pinch', description: copy.pinch },
+      ],
+    },
+    {
+      id: 'interactions',
+      title: copy.interactionsTitle,
+      items: [
+        { label: copy.poi, description: copy.poiDescription },
+        { label: 'Q / E or ← / →', description: copy.cycle },
+        { label: 'T', description: copy.textMode },
+        { label: 'Shift + L', description: copy.lighting },
+      ],
+    },
+    {
+      id: 'accessibility',
+      title: copy.accessibilityTitle,
+      items: [
+        { label: 'Low performance', description: copy.lowPerformance },
+        { label: 'Manual toggle', description: copy.manualToggle },
+        { label: 'Motion blur slider', description: copy.motionBlur },
+        { label: 'Ambient audio', description: copy.ambientAudio },
+      ],
+    },
+  ];
+}
 
 export function buildLatinLocaleOverrides(
   copy: LatinLocaleCopy
@@ -651,6 +798,7 @@ export function buildLatinLocaleOverrides(
           heading: s.settingsHelp,
           description: s.languageDescription,
         },
+        sections: buildLatinHelpSections(copy.locale),
         announcements: {
           open:
             copy.locale === 'de'

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -67,6 +67,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: string;
     keyboardMove: string;
     pointerDrag: string;
+    keyboardZoom: string;
     touchDrag: string;
     cyclePoi: string;
     interactDefault: string;
@@ -111,6 +112,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: 'Exhibiciones de {roomName}',
     keyboardMove: 'Mover',
     pointerDrag: 'Arrastrar para panorámica',
+    keyboardZoom: 'Acercar o alejar con el teclado',
     touchDrag:
       'Arrastra a la izquierda para mover y a la derecha para panorámica',
     cyclePoi: 'Recorrer POI',
@@ -159,6 +161,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: 'Exibições de {roomName}',
     keyboardMove: 'Mover',
     pointerDrag: 'Arrastar para panorâmica',
+    keyboardZoom: 'Aproximar ou afastar pelo teclado',
     touchDrag: 'Arraste à esquerda para mover e à direita para panorâmica',
     cyclePoi: 'Percorrer POIs',
     interactDefault: 'Entrar',
@@ -207,6 +210,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: '{roomName}-Exponate',
     keyboardMove: 'Bewegen',
     pointerDrag: 'Ziehen zum Schwenken',
+    keyboardZoom: 'Per Tastatur hinein- oder herauszoomen',
     touchDrag: 'Links bewegen, rechts schwenken',
     cyclePoi: 'POIs wechseln',
     interactDefault: 'Öffnen',
@@ -254,6 +258,7 @@ const localizedTemplates: Record<
     roomHeadingTemplate: '{roomName} kiállításai',
     keyboardMove: 'Mozgás',
     pointerDrag: 'Húzás a pásztázáshoz',
+    keyboardZoom: 'Nagyítás vagy kicsinyítés billentyűzettel',
     touchDrag: 'Bal oldalon mozgás, jobb oldalon pásztázás',
     cyclePoi: 'POI-k váltása',
     interactDefault: 'Megnyitás',
@@ -447,6 +452,10 @@ export function buildLatinLocaleOverrides(
             description: templates.pointerDrag,
           },
           pointerZoom: { description: 'Zoom' },
+          keyboardZoom: {
+            keys: 'Shift + = / Shift + -',
+            description: templates.keyboardZoom,
+          },
           touchDrag: {
             description: templates.touchDrag,
           },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -144,6 +144,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         keyboardMove: { keys: 'WASD / 方向键', description: '移动' },
         pointerDrag: { keys: '鼠标左键', description: '拖动平移' },
         pointerZoom: { keys: '滚轮', description: '缩放' },
+        keyboardZoom: {
+          keys: 'Shift + = / Shift + -',
+          description: '用键盘放大或缩小',
+        },
         touchDrag: {
           keys: '触控',
           description: '左半屏拖动移动，右半屏拖动平移',
@@ -365,6 +369,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             { label: 'WASD / 方向键', description: '在家中移动探索者。' },
             { label: '鼠标拖动', description: '平移等距相机。' },
             { label: '滚轮', description: '调整缩放级别。' },
+            {
+              label: 'Shift + = / Shift + -',
+              description: '无需鼠标滚轮即可放大或缩小。',
+            },
             { label: '触控摇杆', description: '拖动左垫移动，拖动右垫平移。' },
             { label: '捏合', description: '在触控设备上缩放。' },
           ],

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -38,6 +38,7 @@ export interface ControlOverlayStrings {
     keyboardMove: ControlOverlayItemStrings;
     pointerDrag: ControlOverlayItemStrings;
     pointerZoom: ControlOverlayItemStrings;
+    keyboardZoom: ControlOverlayItemStrings;
     touchDrag: ControlOverlayItemStrings;
     touchPinch: ControlOverlayItemStrings;
     cyclePoi: ControlOverlayItemStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -277,6 +277,13 @@ import {
   createDistantHumBuffer,
   createFootstepBuffer,
 } from './systems/audio/proceduralBuffers';
+import {
+  applyPinchCameraZoom,
+  applyCameraZoomStep,
+  applyWheelCameraZoomStep,
+  getKeyboardZoomDirection,
+  isTextEntryTarget,
+} from './systems/camera/zoomControls';
 import { collidesWithColliders, type RectCollider } from './systems/collision';
 import {
   createAccessibilityPresetControl,
@@ -533,7 +540,6 @@ const CAMERA_ZOOM_SMOOTHING = 6;
 const CAMERA_MARGIN = 1.1;
 const MIN_CAMERA_ZOOM = 0.65;
 const MAX_CAMERA_ZOOM = 12;
-const CAMERA_ZOOM_WHEEL_SENSITIVITY = 0.0018;
 const MANNEQUIN_YAW_SMOOTHING = 8;
 const CEILING_COVE_OFFSET = 0.35;
 const BACKYARD_ROOM_ID = 'backyard';
@@ -2972,20 +2978,6 @@ function initializeImmersiveScene(
     }
     helpModal.toggle(force);
   };
-  const isTextEntryTarget = (target: EventTarget | null): boolean => {
-    if (!(target instanceof HTMLElement)) {
-      return false;
-    }
-    const tagName = target.tagName.toLowerCase();
-    return (
-      target.isContentEditable ||
-      target.hasAttribute('contenteditable') ||
-      target.closest('[contenteditable]') !== null ||
-      tagName === 'input' ||
-      tagName === 'textarea' ||
-      tagName === 'select'
-    );
-  };
   const normalizeKeyboardEventKey = (event: KeyboardEvent): string =>
     event.key.length === 1 ? event.key.toLowerCase() : event.key;
   const normalizeBindingKey = (binding: string): string =>
@@ -3369,10 +3361,34 @@ function initializeImmersiveScene(
 
   updateCameraProjection(aspect);
 
+  const handleKeyboardZoom = (event: KeyboardEvent) => {
+    const direction = getKeyboardZoomDirection(event);
+    if (direction === null) {
+      return;
+    }
+    event.preventDefault();
+    setCameraZoomTarget(
+      applyCameraZoomStep({
+        currentZoomTarget: cameraZoomTarget,
+        direction,
+        source: 'keyboard',
+        minZoom: MIN_CAMERA_ZOOM,
+        maxZoom: MAX_CAMERA_ZOOM,
+      })
+    );
+  };
+
   const handleWheelZoom = (event: WheelEvent) => {
     event.preventDefault();
     setCameraZoomTarget(
-      cameraZoomTarget - event.deltaY * CAMERA_ZOOM_WHEEL_SENSITIVITY
+      applyWheelCameraZoomStep({
+        currentZoomTarget: cameraZoomTarget,
+        deltaY: event.deltaY,
+        deltaMode: event.deltaMode,
+        viewportHeight: window.innerHeight,
+        minZoom: MIN_CAMERA_ZOOM,
+        maxZoom: MAX_CAMERA_ZOOM,
+      })
     );
   };
 
@@ -3416,11 +3432,15 @@ function initializeImmersiveScene(
       pinchStartZoomTarget = cameraZoomTarget;
       return;
     }
-    const scale = distance / pinchStartDistance;
-    if (!isFinite(scale) || scale <= 0) {
-      return;
-    }
-    setCameraZoomTarget(pinchStartZoomTarget * scale);
+    setCameraZoomTarget(
+      applyPinchCameraZoom({
+        startZoomTarget: pinchStartZoomTarget,
+        startDistance: pinchStartDistance,
+        currentDistance: distance,
+        minZoom: MIN_CAMERA_ZOOM,
+        maxZoom: MAX_CAMERA_ZOOM,
+      })
+    );
   };
 
   const handlePointerEndForZoom = (event: PointerEvent) => {
@@ -3496,6 +3516,7 @@ function initializeImmersiveScene(
     mouseCameraDragging = false;
   };
 
+  window.addEventListener('keydown', handleKeyboardZoom);
   renderer.domElement.addEventListener('wheel', handleWheelZoom, {
     passive: false,
   });
@@ -4662,6 +4683,7 @@ function initializeImmersiveScene(
       hudLayoutManager = null;
     }
     window.removeEventListener('keydown', handleControlsKeydown);
+    window.removeEventListener('keydown', handleKeyboardZoom);
     if (hudPanelCoordinator) {
       hudPanelCoordinator.dispose();
       hudPanelCoordinator = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3362,6 +3362,9 @@ function initializeImmersiveScene(
   updateCameraProjection(aspect);
 
   const handleKeyboardZoom = (event: KeyboardEvent) => {
+    if ((hudPanelCoordinator?.getActivePanel() ?? null) !== null) {
+      return;
+    }
     const direction = getKeyboardZoomDirection(event);
     if (direction === null) {
       return;

--- a/src/systems/camera/zoomControls.ts
+++ b/src/systems/camera/zoomControls.ts
@@ -1,0 +1,167 @@
+import { MathUtils } from 'three';
+
+export type CameraZoomStepSource = 'keyboard' | 'wheel' | 'pinch' | 'test';
+
+export const WHEEL_DELTA_PIXEL = 0;
+export const WHEEL_DELTA_LINE = 1;
+export const WHEEL_DELTA_PAGE = 2;
+export const WHEEL_DELTA_LINE_HEIGHT_PX = 16;
+export const WHEEL_DELTA_PAGE_HEIGHT_PX = 800;
+export const CAMERA_ZOOM_WHEEL_PIXEL_SENSITIVITY = 0.0022;
+export const CAMERA_ZOOM_TRACKPAD_MULTIPLIER = 3;
+export const CAMERA_ZOOM_KEYBOARD_FACTOR = 1.12;
+
+export interface CameraZoomBounds {
+  minZoom: number;
+  maxZoom: number;
+}
+
+export interface CameraZoomStepOptions extends CameraZoomBounds {
+  currentZoomTarget: number;
+  direction: 1 | -1;
+  source: CameraZoomStepSource;
+  factor?: number;
+}
+
+export interface WheelZoomStepOptions extends CameraZoomBounds {
+  currentZoomTarget: number;
+  deltaY: number;
+  deltaMode?: number;
+  viewportHeight?: number;
+}
+
+export interface PinchZoomOptions extends CameraZoomBounds {
+  startZoomTarget: number;
+  startDistance: number;
+  currentDistance: number;
+}
+
+export function clampCameraZoom(
+  value: number,
+  bounds: CameraZoomBounds
+): number {
+  const fallback = bounds.minZoom;
+  const finiteValue = Number.isFinite(value) ? value : fallback;
+  return MathUtils.clamp(finiteValue, bounds.minZoom, bounds.maxZoom);
+}
+
+export function applyCameraZoomStep({
+  currentZoomTarget,
+  direction,
+  minZoom,
+  maxZoom,
+  factor = CAMERA_ZOOM_KEYBOARD_FACTOR,
+}: CameraZoomStepOptions): number {
+  const boundedCurrent = clampCameraZoom(currentZoomTarget, {
+    minZoom,
+    maxZoom,
+  });
+  const multiplier = direction > 0 ? factor : 1 / factor;
+  return clampCameraZoom(boundedCurrent * multiplier, { minZoom, maxZoom });
+}
+
+export function normalizeWheelDeltaY(
+  deltaY: number,
+  deltaMode = WHEEL_DELTA_PIXEL,
+  viewportHeight = WHEEL_DELTA_PAGE_HEIGHT_PX
+): number {
+  if (!Number.isFinite(deltaY)) {
+    return 0;
+  }
+  if (deltaMode === WHEEL_DELTA_LINE) {
+    return deltaY * WHEEL_DELTA_LINE_HEIGHT_PX;
+  }
+  if (deltaMode === WHEEL_DELTA_PAGE) {
+    const pageHeight =
+      Number.isFinite(viewportHeight) && viewportHeight > 0
+        ? viewportHeight
+        : WHEEL_DELTA_PAGE_HEIGHT_PX;
+    return deltaY * pageHeight;
+  }
+  return deltaY;
+}
+
+export function applyWheelCameraZoomStep({
+  currentZoomTarget,
+  deltaY,
+  deltaMode = WHEEL_DELTA_PIXEL,
+  viewportHeight,
+  minZoom,
+  maxZoom,
+}: WheelZoomStepOptions): number {
+  const normalizedDeltaY = normalizeWheelDeltaY(
+    deltaY,
+    deltaMode,
+    viewportHeight
+  );
+  if (normalizedDeltaY === 0) {
+    return clampCameraZoom(currentZoomTarget, { minZoom, maxZoom });
+  }
+  const isHighResolutionTrackpadDelta =
+    deltaMode === WHEEL_DELTA_PIXEL && Math.abs(normalizedDeltaY) < 40;
+  const multiplier = isHighResolutionTrackpadDelta
+    ? CAMERA_ZOOM_TRACKPAD_MULTIPLIER
+    : 1;
+  const next =
+    currentZoomTarget *
+    Math.exp(
+      -normalizedDeltaY * CAMERA_ZOOM_WHEEL_PIXEL_SENSITIVITY * multiplier
+    );
+  return clampCameraZoom(next, { minZoom, maxZoom });
+}
+
+export function applyPinchCameraZoom({
+  startZoomTarget,
+  startDistance,
+  currentDistance,
+  minZoom,
+  maxZoom,
+}: PinchZoomOptions): number {
+  if (
+    !Number.isFinite(startDistance) ||
+    !Number.isFinite(currentDistance) ||
+    startDistance <= 0 ||
+    currentDistance <= 0
+  ) {
+    return clampCameraZoom(startZoomTarget, { minZoom, maxZoom });
+  }
+  return clampCameraZoom(startZoomTarget * (currentDistance / startDistance), {
+    minZoom,
+    maxZoom,
+  });
+}
+
+export function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return (
+    target.isContentEditable ||
+    target.hasAttribute('contenteditable') ||
+    target.closest('[contenteditable]') !== null ||
+    tagName === 'input' ||
+    tagName === 'textarea' ||
+    tagName === 'select'
+  );
+}
+
+export function getKeyboardZoomDirection(event: KeyboardEvent): 1 | -1 | null {
+  if (
+    event.defaultPrevented ||
+    !event.shiftKey ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey ||
+    isTextEntryTarget(event.target)
+  ) {
+    return null;
+  }
+  if (event.code === 'Equal') {
+    return 1;
+  }
+  if (event.code === 'Minus') {
+    return -1;
+  }
+  return null;
+}

--- a/src/systems/camera/zoomControls.ts
+++ b/src/systems/camera/zoomControls.ts
@@ -40,8 +40,12 @@ export function clampCameraZoom(
   value: number,
   bounds: CameraZoomBounds
 ): number {
-  const fallback = bounds.minZoom;
-  const finiteValue = Number.isFinite(value) ? value : fallback;
+  const finiteValue =
+    value === Infinity
+      ? bounds.maxZoom
+      : value === -Infinity || Number.isNaN(value)
+        ? bounds.minZoom
+        : value;
   return MathUtils.clamp(finiteValue, bounds.minZoom, bounds.maxZoom);
 }
 
@@ -149,7 +153,6 @@ export function isTextEntryTarget(target: EventTarget | null): boolean {
 export function getKeyboardZoomDirection(event: KeyboardEvent): 1 | -1 | null {
   if (
     event.defaultPrevented ||
-    !event.shiftKey ||
     event.metaKey ||
     event.ctrlKey ||
     event.altKey ||
@@ -157,10 +160,24 @@ export function getKeyboardZoomDirection(event: KeyboardEvent): 1 | -1 | null {
   ) {
     return null;
   }
-  if (event.code === 'Equal') {
+
+  const isNumpadZoomIn = event.code === 'NumpadAdd' || event.key === 'Add';
+  const isNumpadZoomOut =
+    event.code === 'NumpadSubtract' || event.key === 'Subtract';
+  const isShiftZoomIn =
+    event.shiftKey &&
+    (event.code === 'Equal' || event.key === '+' || event.key === '=');
+  const isShiftZoomOut =
+    event.shiftKey &&
+    (event.code === 'Minus' ||
+      event.key === '-' ||
+      event.key === '_' ||
+      event.key === '−');
+
+  if (isNumpadZoomIn || isShiftZoomIn) {
     return 1;
   }
-  if (event.code === 'Minus') {
+  if (isNumpadZoomOut || isShiftZoomOut) {
     return -1;
   }
   return null;

--- a/src/tests/cameraZoomControls.test.ts
+++ b/src/tests/cameraZoomControls.test.ts
@@ -4,6 +4,7 @@ import {
   applyCameraZoomStep,
   applyPinchCameraZoom,
   applyWheelCameraZoomStep,
+  clampCameraZoom,
   getKeyboardZoomDirection,
   normalizeWheelDeltaY,
 } from '../systems/camera/zoomControls';
@@ -11,6 +12,12 @@ import {
 const bounds = { minZoom: 0.65, maxZoom: 12 } as const;
 
 describe('camera zoom controls', () => {
+  it('maps non-finite zoom values to safe bounds', () => {
+    expect(clampCameraZoom(Infinity, bounds)).toBe(bounds.maxZoom);
+    expect(clampCameraZoom(-Infinity, bounds)).toBe(bounds.minZoom);
+    expect(clampCameraZoom(Number.NaN, bounds)).toBe(bounds.minZoom);
+  });
+
   it('recognizes Shift+Equal and Shift+Minus from keyboard codes', () => {
     expect(
       getKeyboardZoomDirection(
@@ -27,6 +34,43 @@ describe('camera zoom controls', () => {
           code: 'Minus',
           key: '_',
           shiftKey: true,
+        })
+      )
+    ).toBe(-1);
+  });
+
+  it('recognizes layout-character and numpad zoom shortcuts', () => {
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'BracketRight',
+          key: '+',
+          shiftKey: true,
+        })
+      )
+    ).toBe(1);
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'Slash',
+          key: '-',
+          shiftKey: true,
+        })
+      )
+    ).toBe(-1);
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'NumpadAdd',
+          key: '+',
+        })
+      )
+    ).toBe(1);
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'NumpadSubtract',
+          key: '-',
         })
       )
     ).toBe(-1);

--- a/src/tests/cameraZoomControls.test.ts
+++ b/src/tests/cameraZoomControls.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyCameraZoomStep,
+  applyPinchCameraZoom,
+  applyWheelCameraZoomStep,
+  getKeyboardZoomDirection,
+  normalizeWheelDeltaY,
+} from '../systems/camera/zoomControls';
+
+const bounds = { minZoom: 0.65, maxZoom: 12 } as const;
+
+describe('camera zoom controls', () => {
+  it('recognizes Shift+Equal and Shift+Minus from keyboard codes', () => {
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'Equal',
+          key: '+',
+          shiftKey: true,
+        })
+      )
+    ).toBe(1);
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'Minus',
+          key: '_',
+          shiftKey: true,
+        })
+      )
+    ).toBe(-1);
+  });
+
+  it('ignores keyboard zoom shortcuts with text-entry focus or system modifiers', () => {
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'Equal',
+          shiftKey: true,
+          metaKey: true,
+        })
+      )
+    ).toBeNull();
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    let direction: 1 | -1 | null = null;
+    input.addEventListener('keydown', (event) => {
+      direction = getKeyboardZoomDirection(event);
+    });
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        code: 'Equal',
+        key: '+',
+        shiftKey: true,
+        bubbles: true,
+      })
+    );
+    expect(direction).toBeNull();
+    input.remove();
+  });
+
+  it('applies repeatable bounded keyboard zoom steps', () => {
+    const zoomedIn = applyCameraZoomStep({
+      currentZoomTarget: 6,
+      direction: 1,
+      source: 'keyboard',
+      ...bounds,
+    });
+    expect(zoomedIn).toBeGreaterThan(6);
+
+    const clampedIn = applyCameraZoomStep({
+      currentZoomTarget: 11.9,
+      direction: 1,
+      source: 'keyboard',
+      ...bounds,
+    });
+    expect(clampedIn).toBe(bounds.maxZoom);
+
+    const clampedOut = applyCameraZoomStep({
+      currentZoomTarget: 0.66,
+      direction: -1,
+      source: 'keyboard',
+      ...bounds,
+    });
+    expect(clampedOut).toBe(bounds.minZoom);
+  });
+
+  it('normalizes wheel delta modes and speeds up high-resolution trackpad deltas', () => {
+    expect(normalizeWheelDeltaY(3, WheelEvent.DOM_DELTA_LINE)).toBe(48);
+    expect(normalizeWheelDeltaY(1, WheelEvent.DOM_DELTA_PAGE, 720)).toBe(720);
+
+    const oldAdditiveTrackpadStep = 6 - 1 * 0.0018;
+    const next = applyWheelCameraZoomStep({
+      currentZoomTarget: 6,
+      deltaY: 1,
+      deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+      ...bounds,
+    });
+    expect(next).toBeLessThan(oldAdditiveTrackpadStep);
+    expect(next).toBeGreaterThan(bounds.minZoom);
+
+    const wheelNotch = applyWheelCameraZoomStep({
+      currentZoomTarget: 6,
+      deltaY: 120,
+      deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+      ...bounds,
+    });
+    expect(wheelNotch).toBeLessThan(6);
+    expect(wheelNotch).toBeGreaterThan(4);
+  });
+
+  it('keeps pinch zoom multiplicative and bounded', () => {
+    expect(
+      applyPinchCameraZoom({
+        startZoomTarget: 4,
+        startDistance: 100,
+        currentDistance: 150,
+        ...bounds,
+      })
+    ).toBe(6);
+    expect(
+      applyPinchCameraZoom({
+        startZoomTarget: 10,
+        startDistance: 100,
+        currentDistance: 200,
+        ...bounds,
+      })
+    ).toBe(bounds.maxZoom);
+    expect(
+      applyPinchCameraZoom({
+        startZoomTarget: 1,
+        startDistance: 100,
+        currentDistance: 10,
+        ...bounds,
+      })
+    ).toBe(bounds.minZoom);
+  });
+});

--- a/src/tests/controlOverlay.test.ts
+++ b/src/tests/controlOverlay.test.ts
@@ -13,6 +13,10 @@ describe('applyControlOverlayStrings', () => {
           <span class="overlay__keys">Keys</span>
           <span class="overlay__description">Move</span>
         </li>
+        <li class="overlay__item" data-control-item="keyboardZoom">
+          <span class="overlay__keys">Keys</span>
+          <span class="overlay__description">Zoom</span>
+        </li>
         <li
           class="overlay__item"
           data-control-item="interact"
@@ -45,6 +49,11 @@ describe('applyControlOverlayStrings', () => {
       '[data-control-item="keyboardMove"] .overlay__keys'
     );
     expect(keyboardItem?.textContent).toBe(strings.items.keyboardMove.keys);
+
+    const zoomItem = container.querySelector(
+      '[data-control-item="keyboardZoom"] .overlay__keys'
+    );
+    expect(zoomItem?.textContent).toBe(strings.items.keyboardZoom.keys);
 
     const interactLabel = container.querySelector(
       '[data-role="interact-label"]'

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -244,12 +244,26 @@ describe('i18n utilities', () => {
     expect(pseudoOverlay.items.keyboardMove.keys).toBe(
       englishOverlay.items.keyboardMove.keys
     );
+    expect(englishOverlay.items.keyboardZoom.keys).toBe(
+      'Shift + = / Shift + -'
+    );
+    expect(arabicOverlay.items.keyboardZoom.description).toContain(
+      'لوحة المفاتيح'
+    );
+    expect(japaneseOverlay.items.keyboardZoom.description).toContain(
+      'キーボード'
+    );
     const helpModal = getHelpModalStrings('en-x-pseudo');
     expect(helpModal.closeLabel).toBe('⟦Close⟧');
     expect(helpModal.announcements.open).toBe(
       '⟦Help menu opened. Review controls and settings.⟧'
     );
     expect(helpModal.announcements.close).toBe('⟦Help menu closed.⟧');
+    expect(
+      helpModal.sections
+        .find((section) => section.id === 'movement')
+        ?.items.some((item) => item.label.includes('Shift + ='))
+    ).toBe(true);
     const arabicHelp = getHelpModalStrings('ar');
     expect(arabicHelp.heading).toBe('الإعدادات والمساعدة');
     expect(arabicHelp.announcements.open).toBe(

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -274,6 +274,17 @@ describe('i18n utilities', () => {
     expect(japaneseHelp.announcements.close).toBe(
       'ヘルプメニューを閉じました。'
     );
+
+    const spanishHelp = getHelpModalStrings('es');
+    expect(spanishHelp.sections[0]?.title).toBe('Movimiento y cámara');
+    expect(spanishHelp.sections[0]?.items[3]?.description).toBe(
+      'Acerca o aleja sin rueda de ratón.'
+    );
+    const germanHelp = getHelpModalStrings('de');
+    expect(germanHelp.sections[2]?.title).toBe('Barrierefreiheit & Fallback');
+    expect(germanHelp.sections[2]?.items[3]?.description).toBe(
+      'Schalte mit der Audio-Schaltfläche um oder drücke M.'
+    );
   });
 
   it('returns localized POI overlay chrome strings', () => {

--- a/src/tests/keyBindings.test.ts
+++ b/src/tests/keyBindings.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { getKeyboardZoomDirection } from '../systems/camera/zoomControls';
+import {
+  DEFAULT_KEY_BINDINGS,
+  KeyBindings,
+  formatKeyLabel,
+} from '../systems/controls/keyBindings';
+
+describe('KeyBindings', () => {
+  it('keeps movement and HUD defaults while keyboard zoom uses code-based shortcuts', () => {
+    const keyBindings = new KeyBindings();
+
+    expect(keyBindings.getBindings('moveForward')).toEqual(
+      DEFAULT_KEY_BINDINGS.moveForward
+    );
+    expect(keyBindings.getBindings('toggleControls')).toEqual(['c']);
+    expect(formatKeyLabel(keyBindings.getPrimaryBinding('help'))).toBe('H');
+
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'Equal',
+          key: '+',
+          shiftKey: true,
+        })
+      )
+    ).toBe(1);
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'Minus',
+          key: '_',
+          shiftKey: true,
+        })
+      )
+    ).toBe(-1);
+  });
+});

--- a/src/tests/keyBindings.test.ts
+++ b/src/tests/keyBindings.test.ts
@@ -35,5 +35,13 @@ describe('KeyBindings', () => {
         })
       )
     ).toBe(-1);
+    expect(
+      getKeyboardZoomDirection(
+        new KeyboardEvent('keydown', {
+          code: 'NumpadAdd',
+          key: '+',
+        })
+      )
+    ).toBe(1);
   });
 });

--- a/src/tests/responsiveControlOverlay.test.ts
+++ b/src/tests/responsiveControlOverlay.test.ts
@@ -13,6 +13,7 @@ const createStrings = (heading = 'Controls'): ControlOverlayStrings => ({
     keyboardMove: { keys: 'WASD / Arrow keys', description: 'Move' },
     pointerDrag: { keys: 'Left mouse button', description: 'Drag to pan' },
     pointerZoom: { keys: 'Scroll wheel', description: 'Zoom' },
+    keyboardZoom: { keys: 'Shift + = / Shift + -', description: 'Zoom' },
     touchDrag: { keys: 'Touch', description: 'Drag to move and pan' },
     touchPinch: { keys: 'Pinch', description: 'Zoom' },
     cyclePoi: { keys: 'Q / E', description: 'Cycle POIs' },

--- a/src/ui/hud/controlOverlay.ts
+++ b/src/ui/hud/controlOverlay.ts
@@ -65,6 +65,7 @@ export function applyControlOverlayStrings(
   applyItem('keyboardMove');
   applyItem('pointerDrag');
   applyItem('pointerZoom');
+  applyItem('keyboardZoom');
   applyItem('touchDrag');
   applyItem('touchPinch');
   applyItem('cyclePoi');


### PR DESCRIPTION
### Motivation
- Make zooming usable for keyboard-only users by adding Shift + = / Shift + - shortcuts and avoid reliance on mouse wheels. 
- Improve MacBook trackpad responsiveness because the previous additive wheel delta felt too slow while keeping touch pinch behavior unchanged. 
- Centralize zoom math so keyboard, wheel, and pinch share bounded, consistent behavior.

### Description
- Introduce a shared camera zoom helper module `src/systems/camera/zoomControls.ts` that provides `applyCameraZoomStep`, `applyWheelCameraZoomStep`, `applyPinchCameraZoom`, `getKeyboardZoomDirection`, and normalization utilities. 
- Wire keyboard zoom into the immersive scene using `getKeyboardZoomDirection` and `applyCameraZoomStep` in `src/main.ts`, and replace the old additive wheel handler with `applyWheelCameraZoomStep` while preserving the touch pinch multiplicative path via `applyPinchCameraZoom`. 
- Document the new shortcuts in the HUD and Settings/help: add a keyboard row to the control overlay (`index.html`, `src/ui/hud/controlOverlay.ts`) and localized strings across supported locales (`src/assets/i18n/locales/*`) including pseudo-locale. 
- Add unit tests and integration checks: `src/tests/cameraZoomControls.test.ts`, `src/tests/keyBindings.test.ts`, and update HUD/i18n tests; extend Playwright coverage in `playwright/immersive-zoom.spec.ts` to assert keyboard zoom and text-entry ignore behavior.

### Testing
- Ran formatting and linting with `npm run format:write` (passed) and `npm run lint` (passed with warnings only). 
- Ran type checking with `npm run typecheck` which failed due to pre-existing, repository-wide TypeScript issues unrelated to the zoom helpers (the zoom code itself types cleanly). 
- Ran focused unit tests with `npm run test:ci -- src/tests/keyBindings.test.ts src/tests/controlOverlayAccessibility.test.ts src/tests/i18n.test.ts` and full test suite with `npm run test:ci`; both completed successfully (`vitest` reports passing test files). 
- Built and smoke-checked the app with `npm run build` and `npm run smoke` (both passed). 
- Executed Playwright e2e via `npm run test:e2e -- playwright/immersive-zoom.spec.ts playwright/small-screen-hud.spec.ts`; the run initially failed due to missing Playwright browsers and host dependencies, then `npx playwright install chromium` and required system libraries were installed and the e2e suite passed (all Playwright tests in the targeted specs passed). 

Notes: `npm run typecheck` still surfaces unrelated TS errors elsewhere in the repo; those pre-existing issues were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ebdef1ac832fa5c6157b7a41df8c)