### PR TITLE
Add upstairs/stairs regression tests, POI suppression unit test, and QA runbook

### DIFF
--- a/docs/qa/upstairs-stairs.md
+++ b/docs/qa/upstairs-stairs.md
@@ -10,7 +10,7 @@ http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
 ## Enable debug coordinates
 
 1. Open **Settings** in the HUD.
-2. Press **Show debug coordinates**.
+2. Press **Debug coordinates off**.
 3. Confirm the overlay appears with position, active floor, predicted floor, stair zone, and room.
 4. Optional console check: `window.portfolio.debugCoordinates.getState()` should mirror the overlay.
 

--- a/docs/qa/upstairs-stairs.md
+++ b/docs/qa/upstairs-stairs.md
@@ -1,0 +1,54 @@
+# Upstairs and stair QA runbook
+
+Use this checklist when reviewing stairwell, upper landing, second-floor room, or debug-coordinate
+changes. Keep the immersive preview URL pinned to:
+
+```text
+http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
+```
+
+## Enable debug coordinates
+
+1. Open **Settings** in the HUD.
+2. Press **Show debug coordinates**.
+3. Confirm the overlay appears with position, active floor, predicted floor, stair zone, and room.
+4. Optional console check: `window.portfolio.debugCoordinates.getState()` should mirror the overlay.
+
+## Stairs up
+
+1. Start on the ground floor and walk to the stair base near **X 12.40, Z -10.60**.
+2. Move north/up the stair ramp through **X 12.40, Z -18.25**.
+3. Continue to the top handoff near **X 12.40, Z -26.00**.
+4. Verify **Active floor** becomes `upper`, **Predicted floor** stays `upper`, and the avatar height
+   sits on the second-floor landing instead of clipping through the ground floor.
+
+## Upper landing regression
+
+1. With the active floor `upper`, stand on the landing edge near **X 17.40, Z -25.20**.
+2. Nudge slightly downward along the landing edge, sampling around **Z -25.35**, **Z -25.50**, and
+   **Z -25.65**.
+3. Verify the active floor remains `upper`; this is the screenshot-4 accidental-teleport guard.
+4. Move back to the center of the stair opening near **X 12.40, Z -25.20** and verify intentional
+   descent still switches the active floor to `ground`.
+
+## Second-floor rooms
+
+1. From the upper landing, walk west into **Creators Studio** around **X -8.00, Z -20.00**.
+2. Walk east/south into **Loft Library** around **X 10.00, Z -4.00**.
+3. Walk south into **Focus Pods** around **X 0.00, Z 18.00**.
+4. Verify the debug overlay reports `upper`, each room name/id changes as expected, and movement does
+   not snap back to the ground floor while crossing upper-floor doorways.
+
+## Floor-specific visuals and labels
+
+1. While upstairs, scan the ground-floor POI locations from the landing and upper rooms.
+2. Verify ground POI labels, visited checkmarks, LEDs, and tooltip markers do not bleed through the
+   second floor.
+3. Optional console check: `window.portfolio.poi.getTooltipState()` should show no visible ground
+   marker IDs while the active floor is `upper`.
+
+## Stairwell visibility from upstairs
+
+1. Stand on the upper landing and look toward the stair opening.
+2. Verify the opening shows the usable stairs down, not a solid cuboid or blocked floor patch.
+3. Walk through the center of the opening to descend, then walk back up to confirm round-trip travel.

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -292,7 +292,7 @@ test('debug coordinates and upstairs POI state stay floor-aware', async ({
   expect(tooltipState.visibleMarkerLabelCount).toBe(0);
   expect(tooltipState.activeInWorldTooltipCount).toBe(0);
   expect(tooltipState.totalInWorldTooltipCount).toBe(0);
-  expect(tooltipState.visibleMarkerLabelPoiIds).not.toEqual(
-    expect.arrayContaining(GROUND_POI_IDS)
-  );
+  for (const groundPoiId of GROUND_POI_IDS) {
+    expect(tooltipState.visibleMarkerLabelPoiIds).not.toContain(groundPoiId);
+  }
 });

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,36 +1,148 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 
+const GROUND_POI_IDS = [
+  'futuroptimist-living-room-tv',
+  'flywheel-studio-flywheel',
+  'danielsmith-portfolio-table',
+  'sigma-kitchen-workbench',
+  'dspace-backyard-rocket',
+];
+
+type FloorId = 'ground' | 'upper';
+
+type StairTransitionZone =
+  | 'lowerStairEntrance'
+  | 'stairRampBody'
+  | 'upperLanding'
+  | 'safeUpperFloor'
+  | 'explicitDescentCorridor'
+  | 'outsideStairs';
+
 type TestWorldApi = {
-  movePlayerTo(target: { x: number; z: number }): void;
+  movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+  getActiveFloor(): FloorId;
+  getPlayerPosition(): { x: number; y: number; z: number };
+  predictFloorAt(target: {
+    x: number;
+    z: number;
+    currentFloor?: FloorId;
+  }): FloorId;
+  getStairTransitionZone(target: {
+    x: number;
+    z: number;
+    currentFloor?: FloorId;
+  }): StairTransitionZone;
   getStairMetrics(): {
     stairCenterX: number;
     stairHalfWidth: number;
     stairBottomZ: number;
     stairTopZ: number;
     stairLandingMinZ: number;
+    stairLandingMaxZ: number;
     stairLandingDepth: number;
+    stairDirection: 1 | -1;
     upperFloorElevation: number;
   };
+};
+
+type DebugCoordinatesApi = {
+  getState(): {
+    enabled: boolean;
+    x: number;
+    y: number;
+    z: number;
+    activeFloorId: FloorId;
+    predictedStairFloorId: FloorId;
+    stairZone: StairTransitionZone;
+    currentRoomId: string | null;
+  };
+  setEnabled(enabled: boolean): void;
+};
+
+type TooltipState = {
+  worldTooltipVisible: boolean;
+  worldTooltipPoiId: string | null;
+  worldTooltipTitle: string | null;
+  visibleMarkerLabelCount: number;
+  visibleMarkerLabelPoiIds: string[];
+  activeInWorldTooltipCount: number;
+  totalInWorldTooltipCount: number;
 };
 
 type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
+    debugCoordinates?: DebugCoordinatesApi;
+    poi?: {
+      getTooltipState(): TooltipState;
+    };
   };
 };
 
 test.setTimeout(150_000);
 
-async function waitForImmersiveReady(page: import('@playwright/test').Page) {
+async function waitForImmersiveReady(page: Page) {
   await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
     () => document.documentElement.dataset.appMode === 'immersive',
     undefined,
     { timeout: IMMERSIVE_READY_TIMEOUT_MS }
   );
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-app-mode',
+    'immersive'
+  );
+  await expect(page.locator('#app canvas')).toHaveCount(1);
+}
+
+async function getStairMetrics(page: Page) {
+  return page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getStairMetrics();
+  });
+}
+
+async function movePlayerTo(
+  page: Page,
+  target: { x: number; z: number; floorId?: FloorId }
+) {
+  await page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    world.movePlayerTo(next);
+  }, target);
+  await page.waitForTimeout(150);
+}
+
+async function getWorldState(page: Page) {
+  return page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return {
+      activeFloor: world.getActiveFloor(),
+      position: world.getPlayerPosition(),
+    };
+  });
+}
+
+async function getTooltipState(page: Page): Promise<TooltipState> {
+  return page.evaluate(() => {
+    const poi = (window as PortfolioWindow).portfolio?.poi;
+    if (!poi) {
+      throw new Error('POI API unavailable');
+    }
+    return poi.getTooltipState();
+  });
 }
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
@@ -38,61 +150,149 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
-
-  const movePlayerTo = async (target: { x: number; z: number }) => {
-    await page.evaluate((next) => {
-      const { portfolio } = window as PortfolioWindow;
-      const world = portfolio?.world;
-      if (!world) {
-        throw new Error('World API unavailable');
-      }
-      world.movePlayerTo(next);
-    }, target);
-    await page.waitForTimeout(150);
-  };
-
-  const metrics = await page.evaluate(() => {
-    const { portfolio } = window as PortfolioWindow;
-    const world = portfolio?.world;
-    if (!world) {
-      throw new Error('World API unavailable');
-    }
-    return world.getStairMetrics();
-  });
-
   const {
     stairCenterX,
     stairBottomZ,
     stairTopZ,
     stairLandingMinZ,
     stairLandingDepth,
-  } = metrics;
+  } = await getStairMetrics(page);
 
   // Start on ground.
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Move to the base of the staircase on the ground floor.
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.3 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Enter the ramp and ascend to the upper floor.
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.1 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.1 });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Roam deeper onto the upper landing and confirm we stay upstairs.
   const landingRoamZ =
     stairLandingMinZ + Math.min(stairLandingDepth * 0.5, 0.6);
-  await movePlayerTo({ x: stairCenterX, z: landingRoamZ });
+  await movePlayerTo(page, { x: stairCenterX, z: landingRoamZ });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
-  // Return toward the stairs, enter the explicit descent handoff, then
-  // continue down the ramp. The helper teleports between sampled positions,
-  // so include the narrow handoff band that real movement crosses frame by frame.
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.15 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ + 0.7 });
+  // Return toward the stairs, enter the explicit descent handoff, then continue down the ramp.
+  // The helper teleports between sampled positions, so include the narrow handoff band that real
+  // movement crosses frame by frame.
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.15 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.35 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.35 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('upper landing edge nudges stay upstairs until the descent corridor is entered', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const { stairCenterX, stairTopZ } = await getStairMetrics(page);
+  const screenshotLandingEdge = {
+    x: stairCenterX + 5,
+    z: stairTopZ + 0.7,
+    floorId: 'upper' as const,
+  };
+
+  await movePlayerTo(page, screenshotLandingEdge);
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const edgeState = await page.evaluate((target) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return {
+      predicted: world.predictFloorAt({ ...target, currentFloor: 'upper' }),
+      zone: world.getStairTransitionZone({ ...target, currentFloor: 'upper' }),
+    };
+  }, screenshotLandingEdge);
+  expect(edgeState).toEqual({ predicted: 'upper', zone: 'safeUpperFloor' });
+
+  // Regression guard for the screenshot-4 failure: small downward nudges along the landing edge
+  // should not be treated as an intentional descent through the stairwell portal.
+  for (const z of [stairTopZ + 0.55, stairTopZ + 0.4, stairTopZ + 0.25]) {
+    await movePlayerTo(page, { x: screenshotLandingEdge.x, z });
+    await expect(html).toHaveAttribute('data-active-floor', 'upper');
+  }
+
+  const stillUpstairs = await getWorldState(page);
+  expect(stillUpstairs.activeFloor).toBe('upper');
+
+  // Moving back to the center of the stair opening remains an intentional descent.
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('debug coordinates and upstairs POI state stay floor-aware', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const { stairCenterX, stairTopZ, stairLandingMinZ, stairLandingDepth } =
+    await getStairMetrics(page);
+  const landingInteriorZ =
+    stairLandingMinZ + Math.min(stairLandingDepth * 0.5, 0.6);
+
+  await page.evaluate(() => {
+    const debugCoordinates = (window as PortfolioWindow).portfolio
+      ?.debugCoordinates;
+    if (!debugCoordinates) {
+      throw new Error('Debug coordinates API unavailable');
+    }
+    debugCoordinates.setEnabled(true);
+  });
+
+  const debugToggle = page.locator('.debug-coordinates-toggle');
+  const debugOverlay = page.locator('.debug-coordinates');
+  await expect(debugToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(debugOverlay).toBeVisible();
+
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.1 });
+  await movePlayerTo(page, { x: stairCenterX, z: landingInteriorZ });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  await expect(debugOverlay).toContainText('upper');
+  await expect(debugOverlay).toContainText(
+    /-?\d+\.\d{2},\s*-?\d+\.\d{2},\s*-?\d+\.\d{2}/
+  );
+
+  const debugState = await page.evaluate(() => {
+    const debugCoordinates = (window as PortfolioWindow).portfolio
+      ?.debugCoordinates;
+    if (!debugCoordinates) {
+      throw new Error('Debug coordinates API unavailable');
+    }
+    return debugCoordinates.getState();
+  });
+  expect(debugState.enabled).toBe(true);
+  expect(debugState.activeFloorId).toBe('upper');
+  expect(debugState.predictedStairFloorId).toBe('upper');
+  expect(debugState.currentRoomId).toBeTruthy();
+
+  const tooltipState = await getTooltipState(page);
+  expect(tooltipState.worldTooltipVisible).toBe(false);
+  expect(tooltipState.worldTooltipPoiId).toBeNull();
+  expect(tooltipState.worldTooltipTitle).toBeNull();
+  expect(tooltipState.visibleMarkerLabelCount).toBe(0);
+  expect(tooltipState.activeInWorldTooltipCount).toBe(0);
+  expect(tooltipState.totalInWorldTooltipCount).toBe(0);
+  expect(tooltipState.visibleMarkerLabelPoiIds).not.toEqual(
+    expect.arrayContaining(GROUND_POI_IDS)
+  );
 });

--- a/src/tests/floorVisibilityController.test.ts
+++ b/src/tests/floorVisibilityController.test.ts
@@ -133,6 +133,33 @@ describe('floor visibility controller', () => {
     expect(groundPoi.displayHighlight?.material.opacity).toBe(0);
   });
 
+  it('keeps hidden ground POI chrome suppressed when animations re-apply visuals upstairs', () => {
+    const groundPoi = createPoiInstance('studio');
+    const controller = createFloorVisibilityController({
+      initialFloorId: 'upper',
+      poiInstances: [groundPoi],
+      getPoiFloorId: createPoiFloorResolver(FLOOR_PLAN_LEVELS),
+    });
+
+    groundPoi.label!.visible = true;
+    groundPoi.labelMaterial!.opacity = 0.9;
+    groundPoi.visitedHighlight!.mesh.visible = true;
+    groundPoi.visitedHighlight!.material.opacity = 0.7;
+    groundPoi.visitedBadge!.mesh.visible = true;
+    groundPoi.displayHighlight!.mesh.visible = true;
+    groundPoi.displayHighlight!.material.opacity = 0.6;
+
+    expect(controller.applyPoiVisualState(groundPoi)).toBe(false);
+    expect(groundPoi.group.visible).toBe(false);
+    expect(groundPoi.label?.visible).toBe(false);
+    expect(groundPoi.labelMaterial?.opacity).toBe(0);
+    expect(groundPoi.visitedHighlight?.mesh.visible).toBe(false);
+    expect(groundPoi.visitedHighlight?.material.opacity).toBe(0);
+    expect(groundPoi.visitedBadge?.mesh.visible).toBe(false);
+    expect(groundPoi.displayHighlight?.mesh.visible).toBe(false);
+    expect(groundPoi.displayHighlight?.material.opacity).toBe(0);
+  });
+
   it('keeps upper POIs visible when the upper floor is active', () => {
     const upperPoi = createPoiInstance('loftLibrary');
     const controller = createFloorVisibilityController({


### PR DESCRIPTION
### Motivation
- Prevent regressions that accidentally teleport upstairs players to the ground floor by adding focused automated coverage around the stair opening and landing edge.
- Ensure floor-specific visuals (POI labels, visited checkmarks, LEDs) remain suppressed when the upper floor is active so ground-floor chrome cannot bleed through.
- Provide a short manual QA runbook so reviewers and testers can reproduce and verify stair/landing/second-floor behavior with debug coordinates.

### Description
- Extend `playwright/immersive-stairs-roundtrip.spec.ts` with typed helpers (`getStairMetrics`, `movePlayerTo`, `getWorldState`, `getTooltipState`), debug-coordinate toggles/assertions, and the upper-landing nudge regression guard to verify small downward nudges do not force an unintended floor transition.
- Add a unit regression in `src/tests/floorVisibilityController.test.ts` that ensures hidden ground POI chrome (labels, visited highlights, badges, and display highlights) remains suppressed if visuals are re-applied while `upper` is active.
- Add a concise manual QA runbook at `docs/qa/upstairs-stairs.md` with steps to enable debug coordinates and reproducible coordinates/steps for stairs, landing edge, second-floor rooms, visual bleed-through checks, and stairwell visibility.
- Small test and lint hygiene changes (fix unused var, format) to keep the new test stable in CI.

Files changed:
- `playwright/immersive-stairs-roundtrip.spec.ts` (E2E regressions and debug overlay assertions)
- `src/tests/floorVisibilityController.test.ts` (unit regression for POI suppression)
- `docs/qa/upstairs-stairs.md` (manual QA runbook)

### Testing
- Ran formatting: `npm run format:write` (succeeded).
- Lint: `npm run lint` (succeeded after removing an unused var in the new spec).
- Type-check: `npm run typecheck` (failed due to pre-existing, project-wide TypeScript errors unrelated to these changes; this is a baseline issue and not introduced by this PR).
- Unit tests: `npm run test:ci` (Vitest run completed; test suite passed locally with existing baseline tests and the new `floorVisibilityController` regression test included).
- Focused unit: `npm run test:ci -- src/tests/floorVisibilityController.test.ts` (passed).
- End-to-end (Playwright): `npm run test:e2e -- playwright/immersive-stairs-roundtrip.spec.ts` (passed after installing Playwright browsers and host deps in the ephemeral environment), and `npm run test:e2e -- playwright/small-screen-hud.spec.ts playwright/immersive-zoom.spec.ts` (both passed).
- Build and smoke: `npm run build` and `npm run smoke` (both succeeded; `docs:check` ran and passed with link-check warnings for unreachable external sites).

Residual risk & follow-ups:
- `npm run typecheck` reports pre-existing type issues across the repo; these are outside the scope of this change but should be triaged separately to enable full type-safety gating in CI.
- Playwright tests require browsers and platform deps in CI (`npx playwright install` / `npx playwright install-deps`), so ensure CI runner has those steps (the repo’s CI already handles Playwright in CI, but local runs may need the install step).
- If future scene geometry shifts, the screenshot-edge coordinates in the spec or QA doc may need small adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f63b8800832fa0417cc90110589a)