### PR TITLE
Add toggleable FPS counter (stats.js) to immersive debug settings

### DIFF
--- a/docs/design/debug-performance-overlay.md
+++ b/docs/design/debug-performance-overlay.md
@@ -1,0 +1,64 @@
+# Debug performance overlay
+
+The immersive scene exposes a debug-only FPS counter powered by
+[`stats.js`](https://github.com/mrdoob/stats.js). `stats.js` is small, widely
+used by Three.js projects, and provides the FPS panel we need without adding a
+larger profiling or observability framework.
+
+## Toggle and state
+
+The Settings diagnostics group now includes an **FPS counter** toggle alongside
+the existing collider overlay, collider ID, and solid ID controls. The toggle
+uses localStorage key `danielsmith.io::debugFpsCounter::v1` so reviewers can
+keep the panel enabled across reloads.
+
+URL overrides follow the existing debug diagnostics conventions:
+
+- `?debugFps=1` enables the FPS panel.
+- `?debugFps=0` disables it, even when localStorage was previously enabled.
+- Truthy values are `1`, `true`, `yes`, and `on`.
+- Falsy values are `0`, `false`, `no`, and `off`.
+
+The debug API is intentionally narrow:
+
+```ts
+window.portfolio.debugPerformance.getState();
+window.portfolio.debugPerformance.setFpsEnabled(true);
+```
+
+`getState()` returns `fpsEnabled` and `panelVisible` only. It does not expose the
+underlying `stats.js` object.
+
+## Rendering behavior
+
+The panel is appended only while enabled, uses the default FPS panel, and is
+reused across repeated toggles so normal scene re-renders do not create duplicate
+DOM nodes. It is fixed near the lower-left viewport edge and sets
+`pointer-events: none` so it cannot block HUD, Settings, or in-scene
+interactions.
+
+The render loop calls `stats.begin()` immediately before the main immersive
+render path and `stats.end()` after the composer or renderer finishes. This keeps
+the displayed reading focused on actual frame rendering work without allocating
+new objects every frame.
+
+## Deployment note
+
+`stats.js` is installed from npm and the lockfile is committed. That keeps the
+Dockerfile and sugarkube deployment path deterministic because they use
+`npm ci`, which requires `package.json` and `package-lock.json` to agree.
+
+## Manual verification
+
+1. Run `npm install` after changing dependencies, or use the committed lockfile
+   with `npm ci` in clean environments.
+2. Start the preview with the immersive failover override.
+3. Open:
+   `/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1&debugColliderIds=1&debugSolidIds=1&debugFps=1`.
+4. Confirm the FPS panel appears, does not block HUD controls, and does not
+   duplicate after toggling the Settings FPS counter off and on.
+5. In DevTools, verify:
+   `window.portfolio.debugPerformance.getState()` reports `{ fpsEnabled: true,
+panelVisible: true }`, then call
+   `window.portfolio.debugPerformance.setFpsEnabled(false)` and confirm both
+   values become `false`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "stats.js": "^0.17.0",
         "three": "^0.161.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.44.0",
         "@types/jszip": "^3.4.0",
         "@types/node": "^20.11.17",
+        "@types/stats.js": "^0.17.4",
         "@types/three": "^0.161.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -5907,6 +5909,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
+    "stats.js": "^0.17.0",
     "three": "^0.161.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",
     "@types/jszip": "^3.4.0",
     "@types/node": "^20.11.17",
+    "@types/stats.js": "^0.17.4",
     "@types/three": "^0.161.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/playwright/debug-performance.spec.ts
+++ b/playwright/debug-performance.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+const IMMERSIVE_PREVIEW_URL =
+  '/?mode=immersive&disablePerformanceFailover=1&debugFps=1';
+
+interface PortfolioWindow extends Window {
+  portfolio?: {
+    debugPerformance?: {
+      getState(): { fpsEnabled: boolean; panelVisible: boolean };
+      setFpsEnabled(enabled: boolean): void;
+    };
+  };
+}
+
+async function waitForImmersive(page: Page) {
+  await page.goto(IMMERSIVE_PREVIEW_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.appMode === 'immersive',
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+}
+
+test.describe('debug performance overlay', () => {
+  test('toggles stats.js FPS panel through the debug API without duplicates', async ({
+    page,
+  }) => {
+    await waitForImmersive(page);
+
+    await page.waitForFunction(() => {
+      const api = (window as PortfolioWindow).portfolio?.debugPerformance;
+      return api?.getState().fpsEnabled === true && api.getState().panelVisible;
+    });
+
+    await expect(page.locator('#debug-performance-stats')).toHaveCount(1);
+
+    const initialState = await page.evaluate(() => {
+      const api = (window as PortfolioWindow).portfolio?.debugPerformance;
+      if (!api) {
+        throw new Error('window.portfolio.debugPerformance is unavailable');
+      }
+      return api.getState();
+    });
+    expect(initialState).toEqual({ fpsEnabled: true, panelVisible: true });
+
+    await page.evaluate(() => {
+      (window as PortfolioWindow).portfolio?.debugPerformance?.setFpsEnabled(
+        false
+      );
+    });
+    await expect(page.locator('#debug-performance-stats')).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as PortfolioWindow).portfolio?.debugPerformance?.getState()
+        )
+      )
+      .toEqual({ fpsEnabled: false, panelVisible: false });
+
+    await page.evaluate(() => {
+      const api = (window as PortfolioWindow).portfolio?.debugPerformance;
+      api?.setFpsEnabled(true);
+      api?.setFpsEnabled(true);
+    });
+    await expect(page.locator('#debug-performance-stats')).toHaveCount(1);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as PortfolioWindow).portfolio?.debugPerformance?.getState()
+        )
+      )
+      .toEqual({ fpsEnabled: true, panelVisible: true });
+
+    const pointerEvents = await page
+      .locator('#debug-performance-stats')
+      .evaluate((element) => getComputedStyle(element).pointerEvents);
+    expect(pointerEvents).toBe('none');
+  });
+});

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -319,6 +319,10 @@ export const AR_OVERRIDES: LocaleOverrides = {
         'يعرض معرّفات ثابتة وإطارات للمجسمات المرئية في المشهد.',
       solidIdsDescriptionDisabled:
         'تبقى معرّفات المجسمات الثابتة وإطاراتها مخفية.',
+      fpsLabelEnabled: 'عداد FPS مفعّل',
+      fpsLabelDisabled: 'عداد FPS معطّل',
+      fpsDescriptionEnabled: 'يعرض لوحة FPS غير تفاعلية من stats.js.',
+      fpsDescriptionDisabled: 'تبقى لوحة FPS من stats.js مخفية.',
     },
     poiOverlay: {
       visited: 'تمت الزيارة',

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -384,6 +384,10 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'Shows stable IDs and wireframes for visible scene solids.',
       solidIdsDescriptionDisabled:
         'Stable solid IDs and wireframes stay hidden.',
+      fpsLabelEnabled: 'FPS counter on',
+      fpsLabelDisabled: 'FPS counter off',
+      fpsDescriptionEnabled: 'Shows a non-interactive stats.js FPS panel.',
+      fpsDescriptionDisabled: 'The stats.js FPS panel stays hidden.',
     },
     tourReset: {
       heading: 'Guided tour',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -319,6 +319,11 @@ export const JA_OVERRIDES: LocaleOverrides = {
         '表示中のシーンソリッドに安定 ID とワイヤーフレームを表示します。',
       solidIdsDescriptionDisabled:
         '安定したソリッド ID とワイヤーフレームを隠します。',
+      fpsLabelEnabled: 'FPS カウンターオン',
+      fpsLabelDisabled: 'FPS カウンターオフ',
+      fpsDescriptionEnabled:
+        '非インタラクティブな stats.js FPS パネルを表示します。',
+      fpsDescriptionDisabled: 'stats.js FPS パネルは非表示です。',
     },
     poiOverlay: {
       visited: '訪問済み',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -79,6 +79,10 @@ interface LatinLocaleCopy {
     debugCollidersSolidIdsLabelDisabled?: string;
     debugCollidersSolidIdsDescriptionEnabled?: string;
     debugCollidersSolidIdsDescriptionDisabled?: string;
+    debugCollidersFpsLabelEnabled?: string;
+    debugCollidersFpsLabelDisabled?: string;
+    debugCollidersFpsDescriptionEnabled?: string;
+    debugCollidersFpsDescriptionDisabled?: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -776,6 +780,14 @@ export function buildLatinLocaleOverrides(
         solidIdsDescriptionDisabled:
           s.debugCollidersSolidIdsDescriptionDisabled ??
           'Stable solid IDs and wireframes stay hidden.',
+        fpsLabelEnabled: s.debugCollidersFpsLabelEnabled ?? 'FPS counter on',
+        fpsLabelDisabled: s.debugCollidersFpsLabelDisabled ?? 'FPS counter off',
+        fpsDescriptionEnabled:
+          s.debugCollidersFpsDescriptionEnabled ??
+          'Shows a non-interactive stats.js FPS panel.',
+        fpsDescriptionDisabled:
+          s.debugCollidersFpsDescriptionDisabled ??
+          'The stats.js FPS panel stays hidden.',
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -302,6 +302,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       solidIdsLabelDisabled: '实体 ID 关',
       solidIdsDescriptionEnabled: '为可见场景实体显示稳定 ID 和线框。',
       solidIdsDescriptionDisabled: '隐藏稳定实体 ID 和线框。',
+      fpsLabelEnabled: 'FPS 计数器开',
+      fpsLabelDisabled: 'FPS 计数器关',
+      fpsDescriptionEnabled: '显示非交互式 stats.js FPS 面板。',
+      fpsDescriptionDisabled: 'stats.js FPS 面板保持隐藏。',
     },
     tourReset: {
       heading: '导览',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -246,6 +246,10 @@ export interface DebugCollidersStrings {
   solidIdsLabelDisabled: string;
   solidIdsDescriptionEnabled: string;
   solidIdsDescriptionDisabled: string;
+  fpsLabelEnabled: string;
+  fpsLabelDisabled: string;
+  fpsDescriptionEnabled: string;
+  fpsDescriptionDisabled: string;
 }
 
 export interface TourResetControlStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import Stats from 'stats.js';
 import {
   ACESFilmicToneMapping,
   AmbientLight,
@@ -485,6 +486,7 @@ const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
 const DEBUG_COLLIDER_IDS_STORAGE_KEY = 'danielsmith.io::debugColliderIds::v1';
 const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
+const DEBUG_FPS_STORAGE_KEY = 'danielsmith.io::debugFpsCounter::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
 const isDebugUrlValueIn = (
@@ -608,6 +610,10 @@ declare global {
         setEnabled(enabled: boolean): void;
         getSolids(): DebugSolidMetadata[];
         getSolidById(id: unknown): DebugSolidMetadata | undefined;
+      };
+      debugPerformance?: {
+        getState(): { fpsEnabled: boolean; panelVisible: boolean };
+        setFpsEnabled(enabled: boolean): void;
       };
       debugCoordinates?: {
         getState(): {
@@ -1449,10 +1455,28 @@ function initializeImmersiveScene(
   let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
     ? false
     : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
+  const debugFpsUrlOverride = new URLSearchParams(window.location.search).get(
+    'debugFps'
+  );
+  const debugFpsUrlEnabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugFpsUrlDisabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugFpsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_FPS_STORAGE_KEY) === '1';
+  let debugFpsEnabled = debugFpsUrlDisabled
+    ? false
+    : debugFpsUrlEnabled || debugFpsStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
   let debugColliderIdsControl: HTMLButtonElement | null = null;
   let debugSolidIdsControl: HTMLButtonElement | null = null;
+  let debugFpsControl: HTMLButtonElement | null = null;
+  let debugPerformanceStats: Stats | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -4509,6 +4533,53 @@ function initializeImmersiveScene(
     debugColliderIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugFpsControl = () => {
+    if (!debugFpsControl) {
+      return;
+    }
+    const label = debugFpsEnabled
+      ? debugCollidersStrings.fpsLabelEnabled
+      : debugCollidersStrings.fpsLabelDisabled;
+    const description = debugFpsEnabled
+      ? debugCollidersStrings.fpsDescriptionEnabled
+      : debugCollidersStrings.fpsDescriptionDisabled;
+    debugFpsControl.textContent = label;
+    debugFpsControl.dataset.state = debugFpsEnabled ? 'enabled' : 'disabled';
+    debugFpsControl.setAttribute(
+      'aria-pressed',
+      debugFpsEnabled ? 'true' : 'false'
+    );
+    debugFpsControl.setAttribute('aria-label', description);
+    debugFpsControl.title = description;
+    debugFpsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
+  const syncDebugPerformancePanel = () => {
+    if (!debugFpsEnabled) {
+      debugPerformanceStats?.dom.remove();
+      return;
+    }
+    if (!debugPerformanceStats) {
+      debugPerformanceStats = new Stats();
+      debugPerformanceStats.showPanel(0);
+      debugPerformanceStats.dom.id = 'debug-performance-stats';
+      debugPerformanceStats.dom.style.position = 'fixed';
+      debugPerformanceStats.dom.style.left = '12px';
+      debugPerformanceStats.dom.style.bottom = '12px';
+      debugPerformanceStats.dom.style.top = 'auto';
+      debugPerformanceStats.dom.style.zIndex = '30';
+      debugPerformanceStats.dom.style.pointerEvents = 'none';
+    }
+    if (!debugPerformanceStats.dom.isConnected) {
+      document.body.appendChild(debugPerformanceStats.dom);
+    }
+  };
+
+  const getDebugPerformanceState = () => ({
+    fpsEnabled: debugFpsEnabled,
+    panelVisible: debugPerformanceStats?.dom.isConnected ?? false,
+  });
+
   const refreshDebugSolidIdsControl = () => {
     if (!debugSolidIdsControl) {
       return;
@@ -4593,6 +4664,25 @@ function initializeImmersiveScene(
     }
   };
 
+  const setDebugFpsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugFpsEnabled = enabled;
+    syncDebugPerformancePanel();
+    refreshDebugFpsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_FPS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug FPS preference.', error);
+      }
+    }
+  };
+
   const setDebugCoordinatesEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4625,6 +4715,7 @@ function initializeImmersiveScene(
     refreshDebugCollidersControl();
     refreshDebugColliderIdsControl();
     refreshDebugSolidIdsControl();
+    refreshDebugFpsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4672,6 +4763,17 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugSolidIdsControl);
   registerHudControlElement(debugSolidIdsControl);
   refreshDebugSolidIdsControl();
+
+  debugFpsControl = document.createElement('button');
+  debugFpsControl.type = 'button';
+  debugFpsControl.className = 'tour-toggle debug-fps-toggle';
+  debugFpsControl.addEventListener('click', () => {
+    setDebugFpsEnabled(!debugFpsEnabled);
+  });
+  hudSettingsStack.appendChild(debugFpsControl);
+  registerHudControlElement(debugFpsControl);
+  refreshDebugFpsControl();
+  syncDebugPerformancePanel();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4723,6 +4825,11 @@ function initializeImmersiveScene(
       ensureSolidVisualizerRegistered();
       return solidVisualizer.getSolidById(id);
     },
+  };
+
+  window.portfolio.debugPerformance = {
+    getState: getDebugPerformanceState,
+    setFpsEnabled: setDebugFpsEnabled,
   };
 
   window.portfolio.debugCoordinates = {
@@ -6253,6 +6360,14 @@ function initializeImmersiveScene(
       debugSolidIdsControl.remove();
       debugSolidIdsControl = null;
     }
+    if (debugFpsControl) {
+      debugFpsControl.remove();
+      debugFpsControl = null;
+    }
+    if (debugPerformanceStats) {
+      debugPerformanceStats.dom.remove();
+      debugPerformanceStats = null;
+    }
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
@@ -6605,11 +6720,13 @@ function initializeImmersiveScene(
         performance.now() - phaseStart
       );
       phaseStart = performance.now();
+      debugPerformanceStats?.begin();
       if (shouldUseComposer()) {
         composer?.render();
       } else {
         renderer.render(scene, camera);
       }
+      debugPerformanceStats?.end();
       performanceDiagnostics?.recordPhase(
         'mainRender',
         performance.now() - phaseStart


### PR DESCRIPTION
### Motivation
- Provide a small, toggleable FPS/performance overlay for immersive-mode debugging that follows existing debug diagnostics conventions (Settings grouping, URL overrides, and persistent localStorage key).
- Instrument the actual immersive render path so readings are meaningful without adding heavy profiling dependencies or changing gameplay or collision behavior.
- Expose a minimal debug API for automated checks and Playwright coverage while keeping the overlay non-interactive and debug-only.

### Description
- Add `stats.js` and `@types/stats.js` to `package.json`/`package-lock.json` and introduce `DEBUG_FPS_STORAGE_KEY = 'danielsmith.io::debugFpsCounter::v1'` with `?debugFps=` truthy/falsy URL parsing in `src/main.ts`.
- Wire a new Settings toggle (`debugFpsControl`) grouped with the existing collider/solid diagnostic toggles and add i18n strings and type updates for the FPS copy in `src/assets/i18n/*` and `src/assets/i18n/types.ts`.
- Create a single reusable non-interactive stats.js DOM panel appended/removed only when enabled (fixed lower-left, `pointer-events: none`) and call `stats.begin()`/`stats.end()` around the main composer/renderer render path to avoid per-frame allocations and duplicate nodes.
- Expose `window.portfolio.debugPerformance.getState()` and `window.portfolio.debugPerformance.setFpsEnabled(enabled)` with state shape `{ fpsEnabled, panelVisible }`, add a short design doc at `docs/design/debug-performance-overlay.md`, and add Playwright coverage at `playwright/debug-performance.spec.ts`.

### Testing
- Formatting and linting: ran `npm run format:write` and `npm run lint` (lint warning fixed), both completed successfully.
- Unit/test suite and build: ran `npm run test:ci` (Vitest) with all repository tests passing (`1111` tests across `146` files), and `npm run build` completed successfully.
- Playwright/E2E: installed Playwright browsers and host deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and ran `npx playwright test playwright/debug-performance.spec.ts` and `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, both passing in the environment used here, and captured a verification screenshot at `/tmp/debug-performance-overlay.png`.
- Docs and smoke: ran `npm run docs:check` (passed; external link checks emitted fetch warnings) and `npm run smoke` (build and artifact assertions passed).
- Notes: `npm run typecheck` surfaced unrelated repo-wide TypeScript errors (pre-existing) and is not blocking this change; `package.json` and `package-lock.json` were updated to include `stats.js` and types to preserve `npm ci` reproducibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4c33b8b4832fa2e0c85d949111cf)