### PR TITLE
Fix upper stairwell egress and over-stair cutout

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -23,6 +23,15 @@ type StairTransitionZone =
 
 type TestWorldApi = {
   movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+  isPositionOccupiable(target: {
+    x: number;
+    z: number;
+    floorId?: FloorId;
+  }): boolean;
+  getFloorPlanRooms(floorId: FloorId): Array<{
+    id: string;
+    bounds: { minX: number; maxX: number; minZ: number; maxZ: number };
+  }>;
   getActiveFloor(): FloorId;
   getPlayerPosition(): { x: number; y: number; z: number };
   predictFloorAt(target: {
@@ -237,6 +246,89 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   });
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.35 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('upper landing opens to upstairs rooms without exposing the hidden stair run', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const { stairCenterX, stairHalfWidth, stairBottomZ, stairTopZ } =
+    await getStairMetrics(page);
+
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.1 });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const targets = await page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+
+    const upperRooms = world.getFloorPlanRooms('upper');
+    const creatorsStudio = upperRooms.find(
+      (room) => room.id === 'creatorsStudio'
+    );
+    const upperLanding = upperRooms.find((room) => room.id === 'upperLanding');
+    if (!creatorsStudio || !upperLanding) {
+      throw new Error('Upper floor room bounds unavailable');
+    }
+
+    const westDoorwayZ = -24;
+    const upstairsRoom = {
+      x: (creatorsStudio.bounds.minX + creatorsStudio.bounds.maxX) / 2,
+      z: westDoorwayZ,
+      floorId: 'upper' as const,
+    };
+
+    return {
+      westDoorway: {
+        x: upperLanding.bounds.minX + 0.4,
+        z: westDoorwayZ,
+        floorId: 'upper' as const,
+      },
+      upstairsRoom,
+      normalUpperSpace: { x: 8.15, z: -11.82, floorId: 'upper' as const },
+      normalUpperSpaceEast: { x: 8.65, z: -11.82, floorId: 'upper' as const },
+      overStairRun: { x: 12.7, z: -23.72, floorId: 'upper' as const },
+    };
+  });
+
+  await movePlayerTo(page, targets.westDoorway);
+  await movePlayerTo(page, targets.upstairsRoom);
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const occupiable = await page.evaluate((sampleTargets) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return {
+      normalUpperSpace: world.isPositionOccupiable(
+        sampleTargets.normalUpperSpace
+      ),
+      normalUpperSpaceEast: world.isPositionOccupiable(
+        sampleTargets.normalUpperSpaceEast
+      ),
+      overStairRun: world.isPositionOccupiable(sampleTargets.overStairRun),
+    };
+  }, targets);
+
+  expect(occupiable.normalUpperSpace).toBe(true);
+  expect(occupiable.normalUpperSpaceEast).toBe(true);
+  expect(occupiable.overStairRun).toBe(false);
+
+  await expect(async () =>
+    movePlayerTo(page, targets.overStairRun)
+  ).rejects.toThrow(/Cannot occupy/);
+  expect(stairHalfWidth).toBeGreaterThan(0);
 });
 
 test('upper landing edge nudges stay upstairs until the descent corridor is entered', async ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -618,6 +618,15 @@ declare global {
           z: number;
           currentFloor?: FloorId;
         }): StairTransitionZone;
+        isPositionOccupiable(target: {
+          x: number;
+          z: number;
+          floorId?: FloorId;
+        }): boolean;
+        getFloorPlanRooms(floorId: FloorId): Array<{
+          id: string;
+          bounds: { minX: number; maxX: number; minZ: number; maxZ: number };
+        }>;
         getStairMetrics(): {
           stairCenterX: number;
           stairHalfWidth: number;
@@ -1817,25 +1826,40 @@ function initializeImmersiveScene(
     stairNavigationZones.stairRampBody,
   ];
   const upperStairNavZones = [stairNavigationZones.upperLanding];
+  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'upperLanding'
+  );
   const upperStairDescentGuardMinZ = Math.min(stairTopZ, stairBottomZ);
   const upperStairDescentGuardMaxZ = Math.max(stairTopZ, stairBottomZ);
-  // Invisible upper-floor guard rails flank the intentional descent corridor.
-  // They keep normal landing/room movement from drifting into the stairwell
-  // void while leaving the middle corridor open for deliberate stair descent.
-  upperFloorColliders.push(
-    {
-      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-      maxX: stairNavigationZones.explicitDescentCorridor.minX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    },
-    {
-      minX: stairNavigationZones.explicitDescentCorridor.maxX,
-      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    }
-  );
+  // An invisible upper-floor guard rail protects the +X side of the
+  // intentional descent corridor. The -X side stays open so the landing can
+  // egress into the upstairs rooms.
+  upperFloorColliders.push({
+    minX: stairNavigationZones.explicitDescentCorridor.maxX,
+    maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+    minZ: upperStairDescentGuardMinZ,
+    maxZ: upperStairDescentGuardMaxZ,
+  });
+  // Keep upper-floor navigation off the ramp void after the visual floor
+  // cutout exposes the hidden stair run. The explicit descent handoff predicts
+  // the ground floor before this upper-only blocker applies, so valid stair
+  // descent still works through the center corridor.
+  const overStairRunBlockerStartZ =
+    stairLayout.directionMultiplier === -1
+      ? stairTopZ + PLAYER_RADIUS * 2
+      : stairTopZ - PLAYER_RADIUS * 2;
+  upperFloorColliders.push({
+    minX: stairCenterX - stairHalfWidth,
+    maxX: stairCenterX + stairHalfWidth,
+    minZ: Math.min(
+      overStairRunBlockerStartZ,
+      upperLandingRoom?.bounds.maxZ ?? overStairRunBlockerStartZ
+    ),
+    maxZ: Math.max(
+      overStairRunBlockerStartZ,
+      upperLandingRoom?.bounds.maxZ ?? overStairRunBlockerStartZ
+    ),
+  });
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -1865,9 +1889,6 @@ function initializeImmersiveScene(
     opacity: 1,
     depthWrite: true,
   });
-  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
-    (room) => room.id === 'upperLanding'
-  );
   const upperStairwellOpening = upperLandingRoom
     ? computeStairwellOpeningBounds({
         centerX: stairCenterX,
@@ -1900,6 +1921,8 @@ function initializeImmersiveScene(
       roomBounds: upperLandingRoom.bounds,
       openingBounds: upperStairwellOpening,
       descentCorridorBounds: stairNavigationZones.explicitDescentCorridor,
+      sideGuards: { west: false },
+      shoulderGuards: { west: false },
       elevation: upperFloorElevation,
       guard: {
         height: 0.56,
@@ -3048,6 +3071,24 @@ function initializeImmersiveScene(
           target.z,
           target.currentFloor ?? activeFloorId
         );
+      },
+      isPositionOccupiable(target: {
+        x: number;
+        z: number;
+        floorId?: FloorId;
+      }) {
+        return canOccupyPosition(
+          target.x,
+          target.z,
+          target.floorId ?? activeFloorId
+        );
+      },
+      getFloorPlanRooms(floorId: FloorId) {
+        const plan = floorId === 'upper' ? UPPER_FLOOR_PLAN : FLOOR_PLAN;
+        return plan.rooms.map((room) => ({
+          id: room.id,
+          bounds: { ...room.bounds },
+        }));
       },
       getStairMetrics() {
         return {

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -112,25 +112,13 @@ describe('createRoomFloorTiles', () => {
       minX: stairwellOpening.minX,
       maxX: stairwellOpening.maxX,
       minZ: stairwellOpening.minZ,
-      maxZ: stairLayout.landingMaxZ,
+      maxZ: stairwellOpening.maxZ,
     };
     expect(
       upperLandingTiles.some((tile) =>
         overlaps(tile.bounds, visibleStairwellVoid)
       )
     ).toBe(false);
-
-    const doorwayBridgePastStairTop = {
-      minX: stairwellOpening.minX,
-      maxX: stairwellOpening.maxX,
-      minZ: stairLayout.landingMaxZ,
-      maxZ: upperLandingRoom!.bounds.maxZ,
-    };
-    expect(
-      upperLandingTiles.some((tile) =>
-        boundsAreClose(tile.bounds, doorwayBridgePastStairTop)
-      )
-    ).toBe(true);
 
     for (const tile of build.tiles) {
       const geometry = tile.mesh.geometry as BoxGeometry;

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -93,6 +93,48 @@ describe('createUpperStairwellLanding', () => {
     ).toBe(false);
   });
 
+  it('can leave the -X side open for upper-room egress while preserving +X guards', () => {
+    const openingBounds = { minX: -2, maxX: 2, minZ: -8, maxZ: 6 };
+    const result = createUpperStairwellLanding({
+      roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
+      openingBounds,
+      descentCorridorBounds: { minX: -1, maxX: 1, minZ: -8, maxZ: 6 },
+      sideGuards: { west: false },
+      shoulderGuards: { west: false },
+      elevation: 4,
+      guard: {
+        height: 0.56,
+        thickness: 0.2,
+        material: { color: 0xff0000 },
+      },
+    });
+
+    expect(result.colliders).not.toContainEqual({
+      minX: -2.2,
+      maxX: -2,
+      minZ: -8,
+      maxZ: 6,
+    });
+    expect(result.colliders).not.toContainEqual({
+      minX: -2,
+      maxX: -1,
+      minZ: -8,
+      maxZ: 6,
+    });
+    expect(result.colliders).toContainEqual({
+      minX: 2,
+      maxX: 2.2,
+      minZ: -8,
+      maxZ: 6,
+    });
+    expect(result.colliders).toContainEqual({
+      minX: 1,
+      maxX: 2,
+      minZ: -8,
+      maxZ: 6,
+    });
+  });
+
   it('clamps guard colliders to the landing room when the opening touches an edge', () => {
     const result = createUpperStairwellLanding({
       roomBounds: { minX: -2, maxX: 4, minZ: -6, maxZ: 6 },

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -13,6 +13,20 @@ export interface UpperStairwellGuardConfig {
   material?: MeshStandardMaterialParameters;
 }
 
+export interface UpperStairwellShoulderGuardConfig {
+  /** Whether to fill the opening shoulder toward -X. Defaults to true. */
+  west?: boolean;
+  /** Whether to fill the opening shoulder toward +X. Defaults to true. */
+  east?: boolean;
+}
+
+export interface UpperStairwellSideGuardConfig {
+  /** Whether to add a rail along the opening edge toward -X. Defaults to true. */
+  west?: boolean;
+  /** Whether to add a rail along the opening edge toward +X. Defaults to true. */
+  east?: boolean;
+}
+
 export interface UpperStairwellLandingConfig {
   /** World-space bounds of the upper landing room. */
   roomBounds: Bounds2D;
@@ -20,6 +34,10 @@ export interface UpperStairwellLandingConfig {
   openingBounds: Bounds2D;
   /** Optional deliberate descent corridor that remains open through the cutout. */
   descentCorridorBounds?: Bounds2D;
+  /** Optional side rail toggles for deliberate egress gaps. */
+  sideGuards?: UpperStairwellSideGuardConfig;
+  /** Optional shoulder blocker toggles around the descent corridor. */
+  shoulderGuards?: UpperStairwellShoulderGuardConfig;
   /** Height of the upper-floor surface measured from world origin. */
   elevation: number;
   /** Guard rail configuration. */
@@ -107,36 +125,41 @@ export function createUpperStairwellLanding(
     return { group, colliders };
   }
 
-  addGuard({
-    group,
-    colliders,
-    material: guardMaterial,
-    name: `${SIDE_GUARD_NAME}-West`,
-    bounds: {
-      minX: openingBounds.minX - thickness,
-      maxX: openingBounds.minX,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.maxZ,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
-  addGuard({
-    group,
-    colliders,
-    material: guardMaterial,
-    name: `${SIDE_GUARD_NAME}-East`,
-    bounds: {
-      minX: openingBounds.maxX,
-      maxX: openingBounds.maxX + thickness,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.maxZ,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
+  const sideGuards = { west: true, east: true, ...config.sideGuards };
+  if (sideGuards.west) {
+    addGuard({
+      group,
+      colliders,
+      material: guardMaterial,
+      name: `${SIDE_GUARD_NAME}-West`,
+      bounds: {
+        minX: openingBounds.minX - thickness,
+        maxX: openingBounds.minX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      },
+      roomBounds: config.roomBounds,
+      elevation: config.elevation,
+      height: config.guard.height,
+    });
+  }
+  if (sideGuards.east) {
+    addGuard({
+      group,
+      colliders,
+      material: guardMaterial,
+      name: `${SIDE_GUARD_NAME}-East`,
+      bounds: {
+        minX: openingBounds.maxX,
+        maxX: openingBounds.maxX + thickness,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      },
+      roomBounds: config.roomBounds,
+      elevation: config.elevation,
+      height: config.guard.height,
+    });
+  }
   addGuard({
     group,
     colliders,
@@ -158,37 +181,46 @@ export function createUpperStairwellLanding(
       config.descentCorridorBounds,
       openingBounds
     );
+    const shoulderGuards = {
+      west: true,
+      east: true,
+      ...config.shoulderGuards,
+    };
 
-    addGuard({
-      group,
-      colliders,
-      material: guardMaterial,
-      name: `${SHOULDER_GUARD_NAME}-West`,
-      bounds: {
-        minX: openingBounds.minX,
-        maxX: descentCorridorBounds.minX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-    addGuard({
-      group,
-      colliders,
-      material: guardMaterial,
-      name: `${SHOULDER_GUARD_NAME}-East`,
-      bounds: {
-        minX: descentCorridorBounds.maxX,
-        maxX: openingBounds.maxX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
+    if (shoulderGuards.west) {
+      addGuard({
+        group,
+        colliders,
+        material: guardMaterial,
+        name: `${SHOULDER_GUARD_NAME}-West`,
+        bounds: {
+          minX: openingBounds.minX,
+          maxX: descentCorridorBounds.minX,
+          minZ: openingBounds.minZ,
+          maxZ: openingBounds.maxZ,
+        },
+        roomBounds: config.roomBounds,
+        elevation: config.elevation,
+        height: config.guard.height,
+      });
+    }
+    if (shoulderGuards.east) {
+      addGuard({
+        group,
+        colliders,
+        material: guardMaterial,
+        name: `${SHOULDER_GUARD_NAME}-East`,
+        bounds: {
+          minX: descentCorridorBounds.maxX,
+          maxX: openingBounds.maxX,
+          minZ: openingBounds.minZ,
+          maxZ: openingBounds.maxZ,
+        },
+        roomBounds: config.roomBounds,
+        elevation: config.elevation,
+        height: config.guard.height,
+      });
+    }
   }
 
   return { group, colliders };

--- a/src/systems/movement/stairLayout.ts
+++ b/src/systems/movement/stairLayout.ts
@@ -89,21 +89,15 @@ export const computeStairLayout = (
 
 /**
  * Clips the visible upstairs stairwell hole to the landing room while deriving
- * the stair landing void from `computeStairLayout`. Movement and visuals
- * therefore use the same threshold metrics without cutting away the normal
- * upper-floor doorway bridge beyond the stair top.
+ * the full stair run void from `computeStairLayout`. Movement and visuals
+ * therefore share the same ramp and landing extents instead of leaving an
+ * opaque upper-floor slab over hidden stairs.
  */
 export const computeStairwellOpeningBounds = (
   config: StairwellOpeningConfig
 ): StairwellBounds => {
-  const openingMinZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.stairHoleRange.minZ
-      : config.layout.landingMinZ;
-  const openingMaxZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.landingMaxZ
-      : config.layout.stairHoleRange.maxZ;
+  const openingMinZ = config.layout.stairHoleRange.minZ;
+  const openingMaxZ = config.layout.stairHoleRange.maxZ;
 
   return {
     minX: Math.max(

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -48,7 +48,7 @@ describe('computeStairLayout', () => {
     });
   });
 
-  it('clips upstairs stairwell hole bounds from the shared stair layout plus margin', () => {
+  it('clips upstairs stairwell hole bounds from the full shared stair run plus margin', () => {
     const layout = computeStairLayout({
       baseZ: -10.6,
       stepRun: 1.7,
@@ -70,6 +70,30 @@ describe('computeStairLayout', () => {
     expect(opening.minX).toBeCloseTo(7.04);
     expect(opening.maxX).toBeCloseTo(12.8);
     expect(opening.minZ).toBeCloseTo(-31.9);
-    expect(opening.maxZ).toBeCloseTo(-25.9);
+    expect(opening.maxZ).toBeCloseTo(-16);
+  });
+
+  it('extends negative-Z upper-floor cutouts over the ramp run, not just the landing lip', () => {
+    const layout = computeStairLayout({
+      baseZ: -10.6,
+      stepRun: 1.7,
+      stepCount: 9,
+      landingDepth: 5.2,
+      direction: 'negativeZ',
+      guardMargin: 1.2,
+      stairwellMargin: 0.8,
+    });
+
+    const opening = computeStairwellOpeningBounds({
+      centerX: 12.4,
+      halfWidth: 3.1,
+      marginX: 0.4,
+      roomBounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+      layout,
+    });
+
+    expect(opening.minZ).toBeLessThan(layout.topZ);
+    expect(opening.maxZ).toBeGreaterThan(-23.72);
+    expect(opening.maxZ).toBeCloseTo(-16);
   });
 });


### PR DESCRIPTION
### Motivation
- Fix the upper-landing UX where the -X egress was blocked and players could walk above the hidden stair run under the opaque upper-floor slab.
- Ensure invisible stairwell blockers are scoped to the actual stair void so normal upstairs movement (e.g. near `8.15, -11.82`) is not blocked.
- Provide a debugable way to validate invisible/upper-floor colliders and tests that exercise real upstairs room egress instead of magic coordinates.

### Description
- Make the upper-floor cutout span the full stair run by updating `computeStairwellOpeningBounds` to use the stair run `stairHoleRange` instead of only the landing lip. (`src/systems/movement/stairLayout.ts`)
- Add a focused upper-only collider that blocks the over-stair void while removing the overly broad -X guard; keep a +X guard and make side/shoulder guards configurable so -X egress can be opened. (`src/main.ts`, `src/scene/structures/upperStairwellLanding.ts`)
- Expose small test helpers on the in-page world API: `isPositionOccupiable(...)` and `getFloorPlanRooms(...)` so Playwright tests can derive upstairs targets from the floor plan. (`src/main.ts`)
- Extend unit and end-to-end coverage: update stair layout/floor-tiles unit tests and add a Playwright test that ascends the stairs, walks into an upstairs room via the -X landing, verifies occupiable coordinates near `8.15, -11.82`, and asserts the over-stair run at `12.70, -23.72` is not occupiable. (`src/tests/...`, `src/scene/structures/__tests__/*`, `playwright/immersive-stairs-roundtrip.spec.ts`)

### Testing
- Formatting/lint: ran `npm run format:write` and `npm run lint` — both completed successfully.
- Typecheck: ran `npm run typecheck` — this reported unrelated existing repo type errors (known baseline issues); change did not introduce new type failures in modified areas (typecheck overall: failed due to preexisting errors).
- Unit & CI tests: ran `npm run test:ci` and focused vitest runs `npx vitest run src/scene/structures/__tests__/floorTiles.test.ts src/tests/movement/stairLayout.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts src/tests/movement/stairTransitions.test.ts` — all vitest tests passed.
- Playwright e2e: ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (installed browsers and host deps as part of the run); tests passed and validated roundtrip ascent/descent, -X egress, occupiable samples, and the over-stair blocker behavior.
- Build/docs/smoke: ran `npm run build`, `npm run docs:check` (link warnings only), and `npm run smoke` — all succeeded; a manual debug screenshot was captured with `?mode=immersive&disablePerformanceFailover=1&debugColliders=1` for visual verification (`/tmp/upper-stairwell-debug-colliders.png`).

If you want, I can split the guard/visual vs. collision changes into a follow-up PR or add a small README note showing how to enable the debug collider HUD during local preview.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2632f64234832fb268f2d33d3cfeb5)