### PR TITLE
Add toggleable collider IDs and stable solid debug IDs

### DIFF
--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -306,6 +306,19 @@ export const AR_OVERRIDES: LocaleOverrides = {
         'يعرض الجدران غير المرئية ومستطيلات التصادم للطابق النشط.',
       descriptionDisabled:
         'تبقى الجدران غير المرئية ومستطيلات التصادم مخفية حتى تفعّلها.',
+
+      idsLabelEnabled: 'معرّفات المصادمات مفعّلة',
+      idsLabelDisabled: 'معرّفات المصادمات معطّلة',
+      idsDescriptionEnabled:
+        'يعرض تسميات معرّفات المصادمات عندما يكون تراكب المصادمات مفعّلًا.',
+      idsDescriptionDisabled:
+        'يخفي تسميات معرّفات المصادمات مع إبقاء إطارات المصادمات متاحة.',
+      solidIdsLabelEnabled: 'معرّفات المجسمات مفعّلة',
+      solidIdsLabelDisabled: 'معرّفات المجسمات معطّلة',
+      solidIdsDescriptionEnabled:
+        'يعرض معرّفات ثابتة وإطارات للمجسمات المرئية في المشهد.',
+      solidIdsDescriptionDisabled:
+        'تبقى معرّفات المجسمات الثابتة وإطاراتها مخفية.',
     },
     poiOverlay: {
       visited: 'تمت الزيارة',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -74,6 +74,18 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
       'Zeigt unsichtbare Wände und Kollisionsrechtecke der aktiven Etage.',
     debugCollidersDescriptionDisabled:
       'Unsichtbare Wände und Kollisionsrechtecke bleiben verborgen, bis du sie einschaltest.',
+    debugCollidersIdsLabelEnabled: 'Collider-IDs ein',
+    debugCollidersIdsLabelDisabled: 'Collider-IDs aus',
+    debugCollidersIdsDescriptionEnabled:
+      'Zeigt Collider-ID-Beschriftungen, während das Collider-Overlay aktiv ist.',
+    debugCollidersIdsDescriptionDisabled:
+      'Blendet Collider-ID-Beschriftungen aus, während die Drahtgitter verfügbar bleiben.',
+    debugCollidersSolidIdsLabelEnabled: 'Solid-IDs ein',
+    debugCollidersSolidIdsLabelDisabled: 'Solid-IDs aus',
+    debugCollidersSolidIdsDescriptionEnabled:
+      'Zeigt stabile IDs und Drahtgitter für sichtbare Szenen-Solids.',
+    debugCollidersSolidIdsDescriptionDisabled:
+      'Stabile Solid-IDs und Drahtgitter bleiben ausgeblendet.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -365,6 +365,19 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       descriptionDisabled: wrap(
         'Invisible walls and collision rectangles stay hidden until you turn them on.'
       ),
+
+      idsLabelEnabled: '⟦Collider IDs on⟧',
+      idsLabelDisabled: '⟦Collider IDs off⟧',
+      idsDescriptionEnabled:
+        '⟦Shows collider ID labels while the collider overlay is on.⟧',
+      idsDescriptionDisabled:
+        '⟦Hides collider ID labels while keeping collider wireframes available.⟧',
+      solidIdsLabelEnabled: '⟦Solid IDs on⟧',
+      solidIdsLabelDisabled: '⟦Solid IDs off⟧',
+      solidIdsDescriptionEnabled:
+        '⟦Shows stable IDs and wireframes for visible scene solids.⟧',
+      solidIdsDescriptionDisabled:
+        '⟦Stable solid IDs and wireframes stay hidden.⟧',
     },
     tourReset: {
       heading: wrap('Guided tour'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -371,6 +371,19 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'Shows invisible walls and collision rectangles for the active floor.',
       descriptionDisabled:
         'Invisible walls and collision rectangles stay hidden until you turn them on.',
+
+      idsLabelEnabled: 'Collider IDs on',
+      idsLabelDisabled: 'Collider IDs off',
+      idsDescriptionEnabled:
+        'Shows collider ID labels while the collider overlay is on.',
+      idsDescriptionDisabled:
+        'Hides collider ID labels while keeping collider wireframes available.',
+      solidIdsLabelEnabled: 'Solid IDs on',
+      solidIdsLabelDisabled: 'Solid IDs off',
+      solidIdsDescriptionEnabled:
+        'Shows stable IDs and wireframes for visible scene solids.',
+      solidIdsDescriptionDisabled:
+        'Stable solid IDs and wireframes stay hidden.',
     },
     tourReset: {
       heading: 'Guided tour',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -74,6 +74,18 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
       'Muestra muros invisibles y rectángulos de colisión del piso activo.',
     debugCollidersDescriptionDisabled:
       'Los muros invisibles y los rectángulos de colisión permanecen ocultos hasta que los actives.',
+    debugCollidersIdsLabelEnabled: 'IDs de colliders activadas',
+    debugCollidersIdsLabelDisabled: 'IDs de colliders desactivadas',
+    debugCollidersIdsDescriptionEnabled:
+      'Muestra etiquetas de ID de colliders mientras la superposición está activa.',
+    debugCollidersIdsDescriptionDisabled:
+      'Oculta las etiquetas de ID de colliders y mantiene disponibles los alambres.',
+    debugCollidersSolidIdsLabelEnabled: 'IDs de sólidos activadas',
+    debugCollidersSolidIdsLabelDisabled: 'IDs de sólidos desactivadas',
+    debugCollidersSolidIdsDescriptionEnabled:
+      'Muestra IDs estables y alambres para sólidos visibles de la escena.',
+    debugCollidersSolidIdsDescriptionDisabled:
+      'Las IDs estables de sólidos y sus alambres permanecen ocultos.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -74,6 +74,18 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
       'Megjeleníti az aktív emelet láthatatlan falait és ütközési téglalapjait.',
     debugCollidersDescriptionDisabled:
       'A láthatatlan falak és ütközési téglalapok rejtve maradnak, amíg be nem kapcsolod.',
+    debugCollidersIdsLabelEnabled: 'Collider-azonosítók be',
+    debugCollidersIdsLabelDisabled: 'Collider-azonosítók ki',
+    debugCollidersIdsDescriptionEnabled:
+      'Megjeleníti a collider-azonosító címkéket, amíg a réteg aktív.',
+    debugCollidersIdsDescriptionDisabled:
+      'Elrejti a collider-azonosító címkéket, de a drótvázakat elérhetően hagyja.',
+    debugCollidersSolidIdsLabelEnabled: 'Solid-azonosítók be',
+    debugCollidersSolidIdsLabelDisabled: 'Solid-azonosítók ki',
+    debugCollidersSolidIdsDescriptionEnabled:
+      'Stabil azonosítókat és drótvázakat mutat a látható jelenetszilárdtestekhez.',
+    debugCollidersSolidIdsDescriptionDisabled:
+      'A stabil solid-azonosítók és drótvázak rejtve maradnak.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -306,6 +306,19 @@ export const JA_OVERRIDES: LocaleOverrides = {
       labelDisabled: 'コライダーオーバーレイオフ',
       descriptionEnabled: '現在の階の見えない壁と衝突矩形を表示します。',
       descriptionDisabled: '見えない壁と衝突矩形はオンにするまで非表示です。',
+
+      idsLabelEnabled: 'Collider ID オン',
+      idsLabelDisabled: 'Collider ID オフ',
+      idsDescriptionEnabled:
+        'コライダーオーバーレイがオンのときに ID ラベルを表示します。',
+      idsDescriptionDisabled:
+        'コライダーのワイヤーフレームを残したまま ID ラベルを隠します。',
+      solidIdsLabelEnabled: 'Solid ID オン',
+      solidIdsLabelDisabled: 'Solid ID オフ',
+      solidIdsDescriptionEnabled:
+        '表示中のシーンソリッドに安定 ID とワイヤーフレームを表示します。',
+      solidIdsDescriptionDisabled:
+        '安定したソリッド ID とワイヤーフレームを隠します。',
     },
     poiOverlay: {
       visited: '訪問済み',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -71,6 +71,14 @@ interface LatinLocaleCopy {
     debugCollidersLabelDisabled: string;
     debugCollidersDescriptionEnabled: string;
     debugCollidersDescriptionDisabled: string;
+    debugCollidersIdsLabelEnabled?: string;
+    debugCollidersIdsLabelDisabled?: string;
+    debugCollidersIdsDescriptionEnabled?: string;
+    debugCollidersIdsDescriptionDisabled?: string;
+    debugCollidersSolidIdsLabelEnabled?: string;
+    debugCollidersSolidIdsLabelDisabled?: string;
+    debugCollidersSolidIdsDescriptionEnabled?: string;
+    debugCollidersSolidIdsDescriptionDisabled?: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -749,6 +757,25 @@ export function buildLatinLocaleOverrides(
         labelDisabled: s.debugCollidersLabelDisabled,
         descriptionEnabled: s.debugCollidersDescriptionEnabled,
         descriptionDisabled: s.debugCollidersDescriptionDisabled,
+        idsLabelEnabled: s.debugCollidersIdsLabelEnabled ?? 'Collider IDs on',
+        idsLabelDisabled:
+          s.debugCollidersIdsLabelDisabled ?? 'Collider IDs off',
+        idsDescriptionEnabled:
+          s.debugCollidersIdsDescriptionEnabled ??
+          'Shows collider ID labels while the collider overlay is on.',
+        idsDescriptionDisabled:
+          s.debugCollidersIdsDescriptionDisabled ??
+          'Hides collider ID labels while keeping collider wireframes available.',
+        solidIdsLabelEnabled:
+          s.debugCollidersSolidIdsLabelEnabled ?? 'Solid IDs on',
+        solidIdsLabelDisabled:
+          s.debugCollidersSolidIdsLabelDisabled ?? 'Solid IDs off',
+        solidIdsDescriptionEnabled:
+          s.debugCollidersSolidIdsDescriptionEnabled ??
+          'Shows stable IDs and wireframes for visible scene solids.',
+        solidIdsDescriptionDisabled:
+          s.debugCollidersSolidIdsDescriptionDisabled ??
+          'Stable solid IDs and wireframes stay hidden.',
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -74,6 +74,18 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
       'Mostra paredes invisíveis e retângulos de colisão do piso ativo.',
     debugCollidersDescriptionDisabled:
       'As paredes invisíveis e os retângulos de colisão ficam ocultos até você ativá-los.',
+    debugCollidersIdsLabelEnabled: 'IDs de colisores ativados',
+    debugCollidersIdsLabelDisabled: 'IDs de colisores desativados',
+    debugCollidersIdsDescriptionEnabled:
+      'Mostra etiquetas de ID dos colisores enquanto a sobreposição está ativa.',
+    debugCollidersIdsDescriptionDisabled:
+      'Oculta etiquetas de ID dos colisores e mantém os wireframes disponíveis.',
+    debugCollidersSolidIdsLabelEnabled: 'IDs de sólidos ativados',
+    debugCollidersSolidIdsLabelDisabled: 'IDs de sólidos desativados',
+    debugCollidersSolidIdsDescriptionEnabled:
+      'Mostra IDs estáveis e wireframes para sólidos visíveis da cena.',
+    debugCollidersSolidIdsDescriptionDisabled:
+      'IDs estáveis de sólidos e wireframes permanecem ocultos.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -293,6 +293,15 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       labelDisabled: '碰撞体叠加层已关闭',
       descriptionEnabled: '显示当前楼层的不可见墙和碰撞矩形。',
       descriptionDisabled: '不可见墙和碰撞矩形会保持隐藏，直到你开启。',
+
+      idsLabelEnabled: '碰撞体 ID 开',
+      idsLabelDisabled: '碰撞体 ID 关',
+      idsDescriptionEnabled: '在碰撞体叠层开启时显示碰撞体 ID 标签。',
+      idsDescriptionDisabled: '隐藏碰撞体 ID 标签，但保留碰撞体线框。',
+      solidIdsLabelEnabled: '实体 ID 开',
+      solidIdsLabelDisabled: '实体 ID 关',
+      solidIdsDescriptionEnabled: '为可见场景实体显示稳定 ID 和线框。',
+      solidIdsDescriptionDisabled: '隐藏稳定实体 ID 和线框。',
     },
     tourReset: {
       heading: '导览',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -238,6 +238,14 @@ export interface DebugCollidersStrings {
   labelDisabled: string;
   descriptionEnabled: string;
   descriptionDisabled: string;
+  idsLabelEnabled: string;
+  idsLabelDisabled: string;
+  idsDescriptionEnabled: string;
+  idsDescriptionDisabled: string;
+  solidIdsLabelEnabled: string;
+  solidIdsLabelDisabled: string;
+  solidIdsDescriptionEnabled: string;
+  solidIdsDescriptionDisabled: string;
 }
 
 export interface TourResetControlStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,6 +116,11 @@ import {
   type DebugColliderVisualizerState,
 } from './scene/debug/colliderVisualizer';
 import {
+  createSolidVisualizer,
+  type DebugSolidMetadata,
+  type DebugSolidVisualizerState,
+} from './scene/debug/solidVisualizer';
+import {
   createBackyardEnvironment,
   type BackyardEnvironmentBuild,
 } from './scene/environments/backyard';
@@ -478,6 +483,8 @@ const LOCALE_STORAGE_KEY = 'danielsmith.io:locale';
 const GUIDED_TOUR_STORAGE_KEY = 'danielsmith.io:guided-tour-enabled';
 const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
+const DEBUG_COLLIDER_IDS_STORAGE_KEY = 'danielsmith.io::debugColliderIds::v1';
+const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
 const isDebugUrlValueIn = (
@@ -587,6 +594,7 @@ declare global {
       debugColliders?: {
         getState(): DebugColliderVisualizerState;
         setEnabled(enabled: boolean): void;
+        setIdsEnabled(enabled: boolean): void;
         getColliders(): DebugColliderMetadata[];
         getBlockingCollidersAt(target: {
           x: number;
@@ -594,6 +602,12 @@ declare global {
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+      };
+      debugSolids?: {
+        getState(): DebugSolidVisualizerState;
+        setEnabled(enabled: boolean): void;
+        getSolids(): DebugSolidMetadata[];
+        getSolidById(id: unknown): DebugSolidMetadata | undefined;
       };
       debugCoordinates?: {
         getState(): {
@@ -1402,8 +1416,43 @@ function initializeImmersiveScene(
   let debugCollidersEnabled = debugCollidersUrlDisabled
     ? false
     : debugCollidersUrlEnabled || debugCollidersStoredEnabled;
+  const debugColliderIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugColliderIds');
+  const debugColliderIdsUrlEnabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugColliderIdsUrlDisabled = isDebugUrlValueIn(
+    debugColliderIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugColliderIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_COLLIDER_IDS_STORAGE_KEY) !== '0';
+  let debugColliderIdsEnabled = debugColliderIdsUrlDisabled
+    ? false
+    : debugColliderIdsUrlEnabled || debugColliderIdsStoredEnabled;
+
+  const debugSolidIdsUrlOverride = new URLSearchParams(
+    window.location.search
+  ).get('debugSolidIds');
+  const debugSolidIdsUrlEnabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugSolidIdsUrlDisabled = isDebugUrlValueIn(
+    debugSolidIdsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugSolidIdsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_SOLID_IDS_STORAGE_KEY) === '1';
+  let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
+    ? false
+    : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
+  let debugColliderIdsControl: HTMLButtonElement | null = null;
+  let debugSolidIdsControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -4175,6 +4224,7 @@ function initializeImmersiveScene(
     activeFloorId,
     enabled: debugCollidersEnabled,
   });
+  colliderVisualizer.setIdsEnabled(debugColliderIdsEnabled);
   colliderVisualizer.register([
     ...createDebugColliderRegistrations(groundColliders, {
       floor: 'ground',
@@ -4194,6 +4244,15 @@ function initializeImmersiveScene(
     }),
   ]);
   scene.add(colliderVisualizer.group);
+
+  const solidVisualizer = createSolidVisualizer({
+    enabled: debugSolidIdsEnabled,
+  });
+  solidVisualizer.register(
+    scene,
+    new Set(colliderVisualizer.getColliders().map((collider) => collider.id))
+  );
+  scene.add(solidVisualizer.group);
 
   const containsRectPoint = (
     rect: { minX: number; maxX: number; minZ: number; maxZ: number },
@@ -4415,6 +4474,54 @@ function initializeImmersiveScene(
     debugCollidersControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugColliderIdsControl = () => {
+    if (!debugColliderIdsControl) {
+      return;
+    }
+    const effectiveEnabled = debugCollidersEnabled && debugColliderIdsEnabled;
+    const label = debugColliderIdsEnabled
+      ? debugCollidersStrings.idsLabelEnabled
+      : debugCollidersStrings.idsLabelDisabled;
+    const description = debugColliderIdsEnabled
+      ? debugCollidersStrings.idsDescriptionEnabled
+      : debugCollidersStrings.idsDescriptionDisabled;
+    debugColliderIdsControl.textContent = label;
+    debugColliderIdsControl.disabled = !debugCollidersEnabled;
+    debugColliderIdsControl.dataset.state = effectiveEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugColliderIdsControl.setAttribute(
+      'aria-pressed',
+      effectiveEnabled ? 'true' : 'false'
+    );
+    debugColliderIdsControl.setAttribute('aria-label', description);
+    debugColliderIdsControl.title = description;
+    debugColliderIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const refreshDebugSolidIdsControl = () => {
+    if (!debugSolidIdsControl) {
+      return;
+    }
+    const label = debugSolidIdsEnabled
+      ? debugCollidersStrings.solidIdsLabelEnabled
+      : debugCollidersStrings.solidIdsLabelDisabled;
+    const description = debugSolidIdsEnabled
+      ? debugCollidersStrings.solidIdsDescriptionEnabled
+      : debugCollidersStrings.solidIdsDescriptionDisabled;
+    debugSolidIdsControl.textContent = label;
+    debugSolidIdsControl.dataset.state = debugSolidIdsEnabled
+      ? 'enabled'
+      : 'disabled';
+    debugSolidIdsControl.setAttribute(
+      'aria-pressed',
+      debugSolidIdsEnabled ? 'true' : 'false'
+    );
+    debugSolidIdsControl.setAttribute('aria-label', description);
+    debugSolidIdsControl.title = description;
+    debugSolidIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
   const setDebugCollidersEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4422,6 +4529,7 @@ function initializeImmersiveScene(
     debugCollidersEnabled = enabled;
     colliderVisualizer.setEnabled(enabled);
     refreshDebugCollidersControl();
+    refreshDebugColliderIdsControl();
     if (options.persist !== false && debugCoordinatesStorage) {
       try {
         debugCoordinatesStorage.setItem(
@@ -4430,6 +4538,44 @@ function initializeImmersiveScene(
         );
       } catch (error) {
         console.warn('Failed to persist debug collider preference.', error);
+      }
+    }
+  };
+
+  const setDebugColliderIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugColliderIdsEnabled = enabled;
+    colliderVisualizer.setIdsEnabled(enabled);
+    refreshDebugColliderIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_COLLIDER_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug collider ID preference.', error);
+      }
+    }
+  };
+
+  const setDebugSolidIdsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugSolidIdsEnabled = enabled;
+    solidVisualizer.setEnabled(enabled);
+    refreshDebugSolidIdsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_SOLID_IDS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug solid ID preference.', error);
       }
     }
   };
@@ -4464,6 +4610,8 @@ function initializeImmersiveScene(
 
   const refreshDebugCollidersStrings = () => {
     refreshDebugCollidersControl();
+    refreshDebugColliderIdsControl();
+    refreshDebugSolidIdsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4491,6 +4639,26 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugCollidersControl);
   registerHudControlElement(debugCollidersControl);
   refreshDebugCollidersControl();
+
+  debugColliderIdsControl = document.createElement('button');
+  debugColliderIdsControl.type = 'button';
+  debugColliderIdsControl.className = 'tour-toggle debug-collider-ids-toggle';
+  debugColliderIdsControl.addEventListener('click', () => {
+    setDebugColliderIdsEnabled(!debugColliderIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugColliderIdsControl);
+  registerHudControlElement(debugColliderIdsControl);
+  refreshDebugColliderIdsControl();
+
+  debugSolidIdsControl = document.createElement('button');
+  debugSolidIdsControl.type = 'button';
+  debugSolidIdsControl.className = 'tour-toggle debug-solid-ids-toggle';
+  debugSolidIdsControl.addEventListener('click', () => {
+    setDebugSolidIdsEnabled(!debugSolidIdsEnabled);
+  });
+  hudSettingsStack.appendChild(debugSolidIdsControl);
+  registerHudControlElement(debugSolidIdsControl);
+  refreshDebugSolidIdsControl();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4521,9 +4689,21 @@ function initializeImmersiveScene(
     setEnabled: (enabled: boolean) => {
       setDebugCollidersEnabled(enabled);
     },
+    setIdsEnabled: (enabled: boolean) => {
+      setDebugColliderIdsEnabled(enabled);
+    },
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+  };
+
+  window.portfolio.debugSolids = {
+    getState: () => solidVisualizer.getState(),
+    setEnabled: (enabled: boolean) => {
+      setDebugSolidIdsEnabled(enabled);
+    },
+    getSolids: () => solidVisualizer.getSolids(),
+    getSolidById: (id: unknown) => solidVisualizer.getSolidById(id),
   };
 
   window.portfolio.debugCoordinates = {
@@ -6021,6 +6201,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugColliders) {
       delete window.portfolio.debugColliders;
     }
+    if (window.portfolio?.debugSolids) {
+      delete window.portfolio.debugSolids;
+    }
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
@@ -6043,6 +6226,14 @@ function initializeImmersiveScene(
       debugCollidersControl.remove();
       debugCollidersControl = null;
     }
+    if (debugColliderIdsControl) {
+      debugColliderIdsControl.remove();
+      debugColliderIdsControl = null;
+    }
+    if (debugSolidIdsControl) {
+      debugSolidIdsControl.remove();
+      debugSolidIdsControl = null;
+    }
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
@@ -6050,6 +6241,7 @@ function initializeImmersiveScene(
       debugCoordinatesRows.clear();
     }
     colliderVisualizer.dispose();
+    solidVisualizer.dispose();
     movementLegend?.dispose();
     narrationPreference.dispose();
     if (proceduralNarrator) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4248,10 +4248,20 @@ function initializeImmersiveScene(
   const solidVisualizer = createSolidVisualizer({
     enabled: debugSolidIdsEnabled,
   });
-  solidVisualizer.register(
-    scene,
-    new Set(colliderVisualizer.getColliders().map((collider) => collider.id))
-  );
+  let solidVisualizerRegistered = false;
+  const ensureSolidVisualizerRegistered = () => {
+    if (solidVisualizerRegistered) {
+      return;
+    }
+    solidVisualizer.register(
+      scene,
+      new Set(colliderVisualizer.getColliders().map((collider) => collider.id))
+    );
+    solidVisualizerRegistered = true;
+  };
+  if (debugSolidIdsEnabled) {
+    ensureSolidVisualizerRegistered();
+  }
   scene.add(solidVisualizer.group);
 
   const containsRectPoint = (
@@ -4566,6 +4576,9 @@ function initializeImmersiveScene(
     options: { persist?: boolean } = { persist: true }
   ) => {
     debugSolidIdsEnabled = enabled;
+    if (enabled) {
+      ensureSolidVisualizerRegistered();
+    }
     solidVisualizer.setEnabled(enabled);
     refreshDebugSolidIdsControl();
     if (options.persist !== false && debugCoordinatesStorage) {
@@ -4702,8 +4715,14 @@ function initializeImmersiveScene(
     setEnabled: (enabled: boolean) => {
       setDebugSolidIdsEnabled(enabled);
     },
-    getSolids: () => solidVisualizer.getSolids(),
-    getSolidById: (id: unknown) => solidVisualizer.getSolidById(id),
+    getSolids: () => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolids();
+    },
+    getSolidById: (id: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidById(id);
+    },
   };
 
   window.portfolio.debugCoordinates = {
@@ -6544,6 +6563,7 @@ function initializeImmersiveScene(
           emphasis: Math.max(activation, focus),
         });
       }
+      solidVisualizer.update();
       if (backyardEnvironment) {
         if (
           sceneDetailController.shouldRunDecorativeUpdate(

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -151,8 +151,9 @@ describe('createColliderVisualizer', () => {
       },
     ]);
 
-    expect(visualizer.getState()).toMatchObject({
+    expect(visualizer.getState()).toEqual({
       enabled: false,
+      idsEnabled: true,
       visibleColliderCount: 0,
       totalColliderCount: 3,
       visibleLabelCount: 0,
@@ -160,8 +161,9 @@ describe('createColliderVisualizer', () => {
     });
 
     visualizer.setEnabled(true);
-    expect(visualizer.getState()).toMatchObject({
+    expect(visualizer.getState()).toEqual({
       enabled: true,
+      idsEnabled: true,
       visibleColliderCount: 2,
       totalColliderCount: 3,
       visibleLabelCount: 2,
@@ -265,11 +267,13 @@ describe('createColliderVisualizer', () => {
     visualizer.setIdsEnabled(false);
     expect(mesh?.visible).toBe(true);
     expect(label?.visible).toBe(false);
-    expect(visualizer.getState()).toMatchObject({
+    expect(visualizer.getState()).toEqual({
       enabled: true,
       idsEnabled: false,
       visibleColliderCount: 1,
+      totalColliderCount: 1,
       visibleLabelCount: 0,
+      totalLabelCount: 1,
     });
 
     visualizer.setEnabled(false);

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -151,7 +151,7 @@ describe('createColliderVisualizer', () => {
       },
     ]);
 
-    expect(visualizer.getState()).toEqual({
+    expect(visualizer.getState()).toMatchObject({
       enabled: false,
       visibleColliderCount: 0,
       totalColliderCount: 3,
@@ -160,7 +160,7 @@ describe('createColliderVisualizer', () => {
     });
 
     visualizer.setEnabled(true);
-    expect(visualizer.getState()).toEqual({
+    expect(visualizer.getState()).toMatchObject({
       enabled: true,
       visibleColliderCount: 2,
       totalColliderCount: 3,
@@ -239,6 +239,42 @@ describe('createColliderVisualizer', () => {
     expect(material.color.getHex()).toBe(labelMaterial.color.getHex());
     expect(labelMaterial.depthTest).toBe(false);
     expect(labelMaterial.depthWrite).toBe(false);
+  });
+
+  it('hides collider ID labels independently from wireframes', () => {
+    const visualizer = createColliderVisualizer({
+      activeFloorId: 'ground',
+      enabled: true,
+    });
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'ground-ids',
+        bounds: collider,
+      },
+    ]);
+
+    const mesh = visualizer.group.children.find(
+      (child) => child.type === 'Mesh'
+    );
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    );
+
+    visualizer.setIdsEnabled(false);
+    expect(mesh?.visible).toBe(true);
+    expect(label?.visible).toBe(false);
+    expect(visualizer.getState()).toMatchObject({
+      enabled: true,
+      idsEnabled: false,
+      visibleColliderCount: 1,
+      visibleLabelCount: 0,
+    });
+
+    visualizer.setEnabled(false);
+    expect(mesh?.visible).toBe(false);
+    expect(label?.visible).toBe(false);
   });
 
   it('keeps explicit collider color overrides synced between wireframes and labels', () => {

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -167,6 +167,25 @@ describe('createSolidVisualizer', () => {
     });
   });
 
+  it('keeps multiplayer projection solids while excluding player/avatar meshes', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    scene.add(createSolid('BackyardMultiplayerProjection'));
+    scene.add(createSolid('MultiplayerProjectionPanel'));
+    scene.add(createSolid('PlayerControllerMesh'));
+    scene.add(createSolid('PlayerAvatarMesh'));
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    expect(
+      visualizer
+        .getSolids()
+        .map((solid) => solid.name)
+        .sort()
+    ).toEqual(['BackyardMultiplayerProjection', 'MultiplayerProjectionPanel']);
+  });
+
   it('registers own-hidden animated solids and shows them after they become visible', () => {
     const scene = new Group();
     scene.name = 'Scene';

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -13,6 +13,16 @@ const createSolid = (name = 'solid') => {
   return mesh;
 };
 
+const getOverlayCounts = (
+  visualizer: ReturnType<typeof createSolidVisualizer>
+) => ({
+  labels: visualizer.group.children.filter((child) => child.type === 'Sprite')
+    .length,
+  wireframes: visualizer.group.children.filter(
+    (child) => child.type === 'LineSegments'
+  ).length,
+});
+
 describe('createSolidDebugId', () => {
   const metadata = {
     name: 'Wall',
@@ -68,7 +78,12 @@ describe('createSolidVisualizer', () => {
     const scene = new Group();
     scene.name = 'Scene';
     scene.add(createSolid('WallA'), createSolid('WallB'));
-    const reservedId = 'ABCD';
+    const reservedId = createColliderDebugId({
+      floor: 'ground',
+      category: 'walls',
+      name: 'WallA',
+      bounds: { minX: -1, maxX: 1, minZ: -1, maxZ: 1 },
+    });
 
     const visualizer = createSolidVisualizer({ enabled: true });
     visualizer.register(scene, new Set([reservedId]));
@@ -98,22 +113,88 @@ describe('createSolidVisualizer', () => {
     );
   });
 
-  it('skips invisible and POI meshes and updates animated solid transforms', () => {
+  it('registers only effective visible stable scene solids', () => {
     const scene = new Group();
     scene.name = 'Scene';
-    const visible = createSolid('AnimatedWall');
+    const visible = createSolid('VisibleWall');
+    const ownHidden = createSolid('OwnHiddenWall');
+    ownHidden.visible = false;
     const hiddenParent = new Group();
     hiddenParent.visible = false;
-    hiddenParent.add(createSolid('HiddenWall'));
-    const poi = createSolid('POI_HIT:demo');
-    scene.add(visible, hiddenParent, poi);
+    hiddenParent.add(createSolid('HiddenAncestorWall'));
+    const debugParent = new Group();
+    debugParent.userData.debugOnly = true;
+    debugParent.add(createSolid('DebugChildWall'));
+    const poiHit = createSolid('POI_HIT:demo');
+    const transparentHitArea = createSolid('TransparentInteractionHitArea');
+    transparentHitArea.material.transparent = true;
+    transparentHitArea.material.opacity = 0;
+    const player = createSolid('PlayerAvatarMesh');
+    const mannequin = createSolid('PortfolioMannequinCollisionProxy');
+    scene.add(
+      visible,
+      ownHidden,
+      hiddenParent,
+      debugParent,
+      poiHit,
+      transparentHitArea,
+      player,
+      mannequin
+    );
 
     const visualizer = createSolidVisualizer({ enabled: true });
     visualizer.register(scene);
 
     expect(visualizer.getSolids().map((solid) => solid.name)).toEqual([
-      'AnimatedWall',
+      'VisibleWall',
     ]);
+  });
+
+  it('does not duplicate overlays after repeated enable-disable cycles', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    scene.add(createSolid('WallA'), createSolid('WallB'));
+    const visualizer = createSolidVisualizer();
+
+    visualizer.register(scene);
+    const initialCounts = getOverlayCounts(visualizer);
+    visualizer.setEnabled(true);
+    visualizer.setEnabled(false);
+    visualizer.setEnabled(true);
+
+    expect(getOverlayCounts(visualizer)).toEqual(initialCounts);
+    expect(visualizer.getState()).toMatchObject({
+      enabled: true,
+      totalSolidCount: 2,
+      totalLabelCount: 2,
+      visibleSolidCount: 2,
+      visibleLabelCount: 2,
+    });
+  });
+
+  it('does not leave computed bounding boxes on source geometry', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solid = createSolid('NoSourceBoundingBoxMutation');
+    solid.geometry.boundingBox = null;
+    scene.add(solid);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    expect(visualizer.getSolids()).toHaveLength(1);
+    expect(solid.geometry.boundingBox).toBeNull();
+  });
+
+  it('updates animated solid transforms and keeps solid labels out of collider metadata', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const visible = createSolid('AnimatedWall');
+    scene.add(visible);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
     const wireframe = visualizer.group.children.find(
       (child) => child.type === 'LineSegments'
     );

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -150,9 +150,9 @@ describe('createSolidVisualizer', () => {
         .getSolids()
         .map((solid) => solid.name)
         .sort()
-    ).toEqual(['HiddenAncestorWall', 'VisibleWall']);
+    ).toEqual(['HiddenAncestorWall', 'OwnHiddenWall', 'VisibleWall']);
     expect(visualizer.getState()).toMatchObject({
-      totalSolidCount: 2,
+      totalSolidCount: 3,
       visibleSolidCount: 1,
       visibleLabelCount: 1,
     });
@@ -161,9 +161,38 @@ describe('createSolidVisualizer', () => {
     visualizer.update();
 
     expect(visualizer.getState()).toMatchObject({
-      totalSolidCount: 2,
+      totalSolidCount: 3,
       visibleSolidCount: 2,
       visibleLabelCount: 2,
+    });
+  });
+
+  it('registers own-hidden animated solids and shows them after they become visible', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const animatedHidden = createSolid('FlywheelDocsCallout');
+    animatedHidden.visible = false;
+    scene.add(animatedHidden);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    expect(visualizer.getSolids().map((solid) => solid.name)).toEqual([
+      'FlywheelDocsCallout',
+    ]);
+    expect(visualizer.getState()).toMatchObject({
+      totalSolidCount: 1,
+      visibleSolidCount: 0,
+      visibleLabelCount: 0,
+    });
+
+    animatedHidden.visible = true;
+    visualizer.update();
+
+    expect(visualizer.getState()).toMatchObject({
+      totalSolidCount: 1,
+      visibleSolidCount: 1,
+      visibleLabelCount: 1,
     });
   });
 

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -167,6 +167,32 @@ describe('createSolidVisualizer', () => {
     });
   });
 
+  it('excludes POI marker implementation children while keeping ordinary solids', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const poiGroup = new Group();
+    poiGroup.name = 'POI:futuroptimist-living-room-tv';
+    poiGroup.add(createSolid(''));
+    poiGroup.add(createSolid('Halo'));
+    poiGroup.add(createSolid('MarkerLabel'));
+    const transparentHit = createSolid('POI_HIT:futuroptimist-living-room-tv');
+    transparentHit.material.transparent = true;
+    transparentHit.material.opacity = 0;
+    scene.add(poiGroup, transparentHit, createSolid('OrdinarySceneWall'));
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    expect(visualizer.getSolids().map((solid) => solid.name)).toEqual([
+      'OrdinarySceneWall',
+    ]);
+    expect(visualizer.getState()).toMatchObject({
+      totalSolidCount: 1,
+      visibleSolidCount: 1,
+      visibleLabelCount: 1,
+    });
+  });
+
   it('keeps multiplayer projection solids while excluding player/avatar meshes', () => {
     const scene = new Group();
     scene.name = 'Scene';

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -113,7 +113,7 @@ describe('createSolidVisualizer', () => {
     );
   });
 
-  it('registers only effective visible stable scene solids', () => {
+  it('registers stable scene solids while hiding currently ineffective entries', () => {
     const scene = new Group();
     scene.name = 'Scene';
     const visible = createSolid('VisibleWall');
@@ -145,9 +145,56 @@ describe('createSolidVisualizer', () => {
     const visualizer = createSolidVisualizer({ enabled: true });
     visualizer.register(scene);
 
+    expect(
+      visualizer
+        .getSolids()
+        .map((solid) => solid.name)
+        .sort()
+    ).toEqual(['HiddenAncestorWall', 'VisibleWall']);
+    expect(visualizer.getState()).toMatchObject({
+      totalSolidCount: 2,
+      visibleSolidCount: 1,
+      visibleLabelCount: 1,
+    });
+
+    hiddenParent.visible = true;
+    visualizer.update();
+
+    expect(visualizer.getState()).toMatchObject({
+      totalSolidCount: 2,
+      visibleSolidCount: 2,
+      visibleLabelCount: 2,
+    });
+  });
+
+  it('registers opacity-animated solids but hides them while fully transparent', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const animated = createSolid('SigmaWorkbenchHologram');
+    animated.material.transparent = true;
+    animated.material.opacity = 0;
+    scene.add(animated);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
     expect(visualizer.getSolids().map((solid) => solid.name)).toEqual([
-      'VisibleWall',
+      'SigmaWorkbenchHologram',
     ]);
+    expect(visualizer.getState()).toMatchObject({
+      totalSolidCount: 1,
+      visibleSolidCount: 0,
+      visibleLabelCount: 0,
+    });
+
+    animated.material.opacity = 1;
+    visualizer.update();
+
+    expect(visualizer.getState()).toMatchObject({
+      totalSolidCount: 1,
+      visibleSolidCount: 1,
+      visibleLabelCount: 1,
+    });
   });
 
   it('does not duplicate overlays after repeated enable-disable cycles', () => {

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -1,0 +1,100 @@
+import { BoxGeometry, Group, Mesh, MeshBasicMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createColliderDebugId } from '../colliderVisualizer';
+import { createSolidDebugId, createSolidVisualizer } from '../solidVisualizer';
+
+const createSolid = (name = 'solid') => {
+  const mesh = new Mesh(
+    new BoxGeometry(1, 2, 3),
+    new MeshBasicMaterial({ color: 'red' })
+  );
+  mesh.name = name;
+  return mesh;
+};
+
+describe('createSolidDebugId', () => {
+  const metadata = {
+    name: 'Wall',
+    path: 'Scene/Wall',
+    parentPath: 'Scene',
+    meshType: 'Mesh',
+    bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 2, z: 3 } },
+    material: 'MeshBasicMaterial:#ff0000',
+  };
+
+  it('is deterministic, uppercase hex, and changes for meaningful metadata', () => {
+    expect(createSolidDebugId(metadata)).toBe(createSolidDebugId(metadata));
+    expect(createSolidDebugId(metadata)).toMatch(/^[0-9A-F]{6}$/);
+    expect(createSolidDebugId(metadata)).not.toBe(
+      createSolidDebugId({ ...metadata, path: 'Scene/WallMoved' })
+    );
+  });
+
+  it('avoids reserved collider IDs', () => {
+    const colliderId = createColliderDebugId({
+      floor: 'ground',
+      category: 'walls',
+      name: 'reserved',
+      bounds: { minX: 0, maxX: 1, minZ: 0, maxZ: 1 },
+    });
+    expect(createSolidDebugId(metadata, new Set([colliderId]))).not.toBe(
+      colliderId
+    );
+  });
+});
+
+describe('createSolidVisualizer', () => {
+  it('registers mesh solids, excludes debug-only meshes, and returns metadata copies', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solid = createSolid('VisibleWall');
+    const debugOnly = createSolid('DebugColliderMesh');
+    debugOnly.userData.debugOnly = true;
+    scene.add(solid, debugOnly);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const solids = visualizer.getSolids();
+    expect(solids).toHaveLength(1);
+    expect(solids[0]).toMatchObject({ name: 'VisibleWall', meshType: 'Mesh' });
+    expect(visualizer.getSolidById(solids[0].id)).toEqual(solids[0]);
+    solids[0].bounds.min.x = 99;
+    expect(visualizer.getSolids()[0].bounds.min.x).not.toBe(99);
+  });
+
+  it('creates matching non-raycasting debug wireframes and labels without ID collisions', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    scene.add(createSolid('WallA'), createSolid('WallB'));
+    const reservedId = 'ABCD';
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene, new Set([reservedId]));
+
+    const solids = visualizer.getSolids();
+    expect(new Set(solids.map((solid) => solid.id)).size).toBe(solids.length);
+    expect(solids.some((solid) => solid.id === reservedId)).toBe(false);
+
+    const wireframe = visualizer.group.children.find(
+      (child) => child.type === 'LineSegments'
+    );
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    );
+    expect(wireframe?.userData.debugOnly).toBe(true);
+    expect(label?.userData.debugOnly).toBe(true);
+    expect(wireframe?.raycast({} as never, [] as never)).toBeUndefined();
+    expect(label?.raycast({} as never, [] as never)).toBeUndefined();
+    expect(
+      (
+        wireframe as { material: { color: { getHex(): number } } }
+      ).material.color.getHex()
+    ).toBe(
+      (
+        label as { material: { color: { getHex(): number } } }
+      ).material.color.getHex()
+    );
+  });
+});

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -97,4 +97,33 @@ describe('createSolidVisualizer', () => {
       ).material.color.getHex()
     );
   });
+
+  it('skips invisible and POI meshes and updates animated solid transforms', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const visible = createSolid('AnimatedWall');
+    const hiddenParent = new Group();
+    hiddenParent.visible = false;
+    hiddenParent.add(createSolid('HiddenWall'));
+    const poi = createSolid('POI_HIT:demo');
+    scene.add(visible, hiddenParent, poi);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    expect(visualizer.getSolids().map((solid) => solid.name)).toEqual([
+      'AnimatedWall',
+    ]);
+    const wireframe = visualizer.group.children.find(
+      (child) => child.type === 'LineSegments'
+    );
+    const label = visualizer.group.children.find(
+      (child) => child.type === 'Sprite'
+    );
+    expect(label?.userData.colliderDebugLabel).toBeUndefined();
+
+    visible.position.x = 4;
+    visualizer.update();
+    expect(wireframe?.position.x).toBe(4);
+  });
 });

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -15,6 +15,13 @@ import type { RectCollider } from '../../systems/collision';
 import type { FloorId } from '../../systems/movement/stairs';
 
 import { getDeclaredColliderDebugId } from './colliderDebugIds';
+import {
+  DEBUG_ID_PRECISION,
+  allocateDebugId,
+  getDebugHash,
+  getDebugPaletteIndex,
+  roundDebugValue,
+} from './debugIds';
 
 export type DebugColliderFloor = FloorId | 'all';
 
@@ -38,6 +45,7 @@ export interface DebugColliderRegistration {
 
 export interface DebugColliderVisualizerState {
   enabled: boolean;
+  idsEnabled: boolean;
   visibleColliderCount: number;
   totalColliderCount: number;
   visibleLabelCount: number;
@@ -47,13 +55,14 @@ export interface DebugColliderVisualizerState {
 interface DebugColliderVisualEntry {
   metadata: DebugColliderMetadata;
   mesh: Mesh<BoxGeometry, MeshBasicMaterial>;
-  label: Sprite<SpriteMaterial>;
+  label: Sprite;
 }
 
 export interface ColliderVisualizer {
   readonly group: Group;
   register(colliders: readonly DebugColliderRegistration[]): void;
   setEnabled(enabled: boolean): void;
+  setIdsEnabled(enabled: boolean): void;
   setActiveFloor(floorId: FloorId): void;
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
@@ -63,12 +72,6 @@ export interface ColliderVisualizer {
 
 const DEFAULT_HEIGHT = 0.08;
 const MIN_DIMENSION = 0.02;
-const DEBUG_ID_MIN_LENGTH = 4;
-const DEBUG_ID_MAX_LENGTH = 6;
-const DEBUG_ID_PRECISION = 2;
-// Keep the visible primary ID namespaced from the raw metadata hash so
-// historical raw-prefix collisions do not decide screenshot-visible labels.
-const DEBUG_ID_PRIMARY_SALT = 'debug-id:v3';
 const LABEL_CANVAS_WIDTH = 256;
 const LABEL_CANVAS_HEIGHT = 128;
 const LABEL_TEXT_MAX_WIDTH = LABEL_CANVAS_WIDTH - 48;
@@ -76,8 +79,8 @@ const LABEL_FONT_MAX_SIZE = 54;
 const LABEL_FONT_MIN_SIZE = 28;
 const LABEL_SCALE_X = 1.6;
 const LABEL_SCALE_Y = 0.8;
-const LABEL_VERTICAL_GAP = 0.5;
-const LABEL_PALETTE = [
+export const DEBUG_LABEL_VERTICAL_GAP = 0.5;
+export const DEBUG_LABEL_PALETTE = [
   '#8BE9FD',
   '#F1FA8C',
   '#FF79C6',
@@ -97,9 +100,6 @@ const isVisibleOnFloor = (
   activeFloorId: FloorId
 ): boolean => colliderFloor === 'all' || colliderFloor === activeFloorId;
 
-const roundDebugValue = (value: number): number =>
-  Math.round(value * 10 ** DEBUG_ID_PRECISION) / 10 ** DEBUG_ID_PRECISION;
-
 const normalizeBoundsForId = (bounds: RectCollider): string =>
   [bounds.minX, bounds.maxX, bounds.minZ, bounds.maxZ]
     .map((value) => roundDebugValue(value).toFixed(DEBUG_ID_PRECISION))
@@ -115,49 +115,15 @@ const getColliderDebugSeed = (
     normalizeBoundsForId(metadata.bounds),
   ].join('|');
 
-const getStableDebugHashValue = (input: string): number => {
-  let low = 0xdeadbeef ^ input.length;
-  let high = 0x41c6ce57 ^ input.length;
-
-  for (let index = 0; index < input.length; index += 1) {
-    const charCode = input.charCodeAt(index);
-    low = Math.imul(low ^ charCode, 2_654_435_761);
-    high = Math.imul(high ^ charCode, 1_597_334_677);
-  }
-
-  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
-  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
-  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
-  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
-
-  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
-};
-
-const getColliderDebugHash = (seed: string): string =>
-  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
-    .toString(16)
-    .toUpperCase()
-    .padStart(DEBUG_ID_MAX_LENGTH, '0');
-
+// Keep the visible primary ID namespaced from the raw metadata hash so
+// historical raw-prefix collisions do not decide screenshot-visible labels.
+const DEBUG_ID_PRIMARY_SALT = 'debug-id:v3';
 const getColliderDebugPrimaryId = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
   seed: string
 ): string =>
   getDeclaredColliderDebugId(metadata) ??
-  getColliderDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`);
-
-const getColliderDebugIdCandidates = (seed: string): string[] => {
-  const hash = getColliderDebugHash(seed);
-  const candidates: string[] = [];
-  for (
-    let length = DEBUG_ID_MIN_LENGTH;
-    length <= DEBUG_ID_MAX_LENGTH;
-    length += 1
-  ) {
-    candidates.push(hash.slice(0, length));
-  }
-  return candidates;
-};
+  getDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`);
 
 const createColliderDebugIdFromMetadata = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
@@ -169,7 +135,7 @@ const createColliderDebugIdFromMetadata = (
     return primaryCandidate;
   }
 
-  return getColliderDebugRetryId(idSeed, new Set(usedIds));
+  return allocateDebugId(idSeed, usedIds, primaryCandidate);
 };
 
 export function createColliderDebugId(
@@ -178,27 +144,6 @@ export function createColliderDebugId(
 ): string {
   return createColliderDebugIdFromMetadata(metadata, usedIds);
 }
-
-const getColliderDebugRetryId = (
-  seed: string,
-  usedIds: Set<string>
-): string => {
-  for (
-    let retryIndex = 1;
-    retryIndex < Number.MAX_SAFE_INTEGER;
-    retryIndex += 1
-  ) {
-    for (const candidate of getColliderDebugIdCandidates(
-      `${seed}|retry:${retryIndex}`
-    )) {
-      if (!usedIds.has(candidate)) {
-        return candidate;
-      }
-    }
-  }
-
-  throw new Error('Unable to allocate a short collider debug ID');
-};
 
 const allocateColliderDebugIds = (
   metadataList: readonly Omit<DebugColliderMetadata, 'id'>[],
@@ -257,16 +202,6 @@ const allocateColliderDebugIds = (
   return ids;
 };
 
-const getLabelPaletteIndex = (id: string): number => {
-  const numericPrefix = Number.parseInt(
-    id.replace(/[^0-9A-F]/g, '').slice(0, DEBUG_ID_MAX_LENGTH),
-    16
-  );
-  return Number.isFinite(numericPrefix)
-    ? numericPrefix % LABEL_PALETTE.length
-    : 0;
-};
-
 const drawRoundedRect = (
   context: CanvasRenderingContext2D,
   x: number,
@@ -289,7 +224,7 @@ const drawRoundedRect = (
   context.quadraticCurveTo(x, y, x + radius, y);
 };
 
-const getLabelColorStyle = (color: ColorRepresentation): string =>
+export const getLabelColorStyle = (color: ColorRepresentation): string =>
   `#${new Color(color).getHexString()}`;
 
 const createLabelTexture = (
@@ -356,10 +291,7 @@ const createLabelTexture = (
   return texture;
 };
 
-const createColliderLabel = (
-  id: string,
-  color: string
-): Sprite<SpriteMaterial> => {
+export const createDebugIdLabel = (id: string, color: string): Sprite => {
   const texture = createLabelTexture(id, color);
   const material = new SpriteMaterial({
     color: texture ? 0xffffff : color,
@@ -395,6 +327,7 @@ export function createColliderVisualizer(options: {
 
   const entries: DebugColliderVisualEntry[] = [];
   let enabled = options.enabled ?? false;
+  let idsEnabled = true;
   let activeFloorId = options.activeFloorId;
 
   const applyVisibility = () => {
@@ -403,7 +336,7 @@ export function createColliderVisualizer(options: {
       const visible =
         enabled && isVisibleOnFloor(entry.metadata.floor, activeFloorId);
       entry.mesh.visible = visible;
-      entry.label.visible = visible;
+      entry.label.visible = visible && idsEnabled;
     }
   };
 
@@ -432,7 +365,10 @@ export function createColliderVisualizer(options: {
       const height = collider.height ?? DEFAULT_HEIGHT;
       const geometry = new BoxGeometry(width, height, depth);
       const labelColor = getLabelColorStyle(
-        collider.color ?? LABEL_PALETTE[getLabelPaletteIndex(id)]
+        collider.color ??
+          DEBUG_LABEL_PALETTE[
+            getDebugPaletteIndex(id, DEBUG_LABEL_PALETTE.length)
+          ]
       );
       const material = new MeshBasicMaterial({
         color: labelColor,
@@ -460,10 +396,10 @@ export function createColliderVisualizer(options: {
       };
       mesh.raycast = () => undefined;
 
-      const label = createColliderLabel(id, labelColor);
+      const label = createDebugIdLabel(id, labelColor);
       label.position.set(
         centerX,
-        baseElevation + height + LABEL_VERTICAL_GAP,
+        baseElevation + height + DEBUG_LABEL_VERTICAL_GAP,
         centerZ
       );
 
@@ -504,6 +440,10 @@ export function createColliderVisualizer(options: {
       enabled = next;
       applyVisibility();
     },
+    setIdsEnabled(next: boolean) {
+      idsEnabled = next;
+      applyVisibility();
+    },
     setActiveFloor(next: FloorId) {
       activeFloorId = next;
       applyVisibility();
@@ -511,9 +451,10 @@ export function createColliderVisualizer(options: {
     getState() {
       return {
         enabled,
+        idsEnabled,
         visibleColliderCount: getVisibleEntryCount(),
         totalColliderCount: entries.length,
-        visibleLabelCount: getVisibleEntryCount(),
+        visibleLabelCount: idsEnabled ? getVisibleEntryCount() : 0,
         totalLabelCount: entries.length,
       };
     },

--- a/src/scene/debug/debugIds.ts
+++ b/src/scene/debug/debugIds.ts
@@ -1,0 +1,80 @@
+export const DEBUG_ID_MIN_LENGTH = 4;
+export const DEBUG_ID_MAX_LENGTH = 6;
+export const DEBUG_ID_PRECISION = 2;
+
+export const roundDebugValue = (value: number): number =>
+  Math.round(value * 10 ** DEBUG_ID_PRECISION) / 10 ** DEBUG_ID_PRECISION;
+
+export const getStableDebugHashValue = (input: string): number => {
+  let low = 0xdeadbeef ^ input.length;
+  let high = 0x41c6ce57 ^ input.length;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const charCode = input.charCodeAt(index);
+    low = Math.imul(low ^ charCode, 2_654_435_761);
+    high = Math.imul(high ^ charCode, 1_597_334_677);
+  }
+
+  low = Math.imul(low ^ (low >>> 16), 2_246_822_507);
+  low ^= Math.imul(high ^ (high >>> 13), 3_266_489_909);
+  high = Math.imul(high ^ (high >>> 16), 2_246_822_507);
+  high ^= Math.imul(low ^ (low >>> 13), 3_266_489_909);
+
+  return 4_294_967_296 * (2_097_151 & high) + (low >>> 0);
+};
+
+export const getDebugHash = (seed: string): string =>
+  Math.floor(getStableDebugHashValue(seed) % 0x1000000)
+    .toString(16)
+    .toUpperCase()
+    .padStart(DEBUG_ID_MAX_LENGTH, '0');
+
+export const getDebugIdCandidates = (seed: string): string[] => {
+  const hash = getDebugHash(seed);
+  const candidates: string[] = [];
+  for (
+    let length = DEBUG_ID_MIN_LENGTH;
+    length <= DEBUG_ID_MAX_LENGTH;
+    length += 1
+  ) {
+    candidates.push(hash.slice(0, length));
+  }
+  return candidates;
+};
+
+export const allocateDebugId = (
+  seed: string,
+  usedIds: ReadonlySet<string>,
+  primaryCandidate = getDebugHash(seed)
+): string => {
+  if (!usedIds.has(primaryCandidate)) {
+    return primaryCandidate;
+  }
+
+  for (
+    let retryIndex = 1;
+    retryIndex < Number.MAX_SAFE_INTEGER;
+    retryIndex += 1
+  ) {
+    for (const candidate of getDebugIdCandidates(
+      `${seed}|retry:${retryIndex}`
+    )) {
+      if (!usedIds.has(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  throw new Error('Unable to allocate a short debug ID');
+};
+
+export const getDebugPaletteIndex = (
+  id: string,
+  paletteLength: number
+): number => {
+  const numericPrefix = Number.parseInt(
+    id.replace(/[^0-9A-F]/g, '').slice(0, DEBUG_ID_MAX_LENGTH),
+    16
+  );
+  return Number.isFinite(numericPrefix) ? numericPrefix % paletteLength : 0;
+};

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -337,11 +337,7 @@ export const createSolidVisualizer = (
     }> = [];
 
     root.traverse((object) => {
-      if (
-        !isMesh(object) ||
-        !object.visible ||
-        !hasNoExcludedAncestors(object)
-      ) {
+      if (!isMesh(object) || !hasNoExcludedAncestors(object)) {
         return;
       }
       const bounds = getBounds(object, object.geometry);

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -78,25 +78,59 @@ const isMesh = (
 ): object is Mesh<BufferGeometry, Material | Material[]> =>
   object instanceof Mesh;
 
+const matchesExcludedName = (name: string): boolean => {
+  const normalizedName = name.toLowerCase();
+  return (
+    name.startsWith('Debug') ||
+    name.startsWith('POI') ||
+    name.startsWith('POI_HIT:') ||
+    normalizedName.includes('debug') ||
+    normalizedName.includes('collider') ||
+    normalizedName.includes('helper') ||
+    normalizedName.includes('hud') ||
+    normalizedName.includes('label') ||
+    normalizedName.includes('sprite') ||
+    normalizedName.includes('ui') ||
+    normalizedName.includes('player') ||
+    normalizedName.includes('avatar') ||
+    normalizedName.includes('mannequin')
+  );
+};
+
 const isExcluded = (object: Object3D): boolean => {
   if (
     object.userData.debugOnly ||
     object.userData.colliderDebug ||
-    object.userData.poiLabel
+    object.userData.poiLabel ||
+    object.userData.poi ||
+    object.userData.hud ||
+    object.userData.ui ||
+    object.userData.label ||
+    object.userData.player ||
+    object.userData.avatar
   ) {
     return true;
   }
-  if (object.name.startsWith('POI') || object.name.startsWith('POI_HIT:')) {
+  if (matchesExcludedName(object.name)) {
     return true;
   }
   if (
     object.type === 'Sprite' ||
     object.type.includes('Light') ||
-    object.type === 'Camera'
+    object.type === 'Camera' ||
+    object.type.includes('Helper')
   ) {
     return true;
   }
-  return object.name.startsWith('Debug') || object.name.includes('Helper');
+  return false;
+};
+
+const isInvisibleMaterial = (material: Material): boolean =>
+  material.transparent === true && material.opacity <= 0;
+
+const hasInvisibleMaterial = (material: Material | Material[]): boolean => {
+  const materials = Array.isArray(material) ? material : [material];
+  return materials.length > 0 && materials.every(isInvisibleMaterial);
 };
 
 const hasVisibleAncestors = (object: Object3D): boolean => {
@@ -133,8 +167,18 @@ const cloneBounds = (bounds: DebugSolidBounds): DebugSolidBounds => ({
   max: { ...bounds.max },
 });
 
-const getBounds = (object: Object3D): DebugSolidBounds => {
+const getBounds = (
+  object: Object3D,
+  sourceGeometry?: BufferGeometry
+): DebugSolidBounds => {
+  const originalBoundingBox = sourceGeometry?.boundingBox ?? null;
+  const hadBoundingBox = sourceGeometry?.boundingBox !== null;
   const box = new Box3().setFromObject(object);
+  if (sourceGeometry && !hadBoundingBox) {
+    sourceGeometry.boundingBox = null;
+  } else if (sourceGeometry) {
+    sourceGeometry.boundingBox = originalBoundingBox;
+  }
   return {
     min: { x: round(box.min.x), y: round(box.min.y), z: round(box.min.z) },
     max: { x: round(box.max.x), y: round(box.max.y), z: round(box.max.z) },
@@ -142,11 +186,16 @@ const getBounds = (object: Object3D): DebugSolidBounds => {
 };
 
 const getGeometrySignature = (geometry: BufferGeometry): string => {
-  geometry.computeBoundingBox();
-  const box = geometry.boundingBox;
+  const sourceBox = geometry.boundingBox;
+  let signatureGeometry: BufferGeometry | undefined;
+  if (!sourceBox) {
+    signatureGeometry = geometry.clone();
+    signatureGeometry.computeBoundingBox();
+  }
+  const box = sourceBox ?? signatureGeometry?.boundingBox ?? null;
   const positionCount = geometry.getAttribute('position')?.count ?? 0;
   const indexCount = geometry.index?.count ?? 0;
-  return [
+  const signature = [
     geometry.type,
     `pos:${positionCount}`,
     `idx:${indexCount}`,
@@ -161,6 +210,8 @@ const getGeometrySignature = (geometry: BufferGeometry): string => {
         ].join(',')
       : 'bounds:none',
   ].join('|');
+  signatureGeometry?.dispose();
+  return signature;
 };
 
 const getMaterialSummary = (
@@ -224,7 +275,7 @@ export const createSolidVisualizer = (
       entry.wireframe.quaternion,
       entry.wireframe.scale
     );
-    const bounds = getBounds(entry.mesh);
+    const bounds = getBounds(entry.mesh, entry.mesh.geometry);
     if (hasFiniteBounds(bounds)) {
       entry.metadata.bounds = bounds;
       entry.label.position.set(
@@ -238,7 +289,10 @@ export const createSolidVisualizer = (
   const applyVisibility = () => {
     group.visible = enabled;
     entries.forEach((entry) => {
-      const entryVisible = enabled && hasVisibleAncestors(entry.mesh);
+      const entryVisible =
+        enabled &&
+        hasVisibleAncestors(entry.mesh) &&
+        !hasInvisibleMaterial(entry.mesh.material);
       entry.wireframe.visible = entryVisible;
       entry.label.visible = entryVisible;
     });
@@ -269,10 +323,14 @@ export const createSolidVisualizer = (
     }> = [];
 
     root.traverse((object) => {
-      if (!isMesh(object) || !hasVisibleAncestors(object)) {
+      if (
+        !isMesh(object) ||
+        !hasVisibleAncestors(object) ||
+        hasInvisibleMaterial(object.material)
+      ) {
         return;
       }
-      const bounds = getBounds(object);
+      const bounds = getBounds(object, object.geometry);
       if (!hasFiniteBounds(bounds)) {
         return;
       }
@@ -370,7 +428,11 @@ export const createSolidVisualizer = (
     },
     getState() {
       const visibleEntryCount = enabled
-        ? entries.filter((entry) => hasVisibleAncestors(entry.mesh)).length
+        ? entries.filter(
+            (entry) =>
+              hasVisibleAncestors(entry.mesh) &&
+              !hasInvisibleMaterial(entry.mesh.material)
+          ).length
         : 0;
       return {
         enabled,

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -1,0 +1,346 @@
+import {
+  Box3,
+  Color,
+  EdgesGeometry,
+  Group,
+  LineBasicMaterial,
+  LineSegments,
+  Mesh,
+  Object3D,
+  type BufferGeometry,
+  type Material,
+  type Sprite,
+} from 'three';
+
+import {
+  DEBUG_LABEL_PALETTE,
+  DEBUG_LABEL_VERTICAL_GAP,
+  createDebugIdLabel,
+  getLabelColorStyle,
+} from './colliderVisualizer';
+import {
+  DEBUG_ID_PRECISION,
+  allocateDebugId,
+  getDebugHash,
+  getDebugPaletteIndex,
+  roundDebugValue,
+} from './debugIds';
+
+export interface DebugSolidBounds {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+export interface DebugSolidMetadata {
+  id: string;
+  name: string;
+  path: string;
+  parentPath: string;
+  meshType: string;
+  bounds: DebugSolidBounds;
+  material?: string;
+}
+
+export interface DebugSolidVisualizerState {
+  enabled: boolean;
+  visibleSolidCount: number;
+  totalSolidCount: number;
+  visibleLabelCount: number;
+  totalLabelCount: number;
+}
+
+interface DebugSolidVisualEntry {
+  metadata: DebugSolidMetadata;
+  wireframe: LineSegments<EdgesGeometry, LineBasicMaterial>;
+  label: Sprite;
+}
+
+export interface SolidVisualizer {
+  readonly group: Group;
+  register(root: Object3D, reservedIds?: ReadonlySet<string>): void;
+  setEnabled(enabled: boolean): void;
+  getState(): DebugSolidVisualizerState;
+  getSolids(): DebugSolidMetadata[];
+  getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  dispose(): void;
+}
+
+const DEBUG_SOLID_PRIMARY_SALT = 'debug-solid-id:v1';
+
+const round = (value: number): number => roundDebugValue(value);
+const format = (value: number): string =>
+  round(value).toFixed(DEBUG_ID_PRECISION);
+
+const isMesh = (
+  object: Object3D
+): object is Mesh<BufferGeometry, Material | Material[]> =>
+  object instanceof Mesh;
+
+const isExcluded = (object: Object3D): boolean => {
+  if (
+    object.userData.debugOnly ||
+    object.userData.colliderDebug ||
+    object.userData.poiLabel
+  ) {
+    return true;
+  }
+  if (
+    object.type === 'Sprite' ||
+    object.type.includes('Light') ||
+    object.type === 'Camera'
+  ) {
+    return true;
+  }
+  return object.name.startsWith('Debug') || object.name.includes('Helper');
+};
+
+const getObjectPath = (object: Object3D): string => {
+  const parts: string[] = [];
+  let current: Object3D | null = object;
+  while (current) {
+    parts.push(current.name || current.type);
+    current = current.parent;
+  }
+  return parts.reverse().join('/');
+};
+
+const cloneBounds = (bounds: DebugSolidBounds): DebugSolidBounds => ({
+  min: { ...bounds.min },
+  max: { ...bounds.max },
+});
+
+const getBounds = (object: Object3D): DebugSolidBounds => {
+  const box = new Box3().setFromObject(object);
+  return {
+    min: { x: round(box.min.x), y: round(box.min.y), z: round(box.min.z) },
+    max: { x: round(box.max.x), y: round(box.max.y), z: round(box.max.z) },
+  };
+};
+
+const getGeometrySignature = (geometry: BufferGeometry): string => {
+  geometry.computeBoundingBox();
+  const box = geometry.boundingBox;
+  const positionCount = geometry.getAttribute('position')?.count ?? 0;
+  const indexCount = geometry.index?.count ?? 0;
+  return [
+    geometry.type,
+    `pos:${positionCount}`,
+    `idx:${indexCount}`,
+    box
+      ? [
+          format(box.min.x),
+          format(box.min.y),
+          format(box.min.z),
+          format(box.max.x),
+          format(box.max.y),
+          format(box.max.z),
+        ].join(',')
+      : 'bounds:none',
+  ].join('|');
+};
+
+const getMaterialSummary = (
+  material: Material | Material[]
+): string | undefined => {
+  const materials = Array.isArray(material) ? material : [material];
+  return materials
+    .map((entry) => {
+      const color = (entry as Material & { color?: Color }).color;
+      return color ? `${entry.type}:#${color.getHexString()}` : entry.type;
+    })
+    .join(',');
+};
+
+const getSolidSeed = (
+  metadata: Omit<DebugSolidMetadata, 'id'>,
+  geometrySignature: string
+) =>
+  [
+    metadata.name,
+    metadata.path,
+    metadata.parentPath,
+    metadata.meshType,
+    `${metadata.bounds.min.x},${metadata.bounds.min.y},${metadata.bounds.min.z}`,
+    `${metadata.bounds.max.x},${metadata.bounds.max.y},${metadata.bounds.max.z}`,
+    geometrySignature,
+  ].join('|');
+
+export const createSolidDebugId = (
+  metadata: Omit<DebugSolidMetadata, 'id'>,
+  usedIds: ReadonlySet<string> = new Set(),
+  geometrySignature = ''
+): string => {
+  const seed = getSolidSeed(metadata, geometrySignature);
+  return allocateDebugId(
+    seed,
+    usedIds,
+    getDebugHash(`${seed}|${DEBUG_SOLID_PRIMARY_SALT}`)
+  );
+};
+
+const cloneMetadata = (metadata: DebugSolidMetadata): DebugSolidMetadata => ({
+  ...metadata,
+  bounds: cloneBounds(metadata.bounds),
+});
+
+export const createSolidVisualizer = (
+  options: { enabled?: boolean } = {}
+): SolidVisualizer => {
+  const group = new Group();
+  group.name = 'DebugSolidVisualizer';
+  group.userData.debugOnly = true;
+  group.visible = options.enabled ?? false;
+  const entries: DebugSolidVisualEntry[] = [];
+  let enabled = options.enabled ?? false;
+
+  const applyVisibility = () => {
+    group.visible = enabled;
+    entries.forEach((entry) => {
+      entry.wireframe.visible = enabled;
+      entry.label.visible = enabled;
+    });
+  };
+
+  const clear = () => {
+    entries.forEach((entry) => {
+      group.remove(entry.wireframe, entry.label);
+      entry.wireframe.geometry.dispose();
+      entry.wireframe.material.dispose();
+      entry.label.material.map?.dispose();
+      entry.label.material.dispose();
+    });
+    entries.length = 0;
+  };
+
+  const register = (
+    root: Object3D,
+    reservedIds: ReadonlySet<string> = new Set()
+  ) => {
+    clear();
+    root.updateMatrixWorld(true);
+    const meshes: Array<{
+      mesh: Mesh<BufferGeometry, Material | Material[]>;
+      seed: string;
+      metadata: Omit<DebugSolidMetadata, 'id'>;
+      geometrySignature: string;
+    }> = [];
+
+    root.traverse((object) => {
+      if (!isMesh(object) || isExcluded(object)) {
+        return;
+      }
+      const bounds = getBounds(object);
+      if (!Number.isFinite(bounds.min.x) || !Number.isFinite(bounds.max.x)) {
+        return;
+      }
+      const path = getObjectPath(object);
+      const parentPath = object.parent ? getObjectPath(object.parent) : '';
+      const geometrySignature = getGeometrySignature(object.geometry);
+      const metadata = {
+        name: object.name || object.type,
+        path,
+        parentPath,
+        meshType: object.type,
+        bounds,
+        material: getMaterialSummary(object.material),
+      };
+      meshes.push({
+        mesh: object,
+        metadata,
+        geometrySignature,
+        seed: getSolidSeed(metadata, geometrySignature),
+      });
+    });
+
+    meshes.sort((left, right) => left.seed.localeCompare(right.seed));
+    const usedIds = new Set(reservedIds);
+    const seedCounts = new Map<string, number>();
+    for (const item of meshes) {
+      const occurrence = seedCounts.get(item.seed) ?? 0;
+      seedCounts.set(item.seed, occurrence + 1);
+      const idSeed =
+        occurrence > 0 ? `${item.seed}|occurrence:${occurrence}` : item.seed;
+      const id = allocateDebugId(
+        idSeed,
+        usedIds,
+        getDebugHash(`${idSeed}|${DEBUG_SOLID_PRIMARY_SALT}`)
+      );
+      usedIds.add(id);
+      const color = getLabelColorStyle(
+        DEBUG_LABEL_PALETTE[
+          getDebugPaletteIndex(id, DEBUG_LABEL_PALETTE.length)
+        ]
+      );
+      const wireframe = new LineSegments(
+        new EdgesGeometry(item.mesh.geometry),
+        new LineBasicMaterial({
+          color,
+          depthTest: false,
+          depthWrite: false,
+          transparent: true,
+          opacity: 0.85,
+          toneMapped: false,
+        })
+      );
+      wireframe.name = `DebugSolid:${id}:${item.metadata.path}`;
+      item.mesh.matrixWorld.decompose(
+        wireframe.position,
+        wireframe.quaternion,
+        wireframe.scale
+      );
+      wireframe.renderOrder = 20_002;
+      wireframe.frustumCulled = false;
+      wireframe.userData.debugOnly = true;
+      wireframe.userData.solidDebug = { id };
+      wireframe.raycast = () => undefined;
+
+      const label = createDebugIdLabel(id, color);
+      label.name = `DebugSolidLabel:${id}`;
+      label.position.set(
+        (item.metadata.bounds.min.x + item.metadata.bounds.max.x) / 2,
+        item.metadata.bounds.max.y + DEBUG_LABEL_VERTICAL_GAP,
+        (item.metadata.bounds.min.z + item.metadata.bounds.max.z) / 2
+      );
+      label.userData.solidDebugLabel = { id };
+      label.raycast = () => undefined;
+
+      group.add(wireframe, label);
+      entries.push({ metadata: { id, ...item.metadata }, wireframe, label });
+    }
+    applyVisibility();
+  };
+
+  return {
+    group,
+    register,
+    setEnabled(next: boolean) {
+      enabled = next;
+      applyVisibility();
+    },
+    getState() {
+      return {
+        enabled,
+        visibleSolidCount: enabled ? entries.length : 0,
+        totalSolidCount: entries.length,
+        visibleLabelCount: enabled ? entries.length : 0,
+        totalLabelCount: entries.length,
+      };
+    },
+    getSolids() {
+      return entries.map((entry) => cloneMetadata(entry.metadata));
+    },
+    getSolidById(id: unknown) {
+      if (typeof id !== 'string' || id.length === 0) {
+        return undefined;
+      }
+      const normalizedId = id.toUpperCase();
+      const entry = entries.find((next) => next.metadata.id === normalizedId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    dispose() {
+      clear();
+      const parent = group.parent as Object3D | null;
+      parent?.remove(group);
+    },
+  };
+};

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -50,6 +50,7 @@ export interface DebugSolidVisualizerState {
 }
 
 interface DebugSolidVisualEntry {
+  mesh: Mesh<BufferGeometry, Material | Material[]>;
   metadata: DebugSolidMetadata;
   wireframe: LineSegments<EdgesGeometry, LineBasicMaterial>;
   label: Sprite;
@@ -62,6 +63,7 @@ export interface SolidVisualizer {
   getState(): DebugSolidVisualizerState;
   getSolids(): DebugSolidMetadata[];
   getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  update(): void;
   dispose(): void;
 }
 
@@ -84,6 +86,9 @@ const isExcluded = (object: Object3D): boolean => {
   ) {
     return true;
   }
+  if (object.name.startsWith('POI') || object.name.startsWith('POI_HIT:')) {
+    return true;
+  }
   if (
     object.type === 'Sprite' ||
     object.type.includes('Light') ||
@@ -93,6 +98,25 @@ const isExcluded = (object: Object3D): boolean => {
   }
   return object.name.startsWith('Debug') || object.name.includes('Helper');
 };
+
+const hasVisibleAncestors = (object: Object3D): boolean => {
+  let current: Object3D | null = object;
+  while (current) {
+    if (!current.visible || isExcluded(current)) {
+      return false;
+    }
+    current = current.parent;
+  }
+  return true;
+};
+
+const hasFiniteBounds = (bounds: DebugSolidBounds): boolean =>
+  Number.isFinite(bounds.min.x) &&
+  Number.isFinite(bounds.min.y) &&
+  Number.isFinite(bounds.min.z) &&
+  Number.isFinite(bounds.max.x) &&
+  Number.isFinite(bounds.max.y) &&
+  Number.isFinite(bounds.max.z);
 
 const getObjectPath = (object: Object3D): string => {
   const parts: string[] = [];
@@ -193,11 +217,30 @@ export const createSolidVisualizer = (
   const entries: DebugSolidVisualEntry[] = [];
   let enabled = options.enabled ?? false;
 
+  const syncEntryTransform = (entry: DebugSolidVisualEntry) => {
+    entry.mesh.updateMatrixWorld(true);
+    entry.mesh.matrixWorld.decompose(
+      entry.wireframe.position,
+      entry.wireframe.quaternion,
+      entry.wireframe.scale
+    );
+    const bounds = getBounds(entry.mesh);
+    if (hasFiniteBounds(bounds)) {
+      entry.metadata.bounds = bounds;
+      entry.label.position.set(
+        (bounds.min.x + bounds.max.x) / 2,
+        bounds.max.y + DEBUG_LABEL_VERTICAL_GAP,
+        (bounds.min.z + bounds.max.z) / 2
+      );
+    }
+  };
+
   const applyVisibility = () => {
     group.visible = enabled;
     entries.forEach((entry) => {
-      entry.wireframe.visible = enabled;
-      entry.label.visible = enabled;
+      const entryVisible = enabled && hasVisibleAncestors(entry.mesh);
+      entry.wireframe.visible = entryVisible;
+      entry.label.visible = entryVisible;
     });
   };
 
@@ -226,11 +269,11 @@ export const createSolidVisualizer = (
     }> = [];
 
     root.traverse((object) => {
-      if (!isMesh(object) || isExcluded(object)) {
+      if (!isMesh(object) || !hasVisibleAncestors(object)) {
         return;
       }
       const bounds = getBounds(object);
-      if (!Number.isFinite(bounds.min.x) || !Number.isFinite(bounds.max.x)) {
+      if (!hasFiniteBounds(bounds)) {
         return;
       }
       const path = getObjectPath(object);
@@ -301,11 +344,19 @@ export const createSolidVisualizer = (
         item.metadata.bounds.max.y + DEBUG_LABEL_VERTICAL_GAP,
         (item.metadata.bounds.min.z + item.metadata.bounds.max.z) / 2
       );
+      delete label.userData.colliderDebugLabel;
       label.userData.solidDebugLabel = { id };
       label.raycast = () => undefined;
 
+      const entry = {
+        mesh: item.mesh,
+        metadata: { id, ...item.metadata },
+        wireframe,
+        label,
+      };
+      syncEntryTransform(entry);
       group.add(wireframe, label);
-      entries.push({ metadata: { id, ...item.metadata }, wireframe, label });
+      entries.push(entry);
     }
     applyVisibility();
   };
@@ -318,11 +369,14 @@ export const createSolidVisualizer = (
       applyVisibility();
     },
     getState() {
+      const visibleEntryCount = enabled
+        ? entries.filter((entry) => hasVisibleAncestors(entry.mesh)).length
+        : 0;
       return {
         enabled,
-        visibleSolidCount: enabled ? entries.length : 0,
+        visibleSolidCount: visibleEntryCount,
         totalSolidCount: entries.length,
-        visibleLabelCount: enabled ? entries.length : 0,
+        visibleLabelCount: visibleEntryCount,
         totalLabelCount: entries.length,
       };
     },
@@ -336,6 +390,13 @@ export const createSolidVisualizer = (
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    update() {
+      if (!enabled) {
+        return;
+      }
+      entries.forEach(syncEntryTransform);
+      applyVisibility();
     },
     dispose() {
       clear();

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -94,7 +94,7 @@ const matchesExcludedName = (name: string): boolean => {
     normalizedName.includes('label') ||
     normalizedName.includes('sprite') ||
     normalizedName.includes('ui') ||
-    normalizedName.includes('player') ||
+    normalizedName.startsWith('player') ||
     normalizedName.includes('avatar') ||
     normalizedName.includes('mannequin')
   );

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -87,6 +87,9 @@ const matchesExcludedName = (name: string): boolean => {
     normalizedName.includes('debug') ||
     normalizedName.includes('collider') ||
     normalizedName.includes('helper') ||
+    normalizedName.includes('hitarea') ||
+    normalizedName.includes('hit-area') ||
+    normalizedName.includes('interaction') ||
     normalizedName.includes('hud') ||
     normalizedName.includes('label') ||
     normalizedName.includes('sprite') ||
@@ -133,7 +136,18 @@ const hasInvisibleMaterial = (material: Material | Material[]): boolean => {
   return materials.length > 0 && materials.every(isInvisibleMaterial);
 };
 
-const hasVisibleAncestors = (object: Object3D): boolean => {
+const hasNoExcludedAncestors = (object: Object3D): boolean => {
+  let current: Object3D | null = object;
+  while (current) {
+    if (isExcluded(current)) {
+      return false;
+    }
+    current = current.parent;
+  }
+  return true;
+};
+
+const hasEffectiveVisibility = (object: Object3D): boolean => {
   let current: Object3D | null = object;
   while (current) {
     if (!current.visible || isExcluded(current)) {
@@ -291,7 +305,7 @@ export const createSolidVisualizer = (
     entries.forEach((entry) => {
       const entryVisible =
         enabled &&
-        hasVisibleAncestors(entry.mesh) &&
+        hasEffectiveVisibility(entry.mesh) &&
         !hasInvisibleMaterial(entry.mesh.material);
       entry.wireframe.visible = entryVisible;
       entry.label.visible = entryVisible;
@@ -325,8 +339,8 @@ export const createSolidVisualizer = (
     root.traverse((object) => {
       if (
         !isMesh(object) ||
-        !hasVisibleAncestors(object) ||
-        hasInvisibleMaterial(object.material)
+        !object.visible ||
+        !hasNoExcludedAncestors(object)
       ) {
         return;
       }
@@ -430,7 +444,7 @@ export const createSolidVisualizer = (
       const visibleEntryCount = enabled
         ? entries.filter(
             (entry) =>
-              hasVisibleAncestors(entry.mesh) &&
+              hasEffectiveVisibility(entry.mesh) &&
               !hasInvisibleMaterial(entry.mesh.material)
           ).length
         : 0;

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -100,7 +100,7 @@ const matchesExcludedName = (name: string): boolean => {
   );
 };
 
-const isExcluded = (object: Object3D): boolean => {
+const isPoiUiDebugOrHelperObject = (object: Object3D): boolean => {
   if (
     object.userData.debugOnly ||
     object.userData.colliderDebug ||
@@ -136,10 +136,10 @@ const hasInvisibleMaterial = (material: Material | Material[]): boolean => {
   return materials.length > 0 && materials.every(isInvisibleMaterial);
 };
 
-const hasNoExcludedAncestors = (object: Object3D): boolean => {
+const isEligibleSolidSource = (object: Object3D): boolean => {
   let current: Object3D | null = object;
   while (current) {
-    if (isExcluded(current)) {
+    if (isPoiUiDebugOrHelperObject(current)) {
       return false;
     }
     current = current.parent;
@@ -147,10 +147,10 @@ const hasNoExcludedAncestors = (object: Object3D): boolean => {
   return true;
 };
 
-const hasEffectiveVisibility = (object: Object3D): boolean => {
+const hasEffectiveSourceVisibility = (object: Object3D): boolean => {
   let current: Object3D | null = object;
   while (current) {
-    if (!current.visible || isExcluded(current)) {
+    if (!current.visible || isPoiUiDebugOrHelperObject(current)) {
       return false;
     }
     current = current.parent;
@@ -305,7 +305,7 @@ export const createSolidVisualizer = (
     entries.forEach((entry) => {
       const entryVisible =
         enabled &&
-        hasEffectiveVisibility(entry.mesh) &&
+        hasEffectiveSourceVisibility(entry.mesh) &&
         !hasInvisibleMaterial(entry.mesh.material);
       entry.wireframe.visible = entryVisible;
       entry.label.visible = entryVisible;
@@ -337,7 +337,7 @@ export const createSolidVisualizer = (
     }> = [];
 
     root.traverse((object) => {
-      if (!isMesh(object) || !hasNoExcludedAncestors(object)) {
+      if (!isMesh(object) || !isEligibleSolidSource(object)) {
         return;
       }
       const bounds = getBounds(object, object.geometry);
@@ -440,7 +440,7 @@ export const createSolidVisualizer = (
       const visibleEntryCount = enabled
         ? entries.filter(
             (entry) =>
-              hasEffectiveVisibility(entry.mesh) &&
+              hasEffectiveSourceVisibility(entry.mesh) &&
               !hasInvisibleMaterial(entry.mesh.material)
           ).length
         : 0;

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -824,6 +824,18 @@ describe('i18n utilities', () => {
           'Zeigt unsichtbare Wände und Kollisionsrechtecke der aktiven Etage.',
         descriptionDisabled:
           'Unsichtbare Wände und Kollisionsrechtecke bleiben verborgen, bis du sie einschaltest.',
+        idsLabelEnabled: 'Collider-IDs ein',
+        idsLabelDisabled: 'Collider-IDs aus',
+        idsDescriptionEnabled:
+          'Zeigt Collider-ID-Beschriftungen, während das Collider-Overlay aktiv ist.',
+        idsDescriptionDisabled:
+          'Blendet Collider-ID-Beschriftungen aus, während die Drahtgitter verfügbar bleiben.',
+        solidIdsLabelEnabled: 'Solid-IDs ein',
+        solidIdsLabelDisabled: 'Solid-IDs aus',
+        solidIdsDescriptionEnabled:
+          'Zeigt stabile IDs und Drahtgitter für sichtbare Szenen-Solids.',
+        solidIdsDescriptionDisabled:
+          'Stabile Solid-IDs und Drahtgitter bleiben ausgeblendet.',
       },
       en: {
         labelEnabled: 'Collider overlay on',
@@ -885,7 +897,27 @@ describe('i18n utilities', () => {
     for (const [locale, expectedStrings] of Object.entries(
       expectedDebugColliderStrings
     )) {
-      expect(getDebugCollidersStrings(locale)).toMatchObject(expectedStrings);
+      const debugStrings = getDebugCollidersStrings(locale);
+      expect(debugStrings).toMatchObject(expectedStrings);
+      for (const key of [
+        'idsLabelEnabled',
+        'idsLabelDisabled',
+        'idsDescriptionEnabled',
+        'idsDescriptionDisabled',
+        'solidIdsLabelEnabled',
+        'solidIdsLabelDisabled',
+        'solidIdsDescriptionEnabled',
+        'solidIdsDescriptionDisabled',
+      ] as const) {
+        expect(debugStrings[key]).toEqual(expect.any(String));
+        expect(debugStrings[key].trim()).not.toBe('');
+      }
+    }
+
+    for (const locale of ['de', 'es', 'hu', 'pt'] as const) {
+      const debugStrings = getDebugCollidersStrings(locale);
+      expect(debugStrings.idsLabelEnabled).not.toBe('Collider IDs on');
+      expect(debugStrings.solidIdsLabelEnabled).not.toBe('Solid IDs on');
     }
   });
 

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -885,7 +885,7 @@ describe('i18n utilities', () => {
     for (const [locale, expectedStrings] of Object.entries(
       expectedDebugColliderStrings
     )) {
-      expect(getDebugCollidersStrings(locale)).toEqual(expectedStrings);
+      expect(getDebugCollidersStrings(locale)).toMatchObject(expectedStrings);
     }
   });
 


### PR DESCRIPTION
### Motivation
- Provide independent control over collider ID labels so wireframes can remain visible while labels are hidden. 
- Add a stable, deterministic ID overlay for scene solids to make it easier to identify problematic geometry in the immersive scene. 
- Keep all changes limited to debug visualizers, HUD Settings wiring, i18n strings, and debug APIs without changing gameplay or collision logic. 

### Description
- Introduce shared debug ID helpers in `src/scene/debug/debugIds.ts` that produce stable uppercase hex IDs, candidate shortening, and collision-avoiding allocation. 
- Extend the existing collider visualizer (`src/scene/debug/colliderVisualizer.ts`) with `idsEnabled` state and a new `setIdsEnabled(enabled: boolean)` API so labels can be toggled independently of wireframes while preserving color syncing. 
- Add a new `solidVisualizer` (`src/scene/debug/solidVisualizer.ts`) that registers visible scene Meshes (excluding debug-only/POI/UI/lighting/helpers), generates deterministic solid IDs that avoid collider ID collisions, and renders non-raycasting wireframes plus camera-facing labels. 
- Wire Settings, storage keys, URL overrides, i18n strings and window APIs in `src/main.ts` so HUD toggles and `window.portfolio.debugColliders` / `window.portfolio.debugSolids` expose the new controls and serializable metadata. 
- Add focused unit tests for ID generation and visualizer behavior (`src/scene/debug/__tests__/colliderVisualizer.test.ts`, `src/scene/debug/__tests__/solidVisualizer.test.ts`) and extend i18n coverage for the new strings. 

### Testing
- Ran formatter: `npm run format:write` — passed. 
- Ran linter: `npm run lint` — passed. 
- Ran focused unit tests: `npm run test:ci src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` — passed. 
- Ran i18n + visualizer focused tests: `npm run test:ci src/tests/i18n.test.ts src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` — passed. 
- Ran full test suite: `npm run test:ci` — passed (all unit tests). 
- Docs and links check: `npm run docs:check` — passed (link checker emitted remote fetch warnings but completed). 
- Smoke + build: `npm run smoke` and `npm run build` — passed and produced `dist`. 
- Playwright browser spec attempt: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — blocked because Playwright browsers were not installed in this environment; attempted `npx playwright install chromium` failed due to network/DNS download errors, so the browser e2e run could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e01bb9d8c832f89cb05db9784598a)