### PR TITLE
Add Helm GitHub metrics cache sidecar

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -118,6 +118,9 @@ jobs:
             --set ingress.host=staging.danielsmith.io \
             --set image.tag=main-deadbee
 
+      - name: Template GitHub metrics cache sidecar
+        run: npm run helm:github-metrics-cache:check
+
       - name: Package Helm chart
         id: package
         shell: bash

--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: danielsmith
 description: Canonical Helm chart for deploying the danielsmith.io static web app.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: '0.1.0'

--- a/charts/danielsmith/templates/_helpers.tpl
+++ b/charts/danielsmith/templates/_helpers.tpl
@@ -55,3 +55,23 @@ immutable `main-<shortsha>` tag or `image.digest`.
 {{- printf "%s:%s" .Values.image.repository (required "image.tag is required when image.digest is not set" .Values.image.tag) -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "danielsmith.githubMetricsCacheConfigMapName" -}}
+{{- printf "%s-github-metrics-cache" (include "danielsmith.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsCacheImage" -}}
+{{- printf "%s:%s" .Values.githubMetricsCache.image.repository .Values.githubMetricsCache.image.tag -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsCacheOutputDir" -}}
+{{- dir .Values.githubMetricsCache.outputPath -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsCachePublicDir" -}}
+{{- dir .Values.githubMetricsCache.publicPath -}}
+{{- end -}}
+
+{{- define "danielsmith.githubMetricsCacheNginxMountPath" -}}
+{{- printf "/usr/share/nginx/html%s" (include "danielsmith.githubMetricsCachePublicDir" .) -}}
+{{- end -}}

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -60,6 +60,11 @@ spec:
               mountPath: /var/cache/nginx
             - name: var-run
               mountPath: /var/run
+            {{- if .Values.githubMetricsCache.enabled }}
+            - name: github-metrics-cache
+              mountPath: {{ include "danielsmith.githubMetricsCacheNginxMountPath" . }}
+              readOnly: true
+            {{- end }}
           {{- if or (gt (len .Values.env) 0) (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if kindIs "map" .Values.env }}
@@ -81,6 +86,46 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics
+          image: {{ include "danielsmith.githubMetricsCacheImage" . | quote }}
+          imagePullPolicy: {{ .Values.githubMetricsCache.image.pullPolicy }}
+          command:
+            - python
+            - /scripts/github-metrics-cache.py
+          securityContext:
+            {{- toYaml .Values.githubMetricsCache.securityContext | nindent 12 }}
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: TMPDIR
+              value: {{ include "danielsmith.githubMetricsCacheOutputDir" . | quote }}
+            - name: GITHUB_METRICS_OUTPUT_PATH
+              value: {{ .Values.githubMetricsCache.outputPath | quote }}
+            - name: GITHUB_METRICS_REPOS_PATH
+              value: /config/repos.json
+            - name: GITHUB_METRICS_REFRESH_INTERVAL_SECONDS
+              value: {{ .Values.githubMetricsCache.refreshIntervalSeconds | quote }}
+            - name: GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS
+              value: {{ .Values.githubMetricsCache.startupTimeoutSeconds | quote }}
+            - name: GITHUB_METRICS_CACHE_TTL_SECONDS
+              value: {{ .Values.githubMetricsCache.cacheTtlSeconds | quote }}
+          resources:
+            {{- toYaml .Values.githubMetricsCache.resources | nindent 12 }}
+          volumeMounts:
+            - name: github-metrics-cache
+              mountPath: {{ include "danielsmith.githubMetricsCacheOutputDir" . }}
+            - name: github-metrics-cache-config
+              mountPath: /scripts/github-metrics-cache.py
+              subPath: github-metrics-cache.py
+              readOnly: true
+            - name: github-metrics-cache-config
+              mountPath: /config/repos.json
+              subPath: repos.json
+              readOnly: true
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -88,6 +133,14 @@ spec:
           emptyDir: {}
         - name: var-run
           emptyDir: {}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics-cache
+          emptyDir: {}
+        - name: github-metrics-cache-config
+          configMap:
+            name: {{ include "danielsmith.githubMetricsCacheConfigMapName" . }}
+            defaultMode: 0555
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
+++ b/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
@@ -1,0 +1,196 @@
+{{- if .Values.githubMetricsCache.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "danielsmith.githubMetricsCacheConfigMapName" . }}
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+data:
+  repos.json: |
+{{ .Values.githubMetricsCache.repos | toJson | nindent 4 }}
+  github-metrics-cache.py: |
+    #!/usr/bin/env python3
+    import json
+    import os
+    import time
+    import urllib.error
+    import urllib.request
+    from datetime import datetime, timezone, timedelta
+    from pathlib import Path
+
+    API_ROOT = "https://api.github.com/repos"
+    USER_AGENT = "danielsmith.io-github-metrics-cache"
+
+
+    def utc_now():
+        return datetime.now(timezone.utc)
+
+
+    def isoformat(value):
+        return value.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+    def positive_int_from_env(name, default):
+        try:
+            value = int(os.environ.get(name, str(default)))
+        except ValueError:
+            return default
+        return value if value > 0 else default
+
+
+    def load_repos(path):
+        with open(path, "r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+        repos = []
+        for entry in loaded:
+            owner = str(entry.get("owner", "")).strip()
+            repo = str(entry.get("repo", "")).strip()
+            if owner and repo:
+                repos.append({"owner": owner, "repo": repo})
+        return repos
+
+
+    def fetch_repo(owner, repo, timeout):
+        url = f"{API_ROOT}/{owner}/{repo}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+
+    def number(value):
+        return value if isinstance(value, (int, float)) else 0
+
+
+    def build_placeholder(repos, errors, source="static-neutral-placeholder"):
+        generated_at = utc_now()
+        expires_at = generated_at + timedelta(seconds=cache_ttl_seconds)
+        return {
+            "schemaVersion": 1,
+            "generatedAt": isoformat(generated_at),
+            "expiresAt": isoformat(expires_at),
+            "source": source,
+            "repos": {},
+            "errors": errors,
+            "configuredRepos": repos,
+        }
+
+
+    def write_json_atomic(path, payload):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f".{path.name}.tmp")
+        encoded = json.dumps(payload, indent=2, sort_keys=True)
+        json.loads(encoded)
+        with open(temp_path, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+
+
+    def refresh_once(repos, output_path, startup_timeout):
+        generated_at = utc_now()
+        expires_at = generated_at + timedelta(seconds=cache_ttl_seconds)
+        records = {}
+        errors = []
+        for entry in repos:
+            owner = entry["owner"]
+            repo = entry["repo"]
+            key = f"{owner}/{repo}".lower()
+            fetched_at = utc_now()
+            try:
+                data = fetch_repo(owner, repo, startup_timeout)
+                records[key] = {
+                    "owner": owner,
+                    "repo": repo,
+                    "stars": number(data.get("stargazers_count")),
+                    "watchers": number(
+                        data.get("subscribers_count", data.get("watchers_count", 0))
+                    ),
+                    "subscribers": number(
+                        data.get("subscribers_count", data.get("watchers_count", 0))
+                    ),
+                    "forks": number(data.get("forks_count")),
+                    "openIssues": number(data.get("open_issues_count")),
+                    "pushedAt": (
+                        data.get("pushed_at")
+                        if isinstance(data.get("pushed_at"), str)
+                        else None
+                    ),
+                    "fetchedAt": isoformat(fetched_at),
+                    "htmlUrl": (
+                        data.get("html_url")
+                        if isinstance(data.get("html_url"), str)
+                        else f"https://github.com/{owner}/{repo}"
+                    ),
+                }
+            except urllib.error.HTTPError as error:
+                errors.append({"owner": owner, "repo": repo, "status": error.code})
+            except Exception as error:
+                errors.append(
+                    {
+                        "owner": owner,
+                        "repo": repo,
+                        "status": "network",
+                        "message": type(error).__name__,
+                    }
+                )
+        if records:
+            payload = {
+                "schemaVersion": 1,
+                "generatedAt": isoformat(generated_at),
+                "expiresAt": isoformat(expires_at),
+                "source": "github-rest-unauthenticated",
+                "repos": records,
+                "errors": errors,
+            }
+            write_json_atomic(output_path, payload)
+        elif not output_path.exists():
+            write_json_atomic(output_path, build_placeholder(repos, errors))
+        return len(records), len(errors)
+
+
+    output_path = Path(
+        os.environ.get("GITHUB_METRICS_OUTPUT_PATH", "/cache/github-metrics.json")
+    )
+    repos_path = Path(os.environ.get("GITHUB_METRICS_REPOS_PATH", "/config/repos.json"))
+    refresh_interval_seconds = positive_int_from_env(
+        "GITHUB_METRICS_REFRESH_INTERVAL_SECONDS",
+        3600,
+    )
+    startup_timeout_seconds = positive_int_from_env(
+        "GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS",
+        20,
+    )
+    cache_ttl_seconds = positive_int_from_env("GITHUB_METRICS_CACHE_TTL_SECONDS", 4500)
+
+    try:
+        configured_repos = load_repos(repos_path)
+    except Exception as error:
+        print(
+            "github-metrics-cache: failed to load repo config: "
+            f"{type(error).__name__}",
+            flush=True,
+        )
+        configured_repos = []
+
+    while True:
+        ok_count, failed_count = refresh_once(
+            configured_repos,
+            output_path,
+            startup_timeout_seconds,
+        )
+        print(
+            "github-metrics-cache: refresh complete "
+            f"ok={ok_count} failed={failed_count} "
+            f"next_refresh_seconds={refresh_interval_seconds}",
+            flush=True,
+        )
+        time.sleep(refresh_interval_seconds)
+{{- end }}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -48,6 +48,57 @@ resources:
     cpu: 250m
     memory: 256Mi
 
+githubMetricsCache:
+  enabled: false
+  image:
+    repository: python
+    tag: '3.12-alpine'
+    pullPolicy: IfNotPresent
+  refreshIntervalSeconds: 3600
+  startupTimeoutSeconds: 20
+  cacheTtlSeconds: 4500
+  outputPath: /cache/github-metrics.json
+  publicPath: /runtime/github-metrics.json
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: pr-reaper
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
 probes:
   liveness:
     path: /livez

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -16,6 +16,8 @@ components.
 - Helm chart version: immutable; bump `charts/danielsmith/Chart.yaml` when chart content changes
 - Runtime: nginx static-site container listening on port `8080`
 - Health endpoints: `/livez` and `/healthz`
+- Optional runtime GitHub metrics cache: `/runtime/github-metrics.json`, refreshed by an
+  unauthenticated Helm sidecar when `githubMetricsCache.enabled=true`
 
 Cloudflare DNS, tunnel, and route setup are separate from Helm deployment. Confirm those routes
 outside this app repo before expecting the public hostnames to resolve.
@@ -111,6 +113,16 @@ curl -fsS https://staging.danielsmith.io/healthz
 curl -fsS https://staging.danielsmith.io/
 ```
 
+If Sugarkube values enable `githubMetricsCache.enabled=true`, also confirm the sidecar-served
+runtime cache is available and schema-compatible:
+
+```bash
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
+```
+
+The cache sidecar uses unauthenticated public GitHub REST requests only. Do not add a PAT, GitHub
+App credential, Kubernetes Secret, or client-visible token for this metrics path.
+
 If these fail, first check the Sugarkube release status and ingress/Cloudflare routing separately.
 Do not rebuild images locally as a release workaround; pick a known-good immutable GitHub Actions
 tag and redeploy it.
@@ -155,6 +167,13 @@ just helm-oci-upgrade \
 curl -fsS https://danielsmith.io/livez
 curl -fsS https://danielsmith.io/healthz
 curl -fsS https://danielsmith.io/
+```
+
+When production values enable the runtime GitHub metrics cache, verify it without supplying any
+GitHub credential:
+
+```bash
+curl -fsS https://danielsmith.io/runtime/github-metrics.json
 ```
 
 ## Rollback

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
-    "links:check": "node scripts/check-links.cjs"
+    "links:check": "node scripts/check-links.cjs",
+    "helm:github-metrics-cache:check": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
     "three": "^0.161.0"

--- a/scripts/check-helm-github-metrics-cache.cjs
+++ b/scripts/check-helm-github-metrics-cache.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+const { execFileSync } = require('node:child_process');
+
+const chart = 'charts/danielsmith';
+
+const helmTemplate = (args = []) =>
+  execFileSync('helm', ['template', 'danielsmith', chart, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+const assertIncludes = (text, needle, label) => {
+  if (!text.includes(needle)) {
+    throw new Error(`${label} missing ${JSON.stringify(needle)}`);
+  }
+};
+
+const assertExcludes = (text, needle, label) => {
+  if (text.includes(needle)) {
+    throw new Error(`${label} unexpectedly included ${JSON.stringify(needle)}`);
+  }
+};
+
+const disabled = helmTemplate();
+assertExcludes(disabled, 'name: github-metrics', 'disabled render');
+assertExcludes(disabled, 'github-metrics-cache.py', 'disabled render');
+assertExcludes(disabled, 'github-metrics-cache', 'disabled render');
+
+const enabled = helmTemplate([
+  '--set',
+  'githubMetricsCache.enabled=true',
+  '--set-json',
+  'githubMetricsCache.repos=[{"owner":"safe-owner","repo":"repo.with-dots"}]',
+]);
+
+assertIncludes(enabled, 'kind: ConfigMap', 'enabled render');
+assertIncludes(enabled, 'github-metrics-cache.py', 'enabled render');
+assertIncludes(enabled, 'repos.json:', 'enabled render');
+assertIncludes(enabled, 'safe-owner', 'enabled render');
+assertIncludes(enabled, 'repo.with-dots', 'enabled render');
+assertIncludes(enabled, 'name: github-metrics', 'enabled render');
+assertIncludes(enabled, 'image: "python:3.12-alpine"', 'enabled render');
+assertIncludes(
+  enabled,
+  'mountPath: /usr/share/nginx/html/runtime',
+  'enabled render'
+);
+assertIncludes(enabled, 'mountPath: /cache', 'enabled render');
+assertIncludes(enabled, 'readOnly: true', 'enabled render');
+assertIncludes(enabled, 'emptyDir: {}', 'enabled render');
+assertIncludes(
+  enabled,
+  'GITHUB_METRICS_REFRESH_INTERVAL_SECONDS',
+  'enabled render'
+);
+assertIncludes(enabled, 'value: "3600"', 'enabled render');
+assertExcludes(enabled, 'kind: Secret', 'enabled render');
+assertExcludes(enabled, 'secretKeyRef', 'enabled render');
+assertExcludes(enabled, 'envFrom:', 'enabled render');
+assertExcludes(enabled, 'mountPath: /var/run/secrets', 'enabled render');
+
+console.log('Helm GitHub metrics cache rendering checks passed.');


### PR DESCRIPTION
### Motivation
- Provide a pod-local, unauthenticated GitHub metrics cache so the static runtime can serve `/runtime/github-metrics.json` and avoid browser-side unauthenticated API fan-out and spurious fallback values.
- Keep the feature opt-in and secret-free so existing installs are unchanged by default and Sugarkube values can enable it in staging/prod.

### Description
- Add `githubMetricsCache` Helm values with image, interval, TTL, output/public paths, repo list, tiny resources, and a locked-down securityContext in `charts/danielsmith/values.yaml`.
- Add a ConfigMap template `charts/danielsmith/templates/github-metrics-cache-configmap.yaml` that embeds a small, auditable Python refresher script plus a `repos.json` payload rendered from chart values; the script fetches public repo metadata unauthenticated, emits the frontend-compatible schema, writes atomically, and writes a neutral placeholder when needed.
- Wire the sidecar into `charts/danielsmith/templates/deployment.yaml` behind `githubMetricsCache.enabled`, mounting a shared `emptyDir` for the cache and mounting the cache read-only into the nginx static root so the app serves `/runtime/github-metrics.json` without secrets.
- Add helper template functions in `_helpers.tpl`, bump the chart `version` to `0.1.1`, add a Node-based helm render check `scripts/check-helm-github-metrics-cache.cjs`, and run that check from the `ci-helm` workflow; update `docs/ops/sugarkube-release.md` with verification steps and no-secret guidance.

### Testing
- Ran formatting and linting: `npm run format:write` (passed) and `npm run lint` (passed).
- Ran unit/integration tests: `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts` (passed) and full `npm run test:ci` (all tests passed: 1014 tests across 137 files passed).
- Chart rendering and Helm checks: `npm run helm:github-metrics-cache:check` (passed), `helm lint charts/danielsmith` (passed), `helm template ... --set githubMetricsCache.enabled=true` (rendered expected ConfigMap, container, mounts and no Secret references).
- Validated sidecar script: extracted and compiled the embedded Python with `python3 -m py_compile` (passed) and exercised it in a short run producing the neutral placeholder JSON (passed).
- Build and docs: `npm run build` (passed), `npm run docs:check` (passed; link checker reported external fetch warnings but completed), and `npm run smoke` (passed).
- Typecheck: `npm run typecheck` failed due to pre-existing TypeScript errors unrelated to these Helm/chart-only changes; this is recorded and left unmodified.

If you'd like, I can split follow-ups (example: move the Python refresher to a separate small image, extend the repo list via values files under `docs/examples/`, or add an in-cluster readiness probe for the cache file) — otherwise this PR is minimal, audit-friendly, and safe-by-default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22762d1954832fa4d1d312432d0e2c)