### PR TITLE
🪜 Harden stair descent zones

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -370,10 +370,12 @@ import {
   computeRampHeight as computeStairRampHeight,
   predictStairFloorId,
   sampleStairSurfaceHeight,
-  createStairNavAreaRect,
+  classifyStairTransitionZone,
+  createStairNavigationZones,
   type FloorId,
   type StairBehavior,
   type StairGeometry,
+  type StairTransitionZone,
 } from './systems/movement/stairs';
 import {
   NARRATION_PREFERENCE_STORAGE_KEY,
@@ -568,7 +570,26 @@ declare global {
           stairLandingDepth: number;
           stairDirection: 1 | -1;
           upperFloorElevation: number;
+          stairDescentCorridorMinX: number;
+          stairDescentCorridorMaxX: number;
+          stairDescentCorridorMinZ: number;
+          stairDescentCorridorMaxZ: number;
         };
+        predictFloorAt(input: {
+          x: number;
+          z: number;
+          currentFloor?: FloorId;
+        }): FloorId;
+        classifyStairZone(input: {
+          x: number;
+          z: number;
+          currentFloor?: FloorId;
+        }): StairTransitionZone;
+        canOccupyPosition(input: {
+          x: number;
+          z: number;
+          floorId?: FloorId;
+        }): boolean;
         getCeilingOpacities(): number[];
         // Test-only helper: current player yaw in radians
         getPlayerYaw?(): number;
@@ -1701,11 +1722,16 @@ function initializeImmersiveScene(
     transitionMargin: stairTransitionMargin,
     landingTriggerMargin: stairLandingTriggerMargin,
     stepRise: STAIRCASE_CONFIG.step.rise,
+    descentCorridorInset: PLAYER_RADIUS * 0.8,
   };
-  const stairNavArea = createStairNavAreaRect(stairGeometry, {
-    marginX: PLAYER_RADIUS * 0.5,
-    marginZ: PLAYER_RADIUS,
-  });
+  const stairNavigationZones = createStairNavigationZones(
+    stairGeometry,
+    stairBehavior,
+    {
+      marginX: PLAYER_RADIUS * 0.5,
+      marginZ: PLAYER_RADIUS,
+    }
+  );
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -1825,6 +1851,14 @@ function initializeImmersiveScene(
     upperFloorColliders.push(instance.collider);
   });
 
+  // Invisible upper-floor guards cover the unsafe ramp-edge strips while leaving
+  // the named explicit descent corridor open. This keeps normal landing/room
+  // movement from touching the floor-transition trigger, but still lets players
+  // deliberately line up with the stairs to descend.
+  stairNavigationZones.unsafeUpperRampEdges.forEach((collider) =>
+    upperFloorColliders.push(collider)
+  );
+
   const floorColliders: Record<FloorId, RectCollider[]> = {
     ground: groundColliders,
     upper: upperFloorColliders,
@@ -1837,12 +1871,20 @@ function initializeImmersiveScene(
     ground: createNavMesh(FLOOR_PLAN, {
       padding: doorwayPadding,
       depth: doorwayDepth,
-      extraZones: [stairNavArea],
+      extraZones: [
+        stairNavigationZones.lowerStairEntrance,
+        stairNavigationZones.stairRampBody,
+        stairNavigationZones.upperLanding,
+      ],
     }),
     upper: createNavMesh(UPPER_FLOOR_PLAN, {
       padding: doorwayPadding,
       depth: doorwayDepth,
-      extraZones: [stairNavArea],
+      extraZones: [
+        stairNavigationZones.upperLanding,
+        stairNavigationZones.explicitDescentCorridor,
+      ],
+      excludedZones: stairNavigationZones.unsafeUpperRampEdges,
     }),
   };
 
@@ -2887,7 +2929,38 @@ function initializeImmersiveScene(
           stairLandingDepth: stairLandingDepth,
           stairDirection: stairLayout.directionMultiplier,
           upperFloorElevation,
+          stairDescentCorridorMinX:
+            stairNavigationZones.explicitDescentCorridor.minX,
+          stairDescentCorridorMaxX:
+            stairNavigationZones.explicitDescentCorridor.maxX,
+          stairDescentCorridorMinZ:
+            stairNavigationZones.explicitDescentCorridor.minZ,
+          stairDescentCorridorMaxZ:
+            stairNavigationZones.explicitDescentCorridor.maxZ,
         };
+      },
+      predictFloorAt(input) {
+        return predictFloorId(
+          input.x,
+          input.z,
+          input.currentFloor ?? activeFloorId
+        );
+      },
+      classifyStairZone(input) {
+        return classifyStairTransitionZone(
+          stairGeometry,
+          stairBehavior,
+          input.x,
+          input.z,
+          input.currentFloor ?? activeFloorId
+        );
+      },
+      canOccupyPosition(input) {
+        return canOccupyPosition(
+          input.x,
+          input.z,
+          input.floorId ?? activeFloorId
+        );
       },
       // Test helpers – expose current mannequin yaw in radians.
       getPlayerYaw() {

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -4,6 +4,14 @@ import type { RectCollider } from '../collision';
 
 export type FloorId = 'ground' | 'upper';
 
+export type StairTransitionZone =
+  | 'lowerStairEntrance'
+  | 'stairRampBody'
+  | 'upperLanding'
+  | 'safeUpperFloor'
+  | 'explicitDescentCorridor'
+  | 'outsideStairTransition';
+
 export interface StairGeometry {
   centerX: number;
   halfWidth: number;
@@ -19,15 +27,64 @@ export interface StairBehavior {
   transitionMargin: number;
   landingTriggerMargin: number;
   stepRise: number;
+  /**
+   * Optional inset that narrows the upstairs descent trigger from the full stair
+   * width. Keeping this corridor explicit prevents upper-floor landing edge
+   * movement from being interpreted as an intent to descend.
+   */
+  descentCorridorInset?: number;
+}
+
+export interface StairNavigationZones {
+  lowerStairEntrance: RectCollider;
+  stairRampBody: RectCollider;
+  upperLanding: RectCollider;
+  explicitDescentCorridor: RectCollider;
+  unsafeUpperRampEdges: RectCollider[];
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
+
+const getDirection = (geometry: StairGeometry): 1 | -1 =>
+  geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
+
+const getDescentCorridorHalfWidth = (
+  geometry: StairGeometry,
+  behavior: StairBehavior
+): number => {
+  const inset =
+    behavior.descentCorridorInset ?? behavior.transitionMargin * 0.5;
+  return Math.max(geometry.halfWidth - inset, geometry.halfWidth * 0.45);
+};
+
+const isWithinHalfWidth = (
+  geometry: StairGeometry,
+  x: number,
+  halfWidth: number,
+  margin = 0
+): boolean => Math.abs(x - geometry.centerX) <= halfWidth + margin;
+
+const isBetween = (value: number, a: number, b: number, margin = 0): boolean =>
+  value >= Math.min(a, b) - margin && value <= Math.max(a, b) + margin;
 
 export const isWithinStairWidth = (
   geometry: StairGeometry,
   x: number,
   margin = 0
-): boolean => Math.abs(x - geometry.centerX) <= geometry.halfWidth + margin;
+): boolean => isWithinHalfWidth(geometry, x, geometry.halfWidth, margin);
+
+export const isWithinDescentCorridor = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  x: number,
+  margin = 0
+): boolean =>
+  isWithinHalfWidth(
+    geometry,
+    x,
+    getDescentCorridorHalfWidth(geometry, behavior),
+    margin
+  );
 
 export const isWithinLanding = (
   geometry: StairGeometry,
@@ -60,6 +117,65 @@ export const computeRampHeight = (
   return clamped * geometry.totalRise;
 };
 
+export const classifyStairTransitionZone = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  x: number,
+  z: number,
+  current: FloorId
+): StairTransitionZone => {
+  const direction = getDirection(geometry);
+  const withinStairWidth = isWithinStairWidth(
+    geometry,
+    x,
+    behavior.transitionMargin
+  );
+
+  // The landing is always safe upper-floor space. It must be checked before the
+  // ramp body because its south/north edge abuts the first descending step.
+  if (isWithinLanding(geometry, x, z, behavior.landingTriggerMargin)) {
+    return 'upperLanding';
+  }
+
+  if (!withinStairWidth) {
+    return current === 'upper' ? 'safeUpperFloor' : 'outsideStairTransition';
+  }
+
+  const reachedLowerEntrance =
+    direction === -1 ? z >= geometry.bottomZ : z <= geometry.bottomZ;
+  if (reachedLowerEntrance && isWithinDescentCorridor(geometry, behavior, x)) {
+    return 'lowerStairEntrance';
+  }
+
+  const withinRamp = isBetween(
+    z,
+    geometry.bottomZ,
+    geometry.topZ,
+    behavior.transitionMargin * 0.25
+  );
+  if (!withinRamp) {
+    return current === 'upper' ? 'safeUpperFloor' : 'outsideStairTransition';
+  }
+
+  const nearUpperRampMouth =
+    direction === -1
+      ? z <= geometry.topZ + behavior.transitionMargin
+      : z >= geometry.topZ - behavior.transitionMargin;
+
+  // Only this narrowed center strip at the upper ramp mouth is allowed to flip
+  // an upstairs avatar onto the stair ramp. Side strips remain upper-floor
+  // edge/guard space so slight landing movement cannot revive the teleport goblin.
+  if (
+    current === 'upper' &&
+    nearUpperRampMouth &&
+    isWithinDescentCorridor(geometry, behavior, x)
+  ) {
+    return 'explicitDescentCorridor';
+  }
+
+  return 'stairRampBody';
+};
+
 export const predictStairFloorId = (
   geometry: StairGeometry,
   behavior: StairBehavior,
@@ -67,70 +183,25 @@ export const predictStairFloorId = (
   z: number,
   current: FloorId
 ): FloorId => {
-  const rampHeight = computeRampHeight(geometry, behavior, x, z);
-  const withinStairs = isWithinStairWidth(
-    geometry,
-    x,
-    behavior.transitionMargin
-  );
-  const direction =
-    geometry.direction ?? (geometry.topZ >= geometry.bottomZ ? 1 : -1);
+  const zone = classifyStairTransitionZone(geometry, behavior, x, z, current);
 
   if (current === 'upper') {
-    if (!withinStairs) {
-      return 'upper';
-    }
-
-    const baseExitHalfWidth = Math.max(
-      geometry.halfWidth - behavior.transitionMargin * 0.5,
-      geometry.halfWidth * 0.5
-    );
-    const withinBaseExit = Math.abs(x - geometry.centerX) <= baseExitHalfWidth;
-
-    const withinLanding = isWithinLanding(
-      geometry,
-      x,
-      z,
-      behavior.landingTriggerMargin
-    );
-    if (withinLanding) {
-      return 'upper';
-    }
-
-    const hasLeftLanding =
-      rampHeight < geometry.totalRise - behavior.stepRise * 0.1;
-    const bottomThreshold =
-      direction === -1
-        ? geometry.bottomZ - behavior.transitionMargin * 0.5
-        : geometry.bottomZ + behavior.transitionMargin * 0.5;
-
-    if (hasLeftLanding) {
-      const reachedLowerRegion =
-        direction === -1 ? z <= bottomThreshold : z >= bottomThreshold;
-      if (reachedLowerRegion) {
-        return 'ground';
-      }
-    }
-
-    const crossedBaseExit =
-      direction === -1 ? z >= geometry.bottomZ : z <= geometry.bottomZ;
-    if (withinBaseExit && crossedBaseExit) {
-      return 'ground';
-    }
-
-    return 'upper';
+    return zone === 'explicitDescentCorridor' || zone === 'lowerStairEntrance'
+      ? 'ground'
+      : 'upper';
   }
 
+  const rampHeight = computeRampHeight(geometry, behavior, x, z);
   const nearTop =
-    direction === -1
+    getDirection(geometry) === -1
       ? z <= geometry.topZ + behavior.transitionMargin
       : z >= geometry.topZ - behavior.transitionMargin;
 
   const nearLanding =
-    withinStairs &&
+    isWithinStairWidth(geometry, x, behavior.transitionMargin) &&
     (nearTop ||
       rampHeight >= geometry.totalRise - behavior.stepRise * 0.25 ||
-      isWithinLanding(geometry, x, z, behavior.landingTriggerMargin));
+      zone === 'upperLanding');
   if (nearLanding) {
     return 'upper';
   }
@@ -164,14 +235,13 @@ export const sampleStairSurfaceHeight = ({
     z,
     currentFloor
   );
+
   if (predictedFloor === 'upper') {
-    const withinStairWidth = isWithinStairWidth(
-      geometry,
-      x,
-      behavior.transitionMargin
-    );
-    const onLanding = isWithinLanding(geometry, x, z);
-    if (!withinStairWidth || onLanding) {
+    if (
+      currentFloor === 'upper' ||
+      isWithinLanding(geometry, x, z) ||
+      !isWithinStairWidth(geometry, x, behavior.transitionMargin)
+    ) {
       return upperFloorElevation;
     }
   }
@@ -206,4 +276,75 @@ export const createStairNavAreaRect = (
     ) + marginZ;
 
   return { minX, maxX, minZ, maxZ };
+};
+
+export const createStairNavigationZones = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  { marginX = 0, marginZ = 0 }: StairNavAreaOptions = {}
+): StairNavigationZones => {
+  const corridorHalfWidth = getDescentCorridorHalfWidth(geometry, behavior);
+  const rampMinZ = Math.min(geometry.bottomZ, geometry.topZ) - marginZ;
+  const rampMaxZ = Math.max(geometry.bottomZ, geometry.topZ) + marginZ;
+  const landingMinZ =
+    Math.min(geometry.landingMinZ, geometry.landingMaxZ) - marginZ;
+  const landingMaxZ =
+    Math.max(geometry.landingMinZ, geometry.landingMaxZ) + marginZ;
+  const lowerEntranceDepth = behavior.transitionMargin + marginZ;
+  const lowerStairEntrance =
+    getDirection(geometry) === -1
+      ? {
+          minX: geometry.centerX - corridorHalfWidth - marginX,
+          maxX: geometry.centerX + corridorHalfWidth + marginX,
+          minZ: geometry.bottomZ - marginZ,
+          maxZ: geometry.bottomZ + lowerEntranceDepth,
+        }
+      : {
+          minX: geometry.centerX - corridorHalfWidth - marginX,
+          maxX: geometry.centerX + corridorHalfWidth + marginX,
+          minZ: geometry.bottomZ - lowerEntranceDepth,
+          maxZ: geometry.bottomZ + marginZ,
+        };
+
+  const explicitDescentCorridor = {
+    minX: geometry.centerX - corridorHalfWidth - marginX,
+    maxX: geometry.centerX + corridorHalfWidth + marginX,
+    minZ: rampMinZ,
+    maxZ: rampMaxZ,
+  };
+  const stairRampBody = {
+    minX: geometry.centerX - geometry.halfWidth - marginX,
+    maxX: geometry.centerX + geometry.halfWidth + marginX,
+    minZ: rampMinZ,
+    maxZ: rampMaxZ,
+  };
+  const upperLanding = {
+    minX: geometry.centerX - geometry.halfWidth - marginX,
+    maxX: geometry.centerX + geometry.halfWidth + marginX,
+    minZ: landingMinZ,
+    maxZ: landingMaxZ,
+  };
+
+  const unsafeUpperRampEdges = [
+    {
+      minX: stairRampBody.minX,
+      maxX: explicitDescentCorridor.minX,
+      minZ: rampMinZ,
+      maxZ: rampMaxZ,
+    },
+    {
+      minX: explicitDescentCorridor.maxX,
+      maxX: stairRampBody.maxX,
+      minZ: rampMinZ,
+      maxZ: rampMaxZ,
+    },
+  ].filter((rect) => rect.maxX > rect.minX && rect.maxZ > rect.minZ);
+
+  return {
+    lowerStairEntrance,
+    stairRampBody,
+    upperLanding,
+    explicitDescentCorridor,
+    unsafeUpperRampEdges,
+  };
 };

--- a/src/systems/navigation/navMesh.ts
+++ b/src/systems/navigation/navMesh.ts
@@ -8,6 +8,8 @@ import type { RectCollider } from '../collision';
 export interface NavMeshOptions extends DoorwayPassageZoneOptions {
   /** Additional rectangles to include in the walkable area. */
   extraZones?: readonly RectCollider[];
+  /** Rectangles to remove from otherwise walkable room/doorway polygons. */
+  excludedZones?: readonly RectCollider[];
   /** Comparison epsilon when determining containment. */
   epsilon?: number;
 }
@@ -43,6 +45,7 @@ export function createNavMesh(
 ): NavMesh {
   const {
     extraZones = [],
+    excludedZones = [],
     epsilon = DEFAULT_EPSILON,
     ...doorwayOptions
   } = options;
@@ -62,10 +65,19 @@ export function createNavMesh(
     polygons.push(cloneRect(zone));
   });
 
+  const exclusions = excludedZones.map(cloneRect);
+
   return {
     polygons,
     contains(x, z) {
-      return polygons.some((polygon) => isWithinRect(polygon, x, z, epsilon));
+      const included = polygons.some((polygon) =>
+        isWithinRect(polygon, x, z, epsilon)
+      );
+      if (!included) {
+        return false;
+      }
+
+      return !exclusions.some((zone) => isWithinRect(zone, x, z, epsilon));
     },
   };
 }

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
 import {
+  classifyStairTransitionZone,
   createStairNavAreaRect,
+  createStairNavigationZones,
   predictStairFloorId,
   type FloorId,
   type StairBehavior,
@@ -86,7 +88,72 @@ describe('stair floor transitions (negative Z ascent)', () => {
     expect(result).toBe('upper');
   });
 
-  it('switches to the ground floor after leaving the landing for the ramp', () => {
+  it('transitions from ground near the top of the stairs to the upper floor', () => {
+    const currentFloor: FloorId = 'ground';
+    const nearTopZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.2);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      NEGATIVE_Z_STAIRS.centerX,
+      nearTopZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+  });
+
+  it('keeps upper-floor room movement away from stair transitions', () => {
+    const currentFloor: FloorId = 'upper';
+    const nearbyRoomX = NEGATIVE_Z_STAIRS.centerX + toWorldUnits(2.3);
+    const nearbyRoomZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(1.4);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      nearbyRoomX,
+      nearbyRoomZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+    expect(
+      classifyStairTransitionZone(
+        NEGATIVE_Z_STAIRS,
+        STAIR_BEHAVIOR,
+        nearbyRoomX,
+        nearbyRoomZ,
+        currentFloor
+      )
+    ).toBe('safeUpperFloor');
+  });
+
+  it('does not teleport at the problematic upper landing edge', () => {
+    const currentFloor: FloorId = 'upper';
+    const edgeX =
+      NEGATIVE_Z_STAIRS.centerX -
+      NEGATIVE_Z_STAIRS.halfWidth +
+      toWorldUnits(0.2);
+    const edgeZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.25);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      edgeX,
+      edgeZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
+    expect(
+      classifyStairTransitionZone(
+        NEGATIVE_Z_STAIRS,
+        STAIR_BEHAVIOR,
+        edgeX,
+        edgeZ,
+        currentFloor
+      )
+    ).toBe('stairRampBody');
+  });
+
+  it('switches to the ground floor after deliberately entering the descent corridor', () => {
     const currentFloor: FloorId = 'upper';
     const firstStepZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.3);
     const result = predictStairFloorId(
@@ -98,6 +165,21 @@ describe('stair floor transitions (negative Z ascent)', () => {
     );
 
     expect(result).toBe('ground');
+  });
+
+  it('does not transition when lateral movement is outside the stair width', () => {
+    const currentFloor: FloorId = 'upper';
+    const farEastX = NEGATIVE_Z_STAIRS.centerX + toWorldUnits(2.5);
+    const firstStepZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.3);
+    const result = predictStairFloorId(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      farEastX,
+      firstStepZ,
+      currentFloor
+    );
+
+    expect(result).toBe('upper');
   });
 
   it('remains on the ground after passing the stair base', () => {
@@ -209,5 +291,30 @@ describe('createStairNavAreaRect', () => {
     );
     expect(rect.minZ).toBeCloseTo(expectedMinZ - marginZ, 6);
     expect(rect.maxZ).toBeCloseTo(expectedMaxZ + marginZ, 6);
+  });
+});
+
+describe('createStairNavigationZones', () => {
+  it('separates broad ramp edges from the deliberate descent corridor', () => {
+    const zones = createStairNavigationZones(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      {
+        marginX: toWorldUnits(0.1),
+        marginZ: toWorldUnits(0.1),
+      }
+    );
+
+    expect(zones.explicitDescentCorridor.minX).toBeGreaterThan(
+      zones.stairRampBody.minX
+    );
+    expect(zones.explicitDescentCorridor.maxX).toBeLessThan(
+      zones.stairRampBody.maxX
+    );
+    expect(zones.unsafeUpperRampEdges).toHaveLength(2);
+    zones.unsafeUpperRampEdges.forEach((edge) => {
+      expect(edge.minZ).toBeCloseTo(zones.stairRampBody.minZ, 6);
+      expect(edge.maxZ).toBeCloseTo(zones.stairRampBody.maxZ, 6);
+    });
   });
 });

--- a/src/tests/navigation/navMesh.test.ts
+++ b/src/tests/navigation/navMesh.test.ts
@@ -78,4 +78,15 @@ describe('createNavMesh', () => {
   it('includes explicitly provided zones', () => {
     expect(navMesh.contains(41, 41)).toBe(true);
   });
+
+  it('removes excluded zones from otherwise walkable rooms', () => {
+    const meshWithExclusion = createNavMesh(FLOOR_PLAN, {
+      padding: doorwayPadding,
+      depth: doorwayDepth,
+      excludedZones: [{ minX: -1, maxX: 1, minZ: -11, maxZ: -9 }],
+    });
+
+    expect(meshWithExclusion.contains(0, -10)).toBe(false);
+    expect(meshWithExclusion.contains(4, -10)).toBe(true);
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent accidental upstairs-to-ground teleport when walking near the upper landing edge by making descent an explicit, deliberate action.
- Make stair transition behavior deterministic and easier to reason about by splitting the stair footprint into named zones and a narrow descent corridor.
- Preserve existing ascent behavior, normal upper-floor movement, and ramp/upper-floor vertical smoothing while adding targeted collision guards to avoid revival of the teleport bug.

### Description
- Refactor: introduce named transition zones and helpers in `src/systems/movement/stairs.ts` (`classifyStairTransitionZone`, `predictStairFloorId`, `createStairNavigationZones`, `isWithinDescentCorridor`, and related types); add `descentCorridorInset` to narrow the upstairs-to-stairs trigger.
- Navmesh & guards: replace broad shared stair nav-area with floor-specific stair zones and add invisible upper-ramp-edge guard colliders, then exclude those unsafe strips from the upper `NavMesh` using a new `excludedZones` option (`src/systems/navigation/navMesh.ts`, `src/main.ts`).
- Scene wiring & API: apply the new navigation zones and guards to `upperFloorColliders` and `navMeshes`, and expose debug/test helpers on `window.portfolio.world` (floor prediction, zone classification, occupancy and corridor metrics) in `src/main.ts`.
- Tests: add and update unit tests covering ground→upper ascent, landing/room roaming, the problematic landing edge, explicit descent corridor, lateral non-transition cases, zone geometry, and navmesh exclusions (`src/tests/movement/stairTransitions.test.ts`, `src/tests/navigation/navMesh.test.ts`).

### Testing
- Ran `npm run format:write` and `npm run lint`; both completed successfully. (✅)
- Ran `npm run typecheck` and observed existing unrelated baseline TypeScript errors in the repository (these are pre-existing and not introduced by this change). (❌ baseline)
- Ran focused unit tests `npm run test:ci -- src/tests/movement/stairLayout.test.ts` and the updated stair tests `npm run test:ci -- src/tests/movement/stairTransitions.test.ts src/tests/movement/stairSurfaceHeight.test.ts`, which passed. (✅)
- Ran the full unit suite `npm run test:ci` and it completed successfully (all tests passed). (✅)
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`; both succeeded. (✅)
- Executed Playwright E2E for the small-screen HUD spec after installing browsers and host deps with `npx playwright install chromium-headless-shell` and `npx playwright install-deps`; the spec passed locally. (✅)
- Secret scan `git diff --cached | ./scripts/scan-secrets.py` found no high-risk secrets. (✅)

Residual risk / follow-ups: the repository contains unrelated TypeScript baseline errors that cause `npm run typecheck` to report failures; those are out of scope for this change and should be addressed separately to get a green global typecheck. The new `descentCorridorInset` and zone sizes are data-driven and may need minor tuning against live QA screenshots; tests cover the regression cases to help future layout tweaks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23bce30f40832f8c0e031dbc804980)