### PR TITLE
🔇 Make audio mute global

### DIFF
--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -26,6 +26,11 @@ type AudioDebugState = {
   preferenceEnabled: boolean;
   ambientEnabled: boolean;
   ambientSourcesPlayingCount: number;
+  ambientBedVolumes: Array<{
+    id: string;
+    currentVolume: number;
+    targetVolume: number;
+  }>;
   footstepEnabled: boolean;
   footstepPlaying: boolean;
   activeStorageKey: string;
@@ -218,7 +223,7 @@ test.describe('small-screen HUD regression coverage', () => {
   test.describe('desktop viewport', () => {
     test.use({ viewport: { width: 1280, height: 720 } });
 
-    test('keeps audio globally muted by default and after legacy storage', async ({
+    test('routes Settings audio and M key toggles through global mute', async ({
       page,
     }) => {
       await page.addInitScript(() => {
@@ -231,8 +236,16 @@ test.describe('small-screen HUD regression coverage', () => {
         );
       });
       await waitForImmersiveReady(page);
-      await page.mouse.click(100, 100);
-      await page.keyboard.press('Space');
+
+      const settingsButton = page.locator('[data-role="settings-button"]');
+      const settingsModal = page.locator('.help-modal-backdrop');
+      await settingsButton.click();
+      await expect(settingsModal).toBeVisible();
+
+      const audioToggle = settingsModal.locator('button.audio-toggle');
+      const audioVolume = settingsModal.locator('.audio-volume__value');
+      await expect(audioToggle).toContainText(/Audio:\s*Off/i);
+      await expect(audioVolume).toContainText(/Muted/i);
 
       await expect
         .poll(async () => getAudioState(page))
@@ -245,7 +258,7 @@ test.describe('small-screen HUD regression coverage', () => {
           activeStorageKey: 'danielsmith.io::ambientAudioEnabled::v2',
         });
 
-      await page.keyboard.press('m');
+      await audioToggle.click();
       await expect
         .poll(async () => getAudioState(page))
         .toMatchObject({
@@ -256,14 +269,20 @@ test.describe('small-screen HUD regression coverage', () => {
 
       await page.keyboard.press('m');
       await expect
-        .poll(async () => getAudioState(page))
-        .toMatchObject({
-          preferenceEnabled: false,
-          ambientEnabled: false,
-          ambientSourcesPlayingCount: 0,
-          footstepEnabled: false,
-          footstepPlaying: false,
-        });
+        .poll(async () => {
+          const state = await getAudioState(page);
+          return (
+            !state.preferenceEnabled &&
+            !state.ambientEnabled &&
+            state.ambientSourcesPlayingCount === 0 &&
+            !state.footstepEnabled &&
+            !state.footstepPlaying &&
+            state.ambientBedVolumes.every(
+              (bed) => bed.currentVolume === 0 && bed.targetVolume === 0
+            )
+          );
+        })
+        .toBe(true);
 
       await page.reload({ waitUntil: 'domcontentloaded' });
       await waitForImmersiveReady(page);

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -22,10 +22,22 @@ type ElementBounds = {
   height: number;
 };
 
+type AudioDebugState = {
+  preferenceEnabled: boolean;
+  ambientEnabled: boolean;
+  ambientSourcesPlayingCount: number;
+  footstepEnabled: boolean;
+  footstepPlaying: boolean;
+  activeStorageKey: string;
+};
+
 type PortfolioPoiWindow = Window & {
   portfolio?: {
     poi?: {
       getTooltipState?: () => PoiTooltipState;
+    };
+    audio?: {
+      getState?: () => AudioDebugState;
     };
   };
 };
@@ -71,6 +83,21 @@ async function waitForImmersiveReady(page: Page) {
   await page.waitForFunction(
     () => (window as PortfolioPoiWindow).portfolio?.poi?.getTooltipState
   );
+  await page.waitForFunction(
+    () => (window as PortfolioPoiWindow).portfolio?.audio?.getState
+  );
+}
+
+async function getAudioState(page: Page): Promise<AudioDebugState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioPoiWindow).portfolio?.audio?.getState;
+
+    if (!getState) {
+      throw new Error('window.portfolio.audio.getState() is unavailable');
+    }
+
+    return getState();
+  });
 }
 
 async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
@@ -190,6 +217,65 @@ test.describe('small-screen HUD regression coverage', () => {
 
   test.describe('desktop viewport', () => {
     test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('keeps audio globally muted by default and after legacy storage', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        window.localStorage.setItem(
+          'danielsmith.io::ambientAudioEnabled::v1',
+          '1'
+        );
+        window.localStorage.removeItem(
+          'danielsmith.io::ambientAudioEnabled::v2'
+        );
+      });
+      await waitForImmersiveReady(page);
+      await page.mouse.click(100, 100);
+      await page.keyboard.press('Space');
+
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+          footstepPlaying: false,
+          activeStorageKey: 'danielsmith.io::ambientAudioEnabled::v2',
+        });
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: true,
+          ambientEnabled: true,
+          footstepEnabled: true,
+        });
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+          footstepPlaying: false,
+        });
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForImmersiveReady(page);
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+        });
+    });
 
     test('keeps desktop keyboard HUD toggles mutually exclusive', async ({
       page,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1059,7 +1059,7 @@ function initializeImmersiveScene(
     ambientAudioController?.disable();
     footstepAudioController?.setEnabled(false);
     stopFootstepAudio();
-    audioSubtitles?.clear();
+    ambientCaptionBridge?.clear();
     audioHudHandle?.refresh();
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1063,10 +1063,14 @@ function initializeImmersiveScene(
     audioHudHandle?.refresh();
   };
 
+  let globalAudioTransitionId = 0;
+
   const setGlobalAudioEnabled = async (
     enabled: boolean,
     source: 'control' | 'storage' = 'control'
   ) => {
+    const transitionId = ++globalAudioTransitionId;
+
     if (!enabled) {
       hardDisableRuntimeAudio();
       ambientAudioPreference?.setEnabled(false, source);
@@ -1075,18 +1079,31 @@ function initializeImmersiveScene(
     }
 
     if (!ambientAudioController) {
-      ambientAudioPreference?.setEnabled(false, source);
+      if (source === 'control') {
+        ambientAudioPreference?.setEnabled(false, source);
+      }
       audioHudHandle?.refresh();
       return;
     }
 
     try {
       await ambientAudioController.enable();
+      if (
+        transitionId !== globalAudioTransitionId ||
+        (source === 'storage' &&
+          !(ambientAudioPreference?.isEnabled() ?? false))
+      ) {
+        hardDisableRuntimeAudio();
+        audioHudHandle?.refresh();
+        return;
+      }
       footstepAudioController?.setEnabled(true);
       ambientAudioPreference?.setEnabled(true, source);
     } catch (error) {
       hardDisableRuntimeAudio();
-      ambientAudioPreference?.setEnabled(false, source);
+      if (source === 'control') {
+        ambientAudioPreference?.setEnabled(false, source);
+      }
       audioHudHandle?.refresh();
       throw error;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,7 @@ import {
   type AmbientAudioSource,
 } from './systems/audio/ambientAudio';
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
   bindAmbientAudioPreference,
   type AmbientAudioPreferenceBindingHandle,
@@ -475,6 +476,26 @@ declare global {
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
+      audio?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          ambientEnabled: boolean;
+          ambientSourcesPlaying: { id: string; isPlaying: boolean }[];
+          ambientSourcesPlayingCount: number;
+          ambientBedVolumes: {
+            id: string;
+            currentVolume: number;
+            targetVolume: number;
+          }[];
+          footstepEnabled: boolean;
+          footstepPlaying: boolean;
+          masterVolume: number;
+          baseVolume: number;
+          audioContextState: AudioContextState | 'unknown';
+          storageKeyVersion: string;
+          activeStorageKey: string;
+        };
       };
       graphics?: {
         getMotionBlurIntensity(): number;
@@ -1022,6 +1043,84 @@ function initializeImmersiveScene(
     ambientAudioController?.getMasterVolume() ?? 1;
   let setAmbientAudioVolume = (volume: number) => {
     ambientAudioController?.setMasterVolume(volume);
+  };
+
+  const stopFootstepAudio = () => {
+    if (!footstepAudio) {
+      return;
+    }
+    footstepAudio.setVolume(0);
+    if (footstepAudio.isPlaying) {
+      footstepAudio.stop();
+    }
+  };
+
+  const hardDisableRuntimeAudio = () => {
+    ambientAudioController?.disable();
+    footstepAudioController?.setEnabled(false);
+    stopFootstepAudio();
+    audioSubtitles?.clear();
+    audioHudHandle?.refresh();
+  };
+
+  const setGlobalAudioEnabled = async (
+    enabled: boolean,
+    source: 'control' | 'storage' = 'control'
+  ) => {
+    if (!enabled) {
+      hardDisableRuntimeAudio();
+      ambientAudioPreference?.setEnabled(false, source);
+      audioHudHandle?.refresh();
+      return;
+    }
+
+    if (!ambientAudioController) {
+      ambientAudioPreference?.setEnabled(false, source);
+      audioHudHandle?.refresh();
+      return;
+    }
+
+    try {
+      await ambientAudioController.enable();
+      footstepAudioController?.setEnabled(true);
+      ambientAudioPreference?.setEnabled(true, source);
+    } catch (error) {
+      hardDisableRuntimeAudio();
+      ambientAudioPreference?.setEnabled(false, source);
+      audioHudHandle?.refresh();
+      throw error;
+    }
+    audioHudHandle?.refresh();
+  };
+
+  const getAudioDebugState = () => {
+    const snapshots = ambientAudioController?.getBedSnapshots() ?? [];
+    const ambientSourcesPlaying = snapshots.map((snapshot) => ({
+      id: snapshot.id,
+      isPlaying: snapshot.definition.source.isPlaying,
+    }));
+    return {
+      preferenceEnabled: ambientAudioPreference?.isEnabled() ?? false,
+      ambientEnabled: ambientAudioController?.isEnabled() ?? false,
+      ambientSourcesPlaying,
+      ambientSourcesPlayingCount: ambientSourcesPlaying.filter(
+        (source) => source.isPlaying
+      ).length,
+      ambientBedVolumes: snapshots.map((snapshot) => ({
+        id: snapshot.id,
+        currentVolume: snapshot.currentVolume,
+        targetVolume: snapshot.targetVolume,
+      })),
+      footstepEnabled: footstepAudioController?.isEnabled() ?? false,
+      footstepPlaying: footstepAudio?.isPlaying ?? false,
+      masterVolume: ambientAudioController?.getMasterVolume() ?? 0,
+      baseVolume: getAmbientAudioVolume(),
+      audioContextState: audioListener?.context?.state ?? 'unknown',
+      storageKeyVersion: 'v2',
+      activeStorageKey:
+        ambientAudioPreference?.getStorageKey() ??
+        AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
+    };
   };
 
   let localeStorage: Storage | undefined;
@@ -1858,6 +1957,9 @@ function initializeImmersiveScene(
   window.portfolio.githubMetrics = {
     getDiagnostics: () => githubRepoStatsService.getDiagnostics(),
   };
+  window.portfolio.audio = {
+    getState: getAudioDebugState,
+  };
   const wirePoiGitHubMetrics = () => {
     githubRepoMetrics?.dispose();
     githubRepoMetrics = wireGitHubRepoMetrics({
@@ -2401,6 +2503,10 @@ function initializeImmersiveScene(
   footstepAudioController = createFootstepAudioController({
     player: {
       play: ({ volume, playbackRate, pan }) => {
+        if (!(ambientAudioPreference?.isEnabled() ?? false)) {
+          stopFootstepAudio();
+          return;
+        }
         const clampedVolume = MathUtils.clamp(volume, 0, 1);
         const clampedRate = MathUtils.clamp(playbackRate, 0.25, 3);
         if (footstepStereoPanner && typeof pan === 'number') {
@@ -2418,7 +2524,9 @@ function initializeImmersiveScene(
         }
         footstepAudioNode.play();
       },
+      stop: stopFootstepAudio,
     },
+    initialEnabled: ambientAudioPreference?.isEnabled() ?? false,
     maxLinearSpeed: PLAYER_SPEED,
     minActivationSpeed: PLAYER_SPEED * 0.12,
     intervalRange: { min: 0.26, max: 0.58 },
@@ -3650,11 +3758,20 @@ function initializeImmersiveScene(
       ambientAudioPreferenceBinding = null;
     }
     ambientAudioPreferenceBinding = bindAmbientAudioPreference({
-      controller: ambientAudioController,
+      controller: {
+        enable: () => setGlobalAudioEnabled(true, 'storage'),
+        disable: () => {
+          void setGlobalAudioEnabled(false, 'storage');
+        },
+        isEnabled: () => ambientAudioController?.isEnabled() ?? false,
+      },
       preference: ambientAudioPreference,
       windowTarget: window,
       logger: console,
     });
+    if (!ambientAudioPreference.isEnabled()) {
+      hardDisableRuntimeAudio();
+    }
 
     if (!ambientCaptionBridge && audioSubtitles) {
       ambientCaptionBridge = new AmbientCaptionBridge({
@@ -3667,19 +3784,10 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       getEnabled: () => ambientAudioController?.isEnabled() ?? false,
       setEnabled: async (enabled) => {
-        if (!ambientAudioController) {
-          return;
-        }
-        if (enabled) {
-          try {
-            await ambientAudioController.enable();
-            ambientAudioPreference?.setEnabled(true, 'control');
-          } catch (error) {
-            console.warn('Ambient audio failed to start', error);
-          }
-        } else {
-          ambientAudioController.disable();
-          ambientAudioPreference?.setEnabled(false, 'control');
+        try {
+          await setGlobalAudioEnabled(enabled, 'control');
+        } catch (error) {
+          console.warn('Ambient audio failed to start', error);
         }
       },
       getVolume: () => getAmbientAudioVolume(),
@@ -4764,6 +4872,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.githubMetrics) {
       delete window.portfolio.githubMetrics;
+    }
+    if (window.portfolio?.audio) {
+      delete window.portfolio.audio;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/systems/audio/ambientAudio.ts
+++ b/src/systems/audio/ambientAudio.ts
@@ -164,15 +164,15 @@ export class AmbientAudioController {
   }
 
   disable(): void {
-    if (!this.enabled) {
-      return;
-    }
     this.enabled = false;
     this.elapsedTime = 0;
     this.beds.forEach((bed) => {
       bed.currentVolume = 0;
       bed.definition.source.setVolume(0);
       bed.targetVolume = 0;
+      if (bed.definition.source.isPlaying) {
+        bed.definition.source.stop();
+      }
     });
   }
 

--- a/src/systems/audio/ambientAudioPreference.ts
+++ b/src/systems/audio/ambientAudioPreference.ts
@@ -25,7 +25,12 @@ export interface AmbientAudioPreferenceBindingHandle {
   dispose(): void;
 }
 
-const DEFAULT_STORAGE_KEY = 'danielsmith.io::ambientAudioEnabled::v1';
+export const AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v2';
+export const LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v1';
+
+const DEFAULT_STORAGE_KEY = AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY;
 
 const parseStoredValue = (value: string | null): boolean | null => {
   if (value === '1' || value === 'true') {
@@ -103,11 +108,18 @@ export class AmbientAudioPreference {
     source: AmbientAudioPreferenceChangeSource = 'control'
   ): void {
     if (this.enabled === enabled) {
+      if (source === 'control') {
+        this.persist();
+      }
       return;
     }
     this.enabled = enabled;
     this.persist();
     this.notify(source);
+  }
+
+  getStorageKey(): string {
+    return this.storageKey;
   }
 
   subscribe(
@@ -240,14 +252,16 @@ export const bindAmbientAudioPreference = ({
   };
 
   const attemptEnable = async () => {
-    if (disposed || controller.isEnabled()) {
+    if (disposed || controller.isEnabled() || !preference.isEnabled()) {
       return;
     }
     try {
       await controller.enable();
     } catch (error) {
       logger.warn('Ambient audio auto-resume failed:', error);
-      scheduleGestureListeners();
+      if (preference.isEnabled()) {
+        scheduleGestureListeners();
+      }
     }
   };
 

--- a/src/systems/audio/ambientCaptionBridge.ts
+++ b/src/systems/audio/ambientCaptionBridge.ts
@@ -49,6 +49,8 @@ export class AmbientCaptionBridge {
 
   private readonly states = new Map<string, AmbientCaptionState>();
 
+  private readonly messageIds = new Set<string>();
+
   constructor({
     controller,
     subtitles,
@@ -60,6 +62,14 @@ export class AmbientCaptionBridge {
     this.subtitles = subtitles;
     this.cooldownMs = Math.max(0, cooldownMs);
     this.now = now;
+  }
+
+  clear(): void {
+    for (const messageId of this.messageIds) {
+      this.subtitles.clear(messageId);
+    }
+    this.messageIds.clear();
+    this.states.clear();
   }
 
   update(): void {
@@ -75,6 +85,7 @@ export class AmbientCaptionBridge {
     for (const id of Array.from(this.states.keys())) {
       if (!snapshotIds.has(id)) {
         this.states.delete(id);
+        this.messageIds.delete(`ambient-${id}`);
       }
     }
   }
@@ -85,8 +96,10 @@ export class AmbientCaptionBridge {
   ): void {
     const { definition, currentVolume } = snapshot;
     const caption = definition.caption;
+    const messageId = `ambient-${snapshot.id}`;
     if (!caption) {
       this.states.delete(snapshot.id);
+      this.messageIds.delete(messageId);
       return;
     }
 
@@ -99,7 +112,6 @@ export class AmbientCaptionBridge {
         lastShownAt: null,
         pendingImmediateReshow: false,
       } satisfies AmbientCaptionState);
-    const messageId = `ambient-${snapshot.id}`;
     const currentMessage = this.subtitles.getCurrent();
     const hasFocus = currentMessage?.id === messageId;
     const otherMessageActive =
@@ -127,6 +139,7 @@ export class AmbientCaptionBridge {
       const elapsed = currentTime - lastShownAt;
       const bypassCooldown = state.pendingImmediateReshow;
       if (bypassCooldown || elapsed >= this.cooldownMs) {
+        this.messageIds.add(messageId);
         this.subtitles.show({
           id: messageId,
           text: caption,

--- a/src/systems/audio/footstepController.ts
+++ b/src/systems/audio/footstepController.ts
@@ -244,6 +244,9 @@ export function createFootstepAudioController(
       );
     },
     setEnabled(nextEnabled) {
+      if (enabled === nextEnabled) {
+        return;
+      }
       enabled = nextEnabled;
       if (!enabled) {
         timeUntilNextStep = 0;

--- a/src/systems/audio/footstepController.ts
+++ b/src/systems/audio/footstepController.ts
@@ -6,6 +6,7 @@ export interface FootstepPlaybackOptions {
 
 export interface FootstepPlayer {
   play(options: FootstepPlaybackOptions): void;
+  stop?(): void;
 }
 
 export interface FootstepControllerOptions {
@@ -29,6 +30,8 @@ export interface FootstepControllerOptions {
   pitchJitter?: number;
   /** Optional deterministic random generator returning values in [0, 1). */
   random?: () => number;
+  /** Initial gate for global audio state. Defaults to enabled for backwards compatibility. */
+  initialEnabled?: boolean;
 }
 
 export interface FootstepControllerUpdate {
@@ -101,7 +104,7 @@ export function createFootstepAudioController(
     maxLinearSpeed - 1e-3
   );
 
-  let enabled = true;
+  let enabled = options.initialEnabled ?? true;
   let timeUntilNextStep = 0;
   let lastFoot: FootLabel = 'right';
   let lastNormalizedSpeed = 0;
@@ -246,6 +249,7 @@ export function createFootstepAudioController(
         timeUntilNextStep = 0;
         lastNormalizedSpeed = 0;
         lastGrounded = true;
+        options.player.stop?.();
       }
     },
     isEnabled() {
@@ -255,6 +259,7 @@ export function createFootstepAudioController(
       enabled = false;
       timeUntilNextStep = 0;
       lastNormalizedSpeed = 0;
+      options.player.stop?.();
     },
   };
 }

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -101,6 +101,27 @@ describe('AmbientAudioController', () => {
     expect(source.volumes.at(-1)).toBe(0);
   });
 
+  it('hard-disables playback by stopping sources and zeroing volumes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    expect(source.isPlaying).toBe(true);
+    expect(source.volumes.at(-1)).toBeGreaterThan(0);
+
+    controller.disable();
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0].currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0].targetVolume).toBe(0);
+
+    await controller.enable();
+    expect(source.isPlaying).toBe(true);
+  });
+
   it('stops playback when disposed', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -131,6 +131,24 @@ describe('AmbientAudioController', () => {
     expect(source.volumes.at(-1)).toBe(0);
   });
 
+  it('keeps disabled beds stopped when master volume changes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    controller.disable();
+
+    controller.setMasterVolume(0.5);
+    controller.update({ x: 0, z: 0 }, 0.1);
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0].currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0].targetVolume).toBe(0);
+  });
+
   it('applies master volume scaling and updates immediately', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
+  LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   type AmbientAudioPreferenceChange,
 } from '../systems/audio/ambientAudioPreference';
 
@@ -54,6 +56,36 @@ describe('AmbientAudioPreference', () => {
     });
 
     expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('uses the v2 storage key by default and ignores legacy enabled consent', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.getStorageKey()).toBe(
+      AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY
+    );
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors explicit opt-in stored under the v2 key', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(true);
+  });
+
+  it('persists false to the v2 key even when already disabled by default', () => {
+    const storage = new MemoryStorage();
+    const preference = new AmbientAudioPreference({ storage });
+
+    preference.setEnabled(false);
+
+    expect(storage.getItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY)).toBe('0');
   });
 
   it('loads a persisted enabled state from storage', () => {

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -79,11 +79,12 @@ describe('AmbientAudioPreference', () => {
     expect(preference.isEnabled()).toBe(true);
   });
 
-  it('persists false to the v2 key even when already disabled by default', () => {
+  it('persists control disables to the v2 key even when already disabled by default', () => {
     const storage = new MemoryStorage();
     const preference = new AmbientAudioPreference({ storage });
 
-    preference.setEnabled(false);
+    preference.setEnabled(false, 'control');
+    preference.setEnabled(false, 'control');
 
     expect(storage.getItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY)).toBe('0');
   });

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -268,6 +268,36 @@ describe('audio subtitles overlay', () => {
     handle.dispose();
   });
 
+  it('clears queued ambient captions by id without dropping active narration', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-narration',
+      text: 'Narration remains active while ambient is muted.',
+      source: 'poi',
+      priority: 4,
+      durationMs: 1000,
+    });
+
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Queued ambient bed should be removed.',
+      source: 'ambient',
+      priority: 1,
+      durationMs: 600,
+    });
+
+    handle.clear('ambient-hum');
+
+    expect(getCaptionText()).toBe(
+      'Narration remains active while ambient is muted.'
+    );
+    vi.advanceTimersByTime(1000);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
   it('clears the active and queued captions when clear is called without an id', () => {
     const handle = createAudioSubtitles();
     handle.show({

--- a/src/tests/footstepAudioController.test.ts
+++ b/src/tests/footstepAudioController.test.ts
@@ -9,8 +9,14 @@ import {
 class StubFootstepPlayer {
   public readonly calls: FootstepPlaybackOptions[] = [];
 
+  public stopCalls = 0;
+
   play(options: FootstepPlaybackOptions): void {
     this.calls.push(options);
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
   }
 }
 
@@ -81,6 +87,30 @@ describe('footstep audio controller', () => {
     controller.update({ delta: 0.2, linearSpeed: 4, isGrounded: false });
     controller.update({ delta: 0.4, linearSpeed: 4, isGrounded: true });
     expect(player.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('can start disabled and stops active playback when globally muted', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player, {
+      initialEnabled: false,
+      random: () => 0.5,
+    });
+
+    expect(controller.isEnabled()).toBe(false);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('left');
+    expect(player.calls).toHaveLength(0);
+
+    controller.setEnabled(true);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    expect(player.calls.length).toBeGreaterThan(0);
+
+    controller.setEnabled(false);
+    const callsAfterDisable = player.calls.length;
+    expect(player.stopCalls).toBe(1);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('right');
+    expect(player.calls).toHaveLength(callsAfterDisable);
   });
 
   it('scales cadence, volume, and pitch with speed and master volume', () => {

--- a/src/tests/footstepAudioController.test.ts
+++ b/src/tests/footstepAudioController.test.ts
@@ -113,6 +113,16 @@ describe('footstep audio controller', () => {
     expect(player.calls).toHaveLength(callsAfterDisable);
   });
 
+  it('does not stop playback again when disabled repeatedly', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player);
+
+    controller.setEnabled(false);
+    controller.setEnabled(false);
+
+    expect(player.stopCalls).toBe(1);
+  });
+
   it('scales cadence, volume, and pitch with speed and master volume', () => {
     const player = new StubFootstepPlayer();
     const controller = createFootstepAudioController({


### PR DESCRIPTION
### Motivation
- Legacy v1 ambient consent could resurrect audible audio after reloads, and the UI toggle only affected ambient beds leaving footsteps and loop sources audible. 
- The goal is a single, user-visible global audio state so Settings / M-key reliably mutes or enables every runtime audio source.

### Description
- Move the runtime preference to a new v2 key (`AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY`) and ignore legacy v1 `true` as automatic consent while still honoring explicit v2 opt-in. 
- Add a centralized global audio path (`setGlobalAudioEnabled` / `hardDisableRuntimeAudio`) in `src/main.ts` that updates the ambient controller, footstep controller, HUD, captions, and persisted preference in one place and expose `window.portfolio.audio.getState()` for runtime diagnostics. 
- Make `AmbientAudioController.disable()` hard-stop ambient beds by zeroing volumes and stopping playing loop sources, and add tests verifying hard-disable/reenable behavior. 
- Add footstep player `stop()` support and `initialEnabled` / stop-on-disable wiring so footstep playback is gated by the global audio state and active footsteps are stopped when muted. 

### Testing
- Ran formatting and linters with `npm run format:write` and `npm run lint`, both succeeded. 
- Ran `npm run typecheck`, which failed due to existing, unrelated repo-wide TypeScript issues (these are out-of-scope for this change). 
- Ran focused unit tests with `npm run test:ci -- src/tests/ambientAudioPreference.test.ts src/tests/ambientAudioPreferenceBinding.test.ts src/tests/footstepAudioController.test.ts src/tests/ambientAudioController.test.ts` and the targeted suites passed. 
- Ran the full unit suite via `npm run test:ci` which completed successfully (988 tests passed). 
- Built and smoke-checked with `npm run build` and `npm run smoke`, both succeeded. 
- Installed Playwright browser and system deps (`npx playwright install chromium-headless-shell` and `npx playwright install-deps`) and ran the E2E spec `npm run test:e2e -- playwright/small-screen-hud.spec.ts`, which passed after the browser/dependency installs. 
- Added/updated tests: `src/tests/ambientAudioPreference.test.ts`, `src/tests/ambientAudioController.test.ts`, and `src/tests/footstepAudioController.test.ts`, plus Playwright coverage in `playwright/small-screen-hud.spec.ts` to validate legacy storage, opt-in, mute behavior, and reload persistence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2130f15f78832fadf89a13017979c3)