### PR TITLE
Add visible collider debug IDs

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -84,6 +84,7 @@ type DebugColliderBounds = {
 };
 
 type DebugColliderMetadata = {
+  id: string;
   floor: FloorId | 'all';
   category: string;
   name: string;
@@ -91,8 +92,17 @@ type DebugColliderMetadata = {
 };
 
 type DebugColliderApi = {
+  getState(): {
+    enabled: boolean;
+    visibleColliderCount: number;
+    totalColliderCount: number;
+    visibleLabelCount: number;
+    totalLabelCount: number;
+  };
   setEnabled(enabled: boolean): void;
   getColliders(): DebugColliderMetadata[];
+  getColliderById(id: string): DebugColliderMetadata | undefined;
+  findColliderById(id: string): DebugColliderMetadata | undefined;
   getBlockingCollidersAt(target: {
     x: number;
     z: number;
@@ -302,6 +312,17 @@ async function getDebugColliders(page: Page) {
     }
     debugApi.setEnabled(true);
     return debugApi.getColliders();
+  });
+}
+
+async function getDebugColliderState(page: Page) {
+  return page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+
+    return debugApi.getState();
   });
 }
 
@@ -757,6 +778,78 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
   });
 });
 
+test('debug collider API exposes unique IDs and label visibility state', async ({
+  page,
+}) => {
+  await waitForImmersiveReady(page);
+
+  const debugColliders = await getDebugColliders(page);
+  const debugColliderIds = debugColliders.map((collider) => collider.id);
+  expect(debugColliderIds.length).toBeGreaterThan(0);
+  expect(new Set(debugColliderIds).size).toBe(debugColliderIds.length);
+  for (const id of debugColliderIds) {
+    expect(id).toMatch(/^[0-9A-F]{4,8}$/);
+  }
+
+  const lookup = await page.evaluate((id) => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug collider API unavailable');
+    }
+    return debugApi.getColliderById(id);
+  }, debugColliderIds[0]);
+  expect(lookup?.id).toBe(debugColliderIds[0]);
+
+  const sampleCollider = debugColliders.find(
+    (collider) => collider.floor === 'ground'
+  );
+  expect(sampleCollider).toBeDefined();
+  if (!sampleCollider) {
+    throw new Error('Missing ground debug collider sample');
+  }
+  const blockers = await page.evaluate((collider) => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug collider API unavailable');
+    }
+    return debugApi.getBlockingCollidersAt({
+      x: (collider.bounds.minX + collider.bounds.maxX) / 2,
+      z: (collider.bounds.minZ + collider.bounds.maxZ) / 2,
+      floorId: collider.floor === 'all' ? undefined : collider.floor,
+    });
+  }, sampleCollider);
+  expect(blockers.map((collider) => collider.id)).toContain(sampleCollider.id);
+  for (const blocker of blockers) {
+    expect(blocker.id).toMatch(/^[0-9A-F]{4,8}$/);
+  }
+
+  await page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug collider API unavailable');
+    }
+    debugApi.setEnabled(true);
+  });
+  const enabledState = await getDebugColliderState(page);
+  expect(enabledState.enabled).toBe(true);
+  expect(enabledState.visibleColliderCount).toBeGreaterThan(0);
+  expect(enabledState.visibleLabelCount).toBe(
+    enabledState.visibleColliderCount
+  );
+
+  await page.evaluate(() => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug collider API unavailable');
+    }
+    debugApi.setEnabled(false);
+  });
+  const disabledState = await getDebugColliderState(page);
+  expect(disabledState.enabled).toBe(false);
+  expect(disabledState.visibleColliderCount).toBe(0);
+  expect(disabledState.visibleLabelCount).toBe(0);
+});
+
 test('upper landing debug colliders exclude middle landing artifact', async ({
   page,
 }) => {
@@ -777,6 +870,11 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   await walkStairCenterlineToUpperLanding(page);
   const debugColliders = await getDebugColliders(page);
   const debugColliderNames = debugColliders.map((collider) => collider.name);
+  const debugColliderIds = debugColliders.map((collider) => collider.id);
+  expect(new Set(debugColliderIds).size).toBe(debugColliderIds.length);
+  for (const id of debugColliderIds) {
+    expect(id).toMatch(/^[0-9A-F]{4,8}$/);
+  }
   for (const removedBroadBlocker of removedBroadStairBlockers) {
     expect(debugColliderNames).not.toContain(removedBroadBlocker);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -587,6 +587,8 @@ declare global {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
+        getColliderById(id: string): DebugColliderMetadata | undefined;
+        findColliderById(id: string): DebugColliderMetadata | undefined;
         getBlockingCollidersAt(target: {
           x: number;
           z: number;
@@ -4502,6 +4504,8 @@ function initializeImmersiveScene(
       setDebugCollidersEnabled(enabled);
     },
     getColliders: () => colliderVisualizer.getColliders(),
+    getColliderById: (id: string) => colliderVisualizer.getColliderById(id),
+    findColliderById: (id: string) => colliderVisualizer.getColliderById(id),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
   };
 

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -1,7 +1,11 @@
 import type { Material, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { createColliderVisualizer } from '../colliderVisualizer';
+import {
+  createColliderDebugId,
+  createColliderVisualizer,
+  type DebugColliderIdMetadata,
+} from '../colliderVisualizer';
 
 const collider = {
   minX: 1,
@@ -9,6 +13,66 @@ const collider = {
   minZ: 2,
   maxZ: 5,
 };
+
+const debugMetadata: DebugColliderIdMetadata = {
+  floor: 'ground',
+  category: 'walls',
+  name: 'GroundWallWest',
+  bounds: collider,
+};
+
+const expectHexId = (id: string) => {
+  expect(id).toMatch(/^[0-9A-F]{4,8}$/);
+};
+
+describe('createColliderDebugId', () => {
+  it('is deterministic for the same stable collider metadata', () => {
+    const first = createColliderDebugId(debugMetadata);
+    const second = createColliderDebugId({
+      ...debugMetadata,
+      bounds: { ...collider },
+    });
+
+    expect(second).toBe(first);
+    expectHexId(first);
+  });
+
+  it('changes when meaningful metadata changes', () => {
+    const first = createColliderDebugId(debugMetadata);
+    const renamed = createColliderDebugId({
+      ...debugMetadata,
+      name: 'GroundWallEast',
+    });
+    const moved = createColliderDebugId({
+      ...debugMetadata,
+      bounds: { ...collider, maxZ: collider.maxZ + 0.25 },
+    });
+
+    expect(renamed).not.toBe(first);
+    expect(moved).not.toBe(first);
+  });
+
+  it('produces uppercase hex IDs', () => {
+    expect(createColliderDebugId(debugMetadata)).toMatch(/^[0-9A-F]+$/);
+  });
+
+  it('resolves used-ID collisions deterministically by extending the hash', () => {
+    const first = createColliderDebugId(debugMetadata);
+    const second = createColliderDebugId(debugMetadata, new Set([first]));
+    const third = createColliderDebugId(
+      debugMetadata,
+      new Set([first, second])
+    );
+
+    expect(second).toHaveLength(first.length + 1);
+    expect(third).toHaveLength(second.length + 1);
+    expect(second.startsWith(first)).toBe(true);
+    expect(third.startsWith(second)).toBe(true);
+    expect(new Set([first, second, third]).size).toBe(3);
+    expectHexId(second);
+    expectHexId(third);
+  });
+});
 
 describe('createColliderVisualizer', () => {
   it('tracks total and active-floor visible collider counts', () => {
@@ -39,6 +103,8 @@ describe('createColliderVisualizer', () => {
       enabled: false,
       visibleColliderCount: 0,
       totalColliderCount: 3,
+      visibleLabelCount: 0,
+      totalLabelCount: 0,
     });
 
     visualizer.setEnabled(true);
@@ -46,6 +112,8 @@ describe('createColliderVisualizer', () => {
       enabled: true,
       visibleColliderCount: 2,
       totalColliderCount: 3,
+      visibleLabelCount: 0,
+      totalLabelCount: 0,
     });
 
     visualizer.setActiveFloor('upper');
@@ -66,19 +134,49 @@ describe('createColliderVisualizer', () => {
       },
     ]);
 
-    const metadata = visualizer.getColliders();
-    metadata[0].bounds.minX = 99;
+    const [metadata] = visualizer.getColliders();
+    metadata.bounds.minX = 99;
 
-    expect(visualizer.getColliders()[0]).toEqual({
+    const [colliderCopy] = visualizer.getColliders();
+    expect(colliderCopy).toEqual({
+      id: metadata.id,
       floor: 'ground',
       category: 'static',
       name: 'static-0',
       bounds: collider,
     });
+    expectHexId(colliderCopy.id);
+    expect(visualizer.getColliderById(colliderCopy.id)).toEqual(colliderCopy);
+    expect(visualizer.getColliderById(colliderCopy.id.toLowerCase())).toEqual(
+      colliderCopy
+    );
     const mesh = visualizer.group.children[0] as Mesh;
     const material = mesh.material as Material;
 
     expect(mesh.raycast({} as never, [] as never)).toBeUndefined();
     expect(material.depthTest).toBe(false);
+  });
+
+  it('assigns unique IDs to duplicate registered colliders', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'duplicate-wall',
+        bounds: collider,
+      },
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'duplicate-wall',
+        bounds: collider,
+      },
+    ]);
+
+    const ids = visualizer.getColliders().map(({ id }) => id);
+    expect(new Set(ids).size).toBe(ids.length);
+    ids.forEach(expectHexId);
   });
 });

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,8 +1,12 @@
 import {
   BoxGeometry,
+  CanvasTexture,
   Group,
+  LinearFilter,
   Mesh,
   MeshBasicMaterial,
+  Sprite,
+  SpriteMaterial,
   type ColorRepresentation,
   type Object3D,
 } from 'three';
@@ -13,13 +17,16 @@ import type { FloorId } from '../../systems/movement/stairs';
 export type DebugColliderFloor = FloorId | 'all';
 
 export interface DebugColliderMetadata {
+  id: string;
   floor: DebugColliderFloor;
   category: string;
   name: string;
   bounds: RectCollider;
 }
 
-export interface DebugColliderRegistration extends DebugColliderMetadata {
+export type DebugColliderIdMetadata = Omit<DebugColliderMetadata, 'id'>;
+
+export interface DebugColliderRegistration extends DebugColliderIdMetadata {
   elevation?: number;
   height?: number;
   color?: ColorRepresentation;
@@ -29,11 +36,14 @@ export interface DebugColliderVisualizerState {
   enabled: boolean;
   visibleColliderCount: number;
   totalColliderCount: number;
+  visibleLabelCount: number;
+  totalLabelCount: number;
 }
 
 interface DebugColliderVisualEntry {
   metadata: DebugColliderMetadata;
   mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
+  label: Sprite | null;
 }
 
 export interface ColliderVisualizer {
@@ -43,17 +53,41 @@ export interface ColliderVisualizer {
   setActiveFloor(floorId: FloorId): void;
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
+  getColliderById(id: string): DebugColliderMetadata | undefined;
   dispose(): void;
 }
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
 const DEFAULT_COLOR = 0x66e6ff;
+const LABEL_Y_OFFSET = 0.34;
+const LABEL_CANVAS_WIDTH = 192;
+const LABEL_CANVAS_HEIGHT = 96;
+const LABEL_WORLD_WIDTH = 1.08;
+const LABEL_WORLD_HEIGHT = 0.54;
+const MIN_ID_LENGTH = 4;
+const MAX_ID_LENGTH = 6;
+const HASH_LENGTH = 8;
+const HASH_SEED = 0x811c9dc5;
+const HASH_PRIME = 0x01000193;
+const BOUNDS_PRECISION = 1000;
+
 const FLOOR_COLORS: Record<DebugColliderFloor, number> = {
   ground: 0x2ee66b,
   upper: 0xf7c948,
   all: 0x66e6ff,
 };
+
+const LABEL_COLORS = [
+  '#7DD3FC',
+  '#FDE047',
+  '#86EFAC',
+  '#FDA4AF',
+  '#C4B5FD',
+  '#FDBA74',
+  '#67E8F9',
+  '#F0ABFC',
+] as const;
 
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
   minX: bounds.minX,
@@ -67,6 +101,125 @@ const isVisibleOnFloor = (
   activeFloorId: FloorId
 ): boolean => colliderFloor === 'all' || colliderFloor === activeFloorId;
 
+const roundBound = (value: number): string =>
+  (Math.round(value * BOUNDS_PRECISION) / BOUNDS_PRECISION).toFixed(3);
+
+const getColliderDebugIdKey = (metadata: DebugColliderIdMetadata): string =>
+  [
+    metadata.name,
+    metadata.floor,
+    metadata.category,
+    roundBound(metadata.bounds.minX),
+    roundBound(metadata.bounds.maxX),
+    roundBound(metadata.bounds.minZ),
+    roundBound(metadata.bounds.maxZ),
+  ].join('|');
+
+const fnv1aHash = (input: string): string => {
+  let hash = HASH_SEED;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, HASH_PRIME) >>> 0;
+  }
+
+  return hash.toString(16).toUpperCase().padStart(HASH_LENGTH, '0');
+};
+
+export function createColliderDebugId(
+  metadata: DebugColliderIdMetadata,
+  usedIds: ReadonlySet<string> = new Set()
+): string {
+  const hash = fnv1aHash(getColliderDebugIdKey(metadata));
+
+  for (let length = MIN_ID_LENGTH; length <= MAX_ID_LENGTH; length += 1) {
+    const candidate = hash.slice(0, length);
+    if (!usedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  const suffixBase = hash.slice(0, MAX_ID_LENGTH - 1);
+  for (let suffix = 0; suffix <= 0xf; suffix += 1) {
+    const candidate = `${suffixBase}${suffix.toString(16).toUpperCase()}`;
+    if (!usedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return hash;
+}
+
+const parseColliderIdColorIndex = (id: string): number => {
+  const parsed = Number.parseInt(id.slice(-2), 16);
+  return Number.isFinite(parsed) ? parsed % LABEL_COLORS.length : 0;
+};
+
+const createLabelCanvas = (): HTMLCanvasElement | null => {
+  if (
+    typeof document === 'undefined' ||
+    (typeof navigator !== 'undefined' &&
+      navigator.userAgent.toLowerCase().includes('jsdom'))
+  ) {
+    return null;
+  }
+
+  return document.createElement('canvas');
+};
+
+const createColliderLabel = (id: string): Sprite | null => {
+  const canvas = createLabelCanvas();
+  const context = canvas?.getContext('2d');
+  if (!canvas || !context) {
+    return null;
+  }
+
+  canvas.width = LABEL_CANVAS_WIDTH;
+  canvas.height = LABEL_CANVAS_HEIGHT;
+
+  const labelColor = LABEL_COLORS[parseColliderIdColorIndex(id)];
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  context.fillStyle = 'rgba(8, 13, 24, 0.82)';
+  context.strokeStyle = labelColor;
+  context.lineWidth = 5;
+  context.beginPath();
+  context.roundRect(8, 16, canvas.width - 16, canvas.height - 32, 18);
+  context.fill();
+  context.stroke();
+
+  context.font =
+    '700 44px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.lineWidth = 8;
+  context.strokeStyle = 'rgba(0, 0, 0, 0.92)';
+  context.strokeText(id, canvas.width / 2, canvas.height / 2 + 1);
+  context.fillStyle = labelColor;
+  context.fillText(id, canvas.width / 2, canvas.height / 2 + 1);
+
+  const texture = new CanvasTexture(canvas);
+  texture.minFilter = LinearFilter;
+  texture.magFilter = LinearFilter;
+  texture.needsUpdate = true;
+
+  const material = new SpriteMaterial({
+    map: texture,
+    depthTest: false,
+    depthWrite: false,
+    transparent: true,
+  });
+  const sprite = new Sprite(material);
+  sprite.name = `DebugColliderLabel:${id}`;
+  sprite.scale.set(LABEL_WORLD_WIDTH, LABEL_WORLD_HEIGHT, 1);
+  sprite.renderOrder = 10_001;
+  sprite.userData.debugOnly = true;
+  sprite.userData.colliderDebugLabel = true;
+  sprite.userData.colliderDebugId = id;
+  sprite.raycast = () => undefined;
+
+  return sprite;
+};
+
 export function createColliderVisualizer(options: {
   activeFloorId: FloorId;
   enabled?: boolean;
@@ -77,19 +230,26 @@ export function createColliderVisualizer(options: {
   group.userData.debugOnly = true;
 
   const entries: DebugColliderVisualEntry[] = [];
+  const usedIds = new Set<string>();
   let enabled = options.enabled ?? false;
   let activeFloorId = options.activeFloorId;
 
   const applyVisibility = () => {
     group.visible = enabled;
     for (const entry of entries) {
-      entry.mesh.visible =
+      const visible =
         enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
+      entry.mesh.visible = visible;
+      if (entry.label) {
+        entry.label.visible = visible;
+      }
     }
   };
 
   const register = (colliders: readonly DebugColliderRegistration[]) => {
     for (const collider of colliders) {
+      const id = createColliderDebugId(collider, usedIds);
+      usedIds.add(id);
       const width = Math.max(
         collider.bounds.maxX - collider.bounds.minX,
         MIN_DIMENSION
@@ -99,6 +259,9 @@ export function createColliderVisualizer(options: {
         MIN_DIMENSION
       );
       const height = collider.height ?? DEFAULT_HEIGHT;
+      const centerX = (collider.bounds.minX + collider.bounds.maxX) / 2;
+      const centerZ = (collider.bounds.minZ + collider.bounds.maxZ) / 2;
+      const elevation = collider.elevation ?? 0;
       const geometry = new BoxGeometry(width, height, depth);
       const material = new MeshBasicMaterial({
         color: collider.color ?? FLOOR_COLORS[collider.floor] ?? DEFAULT_COLOR,
@@ -109,40 +272,60 @@ export function createColliderVisualizer(options: {
         wireframe: true,
       });
       const mesh = new Mesh(geometry, material);
-      mesh.name = `DebugCollider:${collider.floor}:${collider.category}:${collider.name}`;
-      mesh.position.set(
-        (collider.bounds.minX + collider.bounds.maxX) / 2,
-        (collider.elevation ?? 0) + height / 2,
-        (collider.bounds.minZ + collider.bounds.maxZ) / 2
-      );
+      mesh.name = `DebugCollider:${id}:${collider.floor}:${collider.category}:${collider.name}`;
+      mesh.position.set(centerX, elevation + height / 2, centerZ);
       mesh.renderOrder = 10_000;
       mesh.userData.debugOnly = true;
       mesh.userData.colliderDebug = {
+        id,
         floor: collider.floor,
         category: collider.category,
         name: collider.name,
       };
       mesh.raycast = () => undefined;
       group.add(mesh);
+
+      const label = createColliderLabel(id);
+      if (label) {
+        label.position.set(
+          centerX,
+          elevation + height + LABEL_Y_OFFSET,
+          centerZ
+        );
+        group.add(label);
+      }
+
       entries.push({
         metadata: {
+          id,
           floor: collider.floor,
           category: collider.category,
           name: collider.name,
           bounds: cloneBounds(collider.bounds),
         },
         mesh,
+        label,
       });
     }
     applyVisibility();
   };
 
-  const getVisibleColliderCount = () =>
+  const getVisibleEntries = () =>
     enabled
       ? entries.filter((entry) =>
           isVisibleOnFloor(entry.metadata.floor, activeFloorId)
-        ).length
-      : 0;
+        )
+      : [];
+
+  const cloneMetadata = (
+    metadata: DebugColliderMetadata
+  ): DebugColliderMetadata => ({
+    id: metadata.id,
+    floor: metadata.floor,
+    category: metadata.category,
+    name: metadata.name,
+    bounds: cloneBounds(metadata.bounds),
+  });
 
   return {
     group,
@@ -156,27 +339,38 @@ export function createColliderVisualizer(options: {
       applyVisibility();
     },
     getState() {
+      const visibleEntries = getVisibleEntries();
       return {
         enabled,
-        visibleColliderCount: getVisibleColliderCount(),
+        visibleColliderCount: visibleEntries.length,
         totalColliderCount: entries.length,
+        visibleLabelCount: visibleEntries.filter((entry) => entry.label).length,
+        totalLabelCount: entries.filter((entry) => entry.label).length,
       };
     },
     getColliders() {
-      return entries.map((entry) => ({
-        floor: entry.metadata.floor,
-        category: entry.metadata.category,
-        name: entry.metadata.name,
-        bounds: cloneBounds(entry.metadata.bounds),
-      }));
+      return entries.map((entry) => cloneMetadata(entry.metadata));
+    },
+    getColliderById(id: string) {
+      const normalizedId = id.toUpperCase();
+      const entry = entries.find(
+        (candidate) => candidate.metadata.id === normalizedId
+      );
+      return entry ? cloneMetadata(entry.metadata) : undefined;
     },
     dispose() {
       for (const entry of entries) {
         group.remove(entry.mesh);
         entry.mesh.geometry.dispose();
         entry.mesh.material.dispose();
+        if (entry.label) {
+          group.remove(entry.label);
+          entry.label.material.map?.dispose();
+          entry.label.material.dispose();
+        }
       }
       entries.length = 0;
+      usedIds.clear();
       const parent = group.parent as Object3D | null;
       parent?.remove(group);
     },


### PR DESCRIPTION
### Motivation
- Overlapping yellow collider wireframes are hard to identify in screenshots, so we need stable short IDs rendered in-world to map visuals back to precise collider metadata. 
- IDs must be deterministic across reloads and surface in the debug API so QA can reliably locate and reference specific colliders during cleanup and regression investigation.

### Description
- Add deterministic uppercase short hex IDs via `createColliderDebugId(...)` (FNV-1a hash of name/floor/category/rounded bounds, 4–6 chars with deterministic collision fallback). 
- Render non-interactive canvas-based `Sprite` labels near each collider center that face the camera, use a small high-contrast color palette, include a dark backing, and follow the existing debug-collider visibility/floor rules. 
- Extend the visualizer and debug API to include `id` in collider metadata, expose `getColliderById`/`findColliderById`, and add label counts to `getState()`, without exposing Three.js internals or changing collider behavior. 
- Add unit tests for ID generation and visualizer behavior and extend Playwright stairs test coverage to assert IDs, uniqueness, lookup, and label visibility.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully. 
- Ran unit suite with `npm run test:ci` which completed successfully (existing suite: 144 test files, 1086 tests passed). 
- Ran the new visualizer unit tests `src/scene/debug/__tests__/colliderVisualizer.test.ts` and they passed. 
- Ran docs and smoke checks with `npm run docs:check` and `npm run smoke`, both passed (link checker produced benign fetch warnings). 
- Built the app with `npm run build` and the build completed successfully. 
- Ran Playwright checks `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and the spec passed (9 tests passed) including the new assertions for debug IDs and label visibility. 
- Manual preview verification captured a screenshot and printed debug state from `/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1`, showing `visibleColliderCount` and `visibleLabelCount` (example output: `{"enabled":true,"visibleColliderCount":59,"totalColliderCount":86,"visibleLabelCount":59,"totalLabelCount":86}`). 
- `npm run typecheck` failed due to unrelated, existing project-wide TypeScript errors surfaced by broader type checks and not caused by this change; the change keeps types locally consistent and unit/Playwright tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9c7d7970832f91fb76f58e7ee47a)