### PR TITLE
🧱 : – remove upstairs landing blocker

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -102,6 +102,25 @@ type DebugColliderApi = {
   getColliderById(id: unknown): DebugColliderMetadata | undefined;
 };
 
+type DebugSolidBounds = {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+};
+
+type DebugSolidMetadata = {
+  id: string;
+  name: string;
+  path: string;
+  parentPath: string;
+  bounds: DebugSolidBounds;
+};
+
+type DebugSolidApi = {
+  setEnabled(enabled: boolean): void;
+  getSolids(): DebugSolidMetadata[];
+  getSolidById(id: unknown): DebugSolidMetadata | undefined;
+};
+
 function expectCloseTo(
   actual: number,
   expected: number,
@@ -142,6 +161,7 @@ type PortfolioWindow = Window & {
   portfolio?: {
     world?: TestWorldApi;
     debugColliders?: DebugColliderApi;
+    debugSolids?: DebugSolidApi;
     debugCoordinates?: DebugCoordinatesApi;
     poi?: {
       getTooltipState(): TooltipState;
@@ -1619,5 +1639,70 @@ test('debug coordinates and upstairs POI state stay floor-aware', async ({
   expect(tooltipState.totalInWorldTooltipCount).toBe(0);
   for (const groundPoiId of GROUND_POI_IDS) {
     expect(tooltipState.visibleMarkerLabelPoiIds).not.toContain(groundPoiId);
+  }
+});
+
+test('upper landing-side wall and blockers are intentionally removed', async ({
+  page,
+}) => {
+  await waitForImmersiveReady(page);
+
+  const formerWallBounds = {
+    minX: 3.875,
+    maxX: 8.525,
+    minZ: -16.25,
+    maxZ: -15.75,
+  };
+  const passageSamples = [
+    { x: 6.2, z: -16.5, floorId: 'upper' as const },
+    { x: 6.2, z: -16, floorId: 'upper' as const },
+    { x: 7.6, z: -15.5, floorId: 'upper' as const },
+  ];
+
+  const debugState = await page.evaluate((bounds) => {
+    const debugColliders = (window as PortfolioWindow).portfolio
+      ?.debugColliders;
+    const debugSolids = (window as PortfolioWindow).portfolio?.debugSolids;
+    if (!debugColliders || !debugSolids) {
+      throw new Error('Debug solid/collider APIs unavailable');
+    }
+    debugColliders.setEnabled(true);
+    debugSolids.setEnabled(true);
+
+    const matchesFormerWallBounds = (candidate: DebugColliderBounds) =>
+      Math.abs(candidate.minX - bounds.minX) < 0.001 &&
+      Math.abs(candidate.maxX - bounds.maxX) < 0.001 &&
+      Math.abs(candidate.minZ - bounds.minZ) < 0.001 &&
+      Math.abs(candidate.maxZ - bounds.maxZ) < 0.001;
+    const matchesFormerWallSolid = (candidate: DebugSolidMetadata) =>
+      candidate.name === 'WallSegment' &&
+      candidate.parentPath.endsWith('UpperWallSegments') &&
+      Math.abs(candidate.bounds.min.x - bounds.minX) < 0.001 &&
+      Math.abs(candidate.bounds.max.x - bounds.maxX) < 0.001 &&
+      Math.abs(candidate.bounds.min.z - bounds.minZ) < 0.001 &&
+      Math.abs(candidate.bounds.max.z - bounds.maxZ) < 0.001;
+
+    return {
+      solid: debugSolids.getSolidById('DD4252'),
+      collider300A: debugColliders.getColliderById('300A'),
+      collider4005: debugColliders.getColliderById('4005'),
+      formerWallColliders: debugColliders
+        .getColliders()
+        .filter((collider) => matchesFormerWallBounds(collider.bounds)),
+      formerWallSolids: debugSolids
+        .getSolids()
+        .filter((solid) => matchesFormerWallSolid(solid)),
+    };
+  }, formerWallBounds);
+
+  expect(debugState.solid).toBeUndefined();
+  expect(debugState.collider300A).toBeUndefined();
+  expect(debugState.collider4005).toBeUndefined();
+  expect(debugState.formerWallColliders).toEqual([]);
+  expect(debugState.formerWallSolids).toEqual([]);
+
+  for (const sample of passageSamples) {
+    await expect(canOccupyPosition(page, sample)).resolves.toBe(true);
+    await expect(getBlockingColliderNames(page, sample)).resolves.toEqual([]);
   }
 });

--- a/src/assets/floorPlan/index.ts
+++ b/src/assets/floorPlan/index.ts
@@ -137,6 +137,7 @@ const kitchenToBackyardDoorCenter = -9;
 const studioToBackyardDoorCenter = 7.5;
 const kitchenToStudioDoorCenterZ = 2;
 const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
+const upperLandingToLoftLibraryLandingSidePassage = { start: 2, end: 4.2 };
 
 const doorwayRange = (center: number) => ({
   start: center - DOOR_HALF_WIDTH,
@@ -247,6 +248,12 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
         },
         {
           wall: 'north',
+          // Intentional opening: omit the landing-side wall segment and its
+          // matching blocker so the upstairs landing route stays traversable.
+          ...upperLandingToLoftLibraryLandingSidePassage,
+        },
+        {
+          wall: 'north',
           ...doorwayRange(6.2),
         },
       ],
@@ -273,6 +280,10 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
       bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
       ledColor: 0xc3a7ff,
       doorways: [
+        {
+          wall: 'south',
+          ...upperLandingToLoftLibraryLandingSidePassage,
+        },
         {
           wall: 'south',
           ...doorwayRange(6.2),

--- a/src/main.ts
+++ b/src/main.ts
@@ -2157,15 +2157,6 @@ function initializeImmersiveScene(
 
     [
       {
-        name: 'UpperStairWestUpperVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.minX,
-          minZ: upperStairVoidMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
-      {
         name: 'UpperStairEastLowerVoidGuard',
         bounds: {
           minX: stairNavigationZones.explicitDescentCorridor.maxX,
@@ -2336,6 +2327,10 @@ function initializeImmersiveScene(
   upperFloorGroup.add(upperWallMeshes.group);
   upperWallInstances.forEach((instance) => {
     upperFloorColliders.push(instance.collider);
+    namedColliderDebugNames.set(
+      instance.collider,
+      `UpperWallSegment:${instance.segmentId}`
+    );
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {

--- a/src/tests/wallSegments.test.ts
+++ b/src/tests/wallSegments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   FLOOR_PLAN,
+  UPPER_FLOOR_PLAN,
   WALL_THICKNESS,
   type DoorwayDefinition,
 } from '../assets/floorPlan';
@@ -14,7 +15,9 @@ const FENCE_THICKNESS = 0.28;
 const PLAYER_RADIUS = 0.75;
 
 function getRoomCategory(roomId: string) {
-  const room = FLOOR_PLAN.rooms.find((entry) => entry.id === roomId);
+  const room = [...FLOOR_PLAN.rooms, ...UPPER_FLOOR_PLAN.rooms].find(
+    (entry) => entry.id === roomId
+  );
   return room?.category ?? 'interior';
 }
 
@@ -110,5 +113,36 @@ describe('createWallSegmentInstances', () => {
     expect(transition?.isFence).toBe(false);
     expect(transition?.isSharedInterior).toBe(true);
     expect(transition?.dimensions.height).toBeCloseTo(WALL_HEIGHT, 5);
+  });
+
+  it('omits the intentional upper landing-side passage wall segment', () => {
+    const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    });
+    const upperWallColliders = upperWallInstances.map(
+      (instance) => instance.collider
+    );
+    const formerWallBounds = {
+      minX: 3.875,
+      maxX: 8.525,
+      minZ: -16.25,
+      maxZ: -15.75,
+    };
+
+    expect(upperWallInstances).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          collider: expect.objectContaining(formerWallBounds),
+        }),
+      ])
+    );
+    expect(
+      collidesWithColliders(6.2, -16, PLAYER_RADIUS, upperWallColliders)
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Open the upstairs landing-side passage by removing the specific wall segment and its gameplay colliders that previously blocked traversal (debug solid `DD4252` and collider IDs `300A` and `4005`).
- Make a source-level, intentional change instead of hiding or renaming debug labels so runtime collision and visualization reflect the new layout.

### Description
- Removed the landing-side wall segment by adding an explicit landing↔loft passage in `src/assets/floorPlan/index.ts` and documented the omission with a local comment. 
- Removed the matching `UpperStairWestUpperVoidGuard` collider registration and associated blocker generation so the gameplay colliders for `300A`/`4005` are not produced (`src/main.ts`).
- Stabilized debug naming for generated upper wall colliders by recording `segmentId`-based names into `namedColliderDebugNames` to avoid ID reassignment (`src/main.ts`).
- Added tests: a Vitest unit asserting the former wall bounds are not generated (`src/tests/wallSegments.test.ts`) and a Playwright test that verifies `DD4252`, `300A`, and `4005` are absent and that representative points through the opened passage are traversable (`playwright/immersive-stairs-roundtrip.spec.ts`).

### Testing
- Ran formatting and linting with `npm run format:write` (passed) and `npm run lint` (passed). 
- Ran the focused unit test with `npm run test:ci -- src/tests/wallSegments.test.ts` and the new Playwright scenario with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts -g "upper landing-side wall"` (both passed). 
- Executed full Playwright run `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` and full CI suite `npm run test:ci`; all tests passed (full run reported 1124 tests passing). 
- Built and validated production artifacts with `npm run build` and `npm run smoke` (both passed), and ran `npm run docs:check` which passed while the link checker logged external fetch warnings (no repo failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30791e6f70832fa47e4d3158c67f22)