### PR TITLE
Block ground stair east squeeze path

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -241,6 +241,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     { x: 21.35, z: -14.66, floorId: 'ground' as const },
     { x: 22.1, z: -14.66, floorId: 'ground' as const },
     { x: 23, z: -14.66, floorId: 'ground' as const },
+    { x: 23, z: -18, floorId: 'ground' as const },
   ];
   const lowerEntrance = {
     x: stairCenterX,
@@ -279,7 +280,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   });
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
-  expect(debugColliders).toContain('GroundStairEastApproachSeal');
+  expect(debugColliders).toContain('GroundStairEastRunSeal');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -262,6 +262,20 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     await canOccupyPosition(page, { x: 24, z: -18, floorId: 'ground' })
   ).toBe(true);
   expect(
+    await canOccupyPosition(page, {
+      x: 24,
+      z: stairTopZ - 0.05,
+      floorId: 'ground',
+    })
+  ).toBe(false);
+  expect(
+    await canOccupyPosition(page, {
+      x: 24,
+      z: stairBottomZ + 0.05,
+      floorId: 'ground',
+    })
+  ).toBe(false);
+  expect(
     await canOccupyPosition(page, { x: 24, z: -30, floorId: 'ground' })
   ).toBe(true);
   expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
@@ -286,6 +300,8 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
   expect(debugColliders).toContain('GroundStairEastRunSeal');
+  expect(debugColliders).toContain('GroundStairEastRunSealTopCap');
+  expect(debugColliders).toContain('GroundStairEastRunSealBottomCap');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -243,6 +243,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     { x: 23, z: -14.66, floorId: 'ground' as const },
     { x: 23, z: -18, floorId: 'ground' as const },
     { x: 23.91, z: -18, floorId: 'ground' as const },
+    { x: 23.99, z: -18, floorId: 'ground' as const },
   ];
   const lowerEntrance = {
     x: stairCenterX,
@@ -259,7 +260,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
 
   expect(
     await canOccupyPosition(page, { x: 24, z: -18, floorId: 'ground' })
-  ).toBe(false);
+  ).toBe(true);
   expect(
     await canOccupyPosition(page, { x: 24, z: -30, floorId: 'ground' })
   ).toBe(true);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -242,6 +242,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     { x: 22.1, z: -14.66, floorId: 'ground' as const },
     { x: 23, z: -14.66, floorId: 'ground' as const },
     { x: 23, z: -18, floorId: 'ground' as const },
+    { x: 23.91, z: -18, floorId: 'ground' as const },
   ];
   const lowerEntrance = {
     x: stairCenterX,

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -264,17 +264,31 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   expect(
     await canOccupyPosition(page, {
       x: 24,
+      z: stairTopZ + 0.76,
+      floorId: 'ground',
+    })
+  ).toBe(true);
+  expect(
+    await canOccupyPosition(page, {
+      x: 24,
+      z: stairBottomZ - 0.76,
+      floorId: 'ground',
+    })
+  ).toBe(true);
+  expect(
+    await canOccupyPosition(page, {
+      x: 24,
       z: stairTopZ - 0.05,
       floorId: 'ground',
     })
-  ).toBe(false);
+  ).toBe(true);
   expect(
     await canOccupyPosition(page, {
       x: 24,
       z: stairBottomZ + 0.05,
       floorId: 'ground',
     })
-  ).toBe(false);
+  ).toBe(true);
   expect(
     await canOccupyPosition(page, { x: 24, z: -30, floorId: 'ground' })
   ).toBe(true);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -241,7 +241,10 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     { x: 21.35, z: -14.66, floorId: 'ground' as const },
     { x: 22.1, z: -14.66, floorId: 'ground' as const },
   ];
-  const livingRoomSample = { x: 24, z: -18, floorId: 'ground' as const };
+  const livingRoomSamples = [
+    { x: 23, z: -18, floorId: 'ground' as const },
+    { x: 24, z: -18, floorId: 'ground' as const },
+  ];
   const lowerEntrance = {
     x: stairCenterX,
     z: stairBottomZ + 0.3,
@@ -255,7 +258,9 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     );
   }
 
-  expect(await canOccupyPosition(page, livingRoomSample)).toBe(true);
+  for (const sample of livingRoomSamples) {
+    expect(await canOccupyPosition(page, sample)).toBe(true);
+  }
   expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
   await movePlayerTo(page, lowerEntrance);
   await expect(html).toHaveAttribute('data-active-floor', 'ground');

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -260,21 +260,19 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
 
   expect(
     await canOccupyPosition(page, { x: 24, z: -18, floorId: 'ground' })
+  ).toBe(true);
+  expect(
+    await canOccupyPosition(page, { x: 24, z: -25.14, floorId: 'ground' })
+  ).toBe(true);
+  expect(
+    await canOccupyPosition(page, { x: 24, z: -11.36, floorId: 'ground' })
+  ).toBe(true);
+  expect(
+    await canOccupyPosition(page, { x: 28, z: -9.2, floorId: 'ground' })
   ).toBe(false);
   expect(
-    await canOccupyPosition(page, {
-      x: 24,
-      z: stairTopZ - 0.76,
-      floorId: 'ground',
-    })
-  ).toBe(true);
-  expect(
-    await canOccupyPosition(page, {
-      x: 24,
-      z: stairBottomZ + 0.76,
-      floorId: 'ground',
-    })
-  ).toBe(true);
+    await canOccupyPosition(page, { x: 28, z: -29.2, floorId: 'ground' })
+  ).toBe(false);
   expect(
     await canOccupyPosition(page, { x: 24, z: -30, floorId: 'ground' })
   ).toBe(true);
@@ -300,6 +298,8 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
   expect(debugColliders).toContain('GroundStairEastRunSeal');
+  expect(debugColliders).toContain('GroundStairEastRunSealLowerCap');
+  expect(debugColliders).toContain('GroundStairEastRunSealUpperCap');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -259,6 +259,9 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
 
   expect(
     await canOccupyPosition(page, { x: 24, z: -18, floorId: 'ground' })
+  ).toBe(false);
+  expect(
+    await canOccupyPosition(page, { x: 24, z: -30, floorId: 'ground' })
   ).toBe(true);
   expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
   await movePlayerTo(page, lowerEntrance);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -55,6 +55,11 @@ type TestWorldApi = {
   };
 };
 
+type DebugColliderApi = {
+  setEnabled(enabled: boolean): void;
+  getColliders(): Array<{ name: string }>;
+};
+
 type DebugCoordinatesApi = {
   getState(): {
     enabled: boolean;
@@ -82,6 +87,7 @@ type TooltipState = {
 type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
+    debugColliders?: DebugColliderApi;
     debugCoordinates?: DebugCoordinatesApi;
     poi?: {
       getTooltipState(): TooltipState;
@@ -220,6 +226,54 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
     sourceZone: 'outsideStairs',
     liftedZone: 'outsideStairs',
   });
+});
+
+test('ground stair east boundary blocks squeeze corners but preserves the stair path', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const { stairCenterX, stairBottomZ, stairTopZ } = await getStairMetrics(page);
+  const squeezeSamples = [
+    { x: 17.38, z: -8.84, floorId: 'ground' as const },
+    { x: 21.35, z: -14.66, floorId: 'ground' as const },
+  ];
+  const lowerEntrance = {
+    x: stairCenterX,
+    z: stairBottomZ + 0.3,
+    floorId: 'ground' as const,
+  };
+
+  for (const sample of squeezeSamples) {
+    expect(await canOccupyPosition(page, sample)).toBe(false);
+    await expect(async () => movePlayerTo(page, sample)).rejects.toThrow(
+      /Cannot occupy/
+    );
+  }
+
+  expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
+  await movePlayerTo(page, lowerEntrance);
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.1 });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const debugColliders = await page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    debugApi.setEnabled(true);
+    return debugApi.getColliders().map((collider) => collider.name);
+  });
+  expect(debugColliders).toContain('GroundStairEastBoundary');
+  expect(debugColliders).toContain('GroundStairLowerCornerGuard');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -239,6 +239,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   const squeezeSamples = [
     { x: 17.38, z: -8.84, floorId: 'ground' as const },
     { x: 21.35, z: -14.66, floorId: 'ground' as const },
+    { x: 22.1, z: -14.66, floorId: 'ground' as const },
   ];
   const lowerEntrance = {
     x: stairCenterX,

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 
-import { UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
+import { FLOOR_PLAN, UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
 
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
@@ -150,6 +150,15 @@ function getUpperRoomCenter(roomId: string) {
   };
 }
 
+function getGroundRoomBounds(roomId: string) {
+  const room = FLOOR_PLAN.rooms.find((candidate) => candidate.id === roomId);
+  if (!room) {
+    throw new Error(`Missing ground-floor room: ${roomId}`);
+  }
+
+  return room.bounds;
+}
+
 async function canOccupyPosition(
   page: Page,
   target: { x: number; z: number; floorId?: FloorId }
@@ -235,15 +244,37 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
-  const { stairCenterX, stairBottomZ, stairTopZ } = await getStairMetrics(page);
+  const { stairCenterX, stairHalfWidth, stairBottomZ, stairTopZ } =
+    await getStairMetrics(page);
+  const livingRoomBounds = getGroundRoomBounds('livingRoom');
+  const playerRadius = 0.75;
+  const epsilon = 0.1;
+  const stairEastX = stairCenterX + stairHalfWidth;
+  const rampMinZ = Math.min(stairBottomZ, stairTopZ);
+  const rampMaxZ = Math.max(stairBottomZ, stairTopZ);
+  const roomLaneX = stairEastX + (livingRoomBounds.maxX - stairEastX) / 2;
   const squeezeSamples = [
     { x: 17.38, z: -8.84, floorId: 'ground' as const },
     { x: 21.35, z: -14.66, floorId: 'ground' as const },
     { x: 22.1, z: -14.66, floorId: 'ground' as const },
-    { x: 23, z: -14.66, floorId: 'ground' as const },
-    { x: 23, z: -18, floorId: 'ground' as const },
-    { x: 23.91, z: -18, floorId: 'ground' as const },
-    { x: 23.99, z: -18, floorId: 'ground' as const },
+    { x: 24, z: -18, floorId: 'ground' as const },
+  ];
+  const stairRunBandSamples = [
+    { x: stairEastX + epsilon, z: rampMinZ + epsilon },
+    { x: roomLaneX, z: (rampMinZ + rampMaxZ) / 2 },
+    { x: livingRoomBounds.maxX - epsilon, z: rampMaxZ - epsilon },
+  ].map((sample) => ({ ...sample, floorId: 'ground' as const }));
+  const livingRoomSamplesOutsideSeal = [
+    {
+      x: roomLaneX,
+      z: rampMaxZ + playerRadius + epsilon,
+      floorId: 'ground' as const,
+    },
+    {
+      x: roomLaneX,
+      z: rampMinZ - playerRadius - epsilon,
+      floorId: 'ground' as const,
+    },
   ];
   const lowerEntrance = {
     x: stairCenterX,
@@ -251,31 +282,17 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     floorId: 'ground' as const,
   };
 
-  for (const sample of squeezeSamples) {
+  for (const sample of [...squeezeSamples, ...stairRunBandSamples]) {
     expect(await canOccupyPosition(page, sample)).toBe(false);
     await expect(async () => movePlayerTo(page, sample)).rejects.toThrow(
       /Cannot occupy/
     );
   }
 
-  expect(
-    await canOccupyPosition(page, { x: 24, z: -18, floorId: 'ground' })
-  ).toBe(true);
-  expect(
-    await canOccupyPosition(page, { x: 24, z: -25.14, floorId: 'ground' })
-  ).toBe(true);
-  expect(
-    await canOccupyPosition(page, { x: 24, z: -11.36, floorId: 'ground' })
-  ).toBe(true);
-  expect(
-    await canOccupyPosition(page, { x: 28, z: -9.2, floorId: 'ground' })
-  ).toBe(false);
-  expect(
-    await canOccupyPosition(page, { x: 28, z: -29.2, floorId: 'ground' })
-  ).toBe(false);
-  expect(
-    await canOccupyPosition(page, { x: 24, z: -30, floorId: 'ground' })
-  ).toBe(true);
+  for (const sample of livingRoomSamplesOutsideSeal) {
+    expect(await canOccupyPosition(page, sample)).toBe(true);
+  }
+
   expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
   await movePlayerTo(page, lowerEntrance);
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
@@ -298,8 +315,6 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
   expect(debugColliders).toContain('GroundStairEastRunSeal');
-  expect(debugColliders).toContain('GroundStairEastRunSealLowerCap');
-  expect(debugColliders).toContain('GroundStairEastRunSealUpperCap');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -254,6 +254,9 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     );
   }
 
+  expect(
+    await canOccupyPosition(page, { x: 24, z: -18, floorId: 'ground' })
+  ).toBe(true);
   expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
   await movePlayerTo(page, lowerEntrance);
   await expect(html).toHaveAttribute('data-active-floor', 'ground');

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -240,6 +240,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     { x: 17.38, z: -8.84, floorId: 'ground' as const },
     { x: 21.35, z: -14.66, floorId: 'ground' as const },
     { x: 22.1, z: -14.66, floorId: 'ground' as const },
+    { x: 23, z: -14.66, floorId: 'ground' as const },
   ];
   const lowerEntrance = {
     x: stairCenterX,
@@ -278,6 +279,7 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   });
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
+  expect(debugColliders).toContain('GroundStairEastApproachSeal');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -260,32 +260,18 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
 
   expect(
     await canOccupyPosition(page, { x: 24, z: -18, floorId: 'ground' })
-  ).toBe(true);
+  ).toBe(false);
   expect(
     await canOccupyPosition(page, {
       x: 24,
-      z: stairTopZ + 0.76,
+      z: stairTopZ - 0.76,
       floorId: 'ground',
     })
   ).toBe(true);
   expect(
     await canOccupyPosition(page, {
       x: 24,
-      z: stairBottomZ - 0.76,
-      floorId: 'ground',
-    })
-  ).toBe(true);
-  expect(
-    await canOccupyPosition(page, {
-      x: 24,
-      z: stairTopZ - 0.05,
-      floorId: 'ground',
-    })
-  ).toBe(true);
-  expect(
-    await canOccupyPosition(page, {
-      x: 24,
-      z: stairBottomZ + 0.05,
+      z: stairBottomZ + 0.76,
       floorId: 'ground',
     })
   ).toBe(true);
@@ -314,8 +300,6 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
   expect(debugColliders).toContain('GroundStairEastRunSeal');
-  expect(debugColliders).toContain('GroundStairEastRunSealTopCap');
-  expect(debugColliders).toContain('GroundStairEastRunSealBottomCap');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 
-import { FLOOR_PLAN, UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
+import { UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
 
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
@@ -150,15 +150,6 @@ function getUpperRoomCenter(roomId: string) {
   };
 }
 
-function getGroundRoomBounds(roomId: string) {
-  const room = FLOOR_PLAN.rooms.find((candidate) => candidate.id === roomId);
-  if (!room) {
-    throw new Error(`Missing ground-floor room: ${roomId}`);
-  }
-
-  return room.bounds;
-}
-
 async function canOccupyPosition(
   page: Page,
   target: { x: number; z: number; floorId?: FloorId }
@@ -244,55 +235,27 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
-  const { stairCenterX, stairHalfWidth, stairBottomZ, stairTopZ } =
-    await getStairMetrics(page);
-  const livingRoomBounds = getGroundRoomBounds('livingRoom');
-  const playerRadius = 0.75;
-  const epsilon = 0.1;
-  const stairEastX = stairCenterX + stairHalfWidth;
-  const rampMinZ = Math.min(stairBottomZ, stairTopZ);
-  const rampMaxZ = Math.max(stairBottomZ, stairTopZ);
-  const roomLaneX = stairEastX + (livingRoomBounds.maxX - stairEastX) / 2;
-  const squeezeSamples = [
+  const { stairCenterX, stairBottomZ, stairTopZ } = await getStairMetrics(page);
+  const blockedSamples = [
     { x: 17.38, z: -8.84, floorId: 'ground' as const },
     { x: 21.35, z: -14.66, floorId: 'ground' as const },
     { x: 22.1, z: -14.66, floorId: 'ground' as const },
-    { x: 24, z: -18, floorId: 'ground' as const },
   ];
-  const stairRunBandSamples = [
-    { x: stairEastX + epsilon, z: rampMinZ + epsilon },
-    { x: roomLaneX, z: (rampMinZ + rampMaxZ) / 2 },
-    { x: livingRoomBounds.maxX - epsilon, z: rampMaxZ - epsilon },
-  ].map((sample) => ({ ...sample, floorId: 'ground' as const }));
-  const livingRoomSamplesOutsideSeal = [
-    {
-      x: roomLaneX,
-      z: rampMaxZ + playerRadius + epsilon,
-      floorId: 'ground' as const,
-    },
-    {
-      x: roomLaneX,
-      z: rampMinZ - playerRadius - epsilon,
-      floorId: 'ground' as const,
-    },
-  ];
+  const livingRoomSample = { x: 24, z: -18, floorId: 'ground' as const };
   const lowerEntrance = {
     x: stairCenterX,
     z: stairBottomZ + 0.3,
     floorId: 'ground' as const,
   };
 
-  for (const sample of [...squeezeSamples, ...stairRunBandSamples]) {
+  for (const sample of blockedSamples) {
     expect(await canOccupyPosition(page, sample)).toBe(false);
     await expect(async () => movePlayerTo(page, sample)).rejects.toThrow(
       /Cannot occupy/
     );
   }
 
-  for (const sample of livingRoomSamplesOutsideSeal) {
-    expect(await canOccupyPosition(page, sample)).toBe(true);
-  }
-
+  expect(await canOccupyPosition(page, livingRoomSample)).toBe(true);
   expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
   await movePlayerTo(page, lowerEntrance);
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
@@ -314,7 +277,9 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   });
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
-  expect(debugColliders).toContain('GroundStairEastRunSeal');
+  expect(debugColliders).not.toContain('GroundStairEastRunSeal');
+  expect(debugColliders).not.toContain('GroundStairEastRunSealLowerCap');
+  expect(debugColliders).not.toContain('GroundStairEastRunSealUpperCap');
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -382,6 +382,7 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
+  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -865,6 +866,7 @@ const LIGHTING_OPTIONS = {
 } as const;
 
 const groundColliders: RectCollider[] = [];
+const namedGroundColliderDebugNames = new Map<RectCollider, string>();
 const upperFloorColliders: RectCollider[] = [];
 const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
@@ -1837,6 +1839,19 @@ function initializeImmersiveScene(
     maxX: stairCenterX + stairHalfWidth + stairGuardThickness,
     minZ: stairGuardMinZ,
     maxZ: stairGuardMaxZ,
+  });
+
+  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
+    stairGeometry,
+    stairBehavior,
+    {
+      playerRadius: PLAYER_RADIUS,
+      guardThickness: stairGuardThickness,
+    }
+  );
+  groundStairBoundaryColliders.forEach(({ name, bounds }) => {
+    groundColliders.push(bounds);
+    namedGroundColliderDebugNames.set(bounds, name);
   });
 
   const upperFloorGroup = new Group();
@@ -3808,7 +3823,9 @@ function initializeImmersiveScene(
     colliders.map((bounds, index) => ({
       floor: options.floor,
       category: options.category,
-      name: `${options.namePrefix}-${index + 1}`,
+      name:
+        namedGroundColliderDebugNames.get(bounds) ??
+        `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
     }));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,7 +1847,6 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
-      eastRunSealMaxX: floorBounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,7 +1847,6 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
-      eastRunSealCapMaxX: floorBounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,7 +1847,6 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
-      eastApproachSealMaxX: livingRoom?.bounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,6 +1847,7 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
+      eastApproachSealMaxX: livingRoom?.bounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -866,7 +866,7 @@ const LIGHTING_OPTIONS = {
 } as const;
 
 const groundColliders: RectCollider[] = [];
-const namedGroundColliderDebugNames = new Map<RectCollider, string>();
+const namedColliderDebugNames = new Map<RectCollider, string>();
 const upperFloorColliders: RectCollider[] = [];
 const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
@@ -1847,11 +1847,12 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
+      sealMaxX: floorBounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {
     groundColliders.push(bounds);
-    namedGroundColliderDebugNames.set(bounds, name);
+    namedColliderDebugNames.set(bounds, name);
   });
 
   const upperFloorGroup = new Group();
@@ -3824,7 +3825,7 @@ function initializeImmersiveScene(
       floor: options.floor,
       category: options.category,
       name:
-        namedGroundColliderDebugNames.get(bounds) ??
+        namedColliderDebugNames.get(bounds) ??
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,7 +1847,9 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
-      eastRunSealMaxX: floorBounds.maxX,
+      eastRunSealCapMaxX: livingRoom?.bounds.maxX,
+      eastRunSealLowerCapEndZ: livingRoom?.bounds.maxZ,
+      eastRunSealUpperCapEndZ: livingRoom?.bounds.minZ,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,6 +1847,7 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
+      eastRunSealCapMaxX: floorBounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1841,20 +1841,12 @@ function initializeImmersiveScene(
     maxZ: stairGuardMaxZ,
   });
 
-  const groundStairContainingRoomMaxX = livingRoom?.bounds.maxX;
-  if (groundStairContainingRoomMaxX === undefined) {
-    throw new Error(
-      'Missing living room bounds for ground stair boundary seal'
-    );
-  }
-
   const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
     stairGeometry,
     stairBehavior,
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
-      containingRoomMaxX: groundStairContainingRoomMaxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1841,15 +1841,20 @@ function initializeImmersiveScene(
     maxZ: stairGuardMaxZ,
   });
 
+  const groundStairContainingRoomMaxX = livingRoom?.bounds.maxX;
+  if (groundStairContainingRoomMaxX === undefined) {
+    throw new Error(
+      'Missing living room bounds for ground stair boundary seal'
+    );
+  }
+
   const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
     stairGeometry,
     stairBehavior,
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
-      eastRunSealCapMaxX: livingRoom?.bounds.maxX,
-      eastRunSealLowerCapEndZ: livingRoom?.bounds.maxZ,
-      eastRunSealUpperCapEndZ: livingRoom?.bounds.minZ,
+      containingRoomMaxX: groundStairContainingRoomMaxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,7 +1847,6 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
-      sealMaxX: floorBounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1847,6 +1847,7 @@ function initializeImmersiveScene(
     {
       playerRadius: PLAYER_RADIUS,
       guardThickness: stairGuardThickness,
+      eastRunSealMaxX: floorBounds.maxX,
     }
   );
   groundStairBoundaryColliders.forEach(({ name, bounds }) => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,6 +35,7 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
+    eastRunSealCapMaxX: 32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -45,6 +46,8 @@ describe('createGroundStairBoundaryColliders', () => {
       'GroundStairEastBoundary',
       'GroundStairLowerCornerGuard',
       'GroundStairEastRunSeal',
+      'GroundStairEastRunSealTopCap',
+      'GroundStairEastRunSealBottomCap',
     ]);
   });
 
@@ -72,10 +75,26 @@ describe('createGroundStairBoundaryColliders', () => {
     ).toBe(true);
   });
 
-  it('keeps regular living-room positions clear', () => {
+  it('caps the run seal ends while keeping the middle living-room lane clear', () => {
     expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
       false
     );
+    expect(
+      collidesWithColliders(
+        24,
+        geometry.topZ - 0.05,
+        PLAYER_RADIUS,
+        boundaryBounds
+      )
+    ).toBe(true);
+    expect(
+      collidesWithColliders(
+        24,
+        geometry.bottomZ + 0.05,
+        PLAYER_RADIUS,
+        boundaryBounds
+      )
+    ).toBe(true);
     expect(collidesWithColliders(24, -30, PLAYER_RADIUS, boundaryBounds)).toBe(
       false
     );

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -64,6 +64,9 @@ describe('createGroundStairBoundaryColliders', () => {
     expect(collidesWithColliders(23, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
       true
     );
+    expect(
+      collidesWithColliders(23.91, -18, PLAYER_RADIUS, boundaryBounds)
+    ).toBe(true);
   });
 
   it('keeps regular living-room positions east of the stairs clear', () => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,7 +35,6 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
-    eastApproachSealMaxX: 32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -45,7 +44,7 @@ describe('createGroundStairBoundaryColliders', () => {
     expect(boundaryColliders.map((collider) => collider.name)).toEqual([
       'GroundStairEastBoundary',
       'GroundStairLowerCornerGuard',
-      'GroundStairEastApproachSeal',
+      'GroundStairEastRunSeal',
     ]);
   });
 
@@ -62,6 +61,9 @@ describe('createGroundStairBoundaryColliders', () => {
     expect(
       collidesWithColliders(23, -14.66, PLAYER_RADIUS, boundaryBounds)
     ).toBe(true);
+    expect(collidesWithColliders(23, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
+      true
+    );
   });
 
   it('keeps regular living-room positions east of the stairs clear', () => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -11,7 +11,6 @@ import {
 
 const PLAYER_RADIUS = 0.75;
 const EPSILON = 0.1;
-const CONTAINING_ROOM_MAX_X = 32;
 
 const geometry: StairGeometry = {
   centerX: 12.4,
@@ -37,7 +36,6 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
-    containingRoomMaxX: CONTAINING_ROOM_MAX_X,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -48,47 +46,26 @@ const rampMaxZ = Math.max(geometry.bottomZ, geometry.topZ);
 const lowerApproachZ =
   geometry.bottomZ - geometry.direction * behavior.transitionMargin;
 const lowerApproachMaxZ = Math.max(geometry.bottomZ, lowerApproachZ);
-const roomLaneX = stairEastX + (CONTAINING_ROOM_MAX_X - stairEastX) / 2;
+const eastBoundaryMaxX = Math.max(
+  ...boundaryColliders.map((collider) => collider.bounds.maxX)
+);
 
 describe('createGroundStairBoundaryColliders', () => {
-  it('names the ground stair blockers for debug visualization', () => {
+  it('names the local ground stair blockers for debug visualization', () => {
     const names = boundaryColliders.map((collider) => collider.name);
 
     expect(names).toEqual([
       'GroundStairEastBoundary',
       'GroundStairLowerCornerGuard',
-      'GroundStairEastRunSeal',
     ]);
+    expect(names).not.toContain('GroundStairEastRunSeal');
   });
 
-  it('seals the east-side stair-run band to the containing room edge', () => {
-    const stairRunZSamples = [
-      rampMinZ + EPSILON,
-      (rampMinZ + rampMaxZ) / 2,
-      rampMaxZ - EPSILON,
-    ];
-    const eastBandXSamples = [
-      stairEastX + EPSILON,
-      stairEastX + (CONTAINING_ROOM_MAX_X - stairEastX) * 0.25,
-      stairEastX + (CONTAINING_ROOM_MAX_X - stairEastX) * 0.5,
-      CONTAINING_ROOM_MAX_X - EPSILON,
-    ];
-
-    stairRunZSamples.forEach((z) => {
-      eastBandXSamples.forEach((x) => {
-        expect(collidesWithColliders(x, z, PLAYER_RADIUS, boundaryBounds)).toBe(
-          true
-        );
-      });
-    });
-  });
-
-  it('blocks representative east-side squeeze and route-around samples', () => {
+  it('blocks the reported stair-side squeeze samples', () => {
     const blockedSamples = [
       { x: 17.38, z: -8.84 },
       { x: 21.35, z: -14.66 },
       { x: 22.1, z: -14.66 },
-      { x: 24, z: -18 },
     ];
 
     blockedSamples.forEach((sample) => {
@@ -98,14 +75,24 @@ describe('createGroundStairBoundaryColliders', () => {
     });
   });
 
-  it('keeps living-room lanes outside the east-side seal band clear', () => {
+  it('keeps ordinary living-room space east of the local blocker clear', () => {
+    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
+      false
+    );
+  });
+
+  it('keeps living-room lanes outside the local stair-side blocker clear', () => {
     const clearSamples = [
       {
-        x: roomLaneX,
+        x: eastBoundaryMaxX + PLAYER_RADIUS + EPSILON,
+        z: (rampMinZ + rampMaxZ) / 2,
+      },
+      {
+        x: stairEastX + PLAYER_RADIUS + EPSILON,
         z: lowerApproachMaxZ + PLAYER_RADIUS + EPSILON,
       },
       {
-        x: roomLaneX,
+        x: stairEastX + PLAYER_RADIUS + EPSILON,
         z: rampMinZ - PLAYER_RADIUS - EPSILON,
       },
     ];

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,6 +35,7 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
+    eastApproachSealMaxX: 32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -44,6 +45,7 @@ describe('createGroundStairBoundaryColliders', () => {
     expect(boundaryColliders.map((collider) => collider.name)).toEqual([
       'GroundStairEastBoundary',
       'GroundStairLowerCornerGuard',
+      'GroundStairEastApproachSeal',
     ]);
   });
 
@@ -56,6 +58,9 @@ describe('createGroundStairBoundaryColliders', () => {
     ).toBe(true);
     expect(
       collidesWithColliders(22.1, -14.66, PLAYER_RADIUS, boundaryBounds)
+    ).toBe(true);
+    expect(
+      collidesWithColliders(23, -14.66, PLAYER_RADIUS, boundaryBounds)
     ).toBe(true);
   });
 

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -10,6 +10,7 @@ import {
 } from './stairs';
 
 const PLAYER_RADIUS = 0.75;
+const GROUND_FLOOR_EAST_WALL_X = 32;
 
 const geometry: StairGeometry = {
   centerX: 12.4,
@@ -35,6 +36,7 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
+    sealMaxX: GROUND_FLOOR_EAST_WALL_X,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -47,13 +49,24 @@ describe('createGroundStairBoundaryColliders', () => {
     ]);
   });
 
-  it('blocks the east-side squeeze samples near the ground stairs', () => {
+  it('seals the east-side squeeze route against the reachable ground-floor edge', () => {
     expect(
       collidesWithColliders(17.38, -8.84, PLAYER_RADIUS, boundaryBounds)
     ).toBe(true);
     expect(
       collidesWithColliders(21.35, -14.66, PLAYER_RADIUS, boundaryBounds)
     ).toBe(true);
+    expect(
+      collidesWithColliders(22.1, -14.66, PLAYER_RADIUS, boundaryBounds)
+    ).toBe(true);
+  });
+
+  it('extends the east stair boundary to the requested seal edge', () => {
+    const eastBoundary = boundaryColliders.find(
+      (collider) => collider.name === 'GroundStairEastBoundary'
+    );
+
+    expect(eastBoundary?.bounds.maxX).toBe(GROUND_FLOOR_EAST_WALL_X);
   });
 
   it('preserves the center lower entrance and ramp body', () => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { collidesWithColliders } from '../collision';
+
+import {
+  createGroundStairBoundaryColliders,
+  createStairNavigationZones,
+  type StairBehavior,
+  type StairGeometry,
+} from './stairs';
+
+const PLAYER_RADIUS = 0.75;
+
+const geometry: StairGeometry = {
+  centerX: 12.4,
+  halfWidth: 3.1,
+  bottomZ: -10.6,
+  topZ: -25.9,
+  landingMinZ: -31.1,
+  landingMaxZ: -25.9,
+  totalRise: 3.78,
+  direction: -1,
+};
+
+const behavior: StairBehavior = {
+  transitionMargin: 1.2,
+  landingTriggerMargin: 0.4,
+  stepRise: 0.42,
+  descentCorridorInset: PLAYER_RADIUS,
+};
+
+const boundaryColliders = createGroundStairBoundaryColliders(
+  geometry,
+  behavior,
+  {
+    playerRadius: PLAYER_RADIUS,
+    guardThickness: 0.44,
+  }
+);
+const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
+
+describe('createGroundStairBoundaryColliders', () => {
+  it('names the ground stair blockers for debug visualization', () => {
+    expect(boundaryColliders.map((collider) => collider.name)).toEqual([
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+    ]);
+  });
+
+  it('blocks the east-side squeeze samples near the ground stairs', () => {
+    expect(
+      collidesWithColliders(17.38, -8.84, PLAYER_RADIUS, boundaryBounds)
+    ).toBe(true);
+    expect(
+      collidesWithColliders(21.35, -14.66, PLAYER_RADIUS, boundaryBounds)
+    ).toBe(true);
+  });
+
+  it('preserves the center lower entrance and ramp body', () => {
+    const zones = createStairNavigationZones(geometry, behavior);
+    const validSamples = [
+      { x: geometry.centerX, z: geometry.bottomZ + 0.3 },
+      {
+        x: (zones.stairRampBody.minX + zones.stairRampBody.maxX) / 2,
+        z: (geometry.bottomZ + geometry.topZ) / 2,
+      },
+    ];
+
+    validSamples.forEach((sample) => {
+      expect(
+        collidesWithColliders(sample.x, sample.z, PLAYER_RADIUS, boundaryBounds)
+      ).toBe(false);
+    });
+  });
+});

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,7 +35,6 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
-    eastRunSealCapMaxX: 32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -75,10 +74,26 @@ describe('createGroundStairBoundaryColliders', () => {
     ).toBe(true);
   });
 
-  it('caps the run seal ends while keeping the middle living-room lane clear', () => {
+  it('keeps regular living-room lanes clear around localized seal caps', () => {
     expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
       false
     );
+    expect(
+      collidesWithColliders(
+        24,
+        geometry.topZ + PLAYER_RADIUS + 0.01,
+        PLAYER_RADIUS,
+        boundaryBounds
+      )
+    ).toBe(false);
+    expect(
+      collidesWithColliders(
+        24,
+        geometry.bottomZ - PLAYER_RADIUS - 0.01,
+        PLAYER_RADIUS,
+        boundaryBounds
+      )
+    ).toBe(false);
     expect(
       collidesWithColliders(
         24,
@@ -86,7 +101,7 @@ describe('createGroundStairBoundaryColliders', () => {
         PLAYER_RADIUS,
         boundaryBounds
       )
-    ).toBe(true);
+    ).toBe(false);
     expect(
       collidesWithColliders(
         24,
@@ -94,7 +109,7 @@ describe('createGroundStairBoundaryColliders', () => {
         PLAYER_RADIUS,
         boundaryBounds
       )
-    ).toBe(true);
+    ).toBe(false);
     expect(collidesWithColliders(24, -30, PLAYER_RADIUS, boundaryBounds)).toBe(
       false
     );

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,18 +35,22 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
-    eastRunSealMaxX: 32,
+    eastRunSealCapMaxX: 32,
+    eastRunSealLowerCapEndZ: -8,
+    eastRunSealUpperCapEndZ: -32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
 
 describe('createGroundStairBoundaryColliders', () => {
   it('names the ground stair blockers for debug visualization', () => {
-    expect(boundaryColliders.map((collider) => collider.name)).toEqual([
-      'GroundStairEastBoundary',
-      'GroundStairLowerCornerGuard',
-      'GroundStairEastRunSeal',
-    ]);
+    const names = boundaryColliders.map((collider) => collider.name);
+
+    expect(names).toContain('GroundStairEastBoundary');
+    expect(names).toContain('GroundStairLowerCornerGuard');
+    expect(names).toContain('GroundStairEastRunSeal');
+    expect(names).toContain('GroundStairEastRunSealLowerCap');
+    expect(names).toContain('GroundStairEastRunSealUpperCap');
   });
 
   it('blocks the east-side squeeze route without sealing the whole room', () => {
@@ -73,29 +77,25 @@ describe('createGroundStairBoundaryColliders', () => {
     ).toBe(true);
   });
 
-  it('seals the east stair-run lane while keeping non-run room space clear', () => {
+  it('keeps regular room lanes clear while sealing route-around caps', () => {
     expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
-      true
+      false
     );
     expect(
-      collidesWithColliders(
-        24,
-        geometry.topZ - PLAYER_RADIUS - 0.01,
-        PLAYER_RADIUS,
-        boundaryBounds
-      )
+      collidesWithColliders(24, -25.14, PLAYER_RADIUS, boundaryBounds)
     ).toBe(false);
     expect(
-      collidesWithColliders(
-        24,
-        geometry.bottomZ + PLAYER_RADIUS + 0.01,
-        PLAYER_RADIUS,
-        boundaryBounds
-      )
+      collidesWithColliders(24, -11.36, PLAYER_RADIUS, boundaryBounds)
     ).toBe(false);
     expect(collidesWithColliders(24, -30, PLAYER_RADIUS, boundaryBounds)).toBe(
       false
     );
+    expect(collidesWithColliders(28, -9.2, PLAYER_RADIUS, boundaryBounds)).toBe(
+      true
+    );
+    expect(
+      collidesWithColliders(28, -29.2, PLAYER_RADIUS, boundaryBounds)
+    ).toBe(true);
   });
 
   it('preserves the center lower entrance and ramp body', () => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,7 +35,6 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
-    eastRunSealMaxX: 32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -68,12 +67,15 @@ describe('createGroundStairBoundaryColliders', () => {
     expect(
       collidesWithColliders(23.91, -18, PLAYER_RADIUS, boundaryBounds)
     ).toBe(true);
-    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
-      true
-    );
+    expect(
+      collidesWithColliders(23.99, -18, PLAYER_RADIUS, boundaryBounds)
+    ).toBe(true);
   });
 
-  it('keeps living-room positions outside the stair run clear', () => {
+  it('keeps regular living-room positions clear', () => {
+    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
+      false
+    );
     expect(collidesWithColliders(24, -30, PLAYER_RADIUS, boundaryBounds)).toBe(
       false
     );

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -10,6 +10,8 @@ import {
 } from './stairs';
 
 const PLAYER_RADIUS = 0.75;
+const EPSILON = 0.1;
+const CONTAINING_ROOM_MAX_X = 32;
 
 const geometry: StairGeometry = {
   centerX: 12.4,
@@ -35,67 +37,84 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
-    eastRunSealCapMaxX: 32,
-    eastRunSealLowerCapEndZ: -8,
-    eastRunSealUpperCapEndZ: -32,
+    containingRoomMaxX: CONTAINING_ROOM_MAX_X,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
+
+const stairEastX = geometry.centerX + geometry.halfWidth;
+const rampMinZ = Math.min(geometry.bottomZ, geometry.topZ);
+const rampMaxZ = Math.max(geometry.bottomZ, geometry.topZ);
+const lowerApproachZ =
+  geometry.bottomZ - geometry.direction * behavior.transitionMargin;
+const lowerApproachMaxZ = Math.max(geometry.bottomZ, lowerApproachZ);
+const roomLaneX = stairEastX + (CONTAINING_ROOM_MAX_X - stairEastX) / 2;
 
 describe('createGroundStairBoundaryColliders', () => {
   it('names the ground stair blockers for debug visualization', () => {
     const names = boundaryColliders.map((collider) => collider.name);
 
-    expect(names).toContain('GroundStairEastBoundary');
-    expect(names).toContain('GroundStairLowerCornerGuard');
-    expect(names).toContain('GroundStairEastRunSeal');
-    expect(names).toContain('GroundStairEastRunSealLowerCap');
-    expect(names).toContain('GroundStairEastRunSealUpperCap');
+    expect(names).toEqual([
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+      'GroundStairEastRunSeal',
+    ]);
   });
 
-  it('blocks the east-side squeeze route without sealing the whole room', () => {
-    expect(
-      collidesWithColliders(17.38, -8.84, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(true);
-    expect(
-      collidesWithColliders(21.35, -14.66, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(true);
-    expect(
-      collidesWithColliders(22.1, -14.66, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(true);
-    expect(
-      collidesWithColliders(23, -14.66, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(true);
-    expect(collidesWithColliders(23, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
-      true
-    );
-    expect(
-      collidesWithColliders(23.91, -18, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(true);
-    expect(
-      collidesWithColliders(23.99, -18, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(true);
+  it('seals the east-side stair-run band to the containing room edge', () => {
+    const stairRunZSamples = [
+      rampMinZ + EPSILON,
+      (rampMinZ + rampMaxZ) / 2,
+      rampMaxZ - EPSILON,
+    ];
+    const eastBandXSamples = [
+      stairEastX + EPSILON,
+      stairEastX + (CONTAINING_ROOM_MAX_X - stairEastX) * 0.25,
+      stairEastX + (CONTAINING_ROOM_MAX_X - stairEastX) * 0.5,
+      CONTAINING_ROOM_MAX_X - EPSILON,
+    ];
+
+    stairRunZSamples.forEach((z) => {
+      eastBandXSamples.forEach((x) => {
+        expect(collidesWithColliders(x, z, PLAYER_RADIUS, boundaryBounds)).toBe(
+          true
+        );
+      });
+    });
   });
 
-  it('keeps regular room lanes clear while sealing route-around caps', () => {
-    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
-      false
-    );
-    expect(
-      collidesWithColliders(24, -25.14, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(false);
-    expect(
-      collidesWithColliders(24, -11.36, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(false);
-    expect(collidesWithColliders(24, -30, PLAYER_RADIUS, boundaryBounds)).toBe(
-      false
-    );
-    expect(collidesWithColliders(28, -9.2, PLAYER_RADIUS, boundaryBounds)).toBe(
-      true
-    );
-    expect(
-      collidesWithColliders(28, -29.2, PLAYER_RADIUS, boundaryBounds)
-    ).toBe(true);
+  it('blocks representative east-side squeeze and route-around samples', () => {
+    const blockedSamples = [
+      { x: 17.38, z: -8.84 },
+      { x: 21.35, z: -14.66 },
+      { x: 22.1, z: -14.66 },
+      { x: 24, z: -18 },
+    ];
+
+    blockedSamples.forEach((sample) => {
+      expect(
+        collidesWithColliders(sample.x, sample.z, PLAYER_RADIUS, boundaryBounds)
+      ).toBe(true);
+    });
+  });
+
+  it('keeps living-room lanes outside the east-side seal band clear', () => {
+    const clearSamples = [
+      {
+        x: roomLaneX,
+        z: lowerApproachMaxZ + PLAYER_RADIUS + EPSILON,
+      },
+      {
+        x: roomLaneX,
+        z: rampMinZ - PLAYER_RADIUS - EPSILON,
+      },
+    ];
+
+    clearSamples.forEach((sample) => {
+      expect(
+        collidesWithColliders(sample.x, sample.z, PLAYER_RADIUS, boundaryBounds)
+      ).toBe(false);
+    });
   });
 
   it('preserves the center lower entrance and ramp body', () => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -10,7 +10,6 @@ import {
 } from './stairs';
 
 const PLAYER_RADIUS = 0.75;
-const GROUND_FLOOR_EAST_WALL_X = 32;
 
 const geometry: StairGeometry = {
   centerX: 12.4,
@@ -36,7 +35,6 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
-    sealMaxX: GROUND_FLOOR_EAST_WALL_X,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -49,7 +47,7 @@ describe('createGroundStairBoundaryColliders', () => {
     ]);
   });
 
-  it('seals the east-side squeeze route against the reachable ground-floor edge', () => {
+  it('blocks the east-side squeeze route without sealing the whole room', () => {
     expect(
       collidesWithColliders(17.38, -8.84, PLAYER_RADIUS, boundaryBounds)
     ).toBe(true);
@@ -61,12 +59,10 @@ describe('createGroundStairBoundaryColliders', () => {
     ).toBe(true);
   });
 
-  it('extends the east stair boundary to the requested seal edge', () => {
-    const eastBoundary = boundaryColliders.find(
-      (collider) => collider.name === 'GroundStairEastBoundary'
+  it('keeps regular living-room positions east of the stairs clear', () => {
+    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
+      false
     );
-
-    expect(eastBoundary?.bounds.maxX).toBe(GROUND_FLOOR_EAST_WALL_X);
   });
 
   it('preserves the center lower entrance and ramp body', () => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,6 +35,7 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
+    eastRunSealMaxX: 32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -67,10 +68,13 @@ describe('createGroundStairBoundaryColliders', () => {
     expect(
       collidesWithColliders(23.91, -18, PLAYER_RADIUS, boundaryBounds)
     ).toBe(true);
+    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
+      true
+    );
   });
 
-  it('keeps regular living-room positions east of the stairs clear', () => {
-    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
+  it('keeps living-room positions outside the stair run clear', () => {
+    expect(collidesWithColliders(24, -30, PLAYER_RADIUS, boundaryBounds)).toBe(
       false
     );
   });

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -35,6 +35,7 @@ const boundaryColliders = createGroundStairBoundaryColliders(
   {
     playerRadius: PLAYER_RADIUS,
     guardThickness: 0.44,
+    eastRunSealMaxX: 32,
   }
 );
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
@@ -45,8 +46,6 @@ describe('createGroundStairBoundaryColliders', () => {
       'GroundStairEastBoundary',
       'GroundStairLowerCornerGuard',
       'GroundStairEastRunSeal',
-      'GroundStairEastRunSealTopCap',
-      'GroundStairEastRunSealBottomCap',
     ]);
   });
 
@@ -74,14 +73,14 @@ describe('createGroundStairBoundaryColliders', () => {
     ).toBe(true);
   });
 
-  it('keeps regular living-room lanes clear around localized seal caps', () => {
+  it('seals the east stair-run lane while keeping non-run room space clear', () => {
     expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
-      false
+      true
     );
     expect(
       collidesWithColliders(
         24,
-        geometry.topZ + PLAYER_RADIUS + 0.01,
+        geometry.topZ - PLAYER_RADIUS - 0.01,
         PLAYER_RADIUS,
         boundaryBounds
       )
@@ -89,23 +88,7 @@ describe('createGroundStairBoundaryColliders', () => {
     expect(
       collidesWithColliders(
         24,
-        geometry.bottomZ - PLAYER_RADIUS - 0.01,
-        PLAYER_RADIUS,
-        boundaryBounds
-      )
-    ).toBe(false);
-    expect(
-      collidesWithColliders(
-        24,
-        geometry.topZ - 0.05,
-        PLAYER_RADIUS,
-        boundaryBounds
-      )
-    ).toBe(false);
-    expect(
-      collidesWithColliders(
-        24,
-        geometry.bottomZ + 0.05,
+        geometry.bottomZ + PLAYER_RADIUS + 0.01,
         PLAYER_RADIUS,
         boundaryBounds
       )

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -76,9 +76,16 @@ describe('createGroundStairBoundaryColliders', () => {
   });
 
   it('keeps ordinary living-room space east of the local blocker clear', () => {
-    expect(collidesWithColliders(24, -18, PLAYER_RADIUS, boundaryBounds)).toBe(
-      false
-    );
+    const clearSamples = [
+      { x: 23, z: -18 },
+      { x: 24, z: -18 },
+    ];
+
+    clearSamples.forEach((sample) => {
+      expect(
+        collidesWithColliders(sample.x, sample.z, PLAYER_RADIUS, boundaryBounds)
+      ).toBe(false);
+    });
   });
 
   it('keeps living-room lanes outside the local stair-side blocker clear', () => {

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -56,11 +56,17 @@ export interface GroundStairBoundaryColliderOptions {
    */
   eastBoundaryMaxX?: number;
   /**
-   * Optional east-most X coordinate for the stair-run seal. The seal must end
-   * at a real boundary, otherwise players can step just beyond the finite edge
-   * and continue through the same stair-run squeeze lane.
+   * Optional east-most X coordinate for the local stair-run seal. Keep this
+   * near the stair-side squeeze lane; use the cap options below to connect the
+   * seal to room edges without filling the whole ramp band.
    */
   eastRunSealMaxX?: number;
+  /** East-most X coordinate where diagonal seal caps terminate. */
+  eastRunSealCapMaxX?: number;
+  /** Z coordinate where the lower stair-run cap terminates at a room edge. */
+  eastRunSealLowerCapEndZ?: number;
+  /** Z coordinate where the upper stair-run cap terminates at a room edge. */
+  eastRunSealUpperCapEndZ?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -118,6 +124,43 @@ const isWithinPhysicalStairWidth = (
   geometry: StairGeometry,
   x: number
 ): boolean => Math.abs(x - geometry.centerX) <= geometry.halfWidth;
+
+const createSteppedSealCapColliders = (
+  name: string,
+  startX: number,
+  startZ: number,
+  endX: number,
+  endZ: number,
+  guardThickness: number,
+  playerRadius: number
+): NamedStairBoundaryCollider[] => {
+  if (endX <= startX || Math.abs(endZ - startZ) <= DENOMINATOR_EPSILON) {
+    return [];
+  }
+
+  const spanX = endX - startX;
+  const segmentCount = Math.max(4, Math.ceil(spanX / (playerRadius * 0.3)));
+  const halfThickness = Math.max(guardThickness * 0.05, 0.01);
+
+  return Array.from({ length: segmentCount }, (_, index) => {
+    const startT = index / segmentCount;
+    const endT = (index + 1) / segmentCount;
+    const segmentMinX = startX + spanX * startT;
+    const segmentMaxX = startX + spanX * endT;
+    const segmentStartZ = startZ + (endZ - startZ) * startT;
+    const segmentEndZ = startZ + (endZ - startZ) * endT;
+
+    return {
+      name,
+      bounds: {
+        minX: segmentMinX,
+        maxX: segmentMaxX,
+        minZ: getMinZ(segmentStartZ, segmentEndZ) - halfThickness,
+        maxZ: getMaxZ(segmentStartZ, segmentEndZ) + halfThickness,
+      },
+    };
+  });
+};
 
 export const isWithinStairWidth = (
   geometry: StairGeometry,
@@ -238,12 +281,12 @@ export const createGroundStairBoundaryColliders = (
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
-  // Seal the east-side stair run as a filled strip through the whole ramp
-  // band. A finite line or localized cap only moves the bypass point farther
-  // east; callers can extend this to the room edge so the seal terminates at a
-  // real boundary instead of leaving a route-around gap.
+  // Keep the east-side stair-run seal local so ordinary living-room
+  // positions remain occupiable. Diagonal caps can then terminate the local
+  // seal at the room edges without creating full-width horizontal walls after
+  // player-radius expansion.
   const fallbackEastRunSealMaxX =
-    eastBoundaryMaxX + options.playerRadius + options.guardThickness * 0.5;
+    eastBoundaryMaxX + options.playerRadius + options.guardThickness * 0.72;
   const eastRunSealMaxX = Math.max(
     fallbackEastRunSealMaxX,
     options.eastRunSealMaxX ?? fallbackEastRunSealMaxX
@@ -260,6 +303,30 @@ export const createGroundStairBoundaryColliders = (
               maxZ: rampMaxZ,
             },
           },
+        ]
+      : [];
+  const eastRunSealCapMaxX = options.eastRunSealCapMaxX ?? eastRunSealMaxX;
+  const eastRunSealCapColliders =
+    eastRunSealCapMaxX > eastRunSealMaxX
+      ? [
+          ...createSteppedSealCapColliders(
+            'GroundStairEastRunSealLowerCap',
+            eastRunSealMaxX,
+            rampMaxZ,
+            eastRunSealCapMaxX,
+            options.eastRunSealLowerCapEndZ ?? rampMaxZ,
+            options.guardThickness,
+            options.playerRadius
+          ),
+          ...createSteppedSealCapColliders(
+            'GroundStairEastRunSealUpperCap',
+            eastRunSealMaxX,
+            rampMinZ,
+            eastRunSealCapMaxX,
+            options.eastRunSealUpperCapEndZ ?? rampMinZ,
+            options.guardThickness,
+            options.playerRadius
+          ),
         ]
       : [];
 
@@ -283,6 +350,7 @@ export const createGroundStairBoundaryColliders = (
       },
     },
     ...eastRunSealColliders,
+    ...eastRunSealCapColliders,
   ];
 };
 

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -56,9 +56,9 @@ export interface GroundStairBoundaryColliderOptions {
    */
   eastBoundaryMaxX?: number;
   /**
-   * Optional east-most X coordinate for the full-run east seal. Keep this
-   * localized to the bypass lane; using a room edge would overblock the
-   * living-room floor beside the stairs.
+   * Optional east-most X coordinate for the full-run east seal. Pass the
+   * reachable room edge when no nearer physical obstacle can terminate the
+   * barrier; otherwise a finite edge remains routeable around the stair run.
    */
   eastRunSealMaxX?: number;
 }
@@ -238,10 +238,8 @@ export const createGroundStairBoundaryColliders = (
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
-  // The run seal needs to cover the player's collision radius around the
-  // outer edge as well as the visible guard width. Add a small fraction of the
-  // player radius so samples just beyond the previous finite edge still touch
-  // the seal, while keeping the seal below the regular living-room lane.
+  // The run seal must terminate at an actual obstacle or room edge. Padding
+  // only moves the finite edge and leaves another reachable bypass sample.
   const eastRunSealEdgePadding = options.playerRadius * 0.12;
   const fallbackEastRunSealMaxX =
     eastBoundaryMaxX +

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -50,6 +50,12 @@ export interface NamedStairBoundaryCollider {
 export interface GroundStairBoundaryColliderOptions {
   playerRadius: number;
   guardThickness: number;
+  /**
+   * East-most reachable ground-floor X coordinate to seal against. When
+   * provided, the boundary extends to this edge so players cannot route
+   * around the blocker's finite outer side.
+   */
+  sealMaxX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -215,11 +221,15 @@ export const createGroundStairBoundaryColliders = (
   const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
   const stairEastX = geometry.centerX + geometry.halfWidth;
   const eastBoundaryMinX = stairEastX + options.guardThickness;
-  const eastBoundaryMaxX =
+  const fallbackEastBoundaryMaxX =
     stairEastX +
     geometry.halfWidth +
     behavior.transitionMargin +
     options.playerRadius * 2;
+  const eastBoundaryMaxX = Math.max(
+    fallbackEastBoundaryMaxX,
+    options.sealMaxX ?? fallbackEastBoundaryMaxX
+  );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
 

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -51,11 +51,10 @@ export interface GroundStairBoundaryColliderOptions {
   playerRadius: number;
   guardThickness: number;
   /**
-   * East-most reachable ground-floor X coordinate to seal against. When
-   * provided, the boundary extends to this edge so players cannot route
-   * around the blocker's finite outer side.
+   * Optional east-most X coordinate for the stair-side blocker. Keep this
+   * localized to the squeeze seam so regular living-room space stays usable.
    */
-  sealMaxX?: number;
+  eastBoundaryMaxX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -225,10 +224,11 @@ export const createGroundStairBoundaryColliders = (
     stairEastX +
     geometry.halfWidth +
     behavior.transitionMargin +
-    options.playerRadius * 2;
+    options.playerRadius * 2 +
+    options.guardThickness * 2;
   const eastBoundaryMaxX = Math.max(
     fallbackEastBoundaryMaxX,
-    options.sealMaxX ?? fallbackEastBoundaryMaxX
+    options.eastBoundaryMaxX ?? fallbackEastBoundaryMaxX
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -238,8 +238,16 @@ export const createGroundStairBoundaryColliders = (
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
+  // The run seal needs to cover the player's collision radius around the
+  // outer edge as well as the visible guard width. Add a small fraction of the
+  // player radius so samples just beyond the previous finite edge still touch
+  // the seal, while keeping the seal below the regular living-room lane.
+  const eastRunSealEdgePadding = options.playerRadius * 0.12;
   const fallbackEastRunSealMaxX =
-    eastBoundaryMaxX + options.playerRadius + options.guardThickness * 0.5;
+    eastBoundaryMaxX +
+    options.playerRadius +
+    options.guardThickness * 0.5 +
+    eastRunSealEdgePadding;
   const eastRunSealMaxX = Math.max(
     fallbackEastRunSealMaxX,
     options.eastRunSealMaxX ?? fallbackEastRunSealMaxX

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -51,22 +51,13 @@ export interface GroundStairBoundaryColliderOptions {
   playerRadius: number;
   guardThickness: number;
   /**
-   * Optional east-most X coordinate for the stair-side blocker. Keep this
-   * localized to the squeeze seam so regular living-room space stays usable.
+   * East-most X coordinate for the containing room edge that closes the
+   * stair-run no-go band. This should be the local room boundary, not a global
+   * floor edge, unless those are the same physical edge.
    */
+  containingRoomMaxX: number;
+  /** Optional east-most X coordinate for the local stair-side blocker. */
   eastBoundaryMaxX?: number;
-  /**
-   * Optional east-most X coordinate for the local stair-run seal. Keep this
-   * near the stair-side squeeze lane; use the cap options below to connect the
-   * seal to room edges without filling the whole ramp band.
-   */
-  eastRunSealMaxX?: number;
-  /** East-most X coordinate where diagonal seal caps terminate. */
-  eastRunSealCapMaxX?: number;
-  /** Z coordinate where the lower stair-run cap terminates at a room edge. */
-  eastRunSealLowerCapEndZ?: number;
-  /** Z coordinate where the upper stair-run cap terminates at a room edge. */
-  eastRunSealUpperCapEndZ?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -124,43 +115,6 @@ const isWithinPhysicalStairWidth = (
   geometry: StairGeometry,
   x: number
 ): boolean => Math.abs(x - geometry.centerX) <= geometry.halfWidth;
-
-const createSteppedSealCapColliders = (
-  name: string,
-  startX: number,
-  startZ: number,
-  endX: number,
-  endZ: number,
-  guardThickness: number,
-  playerRadius: number
-): NamedStairBoundaryCollider[] => {
-  if (endX <= startX || Math.abs(endZ - startZ) <= DENOMINATOR_EPSILON) {
-    return [];
-  }
-
-  const spanX = endX - startX;
-  const segmentCount = Math.max(4, Math.ceil(spanX / (playerRadius * 0.3)));
-  const halfThickness = Math.max(guardThickness * 0.05, 0.01);
-
-  return Array.from({ length: segmentCount }, (_, index) => {
-    const startT = index / segmentCount;
-    const endT = (index + 1) / segmentCount;
-    const segmentMinX = startX + spanX * startT;
-    const segmentMaxX = startX + spanX * endT;
-    const segmentStartZ = startZ + (endZ - startZ) * startT;
-    const segmentEndZ = startZ + (endZ - startZ) * endT;
-
-    return {
-      name,
-      bounds: {
-        minX: segmentMinX,
-        maxX: segmentMaxX,
-        minZ: getMinZ(segmentStartZ, segmentEndZ) - halfThickness,
-        maxZ: getMaxZ(segmentStartZ, segmentEndZ) + halfThickness,
-      },
-    };
-  });
-};
 
 export const isWithinStairWidth = (
   geometry: StairGeometry,
@@ -279,58 +233,13 @@ export const createGroundStairBoundaryColliders = (
     fallbackEastBoundaryMaxX,
     options.eastBoundaryMaxX ?? fallbackEastBoundaryMaxX
   );
+  const eastRunSealMaxX = Math.max(
+    eastBoundaryMaxX,
+    options.containingRoomMaxX
+  );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
-  // Keep the east-side stair-run seal local so ordinary living-room
-  // positions remain occupiable. Diagonal caps can then terminate the local
-  // seal at the room edges without creating full-width horizontal walls after
-  // player-radius expansion.
-  const fallbackEastRunSealMaxX =
-    eastBoundaryMaxX + options.playerRadius + options.guardThickness * 0.72;
-  const eastRunSealMaxX = Math.max(
-    fallbackEastRunSealMaxX,
-    options.eastRunSealMaxX ?? fallbackEastRunSealMaxX
-  );
-  const eastRunSealColliders: NamedStairBoundaryCollider[] =
-    eastRunSealMaxX > eastBoundaryMaxX
-      ? [
-          {
-            name: 'GroundStairEastRunSeal',
-            bounds: {
-              minX: eastBoundaryMaxX,
-              maxX: eastRunSealMaxX,
-              minZ: rampMinZ,
-              maxZ: rampMaxZ,
-            },
-          },
-        ]
-      : [];
-  const eastRunSealCapMaxX = options.eastRunSealCapMaxX ?? eastRunSealMaxX;
-  const eastRunSealCapColliders =
-    eastRunSealCapMaxX > eastRunSealMaxX
-      ? [
-          ...createSteppedSealCapColliders(
-            'GroundStairEastRunSealLowerCap',
-            eastRunSealMaxX,
-            rampMaxZ,
-            eastRunSealCapMaxX,
-            options.eastRunSealLowerCapEndZ ?? rampMaxZ,
-            options.guardThickness,
-            options.playerRadius
-          ),
-          ...createSteppedSealCapColliders(
-            'GroundStairEastRunSealUpperCap',
-            eastRunSealMaxX,
-            rampMinZ,
-            eastRunSealCapMaxX,
-            options.eastRunSealUpperCapEndZ ?? rampMinZ,
-            options.guardThickness,
-            options.playerRadius
-          ),
-        ]
-      : [];
-
-  return [
+  const colliders: NamedStairBoundaryCollider[] = [
     {
       name: 'GroundStairEastBoundary',
       bounds: {
@@ -349,9 +258,21 @@ export const createGroundStairBoundaryColliders = (
         maxZ: getMaxZ(geometry.bottomZ, lowerApproachZ),
       },
     },
-    ...eastRunSealColliders,
-    ...eastRunSealCapColliders,
   ];
+
+  if (eastRunSealMaxX > eastBoundaryMaxX) {
+    colliders.push({
+      name: 'GroundStairEastRunSeal',
+      bounds: {
+        minX: eastBoundaryMaxX,
+        maxX: eastRunSealMaxX,
+        minZ: rampMinZ,
+        maxZ: rampMaxZ,
+      },
+    });
+  }
+
+  return colliders;
 };
 
 const isInExplicitDescentCorridor = (

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -50,12 +50,6 @@ export interface NamedStairBoundaryCollider {
 export interface GroundStairBoundaryColliderOptions {
   playerRadius: number;
   guardThickness: number;
-  /**
-   * East-most X coordinate for the containing room edge that closes the
-   * stair-run no-go band. This should be the local room boundary, not a global
-   * floor edge, unless those are the same physical edge.
-   */
-  containingRoomMaxX: number;
   /** Optional east-most X coordinate for the local stair-side blocker. */
   eastBoundaryMaxX?: number;
 }
@@ -233,12 +227,10 @@ export const createGroundStairBoundaryColliders = (
     fallbackEastBoundaryMaxX,
     options.eastBoundaryMaxX ?? fallbackEastBoundaryMaxX
   );
-  const eastRunSealMaxX = Math.max(
-    eastBoundaryMaxX,
-    options.containingRoomMaxX
-  );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
+  // Keep the blocker local: east-of-blocker living-room space is
+  // intentionally still navigable, so do not seal this to the room edge.
   const colliders: NamedStairBoundaryCollider[] = [
     {
       name: 'GroundStairEastBoundary',
@@ -259,18 +251,6 @@ export const createGroundStairBoundaryColliders = (
       },
     },
   ];
-
-  if (eastRunSealMaxX > eastBoundaryMaxX) {
-    colliders.push({
-      name: 'GroundStairEastRunSeal',
-      bounds: {
-        minX: eastBoundaryMaxX,
-        maxX: eastRunSealMaxX,
-        minZ: rampMinZ,
-        maxZ: rampMaxZ,
-      },
-    });
-  }
 
   return colliders;
 };

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -60,6 +60,12 @@ export interface GroundStairBoundaryColliderOptions {
    * crossing around the stair-side blocker without filling the living room.
    */
   eastRunSealX?: number;
+  /**
+   * Optional east-most X coordinate for thin caps at each end of the run seal.
+   * These caps should terminate at a nearby obstacle or room edge so the seal
+   * cannot be routed around while the middle of the living room stays open.
+   */
+  eastRunSealCapMaxX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -255,6 +261,10 @@ export const createGroundStairBoundaryColliders = (
     options.guardThickness * 0.05,
     0.02
   );
+  const eastRunSealCapMaxX = Math.max(
+    eastRunSealX,
+    options.eastRunSealCapMaxX ?? eastRunSealX
+  );
   const eastRunSealColliders: NamedStairBoundaryCollider[] =
     eastRunSealX > eastBoundaryMaxX
       ? [
@@ -264,6 +274,24 @@ export const createGroundStairBoundaryColliders = (
               minX: eastRunSealX - eastRunSealVisualThickness,
               maxX: eastRunSealX,
               minZ: rampMinZ,
+              maxZ: rampMaxZ,
+            },
+          },
+          {
+            name: 'GroundStairEastRunSealTopCap',
+            bounds: {
+              minX: eastBoundaryMaxX,
+              maxX: eastRunSealCapMaxX,
+              minZ: rampMinZ,
+              maxZ: rampMinZ + eastRunSealVisualThickness,
+            },
+          },
+          {
+            name: 'GroundStairEastRunSealBottomCap',
+            bounds: {
+              minX: eastBoundaryMaxX,
+              maxX: eastRunSealCapMaxX,
+              minZ: rampMaxZ - eastRunSealVisualThickness,
               maxZ: rampMaxZ,
             },
           },

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -56,11 +56,10 @@ export interface GroundStairBoundaryColliderOptions {
    */
   eastBoundaryMaxX?: number;
   /**
-   * Optional east-most X coordinate for the full-run east seal. Pass the
-   * reachable room edge when no nearer physical obstacle can terminate the
-   * barrier; otherwise a finite edge remains routeable around the stair run.
+   * Optional X coordinate for a thin run seal that prevents players from
+   * crossing around the stair-side blocker without filling the living room.
    */
-  eastRunSealMaxX?: number;
+  eastRunSealX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -238,26 +237,32 @@ export const createGroundStairBoundaryColliders = (
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
-  // The run seal must terminate at an actual obstacle or room edge. Padding
-  // only moves the finite edge and leaves another reachable bypass sample.
-  const eastRunSealEdgePadding = options.playerRadius * 0.12;
-  const fallbackEastRunSealMaxX =
+  // Keep the run seal as a thin local edge instead of a filled strip. A wide
+  // seal to the room edge closes bypasses but also turns normal living-room
+  // positions into an invisible wall.
+  const eastRunSealClearanceEpsilon = 0.001;
+  const fallbackEastRunSealX =
     eastBoundaryMaxX +
     options.playerRadius +
     options.guardThickness * 0.5 +
-    eastRunSealEdgePadding;
-  const eastRunSealMaxX = Math.max(
-    fallbackEastRunSealMaxX,
-    options.eastRunSealMaxX ?? fallbackEastRunSealMaxX
+    options.playerRadius * (2 / 15) -
+    eastRunSealClearanceEpsilon;
+  const eastRunSealX = Math.max(
+    fallbackEastRunSealX,
+    options.eastRunSealX ?? fallbackEastRunSealX
+  );
+  const eastRunSealVisualThickness = Math.min(
+    options.guardThickness * 0.05,
+    0.02
   );
   const eastRunSealColliders: NamedStairBoundaryCollider[] =
-    eastRunSealMaxX > eastBoundaryMaxX
+    eastRunSealX > eastBoundaryMaxX
       ? [
           {
             name: 'GroundStairEastRunSeal',
             bounds: {
-              minX: eastBoundaryMinX,
-              maxX: eastRunSealMaxX,
+              minX: eastRunSealX - eastRunSealVisualThickness,
+              maxX: eastRunSealX,
               minZ: rampMinZ,
               maxZ: rampMaxZ,
             },

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -42,6 +42,16 @@ export interface StairNavigationZones {
   explicitDescentCorridor: RectCollider;
 }
 
+export interface NamedStairBoundaryCollider {
+  name: string;
+  bounds: RectCollider;
+}
+
+export interface GroundStairBoundaryColliderOptions {
+  playerRadius: number;
+  guardThickness: number;
+}
+
 const DENOMINATOR_EPSILON = 1e-6;
 
 const getMinZ = (...values: number[]): number => Math.min(...values);
@@ -194,6 +204,45 @@ export const createStairNavigationZones = (
       rampMaxZ
     ),
   };
+};
+
+export const createGroundStairBoundaryColliders = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  options: GroundStairBoundaryColliderOptions
+): NamedStairBoundaryCollider[] => {
+  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
+  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
+  const stairEastX = geometry.centerX + geometry.halfWidth;
+  const eastBoundaryMinX = stairEastX + options.guardThickness;
+  const eastBoundaryMaxX =
+    stairEastX +
+    geometry.halfWidth +
+    behavior.transitionMargin +
+    options.playerRadius * 2;
+  const lowerApproachZ =
+    geometry.bottomZ - geometry.direction * behavior.transitionMargin;
+
+  return [
+    {
+      name: 'GroundStairEastBoundary',
+      bounds: {
+        minX: eastBoundaryMinX,
+        maxX: eastBoundaryMaxX,
+        minZ: rampMinZ,
+        maxZ: rampMaxZ,
+      },
+    },
+    {
+      name: 'GroundStairLowerCornerGuard',
+      bounds: {
+        minX: stairEastX,
+        maxX: eastBoundaryMaxX,
+        minZ: getMinZ(geometry.bottomZ, lowerApproachZ),
+        maxZ: getMaxZ(geometry.bottomZ, lowerApproachZ),
+      },
+    },
+  ];
 };
 
 const isInExplicitDescentCorridor = (

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -56,17 +56,11 @@ export interface GroundStairBoundaryColliderOptions {
    */
   eastBoundaryMaxX?: number;
   /**
-   * Optional X coordinate for a thin run seal that prevents players from
-   * crossing around the stair-side blocker without filling the living room.
+   * Optional east-most X coordinate for the stair-run seal. The seal must end
+   * at a real boundary, otherwise players can step just beyond the finite edge
+   * and continue through the same stair-run squeeze lane.
    */
-  eastRunSealX?: number;
-  /**
-   * Optional east-most X coordinate for thin caps at each end of the run seal.
-   * Keep this localized; using the full room edge creates invisible horizontal
-   * walls across reachable living-room space once player-radius expansion is
-   * applied.
-   */
-  eastRunSealCapMaxX?: number;
+  eastRunSealMaxX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -244,56 +238,25 @@ export const createGroundStairBoundaryColliders = (
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
-  // Keep the run seal as a thin local edge instead of a filled strip. A wide
-  // seal to the room edge closes bypasses but also turns normal living-room
-  // positions into an invisible wall.
-  const eastRunSealClearanceEpsilon = 0.001;
-  const fallbackEastRunSealX =
-    eastBoundaryMaxX +
-    options.playerRadius +
-    options.guardThickness * 0.5 +
-    options.playerRadius * (2 / 15) -
-    eastRunSealClearanceEpsilon;
-  const eastRunSealX = Math.max(
-    fallbackEastRunSealX,
-    options.eastRunSealX ?? fallbackEastRunSealX
-  );
-  const eastRunSealVisualThickness = Math.min(
-    options.guardThickness * 0.05,
-    0.02
-  );
-  const fallbackEastRunSealCapMaxX = eastRunSealX;
-  const eastRunSealCapMaxX = Math.max(
-    fallbackEastRunSealCapMaxX,
-    options.eastRunSealCapMaxX ?? fallbackEastRunSealCapMaxX
+  // Seal the east-side stair run as a filled strip through the whole ramp
+  // band. A finite line or localized cap only moves the bypass point farther
+  // east; callers can extend this to the room edge so the seal terminates at a
+  // real boundary instead of leaving a route-around gap.
+  const fallbackEastRunSealMaxX =
+    eastBoundaryMaxX + options.playerRadius + options.guardThickness * 0.5;
+  const eastRunSealMaxX = Math.max(
+    fallbackEastRunSealMaxX,
+    options.eastRunSealMaxX ?? fallbackEastRunSealMaxX
   );
   const eastRunSealColliders: NamedStairBoundaryCollider[] =
-    eastRunSealX > eastBoundaryMaxX
+    eastRunSealMaxX > eastBoundaryMaxX
       ? [
           {
             name: 'GroundStairEastRunSeal',
             bounds: {
-              minX: eastRunSealX - eastRunSealVisualThickness,
-              maxX: eastRunSealX,
-              minZ: rampMinZ,
-              maxZ: rampMaxZ,
-            },
-          },
-          {
-            name: 'GroundStairEastRunSealTopCap',
-            bounds: {
               minX: eastBoundaryMaxX,
-              maxX: eastRunSealCapMaxX,
+              maxX: eastRunSealMaxX,
               minZ: rampMinZ,
-              maxZ: rampMinZ + eastRunSealVisualThickness,
-            },
-          },
-          {
-            name: 'GroundStairEastRunSealBottomCap',
-            bounds: {
-              minX: eastBoundaryMaxX,
-              maxX: eastRunSealCapMaxX,
-              minZ: rampMaxZ - eastRunSealVisualThickness,
               maxZ: rampMaxZ,
             },
           },

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -62,8 +62,9 @@ export interface GroundStairBoundaryColliderOptions {
   eastRunSealX?: number;
   /**
    * Optional east-most X coordinate for thin caps at each end of the run seal.
-   * These caps should terminate at a nearby obstacle or room edge so the seal
-   * cannot be routed around while the middle of the living room stays open.
+   * Keep this localized; using the full room edge creates invisible horizontal
+   * walls across reachable living-room space once player-radius expansion is
+   * applied.
    */
   eastRunSealCapMaxX?: number;
 }
@@ -261,9 +262,10 @@ export const createGroundStairBoundaryColliders = (
     options.guardThickness * 0.05,
     0.02
   );
+  const fallbackEastRunSealCapMaxX = eastRunSealX;
   const eastRunSealCapMaxX = Math.max(
-    eastRunSealX,
-    options.eastRunSealCapMaxX ?? eastRunSealX
+    fallbackEastRunSealCapMaxX,
+    options.eastRunSealCapMaxX ?? fallbackEastRunSealCapMaxX
   );
   const eastRunSealColliders: NamedStairBoundaryCollider[] =
     eastRunSealX > eastBoundaryMaxX

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -55,6 +55,11 @@ export interface GroundStairBoundaryColliderOptions {
    * localized to the squeeze seam so regular living-room space stays usable.
    */
   eastBoundaryMaxX?: number;
+  /**
+   * Optional east-most X coordinate for a lower-run seal that closes the
+   * bypass lane only near the bottom stair approach instead of the full room.
+   */
+  eastApproachSealMaxX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -232,6 +237,28 @@ export const createGroundStairBoundaryColliders = (
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
+  const lowerRunSealDepth =
+    behavior.transitionMargin * 4 + options.playerRadius;
+  const lowerRunSealFarZ =
+    geometry.bottomZ + geometry.direction * lowerRunSealDepth;
+  const eastApproachSealMaxX = Math.max(
+    eastBoundaryMaxX,
+    options.eastApproachSealMaxX ?? eastBoundaryMaxX
+  );
+  const eastApproachSealColliders: NamedStairBoundaryCollider[] =
+    eastApproachSealMaxX > eastBoundaryMaxX
+      ? [
+          {
+            name: 'GroundStairEastApproachSeal',
+            bounds: {
+              minX: eastBoundaryMinX,
+              maxX: eastApproachSealMaxX,
+              minZ: getMinZ(geometry.bottomZ, lowerRunSealFarZ),
+              maxZ: getMaxZ(geometry.bottomZ, lowerRunSealFarZ),
+            },
+          },
+        ]
+      : [];
 
   return [
     {
@@ -252,6 +279,7 @@ export const createGroundStairBoundaryColliders = (
         maxZ: getMaxZ(geometry.bottomZ, lowerApproachZ),
       },
     },
+    ...eastApproachSealColliders,
   ];
 };
 

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -56,10 +56,11 @@ export interface GroundStairBoundaryColliderOptions {
    */
   eastBoundaryMaxX?: number;
   /**
-   * Optional east-most X coordinate for a lower-run seal that closes the
-   * bypass lane only near the bottom stair approach instead of the full room.
+   * Optional east-most X coordinate for the full-run east seal. Keep this
+   * localized to the bypass lane; using a room edge would overblock the
+   * living-room floor beside the stairs.
    */
-  eastApproachSealMaxX?: number;
+  eastRunSealMaxX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -237,24 +238,22 @@ export const createGroundStairBoundaryColliders = (
   );
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
-  const lowerRunSealDepth =
-    behavior.transitionMargin * 4 + options.playerRadius;
-  const lowerRunSealFarZ =
-    geometry.bottomZ + geometry.direction * lowerRunSealDepth;
-  const eastApproachSealMaxX = Math.max(
-    eastBoundaryMaxX,
-    options.eastApproachSealMaxX ?? eastBoundaryMaxX
+  const fallbackEastRunSealMaxX =
+    eastBoundaryMaxX + options.playerRadius + options.guardThickness * 0.5;
+  const eastRunSealMaxX = Math.max(
+    fallbackEastRunSealMaxX,
+    options.eastRunSealMaxX ?? fallbackEastRunSealMaxX
   );
-  const eastApproachSealColliders: NamedStairBoundaryCollider[] =
-    eastApproachSealMaxX > eastBoundaryMaxX
+  const eastRunSealColliders: NamedStairBoundaryCollider[] =
+    eastRunSealMaxX > eastBoundaryMaxX
       ? [
           {
-            name: 'GroundStairEastApproachSeal',
+            name: 'GroundStairEastRunSeal',
             bounds: {
               minX: eastBoundaryMinX,
-              maxX: eastApproachSealMaxX,
-              minZ: getMinZ(geometry.bottomZ, lowerRunSealFarZ),
-              maxZ: getMaxZ(geometry.bottomZ, lowerRunSealFarZ),
+              maxX: eastRunSealMaxX,
+              minZ: rampMinZ,
+              maxZ: rampMaxZ,
             },
           },
         ]
@@ -279,7 +278,7 @@ export const createGroundStairBoundaryColliders = (
         maxZ: getMaxZ(geometry.bottomZ, lowerApproachZ),
       },
     },
-    ...eastApproachSealColliders,
+    ...eastRunSealColliders,
   ];
 };
 

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -50,8 +50,6 @@ export interface NamedStairBoundaryCollider {
 export interface GroundStairBoundaryColliderOptions {
   playerRadius: number;
   guardThickness: number;
-  /** Optional east-most X coordinate for the local stair-side blocker. */
-  eastBoundaryMaxX?: number;
 }
 
 const DENOMINATOR_EPSILON = 1e-6;
@@ -223,14 +221,12 @@ export const createGroundStairBoundaryColliders = (
     behavior.transitionMargin +
     options.playerRadius * 2 +
     options.guardThickness * 2;
-  const eastBoundaryMaxX = Math.max(
-    fallbackEastBoundaryMaxX,
-    options.eastBoundaryMaxX ?? fallbackEastBoundaryMaxX
-  );
+  const eastBoundaryMaxX = fallbackEastBoundaryMaxX;
   const lowerApproachZ =
     geometry.bottomZ - geometry.direction * behavior.transitionMargin;
-  // Keep the blocker local: east-of-blocker living-room space is
-  // intentionally still navigable, so do not seal this to the room edge.
+  // Keep this finite on purpose: we block the stair-side squeeze pocket, not
+  // the whole east-side ramp band. Far-east living-room coordinates remain
+  // valid navigation space, so do not seal this local edge to a room bound.
   const colliders: NamedStairBoundaryCollider[] = [
     {
       name: 'GroundStairEastBoundary',


### PR DESCRIPTION
### Motivation
- Prevent players from squeezing around the ground-floor stairs into an unintended right/east corner by adding precise invisible blockers derived from stair metrics. 
- Keep the legitimate stair path (lower entrance, ramp body, centerline ascent) intact while avoiding broad wall widening. 
- Make the blockers visible and discoverable via the existing debug collider visualizer for easier verification.

### Description
- Add `createGroundStairBoundaryColliders(geometry, behavior, options)` in `src/systems/movement/stairs.ts` to derive named stair boundary colliders from `stairGeometry`, `stairBehavior`, `PLAYER_RADIUS`, and a guard thickness option. 
- Wire generated blockers into the ground collider set in `src/main.ts` and preserve their debug names via a `namedGroundColliderDebugNames` map so the debug visualizer shows `GroundStairEastBoundary` and `GroundStairLowerCornerGuard`. 
- Use the existing debug collider visualizer registration so the new blockers appear when `debugColliders` is enabled. 
- Add unit tests `src/systems/movement/stairs.test.ts` and extend `playwright/immersive-stairs-roundtrip.spec.ts` to assert the two reported squeeze coordinates are rejected, the lower stair entrance remains occupiable, the stair ascent still works, and debug names are exposed.

### Testing
- Ran format and lint with `npm run format:write` and `npm run lint` (both completed; ESLint produced one fixable warning which was addressed). 
- Ran unit tests with `npm run test:ci` and the test suite passed (`143 files, 1068 tests` in the recorded run) and the new `src/systems/movement/stairs.test.ts` passed locally. 
- Installed Playwright browsers and dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium` then ran the focused Playwright spec with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and it passed (6 tests) after browser setup. 
- Built and validated artifacts with `npm run build`, `npm run docs:check`, and `npm run smoke` (build/docs/smoke passed; link-check reported external fetch warnings unrelated to these changes). 
- Performed a manual Playwright check against a running dev server at `/?mode=immersive&disablePerformanceFailover=1&debugColliders=1` which confirmed the debug visualizer lists both new blocker names and that the reported squeeze samples are not occupiable while the lower entrance remains occupiable. 
- Note: `npm run typecheck` surfaced unrelated, pre-existing TypeScript errors in the repository (e.g., `upperLandingRoom` possibly `undefined` and other legacy issues) and did not pass; these type errors are outside the scope of the stair-boundary change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265a4d935c832fb5ccde3f6e2f060b)