### PR TITLE
Replace broad upper-stair blocker with L-shaped bannister guards

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -282,6 +282,17 @@ async function getBlockingColliderNames(
   }, target);
 }
 
+function expectBoundsCloseTo(
+  actual: DebugColliderBounds,
+  expected: DebugColliderBounds,
+  tolerance = 0.8
+) {
+  expect(actual.minX).toBeGreaterThanOrEqual(expected.minX - tolerance);
+  expect(actual.maxX).toBeLessThanOrEqual(expected.maxX + tolerance);
+  expect(actual.minZ).toBeGreaterThanOrEqual(expected.minZ - tolerance);
+  expect(actual.maxZ).toBeLessThanOrEqual(expected.maxZ + tolerance);
+}
+
 async function getDebugColliders(page: Page) {
   return page.evaluate(() => {
     const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
@@ -648,6 +659,7 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   await waitForImmersiveReady(page);
 
   const colliderRemovedByThisPr = 'UpperStairDeepVoidBlocker';
+  const broadStairBlockerReplacedByThisPr = 'UpperStairHiddenRunBlocker';
   // These names were removed by earlier stair-artifact fixes. Keep them in a
   // separate regression assertion so this PR's single removed collider is clear.
   const previouslyRemovedArtifactColliders = [
@@ -659,6 +671,9 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   const debugColliders = await getDebugColliders(page);
   const debugColliderNames = debugColliders.map((collider) => collider.name);
   expect(debugColliderNames).not.toContain(colliderRemovedByThisPr);
+  expect(debugColliderNames).not.toContain(broadStairBlockerReplacedByThisPr);
+  expect(debugColliderNames).toContain('UpperStairWestBannisterGuard');
+  expect(debugColliderNames).toContain('UpperStairNorthBannisterGuard');
   for (const previouslyRemovedCollider of previouslyRemovedArtifactColliders) {
     expect(debugColliderNames).not.toContain(previouslyRemovedCollider);
   }
@@ -700,6 +715,28 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
       target: { x: 13.14, z: -29, floorId: 'upper' as const },
     },
   ];
+  const descentCorridorSamples: NamedPosition[] = [
+    {
+      name: 'upper landing mouth centerline',
+      target: {
+        x: stairMetrics.stairCenterX,
+        z: stairMetrics.stairTopZ + stairMetrics.stairDirection * 0.2,
+        floorId: 'upper' as const,
+      },
+    },
+    {
+      name: 'stair centerline below upper landing lip',
+      target: {
+        x: stairMetrics.stairCenterX,
+        z: stairMetrics.stairTopZ - stairMetrics.stairDirection * 0.7,
+        floorId: 'upper' as const,
+      },
+    },
+    {
+      name: 'stair centerline through former broad blocker',
+      target: { x: 12.7, z: -23.72, floorId: 'upper' as const },
+    },
+  ];
   const noFloorHiddenCutoutSamples: Array<
     NamedPosition & { expectedBlocker: string }
   > = [
@@ -712,11 +749,6 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
       name: 'south no-floor cutout beyond StaircaseLanding slab',
       target: { x: 12.99, z: -31.35, floorId: 'upper' as const },
       expectedBlocker: 'UpperStairwellLandingGuard-2',
-    },
-    {
-      name: 'hidden stair run above upper landing lip',
-      target: { x: 12.7, z: -23.72, floorId: 'upper' as const },
-      expectedBlocker: 'UpperStairHiddenRunBlocker',
     },
   ];
 
@@ -737,6 +769,54 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
     );
     expect(blockingColliderNames, sample.name).toEqual([]);
   }
+
+  for (const sample of descentCorridorSamples) {
+    expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
+      true
+    );
+    expect(
+      await getBlockingColliderNames(page, sample.target),
+      sample.name
+    ).toEqual([]);
+  }
+
+  const westBannister = debugColliders.find(
+    (collider) => collider.name === 'UpperStairWestBannisterGuard'
+  );
+  const northBannister = debugColliders.find(
+    (collider) => collider.name === 'UpperStairNorthBannisterGuard'
+  );
+  expect(westBannister).toBeDefined();
+  expect(northBannister).toBeDefined();
+  if (!westBannister || !northBannister) {
+    throw new Error('Missing upper stair bannister guard colliders');
+  }
+  expectBoundsCloseTo(westBannister.bounds, {
+    minX: 10.37,
+    maxX: 10.81,
+    minZ: -24.68,
+    maxZ: -18.25,
+  });
+  expectBoundsCloseTo(northBannister.bounds, {
+    minX: 10.59,
+    maxX: 15.58,
+    minZ: -18.47,
+    maxZ: -18.03,
+  });
+  expect(
+    await getBlockingColliderNames(page, {
+      x: (westBannister.bounds.minX + westBannister.bounds.maxX) / 2,
+      z: (westBannister.bounds.minZ + westBannister.bounds.maxZ) / 2,
+      floorId: 'upper',
+    })
+  ).toContain('UpperStairWestBannisterGuard');
+  expect(
+    await getBlockingColliderNames(page, {
+      x: (northBannister.bounds.minX + northBannister.bounds.maxX) / 2,
+      z: (northBannister.bounds.minZ + northBannister.bounds.maxZ) / 2,
+      floorId: 'upper',
+    })
+  ).toContain('UpperStairNorthBannisterGuard');
 
   for (const sample of noFloorHiddenCutoutSamples) {
     expectSampleOutsidePhysicalStaircaseLanding(sample, stairMetrics);
@@ -965,7 +1045,7 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   });
 });
 
-test('upper landing opens west into upstairs rooms and blocks the hidden stair run', async ({
+test('upper landing opens west and keeps the stair descent corridor clear', async ({
   page,
 }) => {
   test.slow();
@@ -1002,8 +1082,12 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: upperLandingRoom.bounds.maxZ,
     floorId: 'upper' as const,
   };
-  const hiddenStairRun = { x: 12.7, z: -23.72, floorId: 'upper' as const };
-  const hiddenStairTopRun = {
+  const formerHiddenStairRun = {
+    x: 12.7,
+    z: -23.72,
+    floorId: 'upper' as const,
+  };
+  const descentCorridorLip = {
     x: stairCenterX,
     z: stairTopZ - stairDirection * 0.4,
     floorId: 'upper' as const,
@@ -1107,7 +1191,8 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     ).toEqual([]);
   }
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
-  expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
+  expect(await canOccupyPosition(page, descentCorridorLip)).toBe(true);
+  expect(await getBlockingColliderNames(page, descentCorridorLip)).toEqual([]);
   for (const sample of formerLandingArtifactSamples) {
     expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
     expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
@@ -1118,13 +1203,11 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
       sample.name
     ).toEqual([]);
   }
-  expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
-  expect(await getBlockingColliderNames(page, hiddenStairRun)).toContain(
-    'UpperStairHiddenRunBlocker'
+  expect(await canOccupyPosition(page, formerHiddenStairRun)).toBe(true);
+  expect(await getBlockingColliderNames(page, formerHiddenStairRun)).toEqual(
+    []
   );
-  await expect(async () => movePlayerTo(page, hiddenStairRun)).rejects.toThrow(
-    /Cannot occupy/
-  );
+  await movePlayerTo(page, formerHiddenStairRun);
 });
 
 test('upper landing edge nudges stay upstairs until the descent corridor is entered', async ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1949,14 +1949,14 @@ function initializeImmersiveScene(
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable.
     // UpperStairDeepVoidBlocker is intentionally absent: it covered the visible
-    // physical StaircaseLanding slab, while the remaining top-gap/hidden-run/void
-    // blockers still guard the true hidden stair run and no-floor void edges.
-    // The center blockers reject forced upper-floor placement over the hidden
-    // stair-top gap and hidden run while preserving the widened west egress,
-    // narrow stair-top handoff, a west-side bypass lane around the void, and the
-    // north doorway's padded passage into the loft. The top-gap west lip stays
-    // intentionally narrow so its collision edge protects the hidden center gap
-    // without filling the west egress lane around the stairwell.
+    // physical StaircaseLanding slab, while the remaining top-gap/void
+    // blockers still guard no-floor void edges.
+    // The upper-floor stair run stays open for descent from the landing. A thin
+    // L-shaped bannister replaces the former broad center blocker so side/back
+    // entries are rejected without filling the stair centerline or west egress
+    // lane. The top-gap west lip stays intentionally narrow so its collision
+    // edge protects the hidden center gap without filling the west egress lane
+    // around the stairwell.
     const upperStairLandingEntryCorridor = {
       // Keep the upper landing mouth open far enough for a real westward
       // egress step after handoff; side guards still seal hidden void edges.
@@ -2026,12 +2026,29 @@ function initializeImmersiveScene(
       },
       ...upperStairTopGapBlockers,
       {
-        name: 'UpperStairHiddenRunBlocker',
+        name: 'UpperStairWestBannisterGuard',
         bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.minX,
-          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-          minZ: Math.min(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
+          minX:
+            stairNavigationZones.explicitDescentCorridor.minX +
+            stairGuardThickness * 0.7,
+          maxX:
+            stairNavigationZones.explicitDescentCorridor.minX +
+            stairGuardThickness * 1.7,
+          minZ:
+            Math.min(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ) +
+            stairGuardThickness / 2,
           maxZ: Math.max(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
+        },
+      },
+      {
+        name: 'UpperStairNorthBannisterGuard',
+        bounds: {
+          minX:
+            stairNavigationZones.explicitDescentCorridor.minX +
+            stairGuardThickness * 0.7,
+          maxX: upperStairwellOpening.maxX - stairGuardThickness / 2,
+          minZ: hiddenStairBlockerMaxZ - stairGuardThickness / 2,
+          maxZ: hiddenStairBlockerMaxZ + stairGuardThickness / 2,
         },
       },
     ].forEach(({ name, bounds }) => pushNamedUpperFloorCollider(name, bounds));


### PR DESCRIPTION
### Motivation
- A large upper-floor collider was blocking legitimate descent from the upper landing into the stair centerline while intended to only prevent side/back entries. 
- The goal is to preserve stair ascent, west egress, void protections and other movement/visibility systems while replacing the overbroad blocker with a thin L-shaped bannister formed by two rectangular colliders.

### Description
- Replaced the broad center `UpperStairHiddenRunBlocker` with two named colliders `UpperStairWestBannisterGuard` and `UpperStairNorthBannisterGuard` computed from the shared stair layout and registered via `pushNamedUpperFloorCollider(...)` in `src/main.ts` so debug overlays appear. 
- The new guards use nonzero thickness derived from `stairGuardThickness` and are positioned to form the L-shaped bannister that blocks side/back entry but leaves the stair centerline and west egress open. 
- Updated `playwright/immersive-stairs-roundtrip.spec.ts` to add `expectBoundsCloseTo`, assert the old broad blocker is absent, assert both new bannister colliders exist and roughly match the intended L-shape bounds, and add descent/collider assertions that verify the landing→stair centerline is occupiable and side/back samples remain blocked. 
- Kept all existing void guards, east-side protections, landing cutouts, navmesh/stair layout logic, and other movement/POI/floor-visibility code untouched.

### Testing
- Ran formatting with `npm run format:write` (succeeded). 
- Ran lint with `npm run lint` (succeeded). 
- Ran the unit suite with `npm run test:ci` (Vitest: 1081 tests passed). 
- Installed Playwright browsers and host deps then ran the focused Playwright test with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (succeeded: 7 tests passed). 
- Ran `npm run docs:check` (succeeded; link checker emitted external fetch warnings only). 
- Ran smoke/build steps `npm run smoke` and `npm run build` (succeeded; existing Vite large-chunk warnings unchanged). 
- Ran secret scan `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a5b2b6a80832f9cf834a4e1a0f690)