### PR TITLE
Open upper stairwell egress and seal hidden stair run

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import { UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
+
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 
@@ -22,6 +24,11 @@ type StairTransitionZone =
   | 'outsideStairs';
 
 type TestWorldApi = {
+  canOccupyPosition(target: {
+    x: number;
+    z: number;
+    floorId: FloorId;
+  }): boolean;
   movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
   getActiveFloor(): FloorId;
   getPlayerPosition(): { x: number; y: number; z: number };
@@ -135,6 +142,19 @@ async function getWorldState(page: Page) {
   });
 }
 
+async function canOccupyPosition(
+  page: Page,
+  target: { x: number; z: number; floorId: FloorId }
+) {
+  return page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.canOccupyPosition(next);
+  }, target);
+}
+
 async function getTooltipState(page: Page): Promise<TooltipState> {
   return page.evaluate(() => {
     const poi = (window as PortfolioWindow).portfolio?.poi;
@@ -225,6 +245,22 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await movePlayerTo(page, { x: stairCenterX, z: landingRoamZ });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
+  const creatorsStudio = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'creatorsStudio'
+  );
+  expect(creatorsStudio).toBeDefined();
+  if (!creatorsStudio) {
+    throw new Error('Missing creators studio room definition');
+  }
+
+  const upstairsRoomTarget = {
+    x: (creatorsStudio.bounds.minX + creatorsStudio.bounds.maxX) / 2,
+    z: (creatorsStudio.bounds.minZ + creatorsStudio.bounds.maxZ) / 2,
+    floorId: 'upper' as const,
+  };
+  await movePlayerTo(page, upstairsRoomTarget);
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
   // Return toward the stairs, enter the explicit descent handoff, then continue down the ramp.
   // The helper teleports between sampled positions, so include the narrow handoff band that real
   // movement crosses frame by frame.
@@ -281,6 +317,40 @@ test('upper landing edge nudges stay upstairs until the descent corridor is ente
   // Moving back to the center of the stair opening remains an intentional descent.
   await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('upper stairwell blockers preserve upstairs rooms while sealing hidden stairs', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const normalUpstairsTarget = {
+    x: 8.15,
+    z: -11.82,
+    floorId: 'upper' as const,
+  };
+  await expect(canOccupyPosition(page, normalUpstairsTarget)).resolves.toBe(
+    true
+  );
+  await expect(
+    canOccupyPosition(page, {
+      ...normalUpstairsTarget,
+      x: normalUpstairsTarget.x + 0.35,
+    })
+  ).resolves.toBe(true);
+
+  const hiddenStairRunTarget = {
+    x: 12.7,
+    z: -23.72,
+    floorId: 'upper' as const,
+  };
+  await expect(canOccupyPosition(page, hiddenStairRunTarget)).resolves.toBe(
+    false
+  );
+  await expect(movePlayerTo(page, hiddenStairRunTarget)).rejects.toThrow(
+    /Cannot occupy/
+  );
 });
 
 test('debug coordinates and upstairs POI state stay floor-aware', async ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -606,6 +606,11 @@ declare global {
       world?: {
         getActiveFloor(): FloorId;
         setActiveFloor(next: FloorId): void;
+        canOccupyPosition(target: {
+          x: number;
+          z: number;
+          floorId: FloorId;
+        }): boolean;
         movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
         getPlayerPosition(): { x: number; y: number; z: number };
         predictFloorAt(target: {
@@ -1817,25 +1822,6 @@ function initializeImmersiveScene(
     stairNavigationZones.stairRampBody,
   ];
   const upperStairNavZones = [stairNavigationZones.upperLanding];
-  const upperStairDescentGuardMinZ = Math.min(stairTopZ, stairBottomZ);
-  const upperStairDescentGuardMaxZ = Math.max(stairTopZ, stairBottomZ);
-  // Invisible upper-floor guard rails flank the intentional descent corridor.
-  // They keep normal landing/room movement from drifting into the stairwell
-  // void while leaving the middle corridor open for deliberate stair descent.
-  upperFloorColliders.push(
-    {
-      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-      maxX: stairNavigationZones.explicitDescentCorridor.minX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    },
-    {
-      minX: stairNavigationZones.explicitDescentCorridor.maxX,
-      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    }
-  );
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -1895,11 +1881,37 @@ function initializeImmersiveScene(
   });
   upperFloorGroup.add(upperFloorTiles.group);
 
+  if (upperLandingRoom) {
+    const upperStairRunBlockerInset = stairLandingTriggerMargin + PLAYER_RADIUS;
+    const upperStairRunBlockerStartZ =
+      stairLayout.directionMultiplier === -1
+        ? stairTopZ + upperStairRunBlockerInset
+        : stairTopZ - upperStairRunBlockerInset;
+    const upperStairRunBlockerMinZ = Math.max(
+      upperLandingRoom.bounds.minZ,
+      Math.min(stairBottomZ, upperStairRunBlockerStartZ)
+    );
+    const upperStairRunBlockerMaxZ = Math.min(
+      upperLandingRoom.bounds.maxZ,
+      Math.max(stairBottomZ, upperStairRunBlockerStartZ)
+    );
+
+    if (upperStairRunBlockerMaxZ > upperStairRunBlockerMinZ) {
+      upperFloorColliders.push({
+        minX: stairCenterX - stairHalfWidth,
+        maxX: stairCenterX + stairHalfWidth,
+        minZ: upperStairRunBlockerMinZ,
+        maxZ: upperStairRunBlockerMaxZ,
+      });
+    }
+  }
+
   if (upperLandingRoom && upperStairwellOpening) {
     const upperStairwellLanding = createUpperStairwellLanding({
       roomBounds: upperLandingRoom.bounds,
       openingBounds: upperStairwellOpening,
       descentCorridorBounds: stairNavigationZones.explicitDescentCorridor,
+      shoulderGuards: { west: false, east: true },
       elevation: upperFloorElevation,
       guard: {
         height: 0.56,
@@ -3007,6 +3019,9 @@ function initializeImmersiveScene(
       setActiveFloor(next: FloorId) {
         setActiveFloorId(next);
         updatePlayerVerticalPosition();
+      },
+      canOccupyPosition(target: { x: number; z: number; floorId: FloorId }) {
+        return canOccupyPosition(target.x, target.z, target.floorId);
       },
       movePlayerTo(target: { x: number; z: number; floorId?: FloorId }) {
         const { x, z, floorId } = target;

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -108,29 +108,12 @@ describe('createRoomFloorTiles', () => {
     expect(fillsLeftLandingShoulder).toBe(true);
     expect(fillsRightLandingShoulder).toBe(true);
 
-    const visibleStairwellVoid = {
-      minX: stairwellOpening.minX,
-      maxX: stairwellOpening.maxX,
-      minZ: stairwellOpening.minZ,
-      maxZ: stairLayout.landingMaxZ,
-    };
+    const visibleStairwellVoid = stairwellOpening;
     expect(
       upperLandingTiles.some((tile) =>
         overlaps(tile.bounds, visibleStairwellVoid)
       )
     ).toBe(false);
-
-    const doorwayBridgePastStairTop = {
-      minX: stairwellOpening.minX,
-      maxX: stairwellOpening.maxX,
-      minZ: stairLayout.landingMaxZ,
-      maxZ: upperLandingRoom!.bounds.maxZ,
-    };
-    expect(
-      upperLandingTiles.some((tile) =>
-        boundsAreClose(tile.bounds, doorwayBridgePastStairTop)
-      )
-    ).toBe(true);
 
     for (const tile of build.tiles) {
       const geometry = tile.mesh.geometry as BoxGeometry;

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -93,6 +93,36 @@ describe('createUpperStairwellLanding', () => {
     ).toBe(false);
   });
 
+  it('can open the west shoulder as a deliberate upper landing egress', () => {
+    const openingBounds = { minX: -2, maxX: 2, minZ: -8, maxZ: 6 };
+    const result = createUpperStairwellLanding({
+      roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
+      openingBounds,
+      descentCorridorBounds: { minX: -1.2, maxX: 1.1, minZ: -7.6, maxZ: 6 },
+      shoulderGuards: { west: false, east: true },
+      elevation: 4,
+      guard: {
+        height: 0.56,
+        thickness: 0.2,
+        material: { color: 0xff0000 },
+      },
+    });
+
+    expect(result.colliders).toHaveLength(4);
+    expect(result.colliders).not.toContainEqual({
+      minX: -2,
+      maxX: -1.2,
+      minZ: -8,
+      maxZ: 6,
+    });
+    expect(result.colliders).toContainEqual({
+      minX: 1.1,
+      maxX: 2,
+      minZ: -8,
+      maxZ: 6,
+    });
+  });
+
   it('clamps guard colliders to the landing room when the opening touches an edge', () => {
     const result = createUpperStairwellLanding({
       roomBounds: { minX: -2, maxX: 4, minZ: -6, maxZ: 6 },

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -20,6 +20,14 @@ export interface UpperStairwellLandingConfig {
   openingBounds: Bounds2D;
   /** Optional deliberate descent corridor that remains open through the cutout. */
   descentCorridorBounds?: Bounds2D;
+  /**
+   * Shoulder rails can be disabled independently when a side of the landing
+   * is a deliberate egress route rather than a stair-void edge.
+   */
+  shoulderGuards?: {
+    west?: boolean;
+    east?: boolean;
+  };
   /** Height of the upper-floor surface measured from world origin. */
   elevation: number;
   /** Guard rail configuration. */
@@ -158,37 +166,46 @@ export function createUpperStairwellLanding(
       config.descentCorridorBounds,
       openingBounds
     );
+    const shoulderGuards = {
+      west: config.shoulderGuards?.west ?? true,
+      east: config.shoulderGuards?.east ?? true,
+    };
 
-    addGuard({
-      group,
-      colliders,
-      material: guardMaterial,
-      name: `${SHOULDER_GUARD_NAME}-West`,
-      bounds: {
-        minX: openingBounds.minX,
-        maxX: descentCorridorBounds.minX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-    addGuard({
-      group,
-      colliders,
-      material: guardMaterial,
-      name: `${SHOULDER_GUARD_NAME}-East`,
-      bounds: {
-        minX: descentCorridorBounds.maxX,
-        maxX: openingBounds.maxX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
+    if (shoulderGuards.west) {
+      addGuard({
+        group,
+        colliders,
+        material: guardMaterial,
+        name: `${SHOULDER_GUARD_NAME}-West`,
+        bounds: {
+          minX: openingBounds.minX,
+          maxX: descentCorridorBounds.minX,
+          minZ: openingBounds.minZ,
+          maxZ: openingBounds.maxZ,
+        },
+        roomBounds: config.roomBounds,
+        elevation: config.elevation,
+        height: config.guard.height,
+      });
+    }
+
+    if (shoulderGuards.east) {
+      addGuard({
+        group,
+        colliders,
+        material: guardMaterial,
+        name: `${SHOULDER_GUARD_NAME}-East`,
+        bounds: {
+          minX: descentCorridorBounds.maxX,
+          maxX: openingBounds.maxX,
+          minZ: openingBounds.minZ,
+          maxZ: openingBounds.maxZ,
+        },
+        roomBounds: config.roomBounds,
+        elevation: config.elevation,
+        height: config.guard.height,
+      });
+    }
   }
 
   return { group, colliders };

--- a/src/systems/movement/stairLayout.ts
+++ b/src/systems/movement/stairLayout.ts
@@ -90,20 +90,14 @@ export const computeStairLayout = (
 /**
  * Clips the visible upstairs stairwell hole to the landing room while deriving
  * the stair landing void from `computeStairLayout`. Movement and visuals
- * therefore use the same threshold metrics without cutting away the normal
- * upper-floor doorway bridge beyond the stair top.
+ * therefore use the same threshold metrics and include the ramp/run portion
+ * beneath the upper floor instead of cutting only the landing lip.
  */
 export const computeStairwellOpeningBounds = (
   config: StairwellOpeningConfig
 ): StairwellBounds => {
-  const openingMinZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.stairHoleRange.minZ
-      : config.layout.landingMinZ;
-  const openingMaxZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.landingMaxZ
-      : config.layout.stairHoleRange.maxZ;
+  const openingMinZ = config.layout.stairHoleRange.minZ;
+  const openingMaxZ = config.layout.stairHoleRange.maxZ;
 
   return {
     minX: Math.max(

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -70,6 +70,30 @@ describe('computeStairLayout', () => {
     expect(opening.minX).toBeCloseTo(7.04);
     expect(opening.maxX).toBeCloseTo(12.8);
     expect(opening.minZ).toBeCloseTo(-31.9);
-    expect(opening.maxZ).toBeCloseTo(-25.9);
+    expect(opening.maxZ).toBeCloseTo(-16);
+  });
+
+  it('includes the ramp run inside the upper room for negative Z stair cutouts', () => {
+    const layout = computeStairLayout({
+      baseZ: -10.6,
+      stepRun: 1.7,
+      stepCount: 9,
+      landingDepth: 5.2,
+      direction: 'negativeZ',
+      guardMargin: 1.2,
+      stairwellMargin: 0.8,
+    });
+
+    const opening = computeStairwellOpeningBounds({
+      centerX: 12.4,
+      halfWidth: 3.1,
+      marginX: 0.4,
+      roomBounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+      layout,
+    });
+
+    expect(opening.minZ).toBeLessThan(layout.topZ);
+    expect(opening.maxZ).toBeGreaterThan(layout.topZ);
+    expect(opening.maxZ).toBeCloseTo(-16);
   });
 });


### PR DESCRIPTION
### Motivation
- Fix upper-landing navigation so players can legitimately exit the landing toward -X into upstairs rooms while still preventing walking above the hidden stair run. 
- Prevent the opaque upper-floor plane and invisible blockers from letting players stand in the over-stair void or blocking normal upstairs space (notably around `8.15, 4.91, -11.82`).
- Keep visuals, physical guard rails, and invisible navigation blockers conceptually separated so the cutout, railings, and collision each match intent.

### Description
- Expand `computeStairwellOpeningBounds` to use the stair hole range so the upper-floor cutout includes the ramp/run beneath the upper floor for negative-Z stairs.
- Add a precise upper-floor blocker (pushed into `upperFloorColliders`) scoped to the stair run inside the landing room so the hidden over-stair area is not occupiable while preserving the deliberate descent corridor.
- Make shoulder guards configurable in `UpperStairwellLandingConfig` (`shoulderGuards`) and open the west shoulder (`shoulderGuards: { west: false, east: true }`) when building the landing so -X egress is allowed while east-side safety remains.
- Expose a test-only API `canOccupyPosition` on the in-page `world` handle so Playwright asserts occupiability without mutating production logic, and register the new/changed upper-floor colliders with the existing collider visualizer.
- Tests and fixtures: updated unit tests for `computeStairwellOpeningBounds` and `createRoomFloorTiles` behavior, made `upperStairwellLanding` unit tests for shoulder-guard toggling, and extended `playwright/immersive-stairs-roundtrip.spec.ts` with a focused scenario that walks from the landing to an upstairs room and asserts occupied/unoccupiable targets.

### Testing
- Ran formatting and lint: `npm run format:write` (passed), `npm run lint` (passed).
- Unit suites: `npm run test:ci` / `npx vitest run` ran the full Vitest suite and the focused movement/structure tests; all tests (including new/modified unit tests) passed in CI output (1066/1066 tests passed after changes).
- Playwright: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` executed the updated end-to-end spec and passed (5/5 tests) after the environment browser install step; the script was exercised during the rollout and assertions for occupancy and blocked over-stair targets passed.
- Build & smoke: `npm run docs:check` (passed with existing external-link warnings), `npm run build` (passed), `npm run smoke` (passed).
- Typecheck: `npm run typecheck` failed, but failures are pre-existing, repo-wide TypeScript issues unrelated to this change (reported errors in unrelated test/type harness files); these are recorded and not introduced by this PR.

Notes: new behavior is registered with the debug collider visualizer and can be inspected with `?mode=immersive&disablePerformanceFailover=1&debugColliders=1` during manual QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2632f64234832fb268f2d33d3cfeb5)