### PR TITLE
Fix off-stair vertical teleports

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -161,6 +161,27 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   // Start on ground.
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
+  const offStairRegression = await page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    const target = { x: 8.14, z: -25.36, currentFloor: 'ground' as const };
+    const source = { x: 7.4, z: -25.27, currentFloor: 'ground' as const };
+    return {
+      targetPrediction: world.predictFloorAt(target),
+      sourcePrediction: world.predictFloorAt(source),
+      targetZone: world.getStairTransitionZone(target),
+      sourceZone: world.getStairTransitionZone(source),
+    };
+  });
+  expect(offStairRegression).toEqual({
+    targetPrediction: 'ground',
+    sourcePrediction: 'ground',
+    targetZone: 'outsideStairs',
+    sourceZone: 'outsideStairs',
+  });
+
   // Move to the base of the staircase on the ground floor.
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -93,11 +93,26 @@ const createCenteredRect = (
   maxZ,
 });
 
+export const isWithinPhysicalStairWidth = (
+  geometry: StairGeometry,
+  x: number
+): boolean => Math.abs(x - geometry.centerX) <= geometry.halfWidth;
+
 export const isWithinStairWidth = (
   geometry: StairGeometry,
   x: number,
   margin = 0
 ): boolean => Math.abs(x - geometry.centerX) <= geometry.halfWidth + margin;
+
+export const isWithinRampRun = (
+  geometry: StairGeometry,
+  z: number,
+  margin = 0
+): boolean => {
+  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
+  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
+  return isWithinZRange(z, rampMinZ, rampMaxZ, margin);
+};
 
 export const isWithinLanding = (
   geometry: StairGeometry,
@@ -115,7 +130,7 @@ export const computeRampHeight = (
   x: number,
   z: number
 ): number => {
-  if (!isWithinStairWidth(geometry, x, behavior.transitionMargin)) {
+  if (!isWithinPhysicalStairWidth(geometry, x)) {
     return 0;
   }
   const denominator = geometry.bottomZ - geometry.topZ;
@@ -179,13 +194,10 @@ const isInExplicitDescentCorridor = (
   x: number,
   z: number
 ): boolean => {
-  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
-  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
   const descentDistance = getDescentDistanceFromLanding(geometry, z);
-  const insideRampZ = isWithinZRange(
+  const insideRampZ = isWithinRampRun(
+    geometry,
     z,
-    rampMinZ,
-    rampMaxZ,
     behavior.transitionMargin * 0.5
   );
 
@@ -209,9 +221,7 @@ export const classifyStairTransitionZone = (
   z: number,
   current: FloorId
 ): StairTransitionZone => {
-  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
-  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
-  const inActualStairWidth = isWithinStairWidth(geometry, x);
+  const inActualStairWidth = isWithinPhysicalStairWidth(geometry, x);
   const inTransitionWidth = isWithinStairWidth(
     geometry,
     x,
@@ -239,7 +249,7 @@ export const classifyStairTransitionZone = (
 
   const direction = geometry.direction;
 
-  if (inActualStairWidth && isWithinZRange(z, rampMinZ, rampMaxZ)) {
+  if (inActualStairWidth && isWithinRampRun(geometry, z)) {
     return 'stairRampBody';
   }
 
@@ -265,11 +275,7 @@ export const predictStairFloorId = (
 ): FloorId => {
   const zone = classifyStairTransitionZone(geometry, behavior, x, z, current);
   const rampHeight = computeRampHeight(geometry, behavior, x, z);
-  const withinStairs = isWithinStairWidth(
-    geometry,
-    x,
-    behavior.transitionMargin
-  );
+  const withinPhysicalStairs = isWithinPhysicalStairWidth(geometry, x);
   const direction = geometry.direction;
 
   if (current === 'upper') {
@@ -286,7 +292,7 @@ export const predictStairFloorId = (
       : z >= geometry.topZ - behavior.transitionMargin;
 
   const nearLanding =
-    withinStairs &&
+    withinPhysicalStairs &&
     (nearTop ||
       rampHeight >= geometry.totalRise - behavior.stepRise * 0.25 ||
       zone === 'upperLanding');

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -6,6 +6,7 @@ import {
   createStairNavAreaRect,
   createStairNavigationZones,
   predictStairFloorId,
+  sampleStairSurfaceHeight,
   type FloorId,
   type StairBehavior,
   type StairGeometry,
@@ -68,6 +69,33 @@ describe('stair floor transitions (negative Z ascent)', () => {
         'ground'
       )
     ).toBe('upper');
+  });
+
+  it('keeps screenshot-4 ground points outside physical width on ground near the top', () => {
+    const offStairTarget = { x: 8.14, z: -25.36 };
+    const sourcePoint = { x: 7.4, z: -25.27 };
+
+    expect(
+      predict(NEGATIVE_Z_STAIRS, offStairTarget.x, offStairTarget.z, 'ground')
+    ).toBe('ground');
+    expect(
+      predict(NEGATIVE_Z_STAIRS, sourcePoint.x, sourcePoint.z, 'ground')
+    ).toBe('ground');
+  });
+
+  it('does not sample upper-floor height for screenshot-4 ground points outside physical width', () => {
+    const offStairTarget = { x: 8.14, z: -25.36 };
+    const upperFloorElevation = NEGATIVE_Z_STAIRS.totalRise + 0.38;
+
+    expect(
+      sampleStairSurfaceHeight({
+        geometry: NEGATIVE_Z_STAIRS,
+        behavior: STAIR_BEHAVIOR,
+        upperFloorElevation,
+        currentFloor: 'ground',
+        ...offStairTarget,
+      })
+    ).toBe(0);
   });
 
   it('keeps the player on the upper floor while roaming across the landing', () => {


### PR DESCRIPTION
### Motivation
- Prevent ground-floor players adjacent to the stair top from being predicted or lifted onto the upper floor when they are not physically on the stair corridor.
- Preserve valid centerline ascent/descent and existing explicit descent corridor behavior while tightening the prediction/sampling surface to the actual stair geometry.

### Description
- Add explicit predicates `isWithinPhysicalStairWidth` and `isWithinRampRun` and use them so ramp height sampling requires being inside the physical stair width. (changed: `src/systems/movement/stairs.ts`)
- Tighten `predictStairFloorId` to require the physical stair width (not the transition-margin halo) before promoting a ground-side point to `upper`. (changed: `src/systems/movement/stairs.ts`)
- Update `computeRampHeight` / sampling logic so off-stair points no longer return upper-floor height. (changed: `src/systems/movement/stairs.ts`)
- Add focused unit regressions that reproduce the screenshot-4 coordinates and assert they remain `ground` and sample to ground height. (changed: `src/tests/movement/stairTransitions.test.ts`)
- Add a Playwright regression assertion that queries the world API for the problematic coordinates and verifies `predictFloorAt` and stair zone remain `ground` / `outsideStairs` before the normal stair roundtrip flow. (changed: `playwright/immersive-stairs-roundtrip.spec.ts`)

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both succeeded.
- Ran unit suite with `npm run test:ci`, which passed (all Vitest suites ran; movement stair tests included and passed).
- Ran the focused Vitest movement tests: `npm run test:ci -- src/tests/movement/stairTransitions.test.ts src/tests/movement/stairSurfaceHeight.test.ts` and they passed.
- Ran the Playwright spec `playwright/immersive-stairs-roundtrip.spec.ts`, which required installing browsers and deps via `npx playwright install` and `npx playwright install-deps chromium`; after installing those, `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` passed (3 tests).
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`, both succeeded.
- Ran docs/link checks with `npm run docs:check`, which passed; ran the repo secret scan `git diff --cached | ./scripts/scan-secrets.py`, which found no high-risk secrets.
- `npm run typecheck` still fails due to unrelated, pre-existing TypeScript errors outside the patch surface (first reported error: `src/main.ts(2744,33): error TS2345: Argument of type 'null' is not assignable to parameter of type 'AudioNode'`).

Files changed: `src/systems/movement/stairs.ts`, `src/tests/movement/stairTransitions.test.ts`, `playwright/immersive-stairs-roundtrip.spec.ts`.

Residual risk / follow-up
- `npm run typecheck` reports unrelated type errors in `src/main.ts` and other files; this patch intentionally limits scope to stair prediction/sampling and test coverage, so typecheck remediation should be handled separately.
- If further layout regressions appear in other stair geometries, consider expanding named predicates or adding small integration checks around different staircase configs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260cf37ba4832f9866f33e58b863c4)