### PR TITLE
Use runtime GitHub metrics cache

### DIFF
--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -50,7 +50,7 @@ layer without guessing where functionality lives.
   performance budgets. Also exposes POI copy consumed across systems and UI.
 - [`src/systems/`](../../src/systems/) – keyboard controls, audio pipelines,
   movement prediction, collision detection, mode failover, HUD control handles,
-  and the GitHub repo stats service that streams live metrics into POIs.
+  and the GitHub repo stats service that streams runtime-cached metrics into POIs.
   Systems never import from `src/ui/`.
 - [`src/scene/`](../../src/scene/) – avatar importers, environmental builds,
   POI registries, lighting helpers, and structural meshes. Scene code consumes
@@ -91,6 +91,13 @@ layer without guessing where functionality lives.
   [`src/scene/poi/tooltipOverlay.ts`](../../src/scene/poi/tooltipOverlay.ts), while
   [`src/scene/poi/githubMetrics.ts`](../../src/scene/poi/githubMetrics.ts)
   wires GitHub star counts into both the in-world tooltip and HUD overlay.
+  Deployed pods expose public repository metrics through the sidecar-populated
+  `/runtime/github-metrics.json` file, which the static app reads before using
+  any browser cache. Normal staging/production sessions do not fan out direct
+  GitHub API calls; the optional `?enableLiveGitHubMetrics=1` debug path keeps
+  browser live fetches available for local diagnostics only. Cache values can
+  drift by the hourly sidecar refresh interval plus a short grace window, and
+  no GitHub token or other secret is required for public star counts.
 - **Accessibility overlays** – `HudFocusAnnouncerHandle` flows from systems
   into DOM overlays: `src/ui/accessibility/ariaBridges.ts` registers live
   regions, while Playwright specs assert emitted announcements against

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -220,8 +220,8 @@ Focus: anchor each highlighted project with an interactive artifact.
      screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
      - ✅ Undershelf LED wash now breathes with POI emphasis while calm/photosensitive presets
        dampen pulses and flicker spikes.
-     - ✅ Live GitHub star telemetry now feeds the media wall badge so the display mirrors the
-       latest repo metrics alongside the POI overlays.
+     - ✅ Runtime-cached GitHub star telemetry now feeds the media wall badge so the display
+       mirrors sidecar-backed repo metrics alongside the POI overlays without invented counts.
      - ✅ Floor-level clearance halo now pulses with POI focus to keep walkable space obvious
        while accessibility presets soften its bloom and tint transitions.
    - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
@@ -514,7 +514,7 @@ Ideas to evaluate after the core experience is stable:
 - ✅ Procedural storytelling AI that narrates the journey between POIs.
   - ✅ Procedural narrator now weaves journey beats into the HUD story log whenever new exhibits are discovered.
 - ✅ Integration with GitHub API for live repo stats and contribution heatmaps.
-  - ✅ Live GitHub star counts now stream into POI metric panels via the repo stats service.
+  - ✅ GitHub star counts now load from the pod-local runtime cache first, with neutral localized fallback states when the cache is unavailable.
 - ✅ Exportable "press kit" mode now packages screenshots, POI blurbs, and metrics for media kits.
   - ✅ Press kit summary generator now exports POI metadata and performance budgets to JSON for packaging.
   - ✅ Press kit performance report now surfaces headroom for materials, draw calls, and texture

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -1,11 +1,16 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
-const IMMERSIVE_GITHUB_METRICS_URL =
-  '/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1';
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_GITHUB_METRICS_URL = `${IMMERSIVE_PREVIEW_URL}&enableLiveGitHubMetrics=1`;
 
 interface GitHubMetricsDiagnostics {
-  source: 'live' | 'cached' | 'static-fallback';
+  source:
+    | 'runtime-cache'
+    | 'runtime-cache-stale'
+    | 'browser-live'
+    | 'cached'
+    | 'static-neutral';
   requestCount: number;
   suppressedRequestCount: number;
   lastErrorStatus: number | 'network' | null;
@@ -24,6 +29,14 @@ const collectConsole = (page: Page) => {
     }
   });
   return { errors, warnings };
+};
+
+const waitForImmersiveReady = async (page: Page) => {
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
 };
 
 test.describe('GitHub repo metrics fallback', () => {
@@ -53,11 +66,7 @@ test.describe('GitHub repo metrics fallback', () => {
     await page.goto(IMMERSIVE_GITHUB_METRICS_URL, {
       waitUntil: 'domcontentloaded',
     });
-    await page.waitForFunction(
-      () => document.documentElement.dataset.appMode === 'immersive',
-      undefined,
-      { timeout: IMMERSIVE_READY_TIMEOUT_MS }
-    );
+    await waitForImmersiveReady(page);
     await page.waitForFunction(
       () =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -73,7 +82,7 @@ test.describe('GitHub repo metrics fallback', () => {
     });
 
     expect(diagnostics).toMatchObject({
-      source: 'static-fallback',
+      source: 'static-neutral',
       requestCount: 1,
       lastErrorStatus: 403,
     });
@@ -96,5 +105,74 @@ test.describe('GitHub repo metrics fallback', () => {
         message.includes('[github-metrics]')
       )
     ).toHaveLength(1);
+  });
+
+  test('updates a POI tooltip from neutral copy to runtime cache stars', async ({
+    page,
+  }) => {
+    let releaseRuntimeCache: (() => void) | undefined;
+    const runtimeCacheRequested = new Promise<void>((resolve) => {
+      page.route('/runtime/github-metrics.json', async (route) => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseRuntimeCache = release;
+        });
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            schemaVersion: 1,
+            generatedAt: '2026-06-03T00:00:00.000Z',
+            expiresAt: '2027-06-03T01:15:00.000Z',
+            source: 'github-api',
+            repos: {
+              'futuroptimist/danielsmith.io': {
+                owner: 'futuroptimist',
+                repo: 'danielsmith.io',
+                stars: 42,
+                watchers: 7,
+                forks: 3,
+                openIssues: 1,
+                pushedAt: '2026-06-03T00:00:00Z',
+                fetchedAt: '2026-06-03T00:00:00.000Z',
+                htmlUrl: 'https://github.com/futuroptimist/danielsmith.io',
+              },
+            },
+          }),
+        });
+      });
+    });
+    await page.route('https://api.github.com/repos/**', (route) =>
+      route.abort('blockedbyclient')
+    );
+
+    await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+    await waitForImmersiveReady(page);
+    await runtimeCacheRequested;
+
+    await page.keyboard.press('KeyE');
+    const tooltip = page.locator('.poi-tooltip-overlay');
+    await expect(tooltip).toHaveAttribute('aria-hidden', 'false');
+    await expect(tooltip).toContainText('Syncing');
+
+    releaseRuntimeCache?.();
+    await page.waitForFunction(
+      () =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).portfolio?.githubMetrics?.getDiagnostics?.()?.source ===
+        'runtime-cache',
+      undefined,
+      { timeout: 10_000 }
+    );
+
+    await expect(tooltip).toContainText('42 stars');
+    const diagnostics = await page.evaluate<GitHubMetricsDiagnostics>(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).portfolio.githubMetrics.getDiagnostics();
+    });
+    expect(diagnostics).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+    });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1851,7 +1851,13 @@ function initializeImmersiveScene(
     poiTooltipOverlay.setIdleState(idle);
     poiWorldTooltip.setIdleState(idle);
   });
-  const githubRepoStatsService = createGitHubRepoStatsService();
+  const liveGitHubMetricsEnabled =
+    new URLSearchParams(window.location.search).get(
+      'enableLiveGitHubMetrics'
+    ) === '1';
+  const githubRepoStatsService = createGitHubRepoStatsService(undefined, {
+    allowLiveFetch: liveGitHubMetricsEnabled,
+  });
   if (!window.portfolio) {
     window.portfolio = {};
   }
@@ -1863,6 +1869,7 @@ function initializeImmersiveScene(
     githubRepoMetrics = wireGitHubRepoMetrics({
       definitions: poiDefinitions,
       service: githubRepoStatsService,
+      allowLiveFetch: liveGitHubMetricsEnabled,
       onMetricsUpdated: (poiId) => {
         poiTooltipOverlay.notifyPoiUpdated(poiId);
         poiWorldTooltip.notifyPoiUpdated(poiId);

--- a/src/scene/poi/githubMetrics.ts
+++ b/src/scene/poi/githubMetrics.ts
@@ -26,6 +26,7 @@ interface RepoBucket {
 export interface WireGitHubRepoMetricsOptions {
   definitions: PoiDefinition[];
   service: GitHubRepoStatsService;
+  allowLiveFetch?: boolean;
   onMetricsUpdated?(poiId: PoiId): void;
   onRepoStatsUpdated?(update: {
     poiId: PoiId;
@@ -79,6 +80,7 @@ const isGitHubStarsSource = (
 export function wireGitHubRepoMetrics({
   definitions,
   service,
+  allowLiveFetch = false,
   onMetricsUpdated,
   onRepoStatsUpdated,
 }: WireGitHubRepoMetricsOptions): GitHubRepoMetricsController {
@@ -149,13 +151,14 @@ export function wireGitHubRepoMetrics({
     service.getDiagnostics().backoffExpiresAt !== null;
 
   const refreshAll = async () => {
-    const [firstBucket, ...remainingBuckets] = Array.from(repoMap.values());
-    if (!firstBucket) {
+    const buckets = Array.from(repoMap.values());
+
+    await service.loadRuntimeCache();
+    if (!allowLiveFetch) {
       return;
     }
 
-    await service.requestStats(firstBucket.identifier);
-    for (const bucket of remainingBuckets) {
+    for (const bucket of buckets) {
       if (hasActiveBackoff()) {
         return;
       }

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -27,7 +27,7 @@ export interface PoiMetricGitHubStarsSource {
    * their fallback values to avoid surfacing missing asset errors in the client.
    */
   visibility?: 'public' | 'private';
-  /** Format style for rendering live star counts. */
+  /** Format style for rendering resolved star counts. */
   format?: 'compact' | 'standard';
   /** Optional string template that receives the formatted value via `{value}`. */
   template?: string;

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -32,8 +32,10 @@ const CLEARANCE_MAX_OPACITY = 0.52;
 const CLEARANCE_BASE_COLOR = 0x10283b;
 const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
 
+type MediaWallStarCount = number | null;
+
 interface MediaWallScreenRendererOptions {
-  starCount: number;
+  starCount: MediaWallStarCount;
   width?: number;
   height?: number;
   redrawThrottleMs?: number;
@@ -44,7 +46,7 @@ class MediaWallScreenRenderer {
   private readonly context: CanvasRenderingContext2D;
   private readonly texture: CanvasTexture;
   private highlight = 0;
-  private starCount: number;
+  private starCount: MediaWallStarCount;
   private width: number;
   private height: number;
   private redrawThrottleMs: number;
@@ -76,9 +78,9 @@ class MediaWallScreenRenderer {
     return this.texture;
   }
 
-  setStarCount(count: number) {
-    if (!Number.isFinite(count) || count < 0) {
-      this.starCount = 0;
+  setStarCount(count: MediaWallStarCount) {
+    if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) {
+      this.starCount = null;
     } else {
       this.starCount = count;
     }
@@ -246,6 +248,9 @@ class MediaWallScreenRenderer {
   }
 
   private formatStarCount(): string {
+    if (this.starCount === null) {
+      return 'Syncing';
+    }
     if (this.starCount >= 1_000_000) {
       return `${(this.starCount / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
     }
@@ -265,7 +270,7 @@ function createScreenRenderer(
   detailPolicy = getSceneDetailPolicy('balanced')
 ): MediaWallScreenRenderer {
   return new MediaWallScreenRenderer({
-    starCount: detailPolicy.level === 'performance' ? 128 : 1280,
+    starCount: null,
     width: detailPolicy.textures.mediaWallScreen.width,
     height: detailPolicy.textures.mediaWallScreen.height,
     redrawThrottleMs: detailPolicy.updates.canvasRedrawThrottleMs,
@@ -353,7 +358,7 @@ export interface LivingRoomMediaWallPoiBindings {
 
 export interface LivingRoomMediaWallController {
   update(options: { elapsed: number; delta: number; emphasis: number }): void;
-  setStarCount(count: number): void;
+  setStarCount(count: MediaWallStarCount): void;
   dispose(): void;
 }
 

--- a/src/scene/structures/mediaWallStarBridge.ts
+++ b/src/scene/structures/mediaWallStarBridge.ts
@@ -1,21 +1,21 @@
 import type { LivingRoomMediaWallController } from './mediaWall';
 
-const sanitizeStarCount = (value: number | null | undefined): number => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return 0;
+const sanitizeStarCount = (value: number | null | undefined): number | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return null;
   }
-  return Math.max(0, Math.round(value));
+  return Math.round(value);
 };
 
 export interface MediaWallStarBridge {
   attach(controller: LivingRoomMediaWallController): void;
   detach(): void;
   updateStarCount(stars: number | null | undefined): void;
-  getStarCount(): number;
+  getStarCount(): number | null;
 }
 
 export const createMediaWallStarBridge = (
-  initialStars = 1280
+  initialStars: number | null = null
 ): MediaWallStarBridge => {
   let starCount = sanitizeStarCount(initialStars);
   let controller: LivingRoomMediaWallController | null = null;

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -13,7 +13,12 @@ export interface GitHubRepoStats {
 
 export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
 
-export type GitHubRepoMetricsSource = 'live' | 'cached' | 'static-fallback';
+export type GitHubRepoMetricsSource =
+  | 'runtime-cache'
+  | 'runtime-cache-stale'
+  | 'browser-live'
+  | 'cached'
+  | 'static-neutral';
 
 export interface GitHubRepoStatsDiagnostics {
   source: GitHubRepoMetricsSource;
@@ -31,6 +36,7 @@ export interface GitHubRepoStatsService {
   requestStats(
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null>;
+  loadRuntimeCache(): Promise<void>;
   subscribe(
     identifier: GitHubRepoIdentifier,
     listener: GitHubRepoStatsListener
@@ -46,6 +52,8 @@ const DEFAULT_HEADERS = {
 const CACHE_STORAGE_PREFIX = 'danielsmith.io:github-repo-stats:';
 const BACKOFF_STORAGE_KEY = 'danielsmith.io:github-repo-stats:backoff';
 const DEFAULT_SUCCESS_CACHE_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_RUNTIME_CACHE_URL = '/runtime/github-metrics.json';
+const DEFAULT_RUNTIME_CACHE_GRACE_MS = 30 * 60 * 1000;
 const DEFAULT_FAILURE_BACKOFF_MS = 15 * 60 * 1000;
 const DEFAULT_FETCH_TIMEOUT_MS = 3500;
 const WARNING_SESSION_KEY = 'danielsmith.io:github-repo-stats:warning-shown';
@@ -67,6 +75,25 @@ interface BackoffRecord {
 
 interface MemoryCacheEntry extends CachedStatsRecord {
   freshUntil: number;
+  source: 'runtime-cache' | 'runtime-cache-stale' | 'browser-live' | 'cached';
+}
+
+interface RuntimeRepoMetricRecord {
+  owner: string;
+  repo: string;
+  stars: number;
+  watchers: number;
+  forks: number;
+  openIssues: number;
+  pushedAt: string | null;
+}
+
+interface RuntimeMetricsCachePayload {
+  schemaVersion: 1;
+  generatedAt: string;
+  expiresAt: string;
+  source: string;
+  repos: Record<string, RuntimeRepoMetricRecord>;
 }
 
 export interface GitHubRepoStatsServiceOptions {
@@ -78,6 +105,8 @@ export interface GitHubRepoStatsServiceOptions {
   successCacheTtlMs?: number;
   failureBackoffMs?: number;
   fetchTimeoutMs?: number;
+  runtimeCacheUrl?: string;
+  runtimeCacheGraceMs?: number;
   AbortControllerImpl?: typeof AbortController;
 }
 
@@ -99,7 +128,7 @@ const makeStorageKey = (identifier: GitHubRepoIdentifier): string =>
   `${CACHE_STORAGE_PREFIX}${makeCacheKey(identifier)}`;
 
 const shouldAttemptLiveFetch = (() => {
-  const globalScope = globalThis as Partial<
+  const globalScope = globalThis as unknown as Partial<
     Window & { __ENABLE_LIVE_GITHUB_METRICS__?: boolean }
   >;
   if (globalScope.__ENABLE_LIVE_GITHUB_METRICS__) {
@@ -110,14 +139,7 @@ const shouldAttemptLiveFetch = (() => {
     return false;
   }
   const params = new URLSearchParams(location.search);
-  if (params.get('enableLiveGitHubMetrics') === '1') {
-    return true;
-  }
-  const hostname = location.hostname.toLowerCase();
-  if (hostname === 'danielsmith.io' || hostname.endsWith('.danielsmith.io')) {
-    return true;
-  }
-  return false;
+  return params.get('enableLiveGitHubMetrics') === '1';
 })();
 
 const getBrowserStorage = (key: 'localStorage' | 'sessionStorage') => {
@@ -199,6 +221,7 @@ const normalizeCachedRecord = (
     },
     cachedAt,
     freshUntil: cachedAt + ttlMs,
+    source: 'cached',
   };
 };
 
@@ -221,6 +244,86 @@ const toIso = (timestamp: number | null): string | null => {
   return new Date(timestamp).toISOString();
 };
 
+const parseIsoTimestamp = (value: unknown): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const parseRuntimeRepoRecord = (
+  key: string,
+  value: unknown
+): RuntimeRepoMetricRecord | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const [fallbackOwner, fallbackRepo] = key.split('/');
+  const owner =
+    typeof record.owner === 'string' && record.owner
+      ? record.owner
+      : fallbackOwner;
+  const repo =
+    typeof record.repo === 'string' && record.repo ? record.repo : fallbackRepo;
+  if (!owner || !repo || typeof record.stars !== 'number') {
+    return null;
+  }
+  return {
+    owner,
+    repo,
+    stars: sanitizeNumber(record.stars),
+    watchers: sanitizeNumber(record.watchers),
+    forks: sanitizeNumber(record.forks),
+    openIssues: sanitizeNumber(record.openIssues),
+    pushedAt: typeof record.pushedAt === 'string' ? record.pushedAt : null,
+  };
+};
+
+const parseRuntimeCachePayload = (
+  payload: unknown,
+  now: number,
+  graceMs: number
+): { payload: RuntimeMetricsCachePayload; stale: boolean } | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  const expiresAt = parseIsoTimestamp(record.expiresAt);
+  const generatedAt = parseIsoTimestamp(record.generatedAt);
+  if (
+    record.schemaVersion !== 1 ||
+    expiresAt === null ||
+    generatedAt === null
+  ) {
+    return null;
+  }
+  if (generatedAt > now || expiresAt + graceMs < now) {
+    return null;
+  }
+  if (!record.repos || typeof record.repos !== 'object') {
+    return null;
+  }
+  const repos: Record<string, RuntimeRepoMetricRecord> = {};
+  for (const [key, value] of Object.entries(record.repos)) {
+    const parsed = parseRuntimeRepoRecord(key, value);
+    if (parsed) {
+      repos[makeCacheKey(parsed)] = parsed;
+    }
+  }
+  return {
+    payload: {
+      schemaVersion: 1,
+      generatedAt: new Date(generatedAt).toISOString(),
+      expiresAt: new Date(expiresAt).toISOString(),
+      source: typeof record.source === 'string' ? record.source : 'unknown',
+      repos,
+    },
+    stale: expiresAt < now,
+  };
+};
+
 export function createGitHubRepoStatsService(
   fetchImpl: typeof fetch | undefined = globalThis.fetch,
   options: GitHubRepoStatsServiceOptions = {}
@@ -241,13 +344,16 @@ export function createGitHubRepoStatsService(
   const failureBackoffMs =
     options.failureBackoffMs ?? DEFAULT_FAILURE_BACKOFF_MS;
   const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const runtimeCacheUrl = options.runtimeCacheUrl ?? DEFAULT_RUNTIME_CACHE_URL;
+  const runtimeCacheGraceMs =
+    options.runtimeCacheGraceMs ?? DEFAULT_RUNTIME_CACHE_GRACE_MS;
   const AbortControllerTarget =
     options.AbortControllerImpl ?? globalThis.AbortController;
   const cache = new Map<string, MemoryCacheEntry>();
   const listeners = new Map<string, Set<GitHubRepoStatsListener>>();
   const inFlight = new Map<string, Promise<GitHubRepoStats | null>>();
   const diagnostics = {
-    source: 'static-fallback' as GitHubRepoMetricsSource,
+    source: 'static-neutral' as GitHubRepoMetricsSource,
     requestCount: 0,
     suppressedRequestCount: 0,
     lastErrorStatus: null as ErrorStatus | null,
@@ -294,7 +400,7 @@ export function createGitHubRepoStatsService(
     diagnostics.warningCount += 1;
     safeWriteJson(sessionStorage, WARNING_SESSION_KEY, true);
     logger.warn(
-      '[github-metrics] Live GitHub repo metrics are temporarily unavailable; using cached/static project metrics.',
+      '[github-metrics] GitHub repo metrics are temporarily unavailable; using cached or neutral project metrics.',
       {
         status,
         backoffExpiresAt: backoff ? toIso(backoff.expiresAt) : null,
@@ -309,6 +415,9 @@ export function createGitHubRepoStatsService(
     const cached = cache.get(key);
     if (cached) {
       return cached;
+    }
+    if (!allowLiveFetch) {
+      return null;
     }
     const stored = normalizeCachedRecord(
       safeReadJson<CachedStatsRecord>(localStorage, makeStorageKey(identifier)),
@@ -332,6 +441,7 @@ export function createGitHubRepoStatsService(
     cache.set(key, {
       ...record,
       freshUntil: cachedAt + successCacheTtlMs,
+      source: 'browser-live',
     });
     safeWriteJson(localStorage, makeStorageKey(identifier), record);
   };
@@ -361,7 +471,7 @@ export function createGitHubRepoStatsService(
   ): GitHubRepoStats | null => {
     const entry = readCachedEntry(identifier);
     if (entry) {
-      diagnostics.source = diagnostics.source === 'live' ? 'live' : 'cached';
+      diagnostics.source = entry.source;
     }
     return entry?.stats ?? null;
   };
@@ -405,7 +515,8 @@ export function createGitHubRepoStatsService(
     const key = makeCacheKey(identifier);
     const cached = readCachedEntry(identifier);
     if (cached && cached.freshUntil > now()) {
-      diagnostics.source = 'cached';
+      diagnostics.source =
+        cached.source === 'browser-live' ? 'cached' : cached.source;
       return cached.stats;
     }
     const existing = inFlight.get(key);
@@ -413,12 +524,12 @@ export function createGitHubRepoStatsService(
       return existing;
     }
     if (!fetchImpl || !allowLiveFetch) {
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
+      diagnostics.source = cached ? cached.source : 'static-neutral';
       return cached?.stats ?? null;
     }
     if (isBackoffActive(backoff, now())) {
       diagnostics.suppressedRequestCount += 1;
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
+      diagnostics.source = cached ? cached.source : 'static-neutral';
       return cached?.stats ?? null;
     }
     if (backoff) {
@@ -441,7 +552,7 @@ export function createGitHubRepoStatsService(
         );
         if (!response.ok) {
           recordFailure(response.status);
-          diagnostics.source = cached ? 'cached' : 'static-fallback';
+          diagnostics.source = cached ? cached.source : 'static-neutral';
           return cached?.stats ?? null;
         }
         const data = (await response.json()) as Record<string, unknown>;
@@ -455,14 +566,14 @@ export function createGitHubRepoStatsService(
           pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
         };
         writeCachedEntry(identifier, stats);
-        diagnostics.source = 'live';
+        diagnostics.source = 'browser-live';
         diagnostics.lastErrorStatus = null;
         diagnostics.lastErrorAt = null;
         notify(key, stats);
         return stats;
       } catch {
         recordFailure('network');
-        diagnostics.source = cached ? 'cached' : 'static-fallback';
+        diagnostics.source = cached ? cached.source : 'static-neutral';
         return cached?.stats ?? null;
       } finally {
         if (timeoutId) {
@@ -474,6 +585,57 @@ export function createGitHubRepoStatsService(
 
     inFlight.set(key, promise);
     return promise;
+  };
+
+  const loadRuntimeCache = async (): Promise<void> => {
+    if (!fetchImpl) {
+      diagnostics.source = 'static-neutral';
+      return;
+    }
+    try {
+      const response = await fetchImpl(runtimeCacheUrl, {
+        cache: 'no-store',
+        credentials: 'same-origin',
+      });
+      if (!response.ok) {
+        diagnostics.source = 'static-neutral';
+        return;
+      }
+      const parsed = parseRuntimeCachePayload(
+        await response.json(),
+        now(),
+        runtimeCacheGraceMs
+      );
+      if (!parsed) {
+        diagnostics.source = 'static-neutral';
+        return;
+      }
+      const source = parsed.stale ? 'runtime-cache-stale' : 'runtime-cache';
+      const expiresAt = Date.parse(parsed.payload.expiresAt);
+      for (const record of Object.values(parsed.payload.repos)) {
+        const identifier = { owner: record.owner, repo: record.repo };
+        const key = makeCacheKey(identifier);
+        const stats: GitHubRepoStats = {
+          stars: record.stars,
+          watchers: record.watchers,
+          forks: record.forks,
+          openIssues: record.openIssues,
+          pushedAt: record.pushedAt,
+        };
+        cache.set(key, {
+          stats,
+          cachedAt: Date.parse(parsed.payload.generatedAt),
+          freshUntil: expiresAt,
+          source,
+        });
+        notify(key, stats);
+      }
+      diagnostics.source = source;
+      diagnostics.lastErrorStatus = null;
+      diagnostics.lastErrorAt = null;
+    } catch {
+      diagnostics.source = 'static-neutral';
+    }
   };
 
   const getDiagnostics = (): GitHubRepoStatsDiagnostics => ({
@@ -492,6 +654,7 @@ export function createGitHubRepoStatsService(
   return {
     getCachedStats,
     requestStats,
+    loadRuntimeCache,
     subscribe,
     getDiagnostics,
   };

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -28,6 +28,10 @@ class MockRepoStatsService implements GitHubRepoStatsService {
     return this.cache.get(this.key(identifier)) ?? null;
   }
 
+  loadRuntimeCache(): Promise<void> {
+    return Promise.resolve();
+  }
+
   requestStats(
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null> {
@@ -44,7 +48,7 @@ class MockRepoStatsService implements GitHubRepoStatsService {
 
   getDiagnostics() {
     return {
-      source: 'static-fallback' as const,
+      source: 'static-neutral' as const,
       requestCount: this.requested.length,
       suppressedRequestCount: 0,
       lastErrorStatus: null,
@@ -204,6 +208,7 @@ describe('wireGitHubRepoMetrics', () => {
     const controller = wireGitHubRepoMetrics({
       definitions,
       service,
+      allowLiveFetch: true,
       onMetricsUpdated: (poiId) => updated.push(poiId),
     });
 
@@ -283,7 +288,11 @@ describe('wireGitHubRepoMetrics', () => {
     ];
     const service = new MockRepoStatsService();
     service.enterBackoffAfterFirstRequest = true;
-    const controller = wireGitHubRepoMetrics({ definitions, service });
+    const controller = wireGitHubRepoMetrics({
+      definitions,
+      service,
+      allowLiveFetch: true,
+    });
 
     await controller.refreshAll();
 
@@ -346,7 +355,11 @@ describe('wireGitHubRepoMetrics', () => {
       }
       return Promise.resolve(null);
     };
-    const controller = wireGitHubRepoMetrics({ definitions, service });
+    const controller = wireGitHubRepoMetrics({
+      definitions,
+      service,
+      allowLiveFetch: true,
+    });
 
     await controller.refreshAll();
 

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -31,6 +31,158 @@ const createOptions = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe('GitHub repo stats service', () => {
+  it('loads fresh runtime cache before live fetches', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        source: 'github-api',
+        repos: {
+          'futuroptimist/token.place': {
+            owner: 'futuroptimist',
+            repo: 'token.place',
+            stars: 6,
+            watchers: 1,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: '2026-06-03T00:00:00Z',
+            fetchedAt: '2026-06-03T00:00:00.000Z',
+            htmlUrl: 'https://github.com/futuroptimist/token.place',
+          },
+        },
+      }),
+    });
+    const listener = vi.fn();
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        now: () => Date.parse('2026-06-03T00:10:00.000Z'),
+      })
+    );
+
+    service.subscribe(
+      { owner: 'futuroptimist', repo: 'token.place' },
+      listener
+    );
+    await service.loadRuntimeCache();
+
+    expect(fetch).toHaveBeenCalledWith('/runtime/github-metrics.json', {
+      cache: 'no-store',
+      credentials: 'same-origin',
+    });
+    expect(
+      service.getCachedStats({ owner: 'Futuroptimist', repo: 'Token.Place' })
+    ).toEqual({
+      stars: 6,
+      watchers: 1,
+      forks: 0,
+      openIssues: 0,
+      pushedAt: '2026-06-03T00:00:00Z',
+    });
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ stars: 6, watchers: 1 })
+    );
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      cachedRepoCount: 1,
+    });
+  });
+
+  it('accepts slightly stale runtime cache inside the grace period', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        source: 'github-api',
+        repos: {
+          'futuroptimist/flywheel': {
+            owner: 'futuroptimist',
+            repo: 'flywheel',
+            stars: 9,
+            watchers: 2,
+            forks: 1,
+            openIssues: 0,
+            pushedAt: null,
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        now: () => Date.parse('2026-06-03T01:25:00.000Z'),
+      })
+    );
+
+    await service.loadRuntimeCache();
+
+    expect(service.getDiagnostics().source).toBe('runtime-cache-stale');
+    expect(
+      service.getCachedStats({ owner: 'futuroptimist', repo: 'flywheel' })
+        ?.stars
+    ).toBe(9);
+  });
+
+  it('treats invalid or expired runtime cache as unavailable', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        repos: {
+          'futuroptimist/flywheel': {
+            owner: 'futuroptimist',
+            repo: 'flywheel',
+            stars: 9,
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        now: () => Date.parse('2026-06-03T03:00:00.000Z'),
+      })
+    );
+
+    await service.loadRuntimeCache();
+
+    expect(
+      service.getCachedStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      requestCount: 0,
+      cachedRepoCount: 0,
+    });
+  });
+
+  it('uses neutral fallback instead of browser live fetch by default', async () => {
+    const fetch = vi.fn();
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({ allowLiveFetch: false })
+    );
+
+    const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
+
+    expect(stats).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      requestCount: 0,
+    });
+  });
+
   it('fetches stats, caches results, and notifies subscribers', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -67,7 +219,7 @@ describe('GitHub repo stats service', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0][0]).toEqual(stats);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'live',
+      source: 'browser-live',
       requestCount: 1,
       lastErrorStatus: null,
     });
@@ -81,7 +233,27 @@ describe('GitHub repo stats service', () => {
     expect(service.getDiagnostics().source).toBe('cached');
   });
 
-  it('returns static fallback and enters backoff for a 403 response', async () => {
+  it('does not use watchers_count as a substitute for stargazers_count', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        watchers_count: 99,
+        forks_count: 0,
+        open_issues_count: 0,
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions()
+    );
+
+    const stats = await service.requestStats({ owner: 'foo', repo: 'bar' });
+
+    expect(stats?.stars).toBe(0);
+    expect(stats?.watchers).toBe(99);
+  });
+
+  it('returns neutral fallback and enters backoff for a 403 response', async () => {
     const logger = { warn: vi.fn() };
     const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
     const service = createGitHubRepoStatsService(
@@ -95,7 +267,7 @@ describe('GitHub repo stats service', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'static-fallback',
+      source: 'static-neutral',
       requestCount: 1,
       lastErrorStatus: 403,
       warningCount: 1,
@@ -124,7 +296,7 @@ describe('GitHub repo stats service', () => {
       requestCount: 1,
       suppressedRequestCount: 1,
       lastErrorStatus: 429,
-      source: 'static-fallback',
+      source: 'static-neutral',
     });
   });
 
@@ -241,7 +413,7 @@ describe('GitHub repo stats service', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(stats?.stars).toBe(42);
-    expect(service.getDiagnostics().source).toBe('live');
+    expect(service.getDiagnostics().source).toBe('browser-live');
   });
 
   it('honors explicit null storage and logger options', async () => {

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -200,6 +200,30 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('keeps GitHub star fallbacks neutral and non-numeric in every locale', () => {
+    const fakeNumericFallbackPattern = /\b\d[\d,.\s]*(?:\+)?\b/;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      for (const poi of getPoiDefinitions(locale)) {
+        for (const metric of poi.metrics ?? []) {
+          if (metric.source?.type !== 'githubStars') {
+            continue;
+          }
+          const fallback = metric.source.fallback ?? metric.value;
+          expect(metric.source.owner, `${locale}:${poi.id}`).toBeTruthy();
+          expect(metric.source.repo, `${locale}:${poi.id}`).toBeTruthy();
+          expect(fallback, `${locale}:${poi.id}`).toBeTruthy();
+          expect(fallback, `${locale}:${poi.id}`).not.toMatch(
+            fakeNumericFallbackPattern
+          );
+          expect(metric.value, `${locale}:${poi.id}`).not.toMatch(
+            fakeNumericFallbackPattern
+          );
+        }
+      }
+    }
+  });
+
   it('removes the invalid DSPACE Mission Log link from every locale', () => {
     for (const locale of AVAILABLE_LOCALES) {
       const dspace = getPoiDefinitions(locale).find(

--- a/src/tests/mediaWallStarBridge.test.ts
+++ b/src/tests/mediaWallStarBridge.test.ts
@@ -13,19 +13,19 @@ describe('createMediaWallStarBridge', () => {
     return controller;
   };
 
-  it('applies the initial star count when attaching a controller', () => {
-    const bridge = createMediaWallStarBridge(1280);
+  it('applies the neutral initial state when attaching a controller', () => {
+    const bridge = createMediaWallStarBridge();
     const controller = createController();
 
     bridge.attach(controller);
 
     expect(controller.setStarCount).toHaveBeenCalledTimes(1);
-    expect(controller.setStarCount).toHaveBeenCalledWith(1280);
-    expect(bridge.getStarCount()).toBe(1280);
+    expect(controller.setStarCount).toHaveBeenCalledWith(null);
+    expect(bridge.getStarCount()).toBeNull();
   });
 
-  it('updates the controller when live star counts arrive', () => {
-    const bridge = createMediaWallStarBridge(1280);
+  it('updates the controller when runtime star counts arrive', () => {
+    const bridge = createMediaWallStarBridge();
     const controller = createController();
     bridge.attach(controller);
 
@@ -53,17 +53,17 @@ describe('createMediaWallStarBridge', () => {
     expect(firstController.setStarCount).toHaveBeenCalledTimes(2);
   });
 
-  it('sanitizes invalid star counts to zero', () => {
+  it('sanitizes invalid star counts to neutral state', () => {
     const bridge = createMediaWallStarBridge();
     const controller = createController();
     bridge.attach(controller);
 
     bridge.updateStarCount(Number.NaN);
-    expect(bridge.getStarCount()).toBe(0);
-    expect(controller.setStarCount).toHaveBeenLastCalledWith(0);
+    expect(bridge.getStarCount()).toBeNull();
+    expect(controller.setStarCount).toHaveBeenLastCalledWith(null);
 
     bridge.updateStarCount(-42);
-    expect(bridge.getStarCount()).toBe(0);
-    expect(controller.setStarCount).toHaveBeenLastCalledWith(0);
+    expect(bridge.getStarCount()).toBeNull();
+    expect(controller.setStarCount).toHaveBeenLastCalledWith(null);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent user-visible POIs from showing invented GitHub star counts by preferring a pod-local runtime cache and using neutral localized fallbacks when metrics are unavailable.
- Avoid browser fan-out of unauthenticated GitHub API calls in normal staging/production sessions while preserving a debug path for live fetches.

### Description
- Added a runtime-cache-aware GitHub metrics client in `src/systems/github/repoStats.ts` that: reads `/runtime/github-metrics.json`, validates schema and freshness with a grace window, populates an in-memory cache, notifies subscribers, and exposes diagnostics with sources `runtime-cache`, `runtime-cache-stale`, `browser-live`, `cached`, and `static-neutral`.
- Wired runtime cache loading into POI metric wiring in `src/scene/poi/githubMetrics.ts` so `loadRuntimeCache()` runs before any live fetches and browser live fetches are performed only when `allowLiveFetch` is enabled.
- Controlled browser live fetches via a debug URL flag `?enableLiveGitHubMetrics=1` and propagated that flag from `src/main.ts` into the metrics wiring so production/staging defaults remain neutral.
- Replaced invented media-wall star defaults with a neutral `Syncing` state and updated the media wall bridge to accept `null`/neutral star state in `src/scene/structures/mediaWall.ts` and `src/scene/structures/mediaWallStarBridge.ts`.
- Removed numeric/static fallback copy from locale POI data and enforced neutral, non-numeric fallback expectations in `src/tests/i18n.test.ts`.
- Added runtime-cache tests: mapping `/runtime/github-metrics.json` entries to cached repo stats, accepting slightly stale payloads within the grace period, rejecting invalid/expired payloads, ensuring neutral fallback when live fetches are disabled, and confirming `stargazers_count` is used for optional browser live fetches.
- Added a Playwright e2e test `playwright/github-metrics-fallback.spec.ts` that mocks `/runtime/github-metrics.json` and asserts a tooltip updates from neutral copy to the mocked star count.
- Updated docs (`docs/architecture/scene-stack.md`, `docs/roadmap.md`) to describe sidecar-backed runtime metrics, cache behavior, and debug-mode live fetches.

### Testing
- Ran formatter and lint: `npm run format:write` and `npm run lint` — passed.
- Typecheck: `npm run typecheck` — reported unrelated pre-existing TypeScript errors in other areas of the repo; no new errors attributed to changed files were introduced.
- Unit tests: `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/mediaWall.test.ts src/tests/mediaWallStarBridge.test.ts` — all specified tests passed.
- Full test suite: `npm run test:ci` — 137 test files / 999 tests passed in this environment.
- Build: `npm run build` — production build succeeded.
- Playwright e2e: `npm run test:e2e -- playwright/github-metrics-fallback.spec.ts` — tests passed after installing Playwright browsers and OS deps during CI run (note: Playwright browser install step ran in CI emulation during the rollout).
- Docs & smoke: `npm run docs:check` and `npm run smoke` — passed; link checker emitted external fetch warnings (network fetches) but succeeded per repo policy.

Residual notes and follow-ups
- `npm run typecheck` surfaced unrelated repo-wide TypeScript issues that pre-existed these changes; this PR did not introduce new checked-file errors but the repo's global typecheck remains noisy.
- Playwright tests require browser binaries and host dependencies; the e2e test installs them when run in CI as demonstrated in the rollout logs.
- The runtime cache URL and grace window are configurable via `GitHubRepoStatsServiceOptions` and default to `/runtime/github-metrics.json` and 30 minutes grace, respectively.
- No secrets or tokens were added to the frontend or repo.

How to verify locally
- Format, lint, run targeted tests, and run e2e as in the summary: `npm run format:write && npm run lint && npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/mediaWall.test.ts src/tests/mediaWallStarBridge.test.ts && npm run build && npx playwright install && npm run test:e2e -- playwright/github-metrics-fallback.spec.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221b8a4f48832f95a20daff158c6fd)