### PR TITLE
Add visible collider debug IDs and labels

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -84,6 +84,7 @@ type DebugColliderBounds = {
 };
 
 type DebugColliderMetadata = {
+  id: string;
   floor: FloorId | 'all';
   category: string;
   name: string;
@@ -91,8 +92,15 @@ type DebugColliderMetadata = {
 };
 
 type DebugColliderApi = {
+  getState(): {
+    enabled: boolean;
+    visibleColliderCount: number;
+    visibleLabelCount: number;
+    totalColliderCount: number;
+  };
   setEnabled(enabled: boolean): void;
   getColliders(): DebugColliderMetadata[];
+  getColliderById(id: string): DebugColliderMetadata | undefined;
   getBlockingCollidersAt(target: {
     x: number;
     z: number;
@@ -755,6 +763,76 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
     sourceZone: 'outsideStairs',
     liftedZone: 'outsideStairs',
   });
+});
+
+test('debug collider IDs and labels are exposed through debug API', async ({
+  page,
+}) => {
+  await waitForImmersiveReady(page);
+
+  const disabledState = await page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    debugApi.setEnabled(false);
+    return debugApi.getState();
+  });
+  expect(disabledState.visibleColliderCount).toBe(0);
+  expect(disabledState.visibleLabelCount).toBe(0);
+
+  const { colliders, enabledState } = await page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    debugApi.setEnabled(true);
+    return {
+      colliders: debugApi.getColliders(),
+      enabledState: debugApi.getState(),
+    };
+  });
+  const ids = colliders.map((collider) => collider.id);
+
+  expect(colliders.length).toBeGreaterThan(0);
+  expect(new Set(ids).size).toBe(ids.length);
+  for (const id of ids) {
+    expect(id).toMatch(/^[0-9A-F]{4,6}$/);
+  }
+  expect(enabledState.visibleColliderCount).toBeGreaterThan(0);
+  expect(enabledState.visibleLabelCount).toBe(
+    enabledState.visibleColliderCount
+  );
+
+  const firstCollider = colliders[0];
+  const lookup = await page.evaluate((id) => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    return debugApi.getColliderById(id);
+  }, firstCollider.id.toLowerCase());
+  expect(lookup).toEqual(firstCollider);
+
+  const blockers = await page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    const [first] = debugApi.getColliders();
+    if (!first) {
+      throw new Error('No debug colliders registered');
+    }
+    return debugApi.getBlockingCollidersAt({
+      x: (first.bounds.minX + first.bounds.maxX) / 2,
+      z: (first.bounds.minZ + first.bounds.maxZ) / 2,
+      floorId: first.floor === 'all' ? undefined : first.floor,
+    });
+  });
+  expect(blockers.length).toBeGreaterThan(0);
+  expect(
+    blockers.every((collider) => /^[0-9A-F]{4,6}$/.test(collider.id))
+  ).toBe(true);
 });
 
 test('upper landing debug colliders exclude middle landing artifact', async ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -587,6 +587,8 @@ declare global {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
+        getColliderById(id: string): DebugColliderMetadata | undefined;
+        findColliderById(id: string): DebugColliderMetadata | undefined;
         getBlockingCollidersAt(target: {
           x: number;
           z: number;
@@ -4502,6 +4504,8 @@ function initializeImmersiveScene(
       setDebugCollidersEnabled(enabled);
     },
     getColliders: () => colliderVisualizer.getColliders(),
+    getColliderById: (id: string) => colliderVisualizer.getColliderById(id),
+    findColliderById: (id: string) => colliderVisualizer.getColliderById(id),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
   };
 

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -1,7 +1,11 @@
-import type { Material, Mesh } from 'three';
+import type { Material, Mesh, Sprite } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { createColliderVisualizer } from '../colliderVisualizer';
+import {
+  createColliderDebugId,
+  createColliderVisualizer,
+  type DebugColliderIdInput,
+} from '../colliderVisualizer';
 
 const collider = {
   minX: 1,
@@ -10,8 +14,52 @@ const collider = {
   maxZ: 5,
 };
 
+const debugColliderInput: DebugColliderIdInput = {
+  floor: 'ground',
+  category: 'walls',
+  name: 'GroundWallNorth',
+  bounds: collider,
+};
+
+const expectShortUppercaseHexId = (id: string) => {
+  expect(id).toMatch(/^[0-9A-F]{4,6}$/);
+};
+
+describe('createColliderDebugId', () => {
+  it('is deterministic for the same collider metadata', () => {
+    expect(createColliderDebugId(debugColliderInput)).toBe(
+      createColliderDebugId({ ...debugColliderInput, bounds: { ...collider } })
+    );
+  });
+
+  it('changes when meaningful collider metadata changes', () => {
+    expect(createColliderDebugId(debugColliderInput)).not.toBe(
+      createColliderDebugId({
+        ...debugColliderInput,
+        bounds: { ...collider, maxZ: collider.maxZ + 1 },
+      })
+    );
+  });
+
+  it('produces short uppercase hexadecimal IDs', () => {
+    expectShortUppercaseHexId(createColliderDebugId(debugColliderInput));
+  });
+
+  it('resolves reserved ID collisions deterministically', () => {
+    const firstId = createColliderDebugId(debugColliderInput);
+    const reservedIds = new Set([firstId]);
+    const secondId = createColliderDebugId(debugColliderInput, reservedIds);
+
+    expectShortUppercaseHexId(secondId);
+    expect(secondId).not.toBe(firstId);
+    expect(secondId).toBe(
+      createColliderDebugId(debugColliderInput, reservedIds)
+    );
+  });
+});
+
 describe('createColliderVisualizer', () => {
-  it('tracks total and active-floor visible collider counts', () => {
+  it('tracks total and active-floor visible collider and label counts', () => {
     const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
 
     visualizer.register([
@@ -38,6 +86,7 @@ describe('createColliderVisualizer', () => {
     expect(visualizer.getState()).toEqual({
       enabled: false,
       visibleColliderCount: 0,
+      visibleLabelCount: 0,
       totalColliderCount: 3,
     });
 
@@ -45,14 +94,16 @@ describe('createColliderVisualizer', () => {
     expect(visualizer.getState()).toEqual({
       enabled: true,
       visibleColliderCount: 2,
+      visibleLabelCount: 2,
       totalColliderCount: 3,
     });
 
     visualizer.setActiveFloor('upper');
     expect(visualizer.getState().visibleColliderCount).toBe(2);
+    expect(visualizer.getState().visibleLabelCount).toBe(2);
   });
 
-  it('returns redacted metadata copies and non-raycasting meshes', () => {
+  it('returns redacted metadata copies and non-raycasting debug objects', () => {
     const visualizer = createColliderVisualizer({
       activeFloorId: 'ground',
       enabled: true,
@@ -70,15 +121,55 @@ describe('createColliderVisualizer', () => {
     metadata[0].bounds.minX = 99;
 
     expect(visualizer.getColliders()[0]).toEqual({
+      id: metadata[0].id,
       floor: 'ground',
       category: 'static',
       name: 'static-0',
       bounds: collider,
     });
+    expectShortUppercaseHexId(metadata[0].id);
+    expect(visualizer.getColliderById(metadata[0].id)).toEqual(
+      visualizer.getColliders()[0]
+    );
+    expect(visualizer.getColliderById(metadata[0].id.toLowerCase())).toEqual(
+      visualizer.getColliders()[0]
+    );
+
     const mesh = visualizer.group.children[0] as Mesh;
+    const label = visualizer.group.children[1] as Sprite;
     const material = mesh.material as Material;
 
     expect(mesh.raycast({} as never, [] as never)).toBeUndefined();
+    expect(label.raycast({} as never, [] as never)).toBeUndefined();
+    expect(label.name).toBe(`DebugColliderLabel:${metadata[0].id}`);
     expect(material.depthTest).toBe(false);
+  });
+
+  it('creates unique IDs for duplicate collider registrations', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+
+    visualizer.register([debugColliderInput, debugColliderInput]);
+
+    const ids = visualizer.getColliders().map((entry) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('toggles collider labels with debug collider visibility', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    visualizer.register([debugColliderInput]);
+
+    const mesh = visualizer.group.children[0] as Mesh;
+    const label = visualizer.group.children[1] as Sprite;
+
+    expect(mesh.visible).toBe(false);
+    expect(label.visible).toBe(false);
+
+    visualizer.setEnabled(true);
+    expect(mesh.visible).toBe(true);
+    expect(label.visible).toBe(true);
+
+    visualizer.setEnabled(false);
+    expect(mesh.visible).toBe(false);
+    expect(label.visible).toBe(false);
   });
 });

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,8 +1,11 @@
 import {
   BoxGeometry,
+  CanvasTexture,
   Group,
   Mesh,
   MeshBasicMaterial,
+  Sprite,
+  SpriteMaterial,
   type ColorRepresentation,
   type Object3D,
 } from 'three';
@@ -13,13 +16,16 @@ import type { FloorId } from '../../systems/movement/stairs';
 export type DebugColliderFloor = FloorId | 'all';
 
 export interface DebugColliderMetadata {
+  id: string;
   floor: DebugColliderFloor;
   category: string;
   name: string;
   bounds: RectCollider;
 }
 
-export interface DebugColliderRegistration extends DebugColliderMetadata {
+export type DebugColliderIdInput = Omit<DebugColliderMetadata, 'id'>;
+
+export interface DebugColliderRegistration extends DebugColliderIdInput {
   elevation?: number;
   height?: number;
   color?: ColorRepresentation;
@@ -28,12 +34,14 @@ export interface DebugColliderRegistration extends DebugColliderMetadata {
 export interface DebugColliderVisualizerState {
   enabled: boolean;
   visibleColliderCount: number;
+  visibleLabelCount: number;
   totalColliderCount: number;
 }
 
 interface DebugColliderVisualEntry {
   metadata: DebugColliderMetadata;
   mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
+  label: Sprite;
 }
 
 export interface ColliderVisualizer {
@@ -43,17 +51,33 @@ export interface ColliderVisualizer {
   setActiveFloor(floorId: FloorId): void;
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
+  getColliderById(id: string): DebugColliderMetadata | undefined;
   dispose(): void;
 }
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
 const DEFAULT_COLOR = 0x66e6ff;
+const LABEL_WIDTH = 0.78;
+const LABEL_HEIGHT = 0.28;
+const LABEL_Y_OFFSET = 0.2;
+const ID_MIN_LENGTH = 4;
+const ID_MAX_LENGTH = 6;
+const ID_HASH_SEED = 0x811c9dc5;
+const ID_HASH_PRIME = 0x01000193;
 const FLOOR_COLORS: Record<DebugColliderFloor, number> = {
   ground: 0x2ee66b,
   upper: 0xf7c948,
   all: 0x66e6ff,
 };
+const LABEL_COLORS = [
+  '#66E6FF',
+  '#F7C948',
+  '#FF7AB6',
+  '#8BFF8F',
+  '#B692FF',
+  '#FF9F40',
+] as const;
 
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
   minX: bounds.minX,
@@ -67,6 +91,129 @@ const isVisibleOnFloor = (
   activeFloorId: FloorId
 ): boolean => colliderFloor === 'all' || colliderFloor === activeFloorId;
 
+const roundDebugCoordinate = (value: number): string => value.toFixed(3);
+
+const createColliderDebugSignature = (collider: DebugColliderIdInput): string =>
+  [
+    collider.floor,
+    collider.category,
+    collider.name,
+    roundDebugCoordinate(collider.bounds.minX),
+    roundDebugCoordinate(collider.bounds.maxX),
+    roundDebugCoordinate(collider.bounds.minZ),
+    roundDebugCoordinate(collider.bounds.maxZ),
+  ].join('|');
+
+const hashStringToHex = (input: string): string => {
+  let hash = ID_HASH_SEED;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, ID_HASH_PRIME) >>> 0;
+  }
+  return hash.toString(16).toUpperCase().padStart(8, '0');
+};
+
+export function createColliderDebugId(
+  collider: DebugColliderIdInput,
+  reservedIds: ReadonlySet<string> = new Set()
+): string {
+  const signature = createColliderDebugSignature(collider);
+
+  for (let length = ID_MIN_LENGTH; length <= ID_MAX_LENGTH; length += 1) {
+    const candidate = hashStringToHex(signature).slice(0, length);
+    if (!reservedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  for (let salt = 1; salt < 0xffff; salt += 1) {
+    const saltedHash = hashStringToHex(`${signature}|${salt}`);
+    for (let length = ID_MIN_LENGTH; length <= ID_MAX_LENGTH; length += 1) {
+      const candidate = saltedHash.slice(0, length);
+      if (!reservedIds.has(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  throw new Error('Unable to allocate a unique collider debug ID.');
+}
+
+const getLabelPaletteIndex = (id: string): number =>
+  parseInt(id.slice(-2), 16) % LABEL_COLORS.length;
+
+const createLabelCanvasTexture = (
+  id: string,
+  color: string
+): CanvasTexture | null => {
+  if (
+    typeof document === 'undefined' ||
+    (typeof navigator !== 'undefined' && navigator.userAgent.includes('jsdom'))
+  ) {
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 96;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return null;
+  }
+
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  context.fillStyle = 'rgba(7, 12, 20, 0.86)';
+  context.strokeStyle = color;
+  context.lineWidth = 6;
+  context.beginPath();
+  context.roundRect(8, 8, canvas.width - 16, canvas.height - 16, 18);
+  context.fill();
+  context.stroke();
+
+  context.font = '700 48px ui-monospace, SFMono-Regular, Consolas, monospace';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.lineWidth = 8;
+  context.strokeStyle = 'rgba(0, 0, 0, 0.92)';
+  context.strokeText(id, canvas.width / 2, canvas.height / 2 + 2);
+  context.fillStyle = color;
+  context.fillText(id, canvas.width / 2, canvas.height / 2 + 2);
+
+  const texture = new CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const createColliderLabel = (id: string, color: string): Sprite => {
+  const texture = createLabelCanvasTexture(id, color);
+  const material = new SpriteMaterial({
+    color: texture ? 0xffffff : color,
+    depthTest: false,
+    depthWrite: false,
+    transparent: true,
+    ...(texture ? { map: texture } : {}),
+  });
+  const label = new Sprite(material);
+  label.name = `DebugColliderLabel:${id}`;
+  label.renderOrder = 10_001;
+  label.scale.set(LABEL_WIDTH, LABEL_HEIGHT, 1);
+  label.userData.debugOnly = true;
+  label.userData.colliderDebugLabel = true;
+  label.userData.colliderDebugId = id;
+  label.raycast = () => undefined;
+  return label;
+};
+
+const cloneMetadata = (
+  metadata: DebugColliderMetadata
+): DebugColliderMetadata => ({
+  id: metadata.id,
+  floor: metadata.floor,
+  category: metadata.category,
+  name: metadata.name,
+  bounds: cloneBounds(metadata.bounds),
+});
+
 export function createColliderVisualizer(options: {
   activeFloorId: FloorId;
   enabled?: boolean;
@@ -77,14 +224,17 @@ export function createColliderVisualizer(options: {
   group.userData.debugOnly = true;
 
   const entries: DebugColliderVisualEntry[] = [];
+  const reservedIds = new Set<string>();
   let enabled = options.enabled ?? false;
   let activeFloorId = options.activeFloorId;
 
   const applyVisibility = () => {
     group.visible = enabled;
     for (const entry of entries) {
-      entry.mesh.visible =
+      const visible =
         enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
+      entry.mesh.visible = visible;
+      entry.label.visible = visible;
     }
   };
 
@@ -99,6 +249,8 @@ export function createColliderVisualizer(options: {
         MIN_DIMENSION
       );
       const height = collider.height ?? DEFAULT_HEIGHT;
+      const id = createColliderDebugId(collider, reservedIds);
+      reservedIds.add(id);
       const geometry = new BoxGeometry(width, height, depth);
       const material = new MeshBasicMaterial({
         color: collider.color ?? FLOOR_COLORS[collider.floor] ?? DEFAULT_COLOR,
@@ -109,7 +261,7 @@ export function createColliderVisualizer(options: {
         wireframe: true,
       });
       const mesh = new Mesh(geometry, material);
-      mesh.name = `DebugCollider:${collider.floor}:${collider.category}:${collider.name}`;
+      mesh.name = `DebugCollider:${id}:${collider.floor}:${collider.category}:${collider.name}`;
       mesh.position.set(
         (collider.bounds.minX + collider.bounds.maxX) / 2,
         (collider.elevation ?? 0) + height / 2,
@@ -118,20 +270,35 @@ export function createColliderVisualizer(options: {
       mesh.renderOrder = 10_000;
       mesh.userData.debugOnly = true;
       mesh.userData.colliderDebug = {
+        id,
         floor: collider.floor,
         category: collider.category,
         name: collider.name,
       };
       mesh.raycast = () => undefined;
+
+      const label = createColliderLabel(
+        id,
+        LABEL_COLORS[getLabelPaletteIndex(id)]
+      );
+      label.position.set(
+        mesh.position.x,
+        (collider.elevation ?? 0) + height + LABEL_Y_OFFSET,
+        mesh.position.z
+      );
+
       group.add(mesh);
+      group.add(label);
       entries.push({
         metadata: {
+          id,
           floor: collider.floor,
           category: collider.category,
           name: collider.name,
           bounds: cloneBounds(collider.bounds),
         },
         mesh,
+        label,
       });
     }
     applyVisibility();
@@ -156,27 +323,35 @@ export function createColliderVisualizer(options: {
       applyVisibility();
     },
     getState() {
+      const visibleColliderCount = getVisibleColliderCount();
       return {
         enabled,
-        visibleColliderCount: getVisibleColliderCount(),
+        visibleColliderCount,
+        visibleLabelCount: visibleColliderCount,
         totalColliderCount: entries.length,
       };
     },
     getColliders() {
-      return entries.map((entry) => ({
-        floor: entry.metadata.floor,
-        category: entry.metadata.category,
-        name: entry.metadata.name,
-        bounds: cloneBounds(entry.metadata.bounds),
-      }));
+      return entries.map((entry) => cloneMetadata(entry.metadata));
+    },
+    getColliderById(id: string) {
+      const normalizedId = id.toUpperCase();
+      const entry = entries.find(
+        (candidate) => candidate.metadata.id === normalizedId
+      );
+      return entry ? cloneMetadata(entry.metadata) : undefined;
     },
     dispose() {
       for (const entry of entries) {
         group.remove(entry.mesh);
+        group.remove(entry.label);
         entry.mesh.geometry.dispose();
         entry.mesh.material.dispose();
+        entry.label.material.map?.dispose();
+        entry.label.material.dispose();
       }
       entries.length = 0;
+      reservedIds.clear();
       const parent = group.parent as Object3D | null;
       parent?.remove(group);
     },


### PR DESCRIPTION
### Motivation
- Make overlapping debug collider wireframes identifiable in screenshots by adding short, stable hex IDs shown in-scene and mappable back to metadata via the debug API.
- Keep all collision/movement/floor logic unchanged and only augment debug visualization and API surface for easier manual cleanup and testability.

### Description
- Add deterministic ID generation helper `createColliderDebugId(...)` (4–6 uppercase hex chars) based on floor/category/name/rounded bounds with deterministic collision handling; exported and unit-tested in `src/scene/debug/colliderVisualizer.ts`.
- Render camera-facing, non-interactive sprite labels for each debug collider using a canvas-backed `CanvasTexture` (no external fonts) with a small cycling palette and dark backing; labels follow the existing debug toggle and active-floor visibility rules.
- Extend `DebugColliderMetadata` to include `id` and expose `getColliderById`/`findColliderById` on the runtime API (`window.portfolio.debugColliders`), and add `visibleLabelCount` to the visualizer state; no Three.js objects are leaked through the API.
- Add unit tests (`src/scene/debug/__tests__/colliderVisualizer.test.ts`) covering ID determinism, uppercase hex format, collision handling for reserved IDs, unique IDs for duplicate registrations, label visibility toggling, and `getColliderById`; add a Playwright test that enables debug colliders and asserts IDs are present, unique, lookups by lowercase ID succeed, and blockers return IDs (`playwright/immersive-stairs-roundtrip.spec.ts`).

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed.
- `npm run test:ci` (Vitest) — passed; the new collider visualizer unit tests passed (8 tests in file).
- `npm run docs:check` — passed (link checker reported external fetch warnings but completed successfully).
- `npm run build` and `npm run smoke` — passed.
- Playwright: initial run required browser binaries; after running `npx playwright install chromium` and `npx playwright install-deps chromium`, `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` passed (9 tests).
- Manual run: launched preview with `/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1`, captured a screenshot (`/tmp/collider-debug-ids.png`), and `window.portfolio.debugColliders.getState()` reported matching `visibleColliderCount` and `visibleLabelCount` (example: 59).
- `npm run typecheck` — not run to successful completion for the whole repo in this change set (the repository has unrelated TypeScript errors outside the modified debug visualizer files); the changes to the debug visualizer were adjusted to avoid type regressions in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9c7a8de0832fac12118e212fc392)