### PR TITLE
📊 : – add debug FPS counter

### DIFF
--- a/docs/design/debug-performance-overlay.md
+++ b/docs/design/debug-performance-overlay.md
@@ -1,0 +1,47 @@
+# Debug performance overlay
+
+The immersive scene uses [`stats.js`](https://github.com/mrdoob/stats.js) for the
+optional FPS counter because it is a small, familiar Three.js diagnostic panel
+that can be installed from npm instead of copied into the repository or loaded
+from a CDN.
+
+## Toggle, storage, and URL overrides
+
+The Settings diagnostics group now includes an FPS counter toggle beside the
+solid ID tooling. The preference is stored in local storage as
+`danielsmith.io::debugFpsCounter::v1`.
+
+URL parameters use the same debug parsing conventions as the collider tools:
+
+- `?debugFps=1` enables the counter for the immersive session.
+- `?debugFps=0` disables it, even when local storage previously enabled it.
+
+The debug API mirrors that state at `window.portfolio.debugPerformance` with
+`getState()` and `setFpsEnabled(enabled)`.
+
+## Deployment note
+
+`stats.js` is a normal npm dependency and `@types/stats.js` provides TypeScript
+coverage. Both `package.json` and `package-lock.json` are updated so Docker and
+sugarkube deployments that run `npm ci` install the same versions used during
+local verification.
+
+## Overlay behavior
+
+The panel is debug-only and non-interactive. It is fixed near the lower-left
+edge of the viewport, does not capture pointer events, and is removed from the
+DOM when disabled. Repeated toggles reuse the same panel node so rerenders and
+preference changes do not create duplicates.
+
+## Manual verification
+
+Start the immersive preview and open:
+
+```text
+/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1&debugColliderIds=1&debugSolidIds=1&debugFps=1
+```
+
+Confirm that the FPS panel is visible, Settings can turn it off and back on,
+HUD controls remain clickable, and
+`window.portfolio.debugPerformance.getState()` reports matching `fpsEnabled`
+and `panelVisible` values.

--- a/docs/design/debug-performance-overlay.md
+++ b/docs/design/debug-performance-overlay.md
@@ -1,9 +1,8 @@
 # Debug performance overlay
 
-The immersive scene uses [`stats.js`](https://github.com/mrdoob/stats.js) for the
-optional FPS counter because it is a small, familiar Three.js diagnostic panel
-that can be installed from npm instead of copied into the repository or loaded
-from a CDN.
+The immersive scene uses a small in-house FPS counter for the optional
+performance overlay so locked-down npm registry policies cannot block
+installation or deploys.
 
 ## Toggle, storage, and URL overrides
 
@@ -21,16 +20,15 @@ The debug API mirrors that state at `window.portfolio.debugPerformance` with
 
 ## Deployment note
 
-`stats.js` is a normal npm dependency and `@types/stats.js` provides TypeScript
-coverage. Both `package.json` and `package-lock.json` are updated so Docker and
-sugarkube deployments that run `npm ci` install the same versions used during
-local verification.
+The counter has no runtime package dependency. Docker and sugarkube deployments
+that run `npm ci` only need the repository's existing dependency allowlist.
 
 ## Overlay behavior
 
-The panel is debug-only and non-interactive. It is fixed near the lower-left
-edge of the viewport, does not capture pointer events, and is removed from the
-DOM when disabled. Repeated toggles reuse the same panel node so rerenders and
+The panel is debug-only and non-interactive. It is fixed near the upper-left
+edge of the viewport to avoid overlapping the lower-left coordinate debug
+readout, does not capture pointer events, and is removed from the DOM when
+disabled. Repeated toggles reuse the same panel node so rerenders and
 preference changes do not create duplicates.
 
 ## Manual verification

--- a/docs/design/debug-performance-overlay.md
+++ b/docs/design/debug-performance-overlay.md
@@ -1,13 +1,13 @@
 # Debug performance overlay
 
-The immersive scene uses a small in-house FPS counter for the optional
-performance overlay so locked-down npm registry policies cannot block
-installation or deploys.
+The immersive scene uses the external `stats.js` package for the optional
+performance overlay. The local wrapper owns lifecycle, placement, and debug API
+state, while `stats.js` owns FPS measurement and rendering.
 
 ## Toggle, storage, and URL overrides
 
-The Settings diagnostics group now includes an FPS counter toggle beside the
-solid ID tooling. The preference is stored in local storage as
+The Settings diagnostics group includes an FPS counter toggle beside the solid
+ID tooling. The preference is stored in local storage as
 `danielsmith.io::debugFpsCounter::v1`.
 
 URL parameters use the same debug parsing conventions as the collider tools:
@@ -18,18 +18,29 @@ URL parameters use the same debug parsing conventions as the collider tools:
 The debug API mirrors that state at `window.portfolio.debugPerformance` with
 `getState()` and `setFpsEnabled(enabled)`.
 
-## Deployment note
+## Dependency and deployment note
 
-The counter has no runtime package dependency. Docker and sugarkube deployments
-that run `npm ci` only need the repository's existing dependency allowlist.
+`stats.js` is a runtime npm dependency and is locked in `package-lock.json` so
+CI, Docker, and sugarkube deployments install the same package version with
+`npm ci`. If a registry policy blocks the runtime package tarball, treat that
+as a dependency allowlist issue instead of replacing the overlay with a custom
+counter. The repo uses a minimal local TypeScript declaration for `stats.js` so
+it does not need the optional `@types/stats.js` package in environments where
+that typing package is unavailable.
 
 ## Overlay behavior
 
 The panel is debug-only and non-interactive. It is fixed near the upper-left
 edge of the viewport to avoid overlapping the lower-left coordinate debug
 readout, does not capture pointer events, and is removed from the DOM when
-disabled. Repeated toggles reuse the same panel node so rerenders and
+disabled. Repeated toggles reuse the same stats panel node so rerenders and
 preference changes do not create duplicates.
+
+The immersive render loop calls `begin()` before frame work and `end()` after
+frame work; those methods delegate to `stats.begin()` and `stats.end()` when
+the overlay is enabled. Fallback and teardown paths dispose the panel and clear
+`window.portfolio.debugPerformance` so text mode does not retain stale scene
+closures.
 
 ## Manual verification
 
@@ -39,7 +50,7 @@ Start the immersive preview and open:
 /?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1&debugColliderIds=1&debugSolidIds=1&debugFps=1
 ```
 
-Confirm that the FPS panel is visible, Settings can turn it off and back on,
-HUD controls remain clickable, and
-`window.portfolio.debugPerformance.getState()` reports matching `fpsEnabled`
-and `panelVisible` values.
+Confirm that the FPS panel is visible, the coordinate readout remains visible
+without overlap, Settings can turn the panel off and back on, HUD controls
+remain clickable, and `window.portfolio.debugPerformance.getState()` reports
+matching `fpsEnabled` and `panelVisible` values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "stats.js": "^0.17.0",
         "three": "^0.161.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.44.0",
         "@types/jszip": "^3.4.0",
         "@types/node": "^20.11.17",
+        "@types/stats.js": "^0.17.4",
         "@types/three": "^0.161.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -5907,6 +5909,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "stats.js": "^0.17.0",
         "three": "^0.161.0"
       },
       "devDependencies": {
@@ -5907,6 +5908,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "stats.js": "^0.17.0",
         "three": "^0.161.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.44.0",
         "@types/jszip": "^3.4.0",
         "@types/node": "^20.11.17",
-        "@types/stats.js": "^0.17.4",
         "@types/three": "^0.161.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -5909,12 +5907,6 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stats.js": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
-      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
+    "stats.js": "^0.17.0",
     "three": "^0.161.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",
     "@types/jszip": "^3.4.0",
     "@types/node": "^20.11.17",
+    "@types/stats.js": "^0.17.4",
     "@types/three": "^0.161.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,12 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
-    "stats.js": "^0.17.0",
     "three": "^0.161.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",
     "@types/jszip": "^3.4.0",
     "@types/node": "^20.11.17",
-    "@types/stats.js": "^0.17.4",
     "@types/three": "^0.161.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
   },
   "dependencies": {
+    "stats.js": "^0.17.0",
     "three": "^0.161.0"
   },
   "devDependencies": {

--- a/playwright/debug-performance.spec.ts
+++ b/playwright/debug-performance.spec.ts
@@ -52,3 +52,30 @@ test('debug FPS counter toggles through URL and debug API', async ({
     page.locator('[data-debug-performance-panel="fps"]')
   ).toHaveCount(0);
 });
+
+test('debug FPS panel does not overlap debug coordinates', async ({ page }) => {
+  await page.goto(
+    '/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugFps=1'
+  );
+
+  const fpsPanel = page.locator('[data-debug-performance-panel="fps"]');
+  const coordinatesPanel = page.locator('.debug-coordinates');
+  await expect(fpsPanel).toHaveCount(1);
+  await expect(coordinatesPanel).toBeVisible();
+
+  const boxes = await Promise.all([
+    fpsPanel.boundingBox(),
+    coordinatesPanel.boundingBox(),
+  ]);
+  const [fpsBox, coordinatesBox] = boxes;
+  expect(fpsBox).not.toBeNull();
+  expect(coordinatesBox).not.toBeNull();
+
+  const intersects =
+    fpsBox!.x < coordinatesBox!.x + coordinatesBox!.width &&
+    fpsBox!.x + fpsBox!.width > coordinatesBox!.x &&
+    fpsBox!.y < coordinatesBox!.y + coordinatesBox!.height &&
+    fpsBox!.y + fpsBox!.height > coordinatesBox!.y;
+
+  expect(intersects).toBe(false);
+});

--- a/playwright/debug-performance.spec.ts
+++ b/playwright/debug-performance.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+type PortfolioDebugPerformanceWindow = Window & {
+  portfolio?: {
+    debugPerformance?: {
+      getState(): { fpsEnabled: boolean; panelVisible: boolean };
+      setFpsEnabled(enabled: boolean): void;
+    };
+  };
+};
+
+test('debug FPS counter toggles through URL and debug API', async ({
+  page,
+}) => {
+  await page.goto('/?mode=immersive&disablePerformanceFailover=1&debugFps=1');
+  await page.waitForFunction(
+    () =>
+      (window as PortfolioDebugPerformanceWindow).portfolio?.debugPerformance
+        ?.getState
+  );
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        (
+          window as PortfolioDebugPerformanceWindow
+        ).portfolio?.debugPerformance?.getState()
+      )
+    )
+    .toMatchObject({ fpsEnabled: true, panelVisible: true });
+
+  await expect(
+    page.locator('[data-debug-performance-panel="fps"]')
+  ).toHaveCount(1);
+
+  await page.evaluate(() => {
+    (
+      window as PortfolioDebugPerformanceWindow
+    ).portfolio?.debugPerformance?.setFpsEnabled(false);
+  });
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        (
+          window as PortfolioDebugPerformanceWindow
+        ).portfolio?.debugPerformance?.getState()
+      )
+    )
+    .toMatchObject({ fpsEnabled: false, panelVisible: false });
+  await expect(
+    page.locator('[data-debug-performance-panel="fps"]')
+  ).toHaveCount(0);
+});

--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -319,6 +319,12 @@ export const AR_OVERRIDES: LocaleOverrides = {
         'يعرض معرّفات ثابتة وإطارات للمجسمات المرئية في المشهد.',
       solidIdsDescriptionDisabled:
         'تبقى معرّفات المجسمات الثابتة وإطاراتها مخفية.',
+      fpsLabelEnabled: 'عداد FPS مفعّل',
+      fpsLabelDisabled: 'عداد FPS معطّل',
+      fpsDescriptionEnabled:
+        'يعرض لوحة stats.js غير تفاعلية لتشخيص أداء المشهد الغامر.',
+      fpsDescriptionDisabled:
+        'يخفي لوحة stats.js مع إبقاء أدوات التشخيص متاحة.',
     },
     poiOverlay: {
       visited: 'تمت الزيارة',

--- a/src/assets/i18n/locales/de.ts
+++ b/src/assets/i18n/locales/de.ts
@@ -86,6 +86,12 @@ export const DE_OVERRIDES = buildLatinLocaleOverrides({
       'Zeigt stabile IDs und Drahtgitter für sichtbare Szenen-Solids.',
     debugCollidersSolidIdsDescriptionDisabled:
       'Stabile Solid-IDs und Drahtgitter bleiben ausgeblendet.',
+    debugCollidersFpsLabelEnabled: 'FPS-Zähler ein',
+    debugCollidersFpsLabelDisabled: 'FPS-Zähler aus',
+    debugCollidersFpsDescriptionEnabled:
+      'Zeigt ein nicht interaktives stats.js-FPS-Panel für immersive Diagnosen.',
+    debugCollidersFpsDescriptionDisabled:
+      'Blendet das stats.js-FPS-Panel aus, während Diagnosen verfügbar bleiben.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -378,6 +378,12 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
         '⟦Shows stable IDs and wireframes for visible scene solids.⟧',
       solidIdsDescriptionDisabled:
         '⟦Stable solid IDs and wireframes stay hidden.⟧',
+      fpsLabelEnabled: '⟦FPS counter on⟧',
+      fpsLabelDisabled: '⟦FPS counter off⟧',
+      fpsDescriptionEnabled:
+        '⟦Shows a non-interactive stats.js FPS panel for immersive diagnostics.⟧',
+      fpsDescriptionDisabled:
+        '⟦Hides the stats.js FPS panel while keeping diagnostics available.⟧',
     },
     tourReset: {
       heading: wrap('Guided tour'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -384,6 +384,12 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
         'Shows stable IDs and wireframes for visible scene solids.',
       solidIdsDescriptionDisabled:
         'Stable solid IDs and wireframes stay hidden.',
+      fpsLabelEnabled: 'FPS counter on',
+      fpsLabelDisabled: 'FPS counter off',
+      fpsDescriptionEnabled:
+        'Shows a non-interactive stats.js FPS panel for immersive diagnostics.',
+      fpsDescriptionDisabled:
+        'Hides the stats.js FPS panel while keeping diagnostics available.',
     },
     tourReset: {
       heading: 'Guided tour',

--- a/src/assets/i18n/locales/es.ts
+++ b/src/assets/i18n/locales/es.ts
@@ -86,6 +86,12 @@ export const ES_OVERRIDES = buildLatinLocaleOverrides({
       'Muestra IDs estables y alambres para sólidos visibles de la escena.',
     debugCollidersSolidIdsDescriptionDisabled:
       'Las IDs estables de sólidos y sus alambres permanecen ocultos.',
+    debugCollidersFpsLabelEnabled: 'Contador FPS activado',
+    debugCollidersFpsLabelDisabled: 'Contador FPS desactivado',
+    debugCollidersFpsDescriptionEnabled:
+      'Muestra un panel FPS de stats.js no interactivo para diagnósticos inmersivos.',
+    debugCollidersFpsDescriptionDisabled:
+      'Oculta el panel FPS de stats.js y mantiene disponibles los diagnósticos.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/hu.ts
+++ b/src/assets/i18n/locales/hu.ts
@@ -86,6 +86,12 @@ export const HU_OVERRIDES = buildLatinLocaleOverrides({
       'Stabil azonosítókat és drótvázakat mutat a látható jelenetszilárdtestekhez.',
     debugCollidersSolidIdsDescriptionDisabled:
       'A stabil solid-azonosítók és drótvázak rejtve maradnak.',
+    debugCollidersFpsLabelEnabled: 'FPS-számláló be',
+    debugCollidersFpsLabelDisabled: 'FPS-számláló ki',
+    debugCollidersFpsDescriptionEnabled:
+      'Nem interaktív stats.js FPS-panelt jelenít meg az immerzív diagnosztikához.',
+    debugCollidersFpsDescriptionDisabled:
+      'Elrejti a stats.js FPS-panelt, miközben a diagnosztika elérhető marad.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -319,6 +319,12 @@ export const JA_OVERRIDES: LocaleOverrides = {
         '表示中のシーンソリッドに安定 ID とワイヤーフレームを表示します。',
       solidIdsDescriptionDisabled:
         '安定したソリッド ID とワイヤーフレームを隠します。',
+      fpsLabelEnabled: 'FPSカウンターオン',
+      fpsLabelDisabled: 'FPSカウンターオフ',
+      fpsDescriptionEnabled:
+        '没入モード診断用の非対話型stats.js FPSパネルを表示します。',
+      fpsDescriptionDisabled:
+        '診断機能を残したままstats.js FPSパネルを非表示にします。',
     },
     poiOverlay: {
       visited: '訪問済み',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -79,6 +79,10 @@ interface LatinLocaleCopy {
     debugCollidersSolidIdsLabelDisabled?: string;
     debugCollidersSolidIdsDescriptionEnabled?: string;
     debugCollidersSolidIdsDescriptionDisabled?: string;
+    debugCollidersFpsLabelEnabled?: string;
+    debugCollidersFpsLabelDisabled?: string;
+    debugCollidersFpsDescriptionEnabled?: string;
+    debugCollidersFpsDescriptionDisabled?: string;
   };
   poi: Record<string, { summary: string; outcome: string; metrics: string[] }>;
 }
@@ -776,6 +780,14 @@ export function buildLatinLocaleOverrides(
         solidIdsDescriptionDisabled:
           s.debugCollidersSolidIdsDescriptionDisabled ??
           'Stable solid IDs and wireframes stay hidden.',
+        fpsLabelEnabled: s.debugCollidersFpsLabelEnabled ?? 'FPS counter on',
+        fpsLabelDisabled: s.debugCollidersFpsLabelDisabled ?? 'FPS counter off',
+        fpsDescriptionEnabled:
+          s.debugCollidersFpsDescriptionEnabled ??
+          'Shows a non-interactive stats.js FPS panel for immersive diagnostics.',
+        fpsDescriptionDisabled:
+          s.debugCollidersFpsDescriptionDisabled ??
+          'Hides the stats.js FPS panel while keeping diagnostics available.',
       },
       tourReset: {
         heading: s.guidedTour,

--- a/src/assets/i18n/locales/pt.ts
+++ b/src/assets/i18n/locales/pt.ts
@@ -86,6 +86,12 @@ export const PT_OVERRIDES = buildLatinLocaleOverrides({
       'Mostra IDs estáveis e wireframes para sólidos visíveis da cena.',
     debugCollidersSolidIdsDescriptionDisabled:
       'IDs estáveis de sólidos e wireframes permanecem ocultos.',
+    debugCollidersFpsLabelEnabled: 'Contador de FPS ativado',
+    debugCollidersFpsLabelDisabled: 'Contador de FPS desativado',
+    debugCollidersFpsDescriptionEnabled:
+      'Mostra um painel FPS stats.js não interativo para diagnósticos imersivos.',
+    debugCollidersFpsDescriptionDisabled:
+      'Oculta o painel FPS stats.js mantendo os diagnósticos disponíveis.',
   },
   poi: {
     futuroptimist: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -302,6 +302,10 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       solidIdsLabelDisabled: '实体 ID 关',
       solidIdsDescriptionEnabled: '为可见场景实体显示稳定 ID 和线框。',
       solidIdsDescriptionDisabled: '隐藏稳定实体 ID 和线框。',
+      fpsLabelEnabled: 'FPS 计数器已开启',
+      fpsLabelDisabled: 'FPS 计数器已关闭',
+      fpsDescriptionEnabled: '显示用于沉浸式诊断的非交互 stats.js FPS 面板。',
+      fpsDescriptionDisabled: '隐藏 stats.js FPS 面板，同时保留诊断功能。',
     },
     tourReset: {
       heading: '导览',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -246,6 +246,10 @@ export interface DebugCollidersStrings {
   solidIdsLabelDisabled: string;
   solidIdsDescriptionEnabled: string;
   solidIdsDescriptionDisabled: string;
+  fpsLabelEnabled: string;
+  fpsLabelDisabled: string;
+  fpsDescriptionEnabled: string;
+  fpsDescriptionDisabled: string;
 }
 
 export interface TourResetControlStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,6 +116,10 @@ import {
   type DebugColliderVisualizerState,
 } from './scene/debug/colliderVisualizer';
 import {
+  createDebugPerformanceOverlay,
+  type DebugPerformanceState,
+} from './scene/debug/performanceOverlay';
+import {
   createSolidVisualizer,
   type DebugSolidMetadata,
   type DebugSolidVisualizerState,
@@ -485,6 +489,7 @@ const DEBUG_COORDINATES_STORAGE_KEY = 'danielsmith.io::debugCoordinates::v1';
 const DEBUG_COLLIDERS_STORAGE_KEY = 'danielsmith.io::debugColliders::v1';
 const DEBUG_COLLIDER_IDS_STORAGE_KEY = 'danielsmith.io::debugColliderIds::v1';
 const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
+const DEBUG_FPS_STORAGE_KEY = 'danielsmith.io::debugFpsCounter::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
 const isDebugUrlValueIn = (
@@ -608,6 +613,10 @@ declare global {
         setEnabled(enabled: boolean): void;
         getSolids(): DebugSolidMetadata[];
         getSolidById(id: unknown): DebugSolidMetadata | undefined;
+      };
+      debugPerformance?: {
+        getState(): DebugPerformanceState;
+        setFpsEnabled(enabled: boolean): void;
       };
       debugCoordinates?: {
         getState(): {
@@ -1449,10 +1458,31 @@ function initializeImmersiveScene(
   let debugSolidIdsEnabled = debugSolidIdsUrlDisabled
     ? false
     : debugSolidIdsUrlEnabled || debugSolidIdsStoredEnabled;
+
+  const debugFpsUrlOverride = new URLSearchParams(window.location.search).get(
+    'debugFps'
+  );
+  const debugFpsUrlEnabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_TRUTHY_VALUES
+  );
+  const debugFpsUrlDisabled = isDebugUrlValueIn(
+    debugFpsUrlOverride,
+    DEBUG_URL_FALSY_VALUES
+  );
+  const debugFpsStoredEnabled =
+    debugCoordinatesStorage?.getItem(DEBUG_FPS_STORAGE_KEY) === '1';
+  let debugFpsEnabled = debugFpsUrlDisabled
+    ? false
+    : debugFpsUrlEnabled || debugFpsStoredEnabled;
+  const debugPerformanceOverlay = createDebugPerformanceOverlay();
+  debugPerformanceOverlay.setFpsEnabled(debugFpsEnabled);
+
   let debugCoordinatesControl: HTMLButtonElement | null = null;
   let debugCollidersControl: HTMLButtonElement | null = null;
   let debugColliderIdsControl: HTMLButtonElement | null = null;
   let debugSolidIdsControl: HTMLButtonElement | null = null;
+  let debugFpsControl: HTMLButtonElement | null = null;
   let debugCoordinatesOverlay: HTMLElement | null = null;
   let debugCoordinatesHeading: HTMLDivElement | null = null;
   let debugCoordinatesInterval: number | null = null;
@@ -4509,6 +4539,27 @@ function initializeImmersiveScene(
     debugColliderIdsControl.dataset.hudAnnounce = `${label}. ${description}`;
   };
 
+  const refreshDebugFpsControl = () => {
+    if (!debugFpsControl) {
+      return;
+    }
+    const label = debugFpsEnabled
+      ? debugCollidersStrings.fpsLabelEnabled
+      : debugCollidersStrings.fpsLabelDisabled;
+    const description = debugFpsEnabled
+      ? debugCollidersStrings.fpsDescriptionEnabled
+      : debugCollidersStrings.fpsDescriptionDisabled;
+    debugFpsControl.textContent = label;
+    debugFpsControl.dataset.state = debugFpsEnabled ? 'enabled' : 'disabled';
+    debugFpsControl.setAttribute(
+      'aria-pressed',
+      debugFpsEnabled ? 'true' : 'false'
+    );
+    debugFpsControl.setAttribute('aria-label', description);
+    debugFpsControl.title = description;
+    debugFpsControl.dataset.hudAnnounce = `${label}. ${description}`;
+  };
+
   const refreshDebugSolidIdsControl = () => {
     if (!debugSolidIdsControl) {
       return;
@@ -4571,6 +4622,25 @@ function initializeImmersiveScene(
     }
   };
 
+  const setDebugFpsEnabled = (
+    enabled: boolean,
+    options: { persist?: boolean } = { persist: true }
+  ) => {
+    debugFpsEnabled = enabled;
+    debugPerformanceOverlay.setFpsEnabled(enabled);
+    refreshDebugFpsControl();
+    if (options.persist !== false && debugCoordinatesStorage) {
+      try {
+        debugCoordinatesStorage.setItem(
+          DEBUG_FPS_STORAGE_KEY,
+          enabled ? '1' : '0'
+        );
+      } catch (error) {
+        console.warn('Failed to persist debug FPS counter preference.', error);
+      }
+    }
+  };
+
   const setDebugSolidIdsEnabled = (
     enabled: boolean,
     options: { persist?: boolean } = { persist: true }
@@ -4625,6 +4695,7 @@ function initializeImmersiveScene(
     refreshDebugCollidersControl();
     refreshDebugColliderIdsControl();
     refreshDebugSolidIdsControl();
+    refreshDebugFpsControl();
   };
 
   debugCoordinatesOverlay = document.createElement('aside');
@@ -4672,6 +4743,16 @@ function initializeImmersiveScene(
   hudSettingsStack.appendChild(debugSolidIdsControl);
   registerHudControlElement(debugSolidIdsControl);
   refreshDebugSolidIdsControl();
+
+  debugFpsControl = document.createElement('button');
+  debugFpsControl.type = 'button';
+  debugFpsControl.className = 'tour-toggle debug-fps-toggle';
+  debugFpsControl.addEventListener('click', () => {
+    setDebugFpsEnabled(!debugFpsEnabled);
+  });
+  hudSettingsStack.appendChild(debugFpsControl);
+  registerHudControlElement(debugFpsControl);
+  refreshDebugFpsControl();
   updateDebugCoordinatesOverlay();
   debugCoordinatesInterval = window.setInterval(
     updateDebugCoordinatesOverlay,
@@ -4722,6 +4803,13 @@ function initializeImmersiveScene(
     getSolidById: (id: unknown) => {
       ensureSolidVisualizerRegistered();
       return solidVisualizer.getSolidById(id);
+    },
+  };
+
+  window.portfolio.debugPerformance = {
+    getState: () => debugPerformanceOverlay.getState(),
+    setFpsEnabled: (enabled: boolean) => {
+      setDebugFpsEnabled(enabled);
     },
   };
 
@@ -6226,6 +6314,9 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
+    if (window.portfolio?.debugPerformance) {
+      delete window.portfolio.debugPerformance;
+    }
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
     }
@@ -6253,6 +6344,11 @@ function initializeImmersiveScene(
       debugSolidIdsControl.remove();
       debugSolidIdsControl = null;
     }
+    if (debugFpsControl) {
+      debugFpsControl.remove();
+      debugFpsControl = null;
+    }
+    debugPerformanceOverlay.dispose();
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;
@@ -6343,6 +6439,7 @@ function initializeImmersiveScene(
       if (!cadenceDecision.shouldRender) {
         return;
       }
+      debugPerformanceOverlay.begin();
       softwareSafeRenderRequested = cadenceDecision.renderRequested;
       lastSoftwareSafeRenderMs = cadenceDecision.lastRenderMs;
       const delta = clock.getDelta();
@@ -6363,6 +6460,7 @@ function initializeImmersiveScene(
       }
       performanceFailover.update(delta);
       if (performanceFailover.hasTriggered()) {
+        debugPerformanceOverlay.end();
         return;
       }
       let phaseStart = performance.now();
@@ -6619,7 +6717,9 @@ function initializeImmersiveScene(
         writeModePreference('immersive');
         markDocumentReady('immersive');
       }
+      debugPerformanceOverlay.end();
     } catch (error) {
+      debugPerformanceOverlay.end();
       handleFatalError(error);
     }
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1552,6 +1552,7 @@ function initializeImmersiveScene(
       disposeImmersiveResources();
     },
     onFallback: (reason) => {
+      disposeDebugPerformanceRegistration();
       lastFailoverReason = reason;
       inputLatencyTelemetry?.report(`failover-${reason}`);
     },
@@ -6086,6 +6087,13 @@ function initializeImmersiveScene(
     helpKeyWasPressed = pressed;
   }
 
+  function disposeDebugPerformanceRegistration() {
+    debugPerformanceOverlay.dispose();
+    if (window.portfolio?.debugPerformance) {
+      delete window.portfolio.debugPerformance;
+    }
+  }
+
   function disposeImmersiveResources() {
     if (immersiveDisposed) {
       return;
@@ -6314,9 +6322,7 @@ function initializeImmersiveScene(
     if (window.portfolio?.debugCoordinates) {
       delete window.portfolio.debugCoordinates;
     }
-    if (window.portfolio?.debugPerformance) {
-      delete window.portfolio.debugPerformance;
-    }
+    disposeDebugPerformanceRegistration();
     if (window.portfolio?.performance) {
       window.portfolio.performance = crashLogAccess;
     }
@@ -6348,7 +6354,6 @@ function initializeImmersiveScene(
       debugFpsControl.remove();
       debugFpsControl = null;
     }
-    debugPerformanceOverlay.dispose();
     if (debugCoordinatesOverlay) {
       debugCoordinatesOverlay.remove();
       debugCoordinatesOverlay = null;

--- a/src/scene/debug/__tests__/performanceOverlay.test.ts
+++ b/src/scene/debug/__tests__/performanceOverlay.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createDebugPerformanceOverlay } from '../performanceOverlay';
+
+const createCanvasContext = () => ({
+  fillRect: vi.fn(),
+  fillText: vi.fn(),
+  drawImage: vi.fn(),
+  getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4) })),
+  putImageData: vi.fn(),
+  font: '',
+  fillStyle: '',
+  globalAlpha: 1,
+});
+
+describe('debug performance overlay', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () => createCanvasContext() as unknown as CanvasRenderingContext2D
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('reports disabled state before the FPS panel is enabled', () => {
+    const overlay = createDebugPerformanceOverlay();
+
+    expect(overlay.getState()).toEqual({
+      fpsEnabled: false,
+      panelVisible: false,
+    });
+
+    overlay.dispose();
+  });
+
+  it('toggles a single non-interactive stats panel without duplicates', () => {
+    const overlay = createDebugPerformanceOverlay();
+
+    overlay.setFpsEnabled(true);
+    overlay.setFpsEnabled(true);
+
+    const panels = document.querySelectorAll(
+      '[data-debug-performance-panel="fps"]'
+    );
+    expect(panels).toHaveLength(1);
+    expect(overlay.getState()).toEqual({
+      fpsEnabled: true,
+      panelVisible: true,
+    });
+    expect((panels[0] as HTMLElement).style.pointerEvents).toBe('none');
+
+    overlay.setFpsEnabled(false);
+
+    expect(
+      document.querySelectorAll('[data-debug-performance-panel="fps"]')
+    ).toHaveLength(0);
+    expect(overlay.getState()).toEqual({
+      fpsEnabled: false,
+      panelVisible: false,
+    });
+  });
+});

--- a/src/scene/debug/__tests__/performanceOverlay.test.ts
+++ b/src/scene/debug/__tests__/performanceOverlay.test.ts
@@ -1,25 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createDebugPerformanceOverlay } from '../performanceOverlay';
 
-const createCanvasContext = () => ({
-  fillRect: vi.fn(),
-  fillText: vi.fn(),
-  drawImage: vi.fn(),
-  getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4) })),
-  putImageData: vi.fn(),
-  font: '',
-  fillStyle: '',
-  globalAlpha: 1,
-});
-
 describe('debug performance overlay', () => {
-  beforeEach(() => {
-    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
-      () => createCanvasContext() as unknown as CanvasRenderingContext2D
-    );
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
     document.body.innerHTML = '';
@@ -36,7 +19,7 @@ describe('debug performance overlay', () => {
     overlay.dispose();
   });
 
-  it('toggles a single non-interactive stats panel without duplicates', () => {
+  it('toggles a single non-interactive FPS panel without duplicates', () => {
     const overlay = createDebugPerformanceOverlay();
 
     overlay.setFpsEnabled(true);
@@ -51,6 +34,9 @@ describe('debug performance overlay', () => {
       panelVisible: true,
     });
     expect((panels[0] as HTMLElement).style.pointerEvents).toBe('none');
+    expect((panels[0] as HTMLElement).style.top).toBe(
+      'max(1rem, env(safe-area-inset-top))'
+    );
 
     overlay.setFpsEnabled(false);
 
@@ -61,5 +47,24 @@ describe('debug performance overlay', () => {
       fpsEnabled: false,
       panelVisible: false,
     });
+  });
+
+  it('updates the in-house FPS label without a runtime dependency', () => {
+    const now = vi.spyOn(performance, 'now');
+    now
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(250)
+      .mockReturnValueOnce(500);
+    const overlay = createDebugPerformanceOverlay();
+
+    overlay.setFpsEnabled(true);
+    overlay.end();
+    overlay.end();
+
+    expect(
+      document.querySelector<HTMLElement>(
+        '[data-debug-performance-panel="fps"]'
+      )?.textContent
+    ).toBe('FPS 4');
   });
 });

--- a/src/scene/debug/__tests__/performanceOverlay.test.ts
+++ b/src/scene/debug/__tests__/performanceOverlay.test.ts
@@ -2,15 +2,40 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createDebugPerformanceOverlay } from '../performanceOverlay';
 
+const showPanel = vi.fn();
+const begin = vi.fn();
+const end = vi.fn();
+const statsInstances: Array<{
+  dom: HTMLDivElement;
+  domElement: HTMLDivElement;
+}> = [];
+
+vi.mock('stats.js', () => ({
+  default: vi.fn().mockImplementation(() => {
+    const dom = document.createElement('div');
+    const stats = {
+      dom,
+      domElement: dom,
+      showPanel,
+      begin,
+      end,
+    };
+    statsInstances.push(stats);
+    return stats;
+  }),
+}));
+
 describe('debug performance overlay', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    statsInstances.length = 0;
     document.body.innerHTML = '';
   });
 
-  it('reports disabled state before the FPS panel is enabled', () => {
+  it('creates a stats.js FPS panel and reports disabled state before enabling', () => {
     const overlay = createDebugPerformanceOverlay();
 
+    expect(showPanel).toHaveBeenCalledWith(0);
     expect(overlay.getState()).toEqual({
       fpsEnabled: false,
       panelVisible: false,
@@ -49,22 +74,19 @@ describe('debug performance overlay', () => {
     });
   });
 
-  it('updates the in-house FPS label without a runtime dependency', () => {
-    const now = vi.spyOn(performance, 'now');
-    now
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(250)
-      .mockReturnValueOnce(500);
+  it('delegates frame samples to stats.js only while enabled', () => {
     const overlay = createDebugPerformanceOverlay();
 
-    overlay.setFpsEnabled(true);
+    overlay.begin();
     overlay.end();
+    expect(begin).not.toHaveBeenCalled();
+    expect(end).not.toHaveBeenCalled();
+
+    overlay.setFpsEnabled(true);
+    overlay.begin();
     overlay.end();
 
-    expect(
-      document.querySelector<HTMLElement>(
-        '[data-debug-performance-panel="fps"]'
-      )?.textContent
-    ).toBe('FPS 4');
+    expect(begin).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/scene/debug/performanceOverlay.ts
+++ b/src/scene/debug/performanceOverlay.ts
@@ -1,3 +1,5 @@
+import Stats from 'stats.js';
+
 export interface DebugPerformanceState {
   fpsEnabled: boolean;
   panelVisible: boolean;
@@ -12,13 +14,15 @@ export interface DebugPerformanceOverlay {
 }
 
 const PANEL_CLASS = 'debug-performance-overlay';
-const FPS_REFRESH_INTERVAL_MS = 500;
 
 export function createDebugPerformanceOverlay(
   parent: HTMLElement = document.body
 ): DebugPerformanceOverlay {
-  const panel = document.createElement('div');
-  panel.className = PANEL_CLASS;
+  const stats = new Stats();
+  stats.showPanel(0);
+
+  const panel = stats.dom ?? stats.domElement;
+  panel.className = `${panel.className} ${PANEL_CLASS}`.trim();
   panel.dataset.debugPerformancePanel = 'fps';
   panel.setAttribute('aria-hidden', 'true');
   panel.style.position = 'fixed';
@@ -26,21 +30,8 @@ export function createDebugPerformanceOverlay(
   panel.style.top = 'max(1rem, env(safe-area-inset-top))';
   panel.style.zIndex = '40';
   panel.style.pointerEvents = 'none';
-  panel.style.minWidth = '4.25rem';
-  panel.style.padding = '0.35rem 0.45rem';
-  panel.style.border = '1px solid rgba(86, 184, 255, 0.5)';
-  panel.style.borderRadius = '0.45rem';
-  panel.style.background = 'rgba(5, 12, 21, 0.82)';
-  panel.style.boxShadow = '0 10px 24px rgba(3, 9, 18, 0.36)';
-  panel.style.color = '#8fffb1';
-  panel.style.font = '700 0.72rem/1.15 ui-monospace, SFMono-Regular, monospace';
-  panel.style.letterSpacing = '0.02em';
-  panel.style.textTransform = 'uppercase';
-  panel.textContent = 'FPS --';
 
   let fpsEnabled = false;
-  let frameCount = 0;
-  let sampleStartMs = 0;
 
   const attach = () => {
     if (panel.parentElement !== parent) {
@@ -53,33 +44,18 @@ export function createDebugPerformanceOverlay(
     panel.remove();
   };
 
-  const resetSample = (nowMs: number) => {
-    frameCount = 0;
-    sampleStartMs = nowMs;
-    panel.textContent = 'FPS --';
-  };
-
   return {
     begin: () => {
       if (!fpsEnabled) {
         return;
       }
-      // Capture cadence with a lightweight in-house counter instead of an npm
-      // dependency so locked-down registry installs can still run npm ci.
+      stats.begin();
     },
     end: () => {
       if (!fpsEnabled) {
         return;
       }
-      const nowMs = performance.now();
-      frameCount += 1;
-      const elapsedMs = nowMs - sampleStartMs;
-      if (elapsedMs >= FPS_REFRESH_INTERVAL_MS) {
-        const fps = Math.round((frameCount * 1000) / elapsedMs);
-        panel.textContent = `FPS ${fps}`;
-        frameCount = 0;
-        sampleStartMs = nowMs;
-      }
+      stats.end();
     },
     getState: () => ({
       fpsEnabled,
@@ -88,7 +64,6 @@ export function createDebugPerformanceOverlay(
     setFpsEnabled: (enabled: boolean) => {
       fpsEnabled = enabled;
       if (enabled) {
-        resetSample(performance.now());
         attach();
       } else {
         detach();
@@ -96,7 +71,6 @@ export function createDebugPerformanceOverlay(
     },
     dispose: () => {
       fpsEnabled = false;
-      frameCount = 0;
       detach();
     },
   };

--- a/src/scene/debug/performanceOverlay.ts
+++ b/src/scene/debug/performanceOverlay.ts
@@ -1,0 +1,76 @@
+import Stats from 'stats.js';
+
+export interface DebugPerformanceState {
+  fpsEnabled: boolean;
+  panelVisible: boolean;
+}
+
+export interface DebugPerformanceOverlay {
+  begin(): void;
+  end(): void;
+  getState(): DebugPerformanceState;
+  setFpsEnabled(enabled: boolean): void;
+  dispose(): void;
+}
+
+const PANEL_CLASS = 'debug-performance-overlay';
+
+export function createDebugPerformanceOverlay(
+  parent: HTMLElement = document.body
+): DebugPerformanceOverlay {
+  const stats = new Stats();
+  stats.showPanel(0);
+
+  const panel = stats.dom;
+  panel.classList.add(PANEL_CLASS);
+  panel.dataset.debugPerformancePanel = 'fps';
+  panel.setAttribute('aria-hidden', 'true');
+  panel.style.position = 'fixed';
+  panel.style.left = '12px';
+  panel.style.bottom = '12px';
+  panel.style.top = 'auto';
+  panel.style.zIndex = '40';
+  panel.style.pointerEvents = 'none';
+
+  let fpsEnabled = false;
+
+  const attach = () => {
+    if (panel.parentElement !== parent) {
+      panel.remove();
+      parent.appendChild(panel);
+    }
+  };
+
+  const detach = () => {
+    panel.remove();
+  };
+
+  return {
+    begin: () => {
+      if (fpsEnabled) {
+        stats.begin();
+      }
+    },
+    end: () => {
+      if (fpsEnabled) {
+        stats.end();
+      }
+    },
+    getState: () => ({
+      fpsEnabled,
+      panelVisible: panel.isConnected,
+    }),
+    setFpsEnabled: (enabled: boolean) => {
+      fpsEnabled = enabled;
+      if (enabled) {
+        attach();
+      } else {
+        detach();
+      }
+    },
+    dispose: () => {
+      fpsEnabled = false;
+      detach();
+    },
+  };
+}

--- a/src/scene/debug/performanceOverlay.ts
+++ b/src/scene/debug/performanceOverlay.ts
@@ -1,5 +1,3 @@
-import Stats from 'stats.js';
-
 export interface DebugPerformanceState {
   fpsEnabled: boolean;
   panelVisible: boolean;
@@ -14,25 +12,35 @@ export interface DebugPerformanceOverlay {
 }
 
 const PANEL_CLASS = 'debug-performance-overlay';
+const FPS_REFRESH_INTERVAL_MS = 500;
 
 export function createDebugPerformanceOverlay(
   parent: HTMLElement = document.body
 ): DebugPerformanceOverlay {
-  const stats = new Stats();
-  stats.showPanel(0);
-
-  const panel = stats.dom;
-  panel.classList.add(PANEL_CLASS);
+  const panel = document.createElement('div');
+  panel.className = PANEL_CLASS;
   panel.dataset.debugPerformancePanel = 'fps';
   panel.setAttribute('aria-hidden', 'true');
   panel.style.position = 'fixed';
-  panel.style.left = '12px';
-  panel.style.bottom = '12px';
-  panel.style.top = 'auto';
+  panel.style.left = 'max(1rem, env(safe-area-inset-left))';
+  panel.style.top = 'max(1rem, env(safe-area-inset-top))';
   panel.style.zIndex = '40';
   panel.style.pointerEvents = 'none';
+  panel.style.minWidth = '4.25rem';
+  panel.style.padding = '0.35rem 0.45rem';
+  panel.style.border = '1px solid rgba(86, 184, 255, 0.5)';
+  panel.style.borderRadius = '0.45rem';
+  panel.style.background = 'rgba(5, 12, 21, 0.82)';
+  panel.style.boxShadow = '0 10px 24px rgba(3, 9, 18, 0.36)';
+  panel.style.color = '#8fffb1';
+  panel.style.font = '700 0.72rem/1.15 ui-monospace, SFMono-Regular, monospace';
+  panel.style.letterSpacing = '0.02em';
+  panel.style.textTransform = 'uppercase';
+  panel.textContent = 'FPS --';
 
   let fpsEnabled = false;
+  let frameCount = 0;
+  let sampleStartMs = 0;
 
   const attach = () => {
     if (panel.parentElement !== parent) {
@@ -45,15 +53,32 @@ export function createDebugPerformanceOverlay(
     panel.remove();
   };
 
+  const resetSample = (nowMs: number) => {
+    frameCount = 0;
+    sampleStartMs = nowMs;
+    panel.textContent = 'FPS --';
+  };
+
   return {
     begin: () => {
-      if (fpsEnabled) {
-        stats.begin();
+      if (!fpsEnabled) {
+        return;
       }
+      // Capture cadence with a lightweight in-house counter instead of an npm
+      // dependency so locked-down registry installs can still run npm ci.
     },
     end: () => {
-      if (fpsEnabled) {
-        stats.end();
+      if (!fpsEnabled) {
+        return;
+      }
+      const nowMs = performance.now();
+      frameCount += 1;
+      const elapsedMs = nowMs - sampleStartMs;
+      if (elapsedMs >= FPS_REFRESH_INTERVAL_MS) {
+        const fps = Math.round((frameCount * 1000) / elapsedMs);
+        panel.textContent = `FPS ${fps}`;
+        frameCount = 0;
+        sampleStartMs = nowMs;
       }
     },
     getState: () => ({
@@ -63,6 +88,7 @@ export function createDebugPerformanceOverlay(
     setFpsEnabled: (enabled: boolean) => {
       fpsEnabled = enabled;
       if (enabled) {
+        resetSample(performance.now());
         attach();
       } else {
         detach();
@@ -70,6 +96,7 @@ export function createDebugPerformanceOverlay(
     },
     dispose: () => {
       fpsEnabled = false;
+      frameCount = 0;
       detach();
     },
   };

--- a/src/types/stats.js.d.ts
+++ b/src/types/stats.js.d.ts
@@ -3,7 +3,7 @@ declare module 'stats.js' {
     dom: HTMLDivElement;
     domElement: HTMLDivElement;
     begin(): void;
-    end(): number;
+    end(): void;
     showPanel(id: number): void;
   }
 }

--- a/src/types/stats.js.d.ts
+++ b/src/types/stats.js.d.ts
@@ -1,0 +1,9 @@
+declare module 'stats.js' {
+  export default class Stats {
+    dom: HTMLDivElement;
+    domElement: HTMLDivElement;
+    begin(): void;
+    end(): number;
+    showPanel(id: number): void;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide an opt-in FPS/performance overlay for immersive debugging using the well-known `stats.js` package so developers can inspect runtime frame rates during immersive sessions.
- Surface the control alongside existing collider/solid diagnostics and expose a minimal debug API so automation and manual verification can enable/disable the overlay consistently via URL, storage, Settings, and `window.portfolio`.

### Description

- Add `stats.js` as a runtime dependency in `package.json` and `package-lock.json`.
- Avoid the `@types/stats.js` registry/403 issue by using a minimal local TypeScript declaration at `src/types/stats.js.d.ts` instead of depending on the external typings package.
- Introduce a duplicate-safe, non-interactive overlay wrapper in `src/scene/debug/performanceOverlay.ts` that delegates FPS measurement/rendering to `stats.js` via `showPanel(0)`, `begin()`, and `end()`.
- Wire URL overrides (`?debugFps=1|0`), localStorage key `danielsmith.io::debugFpsCounter::v1`, HUD Settings toggle, and persistence through `src/main.ts`.
- Register `window.portfolio.debugPerformance` with `getState()` and `setFpsEnabled()`.
- Instrument the immersive render loop to call the overlay `begin()` / `end()` around frame work without per-frame allocations.
- Preserve cleanup on disable, scene teardown, and performance fallback so the FPS panel does not remain attached after immersive mode exits.
- Place the panel away from the debug coordinates overlay and keep `pointer-events: none` so it does not block HUD or scene interactions.
- Add i18n keys and locale strings for the FPS toggle.
- Add `docs/design/debug-performance-overlay.md` documenting the stats.js dependency, the local typing workaround, storage/URL behavior, sugarkube / `npm ci` deployment expectations, and manual verification.
- Add focused Vitest unit tests for the overlay and a Playwright spec for URL/API toggling and overlay placement.

### Testing

- `npm ci`
- `npm run format:write`
- `npm run lint`
- `npm run test:ci -- src/scene/debug/__tests__/performanceOverlay.test.ts`
- `npm run test:ci`
- `npx playwright test playwright/debug-performance.spec.ts playwright/immersive-stairs-roundtrip.spec.ts`
- `npm run docs:check`
- `npm run build`
- `npm run smoke`

### Manual verification

Opened immersive mode with:

```text
/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1&debugColliderIds=1&debugSolidIds=1&debugFps=1
```

Confirmed the FPS panel appears, does not overlap the debug coordinates readout, can be toggled off/on, does not capture pointer events, and reports matching state through `window.portfolio.debugPerformance.getState()`.