### PR TITLE
Add precise ground-floor stair boundary colliders to block east-side squeeze

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -222,6 +222,51 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
   });
 });
 
+test('ground stair east-side squeeze samples are blocked', async ({ page }) => {
+  await waitForImmersiveReady(page);
+
+  const { stairCenterX, stairBottomZ, stairTopZ } = await getStairMetrics(page);
+  const reportedLowerCornerSqueeze = {
+    x: 17.38,
+    z: -8.84,
+    floorId: 'ground' as const,
+  };
+  const reportedEastBoundarySqueeze = {
+    x: 21.35,
+    z: -14.66,
+    floorId: 'ground' as const,
+  };
+  const lowerStairEntrance = {
+    x: stairCenterX,
+    z: stairBottomZ + 0.3,
+    floorId: 'ground' as const,
+  };
+
+  expect(await canOccupyPosition(page, reportedLowerCornerSqueeze)).toBe(false);
+  expect(await canOccupyPosition(page, reportedEastBoundarySqueeze)).toBe(
+    false
+  );
+  expect(await canOccupyPosition(page, lowerStairEntrance)).toBe(true);
+
+  await expect(async () =>
+    movePlayerTo(page, reportedLowerCornerSqueeze)
+  ).rejects.toThrow(/Cannot occupy/);
+  await expect(async () =>
+    movePlayerTo(page, reportedEastBoundarySqueeze)
+  ).rejects.toThrow(/Cannot occupy/);
+
+  await movePlayerTo(page, lowerStairEntrance);
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.1 });
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-active-floor',
+    'upper'
+  );
+});
+
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   test.slow();
   await waitForImmersiveReady(page);

--- a/src/main.ts
+++ b/src/main.ts
@@ -382,6 +382,7 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
+  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -1822,6 +1823,22 @@ function initializeImmersiveScene(
     stairNavigationZones.stairRampBody,
   ];
   const upperStairNavZones = [stairNavigationZones.upperLanding];
+  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
+    stairGeometry,
+    stairBehavior,
+    {
+      playerRadius: PLAYER_RADIUS,
+      eastSideClearance:
+        stairHalfWidth +
+        stairTransitionMargin +
+        PLAYER_RADIUS +
+        stairwellMarginX,
+    }
+  );
+  groundStairBoundaryColliders.forEach(({ bounds }) =>
+    groundColliders.push(bounds)
+  );
+
   const stairGuardThickness = toWorldUnits(0.22);
   const stairGuardMinZ = stairLayout.guardRange.minZ;
   const stairGuardMaxZ = stairLayout.guardRange.maxZ;
@@ -3796,6 +3813,13 @@ function initializeImmersiveScene(
   updatePlayerVerticalPosition();
   document.documentElement.dataset.activeFloor = activeFloorId;
 
+  const groundStairBoundaryColliderBounds = new Set(
+    groundStairBoundaryColliders.map(({ bounds }) => bounds)
+  );
+  const anonymousGroundColliders = groundColliders.filter(
+    (collider) => !groundStairBoundaryColliderBounds.has(collider)
+  );
+
   const createDebugColliderRegistrations = (
     colliders: readonly RectCollider[],
     options: {
@@ -3818,7 +3842,14 @@ function initializeImmersiveScene(
     enabled: debugCollidersEnabled,
   });
   colliderVisualizer.register([
-    ...createDebugColliderRegistrations(groundColliders, {
+    ...groundStairBoundaryColliders.map(({ name, bounds }) => ({
+      floor: 'ground' as const,
+      category: 'ground-stair-boundary',
+      name,
+      bounds,
+      color: 0xff8a3d,
+    })),
+    ...createDebugColliderRegistrations(anonymousGroundColliders, {
       floor: 'ground',
       category: 'ground',
       namePrefix: 'ground-collider',

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -42,6 +42,18 @@ export interface StairNavigationZones {
   explicitDescentCorridor: RectCollider;
 }
 
+export interface NamedStairBoundaryCollider {
+  name: string;
+  bounds: RectCollider;
+}
+
+export interface GroundStairBoundaryColliderOptions {
+  /** Radius used by movement collision checks. */
+  playerRadius: number;
+  /** Extra east-side width reserved as a no-squeeze buffer beside the stairs. */
+  eastSideClearance?: number;
+}
+
 const DENOMINATOR_EPSILON = 1e-6;
 
 const getMinZ = (...values: number[]): number => Math.min(...values);
@@ -378,6 +390,43 @@ export interface StairNavAreaOptions {
   marginX?: number;
   marginZ?: number;
 }
+
+export const createGroundStairBoundaryColliders = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  options: GroundStairBoundaryColliderOptions
+): NamedStairBoundaryCollider[] => {
+  const eastStairEdgeX = geometry.centerX + geometry.halfWidth;
+  const eastSideClearance =
+    options.eastSideClearance ??
+    geometry.halfWidth + behavior.transitionMargin + options.playerRadius;
+  const eastBoundaryMaxX = eastStairEdgeX + eastSideClearance;
+  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
+  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
+  const lowerCornerFarZ =
+    geometry.bottomZ - geometry.direction * behavior.transitionMargin;
+
+  return [
+    {
+      name: 'GroundStairEastBoundary',
+      bounds: {
+        minX: eastStairEdgeX,
+        maxX: eastBoundaryMaxX,
+        minZ: rampMinZ,
+        maxZ: rampMaxZ,
+      },
+    },
+    {
+      name: 'GroundStairLowerCornerGuard',
+      bounds: {
+        minX: eastStairEdgeX,
+        maxX: eastBoundaryMaxX,
+        minZ: getMinZ(geometry.bottomZ, lowerCornerFarZ),
+        maxZ: getMaxZ(geometry.bottomZ, lowerCornerFarZ),
+      },
+    },
+  ];
+};
 
 export const createStairNavAreaRect = (
   geometry: StairGeometry,

--- a/src/tests/movement/groundStairBoundaryColliders.test.ts
+++ b/src/tests/movement/groundStairBoundaryColliders.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { collidesWithColliders } from '../../systems/collision';
+import {
+  createGroundStairBoundaryColliders,
+  type StairBehavior,
+  type StairGeometry,
+} from '../../systems/movement/stairs';
+
+const playerRadius = 0.75;
+const geometry: StairGeometry = {
+  centerX: 12.4,
+  halfWidth: 3.1,
+  bottomZ: -10.6,
+  topZ: -25.9,
+  landingMinZ: -31.1,
+  landingMaxZ: -25.9,
+  totalRise: 3.78,
+  direction: -1,
+};
+const behavior: StairBehavior = {
+  transitionMargin: 1.2,
+  landingTriggerMargin: 0.4,
+  stepRise: 0.42,
+  descentCorridorInset: playerRadius,
+};
+
+const createColliders = () =>
+  createGroundStairBoundaryColliders(geometry, behavior, {
+    playerRadius,
+    eastSideClearance:
+      geometry.halfWidth + behavior.transitionMargin + playerRadius + 0.4,
+  });
+
+describe('createGroundStairBoundaryColliders', () => {
+  it('names precise east-side blockers for debug visualization', () => {
+    expect(createColliders().map((collider) => collider.name)).toEqual([
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+    ]);
+  });
+
+  it('blocks the reported ground-floor east stair squeeze samples', () => {
+    const colliders = createColliders().map(({ bounds }) => bounds);
+
+    expect(collidesWithColliders(17.38, -8.84, playerRadius, colliders)).toBe(
+      true
+    );
+    expect(collidesWithColliders(21.35, -14.66, playerRadius, colliders)).toBe(
+      true
+    );
+  });
+
+  it('leaves the intended stair centerline and lower entrance clear', () => {
+    const colliders = createColliders().map(({ bounds }) => bounds);
+
+    expect(
+      collidesWithColliders(
+        geometry.centerX,
+        geometry.bottomZ + 0.3,
+        playerRadius,
+        colliders
+      )
+    ).toBe(false);
+    expect(
+      collidesWithColliders(
+        geometry.centerX,
+        (geometry.bottomZ + geometry.topZ) / 2,
+        playerRadius,
+        colliders
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent players from squeezing around the ground-floor stairs into the unintended right/east corner by adding narrow, geometry-driven invisible blockers. 
- Preserve the intended stair path: lower entrance, ramp body, and centerline ascent must remain reachable. 

### Description
- Add `createGroundStairBoundaryColliders(...)` in `src/systems/movement/stairs.ts` that derives named east-side ground stair blockers from `stairGeometry`, `stairBehavior`, and `PLAYER_RADIUS`. 
- Wire the generated bounds into the runtime `groundColliders` in `src/main.ts` and register them with the collider visualizer using clear names `GroundStairEastBoundary` and `GroundStairLowerCornerGuard` and a distinctive color. 
- Keep anonymous/legacy ground colliders separate so debug visualization lists the new named stair-boundary colliders first. 
- Add unit test `src/tests/movement/groundStairBoundaryColliders.test.ts` and an immersive Playwright regression in `playwright/immersive-stairs-roundtrip.spec.ts` to verify the reported squeeze samples are blocked while the stair entrance and centerline remain usable.

### Testing
- `npm run format:write` — ran on modified files (succeeded). 
- `npm run lint` — lint completed with no new errors (succeeded). 
- `npm run typecheck` — failed due to unrelated, pre-existing TypeScript issues elsewhere in the repo (did not block the focused change). 
- `npm run test:ci` — Vitest suite run; all tests (including new unit) passed (143 files, 1068 tests reported as passed). 
- `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — initially required installing Playwright browsers and host deps; after `npx playwright install chromium-headless-shell` and `npx playwright install-deps` the spec passed (6 tests passed). 
- `npm run build` — production build succeeded. 
- `npm run docs:check` — docs check and link checks passed (external fetch warnings only). 
- `npm run smoke` — smoke build+assert passed.

Notes: `typecheck` surfaced unrelated repository type errors; they predate and are outside the scope of this change. Playwright browser and system dependencies were installed in the test environment to run the E2E spec; CI should already have those available or run the equivalent install step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265a4d935c832fb5ccde3f6e2f060b)