### PR TITLE
Add solid debug IDs and independent collider ID toggle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -116,6 +116,11 @@ import {
   type DebugColliderVisualizerState,
 } from './scene/debug/colliderVisualizer';
 import {
+  createSolidVisualizer,
+  type DebugSolidMetadata,
+  type DebugSolidVisualizerState,
+} from './scene/debug/solidVisualizer';
+import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
@@ -478,6 +483,8 @@ const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
+const DEBUG_COLLIDER_IDS_STORAGE_KEY = 'danielsmith.io::debugColliderIds::v1';
+const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
 const isDebugUrlValueIn = (
@@ -587,6 +594,7 @@ declare global {
       debugColliders?: {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
+        setIdsEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
         getBlockingCollidersAt(target: {
           x: number;
@@ -594,6 +602,12 @@ declare global {
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+      };
+      debugSolids?: {
+        getState(): DebugSolidVisualizerState;
+        setEnabled(enabled: boolean): void;
+        getSolids(): DebugSolidMetadata[];
+        getSolidById(id: unknown): DebugSolidMetadata | undefined;
       };
       debugCoordinates?: {
         getState(): {
@@ -1402,8 +1416,42 @@ function initializeImmersiveScene(
   let debugCollidersEnabled = debugCollidersUrlDisabled
     ? false
     : debugCollidersUrlEnabled || debugCollidersStoredEnabled;
+  const debugColliderIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugColliderIds');
+  const debugColliderIdsUrlEnabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugColliderIdsUrlDisabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugColliderIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_COLLIDER_IDS_STORAGE_KEY) !== '0';
+  let debugColliderIdsEnabled = debugColliderIdsUrlDisabled
+    ? false
+    : debugColliderIdsUrlEnabled || debugColliderIdsStoredEnabled;
+  const debugSolidIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugSolidIds');
+  const debugSolidIdsUrlEnabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugSolidIdsUrlDisabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugSolidIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_SOLID_IDS_STORAGE_KEY) === '1';
+  let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
+    ? false
+    : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
+  let debugColliderIdsControl: HTMLButtonElement | null = null;
+  let debugSolidIdsControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -4174,6 +4222,7 @@ function initializeImmersiveScene(
   const colliderVisualizer = createColliderVisualizer({
     activeFloorId,
     enabled: debugCollidersEnabled,
+    idsEnabled: debugColliderIdsEnabled,
   });
   colliderVisualizer.register([
     ...createDebugColliderRegistrations(groundColliders, {
@@ -4194,6 +4243,14 @@ function initializeImmersiveScene(
     }),
   ]);
   scene.add(colliderVisualizer.group);
+  const solidVisualizer = createSolidVisualizer({
+    enabled: debugSolidIdsEnabled,
+    reservedIds: colliderVisualizer
+      .getColliders()
+      .map((collider) => collider.id),
+  });
+  solidVisualizer.register(scene);
+  scene.add(solidVisualizer.group);
 
   const containsRectPoint = (
     rect: { minX: number; maxX: number; minZ: number; maxZ: number },
@@ -4415,6 +4472,50 @@ function initializeImmersiveScene(
     debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugColliderIdsControl = () => {
+    if (!debugColliderIdsControl) {
+      return;
+    }
+    const label = debugColliderIdsEnabled
+      ? 'Collider IDs on'
+      : 'Collider IDs off';
+    const description = debugColliderIdsEnabled
+      ? 'Shows collider ID labels when the collider overlay is on.'
+      : 'Hides collider ID labels while keeping collider wireframes available.';
+    debugColliderIdsControl.textContent = label;
+    debugColliderIdsControl.dataset.state = debugColliderIdsEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugColliderIdsControl.setAttribute(
+      'aria-pressed',
+      debugColliderIdsEnabled ? 'true' : 'false'
+    );
+    debugColliderIdsControl.setAttribute('aria-label', description);
+    debugColliderIdsControl.title = description;
+    debugColliderIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const refreshDebugSolidIdsControl = () => {
+    if (!debugSolidIdsControl) {
+      return;
+    }
+    const label = debugSolidIdsEnabled ? 'Solid IDs on' : 'Solid IDs off';
+    const description = debugSolidIdsEnabled
+      ? 'Shows stable solid ID labels and wireframes for scene meshes.'
+      : 'Hides stable solid ID labels and wireframes.';
+    debugSolidIdsControl.textContent = label;
+    debugSolidIdsControl.dataset.state = debugSolidIdsEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugSolidIdsControl.setAttribute(
+      'aria-pressed',
+      debugSolidIdsEnabled ? 'true' : 'false'
+    );
+    debugSolidIdsControl.setAttribute('aria-label', description);
+    debugSolidIdsControl.title = description;
+    debugSolidIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
   const setDebugCollidersEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4430,6 +4531,44 @@ function initializeImmersiveScene(
         );
       } catch (error) {
         console.warn('Failed to persist debug collider preference.', error);
+      }
+    }
+  };
+
+  const setDebugColliderIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugColliderIdsEnabled = enabled;
+    colliderVisualizer.setIdsEnabled(enabled);
+    refreshDebugColliderIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_COLLIDER_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug collider ID preference.', error);
+      }
+    }
+  };
+
+  const setDebugSolidIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugSolidIdsEnabled = enabled;
+    solidVisualizer.setEnabled(enabled);
+    refreshDebugSolidIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_SOLID_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug solid ID preference.', error);
       }
     }
   };
@@ -4464,6 +4603,8 @@ function initializeImmersiveScene(
 
   const refreshDebugCollidersStrings = () => {
     refreshDebugCollidersControl();
+    refreshDebugColliderIdsControl();
+    refreshDebugSolidIdsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4491,6 +4632,26 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugCollidersControl);
   registerHudControlElement(debugCollidersControl);
   refreshDebugCollidersControl();
+
+  debugColliderIdsControl = document.createElement('button');
+  debugColliderIdsControl.type = 'button';
+  debugColliderIdsControl.className = 'tour-toggle debug-collider-ids-toggle';
+  debugColliderIdsControl.addEventListener('click', () => {
+    setDebugColliderIdsEnabled(!debugColliderIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugColliderIdsControl);
+  registerHudControlElement(debugColliderIdsControl);
+  refreshDebugColliderIdsControl();
+
+  debugSolidIdsControl = document.createElement('button');
+  debugSolidIdsControl.type = 'button';
+  debugSolidIdsControl.className = 'tour-toggle debug-solid-ids-toggle';
+  debugSolidIdsControl.addEventListener('click', () => {
+    setDebugSolidIdsEnabled(!debugSolidIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugSolidIdsControl);
+  registerHudControlElement(debugSolidIdsControl);
+  refreshDebugSolidIdsControl();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4521,9 +4682,21 @@ function initializeImmersiveScene(
     setEnabled: (enabled: boolean) => {
       setDebugCollidersEnabled(enabled);
     },
+    setIdsEnabled: (enabled: boolean) => {
+      setDebugColliderIdsEnabled(enabled);
+    },
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+  };
+
+  window.portfolio.debugSolids = {
+    getState: () => solidVisualizer.getState(),
+    setEnabled: (enabled: boolean) => {
+      setDebugSolidIdsEnabled(enabled);
+    },
+    getSolids: () => solidVisualizer.getSolids(),
+    getSolidById: (id: unknown) => solidVisualizer.getSolidById(id),
   };
 
   window.portfolio.debugCoordinates = {
@@ -6021,6 +6194,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugColliders) {
       delete window.portfolio.debugColliders;
     }
+    if (window.portfolio?.debugSolids) {
+      delete window.portfolio.debugSolids;
+    }
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
@@ -6043,6 +6219,14 @@ function initializeImmersiveScene(
       debugCollidersControl.remove();
       debugCollidersControl = null;
     }
+    if (debugColliderIdsControl) {
+      debugColliderIdsControl.remove();
+      debugColliderIdsControl = null;
+    }
+    if (debugSolidIdsControl) {
+      debugSolidIdsControl.remove();
+      debugSolidIdsControl = null;
+    }
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
@@ -6050,6 +6234,7 @@ function initializeImmersiveScene(
       debugCoordinatesRows.clear();
     }
     colliderVisualizer.dispose();
+    solidVisualizer.dispose();
     movementLegend?.dispose();
     narrationPreference.dispose();
     if (proceduralNarrator) {

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -153,6 +153,7 @@ describe('createColliderVisualizer', () => {
 
     expect(visualizer.getState()).toEqual({
       enabled: false,
+      idsEnabled: true,
       visibleColliderCount: 0,
       totalColliderCount: 3,
       visibleLabelCount: 0,
@@ -162,6 +163,7 @@ describe('createColliderVisualizer', () => {
     visualizer.setEnabled(true);
     expect(visualizer.getState()).toEqual({
       enabled: true,
+      idsEnabled: true,
       visibleColliderCount: 2,
       totalColliderCount: 3,
       visibleLabelCount: 2,
@@ -268,6 +270,43 @@ describe('createColliderVisualizer', () => {
 
     expect(material.color.getStyle()).toBe('rgb(255,105,180)');
     expect(labelMaterial.color.getHex()).toBe(material.color.getHex());
+  });
+
+  it('hides IDs independently while collider wireframes remain visible', () => {
+    const visualizer = createColliderVisualizer({
+      activeFloorId: 'ground',
+      enabled: true,
+    });
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'ground-0',
+        bounds: collider,
+      },
+    ]);
+
+    const mesh = visualizer.group.children.find(
+      (child) => child.type === 'Mesh'
+    ) as Mesh;
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    ) as Sprite;
+
+    visualizer.setIdsEnabled(false);
+
+    expect(mesh.visible).toBe(true);
+    expect(label.visible).toBe(false);
+    expect(visualizer.getState()).toMatchObject({
+      enabled: true,
+      idsEnabled: false,
+      visibleColliderCount: 1,
+      visibleLabelCount: 0,
+    });
+
+    visualizer.setEnabled(false);
+    expect(mesh.visible).toBe(false);
+    expect(label.visible).toBe(false);
   });
 
   it('keeps six-character IDs stable across four-character prefix collisions', () => {

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -1,0 +1,152 @@
+import {
+  BoxGeometry,
+  Group,
+  LineBasicMaterial,
+  Mesh,
+  MeshBasicMaterial,
+  Sprite,
+  SpriteMaterial,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createColliderDebugId } from '../colliderVisualizer';
+import { createSolidDebugId, createSolidVisualizer } from '../solidVisualizer';
+
+const createRoot = () => {
+  const root = new Group();
+  root.name = 'Root';
+  const room = new Group();
+  room.name = 'Room';
+  const mesh = new Mesh(
+    new BoxGeometry(2, 1, 3),
+    new MeshBasicMaterial({ color: '#336699' })
+  );
+  mesh.name = 'Sofa';
+  mesh.position.set(1, 0.5, 2);
+  room.add(mesh);
+  root.add(room);
+  return { root, mesh };
+};
+
+describe('createSolidDebugId', () => {
+  const metadata = {
+    name: 'Sofa',
+    path: 'Root/Room/Sofa',
+    parentPath: 'Root/Room',
+    meshType: 'Mesh',
+    bounds: {
+      min: { x: 0, y: 0, z: 0.5 },
+      max: { x: 2, y: 1, z: 3.5 },
+    },
+    materialSummary: 'MeshBasicMaterial:#336699',
+  };
+
+  it('is deterministic, uppercase hex, and changes with meaningful metadata', () => {
+    expect(createSolidDebugId(metadata)).toBe(createSolidDebugId(metadata));
+    expect(createSolidDebugId(metadata)).toMatch(/^[0-9A-F]{6}$/);
+    expect(createSolidDebugId(metadata)).not.toBe(
+      createSolidDebugId({ ...metadata, path: 'Root/Room/Changed' })
+    );
+  });
+
+  it('avoids collider IDs supplied by the same debug session', () => {
+    const colliderId = createColliderDebugId({
+      floor: 'ground',
+      category: 'walls',
+      name: 'GroundWallWest',
+      bounds: { minX: 1, maxX: 3, minZ: 2, maxZ: 5 },
+    });
+
+    expect(createSolidDebugId(metadata, new Set([colliderId]))).not.toBe(
+      colliderId
+    );
+  });
+});
+
+describe('createSolidVisualizer', () => {
+  it('registers visible mesh solids and excludes debug-only meshes', () => {
+    const { root } = createRoot();
+    const debugOnly = new Mesh(
+      new BoxGeometry(1, 1, 1),
+      new MeshBasicMaterial()
+    );
+    debugOnly.name = 'DebugOnly';
+    debugOnly.userData.debugOnly = true;
+    root.add(debugOnly);
+    const debugOnlyGroup = new Group();
+    debugOnlyGroup.userData.debugOnly = true;
+    debugOnlyGroup.add(
+      new Mesh(new BoxGeometry(1, 1, 1), new MeshBasicMaterial())
+    );
+    root.add(debugOnlyGroup);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(root);
+
+    expect(visualizer.getState()).toEqual({
+      enabled: true,
+      visibleSolidCount: 1,
+      totalSolidCount: 1,
+      visibleLabelCount: 1,
+      totalLabelCount: 1,
+    });
+    expect(visualizer.getSolids()[0]).toMatchObject({
+      name: 'Sofa',
+      path: 'Root/Room/Sofa',
+      parentPath: 'Root/Room',
+      meshType: 'Mesh',
+    });
+  });
+
+  it('returns metadata copies and finds solids by ID', () => {
+    const { root } = createRoot();
+    const visualizer = createSolidVisualizer();
+    visualizer.register(root);
+    const solid = visualizer.getSolids()[0];
+    solid.bounds.min.x = 99;
+
+    expect(visualizer.getSolids()[0].bounds.min.x).not.toBe(99);
+    expect(visualizer.getSolidById(solid.id)?.id).toBe(solid.id);
+    expect(visualizer.getSolidById(solid.id.toLowerCase())?.id).toBe(solid.id);
+    expect(visualizer.getSolidById(null)).toBeUndefined();
+  });
+
+  it('keeps IDs unique and separate from reserved collider IDs', () => {
+    const { root } = createRoot();
+    const colliderId = createColliderDebugId({
+      floor: 'ground',
+      category: 'walls',
+      name: 'GroundWallWest',
+      bounds: { minX: 1, maxX: 3, minZ: 2, maxZ: 5 },
+    });
+    const visualizer = createSolidVisualizer({ reservedIds: [colliderId] });
+    visualizer.register(root);
+
+    const ids = visualizer.getSolids().map((solid) => solid.id);
+    expect(ids).not.toContain(colliderId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('creates non-raycasting debug-only wireframes and matching labels', () => {
+    const { root } = createRoot();
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(root);
+
+    const wireframe = visualizer.group.children.find(
+      (child) => child.type === 'LineSegments'
+    ) as Mesh;
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    ) as Sprite;
+    const wireframeMaterial = wireframe.material as LineBasicMaterial;
+    const labelMaterial = label.material as SpriteMaterial;
+
+    expect(wireframe.userData.debugOnly).toBe(true);
+    expect(label.userData.debugOnly).toBe(true);
+    expect(wireframe.raycast({} as never, [] as never)).toBeUndefined();
+    expect(label.raycast({} as never, [] as never)).toBeUndefined();
+    expect(wireframeMaterial.color.getHex()).toBe(labelMaterial.color.getHex());
+    expect(wireframeMaterial.depthTest).toBe(false);
+    expect(labelMaterial.depthTest).toBe(false);
+  });
+});

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -15,6 +15,13 @@ import type { RectCollider } from '../../systems/collision';
 import type { FloorId } from '../../systems/movement/stairs';
 
 import { getDeclaredColliderDebugId } from './colliderDebugIds';
+import {
+  DEBUG_ID_MAX_LENGTH,
+  DEBUG_ID_PRECISION,
+  allocateDebugId,
+  getDebugHash,
+  roundDebugValue,
+} from './debugIds';
 
 export type DebugColliderFloor = FloorId | 'all';
 
@@ -38,6 +45,7 @@ export interface DebugColliderRegistration {
 
 export interface DebugColliderVisualizerState {
   enabled: boolean;
+  idsEnabled: boolean;
   visibleColliderCount: number;
   totalColliderCount: number;
   visibleLabelCount: number;
@@ -47,13 +55,14 @@ export interface DebugColliderVisualizerState {
 interface DebugColliderVisualEntry {
   metadata: DebugColliderMetadata;
   mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
-  label: Sprite<SpriteMaterial>;
+  label: Sprite;
 }
 
 export interface ColliderVisualizer {
   readonly group: Group;
   register(colliders: readonly DebugColliderRegistration[]): void;
   setEnabled(enabled: boolean): void;
+  setIdsEnabled(enabled: boolean): void;
   setActiveFloor(floorId: FloorId): void;
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
@@ -63,9 +72,6 @@ export interface ColliderVisualizer {
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
-const DEBUG_ID_MIN_LENGTH = 4;
-const DEBUG_ID_MAX_LENGTH = 6;
-const DEBUG_ID_PRECISION = 2;
 // Keep the visible primary ID namespaced from the raw metadata hash so
 // historical raw-prefix collisions do not decide screenshot-visible labels.
 const DEBUG_ID_PRIMARY_SALT = 'debug-id:v3';
@@ -97,9 +103,6 @@ const isVisibleOnFloor = (
   activeFloorId: FloorId
 ): boolean => colliderFloor === 'all' || colliderFloor === activeFloorId;
 
-const roundDebugValue = (value: number): number =>
-  Math.round(value * 10 ** DEBUG_ID_PRECISION) / 10 ** DEBUG_ID_PRECISION;
-
 const normalizeBoundsForId = (bounds: RectCollider): string =>
   [bounds.minX, bounds.maxX, bounds.minZ, bounds.maxZ]
     .map((value) => roundDebugValue(value).toFixed(DEBUG_ID_PRECISION))
@@ -115,29 +118,7 @@ const getColliderDebugSeed = (
     normalizeBoundsForId(metadata.bounds),
   ].join('|');
 
-const getStableDebugHashValue = (input: string): number => {
-  let low = 0xdeadbeef ^ input.length;
-  let high = 0x41c6ce57 ^ input.length;
-
-  for (let index = 0; index < input.length; index += 1) {
-    const charCode = input.charCodeAt(index);
-    low = Math.imul(low ^ charCode, 2_654_435_761);
-    high = Math.imul(high ^ charCode, 1_597_334_677);
-  }
-
-  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
-  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
-  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
-  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
-
-  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
-};
-
-const getColliderDebugHash = (seed: string): string =>
-  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
-    .toString(16)
-    .toUpperCase()
-    .padStart(DEBUG_ID_MAX_LENGTH, '0');
+const getColliderDebugHash = (seed: string): string => getDebugHash(seed);
 
 const getColliderDebugPrimaryId = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
@@ -146,30 +127,13 @@ const getColliderDebugPrimaryId = (
   getDeclaredColliderDebugId(metadata) ??
   getColliderDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`);
 
-const getColliderDebugIdCandidates = (seed: string): string[] => {
-  const hash = getColliderDebugHash(seed);
-  const candidates: string[] = [];
-  for (
-    let length = DEBUG_ID_MIN_LENGTH;
-    length <= DEBUG_ID_MAX_LENGTH;
-    length += 1
-  ) {
-    candidates.push(hash.slice(0, length));
-  }
-  return candidates;
-};
-
 const createColliderDebugIdFromMetadata = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
   usedIds: ReadonlySet<string>,
   idSeed = getColliderDebugSeed(metadata)
 ): string => {
   const primaryCandidate = getColliderDebugPrimaryId(metadata, idSeed);
-  if (!usedIds.has(primaryCandidate)) {
-    return primaryCandidate;
-  }
-
-  return getColliderDebugRetryId(idSeed, new Set(usedIds));
+  return allocateDebugId(primaryCandidate, idSeed, usedIds);
 };
 
 export function createColliderDebugId(
@@ -178,27 +142,6 @@ export function createColliderDebugId(
 ): string {
   return createColliderDebugIdFromMetadata(metadata, usedIds);
 }
-
-const getColliderDebugRetryId = (
-  seed: string,
-  usedIds: Set<string>
-): string => {
-  for (
-    let retryIndex = 1;
-    retryIndex < Number.MAX_SAFE_INTEGER;
-    retryIndex += 1
-  ) {
-    for (const candidate of getColliderDebugIdCandidates(
-      `${seed}|retry:${retryIndex}`
-    )) {
-      if (!usedIds.has(candidate)) {
-        return candidate;
-      }
-    }
-  }
-
-  throw new Error('Unable to allocate a short collider debug ID');
-};
 
 const allocateColliderDebugIds = (
   metadataList: readonly Omit<DebugColliderMetadata, 'id'>[],
@@ -356,10 +299,7 @@ const createLabelTexture = (
   return texture;
 };
 
-const createColliderLabel = (
-  id: string,
-  color: string
-): Sprite<SpriteMaterial> => {
+const createColliderLabel = (id: string, color: string): Sprite => {
   const texture = createLabelTexture(id, color);
   const material = new SpriteMaterial({
     color: texture ? 0xffffff : color,
@@ -387,6 +327,7 @@ const getDebugColliderMeshName = (metadata: DebugColliderMetadata): string =>
 export function createColliderVisualizer(options: {
   activeFloorId: FloorId;
   enabled?: boolean;
+  idsEnabled?: boolean;
 }): ColliderVisualizer {
   const group = new Group();
   group.name = 'DebugColliderVisualizer';
@@ -395,6 +336,7 @@ export function createColliderVisualizer(options: {
 
   const entries: DebugColliderVisualEntry[] = [];
   let enabled = options.enabled ?? false;
+  let idsEnabled = options.idsEnabled ?? true;
   let activeFloorId = options.activeFloorId;
 
   const applyVisibility = () => {
@@ -403,7 +345,7 @@ export function createColliderVisualizer(options: {
       const visible =
         enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
       entry.mesh.visible = visible;
-      entry.label.visible = visible;
+      entry.label.visible = visible && idsEnabled;
     }
   };
 
@@ -504,6 +446,10 @@ export function createColliderVisualizer(options: {
       enabled = next;
       applyVisibility();
     },
+    setIdsEnabled(next: boolean) {
+      idsEnabled = next;
+      applyVisibility();
+    },
     setActiveFloor(next: FloorId) {
       activeFloorId = next;
       applyVisibility();
@@ -511,9 +457,10 @@ export function createColliderVisualizer(options: {
     getState() {
       return {
         enabled,
+        idsEnabled,
         visibleColliderCount: getVisibleEntryCount(),
         totalColliderCount: entries.length,
-        visibleLabelCount: getVisibleEntryCount(),
+        visibleLabelCount: idsEnabled ? getVisibleEntryCount() : 0,
         totalLabelCount: entries.length,
       };
     },

--- a/src/scene/debug/debugIds.ts
+++ b/src/scene/debug/debugIds.ts
@@ -1,0 +1,69 @@
+export const DEBUG_ID_MIN_LENGTH = 4;
+export const DEBUG_ID_MAX_LENGTH = 6;
+export const DEBUG_ID_PRECISION = 2;
+
+export const roundDebugValue = (value: number): number =>
+  Math.round(value * 10 ** DEBUG_ID_PRECISION) / 10 ** DEBUG_ID_PRECISION;
+
+export const getStableDebugHashValue = (input: string): number => {
+  let low = 0xdeadbeef ^ input.length;
+  let high = 0x41c6ce57 ^ input.length;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const charCode = input.charCodeAt(index);
+    low = Math.imul(low ^ charCode, 2_654_435_761);
+    high = Math.imul(high ^ charCode, 1_597_334_677);
+  }
+
+  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
+  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
+  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
+  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
+
+  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
+};
+
+export const getDebugHash = (seed: string): string =>
+  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
+    .toString(16)
+    .toUpperCase()
+    .padStart(DEBUG_ID_MAX_LENGTH, '0');
+
+export const getDebugIdCandidates = (seed: string): string[] => {
+  const hash = getDebugHash(seed);
+  const candidates: string[] = [];
+  for (
+    let length = DEBUG_ID_MIN_LENGTH;
+    length <= DEBUG_ID_MAX_LENGTH;
+    length += 1
+  ) {
+    candidates.push(hash.slice(0, length));
+  }
+  return candidates;
+};
+
+export const allocateDebugId = (
+  primaryCandidate: string,
+  retrySeed: string,
+  usedIds: ReadonlySet<string>
+): string => {
+  if (!usedIds.has(primaryCandidate)) {
+    return primaryCandidate;
+  }
+
+  for (
+    let retryIndex = 1;
+    retryIndex < Number.MAX_SAFE_INTEGER;
+    retryIndex += 1
+  ) {
+    for (const candidate of getDebugIdCandidates(
+      `${retrySeed}|retry:${retryIndex}`
+    )) {
+      if (!usedIds.has(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  throw new Error('Unable to allocate a short debug ID');
+};

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -1,0 +1,410 @@
+import {
+  Box3,
+  CanvasTexture,
+  Color,
+  Group,
+  LineBasicMaterial,
+  LineSegments,
+  Mesh,
+  Sprite,
+  SpriteMaterial,
+  Vector3,
+  WireframeGeometry,
+  type BufferGeometry,
+  type Material,
+  type Object3D,
+} from 'three';
+
+import { allocateDebugId, getDebugHash, roundDebugValue } from './debugIds';
+
+interface DebugSolidEntry {
+  metadata: DebugSolidMetadata;
+  wireframe: LineSegments<WireframeGeometry, LineBasicMaterial>;
+  label: Sprite;
+}
+
+export interface DebugSolidBounds {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+export interface DebugSolidMetadata {
+  id: string;
+  name: string;
+  path: string;
+  parentPath: string;
+  meshType: string;
+  bounds: DebugSolidBounds;
+  geometrySignature?: string;
+  materialSummary?: string;
+}
+
+export interface DebugSolidVisualizerState {
+  enabled: boolean;
+  visibleSolidCount: number;
+  totalSolidCount: number;
+  visibleLabelCount: number;
+  totalLabelCount: number;
+}
+
+export interface SolidVisualizer {
+  readonly group: Group;
+  register(sceneRoot: Object3D): void;
+  setEnabled(enabled: boolean): void;
+  getState(): DebugSolidVisualizerState;
+  getSolids(): DebugSolidMetadata[];
+  getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  dispose(): void;
+}
+
+const LABEL_CANVAS_WIDTH = 256;
+const LABEL_CANVAS_HEIGHT = 128;
+const LABEL_PALETTE = [
+  '#8BE9FD',
+  '#F1FA8C',
+  '#FF79C6',
+  '#50FA7B',
+  '#BD93F9',
+  '#FFB86C',
+];
+const LABEL_SCALE_X = 1.6;
+const LABEL_SCALE_Y = 0.8;
+const LABEL_VERTICAL_GAP = 0.42;
+const DEBUG_ID_PRIMARY_SALT = 'solid-debug-id:v1';
+const scratchBox = new Box3();
+const scratchSize = new Vector3();
+
+const round = (value: number): number => roundDebugValue(value);
+
+const cloneBounds = (bounds: DebugSolidBounds): DebugSolidBounds => ({
+  min: { ...bounds.min },
+  max: { ...bounds.max },
+});
+
+const shouldExcludeObject = (object: Object3D): boolean =>
+  object.userData.debugOnly === true ||
+  object.type === 'Camera' ||
+  object.type.includes('Light') ||
+  object.type === 'Sprite';
+
+const getObjectPath = (object: Object3D, root: Object3D): string => {
+  const names: string[] = [];
+  let current: Object3D | null = object;
+  while (current && current !== root) {
+    names.push(current.name || current.type);
+    current = current.parent;
+  }
+  names.push(root.name || root.type);
+  return names.reverse().join('/');
+};
+
+const summarizeMaterial = (
+  material: Material | Material[]
+): string | undefined => {
+  const first = Array.isArray(material) ? material[0] : material;
+  if (!first) {
+    return undefined;
+  }
+  const color =
+    'color' in first && first.color instanceof Color
+      ? `#${first.color.getHexString()}`
+      : undefined;
+  return [first.type, color].filter(Boolean).join(':');
+};
+
+const getGeometrySignature = (geometry: BufferGeometry): string => {
+  geometry.computeBoundingBox();
+  const box = geometry.boundingBox;
+  const positionCount = geometry.getAttribute('position')?.count ?? 0;
+  const indexCount = geometry.index?.count ?? 0;
+  const dimensions = box
+    ? [
+        round(box.max.x - box.min.x),
+        round(box.max.y - box.min.y),
+        round(box.max.z - box.min.z),
+      ].join(',')
+    : 'unbounded';
+  return `${geometry.type}|p:${positionCount}|i:${indexCount}|d:${dimensions}`;
+};
+
+const getBounds = (object: Object3D): DebugSolidBounds => {
+  scratchBox.setFromObject(object);
+  return {
+    min: {
+      x: round(scratchBox.min.x),
+      y: round(scratchBox.min.y),
+      z: round(scratchBox.min.z),
+    },
+    max: {
+      x: round(scratchBox.max.x),
+      y: round(scratchBox.max.y),
+      z: round(scratchBox.max.z),
+    },
+  };
+};
+
+const getSolidSeed = (metadata: Omit<DebugSolidMetadata, 'id'>): string =>
+  [
+    metadata.name,
+    metadata.path,
+    metadata.parentPath,
+    metadata.meshType,
+    metadata.geometrySignature ?? '',
+    JSON.stringify(metadata.bounds),
+    metadata.materialSummary ?? '',
+  ].join('|');
+
+export const createSolidDebugId = (
+  metadata: Omit<DebugSolidMetadata, 'id'>,
+  usedIds: ReadonlySet<string> = new Set()
+): string => {
+  const seed = getSolidSeed(metadata);
+  return allocateDebugId(
+    getDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`),
+    seed,
+    usedIds
+  );
+};
+
+const getLabelColor = (id: string): string => {
+  const numericPrefix = Number.parseInt(
+    id.replace(/[^0-9A-F]/g, '').slice(0, 6),
+    16
+  );
+  return LABEL_PALETTE[
+    Number.isFinite(numericPrefix) ? numericPrefix % LABEL_PALETTE.length : 0
+  ];
+};
+
+const createLabelTexture = (
+  id: string,
+  color: string
+): CanvasTexture | undefined => {
+  if (
+    typeof document === 'undefined' ||
+    (typeof process !== 'undefined' && Boolean(process.env.VITEST)) ||
+    (typeof navigator !== 'undefined' && navigator.userAgent.includes('jsdom'))
+  ) {
+    return undefined;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = LABEL_CANVAS_WIDTH;
+  canvas.height = LABEL_CANVAS_HEIGHT;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return undefined;
+  }
+  context.fillStyle = 'rgba(5, 8, 16, 0.82)';
+  context.strokeStyle = color;
+  context.lineWidth = 8;
+  context.roundRect(
+    12,
+    22,
+    LABEL_CANVAS_WIDTH - 24,
+    LABEL_CANVAS_HEIGHT - 44,
+    18
+  );
+  context.fill();
+  context.stroke();
+  context.font =
+    '700 48px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.lineWidth = 9;
+  context.strokeStyle = 'rgba(0, 0, 0, 0.9)';
+  context.strokeText(id, LABEL_CANVAS_WIDTH / 2, LABEL_CANVAS_HEIGHT / 2 + 3);
+  context.fillStyle = color;
+  context.fillText(id, LABEL_CANVAS_WIDTH / 2, LABEL_CANVAS_HEIGHT / 2 + 3);
+  const texture = new CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const createLabel = (id: string, color: string): Sprite => {
+  const texture = createLabelTexture(id, color);
+  const label = new Sprite(
+    new SpriteMaterial({
+      color: texture ? 0xffffff : color,
+      depthTest: false,
+      depthWrite: false,
+      opacity: 0.98,
+      toneMapped: false,
+      transparent: true,
+      ...(texture ? { map: texture } : {}),
+    })
+  );
+  label.name = `DebugSolidLabel:${id}`;
+  label.renderOrder = 20_011;
+  label.frustumCulled = false;
+  label.scale.set(LABEL_SCALE_X, LABEL_SCALE_Y, 1);
+  label.userData.debugOnly = true;
+  label.userData.solidDebugLabel = { id };
+  label.raycast = () => undefined;
+  return label;
+};
+
+const cloneMetadata = (metadata: DebugSolidMetadata): DebugSolidMetadata => ({
+  ...metadata,
+  bounds: cloneBounds(metadata.bounds),
+});
+
+export function createSolidVisualizer(
+  options: {
+    enabled?: boolean;
+    reservedIds?: Iterable<string>;
+  } = {}
+): SolidVisualizer {
+  const group = new Group();
+  group.name = 'DebugSolidVisualizer';
+  group.visible = options.enabled ?? false;
+  group.userData.debugOnly = true;
+
+  const entries: DebugSolidEntry[] = [];
+  let enabled = options.enabled ?? false;
+
+  const applyVisibility = () => {
+    group.visible = enabled;
+    for (const entry of entries) {
+      entry.wireframe.visible = enabled;
+      entry.label.visible = enabled;
+    }
+  };
+
+  const disposeEntries = () => {
+    for (const entry of entries) {
+      group.remove(entry.wireframe, entry.label);
+      entry.wireframe.geometry.dispose();
+      entry.wireframe.material.dispose();
+      entry.label.material.map?.dispose();
+      entry.label.material.dispose();
+    }
+    entries.length = 0;
+  };
+
+  return {
+    group,
+    register(sceneRoot: Object3D) {
+      disposeEntries();
+      sceneRoot.updateMatrixWorld(true);
+      const candidates: Array<{
+        mesh: Mesh;
+        metadata: Omit<DebugSolidMetadata, 'id'>;
+      }> = [];
+      const visitObject = (object: Object3D) => {
+        if (shouldExcludeObject(object)) {
+          return;
+        }
+        if (object instanceof Mesh && object.visible) {
+          const path = getObjectPath(object, sceneRoot);
+          candidates.push({
+            mesh: object,
+            metadata: {
+              name: object.name || object.type,
+              path,
+              parentPath: object.parent
+                ? getObjectPath(object.parent, sceneRoot)
+                : '',
+              meshType: object.type,
+              bounds: getBounds(object),
+              geometrySignature: getGeometrySignature(object.geometry),
+              materialSummary: summarizeMaterial(object.material),
+            },
+          });
+        }
+        for (const child of object.children) {
+          visitObject(child);
+        }
+      };
+      visitObject(sceneRoot);
+      candidates.sort((left, right) =>
+        getSolidSeed(left.metadata).localeCompare(getSolidSeed(right.metadata))
+      );
+
+      const usedIds = new Set(options.reservedIds ?? []);
+      const seedCounts = new Map<string, number>();
+      for (const candidate of candidates) {
+        const seed = getSolidSeed(candidate.metadata);
+        const occurrence = seedCounts.get(seed) ?? 0;
+        seedCounts.set(seed, occurrence + 1);
+        const metadataSeed =
+          occurrence > 0
+            ? {
+                ...candidate.metadata,
+                path: `${candidate.metadata.path}|${occurrence}`,
+              }
+            : candidate.metadata;
+        const id = createSolidDebugId(metadataSeed, usedIds);
+        usedIds.add(id);
+        const color = getLabelColor(id);
+        const wireframe = new LineSegments(
+          new WireframeGeometry(candidate.mesh.geometry),
+          new LineBasicMaterial({
+            color,
+            depthTest: false,
+            depthWrite: false,
+            transparent: true,
+            opacity: 0.82,
+            toneMapped: false,
+          })
+        );
+        wireframe.name = `DebugSolid:${id}:${candidate.metadata.name}`;
+        wireframe.matrixAutoUpdate = false;
+        wireframe.matrix.copy(candidate.mesh.matrixWorld);
+        wireframe.renderOrder = 20_010;
+        wireframe.frustumCulled = false;
+        wireframe.userData.debugOnly = true;
+        wireframe.userData.solidDebug = { id };
+        wireframe.raycast = () => undefined;
+
+        const label = createLabel(id, color);
+        scratchBox.setFromObject(candidate.mesh);
+        scratchBox.getSize(scratchSize);
+        label.position.set(
+          (candidate.metadata.bounds.min.x + candidate.metadata.bounds.max.x) /
+            2,
+          candidate.metadata.bounds.max.y +
+            Math.max(LABEL_VERTICAL_GAP, scratchSize.y * 0.08),
+          (candidate.metadata.bounds.min.z + candidate.metadata.bounds.max.z) /
+            2
+        );
+
+        group.add(wireframe, label);
+        entries.push({
+          metadata: { id, ...candidate.metadata },
+          wireframe,
+          label,
+        });
+      }
+      applyVisibility();
+    },
+    setEnabled(next: boolean) {
+      enabled = next;
+      applyVisibility();
+    },
+    getState() {
+      return {
+        enabled,
+        visibleSolidCount: enabled ? entries.length : 0,
+        totalSolidCount: entries.length,
+        visibleLabelCount: enabled ? entries.length : 0,
+        totalLabelCount: entries.length,
+      };
+    },
+    getSolids() {
+      return entries.map((entry) => cloneMetadata(entry.metadata));
+    },
+    getSolidById(id: unknown) {
+      if (typeof id !== 'string' || id.length === 0) {
+        return undefined;
+      }
+      const normalizedId = id.toUpperCase();
+      const entry = entries.find((next) => next.metadata.id === normalizedId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    dispose() {
+      disposeEntries();
+      const parent = group.parent as Object3D | null;
+      parent?.remove(group);
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Collider debug labels were previously coupled to the collider wireframe overlay and needed to be toggleable independently for focused debugging.
- Inspecting and tracking exact scene solids required short, stable IDs and wireframe overlays that do not interfere with gameplay or selection.

### Description
- Add shared deterministic short-hex ID helpers (`src/scene/debug/debugIds.ts`) with allocation/retry to avoid collisions. 
- Extend the collider visualizer (`src/scene/debug/colliderVisualizer.ts`) to expose `idsEnabled` in state and a new `setIdsEnabled(enabled: boolean)` method while preserving existing API and color sync behavior for labels and wireframes. 
- Implement a solid visualizer (`src/scene/debug/solidVisualizer.ts`) that registers visible scene Meshes, generates stable IDs (avoiding collider IDs via reserved set), creates non-interactive wireframes and camera-facing labels, and exposes `createSolidVisualizer`/`createSolidDebugId` APIs plus `window.portfolio.debugSolids`. 
- Wire HUD controls, URL overrides, and persistent storage keys in `src/main.ts` for `debugColliderIds` (`danielsmith.io::debugColliderIds::v1`) and `debugSolidIds` (`danielsmith.io::debugSolidIds::v1`), register the solid visualizer and reserve collider IDs for solids, and add focused tests and small test updates. 

### Testing
- Ran `npm run format:write` — succeeded.
- Ran `npm run lint` — succeeded after fixes to new files.
- Ran focused visualizer tests `npm run test:ci src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` — all tests passed.
- Ran full test suite `npm run test:ci` — succeeded (146 test files, 1105 tests passing in CI run recorded here).
- Ran `npm run docs:check` and `npm run smoke` — both succeeded.
- Ran `npm run build` — succeeded and produced dist artifacts.
- Ran `npm run typecheck` (`tsc --noEmit`) earlier — failed with many unrelated TypeScript errors in other parts of the codebase; these failures are not caused by the introduced debug visualizers and require broader type-cleanup separate from this change.
- Playwright browser tests are blocked in this environment: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` failed due to missing browser executable and needs `npx playwright install` in the runner to execute.  

Files added/modified (high level): `src/scene/debug/debugIds.ts`, `src/scene/debug/solidVisualizer.ts`, `src/scene/debug/colliderVisualizer.ts` (ids toggle + API), `src/main.ts` (HUD wiring, URL/storage keys, `window.portfolio.debugSolids`), tests `src/scene/debug/__tests__/solidVisualizer.test.ts` (new) and updates to `colliderVisualizer.test.ts`.

Residual notes: solid and collider debug overlays are debug-only (non-raycasting, `userData.debugOnly`) and the change avoids touching any gameplay collision or movement logic; Playwright checks require browser installation in CI to run the browser-based verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e01b3bb40832f95e01c4c38b26b69)