### PR TITLE
🪜 Fix stair ascent handoff and strengthen continuous stair-climb tests

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -44,6 +44,13 @@ type TestWorldApi = {
     floorId?: FloorId;
   }): boolean;
   getPlayerPosition(): { x: number; y: number; z: number };
+  stepPlayerForTest(input: { dx?: number; dz?: number }): {
+    movedX: boolean;
+    movedZ: boolean;
+    activeFloor: FloorId;
+    position: { x: number; y: number; z: number };
+    blockedBy?: string[];
+  };
   predictFloorAt(target: {
     x: number;
     z: number;
@@ -216,6 +223,106 @@ async function getFloorVisibilitySnapshot(
   });
 }
 
+type MovementStepResult = ReturnType<TestWorldApi['stepPlayerForTest']>;
+
+async function stepPlayerForTest(
+  page: Page,
+  input: { dx?: number; dz?: number }
+): Promise<MovementStepResult> {
+  return page.evaluate((next) => {
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+    return world.stepPlayerForTest(next);
+  }, input);
+}
+
+async function walkAxisForTest(
+  page: Page,
+  axis: 'x' | 'z',
+  target: number,
+  stepSize = 0.18
+): Promise<MovementStepResult[]> {
+  const results: MovementStepResult[] = [];
+
+  for (let index = 0; index < 240; index += 1) {
+    const { position } = await getWorldState(page);
+    const current = axis === 'x' ? position.x : position.z;
+    const remaining = target - current;
+    if (Math.abs(remaining) <= 0.01) {
+      return results;
+    }
+
+    const step = Math.sign(remaining) * Math.min(Math.abs(remaining), stepSize);
+    const result = await stepPlayerForTest(
+      page,
+      axis === 'x' ? { dx: step } : { dz: step }
+    );
+    results.push(result);
+    const moved = axis === 'x' ? result.movedX : result.movedZ;
+    expect(result.blockedBy ?? []).toEqual([]);
+    expect(moved).toBe(true);
+  }
+
+  throw new Error(`Timed out walking ${axis} axis to ${target.toFixed(2)}`);
+}
+
+async function walkStairCenterlineToUpperLanding(page: Page) {
+  const { stairCenterX, stairBottomZ, stairTopZ, stairDirection } =
+    await getStairMetrics(page);
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairBottomZ - stairDirection * 0.3,
+    floorId: 'ground',
+  });
+
+  const lowerState = await getWorldState(page);
+  expect(lowerState.activeFloor).toBe('ground');
+  expect(Math.abs(lowerState.position.x - stairCenterX)).toBeLessThan(0.01);
+
+  const handoffZ = stairTopZ + stairDirection * 0.9;
+  const results = await walkAxisForTest(page, 'z', handoffZ, 0.18);
+  expect(results.length).toBeGreaterThan(0);
+
+  const transitionIndex = results.findIndex(
+    (result) => result.activeFloor === 'upper'
+  );
+  expect(transitionIndex).toBeGreaterThanOrEqual(0);
+
+  expect(
+    Math.max(...results.map((result) => result.position.y))
+  ).toBeGreaterThan(lowerState.position.y);
+
+  results.forEach((result, index) => {
+    if (index < transitionIndex) {
+      expect(result.activeFloor).toBe('ground');
+      expect(
+        stairDirection === -1
+          ? result.position.z > stairTopZ
+          : result.position.z < stairTopZ
+      ).toBe(true);
+    } else {
+      expect(result.activeFloor).toBe('upper');
+      expect(
+        stairDirection === -1
+          ? result.position.z <= stairTopZ
+          : result.position.z >= stairTopZ
+      ).toBe(true);
+    }
+  });
+
+  const finalState = await getWorldState(page);
+  expect(finalState.activeFloor).toBe('upper');
+  expect(
+    stairDirection === -1
+      ? finalState.position.z < stairTopZ
+      : finalState.position.z > stairTopZ
+  ).toBe(true);
+
+  return results;
+}
+
 test('off-stair ground points near the upper stair top stay on ground', async ({
   page,
 }) => {
@@ -265,7 +372,8 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
-  const { stairCenterX, stairBottomZ, stairTopZ } = await getStairMetrics(page);
+  const { stairCenterX, stairBottomZ, stairTopZ, stairDirection } =
+    await getStairMetrics(page);
   const blockedSamples = [
     { x: 17.38, z: -8.84, floorId: 'ground' as const },
     { x: 21.35, z: -14.66, floorId: 'ground' as const },
@@ -299,7 +407,10 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     x: stairCenterX,
     z: (stairBottomZ + stairTopZ) / 2,
   });
-  await movePlayerTo(page, { x: stairCenterX, z: stairTopZ + 0.1 });
+  await movePlayerTo(page, {
+    x: stairCenterX,
+    z: stairTopZ + stairDirection * 0.1,
+  });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
   const debugColliders = await page.evaluate(() => {
@@ -331,44 +442,30 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     stairDirection,
   } = await getStairMetrics(page);
 
-  // Start on ground.
+  // Start on ground, then walk the real per-frame stair path onto the landing.
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
-
-  // Move to the base of the staircase on the ground floor.
-  await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
-  await expect(html).toHaveAttribute('data-active-floor', 'ground');
-
-  // Enter the ramp and ascend to the upper floor.
-  await movePlayerTo(page, {
-    x: stairCenterX,
-    z: (stairBottomZ + stairTopZ) / 2,
-  });
-  await movePlayerTo(page, {
-    x: stairCenterX,
-    z: stairTopZ - stairDirection * 0.1,
-  });
+  await walkStairCenterlineToUpperLanding(page);
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
-  // Step from the stair top through the explicit upper-landing mouth.
-  const firstUpperLandingStep = {
+  const upperLandingMouthSamples = [0.05, 0.4, 0.8].map((offset) => ({
     x: stairCenterX,
-    z: stairTopZ + stairDirection * 0.4,
+    z: stairTopZ + stairDirection * offset,
     floorId: 'upper' as const,
-  };
-  expect(await canOccupyPosition(page, firstUpperLandingStep)).toBe(true);
-  await movePlayerTo(page, firstUpperLandingStep);
-  await expect(html).toHaveAttribute('data-active-floor', 'upper');
+  }));
 
-  const blockingCollidersAtLandingMouth = await page.evaluate((target) => {
-    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
-    if (!debugApi) {
-      throw new Error('Debug colliders API unavailable');
-    }
-    return debugApi
-      .getBlockingCollidersAt(target)
-      .map((collider) => collider.name);
-  }, firstUpperLandingStep);
-  expect(blockingCollidersAtLandingMouth).toEqual([]);
+  for (const sample of upperLandingMouthSamples) {
+    expect(await canOccupyPosition(page, sample)).toBe(true);
+    const blockingCollidersAtLandingMouth = await page.evaluate((target) => {
+      const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+      if (!debugApi) {
+        throw new Error('Debug colliders API unavailable');
+      }
+      return debugApi
+        .getBlockingCollidersAt(target)
+        .map((collider) => collider.name);
+    }, sample);
+    expect(blockingCollidersAtLandingMouth).toEqual([]);
+  }
 
   // Continue through the intended west upper-landing exit into an upstairs room.
   const upperLandingWestExit = {
@@ -377,9 +474,23 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     floorId: 'upper' as const,
   };
   expect(await canOccupyPosition(page, upperLandingWestExit)).toBe(true);
+  await walkAxisForTest(page, 'z', upperLandingWestExit.z);
   await movePlayerTo(page, upperLandingWestExit);
-  await movePlayerTo(page, getUpperRoomCenter('creatorsStudio'));
+
+  const creatorsStudioCenter = getUpperRoomCenter('creatorsStudio');
+  await movePlayerTo(page, creatorsStudioCenter);
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
+
+  const upstairsRoomState = await page.evaluate(() => {
+    const debugCoordinates = (window as PortfolioWindow).portfolio
+      ?.debugCoordinates;
+    if (!debugCoordinates) {
+      throw new Error('Debug coordinates API unavailable');
+    }
+    debugCoordinates.setEnabled(true);
+    return debugCoordinates.getState();
+  });
+  expect(upstairsRoomState.currentRoomId).toBe('creatorsStudio');
 
   // Roam deeper onto the upper landing and confirm we stay upstairs.
   const landingRoamZ =
@@ -508,19 +619,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const hiddenStairVoidGap = [
-    {
-      x: stairCenterX - PLAYER_RADIUS * 0.5,
-      z: stairTopZ + stairDirection * 0.95,
-      floorId: 'upper' as const,
-    },
-    {
-      x: stairCenterX,
-      z: stairTopZ + stairDirection * 0.95,
-      floorId: 'upper' as const,
-    },
-  ];
-
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await movePlayerTo(page, {
     x: stairCenterX,
@@ -528,7 +626,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   });
   await movePlayerTo(page, {
     x: stairCenterX,
-    z: stairTopZ - stairDirection * 0.1,
+    z: stairTopZ + stairDirection * 0.1,
   });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
@@ -552,9 +650,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
-  for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
-    expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);
-  }
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
   await expect(async () => movePlayerTo(page, hiddenStairRun)).rejects.toThrow(
     /Cannot occupy/
@@ -638,7 +733,7 @@ test('debug coordinates and upstairs POI state stay floor-aware', async ({
 
   await movePlayerTo(page, {
     x: stairCenterX,
-    z: stairTopZ - stairDirection * 0.1,
+    z: stairTopZ + stairDirection * 0.1,
   });
   await movePlayerTo(page, { x: stairCenterX, z: landingInteriorZ });
   await expect(html).toHaveAttribute('data-active-floor', 'upper');

--- a/src/main.ts
+++ b/src/main.ts
@@ -619,6 +619,13 @@ declare global {
         }): boolean;
         setActiveFloor(next: FloorId): void;
         movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+        stepPlayerForTest(input: { dx?: number; dz?: number }): {
+          movedX: boolean;
+          movedZ: boolean;
+          activeFloor: FloorId;
+          position: { x: number; y: number; z: number };
+          blockedBy?: string[];
+        };
         getPlayerPosition(): { x: number; y: number; z: number };
         predictFloorAt(target: {
           x: number;
@@ -2073,15 +2080,6 @@ function initializeImmersiveScene(
       },
       ...upperStairTopGapBlockers,
       {
-        name: 'UpperStairTopGapCenterLipBlocker',
-        bounds: {
-          minX: hiddenStairTopGapBlockerMinX,
-          maxX: stairCenterX + PLAYER_RADIUS,
-          minZ: hiddenStairTopGapBlockerMinZ - stairwellMarginX * 0.1,
-          maxZ: hiddenStairTopGapBlockerMinZ,
-        },
-      },
-      {
         name: 'UpperStairHiddenRunBlocker',
         bounds: {
           minX: stairNavigationZones.explicitDescentCorridor.minX,
@@ -3267,6 +3265,13 @@ function initializeImmersiveScene(
         setActiveFloorId(predictedFloor);
         updatePlayerVerticalPosition();
       },
+      stepPlayerForTest(input: { dx?: number; dz?: number }) {
+        return applyPlayerMovementStep({
+          dx: input.dx ?? 0,
+          dz: input.dz ?? 0,
+          resetBlockedVelocity: false,
+        });
+      },
       // Test helpers – intentionally minimal and read-only in production.
       getPlayerPosition() {
         return {
@@ -3963,6 +3968,113 @@ function initializeImmersiveScene(
       upperFloorElevation,
     });
     player.position.y = PLAYER_RADIUS + baseHeight;
+  };
+
+  const getBlockingColliderNamesAt = (
+    x: number,
+    z: number,
+    floorId: FloorId
+  ): string[] => {
+    const names: string[] = [];
+    if (!navMeshes[floorId].contains(x, z)) {
+      names.push(`${floorId}:NavMesh`);
+    }
+
+    for (const collider of floorColliders[floorId]) {
+      if (collidesWithColliders(x, z, PLAYER_RADIUS, [collider])) {
+        names.push(
+          namedColliderDebugNames.get(collider) ?? `${floorId}:collider`
+        );
+      }
+    }
+
+    if (floorId === 'ground') {
+      for (const collider of staticColliders) {
+        if (collidesWithColliders(x, z, PLAYER_RADIUS, [collider])) {
+          names.push(
+            namedColliderDebugNames.get(collider) ?? 'static:collider'
+          );
+        }
+      }
+    }
+
+    return names;
+  };
+
+  const applyPlayerMovementStep = ({
+    dx,
+    dz,
+    resetBlockedVelocity,
+  }: {
+    dx: number;
+    dz: number;
+    resetBlockedVelocity: boolean;
+  }) => {
+    let movedX = false;
+    let movedZ = false;
+    const blockedBy = new Set<string>();
+
+    if (dx !== 0) {
+      const candidateX = player.position.x + dx;
+      const predictedFloor = predictFloorId(
+        candidateX,
+        player.position.z,
+        activeFloorId
+      );
+      if (canOccupyPosition(candidateX, player.position.z, predictedFloor)) {
+        player.position.x = candidateX;
+        setActiveFloorId(predictedFloor);
+        movedX = true;
+      } else {
+        getBlockingColliderNamesAt(
+          candidateX,
+          player.position.z,
+          predictedFloor
+        ).forEach((name) => blockedBy.add(name));
+        if (resetBlockedVelocity) {
+          targetVelocity.x = 0;
+          velocity.x = 0;
+        }
+      }
+    }
+
+    if (dz !== 0) {
+      const candidateZ = player.position.z + dz;
+      const predictedFloor = predictFloorId(
+        player.position.x,
+        candidateZ,
+        activeFloorId
+      );
+      if (canOccupyPosition(player.position.x, candidateZ, predictedFloor)) {
+        player.position.z = candidateZ;
+        setActiveFloorId(predictedFloor);
+        movedZ = true;
+      } else {
+        getBlockingColliderNamesAt(
+          player.position.x,
+          candidateZ,
+          predictedFloor
+        ).forEach((name) => blockedBy.add(name));
+        if (resetBlockedVelocity) {
+          targetVelocity.z = 0;
+          velocity.z = 0;
+        }
+      }
+    }
+
+    updatePlayerVerticalPosition();
+
+    return {
+      movedX,
+      movedZ,
+      activeFloor: activeFloorId,
+      position: {
+        x: player.position.x,
+        y: player.position.y,
+        z: player.position.z,
+      },
+      ...(blockedBy.size > 0 ? { blockedBy: Array.from(blockedBy) } : {}),
+    };
   };
 
   updatePlayerVerticalPosition();
@@ -5272,39 +5384,11 @@ function initializeImmersiveScene(
     const stepX = velocity.x * delta;
     const stepZ = velocity.z * delta;
 
-    if (stepX !== 0) {
-      const candidateX = player.position.x + stepX;
-      const predictedFloor = predictFloorId(
-        candidateX,
-        player.position.z,
-        activeFloorId
-      );
-      if (canOccupyPosition(candidateX, player.position.z, predictedFloor)) {
-        player.position.x = candidateX;
-        setActiveFloorId(predictedFloor);
-      } else {
-        targetVelocity.x = 0;
-        velocity.x = 0;
-      }
-    }
-
-    if (stepZ !== 0) {
-      const candidateZ = player.position.z + stepZ;
-      const predictedFloor = predictFloorId(
-        player.position.x,
-        candidateZ,
-        activeFloorId
-      );
-      if (canOccupyPosition(player.position.x, candidateZ, predictedFloor)) {
-        player.position.z = candidateZ;
-        setActiveFloorId(predictedFloor);
-      } else {
-        targetVelocity.z = 0;
-        velocity.z = 0;
-      }
-    }
-
-    updatePlayerVerticalPosition();
+    applyPlayerMovementStep({
+      dx: stepX,
+      dz: stepZ,
+      resetBlockedVelocity: true,
+    });
 
     // Update facing: aim toward current planar velocity when moving.
     const speedSq = velocity.x * velocity.x + velocity.z * velocity.z;

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -340,7 +340,6 @@ export const predictStairFloorId = (
   current: FloorId
 ): FloorId => {
   const zone = classifyStairTransitionZone(geometry, behavior, x, z, current);
-  const rampHeight = computeRampHeight(geometry, behavior, x, z);
   const withinPhysicalStairs = isWithinPhysicalStairWidth(geometry, x);
   const withinRampRun = isWithinRampRun(geometry, z);
   const direction = geometry.direction;
@@ -353,16 +352,13 @@ export const predictStairFloorId = (
     return 'ground';
   }
 
-  const nearTop =
-    direction === -1
-      ? z <= geometry.topZ + behavior.transitionMargin
-      : z >= geometry.topZ - behavior.transitionMargin;
-
-  const nearLanding =
+  const atOrPastStairTop =
+    direction === -1 ? z <= geometry.topZ : z >= geometry.topZ;
+  const reachedLandingHandoff =
     withinPhysicalStairs &&
-    withinRampRun &&
-    (nearTop || rampHeight >= geometry.totalRise - behavior.stepRise * 0.25);
-  if (nearLanding) {
+    atOrPastStairTop &&
+    (withinRampRun || isWithinLanding(geometry, x, z));
+  if (reachedLandingHandoff) {
     return 'upper';
   }
 

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -70,17 +70,29 @@ const containsPoint = (
   point.z <= rect.maxZ;
 
 describe('stair floor transitions (negative Z ascent)', () => {
-  it('transitions from ground to upper near the top of the stairs', () => {
-    const nearTopStepZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.15);
+  it('keeps centerline ramp samples just before the stair top on ground', () => {
+    const beforeTopStepZ = NEGATIVE_Z_STAIRS.topZ + toWorldUnits(0.15);
 
     expect(
       predict(
         NEGATIVE_Z_STAIRS,
         NEGATIVE_Z_STAIRS.centerX,
-        nearTopStepZ,
+        beforeTopStepZ,
         'ground'
       )
-    ).toBe('upper');
+    ).toBe('ground');
+  });
+
+  it('transitions from ground to upper at and past the stair top', () => {
+    for (const z of [
+      NEGATIVE_Z_STAIRS.topZ,
+      NEGATIVE_Z_STAIRS.topZ - toWorldUnits(0.05),
+      NEGATIVE_Z_STAIRS.topZ - toWorldUnits(0.4),
+    ]) {
+      expect(
+        predict(NEGATIVE_Z_STAIRS, NEGATIVE_Z_STAIRS.centerX, z, 'ground')
+      ).toBe('upper');
+    }
   });
 
   it('keeps screenshot-4 off-stair ground points near the top on ground', () => {
@@ -107,7 +119,7 @@ describe('stair floor transitions (negative Z ascent)', () => {
     expect(height).toBe(0);
   });
 
-  it('keeps ground-floor positions past the ramp run on ground', () => {
+  it('allows centerline ground ascent to hand off onto the upper landing', () => {
     const upperDoorwayBridgeZ = NEGATIVE_Z_STAIRS.topZ - toWorldUnits(0.6);
 
     expect(
@@ -125,17 +137,7 @@ describe('stair floor transitions (negative Z ascent)', () => {
         upperDoorwayBridgeZ,
         'ground'
       )
-    ).toBe('ground');
-    expect(
-      sampleStairSurfaceHeight({
-        geometry: NEGATIVE_Z_STAIRS,
-        behavior: STAIR_BEHAVIOR,
-        x: NEGATIVE_Z_STAIRS.centerX,
-        z: upperDoorwayBridgeZ,
-        currentFloor: 'ground',
-        upperFloorElevation: UPPER_FLOOR_ELEVATION,
-      })
-    ).toBe(0);
+    ).toBe('upper');
   });
 
   it('keeps the player on the upper floor while roaming across the landing', () => {
@@ -346,6 +348,31 @@ describe('stair floor transitions (positive Z ascent)', () => {
     expect(
       predict(positiveGeometry, positiveGeometry.centerX, firstStepZ, 'upper')
     ).toBe('ground');
+  });
+
+  it('keeps positive-Z centerline ramp samples just before the stair top on ground', () => {
+    const beforeTopStepZ = positiveGeometry.topZ - toWorldUnits(0.15);
+
+    expect(
+      predict(
+        positiveGeometry,
+        positiveGeometry.centerX,
+        beforeTopStepZ,
+        'ground'
+      )
+    ).toBe('ground');
+  });
+
+  it('transitions positive-Z ground ascent at and past the stair top', () => {
+    for (const z of [
+      positiveGeometry.topZ,
+      positiveGeometry.topZ + toWorldUnits(0.05),
+      positiveGeometry.topZ + toWorldUnits(0.4),
+    ]) {
+      expect(
+        predict(positiveGeometry, positiveGeometry.centerX, z, 'ground')
+      ).toBe('upper');
+    }
   });
 
   it('keeps positive-Z descents on ground through the top handoff band', () => {


### PR DESCRIPTION
### Motivation
- Ground→upper floor prediction was happening too early while the avatar was still on the ramp, allowing upper-floor colliders to block a legitimate stair climb. 
- Browser tests relied on teleport-style sampling and missed per-frame axis-by-axis collision/floor-hand-off failures.

### Description
- Change floor prediction so ground→upper only occurs at/past the physical stair top or when classified as `upperLanding`, preserving ground while still on the ramp centerline (`predictStairFloorId`).
- Remove the upper landing center-lip blocker so the real stair-mouth corridor is not blocked while keeping the named upper-run/top-gap/void blockers for other regressions and debug visualization.
- Factor the runtime axis-by-axis movement/collision logic into `applyPlayerMovementStep(...)` and expose `stepPlayerForTest(...)` on `window.portfolio.world` so tests run the exact same `predictFloorId` / `canOccupyPosition` / `setActiveFloorId` / vertical-update path used in production.
- Add unit tests for stair handoff timing and update Playwright test `playwright/immersive-stairs-roundtrip.spec.ts` to walk the stair centerline using many small steps, assert no blocking colliders at several landing-mouth samples, and validate the upstairs room/visibility state after a continuous climb.

### Testing
- Ran formatting and linting via `npm run format:write` and `npm run lint` (both succeeded). 
- Ran unit tests via `npm run test:ci` and the modified stair unit tests passed (Vitest reported all tests passing). 
- Ran smoke/build via `npm run smoke` / `npm run build` (build and smoke checks passed). 
- Ran the updated Playwright scenario with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and the new continuous climb assertions passed. 
- Ran `npm run docs:check` and link checks (passed with external fetch warnings); `git diff --cached | ./scripts/scan-secrets.py` returned no high-risk secrets. 
- `npm run typecheck` still fails due to unrelated repository-wide TypeScript issues and was not changed by this PR (these errors pre-existed and are out-of-scope for the stair fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28d830975c832fabed581bdd486cef)