### PR TITLE
Fix upper-landing z-fighting and make collider debug labels visible

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2096,11 +2096,24 @@ function initializeImmersiveScene(
     minZ: stairLandingMinZ,
     maxZ: stairLandingMaxZ,
   };
+  const finalStairStepFootprint = {
+    minX: stairCenterX - stairHalfWidth,
+    maxX: stairCenterX + stairHalfWidth,
+    minZ: Math.min(
+      stairTopZ,
+      stairTopZ - stairLayout.directionMultiplier * stairRun
+    ),
+    maxZ: Math.max(
+      stairTopZ,
+      stairTopZ - stairLayout.directionMultiplier * stairRun
+    ),
+  };
   const upperLandingCutouts =
     upperLandingRoom && upperStairwellOpening
       ? {
           upperLanding: createUpperLandingFloorCutouts({
             staircaseLandingFootprint,
+            finalStairStepFootprint,
             stairwellOpening: upperStairwellOpening,
             hiddenRunVoidMinX: upperStairWestEgressBlockerMinX,
           }),

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -155,6 +155,8 @@ describe('createColliderVisualizer', () => {
       enabled: false,
       visibleColliderCount: 0,
       totalColliderCount: 3,
+      visibleLabelCount: 0,
+      totalLabelCount: 3,
     });
 
     visualizer.setEnabled(true);
@@ -162,10 +164,13 @@ describe('createColliderVisualizer', () => {
       enabled: true,
       visibleColliderCount: 2,
       totalColliderCount: 3,
+      visibleLabelCount: 2,
+      totalLabelCount: 3,
     });
 
     visualizer.setActiveFloor('upper');
     expect(visualizer.getState().visibleColliderCount).toBe(2);
+    expect(visualizer.getState().visibleLabelCount).toBe(2);
   });
 
   it('returns redacted metadata copies and non-raycasting meshes', () => {
@@ -223,7 +228,15 @@ describe('createColliderVisualizer', () => {
 
     expect(mesh.raycast({} as never, [] as never)).toBeUndefined();
     expect(label.raycast({} as never, [] as never)).toBeUndefined();
+    const labelMaterial = label.material as Material;
+
     expect(material.depthTest).toBe(false);
+    expect(label.renderOrder).toBeGreaterThan(mesh.renderOrder);
+    expect(label.frustumCulled).toBe(false);
+    expect(label.scale.x).toBeGreaterThan(2);
+    expect(label.position.y).toBeGreaterThan(mesh.position.y);
+    expect(labelMaterial.depthTest).toBe(false);
+    expect(labelMaterial.depthWrite).toBe(false);
   });
 
   it('keeps six-character IDs stable across four-character prefix collisions', () => {
@@ -628,6 +641,12 @@ describe('createColliderVisualizer', () => {
 
     visualizer.setEnabled(true);
     expect(labels.map((label) => label.visible)).toEqual([true, false]);
+    expect(visualizer.getState()).toMatchObject({
+      visibleColliderCount: 1,
+      totalColliderCount: 2,
+      visibleLabelCount: 1,
+      totalLabelCount: 2,
+    });
 
     visualizer.setActiveFloor('upper');
     expect(labels.map((label) => label.visible)).toEqual([false, true]);

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -39,6 +39,8 @@ export interface DebugColliderVisualizerState {
   enabled: boolean;
   visibleColliderCount: number;
   totalColliderCount: number;
+  visibleLabelCount: number;
+  totalLabelCount: number;
 }
 
 interface DebugColliderVisualEntry {
@@ -72,9 +74,9 @@ const LABEL_CANVAS_HEIGHT = 128;
 const LABEL_TEXT_MAX_WIDTH = LABEL_CANVAS_WIDTH - 48;
 const LABEL_FONT_MAX_SIZE = 54;
 const LABEL_FONT_MIN_SIZE = 28;
-const LABEL_SCALE_X = 1.15;
-const LABEL_SCALE_Y = 0.58;
-const LABEL_VERTICAL_GAP = 0.18;
+const LABEL_SCALE_X = 3.2;
+const LABEL_SCALE_Y = 1.6;
+const LABEL_VERTICAL_GAP = 0.65;
 const LABEL_PALETTE = [
   '#8BE9FD',
   '#F1FA8C',
@@ -366,13 +368,15 @@ const createColliderLabel = (
     color: texture ? 0xffffff : color,
     depthTest: false,
     depthWrite: false,
-    opacity: 0.95,
+    opacity: 0.98,
+    toneMapped: false,
     transparent: true,
     ...(texture ? { map: texture } : {}),
   });
   const label = new Sprite(material);
   label.name = `DebugColliderLabel:${id}`;
-  label.renderOrder = 10_001;
+  label.renderOrder = 20_001;
+  label.frustumCulled = false;
   label.scale.set(LABEL_SCALE_X, LABEL_SCALE_Y, 1);
   label.userData.debugOnly = true;
   label.userData.colliderDebugLabel = { id };
@@ -436,6 +440,7 @@ export function createColliderVisualizer(options: {
         depthWrite: false,
         opacity: 0.42,
         transparent: true,
+        toneMapped: false,
         wireframe: true,
       });
       const mesh = new Mesh(geometry, material);
@@ -444,7 +449,8 @@ export function createColliderVisualizer(options: {
       const baseElevation = collider.elevation ?? 0;
       mesh.position.set(centerX, baseElevation + height / 2, centerZ);
       mesh.name = getDebugColliderMeshName({ id, ...metadataWithoutId });
-      mesh.renderOrder = 10_000;
+      mesh.renderOrder = 20_000;
+      mesh.frustumCulled = false;
       mesh.userData.debugOnly = true;
       mesh.userData.colliderDebug = {
         id,
@@ -475,7 +481,7 @@ export function createColliderVisualizer(options: {
     applyVisibility();
   };
 
-  const getVisibleColliderCount = () =>
+  const getVisibleEntryCount = () =>
     enabled
       ? entries.filter((entry) =>
           isVisibleOnFloor(entry.metadata.floor, activeFloorId)
@@ -506,8 +512,10 @@ export function createColliderVisualizer(options: {
     getState() {
       return {
         enabled,
-        visibleColliderCount: getVisibleColliderCount(),
+        visibleColliderCount: getVisibleEntryCount(),
         totalColliderCount: entries.length,
+        visibleLabelCount: getVisibleEntryCount(),
+        totalLabelCount: entries.length,
       };
     },
     getColliders() {

--- a/src/scene/structures/upperLandingFloorCutouts.ts
+++ b/src/scene/structures/upperLandingFloorCutouts.ts
@@ -7,6 +7,12 @@ export interface UpperLandingFloorCutoutConfig {
   readonly staircaseLandingFootprint: Bounds2D;
   /** Shared stairwell void used by the upper landing floor tiles. */
   readonly stairwellOpening: Bounds2D;
+  /**
+   * Visible top footprint of the final stair tread. Its top face is coplanar
+   * with the underside of upper-floor tiles, so leaving a tile over this tread
+   * can produce a jagged z-fighting seam at the landing mouth.
+   */
+  readonly finalStairStepFootprint: Bounds2D;
   /** West edge of the hidden-run void after preserving the egress lane. */
   readonly hiddenRunVoidMinX: number;
 }
@@ -14,7 +20,8 @@ export interface UpperLandingFloorCutoutConfig {
 /**
  * Keeps upper landing floor tiles away from the physical staircase landing slab
  * while preserving the narrower hidden-run cutout that protects upstairs egress.
- * The first cutout removes the coplanar slab footprint; the second keeps the
+ * The first cutout removes the coplanar slab footprint; the second removes
+ * upper-floor tile undersides from the final top tread; the third keeps the
  * no-floor void open only where the hidden stair run should remain uncovered.
  */
 export function createUpperLandingFloorCutouts(
@@ -22,6 +29,7 @@ export function createUpperLandingFloorCutouts(
 ): RoomFloorCutout[] {
   return [
     { ...config.staircaseLandingFootprint },
+    { ...config.finalStairStepFootprint },
     {
       ...config.stairwellOpening,
       minX: config.hiddenRunVoidMinX,

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -57,12 +57,25 @@ describe('createUpperLandingFloorCutouts', () => {
       minZ: stairLayout.landingMinZ,
       maxZ: stairLayout.landingMaxZ,
     };
+    const finalStairStepFootprint = {
+      minX: STAIR_CENTER_X - STAIR_HALF_WIDTH,
+      maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH,
+      minZ: Math.min(
+        stairLayout.topZ,
+        stairLayout.topZ - stairLayout.directionMultiplier * STAIR_RUN
+      ),
+      maxZ: Math.max(
+        stairLayout.topZ,
+        stairLayout.topZ - stairLayout.directionMultiplier * STAIR_RUN
+      ),
+    };
     const westEgressLaneX =
       STAIR_CENTER_X - STAIR_HALF_WIDTH + PLAYER_RADIUS * 0.75;
     const hiddenRunVoidMinX = westEgressLaneX + PLAYER_RADIUS + 0.01;
 
     const cutouts = createUpperLandingFloorCutouts({
       staircaseLandingFootprint,
+      finalStairStepFootprint,
       stairwellOpening,
       hiddenRunVoidMinX,
     });
@@ -74,7 +87,8 @@ describe('createUpperLandingFloorCutouts', () => {
     });
 
     expect(cutouts[0]).toEqual(staircaseLandingFootprint);
-    expect(cutouts[1]).toEqual({
+    expect(cutouts[1]).toEqual(finalStairStepFootprint);
+    expect(cutouts[2]).toEqual({
       ...stairwellOpening,
       minX: hiddenRunVoidMinX,
     });
@@ -82,6 +96,61 @@ describe('createUpperLandingFloorCutouts', () => {
       floorTiles.tiles
         .filter((tile) => tile.roomId === 'upperLanding')
         .every((tile) => !overlaps(tile.bounds, staircaseLandingFootprint))
+    ).toBe(true);
+    expect(
+      floorTiles.tiles
+        .filter((tile) => tile.roomId === 'upperLanding')
+        .every((tile) => !overlaps(tile.bounds, finalStairStepFootprint))
+    ).toBe(true);
+
+    const upperFloorTileBottomY = 4.16 - 0.38;
+    const finalStairStepTopY = STAIR_STEP_COUNT * 0.42;
+    expect(upperFloorTileBottomY).toBeCloseTo(finalStairStepTopY);
+  });
+
+  it('prevents upper landing tiles from covering the final top tread underside seam', () => {
+    const finalTopTread = {
+      minX: 9.3,
+      maxX: 15.5,
+      minZ: -25.9,
+      maxZ: -24.2,
+    };
+    const cutouts = createUpperLandingFloorCutouts({
+      staircaseLandingFootprint: {
+        minX: 9.3,
+        maxX: 15.5,
+        minZ: -31.1,
+        maxZ: -25.9,
+      },
+      finalStairStepFootprint: finalTopTread,
+      stairwellOpening: {
+        minX: 8.9,
+        maxX: 15.9,
+        minZ: -31.9,
+        maxZ: -24.2,
+      },
+      hiddenRunVoidMinX: 10.62,
+    });
+
+    const floorTiles = createRoomFloorTiles(
+      [
+        {
+          id: 'upperLanding',
+          name: 'Upper Landing',
+          bounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+          doorways: [],
+        },
+      ],
+      {
+        material: new MeshStandardMaterial(),
+        elevation: 4.16,
+        thickness: 0.38,
+        cutoutsByRoom: { upperLanding: cutouts },
+      }
+    );
+
+    expect(
+      floorTiles.tiles.every((tile) => !overlaps(tile.bounds, finalTopTread))
     ).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- A jagged/z-fighting seam near the upper stair landing was traced to upper-floor tiles covering the final stair top-tread underside (coplanar surfaces), not the main StaircaseLanding slab alone.
- Collider debug wireframes were visible but short hex ID labels were difficult or invisible in the orthographic immersive view due to scale, depth testing, and culling choices.

### Description
- Prevent upper-floor tiles from covering the final top tread by adding a `finalStairStepFootprint` cutout and wiring it into `createUpperLandingFloorCutouts(...)` and `createRoomFloorTiles(...)` (files changed: `src/main.ts`, `src/scene/structures/upperLandingFloorCutouts.ts`).
- Improve collider label visibility by increasing label scale and vertical gap, disabling depth test/write for labels, disabling frustum culling, raising renderOrder, and ensuring meshes/labels are tone-mapped-consistent (file changed: `src/scene/debug/colliderVisualizer.ts`).
- Add label visibility counters to the visualizer state (`visibleLabelCount`, `totalLabelCount`) and expose them through the debug API to make verification deterministic (file changed: `src/scene/debug/colliderVisualizer.ts`).
- Add/extend unit tests covering the new floor-tread cutout and label metadata/visibility (files changed: `src/tests/upperLandingFloorCutouts.test.ts`, `src/scene/debug/__tests__/colliderVisualizer.test.ts`).

### Testing
- Ran formatting: `npm run format:write` — success.
- Ran lint and unit tests: `npm run lint` and `npm run test:ci` — all Vitest suites passed (145 files, 1097 tests in full run; focused visualizer tests passed as well).
- Ran docs check: `npm run docs:check` — success (link checks emit warnings for unreachable external links but did not fail the check).
- Ran Playwright stairs roundtrip: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — 8 tests passed locally after installing Playwright browsers and deps; test run validated stair/landing behavior and that the debug colliders/labels no longer interfere with movement logic.
- Built and smoke-checked production bundle: `npm run build` and `npm run smoke` — success.
- Manual preview & API check: launched preview and exercised `/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1`; verified `window.portfolio.debugColliders.getColliders()` returns stable IDs and `getBlockingCollidersAt(...)` includes IDs, and labels are visible in the upper-landing view (screenshot produced during verification).

All automated checks that could run in this environment passed. Follow-ups: none required for the immediate fix; visual/design tweaks for label art/size can be revisited if different camera framings require further tuning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cbb209060832fbc19e69fd20eab40)