### PR TITLE
Add toggleable collider ID labels and Solid IDs visualizer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -116,6 +116,11 @@ import {
   type DebugColliderVisualizerState,
 } from './scene/debug/colliderVisualizer';
 import {
+  createSolidVisualizer,
+  type DebugSolidMetadata,
+  type DebugSolidVisualizerState,
+} from './scene/debug/solidVisualizer';
+import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
@@ -478,6 +483,8 @@ const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
+const DEBUG_COLLIDER_IDS_STORAGE_KEY = 'danielsmith.io::debugColliderIds::v1';
+const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
 const isDebugUrlValueIn = (
@@ -588,12 +595,19 @@ declare global {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
+        setIdsEnabled(enabled: boolean): void;
         getBlockingCollidersAt(target: {
           x: number;
           z: number;
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+      };
+      debugSolids?: {
+        getState(): DebugSolidVisualizerState;
+        setEnabled(enabled: boolean): void;
+        getSolids(): DebugSolidMetadata[];
+        getSolidById(id: unknown): DebugSolidMetadata | undefined;
       };
       debugCoordinates?: {
         getState(): {
@@ -1402,8 +1416,42 @@ function initializeImmersiveScene(
   let debugCollidersEnabled = debugCollidersUrlDisabled
     ? false
     : debugCollidersUrlEnabled || debugCollidersStoredEnabled;
+  const debugColliderIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugColliderIds');
+  const debugColliderIdsUrlEnabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugColliderIdsUrlDisabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugColliderIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_COLLIDER_IDS_STORAGE_KEY) !== '0';
+  let debugColliderIdsEnabled = debugColliderIdsUrlDisabled
+    ? false
+    : debugColliderIdsUrlEnabled || debugColliderIdsStoredEnabled;
+  const debugSolidIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugSolidIds');
+  const debugSolidIdsUrlEnabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugSolidIdsUrlDisabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugSolidIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_SOLID_IDS_STORAGE_KEY) === '1';
+  let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
+    ? false
+    : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
+  let debugColliderIdsControl: HTMLButtonElement | null = null;
+  let debugSolidIdsControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -4175,6 +4223,7 @@ function initializeImmersiveScene(
     activeFloorId,
     enabled: debugCollidersEnabled,
   });
+  colliderVisualizer.setIdsEnabled(debugColliderIdsEnabled);
   colliderVisualizer.register([
     ...createDebugColliderRegistrations(groundColliders, {
       floor: 'ground',
@@ -4194,6 +4243,15 @@ function initializeImmersiveScene(
     }),
   ]);
   scene.add(colliderVisualizer.group);
+
+  const solidVisualizer = createSolidVisualizer({
+    scene,
+    enabled: debugSolidIdsEnabled,
+    reservedIds: new Set(
+      colliderVisualizer.getColliders().map((collider) => collider.id)
+    ),
+  });
+  scene.add(solidVisualizer.group);
 
   const containsRectPoint = (
     rect: { minX: number; maxX: number; minZ: number; maxZ: number },
@@ -4415,6 +4473,50 @@ function initializeImmersiveScene(
     debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugColliderIdsControl = () => {
+    if (!debugColliderIdsControl) {
+      return;
+    }
+    const label = debugColliderIdsEnabled
+      ? 'Collider IDs on'
+      : 'Collider IDs off';
+    const description = debugCollidersEnabled
+      ? 'Shows collider ID labels when the collider overlay is on.'
+      : 'Collider ID labels stay hidden until the collider overlay is on.';
+    debugColliderIdsControl.textContent = label;
+    debugColliderIdsControl.dataset.state = debugColliderIdsEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugColliderIdsControl.setAttribute(
+      'aria-pressed',
+      debugColliderIdsEnabled ? 'true' : 'false'
+    );
+    debugColliderIdsControl.setAttribute('aria-label', description);
+    debugColliderIdsControl.title = description;
+    debugColliderIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const refreshDebugSolidIdsControl = () => {
+    if (!debugSolidIdsControl) {
+      return;
+    }
+    const label = debugSolidIdsEnabled ? 'Solid IDs on' : 'Solid IDs off';
+    const description = debugSolidIdsEnabled
+      ? 'Shows stable scene solid wireframes and ID labels.'
+      : 'Scene solid debug wireframes and ID labels are hidden.';
+    debugSolidIdsControl.textContent = label;
+    debugSolidIdsControl.dataset.state = debugSolidIdsEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugSolidIdsControl.setAttribute(
+      'aria-pressed',
+      debugSolidIdsEnabled ? 'true' : 'false'
+    );
+    debugSolidIdsControl.setAttribute('aria-label', description);
+    debugSolidIdsControl.title = description;
+    debugSolidIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
   const setDebugCollidersEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4422,6 +4524,7 @@ function initializeImmersiveScene(
     debugCollidersEnabled = enabled;
     colliderVisualizer.setEnabled(enabled);
     refreshDebugCollidersControl();
+    refreshDebugColliderIdsControl();
     if (options.persist !== false && debugCoordinatesStorage) {
       try {
         debugCoordinatesStorage.setItem(
@@ -4430,6 +4533,44 @@ function initializeImmersiveScene(
         );
       } catch (error) {
         console.warn('Failed to persist debug collider preference.', error);
+      }
+    }
+  };
+
+  const setDebugColliderIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugColliderIdsEnabled = enabled;
+    colliderVisualizer.setIdsEnabled(enabled);
+    refreshDebugColliderIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_COLLIDER_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug collider ID preference.', error);
+      }
+    }
+  };
+
+  const setDebugSolidIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugSolidIdsEnabled = enabled;
+    solidVisualizer.setEnabled(enabled);
+    refreshDebugSolidIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_SOLID_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug solid ID preference.', error);
       }
     }
   };
@@ -4464,6 +4605,8 @@ function initializeImmersiveScene(
 
   const refreshDebugCollidersStrings = () => {
     refreshDebugCollidersControl();
+    refreshDebugColliderIdsControl();
+    refreshDebugSolidIdsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4491,6 +4634,26 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugCollidersControl);
   registerHudControlElement(debugCollidersControl);
   refreshDebugCollidersControl();
+
+  debugColliderIdsControl = document.createElement('button');
+  debugColliderIdsControl.type = 'button';
+  debugColliderIdsControl.className = 'tour-toggle debug-collider-ids-toggle';
+  debugColliderIdsControl.addEventListener('click', () => {
+    setDebugColliderIdsEnabled(!debugColliderIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugColliderIdsControl);
+  registerHudControlElement(debugColliderIdsControl);
+  refreshDebugColliderIdsControl();
+
+  debugSolidIdsControl = document.createElement('button');
+  debugSolidIdsControl.type = 'button';
+  debugSolidIdsControl.className = 'tour-toggle debug-solid-ids-toggle';
+  debugSolidIdsControl.addEventListener('click', () => {
+    setDebugSolidIdsEnabled(!debugSolidIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugSolidIdsControl);
+  registerHudControlElement(debugSolidIdsControl);
+  refreshDebugSolidIdsControl();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4521,9 +4684,21 @@ function initializeImmersiveScene(
     setEnabled: (enabled: boolean) => {
       setDebugCollidersEnabled(enabled);
     },
+    setIdsEnabled: (enabled: boolean) => {
+      setDebugColliderIdsEnabled(enabled);
+    },
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+  };
+
+  window.portfolio.debugSolids = {
+    getState: () => solidVisualizer.getState(),
+    setEnabled: (enabled: boolean) => {
+      setDebugSolidIdsEnabled(enabled);
+    },
+    getSolids: () => solidVisualizer.getSolids(),
+    getSolidById: (id: unknown) => solidVisualizer.getSolidById(id),
   };
 
   window.portfolio.debugCoordinates = {
@@ -6043,12 +6218,21 @@ function initializeImmersiveScene(
       debugCollidersControl.remove();
       debugCollidersControl = null;
     }
+    if (debugColliderIdsControl) {
+      debugColliderIdsControl.remove();
+      debugColliderIdsControl = null;
+    }
+    if (debugSolidIdsControl) {
+      debugSolidIdsControl.remove();
+      debugSolidIdsControl = null;
+    }
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
       debugCoordinatesHeading = null;
       debugCoordinatesRows.clear();
     }
+    solidVisualizer.dispose();
     colliderVisualizer.dispose();
     movementLegend?.dispose();
     narrationPreference.dispose();

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -155,6 +155,7 @@ describe('createColliderVisualizer', () => {
       enabled: false,
       visibleColliderCount: 0,
       totalColliderCount: 3,
+      idsEnabled: true,
       visibleLabelCount: 0,
       totalLabelCount: 3,
     });
@@ -164,6 +165,7 @@ describe('createColliderVisualizer', () => {
       enabled: true,
       visibleColliderCount: 2,
       totalColliderCount: 3,
+      idsEnabled: true,
       visibleLabelCount: 2,
       totalLabelCount: 3,
     });
@@ -171,6 +173,38 @@ describe('createColliderVisualizer', () => {
     visualizer.setActiveFloor('upper');
     expect(visualizer.getState().visibleColliderCount).toBe(2);
     expect(visualizer.getState().visibleLabelCount).toBe(2);
+  });
+
+  it('can hide collider ID labels while keeping wireframes visible', () => {
+    const visualizer = createColliderVisualizer({
+      activeFloorId: 'ground',
+      enabled: true,
+    });
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'static',
+        name: 'static-0',
+        bounds: collider,
+      },
+    ]);
+
+    visualizer.setIdsEnabled(false);
+
+    const mesh = visualizer.group.children.find(
+      (child) => child.type === 'Mesh'
+    ) as Mesh;
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    ) as Sprite;
+    expect(mesh.visible).toBe(true);
+    expect(label.visible).toBe(false);
+    expect(visualizer.getState().visibleColliderCount).toBe(1);
+    expect(visualizer.getState().visibleLabelCount).toBe(0);
+
+    visualizer.setEnabled(false);
+    expect(mesh.visible).toBe(false);
+    expect(label.visible).toBe(false);
   });
 
   it('returns redacted metadata copies and non-raycasting meshes', () => {

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -1,0 +1,106 @@
+import {
+  BoxGeometry,
+  Group,
+  LineBasicMaterial,
+  Mesh,
+  MeshBasicMaterial,
+  SpriteMaterial,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createColliderDebugId } from '../colliderVisualizer';
+import { createSolidDebugId, createSolidVisualizer } from '../solidVisualizer';
+
+const createScene = () => {
+  const scene = new Group();
+  scene.name = 'Scene';
+  const mesh = new Mesh(
+    new BoxGeometry(1, 2, 3),
+    new MeshBasicMaterial({ color: 'red' })
+  );
+  mesh.name = 'Wall';
+  mesh.position.set(1, 2, 3);
+  scene.add(mesh);
+  const debug = new Mesh(new BoxGeometry(1, 1, 1), new MeshBasicMaterial());
+  debug.userData.debugOnly = true;
+  scene.add(debug);
+  return { scene, mesh };
+};
+
+describe('createSolidDebugId', () => {
+  const metadata = {
+    name: 'Wall',
+    path: 'Scene/Wall',
+    parentPath: 'Scene',
+    meshType: 'Mesh',
+    bounds: { min: { x: 0, y: 1, z: 1.5 }, max: { x: 2, y: 3, z: 4.5 } },
+    material: 'MeshBasicMaterial:#ff0000',
+  };
+
+  it('is deterministic, uppercase hex, and changes with meaningful metadata', () => {
+    expect(createSolidDebugId(metadata)).toBe(createSolidDebugId(metadata));
+    expect(createSolidDebugId(metadata)).toMatch(/^[0-9A-F]{4,6}$/);
+    expect(createSolidDebugId(metadata)).not.toBe(
+      createSolidDebugId({
+        ...metadata,
+        bounds: { ...metadata.bounds, max: { ...metadata.bounds.max, z: 5 } },
+      })
+    );
+  });
+
+  it('avoids collider IDs', () => {
+    const colliderId = createColliderDebugId({
+      floor: 'ground',
+      category: 'static',
+      name: 'x',
+      bounds: { minX: 0, maxX: 1, minZ: 0, maxZ: 1 },
+    });
+    expect(createSolidDebugId(metadata, new Set([colliderId]))).not.toBe(
+      colliderId
+    );
+  });
+});
+
+describe('createSolidVisualizer', () => {
+  it('registers mesh solids, excludes debug-only objects, and exposes metadata copies', () => {
+    const { scene } = createScene();
+    const visualizer = createSolidVisualizer({
+      scene,
+      enabled: true,
+      reservedIds: new Set(['ABCD']),
+    });
+    const solids = visualizer.getSolids();
+
+    expect(solids).toHaveLength(1);
+    expect(solids[0].name).toBe('Wall');
+    expect(visualizer.getSolidById(solids[0].id)).toEqual(solids[0]);
+    solids[0].bounds.min.x = 99;
+    expect(visualizer.getSolids()[0].bounds.min.x).not.toBe(99);
+    expect(visualizer.getState()).toEqual({
+      enabled: true,
+      visibleSolidCount: 1,
+      totalSolidCount: 1,
+      visibleLabelCount: 1,
+      totalLabelCount: 1,
+    });
+  });
+
+  it('creates matching-color, non-raycasting debug-only overlays', () => {
+    const { scene } = createScene();
+    const visualizer = createSolidVisualizer({ scene, enabled: true });
+    const wireframe = visualizer.group.children.find(
+      (child) => child.type === 'LineSegments'
+    );
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    );
+
+    expect(wireframe?.userData.debugOnly).toBe(true);
+    expect(label?.userData.debugOnly).toBe(true);
+    expect(wireframe?.raycast({} as never, [] as never)).toBeUndefined();
+    expect(label?.raycast({} as never, [] as never)).toBeUndefined();
+    expect((wireframe?.material as LineBasicMaterial).color.getHex()).toBe(
+      (label?.material as SpriteMaterial).color.getHex()
+    );
+  });
+});

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -15,6 +15,11 @@ import type { RectCollider } from '../../systems/collision';
 import type { FloorId } from '../../systems/movement/stairs';
 
 import { getDeclaredColliderDebugId } from './colliderDebugIds';
+import {
+  DEBUG_ID_MAX_LENGTH,
+  DEBUG_ID_MIN_LENGTH,
+  getStableDebugHash as getColliderDebugHash,
+} from './debugIds';
 
 export type DebugColliderFloor = FloorId | 'all';
 
@@ -40,6 +45,7 @@ export interface DebugColliderVisualizerState {
   enabled: boolean;
   visibleColliderCount: number;
   totalColliderCount: number;
+  idsEnabled: boolean;
   visibleLabelCount: number;
   totalLabelCount: number;
 }
@@ -47,13 +53,14 @@ export interface DebugColliderVisualizerState {
 interface DebugColliderVisualEntry {
   metadata: DebugColliderMetadata;
   mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
-  label: Sprite<SpriteMaterial>;
+  label: Sprite;
 }
 
 export interface ColliderVisualizer {
   readonly group: Group;
   register(colliders: readonly DebugColliderRegistration[]): void;
   setEnabled(enabled: boolean): void;
+  setIdsEnabled(enabled: boolean): void;
   setActiveFloor(floorId: FloorId): void;
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
@@ -63,11 +70,7 @@ export interface ColliderVisualizer {
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
-const DEBUG_ID_MIN_LENGTH = 4;
-const DEBUG_ID_MAX_LENGTH = 6;
 const DEBUG_ID_PRECISION = 2;
-// Keep the visible primary ID namespaced from the raw metadata hash so
-// historical raw-prefix collisions do not decide screenshot-visible labels.
 const DEBUG_ID_PRIMARY_SALT = 'debug-id:v3';
 const LABEL_CANVAS_WIDTH = 256;
 const LABEL_CANVAS_HEIGHT = 128;
@@ -114,30 +117,6 @@ const getColliderDebugSeed = (
     metadata.category,
     normalizeBoundsForId(metadata.bounds),
   ].join('|');
-
-const getStableDebugHashValue = (input: string): number => {
-  let low = 0xdeadbeef ^ input.length;
-  let high = 0x41c6ce57 ^ input.length;
-
-  for (let index = 0; index < input.length; index += 1) {
-    const charCode = input.charCodeAt(index);
-    low = Math.imul(low ^ charCode, 2_654_435_761);
-    high = Math.imul(high ^ charCode, 1_597_334_677);
-  }
-
-  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
-  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
-  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
-  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
-
-  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
-};
-
-const getColliderDebugHash = (seed: string): string =>
-  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
-    .toString(16)
-    .toUpperCase()
-    .padStart(DEBUG_ID_MAX_LENGTH, '0');
 
 const getColliderDebugPrimaryId = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
@@ -356,10 +335,7 @@ const createLabelTexture = (
   return texture;
 };
 
-const createColliderLabel = (
-  id: string,
-  color: string
-): Sprite<SpriteMaterial> => {
+const createColliderLabel = (id: string, color: string): Sprite => {
   const texture = createLabelTexture(id, color);
   const material = new SpriteMaterial({
     color: texture ? 0xffffff : color,
@@ -395,6 +371,7 @@ export function createColliderVisualizer(options: {
 
   const entries: DebugColliderVisualEntry[] = [];
   let enabled = options.enabled ?? false;
+  let idsEnabled = true;
   let activeFloorId = options.activeFloorId;
 
   const applyVisibility = () => {
@@ -403,7 +380,7 @@ export function createColliderVisualizer(options: {
       const visible =
         enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
       entry.mesh.visible = visible;
-      entry.label.visible = visible;
+      entry.label.visible = visible && idsEnabled;
     }
   };
 
@@ -504,6 +481,10 @@ export function createColliderVisualizer(options: {
       enabled = next;
       applyVisibility();
     },
+    setIdsEnabled(next: boolean) {
+      idsEnabled = next;
+      applyVisibility();
+    },
     setActiveFloor(next: FloorId) {
       activeFloorId = next;
       applyVisibility();
@@ -513,7 +494,8 @@ export function createColliderVisualizer(options: {
         enabled,
         visibleColliderCount: getVisibleEntryCount(),
         totalColliderCount: entries.length,
-        visibleLabelCount: getVisibleEntryCount(),
+        idsEnabled,
+        visibleLabelCount: idsEnabled ? getVisibleEntryCount() : 0,
         totalLabelCount: entries.length,
       };
     },

--- a/src/scene/debug/debugIds.ts
+++ b/src/scene/debug/debugIds.ts
@@ -1,0 +1,68 @@
+export const DEBUG_ID_MIN_LENGTH = 4;
+export const DEBUG_ID_MAX_LENGTH = 6;
+
+export const getStableDebugHashValue = (input: string): number => {
+  let low = 0xdeadbeef ^ input.length;
+  let high = 0x41c6ce57 ^ input.length;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const charCode = input.charCodeAt(index);
+    low = Math.imul(low ^ charCode, 2_654_435_761);
+    high = Math.imul(high ^ charCode, 1_597_334_677);
+  }
+
+  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
+  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
+  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
+  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
+
+  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
+};
+
+export const getStableDebugHash = (seed: string): string =>
+  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
+    .toString(16)
+    .toUpperCase()
+    .padStart(DEBUG_ID_MAX_LENGTH, '0');
+
+const getRetryCandidates = (seed: string): string[] => {
+  const hash = getStableDebugHash(seed);
+  const candidates: string[] = [];
+  for (
+    let length = DEBUG_ID_MIN_LENGTH;
+    length <= DEBUG_ID_MAX_LENGTH;
+    length += 1
+  ) {
+    candidates.push(hash.slice(0, length));
+  }
+  return candidates;
+};
+
+export const allocateDebugId = (
+  seed: string,
+  usedIds: ReadonlySet<string> = new Set(),
+  options: { primarySeed?: string; minLength?: number } = {}
+): string => {
+  const minLength = options.minLength ?? DEBUG_ID_MAX_LENGTH;
+  const primary = getStableDebugHash(options.primarySeed ?? seed).slice(
+    0,
+    minLength
+  );
+  if (!usedIds.has(primary)) {
+    return primary;
+  }
+
+  for (
+    let retryIndex = 1;
+    retryIndex < Number.MAX_SAFE_INTEGER;
+    retryIndex += 1
+  ) {
+    for (const candidate of getRetryCandidates(`${seed}|retry:${retryIndex}`)) {
+      if (!usedIds.has(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  throw new Error('Unable to allocate a short debug ID');
+};

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -1,0 +1,325 @@
+import {
+  Box3,
+  BufferGeometry,
+  CanvasTexture,
+  Color,
+  Group,
+  LineSegments,
+  LineBasicMaterial,
+  Mesh,
+  Sprite,
+  SpriteMaterial,
+  Vector3,
+  WireframeGeometry,
+  type Material,
+  type Object3D,
+} from 'three';
+
+import { allocateDebugId } from './debugIds';
+
+export interface DebugSolidMetadata {
+  id: string;
+  name: string;
+  path: string;
+  parentPath: string;
+  meshType: string;
+  bounds: {
+    min: { x: number; y: number; z: number };
+    max: { x: number; y: number; z: number };
+  };
+  material?: string;
+}
+
+export interface DebugSolidVisualizerState {
+  enabled: boolean;
+  visibleSolidCount: number;
+  totalSolidCount: number;
+  visibleLabelCount: number;
+  totalLabelCount: number;
+}
+
+interface Entry {
+  metadata: DebugSolidMetadata;
+  wireframe: LineSegments<WireframeGeometry, LineBasicMaterial>;
+  label: Sprite;
+}
+
+const PRECISION = 2;
+const LABEL_PALETTE = [
+  '#8BE9FD',
+  '#F1FA8C',
+  '#FF79C6',
+  '#50FA7B',
+  '#BD93F9',
+  '#FFB86C',
+];
+const tmpBox = new Box3();
+const tmpSize = new Vector3();
+
+const round = (value: number) =>
+  Math.round(value * 10 ** PRECISION) / 10 ** PRECISION;
+const formatVector = (v: Vector3) =>
+  `${round(v.x)},${round(v.y)},${round(v.z)}`;
+
+const isMesh = (object: Object3D): object is Mesh => object instanceof Mesh;
+const isDebugExcluded = (object: Object3D): boolean => {
+  for (
+    let current: Object3D | null = object;
+    current;
+    current = current.parent
+  ) {
+    if (
+      current.userData.debugOnly ||
+      current.userData.poiMarker ||
+      current.userData.hud
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const objectPath = (object: Object3D): string => {
+  const parts: string[] = [];
+  for (
+    let current: Object3D | null = object;
+    current;
+    current = current.parent
+  ) {
+    parts.push(current.name || current.type);
+  }
+  return parts.reverse().join('/');
+};
+
+const materialSummary = (
+  material: Material | Material[]
+): string | undefined => {
+  const first = Array.isArray(material) ? material[0] : material;
+  if (!first) return undefined;
+  const color =
+    'color' in first && first.color instanceof Color
+      ? `#${first.color.getHexString()}`
+      : undefined;
+  return [first.type, color].filter(Boolean).join(':');
+};
+
+const geometrySignature = (geometry: BufferGeometry): string => {
+  geometry.computeBoundingBox();
+  const box = geometry.boundingBox;
+  return [
+    geometry.type,
+    geometry.attributes.position?.count ?? 0,
+    geometry.index?.count ?? 0,
+    box ? `${formatVector(box.min)}>${formatVector(box.max)}` : 'no-box',
+  ].join('|');
+};
+
+const colorForId = (id: string): string => {
+  const numeric = Number.parseInt(id, 16);
+  return LABEL_PALETTE[
+    (Number.isFinite(numeric) ? numeric : 0) % LABEL_PALETTE.length
+  ];
+};
+
+const createLabelTexture = (
+  id: string,
+  color: string
+): CanvasTexture | undefined => {
+  if (
+    typeof document === 'undefined' ||
+    (typeof process !== 'undefined' && Boolean(process.env.VITEST))
+  )
+    return undefined;
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 128;
+  const context = canvas.getContext('2d');
+  if (!context) return undefined;
+  context.fillStyle = 'rgba(5, 8, 16, 0.82)';
+  context.strokeStyle = color;
+  context.lineWidth = 8;
+  context.roundRect(12, 22, 232, 84, 18);
+  context.fill();
+  context.stroke();
+  context.font =
+    '700 54px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.lineWidth = 9;
+  context.strokeStyle = 'rgba(0, 0, 0, 0.9)';
+  context.strokeText(id, 128, 67);
+  context.fillStyle = color;
+  context.fillText(id, 128, 67);
+  const texture = new CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const cloneMetadata = (metadata: DebugSolidMetadata): DebugSolidMetadata => ({
+  ...metadata,
+  bounds: {
+    min: { ...metadata.bounds.min },
+    max: { ...metadata.bounds.max },
+  },
+});
+
+export const createSolidDebugId = (
+  metadata: Omit<DebugSolidMetadata, 'id'>,
+  usedIds: ReadonlySet<string> = new Set()
+): string =>
+  allocateDebugId(
+    `solid|${metadata.path}|${metadata.meshType}|${JSON.stringify(metadata.bounds)}|${metadata.material ?? ''}`,
+    usedIds
+  );
+
+export const createSolidVisualizer = (options: {
+  scene: Object3D;
+  enabled?: boolean;
+  reservedIds?: ReadonlySet<string>;
+}) => {
+  const group = new Group();
+  group.name = 'DebugSolidVisualizer';
+  group.userData.debugOnly = true;
+  const entries: Entry[] = [];
+  let enabled = options.enabled ?? false;
+  const usedIds = new Set(options.reservedIds ?? []);
+
+  const applyVisibility = () => {
+    group.visible = enabled;
+    for (const entry of entries) {
+      entry.wireframe.visible = enabled;
+      entry.label.visible = enabled;
+    }
+  };
+
+  const register = () => {
+    const meshes: Mesh[] = [];
+    options.scene.updateMatrixWorld(true);
+    options.scene.traverse((object) => {
+      if (isMesh(object) && !isDebugExcluded(object) && object.visible)
+        meshes.push(object);
+    });
+    const metadata = meshes.map((mesh) => {
+      tmpBox.setFromObject(mesh);
+      const path = objectPath(mesh);
+      return {
+        name: mesh.name || mesh.type,
+        path,
+        parentPath: mesh.parent ? objectPath(mesh.parent) : '',
+        meshType: mesh.type,
+        bounds: {
+          min: {
+            x: round(tmpBox.min.x),
+            y: round(tmpBox.min.y),
+            z: round(tmpBox.min.z),
+          },
+          max: {
+            x: round(tmpBox.max.x),
+            y: round(tmpBox.max.y),
+            z: round(tmpBox.max.z),
+          },
+        },
+        material: materialSummary(mesh.material),
+        seed: `${path}|${geometrySignature(mesh.geometry)}|${JSON.stringify([tmpBox.min.x, tmpBox.min.y, tmpBox.min.z, tmpBox.max.x, tmpBox.max.y, tmpBox.max.z].map(round))}`,
+        mesh,
+      };
+    });
+    metadata.sort((a, b) => a.seed.localeCompare(b.seed));
+    const seedCounts = new Map<string, number>();
+    for (const item of metadata) {
+      const occurrence = seedCounts.get(item.seed) ?? 0;
+      seedCounts.set(item.seed, occurrence + 1);
+      const base = { ...item };
+      delete (base as { mesh?: Mesh }).mesh;
+      delete (base as { seed?: string }).seed;
+      const id = allocateDebugId(
+        occurrence > 0 ? `${item.seed}|occurrence:${occurrence}` : item.seed,
+        usedIds
+      );
+      usedIds.add(id);
+      const color = colorForId(id);
+      const wireframe = new LineSegments(
+        new WireframeGeometry(item.mesh.geometry),
+        new LineBasicMaterial({
+          color,
+          depthTest: false,
+          depthWrite: false,
+          transparent: true,
+          opacity: 0.72,
+          toneMapped: false,
+        })
+      );
+      item.mesh.updateWorldMatrix(true, false);
+      wireframe.applyMatrix4(item.mesh.matrixWorld);
+      wireframe.name = `DebugSolid:${id}:${item.name}`;
+      wireframe.renderOrder = 19_900;
+      wireframe.frustumCulled = false;
+      wireframe.userData.debugOnly = true;
+      wireframe.raycast = () => undefined;
+      const texture = createLabelTexture(id, color);
+      const label = new Sprite(
+        new SpriteMaterial({
+          color: texture ? 0xffffff : color,
+          depthTest: false,
+          depthWrite: false,
+          transparent: true,
+          opacity: 0.98,
+          toneMapped: false,
+          ...(texture ? { map: texture } : {}),
+        })
+      );
+      tmpBox.getSize(tmpSize);
+      label.name = `DebugSolidLabel:${id}`;
+      label.position.set(
+        (item.bounds.min.x + item.bounds.max.x) / 2,
+        item.bounds.max.y + Math.max(0.25, tmpSize.y * 0.15),
+        (item.bounds.min.z + item.bounds.max.z) / 2
+      );
+      label.scale.set(1.6, 0.8, 1);
+      label.renderOrder = 19_901;
+      label.frustumCulled = false;
+      label.userData.debugOnly = true;
+      label.raycast = () => undefined;
+      group.add(wireframe, label);
+      entries.push({ metadata: { id, ...base }, wireframe, label });
+    }
+    applyVisibility();
+  };
+
+  register();
+  return {
+    group,
+    setEnabled(next: boolean) {
+      enabled = next;
+      applyVisibility();
+    },
+    getState(): DebugSolidVisualizerState {
+      return {
+        enabled,
+        visibleSolidCount: enabled ? entries.length : 0,
+        totalSolidCount: entries.length,
+        visibleLabelCount: enabled ? entries.length : 0,
+        totalLabelCount: entries.length,
+      };
+    },
+    getSolids: () => entries.map((entry) => cloneMetadata(entry.metadata)),
+    getSolidById(id: unknown) {
+      if (typeof id !== 'string' || id.length === 0) return undefined;
+      const entry = entries.find(
+        (next) => next.metadata.id === id.toUpperCase()
+      );
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    dispose() {
+      for (const entry of entries) {
+        group.remove(entry.wireframe, entry.label);
+        entry.wireframe.geometry.dispose();
+        entry.wireframe.material.dispose();
+        entry.label.material.map?.dispose();
+        entry.label.material.dispose();
+      }
+      entries.length = 0;
+      group.parent?.remove(group);
+    },
+  };
+};


### PR DESCRIPTION
### Motivation
- Make collider ID labels independently toggleable from collider wireframes so labels can be hidden while overlays remain visible.
- Provide a stable, deterministic debug ID overlay for visible scene solids to help identify odd geometry (e.g. the upstairs floor slab) without changing gameplay or collision behavior.

### Description
- Added a shared debug ID allocator (`src/scene/debug/debugIds.ts`) that produces short deterministic uppercase hex IDs with collision-retry semantics.
- Extended the collider visualizer (`src/scene/debug/colliderVisualizer.ts`) with an `idsEnabled` state and `setIdsEnabled(enabled)` API so labels can be toggled independently; label/wireframe color parity and declared color overrides are preserved.
- Implemented `src/scene/debug/solidVisualizer.ts` that traverses visible non-debug meshes, generates stable solid metadata and IDs (avoiding collider IDs via a reserved set), and renders non-interactive wireframes + camera-facing labels that match label colors.
- Wired UI, storage, and URL overrides in `src/main.ts` for `debugColliderIds` and `debugSolidIds`, added HUD buttons for the new toggles, and exposed `window.portfolio.debugColliders.setIdsEnabled(...)` and `window.portfolio.debugSolids` debug APIs.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint` which completed successfully.
- Ran focused visualizer tests with `npm run test:ci -- src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` and both test files passed.
- Ran the full test suite with `npm run test:ci` and all tests passed (reported 146 files, 1103 tests passed in this environment).
- Built and smoke-checked artifacts with `npm run build` and `npm run smoke` which succeeded; docs link check `npm run docs:check` completed with network warnings but passed; `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.
- Playwright E2E `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` did not run here because Playwright browsers are not installed in this environment (recommend CI or local `npx playwright install` to validate the runtime stairs/immersive checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e01c292a4832fb189b353b3e1ddc0)