### PR TITLE
Fix upper stair landing z-fighting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -377,6 +377,7 @@ import {
   normalizeRadians,
 } from './systems/movement/facing';
 import {
+  computeStaircaseLandingBounds,
   computeStairLayout,
   computeStairwellOpeningBounds,
 } from './systems/movement/stairLayout';
@@ -1831,6 +1832,11 @@ function initializeImmersiveScene(
   const stairLandingMaxZ = stairLayout.landingMaxZ;
   const upperFloorElevation =
     stairTotalRise + STAIRCASE_CONFIG.landing.thickness;
+  const staircaseLandingBounds = computeStaircaseLandingBounds({
+    centerX: stairCenterX,
+    halfWidth: stairHalfWidth,
+    layout: stairLayout,
+  });
   const stairGeometry: StairGeometry = {
     centerX: stairCenterX,
     halfWidth: stairHalfWidth,
@@ -2095,7 +2101,17 @@ function initializeImmersiveScene(
           upperLanding: [
             {
               ...upperStairwellOpening,
-              minX: upperStairWestEgressBlockerMinX,
+              // Keep the upper-floor tile edge outside the physical landing's
+              // top surface; leaving this at the west egress blocker edge
+              // made the floor slab coplanar with StaircaseLanding and caused
+              // z-fighting stripes around the upper stair landing.
+              minX: Math.max(
+                upperStairwellOpening.minX,
+                Math.min(
+                  upperStairWestEgressBlockerMinX,
+                  staircaseLandingBounds.minX
+                )
+              ),
             },
           ],
         }

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../../../assets/floorPlan';
 import {
+  computeStaircaseLandingBounds,
   computeStairLayout,
   computeStairwellOpeningBounds,
 } from '../../../systems/movement/stairLayout';
@@ -40,6 +41,46 @@ const boundsAreClose = (
   valuesAreClose(actual.minZ, expected.minZ) &&
   valuesAreClose(actual.maxZ, expected.maxZ);
 
+const createUpperStairTestLayout = () => {
+  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'upperLanding'
+  );
+  expect(upperLandingRoom).toBeDefined();
+
+  const stairCenterX = toWorldUnits(6.2);
+  const stairHalfWidth = toWorldUnits(3.1) / 2;
+  const stairLayout = computeStairLayout({
+    baseZ: toWorldUnits(-5.3),
+    stepRun: toWorldUnits(0.85),
+    stepCount: 9,
+    landingDepth: toWorldUnits(2.6),
+    direction: 'negativeZ',
+    guardMargin: toWorldUnits(0.6),
+    stairwellMargin: toWorldUnits(0.4),
+  });
+  const stairwellOpening = computeStairwellOpeningBounds({
+    centerX: stairCenterX,
+    halfWidth: stairHalfWidth,
+    marginX: toWorldUnits(0.2),
+    roomBounds: upperLandingRoom!.bounds,
+    layout: stairLayout,
+  });
+  const landingTopSurface = computeStaircaseLandingBounds({
+    centerX: stairCenterX,
+    halfWidth: stairHalfWidth,
+    layout: stairLayout,
+  });
+
+  return {
+    upperLandingRoom: upperLandingRoom!,
+    stairCenterX,
+    stairHalfWidth,
+    stairLayout,
+    stairwellOpening,
+    landingTopSurface,
+  };
+};
+
 describe('createRoomFloorTiles', () => {
   it('builds opaque upper-floor slabs with a layout-driven stairwell opening', () => {
     const material = new MeshStandardMaterial({
@@ -47,30 +88,8 @@ describe('createRoomFloorTiles', () => {
       opacity: 1,
       depthWrite: true,
     });
-    const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
-      (room) => room.id === 'upperLanding'
-    );
-    expect(upperLandingRoom).toBeDefined();
-
-    const stairCenterX = toWorldUnits(6.2);
-    const stairHalfWidth = toWorldUnits(3.1) / 2;
-    const stairwellMarginX = toWorldUnits(0.2);
-    const stairLayout = computeStairLayout({
-      baseZ: toWorldUnits(-5.3),
-      stepRun: toWorldUnits(0.85),
-      stepCount: 9,
-      landingDepth: toWorldUnits(2.6),
-      direction: 'negativeZ',
-      guardMargin: toWorldUnits(0.6),
-      stairwellMargin: toWorldUnits(0.4),
-    });
-    const stairwellOpening = computeStairwellOpeningBounds({
-      centerX: stairCenterX,
-      halfWidth: stairHalfWidth,
-      marginX: stairwellMarginX,
-      roomBounds: upperLandingRoom!.bounds,
-      layout: stairLayout,
-    });
+    const { upperLandingRoom, stairLayout, stairwellOpening } =
+      createUpperStairTestLayout();
 
     const build = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
       material,
@@ -91,18 +110,18 @@ describe('createRoomFloorTiles', () => {
 
     const fillsLeftLandingShoulder = upperLandingTiles.some((tile) =>
       boundsAreClose(tile.bounds, {
-        minX: upperLandingRoom!.bounds.minX,
+        minX: upperLandingRoom.bounds.minX,
         maxX: stairwellOpening.minX,
-        minZ: upperLandingRoom!.bounds.minZ,
-        maxZ: upperLandingRoom!.bounds.maxZ,
+        minZ: upperLandingRoom.bounds.minZ,
+        maxZ: upperLandingRoom.bounds.maxZ,
       })
     );
     const fillsRightLandingShoulder = upperLandingTiles.some((tile) =>
       boundsAreClose(tile.bounds, {
         minX: stairwellOpening.maxX,
-        maxX: upperLandingRoom!.bounds.maxX,
-        minZ: upperLandingRoom!.bounds.minZ,
-        maxZ: upperLandingRoom!.bounds.maxZ,
+        maxX: upperLandingRoom.bounds.maxX,
+        minZ: upperLandingRoom.bounds.minZ,
+        maxZ: upperLandingRoom.bounds.maxZ,
       })
     );
     expect(fillsLeftLandingShoulder).toBe(true);
@@ -112,7 +131,7 @@ describe('createRoomFloorTiles', () => {
       minX: stairwellOpening.minX,
       maxX: stairwellOpening.maxX,
       minZ: stairLayout.landingMaxZ,
-      maxZ: upperLandingRoom!.bounds.maxZ,
+      maxZ: upperLandingRoom.bounds.maxZ,
     };
     expect(
       upperLandingTiles.some((tile) => overlaps(tile.bounds, stairwellOpening))
@@ -138,5 +157,43 @@ describe('createRoomFloorTiles', () => {
     expect(material.transparent).toBe(false);
     expect(material.opacity).toBe(1);
     expect(material.depthWrite).toBe(true);
+  });
+
+  it('cuts the upper landing floor away from the physical stair landing top surface', () => {
+    const {
+      stairCenterX,
+      stairHalfWidth,
+      stairwellOpening,
+      landingTopSurface,
+    } = createUpperStairTestLayout();
+    const playerRadius = 0.75;
+    const westEgressBlockerMinX =
+      stairCenterX - stairHalfWidth + playerRadius * 0.75 + playerRadius + 0.01;
+    const visualCutout = {
+      ...stairwellOpening,
+      minX: Math.max(
+        stairwellOpening.minX,
+        Math.min(westEgressBlockerMinX, landingTopSurface.minX)
+      ),
+    };
+
+    const build = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+      elevation: 4.16,
+      thickness: 0.38,
+      groupName: 'UpperFloorTiles',
+      cutoutsByRoom: {
+        upperLanding: [visualCutout],
+      },
+    });
+
+    const upperLandingTiles = build.tiles.filter(
+      (tile) => tile.roomId === 'upperLanding'
+    );
+
+    expect(visualCutout.minX).toBeCloseTo(landingTopSurface.minX);
+    expect(upperLandingTiles.length).toBeGreaterThan(0);
+    expect(
+      upperLandingTiles.some((tile) => overlaps(tile.bounds, landingTopSurface))
+    ).toBe(false);
   });
 });

--- a/src/systems/movement/stairLayout.ts
+++ b/src/systems/movement/stairLayout.ts
@@ -17,6 +17,12 @@ export interface StairwellBounds {
   maxZ: number;
 }
 
+export interface StaircaseLandingBoundsConfig {
+  centerX: number;
+  halfWidth: number;
+  layout: Pick<StairLayoutResult, 'landingMinZ' | 'landingMaxZ'>;
+}
+
 export interface StairwellOpeningConfig {
   centerX: number;
   halfWidth: number;
@@ -86,6 +92,16 @@ export const computeStairLayout = (
     stairHoleRange: { minZ: stairHoleMinZ, maxZ: stairHoleMaxZ },
   };
 };
+
+/** Returns the visible top-surface footprint of the physical stair landing slab. */
+export const computeStaircaseLandingBounds = (
+  config: StaircaseLandingBoundsConfig
+): StairwellBounds => ({
+  minX: config.centerX - config.halfWidth,
+  maxX: config.centerX + config.halfWidth,
+  minZ: config.layout.landingMinZ,
+  maxZ: config.layout.landingMaxZ,
+});
 
 /**
  * Clips the visible upstairs stairwell hole to the landing room while deriving

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  computeStaircaseLandingBounds,
   computeStairLayout,
   computeStairwellOpeningBounds,
 } from '../../systems/movement/stairLayout';
@@ -46,6 +47,29 @@ describe('computeStairLayout', () => {
       guardRange: { minZ: -0.5, maxZ: 5 },
       stairHoleRange: { minZ: -0.25, maxZ: 5.25 },
     });
+  });
+
+  it('derives the physical stair landing footprint separately from the wider void', () => {
+    const layout = computeStairLayout({
+      baseZ: -10.6,
+      stepRun: 1.7,
+      stepCount: 9,
+      landingDepth: 5.2,
+      direction: 'negativeZ',
+      guardMargin: 1.2,
+      stairwellMargin: 0.8,
+    });
+
+    const landing = computeStaircaseLandingBounds({
+      centerX: 9.92,
+      halfWidth: 2.48,
+      layout,
+    });
+
+    expect(landing.minX).toBeCloseTo(7.44);
+    expect(landing.maxX).toBeCloseTo(12.4);
+    expect(landing.minZ).toBeCloseTo(-31.1);
+    expect(landing.maxZ).toBeCloseTo(-25.9);
   });
 
   it('clips upstairs stairwell hole bounds from the shared stair layout plus margin', () => {


### PR DESCRIPTION
### Motivation
- Remove the visible z-fighting where the upper-floor tile slab met the StaircaseLanding slab by preventing coplanar/top-surface overlap. 
- Keep the change strictly visual so movement, navmesh, colliders, and POI/visibility behavior remain unchanged. 

### Description
- Add `computeStaircaseLandingBounds(...)` to derive the visible physical stair landing top-surface footprint separately from the wider stairwell void in `src/systems/movement/stairLayout.ts`. 
- Use the landing footprint in `src/main.ts` to clamp the upper-floor cutout west edge so upper floor tiles do not produce a coplanar slab over the `StaircaseLanding` mesh. 
- Add a focused unit test to `src/scene/structures/__tests__/floorTiles.test.ts` asserting upper-floor tiles exclude the landing top surface and add a layout test to `src/tests/movement/stairLayout.test.ts` for the new landing helper. 
- Changes are limited to visual cutout/geometry and tests; no runtime collision, movement, or navmesh semantics were altered. 

### Testing
- Ran formatting and linting: `npm run format:write` (✅) and `npm run lint` (✅). 
- Ran unit test suite: `npm run test:ci` (✅ — full suite passed, 144 files / 1097 tests in this environment). 
- Ran focused tests: `npm run test:ci -- src/scene/structures/__tests__/floorTiles.test.ts src/tests/movement/stairLayout.test.ts` (✅ — passed). 
- Docs and smoke checks: `npm run docs:check` (✅, link warnings reported but link check completed) and `npm run smoke` (✅ build + dist assertions passed). 
- Playwright end-to-end: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` initially failed because browsers were not installed in the environment (⚠️), then I installed Playwright browsers and deps (`npx playwright install` / `npx playwright install-deps`) and re-ran the suite which passed (✅ — immersive stairs roundtrip tests passed). 
- Built and previewed: `npm run build` (✅) and generated a manual verification screenshot at `/tmp/upper-stair-landing-zfight-check.png` while previewing `/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1` (manual visual check saved; no z-fighting observed in that capture). 

If you'd like, I can split the small test additions into a separate commit, but I kept them with the change to ensure the invariant is covered by automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ca34bc804832fa527851e77d62f57)