### PR TITLE
Remove upper landing wall DD4252 and colliders 300A / 4005; add tests

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -91,6 +91,23 @@ type DebugColliderMetadata = {
   bounds: DebugColliderBounds;
 };
 
+type DebugSolidMetadata = {
+  id: string;
+  name: string;
+  path: string;
+  parentPath: string;
+  bounds: {
+    min: { x: number; y: number; z: number };
+    max: { x: number; y: number; z: number };
+  };
+};
+
+type DebugSolidApi = {
+  setEnabled(enabled: boolean): void;
+  getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  getSolids(): DebugSolidMetadata[];
+};
+
 type DebugColliderApi = {
   setEnabled(enabled: boolean): void;
   getColliders(): DebugColliderMetadata[];
@@ -142,6 +159,7 @@ type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
     debugColliders?: DebugColliderApi;
+    debugSolids?: DebugSolidApi;
     debugCoordinates?: DebugCoordinatesApi;
     poi?: {
       getTooltipState(): TooltipState;
@@ -1054,6 +1072,83 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
     );
     expect(blockingColliderNames.length, sample.name).toBeGreaterThan(0);
   }
+});
+
+test('upper landing-side passage omits removed wall and target colliders', async ({
+  page,
+}) => {
+  await waitForImmersiveReady(page);
+
+  const debugState = await page.evaluate(() => {
+    const solidApi = (window as PortfolioWindow).portfolio?.debugSolids;
+    const colliderApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    const world = (window as PortfolioWindow).portfolio?.world;
+    if (!solidApi || !colliderApi || !world) {
+      throw new Error('Debug or world API unavailable');
+    }
+    solidApi.setEnabled(true);
+    colliderApi.setEnabled(true);
+
+    const formerWallBounds = {
+      minX: 3.875,
+      maxX: 8.525,
+      minZ: -16.25,
+      maxZ: -15.75,
+    };
+    const sameFormerWallBounds = (bounds: DebugColliderBounds) =>
+      Math.abs(bounds.minX - formerWallBounds.minX) < 0.001 &&
+      Math.abs(bounds.maxX - formerWallBounds.maxX) < 0.001 &&
+      Math.abs(bounds.minZ - formerWallBounds.minZ) < 0.001 &&
+      Math.abs(bounds.maxZ - formerWallBounds.maxZ) < 0.001;
+
+    return {
+      removedSolid: solidApi.getSolidById('DD4252'),
+      removedCollider300A: colliderApi.getColliderById('300A'),
+      removedCollider4005: colliderApi.getColliderById('4005'),
+      collidersWithFormerWallBounds: colliderApi
+        .getColliders()
+        .filter((collider) => sameFormerWallBounds(collider.bounds)),
+      solidsWithFormerWallBounds: solidApi.getSolids().filter((solid) => {
+        const bounds = solid.bounds;
+        return (
+          Math.abs(bounds.min.x - formerWallBounds.minX) < 0.001 &&
+          Math.abs(bounds.max.x - formerWallBounds.maxX) < 0.001 &&
+          Math.abs(bounds.min.z - formerWallBounds.minZ) < 0.001 &&
+          Math.abs(bounds.max.z - formerWallBounds.maxZ) < 0.001
+        );
+      }),
+      canOccupyWestSide: world.canOccupyPosition({
+        x: 6.2,
+        z: -16.6,
+        floorId: 'upper',
+      }),
+      canOccupyFormerWallCenter: world.canOccupyPosition({
+        x: 6.2,
+        z: -16,
+        floorId: 'upper',
+      }),
+      canOccupyEastSide: world.canOccupyPosition({
+        x: 6.2,
+        z: -15.4,
+        floorId: 'upper',
+      }),
+      blockingAtFormerWallCenter: colliderApi.getBlockingCollidersAt({
+        x: 6.2,
+        z: -16,
+        floorId: 'upper',
+      }),
+    };
+  });
+
+  expect(debugState.removedSolid).toBeUndefined();
+  expect(debugState.removedCollider300A).toBeUndefined();
+  expect(debugState.removedCollider4005).toBeUndefined();
+  expect(debugState.collidersWithFormerWallBounds).toEqual([]);
+  expect(debugState.solidsWithFormerWallBounds).toEqual([]);
+  expect(debugState.canOccupyWestSide).toBe(true);
+  expect(debugState.canOccupyFormerWallCenter).toBe(true);
+  expect(debugState.canOccupyEastSide).toBe(true);
+  expect(debugState.blockingAtFormerWallCenter).toEqual([]);
 });
 
 test('runtime descent from upper landing mouth stays clear of bannister guards', async ({

--- a/src/assets/floorPlan/index.ts
+++ b/src/assets/floorPlan/index.ts
@@ -137,6 +137,7 @@ const kitchenToBackyardDoorCenter = -9;
 const studioToBackyardDoorCenter = 7.5;
 const kitchenToStudioDoorCenterZ = 2;
 const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
+const upperLandingToLoftLibraryLandingSidePassage = { start: 2, end: 4.2 };
 
 const doorwayRange = (center: number) => ({
   start: center - DOOR_HALF_WIDTH,
@@ -245,6 +246,12 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
           wall: 'west',
           ...upperLandingToCreatorsStudioDoorway,
         },
+        // Intentional landing-side passage: omit the former wall segment and
+        // collider between the upper landing and loft library.
+        {
+          wall: 'north',
+          ...upperLandingToLoftLibraryLandingSidePassage,
+        },
         {
           wall: 'north',
           ...doorwayRange(6.2),
@@ -273,6 +280,11 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
       bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
       ledColor: 0xc3a7ff,
       doorways: [
+        // Match the upper landing's intentional landing-side passage.
+        {
+          wall: 'south',
+          ...upperLandingToLoftLibraryLandingSidePassage,
+        },
         {
           wall: 'south',
           ...doorwayRange(6.2),

--- a/src/main.ts
+++ b/src/main.ts
@@ -2157,15 +2157,6 @@ function initializeImmersiveScene(
 
     [
       {
-        name: 'UpperStairWestUpperVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.minX,
-          minZ: upperStairVoidMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
-      {
         name: 'UpperStairEastLowerVoidGuard',
         bounds: {
           minX: stairNavigationZones.explicitDescentCorridor.maxX,
@@ -2336,6 +2327,10 @@ function initializeImmersiveScene(
   upperFloorGroup.add(upperWallMeshes.group);
   upperWallInstances.forEach((instance) => {
     upperFloorColliders.push(instance.collider);
+    namedColliderDebugNames.set(
+      instance.collider,
+      `UpperWallSegment:${instance.segmentId}`
+    );
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {

--- a/src/tests/floorPlanDoorways.test.ts
+++ b/src/tests/floorPlanDoorways.test.ts
@@ -269,3 +269,44 @@ describe('upper landing west egress doorway', () => {
     ).toBe(false);
   });
 });
+
+describe('upper landing north landing-side passage', () => {
+  const formerWallBounds = {
+    minX: 3.875,
+    maxX: 8.525,
+    minZ: -16.25,
+    maxZ: -15.75,
+  };
+
+  it('omits the former wall segment and collider between upper landing and loft library', () => {
+    const wallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    });
+
+    const matchingWall = wallInstances.find(
+      (instance) =>
+        Math.abs(instance.collider.minX - formerWallBounds.minX) <
+          DOOR_EPSILON &&
+        Math.abs(instance.collider.maxX - formerWallBounds.maxX) <
+          DOOR_EPSILON &&
+        Math.abs(instance.collider.minZ - formerWallBounds.minZ) <
+          DOOR_EPSILON &&
+        Math.abs(instance.collider.maxZ - formerWallBounds.maxZ) < DOOR_EPSILON
+    );
+
+    expect(matchingWall).toBeUndefined();
+    expect(
+      collidesWithColliders(
+        6.2,
+        -16,
+        PLAYER_RADIUS,
+        wallInstances.map((instance) => instance.collider)
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Intentionally open the upper-landing → loft-library landing-side passage by removing the single wall segment that previously mapped to solid `DD4252` and its matching gameplay colliders `300A` and `4005` so the area is traversable. 
- Make the removal source-level and explicit (no runtime deny lists, visualizer-only filtering, renames, or equivalent replacements). 

### Description
- Removed the West upper void guard collider source that produced `UpperStairWestUpperVoidGuard` (mapped to debug ID `4005`) from `src/main.ts`, preserving adjacent east-side void/bannister guards. 
- Edited floorplan source in `src/assets/floorPlan/index.ts` to add complementary doorway ranges (upper landing ↔ loft library) and a local comment marking the omission as an intentional, layout-level change so `DD4252` is no longer generated. 
- Registered generated upper wall colliders with source-derived debug names in `src/main.ts` so unrelated generated wall IDs remain stable after the removed source disappears. 
- Added focused tests: a Vitest unit asserting the former wall/collider bounds are no longer generated (`src/tests/floorPlanDoorways.test.ts`) and a Playwright e2e spec that enables debug solids/colliders and asserts `window.portfolio.debugSolids.getSolidById('DD4252')`, `debugColliders.getColliderById('300A')`, and `debugColliders.getColliderById('4005')` are absent and that the passage is traversable (`playwright/immersive-stairs-roundtrip.spec.ts`). 

### Testing
- Ran formatting and lint: `npm run format:write` and `npm run lint` — completed without errors. 
- Ran targeted unit tests: `npm run test:ci -- src/tests/floorPlanDoorways.test.ts` — passed. 
- Ran targeted Playwright test for the new scenario: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts --grep "upper landing-side passage"` — passed. 
- Ran the full Playwright stairs roundtrip spec and the full Vitest suite: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and `npm run test:ci` — both completed with all tests passing (full Vitest run finished with all suites green). 
- Built and validated artifacts via `npm run build`, `npm run docs:check`, and `npm run smoke` — all completed successfully; a debug screenshot was captured at `/tmp/upper-landing-passage-debug.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30791ab0d4832fb08a392a52774768)