### PR TITLE
⭐ : – Fix POI GitHub star sources

### DIFF
--- a/charts/danielsmith/values.yaml
+++ b/charts/danielsmith/values.yaml
@@ -83,6 +83,10 @@ githubMetricsCache:
     - owner: democratizedspace
       repo: dspace
     - owner: futuroptimist
+      repo: axel
+    - owner: futuroptimist
+      repo: sugarkube
+    - owner: futuroptimist
       repo: pr-reaper
   resources:
     requests:

--- a/docs/assets/press-kit.json
+++ b/docs/assets/press-kit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtIso": "2026-06-04T03:26:52.636Z",
+  "generatedAtIso": "2026-06-06T06:30:53.249Z",
   "performance": {
     "budget": {
       "maxMaterials": 36,
@@ -338,6 +338,18 @@
       },
       "metrics": [
         {
+          "label": "Stars",
+          "value": "Syncing from GitHub…",
+          "source": {
+            "type": "githubStars",
+            "owner": "futuroptimist",
+            "repo": "axel",
+            "format": "compact",
+            "template": "{value} stars",
+            "fallback": "Syncing from GitHub…"
+          }
+        },
+        {
           "label": "Status",
           "value": "Alpha · pipx install axel"
         },
@@ -610,6 +622,7 @@
             "type": "githubStars",
             "owner": "democratizedspace",
             "repo": "dspace",
+            "visibility": "public",
             "format": "compact",
             "template": "{value} stars",
             "fallback": "Syncing from GitHub…"
@@ -697,6 +710,18 @@
         "name": "Backyard"
       },
       "metrics": [
+        {
+          "label": "Stars",
+          "value": "Syncing from GitHub…",
+          "source": {
+            "type": "githubStars",
+            "owner": "futuroptimist",
+            "repo": "sugarkube",
+            "format": "compact",
+            "template": "{value} stars",
+            "fallback": "Syncing from GitHub…"
+          }
+        },
         {
           "label": "Platform",
           "value": "k3s, Kubernetes helpers, Cloudflare tunnels, and solar tilt/irrigation notes"

--- a/playwright/github-metrics-fallback.spec.ts
+++ b/playwright/github-metrics-fallback.spec.ts
@@ -15,8 +15,15 @@ const RUNTIME_CACHE_REPOS = [
   'futuroptimist/sigma',
   'futuroptimist/wove',
   'democratizedspace/dspace',
+  'futuroptimist/axel',
+  'futuroptimist/sugarkube',
   'futuroptimist/pr-reaper',
 ] as const;
+
+const ZERO_STAR_RUNTIME_CACHE_REPOS = new Set([
+  'futuroptimist/axel',
+  'futuroptimist/sugarkube',
+]);
 
 const createRuntimeCacheRepos = () =>
   Object.fromEntries(
@@ -27,7 +34,7 @@ const createRuntimeCacheRepos = () =>
         {
           owner,
           repo,
-          stars: 77 + index,
+          stars: ZERO_STAR_RUNTIME_CACHE_REPOS.has(key) ? 0 : 77 + index,
           watchers: 1,
           forks: 2,
           openIssues: 0,

--- a/scripts/check-helm-github-metrics-cache.cjs
+++ b/scripts/check-helm-github-metrics-cache.cjs
@@ -133,6 +133,16 @@ assertIncludes(
   '"repo": "dspace"',
   'repo list should preserve the democratizedspace/dspace repo'
 );
+assertIncludes(
+  enabledRender,
+  '"repo": "axel"',
+  'repo list should include the Axel runtime star source'
+);
+assertIncludes(
+  enabledRender,
+  '"repo": "sugarkube"',
+  'repo list should include the Sugarkube runtime star source'
+);
 assertExcludes(
   enabledRender,
   'kind: Secret',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -728,6 +728,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Alpha releases keep README, FAQ, and threat model coverage in sync with the pytest suite.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         { label: 'Status', value: 'Alpha · pipx install axel' },
         {
           label: 'Repo analytics',
@@ -919,7 +931,7 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
+            visibility: 'public',
             format: 'compact',
             template: '{value} stars',
             fallback: 'Syncing from GitHub…',
@@ -981,6 +993,18 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
           'Docs cover the 3-node HA k3s happy path, Raspberry Pi imaging, flashing, verification, and solar hardware notes.',
       },
       metrics: [
+        {
+          label: 'Stars',
+          value: 'Syncing from GitHub…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} stars',
+            fallback: 'Syncing from GitHub…',
+          },
+        },
         {
           label: 'Platform',
           value:

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -844,7 +844,7 @@ function buildPoi(
 ): LocaleOverrides['poi'] {
   const starSource = (
     repo: string,
-    visibility?: 'private',
+    visibility?: 'public' | 'private',
     owner = 'futuroptimist'
   ) => ({
     type: 'githubStars' as const,
@@ -944,6 +944,11 @@ function buildPoi(
       summary: poi.axel.summary,
       outcome: { label: copy.strings.outcome, value: poi.axel.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('axel'),
+        },
         { label: poi.axel.metrics[0], value: poi.axel.metrics[1] },
         { label: poi.axel.metrics[2], value: poi.axel.metrics[3] },
         { label: poi.axel.metrics[4], value: poi.axel.metrics[5] },
@@ -1033,7 +1038,7 @@ function buildPoi(
         {
           label: githubStars.label,
           value: githubStars.value,
-          source: starSource('dspace', 'private', 'democratizedspace'),
+          source: starSource('dspace', 'public', 'democratizedspace'),
         },
         { label: poi.dspace.metrics[0], value: poi.dspace.metrics[1] },
         { label: poi.dspace.metrics[2], value: poi.dspace.metrics[3] },
@@ -1060,6 +1065,11 @@ function buildPoi(
       summary: poi.sugarkube.summary,
       outcome: { label: copy.strings.outcome, value: poi.sugarkube.outcome },
       metrics: [
+        {
+          label: githubStars.label,
+          value: githubStars.value,
+          source: starSource('sugarkube'),
+        },
         { label: poi.sugarkube.metrics[0], value: poi.sugarkube.metrics[1] },
         { label: poi.sugarkube.metrics[2], value: poi.sugarkube.metrics[3] },
         { label: poi.sugarkube.metrics[4], value: poi.sugarkube.metrics[5] },

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -583,6 +583,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: 'Alpha 版本让 README、FAQ 和威胁模型随 pytest 套件保持同步。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'axel',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: 'Alpha · pipx install axel' },
         { label: '仓库分析', value: '根据仓库列表和扫描进行任务规划' },
         { label: '文档', value: 'FAQ · 已知问题 · 威胁模型随测试维护' },
@@ -755,7 +767,7 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
             type: 'githubStars',
             owner: 'democratizedspace',
             repo: 'dspace',
-            visibility: 'private',
+            visibility: 'public',
             format: 'compact',
             template: '{value} 个星标',
             fallback: '正在从 GitHub 同步…',
@@ -807,6 +819,18 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         value: '在涉及磁盘、集群或硬件之前保持工作流可预演和有护栏。',
       },
       metrics: [
+        {
+          label: '星标',
+          value: '正在从 GitHub 同步…',
+          source: {
+            type: 'githubStars',
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            format: 'compact',
+            template: '{value} 个星标',
+            fallback: '正在从 GitHub 同步…',
+          },
+        },
         { label: '状态', value: '硬件/集群自动化' },
         { label: '安全', value: '干跑优先 · 受保护的破坏性命令' },
         { label: '范围', value: 'k3s · 太阳能 · 设备编排' },

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { wireGitHubRepoMetrics } from '../scene/poi/githubMetrics';
+import { getPoiDefinitions } from '../scene/poi/registry';
 import type { PoiDefinition } from '../scene/poi/types';
 import type {
   GitHubRepoIdentifier,
@@ -199,7 +200,8 @@ describe('wireGitHubRepoMetrics', () => {
               type: 'githubStars',
               owner: 'democratizedspace',
               repo: 'dspace',
-              visibility: 'private',
+              visibility: 'public',
+              template: '{value} stars',
               fallback: 'Hidden',
             },
           },
@@ -219,6 +221,7 @@ describe('wireGitHubRepoMetrics', () => {
     expect(service.requested).toEqual([
       'futuroptimist/flywheel',
       'futuroptimist/axel',
+      'democratizedspace/dspace',
     ]);
     expect(definitions[3].metrics?.[0]?.value).toBe('Hidden');
 
@@ -240,9 +243,15 @@ describe('wireGitHubRepoMetrics', () => {
       { stars: 86, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
     );
     expect(definitions[2].metrics?.[0]?.value).toBe('86 stars');
+
+    service.emit(
+      { owner: 'democratizedspace', repo: 'dspace' },
+      { stars: 3, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    expect(definitions[3].metrics?.[0]?.value).toBe('3 stars');
     expect(
       service.listenerCount({ owner: 'democratizedspace', repo: 'dspace' })
-    ).toBe(0);
+    ).toBe(1);
 
     controller.dispose();
     expect(
@@ -362,6 +371,48 @@ describe('wireGitHubRepoMetrics', () => {
       'futuroptimist/flywheel',
       'futuroptimist/axel',
     ]);
+    controller.dispose();
+  });
+
+  it('wires localized DSPACE, Sugarkube, and Axel definitions to runtime cache star values', async () => {
+    const definitions = getPoiDefinitions('en');
+    const byId = new Map(definitions.map((poi) => [poi.id, poi]));
+    const service = new MockRepoStatsService();
+    service.primeCache(
+      { owner: 'democratizedspace', repo: 'dspace' },
+      { stars: 3, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    service.primeCache(
+      { owner: 'futuroptimist', repo: 'sugarkube' },
+      { stars: 0, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+    service.primeCache(
+      { owner: 'futuroptimist', repo: 'axel' },
+      { stars: 0, watchers: 0, forks: 0, openIssues: 0, pushedAt: null }
+    );
+
+    const controller = wireGitHubRepoMetrics({ definitions, service });
+    await Promise.resolve();
+
+    expect(
+      byId
+        .get('dspace-backyard-rocket')
+        ?.metrics?.find((metric) => metric.source?.type === 'githubStars')
+        ?.value
+    ).toBe('3 stars');
+    expect(
+      byId
+        .get('sugarkube-backyard-greenhouse')
+        ?.metrics?.find((metric) => metric.source?.type === 'githubStars')
+        ?.value
+    ).toBe('0 stars');
+    expect(
+      byId
+        .get('axel-studio-tracker')
+        ?.metrics?.find((metric) => metric.source?.type === 'githubStars')
+        ?.value
+    ).toBe('0 stars');
+
     controller.dispose();
   });
 

--- a/src/tests/githubPoiMetrics.test.ts
+++ b/src/tests/githubPoiMetrics.test.ts
@@ -454,7 +454,7 @@ describe('wireGitHubRepoMetrics', () => {
         ],
       }),
       createPoi({
-        id: 'private-stars-poi',
+        id: 'danielsmith-portfolio-table',
         metrics: [
           {
             label: 'Stars',

--- a/src/tests/githubRepoStatsService.test.ts
+++ b/src/tests/githubRepoStatsService.test.ts
@@ -85,6 +85,71 @@ describe('GitHub repo stats service', () => {
     });
   });
 
+  it('loads runtime cache metrics for DSPACE, Sugarkube, and Axel including zero stars', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        generatedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-03T01:15:00.000Z',
+        repos: {
+          'democratizedspace/dspace': {
+            owner: 'democratizedspace',
+            repo: 'dspace',
+            stars: 3,
+            watchers: 1,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/sugarkube': {
+            owner: 'futuroptimist',
+            repo: 'sugarkube',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+          'futuroptimist/axel': {
+            owner: 'futuroptimist',
+            repo: 'axel',
+            stars: 0,
+            watchers: 0,
+            forks: 0,
+            openIssues: 0,
+            pushedAt: null,
+          },
+        },
+      }),
+    });
+    const service = createGitHubRepoStatsService(
+      fetch as unknown as typeof globalThis.fetch,
+      createOptions({
+        allowLiveFetch: false,
+        runtimeCacheUrl: '/runtime/github-metrics.json',
+        loadRuntimeCacheOnCreate: false,
+        now: () => Date.parse('2026-06-03T01:20:00.000Z'),
+      })
+    );
+
+    await expect(
+      service.requestStats({ owner: 'democratizedspace', repo: 'dspace' })
+    ).resolves.toMatchObject({ stars: 3 });
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'sugarkube' })
+    ).resolves.toMatchObject({ stars: 0 });
+    await expect(
+      service.requestStats({ owner: 'futuroptimist', repo: 'axel' })
+    ).resolves.toMatchObject({ stars: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(service.getDiagnostics()).toMatchObject({
+      source: 'runtime-cache',
+      requestCount: 0,
+      cachedRepoCount: 3,
+    });
+  });
+
   it('does not map runtime watchers to stars', async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -162,6 +162,7 @@ describe('i18n utilities', () => {
       'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
       'jobbot-studio-terminal',
+      'axel-studio-tracker',
       'gitshelves-living-room-installation',
       'danielsmith-portfolio-table',
       'f2clipboard-kitchen-console',
@@ -169,6 +170,7 @@ describe('i18n utilities', () => {
       'wove-kitchen-loom',
       'dspace-backyard-rocket',
       'pr-reaper-backyard-console',
+      'sugarkube-backyard-greenhouse',
     ]);
 
     for (const englishPoi of starBackedPois) {
@@ -268,7 +270,7 @@ describe('i18n utilities', () => {
     }
   });
 
-  it('marks every localized DSPACE GitHub star metric as private and neutral', () => {
+  it('marks every localized DSPACE GitHub star metric as public and neutral', () => {
     const numericFallbackPattern = /\d/;
 
     for (const locale of AVAILABLE_LOCALES) {
@@ -285,11 +287,68 @@ describe('i18n utilities', () => {
         type: 'githubStars',
         owner: 'democratizedspace',
         repo: 'dspace',
-        visibility: 'private',
+        visibility: 'public',
       });
       expect(starMetric?.value, locale).not.toMatch(numericFallbackPattern);
       expect(starMetric?.source?.fallback ?? '', locale).not.toMatch(
         numericFallbackPattern
+      );
+    }
+  });
+
+  it('adds runtime-backed stars to DSPACE, Sugarkube, and Axel without stale DSPACE owners', () => {
+    for (const locale of AVAILABLE_LOCALES) {
+      const definitions = getPoiDefinitions(locale);
+      const byId = new Map(definitions.map((poi) => [poi.id, poi]));
+      const expectedSources = [
+        {
+          id: 'dspace-backyard-rocket',
+          owner: 'democratizedspace',
+          repo: 'dspace',
+          visibility: 'public',
+        },
+        {
+          id: 'sugarkube-backyard-greenhouse',
+          owner: 'futuroptimist',
+          repo: 'sugarkube',
+          visibility: undefined,
+        },
+        {
+          id: 'axel-studio-tracker',
+          owner: 'futuroptimist',
+          repo: 'axel',
+          visibility: undefined,
+        },
+      ] as const;
+
+      for (const { id, owner, repo, visibility } of expectedSources) {
+        const starMetric = byId
+          .get(id)
+          ?.metrics?.find((metric) => metric.source?.type === 'githubStars');
+
+        expect(starMetric, `${locale} ${id}`).toBeDefined();
+        expect(starMetric?.source, `${locale} ${id}`).toMatchObject({
+          type: 'githubStars',
+          owner,
+          repo,
+        });
+        expect(starMetric?.source?.visibility, `${locale} ${id}`).toBe(
+          visibility
+        );
+      }
+
+      const starSources = definitions.flatMap((poi) =>
+        (poi.metrics ?? [])
+          .filter((metric) => metric.source?.type === 'githubStars')
+          .map((metric) => metric.source)
+      );
+      expect(starSources, locale).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            owner: 'futuroptimist',
+            repo: 'dspace',
+          }),
+        ])
       );
     }
   });

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -618,6 +618,24 @@ describe('PoiTooltipOverlay', () => {
     ).toBe('相关案例研究');
   });
 
+  it('renders zero-star metrics as visible values', () => {
+    overlay.setHovered({
+      ...basePoi,
+      id: 'sugarkube-backyard-greenhouse',
+      title: 'Sugarkube',
+      metrics: [{ label: 'Stars', value: '0 stars' }],
+    });
+
+    const metric = container.querySelector('.poi-tooltip-overlay__metric');
+    expect(metric).toBeTruthy();
+    expect(
+      metric?.querySelector('.poi-tooltip-overlay__metric-label')?.textContent
+    ).toBe('Stars');
+    expect(
+      metric?.querySelector('.poi-tooltip-overlay__metric-value')?.textContent
+    ).toBe('0 stars');
+  });
+
   it('skips rebuilding active POI content when updates do not change copy', () => {
     overlay.setHovered(basePoi);
     const metricSelector = '.poi-tooltip-overlay__metric';

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -718,7 +718,7 @@ describe('PoiTooltipOverlay', () => {
 
     const nextPoi: PoiDefinition = {
       ...basePoi,
-      id: 'futuroptimist-living-room-tv-variant',
+      id: 'jobbot-studio-terminal',
       title: 'Futuroptimist Alt',
       interactionPrompt: 'Inspect Futuroptimist Alt',
     };
@@ -879,7 +879,7 @@ describe('PoiTooltipOverlay', () => {
 
   it('hides recommendation badges when guided tour mode is disabled', () => {
     overlay.setIdleState(true);
-    preference.setEnabled(false, 'test');
+    preference.setEnabled(false, 'api');
     overlay.setRecommendation(basePoi);
     const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
     expect(root.classList.contains('poi-tooltip-overlay--visible')).toBe(false);
@@ -892,7 +892,7 @@ describe('PoiTooltipOverlay', () => {
     ) as HTMLSpanElement;
     expect(badge.hidden).toBe(true);
 
-    preference.setEnabled(true, 'test');
+    preference.setEnabled(true, 'api');
     expect(root.dataset.guidedTour).toBe('on');
     expect(badge.hidden).toBe(false);
   });
@@ -947,7 +947,7 @@ describe('PoiTooltipOverlay', () => {
       guidedTourPreference: preference,
     });
 
-    overlay.setSelected({ ...basePoi, summary: undefined });
+    overlay.setSelected({ ...basePoi, summary: '' });
 
     const liveRegion = container.querySelector(
       '.poi-tooltip-overlay__live-region'


### PR DESCRIPTION
### Motivation
- Ensure POI GitHub star metrics use the runtime sidecar cache sources (no stale/fake fallbacks) and correct owner for DSPACE. 
- Add missing Stars metrics for Sugarkube and Axel so zero-star repos are represented as valid fetched values.

### Description
- Point DSPACE star metric to the public `democratizedspace/dspace` and mark its visibility `public` across locales (no numeric fallbacks). 
- Add `githubStars` Stars metric entries for `futuroptimist/axel` and `futuroptimist/sugarkube` in supported locales (en, zh-Hans, ja, ar, es, pt, de, hu, en-x-pseudo via the shared latin overrides), preserving existing localized non-star copy. 
- Extend the latin locale POI builder to accept `visibility?: 'public' | 'private'` so explicit visibility can be set where needed. 
- Add/extend tests to cover owner/org mismatch and runtime-cache zero-star behavior: updates in `src/tests/githubPoiMetrics.test.ts`, `src/tests/githubRepoStatsService.test.ts`, `src/tests/i18n.test.ts`, and `src/tests/poiTooltipOverlay.test.ts` to assert correct sources and that `0 stars` renders as visible metric values.

### Testing
- `npm run format:write` — OK. 
- `npm run lint` — OK (one minor import-order lint warning was addressed). 
- `npm run typecheck` — NOT OK for this change: TypeScript typecheck failed with unrelated, pre-existing type errors elsewhere in the repo (these are outside the scope of this PR). 
- Targeted tests: `npm run test:ci -- src/tests/githubPoiMetrics.test.ts src/tests/githubRepoStatsService.test.ts src/tests/i18n.test.ts src/tests/poiTooltipOverlay.test.ts` — OK (all targeted assertions passed). 
- Full test suite: `npm run test:ci` — OK (tests passed). 
- `npm run build` — OK (production build completed). 

Residual risks / follow-ups: the Sugarkube sidecar repo list must be updated (Prompt 8B) so staging can actually serve these three metrics; otherwise the client will use neutral fallback states as designed. No numeric fallbacks or hard-coded star counts were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237aa7cc3c832f88f57f2a4d453f09)