### PR TITLE
Add optional Helm sidecar to publish pod-local GitHub metrics cache

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -118,6 +118,9 @@ jobs:
             --set ingress.host=staging.danielsmith.io \
             --set image.tag=main-deadbee
 
+      - name: GitHub metrics cache template assertions
+        run: node scripts/check-helm-github-metrics-cache.cjs
+
       - name: Package Helm chart
         id: package
         shell: bash

--- a/charts/danielsmith/Chart.yaml
+++ b/charts/danielsmith/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: danielsmith
 description: Canonical Helm chart for deploying the danielsmith.io static web app.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: '0.1.0'

--- a/charts/danielsmith/templates/deployment.yaml
+++ b/charts/danielsmith/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $githubMetricsPublicDir := printf "/usr/share/nginx/html%s" (dir .Values.githubMetricsCache.publicPath) -}}
+{{- $githubMetricsImage := printf "%s:%s" .Values.githubMetricsCache.image.repository .Values.githubMetricsCache.image.tag -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -60,6 +62,11 @@ spec:
               mountPath: /var/cache/nginx
             - name: var-run
               mountPath: /var/run
+            {{- if .Values.githubMetricsCache.enabled }}
+            - name: github-metrics-cache
+              mountPath: {{ $githubMetricsPublicDir | quote }}
+              readOnly: true
+            {{- end }}
           {{- if or (gt (len .Values.env) 0) (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if kindIs "map" .Values.env }}
@@ -81,6 +88,47 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics
+          image: {{ $githubMetricsImage | quote }}
+          imagePullPolicy: {{ .Values.githubMetricsCache.image.pullPolicy }}
+          command:
+            - python
+            - /scripts/refresh-github-metrics.py
+          env:
+            - name: GITHUB_METRICS_REPOS_PATH
+              value: /config/repos.json
+            - name: GITHUB_METRICS_OUTPUT_PATH
+              value: {{ .Values.githubMetricsCache.outputPath | quote }}
+            - name: GITHUB_METRICS_REFRESH_INTERVAL_SECONDS
+              value: {{ .Values.githubMetricsCache.refreshIntervalSeconds | quote }}
+            - name: GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS
+              value: {{ .Values.githubMetricsCache.startupTimeoutSeconds | quote }}
+            - name: GITHUB_METRICS_CACHE_TTL_SECONDS
+              value: {{ .Values.githubMetricsCache.cacheTtlSeconds | quote }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.githubMetricsCache.resources | nindent 12 }}
+          volumeMounts:
+            - name: github-metrics-cache-config
+              mountPath: /scripts/refresh-github-metrics.py
+              subPath: refresh-github-metrics.py
+              readOnly: true
+            - name: github-metrics-cache-config
+              mountPath: /config/repos.json
+              subPath: repos.json
+              readOnly: true
+            - name: github-metrics-cache
+              mountPath: {{ dir .Values.githubMetricsCache.outputPath | quote }}
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -88,6 +136,14 @@ spec:
           emptyDir: {}
         - name: var-run
           emptyDir: {}
+        {{- if .Values.githubMetricsCache.enabled }}
+        - name: github-metrics-cache
+          emptyDir: {}
+        - name: github-metrics-cache-config
+          configMap:
+            name: {{ include "danielsmith.fullname" . }}-github-metrics-cache
+            defaultMode: 0555
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
+++ b/charts/danielsmith/templates/github-metrics-cache-configmap.yaml
@@ -1,0 +1,205 @@
+{{- if .Values.githubMetricsCache.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "danielsmith.fullname" . }}-github-metrics-cache
+  labels:
+    {{- include "danielsmith.labels" . | nindent 4 }}
+data:
+  repos.json: |
+{{ .Values.githubMetricsCache.repos | toPrettyJson | nindent 4 }}
+  refresh-github-metrics.py: |
+    #!/usr/bin/env python3
+    import json
+    import os
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+    from datetime import datetime, timezone, timedelta
+    from pathlib import Path
+
+    SCHEMA_VERSION = 1
+    SOURCE = "github-rest-unauthenticated"
+    USER_AGENT = "danielsmith.io-github-metrics-cache"
+
+
+    def env_int(name, default):
+        raw = os.environ.get(name, "")
+        try:
+            value = int(raw)
+        except ValueError:
+            return default
+        return value if value > 0 else default
+
+
+    REPOS_PATH = Path(
+        os.environ.get("GITHUB_METRICS_REPOS_PATH", "/config/repos.json")
+    )
+    OUTPUT_PATH = Path(
+        os.environ.get("GITHUB_METRICS_OUTPUT_PATH", "/cache/github-metrics.json")
+    )
+    REFRESH_INTERVAL_SECONDS = env_int(
+        "GITHUB_METRICS_REFRESH_INTERVAL_SECONDS",
+        3600,
+    )
+    STARTUP_TIMEOUT_SECONDS = env_int(
+        "GITHUB_METRICS_STARTUP_TIMEOUT_SECONDS",
+        20,
+    )
+    CACHE_TTL_SECONDS = env_int("GITHUB_METRICS_CACHE_TTL_SECONDS", 4500)
+    REQUEST_TIMEOUT_SECONDS = min(max(STARTUP_TIMEOUT_SECONDS, 1), 30)
+
+
+    def request_timeout_seconds(repo_count):
+        repo_count = max(repo_count, 1)
+        per_repo_timeout = STARTUP_TIMEOUT_SECONDS / repo_count
+        return min(max(per_repo_timeout, 1), 10)
+
+
+    def iso_now():
+        return datetime.now(timezone.utc)
+
+
+    def to_iso(value):
+        return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+    def load_repos():
+        with REPOS_PATH.open("r", encoding="utf-8") as handle:
+            repos = json.load(handle)
+        if not isinstance(repos, list):
+            raise ValueError("repos config must be a list")
+        normalized = []
+        for item in repos:
+            if not isinstance(item, dict):
+                raise ValueError("each repo config entry must be an object")
+            owner = str(item.get("owner", "")).strip()
+            repo = str(item.get("repo", "")).strip()
+            if not owner or not repo:
+                raise ValueError("each repo config entry needs owner and repo")
+            normalized.append({"owner": owner, "repo": repo})
+        return normalized
+
+
+    def fetch_repo(owner, repo):
+        url = f"https://api.github.com/repos/{owner}/{repo}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        fetched_at = to_iso(iso_now())
+        with urllib.request.urlopen(
+            request,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        html_url = payload.get("html_url") or f"https://github.com/{owner}/{repo}"
+        return {
+            "owner": owner,
+            "repo": repo,
+            "stars": payload.get("stargazers_count", 0),
+            "watchers": payload.get("watchers_count", 0),
+            "subscribers": payload.get("subscribers_count", 0),
+            "forks": payload.get("forks_count", 0),
+            "openIssues": payload.get("open_issues_count", 0),
+            "pushedAt": payload.get("pushed_at"),
+            "fetchedAt": fetched_at,
+            "htmlUrl": html_url,
+        }
+
+
+    def error_message(error):
+        if isinstance(error, urllib.error.HTTPError):
+            return f"HTTP {error.code}"
+        if isinstance(error, urllib.error.URLError):
+            reason = getattr(error, "reason", "network error")
+            return f"network error: {reason}"
+        return error.__class__.__name__
+
+
+    def build_payload(repos):
+        started_at = iso_now()
+        expires_at = started_at + timedelta(seconds=CACHE_TTL_SECONDS)
+        repo_records = {}
+        errors = {}
+        for item in repos:
+            owner = item["owner"]
+            repo = item["repo"]
+            key = f"{owner}/{repo}".lower()
+            try:
+                repo_records[key] = fetch_repo(owner, repo)
+            except Exception as error:
+                # Keep per-repo failures isolated so one bad response cannot
+                # prevent healthy public repos from refreshing.
+                errors[key] = {
+                    "owner": owner,
+                    "repo": repo,
+                    "message": error_message(error),
+                    "fetchedAt": to_iso(iso_now()),
+                }
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "generatedAt": to_iso(started_at),
+            "expiresAt": to_iso(expires_at),
+            "source": SOURCE,
+            "repos": repo_records,
+            "errors": errors,
+        }
+
+
+    def atomic_write_json(payload):
+        OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = OUTPUT_PATH.with_name(f".{OUTPUT_PATH.name}.tmp")
+        with temp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+        with temp_path.open("r", encoding="utf-8") as handle:
+            json.load(handle)
+        os.replace(temp_path, OUTPUT_PATH)
+
+
+    def refresh_once(repos):
+        payload = build_payload(repos)
+        ok_count = len(payload["repos"])
+        failed_count = len(payload["errors"])
+        if ok_count == 0 and failed_count > 0 and OUTPUT_PATH.exists():
+            return ok_count, failed_count, False
+        atomic_write_json(payload)
+        return ok_count, failed_count, True
+
+
+    def main():
+        global REQUEST_TIMEOUT_SECONDS
+        repos = load_repos()
+        REQUEST_TIMEOUT_SECONDS = request_timeout_seconds(len(repos))
+        while True:
+            ok_count, failed_count, wrote_file = refresh_once(repos)
+            next_refresh_epoch = time.time() + REFRESH_INTERVAL_SECONDS
+            next_refresh_time = datetime.fromtimestamp(
+                next_refresh_epoch,
+                timezone.utc,
+            )
+            next_refresh = to_iso(next_refresh_time)
+            action = "wrote" if wrote_file else "preserved existing"
+            print(
+                f"github metrics refresh {action}: ok={ok_count} "
+                f"failed={failed_count} next={next_refresh}",
+                flush=True,
+            )
+            time.sleep(REFRESH_INTERVAL_SECONDS)
+
+
+    if __name__ == "__main__":
+        try:
+            main()
+        except Exception as error:
+            print(
+                f"github metrics sidecar exiting: {error_message(error)}",
+                file=sys.stderr,
+            )
+            raise
+{{- end }}

--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -48,6 +48,46 @@ resources:
     cpu: 250m
     memory: 256Mi
 
+githubMetricsCache:
+  enabled: false
+  image:
+    repository: python
+    tag: '3.12-alpine'
+    pullPolicy: IfNotPresent
+  refreshIntervalSeconds: 3600
+  startupTimeoutSeconds: 20
+  cacheTtlSeconds: 4500
+  outputPath: /cache/github-metrics.json
+  publicPath: /runtime/github-metrics.json
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: futuroptimist
+      repo: pr-reaper
+
 probes:
   liveness:
     path: /livez

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -26,6 +26,12 @@ server {
         try_files $uri =404;
     }
 
+    location = /runtime/github-metrics.json {
+        default_type application/json;
+        add_header Cache-Control "no-store" always;
+        try_files $uri =404;
+    }
+
     location ~* ^/assets/.*\.map$ {
         return 404;
     }

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -55,6 +55,28 @@ content changes and the existing version differs, bump `charts/danielsmith/Chart
 publishing. Manual `workflow_dispatch` chart runs validate the selected ref and publish only when
 that ref is `main`/`refs/heads/main`.
 
+## GitHub metrics cache sidecar
+
+The chart includes an optional `githubMetricsCache` sidecar for staging and production. When
+enabled by Sugarkube values, the sidecar uses unauthenticated public GitHub REST API requests on
+startup and then hourly to refresh public repository metadata. It writes an atomic pod-local JSON
+cache to a shared `emptyDir`, and the nginx app container serves that file as
+`/runtime/github-metrics.json`. No Kubernetes Secret, GitHub PAT, GitHub App credential, or client
+secret is required.
+
+Keep the sidecar disabled in the chart defaults; enable it from environment values only after the
+rendered deployment shows the `github-metrics` container and `github-metrics-cache` shared volume.
+Verify the deployed cache with:
+
+```bash
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
+curl -fsS https://danielsmith.io/runtime/github-metrics.json
+```
+
+The JSON should include `schemaVersion`, `generatedAt`, `expiresAt`, `source`, `repos`, and
+`errors`. If GitHub is temporarily unavailable, the frontend treats missing, stale, or empty cache
+data as neutral “Syncing from GitHub…” copy instead of displaying invented numbers.
+
 ## 3. Deploy staging from Sugarkube
 
 Run deployment commands from the Sugarkube repository checkout, not from this app repository.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
-    "links:check": "node scripts/check-links.cjs"
+    "links:check": "node scripts/check-links.cjs",
+    "charts:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
     "three": "^0.161.0"

--- a/scripts/check-helm-github-metrics-cache.cjs
+++ b/scripts/check-helm-github-metrics-cache.cjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const { execFileSync } = require('node:child_process');
+
+const chartPath = 'charts/danielsmith';
+
+const render = (args = []) =>
+  execFileSync('helm', ['template', 'danielsmith', chartPath, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const disabled = render();
+assert(
+  !disabled.includes('name: github-metrics'),
+  'disabled render should not include the github metrics sidecar'
+);
+assert(
+  !disabled.includes('name: github-metrics-cache'),
+  'disabled render should not include the shared github metrics volume'
+);
+
+const enabled = render(['--set', 'githubMetricsCache.enabled=true']);
+assert(
+  enabled.includes('kind: ConfigMap') &&
+    enabled.includes('refresh-github-metrics.py') &&
+    enabled.includes('repos.json'),
+  'enabled render should include the sidecar ConfigMap script and repo config'
+);
+assert(
+  enabled.includes('name: github-metrics') &&
+    enabled.includes('python:3.12-alpine') &&
+    enabled.includes('/scripts/refresh-github-metrics.py'),
+  'enabled render should include the github metrics sidecar container'
+);
+assert(
+  enabled.includes('name: github-metrics-cache') &&
+    enabled.includes('emptyDir: {}') &&
+    enabled.includes('mountPath: "/usr/share/nginx/html/runtime"') &&
+    enabled.includes('mountPath: "/cache"'),
+  'enabled render should include shared runtime mounts for nginx and sidecar'
+);
+assert(
+  enabled.includes('value: "/cache/github-metrics.json"') &&
+    enabled.includes('value: "3600"') &&
+    enabled.includes('value: "4500"'),
+  'enabled render should pass cache path and refresh TTL settings to the sidecar'
+);
+assert(
+  enabled.includes('"owner": "futuroptimist"') &&
+    enabled.includes('"repo": "token.place"') &&
+    enabled.includes('"repo": "pr-reaper"'),
+  'enabled render should serialize public GitHub repos into ConfigMap JSON'
+);
+assert(
+  !/secretKeyRef|github[_-]?token|GITHUB[_-]?TOKEN|personal[_-]?access[_-]?token/i.test(
+    enabled
+  ),
+  'enabled render should not include secret references or GitHub token settings'
+);
+
+console.log('Helm GitHub metrics cache assertions passed.');


### PR DESCRIPTION
### Motivation
- Provide a pod-local, unauthenticated hourly cache of public GitHub repo metadata so the static nginx frontend can serve `/runtime/github-metrics.json` and the client never treats fallback numbers as facts.
- Keep the feature opt-in and secret-free so staging/prod can enable it via Sugarkube values without changing application code or adding credentials.

### Description
- Add `githubMetricsCache` values to `charts/danielsmith/values.yaml` (disabled by default) including image, refresh/TTL times, tiny resource requests/limits, `outputPath`/`publicPath`, and a repo list exported into a ConfigMap.
- Add a chart `ConfigMap` template `templates/github-metrics-cache-configmap.yaml` that embeds a small, audited Python script (`refresh-github-metrics.py`) and a `repos.json` payload; the script fetches public repo REST endpoints unauthenticated, composes the runtime JSON with `schemaVersion`, `generatedAt`, `expiresAt`, `source`, `repos`, and `errors`, validates JSON, writes atomically to a temp file and `os.replace()` into place, preserves an existing cache when a full refresh fails, and logs concise refresh summaries.
- Update `templates/deployment.yaml` to conditionally add the `github-metrics` sidecar container, mount the ConfigMap script and `repos.json`, and expose a shared `emptyDir` so the app container can read the cache at the configured public path (read-only in the nginx container).
- Update `docker/nginx/default.conf` to serve `/runtime/github-metrics.json` with `application/json` and `Cache-Control: no-store` so the runtime path is available from the static image.
- Add a small Node smoke/assert script `scripts/check-helm-github-metrics-cache.cjs` and wire it into the Helm CI smoke step and an npm `charts:test` script to assert template rendering correctness for both disabled and enabled cases, including checks that no secret or token references are present.
- Bump chart `version` and add Sugarkube docs describing enablement and verification; ensure defaults are safe and disabled.
- No Kubernetes Secret, PAT, or other credential was introduced and nothing in the changes exposes secrets to the client.

### Testing
- Ran formatting: `npm run format:write` — passed.
- Linting: `npm run lint` — passed.
- Unit tests: `npm run test:ci` — full suite passed (`137 files / 1014 tests passed` in CI run reported). Targeted tests `npm run test:ci -- src/tests/githubRepoStatsService.test.ts src/tests/githubPoiMetrics.test.ts` also passed.
- Typecheck: `npm run typecheck` — not fully green; baseline repository TypeScript errors unrelated to this Helm change were observed (not introduced here).
- Docs & links: `npm run docs:check` (includes `npm run links:check`) — passed (link checker printed transient external fetch warnings).
- Smoke/build: `npm run smoke` / `npm run build` — passed (dist build produced expected artifacts).
- Helm validation/rendering: `helm lint charts/danielsmith` — passed; `helm template charts/danielsmith --set githubMetricsCache.enabled=true` produced expected manifest entries; `grep -n "github-metrics"` on rendered YAML succeeded.
- Chart assertions: `npm run charts:test` (runs `node scripts/check-helm-github-metrics-cache.cjs`) — passed and verifies the ConfigMap, sidecar container, mounts, TTL/settings, repo list, and absence of secret references.
- Sidecar script syntax: extracted `refresh-github-metrics.py` and ran `python3 -m py_compile /tmp/refresh-github-metrics.py` — passed.
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

Notes: the feature is disabled by default and requires only Helm value overrides to enable in Sugarkube/staging/prod; verification steps are documented in `docs/ops/sugarkube-release.md` and the CI Helm smoke now asserts the template rendering for the sidecar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22762d1954832fa4d1d312432d0e2c)