### PR TITLE
Make narration opt-in and dismissible

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -11,6 +11,7 @@ import { PT_OVERRIDES } from './locales/pt';
 import { ZH_HANS_OVERRIDES } from './locales/zh-Hans';
 import type {
   AudioHudControlStrings,
+  AudioSubtitleStrings,
   ControlOverlayStrings,
   DeepPartial,
   HelpModalStrings,
@@ -23,6 +24,7 @@ import type {
   LocaleToggleStrings,
   ModeAnnouncerStrings,
   ModeToggleResolvedStrings,
+  NarrationToggleStrings,
   MovementLegendStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
@@ -446,6 +448,18 @@ export function getPoiNarrativeLogStrings(
 
 export function getSiteStrings(input?: LocaleInput): SiteStrings {
   return getLocaleStrings(input).site;
+}
+
+export function getNarrationToggleStrings(
+  input?: LocaleInput
+): NarrationToggleStrings {
+  return cloneValue(getLocaleStrings(input).hud.narrationToggle);
+}
+
+export function getAudioSubtitleStrings(
+  input?: LocaleInput
+): AudioSubtitleStrings {
+  return cloneValue(getLocaleStrings(input).hud.audioSubtitles);
 }
 
 export function getTourGuideToggleStrings(

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -299,6 +299,26 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Unable to switch to {target}. Staying on {current} locale.'
       ),
     },
+    narrationToggle: {
+      labelEnabled: wrap('Narration: On'),
+      labelDisabled: wrap('Narration: Off'),
+      descriptionEnabled: wrap(
+        'Disable narration popups and captions. Existing history stays in Settings.'
+      ),
+      descriptionDisabled: wrap(
+        'Enable narration popups and captions for future exhibit and ambient cues.'
+      ),
+    },
+    audioSubtitles: {
+      labels: {
+        ambient: wrap('Ambient caption'),
+        poi: wrap('Narration'),
+      },
+      dismissLabels: {
+        ambient: wrap('Dismiss caption'),
+        poi: wrap('Dismiss narration'),
+      },
+    },
     tourGuideToggle: {
       labelEnabled: wrap('Guided tour on'),
       labelDisabled: wrap('Guided tour off'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -313,6 +313,24 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       failureAnnouncementTemplate:
         'Unable to switch to {target}. Staying on {current} locale.',
     },
+    narrationToggle: {
+      labelEnabled: 'Narration: On',
+      labelDisabled: 'Narration: Off',
+      descriptionEnabled:
+        'Disable narration popups and captions. Existing history stays in Settings.',
+      descriptionDisabled:
+        'Enable narration popups and captions for future exhibit and ambient cues.',
+    },
+    audioSubtitles: {
+      labels: {
+        ambient: 'Ambient caption',
+        poi: 'Narration',
+      },
+      dismissLabels: {
+        ambient: 'Dismiss caption',
+        poi: 'Dismiss narration',
+      },
+    },
     tourGuideToggle: {
       labelEnabled: 'Guided tour on',
       labelDisabled: 'Guided tour off',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -184,6 +184,18 @@ export interface LocaleOptionStrings {
   direction: LocaleDirection;
 }
 
+export interface NarrationToggleStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
+export interface AudioSubtitleStrings {
+  labels: Record<'ambient' | 'poi', string>;
+  dismissLabels: Record<'ambient' | 'poi', string>;
+}
+
 export interface TourGuideToggleStrings {
   labelEnabled: string;
   labelDisabled: string;
@@ -377,6 +389,8 @@ export interface LocaleStrings {
     audioControl: AudioHudControlStrings;
     modeToggle: ModeToggleStrings;
     localeToggle: LocaleToggleStrings;
+    narrationToggle: NarrationToggleStrings;
+    audioSubtitles: AudioSubtitleStrings;
     tourGuideToggle: TourGuideToggleStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,8 @@ import {
   getLocaleToggleStrings,
   getModeAnnouncerStrings,
   getModeToggleStrings,
+  getNarrationToggleStrings,
+  getAudioSubtitleStrings,
   getPoiNarrativeLogStrings,
   getPoiOverlayChromeStrings,
   getSiteStrings,
@@ -317,6 +319,10 @@ import {
   type MotionBlurControlHandle,
 } from './systems/controls/motionBlurControl';
 import {
+  createNarrationToggleControl,
+  type NarrationToggleControlHandle,
+} from './systems/controls/narrationToggleControl';
+import {
   createTourGuideToggleControl,
   type TourGuideToggleControlHandle,
 } from './systems/controls/tourGuideToggleControl';
@@ -369,6 +375,10 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
+import {
+  NarrationPreference,
+  NARRATION_PREFERENCE_STORAGE_KEY,
+} from './systems/narrationPreference';
 import { ProceduralNarrator } from './systems/narrative/proceduralNarrator';
 import { createNavMesh, type NavMesh } from './systems/navigation/navMesh';
 import {
@@ -476,6 +486,17 @@ declare global {
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
+      };
+      narration?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          activeStorageKey: string;
+          currentSubtitle: string | null;
+          queueLength: number;
+          visible: boolean;
+          dismissCount: number;
+          lastDismissedAt: number | null;
+        };
       };
       audio?: {
         getState(): {
@@ -972,6 +993,7 @@ function initializeImmersiveScene(
 
   let inputLatencyTelemetry: InputLatencyTelemetryHandle | null = null;
   let manualModeToggle: ManualModeToggleHandle | null = null;
+  let narrationToggleControl: NarrationToggleControlHandle | null = null;
   let tourGuideToggleControl: TourGuideToggleControlHandle | null = null;
   let tourResetControl: TourResetControlHandle | null = null;
   let hudLayoutManager: HudLayoutManagerHandle | null = null;
@@ -1038,6 +1060,7 @@ function initializeImmersiveScene(
   let removeIdleSubscription: (() => void) | null = null;
   let removeGuidedTourSubscription: (() => void) | null = null;
   let removeGuidedTourPreferenceSubscription: (() => void) | null = null;
+  let removeNarrationPreferenceSubscription: (() => void) | null = null;
   let githubRepoMetrics: GitHubRepoMetricsController | null = null;
   let getAmbientAudioVolume = () =>
     ambientAudioController?.getMasterVolume() ?? 1;
@@ -1110,6 +1133,20 @@ function initializeImmersiveScene(
     audioHudHandle?.refresh();
   };
 
+  const clearVisibleNarration = () => {
+    ambientCaptionBridge?.clear();
+    audioSubtitles?.dismissAll?.();
+  };
+
+  const showNarrationSubtitle = (
+    message: Parameters<AudioSubtitlesHandle['show']>[0]
+  ) => {
+    if (!narrationPreference.isEnabled()) {
+      return;
+    }
+    audioSubtitles?.show(message);
+  };
+
   const getAudioDebugState = () => {
     const snapshots = ambientAudioController?.getBedSnapshots() ?? [];
     const ambientSourcesPlaying = snapshots.map((snapshot) => ({
@@ -1140,12 +1177,42 @@ function initializeImmersiveScene(
     };
   };
 
+  const getNarrationDebugState = () => {
+    const subtitleState = audioSubtitles?.getState?.();
+    return {
+      preferenceEnabled: narrationPreference.isEnabled(),
+      activeStorageKey:
+        narrationPreference.getStorageKey() ?? NARRATION_PREFERENCE_STORAGE_KEY,
+      currentSubtitle: subtitleState?.current?.text ?? null,
+      queueLength: subtitleState?.queueLength ?? 0,
+      visible: subtitleState?.visible ?? false,
+      dismissCount: subtitleState?.dismissCount ?? 0,
+      lastDismissedAt: subtitleState?.lastDismissedAt ?? null,
+    };
+  };
   let localeStorage: Storage | undefined;
   try {
     localeStorage = window.localStorage;
   } catch {
     localeStorage = undefined;
   }
+
+  let narrationStorage: Storage | undefined;
+  try {
+    narrationStorage = window.localStorage;
+  } catch {
+    try {
+      narrationStorage = window.sessionStorage;
+    } catch {
+      narrationStorage = undefined;
+    }
+  }
+
+  const narrationPreference = new NarrationPreference({
+    storage: narrationStorage ?? null,
+    windowTarget: window,
+    defaultEnabled: false,
+  });
 
   let ambientAudioStorage: Storage | undefined;
   try {
@@ -1205,6 +1272,8 @@ function initializeImmersiveScene(
   let audioHudStrings = getAudioHudControlStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
+  let narrationToggleStrings = getNarrationToggleStrings(locale);
+  let audioSubtitleStrings = getAudioSubtitleStrings(locale);
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
   let tourResetControlStrings = getTourResetControlStrings(locale);
   let softwareRendererWarningStrings =
@@ -1977,6 +2046,9 @@ function initializeImmersiveScene(
   window.portfolio.audio = {
     getState: getAudioDebugState,
   };
+  window.portfolio.narration = {
+    getState: getNarrationDebugState,
+  };
   const wirePoiGitHubMetrics = () => {
     githubRepoMetrics?.dispose();
     githubRepoMetrics = wireGitHubRepoMetrics({
@@ -2454,8 +2526,8 @@ function initializeImmersiveScene(
     (poi) => {
       idleMonitor?.reportActivity();
       poiVisitedState.markVisited(poi.id);
-      if (poi.narration?.caption && audioSubtitles) {
-        audioSubtitles.show({
+      if (poi.narration?.caption) {
+        showNarrationSubtitle({
           id: `poi-${poi.id}`,
           text: poi.narration.caption,
           source: 'poi',
@@ -3256,6 +3328,8 @@ function initializeImmersiveScene(
     localeToggleStrings = getLocaleToggleStrings(locale);
     modeToggleStrings = getModeToggleStrings(locale);
     audioHudStrings = getAudioHudControlStrings(locale);
+    narrationToggleStrings = getNarrationToggleStrings(locale);
+    audioSubtitleStrings = getAudioSubtitleStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
@@ -3327,6 +3401,7 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
+    narrationToggleControl?.setStrings(narrationToggleStrings);
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
@@ -3660,7 +3735,19 @@ function initializeImmersiveScene(
   window.addEventListener('pointerup', handlePointerUpForCameraPan);
   window.addEventListener('pointercancel', handlePointerUpForCameraPan);
 
-  audioSubtitles = createAudioSubtitles({ container: document.body });
+  audioSubtitles = createAudioSubtitles({
+    container: document.body,
+    labels: audioSubtitleStrings.labels,
+    dismissLabels: audioSubtitleStrings.dismissLabels,
+  });
+  removeNarrationPreferenceSubscription = narrationPreference.subscribe(
+    ({ enabled }) => {
+      narrationToggleControl?.setEnabled(enabled);
+      if (!enabled) {
+        clearVisibleNarration();
+      }
+    }
+  );
 
   if (!ambientAudioController) {
     const audioBeds: AmbientAudioBedDefinition[] = [];
@@ -3822,6 +3909,16 @@ function initializeImmersiveScene(
       onToggle: activateTextMode,
     });
     registerHudControlElement(manualModeToggle?.element ?? null);
+
+    narrationToggleControl = createNarrationToggleControl({
+      container: hudSettingsStack,
+      initialEnabled: narrationPreference.isEnabled(),
+      onToggle: (enabled) => {
+        narrationPreference.setEnabled(enabled, 'control');
+      },
+      strings: narrationToggleStrings,
+    });
+    registerHudControlElement(narrationToggleControl?.element ?? null);
 
     tourGuideToggleControl = createTourGuideToggleControl({
       container: hudSettingsStack,
@@ -4747,6 +4844,10 @@ function initializeImmersiveScene(
       manualModeToggle.dispose();
       manualModeToggle = null;
     }
+    if (narrationToggleControl) {
+      narrationToggleControl.dispose();
+      narrationToggleControl = null;
+    }
     if (tourGuideToggleControl) {
       tourGuideToggleControl.dispose();
       tourGuideToggleControl = null;
@@ -4893,6 +4994,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.audio) {
       delete window.portfolio.audio;
     }
+    if (window.portfolio?.narration) {
+      delete window.portfolio.narration;
+    }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
     }
@@ -4901,6 +5005,11 @@ function initializeImmersiveScene(
       localeToggleControl = null;
     }
     movementLegend?.dispose();
+    if (removeNarrationPreferenceSubscription) {
+      removeNarrationPreferenceSubscription();
+      removeNarrationPreferenceSubscription = null;
+    }
+    narrationPreference.dispose();
     if (proceduralNarrator) {
       proceduralNarrator.dispose();
       proceduralNarrator = null;
@@ -5069,7 +5178,9 @@ function initializeImmersiveScene(
         ambientAudioController.update(player.position, delta, {
           elapsed: elapsedTime,
         });
-        ambientCaptionBridge?.update();
+        if (narrationPreference.isEnabled()) {
+          ambientCaptionBridge?.update();
+        }
       }
       performanceDiagnostics?.recordPhase(
         'avatarIkAudio',

--- a/src/systems/controls/narrationToggleControl.ts
+++ b/src/systems/controls/narrationToggleControl.ts
@@ -1,0 +1,76 @@
+import type { NarrationToggleStrings } from '../../assets/i18n';
+import { getNarrationToggleStrings } from '../../assets/i18n';
+
+export interface NarrationToggleControlOptions {
+  container: HTMLElement;
+  initialEnabled?: boolean;
+  onToggle?: (enabled: boolean) => void;
+  strings?: NarrationToggleStrings;
+}
+
+export interface NarrationToggleControlHandle {
+  readonly element: HTMLButtonElement;
+  setEnabled(enabled: boolean): void;
+  setStrings(strings: NarrationToggleStrings): void;
+  dispose(): void;
+}
+
+export function createNarrationToggleControl({
+  container,
+  initialEnabled = false,
+  onToggle,
+  strings: providedStrings,
+}: NarrationToggleControlOptions): NarrationToggleControlHandle {
+  const defaultStrings = getNarrationToggleStrings();
+  let strings: NarrationToggleStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+  };
+  let enabled = Boolean(initialEnabled);
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tour-toggle narration-toggle';
+  container.appendChild(button);
+
+  const refresh = () => {
+    const label = enabled ? strings.labelEnabled : strings.labelDisabled;
+    const description = enabled
+      ? strings.descriptionEnabled
+      : strings.descriptionDisabled;
+    button.textContent = label;
+    button.dataset.state = enabled ? 'enabled' : 'disabled';
+    button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    button.setAttribute('aria-label', description);
+    button.title = description;
+    button.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const toggle = () => {
+    enabled = !enabled;
+    refresh();
+    onToggle?.(enabled);
+  };
+
+  button.addEventListener('click', toggle);
+  refresh();
+
+  return {
+    element: button,
+    setEnabled(next) {
+      if (enabled === next) {
+        return;
+      }
+      enabled = next;
+      refresh();
+    },
+    setStrings(nextStrings) {
+      strings = { ...defaultStrings, ...nextStrings };
+      refresh();
+    },
+    dispose() {
+      button.removeEventListener('click', toggle);
+      button.remove();
+    },
+  };
+}

--- a/src/systems/narrationPreference.ts
+++ b/src/systems/narrationPreference.ts
@@ -1,0 +1,172 @@
+export type NarrationPreferenceChangeSource =
+  | 'init'
+  | 'control'
+  | 'storage'
+  | 'api';
+
+export interface NarrationPreferenceChange {
+  readonly enabled: boolean;
+  readonly source: NarrationPreferenceChangeSource;
+}
+
+export interface NarrationPreferenceOptions {
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  storageKey?: string;
+  windowTarget?: Window | null;
+  defaultEnabled?: boolean;
+}
+
+export const NARRATION_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::narrationEnabled::v1';
+
+const parseStoredValue = (value: string | null): boolean | null => {
+  if (value === '1' || value === 'true') {
+    return true;
+  }
+  if (value === '0' || value === 'false') {
+    return false;
+  }
+  return null;
+};
+
+const getDefaultStorage = (
+  target: Window | null
+): Pick<Storage, 'getItem' | 'setItem'> | null => {
+  if (!target) {
+    return null;
+  }
+  try {
+    if (target.localStorage) {
+      return target.localStorage;
+    }
+  } catch (error) {
+    console.warn(
+      'Unable to access localStorage for narration preference.',
+      error
+    );
+  }
+  try {
+    if (target.sessionStorage) {
+      return target.sessionStorage;
+    }
+  } catch (error) {
+    console.warn(
+      'Unable to access sessionStorage for narration preference.',
+      error
+    );
+  }
+  return null;
+};
+
+export class NarrationPreference {
+  private readonly storage: Pick<Storage, 'getItem' | 'setItem'> | null;
+
+  private readonly storageKey: string;
+
+  private readonly windowTarget: Window | null;
+
+  private readonly listeners = new Set<
+    (change: NarrationPreferenceChange) => void
+  >();
+
+  private enabled: boolean;
+
+  constructor(options: NarrationPreferenceOptions = {}) {
+    this.windowTarget =
+      options.windowTarget ?? (typeof window !== 'undefined' ? window : null);
+    this.storage =
+      options.storage === undefined
+        ? getDefaultStorage(this.windowTarget)
+        : options.storage;
+    this.storageKey = options.storageKey ?? NARRATION_PREFERENCE_STORAGE_KEY;
+    this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
+
+    this.windowTarget?.addEventListener('storage', this.handleStorageEvent);
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(
+    enabled: boolean,
+    source: NarrationPreferenceChangeSource = 'control'
+  ): void {
+    if (this.enabled === enabled) {
+      if (source === 'control') {
+        this.persist();
+      }
+      return;
+    }
+    this.enabled = enabled;
+    this.persist();
+    this.notify(source);
+  }
+
+  toggle(source: NarrationPreferenceChangeSource = 'control'): void {
+    this.setEnabled(!this.enabled, source);
+  }
+
+  getStorageKey(): string {
+    return this.storageKey;
+  }
+
+  subscribe(listener: (change: NarrationPreferenceChange) => void): () => void {
+    this.listeners.add(listener);
+    listener({ enabled: this.enabled, source: 'init' });
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  dispose(): void {
+    this.windowTarget?.removeEventListener('storage', this.handleStorageEvent);
+    this.listeners.clear();
+  }
+
+  private loadInitialState(defaultEnabled: boolean): boolean {
+    if (!this.storage?.getItem) {
+      return defaultEnabled;
+    }
+    try {
+      const parsed = parseStoredValue(this.storage.getItem(this.storageKey));
+      return parsed ?? defaultEnabled;
+    } catch (error) {
+      console.warn('Failed to read narration preference from storage.', error);
+      return defaultEnabled;
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage?.setItem) {
+      return;
+    }
+    try {
+      this.storage.setItem(this.storageKey, this.enabled ? '1' : '0');
+    } catch (error) {
+      console.warn('Failed to persist narration preference.', error);
+    }
+  }
+
+  private notify(source: NarrationPreferenceChangeSource): void {
+    const change = {
+      enabled: this.enabled,
+      source,
+    } satisfies NarrationPreferenceChange;
+    for (const listener of this.listeners) {
+      listener(change);
+    }
+  }
+
+  private readonly handleStorageEvent = (event: StorageEvent) => {
+    if (!event.key || event.key !== this.storageKey) {
+      return;
+    }
+    const parsed = parseStoredValue(event.newValue ?? null);
+    if (parsed === null || parsed === this.enabled) {
+      return;
+    }
+    this.enabled = parsed;
+    this.notify('storage');
+  };
+}

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -30,6 +30,75 @@ describe('audio subtitles overlay', () => {
     );
   };
 
+  it('renders an accessible dismiss button while visible', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-narration',
+      text: 'Narration can be dismissed.',
+      source: 'poi',
+      durationMs: 1000,
+    });
+
+    const button = document.querySelector<HTMLButtonElement>(
+      '.audio-subtitles__dismiss'
+    );
+
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect(button?.getAttribute('aria-label')).toBe('Dismiss narration');
+    expect(button?.tabIndex).toBeGreaterThanOrEqual(0);
+    handle.dispose();
+  });
+
+  it('dismisses the active caption immediately and drops queued captions', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-narration',
+      text: 'Long-running narration clip.',
+      source: 'poi',
+      priority: 4,
+      durationMs: 5000,
+    });
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Queued ambient track awaiting playback.',
+      source: 'ambient',
+      priority: 1,
+      durationMs: 600,
+    });
+
+    document
+      .querySelector<HTMLButtonElement>('.audio-subtitles__dismiss')
+      ?.click();
+
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    expect(handle.getState().queueLength).toBe(0);
+    expect(handle.getState().dismissCount).toBe(1);
+    vi.advanceTimersByTime(5000);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
+  it('uses ambient dismiss labels for ambient captions', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'ambient-hum',
+      text: 'Ambient caption can be dismissed.',
+      source: 'ambient',
+      durationMs: 1000,
+    });
+
+    expect(
+      document
+        .querySelector<HTMLButtonElement>('.audio-subtitles__dismiss')
+        ?.getAttribute('aria-label')
+    ).toBe('Dismiss caption');
+    handle.dispose();
+  });
+
   it('shows captions with labels and auto-hides after the configured duration', () => {
     const handle = createAudioSubtitles();
     handle.show({

--- a/src/tests/narrationPreference.test.ts
+++ b/src/tests/narrationPreference.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  NarrationPreference,
+  NARRATION_PREFERENCE_STORAGE_KEY,
+} from '../systems/narrationPreference';
+
+const createStorage = (initial: Record<string, string> = {}) => {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+};
+
+describe('NarrationPreference', () => {
+  it('defaults off when storage is missing', () => {
+    const preference = new NarrationPreference({ storage: null });
+
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors and persists explicit true values', () => {
+    const storage = createStorage({ [NARRATION_PREFERENCE_STORAGE_KEY]: '1' });
+    const preference = new NarrationPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(true);
+    preference.setEnabled(true, 'control');
+
+    expect(storage.getItem(NARRATION_PREFERENCE_STORAGE_KEY)).toBe('1');
+  });
+
+  it('honors and persists explicit false values', () => {
+    const storage = createStorage({ [NARRATION_PREFERENCE_STORAGE_KEY]: '0' });
+    const preference = new NarrationPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(false);
+    preference.setEnabled(true, 'control');
+    preference.setEnabled(false, 'control');
+
+    expect(storage.getItem(NARRATION_PREFERENCE_STORAGE_KEY)).toBe('0');
+  });
+
+  it('ignores legacy true values from unversioned narration storage', () => {
+    const storage = createStorage({
+      'danielsmith.io::narrationEnabled': 'true',
+      'danielsmith.io::guidedTourEnabled::v1': 'true',
+    });
+    const preference = new NarrationPreference({ storage });
+
+    expect(preference.getStorageKey()).toBe(NARRATION_PREFERENCE_STORAGE_KEY);
+    expect(preference.isEnabled()).toBe(false);
+  });
+});

--- a/src/tests/narrationToggleControl.test.ts
+++ b/src/tests/narrationToggleControl.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createNarrationToggleControl } from '../systems/controls/narrationToggleControl';
+
+describe('narrationToggleControl', () => {
+  it('defaults to the off state and toggles persisted preference callbacks', () => {
+    const container = document.createElement('div');
+    const onToggle = vi.fn();
+
+    const handle = createNarrationToggleControl({ container, onToggle });
+
+    expect(handle.element.textContent).toBe('Narration: Off');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('false');
+
+    handle.element.click();
+
+    expect(onToggle).toHaveBeenCalledWith(true);
+    expect(handle.element.textContent).toBe('Narration: On');
+    expect(handle.element.getAttribute('aria-pressed')).toBe('true');
+
+    handle.dispose();
+  });
+
+  it('updates localized strings without changing state', () => {
+    const container = document.createElement('div');
+    const handle = createNarrationToggleControl({
+      container,
+      initialEnabled: true,
+    });
+
+    handle.setStrings({
+      labelEnabled: 'Narración: activada',
+      labelDisabled: 'Narración: desactivada',
+      descriptionEnabled: 'Desactivar narración.',
+      descriptionDisabled: 'Activar narración.',
+    });
+
+    expect(handle.element.textContent).toBe('Narración: activada');
+    expect(handle.element.title).toBe('Desactivar narración.');
+
+    handle.dispose();
+  });
+});

--- a/src/ui/hud/audioSubtitles.ts
+++ b/src/ui/hud/audioSubtitles.ts
@@ -13,15 +13,24 @@ export interface AudioSubtitleMessage {
 export interface AudioSubtitlesHandle {
   show(message: AudioSubtitleMessage): void;
   clear(messageId?: string): void;
+  dismissAll?(): void;
   dispose(): void;
   /** Returns the currently visible caption if any. */
   getCurrent(): AudioSubtitleMessage | null;
+  getState?(): {
+    visible: boolean;
+    current: AudioSubtitleMessage | null;
+    queueLength: number;
+    dismissCount: number;
+    lastDismissedAt: number | null;
+  };
 }
 
 export interface AudioSubtitlesOptions {
   container?: HTMLElement;
   ariaLive?: 'polite' | 'assertive';
   labels?: Partial<Record<AudioSubtitleSource, string>>;
+  dismissLabels?: Partial<Record<AudioSubtitleSource, string>>;
   documentTarget?: Document;
   /**
    * Messages at or above this priority temporarily upgrade the live region to
@@ -47,10 +56,16 @@ const DEFAULT_LABELS: Record<AudioSubtitleSource, string> = {
   poi: 'Narration',
 };
 
+const DEFAULT_DISMISS_LABELS: Record<AudioSubtitleSource, string> = {
+  ambient: 'Dismiss caption',
+  poi: 'Dismiss narration',
+};
+
 export function createAudioSubtitles({
   container = document.body,
   ariaLive = 'polite',
   labels: providedLabels,
+  dismissLabels: providedDismissLabels,
   documentTarget = document,
   assertivePriorityThreshold,
 }: AudioSubtitlesOptions = {}): AudioSubtitlesHandle {
@@ -78,15 +93,24 @@ export function createAudioSubtitles({
 
   root.appendChild(caption);
 
+  const dismissButton = documentTarget.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.className = 'audio-subtitles__dismiss';
+  dismissButton.textContent = '×';
+  root.appendChild(dismissButton);
+
   container.appendChild(root);
 
   const labels = { ...DEFAULT_LABELS, ...providedLabels };
+  const dismissLabels = { ...DEFAULT_DISMISS_LABELS, ...providedDismissLabels };
 
   const queue: NormalizedAudioSubtitleMessage[] = [];
   let hideTimeout: number | null = null;
   let current: NormalizedAudioSubtitleMessage | null = null;
   let currentToken: symbol | null = null;
   let announcementSequence = 0;
+  let dismissCount = 0;
+  let lastDismissedAt: number | null = null;
 
   const baseAriaLive = ariaLive;
   const resolvedAssertiveThreshold = resolveAssertivePriorityThreshold(
@@ -188,6 +212,7 @@ export function createAudioSubtitles({
     applyAriaLive(baseAriaLive);
     captionText.textContent = '';
     captionSequence.textContent = '';
+    dismissButton.setAttribute('aria-label', DEFAULT_DISMISS_LABELS.poi);
     if (advance) {
       void showNextQueued();
     }
@@ -204,6 +229,12 @@ export function createAudioSubtitles({
     }
     label.textContent =
       labels[message.source] ?? DEFAULT_LABELS[message.source];
+    dismissButton.setAttribute(
+      'aria-label',
+      dismissLabels[message.source] ?? DEFAULT_DISMISS_LABELS[message.source]
+    );
+    dismissButton.title =
+      dismissLabels[message.source] ?? DEFAULT_DISMISS_LABELS[message.source];
     captionText.textContent = '';
     captionText.textContent = message.text;
     announcementSequence += 1;
@@ -242,6 +273,19 @@ export function createAudioSubtitles({
     enqueueMessage(normalized);
   };
 
+  const dismissAll = () => {
+    dismissCount += 1;
+    lastDismissedAt = Date.now();
+    queue.length = 0;
+    if (current) {
+      hideCurrent(false);
+    } else {
+      clearTimer();
+    }
+  };
+
+  dismissButton.addEventListener('click', dismissAll);
+
   return {
     show(message) {
       show(message);
@@ -260,7 +304,9 @@ export function createAudioSubtitles({
         hideCurrent(true);
       }
     },
+    dismissAll,
     dispose() {
+      dismissButton.removeEventListener('click', dismissAll);
       queue.length = 0;
       if (current) {
         hideCurrent(false);
@@ -271,6 +317,15 @@ export function createAudioSubtitles({
     },
     getCurrent() {
       return current;
+    },
+    getState() {
+      return {
+        visible: root.dataset.visible === 'true',
+        current,
+        queueLength: queue.length,
+        dismissCount,
+        lastDismissedAt,
+      };
     },
   };
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -568,7 +568,7 @@ canvas {
   bottom: 3.5rem;
   transform: translateX(-50%);
   max-width: min(90vw, 36rem);
-  padding: 0.9rem 1.2rem;
+  padding: 0.9rem 3rem 0.9rem 1.2rem;
   border-radius: 0.9rem;
   background: rgba(5, 12, 21, 0.82);
   border: 1px solid rgba(88, 183, 255, 0.32);
@@ -586,6 +586,30 @@ canvas {
 
 .audio-subtitles[data-visible='true'] {
   opacity: 1;
+  pointer-events: auto;
+}
+
+.audio-subtitles__dismiss {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.65rem;
+  width: 1.8rem;
+  height: 1.8rem;
+  border: 1px solid rgba(148, 208, 255, 0.45);
+  border-radius: 999px;
+  background: rgba(12, 28, 45, 0.72);
+  color: rgba(230, 243, 255, 0.95);
+  cursor: pointer;
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+.audio-subtitles__dismiss:focus-visible,
+.audio-subtitles__dismiss:hover {
+  border-color: rgba(151, 222, 255, 0.9);
+  background: rgba(30, 68, 100, 0.88);
+  outline: 2px solid rgba(151, 222, 255, 0.42);
+  outline-offset: 2px;
 }
 
 .audio-subtitles__label {
@@ -615,7 +639,7 @@ canvas {
 
 html[data-hud-layout='mobile'] .audio-subtitles {
   bottom: 6.5rem;
-  padding: 0.85rem 1.05rem;
+  padding: 0.85rem 3rem 0.85rem 1.05rem;
   font-size: 0.95rem;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent visible narration/caption overlays from appearing without explicit user consent by treating narration as its own opt-in preference separate from guided tour highlights.
- Provide an immediate, accessible way for users to dismiss visible narration without waiting for auto-hide timers.
- Expose a small debug surface so staging can verify narration state and recent dismiss activity.

### Description
- Add a versioned `NarrationPreference` that defaults to `false` and persists user choice under `danielsmith.io::narrationEnabled::v1`, ignoring legacy unversioned keys. (new: `src/systems/narrationPreference.ts`)
- Add a HUD Settings toggle control `createNarrationToggleControl` wired to the `NarrationPreference` so guided-tour and narration are managed independently. (new: `src/systems/controls/narrationToggleControl.ts`, wired in `src/main.ts`)
- Gate visible subtitle/narration pathways through the narration preference by adding a `showNarrationSubtitle(...)` helper and clearing active/queued narration when disabled. POI and ambient caption emission now call the helper instead of calling `audioSubtitles.show` directly. (`src/main.ts`)
- Make the audio subtitles overlay dismissible: add a keyboard-focusable dismiss button, `dismissAll()` behavior, and `getState()` diagnostics on the `AudioSubtitlesHandle`, and style the dismiss control to match the HUD. (`src/ui/hud/audioSubtitles.ts`, `src/ui/styles.css`)
- Add localized strings and types for the narration toggle and subtitle/dismiss labels and surface i18n accessors. (`src/assets/i18n/*`)
- Add `window.portfolio.narration.getState()` to return preference and overlay debug info (current subtitle, queue length, dismiss count, last dismissed timestamp). (`src/main.ts`)
- Tests: add focused unit tests for the narration preference, the narration toggle control, and subtitle dismiss behavior; update subtitle tests to assert dismiss semantics. (`src/tests/*.test.ts`)

### Testing
- Format and lint: ran `npm run format:write` and `npm run lint`, both succeeded.
- Typecheck: ran `npm run typecheck`; noted that unrelated pre-existing TypeScript issues in other test/type mocks surfaced earlier and are not introduced by this change, so typecheck was recorded as problematic for unrelated code (see CI note); narration-specific surface was implemented with minimal type surface changes to avoid broad refactors.
- Unit tests: ran `npm run test:ci` (Vitest) for focused and full suites and observed successful results including the final full run: all Vitest tests passed (1000+ tests in this environment).
- Build & docs: ran `npm run build`, `npm run docs:check` and `npm run smoke`, all succeeded (link checker produced external fetch warnings but no failures for included changes).
- End-to-end: installed Playwright browsers and host deps with `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium`, then ran `npm run test:e2e -- playwright/small-screen-hud.spec.ts`, which passed in this environment.

Commands used (indicative):
- `npm run format:write`
- `npm run lint`
- `npm run typecheck` (see note about unrelated TS issues)
- `npm run test:ci` and `npm run test:ci -- <files>` (Vitest)
- `npm run build`
- `npm run docs:check`
- `npm run smoke`
- `npx playwright install chromium-headless-shell`
- `npx playwright install-deps chromium`
- `npm run test:e2e -- playwright/small-screen-hud.spec.ts`

Residual risks / follow-ups: update any external tooling that relied on the old legacy/unversioned storage key if cross-product compatibility is needed; confirm i18n strings for all public locales beyond the added English/pseudo variants; consider adding an audit log or analytics event when users opt into narration if that is desired for telemetry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236402a2e8832fa81be988c86a0530)