### PR TITLE
📊 : – add debug FPS counter

### DIFF
--- a/docs/design/debug-performance-overlay.md
+++ b/docs/design/debug-performance-overlay.md
@@ -1,0 +1,33 @@
+# Debug performance overlay
+
+The immersive scene uses `stats.js` for its debug FPS panel because it is the
+small, established browser performance widget maintained by the Three.js
+community. The package is installed from npm instead of vendored or loaded from
+a CDN, so Vite bundles it with the rest of the application.
+
+The Settings diagnostics group now includes an **FPS counter** toggle beside the
+solid ID tooling. The preference is persisted in local storage with
+`danielsmith.io::debugFpsCounter::v1`. A URL parameter overrides stored state
+using the same debug truthy/falsy convention as the collider tools:
+`?debugFps=1` or `?debugFps=true` enables the panel, while `?debugFps=0` or
+`?debugFps=false` disables it.
+
+The overlay is debug-only and non-interactive. Its DOM node has pointer events
+disabled and is reused between toggles so repeated Settings changes or normal
+immersive renders do not create duplicate panels. The render loop wraps the
+immersive frame work with `stats.begin()` / `stats.end()` and shows the FPS
+panel by default.
+
+Deployment keeps working with Docker and sugarkube because `stats.js` is tracked
+in both `package.json` and `package-lock.json`; environments that run `npm ci`
+install the exact dependency graph.
+
+Manual verification:
+
+1. Run `npm run dev` or `npm run preview`.
+2. Open `/?mode=immersive&disablePerformanceFailover=1&debugFps=1`.
+3. Confirm the FPS panel appears and HUD controls remain clickable.
+4. Open Settings and toggle **FPS counter** off and on.
+5. In DevTools, verify `window.portfolio.debugPerformance.getState()` reports
+   `fpsEnabled` and `panelVisible`, and repeated toggles leave one
+   `[data-debug-fps-counter="true"]` element in the DOM.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "stats.js": "^0.17.0",
         "three": "^0.161.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.44.0",
         "@types/jszip": "^3.4.0",
         "@types/node": "^20.11.17",
+        "@types/stats.js": "^0.17.4",
         "@types/three": "^0.161.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -5907,6 +5909,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
+    "stats.js": "^0.17.0",
     "three": "^0.161.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",
     "@types/jszip": "^3.4.0",
     "@types/node": "^20.11.17",
+    "@types/stats.js": "^0.17.4",
     "@types/three": "^0.161.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/playwright/debug-performance.spec.ts
+++ b/playwright/debug-performance.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+
+type PortfolioDebugPerformanceWindow = Window & {
+  portfolio?: {
+    debugPerformance?: {
+      getState(): { fpsEnabled: boolean; panelVisible: boolean };
+      setFpsEnabled(enabled: boolean): void;
+    };
+  };
+};
+
+const immersiveDebugUrl =
+  '/?mode=immersive&disablePerformanceFailover=1&debugFps=1';
+
+test('FPS counter debug API toggles the non-interactive stats panel', async ({
+  page,
+}) => {
+  await page.goto(immersiveDebugUrl);
+  await page.waitForFunction(
+    () =>
+      Boolean(
+        (window as PortfolioDebugPerformanceWindow).portfolio?.debugPerformance
+          ?.getState
+      ),
+    null,
+    { timeout: 15_000 }
+  );
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as PortfolioDebugPerformanceWindow
+          ).portfolio?.debugPerformance?.getState().fpsEnabled
+      )
+    )
+    .toBe(true);
+
+  await expect(page.locator('[data-debug-fps-counter="true"]')).toHaveCount(1);
+  await expect(page.locator('[data-debug-fps-counter="true"]')).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const panel = document.querySelector<HTMLElement>(
+          '[data-debug-fps-counter="true"]'
+        );
+        return panel ? getComputedStyle(panel).pointerEvents : null;
+      })
+    )
+    .toBe('none');
+
+  await page.evaluate(() => {
+    (
+      window as PortfolioDebugPerformanceWindow
+    ).portfolio?.debugPerformance?.setFpsEnabled(false);
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const api = (window as PortfolioDebugPerformanceWindow).portfolio
+          ?.debugPerformance;
+        return {
+          panelCount: document.querySelectorAll(
+            '[data-debug-fps-counter="true"]'
+          ).length,
+          state: api?.getState(),
+        };
+      })
+    )
+    .toEqual({
+      panelCount: 1,
+      state: { fpsEnabled: false, panelVisible: false },
+    });
+
+  await page.evaluate(() => {
+    const api = (window as PortfolioDebugPerformanceWindow).portfolio
+      ?.debugPerformance;
+    api?.setFpsEnabled(true);
+    api?.setFpsEnabled(false);
+    api?.setFpsEnabled(true);
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        panelCount: document.querySelectorAll('[data-debug-fps-counter="true"]')
+          .length,
+        state: (
+          window as PortfolioDebugPerformanceWindow
+        ).portfolio?.debugPerformance?.getState(),
+      }))
+    )
+    .toEqual({
+      panelCount: 1,
+      state: { fpsEnabled: true, panelVisible: true },
+    });
+});

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -378,6 +378,12 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         '⟦Shows stable IDs and wireframes for visible scene solids.⟧',
       solidIdsDescriptionDisabled:
         '⟦Stable solid IDs and wireframes stay hidden.⟧',
+      fpsLabelEnabled: wrap('FPS counter on'),
+      fpsLabelDisabled: wrap('FPS counter off'),
+      fpsDescriptionEnabled: wrap(
+        'Shows the debug-only stats.js FPS panel without blocking HUD controls.'
+      ),
+      fpsDescriptionDisabled: wrap('The debug FPS panel stays hidden.'),
     },
     tourReset: {
       heading: wrap('Guided tour'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -384,6 +384,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'Shows stable IDs and wireframes for visible scene solids.',
       solidIdsDescriptionDisabled:
         'Stable solid IDs and wireframes stay hidden.',
+      fpsLabelEnabled: 'FPS counter on',
+      fpsLabelDisabled: 'FPS counter off',
+      fpsDescriptionEnabled:
+        'Shows the debug-only stats.js FPS panel without blocking HUD controls.',
+      fpsDescriptionDisabled: 'The debug FPS panel stays hidden.',
     },
     tourReset: {
       heading: 'Guided tour',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -317,6 +317,11 @@ export const JA_OVERRIDES: LocaleOverrides = {
       solidIdsLabelDisabled: 'Solid ID オフ',
       solidIdsDescriptionEnabled:
         '表示中のシーンソリッドに安定 ID とワイヤーフレームを表示します。',
+      fpsLabelEnabled: 'FPS counter on',
+      fpsLabelDisabled: 'FPS counter off',
+      fpsDescriptionEnabled:
+        'Shows the debug-only stats.js FPS panel without blocking HUD controls.',
+      fpsDescriptionDisabled: 'The debug FPS panel stays hidden.',
       solidIdsDescriptionDisabled:
         '安定したソリッド ID とワイヤーフレームを隠します。',
     },

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -79,6 +79,10 @@ interface LatinLocaleCopy {
     debugCollidersSolidIdsLabelDisabled?: string;
     debugCollidersSolidIdsDescriptionEnabled?: string;
     debugCollidersSolidIdsDescriptionDisabled?: string;
+    debugFpsLabelEnabled?: string;
+    debugFpsLabelDisabled?: string;
+    debugFpsDescriptionEnabled?: string;
+    debugFpsDescriptionDisabled?: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -776,6 +780,13 @@ export function buildLatinLocaleOverrides(
         solidIdsDescriptionDisabled:
           s.debugCollidersSolidIdsDescriptionDisabled ??
           'Stable solid IDs and wireframes stay hidden.',
+        fpsLabelEnabled: s.debugFpsLabelEnabled ?? 'FPS counter on',
+        fpsLabelDisabled: s.debugFpsLabelDisabled ?? 'FPS counter off',
+        fpsDescriptionEnabled:
+          s.debugFpsDescriptionEnabled ??
+          'Shows the debug-only stats.js FPS panel without blocking HUD controls.',
+        fpsDescriptionDisabled:
+          s.debugFpsDescriptionDisabled ?? 'The debug FPS panel stays hidden.',
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -301,6 +301,11 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       solidIdsLabelEnabled: '实体 ID 开',
       solidIdsLabelDisabled: '实体 ID 关',
       solidIdsDescriptionEnabled: '为可见场景实体显示稳定 ID 和线框。',
+      fpsLabelEnabled: 'FPS counter on',
+      fpsLabelDisabled: 'FPS counter off',
+      fpsDescriptionEnabled:
+        'Shows the debug-only stats.js FPS panel without blocking HUD controls.',
+      fpsDescriptionDisabled: 'The debug FPS panel stays hidden.',
       solidIdsDescriptionDisabled: '隐藏稳定实体 ID 和线框。',
     },
     tourReset: {

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -246,6 +246,10 @@ export interface DebugCollidersStrings {
   solidIdsLabelDisabled: string;
   solidIdsDescriptionEnabled: string;
   solidIdsDescriptionDisabled: string;
+  fpsLabelEnabled: string;
+  fpsLabelDisabled: string;
+  fpsDescriptionEnabled: string;
+  fpsDescriptionDisabled: string;
 }
 
 export interface TourResetControlStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import Stats from 'stats.js';
 import {
   ACESFilmicToneMapping,
   AmbientLight,
@@ -485,6 +486,7 @@ const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
 const DEBUG_COLLIDER_IDS_STORAGE_KEY = 'danielsmith.io::debugColliderIds::v1';
 const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
+const DEBUG_FPS_COUNTER_STORAGE_KEY = 'danielsmith.io::debugFpsCounter::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
 const isDebugUrlValueIn = (
@@ -522,6 +524,10 @@ declare global {
         loadAsset?(options: AvatarAssetPipelineLoadOptions): Promise<unknown>;
       };
       performance?: PerformanceDiagnosticsApi | PerformanceCrashBreadcrumbApi;
+      debugPerformance?: {
+        getState(): { fpsEnabled: boolean; panelVisible: boolean };
+        setFpsEnabled(enabled: boolean): void;
+      };
       githubMetrics?: {
         getDiagnostics(): GitHubRepoStatsDiagnostics;
       };
@@ -1449,10 +1455,29 @@ function initializeImmersiveScene(
   let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
     ? false
     : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
+
+  const debugFpsUrlOverride = new URLSearchParams(window.location.search).get(
+    'debugFps'
+  );
+  const debugFpsUrlEnabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugFpsUrlDisabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugFpsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_FPS_COUNTER_STORAGE_KEY) === '1';
+  let debugFpsEnabled = debugFpsUrlDisabled
+    ? false
+    : debugFpsUrlEnabled || debugFpsStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
   let debugColliderIdsControl: HTMLButtonElement | null = null;
   let debugSolidIdsControl: HTMLButtonElement | null = null;
+  let debugFpsControl: HTMLButtonElement | null = null;
+  let debugFpsStats: Stats | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -4509,6 +4534,27 @@ function initializeImmersiveScene(
     debugColliderIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugFpsControl = () => {
+    if (!debugFpsControl) {
+      return;
+    }
+    const label = debugFpsEnabled
+      ? debugCollidersStrings.fpsLabelEnabled
+      : debugCollidersStrings.fpsLabelDisabled;
+    const description = debugFpsEnabled
+      ? debugCollidersStrings.fpsDescriptionEnabled
+      : debugCollidersStrings.fpsDescriptionDisabled;
+    debugFpsControl.textContent = label;
+    debugFpsControl.dataset.state = debugFpsEnabled ? 'enabled' : 'disabled';
+    debugFpsControl.setAttribute(
+      'aria-pressed',
+      debugFpsEnabled ? 'true' : 'false'
+    );
+    debugFpsControl.setAttribute('aria-label', description);
+    debugFpsControl.title = description;
+    debugFpsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
   const refreshDebugSolidIdsControl = () => {
     if (!debugSolidIdsControl) {
       return;
@@ -4593,6 +4639,54 @@ function initializeImmersiveScene(
     }
   };
 
+  const ensureDebugFpsStats = () => {
+    if (debugFpsStats) {
+      return debugFpsStats;
+    }
+    debugFpsStats = new Stats();
+    debugFpsStats.showPanel(0);
+    debugFpsStats.dom.classList.add('debug-fps-counter');
+    debugFpsStats.dom.dataset.debugFpsCounter = 'true';
+    debugFpsStats.dom.style.pointerEvents = 'none';
+    debugFpsStats.dom.style.display = 'none';
+    document.body.appendChild(debugFpsStats.dom);
+    return debugFpsStats;
+  };
+
+  const syncDebugFpsPanelVisibility = () => {
+    const stats = debugFpsEnabled ? ensureDebugFpsStats() : debugFpsStats;
+    if (!stats) {
+      return;
+    }
+    stats.dom.style.display = debugFpsEnabled ? 'block' : 'none';
+  };
+
+  const getDebugPerformanceState = () => ({
+    fpsEnabled: debugFpsEnabled,
+    panelVisible:
+      debugFpsStats?.dom.isConnected === true &&
+      debugFpsStats.dom.style.display !== 'none',
+  });
+
+  const setDebugFpsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugFpsEnabled = enabled;
+    syncDebugFpsPanelVisibility();
+    refreshDebugFpsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_FPS_COUNTER_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug FPS preference.', error);
+      }
+    }
+  };
+
   const setDebugCoordinatesEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4625,6 +4719,7 @@ function initializeImmersiveScene(
     refreshDebugCollidersControl();
     refreshDebugColliderIdsControl();
     refreshDebugSolidIdsControl();
+    refreshDebugFpsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4672,6 +4767,17 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugSolidIdsControl);
   registerHudControlElement(debugSolidIdsControl);
   refreshDebugSolidIdsControl();
+
+  debugFpsControl = document.createElement('button');
+  debugFpsControl.type = 'button';
+  debugFpsControl.className = 'tour-toggle debug-fps-toggle';
+  debugFpsControl.addEventListener('click', () => {
+    setDebugFpsEnabled(!debugFpsEnabled);
+  });
+  hudSettingsStack.appendChild(debugFpsControl);
+  registerHudControlElement(debugFpsControl);
+  refreshDebugFpsControl();
+  syncDebugFpsPanelVisibility();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4722,6 +4828,13 @@ function initializeImmersiveScene(
     getSolidById: (id: unknown) => {
       ensureSolidVisualizerRegistered();
       return solidVisualizer.getSolidById(id);
+    },
+  };
+
+  window.portfolio.debugPerformance = {
+    getState: getDebugPerformanceState,
+    setFpsEnabled: (enabled: boolean) => {
+      setDebugFpsEnabled(enabled);
     },
   };
 
@@ -6226,6 +6339,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
+    if (window.portfolio?.debugPerformance) {
+      delete window.portfolio.debugPerformance;
+    }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
     }
@@ -6252,6 +6368,14 @@ function initializeImmersiveScene(
     if (debugSolidIdsControl) {
       debugSolidIdsControl.remove();
       debugSolidIdsControl = null;
+    }
+    if (debugFpsControl) {
+      debugFpsControl.remove();
+      debugFpsControl = null;
+    }
+    if (debugFpsStats) {
+      debugFpsStats.dom.remove();
+      debugFpsStats = null;
     }
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
@@ -6331,6 +6455,7 @@ function initializeImmersiveScene(
 
   renderer.setAnimationLoop(() => {
     try {
+      debugFpsStats?.begin();
       const frameStartMs = performance.now();
       const cadenceDecision = resolveSoftwareSafeRenderCadence({
         safeMode: softwareRendererPolicy.safeMode,
@@ -6341,6 +6466,7 @@ function initializeImmersiveScene(
         renderIntervalMs: softwareSafeRenderIntervalMs,
       });
       if (!cadenceDecision.shouldRender) {
+        debugFpsStats?.end();
         return;
       }
       softwareSafeRenderRequested = cadenceDecision.renderRequested;
@@ -6614,12 +6740,14 @@ function initializeImmersiveScene(
         'mainRender',
         performance.now() - phaseStart
       );
+      debugFpsStats?.end();
       if (!hasPresentedFirstFrame) {
         hasPresentedFirstFrame = true;
         writeModePreference('immersive');
         markDocumentReady('immersive');
       }
     } catch (error) {
+      debugFpsStats?.end();
       handleFatalError(error);
     }
   });

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2292,3 +2292,10 @@ html[data-hud-layout='mobile'] .audio-subtitles {
     flex: 0 0 auto;
   }
 }
+
+.debug-fps-counter {
+  left: 12px !important;
+  pointer-events: none !important;
+  top: 12px !important;
+  z-index: 30 !important;
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, toggleable FPS/performance overlay in immersive mode to help diagnose runtime performance without blocking HUD interactions.
- Use the established `stats.js` package so the widget is small, familiar to WebGL developers, and can be installed via npm for `npm ci`/sugarkube compatibility.
- Surface the feature in the existing debug diagnostics group (colliders/solid IDs) with the same storage and URL-override semantics as other debug toggles.

### Description
- Add `stats.js` (and `@types/stats.js`) as npm dependencies and update lockfile so CI and Docker/sugarkube `npm ci` remain deterministic.
- Wire `?debugFps=1|0` URL overrides and persist the setting under `danielsmith.io::debugFpsCounter::v1`, and add the HUD toggle next to the existing debug collider/solid controls.
- Create a single non-interactive stats.js DOM panel (reused, pointer events disabled) and show/hide it via the new control; instrument the immersive render loop with `stats.begin()` / `stats.end()` to provide meaningful readings.
- Expose a minimal debug API on `window.portfolio.debugPerformance` with `getState()` and `setFpsEnabled(...)`, add i18n strings for Settings, include CSS positioning, and add a short design doc at `docs/design/debug-performance-overlay.md`.
- Add a focused Playwright test `playwright/debug-performance.spec.ts` to verify URL/API toggles, pointer-events behavior, panel visibility, and duplicate-panel prevention.

### Testing
- Ran formatting and lint: `npm run format:write` and `npm run lint` succeeded (lint warnings fixed during edits).
- Unit/test suite: `npm run test:ci` (Vitest) ran and passed (existing suite, 1111 tests passed in this environment).
- Playwright: initial run failed due to missing browser binaries; after running `npx playwright install chromium` and `npx playwright install-deps chromium` the Playwright checks succeeded for the focused tests: `npx playwright test playwright/debug-performance.spec.ts playwright/immersive-stairs-roundtrip.spec.ts` (both passed).
- Docs/build/smoke: `npm run docs:check`, `npm run build`, and `npm run smoke` completed successfully (build emitted a size warning only).
- Typecheck: `npm run typecheck` surfaces pre-existing unrelated TypeScript errors in other areas of the codebase; no new `stats.js`/debug FPS typing issues were introduced.
- Additional verification: captured a preview screenshot using Playwright against `/?mode=immersive&disablePerformanceFailover=1&debugFps=1` to confirm panel rendering.

If you'd like, I can break the i18n additions into a separate follow-up for translations or add an entry to the Settings docs showing the new toggle UX.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4c5b6d50832f8d225a8a37f6ab4d)