### PR TITLE
🏗️ : – solidify upper floor visuals

### DIFF
--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -82,6 +82,12 @@ layer without guessing where functionality lives.
   [`getCameraRelativeMovementVector`](../../src/systems/movement/cameraRelativeMovement.ts).
   The same loop applies velocity, collision clamping, and yaw so HUD prompts can
   reflect active WASD axes without owning Three.js meshes.
+- **Floor visibility** – `src/main.ts` keeps floor-specific scene objects in
+  explicit ground/upper groups, while
+  [`src/scene/floors/floorVisibility.ts`](../../src/scene/floors/floorVisibility.ts)
+  centralizes active-floor toggles for upstairs slabs, ground POI marker cues,
+  and ground LED strips so second-floor views do not show lower-floor labels or
+  light bands through the navigable floor.
 - **POI orchestration** – The registry
   (`src/scene/poi/registry.ts`) hydrates data from
   [`src/assets/i18n/locales/en.ts`](../../src/assets/i18n/locales/en.ts) and now exposes

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,8 @@ import {
   Group,
   HemisphereLight,
   MathUtils,
-  Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  Shape,
-  ShapeGeometry,
   OrthographicCamera,
   PointLight,
   Scene,
@@ -113,6 +110,7 @@ import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
+import { createFloorVisibilityController } from './scene/floors/floorVisibility';
 import {
   createMotionBlurController,
   type MotionBlurController,
@@ -1381,6 +1379,10 @@ function initializeImmersiveScene(
   const scene = new Scene();
   scene.background = createImmersiveGradientTexture();
 
+  const groundArchitectureGroup = new Group();
+  groundArchitectureGroup.name = 'GroundFloorArchitecture';
+  scene.add(groundArchitectureGroup);
+
   const poiOverrides: PoiInstanceOverrides = {};
   let poiDefinitions = getPoiDefinitions(locale);
   let poiDefinitionsById = new Map(
@@ -1523,7 +1525,7 @@ function initializeImmersiveScene(
       seasonalPreset,
       detailPolicy: activeSceneDetailPolicy,
     });
-    scene.add(backyardEnvironment.group);
+    groundArchitectureGroup.add(backyardEnvironment.group);
     // Remove the enclosing sky dome to avoid a bright circular spheroid.
     // We want a dark void beyond the property in runtime.
     const skyDome =
@@ -1546,7 +1548,7 @@ function initializeImmersiveScene(
     elevation: 0,
     groupName: 'GroundFloorTiles',
   });
-  scene.add(floorTiles.group);
+  groundArchitectureGroup.add(floorTiles.group);
 
   const wallMaterial = new MeshStandardMaterial({ color: 0x3d4a63 });
   const fenceMaterial = new MeshStandardMaterial({ color: 0x4a5668 });
@@ -1585,7 +1587,7 @@ function initializeImmersiveScene(
       return instance.isFence ? fenceMaterial : wallMaterial;
     },
   });
-  scene.add(groundWallMeshes.group);
+  groundArchitectureGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
   });
@@ -1599,7 +1601,7 @@ function initializeImmersiveScene(
     trimDepth: WALL_THICKNESS * 0.92,
     material: doorwayTrimMaterial,
   });
-  scene.add(doorwayOpenings.group);
+  groundArchitectureGroup.add(doorwayOpenings.group);
 
   const ceilings = createRoomCeilingPanels(FLOOR_PLAN.rooms, {
     height: WALL_HEIGHT - 0.15,
@@ -1610,7 +1612,7 @@ function initializeImmersiveScene(
     lightMap: interiorLightmaps.ceiling,
     lightMapIntensity: 0.52,
   });
-  scene.add(ceilings.group);
+  groundArchitectureGroup.add(ceilings.group);
 
   const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom');
   if (livingRoom) {
@@ -1618,7 +1620,7 @@ function initializeImmersiveScene(
       livingRoom.bounds,
       activeSceneDetailPolicy
     );
-    scene.add(mediaWall.group);
+    groundArchitectureGroup.add(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
@@ -1667,7 +1669,7 @@ function initializeImmersiveScene(
       width: 3.4,
       height: 4.1,
     });
-    scene.add(mirror.group);
+    groundArchitectureGroup.add(mirror.group);
     groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }
@@ -1765,48 +1767,38 @@ function initializeImmersiveScene(
   scene.add(upperFloorGroup);
 
   const upperFloorMaterial = new MeshStandardMaterial({
-    color: 0x1f273a,
-    side: DoubleSide,
-    // Nudge the upper floor away from coplanar surfaces (e.g., landing top)
-    // to avoid depth fighting at shared boundaries.
-    polygonOffset: true,
-    polygonOffsetFactor: 1,
-    polygonOffsetUnits: 1,
+    color: 0x242d40,
+    roughness: 0.62,
+    metalness: 0.12,
   });
-  const upperFloorShape = new Shape();
-  const [upperFirstX, upperFirstZ] = UPPER_FLOOR_PLAN.outline[0];
-  upperFloorShape.moveTo(upperFirstX, upperFirstZ);
-  for (let i = 1; i < UPPER_FLOOR_PLAN.outline.length; i += 1) {
-    const [x, z] = UPPER_FLOOR_PLAN.outline[i];
-    upperFloorShape.lineTo(x, z);
-  }
-  upperFloorShape.closePath();
+  upperFloorMaterial.transparent = false;
+  upperFloorMaterial.opacity = 1;
+  upperFloorMaterial.depthWrite = true;
 
-  // Carve a stairwell hole in the upper floor directly above the stairs to
-  // eliminate z-fighting and allow the player to visually descend. Use a
-  // slightly oversized cutout so collision tolerances near edges feel natural.
+  // Carve a stairwell hole in the upper landing tile directly above the stairs
+  // so the floor reads as solid while keeping the descent corridor open.
   const stairHoleHalfWidth = stairHalfWidth + stairwellMarginX;
   const stairHoleMinX = stairCenterX - stairHoleHalfWidth;
   const stairHoleMaxX = stairCenterX + stairHoleHalfWidth;
   const stairHoleMinZ = stairLayout.stairHoleRange.minZ;
   const stairHoleMaxZ = stairLayout.stairHoleRange.maxZ;
-  upperFloorShape.holes.push(
-    (() => {
-      const hole = new Shape();
-      hole.moveTo(stairHoleMinX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMaxZ);
-      hole.lineTo(stairHoleMinX, stairHoleMaxZ);
-      hole.closePath();
-      return hole;
-    })()
-  );
-  const upperFloorGeometry = new ShapeGeometry(upperFloorShape);
-  upperFloorGeometry.rotateX(-Math.PI / 2);
-  const upperFloor = new Mesh(upperFloorGeometry, upperFloorMaterial);
-  // Slightly lower than the landing top to ensure no coplanar z-fighting.
-  upperFloor.position.y = upperFloorElevation - 0.002;
-  upperFloorGroup.add(upperFloor);
+  const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+    material: upperFloorMaterial,
+    elevation: upperFloorElevation,
+    thickness: STAIRCASE_CONFIG.landing.thickness,
+    groupName: 'UpperFloorTiles',
+    cutoutsByRoom: {
+      upperLanding: [
+        {
+          minX: stairHoleMinX,
+          maxX: stairHoleMaxX,
+          minZ: stairHoleMinZ,
+          maxZ: stairHoleMaxZ,
+        },
+      ],
+    },
+  });
+  upperFloorGroup.add(upperFloorTiles.group);
 
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
@@ -1946,18 +1938,31 @@ function initializeImmersiveScene(
   });
   lightmapAnimator.captureBaseline();
 
+  const groundPoiGroup = new Group();
+  groundPoiGroup.name = 'GroundPoiMarkers';
+  scene.add(groundPoiGroup);
+
   const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
     detailPolicy: activeSceneDetailPolicy,
   });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
-      scene.add(poi.group);
+      groundPoiGroup.add(poi.group);
     }
     if (poi.collider) {
       staticColliders.push(poi.collider);
     }
     poiInstances.push(poi);
   });
+
+  const floorVisibilityController = createFloorVisibilityController({
+    upperFloorGroup,
+    groundPoiGroup,
+    groundLedGroups: [ledStripGroup, ledFillLightGroup],
+    groundPoiInstances: poiInstances,
+  });
+
+  let activeFloorId: FloorId = 'ground';
 
   const poiAnalytics = createWindowPoiAnalytics();
   const interactionTimeline = new InteractionTimeline();
@@ -2136,6 +2141,9 @@ function initializeImmersiveScene(
     if (!poi) {
       return null;
     }
+    if ((poi.floorId ?? 'ground') !== activeFloorId) {
+      return null;
+    }
     const instance = poiInstances.find(
       (candidate) => candidate.definition.id === poi.id
     );
@@ -2167,6 +2175,7 @@ function initializeImmersiveScene(
         const worldState = poiWorldTooltip.getState();
         const visibleMarkerLabels = poiInstances.filter(
           (poi) =>
+            (poi.definition.floorId ?? 'ground') === activeFloorId &&
             poi.label?.visible &&
             poi.labelMaterial &&
             poi.labelMaterial.opacity > 0.05
@@ -3331,7 +3340,6 @@ function initializeImmersiveScene(
   const mouseCameraStart = new Vector2();
   let mouseCameraPointerId: number | null = null;
 
-  let activeFloorId: FloorId = 'ground';
   let helpKeyWasPressed = false;
   let helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
   const buildHelpButtonText = (shortcut: string) =>
@@ -3550,7 +3558,9 @@ function initializeImmersiveScene(
       return;
     }
     activeFloorId = next;
-    upperFloorGroup.visible = next === 'upper';
+    floorVisibilityController.setActiveFloor(next);
+    syncPoiRecommendation();
+    syncPoiDetailOverlay();
     document.documentElement.dataset.activeFloor = next;
   };
 
@@ -3567,6 +3577,7 @@ function initializeImmersiveScene(
   };
 
   updatePlayerVerticalPosition();
+  floorVisibilityController.setActiveFloor(activeFloorId);
   document.documentElement.dataset.activeFloor = activeFloorId;
 
   const setCameraZoomTarget = (next: number) => {
@@ -4644,6 +4655,10 @@ function initializeImmersiveScene(
     const worldTooltipVisible = worldTooltipState.visible;
 
     for (const poi of poiInstances) {
+      if (!floorVisibilityController.applyPoiVisibility(poi)) {
+        continue;
+      }
+
       const floatOffset = Math.sin(
         elapsedTime * poi.floatSpeed + poi.floatPhase
       );

--- a/src/scene/floors/floorVisibility.ts
+++ b/src/scene/floors/floorVisibility.ts
@@ -1,0 +1,106 @@
+import type { Group } from 'three';
+
+import type { FloorId } from '../../systems/movement/stairs';
+import type { PoiInstance } from '../poi/markers';
+import type { PoiDefinition } from '../poi/types';
+
+export interface FloorVisibilityControllerOptions {
+  readonly upperFloorGroup: Group;
+  readonly groundPoiGroup: Group;
+  readonly groundLedGroups?: readonly (Group | null | undefined)[];
+  readonly groundPoiInstances?: readonly PoiInstance[];
+}
+
+export interface FloorVisibilityController {
+  readonly activeFloorId: FloorId;
+  setActiveFloor(next: FloorId): void;
+  applyPoiVisibility(poi: PoiInstance): boolean;
+}
+
+export function getPoiFloorId(definition: PoiDefinition): FloorId {
+  return definition.floorId ?? 'ground';
+}
+
+export function isPoiVisibleOnFloor(
+  definition: PoiDefinition,
+  activeFloorId: FloorId
+): boolean {
+  return getPoiFloorId(definition) === activeFloorId;
+}
+
+export function hidePoiFloorVisuals(poi: PoiInstance): void {
+  poi.group.visible = false;
+  if (poi.label) {
+    poi.label.visible = false;
+  }
+  if (poi.labelMaterial) {
+    poi.labelMaterial.opacity = 0;
+  }
+  if (poi.visitedBadge) {
+    poi.visitedBadge.mesh.visible = false;
+  }
+  if (poi.visitedHighlight) {
+    poi.visitedHighlight.mesh.visible = false;
+    poi.visitedHighlight.material.opacity = 0;
+  }
+  if (poi.halo) {
+    poi.halo.visible = false;
+  }
+  if (poi.haloMaterial) {
+    poi.haloMaterial.opacity = 0;
+  }
+  if (poi.displayHighlight) {
+    poi.displayHighlight.mesh.visible = false;
+    poi.displayHighlight.material.opacity = 0;
+  }
+}
+
+export function createFloorVisibilityController(
+  options: FloorVisibilityControllerOptions
+): FloorVisibilityController {
+  let activeFloorId: FloorId = 'ground';
+
+  const setGroundPoiVisibility = (visible: boolean) => {
+    options.groundPoiGroup.visible = visible;
+    options.groundPoiInstances?.forEach((poi) => {
+      if (visible) {
+        poi.group.visible = true;
+      } else {
+        hidePoiFloorVisuals(poi);
+      }
+    });
+  };
+
+  const setGroundLedVisibility = (visible: boolean) => {
+    options.groundLedGroups?.forEach((group) => {
+      if (group) {
+        group.visible = visible;
+      }
+    });
+  };
+
+  const controller: FloorVisibilityController = {
+    get activeFloorId() {
+      return activeFloorId;
+    },
+    setActiveFloor(next: FloorId) {
+      activeFloorId = next;
+      const isUpper = next === 'upper';
+      options.upperFloorGroup.visible = isUpper;
+      setGroundPoiVisibility(!isUpper);
+      setGroundLedVisibility(!isUpper);
+    },
+    applyPoiVisibility(poi: PoiInstance) {
+      const visible = isPoiVisibleOnFloor(poi.definition, activeFloorId);
+      if (!visible) {
+        hidePoiFloorVisuals(poi);
+        return false;
+      }
+      poi.group.visible = true;
+      return true;
+    },
+  };
+
+  controller.setActiveFloor(activeFloorId);
+  return controller;
+}

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -110,6 +110,7 @@ export interface PoiDefinition {
   category: PoiCategory;
   interaction: PoiInteraction;
   roomId: string;
+  floorId?: 'ground' | 'upper';
   position: { x: number; y: number; z: number };
   headingRadians?: number;
   interactionRadius: number;

--- a/src/scene/structures/floorTiles.ts
+++ b/src/scene/structures/floorTiles.ts
@@ -1,6 +1,6 @@
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial, Texture } from 'three';
 
-import type { RoomDefinition } from '../../assets/floorPlan';
+import type { Bounds2D, RoomDefinition } from '../../assets/floorPlan';
 import { applyLightmapUv2 } from '../lighting/bakedLightmaps';
 
 export interface RoomFloorTile {
@@ -32,6 +32,8 @@ export interface RoomFloorOptions {
   readonly groupName?: string;
   /** When true, exterior rooms receive tiles too. */
   readonly includeExterior?: boolean;
+  /** Optional rectangular voids to cut from individual room tiles. */
+  readonly cutoutsByRoom?: Partial<Record<string, Bounds2D[]>>;
 }
 
 const DEFAULT_GROUP_NAME = 'RoomFloorTiles';
@@ -39,6 +41,78 @@ const DEFAULT_THICKNESS = 0.12;
 const DEFAULT_INSET = 0;
 const MIN_DIMENSION = 0.05;
 const DEFAULT_COLOR = 0x2a3547;
+
+interface TileBounds {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minZ: number;
+  readonly maxZ: number;
+}
+
+function intersectBounds(a: TileBounds, b: Bounds2D): TileBounds | null {
+  const minX = Math.max(a.minX, b.minX);
+  const maxX = Math.min(a.maxX, b.maxX);
+  const minZ = Math.max(a.minZ, b.minZ);
+  const maxZ = Math.min(a.maxZ, b.maxZ);
+
+  if (maxX - minX <= MIN_DIMENSION || maxZ - minZ <= MIN_DIMENSION) {
+    return null;
+  }
+
+  return { minX, maxX, minZ, maxZ };
+}
+
+function subtractCutout(tile: TileBounds, cutout: Bounds2D): TileBounds[] {
+  const intersection = intersectBounds(tile, cutout);
+  if (!intersection) {
+    return [tile];
+  }
+
+  return [
+    // West side.
+    {
+      minX: tile.minX,
+      maxX: intersection.minX,
+      minZ: tile.minZ,
+      maxZ: tile.maxZ,
+    },
+    // East side.
+    {
+      minX: intersection.maxX,
+      maxX: tile.maxX,
+      minZ: tile.minZ,
+      maxZ: tile.maxZ,
+    },
+    // South side, between the west/east side strips.
+    {
+      minX: intersection.minX,
+      maxX: intersection.maxX,
+      minZ: tile.minZ,
+      maxZ: intersection.minZ,
+    },
+    // North side, between the west/east side strips.
+    {
+      minX: intersection.minX,
+      maxX: intersection.maxX,
+      minZ: intersection.maxZ,
+      maxZ: tile.maxZ,
+    },
+  ].filter(
+    (candidate) =>
+      candidate.maxX - candidate.minX > MIN_DIMENSION &&
+      candidate.maxZ - candidate.minZ > MIN_DIMENSION
+  );
+}
+
+function applyRoomCutouts(
+  roomTile: TileBounds,
+  cutouts: readonly Bounds2D[]
+): TileBounds[] {
+  return cutouts.reduce<TileBounds[]>(
+    (tiles, cutout) => tiles.flatMap((tile) => subtractCutout(tile, cutout)),
+    [roomTile]
+  );
+}
 
 function applyLightMapOptions(
   material: MeshStandardMaterial,
@@ -102,30 +176,46 @@ export function createRoomFloorTiles(
       return;
     }
 
-    const width = room.bounds.maxX - room.bounds.minX - inset * 2;
-    const depth = room.bounds.maxZ - room.bounds.minZ - inset * 2;
-
-    if (width <= MIN_DIMENSION || depth <= MIN_DIMENSION) {
-      return;
-    }
-
-    const geometry = new BoxGeometry(width, thickness, depth);
-    applyLightmapUv2(geometry);
-
-    const mesh = new Mesh(
-      geometry,
-      resolveMaterial(room, options, defaultMaterial)
+    const roomTile = {
+      minX: room.bounds.minX + inset,
+      maxX: room.bounds.maxX - inset,
+      minZ: room.bounds.minZ + inset,
+      maxZ: room.bounds.maxZ - inset,
+    };
+    const roomTiles = applyRoomCutouts(
+      roomTile,
+      options.cutoutsByRoom?.[room.id] ?? []
     );
-    mesh.position.set(
-      (room.bounds.minX + room.bounds.maxX) / 2,
-      elevation - thickness / 2,
-      (room.bounds.minZ + room.bounds.maxZ) / 2
-    );
-    mesh.name = `${room.name} Floor`;
-    mesh.receiveShadow = true;
 
-    group.add(mesh);
-    tiles.push({ roomId: room.id, mesh });
+    roomTiles.forEach((tile, tileIndex) => {
+      const width = tile.maxX - tile.minX;
+      const depth = tile.maxZ - tile.minZ;
+
+      if (width <= MIN_DIMENSION || depth <= MIN_DIMENSION) {
+        return;
+      }
+
+      const geometry = new BoxGeometry(width, thickness, depth);
+      applyLightmapUv2(geometry);
+
+      const mesh = new Mesh(
+        geometry,
+        resolveMaterial(room, options, defaultMaterial)
+      );
+      mesh.position.set(
+        (tile.minX + tile.maxX) / 2,
+        elevation - thickness / 2,
+        (tile.minZ + tile.maxZ) / 2
+      );
+      mesh.name =
+        roomTiles.length > 1
+          ? `${room.name} Floor ${tileIndex + 1}`
+          : `${room.name} Floor`;
+      mesh.receiveShadow = true;
+
+      group.add(mesh);
+      tiles.push({ roomId: room.id, mesh });
+    });
   });
 
   return { group, tiles };

--- a/src/tests/floorVisibility.test.ts
+++ b/src/tests/floorVisibility.test.ts
@@ -1,0 +1,139 @@
+import { BoxGeometry, Group, Mesh, MeshBasicMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createFloorVisibilityController,
+  isPoiVisibleOnFloor,
+} from '../scene/floors/floorVisibility';
+import type { PoiInstance } from '../scene/poi/markers';
+import type { PoiDefinition } from '../scene/poi/types';
+
+const createDefinition = (
+  overrides: Partial<PoiDefinition> = {}
+): PoiDefinition => ({
+  id: 'gitshelves-living-room-installation',
+  title: 'Gitshelves Installation',
+  summary: 'Automation-ready showcase artifact.',
+  interactionPrompt: 'Inspect Gitshelves Installation',
+  category: 'project',
+  interaction: 'inspect',
+  roomId: 'livingRoom',
+  position: { x: 0, y: 0, z: 0 },
+  interactionRadius: 2.4,
+  footprint: { width: 2.8, depth: 2.2 },
+  ...overrides,
+});
+
+const createPoiInstance = (
+  definition: PoiDefinition = createDefinition()
+): PoiInstance => {
+  const group = new Group();
+  const labelMaterial = new MeshBasicMaterial({
+    transparent: true,
+    opacity: 1,
+  });
+  const label = new Mesh(new BoxGeometry(1, 1, 1), labelMaterial);
+  const visitedMaterial = new MeshBasicMaterial({
+    transparent: true,
+    opacity: 1,
+  });
+  const visitedMesh = new Mesh(new BoxGeometry(1, 1, 1), visitedMaterial);
+  const badgeMesh = new Mesh(new BoxGeometry(1, 1, 1), new MeshBasicMaterial());
+  label.visible = true;
+  visitedMesh.visible = true;
+  badgeMesh.visible = true;
+  group.add(label, visitedMesh, badgeMesh);
+
+  return {
+    definition,
+    group,
+    label,
+    labelMaterial,
+    labelWorldPosition: label.position.clone(),
+    floatPhase: 0,
+    floatSpeed: 0,
+    floatAmplitude: 0,
+    activation: 0,
+    pulseOffset: 0,
+    hitArea: new Mesh(new BoxGeometry(1, 1, 1), new MeshBasicMaterial()),
+    focus: 0,
+    focusTarget: 0,
+    visualMode: 'pedestal',
+    visited: true,
+    visitedStrength: 1,
+    visitedHighlight: { mesh: visitedMesh, material: visitedMaterial },
+    visitedBadge: {
+      mesh: badgeMesh,
+      material: badgeMesh.material as MeshBasicMaterial,
+      baseHeight: 1,
+      rotationSpeed: 0,
+    },
+  };
+};
+
+describe('floor visibility controller', () => {
+  it('toggles upper floor, ground POI, and ground LED group visibility', () => {
+    const upperFloorGroup = new Group();
+    const groundPoiGroup = new Group();
+    const ledStripGroup = new Group();
+    const ledFillLightGroup = new Group();
+    const groundPoi = createPoiInstance();
+    groundPoiGroup.add(groundPoi.group);
+
+    const controller = createFloorVisibilityController({
+      upperFloorGroup,
+      groundPoiGroup,
+      groundLedGroups: [ledStripGroup, ledFillLightGroup],
+      groundPoiInstances: [groundPoi],
+    });
+
+    expect(controller.activeFloorId).toBe('ground');
+    expect(upperFloorGroup.visible).toBe(false);
+    expect(groundPoiGroup.visible).toBe(true);
+    expect(ledStripGroup.visible).toBe(true);
+    expect(ledFillLightGroup.visible).toBe(true);
+
+    controller.setActiveFloor('upper');
+
+    expect(controller.activeFloorId).toBe('upper');
+    expect(upperFloorGroup.visible).toBe(true);
+    expect(groundPoiGroup.visible).toBe(false);
+    expect(ledStripGroup.visible).toBe(false);
+    expect(ledFillLightGroup.visible).toBe(false);
+  });
+
+  it('hides ground marker labels and checkmarks while upstairs', () => {
+    const groundPoi = createPoiInstance();
+    const controller = createFloorVisibilityController({
+      upperFloorGroup: new Group(),
+      groundPoiGroup: new Group(),
+      groundPoiInstances: [groundPoi],
+    });
+
+    controller.setActiveFloor('upper');
+
+    expect(controller.applyPoiVisibility(groundPoi)).toBe(false);
+    expect(groundPoi.group.visible).toBe(false);
+    expect(groundPoi.label?.visible).toBe(false);
+    expect(groundPoi.labelMaterial?.opacity).toBe(0);
+    expect(groundPoi.visitedBadge?.mesh.visible).toBe(false);
+    expect(groundPoi.visitedHighlight?.mesh.visible).toBe(false);
+    expect(groundPoi.visitedHighlight?.material.opacity).toBe(0);
+  });
+
+  it('preserves existing ground-floor POI marker behavior on the ground floor', () => {
+    const groundPoi = createPoiInstance();
+    const controller = createFloorVisibilityController({
+      upperFloorGroup: new Group(),
+      groundPoiGroup: new Group(),
+      groundPoiInstances: [groundPoi],
+    });
+
+    controller.setActiveFloor('ground');
+
+    expect(controller.applyPoiVisibility(groundPoi)).toBe(true);
+    expect(groundPoi.group.visible).toBe(true);
+    expect(isPoiVisibleOnFloor(groundPoi.definition, 'ground')).toBe(true);
+    expect(isPoiVisibleOnFloor(groundPoi.definition, 'upper')).toBe(false);
+  });
+});

--- a/src/tests/roomFloorTiles.test.ts
+++ b/src/tests/roomFloorTiles.test.ts
@@ -120,4 +120,44 @@ describe('createRoomFloorTiles', () => {
     const { tiles } = createRoomFloorTiles([tightRoom], { inset: 0.2 });
     expect(tiles).toHaveLength(0);
   });
+  it('cuts stairwell voids from upper-room tiles while keeping opaque slab materials', () => {
+    const sharedMaterial = new MeshStandardMaterial({ color: 0x242d40 });
+    sharedMaterial.transparent = false;
+    sharedMaterial.opacity = 1;
+    sharedMaterial.depthWrite = true;
+
+    const { group, tiles } = createRoomFloorTiles([livingRoom], {
+      material: sharedMaterial,
+      elevation: 4.2,
+      thickness: 0.36,
+      groupName: 'UpperFloorTiles',
+      cutoutsByRoom: {
+        living: [{ minX: -1, maxX: 1, minZ: -6, maxZ: -2 }],
+      },
+    });
+
+    expect(group.name).toBe('UpperFloorTiles');
+    expect(tiles).toHaveLength(4);
+    expect(tiles.every((tile) => tile.roomId === 'living')).toBe(true);
+    expect(tiles.every((tile) => tile.mesh.material === sharedMaterial)).toBe(
+      true
+    );
+
+    const material = tiles[0].mesh.material as MeshStandardMaterial;
+    expect(material.transparent).toBe(false);
+    expect(material.opacity).toBe(1);
+    expect(material.depthWrite).toBe(true);
+
+    for (const tile of tiles) {
+      const geometry = tile.mesh.geometry as BoxGeometry;
+      expect(geometry.parameters.height).toBeCloseTo(0.36);
+      expect(tile.mesh.position.y).toBeCloseTo(4.2 - 0.18);
+      const minX = tile.mesh.position.x - geometry.parameters.width / 2;
+      const maxX = tile.mesh.position.x + geometry.parameters.width / 2;
+      const minZ = tile.mesh.position.z - geometry.parameters.depth / 2;
+      const maxZ = tile.mesh.position.z + geometry.parameters.depth / 2;
+      const overlapsHole = maxX > -1 && minX < 1 && maxZ > -6 && minZ < -2;
+      expect(overlapsHole).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
### Motivation
- The upstairs currently used a single thin `ShapeGeometry` plane which read like glass and allowed ground-floor POI labels, visited checkmarks, and LED strips to poke through.  
- The goal is to make the upper floor read as a solid navigable slab while preserving the stairwell opening and avoiding z-fighting.  
- Floor-specific visuals (POI labels/checkmarks/LEDs) must be centralized and toggled when the active floor changes so the upstairs view does not show ground-floor cues.

### Description
- Replace the single upper-floor `ShapeGeometry` plane with opaque room floor slabs built via `createRoomFloorTiles(...)` and a new per-room cutout mechanism so the stairwell hole is preserved (`src/scene/structures/floorTiles.ts`, `src/main.ts`).  
- Add a `FloorVisibilityController` to centralize floor toggles and hide ground-only POI visuals and ground LED groups when upstairs (`src/scene/floors/floorVisibility.ts`), and group ground architecture/POIs in explicit scene groups.  
- Make POI/world-tooltip logic and the POI update loop floor-aware so marker counts/labels and visited highlights no longer appear through the upper floor, and add optional `floorId` to POI definitions (defaults to `ground`) (`src/scene/poi/types.ts`, `src/main.ts`).  
- Add tests covering upper-floor cutouts and opaque slab material behavior and floor-aware visibility, and update docs to document the new floor-visibility contract (`src/tests/roomFloorTiles.test.ts`, `src/tests/floorVisibility.test.ts`, `docs/architecture/scene-stack.md`).

### Testing
- Ran formatting with `npm run format:write` which completed successfully.  
- Ran linting with `npm run lint` which completed successfully (only style warnings were addressed during the rollout).  
- Ran type checking with `npm run typecheck` which reported unrelated, pre-existing TypeScript errors outside this change set (typecheck did not pass due to repo-wide typing issues).  
- Ran focused unit tests with `npm run test:ci -- src/tests/floorVisibility.test.ts src/tests/roomFloorTiles.test.ts src/tests/poiMarkers.test.ts src/tests/poiWorldTooltip.test.ts` and observed all focused tests pass.  
- Ran full test suite with `npm run test:ci` and observed the test run complete successfully (`1037 tests` in the environment used).  
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`, which completed successfully.  
- Executed Playwright e2e runs after installing browsers and host deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and ran `npm run test:e2e -- playwright/small-screen-hud.spec.ts`, which passed in the CI environment after the browser install.  

Residual notes and follow-ups: the change keeps the stair geometry and descent corridor intact, preserves selected POI overlays, and centralizes future floor-aware behavior; `tsc --noEmit` still reports unrelated errors elsewhere in the repo that should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ca5bc7e8832f86c3d2ae1fca739e)