### PR TITLE
🔇 Hard mute runtime audio by default

### DIFF
--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -22,8 +22,29 @@ type ElementBounds = {
   height: number;
 };
 
+type AudioDebugState = {
+  preferenceEnabled: boolean;
+  ambientEnabled: boolean;
+  ambientSourcesPlaying: { count: number; ids: string[] };
+  ambientBedVolumes: Array<{
+    id: string;
+    currentVolume: number;
+    targetVolume: number;
+  }>;
+  footstepEnabled: boolean;
+  footstepPlaying: boolean;
+  masterVolume: number;
+  baseVolume: number;
+  audioContextState: string | null;
+  storageKeyVersion: 'v2';
+  activeStorageKey: string;
+};
+
 type PortfolioPoiWindow = Window & {
   portfolio?: {
+    audio?: {
+      getState?: () => AudioDebugState;
+    };
     poi?: {
       getTooltipState?: () => PoiTooltipState;
     };
@@ -71,6 +92,21 @@ async function waitForImmersiveReady(page: Page) {
   await page.waitForFunction(
     () => (window as PortfolioPoiWindow).portfolio?.poi?.getTooltipState
   );
+  await page.waitForFunction(
+    () => (window as PortfolioPoiWindow).portfolio?.audio?.getState
+  );
+}
+
+async function getAudioState(page: Page): Promise<AudioDebugState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioPoiWindow).portfolio?.audio?.getState;
+
+    if (!getState) {
+      throw new Error('window.portfolio.audio.getState() is unavailable');
+    }
+
+    return getState();
+  });
 }
 
 async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
@@ -232,6 +268,73 @@ test.describe('small-screen HUD regression coverage', () => {
       await expect(controlsButton).toHaveAttribute('aria-pressed', 'false');
       await expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
       await expect(settingsButton).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('keeps global audio off by default and hard-mutes runtime sources', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        localStorage.setItem('danielsmith.io::ambientAudioEnabled::v1', '1');
+        localStorage.removeItem('danielsmith.io::ambientAudioEnabled::v2');
+      });
+      await waitForImmersiveReady(page);
+
+      await page.mouse.click(20, 20);
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          footstepEnabled: false,
+          footstepPlaying: false,
+          storageKeyVersion: 'v2',
+        });
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: true,
+          ambientEnabled: true,
+          footstepEnabled: true,
+        });
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          footstepEnabled: false,
+          footstepPlaying: false,
+          ambientSourcesPlaying: { count: 0 },
+        });
+      const mutedState = await getAudioState(page);
+      expect(mutedState.ambientBedVolumes).not.toHaveLength(0);
+      expect(
+        mutedState.ambientBedVolumes.every(
+          ({ currentVolume, targetVolume }) =>
+            currentVolume === 0 && targetVolume === 0
+        )
+      ).toBe(true);
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await page.waitForFunction(
+        () => document.documentElement.dataset.appMode === 'immersive',
+        undefined,
+        { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+      );
+      await page.waitForFunction(
+        () => (window as PortfolioPoiWindow).portfolio?.audio?.getState
+      );
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          footstepEnabled: false,
+          ambientSourcesPlaying: { count: 0 },
+        });
     });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,7 @@ import {
   type AmbientAudioSource,
 } from './systems/audio/ambientAudio';
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
   bindAmbientAudioPreference,
   type AmbientAudioPreferenceBindingHandle,
@@ -475,6 +476,25 @@ declare global {
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
+      audio?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          ambientEnabled: boolean;
+          ambientSourcesPlaying: { count: number; ids: string[] };
+          ambientBedVolumes: Array<{
+            id: string;
+            currentVolume: number;
+            targetVolume: number;
+          }>;
+          footstepEnabled: boolean;
+          footstepPlaying: boolean;
+          masterVolume: number;
+          baseVolume: number;
+          audioContextState: string | null;
+          storageKeyVersion: 'v2';
+          activeStorageKey: string;
+        };
       };
       graphics?: {
         getMotionBlurIntensity(): number;
@@ -1023,6 +1043,7 @@ function initializeImmersiveScene(
   let setAmbientAudioVolume = (volume: number) => {
     ambientAudioController?.setMasterVolume(volume);
   };
+  let runtimeAudioEnabled = false;
 
   let localeStorage: Storage | undefined;
   try {
@@ -1041,6 +1062,107 @@ function initializeImmersiveScene(
       ambientAudioStorage = undefined;
     }
   }
+
+  const ensureAmbientAudioPreference = (): AmbientAudioPreference => {
+    if (!ambientAudioPreference) {
+      ambientAudioPreference = new AmbientAudioPreference({
+        storage: ambientAudioStorage ?? null,
+        windowTarget: window,
+      });
+    }
+    return ambientAudioPreference;
+  };
+
+  const stopFootstepAudio = () => {
+    if (footstepAudio?.isPlaying) {
+      footstepAudio.stop();
+    }
+    footstepAudio?.setVolume(0);
+  };
+
+  const clearAmbientCaptions = () => {
+    ambientCaptionBridge?.clear();
+    const currentCaption = audioSubtitles?.getCurrent();
+    if (currentCaption?.source === 'ambient') {
+      audioSubtitles?.clear(currentCaption.id);
+    }
+  };
+
+  const disableRuntimeAudio = (persist: boolean) => {
+    ambientAudioController?.disable();
+    footstepAudioController?.setEnabled(false);
+    stopFootstepAudio();
+    clearAmbientCaptions();
+    runtimeAudioEnabled = false;
+    if (persist) {
+      ensureAmbientAudioPreference().setEnabled(false, 'control');
+    }
+    audioHudHandle?.refresh();
+  };
+
+  const setRuntimeAudioEnabled = async (enabled: boolean, persist = true) => {
+    if (!enabled) {
+      disableRuntimeAudio(persist);
+      return;
+    }
+
+    if (!ambientAudioController) {
+      return;
+    }
+
+    try {
+      await ambientAudioController.enable();
+      footstepAudioController?.setEnabled(true);
+      runtimeAudioEnabled = true;
+      if (persist) {
+        ensureAmbientAudioPreference().setEnabled(true, 'control');
+      }
+    } catch (error) {
+      disableRuntimeAudio(false);
+      throw error;
+    } finally {
+      audioHudHandle?.refresh();
+    }
+  };
+
+  const ensureAudioDebugApi = () => {
+    const portfolioWindow = window as Window;
+    if (!portfolioWindow.portfolio) {
+      portfolioWindow.portfolio = {};
+    }
+    portfolioWindow.portfolio.audio = {
+      getState() {
+        const snapshots = ambientAudioController?.getBedSnapshots() ?? [];
+        const playingIds = snapshots
+          .filter((snapshot) => snapshot.definition.source.isPlaying)
+          .map((snapshot) => snapshot.id);
+        const baseVolume =
+          accessibilityPresetManager?.getBaseAudioVolume() ??
+          ambientAudioController?.getMasterVolume() ??
+          1;
+        return {
+          preferenceEnabled: ambientAudioPreference?.isEnabled() ?? false,
+          ambientEnabled: ambientAudioController?.isEnabled() ?? false,
+          ambientSourcesPlaying: {
+            count: playingIds.length,
+            ids: playingIds,
+          },
+          ambientBedVolumes: snapshots.map((snapshot) => ({
+            id: snapshot.id,
+            currentVolume: snapshot.currentVolume,
+            targetVolume: snapshot.targetVolume,
+          })),
+          footstepEnabled: footstepAudioController?.isEnabled() ?? false,
+          footstepPlaying: footstepAudio?.isPlaying ?? false,
+          masterVolume: ambientAudioController?.getMasterVolume() ?? 1,
+          baseVolume,
+          audioContextState: audioListener.context.state ?? null,
+          storageKeyVersion: 'v2' as const,
+          activeStorageKey: AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
+        };
+      },
+    };
+  };
 
   inputLatencyTelemetry = createInputLatencyTelemetry({
     windowTarget: window,
@@ -1243,6 +1365,7 @@ function initializeImmersiveScene(
   );
   const audioListener = new AudioListener();
   camera.add(audioListener);
+  ensureAudioDebugApi();
   const cameraBaseOffset = new Vector3(
     baseCameraSize * 1.06,
     baseCameraSize * 1.08,
@@ -2392,11 +2515,10 @@ function initializeImmersiveScene(
   footstepAudioNode.setBuffer(footstepSample);
   if (footstepStereoPanner) {
     footstepAudioNode.setFilter(footstepStereoPanner);
-  } else {
-    footstepAudioNode.setFilter(null);
   }
   player.add(footstepAudioNode);
   footstepAudio = footstepAudioNode;
+  ensureAmbientAudioPreference();
 
   footstepAudioController = createFootstepAudioController({
     player: {
@@ -2418,7 +2540,14 @@ function initializeImmersiveScene(
         }
         footstepAudioNode.play();
       },
+      stop: () => {
+        if (footstepAudioNode.isPlaying) {
+          footstepAudioNode.stop();
+        }
+        footstepAudioNode.setVolume(0);
+      },
     },
+    enabled: false,
     maxLinearSpeed: PLAYER_SPEED,
     minActivationSpeed: PLAYER_SPEED * 0.12,
     intervalRange: { min: 0.26, max: 0.58 },
@@ -3639,19 +3768,19 @@ function initializeImmersiveScene(
       },
     });
 
-    if (!ambientAudioPreference) {
-      ambientAudioPreference = new AmbientAudioPreference({
-        storage: ambientAudioStorage ?? null,
-        windowTarget: window,
-      });
-    }
+    ensureAmbientAudioPreference();
+    runtimeAudioEnabled = false;
     if (ambientAudioPreferenceBinding) {
       ambientAudioPreferenceBinding.dispose();
       ambientAudioPreferenceBinding = null;
     }
     ambientAudioPreferenceBinding = bindAmbientAudioPreference({
-      controller: ambientAudioController,
-      preference: ambientAudioPreference,
+      controller: {
+        isEnabled: () => runtimeAudioEnabled,
+        enable: () => setRuntimeAudioEnabled(true, false),
+        disable: () => disableRuntimeAudio(false),
+      },
+      preference: ensureAmbientAudioPreference(),
       windowTarget: window,
       logger: console,
     });
@@ -3665,21 +3794,12 @@ function initializeImmersiveScene(
 
     audioHudHandle = createAudioHudControl({
       container: hudSettingsStack,
-      getEnabled: () => ambientAudioController?.isEnabled() ?? false,
+      getEnabled: () => runtimeAudioEnabled,
       setEnabled: async (enabled) => {
-        if (!ambientAudioController) {
-          return;
-        }
-        if (enabled) {
-          try {
-            await ambientAudioController.enable();
-            ambientAudioPreference?.setEnabled(true, 'control');
-          } catch (error) {
-            console.warn('Ambient audio failed to start', error);
-          }
-        } else {
-          ambientAudioController.disable();
-          ambientAudioPreference?.setEnabled(false, 'control');
+        try {
+          await setRuntimeAudioEnabled(enabled, true);
+        } catch (error) {
+          console.warn('Ambient audio failed to start', error);
         }
       },
       getVolume: () => getAmbientAudioVolume(),
@@ -4630,6 +4750,7 @@ function initializeImmersiveScene(
       tourResetControl.dispose();
       tourResetControl = null;
     }
+    runtimeAudioEnabled = false;
     if (ambientAudioPreferenceBinding) {
       ambientAudioPreferenceBinding.dispose();
       ambientAudioPreferenceBinding = null;
@@ -4764,6 +4885,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.githubMetrics) {
       delete window.portfolio.githubMetrics;
+    }
+    if (window.portfolio?.audio) {
+      delete window.portfolio.audio;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/systems/audio/ambientAudio.ts
+++ b/src/systems/audio/ambientAudio.ts
@@ -164,15 +164,15 @@ export class AmbientAudioController {
   }
 
   disable(): void {
-    if (!this.enabled) {
-      return;
-    }
     this.enabled = false;
     this.elapsedTime = 0;
     this.beds.forEach((bed) => {
       bed.currentVolume = 0;
-      bed.definition.source.setVolume(0);
       bed.targetVolume = 0;
+      bed.definition.source.setVolume(0);
+      if (bed.definition.source.isPlaying) {
+        bed.definition.source.stop();
+      }
     });
   }
 

--- a/src/systems/audio/ambientAudioPreference.ts
+++ b/src/systems/audio/ambientAudioPreference.ts
@@ -25,7 +25,10 @@ export interface AmbientAudioPreferenceBindingHandle {
   dispose(): void;
 }
 
-const DEFAULT_STORAGE_KEY = 'danielsmith.io::ambientAudioEnabled::v1';
+export const AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v2';
+
+const DEFAULT_STORAGE_KEY = AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY;
 
 const parseStoredValue = (value: string | null): boolean | null => {
   if (value === '1' || value === 'true') {

--- a/src/systems/audio/ambientCaptionBridge.ts
+++ b/src/systems/audio/ambientCaptionBridge.ts
@@ -62,6 +62,13 @@ export class AmbientCaptionBridge {
     this.now = now;
   }
 
+  clear(): void {
+    for (const id of this.states.keys()) {
+      this.subtitles.clear(`ambient-${id}`);
+    }
+    this.states.clear();
+  }
+
   update(): void {
     const snapshots = this.controller.getBedSnapshots();
     const snapshotIds = new Set<string>();

--- a/src/systems/audio/footstepController.ts
+++ b/src/systems/audio/footstepController.ts
@@ -6,6 +6,7 @@ export interface FootstepPlaybackOptions {
 
 export interface FootstepPlayer {
   play(options: FootstepPlaybackOptions): void;
+  stop?(): void;
 }
 
 export interface FootstepControllerOptions {
@@ -29,6 +30,8 @@ export interface FootstepControllerOptions {
   pitchJitter?: number;
   /** Optional deterministic random generator returning values in [0, 1). */
   random?: () => number;
+  /** Whether the controller should begin ready to emit footsteps. Defaults to true. */
+  enabled?: boolean;
 }
 
 export interface FootstepControllerUpdate {
@@ -101,7 +104,7 @@ export function createFootstepAudioController(
     maxLinearSpeed - 1e-3
   );
 
-  let enabled = true;
+  let enabled = options.enabled ?? true;
   let timeUntilNextStep = 0;
   let lastFoot: FootLabel = 'right';
   let lastNormalizedSpeed = 0;
@@ -246,6 +249,7 @@ export function createFootstepAudioController(
         timeUntilNextStep = 0;
         lastNormalizedSpeed = 0;
         lastGrounded = true;
+        options.player.stop?.();
       }
     },
     isEnabled() {
@@ -255,6 +259,7 @@ export function createFootstepAudioController(
       enabled = false;
       timeUntilNextStep = 0;
       lastNormalizedSpeed = 0;
+      options.player.stop?.();
     },
   };
 }

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -101,6 +101,26 @@ describe('AmbientAudioController', () => {
     expect(source.volumes.at(-1)).toBe(0);
   });
 
+  it('hard-disables by stopping loop sources and zeroing bed volumes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    expect(source.isPlaying).toBe(true);
+    expect(source.volumes.at(-1)).toBeGreaterThan(0);
+
+    controller.disable();
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0]).toMatchObject({
+      currentVolume: 0,
+      targetVolume: 0,
+    });
+  });
+
   it('stops playback when disposed', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
   type AmbientAudioPreferenceChange,
 } from '../systems/audio/ambientAudioPreference';
@@ -54,6 +55,27 @@ describe('AmbientAudioPreference', () => {
     });
 
     expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('uses a v2 storage key so legacy v1 true does not opt users in', () => {
+    const storage = new MemoryStorage();
+    storage.setItem('danielsmith.io::ambientAudioEnabled::v1', '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY).toBe(
+      'danielsmith.io::ambientAudioEnabled::v2'
+    );
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors a v2 stored true value as explicit opt-in', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(true);
   });
 
   it('loads a persisted enabled state from storage', () => {

--- a/src/tests/footstepAudioController.test.ts
+++ b/src/tests/footstepAudioController.test.ts
@@ -9,8 +9,14 @@ import {
 class StubFootstepPlayer {
   public readonly calls: FootstepPlaybackOptions[] = [];
 
+  public stopCount = 0;
+
   play(options: FootstepPlaybackOptions): void {
     this.calls.push(options);
+  }
+
+  stop(): void {
+    this.stopCount += 1;
   }
 }
 
@@ -81,6 +87,32 @@ describe('footstep audio controller', () => {
     controller.update({ delta: 0.2, linearSpeed: 4, isGrounded: false });
     controller.update({ delta: 0.4, linearSpeed: 4, isGrounded: true });
     expect(player.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('can start globally disabled and suppresses future play calls', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player, {
+      enabled: false,
+      random: () => 0.5,
+    });
+
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('left');
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(player.calls).toHaveLength(0);
+
+    controller.setEnabled(true);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    expect(player.calls.length).toBeGreaterThan(0);
+
+    controller.setEnabled(false);
+    const callsAfterDisable = player.calls.length;
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('right');
+
+    expect(player.calls).toHaveLength(callsAfterDisable);
+    expect(player.stopCount).toBe(1);
   });
 
   it('scales cadence, volume, and pitch with speed and master volume', () => {


### PR DESCRIPTION
### Motivation
- Prevent legacy opt-ins and accidental audio resume by making a fresh session start with audio off and ensuring the mute action truly kills runtime audio. 
- Consolidate Settings / M-key / storage-driven audio toggles into a single runtime path so the HUD and controllers can never get out of sync.

### Description
- Move ambient preference to a new storage key `AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY = 'danielsmith.io::ambientAudioEnabled::v2'` and treat missing v2 as `false`, so legacy v1 `true` does not auto-enable audio. (`src/systems/audio/ambientAudioPreference.ts`)
- Make ambient controller `disable()` hard-stop loop sources and zero volumes so beds immediately become silent; keep `dispose()` behavior intact. (`src/systems/audio/ambientAudio.ts`)
- Add `clear()` to `AmbientCaptionBridge` and clear ambient captions when global audio is muted. (`src/systems/audio/ambientCaptionBridge.ts`)
- Extend footstep player interface and controller to support `stop()` and start footstep controller disabled when runtime audio is off; `setEnabled(false)` now stops any playing footstep audio. (`src/systems/audio/footstepController.ts`, `src/main.ts` footstep wiring)
- Centralize runtime audio state in `main.ts`: add `runtimeAudioEnabled`, `ensureAmbientAudioPreference()`, `disableRuntimeAudio()`, `setRuntimeAudioEnabled()`, `stopFootstepAudio()`, `clearAmbientCaptions()`, and wire HUD + M-key to this path so toggles persist to the new key and actually stop/disable sources. Also start footsteps disabled until explicit enable. (`src/main.ts`)
- Expose a debug/test API `window.portfolio.audio.getState()` returning preference, ambient/footstep playing info, bed volumes, master/base volumes, audioContext state, and active storage key to replace brittle audible assertions in tests. (`src/main.ts`)
- Tests: add unit tests to validate v2 default-off behavior, that legacy v1 true does not opt-in, that `disable()` hard-stops ambient beds, and that footstep controller respects global-disabled state; add a Playwright spec assertion that validates default-off, opt-in via gesture/key, hard-mute kills sources, and off-after-reload behavior. (tests under `src/tests/*` and `playwright/small-screen-hud.spec.ts`)

### Testing
- Ran formatting and linting: `npm run format:write` (passed) and `npm run lint` (passed).
- Ran focused and full unit suites: `npm run test:ci -- src/tests/ambientAudioPreference.test.ts src/tests/ambientAudioPreferenceBinding.test.ts src/tests/footstepAudioController.test.ts src/tests/ambientAudioController.test.ts` (passed), and `npm run test:ci` (full Vitest run completed: 136 files, 987 tests — all passed).
- Built the app: `npm run build` (passed) and smoke check `npm run docs:check && npm run smoke` (passed).
- Playwright E2E: installed browsers (`npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium`) and ran `npm run test:e2e -- playwright/small-screen-hud.spec.ts`; the added audio debug/API assertions passed (Playwright tests passed for the spec).
- Typecheck: `npm run typecheck` was executed and surfaced pre-existing, repo-wide TypeScript issues unrelated to the audio changes; no new type errors were introduced by the modified audio paths.

All automated checks that touch the changed audio paths (unit tests, e2e spec, build, docs/smoke, lint) passed in CI-local runs; typecheck shows a baseline of unrelated project-wide errors to address separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2130f15f78832fadf89a13017979c3)