### PR TITLE
Add collider debug visualization overlay

### DIFF
--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -27,6 +27,7 @@ import type {
   MovementLegendStrings,
   NarrationToggleStrings,
   DebugCoordinatesStrings,
+  DebugCollidersStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
   PoiOverlayChromeStrings,
@@ -473,6 +474,12 @@ export function getDebugCoordinatesStrings(
   input?: LocaleInput
 ): DebugCoordinatesStrings {
   return cloneValue(getLocaleStrings(input).hud.debugCoordinates);
+}
+
+export function getDebugCollidersStrings(
+  input?: LocaleInput
+): DebugCollidersStrings {
+  return cloneValue(getLocaleStrings(input).hud.debugColliders);
 }
 
 export function getTourResetControlStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -299,6 +299,14 @@ export const AR_OVERRIDES: LocaleOverrides = {
         none: 'لا شيء',
       },
     },
+    debugColliders: {
+      labelEnabled: 'جدران التصادم مرئية',
+      labelDisabled: 'جدران التصادم مخفية',
+      descriptionEnabled:
+        'يعرض هندسة تصحيح للجدران غير المرئية ومستطيلات التصادم.',
+      descriptionDisabled:
+        'تبقى هندسة تصحيح الجدران غير المرئية ومستطيلات التصادم مخفية.',
+    },
     poiOverlay: {
       visited: 'تمت الزيارة',
       nextHighlight: 'المحطة التالية',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -49,6 +49,12 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
       'Erzähl-Pop-ups und Untertitel erscheinen bei künftigen Exponatmomenten.',
     narrationToggleDescriptionDisabled:
       'Erzähl-Pop-ups und Untertitel bleiben verborgen, bis du sie einschaltest.',
+    debugCollidersLabelEnabled: 'Kollisionswände sichtbar',
+    debugCollidersLabelDisabled: 'Kollisionswände verborgen',
+    debugCollidersDescriptionEnabled:
+      'Zeigt Debug-Geometrie für unsichtbare Wände und Kollisionsrechtecke.',
+    debugCollidersDescriptionDisabled:
+      'Debug-Geometrie für unsichtbare Wände und Kollisionsrechtecke bleibt verborgen.',
     debugCoordinatesLabelEnabled: 'Debug-Koordinaten ein',
     debugCoordinatesLabelDisabled: 'Debug-Koordinaten aus',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -356,6 +356,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         none: wrap('None'),
       },
     },
+    debugColliders: {
+      labelEnabled: wrap('Collider walls visible'),
+      labelDisabled: wrap('Collider walls hidden'),
+      descriptionEnabled: wrap(
+        'Shows invisible wall and collision rectangle debug geometry.'
+      ),
+      descriptionDisabled: wrap(
+        'Invisible wall and collision rectangle debug geometry stays hidden.'
+      ),
+    },
     tourReset: {
       heading: wrap('Guided tour'),
       resetKey: 'g',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -364,6 +364,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         none: 'None',
       },
     },
+    debugColliders: {
+      labelEnabled: 'Collider walls visible',
+      labelDisabled: 'Collider walls hidden',
+      descriptionEnabled:
+        'Shows invisible wall and collision rectangle debug geometry.',
+      descriptionDisabled:
+        'Invisible wall and collision rectangle debug geometry stays hidden.',
+    },
     tourReset: {
       heading: 'Guided tour',
       resetKey: 'g',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -49,6 +49,12 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
       'Las ventanas y subtítulos de narración aparecen en futuros momentos de exhibición.',
     narrationToggleDescriptionDisabled:
       'Las ventanas y subtítulos de narración permanecen ocultos hasta que los actives.',
+    debugCollidersLabelEnabled: 'Muros de colisión visibles',
+    debugCollidersLabelDisabled: 'Muros de colisión ocultos',
+    debugCollidersDescriptionEnabled:
+      'Muestra la geometría de depuración de muros invisibles y rectángulos de colisión.',
+    debugCollidersDescriptionDisabled:
+      'La geometría de depuración de muros invisibles y rectángulos de colisión permanece oculta.',
     debugCoordinatesLabelEnabled: 'Coordenadas de depuración activadas',
     debugCoordinatesLabelDisabled: 'Coordenadas de depuración desactivadas',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -49,6 +49,12 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
       'A narrációs felugrók és feliratok megjelennek a következő kiállítási pillanatoknál.',
     narrationToggleDescriptionDisabled:
       'A narrációs felugrók és feliratok rejtve maradnak, amíg be nem kapcsolod őket.',
+    debugCollidersLabelEnabled: 'Ütközési falak láthatók',
+    debugCollidersLabelDisabled: 'Ütközési falak rejtve',
+    debugCollidersDescriptionEnabled:
+      'Megjeleníti a láthatatlan falak és ütközési téglalapok hibakeresési geometriáját.',
+    debugCollidersDescriptionDisabled:
+      'A láthatatlan falak és ütközési téglalapok hibakeresési geometriája rejtve marad.',
     debugCoordinatesLabelEnabled: 'Hibakeresési koordináták be',
     debugCoordinatesLabelDisabled: 'Hibakeresési koordináták ki',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -301,6 +301,14 @@ export const JA_OVERRIDES: LocaleOverrides = {
         none: 'なし',
       },
     },
+    debugColliders: {
+      labelEnabled: 'コライダー壁を表示',
+      labelDisabled: 'コライダー壁を非表示',
+      descriptionEnabled:
+        '不可視の壁と衝突矩形のデバッグジオメトリを表示します。',
+      descriptionDisabled:
+        '不可視の壁と衝突矩形のデバッグジオメトリは非表示のままです。',
+    },
     poiOverlay: {
       visited: '訪問済み',
       nextHighlight: '次のハイライト',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -50,6 +50,10 @@ interface LatinLocaleCopy {
     narrationToggleLabelDisabled: string;
     narrationToggleDescriptionEnabled: string;
     narrationToggleDescriptionDisabled: string;
+    debugCollidersLabelEnabled: string;
+    debugCollidersLabelDisabled: string;
+    debugCollidersDescriptionEnabled: string;
+    debugCollidersDescriptionDisabled: string;
     debugCoordinatesLabelEnabled: string;
     debugCoordinatesLabelDisabled: string;
     debugCoordinatesDescriptionEnabled: string;
@@ -716,6 +720,12 @@ export function buildLatinLocaleOverrides(
         labelDisabled: s.narrationToggleLabelDisabled,
         descriptionEnabled: s.narrationToggleDescriptionEnabled,
         descriptionDisabled: s.narrationToggleDescriptionDisabled,
+      },
+      debugColliders: {
+        labelEnabled: s.debugCollidersLabelEnabled,
+        labelDisabled: s.debugCollidersLabelDisabled,
+        descriptionEnabled: s.debugCollidersDescriptionEnabled,
+        descriptionDisabled: s.debugCollidersDescriptionDisabled,
       },
       debugCoordinates: {
         labelEnabled: s.debugCoordinatesLabelEnabled,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -49,6 +49,12 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
       'Pop-ups e legendas de narração aparecem em futuros momentos da exibição.',
     narrationToggleDescriptionDisabled:
       'Pop-ups e legendas de narração ficam ocultos até você ativá-los.',
+    debugCollidersLabelEnabled: 'Paredes de colisão visíveis',
+    debugCollidersLabelDisabled: 'Paredes de colisão ocultas',
+    debugCollidersDescriptionEnabled:
+      'Mostra a geometria de depuração de paredes invisíveis e retângulos de colisão.',
+    debugCollidersDescriptionDisabled:
+      'A geometria de depuração de paredes invisíveis e retângulos de colisão permanece oculta.',
     debugCoordinatesLabelEnabled: 'Coordenadas de depuração ativadas',
     debugCoordinatesLabelDisabled: 'Coordenadas de depuração desativadas',
     debugCoordinatesDescriptionEnabled:

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -288,6 +288,12 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
         none: '无',
       },
     },
+    debugColliders: {
+      labelEnabled: '碰撞墙已显示',
+      labelDisabled: '碰撞墙已隐藏',
+      descriptionEnabled: '显示隐形墙和碰撞矩形的调试几何体。',
+      descriptionDisabled: '隐形墙和碰撞矩形的调试几何体保持隐藏。',
+    },
     tourReset: {
       heading: '导览',
       resetKey: 'g',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -209,6 +209,13 @@ export interface NarrationToggleStrings {
   descriptionDisabled: string;
 }
 
+export interface DebugCollidersStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
 export interface DebugCoordinatesStrings {
   labelEnabled: string;
   labelDisabled: string;
@@ -423,6 +430,7 @@ export interface LocaleStrings {
     tourGuideToggle: TourGuideToggleStrings;
     narrationToggle: NarrationToggleStrings;
     debugCoordinates: DebugCoordinatesStrings;
+    debugColliders: DebugCollidersStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import {
   getAudioHudControlStrings,
   getAudioSubtitleStrings,
   getControlOverlayStrings,
+  getDebugCollidersStrings,
   getDebugCoordinatesStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
@@ -108,6 +109,11 @@ import {
   type AvatarVariantId,
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
+import {
+  createColliderVisualizer,
+  type DebugColliderMetadata,
+  type DebugColliderRegistration,
+} from './scene/debug/colliderVisualizer';
 import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
@@ -467,6 +473,7 @@ const FENCE_THICKNESS = 0.28;
 const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
+const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
 const AVATAR_ASSET_REQUIRED_BONES = ['Hips', 'Spine'] as const;
 const AVATAR_ASSET_REQUIRED_ANIMATIONS = ['Idle', 'Walk', 'Run'] as const;
 const AVATAR_ASSET_EXPECTED_UNIT_SCALE = 1;
@@ -563,6 +570,15 @@ declare global {
           activeInWorldTooltipCount: number;
           totalInWorldTooltipCount: number;
         };
+      };
+      debugColliders?: {
+        getState(): {
+          enabled: boolean;
+          visibleColliderCount: number;
+          totalColliderCount: number;
+        };
+        setEnabled(enabled: boolean): void;
+        getColliders(): DebugColliderMetadata[];
       };
       debugCoordinates?: {
         getState(): {
@@ -1308,27 +1324,39 @@ function initializeImmersiveScene(
   let poiOverlayStrings = getPoiOverlayChromeStrings(locale);
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
   let narrationToggleStrings = getNarrationToggleStrings(locale);
+  let debugCollidersStrings = getDebugCollidersStrings(locale);
   let debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
   let tourResetControlStrings = getTourResetControlStrings(locale);
   let softwareRendererWarningStrings =
     getSoftwareRendererWarningStrings(locale);
   let siteStrings = getSiteStrings(locale);
   let debugCoordinatesStorage: Storage | undefined;
+  let debugCollidersStorage: Storage | undefined;
   try {
     debugCoordinatesStorage = window.localStorage;
+    debugCollidersStorage = window.localStorage;
   } catch {
     debugCoordinatesStorage = undefined;
+    debugCollidersStorage = undefined;
   }
-  const debugCoordinatesUrlOverride = new URLSearchParams(
-    window.location.search
-  ).get('debugCoordinates');
-  const debugCoordinatesUrlEnabled = ['1', 'true', 'yes', 'on'].includes(
-    debugCoordinatesUrlOverride?.toLowerCase() ?? ''
+  const debugUrlParams = new URLSearchParams(window.location.search);
+  const isTruthyDebugUrlValue = (value: string | null): boolean =>
+    ['1', 'true', 'yes', 'on'].includes(value?.toLowerCase() ?? '');
+  const debugCoordinatesUrlEnabled = isTruthyDebugUrlValue(
+    debugUrlParams.get('debugCoordinates')
   );
   const debugCoordinatesStoredEnabled =
     debugCoordinatesStorage?.getItem(DEBUG_COORDINATES_STORAGE_KEY) === '1';
   let debugCoordinatesEnabled =
     debugCoordinatesUrlEnabled || debugCoordinatesStoredEnabled;
+  const debugCollidersUrlEnabled = isTruthyDebugUrlValue(
+    debugUrlParams.get('debugColliders')
+  );
+  const debugCollidersStoredEnabled =
+    debugCollidersStorage?.getItem(DEBUG_COLLIDERS_STORAGE_KEY) === '1';
+  let debugCollidersEnabled =
+    debugCollidersUrlEnabled || debugCollidersStoredEnabled;
+  let debugCollidersControl: HTMLButtonElement | null = null;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
@@ -2602,6 +2630,37 @@ function initializeImmersiveScene(
     woveLoom = loom;
   }
 
+  const debugColliderRegistrations: DebugColliderRegistration[] = [
+    ...groundColliders.map((collider, index) => ({
+      floor: 'ground' as const,
+      category: 'ground' as const,
+      name: `ground-${index + 1}`,
+      collider,
+    })),
+    ...upperFloorColliders.map((collider, index) => ({
+      floor: 'upper' as const,
+      category: 'upper' as const,
+      name: `upper-${index + 1}`,
+      collider,
+    })),
+    ...staticColliders.map((collider, index) => ({
+      floor: 'ground' as const,
+      category: 'static' as const,
+      name: `static-${index + 1}`,
+      collider,
+    })),
+  ];
+  const debugColliderVisualizer = createColliderVisualizer({
+    colliders: debugColliderRegistrations,
+    activeFloor: activeFloorId,
+    floorHeights: {
+      ground: 0,
+      upper: upperFloorElevation,
+    },
+  });
+  scene.add(debugColliderVisualizer.group);
+  debugColliderVisualizer.setEnabled(debugCollidersEnabled);
+
   poiInteractionManager = new PoiInteractionManager(
     renderer.domElement,
     camera,
@@ -3464,6 +3523,7 @@ function initializeImmersiveScene(
     audioHudStrings = getAudioHudControlStrings(locale);
     audioSubtitleStrings = getAudioSubtitleStrings(locale);
     narrationToggleStrings = getNarrationToggleStrings(locale);
+    debugCollidersStrings = getDebugCollidersStrings(locale);
     debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
@@ -3538,6 +3598,7 @@ function initializeImmersiveScene(
     poiNarrativeLog?.setStrings(narrativeLogStrings);
     audioSubtitles?.setLabels(audioSubtitleStrings);
     narrationToggleControl?.setStrings(narrationToggleStrings);
+    refreshDebugCollidersStrings();
     refreshDebugCoordinatesStrings();
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
@@ -3631,6 +3692,7 @@ function initializeImmersiveScene(
     syncPoiDetailOverlay();
     syncPoiRecommendation();
     document.documentElement.dataset.activeFloor = next;
+    debugColliderVisualizer?.setActiveFloor(next);
   };
 
   const updatePlayerVerticalPosition = () => {
@@ -3661,6 +3723,72 @@ function initializeImmersiveScene(
       containsRectPoint(bounds, player.position.x, player.position.z)
     );
     return room?.id ?? null;
+  };
+
+  const getDebugCollidersState = () => debugColliderVisualizer.getState();
+
+  const refreshDebugCollidersControl = () => {
+    if (!debugCollidersControl) {
+      return;
+    }
+    const label = debugCollidersEnabled
+      ? debugCollidersStrings.labelEnabled
+      : debugCollidersStrings.labelDisabled;
+    const description = debugCollidersEnabled
+      ? debugCollidersStrings.descriptionEnabled
+      : debugCollidersStrings.descriptionDisabled;
+    debugCollidersControl.textContent = label;
+    debugCollidersControl.dataset.state = debugCollidersEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugCollidersControl.setAttribute(
+      'aria-pressed',
+      debugCollidersEnabled ? 'true' : 'false'
+    );
+    debugCollidersControl.setAttribute('aria-label', description);
+    debugCollidersControl.title = description;
+    debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const setDebugCollidersEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugCollidersEnabled = enabled;
+    debugColliderVisualizer.setEnabled(enabled);
+    refreshDebugCollidersControl();
+    if (options.persist !== false && debugCollidersStorage) {
+      try {
+        debugCollidersStorage.setItem(
+          DEBUG_COLLIDERS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug collider preference.', error);
+      }
+    }
+  };
+
+  const refreshDebugCollidersStrings = () => {
+    refreshDebugCollidersControl();
+  };
+
+  debugCollidersControl = document.createElement('button');
+  debugCollidersControl.type = 'button';
+  debugCollidersControl.className = 'tour-toggle debug-colliders-toggle';
+  debugCollidersControl.addEventListener('click', () => {
+    setDebugCollidersEnabled(!debugCollidersEnabled);
+  });
+  hudSettingsStack.appendChild(debugCollidersControl);
+  registerHudControlElement(debugCollidersControl);
+  refreshDebugCollidersControl();
+
+  window.portfolio.debugColliders = {
+    getState: getDebugCollidersState,
+    setEnabled: (enabled: boolean) => {
+      setDebugCollidersEnabled(enabled);
+    },
+    getColliders: () => debugColliderVisualizer.getColliders(),
   };
 
   const getDebugCoordinatesState = () => {
@@ -5408,6 +5536,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.narration) {
       delete window.portfolio.narration;
     }
+    if (window.portfolio?.debugColliders) {
+      delete window.portfolio.debugColliders;
+    }
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
@@ -5422,6 +5553,11 @@ function initializeImmersiveScene(
       window.clearInterval(debugCoordinatesInterval);
       debugCoordinatesInterval = null;
     }
+    if (debugCollidersControl) {
+      debugCollidersControl.remove();
+      debugCollidersControl = null;
+    }
+    debugColliderVisualizer.dispose();
     if (debugCoordinatesControl) {
       debugCoordinatesControl.remove();
       debugCoordinatesControl = null;

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,0 +1,208 @@
+import {
+  BoxGeometry,
+  Color,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  type Object3D,
+} from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+import type { FloorId } from '../../systems/movement/stairs';
+
+export type DebugColliderCategory = 'ground' | 'upper' | 'static' | 'stair';
+
+export interface DebugColliderRegistration {
+  floor: FloorId | 'all';
+  category: DebugColliderCategory;
+  name: string;
+  collider: RectCollider;
+}
+
+export interface DebugColliderMetadata {
+  floor: FloorId | 'all';
+  category: DebugColliderCategory;
+  name: string;
+  bounds: RectCollider;
+}
+
+export interface ColliderVisualizerState {
+  enabled: boolean;
+  visibleColliderCount: number;
+  totalColliderCount: number;
+}
+
+export interface ColliderVisualizerHandle {
+  group: Group;
+  setEnabled(enabled: boolean): void;
+  setActiveFloor(floorId: FloorId): void;
+  getState(): ColliderVisualizerState;
+  getColliders(): DebugColliderMetadata[];
+  dispose(): void;
+}
+
+interface ColliderVisualizerOptions {
+  colliders: readonly DebugColliderRegistration[];
+  activeFloor: FloorId;
+  floorHeights?: Partial<Record<FloorId, number>>;
+}
+
+interface VisualizedCollider extends DebugColliderRegistration {
+  mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
+}
+
+const DEFAULT_FLOOR_HEIGHTS: Record<FloorId, number> = {
+  ground: 0,
+  upper: 5.6,
+};
+
+const CATEGORY_COLORS: Record<DebugColliderCategory, Color> = {
+  ground: new Color(0x4cc9f0),
+  upper: new Color(0xb5179e),
+  static: new Color(0xffb703),
+  stair: new Color(0x80ed99),
+};
+
+const COLLIDER_OVERLAY_HEIGHT = 0.32;
+const MIN_COLLIDER_OVERLAY_SIZE = 0.05;
+
+function disableRaycast(object: Object3D): void {
+  object.raycast = () => undefined;
+}
+
+function cloneColliderBounds(collider: RectCollider): RectCollider {
+  return {
+    minX: collider.minX,
+    maxX: collider.maxX,
+    minZ: collider.minZ,
+    maxZ: collider.maxZ,
+  };
+}
+
+function shouldShowCollider(
+  collider: DebugColliderRegistration,
+  activeFloor: FloorId
+): boolean {
+  if (collider.floor === 'all') {
+    return true;
+  }
+  return collider.floor === activeFloor;
+}
+
+export function createColliderVisualizer({
+  colliders,
+  activeFloor,
+  floorHeights = {},
+}: ColliderVisualizerOptions): ColliderVisualizerHandle {
+  const group = new Group();
+  group.name = 'DebugColliderVisualizer';
+  group.visible = false;
+  disableRaycast(group);
+
+  const resolvedFloorHeights = { ...DEFAULT_FLOOR_HEIGHTS, ...floorHeights };
+  let enabled = false;
+  let currentFloor = activeFloor;
+
+  const visualizedColliders: VisualizedCollider[] = colliders.map(
+    (registration, index) => {
+      const color = CATEGORY_COLORS[registration.category];
+      const material = new MeshBasicMaterial({
+        color,
+        depthWrite: false,
+        opacity: 0.28,
+        transparent: true,
+        wireframe: true,
+      });
+      const mesh = new Mesh(new BoxGeometry(1, 1, 1), material);
+      const bounds = registration.collider;
+      const width = Math.max(
+        Math.abs(bounds.maxX - bounds.minX),
+        MIN_COLLIDER_OVERLAY_SIZE
+      );
+      const depth = Math.max(
+        Math.abs(bounds.maxZ - bounds.minZ),
+        MIN_COLLIDER_OVERLAY_SIZE
+      );
+      const floorHeight =
+        registration.floor === 'all'
+          ? resolvedFloorHeights[currentFloor]
+          : resolvedFloorHeights[registration.floor];
+
+      mesh.name = `DebugCollider:${registration.category}:${registration.name}:${index}`;
+      mesh.position.set(
+        (bounds.minX + bounds.maxX) / 2,
+        floorHeight + COLLIDER_OVERLAY_HEIGHT / 2,
+        (bounds.minZ + bounds.maxZ) / 2
+      );
+      mesh.scale.set(width, COLLIDER_OVERLAY_HEIGHT, depth);
+      mesh.renderOrder = 1000;
+      mesh.userData = {
+        ...mesh.userData,
+        debugCollider: true,
+        nonInteractive: true,
+      };
+      mesh.visible = false;
+      disableRaycast(mesh);
+      group.add(mesh);
+
+      return { ...registration, mesh };
+    }
+  );
+
+  const syncVisibility = () => {
+    group.visible = enabled;
+    for (const visualizedCollider of visualizedColliders) {
+      const isVisible =
+        enabled && shouldShowCollider(visualizedCollider, currentFloor);
+      visualizedCollider.mesh.visible = isVisible;
+      if (visualizedCollider.floor === 'all') {
+        visualizedCollider.mesh.position.y =
+          resolvedFloorHeights[currentFloor] + COLLIDER_OVERLAY_HEIGHT / 2;
+      }
+    }
+  };
+
+  const getVisibleColliderCount = () =>
+    enabled
+      ? visualizedColliders.filter((collider) =>
+          shouldShowCollider(collider, currentFloor)
+        ).length
+      : 0;
+
+  syncVisibility();
+
+  return {
+    group,
+    setEnabled(nextEnabled: boolean) {
+      enabled = nextEnabled;
+      syncVisibility();
+    },
+    setActiveFloor(floorId: FloorId) {
+      currentFloor = floorId;
+      syncVisibility();
+    },
+    getState() {
+      return {
+        enabled,
+        visibleColliderCount: getVisibleColliderCount(),
+        totalColliderCount: visualizedColliders.length,
+      };
+    },
+    getColliders() {
+      return visualizedColliders.map((collider) => ({
+        floor: collider.floor,
+        category: collider.category,
+        name: collider.name,
+        bounds: cloneColliderBounds(collider.collider),
+      }));
+    },
+    dispose() {
+      group.removeFromParent();
+      for (const { mesh } of visualizedColliders) {
+        mesh.geometry.dispose();
+        mesh.material.dispose();
+      }
+      group.clear();
+    },
+  };
+}

--- a/src/tests/colliderVisualizer.test.ts
+++ b/src/tests/colliderVisualizer.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { createColliderVisualizer } from '../scene/debug/colliderVisualizer';
+
+const testColliders = [
+  {
+    floor: 'ground' as const,
+    category: 'ground' as const,
+    name: 'ground-wall',
+    collider: { minX: 0, maxX: 2, minZ: 0, maxZ: 1 },
+  },
+  {
+    floor: 'upper' as const,
+    category: 'upper' as const,
+    name: 'upper-wall',
+    collider: { minX: 4, maxX: 6, minZ: 2, maxZ: 3 },
+  },
+  {
+    floor: 'all' as const,
+    category: 'stair' as const,
+    name: 'transition-blocker',
+    collider: { minX: -1, maxX: 1, minZ: -2, maxZ: -1 },
+  },
+];
+
+describe('createColliderVisualizer', () => {
+  it('keeps debug geometry hidden until enabled and filters by active floor', () => {
+    const visualizer = createColliderVisualizer({
+      colliders: testColliders,
+      activeFloor: 'ground',
+      floorHeights: { ground: 0, upper: 6 },
+    });
+
+    expect(visualizer.group.visible).toBe(false);
+    expect(visualizer.getState()).toEqual({
+      enabled: false,
+      visibleColliderCount: 0,
+      totalColliderCount: 3,
+    });
+
+    visualizer.setEnabled(true);
+
+    expect(visualizer.group.visible).toBe(true);
+    expect(visualizer.getState().visibleColliderCount).toBe(2);
+    expect(visualizer.group.children.map((child) => child.visible)).toEqual([
+      true,
+      false,
+      true,
+    ]);
+
+    visualizer.setActiveFloor('upper');
+
+    expect(visualizer.getState().visibleColliderCount).toBe(2);
+    expect(visualizer.group.children.map((child) => child.visible)).toEqual([
+      false,
+      true,
+      true,
+    ]);
+
+    visualizer.setEnabled(false);
+
+    expect(visualizer.group.visible).toBe(false);
+    expect(visualizer.getState().visibleColliderCount).toBe(0);
+
+    visualizer.dispose();
+  });
+
+  it('exposes cloned collider metadata without mutating source registrations', () => {
+    const visualizer = createColliderVisualizer({
+      colliders: testColliders,
+      activeFloor: 'ground',
+    });
+
+    const [metadata] = visualizer.getColliders();
+    metadata.bounds.minX = 99;
+
+    expect(testColliders[0].collider.minX).toBe(0);
+    expect(visualizer.getColliders()[0]).toEqual({
+      floor: 'ground',
+      category: 'ground',
+      name: 'ground-wall',
+      bounds: { minX: 0, maxX: 2, minZ: 0, maxZ: 1 },
+    });
+
+    visualizer.dispose();
+  });
+});

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -5,6 +5,7 @@ import {
   formatMessage,
   getAudioSubtitleStrings,
   getControlOverlayStrings,
+  getDebugCollidersStrings,
   getDebugCoordinatesStrings,
   getHelpModalStrings,
   getLocaleDirection,
@@ -778,6 +779,36 @@ describe('i18n utilities', () => {
     AVAILABLE_LOCALES.forEach((locale) => {
       assertNoMissingStrings(getLocaleStrings(locale), locale);
     });
+  });
+
+  it('localizes debug collider controls across locales', () => {
+    expect(getDebugCollidersStrings('en').labelDisabled).toBe(
+      'Collider walls hidden'
+    );
+    expect(getDebugCollidersStrings('es').labelEnabled).toBe(
+      'Muros de colisión visibles'
+    );
+    expect(getDebugCollidersStrings('pt').labelDisabled).toBe(
+      'Paredes de colisão ocultas'
+    );
+    expect(getDebugCollidersStrings('de').descriptionEnabled).toContain(
+      'Kollisionsrechtecke'
+    );
+    expect(getDebugCollidersStrings('hu').labelEnabled).toBe(
+      'Ütközési falak láthatók'
+    );
+    expect(getDebugCollidersStrings('zh-Hans').labelDisabled).toBe(
+      '碰撞墙已隐藏'
+    );
+    expect(getDebugCollidersStrings('ja').labelEnabled).toBe(
+      'コライダー壁を表示'
+    );
+    expect(getDebugCollidersStrings('ar').labelDisabled).toBe(
+      'جدران التصادم مخفية'
+    );
+    expect(getDebugCollidersStrings('en-x-pseudo').labelDisabled).toBe(
+      '⟦Collider walls hidden⟧'
+    );
   });
 
   it('localizes debug coordinate controls across locales', () => {


### PR DESCRIPTION
### Motivation
- Make invisible collision walls and collider rectangles inspectable for debugging without changing runtime collision or movement semantics.
- Keep the overlay diagnostic-only: non-interactive, not raycastable, and floor-aware so it follows the current active floor.
- Surface a small, persistent Settings control and a URL override so reviewers can enable the overlay without code changes.

### Description
- Add a reusable Three.js helper `createColliderVisualizer` that renders thin, semi-transparent wireframe boxes for registered colliders and supports `setEnabled`, `setActiveFloor`, `getState`, `getColliders`, and `dispose` (new file: `src/scene/debug/colliderVisualizer.ts`).
- Register existing collider arrays (`groundColliders`, `upperFloorColliders`, `staticColliders`) with the visualizer and add it to the scene without mutating collider arrays or changing movement logic (`src/main.ts`).
- Add a HUD Settings toggle (storage key `danielsmith.io::debugColliders::v1` and URL override `?debugColliders=1`), accessible metadata (`aria-pressed`, title/aria-label, HUD announce), and wire locale strings into `i18n` (`src/assets/i18n/*`).
- Expose `window.portfolio.debugColliders` with `getState()`, `setEnabled(enabled)`, and `getColliders()` (redacted metadata), plus cleanup on scene teardown; add focused unit tests for the visualizer and i18n coverage (`src/tests/colliderVisualizer.test.ts`, updated `src/tests/i18n.test.ts`).

### Testing
- Ran formatting and linting: `npm run format:write` ✅ and `npm run lint` ✅.
- Unit & integration tests: `npm run test:ci` ✅ (full suite run; focused tests `src/tests/colliderVisualizer.test.ts` and updated `src/tests/i18n.test.ts` passed).
- Type-check: `npm run typecheck` ❌ — reported pre-existing repository TypeScript issues unrelated to this change; no debug-collider-specific type errors introduced.
- Build & docs: `npm run build` ✅, `npm run docs:check` ✅ (link check produced external fetch warnings), and `npm run smoke` ✅.
- Playwright preview verification: launched preview and verified via automated headless page that `?mode=immersive&disablePerformanceFailover=1&debugColliders=1` shows collider geometry; screenshot captured at `/tmp/danielsmith-debug-colliders.png` and `window.portfolio.debugColliders.getState()` reported sensible `visibleColliderCount`/`totalColliderCount` before/after toggling (manual Playwright flow performed as part of verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25fc97d238832f8474bee820bb9009)