### PR TITLE
🪜 : – Open upper stairwell egress

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import { UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
+
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 
@@ -23,6 +25,11 @@ type StairTransitionZone =
 
 type TestWorldApi = {
   movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+  canOccupyPosition(target: {
+    x: number;
+    z: number;
+    floorId?: FloorId;
+  }): boolean;
   getActiveFloor(): FloorId;
   getPlayerPosition(): { x: number; y: number; z: number };
   predictFloorAt(target: {
@@ -84,6 +91,27 @@ type PortfolioWindow = Window & {
 
 test.setTimeout(150_000);
 
+const getUpperRoom = (roomId: string) => {
+  const room = UPPER_FLOOR_PLAN.rooms.find(
+    (candidate) => candidate.id === roomId
+  );
+  if (!room) {
+    throw new Error(`Missing upper-floor room: ${roomId}`);
+  }
+  return room;
+};
+
+const getUpperLandingWestDoorCenterZ = (): number => {
+  const upperLanding = getUpperRoom('upperLanding');
+  const doorway = upperLanding.doorways?.find(
+    (candidate) => candidate.wall === 'west'
+  );
+  if (!doorway) {
+    throw new Error('Missing upper landing west doorway.');
+  }
+  return (doorway.start + doorway.end) / 2;
+};
+
 async function waitForImmersiveReady(page: Page) {
   await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
@@ -120,6 +148,19 @@ async function movePlayerTo(
     world.movePlayerTo(next);
   }, target);
   await page.waitForTimeout(150);
+}
+
+async function canOccupyPosition(
+  page: Page,
+  target: { x: number; z: number; floorId?: FloorId }
+): Promise<boolean> {
+  return page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.canOccupyPosition(next);
+  }, target);
 }
 
 async function getWorldState(page: Page) {
@@ -281,6 +322,68 @@ test('upper landing edge nudges stay upstairs until the descent corridor is ente
   // Moving back to the center of the stair opening remains an intentional descent.
   await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('upper landing opens west while hidden stair run stays blocked upstairs', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const {
+    stairCenterX,
+    stairTopZ,
+    stairLandingMinZ,
+    stairLandingMaxZ,
+    stairDirection,
+  } = await getStairMetrics(page);
+  const upperLanding = getUpperRoom('upperLanding');
+  const creatorsStudio = getUpperRoom('creatorsStudio');
+  const westDoorCenterZ = getUpperLandingWestDoorCenterZ();
+
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairTopZ - stairDirection * 0.1,
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const landingEgressZ = Math.max(
+    stairLandingMinZ + 0.6,
+    Math.min(westDoorCenterZ, stairLandingMaxZ - 0.35)
+  );
+  await movePlayerTo(page, {
+    x: upperLanding.bounds.minX + 1,
+    z: landingEgressZ,
+    floorId: 'upper',
+  });
+  await movePlayerTo(page, {
+    x: creatorsStudio.bounds.maxX - 2,
+    z: westDoorCenterZ,
+    floorId: 'upper',
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const upstairsRoomState = await getWorldState(page);
+  expect(upstairsRoomState.activeFloor).toBe('upper');
+  expect(upstairsRoomState.position.x).toBeLessThan(upperLanding.bounds.minX);
+
+  const normalUpperSpace = { x: 8.15, z: -11.82, floorId: 'upper' as const };
+  const nearbyPlusX = { ...normalUpperSpace, x: normalUpperSpace.x + 0.6 };
+  await expect(canOccupyPosition(page, normalUpperSpace)).resolves.toBe(true);
+  await expect(canOccupyPosition(page, nearbyPlusX)).resolves.toBe(true);
+
+  const overHiddenStairs = { x: 12.7, z: -23.72, floorId: 'upper' as const };
+  await expect(canOccupyPosition(page, overHiddenStairs)).resolves.toBe(false);
+  await expect(
+    page.evaluate((target) => {
+      const world = (window as PortfolioWindow).portfolio?.world;
+      if (!world) {
+        throw new Error('World API unavailable');
+      }
+      world.movePlayerTo(target);
+    }, overHiddenStairs)
+  ).rejects.toThrow(/Cannot occupy/);
 });
 
 test('debug coordinates and upstairs POI state stay floor-aware', async ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -607,6 +607,11 @@ declare global {
         getActiveFloor(): FloorId;
         setActiveFloor(next: FloorId): void;
         movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+        canOccupyPosition(target: {
+          x: number;
+          z: number;
+          floorId?: FloorId;
+        }): boolean;
         getPlayerPosition(): { x: number; y: number; z: number };
         predictFloorAt(target: {
           x: number;
@@ -1817,25 +1822,6 @@ function initializeImmersiveScene(
     stairNavigationZones.stairRampBody,
   ];
   const upperStairNavZones = [stairNavigationZones.upperLanding];
-  const upperStairDescentGuardMinZ = Math.min(stairTopZ, stairBottomZ);
-  const upperStairDescentGuardMaxZ = Math.max(stairTopZ, stairBottomZ);
-  // Invisible upper-floor guard rails flank the intentional descent corridor.
-  // They keep normal landing/room movement from drifting into the stairwell
-  // void while leaving the middle corridor open for deliberate stair descent.
-  upperFloorColliders.push(
-    {
-      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-      maxX: stairNavigationZones.explicitDescentCorridor.minX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    },
-    {
-      minX: stairNavigationZones.explicitDescentCorridor.maxX,
-      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    }
-  );
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -1878,14 +1864,36 @@ function initializeImmersiveScene(
       })
     : undefined;
   // The upper-floor stairwell cutout intentionally comes from the same
-  // computeStairLayout result used by movement. It removes the stair landing
-  // void while preserving the normal doorway bridge beyond the stair top.
+  // computeStairLayout result used by movement. It removes both the landing
+  // lip and the ramp/run void so opaque room tiles never cover the stairs.
   const upperLandingCutouts =
     upperLandingRoom && upperStairwellOpening
       ? {
           upperLanding: [upperStairwellOpening],
         }
       : undefined;
+  if (upperLandingRoom) {
+    const rampRoomEdgeZ =
+      stairLayout.directionMultiplier === -1
+        ? upperLandingRoom.bounds.maxZ
+        : upperLandingRoom.bounds.minZ;
+
+    // The player may enter the descent corridor as ground-floor stair
+    // movement, but the upper floor itself must not be occupiable over the
+    // hidden ramp run. Scope this invisible blocker to the landing room so
+    // normal upstairs space north of the stairwell stays walkable.
+    const overStairRunBlockerStartZ =
+      stairTopZ -
+      stairLayout.directionMultiplier *
+        (stairTransitionMargin + stairLandingTriggerMargin);
+    upperFloorColliders.push({
+      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+      minZ: Math.min(overStairRunBlockerStartZ, rampRoomEdgeZ),
+      maxZ: Math.max(overStairRunBlockerStartZ, rampRoomEdgeZ),
+    });
+  }
+
   const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
     material: upperFloorMaterial,
     elevation: upperFloorElevation,
@@ -1904,6 +1912,14 @@ function initializeImmersiveScene(
       guard: {
         height: 0.56,
         thickness: toWorldUnits(0.12),
+        gaps: {
+          west: [
+            {
+              minZ: stairLandingMinZ + toWorldUnits(0.3),
+              maxZ: stairLandingMaxZ - toWorldUnits(0.15),
+            },
+          ],
+        },
         material: {
           color: 0x2a3241,
           roughness: 0.72,
@@ -3020,6 +3036,11 @@ function initializeImmersiveScene(
         player.position.z = z;
         setActiveFloorId(predictedFloor);
         updatePlayerVerticalPosition();
+      },
+      canOccupyPosition(target: { x: number; z: number; floorId?: FloorId }) {
+        const { x, z, floorId } = target;
+        const predictedFloor = floorId ?? predictFloorId(x, z, activeFloorId);
+        return canOccupyPosition(x, z, predictedFloor);
       },
       // Test helpers – intentionally minimal and read-only in production.
       getPlayerPosition() {

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -112,25 +112,13 @@ describe('createRoomFloorTiles', () => {
       minX: stairwellOpening.minX,
       maxX: stairwellOpening.maxX,
       minZ: stairwellOpening.minZ,
-      maxZ: stairLayout.landingMaxZ,
+      maxZ: upperLandingRoom!.bounds.maxZ,
     };
     expect(
       upperLandingTiles.some((tile) =>
         overlaps(tile.bounds, visibleStairwellVoid)
       )
     ).toBe(false);
-
-    const doorwayBridgePastStairTop = {
-      minX: stairwellOpening.minX,
-      maxX: stairwellOpening.maxX,
-      minZ: stairLayout.landingMaxZ,
-      maxZ: upperLandingRoom!.bounds.maxZ,
-    };
-    expect(
-      upperLandingTiles.some((tile) =>
-        boundsAreClose(tile.bounds, doorwayBridgePastStairTop)
-      )
-    ).toBe(true);
 
     for (const tile of build.tiles) {
       const geometry = tile.mesh.geometry as BoxGeometry;

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -120,6 +120,32 @@ describe('createUpperStairwellLanding', () => {
     }
   });
 
+  it('cuts west guard gaps for landing egress while preserving ramp-side shoulders', () => {
+    const result = createUpperStairwellLanding({
+      roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
+      openingBounds: { minX: -2, maxX: 2, minZ: -8, maxZ: 6 },
+      descentCorridorBounds: { minX: -1, maxX: 1, minZ: -8, maxZ: 6 },
+      elevation: 4,
+      guard: {
+        height: 0.56,
+        thickness: 0.2,
+        gaps: { west: [{ minZ: -5, maxZ: -1 }] },
+        material: { color: 0xff0000 },
+      },
+    });
+
+    const egressGap = { minX: -2.2, maxX: -1, minZ: -5, maxZ: -1 };
+    expect(
+      result.colliders.some((collider) => overlaps(collider, egressGap))
+    ).toBe(false);
+    expect(result.colliders).toContainEqual({
+      minX: -2,
+      maxX: -1,
+      minZ: -1,
+      maxZ: 6,
+    });
+  });
+
   it('does not create a landing slab that covers the descent opening', () => {
     const openingBounds = { minX: -2, maxX: 2, minZ: -8, maxZ: 6 };
     const result = createUpperStairwellLanding({

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -4,6 +4,13 @@ import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../../systems/collision';
 
+export interface UpperStairwellGuardGap {
+  /** Lowest Z coordinate left open through a guard. */
+  minZ: number;
+  /** Highest Z coordinate left open through a guard. */
+  maxZ: number;
+}
+
 export interface UpperStairwellGuardConfig {
   /** Height of the guard rail measured from the upper-floor surface. */
   height: number;
@@ -11,6 +18,11 @@ export interface UpperStairwellGuardConfig {
   thickness: number;
   /** Optional material overrides for the guard rails. */
   material?: MeshStandardMaterialParameters;
+  /** Optional openings through guard runs, keyed by camera-relative side. */
+  gaps?: {
+    west?: readonly UpperStairwellGuardGap[];
+    east?: readonly UpperStairwellGuardGap[];
+  };
 }
 
 export interface UpperStairwellLandingConfig {
@@ -49,6 +61,31 @@ const clampBoundsToRoom = (
   maxZ: Math.min(bounds.maxZ, roomBounds.maxZ),
 });
 
+const subtractZGap = (
+  bounds: Bounds2D,
+  gap: UpperStairwellGuardGap
+): Bounds2D[] => {
+  const overlapMinZ = Math.max(bounds.minZ, gap.minZ);
+  const overlapMaxZ = Math.min(bounds.maxZ, gap.maxZ);
+  if (overlapMaxZ <= overlapMinZ) {
+    return [bounds];
+  }
+
+  return [
+    { ...bounds, maxZ: overlapMinZ },
+    { ...bounds, minZ: overlapMaxZ },
+  ].filter(hasPositiveArea);
+};
+
+const applyZGap = (
+  bounds: Bounds2D,
+  gaps: readonly UpperStairwellGuardGap[] = []
+): Bounds2D[] =>
+  gaps.reduce<Bounds2D[]>(
+    (pieces, gap) => pieces.flatMap((piece) => subtractZGap(piece, gap)),
+    [bounds]
+  );
+
 const addGuard = (params: {
   group: Group;
   colliders: RectCollider[];
@@ -58,26 +95,29 @@ const addGuard = (params: {
   roomBounds: Bounds2D;
   elevation: number;
   height: number;
+  gaps?: readonly UpperStairwellGuardGap[];
 }) => {
   const guardBounds = clampBoundsToRoom(params.bounds, params.roomBounds);
-  const width = guardBounds.maxX - guardBounds.minX;
-  const depth = guardBounds.maxZ - guardBounds.minZ;
-  if (width <= 0 || depth <= 0 || params.height <= 0) {
-    return;
-  }
+  applyZGap(guardBounds, params.gaps).forEach((piece, index) => {
+    const width = piece.maxX - piece.minX;
+    const depth = piece.maxZ - piece.minZ;
+    if (width <= 0 || depth <= 0 || params.height <= 0) {
+      return;
+    }
 
-  const guard = new Mesh(
-    new BoxGeometry(width, params.height, depth),
-    params.material
-  );
-  guard.name = params.name;
-  guard.position.set(
-    guardBounds.minX + width / 2,
-    params.elevation + params.height / 2,
-    guardBounds.minZ + depth / 2
-  );
-  params.group.add(guard);
-  params.colliders.push(guardBounds);
+    const guard = new Mesh(
+      new BoxGeometry(width, params.height, depth),
+      params.material
+    );
+    guard.name = index === 0 ? params.name : `${params.name}-${index + 1}`;
+    guard.position.set(
+      piece.minX + width / 2,
+      params.elevation + params.height / 2,
+      piece.minZ + depth / 2
+    );
+    params.group.add(guard);
+    params.colliders.push(piece);
+  });
 };
 
 /**
@@ -121,6 +161,7 @@ export function createUpperStairwellLanding(
     roomBounds: config.roomBounds,
     elevation: config.elevation,
     height: config.guard.height,
+    gaps: config.guard.gaps?.west,
   });
   addGuard({
     group,
@@ -136,6 +177,7 @@ export function createUpperStairwellLanding(
     roomBounds: config.roomBounds,
     elevation: config.elevation,
     height: config.guard.height,
+    gaps: config.guard.gaps?.east,
   });
   addGuard({
     group,
@@ -173,6 +215,7 @@ export function createUpperStairwellLanding(
       roomBounds: config.roomBounds,
       elevation: config.elevation,
       height: config.guard.height,
+      gaps: config.guard.gaps?.west,
     });
     addGuard({
       group,
@@ -188,6 +231,7 @@ export function createUpperStairwellLanding(
       roomBounds: config.roomBounds,
       elevation: config.elevation,
       height: config.guard.height,
+      gaps: config.guard.gaps?.east,
     });
   }
 

--- a/src/systems/movement/stairLayout.ts
+++ b/src/systems/movement/stairLayout.ts
@@ -89,21 +89,15 @@ export const computeStairLayout = (
 
 /**
  * Clips the visible upstairs stairwell hole to the landing room while deriving
- * the stair landing void from `computeStairLayout`. Movement and visuals
- * therefore use the same threshold metrics without cutting away the normal
- * upper-floor doorway bridge beyond the stair top.
+ * the full stair run void from `computeStairLayout`. Movement, visuals, and
+ * collision therefore use the same threshold metrics for the landing lip and
+ * the ramp/run portion hidden below the upper floor.
  */
 export const computeStairwellOpeningBounds = (
   config: StairwellOpeningConfig
 ): StairwellBounds => {
-  const openingMinZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.stairHoleRange.minZ
-      : config.layout.landingMinZ;
-  const openingMaxZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.landingMaxZ
-      : config.layout.stairHoleRange.maxZ;
+  const openingMinZ = config.layout.stairHoleRange.minZ;
+  const openingMaxZ = config.layout.stairHoleRange.maxZ;
 
   return {
     minX: Math.max(

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -48,7 +48,7 @@ describe('computeStairLayout', () => {
     });
   });
 
-  it('clips upstairs stairwell hole bounds from the shared stair layout plus margin', () => {
+  it('clips the negative-Z upstairs stairwell opening across the hidden stair run', () => {
     const layout = computeStairLayout({
       baseZ: -10.6,
       stepRun: 1.7,
@@ -70,6 +70,31 @@ describe('computeStairLayout', () => {
     expect(opening.minX).toBeCloseTo(7.04);
     expect(opening.maxX).toBeCloseTo(12.8);
     expect(opening.minZ).toBeCloseTo(-31.9);
-    expect(opening.maxZ).toBeCloseTo(-25.9);
+    expect(opening.maxZ).toBeCloseTo(-16);
+  });
+
+  it('clips the positive-Z upstairs stairwell opening across the hidden stair run', () => {
+    const layout = computeStairLayout({
+      baseZ: 10,
+      stepRun: 1,
+      stepCount: 4,
+      landingDepth: 3,
+      direction: 'positiveZ',
+      guardMargin: 0.5,
+      stairwellMargin: 0.25,
+    });
+
+    const opening = computeStairwellOpeningBounds({
+      centerX: 5,
+      halfWidth: 1.5,
+      marginX: 0.25,
+      roomBounds: { minX: 0, maxX: 10, minZ: 8, maxZ: 20 },
+      layout,
+    });
+
+    expect(opening.minX).toBeCloseTo(3.25);
+    expect(opening.maxX).toBeCloseTo(6.75);
+    expect(opening.minZ).toBeCloseTo(9.75);
+    expect(opening.maxZ).toBeCloseTo(17.25);
   });
 });


### PR DESCRIPTION
### Motivation
- Fix upper-landing navigation so players can legitimately walk off the landing toward the upstairs rooms while still preventing walking over the hidden stair run.  
- Ensure the opaque upper-floor slab no longer visually covers the stair run and that movement/collision use the same stair-run metrics.  
- Keep the descent corridor safety intact but remove overextended invisible blockers that blocked normal upstairs space.

### Description
- Extend `computeStairwellOpeningBounds` to use the full stair-run hole (`stairHoleRange`) so the upper-floor cutout covers the hidden ramp/run as well as the landing lip.  
- Add a scoped, upper-floor invisible blocker limited to the landing room that prevents occupying the over-stair void while leaving normal upstairs space north of the landing occupiable.  
- Make upper landing guards configurable with optional camera-relative gaps and apply a west-side gap so players can egress from the landing into upstairs rooms; guards now produce colliders for the debug visualizer.  
- Expose a minimal `canOccupyPosition` test helper on the in-page `world` API and add/adjust unit and Playwright tests to verify the egress, normal upstairs occupancy near `x=8.15,z=-11.82`, and blocking of the hidden stair run at `x=12.7,z=-23.72`.

### Testing
- `npm run format:write` — passed.  
- `npm run lint` — passed.  
- `npm run test:ci` — passed (Vitest run; repo-wide suite succeeded: 142 files, 1066 tests passed).  
- `npx playwright install chromium` and `npx playwright install-deps chromium` — both completed successfully in the run environment.  
- `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — passed (the updated stairs roundtrip spec including the new egress/occupancy assertions passed).  
- `npm run build` — passed.  
- `npm run docs:check` and `npm run smoke` — passed (docs link checker emitted external fetch warnings but completed).  
- `npm run typecheck` — NOT OK; TypeScript typecheck failed due to existing repo-wide type issues unrelated to these changes (errors surfaced in files outside the modified scope).  

If you want I can split any remaining follow-ups (additional guard tuning, visual polish, or moving the typecheck fixes into a separate PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2632f64234832fb268f2d33d3cfeb5)