### PR TITLE
Remove upper landing artifact collider

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -563,13 +563,14 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
   });
 });
 
-test('upper landing debug colliders exclude removed landing artifacts', async ({
+test('upper landing debug colliders exclude middle landing artifact', async ({
   page,
 }) => {
   test.slow();
   await waitForImmersiveReady(page);
 
   const removedColliderNames = [
+    'UpperStairDeepVoidBlocker',
     'UpperStairTopGapBlockerWest',
     'UpperStairEastLandingMouthVoidGuard',
   ];
@@ -586,6 +587,9 @@ test('upper landing debug colliders exclude removed landing artifacts', async ({
     { x: 13.14, z: -26.84, floorId: 'upper' as const },
     { x: 12.99, z: -26.72, floorId: 'upper' as const },
     { x: 12.99, z: -26.96, floorId: 'upper' as const },
+    { x: 12.4, z: -29, floorId: 'upper' as const },
+    { x: 12.78, z: -29, floorId: 'upper' as const },
+    { x: 13.5, z: -28.5, floorId: 'upper' as const },
   ];
 
   for (const landingSample of landingSamples) {
@@ -706,30 +710,32 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     expect(await getBlockingColliderNames(page, egressSample)).toEqual([]);
   }
 
-  const hiddenVoidSampleZ = -29;
-  const nonEgressHiddenVoidSamples = [
+  const formerMiddleLandingBlockerSamples = [
     {
       x: stairCenterX - stairHalfWidth + PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
+      z: -29,
       floorId: 'upper' as const,
     },
     {
       x: stairCenterX,
-      z: hiddenVoidSampleZ,
-      floorId: 'upper' as const,
-    },
-    {
-      x: stairCenterX + stairHalfWidth - PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
+      z: -29,
       floorId: 'upper' as const,
     },
   ];
-  for (const hiddenVoidSample of nonEgressHiddenVoidSamples) {
-    expect(await canOccupyPosition(page, hiddenVoidSample)).toBe(false);
-    expect(await getBlockingColliderNames(page, hiddenVoidSample)).not.toEqual(
-      []
-    );
+  for (const landingSample of formerMiddleLandingBlockerSamples) {
+    expect(await canOccupyPosition(page, landingSample)).toBe(true);
+    expect(await getBlockingColliderNames(page, landingSample)).toEqual([]);
   }
+
+  const eastVoidGuardSample = {
+    x: stairCenterX + stairHalfWidth - PLAYER_RADIUS,
+    z: -29,
+    floorId: 'upper' as const,
+  };
+  expect(await canOccupyPosition(page, eastVoidGuardSample)).toBe(false);
+  expect(await getBlockingColliderNames(page, eastVoidGuardSample)).toContain(
+    'UpperStairEastLowerVoidGuard'
+  );
 
   // Continue through the intended west upper-landing exit into an upstairs room
   // with the same step helper used by runtime movement instead of teleporting.
@@ -843,16 +849,24 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const deeperWestHiddenStairVoidGap = {
-    x: stairCenterX - 1.9,
-    z: stairTopZ + stairDirection * 2,
-    floorId: 'upper' as const,
-  };
-  const westHiddenStairVoidSliver = {
-    x: stairCenterX - 1.55,
-    z: stairTopZ + stairDirection * 2.1,
-    floorId: 'upper' as const,
-  };
+  const formerDeepVoidBlockerLandingSamples = [
+    {
+      x: stairCenterX - 1.9,
+      z: stairTopZ + stairDirection * 2,
+      floorId: 'upper' as const,
+    },
+    {
+      x: stairCenterX - 1.55,
+      z: stairTopZ + stairDirection * 2.1,
+      floorId: 'upper' as const,
+    },
+    { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
+    {
+      x: stairCenterX + PLAYER_RADIUS * 0.5,
+      z: -29,
+      floorId: 'upper' as const,
+    },
+  ];
   const westEdgeFloorClearance = {
     x: 7.5,
     z: -23,
@@ -875,15 +889,6 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const hiddenStairVoidGap = [
-    { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
-    {
-      x: stairCenterX + PLAYER_RADIUS * 0.5,
-      z: -29,
-      floorId: 'upper' as const,
-    },
-  ];
-
   await movePlayerTo(page, { x: stairCenterX, z: stairBottomZ + 0.3 });
   await movePlayerTo(page, {
     x: stairCenterX,
@@ -912,18 +917,12 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(
     await getBlockingColliderNames(page, westLandingMouthClearance)
   ).toEqual([]);
-  expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
-    false
-  );
-  expect(
-    await getBlockingColliderNames(page, deeperWestHiddenStairVoidGap)
-  ).toContain('UpperStairDeepVoidBlocker');
-  expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
+  for (const landingSample of formerDeepVoidBlockerLandingSamples) {
+    expect(await canOccupyPosition(page, landingSample)).toBe(true);
+    expect(await getBlockingColliderNames(page, landingSample)).toEqual([]);
+  }
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
-  for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
-    expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);
-  }
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
   expect(await getBlockingColliderNames(page, hiddenStairRun)).toContain(
     'UpperStairHiddenRunBlocker'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1928,10 +1928,6 @@ function initializeImmersiveScene(
   if (upperLandingRoom && upperStairwellOpening) {
     const upperStairVoidMinZ = upperStairwellOpening.minZ;
     const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperStairWestEgressMinZ = Math.min(
-      stairLandingMinZ + stairwellMarginZ,
-      stairLandingMaxZ
-    );
     const upperLandingDoorwayClearanceZ =
       upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
     const hiddenStairTopGapBlockerNearZ =
@@ -1941,13 +1937,6 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerFarZ =
       stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
-    const hiddenStairDeepVoidBlockerMinZ =
-      hiddenStairWestVoidGapBlockerMinZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairDeepVoidBlockerMaxZ =
-      hiddenStairTopGapBlockerNearZ +
-      stairLayout.directionMultiplier * PLAYER_RADIUS * 2;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -1959,15 +1948,15 @@ function initializeImmersiveScene(
     // Invisible upper-floor guard rails flank the intentional descent corridor.
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable. The center
-    // blockers reject forced upper-floor placement over the hidden stair-top gap
-    // and the deeper removed stair run while preserving the widened west egress,
+    // blockers reject forced upper-floor placement over the hidden stair run
+    // and stair-top gap while preserving the widened west egress,
     // narrow stair-top handoff, a west-side bypass lane around the void, and the
     // north doorway's padded passage into the loft. The top-gap west lip stays
     // intentionally narrow so its collision edge protects the hidden center gap
     // without filling the west egress lane around the stairwell.
     const upperStairLandingEntryCorridor = {
       // Keep the upper landing mouth open far enough for a real westward
-      // egress step after handoff; deeper blockers still seal hidden voids.
+      // egress step after handoff; side guards still seal the east void edge.
       minX: upperStairwellOpening.minX,
       // Size the east edge from the real upper-floor descent opening and add
       // one collision radius because collider checks expand the blocker edge.
@@ -2030,21 +2019,6 @@ function initializeImmersiveScene(
           maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
           minZ: upperStairLandingEntryMaxZ,
           maxZ: upperStairVoidMaxZ,
-        },
-      },
-      {
-        name: 'UpperStairDeepVoidBlocker',
-        bounds: {
-          minX: upperStairWestEgressBlockerMinX,
-          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-          minZ: Math.min(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
-          maxZ: Math.max(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
         },
       },
       ...upperStairTopGapBlockers,


### PR DESCRIPTION
### Motivation
- Remove the remaining large yellow rectangular debug collider that appeared in the middle of the upper landing while preserving all other stair, navmesh, doorway, and visibility behavior.

### Description
- Removed only the `UpperStairDeepVoidBlocker` registration from the upper-floor collider list in `src/main.ts` so the middle landing rectangle is no longer registered or visualized.
- Adjusted the Playwright regression test `playwright/immersive-stairs-roundtrip.spec.ts` (renamed the test to emphasize the middle-landing artifact) to assert the removed collider name (`UpperStairDeepVoidBlocker`) is absent and added landing samples that must now be occupiable and unblocked; the prior removed names remain asserted absent.
- Kept all other generated blockers and guards (including `UpperStairTopGapBlocker*`, `UpperStairHiddenRunBlocker`, and `UpperStairEastLowerVoidGuard`) intact to preserve safety / hidden-run protections.

### Testing
- Ran formatting: `npm run format:write` — passed.
- Ran lint: `npm run lint` — passed.
- Ran unit tests: `npm run test:ci` — all vitest suites passed (1081 tests).
- Ran Playwright stairs regression: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — the updated suite passed (7 tests), confirming the middle-landing samples are occupiable and the removed collider names are absent.
- Ran docs check and smoke/build: `npm run docs:check` and `npm run smoke` / `npm run build` — passed.

All automated checks listed in the repository playbook were executed locally and passed; a manual debug screenshot was captured for verification at `/tmp/upper-landing-collider-check.png` with the debug overlays enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a240dc35c832f937fda215a878a21)