### PR TITLE
Add Settings-controlled debug coordinates overlay

### DIFF
--- a/docs/guides/accessibility-overlays.md
+++ b/docs/guides/accessibility-overlays.md
@@ -45,6 +45,19 @@ screen-reader visitors receive the same metadata as 3D players.
   [`playwright/keyboard-traversal.spec.ts`](../../playwright/keyboard-traversal.spec.ts))
   to verify the overlay announces each POI in the expected order.
 
+## Opt-in debug overlays
+
+- Keep diagnostics off by default and expose them through Settings when they are
+  useful to non-developer QA. The immersive coordinate overlay is controlled by
+  the **Debug coordinates** Setting, persists to
+  `danielsmith.io::debugCoordinates::v1`, and may be forced for a review link
+  with `?debugCoordinates=1`.
+- Diagnostic overlays must be non-blocking (`pointer-events: none`) so movement,
+  camera panning, zooming, POI clicks, and Settings controls continue to work.
+- Prefer modest DOM update cadences for diagnostics. The coordinate overlay
+  samples every frame but only rewrites visible text at a throttled cadence so it
+  can report XYZ/floor/stair state without adding per-frame layout churn.
+
 ## Automated audits
 
 - `npm run test:ci` now includes

--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -13,6 +13,8 @@ import type {
   AudioHudControlStrings,
   AudioSubtitleStrings,
   ControlOverlayStrings,
+  DebugCoordinatesControlStrings,
+  DebugCoordinatesOverlayStrings,
   DeepPartial,
   HelpModalStrings,
   Locale,
@@ -466,6 +468,18 @@ export function getNarrationToggleStrings(
   input?: LocaleInput
 ): NarrationToggleStrings {
   return cloneValue(getLocaleStrings(input).hud.narrationToggle);
+}
+
+export function getDebugCoordinatesControlStrings(
+  input?: LocaleInput
+): DebugCoordinatesControlStrings {
+  return cloneValue(getLocaleStrings(input).hud.debugCoordinatesControl);
+}
+
+export function getDebugCoordinatesOverlayStrings(
+  input?: LocaleInput
+): DebugCoordinatesOverlayStrings {
+  return cloneValue(getLocaleStrings(input).hud.debugCoordinatesOverlay);
 }
 
 export function getTourResetControlStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -276,6 +276,31 @@ export const AR_OVERRIDES: LocaleOverrides = {
       descriptionDisabled:
         'تبقى نوافذ السرد والتسميات التوضيحية مخفية حتى تفعّلها.',
     },
+    debugCoordinatesControl: {
+      labelEnabled: 'إحداثيات التصحيح مفعّلة',
+      labelDisabled: 'إحداثيات التصحيح معطّلة',
+      descriptionEnabled: 'تعرض XYZ للاعب والطابق والسلم والتكبير والغرفة.',
+      descriptionDisabled: 'تخفي طبقة الإحداثيات حتى تفعّلها من جديد.',
+    },
+    debugCoordinatesOverlay: {
+      title: 'إحداثيات التصحيح',
+      roomFallback: 'لا توجد غرفة',
+      labels: {
+        position: 'XYZ',
+        activeFloor: 'الطابق النشط',
+        predictedFloor: 'الطابق المتوقع',
+        cameraZoom: 'تكبير الكاميرا',
+        stairWidth: 'عرض السلم',
+        landing: 'البسطة',
+        stairNavArea: 'منطقة تنقل السلم',
+        stairZone: 'منطقة السلم',
+        room: 'الغرفة',
+      },
+      boolean: {
+        yes: 'نعم',
+        no: 'لا',
+      },
+    },
     poiOverlay: {
       visited: 'تمت الزيارة',
       nextHighlight: 'المحطة التالية',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -49,6 +49,27 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
       'Erzähl-Pop-ups und Untertitel erscheinen bei künftigen Exponatmomenten.',
     narrationToggleDescriptionDisabled:
       'Erzähl-Pop-ups und Untertitel bleiben verborgen, bis du sie einschaltest.',
+    debugCoordinatesLabelEnabled: 'Debug-Koordinaten ein',
+    debugCoordinatesLabelDisabled: 'Debug-Koordinaten aus',
+    debugCoordinatesDescriptionEnabled:
+      'Zeigt Spieler-XYZ, Etage, Treppe, Zoom und Raum.',
+    debugCoordinatesDescriptionDisabled:
+      'Blendet das Koordinaten-Overlay aus, bis du es aktivierst.',
+    debugCoordinatesTitle: 'Debug-Koordinaten',
+    debugCoordinatesRoomFallback: 'Kein Raum',
+    debugCoordinatesYes: 'Ja',
+    debugCoordinatesNo: 'Nein',
+    debugCoordinatesLabels: {
+      position: 'XYZ',
+      activeFloor: 'Aktive Etage',
+      predictedFloor: 'Prognose-Etage',
+      cameraZoom: 'Kamera-Zoom',
+      stairWidth: 'Treppenbreite',
+      landing: 'Podest',
+      stairNavArea: 'Treppen-Navigationsbereich',
+      stairZone: 'Treppenzone',
+      room: 'Raum',
+    },
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -329,6 +329,35 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Narration popups and captions stay hidden until you turn them on.'
       ),
     },
+    debugCoordinatesControl: {
+      labelEnabled: wrap('Debug coordinates on'),
+      labelDisabled: wrap('Debug coordinates off'),
+      descriptionEnabled: wrap(
+        'Shows player XYZ, floor, stair, zoom, and room debugging details.'
+      ),
+      descriptionDisabled: wrap(
+        'Hides the coordinate overlay until you turn it back on.'
+      ),
+    },
+    debugCoordinatesOverlay: {
+      title: wrap('Debug coordinates'),
+      roomFallback: wrap('No room'),
+      labels: {
+        position: wrap('XYZ'),
+        activeFloor: wrap('Active floor'),
+        predictedFloor: wrap('Predicted floor'),
+        cameraZoom: wrap('Camera zoom'),
+        stairWidth: wrap('Stair width'),
+        landing: wrap('Landing'),
+        stairNavArea: wrap('Stair nav area'),
+        stairZone: wrap('Stair zone'),
+        room: wrap('Room'),
+      },
+      boolean: {
+        yes: wrap('Yes'),
+        no: wrap('No'),
+      },
+    },
     tourReset: {
       heading: wrap('Guided tour'),
       resetKey: 'g',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -339,6 +339,33 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       descriptionDisabled:
         'Narration popups and captions stay hidden until you turn them on.',
     },
+    debugCoordinatesControl: {
+      labelEnabled: 'Debug coordinates on',
+      labelDisabled: 'Debug coordinates off',
+      descriptionEnabled:
+        'Shows player XYZ, floor, stair, zoom, and room debugging details.',
+      descriptionDisabled:
+        'Hides the coordinate overlay until you turn it back on.',
+    },
+    debugCoordinatesOverlay: {
+      title: 'Debug coordinates',
+      roomFallback: 'No room',
+      labels: {
+        position: 'XYZ',
+        activeFloor: 'Active floor',
+        predictedFloor: 'Predicted floor',
+        cameraZoom: 'Camera zoom',
+        stairWidth: 'Stair width',
+        landing: 'Landing',
+        stairNavArea: 'Stair nav area',
+        stairZone: 'Stair zone',
+        room: 'Room',
+      },
+      boolean: {
+        yes: 'Yes',
+        no: 'No',
+      },
+    },
     tourReset: {
       heading: 'Guided tour',
       resetKey: 'g',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -49,6 +49,27 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
       'Las ventanas y subtítulos de narración aparecen en futuros momentos de exhibición.',
     narrationToggleDescriptionDisabled:
       'Las ventanas y subtítulos de narración permanecen ocultos hasta que los actives.',
+    debugCoordinatesLabelEnabled: 'Coordenadas de depuración activadas',
+    debugCoordinatesLabelDisabled: 'Coordenadas de depuración desactivadas',
+    debugCoordinatesDescriptionEnabled:
+      'Muestra XYZ del jugador, piso, escalera, zoom y sala.',
+    debugCoordinatesDescriptionDisabled:
+      'Oculta la superposición de coordenadas hasta que la actives.',
+    debugCoordinatesTitle: 'Coordenadas de depuración',
+    debugCoordinatesRoomFallback: 'Sin sala',
+    debugCoordinatesYes: 'Sí',
+    debugCoordinatesNo: 'No',
+    debugCoordinatesLabels: {
+      position: 'XYZ',
+      activeFloor: 'Piso activo',
+      predictedFloor: 'Piso previsto',
+      cameraZoom: 'Zoom de cámara',
+      stairWidth: 'Ancho de escalera',
+      landing: 'Descanso',
+      stairNavArea: 'Área nav. escalera',
+      stairZone: 'Zona de escalera',
+      room: 'Sala',
+    },
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -49,6 +49,27 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
       'A narrációs felugrók és feliratok megjelennek a következő kiállítási pillanatoknál.',
     narrationToggleDescriptionDisabled:
       'A narrációs felugrók és feliratok rejtve maradnak, amíg be nem kapcsolod őket.',
+    debugCoordinatesLabelEnabled: 'Debug koordináták bekapcsolva',
+    debugCoordinatesLabelDisabled: 'Debug koordináták kikapcsolva',
+    debugCoordinatesDescriptionEnabled:
+      'Mutatja a játékos XYZ helyét, emeletét, lépcsőjét, zoomját és szobáját.',
+    debugCoordinatesDescriptionDisabled:
+      'Elrejti a koordináta-réteget, amíg be nem kapcsolod.',
+    debugCoordinatesTitle: 'Debug koordináták',
+    debugCoordinatesRoomFallback: 'Nincs szoba',
+    debugCoordinatesYes: 'Igen',
+    debugCoordinatesNo: 'Nem',
+    debugCoordinatesLabels: {
+      position: 'XYZ',
+      activeFloor: 'Aktív emelet',
+      predictedFloor: 'Várt emelet',
+      cameraZoom: 'Kamera zoom',
+      stairWidth: 'Lépcsőszélesség',
+      landing: 'Pihenő',
+      stairNavArea: 'Lépcső nav. terület',
+      stairZone: 'Lépcsőzóna',
+      room: 'Szoba',
+    },
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -277,6 +277,32 @@ export const JA_OVERRIDES: LocaleOverrides = {
       descriptionDisabled:
         'オンにするまでナレーションのポップアップと字幕は非表示です。',
     },
+    debugCoordinatesControl: {
+      labelEnabled: 'デバッグ座標 オン',
+      labelDisabled: 'デバッグ座標 オフ',
+      descriptionEnabled:
+        'プレイヤーの XYZ、階、階段、ズーム、部屋を表示します。',
+      descriptionDisabled: 'オンにするまで座標オーバーレイを非表示にします。',
+    },
+    debugCoordinatesOverlay: {
+      title: 'デバッグ座標',
+      roomFallback: '部屋なし',
+      labels: {
+        position: 'XYZ',
+        activeFloor: '現在の階',
+        predictedFloor: '予測階',
+        cameraZoom: 'カメラズーム',
+        stairWidth: '階段幅',
+        landing: '踊り場',
+        stairNavArea: '階段ナビ領域',
+        stairZone: '階段ゾーン',
+        room: '部屋',
+      },
+      boolean: {
+        yes: 'はい',
+        no: 'いいえ',
+      },
+    },
     poiOverlay: {
       visited: '訪問済み',
       nextHighlight: '次のハイライト',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -50,6 +50,25 @@ interface LatinLocaleCopy {
     narrationToggleLabelDisabled: string;
     narrationToggleDescriptionEnabled: string;
     narrationToggleDescriptionDisabled: string;
+    debugCoordinatesLabelEnabled: string;
+    debugCoordinatesLabelDisabled: string;
+    debugCoordinatesDescriptionEnabled: string;
+    debugCoordinatesDescriptionDisabled: string;
+    debugCoordinatesTitle: string;
+    debugCoordinatesRoomFallback: string;
+    debugCoordinatesYes: string;
+    debugCoordinatesNo: string;
+    debugCoordinatesLabels: {
+      position: string;
+      activeFloor: string;
+      predictedFloor: string;
+      cameraZoom: string;
+      stairWidth: string;
+      landing: string;
+      stairNavArea: string;
+      stairZone: string;
+      room: string;
+    };
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -699,6 +718,21 @@ export function buildLatinLocaleOverrides(
         labelDisabled: s.narrationToggleLabelDisabled,
         descriptionEnabled: s.narrationToggleDescriptionEnabled,
         descriptionDisabled: s.narrationToggleDescriptionDisabled,
+      },
+      debugCoordinatesControl: {
+        labelEnabled: s.debugCoordinatesLabelEnabled,
+        labelDisabled: s.debugCoordinatesLabelDisabled,
+        descriptionEnabled: s.debugCoordinatesDescriptionEnabled,
+        descriptionDisabled: s.debugCoordinatesDescriptionDisabled,
+      },
+      debugCoordinatesOverlay: {
+        title: s.debugCoordinatesTitle,
+        roomFallback: s.debugCoordinatesRoomFallback,
+        labels: s.debugCoordinatesLabels,
+        boolean: {
+          yes: s.debugCoordinatesYes,
+          no: s.debugCoordinatesNo,
+        },
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -49,6 +49,27 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
       'Pop-ups e legendas de narração aparecem em futuros momentos da exibição.',
     narrationToggleDescriptionDisabled:
       'Pop-ups e legendas de narração ficam ocultos até você ativá-los.',
+    debugCoordinatesLabelEnabled: 'Coordenadas de depuração ativadas',
+    debugCoordinatesLabelDisabled: 'Coordenadas de depuração desativadas',
+    debugCoordinatesDescriptionEnabled:
+      'Mostra XYZ do jogador, piso, escada, zoom e sala.',
+    debugCoordinatesDescriptionDisabled:
+      'Oculta a sobreposição de coordenadas até você ativá-la.',
+    debugCoordinatesTitle: 'Coordenadas de depuração',
+    debugCoordinatesRoomFallback: 'Sem sala',
+    debugCoordinatesYes: 'Sim',
+    debugCoordinatesNo: 'Não',
+    debugCoordinatesLabels: {
+      position: 'XYZ',
+      activeFloor: 'Piso ativo',
+      predictedFloor: 'Piso previsto',
+      cameraZoom: 'Zoom da câmera',
+      stairWidth: 'Largura da escada',
+      landing: 'Patamar',
+      stairNavArea: 'Área nav. escada',
+      stairZone: 'Zona da escada',
+      room: 'Sala',
+    },
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -265,6 +265,31 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       descriptionEnabled: '未来展品时刻会显示旁白弹窗和字幕。',
       descriptionDisabled: '旁白弹窗和字幕保持隐藏，直到你开启。',
     },
+    debugCoordinatesControl: {
+      labelEnabled: '调试坐标已开启',
+      labelDisabled: '调试坐标已关闭',
+      descriptionEnabled: '显示玩家 XYZ、楼层、楼梯、缩放和房间。',
+      descriptionDisabled: '隐藏坐标浮层，直到你重新开启。',
+    },
+    debugCoordinatesOverlay: {
+      title: '调试坐标',
+      roomFallback: '无房间',
+      labels: {
+        position: 'XYZ',
+        activeFloor: '当前楼层',
+        predictedFloor: '预测楼层',
+        cameraZoom: '相机缩放',
+        stairWidth: '楼梯宽度',
+        landing: '平台',
+        stairNavArea: '楼梯导航区',
+        stairZone: '楼梯区域',
+        room: '房间',
+      },
+      boolean: {
+        yes: '是',
+        no: '否',
+      },
+    },
     tourReset: {
       heading: '导览',
       resetKey: 'g',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -209,6 +209,33 @@ export interface NarrationToggleStrings {
   descriptionDisabled: string;
 }
 
+export interface DebugCoordinatesControlStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
+export interface DebugCoordinatesOverlayStrings {
+  title: string;
+  roomFallback: string;
+  labels: {
+    position: string;
+    activeFloor: string;
+    predictedFloor: string;
+    cameraZoom: string;
+    stairWidth: string;
+    landing: string;
+    stairNavArea: string;
+    stairZone: string;
+    room: string;
+  };
+  boolean: {
+    yes: string;
+    no: string;
+  };
+}
+
 export interface TourResetControlStrings {
   heading: string;
   resetKey: string;
@@ -398,6 +425,8 @@ export interface LocaleStrings {
     localeToggle: LocaleToggleStrings;
     tourGuideToggle: TourGuideToggleStrings;
     narrationToggle: NarrationToggleStrings;
+    debugCoordinatesControl: DebugCoordinatesControlStrings;
+    debugCoordinatesOverlay: DebugCoordinatesOverlayStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,8 @@ import {
   getAudioHudControlStrings,
   getAudioSubtitleStrings,
   getControlOverlayStrings,
+  getDebugCoordinatesControlStrings,
+  getDebugCoordinatesOverlayStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
   getLocaleDirection,
@@ -299,6 +301,10 @@ import {
 import { createAvatarAccessoryControl } from './systems/controls/avatarAccessoryControl';
 import { createAvatarVariantControl } from './systems/controls/avatarVariantControl';
 import {
+  createDebugCoordinatesControl,
+  type DebugCoordinatesControlHandle,
+} from './systems/controls/debugCoordinatesControl';
+import {
   createGraphicsQualityControl,
   type GraphicsQualityControlHandle,
 } from './systems/controls/graphicsQualityControl';
@@ -369,6 +375,8 @@ import { computeStairLayout } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
   createStairNavigationZones,
+  isWithinLanding,
+  isWithinStairWidth,
   predictStairFloorId,
   sampleStairSurfaceHeight,
   type FloorId,
@@ -415,6 +423,11 @@ import {
   createHudCustomizationSection,
   type HudCustomizationHandle,
 } from './ui/hud/customizationSection';
+import {
+  createDebugCoordinatesOverlay,
+  type DebugCoordinatesOverlayHandle,
+  type DebugCoordinatesSnapshot,
+} from './ui/hud/debugCoordinatesOverlay';
 import { createHelpModal } from './ui/hud/helpModal';
 import {
   attachHelpModalController,
@@ -554,6 +567,14 @@ declare global {
           totalInWorldTooltipCount: number;
         };
       };
+      debugCoordinates?: {
+        getState(): {
+          enabled: boolean;
+          storageKey: string;
+          snapshot: DebugCoordinatesSnapshot | null;
+        };
+        setEnabled(enabled: boolean): void;
+      };
       world?: {
         getActiveFloor(): FloorId;
         setActiveFloor(next: FloorId): void;
@@ -593,6 +614,7 @@ const PLAYER_SPEED = 12;
 const MOVEMENT_SMOOTHING = 8;
 const CAMERA_PAN_SMOOTHING = 6;
 const CAMERA_ZOOM_SMOOTHING = 6;
+const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const CAMERA_MARGIN = 1.1;
 const MIN_CAMERA_ZOOM = 0.65;
 const MAX_CAMERA_ZOOM = 12;
@@ -1008,6 +1030,9 @@ function initializeImmersiveScene(
   let inputLatencyTelemetry: InputLatencyTelemetryHandle | null = null;
   let manualModeToggle: ManualModeToggleHandle | null = null;
   let tourGuideToggleControl: TourGuideToggleControlHandle | null = null;
+  let debugCoordinatesControl: DebugCoordinatesControlHandle | null = null;
+  let debugCoordinatesOverlay: DebugCoordinatesOverlayHandle | null = null;
+  let latestDebugCoordinatesSnapshot: DebugCoordinatesSnapshot | null = null;
   let tourResetControl: TourResetControlHandle | null = null;
   let hudLayoutManager: HudLayoutManagerHandle | null = null;
   let responsiveControlOverlay: ResponsiveControlOverlayHandle | null = null;
@@ -1227,6 +1252,39 @@ function initializeImmersiveScene(
     }
   }
 
+  let debugCoordinatesStorage: Storage | undefined;
+  try {
+    debugCoordinatesStorage = window.localStorage;
+  } catch {
+    debugCoordinatesStorage = undefined;
+  }
+  const debugCoordinatesSearch = new URLSearchParams(window.location.search);
+  const debugCoordinatesOverride =
+    debugCoordinatesSearch.get('debugCoordinates');
+  let debugCoordinatesEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_COORDINATES_STORAGE_KEY) === 'true';
+  if (debugCoordinatesOverride) {
+    debugCoordinatesEnabled = ['1', 'true', 'on', 'yes'].includes(
+      debugCoordinatesOverride.toLowerCase()
+    );
+  }
+  const persistDebugCoordinatesPreference = (enabled: boolean) => {
+    try {
+      debugCoordinatesStorage?.setItem(
+        DEBUG_COORDINATES_STORAGE_KEY,
+        String(enabled)
+      );
+    } catch (error) {
+      console.warn('Failed to persist debug coordinates preference.', error);
+    }
+  };
+  const setDebugCoordinatesEnabled = (enabled: boolean) => {
+    debugCoordinatesEnabled = enabled;
+    persistDebugCoordinatesPreference(enabled);
+    debugCoordinatesControl?.setEnabled(enabled);
+    debugCoordinatesOverlay?.setEnabled(enabled);
+  };
+
   inputLatencyTelemetry = createInputLatencyTelemetry({
     windowTarget: window,
     documentTarget: document,
@@ -1281,6 +1339,10 @@ function initializeImmersiveScene(
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
   let narrationToggleStrings = getNarrationToggleStrings(locale);
+  let debugCoordinatesControlStrings =
+    getDebugCoordinatesControlStrings(locale);
+  let debugCoordinatesOverlayStrings =
+    getDebugCoordinatesOverlayStrings(locale);
   let tourResetControlStrings = getTourResetControlStrings(locale);
   let softwareRendererWarningStrings =
     getSoftwareRendererWarningStrings(locale);
@@ -3116,6 +3178,12 @@ function initializeImmersiveScene(
   const hudSettingsStack = document.createElement('div');
   hudSettingsStack.className = 'hud-settings';
   hudSettingsContainer.appendChild(hudSettingsStack);
+
+  debugCoordinatesOverlay = createDebugCoordinatesOverlay({
+    container: document.body,
+    strings: debugCoordinatesOverlayStrings,
+    enabled: debugCoordinatesEnabled,
+  });
   const hudControlElements = new Set<HTMLElement>();
   const registerHudControlElement = (element?: HTMLElement | null) => {
     if (!element) {
@@ -3390,6 +3458,8 @@ function initializeImmersiveScene(
     audioHudStrings = getAudioHudControlStrings(locale);
     audioSubtitleStrings = getAudioSubtitleStrings(locale);
     narrationToggleStrings = getNarrationToggleStrings(locale);
+    debugCoordinatesControlStrings = getDebugCoordinatesControlStrings(locale);
+    debugCoordinatesOverlayStrings = getDebugCoordinatesOverlayStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
@@ -3463,6 +3533,8 @@ function initializeImmersiveScene(
     poiNarrativeLog?.setStrings(narrativeLogStrings);
     audioSubtitles?.setLabels(audioSubtitleStrings);
     narrationToggleControl?.setStrings(narrationToggleStrings);
+    debugCoordinatesControl?.setStrings(debugCoordinatesControlStrings);
+    debugCoordinatesOverlay?.setStrings(debugCoordinatesOverlayStrings);
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
@@ -3543,6 +3615,78 @@ function initializeImmersiveScene(
     }
 
     return true;
+  };
+
+  const containsPoint = (rect: RectCollider, x: number, z: number): boolean =>
+    x >= rect.minX && x <= rect.maxX && z >= rect.minZ && z <= rect.maxZ;
+
+  const getCurrentRoomId = (x: number, z: number, floorId: FloorId) => {
+    const plan = floorId === 'upper' ? UPPER_FLOOR_PLAN : FLOOR_PLAN;
+    return (
+      plan.rooms.find((room) => containsPoint(room.bounds, x, z))?.id ?? null
+    );
+  };
+
+  const getDebugCoordinatesSnapshot = (): DebugCoordinatesSnapshot => {
+    const x = player.position.x;
+    const y = player.position.y;
+    const z = player.position.z;
+    const predictedFloorId = predictFloorId(x, z, activeFloorId);
+    const stairZone = classifyStairTransitionZone(
+      stairGeometry,
+      stairBehavior,
+      x,
+      z,
+      activeFloorId
+    );
+
+    return {
+      x,
+      y,
+      z,
+      activeFloorId,
+      predictedFloorId,
+      cameraZoom,
+      insideStairWidth: isWithinStairWidth(
+        stairGeometry,
+        x,
+        stairBehavior.transitionMargin
+      ),
+      insideLanding: isWithinLanding(
+        stairGeometry,
+        x,
+        z,
+        stairBehavior.landingTriggerMargin
+      ),
+      insideStairNavArea: Object.values(stairNavigationZones).some((zone) =>
+        containsPoint(zone, x, z)
+      ),
+      stairZone,
+      roomId: getCurrentRoomId(x, z, activeFloorId),
+    };
+  };
+
+  const updateDebugCoordinatesOverlay = (nowMs?: number) => {
+    latestDebugCoordinatesSnapshot = getDebugCoordinatesSnapshot();
+    debugCoordinatesOverlay?.update(latestDebugCoordinatesSnapshot, nowMs);
+  };
+
+  const portfolioWindowForDebugCoordinates = window as Window;
+  if (!portfolioWindowForDebugCoordinates.portfolio) {
+    portfolioWindowForDebugCoordinates.portfolio = {};
+  }
+  portfolioWindowForDebugCoordinates.portfolio.debugCoordinates = {
+    getState() {
+      return {
+        enabled: debugCoordinatesEnabled,
+        storageKey: DEBUG_COORDINATES_STORAGE_KEY,
+        snapshot:
+          latestDebugCoordinatesSnapshot ?? getDebugCoordinatesSnapshot(),
+      };
+    },
+    setEnabled(enabled: boolean) {
+      setDebugCoordinatesEnabled(Boolean(enabled));
+    },
   };
 
   const setActiveFloorId = (next: FloorId) => {
@@ -3987,6 +4131,14 @@ function initializeImmersiveScene(
       strings: narrationToggleStrings,
     });
     registerHudControlElement(narrationToggleControl?.element ?? null);
+
+    debugCoordinatesControl = createDebugCoordinatesControl({
+      container: hudSettingsStack,
+      initialEnabled: debugCoordinatesEnabled,
+      onToggle: setDebugCoordinatesEnabled,
+      strings: debugCoordinatesControlStrings,
+    });
+    registerHudControlElement(debugCoordinatesControl?.element ?? null);
 
     tourGuideToggleControl = createTourGuideToggleControl({
       container: hudSettingsStack,
@@ -4924,6 +5076,14 @@ function initializeImmersiveScene(
       tourGuideToggleControl.dispose();
       tourGuideToggleControl = null;
     }
+    if (debugCoordinatesControl) {
+      debugCoordinatesControl.dispose();
+      debugCoordinatesControl = null;
+    }
+    if (debugCoordinatesOverlay) {
+      debugCoordinatesOverlay.dispose();
+      debugCoordinatesOverlay = null;
+    }
     if (tourResetControl) {
       tourResetControl.dispose();
       tourResetControl = null;
@@ -5056,6 +5216,9 @@ function initializeImmersiveScene(
     }
     if (window.portfolio?.poi) {
       delete window.portfolio.poi;
+    }
+    if (window.portfolio?.debugCoordinates) {
+      delete window.portfolio.debugCoordinates;
     }
     if (window.portfolio?.graphics) {
       delete window.portfolio.graphics;
@@ -5234,6 +5397,7 @@ function initializeImmersiveScene(
       analyticsGlow.update(delta);
       handleInteractionInput();
       handleHelpInput();
+      updateDebugCoordinatesOverlay(frameStartMs);
       performanceDiagnostics?.recordPhase(
         'poiHudTooltips',
         performance.now() - phaseStart

--- a/src/systems/controls/debugCoordinatesControl.ts
+++ b/src/systems/controls/debugCoordinatesControl.ts
@@ -1,0 +1,77 @@
+import type { DebugCoordinatesControlStrings } from '../../assets/i18n';
+import { getDebugCoordinatesControlStrings } from '../../assets/i18n';
+
+export interface DebugCoordinatesControlOptions {
+  container: HTMLElement;
+  initialEnabled?: boolean;
+  onToggle?: (enabled: boolean) => void;
+  strings?: DebugCoordinatesControlStrings;
+}
+
+export interface DebugCoordinatesControlHandle {
+  readonly element: HTMLButtonElement;
+  setEnabled(enabled: boolean): void;
+  setStrings(strings: DebugCoordinatesControlStrings): void;
+  dispose(): void;
+}
+
+export function createDebugCoordinatesControl({
+  container,
+  initialEnabled = false,
+  onToggle,
+  strings: providedStrings,
+}: DebugCoordinatesControlOptions): DebugCoordinatesControlHandle {
+  const defaultStrings = getDebugCoordinatesControlStrings();
+  let strings: DebugCoordinatesControlStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+  };
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tour-toggle debug-coordinates-toggle';
+  container.appendChild(button);
+
+  let enabled = Boolean(initialEnabled);
+
+  const refresh = () => {
+    const label = enabled ? strings.labelEnabled : strings.labelDisabled;
+    const description = enabled
+      ? strings.descriptionEnabled
+      : strings.descriptionDisabled;
+    button.textContent = label;
+    button.dataset.state = enabled ? 'enabled' : 'disabled';
+    button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    button.setAttribute('aria-label', description);
+    button.title = description;
+    button.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const toggle = () => {
+    enabled = !enabled;
+    refresh();
+    onToggle?.(enabled);
+  };
+
+  button.addEventListener('click', toggle);
+  refresh();
+
+  return {
+    element: button,
+    setEnabled(next) {
+      if (enabled === next) {
+        return;
+      }
+      enabled = next;
+      refresh();
+    },
+    setStrings(nextStrings) {
+      strings = { ...defaultStrings, ...nextStrings };
+      refresh();
+    },
+    dispose() {
+      button.removeEventListener('click', toggle);
+      button.remove();
+    },
+  };
+}

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -5,6 +5,8 @@ import {
   formatMessage,
   getAudioSubtitleStrings,
   getControlOverlayStrings,
+  getDebugCoordinatesControlStrings,
+  getDebugCoordinatesOverlayStrings,
   getHelpModalStrings,
   getLocaleDirection,
   getLocaleToggleStrings,
@@ -390,10 +392,16 @@ describe('i18n utilities', () => {
     const pseudoOverlay = getControlOverlayStrings('en-x-pseudo');
     const arabicOverlay = getControlOverlayStrings('ar');
     const japaneseOverlay = getControlOverlayStrings('ja');
+    const englishDebugControl = getDebugCoordinatesControlStrings('en');
+    const pseudoDebugControl = getDebugCoordinatesControlStrings('en-x-pseudo');
+    const arabicDebugOverlay = getDebugCoordinatesOverlayStrings('ar');
     expect(englishOverlay.heading).toBe('Controls');
     expect(pseudoOverlay.heading).toBe('⟦Controls⟧');
     expect(arabicOverlay.heading).toBe('عناصر التحكم');
     expect(japaneseOverlay.heading).toBe('操作');
+    expect(englishDebugControl.labelDisabled).toBe('Debug coordinates off');
+    expect(pseudoDebugControl.labelEnabled).toBe('⟦Debug coordinates on⟧');
+    expect(arabicDebugOverlay.labels.activeFloor).toBe('الطابق النشط');
     expect(getControlOverlayStrings('zh-Hans').heading).toBe('控制');
     expect(getHelpModalStrings('zh-Hans').heading).toBe('设置与帮助');
     expect(pseudoOverlay.items.keyboardMove.keys).toBe(

--- a/src/ui/hud/debugCoordinatesOverlay.ts
+++ b/src/ui/hud/debugCoordinatesOverlay.ts
@@ -1,0 +1,192 @@
+import type { DebugCoordinatesOverlayStrings } from '../../assets/i18n';
+import { getDebugCoordinatesOverlayStrings } from '../../assets/i18n';
+import type {
+  FloorId,
+  StairTransitionZone,
+} from '../../systems/movement/stairs';
+
+export interface DebugCoordinatesSnapshot {
+  x: number;
+  y: number;
+  z: number;
+  activeFloorId: FloorId;
+  predictedFloorId: FloorId;
+  cameraZoom: number;
+  insideStairWidth: boolean;
+  insideLanding: boolean;
+  insideStairNavArea: boolean;
+  stairZone: StairTransitionZone;
+  roomId?: string | null;
+}
+
+export interface DebugCoordinatesOverlayOptions {
+  container: HTMLElement;
+  strings?: DebugCoordinatesOverlayStrings;
+  enabled?: boolean;
+  updateIntervalMs?: number;
+}
+
+export interface DebugCoordinatesOverlayHandle {
+  readonly element: HTMLElement;
+  isEnabled(): boolean;
+  setEnabled(enabled: boolean): void;
+  setStrings(strings: DebugCoordinatesOverlayStrings): void;
+  update(snapshot: DebugCoordinatesSnapshot, nowMs?: number): void;
+  dispose(): void;
+}
+
+const DEFAULT_UPDATE_INTERVAL_MS = 200;
+
+const formatNumber = (value: number): string =>
+  Number.isFinite(value) ? value.toFixed(2) : 'n/a';
+
+const formatBoolean = (
+  value: boolean,
+  strings: DebugCoordinatesOverlayStrings
+): string => (value ? strings.boolean.yes : strings.boolean.no);
+
+export function createDebugCoordinatesOverlay({
+  container,
+  strings: providedStrings,
+  enabled = false,
+  updateIntervalMs = DEFAULT_UPDATE_INTERVAL_MS,
+}: DebugCoordinatesOverlayOptions): DebugCoordinatesOverlayHandle {
+  const defaultStrings = getDebugCoordinatesOverlayStrings();
+  let strings: DebugCoordinatesOverlayStrings = {
+    ...defaultStrings,
+    ...providedStrings,
+    labels: {
+      ...defaultStrings.labels,
+      ...providedStrings?.labels,
+    },
+    boolean: {
+      ...defaultStrings.boolean,
+      ...providedStrings?.boolean,
+    },
+  };
+  let lastSnapshot: DebugCoordinatesSnapshot | null = null;
+  let lastRenderedAt = Number.NEGATIVE_INFINITY;
+
+  const element = document.createElement('aside');
+  element.className = 'debug-coordinates-overlay';
+  element.setAttribute('aria-label', strings.title);
+  element.dataset.enabled = enabled ? 'true' : 'false';
+  element.hidden = !enabled;
+
+  const title = document.createElement('div');
+  title.className = 'debug-coordinates-overlay__title';
+
+  const list = document.createElement('dl');
+  list.className = 'debug-coordinates-overlay__list';
+
+  const fields = new Map<string, HTMLElement>();
+  const addField = (key: keyof DebugCoordinatesOverlayStrings['labels']) => {
+    const row = document.createElement('div');
+    row.className = 'debug-coordinates-overlay__row';
+    const term = document.createElement('dt');
+    term.className = 'debug-coordinates-overlay__label';
+    term.textContent = strings.labels[key];
+    term.dataset.debugCoordinatesLabel = key;
+    const value = document.createElement('dd');
+    value.className = 'debug-coordinates-overlay__value';
+    value.dataset.debugCoordinatesValue = key;
+    row.append(term, value);
+    list.appendChild(row);
+    fields.set(key, value);
+  };
+
+  addField('position');
+  addField('activeFloor');
+  addField('predictedFloor');
+  addField('cameraZoom');
+  addField('stairWidth');
+  addField('landing');
+  addField('stairNavArea');
+  addField('stairZone');
+  addField('room');
+
+  element.append(title, list);
+  container.appendChild(element);
+
+  const render = (snapshot: DebugCoordinatesSnapshot) => {
+    title.textContent = strings.title;
+    element.setAttribute('aria-label', strings.title);
+    element
+      .querySelectorAll<HTMLElement>('[data-debug-coordinates-label]')
+      .forEach((label) => {
+        const key = label.dataset
+          .debugCoordinatesLabel as keyof DebugCoordinatesOverlayStrings['labels'];
+        label.textContent = strings.labels[key];
+      });
+    fields.get('position')!.textContent =
+      `x ${formatNumber(snapshot.x)} · y ${formatNumber(
+        snapshot.y
+      )} · z ${formatNumber(snapshot.z)}`;
+    fields.get('activeFloor')!.textContent = snapshot.activeFloorId;
+    fields.get('predictedFloor')!.textContent = snapshot.predictedFloorId;
+    fields.get('cameraZoom')!.textContent = formatNumber(snapshot.cameraZoom);
+    fields.get('stairWidth')!.textContent = formatBoolean(
+      snapshot.insideStairWidth,
+      strings
+    );
+    fields.get('landing')!.textContent = formatBoolean(
+      snapshot.insideLanding,
+      strings
+    );
+    fields.get('stairNavArea')!.textContent = formatBoolean(
+      snapshot.insideStairNavArea,
+      strings
+    );
+    fields.get('stairZone')!.textContent = snapshot.stairZone;
+    fields.get('room')!.textContent = snapshot.roomId ?? strings.roomFallback;
+  };
+
+  if (enabled && lastSnapshot) {
+    render(lastSnapshot);
+  }
+
+  return {
+    element,
+    isEnabled() {
+      return !element.hidden;
+    },
+    setEnabled(next) {
+      element.hidden = !next;
+      element.dataset.enabled = next ? 'true' : 'false';
+      if (next && lastSnapshot) {
+        render(lastSnapshot);
+      }
+    },
+    setStrings(nextStrings) {
+      strings = {
+        ...defaultStrings,
+        ...nextStrings,
+        labels: {
+          ...defaultStrings.labels,
+          ...nextStrings.labels,
+        },
+        boolean: {
+          ...defaultStrings.boolean,
+          ...nextStrings.boolean,
+        },
+      };
+      if (lastSnapshot) {
+        render(lastSnapshot);
+      } else {
+        title.textContent = strings.title;
+        element.setAttribute('aria-label', strings.title);
+      }
+    },
+    update(snapshot, nowMs = performance.now()) {
+      lastSnapshot = snapshot;
+      if (element.hidden || nowMs - lastRenderedAt < updateIntervalMs) {
+        return;
+      }
+      lastRenderedAt = nowMs;
+      render(snapshot);
+    },
+    dispose() {
+      element.remove();
+    },
+  };
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2242,3 +2242,59 @@ html[data-hud-layout='mobile'] .audio-subtitles {
     flex: 0 0 auto;
   }
 }
+
+.debug-coordinates-overlay {
+  position: fixed;
+  inset-block-start: calc(env(safe-area-inset-top, 0px) + 0.85rem);
+  inset-inline-start: calc(env(safe-area-inset-left, 0px) + 0.85rem);
+  z-index: 26;
+  max-width: min(18rem, calc(100vw - 1.7rem));
+  padding: 0.7rem 0.8rem;
+  border: 1px solid rgba(86, 184, 255, 0.34);
+  border-radius: 0.75rem;
+  background: rgba(5, 12, 21, 0.78);
+  box-shadow: 0 10px 28px rgba(3, 9, 18, 0.42);
+  color: var(--hud-surface-text);
+  font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+  font-size: 0.72rem;
+  line-height: 1.35;
+  pointer-events: none;
+  backdrop-filter: blur(12px);
+}
+
+.debug-coordinates-overlay[hidden] {
+  display: none;
+}
+
+.debug-coordinates-overlay__title {
+  margin-bottom: 0.45rem;
+  color: rgba(214, 231, 255, 0.92);
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.debug-coordinates-overlay__list {
+  display: grid;
+  gap: 0.24rem;
+  margin: 0;
+}
+
+.debug-coordinates-overlay__row {
+  display: grid;
+  grid-template-columns: minmax(6.25rem, max-content) minmax(0, 1fr);
+  gap: 0.55rem;
+}
+
+.debug-coordinates-overlay__label {
+  color: var(--hud-surface-muted-text);
+}
+
+.debug-coordinates-overlay__value {
+  min-width: 0;
+  margin: 0;
+  color: #ffffff;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
### Motivation
- Provide QA and support an opt-in way to report exact XYZ/floor/stair positions without opening DevTools. 
- Keep diagnostics non-invasive and persistent per-session via a clear storage key so reviewers can opt-in or force via URL.

### Description
- Added a HUD Settings control `Debug coordinates` (`src/systems/controls/debugCoordinatesControl.ts`) that defaults off and persists under `danielsmith.io::debugCoordinates::v1`, with `?debugCoordinates=1` URL override support. 
- Implemented the lightweight overlay UI (`src/ui/hud/debugCoordinatesOverlay.ts`) that shows rounded `x/y/z`, `active` and `predicted` floor ids, `cameraZoom`, stair width/landing/nav-area booleans, current `stairZone`, and the `roomId`, updating at a modest cadence to avoid per-frame layout churn. 
- Hooked the control and overlay into the app (`src/main.ts`) with a test/debug API exposed as `window.portfolio.debugCoordinates.getState()` and `.setEnabled(boolean)`, and integrated snapshot sampling (stair/room/floor calculations) while preserving pointer interactions. 
- Added i18n types and getters plus localized strings for the new control/overlay in supported locales and pseudo-locale, and updated tests to exercise the new locale strings. 
- Styled the overlay to match the HUD theme (`src/ui/styles.css`) and documented opt-in overlay guardrails in `docs/guides/accessibility-overlays.md`.

### Testing
- Ran `npm run format:write` which completed successfully. 
- Ran `npm run lint` which completed successfully (only an import-order warning was auto-fixed). 
- Ran `npm run typecheck` which reported existing unrelated repository TypeScript issues (typecheck failure is unrelated to the added debug overlay). 
- Ran focused unit tests `npm run test:ci -- src/tests/i18n.test.ts src/tests/hudPanelCoordinator.test.ts src/tests/textFallbackAccessibility.test.ts` which passed. 
- Ran full unit suite `npm run test:ci` which passed (many tests exercised; failures seen earlier were due to unrelated, pre-existing repo type/test warnings). 
- Built production bundle with `npm run build` which succeeded. 
- Ran Playwright E2E `npm run test:e2e -- playwright/small-screen-hud.spec.ts`; browsers were installed during the run (`npx playwright install` and `npx playwright install-deps chromium`) and the three E2E checks passed. 
- Ran `npm run docs:check` and `npm run smoke` which both passed; link checker emitted external fetch warnings only. 
- A preview screenshot showing the overlay was captured at `/tmp/debug-coordinates-overlay.png` during verification. 

Residual notes: `tsc --noEmit` still surfaces unrelated type errors elsewhere in the repo; this change does not introduce those and the feature-specific tests and E2E checks passed in the verified environment. The branch is `codex/debug-coordinates-overlay` (commit added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23f41b6be0832f810baff492019c05)