### PR TITLE
Hide ground visuals while upstairs

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -23,6 +23,16 @@ type StairTransitionZone =
   | 'explicitDescentCorridor'
   | 'outsideStairs';
 
+type FloorVisibilitySnapshot = {
+  activeFloorId: FloorId;
+  groundFloorVisible: boolean;
+  groundPoiVisible: boolean;
+  groundStructureVisible: boolean;
+  backyardEnvironmentVisible: boolean | null;
+  upperFloorVisible: boolean;
+  upperPoiVisible: boolean;
+};
+
 type TestWorldApi = {
   movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
   getActiveFloor(): FloorId;
@@ -53,6 +63,7 @@ type TestWorldApi = {
     stairDirection: 1 | -1;
     upperFloorElevation: number;
   };
+  getFloorVisibilitySnapshot(): FloorVisibilitySnapshot;
 };
 
 type DebugColliderApi = {
@@ -183,6 +194,18 @@ async function getTooltipState(page: Page): Promise<TooltipState> {
       throw new Error('POI API unavailable');
     }
     return poi.getTooltipState();
+  });
+}
+
+async function getFloorVisibilitySnapshot(
+  page: Page
+): Promise<FloorVisibilitySnapshot> {
+  return page.evaluate(() => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.getFloorVisibilitySnapshot();
   });
 }
 
@@ -553,6 +576,17 @@ test('debug coordinates and upstairs POI state stay floor-aware', async ({
   expect(debugState.predictedStairFloorId).toBe('upper');
   expect(debugState.currentRoomId).toBeTruthy();
 
+  const upperVisibility = await getFloorVisibilitySnapshot(page);
+  expect(upperVisibility).toMatchObject({
+    activeFloorId: 'upper',
+    groundFloorVisible: false,
+    groundPoiVisible: false,
+    groundStructureVisible: false,
+    backyardEnvironmentVisible: false,
+    upperFloorVisible: true,
+    upperPoiVisible: true,
+  });
+
   const tooltipState = await getTooltipState(page);
   expect(tooltipState.worldTooltipVisible).toBe(false);
   expect(tooltipState.worldTooltipPoiId).toBeNull();
@@ -563,4 +597,17 @@ test('debug coordinates and upstairs POI state stay floor-aware', async ({
   for (const groundPoiId of GROUND_POI_IDS) {
     expect(tooltipState.visibleMarkerLabelPoiIds).not.toContain(groundPoiId);
   }
+
+  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.7 });
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+  const groundVisibility = await getFloorVisibilitySnapshot(page);
+  expect(groundVisibility).toMatchObject({
+    activeFloorId: 'ground',
+    groundFloorVisible: true,
+    groundPoiVisible: true,
+    groundStructureVisible: true,
+    backyardEnvironmentVisible: true,
+    upperFloorVisible: false,
+    upperPoiVisible: false,
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -636,6 +636,15 @@ declare global {
           upperFloorElevation: number;
         };
         getCeilingOpacities(): number[];
+        getFloorVisibilitySnapshot(): {
+          activeFloorId: FloorId;
+          groundFloorVisible: boolean;
+          groundPoiVisible: boolean;
+          groundStructureVisible: boolean;
+          backyardEnvironmentVisible: boolean | null;
+          upperFloorVisible: boolean;
+          upperPoiVisible: boolean;
+        };
         // Test-only helper: current player yaw in radians
         getPlayerYaw?(): number;
       };
@@ -1612,6 +1621,10 @@ function initializeImmersiveScene(
   });
   environmentLightAnimator.captureBaseline();
 
+  const groundStructureGroup = new Group();
+  groundStructureGroup.name = 'GroundStructureVisuals';
+  scene.add(groundStructureGroup);
+
   const backyardRoom = FLOOR_PLAN.rooms.find(
     (room) => room.id === BACKYARD_ROOM_ID
   );
@@ -1620,7 +1633,7 @@ function initializeImmersiveScene(
       seasonalPreset,
       detailPolicy: activeSceneDetailPolicy,
     });
-    scene.add(backyardEnvironment.group);
+    groundStructureGroup.add(backyardEnvironment.group);
     // Remove the enclosing sky dome to avoid a bright circular spheroid.
     // We want a dark void beyond the property in runtime.
     const skyDome =
@@ -2143,12 +2156,22 @@ function initializeImmersiveScene(
   groundPoiGroup.name = 'GroundPoiVisuals';
   scene.add(groundPoiGroup);
 
+  const upperPoiGroup = new Group();
+  upperPoiGroup.name = 'UpperPoiVisuals';
+  upperPoiGroup.visible = false;
+  scene.add(upperPoiGroup);
+
+  const getPoiFloorId = createPoiFloorResolver(FLOOR_PLAN_LEVELS);
   const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
     detailPolicy: activeSceneDetailPolicy,
   });
   builtPoiInstances.forEach((poi) => {
     if (!poi.group.parent) {
-      groundPoiGroup.add(poi.group);
+      const targetPoiGroup =
+        getPoiFloorId(poi.definition) === 'upper'
+          ? upperPoiGroup
+          : groundPoiGroup;
+      targetPoiGroup.add(poi.group);
     }
     if (poi.collider) {
       staticColliders.push(poi.collider);
@@ -2156,12 +2179,11 @@ function initializeImmersiveScene(
     poiInstances.push(poi);
   });
 
-  const getPoiFloorId = createPoiFloorResolver(FLOOR_PLAN_LEVELS);
   const floorVisibilityController: FloorVisibilityController =
     createFloorVisibilityController({
       initialFloorId: activeFloorId,
-      groundGroups: [groundFloorGroup, groundPoiGroup],
-      upperGroups: [upperFloorGroup],
+      groundGroups: [groundFloorGroup, groundPoiGroup, groundStructureGroup],
+      upperGroups: [upperFloorGroup, upperPoiGroup],
       groundLedGroups: [ledStripGroup, ledFillLightGroup].filter(
         (group): group is Group => group !== null
       ),
@@ -2576,7 +2598,7 @@ function initializeImmersiveScene(
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
       detailPolicy: activeSceneDetailPolicy,
     });
-    scene.add(showpiece.group);
+    groundStructureGroup.add(showpiece.group);
     showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     flywheelShowpiece = showpiece;
 
@@ -2596,7 +2618,7 @@ function initializeImmersiveScene(
       orientationRadians: terminalOrientation,
       detailPolicy: activeSceneDetailPolicy,
     });
-    scene.add(terminal.group);
+    groundStructureGroup.add(terminal.group);
     terminal.colliders.forEach((collider) => groundColliders.push(collider));
     jobbotTerminal = terminal;
 
@@ -2609,7 +2631,7 @@ function initializeImmersiveScene(
         },
         orientationRadians: axelPoi.group.rotation.y ?? 0,
       });
-      scene.add(navigator.group);
+      groundStructureGroup.add(navigator.group);
       navigator.colliders.forEach((collider) => groundColliders.push(collider));
       axelNavigator = navigator;
     }
@@ -2623,7 +2645,7 @@ function initializeImmersiveScene(
         },
         orientationRadians: tokenPlacePoi.group.rotation.y ?? 0,
       });
-      scene.add(rack.group);
+      groundStructureGroup.add(rack.group);
       rack.colliders.forEach((collider) => groundColliders.push(collider));
       tokenPlaceRack = rack;
     }
@@ -2637,7 +2659,7 @@ function initializeImmersiveScene(
         },
         orientationRadians: gabrielPoi.group.rotation.y ?? 0,
       });
-      scene.add(sentry.group);
+      groundStructureGroup.add(sentry.group);
       sentry.colliders.forEach((collider) => groundColliders.push(collider));
       gabrielSentry = sentry;
     }
@@ -2652,7 +2674,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: prReaperPoi.group.rotation.y ?? 0,
     });
-    scene.add(console.group);
+    groundStructureGroup.add(console.group);
     console.colliders.forEach((collider) => groundColliders.push(collider));
     prReaperConsole = console;
   }
@@ -2666,7 +2688,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: gitshelvesPoi.group.rotation.y ?? 0,
     });
-    scene.add(installation.group);
+    groundStructureGroup.add(installation.group);
     installation.colliders.forEach((collider) =>
       groundColliders.push(collider)
     );
@@ -2696,7 +2718,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: f2ClipboardPoi.group.rotation.y ?? 0,
     });
-    scene.add(console.group);
+    groundStructureGroup.add(console.group);
     console.colliders.forEach((collider) => groundColliders.push(collider));
     f2ClipboardConsole = console;
   }
@@ -2724,7 +2746,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: sigmaPoi.group.rotation.y ?? 0,
     });
-    scene.add(workbench.group);
+    groundStructureGroup.add(workbench.group);
     workbench.colliders.forEach((collider) => groundColliders.push(collider));
     sigmaWorkbench = workbench;
   }
@@ -2752,7 +2774,7 @@ function initializeImmersiveScene(
       },
       orientationRadians: wovePoi.group.rotation.y ?? 0,
     });
-    scene.add(loom.group);
+    groundStructureGroup.add(loom.group);
     loom.colliders.forEach((collider) => groundColliders.push(collider));
     woveLoom = loom;
   }
@@ -3190,6 +3212,19 @@ function initializeImmersiveScene(
           const material = p.mesh.material as MeshStandardMaterial;
           return material.opacity;
         });
+      },
+      getFloorVisibilitySnapshot() {
+        return {
+          activeFloorId,
+          groundFloorVisible: groundFloorGroup.visible,
+          groundPoiVisible: groundPoiGroup.visible,
+          groundStructureVisible: groundStructureGroup.visible,
+          backyardEnvironmentVisible: backyardEnvironment
+            ? groundStructureGroup.visible && backyardEnvironment.group.visible
+            : null,
+          upperFloorVisible: upperFloorGroup.visible,
+          upperPoiVisible: upperPoiGroup.visible,
+        };
       },
     };
   };

--- a/src/tests/floorVisibilityController.test.ts
+++ b/src/tests/floorVisibilityController.test.ts
@@ -88,27 +88,33 @@ function createPoiInstance(roomId: string): PoiInstance {
 describe('floor visibility controller', () => {
   it('toggles floor-specific groups and LED groups with the active floor', () => {
     const groundGroup = new Object3D();
+    const groundStructureGroup = new Object3D();
     const upperGroup = new Object3D();
+    const upperPoiGroup = new Object3D();
     const groundLedGroup = new Object3D();
     const upperLedGroup = new Object3D();
     const controller = createFloorVisibilityController({
-      groundGroups: [groundGroup],
-      upperGroups: [upperGroup],
+      groundGroups: [groundGroup, groundStructureGroup],
+      upperGroups: [upperGroup, upperPoiGroup],
       groundLedGroups: [groundLedGroup],
       upperLedGroups: [upperLedGroup],
       getPoiFloorId: () => 'ground',
     });
 
     expect(groundGroup.visible).toBe(true);
+    expect(groundStructureGroup.visible).toBe(true);
     expect(groundLedGroup.visible).toBe(true);
     expect(upperGroup.visible).toBe(false);
+    expect(upperPoiGroup.visible).toBe(false);
     expect(upperLedGroup.visible).toBe(false);
 
     controller.setActiveFloorId('upper');
 
     expect(groundGroup.visible).toBe(false);
+    expect(groundStructureGroup.visible).toBe(false);
     expect(groundLedGroup.visible).toBe(false);
     expect(upperGroup.visible).toBe(true);
+    expect(upperPoiGroup.visible).toBe(true);
     expect(upperLedGroup.visible).toBe(true);
   });
 


### PR DESCRIPTION
### Motivation
- Upstairs view should not show ground-only POIs, ground-only 3D structures, or the backyard when the active floor is `upper` so the loft look is visually correct. 

### Description
- Add a `GroundStructureVisuals` group and move backyard and ground-only structures (Flywheel, Jobbot, Axel, TokenPlace, Gabriel, PR Reaper, Gitshelves, F2Clipboard, Sigma, Wove) into it so they can be toggled together without changing collision behavior. 
- Split POI parents into `GroundPoiVisuals` and `UpperPoiVisuals` and update POI placement to add instances into the appropriate group. 
- Include the new groups in `createFloorVisibilityController` so `upper` hides all ground visuals while keeping upper POIs/geometry visible. 
- Add a minimal test-only API `portfolio.world.getFloorVisibilitySnapshot()` to surface named group visibility booleans for Playwright assertions. 
- Update unit tests (`src/tests/floorVisibilityController.test.ts`) and end-to-end stairs roundtrip Playwright test (`playwright/immersive-stairs-roundtrip.spec.ts`) to assert ground structures/backyard/POI visibility when switching floors.

### Testing
- Ran `npm run format:write` (succeeded). 
- Ran `npm run lint` (succeeded). 
- Ran `npm run test:ci` (Vitest) and all unit tests passed (1070 tests across suites passed). 
- Ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and the updated stair roundtrip spec passed (6 tests passed). 
- Built production bundle with `npm run build` (succeeded) and `npm run smoke` (succeeded). 
- Ran `npm run docs:check` (passed; link checker emitted transient external fetch warnings). 
- Captured a manual Playwright screenshot and `getFloorVisibilitySnapshot()` returned the expected upstairs snapshot; screenshot saved at `/tmp/danielsmith-upper-floor-visibility.png`. 
- Ran `npm run typecheck` which failed due to unrelated repo-wide TypeScript strictness/errors (reported and unchanged by this patch). 

Residual risk: the typecheck failures are existing, repo-wide issues and not caused by these visibility changes; the runtime and test coverage added exercises the visibility transitions but follow-ups may refine backyard visibility logic if additional ground-only assets are added later.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27672333f0832fb5b8beca82f49d3b)