### PR TITLE
Fix POI GitHub star sources for DSPACE, Sugarkube, and Axel

### DIFF
--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -728,6 +728,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Alpha releases keep README, FAQ, and threat model coverage in sync with the pytest suite.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         { label: 'Status', value: 'Alpha · pipx install axel' },
         {
           label: 'Repo analytics',
@@ -919,7 +931,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
+            visibility: 'public',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',
@@ -981,6 +993,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Docs cover the 3-node HA k3s happy path, Raspberry Pi imaging, flashing, verification, and solar hardware notes.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         {
           label: 'Platform',
           value:

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -844,7 +844,7 @@ function buildPoi(
 ): LocaleOverrides['poi'] {
   const starSource = (
     repo: string,
-    visibility?: 'private',
+    visibility?: 'public' | 'private',
     owner = 'futuroptimist'
   ) => ({
     type: 'githubStars' as const,
@@ -944,6 +944,11 @@ function buildPoi(
       summary: poi.axel.summary,
       outcome: { label: copy.strings.outcome, value: poi.axel.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('axel'),
+        },
         { label: poi.axel.metrics[0], value: poi.axel.metrics[1] },
         { label: poi.axel.metrics[2], value: poi.axel.metrics[3] },
         { label: poi.axel.metrics[4], value: poi.axel.metrics[5] },
@@ -1033,7 +1038,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', 'private', 'democratizedspace'),
+          source: starSource('dspace', 'public', 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },
@@ -1060,6 +1065,11 @@ function buildPoi(
       summary: poi.sugarkube.summary,
       outcome: { label: copy.strings.outcome, value: poi.sugarkube.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('sugarkube'),
+        },
         { label: poi.sugarkube.metrics[0], value: poi.sugarkube.metrics[1] },
         { label: poi.sugarkube.metrics[2], value: poi.sugarkube.metrics[3] },
         { label: poi.sugarkube.metrics[4], value: poi.sugarkube.metrics[5] },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -583,6 +583,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: 'Alpha 版本让 README、FAQ 和威胁模型随 pytest 套件保持同步。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: 'Alpha · pipx install axel' },
         { label: '仓库分析', value: '根据仓库列表和扫描进行任务规划' },
         { label: '文档', value: 'FAQ · 已知问题 · 威胁模型随测试维护' },
@@ -755,7 +767,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
+            visibility: 'public',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
@@ -807,6 +819,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: '在涉及磁盘、集群或硬件之前保持工作流可预演和有护栏。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: '硬件/集群自动化' },
         { label: '安全', value: '干跑优先 · 受保护的破坏性命令' },
         { label: '范围', value: 'k3s · 太阳能 · 设备编排' },

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -194,13 +194,30 @@ describe('wireGitHubRepoMetrics', () => {
         metrics: [
           {
             label: 'Stars',
-            value: 'Hidden',
+            value: 'Syncing',
             source: {
               type: 'githubStars',
               owner: 'democratizedspace',
               repo: 'dspace',
-              visibility: 'private',
-              fallback: 'Hidden',
+              visibility: 'public',
+              template: '{value} stars',
+              fallback: 'Syncing',
+            },
+          },
+        ],
+      }),
+      createPoi({
+        id: 'sugarkube-backyard-greenhouse',
+        metrics: [
+          {
+            label: 'Stars',
+            value: 'Syncing',
+            source: {
+              type: 'githubStars',
+              owner: 'futuroptimist',
+              repo: 'sugarkube',
+              template: '{value} stars',
+              fallback: 'Syncing',
             },
           },
         ],
@@ -219,8 +236,11 @@ describe('wireGitHubRepoMetrics', () => {
     expect(service.requested).toEqual([
       'futuroptimist/flywheel',
       'futuroptimist/axel',
+      'democratizedspace/dspace',
+      'futuroptimist/sugarkube',
     ]);
-    expect(definitions[3].metrics?.[0]?.value).toBe('Hidden');
+    expect(definitions[3].metrics?.[0]?.value).toBe('Syncing');
+    expect(definitions[4].metrics?.[0]?.value).toBe('Syncing');
 
     service.emit(
       { owner: 'futuroptimist', repo: 'flywheel' },
@@ -237,16 +257,31 @@ describe('wireGitHubRepoMetrics', () => {
 
     service.emit(
       { owner: 'futuroptimist', repo: 'axel' },
-      { stars: 86, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+      { stars: 0, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
     );
-    expect(definitions[2].metrics?.[0]?.value).toBe('86 stars');
+    expect(definitions[2].metrics?.[0]?.value).toBe('0 stars');
+
+    service.emit(
+      { owner: 'democratizedspace', repo: 'dspace' },
+      { stars: 3, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    expect(definitions[3].metrics?.[0]?.value).toBe('3 stars');
+
+    service.emit(
+      { owner: 'futuroptimist', repo: 'sugarkube' },
+      { stars: 0, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    expect(definitions[4].metrics?.[0]?.value).toBe('0 stars');
     expect(
       service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
-    ).toBe(0);
+    ).toBe(1);
 
     controller.dispose();
     expect(
       service.listenerCount({ owner: 'futuroptimist', repo: 'flywheel' })
+    ).toBe(0);
+    expect(
+      service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
     ).toBe(0);
     const previousUpdates = updated.length;
     service.emit(

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -85,6 +85,73 @@ describe('GitHub repo stats service', () => {
     });
   });
 
+  it('loads runtime cache data for DSPACE, Sugarkube, and Axel including zero stars', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        source: 'github-api',
+        repos: {
+          'democratizedspace/dspace': {
+            owner: 'democratizedspace',
+            repo: 'dspace',
+            stars: 3,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/sugarkube': {
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/axel': {
+            owner: 'futuroptimist',
+            repo: 'axel',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+        },
+        errors: {},
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'democratizedspace', repo: 'dspace' })
+    ).resolves.toMatchObject({ stars: 3 });
+    expect(
+      service.getCachedStats({ owner: 'futuroptimist', repo: 'sugarkube' })
+    ).toMatchObject({ stars: 0 });
+    expect(
+      service.getCachedStats({ owner: 'futuroptimist', repo: 'axel' })
+    ).toMatchObject({ stars: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      cachedRepoCount: 3,
+    });
+  });
+
   it('does not map runtime watchers to stars', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -162,6 +162,7 @@ describe('i18n utilities', () => {
       'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
       'jobbot-studio-terminal',
+      'axel-studio-tracker',
       'gitshelves-living-room-installation',
       'danielsmith-portfolio-table',
       'f2clipboard-kitchen-console',
@@ -169,6 +170,7 @@ describe('i18n utilities', () => {
       'wove-kitchen-loom',
       'dspace-backyard-rocket',
       'pr-reaper-backyard-console',
+      'sugarkube-backyard-greenhouse',
     ]);
 
     for (const englishPoi of starBackedPois) {
@@ -268,29 +270,61 @@ describe('i18n utilities', () => {
     }
   });
 
-  it('marks every localized DSPACE GitHub star metric as private and neutral', () => {
+  it('covers public GitHub star metrics for DSPACE, Sugarkube, and Axel', () => {
     const numericFallbackPattern = /\d/;
-
-    for (const locale of AVAILABLE_LOCALES) {
-      const dspace = getPoiDefinitions(locale).find(
-        (poi) => poi.id === 'dspace-backyard-rocket'
-      );
-      const starMetric = dspace?.metrics?.find(
-        (metric) => metric.source?.type === 'githubStars'
-      );
-
-      expect(dspace, locale).toBeDefined();
-      expect(starMetric, locale).toBeDefined();
-      expect(starMetric?.source, locale).toMatchObject({
-        type: 'githubStars',
+    const expectedSources = {
+      'dspace-backyard-rocket': {
         owner: 'democratizedspace',
         repo: 'dspace',
-        visibility: 'private',
-      });
-      expect(starMetric?.value, locale).not.toMatch(numericFallbackPattern);
-      expect(starMetric?.source?.fallback ?? '', locale).not.toMatch(
-        numericFallbackPattern
-      );
+      },
+      'sugarkube-backyard-greenhouse': {
+        owner: 'futuroptimist',
+        repo: 'sugarkube',
+      },
+      'axel-studio-tracker': { owner: 'futuroptimist', repo: 'axel' },
+    } as const;
+
+    for (const locale of AVAILABLE_LOCALES) {
+      const definitions = getPoiDefinitions(locale);
+      for (const [poiId, expectedSource] of Object.entries(expectedSources)) {
+        const poi = definitions.find((definition) => definition.id === poiId);
+        const starMetric = poi?.metrics?.find(
+          (metric) => metric.source?.type === 'githubStars'
+        );
+
+        expect(poi, `${locale} ${poiId}`).toBeDefined();
+        expect(starMetric, `${locale} ${poiId}`).toBeDefined();
+        expect(starMetric?.source, `${locale} ${poiId}`).toMatchObject({
+          type: 'githubStars',
+          ...expectedSource,
+        });
+        expect(starMetric?.source?.visibility, `${locale} ${poiId}`).not.toBe(
+          'private'
+        );
+        expect(starMetric?.value, `${locale} ${poiId}`).not.toMatch(
+          numericFallbackPattern
+        );
+        expect(
+          starMetric?.source?.fallback ?? '',
+          `${locale} ${poiId}`
+        ).not.toMatch(numericFallbackPattern);
+      }
+    }
+  });
+
+  it('does not leave any POI GitHub stars pointed at futuroptimist/dspace', () => {
+    for (const locale of AVAILABLE_LOCALES) {
+      const definitions = getPoiDefinitions(locale);
+      const staleMetric = definitions
+        .flatMap((poi) => poi.metrics ?? [])
+        .find(
+          (metric) =>
+            metric.source?.type === 'githubStars' &&
+            metric.source.owner === 'futuroptimist' &&
+            metric.source.repo === 'dspace'
+        );
+
+      expect(staleMetric, locale).toBeUndefined();
     }
   });
 

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -648,6 +648,26 @@ describe('PoiTooltipOverlay', () => {
     expect(updatedValues).toContain('Updated workflow');
   });
 
+  it('renders zero-star GitHub metrics as visible values', () => {
+    const zeroStarPoi: PoiDefinition = {
+      ...basePoi,
+      id: 'sugarkube-backyard-greenhouse',
+      title: 'Sugarkube',
+      metrics: [{ label: 'Stars', value: '0 stars' }],
+    };
+
+    overlay.setHovered(zeroStarPoi);
+
+    const metric = container.querySelector('.poi-tooltip-overlay__metric');
+    expect(metric).toBeTruthy();
+    expect(
+      metric?.querySelector('.poi-tooltip-overlay__metric-label')?.textContent
+    ).toBe('Stars');
+    expect(
+      metric?.querySelector('.poi-tooltip-overlay__metric-value')?.textContent
+    ).toBe('0 stars');
+  });
+
   it('hides the outcome row when a POI omits the outcome field', () => {
     const poiWithoutOutcome: PoiDefinition = {
       ...basePoi,


### PR DESCRIPTION
### Motivation
- Ensure POI GitHub Stars point at the correct public repos and are backed by the runtime sidecar cache so no fake numeric fallbacks are shown. 
- Add missing Stars metrics for Sugarkube and Axel so zero-star repos render as valid fetched values. 
- Keep localized fallback copy neutral and preserve existing non-star copy.

### Description
- Point DSPACE star metric to the public `democratizedspace/dspace` and mark it `visibility: 'public'` instead of `futuroptimist/dspace`/private. 
- Add `githubStars` metric entries for `futuroptimist/axel` and `futuroptimist/sugarkube` across `en`, `zh-Hans`, `ja`, `ar`, `es`, `pt`, `de`, `hu`, and `en-x-pseudo` flows (via `latinLocaleOverrides` and individual locale files) using the neutral fallback `Syncing from GitHub…` and the same localized label/template pattern. 
- Broadened `starSource` helper signature in `latinLocaleOverrides` to accept `visibility?: 'public' | 'private'` so we can express public/private hints consistently. 
- Updated POI wiring to consume runtime-cache-backed metrics unchanged; kept fallback neutral (no numeric fallbacks introduced). 
- Tests: added/updated assertions in `src/tests/githubPoiMetrics.test.ts`, `src/tests/githubRepoStatsService.test.ts`, `src/tests/i18n.test.ts`, and `src/tests/poiTooltipOverlay.test.ts` to cover owner/org mismatch, public visibility, presence of `githubStars` sources for Axel/Sugarkube, mapping of runtime cache entries (including zero-star repos), and visible rendering of `0 stars`.

### Testing
- Ran formatting: `npm run format:write` (files formatted). 
- Lint: `npm run lint` — passed. 
- Targeted unit tests: `npm run test:ci -- src/tests/githubPoiMetrics.test.ts src/tests/githubRepoStatsService.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts` — all targeted tests passed. 
- Full unit test suite: `npm run test:ci` — all tests passed (137 files, 1017 tests in this environment). 
- Typecheck: `npm run typecheck` — failed due to existing unrelated TypeScript errors elsewhere in the repository; no type errors were introduced by these POI/locale/test changes. 
- Build: `npm run build` — passed and produced `dist`. 
- Docs check: `npm run docs:check` — passed (link checker emitted external fetch warnings). 
- Smoke: `npm run smoke` — passed. 
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets found.

Residual notes: `npm run typecheck` surfaced unrelated repository-wide TS issues; the POI/locale/test changes themselves are covered by unit tests and build/smoke checks passed. After this change lands, the Sugarkube sidecar repo list must be updated server-side so staging can populate those runtime cache entries at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237aa7cc3c832f88f57f2a4d453f09)