### PR TITLE
Remove upper landing artifact colliders

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -204,6 +204,17 @@ async function getBlockingColliderNames(
   }, target);
 }
 
+async function getDebugColliderNames(page: Page) {
+  return page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    debugApi.setEnabled(true);
+    return debugApi.getColliders().map((collider) => collider.name);
+  });
+}
+
 async function walkStairCenterlineToUpperLanding(page: Page) {
   const {
     stairCenterX,
@@ -552,6 +563,44 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
   });
 });
 
+test('upper landing debug colliders exclude removed landing artifacts', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const removedColliderNames = [
+    'UpperStairTopGapBlockerWest',
+    'UpperStairEastLandingMouthVoidGuard',
+  ];
+
+  await walkStairCenterlineToUpperLanding(page);
+  const debugColliderNames = await getDebugColliderNames(page);
+  expect(debugColliderNames).not.toEqual(
+    expect.arrayContaining(removedColliderNames)
+  );
+
+  const landingSamples = [
+    { x: 12.99, z: -26.84, floorId: 'upper' as const },
+    { x: 12.84, z: -26.84, floorId: 'upper' as const },
+    { x: 13.14, z: -26.84, floorId: 'upper' as const },
+    { x: 12.99, z: -26.72, floorId: 'upper' as const },
+    { x: 12.99, z: -26.96, floorId: 'upper' as const },
+  ];
+
+  for (const landingSample of landingSamples) {
+    expect(await canOccupyPosition(page, landingSample)).toBe(true);
+    const blockingColliderNames = await getBlockingColliderNames(
+      page,
+      landingSample
+    );
+    expect(blockingColliderNames).not.toEqual(
+      expect.arrayContaining(removedColliderNames)
+    );
+    expect(blockingColliderNames).toEqual([]);
+  }
+});
+
 test('ground stair east boundary blocks squeeze corners but preserves the stair path', async ({
   page,
 }) => {
@@ -789,7 +838,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ - stairDirection * 0.4,
     floorId: 'upper' as const,
   };
-  const westHiddenStairVoidGap = {
+  const westLandingMouthClearance = {
     x: stairCenterX - PLAYER_RADIUS * 0.5,
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
@@ -827,11 +876,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     floorId: 'upper' as const,
   };
   const hiddenStairVoidGap = [
-    {
-      x: stairCenterX - PLAYER_RADIUS * 0.5,
-      z: stairTopZ + stairDirection * 0.95,
-      floorId: 'upper' as const,
-    },
     { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
     {
       x: stairCenterX + PLAYER_RADIUS * 0.5,
@@ -864,7 +908,10 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, normalLoftEastNudge)).toBe(true);
   expect(await canOccupyPosition(page, loftDoorway)).toBe(true);
   expect(await canOccupyPosition(page, westVoidBypass)).toBe(true);
-  expect(await canOccupyPosition(page, westHiddenStairVoidGap)).toBe(false);
+  expect(await canOccupyPosition(page, westLandingMouthClearance)).toBe(true);
+  expect(
+    await getBlockingColliderNames(page, westLandingMouthClearance)
+  ).toEqual([]);
   expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
     false
   );

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -576,9 +576,9 @@ test('upper landing debug colliders exclude removed landing artifacts', async ({
 
   await walkStairCenterlineToUpperLanding(page);
   const debugColliderNames = await getDebugColliderNames(page);
-  expect(debugColliderNames).not.toEqual(
-    expect.arrayContaining(removedColliderNames)
-  );
+  for (const removedColliderName of removedColliderNames) {
+    expect(debugColliderNames).not.toContain(removedColliderName);
+  }
 
   const landingSamples = [
     { x: 12.99, z: -26.84, floorId: 'upper' as const },
@@ -594,9 +594,9 @@ test('upper landing debug colliders exclude removed landing artifacts', async ({
       page,
       landingSample
     );
-    expect(blockingColliderNames).not.toEqual(
-      expect.arrayContaining(removedColliderNames)
-    );
+    for (const removedColliderName of removedColliderNames) {
+      expect(blockingColliderNames).not.toContain(removedColliderName);
+    }
     expect(blockingColliderNames).toEqual([]);
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1981,17 +1981,6 @@ function initializeImmersiveScene(
       hiddenStairTopGapBlockerNearZ,
       hiddenStairTopGapBlockerFarZ
     );
-    const hiddenStairTopGapSampleZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS * 1.27;
-    const hiddenStairTopGapSampleBlocker = {
-      name: 'UpperStairTopGapBlockerWest',
-      bounds: {
-        minX: stairCenterX - PLAYER_RADIUS,
-        maxX: stairCenterX - PLAYER_RADIUS,
-        minZ: hiddenStairTopGapSampleZ - 0.02,
-        maxZ: hiddenStairTopGapSampleZ + 0.02,
-      },
-    };
     const upperStairLandingEntryMinZ = Math.max(
       upperStairVoidMinZ,
       hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
@@ -2035,16 +2024,6 @@ function initializeImmersiveScene(
         },
       },
       {
-        name: 'UpperStairEastLandingMouthVoidGuard',
-        bounds: {
-          minX:
-            stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairLandingEntryMinZ,
-          maxZ: upperStairLandingEntryMaxZ,
-        },
-      },
-      {
         name: 'UpperStairEastUpperVoidGuard',
         bounds: {
           minX: stairNavigationZones.explicitDescentCorridor.maxX,
@@ -2068,7 +2047,6 @@ function initializeImmersiveScene(
           ),
         },
       },
-      hiddenStairTopGapSampleBlocker,
       ...upperStairTopGapBlockers,
       {
         name: 'UpperStairHiddenRunBlocker',


### PR DESCRIPTION
### Motivation
- Remove two accidental upper-floor colliders that produced a tiny degenerate dot and a large bisecting mouth artifact which blocked landing movement without changing any stair, doorway, navmesh, visibility, or floor-transition logic.

### Description
- Deleted the degenerate sample blocker (`UpperStairTopGapBlockerWest`) and the east landing-mouth void guard (`UpperStairEastLandingMouthVoidGuard`) from the upper-floor collider registration in `src/main.ts` so only the intended blockers remain.
- Added a Playwright helper `getDebugColliderNames` and a spec `upper landing debug colliders exclude removed landing artifacts` in `playwright/immersive-stairs-roundtrip.spec.ts` that asserts the two collider names are no longer registered and that landing samples near `12.99, -26.84` are occupiable with no blocking colliders.
- Updated one test sample variable and its expectations so the cleared west landing mouth is asserted passable while preserving deeper hidden-run blockers and existing regression coverage.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed with no errors.
- Ran the unit suite with `npm run test:ci`, which completed successfully (Vitest: all tests passed).
- Executed the Playwright spec with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, and the suite passed (all relevant stairs/landing tests including the new check passed).
- Verified docs and build with `npm run docs:check`, `npm run smoke`, and `npm run build`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a09f06364832f9446b43ad62a70d2)