### PR TITLE
🧱 – Block ground stair squeeze path

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -222,6 +222,61 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
   });
 });
 
+test('ground stair boundary blocks the east-side squeeze corner', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const html = page.locator('html');
+  const { stairCenterX, stairBottomZ, stairTopZ, stairDirection } =
+    await getStairMetrics(page);
+  const reportedSqueezePoints = [
+    { x: 17.38, z: -8.84, floorId: 'ground' as const },
+    { x: 21.35, z: -14.66, floorId: 'ground' as const },
+  ];
+
+  for (const point of reportedSqueezePoints) {
+    expect(await canOccupyPosition(page, point)).toBe(false);
+    await expect(async () => movePlayerTo(page, point)).rejects.toThrow(
+      /Cannot occupy/
+    );
+  }
+
+  const lowerStairEntrance = {
+    x: stairCenterX,
+    z: stairBottomZ + 0.3,
+    floorId: 'ground' as const,
+  };
+  expect(await canOccupyPosition(page, lowerStairEntrance)).toBe(true);
+  await movePlayerTo(page, lowerStairEntrance);
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: (stairBottomZ + stairTopZ) / 2,
+  });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairTopZ - stairDirection * 0.1,
+  });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const debugColliders = await page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug collider API unavailable');
+    }
+    return debugApi.getColliders().map((collider) => collider.name);
+  });
+  expect(debugColliders).toEqual(
+    expect.arrayContaining([
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+    ])
+  );
+});
+
 test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   test.slow();
   await waitForImmersiveReady(page);

--- a/src/main.ts
+++ b/src/main.ts
@@ -382,6 +382,7 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
+  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -1837,6 +1838,18 @@ function initializeImmersiveScene(
     maxX: stairCenterX + stairHalfWidth + stairGuardThickness,
     minZ: stairGuardMinZ,
     maxZ: stairGuardMaxZ,
+  });
+
+  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
+    stairGeometry,
+    {
+      playerRadius: PLAYER_RADIUS,
+      guardThickness: stairGuardThickness,
+      transitionMargin: stairTransitionMargin,
+    }
+  );
+  groundStairBoundaryColliders.forEach((collider) => {
+    groundColliders.push(collider.bounds);
   });
 
   const upperFloorGroup = new Group();
@@ -3823,6 +3836,14 @@ function initializeImmersiveScene(
       category: 'ground',
       namePrefix: 'ground-collider',
     }),
+    ...groundStairBoundaryColliders.map(
+      (collider): DebugColliderRegistration => ({
+        floor: 'ground',
+        category: 'ground-stair-boundary',
+        name: collider.name,
+        bounds: collider.bounds,
+      })
+    ),
     ...createDebugColliderRegistrations(staticColliders, {
       floor: 'ground',
       category: 'static',

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -153,6 +153,69 @@ export const computeRampHeight = (
   return clamped * geometry.totalRise;
 };
 
+export type GroundStairBoundaryColliderName =
+  | 'GroundStairEastBoundary'
+  | 'GroundStairLowerCornerGuard';
+
+export interface GroundStairBoundaryCollider {
+  name: GroundStairBoundaryColliderName;
+  bounds: RectCollider;
+}
+
+export interface GroundStairBoundaryColliderOptions {
+  /** Radius used by avatar collision checks. */
+  playerRadius: number;
+  /** Thickness already used by the visual/invisible stair guard rails. */
+  guardThickness: number;
+  /** Lower stair handoff margin from the stair behavior. */
+  transitionMargin: number;
+}
+
+export const createGroundStairBoundaryColliders = (
+  geometry: StairGeometry,
+  options: GroundStairBoundaryColliderOptions
+): GroundStairBoundaryCollider[] => {
+  const eastStairEdgeX = geometry.centerX + geometry.halfWidth;
+  const guardOuterX = eastStairEdgeX + options.guardThickness;
+  const eastPocketMaxX =
+    eastStairEdgeX +
+    geometry.halfWidth +
+    options.transitionMargin +
+    options.playerRadius +
+    options.guardThickness;
+  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
+  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
+  const lowerApproachNearZ =
+    geometry.direction === -1
+      ? geometry.bottomZ - options.transitionMargin
+      : geometry.bottomZ;
+  const lowerApproachFarZ =
+    geometry.direction === -1
+      ? geometry.bottomZ + options.transitionMargin + options.playerRadius
+      : geometry.bottomZ - options.transitionMargin - options.playerRadius;
+
+  return [
+    {
+      name: 'GroundStairEastBoundary',
+      bounds: {
+        minX: guardOuterX,
+        maxX: eastPocketMaxX,
+        minZ: rampMinZ,
+        maxZ: rampMaxZ,
+      },
+    },
+    {
+      name: 'GroundStairLowerCornerGuard',
+      bounds: {
+        minX: guardOuterX,
+        maxX: eastPocketMaxX,
+        minZ: getMinZ(lowerApproachNearZ, lowerApproachFarZ),
+        maxZ: getMaxZ(lowerApproachNearZ, lowerApproachFarZ),
+      },
+    },
+  ];
+};
+
 export const createStairNavigationZones = (
   geometry: StairGeometry,
   behavior: StairBehavior

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import { collidesWithColliders } from '../../systems/collision';
 import {
   classifyStairTransitionZone,
   createStairNavAreaRect,
+  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   predictStairFloorId,
   sampleStairSurfaceHeight,
@@ -489,5 +491,57 @@ describe('stair navigation zones', () => {
     );
     expect(rect.minZ).toBeCloseTo(expectedMinZ - marginZ, 6);
     expect(rect.maxZ).toBeCloseTo(expectedMaxZ + marginZ, 6);
+  });
+});
+
+describe('ground stair boundary colliders', () => {
+  const PLAYER_RADIUS = 0.75;
+  const GUARD_THICKNESS = toWorldUnits(0.22);
+  const reportedSqueezePoints = [
+    { x: 17.38, z: -8.84 },
+    { x: 21.35, z: -14.66 },
+  ];
+
+  it('blocks the east-side squeeze points without covering the stair centerline', () => {
+    const colliders = createGroundStairBoundaryColliders(NEGATIVE_Z_STAIRS, {
+      playerRadius: PLAYER_RADIUS,
+      guardThickness: GUARD_THICKNESS,
+      transitionMargin: STAIR_BEHAVIOR.transitionMargin,
+    });
+    const bounds = colliders.map((collider) => collider.bounds);
+
+    for (const point of reportedSqueezePoints) {
+      expect(
+        collidesWithColliders(point.x, point.z, PLAYER_RADIUS, bounds)
+      ).toBe(true);
+    }
+
+    const stairCenterlineSamples = [
+      { x: NEGATIVE_Z_STAIRS.centerX, z: NEGATIVE_Z_STAIRS.bottomZ + 0.3 },
+      {
+        x: NEGATIVE_Z_STAIRS.centerX,
+        z: (NEGATIVE_Z_STAIRS.bottomZ + NEGATIVE_Z_STAIRS.topZ) / 2,
+      },
+      { x: NEGATIVE_Z_STAIRS.centerX, z: NEGATIVE_Z_STAIRS.topZ + 0.3 },
+    ];
+
+    for (const point of stairCenterlineSamples) {
+      expect(
+        collidesWithColliders(point.x, point.z, PLAYER_RADIUS, bounds)
+      ).toBe(false);
+    }
+  });
+
+  it('labels the debug-visible boundary blockers', () => {
+    const colliders = createGroundStairBoundaryColliders(NEGATIVE_Z_STAIRS, {
+      playerRadius: PLAYER_RADIUS,
+      guardThickness: GUARD_THICKNESS,
+      transitionMargin: STAIR_BEHAVIOR.transitionMargin,
+    });
+
+    expect(colliders.map((collider) => collider.name)).toEqual([
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+    ]);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent players from squeezing around the east/right side of the ground-floor stairs into an unintended corner by adding precise, camera-derived invisible blockers rather than widening room walls.

### Description
- Add `createGroundStairBoundaryColliders(...)` to derive east-side ground stair boundary colliders from `StairGeometry`, `PLAYER_RADIUS`, guard thickness and stair margins (file: `src/systems/movement/stairs.ts`).
- Add the derived boundary colliders to the ground collider list and register them with the collider visualizer using explicit names (`GroundStairEastBoundary`, `GroundStairLowerCornerGuard`) so they appear in debug mode (file: `src/main.ts`).
- Add a unit test for the helper that verifies the reported squeeze points are blocked and the stair centerline remains clear (file: `src/tests/movement/stairTransitions.test.ts`).
- Add an immersive Playwright regression that asserts the two reported ground positions cannot be occupied, the lower stair entrance and centerline ascent remain usable, and debug collider names are exposed (file: `playwright/immersive-stairs-roundtrip.spec.ts`).

### Testing
- Ran formatting and linting: `npm run format:write` (passed), `npm run lint` (passed).
- Ran unit tests: `npm run test:ci` (full test suite: 142 files / 1067 tests — all passed) and `npm run test:ci -- src/tests/movement/stairTransitions.test.ts` (passed).
- Ran Playwright checks: `npx playwright install chromium` and `npx playwright install-deps chromium` (browsers & deps installed), then `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (6 tests passed).
- Docs/build/smoke: `npm run docs:check` (passed; external link fetch warnings only), `npm run build` (passed), `npm run smoke` (passed).
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).
- Typecheck: `npm run typecheck` was run but reported unrelated existing TypeScript errors in the codebase (not introduced by this change); these are recorded and left for follow-up.

If reviewers want a follow-up, I can tighten blocker bounds further or expose an optional HUD toggle to temporarily disable the specific boundary colliders for debugging, but the current change aims to be minimal and derived from existing stair geometry to preserve the legitimate stair path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265a4d935c832fb5ccde3f6e2f060b)