### PR TITLE
Tune collider debug label scale and wireframe colors

### DIFF
--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -241,6 +241,35 @@ describe('createColliderVisualizer', () => {
     expect(labelMaterial.depthWrite).toBe(false);
   });
 
+  it('keeps explicit collider color overrides synced between wireframes and labels', () => {
+    const visualizer = createColliderVisualizer({
+      activeFloorId: 'ground',
+      enabled: true,
+    });
+
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'static',
+        name: 'custom-color',
+        bounds: collider,
+        color: 'hotpink',
+      },
+    ]);
+
+    const mesh = visualizer.group.children.find(
+      (child) => child.type === 'Mesh'
+    ) as Mesh;
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    ) as Sprite;
+    const material = mesh.material as MeshBasicMaterial;
+    const labelMaterial = label.material as SpriteMaterial;
+
+    expect(material.color.getStyle()).toBe('rgb(255,105,180)');
+    expect(labelMaterial.color.getHex()).toBe(material.color.getHex());
+  });
+
   it('keeps six-character IDs stable across four-character prefix collisions', () => {
     const colliders = [
       {

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -1,4 +1,4 @@
-import type { Material, Mesh, Sprite } from 'three';
+import type { Mesh, MeshBasicMaterial, Sprite, SpriteMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -224,17 +224,19 @@ describe('createColliderVisualizer', () => {
     const label = visualizer.group.children.find(
       (child) => child.type === 'Sprite'
     ) as Sprite;
-    const material = mesh.material as Material;
+    const material = mesh.material as MeshBasicMaterial;
 
     expect(mesh.raycast({} as never, [] as never)).toBeUndefined();
     expect(label.raycast({} as never, [] as never)).toBeUndefined();
-    const labelMaterial = label.material as Material;
+    const labelMaterial = label.material as SpriteMaterial;
 
     expect(material.depthTest).toBe(false);
     expect(label.renderOrder).toBeGreaterThan(mesh.renderOrder);
     expect(label.frustumCulled).toBe(false);
-    expect(label.scale.x).toBeGreaterThan(2);
+    expect(label.scale.x).toBeCloseTo(1.6);
+    expect(label.scale.y).toBeCloseTo(0.8);
     expect(label.position.y).toBeGreaterThan(mesh.position.y);
+    expect(material.color.getHex()).toBe(labelMaterial.color.getHex());
     expect(labelMaterial.depthTest).toBe(false);
     expect(labelMaterial.depthWrite).toBe(false);
   });

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -62,7 +62,6 @@ export interface ColliderVisualizer {
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
-const DEFAULT_COLOR = 0x66e6ff;
 const DEBUG_ID_MIN_LENGTH = 4;
 const DEBUG_ID_MAX_LENGTH = 6;
 const DEBUG_ID_PRECISION = 2;
@@ -74,9 +73,9 @@ const LABEL_CANVAS_HEIGHT = 128;
 const LABEL_TEXT_MAX_WIDTH = LABEL_CANVAS_WIDTH - 48;
 const LABEL_FONT_MAX_SIZE = 54;
 const LABEL_FONT_MIN_SIZE = 28;
-const LABEL_SCALE_X = 3.2;
-const LABEL_SCALE_Y = 1.6;
-const LABEL_VERTICAL_GAP = 0.65;
+const LABEL_SCALE_X = 1.6;
+const LABEL_SCALE_Y = 0.8;
+const LABEL_VERTICAL_GAP = 0.5;
 const LABEL_PALETTE = [
   '#8BE9FD',
   '#F1FA8C',
@@ -85,12 +84,6 @@ const LABEL_PALETTE = [
   '#BD93F9',
   '#FFB86C',
 ];
-const FLOOR_COLORS: Record<DebugColliderFloor, number> = {
-  ground: 0x2ee66b,
-  upper: 0xf7c948,
-  all: 0x66e6ff,
-};
-
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
   minX: bounds.minX,
   maxX: bounds.maxX,
@@ -434,8 +427,9 @@ export function createColliderVisualizer(options: {
       );
       const height = collider.height ?? DEFAULT_HEIGHT;
       const geometry = new BoxGeometry(width, height, depth);
+      const labelColor = LABEL_PALETTE[getLabelPaletteIndex(id)];
       const material = new MeshBasicMaterial({
-        color: collider.color ?? FLOOR_COLORS[collider.floor] ?? DEFAULT_COLOR,
+        color: labelColor,
         depthTest: false,
         depthWrite: false,
         opacity: 0.42,
@@ -460,7 +454,6 @@ export function createColliderVisualizer(options: {
       };
       mesh.raycast = () => undefined;
 
-      const labelColor = LABEL_PALETTE[getLabelPaletteIndex(id)];
       const label = createColliderLabel(id, labelColor);
       label.position.set(
         centerX,

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -1,6 +1,7 @@
 import {
   BoxGeometry,
   CanvasTexture,
+  Color,
   Group,
   Mesh,
   MeshBasicMaterial,
@@ -288,6 +289,9 @@ const drawRoundedRect = (
   context.quadraticCurveTo(x, y, x + radius, y);
 };
 
+const getLabelColorStyle = (color: ColorRepresentation): string =>
+  `#${new Color(color).getHexString()}`;
+
 const createLabelTexture = (
   id: string,
   color: string
@@ -427,7 +431,9 @@ export function createColliderVisualizer(options: {
       );
       const height = collider.height ?? DEFAULT_HEIGHT;
       const geometry = new BoxGeometry(width, height, depth);
-      const labelColor = LABEL_PALETTE[getLabelPaletteIndex(id)];
+      const labelColor = getLabelColorStyle(
+        collider.color ?? LABEL_PALETTE[getLabelPaletteIndex(id)]
+      );
       const material = new MeshBasicMaterial({
         color: labelColor,
         depthTest: false,


### PR DESCRIPTION
### Motivation
- Collider ID labels were visually too large in the immersive orthographic view and wireframe colors differed from label colors, making it hard to pair labels with colliders.
- The intent is to reduce visual clutter while keeping the existing debug API and deterministic ID/color behavior.

### Description
- Halved the in-world label footprint by reducing `LABEL_SCALE_X` and `LABEL_SCALE_Y` and slightly tightened `LABEL_VERTICAL_GAP` to keep labels above wireframes without overlap (`src/scene/debug/colliderVisualizer.ts`).
- Color-match each collider mesh to its ID-derived palette by reusing the label palette index (`LABEL_PALETTE[getLabelPaletteIndex(id)]`) as the `MeshBasicMaterial` color for wireframes, replacing the previous floor/category color only for debug rendering (`src/scene/debug/colliderVisualizer.ts`).
- Preserved debug rendering flags and behavior including `wireframe`, `opacity`, `depthTest: false`, `depthWrite: false`, `toneMapped: false`, `renderOrder`, and `frustumCulled` semantics.
- Updated the visualizer tests to assert the new label scales and that the collider mesh material color matches the label color, and adjusted type imports for the stronger assertions (`src/scene/debug/__tests__/colliderVisualizer.test.ts`).

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully.
- Ran the focused unit test with `npm run test:ci -- src/scene/debug/__tests__/colliderVisualizer.test.ts`, which passed, and then `npm run test:ci` for the full suite, which also passed.
- Installed Playwright browsers and system deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed (8 tests).
- Built and smoke-checked the app with `npm run build` and `npm run smoke`, and ran `npm run docs:check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2da0a55e84832f9eb4c434104e327f)