### PR TITLE
Add collider debug visualization toggle

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -27,6 +27,7 @@ import type {
   MovementLegendStrings,
   NarrationToggleStrings,
   DebugCoordinatesStrings,
+  DebugCollidersStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
   PoiOverlayChromeStrings,
@@ -473,6 +474,12 @@ export function getDebugCoordinatesStrings(
   input?: LocaleInput
 ): DebugCoordinatesStrings {
   return cloneValue(getLocaleStrings(input).hud.debugCoordinates);
+}
+
+export function getDebugCollidersStrings(
+  input?: LocaleInput
+): DebugCollidersStrings {
+  return cloneValue(getLocaleStrings(input).hud.debugColliders);
 }
 
 export function getTourResetControlStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -300,10 +300,12 @@ export const AR_OVERRIDES: LocaleOverrides = {
       },
     },
     debugColliders: {
-      labelEnabled: 'جدران التصادم مفعّلة',
-      labelDisabled: 'جدران التصادم معطّلة',
-      descriptionEnabled: 'يعرض جدران التصادم المخفية للطابق النشط.',
-      descriptionDisabled: 'تبقى جدران التصادم المخفية غير ظاهرة حتى تفعّلها.',
+      labelEnabled: 'تراكب المصادمات مفعّل',
+      labelDisabled: 'تراكب المصادمات معطّل',
+      descriptionEnabled:
+        'يعرض الجدران غير المرئية ومستطيلات التصادم للطابق النشط.',
+      descriptionDisabled:
+        'تبقى الجدران غير المرئية ومستطيلات التصادم مخفية حتى تفعّلها.',
     },
     poiOverlay: {
       visited: 'تمت الزيارة',

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -299,6 +299,12 @@ export const AR_OVERRIDES: LocaleOverrides = {
         none: 'لا شيء',
       },
     },
+    debugColliders: {
+      labelEnabled: 'جدران التصادم مفعّلة',
+      labelDisabled: 'جدران التصادم معطّلة',
+      descriptionEnabled: 'يعرض جدران التصادم المخفية للطابق النشط.',
+      descriptionDisabled: 'تبقى جدران التصادم المخفية غير ظاهرة حتى تفعّلها.',
+    },
     poiOverlay: {
       visited: 'تمت الزيارة',
       nextHighlight: 'المحطة التالية',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -68,12 +68,12 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Ja',
     debugCoordinatesNo: 'Nein',
     debugCoordinatesNone: 'Keine',
-    debugCollidersLabelEnabled: 'Kollisionswände ein',
-    debugCollidersLabelDisabled: 'Kollisionswände aus',
+    debugCollidersLabelEnabled: 'Collider-Overlay ein',
+    debugCollidersLabelDisabled: 'Collider-Overlay aus',
     debugCollidersDescriptionEnabled:
-      'Zeigt die unsichtbaren Kollisionswände der aktiven Etage.',
+      'Zeigt unsichtbare Wände und Kollisionsrechtecke der aktiven Etage.',
     debugCollidersDescriptionDisabled:
-      'Unsichtbare Kollisionswände bleiben verborgen, bis du sie einschaltest.',
+      'Unsichtbare Wände und Kollisionsrechtecke bleiben verborgen, bis du sie einschaltest.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -68,6 +68,12 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Ja',
     debugCoordinatesNo: 'Nein',
     debugCoordinatesNone: 'Keine',
+    debugCollidersLabelEnabled: 'Kollisionswände ein',
+    debugCollidersLabelDisabled: 'Kollisionswände aus',
+    debugCollidersDescriptionEnabled:
+      'Zeigt die unsichtbaren Kollisionswände der aktiven Etage.',
+    debugCollidersDescriptionDisabled:
+      'Unsichtbare Kollisionswände bleiben verborgen, bis du sie einschaltest.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -356,6 +356,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         none: wrap('None'),
       },
     },
+    debugColliders: {
+      labelEnabled: wrap('Collider walls on'),
+      labelDisabled: wrap('Collider walls off'),
+      descriptionEnabled: wrap(
+        'Shows invisible collision walls for the active floor.'
+      ),
+      descriptionDisabled: wrap(
+        'Invisible collision walls stay hidden until you turn them on.'
+      ),
+    },
     tourReset: {
       heading: wrap('Guided tour'),
       resetKey: 'g',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -357,13 +357,13 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       },
     },
     debugColliders: {
-      labelEnabled: wrap('Collider walls on'),
-      labelDisabled: wrap('Collider walls off'),
+      labelEnabled: wrap('Collider overlay on'),
+      labelDisabled: wrap('Collider overlay off'),
       descriptionEnabled: wrap(
-        'Shows invisible collision walls for the active floor.'
+        'Shows invisible walls and collision rectangles for the active floor.'
       ),
       descriptionDisabled: wrap(
-        'Invisible collision walls stay hidden until you turn them on.'
+        'Invisible walls and collision rectangles stay hidden until you turn them on.'
       ),
     },
     tourReset: {

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -364,6 +364,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         none: 'None',
       },
     },
+    debugColliders: {
+      labelEnabled: 'Collider walls on',
+      labelDisabled: 'Collider walls off',
+      descriptionEnabled:
+        'Shows invisible collision walls for the active floor.',
+      descriptionDisabled:
+        'Invisible collision walls stay hidden until you turn them on.',
+    },
     tourReset: {
       heading: 'Guided tour',
       resetKey: 'g',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -365,12 +365,12 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       },
     },
     debugColliders: {
-      labelEnabled: 'Collider walls on',
-      labelDisabled: 'Collider walls off',
+      labelEnabled: 'Collider overlay on',
+      labelDisabled: 'Collider overlay off',
       descriptionEnabled:
-        'Shows invisible collision walls for the active floor.',
+        'Shows invisible walls and collision rectangles for the active floor.',
       descriptionDisabled:
-        'Invisible collision walls stay hidden until you turn them on.',
+        'Invisible walls and collision rectangles stay hidden until you turn them on.',
     },
     tourReset: {
       heading: 'Guided tour',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -68,12 +68,12 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Sí',
     debugCoordinatesNo: 'No',
     debugCoordinatesNone: 'Ninguna',
-    debugCollidersLabelEnabled: 'Muros de colisión activados',
-    debugCollidersLabelDisabled: 'Muros de colisión desactivados',
+    debugCollidersLabelEnabled: 'Superposición de colliders activada',
+    debugCollidersLabelDisabled: 'Superposición de colliders desactivada',
     debugCollidersDescriptionEnabled:
-      'Muestra los muros de colisión invisibles del piso activo.',
+      'Muestra muros invisibles y rectángulos de colisión del piso activo.',
     debugCollidersDescriptionDisabled:
-      'Los muros de colisión invisibles permanecen ocultos hasta que los actives.',
+      'Los muros invisibles y los rectángulos de colisión permanecen ocultos hasta que los actives.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -68,6 +68,12 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Sí',
     debugCoordinatesNo: 'No',
     debugCoordinatesNone: 'Ninguna',
+    debugCollidersLabelEnabled: 'Muros de colisión activados',
+    debugCollidersLabelDisabled: 'Muros de colisión desactivados',
+    debugCollidersDescriptionEnabled:
+      'Muestra los muros de colisión invisibles del piso activo.',
+    debugCollidersDescriptionDisabled:
+      'Los muros de colisión invisibles permanecen ocultos hasta que los actives.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -68,6 +68,12 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Igen',
     debugCoordinatesNo: 'Nem',
     debugCoordinatesNone: 'Nincs',
+    debugCollidersLabelEnabled: 'Ütközési falak be',
+    debugCollidersLabelDisabled: 'Ütközési falak ki',
+    debugCollidersDescriptionEnabled:
+      'Megjeleníti az aktív emelet láthatatlan ütközési falait.',
+    debugCollidersDescriptionDisabled:
+      'A láthatatlan ütközési falak rejtve maradnak, amíg be nem kapcsolod.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -68,12 +68,12 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Igen',
     debugCoordinatesNo: 'Nem',
     debugCoordinatesNone: 'Nincs',
-    debugCollidersLabelEnabled: 'Ütközési falak be',
-    debugCollidersLabelDisabled: 'Ütközési falak ki',
+    debugCollidersLabelEnabled: 'Collider-réteg be',
+    debugCollidersLabelDisabled: 'Collider-réteg ki',
     debugCollidersDescriptionEnabled:
-      'Megjeleníti az aktív emelet láthatatlan ütközési falait.',
+      'Megjeleníti az aktív emelet láthatatlan falait és ütközési téglalapjait.',
     debugCollidersDescriptionDisabled:
-      'A láthatatlan ütközési falak rejtve maradnak, amíg be nem kapcsolod.',
+      'A láthatatlan falak és ütközési téglalapok rejtve maradnak, amíg be nem kapcsolod.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -302,10 +302,10 @@ export const JA_OVERRIDES: LocaleOverrides = {
       },
     },
     debugColliders: {
-      labelEnabled: 'コライダー壁オン',
-      labelDisabled: 'コライダー壁オフ',
-      descriptionEnabled: '現在の階の見えない衝突壁を表示します。',
-      descriptionDisabled: '見えない衝突壁はオンにするまで非表示です。',
+      labelEnabled: 'コライダーオーバーレイオン',
+      labelDisabled: 'コライダーオーバーレイオフ',
+      descriptionEnabled: '現在の階の見えない壁と衝突矩形を表示します。',
+      descriptionDisabled: '見えない壁と衝突矩形はオンにするまで非表示です。',
     },
     poiOverlay: {
       visited: '訪問済み',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -301,6 +301,12 @@ export const JA_OVERRIDES: LocaleOverrides = {
         none: 'なし',
       },
     },
+    debugColliders: {
+      labelEnabled: 'コライダー壁オン',
+      labelDisabled: 'コライダー壁オフ',
+      descriptionEnabled: '現在の階の見えない衝突壁を表示します。',
+      descriptionDisabled: '見えない衝突壁はオンにするまで非表示です。',
+    },
     poiOverlay: {
       visited: '訪問済み',
       nextHighlight: '次のハイライト',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -67,6 +67,10 @@ interface LatinLocaleCopy {
     debugCoordinatesYes: string;
     debugCoordinatesNo: string;
     debugCoordinatesNone: string;
+    debugCollidersLabelEnabled: string;
+    debugCollidersLabelDisabled: string;
+    debugCollidersDescriptionEnabled: string;
+    debugCollidersDescriptionDisabled: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -739,6 +743,12 @@ export function buildLatinLocaleOverrides(
           no: s.debugCoordinatesNo,
           none: s.debugCoordinatesNone,
         },
+      },
+      debugColliders: {
+        labelEnabled: s.debugCollidersLabelEnabled,
+        labelDisabled: s.debugCollidersLabelDisabled,
+        descriptionEnabled: s.debugCollidersDescriptionEnabled,
+        descriptionDisabled: s.debugCollidersDescriptionDisabled,
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -68,6 +68,12 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Sim',
     debugCoordinatesNo: 'Não',
     debugCoordinatesNone: 'Nenhuma',
+    debugCollidersLabelEnabled: 'Paredes de colisão ativadas',
+    debugCollidersLabelDisabled: 'Paredes de colisão desativadas',
+    debugCollidersDescriptionEnabled:
+      'Mostra as paredes de colisão invisíveis do piso ativo.',
+    debugCollidersDescriptionDisabled:
+      'As paredes de colisão invisíveis ficam ocultas até você ativá-las.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -68,12 +68,12 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesYes: 'Sim',
     debugCoordinatesNo: 'Não',
     debugCoordinatesNone: 'Nenhuma',
-    debugCollidersLabelEnabled: 'Paredes de colisão ativadas',
-    debugCollidersLabelDisabled: 'Paredes de colisão desativadas',
+    debugCollidersLabelEnabled: 'Sobreposição de colisores ativada',
+    debugCollidersLabelDisabled: 'Sobreposição de colisores desativada',
     debugCollidersDescriptionEnabled:
-      'Mostra as paredes de colisão invisíveis do piso ativo.',
+      'Mostra paredes invisíveis e retângulos de colisão do piso ativo.',
     debugCollidersDescriptionDisabled:
-      'As paredes de colisão invisíveis ficam ocultas até você ativá-las.',
+      'As paredes invisíveis e os retângulos de colisão ficam ocultos até você ativá-los.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -288,6 +288,12 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         none: '无',
       },
     },
+    debugColliders: {
+      labelEnabled: '碰撞墙已开启',
+      labelDisabled: '碰撞墙已关闭',
+      descriptionEnabled: '显示当前楼层的不可见碰撞墙。',
+      descriptionDisabled: '不可见碰撞墙会保持隐藏，直到你开启。',
+    },
     tourReset: {
       heading: '导览',
       resetKey: 'g',

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -289,10 +289,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       },
     },
     debugColliders: {
-      labelEnabled: '碰撞墙已开启',
-      labelDisabled: '碰撞墙已关闭',
-      descriptionEnabled: '显示当前楼层的不可见碰撞墙。',
-      descriptionDisabled: '不可见碰撞墙会保持隐藏，直到你开启。',
+      labelEnabled: '碰撞体叠加层已开启',
+      labelDisabled: '碰撞体叠加层已关闭',
+      descriptionEnabled: '显示当前楼层的不可见墙和碰撞矩形。',
+      descriptionDisabled: '不可见墙和碰撞矩形会保持隐藏，直到你开启。',
     },
     tourReset: {
       heading: '导览',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -233,6 +233,13 @@ export interface DebugCoordinatesStrings {
   };
 }
 
+export interface DebugCollidersStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
 export interface TourResetControlStrings {
   heading: string;
   resetKey: string;
@@ -423,6 +430,7 @@ export interface LocaleStrings {
     tourGuideToggle: TourGuideToggleStrings;
     narrationToggle: NarrationToggleStrings;
     debugCoordinates: DebugCoordinatesStrings;
+    debugColliders: DebugCollidersStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ import {
   getAudioSubtitleStrings,
   getControlOverlayStrings,
   getDebugCoordinatesStrings,
+  getDebugCollidersStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
   getLocaleDirection,
@@ -108,6 +109,12 @@ import {
   type AvatarVariantId,
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
+import {
+  createColliderVisualizer,
+  type DebugColliderMetadata,
+  type DebugColliderRegistration,
+  type DebugColliderVisualizerState,
+} from './scene/debug/colliderVisualizer';
 import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
@@ -467,6 +474,8 @@ const FENCE_THICKNESS = 0.28;
 const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
+const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
+const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const AVATAR_ASSET_REQUIRED_BONES = ['Hips', 'Spine'] as const;
 const AVATAR_ASSET_REQUIRED_ANIMATIONS = ['Idle', 'Walk', 'Run'] as const;
 const AVATAR_ASSET_EXPECTED_UNIT_SCALE = 1;
@@ -563,6 +572,11 @@ declare global {
           activeInWorldTooltipCount: number;
           totalInWorldTooltipCount: number;
         };
+      };
+      debugColliders?: {
+        getState(): DebugColliderVisualizerState;
+        setEnabled(enabled: boolean): void;
+        getColliders(): DebugColliderMetadata[];
       };
       debugCoordinates?: {
         getState(): {
@@ -1309,6 +1323,7 @@ function initializeImmersiveScene(
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
   let narrationToggleStrings = getNarrationToggleStrings(locale);
   let debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
+  let debugCollidersStrings = getDebugCollidersStrings(locale);
   let tourResetControlStrings = getTourResetControlStrings(locale);
   let softwareRendererWarningStrings =
     getSoftwareRendererWarningStrings(locale);
@@ -1322,14 +1337,28 @@ function initializeImmersiveScene(
   const debugCoordinatesUrlOverride = new URLSearchParams(
     window.location.search
   ).get('debugCoordinates');
-  const debugCoordinatesUrlEnabled = ['1', 'true', 'yes', 'on'].includes(
-    debugCoordinatesUrlOverride?.toLowerCase() ?? ''
+  const debugCoordinatesUrlEnabled = DEBUG_URL_TRUTHY_VALUES.includes(
+    (debugCoordinatesUrlOverride?.toLowerCase() ??
+      '') as (typeof DEBUG_URL_TRUTHY_VALUES)[number]
   );
   const debugCoordinatesStoredEnabled =
     debugCoordinatesStorage?.getItem(DEBUG_COORDINATES_STORAGE_KEY) === '1';
   let debugCoordinatesEnabled =
     debugCoordinatesUrlEnabled || debugCoordinatesStoredEnabled;
+
+  const debugCollidersUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugColliders');
+  const debugCollidersUrlEnabled = DEBUG_URL_TRUTHY_VALUES.includes(
+    (debugCollidersUrlOverride?.toLowerCase() ??
+      '') as (typeof DEBUG_URL_TRUTHY_VALUES)[number]
+  );
+  const debugCollidersStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_COLLIDERS_STORAGE_KEY) === '1';
+  let debugCollidersEnabled =
+    debugCollidersUrlEnabled || debugCollidersStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
+  let debugCollidersControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -3465,6 +3494,7 @@ function initializeImmersiveScene(
     audioSubtitleStrings = getAudioSubtitleStrings(locale);
     narrationToggleStrings = getNarrationToggleStrings(locale);
     debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
+    debugCollidersStrings = getDebugCollidersStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
@@ -3539,6 +3569,7 @@ function initializeImmersiveScene(
     audioSubtitles?.setLabels(audioSubtitleStrings);
     narrationToggleControl?.setStrings(narrationToggleStrings);
     refreshDebugCoordinatesStrings();
+    refreshDebugCollidersStrings();
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
@@ -3631,6 +3662,7 @@ function initializeImmersiveScene(
     syncPoiDetailOverlay();
     syncPoiRecommendation();
     document.documentElement.dataset.activeFloor = next;
+    colliderVisualizer.setActiveFloor(next);
   };
 
   const updatePlayerVerticalPosition = () => {
@@ -3647,6 +3679,47 @@ function initializeImmersiveScene(
 
   updatePlayerVerticalPosition();
   document.documentElement.dataset.activeFloor = activeFloorId;
+
+  const createDebugColliderRegistrations = (
+    colliders: readonly RectCollider[],
+    options: {
+      floor: DebugColliderRegistration['floor'];
+      category: string;
+      namePrefix: string;
+      elevation?: number;
+    }
+  ): DebugColliderRegistration[] =>
+    colliders.map((bounds, index) => ({
+      floor: options.floor,
+      category: options.category,
+      name: `${options.namePrefix}-${index + 1}`,
+      bounds,
+      elevation: options.elevation,
+    }));
+
+  const colliderVisualizer = createColliderVisualizer({
+    activeFloorId,
+    enabled: debugCollidersEnabled,
+  });
+  colliderVisualizer.register([
+    ...createDebugColliderRegistrations(groundColliders, {
+      floor: 'ground',
+      category: 'ground',
+      namePrefix: 'ground-collider',
+    }),
+    ...createDebugColliderRegistrations(staticColliders, {
+      floor: 'ground',
+      category: 'static',
+      namePrefix: 'static-collider',
+    }),
+    ...createDebugColliderRegistrations(upperFloorColliders, {
+      floor: 'upper',
+      category: 'upper',
+      namePrefix: 'upper-collider',
+      elevation: upperFloorElevation,
+    }),
+  ]);
+  scene.add(colliderVisualizer.group);
 
   const containsRectPoint = (
     rect: { minX: number; maxX: number; minZ: number; maxZ: number },
@@ -3845,6 +3918,48 @@ function initializeImmersiveScene(
     debugCoordinatesControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugCollidersControl = () => {
+    if (!debugCollidersControl) {
+      return;
+    }
+    const label = debugCollidersEnabled
+      ? debugCollidersStrings.labelEnabled
+      : debugCollidersStrings.labelDisabled;
+    const description = debugCollidersEnabled
+      ? debugCollidersStrings.descriptionEnabled
+      : debugCollidersStrings.descriptionDisabled;
+    debugCollidersControl.textContent = label;
+    debugCollidersControl.dataset.state = debugCollidersEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugCollidersControl.setAttribute(
+      'aria-pressed',
+      debugCollidersEnabled ? 'true' : 'false'
+    );
+    debugCollidersControl.setAttribute('aria-label', description);
+    debugCollidersControl.title = description;
+    debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const setDebugCollidersEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugCollidersEnabled = enabled;
+    colliderVisualizer.setEnabled(enabled);
+    refreshDebugCollidersControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_COLLIDERS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug collider preference.', error);
+      }
+    }
+  };
+
   const setDebugCoordinatesEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -3873,6 +3988,10 @@ function initializeImmersiveScene(
     updateDebugCoordinatesOverlay();
   };
 
+  const refreshDebugCollidersStrings = () => {
+    refreshDebugCollidersControl();
+  };
+
   debugCoordinatesOverlay = document.createElement('aside');
   debugCoordinatesOverlay.className = 'debug-coordinates';
   syncDebugCoordinatesOverlayVisibility();
@@ -3888,11 +4007,29 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugCoordinatesControl);
   registerHudControlElement(debugCoordinatesControl);
   refreshDebugCoordinatesControl();
+
+  debugCollidersControl = document.createElement('button');
+  debugCollidersControl.type = 'button';
+  debugCollidersControl.className = 'tour-toggle debug-colliders-toggle';
+  debugCollidersControl.addEventListener('click', () => {
+    setDebugCollidersEnabled(!debugCollidersEnabled);
+  });
+  hudSettingsStack.appendChild(debugCollidersControl);
+  registerHudControlElement(debugCollidersControl);
+  refreshDebugCollidersControl();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
     250
   );
+
+  window.portfolio.debugColliders = {
+    getState: () => colliderVisualizer.getState(),
+    setEnabled: (enabled: boolean) => {
+      setDebugCollidersEnabled(enabled);
+    },
+    getColliders: () => colliderVisualizer.getColliders(),
+  };
 
   window.portfolio.debugCoordinates = {
     getState: getDebugCoordinatesState,
@@ -5408,6 +5545,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.narration) {
       delete window.portfolio.narration;
     }
+    if (window.portfolio?.debugColliders) {
+      delete window.portfolio.debugColliders;
+    }
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
@@ -5426,12 +5566,17 @@ function initializeImmersiveScene(
       debugCoordinatesControl.remove();
       debugCoordinatesControl = null;
     }
+    if (debugCollidersControl) {
+      debugCollidersControl.remove();
+      debugCollidersControl = null;
+    }
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
       debugCoordinatesHeading = null;
       debugCoordinatesRows.clear();
     }
+    colliderVisualizer.dispose();
     movementLegend?.dispose();
     narrationPreference.dispose();
     if (proceduralNarrator) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -476,6 +476,14 @@ const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
+const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
+const isDebugUrlValueIn = (
+  value: string | null | undefined,
+  candidates: readonly string[]
+) => {
+  const normalizedValue = value?.toLowerCase() ?? '';
+  return candidates.some((candidate) => candidate === normalizedValue);
+};
 const AVATAR_ASSET_REQUIRED_BONES = ['Hips', 'Spine'] as const;
 const AVATAR_ASSET_REQUIRED_ANIMATIONS = ['Idle', 'Walk', 'Run'] as const;
 const AVATAR_ASSET_EXPECTED_UNIT_SCALE = 1;
@@ -1337,9 +1345,9 @@ function initializeImmersiveScene(
   const debugCoordinatesUrlOverride = new URLSearchParams(
     window.location.search
   ).get('debugCoordinates');
-  const debugCoordinatesUrlEnabled = DEBUG_URL_TRUTHY_VALUES.includes(
-    (debugCoordinatesUrlOverride?.toLowerCase() ??
-      '') as (typeof DEBUG_URL_TRUTHY_VALUES)[number]
+  const debugCoordinatesUrlEnabled = isDebugUrlValueIn(
+    debugCoordinatesUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
   );
   const debugCoordinatesStoredEnabled =
     debugCoordinatesStorage?.getItem(DEBUG_COORDINATES_STORAGE_KEY) === '1';
@@ -1349,14 +1357,19 @@ function initializeImmersiveScene(
   const debugCollidersUrlOverride = new URLSearchParams(
     window.location.search
   ).get('debugColliders');
-  const debugCollidersUrlEnabled = DEBUG_URL_TRUTHY_VALUES.includes(
-    (debugCollidersUrlOverride?.toLowerCase() ??
-      '') as (typeof DEBUG_URL_TRUTHY_VALUES)[number]
+  const debugCollidersUrlEnabled = isDebugUrlValueIn(
+    debugCollidersUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugCollidersUrlDisabled = isDebugUrlValueIn(
+    debugCollidersUrlOverride,
+    DEBUG_URL_FALSY_VALUES
   );
   const debugCollidersStoredEnabled =
     debugCoordinatesStorage?.getItem(DEBUG_COLLIDERS_STORAGE_KEY) === '1';
-  let debugCollidersEnabled =
-    debugCollidersUrlEnabled || debugCollidersStoredEnabled;
+  let debugCollidersEnabled = debugCollidersUrlDisabled
+    ? false
+    : debugCollidersUrlEnabled || debugCollidersStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -74,8 +74,10 @@ describe('createColliderVisualizer', () => {
       name: 'static-0',
       bounds: collider,
     });
-    expect(
-      visualizer.group.children[0].raycast({} as never, [] as never)
-    ).toBeUndefined();
+    const mesh = visualizer.group.children[0];
+    const material = (mesh as { material: { depthTest: boolean } }).material;
+
+    expect(mesh.raycast({} as never, [] as never)).toBeUndefined();
+    expect(material.depthTest).toBe(false);
   });
 });

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { createColliderVisualizer } from '../colliderVisualizer';
+
+const collider = {
+  minX: 1,
+  maxX: 3,
+  minZ: 2,
+  maxZ: 5,
+};
+
+describe('createColliderVisualizer', () => {
+  it('tracks total and active-floor visible collider counts', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'ground-0',
+        bounds: collider,
+      },
+      {
+        floor: 'upper',
+        category: 'walls',
+        name: 'upper-0',
+        bounds: { minX: -2, maxX: -1, minZ: -3, maxZ: -2 },
+      },
+      {
+        floor: 'all',
+        category: 'stairs',
+        name: 'transition-0',
+        bounds: { minX: 0, maxX: 1, minZ: 0, maxZ: 1 },
+      },
+    ]);
+
+    expect(visualizer.getState()).toEqual({
+      enabled: false,
+      visibleColliderCount: 0,
+      totalColliderCount: 3,
+    });
+
+    visualizer.setEnabled(true);
+    expect(visualizer.getState()).toEqual({
+      enabled: true,
+      visibleColliderCount: 2,
+      totalColliderCount: 3,
+    });
+
+    visualizer.setActiveFloor('upper');
+    expect(visualizer.getState().visibleColliderCount).toBe(2);
+  });
+
+  it('returns redacted metadata copies and non-raycasting meshes', () => {
+    const visualizer = createColliderVisualizer({
+      activeFloorId: 'ground',
+      enabled: true,
+    });
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'static',
+        name: 'static-0',
+        bounds: collider,
+      },
+    ]);
+
+    const metadata = visualizer.getColliders();
+    metadata[0].bounds.minX = 99;
+
+    expect(visualizer.getColliders()[0]).toEqual({
+      floor: 'ground',
+      category: 'static',
+      name: 'static-0',
+      bounds: collider,
+    });
+    expect(
+      visualizer.group.children[0].raycast({} as never, [] as never)
+    ).toBeUndefined();
+  });
+});

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -1,3 +1,4 @@
+import type { Material, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { createColliderVisualizer } from '../colliderVisualizer';
@@ -74,8 +75,8 @@ describe('createColliderVisualizer', () => {
       name: 'static-0',
       bounds: collider,
     });
-    const mesh = visualizer.group.children[0];
-    const material = (mesh as { material: { depthTest: boolean } }).material;
+    const mesh = visualizer.group.children[0] as Mesh;
+    const material = mesh.material as Material;
 
     expect(mesh.raycast({} as never, [] as never)).toBeUndefined();
     expect(material.depthTest).toBe(false);

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -102,6 +102,7 @@ export function createColliderVisualizer(options: {
       const geometry = new BoxGeometry(width, height, depth);
       const material = new MeshBasicMaterial({
         color: collider.color ?? FLOOR_COLORS[collider.floor] ?? DEFAULT_COLOR,
+        depthTest: false,
         depthWrite: false,
         opacity: 0.42,
         transparent: true,

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,0 +1,183 @@
+import {
+  BoxGeometry,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  type ColorRepresentation,
+  type Object3D,
+} from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+import type { FloorId } from '../../systems/movement/stairs';
+
+export type DebugColliderFloor = FloorId | 'all';
+
+export interface DebugColliderMetadata {
+  floor: DebugColliderFloor;
+  category: string;
+  name: string;
+  bounds: RectCollider;
+}
+
+export interface DebugColliderRegistration extends DebugColliderMetadata {
+  elevation?: number;
+  height?: number;
+  color?: ColorRepresentation;
+}
+
+export interface DebugColliderVisualizerState {
+  enabled: boolean;
+  visibleColliderCount: number;
+  totalColliderCount: number;
+}
+
+interface DebugColliderVisualEntry {
+  metadata: DebugColliderMetadata;
+  mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
+}
+
+export interface ColliderVisualizer {
+  readonly group: Group;
+  register(colliders: readonly DebugColliderRegistration[]): void;
+  setEnabled(enabled: boolean): void;
+  setActiveFloor(floorId: FloorId): void;
+  getState(): DebugColliderVisualizerState;
+  getColliders(): DebugColliderMetadata[];
+  dispose(): void;
+}
+
+const DEFAULT_HEIGHT = 0.08;
+const MIN_DIMENSION = 0.02;
+const DEFAULT_COLOR = 0x66e6ff;
+const FLOOR_COLORS: Record<DebugColliderFloor, number> = {
+  ground: 0x2ee66b,
+  upper: 0xf7c948,
+  all: 0x66e6ff,
+};
+
+const cloneBounds = (bounds: RectCollider): RectCollider => ({
+  minX: bounds.minX,
+  maxX: bounds.maxX,
+  minZ: bounds.minZ,
+  maxZ: bounds.maxZ,
+});
+
+const isVisibleOnFloor = (
+  colliderFloor: DebugColliderFloor,
+  activeFloorId: FloorId
+): boolean => colliderFloor === 'all' || colliderFloor === activeFloorId;
+
+export function createColliderVisualizer(options: {
+  activeFloorId: FloorId;
+  enabled?: boolean;
+}): ColliderVisualizer {
+  const group = new Group();
+  group.name = 'DebugColliderVisualizer';
+  group.visible = options.enabled ?? false;
+  group.userData.debugOnly = true;
+
+  const entries: DebugColliderVisualEntry[] = [];
+  let enabled = options.enabled ?? false;
+  let activeFloorId = options.activeFloorId;
+
+  const applyVisibility = () => {
+    group.visible = enabled;
+    for (const entry of entries) {
+      entry.mesh.visible =
+        enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
+    }
+  };
+
+  const register = (colliders: readonly DebugColliderRegistration[]) => {
+    for (const collider of colliders) {
+      const width = Math.max(
+        collider.bounds.maxX - collider.bounds.minX,
+        MIN_DIMENSION
+      );
+      const depth = Math.max(
+        collider.bounds.maxZ - collider.bounds.minZ,
+        MIN_DIMENSION
+      );
+      const height = collider.height ?? DEFAULT_HEIGHT;
+      const geometry = new BoxGeometry(width, height, depth);
+      const material = new MeshBasicMaterial({
+        color: collider.color ?? FLOOR_COLORS[collider.floor] ?? DEFAULT_COLOR,
+        depthWrite: false,
+        opacity: 0.42,
+        transparent: true,
+        wireframe: true,
+      });
+      const mesh = new Mesh(geometry, material);
+      mesh.name = `DebugCollider:${collider.floor}:${collider.category}:${collider.name}`;
+      mesh.position.set(
+        (collider.bounds.minX + collider.bounds.maxX) / 2,
+        (collider.elevation ?? 0) + height / 2,
+        (collider.bounds.minZ + collider.bounds.maxZ) / 2
+      );
+      mesh.renderOrder = 10_000;
+      mesh.userData.debugOnly = true;
+      mesh.userData.colliderDebug = {
+        floor: collider.floor,
+        category: collider.category,
+        name: collider.name,
+      };
+      mesh.raycast = () => undefined;
+      group.add(mesh);
+      entries.push({
+        metadata: {
+          floor: collider.floor,
+          category: collider.category,
+          name: collider.name,
+          bounds: cloneBounds(collider.bounds),
+        },
+        mesh,
+      });
+    }
+    applyVisibility();
+  };
+
+  const getVisibleColliderCount = () =>
+    enabled
+      ? entries.filter((entry) =>
+          isVisibleOnFloor(entry.metadata.floor, activeFloorId)
+        ).length
+      : 0;
+
+  return {
+    group,
+    register,
+    setEnabled(next: boolean) {
+      enabled = next;
+      applyVisibility();
+    },
+    setActiveFloor(next: FloorId) {
+      activeFloorId = next;
+      applyVisibility();
+    },
+    getState() {
+      return {
+        enabled,
+        visibleColliderCount: getVisibleColliderCount(),
+        totalColliderCount: entries.length,
+      };
+    },
+    getColliders() {
+      return entries.map((entry) => ({
+        floor: entry.metadata.floor,
+        category: entry.metadata.category,
+        name: entry.metadata.name,
+        bounds: cloneBounds(entry.metadata.bounds),
+      }));
+    },
+    dispose() {
+      for (const entry of entries) {
+        group.remove(entry.mesh);
+        entry.mesh.geometry.dispose();
+        entry.mesh.material.dispose();
+      }
+      entries.length = 0;
+      const parent = group.parent as Object3D | null;
+      parent?.remove(group);
+    },
+  };
+}

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -808,33 +808,85 @@ describe('i18n utilities', () => {
   });
 
   it('localizes debug collider controls across locales', () => {
-    expect(getDebugCollidersStrings('en').labelDisabled).toBe(
-      'Collider walls off'
+    const expectedDebugColliderStrings = {
+      ar: {
+        labelEnabled: 'تراكب المصادمات مفعّل',
+        labelDisabled: 'تراكب المصادمات معطّل',
+        descriptionEnabled:
+          'يعرض الجدران غير المرئية ومستطيلات التصادم للطابق النشط.',
+        descriptionDisabled:
+          'تبقى الجدران غير المرئية ومستطيلات التصادم مخفية حتى تفعّلها.',
+      },
+      de: {
+        labelEnabled: 'Collider-Overlay ein',
+        labelDisabled: 'Collider-Overlay aus',
+        descriptionEnabled:
+          'Zeigt unsichtbare Wände und Kollisionsrechtecke der aktiven Etage.',
+        descriptionDisabled:
+          'Unsichtbare Wände und Kollisionsrechtecke bleiben verborgen, bis du sie einschaltest.',
+      },
+      en: {
+        labelEnabled: 'Collider overlay on',
+        labelDisabled: 'Collider overlay off',
+        descriptionEnabled:
+          'Shows invisible walls and collision rectangles for the active floor.',
+        descriptionDisabled:
+          'Invisible walls and collision rectangles stay hidden until you turn them on.',
+      },
+      'en-x-pseudo': {
+        labelEnabled: '⟦Collider overlay on⟧',
+        labelDisabled: '⟦Collider overlay off⟧',
+        descriptionEnabled:
+          '⟦Shows invisible walls and collision rectangles for the active floor.⟧',
+        descriptionDisabled:
+          '⟦Invisible walls and collision rectangles stay hidden until you turn them on.⟧',
+      },
+      es: {
+        labelEnabled: 'Superposición de colliders activada',
+        labelDisabled: 'Superposición de colliders desactivada',
+        descriptionEnabled:
+          'Muestra muros invisibles y rectángulos de colisión del piso activo.',
+        descriptionDisabled:
+          'Los muros invisibles y los rectángulos de colisión permanecen ocultos hasta que los actives.',
+      },
+      hu: {
+        labelEnabled: 'Collider-réteg be',
+        labelDisabled: 'Collider-réteg ki',
+        descriptionEnabled:
+          'Megjeleníti az aktív emelet láthatatlan falait és ütközési téglalapjait.',
+        descriptionDisabled:
+          'A láthatatlan falak és ütközési téglalapok rejtve maradnak, amíg be nem kapcsolod.',
+      },
+      ja: {
+        labelEnabled: 'コライダーオーバーレイオン',
+        labelDisabled: 'コライダーオーバーレイオフ',
+        descriptionEnabled: '現在の階の見えない壁と衝突矩形を表示します。',
+        descriptionDisabled: '見えない壁と衝突矩形はオンにするまで非表示です。',
+      },
+      pt: {
+        labelEnabled: 'Sobreposição de colisores ativada',
+        labelDisabled: 'Sobreposição de colisores desativada',
+        descriptionEnabled:
+          'Mostra paredes invisíveis e retângulos de colisão do piso ativo.',
+        descriptionDisabled:
+          'As paredes invisíveis e os retângulos de colisão ficam ocultos até você ativá-los.',
+      },
+      'zh-Hans': {
+        labelEnabled: '碰撞体叠加层已开启',
+        labelDisabled: '碰撞体叠加层已关闭',
+        descriptionEnabled: '显示当前楼层的不可见墙和碰撞矩形。',
+        descriptionDisabled: '不可见墙和碰撞矩形会保持隐藏，直到你开启。',
+      },
+    } as const;
+
+    expect(Object.keys(expectedDebugColliderStrings).sort()).toEqual(
+      [...AVAILABLE_LOCALES].sort()
     );
-    expect(getDebugCollidersStrings('es').labelEnabled).toBe(
-      'Muros de colisión activados'
-    );
-    expect(getDebugCollidersStrings('pt').descriptionEnabled).toBe(
-      'Mostra as paredes de colisão invisíveis do piso ativo.'
-    );
-    expect(getDebugCollidersStrings('de').labelDisabled).toBe(
-      'Kollisionswände aus'
-    );
-    expect(getDebugCollidersStrings('hu').labelEnabled).toBe(
-      'Ütközési falak be'
-    );
-    expect(getDebugCollidersStrings('zh-Hans').labelDisabled).toBe(
-      '碰撞墙已关闭'
-    );
-    expect(getDebugCollidersStrings('ja').descriptionDisabled).toBe(
-      '見えない衝突壁はオンにするまで非表示です。'
-    );
-    expect(getDebugCollidersStrings('ar').labelEnabled).toBe(
-      'جدران التصادم مفعّلة'
-    );
-    expect(getDebugCollidersStrings('en-x-pseudo').labelEnabled).toBe(
-      '⟦Collider walls on⟧'
-    );
+    for (const [locale, expectedStrings] of Object.entries(
+      expectedDebugColliderStrings
+    )) {
+      expect(getDebugCollidersStrings(locale)).toEqual(expectedStrings);
+    }
   });
 
   it('localizes narration controls and subtitle labels for Latin locales', () => {

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -6,6 +6,7 @@ import {
   getAudioSubtitleStrings,
   getControlOverlayStrings,
   getDebugCoordinatesStrings,
+  getDebugCollidersStrings,
   getHelpModalStrings,
   getLocaleDirection,
   getLocaleToggleStrings,
@@ -803,6 +804,36 @@ describe('i18n utilities', () => {
     );
     expect(getDebugCoordinatesStrings('en-x-pseudo').labelDisabled).toBe(
       '⟦Debug coordinates off⟧'
+    );
+  });
+
+  it('localizes debug collider controls across locales', () => {
+    expect(getDebugCollidersStrings('en').labelDisabled).toBe(
+      'Collider walls off'
+    );
+    expect(getDebugCollidersStrings('es').labelEnabled).toBe(
+      'Muros de colisión activados'
+    );
+    expect(getDebugCollidersStrings('pt').descriptionEnabled).toBe(
+      'Mostra as paredes de colisão invisíveis do piso ativo.'
+    );
+    expect(getDebugCollidersStrings('de').labelDisabled).toBe(
+      'Kollisionswände aus'
+    );
+    expect(getDebugCollidersStrings('hu').labelEnabled).toBe(
+      'Ütközési falak be'
+    );
+    expect(getDebugCollidersStrings('zh-Hans').labelDisabled).toBe(
+      '碰撞墙已关闭'
+    );
+    expect(getDebugCollidersStrings('ja').descriptionDisabled).toBe(
+      '見えない衝突壁はオンにするまで非表示です。'
+    );
+    expect(getDebugCollidersStrings('ar').labelEnabled).toBe(
+      'جدران التصادم مفعّلة'
+    );
+    expect(getDebugCollidersStrings('en-x-pseudo').labelEnabled).toBe(
+      '⟦Collider walls on⟧'
     );
   });
 


### PR DESCRIPTION
### Motivation
- Make invisible collision walls inspectable for debugging without altering movement or collision semantics.
- Provide a small, reusable visualizer and a persistent Settings/URL toggle so future stair-blocker work can be validated visually.

### Description
- Add a floor-aware Three.js collider visualizer at `src/scene/debug/colliderVisualizer.ts` that renders thin, semi-transparent wire boxes which do not participate in raycasting or collision and exposes a small API (`getState`, `setEnabled`, `getColliders`).
- Wire the visualizer into scene composition in `src/main.ts`, registering existing `groundColliders`, `upperFloorColliders`, and `staticColliders`, and update it on active-floor changes; add a HUD Settings toggle with URL override and persistent storage (`danielsmith.io::debugColliders::v1`).
- Add localized HUD strings and pseudo-locale support via i18n updates and a `getDebugCollidersStrings` getter; add focused tests for i18n coverage.
- Add unit tests for the visualizer (`src/scene/debug/__tests__/colliderVisualizer.test.ts`) that verify counts, floor-awareness, metadata redaction, and non-raycasting behavior.

### Testing
- Ran formatting and lint: `npm run format:write` (passed), `npm run lint` (passed).
- Unit and CI tests: `npx vitest run src/scene/debug/__tests__/colliderVisualizer.test.ts src/tests/i18n.test.ts` (passed), and `npm run test:ci` (full test suite passed: 142 files / 1058 tests in this environment).
- Build and docs: `npm run build` (passed), `npm run docs:check` (passed with external-link fetch warnings), and `npm run smoke` (passed).
- Focused visualizer tests: `npx vitest run src/scene/debug/__tests__/colliderVisualizer.test.ts` (passed).
- Typecheck: `npm run typecheck` was run and failed with existing repository-wide TypeScript errors unrelated to these changes (reported and left as pre-existing issues). (failed)
- Manual preview/screenshot: attempted a Playwright-based check against `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1&debugColliders=1`, but the headless-browser run was blocked by missing host browser system dependencies despite installing the Chromium headless shell; this prevented an automated screenshot in this environment (blocked).

Notes: the change intentionally does not alter collision or movement logic when the setting is off; the new debug meshes are diagnostic-only (non-interactive, non-raycasting). Follow-ups: confirm visual overlay in a local browser or CI Playwright environment with full browser deps to validate runtime visuals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25fc97d238832f8474bee820bb9009)