### PR TITLE
Add upstairs/stairs regression Playwright coverage and manual QA runbook

### DIFF
--- a/docs/qa/upstairs-stairs.md
+++ b/docs/qa/upstairs-stairs.md
@@ -1,0 +1,65 @@
+# Upstairs and stairs manual QA
+
+Use this runbook when reviewing stair, landing, second-floor room, or debug
+coordinate changes. Keep the immersive preview URL forced to immersive mode:
+
+```bash
+npm run dev -- --host 127.0.0.1 --port 5173
+```
+
+Open `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`.
+
+## Enable debug coordinates
+
+1. Open Settings from the HUD.
+2. Toggle **Debug coordinates** on.
+3. Confirm the non-interactive overlay appears and reports:
+   - `XYZ`
+   - `Active floor`
+   - `Predicted floor`
+   - stair width / landing / stair nav booleans
+   - stair zone and room id
+
+## Stairs up
+
+1. Start on the ground floor near spawn; `Active floor` should be `ground`.
+2. Walk to the living-room stairs around `X 12.40`, `Z -10.60`.
+3. Walk up the stair run toward `Z -25.90`.
+4. Verify `Active floor` changes to `upper` only near the top or landing.
+5. Verify the avatar height rises smoothly instead of snapping.
+
+## Upper landing regression point
+
+1. With Debug coordinates on, place the avatar near the upper landing edge:
+   `X 12.40`, `Z -22.90`, `Active floor upper`.
+2. Nudge slightly downward/toward the stair opening without entering the stair
+   centerline.
+3. Verify `Active floor` and `Predicted floor` remain `upper`.
+4. Verify the stair opening shows usable stairs down, not a solid cuboid.
+
+## Second-floor rooms
+
+1. From the upper landing, walk west into Creators Studio.
+2. Walk north/east into Loft Library.
+3. Walk north into Focus Pods.
+4. Confirm `Active floor` remains `upper` and `Room` updates when crossing room
+   boundaries.
+5. Confirm walls, floors, LEDs, and labels look second-floor-specific.
+
+## Ground POI and LED bleed-through
+
+1. While upstairs, look for downstairs POI labels, visited checkmarks, and LED
+   strips.
+2. Press `E` to cycle POIs; ground-floor markers should not appear as in-world
+   labels while `Active floor upper`.
+3. Confirm no backyard, kitchen, studio, or living-room ground markers ghost
+   through the second floor.
+
+## Intentional descent
+
+1. Return to the stair centerline near `X 12.40`, `Z -24.50`.
+2. Step into the stair opening and continue down the ramp.
+3. Verify `Active floor` changes to `ground` only after entering the descent
+   corridor.
+4. Continue to the stair base around `Z -10.60`; verify the avatar stays on the
+   ground floor.

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,36 +1,185 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const GROUND_POI_IDS = [
+  'tokenplace-studio-cluster',
+  'gabriel-studio-sentry',
+  'flywheel-studio-flywheel',
+  'jobbot-studio-terminal',
+  'axel-studio-tracker',
+  'futuroptimist-living-room-tv',
+  'gitshelves-living-room-installation',
+  'danielsmith-portfolio-table',
+  'f2clipboard-kitchen-console',
+  'sigma-kitchen-workbench',
+  'wove-kitchen-loom',
+  'dspace-backyard-rocket',
+  'pr-reaper-backyard-console',
+  'sugarkube-backyard-greenhouse',
+] as const;
+
+const SCREENSHOT_LANDING_NUDGE = 0.4;
+const SCREENSHOT_LANDING_OFFSET = 3.0;
+const INTENTIONAL_DESCENT_OFFSET = 0.7;
+
+type FloorId = 'ground' | 'upper';
+
+type DebugCoordinatesState = {
+  enabled: boolean;
+  x: number;
+  y: number;
+  z: number;
+  activeFloorId: FloorId;
+  predictedStairFloorId: FloorId;
+  cameraZoom: number;
+  insideStairWidth: boolean;
+  insideLanding: boolean;
+  insideStairNavArea: boolean;
+  stairZone: string;
+  currentRoomId: string | null;
+};
+
+type PoiTooltipState = {
+  overlayVisiblePoiId: string | null;
+  worldTooltipVisible: boolean;
+  worldTooltipPoiId: string | null;
+  worldTooltipTitle: string | null;
+  markerLabelVisible: boolean;
+  markerLabelPoiId: string | null;
+  visibleMarkerLabelCount: number;
+  visibleMarkerLabelPoiIds: string[];
+  activePoiMarkerLabelVisible: boolean;
+  activeInWorldTooltipCount: number;
+  totalInWorldTooltipCount: number;
+};
+
+type StairMetrics = {
+  stairCenterX: number;
+  stairHalfWidth: number;
+  stairBottomZ: number;
+  stairTopZ: number;
+  stairLandingMinZ: number;
+  stairLandingMaxZ: number;
+  stairLandingDepth: number;
+  stairDirection: 1 | -1;
+  upperFloorElevation: number;
+};
 
 type TestWorldApi = {
-  movePlayerTo(target: { x: number; z: number }): void;
-  getStairMetrics(): {
-    stairCenterX: number;
-    stairHalfWidth: number;
-    stairBottomZ: number;
-    stairTopZ: number;
-    stairLandingMinZ: number;
-    stairLandingDepth: number;
-    upperFloorElevation: number;
-  };
+  movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+  getActiveFloor(): FloorId;
+  getPlayerPosition(): { x: number; y: number; z: number };
+  predictFloorAt(target: {
+    x: number;
+    z: number;
+    currentFloor?: FloorId;
+  }): FloorId;
+  getStairTransitionZone(target: {
+    x: number;
+    z: number;
+    currentFloor?: FloorId;
+  }): string;
+  getStairMetrics(): StairMetrics;
 };
 
 type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
+    poi?: {
+      getTooltipState?: () => PoiTooltipState;
+    };
+    debugCoordinates?: {
+      getState?: () => DebugCoordinatesState;
+      setEnabled?: (enabled: boolean) => void;
+    };
   };
 };
 
 test.setTimeout(150_000);
 
-async function waitForImmersiveReady(page: import('@playwright/test').Page) {
+async function waitForImmersiveReady(page: Page) {
   await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
     () => document.documentElement.dataset.appMode === 'immersive',
     undefined,
     { timeout: IMMERSIVE_READY_TIMEOUT_MS }
   );
+  await page.waitForFunction(
+    () => (window as PortfolioWindow).portfolio?.world?.getStairMetrics
+  );
+  await page.waitForFunction(
+    () => (window as PortfolioWindow).portfolio?.poi?.getTooltipState
+  );
+  await page.waitForFunction(
+    () => (window as PortfolioWindow).portfolio?.debugCoordinates?.getState
+  );
+}
+
+async function movePlayerTo(
+  page: Page,
+  target: { x: number; z: number; floorId?: FloorId }
+) {
+  await page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    world.movePlayerTo(next);
+  }, target);
+  await page.waitForTimeout(150);
+}
+
+async function getStairMetrics(page: Page): Promise<StairMetrics> {
+  return page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getStairMetrics();
+  });
+}
+
+async function getTooltipState(page: Page): Promise<PoiTooltipState> {
+  return page.evaluate(() => {
+    const getTooltipState = (window as PortfolioWindow).portfolio?.poi
+      ?.getTooltipState;
+    if (!getTooltipState) {
+      throw new Error('Tooltip API unavailable');
+    }
+    return getTooltipState();
+  });
+}
+
+async function getDebugCoordinatesState(
+  page: Page
+): Promise<DebugCoordinatesState> {
+  return page.evaluate(() => {
+    const getState = (window as PortfolioWindow).portfolio?.debugCoordinates
+      ?.getState;
+    if (!getState) {
+      throw new Error('Debug coordinates API unavailable');
+    }
+    return getState();
+  });
+}
+
+async function setDebugCoordinatesEnabled(page: Page, enabled: boolean) {
+  await page.evaluate((nextEnabled) => {
+    const setEnabled = (window as PortfolioWindow).portfolio?.debugCoordinates
+      ?.setEnabled;
+    if (!setEnabled) {
+      throw new Error('Debug coordinates API unavailable');
+    }
+    setEnabled(nextEnabled);
+  }, enabled);
+}
+
+function getLandingRegressionPoint(metrics: StairMetrics) {
+  return {
+    x: metrics.stairCenterX,
+    z: metrics.stairTopZ - metrics.stairDirection * SCREENSHOT_LANDING_OFFSET,
+  };
 }
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
@@ -38,27 +187,7 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
-
-  const movePlayerTo = async (target: { x: number; z: number }) => {
-    await page.evaluate((next) => {
-      const { portfolio } = window as PortfolioWindow;
-      const world = portfolio?.world;
-      if (!world) {
-        throw new Error('World API unavailable');
-      }
-      world.movePlayerTo(next);
-    }, target);
-    await page.waitForTimeout(150);
-  };
-
-  const metrics = await page.evaluate(() => {
-    const { portfolio } = window as PortfolioWindow;
-    const world = portfolio?.world;
-    if (!world) {
-      throw new Error('World API unavailable');
-    }
-    return world.getStairMetrics();
-  });
+  const metrics = await getStairMetrics(page);
 
   const {
     stairCenterX,
@@ -72,27 +201,142 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Move to the base of the staircase on the ground floor.
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.3 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
   // Enter the ramp and ascend to the upper floor.
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.1 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.1 });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Roam deeper onto the upper landing and confirm we stay upstairs.
   const landingRoamZ =
     stairLandingMinZ + Math.min(stairLandingDepth * 0.5, 0.6);
-  await movePlayerTo({ x: stairCenterX, z: landingRoamZ });
+  await movePlayerTo(page, { x: stairCenterX, z: landingRoamZ });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Return toward the stairs, enter the explicit descent handoff, then
   // continue down the ramp. The helper teleports between sampled positions,
   // so include the narrow handoff band that real movement crosses frame by frame.
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ - 0.15 });
-  await movePlayerTo({ x: stairCenterX, z: stairTopZ + 0.7 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.15 });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
-  await movePlayerTo({ x: stairCenterX, z: (stairBottomZ + stairTopZ) / 2 });
-  await movePlayerTo({ x: stairCenterX, z: stairBottomZ + 0.35 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.35 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('landing edge nudge stays upstairs but center descent still works', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const metrics = await getStairMetrics(page);
+  const landingEdge = getLandingRegressionPoint(metrics);
+  const nudgeTowardStairs = {
+    x: landingEdge.x,
+    z: landingEdge.z + metrics.stairDirection * SCREENSHOT_LANDING_NUDGE,
+  };
+
+  await movePlayerTo(page, { ...landingEdge, floorId: 'upper' });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+  await expect
+    .poll(() => getDebugCoordinatesState(page))
+    .toMatchObject({
+      activeFloorId: 'upper',
+      predictedStairFloorId: 'upper',
+      stairZone: 'safeUpperFloor',
+    });
+
+  await movePlayerTo(page, nudgeTowardStairs);
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+  await expect
+    .poll(() => getDebugCoordinatesState(page))
+    .toMatchObject({ activeFloorId: 'upper', predictedStairFloorId: 'upper' });
+
+  await movePlayerTo(page, {
+    x: metrics.stairCenterX,
+    z: metrics.stairTopZ - metrics.stairDirection * INTENTIONAL_DESCENT_OFFSET,
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('debug coordinate overlay reports floor and XYZ upstairs', async ({
+  page,
+}) => {
+  await waitForImmersiveReady(page);
+
+  const metrics = await getStairMetrics(page);
+  const upperLanding = getLandingRegressionPoint(metrics);
+  const overlay = page.locator('.debug-coordinates');
+
+  await setDebugCoordinatesEnabled(page, false);
+  await expect(overlay).toBeHidden();
+  await expect(overlay).toHaveAttribute('aria-hidden', 'true');
+
+  await movePlayerTo(page, { ...upperLanding, floorId: 'upper' });
+  await setDebugCoordinatesEnabled(page, true);
+
+  await expect(overlay).toBeVisible();
+  await expect(overlay).toContainText(/XYZ/i);
+  await expect(overlay).toContainText(/Active floor/i);
+  await expect(overlay).toContainText(/upper/i);
+  await expect
+    .poll(() => getDebugCoordinatesState(page))
+    .toMatchObject({ enabled: true, activeFloorId: 'upper' });
+
+  const state = await getDebugCoordinatesState(page);
+  expect(state.x).toBeCloseTo(upperLanding.x, 1);
+  expect(state.z).toBeCloseTo(upperLanding.z, 1);
+  expect(state.y).toBeGreaterThan(0);
+});
+
+test('upper floor suppresses ground POI marker labels and checkmarks', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const metrics = await getStairMetrics(page);
+
+  // First activate a downstairs POI and mark it visited so label/checkmark state
+  // exists before moving upstairs. The floor controller must suppress it there.
+  await movePlayerTo(page, { x: 0, z: -4 });
+  await page.keyboard.press('KeyE');
+  await page.keyboard.press('Enter');
+  await expect(page.locator('.poi-tooltip-overlay')).toHaveAttribute(
+    'aria-hidden',
+    'false'
+  );
+
+  await movePlayerTo(page, {
+    x: metrics.stairCenterX,
+    z: metrics.stairTopZ - 0.1,
+    floorId: 'upper',
+  });
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-active-floor',
+    'upper'
+  );
+
+  const state = await getTooltipState(page);
+  expect(state.overlayVisiblePoiId).toBeNull();
+  expect(state.worldTooltipVisible).toBe(false);
+  expect(state.worldTooltipPoiId).toBeNull();
+  expect(state.markerLabelPoiId).toBeNull();
+  expect(state.visibleMarkerLabelCount).toBe(0);
+  expect(state.visibleMarkerLabelPoiIds).toEqual([]);
+  expect(state.activeInWorldTooltipCount).toBe(0);
+  expect(state.totalInWorldTooltipCount).toBe(0);
+  for (const poiId of GROUND_POI_IDS) {
+    expect(state.visibleMarkerLabelPoiIds).not.toContain(poiId);
+  }
 });


### PR DESCRIPTION
### Motivation
- Lock down recent upstairs/stair fixes so future scene edits do not accidentally teleport upstairs actors back to ground or re-introduce POI/LED bleed-through.
- Provide a concise manual QA runbook and machine-checkable e2e coverage so regressions are reproducible and triageable with exact coordinates/debug state.

### Description
- Extended `playwright/immersive-stairs-roundtrip.spec.ts` with shared immersive helpers (`world`, `poi`, `debugCoordinates`) and new tests that exercise ascent, landing roaming, the screenshot-like landing-edge nudge, intentional descent, debug-overlay assertions, and upstairs suppression of ground POI markers.
- Added `docs/qa/upstairs-stairs.md` which documents how to enable Debug coordinates and contains concise reproduction/verification steps and coordinates for stairs, landing, second-floor rooms, POI bleed-through, and intentional descent.
- Added runtime assertions that read `window.portfolio.world.getStairMetrics()`, `window.portfolio.debugCoordinates.getState()`, and `window.portfolio.poi.getTooltipState()` so CI-level checks validate floor/prediction/tooltip state rather than flaky pixel assertions.
- Small test-constants and helpers were tuned in the spec so the landing regression point is derived from runtime stair metrics rather than in-test magic numbers.

### Testing
- `npm run format:write -- playwright/immersive-stairs-roundtrip.spec.ts docs/qa/upstairs-stairs.md` — passed.
- `npm run lint` — passed.
- `npm run typecheck` — failed due to existing, unrelated project-wide TypeScript issues (these failures are not caused by this PR and are documented in the run output).
- `npm run test:ci` (Vitest unit suite) — passed; all tests ran locally (`1054` tests passed in this run).
- `npm run build` — passed and produced `dist/` artifacts.
- Playwright e2e: initial run reported missing browsers, then `npx playwright install` and `npx playwright install-deps` were run; after that `npm run test:e2e -- playwright/immersive-stairs-roundtrip.spec.ts` passed (4/4), and `npm run test:e2e -- playwright/small-screen-hud.spec.ts playwright/immersive-zoom.spec.ts` passed (all targeted e2e specs passed).
- `npm run docs:check` and `npm run smoke` — passed; `docs:check` reported external link fetch warnings only.

Residual notes: the TypeScript failures come from pre-existing typing issues outside the touched files and should be addressed in a follow-up that doesn't alter this PR's behavioral tests or QA docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f63b8800832fa0417cc90110589a)