### PR TITLE
Fix POI GitHub star sources for DSPACE, Sugarkube, and Axel

### DIFF
--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -728,6 +728,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Alpha releases keep README, FAQ, and threat model coverage in sync with the pytest suite.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         { label: 'Status', value: 'Alpha · pipx install axel' },
         {
           label: 'Repo analytics',
@@ -919,7 +931,6 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',
@@ -981,6 +992,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Docs cover the 3-node HA k3s happy path, Raspberry Pi imaging, flashing, verification, and solar hardware notes.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         {
           label: 'Platform',
           value:

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -842,15 +842,10 @@ function buildPoi(
     fallback: string;
   }
 ): LocaleOverrides['poi'] {
-  const starSource = (
-    repo: string,
-    visibility?: 'private',
-    owner = 'futuroptimist'
-  ) => ({
+  const starSource = (repo: string, owner = 'futuroptimist') => ({
     type: 'githubStars' as const,
     owner,
     repo,
-    ...(visibility ? { visibility } : {}),
     format: 'compact' as const,
     template: githubStars.template,
     fallback: githubStars.fallback,
@@ -944,6 +939,11 @@ function buildPoi(
       summary: poi.axel.summary,
       outcome: { label: copy.strings.outcome, value: poi.axel.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('axel'),
+        },
         { label: poi.axel.metrics[0], value: poi.axel.metrics[1] },
         { label: poi.axel.metrics[2], value: poi.axel.metrics[3] },
         { label: poi.axel.metrics[4], value: poi.axel.metrics[5] },
@@ -1033,7 +1033,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', 'private', 'democratizedspace'),
+          source: starSource('dspace', 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },
@@ -1060,6 +1060,11 @@ function buildPoi(
       summary: poi.sugarkube.summary,
       outcome: { label: copy.strings.outcome, value: poi.sugarkube.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('sugarkube'),
+        },
         { label: poi.sugarkube.metrics[0], value: poi.sugarkube.metrics[1] },
         { label: poi.sugarkube.metrics[2], value: poi.sugarkube.metrics[3] },
         { label: poi.sugarkube.metrics[4], value: poi.sugarkube.metrics[5] },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -583,6 +583,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: 'Alpha 版本让 README、FAQ 和威胁模型随 pytest 套件保持同步。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: 'Alpha · pipx install axel' },
         { label: '仓库分析', value: '根据仓库列表和扫描进行任务规划' },
         { label: '文档', value: 'FAQ · 已知问题 · 威胁模型随测试维护' },
@@ -755,7 +767,6 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
@@ -807,6 +818,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: '在涉及磁盘、集群或硬件之前保持工作流可预演和有护栏。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: '硬件/集群自动化' },
         { label: '安全', value: '干跑优先 · 受保护的破坏性命令' },
         { label: '范围', value: 'k3s · 太阳能 · 设备编排' },

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { wireGitHubRepoMetrics } from '../scene/poi/githubMetrics';
+import { getPoiDefinitions } from '../scene/poi/registry';
 import type { PoiDefinition } from '../scene/poi/types';
+import { createGitHubRepoStatsService } from '../systems/github/repoStats';
 import type {
   GitHubRepoIdentifier,
   GitHubRepoStats,
@@ -199,7 +201,6 @@ describe('wireGitHubRepoMetrics', () => {
               type: 'githubStars',
               owner: 'democratizedspace',
               repo: 'dspace',
-              visibility: 'private',
               fallback: 'Hidden',
             },
           },
@@ -219,6 +220,7 @@ describe('wireGitHubRepoMetrics', () => {
     expect(service.requested).toEqual([
       'futuroptimist/flywheel',
       'futuroptimist/axel',
+      'democratizedspace/dspace',
     ]);
     expect(definitions[3].metrics?.[0]?.value).toBe('Hidden');
 
@@ -240,13 +242,21 @@ describe('wireGitHubRepoMetrics', () => {
       { stars: 86, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
     );
     expect(definitions[2].metrics?.[0]?.value).toBe('86 stars');
+    service.emit(
+      { owner: 'democratizedspace', repo: 'dspace' },
+      { stars: 3, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    expect(definitions[3].metrics?.[0]?.value).toBe('3');
     expect(
       service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
-    ).toBe(0);
+    ).toBe(1);
 
     controller.dispose();
     expect(
       service.listenerCount({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).toBe(0);
+    expect(
+      service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
     ).toBe(0);
     const previousUpdates = updated.length;
     service.emit(
@@ -254,6 +264,71 @@ describe('wireGitHubRepoMetrics', () => {
       { stars: 2000, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
     );
     expect(updated).toHaveLength(previousUpdates);
+  });
+
+  it('renders DSPACE, Sugarkube, and Axel stars from the runtime cache, including zeroes', async () => {
+    const generatedAt = '2026-06-03T00:00:00.000Z';
+    const expiresAt = '2026-06-03T01:15:00.000Z';
+    const repoStats = (owner: string, repo: string, stars: number) => ({
+      owner,
+      repo,
+      stars,
+      watchers: 0,
+      forks: 0,
+      openIssues: 0,
+      pushedAt: null,
+    });
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt,
+        expiresAt,
+        repos: {
+          'democratizedspace/dspace': repoStats(
+            'democratizedspace',
+            'dspace',
+            3
+          ),
+          'futuroptimist/sugarkube': repoStats('futuroptimist', 'sugarkube', 0),
+          'futuroptimist/axel': repoStats('futuroptimist', 'axel', 0),
+        },
+      }),
+    });
+    const definitions = getPoiDefinitions('en');
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      {
+        allowLiveFetch: false,
+        localStorage: null,
+        sessionStorage: null,
+        logger: null,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        fetchTimeoutMs: 0,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      }
+    );
+    const controller = wireGitHubRepoMetrics({ definitions, service });
+
+    await controller.refreshAll();
+
+    const starValue = (id: PoiDefinition['id']) =>
+      definitions
+        .find((poi) => poi.id === id)
+        ?.metrics?.find((metric) => metric.source?.type === 'githubStars')
+        ?.value;
+
+    expect(starValue('dspace-backyard-rocket')).toBe('3 stars');
+    expect(starValue('sugarkube-backyard-greenhouse')).toBe('0 stars');
+    expect(starValue('axel-studio-tracker')).toBe('0 stars');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      requestCount: 0,
+      cachedRepoCount: 3,
+    });
+
+    controller.dispose();
   });
 
   it('stops refreshes when the probe request restores backoff', async () => {

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -85,6 +85,72 @@ describe('GitHub repo stats service', () => {
     });
   });
 
+  it('loads mixed-owner runtime cache repos and preserves zero-star values', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        repos: {
+          'democratizedspace/dspace': {
+            owner: 'democratizedspace',
+            repo: 'dspace',
+            stars: 3,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/sugarkube': {
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/axel': {
+            owner: 'futuroptimist',
+            repo: 'axel',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'democratizedspace', repo: 'dspace' })
+    ).resolves.toMatchObject({ stars: 3 });
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'sugarkube' })
+    ).resolves.toMatchObject({ stars: 0 });
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'axel' })
+    ).resolves.toMatchObject({ stars: 0 });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      cachedRepoCount: 3,
+    });
+  });
+
   it('does not map runtime watchers to stars', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -162,6 +162,7 @@ describe('i18n utilities', () => {
       'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
       'jobbot-studio-terminal',
+      'axel-studio-tracker',
       'gitshelves-living-room-installation',
       'danielsmith-portfolio-table',
       'f2clipboard-kitchen-console',
@@ -169,6 +170,7 @@ describe('i18n utilities', () => {
       'wove-kitchen-loom',
       'dspace-backyard-rocket',
       'pr-reaper-backyard-console',
+      'sugarkube-backyard-greenhouse',
     ]);
 
     for (const englishPoi of starBackedPois) {
@@ -268,7 +270,7 @@ describe('i18n utilities', () => {
     }
   });
 
-  it('marks every localized DSPACE GitHub star metric as private and neutral', () => {
+  it('keeps every localized DSPACE GitHub star metric public and neutral', () => {
     const numericFallbackPattern = /\d/;
 
     for (const locale of AVAILABLE_LOCALES) {
@@ -285,12 +287,59 @@ describe('i18n utilities', () => {
         type: 'githubStars',
         owner: 'democratizedspace',
         repo: 'dspace',
-        visibility: 'private',
       });
+      expect(starMetric?.source).not.toHaveProperty('visibility', 'private');
       expect(starMetric?.value, locale).not.toMatch(numericFallbackPattern);
       expect(starMetric?.source?.fallback ?? '', locale).not.toMatch(
         numericFallbackPattern
       );
+    }
+  });
+
+  it('covers DSPACE, Sugarkube, and Axel GitHub star metric sources in every locale', () => {
+    const expectedSources = {
+      'dspace-backyard-rocket': {
+        owner: 'democratizedspace',
+        repo: 'dspace',
+      },
+      'sugarkube-backyard-greenhouse': {
+        owner: 'futuroptimist',
+        repo: 'sugarkube',
+      },
+      'axel-studio-tracker': {
+        owner: 'futuroptimist',
+        repo: 'axel',
+      },
+    } as const;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const definitions = getPoiDefinitions(locale);
+      const starSources = definitions.flatMap((poi) =>
+        (poi.metrics ?? [])
+          .filter((metric) => metric.source?.type === 'githubStars')
+          .map((metric) => ({ poiId: poi.id, source: metric.source }))
+      );
+
+      expect(starSources, locale).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            source: expect.objectContaining({
+              owner: 'futuroptimist',
+              repo: 'dspace',
+            }),
+          }),
+        ])
+      );
+
+      for (const [poiId, source] of Object.entries(expectedSources)) {
+        expect(
+          starSources.find((entry) => entry.poiId === poiId)?.source,
+          `${locale} ${poiId}`
+        ).toMatchObject({
+          type: 'githubStars',
+          ...source,
+        });
+      }
     }
   });
 

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -188,6 +188,26 @@ describe('PoiTooltipOverlay', () => {
     expect(describedIds).toContain(linksList.id);
   });
 
+  it('renders zero-star metrics as valid visible values', () => {
+    overlay.setHovered({
+      ...basePoi,
+      id: 'axel-studio-tracker',
+      title: 'Axel',
+      metrics: [{ label: 'Stars', value: '0 stars' }],
+      links: [
+        { label: 'GitHub', href: 'https://github.com/futuroptimist/axel' },
+      ],
+    });
+
+    const metrics = Array.from(
+      container.querySelectorAll('.poi-tooltip-overlay__metric')
+    );
+    const value = container.querySelector('.poi-tooltip-overlay__metric-value');
+
+    expect(metrics).toHaveLength(1);
+    expect(value?.textContent).toBe('0 stars');
+  });
+
   it('renders selected POI metadata without a hover target', () => {
     overlay.setSelected(basePoi, { inputMethod: 'pointer' });
 


### PR DESCRIPTION
### Motivation
- DSPACE was incorrectly hinted/treated as private and pointed at the wrong org in some places, preventing the runtime cache from surfacing its public star count.
- Sugarkube and Axel had no app-side Stars metric, so zero-star runtime-cache values could not be rendered as valid metrics.
- Keep client-side star fallbacks neutral and localized (no hardcoded numeric fallbacks) while ensuring mixed-owner runtime caches are supported.

### Description
- Updated POI metric definitions and locale wiring to point DSPACE to `democratizedspace/dspace` (public) and removed the private visibility hint across locale variants. 
- Added localized GitHub Stars metric entries for Axel (`futuroptimist/axel`) and Sugarkube (`futuroptimist/sugarkube`) in `en`, `zh-Hans`, and the shared Latin-locale builder used by `es/pt/de/hu` (neutral `Syncing from GitHub…` fallbacks and templates retained).
- Adjusted the Latin-locale star source helper to support explicit owner strings and added the new stars entries where appropriate; preserved all other localized, non-star copy.
- Extended and added unit tests to cover: DSPACE owner/org mismatch, that DSPACE is not marked private, presence of `githubStars` sources for Sugarkube and Axel, runtime-cache updates for mixed-owner repos including zero-star values, and rendering of zero as a visible metric value; tests mock the runtime cache and do not hit live GitHub.

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed (import ordering warning addressed during changes).
- `npm run typecheck` — not run to completion for the repo-wide set (existing unrelated TypeScript issues in other areas cause failures; these are pre-existing and not introduced by this change).
- Targeted tests: `npm run test:ci -- src/tests/githubPoiMetrics.test.ts src/tests/githubRepoStatsService.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts` — all passed; added tests validate mixed-owner runtime cache handling and zero-star rendering.
- Full test suite: `npm run test:ci` — passed in this environment (1018 tests ran successfully).
- `npm run build` — passed and produced `dist/` artifacts.
- `npm run docs:check` — passed; note link checker emitted external network warnings (environment fetches) but no blocking failures.
- `npm run smoke` — passed.

Notes and follow-ups: the Sugarkube sidecar repo list update (server/helm side) is required to make these new metric entries available on staging; this PR only adds the app-side wiring and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237aa7cc3c832f88f57f2a4d453f09)