### PR TITLE
Harden stair floor transitions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -367,6 +367,7 @@ import {
 } from './systems/movement/facing';
 import { computeStairLayout } from './systems/movement/stairLayout';
 import {
+  classifyStairTransitionZone,
   computeRampHeight as computeStairRampHeight,
   predictStairFloorId,
   sampleStairSurfaceHeight,
@@ -374,6 +375,7 @@ import {
   type FloorId,
   type StairBehavior,
   type StairGeometry,
+  type StairTransitionZoneSample,
 } from './systems/movement/stairs';
 import {
   NARRATION_PREFERENCE_STORAGE_KEY,
@@ -567,8 +569,24 @@ declare global {
           stairLandingMaxZ: number;
           stairLandingDepth: number;
           stairDirection: 1 | -1;
+          stairDescentCorridorHalfWidth: number;
+          stairZones: {
+            lowerStairEntrance: RectCollider;
+            stairRampBody: RectCollider;
+            upperLanding: RectCollider;
+          };
           upperFloorElevation: number;
         };
+        predictStairFloor(target: {
+          x: number;
+          z: number;
+          currentFloor?: FloorId;
+        }): FloorId;
+        classifyStairTransition(target: {
+          x: number;
+          z: number;
+          currentFloor?: FloorId;
+        }): StairTransitionZoneSample;
         getCeilingOpacities(): number[];
         // Test-only helper: current player yaw in radians
         getPlayerYaw?(): number;
@@ -1702,10 +1720,26 @@ function initializeImmersiveScene(
     landingTriggerMargin: stairLandingTriggerMargin,
     stepRise: STAIRCASE_CONFIG.step.rise,
   };
-  const stairNavArea = createStairNavAreaRect(stairGeometry, {
+  const stairGroundNavArea = createStairNavAreaRect(stairGeometry, {
     marginX: PLAYER_RADIUS * 0.5,
     marginZ: PLAYER_RADIUS,
   });
+  const stairLandingNavArea: RectCollider = {
+    minX: stairCenterX - stairHalfWidth - PLAYER_RADIUS * 0.5,
+    maxX: stairCenterX + stairHalfWidth + PLAYER_RADIUS * 0.5,
+    minZ: stairLandingMinZ - PLAYER_RADIUS * 0.25,
+    maxZ: stairLandingMaxZ + PLAYER_RADIUS * 0.25,
+  };
+  const stairDescentCorridorHalfWidth = Math.max(
+    stairHalfWidth - stairTransitionMargin * 0.35,
+    stairHalfWidth * 0.55
+  );
+  const stairDescentCorridorNavArea: RectCollider = {
+    minX: stairCenterX - stairDescentCorridorHalfWidth,
+    maxX: stairCenterX + stairDescentCorridorHalfWidth,
+    minZ: Math.min(stairBottomZ, stairTopZ) - PLAYER_RADIUS * 0.25,
+    maxZ: Math.max(stairBottomZ, stairTopZ) + PLAYER_RADIUS * 0.25,
+  };
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -1721,6 +1755,26 @@ function initializeImmersiveScene(
     maxX: stairCenterX + stairHalfWidth + stairGuardThickness,
     minZ: stairGuardMinZ,
     maxZ: stairGuardMaxZ,
+  });
+
+  // Invisible upper-floor guard rails close the stairwell margins while leaving
+  // the central descent corridor open. They keep ordinary upstairs movement
+  // from drifting into the transition trigger on the landing edge without
+  // blocking intentional movement down the usable stair run.
+  const upperStairVoidGuardMargin = toWorldUnits(0.08);
+  const upperStairVoidGuardMinZ = Math.min(stairBottomZ, stairTopZ);
+  const upperStairVoidGuardMaxZ = Math.max(stairBottomZ, stairTopZ);
+  upperFloorColliders.push({
+    minX: stairCenterX - stairHalfWidth - stairTransitionMargin,
+    maxX: stairCenterX - stairHalfWidth - upperStairVoidGuardMargin,
+    minZ: upperStairVoidGuardMinZ,
+    maxZ: upperStairVoidGuardMaxZ,
+  });
+  upperFloorColliders.push({
+    minX: stairCenterX + stairHalfWidth + upperStairVoidGuardMargin,
+    maxX: stairCenterX + stairHalfWidth + stairTransitionMargin,
+    minZ: upperStairVoidGuardMinZ,
+    maxZ: upperStairVoidGuardMaxZ,
   });
 
   const upperFloorGroup = new Group();
@@ -1837,12 +1891,12 @@ function initializeImmersiveScene(
     ground: createNavMesh(FLOOR_PLAN, {
       padding: doorwayPadding,
       depth: doorwayDepth,
-      extraZones: [stairNavArea],
+      extraZones: [stairGroundNavArea],
     }),
     upper: createNavMesh(UPPER_FLOOR_PLAN, {
       padding: doorwayPadding,
       depth: doorwayDepth,
-      extraZones: [stairNavArea],
+      extraZones: [stairLandingNavArea, stairDescentCorridorNavArea],
     }),
   };
 
@@ -2886,8 +2940,38 @@ function initializeImmersiveScene(
           stairLandingMaxZ,
           stairLandingDepth: stairLandingDepth,
           stairDirection: stairLayout.directionMultiplier,
+          stairDescentCorridorHalfWidth,
+          stairZones: {
+            lowerStairEntrance: { ...stairGroundNavArea },
+            stairRampBody: { ...stairDescentCorridorNavArea },
+            upperLanding: { ...stairLandingNavArea },
+          },
           upperFloorElevation,
         };
+      },
+      predictStairFloor(target: {
+        x: number;
+        z: number;
+        currentFloor?: FloorId;
+      }) {
+        return predictFloorId(
+          target.x,
+          target.z,
+          target.currentFloor ?? activeFloorId
+        );
+      },
+      classifyStairTransition(target: {
+        x: number;
+        z: number;
+        currentFloor?: FloorId;
+      }) {
+        return classifyStairTransitionZone(
+          stairGeometry,
+          stairBehavior,
+          target.x,
+          target.z,
+          target.currentFloor ?? activeFloorId
+        );
       },
       // Test helpers – expose current mannequin yaw in radians.
       getPlayerYaw() {

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -23,6 +23,34 @@ export interface StairBehavior {
 
 const DENOMINATOR_EPSILON = 1e-6;
 
+export type StairTransitionZone =
+  | 'lowerStairEntrance'
+  | 'stairRampBody'
+  | 'upperLanding'
+  | 'safeUpperFloor'
+  | 'explicitDescentCorridor';
+
+export interface StairTransitionZoneSample {
+  zone: StairTransitionZone;
+  withinStairWidth: boolean;
+  withinCoreStairWidth: boolean;
+  withinDescentCorridorWidth: boolean;
+  withinRampZ: boolean;
+  withinLanding: boolean;
+}
+
+const isBetween = (value: number, a: number, b: number, margin = 0): boolean =>
+  value >= Math.min(a, b) - margin && value <= Math.max(a, b) + margin;
+
+const getDescentCorridorHalfWidth = (
+  geometry: StairGeometry,
+  behavior: StairBehavior
+): number =>
+  Math.max(
+    geometry.halfWidth - behavior.transitionMargin * 0.35,
+    geometry.halfWidth * 0.55
+  );
+
 export const isWithinStairWidth = (
   geometry: StairGeometry,
   x: number,
@@ -60,6 +88,98 @@ export const computeRampHeight = (
   return clamped * geometry.totalRise;
 };
 
+export const classifyStairTransitionZone = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  x: number,
+  z: number,
+  current: FloorId
+): StairTransitionZoneSample => {
+  const direction =
+    geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
+  const withinStairWidth = isWithinStairWidth(
+    geometry,
+    x,
+    behavior.transitionMargin
+  );
+  const withinCoreStairWidth = isWithinStairWidth(geometry, x);
+  const descentCorridorHalfWidth = getDescentCorridorHalfWidth(
+    geometry,
+    behavior
+  );
+  const withinDescentCorridorWidth =
+    Math.abs(x - geometry.centerX) <= descentCorridorHalfWidth;
+  const withinLanding = isWithinLanding(
+    geometry,
+    x,
+    z,
+    behavior.landingTriggerMargin
+  );
+  const withinRampZ = isBetween(
+    z,
+    geometry.bottomZ,
+    geometry.topZ,
+    behavior.transitionMargin * 0.5
+  );
+  const nearBottom =
+    direction === -1
+      ? z >= geometry.bottomZ - behavior.transitionMargin * 0.5
+      : z <= geometry.bottomZ + behavior.transitionMargin * 0.5;
+
+  if (withinLanding) {
+    return {
+      zone: 'upperLanding',
+      withinStairWidth,
+      withinCoreStairWidth,
+      withinDescentCorridorWidth,
+      withinRampZ,
+      withinLanding,
+    };
+  }
+
+  if (current === 'upper' && withinDescentCorridorWidth && withinRampZ) {
+    return {
+      zone: 'explicitDescentCorridor',
+      withinStairWidth,
+      withinCoreStairWidth,
+      withinDescentCorridorWidth,
+      withinRampZ,
+      withinLanding,
+    };
+  }
+
+  if (withinCoreStairWidth && withinRampZ) {
+    return {
+      zone: 'stairRampBody',
+      withinStairWidth,
+      withinCoreStairWidth,
+      withinDescentCorridorWidth,
+      withinRampZ,
+      withinLanding,
+    };
+  }
+
+  if (withinCoreStairWidth && nearBottom) {
+    return {
+      zone: 'lowerStairEntrance',
+      withinStairWidth,
+      withinCoreStairWidth,
+      withinDescentCorridorWidth,
+      withinRampZ,
+      withinLanding,
+    };
+  }
+
+  return {
+    zone: 'safeUpperFloor',
+    withinStairWidth,
+    withinCoreStairWidth,
+    withinDescentCorridorWidth,
+    withinRampZ,
+    withinLanding,
+  };
+};
+
 export const predictStairFloorId = (
   geometry: StairGeometry,
   behavior: StairBehavior,
@@ -68,53 +188,22 @@ export const predictStairFloorId = (
   current: FloorId
 ): FloorId => {
   const rampHeight = computeRampHeight(geometry, behavior, x, z);
-  const withinStairs = isWithinStairWidth(
-    geometry,
-    x,
-    behavior.transitionMargin
-  );
   const direction =
     geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
+  const zoneSample = classifyStairTransitionZone(
+    geometry,
+    behavior,
+    x,
+    z,
+    current
+  );
 
   if (current === 'upper') {
-    if (!withinStairs) {
-      return 'upper';
-    }
-
-    const baseExitHalfWidth = Math.max(
-      geometry.halfWidth - behavior.transitionMargin * 0.5,
-      geometry.halfWidth * 0.5
-    );
-    const withinBaseExit = Math.abs(x - geometry.centerX) <= baseExitHalfWidth;
-
-    const withinLanding = isWithinLanding(
-      geometry,
-      x,
-      z,
-      behavior.landingTriggerMargin
-    );
-    if (withinLanding) {
-      return 'upper';
-    }
-
-    const hasLeftLanding =
-      rampHeight < geometry.totalRise - behavior.stepRise * 0.1;
-    const bottomThreshold =
-      direction === -1
-        ? geometry.bottomZ - behavior.transitionMargin * 0.5
-        : geometry.bottomZ + behavior.transitionMargin * 0.5;
-
-    if (hasLeftLanding) {
-      const reachedLowerRegion =
-        direction === -1 ? z <= bottomThreshold : z >= bottomThreshold;
-      if (reachedLowerRegion) {
-        return 'ground';
-      }
-    }
-
-    const crossedBaseExit =
-      direction === -1 ? z >= geometry.bottomZ : z <= geometry.bottomZ;
-    if (withinBaseExit && crossedBaseExit) {
+    // Upper-to-ground transitions are intentionally narrower than the full
+    // stair nav footprint. The broad footprint keeps ascent forgiving, while
+    // this named descent corridor prevents landing-edge drift from reviving
+    // accidental teleport goblins.
+    if (zoneSample.zone === 'explicitDescentCorridor') {
       return 'ground';
     }
 
@@ -127,10 +216,10 @@ export const predictStairFloorId = (
       : z >= geometry.topZ - behavior.transitionMargin;
 
   const nearLanding =
-    withinStairs &&
+    zoneSample.withinStairWidth &&
     (nearTop ||
       rampHeight >= geometry.totalRise - behavior.stepRise * 0.25 ||
-      isWithinLanding(geometry, x, z, behavior.landingTriggerMargin));
+      zoneSample.withinLanding);
   if (nearLanding) {
     return 'upper';
   }
@@ -165,13 +254,24 @@ export const sampleStairSurfaceHeight = ({
     currentFloor
   );
   if (predictedFloor === 'upper') {
+    const zoneSample = classifyStairTransitionZone(
+      geometry,
+      behavior,
+      x,
+      z,
+      currentFloor
+    );
     const withinStairWidth = isWithinStairWidth(
       geometry,
       x,
       behavior.transitionMargin
     );
     const onLanding = isWithinLanding(geometry, x, z);
-    if (!withinStairWidth || onLanding) {
+    if (
+      (currentFloor === 'upper' && zoneSample.zone === 'safeUpperFloor') ||
+      !withinStairWidth ||
+      onLanding
+    ) {
       return upperFloorElevation;
     }
   }

--- a/src/tests/movement/stairSurfaceHeight.test.ts
+++ b/src/tests/movement/stairSurfaceHeight.test.ts
@@ -68,6 +68,13 @@ describe('sampleStairSurfaceHeight', () => {
     expect(height).toBeCloseTo(upperFloorElevation, 6);
   });
 
+  it('keeps safe upper-floor edges at the upper floor elevation', () => {
+    const edgeX = geometry.centerX + geometry.halfWidth + toWorldUnits(0.12);
+    const edgeZ = geometry.topZ - toWorldUnits(0.45);
+    const height = sample({ x: edgeX, z: edgeZ, currentFloor: 'upper' });
+    expect(height).toBeCloseTo(upperFloorElevation, 6);
+  });
+
   it('clamps to ground level when outside the stair span', () => {
     const farEastX = geometry.centerX + geometry.halfWidth + toWorldUnits(0.8);
     const height = sample({

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
 import {
+  classifyStairTransitionZone,
   createStairNavAreaRect,
   predictStairFloorId,
   type FloorId,
@@ -40,13 +41,29 @@ const STAIR_BEHAVIOR: StairBehavior = {
 };
 
 describe('stair floor transitions (negative Z ascent)', () => {
+  it('transitions from ground to upper near the top of the stairs', () => {
+    const currentFloor: FloorId = 'ground';
+    const nearTopZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.25);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      NEGATIVE_Z_STAIRS.centerX,
+      nearTopZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+  });
+
   it('keeps the player on the upper floor when walking above the stair void', () => {
     const currentFloor: FloorId = 'upper';
     const walkwayZ = NEGATIVE_Z_STAIRS.bottomZ - toWorldUnits(0.2);
     const result = predictStairFloorId(
       NEGATIVE_Z_STAIRS,
       STAIR_BEHAVIOR,
-      NEGATIVE_Z_STAIRS.centerX,
+      NEGATIVE_Z_STAIRS.centerX +
+        NEGATIVE_Z_STAIRS.halfWidth +
+        toWorldUnits(0.1),
       walkwayZ,
       currentFloor
     );
@@ -80,6 +97,88 @@ describe('stair floor transitions (negative Z ascent)', () => {
       STAIR_BEHAVIOR,
       westLandingX,
       southOfLandingZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+  });
+
+  it('keeps the player upstairs in a nearby room south of the landing edge', () => {
+    const currentFloor: FloorId = 'upper';
+    const nearbyRoomX = NEGATIVE_Z_STAIRS.centerX + toWorldUnits(2.9);
+    const nearbyRoomZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(1.5);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      nearbyRoomX,
+      nearbyRoomZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+  });
+
+  it('keeps the screenshot-like landing-edge drift upstairs instead of teleporting', () => {
+    const currentFloor: FloorId = 'upper';
+    const landingEdgeX =
+      NEGATIVE_Z_STAIRS.centerX +
+      NEGATIVE_Z_STAIRS.halfWidth +
+      toWorldUnits(0.12);
+    const landingEdgeZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.45);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      landingEdgeX,
+      landingEdgeZ,
+      currentFloor
+    );
+    const zone = classifyStairTransitionZone(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      landingEdgeX,
+      landingEdgeZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+    expect(zone.zone).toBe('safeUpperFloor');
+    expect(zone.withinDescentCorridorWidth).toBe(false);
+  });
+
+  it('allows deliberate upper-to-ground descent inside the central corridor', () => {
+    const currentFloor: FloorId = 'upper';
+    const descentZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.6);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      NEGATIVE_Z_STAIRS.centerX,
+      descentZ,
+      currentFloor
+    );
+    const zone = classifyStairTransitionZone(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      NEGATIVE_Z_STAIRS.centerX,
+      descentZ,
+      currentFloor
+    );
+
+    expect(result).toBe('ground');
+    expect(zone.zone).toBe('explicitDescentCorridor');
+  });
+
+  it('does not transition floors for lateral movement outside the stair width', () => {
+    const currentFloor: FloorId = 'upper';
+    const lateralX =
+      NEGATIVE_Z_STAIRS.centerX +
+      NEGATIVE_Z_STAIRS.halfWidth +
+      toWorldUnits(0.5);
+    const rampZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(1.0);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      lateralX,
+      rampZ,
       currentFloor
     );
 


### PR DESCRIPTION
### Motivation
- Prevent accidental upstairs->ground teleport when the player drifts near the upper landing edge by making descent an explicit, narrow action.
- Keep ascent forgiving while making upstairs roaming and room movement deterministic and free of teleport “drift”.
- Provide actionable debug/test helpers (stair metrics, zone classifier, floor predictor) so coordinates and regressions can be reported precisely.

### Description
- Add named stair transition zones and a classifier (`StairTransitionZone`, `classifyStairTransitionZone`) and use it to make `predictStairFloorId` require an `explicitDescentCorridor` for upper-to-ground transitions (changes in `src/systems/movement/stairs.ts`).
- Split the single shared stair nav area into floor-specific zones (`stairGroundNavArea`, `stairLandingNavArea`, `stairDescentCorridorNavArea`) and use those as `extraZones` for `createNavMesh`, avoiding a broad upstairs rectangle that could trigger teleportation (changes in `src/main.ts`).
- Add invisible upper-floor guard colliders around the stair void that keep ordinary upstairs movement from entering the teleport trigger while leaving the central descent corridor open for intentional descent (changes in `src/main.ts`).
- Make stair surface sampling respect the new zone classification so safe upper-floor edges and nearby rooms sample `upperFloorElevation` instead of ramp height (changes in `src/systems/movement/stairs.ts`).
- Expose helpers and metrics on `window.portfolio.world` including `getStairMetrics()`, `predictStairFloor(...)`, and `classifyStairTransition(...)` for QA and bug reports (changes in `src/main.ts`).
- Add regression tests covering ascent, landing interior, lateral non-transition, screenshot-like landing-edge drift, explicit descent corridor behavior, and height sampling (changes in `src/tests/movement/stairTransitions.test.ts` and `src/tests/movement/stairSurfaceHeight.test.ts`).

### Testing
- `npm run format:write -- src/systems/movement/stairs.ts src/tests/movement/stairTransitions.test.ts src/main.ts` — ran and succeeded.
- `npm run format:write -- src/tests/movement/stairSurfaceHeight.test.ts` — ran and succeeded.
- `npm run lint` — ran and succeeded.
- `npm run typecheck` — run but failed due to unrelated repo-wide TypeScript issues (first error: `src/main.ts(2644,33): error TS2345`); this is not introduced by this change.
- Unit tests: `npm run test:ci -- src/tests/movement/stairLayout.test.ts` and `npm run test:ci -- src/tests/movement/stairTransitions.test.ts src/tests/movement/stairSurfaceHeight.test.ts` — targeted tests passed; `npm run test:ci` (full suite) also passed locally (all tests ran green).
- `npm run build` — build succeeded.
- Playwright e2e: `npm run test:e2e -- playwright/small-screen-hud.spec.ts` initially reported missing browser binaries, then `npx playwright install chromium` and `npx playwright install-deps chromium` were run and the e2e tests passed.
- Docs & smoke: `npm run docs:check` and `npm run smoke` ran and passed.
- Secret scan: `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

Files changed (high level): `src/systems/movement/stairs.ts`, `src/main.ts`, and test files under `src/tests/movement/`.

Residual notes: `tsc --noEmit` reports pre-existing type errors unrelated to this change; those should be addressed independently to restore a clean typecheck in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23bce30f40832f8c0e031dbc804980)