### PR TITLE
Guard ground stair boundary

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -55,6 +55,21 @@ type TestWorldApi = {
   };
 };
 
+type DebugCollidersApi = {
+  getState(): {
+    enabled: boolean;
+    visibleColliderCount: number;
+    totalColliderCount: number;
+  };
+  setEnabled(enabled: boolean): void;
+  getColliders(): Array<{
+    floor: FloorId | 'all';
+    category: string;
+    name: string;
+    bounds: { minX: number; maxX: number; minZ: number; maxZ: number };
+  }>;
+};
+
 type DebugCoordinatesApi = {
   getState(): {
     enabled: boolean;
@@ -83,6 +98,7 @@ type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
     debugCoordinates?: DebugCoordinatesApi;
+    debugColliders?: DebugCollidersApi;
     poi?: {
       getTooltipState(): TooltipState;
     };
@@ -220,6 +236,69 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
     sourceZone: 'outsideStairs',
     liftedZone: 'outsideStairs',
   });
+});
+
+test('ground stair east boundary blocks squeeze corner while preserving ascent', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const { stairCenterX, stairBottomZ, stairTopZ, stairDirection } =
+    await getStairMetrics(page);
+  const blockedSqueezePoint = {
+    x: 17.38,
+    z: -8.84,
+    floorId: 'ground' as const,
+  };
+  const blockedCornerPoint = {
+    x: 21.35,
+    z: -14.66,
+    floorId: 'ground' as const,
+  };
+  const lowerEntrance = {
+    x: stairCenterX,
+    z: stairBottomZ + 0.3,
+    floorId: 'ground' as const,
+  };
+
+  expect(await canOccupyPosition(page, blockedSqueezePoint)).toBe(false);
+  expect(await canOccupyPosition(page, blockedCornerPoint)).toBe(false);
+  await expect(async () =>
+    movePlayerTo(page, blockedSqueezePoint)
+  ).rejects.toThrow(/Cannot occupy/);
+  await expect(async () =>
+    movePlayerTo(page, blockedCornerPoint)
+  ).rejects.toThrow(/Cannot occupy/);
+
+  expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
+  await movePlayerTo(page, lowerEntrance);
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairTopZ - stairDirection * 0.1,
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const debugColliderNames = await page.evaluate(() => {
+    const debugColliders = (window as PortfolioWindow).portfolio
+      ?.debugColliders;
+    if (!debugColliders) {
+      throw new Error('Debug collider API unavailable');
+    }
+    debugColliders.setEnabled(true);
+    return debugColliders.getColliders().map((collider) => collider.name);
+  });
+  expect(debugColliderNames).toEqual(
+    expect.arrayContaining([
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+    ])
+  );
 });
 
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -382,6 +382,7 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
+  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -1823,21 +1824,20 @@ function initializeImmersiveScene(
   ];
   const upperStairNavZones = [stairNavigationZones.upperLanding];
   const stairGuardThickness = toWorldUnits(0.22);
-  const stairGuardMinZ = stairLayout.guardRange.minZ;
-  const stairGuardMaxZ = stairLayout.guardRange.maxZ;
-
-  groundColliders.push({
-    minX: stairCenterX - stairHalfWidth - stairGuardThickness,
-    maxX: stairCenterX - stairHalfWidth,
-    minZ: stairGuardMinZ,
-    maxZ: stairGuardMaxZ,
-  });
-  groundColliders.push({
-    minX: stairCenterX + stairHalfWidth,
-    maxX: stairCenterX + stairHalfWidth + stairGuardThickness,
-    minZ: stairGuardMinZ,
-    maxZ: stairGuardMaxZ,
-  });
+  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
+    stairGeometry,
+    stairBehavior,
+    {
+      guardThickness: stairGuardThickness,
+      playerRadius: PLAYER_RADIUS,
+    }
+  );
+  const namedGroundColliderBounds = new Set<RectCollider>(
+    groundStairBoundaryColliders.map((collider) => collider.bounds)
+  );
+  groundStairBoundaryColliders.forEach((collider) =>
+    groundColliders.push(collider.bounds)
+  );
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;
@@ -3818,11 +3818,22 @@ function initializeImmersiveScene(
     enabled: debugCollidersEnabled,
   });
   colliderVisualizer.register([
-    ...createDebugColliderRegistrations(groundColliders, {
-      floor: 'ground',
-      category: 'ground',
-      namePrefix: 'ground-collider',
-    }),
+    ...createDebugColliderRegistrations(
+      groundColliders.filter(
+        (collider) => !namedGroundColliderBounds.has(collider)
+      ),
+      {
+        floor: 'ground',
+        category: 'ground',
+        namePrefix: 'ground-collider',
+      }
+    ),
+    ...groundStairBoundaryColliders.map((collider) => ({
+      floor: 'ground' as const,
+      category: 'stair-boundary',
+      name: collider.name,
+      bounds: collider.bounds,
+    })),
     ...createDebugColliderRegistrations(staticColliders, {
       floor: 'ground',
       category: 'static',

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -42,6 +42,16 @@ export interface StairNavigationZones {
   explicitDescentCorridor: RectCollider;
 }
 
+export interface NamedStairBoundaryCollider {
+  name: string;
+  bounds: RectCollider;
+}
+
+export interface GroundStairBoundaryColliderOptions {
+  guardThickness: number;
+  playerRadius: number;
+}
+
 const DENOMINATOR_EPSILON = 1e-6;
 
 const getMinZ = (...values: number[]): number => Math.min(...values);
@@ -194,6 +204,69 @@ export const createStairNavigationZones = (
       rampMaxZ
     ),
   };
+};
+
+export const createGroundStairBoundaryColliders = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  options: GroundStairBoundaryColliderOptions
+): NamedStairBoundaryCollider[] => {
+  const lowerApproachZ =
+    geometry.bottomZ - geometry.direction * behavior.transitionMargin;
+  const guardMinZ = getMinZ(
+    geometry.landingMinZ,
+    geometry.landingMaxZ,
+    geometry.bottomZ,
+    lowerApproachZ
+  );
+  const guardMaxZ = getMaxZ(
+    geometry.landingMinZ,
+    geometry.landingMaxZ,
+    geometry.bottomZ,
+    lowerApproachZ
+  );
+  const westEdgeX = geometry.centerX - geometry.halfWidth;
+  const eastEdgeX = geometry.centerX + geometry.halfWidth;
+  const eastBoundaryDepth =
+    geometry.halfWidth +
+    behavior.transitionMargin +
+    options.playerRadius +
+    options.guardThickness;
+  const lowerCornerMinZ = getMinZ(geometry.bottomZ, lowerApproachZ);
+  const lowerCornerMaxZ = getMaxZ(
+    geometry.bottomZ,
+    lowerApproachZ + geometry.direction * -options.playerRadius
+  );
+
+  return [
+    {
+      name: 'GroundStairWestBoundary',
+      bounds: {
+        minX: westEdgeX - options.guardThickness,
+        maxX: westEdgeX,
+        minZ: guardMinZ,
+        maxZ: guardMaxZ,
+      },
+    },
+    {
+      name: 'GroundStairEastBoundary',
+      bounds: {
+        minX: eastEdgeX,
+        maxX: eastEdgeX + eastBoundaryDepth,
+        minZ: guardMinZ,
+        maxZ: guardMaxZ,
+      },
+    },
+    {
+      name: 'GroundStairLowerCornerGuard',
+      bounds: {
+        minX: eastEdgeX,
+        maxX: eastEdgeX + behavior.transitionMargin + options.playerRadius,
+        minZ: lowerCornerMinZ,
+        maxZ: lowerCornerMaxZ,
+      },
+    },
+  ];
 };
 
 const isInExplicitDescentCorridor = (

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import { collidesWithColliders } from '../../systems/collision';
 import {
   classifyStairTransitionZone,
+  createGroundStairBoundaryColliders,
   createStairNavAreaRect,
   createStairNavigationZones,
   predictStairFloorId,
@@ -38,6 +40,9 @@ const NEGATIVE_Z_STAIRS = createStairGeometry(-1);
 const UPPER_FLOOR_ELEVATION = NEGATIVE_Z_STAIRS.totalRise + 0.38;
 const SCREENSHOT_4_SOURCE_POINT = { x: 7.4, z: -25.27 };
 const SCREENSHOT_4_LIFT_POINT = { x: 8.14, z: -25.36 };
+const GROUND_STAIR_SQUEEZE_POINT = { x: 17.38, z: -8.84 };
+const GROUND_STAIR_CORNER_POINT = { x: 21.35, z: -14.66 };
+const PLAYER_RADIUS = 0.75;
 
 const STAIR_BEHAVIOR: StairBehavior = {
   transitionMargin: toWorldUnits(0.6),
@@ -456,6 +461,53 @@ describe('stair navigation zones', () => {
       NEGATIVE_Z_STAIRS.landingMaxZ,
       6
     );
+  });
+
+  it('blocks the ground-floor east-side stair squeeze without covering the centerline', () => {
+    const boundaryColliders = createGroundStairBoundaryColliders(
+      NEGATIVE_Z_STAIRS,
+      STAIR_BEHAVIOR,
+      { guardThickness: toWorldUnits(0.22), playerRadius: PLAYER_RADIUS }
+    );
+    const colliderBounds = boundaryColliders.map((collider) => collider.bounds);
+
+    expect(boundaryColliders.map((collider) => collider.name)).toEqual([
+      'GroundStairWestBoundary',
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+    ]);
+    expect(
+      collidesWithColliders(
+        GROUND_STAIR_SQUEEZE_POINT.x,
+        GROUND_STAIR_SQUEEZE_POINT.z,
+        PLAYER_RADIUS,
+        colliderBounds
+      )
+    ).toBe(true);
+    expect(
+      collidesWithColliders(
+        GROUND_STAIR_CORNER_POINT.x,
+        GROUND_STAIR_CORNER_POINT.z,
+        PLAYER_RADIUS,
+        colliderBounds
+      )
+    ).toBe(true);
+    expect(
+      collidesWithColliders(
+        NEGATIVE_Z_STAIRS.centerX,
+        NEGATIVE_Z_STAIRS.bottomZ + toWorldUnits(0.15),
+        PLAYER_RADIUS,
+        colliderBounds
+      )
+    ).toBe(false);
+    expect(
+      collidesWithColliders(
+        NEGATIVE_Z_STAIRS.centerX,
+        (NEGATIVE_Z_STAIRS.bottomZ + NEGATIVE_Z_STAIRS.topZ) / 2,
+        PLAYER_RADIUS,
+        colliderBounds
+      )
+    ).toBe(false);
   });
 
   it('expands the legacy stair footprint with margins for compatibility', () => {


### PR DESCRIPTION
### Motivation
- Prevent players from squeezing around the ground-floor stairs into the unintended right/east corner while preserving the valid stair path and lower entrance. 
- Derive precise invisible blockers from the canonical `stairGeometry` and layout metrics instead of widening unrelated room walls. 

### Description
- Add a small helper `createGroundStairBoundaryColliders(geometry, behavior, options)` that returns named `GroundStair*` rect colliders computed from `stairGeometry`, `stairBehavior`, `PLAYER_RADIUS`, and a supplied `guardThickness` (`src/systems/movement/stairs.ts`).
- Wire the generated colliders into the ground collision set in `src/main.ts` and register them with the debug collider visualizer as explicit `stair-boundary` entries while keeping existing ground colliders labeled normally. 
- Add unit tests for the helper and nav logic in `src/tests/movement/stairTransitions.test.ts` to assert the reported squeeze / corner points collide and that the stair centerline and lower entrance remain clear. 
- Extend `playwright/immersive-stairs-roundtrip.spec.ts` with an E2E test that rejects the two reported ground-floor coordinates, verifies ascent still works, and checks the debug visualizer exposes the new `GroundStair*` names.

### Testing
- Ran formatting and linting: `npm run format:write` and `npx prettier --write` succeeded and `npm run lint` succeeded. 
- Type-check: `npm run typecheck` reported pre-existing repository-wide TypeScript issues unrelated to this change and therefore failed; this is a blocking repo state outside this patch. 
- Unit tests: `npm run test:ci -- src/tests/movement/stairTransitions.test.ts` succeeded, and full `npm run test:ci` completed successfully (all suites passed). 
- Playwright: installed browsers (`npx playwright install chromium`) and dependencies (`npx playwright install-deps chromium`) then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and the updated spec passed (6 tests). 
- Build & docs: `npm run build`, `npm run docs:check`, and `npm run smoke` all completed successfully. 
- Manual debug verification: launched a preview and queried the runtime debug APIs (with `debugColliders=1`) and confirmed both reported coordinates returned `canOccupy: false` and the visualizer lists `GroundStairWestBoundary`, `GroundStairEastBoundary`, and `GroundStairLowerCornerGuard`; a review screenshot was saved to `/tmp/ground-stair-debug-colliders.png` during verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265a4d935c832fb5ccde3f6e2f060b)