### PR TITLE
✨ Use runtime GitHub metrics cache

### DIFF
--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -50,7 +50,7 @@ layer without guessing where functionality lives.
   performance budgets. Also exposes POI copy consumed across systems and UI.
 - [`src/systems/`](../../src/systems/) – keyboard controls, audio pipelines,
   movement prediction, collision detection, mode failover, HUD control handles,
-  and the GitHub repo stats service that streams live metrics into POIs.
+  and the GitHub repo stats service that reads the pod-local runtime cache before updating POIs.
   Systems never import from `src/ui/`.
 - [`src/scene/`](../../src/scene/) – avatar importers, environmental builds,
   POI registries, lighting helpers, and structural meshes. Scene code consumes
@@ -58,6 +58,21 @@ layer without guessing where functionality lives.
 - [`src/ui/`](../../src/ui/) – HUD layout, accessibility bridges, immersive URL
   helpers, and stylesheet entry points. UI reads assets/systems and mirrors
   them for DOM accessibility.
+
+### GitHub POI metrics
+
+Public GitHub star counts are not embedded in locale copy. Deployed pods expose
+`/runtime/github-metrics.json`, refreshed by an unauthenticated sidecar against
+public GitHub repository metadata. The static frontend reads that pod-local JSON
+first and treats invalid or stale data as unavailable, so POIs show localized
+neutral copy such as “Syncing from GitHub…” instead of invented counts. Values may
+drift by up to the sidecar refresh interval plus a small grace window for late
+hourly refreshes.
+
+Normal staging and production browser sessions do not fan out direct GitHub API
+requests. Browser live fetch is reserved for explicit debug/development mode via
+`?enableLiveGitHubMetrics=1` or the test hook, and no GitHub token, PAT, app
+secret, or other credential is required for public star metrics.
 
 ### State surfaces & consumers
 

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -2,10 +2,16 @@ import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 const IMMERSIVE_GITHUB_METRICS_URL =
-  '/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1';
+  '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_DEBUG_GITHUB_METRICS_URL = `${IMMERSIVE_GITHUB_METRICS_URL}&enableLiveGitHubMetrics=1`;
 
 interface GitHubMetricsDiagnostics {
-  source: 'live' | 'cached' | 'static-fallback';
+  source:
+    | 'runtime-cache'
+    | 'runtime-cache-stale'
+    | 'browser-live'
+    | 'cached'
+    | 'static-neutral';
   requestCount: number;
   suppressedRequestCount: number;
   lastErrorStatus: number | 'network' | null;
@@ -27,10 +33,80 @@ const collectConsole = (page: Page) => {
 };
 
 test.describe('GitHub repo metrics fallback', () => {
-  test('keeps immersive stable and suppresses fan-out when GitHub returns 403', async ({
+  test('updates a POI tooltip from runtime cache without browser fan-out', async ({
+    page,
+  }) => {
+    await page.route('/runtime/github-metrics.json', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2999-06-03T01:15:00.000Z',
+          source: 'github-api',
+          repos: {
+            'futuroptimist/danielsmith.io': {
+              owner: 'futuroptimist',
+              repo: 'danielsmith.io',
+              stars: 1234,
+              watchers: 5,
+              forks: 6,
+              openIssues: 7,
+              pushedAt: '2026-06-03T00:00:00Z',
+              fetchedAt: '2026-06-03T00:00:00.000Z',
+              htmlUrl: 'https://github.com/futuroptimist/danielsmith.io',
+            },
+          },
+          errors: {},
+        }),
+      })
+    );
+    const liveRequests: string[] = [];
+    await page.route('https://api.github.com/repos/**', (route) => {
+      liveRequests.push(route.request().url());
+      return route.abort();
+    });
+
+    await page.goto(IMMERSIVE_GITHUB_METRICS_URL, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.appMode === 'immersive',
+      undefined,
+      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+    );
+
+    const tooltip = page.locator('.poi-tooltip-overlay');
+    await page.keyboard.press('KeyE');
+    await expect(tooltip).toHaveAttribute('aria-hidden', 'false');
+    await expect(
+      tooltip.locator('.poi-tooltip-overlay__metrics')
+    ).toContainText(/1\.2K stars|1,234 stars/i);
+
+    const diagnostics = await page.evaluate<GitHubMetricsDiagnostics>(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).portfolio.githubMetrics.getDiagnostics();
+    });
+    expect(diagnostics).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      lastErrorStatus: null,
+    });
+    expect(liveRequests).toEqual([]);
+  });
+
+  test('keeps immersive stable and suppresses fan-out when GitHub returns 403 in debug live mode', async ({
     page,
   }) => {
     const consoleMessages = collectConsole(page);
+    await page.route('/runtime/github-metrics.json', (route) =>
+      route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: '{}',
+      })
+    );
     await page.route('https://api.github.com/repos/**', (route) =>
       route.fulfill({
         status: 403,
@@ -50,7 +126,7 @@ test.describe('GitHub repo metrics fallback', () => {
       });
     });
 
-    await page.goto(IMMERSIVE_GITHUB_METRICS_URL, {
+    await page.goto(IMMERSIVE_DEBUG_GITHUB_METRICS_URL, {
       waitUntil: 'domcontentloaded',
     });
     await page.waitForFunction(
@@ -73,7 +149,7 @@ test.describe('GitHub repo metrics fallback', () => {
     });
 
     expect(diagnostics).toMatchObject({
-      source: 'static-fallback',
+      source: 'static-neutral',
       requestCount: 1,
       lastErrorStatus: 403,
     });
@@ -90,7 +166,7 @@ test.describe('GitHub repo metrics fallback', () => {
         (message) => !message.includes('Failed to load resource')
       )
     ).toEqual([]);
-    expect(consoleMessages.errors).toHaveLength(1);
+    expect(consoleMessages.errors).toHaveLength(2);
     expect(
       consoleMessages.warnings.filter((message) =>
         message.includes('[github-metrics]')

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -919,6 +919,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
+            visibility: 'private',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -1033,7 +1033,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', undefined, 'democratizedspace'),
+          source: starSource('dspace', 'private', 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -755,6 +755,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
+            visibility: 'private',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -13,7 +13,12 @@ export interface GitHubRepoStats {
 
 export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
 
-export type GitHubRepoMetricsSource = 'live' | 'cached' | 'static-fallback';
+export type GitHubRepoMetricsSource =
+  | 'runtime-cache'
+  | 'runtime-cache-stale'
+  | 'browser-live'
+  | 'cached'
+  | 'static-neutral';
 
 export interface GitHubRepoStatsDiagnostics {
   source: GitHubRepoMetricsSource;
@@ -48,6 +53,8 @@ const BACKOFF_STORAGE_KEY = 'danielsmith.io:github-repo-stats:backoff';
 const DEFAULT_SUCCESS_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_FAILURE_BACKOFF_MS = 15 * 60 * 1000;
 const DEFAULT_FETCH_TIMEOUT_MS = 3500;
+const DEFAULT_RUNTIME_CACHE_URL = '/runtime/github-metrics.json';
+const DEFAULT_RUNTIME_CACHE_GRACE_MS = 30 * 60 * 1000;
 const WARNING_SESSION_KEY = 'danielsmith.io:github-repo-stats:warning-shown';
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
@@ -78,6 +85,8 @@ export interface GitHubRepoStatsServiceOptions {
   successCacheTtlMs?: number;
   failureBackoffMs?: number;
   fetchTimeoutMs?: number;
+  runtimeCacheUrl?: string | null;
+  runtimeCacheGraceMs?: number;
   AbortControllerImpl?: typeof AbortController;
 }
 
@@ -99,7 +108,7 @@ const makeStorageKey = (identifier: GitHubRepoIdentifier): string =>
   `${CACHE_STORAGE_PREFIX}${makeCacheKey(identifier)}`;
 
 const shouldAttemptLiveFetch = (() => {
-  const globalScope = globalThis as Partial<
+  const globalScope = globalThis as unknown as Partial<
     Window & { __ENABLE_LIVE_GITHUB_METRICS__?: boolean }
   >;
   if (globalScope.__ENABLE_LIVE_GITHUB_METRICS__) {
@@ -110,14 +119,7 @@ const shouldAttemptLiveFetch = (() => {
     return false;
   }
   const params = new URLSearchParams(location.search);
-  if (params.get('enableLiveGitHubMetrics') === '1') {
-    return true;
-  }
-  const hostname = location.hostname.toLowerCase();
-  if (hostname === 'danielsmith.io' || hostname.endsWith('.danielsmith.io')) {
-    return true;
-  }
-  return false;
+  return params.get('enableLiveGitHubMetrics') === '1';
 })();
 
 const getBrowserStorage = (key: 'localStorage' | 'sessionStorage') => {
@@ -221,6 +223,77 @@ const toIso = (timestamp: number | null): string | null => {
   return new Date(timestamp).toISOString();
 };
 
+const parseTimestamp = (value: unknown): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+interface RuntimeGitHubMetricsEntry {
+  identifier: GitHubRepoIdentifier;
+  stats: GitHubRepoStats;
+}
+
+interface RuntimeGitHubMetricsParseResult {
+  entries: RuntimeGitHubMetricsEntry[];
+  stale: boolean;
+}
+
+const parseRuntimeGitHubMetrics = (
+  payload: unknown,
+  nowMs: number,
+  graceMs: number
+): RuntimeGitHubMetricsParseResult | null => {
+  if (!isRecord(payload) || payload.schemaVersion !== 1) {
+    return null;
+  }
+  const generatedAt = parseTimestamp(payload.generatedAt);
+  const expiresAt = parseTimestamp(payload.expiresAt);
+  if (generatedAt === null || expiresAt === null || generatedAt > nowMs) {
+    return null;
+  }
+  const stale = expiresAt + graceMs < nowMs;
+  if (stale) {
+    return { entries: [], stale: true };
+  }
+  if (!isRecord(payload.repos)) {
+    return null;
+  }
+  const entries: RuntimeGitHubMetricsEntry[] = [];
+  Object.values(payload.repos).forEach((repoPayload) => {
+    if (!isRecord(repoPayload)) {
+      return;
+    }
+    const { owner, repo } = repoPayload;
+    if (typeof owner !== 'string' || typeof repo !== 'string') {
+      return;
+    }
+    const fetchedAt = parseTimestamp(repoPayload.fetchedAt) ?? generatedAt;
+    if (fetchedAt > nowMs) {
+      return;
+    }
+    entries.push({
+      identifier: { owner, repo },
+      stats: {
+        stars: sanitizeNumber(repoPayload.stars),
+        watchers: sanitizeNumber(repoPayload.watchers),
+        forks: sanitizeNumber(repoPayload.forks),
+        openIssues: sanitizeNumber(repoPayload.openIssues),
+        pushedAt:
+          typeof repoPayload.pushedAt === 'string'
+            ? repoPayload.pushedAt
+            : null,
+      },
+    });
+  });
+  return { entries, stale: false };
+};
+
 export function createGitHubRepoStatsService(
   fetchImpl: typeof fetch | undefined = globalThis.fetch,
   options: GitHubRepoStatsServiceOptions = {}
@@ -241,13 +314,21 @@ export function createGitHubRepoStatsService(
   const failureBackoffMs =
     options.failureBackoffMs ?? DEFAULT_FAILURE_BACKOFF_MS;
   const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const runtimeCacheUrl =
+    options.runtimeCacheUrl === undefined
+      ? DEFAULT_RUNTIME_CACHE_URL
+      : options.runtimeCacheUrl;
+  const runtimeCacheGraceMs =
+    options.runtimeCacheGraceMs ?? DEFAULT_RUNTIME_CACHE_GRACE_MS;
   const AbortControllerTarget =
     options.AbortControllerImpl ?? globalThis.AbortController;
   const cache = new Map<string, MemoryCacheEntry>();
   const listeners = new Map<string, Set<GitHubRepoStatsListener>>();
   const inFlight = new Map<string, Promise<GitHubRepoStats | null>>();
+  let runtimeCacheRequest: Promise<boolean> | null = null;
+  let runtimeCacheAttempted = false;
   const diagnostics = {
-    source: 'static-fallback' as GitHubRepoMetricsSource,
+    source: 'static-neutral' as GitHubRepoMetricsSource,
     requestCount: 0,
     suppressedRequestCount: 0,
     lastErrorStatus: null as ErrorStatus | null,
@@ -294,7 +375,7 @@ export function createGitHubRepoStatsService(
     diagnostics.warningCount += 1;
     safeWriteJson(sessionStorage, WARNING_SESSION_KEY, true);
     logger.warn(
-      '[github-metrics] Live GitHub repo metrics are temporarily unavailable; using cached/static project metrics.',
+      '[github-metrics] GitHub repo metrics are temporarily unavailable; using cached or neutral project metrics.',
       {
         status,
         backoffExpiresAt: backoff ? toIso(backoff.expiresAt) : null,
@@ -303,18 +384,24 @@ export function createGitHubRepoStatsService(
   };
 
   const readCachedEntry = (
-    identifier: GitHubRepoIdentifier
+    identifier: GitHubRepoIdentifier,
+    includeStored = true
   ): MemoryCacheEntry | null => {
     const key = makeCacheKey(identifier);
     const cached = cache.get(key);
     if (cached) {
       return cached;
     }
-    const stored = normalizeCachedRecord(
-      safeReadJson<CachedStatsRecord>(localStorage, makeStorageKey(identifier)),
-      now(),
-      successCacheTtlMs
-    );
+    const stored = includeStored
+      ? normalizeCachedRecord(
+          safeReadJson<CachedStatsRecord>(
+            localStorage,
+            makeStorageKey(identifier)
+          ),
+          now(),
+          successCacheTtlMs
+        )
+      : null;
     if (stored) {
       cache.set(key, stored);
       return stored;
@@ -324,10 +411,11 @@ export function createGitHubRepoStatsService(
 
   const writeCachedEntry = (
     identifier: GitHubRepoIdentifier,
-    stats: GitHubRepoStats
+    stats: GitHubRepoStats,
+    cachedAtOverride?: number
   ) => {
     const key = makeCacheKey(identifier);
-    const cachedAt = now();
+    const cachedAt = cachedAtOverride ?? now();
     const record: CachedStatsRecord = { stats, cachedAt };
     cache.set(key, {
       ...record,
@@ -356,12 +444,69 @@ export function createGitHubRepoStatsService(
     warnOnce(status);
   };
 
+  const refreshRuntimeCache = async (): Promise<boolean> => {
+    if (!fetchImpl || !runtimeCacheUrl || runtimeCacheAttempted) {
+      return false;
+    }
+    if (runtimeCacheRequest) {
+      return runtimeCacheRequest;
+    }
+    runtimeCacheAttempted = true;
+    runtimeCacheRequest = (async () => {
+      try {
+        const response = await fetchImpl(runtimeCacheUrl, {
+          headers: { Accept: 'application/json' },
+        });
+        if (!response.ok) {
+          diagnostics.lastErrorStatus = response.status;
+          diagnostics.lastErrorAt = now();
+          diagnostics.source = 'static-neutral';
+          return false;
+        }
+        const parsed = parseRuntimeGitHubMetrics(
+          await response.json(),
+          now(),
+          runtimeCacheGraceMs
+        );
+        if (!parsed) {
+          diagnostics.source = 'static-neutral';
+          return false;
+        }
+        if (parsed.stale) {
+          diagnostics.source = 'runtime-cache-stale';
+          return false;
+        }
+        parsed.entries.forEach(({ identifier, stats }) => {
+          writeCachedEntry(identifier, stats);
+          notify(makeCacheKey(identifier), stats);
+        });
+        diagnostics.source = 'runtime-cache';
+        diagnostics.lastErrorStatus = null;
+        diagnostics.lastErrorAt = null;
+        return parsed.entries.length > 0;
+      } catch {
+        diagnostics.lastErrorStatus = 'network';
+        diagnostics.lastErrorAt = now();
+        diagnostics.source = 'static-neutral';
+        return false;
+      } finally {
+        runtimeCacheRequest = null;
+      }
+    })();
+    return runtimeCacheRequest;
+  };
+
   const getCachedStats = (
     identifier: GitHubRepoIdentifier
   ): GitHubRepoStats | null => {
-    const entry = readCachedEntry(identifier);
+    const entry = readCachedEntry(identifier, allowLiveFetch);
     if (entry) {
-      diagnostics.source = diagnostics.source === 'live' ? 'live' : 'cached';
+      diagnostics.source =
+        diagnostics.source === 'browser-live'
+          ? 'browser-live'
+          : diagnostics.source === 'runtime-cache'
+            ? 'runtime-cache'
+            : 'cached';
     }
     return entry?.stats ?? null;
   };
@@ -378,7 +523,7 @@ export function createGitHubRepoStatsService(
     }
     repoListeners.add(listener);
 
-    const cached = readCachedEntry(identifier)?.stats;
+    const cached = readCachedEntry(identifier, allowLiveFetch)?.stats;
     if (cached) {
       queueMicrotask(() => {
         if (listeners.get(key)?.has(listener)) {
@@ -403,8 +548,8 @@ export function createGitHubRepoStatsService(
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null> => {
     const key = makeCacheKey(identifier);
-    const cached = readCachedEntry(identifier);
-    if (cached && cached.freshUntil > now()) {
+    const cached = readCachedEntry(identifier, allowLiveFetch);
+    if (cached && cached.freshUntil > now() && runtimeCacheAttempted) {
       diagnostics.source = 'cached';
       return cached.stats;
     }
@@ -412,14 +557,21 @@ export function createGitHubRepoStatsService(
     if (existing) {
       return existing;
     }
+    await refreshRuntimeCache();
+    const runtimeCached = readCachedEntry(identifier, allowLiveFetch);
+    if (runtimeCached && runtimeCached.freshUntil > now()) {
+      diagnostics.source =
+        diagnostics.source === 'runtime-cache' ? 'runtime-cache' : 'cached';
+      return runtimeCached.stats;
+    }
     if (!fetchImpl || !allowLiveFetch) {
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
-      return cached?.stats ?? null;
+      diagnostics.source = runtimeCached ? 'cached' : diagnostics.source;
+      return runtimeCached?.stats ?? null;
     }
     if (isBackoffActive(backoff, now())) {
       diagnostics.suppressedRequestCount += 1;
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
-      return cached?.stats ?? null;
+      diagnostics.source = runtimeCached ? 'cached' : 'static-neutral';
+      return runtimeCached?.stats ?? null;
     }
     if (backoff) {
       backoff = null;
@@ -441,8 +593,8 @@ export function createGitHubRepoStatsService(
         );
         if (!response.ok) {
           recordFailure(response.status);
-          diagnostics.source = cached ? 'cached' : 'static-fallback';
-          return cached?.stats ?? null;
+          diagnostics.source = runtimeCached ? 'cached' : 'static-neutral';
+          return runtimeCached?.stats ?? null;
         }
         const data = (await response.json()) as Record<string, unknown>;
         const stats: GitHubRepoStats = {
@@ -455,15 +607,15 @@ export function createGitHubRepoStatsService(
           pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
         };
         writeCachedEntry(identifier, stats);
-        diagnostics.source = 'live';
+        diagnostics.source = 'browser-live';
         diagnostics.lastErrorStatus = null;
         diagnostics.lastErrorAt = null;
         notify(key, stats);
         return stats;
       } catch {
         recordFailure('network');
-        diagnostics.source = cached ? 'cached' : 'static-fallback';
-        return cached?.stats ?? null;
+        diagnostics.source = runtimeCached ? 'cached' : 'static-neutral';
+        return runtimeCached?.stats ?? null;
       } finally {
         if (timeoutId) {
           clearTimeout(timeoutId);

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -44,7 +44,7 @@ class MockRepoStatsService implements GitHubRepoStatsService {
 
   getDiagnostics() {
     return {
-      source: 'static-fallback' as const,
+      source: 'static-neutral' as const,
       requestCount: this.requested.length,
       suppressedRequestCount: 0,
       lastErrorStatus: null,

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -27,6 +27,7 @@ const createOptions = (overrides: Record<string, unknown> = {}) => ({
   logger: { warn: vi.fn() },
   now: () => 1_000,
   fetchTimeoutMs: 0,
+  runtimeCacheUrl: null,
   ...overrides,
 });
 
@@ -67,7 +68,7 @@ describe('GitHub repo stats service', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0][0]).toEqual(stats);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'live',
+      source: 'browser-live',
       requestCount: 1,
       lastErrorStatus: null,
     });
@@ -95,7 +96,7 @@ describe('GitHub repo stats service', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'static-fallback',
+      source: 'static-neutral',
       requestCount: 1,
       lastErrorStatus: 403,
       warningCount: 1,
@@ -124,7 +125,7 @@ describe('GitHub repo stats service', () => {
       requestCount: 1,
       suppressedRequestCount: 1,
       lastErrorStatus: 429,
-      source: 'static-fallback',
+      source: 'static-neutral',
     });
   });
 
@@ -241,7 +242,7 @@ describe('GitHub repo stats service', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(stats?.stars).toBe(42);
-    expect(service.getDiagnostics().source).toBe('live');
+    expect(service.getDiagnostics().source).toBe('browser-live');
   });
 
   it('honors explicit null storage and logger options', async () => {
@@ -345,5 +346,135 @@ describe('GitHub repo stats service', () => {
       openIssues: 0,
       pushedAt: null,
     });
+  });
+
+  it('loads valid runtime cache stats before browser live fallback', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        source: 'github-api',
+        repos: {
+          'futuroptimist/token.place': {
+            owner: 'futuroptimist',
+            repo: 'token.place',
+            stars: 6,
+            watchers: 99,
+            forks: 1,
+            openIssues: 2,
+            pushedAt: '2026-06-03T00:00:00Z',
+            fetchedAt: '2026-06-03T00:00:00.000Z',
+            htmlUrl: 'https://github.com/futuroptimist/token.place',
+          },
+        },
+        errors: {},
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    const stats = await service.requestStats({
+      owner: 'futuroptimist',
+      repo: 'token.place',
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toBe('/runtime/github-metrics.json');
+    expect(stats).toMatchObject({ stars: 6, watchers: 99 });
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      lastErrorStatus: null,
+    });
+  });
+
+  it('treats stale runtime cache as unavailable neutral state', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:00:00.000Z',
+        source: 'github-api',
+        repos: {
+          'futuroptimist/flywheel': {
+            owner: 'futuroptimist',
+            repo: 'flywheel',
+            stars: 999,
+            watchers: 1,
+            forks: 0,
+            openIssues: 0,
+            fetchedAt: '2026-06-03T00:00:00.000Z',
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        now: () => Date.parse('2026-06-03T02:00:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics().source).toBe('runtime-cache-stale');
+  });
+
+  it('ignores invalid runtime cache and does not fan out live requests by default', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toBe('/runtime/github-metrics.json');
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      requestCount: 0,
+    });
+  });
+
+  it('maps browser live stars from stargazers_count, not watchers_count', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        stargazers_count: 42,
+        watchers_count: 9876,
+        subscribers_count: 5,
+        forks_count: 0,
+        open_issues_count: 0,
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({ allowLiveFetch: true })
+    );
+
+    const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
+
+    expect(stats).toMatchObject({ stars: 42, watchers: 5 });
+    expect(stats?.stars).not.toBe(9876);
   });
 });

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -200,6 +200,36 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('keeps GitHub star fallbacks neutral and marks DSPACE private', () => {
+    const numericStarFallback =
+      /\b\d[\d,.]*(?:\.\d+)?\s*(?:k|m)?\+?\s*(?:stars?|星标|Sterne|csillag|estrellas|estrelas)\b/i;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      for (const poi of getPoiDefinitions(locale)) {
+        for (const metric of poi.metrics ?? []) {
+          if (metric.source?.type !== 'githubStars') {
+            continue;
+          }
+          expect(metric.value, `${locale}:${poi.id}`).not.toMatch(
+            numericStarFallback
+          );
+          expect(metric.source.fallback, `${locale}:${poi.id}`).not.toMatch(
+            numericStarFallback
+          );
+        }
+      }
+
+      const dspaceStars = getPoiDefinitions(locale)
+        .find((poi) => poi.id === 'dspace-backyard-rocket')
+        ?.metrics?.find((metric) => metric.source?.type === 'githubStars');
+      expect(dspaceStars?.source).toMatchObject({
+        owner: 'democratizedspace',
+        repo: 'dspace',
+        visibility: 'private',
+      });
+    }
+  });
+
   it('removes the invalid DSPACE Mission Log link from every locale', () => {
     for (const locale of AVAILABLE_LOCALES) {
       const dspace = getPoiDefinitions(locale).find(


### PR DESCRIPTION
### Motivation
- POI GitHub star metrics must never present invented numeric fallbacks as facts, and public star counts should be sourced from a pod-local cache when available.
- Avoid browser fan-out to the public GitHub API for every visitor; prefer a sidecar-served `/runtime/github-metrics.json` runtime cache and neutral localized fallback states when unavailable.

### Description
- Add runtime-cache support to the GitHub repo stats service (`src/systems/github/repoStats.ts`) including schema parsing/validation, stale detection, diagnostics states (`runtime-cache`, `runtime-cache-stale`, `browser-live`, `cached`, `static-neutral`), and a configurable `runtimeCacheUrl` with a small grace window.
- Prefer values from the pod-local `/runtime/github-metrics.json` before attempting browser live fetch, and gate live browser fetches behind explicit debug/test flags (`?enableLiveGitHubMetrics=1` or test hooks).
- Update POI copy to remove invented numeric fallbacks and mark the `democratizedspace/dspace` POI as `visibility: 'private'` in localized assets so it is not treated as a public live-metrics target (`src/assets/i18n/locales/*` and `src/assets/i18n/locales/latinLocaleOverrides.ts`).
- Wire runtime-cache updates into the existing subscription/notify model so tooltips and in-world HUD update when cache values arrive, and add/adjust tests and Playwright coverage to assert cache-first behavior and neutral fallbacks (`src/tests/*`, `playwright/github-metrics-fallback.spec.ts`).
- Document the runtime contract and behavior in the architecture docs (`docs/architecture/scene-stack.md`).

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both succeeded.
- Ran targeted unit tests with `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts`, and the targeted suites passed; the full test suite `npm run test:ci` also passed locally (all Vitest tests green).
- Performed typecheck with `npm run typecheck`, which surfaced unrelated repository TypeScript errors (existing upstream type issues) and therefore failed; these are unrelated to the new runtime cache logic.
- Built the app with `npm run build`, which completed and produced `dist` artifacts.
- Executed Playwright E2E `npm run test:e2e -- playwright/github-metrics-fallback.spec.ts`; initial failures were due to missing Playwright browser binaries and host deps, resolved by running `npx playwright install chromium` and `npx playwright install-deps`, after which the Playwright tests passed and confirmed the POI tooltip updates from the runtime cache without browser fan-out and debug-mode 403 behavior.
- Ran `npm run docs:check` and `npm run smoke` which passed; `node scripts/check-links.cjs` produced network reachability warnings but completed successfully, and `./scripts/scan-secrets.py` reported no high-risk secrets.

Notes: `npm run typecheck` failing is a pre-existing repository issue unrelated to these changes; CI should ensure Playwright browser dependencies are available (the branch installs browsers locally during the run in my environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221b8a4f48832f95a20daff158c6fd)