### PR TITLE
Make upstairs visually solid and floor-aware

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1784,24 +1784,29 @@ function initializeImmersiveScene(
   );
   const upperLandingClearance = toWorldUnits(0.05);
   const upperLandingSolidStartZ = stairTopZ + upperLandingClearance;
-  const upperLandingStairwellCutout = upperLandingRoom
+  const upperLandingDescentCutoutMaxZ =
+    stairTopZ + stairLandingTriggerMargin + upperLandingClearance;
+  const upperLandingDescentCutout = upperLandingRoom
     ? {
-        minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minX: stairNavigationZones.explicitDescentCorridor.minX,
+        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
         minZ: upperLandingRoom.bounds.minZ,
-        maxZ: upperLandingRoom.bounds.maxZ,
+        maxZ: Math.min(
+          upperLandingRoom.bounds.maxZ,
+          upperLandingDescentCutoutMaxZ
+        ),
       }
     : undefined;
   const upperLandingStubBounds = upperLandingRoom
     ? [
         {
           minX: upperLandingRoom.bounds.minX,
-          maxX: upperLandingStairwellCutout!.minX,
+          maxX: upperLandingDescentCutout!.minX,
           minZ: upperLandingRoom.bounds.minZ,
           maxZ: upperLandingRoom.bounds.maxZ,
         },
         {
-          minX: upperLandingStairwellCutout!.maxX,
+          minX: upperLandingDescentCutout!.maxX,
           maxX: upperLandingRoom.bounds.maxX,
           minZ: upperLandingRoom.bounds.minZ,
           maxZ: upperLandingRoom.bounds.maxZ,
@@ -1813,10 +1818,10 @@ function initializeImmersiveScene(
       )
     : [];
   const upperLandingCutouts =
-    upperLandingRoom && upperLandingStairwellCutout
+    upperLandingRoom && upperLandingDescentCutout
       ? {
           upperLanding: [
-            upperLandingStairwellCutout,
+            upperLandingDescentCutout,
             ...upperLandingStubBounds.map((bounds) => ({
               minX: bounds.minX,
               maxX: bounds.maxX,
@@ -1835,8 +1840,9 @@ function initializeImmersiveScene(
   });
   upperFloorGroup.add(upperFloorTiles.group);
 
-  // Keep the central stairwell/descent corridor open: room tiles and side
-  // stubs only fill the landing shoulders, avoiding a full-width seal or z-fight.
+  // Keep only the explicit stairwell/descent handoff open. Room tiles and
+  // side stubs fill the walkable landing shoulders without a full-width seal
+  // or z-fight.
 
   upperLandingStubBounds.forEach((bounds, index) => {
     const upperLandingStub = createUpperLandingStub({

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,8 @@ import {
   Group,
   HemisphereLight,
   MathUtils,
-  Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  Shape,
-  ShapeGeometry,
   OrthographicCamera,
   PointLight,
   Scene,
@@ -32,6 +29,7 @@ import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPa
 
 import {
   FLOOR_PLAN,
+  FLOOR_PLAN_LEVELS,
   FLOOR_PLAN_SCALE,
   UPPER_FLOOR_PLAN,
   getFloorBounds,
@@ -113,6 +111,11 @@ import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
+import {
+  createFloorVisibilityController,
+  createPoiFloorResolver,
+  type FloorVisibilityController,
+} from './scene/floors/visibilityController';
 import {
   createMotionBlurController,
   type MotionBlurController,
@@ -1536,6 +1539,10 @@ function initializeImmersiveScene(
     );
   }
 
+  const groundFloorGroup = new Group();
+  groundFloorGroup.name = 'GroundFloorVisuals';
+  scene.add(groundFloorGroup);
+
   const floorMaterial = new MeshStandardMaterial({
     color: 0x2a3547,
     roughness: 0.58,
@@ -1546,7 +1553,7 @@ function initializeImmersiveScene(
     elevation: 0,
     groupName: 'GroundFloorTiles',
   });
-  scene.add(floorTiles.group);
+  groundFloorGroup.add(floorTiles.group);
 
   const wallMaterial = new MeshStandardMaterial({ color: 0x3d4a63 });
   const fenceMaterial = new MeshStandardMaterial({ color: 0x4a5668 });
@@ -1585,7 +1592,7 @@ function initializeImmersiveScene(
       return instance.isFence ? fenceMaterial : wallMaterial;
     },
   });
-  scene.add(groundWallMeshes.group);
+  groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
   });
@@ -1599,7 +1606,7 @@ function initializeImmersiveScene(
     trimDepth: WALL_THICKNESS * 0.92,
     material: doorwayTrimMaterial,
   });
-  scene.add(doorwayOpenings.group);
+  groundFloorGroup.add(doorwayOpenings.group);
 
   const ceilings = createRoomCeilingPanels(FLOOR_PLAN.rooms, {
     height: WALL_HEIGHT - 0.15,
@@ -1610,7 +1617,7 @@ function initializeImmersiveScene(
     lightMap: interiorLightmaps.ceiling,
     lightMapIntensity: 0.52,
   });
-  scene.add(ceilings.group);
+  groundFloorGroup.add(ceilings.group);
 
   const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom');
   if (livingRoom) {
@@ -1765,48 +1772,26 @@ function initializeImmersiveScene(
   scene.add(upperFloorGroup);
 
   const upperFloorMaterial = new MeshStandardMaterial({
-    color: 0x1f273a,
-    side: DoubleSide,
-    // Nudge the upper floor away from coplanar surfaces (e.g., landing top)
-    // to avoid depth fighting at shared boundaries.
-    polygonOffset: true,
-    polygonOffsetFactor: 1,
-    polygonOffsetUnits: 1,
+    color: 0x263149,
+    roughness: 0.62,
+    metalness: 0.12,
+    transparent: false,
+    opacity: 1,
+    depthWrite: true,
   });
-  const upperFloorShape = new Shape();
-  const [upperFirstX, upperFirstZ] = UPPER_FLOOR_PLAN.outline[0];
-  upperFloorShape.moveTo(upperFirstX, upperFirstZ);
-  for (let i = 1; i < UPPER_FLOOR_PLAN.outline.length; i += 1) {
-    const [x, z] = UPPER_FLOOR_PLAN.outline[i];
-    upperFloorShape.lineTo(x, z);
-  }
-  upperFloorShape.closePath();
-
-  // Carve a stairwell hole in the upper floor directly above the stairs to
-  // eliminate z-fighting and allow the player to visually descend. Use a
-  // slightly oversized cutout so collision tolerances near edges feel natural.
-  const stairHoleHalfWidth = stairHalfWidth + stairwellMarginX;
-  const stairHoleMinX = stairCenterX - stairHoleHalfWidth;
-  const stairHoleMaxX = stairCenterX + stairHoleHalfWidth;
-  const stairHoleMinZ = stairLayout.stairHoleRange.minZ;
-  const stairHoleMaxZ = stairLayout.stairHoleRange.maxZ;
-  upperFloorShape.holes.push(
-    (() => {
-      const hole = new Shape();
-      hole.moveTo(stairHoleMinX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMaxZ);
-      hole.lineTo(stairHoleMinX, stairHoleMaxZ);
-      hole.closePath();
-      return hole;
-    })()
+  const upperFloorTiles = createRoomFloorTiles(
+    UPPER_FLOOR_PLAN.rooms.filter((room) => room.id !== 'upperLanding'),
+    {
+      material: upperFloorMaterial,
+      elevation: upperFloorElevation,
+      thickness: STAIRCASE_CONFIG.landing.thickness,
+      groupName: 'UpperFloorTiles',
+    }
   );
-  const upperFloorGeometry = new ShapeGeometry(upperFloorShape);
-  upperFloorGeometry.rotateX(-Math.PI / 2);
-  const upperFloor = new Mesh(upperFloorGeometry, upperFloorMaterial);
-  // Slightly lower than the landing top to ensure no coplanar z-fighting.
-  upperFloor.position.y = upperFloorElevation - 0.002;
-  upperFloorGroup.add(upperFloor);
+  upperFloorGroup.add(upperFloorTiles.group);
+
+  // Keep the stairwell open: the landing stub below bridges from the stairs to
+  // the room tiles while avoiding a sealed slab over the descent corridor.
 
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
@@ -1946,18 +1931,37 @@ function initializeImmersiveScene(
   });
   lightmapAnimator.captureBaseline();
 
+  let activeFloorId: FloorId = 'ground';
+
+  const groundPoiGroup = new Group();
+  groundPoiGroup.name = 'GroundPoiVisuals';
+  scene.add(groundPoiGroup);
+
   const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
     detailPolicy: activeSceneDetailPolicy,
   });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
-      scene.add(poi.group);
+      groundPoiGroup.add(poi.group);
     }
     if (poi.collider) {
       staticColliders.push(poi.collider);
     }
     poiInstances.push(poi);
   });
+
+  const getPoiFloorId = createPoiFloorResolver(FLOOR_PLAN_LEVELS);
+  const floorVisibilityController: FloorVisibilityController =
+    createFloorVisibilityController({
+      initialFloorId: activeFloorId,
+      groundGroups: [groundPoiGroup],
+      upperGroups: [upperFloorGroup],
+      groundLedGroups: [ledStripGroup, ledFillLightGroup].filter(
+        (group): group is Group => group !== null
+      ),
+      poiInstances,
+      getPoiFloorId,
+    });
 
   const poiAnalytics = createWindowPoiAnalytics();
   const interactionTimeline = new InteractionTimeline();
@@ -1992,10 +1996,19 @@ function initializeImmersiveScene(
   const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
     (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
     (!isMobilePoiLayout(layoutOverride) || currentSelectedPoi !== null);
+  const isPoiVisibleOnActiveFloor = (poi: PoiDefinition | null): boolean =>
+    poi !== null && floorVisibilityController.isPoiVisibleOnActiveFloor(poi);
+  const getFloorVisiblePoi = (
+    poi: PoiDefinition | null
+  ): PoiDefinition | null => (isPoiVisibleOnActiveFloor(poi) ? poi : null);
   const getVisiblePoiRecommendation = (): PoiDefinition | null => {
     if (
       currentGuidedTourRecommendation &&
-      currentGuidedTourRecommendation.id !== dismissedPassiveRecommendationPoiId
+      currentGuidedTourRecommendation.id !==
+        dismissedPassiveRecommendationPoiId &&
+      floorVisibilityController.isPoiVisibleOnActiveFloor(
+        currentGuidedTourRecommendation
+      )
     ) {
       return currentGuidedTourRecommendation;
     }
@@ -2023,9 +2036,11 @@ function initializeImmersiveScene(
     const canShowDetail = canShowPoiDetailOverlay(layoutOverride);
     const showHover =
       canShowDetail && !isMobilePoiLayout(layoutOverride)
-        ? currentHoveredPoi
+        ? getFloorVisiblePoi(currentHoveredPoi)
         : null;
-    const showSelected = canShowDetail ? currentSelectedPoi : null;
+    const showSelected = canShowDetail
+      ? getFloorVisiblePoi(currentSelectedPoi)
+      : null;
     poiTooltipOverlay.setHovered(showHover);
     poiTooltipOverlay.setSelected(showSelected);
     poiWorldTooltip.setHovered(resolveWorldTooltipTarget(showHover));
@@ -2144,6 +2159,7 @@ function initializeImmersiveScene(
     }
     return {
       poi,
+      floorId: getPoiFloorId(poi),
       getAnchorPosition: (out: Vector3) => {
         if (instance.label) {
           return out.copy(instance.labelWorldPosition);
@@ -2539,6 +2555,10 @@ function initializeImmersiveScene(
     renderer.domElement,
     camera,
     poiInstances,
+    {
+      isPoiEnabled: (poi) =>
+        floorVisibilityController.isPoiVisibleOnActiveFloor(poi.definition),
+    },
     poiAnalytics
   );
   const removeHoverListener = poiInteractionManager.addHoverListener((poi) => {
@@ -2552,12 +2572,16 @@ function initializeImmersiveScene(
         hudPanelCoordinator?.closeAllPanels();
       }
       poiTooltipOverlay.setSelected(
-        canShowPoiDetailOverlay() ? currentSelectedPoi : null,
+        canShowPoiDetailOverlay()
+          ? getFloorVisiblePoi(currentSelectedPoi)
+          : null,
         context
       );
       poiWorldTooltip.setSelected(
         resolveWorldTooltipTarget(
-          canShowPoiDetailOverlay() ? currentSelectedPoi : null
+          canShowPoiDetailOverlay()
+            ? getFloorVisiblePoi(currentSelectedPoi)
+            : null
         )
       );
       syncPoiDetailOverlay();
@@ -3331,7 +3355,6 @@ function initializeImmersiveScene(
   const mouseCameraStart = new Vector2();
   let mouseCameraPointerId: number | null = null;
 
-  let activeFloorId: FloorId = 'ground';
   let helpKeyWasPressed = false;
   let helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
   const buildHelpButtonText = (shortcut: string) =>
@@ -3550,7 +3573,10 @@ function initializeImmersiveScene(
       return;
     }
     activeFloorId = next;
-    upperFloorGroup.visible = next === 'upper';
+    floorVisibilityController.setActiveFloorId(next);
+    poiWorldTooltip.setActiveFloorId(next);
+    syncPoiDetailOverlay();
+    syncPoiRecommendation();
     document.documentElement.dataset.activeFloor = next;
   };
 
@@ -4644,6 +4670,13 @@ function initializeImmersiveScene(
     const worldTooltipVisible = worldTooltipState.visible;
 
     for (const poi of poiInstances) {
+      if (!floorVisibilityController.applyPoiVisualState(poi)) {
+        poi.activation = 0;
+        poi.focus = 0;
+        poi.focusTarget = 0;
+        continue;
+      }
+
       const floatOffset = Math.sin(
         elapsedTime * poi.floatSpeed + poi.floatPhase
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1784,24 +1784,48 @@ function initializeImmersiveScene(
   );
   const upperLandingClearance = toWorldUnits(0.05);
   const upperLandingSolidStartZ = stairTopZ + upperLandingClearance;
-  const upperLandingCutouts = upperLandingRoom
+  const upperLandingStairwellCutout = upperLandingRoom
     ? {
-        upperLanding: [
-          {
-            minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-            maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-            minZ: upperLandingRoom.bounds.minZ,
-            maxZ: upperLandingSolidStartZ,
-          },
-          {
-            minX: upperLandingRoom.bounds.minX,
-            maxX: upperLandingRoom.bounds.maxX,
-            minZ: upperLandingSolidStartZ,
-            maxZ: upperLandingRoom.bounds.maxZ,
-          },
-        ],
+        minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperLandingRoom.bounds.minZ,
+        maxZ: upperLandingRoom.bounds.maxZ,
       }
     : undefined;
+  const upperLandingStubBounds = upperLandingRoom
+    ? [
+        {
+          minX: upperLandingRoom.bounds.minX,
+          maxX: upperLandingStairwellCutout!.minX,
+          minZ: upperLandingRoom.bounds.minZ,
+          maxZ: upperLandingRoom.bounds.maxZ,
+        },
+        {
+          minX: upperLandingStairwellCutout!.maxX,
+          maxX: upperLandingRoom.bounds.maxX,
+          minZ: upperLandingRoom.bounds.minZ,
+          maxZ: upperLandingRoom.bounds.maxZ,
+        },
+      ].filter(
+        (bounds) =>
+          bounds.maxX - bounds.minX > 0 &&
+          bounds.maxZ - upperLandingSolidStartZ > 0
+      )
+    : [];
+  const upperLandingCutouts =
+    upperLandingRoom && upperLandingStairwellCutout
+      ? {
+          upperLanding: [
+            upperLandingStairwellCutout,
+            ...upperLandingStubBounds.map((bounds) => ({
+              minX: bounds.minX,
+              maxX: bounds.maxX,
+              minZ: upperLandingSolidStartZ,
+              maxZ: bounds.maxZ,
+            })),
+          ],
+        }
+      : undefined;
   const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
     material: upperFloorMaterial,
     elevation: upperFloorElevation,
@@ -1811,12 +1835,12 @@ function initializeImmersiveScene(
   });
   upperFloorGroup.add(upperFloorTiles.group);
 
-  // Keep only the stairwell open: room tiles fill the upper landing shoulders,
-  // while the stub remains the visible bridge from the stairs without z-fighting.
+  // Keep the central stairwell/descent corridor open: room tiles and side
+  // stubs only fill the landing shoulders, avoiding a full-width seal or z-fight.
 
-  if (upperLandingRoom) {
+  upperLandingStubBounds.forEach((bounds, index) => {
     const upperLandingStub = createUpperLandingStub({
-      bounds: upperLandingRoom.bounds,
+      bounds,
       landingMaxZ: stairTopZ,
       elevation: upperFloorElevation,
       thickness: STAIRCASE_CONFIG.landing.thickness,
@@ -1837,11 +1861,12 @@ function initializeImmersiveScene(
         },
       },
     });
+    upperLandingStub.group.name = `UpperLandingShoulderStub-${index + 1}`;
     upperFloorGroup.add(upperLandingStub.group);
     upperLandingStub.colliders.forEach((collider) =>
       upperFloorColliders.push(collider)
     );
-  }
+  });
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
   const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1779,30 +1779,48 @@ function initializeImmersiveScene(
     opacity: 1,
     depthWrite: true,
   });
-  const upperFloorTiles = createRoomFloorTiles(
-    UPPER_FLOOR_PLAN.rooms.filter((room) => room.id !== 'upperLanding'),
-    {
-      material: upperFloorMaterial,
-      elevation: upperFloorElevation,
-      thickness: STAIRCASE_CONFIG.landing.thickness,
-      groupName: 'UpperFloorTiles',
-    }
-  );
-  upperFloorGroup.add(upperFloorTiles.group);
-
-  // Keep the stairwell open: the landing stub below bridges from the stairs to
-  // the room tiles while avoiding a sealed slab over the descent corridor.
-
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
   );
+  const upperLandingClearance = toWorldUnits(0.05);
+  const upperLandingSolidStartZ = stairTopZ + upperLandingClearance;
+  const upperLandingCutouts = upperLandingRoom
+    ? {
+        upperLanding: [
+          {
+            minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+            maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+            minZ: upperLandingRoom.bounds.minZ,
+            maxZ: upperLandingSolidStartZ,
+          },
+          {
+            minX: upperLandingRoom.bounds.minX,
+            maxX: upperLandingRoom.bounds.maxX,
+            minZ: upperLandingSolidStartZ,
+            maxZ: upperLandingRoom.bounds.maxZ,
+          },
+        ],
+      }
+    : undefined;
+  const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+    material: upperFloorMaterial,
+    elevation: upperFloorElevation,
+    thickness: STAIRCASE_CONFIG.landing.thickness,
+    groupName: 'UpperFloorTiles',
+    cutoutsByRoom: upperLandingCutouts,
+  });
+  upperFloorGroup.add(upperFloorTiles.group);
+
+  // Keep only the stairwell open: room tiles fill the upper landing shoulders,
+  // while the stub remains the visible bridge from the stairs without z-fighting.
+
   if (upperLandingRoom) {
     const upperLandingStub = createUpperLandingStub({
       bounds: upperLandingRoom.bounds,
       landingMaxZ: stairTopZ,
       elevation: upperFloorElevation,
       thickness: STAIRCASE_CONFIG.landing.thickness,
-      landingClearance: toWorldUnits(0.05),
+      landingClearance: upperLandingClearance,
       material: {
         color: 0x4c596b,
         roughness: 0.58,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1625,7 +1625,7 @@ function initializeImmersiveScene(
       livingRoom.bounds,
       activeSceneDetailPolicy
     );
-    scene.add(mediaWall.group);
+    groundFloorGroup.add(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
@@ -1674,7 +1674,7 @@ function initializeImmersiveScene(
       width: 3.4,
       height: 4.1,
     });
-    scene.add(mirror.group);
+    groundFloorGroup.add(mirror.group);
     groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }
@@ -1954,7 +1954,7 @@ function initializeImmersiveScene(
   const floorVisibilityController: FloorVisibilityController =
     createFloorVisibilityController({
       initialFloorId: activeFloorId,
-      groundGroups: [groundPoiGroup],
+      groundGroups: [groundFloorGroup, groundPoiGroup],
       upperGroups: [upperFloorGroup],
       groundLedGroups: [ledStripGroup, ledFillLightGroup].filter(
         (group): group is Group => group !== null

--- a/src/scene/floors/visibilityController.ts
+++ b/src/scene/floors/visibilityController.ts
@@ -71,6 +71,10 @@ export function createFloorVisibilityController(
       if (poi.visitedBadge) {
         poi.visitedBadge.mesh.visible = false;
       }
+      if (poi.displayHighlight) {
+        poi.displayHighlight.material.opacity = 0;
+        poi.displayHighlight.mesh.visible = false;
+      }
     }
 
     return visible;

--- a/src/scene/floors/visibilityController.ts
+++ b/src/scene/floors/visibilityController.ts
@@ -1,0 +1,104 @@
+import type { Object3D } from 'three';
+
+import type { FloorPlanLevel } from '../../assets/floorPlan';
+import type { FloorId } from '../../systems/movement/stairs';
+import type { PoiInstance } from '../poi/markers';
+import type { PoiDefinition } from '../poi/types';
+
+export interface FloorVisibilityControllerOptions {
+  readonly initialFloorId?: FloorId;
+  readonly groundGroups?: Object3D[];
+  readonly upperGroups?: Object3D[];
+  readonly groundLedGroups?: Object3D[];
+  readonly upperLedGroups?: Object3D[];
+  readonly poiInstances?: PoiInstance[];
+  readonly getPoiFloorId: (poi: PoiDefinition) => FloorId;
+}
+
+export interface FloorVisibilityController {
+  getActiveFloorId(): FloorId;
+  setActiveFloorId(next: FloorId): void;
+  isPoiVisibleOnActiveFloor(poi: PoiDefinition): boolean;
+  applyPoiVisualState(poi: PoiInstance): boolean;
+}
+
+export function createPoiFloorResolver(
+  levels: readonly FloorPlanLevel[]
+): (poi: PoiDefinition) => FloorId {
+  const roomFloorIds = new Map<string, FloorId>();
+  levels.forEach((level) => {
+    const floorId = level.id === 'upper' ? 'upper' : 'ground';
+    level.plan.rooms.forEach((room) => {
+      roomFloorIds.set(room.id, floorId);
+    });
+  });
+
+  return (poi) => roomFloorIds.get(poi.roomId) ?? 'ground';
+}
+
+export function createFloorVisibilityController(
+  options: FloorVisibilityControllerOptions
+): FloorVisibilityController {
+  let activeFloorId = options.initialFloorId ?? 'ground';
+
+  const setVisible = (
+    objects: readonly Object3D[] | undefined,
+    visible: boolean
+  ) => {
+    objects?.forEach((object) => {
+      object.visible = visible;
+    });
+  };
+
+  const isPoiVisibleOnActiveFloor = (poi: PoiDefinition): boolean =>
+    options.getPoiFloorId(poi) === activeFloorId;
+
+  const applyPoiVisualState = (poi: PoiInstance): boolean => {
+    const visible = isPoiVisibleOnActiveFloor(poi.definition);
+    poi.group.visible = visible;
+
+    if (!visible) {
+      if (poi.labelMaterial) {
+        poi.labelMaterial.opacity = 0;
+      }
+      if (poi.label) {
+        poi.label.visible = false;
+      }
+      if (poi.visitedHighlight) {
+        poi.visitedHighlight.material.opacity = 0;
+        poi.visitedHighlight.mesh.visible = false;
+      }
+      if (poi.visitedBadge) {
+        poi.visitedBadge.mesh.visible = false;
+      }
+    }
+
+    return visible;
+  };
+
+  const apply = () => {
+    const showGround = activeFloorId === 'ground';
+    setVisible(options.groundGroups, showGround);
+    setVisible(options.upperGroups, !showGround);
+    setVisible(options.groundLedGroups, showGround);
+    setVisible(options.upperLedGroups, !showGround);
+    options.poiInstances?.forEach(applyPoiVisualState);
+  };
+
+  apply();
+
+  return {
+    getActiveFloorId() {
+      return activeFloorId;
+    },
+    setActiveFloorId(next: FloorId) {
+      if (activeFloorId === next) {
+        return;
+      }
+      activeFloorId = next;
+      apply();
+    },
+    isPoiVisibleOnActiveFloor,
+    applyPoiVisualState,
+  };
+}

--- a/src/scene/poi/interactionManager.ts
+++ b/src/scene/poi/interactionManager.ts
@@ -40,6 +40,7 @@ type ListenerTarget = Pick<
 export interface PoiInteractionOptions {
   keyboardTarget?: ListenerTarget | null;
   enableKeyboard?: boolean;
+  isPoiEnabled?: (poi: PoiInstance) => boolean;
 }
 
 export class PoiInteractionManager {
@@ -54,6 +55,7 @@ export class PoiInteractionManager {
   private active = false;
   private readonly keyboardTarget: ListenerTarget | null;
   private readonly enableKeyboard: boolean;
+  private readonly isPoiEnabled: (poi: PoiInstance) => boolean;
   private keyboardIndex: number | null = null;
   private usingKeyboard = false;
   private touchPointerId: number | null = null;
@@ -97,6 +99,7 @@ export class PoiInteractionManager {
         : null) as ListenerTarget | null);
     this.keyboardTarget = defaultKeyboardTarget ?? domElement;
     this.enableKeyboard = resolvedOptions.enableKeyboard ?? true;
+    this.isPoiEnabled = resolvedOptions.isPoiEnabled ?? (() => true);
   }
 
   start() {
@@ -289,7 +292,7 @@ export class PoiInteractionManager {
   }
 
   private handleKeyDown(event: KeyboardEvent) {
-    if (!this.enableKeyboard || this.poiInstances.length === 0) {
+    if (!this.enableKeyboard || this.getEnabledPoiInstances().length === 0) {
       return;
     }
 
@@ -350,15 +353,24 @@ export class PoiInteractionManager {
 
   private moveKeyboardFocus(direction: 1 | -1) {
     this.usingKeyboard = true;
-    const count = this.poiInstances.length;
+    const enabledPoiInstances = this.getEnabledPoiInstances();
+    const count = enabledPoiInstances.length;
     if (!count) {
       return;
     }
 
-    const currentIndex = this.keyboardIndex ?? (direction > 0 ? -1 : 0);
+    const currentPoi =
+      this.keyboardIndex === null
+        ? null
+        : this.poiInstances[this.keyboardIndex];
+    const enabledCurrentIndex = currentPoi
+      ? enabledPoiInstances.indexOf(currentPoi)
+      : -1;
+    const currentIndex =
+      enabledCurrentIndex >= 0 ? enabledCurrentIndex : direction > 0 ? -1 : 0;
     const nextIndex = (currentIndex + direction + count) % count;
-    this.keyboardIndex = nextIndex;
-    const poi = this.poiInstances[nextIndex];
+    const poi = enabledPoiInstances[nextIndex];
+    this.keyboardIndex = this.poiInstances.indexOf(poi);
     this.setHovered(poi, 'keyboard');
   }
 
@@ -385,22 +397,27 @@ export class PoiInteractionManager {
   }
 
   private pickPoi(): PoiInstance | null {
-    if (this.poiInstances.length === 0) {
+    const enabledPoiInstances = this.getEnabledPoiInstances();
+    if (enabledPoiInstances.length === 0) {
       return null;
     }
-    for (const poi of this.poiInstances) {
+    for (const poi of enabledPoiInstances) {
       poi.hitArea.updateWorldMatrix(true, false);
     }
     this.raycaster.setFromCamera(this.pointer, this.camera);
     const intersections = this.raycaster.intersectObjects(
-      this.poiInstances.map((poi) => poi.hitArea),
+      enabledPoiInstances.map((poi) => poi.hitArea),
       false
     );
     if (!intersections.length) {
       return null;
     }
     const target = intersections[0].object;
-    return this.poiInstances.find((poi) => poi.hitArea === target) ?? null;
+    return enabledPoiInstances.find((poi) => poi.hitArea === target) ?? null;
+  }
+
+  private getEnabledPoiInstances(): PoiInstance[] {
+    return this.poiInstances.filter(this.isPoiEnabled);
   }
 
   private setHovered(

--- a/src/scene/poi/interactionManager.ts
+++ b/src/scene/poi/interactionManager.ts
@@ -292,7 +292,7 @@ export class PoiInteractionManager {
   }
 
   private handleKeyDown(event: KeyboardEvent) {
-    if (!this.enableKeyboard || this.getEnabledPoiInstances().length === 0) {
+    if (!this.enableKeyboard) {
       return;
     }
 
@@ -332,12 +332,23 @@ export class PoiInteractionManager {
       case 'enter':
       case ' ':
       case 'f': {
-        if (this.hovered) {
-          event.preventDefault();
-          this.usingKeyboard = true;
-          this.setSelected(this.hovered, 'keyboard');
-          this.dispatchSelection(this.hovered.definition);
+        if (!this.hovered) {
+          break;
         }
+
+        event.preventDefault();
+        if (!this.isPoiEnabled(this.hovered)) {
+          const staleHovered = this.hovered;
+          this.setHovered(null, 'keyboard');
+          if (this.selected === staleHovered) {
+            this.setSelected(null, 'keyboard');
+          }
+          break;
+        }
+
+        this.usingKeyboard = true;
+        this.setSelected(this.hovered, 'keyboard');
+        this.dispatchSelection(this.hovered.definition);
         break;
       }
       case 'escape':

--- a/src/scene/poi/interactionManager.ts
+++ b/src/scene/poi/interactionManager.ts
@@ -171,7 +171,7 @@ export class PoiInteractionManager {
     const poi = this.poiInstances.find(
       (instance) => instance.definition.id === poiId
     );
-    if (!poi) {
+    if (!poi || !this.isPoiEnabled(poi)) {
       return;
     }
     this.usingKeyboard = true;

--- a/src/scene/poi/worldTooltip.ts
+++ b/src/scene/poi/worldTooltip.ts
@@ -15,6 +15,7 @@ import {
   GuidedTourPreference,
   defaultGuidedTourPreference,
 } from '../../systems/guidedTour/preference';
+import type { FloorId } from '../../systems/movement/stairs';
 
 import type { PoiDefinition } from './types';
 
@@ -22,6 +23,7 @@ type PoiWorldTooltipMode = 'hovered' | 'selected' | 'recommended';
 
 export interface PoiWorldTooltipTarget {
   poi: PoiDefinition;
+  floorId?: FloorId;
   getAnchorPosition(out: Vector3): Vector3;
 }
 
@@ -110,6 +112,8 @@ export class PoiWorldTooltip {
   private passiveRecommendationsEnabled = true;
 
   private idle = false;
+
+  private activeFloorId: FloorId = 'ground';
 
   private unsubscribeGuidedTour: (() => void) | null = null;
 
@@ -207,6 +211,14 @@ export class PoiWorldTooltip {
     this.recommendation = target;
   }
 
+  setActiveFloorId(floorId: FloorId): void {
+    if (this.activeFloorId === floorId) {
+      return;
+    }
+    this.activeFloorId = floorId;
+    this.fadeOut(0);
+  }
+
   setPassiveRecommendationsEnabled(enabled: boolean): void {
     if (this.passiveRecommendationsEnabled === enabled) {
       return;
@@ -244,7 +256,7 @@ export class PoiWorldTooltip {
           ? 'recommended'
           : null;
 
-    if (!active || !mode) {
+    if (!active || !mode || !this.isTargetOnActiveFloor(active)) {
       this.fadeOut(delta);
       return;
     }
@@ -375,6 +387,10 @@ export class PoiWorldTooltip {
       visible: this.group.visible,
       opacity: this.mesh.material.opacity,
     };
+  }
+
+  private isTargetOnActiveFloor(target: PoiWorldTooltipTarget): boolean {
+    return !target.floorId || target.floorId === this.activeFloorId;
   }
 
   private isFacingCamera(target: Vector3): boolean {

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -37,23 +37,29 @@ describe('createRoomFloorTiles', () => {
       minX: stairCenterX - stairHalfWidth - stairwellMarginX,
       maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
       minZ: upperLandingRoom!.bounds.minZ,
-      maxZ: upperLandingSolidStartZ,
+      maxZ: upperLandingRoom!.bounds.maxZ,
     };
+    const shoulderStubCutouts = [
+      {
+        minX: upperLandingRoom!.bounds.minX,
+        maxX: stairwellCutout.minX,
+        minZ: upperLandingSolidStartZ,
+        maxZ: upperLandingRoom!.bounds.maxZ,
+      },
+      {
+        minX: stairwellCutout.maxX,
+        maxX: upperLandingRoom!.bounds.maxX,
+        minZ: upperLandingSolidStartZ,
+        maxZ: upperLandingRoom!.bounds.maxZ,
+      },
+    ];
     const build = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
       material,
       elevation: 4,
       thickness: 0.45,
       groupName: 'UpperFloorTiles',
       cutoutsByRoom: {
-        upperLanding: [
-          stairwellCutout,
-          {
-            minX: upperLandingRoom!.bounds.minX,
-            maxX: upperLandingRoom!.bounds.maxX,
-            minZ: upperLandingSolidStartZ,
-            maxZ: upperLandingRoom!.bounds.maxZ,
-          },
-        ],
+        upperLanding: [stairwellCutout, ...shoulderStubCutouts],
       },
     });
 
@@ -79,6 +85,9 @@ describe('createRoomFloorTiles', () => {
 
     for (const tile of upperLandingTiles) {
       expect(overlaps(tile.bounds, stairwellCutout)).toBe(false);
+      for (const shoulderStubCutout of shoulderStubCutouts) {
+        expect(overlaps(tile.bounds, shoulderStubCutout)).toBe(false);
+      }
     }
 
     expect(material.transparent).toBe(false);

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -30,14 +30,26 @@ describe('createRoomFloorTiles', () => {
     const stairCenterX = toWorldUnits(6.2);
     const stairHalfWidth = toWorldUnits(3.1) / 2;
     const stairwellMarginX = toWorldUnits(0.2);
+    const descentCorridorInset = 0.75;
     const stairTopZ = toWorldUnits(-5.3) - toWorldUnits(0.85) * 9;
     const landingClearance = toWorldUnits(0.05);
+    const landingTriggerMargin = toWorldUnits(0.2);
     const upperLandingSolidStartZ = stairTopZ + landingClearance;
-    const stairwellCutout = {
+    const broadStairwellBounds = {
       minX: stairCenterX - stairHalfWidth - stairwellMarginX,
       maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
       minZ: upperLandingRoom!.bounds.minZ,
       maxZ: upperLandingRoom!.bounds.maxZ,
+    };
+    const descentCorridorHalfWidth = Math.max(
+      stairHalfWidth - descentCorridorInset,
+      stairHalfWidth * 0.55
+    );
+    const stairwellCutout = {
+      minX: stairCenterX - descentCorridorHalfWidth,
+      maxX: stairCenterX + descentCorridorHalfWidth,
+      minZ: upperLandingRoom!.bounds.minZ,
+      maxZ: stairTopZ + landingTriggerMargin + landingClearance,
     };
     const shoulderStubCutouts = [
       {
@@ -69,12 +81,28 @@ describe('createRoomFloorTiles', () => {
 
     expect(build.group.name).toBe('UpperFloorTiles');
     expect(upperLandingTiles.length).toBeGreaterThan(0);
-    expect(
-      upperLandingTiles.some((tile) => tile.bounds.maxX <= stairwellCutout.minX)
-    ).toBe(true);
-    expect(
-      upperLandingTiles.some((tile) => tile.bounds.minX >= stairwellCutout.maxX)
-    ).toBe(true);
+    const fillsLeftStairwellShoulder = upperLandingTiles.some(
+      (tile) =>
+        tile.bounds.minX < broadStairwellBounds.minX &&
+        tile.bounds.maxX > broadStairwellBounds.minX &&
+        tile.bounds.maxX <= stairwellCutout.minX
+    );
+    const fillsRightStairwellShoulder = upperLandingTiles.some(
+      (tile) =>
+        tile.bounds.minX >= stairwellCutout.maxX &&
+        tile.bounds.minX < broadStairwellBounds.maxX &&
+        tile.bounds.maxX > broadStairwellBounds.maxX
+    );
+    const fillsCentralLandingPastDescent = upperLandingTiles.some(
+      (tile) =>
+        tile.bounds.minX >= stairwellCutout.minX &&
+        tile.bounds.maxX <= stairwellCutout.maxX &&
+        tile.bounds.minZ >= stairwellCutout.maxZ &&
+        tile.bounds.maxZ === upperLandingRoom!.bounds.maxZ
+    );
+    expect(fillsLeftStairwellShoulder).toBe(true);
+    expect(fillsRightStairwellShoulder).toBe(true);
+    expect(fillsCentralLandingPastDescent).toBe(true);
 
     for (const tile of build.tiles) {
       const geometry = tile.mesh.geometry as BoxGeometry;

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -1,37 +1,84 @@
 import { BoxGeometry, MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { UPPER_FLOOR_PLAN } from '../../../assets/floorPlan';
+import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../../../assets/floorPlan';
 import { createRoomFloorTiles } from '../floorTiles';
 
+const toWorldUnits = (value: number): number => value * FLOOR_PLAN_SCALE;
+
+const overlaps = (
+  bounds: { minX: number; maxX: number; minZ: number; maxZ: number },
+  cutout: { minX: number; maxX: number; minZ: number; maxZ: number }
+): boolean =>
+  bounds.minX < cutout.maxX &&
+  bounds.maxX > cutout.minX &&
+  bounds.minZ < cutout.maxZ &&
+  bounds.maxZ > cutout.minZ;
+
 describe('createRoomFloorTiles', () => {
-  it('builds opaque upper-floor slabs without sealing the stair landing room', () => {
+  it('builds opaque upper-floor slabs with a targeted stairwell cutout', () => {
     const material = new MeshStandardMaterial({
       transparent: false,
       opacity: 1,
       depthWrite: true,
     });
-    const build = createRoomFloorTiles(
-      UPPER_FLOOR_PLAN.rooms.filter((room) => room.id !== 'upperLanding'),
-      {
-        material,
-        elevation: 4,
-        thickness: 0.45,
-        groupName: 'UpperFloorTiles',
-      }
+    const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+      (room) => room.id === 'upperLanding'
+    );
+    expect(upperLandingRoom).toBeDefined();
+
+    const stairCenterX = toWorldUnits(6.2);
+    const stairHalfWidth = toWorldUnits(3.1) / 2;
+    const stairwellMarginX = toWorldUnits(0.2);
+    const stairTopZ = toWorldUnits(-5.3) - toWorldUnits(0.85) * 9;
+    const landingClearance = toWorldUnits(0.05);
+    const upperLandingSolidStartZ = stairTopZ + landingClearance;
+    const stairwellCutout = {
+      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+      minZ: upperLandingRoom!.bounds.minZ,
+      maxZ: upperLandingSolidStartZ,
+    };
+    const build = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+      material,
+      elevation: 4,
+      thickness: 0.45,
+      groupName: 'UpperFloorTiles',
+      cutoutsByRoom: {
+        upperLanding: [
+          stairwellCutout,
+          {
+            minX: upperLandingRoom!.bounds.minX,
+            maxX: upperLandingRoom!.bounds.maxX,
+            minZ: upperLandingSolidStartZ,
+            maxZ: upperLandingRoom!.bounds.maxZ,
+          },
+        ],
+      },
+    });
+
+    const upperLandingTiles = build.tiles.filter(
+      (tile) => tile.roomId === 'upperLanding'
     );
 
     expect(build.group.name).toBe('UpperFloorTiles');
-    expect(build.tiles.map((tile) => tile.roomId)).not.toContain(
-      'upperLanding'
-    );
-    expect(build.tiles.length).toBeGreaterThan(0);
+    expect(upperLandingTiles.length).toBeGreaterThan(0);
+    expect(
+      upperLandingTiles.some((tile) => tile.bounds.maxX <= stairwellCutout.minX)
+    ).toBe(true);
+    expect(
+      upperLandingTiles.some((tile) => tile.bounds.minX >= stairwellCutout.maxX)
+    ).toBe(true);
 
     for (const tile of build.tiles) {
       const geometry = tile.mesh.geometry as BoxGeometry;
       expect(geometry.parameters.height).toBeCloseTo(0.45);
       expect(tile.mesh.position.y).toBeCloseTo(4 - 0.45 / 2);
       expect(tile.mesh.material).toBe(material);
+    }
+
+    for (const tile of upperLandingTiles) {
+      expect(overlaps(tile.bounds, stairwellCutout)).toBe(false);
     }
 
     expect(material.transparent).toBe(false);

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -1,0 +1,41 @@
+import { BoxGeometry, MeshStandardMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { UPPER_FLOOR_PLAN } from '../../../assets/floorPlan';
+import { createRoomFloorTiles } from '../floorTiles';
+
+describe('createRoomFloorTiles', () => {
+  it('builds opaque upper-floor slabs without sealing the stair landing room', () => {
+    const material = new MeshStandardMaterial({
+      transparent: false,
+      opacity: 1,
+      depthWrite: true,
+    });
+    const build = createRoomFloorTiles(
+      UPPER_FLOOR_PLAN.rooms.filter((room) => room.id !== 'upperLanding'),
+      {
+        material,
+        elevation: 4,
+        thickness: 0.45,
+        groupName: 'UpperFloorTiles',
+      }
+    );
+
+    expect(build.group.name).toBe('UpperFloorTiles');
+    expect(build.tiles.map((tile) => tile.roomId)).not.toContain(
+      'upperLanding'
+    );
+    expect(build.tiles.length).toBeGreaterThan(0);
+
+    for (const tile of build.tiles) {
+      const geometry = tile.mesh.geometry as BoxGeometry;
+      expect(geometry.parameters.height).toBeCloseTo(0.45);
+      expect(tile.mesh.position.y).toBeCloseTo(4 - 0.45 / 2);
+      expect(tile.mesh.material).toBe(material);
+    }
+
+    expect(material.transparent).toBe(false);
+    expect(material.opacity).toBe(1);
+    expect(material.depthWrite).toBe(true);
+  });
+});

--- a/src/scene/structures/floorTiles.ts
+++ b/src/scene/structures/floorTiles.ts
@@ -1,16 +1,24 @@
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial, Texture } from 'three';
 
-import type { RoomDefinition } from '../../assets/floorPlan';
+import type { Bounds2D, RoomDefinition } from '../../assets/floorPlan';
 import { applyLightmapUv2 } from '../lighting/bakedLightmaps';
 
 export interface RoomFloorTile {
   readonly roomId: string;
   readonly mesh: Mesh;
+  readonly bounds: Bounds2D;
 }
 
 export interface RoomFloorBuild {
   readonly group: Group;
   readonly tiles: RoomFloorTile[];
+}
+
+export interface RoomFloorCutout {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minZ: number;
+  readonly maxZ: number;
 }
 
 export interface RoomFloorOptions {
@@ -32,6 +40,10 @@ export interface RoomFloorOptions {
   readonly groupName?: string;
   /** When true, exterior rooms receive tiles too. */
   readonly includeExterior?: boolean;
+  /** World-space openings removed from every room tile. */
+  readonly cutouts?: RoomFloorCutout[];
+  /** World-space openings removed only from a matching room id. */
+  readonly cutoutsByRoom?: Readonly<Record<string, RoomFloorCutout[]>>;
 }
 
 const DEFAULT_GROUP_NAME = 'RoomFloorTiles';
@@ -74,6 +86,91 @@ function resolveMaterial(
   return defaultMaterial;
 }
 
+const hasPositiveArea = (bounds: Bounds2D): boolean =>
+  bounds.maxX - bounds.minX > MIN_DIMENSION &&
+  bounds.maxZ - bounds.minZ > MIN_DIMENSION;
+
+const clipCutoutToBounds = (
+  bounds: Bounds2D,
+  cutout: RoomFloorCutout
+): Bounds2D | null => {
+  const overlap = {
+    minX: Math.max(bounds.minX, cutout.minX),
+    maxX: Math.min(bounds.maxX, cutout.maxX),
+    minZ: Math.max(bounds.minZ, cutout.minZ),
+    maxZ: Math.min(bounds.maxZ, cutout.maxZ),
+  };
+
+  return hasPositiveArea(overlap) ? overlap : null;
+};
+
+const subtractCutout = (
+  bounds: Bounds2D,
+  cutout: RoomFloorCutout
+): Bounds2D[] => {
+  const overlap = clipCutoutToBounds(bounds, cutout);
+  if (!overlap) {
+    return [bounds];
+  }
+
+  const pieces: Bounds2D[] = [
+    {
+      minX: bounds.minX,
+      maxX: overlap.minX,
+      minZ: bounds.minZ,
+      maxZ: bounds.maxZ,
+    },
+    {
+      minX: overlap.maxX,
+      maxX: bounds.maxX,
+      minZ: bounds.minZ,
+      maxZ: bounds.maxZ,
+    },
+    {
+      minX: overlap.minX,
+      maxX: overlap.maxX,
+      minZ: bounds.minZ,
+      maxZ: overlap.minZ,
+    },
+    {
+      minX: overlap.minX,
+      maxX: overlap.maxX,
+      minZ: overlap.maxZ,
+      maxZ: bounds.maxZ,
+    },
+  ];
+
+  return pieces.filter(hasPositiveArea);
+};
+
+const getRoomTileBounds = (
+  room: RoomDefinition,
+  options: RoomFloorOptions,
+  inset: number
+): Bounds2D[] => {
+  const roomBounds = {
+    minX: room.bounds.minX + inset,
+    maxX: room.bounds.maxX - inset,
+    minZ: room.bounds.minZ + inset,
+    maxZ: room.bounds.maxZ - inset,
+  };
+
+  if (!hasPositiveArea(roomBounds)) {
+    return [];
+  }
+
+  const cutouts = [
+    ...(options.cutouts ?? []),
+    ...(options.cutoutsByRoom?.[room.id] ?? []),
+  ];
+
+  return cutouts.reduce<Bounds2D[]>(
+    (pieces, cutout) =>
+      pieces.flatMap((piece) => subtractCutout(piece, cutout)),
+    [roomBounds]
+  );
+};
+
 export function createRoomFloorTiles(
   rooms: RoomDefinition[],
   options: RoomFloorOptions = {}
@@ -102,30 +199,28 @@ export function createRoomFloorTiles(
       return;
     }
 
-    const width = room.bounds.maxX - room.bounds.minX - inset * 2;
-    const depth = room.bounds.maxZ - room.bounds.minZ - inset * 2;
+    getRoomTileBounds(room, options, inset).forEach((bounds, index) => {
+      const width = bounds.maxX - bounds.minX;
+      const depth = bounds.maxZ - bounds.minZ;
+      const geometry = new BoxGeometry(width, thickness, depth);
+      applyLightmapUv2(geometry);
 
-    if (width <= MIN_DIMENSION || depth <= MIN_DIMENSION) {
-      return;
-    }
+      const mesh = new Mesh(
+        geometry,
+        resolveMaterial(room, options, defaultMaterial)
+      );
+      mesh.position.set(
+        (bounds.minX + bounds.maxX) / 2,
+        elevation - thickness / 2,
+        (bounds.minZ + bounds.maxZ) / 2
+      );
+      mesh.name =
+        index === 0 ? `${room.name} Floor` : `${room.name} Floor ${index + 1}`;
+      mesh.receiveShadow = true;
 
-    const geometry = new BoxGeometry(width, thickness, depth);
-    applyLightmapUv2(geometry);
-
-    const mesh = new Mesh(
-      geometry,
-      resolveMaterial(room, options, defaultMaterial)
-    );
-    mesh.position.set(
-      (room.bounds.minX + room.bounds.maxX) / 2,
-      elevation - thickness / 2,
-      (room.bounds.minZ + room.bounds.maxZ) / 2
-    );
-    mesh.name = `${room.name} Floor`;
-    mesh.receiveShadow = true;
-
-    group.add(mesh);
-    tiles.push({ roomId: room.id, mesh });
+      group.add(mesh);
+      tiles.push({ roomId: room.id, mesh, bounds });
+    });
   });
 
   return { group, tiles };

--- a/src/tests/floorVisibilityController.test.ts
+++ b/src/tests/floorVisibilityController.test.ts
@@ -1,0 +1,132 @@
+import { Group, Mesh, MeshBasicMaterial, Object3D, PlaneGeometry } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
+import {
+  createFloorVisibilityController,
+  createPoiFloorResolver,
+} from '../scene/floors/visibilityController';
+import type { PoiInstance } from '../scene/poi/markers';
+import type { PoiDefinition } from '../scene/poi/types';
+
+function createPoi(roomId: string): PoiDefinition {
+  return {
+    id: `${roomId}-poi`,
+    title: roomId,
+    category: 'project',
+    roomId,
+    position: { x: 0, y: 0, z: 0 },
+    interactionRadius: 2,
+    footprint: { width: 1, depth: 1 },
+    links: [],
+  } as PoiDefinition;
+}
+
+function createPoiInstance(roomId: string): PoiInstance {
+  const group = new Group();
+  const labelMaterial = new MeshBasicMaterial({
+    transparent: true,
+    opacity: 0.75,
+  });
+  const label = new Mesh(new PlaneGeometry(1, 0.5), labelMaterial);
+  label.visible = true;
+  const visitedMaterial = new MeshBasicMaterial({
+    transparent: true,
+    opacity: 0.5,
+  });
+  const visitedRing = new Mesh(new PlaneGeometry(1, 1), visitedMaterial);
+  visitedRing.visible = true;
+  const visitedBadge = new Mesh(
+    new PlaneGeometry(0.5, 0.5),
+    new MeshBasicMaterial()
+  );
+  visitedBadge.visible = true;
+  group.add(label, visitedRing, visitedBadge);
+
+  return {
+    definition: createPoi(roomId),
+    group,
+    hitArea: new Mesh(new PlaneGeometry(1, 1), new MeshBasicMaterial()),
+    label,
+    labelMaterial,
+    labelWorldPosition: group.position.clone(),
+    floatPhase: 0,
+    floatSpeed: 0,
+    floatAmplitude: 0,
+    activation: 0,
+    pulseOffset: 0,
+    focus: 0,
+    focusTarget: 0,
+    visualMode: 'pedestal',
+    visited: true,
+    visitedStrength: 1,
+    visitedHighlight: { mesh: visitedRing, material: visitedMaterial },
+    visitedBadge: {
+      mesh: visitedBadge,
+      material: new MeshBasicMaterial(),
+      baseHeight: 1,
+      rotationSpeed: 0,
+    },
+  } as PoiInstance;
+}
+
+describe('floor visibility controller', () => {
+  it('toggles floor-specific groups and LED groups with the active floor', () => {
+    const groundGroup = new Object3D();
+    const upperGroup = new Object3D();
+    const groundLedGroup = new Object3D();
+    const upperLedGroup = new Object3D();
+    const controller = createFloorVisibilityController({
+      groundGroups: [groundGroup],
+      upperGroups: [upperGroup],
+      groundLedGroups: [groundLedGroup],
+      upperLedGroups: [upperLedGroup],
+      getPoiFloorId: () => 'ground',
+    });
+
+    expect(groundGroup.visible).toBe(true);
+    expect(groundLedGroup.visible).toBe(true);
+    expect(upperGroup.visible).toBe(false);
+    expect(upperLedGroup.visible).toBe(false);
+
+    controller.setActiveFloorId('upper');
+
+    expect(groundGroup.visible).toBe(false);
+    expect(groundLedGroup.visible).toBe(false);
+    expect(upperGroup.visible).toBe(true);
+    expect(upperLedGroup.visible).toBe(true);
+  });
+
+  it('hides ground POI labels and visited checkmarks on the upper floor', () => {
+    const groundPoi = createPoiInstance('studio');
+    const controller = createFloorVisibilityController({
+      initialFloorId: 'upper',
+      poiInstances: [groundPoi],
+      getPoiFloorId: createPoiFloorResolver(FLOOR_PLAN_LEVELS),
+    });
+
+    expect(controller.isPoiVisibleOnActiveFloor(groundPoi.definition)).toBe(
+      false
+    );
+    expect(groundPoi.group.visible).toBe(false);
+    expect(groundPoi.label?.visible).toBe(false);
+    expect(groundPoi.labelMaterial?.opacity).toBe(0);
+    expect(groundPoi.visitedHighlight?.mesh.visible).toBe(false);
+    expect(groundPoi.visitedHighlight?.material.opacity).toBe(0);
+    expect(groundPoi.visitedBadge?.mesh.visible).toBe(false);
+  });
+
+  it('keeps upper POIs visible when the upper floor is active', () => {
+    const upperPoi = createPoiInstance('loftLibrary');
+    const controller = createFloorVisibilityController({
+      initialFloorId: 'upper',
+      poiInstances: [upperPoi],
+      getPoiFloorId: createPoiFloorResolver(FLOOR_PLAN_LEVELS),
+    });
+
+    expect(controller.isPoiVisibleOnActiveFloor(upperPoi.definition)).toBe(
+      true
+    );
+    expect(upperPoi.group.visible).toBe(true);
+  });
+});

--- a/src/tests/floorVisibilityController.test.ts
+++ b/src/tests/floorVisibilityController.test.ts
@@ -41,6 +41,15 @@ function createPoiInstance(roomId: string): PoiInstance {
     new MeshBasicMaterial()
   );
   visitedBadge.visible = true;
+  const displayHighlightMaterial = new MeshBasicMaterial({
+    transparent: true,
+    opacity: 0.8,
+  });
+  const displayHighlight = new Mesh(
+    new PlaneGeometry(1, 1),
+    displayHighlightMaterial
+  );
+  displayHighlight.visible = true;
   group.add(label, visitedRing, visitedBadge);
 
   return {
@@ -66,6 +75,12 @@ function createPoiInstance(roomId: string): PoiInstance {
       material: new MeshBasicMaterial(),
       baseHeight: 1,
       rotationSpeed: 0,
+    },
+    displayHighlight: {
+      mesh: displayHighlight,
+      material: displayHighlightMaterial,
+      baseOpacity: 0.8,
+      focusOpacity: 1,
     },
   } as PoiInstance;
 }
@@ -114,6 +129,8 @@ describe('floor visibility controller', () => {
     expect(groundPoi.visitedHighlight?.mesh.visible).toBe(false);
     expect(groundPoi.visitedHighlight?.material.opacity).toBe(0);
     expect(groundPoi.visitedBadge?.mesh.visible).toBe(false);
+    expect(groundPoi.displayHighlight?.mesh.visible).toBe(false);
+    expect(groundPoi.displayHighlight?.material.opacity).toBe(0);
   });
 
   it('keeps upper POIs visible when the upper floor is active', () => {

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -501,6 +501,28 @@ describe('PoiInteractionManager', () => {
     expect(poi.focusTarget).toBe(1);
   });
 
+  it('ignores disabled POIs during programmatic selection', () => {
+    manager.dispose();
+    const disabledManager = new PoiInteractionManager(
+      domElement,
+      camera,
+      [poi],
+      {
+        isPoiEnabled: () => false,
+      }
+    );
+    disabledManager.start();
+    const listener = vi.fn();
+    disabledManager.addSelectionListener(listener);
+
+    disabledManager.selectPoiById(definition.id);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(poi.focusTarget).toBe(0);
+
+    disabledManager.dispose();
+  });
+
   it('clearSelection notifies selection state listeners with null', () => {
     manager.start();
     const selectionState = vi.fn();

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -488,6 +488,36 @@ describe('PoiInteractionManager', () => {
     window.removeEventListener('poi:selected', customEventHandler);
   });
 
+  it('does not activate a stale hovered POI after it becomes disabled', () => {
+    manager.dispose();
+    let enabled = true;
+    manager = new PoiInteractionManager(domElement, camera, [poi], {
+      isPoiEnabled: () => enabled,
+    });
+    manager.start();
+    const listener = vi.fn();
+    const selectionState = vi.fn();
+    manager.addSelectionListener(listener);
+    manager.addSelectionStateListener(selectionState);
+    const customEventHandler = vi.fn();
+    window.addEventListener('poi:selected', customEventHandler);
+
+    domElement.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 200, clientY: 200 })
+    );
+    expect(poi.focusTarget).toBe(1);
+
+    enabled = false;
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(customEventHandler).not.toHaveBeenCalled();
+    expect(selectionState).not.toHaveBeenCalled();
+    expect(poi.focusTarget).toBe(0);
+
+    window.removeEventListener('poi:selected', customEventHandler);
+  });
+
   it('selects POIs programmatically by id', () => {
     manager.start();
     const listener = vi.fn();

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -6,6 +6,11 @@ import {
 } from 'three';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
+import {
+  createFloorVisibilityController,
+  createPoiFloorResolver,
+} from '../scene/floors/visibilityController';
 import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import { scalePoiValue } from '../scene/poi/constants';
 import {
@@ -292,5 +297,36 @@ describe('createPoiInstances', () => {
     );
     expect(performance.collider).toEqual(balanced.collider);
     expect(performance.hitArea.name).toBe(`POI_HIT:${definition.id}`);
+  });
+
+  it('hides ground-floor marker labels and checkmarks when the upper floor is active', () => {
+    const [instance] = createPoiInstances([
+      createDefinition({ id: 'flywheel-studio-flywheel', roomId: 'studio' }),
+    ]);
+    if (
+      !instance.label ||
+      !instance.labelMaterial ||
+      !instance.visitedHighlight
+    ) {
+      throw new Error(
+        'Expected default POI to include floor-hideable visuals.'
+      );
+    }
+    instance.label.visible = true;
+    instance.labelMaterial.opacity = 0.72;
+    instance.visitedHighlight.mesh.visible = true;
+    instance.visitedHighlight.material.opacity = 0.55;
+
+    createFloorVisibilityController({
+      initialFloorId: 'upper',
+      poiInstances: [instance],
+      getPoiFloorId: createPoiFloorResolver(FLOOR_PLAN_LEVELS),
+    });
+
+    expect(instance.group.visible).toBe(false);
+    expect(instance.label.visible).toBe(false);
+    expect(instance.labelMaterial.opacity).toBe(0);
+    expect(instance.visitedHighlight.mesh.visible).toBe(false);
+    expect(instance.visitedHighlight.material.opacity).toBe(0);
   });
 });

--- a/src/tests/poiWorldTooltip.test.ts
+++ b/src/tests/poiWorldTooltip.test.ts
@@ -544,6 +544,30 @@ describe('PoiWorldTooltip', () => {
     preference.dispose();
   });
 
+  it('does not render ghost ground-floor world labels on the upper floor', () => {
+    const { tooltip, preference } = createTooltip();
+    const poi = createPoiDefinition({ roomId: 'studio' });
+    tooltip.setActiveFloorId('upper');
+    tooltip.setHovered({
+      ...createTarget(poi, new Vector3(0, 1, 0)),
+      floorId: 'ground',
+    });
+    tooltip.update(0.016);
+
+    const state = tooltip.getState();
+    expect(state.visible).toBe(false);
+    expect(state.poiId).toBeNull();
+
+    tooltip.setActiveFloorId('ground');
+    tooltip.update(0.016);
+
+    expect(tooltip.getState().visible).toBe(true);
+    expect(tooltip.getState().poiId).toBe(poi.id);
+
+    tooltip.dispose();
+    preference.dispose();
+  });
+
   it('disposes resources without leaking scene children', () => {
     const { tooltip, scene } = createTooltip();
     const poi = createPoiDefinition({ id: 'pr-reaper-backyard-console' });


### PR DESCRIPTION
### Motivation
- Fix the second-floor “walking on glass” appearance by replacing the single thin upper-plane with opaque room slabs while preserving the stair opening. 
- Prevent ground-floor POI labels, visited checkmarks and LED/fill lights from poking through the upstairs view. 
- Centralize floor-specific visibility rules so the scene and POI UX respect the active floor without sprinkling checks across modules.

### Description
- Replace the single upstairs `ShapeGeometry` plane with per-room opaque slabs using `createRoomFloorTiles(...)` for the upper floor and keep the `upperLanding` stub open for stairs; material uses depth-write so lower-floor objects are occluded. (src/main.ts)
- Add a `FloorVisibilityController` with `createPoiFloorResolver` to resolve room→floor and toggle ground/upper groups, LED groups, and per-POI visuals (labels, visited rings, badges). (src/scene/floors/visibilityController.ts)
- Group ground visuals and POIs into named groups (`GroundFloorVisuals`, `GroundPoiVisuals`) and wire a single controller into `setActiveFloorId(...)` so toggling floors updates visuals and POI/tooltips consistently. (src/main.ts)
- Make POI systems floor-aware: `PoiInteractionManager` now accepts `isPoiEnabled` so picking/keyboard traversal ignores off-floor POIs, and `PoiWorldTooltip` and resolve-targets carry floor ids and hide off-floor tooltips. (src/scene/poi/interactionManager.ts, src/scene/poi/worldTooltip.ts)
- Add tests covering floor visibility, opaque upper-floor slabs, POI label/checkmark hiding, and world-tooltip floor filtering. (src/tests/floorVisibilityController.test.ts, src/scene/structures/__tests__/floorTiles.test.ts, src/tests/poiMarkers.test.ts, src/tests/poiWorldTooltip.test.ts)

### Testing
- Ran formatting and lint: `npm run format:write` (passed) and `npm run lint` (passed).
- Typecheck: `npm run typecheck` (failed due to unrelated, pre-existing repo-wide TypeScript issues; failure not introduced by these changes).
- Unit tests: `npm run test:ci -- src/tests/poiMarkers.test.ts src/tests/poiWorldTooltip.test.ts` (passed); expanded run including added floor tests `npm run test:ci -- src/tests/poiMarkers.test.ts src/tests/poiWorldTooltip.test.ts src/tests/floorVisibilityController.test.ts src/scene/structures/__tests__/floorTiles.test.ts` (passed); full `npm run test:ci` completed with the repository test suite (existing tests) and all ran in the environment (many tests passed; unrelated test logs shown).
- Build and docs: `npm run build` (passed) and `npm run docs:check` (passed with external link fetch warnings only), and `npm run smoke` (passed).
- Playwright/e2e: `npm run test:e2e -- playwright/small-screen-hud.spec.ts` initially failed because Playwright browsers were not installed; `npx playwright install chromium` downloaded browsers but the host environment lacked required system libraries so Playwright e2e remains blocked by host dependencies (recommend CI or reviewer run `npx playwright install-deps` / apt install list shown in logs).

Residual risks & follow-ups: the change relies on the shared `FloorVisibilityController` to be the single source of truth for floor visibility; future floor-specific visuals should register with it rather than adding ad-hoc checks. `tsc` reveals unrelated, pre-existing typing issues in the repo which should be addressed separately; Playwright e2e needs host system deps to be installed to run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ca5bc7e8832f86c3d2ae1fca739e)