### PR TITLE
Remove upper landing middle collider (UpperStairDeepVoidBlocker)

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -570,6 +570,7 @@ test('upper landing debug colliders exclude removed landing artifacts', async ({
   await waitForImmersiveReady(page);
 
   const removedColliderNames = [
+    'UpperStairDeepVoidBlocker',
     'UpperStairTopGapBlockerWest',
     'UpperStairEastLandingMouthVoidGuard',
   ];
@@ -586,6 +587,9 @@ test('upper landing debug colliders exclude removed landing artifacts', async ({
     { x: 13.14, z: -26.84, floorId: 'upper' as const },
     { x: 12.99, z: -26.72, floorId: 'upper' as const },
     { x: 12.99, z: -26.96, floorId: 'upper' as const },
+    { x: 12.4, z: -29, floorId: 'upper' as const },
+    { x: 12.99, z: -29.05, floorId: 'upper' as const },
+    { x: 13.4, z: -29.05, floorId: 'upper' as const },
   ];
 
   for (const landingSample of landingSamples) {
@@ -706,29 +710,31 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     expect(await getBlockingColliderNames(page, egressSample)).toEqual([]);
   }
 
-  const hiddenVoidSampleZ = -29;
-  const nonEgressHiddenVoidSamples = [
+  const middleLandingArtifactSampleZ = -29;
+  const middleLandingArtifactSamples = [
     {
       x: stairCenterX - stairHalfWidth + PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
+      z: middleLandingArtifactSampleZ,
       floorId: 'upper' as const,
     },
     {
       x: stairCenterX,
-      z: hiddenVoidSampleZ,
+      z: middleLandingArtifactSampleZ,
       floorId: 'upper' as const,
     },
     {
-      x: stairCenterX + stairHalfWidth - PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
+      x: stairCenterX + stairHalfWidth - PLAYER_RADIUS * 2,
+      z: middleLandingArtifactSampleZ,
       floorId: 'upper' as const,
     },
   ];
-  for (const hiddenVoidSample of nonEgressHiddenVoidSamples) {
-    expect(await canOccupyPosition(page, hiddenVoidSample)).toBe(false);
-    expect(await getBlockingColliderNames(page, hiddenVoidSample)).not.toEqual(
-      []
+  for (const middleLandingArtifactSample of middleLandingArtifactSamples) {
+    expect(await canOccupyPosition(page, middleLandingArtifactSample)).toBe(
+      true
     );
+    expect(
+      await getBlockingColliderNames(page, middleLandingArtifactSample)
+    ).toEqual([]);
   }
 
   // Continue through the intended west upper-landing exit into an upstairs room
@@ -843,12 +849,12 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const deeperWestHiddenStairVoidGap = {
-    x: stairCenterX - 1.9,
-    z: stairTopZ + stairDirection * 2,
+  const middleLandingSlab = {
+    x: stairCenterX,
+    z: stairTopZ + stairDirection * 3.1,
     floorId: 'upper' as const,
   };
-  const westHiddenStairVoidSliver = {
+  const westLandingSlab = {
     x: stairCenterX - 1.55,
     z: stairTopZ + stairDirection * 2.1,
     floorId: 'upper' as const,
@@ -875,7 +881,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const hiddenStairVoidGap = [
+  const middleLandingSlabSamples = [
     { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
     {
       x: stairCenterX + PLAYER_RADIUS * 0.5,
@@ -912,17 +918,17 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(
     await getBlockingColliderNames(page, westLandingMouthClearance)
   ).toEqual([]);
-  expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
-    false
-  );
-  expect(
-    await getBlockingColliderNames(page, deeperWestHiddenStairVoidGap)
-  ).toContain('UpperStairDeepVoidBlocker');
-  expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
+  expect(await canOccupyPosition(page, middleLandingSlab)).toBe(true);
+  expect(await getBlockingColliderNames(page, middleLandingSlab)).toEqual([]);
+  expect(await canOccupyPosition(page, westLandingSlab)).toBe(true);
+  expect(await getBlockingColliderNames(page, westLandingSlab)).toEqual([]);
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
-  for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
-    expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);
+  for (const middleLandingSlabSample of middleLandingSlabSamples) {
+    expect(await canOccupyPosition(page, middleLandingSlabSample)).toBe(true);
+    expect(
+      await getBlockingColliderNames(page, middleLandingSlabSample)
+    ).toEqual([]);
   }
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
   expect(await getBlockingColliderNames(page, hiddenStairRun)).toContain(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1928,10 +1928,6 @@ function initializeImmersiveScene(
   if (upperLandingRoom && upperStairwellOpening) {
     const upperStairVoidMinZ = upperStairwellOpening.minZ;
     const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperStairWestEgressMinZ = Math.min(
-      stairLandingMinZ + stairwellMarginZ,
-      stairLandingMaxZ
-    );
     const upperLandingDoorwayClearanceZ =
       upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
     const hiddenStairTopGapBlockerNearZ =
@@ -1941,13 +1937,6 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerFarZ =
       stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
-    const hiddenStairDeepVoidBlockerMinZ =
-      hiddenStairWestVoidGapBlockerMinZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairDeepVoidBlockerMaxZ =
-      hiddenStairTopGapBlockerNearZ +
-      stairLayout.directionMultiplier * PLAYER_RADIUS * 2;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -1959,15 +1948,15 @@ function initializeImmersiveScene(
     // Invisible upper-floor guard rails flank the intentional descent corridor.
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable. The center
-    // blockers reject forced upper-floor placement over the hidden stair-top gap
-    // and the deeper removed stair run while preserving the widened west egress,
-    // narrow stair-top handoff, a west-side bypass lane around the void, and the
-    // north doorway's padded passage into the loft. The top-gap west lip stays
-    // intentionally narrow so its collision edge protects the hidden center gap
-    // without filling the west egress lane around the stairwell.
+    // blocker rejects forced upper-floor placement over the hidden stair run while
+    // preserving the widened west egress, narrow stair-top handoff, a west-side
+    // bypass lane around the void, and the north doorway's padded passage into
+    // the loft. The top-gap west lip stays intentionally narrow so its collision
+    // edge protects the hidden center gap without filling the west egress lane
+    // around the stairwell.
     const upperStairLandingEntryCorridor = {
       // Keep the upper landing mouth open far enough for a real westward
-      // egress step after handoff; deeper blockers still seal hidden voids.
+      // egress step after handoff.
       minX: upperStairwellOpening.minX,
       // Size the east edge from the real upper-floor descent opening and add
       // one collision radius because collider checks expand the blocker edge.
@@ -2030,21 +2019,6 @@ function initializeImmersiveScene(
           maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
           minZ: upperStairLandingEntryMaxZ,
           maxZ: upperStairVoidMaxZ,
-        },
-      },
-      {
-        name: 'UpperStairDeepVoidBlocker',
-        bounds: {
-          minX: upperStairWestEgressBlockerMinX,
-          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-          minZ: Math.min(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
-          maxZ: Math.max(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
         },
       },
       ...upperStairTopGapBlockers,


### PR DESCRIPTION
### Motivation
- A large rectangular yellow debug collider remained in the middle of the upper landing and blocked normal movement; the change removes that single artifact while preserving all other stair, doorway, navmesh, and visibility logic.

### Description
- Removed the `UpperStairDeepVoidBlocker` collider registration and the small amount of derived bounds math that only supported it, leaving other upper-stair guards and the `UpperStairHiddenRunBlocker` intact.
- Kept debug collider visualization available and only removed the single named collider responsible for the visible middle-landing rectangle.
- Updated `playwright/immersive-stairs-roundtrip.spec.ts` to assert the removed name is absent and to add representative middle-landing samples that must be occupiable and unblocked.

### Testing
- `npm run format:write` — succeeded.
- `npm run lint` — succeeded after removing the unused variable.
- `npm run test:ci` (Vitest) — succeeded; unit suite passed (all tests green).
- `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — succeeded; Playwright stairs roundtrip spec passed (7 tests across stairs scenarios).
- `npm run docs:check` — succeeded (link-check produced external fetch warnings only).
- `npm run smoke` and `npm run build` — succeeded (Vite chunk-size warnings noted but unrelated).
- Captured a local debug screenshot with `?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1` at `/tmp/upper-landing-collider-debug.png` for manual verification (not committed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a240dc35c832f937fda215a878a21)