### PR TITLE
Fix upper stairwell egress and hidden-stair blockers

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -324,6 +324,11 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 2,
     floorId: 'upper' as const,
   };
+  const westHiddenStairVoidSliver = {
+    x: stairCenterX - 1.55,
+    z: stairTopZ + stairDirection * 2.1,
+    floorId: 'upper' as const,
+  };
   const westVoidBypass = {
     x: stairCenterX - 4.4,
     z: stairTopZ + stairDirection * 0.95,
@@ -366,6 +371,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
     false
   );
+  expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
   for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
     expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -329,7 +329,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 2.1,
     floorId: 'upper' as const,
   };
-  const westHiddenStairVoidEdge = {
+  const westEdgeFloorClearance = {
     x: 7.5,
     z: -23,
     floorId: 'upper' as const,
@@ -377,7 +377,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     false
   );
   expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
-  expect(await canOccupyPosition(page, westHiddenStairVoidEdge)).toBe(false);
+  expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
   for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
     expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -294,7 +294,23 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     ...normalLoftSpace,
     x: normalLoftSpace.x + 0.45,
   };
+  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'upperLanding'
+  );
+  if (!upperLandingRoom) {
+    throw new Error('Missing upper landing room');
+  }
+  const loftDoorway = {
+    x: stairCenterX,
+    z: upperLandingRoom.bounds.maxZ,
+    floorId: 'upper' as const,
+  };
   const hiddenStairRun = { x: 12.7, z: -23.72, floorId: 'upper' as const };
+  const hiddenStairTopRun = {
+    x: stairCenterX,
+    z: stairTopZ - stairDirection * 0.4,
+    floorId: 'upper' as const,
+  };
 
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await movePlayerTo(page, {
@@ -314,6 +330,8 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
 
   expect(await canOccupyPosition(page, normalLoftSpace)).toBe(true);
   expect(await canOccupyPosition(page, normalLoftEastNudge)).toBe(true);
+  expect(await canOccupyPosition(page, loftDoorway)).toBe(true);
+  expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
   await expect(async () => movePlayerTo(page, hiddenStairRun)).rejects.toThrow(
     /Cannot occupy/

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -314,6 +314,16 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ - stairDirection * 0.4,
     floorId: 'upper' as const,
   };
+  const westHiddenStairVoidGap = {
+    x: stairCenterX - 1.9,
+    z: stairTopZ + stairDirection * 0.95,
+    floorId: 'upper' as const,
+  };
+  const westVoidBypass = {
+    x: stairCenterX - 4.4,
+    z: stairTopZ + stairDirection * 0.95,
+    floorId: 'upper' as const,
+  };
   const hiddenStairVoidGap = [
     {
       x: stairCenterX,
@@ -346,6 +356,8 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, normalLoftSpace)).toBe(true);
   expect(await canOccupyPosition(page, normalLoftEastNudge)).toBe(true);
   expect(await canOccupyPosition(page, loftDoorway)).toBe(true);
+  expect(await canOccupyPosition(page, westVoidBypass)).toBe(true);
+  expect(await canOccupyPosition(page, westHiddenStairVoidGap)).toBe(false);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
   for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
     expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import { UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
+
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 
@@ -24,6 +26,11 @@ type StairTransitionZone =
 type TestWorldApi = {
   movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
   getActiveFloor(): FloorId;
+  canOccupyPosition(target: {
+    x: number;
+    z: number;
+    floorId?: FloorId;
+  }): boolean;
   getPlayerPosition(): { x: number; y: number; z: number };
   predictFloorAt(target: {
     x: number;
@@ -120,6 +127,34 @@ async function movePlayerTo(
     world.movePlayerTo(next);
   }, target);
   await page.waitForTimeout(150);
+}
+
+function getUpperRoomCenter(roomId: string) {
+  const room = UPPER_FLOOR_PLAN.rooms.find(
+    (candidate) => candidate.id === roomId
+  );
+  if (!room) {
+    throw new Error(`Missing upper-floor room: ${roomId}`);
+  }
+
+  return {
+    x: (room.bounds.minX + room.bounds.maxX) / 2,
+    z: (room.bounds.minZ + room.bounds.maxZ) / 2,
+    floorId: 'upper' as const,
+  };
+}
+
+async function canOccupyPosition(
+  page: Page,
+  target: { x: number; z: number; floorId?: FloorId }
+) {
+  return page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.canOccupyPosition(next);
+  }, target);
 }
 
 async function getWorldState(page: Page) {
@@ -237,6 +272,52 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   });
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.35 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
+});
+
+test('upper landing opens west into upstairs rooms and blocks the hidden stair run', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const { stairCenterX, stairBottomZ, stairTopZ, stairDirection } =
+    await getStairMetrics(page);
+  const creatorsStudioCenter = getUpperRoomCenter('creatorsStudio');
+  const westLandingEgress = {
+    x: stairCenterX - 1.6,
+    z: stairTopZ + stairDirection * 1.8,
+    floorId: 'upper' as const,
+  };
+  const normalLoftSpace = { x: 8.15, z: -11.82, floorId: 'upper' as const };
+  const normalLoftEastNudge = {
+    ...normalLoftSpace,
+    x: normalLoftSpace.x + 0.45,
+  };
+  const hiddenStairRun = { x: 12.7, z: -23.72, floorId: 'upper' as const };
+
+  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairTopZ - stairDirection * 0.1,
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  expect(await canOccupyPosition(page, westLandingEgress)).toBe(true);
+  await movePlayerTo(page, westLandingEgress);
+  await movePlayerTo(page, creatorsStudioCenter);
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  expect(await canOccupyPosition(page, normalLoftSpace)).toBe(true);
+  expect(await canOccupyPosition(page, normalLoftEastNudge)).toBe(true);
+  expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
+  await expect(async () => movePlayerTo(page, hiddenStairRun)).rejects.toThrow(
+    /Cannot occupy/
+  );
 });
 
 test('upper landing edge nudges stay upstairs until the descent corridor is entered', async ({

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -329,6 +329,11 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 2.1,
     floorId: 'upper' as const,
   };
+  const westHiddenStairVoidEdge = {
+    x: 7.5,
+    z: -23,
+    floorId: 'upper' as const,
+  };
   const westVoidBypass = {
     x: stairCenterX - 4.4,
     z: stairTopZ + stairDirection * 0.95,
@@ -372,6 +377,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     false
   );
   expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
+  expect(await canOccupyPosition(page, westHiddenStairVoidEdge)).toBe(false);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
   for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
     expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -263,7 +263,10 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   // Return toward the stairs, enter the explicit descent handoff, then continue down the ramp.
   // The helper teleports between sampled positions, so include the narrow handoff band that real
   // movement crosses frame by frame.
-  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ - 0.15 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairTopZ - stairDirection * 0.1,
+  });
   await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
   await movePlayerTo(page, {
@@ -311,6 +314,18 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ - stairDirection * 0.4,
     floorId: 'upper' as const,
   };
+  const hiddenStairVoidGap = [
+    {
+      x: stairCenterX,
+      z: stairTopZ + stairDirection * 0.1,
+      floorId: 'upper' as const,
+    },
+    {
+      x: stairCenterX,
+      z: stairTopZ + stairDirection * 0.6,
+      floorId: 'upper' as const,
+    },
+  ];
 
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await movePlayerTo(page, {
@@ -332,6 +347,9 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, normalLoftEastNudge)).toBe(true);
   expect(await canOccupyPosition(page, loftDoorway)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
+  for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
+    expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);
+  }
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
   await expect(async () => movePlayerTo(page, hiddenStairRun)).rejects.toThrow(
     /Cannot occupy/

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -319,6 +319,11 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
+  const deeperWestHiddenStairVoidGap = {
+    x: stairCenterX - 1.9,
+    z: stairTopZ + stairDirection * 2,
+    floorId: 'upper' as const,
+  };
   const westVoidBypass = {
     x: stairCenterX - 4.4,
     z: stairTopZ + stairDirection * 0.95,
@@ -358,6 +363,9 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, loftDoorway)).toBe(true);
   expect(await canOccupyPosition(page, westVoidBypass)).toBe(true);
   expect(await canOccupyPosition(page, westHiddenStairVoidGap)).toBe(false);
+  expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
+    false
+  );
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
   for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
     expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1890,6 +1890,7 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerFarZ =
       stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
+    const hiddenStairWestVoidGapBlockerZ = hiddenStairTopGapBlockerFarZ;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -1903,8 +1904,9 @@ function initializeImmersiveScene(
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable. The center
     // blockers reject forced upper-floor placement over the hidden stair-top gap
-    // and doorway-side void while preserving the narrow stair-top handoff, west
-    // egress path, and north doorway's padded passage into the loft.
+    // and doorway-side void while preserving the narrow stair-top handoff, a
+    // west-side bypass around the void, and the north doorway's padded passage
+    // into the loft.
     upperFloorColliders.push(
       {
         minX: stairCenterX - stairHalfWidth - stairwellMarginX,
@@ -1923,6 +1925,12 @@ function initializeImmersiveScene(
         maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
         minZ: upperStairVoidMinZ,
         maxZ: upperStairVoidMaxZ,
+      },
+      {
+        minX: upperStairwellOpening.minX,
+        maxX: hiddenStairTopGapBlockerMinX,
+        minZ: hiddenStairWestVoidGapBlockerZ,
+        maxZ: hiddenStairWestVoidGapBlockerZ,
       },
       {
         minX: hiddenStairTopGapBlockerMinX,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1851,6 +1851,9 @@ function initializeImmersiveScene(
     opacity: 1,
     depthWrite: true,
   });
+  const doorwayPadding = PLAYER_RADIUS * 0.6;
+  const doorwayDepth = WALL_THICKNESS + PLAYER_RADIUS * 2;
+
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
   );
@@ -1878,11 +1881,22 @@ function initializeImmersiveScene(
       stairLandingMaxZ
     );
 
+    const upperLandingDoorwayClearanceZ =
+      upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
+    const hiddenStairBlockerStartZ =
+      stairTopZ -
+      stairLayout.directionMultiplier *
+        (PLAYER_RADIUS + stairLandingTriggerMargin / 2);
+    const hiddenStairBlockerMaxZ = Math.min(
+      upperStairVoidMaxZ,
+      upperLandingDoorwayClearanceZ
+    );
+
     // Invisible upper-floor guard rails flank the intentional descent corridor.
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable. The center
-    // blocker below rejects forced upper-floor placement over the hidden stairs;
-    // live movement still hands off to the ground floor through the descent zone.
+    // blocker rejects forced upper-floor placement over the hidden stairs while
+    // stopping short of the north doorway's padded passage into the loft.
     upperFloorColliders.push(
       {
         minX: stairCenterX - stairHalfWidth - stairwellMarginX,
@@ -1905,18 +1919,8 @@ function initializeImmersiveScene(
       {
         minX: stairNavigationZones.explicitDescentCorridor.minX,
         maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-        minZ: Math.min(
-          stairTopZ -
-            stairLayout.directionMultiplier *
-              (stairLandingTriggerMargin + PLAYER_RADIUS),
-          upperStairVoidMaxZ
-        ),
-        maxZ: Math.max(
-          stairTopZ -
-            stairLayout.directionMultiplier *
-              (stairLandingTriggerMargin + PLAYER_RADIUS),
-          upperStairVoidMaxZ
-        ),
+        minZ: Math.min(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
+        maxZ: Math.max(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
       }
     );
   }
@@ -1992,9 +1996,6 @@ function initializeImmersiveScene(
     ground: groundColliders,
     upper: upperFloorColliders,
   };
-
-  const doorwayPadding = PLAYER_RADIUS * 0.6;
-  const doorwayDepth = WALL_THICKNESS + PLAYER_RADIUS * 2;
 
   const navMeshes: Record<FloorId, NavMesh> = {
     ground: createNavMesh(FLOOR_PLAN, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1883,6 +1883,13 @@ function initializeImmersiveScene(
 
     const upperLandingDoorwayClearanceZ =
       upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
+    const hiddenStairTopGapBlockerNearZ =
+      stairTopZ +
+      stairLayout.directionMultiplier *
+        (PLAYER_RADIUS + stairLandingTriggerMargin);
+    const hiddenStairTopGapBlockerFarZ =
+      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
+    const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -1895,8 +1902,9 @@ function initializeImmersiveScene(
     // Invisible upper-floor guard rails flank the intentional descent corridor.
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable. The center
-    // blocker rejects forced upper-floor placement over the hidden stairs while
-    // stopping short of the north doorway's padded passage into the loft.
+    // blockers reject forced upper-floor placement over the hidden stair-top gap
+    // and doorway-side void while preserving the narrow stair-top handoff, west
+    // egress path, and north doorway's padded passage into the loft.
     upperFloorColliders.push(
       {
         minX: stairCenterX - stairHalfWidth - stairwellMarginX,
@@ -1915,6 +1923,18 @@ function initializeImmersiveScene(
         maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
         minZ: upperStairVoidMinZ,
         maxZ: upperStairVoidMaxZ,
+      },
+      {
+        minX: hiddenStairTopGapBlockerMinX,
+        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
+        minZ: Math.min(
+          hiddenStairTopGapBlockerNearZ,
+          hiddenStairTopGapBlockerFarZ
+        ),
+        maxZ: Math.max(
+          hiddenStairTopGapBlockerNearZ,
+          hiddenStairTopGapBlockerFarZ
+        ),
       },
       {
         minX: stairNavigationZones.explicitDescentCorridor.minX,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1892,6 +1892,12 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
     const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
     const hiddenStairWestVoidGapBlockerMaxZ = upperStairWestEgressMaxZ;
+    const hiddenStairDeepVoidBlockerMinZ =
+      hiddenStairWestVoidGapBlockerMinZ -
+      stairLayout.directionMultiplier * PLAYER_RADIUS;
+    const hiddenStairDeepVoidBlockerMaxZ =
+      hiddenStairTopGapBlockerNearZ +
+      stairLayout.directionMultiplier * PLAYER_RADIUS * 2;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -1904,10 +1910,10 @@ function initializeImmersiveScene(
     // Invisible upper-floor guard rails flank the intentional descent corridor.
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable. The center
-    // blockers reject forced upper-floor placement over the hidden stair-top gap
-    // and doorway-side void while preserving the narrow stair-top handoff, a
-    // west-side bypass lane around the void, and the north doorway's padded passage
-    // into the loft.
+    // blockers reject forced upper-floor placement over the hidden stair-top gap,
+    // the deeper removed stair run, and doorway-side void while preserving the
+    // narrow stair-top handoff, a west-side bypass lane around the void, and the
+    // north doorway's padded passage into the loft.
     upperFloorColliders.push(
       {
         minX: stairCenterX - stairHalfWidth - stairwellMarginX,
@@ -1932,6 +1938,18 @@ function initializeImmersiveScene(
         maxX: stairNavigationZones.explicitDescentCorridor.minX,
         minZ: hiddenStairWestVoidGapBlockerMinZ,
         maxZ: hiddenStairWestVoidGapBlockerMaxZ,
+      },
+      {
+        minX: stairNavigationZones.explicitDescentCorridor.minX,
+        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
+        minZ: Math.min(
+          hiddenStairDeepVoidBlockerMinZ,
+          hiddenStairDeepVoidBlockerMaxZ
+        ),
+        maxZ: Math.max(
+          hiddenStairDeepVoidBlockerMinZ,
+          hiddenStairDeepVoidBlockerMaxZ
+        ),
       },
       {
         minX: hiddenStairTopGapBlockerMinX,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1890,7 +1890,8 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerFarZ =
       stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairWestVoidGapBlockerZ = hiddenStairTopGapBlockerFarZ;
+    const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
+    const hiddenStairWestVoidGapBlockerMaxZ = upperStairWestEgressMaxZ;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -1905,7 +1906,7 @@ function initializeImmersiveScene(
     // run so normal loft space beyond the landing remains occupiable. The center
     // blockers reject forced upper-floor placement over the hidden stair-top gap
     // and doorway-side void while preserving the narrow stair-top handoff, a
-    // west-side bypass around the void, and the north doorway's padded passage
+    // west-side bypass lane around the void, and the north doorway's padded passage
     // into the loft.
     upperFloorColliders.push(
       {
@@ -1928,9 +1929,9 @@ function initializeImmersiveScene(
       },
       {
         minX: upperStairwellOpening.minX,
-        maxX: hiddenStairTopGapBlockerMinX,
-        minZ: hiddenStairWestVoidGapBlockerZ,
-        maxZ: hiddenStairWestVoidGapBlockerZ,
+        maxX: stairNavigationZones.explicitDescentCorridor.minX,
+        minZ: hiddenStairWestVoidGapBlockerMinZ,
+        maxZ: hiddenStairWestVoidGapBlockerMaxZ,
       },
       {
         minX: hiddenStairTopGapBlockerMinX,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1892,8 +1892,6 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
     const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
     const hiddenStairWestVoidGapBlockerMaxZ = upperStairWestEgressMaxZ;
-    const upperStairWestEdgeSafetyMinX =
-      upperStairwellOpening.minX - PLAYER_RADIUS;
     const hiddenStairDeepVoidBlockerMinZ =
       hiddenStairWestVoidGapBlockerMinZ -
       stairLayout.directionMultiplier * PLAYER_RADIUS;
@@ -1915,9 +1913,9 @@ function initializeImmersiveScene(
     // blockers reject forced upper-floor placement over the hidden stair-top gap,
     // the deeper removed stair run, and doorway-side void while preserving the
     // narrow stair-top handoff, a west-side bypass lane around the void, and the
-    // north doorway's padded passage into the loft. The west edge safety blocker
-    // starts one player radius before the visual cutout so center-point placement
-    // cannot leave the avatar overhanging the missing upper-floor slab.
+    // north doorway's padded passage into the loft. The west-edge blocker starts
+    // at the visual cutout because collider checks already apply PLAYER_RADIUS
+    // clearance around the blocker edge.
     upperFloorColliders.push(
       {
         minX: stairCenterX - stairHalfWidth - stairwellMarginX,
@@ -1926,7 +1924,7 @@ function initializeImmersiveScene(
         maxZ: upperStairWestEgressMinZ,
       },
       {
-        minX: upperStairWestEdgeSafetyMinX,
+        minX: upperStairwellOpening.minX,
         maxX: stairNavigationZones.explicitDescentCorridor.minX,
         minZ: upperStairWestEgressMaxZ,
         maxZ: upperStairVoidMaxZ,

--- a/src/main.ts
+++ b/src/main.ts
@@ -605,6 +605,11 @@ declare global {
       };
       world?: {
         getActiveFloor(): FloorId;
+        canOccupyPosition(target: {
+          x: number;
+          z: number;
+          floorId?: FloorId;
+        }): boolean;
         setActiveFloor(next: FloorId): void;
         movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
         getPlayerPosition(): { x: number; y: number; z: number };
@@ -1817,25 +1822,6 @@ function initializeImmersiveScene(
     stairNavigationZones.stairRampBody,
   ];
   const upperStairNavZones = [stairNavigationZones.upperLanding];
-  const upperStairDescentGuardMinZ = Math.min(stairTopZ, stairBottomZ);
-  const upperStairDescentGuardMaxZ = Math.max(stairTopZ, stairBottomZ);
-  // Invisible upper-floor guard rails flank the intentional descent corridor.
-  // They keep normal landing/room movement from drifting into the stairwell
-  // void while leaving the middle corridor open for deliberate stair descent.
-  upperFloorColliders.push(
-    {
-      minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-      maxX: stairNavigationZones.explicitDescentCorridor.minX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    },
-    {
-      minX: stairNavigationZones.explicitDescentCorridor.maxX,
-      maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-      minZ: upperStairDescentGuardMinZ,
-      maxZ: upperStairDescentGuardMaxZ,
-    }
-  );
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -1878,8 +1864,63 @@ function initializeImmersiveScene(
       })
     : undefined;
   // The upper-floor stairwell cutout intentionally comes from the same
-  // computeStairLayout result used by movement. It removes the stair landing
-  // void while preserving the normal doorway bridge beyond the stair top.
+  // computeStairLayout result used by movement. It removes both the stair
+  // landing void and the hidden ramp run below the landing lip.
+  if (upperStairwellOpening) {
+    const upperStairVoidMinZ = upperStairwellOpening.minZ;
+    const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
+    const upperStairWestEgressMinZ = Math.min(
+      stairLandingMinZ + stairwellMarginZ,
+      stairLandingMaxZ
+    );
+    const upperStairWestEgressMaxZ = Math.max(
+      stairLandingMinZ + stairwellMarginZ,
+      stairLandingMaxZ
+    );
+
+    // Invisible upper-floor guard rails flank the intentional descent corridor.
+    // They are scoped to the actual upper-floor cutout instead of the full ramp
+    // run so normal loft space beyond the landing remains occupiable. The center
+    // blocker below rejects forced upper-floor placement over the hidden stairs;
+    // live movement still hands off to the ground floor through the descent zone.
+    upperFloorColliders.push(
+      {
+        minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+        maxX: stairNavigationZones.explicitDescentCorridor.minX,
+        minZ: upperStairVoidMinZ,
+        maxZ: upperStairWestEgressMinZ,
+      },
+      {
+        minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+        maxX: stairNavigationZones.explicitDescentCorridor.minX,
+        minZ: upperStairWestEgressMaxZ,
+        maxZ: upperStairVoidMaxZ,
+      },
+      {
+        minX: stairNavigationZones.explicitDescentCorridor.maxX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperStairVoidMinZ,
+        maxZ: upperStairVoidMaxZ,
+      },
+      {
+        minX: stairNavigationZones.explicitDescentCorridor.minX,
+        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
+        minZ: Math.min(
+          stairTopZ -
+            stairLayout.directionMultiplier *
+              (stairLandingTriggerMargin + PLAYER_RADIUS),
+          upperStairVoidMaxZ
+        ),
+        maxZ: Math.max(
+          stairTopZ -
+            stairLayout.directionMultiplier *
+              (stairLandingTriggerMargin + PLAYER_RADIUS),
+          upperStairVoidMaxZ
+        ),
+      }
+    );
+  }
+
   const upperLandingCutouts =
     upperLandingRoom && upperStairwellOpening
       ? {
@@ -1896,14 +1937,22 @@ function initializeImmersiveScene(
   upperFloorGroup.add(upperFloorTiles.group);
 
   if (upperLandingRoom && upperStairwellOpening) {
+    const upperStairwellGuardOpening = {
+      minX: upperStairwellOpening.minX,
+      maxX: upperStairwellOpening.maxX,
+      minZ: upperStairwellOpening.minZ,
+      maxZ: Math.min(upperLandingRoom.bounds.maxZ, stairLandingMaxZ),
+    };
     const upperStairwellLanding = createUpperStairwellLanding({
       roomBounds: upperLandingRoom.bounds,
-      openingBounds: upperStairwellOpening,
+      openingBounds: upperStairwellGuardOpening,
       descentCorridorBounds: stairNavigationZones.explicitDescentCorridor,
       elevation: upperFloorElevation,
       guard: {
         height: 0.56,
         thickness: toWorldUnits(0.12),
+        sideSides: ['east'],
+        shoulderSides: ['east'],
         material: {
           color: 0x2a3241,
           roughness: 0.72,
@@ -3003,6 +3052,11 @@ function initializeImmersiveScene(
     portfolioWindow.portfolio.world = {
       getActiveFloor() {
         return activeFloorId;
+      },
+      canOccupyPosition(target: { x: number; z: number; floorId?: FloorId }) {
+        const floorId =
+          target.floorId ?? predictFloorId(target.x, target.z, activeFloorId);
+        return canOccupyPosition(target.x, target.z, floorId);
       },
       setActiveFloor(next: FloorId) {
         setActiveFloorId(next);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1892,6 +1892,8 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
     const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
     const hiddenStairWestVoidGapBlockerMaxZ = upperStairWestEgressMaxZ;
+    const upperStairWestEdgeSafetyMinX =
+      upperStairwellOpening.minX - PLAYER_RADIUS;
     const hiddenStairDeepVoidBlockerMinZ =
       hiddenStairWestVoidGapBlockerMinZ -
       stairLayout.directionMultiplier * PLAYER_RADIUS;
@@ -1913,7 +1915,9 @@ function initializeImmersiveScene(
     // blockers reject forced upper-floor placement over the hidden stair-top gap,
     // the deeper removed stair run, and doorway-side void while preserving the
     // narrow stair-top handoff, a west-side bypass lane around the void, and the
-    // north doorway's padded passage into the loft.
+    // north doorway's padded passage into the loft. The west edge safety blocker
+    // starts one player radius before the visual cutout so center-point placement
+    // cannot leave the avatar overhanging the missing upper-floor slab.
     upperFloorColliders.push(
       {
         minX: stairCenterX - stairHalfWidth - stairwellMarginX,
@@ -1922,7 +1926,7 @@ function initializeImmersiveScene(
         maxZ: upperStairWestEgressMinZ,
       },
       {
-        minX: stairCenterX - stairHalfWidth - stairwellMarginX,
+        minX: upperStairWestEdgeSafetyMinX,
         maxX: stairNavigationZones.explicitDescentCorridor.minX,
         minZ: upperStairWestEgressMaxZ,
         maxZ: upperStairVoidMaxZ,

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -108,29 +108,20 @@ describe('createRoomFloorTiles', () => {
     expect(fillsLeftLandingShoulder).toBe(true);
     expect(fillsRightLandingShoulder).toBe(true);
 
-    const visibleStairwellVoid = {
-      minX: stairwellOpening.minX,
-      maxX: stairwellOpening.maxX,
-      minZ: stairwellOpening.minZ,
-      maxZ: stairLayout.landingMaxZ,
-    };
-    expect(
-      upperLandingTiles.some((tile) =>
-        overlaps(tile.bounds, visibleStairwellVoid)
-      )
-    ).toBe(false);
-
-    const doorwayBridgePastStairTop = {
+    const hiddenStairRunVoid = {
       minX: stairwellOpening.minX,
       maxX: stairwellOpening.maxX,
       minZ: stairLayout.landingMaxZ,
       maxZ: upperLandingRoom!.bounds.maxZ,
     };
     expect(
+      upperLandingTiles.some((tile) => overlaps(tile.bounds, stairwellOpening))
+    ).toBe(false);
+    expect(
       upperLandingTiles.some((tile) =>
-        boundsAreClose(tile.bounds, doorwayBridgePastStairTop)
+        overlaps(tile.bounds, hiddenStairRunVoid)
       )
-    ).toBe(true);
+    ).toBe(false);
 
     for (const tile of build.tiles) {
       const geometry = tile.mesh.geometry as BoxGeometry;

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -9,6 +9,17 @@ export interface UpperStairwellGuardConfig {
   height: number;
   /** Physical thickness of each rail. */
   thickness: number;
+  /**
+   * Optional long side rail edges around the opening. Omitting west keeps the
+   * upstairs-room egress open while east can still protect the stair void edge.
+   */
+  sideSides?: ReadonlyArray<'east' | 'west'>;
+  /**
+   * Optional shoulder rail sides to add around the descent corridor. Omitting
+   * west keeps the upstairs-room egress open while east can still protect the
+   * stair void edge.
+   */
+  shoulderSides?: ReadonlyArray<'east' | 'west'>;
   /** Optional material overrides for the guard rails. */
   material?: MeshStandardMaterialParameters;
 }
@@ -107,36 +118,43 @@ export function createUpperStairwellLanding(
     return { group, colliders };
   }
 
-  addGuard({
-    group,
-    colliders,
-    material: guardMaterial,
-    name: `${SIDE_GUARD_NAME}-West`,
-    bounds: {
-      minX: openingBounds.minX - thickness,
-      maxX: openingBounds.minX,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.maxZ,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
-  addGuard({
-    group,
-    colliders,
-    material: guardMaterial,
-    name: `${SIDE_GUARD_NAME}-East`,
-    bounds: {
-      minX: openingBounds.maxX,
-      maxX: openingBounds.maxX + thickness,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.maxZ,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
+  const sideSides = config.guard.sideSides ?? ['east', 'west'];
+
+  if (sideSides.includes('west')) {
+    addGuard({
+      group,
+      colliders,
+      material: guardMaterial,
+      name: `${SIDE_GUARD_NAME}-West`,
+      bounds: {
+        minX: openingBounds.minX - thickness,
+        maxX: openingBounds.minX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      },
+      roomBounds: config.roomBounds,
+      elevation: config.elevation,
+      height: config.guard.height,
+    });
+  }
+
+  if (sideSides.includes('east')) {
+    addGuard({
+      group,
+      colliders,
+      material: guardMaterial,
+      name: `${SIDE_GUARD_NAME}-East`,
+      bounds: {
+        minX: openingBounds.maxX,
+        maxX: openingBounds.maxX + thickness,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      },
+      roomBounds: config.roomBounds,
+      elevation: config.elevation,
+      height: config.guard.height,
+    });
+  }
   addGuard({
     group,
     colliders,
@@ -153,42 +171,49 @@ export function createUpperStairwellLanding(
     height: config.guard.height,
   });
 
-  if (config.descentCorridorBounds) {
+  const shoulderSides = config.guard.shoulderSides ?? ['east', 'west'];
+
+  if (config.descentCorridorBounds && shoulderSides.length > 0) {
     const descentCorridorBounds = clampBoundsToRoom(
       config.descentCorridorBounds,
       openingBounds
     );
 
-    addGuard({
-      group,
-      colliders,
-      material: guardMaterial,
-      name: `${SHOULDER_GUARD_NAME}-West`,
-      bounds: {
-        minX: openingBounds.minX,
-        maxX: descentCorridorBounds.minX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-    addGuard({
-      group,
-      colliders,
-      material: guardMaterial,
-      name: `${SHOULDER_GUARD_NAME}-East`,
-      bounds: {
-        minX: descentCorridorBounds.maxX,
-        maxX: openingBounds.maxX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
+    if (shoulderSides.includes('west')) {
+      addGuard({
+        group,
+        colliders,
+        material: guardMaterial,
+        name: `${SHOULDER_GUARD_NAME}-West`,
+        bounds: {
+          minX: openingBounds.minX,
+          maxX: descentCorridorBounds.minX,
+          minZ: openingBounds.minZ,
+          maxZ: openingBounds.maxZ,
+        },
+        roomBounds: config.roomBounds,
+        elevation: config.elevation,
+        height: config.guard.height,
+      });
+    }
+
+    if (shoulderSides.includes('east')) {
+      addGuard({
+        group,
+        colliders,
+        material: guardMaterial,
+        name: `${SHOULDER_GUARD_NAME}-East`,
+        bounds: {
+          minX: descentCorridorBounds.maxX,
+          maxX: openingBounds.maxX,
+          minZ: openingBounds.minZ,
+          maxZ: openingBounds.maxZ,
+        },
+        roomBounds: config.roomBounds,
+        elevation: config.elevation,
+        height: config.guard.height,
+      });
+    }
   }
 
   return { group, colliders };

--- a/src/systems/movement/stairLayout.ts
+++ b/src/systems/movement/stairLayout.ts
@@ -89,21 +89,15 @@ export const computeStairLayout = (
 
 /**
  * Clips the visible upstairs stairwell hole to the landing room while deriving
- * the stair landing void from `computeStairLayout`. Movement and visuals
- * therefore use the same threshold metrics without cutting away the normal
- * upper-floor doorway bridge beyond the stair top.
+ * the full hidden stair-run void from `computeStairLayout`. Movement and
+ * visuals therefore use the same threshold metrics without leaving an opaque
+ * upper-floor slab over the ramp below the landing lip.
  */
 export const computeStairwellOpeningBounds = (
   config: StairwellOpeningConfig
 ): StairwellBounds => {
-  const openingMinZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.stairHoleRange.minZ
-      : config.layout.landingMinZ;
-  const openingMaxZ =
-    config.layout.directionMultiplier === -1
-      ? config.layout.landingMaxZ
-      : config.layout.stairHoleRange.maxZ;
+  const openingMinZ = config.layout.stairHoleRange.minZ;
+  const openingMaxZ = config.layout.stairHoleRange.maxZ;
 
   return {
     minX: Math.max(

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -70,6 +70,29 @@ describe('computeStairLayout', () => {
     expect(opening.minX).toBeCloseTo(7.04);
     expect(opening.maxX).toBeCloseTo(12.8);
     expect(opening.minZ).toBeCloseTo(-31.9);
-    expect(opening.maxZ).toBeCloseTo(-25.9);
+    expect(opening.maxZ).toBeCloseTo(-16);
+  });
+
+  it('extends negative Z cutouts over the hidden stair run, not just the landing lip', () => {
+    const layout = computeStairLayout({
+      baseZ: 0,
+      stepRun: 1,
+      stepCount: 4,
+      landingDepth: 2,
+      direction: 'negativeZ',
+      guardMargin: 0.5,
+      stairwellMargin: 0.25,
+    });
+
+    const opening = computeStairwellOpeningBounds({
+      centerX: 0,
+      halfWidth: 1,
+      marginX: 0.25,
+      roomBounds: { minX: -5, maxX: 5, minZ: -7, maxZ: 1 },
+      layout,
+    });
+
+    expect(opening.minZ).toBeCloseTo(-6.25);
+    expect(opening.maxZ).toBeCloseTo(0.25);
   });
 });


### PR DESCRIPTION
### Motivation
- The upper landing was effectively sealed by overbroad invisible colliders and a floor slab that visually/physically covered the stair run, preventing legitimate westward egress into upstairs rooms. 
- The existing stair cutout only removed the landing lip, leaving an opaque/walkable slab above the hidden ramp run. 
- Invisible stairwell blockers extended too far into normal upstairs space and needed to be scoped to the actual stair void while preserving descent safety.

### Description
- Extend the upstairs cutout to use the computed `stairHoleRange` so the upper-floor slab is removed over the full hidden stair run instead of just the landing lip (`src/systems/movement/stairLayout.ts`).
- Replace the old broad upper-floor colliders with a set scoped to the computed cutout (including a focused center blocker over the hidden run) and leave a gap for west egress; adjust placement and trigger margins accordingly (`src/main.ts`).
- Make upper stairwell guard rails configurable with `sideSides` and `shoulderSides`, and use east-only shoulder/side guards for this layout so the west egress remains open (`src/scene/structures/upperStairwellLanding.ts`).
- Add a small test helper to the in-page world API (`world.canOccupyPosition`) and extend Playwright and unit tests to verify valid west egress, normal loft occupancy near `x=8.15, z=-11.82`, and rejection of the hidden-stair target near `x=12.70, z=-23.72` (`playwright/immersive-stairs-roundtrip.spec.ts`, `src/tests/movement/stairLayout.test.ts`, `src/scene/structures/__tests__/floorTiles.test.ts`).

### Testing
- Ran formatting with `npm run format:write` and lint with `npm run lint` and both completed successfully. 
- Ran unit suite with `npm run test:ci` (Vitest) and the repository tests passed (Vitest: 1065 tests in this run passed). 
- Installed Playwright browsers and OS deps with `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell` then executed the focused e2e with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and the spec passed (5/5 tests). 
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke` and both succeeded. 
- Ran docs check with `npm run docs:check` which passed. 
- Ran `npm run typecheck` which surfaced existing, repository-wide TypeScript errors unrelated to this change (TypeScript errors remained and were not introduced by this PR). 

Files changed (high level): `src/main.ts`, `src/systems/movement/stairLayout.ts`, `src/scene/structures/upperStairwellLanding.ts`, `playwright/immersive-stairs-roundtrip.spec.ts`, `src/tests/movement/stairLayout.test.ts`, and a small test update in `src/scene/structures/__tests__/floorTiles.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2632f64234832fb268f2d33d3cfeb5)