### PR TITLE
Add upstairs/stair regression e2e coverage and QA runbook

### DIFF
--- a/docs/qa/upstairs-stairs.md
+++ b/docs/qa/upstairs-stairs.md
@@ -1,0 +1,50 @@
+# Upstairs stairs QA runbook
+
+Use this runbook when reviewing stairwell, landing, and second-floor edits. Load the
+immersive scene with failover disabled:
+
+```text
+http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
+```
+
+## Enable debug coordinates
+
+1. Open **Settings** with the `H` key or the Settings button.
+2. Turn **Debug coordinates** on.
+3. Confirm the overlay shows `XYZ`, `Active floor`, `Predicted stair floor`,
+   `Stair zone`, and `Room`.
+
+## Stair reference coordinates
+
+Approximate current world coordinates:
+
+| Area                         | Expected floor         | XYZ / zone to check                              |
+| ---------------------------- | ---------------------- | ------------------------------------------------ |
+| Stair base                   | Ground                 | `x≈12.40`, `z≈-10.30`, lower stair entrance      |
+| Stair middle                 | Ground while ascending | `x≈12.40`, `z≈-18.25`, stair ramp body           |
+| Stair top / landing          | Upper                  | `x≈12.40`, `z≈-26.00`, upper landing             |
+| Landing edge regression spot | Upper                  | `x≈16.70`, `z≈-25.20`, safe upper floor          |
+| Intentional descent corridor | Ground handoff         | `x≈12.40`, `z≈-25.20`, explicit descent corridor |
+| Loft Library                 | Upper                  | `x≈12.00`, `z≈-4.00`, room `loftLibrary`         |
+| Focus Pods                   | Upper                  | `x≈0.00`, `z≈20.00`, room `focusPods`            |
+
+## QA steps
+
+1. **Stairs up:** Start downstairs, walk to the stair base, then continue up the
+   stairs. The overlay should switch from `ground` to `upper` only near the top
+   stair / landing zone.
+2. **Landing:** Stand near the landing edge regression spot (`x≈16.70`,
+   `z≈-25.20`) and nudge toward the lower stairs. `Active floor` and
+   `Predicted stair floor` should remain `upper` unless the avatar is centered
+   in the explicit descent corridor.
+3. **Second-floor rooms:** Walk from the landing into Loft Library and Focus
+   Pods. The overlay should stay on `upper` and report the expected room when
+   inside each room.
+4. **Ground POI / LED bleed-through:** While upstairs, verify ground POI labels,
+   visited checkmarks, and room LEDs are hidden. No ground marker tooltip should
+   appear when moving around upstairs rooms.
+5. **Stairwell visibility from upstairs:** From the upper landing, confirm the
+   stair opening shows usable stairs down, not a solid cuboid or closed floor.
+6. **Intentional descent:** Move to the center of the stairwell at
+   `x≈12.40`, `z≈-25.20`, then continue down the ramp. The active floor should
+   change to `ground`, and it should remain ground at the stair base.

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,36 +1,200 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const GROUND_POI_IDS = [
+  'futuroptimist-living-room-tv',
+  'flywheel-studio-flywheel',
+  'jobbot-studio-terminal',
+  'f2clipboard-kitchen-console',
+  'sigma-kitchen-workbench',
+  'wove-kitchen-loom',
+  'axel-studio-tracker',
+  'tokenplace-studio-cluster',
+  'gabriel-studio-sentry',
+  'gitshelves-living-room-installation',
+  'pr-reaper-backyard-console',
+];
+
+type FloorId = 'ground' | 'upper';
+
+type StairTransitionZone =
+  | 'lowerStairEntrance'
+  | 'stairRampBody'
+  | 'upperLanding'
+  | 'safeUpperFloor'
+  | 'explicitDescentCorridor'
+  | 'outsideStairs';
+
+type StairMetrics = {
+  stairCenterX: number;
+  stairHalfWidth: number;
+  stairBottomZ: number;
+  stairTopZ: number;
+  stairLandingMinZ: number;
+  stairLandingMaxZ: number;
+  stairLandingDepth: number;
+  stairDirection: 1 | -1;
+  upperFloorElevation: number;
+};
+
+type DebugCoordinatesState = {
+  enabled: boolean;
+  x: number;
+  y: number;
+  z: number;
+  activeFloorId: FloorId;
+  predictedStairFloorId: FloorId;
+  cameraZoom: number;
+  insideStairWidth: boolean;
+  insideLanding: boolean;
+  insideStairNavArea: boolean;
+  stairZone: StairTransitionZone;
+  currentRoomId: string | null;
+};
+
+type PoiTooltipState = {
+  overlayVisiblePoiId: string | null;
+  worldTooltipVisible: boolean;
+  worldTooltipPoiId: string | null;
+  worldTooltipTitle: string | null;
+  markerLabelVisible: boolean;
+  markerLabelPoiId: string | null;
+  visibleMarkerLabelCount: number;
+  visibleMarkerLabelPoiIds: string[];
+  activePoiMarkerLabelVisible: boolean;
+  activeInWorldTooltipCount: number;
+  totalInWorldTooltipCount: number;
+};
 
 type TestWorldApi = {
-  movePlayerTo(target: { x: number; z: number }): void;
-  getStairMetrics(): {
-    stairCenterX: number;
-    stairHalfWidth: number;
-    stairBottomZ: number;
-    stairTopZ: number;
-    stairLandingMinZ: number;
-    stairLandingDepth: number;
-    upperFloorElevation: number;
-  };
+  movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+  getActiveFloor(): FloorId;
+  getPlayerPosition(): { x: number; y: number; z: number };
+  getStairMetrics(): StairMetrics;
+  predictFloorAt(target: {
+    x: number;
+    z: number;
+    currentFloor?: FloorId;
+  }): FloorId;
+  getStairTransitionZone(target: {
+    x: number;
+    z: number;
+    currentFloor?: FloorId;
+  }): StairTransitionZone;
 };
 
 type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
+    debugCoordinates?: {
+      getState(): DebugCoordinatesState;
+    };
+    poi?: {
+      getTooltipState(): PoiTooltipState;
+    };
   };
 };
 
 test.setTimeout(150_000);
 
-async function waitForImmersiveReady(page: import('@playwright/test').Page) {
+async function waitForImmersiveReady(page: Page) {
   await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
     () => document.documentElement.dataset.appMode === 'immersive',
     undefined,
     { timeout: IMMERSIVE_READY_TIMEOUT_MS }
   );
+  await page.waitForFunction(
+    () =>
+      Boolean(
+        (window as PortfolioWindow).portfolio?.world?.getStairMetrics &&
+          (window as PortfolioWindow).portfolio?.debugCoordinates?.getState &&
+          (window as PortfolioWindow).portfolio?.poi?.getTooltipState
+      ),
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+}
+
+async function movePlayerTo(
+  page: Page,
+  target: { x: number; z: number; floorId?: FloorId }
+) {
+  await page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    world.movePlayerTo(next);
+  }, target);
+  await page.waitForTimeout(150);
+}
+
+async function getStairMetrics(page: Page): Promise<StairMetrics> {
+  return page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getStairMetrics();
+  });
+}
+
+async function getDebugCoordinatesState(
+  page: Page
+): Promise<DebugCoordinatesState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioWindow).portfolio?.debugCoordinates
+      ?.getState;
+    if (!getState) {
+      throw new Error('Debug coordinates API unavailable');
+    }
+    return getState();
+  });
+}
+
+async function getPoiTooltipState(page: Page): Promise<PoiTooltipState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioWindow).portfolio?.poi
+      ?.getTooltipState;
+    if (!getState) {
+      throw new Error('POI tooltip API unavailable');
+    }
+    return getState();
+  });
+}
+
+async function predictFloorAt(
+  page: Page,
+  target: { x: number; z: number; currentFloor?: FloorId }
+): Promise<FloorId> {
+  return page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.predictFloorAt(next);
+  }, target);
+}
+
+async function getStairTransitionZone(
+  page: Page,
+  target: { x: number; z: number; currentFloor?: FloorId }
+): Promise<StairTransitionZone> {
+  return page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getStairTransitionZone(next);
+  }, target);
+}
+
+async function openSettings(page: Page) {
+  const settingsButton = page.locator('[data-role="settings-button"]');
+  await settingsButton.click();
+  await expect(page.locator('.help-modal-backdrop')).toBeVisible();
 }
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
@@ -38,28 +202,7 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
-
-  const movePlayerTo = async (target: { x: number; z: number }) => {
-    await page.evaluate((next) => {
-      const { portfolio } = window as PortfolioWindow;
-      const world = portfolio?.world;
-      if (!world) {
-        throw new Error('World API unavailable');
-      }
-      world.movePlayerTo(next);
-    }, target);
-    await page.waitForTimeout(150);
-  };
-
-  const metrics = await page.evaluate(() => {
-    const { portfolio } = window as PortfolioWindow;
-    const world = portfolio?.world;
-    if (!world) {
-      throw new Error('World API unavailable');
-    }
-    return world.getStairMetrics();
-  });
-
+  const metrics = await getStairMetrics(page);
   const {
     stairCenterX,
     stairBottomZ,
@@ -72,27 +215,144 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Move to the base of the staircase on the ground floor.
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.3 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Enter the ramp and ascend to the upper floor.
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.1 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.1 });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Roam deeper onto the upper landing and confirm we stay upstairs.
   const landingRoamZ =
     stairLandingMinZ + Math.min(stairLandingDepth * 0.5, 0.6);
-  await movePlayerTo({ x: stairCenterX, z: landingRoamZ });
+  await movePlayerTo(page, { x: stairCenterX, z: landingRoamZ });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Return toward the stairs, enter the explicit descent handoff, then
   // continue down the ramp. The helper teleports between sampled positions,
   // so include the narrow handoff band that real movement crosses frame by frame.
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.15 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ + 0.7 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.15 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.35 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.35 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('upper landing edge does not teleport while the stairwell still descends', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const metrics = await getStairMetrics(page);
+  const landingEdgeX = metrics.stairCenterX + metrics.stairHalfWidth + 1.2;
+  const landingEdgeZ = metrics.stairTopZ + 0.7;
+
+  await movePlayerTo(page, {
+    x: landingEdgeX,
+    z: landingEdgeZ - 0.1,
+    floorId: 'upper',
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  await expect
+    .poll(() =>
+      getStairTransitionZone(page, {
+        x: landingEdgeX,
+        z: landingEdgeZ,
+        currentFloor: 'upper',
+      })
+    )
+    .toBe('safeUpperFloor');
+  await expect
+    .poll(() =>
+      predictFloorAt(page, {
+        x: landingEdgeX,
+        z: landingEdgeZ,
+        currentFloor: 'upper',
+      })
+    )
+    .toBe('upper');
+
+  // This is the screenshot-4-style regression guard: nudging down at the
+  // landing edge must not use the stairwell descent handoff.
+  await movePlayerTo(page, { x: landingEdgeX, z: landingEdgeZ });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  // The center of the stairwell remains the intentional descent corridor.
+  await expect
+    .poll(() =>
+      getStairTransitionZone(page, {
+        x: metrics.stairCenterX,
+        z: landingEdgeZ,
+        currentFloor: 'upper',
+      })
+    )
+    .toBe('explicitDescentCorridor');
+  await movePlayerTo(page, { x: metrics.stairCenterX, z: landingEdgeZ });
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('debug overlay and POI state remain floor-aware upstairs', async ({
+  page,
+}) => {
+  test.slow();
+  await page.addInitScript(() => {
+    window.localStorage.removeItem('danielsmith.io::debugCoordinates::v1');
+  });
+  await waitForImmersiveReady(page);
+
+  const metrics = await getStairMetrics(page);
+  await movePlayerTo(page, {
+    x: metrics.stairCenterX,
+    z: metrics.stairTopZ - 0.1,
+  });
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-active-floor',
+    'upper'
+  );
+
+  await openSettings(page);
+  const debugToggle = page.locator(
+    '.help-modal-backdrop .debug-coordinates-toggle'
+  );
+  const overlay = page.locator('.debug-coordinates');
+  await expect(overlay).toBeHidden();
+  await debugToggle.click();
+  await expect(overlay).toBeVisible();
+  await expect(overlay).toContainText(/XYZ/i);
+  await expect(overlay).toContainText(/Active floor/i);
+  await expect(overlay).toContainText(/upper/i);
+
+  await expect
+    .poll(() => getDebugCoordinatesState(page))
+    .toMatchObject({
+      enabled: true,
+      activeFloorId: 'upper',
+      predictedStairFloorId: 'upper',
+    });
+
+  const debugState = await getDebugCoordinatesState(page);
+  expect(Number.isFinite(debugState.x)).toBe(true);
+  expect(Number.isFinite(debugState.y)).toBe(true);
+  expect(Number.isFinite(debugState.z)).toBe(true);
+
+  const poiState = await getPoiTooltipState(page);
+  expect(poiState.visibleMarkerLabelPoiIds).toEqual(
+    expect.not.arrayContaining(GROUND_POI_IDS)
+  );
+  expect(poiState.markerLabelPoiId).not.toEqual(expect.stringMatching(/./));
+  expect(poiState.worldTooltipPoiId).toBeNull();
+  expect(poiState.worldTooltipTitle).toBeNull();
+  expect(poiState.activeInWorldTooltipCount).toBe(0);
+  expect(poiState.totalInWorldTooltipCount).toBe(0);
 });


### PR DESCRIPTION
### Motivation
- Lock down recent upstairs/stair fixes with deterministic regression coverage to prevent accidental upstairs→ground teleports. 
- Make debug-coordinate state and POI visuals easy to validate so visual/DOM regressions (POI bleed-through, missing overlay) are caught early. 
- Provide a concise manual QA runbook for reviewers and QA to reproduce the edge cases and report coordinates.

### Description
- Extended `playwright/immersive-stairs-roundtrip.spec.ts` with typed helpers for `window.portfolio.world`, `debugCoordinates`, and POI tooltip state and added reusable helpers like `movePlayerTo`, `getStairMetrics`, `predictFloorAt`, and `getStairTransitionZone`.
- Added an explicit landing-edge regression assertion that nudging down at the landing edge remains on `upper` while the central stair corridor still permits intentional descent to `ground`.
- Added assertions that toggle and inspect the debug-coordinate overlay, assert numeric XYZ/floor values, and verify upstairs suppresses ground POI labels/visited checkmarks (`poi.getTooltipState()` expectations).
- Added `docs/qa/upstairs-stairs.md` with how-to enable Debug coordinates, authoritative coordinates to check, and a short QA checklist covering stairs up, landing, second-floor rooms, POI/LED bleed-through, stairwell visibility, and intentional descent.

### Testing
- Ran formatting: `npm run format:write` and `npx prettier --write` on the new files — passed.
- Lint: `npm run lint` — passed.
- Typecheck: `npm run typecheck` — failed due to pre-existing, unrelated repository TypeScript issues (reported; not caused by these changes).
- Unit tests: `npm run test:ci` (Vitest) — full suite passed locally (`141 files`, `1054 tests`).
- Build: `npm run build` — production build completed successfully.
- Playwright e2e: `npm run test:e2e -- playwright/immersive-stairs-roundtrip.spec.ts` — new stairs e2e passed after installing Playwright browsers and host dependencies (`npx playwright install chromium` / `npx playwright install-deps`).
- Additional e2e smoke: `npm run test:e2e -- playwright/small-screen-hud.spec.ts playwright/immersive-zoom.spec.ts` — passed.
- Docs check: `npm run docs:check` — passed (link checker returned external fetch warnings only).
- Smoke: `npm run smoke` — passed.

Notes and residual risks: the repo has pre-existing TypeScript typecheck failures unrelated to these changes (so CI typecheck will still fail until addressed); Playwright runs require the usual browser install and system deps in fresh CI runners (`npx playwright install` / `npx playwright install-deps`). The PR adds only test and doc assets and small test helpers, and does not modify runtime movement logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f63b8800832fa0417cc90110589a)