### PR TITLE
Fix upper stair landing z-fighting by removing overlapping upper-floor tile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -263,6 +263,7 @@ import {
   createTokenPlaceRack,
   type TokenPlaceRackBuild,
 } from './scene/structures/tokenPlaceRack';
+import { createUpperLandingFloorCutouts } from './scene/structures/upperLandingFloorCutouts';
 import { createUpperStairwellLanding } from './scene/structures/upperStairwellLanding';
 import { createWallSegmentMeshes } from './scene/structures/wallSegmentsMesh';
 import {
@@ -2089,15 +2090,20 @@ function initializeImmersiveScene(
     ].forEach(({ name, bounds }) => pushNamedUpperFloorCollider(name, bounds));
   }
 
+  const staircaseLandingFootprint = {
+    minX: stairCenterX - stairHalfWidth,
+    maxX: stairCenterX + stairHalfWidth,
+    minZ: stairLandingMinZ,
+    maxZ: stairLandingMaxZ,
+  };
   const upperLandingCutouts =
     upperLandingRoom && upperStairwellOpening
       ? {
-          upperLanding: [
-            {
-              ...upperStairwellOpening,
-              minX: upperStairWestEgressBlockerMinX,
-            },
-          ],
+          upperLanding: createUpperLandingFloorCutouts({
+            staircaseLandingFootprint,
+            stairwellOpening: upperStairwellOpening,
+            hiddenRunVoidMinX: upperStairWestEgressBlockerMinX,
+          }),
         }
       : undefined;
   const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {

--- a/src/scene/structures/upperLandingFloorCutouts.ts
+++ b/src/scene/structures/upperLandingFloorCutouts.ts
@@ -1,0 +1,30 @@
+import type { Bounds2D } from '../../assets/floorPlan';
+
+import type { RoomFloorCutout } from './floorTiles';
+
+export interface UpperLandingFloorCutoutConfig {
+  /** Full visible top footprint of the physical StaircaseLanding slab. */
+  readonly staircaseLandingFootprint: Bounds2D;
+  /** Shared stairwell void used by the upper landing floor tiles. */
+  readonly stairwellOpening: Bounds2D;
+  /** West edge of the hidden-run void after preserving the egress lane. */
+  readonly hiddenRunVoidMinX: number;
+}
+
+/**
+ * Keeps upper landing floor tiles away from the physical staircase landing slab
+ * while preserving the narrower hidden-run cutout that protects upstairs egress.
+ * The first cutout removes the coplanar slab footprint; the second keeps the
+ * no-floor void open only where the hidden stair run should remain uncovered.
+ */
+export function createUpperLandingFloorCutouts(
+  config: UpperLandingFloorCutoutConfig
+): RoomFloorCutout[] {
+  return [
+    { ...config.staircaseLandingFootprint },
+    {
+      ...config.stairwellOpening,
+      minX: config.hiddenRunVoidMinX,
+    },
+  ];
+}

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -1,0 +1,87 @@
+import { MeshStandardMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../assets/floorPlan';
+import type { Bounds2D } from '../assets/floorPlan';
+import { createRoomFloorTiles } from '../scene/structures/floorTiles';
+import { createUpperLandingFloorCutouts } from '../scene/structures/upperLandingFloorCutouts';
+import {
+  computeStairLayout,
+  computeStairwellOpeningBounds,
+} from '../systems/movement/stairLayout';
+
+const toWorldUnits = (value: number) => value * FLOOR_PLAN_SCALE;
+
+const STAIR_CENTER_X = toWorldUnits(6.2);
+const STAIR_HALF_WIDTH = toWorldUnits(3.1) / 2;
+const STAIR_BOTTOM_Z = toWorldUnits(-5.3);
+const STAIR_RUN = toWorldUnits(0.85);
+const STAIR_STEP_COUNT = 9;
+const STAIR_LANDING_DEPTH = toWorldUnits(2.6);
+const STAIRWELL_MARGIN_X = toWorldUnits(0.2);
+const STAIRWELL_MARGIN_Z = toWorldUnits(0.4);
+const PLAYER_RADIUS = 0.75;
+
+const overlaps = (a: Bounds2D, b: Bounds2D): boolean =>
+  a.minX < b.maxX && a.maxX > b.minX && a.minZ < b.maxZ && a.maxZ > b.minZ;
+
+describe('createUpperLandingFloorCutouts', () => {
+  it('removes the physical staircase landing footprint from upper landing floor tiles', () => {
+    const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+      (room) => room.id === 'upperLanding'
+    );
+    expect(upperLandingRoom).toBeDefined();
+    if (!upperLandingRoom) {
+      return;
+    }
+
+    const stairLayout = computeStairLayout({
+      baseZ: STAIR_BOTTOM_Z,
+      stepRun: STAIR_RUN,
+      stepCount: STAIR_STEP_COUNT,
+      landingDepth: STAIR_LANDING_DEPTH,
+      direction: 'negativeZ',
+      guardMargin: toWorldUnits(0.6),
+      stairwellMargin: STAIRWELL_MARGIN_Z,
+    });
+    const stairwellOpening = computeStairwellOpeningBounds({
+      centerX: STAIR_CENTER_X,
+      halfWidth: STAIR_HALF_WIDTH,
+      marginX: STAIRWELL_MARGIN_X,
+      roomBounds: upperLandingRoom.bounds,
+      layout: stairLayout,
+    });
+    const staircaseLandingFootprint = {
+      minX: STAIR_CENTER_X - STAIR_HALF_WIDTH,
+      maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH,
+      minZ: stairLayout.landingMinZ,
+      maxZ: stairLayout.landingMaxZ,
+    };
+    const westEgressLaneX =
+      STAIR_CENTER_X - STAIR_HALF_WIDTH + PLAYER_RADIUS * 0.75;
+    const hiddenRunVoidMinX = westEgressLaneX + PLAYER_RADIUS + 0.01;
+
+    const cutouts = createUpperLandingFloorCutouts({
+      staircaseLandingFootprint,
+      stairwellOpening,
+      hiddenRunVoidMinX,
+    });
+    const floorTiles = createRoomFloorTiles([upperLandingRoom], {
+      material: new MeshStandardMaterial(),
+      elevation: 4.16,
+      thickness: 0.38,
+      cutoutsByRoom: { upperLanding: cutouts },
+    });
+
+    expect(cutouts[0]).toEqual(staircaseLandingFootprint);
+    expect(cutouts[1]).toEqual({
+      ...stairwellOpening,
+      minX: hiddenRunVoidMinX,
+    });
+    expect(
+      floorTiles.tiles
+        .filter((tile) => tile.roomId === 'upperLanding')
+        .every((tile) => !overlaps(tile.bounds, staircaseLandingFootprint))
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- The upper stair landing showed z-fighting where the visible `StaircaseLanding` slab and the auto-generated upper-floor tile were coplanar/overlapping at the same top-surface elevation.
- The fix must be visual only: remove the overlapping floor tile footprint while preserving existing movement, navmesh, and collider semantics.

### Description
- Add `createUpperLandingFloorCutouts(...)` (`src/scene/structures/upperLandingFloorCutouts.ts`) which emits targeted cutouts that (a) remove the visible `StaircaseLanding` footprint and (b) preserve the narrower hidden-run void for egress.
- Wire the new helper into scene assembly in `src/main.ts` so `createRoomFloorTiles(...)` for the upper landing receives the landing-footprint cutout instead of leaving a coplanar tile overlapping the physical landing slab.
- Add a focused unit test `src/tests/upperLandingFloorCutouts.test.ts` that asserts upper-floor tile bounds do not overlap the visible staircase landing footprint.

### Testing
- Ran `npm run format:write` which completed successfully.
- Ran `npm run lint` which completed successfully (minor import-group warning fixed during formatting).
- Ran `npm run test:ci` (Vitest) and the full suite passed including the new `src/tests/upperLandingFloorCutouts.test.ts` (all tests green).
- Ran `npm run docs:check` (passed with external-link fetch warnings) and `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` which passed the targeted stairs spec after installing Playwright browsers and deps.
- Built and validated the distribution with `npm run build` and `npm run smoke`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ca3860774832f88bcc6b1d8c081fa)