### PR TITLE
🧱 : – remove errant upper landing colliders

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -14,6 +14,11 @@ const GROUND_POI_IDS = [
   'dspace-backyard-rocket',
 ];
 
+const REMOVED_UPPER_LANDING_COLLIDERS = [
+  'UpperStairTopGapBlockerWest',
+  'UpperStairEastLandingMouthVoidGuard',
+];
+
 type FloorId = 'ground' | 'upper';
 
 type StairTransitionZone =
@@ -202,6 +207,17 @@ async function getBlockingColliderNames(
       .getBlockingCollidersAt(next)
       .map((collider) => collider.name);
   }, target);
+}
+
+async function getColliderNames(page: Page) {
+  return page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    debugApi.setEnabled(true);
+    return debugApi.getColliders().map((collider) => collider.name);
+  });
 }
 
 async function walkStairCenterlineToUpperLanding(page: Page) {
@@ -789,7 +805,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ - stairDirection * 0.4,
     floorId: 'upper' as const,
   };
-  const westHiddenStairVoidGap = {
+  const westTopGapLandingSample = {
     x: stairCenterX - PLAYER_RADIUS * 0.5,
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
@@ -827,11 +843,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     floorId: 'upper' as const,
   };
   const hiddenStairVoidGap = [
-    {
-      x: stairCenterX - PLAYER_RADIUS * 0.5,
-      z: stairTopZ + stairDirection * 0.95,
-      floorId: 'upper' as const,
-    },
     { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
     {
       x: stairCenterX + PLAYER_RADIUS * 0.5,
@@ -839,6 +850,28 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
       floorId: 'upper' as const,
     },
   ];
+  const screenshotLandingSamples = [
+    westTopGapLandingSample,
+    { x: 12.99, z: -26.84, floorId: 'upper' as const },
+    { x: 12.74, z: -26.84, floorId: 'upper' as const },
+    { x: 13.24, z: -26.84, floorId: 'upper' as const },
+    { x: 12.99, z: -27.04, floorId: 'upper' as const },
+    { x: 12.99, z: -26.64, floorId: 'upper' as const },
+  ];
+
+  const colliderNames = await getColliderNames(page);
+  for (const removedCollider of REMOVED_UPPER_LANDING_COLLIDERS) {
+    expect(colliderNames).not.toContain(removedCollider);
+  }
+
+  for (const landingSample of screenshotLandingSamples) {
+    expect(await canOccupyPosition(page, landingSample)).toBe(true);
+    const blockers = await getBlockingColliderNames(page, landingSample);
+    expect(blockers).toEqual([]);
+    expect(blockers).not.toEqual(
+      expect.arrayContaining(REMOVED_UPPER_LANDING_COLLIDERS)
+    );
+  }
 
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await movePlayerTo(page, {
@@ -864,7 +897,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, normalLoftEastNudge)).toBe(true);
   expect(await canOccupyPosition(page, loftDoorway)).toBe(true);
   expect(await canOccupyPosition(page, westVoidBypass)).toBe(true);
-  expect(await canOccupyPosition(page, westHiddenStairVoidGap)).toBe(false);
   expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
     false
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1981,17 +1981,6 @@ function initializeImmersiveScene(
       hiddenStairTopGapBlockerNearZ,
       hiddenStairTopGapBlockerFarZ
     );
-    const hiddenStairTopGapSampleZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS * 1.27;
-    const hiddenStairTopGapSampleBlocker = {
-      name: 'UpperStairTopGapBlockerWest',
-      bounds: {
-        minX: stairCenterX - PLAYER_RADIUS,
-        maxX: stairCenterX - PLAYER_RADIUS,
-        minZ: hiddenStairTopGapSampleZ - 0.02,
-        maxZ: hiddenStairTopGapSampleZ + 0.02,
-      },
-    };
     const upperStairLandingEntryMinZ = Math.max(
       upperStairVoidMinZ,
       hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
@@ -2035,16 +2024,6 @@ function initializeImmersiveScene(
         },
       },
       {
-        name: 'UpperStairEastLandingMouthVoidGuard',
-        bounds: {
-          minX:
-            stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairLandingEntryMinZ,
-          maxZ: upperStairLandingEntryMaxZ,
-        },
-      },
-      {
         name: 'UpperStairEastUpperVoidGuard',
         bounds: {
           minX: stairNavigationZones.explicitDescentCorridor.maxX,
@@ -2068,7 +2047,6 @@ function initializeImmersiveScene(
           ),
         },
       },
-      hiddenStairTopGapSampleBlocker,
       ...upperStairTopGapBlockers,
       {
         name: 'UpperStairHiddenRunBlocker',


### PR DESCRIPTION
### Motivation
- Two accidental upper-floor colliders (a tiny sample blocker and a large east-mouth guard) were visible in the debug collider overlay and interfered with landing movement without changing any other stair, navmesh, or visibility logic.
- The goal is to remove exactly those two colliders while preserving the existing upper-stair blocker system and behavior.

### Description
- Removed the `hiddenStairTopGapSampleBlocker` (runtime/debug name `UpperStairTopGapBlockerWest`) declaration and its inclusion in the upper-floor collider registration inside `src/main.ts`.
- Removed the `UpperStairEastLandingMouthVoidGuard` entry from the upper-floor collider registration in `src/main.ts`.
- Added Playwright assertions in `playwright/immersive-stairs-roundtrip.spec.ts` that the two removed collider names are not registered and that a set of landing samples around `{ x: 12.99, z: -26.84, floorId: 'upper' }` are occupiable and report no blocking colliders.
- Kept all other colliders, stair transition logic, cutouts, and visibility behavior unchanged and made the minimal possible diff.

### Testing
- Ran formatting: `npm run format:write` — passed (applied formatting).
- Lint: `npm run lint` — passed (no ESLint errors).
- Unit tests: `npm run test:ci` (Vitest) — passed (1081 tests, 144 files; all green).
- Docs/links check: `npm run docs:check` — passed with existing external-link warnings (no new doc failures).
- Smoke/build: `npm run smoke` and `npm run build` — passed (dist built; existing Vite chunk-size warnings only).
- Playwright setup and spec: `npx playwright install chromium-headless-shell` and `npx playwright install-deps` were run as needed, then `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — passed (6 tests in the spec passed); manual runtime check via a headless browser confirmed the removed collider names are absent and `{ x: 12.99, z: -26.84, floorId: 'upper' }` is occupiable with `[]` blockers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a09f06364832f9446b43ad62a70d2)