### PR TITLE
Add toggleable FPS/performance counter (stats.js) to immersive debug settings

### DIFF
--- a/docs/design/debug-performance-overlay.md
+++ b/docs/design/debug-performance-overlay.md
@@ -1,0 +1,53 @@
+# Debug performance overlay
+
+## Why stats.js
+
+The immersive scene now uses [`stats.js`](https://github.com/mrdoob/stats.js) for
+its debug FPS counter because it is the small, established performance panel used
+across many Three.js projects. It gives contributors an immediate FPS readout
+without introducing a custom sampling algorithm or a larger profiling package.
+
+## Toggle, storage, and URL override
+
+The Settings diagnostics group includes an **FPS counter** toggle alongside the
+collider overlay, collider IDs, and solid IDs controls. The preference persists
+in local storage under:
+
+```text
+danielsmith.io::debugFpsCounter::v1
+```
+
+Immersive URLs can override the stored preference with the same truthy/falsy
+conventions as the existing debug diagnostics:
+
+- `?debugFps=1`, `?debugFps=true`, `?debugFps=yes`, or `?debugFps=on` enables it.
+- `?debugFps=0`, `?debugFps=false`, `?debugFps=no`, or `?debugFps=off` disables it.
+
+## Deployment note
+
+`stats.js` and its TypeScript declarations are installed through npm, so
+`package.json` and `package-lock.json` stay in sync for CI, Docker, and the
+sugarkube deployment flow. Those environments use `npm ci`, so the lockfile must
+include the dependency graph instead of relying on a CDN or vendored source.
+
+## Debug-only and non-interactive behavior
+
+The overlay is only created when the debug preference or URL override enables it.
+It is fixed near the lower-left corner of the viewport to avoid the core HUD
+controls, and it sets `pointer-events: none` plus `aria-hidden="true"` so it does
+not intercept clicks, taps, or screen-reader focus.
+
+## Manual verification
+
+1. Start the preview with the immersive performance failover disabled.
+2. Open:
+
+   ```text
+   /?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1&debugColliderIds=1&debugSolidIds=1&debugFps=1
+   ```
+
+3. Confirm the stats.js FPS panel appears without blocking HUD controls.
+4. Open Settings and toggle **FPS counter** off and on repeatedly.
+5. Confirm only one stats panel exists and
+   `window.portfolio.debugPerformance.getState()` reports `fpsEnabled` and
+   `panelVisible` accurately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "stats.js": "^0.17.0",
         "three": "^0.161.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.44.0",
         "@types/jszip": "^3.4.0",
         "@types/node": "^20.11.17",
+        "@types/stats.js": "^0.17.4",
         "@types/three": "^0.161.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -5907,6 +5909,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
+    "stats.js": "^0.17.0",
     "three": "^0.161.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",
     "@types/jszip": "^3.4.0",
     "@types/node": "^20.11.17",
+    "@types/stats.js": "^0.17.4",
     "@types/three": "^0.161.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/playwright/debug-performance.spec.ts
+++ b/playwright/debug-performance.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
+const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
+
+type PortfolioDebugPerformanceWindow = Window & {
+  portfolio?: {
+    debugPerformance?: {
+      getState(): { fpsEnabled: boolean; panelVisible: boolean };
+      setFpsEnabled(enabled: boolean): void;
+    };
+  };
+};
+
+test('toggles the immersive stats.js FPS panel through URL and API', async ({
+  page,
+}) => {
+  await page.goto(`${IMMERSIVE_PREVIEW_URL}&debugFps=1`);
+  await page.waitForFunction(
+    () =>
+      Boolean(
+        (window as PortfolioDebugPerformanceWindow).portfolio?.debugPerformance
+          ?.getState
+      ),
+    undefined,
+    { timeout: IMMERSIVE_READY_TIMEOUT_MS }
+  );
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as PortfolioDebugPerformanceWindow
+          ).portfolio?.debugPerformance?.getState().fpsEnabled
+      )
+    )
+    .toBe(true);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as PortfolioDebugPerformanceWindow
+          ).portfolio?.debugPerformance?.getState().panelVisible
+      )
+    )
+    .toBe(true);
+  await expect(
+    page.locator('[data-debug-performance-panel="fps"]')
+  ).toHaveCount(1);
+
+  await page.evaluate(() => {
+    (
+      window as PortfolioDebugPerformanceWindow
+    ).portfolio?.debugPerformance?.setFpsEnabled(false);
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as PortfolioDebugPerformanceWindow
+          ).portfolio?.debugPerformance?.getState().panelVisible
+      )
+    )
+    .toBe(false);
+  await expect(
+    page.locator('[data-debug-performance-panel="fps"]')
+  ).toHaveCount(0);
+});

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -317,6 +317,11 @@ export const AR_OVERRIDES: LocaleOverrides = {
       solidIdsLabelDisabled: 'معرّفات المجسمات معطّلة',
       solidIdsDescriptionEnabled:
         'يعرض معرّفات ثابتة وإطارات للمجسمات المرئية في المشهد.',
+      fpsLabelEnabled: 'عداد FPS مفعّل',
+      fpsLabelDisabled: 'عداد FPS معطّل',
+      fpsDescriptionEnabled:
+        'يعرض لوحة FPS من stats.js لفحوصات أداء التصحيح الغامر.',
+      fpsDescriptionDisabled: 'يخفي لوحة FPS من stats.js.',
       solidIdsDescriptionDisabled:
         'تبقى معرّفات المجسمات الثابتة وإطاراتها مخفية.',
     },

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -378,6 +378,11 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         '⟦Shows stable IDs and wireframes for visible scene solids.⟧',
       solidIdsDescriptionDisabled:
         '⟦Stable solid IDs and wireframes stay hidden.⟧',
+      fpsLabelEnabled: '⟦FPS counter on⟧',
+      fpsLabelDisabled: '⟦FPS counter off⟧',
+      fpsDescriptionEnabled:
+        '⟦Shows a stats.js FPS panel for immersive debug performance checks.⟧',
+      fpsDescriptionDisabled: '⟦Hides the stats.js FPS panel.⟧',
     },
     tourReset: {
       heading: wrap('Guided tour'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -384,6 +384,11 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'Shows stable IDs and wireframes for visible scene solids.',
       solidIdsDescriptionDisabled:
         'Stable solid IDs and wireframes stay hidden.',
+      fpsLabelEnabled: 'FPS counter on',
+      fpsLabelDisabled: 'FPS counter off',
+      fpsDescriptionEnabled:
+        'Shows a stats.js FPS panel for immersive debug performance checks.',
+      fpsDescriptionDisabled: 'Hides the stats.js FPS panel.',
     },
     tourReset: {
       heading: 'Guided tour',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -317,6 +317,11 @@ export const JA_OVERRIDES: LocaleOverrides = {
       solidIdsLabelDisabled: 'Solid ID オフ',
       solidIdsDescriptionEnabled:
         '表示中のシーンソリッドに安定 ID とワイヤーフレームを表示します。',
+      fpsLabelEnabled: 'FPS カウンター オン',
+      fpsLabelDisabled: 'FPS カウンター オフ',
+      fpsDescriptionEnabled:
+        '没入デバッグ用の stats.js FPS パネルを表示します。',
+      fpsDescriptionDisabled: 'stats.js FPS パネルを非表示にします。',
       solidIdsDescriptionDisabled:
         '安定したソリッド ID とワイヤーフレームを隠します。',
     },

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -79,6 +79,10 @@ interface LatinLocaleCopy {
     debugCollidersSolidIdsLabelDisabled?: string;
     debugCollidersSolidIdsDescriptionEnabled?: string;
     debugCollidersSolidIdsDescriptionDisabled?: string;
+    debugCollidersFpsLabelEnabled?: string;
+    debugCollidersFpsLabelDisabled?: string;
+    debugCollidersFpsDescriptionEnabled?: string;
+    debugCollidersFpsDescriptionDisabled?: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -776,6 +780,14 @@ export function buildLatinLocaleOverrides(
         solidIdsDescriptionDisabled:
           s.debugCollidersSolidIdsDescriptionDisabled ??
           'Stable solid IDs and wireframes stay hidden.',
+        fpsLabelEnabled: s.debugCollidersFpsLabelEnabled ?? 'FPS counter on',
+        fpsLabelDisabled: s.debugCollidersFpsLabelDisabled ?? 'FPS counter off',
+        fpsDescriptionEnabled:
+          s.debugCollidersFpsDescriptionEnabled ??
+          'Shows a stats.js FPS panel for immersive debug performance checks.',
+        fpsDescriptionDisabled:
+          s.debugCollidersFpsDescriptionDisabled ??
+          'Hides the stats.js FPS panel.',
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -301,6 +301,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       solidIdsLabelEnabled: '实体 ID 开',
       solidIdsLabelDisabled: '实体 ID 关',
       solidIdsDescriptionEnabled: '为可见场景实体显示稳定 ID 和线框。',
+      fpsLabelEnabled: 'FPS 计数器开',
+      fpsLabelDisabled: 'FPS 计数器关',
+      fpsDescriptionEnabled: '显示用于沉浸式调试性能检查的 stats.js FPS 面板。',
+      fpsDescriptionDisabled: '隐藏 stats.js FPS 面板。',
       solidIdsDescriptionDisabled: '隐藏稳定实体 ID 和线框。',
     },
     tourReset: {

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -246,6 +246,10 @@ export interface DebugCollidersStrings {
   solidIdsLabelDisabled: string;
   solidIdsDescriptionEnabled: string;
   solidIdsDescriptionDisabled: string;
+  fpsLabelEnabled: string;
+  fpsLabelDisabled: string;
+  fpsDescriptionEnabled: string;
+  fpsDescriptionDisabled: string;
 }
 
 export interface TourResetControlStrings {

--- a/src/debugPerformanceOverlay.ts
+++ b/src/debugPerformanceOverlay.ts
@@ -1,0 +1,93 @@
+import Stats from 'stats.js';
+
+export const DEBUG_FPS_STORAGE_KEY = 'danielsmith.io::debugFpsCounter::v1';
+
+export interface DebugPerformanceState {
+  fpsEnabled: boolean;
+  panelVisible: boolean;
+}
+
+interface StatsLike {
+  dom: HTMLElement;
+  showPanel(id: number): void;
+  begin(): void;
+  end(): void;
+}
+
+export interface DebugPerformanceOverlay {
+  beginFrame(): void;
+  endFrame(): void;
+  getState(): DebugPerformanceState;
+  setFpsEnabled(enabled: boolean): void;
+  dispose(): void;
+}
+
+export const createDebugPerformanceOverlay = ({
+  enabled,
+  parent = document.body,
+  createStats = () => new Stats(),
+}: {
+  enabled: boolean;
+  parent?: HTMLElement;
+  createStats?: () => StatsLike;
+}): DebugPerformanceOverlay => {
+  let fpsEnabled = enabled;
+  let stats: StatsLike | null = null;
+
+  const ensureStats = () => {
+    if (stats) {
+      return stats;
+    }
+    stats = createStats();
+    stats.showPanel(0);
+    stats.dom.classList.add('debug-performance-overlay');
+    stats.dom.dataset.debugPerformancePanel = 'fps';
+    stats.dom.style.position = 'fixed';
+    stats.dom.style.left = '12px';
+    stats.dom.style.bottom = '12px';
+    stats.dom.style.top = 'auto';
+    stats.dom.style.right = 'auto';
+    stats.dom.style.zIndex = '30';
+    stats.dom.style.pointerEvents = 'none';
+    stats.dom.setAttribute('aria-hidden', 'true');
+    return stats;
+  };
+
+  const syncPanel = () => {
+    if (!fpsEnabled) {
+      stats?.dom.remove();
+      return;
+    }
+    const panel = ensureStats().dom;
+    if (panel.parentElement !== parent) {
+      parent.appendChild(panel);
+    }
+  };
+
+  syncPanel();
+
+  return {
+    beginFrame() {
+      if (fpsEnabled) {
+        ensureStats().begin();
+      }
+    },
+    endFrame() {
+      if (fpsEnabled) {
+        ensureStats().end();
+      }
+    },
+    getState: () => ({
+      fpsEnabled,
+      panelVisible: stats?.dom.parentElement === parent,
+    }),
+    setFpsEnabled(enabled: boolean) {
+      fpsEnabled = enabled;
+      syncPanel();
+    },
+    dispose() {
+      stats?.dom.remove();
+      stats = null;
+    },
+  };
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,10 @@ import {
 } from './assets/i18n';
 import { createImmersiveGradientTexture } from './assets/theme/immersiveGradient';
 import {
+  DEBUG_FPS_STORAGE_KEY,
+  createDebugPerformanceOverlay,
+} from './debugPerformanceOverlay';
+import {
   createAvatarAccessorySuite,
   type AvatarAccessorySuite,
   type AvatarAccessoryState,
@@ -608,6 +612,13 @@ declare global {
         setEnabled(enabled: boolean): void;
         getSolids(): DebugSolidMetadata[];
         getSolidById(id: unknown): DebugSolidMetadata | undefined;
+      };
+      debugPerformance?: {
+        getState(): {
+          fpsEnabled: boolean;
+          panelVisible: boolean;
+        };
+        setFpsEnabled(enabled: boolean): void;
       };
       debugCoordinates?: {
         getState(): {
@@ -1449,13 +1460,34 @@ function initializeImmersiveScene(
   let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
     ? false
     : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
+
+  const debugFpsUrlOverride = new URLSearchParams(window.location.search).get(
+    'debugFps'
+  );
+  const debugFpsUrlEnabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugFpsUrlDisabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugFpsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_FPS_STORAGE_KEY) === '1';
+  let debugFpsEnabled = debugFpsUrlDisabled
+    ? false
+    : debugFpsUrlEnabled || debugFpsStoredEnabled;
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
   let debugColliderIdsControl: HTMLButtonElement | null = null;
   let debugSolidIdsControl: HTMLButtonElement | null = null;
+  let debugFpsControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
+  const debugPerformanceOverlay = createDebugPerformanceOverlay({
+    enabled: debugFpsEnabled,
+  });
   if (rendererInfo.isDangerousSoftwareRenderer) {
     softwareRendererWarning = createSoftwareRendererWarning({
       rendererInfo,
@@ -4509,6 +4541,27 @@ function initializeImmersiveScene(
     debugColliderIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugFpsControl = () => {
+    if (!debugFpsControl) {
+      return;
+    }
+    const label = debugFpsEnabled
+      ? debugCollidersStrings.fpsLabelEnabled
+      : debugCollidersStrings.fpsLabelDisabled;
+    const description = debugFpsEnabled
+      ? debugCollidersStrings.fpsDescriptionEnabled
+      : debugCollidersStrings.fpsDescriptionDisabled;
+    debugFpsControl.textContent = label;
+    debugFpsControl.dataset.state = debugFpsEnabled ? 'enabled' : 'disabled';
+    debugFpsControl.setAttribute(
+      'aria-pressed',
+      debugFpsEnabled ? 'true' : 'false'
+    );
+    debugFpsControl.setAttribute('aria-label', description);
+    debugFpsControl.title = description;
+    debugFpsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
   const refreshDebugSolidIdsControl = () => {
     if (!debugSolidIdsControl) {
       return;
@@ -4571,6 +4624,25 @@ function initializeImmersiveScene(
     }
   };
 
+  const setDebugFpsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugFpsEnabled = enabled;
+    debugPerformanceOverlay.setFpsEnabled(enabled);
+    refreshDebugFpsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_FPS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug FPS counter preference.', error);
+      }
+    }
+  };
+
   const setDebugSolidIdsEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4625,6 +4697,7 @@ function initializeImmersiveScene(
     refreshDebugCollidersControl();
     refreshDebugColliderIdsControl();
     refreshDebugSolidIdsControl();
+    refreshDebugFpsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4672,6 +4745,17 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugSolidIdsControl);
   registerHudControlElement(debugSolidIdsControl);
   refreshDebugSolidIdsControl();
+
+  debugFpsControl = document.createElement('button');
+  debugFpsControl.type = 'button';
+  debugFpsControl.className = 'tour-toggle debug-fps-toggle';
+  debugFpsControl.addEventListener('click', () => {
+    setDebugFpsEnabled(!debugFpsEnabled);
+  });
+  hudSettingsStack.appendChild(debugFpsControl);
+  registerHudControlElement(debugFpsControl);
+  refreshDebugFpsControl();
+
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4729,6 +4813,13 @@ function initializeImmersiveScene(
     getState: getDebugCoordinatesState,
     setEnabled: (enabled: boolean) => {
       setDebugCoordinatesEnabled(enabled);
+    },
+  };
+
+  window.portfolio.debugPerformance = {
+    getState: debugPerformanceOverlay.getState,
+    setFpsEnabled: (enabled: boolean) => {
+      setDebugFpsEnabled(enabled);
     },
   };
 
@@ -6226,6 +6317,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
+    if (window.portfolio?.debugPerformance) {
+      delete window.portfolio.debugPerformance;
+    }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
     }
@@ -6253,6 +6347,11 @@ function initializeImmersiveScene(
       debugSolidIdsControl.remove();
       debugSolidIdsControl = null;
     }
+    if (debugFpsControl) {
+      debugFpsControl.remove();
+      debugFpsControl = null;
+    }
+    debugPerformanceOverlay.dispose();
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
@@ -6331,6 +6430,7 @@ function initializeImmersiveScene(
 
   renderer.setAnimationLoop(() => {
     try {
+      debugPerformanceOverlay.beginFrame();
       const frameStartMs = performance.now();
       const cadenceDecision = resolveSoftwareSafeRenderCadence({
         safeMode: softwareRendererPolicy.safeMode,
@@ -6341,6 +6441,7 @@ function initializeImmersiveScene(
         renderIntervalMs: softwareSafeRenderIntervalMs,
       });
       if (!cadenceDecision.shouldRender) {
+        debugPerformanceOverlay.endFrame();
         return;
       }
       softwareSafeRenderRequested = cadenceDecision.renderRequested;
@@ -6363,6 +6464,7 @@ function initializeImmersiveScene(
       }
       performanceFailover.update(delta);
       if (performanceFailover.hasTriggered()) {
+        debugPerformanceOverlay.endFrame();
         return;
       }
       let phaseStart = performance.now();
@@ -6614,12 +6716,14 @@ function initializeImmersiveScene(
         'mainRender',
         performance.now() - phaseStart
       );
+      debugPerformanceOverlay.endFrame();
       if (!hasPresentedFirstFrame) {
         hasPresentedFirstFrame = true;
         writeModePreference('immersive');
         markDocumentReady('immersive');
       }
     } catch (error) {
+      debugPerformanceOverlay.endFrame();
       handleFatalError(error);
     }
   });

--- a/src/tests/debugPerformanceOverlay.test.ts
+++ b/src/tests/debugPerformanceOverlay.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDebugPerformanceOverlay } from '../debugPerformanceOverlay';
+
+const createStatsStub = () => {
+  const calls = { begin: 0, end: 0, showPanel: [] as number[] };
+  const stats = {
+    calls,
+    dom: document.createElement('div'),
+    showPanel(id: number) {
+      calls.showPanel.push(id);
+    },
+    begin() {
+      calls.begin += 1;
+    },
+    end() {
+      calls.end += 1;
+    },
+  };
+  return stats;
+};
+
+describe('debug performance overlay', () => {
+  it('reports initial disabled state without creating a panel', () => {
+    const parent = document.createElement('div');
+    const overlay = createDebugPerformanceOverlay({
+      enabled: false,
+      parent,
+      createStats: createStatsStub,
+    });
+
+    expect(overlay.getState()).toEqual({
+      fpsEnabled: false,
+      panelVisible: false,
+    });
+    expect(
+      parent.querySelectorAll('[data-debug-performance-panel="fps"]')
+    ).toHaveLength(0);
+  });
+
+  it('toggles the FPS panel without duplicating DOM nodes', () => {
+    const parent = document.createElement('div');
+    const overlay = createDebugPerformanceOverlay({
+      enabled: false,
+      parent,
+      createStats: createStatsStub,
+    });
+
+    overlay.setFpsEnabled(true);
+    overlay.setFpsEnabled(true);
+    expect(
+      parent.querySelectorAll('[data-debug-performance-panel="fps"]')
+    ).toHaveLength(1);
+    expect(overlay.getState()).toEqual({
+      fpsEnabled: true,
+      panelVisible: true,
+    });
+
+    overlay.setFpsEnabled(false);
+    expect(
+      parent.querySelectorAll('[data-debug-performance-panel="fps"]')
+    ).toHaveLength(0);
+    expect(overlay.getState()).toEqual({
+      fpsEnabled: false,
+      panelVisible: false,
+    });
+  });
+
+  it('uses the default FPS panel and does not capture pointer events', () => {
+    const parent = document.createElement('div');
+    const stats = createStatsStub();
+    const overlay = createDebugPerformanceOverlay({
+      enabled: true,
+      parent,
+      createStats: () => stats,
+    });
+
+    overlay.beginFrame();
+    overlay.endFrame();
+
+    expect(stats.calls.showPanel).toEqual([0]);
+    expect(stats.calls.begin).toBe(1);
+    expect(stats.calls.end).toBe(1);
+    expect(stats.dom.style.pointerEvents).toBe('none');
+    expect(stats.dom.style.position).toBe('fixed');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a lightweight, familiar FPS readout for immersive-mode debugging without adding a custom profiler. 
- Surface the counter alongside existing collider/solid debug toggles so QA and contributors can enable performance instrumentation from Settings or the URL. 
- Ensure CI/Docker/sugarkube installs work by adding the dependency and lockfile changes.

### Description
- Add `stats.js` and `@types/stats.js` to `package.json` and `package-lock.json` so `npm ci` installs the runtime and types. 
- Implement a reusable overlay in `src/debugPerformanceOverlay.ts` that creates the stats.js FPS panel, positions it fixed/non-interactive in the lower-left, prevents duplicate DOM nodes, and exposes `getState()` and `setFpsEnabled(...)`. 
- Wire URL override (`?debugFps=1/0` with the repo’s truthy/falsy rules) and persistent storage under `danielsmith.io::debugFpsCounter::v1`, plus a HUD Settings button grouped with collider/solid diagnostics and localized strings. 
- Instrument the immersive render loop to call overlay `begin()`/`end()` around the actual frame/render work so reported FPS reflects real render timing. 
- Expose a small debug API on `window.portfolio.debugPerformance` with `getState()` and `setFpsEnabled(enabled: boolean)`. 
- Add a short design doc `docs/design/debug-performance-overlay.md`, a focused unit test `src/tests/debugPerformanceOverlay.test.ts`, and a Playwright spec `playwright/debug-performance.spec.ts` verifying URL + API behavior.

### Testing
- Ran formatting: `npm run format:write` (passed).
- Lint: `npm run lint` (warnings auto-fixed where applicable; no blocking errors).
- Unit tests: `npm run test:ci` (Vitest) ran full suite; unit tests including `src/tests/debugPerformanceOverlay.test.ts` passed (Vitest summary: all tests passed).
- Playwright: `npx playwright install chromium` and `npx playwright install-deps chromium` were executed to provision browsers and system deps, then `npx playwright test playwright/debug-performance.spec.ts playwright/immersive-stairs-roundtrip.spec.ts` passed (Playwright: 9 tests passed).
- Docs: `npm run docs:check` passed (link-check produced unreachable external URL warnings unrelated to this change).
- Build & smoke: `npm run build` and `npm run smoke` passed (dist assertions OK).
- Typecheck: `npm run typecheck` reported existing repo-wide TypeScript errors unrelated to this change (did not block the focused tests or CI flows exercised here).

Commands to reproduce locally
- `npm install` (or `npm ci` in CI/Docker)
- `npm run format:write`
- `npm run lint`
- `npm run test:ci`
- `npx playwright install chromium`
- `npx playwright install-deps chromium`
- `npx playwright test playwright/debug-performance.spec.ts`

Notes & follow-ups
- The overlay is debug-only and non-interactive (`pointer-events: none` and `aria-hidden="true"`).
- The TS typecheck failures are pre-existing and unrelated; they should be addressed separately to restore a clean `npm run typecheck` run.
- Manual verification: open `/?mode=immersive&disablePerformanceFailover=1&debugColliders=1&debugColliderIds=1&debugSolidIds=1&debugFps=1` and confirm the panel and API behavior as documented in `docs/design/debug-performance-overlay.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4c62d04c832f999b869bb10dafbf)