### PR TITLE
🪜 Open upper stairwell landing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -255,7 +255,10 @@ import {
   createTokenPlaceRack,
   type TokenPlaceRackBuild,
 } from './scene/structures/tokenPlaceRack';
-import { createUpperLandingStub } from './scene/structures/upperLandingStub';
+import {
+  createUpperStairwellHoleBounds,
+  createUpperStairwellLanding,
+} from './scene/structures/upperLandingStub';
 import { createWallSegmentMeshes } from './scene/structures/wallSegmentsMesh';
 import {
   createWoveLoom,
@@ -1782,53 +1785,19 @@ function initializeImmersiveScene(
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
   );
-  const upperLandingClearance = toWorldUnits(0.05);
-  const upperLandingSolidStartZ = stairTopZ + upperLandingClearance;
-  const upperLandingDescentCutoutMaxZ =
-    stairTopZ + stairLandingTriggerMargin + upperLandingClearance;
-  const upperLandingDescentCutout = upperLandingRoom
-    ? {
-        minX: stairNavigationZones.explicitDescentCorridor.minX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-        minZ: upperLandingRoom.bounds.minZ,
-        maxZ: Math.min(
-          upperLandingRoom.bounds.maxZ,
-          upperLandingDescentCutoutMaxZ
-        ),
-      }
+  const upperStairwellHoleBounds = upperLandingRoom
+    ? createUpperStairwellHoleBounds({
+        roomBounds: upperLandingRoom.bounds,
+        stairCenterX,
+        stairHalfWidth,
+        stairwellMarginX,
+        stairHoleRange: stairLayout.stairHoleRange,
+      })
     : undefined;
-  const upperLandingStubBounds = upperLandingRoom
-    ? [
-        {
-          minX: upperLandingRoom.bounds.minX,
-          maxX: upperLandingDescentCutout!.minX,
-          minZ: upperLandingRoom.bounds.minZ,
-          maxZ: upperLandingRoom.bounds.maxZ,
-        },
-        {
-          minX: upperLandingDescentCutout!.maxX,
-          maxX: upperLandingRoom.bounds.maxX,
-          minZ: upperLandingRoom.bounds.minZ,
-          maxZ: upperLandingRoom.bounds.maxZ,
-        },
-      ].filter(
-        (bounds) =>
-          bounds.maxX - bounds.minX > 0 &&
-          bounds.maxZ - upperLandingSolidStartZ > 0
-      )
-    : [];
   const upperLandingCutouts =
-    upperLandingRoom && upperLandingDescentCutout
+    upperLandingRoom && upperStairwellHoleBounds
       ? {
-          upperLanding: [
-            upperLandingDescentCutout,
-            ...upperLandingStubBounds.map((bounds) => ({
-              minX: bounds.minX,
-              maxX: bounds.maxX,
-              minZ: upperLandingSolidStartZ,
-              maxZ: bounds.maxZ,
-            })),
-          ],
+          upperLanding: [upperStairwellHoleBounds],
         }
       : undefined;
   const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
@@ -1840,26 +1809,13 @@ function initializeImmersiveScene(
   });
   upperFloorGroup.add(upperFloorTiles.group);
 
-  // Keep only the explicit stairwell/descent handoff open. Room tiles and
-  // side stubs fill the walkable landing shoulders without a full-width seal
-  // or z-fight.
-
-  upperLandingStubBounds.forEach((bounds, index) => {
-    const upperLandingStub = createUpperLandingStub({
-      bounds,
-      landingMaxZ: stairTopZ,
+  if (upperStairwellHoleBounds) {
+    const upperStairwellLanding = createUpperStairwellLanding({
+      stairwellBounds: upperStairwellHoleBounds,
       elevation: upperFloorElevation,
-      thickness: STAIRCASE_CONFIG.landing.thickness,
-      landingClearance: upperLandingClearance,
-      material: {
-        color: 0x4c596b,
-        roughness: 0.58,
-        metalness: 0.06,
-      },
       guard: {
         height: 0.62,
         thickness: toWorldUnits(0.12),
-        inset: toWorldUnits(0.4),
         material: {
           color: 0x2a3241,
           roughness: 0.72,
@@ -1867,12 +1823,11 @@ function initializeImmersiveScene(
         },
       },
     });
-    upperLandingStub.group.name = `UpperLandingShoulderStub-${index + 1}`;
-    upperFloorGroup.add(upperLandingStub.group);
-    upperLandingStub.colliders.forEach((collider) =>
+    upperFloorGroup.add(upperStairwellLanding.group);
+    upperStairwellLanding.colliders.forEach((collider) =>
       upperFloorColliders.push(collider)
     );
-  });
+  }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
   const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -2,7 +2,9 @@ import { BoxGeometry, MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../../../assets/floorPlan';
+import { computeStairLayout } from '../../../systems/movement/stairLayout';
 import { createRoomFloorTiles } from '../floorTiles';
+import { createUpperStairwellHoleBounds } from '../upperLandingStub';
 
 const toWorldUnits = (value: number): number => value * FLOOR_PLAN_SCALE;
 
@@ -15,8 +17,17 @@ const overlaps = (
   bounds.minZ < cutout.maxZ &&
   bounds.maxZ > cutout.minZ;
 
+const contains = (
+  bounds: { minX: number; maxX: number; minZ: number; maxZ: number },
+  other: { minX: number; maxX: number; minZ: number; maxZ: number }
+): boolean =>
+  bounds.minX <= other.minX &&
+  bounds.maxX >= other.maxX &&
+  bounds.minZ <= other.minZ &&
+  bounds.maxZ >= other.maxZ;
+
 describe('createRoomFloorTiles', () => {
-  it('builds opaque upper-floor slabs with a targeted stairwell cutout', () => {
+  it('builds opaque upper-floor slabs with a layout-derived stairwell cutout', () => {
     const material = new MeshStandardMaterial({
       transparent: false,
       opacity: 1,
@@ -30,48 +41,36 @@ describe('createRoomFloorTiles', () => {
     const stairCenterX = toWorldUnits(6.2);
     const stairHalfWidth = toWorldUnits(3.1) / 2;
     const stairwellMarginX = toWorldUnits(0.2);
-    const descentCorridorInset = 0.75;
-    const stairTopZ = toWorldUnits(-5.3) - toWorldUnits(0.85) * 9;
-    const landingClearance = toWorldUnits(0.05);
-    const landingTriggerMargin = toWorldUnits(0.2);
-    const upperLandingSolidStartZ = stairTopZ + landingClearance;
-    const broadStairwellBounds = {
-      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-      minZ: upperLandingRoom!.bounds.minZ,
+    const layout = computeStairLayout({
+      baseZ: toWorldUnits(-5.3),
+      stepRun: toWorldUnits(0.85),
+      stepCount: 9,
+      landingDepth: toWorldUnits(2.6),
+      direction: 'negativeZ',
+      guardMargin: toWorldUnits(0.6),
+      stairwellMargin: toWorldUnits(0.4),
+    });
+    const stairwellCutout = createUpperStairwellHoleBounds({
+      roomBounds: upperLandingRoom!.bounds,
+      stairCenterX,
+      stairHalfWidth,
+      stairwellMarginX,
+      stairHoleRange: layout.stairHoleRange,
+    });
+    const descentOpening = {
+      minX: stairCenterX - stairHalfWidth,
+      maxX: stairCenterX + stairHalfWidth,
+      minZ: layout.topZ,
       maxZ: upperLandingRoom!.bounds.maxZ,
     };
-    const descentCorridorHalfWidth = Math.max(
-      stairHalfWidth - descentCorridorInset,
-      stairHalfWidth * 0.55
-    );
-    const stairwellCutout = {
-      minX: stairCenterX - descentCorridorHalfWidth,
-      maxX: stairCenterX + descentCorridorHalfWidth,
-      minZ: upperLandingRoom!.bounds.minZ,
-      maxZ: stairTopZ + landingTriggerMargin + landingClearance,
-    };
-    const shoulderStubCutouts = [
-      {
-        minX: upperLandingRoom!.bounds.minX,
-        maxX: stairwellCutout.minX,
-        minZ: upperLandingSolidStartZ,
-        maxZ: upperLandingRoom!.bounds.maxZ,
-      },
-      {
-        minX: stairwellCutout.maxX,
-        maxX: upperLandingRoom!.bounds.maxX,
-        minZ: upperLandingSolidStartZ,
-        maxZ: upperLandingRoom!.bounds.maxZ,
-      },
-    ];
+
     const build = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
       material,
       elevation: 4,
       thickness: 0.45,
       groupName: 'UpperFloorTiles',
       cutoutsByRoom: {
-        upperLanding: [stairwellCutout, ...shoulderStubCutouts],
+        upperLanding: [stairwellCutout],
       },
     });
 
@@ -81,28 +80,23 @@ describe('createRoomFloorTiles', () => {
 
     expect(build.group.name).toBe('UpperFloorTiles');
     expect(upperLandingTiles.length).toBeGreaterThan(0);
+
     const fillsLeftStairwellShoulder = upperLandingTiles.some(
       (tile) =>
-        tile.bounds.minX < broadStairwellBounds.minX &&
-        tile.bounds.maxX > broadStairwellBounds.minX &&
-        tile.bounds.maxX <= stairwellCutout.minX
+        tile.bounds.minX <= upperLandingRoom!.bounds.minX &&
+        tile.bounds.maxX <= stairwellCutout.minX &&
+        tile.bounds.minZ === upperLandingRoom!.bounds.minZ &&
+        tile.bounds.maxZ === upperLandingRoom!.bounds.maxZ
     );
     const fillsRightStairwellShoulder = upperLandingTiles.some(
       (tile) =>
         tile.bounds.minX >= stairwellCutout.maxX &&
-        tile.bounds.minX < broadStairwellBounds.maxX &&
-        tile.bounds.maxX > broadStairwellBounds.maxX
-    );
-    const fillsCentralLandingPastDescent = upperLandingTiles.some(
-      (tile) =>
-        tile.bounds.minX >= stairwellCutout.minX &&
-        tile.bounds.maxX <= stairwellCutout.maxX &&
-        tile.bounds.minZ >= stairwellCutout.maxZ &&
+        tile.bounds.maxX >= upperLandingRoom!.bounds.maxX &&
+        tile.bounds.minZ === upperLandingRoom!.bounds.minZ &&
         tile.bounds.maxZ === upperLandingRoom!.bounds.maxZ
     );
     expect(fillsLeftStairwellShoulder).toBe(true);
     expect(fillsRightStairwellShoulder).toBe(true);
-    expect(fillsCentralLandingPastDescent).toBe(true);
 
     for (const tile of build.tiles) {
       const geometry = tile.mesh.geometry as BoxGeometry;
@@ -113,9 +107,7 @@ describe('createRoomFloorTiles', () => {
 
     for (const tile of upperLandingTiles) {
       expect(overlaps(tile.bounds, stairwellCutout)).toBe(false);
-      for (const shoulderStubCutout of shoulderStubCutouts) {
-        expect(overlaps(tile.bounds, shoulderStubCutout)).toBe(false);
-      }
+      expect(contains(tile.bounds, descentOpening)).toBe(false);
     }
 
     expect(material.transparent).toBe(false);

--- a/src/scene/structures/__tests__/upperLandingStub.test.ts
+++ b/src/scene/structures/__tests__/upperLandingStub.test.ts
@@ -1,66 +1,106 @@
-import { BoxGeometry } from 'three';
+import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { createUpperLandingStub } from '../upperLandingStub';
+import { computeStairLayout } from '../../../systems/movement/stairLayout';
+import {
+  createUpperStairwellHoleBounds,
+  createUpperStairwellLanding,
+} from '../upperLandingStub';
 
-describe('createUpperLandingStub', () => {
-  it('creates a landing slab that starts past the stair landing', () => {
-    const result = createUpperLandingStub({
-      bounds: { minX: -4, maxX: 4, minZ: -20, maxZ: -8 },
-      landingMaxZ: -12,
-      elevation: 4,
-      thickness: 0.4,
-      landingClearance: 0.2,
-      material: { color: 0xffffff },
+const overlaps = (
+  bounds: { minX: number; maxX: number; minZ: number; maxZ: number },
+  other: { minX: number; maxX: number; minZ: number; maxZ: number }
+): boolean =>
+  bounds.minX < other.maxX &&
+  bounds.maxX > other.minX &&
+  bounds.minZ < other.maxZ &&
+  bounds.maxZ > other.minZ;
+
+describe('createUpperStairwellHoleBounds', () => {
+  it('matches the stair layout hole range plus side margin', () => {
+    const layout = computeStairLayout({
+      baseZ: -10.6,
+      stepRun: 1.7,
+      stepCount: 9,
+      landingDepth: 5.2,
+      direction: 'negativeZ',
+      guardMargin: 1.2,
+      stairwellMargin: 0.8,
     });
 
-    const slab = result.group.children.find(
-      (child) => child.name === 'UpperLandingStubSlab'
-    );
-    if (!slab) {
-      throw new Error('Expected slab mesh to be created');
-    }
+    const bounds = createUpperStairwellHoleBounds({
+      roomBounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+      stairCenterX: 12.4,
+      stairHalfWidth: 3.1,
+      stairwellMarginX: 0.4,
+      stairHoleRange: layout.stairHoleRange,
+    });
 
-    const geometry = slab.geometry as BoxGeometry;
-    expect(geometry.parameters.width).toBeCloseTo(8);
-    expect(geometry.parameters.depth).toBeCloseTo(3.8);
-    expect(slab.position.x).toBeCloseTo(0);
-    expect(slab.position.y).toBeCloseTo(3.8);
-    expect(slab.position.z).toBeCloseTo(-9.9);
+    expect(bounds.minX).toBeCloseTo(8.9);
+    expect(bounds.maxX).toBeCloseTo(15.9);
+    expect(bounds.minZ).toBeCloseTo(layout.stairHoleRange.minZ);
+    expect(bounds.maxZ).toBeCloseTo(-16);
   });
+});
 
-  it('adds a guard rail collider when configured', () => {
-    const result = createUpperLandingStub({
-      bounds: { minX: -4, maxX: 4, minZ: -20, maxZ: -8 },
-      landingMaxZ: -12,
-      elevation: 4,
-      thickness: 0.4,
-      landingClearance: 0.2,
-      material: { color: 0xffffff },
+describe('createUpperStairwellLanding', () => {
+  const stairwellBounds = { minX: 8.9, maxX: 15.9, minZ: -31.9, maxZ: -16 };
+  const descentPath = { minX: 10.05, maxX: 14.75, minZ: -25.9, maxZ: -16 };
+
+  it('does not add a slab or any mesh covering the descent opening', () => {
+    const result = createUpperStairwellLanding({
+      stairwellBounds,
+      elevation: 4.16,
       guard: {
-        height: 0.6,
-        thickness: 0.2,
-        inset: 0.4,
-        material: { color: 0xff0000 },
+        height: 0.62,
+        thickness: 0.24,
+        material: { color: 0x2a3241 },
       },
     });
 
-    const guard = result.group.children.find(
-      (child) => child.name === 'UpperLandingStubGuard'
-    );
-    if (!guard) {
-      throw new Error('Expected guard mesh to be created');
+    expect(result.group.name).toBe('UpperStairwellLanding');
+    expect(result.group.children.map((child) => child.name)).toEqual([
+      'UpperStairwellLandingGuardLeft',
+      'UpperStairwellLandingGuardRight',
+    ]);
+
+    for (const child of result.group.children) {
+      expect(child.name).not.toContain('Slab');
+      const mesh = child as Mesh;
+      const geometry = mesh.geometry as BoxGeometry;
+      const meshBounds = {
+        minX: mesh.position.x - geometry.parameters.width / 2,
+        maxX: mesh.position.x + geometry.parameters.width / 2,
+        minZ: mesh.position.z - geometry.parameters.depth / 2,
+        maxZ: mesh.position.z + geometry.parameters.depth / 2,
+      };
+      expect(overlaps(meshBounds, descentPath)).toBe(false);
     }
+  });
 
-    expect(guard.position.x).toBeCloseTo(0);
-    expect(guard.position.y).toBeCloseTo(4.3);
-    expect(guard.position.z).toBeCloseTo(-8.1);
+  it('adds guard colliders around non-traversable edges but not across the stair path', () => {
+    const result = createUpperStairwellLanding({
+      stairwellBounds,
+      elevation: 4.16,
+      guard: {
+        height: 0.62,
+        thickness: 0.24,
+        material: { color: 0x2a3241 },
+      },
+    });
 
-    expect(result.colliders).toHaveLength(1);
-    const [collider] = result.colliders;
-    expect(collider.minX).toBeCloseTo(-3.6);
-    expect(collider.maxX).toBeCloseTo(3.6);
-    expect(collider.minZ).toBeCloseTo(-8.2);
-    expect(collider.maxZ).toBeCloseTo(-8);
+    expect(result.colliders).toHaveLength(2);
+    expect(result.colliders[0].minX).toBeCloseTo(8.9);
+    expect(result.colliders[0].maxX).toBeCloseTo(9.14);
+    expect(result.colliders[0].minZ).toBeCloseTo(-31.9);
+    expect(result.colliders[0].maxZ).toBeCloseTo(-16);
+    expect(result.colliders[1].minX).toBeCloseTo(15.66);
+    expect(result.colliders[1].maxX).toBeCloseTo(15.9);
+    expect(result.colliders[1].minZ).toBeCloseTo(-31.9);
+    expect(result.colliders[1].maxZ).toBeCloseTo(-16);
+
+    for (const collider of result.colliders) {
+      expect(overlaps(collider, descentPath)).toBe(false);
+    }
   });
 });

--- a/src/scene/structures/upperLandingStub.ts
+++ b/src/scene/structures/upperLandingStub.ts
@@ -4,114 +4,160 @@ import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../../systems/collision';
 
-export interface UpperLandingGuardConfig {
-  /** Height of the guard rail measured from the landing surface. */
+export interface UpperStairwellHoleBoundsConfig {
+  /** World-space bounds of the upper landing room that owns the stair opening. */
+  roomBounds: Bounds2D;
+  /** Stair center from the navigation geometry. */
+  stairCenterX: number;
+  /** Half of the physical stair width used by movement. */
+  stairHalfWidth: number;
+  /** Extra side margin that keeps the visual void outside stair guard colliders. */
+  stairwellMarginX: number;
+  /** Z range computed by computeStairLayout from the same stair metrics as movement. */
+  stairHoleRange: { minZ: number; maxZ: number };
+}
+
+export interface UpperStairwellGuardConfig {
+  /** Height of the guard rail measured from the upper-floor surface. */
   height: number;
-  /** Thickness of the guard rail along the Z axis. */
+  /** Thickness of the guard rail measured perpendicular to the guarded edge. */
   thickness: number;
-  /** Inset applied to both sides of the guard rail along the X axis. */
-  inset: number;
-  /** Optional material overrides for the guard rail. */
-  material?: MeshStandardMaterialParameters;
-}
-
-export interface UpperLandingStubConfig {
-  /** World-space bounds of the upper landing room. */
-  bounds: Bounds2D;
-  /** World-space Z coordinate where the stair landing ends (south edge). */
-  landingMaxZ: number;
-  /** Height of the landing surface measured from world origin. */
-  elevation: number;
-  /** Thickness of the landing slab. */
-  thickness: number;
-  /** Gap maintained between the landing slab and the stair landing. */
-  landingClearance: number;
-  /** Material applied to the landing stub. */
+  /** Material applied to the guard rails. */
   material: MeshStandardMaterialParameters;
-  /** Optional guard rail configuration. */
-  guard?: UpperLandingGuardConfig;
 }
 
-export interface UpperLandingStubBuild {
+export interface UpperStairwellLandingConfig {
+  /** Clipped world-space bounds of the open stairwell void. */
+  stairwellBounds: Bounds2D;
+  /** Height of the upper floor surface measured from world origin. */
+  elevation: number;
+  /** Guard rail settings for sealed/non-traversable edges. */
+  guard: UpperStairwellGuardConfig;
+}
+
+export interface UpperStairwellLandingBuild {
   group: Group;
   colliders: RectCollider[];
 }
 
-const GROUP_NAME = 'UpperLandingStub';
-const SLAB_NAME = 'UpperLandingStubSlab';
-const GUARD_NAME = 'UpperLandingStubGuard';
+const GROUP_NAME = 'UpperStairwellLanding';
+const LEFT_GUARD_NAME = 'UpperStairwellLandingGuardLeft';
+const RIGHT_GUARD_NAME = 'UpperStairwellLandingGuardRight';
+const MIN_DIMENSION = 0.05;
 
 /**
- * Builds a placeholder upper landing slab that bridges the stair landing to the
- * future second-floor layout. The geometry is intentionally minimal so future
- * automation can reshape or reskin it without rewriting scene wiring.
+ * Derives the second-floor stairwell void from the same computeStairLayout
+ * stairHoleRange used by navigation. Clipping to the upper-landing room keeps
+ * the visible hole, floor cutouts, and guard colliders coupled to movement so
+ * future stair metric tweaks cannot leave a solid slab over the descent path.
  */
-export function createUpperLandingStub(
-  config: UpperLandingStubConfig
-): UpperLandingStubBuild {
+export function createUpperStairwellHoleBounds(
+  config: UpperStairwellHoleBoundsConfig
+): Bounds2D {
+  const halfWidth = config.stairHalfWidth + config.stairwellMarginX;
+  const bounds = {
+    minX: config.stairCenterX - halfWidth,
+    maxX: config.stairCenterX + halfWidth,
+    minZ: Math.max(config.roomBounds.minZ, config.stairHoleRange.minZ),
+    maxZ: Math.min(config.roomBounds.maxZ, config.stairHoleRange.maxZ),
+  };
+
+  if (
+    bounds.maxX - bounds.minX <= MIN_DIMENSION ||
+    bounds.maxZ - bounds.minZ <= MIN_DIMENSION
+  ) {
+    throw new Error(
+      'Upper stairwell hole bounds must overlap the landing room.'
+    );
+  }
+
+  return bounds;
+}
+
+const addGuard = ({
+  group,
+  colliders,
+  material,
+  name,
+  centerX,
+  centerZ,
+  elevation,
+  height,
+  thickness,
+  depth,
+}: {
+  group: Group;
+  colliders: RectCollider[];
+  material: MeshStandardMaterial;
+  name: string;
+  centerX: number;
+  centerZ: number;
+  elevation: number;
+  height: number;
+  thickness: number;
+  depth: number;
+}) => {
+  const geometry = new BoxGeometry(thickness, height, depth);
+  const guard = new Mesh(geometry, material);
+  guard.name = name;
+  guard.position.set(centerX, elevation + height / 2, centerZ);
+  group.add(guard);
+
+  colliders.push({
+    minX: centerX - thickness / 2,
+    maxX: centerX + thickness / 2,
+    minZ: centerZ - depth / 2,
+    maxZ: centerZ + depth / 2,
+  });
+};
+
+/**
+ * Builds the upstairs stairwell railings without placing any slab over the
+ * descent opening. The existing StaircaseLanding mesh remains the walkable top
+ * landing surface; this helper only marks the dangerous side edges so the
+ * central stair path stays visible and traversable.
+ */
+export function createUpperStairwellLanding(
+  config: UpperStairwellLandingConfig
+): UpperStairwellLandingBuild {
   const group = new Group();
   group.name = GROUP_NAME;
   const colliders: RectCollider[] = [];
 
-  const width = config.bounds.maxX - config.bounds.minX;
-  if (width <= 0) {
-    throw new Error('Upper landing bounds must have a positive width.');
+  const depth = config.stairwellBounds.maxZ - config.stairwellBounds.minZ;
+  if (depth <= MIN_DIMENSION) {
+    throw new Error('Upper stairwell landing requires a positive guard span.');
   }
 
-  const startZ = Math.max(
-    config.bounds.minZ,
-    config.landingMaxZ + config.landingClearance
-  );
-  const depth = config.bounds.maxZ - startZ;
-  if (depth <= 0) {
-    throw new Error(
-      'Upper landing bounds must extend beyond the stair landing.'
-    );
-  }
+  const guardMaterial = new MeshStandardMaterial(config.guard.material);
+  const centerZ =
+    (config.stairwellBounds.minZ + config.stairwellBounds.maxZ) / 2;
 
-  const slabMaterial = new MeshStandardMaterial(config.material);
-  const slabGeometry = new BoxGeometry(width, config.thickness, depth);
-  const slab = new Mesh(slabGeometry, slabMaterial);
-  slab.name = SLAB_NAME;
-  slab.position.set(
-    config.bounds.minX + width / 2,
-    config.elevation - config.thickness / 2,
-    startZ + depth / 2
-  );
-  group.add(slab);
+  addGuard({
+    group,
+    colliders,
+    material: guardMaterial,
+    name: LEFT_GUARD_NAME,
+    centerX: config.stairwellBounds.minX + config.guard.thickness / 2,
+    centerZ,
+    elevation: config.elevation,
+    height: config.guard.height,
+    thickness: config.guard.thickness,
+    depth,
+  });
 
-  if (config.guard) {
-    const guardMaterial = new MeshStandardMaterial(
-      config.guard.material ?? config.material
-    );
-    const guardLength = Math.max(0, width - config.guard.inset * 2);
-    if (
-      guardLength > 0 &&
-      config.guard.thickness > 0 &&
-      config.guard.height > 0
-    ) {
-      const guardGeometry = new BoxGeometry(
-        guardLength,
-        config.guard.height,
-        config.guard.thickness
-      );
-      const guard = new Mesh(guardGeometry, guardMaterial);
-      guard.name = GUARD_NAME;
-      guard.position.set(
-        config.bounds.minX + config.guard.inset + guardLength / 2,
-        config.elevation + config.guard.height / 2,
-        config.bounds.maxZ - config.guard.thickness / 2
-      );
-      group.add(guard);
-
-      colliders.push({
-        minX: guard.position.x - guardLength / 2,
-        maxX: guard.position.x + guardLength / 2,
-        minZ: guard.position.z - config.guard.thickness / 2,
-        maxZ: guard.position.z + config.guard.thickness / 2,
-      });
-    }
-  }
+  addGuard({
+    group,
+    colliders,
+    material: guardMaterial,
+    name: RIGHT_GUARD_NAME,
+    centerX: config.stairwellBounds.maxX - config.guard.thickness / 2,
+    centerZ,
+    elevation: config.elevation,
+    height: config.guard.height,
+    thickness: config.guard.thickness,
+    depth,
+  });
 
   return { group, colliders };
 }


### PR DESCRIPTION
### Motivation
- Fix the upstairs visual regression where the upper landing produced a solid cuboid over the stairs by making the visible stairwell opening driven by the same stair layout used for navigation so visuals and movement stay in sync.

### Description
- Replace the placeholder landing slab with a layout-derived stairwell hole and side guards by adding `createUpperStairwellHoleBounds` and `createUpperStairwellLanding` in `src/scene/structures/upperLandingStub.ts` so the central descent remains visible and traversable.
- Wire the new stairwell helpers into scene assembly in `src/main.ts` so `createRoomFloorTiles` receives an upper-floor cutout derived from `computeStairLayout().stairHoleRange`, and add guard meshes + colliders that flank but do not block the descent corridor.
- Update/extend tests in `src/scene/structures/__tests__/upperLandingStub.test.ts` and `src/scene/structures/__tests__/floorTiles.test.ts` to assert hole bounds match layout, no slab covers the descent opening, guard colliders exist on non-traversable edges, and floor tiles honor cutouts.

### Testing
- Ran formatting and lint: `npm run format:write` (ok) and `npm run lint` (ok).
- Unit tests: `npm run test:ci -- src/scene/structures/__tests__/upperLandingStub.test.ts src/scene/structures/__tests__/floorTiles.test.ts src/tests/movement/stairLayout.test.ts src/tests/movement/stairTransitions.test.ts` — initial assertion adjusted then re-run; final `npm run test:ci` completed with all suites passing (`141 files, 1046 tests` passed).
- Build and e2e: `npm run build` (ok) and `npm run test:e2e -- playwright/small-screen-hud.spec.ts` — initially failed due to missing Playwright browsers, then after `npx playwright install chromium` and `npx playwright install-deps chromium` the e2e spec passed (3 tests passed).
- Docs & smoke: `npm run docs:check` passed (link checker emitted transient fetch warnings) and `npm run smoke` passed.
- Typecheck: `npm run typecheck` reported pre-existing, unrelated TypeScript errors in other areas of the repo and was not fully green; none of the reported type errors are introduced by the changed files in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24990c2b9c832fa2418cea517c6031)