### PR TITLE
Use pod-local GitHub metrics cache

### DIFF
--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -50,8 +50,8 @@ layer without guessing where functionality lives.
   performance budgets. Also exposes POI copy consumed across systems and UI.
 - [`src/systems/`](../../src/systems/) – keyboard controls, audio pipelines,
   movement prediction, collision detection, mode failover, HUD control handles,
-  and the GitHub repo stats service that streams live metrics into POIs.
-  Systems never import from `src/ui/`.
+  and the GitHub repo stats service that reads pod-local runtime metrics before
+  using neutral POI fallbacks. Systems never import from `src/ui/`.
 - [`src/scene/`](../../src/scene/) – avatar importers, environmental builds,
   POI registries, lighting helpers, and structural meshes. Scene code consumes
   system handles and emits immutable references for UI/tests.
@@ -91,6 +91,14 @@ layer without guessing where functionality lives.
   [`src/scene/poi/tooltipOverlay.ts`](../../src/scene/poi/tooltipOverlay.ts), while
   [`src/scene/poi/githubMetrics.ts`](../../src/scene/poi/githubMetrics.ts)
   wires GitHub star counts into both the in-world tooltip and HUD overlay.
+  Deployed pods refresh public repository metadata server-side into
+  `/runtime/github-metrics.json`; the static frontend reads that unauthenticated
+  JSON cache first, accepts a small grace period for late hourly refreshes, and
+  otherwise shows localized neutral states such as “Syncing from GitHub…” rather
+  than invented counts. Browser live GitHub API fan-out is reserved for explicit
+  debug/dev fallback (`?enableLiveGitHubMetrics=1`), so staging and production
+  visitors do not require secrets and may see values drift by up to the cache
+  refresh interval.
 - **Accessibility overlays** – `HudFocusAnnouncerHandle` flows from systems
   into DOM overlays: `src/ui/accessibility/ariaBridges.ts` registers live
   regions, while Playwright specs assert emitted announcements against

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -514,7 +514,9 @@ Ideas to evaluate after the core experience is stable:
 - ✅ Procedural storytelling AI that narrates the journey between POIs.
   - ✅ Procedural narrator now weaves journey beats into the HUD story log whenever new exhibits are discovered.
 - ✅ Integration with GitHub API for live repo stats and contribution heatmaps.
-  - ✅ Live GitHub star counts now stream into POI metric panels via the repo stats service.
+  - ✅ GitHub star counts now prefer the pod-local `/runtime/github-metrics.json`
+    cache generated from public unauthenticated metadata, with neutral localized
+    fallbacks when the cache is missing, stale, or invalid.
 - ✅ Exportable "press kit" mode now packages screenshots, POI blurbs, and metrics for media kits.
   - ✅ Press kit summary generator now exports POI metadata and performance budgets to JSON for packaging.
   - ✅ Press kit performance report now surfaces headroom for materials, draw calls, and texture

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -5,7 +5,12 @@ const IMMERSIVE_GITHUB_METRICS_URL =
   '/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1';
 
 interface GitHubMetricsDiagnostics {
-  source: 'live' | 'cached' | 'static-fallback';
+  source:
+    | 'runtime-cache'
+    | 'runtime-cache-stale'
+    | 'browser-live'
+    | 'cached'
+    | 'static-neutral';
   requestCount: number;
   suppressedRequestCount: number;
   lastErrorStatus: number | 'network' | null;
@@ -31,6 +36,22 @@ test.describe('GitHub repo metrics fallback', () => {
     page,
   }) => {
     const consoleMessages = collectConsole(page);
+    await page.route('**/runtime/github-metrics.json', (route) => {
+      const generatedAt = new Date().toISOString();
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schemaVersion: 1,
+          generatedAt,
+          expiresAt,
+          source: 'github-api',
+          repos: {},
+          errors: {},
+        }),
+      });
+    });
     await page.route('https://api.github.com/repos/**', (route) =>
       route.fulfill({
         status: 403,
@@ -73,7 +94,7 @@ test.describe('GitHub repo metrics fallback', () => {
     });
 
     expect(diagnostics).toMatchObject({
-      source: 'static-fallback',
+      source: 'static-neutral',
       requestCount: 1,
       lastErrorStatus: 403,
     });

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -13,17 +13,25 @@ export interface GitHubRepoStats {
 
 export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
 
-export type GitHubRepoMetricsSource = 'live' | 'cached' | 'static-fallback';
+export type GitHubRepoMetricsSource =
+  | 'runtime-cache'
+  | 'runtime-cache-stale'
+  | 'browser-live'
+  | 'cached'
+  | 'static-neutral';
 
 export interface GitHubRepoStatsDiagnostics {
   source: GitHubRepoMetricsSource;
   requestCount: number;
+  runtimeCacheRequestCount: number;
   suppressedRequestCount: number;
-  lastErrorStatus: number | 'network' | null;
+  lastErrorStatus: number | 'network' | 'invalid-runtime-cache' | null;
   lastErrorAt: string | null;
   backoffExpiresAt: string | null;
   cachedRepoCount: number;
   warningCount: number;
+  runtimeCacheGeneratedAt: string | null;
+  runtimeCacheExpiresAt: string | null;
 }
 
 export interface GitHubRepoStatsService {
@@ -48,11 +56,15 @@ const BACKOFF_STORAGE_KEY = 'danielsmith.io:github-repo-stats:backoff';
 const DEFAULT_SUCCESS_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_FAILURE_BACKOFF_MS = 15 * 60 * 1000;
 const DEFAULT_FETCH_TIMEOUT_MS = 3500;
+const DEFAULT_RUNTIME_CACHE_URL = '/runtime/github-metrics.json';
+const DEFAULT_RUNTIME_CACHE_GRACE_MS = 30 * 60 * 1000;
 const WARNING_SESSION_KEY = 'danielsmith.io:github-repo-stats:warning-shown';
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 type ErrorStatus = number | 'network';
+
+type DiagnosticsErrorStatus = ErrorStatus | 'invalid-runtime-cache';
 
 interface CachedStatsRecord {
   stats: GitHubRepoStats;
@@ -67,10 +79,29 @@ interface BackoffRecord {
 
 interface MemoryCacheEntry extends CachedStatsRecord {
   freshUntil: number;
+  source: 'runtime-cache' | 'cached';
+}
+
+interface RuntimeRepoMetrics {
+  owner: string;
+  repo: string;
+  stars: number;
+  watchers: number;
+  forks: number;
+  openIssues: number;
+  pushedAt: string | null;
+}
+
+interface RuntimeCachePayload {
+  generatedAt: string;
+  expiresAt: string;
+  repos: Map<string, RuntimeRepoMetrics>;
 }
 
 export interface GitHubRepoStatsServiceOptions {
   allowLiveFetch?: boolean;
+  runtimeCacheUrl?: string | null;
+  runtimeCacheGraceMs?: number;
   localStorage?: StorageLike | null;
   sessionStorage?: StorageLike | null;
   logger?: Pick<Console, 'warn'> | null;
@@ -99,7 +130,7 @@ const makeStorageKey = (identifier: GitHubRepoIdentifier): string =>
   `${CACHE_STORAGE_PREFIX}${makeCacheKey(identifier)}`;
 
 const shouldAttemptLiveFetch = (() => {
-  const globalScope = globalThis as Partial<
+  const globalScope = globalThis as unknown as Partial<
     Window & { __ENABLE_LIVE_GITHUB_METRICS__?: boolean }
   >;
   if (globalScope.__ENABLE_LIVE_GITHUB_METRICS__) {
@@ -110,14 +141,7 @@ const shouldAttemptLiveFetch = (() => {
     return false;
   }
   const params = new URLSearchParams(location.search);
-  if (params.get('enableLiveGitHubMetrics') === '1') {
-    return true;
-  }
-  const hostname = location.hostname.toLowerCase();
-  if (hostname === 'danielsmith.io' || hostname.endsWith('.danielsmith.io')) {
-    return true;
-  }
-  return false;
+  return params.get('enableLiveGitHubMetrics') === '1';
 })();
 
 const getBrowserStorage = (key: 'localStorage' | 'sessionStorage') => {
@@ -199,6 +223,61 @@ const normalizeCachedRecord = (
     },
     cachedAt,
     freshUntil: cachedAt + ttlMs,
+    source: 'cached',
+  };
+};
+
+const parseDateMs = (value: unknown): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const normalizeRuntimeCache = (
+  data: unknown,
+  now: number,
+  graceMs: number
+): RuntimeCachePayload | 'stale' | null => {
+  if (!isRecord(data) || data.schemaVersion !== 1 || !isRecord(data.repos)) {
+    return null;
+  }
+  const generatedAt = parseDateMs(data.generatedAt);
+  const expiresAt = parseDateMs(data.expiresAt);
+  if (generatedAt === null || expiresAt === null || generatedAt > now) {
+    return null;
+  }
+  if (expiresAt + graceMs < now) {
+    return 'stale';
+  }
+  const repos = new Map<string, RuntimeRepoMetrics>();
+  Object.values(data.repos).forEach((value) => {
+    if (!isRecord(value)) {
+      return;
+    }
+    const owner = typeof value.owner === 'string' ? value.owner : null;
+    const repo = typeof value.repo === 'string' ? value.repo : null;
+    if (!owner || !repo) {
+      return;
+    }
+    repos.set(makeCacheKey({ owner, repo }), {
+      owner,
+      repo,
+      stars: sanitizeNumber(value.stars),
+      watchers: sanitizeNumber(value.watchers),
+      forks: sanitizeNumber(value.forks),
+      openIssues: sanitizeNumber(value.openIssues),
+      pushedAt: typeof value.pushedAt === 'string' ? value.pushedAt : null,
+    });
+  });
+  return {
+    generatedAt: new Date(generatedAt).toISOString(),
+    expiresAt: new Date(expiresAt).toISOString(),
+    repos,
   };
 };
 
@@ -226,6 +305,12 @@ export function createGitHubRepoStatsService(
   options: GitHubRepoStatsServiceOptions = {}
 ): GitHubRepoStatsService {
   const allowLiveFetch = options.allowLiveFetch ?? shouldAttemptLiveFetch;
+  const runtimeCacheUrl =
+    options.runtimeCacheUrl === undefined
+      ? DEFAULT_RUNTIME_CACHE_URL
+      : options.runtimeCacheUrl;
+  const runtimeCacheGraceMs =
+    options.runtimeCacheGraceMs ?? DEFAULT_RUNTIME_CACHE_GRACE_MS;
   const localStorage =
     options.localStorage === undefined
       ? getBrowserStorage('localStorage')
@@ -247,12 +332,15 @@ export function createGitHubRepoStatsService(
   const listeners = new Map<string, Set<GitHubRepoStatsListener>>();
   const inFlight = new Map<string, Promise<GitHubRepoStats | null>>();
   const diagnostics = {
-    source: 'static-fallback' as GitHubRepoMetricsSource,
+    source: 'static-neutral' as GitHubRepoMetricsSource,
     requestCount: 0,
+    runtimeCacheRequestCount: 0,
     suppressedRequestCount: 0,
-    lastErrorStatus: null as ErrorStatus | null,
+    lastErrorStatus: null as DiagnosticsErrorStatus | null,
     lastErrorAt: null as number | null,
     warningCount: 0,
+    runtimeCacheGeneratedAt: null as string | null,
+    runtimeCacheExpiresAt: null as string | null,
   };
 
   let backoff = safeReadJson<BackoffRecord>(localStorage, BACKOFF_STORAGE_KEY);
@@ -294,7 +382,7 @@ export function createGitHubRepoStatsService(
     diagnostics.warningCount += 1;
     safeWriteJson(sessionStorage, WARNING_SESSION_KEY, true);
     logger.warn(
-      '[github-metrics] Live GitHub repo metrics are temporarily unavailable; using cached/static project metrics.',
+      '[github-metrics] Live GitHub repo metrics are temporarily unavailable; using cached or neutral project metrics.',
       {
         status,
         backoffExpiresAt: backoff ? toIso(backoff.expiresAt) : null,
@@ -332,9 +420,71 @@ export function createGitHubRepoStatsService(
     cache.set(key, {
       ...record,
       freshUntil: cachedAt + successCacheTtlMs,
+      source: 'cached',
     });
     safeWriteJson(localStorage, makeStorageKey(identifier), record);
   };
+
+  const setRuntimeCacheEntries = (payload: RuntimeCachePayload) => {
+    diagnostics.runtimeCacheGeneratedAt = payload.generatedAt;
+    diagnostics.runtimeCacheExpiresAt = payload.expiresAt;
+    diagnostics.source = 'runtime-cache';
+    const fetchedAt = now();
+    const freshUntil = Date.parse(payload.expiresAt) + runtimeCacheGraceMs;
+    payload.repos.forEach((repoMetrics, key) => {
+      const stats: GitHubRepoStats = {
+        stars: repoMetrics.stars,
+        watchers: repoMetrics.watchers,
+        forks: repoMetrics.forks,
+        openIssues: repoMetrics.openIssues,
+        pushedAt: repoMetrics.pushedAt,
+      };
+      cache.set(key, {
+        stats,
+        cachedAt: fetchedAt,
+        freshUntil,
+        source: 'runtime-cache',
+      });
+      notify(key, stats);
+    });
+  };
+
+  const loadRuntimeCache = async (): Promise<void> => {
+    if (!fetchImpl || !runtimeCacheUrl) {
+      return;
+    }
+    try {
+      diagnostics.runtimeCacheRequestCount += 1;
+      const response = await fetchImpl(runtimeCacheUrl, {
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        diagnostics.source = 'static-neutral';
+        return;
+      }
+      const normalized = normalizeRuntimeCache(
+        await response.json(),
+        now(),
+        runtimeCacheGraceMs
+      );
+      if (normalized === 'stale') {
+        diagnostics.source = 'runtime-cache-stale';
+        return;
+      }
+      if (!normalized) {
+        diagnostics.source = 'static-neutral';
+        diagnostics.lastErrorStatus = 'invalid-runtime-cache';
+        diagnostics.lastErrorAt = now();
+        return;
+      }
+      setRuntimeCacheEntries(normalized);
+    } catch {
+      diagnostics.source = 'static-neutral';
+    }
+  };
+
+  const runtimeCachePromise = loadRuntimeCache();
 
   const setBackoff = (status: ErrorStatus) => {
     if (!shouldBackoffForStatus(status)) {
@@ -360,10 +510,12 @@ export function createGitHubRepoStatsService(
     identifier: GitHubRepoIdentifier
   ): GitHubRepoStats | null => {
     const entry = readCachedEntry(identifier);
-    if (entry) {
-      diagnostics.source = diagnostics.source === 'live' ? 'live' : 'cached';
+    if (entry && entry.freshUntil > now()) {
+      diagnostics.source =
+        entry.source === 'runtime-cache' ? 'runtime-cache' : 'cached';
+      return entry.stats;
     }
-    return entry?.stats ?? null;
+    return null;
   };
 
   const subscribe = (
@@ -378,7 +530,7 @@ export function createGitHubRepoStatsService(
     }
     repoListeners.add(listener);
 
-    const cached = readCachedEntry(identifier)?.stats;
+    const cached = getCachedStats(identifier);
     if (cached) {
       queueMicrotask(() => {
         if (listeners.get(key)?.has(listener)) {
@@ -402,10 +554,12 @@ export function createGitHubRepoStatsService(
   const requestStats = async (
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null> => {
+    await runtimeCachePromise;
     const key = makeCacheKey(identifier);
     const cached = readCachedEntry(identifier);
     if (cached && cached.freshUntil > now()) {
-      diagnostics.source = 'cached';
+      diagnostics.source =
+        cached.source === 'runtime-cache' ? 'runtime-cache' : 'cached';
       return cached.stats;
     }
     const existing = inFlight.get(key);
@@ -413,12 +567,15 @@ export function createGitHubRepoStatsService(
       return existing;
     }
     if (!fetchImpl || !allowLiveFetch) {
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
-      return cached?.stats ?? null;
+      diagnostics.source =
+        diagnostics.source === 'runtime-cache-stale'
+          ? 'runtime-cache-stale'
+          : 'static-neutral';
+      return null;
     }
     if (isBackoffActive(backoff, now())) {
       diagnostics.suppressedRequestCount += 1;
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
+      diagnostics.source = cached ? 'cached' : 'static-neutral';
       return cached?.stats ?? null;
     }
     if (backoff) {
@@ -441,7 +598,7 @@ export function createGitHubRepoStatsService(
         );
         if (!response.ok) {
           recordFailure(response.status);
-          diagnostics.source = cached ? 'cached' : 'static-fallback';
+          diagnostics.source = cached ? 'cached' : 'static-neutral';
           return cached?.stats ?? null;
         }
         const data = (await response.json()) as Record<string, unknown>;
@@ -455,14 +612,14 @@ export function createGitHubRepoStatsService(
           pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
         };
         writeCachedEntry(identifier, stats);
-        diagnostics.source = 'live';
+        diagnostics.source = 'browser-live';
         diagnostics.lastErrorStatus = null;
         diagnostics.lastErrorAt = null;
         notify(key, stats);
         return stats;
       } catch {
         recordFailure('network');
-        diagnostics.source = cached ? 'cached' : 'static-fallback';
+        diagnostics.source = cached ? 'cached' : 'static-neutral';
         return cached?.stats ?? null;
       } finally {
         if (timeoutId) {
@@ -479,6 +636,7 @@ export function createGitHubRepoStatsService(
   const getDiagnostics = (): GitHubRepoStatsDiagnostics => ({
     source: diagnostics.source,
     requestCount: diagnostics.requestCount,
+    runtimeCacheRequestCount: diagnostics.runtimeCacheRequestCount,
     suppressedRequestCount: diagnostics.suppressedRequestCount,
     lastErrorStatus: diagnostics.lastErrorStatus,
     lastErrorAt: toIso(diagnostics.lastErrorAt),
@@ -487,6 +645,8 @@ export function createGitHubRepoStatsService(
       : null,
     cachedRepoCount: cache.size,
     warningCount: diagnostics.warningCount,
+    runtimeCacheGeneratedAt: diagnostics.runtimeCacheGeneratedAt,
+    runtimeCacheExpiresAt: diagnostics.runtimeCacheExpiresAt,
   });
 
   return {

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -44,7 +44,7 @@ class MockRepoStatsService implements GitHubRepoStatsService {
 
   getDiagnostics() {
     return {
-      source: 'static-fallback' as const,
+      source: 'static-neutral' as const,
       requestCount: this.requested.length,
       suppressedRequestCount: 0,
       lastErrorStatus: null,
@@ -52,6 +52,9 @@ class MockRepoStatsService implements GitHubRepoStatsService {
       backoffExpiresAt: this.backoffExpiresAt,
       cachedRepoCount: this.cache.size,
       warningCount: 0,
+      runtimeCacheRequestCount: 0,
+      runtimeCacheGeneratedAt: null,
+      runtimeCacheExpiresAt: null,
     };
   }
 

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -27,10 +27,179 @@ const createOptions = (overrides: Record<string, unknown> = {}) => ({
   logger: { warn: vi.fn() },
   now: () => 1_000,
   fetchTimeoutMs: 0,
+  runtimeCacheUrl: null,
   ...overrides,
 });
 
 describe('GitHub repo stats service', () => {
+  it('does not call browser GitHub API when live fallback is disabled', async () => {
+    const fetch = vi.fn();
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({ allowLiveFetch: false, runtimeCacheUrl: null })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'foo', repo: 'bar' })
+    ).resolves.toBeNull();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      requestCount: 0,
+    });
+  });
+
+  it('loads valid runtime cache stats before browser live fetches', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '1970-01-01T00:00:01.000Z',
+        expiresAt: '1970-01-01T01:00:01.000Z',
+        source: 'github-api',
+        repos: {
+          'futuroptimist/token.place': {
+            owner: 'futuroptimist',
+            repo: 'token.place',
+            stars: 6,
+            watchers: 1,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: '1970-01-01T00:00:00Z',
+            fetchedAt: '1970-01-01T00:00:01.000Z',
+            htmlUrl: 'https://github.com/futuroptimist/token.place',
+          },
+        },
+        errors: {},
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+      })
+    );
+
+    const stats = await service.requestStats({
+      owner: 'futuroptimist',
+      repo: 'token.place',
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith('/runtime/github-metrics.json', {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    });
+    expect(stats?.stars).toBe(6);
+    expect(stats?.watchers).toBe(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      runtimeCacheRequestCount: 1,
+      runtimeCacheGeneratedAt: '1970-01-01T00:00:01.000Z',
+      runtimeCacheExpiresAt: '1970-01-01T01:00:01.000Z',
+    });
+  });
+
+  it('treats stale runtime cache as unavailable without live fallback by default', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '1970-01-01T00:00:01.000Z',
+        expiresAt: '1970-01-01T00:01:00.000Z',
+        repos: {
+          'futuroptimist/flywheel': {
+            owner: 'futuroptimist',
+            repo: 'flywheel',
+            stars: 999,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        now: () => 7_200_000,
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache-stale',
+      requestCount: 0,
+      runtimeCacheRequestCount: 1,
+    });
+  });
+
+  it('treats invalid runtime cache as unavailable', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      lastErrorStatus: 'invalid-runtime-cache',
+    });
+  });
+
+  it('uses stargazers_count rather than watchers_count for debug live stars', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        stargazers_count: 5,
+        watchers_count: 999,
+        forks_count: 1,
+        open_issues_count: 0,
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({ allowLiveFetch: true, runtimeCacheUrl: null })
+    );
+
+    const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
+
+    expect(stats?.stars).toBe(5);
+    expect(stats?.watchers).toBe(999);
+    expect(service.getDiagnostics().source).toBe('browser-live');
+  });
+
+  it('uses neutral fallback for network failure when live debug is enabled', async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error('offline'));
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({ allowLiveFetch: true, runtimeCacheUrl: null })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'foo', repo: 'bar' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      lastErrorStatus: 'network',
+    });
+  });
+
   it('fetches stats, caches results, and notifies subscribers', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -67,7 +236,7 @@ describe('GitHub repo stats service', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0][0]).toEqual(stats);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'live',
+      source: 'browser-live',
       requestCount: 1,
       lastErrorStatus: null,
     });
@@ -95,7 +264,7 @@ describe('GitHub repo stats service', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'static-fallback',
+      source: 'static-neutral',
       requestCount: 1,
       lastErrorStatus: 403,
       warningCount: 1,
@@ -124,7 +293,7 @@ describe('GitHub repo stats service', () => {
       requestCount: 1,
       suppressedRequestCount: 1,
       lastErrorStatus: 429,
-      source: 'static-fallback',
+      source: 'static-neutral',
     });
   });
 
@@ -241,7 +410,7 @@ describe('GitHub repo stats service', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(stats?.stars).toBe(42);
-    expect(service.getDiagnostics().source).toBe('live');
+    expect(service.getDiagnostics().source).toBe('browser-live');
   });
 
   it('honors explicit null storage and logger options', async () => {

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -200,6 +200,24 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('keeps GitHub star fallbacks neutral and non-numeric in every locale', () => {
+    for (const locale of AVAILABLE_LOCALES) {
+      for (const poi of getPoiDefinitions(locale)) {
+        for (const metric of poi.metrics ?? []) {
+          if (metric.source?.type !== 'githubStars') {
+            continue;
+          }
+          expect(metric.source.owner, `${locale}:${poi.id}`).toBeTruthy();
+          expect(metric.source.repo, `${locale}:${poi.id}`).toBeTruthy();
+          expect(metric.value, `${locale}:${poi.id}`).not.toMatch(/\d/);
+          expect(metric.source.fallback, `${locale}:${poi.id}`).not.toMatch(
+            /\d/
+          );
+        }
+      }
+    }
+  });
+
   it('removes the invalid DSPACE Mission Log link from every locale', () => {
     for (const locale of AVAILABLE_LOCALES) {
       const dspace = getPoiDefinitions(locale).find(


### PR DESCRIPTION
### Motivation
- Prevent POIs from presenting invented or hard-coded GitHub star counts by preferring a pod-local runtime cache and neutral localized fallbacks.
- Avoid browser fan-out to the public GitHub API in production/staging and make live fetches an explicit debug/dev opt-in.

### Description
- Add runtime cache support to the repo stats service: load and validate `/runtime/github-metrics.json`, apply a modest freshness grace window, hydrate an in-memory cache, and notify subscribers so POI tooltips update when cached stats arrive (`src/systems/github/repoStats.ts`).
- Extend diagnostics with explicit sources (`runtime-cache`, `runtime-cache-stale`, `browser-live`, `cached`, `static-neutral`) and runtime-cache metadata fields for observability.
- Gate browser live GitHub API requests behind debug flags (`?enableLiveGitHubMetrics=1` or `window.__ENABLE_LIVE_GITHUB_METRICS__`) so normal visitors rely on the pod-local cache or neutral fallback states.
- Update tests and E2E to cover runtime-cache behavior and neutral fallbacks, adjust Playwright spec to mock the runtime cache, and update locale tests to assert non-numeric neutral fallbacks and correct owner/repo presence.

### Testing
- Ran `npm run lint` — passed (no lint errors introduced).
- Ran `npm run typecheck` — failed due to pre-existing unrelated TypeScript errors in the repo (status: failed; these are outside the scope of this change). 
- Ran focused unit tests `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts` — passed.
- Ran full test suite `npm run test:ci` — all tests passed (1000 tests).
- Built distribution `npm run build` — succeeded.
- Ran Playwright E2E `npm run test:e2e -- playwright/github-metrics-fallback.spec.ts` — initially required browser install; after installing deps the E2E passed.
- Docs and links checks `npm run docs:check` / `npm run smoke` / `npm run format:check` — passed.

All changes are confined to the GitHub metrics service, related POI wiring/tests, Playwright coverage, and docs; no secrets or credentials were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221b8a4f48832f95a20daff158c6fd)