### PR TITLE
🧭 Fix upper landing stair blocker

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -70,6 +70,11 @@ type TestWorldApi = {
 type DebugColliderApi = {
   setEnabled(enabled: boolean): void;
   getColliders(): Array<{ name: string }>;
+  getBlockingCollidersAt(target: {
+    x: number;
+    z: number;
+    floorId?: FloorId;
+  }): Array<{ name: string }>;
 };
 
 type DebugCoordinatesApi = {
@@ -332,21 +337,47 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
-  // Enter the ramp and ascend to the upper floor.
+  // Enter the ramp, ascend to the upper floor, and step through the precise
+  // stair-top mouth onto the upper landing centerline.
   await movePlayerTo(page, {
     x: stairCenterX,
     z: (stairBottomZ + stairTopZ) / 2,
   });
-  await movePlayerTo(page, {
+  const stairTopHandoff = {
     x: stairCenterX,
     z: stairTopZ - stairDirection * 0.1,
-  });
+    floorId: 'upper' as const,
+  };
+  const firstLandingStep = {
+    x: stairCenterX,
+    z: stairTopZ + stairDirection * 0.1,
+    floorId: 'upper' as const,
+  };
+  expect(await canOccupyPosition(page, stairTopHandoff)).toBe(true);
+  expect(await canOccupyPosition(page, firstLandingStep)).toBe(true);
+  await movePlayerTo(page, stairTopHandoff);
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+  await movePlayerTo(page, firstLandingStep);
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   // Roam deeper onto the upper landing and confirm we stay upstairs.
   const landingRoamZ =
     stairLandingMinZ + Math.min(stairLandingDepth * 0.5, 0.6);
   await movePlayerTo(page, { x: stairCenterX, z: landingRoamZ });
+  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+  const landingState = await getWorldState(page);
+  expect(landingState.position.x).toBeCloseTo(stairCenterX, 1);
+  expect(landingState.position.z).toBeCloseTo(landingRoamZ, 1);
+
+  // Continue through the intended west (-X) landing exit into an upstairs room.
+  const landingWestExit = {
+    x: stairCenterX - 1.6,
+    z: stairTopZ + stairDirection * 1.8,
+    floorId: 'upper' as const,
+  };
+  expect(await canOccupyPosition(page, landingWestExit)).toBe(true);
+  await movePlayerTo(page, landingWestExit);
+  await movePlayerTo(page, getUpperRoomCenter('creatorsStudio'));
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   const upperTooltipState = await getTooltipState(page);
@@ -438,7 +469,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 2,
     floorId: 'upper' as const,
   };
-  const westHiddenStairVoidSliver = {
+  const westLandingMouthSliver = {
     x: stairCenterX - 1.55,
     z: stairTopZ + stairDirection * 2.1,
     floorId: 'upper' as const,
@@ -453,7 +484,12 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const hiddenStairVoidGap = [
+  const landingMouthSamples = [
+    {
+      x: stairCenterX,
+      z: stairTopZ - stairDirection * 0.1,
+      floorId: 'upper' as const,
+    },
     {
       x: stairCenterX,
       z: stairTopZ + stairDirection * 0.1,
@@ -490,13 +526,23 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
     false
   );
-  expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
+  expect(await canOccupyPosition(page, westLandingMouthSliver)).toBe(true);
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
-  expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
-  for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
-    expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);
+  for (const landingMouthSample of landingMouthSamples) {
+    expect(await canOccupyPosition(page, landingMouthSample)).toBe(true);
   }
+  expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
+  const hiddenRunBlockers = await page.evaluate((target) => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    return debugApi
+      .getBlockingCollidersAt(target)
+      .map((collider) => collider.name);
+  }, hiddenStairRun);
+  expect(hiddenRunBlockers).toContain('UpperStairHiddenRampGuard');
   await expect(async () => movePlayerTo(page, hiddenStairRun)).rejects.toThrow(
     /Cannot occupy/
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -384,6 +384,7 @@ import {
   classifyStairTransitionZone,
   createGroundStairBoundaryColliders,
   createStairNavigationZones,
+  createUpperStairVoidBoundaryColliders,
   isWithinLanding,
   isWithinStairWidth,
   predictStairFloorId,
@@ -586,6 +587,11 @@ declare global {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
+        getBlockingCollidersAt(target: {
+          x: number;
+          z: number;
+          floorId?: FloorId;
+        }): DebugColliderMetadata[];
       };
       debugCoordinates?: {
         getState(): {
@@ -1902,9 +1908,7 @@ function initializeImmersiveScene(
   // The upper-floor stairwell cutout intentionally comes from the same
   // computeStairLayout result used by movement. It removes both the stair
   // landing void and the hidden ramp run below the landing lip.
-  if (upperStairwellOpening) {
-    const upperStairVoidMinZ = upperStairwellOpening.minZ;
-    const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
+  if (upperLandingRoom && upperStairwellOpening) {
     const upperStairWestEgressMinZ = Math.min(
       stairLandingMinZ + stairwellMarginZ,
       stairLandingMaxZ
@@ -1916,95 +1920,27 @@ function initializeImmersiveScene(
 
     const upperLandingDoorwayClearanceZ =
       upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerNearZ =
-      stairTopZ +
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin);
-    const hiddenStairTopGapBlockerFarZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
-    const hiddenStairWestVoidGapBlockerMaxZ = upperStairWestEgressMaxZ;
-    const hiddenStairDeepVoidBlockerMinZ =
-      hiddenStairWestVoidGapBlockerMinZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairDeepVoidBlockerMaxZ =
-      hiddenStairTopGapBlockerNearZ +
-      stairLayout.directionMultiplier * PLAYER_RADIUS * 2;
-    const hiddenStairBlockerStartZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin / 2);
-    const hiddenStairBlockerMaxZ = Math.min(
-      upperStairVoidMaxZ,
-      upperLandingDoorwayClearanceZ
-    );
+    const upperStairVoidBoundaryColliders =
+      createUpperStairVoidBoundaryColliders(stairGeometry, {
+        openingBounds: upperStairwellOpening,
+        roomBounds: upperLandingRoom.bounds,
+        explicitDescentCorridor: stairNavigationZones.explicitDescentCorridor,
+        playerRadius: PLAYER_RADIUS,
+        stairwellMarginX,
+        westEgressMinZ: upperStairWestEgressMinZ,
+        westEgressMaxZ: upperStairWestEgressMaxZ,
+        doorwayClearanceZ: upperLandingDoorwayClearanceZ,
+      });
 
-    // Invisible upper-floor guard rails flank the intentional descent corridor.
-    // They are scoped to the actual upper-floor cutout instead of the full ramp
-    // run so normal loft space beyond the landing remains occupiable. The center
-    // blockers reject forced upper-floor placement over the hidden stair-top gap,
-    // the deeper removed stair run, and doorway-side void while preserving the
-    // narrow stair-top handoff, a west-side bypass lane around the void, and the
-    // north doorway's padded passage into the loft. The west-edge blocker starts
-    // at the visual cutout because collider checks already apply PLAYER_RADIUS
-    // clearance around the blocker edge.
-    upperFloorColliders.push(
-      {
-        minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-        maxX: stairNavigationZones.explicitDescentCorridor.minX,
-        minZ: upperStairVoidMinZ,
-        maxZ: upperStairWestEgressMinZ,
-      },
-      {
-        minX: upperStairwellOpening.minX,
-        maxX: stairNavigationZones.explicitDescentCorridor.minX,
-        minZ: upperStairWestEgressMaxZ,
-        maxZ: upperStairVoidMaxZ,
-      },
-      {
-        minX: stairNavigationZones.explicitDescentCorridor.maxX,
-        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-        minZ: upperStairVoidMinZ,
-        maxZ: upperStairVoidMaxZ,
-      },
-      {
-        minX: upperStairwellOpening.minX,
-        maxX: stairNavigationZones.explicitDescentCorridor.minX,
-        minZ: hiddenStairWestVoidGapBlockerMinZ,
-        maxZ: hiddenStairWestVoidGapBlockerMaxZ,
-      },
-      {
-        minX: stairNavigationZones.explicitDescentCorridor.minX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-        minZ: Math.min(
-          hiddenStairDeepVoidBlockerMinZ,
-          hiddenStairDeepVoidBlockerMaxZ
-        ),
-        maxZ: Math.max(
-          hiddenStairDeepVoidBlockerMinZ,
-          hiddenStairDeepVoidBlockerMaxZ
-        ),
-      },
-      {
-        minX: hiddenStairTopGapBlockerMinX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-        minZ: Math.min(
-          hiddenStairTopGapBlockerNearZ,
-          hiddenStairTopGapBlockerFarZ
-        ),
-        maxZ: Math.max(
-          hiddenStairTopGapBlockerNearZ,
-          hiddenStairTopGapBlockerFarZ
-        ),
-      },
-      {
-        minX: stairNavigationZones.explicitDescentCorridor.minX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-        minZ: Math.min(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
-        maxZ: Math.max(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
-      }
-    );
+    // Invisible upper-floor guard rails flank the hidden stair run without
+    // covering the stair-top-to-landing mouth. Keeping the blockers generated
+    // from the shared stair layout makes the collision contract explicit: the
+    // hidden ramp side is protected, while the upper landing side remains
+    // occupiable for legitimate ascents.
+    upperStairVoidBoundaryColliders.forEach(({ name, bounds }) => {
+      upperFloorColliders.push(bounds);
+      namedColliderDebugNames.set(bounds, name);
+    });
   }
 
   const upperLandingCutouts =
@@ -4227,6 +4163,14 @@ function initializeImmersiveScene(
       setDebugCollidersEnabled(enabled);
     },
     getColliders: () => colliderVisualizer.getColliders(),
+    getBlockingCollidersAt: ({ x, z, floorId = activeFloorId }) =>
+      colliderVisualizer
+        .getColliders()
+        .filter(
+          (collider) =>
+            (collider.floor === 'all' || collider.floor === floorId) &&
+            collidesWithColliders(x, z, PLAYER_RADIUS, [collider.bounds])
+        ),
   };
 
   window.portfolio.debugCoordinates = {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -5,6 +5,7 @@ import { collidesWithColliders } from '../collision';
 import {
   createGroundStairBoundaryColliders,
   createStairNavigationZones,
+  createUpperStairVoidBoundaryColliders,
   type StairBehavior,
   type StairGeometry,
 } from './stairs';
@@ -125,6 +126,76 @@ describe('createGroundStairBoundaryColliders', () => {
       expect(
         collidesWithColliders(sample.x, sample.z, PLAYER_RADIUS, boundaryBounds)
       ).toBe(false);
+    });
+  });
+});
+
+describe('createUpperStairVoidBoundaryColliders', () => {
+  const zones = createStairNavigationZones(geometry, behavior);
+  const upperVoidColliders = createUpperStairVoidBoundaryColliders(geometry, {
+    openingBounds: { minX: 8.9, maxX: 15.9, minZ: -31.9, maxZ: -16 },
+    roomBounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+    explicitDescentCorridor: zones.explicitDescentCorridor,
+    playerRadius: PLAYER_RADIUS,
+    stairwellMarginX: 0.4,
+    westEgressMinZ: -30.3,
+    westEgressMaxZ: -25.9,
+    doorwayClearanceZ: -17.75,
+  });
+  const upperVoidBounds = upperVoidColliders.map((collider) => collider.bounds);
+
+  it('names concise upper void guards for collider debug visualization', () => {
+    expect(upperVoidColliders.map((collider) => collider.name)).toEqual([
+      'UpperStairWestVoidGuard-LandingSide',
+      'UpperStairWestVoidGuard-RoomSide',
+      'UpperStairEastVoidGuard',
+      'UpperStairWestVoidGapGuard',
+      'UpperStairHiddenRampGuard',
+    ]);
+  });
+
+  it('leaves the stair-top and landing centerline occupiable', () => {
+    const clearSamples = [
+      { x: geometry.centerX, z: geometry.topZ - geometry.direction * 0.1 },
+      { x: geometry.centerX, z: geometry.topZ + geometry.direction * 0.1 },
+      { x: geometry.centerX, z: geometry.landingMinZ + 0.6 },
+    ];
+
+    clearSamples.forEach((sample) => {
+      expect(
+        collidesWithColliders(
+          sample.x,
+          sample.z,
+          PLAYER_RADIUS,
+          upperVoidBounds
+        )
+      ).toBe(false);
+    });
+  });
+
+  it('continues blocking the hidden ramp and west void gaps', () => {
+    const blockedSamples = [
+      { x: 12.7, z: -23.72 },
+      {
+        x: geometry.centerX - 1.9,
+        z: geometry.topZ + geometry.direction * 0.95,
+      },
+      {
+        x: geometry.centerX - 2.6,
+        z: geometry.topZ + geometry.direction * 2.1,
+      },
+      { x: geometry.centerX + geometry.halfWidth + 0.15, z: geometry.topZ - 1 },
+    ];
+
+    blockedSamples.forEach((sample) => {
+      expect(
+        collidesWithColliders(
+          sample.x,
+          sample.z,
+          PLAYER_RADIUS,
+          upperVoidBounds
+        )
+      ).toBe(true);
     });
   });
 });

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -251,6 +251,127 @@ export const createGroundStairBoundaryColliders = (
   return colliders;
 };
 
+export interface UpperStairVoidBoundaryColliderOptions {
+  openingBounds: RectCollider;
+  roomBounds: RectCollider;
+  explicitDescentCorridor: RectCollider;
+  playerRadius: number;
+  stairwellMarginX: number;
+  /**
+   * Furthest usable landing z before the west-side room egress begins. This
+   * keeps the void guards out of the intentional stair-top landing mouth.
+   */
+  westEgressMinZ: number;
+  westEgressMaxZ: number;
+  doorwayClearanceZ: number;
+}
+
+const clampRectToBounds = (
+  rect: RectCollider,
+  bounds: RectCollider
+): RectCollider => ({
+  minX: Math.max(rect.minX, bounds.minX),
+  maxX: Math.min(rect.maxX, bounds.maxX),
+  minZ: Math.max(rect.minZ, bounds.minZ),
+  maxZ: Math.min(rect.maxZ, bounds.maxZ),
+});
+
+const maybeAddNamedCollider = (
+  colliders: NamedStairBoundaryCollider[],
+  name: string,
+  bounds: RectCollider,
+  clipBounds: RectCollider
+) => {
+  const clipped = clampRectToBounds(bounds, clipBounds);
+  if (clipped.maxX > clipped.minX && clipped.maxZ > clipped.minZ) {
+    colliders.push({ name, bounds: clipped });
+  }
+};
+
+/**
+ * Creates upper-floor void blockers around the hidden stair run while leaving
+ * the physical stair-top-to-landing mouth open. The center corridor is only
+ * blocked on the hidden ramp side of the stair lip; the upper landing side is
+ * walkable so legitimate ascents can complete without loosening floor
+ * prediction.
+ */
+export const createUpperStairVoidBoundaryColliders = (
+  geometry: StairGeometry,
+  options: UpperStairVoidBoundaryColliderOptions
+): NamedStairBoundaryCollider[] => {
+  const colliders: NamedStairBoundaryCollider[] = [];
+  const openingBounds = clampRectToBounds(
+    options.openingBounds,
+    options.roomBounds
+  );
+  const stairWestEdge = geometry.centerX - geometry.halfWidth;
+  const stairEastEdge = geometry.centerX + geometry.halfWidth;
+  const voidRunBlockerNearZ =
+    geometry.topZ - geometry.direction * (options.playerRadius + 0.15);
+  const voidRunBlockerFarZ =
+    geometry.direction === -1
+      ? Math.min(openingBounds.maxZ, options.doorwayClearanceZ)
+      : Math.max(openingBounds.minZ, options.doorwayClearanceZ);
+
+  maybeAddNamedCollider(
+    colliders,
+    'UpperStairWestVoidGuard-LandingSide',
+    {
+      minX: stairWestEdge - options.stairwellMarginX,
+      maxX: options.explicitDescentCorridor.minX,
+      minZ: openingBounds.minZ,
+      maxZ: options.westEgressMinZ,
+    },
+    openingBounds
+  );
+  maybeAddNamedCollider(
+    colliders,
+    'UpperStairWestVoidGuard-RoomSide',
+    {
+      minX: openingBounds.minX,
+      maxX: options.explicitDescentCorridor.minX,
+      minZ: options.westEgressMaxZ,
+      maxZ: openingBounds.maxZ,
+    },
+    openingBounds
+  );
+  maybeAddNamedCollider(
+    colliders,
+    'UpperStairEastVoidGuard',
+    {
+      minX: options.explicitDescentCorridor.maxX,
+      maxX: stairEastEdge + options.stairwellMarginX,
+      minZ: openingBounds.minZ,
+      maxZ: openingBounds.maxZ,
+    },
+    openingBounds
+  );
+  maybeAddNamedCollider(
+    colliders,
+    'UpperStairWestVoidGapGuard',
+    {
+      minX: openingBounds.minX,
+      maxX: options.explicitDescentCorridor.minX,
+      minZ: options.westEgressMinZ,
+      maxZ: options.westEgressMaxZ,
+    },
+    openingBounds
+  );
+  maybeAddNamedCollider(
+    colliders,
+    'UpperStairHiddenRampGuard',
+    {
+      minX: options.explicitDescentCorridor.minX,
+      maxX: options.explicitDescentCorridor.maxX,
+      minZ: Math.min(voidRunBlockerNearZ, voidRunBlockerFarZ),
+      maxZ: Math.max(voidRunBlockerNearZ, voidRunBlockerFarZ),
+    },
+    openingBounds
+  );
+
+  return colliders;
+};
+
 const isInExplicitDescentCorridor = (
   geometry: StairGeometry,
   behavior: StairBehavior,


### PR DESCRIPTION
### Motivation
- Repair a regression that allowed a legitimate stair ascent to reach the stair top but be blocked by upper-floor collision/nav guards before entering the upper landing. 
- Preserve the previous fixes and safety contracts: off-stair teleport remains blocked, over-stair/void remains blocked, ground squeeze guards remain effective, and floor-prediction (Contract A) is not loosened. 
- Add minimal debug tooling to make it easy to identify which named collider blocks a given position during tests and manual inspection.

### Description
- Added `createUpperStairVoidBoundaryColliders(...)` in `src/systems/movement/stairs.ts` to generate named, clipped upper-floor void blockers that explicitly leave the stair-top-to-landing mouth walkable. 
- Replaced the ad-hoc upper-floor blocker stack in `src/main.ts` with the generated named colliders and registered names in `namedColliderDebugNames` so debug visualization remains useful and human-readable. 
- Exposed a lightweight debug helper `window.portfolio.debugColliders.getBlockingCollidersAt({ x, z, floorId })` in `src/main.ts` that returns collider metadata (names/bounds) for tests and diagnostics without returning Three.js objects. 
- Added unit tests and e2e coverage by extending `src/systems/movement/stairs.test.ts` (new `createUpperStairVoidBoundaryColliders` checks) and `playwright/immersive-stairs-roundtrip.spec.ts` to assert the precise stair-top handoff, the first upper-landing step, west (-X) landing exit, hidden-ramp rejection, and debug-collider attribution.

### Testing
- Formatting and linting: ran `npm run format:write` (succeeded) and `npm run lint` (succeeded). 
- Unit / CI tests: ran `npm run test:ci` (Vitest) and targeted `npx vitest run src/systems/movement/stairs.test.ts`, both succeeded (Vitest suite passed; local stair tests passed). 
- Playwright: ran `npx playwright install` / `npx playwright install-deps` as needed and then `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed locally (the spec's stair handoff, landing, west-exit, and hidden-run assertions all passed). 
- Build / docs / smoke: ran `npm run build`, `npm run docs:check` (docs check passed; link checker printed external fetch warnings), and `npm run smoke`, all succeeded. 
- Typecheck: ran `npm run typecheck` which reported existing repository-wide TypeScript errors unrelated to this change (these pre-existing errors are outside this PR and did not block testing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a284a0aaf28832f917ebe7ae71cde5e)