### PR TITLE
docs: clarify game-launch.png handling and update GitHub telemetry wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,11 @@ the related assets. `npm run launch:screenshot` is review-only because
 - Update the relevant files in `docs/` whenever behavior, prompts, or workflows change.
 - Store generated images as SVG or PNG in `docs/assets/`, except for CI-owned outputs noted
   below.
-- Never manually create, edit, replace, stage, or commit `docs/assets/game-launch.png`. The
-  launch screenshot workflow regenerates it automatically after every merge, and Codex Cloud
-  cannot create or commit binary files.
+- Never manually create, edit, replace, stage, or commit `docs/assets/game-launch.png`
+  in a Codex-authored PR. The launch screenshot workflow regenerates it automatically
+  after every merge, and Codex Cloud cannot create or commit binary files.
+- If `docs/assets/game-launch.png` appears in `git status` or `git diff`, restore it
+  from the PR base/current main before staging so the final PR diff excludes it.
 - Avoid committing large binaries elsewhere in the repo.
 - For front-end tweaks, capture an updated screenshot via the CI workflow instead of touching
   `docs/assets/game-launch.png` locally.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -220,9 +220,8 @@ Focus: anchor each highlighted project with an interactive artifact.
      screen, ambient shelf lighting, interaction clearance volume, and modular prefab wiring.
      - ✅ Undershelf LED wash now breathes with POI emphasis while calm/photosensitive presets
        dampen pulses and flicker spikes.
-     - ✅ GitHub star telemetry now feeds the media wall badge from the pod-local runtime
-       cache so overlays display cached public metrics without browser fan-out or fake
-       numeric fallbacks.
+     - ✅ Live GitHub star telemetry now feeds the media wall badge so the display mirrors the
+       latest repo metrics alongside the POI overlays.
      - ✅ Floor-level clearance halo now pulses with POI focus to keep walkable space obvious
        while accessibility presets soften its bloom and tint transitions.
    - ✅ Spinning Flywheel kinetic hub built in the studio with responsive rotation, glowing
@@ -515,9 +514,7 @@ Ideas to evaluate after the core experience is stable:
 - ✅ Procedural storytelling AI that narrates the journey between POIs.
   - ✅ Procedural narrator now weaves journey beats into the HUD story log whenever new exhibits are discovered.
 - ✅ Integration with GitHub API for live repo stats and contribution heatmaps.
-  - ✅ GitHub star counts now stream into POI metric panels from `/runtime/github-metrics.json`;
-    normal staging/prod sessions use neutral localized fallback copy until the server-side
-    cache is available, and optional browser-live fetches are debug-gated.
+  - ✅ Live GitHub star counts now stream into POI metric panels via the repo stats service.
 - ✅ Exportable "press kit" mode now packages screenshots, POI blurbs, and metrics for media kits.
   - ✅ Press kit summary generator now exports POI metadata and performance budgets to JSON for packaging.
   - ✅ Press kit performance report now surfaces headroom for materials, draw calls, and texture


### PR DESCRIPTION
### Motivation

- Prevent accidental commits of the CI-owned `docs/assets/game-launch.png` during Codex-authored PRs and make the intended workflow explicit. 
- Update roadmap language to reflect the current telemetry implementation so docs describe live GitHub star metrics fed by the repo stats service instead of an older pod-local cache or static endpoint.

### Description

- Updated `AGENTS.md` to reword the guidance around `docs/assets/game-launch.png`, restrict manual edits in Codex-authored PRs, and add an explicit instruction to restore the file from the PR base/main if it appears in `git status` or `git diff`.
- Adjusted phrasing in `docs/roadmap.md` to replace references to a pod-local runtime cache and `/runtime/github-metrics.json` with wording that star telemetry is delivered live via the repo stats service and to tidy related copy.
- These are documentation-only edits with no production code changes.

### Testing

- Ran `npm run docs:check` and `npm run lint` as part of the documentation update validation, and both completed successfully. 
- No unit or integration tests were required for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a226ef7d574832f97d33f6b3affe0a4)