### PR TITLE
🧹 Remove errant collider sources

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -785,11 +785,86 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   for (const previouslyRemovedCollider of previouslyRemovedArtifactColliders) {
     expect(debugColliderNames).not.toContain(previouslyRemovedCollider);
   }
+  const removedTargetColliderIds = [
+    '4005',
+    '4008',
+    '4006',
+    '400B',
+    '400C',
+    '4001',
+    '1023',
+    '101A',
+    '1020',
+    '102C',
+    '2001',
+    '200F',
+    '1003',
+    '1027',
+    '1007',
+    '200D',
+  ];
+  const removedTargetColliderNames = [
+    'UpperStairWestUpperVoidGuard',
+    'UpperStairHiddenRunVoidGuard',
+    'UpperStairEastLowerVoidGuard',
+    'UpperStairwellLandingGuard-1',
+    'UpperStairwellLandingGuard-2',
+    'GroundStairEastBoundary',
+  ];
+  for (const removedColliderName of removedTargetColliderNames) {
+    expect(debugColliderNames).not.toContain(removedColliderName);
+  }
   expect(debugColliderNames).toContain('UpperStairWestBannisterGuard');
   expect(debugColliderNames).toContain('UpperStairNorthBannisterGuard');
-  expect(debugColliderNames).toContain('UpperStairHiddenRunVoidGuard');
 
   const debugColliderIds = debugColliders.map((collider) => collider.id);
+  for (const removedColliderId of removedTargetColliderIds) {
+    expect(debugColliderIds).not.toContain(removedColliderId);
+  }
+  for (const removedColliderId of removedTargetColliderIds) {
+    const foundTarget = await page.evaluate((id) => {
+      const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+      if (!debugApi) {
+        throw new Error('Debug colliders API unavailable');
+      }
+      return debugApi.getColliderById(id);
+    }, removedColliderId);
+    expect(foundTarget).toBeUndefined();
+  }
+  const removedSourceBounds = [
+    { minX: 15.94, maxX: 22.18, minZ: -25.9, maxZ: -10.6 },
+    {
+      minX: 28.138991631191697,
+      maxX: 29.46100836880832,
+      minZ: -25.126903730815343,
+      maxZ: -20.473096269184673,
+    },
+    { minX: 12.63, maxX: 13.23, minZ: -4.3, maxZ: -3.7 },
+    { minX: 19.55, maxX: 20.45, minZ: -3.5, maxZ: -2.7 },
+    {
+      minX: -15.427711452812336,
+      maxX: -14.572288547187664,
+      minZ: 4.4434114543880145,
+      maxZ: 6.196588545611986,
+    },
+    { minX: -15.4, maxX: -8.6, minZ: 20.6, maxZ: 27.4 },
+    { minX: 8.4, maxX: 15.6, minZ: 22.8, maxZ: 29.2 },
+  ];
+  const hasMatchingBounds = (
+    bounds: DebugCollider['bounds'],
+    target: DebugCollider['bounds']
+  ) =>
+    Math.abs(bounds.minX - target.minX) < 0.001 &&
+    Math.abs(bounds.maxX - target.maxX) < 0.001 &&
+    Math.abs(bounds.minZ - target.minZ) < 0.001 &&
+    Math.abs(bounds.maxZ - target.maxZ) < 0.001;
+  for (const removedBounds of removedSourceBounds) {
+    expect(
+      debugColliders.some((collider) =>
+        hasMatchingBounds(collider.bounds, removedBounds)
+      )
+    ).toBe(false);
+  }
   expect(debugColliderIds.length).toBeGreaterThan(0);
   expect(new Set(debugColliderIds).size).toBe(debugColliderIds.length);
   expect(debugColliderIds.every((id) => /^[0-9A-F]{4,6}$/.test(id))).toBe(true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1885,7 +1885,6 @@ function initializeImmersiveScene(
       height: 4.1,
     });
     groundFloorGroup.add(mirror.group);
-    groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }
 
@@ -2011,7 +2010,6 @@ function initializeImmersiveScene(
   // computeStairLayout result used by movement. It removes both the stair
   // landing void and the hidden ramp run below the landing lip.
   if (upperLandingRoom && upperStairwellOpening) {
-    const upperStairVoidMinZ = upperStairwellOpening.minZ;
     const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
     const upperLandingDoorwayClearanceZ =
       upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
@@ -2050,10 +2048,6 @@ function initializeImmersiveScene(
       hiddenStairTopGapBlockerNearZ,
       hiddenStairTopGapBlockerFarZ
     );
-    const upperStairLandingEntryMinZ = Math.max(
-      upperStairVoidMinZ,
-      hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
-    );
     const upperStairLandingEntryMaxZ = Math.min(
       upperStairVoidMaxZ,
       hiddenStairTopGapBlockerMaxZ + PLAYER_RADIUS
@@ -2089,33 +2083,7 @@ function initializeImmersiveScene(
       hiddenStairBlockerStartZ + upperStairBannisterThickness;
     const upperStairNorthBannisterMaxX =
       upperStairwellOpening.maxX - upperStairBannisterThickness;
-    const upperStairDescentHandoffFarZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (stairTransitionMargin + stairLandingTriggerMargin);
-    const upperStairHiddenRunGuardNearZ =
-      upperStairDescentHandoffFarZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-
     [
-      {
-        name: 'UpperStairWestUpperVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.minX,
-          minZ: upperStairVoidMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
-      {
-        name: 'UpperStairEastLowerVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairVoidMinZ,
-          maxZ: upperStairLandingEntryMinZ,
-        },
-      },
       {
         name: 'UpperStairEastUpperVoidGuard',
         bounds: {
@@ -2126,24 +2094,6 @@ function initializeImmersiveScene(
         },
       },
       ...upperStairTopGapBlockers,
-      {
-        name: 'UpperStairHiddenRunVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.maxX,
-          minZ: Math.min(
-            upperStairHiddenRunGuardNearZ,
-            upperLandingDoorwayClearanceZ
-          ),
-          maxZ: Math.max(
-            upperStairHiddenRunGuardNearZ,
-            upperStairNorthBannisterCenterZ -
-              upperStairBannisterThickness / 2 -
-              PLAYER_RADIUS -
-              0.01
-          ),
-        },
-      },
       {
         name: 'UpperStairWestBannisterGuard',
         bounds: {
@@ -2249,12 +2199,14 @@ function initializeImmersiveScene(
       },
     });
     upperFloorGroup.add(upperStairwellLanding.group);
-    upperStairwellLanding.colliders.forEach((collider, index) =>
-      pushNamedUpperFloorCollider(
-        `UpperStairwellLandingGuard-${index + 1}`,
-        collider
-      )
-    );
+    upperStairwellLanding.colliders
+      .slice(2)
+      .forEach((collider, index) =>
+        pushNamedUpperFloorCollider(
+          `UpperStairwellLandingGuard-${index + 3}`,
+          collider
+        )
+      );
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
@@ -2385,7 +2337,10 @@ function initializeImmersiveScene(
     if (poi.collider) {
       if (getPoiFloorId(poi.definition) === 'upper') {
         upperFloorColliders.push(poi.collider);
-      } else {
+      } else if (
+        poi.definition.id !== 'dspace-backyard-rocket' &&
+        poi.definition.id !== 'sugarkube-backyard-greenhouse'
+      ) {
         staticColliders.push(poi.collider);
       }
     }

--- a/src/scene/structures/__tests__/axelNavigator.test.ts
+++ b/src/scene/structures/__tests__/axelNavigator.test.ts
@@ -10,7 +10,7 @@ describe('createAxelNavigator', () => {
     expect(build.group.name).toBe('AxelQuestNavigator');
     expect(build.group.position.x).toBeCloseTo(2);
     expect(build.group.position.z).toBeCloseTo(-3);
-    expect(build.colliders).toHaveLength(2);
+    expect(build.colliders).toHaveLength(1);
 
     const dais = build.group.getObjectByName('AxelNavigatorDais');
     const slate = build.group.getObjectByName('AxelNavigatorSlate');
@@ -20,10 +20,9 @@ describe('createAxelNavigator', () => {
     expect(slate).toBeInstanceOf(Mesh);
     expect(questCard).toBeInstanceOf(Mesh);
 
-    const [mainCollider, consoleCollider] = build.colliders;
+    const [mainCollider] = build.colliders;
     expect(mainCollider.minX).toBeLessThan(mainCollider.maxX);
     expect(mainCollider.minZ).toBeLessThan(mainCollider.maxZ);
-    expect(consoleCollider.minX).toBeLessThan(consoleCollider.maxX);
   });
 
   it('animates hologram layers and beacons based on emphasis', () => {

--- a/src/scene/structures/axelNavigator.ts
+++ b/src/scene/structures/axelNavigator.ts
@@ -462,19 +462,6 @@ export function createAxelNavigator(
     )
   );
 
-  colliders.push(
-    createCollider(
-      new Vector3(
-        basePosition.x + Math.sin(orientationRadians) * 0.9,
-        0,
-        basePosition.z - Math.cos(orientationRadians) * 0.9
-      ),
-      0.9,
-      0.8,
-      orientationRadians
-    )
-  );
-
   let wavePhase = 0;
 
   const update = ({

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -554,13 +554,6 @@ export function createFlywheelShowpiece(
     maxZ: options.centerZ + daisRadius,
   });
 
-  colliders.push({
-    minX: infoPanelGroup.position.x - kioskWidth / 2,
-    maxX: infoPanelGroup.position.x + kioskWidth / 2,
-    minZ: infoPanelGroup.position.z - kioskWidth / 2,
-    maxZ: infoPanelGroup.position.z + kioskWidth / 2,
-  });
-
   let spinVelocity = 0.6;
   let infoReveal = 0.08;
   let calloutPhase = 0;

--- a/src/scene/structures/prReaperConsole.ts
+++ b/src/scene/structures/prReaperConsole.ts
@@ -745,18 +745,6 @@ export function createPrReaperConsole(
     orientationRadians
   );
   colliders.push(deckCollider);
-  const walkwayOffset = deckDepth / 2 + walkwayDepth / 2 - 0.12;
-  const walkwayCenter = offsetLocal(
-    basePosition,
-    right,
-    forward,
-    0,
-    walkwayOffset
-  );
-  colliders.push(
-    createCollider(walkwayCenter, 1.6, walkwayDepth, orientationRadians)
-  );
-
   const update = ({
     elapsed,
     delta,

--- a/src/scene/structures/woveLoom.ts
+++ b/src/scene/structures/woveLoom.ts
@@ -371,15 +371,6 @@ export function createWoveLoom(options: WoveLoomOptions): WoveLoomBuild {
       orientationRadians
     )
   );
-  colliders.push(
-    createCollider(
-      new Vector3(basePosition.x, 0, basePosition.z + 0.32),
-      tableWidth * 0.7,
-      0.6,
-      orientationRadians
-    )
-  );
-
   return {
     group,
     colliders,

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -54,19 +54,13 @@ describe('createGroundStairBoundaryColliders', () => {
   it('names the local ground stair blockers for debug visualization', () => {
     const names = boundaryColliders.map((collider) => collider.name);
 
-    expect(names).toEqual([
-      'GroundStairEastBoundary',
-      'GroundStairLowerCornerGuard',
-    ]);
+    expect(names).toEqual(['GroundStairLowerCornerGuard']);
+    expect(names).not.toContain('GroundStairEastBoundary');
     expect(names).not.toContain('GroundStairEastRunSeal');
   });
 
   it('blocks the reported stair-side squeeze samples', () => {
-    const blockedSamples = [
-      { x: 17.38, z: -8.84 },
-      { x: 21.35, z: -14.66 },
-      { x: 22.1, z: -14.66 },
-    ];
+    const blockedSamples = [{ x: 17.38, z: -8.84 }];
 
     blockedSamples.forEach((sample) => {
       expect(

--- a/src/systems/movement/stairs.ts
+++ b/src/systems/movement/stairs.ts
@@ -211,10 +211,7 @@ export const createGroundStairBoundaryColliders = (
   behavior: StairBehavior,
   options: GroundStairBoundaryColliderOptions
 ): NamedStairBoundaryCollider[] => {
-  const rampMinZ = getMinZ(geometry.bottomZ, geometry.topZ);
-  const rampMaxZ = getMaxZ(geometry.bottomZ, geometry.topZ);
   const stairEastX = geometry.centerX + geometry.halfWidth;
-  const eastBoundaryMinX = stairEastX + options.guardThickness;
   const fallbackEastBoundaryMaxX =
     stairEastX +
     geometry.halfWidth +
@@ -228,15 +225,6 @@ export const createGroundStairBoundaryColliders = (
   // the whole east-side ramp band. Far-east living-room coordinates remain
   // valid navigation space, so do not seal this local edge to a room bound.
   const colliders: NamedStairBoundaryCollider[] = [
-    {
-      name: 'GroundStairEastBoundary',
-      bounds: {
-        minX: eastBoundaryMinX,
-        maxX: eastBoundaryMaxX,
-        minZ: rampMinZ,
-        maxZ: rampMaxZ,
-      },
-    },
     {
       name: 'GroundStairLowerCornerGuard',
       bounds: {

--- a/src/tests/prReaperConsole.test.ts
+++ b/src/tests/prReaperConsole.test.ts
@@ -117,23 +117,13 @@ describe('createPrReaperConsole', () => {
       console.group.getObjectByName('PrReaperConsoleLogGlow')
     ).toBeInstanceOf(Mesh);
 
-    expect(console.colliders).toHaveLength(2);
-    const [deckCollider, walkwayCollider] = console.colliders;
+    expect(console.colliders).toHaveLength(1);
+    const [deckCollider] = console.colliders;
 
     const deckCenterX = (deckCollider.minX + deckCollider.maxX) / 2;
     const deckCenterZ = (deckCollider.minZ + deckCollider.maxZ) / 2;
     expect(deckCenterX).toBeCloseTo(position.x, 6);
     expect(deckCenterZ).toBeCloseTo(position.z, 6);
-
-    const walkwayCenterX = (walkwayCollider.minX + walkwayCollider.maxX) / 2;
-    const walkwayCenterZ = (walkwayCollider.minZ + walkwayCollider.maxZ) / 2;
-    const walkwayOffset = 1.6 / 2 + 0.7 / 2 - 0.12;
-    const expectedWalkwayX = position.x + Math.sin(orientation) * walkwayOffset;
-    const expectedWalkwayZ = position.z + Math.cos(orientation) * walkwayOffset;
-    expect(walkwayCenterX).toBeCloseTo(expectedWalkwayX, 6);
-    expect(walkwayCenterZ).toBeCloseTo(expectedWalkwayZ, 6);
-    expect(walkwayCenterX).not.toBeCloseTo(deckCenterX, 6);
-    expect(walkwayCenterZ).not.toBeCloseTo(deckCenterZ, 6);
   });
 
   it('elevates walkway beacons with emphasis pulses and calm-mode damping', () => {


### PR DESCRIPTION
### Motivation
- Remove the active collider registrations that produced the listed debug IDs so the runtime collision arrays no longer include those shapes.
- Make the removals as narrow as possible by deleting source registrations or generator inputs rather than introducing debug-only filters or deny lists.
- Add targeted regression coverage to assert the removed debug IDs, names, and source bounds are absent from the debug-collider API.

### Description
- Deleted specific source-level collider registrations: the named `GroundStairEastBoundary` registration, selected upper stair guard registrations, and the first two upper-stairwell landing guard colliders so those debug colliders are no longer registered at runtime.
- Stopped registering several generated/secondary structure and POI colliders (Axel navigator secondary console footprint, Flywheel info-kiosk footprint, PR Reaper walkway collider, Wove loom secondary footprint) and excluded `dspace-backyard-rocket` and `sugarkube-backyard-greenhouse` POI colliders from static gameplay registration.
- Updated small unit tests to reflect the narrowed collider outputs and added Playwright assertions in `playwright/immersive-stairs-roundtrip.spec.ts` that assert the specified debug IDs, names, and source bounds are absent via the runtime `window.portfolio.debugColliders` API.

### Testing
- Ran formatting and linting: `npm run format:write` (passed) and `npm run lint` (passed with one unused-variable fix during the rollout). 
- Ran unit tests: `npm run test:ci` (all Vitest suites passed: 1116 tests total passed). Focused unit runs for modified tests also passed: `npm run test:ci -- src/systems/movement/stairs.test.ts src/scene/structures/__tests__/axelNavigator.test.ts src/tests/prReaperConsole.test.ts src/scene/structures/__tests__/woveLoom.test.ts` (passed).
- Docs and smoke: `npm run docs:check` (passed; link-check reported external fetch warnings) and `npm run smoke` (build + artifact checks passed).
- Playwright immersive stairs spec: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (failed). Manual dev-server runs showed some individual tests pass, but four Playwright assertions failed indicating that removing some requested stair/void colliders violated existing navigation safety invariants and that generated debug IDs shifted onto remaining colliders after the deletions; failures reproduceably indicate these colliders are still needed or must be replaced narrowly rather than removed outright.

Follow-ups / risks: the Playwright failures show a conflict between the removal of certain stair and boundary colliders and required movement safety; do not merge until the stair safety behavior is reconciled (either restore required blockers or provide narrowly-scoped replacements and re-run the immersive Playwright stairs roundtrip).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f25d27fa4832f989c7cfdd7a2de34)