### PR TITLE
🔇 Enforce global audio mute

### DIFF
--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -22,10 +22,23 @@ type ElementBounds = {
   height: number;
 };
 
+type AudioDebugState = {
+  preferenceEnabled: boolean;
+  ambientEnabled: boolean;
+  ambientSourcesPlayingCount: number;
+  ambientBedVolumes: Array<{ currentVolume: number; targetVolume: number }>;
+  footstepEnabled: boolean;
+  footstepPlaying: boolean;
+  activeStorageKey: string | null;
+};
+
 type PortfolioPoiWindow = Window & {
   portfolio?: {
     poi?: {
       getTooltipState?: () => PoiTooltipState;
+    };
+    audio?: {
+      getState?: () => AudioDebugState;
     };
   };
 };
@@ -71,6 +84,21 @@ async function waitForImmersiveReady(page: Page) {
   await page.waitForFunction(
     () => (window as PortfolioPoiWindow).portfolio?.poi?.getTooltipState
   );
+  await page.waitForFunction(
+    () => (window as PortfolioPoiWindow).portfolio?.audio?.getState
+  );
+}
+
+async function getAudioDebugState(page: Page): Promise<AudioDebugState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioPoiWindow).portfolio?.audio?.getState;
+
+    if (!getState) {
+      throw new Error('window.portfolio.audio.getState() is unavailable');
+    }
+
+    return getState();
+  });
 }
 
 async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
@@ -190,6 +218,44 @@ test.describe('small-screen HUD regression coverage', () => {
 
   test.describe('desktop viewport', () => {
     test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('keeps audio off by default and ignores legacy v1 opt-in', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        window.localStorage.setItem(
+          'danielsmith.io::ambientAudioEnabled::v1',
+          '1'
+        );
+        window.localStorage.removeItem(
+          'danielsmith.io::ambientAudioEnabled::v2'
+        );
+      });
+      await waitForImmersiveReady(page);
+      await page.mouse.click(20, 20);
+
+      const settingsButton = page.locator('[data-role="settings-button"]');
+      await settingsButton.click();
+      await expect(page.locator('.audio-toggle')).toContainText(/Off|Muted/i);
+
+      await expect
+        .poll(async () => getAudioDebugState(page), { timeout: 2_000 })
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+          footstepPlaying: false,
+          activeStorageKey: 'danielsmith.io::ambientAudioEnabled::v2',
+        });
+
+      const state = await getAudioDebugState(page);
+      expect(
+        state.ambientBedVolumes.every(
+          (bed) => bed.currentVolume === 0 && bed.targetVolume === 0
+        )
+      ).toBe(true);
+    });
 
     test('keeps desktop keyboard HUD toggles mutually exclusive', async ({
       page,

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,6 +273,10 @@ import {
   type FootstepAudioControllerHandle,
 } from './systems/audio/footstepController';
 import {
+  createGlobalAudioController,
+  type GlobalAudioControllerHandle,
+} from './systems/audio/globalAudioController';
+import {
   createCricketChorusBuffer,
   createDistantHumBuffer,
   createFootstepBuffer,
@@ -475,6 +479,26 @@ declare global {
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
+      audio?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          ambientEnabled: boolean;
+          ambientSourcesPlaying: string[];
+          ambientSourcesPlayingCount: number;
+          ambientBedVolumes: Array<{
+            id: string;
+            currentVolume: number;
+            targetVolume: number;
+          }>;
+          footstepEnabled: boolean;
+          footstepPlaying: boolean;
+          masterVolume: number;
+          baseVolume: number;
+          audioContextState: AudioContextState | 'unknown';
+          storageKeyVersion: 'v2';
+          activeStorageKey: string | null;
+        };
       };
       graphics?: {
         getMotionBlurIntensity(): number;
@@ -783,6 +807,7 @@ let ambientAudioController: AmbientAudioController | null = null;
 let ambientAudioPreference: AmbientAudioPreference | null = null;
 let ambientAudioPreferenceBinding: AmbientAudioPreferenceBindingHandle | null =
   null;
+let globalAudioController: GlobalAudioControllerHandle | null = null;
 let footstepAudioController: FootstepAudioControllerHandle | null = null;
 let footstepAudio: Audio | null = null;
 let avatarInteractionAnimator: AvatarInteractionAnimatorHandle | null = null;
@@ -2392,8 +2417,6 @@ function initializeImmersiveScene(
   footstepAudioNode.setBuffer(footstepSample);
   if (footstepStereoPanner) {
     footstepAudioNode.setFilter(footstepStereoPanner);
-  } else {
-    footstepAudioNode.setFilter(null);
   }
   player.add(footstepAudioNode);
   footstepAudio = footstepAudioNode;
@@ -2401,6 +2424,9 @@ function initializeImmersiveScene(
   footstepAudioController = createFootstepAudioController({
     player: {
       play: ({ volume, playbackRate, pan }) => {
+        if (!globalAudioController?.isEnabled()) {
+          return;
+        }
         const clampedVolume = MathUtils.clamp(volume, 0, 1);
         const clampedRate = MathUtils.clamp(playbackRate, 0.25, 3);
         if (footstepStereoPanner && typeof pan === 'number') {
@@ -2418,7 +2444,14 @@ function initializeImmersiveScene(
         }
         footstepAudioNode.play();
       },
+      stop: () => {
+        footstepAudioNode.setVolume(0);
+        if (footstepAudioNode.isPlaying) {
+          footstepAudioNode.stop();
+        }
+      },
     },
+    enabled: false,
     maxLinearSpeed: PLAYER_SPEED,
     minActivationSpeed: PLAYER_SPEED * 0.12,
     intervalRange: { min: 0.26, max: 0.58 },
@@ -3649,12 +3682,6 @@ function initializeImmersiveScene(
       ambientAudioPreferenceBinding.dispose();
       ambientAudioPreferenceBinding = null;
     }
-    ambientAudioPreferenceBinding = bindAmbientAudioPreference({
-      controller: ambientAudioController,
-      preference: ambientAudioPreference,
-      windowTarget: window,
-      logger: console,
-    });
 
     if (!ambientCaptionBridge && audioSubtitles) {
       ambientCaptionBridge = new AmbientCaptionBridge({
@@ -3665,21 +3692,19 @@ function initializeImmersiveScene(
 
     audioHudHandle = createAudioHudControl({
       container: hudSettingsStack,
-      getEnabled: () => ambientAudioController?.isEnabled() ?? false,
+      getEnabled: () => globalAudioController?.isEnabled() ?? false,
       setEnabled: async (enabled) => {
-        if (!ambientAudioController) {
+        if (!globalAudioController) {
           return;
         }
         if (enabled) {
           try {
-            await ambientAudioController.enable();
-            ambientAudioPreference?.setEnabled(true, 'control');
+            await globalAudioController.enable();
           } catch (error) {
             console.warn('Ambient audio failed to start', error);
           }
         } else {
-          ambientAudioController.disable();
-          ambientAudioPreference?.setEnabled(false, 'control');
+          globalAudioController.disable();
         }
       },
       getVolume: () => getAmbientAudioVolume(),
@@ -3689,6 +3714,60 @@ function initializeImmersiveScene(
       strings: audioHudStrings,
     });
     registerHudControlElement(audioHudHandle?.element);
+
+    const stopFootstepAudio = () => {
+      footstepAudio?.setVolume(0);
+      if (footstepAudio?.isPlaying) {
+        footstepAudio.stop();
+      }
+    };
+
+    globalAudioController = createGlobalAudioController({
+      ambient: ambientAudioController,
+      preference: ambientAudioPreference,
+      footstep: footstepAudioController,
+      stopFootstep: stopFootstepAudio,
+      subtitles: audioSubtitles,
+      hud: audioHudHandle,
+    });
+
+    ambientAudioPreferenceBinding = bindAmbientAudioPreference({
+      controller: globalAudioController,
+      preference: ambientAudioPreference,
+      windowTarget: window,
+      logger: console,
+    });
+
+    const portfolioWindow = window as Window;
+    if (!portfolioWindow.portfolio) {
+      portfolioWindow.portfolio = {};
+    }
+    portfolioWindow.portfolio.audio = {
+      getState: () => {
+        const snapshots = ambientAudioController?.getBedSnapshots() ?? [];
+        const ambientSourcesPlaying = snapshots
+          .filter((snapshot) => snapshot.definition.source.isPlaying)
+          .map((snapshot) => snapshot.id);
+        return {
+          preferenceEnabled: ambientAudioPreference?.isEnabled() ?? false,
+          ambientEnabled: ambientAudioController?.isEnabled() ?? false,
+          ambientSourcesPlaying,
+          ambientSourcesPlayingCount: ambientSourcesPlaying.length,
+          ambientBedVolumes: snapshots.map((snapshot) => ({
+            id: snapshot.id,
+            currentVolume: snapshot.currentVolume,
+            targetVolume: snapshot.targetVolume,
+          })),
+          footstepEnabled: footstepAudioController?.isEnabled() ?? false,
+          footstepPlaying: footstepAudio?.isPlaying ?? false,
+          masterVolume: ambientAudioController?.getMasterVolume() ?? 1,
+          baseVolume: getAmbientAudioVolume(),
+          audioContextState: audioListener.context.state ?? 'unknown',
+          storageKeyVersion: 'v2' as const,
+          activeStorageKey: ambientAudioPreference?.getStorageKey() ?? null,
+        };
+      },
+    };
 
     manualModeToggle = createManualModeToggle({
       container: hudSettingsStack,
@@ -4634,6 +4713,10 @@ function initializeImmersiveScene(
       ambientAudioPreferenceBinding.dispose();
       ambientAudioPreferenceBinding = null;
     }
+    if (globalAudioController) {
+      globalAudioController.disable({ persist: false });
+      globalAudioController = null;
+    }
     if (ambientAudioController) {
       ambientAudioController.dispose();
       ambientAudioController = null;
@@ -4758,6 +4841,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.poi) {
       delete window.portfolio.poi;
+    }
+    if (window.portfolio?.audio) {
+      delete window.portfolio.audio;
     }
     if (window.portfolio?.graphics) {
       delete window.portfolio.graphics;

--- a/src/systems/audio/ambientAudio.ts
+++ b/src/systems/audio/ambientAudio.ts
@@ -164,15 +164,15 @@ export class AmbientAudioController {
   }
 
   disable(): void {
-    if (!this.enabled) {
-      return;
-    }
     this.enabled = false;
     this.elapsedTime = 0;
     this.beds.forEach((bed) => {
       bed.currentVolume = 0;
-      bed.definition.source.setVolume(0);
       bed.targetVolume = 0;
+      bed.definition.source.setVolume(0);
+      if (bed.definition.source.isPlaying) {
+        bed.definition.source.stop();
+      }
     });
   }
 

--- a/src/systems/audio/ambientAudioPreference.ts
+++ b/src/systems/audio/ambientAudioPreference.ts
@@ -10,6 +10,7 @@ export interface AmbientAudioPreferenceChange {
 export interface AmbientAudioPreferenceOptions {
   storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
   storageKey?: string;
+  legacyStorageKey?: string | null;
   windowTarget?: Window | null;
   defaultEnabled?: boolean;
 }
@@ -25,7 +26,13 @@ export interface AmbientAudioPreferenceBindingHandle {
   dispose(): void;
 }
 
-const DEFAULT_STORAGE_KEY = 'danielsmith.io::ambientAudioEnabled::v1';
+export const AMBIENT_AUDIO_STORAGE_KEY_V1 =
+  'danielsmith.io::ambientAudioEnabled::v1';
+
+export const AMBIENT_AUDIO_STORAGE_KEY_V2 =
+  'danielsmith.io::ambientAudioEnabled::v2';
+
+const DEFAULT_STORAGE_KEY = AMBIENT_AUDIO_STORAGE_KEY_V2;
 
 const parseStoredValue = (value: string | null): boolean | null => {
   if (value === '1' || value === 'true') {
@@ -73,6 +80,8 @@ export class AmbientAudioPreference {
 
   private readonly windowTarget: Window | null;
 
+  private readonly legacyStorageKey: string | null;
+
   private readonly listeners = new Set<
     (change: AmbientAudioPreferenceChange) => void
   >();
@@ -87,6 +96,12 @@ export class AmbientAudioPreference {
         ? getDefaultStorage(this.windowTarget)
         : options.storage;
     this.storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
+    this.legacyStorageKey =
+      options.legacyStorageKey === undefined
+        ? this.storageKey === DEFAULT_STORAGE_KEY
+          ? AMBIENT_AUDIO_STORAGE_KEY_V1
+          : null
+        : options.legacyStorageKey;
     this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
 
     if (this.windowTarget) {
@@ -102,12 +117,16 @@ export class AmbientAudioPreference {
     enabled: boolean,
     source: AmbientAudioPreferenceChangeSource = 'control'
   ): void {
-    if (this.enabled === enabled) {
-      return;
-    }
+    const changed = this.enabled !== enabled;
     this.enabled = enabled;
     this.persist();
-    this.notify(source);
+    if (changed) {
+      this.notify(source);
+    }
+  }
+
+  getStorageKey(): string {
+    return this.storageKey;
   }
 
   subscribe(
@@ -134,10 +153,21 @@ export class AmbientAudioPreference {
     try {
       const stored = this.storage.getItem(this.storageKey);
       const parsed = parseStoredValue(stored);
-      if (parsed === null) {
-        return defaultEnabled;
+      if (parsed !== null) {
+        return parsed;
       }
-      return parsed;
+      if (this.legacyStorageKey) {
+        const legacy = parseStoredValue(
+          this.storage.getItem(this.legacyStorageKey)
+        );
+        if (legacy === false) {
+          return false;
+        }
+      }
+      if (this.storageKey === DEFAULT_STORAGE_KEY) {
+        return false;
+      }
+      return defaultEnabled;
     } catch (error) {
       console.warn(
         'Failed to read ambient audio preference from storage.',

--- a/src/systems/audio/footstepController.ts
+++ b/src/systems/audio/footstepController.ts
@@ -6,6 +6,7 @@ export interface FootstepPlaybackOptions {
 
 export interface FootstepPlayer {
   play(options: FootstepPlaybackOptions): void;
+  stop?(): void;
 }
 
 export interface FootstepControllerOptions {
@@ -29,6 +30,8 @@ export interface FootstepControllerOptions {
   pitchJitter?: number;
   /** Optional deterministic random generator returning values in [0, 1). */
   random?: () => number;
+  /** Initial enabled state. Defaults to true for standalone controllers. */
+  enabled?: boolean;
 }
 
 export interface FootstepControllerUpdate {
@@ -101,7 +104,7 @@ export function createFootstepAudioController(
     maxLinearSpeed - 1e-3
   );
 
-  let enabled = true;
+  let enabled = options.enabled ?? true;
   let timeUntilNextStep = 0;
   let lastFoot: FootLabel = 'right';
   let lastNormalizedSpeed = 0;
@@ -246,6 +249,7 @@ export function createFootstepAudioController(
         timeUntilNextStep = 0;
         lastNormalizedSpeed = 0;
         lastGrounded = true;
+        options.player.stop?.();
       }
     },
     isEnabled() {
@@ -255,6 +259,7 @@ export function createFootstepAudioController(
       enabled = false;
       timeUntilNextStep = 0;
       lastNormalizedSpeed = 0;
+      options.player.stop?.();
     },
   };
 }

--- a/src/systems/audio/globalAudioController.ts
+++ b/src/systems/audio/globalAudioController.ts
@@ -1,0 +1,71 @@
+import type { AudioSubtitlesHandle } from '../../ui/hud/audioSubtitles';
+import type { AudioHudControlHandle } from '../controls/audioHudControl';
+
+import type { AmbientAudioController } from './ambientAudio';
+import type { AmbientAudioPreference } from './ambientAudioPreference';
+import type { FootstepAudioControllerHandle } from './footstepController';
+
+export interface GlobalAudioControllerOptions {
+  ambient: Pick<AmbientAudioController, 'enable' | 'disable' | 'isEnabled'>;
+  preference: Pick<AmbientAudioPreference, 'isEnabled' | 'setEnabled'>;
+  footstep?: Pick<
+    FootstepAudioControllerHandle,
+    'setEnabled' | 'isEnabled'
+  > | null;
+  stopFootstep?: () => void;
+  subtitles?: Pick<AudioSubtitlesHandle, 'clear'> | null;
+  hud?: Pick<AudioHudControlHandle, 'refresh'> | null;
+}
+
+export interface GlobalAudioControllerHandle {
+  enable(): Promise<void>;
+  disable(options?: { persist?: boolean }): void;
+  isEnabled(): boolean;
+  refreshHud(): void;
+}
+
+export function createGlobalAudioController({
+  ambient,
+  preference,
+  footstep = null,
+  stopFootstep,
+  subtitles = null,
+  hud = null,
+}: GlobalAudioControllerOptions): GlobalAudioControllerHandle {
+  const refreshHud = () => {
+    hud?.refresh();
+  };
+
+  const hardDisableRuntimeAudio = () => {
+    ambient.disable();
+    footstep?.setEnabled(false);
+    stopFootstep?.();
+    subtitles?.clear();
+  };
+
+  return {
+    async enable() {
+      try {
+        await ambient.enable();
+      } catch (error) {
+        hardDisableRuntimeAudio();
+        refreshHud();
+        throw error;
+      }
+      footstep?.setEnabled(true);
+      preference.setEnabled(true, 'control');
+      refreshHud();
+    },
+    disable(options = {}) {
+      hardDisableRuntimeAudio();
+      if (options.persist ?? true) {
+        preference.setEnabled(false, 'control');
+      }
+      refreshHud();
+    },
+    isEnabled() {
+      return ambient.isEnabled();
+    },
+    refreshHud,
+  };
+}

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -101,6 +101,20 @@ describe('AmbientAudioController', () => {
     expect(source.volumes.at(-1)).toBe(0);
   });
 
+  it('stops playback and zeroes volume when disabled', () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+    controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+
+    controller.disable();
+
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0].currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0].targetVolume).toBe(0);
+  });
+
   it('stops playback when disposed', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  AMBIENT_AUDIO_STORAGE_KEY_V1,
+  AMBIENT_AUDIO_STORAGE_KEY_V2,
   AmbientAudioPreference,
   type AmbientAudioPreferenceChange,
 } from '../systems/audio/ambientAudioPreference';
@@ -54,6 +56,48 @@ describe('AmbientAudioPreference', () => {
     });
 
     expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('uses the v2 storage key and defaults off even if callers pass a true default', () => {
+    const storage = new MemoryStorage();
+
+    const preference = new AmbientAudioPreference({
+      storage,
+      defaultEnabled: true,
+    });
+
+    expect(preference.getStorageKey()).toBe(AMBIENT_AUDIO_STORAGE_KEY_V2);
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('uses the v2 storage key and ignores legacy v1 enabled consent', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_STORAGE_KEY_V1, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.getStorageKey()).toBe(AMBIENT_AUDIO_STORAGE_KEY_V2);
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors explicit v2 opt-in over legacy values', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_STORAGE_KEY_V1, '0');
+    storage.setItem(AMBIENT_AUDIO_STORAGE_KEY_V2, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(true);
+  });
+
+  it('persists repeated off writes so global mute records v2 false', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_STORAGE_KEY_V2, '0');
+    const preference = new AmbientAudioPreference({ storage });
+
+    preference.setEnabled(false);
+
+    expect(storage.getItem(AMBIENT_AUDIO_STORAGE_KEY_V2)).toBe('0');
   });
 
   it('loads a persisted enabled state from storage', () => {

--- a/src/tests/footstepAudioController.test.ts
+++ b/src/tests/footstepAudioController.test.ts
@@ -9,8 +9,14 @@ import {
 class StubFootstepPlayer {
   public readonly calls: FootstepPlaybackOptions[] = [];
 
+  public stopCount = 0;
+
   play(options: FootstepPlaybackOptions): void {
     this.calls.push(options);
+  }
+
+  stop(): void {
+    this.stopCount += 1;
   }
 }
 
@@ -39,6 +45,24 @@ describe('footstep audio controller', () => {
       random: makeSequenceRandom([0.1, 0.9, 0.3, 0.7, 0.2, 0.8]),
       ...overrides,
     });
+
+  it('starts disabled when requested and stops any active hit on mute', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player, { enabled: false });
+
+    expect(controller.isEnabled()).toBe(false);
+    controller.update({ delta: 1, linearSpeed: 4 });
+    controller.notifyFootfall('left');
+    expect(player.calls).toHaveLength(0);
+
+    controller.setEnabled(true);
+    controller.update({ delta: 0.4, linearSpeed: 4 });
+    controller.update({ delta: 0.4, linearSpeed: 4 });
+    expect(player.calls.length).toBeGreaterThan(0);
+
+    controller.setEnabled(false);
+    expect(player.stopCount).toBe(1);
+  });
 
   it('plays alternating stereo hits as the avatar moves', () => {
     const player = new StubFootstepPlayer();

--- a/src/tests/globalAudioController.test.ts
+++ b/src/tests/globalAudioController.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGlobalAudioController } from '../systems/audio/globalAudioController';
+
+const createRuntime = () => {
+  let ambientEnabled = false;
+  let preferenceEnabled = false;
+  let footstepEnabled = true;
+  const runtime = {
+    ambient: {
+      enable: vi.fn(async () => {
+        ambientEnabled = true;
+      }),
+      disable: vi.fn(() => {
+        ambientEnabled = false;
+      }),
+      isEnabled: vi.fn(() => ambientEnabled),
+    },
+    preference: {
+      isEnabled: vi.fn(() => preferenceEnabled),
+      setEnabled: vi.fn((enabled: boolean) => {
+        preferenceEnabled = enabled;
+      }),
+    },
+    footstep: {
+      setEnabled: vi.fn((enabled: boolean) => {
+        footstepEnabled = enabled;
+      }),
+      isEnabled: vi.fn(() => footstepEnabled),
+    },
+    stopFootstep: vi.fn(),
+    subtitles: { clear: vi.fn() },
+    hud: { refresh: vi.fn() },
+  };
+  return runtime;
+};
+
+describe('global audio controller', () => {
+  it('enables ambient and footsteps through one persisted path', async () => {
+    const runtime = createRuntime();
+    const controller = createGlobalAudioController(runtime);
+
+    await controller.enable();
+
+    expect(runtime.ambient.enable).toHaveBeenCalledTimes(1);
+    expect(runtime.footstep.setEnabled).toHaveBeenCalledWith(true);
+    expect(runtime.preference.setEnabled).toHaveBeenCalledWith(true, 'control');
+    expect(runtime.hud.refresh).toHaveBeenCalled();
+    expect(controller.isEnabled()).toBe(true);
+  });
+
+  it('hard-disables every runtime audio source and persists off', async () => {
+    const runtime = createRuntime();
+    const controller = createGlobalAudioController(runtime);
+
+    await controller.enable();
+    controller.disable();
+
+    expect(runtime.ambient.disable).toHaveBeenCalledTimes(1);
+    expect(runtime.footstep.setEnabled).toHaveBeenLastCalledWith(false);
+    expect(runtime.stopFootstep).toHaveBeenCalledTimes(1);
+    expect(runtime.subtitles.clear).toHaveBeenCalledTimes(1);
+    expect(runtime.preference.setEnabled).toHaveBeenLastCalledWith(
+      false,
+      'control'
+    );
+    expect(controller.isEnabled()).toBe(false);
+  });
+
+  it('can silence runtime sources without overwriting explicit opt-in', async () => {
+    const runtime = createRuntime();
+    const controller = createGlobalAudioController(runtime);
+
+    await controller.enable();
+    runtime.preference.setEnabled.mockClear();
+    controller.disable({ persist: false });
+
+    expect(runtime.ambient.disable).toHaveBeenCalledTimes(1);
+    expect(runtime.footstep.setEnabled).toHaveBeenLastCalledWith(false);
+    expect(runtime.stopFootstep).toHaveBeenCalledTimes(1);
+    expect(runtime.preference.setEnabled).not.toHaveBeenCalled();
+  });
+
+  it('does not leave UI enabled when ambient startup fails', async () => {
+    const runtime = createRuntime();
+    runtime.ambient.enable.mockRejectedValueOnce(new Error('autoplay'));
+    const controller = createGlobalAudioController(runtime);
+
+    await expect(controller.enable()).rejects.toThrow('autoplay');
+
+    expect(runtime.ambient.disable).toHaveBeenCalledTimes(1);
+    expect(runtime.footstep.setEnabled).toHaveBeenCalledWith(false);
+    expect(runtime.stopFootstep).toHaveBeenCalledTimes(1);
+    expect(runtime.preference.setEnabled).not.toHaveBeenCalledWith(
+      true,
+      'control'
+    );
+    expect(runtime.hud.refresh).toHaveBeenCalled();
+    expect(controller.isEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Audio could resume from a legacy persisted opt-in and the Settings/M-key toggles only controlled ambient loops while footsteps and other runtime sources could remain audible.
- The code needed a single, authoritative path to persist and apply a global audio enabled/disabled state so UI, ambient beds, footstep playback, and captions remain in-sync.

### Description
- Add a `createGlobalAudioController(...)` helper that coordinates `AmbientAudioController`, `FootstepAudioController`, subtitles/HUD refresh, and persisted preference state, and wire the Settings HUD and M-key through it (new `src/systems/audio/globalAudioController.ts` and main wiring in `src/main.ts`).
- Move the stored consent to a new storage key `danielsmith.io::ambientAudioEnabled::v2`, treat missing v2 as `false`, and purposely ignore legacy `v1 === '1'` as consent to autoplay while preserving explicit v2 opt-in (changes in `src/systems/audio/ambientAudioPreference.ts`).
- Make ambient `disable()` a hard mute that zeroes volumes and stops any playing loop sources, gate footstep playback on the global controller, and add a stop hook so mute kills in-flight footstep hits (changes in `src/systems/audio/ambientAudio.ts`, `src/systems/audio/footstepController.ts`, and `src/main.ts`).
- Expose a debug API at `window.portfolio.audio.getState()` that returns preference/ambient/footstep state, bed volumes, master/base volume, audio context state, and active storage key for staging verification, and add unit + Playwright tests that assert default-off and legacy-v1 safety (`src/tests/*` and `playwright/small-screen-hud.spec.ts`).

### Testing
- Ran unit tests with `npm run test:ci` (Vitest) including the focused audio suites and the full test suite; unit tests passed: `✓ 137 files, 992 tests` and focused runs passed (`src/tests/globalAudioController.test.ts`, `src/tests/ambientAudioPreference.test.ts`, `src/tests/ambientAudioPreferenceBinding.test.ts`, `src/tests/footstepAudioController.test.ts`, `src/tests/ambientAudioController.test.ts`).
- Built and smoke-checked the app with `npm run build` and `npm run smoke`, both succeeded and produced the `dist` artifacts.
- Ran Playwright e2e `npm run test:e2e -- playwright/small-screen-hud.spec.ts` after installing browsers and deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, and the three Playwright scenarios passed locally (`3 passed`).
- Lint/format commands `npm run format:write` and `npm run lint` completed with no blocking errors (lint produced only import-order warnings which were fixed where applicable).
- Type checking `npm run typecheck` currently fails due to unrelated, pre-existing project-wide TypeScript issues in other areas of the repo and is not caused by these changes, so it is reported as a known residual issue; I did not relax type checks to make the PR pass.

Commands used (high-level): `npm run format:write`, `npm run lint`, `npm run test:ci` (focused and full runs), `npm run build`, `npm run docs:check`, `npm run smoke`, `npx playwright install chromium`, `npx playwright install-deps chromium`, `npm run test:e2e -- playwright/small-screen-hud.spec.ts`, `npm run typecheck` (fails due to unrelated TS errors).

If you want I can split follow-ups: migrate any remaining audio-related types into narrower interfaces, add a migration/cleanup job for legacy v1 keys, or add a small README note for the new `window.portfolio.audio.getState()` debug API.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2130f15f78832fadf89a13017979c3)