### PR TITLE
🏗️ Solidify upper floor visuals

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,8 @@ import {
   Group,
   HemisphereLight,
   MathUtils,
-  Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  Shape,
-  ShapeGeometry,
   OrthographicCamera,
   PointLight,
   Scene,
@@ -113,6 +110,7 @@ import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
+import { createFloorVisibilityController } from './scene/floors/visibilityController';
 import {
   createMotionBlurController,
   type MotionBlurController,
@@ -1672,6 +1670,11 @@ function initializeImmersiveScene(
     selfieMirror = mirror;
   }
 
+  let activeFloorId: FloorId = 'ground';
+  let floorVisibilityController: ReturnType<
+    typeof createFloorVisibilityController
+  > | null = null;
+
   const staircase = createStaircase(STAIRCASE_CONFIG);
   scene.add(staircase.group);
   const stairTotalRise = staircase.totalRise;
@@ -1766,21 +1769,13 @@ function initializeImmersiveScene(
 
   const upperFloorMaterial = new MeshStandardMaterial({
     color: 0x1f273a,
-    side: DoubleSide,
-    // Nudge the upper floor away from coplanar surfaces (e.g., landing top)
-    // to avoid depth fighting at shared boundaries.
-    polygonOffset: true,
-    polygonOffsetFactor: 1,
-    polygonOffsetUnits: 1,
+    roughness: 0.62,
+    metalness: 0.14,
+    transparent: false,
+    opacity: 1,
+    depthWrite: true,
+    depthTest: true,
   });
-  const upperFloorShape = new Shape();
-  const [upperFirstX, upperFirstZ] = UPPER_FLOOR_PLAN.outline[0];
-  upperFloorShape.moveTo(upperFirstX, upperFirstZ);
-  for (let i = 1; i < UPPER_FLOOR_PLAN.outline.length; i += 1) {
-    const [x, z] = UPPER_FLOOR_PLAN.outline[i];
-    upperFloorShape.lineTo(x, z);
-  }
-  upperFloorShape.closePath();
 
   // Carve a stairwell hole in the upper floor directly above the stairs to
   // eliminate z-fighting and allow the player to visually descend. Use a
@@ -1790,23 +1785,21 @@ function initializeImmersiveScene(
   const stairHoleMaxX = stairCenterX + stairHoleHalfWidth;
   const stairHoleMinZ = stairLayout.stairHoleRange.minZ;
   const stairHoleMaxZ = stairLayout.stairHoleRange.maxZ;
-  upperFloorShape.holes.push(
-    (() => {
-      const hole = new Shape();
-      hole.moveTo(stairHoleMinX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMaxZ);
-      hole.lineTo(stairHoleMinX, stairHoleMaxZ);
-      hole.closePath();
-      return hole;
-    })()
-  );
-  const upperFloorGeometry = new ShapeGeometry(upperFloorShape);
-  upperFloorGeometry.rotateX(-Math.PI / 2);
-  const upperFloor = new Mesh(upperFloorGeometry, upperFloorMaterial);
-  // Slightly lower than the landing top to ensure no coplanar z-fighting.
-  upperFloor.position.y = upperFloorElevation - 0.002;
-  upperFloorGroup.add(upperFloor);
+  const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+    material: upperFloorMaterial,
+    elevation: upperFloorElevation - 0.004,
+    thickness: STAIRCASE_CONFIG.landing.thickness,
+    groupName: 'UpperFloorTiles',
+    cutouts: [
+      {
+        minX: stairHoleMinX,
+        maxX: stairHoleMaxX,
+        minZ: stairHoleMinZ,
+        maxZ: stairHoleMaxZ,
+      },
+    ],
+  });
+  upperFloorGroup.add(upperFloorTiles.group);
 
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
@@ -1957,6 +1950,15 @@ function initializeImmersiveScene(
       staticColliders.push(poi.collider);
     }
     poiInstances.push(poi);
+  });
+
+  floorVisibilityController = createFloorVisibilityController({
+    activeFloorId,
+    upperFloorGroups: [upperFloorGroup],
+    groundPoiInstances: poiInstances,
+    groundLedGroups: [ledStripGroup, ledFillLightGroup].filter(
+      (group): group is Group => Boolean(group)
+    ),
   });
 
   const poiAnalytics = createWindowPoiAnalytics();
@@ -3331,7 +3333,6 @@ function initializeImmersiveScene(
   const mouseCameraStart = new Vector2();
   let mouseCameraPointerId: number | null = null;
 
-  let activeFloorId: FloorId = 'ground';
   let helpKeyWasPressed = false;
   let helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
   const buildHelpButtonText = (shortcut: string) =>
@@ -3547,10 +3548,11 @@ function initializeImmersiveScene(
 
   const setActiveFloorId = (next: FloorId) => {
     if (activeFloorId === next) {
+      floorVisibilityController?.setActiveFloorId(next);
       return;
     }
     activeFloorId = next;
-    upperFloorGroup.visible = next === 'upper';
+    floorVisibilityController?.setActiveFloorId(next);
     document.documentElement.dataset.activeFloor = next;
   };
 
@@ -3568,6 +3570,7 @@ function initializeImmersiveScene(
 
   updatePlayerVerticalPosition();
   document.documentElement.dataset.activeFloor = activeFloorId;
+  floorVisibilityController?.setActiveFloorId(activeFloorId);
 
   const setCameraZoomTarget = (next: number) => {
     cameraZoomTarget = MathUtils.clamp(next, MIN_CAMERA_ZOOM, MAX_CAMERA_ZOOM);
@@ -4644,6 +4647,10 @@ function initializeImmersiveScene(
     const worldTooltipVisible = worldTooltipState.visible;
 
     for (const poi of poiInstances) {
+      if (floorVisibilityController?.applyPoiVisibility(poi) === false) {
+        continue;
+      }
+
       const floatOffset = Math.sin(
         elapsedTime * poi.floatSpeed + poi.floatPhase
       );

--- a/src/scene/floors/visibilityController.ts
+++ b/src/scene/floors/visibilityController.ts
@@ -1,0 +1,120 @@
+import type { Object3D } from 'three';
+
+import type { FloorId } from '../../systems/movement/stairs';
+import type { PoiInstance } from '../poi/markers';
+
+export interface FloorVisibilityControllerOptions {
+  readonly activeFloorId?: FloorId;
+  readonly upperFloorGroups?: Object3D[];
+  readonly groundPoiInstances?: PoiInstance[];
+  readonly upperPoiInstances?: PoiInstance[];
+  readonly groundLedGroups?: Object3D[];
+  readonly upperLedGroups?: Object3D[];
+}
+
+export interface FloorVisibilityController {
+  getActiveFloorId(): FloorId;
+  setActiveFloorId(next: FloorId): void;
+  isPoiVisible(poi: PoiInstance): boolean;
+  applyPoiVisibility(poi: PoiInstance): boolean;
+}
+
+function setObjectVisible(target: Object3D | undefined, visible: boolean) {
+  if (target) {
+    target.visible = visible;
+  }
+}
+
+function hidePoiVisuals(poi: PoiInstance) {
+  setObjectVisible(poi.group, false);
+  setObjectVisible(poi.label, false);
+  setObjectVisible(poi.visitedHighlight?.mesh, false);
+  setObjectVisible(poi.visitedBadge?.mesh, false);
+  setObjectVisible(poi.halo, false);
+  setObjectVisible(poi.displayHighlight?.mesh, false);
+
+  if (poi.labelMaterial) {
+    poi.labelMaterial.opacity = 0;
+  }
+  if (poi.visitedHighlight) {
+    poi.visitedHighlight.material.opacity = 0;
+  }
+  if (poi.visitedBadge) {
+    poi.visitedBadge.material.opacity = 0;
+  }
+  if (poi.haloMaterial) {
+    poi.haloMaterial.opacity = 0;
+  }
+  if (poi.displayHighlight) {
+    poi.displayHighlight.material.opacity = 0;
+  }
+}
+
+function showPoiVisuals(poi: PoiInstance) {
+  setObjectVisible(poi.group, true);
+}
+
+export function createFloorVisibilityController(
+  options: FloorVisibilityControllerOptions
+): FloorVisibilityController {
+  let activeFloorId = options.activeFloorId ?? 'ground';
+  const groundPoiInstances = new Set(options.groundPoiInstances ?? []);
+  const upperPoiInstances = new Set(options.upperPoiInstances ?? []);
+
+  const isPoiVisible = (poi: PoiInstance): boolean => {
+    if (groundPoiInstances.has(poi)) {
+      return activeFloorId === 'ground';
+    }
+    if (upperPoiInstances.has(poi)) {
+      return activeFloorId === 'upper';
+    }
+    return true;
+  };
+
+  const applyPoiVisibility = (poi: PoiInstance): boolean => {
+    const visible = isPoiVisible(poi);
+    if (visible) {
+      showPoiVisuals(poi);
+    } else {
+      hidePoiVisuals(poi);
+    }
+    return visible;
+  };
+
+  const apply = () => {
+    const showUpper = activeFloorId === 'upper';
+    for (const group of options.upperFloorGroups ?? []) {
+      group.visible = showUpper;
+    }
+    for (const group of options.groundLedGroups ?? []) {
+      group.visible = activeFloorId === 'ground';
+    }
+    for (const group of options.upperLedGroups ?? []) {
+      group.visible = showUpper;
+    }
+    for (const poi of groundPoiInstances) {
+      applyPoiVisibility(poi);
+    }
+    for (const poi of upperPoiInstances) {
+      applyPoiVisibility(poi);
+    }
+  };
+
+  apply();
+
+  return {
+    getActiveFloorId() {
+      return activeFloorId;
+    },
+    setActiveFloorId(next: FloorId) {
+      if (activeFloorId === next) {
+        apply();
+        return;
+      }
+      activeFloorId = next;
+      apply();
+    },
+    isPoiVisible,
+    applyPoiVisibility,
+  };
+}

--- a/src/scene/structures/floorTiles.ts
+++ b/src/scene/structures/floorTiles.ts
@@ -13,6 +13,13 @@ export interface RoomFloorBuild {
   readonly tiles: RoomFloorTile[];
 }
 
+export interface RectangularFloorCutout {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minZ: number;
+  readonly maxZ: number;
+}
+
 export interface RoomFloorOptions {
   /** Height of the tile's top surface. */
   readonly elevation?: number;
@@ -32,6 +39,8 @@ export interface RoomFloorOptions {
   readonly groupName?: string;
   /** When true, exterior rooms receive tiles too. */
   readonly includeExterior?: boolean;
+  /** Rectangular openings to carve out of any intersecting room tile. */
+  readonly cutouts?: RectangularFloorCutout[];
 }
 
 const DEFAULT_GROUP_NAME = 'RoomFloorTiles';
@@ -39,6 +48,79 @@ const DEFAULT_THICKNESS = 0.12;
 const DEFAULT_INSET = 0;
 const MIN_DIMENSION = 0.05;
 const DEFAULT_COLOR = 0x2a3547;
+
+function intersectCutout(
+  bounds: RectangularFloorCutout,
+  cutout: RectangularFloorCutout
+): RectangularFloorCutout | null {
+  const minX = Math.max(bounds.minX, cutout.minX);
+  const maxX = Math.min(bounds.maxX, cutout.maxX);
+  const minZ = Math.max(bounds.minZ, cutout.minZ);
+  const maxZ = Math.min(bounds.maxZ, cutout.maxZ);
+
+  if (maxX - minX <= MIN_DIMENSION || maxZ - minZ <= MIN_DIMENSION) {
+    return null;
+  }
+
+  return { minX, maxX, minZ, maxZ };
+}
+
+function splitBoundsAroundCutout(
+  bounds: RectangularFloorCutout,
+  cutout: RectangularFloorCutout
+): RectangularFloorCutout[] {
+  const intersection = intersectCutout(bounds, cutout);
+  if (!intersection) {
+    return [bounds];
+  }
+
+  return [
+    { ...bounds, maxX: intersection.minX },
+    { ...bounds, minX: intersection.maxX },
+    {
+      minX: intersection.minX,
+      maxX: intersection.maxX,
+      minZ: bounds.minZ,
+      maxZ: intersection.minZ,
+    },
+    {
+      minX: intersection.minX,
+      maxX: intersection.maxX,
+      minZ: intersection.maxZ,
+      maxZ: bounds.maxZ,
+    },
+  ].filter(
+    (candidate) =>
+      candidate.maxX - candidate.minX > MIN_DIMENSION &&
+      candidate.maxZ - candidate.minZ > MIN_DIMENSION
+  );
+}
+
+function getRoomTileBounds(
+  room: RoomDefinition,
+  inset: number,
+  cutouts: readonly RectangularFloorCutout[]
+): RectangularFloorCutout[] {
+  const baseBounds = {
+    minX: room.bounds.minX + inset,
+    maxX: room.bounds.maxX - inset,
+    minZ: room.bounds.minZ + inset,
+    maxZ: room.bounds.maxZ - inset,
+  };
+
+  if (
+    baseBounds.maxX - baseBounds.minX <= MIN_DIMENSION ||
+    baseBounds.maxZ - baseBounds.minZ <= MIN_DIMENSION
+  ) {
+    return [];
+  }
+
+  return cutouts.reduce<RectangularFloorCutout[]>(
+    (boundsList, cutout) =>
+      boundsList.flatMap((bounds) => splitBoundsAroundCutout(bounds, cutout)),
+    [baseBounds]
+  );
+}
 
 function applyLightMapOptions(
   material: MeshStandardMaterial,
@@ -102,30 +184,34 @@ export function createRoomFloorTiles(
       return;
     }
 
-    const width = room.bounds.maxX - room.bounds.minX - inset * 2;
-    const depth = room.bounds.maxZ - room.bounds.minZ - inset * 2;
-
-    if (width <= MIN_DIMENSION || depth <= MIN_DIMENSION) {
-      return;
-    }
-
-    const geometry = new BoxGeometry(width, thickness, depth);
-    applyLightmapUv2(geometry);
-
-    const mesh = new Mesh(
-      geometry,
-      resolveMaterial(room, options, defaultMaterial)
+    const roomTileBounds = getRoomTileBounds(
+      room,
+      inset,
+      options.cutouts ?? []
     );
-    mesh.position.set(
-      (room.bounds.minX + room.bounds.maxX) / 2,
-      elevation - thickness / 2,
-      (room.bounds.minZ + room.bounds.maxZ) / 2
-    );
-    mesh.name = `${room.name} Floor`;
-    mesh.receiveShadow = true;
+    const material = resolveMaterial(room, options, defaultMaterial);
 
-    group.add(mesh);
-    tiles.push({ roomId: room.id, mesh });
+    roomTileBounds.forEach((bounds, index) => {
+      const width = bounds.maxX - bounds.minX;
+      const depth = bounds.maxZ - bounds.minZ;
+      const geometry = new BoxGeometry(width, thickness, depth);
+      applyLightmapUv2(geometry);
+
+      const mesh = new Mesh(geometry, material);
+      mesh.position.set(
+        (bounds.minX + bounds.maxX) / 2,
+        elevation - thickness / 2,
+        (bounds.minZ + bounds.maxZ) / 2
+      );
+      mesh.name =
+        roomTileBounds.length > 1
+          ? `${room.name} Floor ${index + 1}`
+          : `${room.name} Floor`;
+      mesh.receiveShadow = true;
+
+      group.add(mesh);
+      tiles.push({ roomId: room.id, mesh });
+    });
   });
 
   return { group, tiles };

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -1,11 +1,13 @@
 import {
   Color,
   CylinderGeometry,
+  Group,
   MeshStandardMaterial,
   SphereGeometry,
 } from 'three';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { createFloorVisibilityController } from '../scene/floors/visibilityController';
 import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import { scalePoiValue } from '../scene/poi/constants';
 import {
@@ -240,6 +242,53 @@ describe('createPoiInstances', () => {
     expect(instance.labelBaseHeight ?? 0).toBeGreaterThan(
       instance.orbBaseHeight ?? 0
     );
+  });
+
+  it('hides ground-floor marker labels and checkmarks while the upper floor is active', () => {
+    const [instance] = createPoiInstances([
+      createDefinition({ title: 'Ground Floor POI' }),
+    ]);
+    const upperFloorGroup = new Group();
+    const ledGroup = new Group();
+
+    instance.group.visible = true;
+    if (!instance.label || !instance.labelMaterial || !instance.visitedBadge) {
+      throw new Error('Expected a pedestal POI with label and visited badge.');
+    }
+    instance.label.visible = true;
+    instance.labelMaterial.opacity = 0.8;
+    instance.visitedBadge.mesh.visible = true;
+    instance.visitedBadge.material.opacity = 0.88;
+
+    const controller = createFloorVisibilityController({
+      activeFloorId: 'ground',
+      upperFloorGroups: [upperFloorGroup],
+      groundPoiInstances: [instance],
+      groundLedGroups: [ledGroup],
+    });
+
+    expect(controller.isPoiVisible(instance)).toBe(true);
+    expect(instance.group.visible).toBe(true);
+    expect(ledGroup.visible).toBe(true);
+    expect(upperFloorGroup.visible).toBe(false);
+
+    controller.setActiveFloorId('upper');
+
+    expect(controller.isPoiVisible(instance)).toBe(false);
+    expect(instance.group.visible).toBe(false);
+    expect(instance.label.visible).toBe(false);
+    expect(instance.labelMaterial.opacity).toBe(0);
+    expect(instance.visitedBadge.mesh.visible).toBe(false);
+    expect(instance.visitedBadge.material.opacity).toBe(0);
+    expect(ledGroup.visible).toBe(false);
+    expect(upperFloorGroup.visible).toBe(true);
+
+    controller.setActiveFloorId('ground');
+
+    expect(controller.isPoiVisible(instance)).toBe(true);
+    expect(instance.group.visible).toBe(true);
+    expect(ledGroup.visible).toBe(true);
+    expect(upperFloorGroup.visible).toBe(false);
   });
 
   it('keeps default pedestal styling when no hologram config is provided', () => {

--- a/src/tests/roomFloorTiles.test.ts
+++ b/src/tests/roomFloorTiles.test.ts
@@ -120,4 +120,41 @@ describe('createRoomFloorTiles', () => {
     const { tiles } = createRoomFloorTiles([tightRoom], { inset: 0.2 });
     expect(tiles).toHaveLength(0);
   });
+
+  it('cuts stairwell openings out of upper-floor tile slabs', () => {
+    const opaqueMaterial = new MeshStandardMaterial({
+      transparent: false,
+      opacity: 1,
+      depthWrite: true,
+    });
+
+    const { group, tiles } = createRoomFloorTiles([livingRoom], {
+      material: opaqueMaterial,
+      elevation: 4.2,
+      thickness: 0.38,
+      groupName: 'UpperFloorTiles',
+      cutouts: [{ minX: -2, maxX: 2, minZ: -6, maxZ: -2 }],
+    });
+
+    expect(group.name).toBe('UpperFloorTiles');
+    expect(tiles).toHaveLength(4);
+    expect(tiles.every((tile) => tile.roomId === 'living')).toBe(true);
+
+    for (const tile of tiles) {
+      const geometry = tile.mesh.geometry as BoxGeometry;
+      const material = tile.mesh.material as MeshStandardMaterial;
+      const minX = tile.mesh.position.x - geometry.parameters.width / 2;
+      const maxX = tile.mesh.position.x + geometry.parameters.width / 2;
+      const minZ = tile.mesh.position.z - geometry.parameters.depth / 2;
+      const maxZ = tile.mesh.position.z + geometry.parameters.depth / 2;
+      const overlapsCutout = maxX > -2 && minX < 2 && maxZ > -6 && minZ < -2;
+
+      expect(overlapsCutout).toBe(false);
+      expect(geometry.parameters.height).toBeCloseTo(0.38);
+      expect(tile.mesh.position.y).toBeCloseTo(4.2 - 0.19);
+      expect(material.transparent).toBe(false);
+      expect(material.opacity).toBe(1);
+      expect(material.depthWrite).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
### Motivation
- The existing upstairs used a single thin `ShapeGeometry` plane that read like glass and permitted ground-floor POI labels/checkmarks and LED strips to poke through, breaking visual and UX expectations. 
- Provide a solid, opaque upper floor that preserves the stairwell opening and keeps floor-specific visuals (POIs/LEDs) constrained to their active floor.

### Description
- Replace the single upstairs `ShapeGeometry` with opaque room slabs produced by `createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, { ... })`, using a depth-writing `MeshStandardMaterial` and a stairwell `cutouts` rectangle so the landing and descent corridor remain open. 
- Extend `createRoomFloorTiles` to accept rectangular `cutouts` and split room tile bounds into multiple `BoxGeometry` slabs so openings (stairwells) are carved without z-fighting. 
- Add a central `createFloorVisibilityController` (`src/scene/floors/visibilityController.ts`) that toggles upper-floor groups, hides ground POI visuals (labels, visited checkmarks, halos, display highlights) and controls LED group visibility based on the active floor. 
- Wire the controller into scene setup and runtime: instantiate in `main.ts` with `poiInstances` and LED groups, call `setActiveFloorId(...)` to update visibility, and consult `applyPoiVisibility(...)` in the POI update loop so hidden POIs are skipped during visual updates. 

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both succeeded, while `npm run typecheck` failed due to unrelated, pre-existing repository TypeScript issues (examples: `src/scene/avatar/importer.ts` and various test typing mismatches). 
- Ran targeted unit tests with `npm run test:ci -- src/tests/poiMarkers.test.ts src/tests/poiWorldTooltip.test.ts src/tests/roomFloorTiles.test.ts`, which passed, and the full suite with `npm run test:ci`, which also passed (139 test files, 1,035 tests). 
- Built and verified artifacts with `npm run build`, `npm run docs:check` (passed with external link warnings), and `npm run smoke`, all of which succeeded. 
- Executed the Playwright check `npm run test:e2e -- playwright/small-screen-hud.spec.ts` (initial failure due to missing browser binaries), followed by `npx playwright install` and `npx playwright install-deps chromium`, after which the e2e run passed; a local review screenshot was captured at `/tmp/upper-floor-solid.png` (not committed). 

Files changed: `src/main.ts`, `src/scene/structures/floorTiles.ts`, new `src/scene/floors/visibilityController.ts`, and added/updated tests under `src/tests` to cover cutouts and floor-aware POI visibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ca5bc7e8832f86c3d2ae1fca739e)