### PR TITLE
Widen upper landing west egress

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -161,6 +161,35 @@ async function movePlayerTo(
   await page.waitForTimeout(150);
 }
 
+function getUpperLandingWestDoorway() {
+  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'upperLanding'
+  );
+  const westDoorway = upperLandingRoom?.doorways?.find(
+    (doorway) => doorway.wall === 'west'
+  );
+  if (!upperLandingRoom || !westDoorway) {
+    throw new Error('Missing upper landing west doorway');
+  }
+
+  return { upperLandingRoom, westDoorway };
+}
+
+function getUpperLandingWestEgressZSamples(westDoorway: {
+  start: number;
+  end: number;
+}) {
+  const desiredWorldZSamples = [-26.14, -27.5, -29, -30.5, -31.24];
+  const doorwayMinZ = Math.min(westDoorway.start, westDoorway.end);
+  const doorwayMaxZ = Math.max(westDoorway.start, westDoorway.end);
+
+  return desiredWorldZSamples.map((z) => {
+    expect(z).toBeGreaterThanOrEqual(doorwayMinZ - 0.01);
+    expect(z).toBeLessThanOrEqual(doorwayMaxZ + 0.01);
+    return z;
+  });
+}
+
 function getUpperRoomCenter(roomId: string) {
   const room = UPPER_FLOOR_PLAN.rooms.find(
     (candidate) => candidate.id === roomId
@@ -306,20 +335,14 @@ async function walkStairCenterlineToUpperLanding(page: Page) {
 }
 
 async function walkUpperLandingWestExitToCreatorsStudio(page: Page) {
-  const { stairCenterX, stairTopZ, stairDirection } =
+  const { stairCenterX, stairHalfWidth, stairTopZ, stairDirection } =
     await getStairMetrics(page);
-  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
-    (room) => room.id === 'upperLanding'
-  );
-  const westDoorway = upperLandingRoom?.doorways?.find(
-    (doorway) => doorway.wall === 'west'
-  );
-  if (!upperLandingRoom || !westDoorway) {
-    throw new Error('Missing upper landing west doorway');
-  }
+  const { upperLandingRoom, westDoorway } = getUpperLandingWestDoorway();
 
   const creatorsStudioCenter = getUpperRoomCenter('creatorsStudio');
-  const doorwayZ = (westDoorway.start + westDoorway.end) / 2;
+  const egressZSamples = getUpperLandingWestEgressZSamples(westDoorway);
+  const doorwayZ = egressZSamples[egressZSamples.length - 1];
+  const stairSideEgressX = stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
   const westLandingExitX = upperLandingRoom.bounds.minX + PLAYER_RADIUS;
   const creatorsDoorwayEntryX = upperLandingRoom.bounds.minX - PLAYER_RADIUS;
 
@@ -380,8 +403,8 @@ async function walkUpperLandingWestExitToCreatorsStudio(page: Page) {
     {
       waypoints: [
         { x: stairCenterX, z: stairTopZ + stairDirection * 0.05 },
-        { x: stairCenterX - 1.6, z: stairTopZ + stairDirection * 0.05 },
-        { x: westLandingExitX, z: stairTopZ + stairDirection * 0.05 },
+        { x: stairSideEgressX, z: stairTopZ + stairDirection * 0.05 },
+        ...egressZSamples.map((z) => ({ x: stairSideEgressX, z })),
         { x: westLandingExitX, z: doorwayZ },
         { x: creatorsDoorwayEntryX, z: doorwayZ },
         { x: creatorsStudioCenter.x, z: doorwayZ },
@@ -617,6 +640,7 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   const html = page.locator('html');
   const {
     stairCenterX,
+    stairHalfWidth,
     stairBottomZ,
     stairTopZ,
     stairLandingMinZ,
@@ -641,6 +665,29 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     expect(await getBlockingColliderNames(page, landingHandoffSample)).toEqual(
       []
     );
+  }
+
+  const { westDoorway } = getUpperLandingWestDoorway();
+  const egressZSamples = getUpperLandingWestEgressZSamples(westDoorway);
+  const stairSideEgressX = stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
+  const doorwayThresholdXs = [
+    stairSideEgressX,
+    UPPER_FLOOR_PLAN.rooms.find((room) => room.id === 'upperLanding')!.bounds
+      .minX + PLAYER_RADIUS,
+    UPPER_FLOOR_PLAN.rooms.find((room) => room.id === 'upperLanding')!.bounds
+      .minX - PLAYER_RADIUS,
+  ];
+  for (const z of egressZSamples) {
+    for (const x of doorwayThresholdXs) {
+      const sample = { x, z, floorId: 'upper' as const };
+      const canOccupy = await canOccupyPosition(page, sample);
+      const blockingColliders = await getBlockingColliderNames(page, sample);
+      expect(
+        canOccupy,
+        `expected upper landing west egress sample (${x}, ${z}) to be occupiable; blockers=${blockingColliders.join(', ')}`
+      ).toBe(true);
+      expect(blockingColliders).toEqual([]);
+    }
   }
 
   // Continue through the intended west upper-landing exit into an upstairs room
@@ -724,7 +771,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   } = await getStairMetrics(page);
   const creatorsStudioCenter = getUpperRoomCenter('creatorsStudio');
   const westLandingEgress = {
-    x: stairCenterX - 1.6,
+    x: stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75,
     z: stairTopZ + stairDirection * 1.8,
     floorId: 'upper' as const,
   };
@@ -793,8 +840,16 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
       z: stairTopZ + stairDirection * 0.95,
       floorId: 'upper' as const,
     },
-    { x: 9, z: -28, floorId: 'upper' as const },
-    { x: 9, z: -29, floorId: 'upper' as const },
+    {
+      x: stairCenterX - PLAYER_RADIUS * 1.2,
+      z: -28,
+      floorId: 'upper' as const,
+    },
+    {
+      x: stairCenterX - PLAYER_RADIUS * 1.2,
+      z: -29,
+      floorId: 'upper' as const,
+    },
   ];
 
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
@@ -830,7 +885,13 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   );
   expect(
     await getBlockingColliderNames(page, deeperWestHiddenStairVoidGap)
-  ).toContain('UpperStairDeepVoidBlocker');
+  ).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(
+        /^UpperStair(?:DeepVoidBlocker|WestVoidGapBlocker)$/
+      ),
+    ])
+  );
   expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);

--- a/src/assets/floorPlan/index.ts
+++ b/src/assets/floorPlan/index.ts
@@ -136,6 +136,9 @@ const livingToStudioDoorCenter = 7.5;
 const kitchenToBackyardDoorCenter = -9;
 const studioToBackyardDoorCenter = 7.5;
 const kitchenToStudioDoorCenterZ = 2;
+// Keep the upstairs west egress aligned to the landing's south edge while
+// preserving the prior north edge of the shared creators-studio opening.
+const upperLandingWestEgressDoorway = { start: -16, end: -10 };
 
 const doorwayRange = (center: number) => ({
   start: center - DOOR_HALF_WIDTH,
@@ -242,7 +245,7 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
       doorways: [
         {
           wall: 'west',
-          ...doorwayRange(-12),
+          ...upperLandingWestEgressDoorway,
         },
         {
           wall: 'north',
@@ -258,7 +261,7 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
       doorways: [
         {
           wall: 'east',
-          ...doorwayRange(-12),
+          ...upperLandingWestEgressDoorway,
         },
         {
           wall: 'east',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1916,6 +1916,9 @@ function initializeImmersiveScene(
     upperFloorColliders.push(bounds);
     namedColliderDebugNames.set(bounds, name);
   };
+  // Keep hidden stair-run blockers near the center of the removed stairwell
+  // so the west side can serve as the intended upper-landing room egress.
+  const hiddenStairCenterVoidMinX = stairCenterX - PLAYER_RADIUS * 1.6;
 
   // The upper-floor stairwell cutout intentionally comes from the same
   // computeStairLayout result used by movement. It removes both the stair
@@ -2013,15 +2016,6 @@ function initializeImmersiveScene(
 
     [
       {
-        name: 'UpperStairWestLowerVoidGuard',
-        bounds: {
-          minX: stairCenterX - stairHalfWidth - stairwellMarginX,
-          maxX: stairNavigationZones.explicitDescentCorridor.minX,
-          minZ: upperStairVoidMinZ,
-          maxZ: upperStairWestEgressMinZ,
-        },
-      },
-      {
         name: 'UpperStairWestUpperVoidGuard',
         bounds: {
           minX: upperStairwellOpening.minX,
@@ -2061,8 +2055,8 @@ function initializeImmersiveScene(
       {
         name: 'UpperStairWestVoidGapBlocker',
         bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: stairNavigationZones.explicitDescentCorridor.minX,
+          minX: hiddenStairCenterVoidMinX,
+          maxX: hiddenStairCenterVoidMinX,
           minZ: upperStairVoidMinZ,
           maxZ: hiddenStairTopGapBlockerMinZ,
         },
@@ -2070,7 +2064,7 @@ function initializeImmersiveScene(
       {
         name: 'UpperStairDeepVoidBlocker',
         bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.minX,
+          minX: hiddenStairCenterVoidMinX,
           maxX: stairNavigationZones.explicitDescentCorridor.maxX,
           minZ: Math.min(
             hiddenStairDeepVoidBlockerMinZ,
@@ -2129,6 +2123,7 @@ function initializeImmersiveScene(
       guard: {
         height: 0.56,
         thickness: toWorldUnits(0.12),
+        farGuardMinX: hiddenStairCenterVoidMinX,
         sideSides: ['east'],
         shoulderSides: ['east'],
         material: {

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -20,6 +20,8 @@ export interface UpperStairwellGuardConfig {
    * stair void edge.
    */
   shoulderSides?: ReadonlyArray<'east' | 'west'>;
+  /** Optional X start for the far rail when a west-side egress lane remains open. */
+  farGuardMinX?: number;
   /** Optional material overrides for the guard rails. */
   material?: MeshStandardMaterialParameters;
 }
@@ -161,7 +163,10 @@ export function createUpperStairwellLanding(
     material: guardMaterial,
     name: FAR_GUARD_NAME,
     bounds: {
-      minX: openingBounds.minX,
+      minX: Math.max(
+        openingBounds.minX,
+        config.guard.farGuardMinX ?? openingBounds.minX
+      ),
       maxX: openingBounds.maxX,
       minZ: openingBounds.minZ,
       maxZ: openingBounds.minZ + thickness,

--- a/src/tests/floorPlanDoorways.test.ts
+++ b/src/tests/floorPlanDoorways.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN, UPPER_FLOOR_PLAN } from '../assets/floorPlan';
 import {
   getDoorwayClearanceZones,
   getDoorwayPassageZones,
@@ -143,5 +143,64 @@ describe('getDoorwayPassageZones', () => {
       kitchenStudio.doorway.center.z + halfWidth + padding,
       3
     );
+  });
+});
+
+describe('upper landing west egress doorway', () => {
+  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'upperLanding'
+  );
+  const creatorsStudioRoom = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'creatorsStudio'
+  );
+  const upperLandingWestDoorway = upperLandingRoom?.doorways?.find(
+    (doorway) => doorway.wall === 'west'
+  );
+  const creatorsStudioEastDoorway = creatorsStudioRoom?.doorways?.find(
+    (doorway) => doorway.wall === 'east' && doorway.start < -30
+  );
+
+  it('aligns the upperLanding west doorway with creatorsStudio east doorway', () => {
+    expect(upperLandingWestDoorway).toBeDefined();
+    expect(creatorsStudioEastDoorway).toBeDefined();
+    expect(upperLandingWestDoorway?.start).toBeCloseTo(
+      creatorsStudioEastDoorway!.start,
+      3
+    );
+    expect(upperLandingWestDoorway?.end).toBeCloseTo(
+      creatorsStudioEastDoorway!.end,
+      3
+    );
+  });
+
+  it('covers the desired world-space landing egress band', () => {
+    expect(upperLandingWestDoorway).toBeDefined();
+    const minZ = Math.min(
+      upperLandingWestDoorway!.start,
+      upperLandingWestDoorway!.end
+    );
+    const maxZ = Math.max(
+      upperLandingWestDoorway!.start,
+      upperLandingWestDoorway!.end
+    );
+
+    for (const sampleZ of [-26.14, -27.5, -29, -30.5, -31.24]) {
+      expect(sampleZ).toBeGreaterThanOrEqual(minZ);
+      expect(sampleZ).toBeLessThanOrEqual(maxZ);
+    }
+  });
+
+  it('normalizes the widened shared opening as a single vertical doorway', () => {
+    const doorway = resolveNormalizedDoorway({
+      plan: UPPER_FLOOR_PLAN,
+      roomAId: 'upperLanding',
+      wallA: 'west',
+      roomBId: 'creatorsStudio',
+      wallB: 'east',
+    });
+
+    expect(doorway).toBeDefined();
+    expect(doorway?.axis).toBe('vertical');
+    expect(doorway?.width).toBeGreaterThanOrEqual(12);
   });
 });

--- a/src/tests/navigation/navMesh.test.ts
+++ b/src/tests/navigation/navMesh.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN, WALL_THICKNESS } from '../../assets/floorPlan';
+import {
+  FLOOR_PLAN,
+  UPPER_FLOOR_PLAN,
+  WALL_THICKNESS,
+} from '../../assets/floorPlan';
 import { createNavMesh } from '../../systems/navigation/navMesh';
 import { resolveNormalizedDoorway } from '../helpers/doorwayTestHelpers';
 
@@ -77,5 +81,35 @@ describe('createNavMesh', () => {
 
   it('includes explicitly provided zones', () => {
     expect(navMesh.contains(41, 41)).toBe(true);
+  });
+});
+
+describe('createNavMesh for upper landing egress', () => {
+  const doorwayPadding = PLAYER_RADIUS * 0.6;
+  const doorwayDepth = WALL_THICKNESS + PLAYER_RADIUS * 2;
+  const navMesh = createNavMesh(UPPER_FLOOR_PLAN, {
+    padding: doorwayPadding,
+    depth: doorwayDepth,
+  });
+
+  it('contains the widened upperLanding west doorway passage zone', () => {
+    const doorway = resolveNormalizedDoorway({
+      plan: UPPER_FLOOR_PLAN,
+      roomAId: 'upperLanding',
+      wallA: 'west',
+      roomBId: 'creatorsStudio',
+      wallB: 'east',
+    });
+    expect(doorway).toBeDefined();
+    if (!doorway) {
+      return;
+    }
+
+    const halfDepth = doorwayDepth / 2 - 0.05;
+    for (const z of [-26.14, -27.5, -29, -30.5, -31.24]) {
+      expect(navMesh.contains(doorway.center.x, z)).toBe(true);
+      expect(navMesh.contains(doorway.center.x + halfDepth, z)).toBe(true);
+      expect(navMesh.contains(doorway.center.x - halfDepth, z)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- The upstairs west/-X egress from the upper landing was effectively narrowed to a small passable gap instead of the intended band from world z ≈ -26.14 through -31.24.  
- The change re-opens that west egress while preserving existing stair/hidden-run safety and floor-transition behavior.

### Description
- Expand the shared opening by replacing the previous centered `doorwayRange(-12)` with a wider `upperLandingWestEgressDoorway` and apply it to both `upperLanding` (west) and `creatorsStudio` (east) in `src/assets/floorPlan/index.ts`.  
- Re-scoped upper stairwell blockers so hidden-run/center blockers remain in the stairwell center while the west egress lane is left open, and exposed the far-guard start via `farGuardMinX` when building the upper landing guards in `src/main.ts` and `src/scene/structures/upperStairwellLanding.ts`.  
- Adjusted upper-floor guard placement logic so the far guard clamps to the new west-opening policy without creating a slab over the stair hole.  
- Added coverage and assertions: widened-doorway unit tests in `src/tests/floorPlanDoorways.test.ts` and navmesh checks in `src/tests/navigation/navMesh.test.ts`, plus Playwright e2e updates in `playwright/immersive-stairs-roundtrip.spec.ts` that sweep the desired z samples, assert occupiability and empty blocking-collider lists, and walk the runtime stair→room path.

### Testing
- Ran code formatting with `npm run format:write` and linting with `npm run lint`, bothSucceeded.  
- Ran unit tests with `npm run test:ci` (Vitest); full suite passed locally: `144 files, 1082 tests` passed.  
- Ran the focused Playwright scenario with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`; tests passed locally (6/6) after installing browsers and host deps during the run.  
- Ran docs and smoke checks with `npm run docs:check` (passed with external-link warnings) and `npm run smoke` / `npm run build` (both passed).  
- Created a local debug screenshot at `/tmp/upper-landing-west-egress.png` demonstrating the open west egress.  
- Notes: Playwright browser binaries were installed as part of the test run (`npx playwright install` / `npx playwright install-deps`) in this environment; CI should already provide playwright browsers or run the install step if required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a291746c9e4832f929c22507593514d)