### PR TITLE
🛡️ : – Replace broad upper stair blocker with L-shaped bannister guards

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -481,6 +481,73 @@ async function walkUpperLandingWestExitToCreatorsStudio(page: Page) {
   );
 }
 
+async function walkUpperLandingToGroundViaStairCenterline(page: Page) {
+  const { stairCenterX, stairBottomZ, stairTopZ, stairDirection } =
+    await getStairMetrics(page);
+
+  return page.evaluate(
+    ({
+      stairCenterX: nextStairCenterX,
+      stairBottomZ,
+      stairTopZ,
+      stairDirection,
+    }) => {
+      const world = (window as PortfolioWindow).portfolio?.world;
+      const debugColliders = (window as PortfolioWindow).portfolio
+        ?.debugColliders;
+      if (!world || !debugColliders) {
+        throw new Error('World/debug colliders API unavailable');
+      }
+
+      const landingMouthZ = stairTopZ + stairDirection * 0.45;
+      world.movePlayerTo({
+        x: nextStairCenterX,
+        z: landingMouthZ,
+        floorId: 'upper',
+      });
+
+      const samples: Array<{
+        before: { x: number; z: number; activeFloor: FloorId };
+        result: ReturnType<TestWorldApi['stepPlayerForTest']>;
+        blockingColliderNames: string[];
+      }> = [];
+      const stepZ = -stairDirection * 0.08;
+      const targetZ = stairBottomZ - stairDirection * 0.15;
+
+      for (let index = 0; index < 260; index += 1) {
+        const beforePosition = world.getPlayerPosition();
+        const before = {
+          x: beforePosition.x,
+          z: beforePosition.z,
+          activeFloor: world.getActiveFloor(),
+        };
+        if (stairDirection === -1 ? before.z >= targetZ : before.z <= targetZ) {
+          break;
+        }
+
+        const target = { x: nextStairCenterX, z: before.z + stepZ };
+        const blockingColliderNames = debugColliders
+          .getBlockingCollidersAt(target)
+          .map((collider) => collider.name);
+        const result = world.stepPlayerForTest({ dx: 0, dz: stepZ });
+        samples.push({ before, result, blockingColliderNames });
+        if (!result.movedZ) {
+          break;
+        }
+      }
+
+      return {
+        samples,
+        finalState: {
+          activeFloor: world.getActiveFloor(),
+          position: world.getPlayerPosition(),
+        },
+      };
+    },
+    { stairCenterX, stairBottomZ, stairTopZ, stairDirection }
+  );
+}
+
 async function walkUpperDescentLipBand(page: Page) {
   const { stairCenterX, stairTopZ, stairDirection } =
     await getStairMetrics(page);
@@ -648,8 +715,9 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   await waitForImmersiveReady(page);
 
   const colliderRemovedByThisPr = 'UpperStairDeepVoidBlocker';
+  const broadStairBlockerRemovedByThisPr = 'UpperStairHiddenRunBlocker';
   // These names were removed by earlier stair-artifact fixes. Keep them in a
-  // separate regression assertion so this PR's single removed collider is clear.
+  // separate regression assertion so the bannister replacement remains focused.
   const previouslyRemovedArtifactColliders = [
     'UpperStairTopGapBlockerWest',
     'UpperStairEastLandingMouthVoidGuard',
@@ -659,9 +727,33 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   const debugColliders = await getDebugColliders(page);
   const debugColliderNames = debugColliders.map((collider) => collider.name);
   expect(debugColliderNames).not.toContain(colliderRemovedByThisPr);
+  expect(debugColliderNames).not.toContain(broadStairBlockerRemovedByThisPr);
+  expect(debugColliderNames).toContain('UpperStairWestBannisterGuard');
+  expect(debugColliderNames).toContain('UpperStairNorthBannisterGuard');
   for (const previouslyRemovedCollider of previouslyRemovedArtifactColliders) {
     expect(debugColliderNames).not.toContain(previouslyRemovedCollider);
   }
+
+  const westBannister = debugColliders.find(
+    (collider) => collider.name === 'UpperStairWestBannisterGuard'
+  );
+  const northBannister = debugColliders.find(
+    (collider) => collider.name === 'UpperStairNorthBannisterGuard'
+  );
+  expect(westBannister).toBeDefined();
+  expect(northBannister).toBeDefined();
+  expect(westBannister?.bounds.minX).toBeGreaterThan(10.3);
+  expect(westBannister?.bounds.maxX).toBeLessThan(10.9);
+  expect(westBannister?.bounds.minZ).toBeGreaterThan(-25.3);
+  expect(westBannister?.bounds.minZ).toBeLessThan(-24.4);
+  expect(westBannister?.bounds.maxZ).toBeGreaterThan(-19);
+  expect(westBannister?.bounds.maxZ).toBeLessThan(-18);
+  expect(northBannister?.bounds.minX).toBeGreaterThan(10.3);
+  expect(northBannister?.bounds.minX).toBeLessThan(10.9);
+  expect(northBannister?.bounds.maxX).toBeGreaterThan(15.3);
+  expect(northBannister?.bounds.maxX).toBeLessThan(15.9);
+  expect(northBannister?.bounds.minZ).toBeGreaterThan(-18.8);
+  expect(northBannister?.bounds.maxZ).toBeLessThan(-18);
 
   const stairMetrics = await getStairMetrics(page);
   const visibleMiddleLandingArtifactSamples: NamedPosition[] = [
@@ -714,9 +806,14 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
       expectedBlocker: 'UpperStairwellLandingGuard-2',
     },
     {
-      name: 'hidden stair run above upper landing lip',
-      target: { x: 12.7, z: -23.72, floorId: 'upper' as const },
-      expectedBlocker: 'UpperStairHiddenRunBlocker',
+      name: 'west side-entry into hidden stair run',
+      target: { x: 10.6, z: -23.72, floorId: 'upper' as const },
+      expectedBlocker: 'UpperStairWestBannisterGuard',
+    },
+    {
+      name: 'north back-entry into hidden stair run',
+      target: { x: 12.7, z: -18.35, floorId: 'upper' as const },
+      expectedBlocker: 'UpperStairNorthBannisterGuard',
     },
   ];
 
@@ -928,8 +1025,34 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     backyardEnvironmentVisible: false,
   });
 
-  // Return toward the stairs with continuous upper→ground steps. The first ground
-  // samples should keep the upper-origin lip blend instead of snapping to raw ramp height.
+  // Return toward the stairs with continuous upper→ground steps. First verify the
+  // legitimate landing mouth can re-enter the stair centerline without hitting
+  // the bannister guards or the removed broad hidden-run blocker.
+  const roundTripDescent =
+    await walkUpperLandingToGroundViaStairCenterline(page);
+  expect(roundTripDescent.samples.length).toBeGreaterThan(0);
+  for (const sample of roundTripDescent.samples) {
+    expect(
+      sample.blockingColliderNames,
+      `descent sample at z=${sample.before.z}`
+    ).not.toEqual(expect.arrayContaining(['UpperStairHiddenRunBlocker']));
+    expect(
+      sample.blockingColliderNames,
+      `descent sample at z=${sample.before.z}`
+    ).not.toEqual(
+      expect.arrayContaining([
+        'UpperStairWestBannisterGuard',
+        'UpperStairNorthBannisterGuard',
+      ])
+    );
+    expect(sample.result.movedZ, `blocked at z=${sample.before.z}`).toBe(true);
+  }
+  expect(roundTripDescent.finalState.activeFloor).toBe('ground');
+  await expect(html).toHaveAttribute('data-active-floor', 'ground');
+
+  // Reset at the upper landing to inspect the first ground samples: they should
+  // keep the upper-origin lip blend instead of snapping to raw ramp height.
+  await walkStairCenterlineToUpperLanding(page);
   const descentSamples = await walkUpperDescentLipBand(page);
   const descentGroundSamples = descentSamples.filter(
     (sample) =>
@@ -1002,7 +1125,16 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     z: upperLandingRoom.bounds.maxZ,
     floorId: 'upper' as const,
   };
-  const hiddenStairRun = { x: 12.7, z: -23.72, floorId: 'upper' as const };
+  const westHiddenRunSideEntry = {
+    x: 10.6,
+    z: -23.72,
+    floorId: 'upper' as const,
+  };
+  const northHiddenRunBackEntry = {
+    x: 12.7,
+    z: -18.35,
+    floorId: 'upper' as const,
+  };
   const hiddenStairTopRun = {
     x: stairCenterX,
     z: stairTopZ - stairDirection * 0.4,
@@ -1107,7 +1239,8 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
     ).toEqual([]);
   }
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
-  expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(false);
+  expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(true);
+  expect(await getBlockingColliderNames(page, hiddenStairTopRun)).toEqual([]);
   for (const sample of formerLandingArtifactSamples) {
     expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
     expect(await canOccupyPosition(page, sample.target), sample.name).toBe(
@@ -1118,13 +1251,17 @@ test('upper landing opens west into upstairs rooms and blocks the hidden stair r
       sample.name
     ).toEqual([]);
   }
-  expect(await canOccupyPosition(page, hiddenStairRun)).toBe(false);
-  expect(await getBlockingColliderNames(page, hiddenStairRun)).toContain(
-    'UpperStairHiddenRunBlocker'
-  );
-  await expect(async () => movePlayerTo(page, hiddenStairRun)).rejects.toThrow(
-    /Cannot occupy/
-  );
+  expect(await canOccupyPosition(page, westHiddenRunSideEntry)).toBe(false);
+  expect(
+    await getBlockingColliderNames(page, westHiddenRunSideEntry)
+  ).toContain('UpperStairWestBannisterGuard');
+  await expect(async () =>
+    movePlayerTo(page, westHiddenRunSideEntry)
+  ).rejects.toThrow(/Cannot occupy/);
+  expect(await canOccupyPosition(page, northHiddenRunBackEntry)).toBe(false);
+  expect(
+    await getBlockingColliderNames(page, northHiddenRunBackEntry)
+  ).toContain('UpperStairNorthBannisterGuard');
 });
 
 test('upper landing edge nudges stay upstairs until the descent corridor is entered', async ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1945,16 +1945,18 @@ function initializeImmersiveScene(
       upperStairVoidMaxZ,
       upperLandingDoorwayClearanceZ
     );
+    const upperStairBackBannisterZ =
+      hiddenStairBlockerMaxZ - stairGuardThickness;
     // Invisible upper-floor guard rails flank the intentional descent corridor.
     // They are scoped to the actual upper-floor cutout instead of the full ramp
     // run so normal loft space beyond the landing remains occupiable.
     // UpperStairDeepVoidBlocker is intentionally absent: it covered the visible
-    // physical StaircaseLanding slab, while the remaining top-gap/hidden-run/void
-    // blockers still guard the true hidden stair run and no-floor void edges.
-    // The center blockers reject forced upper-floor placement over the hidden
-    // stair-top gap and hidden run while preserving the widened west egress,
-    // narrow stair-top handoff, a west-side bypass lane around the void, and the
-    // north doorway's padded passage into the loft. The top-gap west lip stays
+    // physical StaircaseLanding slab, while the remaining top-gap, bannister,
+    // and void guards still protect the hidden stair run and no-floor edges.
+    // The guards reject forced upper-floor side/back entry around the hidden
+    // stair run while preserving the widened west egress, narrow stair-top
+    // handoff, a west-side bypass lane around the void, and the north doorway's
+    // padded passage into the loft. The top-gap west lip stays
     // intentionally narrow so its collision edge protects the hidden center gap
     // without filling the west egress lane around the stairwell.
     const upperStairLandingEntryCorridor = {
@@ -2026,12 +2028,27 @@ function initializeImmersiveScene(
       },
       ...upperStairTopGapBlockers,
       {
-        name: 'UpperStairHiddenRunBlocker',
+        name: 'UpperStairWestBannisterGuard',
         bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.minX,
-          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-          minZ: Math.min(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
-          maxZ: Math.max(hiddenStairBlockerStartZ, hiddenStairBlockerMaxZ),
+          minX:
+            stairNavigationZones.explicitDescentCorridor.minX +
+            stairGuardThickness,
+          maxX:
+            stairNavigationZones.explicitDescentCorridor.minX +
+            stairGuardThickness * 1.5,
+          minZ: Math.min(hiddenStairBlockerStartZ, upperStairBackBannisterZ),
+          maxZ: Math.max(hiddenStairBlockerStartZ, upperStairBackBannisterZ),
+        },
+      },
+      {
+        name: 'UpperStairNorthBannisterGuard',
+        bounds: {
+          minX:
+            stairNavigationZones.explicitDescentCorridor.minX +
+            stairGuardThickness,
+          maxX: stairCenterX + stairHalfWidth + stairGuardThickness * 0.5,
+          minZ: upperStairBackBannisterZ - stairGuardThickness * 0.5,
+          maxZ: upperStairBackBannisterZ,
         },
       },
     ].forEach(({ name, bounds }) => pushNamedUpperFloorCollider(name, bounds));


### PR DESCRIPTION
### Motivation
- The existing broad upper-floor collider prevented legitimate descent from the upper landing by blocking the staircase mouth. 
- The intent is to preserve side/back safety around the hidden stair run while allowing normal landing→stair centerline descent. 

### Description
- Replaced the single broad `UpperStairHiddenRunBlocker` with two narrow rectangular upper-floor colliders named `UpperStairWestBannisterGuard` and `UpperStairNorthBannisterGuard` derived from stair geometry so the descent corridor remains open. 
- Bannister bounds are computed from `stairNavigationZones`, `stairGuardThickness`, and the hidden-run/top-gap geometry to produce the L-shaped coverage described in the task. 
- Added a helper `walkUpperLandingToGroundViaStairCenterline` and extended `playwright/immersive-stairs-roundtrip.spec.ts` to assert the removed blocker is absent, the two bannister colliders exist with approximate bounds, legitimate landing-mouth re-entry is unblocked, and side/back entries remain blocked. 
- Kept all existing stair/plan/navmesh/visibility systems and prior artifact removals intact (only the broad blocking collider shape was replaced). 

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully. 
- Ran unit tests with `npm run test:ci` (Vitest), which completed successfully (`1081 tests passed`). 
- Installed Playwright browsers and OS deps with `npx playwright install chromium` and `npx playwright install-deps chromium` and executed the focused E2E with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed (all Playwright cases in the spec passed). 
- Built and smoke-checked the site with `npm run build` and `npm run smoke`, and ran `npm run docs:check`; all checks passed (link checker reported external fetch warnings only). 
- Captured a debug screenshot via `npx playwright screenshot 'http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1' /tmp/upper-stair-bannister-guards.png` for visual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a5b23b02c832f99e8f22dfa710c1a)