### PR TITLE
🪜 Remove upper stair floor strip (fix 634BE9)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2157,12 +2157,22 @@ function initializeImmersiveScene(
       stairTopZ - stairLayout.directionMultiplier * stairRun
     ),
   };
-  const upperLandingCutouts =
+  const stairRunApproachFootprint =
     upperLandingRoom && upperStairwellOpening
+      ? {
+          minX: stairCenterX,
+          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
+          minZ: upperStairwellOpening.minZ,
+          maxZ: upperLandingRoom.bounds.maxZ,
+        }
+      : undefined;
+  const upperLandingCutouts =
+    upperLandingRoom && upperStairwellOpening && stairRunApproachFootprint
       ? {
           upperLanding: createUpperLandingFloorCutouts({
             staircaseLandingFootprint,
             finalStairStepFootprint,
+            stairRunApproachFootprint,
             stairwellOpening: upperStairwellOpening,
             hiddenRunVoidMinX: upperStairWestEgressBlockerMinX,
           }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -268,7 +268,10 @@ import {
   createTokenPlaceRack,
   type TokenPlaceRackBuild,
 } from './scene/structures/tokenPlaceRack';
-import { createUpperLandingFloorCutouts } from './scene/structures/upperLandingFloorCutouts';
+import {
+  createUpperLandingFloorCutouts,
+  createUpperLandingStairRunApproachFootprint,
+} from './scene/structures/upperLandingFloorCutouts';
 import { createUpperStairwellLanding } from './scene/structures/upperStairwellLanding';
 import { createWallSegmentMeshes } from './scene/structures/wallSegmentsMesh';
 import {
@@ -2159,12 +2162,12 @@ function initializeImmersiveScene(
   };
   const stairRunApproachFootprint =
     upperLandingRoom && upperStairwellOpening
-      ? {
-          minX: stairCenterX,
-          maxX: stairNavigationZones.explicitDescentCorridor.maxX,
-          minZ: upperStairwellOpening.minZ,
-          maxZ: upperLandingRoom.bounds.maxZ,
-        }
+      ? createUpperLandingStairRunApproachFootprint({
+          stairCenterX,
+          stairHalfWidth,
+          stairwellOpening: upperStairwellOpening,
+          upperLandingRoomBounds: upperLandingRoom.bounds,
+        })
       : undefined;
   const upperLandingCutouts =
     upperLandingRoom && upperStairwellOpening && stairRunApproachFootprint

--- a/src/scene/structures/upperLandingFloorCutouts.ts
+++ b/src/scene/structures/upperLandingFloorCutouts.ts
@@ -13,6 +13,12 @@ export interface UpperLandingFloorCutoutConfig {
    * can produce a jagged z-fighting seam at the landing mouth.
    */
   readonly finalStairStepFootprint: Bounds2D;
+  /**
+   * Upper Landing Floor 6 (debug solid 634BE9 before the fix) was the
+   * camera-facing half of this approach strip. Keep that upper-floor tile out
+   * of the stair-run approach so it cannot obscure the visible treads.
+   */
+  readonly stairRunApproachFootprint: Bounds2D;
   /** West edge of the hidden-run void after preserving the egress lane. */
   readonly hiddenRunVoidMinX: number;
 }
@@ -21,8 +27,10 @@ export interface UpperLandingFloorCutoutConfig {
  * Keeps upper landing floor tiles away from the physical staircase landing slab
  * while preserving the narrower hidden-run cutout that protects upstairs egress.
  * The first cutout removes the coplanar slab footprint; the second removes
- * upper-floor tile undersides from the final top tread; the third keeps the
- * no-floor void open only where the hidden stair run should remain uncovered.
+ * upper-floor tile undersides from the final top tread; the third removes the
+ * narrow stair-run approach strip that used to cover the upper treads; the
+ * fourth keeps the no-floor void open only where the hidden stair run should
+ * remain uncovered.
  */
 export function createUpperLandingFloorCutouts(
   config: UpperLandingFloorCutoutConfig
@@ -30,6 +38,7 @@ export function createUpperLandingFloorCutouts(
   return [
     { ...config.staircaseLandingFootprint },
     { ...config.finalStairStepFootprint },
+    { ...config.stairRunApproachFootprint },
     {
       ...config.stairwellOpening,
       minX: config.hiddenRunVoidMinX,

--- a/src/scene/structures/upperLandingFloorCutouts.ts
+++ b/src/scene/structures/upperLandingFloorCutouts.ts
@@ -23,6 +23,31 @@ export interface UpperLandingFloorCutoutConfig {
   readonly hiddenRunVoidMinX: number;
 }
 
+export interface UpperLandingStairRunApproachFootprintConfig {
+  readonly stairCenterX: number;
+  readonly stairHalfWidth: number;
+  readonly stairwellOpening: Bounds2D;
+  readonly upperLandingRoomBounds: Bounds2D;
+}
+
+/**
+ * Covers the full physical stair width where upper-floor tiles would otherwise
+ * extend from the stairwell mouth toward the camera-facing upper landing edge.
+ */
+export function createUpperLandingStairRunApproachFootprint({
+  stairCenterX,
+  stairHalfWidth,
+  stairwellOpening,
+  upperLandingRoomBounds,
+}: UpperLandingStairRunApproachFootprintConfig): Bounds2D {
+  return {
+    minX: stairCenterX - stairHalfWidth,
+    maxX: stairCenterX + stairHalfWidth,
+    minZ: stairwellOpening.minZ,
+    maxZ: upperLandingRoomBounds.maxZ,
+  };
+}
+
 /**
  * Keeps upper landing floor tiles away from the physical staircase landing slab
  * while preserving the narrower hidden-run cutout that protects upstairs egress.

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -4,11 +4,19 @@ import { describe, expect, it } from 'vitest';
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../assets/floorPlan';
 import type { Bounds2D } from '../assets/floorPlan';
 import { createRoomFloorTiles } from '../scene/structures/floorTiles';
-import { createUpperLandingFloorCutouts } from '../scene/structures/upperLandingFloorCutouts';
+import {
+  createUpperLandingFloorCutouts,
+  createUpperLandingStairRunApproachFootprint,
+} from '../scene/structures/upperLandingFloorCutouts';
 import {
   computeStairLayout,
   computeStairwellOpeningBounds,
 } from '../systems/movement/stairLayout';
+import {
+  createStairNavigationZones,
+  type StairBehavior,
+  type StairGeometry,
+} from '../systems/movement/stairs';
 
 const toWorldUnits = (value: number) => value * FLOOR_PLAN_SCALE;
 
@@ -25,59 +33,102 @@ const PLAYER_RADIUS = 0.75;
 const overlaps = (a: Bounds2D, b: Bounds2D): boolean =>
   a.minX < b.maxX && a.maxX > b.minX && a.minZ < b.maxZ && a.maxZ > b.minZ;
 
+const createProductionUpperLandingCutoutFixture = () => {
+  const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
+    (room) => room.id === 'upperLanding'
+  );
+  expect(upperLandingRoom).toBeDefined();
+  if (!upperLandingRoom) {
+    throw new Error('Expected upper landing room fixture to exist');
+  }
+
+  const stairLayout = computeStairLayout({
+    baseZ: STAIR_BOTTOM_Z,
+    stepRun: STAIR_RUN,
+    stepCount: STAIR_STEP_COUNT,
+    landingDepth: STAIR_LANDING_DEPTH,
+    direction: 'negativeZ',
+    guardMargin: toWorldUnits(0.6),
+    stairwellMargin: STAIRWELL_MARGIN_Z,
+  });
+  const stairwellOpening = computeStairwellOpeningBounds({
+    centerX: STAIR_CENTER_X,
+    halfWidth: STAIR_HALF_WIDTH,
+    marginX: STAIRWELL_MARGIN_X,
+    roomBounds: upperLandingRoom.bounds,
+    layout: stairLayout,
+  });
+  const staircaseLandingFootprint = {
+    minX: STAIR_CENTER_X - STAIR_HALF_WIDTH,
+    maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH,
+    minZ: stairLayout.landingMinZ,
+    maxZ: stairLayout.landingMaxZ,
+  };
+  const finalStairStepFootprint = {
+    minX: STAIR_CENTER_X - STAIR_HALF_WIDTH,
+    maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH,
+    minZ: Math.min(
+      stairLayout.topZ,
+      stairLayout.topZ - stairLayout.directionMultiplier * STAIR_RUN
+    ),
+    maxZ: Math.max(
+      stairLayout.topZ,
+      stairLayout.topZ - stairLayout.directionMultiplier * STAIR_RUN
+    ),
+  };
+  const stairGeometry: StairGeometry = {
+    centerX: STAIR_CENTER_X,
+    halfWidth: STAIR_HALF_WIDTH,
+    bottomZ: STAIR_BOTTOM_Z,
+    topZ: stairLayout.topZ,
+    landingMinZ: stairLayout.landingMinZ,
+    landingMaxZ: stairLayout.landingMaxZ,
+    totalRise: STAIR_STEP_COUNT * 0.42,
+    direction: stairLayout.directionMultiplier,
+  };
+  const stairBehavior: StairBehavior = {
+    transitionMargin: toWorldUnits(0.6),
+    landingTriggerMargin: toWorldUnits(0.2),
+    stepRise: 0.42,
+    descentCorridorInset: PLAYER_RADIUS,
+  };
+  const stairNavigationZones = createStairNavigationZones(
+    stairGeometry,
+    stairBehavior
+  );
+  const westEgressLaneX =
+    STAIR_CENTER_X - STAIR_HALF_WIDTH + PLAYER_RADIUS * 0.75;
+  const hiddenRunVoidMinX = westEgressLaneX + PLAYER_RADIUS + 0.01;
+  const stairRunApproachFootprint = createUpperLandingStairRunApproachFootprint(
+    {
+      stairCenterX: STAIR_CENTER_X,
+      stairHalfWidth: STAIR_HALF_WIDTH,
+      stairwellOpening,
+      upperLandingRoomBounds: upperLandingRoom.bounds,
+    }
+  );
+
+  return {
+    upperLandingRoom,
+    stairNavigationZones,
+    staircaseLandingFootprint,
+    finalStairStepFootprint,
+    stairRunApproachFootprint,
+    stairwellOpening,
+    hiddenRunVoidMinX,
+  };
+};
+
 describe('createUpperLandingFloorCutouts', () => {
   it('removes the physical staircase landing footprint from upper landing floor tiles', () => {
-    const upperLandingRoom = UPPER_FLOOR_PLAN.rooms.find(
-      (room) => room.id === 'upperLanding'
-    );
-    expect(upperLandingRoom).toBeDefined();
-    if (!upperLandingRoom) {
-      return;
-    }
-
-    const stairLayout = computeStairLayout({
-      baseZ: STAIR_BOTTOM_Z,
-      stepRun: STAIR_RUN,
-      stepCount: STAIR_STEP_COUNT,
-      landingDepth: STAIR_LANDING_DEPTH,
-      direction: 'negativeZ',
-      guardMargin: toWorldUnits(0.6),
-      stairwellMargin: STAIRWELL_MARGIN_Z,
-    });
-    const stairwellOpening = computeStairwellOpeningBounds({
-      centerX: STAIR_CENTER_X,
-      halfWidth: STAIR_HALF_WIDTH,
-      marginX: STAIRWELL_MARGIN_X,
-      roomBounds: upperLandingRoom.bounds,
-      layout: stairLayout,
-    });
-    const staircaseLandingFootprint = {
-      minX: STAIR_CENTER_X - STAIR_HALF_WIDTH,
-      maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH,
-      minZ: stairLayout.landingMinZ,
-      maxZ: stairLayout.landingMaxZ,
-    };
-    const finalStairStepFootprint = {
-      minX: STAIR_CENTER_X - STAIR_HALF_WIDTH,
-      maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH,
-      minZ: Math.min(
-        stairLayout.topZ,
-        stairLayout.topZ - stairLayout.directionMultiplier * STAIR_RUN
-      ),
-      maxZ: Math.max(
-        stairLayout.topZ,
-        stairLayout.topZ - stairLayout.directionMultiplier * STAIR_RUN
-      ),
-    };
-    const westEgressLaneX =
-      STAIR_CENTER_X - STAIR_HALF_WIDTH + PLAYER_RADIUS * 0.75;
-    const hiddenRunVoidMinX = westEgressLaneX + PLAYER_RADIUS + 0.01;
-    const stairRunApproachFootprint = {
-      minX: STAIR_CENTER_X,
-      maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH - PLAYER_RADIUS,
-      minZ: stairwellOpening.minZ,
-      maxZ: upperLandingRoom.bounds.maxZ,
-    };
+    const {
+      upperLandingRoom,
+      staircaseLandingFootprint,
+      finalStairStepFootprint,
+      stairRunApproachFootprint,
+      stairwellOpening,
+      hiddenRunVoidMinX,
+    } = createProductionUpperLandingCutoutFixture();
 
     const cutouts = createUpperLandingFloorCutouts({
       staircaseLandingFootprint,
@@ -119,6 +170,28 @@ describe('createUpperLandingFloorCutouts', () => {
     const upperFloorTileBottomY = 4.16 - 0.38;
     const finalStairStepTopY = STAIR_STEP_COUNT * 0.42;
     expect(upperFloorTileBottomY).toBeCloseTo(finalStairStepTopY);
+  });
+
+  it('derives the stair-run approach cutout from the production stair geometry', () => {
+    const {
+      stairNavigationZones,
+      stairRunApproachFootprint,
+      stairwellOpening,
+      upperLandingRoom,
+    } = createProductionUpperLandingCutoutFixture();
+
+    expect(stairRunApproachFootprint).toEqual({
+      minX: STAIR_CENTER_X - STAIR_HALF_WIDTH,
+      maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH,
+      minZ: stairwellOpening.minZ,
+      maxZ: upperLandingRoom.bounds.maxZ,
+    });
+    expect(stairRunApproachFootprint.minX).toBeLessThan(
+      stairNavigationZones.explicitDescentCorridor.minX
+    );
+    expect(stairRunApproachFootprint.maxX).toBeGreaterThan(
+      stairNavigationZones.explicitDescentCorridor.maxX
+    );
   });
 
   it('prevents upper landing tiles from covering the final top tread underside seam', () => {
@@ -174,55 +247,32 @@ describe('createUpperLandingFloorCutouts', () => {
   });
 
   it('removes the Upper Landing Floor 6 approach strip over the upper stair run', () => {
-    const upperLandingFloor6ApproachStrip = {
-      minX: 9.3,
-      maxX: 10.62,
-      minZ: -24.2,
-      maxZ: -16,
-    };
+    const {
+      upperLandingRoom,
+      staircaseLandingFootprint,
+      finalStairStepFootprint,
+      stairRunApproachFootprint,
+      stairwellOpening,
+      hiddenRunVoidMinX,
+    } = createProductionUpperLandingCutoutFixture();
     const cutouts = createUpperLandingFloorCutouts({
-      staircaseLandingFootprint: {
-        minX: 9.3,
-        maxX: 15.5,
-        minZ: -31.1,
-        maxZ: -25.9,
-      },
-      finalStairStepFootprint: {
-        minX: 9.3,
-        maxX: 15.5,
-        minZ: -25.9,
-        maxZ: -24.2,
-      },
-      stairRunApproachFootprint: upperLandingFloor6ApproachStrip,
-      stairwellOpening: {
-        minX: 8.9,
-        maxX: 15.9,
-        minZ: -31.9,
-        maxZ: -24.2,
-      },
-      hiddenRunVoidMinX: 10.62,
+      staircaseLandingFootprint,
+      finalStairStepFootprint,
+      stairRunApproachFootprint,
+      stairwellOpening,
+      hiddenRunVoidMinX,
     });
 
-    const floorTiles = createRoomFloorTiles(
-      [
-        {
-          id: 'upperLanding',
-          name: 'Upper Landing',
-          bounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
-          doorways: [],
-        },
-      ],
-      {
-        material: new MeshStandardMaterial(),
-        elevation: 4.16,
-        thickness: 0.38,
-        cutoutsByRoom: { upperLanding: cutouts },
-      }
-    );
+    const floorTiles = createRoomFloorTiles([upperLandingRoom], {
+      material: new MeshStandardMaterial(),
+      elevation: 4.16,
+      thickness: 0.38,
+      cutoutsByRoom: { upperLanding: cutouts },
+    });
 
     expect(
       floorTiles.tiles.every(
-        (tile) => !overlaps(tile.bounds, upperLandingFloor6ApproachStrip)
+        (tile) => !overlaps(tile.bounds, stairRunApproachFootprint)
       )
     ).toBe(true);
   });

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -72,10 +72,17 @@ describe('createUpperLandingFloorCutouts', () => {
     const westEgressLaneX =
       STAIR_CENTER_X - STAIR_HALF_WIDTH + PLAYER_RADIUS * 0.75;
     const hiddenRunVoidMinX = westEgressLaneX + PLAYER_RADIUS + 0.01;
+    const stairRunApproachFootprint = {
+      minX: STAIR_CENTER_X,
+      maxX: STAIR_CENTER_X + STAIR_HALF_WIDTH - PLAYER_RADIUS,
+      minZ: stairwellOpening.minZ,
+      maxZ: upperLandingRoom.bounds.maxZ,
+    };
 
     const cutouts = createUpperLandingFloorCutouts({
       staircaseLandingFootprint,
       finalStairStepFootprint,
+      stairRunApproachFootprint,
       stairwellOpening,
       hiddenRunVoidMinX,
     });
@@ -88,7 +95,8 @@ describe('createUpperLandingFloorCutouts', () => {
 
     expect(cutouts[0]).toEqual(staircaseLandingFootprint);
     expect(cutouts[1]).toEqual(finalStairStepFootprint);
-    expect(cutouts[2]).toEqual({
+    expect(cutouts[2]).toEqual(stairRunApproachFootprint);
+    expect(cutouts[3]).toEqual({
       ...stairwellOpening,
       minX: hiddenRunVoidMinX,
     });
@@ -101,6 +109,11 @@ describe('createUpperLandingFloorCutouts', () => {
       floorTiles.tiles
         .filter((tile) => tile.roomId === 'upperLanding')
         .every((tile) => !overlaps(tile.bounds, finalStairStepFootprint))
+    ).toBe(true);
+    expect(
+      floorTiles.tiles
+        .filter((tile) => tile.roomId === 'upperLanding')
+        .every((tile) => !overlaps(tile.bounds, stairRunApproachFootprint))
     ).toBe(true);
 
     const upperFloorTileBottomY = 4.16 - 0.38;
@@ -123,6 +136,12 @@ describe('createUpperLandingFloorCutouts', () => {
         maxZ: -25.9,
       },
       finalStairStepFootprint: finalTopTread,
+      stairRunApproachFootprint: {
+        minX: 9.3,
+        maxX: 10.62,
+        minZ: -24.2,
+        maxZ: -16,
+      },
       stairwellOpening: {
         minX: 8.9,
         maxX: 15.9,
@@ -151,6 +170,60 @@ describe('createUpperLandingFloorCutouts', () => {
 
     expect(
       floorTiles.tiles.every((tile) => !overlaps(tile.bounds, finalTopTread))
+    ).toBe(true);
+  });
+
+  it('removes the Upper Landing Floor 6 approach strip over the upper stair run', () => {
+    const upperLandingFloor6ApproachStrip = {
+      minX: 9.3,
+      maxX: 10.62,
+      minZ: -24.2,
+      maxZ: -16,
+    };
+    const cutouts = createUpperLandingFloorCutouts({
+      staircaseLandingFootprint: {
+        minX: 9.3,
+        maxX: 15.5,
+        minZ: -31.1,
+        maxZ: -25.9,
+      },
+      finalStairStepFootprint: {
+        minX: 9.3,
+        maxX: 15.5,
+        minZ: -25.9,
+        maxZ: -24.2,
+      },
+      stairRunApproachFootprint: upperLandingFloor6ApproachStrip,
+      stairwellOpening: {
+        minX: 8.9,
+        maxX: 15.9,
+        minZ: -31.9,
+        maxZ: -24.2,
+      },
+      hiddenRunVoidMinX: 10.62,
+    });
+
+    const floorTiles = createRoomFloorTiles(
+      [
+        {
+          id: 'upperLanding',
+          name: 'Upper Landing',
+          bounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+          doorways: [],
+        },
+      ],
+      {
+        material: new MeshStandardMaterial(),
+        elevation: 4.16,
+        thickness: 0.38,
+        cutoutsByRoom: { upperLanding: cutouts },
+      }
+    );
+
+    expect(
+      floorTiles.tiles.every(
+        (tile) => !overlaps(tile.bounds, upperLandingFloor6ApproachStrip)
+      )
     ).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- A narrow upper-floor tile was rendering over the upper stair run (debug solid `634BE9` / “Upper Landing Floor 6”), visually obscuring the stair treads; the change removes that accidental approach strip via source-level cutout logic rather than hiding or offsetting geometry.

### Description
- Add a targeted `stairRunApproachFootprint` to the `createUpperLandingFloorCutouts` config and include it in the upper-floor cutout sequence so tiles that produced `Upper Landing Floor 6` are not generated over the stair approach. 
- Compute the `stairRunApproachFootprint` in `src/main.ts` from the stair navigation geometry and pass it into `createUpperLandingFloorCutouts` so visuals and movement metrics remain derived from the same layout. 
- Update `src/tests/upperLandingFloorCutouts.test.ts` to assert the new approach cutout is present and to add a focused regression test that ensures the previous `Upper Landing Floor 6` approach strip is not created. 
- The change is intentionally minimal and only affects upper-floor tile generation; collider / nav / movement behavior and debug visualizer IDs are preserved.

### Testing
- Ran formatting: `npm run format:write` (succeeded). 
- Ran unit tests: `npm run test:ci` and the focused `npm run test:ci -- src/tests/upperLandingFloorCutouts.test.ts` (all Vitest suites passed). 
- Lint: `npm run lint` (succeeded). 
- Docs and smoke: `npm run docs:check` (passed with external link warnings) and `npm run smoke` (passed), `npm run build` (succeeded). 
- Playwright: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (all 8 stairs tests passed). 
- Manual verification: launched the immersive preview with `/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugSolidIds=1` and confirmed `window.portfolio.debugSolids.getSolidById('634BE9')` no longer returns the offending solid (approach strip absent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e471b79dc832f979e66acaec6deaf)