### PR TITLE
Add collider debug overlay

### DIFF
--- a/docs/qa/upstairs-stairs.md
+++ b/docs/qa/upstairs-stairs.md
@@ -14,6 +14,14 @@ http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
 3. Confirm the overlay appears with position, active floor, predicted floor, stair zone, and room.
 4. Optional console check: `window.portfolio.debugCoordinates.getState()` should mirror the overlay.
 
+## Enable collider visualization
+
+1. Open `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1&debugColliders=1`.
+2. Open **Settings** in the HUD and confirm **Collider overlay on** is pressed.
+3. Confirm thin debug rectangles are visible for the active floor only.
+4. Toggle **Collider overlay on/off** and confirm `window.portfolio.debugColliders.getState()`
+   switches between visible collider counts and zero visible colliders without changing movement.
+
 ## Stairs up
 
 1. Start on the ground floor and walk to the stair base near **X 12.40, Z -10.60**.

--- a/src/assets/i18n/index.ts
+++ b/src/assets/i18n/index.ts
@@ -26,6 +26,7 @@ import type {
   ModeToggleResolvedStrings,
   MovementLegendStrings,
   NarrationToggleStrings,
+  DebugCollidersStrings,
   DebugCoordinatesStrings,
   PoiCopy,
   PoiNarrativeLogStrings,
@@ -473,6 +474,12 @@ export function getDebugCoordinatesStrings(
   input?: LocaleInput
 ): DebugCoordinatesStrings {
   return cloneValue(getLocaleStrings(input).hud.debugCoordinates);
+}
+
+export function getDebugCollidersStrings(
+  input?: LocaleInput
+): DebugCollidersStrings {
+  return cloneValue(getLocaleStrings(input).hud.debugColliders);
 }
 
 export function getTourResetControlStrings(

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -299,6 +299,14 @@ export const AR_OVERRIDES: LocaleOverrides = {
         none: 'لا شيء',
       },
     },
+    debugColliders: {
+      labelEnabled: 'طبقة المصادمات مفعّلة',
+      labelDisabled: 'طبقة المصادمات معطّلة',
+      descriptionEnabled:
+        'تعرض هندسة تصحيح الجدران غير المرئية ومستطيلات التصادم.',
+      descriptionDisabled:
+        'تبقى هندسة الجدران غير المرئية ومستطيلات التصادم مخفية.',
+    },
     poiOverlay: {
       visited: 'تمت الزيارة',
       nextHighlight: 'المحطة التالية',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -67,6 +67,12 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesRoom: 'Raum',
     debugCoordinatesYes: 'Ja',
     debugCoordinatesNo: 'Nein',
+    debugCollidersLabelEnabled: 'Collider-Overlay ein',
+    debugCollidersLabelDisabled: 'Collider-Overlay aus',
+    debugCollidersDescriptionEnabled:
+      'Zeigt Debug-Geometrie für unsichtbare Wände und Kollisionsrechtecke.',
+    debugCollidersDescriptionDisabled:
+      'Geometrie für unsichtbare Wände und Kollisionsrechtecke bleibt verborgen.',
     debugCoordinatesNone: 'Keine',
   },
   poi: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -356,6 +356,16 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         none: wrap('None'),
       },
     },
+    debugColliders: {
+      labelEnabled: wrap('Collider overlay on'),
+      labelDisabled: wrap('Collider overlay off'),
+      descriptionEnabled: wrap(
+        'Shows invisible wall and collision rectangle debug geometry.'
+      ),
+      descriptionDisabled: wrap(
+        'Invisible wall and collision rectangle geometry stays hidden.'
+      ),
+    },
     tourReset: {
       heading: wrap('Guided tour'),
       resetKey: 'g',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -364,6 +364,14 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         none: 'None',
       },
     },
+    debugColliders: {
+      labelEnabled: 'Collider overlay on',
+      labelDisabled: 'Collider overlay off',
+      descriptionEnabled:
+        'Shows invisible wall and collision rectangle debug geometry.',
+      descriptionDisabled:
+        'Invisible wall and collision rectangle geometry stays hidden.',
+    },
     tourReset: {
       heading: 'Guided tour',
       resetKey: 'g',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -67,6 +67,12 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesRoom: 'Sala',
     debugCoordinatesYes: 'Sí',
     debugCoordinatesNo: 'No',
+    debugCollidersLabelEnabled: 'Superposición de colisionadores activada',
+    debugCollidersLabelDisabled: 'Superposición de colisionadores desactivada',
+    debugCollidersDescriptionEnabled:
+      'Muestra la geometría de depuración de muros invisibles y rectángulos de colisión.',
+    debugCollidersDescriptionDisabled:
+      'La geometría de muros invisibles y rectángulos de colisión permanece oculta.',
     debugCoordinatesNone: 'Ninguna',
   },
   poi: {

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -67,6 +67,12 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesRoom: 'Szoba',
     debugCoordinatesYes: 'Igen',
     debugCoordinatesNo: 'Nem',
+    debugCollidersLabelEnabled: 'Ütköző overlay be',
+    debugCollidersLabelDisabled: 'Ütköző overlay ki',
+    debugCollidersDescriptionEnabled:
+      'Megjeleníti a láthatatlan falak és ütközési téglalapok hibakeresési geometriáját.',
+    debugCollidersDescriptionDisabled:
+      'A láthatatlan falak és ütközési téglalapok geometriája rejtve marad.',
     debugCoordinatesNone: 'Nincs',
   },
   poi: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -301,6 +301,14 @@ export const JA_OVERRIDES: LocaleOverrides = {
         none: 'なし',
       },
     },
+    debugColliders: {
+      labelEnabled: 'コライダー表示オン',
+      labelDisabled: 'コライダー表示オフ',
+      descriptionEnabled:
+        '見えない壁と衝突矩形のデバッグジオメトリを表示します。',
+      descriptionDisabled:
+        '見えない壁と衝突矩形のジオメトリは非表示のままです。',
+    },
     poiOverlay: {
       visited: '訪問済み',
       nextHighlight: '次のハイライト',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -67,6 +67,10 @@ interface LatinLocaleCopy {
     debugCoordinatesYes: string;
     debugCoordinatesNo: string;
     debugCoordinatesNone: string;
+    debugCollidersLabelEnabled: string;
+    debugCollidersLabelDisabled: string;
+    debugCollidersDescriptionEnabled: string;
+    debugCollidersDescriptionDisabled: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -739,6 +743,12 @@ export function buildLatinLocaleOverrides(
           no: s.debugCoordinatesNo,
           none: s.debugCoordinatesNone,
         },
+      },
+      debugColliders: {
+        labelEnabled: s.debugCollidersLabelEnabled,
+        labelDisabled: s.debugCollidersLabelDisabled,
+        descriptionEnabled: s.debugCollidersDescriptionEnabled,
+        descriptionDisabled: s.debugCollidersDescriptionDisabled,
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -67,6 +67,12 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
     debugCoordinatesRoom: 'Sala',
     debugCoordinatesYes: 'Sim',
     debugCoordinatesNo: 'Não',
+    debugCollidersLabelEnabled: 'Sobreposição de colisores ativada',
+    debugCollidersLabelDisabled: 'Sobreposição de colisores desativada',
+    debugCollidersDescriptionEnabled:
+      'Mostra a geometria de depuração de paredes invisíveis e retângulos de colisão.',
+    debugCollidersDescriptionDisabled:
+      'A geometria de paredes invisíveis e retângulos de colisão permanece oculta.',
     debugCoordinatesNone: 'Nenhuma',
   },
   poi: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -335,6 +335,12 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       errorAnnouncementTemplate: '文本模式切换失败。按 {keyHint} 重试。',
       errorTitleTemplate: '文本模式切换失败。按 {keyHint} 重试文本模式。',
     },
+    debugColliders: {
+      labelEnabled: '碰撞体浮层已开启',
+      labelDisabled: '碰撞体浮层已关闭',
+      descriptionEnabled: '显示隐形墙和碰撞矩形的调试几何体。',
+      descriptionDisabled: '隐形墙和碰撞矩形几何体会保持隐藏。',
+    },
     poiOverlay: {
       visited: '已访问',
       nextHighlight: '下一个亮点',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -209,6 +209,13 @@ export interface NarrationToggleStrings {
   descriptionDisabled: string;
 }
 
+export interface DebugCollidersStrings {
+  labelEnabled: string;
+  labelDisabled: string;
+  descriptionEnabled: string;
+  descriptionDisabled: string;
+}
+
 export interface DebugCoordinatesStrings {
   labelEnabled: string;
   labelDisabled: string;
@@ -423,6 +430,7 @@ export interface LocaleStrings {
     tourGuideToggle: TourGuideToggleStrings;
     narrationToggle: NarrationToggleStrings;
     debugCoordinates: DebugCoordinatesStrings;
+    debugColliders: DebugCollidersStrings;
     tourReset: TourResetControlStrings;
     softwareRendererWarning: SoftwareRendererWarningStrings;
     helpModal: HelpModalStrings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import {
   getAudioHudControlStrings,
   getAudioSubtitleStrings,
   getControlOverlayStrings,
+  getDebugCollidersStrings,
   getDebugCoordinatesStrings,
   getHelpModalStrings,
   getHudCustomizationStrings,
@@ -108,6 +109,13 @@ import {
   type AvatarVariantId,
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
+import {
+  createColliderDebugEntries,
+  createColliderVisualizer,
+  type ColliderDebugMetadata,
+  type ColliderVisualizer,
+  type ColliderVisualizerState,
+} from './scene/debug/colliderVisualizer';
 import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
@@ -467,6 +475,8 @@ const FENCE_THICKNESS = 0.28;
 const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
+const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
+const DEBUG_URL_TRUTHY_VALUES = new Set(['1', 'true', 'yes', 'on']);
 const AVATAR_ASSET_REQUIRED_BONES = ['Hips', 'Spine'] as const;
 const AVATAR_ASSET_REQUIRED_ANIMATIONS = ['Idle', 'Walk', 'Run'] as const;
 const AVATAR_ASSET_EXPECTED_UNIT_SCALE = 1;
@@ -580,6 +590,11 @@ declare global {
           currentRoomId: string | null;
         };
         setEnabled(enabled: boolean): void;
+      };
+      debugColliders?: {
+        getState(): ColliderVisualizerState;
+        setEnabled(enabled: boolean): void;
+        getColliders(): ColliderDebugMetadata[];
       };
       world?: {
         getActiveFloor(): FloorId;
@@ -1309,6 +1324,7 @@ function initializeImmersiveScene(
   let tourGuideToggleStrings = getTourGuideToggleStrings(locale);
   let narrationToggleStrings = getNarrationToggleStrings(locale);
   let debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
+  let debugCollidersStrings = getDebugCollidersStrings(locale);
   let tourResetControlStrings = getTourResetControlStrings(locale);
   let softwareRendererWarningStrings =
     getSoftwareRendererWarningStrings(locale);
@@ -1322,14 +1338,25 @@ function initializeImmersiveScene(
   const debugCoordinatesUrlOverride = new URLSearchParams(
     window.location.search
   ).get('debugCoordinates');
-  const debugCoordinatesUrlEnabled = ['1', 'true', 'yes', 'on'].includes(
+  const debugCoordinatesUrlEnabled = DEBUG_URL_TRUTHY_VALUES.has(
     debugCoordinatesUrlOverride?.toLowerCase() ?? ''
   );
   const debugCoordinatesStoredEnabled =
     debugCoordinatesStorage?.getItem(DEBUG_COORDINATES_STORAGE_KEY) === '1';
   let debugCoordinatesEnabled =
     debugCoordinatesUrlEnabled || debugCoordinatesStoredEnabled;
+  const debugCollidersUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugColliders');
+  const debugCollidersUrlEnabled = DEBUG_URL_TRUTHY_VALUES.has(
+    debugCollidersUrlOverride?.toLowerCase() ?? ''
+  );
+  const debugCollidersStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_COLLIDERS_STORAGE_KEY) === '1';
+  let debugCollidersEnabled =
+    debugCollidersUrlEnabled || debugCollidersStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
+  let debugCollidersControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -2602,6 +2629,17 @@ function initializeImmersiveScene(
     woveLoom = loom;
   }
 
+  const colliderVisualizer: ColliderVisualizer = createColliderVisualizer(
+    createColliderDebugEntries({
+      groundColliders,
+      upperFloorColliders,
+      staticColliders,
+      upperFloorElevation,
+    }),
+    activeFloorId
+  );
+  scene.add(colliderVisualizer.group);
+
   poiInteractionManager = new PoiInteractionManager(
     renderer.domElement,
     camera,
@@ -3465,6 +3503,7 @@ function initializeImmersiveScene(
     audioSubtitleStrings = getAudioSubtitleStrings(locale);
     narrationToggleStrings = getNarrationToggleStrings(locale);
     debugCoordinatesStrings = getDebugCoordinatesStrings(locale);
+    debugCollidersStrings = getDebugCollidersStrings(locale);
     helpModalController?.setAnnouncements(helpModalStrings.announcements);
     narrativeLogStrings = getPoiNarrativeLogStrings(locale);
     poiOverlayStrings = getPoiOverlayChromeStrings(locale);
@@ -3539,6 +3578,7 @@ function initializeImmersiveScene(
     audioSubtitles?.setLabels(audioSubtitleStrings);
     narrationToggleControl?.setStrings(narrationToggleStrings);
     refreshDebugCoordinatesStrings();
+    refreshDebugCollidersControl();
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
@@ -3626,6 +3666,7 @@ function initializeImmersiveScene(
       return;
     }
     activeFloorId = next;
+    colliderVisualizer.setActiveFloorId(next);
     floorVisibilityController.setActiveFloorId(next);
     poiWorldTooltip.setActiveFloorId(next);
     syncPoiDetailOverlay();
@@ -3867,6 +3908,48 @@ function initializeImmersiveScene(
     }
   };
 
+  const refreshDebugCollidersControl = () => {
+    if (!debugCollidersControl) {
+      return;
+    }
+    const label = debugCollidersEnabled
+      ? debugCollidersStrings.labelEnabled
+      : debugCollidersStrings.labelDisabled;
+    const description = debugCollidersEnabled
+      ? debugCollidersStrings.descriptionEnabled
+      : debugCollidersStrings.descriptionDisabled;
+    debugCollidersControl.textContent = label;
+    debugCollidersControl.dataset.state = debugCollidersEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugCollidersControl.setAttribute(
+      'aria-pressed',
+      debugCollidersEnabled ? 'true' : 'false'
+    );
+    debugCollidersControl.setAttribute('aria-label', description);
+    debugCollidersControl.title = description;
+    debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const setDebugCollidersEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugCollidersEnabled = enabled;
+    colliderVisualizer.setEnabled(enabled);
+    refreshDebugCollidersControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_COLLIDERS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug collider preference.', error);
+      }
+    }
+  };
+
   const refreshDebugCoordinatesStrings = () => {
     refreshDebugCoordinatesControl();
     updateDebugCoordinatesLabels();
@@ -3899,6 +3982,25 @@ function initializeImmersiveScene(
     setEnabled: (enabled: boolean) => {
       setDebugCoordinatesEnabled(enabled);
     },
+  };
+
+  debugCollidersControl = document.createElement('button');
+  debugCollidersControl.type = 'button';
+  debugCollidersControl.className = 'tour-toggle debug-colliders-toggle';
+  debugCollidersControl.addEventListener('click', () => {
+    setDebugCollidersEnabled(!debugCollidersEnabled);
+  });
+  hudSettingsStack.appendChild(debugCollidersControl);
+  registerHudControlElement(debugCollidersControl);
+  refreshDebugCollidersControl();
+  setDebugCollidersEnabled(debugCollidersEnabled, { persist: false });
+
+  window.portfolio.debugColliders = {
+    getState: () => colliderVisualizer.getState(),
+    setEnabled: (enabled: boolean) => {
+      setDebugCollidersEnabled(enabled);
+    },
+    getColliders: () => colliderVisualizer.getColliders(),
   };
 
   const setCameraZoomTarget = (next: number) => {

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,0 +1,217 @@
+import { BoxGeometry, Color, Group, Mesh, MeshBasicMaterial } from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+import type { FloorId } from '../../systems/movement/stairs';
+
+export type ColliderDebugCategory =
+  | 'ground'
+  | 'upper'
+  | 'static'
+  | 'stairs'
+  | 'transition';
+
+export interface ColliderDebugEntry {
+  floor: FloorId | 'all';
+  category: ColliderDebugCategory;
+  name: string;
+  bounds: RectCollider;
+  elevation?: number;
+}
+
+export interface ColliderDebugMetadata extends ColliderDebugEntry {
+  visible: boolean;
+}
+
+export interface ColliderVisualizerState {
+  enabled: boolean;
+  visibleColliderCount: number;
+  totalColliderCount: number;
+}
+
+export interface ColliderVisualizer {
+  group: Group;
+  setEnabled(enabled: boolean): void;
+  setActiveFloorId(floorId: FloorId): void;
+  getState(): ColliderVisualizerState;
+  getColliders(): ColliderDebugMetadata[];
+  dispose(): void;
+}
+
+interface ColliderVisualNode {
+  entry: ColliderDebugEntry;
+  mesh: Mesh;
+}
+
+const COLLIDER_VISUAL_HEIGHT = 0.08;
+const COLLIDER_VISUAL_Y = 0.08;
+const CATEGORY_COLORS: Record<ColliderDebugCategory, number> = {
+  ground: 0x36d399,
+  upper: 0x60a5fa,
+  static: 0xf59e0b,
+  stairs: 0xf472b6,
+  transition: 0xc084fc,
+};
+
+function cloneColliderBounds(bounds: RectCollider): RectCollider {
+  return {
+    minX: bounds.minX,
+    maxX: bounds.maxX,
+    minZ: bounds.minZ,
+    maxZ: bounds.maxZ,
+  };
+}
+
+function isEntryVisibleOnFloor(
+  entry: ColliderDebugEntry,
+  floorId: FloorId
+): boolean {
+  return entry.floor === 'all' || entry.floor === floorId;
+}
+
+function createColliderMesh(entry: ColliderDebugEntry): Mesh {
+  const width = Math.max(entry.bounds.maxX - entry.bounds.minX, 0.01);
+  const depth = Math.max(entry.bounds.maxZ - entry.bounds.minZ, 0.01);
+  const geometry = new BoxGeometry(width, COLLIDER_VISUAL_HEIGHT, depth);
+  const material = new MeshBasicMaterial({
+    color: new Color(CATEGORY_COLORS[entry.category]),
+    transparent: true,
+    opacity: 0.34,
+    depthWrite: false,
+    toneMapped: false,
+    wireframe: true,
+  });
+  const mesh = new Mesh(geometry, material);
+  mesh.name = `DebugCollider:${entry.floor}:${entry.category}:${entry.name}`;
+  mesh.position.set(
+    entry.bounds.minX + width / 2,
+    (entry.elevation ?? 0) + COLLIDER_VISUAL_Y,
+    entry.bounds.minZ + depth / 2
+  );
+  mesh.renderOrder = 999;
+  mesh.userData = {
+    ...mesh.userData,
+    debugOnly: true,
+    nonInteractive: true,
+    colliderDebug: {
+      floor: entry.floor,
+      category: entry.category,
+      name: entry.name,
+    },
+  };
+  mesh.raycast = () => undefined;
+  return mesh;
+}
+
+export function createColliderVisualizer(
+  entries: readonly ColliderDebugEntry[],
+  initialFloorId: FloorId = 'ground'
+): ColliderVisualizer {
+  const group = new Group();
+  group.name = 'DebugColliderVisualizer';
+  group.visible = false;
+  group.userData = {
+    ...group.userData,
+    debugOnly: true,
+    nonInteractive: true,
+  };
+
+  let enabled = false;
+  let activeFloorId = initialFloorId;
+  const nodes: ColliderVisualNode[] = entries.map((entry) => {
+    const clonedEntry: ColliderDebugEntry = {
+      floor: entry.floor,
+      category: entry.category,
+      name: entry.name,
+      bounds: cloneColliderBounds(entry.bounds),
+      elevation: entry.elevation,
+    };
+    const mesh = createColliderMesh(clonedEntry);
+    group.add(mesh);
+    return { entry: clonedEntry, mesh };
+  });
+
+  const syncVisibility = () => {
+    group.visible = enabled;
+    for (const node of nodes) {
+      node.mesh.visible =
+        enabled && isEntryVisibleOnFloor(node.entry, activeFloorId);
+    }
+  };
+
+  syncVisibility();
+
+  return {
+    group,
+    setEnabled(nextEnabled: boolean) {
+      enabled = nextEnabled;
+      syncVisibility();
+    },
+    setActiveFloorId(floorId: FloorId) {
+      activeFloorId = floorId;
+      syncVisibility();
+    },
+    getState() {
+      return {
+        enabled,
+        visibleColliderCount: nodes.filter((node) => node.mesh.visible).length,
+        totalColliderCount: nodes.length,
+      };
+    },
+    getColliders() {
+      return nodes.map(({ entry, mesh }) => ({
+        floor: entry.floor,
+        category: entry.category,
+        name: entry.name,
+        bounds: cloneColliderBounds(entry.bounds),
+        elevation: entry.elevation,
+        visible: mesh.visible,
+      }));
+    },
+    dispose() {
+      for (const node of nodes) {
+        node.mesh.geometry.dispose();
+        if (Array.isArray(node.mesh.material)) {
+          node.mesh.material.forEach((material) => material.dispose());
+        } else {
+          node.mesh.material.dispose();
+        }
+      }
+      group.clear();
+    },
+  };
+}
+
+export function createColliderDebugEntries(input: {
+  groundColliders: readonly RectCollider[];
+  upperFloorColliders: readonly RectCollider[];
+  staticColliders: readonly RectCollider[];
+  upperFloorElevation?: number;
+}): ColliderDebugEntry[] {
+  const entries: ColliderDebugEntry[] = [];
+  input.groundColliders.forEach((bounds, index) => {
+    entries.push({
+      floor: 'ground',
+      category: 'ground',
+      name: `ground-${index + 1}`,
+      bounds,
+    });
+  });
+  input.upperFloorColliders.forEach((bounds, index) => {
+    entries.push({
+      floor: 'upper',
+      category: 'upper',
+      name: `upper-${index + 1}`,
+      bounds,
+      elevation: input.upperFloorElevation,
+    });
+  });
+  input.staticColliders.forEach((bounds, index) => {
+    entries.push({
+      floor: 'ground',
+      category: 'static',
+      name: `static-${index + 1}`,
+      bounds,
+    });
+  });
+  return entries;
+}

--- a/src/tests/colliderVisualizer.test.ts
+++ b/src/tests/colliderVisualizer.test.ts
@@ -1,0 +1,102 @@
+import { Raycaster, type Intersection } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createColliderDebugEntries,
+  createColliderVisualizer,
+} from '../scene/debug/colliderVisualizer';
+
+const ground = { minX: 0, maxX: 1, minZ: 0, maxZ: 1 };
+const upper = { minX: 2, maxX: 3, minZ: 2, maxZ: 3 };
+const staticCollider = { minX: 4, maxX: 5, minZ: 4, maxZ: 5 };
+
+describe('collider visualizer', () => {
+  it('builds active-floor debug entries without mutating collider arrays', () => {
+    const entries = createColliderDebugEntries({
+      groundColliders: [ground],
+      upperFloorColliders: [upper],
+      staticColliders: [staticCollider],
+    });
+
+    expect(entries).toEqual([
+      { floor: 'ground', category: 'ground', name: 'ground-1', bounds: ground },
+      { floor: 'upper', category: 'upper', name: 'upper-1', bounds: upper },
+      {
+        floor: 'ground',
+        category: 'static',
+        name: 'static-1',
+        bounds: staticCollider,
+      },
+    ]);
+  });
+
+  it('only displays colliders for the active floor when enabled', () => {
+    const visualizer = createColliderVisualizer(
+      createColliderDebugEntries({
+        groundColliders: [ground],
+        upperFloorColliders: [upper],
+        staticColliders: [staticCollider],
+      }),
+      'ground'
+    );
+
+    expect(visualizer.getState()).toEqual({
+      enabled: false,
+      visibleColliderCount: 0,
+      totalColliderCount: 3,
+    });
+
+    visualizer.setEnabled(true);
+    expect(visualizer.getState()).toEqual({
+      enabled: true,
+      visibleColliderCount: 2,
+      totalColliderCount: 3,
+    });
+    expect(visualizer.getColliders().filter((entry) => entry.visible)).toEqual([
+      expect.objectContaining({ floor: 'ground', category: 'ground' }),
+      expect.objectContaining({ floor: 'ground', category: 'static' }),
+    ]);
+
+    visualizer.setActiveFloorId('upper');
+    expect(visualizer.getState()).toEqual({
+      enabled: true,
+      visibleColliderCount: 1,
+      totalColliderCount: 3,
+    });
+    expect(visualizer.getColliders().filter((entry) => entry.visible)).toEqual([
+      expect.objectContaining({ floor: 'upper', category: 'upper' }),
+    ]);
+
+    visualizer.setEnabled(false);
+    expect(visualizer.getState()).toEqual({
+      enabled: false,
+      visibleColliderCount: 0,
+      totalColliderCount: 3,
+    });
+
+    visualizer.dispose();
+  });
+
+  it('marks meshes as debug-only and opts them out of raycasting', () => {
+    const visualizer = createColliderVisualizer(
+      createColliderDebugEntries({
+        groundColliders: [ground],
+        upperFloorColliders: [],
+        staticColliders: [],
+      })
+    );
+    const mesh = visualizer.group.children[0];
+
+    expect(visualizer.group.userData).toMatchObject({
+      debugOnly: true,
+      nonInteractive: true,
+    });
+    expect(mesh.userData).toMatchObject({
+      debugOnly: true,
+      nonInteractive: true,
+    });
+    expect(mesh.raycast(new Raycaster(), [] as Intersection[])).toBeUndefined();
+
+    visualizer.dispose();
+  });
+});

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -5,6 +5,7 @@ import {
   formatMessage,
   getAudioSubtitleStrings,
   getControlOverlayStrings,
+  getDebugCollidersStrings,
   getDebugCoordinatesStrings,
   getHelpModalStrings,
   getLocaleDirection,
@@ -803,6 +804,36 @@ describe('i18n utilities', () => {
     );
     expect(getDebugCoordinatesStrings('en-x-pseudo').labelDisabled).toBe(
       '⟦Debug coordinates off⟧'
+    );
+  });
+
+  it('localizes debug collider controls across locales', () => {
+    expect(getDebugCollidersStrings('en').labelDisabled).toBe(
+      'Collider overlay off'
+    );
+    expect(getDebugCollidersStrings('es').labelEnabled).toBe(
+      'Superposición de colisionadores activada'
+    );
+    expect(getDebugCollidersStrings('pt').descriptionDisabled).toContain(
+      'permanece oculta'
+    );
+    expect(getDebugCollidersStrings('de').labelDisabled).toBe(
+      'Collider-Overlay aus'
+    );
+    expect(getDebugCollidersStrings('hu').labelEnabled).toBe(
+      'Ütköző overlay be'
+    );
+    expect(getDebugCollidersStrings('zh-Hans').labelDisabled).toBe(
+      '碰撞体浮层已关闭'
+    );
+    expect(getDebugCollidersStrings('ja').labelEnabled).toBe(
+      'コライダー表示オン'
+    );
+    expect(getDebugCollidersStrings('ar').descriptionEnabled).toContain(
+      'الجدران غير المرئية'
+    );
+    expect(getDebugCollidersStrings('en-x-pseudo').labelDisabled).toBe(
+      '⟦Collider overlay off⟧'
     );
   });
 


### PR DESCRIPTION
### Motivation
- Provide an opt-in visualization for invisible walls and collision rectangles so debugging and QA can see existing colliders without changing movement or collision semantics.
- Surface an easily persisted Settings toggle + URL override and a small runtime API to support browser QA and upcoming stair/collider tweaks.

### Description
- Add a reusable Three.js visualizer at `src/scene/debug/colliderVisualizer.ts` that renders thin, semi-transparent wire-boxes for collider bounds, is floor-aware, non-interactive, and opts out of raycasting. (`createColliderVisualizer`, `createColliderDebugEntries`).
- Wire the visualizer into the scene in `src/main.ts` after collider arrays are populated and keep it synchronized with `activeFloorId` so only the active-floor colliders are shown by default.
- Add a HUD Settings toggle with persistent storage key `danielsmith.io::debugColliders::v1` and URL override `?debugColliders=1`, plus `window.portfolio.debugColliders` exposing `getState()`, `setEnabled()`, and `getColliders()` for console/automation checks.
- Add typed i18n support (`DebugCollidersStrings`), English strings and equivalents for existing locales (including pseudo-locale), and `getDebugCollidersStrings(...)` accessor in the i18n surface.
- Add focused unit tests: `src/tests/colliderVisualizer.test.ts` for visualizer behavior and `src/tests/i18n.test.ts` coverage for the new strings; and update the QA runbook `docs/qa/upstairs-stairs.md` with collider visualization steps.
- Changes are intentionally diagnostic-only and do not modify or remove the existing `groundColliders`, `upperFloorColliders`, `staticColliders` arrays or collision checks.

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed.
- `npm run test:ci` — full test suite run completed; focused runs `npm run test:ci -- src/tests/colliderVisualizer.test.ts src/tests/i18n.test.ts` passed (collider visualizer + i18n tests succeeded).
- `npm run typecheck` — failed due to preexisting, unrelated TypeScript errors in the repository; no new type errors referencing `colliderVisualizer`/`debugColliders` were introduced.
- `npm run build` — passed (production build produced `dist/`).
- `npm run docs:check` — passed; link checker reported external fetch warnings (unchanged).
- `npm run smoke` — passed.
- Manual Playwright verification (headful/headless run against the preview URL) using `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1&debugColliders=1` confirmed the overlay appears and toggles: initial `visibleColliderCount` was `57` / `totalColliderCount` `83`, toggling the HUD button set visible count to `0` and toggling again returned `57`; screenshot saved to `/tmp/danielsmith-debug-colliders.png` during the run.

Notes and follow-ups
- The visualizer is strictly diagnostic: meshes are marked `debugOnly`/`nonInteractive`, `raycast` is disabled on them, and they are not included in navigation/collision logic.
- `npm run typecheck` failure is preexisting in the repo and unrelated to this change; a follow-up/typeclean PR could address broader type issues if desired.
- Branch: `codex/collider-debug-visualizer`; commit: `a54615a`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25fc97d238832f8474bee820bb9009)