### PR TITLE
Fix upper stair landing z-fighting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -256,6 +256,7 @@ import {
   type SigmaWorkbenchBuild,
 } from './scene/structures/sigmaWorkbench';
 import {
+  computeStaircaseLandingBounds,
   createStaircase,
   type StaircaseConfig,
 } from './scene/structures/staircase';
@@ -1829,6 +1830,8 @@ function initializeImmersiveScene(
   const stairTopZ = stairLayout.topZ;
   const stairLandingMinZ = stairLayout.landingMinZ;
   const stairLandingMaxZ = stairLayout.landingMaxZ;
+  const stairLandingVisualBounds =
+    computeStaircaseLandingBounds(STAIRCASE_CONFIG);
   const upperFloorElevation =
     stairTotalRise + STAIRCASE_CONFIG.landing.thickness;
   const stairGeometry: StairGeometry = {
@@ -2093,6 +2096,10 @@ function initializeImmersiveScene(
     upperLandingRoom && upperStairwellOpening
       ? {
           upperLanding: [
+            // Remove the visible StaircaseLanding slab footprint from the
+            // upper-floor tile mesh. The slab top is intentionally coplanar
+            // with the upper floor, so leaving any overlap causes z-fighting.
+            stairLandingVisualBounds,
             {
               ...upperStairwellOpening,
               minX: upperStairWestEgressBlockerMinX,

--- a/src/scene/structures/__tests__/floorTiles.test.ts
+++ b/src/scene/structures/__tests__/floorTiles.test.ts
@@ -1,4 +1,4 @@
-import { BoxGeometry, MeshStandardMaterial } from 'three';
+import { BoxGeometry, MeshStandardMaterial, Vector3 } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../../../assets/floorPlan';
@@ -7,6 +7,10 @@ import {
   computeStairwellOpeningBounds,
 } from '../../../systems/movement/stairLayout';
 import { createRoomFloorTiles } from '../floorTiles';
+import {
+  computeStaircaseLandingBounds,
+  type StaircaseConfig,
+} from '../staircase';
 
 const toWorldUnits = (value: number): number => value * FLOOR_PLAN_SCALE;
 
@@ -138,5 +142,92 @@ describe('createRoomFloorTiles', () => {
     expect(material.transparent).toBe(false);
     expect(material.opacity).toBe(1);
     expect(material.depthWrite).toBe(true);
+  });
+  it('cuts the visible staircase landing out of coplanar upper-floor slabs', () => {
+    const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+      (room) => room.id === 'upperLanding'
+    );
+    expect(upperLandingRoom).toBeDefined();
+
+    const stairConfig = {
+      basePosition: new Vector3(toWorldUnits(6.2), 0, toWorldUnits(-5.3)),
+      direction: 'negativeZ',
+      step: {
+        count: 9,
+        rise: 0.42,
+        run: toWorldUnits(0.85),
+        width: toWorldUnits(3.1),
+        material: {},
+      },
+      landing: {
+        depth: toWorldUnits(2.6),
+        thickness: 0.38,
+        material: {},
+      },
+    } satisfies StaircaseConfig;
+    const stairLandingVisualBounds = computeStaircaseLandingBounds(stairConfig);
+    const stairwellMarginX = toWorldUnits(0.2);
+    const stairLayout = computeStairLayout({
+      baseZ: stairConfig.basePosition.z,
+      stepRun: stairConfig.step.run,
+      stepCount: stairConfig.step.count,
+      landingDepth: stairConfig.landing.depth,
+      direction: stairConfig.direction,
+      guardMargin: toWorldUnits(0.6),
+      stairwellMargin: toWorldUnits(0.4),
+    });
+    const stairwellOpening = computeStairwellOpeningBounds({
+      centerX: stairConfig.basePosition.x,
+      halfWidth: stairConfig.step.width / 2,
+      marginX: stairwellMarginX,
+      roomBounds: upperLandingRoom!.bounds,
+      layout: stairLayout,
+    });
+    const upperStairWestEgressBlockerMinX =
+      stairConfig.basePosition.x -
+      stairConfig.step.width / 2 +
+      0.75 * 0.75 +
+      0.75 +
+      0.01;
+
+    const build = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+      elevation:
+        stairConfig.step.count * stairConfig.step.rise +
+        stairConfig.landing.thickness,
+      thickness: stairConfig.landing.thickness,
+      cutoutsByRoom: {
+        upperLanding: [
+          stairLandingVisualBounds,
+          {
+            ...stairwellOpening,
+            minX: upperStairWestEgressBlockerMinX,
+          },
+        ],
+      },
+    });
+
+    const upperLandingTiles = build.tiles.filter(
+      (tile) => tile.roomId === 'upperLanding'
+    );
+
+    expect(stairLandingVisualBounds.minX).toBeLessThan(
+      upperStairWestEgressBlockerMinX
+    );
+    expect(stairLandingVisualBounds.maxX).toBeLessThanOrEqual(
+      stairwellOpening.maxX
+    );
+    expect(
+      upperLandingTiles.some((tile) =>
+        overlaps(tile.bounds, stairLandingVisualBounds)
+      )
+    ).toBe(false);
+    expect(
+      upperLandingTiles.some(
+        (tile) =>
+          valuesAreClose(tile.bounds.maxX, stairLandingVisualBounds.minX) &&
+          tile.bounds.minZ < stairLandingVisualBounds.maxZ &&
+          tile.bounds.maxZ > stairLandingVisualBounds.minZ
+      )
+    ).toBe(true);
   });
 });

--- a/src/scene/structures/staircase.ts
+++ b/src/scene/structures/staircase.ts
@@ -52,6 +52,24 @@ export interface StaircaseBuildResult {
   totalRise: number;
 }
 
+export function computeStaircaseLandingBounds(
+  config: StaircaseConfig
+): RectCollider {
+  const direction = config.direction ?? 'positiveZ';
+  const directionMultiplier = direction === 'negativeZ' ? -1 : 1;
+  const landingCenterZ =
+    config.basePosition.z +
+    directionMultiplier *
+      (config.step.run * config.step.count + config.landing.depth / 2);
+
+  return {
+    minX: config.basePosition.x - config.step.width / 2,
+    maxX: config.basePosition.x + config.step.width / 2,
+    minZ: landingCenterZ - config.landing.depth / 2,
+    maxZ: landingCenterZ + config.landing.depth / 2,
+  };
+}
+
 /**
  * Creates a rectangular staircase with uniform treads, landing, and structural supports.
  * The geometry is intentionally data-driven so future automation can adjust sizes or
@@ -110,22 +128,21 @@ export function createStaircase(config: StaircaseConfig): StaircaseBuildResult {
     config.landing.thickness,
     config.landing.depth
   );
+  const landingVisualBounds = computeStaircaseLandingBounds(config);
   const landing = new Mesh(landingGeometry, landingMaterial);
   landing.position.set(
-    basePosition.x,
+    (landingVisualBounds.minX + landingVisualBounds.maxX) / 2,
     basePosition.y + totalRise + config.landing.thickness / 2,
-    basePosition.z +
-      directionMultiplier *
-        (config.step.run * config.step.count + config.landing.depth / 2)
+    (landingVisualBounds.minZ + landingVisualBounds.maxZ) / 2
   );
   landing.name = 'StaircaseLanding';
   group.add(landing);
 
   colliders.push({
-    minX: landing.position.x - config.step.width / 2 + landingColliderInset,
-    maxX: landing.position.x + config.step.width / 2 - landingColliderInset,
-    minZ: landing.position.z - config.landing.depth / 2 + landingColliderInset,
-    maxZ: landing.position.z + config.landing.depth / 2 - landingColliderInset,
+    minX: landingVisualBounds.minX + landingColliderInset,
+    maxX: landingVisualBounds.maxX - landingColliderInset,
+    minZ: landingVisualBounds.minZ + landingColliderInset,
+    maxZ: landingVisualBounds.maxZ - landingColliderInset,
   });
 
   if (config.landing.guard && guardMaterial) {


### PR DESCRIPTION
### Motivation
- Eliminate visible z-fighting where the upper-floor tile slab overlaps the physical StaircaseLanding top surface by removing the coplanar overlap rather than applying rendering offsets.
- Keep movement, collision, navmesh, and POI behavior unchanged by making this strictly a visual/cutout fix.

### Description
- Add `computeStaircaseLandingBounds(...)` to derive the visible StaircaseLanding footprint from the staircase config and reuse it for landing placement and collider bounds. (`src/scene/structures/staircase.ts`)
- Subtract the staircase landing footprint from the upper-floor tiles by including that footprint in `upperLandingCutouts` so upper-floor tiles do not generate coplanar geometry over the landing. (`src/main.ts`)
- Update the landing mesh placement/collider calculation to use the new shared helper so visuals and cutouts share the same geometry source. (`src/scene/structures/staircase.ts`)
- Add a targeted regression test asserting that upper-floor tiles do not overlap the visible StaircaseLanding footprint and that the shoulder tiles meet the landing edge cleanly. (`src/scene/structures/__tests__/floorTiles.test.ts`)

### Testing
- Ran formatting: `npm run format:write` — passed.
- Ran linter: `npm run lint` — passed (initial import order warning surfaced and was addressed during edits).
- Unit tests: `npm run test:ci` — all tests passed (144 files, 1096 tests in the full suite during verification); targeted tests `src/scene/structures/__tests__/floorTiles.test.ts` and `src/tests/movement/stairLayout.test.ts` passed.
- Docs and links: `npm run docs:check` — docs check passed (link-check produced external fetch warnings as expected).
- Playwright E2E: installed browsers with `npx playwright install chromium` and host deps with `npx playwright install-deps chromium`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — the stairs roundtrip suite passed (8/8 tests).
- Build & smoke: `npm run build` and `npm run smoke` — both passed and smoke validated `dist` artifacts.
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

All automated checks required by the project were run and passed locally; the change is limited to visual geometry/cutout behavior and adds a unit regression to prevent reintroduction of coplanar overlap.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ca38f1684832f94205ad23225f7f6)