### PR TITLE
Hide ground visuals when on upper floor

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -23,6 +23,14 @@ type StairTransitionZone =
   | 'explicitDescentCorridor'
   | 'outsideStairs';
 
+type FloorVisibilitySnapshot = {
+  groundFloorVisible: boolean;
+  groundPoiVisible: boolean;
+  groundStructureVisible: boolean;
+  groundEnvironmentVisible: boolean;
+  upperFloorVisible: boolean;
+};
+
 type TestWorldApi = {
   movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
   getActiveFloor(): FloorId;
@@ -42,6 +50,7 @@ type TestWorldApi = {
     z: number;
     currentFloor?: FloorId;
   }): StairTransitionZone;
+  getFloorVisibilitySnapshot(): FloorVisibilitySnapshot;
   getStairMetrics(): {
     stairCenterX: number;
     stairHalfWidth: number;
@@ -173,6 +182,18 @@ async function getWorldState(page: Page) {
       activeFloor: world.getActiveFloor(),
       position: world.getPlayerPosition(),
     };
+  });
+}
+
+async function getFloorVisibilitySnapshot(
+  page: Page
+): Promise<FloorVisibilitySnapshot> {
+  return page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getFloorVisibilitySnapshot();
   });
 }
 
@@ -563,4 +584,30 @@ test('debug coordinates and upstairs POI state stay floor-aware', async ({
   for (const groundPoiId of GROUND_POI_IDS) {
     expect(tooltipState.visibleMarkerLabelPoiIds).not.toContain(groundPoiId);
   }
+
+  await expect
+    .poll(() => getFloorVisibilitySnapshot(page))
+    .toEqual({
+      groundFloorVisible: false,
+      groundPoiVisible: false,
+      groundStructureVisible: false,
+      groundEnvironmentVisible: false,
+      upperFloorVisible: true,
+    });
+
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairTopZ - stairDirection * 0.1,
+  });
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+  await expect
+    .poll(() => getFloorVisibilitySnapshot(page))
+    .toEqual({
+      groundFloorVisible: true,
+      groundPoiVisible: true,
+      groundStructureVisible: true,
+      groundEnvironmentVisible: true,
+      upperFloorVisible: false,
+    });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -636,6 +636,13 @@ declare global {
           upperFloorElevation: number;
         };
         getCeilingOpacities(): number[];
+        getFloorVisibilitySnapshot(): {
+          groundFloorVisible: boolean;
+          groundPoiVisible: boolean;
+          groundStructureVisible: boolean;
+          groundEnvironmentVisible: boolean;
+          upperFloorVisible: boolean;
+        };
         // Test-only helper: current player yaw in radians
         getPlayerYaw?(): number;
       };
@@ -1612,6 +1619,10 @@ function initializeImmersiveScene(
   });
   environmentLightAnimator.captureBaseline();
 
+  const groundEnvironmentGroup = new Group();
+  groundEnvironmentGroup.name = 'GroundEnvironmentVisuals';
+  scene.add(groundEnvironmentGroup);
+
   const backyardRoom = FLOOR_PLAN.rooms.find(
     (room) => room.id === BACKYARD_ROOM_ID
   );
@@ -1620,7 +1631,7 @@ function initializeImmersiveScene(
       seasonalPreset,
       detailPolicy: activeSceneDetailPolicy,
     });
-    scene.add(backyardEnvironment.group);
+    groundEnvironmentGroup.add(backyardEnvironment.group);
     // Remove the enclosing sky dome to avoid a bright circular spheroid.
     // We want a dark void beyond the property in runtime.
     const skyDome =
@@ -2143,6 +2154,10 @@ function initializeImmersiveScene(
   groundPoiGroup.name = 'GroundPoiVisuals';
   scene.add(groundPoiGroup);
 
+  const groundStructureGroup = new Group();
+  groundStructureGroup.name = 'GroundStructureVisuals';
+  scene.add(groundStructureGroup);
+
   const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
     detailPolicy: activeSceneDetailPolicy,
   });
@@ -2160,7 +2175,12 @@ function initializeImmersiveScene(
   const floorVisibilityController: FloorVisibilityController =
     createFloorVisibilityController({
       initialFloorId: activeFloorId,
-      groundGroups: [groundFloorGroup, groundPoiGroup],
+      groundGroups: [
+        groundFloorGroup,
+        groundPoiGroup,
+        groundStructureGroup,
+        groundEnvironmentGroup,
+      ],
       upperGroups: [upperFloorGroup],
       groundLedGroups: [ledStripGroup, ledFillLightGroup].filter(
         (group): group is Group => group !== null
@@ -2576,7 +2596,7 @@ function initializeImmersiveScene(
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
       detailPolicy: activeSceneDetailPolicy,
     });
-    scene.add(showpiece.group);
+    groundStructureGroup.add(showpiece.group);
     showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     flywheelShowpiece = showpiece;
 
@@ -2596,7 +2616,7 @@ function initializeImmersiveScene(
       orientationRadians: terminalOrientation,
       detailPolicy: activeSceneDetailPolicy,
     });
-    scene.add(terminal.group);
+    groundStructureGroup.add(terminal.group);
     terminal.colliders.forEach((collider) => groundColliders.push(collider));
     jobbotTerminal = terminal;
 
@@ -2609,7 +2629,7 @@ function initializeImmersiveScene(
         },
         orientationRadians: axelPoi.group.rotation.y ?? 0,
       });
-      scene.add(navigator.group);
+      groundStructureGroup.add(navigator.group);
       navigator.colliders.forEach((collider) => groundColliders.push(collider));
       axelNavigator = navigator;
     }
@@ -2623,7 +2643,7 @@ function initializeImmersiveScene(
         },
         orientationRadians: tokenPlacePoi.group.rotation.y ?? 0,
       });
-      scene.add(rack.group);
+      groundStructureGroup.add(rack.group);
       rack.colliders.forEach((collider) => groundColliders.push(collider));
       tokenPlaceRack = rack;
     }
@@ -2637,7 +2657,7 @@ function initializeImmersiveScene(
         },
         orientationRadians: gabrielPoi.group.rotation.y ?? 0,
       });
-      scene.add(sentry.group);
+      groundStructureGroup.add(sentry.group);
       sentry.colliders.forEach((collider) => groundColliders.push(collider));
       gabrielSentry = sentry;
     }
@@ -2652,7 +2672,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: prReaperPoi.group.rotation.y ?? 0,
     });
-    scene.add(console.group);
+    groundStructureGroup.add(console.group);
     console.colliders.forEach((collider) => groundColliders.push(collider));
     prReaperConsole = console;
   }
@@ -2666,7 +2686,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: gitshelvesPoi.group.rotation.y ?? 0,
     });
-    scene.add(installation.group);
+    groundStructureGroup.add(installation.group);
     installation.colliders.forEach((collider) =>
       groundColliders.push(collider)
     );
@@ -2696,7 +2716,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: f2ClipboardPoi.group.rotation.y ?? 0,
     });
-    scene.add(console.group);
+    groundStructureGroup.add(console.group);
     console.colliders.forEach((collider) => groundColliders.push(collider));
     f2ClipboardConsole = console;
   }
@@ -2724,7 +2744,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: sigmaPoi.group.rotation.y ?? 0,
     });
-    scene.add(workbench.group);
+    groundStructureGroup.add(workbench.group);
     workbench.colliders.forEach((collider) => groundColliders.push(collider));
     sigmaWorkbench = workbench;
   }
@@ -2752,7 +2772,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: wovePoi.group.rotation.y ?? 0,
     });
-    scene.add(loom.group);
+    groundStructureGroup.add(loom.group);
     loom.colliders.forEach((collider) => groundColliders.push(collider));
     woveLoom = loom;
   }
@@ -3184,6 +3204,15 @@ function initializeImmersiveScene(
       // Test helpers – expose current mannequin yaw in radians.
       getPlayerYaw() {
         return normalizeRadians(mannequinRelativeYaw);
+      },
+      getFloorVisibilitySnapshot() {
+        return {
+          groundFloorVisible: groundFloorGroup.visible,
+          groundPoiVisible: groundPoiGroup.visible,
+          groundStructureVisible: groundStructureGroup.visible,
+          groundEnvironmentVisible: groundEnvironmentGroup.visible,
+          upperFloorVisible: upperFloorGroup.visible,
+        };
       },
       getCeilingOpacities(): number[] {
         return ceilings.panels.map((p) => {

--- a/src/tests/floorVisibilityController.test.ts
+++ b/src/tests/floorVisibilityController.test.ts
@@ -88,11 +88,13 @@ function createPoiInstance(roomId: string): PoiInstance {
 describe('floor visibility controller', () => {
   it('toggles floor-specific groups and LED groups with the active floor', () => {
     const groundGroup = new Object3D();
+    const groundStructureGroup = new Object3D();
+    const groundEnvironmentGroup = new Object3D();
     const upperGroup = new Object3D();
     const groundLedGroup = new Object3D();
     const upperLedGroup = new Object3D();
     const controller = createFloorVisibilityController({
-      groundGroups: [groundGroup],
+      groundGroups: [groundGroup, groundStructureGroup, groundEnvironmentGroup],
       upperGroups: [upperGroup],
       groundLedGroups: [groundLedGroup],
       upperLedGroups: [upperLedGroup],
@@ -101,6 +103,8 @@ describe('floor visibility controller', () => {
 
     expect(groundGroup.visible).toBe(true);
     expect(groundLedGroup.visible).toBe(true);
+    expect(groundStructureGroup.visible).toBe(true);
+    expect(groundEnvironmentGroup.visible).toBe(true);
     expect(upperGroup.visible).toBe(false);
     expect(upperLedGroup.visible).toBe(false);
 
@@ -108,8 +112,19 @@ describe('floor visibility controller', () => {
 
     expect(groundGroup.visible).toBe(false);
     expect(groundLedGroup.visible).toBe(false);
+    expect(groundStructureGroup.visible).toBe(false);
+    expect(groundEnvironmentGroup.visible).toBe(false);
     expect(upperGroup.visible).toBe(true);
     expect(upperLedGroup.visible).toBe(true);
+
+    controller.setActiveFloorId('ground');
+
+    expect(groundGroup.visible).toBe(true);
+    expect(groundLedGroup.visible).toBe(true);
+    expect(groundStructureGroup.visible).toBe(true);
+    expect(groundEnvironmentGroup.visible).toBe(true);
+    expect(upperGroup.visible).toBe(false);
+    expect(upperLedGroup.visible).toBe(false);
   });
 
   it('hides ground POI labels and visited checkmarks on the upper floor', () => {


### PR DESCRIPTION
### Motivation
- Upstairs views were still showing ground-only POIs, set pieces and the backyard which should be hidden when the active floor is `upper`. 
- Provide a minimal, test-oriented API so E2E specs can assert the visibility snapshot and prevent regressions (screenshot-7 class failure).

### Description
- Add `groundEnvironmentGroup` and `groundStructureGroup` in `src/main.ts` and move the backyard and ground-only structures (Flywheel, Jobbot, Axel, TokenPlace, Gabriel, PR Reaper, Gitshelves, F2Clipboard, Sigma, Wove) into these groups rather than adding them directly to `scene`.
- Include the new groups in the `groundGroups` passed to `createFloorVisibilityController` so they are hidden/shown with other ground visuals.
- Expose a minimal test helper `getFloorVisibilitySnapshot()` on the `window.portfolio.world` API returning boolean visibility for `groundFloor`, `groundPoi`, `groundStructure`, `groundEnvironment`, and `upperFloor`.
- Update unit tests (`src/tests/floorVisibilityController.test.ts`) and the stairs Playwright spec (`playwright/immersive-stairs-roundtrip.spec.ts`) to assert that ground POIs, ground-only structures, and the backyard are hidden when upstairs and restored when returning to ground.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both succeeded.
- Ran unit tests with `npm run test:ci` and focused unit run `npm run test:ci -- src/tests/floorVisibilityController.test.ts`, both succeeded (Vitest suite completed; the modified controller tests passed).
- Type-check with `npm run typecheck` failed due to existing repository-wide TypeScript issues unrelated to these visibility changes (reported errors like `upperLandingRoom` possibly `undefined`); no new type errors were introduced by the visibility snapshot code.
- Playwright E2E: installed browsers and dependencies with `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, and all spec tests passed (6 passed); also captured a verification screenshot and read `getFloorVisibilitySnapshot()` which returned the expected visibility values for upstairs/ground transitions.
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`, both succeeded; docs link check `npm run docs:check` passed (external fetch warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27672333f0832fb5b8beca82f49d3b)