### PR TITLE
Fix POI GitHub star sources for DSPACE, Sugarkube, and Axel

### DIFF
--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -728,6 +728,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Alpha releases keep README, FAQ, and threat model coverage in sync with the pytest suite.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         { label: 'Status', value: 'Alpha · pipx install axel' },
         {
           label: 'Repo analytics',
@@ -919,7 +931,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
+            visibility: 'public',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',
@@ -981,6 +993,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Docs cover the 3-node HA k3s happy path, Raspberry Pi imaging, flashing, verification, and solar hardware notes.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         {
           label: 'Platform',
           value:

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -844,7 +844,7 @@ function buildPoi(
 ): LocaleOverrides['poi'] {
   const starSource = (
     repo: string,
-    visibility?: 'private',
+    visibility?: 'public' | 'private',
     owner = 'futuroptimist'
   ) => ({
     type: 'githubStars' as const,
@@ -944,6 +944,11 @@ function buildPoi(
       summary: poi.axel.summary,
       outcome: { label: copy.strings.outcome, value: poi.axel.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('axel'),
+        },
         { label: poi.axel.metrics[0], value: poi.axel.metrics[1] },
         { label: poi.axel.metrics[2], value: poi.axel.metrics[3] },
         { label: poi.axel.metrics[4], value: poi.axel.metrics[5] },
@@ -1033,7 +1038,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', 'private', 'democratizedspace'),
+          source: starSource('dspace', 'public', 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },
@@ -1060,6 +1065,11 @@ function buildPoi(
       summary: poi.sugarkube.summary,
       outcome: { label: copy.strings.outcome, value: poi.sugarkube.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('sugarkube'),
+        },
         { label: poi.sugarkube.metrics[0], value: poi.sugarkube.metrics[1] },
         { label: poi.sugarkube.metrics[2], value: poi.sugarkube.metrics[3] },
         { label: poi.sugarkube.metrics[4], value: poi.sugarkube.metrics[5] },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -583,6 +583,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: 'Alpha 版本让 README、FAQ 和威胁模型随 pytest 套件保持同步。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: 'Alpha · pipx install axel' },
         { label: '仓库分析', value: '根据仓库列表和扫描进行任务规划' },
         { label: '文档', value: 'FAQ · 已知问题 · 威胁模型随测试维护' },
@@ -755,7 +767,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
+            visibility: 'public',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
@@ -807,6 +819,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: '在涉及磁盘、集群或硬件之前保持工作流可预演和有护栏。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: '硬件/集群自动化' },
         { label: '安全', value: '干跑优先 · 受保护的破坏性命令' },
         { label: '范围', value: 'k3s · 太阳能 · 设备编排' },

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -199,7 +199,8 @@ describe('wireGitHubRepoMetrics', () => {
               type: 'githubStars',
               owner: 'democratizedspace',
               repo: 'dspace',
-              visibility: 'private',
+              visibility: 'public',
+              template: '{value} stars',
               fallback: 'Hidden',
             },
           },
@@ -219,6 +220,7 @@ describe('wireGitHubRepoMetrics', () => {
     expect(service.requested).toEqual([
       'futuroptimist/flywheel',
       'futuroptimist/axel',
+      'democratizedspace/dspace',
     ]);
     expect(definitions[3].metrics?.[0]?.value).toBe('Hidden');
 
@@ -242,7 +244,13 @@ describe('wireGitHubRepoMetrics', () => {
     expect(definitions[2].metrics?.[0]?.value).toBe('86 stars');
     expect(
       service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
-    ).toBe(0);
+    ).toBe(1);
+
+    service.emit(
+      { owner: 'democratizedspace', repo: 'dspace' },
+      { stars: 3, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    expect(definitions[3].metrics?.[0]?.value).toBe('3 stars');
 
     controller.dispose();
     expect(
@@ -254,6 +262,58 @@ describe('wireGitHubRepoMetrics', () => {
       { stars: 2000, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
     );
     expect(updated).toHaveLength(previousUpdates);
+  });
+
+  it('renders zero-star GitHub updates as valid metric values', async () => {
+    const definitions: PoiDefinition[] = [
+      createPoi({
+        id: 'sugarkube-backyard-greenhouse',
+        metrics: [
+          {
+            label: 'Stars',
+            value: 'Syncing from GitHub…',
+            source: {
+              type: 'githubStars',
+              owner: 'futuroptimist',
+              repo: 'sugarkube',
+              template: '{value} stars',
+              fallback: 'Syncing from GitHub…',
+            },
+          },
+        ],
+      }),
+      createPoi({
+        id: 'axel-studio-tracker',
+        metrics: [
+          {
+            label: 'Stars',
+            value: 'Syncing from GitHub…',
+            source: {
+              type: 'githubStars',
+              owner: 'futuroptimist',
+              repo: 'axel',
+              template: '{value} stars',
+              fallback: 'Syncing from GitHub…',
+            },
+          },
+        ],
+      }),
+    ];
+    const service = new MockRepoStatsService();
+    const controller = wireGitHubRepoMetrics({ definitions, service });
+
+    service.emit(
+      { owner: 'futuroptimist', repo: 'sugarkube' },
+      { stars: 0, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    service.emit(
+      { owner: 'futuroptimist', repo: 'axel' },
+      { stars: 0, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+
+    expect(definitions[0].metrics?.[0]?.value).toBe('0 stars');
+    expect(definitions[1].metrics?.[0]?.value).toBe('0 stars');
+    controller.dispose();
   });
 
   it('stops refreshes when the probe request restores backoff', async () => {

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -85,6 +85,71 @@ describe('GitHub repo stats service', () => {
     });
   });
 
+  it('loads DSPACE, Sugarkube, and Axel from runtime cache including zero stars', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        repos: {
+          'democratizedspace/dspace': {
+            owner: 'democratizedspace',
+            repo: 'dspace',
+            stars: 3,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/sugarkube': {
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/axel': {
+            owner: 'futuroptimist',
+            repo: 'axel',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'democratizedspace', repo: 'dspace' })
+    ).resolves.toMatchObject({ stars: 3 });
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'sugarkube' })
+    ).resolves.toMatchObject({ stars: 0 });
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'axel' })
+    ).resolves.toMatchObject({ stars: 0 });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      cachedRepoCount: 3,
+    });
+  });
+
   it('does not map runtime watchers to stars', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -162,6 +162,7 @@ describe('i18n utilities', () => {
       'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
       'jobbot-studio-terminal',
+      'axel-studio-tracker',
       'gitshelves-living-room-installation',
       'danielsmith-portfolio-table',
       'f2clipboard-kitchen-console',
@@ -169,6 +170,7 @@ describe('i18n utilities', () => {
       'wove-kitchen-loom',
       'dspace-backyard-rocket',
       'pr-reaper-backyard-console',
+      'sugarkube-backyard-greenhouse',
     ]);
 
     for (const englishPoi of starBackedPois) {
@@ -268,7 +270,7 @@ describe('i18n utilities', () => {
     }
   });
 
-  it('marks every localized DSPACE GitHub star metric as private and neutral', () => {
+  it('marks every localized DSPACE GitHub star metric as public and neutral', () => {
     const numericFallbackPattern = /\d/;
 
     for (const locale of AVAILABLE_LOCALES) {
@@ -285,12 +287,55 @@ describe('i18n utilities', () => {
         type: 'githubStars',
         owner: 'democratizedspace',
         repo: 'dspace',
-        visibility: 'private',
+        visibility: 'public',
       });
       expect(starMetric?.value, locale).not.toMatch(numericFallbackPattern);
       expect(starMetric?.source?.fallback ?? '', locale).not.toMatch(
         numericFallbackPattern
       );
+    }
+  });
+
+  it('covers DSPACE, Sugarkube, and Axel GitHub star sources in every locale', () => {
+    const expectedSources = {
+      'dspace-backyard-rocket': {
+        owner: 'democratizedspace',
+        repo: 'dspace',
+      },
+      'sugarkube-backyard-greenhouse': {
+        owner: 'futuroptimist',
+        repo: 'sugarkube',
+      },
+      'axel-studio-tracker': {
+        owner: 'futuroptimist',
+        repo: 'axel',
+      },
+    } as const;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const definitions = getPoiDefinitions(locale);
+      for (const [poiId, expectedSource] of Object.entries(expectedSources)) {
+        const poi = definitions.find((candidate) => candidate.id === poiId);
+        const starMetric = poi?.metrics?.find(
+          (metric) => metric.source?.type === 'githubStars'
+        );
+
+        expect(starMetric, `${locale} ${poiId}`).toBeDefined();
+        expect(starMetric?.source, `${locale} ${poiId}`).toMatchObject({
+          type: 'githubStars',
+          ...expectedSource,
+        });
+      }
+
+      const staleDspaceSources = definitions.flatMap((poi) =>
+        (poi.metrics ?? []).filter(
+          (metric) =>
+            metric.source?.type === 'githubStars' &&
+            metric.source.owner === 'futuroptimist' &&
+            metric.source.repo === 'dspace'
+        )
+      );
+      expect(staleDspaceSources, locale).toHaveLength(0);
     }
   });
 

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -188,6 +188,25 @@ describe('PoiTooltipOverlay', () => {
     expect(describedIds).toContain(linksList.id);
   });
 
+  it('renders zero-star metrics instead of treating them as missing', () => {
+    overlay.setHovered({
+      ...basePoi,
+      metrics: [{ label: 'Stars', value: '0 stars' }],
+    });
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    const metrics = Array.from(
+      root.querySelectorAll('.poi-tooltip-overlay__metric')
+    );
+    expect(metrics).toHaveLength(1);
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-label')?.textContent
+    ).toBe('Stars');
+    expect(
+      root.querySelector('.poi-tooltip-overlay__metric-value')?.textContent
+    ).toBe('0 stars');
+  });
+
   it('renders selected POI metadata without a hover target', () => {
     overlay.setSelected(basePoi, { inputMethod: 'pointer' });
 


### PR DESCRIPTION
### Motivation
- Staging showed DSPACE was pointing at the wrong/fake repo (`futuroptimist/dspace`) and Sugarkube/Axel lacked a Stars metric, causing missing or incorrect GitHub-star UX. 
- Star metrics must read the runtime sidecar cache (including owners outside `futuroptimist`) and treat zero stars as a valid fetched value instead of hiding behind neutral fallbacks.

### Description
- Point the DSPACE POI GitHub stars to the public repo `democratizedspace/dspace` and mark the metric as public (no numeric fallback introduced). 
- Add a `Stars` GitHub metric to the Sugarkube and Axel POIs using `futuroptimist/sugarkube` and `futuroptimist/axel` with the same localized neutral fallback (`Syncing from GitHub…`) and templating used elsewhere. 
- Apply the changes across locales by updating `src/assets/i18n/locales/en.ts`, `src/assets/i18n/locales/zh-Hans.ts`, and the Latin locale generator `src/assets/i18n/locales/latinLocaleOverrides.ts` so supported locales (en, zh-Hans, ja, ar, es, pt, de, hu, en-x-pseudo) receive the star metric wiring. 
- Extend and add tests to cover the owner/org mismatch and zero-star handling in `src/tests/githubPoiMetrics.test.ts`, `src/tests/githubRepoStatsService.test.ts`, `src/tests/i18n.test.ts`, and `src/tests/poiTooltipOverlay.test.ts` without hitting live GitHub by mocking the runtime cache.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully. 
- Ran a focused test subset with `npm run test:ci -- src/tests/githubPoiMetrics.test.ts src/tests/githubRepoStatsService.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts` and then the full suite with `npm run test:ci`, and all tests passed (new tests included and green). 
- Built and validated artifacts with `npm run build`, `npm run docs:check`, and `npm run smoke`, all succeeding (Vite chunk-size advisory only). 
- Type-checking via `npm run typecheck` surfaced unrelated existing TypeScript errors in other areas of the codebase and did not fail the POI metric changes; these are pre-existing and out of scope for this PR.

Residual notes: the Sugarkube sidecar repo-list must be updated (Prompt 8B) before staging will actually serve those metrics; this PR wires the app to consume that runtime cache correctly and ensures zero-star repos are rendered as valid values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237aa7cc3c832f88f57f2a4d453f09)