### PR TITLE
Add optional Helm sidecar to cache unauthenticated GitHub metrics

### DIFF
--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: danielsmith
 description: Canonical Helm chart for deploying the danielsmith.io static web app.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: '0.1.0'

--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: danielsmith
 description: Canonical Helm chart for deploying the danielsmith.io static web app.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: '0.1.0'

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -81,11 +81,19 @@ immutable `main-<shortsha>` tag or `image.digest`.
 {{- if eq $publicDir "/" -}}
 {{- fail "githubMetricsCache.publicPath must include a non-root directory" -}}
 {{- end -}}
-{{- if not (hasPrefix "/runtime/" $publicPath) -}}
-{{- fail "githubMetricsCache.publicPath must live under /runtime/ so nginx serves it with runtime cache headers" -}}
-{{- end -}}
 {{- if ne (base $outputPath) (base $publicPath) -}}
 {{- fail "githubMetricsCache.outputPath and githubMetricsCache.publicPath must use the same file name" -}}
+{{- end -}}
+{{- if ne $publicPath "/runtime/github-metrics.json" -}}
+{{- fail "githubMetricsCache.publicPath must be exactly /runtime/github-metrics.json" -}}
+{{- end -}}
+{{- if eq (len .Values.githubMetricsCache.repos) 0 -}}
+{{- fail "githubMetricsCache.repos must include at least one repository" -}}
+{{- end -}}
+{{- range $index, $repo := .Values.githubMetricsCache.repos -}}
+{{- if or (not $repo.owner) (not $repo.repo) -}}
+{{- fail (printf "githubMetricsCache.repos[%d] must include non-empty owner and repo" $index) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -59,14 +59,43 @@ immutable `main-<shortsha>` tag or `image.digest`.
 {{/* Validate GitHub metrics cache values that must line up across mounts. */}}
 {{- define "danielsmith.githubMetricsCache.validate" -}}
 {{- if .Values.githubMetricsCache.enabled -}}
-{{- if ne (base .Values.githubMetricsCache.outputPath) (base .Values.githubMetricsCache.publicPath) -}}
+{{- $outputPath := toString .Values.githubMetricsCache.outputPath -}}
+{{- $publicPath := toString .Values.githubMetricsCache.publicPath -}}
+{{- $outputDir := dir $outputPath -}}
+{{- $publicDir := dir $publicPath -}}
+{{- if not (hasPrefix "/" $outputPath) -}}
+{{- fail "githubMetricsCache.outputPath must be an absolute path" -}}
+{{- end -}}
+{{- if not (hasPrefix "/" $publicPath) -}}
+{{- fail "githubMetricsCache.publicPath must be an absolute path" -}}
+{{- end -}}
+{{- if ne (clean $outputPath) $outputPath -}}
+{{- fail "githubMetricsCache.outputPath must be normalized and must not contain dot segments" -}}
+{{- end -}}
+{{- if ne (clean $publicPath) $publicPath -}}
+{{- fail "githubMetricsCache.publicPath must be normalized and must not contain dot segments" -}}
+{{- end -}}
+{{- if eq $outputDir "/" -}}
+{{- fail "githubMetricsCache.outputPath must include a non-root directory" -}}
+{{- end -}}
+{{- if eq $publicDir "/" -}}
+{{- fail "githubMetricsCache.publicPath must include a non-root directory" -}}
+{{- end -}}
+{{- if not (hasPrefix "/runtime/" $publicPath) -}}
+{{- fail "githubMetricsCache.publicPath must live under /runtime/ so nginx serves it with runtime cache headers" -}}
+{{- end -}}
+{{- if ne (base $outputPath) (base $publicPath) -}}
 {{- fail "githubMetricsCache.outputPath and githubMetricsCache.publicPath must use the same file name" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "danielsmith.githubMetricsCache.image" -}}
-{{- printf "%s:%s" .Values.githubMetricsCache.image.repository .Values.githubMetricsCache.image.tag -}}
+{{- if .Values.githubMetricsCache.image.digest -}}
+{{- printf "%s@%s" .Values.githubMetricsCache.image.repository .Values.githubMetricsCache.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.githubMetricsCache.image.repository (required "githubMetricsCache.image.tag is required when githubMetricsCache.image.digest is not set" .Values.githubMetricsCache.image.tag) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "danielsmith.githubMetricsCache.outputDir" -}}

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -55,3 +55,24 @@ immutable `main-<shortsha>` tag or `image.digest`.
 {{- printf "%s:%s" .Values.image.repository (required "image.tag is required when image.digest is not set" .Values.image.tag) -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Validate GitHub metrics cache values that must line up across mounts. */}}
+{{- define "danielsmith.githubMetricsCache.validate" -}}
+{{- if .Values.githubMetricsCache.enabled -}}
+{{- if ne (base .Values.githubMetricsCache.outputPath) (base .Values.githubMetricsCache.publicPath) -}}
+{{- fail "githubMetricsCache.outputPath and githubMetricsCache.publicPath must use the same file name" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsCache.image" -}}
+{{- printf "%s:%s" .Values.githubMetricsCache.image.repository .Values.githubMetricsCache.image.tag -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsCache.outputDir" -}}
+{{- dir .Values.githubMetricsCache.outputPath -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsCache.publicDir" -}}
+{{- printf "/usr/share/nginx/html/%s" (dir (trimPrefix "/" .Values.githubMetricsCache.publicPath)) | clean -}}
+{{- end -}}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "danielsmith.githubMetricsCache.validate" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -60,6 +61,11 @@ spec:
               mountPath: /var/cache/nginx
             - name: var-run
               mountPath: /var/run
+            {{- if .Values.githubMetricsCache.enabled }}
+            - name: github-metrics-cache
+              mountPath: {{ include "danielsmith.githubMetricsCache.publicDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if or (gt (len .Values.env) 0) (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if kindIs "map" .Values.env }}
@@ -81,6 +87,37 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics
+          image: {{ include "danielsmith.githubMetricsCache.image" . | quote }}
+          imagePullPolicy: {{ .Values.githubMetricsCache.image.pullPolicy }}
+          command:
+            - python
+            - /etc/github-metrics/refresh-github-metrics.py
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+            - name: GITHUB_METRICS_REPOS_PATH
+              value: /etc/github-metrics/repos.json
+            - name: GITHUB_METRICS_OUTPUT_PATH
+              value: {{ .Values.githubMetricsCache.outputPath | quote }}
+            - name: GITHUB_METRICS_REFRESH_INTERVAL_SECONDS
+              value: {{ .Values.githubMetricsCache.refreshIntervalSeconds | quote }}
+            - name: GITHUB_METRICS_REQUEST_TIMEOUT_SECONDS
+              value: {{ .Values.githubMetricsCache.startupTimeoutSeconds | quote }}
+            - name: GITHUB_METRICS_CACHE_TTL_SECONDS
+              value: {{ .Values.githubMetricsCache.cacheTtlSeconds | quote }}
+          securityContext:
+            {{- toYaml .Values.githubMetricsCache.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.githubMetricsCache.resources | nindent 12 }}
+          volumeMounts:
+            - name: github-metrics-config
+              mountPath: /etc/github-metrics
+              readOnly: true
+            - name: github-metrics-cache
+              mountPath: {{ include "danielsmith.githubMetricsCache.outputDir" . }}
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -88,6 +125,14 @@ spec:
           emptyDir: {}
         - name: var-run
           emptyDir: {}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics-cache
+          emptyDir: {}
+        - name: github-metrics-config
+          configMap:
+            name: {{ include "danielsmith.fullname" . }}-github-metrics-cache
+            defaultMode: 0555
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -104,6 +104,8 @@ spec:
             - name: GITHUB_METRICS_REFRESH_INTERVAL_SECONDS
               value: {{ .Values.githubMetricsCache.refreshIntervalSeconds | quote }}
             - name: GITHUB_METRICS_REQUEST_TIMEOUT_SECONDS
+              value: {{ .Values.githubMetricsCache.requestTimeoutSeconds | quote }}
+            - name: GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS
               value: {{ .Values.githubMetricsCache.startupTimeoutSeconds | quote }}
             - name: GITHUB_METRICS_CACHE_TTL_SECONDS
               value: {{ .Values.githubMetricsCache.cacheTtlSeconds | quote }}

--- a/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
+++ b/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
@@ -1,0 +1,222 @@
+{{- if .Values.githubMetricsCache.enabled -}}
+{{- include "danielsmith.githubMetricsCache.validate" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "danielsmith.fullname" . }}-github-metrics-cache
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+data:
+  repos.json: |
+{{ toPrettyJson .Values.githubMetricsCache.repos | indent 4 }}
+  refresh-github-metrics.py: |
+    #!/usr/bin/env python3
+    """Refresh unauthenticated public GitHub repository metrics into JSON."""
+
+    import datetime as dt
+    import json
+    import os
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+
+
+    API_ROOT = "https://api.github.com/repos"
+    SOURCE = "github-api"
+    USER_AGENT = "danielsmith.io-github-metrics-cache"
+
+
+    def utc_now():
+        return dt.datetime.now(dt.timezone.utc)
+
+
+    def isoformat(timestamp):
+        return timestamp.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+    def read_int_env(name, default):
+        value = os.environ.get(name, "")
+        try:
+            parsed = int(value)
+        except ValueError:
+            return default
+        return parsed if parsed > 0 else default
+
+
+    def load_repos(path):
+        with open(path, "r", encoding="utf-8") as handle:
+            repos = json.load(handle)
+        if not isinstance(repos, list):
+            raise ValueError("repos config must be a list")
+        normalized = []
+        for item in repos:
+            if not isinstance(item, dict):
+                continue
+            owner = str(item.get("owner", "")).strip()
+            repo = str(item.get("repo", "")).strip()
+            if owner and repo:
+                normalized.append({"owner": owner, "repo": repo})
+        return normalized
+
+
+    def fetch_repo(owner, repo, timeout):
+        url = f"{API_ROOT}/{owner}/{repo}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": USER_AGENT,
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+
+    def error_record(owner, repo, fetched_at, exc):
+        status = getattr(exc, "code", "network")
+        reason = getattr(exc, "reason", None) or str(exc)
+        return {
+            "owner": owner,
+            "repo": repo,
+            "status": status,
+            "message": str(reason)[:240],
+            "fetchedAt": fetched_at,
+        }
+
+
+    def repo_record(owner, repo, fetched_at, data):
+        return {
+            "owner": owner,
+            "repo": repo,
+            "stars": data.get("stargazers_count", 0) or 0,
+            "watchers": data.get("subscribers_count", data.get("watchers_count", 0)) or 0,
+            "forks": data.get("forks_count", 0) or 0,
+            "openIssues": data.get("open_issues_count", 0) or 0,
+            "pushedAt": data.get("pushed_at"),
+            "fetchedAt": fetched_at,
+            "htmlUrl": data.get("html_url"),
+        }
+
+
+    def manual_error_record(owner, repo, fetched_at, status, message):
+        return {
+            "owner": owner,
+            "repo": repo,
+            "status": status,
+            "message": message[:240],
+            "fetchedAt": fetched_at,
+        }
+
+
+    def build_payload(repos, timeout, cache_ttl, deadline=None):
+        generated_at = utc_now()
+        fetched_at = isoformat(generated_at)
+        payload = {
+            "schemaVersion": 1,
+            "generatedAt": fetched_at,
+            "expiresAt": isoformat(generated_at + dt.timedelta(seconds=cache_ttl)),
+            "source": SOURCE,
+            "repos": {},
+            "errors": {},
+        }
+        ok_count = 0
+        failed_count = 0
+        for item in repos:
+            owner = item["owner"]
+            repo = item["repo"]
+            key = f"{owner.lower()}/{repo.lower()}"
+            remaining_timeout = timeout
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    payload["errors"][key] = manual_error_record(
+                        owner, repo, fetched_at, "startup-timeout", "startup timeout elapsed"
+                    )
+                    failed_count += 1
+                    continue
+                remaining_timeout = max(min(timeout, remaining), 1)
+            try:
+                data = fetch_repo(owner, repo, remaining_timeout)
+                payload["repos"][key] = repo_record(owner, repo, fetched_at, data)
+                ok_count += 1
+            except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as exc:
+                payload["errors"][key] = error_record(owner, repo, fetched_at, exc)
+                failed_count += 1
+        return payload, ok_count, failed_count
+
+
+    def atomic_write_json(path, payload):
+        directory = os.path.dirname(path)
+        os.makedirs(directory, exist_ok=True)
+        temp_path = f"{path}.tmp.{os.getpid()}"
+        with open(temp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        with open(temp_path, "r", encoding="utf-8") as handle:
+            json.load(handle)
+        os.replace(temp_path, path)
+
+
+    def write_neutral_if_missing(path, errors, cache_ttl):
+        if os.path.exists(path):
+            return False
+        generated_at = utc_now()
+        payload = {
+            "schemaVersion": 1,
+            "generatedAt": isoformat(generated_at),
+            "expiresAt": isoformat(generated_at + dt.timedelta(seconds=cache_ttl)),
+            "source": "github-api-unavailable",
+            "repos": {},
+            "errors": errors,
+        }
+        atomic_write_json(path, payload)
+        return True
+
+
+    def log(message):
+        print(f"[github-metrics] {message}", flush=True)
+
+
+    def main():
+        repos_path = os.environ.get("GITHUB_METRICS_REPOS_PATH", "/etc/github-metrics/repos.json")
+        output_path = os.environ.get("GITHUB_METRICS_OUTPUT_PATH", "/cache/github-metrics.json")
+        refresh_interval = read_int_env("GITHUB_METRICS_REFRESH_INTERVAL_SECONDS", 3600)
+        request_timeout = read_int_env("GITHUB_METRICS_REQUEST_TIMEOUT_SECONDS", 20)
+        cache_ttl = read_int_env("GITHUB_METRICS_CACHE_TTL_SECONDS", 4500)
+        repos = load_repos(repos_path)
+        log(f"loaded {len(repos)} public repo targets; writing {output_path}")
+        first_refresh = True
+        while True:
+            started = time.monotonic()
+            deadline = started + request_timeout if first_refresh else None
+            try:
+                payload, ok_count, failed_count = build_payload(
+                    repos, request_timeout, cache_ttl, deadline
+                )
+                if ok_count > 0 or failed_count == 0:
+                    atomic_write_json(output_path, payload)
+                    log(f"refresh complete ok={ok_count} failed={failed_count}; next={refresh_interval}s")
+                else:
+                    wrote_neutral = write_neutral_if_missing(
+                        output_path, payload.get("errors", {}), cache_ttl
+                    )
+                    action = "wrote neutral cache" if wrote_neutral else "kept existing cache"
+                    log(f"refresh failed for all repos; {action}; next={refresh_interval}s")
+            except Exception as exc:
+                wrote_neutral = write_neutral_if_missing(output_path, {}, cache_ttl)
+                action = "wrote neutral cache" if wrote_neutral else "kept existing cache"
+                log(f"refresh error {type(exc).__name__}: {exc}; {action}; next={refresh_interval}s")
+            first_refresh = False
+            elapsed = time.monotonic() - started
+            time.sleep(max(refresh_interval - elapsed, 1))
+
+
+    if __name__ == "__main__":
+        try:
+            main()
+        except KeyboardInterrupt:
+            sys.exit(0)
+
+{{- end }}

--- a/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
+++ b/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
@@ -136,7 +136,7 @@ data:
                     )
                     failed_count += 1
                     continue
-                remaining_timeout = max(min(timeout, remaining), 1)
+                remaining_timeout = min(timeout, remaining)
             try:
                 data = fetch_repo(owner, repo, remaining_timeout)
                 payload["repos"][key] = repo_record(owner, repo, fetched_at, data)
@@ -183,14 +183,15 @@ data:
         repos_path = os.environ.get("GITHUB_METRICS_REPOS_PATH", "/etc/github-metrics/repos.json")
         output_path = os.environ.get("GITHUB_METRICS_OUTPUT_PATH", "/cache/github-metrics.json")
         refresh_interval = read_int_env("GITHUB_METRICS_REFRESH_INTERVAL_SECONDS", 3600)
-        request_timeout = read_int_env("GITHUB_METRICS_REQUEST_TIMEOUT_SECONDS", 20)
+        request_timeout = read_int_env("GITHUB_METRICS_REQUEST_TIMEOUT_SECONDS", 5)
+        startup_timeout = read_int_env("GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS", 20)
         cache_ttl = read_int_env("GITHUB_METRICS_CACHE_TTL_SECONDS", 4500)
         repos = load_repos(repos_path)
         log(f"loaded {len(repos)} public repo targets; writing {output_path}")
         first_refresh = True
         while True:
             started = time.monotonic()
-            deadline = started + request_timeout if first_refresh else None
+            deadline = started + startup_timeout if first_refresh else None
             try:
                 payload, ok_count, failed_count = build_payload(
                     repos, request_timeout, cache_ttl, deadline

--- a/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
+++ b/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
@@ -91,6 +91,7 @@ data:
             "owner": owner,
             "repo": repo,
             "stars": data.get("stargazers_count", 0) or 0,
+            "subscribers": data.get("subscribers_count", 0) or 0,
             "watchers": data.get("subscribers_count", data.get("watchers_count", 0)) or 0,
             "forks": data.get("forks_count", 0) or 0,
             "openIssues": data.get("open_issues_count", 0) or 0,

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -53,8 +53,10 @@ githubMetricsCache:
   image:
     repository: python
     tag: '3.12-alpine'
+    digest: ''
     pullPolicy: IfNotPresent
   refreshIntervalSeconds: 3600
+  requestTimeoutSeconds: 5
   startupTimeoutSeconds: 20
   cacheTtlSeconds: 4500
   outputPath: /cache/github-metrics.json

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -48,6 +48,57 @@ resources:
     cpu: 250m
     memory: 256Mi
 
+githubMetricsCache:
+  enabled: false
+  image:
+    repository: python
+    tag: '3.12-alpine'
+    pullPolicy: IfNotPresent
+  refreshIntervalSeconds: 3600
+  startupTimeoutSeconds: 20
+  cacheTtlSeconds: 4500
+  outputPath: /cache/github-metrics.json
+  publicPath: /runtime/github-metrics.json
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: pr-reaper
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
 probes:
   liveness:
     path: /livez

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -26,6 +26,11 @@ server {
         try_files $uri =404;
     }
 
+    location ~* ^/runtime/.*\.json$ {
+        add_header Cache-Control "no-store" always;
+        try_files $uri =404;
+    }
+
     location ~* ^/assets/.*\.map$ {
         return 404;
     }

--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -91,8 +91,9 @@ layer without guessing where functionality lives.
   [`src/scene/poi/tooltipOverlay.ts`](../../src/scene/poi/tooltipOverlay.ts), while
   [`src/scene/poi/githubMetrics.ts`](../../src/scene/poi/githubMetrics.ts)
   wires GitHub star counts into both the in-world tooltip and HUD overlay. Deployed pods serve
-  a sidecar-refreshed `/runtime/github-metrics.json` file, and the static frontend treats that
-  cache as the normal source of truth. The cache has a modest grace window beyond `expiresAt`
+  a sidecar-refreshed `/runtime/github-metrics.json` file with no-store cache headers, and the
+  static frontend treats that cache as the normal source of truth. The cache has a modest grace
+  window beyond `expiresAt`
   so an hourly refresh that lands slightly late does not flicker metrics back to neutral copy;
   long-lived sessions retry the runtime file after that cache window instead of pinning the
   first successful response forever; failed refreshes clear expired runtime metrics and notify open

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -16,9 +16,36 @@ components.
 - Helm chart version: immutable; bump `charts/danielsmith/Chart.yaml` when chart content changes
 - Runtime: nginx static-site container listening on port `8080`
 - Health endpoints: `/livez` and `/healthz`
+- Optional runtime GitHub metrics cache: `/runtime/github-metrics.json` served by nginx
 
 Cloudflare DNS, tunnel, and route setup are separate from Helm deployment. Confirm those routes
 outside this app repo before expecting the public hostnames to resolve.
+
+## Runtime GitHub metrics cache
+
+The chart includes an optional `githubMetricsCache` sidecar for Sugarkube environments that should
+serve project star/fork metadata without requiring each browser to call GitHub directly. It is off
+by default so local `helm template` and existing releases keep rendering exactly one app container
+unless environment values opt in.
+
+When enabled, the sidecar uses the public GitHub REST API without a token, GitHub App credential,
+or Kubernetes Secret. On startup and then every `githubMetricsCache.refreshIntervalSeconds`
+(default `3600`), it fetches the configured public repositories, writes an atomic JSON cache to a
+shared `emptyDir`, and nginx serves that file at `githubMetricsCache.publicPath` (default
+`/runtime/github-metrics.json`). If GitHub is unavailable during startup, the sidecar writes a valid
+neutral JSON document when no prior cache exists so nginx readiness is not held hostage by GitHub.
+
+After enabling the sidecar in Sugarkube staging or production values, verify the public cache shape
+without adding secrets:
+
+```bash
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
+curl -fsS https://danielsmith.io/runtime/github-metrics.json
+```
+
+The response should include `schemaVersion`, `generatedAt`, `expiresAt`, `source`, `repos`, and
+`errors`. A populated `repos` object indicates successful unauthenticated GitHub refreshes; an empty
+`repos` object with `errors` is a safe neutral state to investigate without rotating credentials.
 
 ## 1. Pick the immutable image tag
 

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -32,8 +32,12 @@ When enabled, the sidecar uses the public GitHub REST API without a token, GitHu
 or Kubernetes Secret. On startup and then every `githubMetricsCache.refreshIntervalSeconds`
 (default `3600`), it fetches the configured public repositories, writes an atomic JSON cache to a
 shared `emptyDir`, and nginx serves that file at `githubMetricsCache.publicPath` (default
-`/runtime/github-metrics.json`). If GitHub is unavailable during startup, the sidecar writes a valid
-neutral JSON document when no prior cache exists so nginx readiness is not held hostage by GitHub.
+`/runtime/github-metrics.json`) with `Cache-Control: no-store`. Runtime public paths must be
+absolute, normalized, under `/runtime/`, and inside a non-root directory so the shared cache volume
+cannot hide the nginx document root. `githubMetricsCache.requestTimeoutSeconds` caps each GitHub
+request, while `githubMetricsCache.startupTimeoutSeconds` caps only the first whole refresh before a
+neutral cache is written. If GitHub is unavailable during startup, the sidecar writes a valid neutral
+JSON document when no prior cache exists so nginx readiness is not held hostage by GitHub.
 
 After enabling the sidecar in Sugarkube staging or production values, verify the public cache shape
 without adding secrets:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
-    "links:check": "node scripts/check-links.cjs"
+    "links:check": "node scripts/check-links.cjs",
+    "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
     "three": "^0.161.0"

--- a/scripts/check-helm-github-metrics-cache.cjs
+++ b/scripts/check-helm-github-metrics-cache.cjs
@@ -82,18 +82,16 @@ assertIncludes(
 );
 assertIncludes(
   enabledRender,
-  'mountPath: /usr/share/nginx/html/runtime',
-  'nginx should mount the runtime cache directory instead of the document root'
+  `- name: github-metrics-cache
+              mountPath: /usr/share/nginx/html/runtime
+              readOnly: true`,
+  'nginx should mount the runtime cache directory read-only instead of the document root'
 );
 assertIncludes(
   enabledRender,
-  'readOnly: true',
-  'nginx/config mounts should be read-only'
-);
-assertIncludes(
-  enabledRender,
-  'mountPath: /cache',
-  'sidecar should mount the writable cache directory'
+  `- name: github-metrics-cache
+              mountPath: /cache`,
+  'sidecar should mount the cache directory writable by omitting readOnly'
 );
 assertIncludes(
   enabledRender,
@@ -117,6 +115,11 @@ assertIncludes(
 );
 assertIncludes(
   enabledRender,
+  '"subscribers": data.get("subscribers_count", 0) or 0',
+  'rendered script should expose subscribers_count as subscribers'
+);
+assertIncludes(
+  enabledRender,
   '"repo": "token.place"',
   'repo list should render into the sidecar config'
 );
@@ -124,6 +127,11 @@ assertIncludes(
   enabledRender,
   '"owner": "democratizedspace"',
   'repo list should preserve non-default owners'
+);
+assertIncludes(
+  enabledRender,
+  '"repo": "dspace"',
+  'repo list should preserve the democratizedspace/dspace repo'
 );
 assertExcludes(
   enabledRender,
@@ -215,10 +223,42 @@ assertRenderFails(
     '--set',
     'githubMetricsCache.enabled=true',
     '--set',
-    'githubMetricsCache.publicPath=/metrics/github-metrics.json',
+    'githubMetricsCache.publicPath=/runtime/github-stars.json',
   ],
-  'githubMetricsCache.publicPath must live under /runtime/',
-  'public paths outside /runtime should be rejected so nginx runtime headers apply'
+  'githubMetricsCache.outputPath and githubMetricsCache.publicPath must use the same file name',
+  'mismatched output/public basenames should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.outputPath=/cache/github-stars.json',
+  ],
+  'githubMetricsCache.outputPath and githubMetricsCache.publicPath must use the same file name',
+  'mismatched output/public basenames should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.publicPath=/runtime/github-stars.json',
+    '--set',
+    'githubMetricsCache.outputPath=/cache/github-stars.json',
+  ],
+  'githubMetricsCache.publicPath must be exactly /runtime/github-metrics.json',
+  'public paths outside the wired frontend runtime URL should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set-json',
+    'githubMetricsCache.repos=[]',
+  ],
+  'githubMetricsCache.repos must include at least one repository',
+  'empty repo lists should be rejected'
 );
 assertRenderFails(
   [

--- a/scripts/check-helm-github-metrics-cache.cjs
+++ b/scripts/check-helm-github-metrics-cache.cjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+const { execFileSync } = require('node:child_process');
+
+const chartPath = 'charts/danielsmith';
+
+const render = (args = []) =>
+  execFileSync('helm', ['template', 'danielsmith', chartPath, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+const assertIncludes = (haystack, needle, message) => {
+  if (!haystack.includes(needle)) {
+    throw new Error(
+      `${message}: expected rendered chart to include ${JSON.stringify(needle)}`
+    );
+  }
+};
+
+const assertExcludes = (haystack, needle, message) => {
+  if (haystack.includes(needle)) {
+    throw new Error(
+      `${message}: rendered chart unexpectedly included ${JSON.stringify(needle)}`
+    );
+  }
+};
+
+const defaultRender = render();
+assertExcludes(
+  defaultRender,
+  'name: github-metrics',
+  'disabled cache should not render sidecar'
+);
+assertExcludes(
+  defaultRender,
+  'danielsmith-github-metrics-cache',
+  'disabled cache should not render ConfigMap'
+);
+assertExcludes(
+  defaultRender,
+  'github-metrics-cache',
+  'disabled cache should not render shared cache volume'
+);
+
+const enabledRender = render(['--set', 'githubMetricsCache.enabled=true']);
+assertIncludes(
+  enabledRender,
+  'kind: ConfigMap',
+  'enabled cache should render script ConfigMap'
+);
+assertIncludes(
+  enabledRender,
+  'name: github-metrics',
+  'enabled cache should render sidecar'
+);
+assertIncludes(
+  enabledRender,
+  'image: "python:3.12-alpine"',
+  'sidecar should use configured image'
+);
+assertIncludes(
+  enabledRender,
+  'emptyDir: {}',
+  'enabled cache should render an emptyDir volume'
+);
+assertIncludes(
+  enabledRender,
+  'mountPath: /usr/share/nginx/html/runtime',
+  'nginx should mount the runtime cache directory'
+);
+assertIncludes(
+  enabledRender,
+  'readOnly: true',
+  'nginx/config mounts should be read-only'
+);
+assertIncludes(
+  enabledRender,
+  'mountPath: /cache',
+  'sidecar should mount the writable cache directory'
+);
+assertIncludes(
+  enabledRender,
+  '"repo": "token.place"',
+  'repo list should render into the sidecar config'
+);
+assertIncludes(
+  enabledRender,
+  '"owner": "democratizedspace"',
+  'repo list should preserve non-default owners'
+);
+assertExcludes(
+  enabledRender,
+  'kind: Secret',
+  'cache sidecar must not introduce Kubernetes Secrets'
+);
+assertExcludes(
+  enabledRender,
+  'secretKeyRef',
+  'cache sidecar must not use secret env vars'
+);
+assertExcludes(
+  enabledRender,
+  'GITHUB_TOKEN',
+  'cache sidecar must remain unauthenticated'
+);
+assertExcludes(
+  enabledRender,
+  'PERSONAL_ACCESS_TOKEN',
+  'cache sidecar must not reference PATs'
+);
+
+console.log('Helm GitHub metrics cache render assertions passed.');

--- a/scripts/check-helm-github-metrics-cache.cjs
+++ b/scripts/check-helm-github-metrics-cache.cjs
@@ -25,6 +25,23 @@ const assertExcludes = (haystack, needle, message) => {
   }
 };
 
+const assertRenderFails = (args, needle, message) => {
+  try {
+    render(args);
+  } catch (error) {
+    const output = `${error.stdout ?? ''}${error.stderr ?? ''}${error.message ?? ''}`;
+    if (!output.includes(needle)) {
+      throw new Error(
+        `${message}: expected failure to include ${JSON.stringify(needle)}, got ${JSON.stringify(
+          output
+        )}`
+      );
+    }
+    return;
+  }
+  throw new Error(`${message}: expected helm template to fail`);
+};
+
 const defaultRender = render();
 assertExcludes(
   defaultRender,
@@ -66,7 +83,7 @@ assertIncludes(
 assertIncludes(
   enabledRender,
   'mountPath: /usr/share/nginx/html/runtime',
-  'nginx should mount the runtime cache directory'
+  'nginx should mount the runtime cache directory instead of the document root'
 );
 assertIncludes(
   enabledRender,
@@ -77,6 +94,26 @@ assertIncludes(
   enabledRender,
   'mountPath: /cache',
   'sidecar should mount the writable cache directory'
+);
+assertIncludes(
+  enabledRender,
+  'value: "5"',
+  'sidecar should use the separate per-request timeout default'
+);
+assertIncludes(
+  enabledRender,
+  'GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS',
+  'sidecar should render a separate startup deadline env var'
+);
+assertIncludes(
+  enabledRender,
+  'value: "20"',
+  'sidecar should preserve the startup timeout default'
+);
+assertIncludes(
+  enabledRender,
+  'remaining_timeout = min(timeout, remaining)',
+  'startup refresh should use the actual remaining deadline budget'
 );
 assertIncludes(
   enabledRender,
@@ -107,6 +144,91 @@ assertExcludes(
   enabledRender,
   'PERSONAL_ACCESS_TOKEN',
   'cache sidecar must not reference PATs'
+);
+
+const digestRender = render([
+  '--set',
+  'githubMetricsCache.enabled=true',
+  '--set',
+  'githubMetricsCache.image.digest=sha256:abc123',
+  '--set',
+  'githubMetricsCache.image.tag=',
+]);
+assertIncludes(
+  digestRender,
+  'image: "python@sha256:abc123"',
+  'sidecar should support digest-pinned images'
+);
+
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.outputPath=cache/foo.json',
+  ],
+  'githubMetricsCache.outputPath must be an absolute path',
+  'relative output paths should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.publicPath=runtime/github-metrics.json',
+  ],
+  'githubMetricsCache.publicPath must be an absolute path',
+  'relative public paths should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.publicPath=/github-metrics.json',
+  ],
+  'githubMetricsCache.publicPath must include a non-root directory',
+  'root-level public paths should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.publicPath=/runtime/../github-metrics.json',
+  ],
+  'githubMetricsCache.publicPath must be normalized and must not contain dot segments',
+  'public paths with dot segments should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.outputPath=/cache/../github-metrics.json',
+  ],
+  'githubMetricsCache.outputPath must be normalized and must not contain dot segments',
+  'output paths with dot segments should be rejected'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.publicPath=/metrics/github-metrics.json',
+  ],
+  'githubMetricsCache.publicPath must live under /runtime/',
+  'public paths outside /runtime should be rejected so nginx runtime headers apply'
+);
+assertRenderFails(
+  [
+    '--set',
+    'githubMetricsCache.enabled=true',
+    '--set',
+    'githubMetricsCache.image.tag=',
+  ],
+  'githubMetricsCache.image.tag is required when githubMetricsCache.image.digest is not set',
+  'empty sidecar tags without a digest should be rejected'
 );
 
 console.log('Helm GitHub metrics cache render assertions passed.');


### PR DESCRIPTION
### Motivation
- Serve public GitHub repo metadata from a pod-local runtime cache so browsers do not display unauthenticated fallback facts as truths.
- Provide an opt-in Helm-sidecar implementation that requires no secrets and is safe for local `helm template`/lint workflows by defaulting to disabled.

### Description
- Add `githubMetricsCache` values to `charts/danielsmith/values.yaml` (image, intervals, TTLs, `outputPath`/`publicPath`, repo list, tiny resources, and securityContext) and bump the chart version.
- Add Helm helpers in `charts/danielsmith/templates/_helpers.tpl` to validate cache filenames and derive image/mount directories, update `charts/danielsmith/templates/deployment.yaml` to render a read-only nginx mount, a writable `emptyDir` cache, and the `github-metrics` sidecar when enabled.
- Introduce `charts/danielsmith/templates/github-metrics-cache-configmap.yaml` with a readable Python refresher script and `repos.json` payload; the script fetches unauthenticated GitHub repo REST data on startup and periodically, builds the schema (`schemaVersion`, `generatedAt`, `expiresAt`, `source`, `repos`, `errors`), writes JSON atomically, and emits a neutral JSON when needed.
- Add a render-time assertion script `scripts/check-helm-github-metrics-cache.cjs` and `npm` script `helm:cache:test`, and document the optional runtime cache and verification steps in `docs/ops/sugarkube-release.md`.

### Testing
- `npm run format:write` — succeeded.
- `npm run lint` — succeeded.
- `npm run typecheck` (`tsc --noEmit`) — failed due to existing unrelated TypeScript errors in the repo (reported and not caused by these chart/template changes).
- `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts` — succeeded (both test files passed).
- `helm lint charts/danielsmith` — succeeded.
- `helm template danielsmith charts/danielsmith` and `helm template danielsmith charts/danielsmith --set githubMetricsCache.enabled=true` — both rendered successfully and produced the expected enabled/disabled manifests.
- `npm run helm:cache:test` (render assertions) — succeeded.
- `python -m py_compile /tmp/refresh-github-metrics.py` (extracted script) — succeeded.
- `npm run build` and `npm run smoke` — succeeded.
- `npm run docs:check` (includes link checks) — succeeded; link checker produced external fetch warnings but completed.
- Repository secret scan (`./scripts/scan-secrets.py` on staged diff) — no high-risk secrets detected.

Notes/risks: sidecar is opt-in and uses unauthenticated GitHub calls (rate-limits apply); ensure Sugarkube/staging values enable it only where appropriate and monitor refresh logs for 403/429 patterns. If you want, I can follow up to wire staging/prod values and add Helm tests for values files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22762d1954832fa4d1d312432d0e2c)