### PR TITLE
Add global audio mute/control, v2 preference storage, and audio debug state; update audio caption/footstep behavior and i18n POI visibility

### DIFF
--- a/playwright/small-screen-hud.spec.ts
+++ b/playwright/small-screen-hud.spec.ts
@@ -22,10 +22,27 @@ type ElementBounds = {
   height: number;
 };
 
+type AudioDebugState = {
+  preferenceEnabled: boolean;
+  ambientEnabled: boolean;
+  ambientSourcesPlayingCount: number;
+  ambientBedVolumes: Array<{
+    id: string;
+    currentVolume: number;
+    targetVolume: number;
+  }>;
+  footstepEnabled: boolean;
+  footstepPlaying: boolean;
+  activeStorageKey: string;
+};
+
 type PortfolioPoiWindow = Window & {
   portfolio?: {
     poi?: {
       getTooltipState?: () => PoiTooltipState;
+    };
+    audio?: {
+      getState?: () => AudioDebugState;
     };
   };
 };
@@ -71,6 +88,21 @@ async function waitForImmersiveReady(page: Page) {
   await page.waitForFunction(
     () => (window as PortfolioPoiWindow).portfolio?.poi?.getTooltipState
   );
+  await page.waitForFunction(
+    () => (window as PortfolioPoiWindow).portfolio?.audio?.getState
+  );
+}
+
+async function getAudioState(page: Page): Promise<AudioDebugState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioPoiWindow).portfolio?.audio?.getState;
+
+    if (!getState) {
+      throw new Error('window.portfolio.audio.getState() is unavailable');
+    }
+
+    return getState();
+  });
 }
 
 async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
@@ -190,6 +222,79 @@ test.describe('small-screen HUD regression coverage', () => {
 
   test.describe('desktop viewport', () => {
     test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('routes Settings audio and M key toggles through global mute', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        window.localStorage.setItem(
+          'danielsmith.io::ambientAudioEnabled::v1',
+          '1'
+        );
+        window.localStorage.removeItem(
+          'danielsmith.io::ambientAudioEnabled::v2'
+        );
+      });
+      await waitForImmersiveReady(page);
+
+      const settingsButton = page.locator('[data-role="settings-button"]');
+      const settingsModal = page.locator('.help-modal-backdrop');
+      await settingsButton.click();
+      await expect(settingsModal).toBeVisible();
+
+      const audioToggle = settingsModal.locator('button.audio-toggle');
+      const audioVolume = settingsModal.locator('.audio-volume__value');
+      await expect(audioToggle).toContainText(/Audio:\s*Off/i);
+      await expect(audioVolume).toContainText(/Muted/i);
+
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+          footstepPlaying: false,
+          activeStorageKey: 'danielsmith.io::ambientAudioEnabled::v2',
+        });
+
+      await audioToggle.click();
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: true,
+          ambientEnabled: true,
+          footstepEnabled: true,
+        });
+
+      await page.keyboard.press('m');
+      await expect
+        .poll(async () => {
+          const state = await getAudioState(page);
+          return (
+            !state.preferenceEnabled &&
+            !state.ambientEnabled &&
+            state.ambientSourcesPlayingCount === 0 &&
+            !state.footstepEnabled &&
+            !state.footstepPlaying &&
+            state.ambientBedVolumes.every(
+              (bed) => bed.currentVolume === 0 && bed.targetVolume === 0
+            )
+          );
+        })
+        .toBe(true);
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForImmersiveReady(page);
+      await expect
+        .poll(async () => getAudioState(page))
+        .toMatchObject({
+          preferenceEnabled: false,
+          ambientEnabled: false,
+          ambientSourcesPlayingCount: 0,
+          footstepEnabled: false,
+        });
+    });
 
     test('keeps desktop keyboard HUD toggles mutually exclusive', async ({
       page,

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -909,7 +909,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       outcome: {
         label: 'Outcome',
         value:
-          'Links to the public democratizedspace/dspace repository and official game documentation instead of an unverified mission log.',
+          'Keeps private democratizedspace/dspace repository metadata unavailable while linking official game documentation instead of an unverified mission log.',
       },
       metrics: [
         {
@@ -919,6 +919,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
+            visibility: 'private',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -1033,7 +1033,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', undefined, 'democratizedspace'),
+          source: starSource('dspace', 'private', 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -744,7 +744,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       outcome: {
         label: '成果',
         value:
-          '链接到公开的 democratizedspace/dspace 仓库和官方游戏文档，避免未经验证的任务日志。',
+          '将私有的 democratizedspace/dspace 仓库指标保持为不可用，同时链接官方游戏文档，避免未经验证的任务日志。',
       },
       metrics: [
         { label: '游戏', value: '资源管理 · 任务 · 探索' },
@@ -755,6 +755,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
+            visibility: 'private',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,7 @@ import {
   type AmbientAudioSource,
 } from './systems/audio/ambientAudio';
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
   bindAmbientAudioPreference,
   type AmbientAudioPreferenceBindingHandle,
@@ -475,6 +476,26 @@ declare global {
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
+      audio?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          ambientEnabled: boolean;
+          ambientSourcesPlaying: { id: string; isPlaying: boolean }[];
+          ambientSourcesPlayingCount: number;
+          ambientBedVolumes: {
+            id: string;
+            currentVolume: number;
+            targetVolume: number;
+          }[];
+          footstepEnabled: boolean;
+          footstepPlaying: boolean;
+          masterVolume: number;
+          baseVolume: number;
+          audioContextState: AudioContextState | 'unknown';
+          storageKeyVersion: string;
+          activeStorageKey: string;
+        };
       };
       graphics?: {
         getMotionBlurIntensity(): number;
@@ -1022,6 +1043,101 @@ function initializeImmersiveScene(
     ambientAudioController?.getMasterVolume() ?? 1;
   let setAmbientAudioVolume = (volume: number) => {
     ambientAudioController?.setMasterVolume(volume);
+  };
+
+  const stopFootstepAudio = () => {
+    if (!footstepAudio) {
+      return;
+    }
+    footstepAudio.setVolume(0);
+    if (footstepAudio.isPlaying) {
+      footstepAudio.stop();
+    }
+  };
+
+  const hardDisableRuntimeAudio = () => {
+    ambientAudioController?.disable();
+    footstepAudioController?.setEnabled(false);
+    stopFootstepAudio();
+    ambientCaptionBridge?.clear();
+    audioHudHandle?.refresh();
+  };
+
+  let globalAudioTransitionId = 0;
+
+  const setGlobalAudioEnabled = async (
+    enabled: boolean,
+    source: 'control' | 'storage' = 'control'
+  ) => {
+    const transitionId = ++globalAudioTransitionId;
+
+    if (!enabled) {
+      hardDisableRuntimeAudio();
+      ambientAudioPreference?.setEnabled(false, source);
+      audioHudHandle?.refresh();
+      return;
+    }
+
+    if (!ambientAudioController) {
+      if (source === 'control') {
+        ambientAudioPreference?.setEnabled(false, source);
+      }
+      audioHudHandle?.refresh();
+      return;
+    }
+
+    try {
+      await ambientAudioController.enable();
+      if (
+        transitionId !== globalAudioTransitionId ||
+        (source === 'storage' &&
+          !(ambientAudioPreference?.isEnabled() ?? false))
+      ) {
+        hardDisableRuntimeAudio();
+        audioHudHandle?.refresh();
+        return;
+      }
+      footstepAudioController?.setEnabled(true);
+      ambientAudioPreference?.setEnabled(true, source);
+    } catch (error) {
+      hardDisableRuntimeAudio();
+      if (source === 'control') {
+        ambientAudioPreference?.setEnabled(false, source);
+      }
+      audioHudHandle?.refresh();
+      throw error;
+    }
+    audioHudHandle?.refresh();
+  };
+
+  const getAudioDebugState = () => {
+    const snapshots = ambientAudioController?.getBedSnapshots() ?? [];
+    const ambientSourcesPlaying = snapshots.map((snapshot) => ({
+      id: snapshot.id,
+      isPlaying: snapshot.definition.source.isPlaying,
+    }));
+    return {
+      preferenceEnabled: ambientAudioPreference?.isEnabled() ?? false,
+      ambientEnabled: ambientAudioController?.isEnabled() ?? false,
+      ambientSourcesPlaying,
+      ambientSourcesPlayingCount: ambientSourcesPlaying.filter(
+        (source) => source.isPlaying
+      ).length,
+      ambientBedVolumes: snapshots.map((snapshot) => ({
+        id: snapshot.id,
+        currentVolume: snapshot.currentVolume,
+        targetVolume: snapshot.targetVolume,
+      })),
+      footstepEnabled: footstepAudioController?.isEnabled() ?? false,
+      footstepPlaying: footstepAudio?.isPlaying ?? false,
+      masterVolume: ambientAudioController?.getMasterVolume() ?? 0,
+      baseVolume: getAmbientAudioVolume(),
+      audioContextState: audioListener?.context?.state ?? 'unknown',
+      storageKeyVersion: 'v2',
+      activeStorageKey:
+        ambientAudioPreference?.getStorageKey() ??
+        AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
+    };
   };
 
   let localeStorage: Storage | undefined;
@@ -1858,6 +1974,9 @@ function initializeImmersiveScene(
   window.portfolio.githubMetrics = {
     getDiagnostics: () => githubRepoStatsService.getDiagnostics(),
   };
+  window.portfolio.audio = {
+    getState: getAudioDebugState,
+  };
   const wirePoiGitHubMetrics = () => {
     githubRepoMetrics?.dispose();
     githubRepoMetrics = wireGitHubRepoMetrics({
@@ -2401,6 +2520,10 @@ function initializeImmersiveScene(
   footstepAudioController = createFootstepAudioController({
     player: {
       play: ({ volume, playbackRate, pan }) => {
+        if (!(ambientAudioPreference?.isEnabled() ?? false)) {
+          stopFootstepAudio();
+          return;
+        }
         const clampedVolume = MathUtils.clamp(volume, 0, 1);
         const clampedRate = MathUtils.clamp(playbackRate, 0.25, 3);
         if (footstepStereoPanner && typeof pan === 'number') {
@@ -2418,7 +2541,9 @@ function initializeImmersiveScene(
         }
         footstepAudioNode.play();
       },
+      stop: stopFootstepAudio,
     },
+    initialEnabled: ambientAudioPreference?.isEnabled() ?? false,
     maxLinearSpeed: PLAYER_SPEED,
     minActivationSpeed: PLAYER_SPEED * 0.12,
     intervalRange: { min: 0.26, max: 0.58 },
@@ -3650,11 +3775,20 @@ function initializeImmersiveScene(
       ambientAudioPreferenceBinding = null;
     }
     ambientAudioPreferenceBinding = bindAmbientAudioPreference({
-      controller: ambientAudioController,
+      controller: {
+        enable: () => setGlobalAudioEnabled(true, 'storage'),
+        disable: () => {
+          void setGlobalAudioEnabled(false, 'storage');
+        },
+        isEnabled: () => ambientAudioController?.isEnabled() ?? false,
+      },
       preference: ambientAudioPreference,
       windowTarget: window,
       logger: console,
     });
+    if (!ambientAudioPreference.isEnabled()) {
+      hardDisableRuntimeAudio();
+    }
 
     if (!ambientCaptionBridge && audioSubtitles) {
       ambientCaptionBridge = new AmbientCaptionBridge({
@@ -3667,19 +3801,10 @@ function initializeImmersiveScene(
       container: hudSettingsStack,
       getEnabled: () => ambientAudioController?.isEnabled() ?? false,
       setEnabled: async (enabled) => {
-        if (!ambientAudioController) {
-          return;
-        }
-        if (enabled) {
-          try {
-            await ambientAudioController.enable();
-            ambientAudioPreference?.setEnabled(true, 'control');
-          } catch (error) {
-            console.warn('Ambient audio failed to start', error);
-          }
-        } else {
-          ambientAudioController.disable();
-          ambientAudioPreference?.setEnabled(false, 'control');
+        try {
+          await setGlobalAudioEnabled(enabled, 'control');
+        } catch (error) {
+          console.warn('Ambient audio failed to start', error);
         }
       },
       getVolume: () => getAmbientAudioVolume(),
@@ -4764,6 +4889,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.githubMetrics) {
       delete window.portfolio.githubMetrics;
+    }
+    if (window.portfolio?.audio) {
+      delete window.portfolio.audio;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/systems/audio/ambientAudio.ts
+++ b/src/systems/audio/ambientAudio.ts
@@ -164,15 +164,15 @@ export class AmbientAudioController {
   }
 
   disable(): void {
-    if (!this.enabled) {
-      return;
-    }
     this.enabled = false;
     this.elapsedTime = 0;
     this.beds.forEach((bed) => {
       bed.currentVolume = 0;
       bed.definition.source.setVolume(0);
       bed.targetVolume = 0;
+      if (bed.definition.source.isPlaying) {
+        bed.definition.source.stop();
+      }
     });
   }
 

--- a/src/systems/audio/ambientAudioPreference.ts
+++ b/src/systems/audio/ambientAudioPreference.ts
@@ -25,7 +25,12 @@ export interface AmbientAudioPreferenceBindingHandle {
   dispose(): void;
 }
 
-const DEFAULT_STORAGE_KEY = 'danielsmith.io::ambientAudioEnabled::v1';
+export const AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v2';
+export const LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::ambientAudioEnabled::v1';
+
+const DEFAULT_STORAGE_KEY = AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY;
 
 const parseStoredValue = (value: string | null): boolean | null => {
   if (value === '1' || value === 'true') {
@@ -103,11 +108,18 @@ export class AmbientAudioPreference {
     source: AmbientAudioPreferenceChangeSource = 'control'
   ): void {
     if (this.enabled === enabled) {
+      if (source === 'control') {
+        this.persist();
+      }
       return;
     }
     this.enabled = enabled;
     this.persist();
     this.notify(source);
+  }
+
+  getStorageKey(): string {
+    return this.storageKey;
   }
 
   subscribe(
@@ -240,14 +252,16 @@ export const bindAmbientAudioPreference = ({
   };
 
   const attemptEnable = async () => {
-    if (disposed || controller.isEnabled()) {
+    if (disposed || controller.isEnabled() || !preference.isEnabled()) {
       return;
     }
     try {
       await controller.enable();
     } catch (error) {
       logger.warn('Ambient audio auto-resume failed:', error);
-      scheduleGestureListeners();
+      if (preference.isEnabled()) {
+        scheduleGestureListeners();
+      }
     }
   };
 

--- a/src/systems/audio/ambientCaptionBridge.ts
+++ b/src/systems/audio/ambientCaptionBridge.ts
@@ -49,6 +49,8 @@ export class AmbientCaptionBridge {
 
   private readonly states = new Map<string, AmbientCaptionState>();
 
+  private readonly messageIds = new Set<string>();
+
   constructor({
     controller,
     subtitles,
@@ -60,6 +62,14 @@ export class AmbientCaptionBridge {
     this.subtitles = subtitles;
     this.cooldownMs = Math.max(0, cooldownMs);
     this.now = now;
+  }
+
+  clear(): void {
+    for (const messageId of this.messageIds) {
+      this.subtitles.clear(messageId);
+    }
+    this.messageIds.clear();
+    this.states.clear();
   }
 
   update(): void {
@@ -75,6 +85,7 @@ export class AmbientCaptionBridge {
     for (const id of Array.from(this.states.keys())) {
       if (!snapshotIds.has(id)) {
         this.states.delete(id);
+        this.messageIds.delete(`ambient-${id}`);
       }
     }
   }
@@ -85,8 +96,10 @@ export class AmbientCaptionBridge {
   ): void {
     const { definition, currentVolume } = snapshot;
     const caption = definition.caption;
+    const messageId = `ambient-${snapshot.id}`;
     if (!caption) {
       this.states.delete(snapshot.id);
+      this.messageIds.delete(messageId);
       return;
     }
 
@@ -99,7 +112,6 @@ export class AmbientCaptionBridge {
         lastShownAt: null,
         pendingImmediateReshow: false,
       } satisfies AmbientCaptionState);
-    const messageId = `ambient-${snapshot.id}`;
     const currentMessage = this.subtitles.getCurrent();
     const hasFocus = currentMessage?.id === messageId;
     const otherMessageActive =
@@ -127,6 +139,7 @@ export class AmbientCaptionBridge {
       const elapsed = currentTime - lastShownAt;
       const bypassCooldown = state.pendingImmediateReshow;
       if (bypassCooldown || elapsed >= this.cooldownMs) {
+        this.messageIds.add(messageId);
         this.subtitles.show({
           id: messageId,
           text: caption,

--- a/src/systems/audio/footstepController.ts
+++ b/src/systems/audio/footstepController.ts
@@ -6,6 +6,7 @@ export interface FootstepPlaybackOptions {
 
 export interface FootstepPlayer {
   play(options: FootstepPlaybackOptions): void;
+  stop?(): void;
 }
 
 export interface FootstepControllerOptions {
@@ -29,6 +30,8 @@ export interface FootstepControllerOptions {
   pitchJitter?: number;
   /** Optional deterministic random generator returning values in [0, 1). */
   random?: () => number;
+  /** Initial gate for global audio state. Defaults to enabled for backwards compatibility. */
+  initialEnabled?: boolean;
 }
 
 export interface FootstepControllerUpdate {
@@ -101,7 +104,7 @@ export function createFootstepAudioController(
     maxLinearSpeed - 1e-3
   );
 
-  let enabled = true;
+  let enabled = options.initialEnabled ?? true;
   let timeUntilNextStep = 0;
   let lastFoot: FootLabel = 'right';
   let lastNormalizedSpeed = 0;
@@ -241,11 +244,15 @@ export function createFootstepAudioController(
       );
     },
     setEnabled(nextEnabled) {
+      if (enabled === nextEnabled) {
+        return;
+      }
       enabled = nextEnabled;
       if (!enabled) {
         timeUntilNextStep = 0;
         lastNormalizedSpeed = 0;
         lastGrounded = true;
+        options.player.stop?.();
       }
     },
     isEnabled() {
@@ -255,6 +262,7 @@ export function createFootstepAudioController(
       enabled = false;
       timeUntilNextStep = 0;
       lastNormalizedSpeed = 0;
+      options.player.stop?.();
     },
   };
 }

--- a/src/tests/ambientAudioController.test.ts
+++ b/src/tests/ambientAudioController.test.ts
@@ -101,6 +101,27 @@ describe('AmbientAudioController', () => {
     expect(source.volumes.at(-1)).toBe(0);
   });
 
+  it('hard-disables playback by stopping sources and zeroing volumes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    expect(source.isPlaying).toBe(true);
+    expect(source.volumes.at(-1)).toBeGreaterThan(0);
+
+    controller.disable();
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0].currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0].targetVolume).toBe(0);
+
+    await controller.enable();
+    expect(source.isPlaying).toBe(true);
+  });
+
   it('stops playback when disposed', () => {
     const { bed, source } = createBed();
     const controller = new AmbientAudioController([bed], { smoothing: 0 });
@@ -108,6 +129,24 @@ describe('AmbientAudioController', () => {
     controller.dispose();
     expect(source.isPlaying).toBe(false);
     expect(source.volumes.at(-1)).toBe(0);
+  });
+
+  it('keeps disabled beds stopped when master volume changes', async () => {
+    const { bed, source } = createBed();
+    const controller = new AmbientAudioController([bed], { smoothing: 0 });
+
+    await controller.enable();
+    controller.update({ x: 0, z: 0 }, 0.1);
+    controller.disable();
+
+    controller.setMasterVolume(0.5);
+    controller.update({ x: 0, z: 0 }, 0.1);
+
+    expect(controller.isEnabled()).toBe(false);
+    expect(source.isPlaying).toBe(false);
+    expect(source.volumes.at(-1)).toBe(0);
+    expect(controller.getBedSnapshots()[0].currentVolume).toBe(0);
+    expect(controller.getBedSnapshots()[0].targetVolume).toBe(0);
   });
 
   it('applies master volume scaling and updates immediately', () => {

--- a/src/tests/ambientAudioPreference.test.ts
+++ b/src/tests/ambientAudioPreference.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   AmbientAudioPreference,
+  LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY,
   type AmbientAudioPreferenceChange,
 } from '../systems/audio/ambientAudioPreference';
 
@@ -54,6 +56,37 @@ describe('AmbientAudioPreference', () => {
     });
 
     expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('uses the v2 storage key by default and ignores legacy enabled consent', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.getStorageKey()).toBe(
+      AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY
+    );
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors explicit opt-in stored under the v2 key', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY, '1');
+
+    const preference = new AmbientAudioPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(true);
+  });
+
+  it('persists control disables to the v2 key even when already disabled by default', () => {
+    const storage = new MemoryStorage();
+    const preference = new AmbientAudioPreference({ storage });
+
+    preference.setEnabled(false, 'control');
+    preference.setEnabled(false, 'control');
+
+    expect(storage.getItem(AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY)).toBe('0');
   });
 
   it('loads a persisted enabled state from storage', () => {

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -268,6 +268,36 @@ describe('audio subtitles overlay', () => {
     handle.dispose();
   });
 
+  it('clears queued ambient captions by id without dropping active narration', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-narration',
+      text: 'Narration remains active while ambient is muted.',
+      source: 'poi',
+      priority: 4,
+      durationMs: 1000,
+    });
+
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Queued ambient bed should be removed.',
+      source: 'ambient',
+      priority: 1,
+      durationMs: 600,
+    });
+
+    handle.clear('ambient-hum');
+
+    expect(getCaptionText()).toBe(
+      'Narration remains active while ambient is muted.'
+    );
+    vi.advanceTimersByTime(1000);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
   it('clears the active and queued captions when clear is called without an id', () => {
     const handle = createAudioSubtitles();
     handle.show({

--- a/src/tests/footstepAudioController.test.ts
+++ b/src/tests/footstepAudioController.test.ts
@@ -9,8 +9,14 @@ import {
 class StubFootstepPlayer {
   public readonly calls: FootstepPlaybackOptions[] = [];
 
+  public stopCalls = 0;
+
   play(options: FootstepPlaybackOptions): void {
     this.calls.push(options);
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
   }
 }
 
@@ -81,6 +87,40 @@ describe('footstep audio controller', () => {
     controller.update({ delta: 0.2, linearSpeed: 4, isGrounded: false });
     controller.update({ delta: 0.4, linearSpeed: 4, isGrounded: true });
     expect(player.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('can start disabled and stops active playback when globally muted', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player, {
+      initialEnabled: false,
+      random: () => 0.5,
+    });
+
+    expect(controller.isEnabled()).toBe(false);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('left');
+    expect(player.calls).toHaveLength(0);
+
+    controller.setEnabled(true);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    expect(player.calls.length).toBeGreaterThan(0);
+
+    controller.setEnabled(false);
+    const callsAfterDisable = player.calls.length;
+    expect(player.stopCalls).toBe(1);
+    controller.update({ delta: 0.6, linearSpeed: 4 });
+    controller.notifyFootfall('right');
+    expect(player.calls).toHaveLength(callsAfterDisable);
+  });
+
+  it('does not stop playback again when disabled repeatedly', () => {
+    const player = new StubFootstepPlayer();
+    const controller = createController(player);
+
+    controller.setEnabled(false);
+    controller.setEnabled(false);
+
+    expect(player.stopCalls).toBe(1);
   });
 
   it('scales cadence, volume, and pitch with speed and master volume', () => {

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -197,7 +197,7 @@ describe('wireGitHubRepoMetrics', () => {
             value: 'Hidden',
             source: {
               type: 'githubStars',
-              owner: 'futuroptimist',
+              owner: 'democratizedspace',
               repo: 'dspace',
               visibility: 'private',
               fallback: 'Hidden',
@@ -241,7 +241,7 @@ describe('wireGitHubRepoMetrics', () => {
     );
     expect(definitions[2].metrics?.[0]?.value).toBe('86 stars');
     expect(
-      service.listenerCount({ owner: 'futuroptimist', repo: 'dspace' })
+      service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
     ).toBe(0);
 
     controller.dispose();

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -268,6 +268,32 @@ describe('i18n utilities', () => {
     }
   });
 
+  it('marks every localized DSPACE GitHub star metric as private and neutral', () => {
+    const numericFallbackPattern = /\d/;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const dspace = getPoiDefinitions(locale).find(
+        (poi) => poi.id === 'dspace-backyard-rocket'
+      );
+      const starMetric = dspace?.metrics?.find(
+        (metric) => metric.source?.type === 'githubStars'
+      );
+
+      expect(dspace, locale).toBeDefined();
+      expect(starMetric, locale).toBeDefined();
+      expect(starMetric?.source, locale).toMatchObject({
+        type: 'githubStars',
+        owner: 'democratizedspace',
+        repo: 'dspace',
+        visibility: 'private',
+      });
+      expect(starMetric?.value, locale).not.toMatch(numericFallbackPattern);
+      expect(starMetric?.source?.fallback ?? '', locale).not.toMatch(
+        numericFallbackPattern
+      );
+    }
+  });
+
   it('deep-clones localized POI metric sources per call', () => {
     const firstDefinitions = getPoiDefinitions('en-x-pseudo');
     const firstPoi = firstDefinitions.find(


### PR DESCRIPTION
### Motivation
- Introduce a single global audio control path that unifies Settings toggles, keyboard mute (M), and stored preference handling while surfacing an audio debug state to tests and devtools.
- Ensure ambient audio preference storage is migrated to a v2 key and that legacy consent does not incorrectly opt users in.
- Make audio subsystems behave deterministically when globally disabled (stop playback, clear captions, and gate footsteps) and mark a private POI GitHub metric as private in all locales.

### Description
- Added `AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY`/`LEGACY_AMBIENT_AUDIO_PREFERENCE_STORAGE_KEY` constants and switched the default storage key to v2 in `ambientAudioPreference.ts`, including migration/ignore behavior and a `getStorageKey()` accessor.
- Implemented a global audio control flow in `main.ts` with `setGlobalAudioEnabled`, `hardDisableRuntimeAudio`, `getAudioDebugState`, and exposed `window.portfolio.audio.getState` for debugging/tests; wired `audioHud` and preference binding to route through this flow.
- Made `AmbientAudioController.disable()` stop underlying sources and zero volumes, added snapshots to debug state, and added new unit tests for hard-disable and master-volume interactions in `ambientAudioController.test.ts`.
- Added footstep controller/player stop support and an `initialEnabled` gate so footsteps respect the global audio preference and actively stop playback when muted in `footstepController.ts` and tests in `footstepAudioController.test.ts`.
- Added `AmbientCaptionBridge.clear()` and tracking of ambient caption ids to ensure queued ambient captions can be cleared without disrupting active narration in `ambientCaptionBridge.ts` and `audioSubtitles.test.ts`.
- Updated localized POI definitions for the DSPACE POI to mark its GitHub star metric as `visibility: 'private'` and adjusted localized copy, plus added an i18n test asserting the DSPACE metric is private in every locale (`i18n.test.ts`).
- Exposed a typed audio debug shape in tests/playwright (`small-screen-hud.spec.ts`) and added an integration Playwright test that verifies Settings audio toggle and the `m` key mute route through the global mute/storage flow.

### Testing
- Ran unit tests for audio and preference modules with `vitest` including `ambientAudioController.test.ts`, `ambientAudioPreference.test.ts`, `footstepAudioController.test.ts`, `audioSubtitles.test.ts`, and i18n checks, and they passed locally.
- Ran the updated Playwright spec `playwright/small-screen-hud.spec.ts` which includes the desktop audio-mute integration scenario and it passed in the test environment.
- All modified and newly added automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22621addd0832f92fbf3b3bbe33523)