### PR TITLE
🪜 : – Patch off-stair teleports

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -145,6 +145,36 @@ async function getTooltipState(page: Page): Promise<TooltipState> {
   });
 }
 
+test('off-stair ground positions near the upper stair top predict ground', async ({
+  page,
+}) => {
+  await waitForImmersiveReady(page);
+
+  const predictions = await page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return {
+      screenshotSource: world.predictFloorAt({
+        x: 7.4,
+        z: -25.27,
+        currentFloor: 'ground',
+      }),
+      screenshotLandingEdge: world.predictFloorAt({
+        x: 8.14,
+        z: -25.36,
+        currentFloor: 'ground',
+      }),
+    };
+  });
+
+  expect(predictions).toEqual({
+    screenshotSource: 'ground',
+    screenshotLandingEdge: 'ground',
+  });
+});
+
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   test.slow();
   await waitForImmersiveReady(page);

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -93,11 +93,28 @@ const createCenteredRect = (
   maxZ,
 });
 
+export const isWithinPhysicalStairWidth = (
+  geometry: StairGeometry,
+  x: number
+): boolean => Math.abs(x - geometry.centerX) <= geometry.halfWidth;
+
 export const isWithinStairWidth = (
   geometry: StairGeometry,
   x: number,
   margin = 0
 ): boolean => Math.abs(x - geometry.centerX) <= geometry.halfWidth + margin;
+
+export const isWithinRampRun = (
+  geometry: StairGeometry,
+  z: number,
+  margin = 0
+): boolean =>
+  isWithinZRange(
+    z,
+    getMinZ(geometry.bottomZ, geometry.topZ),
+    getMaxZ(geometry.bottomZ, geometry.topZ),
+    margin
+  );
 
 export const isWithinLanding = (
   geometry: StairGeometry,
@@ -115,7 +132,10 @@ export const computeRampHeight = (
   x: number,
   z: number
 ): number => {
-  if (!isWithinStairWidth(geometry, x, behavior.transitionMargin)) {
+  if (
+    !isWithinPhysicalStairWidth(geometry, x) ||
+    !isWithinRampRun(geometry, z)
+  ) {
     return 0;
   }
   const denominator = geometry.bottomZ - geometry.topZ;
@@ -211,7 +231,7 @@ export const classifyStairTransitionZone = (
 ): StairTransitionZone => {
   const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
   const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
-  const inActualStairWidth = isWithinStairWidth(geometry, x);
+  const inActualStairWidth = isWithinPhysicalStairWidth(geometry, x);
   const inTransitionWidth = isWithinStairWidth(
     geometry,
     x,
@@ -265,11 +285,7 @@ export const predictStairFloorId = (
 ): FloorId => {
   const zone = classifyStairTransitionZone(geometry, behavior, x, z, current);
   const rampHeight = computeRampHeight(geometry, behavior, x, z);
-  const withinStairs = isWithinStairWidth(
-    geometry,
-    x,
-    behavior.transitionMargin
-  );
+  const withinPhysicalStairs = isWithinPhysicalStairWidth(geometry, x);
   const direction = geometry.direction;
 
   if (current === 'upper') {
@@ -286,7 +302,7 @@ export const predictStairFloorId = (
       : z >= geometry.topZ - behavior.transitionMargin;
 
   const nearLanding =
-    withinStairs &&
+    withinPhysicalStairs &&
     (nearTop ||
       rampHeight >= geometry.totalRise - behavior.stepRise * 0.25 ||
       zone === 'upperLanding');

--- a/src/tests/movement/stairSurfaceHeight.test.ts
+++ b/src/tests/movement/stairSurfaceHeight.test.ts
@@ -30,6 +30,34 @@ const behavior: StairBehavior = {
 
 const upperFloorElevation = geometry.totalRise + 0.38;
 
+const negativeZGeometry: StairGeometry = {
+  centerX: toWorldUnits(6.2),
+  halfWidth: toWorldUnits(3.1) / 2,
+  bottomZ: toWorldUnits(-5.3),
+  topZ: toWorldUnits(-5.3) - toWorldUnits(0.85) * 9,
+  landingMinZ: toWorldUnits(-5.3) - toWorldUnits(0.85) * 9 - toWorldUnits(2.6),
+  landingMaxZ: toWorldUnits(-5.3) - toWorldUnits(0.85) * 9,
+  totalRise: 0.42 * 9,
+  direction: -1,
+};
+
+const negativeZBehavior: StairBehavior = {
+  ...behavior,
+  descentCorridorInset: 0.75,
+};
+
+const sampleNegativeZ = (params: {
+  x: number;
+  z: number;
+  currentFloor: FloorId;
+}) =>
+  sampleStairSurfaceHeight({
+    geometry: negativeZGeometry,
+    behavior: negativeZBehavior,
+    upperFloorElevation,
+    ...params,
+  });
+
 const sample = (params: { x: number; z: number; currentFloor: FloorId }) =>
   sampleStairSurfaceHeight({
     geometry,
@@ -43,6 +71,16 @@ describe('sampleStairSurfaceHeight', () => {
     const midRampZ = geometry.topZ / 2;
     const height = sample({ x: 0, z: midRampZ, currentFloor: 'ground' });
     expect(height).toBeCloseTo(geometry.totalRise / 2, 5);
+  });
+
+  it('does not lift off-stair ground positions near the upper stair top', () => {
+    const height = sampleNegativeZ({
+      x: 8.14,
+      z: -25.36,
+      currentFloor: 'ground',
+    });
+
+    expect(height).toBe(0);
   });
 
   it('keeps landing height at the descent threshold', () => {

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -57,6 +57,36 @@ const classify = (
 ) => classifyStairTransitionZone(geometry, STAIR_BEHAVIOR, x, z, currentFloor);
 
 describe('stair floor transitions (negative Z ascent)', () => {
+  it('keeps screenshot-4 off-stair positions on ground near the upper stair top', () => {
+    const screenshotSource = { x: 7.4, z: -25.27 };
+    const screenshotLandingEdge = { x: 8.14, z: -25.36 };
+
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        screenshotSource.x,
+        screenshotSource.z,
+        'ground'
+      )
+    ).toBe('ground');
+    expect(
+      predict(
+        NEGATIVE_Z_STAIRS,
+        screenshotLandingEdge.x,
+        screenshotLandingEdge.z,
+        'ground'
+      )
+    ).toBe('ground');
+    expect(
+      classify(
+        NEGATIVE_Z_STAIRS,
+        screenshotLandingEdge.x,
+        screenshotLandingEdge.z,
+        'ground'
+      )
+    ).toBe('outsideStairs');
+  });
+
   it('transitions from ground to upper near the top of the stairs', () => {
     const nearTopStepZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.15);
 


### PR DESCRIPTION
### Motivation
- Prevent off-stair ground positions beside the stair top from being predicted or sampled as the upper floor, which caused an unintended vertical teleport for coordinates near the screenshot-4 area.
- Tighten floor transition and ramp-sampling math so vertical movement only occurs when the avatar is physically inside the stair corridor or explicit descent handoff.

### Description
- Added explicit predicates `isWithinPhysicalStairWidth` and `isWithinRampRun` and used them to require the physical stair corridor for ramp height sampling and ground→upper prediction (changes in `src/systems/movement/stairs.ts`).
- Replaced ad-hoc usage of transition-margin halo for ascent with checks against the physical stair width so off-stair halo positions no longer trigger upward transitions (logic updates in `predictStairFloorId` and `computeRampHeight`).
- Added unit tests exercising the regression coordinates and sampling behavior (`src/tests/movement/stairTransitions.test.ts` and `src/tests/movement/stairSurfaceHeight.test.ts`) to assert off-stair points remain `ground` and do not receive upper-floor height.
- Added a Playwright regression assertion to `playwright/immersive-stairs-roundtrip.spec.ts` to validate `window.portfolio.world.predictFloorAt(...)` for the screenshot-4 source/landing-edge coordinates.

### Testing
- `npm run format:write -- src/systems/movement/stairs.ts src/tests/movement/stairTransitions.test.ts src/tests/movement/stairSurfaceHeight.test.ts playwright/immersive-stairs-roundtrip.spec.ts` — succeeded.
- `npm run lint` — succeeded.
- `npm run test:ci` (Vitest) — succeeded; full suite ran (all tests passed in CI run used here).
- `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell` — performed to satisfy Playwright prerequisites, then `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — succeeded (the spec including the new regression test passed).
- `npm run build` — succeeded and produced `dist` artifacts.
- `npm run docs:check` — succeeded (link checks produced existing external warnings but no blocking failures).
- `npm run smoke` — succeeded.
- `npm run typecheck -- --pretty false` — NOT run to completion here (TypeScript typecheck fails due to unrelated pre-existing errors elsewhere in the repo; this change did not introduce those failures).

Notes: The change is intentionally scoped to stair floor prediction and sampling (no broad nav mesh or collision layout alterations were made). Follow-ups could include a broader cleanup of pre-existing `tsc` issues so `npm run typecheck` is green across the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260cf37ba4832f9866f33e58b863c4)