### PR TITLE
Make narration opt-in and dismissible

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -11,6 +11,7 @@ import { PT_OVERRIDES } from './locales/pt';
 import { ZH_HANS_OVERRIDES } from './locales/zh-Hans';
 import type {
   AudioHudControlStrings,
+  AudioSubtitleStrings,
   ControlOverlayStrings,
   DeepPartial,
   HelpModalStrings,
@@ -24,6 +25,7 @@ import type {
   ModeAnnouncerStrings,
   ModeToggleResolvedStrings,
   MovementLegendStrings,
+  NarrationToggleStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
   PoiOverlayChromeStrings,
@@ -366,6 +368,12 @@ export function getAudioHudControlStrings(
   return cloneValue(strings);
 }
 
+export function getAudioSubtitleStrings(
+  input?: LocaleInput
+): AudioSubtitleStrings {
+  return cloneValue(getLocaleStrings(input).hud.audioSubtitles);
+}
+
 export function getLocaleToggleStrings(
   input?: LocaleInput
 ): LocaleToggleResolvedStrings {
@@ -452,6 +460,12 @@ export function getTourGuideToggleStrings(
   input?: LocaleInput
 ): TourGuideToggleStrings {
   return cloneValue(getLocaleStrings(input).hud.tourGuideToggle);
+}
+
+export function getNarrationToggleStrings(
+  input?: LocaleInput
+): NarrationToggleStrings {
+  return cloneValue(getLocaleStrings(input).hud.narrationToggle);
 }
 
 export function getTourResetControlStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -258,6 +258,24 @@ export const AR_OVERRIDES: LocaleOverrides = {
         description: 'فعّل سوار المعصم أو الطائرة الهولوغرافية.',
       },
     },
+    audioSubtitles: {
+      labels: {
+        ambient: 'الصوت المحيط',
+        poi: 'السرد',
+      },
+      dismissLabels: {
+        ambient: 'إغلاق التسمية التوضيحية',
+        poi: 'إغلاق السرد',
+      },
+    },
+    narrationToggle: {
+      labelEnabled: 'السرد مفعّل',
+      labelDisabled: 'السرد معطّل',
+      descriptionEnabled:
+        'تظهر نوافذ السرد والتسميات التوضيحية في محطات المعرض القادمة.',
+      descriptionDisabled:
+        'تبقى نوافذ السرد والتسميات التوضيحية مخفية حتى تفعّلها.',
+    },
     poiOverlay: {
       visited: 'تمت الزيارة',
       nextHighlight: 'المحطة التالية',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -39,6 +39,16 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
     guidedTourOff: 'Geführte Tour aus',
     audioOn: 'Audio: an',
     audioOff: 'Audio: aus',
+    audioSubtitleAmbientLabel: 'Ambient-Audio',
+    audioSubtitlePoiLabel: 'Erzählung',
+    audioSubtitleDismissAmbient: 'Untertitel schließen',
+    audioSubtitleDismissPoi: 'Erzählung schließen',
+    narrationToggleLabelEnabled: 'Erzählung ein',
+    narrationToggleLabelDisabled: 'Erzählung aus',
+    narrationToggleDescriptionEnabled:
+      'Erzähl-Pop-ups und Untertitel erscheinen bei künftigen Exponatmomenten.',
+    narrationToggleDescriptionDisabled:
+      'Erzähl-Pop-ups und Untertitel bleiben verborgen, bis du sie einschaltest.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -254,6 +254,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         ),
       },
     },
+    audioSubtitles: {
+      labels: {
+        ambient: wrap('Ambient audio'),
+        poi: wrap('Narration'),
+      },
+      dismissLabels: {
+        ambient: wrap('Dismiss caption'),
+        poi: wrap('Dismiss narration'),
+      },
+    },
     audioControl: {
       keyHint: wrap('M'),
       groupLabel: wrap('Ambient audio controls'),
@@ -307,6 +317,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       ),
       descriptionDisabled: wrap(
         'Guided tour highlights are hidden until you turn them back on.'
+      ),
+    },
+    narrationToggle: {
+      labelEnabled: wrap('Narration on'),
+      labelDisabled: wrap('Narration off'),
+      descriptionEnabled: wrap(
+        'Narration popups and captions are shown for future exhibit moments.'
+      ),
+      descriptionDisabled: wrap(
+        'Narration popups and captions stay hidden until you turn them on.'
       ),
     },
     tourReset: {

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -270,6 +270,16 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Toggle the wrist console or holographic drone companions.',
       },
     },
+    audioSubtitles: {
+      labels: {
+        ambient: 'Ambient audio',
+        poi: 'Narration',
+      },
+      dismissLabels: {
+        ambient: 'Dismiss caption',
+        poi: 'Dismiss narration',
+      },
+    },
     audioControl: {
       keyHint: 'M',
       groupLabel: 'Ambient audio controls',
@@ -320,6 +330,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'Highlights the next recommended exhibit in the immersive tour.',
       descriptionDisabled:
         'Guided tour highlights are hidden until you turn them back on.',
+    },
+    narrationToggle: {
+      labelEnabled: 'Narration on',
+      labelDisabled: 'Narration off',
+      descriptionEnabled:
+        'Narration popups and captions are shown for future exhibit moments.',
+      descriptionDisabled:
+        'Narration popups and captions stay hidden until you turn them on.',
     },
     tourReset: {
       heading: 'Guided tour',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -39,6 +39,16 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
     guidedTourOff: 'Visita guiada desactivada',
     audioOn: 'Audio: activado',
     audioOff: 'Audio: desactivado',
+    audioSubtitleAmbientLabel: 'Audio ambiental',
+    audioSubtitlePoiLabel: 'Narración',
+    audioSubtitleDismissAmbient: 'Descartar subtítulo',
+    audioSubtitleDismissPoi: 'Descartar narración',
+    narrationToggleLabelEnabled: 'Narración activada',
+    narrationToggleLabelDisabled: 'Narración desactivada',
+    narrationToggleDescriptionEnabled:
+      'Las ventanas y subtítulos de narración aparecen en futuros momentos de exhibición.',
+    narrationToggleDescriptionDisabled:
+      'Las ventanas y subtítulos de narración permanecen ocultos hasta que los actives.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -39,6 +39,16 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
     guidedTourOff: 'Vezetett túra ki',
     audioOn: 'Hang: be',
     audioOff: 'Hang: ki',
+    audioSubtitleAmbientLabel: 'Környezeti hang',
+    audioSubtitlePoiLabel: 'Narráció',
+    audioSubtitleDismissAmbient: 'Felirat elvetése',
+    audioSubtitleDismissPoi: 'Narráció elvetése',
+    narrationToggleLabelEnabled: 'Narráció bekapcsolva',
+    narrationToggleLabelDisabled: 'Narráció kikapcsolva',
+    narrationToggleDescriptionEnabled:
+      'A narrációs felugrók és feliratok megjelennek a következő kiállítási pillanatoknál.',
+    narrationToggleDescriptionDisabled:
+      'A narrációs felugrók és feliratok rejtve maradnak, amíg be nem kapcsolod őket.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -259,6 +259,24 @@ export const JA_OVERRIDES: LocaleOverrides = {
           'リストコンソールやホログラフィックドローンを切り替えます。',
       },
     },
+    audioSubtitles: {
+      labels: {
+        ambient: '環境音',
+        poi: 'ナレーション',
+      },
+      dismissLabels: {
+        ambient: '字幕を閉じる',
+        poi: 'ナレーションを閉じる',
+      },
+    },
+    narrationToggle: {
+      labelEnabled: 'ナレーション オン',
+      labelDisabled: 'ナレーション オフ',
+      descriptionEnabled:
+        '今後の展示シーンでナレーションのポップアップと字幕を表示します。',
+      descriptionDisabled:
+        'オンにするまでナレーションのポップアップと字幕は非表示です。',
+    },
     poiOverlay: {
       visited: '訪問済み',
       nextHighlight: '次のハイライト',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -642,6 +642,16 @@ export function buildLatinLocaleOverrides(
           settings: { label: s.settingsHelp, title: s.settingsHelp },
         },
       },
+      audioSubtitles: {
+        labels: {
+          ambient: 'Ambient audio',
+          poi: 'Narration',
+        },
+        dismissLabels: {
+          ambient: 'Dismiss caption',
+          poi: 'Dismiss narration',
+        },
+      },
       audioControl: {
         groupLabel: templates.audioGroupLabel,
         toggle: {
@@ -675,6 +685,14 @@ export function buildLatinLocaleOverrides(
         labelDisabled: s.guidedTourOff,
         descriptionEnabled: s.guidedTour,
         descriptionDisabled: s.guidedTour,
+      },
+      narrationToggle: {
+        labelEnabled: 'Narration on',
+        labelDisabled: 'Narration off',
+        descriptionEnabled:
+          'Narration popups and captions are shown for future exhibit moments.',
+        descriptionDisabled:
+          'Narration popups and captions stay hidden until you turn them on.',
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -92,6 +92,14 @@ const localizedTemplates: Record<
     audioMutedAnnouncementTemplate: string;
     audioMutedValueTemplate: string;
     audioMutedAriaValueTemplate: string;
+    audioSubtitleAmbientLabel: string;
+    audioSubtitlePoiLabel: string;
+    audioSubtitleDismissAmbient: string;
+    audioSubtitleDismissPoi: string;
+    narrationToggleLabelEnabled: string;
+    narrationToggleLabelDisabled: string;
+    narrationToggleDescriptionEnabled: string;
+    narrationToggleDescriptionDisabled: string;
     tourResetLabel: string;
     tourResetDescription: string;
     fallbackRendererLabel: string;
@@ -140,6 +148,16 @@ const localizedTemplates: Record<
       'Audio ambiental silenciado. Volumen {volume}.',
     audioMutedValueTemplate: 'Silenciado · {volume}',
     audioMutedAriaValueTemplate: 'Silenciado ({volume})',
+    audioSubtitleAmbientLabel: 'Audio ambiental',
+    audioSubtitlePoiLabel: 'Narración',
+    audioSubtitleDismissAmbient: 'Descartar subtítulo',
+    audioSubtitleDismissPoi: 'Descartar narración',
+    narrationToggleLabelEnabled: 'Narración activada',
+    narrationToggleLabelDisabled: 'Narración desactivada',
+    narrationToggleDescriptionEnabled:
+      'Las ventanas y subtítulos de narración aparecen en futuros momentos de exhibición.',
+    narrationToggleDescriptionDisabled:
+      'Las ventanas y subtítulos de narración permanecen ocultos hasta que los actives.',
     tourResetLabel: 'Reiniciar visita guiada',
     tourResetDescription: 'Borra los POI visitados y repite la ruta curada.',
     fallbackRendererLabel: 'renderizador WebGL por software',
@@ -188,6 +206,16 @@ const localizedTemplates: Record<
       'Áudio ambiente silenciado. Volume {volume}.',
     audioMutedValueTemplate: 'Silenciado · {volume}',
     audioMutedAriaValueTemplate: 'Silenciado ({volume})',
+    audioSubtitleAmbientLabel: 'Áudio ambiente',
+    audioSubtitlePoiLabel: 'Narração',
+    audioSubtitleDismissAmbient: 'Dispensar legenda',
+    audioSubtitleDismissPoi: 'Dispensar narração',
+    narrationToggleLabelEnabled: 'Narração ativada',
+    narrationToggleLabelDisabled: 'Narração desativada',
+    narrationToggleDescriptionEnabled:
+      'Pop-ups e legendas de narração aparecem nos próximos momentos das exibições.',
+    narrationToggleDescriptionDisabled:
+      'Pop-ups e legendas de narração ficam ocultos até você ativá-los.',
     tourResetLabel: 'Reiniciar visita guiada',
     tourResetDescription:
       'Limpe os POIs visitados e repita o caminho selecionado.',
@@ -236,6 +264,16 @@ const localizedTemplates: Record<
     audioMutedAnnouncementTemplate: 'Ambient-Audio stumm. Lautstärke {volume}.',
     audioMutedValueTemplate: 'Stumm · {volume}',
     audioMutedAriaValueTemplate: 'Stumm ({volume})',
+    audioSubtitleAmbientLabel: 'Ambient-Audio',
+    audioSubtitlePoiLabel: 'Erzählung',
+    audioSubtitleDismissAmbient: 'Untertitel schließen',
+    audioSubtitleDismissPoi: 'Erzählung schließen',
+    narrationToggleLabelEnabled: 'Erzählung ein',
+    narrationToggleLabelDisabled: 'Erzählung aus',
+    narrationToggleDescriptionEnabled:
+      'Erzähl-Popups und Untertitel erscheinen bei zukünftigen Exponatmomenten.',
+    narrationToggleDescriptionDisabled:
+      'Erzähl-Popups und Untertitel bleiben verborgen, bis du sie einschaltest.',
     tourResetLabel: 'Geführte Tour neu starten',
     tourResetDescription:
       'Besuchte POIs löschen und den kuratierten Pfad wiederholen.',
@@ -285,6 +323,16 @@ const localizedTemplates: Record<
       'Környezeti hang némítva. Hangerő {volume}.',
     audioMutedValueTemplate: 'Némítva · {volume}',
     audioMutedAriaValueTemplate: 'Némítva ({volume})',
+    audioSubtitleAmbientLabel: 'Környezeti hang',
+    audioSubtitlePoiLabel: 'Narráció',
+    audioSubtitleDismissAmbient: 'Felirat elvetése',
+    audioSubtitleDismissPoi: 'Narráció elvetése',
+    narrationToggleLabelEnabled: 'Narráció bekapcsolva',
+    narrationToggleLabelDisabled: 'Narráció kikapcsolva',
+    narrationToggleDescriptionEnabled:
+      'A narrációs felugrók és feliratok megjelennek a későbbi kiállítási pillanatoknál.',
+    narrationToggleDescriptionDisabled:
+      'A narrációs felugrók és feliratok rejtve maradnak, amíg be nem kapcsolod őket.',
     tourResetLabel: 'Vezetett túra újraindítása',
     tourResetDescription:
       'Látogatott POI-k törlése és a kijelölt útvonal újrajátszása.',
@@ -644,12 +692,12 @@ export function buildLatinLocaleOverrides(
       },
       audioSubtitles: {
         labels: {
-          ambient: 'Ambient audio',
-          poi: 'Narration',
+          ambient: templates.audioSubtitleAmbientLabel,
+          poi: templates.audioSubtitlePoiLabel,
         },
         dismissLabels: {
-          ambient: 'Dismiss caption',
-          poi: 'Dismiss narration',
+          ambient: templates.audioSubtitleDismissAmbient,
+          poi: templates.audioSubtitleDismissPoi,
         },
       },
       audioControl: {
@@ -687,12 +735,10 @@ export function buildLatinLocaleOverrides(
         descriptionDisabled: s.guidedTour,
       },
       narrationToggle: {
-        labelEnabled: 'Narration on',
-        labelDisabled: 'Narration off',
-        descriptionEnabled:
-          'Narration popups and captions are shown for future exhibit moments.',
-        descriptionDisabled:
-          'Narration popups and captions stay hidden until you turn them on.',
+        labelEnabled: templates.narrationToggleLabelEnabled,
+        labelDisabled: templates.narrationToggleLabelDisabled,
+        descriptionEnabled: templates.narrationToggleDescriptionEnabled,
+        descriptionDisabled: templates.narrationToggleDescriptionDisabled,
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -42,6 +42,14 @@ interface LatinLocaleCopy {
     guidedTourOff: string;
     audioOn: string;
     audioOff: string;
+    audioSubtitleAmbientLabel: string;
+    audioSubtitlePoiLabel: string;
+    audioSubtitleDismissAmbient: string;
+    audioSubtitleDismissPoi: string;
+    narrationToggleLabelEnabled: string;
+    narrationToggleLabelDisabled: string;
+    narrationToggleDescriptionEnabled: string;
+    narrationToggleDescriptionDisabled: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -92,14 +100,6 @@ const localizedTemplates: Record<
     audioMutedAnnouncementTemplate: string;
     audioMutedValueTemplate: string;
     audioMutedAriaValueTemplate: string;
-    audioSubtitleAmbientLabel: string;
-    audioSubtitlePoiLabel: string;
-    audioSubtitleDismissAmbient: string;
-    audioSubtitleDismissPoi: string;
-    narrationToggleLabelEnabled: string;
-    narrationToggleLabelDisabled: string;
-    narrationToggleDescriptionEnabled: string;
-    narrationToggleDescriptionDisabled: string;
     tourResetLabel: string;
     tourResetDescription: string;
     fallbackRendererLabel: string;
@@ -148,16 +148,6 @@ const localizedTemplates: Record<
       'Audio ambiental silenciado. Volumen {volume}.',
     audioMutedValueTemplate: 'Silenciado · {volume}',
     audioMutedAriaValueTemplate: 'Silenciado ({volume})',
-    audioSubtitleAmbientLabel: 'Audio ambiental',
-    audioSubtitlePoiLabel: 'Narración',
-    audioSubtitleDismissAmbient: 'Descartar subtítulo',
-    audioSubtitleDismissPoi: 'Descartar narración',
-    narrationToggleLabelEnabled: 'Narración activada',
-    narrationToggleLabelDisabled: 'Narración desactivada',
-    narrationToggleDescriptionEnabled:
-      'Las ventanas y subtítulos de narración aparecen en futuros momentos de exhibición.',
-    narrationToggleDescriptionDisabled:
-      'Las ventanas y subtítulos de narración permanecen ocultos hasta que los actives.',
     tourResetLabel: 'Reiniciar visita guiada',
     tourResetDescription: 'Borra los POI visitados y repite la ruta curada.',
     fallbackRendererLabel: 'renderizador WebGL por software',
@@ -206,16 +196,6 @@ const localizedTemplates: Record<
       'Áudio ambiente silenciado. Volume {volume}.',
     audioMutedValueTemplate: 'Silenciado · {volume}',
     audioMutedAriaValueTemplate: 'Silenciado ({volume})',
-    audioSubtitleAmbientLabel: 'Áudio ambiente',
-    audioSubtitlePoiLabel: 'Narração',
-    audioSubtitleDismissAmbient: 'Dispensar legenda',
-    audioSubtitleDismissPoi: 'Dispensar narração',
-    narrationToggleLabelEnabled: 'Narração ativada',
-    narrationToggleLabelDisabled: 'Narração desativada',
-    narrationToggleDescriptionEnabled:
-      'Pop-ups e legendas de narração aparecem nos próximos momentos das exibições.',
-    narrationToggleDescriptionDisabled:
-      'Pop-ups e legendas de narração ficam ocultos até você ativá-los.',
     tourResetLabel: 'Reiniciar visita guiada',
     tourResetDescription:
       'Limpe os POIs visitados e repita o caminho selecionado.',
@@ -264,16 +244,6 @@ const localizedTemplates: Record<
     audioMutedAnnouncementTemplate: 'Ambient-Audio stumm. Lautstärke {volume}.',
     audioMutedValueTemplate: 'Stumm · {volume}',
     audioMutedAriaValueTemplate: 'Stumm ({volume})',
-    audioSubtitleAmbientLabel: 'Ambient-Audio',
-    audioSubtitlePoiLabel: 'Erzählung',
-    audioSubtitleDismissAmbient: 'Untertitel schließen',
-    audioSubtitleDismissPoi: 'Erzählung schließen',
-    narrationToggleLabelEnabled: 'Erzählung ein',
-    narrationToggleLabelDisabled: 'Erzählung aus',
-    narrationToggleDescriptionEnabled:
-      'Erzähl-Popups und Untertitel erscheinen bei zukünftigen Exponatmomenten.',
-    narrationToggleDescriptionDisabled:
-      'Erzähl-Popups und Untertitel bleiben verborgen, bis du sie einschaltest.',
     tourResetLabel: 'Geführte Tour neu starten',
     tourResetDescription:
       'Besuchte POIs löschen und den kuratierten Pfad wiederholen.',
@@ -323,16 +293,6 @@ const localizedTemplates: Record<
       'Környezeti hang némítva. Hangerő {volume}.',
     audioMutedValueTemplate: 'Némítva · {volume}',
     audioMutedAriaValueTemplate: 'Némítva ({volume})',
-    audioSubtitleAmbientLabel: 'Környezeti hang',
-    audioSubtitlePoiLabel: 'Narráció',
-    audioSubtitleDismissAmbient: 'Felirat elvetése',
-    audioSubtitleDismissPoi: 'Narráció elvetése',
-    narrationToggleLabelEnabled: 'Narráció bekapcsolva',
-    narrationToggleLabelDisabled: 'Narráció kikapcsolva',
-    narrationToggleDescriptionEnabled:
-      'A narrációs felugrók és feliratok megjelennek a későbbi kiállítási pillanatoknál.',
-    narrationToggleDescriptionDisabled:
-      'A narrációs felugrók és feliratok rejtve maradnak, amíg be nem kapcsolod őket.',
     tourResetLabel: 'Vezetett túra újraindítása',
     tourResetDescription:
       'Látogatott POI-k törlése és a kijelölt útvonal újrajátszása.',
@@ -692,12 +652,12 @@ export function buildLatinLocaleOverrides(
       },
       audioSubtitles: {
         labels: {
-          ambient: templates.audioSubtitleAmbientLabel,
-          poi: templates.audioSubtitlePoiLabel,
+          ambient: s.audioSubtitleAmbientLabel,
+          poi: s.audioSubtitlePoiLabel,
         },
         dismissLabels: {
-          ambient: templates.audioSubtitleDismissAmbient,
-          poi: templates.audioSubtitleDismissPoi,
+          ambient: s.audioSubtitleDismissAmbient,
+          poi: s.audioSubtitleDismissPoi,
         },
       },
       audioControl: {
@@ -735,10 +695,10 @@ export function buildLatinLocaleOverrides(
         descriptionDisabled: s.guidedTour,
       },
       narrationToggle: {
-        labelEnabled: templates.narrationToggleLabelEnabled,
-        labelDisabled: templates.narrationToggleLabelDisabled,
-        descriptionEnabled: templates.narrationToggleDescriptionEnabled,
-        descriptionDisabled: templates.narrationToggleDescriptionDisabled,
+        labelEnabled: s.narrationToggleLabelEnabled,
+        labelDisabled: s.narrationToggleLabelDisabled,
+        descriptionEnabled: s.narrationToggleDescriptionEnabled,
+        descriptionDisabled: s.narrationToggleDescriptionDisabled,
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -39,6 +39,16 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
     guidedTourOff: 'Visita guiada desativada',
     audioOn: 'Áudio: ligado',
     audioOff: 'Áudio: desligado',
+    audioSubtitleAmbientLabel: 'Áudio ambiente',
+    audioSubtitlePoiLabel: 'Narração',
+    audioSubtitleDismissAmbient: 'Dispensar legenda',
+    audioSubtitleDismissPoi: 'Dispensar narração',
+    narrationToggleLabelEnabled: 'Narração ativada',
+    narrationToggleLabelDisabled: 'Narração desativada',
+    narrationToggleDescriptionEnabled:
+      'Pop-ups e legendas de narração aparecem em futuros momentos da exibição.',
+    narrationToggleDescriptionDisabled:
+      'Pop-ups e legendas de narração ficam ocultos até você ativá-los.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -208,6 +208,16 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         description: '切换腕部控制台或全息无人机伙伴。',
       },
     },
+    audioSubtitles: {
+      labels: {
+        ambient: '环境音频',
+        poi: '旁白',
+      },
+      dismissLabels: {
+        ambient: '关闭字幕',
+        poi: '关闭旁白',
+      },
+    },
     audioControl: {
       keyHint: 'M',
       groupLabel: '环境音频控制',
@@ -248,6 +258,12 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       labelDisabled: '导览已关闭',
       descriptionEnabled: '高亮沉浸式导览中下一个推荐展品。',
       descriptionDisabled: '导览高亮已隐藏，直到你重新开启。',
+    },
+    narrationToggle: {
+      labelEnabled: '旁白已开启',
+      labelDisabled: '旁白已关闭',
+      descriptionEnabled: '未来展品时刻会显示旁白弹窗和字幕。',
+      descriptionDisabled: '旁白弹窗和字幕保持隐藏，直到你开启。',
     },
     tourReset: {
       heading: '导览',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -73,6 +73,17 @@ export interface MovementLegendStrings {
   interactPromptTemplates: Record<InputMethod | 'default', string>;
 }
 
+export interface AudioSubtitleStrings {
+  labels: {
+    ambient: string;
+    poi: string;
+  };
+  dismissLabels: {
+    ambient: string;
+    poi: string;
+  };
+}
+
 export interface AudioHudControlStrings {
   keyHint: string;
   groupLabel: string;
@@ -185,6 +196,13 @@ export interface LocaleOptionStrings {
 }
 
 export interface TourGuideToggleStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
+export interface NarrationToggleStrings {
   labelEnabled: string;
   labelDisabled: string;
   descriptionEnabled: string;
@@ -375,9 +393,11 @@ export interface LocaleStrings {
     controlOverlay: ControlOverlayStrings;
     movementLegend: MovementLegendStrings;
     audioControl: AudioHudControlStrings;
+    audioSubtitles: AudioSubtitleStrings;
     modeToggle: ModeToggleStrings;
     localeToggle: LocaleToggleStrings;
     tourGuideToggle: TourGuideToggleStrings;
+    narrationToggle: NarrationToggleStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import { createWallSegmentInstances } from './assets/floorPlan/wallSegments';
 import {
   formatMessage,
   getAudioHudControlStrings,
+  getAudioSubtitleStrings,
   getControlOverlayStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
@@ -50,6 +51,7 @@ import {
   getLocaleToggleStrings,
   getModeAnnouncerStrings,
   getModeToggleStrings,
+  getNarrationToggleStrings,
   getPoiNarrativeLogStrings,
   getPoiOverlayChromeStrings,
   getSiteStrings,
@@ -317,6 +319,10 @@ import {
   type MotionBlurControlHandle,
 } from './systems/controls/motionBlurControl';
 import {
+  createNarrationToggleControl,
+  type NarrationToggleControlHandle,
+} from './systems/controls/narrationToggleControl';
+import {
   createTourGuideToggleControl,
   type TourGuideToggleControlHandle,
 } from './systems/controls/tourGuideToggleControl';
@@ -369,6 +375,10 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
+import {
+  NARRATION_PREFERENCE_STORAGE_KEY,
+  NarrationPreference,
+} from './systems/narrative/narrationPreference';
 import { ProceduralNarrator } from './systems/narrative/proceduralNarrator';
 import { createNavMesh, type NavMesh } from './systems/navigation/navMesh';
 import {
@@ -495,6 +505,20 @@ declare global {
           audioContextState: AudioContextState | 'unknown';
           storageKeyVersion: string;
           activeStorageKey: string;
+        };
+      };
+      narration?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          activeStorageKey: string;
+          storageKeyVersion: string;
+          currentSubtitle: string | null;
+          currentSubtitleId: string | null;
+          currentSubtitleSource: string | null;
+          queueLength: number;
+          visible: boolean;
+          dismissCount: number;
+          lastDismissedAt: number | null;
         };
       };
       graphics?: {
@@ -980,6 +1004,7 @@ function initializeImmersiveScene(
   let immersiveDisposed = false;
   let beforeUnloadHandler: (() => void) | null = null;
   let audioHudHandle: AudioHudControlHandle | null = null;
+  let narrationToggleControl: NarrationToggleControlHandle | null = null;
   let motionBlurControl: MotionBlurControlHandle | null = null;
   let audioSubtitles: AudioSubtitlesHandle | null = null;
   let ambientCaptionBridge: AmbientCaptionBridge | null = null;
@@ -1038,6 +1063,7 @@ function initializeImmersiveScene(
   let removeIdleSubscription: (() => void) | null = null;
   let removeGuidedTourSubscription: (() => void) | null = null;
   let removeGuidedTourPreferenceSubscription: (() => void) | null = null;
+  let removeNarrationPreferenceSubscription: (() => void) | null = null;
   let githubRepoMetrics: GitHubRepoMetricsController | null = null;
   let getAmbientAudioVolume = () =>
     ambientAudioController?.getMasterVolume() ?? 1;
@@ -1140,6 +1166,38 @@ function initializeImmersiveScene(
     };
   };
 
+  const isNarrationEnabled = () => narrationPreference.isEnabled();
+
+  const getNarrationDebugState = () => ({
+    preferenceEnabled: narrationPreference.isEnabled(),
+    activeStorageKey: narrationPreference.getStorageKey(),
+    storageKeyVersion:
+      narrationPreference.getStorageKey() === NARRATION_PREFERENCE_STORAGE_KEY
+        ? 'v1'
+        : 'custom',
+    currentSubtitle: audioSubtitles?.getCurrent()?.text ?? null,
+    currentSubtitleId: audioSubtitles?.getCurrent()?.id ?? null,
+    currentSubtitleSource: audioSubtitles?.getCurrent()?.source ?? null,
+    queueLength: audioSubtitles?.getQueueLength() ?? 0,
+    visible: audioSubtitles?.isVisible() ?? false,
+    dismissCount: audioSubtitles?.getDismissCount() ?? 0,
+    lastDismissedAt: audioSubtitles?.getLastDismissedAt() ?? null,
+  });
+
+  const showNarrationSubtitle = (
+    message: Parameters<AudioSubtitlesHandle['show']>[0]
+  ) => {
+    if (!isNarrationEnabled()) {
+      return;
+    }
+    audioSubtitles?.show(message);
+  };
+
+  const clearNarrationSubtitles = () => {
+    audioSubtitles?.dismissAll();
+    ambientCaptionBridge?.clear();
+  };
+
   let localeStorage: Storage | undefined;
   try {
     localeStorage = window.localStorage;
@@ -1166,6 +1224,10 @@ function initializeImmersiveScene(
 
   const guidedTourPreference = new GuidedTourPreference({
     storageKey: GUIDED_TOUR_STORAGE_KEY,
+    windowTarget: window,
+    defaultEnabled: false,
+  });
+  const narrationPreference = new NarrationPreference({
     windowTarget: window,
     defaultEnabled: false,
   });
@@ -1203,9 +1265,11 @@ function initializeImmersiveScene(
   let localeToggleStrings = getLocaleToggleStrings(locale);
   let modeToggleStrings = getModeToggleStrings(locale);
   let audioHudStrings = getAudioHudControlStrings(locale);
+  let audioSubtitleStrings = getAudioSubtitleStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
+  let narrationToggleStrings = getNarrationToggleStrings(locale);
   let tourResetControlStrings = getTourResetControlStrings(locale);
   let softwareRendererWarningStrings =
     getSoftwareRendererWarningStrings(locale);
@@ -1977,6 +2041,9 @@ function initializeImmersiveScene(
   window.portfolio.audio = {
     getState: getAudioDebugState,
   };
+  window.portfolio.narration = {
+    getState: getNarrationDebugState,
+  };
   const wirePoiGitHubMetrics = () => {
     githubRepoMetrics?.dispose();
     githubRepoMetrics = wireGitHubRepoMetrics({
@@ -2176,6 +2243,14 @@ function initializeImmersiveScene(
     source: poiTourGuide,
     enabled: initialGuidedTourEnabled,
   });
+  removeNarrationPreferenceSubscription = narrationPreference.subscribe(
+    ({ enabled }) => {
+      narrationToggleControl?.setEnabled(enabled);
+      if (!enabled) {
+        clearNarrationSubtitles();
+      }
+    }
+  );
   removeGuidedTourPreferenceSubscription = guidedTourPreference.subscribe(
     (enabled) => {
       guidedTourChannel?.setEnabled(enabled);
@@ -2454,8 +2529,8 @@ function initializeImmersiveScene(
     (poi) => {
       idleMonitor?.reportActivity();
       poiVisitedState.markVisited(poi.id);
-      if (poi.narration?.caption && audioSubtitles) {
-        audioSubtitles.show({
+      if (poi.narration?.caption) {
+        showNarrationSubtitle({
           id: `poi-${poi.id}`,
           text: poi.narration.caption,
           source: 'poi',
@@ -3256,6 +3331,8 @@ function initializeImmersiveScene(
     localeToggleStrings = getLocaleToggleStrings(locale);
     modeToggleStrings = getModeToggleStrings(locale);
     audioHudStrings = getAudioHudControlStrings(locale);
+    audioSubtitleStrings = getAudioSubtitleStrings(locale);
+    narrationToggleStrings = getNarrationToggleStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
@@ -3327,6 +3404,8 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
+    audioSubtitles?.setLabels(audioSubtitleStrings);
+    narrationToggleControl?.setStrings(narrationToggleStrings);
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
@@ -3660,7 +3739,14 @@ function initializeImmersiveScene(
   window.addEventListener('pointerup', handlePointerUpForCameraPan);
   window.addEventListener('pointercancel', handlePointerUpForCameraPan);
 
-  audioSubtitles = createAudioSubtitles({ container: document.body });
+  audioSubtitles = createAudioSubtitles({
+    container: document.body,
+    labels: audioSubtitleStrings.labels,
+    dismissLabels: audioSubtitleStrings.dismissLabels,
+  });
+  if (!narrationPreference.isEnabled()) {
+    clearNarrationSubtitles();
+  }
 
   if (!ambientAudioController) {
     const audioBeds: AmbientAudioBedDefinition[] = [];
@@ -3793,7 +3879,19 @@ function initializeImmersiveScene(
     if (!ambientCaptionBridge && audioSubtitles) {
       ambientCaptionBridge = new AmbientCaptionBridge({
         controller: ambientAudioController,
-        subtitles: audioSubtitles,
+        subtitles: {
+          show: (message) => showNarrationSubtitle(message),
+          clear: (messageId) => audioSubtitles?.clear(messageId),
+          dismissAll: () => audioSubtitles?.dismissAll(),
+          dispose: () => audioSubtitles?.dispose(),
+          getCurrent: () => audioSubtitles?.getCurrent() ?? null,
+          getQueueLength: () => audioSubtitles?.getQueueLength() ?? 0,
+          isVisible: () => audioSubtitles?.isVisible() ?? false,
+          getDismissCount: () => audioSubtitles?.getDismissCount() ?? 0,
+          getLastDismissedAt: () =>
+            audioSubtitles?.getLastDismissedAt() ?? null,
+          setLabels: (options) => audioSubtitles?.setLabels(options),
+        },
       });
     }
 
@@ -3822,6 +3920,16 @@ function initializeImmersiveScene(
       onToggle: activateTextMode,
     });
     registerHudControlElement(manualModeToggle?.element ?? null);
+
+    narrationToggleControl = createNarrationToggleControl({
+      container: hudSettingsStack,
+      initialEnabled: narrationPreference.isEnabled(),
+      onToggle: (enabled) => {
+        narrationPreference.setEnabled(enabled, 'control');
+      },
+      strings: narrationToggleStrings,
+    });
+    registerHudControlElement(narrationToggleControl?.element ?? null);
 
     tourGuideToggleControl = createTourGuideToggleControl({
       container: hudSettingsStack,
@@ -4732,6 +4840,10 @@ function initializeImmersiveScene(
       removeGuidedTourPreferenceSubscription();
       removeGuidedTourPreferenceSubscription = null;
     }
+    if (removeNarrationPreferenceSubscription) {
+      removeNarrationPreferenceSubscription();
+      removeNarrationPreferenceSubscription = null;
+    }
     guidedTourChannel?.dispose();
     guidedTourChannel = null;
     guidedTourPreference.dispose();
@@ -4746,6 +4858,10 @@ function initializeImmersiveScene(
     if (manualModeToggle) {
       manualModeToggle.dispose();
       manualModeToggle = null;
+    }
+    if (narrationToggleControl) {
+      narrationToggleControl.dispose();
+      narrationToggleControl = null;
     }
     if (tourGuideToggleControl) {
       tourGuideToggleControl.dispose();
@@ -4893,6 +5009,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.audio) {
       delete window.portfolio.audio;
     }
+    if (window.portfolio?.narration) {
+      delete window.portfolio.narration;
+    }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
     }
@@ -4901,6 +5020,7 @@ function initializeImmersiveScene(
       localeToggleControl = null;
     }
     movementLegend?.dispose();
+    narrationPreference.dispose();
     if (proceduralNarrator) {
       proceduralNarrator.dispose();
       proceduralNarrator = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1194,7 +1194,7 @@ function initializeImmersiveScene(
   };
 
   const clearNarrationSubtitles = () => {
-    audioSubtitles?.dismissAll();
+    audioSubtitles?.clear();
     ambientCaptionBridge?.clear();
   };
 

--- a/src/systems/controls/narrationToggleControl.ts
+++ b/src/systems/controls/narrationToggleControl.ts
@@ -1,0 +1,77 @@
+import type { NarrationToggleStrings } from '../../assets/i18n';
+import { getNarrationToggleStrings } from '../../assets/i18n';
+
+export interface NarrationToggleControlOptions {
+  container: HTMLElement;
+  initialEnabled?: boolean;
+  onToggle?: (enabled: boolean) => void;
+  strings?: NarrationToggleStrings;
+}
+
+export interface NarrationToggleControlHandle {
+  readonly element: HTMLButtonElement;
+  setEnabled(enabled: boolean): void;
+  setStrings(strings: NarrationToggleStrings): void;
+  dispose(): void;
+}
+
+export function createNarrationToggleControl({
+  container,
+  initialEnabled = false,
+  onToggle,
+  strings: providedStrings,
+}: NarrationToggleControlOptions): NarrationToggleControlHandle {
+  const defaultStrings = getNarrationToggleStrings();
+  let strings: NarrationToggleStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+  };
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tour-toggle narration-toggle';
+  container.appendChild(button);
+
+  let enabled = Boolean(initialEnabled);
+
+  const refresh = () => {
+    const label = enabled ? strings.labelEnabled : strings.labelDisabled;
+    const description = enabled
+      ? strings.descriptionEnabled
+      : strings.descriptionDisabled;
+    button.textContent = label;
+    button.dataset.state = enabled ? 'enabled' : 'disabled';
+    button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    button.setAttribute('aria-label', description);
+    button.title = description;
+    button.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const toggle = () => {
+    enabled = !enabled;
+    refresh();
+    onToggle?.(enabled);
+  };
+
+  button.addEventListener('click', toggle);
+  refresh();
+
+  return {
+    element: button,
+    setEnabled(next) {
+      if (enabled === next) {
+        return;
+      }
+      enabled = next;
+      refresh();
+    },
+    setStrings(nextStrings) {
+      strings = { ...defaultStrings, ...nextStrings };
+      refresh();
+    },
+    dispose() {
+      button.removeEventListener('click', toggle);
+      button.remove();
+    },
+  };
+}

--- a/src/systems/narrative/narrationPreference.ts
+++ b/src/systems/narrative/narrationPreference.ts
@@ -1,0 +1,179 @@
+export type NarrationPreferenceChangeSource =
+  | 'init'
+  | 'control'
+  | 'storage'
+  | 'api';
+
+export interface NarrationPreferenceChange {
+  readonly enabled: boolean;
+  readonly source: NarrationPreferenceChangeSource;
+}
+
+export interface NarrationPreferenceOptions {
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  storageKey?: string;
+  windowTarget?: Window | null;
+  defaultEnabled?: boolean;
+}
+
+export const NARRATION_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::narrationEnabled::v1';
+export const LEGACY_NARRATION_PREFERENCE_STORAGE_KEYS = [
+  'danielsmith.io::narrationEnabled',
+  'danielsmith.io:narration-enabled',
+] as const;
+
+const parseStoredValue = (value: string | null): boolean | null => {
+  if (value === '1' || value === 'true') {
+    return true;
+  }
+  if (value === '0' || value === 'false') {
+    return false;
+  }
+  return null;
+};
+
+const getDefaultStorage = (
+  target: Window | null
+): Pick<Storage, 'getItem' | 'setItem'> | null => {
+  if (!target) {
+    return null;
+  }
+  try {
+    if (target.localStorage) {
+      return target.localStorage;
+    }
+  } catch (error) {
+    console.warn(
+      'Unable to access localStorage for narration preference.',
+      error
+    );
+  }
+  try {
+    if (target.sessionStorage) {
+      return target.sessionStorage;
+    }
+  } catch (error) {
+    console.warn(
+      'Unable to access sessionStorage for narration preference.',
+      error
+    );
+  }
+  return null;
+};
+
+export class NarrationPreference {
+  private readonly storage: Pick<Storage, 'getItem' | 'setItem'> | null;
+
+  private readonly storageKey: string;
+
+  private readonly windowTarget: Window | null;
+
+  private readonly listeners = new Set<
+    (change: NarrationPreferenceChange) => void
+  >();
+
+  private enabled: boolean;
+
+  constructor(options: NarrationPreferenceOptions = {}) {
+    this.windowTarget =
+      options.windowTarget ?? (typeof window !== 'undefined' ? window : null);
+    this.storage =
+      options.storage === undefined
+        ? getDefaultStorage(this.windowTarget)
+        : options.storage;
+    this.storageKey = options.storageKey ?? NARRATION_PREFERENCE_STORAGE_KEY;
+    this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
+
+    if (this.windowTarget) {
+      this.windowTarget.addEventListener('storage', this.handleStorageEvent);
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(
+    enabled: boolean,
+    source: NarrationPreferenceChangeSource = 'control'
+  ): void {
+    if (this.enabled === enabled) {
+      if (source === 'control') {
+        this.persist();
+      }
+      return;
+    }
+    this.enabled = enabled;
+    this.persist();
+    this.notify(source);
+  }
+
+  getStorageKey(): string {
+    return this.storageKey;
+  }
+
+  subscribe(listener: (change: NarrationPreferenceChange) => void): () => void {
+    this.listeners.add(listener);
+    listener({ enabled: this.enabled, source: 'init' });
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  dispose(): void {
+    if (this.windowTarget) {
+      this.windowTarget.removeEventListener('storage', this.handleStorageEvent);
+    }
+    this.listeners.clear();
+  }
+
+  private loadInitialState(defaultEnabled: boolean): boolean {
+    if (!this.storage?.getItem) {
+      return defaultEnabled;
+    }
+    try {
+      const parsed = parseStoredValue(this.storage.getItem(this.storageKey));
+      if (parsed === null) {
+        return defaultEnabled;
+      }
+      return parsed;
+    } catch (error) {
+      console.warn('Failed to read narration preference from storage.', error);
+      return defaultEnabled;
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage?.setItem) {
+      return;
+    }
+    try {
+      this.storage.setItem(this.storageKey, this.enabled ? '1' : '0');
+    } catch (error) {
+      console.warn('Failed to persist narration preference.', error);
+    }
+  }
+
+  private notify(source: NarrationPreferenceChangeSource): void {
+    const change: NarrationPreferenceChange = {
+      enabled: this.enabled,
+      source,
+    };
+    for (const listener of this.listeners) {
+      listener(change);
+    }
+  }
+
+  private readonly handleStorageEvent = (event: StorageEvent) => {
+    if (!event.key || event.key !== this.storageKey) {
+      return;
+    }
+    const parsed = parseStoredValue(event.newValue ?? null);
+    if (parsed === null || parsed === this.enabled) {
+      return;
+    }
+    this.enabled = parsed;
+    this.notify('storage');
+  };
+}

--- a/src/systems/narrative/narrationPreference.ts
+++ b/src/systems/narrative/narrationPreference.ts
@@ -166,10 +166,11 @@ export class NarrationPreference {
   }
 
   private readonly handleStorageEvent = (event: StorageEvent) => {
-    if (!event.key || event.key !== this.storageKey) {
+    if (event.key !== null && event.key !== this.storageKey) {
       return;
     }
-    const parsed = parseStoredValue(event.newValue ?? null);
+    const parsed =
+      event.newValue === null ? false : parseStoredValue(event.newValue);
     if (parsed === null || parsed === this.enabled) {
       return;
     }

--- a/src/tests/ambientCaptionBridge.test.ts
+++ b/src/tests/ambientCaptionBridge.test.ts
@@ -77,6 +77,14 @@ describe('AmbientCaptionBridge', () => {
       }),
       dispose: vi.fn(),
       getCurrent: vi.fn(() => current),
+      dismissAll: vi.fn(() => {
+        current = null;
+      }),
+      getQueueLength: vi.fn(() => 0),
+      isVisible: vi.fn(() => current !== null),
+      getDismissCount: vi.fn(() => 0),
+      getLastDismissedAt: vi.fn(() => null),
+      setLabels: vi.fn(),
     };
 
     const bridge = new AmbientCaptionBridge({
@@ -154,6 +162,14 @@ describe('AmbientCaptionBridge priority handling', () => {
       }),
       dispose: vi.fn(),
       getCurrent: vi.fn(() => current),
+      dismissAll: vi.fn(() => {
+        current = null;
+      }),
+      getQueueLength: vi.fn(() => 0),
+      isVisible: vi.fn(() => current !== null),
+      getDismissCount: vi.fn(() => 0),
+      getLastDismissedAt: vi.fn(() => null),
+      setLabels: vi.fn(),
     };
 
     const bridge = new AmbientCaptionBridge({
@@ -207,6 +223,14 @@ describe('AmbientCaptionBridge priority handling', () => {
       }),
       dispose: vi.fn(),
       getCurrent: vi.fn(() => current),
+      dismissAll: vi.fn(() => {
+        current = null;
+      }),
+      getQueueLength: vi.fn(() => 0),
+      isVisible: vi.fn(() => current !== null),
+      getDismissCount: vi.fn(() => 0),
+      getLastDismissedAt: vi.fn(() => null),
+      setLabels: vi.fn(),
     };
 
     const bridge = new AmbientCaptionBridge({
@@ -272,6 +296,14 @@ describe('AmbientCaptionBridge priority handling', () => {
       }),
       dispose: vi.fn(),
       getCurrent: vi.fn(() => current),
+      dismissAll: vi.fn(() => {
+        current = null;
+      }),
+      getQueueLength: vi.fn(() => 0),
+      isVisible: vi.fn(() => current !== null),
+      getDismissCount: vi.fn(() => 0),
+      getLastDismissedAt: vi.fn(() => null),
+      setLabels: vi.fn(),
     } satisfies AudioSubtitlesHandle;
 
     const bridge = new AmbientCaptionBridge({
@@ -345,6 +377,14 @@ describe('AmbientCaptionBridge priority handling', () => {
       }),
       dispose: vi.fn(),
       getCurrent: vi.fn(() => current),
+      dismissAll: vi.fn(() => {
+        current = null;
+      }),
+      getQueueLength: vi.fn(() => 0),
+      isVisible: vi.fn(() => current !== null),
+      getDismissCount: vi.fn(() => 0),
+      getLastDismissedAt: vi.fn(() => null),
+      setLabels: vi.fn(),
     };
 
     const bridge = new AmbientCaptionBridge({
@@ -387,6 +427,14 @@ describe('AmbientCaptionBridge priority handling', () => {
       }),
       dispose: vi.fn(),
       getCurrent: vi.fn(() => current),
+      dismissAll: vi.fn(() => {
+        current = null;
+      }),
+      getQueueLength: vi.fn(() => 0),
+      isVisible: vi.fn(() => current !== null),
+      getDismissCount: vi.fn(() => 0),
+      getLastDismissedAt: vi.fn(() => null),
+      setLabels: vi.fn(),
     };
 
     const bridge = new AmbientCaptionBridge({

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -446,14 +446,18 @@ describe('audio subtitles overlay', () => {
     });
 
     expect(handle.getQueueLength()).toBe(1);
-    document
-      .querySelector<HTMLButtonElement>('.audio-subtitles__dismiss')
-      ?.click();
+    const dismissButton = document.querySelector<HTMLButtonElement>(
+      '.audio-subtitles__dismiss'
+    );
+    dismissButton?.focus();
+    expect(document.activeElement).toBe(dismissButton);
+    dismissButton?.click();
 
     expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
       'false'
     );
     expect(handle.getQueueLength()).toBe(0);
+    expect(document.activeElement).not.toBe(dismissButton);
     expect(handle.getDismissCount()).toBe(1);
     expect(handle.getLastDismissedAt()).toBeGreaterThan(0);
 

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -405,4 +405,81 @@ describe('audio subtitles overlay', () => {
 
     handle.dispose();
   });
+
+  it('renders an accessible dismiss button while a message is visible', () => {
+    const handle = createAudioSubtitles();
+
+    handle.show({
+      id: 'poi-narration',
+      text: 'Narration is visible until dismissed.',
+      source: 'poi',
+      durationMs: 5000,
+    });
+
+    const button = document.querySelector<HTMLButtonElement>(
+      '.audio-subtitles__dismiss'
+    );
+    expect(button).toBeTruthy();
+    expect(button?.hidden).toBe(false);
+    expect(button?.getAttribute('aria-label')).toBe('Dismiss narration');
+    expect(button?.tabIndex).toBe(0);
+
+    handle.dispose();
+  });
+
+  it('dismiss button hides the current message and clears queued captions', () => {
+    const handle = createAudioSubtitles();
+
+    handle.show({
+      id: 'poi-narration',
+      text: 'Narration is active.',
+      source: 'poi',
+      priority: 5,
+      durationMs: 5000,
+    });
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Ambient caption is queued.',
+      source: 'ambient',
+      priority: 1,
+      durationMs: 1000,
+    });
+
+    expect(handle.getQueueLength()).toBe(1);
+    document
+      .querySelector<HTMLButtonElement>('.audio-subtitles__dismiss')
+      ?.click();
+
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    expect(handle.getQueueLength()).toBe(0);
+    expect(handle.getDismissCount()).toBe(1);
+    expect(handle.getLastDismissedAt()).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(5000);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
+  it('uses the caption dismiss label for ambient messages', () => {
+    const handle = createAudioSubtitles();
+
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Ambient caption is visible.',
+      source: 'ambient',
+      durationMs: 5000,
+    });
+
+    expect(
+      document
+        .querySelector<HTMLButtonElement>('.audio-subtitles__dismiss')
+        ?.getAttribute('aria-label')
+    ).toBe('Dismiss caption');
+
+    handle.dispose();
+  });
 });

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AVAILABLE_LOCALES,
   formatMessage,
+  getAudioSubtitleStrings,
   getControlOverlayStrings,
   getHelpModalStrings,
   getLocaleDirection,
@@ -11,6 +12,7 @@ import {
   getModeToggleStrings,
   getLocaleScript,
   getLocaleStrings,
+  getNarrationToggleStrings,
   getTourGuideToggleStrings,
   getTourResetControlStrings,
   isI18nDebugEnabled,
@@ -716,6 +718,17 @@ describe('i18n utilities', () => {
     AVAILABLE_LOCALES.forEach((locale) => {
       assertNoMissingStrings(getLocaleStrings(locale), locale);
     });
+  });
+
+  it('localizes narration controls and subtitle labels for Latin locales', () => {
+    expect(getAudioSubtitleStrings('es').dismissLabels.poi).toBe(
+      'Descartar narración'
+    );
+    expect(getAudioSubtitleStrings('pt').labels.ambient).toBe('Áudio ambiente');
+    expect(getNarrationToggleStrings('de').labelEnabled).toBe('Erzählung ein');
+    expect(getNarrationToggleStrings('hu').descriptionDisabled).toContain(
+      'rejtve maradnak'
+    );
   });
 
   it('localizes guided tour controls for Mandarin and pseudo locale', () => {

--- a/src/tests/narrationPreference.test.ts
+++ b/src/tests/narrationPreference.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  LEGACY_NARRATION_PREFERENCE_STORAGE_KEYS,
+  NARRATION_PREFERENCE_STORAGE_KEY,
+  NarrationPreference,
+} from '../systems/narrative/narrationPreference';
+
+class MemoryStorage implements Pick<Storage, 'getItem' | 'setItem'> {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+describe('NarrationPreference', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults off when storage is missing', () => {
+    const preference = new NarrationPreference({ storage: null });
+
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('persists and honors explicit opt-in', () => {
+    const storage = new MemoryStorage();
+    const preference = new NarrationPreference({ storage });
+
+    preference.setEnabled(true, 'control');
+
+    expect(storage.getItem(NARRATION_PREFERENCE_STORAGE_KEY)).toBe('1');
+    expect(new NarrationPreference({ storage }).isEnabled()).toBe(true);
+  });
+
+  it('persists and honors explicit opt-out', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(NARRATION_PREFERENCE_STORAGE_KEY, '1');
+    const preference = new NarrationPreference({ storage });
+
+    preference.setEnabled(false, 'control');
+
+    expect(storage.getItem(NARRATION_PREFERENCE_STORAGE_KEY)).toBe('0');
+    expect(new NarrationPreference({ storage }).isEnabled()).toBe(false);
+  });
+
+  it('does not treat legacy true values as consent', () => {
+    const storage = new MemoryStorage();
+    for (const key of LEGACY_NARRATION_PREFERENCE_STORAGE_KEYS) {
+      storage.setItem(key, '1');
+    }
+
+    const preference = new NarrationPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(false);
+  });
+});

--- a/src/tests/narrationPreference.test.ts
+++ b/src/tests/narrationPreference.test.ts
@@ -60,4 +60,50 @@ describe('NarrationPreference', () => {
 
     expect(preference.isEnabled()).toBe(false);
   });
+
+  it('treats removed storage keys as cross-tab opt-out', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(NARRATION_PREFERENCE_STORAGE_KEY, '1');
+    const preference = new NarrationPreference({
+      storage,
+      windowTarget: window,
+    });
+    const listener = vi.fn();
+
+    preference.subscribe(listener);
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: NARRATION_PREFERENCE_STORAGE_KEY,
+        newValue: null,
+      })
+    );
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(listener).toHaveBeenLastCalledWith({
+      enabled: false,
+      source: 'storage',
+    });
+
+    preference.dispose();
+  });
+
+  it('treats localStorage clear events as cross-tab opt-out', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(NARRATION_PREFERENCE_STORAGE_KEY, '1');
+    const preference = new NarrationPreference({
+      storage,
+      windowTarget: window,
+    });
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: null,
+        newValue: null,
+      })
+    );
+
+    expect(preference.isEnabled()).toBe(false);
+
+    preference.dispose();
+  });
 });

--- a/src/tests/narrationToggleControl.test.ts
+++ b/src/tests/narrationToggleControl.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createNarrationToggleControl } from '../systems/controls/narrationToggleControl';
+
+describe('narrationToggleControl', () => {
+  it('starts off by default and toggles persisted preference callback state', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const onToggle = vi.fn();
+
+    const handle = createNarrationToggleControl({ container, onToggle });
+
+    expect(handle.element.textContent).toBe('Narration off');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('false');
+
+    handle.element.click();
+
+    expect(onToggle).toHaveBeenLastCalledWith(true);
+    expect(handle.element.textContent).toBe('Narration on');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('true');
+
+    handle.element.click();
+
+    expect(onToggle).toHaveBeenLastCalledWith(false);
+    expect(handle.element.textContent).toBe('Narration off');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('false');
+
+    handle.dispose();
+    document.body.innerHTML = '';
+  });
+
+  it('updates labels from preference subscription state', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const handle = createNarrationToggleControl({
+      container,
+      initialEnabled: true,
+    });
+
+    expect(handle.element.textContent).toBe('Narration on');
+
+    handle.setEnabled(false);
+
+    expect(handle.element.textContent).toBe('Narration off');
+
+    handle.dispose();
+    document.body.innerHTML = '';
+  });
+});

--- a/src/ui/hud/audioSubtitles.ts
+++ b/src/ui/hud/audioSubtitles.ts
@@ -280,6 +280,7 @@ export function createAudioSubtitles({
   };
 
   const dismissAll = () => {
+    dismissButton.blur();
     dismissCount += 1;
     lastDismissedAt = Date.now();
     queue.length = 0;

--- a/src/ui/hud/audioSubtitles.ts
+++ b/src/ui/hud/audioSubtitles.ts
@@ -13,15 +13,25 @@ export interface AudioSubtitleMessage {
 export interface AudioSubtitlesHandle {
   show(message: AudioSubtitleMessage): void;
   clear(messageId?: string): void;
+  dismissAll(): void;
+  setLabels(options: {
+    labels?: Partial<Record<AudioSubtitleSource, string>>;
+    dismissLabels?: Partial<Record<AudioSubtitleSource, string>>;
+  }): void;
   dispose(): void;
   /** Returns the currently visible caption if any. */
   getCurrent(): AudioSubtitleMessage | null;
+  getQueueLength(): number;
+  isVisible(): boolean;
+  getDismissCount(): number;
+  getLastDismissedAt(): number | null;
 }
 
 export interface AudioSubtitlesOptions {
   container?: HTMLElement;
   ariaLive?: 'polite' | 'assertive';
   labels?: Partial<Record<AudioSubtitleSource, string>>;
+  dismissLabels?: Partial<Record<AudioSubtitleSource, string>>;
   documentTarget?: Document;
   /**
    * Messages at or above this priority temporarily upgrade the live region to
@@ -47,10 +57,16 @@ const DEFAULT_LABELS: Record<AudioSubtitleSource, string> = {
   poi: 'Narration',
 };
 
+const DEFAULT_DISMISS_LABELS: Record<AudioSubtitleSource, string> = {
+  ambient: 'Dismiss caption',
+  poi: 'Dismiss narration',
+};
+
 export function createAudioSubtitles({
   container = document.body,
   ariaLive = 'polite',
   labels: providedLabels,
+  dismissLabels: providedDismissLabels,
   documentTarget = document,
   assertivePriorityThreshold,
 }: AudioSubtitlesOptions = {}): AudioSubtitlesHandle {
@@ -78,15 +94,28 @@ export function createAudioSubtitles({
 
   root.appendChild(caption);
 
+  const dismissButton = documentTarget.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.className = 'audio-subtitles__dismiss';
+  dismissButton.textContent = '×';
+  dismissButton.hidden = true;
+  root.appendChild(dismissButton);
+
   container.appendChild(root);
 
-  const labels = { ...DEFAULT_LABELS, ...providedLabels };
+  let labels = { ...DEFAULT_LABELS, ...providedLabels };
+  let dismissLabels = {
+    ...DEFAULT_DISMISS_LABELS,
+    ...providedDismissLabels,
+  };
 
   const queue: NormalizedAudioSubtitleMessage[] = [];
   let hideTimeout: number | null = null;
   let current: NormalizedAudioSubtitleMessage | null = null;
   let currentToken: symbol | null = null;
   let announcementSequence = 0;
+  let dismissCount = 0;
+  let lastDismissedAt: number | null = null;
 
   const baseAriaLive = ariaLive;
   const resolvedAssertiveThreshold = resolveAssertivePriorityThreshold(
@@ -188,6 +217,7 @@ export function createAudioSubtitles({
     applyAriaLive(baseAriaLive);
     captionText.textContent = '';
     captionSequence.textContent = '';
+    dismissButton.hidden = true;
     if (advance) {
       void showNextQueued();
     }
@@ -204,6 +234,13 @@ export function createAudioSubtitles({
     }
     label.textContent =
       labels[message.source] ?? DEFAULT_LABELS[message.source];
+    dismissButton.hidden = false;
+    dismissButton.setAttribute(
+      'aria-label',
+      dismissLabels[message.source] ?? DEFAULT_DISMISS_LABELS[message.source]
+    );
+    dismissButton.title =
+      dismissLabels[message.source] ?? DEFAULT_DISMISS_LABELS[message.source];
     captionText.textContent = '';
     captionText.textContent = message.text;
     announcementSequence += 1;
@@ -242,6 +279,19 @@ export function createAudioSubtitles({
     enqueueMessage(normalized);
   };
 
+  const dismissAll = () => {
+    dismissCount += 1;
+    lastDismissedAt = Date.now();
+    queue.length = 0;
+    if (current) {
+      hideCurrent(false);
+    } else {
+      clearTimer();
+    }
+  };
+
+  dismissButton.addEventListener('click', dismissAll);
+
   return {
     show(message) {
       show(message);
@@ -260,7 +310,22 @@ export function createAudioSubtitles({
         hideCurrent(true);
       }
     },
+    dismissAll,
+    setLabels({ labels: nextLabels, dismissLabels: nextDismissLabels }) {
+      labels = { ...DEFAULT_LABELS, ...nextLabels };
+      dismissLabels = { ...DEFAULT_DISMISS_LABELS, ...nextDismissLabels };
+      if (current) {
+        label.textContent =
+          labels[current.source] ?? DEFAULT_LABELS[current.source];
+        const dismissLabel =
+          dismissLabels[current.source] ??
+          DEFAULT_DISMISS_LABELS[current.source];
+        dismissButton.setAttribute('aria-label', dismissLabel);
+        dismissButton.title = dismissLabel;
+      }
+    },
     dispose() {
+      dismissButton.removeEventListener('click', dismissAll);
       queue.length = 0;
       if (current) {
         hideCurrent(false);
@@ -271,6 +336,18 @@ export function createAudioSubtitles({
     },
     getCurrent() {
       return current;
+    },
+    getQueueLength() {
+      return queue.length;
+    },
+    isVisible() {
+      return root.dataset.visible === 'true';
+    },
+    getDismissCount() {
+      return dismissCount;
+    },
+    getLastDismissedAt() {
+      return lastDismissedAt;
     },
   };
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -586,7 +586,6 @@ canvas {
 
 .audio-subtitles[data-visible='true'] {
   opacity: 1;
-  pointer-events: auto;
 }
 
 .audio-subtitles__label {
@@ -616,6 +615,7 @@ canvas {
 
 .audio-subtitles__dismiss {
   position: absolute;
+  pointer-events: auto;
   top: 0.55rem;
   right: 0.65rem;
   width: 1.8rem;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -568,7 +568,7 @@ canvas {
   bottom: 3.5rem;
   transform: translateX(-50%);
   max-width: min(90vw, 36rem);
-  padding: 0.9rem 1.2rem;
+  padding: 0.9rem 3rem 0.9rem 1.2rem;
   border-radius: 0.9rem;
   background: rgba(5, 12, 21, 0.82);
   border: 1px solid rgba(88, 183, 255, 0.32);
@@ -586,6 +586,7 @@ canvas {
 
 .audio-subtitles[data-visible='true'] {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .audio-subtitles__label {
@@ -613,9 +614,31 @@ canvas {
   overflow: hidden;
 }
 
+.audio-subtitles__dismiss {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.65rem;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 208, 255, 0.45);
+  background: rgba(10, 24, 40, 0.72);
+  color: rgba(230, 243, 255, 0.95);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.audio-subtitles__dismiss:hover,
+.audio-subtitles__dismiss:focus-visible {
+  border-color: rgba(148, 208, 255, 0.88);
+  background: rgba(21, 44, 70, 0.92);
+  outline: none;
+}
+
 html[data-hud-layout='mobile'] .audio-subtitles {
   bottom: 6.5rem;
-  padding: 0.85rem 1.05rem;
+  padding: 0.85rem 2.85rem 0.85rem 1.05rem;
   font-size: 0.95rem;
 }
 


### PR DESCRIPTION
### Motivation
- Visible narration/popups were effectively opt-out and could appear by default, and the Settings control did not reliably gate subtitle/toast presentation.  
- Users need an explicit, persistent opt-in that is independent from audio and guided-tour features, and the visible narration overlay must be dismissible immediately.  

### Description
- Add a versioned `NarrationPreference` (storage key `danielsmith.io::narrationEnabled::v1`) that defaults false and ignores legacy truthy keys so stale storage cannot enable narration.  
- Add `createNarrationToggleControl` and a dedicated HUD toggle wired to the new preference so Settings explicitly controls visible narration (separate from guided tour).  
- Gate all visible subtitle/toast paths through a single `showNarrationSubtitle(...)` helper and wire ambient/POI caption paths to it so disabling narration clears active/queued captions.  
- Extend `createAudioSubtitles` with an accessible dismiss button, `dismissAll()`/debug getters, `setLabels(...)` API, localized dismiss labels, and styling for the dismiss affordance.  

### Testing
- `npm run format:write` — passed.  
- `npm run lint` — passed (one import ordering warning fixed).  
- `npm run typecheck` (`tsc --noEmit`) — failed due to existing, repo-wide TypeScript issues unrelated to this change (reported locations such as `src/main.ts` and `src/scene/avatar/importer.ts`); the change itself does not introduce new type regressions in the touched tests.  
- Unit tests: `npm run test:ci -- src/tests/audioSubtitles.test.ts src/tests/narrationPreference.test.ts src/tests/narrationToggleControl.test.ts src/tests/ambientCaptionBridge.test.ts src/tests/i18n.test.ts src/tests/poiNarrativeLog.test.ts` — all targeted tests passed.  
- Full test suite: `npm run test:ci` — all test files passed (139 files, 1023 tests).  
- Build & smoke: `npm run build` and `npm run smoke` — passed and produced valid `dist` artifacts.  
- Docs/link check: `npm run docs:check` — passed; link checker emitted external fetch warnings but no failures.  
- E2E: `npm run test:e2e -- playwright/small-screen-hud.spec.ts` — executed (Playwright browsers were installed as part of the run) and the spec passed.  

Notes: a local preview screenshot for review was captured at `/tmp/narration-settings-open.png`.  Type-check failures reflect pre-existing repo typing issues and should be addressed separately from this feature change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236402a2e8832fa81be988c86a0530)