### PR TITLE
Fix upper stair landing z-fighting overlap

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -378,6 +378,7 @@ import {
 } from './systems/movement/facing';
 import {
   computeStairLayout,
+  computeStaircaseLandingBounds,
   computeStairwellOpeningBounds,
 } from './systems/movement/stairLayout';
 import {
@@ -1904,6 +1905,11 @@ function initializeImmersiveScene(
   const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
     (room) => room.id === 'upperLanding'
   );
+  const visibleStairLandingBounds = computeStaircaseLandingBounds({
+    centerX: stairCenterX,
+    halfWidth: stairHalfWidth,
+    layout: stairLayout,
+  });
   const upperStairwellOpening = upperLandingRoom
     ? computeStairwellOpeningBounds({
         centerX: stairCenterX,
@@ -2093,6 +2099,10 @@ function initializeImmersiveScene(
     upperLandingRoom && upperStairwellOpening
       ? {
           upperLanding: [
+            // Remove the visible StaircaseLanding slab footprint at its exact
+            // upper-floor elevation so room floor tiles meet it without a
+            // coplanar overlap that flickers in the isometric camera view.
+            visibleStairLandingBounds,
             {
               ...upperStairwellOpening,
               minX: upperStairWestEgressBlockerMinX,

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../../../assets/floorPlan';
 import {
   computeStairLayout,
+  computeStaircaseLandingBounds,
   computeStairwellOpeningBounds,
 } from '../../../systems/movement/stairLayout';
 import { createRoomFloorTiles } from '../floorTiles';
@@ -138,5 +139,89 @@ describe('createRoomFloorTiles', () => {
     expect(material.transparent).toBe(false);
     expect(material.opacity).toBe(1);
     expect(material.depthWrite).toBe(true);
+  });
+
+  it('cuts the visible staircase landing footprint out of the upper landing floor', () => {
+    const material = new MeshStandardMaterial();
+    const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+      (room) => room.id === 'upperLanding'
+    );
+    expect(upperLandingRoom).toBeDefined();
+
+    const playerRadius = 0.75;
+    const stairCenterX = toWorldUnits(6.2);
+    const stairHalfWidth = toWorldUnits(3.1) / 2;
+    const stairwellMarginX = toWorldUnits(0.2);
+    const stairLayout = computeStairLayout({
+      baseZ: toWorldUnits(-5.3),
+      stepRun: toWorldUnits(0.85),
+      stepCount: 9,
+      landingDepth: toWorldUnits(2.6),
+      direction: 'negativeZ',
+      guardMargin: toWorldUnits(0.6),
+      stairwellMargin: toWorldUnits(0.4),
+    });
+    const stairwellOpening = computeStairwellOpeningBounds({
+      centerX: stairCenterX,
+      halfWidth: stairHalfWidth,
+      marginX: stairwellMarginX,
+      roomBounds: upperLandingRoom!.bounds,
+      layout: stairLayout,
+    });
+    const visibleStairLandingBounds = computeStaircaseLandingBounds({
+      centerX: stairCenterX,
+      halfWidth: stairHalfWidth,
+      layout: stairLayout,
+    });
+    const upperStairWestEgressLaneX =
+      stairCenterX - stairHalfWidth + playerRadius * 0.75;
+    const upperStairWestEgressBlockerMinX =
+      upperStairWestEgressLaneX + playerRadius + 0.01;
+
+    const build = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+      material,
+      elevation: 4,
+      thickness: 0.38,
+      groupName: 'UpperFloorTiles',
+      cutoutsByRoom: {
+        upperLanding: [
+          visibleStairLandingBounds,
+          {
+            ...stairwellOpening,
+            minX: upperStairWestEgressBlockerMinX,
+          },
+        ],
+      },
+    });
+
+    const upperLandingTiles = build.tiles.filter(
+      (tile) => tile.roomId === 'upperLanding'
+    );
+
+    expect(upperLandingTiles.length).toBeGreaterThan(0);
+    expect(
+      upperLandingTiles.some((tile) =>
+        overlaps(tile.bounds, visibleStairLandingBounds)
+      )
+    ).toBe(false);
+    expect(
+      upperLandingTiles.some((tile) =>
+        overlaps(tile.bounds, {
+          ...visibleStairLandingBounds,
+          minX: visibleStairLandingBounds.minX + 0.01,
+          maxX: upperStairWestEgressBlockerMinX - 0.01,
+        })
+      )
+    ).toBe(false);
+    expect(
+      upperLandingTiles.some((tile) =>
+        boundsAreClose(tile.bounds, {
+          minX: upperLandingRoom!.bounds.minX,
+          maxX: visibleStairLandingBounds.minX,
+          minZ: upperLandingRoom!.bounds.minZ,
+          maxZ: upperLandingRoom!.bounds.maxZ,
+        })
+      )
+    ).toBe(true);
   });
 });

--- a/src/systems/movement/stairLayout.ts
+++ b/src/systems/movement/stairLayout.ts
@@ -17,6 +17,12 @@ export interface StairwellBounds {
   maxZ: number;
 }
 
+export interface StaircaseLandingBoundsConfig {
+  centerX: number;
+  halfWidth: number;
+  layout: Pick<StairLayoutResult, 'landingMinZ' | 'landingMaxZ'>;
+}
+
 export interface StairwellOpeningConfig {
   centerX: number;
   halfWidth: number;
@@ -86,6 +92,15 @@ export const computeStairLayout = (
     stairHoleRange: { minZ: stairHoleMinZ, maxZ: stairHoleMaxZ },
   };
 };
+
+export const computeStaircaseLandingBounds = (
+  config: StaircaseLandingBoundsConfig
+): StairwellBounds => ({
+  minX: config.centerX - config.halfWidth,
+  maxX: config.centerX + config.halfWidth,
+  minZ: config.layout.landingMinZ,
+  maxZ: config.layout.landingMaxZ,
+});
 
 /**
  * Clips the visible upstairs stairwell hole to the landing room while deriving

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   computeStairLayout,
+  computeStaircaseLandingBounds,
   computeStairwellOpeningBounds,
 } from '../../systems/movement/stairLayout';
 
@@ -46,6 +47,29 @@ describe('computeStairLayout', () => {
       guardRange: { minZ: -0.5, maxZ: 5 },
       stairHoleRange: { minZ: -0.25, maxZ: 5.25 },
     });
+  });
+
+  it('derives the visible landing slab footprint from shared stair layout metrics', () => {
+    const layout = computeStairLayout({
+      baseZ: -10.6,
+      stepRun: 1.7,
+      stepCount: 9,
+      landingDepth: 5.2,
+      direction: 'negativeZ',
+      guardMargin: 1.2,
+      stairwellMargin: 0.8,
+    });
+
+    const bounds = computeStaircaseLandingBounds({
+      centerX: 12.4,
+      halfWidth: 3.1,
+      layout,
+    });
+
+    expect(bounds.minX).toBeCloseTo(9.3);
+    expect(bounds.maxX).toBeCloseTo(15.5);
+    expect(bounds.minZ).toBeCloseTo(-31.1);
+    expect(bounds.maxZ).toBeCloseTo(-25.9);
   });
 
   it('clips upstairs stairwell hole bounds from the shared stair layout plus margin', () => {


### PR DESCRIPTION
### Motivation
- The upper stair landing produced visible z-fighting where the Room floor tiles and the physical `StaircaseLanding` slab were coplanar at the same elevation. 
- The root cause was that the visible landing slab footprint was not removed from the upper-floor tiles before the larger stairwell cutout was applied. 
- The change aims to resolve the visual flicker via a targeted geometry/cutout fix while preserving movement, colliders, and nav behavior.

### Description
- Add `computeStaircaseLandingBounds(...)` to `src/systems/movement/stairLayout.ts` to derive the visible landing slab footprint from shared stair layout metrics. 
- Remove the visible landing footprint from upper-floor tiles by inserting `visibleStairLandingBounds` into `upperLandingCutouts` in `src/main.ts` so tiles meet the landing without coplanar overlap. 
- Add unit tests: a floor-tiles regression in `src/scene/structures/__tests__/floorTiles.test.ts` asserting upper landing tiles do not overlap the visible landing, and a layout test in `src/tests/movement/stairLayout.test.ts` for the derived landing bounds. 

### Testing
- Ran formatting: `npm run format:write` (succeeded). 
- Ran lint: `npm run lint` (succeeded). 
- Ran unit tests: `npm run test:ci` (Vitest full run completed; all tests passed: 144 files, 1097 tests). 
- Ran targeted tests before and after edits: `npm run test:ci -- src/scene/structures/__tests__/floorTiles.test.ts src/tests/movement/stairLayout.test.ts` (succeeded). 
- Docs check: `npm run docs:check` (succeeded). 
- Smoke/build: `npm run smoke` / `npm run build` (succeeded). 
- Playwright: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` initially failed due to missing Playwright browsers/deps, then I ran `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell` and re-ran the spec which then passed (8 tests). 
- Captured a local review screenshot of the immersive debug view at `/tmp/upper-stair-landing-zfight-check.png` for visual verification. 

All automated checks and the end-to-end stairs roundtrip spec passed after installing the Playwright runtime; no movement, navmesh, collider, or POI semantics were changed and no runtime collision geometry was altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ca397049c832fafcdd5e5d3c0c07f)