### PR TITLE
Remove upper landing artifact collider

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -176,6 +176,44 @@ function getUpperRoomCenter(roomId: string) {
   };
 }
 
+type NamedPosition = {
+  name: string;
+  target: { x: number; z: number; floorId?: FloorId };
+};
+
+function expectSampleOnPhysicalStaircaseLanding(
+  sample: NamedPosition,
+  metrics: Awaited<ReturnType<typeof getStairMetrics>>
+) {
+  const landingMinX = metrics.stairCenterX - metrics.stairHalfWidth;
+  const landingMaxX = metrics.stairCenterX + metrics.stairHalfWidth;
+  const landingMinZ = Math.min(
+    metrics.stairLandingMinZ,
+    metrics.stairLandingMaxZ
+  );
+  const landingMaxZ = Math.max(
+    metrics.stairLandingMinZ,
+    metrics.stairLandingMaxZ
+  );
+
+  expect(
+    sample.target.x,
+    `${sample.name} x should sit on the visible StaircaseLanding slab`
+  ).toBeGreaterThanOrEqual(landingMinX);
+  expect(
+    sample.target.x,
+    `${sample.name} x should sit on the visible StaircaseLanding slab`
+  ).toBeLessThanOrEqual(landingMaxX);
+  expect(
+    sample.target.z,
+    `${sample.name} z should sit on the visible StaircaseLanding slab`
+  ).toBeGreaterThanOrEqual(landingMinZ);
+  expect(
+    sample.target.z,
+    `${sample.name} z should sit on the visible StaircaseLanding slab`
+  ).toBeLessThanOrEqual(landingMaxZ);
+}
+
 async function canOccupyPosition(
   page: Page,
   target: { x: number; z: number; floorId?: FloorId }
@@ -569,41 +607,78 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   test.slow();
   await waitForImmersiveReady(page);
 
-  const removedColliderNames = [
-    'UpperStairDeepVoidBlocker',
+  const colliderRemovedByThisPr = 'UpperStairDeepVoidBlocker';
+  // These names were removed by earlier stair-artifact fixes. Keep them in a
+  // separate regression assertion so this PR's single removed collider is clear.
+  const previouslyRemovedArtifactColliders = [
     'UpperStairTopGapBlockerWest',
     'UpperStairEastLandingMouthVoidGuard',
   ];
 
   await walkStairCenterlineToUpperLanding(page);
   const debugColliderNames = await getDebugColliderNames(page);
-  for (const removedColliderName of removedColliderNames) {
-    expect(debugColliderNames).not.toContain(removedColliderName);
+  expect(debugColliderNames).not.toContain(colliderRemovedByThisPr);
+  for (const previouslyRemovedCollider of previouslyRemovedArtifactColliders) {
+    expect(debugColliderNames).not.toContain(previouslyRemovedCollider);
   }
 
-  const landingSamples = [
-    { x: 12.99, z: -26.84, floorId: 'upper' as const },
-    { x: 12.84, z: -26.84, floorId: 'upper' as const },
-    { x: 13.14, z: -26.84, floorId: 'upper' as const },
-    { x: 12.99, z: -26.72, floorId: 'upper' as const },
-    { x: 12.99, z: -26.96, floorId: 'upper' as const },
-    { x: 12.99, z: -29, floorId: 'upper' as const },
-    { x: 12.84, z: -29, floorId: 'upper' as const },
-    { x: 13.14, z: -29, floorId: 'upper' as const },
-    { x: 12.99, z: -28.82, floorId: 'upper' as const },
-    { x: 12.99, z: -29.18, floorId: 'upper' as const },
+  const stairMetrics = await getStairMetrics(page);
+  const physicalLandingSamples: NamedPosition[] = [
+    {
+      name: 'near stair handoff center',
+      target: { x: 12.99, z: -26.84, floorId: 'upper' as const },
+    },
+    {
+      name: 'near stair handoff west edge',
+      target: { x: 12.84, z: -26.84, floorId: 'upper' as const },
+    },
+    {
+      name: 'near stair handoff east edge',
+      target: { x: 13.14, z: -26.84, floorId: 'upper' as const },
+    },
+    {
+      name: 'near stair handoff north edge',
+      target: { x: 12.99, z: -26.72, floorId: 'upper' as const },
+    },
+    {
+      name: 'near stair handoff south edge',
+      target: { x: 12.99, z: -26.96, floorId: 'upper' as const },
+    },
+    {
+      name: 'former UpperStairDeepVoidBlocker center',
+      target: { x: 12.99, z: -29, floorId: 'upper' as const },
+    },
+    {
+      name: 'former UpperStairDeepVoidBlocker west sample',
+      target: { x: 12.84, z: -29, floorId: 'upper' as const },
+    },
+    {
+      name: 'former UpperStairDeepVoidBlocker east sample',
+      target: { x: 13.14, z: -29, floorId: 'upper' as const },
+    },
+    {
+      name: 'former UpperStairDeepVoidBlocker north sample',
+      target: { x: 12.99, z: -28.82, floorId: 'upper' as const },
+    },
+    {
+      name: 'former UpperStairDeepVoidBlocker south sample',
+      target: { x: 12.99, z: -29.18, floorId: 'upper' as const },
+    },
   ];
 
-  for (const landingSample of landingSamples) {
-    expect(await canOccupyPosition(page, landingSample)).toBe(true);
+  for (const sample of physicalLandingSamples) {
+    expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
+    expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
+      true
+    );
     const blockingColliderNames = await getBlockingColliderNames(
       page,
-      landingSample
+      sample.target
     );
-    for (const removedColliderName of removedColliderNames) {
-      expect(blockingColliderNames).not.toContain(removedColliderName);
-    }
-    expect(blockingColliderNames).toEqual([]);
+    expect(blockingColliderNames, sample.name).not.toContain(
+      colliderRemovedByThisPr
+    );
+    expect(blockingColliderNames, sample.name).toEqual([]);
   }
 });
 
@@ -671,6 +746,7 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
+  const stairMetrics = await getStairMetrics(page);
   const {
     stairCenterX,
     stairHalfWidth,
@@ -679,7 +755,7 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     stairLandingMinZ,
     stairLandingDepth,
     stairDirection,
-  } = await getStairMetrics(page);
+  } = stairMetrics;
 
   // Start on ground.
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
@@ -713,24 +789,32 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   }
 
   const formerMiddleLandingArtifactZ = -29;
-  const formerMiddleLandingArtifactSamples = [
+  const formerLandingArtifactSamples: NamedPosition[] = [
     {
-      x: stairCenterX - stairHalfWidth + PLAYER_RADIUS,
-      z: formerMiddleLandingArtifactZ,
-      floorId: 'upper' as const,
+      name: 'former UpperStairDeepVoidBlocker west landing sample',
+      target: {
+        x: stairCenterX - stairHalfWidth + PLAYER_RADIUS,
+        z: formerMiddleLandingArtifactZ,
+        floorId: 'upper' as const,
+      },
     },
     {
-      x: stairCenterX,
-      z: formerMiddleLandingArtifactZ,
-      floorId: 'upper' as const,
+      name: 'former UpperStairDeepVoidBlocker center landing sample',
+      target: {
+        x: stairCenterX,
+        z: formerMiddleLandingArtifactZ,
+        floorId: 'upper' as const,
+      },
     },
   ];
-  for (const formerMiddleLandingArtifactSample of formerMiddleLandingArtifactSamples) {
+  for (const sample of formerLandingArtifactSamples) {
+    expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
+    expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
+      true
+    );
     expect(
-      await canOccupyPosition(page, formerMiddleLandingArtifactSample)
-    ).toBe(true);
-    expect(
-      await getBlockingColliderNames(page, formerMiddleLandingArtifactSample)
+      await getBlockingColliderNames(page, sample.target),
+      sample.name
     ).toEqual([]);
   }
 
@@ -816,13 +900,14 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   await waitForImmersiveReady(page);
 
   const html = page.locator('html');
+  const stairMetrics = await getStairMetrics(page);
   const {
     stairCenterX,
     stairHalfWidth,
     stairBottomZ,
     stairTopZ,
     stairDirection,
-  } = await getStairMetrics(page);
+  } = stairMetrics;
   const creatorsStudioCenter = getUpperRoomCenter('creatorsStudio');
   const westLandingEgress = {
     x: stairCenterX - 1.6,
@@ -856,16 +941,22 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const formerDeepVoidArtifactSamples = [
+  const physicalLandingSamples: NamedPosition[] = [
     {
-      x: stairCenterX - 1.9,
-      z: stairTopZ + stairDirection * 2,
-      floorId: 'upper' as const,
+      name: 'former UpperStairDeepVoidBlocker west landing sample',
+      target: {
+        x: stairCenterX - 1.9,
+        z: stairTopZ + stairDirection * 2,
+        floorId: 'upper' as const,
+      },
     },
     {
-      x: stairCenterX - 1.55,
-      z: stairTopZ + stairDirection * 2.1,
-      floorId: 'upper' as const,
+      name: 'former UpperStairDeepVoidBlocker west egress landing sample',
+      target: {
+        x: stairCenterX - 1.55,
+        z: stairTopZ + stairDirection * 2.1,
+        floorId: 'upper' as const,
+      },
     },
   ];
   const westEdgeFloorClearance = {
@@ -890,12 +981,18 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const formerMiddleLandingArtifactSamples = [
-    { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
+  const formerLandingArtifactSamples: NamedPosition[] = [
     {
-      x: stairCenterX + PLAYER_RADIUS * 0.5,
-      z: -29,
-      floorId: 'upper' as const,
+      name: 'former UpperStairDeepVoidBlocker center landing sample',
+      target: { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
+    },
+    {
+      name: 'former UpperStairDeepVoidBlocker east landing sample',
+      target: {
+        x: stairCenterX + PLAYER_RADIUS * 0.5,
+        z: -29,
+        floorId: 'upper' as const,
+      },
     },
   ];
 
@@ -927,22 +1024,26 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(
     await getBlockingColliderNames(page, westLandingMouthClearance)
   ).toEqual([]);
-  for (const formerDeepVoidArtifactSample of formerDeepVoidArtifactSamples) {
-    expect(await canOccupyPosition(page, formerDeepVoidArtifactSample)).toBe(
+  for (const sample of physicalLandingSamples) {
+    expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
+    expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
       true
     );
     expect(
-      await getBlockingColliderNames(page, formerDeepVoidArtifactSample)
+      await getBlockingColliderNames(page, sample.target),
+      sample.name
     ).toEqual([]);
   }
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
-  for (const formerMiddleLandingArtifactSample of formerMiddleLandingArtifactSamples) {
+  for (const sample of formerLandingArtifactSamples) {
+    expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
+    expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
+      true
+    );
     expect(
-      await canOccupyPosition(page, formerMiddleLandingArtifactSample)
-    ).toBe(true);
-    expect(
-      await getBlockingColliderNames(page, formerMiddleLandingArtifactSample)
+      await getBlockingColliderNames(page, sample.target),
+      sample.name
     ).toEqual([]);
   }
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -563,13 +563,14 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
   });
 });
 
-test('upper landing debug colliders exclude removed landing artifacts', async ({
+test('upper landing debug colliders exclude middle landing artifact', async ({
   page,
 }) => {
   test.slow();
   await waitForImmersiveReady(page);
 
   const removedColliderNames = [
+    'UpperStairDeepVoidBlocker',
     'UpperStairTopGapBlockerWest',
     'UpperStairEastLandingMouthVoidGuard',
   ];
@@ -586,6 +587,11 @@ test('upper landing debug colliders exclude removed landing artifacts', async ({
     { x: 13.14, z: -26.84, floorId: 'upper' as const },
     { x: 12.99, z: -26.72, floorId: 'upper' as const },
     { x: 12.99, z: -26.96, floorId: 'upper' as const },
+    { x: 12.99, z: -29, floorId: 'upper' as const },
+    { x: 12.84, z: -29, floorId: 'upper' as const },
+    { x: 13.14, z: -29, floorId: 'upper' as const },
+    { x: 12.99, z: -28.82, floorId: 'upper' as const },
+    { x: 12.99, z: -29.18, floorId: 'upper' as const },
   ];
 
   for (const landingSample of landingSamples) {
@@ -706,30 +712,37 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     expect(await getBlockingColliderNames(page, egressSample)).toEqual([]);
   }
 
-  const hiddenVoidSampleZ = -29;
-  const nonEgressHiddenVoidSamples = [
+  const formerMiddleLandingArtifactZ = -29;
+  const formerMiddleLandingArtifactSamples = [
     {
       x: stairCenterX - stairHalfWidth + PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
+      z: formerMiddleLandingArtifactZ,
       floorId: 'upper' as const,
     },
     {
       x: stairCenterX,
-      z: hiddenVoidSampleZ,
-      floorId: 'upper' as const,
-    },
-    {
-      x: stairCenterX + stairHalfWidth - PLAYER_RADIUS,
-      z: hiddenVoidSampleZ,
+      z: formerMiddleLandingArtifactZ,
       floorId: 'upper' as const,
     },
   ];
-  for (const hiddenVoidSample of nonEgressHiddenVoidSamples) {
-    expect(await canOccupyPosition(page, hiddenVoidSample)).toBe(false);
-    expect(await getBlockingColliderNames(page, hiddenVoidSample)).not.toEqual(
-      []
-    );
+  for (const formerMiddleLandingArtifactSample of formerMiddleLandingArtifactSamples) {
+    expect(
+      await canOccupyPosition(page, formerMiddleLandingArtifactSample)
+    ).toBe(true);
+    expect(
+      await getBlockingColliderNames(page, formerMiddleLandingArtifactSample)
+    ).toEqual([]);
   }
+
+  const eastVoidGuardSample = {
+    x: stairCenterX + stairHalfWidth - PLAYER_RADIUS,
+    z: formerMiddleLandingArtifactZ,
+    floorId: 'upper' as const,
+  };
+  expect(await canOccupyPosition(page, eastVoidGuardSample)).toBe(false);
+  expect(await getBlockingColliderNames(page, eastVoidGuardSample)).toContain(
+    'UpperStairEastLowerVoidGuard'
+  );
 
   // Continue through the intended west upper-landing exit into an upstairs room
   // with the same step helper used by runtime movement instead of teleporting.
@@ -843,16 +856,18 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const deeperWestHiddenStairVoidGap = {
-    x: stairCenterX - 1.9,
-    z: stairTopZ + stairDirection * 2,
-    floorId: 'upper' as const,
-  };
-  const westHiddenStairVoidSliver = {
-    x: stairCenterX - 1.55,
-    z: stairTopZ + stairDirection * 2.1,
-    floorId: 'upper' as const,
-  };
+  const formerDeepVoidArtifactSamples = [
+    {
+      x: stairCenterX - 1.9,
+      z: stairTopZ + stairDirection * 2,
+      floorId: 'upper' as const,
+    },
+    {
+      x: stairCenterX - 1.55,
+      z: stairTopZ + stairDirection * 2.1,
+      floorId: 'upper' as const,
+    },
+  ];
   const westEdgeFloorClearance = {
     x: 7.5,
     z: -23,
@@ -875,7 +890,7 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: stairTopZ + stairDirection * 0.95,
     floorId: 'upper' as const,
   };
-  const hiddenStairVoidGap = [
+  const formerMiddleLandingArtifactSamples = [
     { x: stairCenterX, z: -28.8, floorId: 'upper' as const },
     {
       x: stairCenterX + PLAYER_RADIUS * 0.5,
@@ -912,17 +927,23 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
   expect(
     await getBlockingColliderNames(page, westLandingMouthClearance)
   ).toEqual([]);
-  expect(await canOccupyPosition(page, deeperWestHiddenStairVoidGap)).toBe(
-    false
-  );
-  expect(
-    await getBlockingColliderNames(page, deeperWestHiddenStairVoidGap)
-  ).toContain('UpperStairDeepVoidBlocker');
-  expect(await canOccupyPosition(page, westHiddenStairVoidSliver)).toBe(false);
+  for (const formerDeepVoidArtifactSample of formerDeepVoidArtifactSamples) {
+    expect(await canOccupyPosition(page, formerDeepVoidArtifactSample)).toBe(
+      true
+    );
+    expect(
+      await getBlockingColliderNames(page, formerDeepVoidArtifactSample)
+    ).toEqual([]);
+  }
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
-  for (const hiddenStairVoidGapSample of hiddenStairVoidGap) {
-    expect(await canOccupyPosition(page, hiddenStairVoidGapSample)).toBe(false);
+  for (const formerMiddleLandingArtifactSample of formerMiddleLandingArtifactSamples) {
+    expect(
+      await canOccupyPosition(page, formerMiddleLandingArtifactSample)
+    ).toBe(true);
+    expect(
+      await getBlockingColliderNames(page, formerMiddleLandingArtifactSample)
+    ).toEqual([]);
   }
   expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
   expect(await getBlockingColliderNames(page, hiddenStairRun)).toContain(

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -76,14 +76,28 @@ type TestWorldApi = {
   getFloorVisibilitySnapshot(): FloorVisibilitySnapshot;
 };
 
+type DebugColliderBounds = {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+};
+
+type DebugColliderMetadata = {
+  floor: FloorId | 'all';
+  category: string;
+  name: string;
+  bounds: DebugColliderBounds;
+};
+
 type DebugColliderApi = {
   setEnabled(enabled: boolean): void;
-  getColliders(): Array<{ name: string }>;
+  getColliders(): DebugColliderMetadata[];
   getBlockingCollidersAt(target: {
     x: number;
     z: number;
     floorId?: FloorId;
-  }): Array<{ name: string }>;
+  }): DebugColliderMetadata[];
 };
 
 type DebugCoordinatesApi = {
@@ -214,6 +228,32 @@ function expectSampleOnPhysicalStaircaseLanding(
   ).toBeLessThanOrEqual(landingMaxZ);
 }
 
+function expectSampleOutsidePhysicalStaircaseLanding(
+  sample: NamedPosition,
+  metrics: Awaited<ReturnType<typeof getStairMetrics>>
+) {
+  const landingMinX = metrics.stairCenterX - metrics.stairHalfWidth;
+  const landingMaxX = metrics.stairCenterX + metrics.stairHalfWidth;
+  const landingMinZ = Math.min(
+    metrics.stairLandingMinZ,
+    metrics.stairLandingMaxZ
+  );
+  const landingMaxZ = Math.max(
+    metrics.stairLandingMinZ,
+    metrics.stairLandingMaxZ
+  );
+  const isOnLandingSlab =
+    sample.target.x >= landingMinX &&
+    sample.target.x <= landingMaxX &&
+    sample.target.z >= landingMinZ &&
+    sample.target.z <= landingMaxZ;
+
+  expect(
+    isOnLandingSlab,
+    `${sample.name} should sit in the no-floor stairwell cutout, not on the visible StaircaseLanding slab`
+  ).toBe(false);
+}
+
 async function canOccupyPosition(
   page: Page,
   target: { x: number; z: number; floorId?: FloorId }
@@ -242,14 +282,14 @@ async function getBlockingColliderNames(
   }, target);
 }
 
-async function getDebugColliderNames(page: Page) {
+async function getDebugColliders(page: Page) {
   return page.evaluate(() => {
     const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
     if (!debugApi) {
       throw new Error('Debug colliders API unavailable');
     }
     debugApi.setEnabled(true);
-    return debugApi.getColliders().map((collider) => collider.name);
+    return debugApi.getColliders();
   });
 }
 
@@ -616,57 +656,74 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   ];
 
   await walkStairCenterlineToUpperLanding(page);
-  const debugColliderNames = await getDebugColliderNames(page);
+  const debugColliders = await getDebugColliders(page);
+  const debugColliderNames = debugColliders.map((collider) => collider.name);
   expect(debugColliderNames).not.toContain(colliderRemovedByThisPr);
   for (const previouslyRemovedCollider of previouslyRemovedArtifactColliders) {
     expect(debugColliderNames).not.toContain(previouslyRemovedCollider);
   }
 
   const stairMetrics = await getStairMetrics(page);
-  const physicalLandingSamples: NamedPosition[] = [
+  const visibleMiddleLandingArtifactSamples: NamedPosition[] = [
     {
-      name: 'near stair handoff center',
+      name: 'visible middle-landing artifact center',
       target: { x: 12.99, z: -26.84, floorId: 'upper' as const },
     },
     {
-      name: 'near stair handoff west edge',
+      name: 'visible middle-landing artifact west edge',
       target: { x: 12.84, z: -26.84, floorId: 'upper' as const },
     },
     {
-      name: 'near stair handoff east edge',
+      name: 'visible middle-landing artifact east edge',
       target: { x: 13.14, z: -26.84, floorId: 'upper' as const },
     },
     {
-      name: 'near stair handoff north edge',
+      name: 'visible middle-landing artifact north edge',
       target: { x: 12.99, z: -26.72, floorId: 'upper' as const },
     },
     {
-      name: 'near stair handoff south edge',
+      name: 'visible middle-landing artifact south edge',
       target: { x: 12.99, z: -26.96, floorId: 'upper' as const },
     },
+  ];
+  const physicalLandingSamplesAtFormerZ29: NamedPosition[] = [
     {
-      name: 'former UpperStairDeepVoidBlocker center',
+      name: 'former UpperStairDeepVoidBlocker z=-29 landing center',
       target: { x: 12.99, z: -29, floorId: 'upper' as const },
     },
     {
-      name: 'former UpperStairDeepVoidBlocker west sample',
+      name: 'former UpperStairDeepVoidBlocker z=-29 landing west sample',
       target: { x: 12.84, z: -29, floorId: 'upper' as const },
     },
     {
-      name: 'former UpperStairDeepVoidBlocker east sample',
+      name: 'former UpperStairDeepVoidBlocker z=-29 landing east sample',
       target: { x: 13.14, z: -29, floorId: 'upper' as const },
     },
+  ];
+  const noFloorHiddenCutoutSamples: Array<
+    NamedPosition & { expectedBlocker: string }
+  > = [
     {
-      name: 'former UpperStairDeepVoidBlocker north sample',
-      target: { x: 12.99, z: -28.82, floorId: 'upper' as const },
+      name: 'east no-floor cutout beside z=-29 landing sample',
+      target: { x: 15.75, z: -29, floorId: 'upper' as const },
+      expectedBlocker: 'UpperStairEastLowerVoidGuard',
     },
     {
-      name: 'former UpperStairDeepVoidBlocker south sample',
-      target: { x: 12.99, z: -29.18, floorId: 'upper' as const },
+      name: 'south no-floor cutout beyond StaircaseLanding slab',
+      target: { x: 12.99, z: -31.35, floorId: 'upper' as const },
+      expectedBlocker: 'UpperStairwellLandingGuard-2',
+    },
+    {
+      name: 'hidden stair run above upper landing lip',
+      target: { x: 12.7, z: -23.72, floorId: 'upper' as const },
+      expectedBlocker: 'UpperStairHiddenRunBlocker',
     },
   ];
 
-  for (const sample of physicalLandingSamples) {
+  for (const sample of [
+    ...visibleMiddleLandingArtifactSamples,
+    ...physicalLandingSamplesAtFormerZ29,
+  ]) {
     expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
     expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
       true
@@ -679,6 +736,21 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
       colliderRemovedByThisPr
     );
     expect(blockingColliderNames, sample.name).toEqual([]);
+  }
+
+  for (const sample of noFloorHiddenCutoutSamples) {
+    expectSampleOutsidePhysicalStaircaseLanding(sample, stairMetrics);
+    expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
+      false
+    );
+    const blockingColliderNames = await getBlockingColliderNames(
+      page,
+      sample.target
+    );
+    expect(blockingColliderNames, sample.name).toContain(
+      sample.expectedBlocker
+    );
+    expect(blockingColliderNames.length, sample.name).toBeGreaterThan(0);
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1947,9 +1947,12 @@ function initializeImmersiveScene(
     );
     // Invisible upper-floor guard rails flank the intentional descent corridor.
     // They are scoped to the actual upper-floor cutout instead of the full ramp
-    // run so normal loft space beyond the landing remains occupiable. The center
-    // blockers reject forced upper-floor placement over the hidden stair-top gap
-    // and hidden run while preserving the widened west egress,
+    // run so normal loft space beyond the landing remains occupiable.
+    // UpperStairDeepVoidBlocker is intentionally absent: it covered the visible
+    // physical StaircaseLanding slab, while the remaining top-gap/hidden-run/void
+    // blockers still guard the true hidden stair run and no-floor void edges.
+    // The center blockers reject forced upper-floor placement over the hidden
+    // stair-top gap and hidden run while preserving the widened west egress,
     // narrow stair-top handoff, a west-side bypass lane around the void, and the
     // north doorway's padded passage into the loft. The top-gap west lip stays
     // intentionally narrow so its collision edge protects the hidden center gap

--- a/src/main.ts
+++ b/src/main.ts
@@ -1928,10 +1928,6 @@ function initializeImmersiveScene(
   if (upperLandingRoom && upperStairwellOpening) {
     const upperStairVoidMinZ = upperStairwellOpening.minZ;
     const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperStairWestEgressMinZ = Math.min(
-      stairLandingMinZ + stairwellMarginZ,
-      stairLandingMaxZ
-    );
     const upperLandingDoorwayClearanceZ =
       upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
     const hiddenStairTopGapBlockerNearZ =
@@ -1941,13 +1937,6 @@ function initializeImmersiveScene(
     const hiddenStairTopGapBlockerFarZ =
       stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
     const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairWestVoidGapBlockerMinZ = upperStairWestEgressMinZ;
-    const hiddenStairDeepVoidBlockerMinZ =
-      hiddenStairWestVoidGapBlockerMinZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairDeepVoidBlockerMaxZ =
-      hiddenStairTopGapBlockerNearZ +
-      stairLayout.directionMultiplier * PLAYER_RADIUS * 2;
     const hiddenStairBlockerStartZ =
       stairTopZ -
       stairLayout.directionMultiplier *
@@ -1960,14 +1949,14 @@ function initializeImmersiveScene(
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable. The center
     // blockers reject forced upper-floor placement over the hidden stair-top gap
-    // and the deeper removed stair run while preserving the widened west egress,
+    // and hidden run while preserving the widened west egress,
     // narrow stair-top handoff, a west-side bypass lane around the void, and the
     // north doorway's padded passage into the loft. The top-gap west lip stays
     // intentionally narrow so its collision edge protects the hidden center gap
     // without filling the west egress lane around the stairwell.
     const upperStairLandingEntryCorridor = {
       // Keep the upper landing mouth open far enough for a real westward
-      // egress step after handoff; deeper blockers still seal hidden voids.
+      // egress step after handoff; side guards still seal hidden void edges.
       minX: upperStairwellOpening.minX,
       // Size the east edge from the real upper-floor descent opening and add
       // one collision radius because collider checks expand the blocker edge.
@@ -2030,21 +2019,6 @@ function initializeImmersiveScene(
           maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
           minZ: upperStairLandingEntryMaxZ,
           maxZ: upperStairVoidMaxZ,
-        },
-      },
-      {
-        name: 'UpperStairDeepVoidBlocker',
-        bounds: {
-          minX: upperStairWestEgressBlockerMinX,
-          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-          minZ: Math.min(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
-          maxZ: Math.max(
-            hiddenStairDeepVoidBlockerMinZ,
-            hiddenStairDeepVoidBlockerMaxZ
-          ),
         },
       },
       ...upperStairTopGapBlockers,


### PR DESCRIPTION
### Motivation
- Remove a visible rectangular yellow debug collider occupying the middle of the upper landing while preserving all intentional stair, doorway, navmesh, and visibility behavior.
- Identify the exact registered collider causing the artifact using the debug collider API and remove only that single registration to avoid regressions.

### Description
- Removed the lone upper-floor collider registration `UpperStairDeepVoidBlocker` so the visible middle-landing rectangle is no longer registered or visualized (`src/main.ts`).
- Removed now-unused helper variables tied to that registration to keep the code clean and focused (`src/main.ts`).
- Updated the Playwright stairs spec to explicitly assert the removed collider name is absent and expanded landing samples to verify the former artifact area is occupiable while the intentional east void guard and hidden-run blocker remain enforced (`playwright/immersive-stairs-roundtrip.spec.ts`).
- No other upper-floor colliders, stair handoff, navmesh, doorway logic, or visibility behavior were changed.

### Testing
- Ran formatter with `npm run format:write` and it completed successfully.
- Ran linter with `npm run lint` and it completed successfully.
- Ran unit tests with `npm run test:ci` (Vitest) and the suite passed (all tests green).
- Ran Playwright focused spec with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and the updated stairs tests passed.
- Ran docs checks with `npm run docs:check` and smoke/build with `npm run smoke` / `npm run build`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a240dc35c832f937fda215a878a21)