### PR TITLE
🔎 : – Add collider debug IDs

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -84,6 +84,7 @@ type DebugColliderBounds = {
 };
 
 type DebugColliderMetadata = {
+  id: string;
   floor: FloorId | 'all';
   category: string;
   name: string;
@@ -93,6 +94,7 @@ type DebugColliderMetadata = {
 type DebugColliderApi = {
   setEnabled(enabled: boolean): void;
   getColliders(): DebugColliderMetadata[];
+  getColliderById(id: string): DebugColliderMetadata | undefined;
   getBlockingCollidersAt(target: {
     x: number;
     z: number;
@@ -776,6 +778,21 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
 
   await walkStairCenterlineToUpperLanding(page);
   const debugColliders = await getDebugColliders(page);
+  const debugColliderIds = debugColliders.map((collider) => collider.id);
+  expect(debugColliderIds.length).toBeGreaterThan(0);
+  expect(new Set(debugColliderIds).size).toBe(debugColliderIds.length);
+  for (const debugColliderId of debugColliderIds) {
+    expect(debugColliderId).toMatch(/^[0-9A-F]{4,6}$/);
+  }
+  const firstColliderById = await page.evaluate((id) => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    return debugApi.getColliderById(id);
+  }, debugColliderIds[0]);
+  expect(firstColliderById).toEqual(debugColliders[0]);
+
   const debugColliderNames = debugColliders.map((collider) => collider.name);
   for (const removedBroadBlocker of removedBroadStairBlockers) {
     expect(debugColliderNames).not.toContain(removedBroadBlocker);
@@ -802,6 +819,22 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   if (!westBannister || !northBannister || !hiddenRunGuard) {
     throw new Error('Missing upper stair guard debug collider');
   }
+
+  const westBannisterBlockers = await page.evaluate(
+    (target) => {
+      const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+      if (!debugApi) {
+        throw new Error('Debug colliders API unavailable');
+      }
+      return debugApi.getBlockingCollidersAt(target);
+    },
+    {
+      x: (westBannister.bounds.minX + westBannister.bounds.maxX) / 2,
+      z: (westBannister.bounds.minZ + westBannister.bounds.maxZ) / 2,
+      floorId: 'upper' as const,
+    }
+  );
+  expect(westBannisterBlockers).toContainEqual(westBannister);
 
   const northBannisterCenterZ =
     (northBannister.bounds.minZ + northBannister.bounds.maxZ) / 2;

--- a/src/main.ts
+++ b/src/main.ts
@@ -587,6 +587,7 @@ declare global {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
+        getColliderById(id: string): DebugColliderMetadata | undefined;
         getBlockingCollidersAt(target: {
           x: number;
           z: number;
@@ -4502,6 +4503,7 @@ function initializeImmersiveScene(
       setDebugCollidersEnabled(enabled);
     },
     getColliders: () => colliderVisualizer.getColliders(),
+    getColliderById: (id: string) => colliderVisualizer.getColliderById(id),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
   };
 

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -1,7 +1,10 @@
 import type { Material, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { createColliderVisualizer } from '../colliderVisualizer';
+import {
+  createColliderDebugId,
+  createColliderVisualizer,
+} from '../colliderVisualizer';
 
 const collider = {
   minX: 1,
@@ -9,6 +12,47 @@ const collider = {
   minZ: 2,
   maxZ: 5,
 };
+
+const metadata = {
+  floor: 'ground' as const,
+  category: 'walls',
+  name: 'ground-0',
+  bounds: collider,
+};
+
+describe('createColliderDebugId', () => {
+  it('is deterministic for the same collider metadata', () => {
+    expect(createColliderDebugId(metadata)).toBe(
+      createColliderDebugId(metadata)
+    );
+  });
+
+  it('changes when meaningful metadata changes', () => {
+    expect(createColliderDebugId(metadata)).not.toBe(
+      createColliderDebugId({
+        ...metadata,
+        bounds: { ...metadata.bounds, maxX: metadata.bounds.maxX + 1 },
+      })
+    );
+  });
+
+  it('produces short uppercase hexadecimal labels', () => {
+    expect(createColliderDebugId(metadata)).toMatch(/^[0-9A-F]{4,6}$/);
+  });
+
+  it('resolves ID collisions deterministically by extending the hash', () => {
+    const baseId = createColliderDebugId(metadata);
+    const resolvedId = createColliderDebugId(metadata, {
+      usedIds: new Set([baseId]),
+    });
+
+    expect(resolvedId).toMatch(/^[0-9A-F]{4,6}$/);
+    expect(resolvedId).not.toBe(baseId);
+    expect(resolvedId).toBe(
+      createColliderDebugId(metadata, { usedIds: new Set([baseId]) })
+    );
+  });
+});
 
 describe('createColliderVisualizer', () => {
   it('tracks total and active-floor visible collider counts', () => {
@@ -67,18 +111,56 @@ describe('createColliderVisualizer', () => {
     ]);
 
     const metadata = visualizer.getColliders();
+    const id = metadata[0].id;
     metadata[0].bounds.minX = 99;
 
     expect(visualizer.getColliders()[0]).toEqual({
+      id,
       floor: 'ground',
       category: 'static',
       name: 'static-0',
       bounds: collider,
     });
+    expect(visualizer.getColliderById(id)).toEqual(
+      visualizer.getColliders()[0]
+    );
     const mesh = visualizer.group.children[0] as Mesh;
     const material = mesh.material as Material;
 
     expect(mesh.raycast({} as never, [] as never)).toBeUndefined();
     expect(material.depthTest).toBe(false);
+  });
+
+  it('creates floor-aware non-raycasting labels for registered colliders', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'ground-0',
+        bounds: collider,
+      },
+      {
+        floor: 'upper',
+        category: 'walls',
+        name: 'upper-0',
+        bounds: { minX: -2, maxX: -1, minZ: -3, maxZ: -2 },
+      },
+    ]);
+
+    const labels = visualizer.group.children.filter((child) =>
+      child.name.startsWith('DebugColliderLabel:')
+    );
+    expect(labels).toHaveLength(2);
+    expect(labels[0].visible).toBe(false);
+
+    visualizer.setEnabled(true);
+    expect(labels[0].visible).toBe(true);
+    expect(labels[1].visible).toBe(false);
+
+    visualizer.setActiveFloor('upper');
+    expect(labels[0].visible).toBe(false);
+    expect(labels[1].visible).toBe(true);
+    expect(labels[1].raycast({} as never, [] as never)).toBeUndefined();
   });
 });

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,8 +1,12 @@
 import {
   BoxGeometry,
+  CanvasTexture,
   Group,
+  LinearFilter,
   Mesh,
   MeshBasicMaterial,
+  Sprite,
+  SpriteMaterial,
   type ColorRepresentation,
   type Object3D,
 } from 'three';
@@ -12,14 +16,18 @@ import type { FloorId } from '../../systems/movement/stairs';
 
 export type DebugColliderFloor = FloorId | 'all';
 
-export interface DebugColliderMetadata {
+export interface DebugColliderBaseMetadata {
   floor: DebugColliderFloor;
   category: string;
   name: string;
   bounds: RectCollider;
 }
 
-export interface DebugColliderRegistration extends DebugColliderMetadata {
+export interface DebugColliderMetadata extends DebugColliderBaseMetadata {
+  id: string;
+}
+
+export interface DebugColliderRegistration extends DebugColliderBaseMetadata {
   elevation?: number;
   height?: number;
   color?: ColorRepresentation;
@@ -34,6 +42,7 @@ export interface DebugColliderVisualizerState {
 interface DebugColliderVisualEntry {
   metadata: DebugColliderMetadata;
   mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
+  label: Sprite<SpriteMaterial>;
 }
 
 export interface ColliderVisualizer {
@@ -43,12 +52,34 @@ export interface ColliderVisualizer {
   setActiveFloor(floorId: FloorId): void;
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
+  getColliderById(id: string): DebugColliderMetadata | undefined;
   dispose(): void;
+}
+
+interface CreateColliderDebugIdOptions {
+  usedIds?: ReadonlySet<string>;
+  minLength?: number;
+  maxLength?: number;
 }
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
 const DEFAULT_COLOR = 0x66e6ff;
+const DEBUG_ID_MIN_LENGTH = 4;
+const DEBUG_ID_MAX_LENGTH = 6;
+const LABEL_WIDTH = 0.62;
+const LABEL_HEIGHT = 0.28;
+const LABEL_Y_OFFSET = 0.16;
+const LABEL_TEXTURE_WIDTH = 256;
+const LABEL_TEXTURE_HEIGHT = 128;
+const LABEL_COLORS = [
+  '#66E6FF',
+  '#F7C948',
+  '#FF7AB6',
+  '#8BFF8B',
+  '#C9A7FF',
+  '#FF9F43',
+] as const;
 const FLOOR_COLORS: Record<DebugColliderFloor, number> = {
   ground: 0x2ee66b,
   upper: 0xf7c948,
@@ -62,10 +93,147 @@ const cloneBounds = (bounds: RectCollider): RectCollider => ({
   maxZ: bounds.maxZ,
 });
 
+const cloneMetadata = (
+  metadata: DebugColliderMetadata
+): DebugColliderMetadata => ({
+  id: metadata.id,
+  floor: metadata.floor,
+  category: metadata.category,
+  name: metadata.name,
+  bounds: cloneBounds(metadata.bounds),
+});
+
 const isVisibleOnFloor = (
   colliderFloor: DebugColliderFloor,
   activeFloorId: FloorId
 ): boolean => colliderFloor === 'all' || colliderFloor === activeFloorId;
+
+const formatBound = (value: number): string => {
+  const rounded = Math.round(value * 1000) / 1000;
+  return Object.is(rounded, -0) ? '0' : rounded.toFixed(3);
+};
+
+const getColliderDebugIdSource = (metadata: DebugColliderBaseMetadata) =>
+  [
+    metadata.floor,
+    metadata.category,
+    metadata.name,
+    formatBound(metadata.bounds.minX),
+    formatBound(metadata.bounds.maxX),
+    formatBound(metadata.bounds.minZ),
+    formatBound(metadata.bounds.maxZ),
+  ].join('|');
+
+const hashStringToHex = (value: string): string => {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).toUpperCase().padStart(8, '0');
+};
+
+export function createColliderDebugId(
+  metadata: DebugColliderBaseMetadata,
+  options: CreateColliderDebugIdOptions = {}
+): string {
+  const usedIds = options.usedIds ?? new Set<string>();
+  const minLength = options.minLength ?? DEBUG_ID_MIN_LENGTH;
+  const maxLength = options.maxLength ?? DEBUG_ID_MAX_LENGTH;
+  const hash = hashStringToHex(getColliderDebugIdSource(metadata));
+
+  for (let length = minLength; length <= maxLength; length += 1) {
+    const candidate = hash.slice(0, length);
+    if (!usedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  const prefix = hash.slice(0, Math.max(minLength - 1, maxLength - 1));
+  for (let suffix = 0; suffix <= 0xf; suffix += 1) {
+    const candidate = `${prefix}${suffix.toString(16).toUpperCase()}`.slice(
+      0,
+      maxLength
+    );
+    if (!usedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return hash;
+}
+
+const getLabelColor = (id: string): string => {
+  const numericId = Number.parseInt(id, 16);
+  const paletteIndex = Number.isFinite(numericId)
+    ? numericId % LABEL_COLORS.length
+    : 0;
+  return LABEL_COLORS[paletteIndex];
+};
+
+const createLabelTexture = (
+  id: string,
+  color: string
+): CanvasTexture | null => {
+  if (
+    typeof document === 'undefined' ||
+    (typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent))
+  ) {
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = LABEL_TEXTURE_WIDTH;
+  canvas.height = LABEL_TEXTURE_HEIGHT;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return null;
+  }
+
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  context.fillStyle = 'rgba(3, 8, 18, 0.78)';
+  context.strokeStyle = color;
+  context.lineWidth = 5;
+  context.beginPath();
+  context.roundRect(12, 20, canvas.width - 24, canvas.height - 40, 18);
+  context.fill();
+  context.stroke();
+  context.font = '700 56px monospace';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.lineWidth = 8;
+  context.strokeStyle = 'rgba(0, 0, 0, 0.88)';
+  context.strokeText(id, canvas.width / 2, canvas.height / 2 + 2);
+  context.fillStyle = color;
+  context.fillText(id, canvas.width / 2, canvas.height / 2 + 2);
+
+  const texture = new CanvasTexture(canvas);
+  texture.minFilter = LinearFilter;
+  texture.magFilter = LinearFilter;
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const createColliderLabel = (id: string): Sprite<SpriteMaterial> => {
+  const color = getLabelColor(id);
+  const texture = createLabelTexture(id, color);
+  const material = new SpriteMaterial({
+    color: texture ? 0xffffff : color,
+    depthTest: false,
+    depthWrite: false,
+    ...(texture ? { map: texture } : {}),
+    transparent: true,
+  });
+  const label = new Sprite(material);
+  label.name = `DebugColliderLabel:${id}`;
+  label.scale.set(LABEL_WIDTH, LABEL_HEIGHT, 1);
+  label.renderOrder = 10_001;
+  label.userData.debugOnly = true;
+  label.userData.colliderDebugLabel = true;
+  label.userData.colliderDebugId = id;
+  label.raycast = () => undefined;
+  return label;
+};
 
 export function createColliderVisualizer(options: {
   activeFloorId: FloorId;
@@ -77,19 +245,24 @@ export function createColliderVisualizer(options: {
   group.userData.debugOnly = true;
 
   const entries: DebugColliderVisualEntry[] = [];
+  const usedColliderIds = new Set<string>();
   let enabled = options.enabled ?? false;
   let activeFloorId = options.activeFloorId;
 
   const applyVisibility = () => {
     group.visible = enabled;
     for (const entry of entries) {
-      entry.mesh.visible =
+      const visible =
         enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
+      entry.mesh.visible = visible;
+      entry.label.visible = visible;
     }
   };
 
   const register = (colliders: readonly DebugColliderRegistration[]) => {
     for (const collider of colliders) {
+      const id = createColliderDebugId(collider, { usedIds: usedColliderIds });
+      usedColliderIds.add(id);
       const width = Math.max(
         collider.bounds.maxX - collider.bounds.minX,
         MIN_DIMENSION
@@ -109,29 +282,35 @@ export function createColliderVisualizer(options: {
         wireframe: true,
       });
       const mesh = new Mesh(geometry, material);
-      mesh.name = `DebugCollider:${collider.floor}:${collider.category}:${collider.name}`;
-      mesh.position.set(
-        (collider.bounds.minX + collider.bounds.maxX) / 2,
-        (collider.elevation ?? 0) + height / 2,
-        (collider.bounds.minZ + collider.bounds.maxZ) / 2
-      );
+      mesh.name = `DebugCollider:${id}:${collider.floor}:${collider.category}:${collider.name}`;
+      const centerX = (collider.bounds.minX + collider.bounds.maxX) / 2;
+      const centerZ = (collider.bounds.minZ + collider.bounds.maxZ) / 2;
+      const baseY = collider.elevation ?? 0;
+      mesh.position.set(centerX, baseY + height / 2, centerZ);
       mesh.renderOrder = 10_000;
       mesh.userData.debugOnly = true;
       mesh.userData.colliderDebug = {
+        id,
         floor: collider.floor,
         category: collider.category,
         name: collider.name,
       };
       mesh.raycast = () => undefined;
-      group.add(mesh);
+
+      const label = createColliderLabel(id);
+      label.position.set(centerX, baseY + height + LABEL_Y_OFFSET, centerZ);
+      label.userData.colliderDebug = mesh.userData.colliderDebug;
+      group.add(mesh, label);
       entries.push({
         metadata: {
+          id,
           floor: collider.floor,
           category: collider.category,
           name: collider.name,
           bounds: cloneBounds(collider.bounds),
         },
         mesh,
+        label,
       });
     }
     applyVisibility();
@@ -163,20 +342,25 @@ export function createColliderVisualizer(options: {
       };
     },
     getColliders() {
-      return entries.map((entry) => ({
-        floor: entry.metadata.floor,
-        category: entry.metadata.category,
-        name: entry.metadata.name,
-        bounds: cloneBounds(entry.metadata.bounds),
-      }));
+      return entries.map((entry) => cloneMetadata(entry.metadata));
+    },
+    getColliderById(id: string) {
+      const normalizedId = id.toUpperCase();
+      const entry = entries.find(
+        (candidate) => candidate.metadata.id === normalizedId
+      );
+      return entry ? cloneMetadata(entry.metadata) : undefined;
     },
     dispose() {
       for (const entry of entries) {
-        group.remove(entry.mesh);
+        group.remove(entry.mesh, entry.label);
         entry.mesh.geometry.dispose();
         entry.mesh.material.dispose();
+        entry.label.material.map?.dispose();
+        entry.label.material.dispose();
       }
       entries.length = 0;
+      usedColliderIds.clear();
       const parent = group.parent as Object3D | null;
       parent?.remove(group);
     },


### PR DESCRIPTION
### Motivation
- Collider wireframe overlays are useful but overlapping yellow boxes make it hard to identify exact colliders from screenshots and DevTools, so a stable short ID and in-world label are needed to map visual artifacts back to collider metadata.
- IDs must be deterministic across reloads and available through the existing debug API so debugging and cleanup workflows can reference colliders precisely.

### Description
- Add `createColliderDebugId(...)` which deterministically derives a short uppercase hex ID (4–6 chars) from stable collider metadata (floor, category, name, rounded bounds) with deterministic collision resolution; exported and unit-tested.
- Render non-interactive in-world labels using Three.js `Sprite` + canvas-generated `CanvasTexture` when debug colliders are enabled, with a deterministic small palette, subtle dark backing, camera-facing sprite placement slightly above collider centers, and no participation in raycasting or collisions.
- Enrich debug metadata with `id` and add `getColliderById(id)` to the `ColliderVisualizer` and `window.portfolio.debugColliders` API while preserving `getColliders()` and `getBlockingCollidersAt(...)` semantics.
- Add and update tests: unit tests for `createColliderDebugId` and visualizer behavior (metadata redaction, floor-aware labels), and Playwright spec updates to assert non-empty unique IDs and `getColliderById` mapping.

### Testing
- Ran formatting with `npm run format:write` and lint with `npm run lint`, both completed successfully.
- Ran unit suite with `npm run test:ci` (Vitest) and observed all suites pass (local run: 1086 tests passed in the workspace run); targeted visualizer tests also passed after a small jsdom-aware adjustment to skip canvas texture creation under jsdom.
- Ran `npm run docs:check` which passed; link checker emitted existing external fetch warnings but no failures.
- Built and validated the production bundle with `npm run smoke` / `npm run build`, both succeeded and the dist artifacts were produced.
- Executed Playwright coverage for the updated stairs spec with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`; initial test run required downloading Playwright browsers and host deps, `npx playwright install chromium-headless-shell` and `npx playwright install-deps` were run, after which the spec passed (8 tests) in this environment.
- No changes were made to runtime collision, movement, navmesh, floor-plan geometry, or POI behavior; the change is debug-visualization-only and unit/End-to-end tests verify metadata mapping and visibility toggling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9c608e7c832fadb533e7cc66e876)