### PR TITLE
Remove errant upper landing colliders

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -204,6 +204,17 @@ async function getBlockingColliderNames(
   }, target);
 }
 
+async function getDebugColliderNames(page: Page) {
+  return page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    debugApi.setEnabled(true);
+    return debugApi.getColliders().map((collider) => collider.name);
+  });
+}
+
 async function walkStairCenterlineToUpperLanding(page: Page) {
   const {
     stairCenterX,
@@ -747,6 +758,38 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   });
 });
 
+test('upper landing debug colliders omit removed landing artifacts', async ({
+  page,
+}) => {
+  await waitForImmersiveReady(page);
+
+  const removedColliderNames = [
+    'UpperStairTopGapBlockerWest',
+    'UpperStairEastLandingMouthVoidGuard',
+  ];
+  const colliderNames = await getDebugColliderNames(page);
+  expect(colliderNames).not.toEqual(
+    expect.arrayContaining(removedColliderNames)
+  );
+
+  const landingSamples = [
+    { x: 12.99, z: -26.84, floorId: 'upper' as const },
+    { x: 12.7, z: -26.84, floorId: 'upper' as const },
+    { x: 13.28, z: -26.84, floorId: 'upper' as const },
+    { x: 12.99, z: -26.55, floorId: 'upper' as const },
+    { x: 12.99, z: -27.13, floorId: 'upper' as const },
+  ];
+
+  for (const sample of landingSamples) {
+    expect(await canOccupyPosition(page, sample)).toBe(true);
+    const blockingColliderNames = await getBlockingColliderNames(page, sample);
+    expect(blockingColliderNames).not.toEqual(
+      expect.arrayContaining(removedColliderNames)
+    );
+    expect(blockingColliderNames).toEqual([]);
+  }
+});
+
 test('upper landing opens west into upstairs rooms and blocks the hidden stair run', async ({
   page,
 }) => {
@@ -789,7 +832,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ - stairDirection * 0.4,
     floorId: 'upper' as const,
   };
-  const westHiddenStairVoidGap = {
+  const westTopGapLandingLane = {
     x: stairCenterX - PLAYER_RADIUS * 0.5,
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
@@ -827,11 +870,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     floorId: 'upper' as const,
   };
   const hiddenStairVoidGap = [
-    {
-      x: stairCenterX - PLAYER_RADIUS * 0.5,
-      z: stairTopZ + stairDirection * 0.95,
-      floorId: 'upper' as const,
-    },
     { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
     {
       x: stairCenterX + PLAYER_RADIUS * 0.5,
@@ -864,7 +902,10 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(await canOccupyPosition(page, normalLoftEastNudge)).toBe(true);
   expect(await canOccupyPosition(page, loftDoorway)).toBe(true);
   expect(await canOccupyPosition(page, westVoidBypass)).toBe(true);
-  expect(await canOccupyPosition(page, westHiddenStairVoidGap)).toBe(false);
+  expect(await canOccupyPosition(page, westTopGapLandingLane)).toBe(true);
+  expect(await getBlockingColliderNames(page, westTopGapLandingLane)).toEqual(
+    []
+  );
   expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
     false
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1981,17 +1981,6 @@ function initializeImmersiveScene(
       hiddenStairTopGapBlockerNearZ,
       hiddenStairTopGapBlockerFarZ
     );
-    const hiddenStairTopGapSampleZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS * 1.27;
-    const hiddenStairTopGapSampleBlocker = {
-      name: 'UpperStairTopGapBlockerWest',
-      bounds: {
-        minX: stairCenterX - PLAYER_RADIUS,
-        maxX: stairCenterX - PLAYER_RADIUS,
-        minZ: hiddenStairTopGapSampleZ - 0.02,
-        maxZ: hiddenStairTopGapSampleZ + 0.02,
-      },
-    };
     const upperStairLandingEntryMinZ = Math.max(
       upperStairVoidMinZ,
       hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
@@ -2035,16 +2024,6 @@ function initializeImmersiveScene(
         },
       },
       {
-        name: 'UpperStairEastLandingMouthVoidGuard',
-        bounds: {
-          minX:
-            stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairLandingEntryMinZ,
-          maxZ: upperStairLandingEntryMaxZ,
-        },
-      },
-      {
         name: 'UpperStairEastUpperVoidGuard',
         bounds: {
           minX: stairNavigationZones.explicitDescentCorridor.maxX,
@@ -2068,7 +2047,6 @@ function initializeImmersiveScene(
           ),
         },
       },
-      hiddenStairTopGapSampleBlocker,
       ...upperStairTopGapBlockers,
       {
         name: 'UpperStairHiddenRunBlocker',


### PR DESCRIPTION
### Motivation
- Two accidental upper-floor colliders were visibly blocking landing movement in the debug overlay and needed to be removed without changing any other stair, doorway, navmesh, or visibility logic.
- The change must remove exactly the two artifacts that appeared in runtime debug names and preserve all other upper-stair guard/blocker rules and debug visualization.

### Description
- Remove the degenerate sample blocker declaration (runtime name `UpperStairTopGapBlockerWest`) and its registration from the upper-floor collider list in `src/main.ts`.
- Remove the `UpperStairEastLandingMouthVoidGuard` entry from the upper-floor collider registration in `src/main.ts`.
- Add a Playwright helper `getDebugColliderNames` and a focused Playwright test `upper landing debug colliders omit removed landing artifacts` in `playwright/immersive-stairs-roundtrip.spec.ts` asserting the removed names do not appear and that landing samples around `12.99, -26.84` remain occupiable and unblocked.
- Keep all other collider generation, stair transition, navmesh, and visibility code unchanged and only touch the two targeted entries and small test scaffolding.

### Testing
- Ran formatting with `npm run format:write` (succeeded) and lint with `npm run lint` (succeeded).
- Ran unit tests with `npm run test:ci` which completed: `Test Files 144 passed` and `Tests 1081 passed`.
- Ran Playwright for the focused scenario with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and received `7 passed` for that file after installing Playwright browsers and host deps during the run.
- Ran docs checks with `npm run docs:check` (passed with external link reachability warnings), `npm run build` (passed), `npm run smoke` (passed), and ran the secrets scan `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a09f06364832f9446b43ad62a70d2)