### PR TITLE
Add toggleable collider IDs and solid debug ID visualizer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -116,6 +116,11 @@ import {
   type DebugColliderVisualizerState,
 } from './scene/debug/colliderVisualizer';
 import {
+  createSolidVisualizer,
+  type DebugSolidMetadata,
+  type DebugSolidVisualizerState,
+} from './scene/debug/solidVisualizer';
+import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
@@ -478,6 +483,8 @@ const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
+const DEBUG_COLLIDER_IDS_STORAGE_KEY = 'danielsmith.io::debugColliderIds::v1';
+const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
 const isDebugUrlValueIn = (
@@ -587,6 +594,7 @@ declare global {
       debugColliders?: {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
+        setIdsEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
         getBlockingCollidersAt(target: {
           x: number;
@@ -594,6 +602,12 @@ declare global {
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+      };
+      debugSolids?: {
+        getState(): DebugSolidVisualizerState;
+        setEnabled(enabled: boolean): void;
+        getSolids(): DebugSolidMetadata[];
+        getSolidById(id: unknown): DebugSolidMetadata | undefined;
       };
       debugCoordinates?: {
         getState(): {
@@ -1402,8 +1416,42 @@ function initializeImmersiveScene(
   let debugCollidersEnabled = debugCollidersUrlDisabled
     ? false
     : debugCollidersUrlEnabled || debugCollidersStoredEnabled;
+  const debugColliderIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugColliderIds');
+  const debugColliderIdsUrlEnabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugColliderIdsUrlDisabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugColliderIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_COLLIDER_IDS_STORAGE_KEY) !== '0';
+  let debugColliderIdsEnabled = debugColliderIdsUrlDisabled
+    ? false
+    : debugColliderIdsUrlEnabled || debugColliderIdsStoredEnabled;
+  const debugSolidIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugSolidIds');
+  const debugSolidIdsUrlEnabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugSolidIdsUrlDisabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugSolidIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_SOLID_IDS_STORAGE_KEY) === '1';
+  let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
+    ? false
+    : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
+  let debugColliderIdsControl: HTMLButtonElement | null = null;
+  let debugSolidIdsControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -4174,6 +4222,7 @@ function initializeImmersiveScene(
   const colliderVisualizer = createColliderVisualizer({
     activeFloorId,
     enabled: debugCollidersEnabled,
+    idsEnabled: debugColliderIdsEnabled,
   });
   colliderVisualizer.register([
     ...createDebugColliderRegistrations(groundColliders, {
@@ -4194,6 +4243,14 @@ function initializeImmersiveScene(
     }),
   ]);
   scene.add(colliderVisualizer.group);
+  const solidVisualizer = createSolidVisualizer({
+    enabled: debugSolidIdsEnabled,
+  });
+  scene.add(solidVisualizer.group);
+  solidVisualizer.register(
+    scene,
+    new Set(colliderVisualizer.getColliders().map((collider) => collider.id))
+  );
 
   const containsRectPoint = (
     rect: { minX: number; maxX: number; minZ: number; maxZ: number },
@@ -4415,6 +4472,38 @@ function initializeImmersiveScene(
     debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugColliderIdsControl = () => {
+    if (!debugColliderIdsControl) {
+      return;
+    }
+    debugColliderIdsControl.textContent = debugColliderIdsEnabled
+      ? 'Collider IDs on'
+      : 'Collider IDs off';
+    debugColliderIdsControl.dataset.state = debugColliderIdsEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugColliderIdsControl.setAttribute(
+      'aria-pressed',
+      debugColliderIdsEnabled ? 'true' : 'false'
+    );
+  };
+
+  const refreshDebugSolidIdsControl = () => {
+    if (!debugSolidIdsControl) {
+      return;
+    }
+    debugSolidIdsControl.textContent = debugSolidIdsEnabled
+      ? 'Solid IDs on'
+      : 'Solid IDs off';
+    debugSolidIdsControl.dataset.state = debugSolidIdsEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugSolidIdsControl.setAttribute(
+      'aria-pressed',
+      debugSolidIdsEnabled ? 'true' : 'false'
+    );
+  };
+
   const setDebugCollidersEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4430,6 +4519,44 @@ function initializeImmersiveScene(
         );
       } catch (error) {
         console.warn('Failed to persist debug collider preference.', error);
+      }
+    }
+  };
+
+  const setDebugColliderIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugColliderIdsEnabled = enabled;
+    colliderVisualizer.setIdsEnabled(enabled);
+    refreshDebugColliderIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_COLLIDER_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug collider ID preference.', error);
+      }
+    }
+  };
+
+  const setDebugSolidIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugSolidIdsEnabled = enabled;
+    solidVisualizer.setEnabled(enabled);
+    refreshDebugSolidIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_SOLID_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug solid ID preference.', error);
       }
     }
   };
@@ -4464,6 +4591,8 @@ function initializeImmersiveScene(
 
   const refreshDebugCollidersStrings = () => {
     refreshDebugCollidersControl();
+    refreshDebugColliderIdsControl();
+    refreshDebugSolidIdsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4491,6 +4620,26 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugCollidersControl);
   registerHudControlElement(debugCollidersControl);
   refreshDebugCollidersControl();
+
+  debugColliderIdsControl = document.createElement('button');
+  debugColliderIdsControl.type = 'button';
+  debugColliderIdsControl.className = 'tour-toggle debug-collider-ids-toggle';
+  debugColliderIdsControl.addEventListener('click', () => {
+    setDebugColliderIdsEnabled(!debugColliderIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugColliderIdsControl);
+  registerHudControlElement(debugColliderIdsControl);
+  refreshDebugColliderIdsControl();
+
+  debugSolidIdsControl = document.createElement('button');
+  debugSolidIdsControl.type = 'button';
+  debugSolidIdsControl.className = 'tour-toggle debug-solid-ids-toggle';
+  debugSolidIdsControl.addEventListener('click', () => {
+    setDebugSolidIdsEnabled(!debugSolidIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugSolidIdsControl);
+  registerHudControlElement(debugSolidIdsControl);
+  refreshDebugSolidIdsControl();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4521,9 +4670,21 @@ function initializeImmersiveScene(
     setEnabled: (enabled: boolean) => {
       setDebugCollidersEnabled(enabled);
     },
+    setIdsEnabled: (enabled: boolean) => {
+      setDebugColliderIdsEnabled(enabled);
+    },
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+  };
+
+  window.portfolio.debugSolids = {
+    getState: () => solidVisualizer.getState(),
+    setEnabled: (enabled: boolean) => {
+      setDebugSolidIdsEnabled(enabled);
+    },
+    getSolids: () => solidVisualizer.getSolids(),
+    getSolidById: (id: unknown) => solidVisualizer.getSolidById(id),
   };
 
   window.portfolio.debugCoordinates = {
@@ -6021,6 +6182,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugColliders) {
       delete window.portfolio.debugColliders;
     }
+    if (window.portfolio?.debugSolids) {
+      delete window.portfolio.debugSolids;
+    }
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
@@ -6043,6 +6207,14 @@ function initializeImmersiveScene(
       debugCollidersControl.remove();
       debugCollidersControl = null;
     }
+    if (debugColliderIdsControl) {
+      debugColliderIdsControl.remove();
+      debugColliderIdsControl = null;
+    }
+    if (debugSolidIdsControl) {
+      debugSolidIdsControl.remove();
+      debugSolidIdsControl = null;
+    }
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
@@ -6050,6 +6222,7 @@ function initializeImmersiveScene(
       debugCoordinatesRows.clear();
     }
     colliderVisualizer.dispose();
+    solidVisualizer.dispose();
     movementLegend?.dispose();
     narrationPreference.dispose();
     if (proceduralNarrator) {

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -153,6 +153,7 @@ describe('createColliderVisualizer', () => {
 
     expect(visualizer.getState()).toEqual({
       enabled: false,
+      idsEnabled: true,
       visibleColliderCount: 0,
       totalColliderCount: 3,
       visibleLabelCount: 0,
@@ -162,6 +163,7 @@ describe('createColliderVisualizer', () => {
     visualizer.setEnabled(true);
     expect(visualizer.getState()).toEqual({
       enabled: true,
+      idsEnabled: true,
       visibleColliderCount: 2,
       totalColliderCount: 3,
       visibleLabelCount: 2,
@@ -171,6 +173,41 @@ describe('createColliderVisualizer', () => {
     visualizer.setActiveFloor('upper');
     expect(visualizer.getState().visibleColliderCount).toBe(2);
     expect(visualizer.getState().visibleLabelCount).toBe(2);
+  });
+
+  it('can hide ID labels while leaving wireframes visible', () => {
+    const visualizer = createColliderVisualizer({
+      activeFloorId: 'ground',
+      enabled: true,
+    });
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'ground-0',
+        bounds: collider,
+      },
+    ]);
+    const mesh = visualizer.group.children.find(
+      (child) => child.type === 'Mesh'
+    );
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    );
+
+    visualizer.setIdsEnabled(false);
+    expect(mesh?.visible).toBe(true);
+    expect(label?.visible).toBe(false);
+    expect(visualizer.getState()).toMatchObject({
+      enabled: true,
+      idsEnabled: false,
+      visibleColliderCount: 1,
+      visibleLabelCount: 0,
+    });
+
+    visualizer.setEnabled(false);
+    expect(mesh?.visible).toBe(false);
+    expect(label?.visible).toBe(false);
   });
 
   it('returns redacted metadata copies and non-raycasting meshes', () => {

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -1,0 +1,147 @@
+import { BoxGeometry, Group, Mesh, MeshBasicMaterial } from 'three';
+import type { LineBasicMaterial, SpriteMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createColliderDebugId } from '../colliderVisualizer';
+import { createSolidDebugId, createSolidVisualizer } from '../solidVisualizer';
+
+const solidMetadata = {
+  name: 'WallPanel',
+  path: 'Scene/Room/WallPanel',
+  parentPath: 'Scene/Room',
+  meshType: 'Mesh',
+  bounds: {
+    min: { x: 0, y: 0, z: 0 },
+    max: { x: 1, y: 2, z: 3 },
+  },
+  material: 'MeshBasicMaterial #ffffff',
+};
+
+const colliderMetadata = {
+  floor: 'ground' as const,
+  category: 'walls',
+  name: 'GroundWallWest',
+  bounds: { minX: 1, maxX: 3, minZ: 2, maxZ: 5 },
+};
+
+describe('createSolidDebugId', () => {
+  it('is deterministic, uppercase hex, and changes with meaningful metadata', () => {
+    const id = createSolidDebugId(solidMetadata);
+
+    expect(id).toBe(createSolidDebugId(solidMetadata));
+    expect(id).toMatch(/^[0-9A-F]{6}$/);
+    expect(id).not.toBe(
+      createSolidDebugId({
+        ...solidMetadata,
+        bounds: { ...solidMetadata.bounds, max: { x: 2, y: 2, z: 3 } },
+      })
+    );
+  });
+
+  it('avoids collider ID collisions deterministically', () => {
+    const colliderId = createColliderDebugId(colliderMetadata);
+    const solidId = createSolidDebugId(solidMetadata, new Set([colliderId]));
+
+    expect(solidId).not.toBe(colliderId);
+    expect(solidId).toMatch(/^[0-9A-F]{4,6}$/);
+    expect(createSolidDebugId(solidMetadata, new Set([colliderId]))).toBe(
+      solidId
+    );
+  });
+});
+
+describe('createSolidVisualizer', () => {
+  it('registers mesh solids, excludes debug-only objects, and returns metadata copies', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solid = new Mesh(
+      new BoxGeometry(1, 2, 3),
+      new MeshBasicMaterial({ color: 'white' })
+    );
+    solid.name = 'SolidWall';
+    scene.add(solid);
+    const debugOnly = new Mesh(new BoxGeometry(), new MeshBasicMaterial());
+    debugOnly.userData.debugOnly = true;
+    scene.add(debugOnly);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene, new Set(['ABCD']));
+
+    const solids = visualizer.getSolids();
+    expect(solids).toHaveLength(1);
+    expect(solids[0].name).toBe('SolidWall');
+    expect(solids[0].id).toMatch(/^[0-9A-F]{4,6}$/);
+    expect(visualizer.getSolidById(solids[0].id)).toEqual(solids[0]);
+    expect(visualizer.getSolidById(solids[0].id.toLowerCase())?.id).toBe(
+      solids[0].id
+    );
+    solids[0].bounds.min.x = 99;
+    expect(visualizer.getSolids()[0].bounds.min.x).not.toBe(99);
+    expect(visualizer.getState()).toEqual({
+      enabled: true,
+      visibleSolidCount: 1,
+      totalSolidCount: 1,
+      visibleLabelCount: 1,
+      totalLabelCount: 1,
+    });
+  });
+
+  it('keeps IDs unique from supplied collider IDs', () => {
+    const scene = new Group();
+    const first = new Mesh(new BoxGeometry(1, 1, 1), new MeshBasicMaterial());
+    const second = new Mesh(new BoxGeometry(2, 1, 1), new MeshBasicMaterial());
+    first.name = 'FirstSolid';
+    second.name = 'SecondSolid';
+    second.position.x = 3;
+    scene.add(first, second);
+    const colliderId = createColliderDebugId(colliderMetadata);
+
+    const visualizer = createSolidVisualizer();
+    visualizer.register(scene, new Set([colliderId]));
+    const ids = visualizer.getSolids().map((solid) => solid.id);
+
+    expect(ids).not.toContain(colliderId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('creates non-raycasting debug-only overlays with matching wireframe and label colors', () => {
+    const scene = new Group();
+    const solid = new Mesh(
+      new BoxGeometry(1, 1, 1),
+      new MeshBasicMaterial({ color: 'red' })
+    );
+    solid.name = 'DebuggableSolid';
+    scene.add(solid);
+    const visualizer = createSolidVisualizer({ enabled: true });
+
+    visualizer.register(scene);
+    const wireframe = visualizer.group.children.find(
+      (child) => child.type === 'LineSegments'
+    ) as
+      | {
+          material: LineBasicMaterial;
+          raycast: (raycaster: never, intersects: never) => void;
+          userData: Record<string, unknown>;
+        }
+      | undefined;
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    ) as
+      | {
+          material: SpriteMaterial;
+          raycast: (raycaster: never, intersects: never) => void;
+          userData: Record<string, unknown>;
+        }
+      | undefined;
+    const wireframeMaterial = wireframe?.material as LineBasicMaterial;
+    const labelMaterial = label?.material as SpriteMaterial;
+
+    expect(wireframe?.userData.debugOnly).toBe(true);
+    expect(label?.userData.debugOnly).toBe(true);
+    expect(wireframe?.raycast({} as never, [] as never)).toBeUndefined();
+    expect(label?.raycast({} as never, [] as never)).toBeUndefined();
+    expect(wireframeMaterial.color.getHex()).toBe(labelMaterial.color.getHex());
+    expect(wireframeMaterial.depthTest).toBe(false);
+    expect(labelMaterial.depthWrite).toBe(false);
+  });
+});

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -15,6 +15,7 @@ import type { RectCollider } from '../../systems/collision';
 import type { FloorId } from '../../systems/movement/stairs';
 
 import { getDeclaredColliderDebugId } from './colliderDebugIds';
+import { DEBUG_ID_MAX_LENGTH, allocateDebugId, getDebugHash } from './debugIds';
 
 export type DebugColliderFloor = FloorId | 'all';
 
@@ -38,6 +39,7 @@ export interface DebugColliderRegistration {
 
 export interface DebugColliderVisualizerState {
   enabled: boolean;
+  idsEnabled: boolean;
   visibleColliderCount: number;
   totalColliderCount: number;
   visibleLabelCount: number;
@@ -47,13 +49,14 @@ export interface DebugColliderVisualizerState {
 interface DebugColliderVisualEntry {
   metadata: DebugColliderMetadata;
   mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
-  label: Sprite<SpriteMaterial>;
+  label: Sprite;
 }
 
 export interface ColliderVisualizer {
   readonly group: Group;
   register(colliders: readonly DebugColliderRegistration[]): void;
   setEnabled(enabled: boolean): void;
+  setIdsEnabled(enabled: boolean): void;
   setActiveFloor(floorId: FloorId): void;
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
@@ -63,8 +66,6 @@ export interface ColliderVisualizer {
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
-const DEBUG_ID_MIN_LENGTH = 4;
-const DEBUG_ID_MAX_LENGTH = 6;
 const DEBUG_ID_PRECISION = 2;
 // Keep the visible primary ID namespaced from the raw metadata hash so
 // historical raw-prefix collisions do not decide screenshot-visible labels.
@@ -115,29 +116,7 @@ const getColliderDebugSeed = (
     normalizeBoundsForId(metadata.bounds),
   ].join('|');
 
-const getStableDebugHashValue = (input: string): number => {
-  let low = 0xdeadbeef ^ input.length;
-  let high = 0x41c6ce57 ^ input.length;
-
-  for (let index = 0; index < input.length; index += 1) {
-    const charCode = input.charCodeAt(index);
-    low = Math.imul(low ^ charCode, 2_654_435_761);
-    high = Math.imul(high ^ charCode, 1_597_334_677);
-  }
-
-  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
-  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
-  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
-  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
-
-  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
-};
-
-const getColliderDebugHash = (seed: string): string =>
-  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
-    .toString(16)
-    .toUpperCase()
-    .padStart(DEBUG_ID_MAX_LENGTH, '0');
+const getColliderDebugHash = getDebugHash;
 
 const getColliderDebugPrimaryId = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
@@ -146,30 +125,13 @@ const getColliderDebugPrimaryId = (
   getDeclaredColliderDebugId(metadata) ??
   getColliderDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`);
 
-const getColliderDebugIdCandidates = (seed: string): string[] => {
-  const hash = getColliderDebugHash(seed);
-  const candidates: string[] = [];
-  for (
-    let length = DEBUG_ID_MIN_LENGTH;
-    length <= DEBUG_ID_MAX_LENGTH;
-    length += 1
-  ) {
-    candidates.push(hash.slice(0, length));
-  }
-  return candidates;
-};
-
 const createColliderDebugIdFromMetadata = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
   usedIds: ReadonlySet<string>,
   idSeed = getColliderDebugSeed(metadata)
 ): string => {
   const primaryCandidate = getColliderDebugPrimaryId(metadata, idSeed);
-  if (!usedIds.has(primaryCandidate)) {
-    return primaryCandidate;
-  }
-
-  return getColliderDebugRetryId(idSeed, new Set(usedIds));
+  return allocateDebugId(primaryCandidate, idSeed, usedIds);
 };
 
 export function createColliderDebugId(
@@ -178,27 +140,6 @@ export function createColliderDebugId(
 ): string {
   return createColliderDebugIdFromMetadata(metadata, usedIds);
 }
-
-const getColliderDebugRetryId = (
-  seed: string,
-  usedIds: Set<string>
-): string => {
-  for (
-    let retryIndex = 1;
-    retryIndex < Number.MAX_SAFE_INTEGER;
-    retryIndex += 1
-  ) {
-    for (const candidate of getColliderDebugIdCandidates(
-      `${seed}|retry:${retryIndex}`
-    )) {
-      if (!usedIds.has(candidate)) {
-        return candidate;
-      }
-    }
-  }
-
-  throw new Error('Unable to allocate a short collider debug ID');
-};
 
 const allocateColliderDebugIds = (
   metadataList: readonly Omit<DebugColliderMetadata, 'id'>[],
@@ -356,10 +297,7 @@ const createLabelTexture = (
   return texture;
 };
 
-const createColliderLabel = (
-  id: string,
-  color: string
-): Sprite<SpriteMaterial> => {
+const createColliderLabel = (id: string, color: string): Sprite => {
   const texture = createLabelTexture(id, color);
   const material = new SpriteMaterial({
     color: texture ? 0xffffff : color,
@@ -387,6 +325,7 @@ const getDebugColliderMeshName = (metadata: DebugColliderMetadata): string =>
 export function createColliderVisualizer(options: {
   activeFloorId: FloorId;
   enabled?: boolean;
+  idsEnabled?: boolean;
 }): ColliderVisualizer {
   const group = new Group();
   group.name = 'DebugColliderVisualizer';
@@ -395,6 +334,7 @@ export function createColliderVisualizer(options: {
 
   const entries: DebugColliderVisualEntry[] = [];
   let enabled = options.enabled ?? false;
+  let idsEnabled = options.idsEnabled ?? true;
   let activeFloorId = options.activeFloorId;
 
   const applyVisibility = () => {
@@ -403,7 +343,7 @@ export function createColliderVisualizer(options: {
       const visible =
         enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
       entry.mesh.visible = visible;
-      entry.label.visible = visible;
+      entry.label.visible = visible && idsEnabled;
     }
   };
 
@@ -504,6 +444,10 @@ export function createColliderVisualizer(options: {
       enabled = next;
       applyVisibility();
     },
+    setIdsEnabled(next: boolean) {
+      idsEnabled = next;
+      applyVisibility();
+    },
     setActiveFloor(next: FloorId) {
       activeFloorId = next;
       applyVisibility();
@@ -511,9 +455,10 @@ export function createColliderVisualizer(options: {
     getState() {
       return {
         enabled,
+        idsEnabled,
         visibleColliderCount: getVisibleEntryCount(),
         totalColliderCount: entries.length,
-        visibleLabelCount: getVisibleEntryCount(),
+        visibleLabelCount: idsEnabled ? getVisibleEntryCount() : 0,
         totalLabelCount: entries.length,
       };
     },

--- a/src/scene/debug/debugIds.ts
+++ b/src/scene/debug/debugIds.ts
@@ -1,0 +1,66 @@
+export const DEBUG_ID_MIN_LENGTH = 4;
+export const DEBUG_ID_MAX_LENGTH = 6;
+
+export const getStableDebugHashValue = (input: string): number => {
+  let low = 0xdeadbeef ^ input.length;
+  let high = 0x41c6ce57 ^ input.length;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const charCode = input.charCodeAt(index);
+    low = Math.imul(low ^ charCode, 2_654_435_761);
+    high = Math.imul(high ^ charCode, 1_597_334_677);
+  }
+
+  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
+  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
+  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
+  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
+
+  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
+};
+
+export const getDebugHash = (seed: string): string =>
+  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
+    .toString(16)
+    .toUpperCase()
+    .padStart(DEBUG_ID_MAX_LENGTH, '0');
+
+export const getDebugIdCandidates = (seed: string): string[] => {
+  const hash = getDebugHash(seed);
+  const candidates: string[] = [];
+  for (
+    let length = DEBUG_ID_MIN_LENGTH;
+    length <= DEBUG_ID_MAX_LENGTH;
+    length += 1
+  ) {
+    candidates.push(hash.slice(0, length));
+  }
+  return candidates;
+};
+
+export const allocateDebugId = (
+  primaryCandidate: string,
+  seed: string,
+  usedIds: ReadonlySet<string>
+): string => {
+  const normalizedPrimaryCandidate = primaryCandidate.toUpperCase();
+  if (!usedIds.has(normalizedPrimaryCandidate)) {
+    return normalizedPrimaryCandidate;
+  }
+
+  for (
+    let retryIndex = 1;
+    retryIndex < Number.MAX_SAFE_INTEGER;
+    retryIndex += 1
+  ) {
+    for (const candidate of getDebugIdCandidates(
+      `${seed}|retry:${retryIndex}`
+    )) {
+      if (!usedIds.has(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  throw new Error('Unable to allocate a short debug ID');
+};

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -1,0 +1,419 @@
+import {
+  Box3,
+  CanvasTexture,
+  Color,
+  EdgesGeometry,
+  Group,
+  LineBasicMaterial,
+  LineSegments,
+  Mesh,
+  Quaternion,
+  Sprite,
+  SpriteMaterial,
+  Vector3,
+  type BufferGeometry,
+  type Material,
+  type Object3D,
+} from 'three';
+
+import { allocateDebugId, getDebugHash } from './debugIds';
+
+interface SolidBounds {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+export interface DebugSolidMetadata {
+  id: string;
+  name: string;
+  path: string;
+  parentPath: string;
+  meshType: string;
+  bounds: SolidBounds;
+  material: string | undefined;
+}
+
+export interface DebugSolidVisualizerState {
+  enabled: boolean;
+  visibleSolidCount: number;
+  totalSolidCount: number;
+  visibleLabelCount: number;
+  totalLabelCount: number;
+}
+
+interface SolidEntry {
+  metadata: DebugSolidMetadata;
+  wireframe: LineSegments;
+  label: Sprite;
+}
+
+export interface SolidVisualizer {
+  readonly group: Group;
+  register(sceneRoot: Object3D, existingIds?: ReadonlySet<string>): void;
+  setEnabled(enabled: boolean): void;
+  getState(): DebugSolidVisualizerState;
+  getSolids(): DebugSolidMetadata[];
+  getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  dispose(): void;
+}
+
+const LABEL_PALETTE = [
+  '#FF5555',
+  '#8BE9FD',
+  '#F1FA8C',
+  '#50FA7B',
+  '#BD93F9',
+  '#FFB86C',
+];
+const LABEL_CANVAS_WIDTH = 256;
+const LABEL_CANVAS_HEIGHT = 128;
+const LABEL_SCALE_X = 1.6;
+const LABEL_SCALE_Y = 0.8;
+const LABEL_VERTICAL_GAP = 0.35;
+const DEBUG_ID_PRIMARY_SALT = 'solid-debug-id:v1';
+const DEBUG_ID_PRECISION = 2;
+
+const roundDebugValue = (value: number): number =>
+  Math.round(value * 10 ** DEBUG_ID_PRECISION) / 10 ** DEBUG_ID_PRECISION;
+
+const cloneBounds = (bounds: SolidBounds): SolidBounds => ({
+  min: { ...bounds.min },
+  max: { ...bounds.max },
+});
+
+const getObjectSegment = (object: Object3D): string =>
+  object.name || object.type;
+
+const getObjectPath = (object: Object3D): string => {
+  const segments: string[] = [];
+  let current: Object3D | null = object;
+  while (current) {
+    segments.push(getObjectSegment(current));
+    current = current.parent;
+  }
+  return segments.reverse().join('/');
+};
+
+const isExcludedObject = (object: Object3D): boolean => {
+  if (
+    object.userData.debugOnly ||
+    object.type.includes('Light') ||
+    object.type === 'Camera'
+  ) {
+    return true;
+  }
+  if (
+    object.userData.poiId ||
+    object.userData.poiLabel ||
+    object.userData.colliderDebug
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const isSolidMesh = (
+  object: Object3D
+): object is Mesh<BufferGeometry, Material | Material[]> =>
+  object instanceof Mesh && !isExcludedObject(object);
+
+const materialSummary = (
+  material: Material | Material[]
+): string | undefined => {
+  const firstMaterial = Array.isArray(material) ? material[0] : material;
+  if (!firstMaterial) {
+    return undefined;
+  }
+  const color = (firstMaterial as Material & { color?: Color }).color;
+  return color
+    ? `${firstMaterial.type} #${color.getHexString()}`
+    : firstMaterial.type;
+};
+
+const boundsToMetadata = (box: Box3): SolidBounds => ({
+  min: { x: box.min.x, y: box.min.y, z: box.min.z },
+  max: { x: box.max.x, y: box.max.y, z: box.max.z },
+});
+
+const getGeometrySignature = (geometry: BufferGeometry): string => {
+  geometry.computeBoundingBox();
+  const box = geometry.boundingBox ?? new Box3();
+  const position = geometry.getAttribute('position');
+  return [
+    geometry.type,
+    position?.count ?? 0,
+    roundDebugValue(box.min.x),
+    roundDebugValue(box.min.y),
+    roundDebugValue(box.min.z),
+    roundDebugValue(box.max.x),
+    roundDebugValue(box.max.y),
+    roundDebugValue(box.max.z),
+  ].join('|');
+};
+
+const getStableSeed = (
+  metadata: Omit<DebugSolidMetadata, 'id'>,
+  mesh: Mesh<BufferGeometry>
+): string => {
+  const position = new Vector3();
+  const scale = new Vector3();
+  mesh.matrixWorld.decompose(position, new Quaternion(), scale);
+  return [
+    metadata.name,
+    metadata.path,
+    metadata.parentPath,
+    metadata.meshType,
+    getGeometrySignature(mesh.geometry),
+    [position.x, position.y, position.z, scale.x, scale.y, scale.z]
+      .map((value) => roundDebugValue(value).toFixed(DEBUG_ID_PRECISION))
+      .join(','),
+    [
+      metadata.bounds.min.x,
+      metadata.bounds.min.y,
+      metadata.bounds.min.z,
+      metadata.bounds.max.x,
+      metadata.bounds.max.y,
+      metadata.bounds.max.z,
+    ]
+      .map((value) => roundDebugValue(value).toFixed(DEBUG_ID_PRECISION))
+      .join(','),
+  ].join('|');
+};
+
+export const createSolidDebugId = (
+  metadata: Omit<DebugSolidMetadata, 'id'>,
+  usedIds: ReadonlySet<string> = new Set(),
+  seed = [
+    metadata.name,
+    metadata.path,
+    metadata.parentPath,
+    metadata.meshType,
+    metadata.material ?? '',
+    metadata.bounds.min.x,
+    metadata.bounds.min.y,
+    metadata.bounds.min.z,
+    metadata.bounds.max.x,
+    metadata.bounds.max.y,
+    metadata.bounds.max.z,
+  ].join('|')
+): string =>
+  allocateDebugId(
+    getDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`),
+    seed,
+    usedIds
+  );
+
+const getLabelColor = (id: string): string => {
+  const numericPrefix = Number.parseInt(
+    id.replace(/[^0-9A-F]/g, '').slice(0, 6),
+    16
+  );
+  return LABEL_PALETTE[
+    (Number.isFinite(numericPrefix) ? numericPrefix : 0) % LABEL_PALETTE.length
+  ];
+};
+
+const createLabelTexture = (
+  id: string,
+  color: string
+): CanvasTexture | undefined => {
+  if (
+    typeof document === 'undefined' ||
+    (typeof process !== 'undefined' && Boolean(process.env.VITEST))
+  ) {
+    return undefined;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = LABEL_CANVAS_WIDTH;
+  canvas.height = LABEL_CANVAS_HEIGHT;
+  const context = canvas.getContext('2d');
+  if (!context) return undefined;
+  context.fillStyle = 'rgba(5, 8, 16, 0.82)';
+  context.strokeStyle = color;
+  context.lineWidth = 8;
+  context.roundRect(
+    12,
+    22,
+    LABEL_CANVAS_WIDTH - 24,
+    LABEL_CANVAS_HEIGHT - 44,
+    18
+  );
+  context.fill();
+  context.stroke();
+  context.font =
+    '700 54px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.lineWidth = 9;
+  context.strokeStyle = 'rgba(0, 0, 0, 0.9)';
+  context.strokeText(id, LABEL_CANVAS_WIDTH / 2, LABEL_CANVAS_HEIGHT / 2 + 3);
+  context.fillStyle = color;
+  context.fillText(id, LABEL_CANVAS_WIDTH / 2, LABEL_CANVAS_HEIGHT / 2 + 3);
+  const texture = new CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const createLabel = (id: string, color: string): Sprite => {
+  const texture = createLabelTexture(id, color);
+  const label = new Sprite(
+    new SpriteMaterial({
+      color: texture ? 0xffffff : color,
+      depthTest: false,
+      depthWrite: false,
+      opacity: 0.98,
+      toneMapped: false,
+      transparent: true,
+      ...(texture ? { map: texture } : {}),
+    })
+  );
+  label.name = `DebugSolidLabel:${id}`;
+  label.renderOrder = 20_101;
+  label.frustumCulled = false;
+  label.scale.set(LABEL_SCALE_X, LABEL_SCALE_Y, 1);
+  label.userData.debugOnly = true;
+  label.userData.solidDebugLabel = { id };
+  label.raycast = () => undefined;
+  return label;
+};
+
+export const createSolidVisualizer = (
+  options: { enabled?: boolean } = {}
+): SolidVisualizer => {
+  const group = new Group();
+  group.name = 'DebugSolidVisualizer';
+  group.visible = options.enabled ?? false;
+  group.userData.debugOnly = true;
+  const entries: SolidEntry[] = [];
+  let enabled = options.enabled ?? false;
+
+  const applyVisibility = () => {
+    group.visible = enabled;
+    entries.forEach((entry) => {
+      entry.wireframe.visible = enabled;
+      entry.label.visible = enabled;
+    });
+  };
+
+  const clear = () => {
+    for (const entry of entries) {
+      group.remove(entry.wireframe, entry.label);
+      entry.wireframe.geometry.dispose();
+      (entry.wireframe.material as LineBasicMaterial).dispose();
+      entry.label.material.map?.dispose();
+      entry.label.material.dispose();
+    }
+    entries.length = 0;
+  };
+
+  const cloneMetadata = (metadata: DebugSolidMetadata): DebugSolidMetadata => ({
+    ...metadata,
+    bounds: cloneBounds(metadata.bounds),
+  });
+
+  return {
+    group,
+    register(sceneRoot, existingIds = new Set()) {
+      clear();
+      sceneRoot.updateMatrixWorld(true);
+      const items: Array<{
+        mesh: Mesh<BufferGeometry>;
+        metadata: Omit<DebugSolidMetadata, 'id'>;
+        seed: string;
+      }> = [];
+      sceneRoot.traverse((object) => {
+        if (!isSolidMesh(object)) return;
+        const worldBox = new Box3().setFromObject(object);
+        if (worldBox.isEmpty()) return;
+        const metadata = {
+          name: object.name || object.type,
+          path: getObjectPath(object),
+          parentPath: object.parent ? getObjectPath(object.parent) : '',
+          meshType: object.type,
+          bounds: boundsToMetadata(worldBox),
+          material: materialSummary(object.material),
+        };
+        items.push({
+          mesh: object,
+          metadata,
+          seed: getStableSeed(metadata, object),
+        });
+      });
+      items.sort((left, right) => left.seed.localeCompare(right.seed));
+      const usedIds = new Set(existingIds);
+      for (const item of items) {
+        const id = createSolidDebugId(item.metadata, usedIds, item.seed);
+        usedIds.add(id);
+        const color = getLabelColor(id);
+        const edges = new EdgesGeometry(item.mesh.geometry);
+        const wireframe = new LineSegments(
+          edges,
+          new LineBasicMaterial({
+            color,
+            depthTest: false,
+            depthWrite: false,
+            transparent: true,
+            opacity: 0.9,
+            toneMapped: false,
+          })
+        );
+        wireframe.name = `DebugSolid:${id}:${item.metadata.name}`;
+        wireframe.matrixAutoUpdate = false;
+        wireframe.matrix.copy(item.mesh.matrixWorld);
+        wireframe.renderOrder = 20_100;
+        wireframe.frustumCulled = false;
+        wireframe.userData.debugOnly = true;
+        wireframe.userData.solidDebug = { id };
+        wireframe.raycast = () => undefined;
+        const label = createLabel(id, color);
+        const center = new Box3(
+          new Vector3(
+            item.metadata.bounds.min.x,
+            item.metadata.bounds.min.y,
+            item.metadata.bounds.min.z
+          ),
+          new Vector3(
+            item.metadata.bounds.max.x,
+            item.metadata.bounds.max.y,
+            item.metadata.bounds.max.z
+          )
+        ).getCenter(new Vector3());
+        label.position.set(
+          center.x,
+          item.metadata.bounds.max.y + LABEL_VERTICAL_GAP,
+          center.z
+        );
+        group.add(wireframe, label);
+        entries.push({ metadata: { id, ...item.metadata }, wireframe, label });
+      }
+      applyVisibility();
+    },
+    setEnabled(next) {
+      enabled = next;
+      applyVisibility();
+    },
+    getState() {
+      const visibleCount = enabled ? entries.length : 0;
+      return {
+        enabled,
+        visibleSolidCount: visibleCount,
+        totalSolidCount: entries.length,
+        visibleLabelCount: visibleCount,
+        totalLabelCount: entries.length,
+      };
+    },
+    getSolids() {
+      return entries.map((entry) => cloneMetadata(entry.metadata));
+    },
+    getSolidById(id) {
+      if (typeof id !== 'string' || id.length === 0) return undefined;
+      const normalizedId = id.toUpperCase();
+      const entry = entries.find((next) => next.metadata.id === normalizedId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    dispose() {
+      clear();
+      (group.parent as Object3D | null)?.remove(group);
+    },
+  };
+};


### PR DESCRIPTION
### Motivation
- Make collider ID labels independently toggleable from collider wireframes so wireframes can remain visible when labels are hidden.
- Add a scene-solid debug overlay that assigns stable short hex IDs to visible scene meshes to help identify odd geometry during debugging without changing gameplay.

### Description
- Introduced shared debug ID utilities in `src/scene/debug/debugIds.ts` used to allocate short uppercase hex IDs with deterministic retry/collision avoidance. 
- Extended the existing collider visualizer (`src/scene/debug/colliderVisualizer.ts`) with an `idsEnabled` state, `setIdsEnabled(...)` API, and `idsEnabled` in `getState()` so labels may be toggled independently of wireframes while preserving existing APIs (`setEnabled`, `getState`, `getColliders`, `getBlockingCollidersAt`, `getColliderById`).
- Added a new `solidVisualizer` (`src/scene/debug/solidVisualizer.ts`) that registers visible scene Mesh objects (excluding debug-only, colliders, POI/UI, lights, cameras), generates stable IDs, renders non-interactive wireframes and camera-facing labels with matching colors, and exposes serializable metadata via `window.portfolio.debugSolids`.
- Wired new HUD Settings + URL overrides + storage keys in `src/main.ts` for `debugColliderIds` (`danielsmith.io::debugColliderIds::v1`) and `debugSolidIds` (`danielsmith.io::debugSolidIds::v1`), and added controls to toggle them; collider IDs remain hidden if the parent collider overlay is disabled.
- Added focused tests: updated collider visualizer tests to cover `setIdsEnabled(...)`, and added `src/scene/debug/__tests__/solidVisualizer.test.ts` plus unit tests proving determinism and collision avoidance between collider and solid IDs.

### Testing
- Ran formatting: `npm run format:write` — passed.
- Ran lint: `npm run lint` — passed.
- Ran focused unit tests: `npm run test:ci src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` — passed.
- Ran full unit test suite: `npm run test:ci` — passed (existing test suite exercised; visualizer tests included).
- Ran docs check: `npm run docs:check` — passed (link checker emitted external fetch warnings unrelated to changes).
- Ran smoke/build: `npm run smoke` / `npm run build` — passed (dist build produced expected artifacts).
- Playwright E2E: initial `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` failed because Playwright browsers/deps were not installed; after running `npx playwright install chromium` and `npx playwright install-deps chromium`, the spec ran and passed.
- Typecheck: `npm run typecheck` — failed due to existing, repo-wide TypeScript issues unrelated to the visualizer changes (reported by `tsc --noEmit`).

Notes: all changes are limited to debug/visualizer helpers, HUD Settings wiring, and tests per the scope lock; no gameplay collision, movement, stair prediction, navmesh, floor-plan geometry, or runtime collision math were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e018fea6c832fa76df762a2e1550b)