### PR TITLE
Add upstairs/stairs regression Playwright coverage and QA runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ lightweight.
 - **Visual smoke thresholds** – [`playwright.config.ts`](playwright.config.ts) loads [`VISUAL_SMOKE_DIFF_BUDGET`](src/assets/performance.ts#L37-L45) so `expect().toHaveScreenshot` allows at most a 0.015 diff ratio or 1,200 differing pixels.
 - **Keyboard traversal macro** – [`playwright/keyboard-traversal.spec.ts`](playwright/keyboard-traversal.spec.ts) touches every POI and HUD overlay using keyboard-only input. Use `npm run test:e2e -- --grep traversal` to run just that macro when iterating.
 - **Animation QA checklist** – [`docs/media/animation-qa.md`](docs/media/animation-qa.md) links the IK contact/footstep sync tests and describes how to capture fresh clips when polishing locomotion.
+- **Upstairs/stairs QA runbook** – [`docs/qa/upstairs-stairs.md`](docs/qa/upstairs-stairs.md) covers the debug-coordinate overlay, stair ascent/descent, upper landing regression, and ground POI/LED bleed-through checks.
 - **Docs validation** – `npm run docs:check` enforces prompt, roadmap, and architecture coverage, then runs `npm run links:check`. The link checker collects POI locale links plus README/docs Markdown links, validates URL syntax, checks local targets, and probes external HTTP(S) targets with HEAD plus GET fallback while treating private, rate-limited, or unreachable hosts as warnings instead of clear broken-link failures.
 - **Launch smoke** – `npm run smoke` builds once, validates bundled output references, and reports
   manual static binary assets (resume/favicon) as warnings by default.

--- a/docs/qa/upstairs-stairs.md
+++ b/docs/qa/upstairs-stairs.md
@@ -1,0 +1,90 @@
+# Upstairs/stairs manual QA
+
+Use this runbook when changing stair geometry, upper-floor rooms, POI visibility, or debug
+coordinate reporting. Keep the preview URL in immersive mode with failover disabled:
+
+```text
+http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
+```
+
+## Enable debug coordinates
+
+1. Open Settings from the HUD.
+2. Toggle **Debug coordinates** on.
+3. Confirm the non-interactive overlay shows:
+   - `XYZ`
+   - `Active floor`
+   - `Predicted stair floor`
+   - `Stair zone`
+   - `Room`
+
+You can also enable it from the console for a local QA session:
+
+```js
+window.portfolio.debugCoordinates.setEnabled(true);
+```
+
+## Stairs up
+
+1. Start on the ground floor (`Active floor: ground`).
+2. Walk to the stair base near `XYZ 12.40, 0.75, -10.60`.
+3. Walk north/away from the camera up the visible stairs.
+4. Near the top (`Z ≈ -25.90`), confirm `Active floor` changes to `upper`.
+5. Confirm the avatar height rises smoothly and does not snap back to ground.
+
+## Upper landing regression
+
+1. Stand on the upper landing edge near `XYZ 13.40, 4.91, -28.50`.
+2. Nudge south/toward the camera with `S` or `ArrowDown`.
+3. Confirm `Active floor` stays `upper` unless the avatar is centered in the stairwell
+   descent corridor.
+4. Confirm `Stair zone` reads a safe upper-floor/landing state at the edge, not an
+   accidental ground transition.
+
+## Intentional descent
+
+1. From the landing, move to the center of the stair opening near
+   `XYZ 12.40, 4.91, -25.20`.
+2. Continue south/down the stairwell.
+3. Confirm `Active floor` changes to `ground` only after entering the descent corridor.
+4. Continue to the base near `XYZ 12.40, 0.75, -10.60` and confirm the floor remains
+   `ground`.
+
+## Second-floor rooms
+
+Check each upstairs room after ascending:
+
+- **Upper Landing:** around `X 4.00–20.80`, `Z -32.00–-16.00`.
+- **Creators Studio:** around `X -20.00–4.00`, `Z -32.00–0.00`.
+- **Loft Library:** around `X 4.00–24.00`, `Z -16.00–12.00`.
+- **Focus Pods:** around `X -20.00–24.00`, `Z 12.00–28.00`.
+
+For each room, confirm the overlay reports `Active floor: upper`, the room name/id is
+reasonable, and normal movement does not teleport to the ground floor.
+
+## Ground POI, LED, and marker bleed-through
+
+While upstairs:
+
+1. Confirm ground POI labels, visited checkmarks, and in-world tooltip markers are not
+   visible through the upper floor.
+2. Confirm ground-room LED strips/fill lights are suppressed and upstairs lighting remains
+   visible.
+3. In the console, confirm there are no ghost ground markers:
+
+```js
+window.portfolio.poi.getTooltipState();
+```
+
+Expected upstairs state when no upstairs POI is active:
+
+- `overlayVisiblePoiId: null`
+- `worldTooltipPoiId: null`
+- `visibleMarkerLabelCount: 0`
+- `visibleMarkerLabelPoiIds: []`
+- `activeInWorldTooltipCount: 0`
+
+## Stairwell visibility from upstairs
+
+From the upper landing, look at the stair opening and confirm usable stairs down are visible.
+The opening should not be blocked by a solid cuboid, floor slab, or ground-floor-only visual.

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,30 +1,142 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 
 type TestWorldApi = {
-  movePlayerTo(target: { x: number; z: number }): void;
+  getActiveFloor(): string;
+  movePlayerTo(target: { x: number; z: number; floorId?: string }): void;
+  getStairTransitionZone(target: {
+    x: number;
+    z: number;
+    currentFloor?: string;
+  }): string;
   getStairMetrics(): {
     stairCenterX: number;
     stairHalfWidth: number;
     stairBottomZ: number;
     stairTopZ: number;
     stairLandingMinZ: number;
+    stairLandingMaxZ: number;
     stairLandingDepth: number;
     upperFloorElevation: number;
   };
 };
 
+type PoiTooltipState = {
+  overlayVisiblePoiId: string | null;
+  worldTooltipVisible: boolean;
+  worldTooltipPoiId: string | null;
+  markerLabelVisible: boolean;
+  markerLabelPoiId: string | null;
+  visibleMarkerLabelCount: number;
+  visibleMarkerLabelPoiIds: string[];
+  activeInWorldTooltipCount: number;
+  totalInWorldTooltipCount: number;
+};
+
+type DebugCoordinatesState = {
+  enabled: boolean;
+  x: number;
+  y: number;
+  z: number;
+  activeFloorId: string;
+  predictedStairFloorId: string;
+  currentRoomId: string | null;
+};
+
 type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
+    poi?: {
+      getTooltipState?: () => PoiTooltipState;
+    };
+    debugCoordinates?: {
+      getState?: () => DebugCoordinatesState;
+      setEnabled?: (enabled: boolean) => void;
+    };
   };
 };
 
 test.setTimeout(150_000);
 
-async function waitForImmersiveReady(page: import('@playwright/test').Page) {
+async function movePlayerTo(
+  page: Page,
+  target: { x: number; z: number; floorId?: string }
+) {
+  await page.evaluate((next) => {
+    const { portfolio } = window as PortfolioWindow;
+    const world = portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    world.movePlayerTo(next);
+  }, target);
+  await page.waitForTimeout(150);
+}
+
+async function getStairMetrics(page: Page) {
+  return page.evaluate(() => {
+    const { portfolio } = window as PortfolioWindow;
+    const world = portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getStairMetrics();
+  });
+}
+
+async function getStairTransitionZone(
+  page: Page,
+  target: { x: number; z: number; currentFloor?: string }
+) {
+  return page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getStairTransitionZone(next);
+  }, target);
+}
+
+async function getTooltipState(page: Page) {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioWindow).portfolio?.poi
+      ?.getTooltipState;
+    if (!getState) {
+      throw new Error('window.portfolio.poi.getTooltipState() is unavailable');
+    }
+    return getState();
+  });
+}
+
+async function setDebugCoordinatesEnabled(page: Page, enabled: boolean) {
+  await page.evaluate((next) => {
+    const setEnabled = (window as PortfolioWindow).portfolio?.debugCoordinates
+      ?.setEnabled;
+    if (!setEnabled) {
+      throw new Error(
+        'window.portfolio.debugCoordinates.setEnabled() is unavailable'
+      );
+    }
+    setEnabled(next);
+  }, enabled);
+}
+
+async function getDebugCoordinatesState(page: Page) {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioWindow).portfolio?.debugCoordinates
+      ?.getState;
+    if (!getState) {
+      throw new Error(
+        'window.portfolio.debugCoordinates.getState() is unavailable'
+      );
+    }
+    return getState();
+  });
+}
+
+async function waitForImmersiveReady(page: Page) {
   await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
     () => document.documentElement.dataset.appMode === 'immersive',
@@ -39,26 +151,7 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
 
   const html = page.locator('html');
 
-  const movePlayerTo = async (target: { x: number; z: number }) => {
-    await page.evaluate((next) => {
-      const { portfolio } = window as PortfolioWindow;
-      const world = portfolio?.world;
-      if (!world) {
-        throw new Error('World API unavailable');
-      }
-      world.movePlayerTo(next);
-    }, target);
-    await page.waitForTimeout(150);
-  };
-
-  const metrics = await page.evaluate(() => {
-    const { portfolio } = window as PortfolioWindow;
-    const world = portfolio?.world;
-    if (!world) {
-      throw new Error('World API unavailable');
-    }
-    return world.getStairMetrics();
-  });
+  const metrics = await getStairMetrics(page);
 
   const {
     stairCenterX,
@@ -72,27 +165,133 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Move to the base of the staircase on the ground floor.
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.3 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Enter the ramp and ascend to the upper floor.
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.1 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.1 });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Roam deeper onto the upper landing and confirm we stay upstairs.
   const landingRoamZ =
     stairLandingMinZ + Math.min(stairLandingDepth * 0.5, 0.6);
-  await movePlayerTo({ x: stairCenterX, z: landingRoamZ });
+  await movePlayerTo(page, { x: stairCenterX, z: landingRoamZ });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Return toward the stairs, enter the explicit descent handoff, then
   // continue down the ramp. The helper teleports between sampled positions,
   // so include the narrow handoff band that real movement crosses frame by frame.
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.15 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ + 0.7 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.15 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.35 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.35 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('upper landing nudge keeps the player upstairs until intentional descent', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const metrics = await getStairMetrics(page);
+  const { stairCenterX, stairTopZ } = metrics;
+  const upperLandingEdgeX = stairCenterX + 1;
+  const upperLandingNudgeZ = stairTopZ - 2.6;
+  const explicitDescentZ = stairTopZ + 0.7;
+
+  await expect(
+    getStairTransitionZone(page, {
+      x: upperLandingEdgeX,
+      z: upperLandingNudgeZ,
+      currentFloor: 'upper',
+    })
+  ).resolves.toBe('upperLanding');
+
+  await movePlayerTo(page, {
+    x: upperLandingEdgeX,
+    z: upperLandingNudgeZ,
+    floorId: 'upper',
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  await page.keyboard.press('ArrowDown');
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+  await expect
+    .poll(async () => getDebugCoordinatesState(page))
+    .toMatchObject({ activeFloorId: 'upper' });
+
+  await expect(
+    getStairTransitionZone(page, {
+      x: stairCenterX,
+      z: explicitDescentZ,
+      currentFloor: 'upper',
+    })
+  ).resolves.toBe('explicitDescentCorridor');
+
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: explicitDescentZ,
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('debug coordinates and POI tooltip state stay floor-aware upstairs', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const overlay = page.locator('.debug-coordinates');
+  const metrics = await getStairMetrics(page);
+  const { stairCenterX, stairLandingMinZ, stairLandingMaxZ } = metrics;
+  const landingMidZ = (stairLandingMinZ + stairLandingMaxZ) / 2;
+
+  await setDebugCoordinatesEnabled(page, true);
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: landingMidZ,
+    floorId: 'upper',
+  });
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-active-floor',
+    'upper'
+  );
+
+  await expect(overlay).toBeVisible();
+  await expect(overlay).toContainText(/XYZ/i);
+  await expect(overlay).toContainText(/Active floor/i);
+  await expect(overlay).toContainText(/upper/i);
+  const debugState = await getDebugCoordinatesState(page);
+  expect(debugState).toMatchObject({
+    enabled: true,
+    activeFloorId: 'upper',
+    predictedStairFloorId: 'upper',
+  });
+  expect(Number.isFinite(debugState.x)).toBe(true);
+  expect(Number.isFinite(debugState.y)).toBe(true);
+  expect(Number.isFinite(debugState.z)).toBe(true);
+
+  await expect
+    .poll(async () => getTooltipState(page))
+    .toMatchObject({
+      overlayVisiblePoiId: null,
+      worldTooltipVisible: false,
+      worldTooltipPoiId: null,
+      markerLabelVisible: false,
+      markerLabelPoiId: null,
+      visibleMarkerLabelCount: 0,
+      visibleMarkerLabelPoiIds: [],
+      activeInWorldTooltipCount: 0,
+      totalInWorldTooltipCount: 0,
+    });
 });


### PR DESCRIPTION
### Motivation
- Lock down recent upstairs/stair hardening by adding automated regression coverage that detects accidental upstairs→ground teleports, landing-edge drift, and POI/LED bleed-through.
- Provide a concise manual QA runbook so reviewers and designers can reproduce and validate stair/floor interactions and the debug-coordinate overlay.

### Description
- Extend `playwright/immersive-stairs-roundtrip.spec.ts` with reusable helpers for the test-only `window.portfolio.world` API and add three focused tests: full ascend/return descent, an upper-landing nudge regression check (ensures nudges don’t teleport to ground), and a debug-coordinate + POI tooltip state floor-awareness check.
- Add `docs/qa/upstairs-stairs.md` with step-by-step manual QA instructions (how to enable Debug coordinates, coordinates to exercise stairs/landing/rooms, and POI/LED bleed-through checks) and link it from `README.md` testing section.
- Keep scene geometry unchanged; tests exercise the exposed metrics (`getStairMetrics`, `getStairTransitionZone`, `movePlayerTo`) and DOM dataset (`data-active-floor`) along with the debug overlay and `window.portfolio.poi.getTooltipState()`.

### Testing
- `npm run format:write -- playwright/immersive-stairs-roundtrip.spec.ts docs/qa/upstairs-stairs.md README.md` — succeeded.
- `npm run lint` — succeeded (ESLint run passed after removing a local unused variable in the spec).
- `npm run typecheck` — did not pass; TSC reported pre-existing repo-wide type errors unrelated to this change (these failures are present across many files and are outside the scope of this PR).
- `npm run test:ci` (Vitest) — succeeded; unit suites completed (Test files: 141, Tests: 1054 passed).
- `npm run build` — succeeded; production build completed.
- Playwright E2E runs:
  - `npm run test:e2e -- playwright/immersive-stairs-roundtrip.spec.ts` — succeeded (3 tests passed: ascend/roundtrip, upper-landing nudge, debug-coordinates/POI checks).
  - `npm run test:e2e -- playwright/small-screen-hud.spec.ts playwright/immersive-zoom.spec.ts` — succeeded (10 tests passed for the chosen suites).
  Note: Playwright required `npx playwright install chromium-headless-shell` and `npx playwright install-deps` to download browser binaries and host deps during local runs; those are environment steps, not part of the change.
- `npm run docs:check` — succeeded (link checker emitted external fetch warnings as expected in CI-like environments).
- `npm run smoke` — succeeded (build + assertion of dist artifact references passed).

Residual risks and follow-ups: the TypeScript typecheck fails are repository-wide and pre-existing; they are unrelated to the new tests/docs but should be addressed separately if strict `tsc` passing is required in CI for all branches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f63b8800832fa0417cc90110589a)