### PR TITLE
Make audio mute global and hard-stop runtime audio

### DIFF
--- a/docs/architecture/accessibility-presets.md
+++ b/docs/architecture/accessibility-presets.md
@@ -182,6 +182,13 @@ This allows fine-grained control without requiring preset switches. For example,
 the `calm` preset can further reduce volume to 0.5 by setting `baseAudioVolume = 0.625`
 (0.625 × 0.8 = 0.5).
 
+Mute state is intentionally separate from base volume. Fresh immersive sessions default to
+`Audio: Off` using the `danielsmith.io::ambientAudioEnabled::v2` key; legacy v1 `true` values are
+not treated as consent. While muted, presets and slider changes may update the remembered base
+volume, but they must not restart ambient beds, footstep audio, or ambient captions. Staging
+verification can inspect `window.portfolio.audio.getState()` for the active storage key, ambient
+source playback, bed volumes, footstep state, master/base volume, and browser audio context state.
+
 ## Acceptance Criteria & Manual Testing
 
 ### Testing Standard Preset

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -22,10 +22,29 @@ type ElementBounds = {
   height: number;
 };
 
+type AudioDebugState = {
+  preferenceEnabled: boolean;
+  ambientEnabled: boolean;
+  ambientSourcesPlaying: { count: number; ids: string[] };
+  ambientBedVolumes: Array<{
+    id: string;
+    currentVolume: number;
+    targetVolume: number;
+    isPlaying: boolean;
+  }>;
+  footstepEnabled: boolean;
+  footstepPlaying: boolean;
+  activeStorageKey: string;
+  storageKeyVersion: string;
+};
+
 type PortfolioPoiWindow = Window & {
   portfolio?: {
     poi?: {
       getTooltipState?: () => PoiTooltipState;
+    };
+    audio?: {
+      getState?: () => AudioDebugState;
     };
   };
 };
@@ -71,6 +90,18 @@ async function waitForImmersiveReady(page: Page) {
   await page.waitForFunction(
     () => (window as PortfolioPoiWindow).portfolio?.poi?.getTooltipState
   );
+}
+
+async function getAudioDebugState(page: Page): Promise<AudioDebugState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioPoiWindow).portfolio?.audio?.getState;
+
+    if (!getState) {
+      throw new Error('window.portfolio.audio.getState() is unavailable');
+    }
+
+    return getState();
+  });
 }
 
 async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
@@ -232,6 +263,65 @@ test.describe('small-screen HUD regression coverage', () => {
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
       await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
       await expect(settingsButton).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('keeps global audio muted by default and after legacy storage opt-in', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        window.localStorage.setItem(
+          'danielsmith.io::ambientAudioEnabled::v1',
+          '1'
+        );
+        window.localStorage.removeItem(
+          'danielsmith.io::ambientAudioEnabled::v2'
+        );
+      });
+
+      await waitForImmersiveReady(page);
+      await page.keyboard.press('Space');
+
+      await expect
+        .poll(async () => getAudioDebugState(page), { timeout: 5_000 })
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlaying: { count: 0, ids: [] },
+          footstepEnabled: false,
+          footstepPlaying: false,
+          activeStorageKey: 'danielsmith.io::ambientAudioEnabled::v2',
+          storageKeyVersion: 'v2',
+        });
+
+      const offState = await getAudioDebugState(page);
+      expect(offState.ambientBedVolumes.every((bed) => !bed.isPlaying)).toBe(
+        true
+      );
+      expect(
+        offState.ambientBedVolumes.every(
+          (bed) => bed.currentVolume === 0 && bed.targetVolume === 0
+        )
+      ).toBe(true);
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => getAudioDebugState(page), { timeout: 5_000 })
+        .toMatchObject({
+          preferenceEnabled: true,
+          ambientEnabled: true,
+          footstepEnabled: true,
+        });
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => getAudioDebugState(page), { timeout: 5_000 })
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlaying: { count: 0, ids: [] },
+          footstepEnabled: false,
+          footstepPlaying: false,
+        });
     });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,7 @@ import {
   type AmbientAudioSource,
 } from './systems/audio/ambientAudio';
 import {
+  AMBIENT_AUDIO_STORAGE_KEY,
   AmbientAudioPreference,
   bindAmbientAudioPreference,
   type AmbientAudioPreferenceBindingHandle,
@@ -475,6 +476,26 @@ declare global {
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
+      audio?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          ambientEnabled: boolean;
+          ambientSourcesPlaying: { count: number; ids: string[] };
+          ambientBedVolumes: Array<{
+            id: string;
+            currentVolume: number;
+            targetVolume: number;
+            isPlaying: boolean;
+          }>;
+          footstepEnabled: boolean;
+          footstepPlaying: boolean;
+          masterVolume: number;
+          baseVolume: number;
+          audioContextState: AudioContextState | 'unknown';
+          storageKeyVersion: string;
+          activeStorageKey: string;
+        };
       };
       graphics?: {
         getMotionBlurIntensity(): number;
@@ -1022,6 +1043,42 @@ function initializeImmersiveScene(
     ambientAudioController?.getMasterVolume() ?? 1;
   let setAmbientAudioVolume = (volume: number) => {
     ambientAudioController?.setMasterVolume(volume);
+  };
+  let globalAudioEnabled = false;
+
+  const stopFootstepAudio = () => {
+    if (!footstepAudio) {
+      return;
+    }
+    footstepAudio.setVolume(0);
+    if (footstepAudio.isPlaying) {
+      footstepAudio.stop();
+    }
+  };
+
+  const clearAudioCaptions = () => {
+    audioSubtitles?.clear();
+  };
+
+  const globalAudioController = {
+    isEnabled: () => globalAudioEnabled,
+    enable: async () => {
+      if (!ambientAudioController) {
+        return;
+      }
+      await ambientAudioController.enable();
+      globalAudioEnabled = true;
+      footstepAudioController?.setEnabled(true);
+      audioHudHandle?.refresh();
+    },
+    disable: () => {
+      globalAudioEnabled = false;
+      ambientAudioController?.disable();
+      footstepAudioController?.setEnabled(false);
+      stopFootstepAudio();
+      clearAudioCaptions();
+      audioHudHandle?.refresh();
+    },
   };
 
   let localeStorage: Storage | undefined;
@@ -2392,8 +2449,6 @@ function initializeImmersiveScene(
   footstepAudioNode.setBuffer(footstepSample);
   if (footstepStereoPanner) {
     footstepAudioNode.setFilter(footstepStereoPanner);
-  } else {
-    footstepAudioNode.setFilter(null);
   }
   player.add(footstepAudioNode);
   footstepAudio = footstepAudioNode;
@@ -2401,6 +2456,10 @@ function initializeImmersiveScene(
   footstepAudioController = createFootstepAudioController({
     player: {
       play: ({ volume, playbackRate, pan }) => {
+        if (!globalAudioEnabled) {
+          stopFootstepAudio();
+          return;
+        }
         const clampedVolume = MathUtils.clamp(volume, 0, 1);
         const clampedRate = MathUtils.clamp(playbackRate, 0.25, 3);
         if (footstepStereoPanner && typeof pan === 'number') {
@@ -2418,6 +2477,7 @@ function initializeImmersiveScene(
         }
         footstepAudioNode.play();
       },
+      stop: stopFootstepAudio,
     },
     maxLinearSpeed: PLAYER_SPEED,
     minActivationSpeed: PLAYER_SPEED * 0.12,
@@ -2425,6 +2485,7 @@ function initializeImmersiveScene(
     volumeRange: { min: 0.32, max: 0.7 },
     pitchRange: { min: 0.88, max: 1.18 },
     stereoSeparation: 0.22,
+    enabled: false,
   });
 
   const mannequinMixer = new AnimationMixer(player);
@@ -3650,7 +3711,7 @@ function initializeImmersiveScene(
       ambientAudioPreferenceBinding = null;
     }
     ambientAudioPreferenceBinding = bindAmbientAudioPreference({
-      controller: ambientAudioController,
+      controller: globalAudioController,
       preference: ambientAudioPreference,
       windowTarget: window,
       logger: console,
@@ -3665,22 +3726,9 @@ function initializeImmersiveScene(
 
     audioHudHandle = createAudioHudControl({
       container: hudSettingsStack,
-      getEnabled: () => ambientAudioController?.isEnabled() ?? false,
+      getEnabled: () => globalAudioController.isEnabled(),
       setEnabled: async (enabled) => {
-        if (!ambientAudioController) {
-          return;
-        }
-        if (enabled) {
-          try {
-            await ambientAudioController.enable();
-            ambientAudioPreference?.setEnabled(true, 'control');
-          } catch (error) {
-            console.warn('Ambient audio failed to start', error);
-          }
-        } else {
-          ambientAudioController.disable();
-          ambientAudioPreference?.setEnabled(false, 'control');
-        }
+        ambientAudioPreference?.setEnabled(enabled, 'control');
       },
       getVolume: () => getAmbientAudioVolume(),
       setVolume: (volume) => {
@@ -3689,6 +3737,40 @@ function initializeImmersiveScene(
       strings: audioHudStrings,
     });
     registerHudControlElement(audioHudHandle?.element);
+
+    const portfolioWindow = window as Window;
+    if (!portfolioWindow.portfolio) {
+      portfolioWindow.portfolio = {};
+    }
+    portfolioWindow.portfolio.audio = {
+      getState: () => {
+        const bedSnapshots = ambientAudioController?.getBedSnapshots() ?? [];
+        const ambientSourcesPlaying = bedSnapshots
+          .filter((snapshot) => snapshot.definition.source.isPlaying)
+          .map((snapshot) => snapshot.id);
+        return {
+          preferenceEnabled: ambientAudioPreference?.isEnabled() ?? false,
+          ambientEnabled: ambientAudioController?.isEnabled() ?? false,
+          ambientSourcesPlaying: {
+            count: ambientSourcesPlaying.length,
+            ids: ambientSourcesPlaying,
+          },
+          ambientBedVolumes: bedSnapshots.map((snapshot) => ({
+            id: snapshot.id,
+            currentVolume: snapshot.currentVolume,
+            targetVolume: snapshot.targetVolume,
+            isPlaying: snapshot.definition.source.isPlaying,
+          })),
+          footstepEnabled: footstepAudioController?.isEnabled() ?? false,
+          footstepPlaying: footstepAudio?.isPlaying ?? false,
+          masterVolume: ambientAudioController?.getMasterVolume() ?? 1,
+          baseVolume: getAmbientAudioVolume(),
+          audioContextState: audioContext.state ?? 'unknown',
+          storageKeyVersion: 'v2',
+          activeStorageKey: AMBIENT_AUDIO_STORAGE_KEY,
+        };
+      },
+    };
 
     manualModeToggle = createManualModeToggle({
       container: hudSettingsStack,
@@ -4764,6 +4846,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.githubMetrics) {
       delete window.portfolio.githubMetrics;
+    }
+    if (window.portfolio?.audio) {
+      delete window.portfolio.audio;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/systems/audio/ambientAudio.ts
+++ b/src/systems/audio/ambientAudio.ts
@@ -164,15 +164,15 @@ export class AmbientAudioController {
   }
 
   disable(): void {
-    if (!this.enabled) {
-      return;
-    }
     this.enabled = false;
     this.elapsedTime = 0;
     this.beds.forEach((bed) => {
       bed.currentVolume = 0;
-      bed.definition.source.setVolume(0);
       bed.targetVolume = 0;
+      bed.definition.source.setVolume(0);
+      if (bed.definition.source.isPlaying) {
+        bed.definition.source.stop();
+      }
     });
   }
 

--- a/src/systems/audio/ambientAudioPreference.ts
+++ b/src/systems/audio/ambientAudioPreference.ts
@@ -25,7 +25,8 @@ export interface AmbientAudioPreferenceBindingHandle {
   dispose(): void;
 }
 
-const DEFAULT_STORAGE_KEY = 'danielsmith.io::ambientAudioEnabled::v1';
+export const AMBIENT_AUDIO_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v2';
 
 const parseStoredValue = (value: string | null): boolean | null => {
   if (value === '1' || value === 'true') {
@@ -86,7 +87,7 @@ export class AmbientAudioPreference {
       options.storage === undefined
         ? getDefaultStorage(this.windowTarget)
         : options.storage;
-    this.storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
+    this.storageKey = options.storageKey ?? AMBIENT_AUDIO_STORAGE_KEY;
     this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
 
     if (this.windowTarget) {
@@ -103,6 +104,10 @@ export class AmbientAudioPreference {
     source: AmbientAudioPreferenceChangeSource = 'control'
   ): void {
     if (this.enabled === enabled) {
+      this.persist();
+      if (source === 'control') {
+        this.notify(source);
+      }
       return;
     }
     this.enabled = enabled;
@@ -256,17 +261,19 @@ export const bindAmbientAudioPreference = ({
       return;
     }
     if (change.enabled) {
-      if (change.source === 'control' || controller.isEnabled()) {
+      if (controller.isEnabled()) {
         clearGestureListeners();
+        return;
+      }
+      if (change.source === 'control') {
+        clearGestureListeners();
+        void attemptEnable();
         return;
       }
       scheduleGestureListeners();
       return;
     }
     clearGestureListeners();
-    if (change.source === 'control' || !controller.isEnabled()) {
-      return;
-    }
     controller.disable();
   };
 

--- a/src/systems/audio/footstepController.ts
+++ b/src/systems/audio/footstepController.ts
@@ -6,6 +6,7 @@ export interface FootstepPlaybackOptions {
 
 export interface FootstepPlayer {
   play(options: FootstepPlaybackOptions): void;
+  stop?(): void;
 }
 
 export interface FootstepControllerOptions {
@@ -29,6 +30,8 @@ export interface FootstepControllerOptions {
   pitchJitter?: number;
   /** Optional deterministic random generator returning values in [0, 1). */
   random?: () => number;
+  /** Whether footstep generation starts enabled. Defaults to true. */
+  enabled?: boolean;
 }
 
 export interface FootstepControllerUpdate {
@@ -101,7 +104,7 @@ export function createFootstepAudioController(
     maxLinearSpeed - 1e-3
   );
 
-  let enabled = true;
+  let enabled = options.enabled ?? true;
   let timeUntilNextStep = 0;
   let lastFoot: FootLabel = 'right';
   let lastNormalizedSpeed = 0;
@@ -246,6 +249,7 @@ export function createFootstepAudioController(
         timeUntilNextStep = 0;
         lastNormalizedSpeed = 0;
         lastGrounded = true;
+        options.player.stop?.();
       }
     },
     isEnabled() {
@@ -255,6 +259,7 @@ export function createFootstepAudioController(
       enabled = false;
       timeUntilNextStep = 0;
       lastNormalizedSpeed = 0;
+      options.player.stop?.();
     },
   };
 }

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -101,6 +101,27 @@ describe('AmbientAudioController', () => {
     expect(source.volumes.at(-1)).toBe(0);
   });
 
+  it('hard-disables playback by stopping sources and zeroing volumes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    expect(source.isPlaying).toBe(true);
+    expect(source.volumes.at(-1)).toBeGreaterThan(0);
+
+    controller.disable();
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0]?.currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0]?.targetVolume).toBe(0);
+
+    await controller.enable();
+    expect(source.isPlaying).toBe(true);
+  });
+
   it('stops playback when disposed', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  AMBIENT_AUDIO_STORAGE_KEY,
   AmbientAudioPreference,
   type AmbientAudioPreferenceChange,
 } from '../systems/audio/ambientAudioPreference';
@@ -63,6 +64,33 @@ describe('AmbientAudioPreference', () => {
     const preference = new AmbientAudioPreference({
       storage,
       storageKey: 'test::preference',
+      defaultEnabled: false,
+    });
+
+    expect(preference.isEnabled()).toBe(true);
+  });
+
+  it('uses the v2 storage key and ignores legacy v1 true opt-in', () => {
+    const storage = new MemoryStorage();
+    storage.setItem('danielsmith.io::ambientAudioEnabled::v1', '1');
+
+    const preference = new AmbientAudioPreference({
+      storage,
+      defaultEnabled: false,
+    });
+
+    expect(AMBIENT_AUDIO_STORAGE_KEY).toBe(
+      'danielsmith.io::ambientAudioEnabled::v2'
+    );
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors explicit opt-in stored under the v2 key', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({
+      storage,
       defaultEnabled: false,
     });
 

--- a/src/tests/ambientAudioPreferenceBinding.test.ts
+++ b/src/tests/ambientAudioPreferenceBinding.test.ts
@@ -120,7 +120,7 @@ describe('bindAmbientAudioPreference', () => {
     binding.dispose();
   });
 
-  it('ignores control-sourced changes because the UI already applied them', async () => {
+  it('uses control-sourced changes to drive the same controller path', async () => {
     const windowStub = new EventTarget();
     const preference = new AmbientAudioPreference({
       windowTarget: windowStub as unknown as Window,
@@ -135,16 +135,15 @@ describe('bindAmbientAudioPreference', () => {
       logger: { warn: vi.fn() },
     });
 
-    await controller.enable();
     preference.setEnabled(true, 'control');
-
-    windowStub.dispatchEvent(new Event('pointerdown'));
     await Promise.resolve();
 
     expect(controller.enableMock).toHaveBeenCalledTimes(1);
+    expect(controller.isEnabled()).toBe(true);
 
     preference.setEnabled(false, 'control');
-    expect(controller.disableMock).not.toHaveBeenCalled();
+    expect(controller.disableMock).toHaveBeenCalledTimes(2);
+    expect(controller.isEnabled()).toBe(false);
 
     binding.dispose();
   });
@@ -168,7 +167,7 @@ describe('bindAmbientAudioPreference', () => {
     await controller.enable();
     preference.setEnabled(false, 'storage');
 
-    expect(controller.disableMock).toHaveBeenCalledTimes(1);
+    expect(controller.disableMock).toHaveBeenCalledTimes(2);
 
     binding.dispose();
   });

--- a/src/tests/footstepAudioController.test.ts
+++ b/src/tests/footstepAudioController.test.ts
@@ -9,8 +9,14 @@ import {
 class StubFootstepPlayer {
   public readonly calls: FootstepPlaybackOptions[] = [];
 
+  public stopCount = 0;
+
   play(options: FootstepPlaybackOptions): void {
     this.calls.push(options);
+  }
+
+  stop(): void {
+    this.stopCount += 1;
   }
 }
 
@@ -81,6 +87,30 @@ describe('footstep audio controller', () => {
     controller.update({ delta: 0.2, linearSpeed: 4, isGrounded: false });
     controller.update({ delta: 0.4, linearSpeed: 4, isGrounded: true });
     expect(player.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('can start disabled and stops active playback when muted', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player, {
+      enabled: false,
+      random: () => 0.5,
+    });
+
+    expect(controller.isEnabled()).toBe(false);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('left');
+    expect(player.calls).toHaveLength(0);
+
+    controller.setEnabled(true);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    expect(player.calls.length).toBeGreaterThan(0);
+
+    controller.setEnabled(false);
+    const callsAfterMute = player.calls.length;
+    expect(player.stopCount).toBe(1);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('right');
+    expect(player.calls).toHaveLength(callsAfterMute);
   });
 
   it('scales cadence, volume, and pitch with speed and master volume', () => {


### PR DESCRIPTION
### Motivation
- A global audio mute was needed so "Audio: Off" is a real runtime kill switch (not just a UI label) and legacy v1 opt-in can’t auto-resume sound on hard reloads.
- Settings / M-key, ambient beds, footsteps, and subtitle captions must be driven from a single source of truth to avoid split-brain behavior and reliably silence all audio at runtime.

### Description
- Introduce a single global audio controller in `src/main.ts` that routes HUD toggles, the `M` key, `bindAmbientAudioPreference`, ambient controller, and footstep controller through one path, plus `window.portfolio.audio.getState()` for runtime debugging/verification.
- Move persisted opt-in to a new storage key `danielsmith.io::ambientAudioEnabled::v2` (exported as `AMBIENT_AUDIO_STORAGE_KEY`) and treat missing v2 as `false`, so legacy `v1: true` does not auto-enable audio.
- Make ambient audio disable a hard mute by zeroing bed volumes and stopping loop sources in `AmbientAudioController.disable()` and keep `enable()` able to restart playback safely.
- Ensure footstep controller can start disabled and that disabling stops any playing footstep audio; add an optional `stop()` to the `FootstepPlayer` interface and wire the player to call it when muted.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully.
- Ran focused unit tests with `npm run test:ci -- src/tests/ambientAudioPreference.test.ts src/tests/ambientAudioPreferenceBinding.test.ts src/tests/ambientAudioController.test.ts src/tests/footstepAudioController.test.ts`, and all targeted tests passed.
- Ran the full Vitest suite with `npm run test:ci`, and the repo test run completed successfully (all suites passed in CI run observed); the added audio tests passed in that run.
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`, both succeeded.
- Ran Playwright E2E for the small-screen HUD spec with `npm run test:e2e -- playwright/small-screen-hud.spec.ts`; initial runs required installing Playwright browsers and deps which were installed during the run, and the spec passed after that setup.
- Ran the repository secret scan (`git diff --cached | ./scripts/scan-secrets.py`) and it reported no high-risk secrets.
- Type-checking with `npm run typecheck` still fails due to pre-existing, repo-wide TypeScript issues unrelated to this change (notably several unrelated test/type incompatibilities and an unrelated `listAccessories` typing mismatch); these errors were observed and are noted for follow-up but are not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2130f15f78832fadf89a13017979c3)