### PR TITLE
Make narration opt-in and dismissible

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -11,6 +11,7 @@ import { PT_OVERRIDES } from './locales/pt';
 import { ZH_HANS_OVERRIDES } from './locales/zh-Hans';
 import type {
   AudioHudControlStrings,
+  AudioSubtitleOverlayStrings,
   ControlOverlayStrings,
   DeepPartial,
   HelpModalStrings,
@@ -23,6 +24,7 @@ import type {
   LocaleToggleStrings,
   ModeAnnouncerStrings,
   ModeToggleResolvedStrings,
+  NarrationToggleStrings,
   MovementLegendStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
@@ -452,6 +454,18 @@ export function getTourGuideToggleStrings(
   input?: LocaleInput
 ): TourGuideToggleStrings {
   return cloneValue(getLocaleStrings(input).hud.tourGuideToggle);
+}
+
+export function getNarrationToggleStrings(
+  input?: LocaleInput
+): NarrationToggleStrings {
+  return cloneValue(getLocaleStrings(input).hud.narrationToggle);
+}
+
+export function getAudioSubtitleOverlayStrings(
+  input?: LocaleInput
+): AudioSubtitleOverlayStrings {
+  return cloneValue(getLocaleStrings(input).hud.audioSubtitles);
 }
 
 export function getTourResetControlStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -158,6 +158,23 @@ export const AR_OVERRIDES: LocaleOverrides = {
     },
   },
   hud: {
+    narrationToggle: {
+      labelEnabled: 'السرد: تشغيل',
+      labelDisabled: 'السرد: إيقاف',
+      descriptionEnabled: 'تظهر نوافذ السرد والتعليقات. فعّل لإخفائها.',
+      descriptionDisabled:
+        'تبقى نوافذ السرد والتعليقات مخفية حتى تختار تشغيلها.',
+    },
+    audioSubtitles: {
+      labels: {
+        ambient: 'تعليق',
+        poi: 'سرد',
+      },
+      dismissLabels: {
+        ambient: 'إغلاق التعليق',
+        poi: 'إغلاق السرد',
+      },
+    },
     controlOverlay: {
       heading: 'عناصر التحكم',
       items: {

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -37,6 +37,16 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
     guidedTour: 'Geführte Tour',
     guidedTourOn: 'Geführte Tour an',
     guidedTourOff: 'Geführte Tour aus',
+    narrationOn: 'Erzählung: Ein',
+    narrationOff: 'Erzählung: Aus',
+    narrationDescriptionOn:
+      'Erzähl-Popups und Untertitel werden angezeigt. Aktivieren blendet sie aus.',
+    narrationDescriptionOff:
+      'Erzähl-Popups und Untertitel bleiben ausgeblendet, bis du sie aktivierst.',
+    captionLabel: 'Untertitel',
+    narrationLabel: 'Erzählung',
+    dismissCaption: 'Untertitel schließen',
+    dismissNarration: 'Erzählung schließen',
     audioOn: 'Audio: an',
     audioOff: 'Audio: aus',
   },

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -309,6 +309,26 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Guided tour highlights are hidden until you turn them back on.'
       ),
     },
+    narrationToggle: {
+      labelEnabled: wrap('Narration: On'),
+      labelDisabled: wrap('Narration: Off'),
+      descriptionEnabled: wrap(
+        'Narration popups and captions are shown. Activate to hide them.'
+      ),
+      descriptionDisabled: wrap(
+        'Narration popups and captions are hidden until you opt in.'
+      ),
+    },
+    audioSubtitles: {
+      labels: {
+        ambient: wrap('Caption'),
+        poi: wrap('Narration'),
+      },
+      dismissLabels: {
+        ambient: wrap('Dismiss caption'),
+        poi: wrap('Dismiss narration'),
+      },
+    },
     tourReset: {
       heading: wrap('Guided tour'),
       resetKey: 'g',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -321,6 +321,24 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       descriptionDisabled:
         'Guided tour highlights are hidden until you turn them back on.',
     },
+    narrationToggle: {
+      labelEnabled: 'Narration: On',
+      labelDisabled: 'Narration: Off',
+      descriptionEnabled:
+        'Narration popups and captions are shown. Activate to hide them.',
+      descriptionDisabled:
+        'Narration popups and captions are hidden until you opt in.',
+    },
+    audioSubtitles: {
+      labels: {
+        ambient: 'Caption',
+        poi: 'Narration',
+      },
+      dismissLabels: {
+        ambient: 'Dismiss caption',
+        poi: 'Dismiss narration',
+      },
+    },
     tourReset: {
       heading: 'Guided tour',
       resetKey: 'g',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -37,6 +37,16 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
     guidedTour: 'Visita guiada',
     guidedTourOn: 'Visita guiada activada',
     guidedTourOff: 'Visita guiada desactivada',
+    narrationOn: 'Narración: activada',
+    narrationOff: 'Narración: desactivada',
+    narrationDescriptionOn:
+      'Se muestran ventanas y subtítulos de narración. Activa para ocultarlos.',
+    narrationDescriptionOff:
+      'Las ventanas y subtítulos de narración están ocultos hasta que los actives.',
+    captionLabel: 'Subtítulo',
+    narrationLabel: 'Narración',
+    dismissCaption: 'Cerrar subtítulo',
+    dismissNarration: 'Cerrar narración',
     audioOn: 'Audio: activado',
     audioOff: 'Audio: desactivado',
   },

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -37,6 +37,16 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
     guidedTour: 'Vezetett túra',
     guidedTourOn: 'Vezetett túra be',
     guidedTourOff: 'Vezetett túra ki',
+    narrationOn: 'Narráció: be',
+    narrationOff: 'Narráció: ki',
+    narrationDescriptionOn:
+      'A narrációs felugrók és feliratok láthatók. Aktiváld az elrejtéshez.',
+    narrationDescriptionOff:
+      'A narrációs felugrók és feliratok rejtve maradnak, amíg be nem kapcsolod.',
+    captionLabel: 'Felirat',
+    narrationLabel: 'Narráció',
+    dismissCaption: 'Felirat bezárása',
+    dismissNarration: 'Narráció bezárása',
     audioOn: 'Hang: be',
     audioOff: 'Hang: ki',
   },

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -159,6 +159,24 @@ export const JA_OVERRIDES: LocaleOverrides = {
     },
   },
   hud: {
+    narrationToggle: {
+      labelEnabled: 'ナレーション: オン',
+      labelDisabled: 'ナレーション: オフ',
+      descriptionEnabled:
+        'ナレーションのポップアップと字幕を表示します。押すと非表示にします。',
+      descriptionDisabled:
+        'ナレーションのポップアップと字幕は、オンにするまで非表示です。',
+    },
+    audioSubtitles: {
+      labels: {
+        ambient: '字幕',
+        poi: 'ナレーション',
+      },
+      dismissLabels: {
+        ambient: '字幕を閉じる',
+        poi: 'ナレーションを閉じる',
+      },
+    },
     controlOverlay: {
       heading: '操作',
       items: {

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -40,6 +40,14 @@ interface LatinLocaleCopy {
     guidedTour: string;
     guidedTourOn: string;
     guidedTourOff: string;
+    narrationOn: string;
+    narrationOff: string;
+    narrationDescriptionOn: string;
+    narrationDescriptionOff: string;
+    captionLabel: string;
+    narrationLabel: string;
+    dismissCaption: string;
+    dismissNarration: string;
     audioOn: string;
     audioOff: string;
   };
@@ -675,6 +683,22 @@ export function buildLatinLocaleOverrides(
         labelDisabled: s.guidedTourOff,
         descriptionEnabled: s.guidedTour,
         descriptionDisabled: s.guidedTour,
+      },
+      narrationToggle: {
+        labelEnabled: s.narrationOn,
+        labelDisabled: s.narrationOff,
+        descriptionEnabled: s.narrationDescriptionOn,
+        descriptionDisabled: s.narrationDescriptionOff,
+      },
+      audioSubtitles: {
+        labels: {
+          ambient: s.captionLabel,
+          poi: s.narrationLabel,
+        },
+        dismissLabels: {
+          ambient: s.dismissCaption,
+          poi: s.dismissNarration,
+        },
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -37,6 +37,16 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
     guidedTour: 'Visita guiada',
     guidedTourOn: 'Visita guiada ativada',
     guidedTourOff: 'Visita guiada desativada',
+    narrationOn: 'Narração: ativada',
+    narrationOff: 'Narração: desativada',
+    narrationDescriptionOn:
+      'Pop-ups e legendas de narração aparecem. Ative para ocultá-los.',
+    narrationDescriptionOff:
+      'Pop-ups e legendas de narração ficam ocultos até você ativar.',
+    captionLabel: 'Legenda',
+    narrationLabel: 'Narração',
+    dismissCaption: 'Fechar legenda',
+    dismissNarration: 'Fechar narração',
     audioOn: 'Áudio: ligado',
     audioOff: 'Áudio: desligado',
   },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -249,6 +249,22 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       descriptionEnabled: '高亮沉浸式导览中下一个推荐展品。',
       descriptionDisabled: '导览高亮已隐藏，直到你重新开启。',
     },
+    narrationToggle: {
+      labelEnabled: '旁白：开启',
+      labelDisabled: '旁白：关闭',
+      descriptionEnabled: '显示旁白弹窗和字幕。激活后可隐藏。',
+      descriptionDisabled: '旁白弹窗和字幕已隐藏，直到你选择开启。',
+    },
+    audioSubtitles: {
+      labels: {
+        ambient: '字幕',
+        poi: '旁白',
+      },
+      dismissLabels: {
+        ambient: '关闭字幕',
+        poi: '关闭旁白',
+      },
+    },
     tourReset: {
       heading: '导览',
       resetKey: 'g',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -191,6 +191,18 @@ export interface TourGuideToggleStrings {
   descriptionDisabled: string;
 }
 
+export interface NarrationToggleStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
+export interface AudioSubtitleOverlayStrings {
+  labels: Record<'ambient' | 'poi', string>;
+  dismissLabels: Record<'ambient' | 'poi', string>;
+}
+
 export interface TourResetControlStrings {
   heading: string;
   resetKey: string;
@@ -378,6 +390,8 @@ export interface LocaleStrings {
     modeToggle: ModeToggleStrings;
     localeToggle: LocaleToggleStrings;
     tourGuideToggle: TourGuideToggleStrings;
+    narrationToggle: NarrationToggleStrings;
+    audioSubtitles: AudioSubtitleOverlayStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import { createWallSegmentInstances } from './assets/floorPlan/wallSegments';
 import {
   formatMessage,
   getAudioHudControlStrings,
+  getAudioSubtitleOverlayStrings,
   getControlOverlayStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
@@ -50,6 +51,7 @@ import {
   getLocaleToggleStrings,
   getModeAnnouncerStrings,
   getModeToggleStrings,
+  getNarrationToggleStrings,
   getPoiNarrativeLogStrings,
   getPoiOverlayChromeStrings,
   getSiteStrings,
@@ -317,6 +319,10 @@ import {
   type MotionBlurControlHandle,
 } from './systems/controls/motionBlurControl';
 import {
+  createNarrationToggleControl,
+  type NarrationToggleControlHandle,
+} from './systems/controls/narrationToggleControl';
+import {
   createTourGuideToggleControl,
   type TourGuideToggleControlHandle,
 } from './systems/controls/tourGuideToggleControl';
@@ -369,6 +375,10 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
+import {
+  NARRATION_PREFERENCE_STORAGE_KEY,
+  NarrationPreference,
+} from './systems/narrative/narrationPreference';
 import { ProceduralNarrator } from './systems/narrative/proceduralNarrator';
 import { createNavMesh, type NavMesh } from './systems/navigation/navMesh';
 import {
@@ -495,6 +505,18 @@ declare global {
           audioContextState: AudioContextState | 'unknown';
           storageKeyVersion: string;
           activeStorageKey: string;
+        };
+      };
+      narration?: {
+        getState(): {
+          preferenceEnabled: boolean;
+          activeStorageKey: string;
+          currentSubtitle: string | null;
+          currentSource: string | null;
+          queueLength: number;
+          visible: boolean;
+          dismissCount: number;
+          lastDismissedAt: number | null;
         };
       };
       graphics?: {
@@ -973,6 +995,7 @@ function initializeImmersiveScene(
   let inputLatencyTelemetry: InputLatencyTelemetryHandle | null = null;
   let manualModeToggle: ManualModeToggleHandle | null = null;
   let tourGuideToggleControl: TourGuideToggleControlHandle | null = null;
+  let narrationToggleControl: NarrationToggleControlHandle | null = null;
   let tourResetControl: TourResetControlHandle | null = null;
   let hudLayoutManager: HudLayoutManagerHandle | null = null;
   let responsiveControlOverlay: ResponsiveControlOverlayHandle | null = null;
@@ -982,6 +1005,7 @@ function initializeImmersiveScene(
   let audioHudHandle: AudioHudControlHandle | null = null;
   let motionBlurControl: MotionBlurControlHandle | null = null;
   let audioSubtitles: AudioSubtitlesHandle | null = null;
+  let narrationPreference: NarrationPreference | null = null;
   let ambientCaptionBridge: AmbientCaptionBridge | null = null;
   let graphicsQualityManager: GraphicsQualityManager | null = null;
   let graphicsQualityControl: GraphicsQualityControlHandle | null = null;
@@ -1038,6 +1062,7 @@ function initializeImmersiveScene(
   let removeIdleSubscription: (() => void) | null = null;
   let removeGuidedTourSubscription: (() => void) | null = null;
   let removeGuidedTourPreferenceSubscription: (() => void) | null = null;
+  let removeNarrationPreferenceSubscription: (() => void) | null = null;
   let githubRepoMetrics: GitHubRepoMetricsController | null = null;
   let getAmbientAudioVolume = () =>
     ambientAudioController?.getMasterVolume() ?? 1;
@@ -1140,6 +1165,33 @@ function initializeImmersiveScene(
     };
   };
 
+  const isNarrationEnabled = () => narrationPreference?.isEnabled() ?? false;
+
+  const clearVisibleNarration = () => {
+    ambientCaptionBridge?.clear();
+    audioSubtitles?.dismissAll?.();
+  };
+
+  const setNarrationEnabled = (enabled: boolean) => {
+    narrationPreference?.setEnabled(enabled, 'control');
+  };
+
+  const getNarrationDebugState = () => {
+    const subtitleState = audioSubtitles?.getState?.();
+    return {
+      preferenceEnabled: isNarrationEnabled(),
+      activeStorageKey:
+        narrationPreference?.getStorageKey() ??
+        NARRATION_PREFERENCE_STORAGE_KEY,
+      currentSubtitle: subtitleState?.current?.text ?? null,
+      currentSource: subtitleState?.current?.source ?? null,
+      queueLength: subtitleState?.queueLength ?? 0,
+      visible: subtitleState?.visible ?? false,
+      dismissCount: subtitleState?.dismissCount ?? 0,
+      lastDismissedAt: subtitleState?.lastDismissedAt ?? null,
+    };
+  };
+
   let localeStorage: Storage | undefined;
   try {
     localeStorage = window.localStorage;
@@ -1166,6 +1218,11 @@ function initializeImmersiveScene(
 
   const guidedTourPreference = new GuidedTourPreference({
     storageKey: GUIDED_TOUR_STORAGE_KEY,
+    windowTarget: window,
+    defaultEnabled: false,
+  });
+
+  narrationPreference = new NarrationPreference({
     windowTarget: window,
     defaultEnabled: false,
   });
@@ -1203,6 +1260,8 @@ function initializeImmersiveScene(
   let localeToggleStrings = getLocaleToggleStrings(locale);
   let modeToggleStrings = getModeToggleStrings(locale);
   let audioHudStrings = getAudioHudControlStrings(locale);
+  let audioSubtitleStrings = getAudioSubtitleOverlayStrings(locale);
+  let narrationToggleStrings = getNarrationToggleStrings(locale);
   let narrativeLogStrings = getPoiNarrativeLogStrings(locale);
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
@@ -1977,6 +2036,9 @@ function initializeImmersiveScene(
   window.portfolio.audio = {
     getState: getAudioDebugState,
   };
+  window.portfolio.narration = {
+    getState: getNarrationDebugState,
+  };
   const wirePoiGitHubMetrics = () => {
     githubRepoMetrics?.dispose();
     githubRepoMetrics = wireGitHubRepoMetrics({
@@ -2454,7 +2516,7 @@ function initializeImmersiveScene(
     (poi) => {
       idleMonitor?.reportActivity();
       poiVisitedState.markVisited(poi.id);
-      if (poi.narration?.caption && audioSubtitles) {
+      if (poi.narration?.caption && audioSubtitles && isNarrationEnabled()) {
         audioSubtitles.show({
           id: `poi-${poi.id}`,
           text: poi.narration.caption,
@@ -3256,6 +3318,8 @@ function initializeImmersiveScene(
     localeToggleStrings = getLocaleToggleStrings(locale);
     modeToggleStrings = getModeToggleStrings(locale);
     audioHudStrings = getAudioHudControlStrings(locale);
+    audioSubtitleStrings = getAudioSubtitleOverlayStrings(locale);
+    narrationToggleStrings = getNarrationToggleStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
@@ -3322,6 +3386,11 @@ function initializeImmersiveScene(
     }
     manualModeToggle?.setStrings(modeToggleStrings);
     audioHudHandle?.setStrings(audioHudStrings);
+    narrationToggleControl?.setStrings(narrationToggleStrings);
+    audioSubtitles?.setStrings?.({
+      labels: audioSubtitleStrings.labels,
+      dismissLabels: audioSubtitleStrings.dismissLabels,
+    });
     softwareRendererWarning?.setStrings(softwareRendererWarningStrings);
     helpModal.setContent(helpModalStrings);
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
@@ -3660,7 +3729,20 @@ function initializeImmersiveScene(
   window.addEventListener('pointerup', handlePointerUpForCameraPan);
   window.addEventListener('pointercancel', handlePointerUpForCameraPan);
 
-  audioSubtitles = createAudioSubtitles({ container: document.body });
+  audioSubtitles = createAudioSubtitles({
+    container: document.body,
+    labels: audioSubtitleStrings.labels,
+    dismissLabels: audioSubtitleStrings.dismissLabels,
+  });
+
+  removeNarrationPreferenceSubscription = narrationPreference.subscribe(
+    ({ enabled }) => {
+      narrationToggleControl?.setEnabled(enabled);
+      if (!enabled) {
+        clearVisibleNarration();
+      }
+    }
+  );
 
   if (!ambientAudioController) {
     const audioBeds: AmbientAudioBedDefinition[] = [];
@@ -3794,6 +3876,7 @@ function initializeImmersiveScene(
       ambientCaptionBridge = new AmbientCaptionBridge({
         controller: ambientAudioController,
         subtitles: audioSubtitles,
+        isEnabled: isNarrationEnabled,
       });
     }
 
@@ -3832,6 +3915,14 @@ function initializeImmersiveScene(
       strings: tourGuideToggleStrings,
     });
     registerHudControlElement(tourGuideToggleControl?.element ?? null);
+
+    narrationToggleControl = createNarrationToggleControl({
+      container: hudSettingsStack,
+      initialEnabled: isNarrationEnabled(),
+      onToggle: setNarrationEnabled,
+      strings: narrationToggleStrings,
+    });
+    registerHudControlElement(narrationToggleControl?.element ?? null);
 
     tourResetControl = createTourResetControl({
       container: hudSettingsStack,
@@ -4732,9 +4823,15 @@ function initializeImmersiveScene(
       removeGuidedTourPreferenceSubscription();
       removeGuidedTourPreferenceSubscription = null;
     }
+    if (removeNarrationPreferenceSubscription) {
+      removeNarrationPreferenceSubscription();
+      removeNarrationPreferenceSubscription = null;
+    }
     guidedTourChannel?.dispose();
     guidedTourChannel = null;
     guidedTourPreference.dispose();
+    narrationPreference?.dispose();
+    narrationPreference = null;
     if (githubRepoMetrics) {
       githubRepoMetrics.dispose();
       githubRepoMetrics = null;
@@ -4750,6 +4847,10 @@ function initializeImmersiveScene(
     if (tourGuideToggleControl) {
       tourGuideToggleControl.dispose();
       tourGuideToggleControl = null;
+    }
+    if (narrationToggleControl) {
+      narrationToggleControl.dispose();
+      narrationToggleControl = null;
     }
     if (tourResetControl) {
       tourResetControl.dispose();
@@ -4892,6 +4993,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.audio) {
       delete window.portfolio.audio;
+    }
+    if (window.portfolio?.narration) {
+      delete window.portfolio.narration;
     }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;

--- a/src/systems/audio/ambientCaptionBridge.ts
+++ b/src/systems/audio/ambientCaptionBridge.ts
@@ -10,6 +10,7 @@ export interface AmbientCaptionBridgeOptions {
   subtitles: AudioSubtitlesHandle;
   cooldownMs?: number;
   now?: () => number;
+  isEnabled?: () => boolean;
 }
 
 interface AmbientCaptionState {
@@ -47,6 +48,8 @@ export class AmbientCaptionBridge {
 
   private readonly now: () => number;
 
+  private readonly isEnabled: () => boolean;
+
   private readonly states = new Map<string, AmbientCaptionState>();
 
   private readonly messageIds = new Set<string>();
@@ -57,11 +60,13 @@ export class AmbientCaptionBridge {
     cooldownMs = DEFAULT_COOLDOWN_MS,
     now = () =>
       typeof performance !== 'undefined' ? performance.now() : Date.now(),
+    isEnabled = () => true,
   }: AmbientCaptionBridgeOptions) {
     this.controller = controller;
     this.subtitles = subtitles;
     this.cooldownMs = Math.max(0, cooldownMs);
     this.now = now;
+    this.isEnabled = isEnabled;
   }
 
   clear(): void {
@@ -73,6 +78,11 @@ export class AmbientCaptionBridge {
   }
 
   update(): void {
+    if (!this.isEnabled()) {
+      this.clear();
+      return;
+    }
+
     const snapshots = this.controller.getBedSnapshots();
     const snapshotIds = new Set<string>();
     const currentTime = this.now();

--- a/src/systems/controls/narrationToggleControl.ts
+++ b/src/systems/controls/narrationToggleControl.ts
@@ -1,0 +1,80 @@
+import type { NarrationToggleStrings } from '../../assets/i18n';
+import { getNarrationToggleStrings } from '../../assets/i18n';
+
+export interface NarrationToggleControlOptions {
+  container: HTMLElement;
+  initialEnabled?: boolean;
+  onToggle?: (enabled: boolean) => void;
+  strings?: NarrationToggleStrings;
+}
+
+export interface NarrationToggleControlHandle {
+  readonly element: HTMLButtonElement;
+  setEnabled(enabled: boolean): void;
+  setStrings(strings: NarrationToggleStrings): void;
+  dispose(): void;
+}
+
+export function createNarrationToggleControl({
+  container,
+  initialEnabled = false,
+  onToggle,
+  strings: providedStrings,
+}: NarrationToggleControlOptions): NarrationToggleControlHandle {
+  const defaultStrings = getNarrationToggleStrings();
+  let strings: NarrationToggleStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+  };
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tour-toggle narration-toggle';
+  container.appendChild(button);
+
+  let enabled = Boolean(initialEnabled);
+
+  const getLabel = () =>
+    enabled ? strings.labelEnabled : strings.labelDisabled;
+  const getDescription = () =>
+    enabled ? strings.descriptionEnabled : strings.descriptionDisabled;
+
+  const refresh = () => {
+    const label = getLabel();
+    const description = getDescription();
+    button.textContent = label;
+    button.dataset.state = enabled ? 'enabled' : 'disabled';
+    button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    button.setAttribute('aria-label', description);
+    button.title = description;
+    button.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const toggle = () => {
+    enabled = !enabled;
+    refresh();
+    onToggle?.(enabled);
+  };
+
+  button.addEventListener('click', toggle);
+  refresh();
+
+  return {
+    element: button,
+    setEnabled(next) {
+      if (enabled === next) {
+        return;
+      }
+      enabled = next;
+      refresh();
+    },
+    setStrings(nextStrings) {
+      strings = { ...defaultStrings, ...nextStrings };
+      refresh();
+    },
+    dispose() {
+      button.removeEventListener('click', toggle);
+      button.remove();
+    },
+  };
+}

--- a/src/systems/narrative/narrationPreference.ts
+++ b/src/systems/narrative/narrationPreference.ts
@@ -1,0 +1,170 @@
+export type NarrationPreferenceChangeSource =
+  | 'init'
+  | 'control'
+  | 'storage'
+  | 'api';
+
+export interface NarrationPreferenceChange {
+  readonly enabled: boolean;
+  readonly source: NarrationPreferenceChangeSource;
+}
+
+export interface NarrationPreferenceOptions {
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  storageKey?: string;
+  windowTarget?: Window | null;
+  defaultEnabled?: boolean;
+}
+
+export const NARRATION_PREFERENCE_STORAGE_KEY =
+  'danielsmith.io::narrationEnabled::v1';
+
+const parseStoredValue = (value: string | null): boolean | null => {
+  if (value === '1' || value === 'true') {
+    return true;
+  }
+  if (value === '0' || value === 'false') {
+    return false;
+  }
+  return null;
+};
+
+const getDefaultStorage = (
+  target: Window | null
+): Pick<Storage, 'getItem' | 'setItem'> | null => {
+  if (!target) {
+    return null;
+  }
+  try {
+    if (target.localStorage) {
+      return target.localStorage;
+    }
+  } catch (error) {
+    console.warn(
+      'Unable to access localStorage for narration preference.',
+      error
+    );
+  }
+  try {
+    if (target.sessionStorage) {
+      return target.sessionStorage;
+    }
+  } catch (error) {
+    console.warn(
+      'Unable to access sessionStorage for narration preference.',
+      error
+    );
+  }
+  return null;
+};
+
+export class NarrationPreference {
+  private readonly storage: Pick<Storage, 'getItem' | 'setItem'> | null;
+
+  private readonly storageKey: string;
+
+  private readonly windowTarget: Window | null;
+
+  private readonly listeners = new Set<
+    (change: NarrationPreferenceChange) => void
+  >();
+
+  private enabled: boolean;
+
+  constructor(options: NarrationPreferenceOptions = {}) {
+    this.windowTarget =
+      options.windowTarget ?? (typeof window !== 'undefined' ? window : null);
+    this.storage =
+      options.storage === undefined
+        ? getDefaultStorage(this.windowTarget)
+        : options.storage;
+    this.storageKey = options.storageKey ?? NARRATION_PREFERENCE_STORAGE_KEY;
+    this.enabled = this.loadInitialState(options.defaultEnabled ?? false);
+
+    if (this.windowTarget) {
+      this.windowTarget.addEventListener('storage', this.handleStorageEvent);
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(
+    enabled: boolean,
+    source: NarrationPreferenceChangeSource = 'control'
+  ): void {
+    if (this.enabled === enabled) {
+      if (source === 'control') {
+        this.persist();
+      }
+      return;
+    }
+    this.enabled = enabled;
+    this.persist();
+    this.notify(source);
+  }
+
+  getStorageKey(): string {
+    return this.storageKey;
+  }
+
+  subscribe(listener: (change: NarrationPreferenceChange) => void): () => void {
+    this.listeners.add(listener);
+    listener({ enabled: this.enabled, source: 'init' });
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  dispose(): void {
+    if (this.windowTarget) {
+      this.windowTarget.removeEventListener('storage', this.handleStorageEvent);
+    }
+    this.listeners.clear();
+  }
+
+  private loadInitialState(defaultEnabled: boolean): boolean {
+    if (!this.storage?.getItem) {
+      return defaultEnabled;
+    }
+    try {
+      const stored = this.storage.getItem(this.storageKey);
+      const parsed = parseStoredValue(stored);
+      return parsed ?? defaultEnabled;
+    } catch (error) {
+      console.warn('Failed to read narration preference from storage.', error);
+      return defaultEnabled;
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage?.setItem) {
+      return;
+    }
+    try {
+      this.storage.setItem(this.storageKey, this.enabled ? '1' : '0');
+    } catch (error) {
+      console.warn('Failed to persist narration preference.', error);
+    }
+  }
+
+  private notify(source: NarrationPreferenceChangeSource): void {
+    const change: NarrationPreferenceChange = { enabled: this.enabled, source };
+    for (const listener of this.listeners) {
+      listener(change);
+    }
+  }
+
+  private readonly handleStorageEvent = (event: StorageEvent) => {
+    if (!event.key || event.key !== this.storageKey) {
+      return;
+    }
+    const parsed = parseStoredValue(event.newValue ?? null);
+    if (parsed === null || parsed === this.enabled) {
+      return;
+    }
+    this.enabled = parsed;
+    this.notify('storage');
+  };
+}

--- a/src/tests/ambientCaptionBridge.test.ts
+++ b/src/tests/ambientCaptionBridge.test.ts
@@ -113,6 +113,36 @@ describe('AmbientCaptionBridge', () => {
     bridge.update();
     expect(show).toHaveBeenCalledTimes(2);
   });
+
+  it('clears and suppresses captions while narration is disabled', () => {
+    const controller = new FakeController({
+      id: 'hum',
+      center: { x: 0, z: 0 },
+      innerRadius: 1,
+      outerRadius: 4,
+      baseVolume: 0.4,
+      source: fakeSource,
+      caption: 'Soft hum fills the room.',
+    });
+    controller.setVolume(0.3);
+    const subtitles = {
+      show: vi.fn(),
+      clear: vi.fn(),
+      dispose: vi.fn(),
+      getCurrent: vi.fn(() => null),
+    };
+
+    const bridge = new AmbientCaptionBridge({
+      controller,
+      subtitles,
+      isEnabled: () => false,
+    });
+
+    bridge.update();
+
+    expect(subtitles.show).not.toHaveBeenCalled();
+    expect(subtitles.clear).not.toHaveBeenCalled();
+  });
 });
 
 describe('AmbientCaptionBridge priority handling', () => {

--- a/src/tests/audioSubtitles.test.ts
+++ b/src/tests/audioSubtitles.test.ts
@@ -112,6 +112,63 @@ describe('audio subtitles overlay', () => {
     handle.dispose();
   });
 
+  it('renders an accessible dismiss button and hides immediately when activated', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-dismiss',
+      text: 'Dismissible narration appears.',
+      source: 'poi',
+      durationMs: 5000,
+    });
+
+    const element = document.querySelector('.audio-subtitles');
+    const button = document.querySelector(
+      '.audio-subtitles__dismiss'
+    ) as HTMLButtonElement | null;
+
+    expect(element?.dataset.visible).toBe('true');
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute('aria-label')).toBe('Dismiss narration');
+
+    button?.click();
+
+    expect(element?.dataset.visible).toBe('false');
+    expect(handle.getCurrent()).toBeNull();
+    expect(handle.getState?.().dismissCount).toBe(1);
+    handle.dispose();
+  });
+
+  it('dismisses active and queued captions without immediately replacing them', () => {
+    const handle = createAudioSubtitles();
+    handle.show({
+      id: 'poi-active',
+      text: 'Active narration.',
+      source: 'poi',
+      priority: 4,
+      durationMs: 5000,
+    });
+    handle.show({
+      id: 'ambient-queued',
+      text: 'Queued caption.',
+      source: 'ambient',
+      priority: 1,
+      durationMs: 5000,
+    });
+
+    expect(handle.getState?.().queueLength).toBe(1);
+    handle.dismissAll?.();
+
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    expect(handle.getState?.().queueLength).toBe(0);
+    vi.advanceTimersByTime(5000);
+    expect(document.querySelector('.audio-subtitles')?.dataset.visible).toBe(
+      'false'
+    );
+    handle.dispose();
+  });
+
   it('clears captions only when the matching identifier is provided', () => {
     const handle = createAudioSubtitles();
     handle.show({

--- a/src/tests/narrationPreference.test.ts
+++ b/src/tests/narrationPreference.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  NARRATION_PREFERENCE_STORAGE_KEY,
+  NarrationPreference,
+} from '../systems/narrative/narrationPreference';
+
+const createMemoryStorage = (initial: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+};
+
+describe('NarrationPreference', () => {
+  it('defaults off when storage is missing', () => {
+    const preference = new NarrationPreference({ storage: null });
+
+    expect(preference.isEnabled()).toBe(false);
+  });
+
+  it('honors and persists explicit true values', () => {
+    const storage = createMemoryStorage({
+      [NARRATION_PREFERENCE_STORAGE_KEY]: '1',
+    });
+    const preference = new NarrationPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(true);
+
+    preference.setEnabled(false);
+    preference.setEnabled(true);
+
+    expect(storage.setItem).toHaveBeenLastCalledWith(
+      NARRATION_PREFERENCE_STORAGE_KEY,
+      '1'
+    );
+  });
+
+  it('honors and persists explicit false values', () => {
+    const storage = createMemoryStorage({
+      [NARRATION_PREFERENCE_STORAGE_KEY]: '0',
+    });
+    const preference = new NarrationPreference({
+      storage,
+      defaultEnabled: true,
+    });
+
+    expect(preference.isEnabled()).toBe(false);
+
+    preference.setEnabled(false, 'control');
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      NARRATION_PREFERENCE_STORAGE_KEY,
+      '0'
+    );
+  });
+
+  it('ignores legacy true values stored under unrelated keys', () => {
+    const storage = createMemoryStorage({
+      'danielsmith.io::narrationEnabled': 'true',
+      'danielsmith.io::narrationEnabled::legacy': '1',
+    });
+    const preference = new NarrationPreference({ storage });
+
+    expect(preference.isEnabled()).toBe(false);
+    expect(storage.getItem).toHaveBeenCalledWith(
+      NARRATION_PREFERENCE_STORAGE_KEY
+    );
+  });
+});

--- a/src/tests/narrationToggleControl.test.ts
+++ b/src/tests/narrationToggleControl.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createNarrationToggleControl } from '../systems/controls/narrationToggleControl';
+
+describe('createNarrationToggleControl', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('starts off by default and toggles persisted state callbacks', () => {
+    const onToggle = vi.fn();
+    const control = createNarrationToggleControl({
+      container: document.body,
+      onToggle,
+      strings: {
+        labelEnabled: 'Narration: On',
+        labelDisabled: 'Narration: Off',
+        descriptionEnabled: 'Narration popups are shown.',
+        descriptionDisabled: 'Narration popups are hidden.',
+      },
+    });
+
+    expect(control.element.textContent).toBe('Narration: Off');
+    expect(control.element.getAttribute('aria-pressed')).toBe('false');
+
+    control.element.click();
+
+    expect(onToggle).toHaveBeenLastCalledWith(true);
+    expect(control.element.textContent).toBe('Narration: On');
+    expect(control.element.getAttribute('aria-pressed')).toBe('true');
+
+    control.element.click();
+
+    expect(onToggle).toHaveBeenLastCalledWith(false);
+    expect(control.element.textContent).toBe('Narration: Off');
+    control.dispose();
+  });
+
+  it('updates UI when external preference changes arrive', () => {
+    const control = createNarrationToggleControl({
+      container: document.body,
+      initialEnabled: true,
+    });
+
+    control.setEnabled(false);
+
+    expect(control.element.textContent).toBe('Narration: Off');
+    expect(control.element.getAttribute('aria-pressed')).toBe('false');
+    control.dispose();
+  });
+});

--- a/src/ui/hud/audioSubtitles.ts
+++ b/src/ui/hud/audioSubtitles.ts
@@ -10,18 +10,33 @@ export interface AudioSubtitleMessage {
   durationMs?: number;
 }
 
+export interface AudioSubtitlesState {
+  current: AudioSubtitleMessage | null;
+  queueLength: number;
+  visible: boolean;
+  dismissCount: number;
+  lastDismissedAt: number | null;
+}
+
+export interface AudioSubtitlesStrings {
+  labels?: Partial<Record<AudioSubtitleSource, string>>;
+  dismissLabels?: Partial<Record<AudioSubtitleSource, string>>;
+}
+
 export interface AudioSubtitlesHandle {
   show(message: AudioSubtitleMessage): void;
   clear(messageId?: string): void;
+  dismissAll?(): void;
+  setStrings?(strings: AudioSubtitlesStrings): void;
   dispose(): void;
   /** Returns the currently visible caption if any. */
   getCurrent(): AudioSubtitleMessage | null;
+  getState?(): AudioSubtitlesState;
 }
 
-export interface AudioSubtitlesOptions {
+export interface AudioSubtitlesOptions extends AudioSubtitlesStrings {
   container?: HTMLElement;
   ariaLive?: 'polite' | 'assertive';
-  labels?: Partial<Record<AudioSubtitleSource, string>>;
   documentTarget?: Document;
   /**
    * Messages at or above this priority temporarily upgrade the live region to
@@ -47,10 +62,16 @@ const DEFAULT_LABELS: Record<AudioSubtitleSource, string> = {
   poi: 'Narration',
 };
 
+const DEFAULT_DISMISS_LABELS: Record<AudioSubtitleSource, string> = {
+  ambient: 'Dismiss caption',
+  poi: 'Dismiss narration',
+};
+
 export function createAudioSubtitles({
   container = document.body,
   ariaLive = 'polite',
   labels: providedLabels,
+  dismissLabels: providedDismissLabels,
   documentTarget = document,
   assertivePriorityThreshold,
 }: AudioSubtitlesOptions = {}): AudioSubtitlesHandle {
@@ -78,15 +99,23 @@ export function createAudioSubtitles({
 
   root.appendChild(caption);
 
+  const dismissButton = documentTarget.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.className = 'audio-subtitles__dismiss';
+  root.appendChild(dismissButton);
+
   container.appendChild(root);
 
-  const labels = { ...DEFAULT_LABELS, ...providedLabels };
+  let labels = { ...DEFAULT_LABELS, ...providedLabels };
+  let dismissLabels = { ...DEFAULT_DISMISS_LABELS, ...providedDismissLabels };
 
   const queue: NormalizedAudioSubtitleMessage[] = [];
   let hideTimeout: number | null = null;
   let current: NormalizedAudioSubtitleMessage | null = null;
   let currentToken: symbol | null = null;
   let announcementSequence = 0;
+  let dismissCount = 0;
+  let lastDismissedAt: number | null = null;
 
   const baseAriaLive = ariaLive;
   const resolvedAssertiveThreshold = resolveAssertivePriorityThreshold(
@@ -188,6 +217,9 @@ export function createAudioSubtitles({
     applyAriaLive(baseAriaLive);
     captionText.textContent = '';
     captionSequence.textContent = '';
+    dismissButton.textContent = '';
+    dismissButton.removeAttribute('aria-label');
+    dismissButton.removeAttribute('title');
     if (advance) {
       void showNextQueued();
     }
@@ -204,6 +236,11 @@ export function createAudioSubtitles({
     }
     label.textContent =
       labels[message.source] ?? DEFAULT_LABELS[message.source];
+    const dismissLabel =
+      dismissLabels[message.source] ?? DEFAULT_DISMISS_LABELS[message.source];
+    dismissButton.textContent = '×';
+    dismissButton.setAttribute('aria-label', dismissLabel);
+    dismissButton.title = dismissLabel;
     captionText.textContent = '';
     captionText.textContent = message.text;
     announcementSequence += 1;
@@ -242,6 +279,18 @@ export function createAudioSubtitles({
     enqueueMessage(normalized);
   };
 
+  const dismissAll = () => {
+    queue.length = 0;
+    dismissCount += 1;
+    lastDismissedAt = Date.now();
+    if (!current) {
+      return;
+    }
+    hideCurrent(false);
+  };
+
+  dismissButton.addEventListener('click', dismissAll);
+
   return {
     show(message) {
       show(message);
@@ -260,7 +309,25 @@ export function createAudioSubtitles({
         hideCurrent(true);
       }
     },
+    dismissAll,
+    setStrings(nextStrings) {
+      labels = { ...DEFAULT_LABELS, ...nextStrings.labels };
+      dismissLabels = {
+        ...DEFAULT_DISMISS_LABELS,
+        ...nextStrings.dismissLabels,
+      };
+      if (current) {
+        label.textContent =
+          labels[current.source] ?? DEFAULT_LABELS[current.source];
+        const dismissLabel =
+          dismissLabels[current.source] ??
+          DEFAULT_DISMISS_LABELS[current.source];
+        dismissButton.setAttribute('aria-label', dismissLabel);
+        dismissButton.title = dismissLabel;
+      }
+    },
     dispose() {
+      dismissButton.removeEventListener('click', dismissAll);
       queue.length = 0;
       if (current) {
         hideCurrent(false);
@@ -271,6 +338,15 @@ export function createAudioSubtitles({
     },
     getCurrent() {
       return current;
+    },
+    getState() {
+      return {
+        current,
+        queueLength: queue.length,
+        visible: root.dataset.visible === 'true',
+        dismissCount,
+        lastDismissedAt,
+      };
     },
   };
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -575,9 +575,9 @@ canvas {
   box-shadow: 0 22px 48px rgba(3, 9, 18, 0.6);
   color: #e7f1ff;
   backdrop-filter: blur(16px);
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.35rem 0.75rem;
   opacity: 0;
   pointer-events: none;
   transition: opacity 180ms ease;
@@ -586,9 +586,11 @@ canvas {
 
 .audio-subtitles[data-visible='true'] {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .audio-subtitles__label {
+  grid-column: 1;
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.14em;
@@ -596,10 +598,38 @@ canvas {
 }
 
 .audio-subtitles__caption {
+  grid-column: 1;
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.45;
   color: rgba(230, 243, 255, 0.95);
+}
+
+.audio-subtitles__dismiss {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: start;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid rgba(148, 208, 255, 0.45);
+  border-radius: 999px;
+  background: rgba(12, 28, 44, 0.82);
+  color: rgba(230, 243, 255, 0.95);
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.audio-subtitles__dismiss:focus-visible,
+.audio-subtitles__dismiss:hover {
+  border-color: rgba(148, 208, 255, 0.9);
+  background: rgba(32, 76, 116, 0.9);
+  outline: 2px solid rgba(148, 208, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.audio-subtitles[data-visible='false'] .audio-subtitles__dismiss {
+  display: none;
 }
 
 .audio-subtitles__text {


### PR DESCRIPTION
### Motivation
- Visible narration/caption overlays were effectively enabled by default and tied to guided-tour behavior, and the overlay had no accessible dismiss control.
- The change separates narration presentation from guided-tour recommendations so users must explicitly opt in and can immediately dismiss overlays.

### Description
- Add a dedicated persisted `NarrationPreference` (storage key `danielsmith.io::narrationEnabled::v1`) that defaults to off and ignores legacy keys; preference API supports subscribe/set/get. (new `src/systems/narrative/narrationPreference.ts`)
- Add a Settings toggle `createNarrationToggleControl` and locale strings for the toggle and subtitle/dismiss labels; wire the toggle to the new preference. (new `src/systems/controls/narrationToggleControl.ts`, i18n updates)
- Make the visible subtitle overlay dismissible and observable by extending `createAudioSubtitles` with a keyboard-focusable dismiss button, `dismissAll`/`setStrings`/`getState` APIs, localized dismiss labels, and styling changes. (`src/ui/hud/audioSubtitles.ts`, `src/ui/styles.css`)
- Gate POI and ambient captions through the narration preference and add `isEnabled` handling to `AmbientCaptionBridge`; expose `window.portfolio.narration.getState()` for debug visibility. (`src/systems/audio/ambientCaptionBridge.ts`, `src/main.ts`)

### Testing
- Formatting and lint: ran `npm run format:write` and `npm run lint`; both completed successfully.
- Unit tests: ran `npm run test:ci -- src/tests/audioSubtitles.test.ts src/tests/i18n.test.ts src/tests/poiNarrativeLog.test.ts src/tests/narrationPreference.test.ts src/tests/narrationToggleControl.test.ts src/tests/ambientCaptionBridge.test.ts` and then `npm run test:ci` for the full suite; tests passed (selected suites and full-run reported all tests passing).
- Build / smoke / docs: ran `npm run build`, `npm run docs:check`, and `npm run smoke`; these completed and produced valid `dist` artifacts.
- E2E: installed Playwright browsers and host deps with `npx playwright install chromium` and `npx playwright install-deps chromium` and ran `npm run test:e2e -- playwright/small-screen-hud.spec.ts`; the e2e spec passed in the environment after installing deps and browsers, and a local verification screenshot was captured at `/tmp/narration-settings.png`.
- Typecheck: ran `npm run typecheck`; this failed due to pre-existing, repository-wide TypeScript errors unrelated to the narration changes (reported locations include `src/main.ts` and `src/systems/failover/index.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236402a2e8832fa81be988c86a0530)