### PR TITLE
Use runtime GitHub metrics cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,11 @@ the related assets. `npm run launch:screenshot` is review-only because
 - Update the relevant files in `docs/` whenever behavior, prompts, or workflows change.
 - Store generated images as SVG or PNG in `docs/assets/`, except for CI-owned outputs noted
   below.
-- Never manually create, edit, replace, stage, or commit `docs/assets/game-launch.png`. The
-  launch screenshot workflow regenerates it automatically after every merge, and Codex Cloud
-  cannot create or commit binary files.
+- Never manually create, edit, replace, stage, or commit `docs/assets/game-launch.png`
+  in a Codex-authored PR. The launch screenshot workflow regenerates it automatically
+  after every merge, and Codex Cloud cannot create or commit binary files.
+- If `docs/assets/game-launch.png` appears in `git status` or `git diff`, restore it
+  from the PR base/current main before staging so the final PR diff excludes it.
 - Avoid committing large binaries elsewhere in the repo.
 - For front-end tweaks, capture an updated screenshot via the CI workflow instead of touching
   `docs/assets/game-launch.png` locally.

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -101,7 +101,9 @@ layer without guessing where functionality lives.
   such as “Syncing from GitHub…” rather than invented numbers. Browser live GitHub API fetches
   are disabled for normal visitors and require an explicit debug/test flag
   (`?enableLiveGitHubMetrics=1` or `window.__ENABLE_LIVE_GITHUB_METRICS__ = true`). No GitHub
-  token or other secret is required or exposed for public star counts.
+  token or other secret is required or exposed for public star counts. Local preview builds include
+  `public/runtime/github-metrics.json` as an empty neutral placeholder so normal immersive
+  startup can request the same pod-local path without producing browser 404 console noise.
 - **Accessibility overlays** – `HudFocusAnnouncerHandle` flows from systems
   into DOM overlays: `src/ui/accessibility/ariaBridges.ts` registers live
   regions, while Playwright specs assert emitted announcements against

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -95,8 +95,9 @@ layer without guessing where functionality lives.
   cache as the normal source of truth. The cache has a modest grace window beyond `expiresAt`
   so an hourly refresh that lands slightly late does not flicker metrics back to neutral copy;
   long-lived sessions retry the runtime file after that cache window instead of pinning the
-  first successful response forever. Stale, invalid, missing, private, or rate-limited data falls
-  back to localized neutral text
+  first successful response forever; failed refreshes clear expired runtime metrics and notify open
+  UI so tooltips and the media wall return to neutral copy. Stale, invalid, missing, private, or
+  rate-limited data falls back to localized neutral text
   such as “Syncing from GitHub…” rather than invented numbers. Browser live GitHub API fetches
   are disabled for normal visitors and require an explicit debug/test flag
   (`?enableLiveGitHubMetrics=1` or `window.__ENABLE_LIVE_GITHUB_METRICS__ = true`). No GitHub

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -102,8 +102,9 @@ layer without guessing where functionality lives.
   are disabled for normal visitors and require an explicit debug/test flag
   (`?enableLiveGitHubMetrics=1` or `window.__ENABLE_LIVE_GITHUB_METRICS__ = true`). No GitHub
   token or other secret is required or exposed for public star counts. Local preview builds include
-  `public/runtime/github-metrics.json` as an empty neutral placeholder so normal immersive
-  startup can request the same pod-local path without producing browser 404 console noise.
+  `public/runtime/github-metrics.json` as an expired, non-authoritative neutral placeholder so
+  normal immersive startup can request the same pod-local path without producing browser 404
+  console noise or pinning neutral metrics ahead of a real sidecar refresh.
 - **Accessibility overlays** – `HudFocusAnnouncerHandle` flows from systems
   into DOM overlays: `src/ui/accessibility/ariaBridges.ts` registers live
   regions, while Playwright specs assert emitted announcements against

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -94,7 +94,9 @@ layer without guessing where functionality lives.
   a sidecar-refreshed `/runtime/github-metrics.json` file, and the static frontend treats that
   cache as the normal source of truth. The cache has a modest grace window beyond `expiresAt`
   so an hourly refresh that lands slightly late does not flicker metrics back to neutral copy;
-  stale, invalid, missing, private, or rate-limited data falls back to localized neutral text
+  long-lived sessions retry the runtime file after that cache window instead of pinning the
+  first successful response forever. Stale, invalid, missing, private, or rate-limited data falls
+  back to localized neutral text
   such as “Syncing from GitHub…” rather than invented numbers. Browser live GitHub API fetches
   are disabled for normal visitors and require an explicit debug/test flag
   (`?enableLiveGitHubMetrics=1` or `window.__ENABLE_LIVE_GITHUB_METRICS__ = true`). No GitHub

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -50,7 +50,7 @@ layer without guessing where functionality lives.
   performance budgets. Also exposes POI copy consumed across systems and UI.
 - [`src/systems/`](../../src/systems/) – keyboard controls, audio pipelines,
   movement prediction, collision detection, mode failover, HUD control handles,
-  and the GitHub repo stats service that streams live metrics into POIs.
+  and the GitHub repo stats service that reads pod-local runtime metrics into POIs.
   Systems never import from `src/ui/`.
 - [`src/scene/`](../../src/scene/) – avatar importers, environmental builds,
   POI registries, lighting helpers, and structural meshes. Scene code consumes
@@ -90,7 +90,15 @@ layer without guessing where functionality lives.
   listen via the shared observable to mirror selection state in
   [`src/scene/poi/tooltipOverlay.ts`](../../src/scene/poi/tooltipOverlay.ts), while
   [`src/scene/poi/githubMetrics.ts`](../../src/scene/poi/githubMetrics.ts)
-  wires GitHub star counts into both the in-world tooltip and HUD overlay.
+  wires GitHub star counts into both the in-world tooltip and HUD overlay. Deployed pods serve
+  a sidecar-refreshed `/runtime/github-metrics.json` file, and the static frontend treats that
+  cache as the normal source of truth. The cache has a modest grace window beyond `expiresAt`
+  so an hourly refresh that lands slightly late does not flicker metrics back to neutral copy;
+  stale, invalid, missing, private, or rate-limited data falls back to localized neutral text
+  such as “Syncing from GitHub…” rather than invented numbers. Browser live GitHub API fetches
+  are disabled for normal visitors and require an explicit debug/test flag
+  (`?enableLiveGitHubMetrics=1` or `window.__ENABLE_LIVE_GITHUB_METRICS__ = true`). No GitHub
+  token or other secret is required or exposed for public star counts.
 - **Accessibility overlays** – `HudFocusAnnouncerHandle` flows from systems
   into DOM overlays: `src/ui/accessibility/ariaBridges.ts` registers live
   regions, while Playwright specs assert emitted announcements against

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -220,9 +220,8 @@ Focus: anchor each highlighted project with an interactive artifact.
      screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
      - ✅ Undershelf LED wash now breathes with POI emphasis while calm/photosensitive presets
        dampen pulses and flicker spikes.
-     - ✅ GitHub star telemetry now feeds the media wall badge from the pod-local runtime
-       cache so overlays display cached public metrics without browser fan-out or fake
-       numeric fallbacks.
+     - ✅ Live GitHub star telemetry now feeds the media wall badge so the display mirrors the
+       latest repo metrics alongside the POI overlays.
      - ✅ Floor-level clearance halo now pulses with POI focus to keep walkable space obvious
        while accessibility presets soften its bloom and tint transitions.
    - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
@@ -515,9 +514,7 @@ Ideas to evaluate after the core experience is stable:
 - ✅ Procedural storytelling AI that narrates the journey between POIs.
   - ✅ Procedural narrator now weaves journey beats into the HUD story log whenever new exhibits are discovered.
 - ✅ Integration with GitHub API for live repo stats and contribution heatmaps.
-  - ✅ GitHub star counts now stream into POI metric panels from `/runtime/github-metrics.json`;
-    normal staging/prod sessions use neutral localized fallback copy until the server-side
-    cache is available, and optional browser-live fetches are debug-gated.
+  - ✅ Live GitHub star counts now stream into POI metric panels via the repo stats service.
 - ✅ Exportable "press kit" mode now packages screenshots, POI blurbs, and metrics for media kits.
   - ✅ Press kit summary generator now exports POI metadata and performance budgets to JSON for packaging.
   - ✅ Press kit performance report now surfaces headroom for materials, draw calls, and texture

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -220,8 +220,9 @@ Focus: anchor each highlighted project with an interactive artifact.
      screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
      - ✅ Undershelf LED wash now breathes with POI emphasis while calm/photosensitive presets
        dampen pulses and flicker spikes.
-     - ✅ Live GitHub star telemetry now feeds the media wall badge so the display mirrors the
-       latest repo metrics alongside the POI overlays.
+     - ✅ GitHub star telemetry now feeds the media wall badge from the pod-local runtime
+       cache so overlays display cached public metrics without browser fan-out or fake
+       numeric fallbacks.
      - ✅ Floor-level clearance halo now pulses with POI focus to keep walkable space obvious
        while accessibility presets soften its bloom and tint transitions.
    - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
@@ -514,7 +515,9 @@ Ideas to evaluate after the core experience is stable:
 - ✅ Procedural storytelling AI that narrates the journey between POIs.
   - ✅ Procedural narrator now weaves journey beats into the HUD story log whenever new exhibits are discovered.
 - ✅ Integration with GitHub API for live repo stats and contribution heatmaps.
-  - ✅ Live GitHub star counts now stream into POI metric panels via the repo stats service.
+  - ✅ GitHub star counts now stream into POI metric panels from `/runtime/github-metrics.json`;
+    normal staging/prod sessions use neutral localized fallback copy until the server-side
+    cache is available, and optional browser-live fetches are debug-gated.
 - ✅ Exportable "press kit" mode now packages screenshots, POI blurbs, and metrics for media kits.
   - ✅ Press kit summary generator now exports POI metadata and performance budgets to JSON for packaging.
   - ✅ Press kit performance report now surfaces headroom for materials, draw calls, and texture

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -4,6 +4,41 @@ const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 const IMMERSIVE_GITHUB_METRICS_URL =
   '/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=safe';
 
+const RUNTIME_CACHE_REPOS = [
+  'futuroptimist/danielsmith.io',
+  'futuroptimist/token.place',
+  'futuroptimist/gabriel',
+  'futuroptimist/flywheel',
+  'futuroptimist/jobbot3000',
+  'futuroptimist/gitshelves',
+  'futuroptimist/f2clipboard',
+  'futuroptimist/sigma',
+  'futuroptimist/wove',
+  'democratizedspace/dspace',
+  'futuroptimist/pr-reaper',
+] as const;
+
+const createRuntimeCacheRepos = () =>
+  Object.fromEntries(
+    RUNTIME_CACHE_REPOS.map((key, index) => {
+      const [owner, repo] = key.split('/');
+      return [
+        key,
+        {
+          owner,
+          repo,
+          stars: 77 + index,
+          watchers: 1,
+          forks: 2,
+          openIssues: 0,
+          pushedAt: '2026-06-03T00:00:00Z',
+          fetchedAt: '2026-06-03T00:00:00.000Z',
+          htmlUrl: `https://github.com/${key}`,
+        },
+      ];
+    })
+  );
+
 interface GitHubMetricsDiagnostics {
   source:
     | 'runtime-cache'
@@ -55,19 +90,7 @@ test.describe('GitHub repo metrics fallback', () => {
           generatedAt: '2026-06-03T00:00:00.000Z',
           expiresAt: '2999-06-03T01:15:00.000Z',
           source: 'github-api',
-          repos: {
-            'futuroptimist/danielsmith.io': {
-              owner: 'futuroptimist',
-              repo: 'danielsmith.io',
-              stars: 77,
-              watchers: 1,
-              forks: 2,
-              openIssues: 0,
-              pushedAt: '2026-06-03T00:00:00Z',
-              fetchedAt: '2026-06-03T00:00:00.000Z',
-              htmlUrl: 'https://github.com/futuroptimist/danielsmith.io',
-            },
-          },
+          repos: createRuntimeCacheRepos(),
           errors: {},
         }),
       })
@@ -93,11 +116,11 @@ test.describe('GitHub repo metrics fallback', () => {
       { timeout: IMMERSIVE_READY_TIMEOUT_MS }
     );
     await page.waitForFunction(
-      () =>
+      (expectedRepoCount) =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (window as any).portfolio?.githubMetrics?.getDiagnostics?.()
-          ?.cachedRepoCount === 1,
-      undefined,
+          ?.cachedRepoCount === expectedRepoCount,
+      RUNTIME_CACHE_REPOS.length,
       { timeout: 10_000 }
     );
 
@@ -109,7 +132,7 @@ test.describe('GitHub repo metrics fallback', () => {
     expect(diagnostics).toMatchObject({
       requestCount: 0,
       lastErrorStatus: null,
-      cachedRepoCount: 1,
+      cachedRepoCount: RUNTIME_CACHE_REPOS.length,
     });
     expect(['runtime-cache', 'cached']).toContain(diagnostics.source);
     expect(liveRequests).toEqual([]);

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -2,14 +2,20 @@ import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 const IMMERSIVE_GITHUB_METRICS_URL =
-  '/?mode=immersive&disablePerformanceFailover=1&enableLiveGitHubMetrics=1';
+  '/?mode=immersive&disablePerformanceFailover=1&softwareRendererMode=safe';
 
 interface GitHubMetricsDiagnostics {
-  source: 'live' | 'cached' | 'static-fallback';
+  source:
+    | 'runtime-cache'
+    | 'runtime-cache-stale'
+    | 'browser-live'
+    | 'cached'
+    | 'static-neutral';
   requestCount: number;
   suppressedRequestCount: number;
   lastErrorStatus: number | 'network' | null;
   backoffExpiresAt: string | null;
+  cachedRepoCount: number;
 }
 
 const collectConsole = (page: Page) => {
@@ -27,15 +33,43 @@ const collectConsole = (page: Page) => {
 };
 
 test.describe('GitHub repo metrics fallback', () => {
-  test('keeps immersive stable and suppresses fan-out when GitHub returns 403', async ({
+  test('loads pod-local runtime cache without browser GitHub API fan-out', async ({
     page,
   }) => {
     const consoleMessages = collectConsole(page);
-    await page.route('https://api.github.com/repos/**', (route) =>
-      route.fulfill({
-        status: 403,
+    const liveRequests: string[] = [];
+    await page.route('https://api.github.com/repos/**', (route) => {
+      liveRequests.push(route.request().url());
+      return route.fulfill({
+        status: 500,
         contentType: 'application/json',
-        body: JSON.stringify({ message: 'API rate limit exceeded' }),
+        body: JSON.stringify({ message: 'unexpected browser live fetch' }),
+      });
+    });
+    await page.route('**/runtime/github-metrics.json', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2999-06-03T01:15:00.000Z',
+          source: 'github-api',
+          repos: {
+            'futuroptimist/danielsmith.io': {
+              owner: 'futuroptimist',
+              repo: 'danielsmith.io',
+              stars: 77,
+              watchers: 1,
+              forks: 2,
+              openIssues: 0,
+              pushedAt: '2026-06-03T00:00:00Z',
+              fetchedAt: '2026-06-03T00:00:00.000Z',
+              htmlUrl: 'https://github.com/futuroptimist/danielsmith.io',
+            },
+          },
+          errors: {},
+        }),
       })
     );
     await page.addInitScript(() => {
@@ -62,7 +96,7 @@ test.describe('GitHub repo metrics fallback', () => {
       () =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (window as any).portfolio?.githubMetrics?.getDiagnostics?.()
-          ?.lastErrorStatus === 403,
+          ?.cachedRepoCount === 1,
       undefined,
       { timeout: 10_000 }
     );
@@ -73,12 +107,12 @@ test.describe('GitHub repo metrics fallback', () => {
     });
 
     expect(diagnostics).toMatchObject({
-      source: 'static-fallback',
-      requestCount: 1,
-      lastErrorStatus: 403,
+      requestCount: 0,
+      lastErrorStatus: null,
+      cachedRepoCount: 1,
     });
-    expect(diagnostics.suppressedRequestCount).toBe(0);
-    expect(diagnostics.backoffExpiresAt).toEqual(expect.any(String));
+    expect(['runtime-cache', 'cached']).toContain(diagnostics.source);
+    expect(liveRequests).toEqual([]);
     await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
     await expect(page.locator('.poi-tooltip-overlay')).toHaveCount(1);
     await expect(page.locator('html')).not.toHaveAttribute(
@@ -90,11 +124,10 @@ test.describe('GitHub repo metrics fallback', () => {
         (message) => !message.includes('Failed to load resource')
       )
     ).toEqual([]);
-    expect(consoleMessages.errors).toHaveLength(1);
     expect(
       consoleMessages.warnings.filter((message) =>
         message.includes('[github-metrics]')
       )
-    ).toHaveLength(1);
+    ).toHaveLength(0);
   });
 });

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -81,8 +81,13 @@ test.describe('GitHub repo metrics fallback', () => {
         body: JSON.stringify({ message: 'unexpected browser live fetch' }),
       });
     });
-    await page.route('**/runtime/github-metrics.json', (route) =>
-      route.fulfill({
+    let releaseRuntimeCache!: () => void;
+    const runtimeCacheReady = new Promise<void>((resolve) => {
+      releaseRuntimeCache = resolve;
+    });
+    await page.route('**/runtime/github-metrics.json', async (route) => {
+      await runtimeCacheReady;
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
@@ -93,8 +98,8 @@ test.describe('GitHub repo metrics fallback', () => {
           repos: createRuntimeCacheRepos(),
           errors: {},
         }),
-      })
-    );
+      });
+    });
     await page.addInitScript(() => {
       window.localStorage.removeItem(
         'danielsmith.io:github-repo-stats:backoff'
@@ -115,6 +120,22 @@ test.describe('GitHub repo metrics fallback', () => {
       undefined,
       { timeout: IMMERSIVE_READY_TIMEOUT_MS }
     );
+    const tooltip = page.locator('.poi-tooltip-overlay');
+    const starsMetric = tooltip
+      .locator('.poi-tooltip-overlay__metric')
+      .filter({ hasText: 'Stars' })
+      .first();
+
+    await page.keyboard.press('KeyE');
+    await expect(tooltip).toHaveAttribute('aria-hidden', 'false');
+    await expect(tooltip.locator('.poi-tooltip-overlay__title')).toHaveText(
+      'Futuroptimist'
+    );
+    await expect(
+      starsMetric.locator('.poi-tooltip-overlay__metric-value')
+    ).toHaveText('Syncing from GitHub…');
+
+    releaseRuntimeCache();
     await page.waitForFunction(
       (expectedRepoCount) =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -123,6 +144,9 @@ test.describe('GitHub repo metrics fallback', () => {
       RUNTIME_CACHE_REPOS.length,
       { timeout: 10_000 }
     );
+    await expect(
+      starsMetric.locator('.poi-tooltip-overlay__metric-value')
+    ).toHaveText('77 stars');
 
     const diagnostics = await page.evaluate<GitHubMetricsDiagnostics>(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,7 +161,7 @@ test.describe('GitHub repo metrics fallback', () => {
     expect(['runtime-cache', 'cached']).toContain(diagnostics.source);
     expect(liveRequests).toEqual([]);
     await expect(page.locator('#app')).not.toHaveAttribute('data-mode', 'text');
-    await expect(page.locator('.poi-tooltip-overlay')).toHaveCount(1);
+    await expect(tooltip).toHaveCount(1);
     await expect(page.locator('html')).not.toHaveAttribute(
       'data-performance-failover-event',
       '1'

--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -22,10 +22,27 @@ type ElementBounds = {
   height: number;
 };
 
+type AudioDebugState = {
+  preferenceEnabled: boolean;
+  ambientEnabled: boolean;
+  ambientSourcesPlayingCount: number;
+  ambientBedVolumes: Array<{
+    id: string;
+    currentVolume: number;
+    targetVolume: number;
+  }>;
+  footstepEnabled: boolean;
+  footstepPlaying: boolean;
+  activeStorageKey: string;
+};
+
 type PortfolioPoiWindow = Window & {
   portfolio?: {
     poi?: {
       getTooltipState?: () => PoiTooltipState;
+    };
+    audio?: {
+      getState?: () => AudioDebugState;
     };
   };
 };
@@ -71,6 +88,21 @@ async function waitForImmersiveReady(page: Page) {
   await page.waitForFunction(
     () => (window as PortfolioPoiWindow).portfolio?.poi?.getTooltipState
   );
+  await page.waitForFunction(
+    () => (window as PortfolioPoiWindow).portfolio?.audio?.getState
+  );
+}
+
+async function getAudioState(page: Page): Promise<AudioDebugState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioPoiWindow).portfolio?.audio?.getState;
+
+    if (!getState) {
+      throw new Error('window.portfolio.audio.getState() is unavailable');
+    }
+
+    return getState();
+  });
 }
 
 async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
@@ -190,6 +222,79 @@ test.describe('small-screen HUD regression coverage', () => {
 
   test.describe('desktop viewport', () => {
     test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('routes Settings audio and M key toggles through global mute', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        window.localStorage.setItem(
+          'danielsmith.io::ambientAudioEnabled::v1',
+          '1'
+        );
+        window.localStorage.removeItem(
+          'danielsmith.io::ambientAudioEnabled::v2'
+        );
+      });
+      await waitForImmersiveReady(page);
+
+      const settingsButton = page.locator('[data-role="settings-button"]');
+      const settingsModal = page.locator('.help-modal-backdrop');
+      await settingsButton.click();
+      await expect(settingsModal).toBeVisible();
+
+      const audioToggle = settingsModal.locator('button.audio-toggle');
+      const audioVolume = settingsModal.locator('.audio-volume__value');
+      await expect(audioToggle).toContainText(/Audio:\s*Off/i);
+      await expect(audioVolume).toContainText(/Muted/i);
+
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+          footstepPlaying: false,
+          activeStorageKey: 'danielsmith.io::ambientAudioEnabled::v2',
+        });
+
+      await audioToggle.click();
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: true,
+          ambientEnabled: true,
+          footstepEnabled: true,
+        });
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => {
+          const state = await getAudioState(page);
+          return (
+            !state.preferenceEnabled &&
+            !state.ambientEnabled &&
+            state.ambientSourcesPlayingCount === 0 &&
+            !state.footstepEnabled &&
+            !state.footstepPlaying &&
+            state.ambientBedVolumes.every(
+              (bed) => bed.currentVolume === 0 && bed.targetVolume === 0
+            )
+          );
+        })
+        .toBe(true);
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForImmersiveReady(page);
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+        });
+    });
 
     test('keeps desktop keyboard HUD toggles mutually exclusive', async ({
       page,

--- a/public/runtime/github-metrics.json
+++ b/public/runtime/github-metrics.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "generatedAt": "2026-01-01T00:00:00.000Z",
-  "expiresAt": "2999-01-01T00:00:00.000Z",
+  "expiresAt": "2026-01-01T00:00:00.000Z",
   "source": "static-neutral-placeholder",
   "repos": {},
   "errors": {}

--- a/public/runtime/github-metrics.json
+++ b/public/runtime/github-metrics.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-01-01T00:00:00.000Z",
+  "expiresAt": "2999-01-01T00:00:00.000Z",
+  "source": "static-neutral-placeholder",
+  "repos": {},
+  "errors": {}
+}

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -561,7 +561,18 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Futuroptimist hub for open-source scripts, data pipelines, tests, and YouTube-oriented automation metadata.'
       ),
       metrics: [
-        { label: wrap('Stars'), value: wrap('Syncing from GitHub…') },
+        {
+          label: wrap('Stars'),
+          value: wrap('Syncing from GitHub…'),
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'danielsmith.io',
+            format: 'compact',
+            template: wrap('{value} stars'),
+            fallback: wrap('Syncing from GitHub…'),
+          },
+        },
         {
           label: wrap('Workflow'),
           value: wrap('uv, Make targets, pytest, and GitHub Actions'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -909,7 +909,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       outcome: {
         label: 'Outcome',
         value:
-          'Links to the public democratizedspace/dspace repository and official game documentation instead of an unverified mission log.',
+          'Keeps private democratizedspace/dspace repository metadata unavailable while linking official game documentation instead of an unverified mission log.',
       },
       metrics: [
         {
@@ -919,6 +919,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
+            visibility: 'private',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -1033,7 +1033,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', undefined, 'democratizedspace'),
+          source: starSource('dspace', 'private', 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -744,7 +744,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       outcome: {
         label: '成果',
         value:
-          '链接到公开的 democratizedspace/dspace 仓库和官方游戏文档，避免未经验证的任务日志。',
+          '将私有的 democratizedspace/dspace 仓库指标保持为不可用，同时链接官方游戏文档，避免未经验证的任务日志。',
       },
       metrics: [
         { label: '游戏', value: '资源管理 · 任务 · 探索' },
@@ -755,6 +755,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
+            visibility: 'private',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1869,7 +1869,7 @@ function initializeImmersiveScene(
       },
       onRepoStatsUpdated: ({ poiId, stats }) => {
         if (poiId === 'futuroptimist-living-room-tv') {
-          mediaWallStarBridge.updateStarCount(stats.stars);
+          mediaWallStarBridge.updateStarCount(stats?.stars ?? null);
         }
       },
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,7 @@ import {
   type AmbientAudioSource,
 } from './systems/audio/ambientAudio';
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
   bindAmbientAudioPreference,
   type AmbientAudioPreferenceBindingHandle,
@@ -475,6 +476,26 @@ declare global {
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
+      audio?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          ambientEnabled: boolean;
+          ambientSourcesPlaying: { id: string; isPlaying: boolean }[];
+          ambientSourcesPlayingCount: number;
+          ambientBedVolumes: {
+            id: string;
+            currentVolume: number;
+            targetVolume: number;
+          }[];
+          footstepEnabled: boolean;
+          footstepPlaying: boolean;
+          masterVolume: number;
+          baseVolume: number;
+          audioContextState: AudioContextState | 'unknown';
+          storageKeyVersion: string;
+          activeStorageKey: string;
+        };
       };
       graphics?: {
         getMotionBlurIntensity(): number;
@@ -1022,6 +1043,101 @@ function initializeImmersiveScene(
     ambientAudioController?.getMasterVolume() ?? 1;
   let setAmbientAudioVolume = (volume: number) => {
     ambientAudioController?.setMasterVolume(volume);
+  };
+
+  const stopFootstepAudio = () => {
+    if (!footstepAudio) {
+      return;
+    }
+    footstepAudio.setVolume(0);
+    if (footstepAudio.isPlaying) {
+      footstepAudio.stop();
+    }
+  };
+
+  const hardDisableRuntimeAudio = () => {
+    ambientAudioController?.disable();
+    footstepAudioController?.setEnabled(false);
+    stopFootstepAudio();
+    ambientCaptionBridge?.clear();
+    audioHudHandle?.refresh();
+  };
+
+  let globalAudioTransitionId = 0;
+
+  const setGlobalAudioEnabled = async (
+    enabled: boolean,
+    source: 'control' | 'storage' = 'control'
+  ) => {
+    const transitionId = ++globalAudioTransitionId;
+
+    if (!enabled) {
+      hardDisableRuntimeAudio();
+      ambientAudioPreference?.setEnabled(false, source);
+      audioHudHandle?.refresh();
+      return;
+    }
+
+    if (!ambientAudioController) {
+      if (source === 'control') {
+        ambientAudioPreference?.setEnabled(false, source);
+      }
+      audioHudHandle?.refresh();
+      return;
+    }
+
+    try {
+      await ambientAudioController.enable();
+      if (
+        transitionId !== globalAudioTransitionId ||
+        (source === 'storage' &&
+          !(ambientAudioPreference?.isEnabled() ?? false))
+      ) {
+        hardDisableRuntimeAudio();
+        audioHudHandle?.refresh();
+        return;
+      }
+      footstepAudioController?.setEnabled(true);
+      ambientAudioPreference?.setEnabled(true, source);
+    } catch (error) {
+      hardDisableRuntimeAudio();
+      if (source === 'control') {
+        ambientAudioPreference?.setEnabled(false, source);
+      }
+      audioHudHandle?.refresh();
+      throw error;
+    }
+    audioHudHandle?.refresh();
+  };
+
+  const getAudioDebugState = () => {
+    const snapshots = ambientAudioController?.getBedSnapshots() ?? [];
+    const ambientSourcesPlaying = snapshots.map((snapshot) => ({
+      id: snapshot.id,
+      isPlaying: snapshot.definition.source.isPlaying,
+    }));
+    return {
+      preferenceEnabled: ambientAudioPreference?.isEnabled() ?? false,
+      ambientEnabled: ambientAudioController?.isEnabled() ?? false,
+      ambientSourcesPlaying,
+      ambientSourcesPlayingCount: ambientSourcesPlaying.filter(
+        (source) => source.isPlaying
+      ).length,
+      ambientBedVolumes: snapshots.map((snapshot) => ({
+        id: snapshot.id,
+        currentVolume: snapshot.currentVolume,
+        targetVolume: snapshot.targetVolume,
+      })),
+      footstepEnabled: footstepAudioController?.isEnabled() ?? false,
+      footstepPlaying: footstepAudio?.isPlaying ?? false,
+      masterVolume: ambientAudioController?.getMasterVolume() ?? 0,
+      baseVolume: getAmbientAudioVolume(),
+      audioContextState: audioListener?.context?.state ?? 'unknown',
+      storageKeyVersion: 'v2',
+      activeStorageKey:
+        ambientAudioPreference?.getStorageKey() ??
+        AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
+    };
   };
 
   let localeStorage: Storage | undefined;
@@ -1858,6 +1974,9 @@ function initializeImmersiveScene(
   window.portfolio.githubMetrics = {
     getDiagnostics: () => githubRepoStatsService.getDiagnostics(),
   };
+  window.portfolio.audio = {
+    getState: getAudioDebugState,
+  };
   const wirePoiGitHubMetrics = () => {
     githubRepoMetrics?.dispose();
     githubRepoMetrics = wireGitHubRepoMetrics({
@@ -2401,6 +2520,10 @@ function initializeImmersiveScene(
   footstepAudioController = createFootstepAudioController({
     player: {
       play: ({ volume, playbackRate, pan }) => {
+        if (!(ambientAudioPreference?.isEnabled() ?? false)) {
+          stopFootstepAudio();
+          return;
+        }
         const clampedVolume = MathUtils.clamp(volume, 0, 1);
         const clampedRate = MathUtils.clamp(playbackRate, 0.25, 3);
         if (footstepStereoPanner && typeof pan === 'number') {
@@ -2418,7 +2541,9 @@ function initializeImmersiveScene(
         }
         footstepAudioNode.play();
       },
+      stop: stopFootstepAudio,
     },
+    initialEnabled: ambientAudioPreference?.isEnabled() ?? false,
     maxLinearSpeed: PLAYER_SPEED,
     minActivationSpeed: PLAYER_SPEED * 0.12,
     intervalRange: { min: 0.26, max: 0.58 },
@@ -3650,11 +3775,20 @@ function initializeImmersiveScene(
       ambientAudioPreferenceBinding = null;
     }
     ambientAudioPreferenceBinding = bindAmbientAudioPreference({
-      controller: ambientAudioController,
+      controller: {
+        enable: () => setGlobalAudioEnabled(true, 'storage'),
+        disable: () => {
+          void setGlobalAudioEnabled(false, 'storage');
+        },
+        isEnabled: () => ambientAudioController?.isEnabled() ?? false,
+      },
       preference: ambientAudioPreference,
       windowTarget: window,
       logger: console,
     });
+    if (!ambientAudioPreference.isEnabled()) {
+      hardDisableRuntimeAudio();
+    }
 
     if (!ambientCaptionBridge && audioSubtitles) {
       ambientCaptionBridge = new AmbientCaptionBridge({
@@ -3667,19 +3801,10 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       getEnabled: () => ambientAudioController?.isEnabled() ?? false,
       setEnabled: async (enabled) => {
-        if (!ambientAudioController) {
-          return;
-        }
-        if (enabled) {
-          try {
-            await ambientAudioController.enable();
-            ambientAudioPreference?.setEnabled(true, 'control');
-          } catch (error) {
-            console.warn('Ambient audio failed to start', error);
-          }
-        } else {
-          ambientAudioController.disable();
-          ambientAudioPreference?.setEnabled(false, 'control');
+        try {
+          await setGlobalAudioEnabled(enabled, 'control');
+        } catch (error) {
+          console.warn('Ambient audio failed to start', error);
         }
       },
       getVolume: () => getAmbientAudioVolume(),
@@ -4764,6 +4889,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.githubMetrics) {
       delete window.portfolio.githubMetrics;
+    }
+    if (window.portfolio?.audio) {
+      delete window.portfolio.audio;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/scene/poi/githubMetrics.ts
+++ b/src/scene/poi/githubMetrics.ts
@@ -15,6 +15,7 @@ interface MetricEntry {
   poi: PoiDefinition;
   metric: PoiMetric;
   source: PoiMetricGitHubStarsSource;
+  fallbackValue: string;
 }
 
 interface RepoBucket {
@@ -30,7 +31,7 @@ export interface WireGitHubRepoMetricsOptions {
   onRepoStatsUpdated?(update: {
     poiId: PoiId;
     source: PoiMetricGitHubStarsSource;
-    stats: GitHubRepoStats;
+    stats: GitHubRepoStats | null;
   }): void;
 }
 
@@ -104,14 +105,17 @@ export function wireGitHubRepoMetrics({
         return;
       }
       const fallback = metric.source.fallback ?? metric.value;
-      if (fallback) {
-        metric.value = fallback;
-      }
+      metric.value = fallback;
       if (metric.source.visibility === 'private') {
         return;
       }
       const bucket = getBucket(metric.source);
-      bucket.entries.push({ poi, metric, source: metric.source });
+      bucket.entries.push({
+        poi,
+        metric,
+        source: metric.source,
+        fallbackValue: fallback,
+      });
       const cached = service.getCachedStats(bucket.identifier);
       if (cached) {
         metric.value = formatStars(cached.stars, metric.source);
@@ -128,11 +132,12 @@ export function wireGitHubRepoMetrics({
   repoMap.forEach((bucket) => {
     const unsubscribe = service.subscribe(bucket.identifier, (stats) => {
       const previousStars = bucket.lastStars;
-      bucket.lastStars = stats.stars;
-      const starChanged = previousStars !== stats.stars;
+      const nextStars = stats?.stars;
+      bucket.lastStars = nextStars;
+      const starChanged = previousStars !== nextStars;
       const updated = new Set<PoiId>();
-      bucket.entries.forEach(({ poi, metric, source }) => {
-        metric.value = formatStars(stats.stars, source);
+      bucket.entries.forEach(({ poi, metric, source, fallbackValue }) => {
+        metric.value = stats ? formatStars(stats.stars, source) : fallbackValue;
         updated.add(poi.id);
         if (starChanged) {
           onRepoStatsUpdated?.({ poiId: poi.id, source, stats });

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -33,7 +33,7 @@ const CLEARANCE_BASE_COLOR = 0x10283b;
 const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
 
 interface MediaWallScreenRendererOptions {
-  starCount: number;
+  starCount: number | null;
   width?: number;
   height?: number;
   redrawThrottleMs?: number;
@@ -44,7 +44,7 @@ class MediaWallScreenRenderer {
   private readonly context: CanvasRenderingContext2D;
   private readonly texture: CanvasTexture;
   private highlight = 0;
-  private starCount: number;
+  private starCount: number | null;
   private width: number;
   private height: number;
   private redrawThrottleMs: number;
@@ -76,9 +76,11 @@ class MediaWallScreenRenderer {
     return this.texture;
   }
 
-  setStarCount(count: number) {
-    if (!Number.isFinite(count) || count < 0) {
-      this.starCount = 0;
+  setStarCount(count: number | null) {
+    if (count === null) {
+      this.starCount = null;
+    } else if (!Number.isFinite(count) || count < 0) {
+      this.starCount = null;
     } else {
       this.starCount = count;
     }
@@ -246,6 +248,9 @@ class MediaWallScreenRenderer {
   }
 
   private formatStarCount(): string {
+    if (this.starCount === null) {
+      return 'Syncing';
+    }
     if (this.starCount >= 1_000_000) {
       return `${(this.starCount / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
     }
@@ -265,7 +270,7 @@ function createScreenRenderer(
   detailPolicy = getSceneDetailPolicy('balanced')
 ): MediaWallScreenRenderer {
   return new MediaWallScreenRenderer({
-    starCount: detailPolicy.level === 'performance' ? 128 : 1280,
+    starCount: null,
     width: detailPolicy.textures.mediaWallScreen.width,
     height: detailPolicy.textures.mediaWallScreen.height,
     redrawThrottleMs: detailPolicy.updates.canvasRedrawThrottleMs,
@@ -353,7 +358,7 @@ export interface LivingRoomMediaWallPoiBindings {
 
 export interface LivingRoomMediaWallController {
   update(options: { elapsed: number; delta: number; emphasis: number }): void;
-  setStarCount(count: number): void;
+  setStarCount(count: number | null): void;
   dispose(): void;
 }
 

--- a/src/scene/structures/mediaWallStarBridge.ts
+++ b/src/scene/structures/mediaWallStarBridge.ts
@@ -1,21 +1,21 @@
 import type { LivingRoomMediaWallController } from './mediaWall';
 
-const sanitizeStarCount = (value: number | null | undefined): number => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return 0;
+const sanitizeStarCount = (value: number | null | undefined): number | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return null;
   }
-  return Math.max(0, Math.round(value));
+  return Math.round(value);
 };
 
 export interface MediaWallStarBridge {
   attach(controller: LivingRoomMediaWallController): void;
   detach(): void;
   updateStarCount(stars: number | null | undefined): void;
-  getStarCount(): number;
+  getStarCount(): number | null;
 }
 
 export const createMediaWallStarBridge = (
-  initialStars = 1280
+  initialStars: number | null = null
 ): MediaWallStarBridge => {
   let starCount = sanitizeStarCount(initialStars);
   let controller: LivingRoomMediaWallController | null = null;

--- a/src/systems/audio/ambientAudio.ts
+++ b/src/systems/audio/ambientAudio.ts
@@ -164,15 +164,15 @@ export class AmbientAudioController {
   }
 
   disable(): void {
-    if (!this.enabled) {
-      return;
-    }
     this.enabled = false;
     this.elapsedTime = 0;
     this.beds.forEach((bed) => {
       bed.currentVolume = 0;
       bed.definition.source.setVolume(0);
       bed.targetVolume = 0;
+      if (bed.definition.source.isPlaying) {
+        bed.definition.source.stop();
+      }
     });
   }
 

--- a/src/systems/audio/ambientAudioPreference.ts
+++ b/src/systems/audio/ambientAudioPreference.ts
@@ -25,7 +25,12 @@ export interface AmbientAudioPreferenceBindingHandle {
   dispose(): void;
 }
 
-const DEFAULT_STORAGE_KEY = 'danielsmith.io::ambientAudioEnabled::v1';
+export const AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v2';
+export const LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v1';
+
+const DEFAULT_STORAGE_KEY = AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY;
 
 const parseStoredValue = (value: string | null): boolean | null => {
   if (value === '1' || value === 'true') {
@@ -103,11 +108,18 @@ export class AmbientAudioPreference {
     source: AmbientAudioPreferenceChangeSource = 'control'
   ): void {
     if (this.enabled === enabled) {
+      if (source === 'control') {
+        this.persist();
+      }
       return;
     }
     this.enabled = enabled;
     this.persist();
     this.notify(source);
+  }
+
+  getStorageKey(): string {
+    return this.storageKey;
   }
 
   subscribe(
@@ -240,14 +252,16 @@ export const bindAmbientAudioPreference = ({
   };
 
   const attemptEnable = async () => {
-    if (disposed || controller.isEnabled()) {
+    if (disposed || controller.isEnabled() || !preference.isEnabled()) {
       return;
     }
     try {
       await controller.enable();
     } catch (error) {
       logger.warn('Ambient audio auto-resume failed:', error);
-      scheduleGestureListeners();
+      if (preference.isEnabled()) {
+        scheduleGestureListeners();
+      }
     }
   };
 

--- a/src/systems/audio/ambientCaptionBridge.ts
+++ b/src/systems/audio/ambientCaptionBridge.ts
@@ -49,6 +49,8 @@ export class AmbientCaptionBridge {
 
   private readonly states = new Map<string, AmbientCaptionState>();
 
+  private readonly messageIds = new Set<string>();
+
   constructor({
     controller,
     subtitles,
@@ -60,6 +62,14 @@ export class AmbientCaptionBridge {
     this.subtitles = subtitles;
     this.cooldownMs = Math.max(0, cooldownMs);
     this.now = now;
+  }
+
+  clear(): void {
+    for (const messageId of this.messageIds) {
+      this.subtitles.clear(messageId);
+    }
+    this.messageIds.clear();
+    this.states.clear();
   }
 
   update(): void {
@@ -75,6 +85,7 @@ export class AmbientCaptionBridge {
     for (const id of Array.from(this.states.keys())) {
       if (!snapshotIds.has(id)) {
         this.states.delete(id);
+        this.messageIds.delete(`ambient-${id}`);
       }
     }
   }
@@ -85,8 +96,10 @@ export class AmbientCaptionBridge {
   ): void {
     const { definition, currentVolume } = snapshot;
     const caption = definition.caption;
+    const messageId = `ambient-${snapshot.id}`;
     if (!caption) {
       this.states.delete(snapshot.id);
+      this.messageIds.delete(messageId);
       return;
     }
 
@@ -99,7 +112,6 @@ export class AmbientCaptionBridge {
         lastShownAt: null,
         pendingImmediateReshow: false,
       } satisfies AmbientCaptionState);
-    const messageId = `ambient-${snapshot.id}`;
     const currentMessage = this.subtitles.getCurrent();
     const hasFocus = currentMessage?.id === messageId;
     const otherMessageActive =
@@ -127,6 +139,7 @@ export class AmbientCaptionBridge {
       const elapsed = currentTime - lastShownAt;
       const bypassCooldown = state.pendingImmediateReshow;
       if (bypassCooldown || elapsed >= this.cooldownMs) {
+        this.messageIds.add(messageId);
         this.subtitles.show({
           id: messageId,
           text: caption,

--- a/src/systems/audio/footstepController.ts
+++ b/src/systems/audio/footstepController.ts
@@ -6,6 +6,7 @@ export interface FootstepPlaybackOptions {
 
 export interface FootstepPlayer {
   play(options: FootstepPlaybackOptions): void;
+  stop?(): void;
 }
 
 export interface FootstepControllerOptions {
@@ -29,6 +30,8 @@ export interface FootstepControllerOptions {
   pitchJitter?: number;
   /** Optional deterministic random generator returning values in [0, 1). */
   random?: () => number;
+  /** Initial gate for global audio state. Defaults to enabled for backwards compatibility. */
+  initialEnabled?: boolean;
 }
 
 export interface FootstepControllerUpdate {
@@ -101,7 +104,7 @@ export function createFootstepAudioController(
     maxLinearSpeed - 1e-3
   );
 
-  let enabled = true;
+  let enabled = options.initialEnabled ?? true;
   let timeUntilNextStep = 0;
   let lastFoot: FootLabel = 'right';
   let lastNormalizedSpeed = 0;
@@ -241,11 +244,15 @@ export function createFootstepAudioController(
       );
     },
     setEnabled(nextEnabled) {
+      if (enabled === nextEnabled) {
+        return;
+      }
       enabled = nextEnabled;
       if (!enabled) {
         timeUntilNextStep = 0;
         lastNormalizedSpeed = 0;
         lastGrounded = true;
+        options.player.stop?.();
       }
     },
     isEnabled() {
@@ -255,6 +262,7 @@ export function createFootstepAudioController(
       enabled = false;
       timeUntilNextStep = 0;
       lastNormalizedSpeed = 0;
+      options.player.stop?.();
     },
   };
 }

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -73,8 +73,11 @@ interface BackoffRecord {
   lastErrorAt: number;
 }
 
+type MemoryCacheSource = 'runtime-cache' | 'browser-live' | 'local-storage';
+
 interface MemoryCacheEntry extends CachedStatsRecord {
   freshUntil: number;
+  source: MemoryCacheSource;
 }
 
 export interface GitHubRepoStatsServiceOptions {
@@ -182,7 +185,8 @@ const safeRemove = (storage: StorageLike | null, key: string): void => {
 const normalizeCachedRecord = (
   record: CachedStatsRecord | null,
   now: number,
-  ttlMs: number
+  ttlMs: number,
+  source: MemoryCacheSource
 ): MemoryCacheEntry | null => {
   if (!record || typeof record !== 'object') {
     return null;
@@ -206,6 +210,7 @@ const normalizeCachedRecord = (
     },
     cachedAt,
     freshUntil: cachedAt + ttlMs,
+    source,
   };
 };
 
@@ -322,11 +327,13 @@ export function createGitHubRepoStatsService(
     freshUntil: number
   ) => {
     const key = makeCacheKey(identifier);
-    cache.set(key, { stats, cachedAt, freshUntil });
+    cache.set(key, { stats, cachedAt, freshUntil, source: 'runtime-cache' });
     notify(key, stats);
   };
 
   let runtimeCacheLoadPromise: Promise<boolean> | null = null;
+  let runtimeCacheAvailable = false;
+  const runtimeCacheRepoKeys = new Set<string>();
 
   const loadRuntimeCache = async (): Promise<boolean> => {
     if (!runtimeCacheUrl || !fetchImpl) {
@@ -337,10 +344,20 @@ export function createGitHubRepoStatsService(
     }
 
     runtimeCacheLoadPromise = (async () => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      let controller: AbortController | undefined;
       try {
-        const response = await fetchImpl(runtimeCacheUrl, {
+        if (AbortControllerTarget && fetchTimeoutMs > 0) {
+          controller = new AbortControllerTarget();
+          timeoutId = setTimeout(() => controller?.abort(), fetchTimeoutMs);
+        }
+        const requestInit: RequestInit = {
           headers: { Accept: 'application/json' },
-        });
+        };
+        if (controller?.signal) {
+          requestInit.signal = controller.signal;
+        }
+        const response = await fetchImpl(runtimeCacheUrl, requestInit);
         if (!response.ok) {
           diagnostics.source = 'static-neutral';
           return false;
@@ -365,6 +382,7 @@ export function createGitHubRepoStatsService(
           return false;
         }
 
+        const loadedRepoKeys = new Set<string>();
         let loadedCount = 0;
         for (const [key, repoStats] of Object.entries(payload.repos)) {
           const normalized = normalizeRuntimeRepoStats(repoStats);
@@ -382,6 +400,8 @@ export function createGitHubRepoStatsService(
           ) {
             continue;
           }
+          const normalizedKey = makeCacheKey({ owner, repo });
+          loadedRepoKeys.add(normalizedKey);
           writeMemoryEntry(
             { owner, repo },
             normalized,
@@ -390,16 +410,35 @@ export function createGitHubRepoStatsService(
           );
           loadedCount += 1;
         }
+
+        for (const [key, entry] of cache) {
+          if (entry.source === 'runtime-cache' && !loadedRepoKeys.has(key)) {
+            cache.delete(key);
+          }
+        }
+        runtimeCacheRepoKeys.clear();
+        for (const key of loadedRepoKeys) {
+          runtimeCacheRepoKeys.add(key);
+        }
+        runtimeCacheAvailable = true;
         diagnostics.source =
           loadedCount > 0 ? 'runtime-cache' : 'static-neutral';
-        return loadedCount > 0;
+        return true;
       } catch {
         diagnostics.source = 'static-neutral';
         return false;
+      } finally {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
       }
     })();
 
-    return runtimeCacheLoadPromise;
+    const loaded = await runtimeCacheLoadPromise;
+    if (!loaded) {
+      runtimeCacheLoadPromise = null;
+    }
+    return loaded;
   };
 
   const warnOnce = (status: ErrorStatus) => {
@@ -431,15 +470,16 @@ export function createGitHubRepoStatsService(
   ): MemoryCacheEntry | null => {
     const key = makeCacheKey(identifier);
     const cached = cache.get(key);
-    if (cached) {
+    if (cached && canUseCachedEntry(key, cached)) {
       return cached;
     }
     const stored = normalizeCachedRecord(
       safeReadJson<CachedStatsRecord>(localStorage, makeStorageKey(identifier)),
       now(),
-      successCacheTtlMs
+      successCacheTtlMs,
+      'local-storage'
     );
-    if (stored) {
+    if (stored && canUseCachedEntry(key, stored)) {
       cache.set(key, stored);
       return stored;
     }
@@ -456,6 +496,7 @@ export function createGitHubRepoStatsService(
     cache.set(key, {
       ...record,
       freshUntil: cachedAt + successCacheTtlMs,
+      source: 'browser-live',
     });
     safeWriteJson(localStorage, makeStorageKey(identifier), record);
   };
@@ -478,6 +519,19 @@ export function createGitHubRepoStatsService(
     diagnostics.lastErrorAt = now();
     setBackoff(status);
     warnOnce(status);
+  };
+
+  const canUseCachedEntry = (key: string, entry: MemoryCacheEntry): boolean => {
+    if (!runtimeCacheUrl) {
+      return true;
+    }
+    if (entry.source === 'runtime-cache') {
+      return runtimeCacheRepoKeys.has(key);
+    }
+    if (runtimeCacheAvailable) {
+      return false;
+    }
+    return allowLiveFetch;
   };
 
   const getCachedStats = (
@@ -528,9 +582,13 @@ export function createGitHubRepoStatsService(
   ): Promise<GitHubRepoStats | null> => {
     await loadRuntimeCache();
     const key = makeCacheKey(identifier);
+    if (runtimeCacheAvailable && !runtimeCacheRepoKeys.has(key)) {
+      diagnostics.source = 'static-neutral';
+      return null;
+    }
     const cached = readCachedEntry(identifier);
     if (cached && cached.freshUntil > now()) {
-      if (diagnostics.source !== 'runtime-cache') {
+      if (cached.source !== 'runtime-cache') {
         diagnostics.source = 'cached';
       }
       return cached.stats;
@@ -541,13 +599,12 @@ export function createGitHubRepoStatsService(
     }
     if (!fetchImpl || !allowLiveFetch) {
       if (
-        !cached &&
         diagnostics.source !== 'runtime-cache' &&
         diagnostics.source !== 'runtime-cache-stale'
       ) {
         diagnostics.source = 'static-neutral';
       }
-      return cached?.stats ?? null;
+      return null;
     }
     if (isBackoffActive(backoff, now())) {
       diagnostics.suppressedRequestCount += 1;

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -11,7 +11,7 @@ export interface GitHubRepoStats {
   pushedAt: string | null;
 }
 
-export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
+export type GitHubRepoStatsListener = (stats: GitHubRepoStats | null) => void;
 
 export type GitHubRepoMetricsSource =
   | 'runtime-cache'
@@ -306,7 +306,7 @@ export function createGitHubRepoStatsService(
   }
   let warnedThisService = false;
 
-  const notify = (key: string, stats: GitHubRepoStats) => {
+  const notify = (key: string, stats: GitHubRepoStats | null) => {
     const repoListeners = listeners.get(key);
     if (!repoListeners || repoListeners.size === 0) {
       return;
@@ -329,6 +329,23 @@ export function createGitHubRepoStatsService(
     const key = makeCacheKey(identifier);
     cache.set(key, { stats, cachedAt, freshUntil, source: 'runtime-cache' });
     notify(key, stats);
+  };
+
+  const clearRuntimeCacheState = (notifyListeners: boolean) => {
+    const removedKeys: string[] = [];
+    for (const [key, entry] of cache) {
+      if (entry.source === 'runtime-cache') {
+        cache.delete(key);
+        removedKeys.push(key);
+      }
+    }
+    runtimeCacheRepoKeys.clear();
+    runtimeCacheAvailable = false;
+    runtimeCacheRefreshAfter = 0;
+    if (!notifyListeners) {
+      return;
+    }
+    removedKeys.forEach((key) => notify(key, null));
   };
 
   let runtimeCacheLoadPromise: Promise<boolean> | null = null;
@@ -449,7 +466,7 @@ export function createGitHubRepoStatsService(
     const loaded = await runtimeCacheLoadPromise;
     if (!loaded) {
       runtimeCacheLoadPromise = null;
-      runtimeCacheRefreshAfter = 0;
+      clearRuntimeCacheState(true);
     }
     return loaded;
   };

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -13,7 +13,12 @@ export interface GitHubRepoStats {
 
 export type GitHubRepoStatsListener = (stats: GitHubRepoStats) => void;
 
-export type GitHubRepoMetricsSource = 'live' | 'cached' | 'static-fallback';
+export type GitHubRepoMetricsSource =
+  | 'runtime-cache'
+  | 'runtime-cache-stale'
+  | 'browser-live'
+  | 'cached'
+  | 'static-neutral';
 
 export interface GitHubRepoStatsDiagnostics {
   source: GitHubRepoMetricsSource;
@@ -31,6 +36,7 @@ export interface GitHubRepoStatsService {
   requestStats(
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null>;
+  loadRuntimeCache(): Promise<boolean>;
   subscribe(
     identifier: GitHubRepoIdentifier,
     listener: GitHubRepoStatsListener
@@ -48,6 +54,8 @@ const BACKOFF_STORAGE_KEY = 'danielsmith.io:github-repo-stats:backoff';
 const DEFAULT_SUCCESS_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_FAILURE_BACKOFF_MS = 15 * 60 * 1000;
 const DEFAULT_FETCH_TIMEOUT_MS = 3500;
+const DEFAULT_RUNTIME_CACHE_URL = '/runtime/github-metrics.json';
+const DEFAULT_RUNTIME_CACHE_GRACE_MS = 20 * 60 * 1000;
 const WARNING_SESSION_KEY = 'danielsmith.io:github-repo-stats:warning-shown';
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
@@ -78,6 +86,9 @@ export interface GitHubRepoStatsServiceOptions {
   successCacheTtlMs?: number;
   failureBackoffMs?: number;
   fetchTimeoutMs?: number;
+  runtimeCacheUrl?: string | null;
+  runtimeCacheGraceMs?: number;
+  loadRuntimeCacheOnCreate?: boolean;
   AbortControllerImpl?: typeof AbortController;
 }
 
@@ -99,7 +110,7 @@ const makeStorageKey = (identifier: GitHubRepoIdentifier): string =>
   `${CACHE_STORAGE_PREFIX}${makeCacheKey(identifier)}`;
 
 const shouldAttemptLiveFetch = (() => {
-  const globalScope = globalThis as Partial<
+  const globalScope = globalThis as unknown as Partial<
     Window & { __ENABLE_LIVE_GITHUB_METRICS__?: boolean }
   >;
   if (globalScope.__ENABLE_LIVE_GITHUB_METRICS__) {
@@ -111,10 +122,6 @@ const shouldAttemptLiveFetch = (() => {
   }
   const params = new URLSearchParams(location.search);
   if (params.get('enableLiveGitHubMetrics') === '1') {
-    return true;
-  }
-  const hostname = location.hostname.toLowerCase();
-  if (hostname === 'danielsmith.io' || hostname.endsWith('.danielsmith.io')) {
     return true;
   }
   return false;
@@ -214,6 +221,30 @@ const isBackoffActive = (
 const shouldBackoffForStatus = (status: ErrorStatus): boolean =>
   status === 'network' || status === 403 || status === 429;
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const parseTimestamp = (value: unknown): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const normalizeRuntimeRepoStats = (value: unknown): GitHubRepoStats | null => {
+  if (!isRecord(value) || !Number.isFinite(value.stars)) {
+    return null;
+  }
+  return {
+    stars: sanitizeNumber(value.stars),
+    watchers: sanitizeNumber(value.watchers),
+    forks: sanitizeNumber(value.forks),
+    openIssues: sanitizeNumber(value.openIssues),
+    pushedAt: typeof value.pushedAt === 'string' ? value.pushedAt : null,
+  };
+};
+
 const toIso = (timestamp: number | null): string | null => {
   if (timestamp === null || !Number.isFinite(timestamp)) {
     return null;
@@ -241,13 +272,19 @@ export function createGitHubRepoStatsService(
   const failureBackoffMs =
     options.failureBackoffMs ?? DEFAULT_FAILURE_BACKOFF_MS;
   const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const runtimeCacheUrl =
+    options.runtimeCacheUrl === undefined
+      ? DEFAULT_RUNTIME_CACHE_URL
+      : options.runtimeCacheUrl;
+  const runtimeCacheGraceMs =
+    options.runtimeCacheGraceMs ?? DEFAULT_RUNTIME_CACHE_GRACE_MS;
   const AbortControllerTarget =
     options.AbortControllerImpl ?? globalThis.AbortController;
   const cache = new Map<string, MemoryCacheEntry>();
   const listeners = new Map<string, Set<GitHubRepoStatsListener>>();
   const inFlight = new Map<string, Promise<GitHubRepoStats | null>>();
   const diagnostics = {
-    source: 'static-fallback' as GitHubRepoMetricsSource,
+    source: 'static-neutral' as GitHubRepoMetricsSource,
     requestCount: 0,
     suppressedRequestCount: 0,
     lastErrorStatus: null as ErrorStatus | null,
@@ -278,6 +315,93 @@ export function createGitHubRepoStatsService(
     }
   };
 
+  const writeMemoryEntry = (
+    identifier: GitHubRepoIdentifier,
+    stats: GitHubRepoStats,
+    cachedAt: number,
+    freshUntil: number
+  ) => {
+    const key = makeCacheKey(identifier);
+    cache.set(key, { stats, cachedAt, freshUntil });
+    notify(key, stats);
+  };
+
+  let runtimeCacheLoadPromise: Promise<boolean> | null = null;
+
+  const loadRuntimeCache = async (): Promise<boolean> => {
+    if (!runtimeCacheUrl || !fetchImpl) {
+      return false;
+    }
+    if (runtimeCacheLoadPromise) {
+      return runtimeCacheLoadPromise;
+    }
+
+    runtimeCacheLoadPromise = (async () => {
+      try {
+        const response = await fetchImpl(runtimeCacheUrl, {
+          headers: { Accept: 'application/json' },
+        });
+        if (!response.ok) {
+          diagnostics.source = 'static-neutral';
+          return false;
+        }
+        const payload = (await response.json()) as unknown;
+        if (!isRecord(payload) || payload.schemaVersion !== 1) {
+          diagnostics.source = 'static-neutral';
+          return false;
+        }
+        const generatedAt = parseTimestamp(payload.generatedAt);
+        const expiresAt = parseTimestamp(payload.expiresAt);
+        if (generatedAt === null || expiresAt === null || generatedAt > now()) {
+          diagnostics.source = 'static-neutral';
+          return false;
+        }
+        if (expiresAt + runtimeCacheGraceMs < now()) {
+          diagnostics.source = 'runtime-cache-stale';
+          return false;
+        }
+        if (!isRecord(payload.repos)) {
+          diagnostics.source = 'static-neutral';
+          return false;
+        }
+
+        let loadedCount = 0;
+        for (const [key, repoStats] of Object.entries(payload.repos)) {
+          const normalized = normalizeRuntimeRepoStats(repoStats);
+          if (!normalized || !isRecord(repoStats)) {
+            continue;
+          }
+          const owner =
+            typeof repoStats.owner === 'string' ? repoStats.owner : null;
+          const repo =
+            typeof repoStats.repo === 'string' ? repoStats.repo : null;
+          if (
+            !owner ||
+            !repo ||
+            key.toLowerCase() !== `${owner}/${repo}`.toLowerCase()
+          ) {
+            continue;
+          }
+          writeMemoryEntry(
+            { owner, repo },
+            normalized,
+            generatedAt,
+            expiresAt + runtimeCacheGraceMs
+          );
+          loadedCount += 1;
+        }
+        diagnostics.source =
+          loadedCount > 0 ? 'runtime-cache' : 'static-neutral';
+        return loadedCount > 0;
+      } catch {
+        diagnostics.source = 'static-neutral';
+        return false;
+      }
+    })();
+
+    return runtimeCacheLoadPromise;
+  };
+
   const warnOnce = (status: ErrorStatus) => {
     if (!logger || warnedThisService) {
       return;
@@ -294,7 +418,7 @@ export function createGitHubRepoStatsService(
     diagnostics.warningCount += 1;
     safeWriteJson(sessionStorage, WARNING_SESSION_KEY, true);
     logger.warn(
-      '[github-metrics] Live GitHub repo metrics are temporarily unavailable; using cached/static project metrics.',
+      '[github-metrics] Browser live GitHub repo metrics are temporarily unavailable; using cached or neutral project metrics.',
       {
         status,
         backoffExpiresAt: backoff ? toIso(backoff.expiresAt) : null,
@@ -360,8 +484,8 @@ export function createGitHubRepoStatsService(
     identifier: GitHubRepoIdentifier
   ): GitHubRepoStats | null => {
     const entry = readCachedEntry(identifier);
-    if (entry) {
-      diagnostics.source = diagnostics.source === 'live' ? 'live' : 'cached';
+    if (entry && diagnostics.source === 'static-neutral') {
+      diagnostics.source = 'cached';
     }
     return entry?.stats ?? null;
   };
@@ -402,10 +526,13 @@ export function createGitHubRepoStatsService(
   const requestStats = async (
     identifier: GitHubRepoIdentifier
   ): Promise<GitHubRepoStats | null> => {
+    await loadRuntimeCache();
     const key = makeCacheKey(identifier);
     const cached = readCachedEntry(identifier);
     if (cached && cached.freshUntil > now()) {
-      diagnostics.source = 'cached';
+      if (diagnostics.source !== 'runtime-cache') {
+        diagnostics.source = 'cached';
+      }
       return cached.stats;
     }
     const existing = inFlight.get(key);
@@ -413,12 +540,24 @@ export function createGitHubRepoStatsService(
       return existing;
     }
     if (!fetchImpl || !allowLiveFetch) {
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
+      if (
+        !cached &&
+        diagnostics.source !== 'runtime-cache' &&
+        diagnostics.source !== 'runtime-cache-stale'
+      ) {
+        diagnostics.source = 'static-neutral';
+      }
       return cached?.stats ?? null;
     }
     if (isBackoffActive(backoff, now())) {
       diagnostics.suppressedRequestCount += 1;
-      diagnostics.source = cached ? 'cached' : 'static-fallback';
+      if (
+        !cached &&
+        diagnostics.source !== 'runtime-cache' &&
+        diagnostics.source !== 'runtime-cache-stale'
+      ) {
+        diagnostics.source = 'static-neutral';
+      }
       return cached?.stats ?? null;
     }
     if (backoff) {
@@ -441,7 +580,7 @@ export function createGitHubRepoStatsService(
         );
         if (!response.ok) {
           recordFailure(response.status);
-          diagnostics.source = cached ? 'cached' : 'static-fallback';
+          diagnostics.source = cached ? 'cached' : 'static-neutral';
           return cached?.stats ?? null;
         }
         const data = (await response.json()) as Record<string, unknown>;
@@ -455,14 +594,14 @@ export function createGitHubRepoStatsService(
           pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
         };
         writeCachedEntry(identifier, stats);
-        diagnostics.source = 'live';
+        diagnostics.source = 'browser-live';
         diagnostics.lastErrorStatus = null;
         diagnostics.lastErrorAt = null;
         notify(key, stats);
         return stats;
       } catch {
         recordFailure('network');
-        diagnostics.source = cached ? 'cached' : 'static-fallback';
+        diagnostics.source = cached ? 'cached' : 'static-neutral';
         return cached?.stats ?? null;
       } finally {
         if (timeoutId) {
@@ -489,9 +628,14 @@ export function createGitHubRepoStatsService(
     warningCount: diagnostics.warningCount,
   });
 
+  if (options.loadRuntimeCacheOnCreate !== false) {
+    void loadRuntimeCache();
+  }
+
   return {
     getCachedStats,
     requestStats,
+    loadRuntimeCache,
     subscribe,
     getDiagnostics,
   };

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -438,11 +438,14 @@ export function createGitHubRepoStatsService(
           loadedCount += 1;
         }
 
+        const removedRepoKeys: string[] = [];
         for (const [key, entry] of cache) {
           if (entry.source === 'runtime-cache' && !loadedRepoKeys.has(key)) {
             cache.delete(key);
+            removedRepoKeys.push(key);
           }
         }
+        removedRepoKeys.forEach((key) => notify(key, null));
         runtimeCacheRepoKeys.clear();
         for (const key of loadedRepoKeys) {
           runtimeCacheRepoKeys.add(key);

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -394,6 +394,10 @@ export function createGitHubRepoStatsService(
           diagnostics.source = 'static-neutral';
           return false;
         }
+        if (payload.source === 'static-neutral-placeholder') {
+          diagnostics.source = 'static-neutral';
+          return false;
+        }
         const generatedAt = parseTimestamp(payload.generatedAt);
         const expiresAt = parseTimestamp(payload.expiresAt);
         if (generatedAt === null || expiresAt === null || generatedAt > now()) {

--- a/src/systems/github/repoStats.ts
+++ b/src/systems/github/repoStats.ts
@@ -332,6 +332,8 @@ export function createGitHubRepoStatsService(
   };
 
   let runtimeCacheLoadPromise: Promise<boolean> | null = null;
+  let runtimeCacheLoadInFlight = false;
+  let runtimeCacheRefreshAfter = 0;
   let runtimeCacheAvailable = false;
   const runtimeCacheRepoKeys = new Set<string>();
 
@@ -340,9 +342,17 @@ export function createGitHubRepoStatsService(
       return false;
     }
     if (runtimeCacheLoadPromise) {
-      return runtimeCacheLoadPromise;
+      if (
+        runtimeCacheLoadInFlight ||
+        runtimeCacheRefreshAfter === 0 ||
+        now() < runtimeCacheRefreshAfter
+      ) {
+        return runtimeCacheLoadPromise;
+      }
+      runtimeCacheLoadPromise = null;
     }
 
+    runtimeCacheLoadInFlight = true;
     runtimeCacheLoadPromise = (async () => {
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       let controller: AbortController | undefined;
@@ -420,6 +430,7 @@ export function createGitHubRepoStatsService(
         for (const key of loadedRepoKeys) {
           runtimeCacheRepoKeys.add(key);
         }
+        runtimeCacheRefreshAfter = expiresAt + runtimeCacheGraceMs;
         runtimeCacheAvailable = true;
         diagnostics.source =
           loadedCount > 0 ? 'runtime-cache' : 'static-neutral';
@@ -431,12 +442,14 @@ export function createGitHubRepoStatsService(
         if (timeoutId) {
           clearTimeout(timeoutId);
         }
+        runtimeCacheLoadInFlight = false;
       }
     })();
 
     const loaded = await runtimeCacheLoadPromise;
     if (!loaded) {
       runtimeCacheLoadPromise = null;
+      runtimeCacheRefreshAfter = 0;
     }
     return loaded;
   };
@@ -664,6 +677,7 @@ export function createGitHubRepoStatsService(
         if (timeoutId) {
           clearTimeout(timeoutId);
         }
+        runtimeCacheLoadInFlight = false;
         inFlight.delete(key);
       }
     })();

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -101,6 +101,27 @@ describe('AmbientAudioController', () => {
     expect(source.volumes.at(-1)).toBe(0);
   });
 
+  it('hard-disables playback by stopping sources and zeroing volumes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    expect(source.isPlaying).toBe(true);
+    expect(source.volumes.at(-1)).toBeGreaterThan(0);
+
+    controller.disable();
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0].currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0].targetVolume).toBe(0);
+
+    await controller.enable();
+    expect(source.isPlaying).toBe(true);
+  });
+
   it('stops playback when disposed', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });
@@ -108,6 +129,24 @@ describe('AmbientAudioController', () => {
     controller.dispose();
     expect(source.isPlaying).toBe(false);
     expect(source.volumes.at(-1)).toBe(0);
+  });
+
+  it('keeps disabled beds stopped when master volume changes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    controller.disable();
+
+    controller.setMasterVolume(0.5);
+    controller.update({ x: 0, z: 0 }, 0.1);
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0].currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0].targetVolume).toBe(0);
   });
 
   it('applies master volume scaling and updates immediately', () => {

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
+  LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   type AmbientAudioPreferenceChange,
 } from '../systems/audio/ambientAudioPreference';
 
@@ -54,6 +56,37 @@ describe('AmbientAudioPreference', () => {
     });
 
     expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('uses the v2 storage key by default and ignores legacy enabled consent', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.getStorageKey()).toBe(
+      AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY
+    );
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors explicit opt-in stored under the v2 key', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(true);
+  });
+
+  it('persists control disables to the v2 key even when already disabled by default', () => {
+    const storage = new MemoryStorage();
+    const preference = new AmbientAudioPreference({ storage });
+
+    preference.setEnabled(false, 'control');
+    preference.setEnabled(false, 'control');
+
+    expect(storage.getItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY)).toBe('0');
   });
 
   it('loads a persisted enabled state from storage', () => {

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -268,6 +268,36 @@ describe('audio subtitles overlay', () => {
     handle.dispose();
   });
 
+  it('clears queued ambient captions by id without dropping active narration', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-narration',
+      text: 'Narration remains active while ambient is muted.',
+      source: 'poi',
+      priority: 4,
+      durationMs: 1000,
+    });
+
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Queued ambient bed should be removed.',
+      source: 'ambient',
+      priority: 1,
+      durationMs: 600,
+    });
+
+    handle.clear('ambient-hum');
+
+    expect(getCaptionText()).toBe(
+      'Narration remains active while ambient is muted.'
+    );
+    vi.advanceTimersByTime(1000);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
   it('clears the active and queued captions when clear is called without an id', () => {
     const handle = createAudioSubtitles();
     handle.show({

--- a/src/tests/footstepAudioController.test.ts
+++ b/src/tests/footstepAudioController.test.ts
@@ -9,8 +9,14 @@ import {
 class StubFootstepPlayer {
   public readonly calls: FootstepPlaybackOptions[] = [];
 
+  public stopCalls = 0;
+
   play(options: FootstepPlaybackOptions): void {
     this.calls.push(options);
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
   }
 }
 
@@ -81,6 +87,40 @@ describe('footstep audio controller', () => {
     controller.update({ delta: 0.2, linearSpeed: 4, isGrounded: false });
     controller.update({ delta: 0.4, linearSpeed: 4, isGrounded: true });
     expect(player.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('can start disabled and stops active playback when globally muted', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player, {
+      initialEnabled: false,
+      random: () => 0.5,
+    });
+
+    expect(controller.isEnabled()).toBe(false);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('left');
+    expect(player.calls).toHaveLength(0);
+
+    controller.setEnabled(true);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    expect(player.calls.length).toBeGreaterThan(0);
+
+    controller.setEnabled(false);
+    const callsAfterDisable = player.calls.length;
+    expect(player.stopCalls).toBe(1);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('right');
+    expect(player.calls).toHaveLength(callsAfterDisable);
+  });
+
+  it('does not stop playback again when disabled repeatedly', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player);
+
+    controller.setEnabled(false);
+    controller.setEnabled(false);
+
+    expect(player.stopCalls).toBe(1);
   });
 
   it('scales cadence, volume, and pitch with speed and master volume', () => {

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -93,9 +93,13 @@ class MockRepoStatsService implements GitHubRepoStatsService {
     this.cache.set(this.key(identifier), stats);
   }
 
-  emit(identifier: GitHubRepoIdentifier, stats: GitHubRepoStats) {
+  emit(identifier: GitHubRepoIdentifier, stats: GitHubRepoStats | null) {
     const key = this.key(identifier);
-    this.cache.set(key, stats);
+    if (stats) {
+      this.cache.set(key, stats);
+    } else {
+      this.cache.delete(key);
+    }
     const listeners = this.listeners.get(key);
     if (!listeners) {
       return;
@@ -425,12 +429,12 @@ describe('wireGitHubRepoMetrics', () => {
       pushedAt: '2024-01-01T00:00:00Z',
     });
 
-    const updates: Array<{ poiId: string; stars: number }> = [];
+    const updates: Array<{ poiId: string; stars: number | null }> = [];
     const controller = wireGitHubRepoMetrics({
       definitions,
       service,
       onRepoStatsUpdated: ({ poiId, stats }) => {
-        updates.push({ poiId, stars: stats.stars });
+        updates.push({ poiId, stars: stats?.stars ?? null });
       },
     });
 
@@ -463,6 +467,15 @@ describe('wireGitHubRepoMetrics', () => {
     expect(updates.slice(-2)).toEqual([
       { poiId: 'futuroptimist-living-room-tv', stars: 1425 },
       { poiId: 'gitshelves-living-room-installation', stars: 1425 },
+    ]);
+
+    service.emit(identifier, null);
+    await Promise.resolve();
+    expect(definitions[0].metrics?.[0]?.value).toBe('Fallback');
+    expect(definitions[1].metrics?.[0]?.value).toBe('Fallback');
+    expect(updates.slice(-2)).toEqual([
+      { poiId: 'futuroptimist-living-room-tv', stars: null },
+      { poiId: 'gitshelves-living-room-installation', stars: null },
     ]);
 
     controller.dispose();

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -42,9 +42,13 @@ class MockRepoStatsService implements GitHubRepoStatsService {
     return Promise.resolve(this.cache.get(key) ?? null);
   }
 
+  loadRuntimeCache(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
   getDiagnostics() {
     return {
-      source: 'static-fallback' as const,
+      source: 'static-neutral' as const,
       requestCount: this.requested.length,
       suppressedRequestCount: 0,
       lastErrorStatus: null,

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -197,7 +197,7 @@ describe('wireGitHubRepoMetrics', () => {
             value: 'Hidden',
             source: {
               type: 'githubStars',
-              owner: 'futuroptimist',
+              owner: 'democratizedspace',
               repo: 'dspace',
               visibility: 'private',
               fallback: 'Hidden',
@@ -241,7 +241,7 @@ describe('wireGitHubRepoMetrics', () => {
     );
     expect(definitions[2].metrics?.[0]?.value).toBe('86 stars');
     expect(
-      service.listenerCount({ owner: 'futuroptimist', repo: 'dspace' })
+      service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
     ).toBe(0);
 
     controller.dispose();

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -27,10 +27,156 @@ const createOptions = (overrides: Record<string, unknown> = {}) => ({
   logger: { warn: vi.fn() },
   now: () => 1_000,
   fetchTimeoutMs: 0,
+  runtimeCacheUrl: null,
+  loadRuntimeCacheOnCreate: false,
   ...overrides,
 });
 
 describe('GitHub repo stats service', () => {
+  it('loads valid pod-local runtime cache before live browser fetches', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        source: 'github-api',
+        repos: {
+          'futuroptimist/token.place': {
+            owner: 'futuroptimist',
+            repo: 'token.place',
+            stars: 6,
+            watchers: 1,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: '2026-06-03T00:00:00Z',
+            fetchedAt: '2026-06-03T00:00:00.000Z',
+            htmlUrl: 'https://github.com/futuroptimist/token.place',
+          },
+        },
+        errors: {},
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    const stats = await service.requestStats({
+      owner: 'futuroptimist',
+      repo: 'token.place',
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/runtime/github-metrics.json', {
+      headers: { Accept: 'application/json' },
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(stats?.stars).toBe(6);
+    expect(stats?.watchers).toBe(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      cachedRepoCount: 1,
+    });
+  });
+
+  it('does not map runtime watchers to stars', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        repos: {
+          'futuroptimist/flywheel': {
+            owner: 'futuroptimist',
+            repo: 'flywheel',
+            stars: 2,
+            watchers: 999,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    const stats = await service.requestStats({
+      owner: 'futuroptimist',
+      repo: 'flywheel',
+    });
+
+    expect(stats?.stars).toBe(2);
+    expect(stats?.watchers).toBe(999);
+  });
+
+  it('treats stale and invalid runtime cache as neutral fallback', async () => {
+    const staleFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:00:00.000Z',
+        repos: {
+          'futuroptimist/flywheel': {
+            owner: 'futuroptimist',
+            repo: 'flywheel',
+            stars: 123,
+            watchers: 1,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+        },
+      }),
+    });
+    const staleService = createGitHubRepoStatsService(
+      staleFetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        runtimeCacheGraceMs: 20 * 60 * 1000,
+        now: () => Date.parse('2026-06-03T01:30:01.000Z'),
+      })
+    );
+
+    await expect(
+      staleService.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    expect(staleService.getDiagnostics().source).toBe('runtime-cache-stale');
+
+    const invalidFetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    const invalidService = createGitHubRepoStatsService(
+      invalidFetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+      })
+    );
+
+    await expect(
+      invalidService.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    expect(invalidService.getDiagnostics().source).toBe('static-neutral');
+  });
   it('fetches stats, caches results, and notifies subscribers', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -67,7 +213,7 @@ describe('GitHub repo stats service', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0][0]).toEqual(stats);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'live',
+      source: 'browser-live',
       requestCount: 1,
       lastErrorStatus: null,
     });
@@ -95,7 +241,7 @@ describe('GitHub repo stats service', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(service.getDiagnostics()).toMatchObject({
-      source: 'static-fallback',
+      source: 'static-neutral',
       requestCount: 1,
       lastErrorStatus: 403,
       warningCount: 1,
@@ -124,7 +270,7 @@ describe('GitHub repo stats service', () => {
       requestCount: 1,
       suppressedRequestCount: 1,
       lastErrorStatus: 429,
-      source: 'static-fallback',
+      source: 'static-neutral',
     });
   });
 
@@ -241,7 +387,7 @@ describe('GitHub repo stats service', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(stats?.stars).toBe(42);
-    expect(service.getDiagnostics().source).toBe('live');
+    expect(service.getDiagnostics().source).toBe('browser-live');
   });
 
   it('honors explicit null storage and logger options', async () => {

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -292,6 +292,67 @@ describe('GitHub repo stats service', () => {
     expect(service.getDiagnostics().source).toBe('runtime-cache');
   });
 
+  it('clears expired runtime stats and notifies subscribers after failed refreshes', async () => {
+    let currentTime = Date.parse('2026-06-03T01:20:00.000Z');
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2026-06-03T01:15:00.000Z',
+          repos: {
+            'futuroptimist/flywheel': {
+              owner: 'futuroptimist',
+              repo: 'flywheel',
+              stars: 8,
+              watchers: 2,
+              forks: 1,
+              openIssues: 0,
+              pushedAt: null,
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 404 });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        runtimeCacheGraceMs: 20 * 60 * 1000,
+        now: () => currentTime,
+      })
+    );
+    const listener = vi.fn();
+    service.subscribe({ owner: 'futuroptimist', repo: 'flywheel' }, listener);
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toMatchObject({ stars: 8 });
+
+    currentTime = Date.parse('2026-06-03T01:36:00.000Z');
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls.map(([stats]) => stats?.stars ?? null)).toEqual([
+      8,
+      null,
+    ]);
+    expect(
+      service.getCachedStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      cachedRepoCount: 0,
+    });
+  });
+
   it('times out hung runtime cache loads before returning neutral stats', async () => {
     const fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
       return new Promise<Response>((_resolve, reject) => {

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -292,6 +292,88 @@ describe('GitHub repo stats service', () => {
     expect(service.getDiagnostics().source).toBe('runtime-cache');
   });
 
+  it('notifies subscribers when refreshed runtime cache omits a loaded repo', async () => {
+    let currentTime = Date.parse('2026-06-03T01:20:00.000Z');
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2026-06-03T01:15:00.000Z',
+          repos: {
+            'futuroptimist/flywheel': {
+              owner: 'futuroptimist',
+              repo: 'flywheel',
+              stars: 8,
+              watchers: 2,
+              forks: 1,
+              openIssues: 0,
+              pushedAt: null,
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T01:30:00.000Z',
+          expiresAt: '2026-06-03T02:30:00.000Z',
+          repos: {
+            'futuroptimist/token.place': {
+              owner: 'futuroptimist',
+              repo: 'token.place',
+              stars: 12,
+              watchers: 2,
+              forks: 1,
+              openIssues: 0,
+              pushedAt: null,
+            },
+          },
+          errors: {
+            'futuroptimist/flywheel': { status: 404, message: 'Not found' },
+          },
+        }),
+      });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        runtimeCacheGraceMs: 20 * 60 * 1000,
+        now: () => currentTime,
+      })
+    );
+    const listener = vi.fn();
+    service.subscribe({ owner: 'futuroptimist', repo: 'flywheel' }, listener);
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toMatchObject({ stars: 8 });
+
+    currentTime = Date.parse('2026-06-03T01:36:00.000Z');
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls.map(([stats]) => stats?.stars ?? null)).toEqual([
+      8,
+      null,
+    ]);
+    expect(
+      service.getCachedStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).toBeNull();
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'static-neutral',
+      cachedRepoCount: 1,
+    });
+  });
+
   it('clears expired runtime stats and notifies subscribers after failed refreshes', async () => {
     let currentTime = Date.parse('2026-06-03T01:20:00.000Z');
     const fetch = vi

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -222,6 +222,76 @@ describe('GitHub repo stats service', () => {
     expect(service.getDiagnostics().source).toBe('runtime-cache');
   });
 
+  it('refreshes successful runtime cache loads after the cache window expires', async () => {
+    let currentTime = Date.parse('2026-06-03T01:20:00.000Z');
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2026-06-03T01:15:00.000Z',
+          repos: {
+            'futuroptimist/flywheel': {
+              owner: 'futuroptimist',
+              repo: 'flywheel',
+              stars: 8,
+              watchers: 2,
+              forks: 1,
+              openIssues: 0,
+              pushedAt: null,
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T01:30:00.000Z',
+          expiresAt: '2026-06-03T02:30:00.000Z',
+          repos: {
+            'futuroptimist/flywheel': {
+              owner: 'futuroptimist',
+              repo: 'flywheel',
+              stars: 13,
+              watchers: 3,
+              forks: 1,
+              openIssues: 0,
+              pushedAt: null,
+            },
+          },
+        }),
+      });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        runtimeCacheGraceMs: 20 * 60 * 1000,
+        now: () => currentTime,
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toMatchObject({ stars: 8 });
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toMatchObject({ stars: 8 });
+
+    currentTime = Date.parse('2026-06-03T01:36:00.000Z');
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toMatchObject({ stars: 13 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(service.getDiagnostics().source).toBe('runtime-cache');
+  });
+
   it('times out hung runtime cache loads before returning neutral stats', async () => {
     const fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
       return new Promise<Response>((_resolve, reject) => {

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -177,6 +177,153 @@ describe('GitHub repo stats service', () => {
     ).resolves.toBeNull();
     expect(invalidService.getDiagnostics().source).toBe('static-neutral');
   });
+
+  it('retries runtime cache after temporary load failures', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2026-06-03T01:15:00.000Z',
+          repos: {
+            'futuroptimist/flywheel': {
+              owner: 'futuroptimist',
+              repo: 'flywheel',
+              stars: 8,
+              watchers: 2,
+              forks: 1,
+              openIssues: 0,
+              pushedAt: null,
+            },
+          },
+        }),
+      });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toMatchObject({ stars: 8 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(service.getDiagnostics().source).toBe('runtime-cache');
+  });
+
+  it('times out hung runtime cache loads before returning neutral stats', async () => {
+    const fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        fetchTimeoutMs: 1,
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics().source).toBe('static-neutral');
+  });
+
+  it('keeps runtime-cache-missing repos neutral instead of using old browser cache', async () => {
+    const localStorage = new MemoryStorage();
+    localStorage.setItem(
+      'danielsmith.io:github-repo-stats:futuroptimist/private-repo',
+      JSON.stringify({
+        stats: {
+          stars: 99,
+          watchers: 4,
+          forks: 3,
+          openIssues: 2,
+          pushedAt: null,
+        },
+        cachedAt: Date.parse('2026-06-03T01:00:00.000Z'),
+      })
+    );
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T01:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        repos: {},
+        errors: {
+          'futuroptimist/private-repo': { status: 404, message: 'Not found' },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        localStorage,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:10:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'private-repo' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics().source).toBe('static-neutral');
+  });
+
+  it('treats expired local stats as neutral when live fetches are disabled', async () => {
+    const localStorage = new MemoryStorage();
+    localStorage.setItem(
+      'danielsmith.io:github-repo-stats:futuroptimist/flywheel',
+      JSON.stringify({
+        stats: {
+          stars: 77,
+          watchers: 3,
+          forks: 4,
+          openIssues: 5,
+          pushedAt: '2024-01-01T00:00:00Z',
+        },
+        cachedAt: 1,
+      })
+    );
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        localStorage,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => 3_700_000,
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    expect(service.getDiagnostics().source).toBe('static-neutral');
+  });
   it('fetches stats, caches results, and notifies subscribers', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -178,6 +178,60 @@ describe('GitHub repo stats service', () => {
     expect(invalidService.getDiagnostics().source).toBe('static-neutral');
   });
 
+  it('treats the static neutral placeholder as retryable instead of authoritative', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2999-01-01T00:00:00.000Z',
+          source: 'static-neutral-placeholder',
+          repos: {},
+          errors: {},
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          generatedAt: '2026-06-03T00:00:00.000Z',
+          expiresAt: '2026-06-03T01:15:00.000Z',
+          repos: {
+            'futuroptimist/flywheel': {
+              owner: 'futuroptimist',
+              repo: 'flywheel',
+              stars: 8,
+              watchers: 2,
+              forks: 1,
+              openIssues: 0,
+              pushedAt: null,
+            },
+          },
+        }),
+      });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toBeNull();
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).resolves.toMatchObject({ stars: 8 });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(service.getDiagnostics().source).toBe('runtime-cache');
+  });
+
   it('retries runtime cache after temporary load failures', async () => {
     const fetch = vi
       .fn()

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -240,6 +240,34 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('keeps GitHub star metric metadata and neutral fallback copy in every locale', () => {
+    const fakeFallbackPattern =
+      /(?:\d[\d,.]*\s*(?:\+|k|m)?\s*(?:stars?|estrelas|sterne|星标|スター|نجوم|csillag))/i;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const definitions = getPoiDefinitions(locale);
+      const starMetrics = definitions.flatMap((poi) =>
+        (poi.metrics ?? [])
+          .filter((metric) => metric.source?.type === 'githubStars')
+          .map((metric) => ({ poi, metric, source: metric.source }))
+      );
+
+      expect(starMetrics.length, locale).toBeGreaterThan(0);
+      for (const { poi, metric, source } of starMetrics) {
+        expect(source?.owner, `${locale} ${poi.id}`).toEqual(
+          expect.any(String)
+        );
+        expect(source?.repo, `${locale} ${poi.id}`).toEqual(expect.any(String));
+        expect(metric.value, `${locale} ${poi.id}`).not.toMatch(
+          fakeFallbackPattern
+        );
+        expect(source?.fallback ?? '', `${locale} ${poi.id}`).not.toMatch(
+          fakeFallbackPattern
+        );
+      }
+    }
+  });
+
   it('deep-clones localized POI metric sources per call', () => {
     const firstDefinitions = getPoiDefinitions('en-x-pseudo');
     const firstPoi = firstDefinitions.find(

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -268,6 +268,32 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('marks every localized DSPACE GitHub star metric as private and neutral', () => {
+    const numericFallbackPattern = /\d/;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const dspace = getPoiDefinitions(locale).find(
+        (poi) => poi.id === 'dspace-backyard-rocket'
+      );
+      const starMetric = dspace?.metrics?.find(
+        (metric) => metric.source?.type === 'githubStars'
+      );
+
+      expect(dspace, locale).toBeDefined();
+      expect(starMetric, locale).toBeDefined();
+      expect(starMetric?.source, locale).toMatchObject({
+        type: 'githubStars',
+        owner: 'democratizedspace',
+        repo: 'dspace',
+        visibility: 'private',
+      });
+      expect(starMetric?.value, locale).not.toMatch(numericFallbackPattern);
+      expect(starMetric?.source?.fallback ?? '', locale).not.toMatch(
+        numericFallbackPattern
+      );
+    }
+  });
+
   it('deep-clones localized POI metric sources per call', () => {
     const firstDefinitions = getPoiDefinitions('en-x-pseudo');
     const firstPoi = firstDefinitions.find(

--- a/src/tests/mediaWallStarBridge.test.ts
+++ b/src/tests/mediaWallStarBridge.test.ts
@@ -13,19 +13,19 @@ describe('createMediaWallStarBridge', () => {
     return controller;
   };
 
-  it('applies the initial star count when attaching a controller', () => {
-    const bridge = createMediaWallStarBridge(1280);
+  it('applies a neutral initial state when attaching a controller', () => {
+    const bridge = createMediaWallStarBridge();
     const controller = createController();
 
     bridge.attach(controller);
 
     expect(controller.setStarCount).toHaveBeenCalledTimes(1);
-    expect(controller.setStarCount).toHaveBeenCalledWith(1280);
-    expect(bridge.getStarCount()).toBe(1280);
+    expect(controller.setStarCount).toHaveBeenCalledWith(null);
+    expect(bridge.getStarCount()).toBeNull();
   });
 
   it('updates the controller when live star counts arrive', () => {
-    const bridge = createMediaWallStarBridge(1280);
+    const bridge = createMediaWallStarBridge();
     const controller = createController();
     bridge.attach(controller);
 
@@ -53,17 +53,17 @@ describe('createMediaWallStarBridge', () => {
     expect(firstController.setStarCount).toHaveBeenCalledTimes(2);
   });
 
-  it('sanitizes invalid star counts to zero', () => {
+  it('sanitizes invalid star counts to a neutral state', () => {
     const bridge = createMediaWallStarBridge();
     const controller = createController();
     bridge.attach(controller);
 
     bridge.updateStarCount(Number.NaN);
-    expect(bridge.getStarCount()).toBe(0);
-    expect(controller.setStarCount).toHaveBeenLastCalledWith(0);
+    expect(bridge.getStarCount()).toBeNull();
+    expect(controller.setStarCount).toHaveBeenLastCalledWith(null);
 
     bridge.updateStarCount(-42);
-    expect(bridge.getStarCount()).toBe(0);
-    expect(controller.setStarCount).toHaveBeenLastCalledWith(0);
+    expect(bridge.getStarCount()).toBeNull();
+    expect(controller.setStarCount).toHaveBeenLastCalledWith(null);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent POIs and the media wall from ever displaying invented GitHub star counts and prefer neutral localized fallback copy when live data is unavailable.
- Prefer a pod-local sidecar cache (`/runtime/github-metrics.json`) as the primary source of truth for public repo metrics to avoid browser-side fan-out and rate-limit noise.
- Treat stale/invalid/missing cache as unavailable (neutral state) and only surface private/unavailable repos as unavailable, not with hard-coded numbers.
- Preserve i18n POI metadata (owner/repo/source) while ensuring localized neutral fallback copy is used until authentic metrics arrive.

### Description
- Add runtime-cache support to the repo stats service (`src/systems/github/repoStats.ts`) including: fetching and validating `/runtime/github-metrics.json`, schema/timestamp checks, modest grace window, normalization, in-memory population, diagnostics sources (`runtime-cache`, `runtime-cache-stale`, `browser-live`, `cached`, `static-neutral`), and `loadRuntimeCache()` API.
- Gate browser live GitHub API requests behind explicit debug/test flags and only attempt `https://api.github.com` when allowed; map stars from `stargazers_count` and avoid using `watchers_count` as stars.
- Wire runtime cache load before `requestStats(...)` and notify subscribers when runtime cache entries populate so open tooltips/world tooltips update automatically (`src/scene/poi/githubMetrics.ts`).
- Make the media wall start in a neutral/"Syncing" state and accept `null` star updates via `createMediaWallStarBridge` so it never shows fake defaults (`src/scene/structures/mediaWall.ts`, `mediaWallStarBridge.ts`).
- Ensure POI i18n entries keep `githubStars` source metadata while using neutral fallback text; update pseudo locale copy accordingly (`src/assets/i18n/locales/*`).
- Add unit tests and a Playwright spec covering runtime cache parsing, stale/invalid cache handling, star vs watcher mapping, neutral fallbacks, and no browser GitHub fan-out (`src/tests/*`, `playwright/github-metrics-fallback.spec.ts`).
- Update docs to explain the sidecar-backed cache, cache freshness/grace behavior, debug gating for live fetches, and that no secrets are added to the frontend (`docs/architecture/scene-stack.md`, `docs/roadmap.md`).

### Testing
- Ran formatting and linting: `npm run format:write` (succeeded), `npm run lint` (succeeded).
- Ran focused unit suites: `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts` (all tests passed).
- Ran full unit suite: `npm run test:ci` (all tests passed in CI run; 997 tests passed in local run shown in transcript).
- Built and smoke-tested: `npm run build` (succeeded) and `npm run smoke` (succeeded).
- End-to-end Playwright test: `npm run test:e2e -- playwright/github-metrics-fallback.spec.ts` (initial environment install steps were required; after installing Playwright browsers and deps the spec passed and verified runtime cache loading and no browser fan-out).
- Docs check and links: `npm run docs:check` (passed; link checker produced expected external reachability warnings in this environment).
- Type-check: `npm run typecheck` remains failing due to existing unrelated, project-wide TypeScript issues outside this change set and is noted as a residual (no secrets introduced by this PR).

Notes: the PR keeps runtime behavior conservative by default (neutral fallbacks, pod-local cache preferred), adds diagnostics accessible via `window.portfolio.githubMetrics.getDiagnostics()`, and includes tests that mock fetch and verify no live GitHub requests occur in normal mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221b8a4f48832f95a20daff158c6fd)