### PR TITLE
Add Helm GitHub metrics cache sidecar

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -118,6 +118,9 @@ jobs:
             --set ingress.host=staging.danielsmith.io \
             --set image.tag=main-deadbee
 
+      - name: Run chart render assertions
+        run: npm run test:helm
+
       - name: Package Helm chart
         id: package
         shell: bash

--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: danielsmith
 description: Canonical Helm chart for deploying the danielsmith.io static web app.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: '0.1.0'

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -55,3 +55,11 @@ immutable `main-<shortsha>` tag or `image.digest`.
 {{- printf "%s:%s" .Values.image.repository (required "image.tag is required when image.digest is not set" .Values.image.tag) -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "danielsmith.githubMetricsImage" -}}
+{{- printf "%s:%s" .Values.githubMetricsCache.image.repository .Values.githubMetricsCache.image.tag -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsPublicMountPath" -}}
+{{- printf "/usr/share/nginx/html%s" (.Values.githubMetricsCache.publicPath | dir) -}}
+{{- end -}}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -60,6 +60,11 @@ spec:
               mountPath: /var/cache/nginx
             - name: var-run
               mountPath: /var/run
+            {{- if .Values.githubMetricsCache.enabled }}
+            - name: github-metrics-cache
+              mountPath: {{ include "danielsmith.githubMetricsPublicMountPath" . }}
+              readOnly: true
+            {{- end }}
           {{- if or (gt (len .Values.env) 0) (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if kindIs "map" .Values.env }}
@@ -81,6 +86,46 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics
+          image: {{ include "danielsmith.githubMetricsImage" . | quote }}
+          imagePullPolicy: {{ .Values.githubMetricsCache.image.pullPolicy }}
+          command:
+            - python
+            - /scripts/refresh-github-metrics.py
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: '1'
+            - name: PYTHONUNBUFFERED
+              value: '1'
+            - name: GITHUB_METRICS_OUTPUT_PATH
+              value: {{ .Values.githubMetricsCache.outputPath | quote }}
+            - name: GITHUB_METRICS_REPOS_PATH
+              value: /config/repos.json
+            - name: GITHUB_METRICS_REFRESH_INTERVAL_SECONDS
+              value: {{ .Values.githubMetricsCache.refreshIntervalSeconds | quote }}
+            - name: GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS
+              value: {{ .Values.githubMetricsCache.startupTimeoutSeconds | quote }}
+            - name: GITHUB_METRICS_CACHE_TTL_SECONDS
+              value: {{ .Values.githubMetricsCache.cacheTtlSeconds | quote }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.githubMetricsCache.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: github-metrics-cache
+              mountPath: {{ .Values.githubMetricsCache.outputPath | dir }}
+            - name: github-metrics-config
+              mountPath: /scripts/refresh-github-metrics.py
+              subPath: refresh-github-metrics.py
+              readOnly: true
+            - name: github-metrics-config
+              mountPath: /config/repos.json
+              subPath: repos.json
+              readOnly: true
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -88,6 +133,14 @@ spec:
           emptyDir: {}
         - name: var-run
           emptyDir: {}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics-cache
+          emptyDir: {}
+        - name: github-metrics-config
+          configMap:
+            name: {{ include "danielsmith.fullname" . }}-github-metrics
+            defaultMode: 0444
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
+++ b/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
@@ -1,0 +1,174 @@
+{{- if .Values.githubMetricsCache.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "danielsmith.fullname" . }}-github-metrics
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+data:
+  repos.json: |
+{{ .Values.githubMetricsCache.repos | toJson | nindent 4 }}
+  refresh-github-metrics.py: |
+    import json
+    import os
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+    from datetime import datetime, timezone, timedelta
+    from pathlib import Path
+
+    API_ROOT = "https://api.github.com/repos"
+    SCHEMA_VERSION = 1
+    OUTPUT_PATH = Path(os.environ["GITHUB_METRICS_OUTPUT_PATH"])
+    REPOS_PATH = Path(os.environ["GITHUB_METRICS_REPOS_PATH"])
+    REFRESH_INTERVAL_SECONDS = int(
+        os.environ.get("GITHUB_METRICS_REFRESH_INTERVAL_SECONDS", "3600")
+    )
+    STARTUP_TIMEOUT_SECONDS = int(
+        os.environ.get("GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS", "20")
+    )
+    CACHE_TTL_SECONDS = int(
+        os.environ.get("GITHUB_METRICS_CACHE_TTL_SECONDS", "4500")
+    )
+    USER_AGENT = "danielsmith.io-github-metrics-cache"
+
+
+    def iso_now():
+        return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+    def to_iso(value):
+        return value.isoformat().replace("+00:00", "Z")
+
+
+    def load_repos():
+        with REPOS_PATH.open("r", encoding="utf-8") as handle:
+            repos = json.load(handle)
+        if not isinstance(repos, list):
+            raise ValueError("repo config must be a list")
+        normalized = []
+        seen = set()
+        for item in repos:
+            owner = str(item.get("owner", "")).strip()
+            repo = str(item.get("repo", "")).strip()
+            key = f"{owner.lower()}/{repo.lower()}"
+            if not owner or not repo or key in seen:
+                continue
+            normalized.append({"owner": owner, "repo": repo})
+            seen.add(key)
+        return normalized
+
+
+    def fetch_repo(repo_config):
+        owner = repo_config["owner"]
+        repo = repo_config["repo"]
+        url = f"{API_ROOT}/{owner}/{repo}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": USER_AGENT,
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        fetched_at = iso_now()
+        with urllib.request.urlopen(
+            request, timeout=STARTUP_TIMEOUT_SECONDS
+        ) as response:
+            payload = json.load(response)
+        subscribers = int(payload.get("subscribers_count") or 0)
+        return {
+            "owner": owner,
+            "repo": repo,
+            "stars": int(payload.get("stargazers_count") or 0),
+            "watchers": int(subscribers or payload.get("watchers_count") or 0),
+            "subscribers": subscribers,
+            "forks": int(payload.get("forks_count") or 0),
+            "openIssues": int(payload.get("open_issues_count") or 0),
+            "pushedAt": payload.get("pushed_at"),
+            "fetchedAt": to_iso(fetched_at),
+            "htmlUrl": payload.get("html_url")
+            or f"https://github.com/{owner}/{repo}",
+        }
+
+
+    def build_neutral_payload(repos, errors):
+        generated_at = iso_now()
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "generatedAt": to_iso(generated_at),
+            "expiresAt": to_iso(
+                generated_at + timedelta(seconds=CACHE_TTL_SECONDS)
+            ),
+            "source": "static-neutral-placeholder",
+            "repos": {},
+            "errors": errors,
+        }
+
+
+    def write_payload(payload):
+        OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = OUTPUT_PATH.with_name(f".{OUTPUT_PATH.name}.tmp")
+        with temp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+        with temp_path.open("r", encoding="utf-8") as handle:
+            json.load(handle)
+        os.replace(temp_path, OUTPUT_PATH)
+
+
+    def refresh_once(repos):
+        generated_at = iso_now()
+        records = {}
+        errors = {}
+        for repo_config in repos:
+            key = f"{repo_config['owner'].lower()}/{repo_config['repo'].lower()}"
+            try:
+                records[key] = fetch_repo(repo_config)
+            except urllib.error.HTTPError as exc:
+                errors[key] = {"status": exc.code, "message": exc.reason}
+            except Exception as exc:
+                # Keep diagnostics concise and avoid printing URLs repeatedly.
+                errors[key] = {"status": "network", "message": exc.__class__.__name__}
+        if records:
+            payload = {
+                "schemaVersion": SCHEMA_VERSION,
+                "generatedAt": to_iso(generated_at),
+                "expiresAt": to_iso(
+                    generated_at + timedelta(seconds=CACHE_TTL_SECONDS)
+                ),
+                "source": "github-api",
+                "repos": records,
+                "errors": errors,
+            }
+            write_payload(payload)
+        elif not OUTPUT_PATH.exists():
+            write_payload(build_neutral_payload(repos, errors))
+        next_refresh = iso_now() + timedelta(seconds=REFRESH_INTERVAL_SECONDS)
+        print(
+            "github-metrics refresh complete "
+            f"ok={len(records)} failed={len(errors)} next={to_iso(next_refresh)}",
+            flush=True,
+        )
+
+
+    def main():
+        repos = load_repos()
+        while True:
+            refresh_once(repos)
+            time.sleep(max(REFRESH_INTERVAL_SECONDS, 60))
+
+
+    if __name__ == "__main__":
+        try:
+            main()
+        except Exception as exc:
+            # Fail fast for invalid chart configuration.
+            print(
+                f"github-metrics sidecar failed: {exc.__class__.__name__}",
+                file=sys.stderr,
+                flush=True,
+            )
+            raise
+{{- end }}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -77,6 +77,48 @@ ingress:
     enabled: false
     secretName: ''
 
+githubMetricsCache:
+  enabled: false
+  image:
+    repository: python
+    tag: '3.12-alpine'
+    pullPolicy: IfNotPresent
+  refreshIntervalSeconds: 3600
+  startupTimeoutSeconds: 20
+  cacheTtlSeconds: 4500
+  outputPath: /cache/github-metrics.json
+  publicPath: /runtime/github-metrics.json
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: pr-reaper
+  resources:
+    requests:
+      cpu: 5m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -34,6 +34,12 @@ server {
         return 404;
     }
 
+    location ^~ /runtime/ {
+        add_header Cache-Control "no-store" always;
+        default_type application/json;
+        try_files $uri =404;
+    }
+
     location ~* ^/assets/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         try_files $uri =404;

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -15,6 +15,8 @@ components.
 - Helm chart reference: `oci://ghcr.io/futuroptimist/charts/danielsmith`
 - Helm chart version: immutable; bump `charts/danielsmith/Chart.yaml` when chart content changes
 - Runtime: nginx static-site container listening on port `8080`
+- Optional runtime GitHub metrics cache: unauthenticated sidecar writing
+  `/runtime/github-metrics.json` for public repo stars/forks/watchers
 - Health endpoints: `/livez` and `/healthz`
 
 Cloudflare DNS, tunnel, and route setup are separate from Helm deployment. Confirm those routes
@@ -111,6 +113,18 @@ curl -fsS https://staging.danielsmith.io/healthz
 curl -fsS https://staging.danielsmith.io/
 ```
 
+If the Sugarkube environment enables `githubMetricsCache.enabled`, also verify the sidecar-backed
+public metrics cache. It uses unauthenticated GitHub REST requests only; do not add a PAT, GitHub App
+credential, Kubernetes Secret, or client-visible token for this cache.
+
+```bash
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
+```
+
+The JSON should include `schemaVersion`, `generatedAt`, `expiresAt`, `source`, `repos`, and
+`errors`. If GitHub is temporarily unavailable during pod startup, the sidecar may serve a valid
+neutral placeholder instead of blocking nginx readiness forever.
+
 If these fail, first check the Sugarkube release status and ingress/Cloudflare routing separately.
 Do not rebuild images locally as a release workaround; pick a known-good immutable GitHub Actions
 tag and redeploy it.
@@ -155,6 +169,12 @@ just helm-oci-upgrade \
 curl -fsS https://danielsmith.io/livez
 curl -fsS https://danielsmith.io/healthz
 curl -fsS https://danielsmith.io/
+```
+
+When production values enable `githubMetricsCache.enabled`, verify the public runtime cache too:
+
+```bash
+curl -fsS https://danielsmith.io/runtime/github-metrics.json
 ```
 
 ## Rollback

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
-    "links:check": "node scripts/check-links.cjs"
+    "links:check": "node scripts/check-links.cjs",
+    "test:helm": "node scripts/test-helm-chart.cjs"
   },
   "dependencies": {
     "three": "^0.161.0"

--- a/scripts/test-helm-chart.cjs
+++ b/scripts/test-helm-chart.cjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+
+const helmTemplate = (args = []) =>
+  execFileSync(
+    'helm',
+    ['template', 'danielsmith', 'charts/danielsmith', ...args],
+    {
+      encoding: 'utf8',
+    }
+  );
+
+const disabled = helmTemplate();
+assert(
+  !disabled.includes('name: github-metrics'),
+  'default render must not include sidecar'
+);
+assert(
+  !disabled.includes('refresh-github-metrics.py'),
+  'default render must not include metrics ConfigMap script'
+);
+assert(
+  !disabled.includes('github-metrics-cache'),
+  'default render must not include shared metrics volume'
+);
+
+const enabled = helmTemplate(['--set', 'githubMetricsCache.enabled=true']);
+assert(
+  enabled.includes('kind: ConfigMap'),
+  'enabled render includes a ConfigMap'
+);
+assert(
+  enabled.includes('name: github-metrics'),
+  'enabled render includes sidecar'
+);
+assert(
+  enabled.includes('refresh-github-metrics.py'),
+  'enabled render includes refresh script'
+);
+assert(
+  enabled.includes('emptyDir: {}') &&
+    enabled.includes('name: github-metrics-cache'),
+  'enabled render includes shared emptyDir cache volume'
+);
+assert(
+  enabled.includes('mountPath: /usr/share/nginx/html/runtime') &&
+    enabled.includes('readOnly: true'),
+  'enabled render mounts runtime directory read-only into nginx container'
+);
+assert(
+  enabled.includes('mountPath: /cache') &&
+    enabled.includes('GITHUB_METRICS_OUTPUT_PATH'),
+  'enabled render mounts writable cache directory into sidecar'
+);
+assert(
+  !/kind:\s*Secret\b/.test(enabled),
+  'enabled render must not create Secrets'
+);
+assert(
+  !/secretKeyRef|secretName|\/var\/run\/secrets/.test(enabled),
+  'enabled render has no secret refs'
+);
+assert(
+  !/GITHUB_TOKEN|PERSONAL_ACCESS_TOKEN|PAT\b/i.test(enabled),
+  'enabled render has no GitHub auth env'
+);
+for (const repo of [
+  'futuroptimist/danielsmith.io',
+  'futuroptimist/token.place',
+  'futuroptimist/gabriel',
+  'futuroptimist/flywheel',
+  'futuroptimist/jobbot3000',
+  'futuroptimist/gitshelves',
+  'futuroptimist/f2clipboard',
+  'futuroptimist/sigma',
+  'futuroptimist/wove',
+  'democratizedspace/dspace',
+  'futuroptimist/pr-reaper',
+]) {
+  const [owner, name] = repo.split('/');
+  assert(
+    enabled.includes(`{"owner":"${owner}","repo":"${name}"}`),
+    `enabled render includes ${repo} in repo config`
+  );
+}
+
+console.log('Helm chart metrics-cache render checks passed.');


### PR DESCRIPTION
### Motivation
- Prevent the frontend from surfacing unauthenticated/fallback GitHub star numbers by providing an opt-in pod-local runtime cache that nginx can serve at `/runtime/github-metrics.json`.
- Keep the cache unauthenticated and secret-free so deploys do not introduce tokens or Secrets, and make the behaviour opt-in via Helm values.
- Provide a small, auditable refresher (ConfigMap-mounted script) that writes JSON atomically and serves a neutral placeholder if GitHub is unavailable on startup.

### Description
- Add `githubMetricsCache` values to `charts/danielsmith/values.yaml` (disabled by default) including image, intervals, TTL, output/public paths, repo list, and tiny resources, and bump chart version to `0.2.0` in `charts/danielsmith/Chart.yaml`.
- Add a ConfigMap template `charts/danielsmith/templates/github-metrics-cache-configmap.yaml` containing `repos.json` and `refresh-github-metrics.py`, which fetches unauthenticated GitHub repo REST data, composes the schema-compatible payload, validates JSON, writes atomically, preserves last-good file if the full refresh fails, and emits concise diagnostics.
- Wire a sidecar container and shared `emptyDir` into `charts/danielsmith/templates/deployment.yaml` with read-only mount into the nginx/static container at the runtime public path and writable mount into the sidecar at the cache path, using helper templates in `_helpers.tpl` for image/mount resolution.
- Update `docker/nginx/default.conf` to serve `^~ /runtime/` with `Cache-Control: no-store` so the static nginx image can expose `/runtime/github-metrics.json` from the shared mount.
- Add `scripts/test-helm-chart.cjs` and a `test:helm` NPM script to assert both disabled and enabled Helm rendering (no Secrets, ConfigMap/script presence, mounts, repo list), and call that assertion from the Helm CI job (`.github/workflows/ci-helm.yml`).
- Document the optional runtime cache and verification curl in `docs/ops/sugarkube-release.md` and add minimal formatting/Prettier updates.

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed.
- `helm lint charts/danielsmith` — passed.
- `helm template danielsmith charts/danielsmith` (default) — rendered without sidecar.
- `helm template danielsmith charts/danielsmith --set githubMetricsCache.enabled=true` — rendered sidecar, `ConfigMap`, mounts and repo list; `scripts/test-helm-chart.cjs` assertions passed (`npm run test:helm`).
- `python -m py_compile /tmp/refresh-github-metrics.py` (extracted from rendered ConfigMap) — passed (script is valid Python).
- `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts` — passed (targeted tests passed).
- `npm run test:ci` (full Vitest suite) — passed (all tests passed in CI run observed).
- `npm run build` and `npm run smoke` — passed (dist build and smoke checks succeeded).
- `npm run typecheck` — not fully green: this change did not introduce TypeScript failures, but `tsc --noEmit` failed on preexisting TypeScript errors unrelated to the Helm/nginx changes; see `src/main.ts` first error in the transcript.

Notes: the runtime cache is opt-in and disabled by default so `helm template`/`helm lint` remain safe for local rendering; no Secrets or GitHub auth tokens were added. Follow-up work: enable `githubMetricsCache.enabled=true` in Sugarkube staging/prod values and monitor sidecar logs for refresh summaries (ok/failed/next).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22762d1954832fa4d1d312432d0e2c)