### PR TITLE
Make upstairs floor visually solid

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,8 @@ import {
   Group,
   HemisphereLight,
   MathUtils,
-  Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  Shape,
-  ShapeGeometry,
   OrthographicCamera,
   PointLight,
   Scene,
@@ -113,6 +110,11 @@ import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
+import {
+  createFloorVisibilityController,
+  createNamedFloorGroup,
+  type SceneFloorId,
+} from './scene/floors/visibility';
 import {
   createMotionBlurController,
   type MotionBlurController,
@@ -1536,6 +1538,15 @@ function initializeImmersiveScene(
     );
   }
 
+  const groundArchitectureGroup = createNamedFloorGroup(
+    'GroundFloorArchitecture'
+  );
+  scene.add(groundArchitectureGroup);
+  const groundPoiGroup = createNamedFloorGroup('GroundFloorPoiVisuals');
+  scene.add(groundPoiGroup);
+  const groundLedGroup = createNamedFloorGroup('GroundFloorLedVisuals');
+  scene.add(groundLedGroup);
+
   const floorMaterial = new MeshStandardMaterial({
     color: 0x2a3547,
     roughness: 0.58,
@@ -1546,7 +1557,7 @@ function initializeImmersiveScene(
     elevation: 0,
     groupName: 'GroundFloorTiles',
   });
-  scene.add(floorTiles.group);
+  groundArchitectureGroup.add(floorTiles.group);
 
   const wallMaterial = new MeshStandardMaterial({ color: 0x3d4a63 });
   const fenceMaterial = new MeshStandardMaterial({ color: 0x4a5668 });
@@ -1585,7 +1596,7 @@ function initializeImmersiveScene(
       return instance.isFence ? fenceMaterial : wallMaterial;
     },
   });
-  scene.add(groundWallMeshes.group);
+  groundArchitectureGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
   });
@@ -1599,7 +1610,7 @@ function initializeImmersiveScene(
     trimDepth: WALL_THICKNESS * 0.92,
     material: doorwayTrimMaterial,
   });
-  scene.add(doorwayOpenings.group);
+  groundArchitectureGroup.add(doorwayOpenings.group);
 
   const ceilings = createRoomCeilingPanels(FLOOR_PLAN.rooms, {
     height: WALL_HEIGHT - 0.15,
@@ -1610,7 +1621,7 @@ function initializeImmersiveScene(
     lightMap: interiorLightmaps.ceiling,
     lightMapIntensity: 0.52,
   });
-  scene.add(ceilings.group);
+  groundArchitectureGroup.add(ceilings.group);
 
   const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom');
   if (livingRoom) {
@@ -1618,7 +1629,7 @@ function initializeImmersiveScene(
       livingRoom.bounds,
       activeSceneDetailPolicy
     );
-    scene.add(mediaWall.group);
+    groundArchitectureGroup.add(mediaWall.group);
     mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
@@ -1667,7 +1678,7 @@ function initializeImmersiveScene(
       width: 3.4,
       height: 4.1,
     });
-    scene.add(mirror.group);
+    groundArchitectureGroup.add(mirror.group);
     groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }
@@ -1765,48 +1776,38 @@ function initializeImmersiveScene(
   scene.add(upperFloorGroup);
 
   const upperFloorMaterial = new MeshStandardMaterial({
-    color: 0x1f273a,
-    side: DoubleSide,
-    // Nudge the upper floor away from coplanar surfaces (e.g., landing top)
-    // to avoid depth fighting at shared boundaries.
-    polygonOffset: true,
-    polygonOffsetFactor: 1,
-    polygonOffsetUnits: 1,
+    color: 0x242e42,
+    roughness: 0.64,
+    metalness: 0.08,
+    transparent: false,
+    opacity: 1,
+    depthWrite: true,
+    depthTest: true,
   });
-  const upperFloorShape = new Shape();
-  const [upperFirstX, upperFirstZ] = UPPER_FLOOR_PLAN.outline[0];
-  upperFloorShape.moveTo(upperFirstX, upperFirstZ);
-  for (let i = 1; i < UPPER_FLOOR_PLAN.outline.length; i += 1) {
-    const [x, z] = UPPER_FLOOR_PLAN.outline[i];
-    upperFloorShape.lineTo(x, z);
-  }
-  upperFloorShape.closePath();
 
-  // Carve a stairwell hole in the upper floor directly above the stairs to
-  // eliminate z-fighting and allow the player to visually descend. Use a
-  // slightly oversized cutout so collision tolerances near edges feel natural.
+  // Build the upstairs deck as opaque slabs instead of a single paper-thin
+  // ShapeGeometry plane. The stairwell cutout is applied to overlapping room
+  // tiles so the landing remains usable without sealing the descent opening.
   const stairHoleHalfWidth = stairHalfWidth + stairwellMarginX;
   const stairHoleMinX = stairCenterX - stairHoleHalfWidth;
   const stairHoleMaxX = stairCenterX + stairHoleHalfWidth;
   const stairHoleMinZ = stairLayout.stairHoleRange.minZ;
   const stairHoleMaxZ = stairLayout.stairHoleRange.maxZ;
-  upperFloorShape.holes.push(
-    (() => {
-      const hole = new Shape();
-      hole.moveTo(stairHoleMinX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMinZ);
-      hole.lineTo(stairHoleMaxX, stairHoleMaxZ);
-      hole.lineTo(stairHoleMinX, stairHoleMaxZ);
-      hole.closePath();
-      return hole;
-    })()
-  );
-  const upperFloorGeometry = new ShapeGeometry(upperFloorShape);
-  upperFloorGeometry.rotateX(-Math.PI / 2);
-  const upperFloor = new Mesh(upperFloorGeometry, upperFloorMaterial);
-  // Slightly lower than the landing top to ensure no coplanar z-fighting.
-  upperFloor.position.y = upperFloorElevation - 0.002;
-  upperFloorGroup.add(upperFloor);
+  const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+    material: upperFloorMaterial,
+    elevation: upperFloorElevation,
+    thickness: STAIRCASE_CONFIG.landing.thickness,
+    groupName: 'UpperFloorTiles',
+    cutouts: [
+      {
+        minX: stairHoleMinX,
+        maxX: stairHoleMaxX,
+        minZ: stairHoleMinZ,
+        maxZ: stairHoleMaxZ,
+      },
+    ],
+  });
+  upperFloorGroup.add(upperFloorTiles.group);
 
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
@@ -1925,8 +1926,8 @@ function initializeImmersiveScene(
     });
     ledAnimator.captureBaseline();
 
-    scene.add(ledBuild.group);
-    scene.add(ledBuild.fillLightGroup);
+    groundLedGroup.add(ledBuild.group);
+    groundLedGroup.add(ledBuild.fillLightGroup);
   } else {
     applySeasonalLightingPreset({
       preset: seasonalPreset,
@@ -1951,7 +1952,7 @@ function initializeImmersiveScene(
   });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
-      scene.add(poi.group);
+      groundPoiGroup.add(poi.group);
     }
     if (poi.collider) {
       staticColliders.push(poi.collider);
@@ -1959,10 +1960,30 @@ function initializeImmersiveScene(
     poiInstances.push(poi);
   });
 
+  const upperRoomIds = new Set(UPPER_FLOOR_PLAN.rooms.map((room) => room.id));
+  const getPoiFloorId = (poi: PoiDefinition): SceneFloorId =>
+    upperRoomIds.has(poi.roomId) ? 'upper' : 'ground';
+  const getPoiInstanceFloorId = (poi: PoiInstance): SceneFloorId =>
+    getPoiFloorId(poi.definition);
+  const floorVisibilityController = createFloorVisibilityController({
+    groups: {
+      groundArchitecture: groundArchitectureGroup,
+      groundPoi: groundPoiGroup,
+      groundLed: ledStripGroup ? groundLedGroup : undefined,
+      groundLedFillLights: ledFillLightGroup ?? undefined,
+      upperArchitecture: upperFloorGroup,
+    },
+    poi: {
+      instances: poiInstances,
+      floorForPoi: getPoiInstanceFloorId,
+    },
+  });
+
   const poiAnalytics = createWindowPoiAnalytics();
   const interactionTimeline = new InteractionTimeline();
   let currentHoveredPoi: PoiDefinition | null = null;
   let currentSelectedPoi: PoiDefinition | null = null;
+  let activeFloorId: FloorId = 'ground';
   let currentGuidedTourRecommendation: PoiDefinition | null = null;
   let dismissedPassiveRecommendationPoiId: string | null = null;
   let poiInteractionManager: PoiInteractionManager | null = null;
@@ -1989,13 +2010,21 @@ function initializeImmersiveScene(
     camera,
     guidedTourPreference,
   });
+  const isPoiVisibleOnActiveFloor = (poi: PoiDefinition | null): boolean =>
+    poi !== null && getPoiFloorId(poi) === activeFloorId;
+  const resolveFloorAwareWorldTooltipTarget = (
+    poi: PoiDefinition | null
+  ): PoiWorldTooltipTarget | null =>
+    isPoiVisibleOnActiveFloor(poi) ? resolveWorldTooltipTarget(poi) : null;
   const canShowPoiDetailOverlay = (layoutOverride?: HudLayout): boolean =>
     (hudPanelCoordinator?.getActivePanel() ?? null) === null &&
     (!isMobilePoiLayout(layoutOverride) || currentSelectedPoi !== null);
   const getVisiblePoiRecommendation = (): PoiDefinition | null => {
     if (
       currentGuidedTourRecommendation &&
-      currentGuidedTourRecommendation.id !== dismissedPassiveRecommendationPoiId
+      currentGuidedTourRecommendation.id !==
+        dismissedPassiveRecommendationPoiId &&
+      isPoiVisibleOnActiveFloor(currentGuidedTourRecommendation)
     ) {
       return currentGuidedTourRecommendation;
     }
@@ -2005,7 +2034,7 @@ function initializeImmersiveScene(
     const visibleRecommendation = getVisiblePoiRecommendation();
     poiTooltipOverlay.setRecommendation(visibleRecommendation);
     poiWorldTooltip.setRecommendation(
-      resolveWorldTooltipTarget(visibleRecommendation)
+      resolveFloorAwareWorldTooltipTarget(visibleRecommendation)
     );
   };
   const suppressActivePoiRecommendation = (poi: PoiDefinition | null) => {
@@ -2028,8 +2057,10 @@ function initializeImmersiveScene(
     const showSelected = canShowDetail ? currentSelectedPoi : null;
     poiTooltipOverlay.setHovered(showHover);
     poiTooltipOverlay.setSelected(showSelected);
-    poiWorldTooltip.setHovered(resolveWorldTooltipTarget(showHover));
-    poiWorldTooltip.setSelected(resolveWorldTooltipTarget(showSelected));
+    poiWorldTooltip.setHovered(resolveFloorAwareWorldTooltipTarget(showHover));
+    poiWorldTooltip.setSelected(
+      resolveFloorAwareWorldTooltipTarget(showSelected)
+    );
   };
   const clearPoiDetailState = (
     inputMethod: 'keyboard' | 'pointer' | 'touch' = 'pointer'
@@ -3331,7 +3362,6 @@ function initializeImmersiveScene(
   const mouseCameraStart = new Vector2();
   let mouseCameraPointerId: number | null = null;
 
-  let activeFloorId: FloorId = 'ground';
   let helpKeyWasPressed = false;
   let helpLabelFallback = controlOverlayStrings.helpButton.shortcutFallback;
   const buildHelpButtonText = (shortcut: string) =>
@@ -3550,7 +3580,9 @@ function initializeImmersiveScene(
       return;
     }
     activeFloorId = next;
-    upperFloorGroup.visible = next === 'upper';
+    floorVisibilityController.setActiveFloor(next);
+    syncPoiRecommendation();
+    syncPoiDetailOverlay();
     document.documentElement.dataset.activeFloor = next;
   };
 
@@ -3567,6 +3599,7 @@ function initializeImmersiveScene(
   };
 
   updatePlayerVerticalPosition();
+  floorVisibilityController.setActiveFloor(activeFloorId);
   document.documentElement.dataset.activeFloor = activeFloorId;
 
   const setCameraZoomTarget = (next: number) => {
@@ -4644,6 +4677,8 @@ function initializeImmersiveScene(
     const worldTooltipVisible = worldTooltipState.visible;
 
     for (const poi of poiInstances) {
+      const poiVisibleOnActiveFloor =
+        getPoiInstanceFloorId(poi) === activeFloorId;
       const floatOffset = Math.sin(
         elapsedTime * poi.floatSpeed + poi.floatPhase
       );
@@ -4670,12 +4705,10 @@ function initializeImmersiveScene(
       );
       const planarDistance = poiPlayerOffset.length();
       const maxRadius = poi.definition.interactionRadius;
-      const targetActivation = MathUtils.clamp(
-        1 - planarDistance / maxRadius,
-        0,
-        1
-      );
-      const visitedTarget = poi.visited ? 1 : 0;
+      const targetActivation = poiVisibleOnActiveFloor
+        ? MathUtils.clamp(1 - planarDistance / maxRadius, 0, 1)
+        : 0;
+      const visitedTarget = poiVisibleOnActiveFloor && poi.visited ? 1 : 0;
       poi.activation = MathUtils.lerp(
         poi.activation,
         targetActivation,
@@ -4700,9 +4733,10 @@ function initializeImmersiveScene(
       }
 
       if (poi.label && poi.labelMaterial) {
-        const labelOpacity = worldTooltipVisible
-          ? 0
-          : computePoiLabelOpacity(emphasis, visitedEmphasis);
+        const labelOpacity =
+          poiVisibleOnActiveFloor && !worldTooltipVisible
+            ? computePoiLabelOpacity(emphasis, visitedEmphasis)
+            : 0;
         poi.labelMaterial.opacity = labelOpacity;
         poi.label.visible = labelOpacity > 0.05;
       }
@@ -4718,7 +4752,9 @@ function initializeImmersiveScene(
         } = poi.displayHighlight;
         const visitedOpacityBoost = MathUtils.lerp(0, 0.25, visitedEmphasis);
         const nextOpacity = MathUtils.lerp(baseOpacity, focusOpacity, emphasis);
-        const combinedOpacity = Math.min(nextOpacity + visitedOpacityBoost, 1);
+        const combinedOpacity = poiVisibleOnActiveFloor
+          ? Math.min(nextOpacity + visitedOpacityBoost, 1)
+          : 0;
         material.opacity = combinedOpacity;
         mesh.visible = combinedOpacity > 0.02;
         if (baseScale !== undefined && focusScale !== undefined && mesh.scale) {
@@ -4783,7 +4819,9 @@ function initializeImmersiveScene(
           const haloScale =
             MathUtils.lerp(baseHaloScale, 1.18, emphasis) * haloPulse;
           poi.halo.scale.setScalar(haloScale);
-          const haloOpacity = computePoiHaloOpacity(emphasis, visitedEmphasis);
+          const haloOpacity = poiVisibleOnActiveFloor
+            ? computePoiHaloOpacity(emphasis, visitedEmphasis)
+            : 0;
           poi.haloMaterial.opacity = haloOpacity;
           poi.halo.visible = haloOpacity > 0.04;
           poi.haloMaterial.color.lerpColors(

--- a/src/scene/floors/visibility.ts
+++ b/src/scene/floors/visibility.ts
@@ -1,0 +1,127 @@
+import { Group, type Object3D } from 'three';
+
+import type { PoiInstance } from '../poi/markers';
+
+export type SceneFloorId = 'ground' | 'upper';
+
+export interface FloorVisibilityGroups {
+  /** Ground-level architecture that remains visible unless callers choose otherwise. */
+  readonly groundArchitecture?: Object3D;
+  /** Ground-only POI markers, labels, badges, and hit/display affordances. */
+  readonly groundPoi?: Object3D;
+  /** Ground-only LED strip meshes. */
+  readonly groundLed?: Object3D;
+  /** Ground-only LED fill lights. */
+  readonly groundLedFillLights?: Object3D;
+  /** Upper-floor-only slab, walls, and landing visuals. */
+  readonly upperArchitecture?: Object3D;
+}
+
+export interface FloorVisibilityPoiOptions {
+  readonly instances: readonly PoiInstance[];
+  readonly floorForPoi: (instance: PoiInstance) => SceneFloorId;
+}
+
+export interface FloorVisibilityControllerOptions {
+  readonly groups?: FloorVisibilityGroups;
+  readonly poi?: FloorVisibilityPoiOptions;
+}
+
+export interface FloorVisibilityController {
+  readonly activeFloor: SceneFloorId;
+  setActiveFloor(next: SceneFloorId): void;
+  apply(): void;
+}
+
+const setGroupVisible = (group: Object3D | undefined, visible: boolean) => {
+  if (group) {
+    group.visible = visible;
+  }
+};
+
+export const isPoiOnFloor = (
+  instance: PoiInstance,
+  floorForPoi: (instance: PoiInstance) => SceneFloorId,
+  floorId: SceneFloorId
+): boolean => floorForPoi(instance) === floorId;
+
+export const applyPoiFloorVisibility = (
+  instances: readonly PoiInstance[],
+  floorForPoi: (instance: PoiInstance) => SceneFloorId,
+  activeFloor: SceneFloorId
+): void => {
+  instances.forEach((instance) => {
+    const visible = isPoiOnFloor(instance, floorForPoi, activeFloor);
+    instance.group.visible = visible;
+
+    if (instance.label && instance.labelMaterial) {
+      instance.labelMaterial.opacity = visible
+        ? instance.labelMaterial.opacity
+        : 0;
+      instance.label.visible = visible && instance.labelMaterial.opacity > 0.05;
+    }
+
+    if (instance.visitedHighlight) {
+      instance.visitedHighlight.material.opacity = visible
+        ? instance.visitedHighlight.material.opacity
+        : 0;
+      instance.visitedHighlight.mesh.visible =
+        visible && instance.visitedHighlight.material.opacity > 0.02;
+    }
+
+    if (instance.visitedBadge) {
+      instance.visitedBadge.mesh.visible = visible && instance.visited;
+    }
+  });
+};
+
+export const applyFloorVisibility = (
+  activeFloor: SceneFloorId,
+  options: FloorVisibilityControllerOptions
+): void => {
+  const groups = options.groups ?? {};
+  const showingGround = activeFloor === 'ground';
+
+  setGroupVisible(groups.groundArchitecture, true);
+  setGroupVisible(groups.groundPoi, showingGround);
+  setGroupVisible(groups.groundLed, showingGround);
+  setGroupVisible(groups.groundLedFillLights, showingGround);
+  setGroupVisible(groups.upperArchitecture, activeFloor === 'upper');
+
+  if (options.poi) {
+    applyPoiFloorVisibility(
+      options.poi.instances,
+      options.poi.floorForPoi,
+      activeFloor
+    );
+  }
+};
+
+export const createFloorVisibilityController = (
+  options: FloorVisibilityControllerOptions,
+  initialFloor: SceneFloorId = 'ground'
+): FloorVisibilityController => {
+  let activeFloor = initialFloor;
+
+  const controller: FloorVisibilityController = {
+    get activeFloor() {
+      return activeFloor;
+    },
+    setActiveFloor(next) {
+      activeFloor = next;
+      applyFloorVisibility(activeFloor, options);
+    },
+    apply() {
+      applyFloorVisibility(activeFloor, options);
+    },
+  };
+
+  controller.apply();
+  return controller;
+};
+
+export const createNamedFloorGroup = (name: string): Group => {
+  const group = new Group();
+  group.name = name;
+  return group;
+};

--- a/src/scene/structures/floorTiles.ts
+++ b/src/scene/structures/floorTiles.ts
@@ -1,6 +1,6 @@
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial, Texture } from 'three';
 
-import type { RoomDefinition } from '../../assets/floorPlan';
+import type { Bounds2D, RoomDefinition } from '../../assets/floorPlan';
 import { applyLightmapUv2 } from '../lighting/bakedLightmaps';
 
 export interface RoomFloorTile {
@@ -24,6 +24,8 @@ export interface RoomFloorOptions {
   readonly material?: MeshStandardMaterial;
   /** Optional factory for bespoke materials per room. */
   readonly materialFactory?: (room: RoomDefinition) => MeshStandardMaterial;
+  /** Optional rectangular floor voids that should not receive tile geometry. */
+  readonly cutouts?: readonly Bounds2D[];
   /** Optional baked lightmap assigned to each tile. */
   readonly lightMap?: Texture;
   /** Intensity multiplier applied to the baked lightmap. */
@@ -52,6 +54,75 @@ function applyLightMapOptions(
   } else if (typeof options.lightMapIntensity === 'number') {
     material.lightMapIntensity = Math.max(0, options.lightMapIntensity);
   }
+}
+
+function getIntersection(a: Bounds2D, b: Bounds2D): Bounds2D | null {
+  const minX = Math.max(a.minX, b.minX);
+  const maxX = Math.min(a.maxX, b.maxX);
+  const minZ = Math.max(a.minZ, b.minZ);
+  const maxZ = Math.min(a.maxZ, b.maxZ);
+
+  if (maxX - minX <= MIN_DIMENSION || maxZ - minZ <= MIN_DIMENSION) {
+    return null;
+  }
+
+  return { minX, maxX, minZ, maxZ };
+}
+
+function subtractCutout(rect: Bounds2D, cutout: Bounds2D): Bounds2D[] {
+  const overlap = getIntersection(rect, cutout);
+  if (!overlap) {
+    return [rect];
+  }
+
+  const pieces: Bounds2D[] = [];
+  const pushPiece = (piece: Bounds2D) => {
+    if (
+      piece.maxX - piece.minX > MIN_DIMENSION &&
+      piece.maxZ - piece.minZ > MIN_DIMENSION
+    ) {
+      pieces.push(piece);
+    }
+  };
+
+  pushPiece({
+    minX: rect.minX,
+    maxX: rect.maxX,
+    minZ: rect.minZ,
+    maxZ: overlap.minZ,
+  });
+  pushPiece({
+    minX: rect.minX,
+    maxX: rect.maxX,
+    minZ: overlap.maxZ,
+    maxZ: rect.maxZ,
+  });
+  pushPiece({
+    minX: rect.minX,
+    maxX: overlap.minX,
+    minZ: overlap.minZ,
+    maxZ: overlap.maxZ,
+  });
+  pushPiece({
+    minX: overlap.maxX,
+    maxX: rect.maxX,
+    minZ: overlap.minZ,
+    maxZ: overlap.maxZ,
+  });
+
+  return pieces;
+}
+
+function applyCutouts(
+  rect: Bounds2D,
+  cutouts: readonly Bounds2D[]
+): Bounds2D[] {
+  return cutouts.reduce<Bounds2D[]>(
+    (pieces, cutout) => {
+      return pieces.flatMap((piece) => subtractCutout(piece, cutout));
+    },
+    [rect]
+  );
 }
 
 function resolveMaterial(
@@ -102,30 +173,42 @@ export function createRoomFloorTiles(
       return;
     }
 
-    const width = room.bounds.maxX - room.bounds.minX - inset * 2;
-    const depth = room.bounds.maxZ - room.bounds.minZ - inset * 2;
+    const roomRect = {
+      minX: room.bounds.minX + inset,
+      maxX: room.bounds.maxX - inset,
+      minZ: room.bounds.minZ + inset,
+      maxZ: room.bounds.maxZ - inset,
+    };
 
-    if (width <= MIN_DIMENSION || depth <= MIN_DIMENSION) {
-      return;
-    }
+    const pieces = applyCutouts(roomRect, options.cutouts ?? []);
+    const material = resolveMaterial(room, options, defaultMaterial);
 
-    const geometry = new BoxGeometry(width, thickness, depth);
-    applyLightmapUv2(geometry);
+    pieces.forEach((piece, index) => {
+      const width = piece.maxX - piece.minX;
+      const depth = piece.maxZ - piece.minZ;
 
-    const mesh = new Mesh(
-      geometry,
-      resolveMaterial(room, options, defaultMaterial)
-    );
-    mesh.position.set(
-      (room.bounds.minX + room.bounds.maxX) / 2,
-      elevation - thickness / 2,
-      (room.bounds.minZ + room.bounds.maxZ) / 2
-    );
-    mesh.name = `${room.name} Floor`;
-    mesh.receiveShadow = true;
+      if (width <= MIN_DIMENSION || depth <= MIN_DIMENSION) {
+        return;
+      }
 
-    group.add(mesh);
-    tiles.push({ roomId: room.id, mesh });
+      const geometry = new BoxGeometry(width, thickness, depth);
+      applyLightmapUv2(geometry);
+
+      const mesh = new Mesh(geometry, material);
+      mesh.position.set(
+        (piece.minX + piece.maxX) / 2,
+        elevation - thickness / 2,
+        (piece.minZ + piece.maxZ) / 2
+      );
+      mesh.name =
+        pieces.length > 1
+          ? `${room.name} Floor ${index + 1}`
+          : `${room.name} Floor`;
+      mesh.receiveShadow = true;
+
+      group.add(mesh);
+      tiles.push({ roomId: room.id, mesh });
+    });
   });
 
   return { group, tiles };

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -1,11 +1,16 @@
 import {
   Color,
   CylinderGeometry,
+  Group,
   MeshStandardMaterial,
   SphereGeometry,
 } from 'three';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import {
+  createFloorVisibilityController,
+  applyPoiFloorVisibility,
+} from '../scene/floors/visibility';
 import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
 import { scalePoiValue } from '../scene/poi/constants';
 import {
@@ -292,5 +297,72 @@ describe('createPoiInstances', () => {
     );
     expect(performance.collider).toEqual(balanced.collider);
     expect(performance.hitArea.name).toBe(`POI_HIT:${definition.id}`);
+  });
+
+  it('keeps ground POI labels and visited checkmarks off while the upper floor is active', () => {
+    const [groundPoi] = createPoiInstances([
+      createDefinition({ title: 'Ground Exhibit' }),
+    ]);
+    expect(groundPoi.label).toBeDefined();
+    expect(groundPoi.labelMaterial).toBeDefined();
+    expect(groundPoi.visitedHighlight).toBeDefined();
+
+    groundPoi.labelMaterial!.opacity = 0.76;
+    groundPoi.label!.visible = true;
+    groundPoi.visited = true;
+    groundPoi.visitedHighlight!.material.opacity = 0.55;
+    groundPoi.visitedHighlight!.mesh.visible = true;
+
+    applyPoiFloorVisibility([groundPoi], () => 'ground', 'upper');
+
+    expect(groundPoi.group.visible).toBe(false);
+    expect(groundPoi.label!.visible).toBe(false);
+    expect(groundPoi.labelMaterial!.opacity).toBe(0);
+    expect(groundPoi.visitedHighlight!.mesh.visible).toBe(false);
+    expect(groundPoi.visitedHighlight!.material.opacity).toBe(0);
+  });
+
+  it('toggles floor-specific visual groups without hiding the staircase group', () => {
+    const groundArchitecture = new Group();
+    const groundPoi = new Group();
+    const groundLed = new Group();
+    const groundLedFillLights = new Group();
+    const upperArchitecture = new Group();
+    const staircase = new Group();
+    staircase.name = 'LivingRoomStaircase';
+
+    const controller = createFloorVisibilityController({
+      groups: {
+        groundArchitecture,
+        groundPoi,
+        groundLed,
+        groundLedFillLights,
+        upperArchitecture,
+      },
+    });
+
+    expect(groundArchitecture.visible).toBe(true);
+    expect(groundPoi.visible).toBe(true);
+    expect(groundLed.visible).toBe(true);
+    expect(groundLedFillLights.visible).toBe(true);
+    expect(upperArchitecture.visible).toBe(false);
+    expect(staircase.visible).toBe(true);
+
+    controller.setActiveFloor('upper');
+
+    expect(controller.activeFloor).toBe('upper');
+    expect(groundArchitecture.visible).toBe(true);
+    expect(groundPoi.visible).toBe(false);
+    expect(groundLed.visible).toBe(false);
+    expect(groundLedFillLights.visible).toBe(false);
+    expect(upperArchitecture.visible).toBe(true);
+    expect(staircase.visible).toBe(true);
+
+    controller.setActiveFloor('ground');
+
+    expect(groundPoi.visible).toBe(true);
+    expect(groundLed.visible).toBe(true);
+    expect(groundLedFillLights.visible).toBe(true);
+    expect(upperArchitecture.visible).toBe(false);
   });
 });

--- a/src/tests/roomFloorTiles.test.ts
+++ b/src/tests/roomFloorTiles.test.ts
@@ -109,6 +109,33 @@ describe('createRoomFloorTiles', () => {
     expect(tileMaterial.lightMapIntensity).toBeCloseTo(0.18);
   });
 
+  it('splits upstairs slabs around rectangular stairwell cutouts', () => {
+    const { group, tiles } = createRoomFloorTiles([livingRoom], {
+      elevation: 4,
+      thickness: 0.4,
+      cutouts: [{ minX: -1, maxX: 1, minZ: -5, maxZ: -3 }],
+    });
+
+    expect(group.name).toBe('RoomFloorTiles');
+    expect(tiles).toHaveLength(4);
+    tiles.forEach((tile) => {
+      const material = tile.mesh.material as MeshStandardMaterial;
+      expect(material.transparent).toBe(false);
+      expect(material.depthWrite).toBe(true);
+      expect(tile.mesh.position.y).toBeCloseTo(3.8);
+    });
+
+    const hasCutoutCoveringTile = tiles.some((tile) => {
+      const geometry = tile.mesh.geometry as BoxGeometry;
+      const minX = tile.mesh.position.x - geometry.parameters.width / 2;
+      const maxX = tile.mesh.position.x + geometry.parameters.width / 2;
+      const minZ = tile.mesh.position.z - geometry.parameters.depth / 2;
+      const maxZ = tile.mesh.position.z + geometry.parameters.depth / 2;
+      return minX < 1 && maxX > -1 && minZ < -3 && maxZ > -5;
+    });
+    expect(hasCutoutCoveringTile).toBe(false);
+  });
+
   it('skips rooms that are too small after inset adjustments', () => {
     const tightRoom: RoomDefinition = {
       id: 'micro',


### PR DESCRIPTION
### Motivation
- Fix the upper-floor “walking on glass” visual by replacing the single thin ShapeGeometry plane with opaque slab geometry so the second floor reads as a solid, navigable deck.
- Prevent ground-floor POI labels, green checkmarks, and LED strips from poking through the upstairs view when the active floor is upper.
- Centralize floor-visibility behavior so floor-specific visuals and POI overlays respect the active floor without scattering checks across modules.

### Description
- Replace the single upstairs `ShapeGeometry` w/ opaque, depth-writing slabs built via `createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, { elevation: upperFloorElevation, thickness: ... , cutouts: [...] })` so rooms are rendered as BoxGeometry slabs and the stairwell is carved as a rectangular cutout (see `src/main.ts` and `src/scene/structures/floorTiles.ts`).
- Extend `createRoomFloorTiles` to accept `cutouts: Bounds2D[]`, split room tiles around rectangular voids, and preserve lightmap / materialFactory plumbing (new splitting helpers and cutout logic in `src/scene/structures/floorTiles.ts`).
- Add a small floor visibility controller and helpers in `src/scene/floors/visibility.ts` and create named groups for ground architecture, ground POI visuals, and ground LED visuals; wire scene composition in `src/main.ts` so ground objects are added to those groups and the controller toggles visibility on `setActiveFloorId` without hiding the staircase.
- Make POI label/visited/LED/tooltip behavior floor-aware by (a) mapping POIs to their floor, (b) filtering world-tooltip targets/recommendations to the active floor, and (c) gating POI label/halo/visited visual opacity when the player is on the other floor (changes in `src/main.ts`); added unit tests for cutouts and floor visibility changes.

### Testing
- Ran `npm run format:write` and formatting applied successfully.
- Ran `npm run lint` and ESLint passed (no blocking errors after fixups).
- Ran targeted unit tests with `npm run test:ci -- src/tests/roomFloorTiles.test.ts src/tests/poiMarkers.test.ts src/tests/poiWorldTooltip.test.ts` and then the full suite `npm run test:ci`; Vitest passed locally (summary: 139 files, 1036 tests passed).
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`, and ran `npm run docs:check`; all succeeded in this environment; `npm run typecheck` failed due to pre-existing project-wide TypeScript issues outside this change, and `npm run test:e2e` is blocked in this environment because Playwright browsers are not installed (error: run `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ca5bc7e8832f86c3d2ae1fca739e)