### PR TITLE
🧱 : – Add collider debug overlay

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -27,6 +27,7 @@ import type {
   MovementLegendStrings,
   NarrationToggleStrings,
   DebugCoordinatesStrings,
+  DebugColliderStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
   PoiOverlayChromeStrings,
@@ -473,6 +474,12 @@ export function getDebugCoordinatesStrings(
   input?: LocaleInput
 ): DebugCoordinatesStrings {
   return cloneValue(getLocaleStrings(input).hud.debugCoordinates);
+}
+
+export function getDebugColliderStrings(
+  input?: LocaleInput
+): DebugColliderStrings {
+  return cloneValue(getLocaleStrings(input).hud.debugColliders);
 }
 
 export function getTourResetControlStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -276,6 +276,14 @@ export const AR_OVERRIDES: LocaleOverrides = {
       descriptionDisabled:
         'تبقى نوافذ السرد والتسميات التوضيحية مخفية حتى تفعّلها.',
     },
+    debugColliders: {
+      labelEnabled: 'طبقة المصادمات مفعّلة',
+      labelDisabled: 'طبقة المصادمات معطّلة',
+      descriptionEnabled:
+        'تعرض الجدران غير المرئية ومستطيلات التصادم للطابق النشط.',
+      descriptionDisabled:
+        'تبقى الجدران غير المرئية ومستطيلات التصادم مخفية حتى تفعّلها.',
+    },
     debugCoordinates: {
       labelEnabled: 'إحداثيات التصحيح مفعّلة',
       labelDisabled: 'إحداثيات التصحيح معطّلة',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -49,6 +49,12 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
       'Erzähl-Pop-ups und Untertitel erscheinen bei künftigen Exponatmomenten.',
     narrationToggleDescriptionDisabled:
       'Erzähl-Pop-ups und Untertitel bleiben verborgen, bis du sie einschaltest.',
+    debugCollidersLabelEnabled: 'Collider-Overlay ein',
+    debugCollidersLabelDisabled: 'Collider-Overlay aus',
+    debugCollidersDescriptionEnabled:
+      'Zeigt unsichtbare Wände und Kollisionsrechtecke der aktiven Etage.',
+    debugCollidersDescriptionDisabled:
+      'Unsichtbare Wände und Kollisionsrechtecke bleiben verborgen, bis du sie einschaltest.',
     debugCoordinatesLabelEnabled: 'Debug-Koordinaten ein',
     debugCoordinatesLabelDisabled: 'Debug-Koordinaten aus',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -329,6 +329,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         'Narration popups and captions stay hidden until you turn them on.'
       ),
     },
+    debugColliders: {
+      labelEnabled: wrap('Collider overlay on'),
+      labelDisabled: wrap('Collider overlay off'),
+      descriptionEnabled: wrap(
+        'Shows invisible wall and collision rectangles for the active floor.'
+      ),
+      descriptionDisabled: wrap(
+        'Invisible wall and collision rectangles stay hidden until you turn them on.'
+      ),
+    },
     debugCoordinates: {
       labelEnabled: wrap('Debug coordinates on'),
       labelDisabled: wrap('Debug coordinates off'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -339,6 +339,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       descriptionDisabled:
         'Narration popups and captions stay hidden until you turn them on.',
     },
+    debugColliders: {
+      labelEnabled: 'Collider overlay on',
+      labelDisabled: 'Collider overlay off',
+      descriptionEnabled:
+        'Shows invisible wall and collision rectangles for the active floor.',
+      descriptionDisabled:
+        'Invisible wall and collision rectangles stay hidden until you turn them on.',
+    },
     debugCoordinates: {
       labelEnabled: 'Debug coordinates on',
       labelDisabled: 'Debug coordinates off',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -49,6 +49,12 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
       'Las ventanas y subtítulos de narración aparecen en futuros momentos de exhibición.',
     narrationToggleDescriptionDisabled:
       'Las ventanas y subtítulos de narración permanecen ocultos hasta que los actives.',
+    debugCollidersLabelEnabled: 'Superposición de colisionadores activada',
+    debugCollidersLabelDisabled: 'Superposición de colisionadores desactivada',
+    debugCollidersDescriptionEnabled:
+      'Muestra paredes invisibles y rectángulos de colisión del piso activo.',
+    debugCollidersDescriptionDisabled:
+      'Las paredes invisibles y los rectángulos de colisión permanecen ocultos hasta que los actives.',
     debugCoordinatesLabelEnabled: 'Coordenadas de depuración activadas',
     debugCoordinatesLabelDisabled: 'Coordenadas de depuración desactivadas',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -49,6 +49,12 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
       'A narrációs felugrók és feliratok megjelennek a következő kiállítási pillanatoknál.',
     narrationToggleDescriptionDisabled:
       'A narrációs felugrók és feliratok rejtve maradnak, amíg be nem kapcsolod őket.',
+    debugCollidersLabelEnabled: 'Ütközőfedvény bekapcsolva',
+    debugCollidersLabelDisabled: 'Ütközőfedvény kikapcsolva',
+    debugCollidersDescriptionEnabled:
+      'Megjeleníti az aktív szint láthatatlan falait és ütközési téglalapjait.',
+    debugCollidersDescriptionDisabled:
+      'A láthatatlan falak és ütközési téglalapok rejtve maradnak, amíg be nem kapcsolod őket.',
     debugCoordinatesLabelEnabled: 'Hibakeresési koordináták be',
     debugCoordinatesLabelDisabled: 'Hibakeresési koordináták ki',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -277,6 +277,13 @@ export const JA_OVERRIDES: LocaleOverrides = {
       descriptionDisabled:
         'オンにするまでナレーションのポップアップと字幕は非表示です。',
     },
+    debugColliders: {
+      labelEnabled: 'コライダー表示オン',
+      labelDisabled: 'コライダー表示オフ',
+      descriptionEnabled: 'アクティブな階の見えない壁と衝突矩形を表示します。',
+      descriptionDisabled:
+        '見えない壁と衝突矩形はオンにするまで非表示のままです。',
+    },
     debugCoordinates: {
       labelEnabled: 'デバッグ座標オン',
       labelDisabled: 'デバッグ座標オフ',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -50,6 +50,10 @@ interface LatinLocaleCopy {
     narrationToggleLabelDisabled: string;
     narrationToggleDescriptionEnabled: string;
     narrationToggleDescriptionDisabled: string;
+    debugCollidersLabelEnabled: string;
+    debugCollidersLabelDisabled: string;
+    debugCollidersDescriptionEnabled: string;
+    debugCollidersDescriptionDisabled: string;
     debugCoordinatesLabelEnabled: string;
     debugCoordinatesLabelDisabled: string;
     debugCoordinatesDescriptionEnabled: string;
@@ -716,6 +720,12 @@ export function buildLatinLocaleOverrides(
         labelDisabled: s.narrationToggleLabelDisabled,
         descriptionEnabled: s.narrationToggleDescriptionEnabled,
         descriptionDisabled: s.narrationToggleDescriptionDisabled,
+      },
+      debugColliders: {
+        labelEnabled: s.debugCollidersLabelEnabled,
+        labelDisabled: s.debugCollidersLabelDisabled,
+        descriptionEnabled: s.debugCollidersDescriptionEnabled,
+        descriptionDisabled: s.debugCollidersDescriptionDisabled,
       },
       debugCoordinates: {
         labelEnabled: s.debugCoordinatesLabelEnabled,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -49,6 +49,12 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
       'Pop-ups e legendas de narração aparecem em futuros momentos da exibição.',
     narrationToggleDescriptionDisabled:
       'Pop-ups e legendas de narração ficam ocultos até você ativá-los.',
+    debugCollidersLabelEnabled: 'Sobreposição de colisores ativada',
+    debugCollidersLabelDisabled: 'Sobreposição de colisores desativada',
+    debugCollidersDescriptionEnabled:
+      'Mostra paredes invisíveis e retângulos de colisão do piso ativo.',
+    debugCollidersDescriptionDisabled:
+      'Paredes invisíveis e retângulos de colisão ficam ocultos até você ativá-los.',
     debugCoordinatesLabelEnabled: 'Coordenadas de depuração ativadas',
     debugCoordinatesLabelDisabled: 'Coordenadas de depuração desativadas',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -265,6 +265,12 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       descriptionEnabled: '未来展品时刻会显示旁白弹窗和字幕。',
       descriptionDisabled: '旁白弹窗和字幕保持隐藏，直到你开启。',
     },
+    debugColliders: {
+      labelEnabled: '碰撞体叠加层开启',
+      labelDisabled: '碰撞体叠加层关闭',
+      descriptionEnabled: '显示当前楼层的隐形墙和碰撞矩形。',
+      descriptionDisabled: '隐形墙和碰撞矩形会保持隐藏，直到你开启它们。',
+    },
     debugCoordinates: {
       labelEnabled: '调试坐标已开启',
       labelDisabled: '调试坐标已关闭',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -209,6 +209,13 @@ export interface NarrationToggleStrings {
   descriptionDisabled: string;
 }
 
+export interface DebugColliderStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
 export interface DebugCoordinatesStrings {
   labelEnabled: string;
   labelDisabled: string;
@@ -423,6 +430,7 @@ export interface LocaleStrings {
     tourGuideToggle: TourGuideToggleStrings;
     narrationToggle: NarrationToggleStrings;
     debugCoordinates: DebugCoordinatesStrings;
+    debugColliders: DebugColliderStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import {
   getAudioHudControlStrings,
   getAudioSubtitleStrings,
   getControlOverlayStrings,
+  getDebugColliderStrings,
   getDebugCoordinatesStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
@@ -108,6 +109,12 @@ import {
   type AvatarVariantId,
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
+import {
+  createColliderVisualizer,
+  type ColliderDebugDescriptor,
+  type ColliderDebugMetadata,
+  type ColliderVisualizerHandle,
+} from './scene/debug/colliderVisualizer';
 import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
@@ -467,6 +474,7 @@ const FENCE_THICKNESS = 0.28;
 const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
+const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
 const AVATAR_ASSET_REQUIRED_BONES = ['Hips', 'Spine'] as const;
 const AVATAR_ASSET_REQUIRED_ANIMATIONS = ['Idle', 'Walk', 'Run'] as const;
 const AVATAR_ASSET_EXPECTED_UNIT_SCALE = 1;
@@ -563,6 +571,15 @@ declare global {
           activeInWorldTooltipCount: number;
           totalInWorldTooltipCount: number;
         };
+      };
+      debugColliders?: {
+        getState(): {
+          enabled: boolean;
+          visibleColliderCount: number;
+          totalColliderCount: number;
+        };
+        setEnabled(enabled: boolean): void;
+        getColliders(): ColliderDebugMetadata[];
       };
       debugCoordinates?: {
         getState(): {
@@ -1308,27 +1325,42 @@ function initializeImmersiveScene(
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
   let narrationToggleStrings = getNarrationToggleStrings(locale);
+  let debugColliderStrings = getDebugColliderStrings(locale);
   let debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
   let tourResetControlStrings = getTourResetControlStrings(locale);
   let softwareRendererWarningStrings =
     getSoftwareRendererWarningStrings(locale);
   let siteStrings = getSiteStrings(locale);
-  let debugCoordinatesStorage: Storage | undefined;
+  let debugSettingsStorage: Storage | undefined;
   try {
-    debugCoordinatesStorage = window.localStorage;
+    debugSettingsStorage = window.localStorage;
   } catch {
-    debugCoordinatesStorage = undefined;
+    debugSettingsStorage = undefined;
   }
   const debugCoordinatesUrlOverride = new URLSearchParams(
     window.location.search
   ).get('debugCoordinates');
-  const debugCoordinatesUrlEnabled = ['1', 'true', 'yes', 'on'].includes(
-    debugCoordinatesUrlOverride?.toLowerCase() ?? ''
+  const isTruthyDebugUrlValue = (value: string | null): boolean =>
+    ['1', 'true', 'yes', 'on'].includes(value?.toLowerCase() ?? '');
+  const debugCoordinatesUrlEnabled = isTruthyDebugUrlValue(
+    debugCoordinatesUrlOverride
   );
   const debugCoordinatesStoredEnabled =
-    debugCoordinatesStorage?.getItem(DEBUG_COORDINATES_STORAGE_KEY) === '1';
+    debugSettingsStorage?.getItem(DEBUG_COORDINATES_STORAGE_KEY) === '1';
   let debugCoordinatesEnabled =
     debugCoordinatesUrlEnabled || debugCoordinatesStoredEnabled;
+  const debugCollidersUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugColliders');
+  const debugCollidersUrlEnabled = isTruthyDebugUrlValue(
+    debugCollidersUrlOverride
+  );
+  const debugCollidersStoredEnabled =
+    debugSettingsStorage?.getItem(DEBUG_COLLIDERS_STORAGE_KEY) === '1';
+  let debugCollidersEnabled =
+    debugCollidersUrlEnabled || debugCollidersStoredEnabled;
+  let debugCollidersControl: HTMLButtonElement | null = null;
+  let colliderVisualizer: ColliderVisualizerHandle | null = null;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
@@ -2602,6 +2634,36 @@ function initializeImmersiveScene(
     woveLoom = loom;
   }
 
+  const colliderDebugDescriptors: ColliderDebugDescriptor[] = [
+    ...groundColliders.map((collider, index) => ({
+      floor: 'ground' as const,
+      category: 'ground',
+      name: `ground-${index + 1}`,
+      bounds: collider,
+      elevation: 0,
+    })),
+    ...upperFloorColliders.map((collider, index) => ({
+      floor: 'upper' as const,
+      category: 'upper-floor',
+      name: `upper-${index + 1}`,
+      bounds: collider,
+      elevation: upperFloorElevation,
+    })),
+    ...staticColliders.map((collider, index) => ({
+      floor: 'ground' as const,
+      category: 'static',
+      name: `static-${index + 1}`,
+      bounds: collider,
+      elevation: 0,
+    })),
+  ];
+  colliderVisualizer = createColliderVisualizer({
+    scene,
+    colliders: colliderDebugDescriptors,
+    activeFloorId,
+    enabled: debugCollidersEnabled,
+  });
+
   poiInteractionManager = new PoiInteractionManager(
     renderer.domElement,
     camera,
@@ -3464,6 +3526,7 @@ function initializeImmersiveScene(
     audioHudStrings = getAudioHudControlStrings(locale);
     audioSubtitleStrings = getAudioSubtitleStrings(locale);
     narrationToggleStrings = getNarrationToggleStrings(locale);
+    debugColliderStrings = getDebugColliderStrings(locale);
     debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
@@ -3538,6 +3601,7 @@ function initializeImmersiveScene(
     poiNarrativeLog?.setStrings(narrativeLogStrings);
     audioSubtitles?.setLabels(audioSubtitleStrings);
     narrationToggleControl?.setStrings(narrationToggleStrings);
+    updateDebugCollidersControl();
     refreshDebugCoordinatesStrings();
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
@@ -3627,6 +3691,7 @@ function initializeImmersiveScene(
     }
     activeFloorId = next;
     floorVisibilityController.setActiveFloorId(next);
+    colliderVisualizer?.setActiveFloorId(next);
     poiWorldTooltip.setActiveFloorId(next);
     syncPoiDetailOverlay();
     syncPoiRecommendation();
@@ -3661,6 +3726,48 @@ function initializeImmersiveScene(
       containsRectPoint(bounds, player.position.x, player.position.z)
     );
     return room?.id ?? null;
+  };
+
+  const updateDebugCollidersControl = () => {
+    if (!debugCollidersControl) {
+      return;
+    }
+    const label = debugCollidersEnabled
+      ? debugColliderStrings.labelEnabled
+      : debugColliderStrings.labelDisabled;
+    const description = debugCollidersEnabled
+      ? debugColliderStrings.descriptionEnabled
+      : debugColliderStrings.descriptionDisabled;
+    debugCollidersControl.textContent = label;
+    debugCollidersControl.dataset.state = debugCollidersEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugCollidersControl.setAttribute(
+      'aria-pressed',
+      debugCollidersEnabled ? 'true' : 'false'
+    );
+    debugCollidersControl.setAttribute('aria-label', description);
+    debugCollidersControl.title = description;
+    debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const setDebugCollidersEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugCollidersEnabled = enabled;
+    colliderVisualizer?.setEnabled(enabled);
+    updateDebugCollidersControl();
+    if (options.persist !== false && debugSettingsStorage) {
+      try {
+        debugSettingsStorage.setItem(
+          DEBUG_COLLIDERS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist collider debug preference.', error);
+      }
+    }
   };
 
   const getDebugCoordinatesState = () => {
@@ -3855,9 +3962,9 @@ function initializeImmersiveScene(
     if (enabled) {
       updateDebugCoordinatesOverlay();
     }
-    if (options.persist !== false && debugCoordinatesStorage) {
+    if (options.persist !== false && debugSettingsStorage) {
       try {
-        debugCoordinatesStorage.setItem(
+        debugSettingsStorage.setItem(
           DEBUG_COORDINATES_STORAGE_KEY,
           enabled ? '1' : '0'
         );
@@ -3879,6 +3986,16 @@ function initializeImmersiveScene(
   document.body.appendChild(debugCoordinatesOverlay);
   createDebugCoordinatesOverlayContent();
 
+  debugCollidersControl = document.createElement('button');
+  debugCollidersControl.type = 'button';
+  debugCollidersControl.className = 'tour-toggle debug-colliders-toggle';
+  debugCollidersControl.addEventListener('click', () => {
+    setDebugCollidersEnabled(!debugCollidersEnabled);
+  });
+  hudSettingsStack.appendChild(debugCollidersControl);
+  registerHudControlElement(debugCollidersControl);
+  updateDebugCollidersControl();
+
   debugCoordinatesControl = document.createElement('button');
   debugCoordinatesControl.type = 'button';
   debugCoordinatesControl.className = 'tour-toggle debug-coordinates-toggle';
@@ -3893,6 +4010,19 @@ function initializeImmersiveScene(
     updateDebugCoordinatesOverlay,
     250
   );
+
+  window.portfolio.debugColliders = {
+    getState: () =>
+      colliderVisualizer?.getState() ?? {
+        enabled: debugCollidersEnabled,
+        visibleColliderCount: 0,
+        totalColliderCount: 0,
+      },
+    setEnabled: (enabled: boolean) => {
+      setDebugCollidersEnabled(enabled);
+    },
+    getColliders: () => colliderVisualizer?.getColliders() ?? [],
+  };
 
   window.portfolio.debugCoordinates = {
     getState: getDebugCoordinatesState,
@@ -5411,6 +5541,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
+    if (window.portfolio?.debugColliders) {
+      delete window.portfolio.debugColliders;
+    }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
     }
@@ -5421,6 +5554,14 @@ function initializeImmersiveScene(
     if (debugCoordinatesInterval !== null) {
       window.clearInterval(debugCoordinatesInterval);
       debugCoordinatesInterval = null;
+    }
+    if (debugCollidersControl) {
+      debugCollidersControl.remove();
+      debugCollidersControl = null;
+    }
+    if (colliderVisualizer) {
+      colliderVisualizer.dispose();
+      colliderVisualizer = null;
     }
     if (debugCoordinatesControl) {
       debugCoordinatesControl.remove();

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,0 +1,180 @@
+import {
+  BoxGeometry,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  type Object3D,
+  type Scene,
+} from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+import type { FloorId } from '../../systems/movement/stairs';
+
+export type ColliderDebugFloor = FloorId | 'all';
+
+export interface ColliderDebugDescriptor {
+  floor: ColliderDebugFloor;
+  category: string;
+  name: string;
+  bounds: RectCollider;
+  elevation?: number;
+}
+
+export interface ColliderDebugMetadata {
+  floor: ColliderDebugFloor;
+  category: string;
+  name: string;
+  bounds: RectCollider;
+}
+
+export interface ColliderVisualizerOptions {
+  colliders: readonly ColliderDebugDescriptor[];
+  scene: Scene;
+  activeFloorId: FloorId;
+  enabled?: boolean;
+}
+
+export interface ColliderVisualizerHandle {
+  group: Group;
+  setEnabled(enabled: boolean): void;
+  setActiveFloorId(floorId: FloorId): void;
+  getState(): {
+    enabled: boolean;
+    visibleColliderCount: number;
+    totalColliderCount: number;
+  };
+  getColliders(): ColliderDebugMetadata[];
+  dispose(): void;
+}
+
+const COLLIDER_HEIGHT = 0.18;
+const COLLIDER_Y_OFFSET = 0.11;
+const MIN_COLLIDER_DIMENSION = 0.02;
+
+const MATERIALS_BY_FLOOR: Record<ColliderDebugFloor, MeshBasicMaterial> = {
+  ground: new MeshBasicMaterial({
+    color: 0x35c4ff,
+    transparent: true,
+    opacity: 0.24,
+    depthWrite: false,
+  }),
+  upper: new MeshBasicMaterial({
+    color: 0xffb347,
+    transparent: true,
+    opacity: 0.24,
+    depthWrite: false,
+  }),
+  all: new MeshBasicMaterial({
+    color: 0xd764ff,
+    transparent: true,
+    opacity: 0.28,
+    depthWrite: false,
+  }),
+};
+
+const disableRaycast = (object: Object3D) => {
+  object.raycast = () => undefined;
+  object.traverse((child) => {
+    child.raycast = () => undefined;
+  });
+};
+
+const isColliderVisibleForFloor = (
+  colliderFloor: ColliderDebugFloor,
+  activeFloorId: FloorId
+): boolean => colliderFloor === 'all' || colliderFloor === activeFloorId;
+
+const createColliderMesh = (descriptor: ColliderDebugDescriptor): Mesh => {
+  const { bounds } = descriptor;
+  const width = Math.max(bounds.maxX - bounds.minX, MIN_COLLIDER_DIMENSION);
+  const depth = Math.max(bounds.maxZ - bounds.minZ, MIN_COLLIDER_DIMENSION);
+  const geometry = new BoxGeometry(width, COLLIDER_HEIGHT, depth);
+  const material = MATERIALS_BY_FLOOR[descriptor.floor];
+  const mesh = new Mesh(geometry, material);
+  mesh.name = `DebugCollider:${descriptor.floor}:${descriptor.category}:${descriptor.name}`;
+  mesh.position.set(
+    (bounds.minX + bounds.maxX) / 2,
+    (descriptor.elevation ?? 0) + COLLIDER_Y_OFFSET,
+    (bounds.minZ + bounds.maxZ) / 2
+  );
+  mesh.renderOrder = 10_000;
+  mesh.userData = {
+    ...mesh.userData,
+    debugOnly: true,
+    colliderDebug: {
+      floor: descriptor.floor,
+      category: descriptor.category,
+      name: descriptor.name,
+    },
+  };
+  disableRaycast(mesh);
+  return mesh;
+};
+
+export function createColliderVisualizer({
+  colliders,
+  scene,
+  activeFloorId,
+  enabled = false,
+}: ColliderVisualizerOptions): ColliderVisualizerHandle {
+  let currentFloorId = activeFloorId;
+  let isEnabled = enabled;
+  const group = new Group();
+  group.name = 'DebugColliderVisualizer';
+  group.userData = { ...group.userData, debugOnly: true };
+  disableRaycast(group);
+
+  const entries = colliders.map((descriptor) => ({
+    descriptor,
+    mesh: createColliderMesh(descriptor),
+  }));
+  entries.forEach(({ mesh }) => group.add(mesh));
+  scene.add(group);
+
+  const syncVisibility = () => {
+    group.visible = isEnabled;
+    entries.forEach(({ descriptor, mesh }) => {
+      mesh.visible =
+        isEnabled &&
+        isColliderVisibleForFloor(descriptor.floor, currentFloorId);
+    });
+  };
+
+  syncVisibility();
+
+  return {
+    group,
+    setEnabled(nextEnabled: boolean) {
+      isEnabled = nextEnabled;
+      syncVisibility();
+    },
+    setActiveFloorId(floorId: FloorId) {
+      currentFloorId = floorId;
+      syncVisibility();
+    },
+    getState() {
+      const visibleColliderCount = isEnabled
+        ? entries.filter(({ descriptor }) =>
+            isColliderVisibleForFloor(descriptor.floor, currentFloorId)
+          ).length
+        : 0;
+      return {
+        enabled: isEnabled,
+        visibleColliderCount,
+        totalColliderCount: entries.length,
+      };
+    },
+    getColliders() {
+      return entries.map(({ descriptor }) => ({
+        floor: descriptor.floor,
+        category: descriptor.category,
+        name: descriptor.name,
+        bounds: { ...descriptor.bounds },
+      }));
+    },
+    dispose() {
+      group.removeFromParent();
+      entries.forEach(({ mesh }) => mesh.geometry.dispose());
+    },
+  };
+}

--- a/src/tests/colliderVisualizer.test.ts
+++ b/src/tests/colliderVisualizer.test.ts
@@ -1,0 +1,93 @@
+import { Scene } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createColliderVisualizer } from '../scene/debug/colliderVisualizer';
+
+const colliders = [
+  {
+    floor: 'ground' as const,
+    category: 'ground',
+    name: 'ground-wall',
+    bounds: { minX: 0, maxX: 2, minZ: 0, maxZ: 1 },
+  },
+  {
+    floor: 'upper' as const,
+    category: 'upper-floor',
+    name: 'upper-wall',
+    bounds: { minX: 3, maxX: 4, minZ: 3, maxZ: 5 },
+    elevation: 6,
+  },
+  {
+    floor: 'all' as const,
+    category: 'stairs',
+    name: 'handoff',
+    bounds: { minX: -1, maxX: 1, minZ: -1, maxZ: 1 },
+  },
+];
+
+describe('createColliderVisualizer', () => {
+  it('hides debug geometry until enabled and filters by active floor', () => {
+    const scene = new Scene();
+    const visualizer = createColliderVisualizer({
+      scene,
+      colliders,
+      activeFloorId: 'ground',
+    });
+
+    expect(scene.children).toContain(visualizer.group);
+    expect(visualizer.group.visible).toBe(false);
+    expect(visualizer.getState()).toEqual({
+      enabled: false,
+      visibleColliderCount: 0,
+      totalColliderCount: 3,
+    });
+
+    visualizer.setEnabled(true);
+
+    expect(visualizer.group.visible).toBe(true);
+    expect(visualizer.getState()).toEqual({
+      enabled: true,
+      visibleColliderCount: 2,
+      totalColliderCount: 3,
+    });
+    expect(visualizer.group.children.map((child) => child.visible)).toEqual([
+      true,
+      false,
+      true,
+    ]);
+
+    visualizer.setActiveFloorId('upper');
+
+    expect(visualizer.getState().visibleColliderCount).toBe(2);
+    expect(visualizer.group.children.map((child) => child.visible)).toEqual([
+      false,
+      true,
+      true,
+    ]);
+
+    visualizer.dispose();
+    expect(scene.children).not.toContain(visualizer.group);
+  });
+
+  it('returns redacted collider metadata and disables raycasting', () => {
+    const visualizer = createColliderVisualizer({
+      scene: new Scene(),
+      colliders,
+      activeFloorId: 'ground',
+      enabled: true,
+    });
+
+    expect(visualizer.getColliders()).toEqual(
+      colliders.map(({ floor, category, name, bounds }) => ({
+        floor,
+        category,
+        name,
+        bounds,
+      }))
+    );
+    expect((visualizer.group.raycast as () => undefined)()).toBeUndefined();
+    expect(
+      (visualizer.group.children[0].raycast as () => undefined)()
+    ).toBeUndefined();
+  });
+});

--- a/src/tests/debugColliderI18n.test.ts
+++ b/src/tests/debugColliderI18n.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { AVAILABLE_LOCALES, getDebugColliderStrings } from '../assets/i18n';
+
+describe('debug collider i18n strings', () => {
+  it('provides accessible toggle copy for every locale', () => {
+    for (const locale of AVAILABLE_LOCALES) {
+      const strings = getDebugColliderStrings(locale);
+
+      expect(strings.labelEnabled, `${locale} enabled label`).toBeTruthy();
+      expect(strings.labelDisabled, `${locale} disabled label`).toBeTruthy();
+      expect(
+        strings.descriptionEnabled,
+        `${locale} enabled description`
+      ).toBeTruthy();
+      expect(
+        strings.descriptionDisabled,
+        `${locale} disabled description`
+      ).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Make invisible walls and collision rectangles inspectable during level/stair work without changing movement or collision semantics.
- Provide a lightweight, floor-aware diagnostic overlay and a persisted HUD toggle so QA can visualize colliders per active floor.

### Description
- Added a reusable visualizer at `src/scene/debug/colliderVisualizer.ts` that renders thin, semi-transparent Three.js boxes, disables raycasting, and is strictly diagnostic (non-interactive). 
- Registered descriptors for `groundColliders`, `upperFloorColliders`, and `staticColliders` in `src/main.ts` after collider arrays are populated and wired the visualizer to follow the active floor.
- Added a persisted Settings toggle and URL override with storage key `danielsmith.io::debugColliders::v1` and truthy URL values (`?debugColliders=1`), plus accessible ARIA attributes and HUD announcement metadata mirroring the existing debug coordinates flow.
- Exposed `window.portfolio.debugColliders` with `getState()`, `setEnabled(enabled)`, and `getColliders()` helpers; this is redacted metadata only and does not affect runtime collision arrays.
- Added i18n support and localized strings for the toggle across locales and updated `src/assets/i18n/types.ts` / `index.ts` to include `debugColliders` accessors.
- Added focused unit tests: `src/tests/colliderVisualizer.test.ts` (visualization visibility, floor filtering, raycast disable, disposal) and `src/tests/debugColliderI18n.test.ts` (locale coverage).

### Testing
- Ran formatting: `npm run format:write` — passed.
- Lint: `npm run lint` — passed.
- Focused tests: `npm run test:ci -- src/tests/colliderVisualizer.test.ts src/tests/debugColliderI18n.test.ts` — passed.
- Full test suite: `npm run test:ci` — passed (143 files, 1058 tests ran; all passed in CI run shown).
- Build: `npm run build` — passed (vite build completed; chunk size warnings noted but expected).
- Docs check: `npm run docs:check` — passed (link checker reported expected external-fetch warnings).
- Smoke: `npm run smoke` — passed.
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — passed (no high-risk secrets detected).
- Typecheck: `npm run typecheck` — failed due to pre-existing, unrelated TypeScript issues elsewhere in the repo (reported but not caused by this change).
- Playwright/manual screenshot attempt for `?mode=immersive&disablePerformanceFailover=1&debugColliders=1` was attempted but blocked because Playwright Chromium isn't installed in the container; manual browser verification was attempted and is recommended locally.

Notes: The overlay is diagnostic only and explicitly disables raycasting and interaction; enabling the HUD does not change collision behavior. Follow-ups could expose an “all floors” mode in the UI, but the toggle defaults to active-floor visualization as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25fc97d238832f8474bee820bb9009)