### PR TITLE
Remove upper landing middle collider (UpperStairDeepVoidBlocker)

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -563,13 +563,14 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
   });
 });
 
-test('upper landing debug colliders exclude removed landing artifacts', async ({
+test('upper landing debug colliders exclude middle landing artifact', async ({
   page,
 }) => {
   test.slow();
   await waitForImmersiveReady(page);
 
   const removedColliderNames = [
+    'UpperStairDeepVoidBlocker',
     'UpperStairTopGapBlockerWest',
     'UpperStairEastLandingMouthVoidGuard',
   ];
@@ -586,6 +587,9 @@ test('upper landing debug colliders exclude removed landing artifacts', async ({
     { x: 13.14, z: -26.84, floorId: 'upper' as const },
     { x: 12.99, z: -26.72, floorId: 'upper' as const },
     { x: 12.99, z: -26.96, floorId: 'upper' as const },
+    { x: 12.4, z: -28.8, floorId: 'upper' as const },
+    { x: 12.78, z: -29, floorId: 'upper' as const },
+    { x: 13, z: -29, floorId: 'upper' as const },
   ];
 
   for (const landingSample of landingSamples) {
@@ -706,30 +710,13 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     expect(await getBlockingColliderNames(page, egressSample)).toEqual([]);
   }
 
-  const hiddenVoidSampleZ = -29;
-  const nonEgressHiddenVoidSamples = [
-    {
-      x: stairCenterX - stairHalfWidth + PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
-      floorId: 'upper' as const,
-    },
-    {
-      x: stairCenterX,
-      z: hiddenVoidSampleZ,
-      floorId: 'upper' as const,
-    },
-    {
-      x: stairCenterX + stairHalfWidth - PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
-      floorId: 'upper' as const,
-    },
-  ];
-  for (const hiddenVoidSample of nonEgressHiddenVoidSamples) {
-    expect(await canOccupyPosition(page, hiddenVoidSample)).toBe(false);
-    expect(await getBlockingColliderNames(page, hiddenVoidSample)).not.toEqual(
-      []
-    );
-  }
+  const middleLandingSample = {
+    x: stairCenterX,
+    z: -29,
+    floorId: 'upper' as const,
+  };
+  expect(await canOccupyPosition(page, middleLandingSample)).toBe(true);
+  expect(await getBlockingColliderNames(page, middleLandingSample)).toEqual([]);
 
   // Continue through the intended west upper-landing exit into an upstairs room
   // with the same step helper used by runtime movement instead of teleporting.
@@ -843,14 +830,9 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const deeperWestHiddenStairVoidGap = {
-    x: stairCenterX - 1.9,
-    z: stairTopZ + stairDirection * 2,
-    floorId: 'upper' as const,
-  };
-  const westHiddenStairVoidSliver = {
-    x: stairCenterX - 1.55,
-    z: stairTopZ + stairDirection * 2.1,
+  const formerMiddleLandingArtifact = {
+    x: stairCenterX + 0.6,
+    z: stairTopZ + stairDirection * 3.1,
     floorId: 'upper' as const,
   };
   const westEdgeFloorClearance = {
@@ -875,15 +857,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const hiddenStairVoidGap = [
-    { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
-    {
-      x: stairCenterX + PLAYER_RADIUS * 0.5,
-      z: -29,
-      floorId: 'upper' as const,
-    },
-  ];
-
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await movePlayerTo(page, {
     x: stairCenterX,
@@ -912,18 +885,12 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(
     await getBlockingColliderNames(page, westLandingMouthClearance)
   ).toEqual([]);
-  expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
-    false
-  );
+  expect(await canOccupyPosition(page, formerMiddleLandingArtifact)).toBe(true);
   expect(
-    await getBlockingColliderNames(page, deeperWestHiddenStairVoidGap)
-  ).toContain('UpperStairDeepVoidBlocker');
-  expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
+    await getBlockingColliderNames(page, formerMiddleLandingArtifact)
+  ).toEqual([]);
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
-  for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
-    expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);
-  }
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
   expect(await getBlockingColliderNames(page, hiddenStairRun)).toContain(
     'UpperStairHiddenRunBlocker'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1928,10 +1928,6 @@ function initializeImmersiveScene(
   if (upperLandingRoom && upperStairwellOpening) {
     const upperStairVoidMinZ = upperStairwellOpening.minZ;
     const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperStairWestEgressMinZ = Math.min(
-      stairLandingMinZ + stairwellMarginZ,
-      stairLandingMaxZ
-    );
     const upperLandingDoorwayClearanceZ =
       upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
     const hiddenStairTopGapBlockerNearZ =
@@ -1941,13 +1937,6 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerFarZ =
       stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
-    const hiddenStairDeepVoidBlockerMinZ =
-      hiddenStairWestVoidGapBlockerMinZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairDeepVoidBlockerMaxZ =
-      hiddenStairTopGapBlockerNearZ +
-      stairLayout.directionMultiplier * PLAYER_RADIUS * 2;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -2030,21 +2019,6 @@ function initializeImmersiveScene(
           maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
           minZ: upperStairLandingEntryMaxZ,
           maxZ: upperStairVoidMaxZ,
-        },
-      },
-      {
-        name: 'UpperStairDeepVoidBlocker',
-        bounds: {
-          minX: upperStairWestEgressBlockerMinX,
-          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-          minZ: Math.min(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
-          maxZ: Math.max(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
         },
       },
       ...upperStairTopGapBlockers,


### PR DESCRIPTION
### Motivation
- Remove the large rectangular yellow debug collider that appeared in the middle of the upper landing while preserving all stair, doorway, navmesh, floor-plan, visibility, and POI behavior.

### Description
- Remove the single upper-floor collider registration `UpperStairDeepVoidBlocker` from `src/main.ts` so the middle-landing artifact is no longer registered or visualized.
- Preserve existing side guards, `UpperStairTopGapBlocker*` pieces, and `UpperStairHiddenRunBlocker`, and do not change floor cutouts, doorways, or navmesh logic.
- Update `playwright/immersive-stairs-roundtrip.spec.ts` to add targeted middle-landing samples and assert the removed collider name is absent alongside the two previously removed names, and assert those samples are occupiable with no blocking colliders.

### Testing
- Formatting and lint: ran `npm run format:write` (passed) and `npm run lint` (passed).
- Unit tests: ran `npm run test:ci` (Vitest suites passed).
- Docs and build checks: ran `npm run docs:check` (passed), `npm run smoke` (passed), and `npm run build` (passed).
- E2E: ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and the modified spec passed.
- Secret scan: ran `git diff --cached | ./scripts/scan-secrets.py` and found no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a240dc35c832f937fda215a878a21)