### PR TITLE
Harden stair floor transitions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -368,9 +368,10 @@ import {
 import { computeStairLayout } from './systems/movement/stairLayout';
 import {
   computeRampHeight as computeStairRampHeight,
+  classifyStairTransitionZone,
+  createStairNavigationZones,
   predictStairFloorId,
   sampleStairSurfaceHeight,
-  createStairNavAreaRect,
   type FloorId,
   type StairBehavior,
   type StairGeometry,
@@ -558,6 +559,16 @@ declare global {
         setActiveFloor(next: FloorId): void;
         movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
         getPlayerPosition(): { x: number; y: number; z: number };
+        predictFloorAt(target: {
+          x: number;
+          z: number;
+          currentFloor?: FloorId;
+        }): FloorId;
+        getStairTransitionZone(target: {
+          x: number;
+          z: number;
+          currentFloor?: FloorId;
+        }): string;
         getStairMetrics(): {
           stairCenterX: number;
           stairHalfWidth: number;
@@ -1701,11 +1712,37 @@ function initializeImmersiveScene(
     transitionMargin: stairTransitionMargin,
     landingTriggerMargin: stairLandingTriggerMargin,
     stepRise: STAIRCASE_CONFIG.step.rise,
+    descentCorridorInset: PLAYER_RADIUS,
   };
-  const stairNavArea = createStairNavAreaRect(stairGeometry, {
-    marginX: PLAYER_RADIUS * 0.5,
-    marginZ: PLAYER_RADIUS,
-  });
+  const stairNavigationZones = createStairNavigationZones(
+    stairGeometry,
+    stairBehavior
+  );
+  const groundStairNavZones = [
+    stairNavigationZones.lowerStairEntrance,
+    stairNavigationZones.stairRampBody,
+    stairNavigationZones.upperLanding,
+  ];
+  const upperStairNavZones = [stairNavigationZones.upperLanding];
+  const upperStairDescentGuardMinZ = Math.min(stairTopZ, stairBottomZ);
+  const upperStairDescentGuardMaxZ = Math.max(stairTopZ, stairBottomZ);
+  // Invisible upper-floor guard rails flank the intentional descent corridor.
+  // They keep normal landing/room movement from drifting into the stairwell
+  // void while leaving the middle corridor open for deliberate stair descent.
+  upperFloorColliders.push(
+    {
+      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+      maxX: stairNavigationZones.explicitDescentCorridor.minX,
+      minZ: upperStairDescentGuardMinZ,
+      maxZ: upperStairDescentGuardMaxZ,
+    },
+    {
+      minX: stairNavigationZones.explicitDescentCorridor.maxX,
+      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+      minZ: upperStairDescentGuardMinZ,
+      maxZ: upperStairDescentGuardMaxZ,
+    }
+  );
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -1837,12 +1874,12 @@ function initializeImmersiveScene(
     ground: createNavMesh(FLOOR_PLAN, {
       padding: doorwayPadding,
       depth: doorwayDepth,
-      extraZones: [stairNavArea],
+      extraZones: groundStairNavZones,
     }),
     upper: createNavMesh(UPPER_FLOOR_PLAN, {
       padding: doorwayPadding,
       depth: doorwayDepth,
-      extraZones: [stairNavArea],
+      extraZones: upperStairNavZones,
     }),
   };
 
@@ -2875,6 +2912,26 @@ function initializeImmersiveScene(
           y: player.position.y,
           z: player.position.z,
         };
+      },
+      predictFloorAt(target: { x: number; z: number; currentFloor?: FloorId }) {
+        return predictFloorId(
+          target.x,
+          target.z,
+          target.currentFloor ?? activeFloorId
+        );
+      },
+      getStairTransitionZone(target: {
+        x: number;
+        z: number;
+        currentFloor?: FloorId;
+      }) {
+        return classifyStairTransitionZone(
+          stairGeometry,
+          stairBehavior,
+          target.x,
+          target.z,
+          target.currentFloor ?? activeFloorId
+        );
       },
       getStairMetrics() {
         return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,12 +367,12 @@ import {
 } from './systems/movement/facing';
 import { computeStairLayout } from './systems/movement/stairLayout';
 import {
-  computeRampHeight as computeStairRampHeight,
   classifyStairTransitionZone,
   createStairNavigationZones,
   predictStairFloorId,
   sampleStairSurfaceHeight,
   type FloorId,
+  type StairTransitionZone,
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
@@ -568,7 +568,7 @@ declare global {
           x: number;
           z: number;
           currentFloor?: FloorId;
-        }): string;
+        }): StairTransitionZone;
         getStairMetrics(): {
           stairCenterX: number;
           stairHalfWidth: number;
@@ -3518,9 +3518,6 @@ function initializeImmersiveScene(
     })
   );
 
-  const computeRampHeight = (x: number, z: number): number =>
-    computeStairRampHeight(stairGeometry, stairBehavior, x, z);
-
   const predictFloorId = (x: number, z: number, current: FloorId): FloorId =>
     predictStairFloorId(stairGeometry, stairBehavior, x, z, current);
 
@@ -3558,11 +3555,14 @@ function initializeImmersiveScene(
   };
 
   const updatePlayerVerticalPosition = () => {
-    const rampHeight = computeRampHeight(player.position.x, player.position.z);
-    const baseHeight =
-      activeFloorId === 'upper'
-        ? upperFloorElevation
-        : Math.min(rampHeight, upperFloorElevation);
+    const baseHeight = sampleStairSurfaceHeight({
+      geometry: stairGeometry,
+      behavior: stairBehavior,
+      x: player.position.x,
+      z: player.position.z,
+      currentFloor: activeFloorId,
+      upperFloorElevation,
+    });
     player.position.y = PLAYER_RADIUS + baseHeight;
   };
 

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -55,6 +55,15 @@ const isWithinZRange = (
   margin = 0
 ): boolean => z >= minZ - margin && z <= maxZ + margin;
 
+const getDescentDistanceFromLanding = (
+  geometry: StairGeometry,
+  z: number
+): number =>
+  geometry.direction === -1 ? z - geometry.topZ : geometry.topZ - z;
+
+const getSmoothstep = (value: number): number =>
+  value * value * (3 - 2 * value);
+
 const getDescentCorridorHalfWidth = (
   geometry: StairGeometry,
   behavior: StairBehavior
@@ -164,6 +173,29 @@ export const createStairNavigationZones = (
   };
 };
 
+const isInExplicitDescentCorridor = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  x: number,
+  z: number
+): boolean => {
+  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
+  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
+  const descentDistance = getDescentDistanceFromLanding(geometry, z);
+  const insideRampZ = isWithinZRange(
+    z,
+    rampMinZ,
+    rampMaxZ,
+    behavior.transitionMargin * 0.5
+  );
+
+  return (
+    descentDistance > behavior.landingTriggerMargin &&
+    insideRampZ &&
+    isWithinDescentCorridorWidth(geometry, behavior, x)
+  );
+};
+
 export const classifyStairTransitionZone = (
   geometry: StairGeometry,
   behavior: StairBehavior,
@@ -171,8 +203,6 @@ export const classifyStairTransitionZone = (
   z: number,
   current: FloorId
 ): StairTransitionZone => {
-  const direction =
-    geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
   const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
   const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
   const inActualStairWidth = isWithinStairWidth(geometry, x);
@@ -190,21 +220,9 @@ export const classifyStairTransitionZone = (
     return 'upperLanding';
   }
 
-  const hasLeftLandingForDescent =
-    direction === -1
-      ? z > geometry.topZ + behavior.landingTriggerMargin
-      : z < geometry.topZ - behavior.landingTriggerMargin;
-  const insideRampZ = isWithinZRange(
-    z,
-    rampMinZ,
-    rampMaxZ,
-    behavior.transitionMargin * 0.5
-  );
   if (
     current === 'upper' &&
-    hasLeftLandingForDescent &&
-    insideRampZ &&
-    isWithinDescentCorridorWidth(geometry, behavior, x)
+    isInExplicitDescentCorridor(geometry, behavior, x, z)
   ) {
     return 'explicitDescentCorridor';
   }
@@ -212,6 +230,8 @@ export const classifyStairTransitionZone = (
   if (current === 'upper') {
     return 'safeUpperFloor';
   }
+
+  const direction = geometry.direction;
 
   if (inActualStairWidth && isWithinZRange(z, rampMinZ, rampMaxZ)) {
     return 'stairRampBody';
@@ -244,11 +264,14 @@ export const predictStairFloorId = (
     x,
     behavior.transitionMargin
   );
-  const direction =
-    geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
+  const direction = geometry.direction;
 
   if (current === 'upper') {
     return zone === 'explicitDescentCorridor' ? 'ground' : 'upper';
+  }
+
+  if (isInExplicitDescentCorridor(geometry, behavior, x, z)) {
+    return 'ground';
   }
 
   const nearTop =
@@ -307,6 +330,22 @@ export const sampleStairSurfaceHeight = ({
     currentFloor === 'upper'
   ) {
     return upperFloorElevation;
+  }
+
+  if (isInExplicitDescentCorridor(geometry, behavior, x, z)) {
+    const blendRange = Math.max(
+      behavior.transitionMargin - behavior.landingTriggerMargin,
+      DENOMINATOR_EPSILON
+    );
+    const descentDistance = getDescentDistanceFromLanding(geometry, z);
+    const descentProgress = MathUtils.clamp(
+      (descentDistance - behavior.landingTriggerMargin) / blendRange,
+      0,
+      1
+    );
+    const lipBlend = getSmoothstep(descentProgress);
+
+    return MathUtils.lerp(upperFloorElevation, clampedRamp, lipBlend);
   }
 
   return clampedRamp;

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -19,9 +19,70 @@ export interface StairBehavior {
   transitionMargin: number;
   landingTriggerMargin: number;
   stepRise: number;
+  /**
+   * Amount removed from each stair side when deciding that an upper-floor
+   * player deliberately entered the descent corridor. Keeping this stricter
+   * than ascent width prevents landing-edge drift from becoming a floor hop.
+   */
+  descentCorridorInset?: number;
+}
+
+export type StairTransitionZone =
+  | 'lowerStairEntrance'
+  | 'stairRampBody'
+  | 'upperLanding'
+  | 'safeUpperFloor'
+  | 'explicitDescentCorridor'
+  | 'outsideStairs';
+
+export interface StairNavigationZones {
+  lowerStairEntrance: RectCollider;
+  stairRampBody: RectCollider;
+  upperLanding: RectCollider;
+  explicitDescentCorridor: RectCollider;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
+
+const getMinZ = (...values: number[]): number => Math.min(...values);
+
+const getMaxZ = (...values: number[]): number => Math.max(...values);
+
+const isWithinZRange = (
+  z: number,
+  minZ: number,
+  maxZ: number,
+  margin = 0
+): boolean => z >= minZ - margin && z <= maxZ + margin;
+
+const getDescentCorridorHalfWidth = (
+  geometry: StairGeometry,
+  behavior: StairBehavior
+): number => {
+  const inset =
+    behavior.descentCorridorInset ?? behavior.transitionMargin * 0.25;
+  return Math.max(geometry.halfWidth - inset, geometry.halfWidth * 0.55);
+};
+
+const isWithinDescentCorridorWidth = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  x: number
+): boolean =>
+  Math.abs(x - geometry.centerX) <=
+  getDescentCorridorHalfWidth(geometry, behavior);
+
+const createCenteredRect = (
+  geometry: StairGeometry,
+  halfWidth: number,
+  minZ: number,
+  maxZ: number
+): RectCollider => ({
+  minX: geometry.centerX - halfWidth,
+  maxX: geometry.centerX + halfWidth,
+  minZ,
+  maxZ,
+});
 
 export const isWithinStairWidth = (
   geometry: StairGeometry,
@@ -60,6 +121,115 @@ export const computeRampHeight = (
   return clamped * geometry.totalRise;
 };
 
+export const createStairNavigationZones = (
+  geometry: StairGeometry,
+  behavior: StairBehavior
+): StairNavigationZones => {
+  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
+  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
+  const entranceMinZ =
+    geometry.direction === -1
+      ? geometry.bottomZ - behavior.transitionMargin
+      : geometry.bottomZ;
+  const entranceMaxZ =
+    geometry.direction === -1
+      ? geometry.bottomZ
+      : geometry.bottomZ + behavior.transitionMargin;
+
+  return {
+    lowerStairEntrance: createCenteredRect(
+      geometry,
+      geometry.halfWidth + behavior.transitionMargin,
+      getMinZ(entranceMinZ, entranceMaxZ),
+      getMaxZ(entranceMinZ, entranceMaxZ)
+    ),
+    stairRampBody: createCenteredRect(
+      geometry,
+      geometry.halfWidth + behavior.transitionMargin * 0.25,
+      rampMinZ,
+      rampMaxZ
+    ),
+    upperLanding: createCenteredRect(
+      geometry,
+      geometry.halfWidth + behavior.landingTriggerMargin,
+      geometry.landingMinZ,
+      geometry.landingMaxZ
+    ),
+    explicitDescentCorridor: createCenteredRect(
+      geometry,
+      getDescentCorridorHalfWidth(geometry, behavior),
+      rampMinZ,
+      rampMaxZ
+    ),
+  };
+};
+
+export const classifyStairTransitionZone = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  x: number,
+  z: number,
+  current: FloorId
+): StairTransitionZone => {
+  const direction =
+    geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
+  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
+  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
+  const inActualStairWidth = isWithinStairWidth(geometry, x);
+  const inTransitionWidth = isWithinStairWidth(
+    geometry,
+    x,
+    behavior.transitionMargin
+  );
+
+  // Named zones intentionally separate upper-floor intent from ground-floor
+  // ascent. The safe upper floor includes rooms and landing-edge positions near
+  // the stair void; only the stricter explicit descent corridor may hand the
+  // player from upper to ground. This avoids teleport goblins when layouts move.
+  if (isWithinLanding(geometry, x, z, behavior.landingTriggerMargin)) {
+    return 'upperLanding';
+  }
+
+  const hasLeftLandingForDescent =
+    direction === -1
+      ? z > geometry.topZ + behavior.landingTriggerMargin
+      : z < geometry.topZ - behavior.landingTriggerMargin;
+  const insideRampZ = isWithinZRange(
+    z,
+    rampMinZ,
+    rampMaxZ,
+    behavior.transitionMargin * 0.5
+  );
+  if (
+    current === 'upper' &&
+    hasLeftLandingForDescent &&
+    insideRampZ &&
+    isWithinDescentCorridorWidth(geometry, behavior, x)
+  ) {
+    return 'explicitDescentCorridor';
+  }
+
+  if (current === 'upper') {
+    return 'safeUpperFloor';
+  }
+
+  if (inActualStairWidth && isWithinZRange(z, rampMinZ, rampMaxZ)) {
+    return 'stairRampBody';
+  }
+
+  const nearLowerEntrance =
+    direction === -1
+      ? z >= geometry.bottomZ - behavior.transitionMargin &&
+        z <= geometry.bottomZ
+      : z <= geometry.bottomZ + behavior.transitionMargin &&
+        z >= geometry.bottomZ;
+  if (inTransitionWidth && nearLowerEntrance) {
+    return 'lowerStairEntrance';
+  }
+
+  return 'outsideStairs';
+};
+
 export const predictStairFloorId = (
   geometry: StairGeometry,
   behavior: StairBehavior,
@@ -67,6 +237,7 @@ export const predictStairFloorId = (
   z: number,
   current: FloorId
 ): FloorId => {
+  const zone = classifyStairTransitionZone(geometry, behavior, x, z, current);
   const rampHeight = computeRampHeight(geometry, behavior, x, z);
   const withinStairs = isWithinStairWidth(
     geometry,
@@ -77,48 +248,7 @@ export const predictStairFloorId = (
     geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
 
   if (current === 'upper') {
-    if (!withinStairs) {
-      return 'upper';
-    }
-
-    const baseExitHalfWidth = Math.max(
-      geometry.halfWidth - behavior.transitionMargin * 0.5,
-      geometry.halfWidth * 0.5
-    );
-    const withinBaseExit = Math.abs(x - geometry.centerX) <= baseExitHalfWidth;
-
-    const withinLanding = isWithinLanding(
-      geometry,
-      x,
-      z,
-      behavior.landingTriggerMargin
-    );
-    if (withinLanding) {
-      return 'upper';
-    }
-
-    const hasLeftLanding =
-      rampHeight < geometry.totalRise - behavior.stepRise * 0.1;
-    const bottomThreshold =
-      direction === -1
-        ? geometry.bottomZ - behavior.transitionMargin * 0.5
-        : geometry.bottomZ + behavior.transitionMargin * 0.5;
-
-    if (hasLeftLanding) {
-      const reachedLowerRegion =
-        direction === -1 ? z <= bottomThreshold : z >= bottomThreshold;
-      if (reachedLowerRegion) {
-        return 'ground';
-      }
-    }
-
-    const crossedBaseExit =
-      direction === -1 ? z >= geometry.bottomZ : z <= geometry.bottomZ;
-    if (withinBaseExit && crossedBaseExit) {
-      return 'ground';
-    }
-
-    return 'upper';
+    return zone === 'explicitDescentCorridor' ? 'ground' : 'upper';
   }
 
   const nearTop =
@@ -130,7 +260,7 @@ export const predictStairFloorId = (
     withinStairs &&
     (nearTop ||
       rampHeight >= geometry.totalRise - behavior.stepRise * 0.25 ||
-      isWithinLanding(geometry, x, z, behavior.landingTriggerMargin));
+      zone === 'upperLanding');
   if (nearLanding) {
     return 'upper';
   }
@@ -164,16 +294,19 @@ export const sampleStairSurfaceHeight = ({
     z,
     currentFloor
   );
-  if (predictedFloor === 'upper') {
-    const withinStairWidth = isWithinStairWidth(
-      geometry,
-      x,
-      behavior.transitionMargin
-    );
-    const onLanding = isWithinLanding(geometry, x, z);
-    if (!withinStairWidth || onLanding) {
-      return upperFloorElevation;
-    }
+  const zone = classifyStairTransitionZone(
+    geometry,
+    behavior,
+    x,
+    z,
+    currentFloor
+  );
+  if (
+    predictedFloor === 'upper' &&
+    zone !== 'explicitDescentCorridor' &&
+    currentFloor === 'upper'
+  ) {
+    return upperFloorElevation;
   }
 
   return clampedRamp;

--- a/src/tests/movement/stairSurfaceHeight.test.ts
+++ b/src/tests/movement/stairSurfaceHeight.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
 import {
+  computeRampHeight,
   sampleStairSurfaceHeight,
   type FloorId,
   type StairBehavior,
@@ -44,11 +45,47 @@ describe('sampleStairSurfaceHeight', () => {
     expect(height).toBeCloseTo(geometry.totalRise / 2, 5);
   });
 
-  it('retains ramp height when descending toward the top step', () => {
+  it('keeps landing height at the descent threshold', () => {
     const nearTopStepZ = geometry.topZ - toWorldUnits(0.2);
     const height = sample({ x: 0, z: nearTopStepZ, currentFloor: 'ground' });
-    expect(height).toBeGreaterThan(geometry.totalRise * 0.9);
-    expect(height).toBeLessThanOrEqual(geometry.totalRise);
+
+    expect(height).toBeCloseTo(upperFloorElevation, 6);
+  });
+
+  it('smooths the landing lip after an intentional descent begins', () => {
+    const firstDescentStepZ =
+      geometry.topZ - behavior.landingTriggerMargin - toWorldUnits(0.01);
+    const rampHeight = computeRampHeight(
+      geometry,
+      behavior,
+      0,
+      firstDescentStepZ
+    );
+    const height = sample({
+      x: 0,
+      z: firstDescentStepZ,
+      currentFloor: 'ground',
+    });
+
+    expect(height).toBeGreaterThan(rampHeight);
+    expect(height).toBeCloseTo(upperFloorElevation, 1);
+  });
+
+  it('returns the ramp height after clearing the top handoff band', () => {
+    const clearedTopStepZ = geometry.topZ - behavior.transitionMargin;
+    const rampHeight = computeRampHeight(
+      geometry,
+      behavior,
+      0,
+      clearedTopStepZ
+    );
+    const height = sample({
+      x: 0,
+      z: clearedTopStepZ,
+      currentFloor: 'ground',
+    });
+
+    expect(height).toBeCloseTo(rampHeight, 6);
   });
 
   it('returns upper floor elevation across the landing interior', () => {

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
 import {
+  classifyStairTransitionZone,
   createStairNavAreaRect,
+  createStairNavigationZones,
   predictStairFloorId,
   type FloorId,
   type StairBehavior,
@@ -37,81 +39,129 @@ const STAIR_BEHAVIOR: StairBehavior = {
   transitionMargin: toWorldUnits(0.6),
   landingTriggerMargin: toWorldUnits(0.2),
   stepRise: 0.42,
+  descentCorridorInset: 0.75,
 };
 
+const predict = (
+  geometry: StairGeometry,
+  x: number,
+  z: number,
+  currentFloor: FloorId
+): FloorId => predictStairFloorId(geometry, STAIR_BEHAVIOR, x, z, currentFloor);
+
+const classify = (
+  geometry: StairGeometry,
+  x: number,
+  z: number,
+  currentFloor: FloorId
+) => classifyStairTransitionZone(geometry, STAIR_BEHAVIOR, x, z, currentFloor);
+
 describe('stair floor transitions (negative Z ascent)', () => {
-  it('keeps the player on the upper floor when walking above the stair void', () => {
-    const currentFloor: FloorId = 'upper';
-    const walkwayZ = NEGATIVE_Z_STAIRS.bottomZ - toWorldUnits(0.2);
-    const result = predictStairFloorId(
-      NEGATIVE_Z_STAIRS,
-      STAIR_BEHAVIOR,
-      NEGATIVE_Z_STAIRS.centerX,
-      walkwayZ,
-      currentFloor
-    );
+  it('transitions from ground to upper near the top of the stairs', () => {
+    const nearTopStepZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.15);
 
-    expect(result).toBe('upper');
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        NEGATIVE_Z_STAIRS.centerX,
+        nearTopStepZ,
+        'ground'
+      )
+    ).toBe('upper');
   });
 
-  it('stays on the upper floor while roaming across the landing', () => {
-    const currentFloor: FloorId = 'upper';
+  it('keeps the player on the upper floor while roaming across the landing', () => {
     const landingInteriorZ = NEGATIVE_Z_STAIRS.landingMinZ + toWorldUnits(0.6);
-    const result = predictStairFloorId(
-      NEGATIVE_Z_STAIRS,
-      STAIR_BEHAVIOR,
-      NEGATIVE_Z_STAIRS.centerX,
-      landingInteriorZ,
-      currentFloor
-    );
 
-    expect(result).toBe('upper');
+    expect(
+      classify(
+        NEGATIVE_Z_STAIRS,
+        NEGATIVE_Z_STAIRS.centerX,
+        landingInteriorZ,
+        'upper'
+      )
+    ).toBe('upperLanding');
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        NEGATIVE_Z_STAIRS.centerX,
+        landingInteriorZ,
+        'upper'
+      )
+    ).toBe('upper');
   });
 
-  it('does not leave the upper floor when west of the stair base', () => {
-    const currentFloor: FloorId = 'upper';
-    const westLandingX =
-      NEGATIVE_Z_STAIRS.centerX -
-      NEGATIVE_Z_STAIRS.halfWidth +
-      toWorldUnits(0.15);
-    const southOfLandingZ = NEGATIVE_Z_STAIRS.bottomZ + toWorldUnits(0.35);
-    const result = predictStairFloorId(
-      NEGATIVE_Z_STAIRS,
-      STAIR_BEHAVIOR,
-      westLandingX,
-      southOfLandingZ,
-      currentFloor
-    );
+  it('keeps the player on upper in nearby upstairs room/landing-edge space', () => {
+    const nearbyRoomX = NEGATIVE_Z_STAIRS.centerX + toWorldUnits(3.0);
+    const upperRoomZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(1.1);
 
-    expect(result).toBe('upper');
+    expect(classify(NEGATIVE_Z_STAIRS, nearbyRoomX, upperRoomZ, 'upper')).toBe(
+      'safeUpperFloor'
+    );
+    expect(predict(NEGATIVE_Z_STAIRS, nearbyRoomX, upperRoomZ, 'upper')).toBe(
+      'upper'
+    );
   });
 
-  it('switches to the ground floor after leaving the landing for the ramp', () => {
-    const currentFloor: FloorId = 'upper';
-    const firstStepZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.3);
-    const result = predictStairFloorId(
-      NEGATIVE_Z_STAIRS,
-      STAIR_BEHAVIOR,
-      NEGATIVE_Z_STAIRS.centerX,
-      firstStepZ,
-      currentFloor
-    );
+  it('does not teleport at the screenshot-like upper landing edge', () => {
+    const oldSharedNavEdgeX =
+      NEGATIVE_Z_STAIRS.centerX +
+      NEGATIVE_Z_STAIRS.halfWidth -
+      toWorldUnits(0.1);
+    const slightlyDownFromLandingZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.7);
 
-    expect(result).toBe('ground');
+    expect(
+      classify(
+        NEGATIVE_Z_STAIRS,
+        oldSharedNavEdgeX,
+        slightlyDownFromLandingZ,
+        'upper'
+      )
+    ).toBe('safeUpperFloor');
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        oldSharedNavEdgeX,
+        slightlyDownFromLandingZ,
+        'upper'
+      )
+    ).toBe('upper');
+  });
+
+  it('transitions to ground only inside the explicit descent corridor', () => {
+    const descentZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.7);
+
+    expect(
+      classify(NEGATIVE_Z_STAIRS, NEGATIVE_Z_STAIRS.centerX, descentZ, 'upper')
+    ).toBe('explicitDescentCorridor');
+    expect(
+      predict(NEGATIVE_Z_STAIRS, NEGATIVE_Z_STAIRS.centerX, descentZ, 'upper')
+    ).toBe('ground');
+  });
+
+  it('does not transition floors for lateral movement outside stair width', () => {
+    const farEastX = NEGATIVE_Z_STAIRS.centerX + toWorldUnits(2.5);
+    const descentZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.7);
+
+    expect(predict(NEGATIVE_Z_STAIRS, farEastX, descentZ, 'upper')).toBe(
+      'upper'
+    );
+    expect(predict(NEGATIVE_Z_STAIRS, farEastX, descentZ, 'ground')).toBe(
+      'ground'
+    );
   });
 
   it('remains on the ground after passing the stair base', () => {
-    const currentFloor: FloorId = 'upper';
     const groundExitZ = NEGATIVE_Z_STAIRS.bottomZ + toWorldUnits(0.1);
-    const result = predictStairFloorId(
-      NEGATIVE_Z_STAIRS,
-      STAIR_BEHAVIOR,
-      NEGATIVE_Z_STAIRS.centerX,
-      groundExitZ,
-      currentFloor
-    );
 
-    expect(result).toBe('ground');
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        NEGATIVE_Z_STAIRS.centerX,
+        groundExitZ,
+        'upper'
+      )
+    ).toBe('ground');
   });
 });
 
@@ -119,66 +169,69 @@ describe('stair floor transitions (positive Z ascent)', () => {
   const positiveGeometry = createStairGeometry(1);
 
   it('keeps the player on the upper floor across the landing interior', () => {
-    const currentFloor: FloorId = 'upper';
     const landingInteriorZ = positiveGeometry.landingMaxZ - toWorldUnits(0.6);
-    const result = predictStairFloorId(
-      positiveGeometry,
-      STAIR_BEHAVIOR,
-      positiveGeometry.centerX,
-      landingInteriorZ,
-      currentFloor
-    );
 
-    expect(result).toBe('upper');
+    expect(
+      predict(
+        positiveGeometry,
+        positiveGeometry.centerX,
+        landingInteriorZ,
+        'upper'
+      )
+    ).toBe('upper');
   });
 
-  it('switches to the ground floor after stepping off the landing', () => {
-    const currentFloor: FloorId = 'upper';
-    const firstStepZ = positiveGeometry.topZ - toWorldUnits(0.3);
-    const result = predictStairFloorId(
-      positiveGeometry,
-      STAIR_BEHAVIOR,
-      positiveGeometry.centerX,
-      firstStepZ,
-      currentFloor
-    );
+  it('switches to the ground floor after deliberately entering descent', () => {
+    const firstStepZ = positiveGeometry.topZ - toWorldUnits(0.7);
 
-    expect(result).toBe('ground');
+    expect(
+      classify(positiveGeometry, positiveGeometry.centerX, firstStepZ, 'upper')
+    ).toBe('explicitDescentCorridor');
+    expect(
+      predict(positiveGeometry, positiveGeometry.centerX, firstStepZ, 'upper')
+    ).toBe('ground');
   });
 
   it('remains on the ground after moving past the stair base', () => {
-    const currentFloor: FloorId = 'upper';
     const groundExitZ = positiveGeometry.bottomZ - toWorldUnits(0.1);
-    const result = predictStairFloorId(
-      positiveGeometry,
-      STAIR_BEHAVIOR,
-      positiveGeometry.centerX,
-      groundExitZ,
-      currentFloor
-    );
 
-    expect(result).toBe('ground');
+    expect(
+      predict(positiveGeometry, positiveGeometry.centerX, groundExitZ, 'upper')
+    ).toBe('ground');
   });
 
   it('ignores stair transitions when outside the stair width', () => {
-    const currentFloor: FloorId = 'ground';
     const farEastX = positiveGeometry.centerX + toWorldUnits(2.5);
     const landingMidpointZ =
       (positiveGeometry.landingMinZ + positiveGeometry.landingMaxZ) / 2;
-    const result = predictStairFloorId(
-      positiveGeometry,
-      STAIR_BEHAVIOR,
-      farEastX,
-      landingMidpointZ,
-      currentFloor
-    );
 
-    expect(result).toBe('ground');
+    expect(
+      predict(positiveGeometry, farEastX, landingMidpointZ, 'ground')
+    ).toBe('ground');
   });
 });
 
-describe('createStairNavAreaRect', () => {
-  it('expands the stair footprint with margins', () => {
+describe('stair navigation zones', () => {
+  it('exposes narrower upper descent nav than the legacy shared stair footprint', () => {
+    const zones = createStairNavigationZones(NEGATIVE_Z_STAIRS, STAIR_BEHAVIOR);
+    const legacyRect = createStairNavAreaRect(NEGATIVE_Z_STAIRS, {
+      marginX: STAIR_BEHAVIOR.transitionMargin,
+      marginZ: STAIR_BEHAVIOR.transitionMargin,
+    });
+
+    expect(zones.explicitDescentCorridor.minX).toBeGreaterThan(legacyRect.minX);
+    expect(zones.explicitDescentCorridor.maxX).toBeLessThan(legacyRect.maxX);
+    expect(zones.upperLanding.minZ).toBeCloseTo(
+      NEGATIVE_Z_STAIRS.landingMinZ,
+      6
+    );
+    expect(zones.upperLanding.maxZ).toBeCloseTo(
+      NEGATIVE_Z_STAIRS.landingMaxZ,
+      6
+    );
+  });
+
+  it('expands the legacy stair footprint with margins for compatibility', () => {
     const marginX = toWorldUnits(0.25);
     const marginZ = toWorldUnits(0.5);
     const rect = createStairNavAreaRect(NEGATIVE_Z_STAIRS, {

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -139,6 +139,36 @@ describe('stair floor transitions (negative Z ascent)', () => {
     ).toBe('ground');
   });
 
+  it('keeps a deliberate descent on ground through the top handoff band', () => {
+    const firstDescentStepZ =
+      NEGATIVE_Z_STAIRS.topZ + STAIR_BEHAVIOR.landingTriggerMargin + 0.01;
+
+    expect(
+      classify(
+        NEGATIVE_Z_STAIRS,
+        NEGATIVE_Z_STAIRS.centerX,
+        firstDescentStepZ,
+        'upper'
+      )
+    ).toBe('explicitDescentCorridor');
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        NEGATIVE_Z_STAIRS.centerX,
+        firstDescentStepZ,
+        'upper'
+      )
+    ).toBe('ground');
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        NEGATIVE_Z_STAIRS.centerX,
+        firstDescentStepZ,
+        'ground'
+      )
+    ).toBe('ground');
+  });
+
   it('does not transition floors for lateral movement outside stair width', () => {
     const farEastX = NEGATIVE_Z_STAIRS.centerX + toWorldUnits(2.5);
     const descentZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.7);
@@ -189,6 +219,28 @@ describe('stair floor transitions (positive Z ascent)', () => {
     ).toBe('explicitDescentCorridor');
     expect(
       predict(positiveGeometry, positiveGeometry.centerX, firstStepZ, 'upper')
+    ).toBe('ground');
+  });
+
+  it('keeps positive-Z descents on ground through the top handoff band', () => {
+    const firstDescentStepZ =
+      positiveGeometry.topZ - STAIR_BEHAVIOR.landingTriggerMargin - 0.01;
+
+    expect(
+      predict(
+        positiveGeometry,
+        positiveGeometry.centerX,
+        firstDescentStepZ,
+        'upper'
+      )
+    ).toBe('ground');
+    expect(
+      predict(
+        positiveGeometry,
+        positiveGeometry.centerX,
+        firstDescentStepZ,
+        'ground'
+      )
     ).toBe('ground');
   });
 


### PR DESCRIPTION
### Motivation
- Prevent accidental upstairs-to-ground teleporting when the player walks near the upper landing edge by making floor transitions deliberate and deterministic.
- Separate ascent intent (ground→upper) from descent intent (upper→ground) so small layout tweaks or navmesh expansions do not reintroduce teleport goblins.
- Keep existing ascent behavior, ramp/upper/ground vertical smoothing, and normal upper-floor room movement intact while making descent explicit.
- Provide testable debug helpers so staircase regressions can be reported with exact coordinates and zones.

### Description
- Introduce named stair transition/navigation zones and helpers in `src/systems/movement/stairs.ts` (`StairTransitionZone`, `createStairNavigationZones`, `classifyStairTransitionZone`) and tighten the descent corridor width via a `descentCorridorInset` behaviour parameter.
- Restrict upper→ground transitions so only positions classified as `explicitDescentCorridor` become `ground`, and preserve upper-floor height unless the player intentionally enters that corridor (updates to `predictStairFloorId` and `sampleStairSurfaceHeight`).
- Replace the single broad `stairNavArea` with separate `groundStairNavZones` and `upperStairNavZones` and add invisible upper-floor guard colliders that flank but do not block the middle descent corridor (changes in `src/main.ts`).
- Expose test/debug world helpers on `window.portfolio.world`: `predictFloorAt(...)` and `getStairTransitionZone(...)` and add/extend regression unit tests in `src/tests/movement/stairTransitions.test.ts` to cover landing-edge, nearby room, explicit descent, lateral movement, and nav-zone expectations.

### Testing
- Ran `npm run format:write` and `npm run lint` — both completed successfully.
- Ran `npm run typecheck` (`tsc --noEmit`) which reported unrelated, pre-existing TypeScript errors elsewhere in the repo and therefore did not pass; this PR does not attempt to fix those global type issues.
- Ran focused unit tests `npm run test:ci -- src/tests/movement/stairLayout.test.ts` and the updated stair tests `src/tests/movement/stairTransitions.test.ts` and `src/tests/movement/stairSurfaceHeight.test.ts` which passed locally, and then ran the full `npm run test:ci` where the test suite completed successfully (`1029 tests passed`).
- Built and validated artifacts with `npm run build` and `npm run smoke` which completed successfully, and ran `npm run docs:check` which passed with link-fetch warnings.
- Ran Playwright e2e `npm run test:e2e -- playwright/small-screen-hud.spec.ts` which initially failed because browsers were not installed in CI; after `npx playwright install chromium` and `npx playwright install-deps chromium` the E2E run passed (3 tests).
- Ran the repository secrets scan (`git diff --cached | ./scripts/scan-secrets.py`) which reported no high-risk secrets.

If reviewers want a quick QA checklist: use `window.portfolio.world.getStairMetrics()` and `predictFloorAt(...)` / `getStairTransitionZone(...)` to reproduce the screenshot-4 coordinates and verify the player remains on the upper floor unless deliberately centered in the descent corridor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23bce30f40832f8c0e031dbc804980)