### PR TITLE
Remove upper landing wall DD4252 and colliders 300A / 4005

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -91,6 +91,23 @@ type DebugColliderMetadata = {
   bounds: DebugColliderBounds;
 };
 
+type DebugSolidMetadata = {
+  id: string;
+  name: string;
+  path: string;
+  parentPath: string;
+  bounds: {
+    min: { x: number; y: number; z: number };
+    max: { x: number; y: number; z: number };
+  };
+};
+
+type DebugSolidApi = {
+  setEnabled(enabled: boolean): void;
+  getSolids(): DebugSolidMetadata[];
+  getSolidById(id: unknown): DebugSolidMetadata | undefined;
+};
+
 type DebugColliderApi = {
   setEnabled(enabled: boolean): void;
   getColliders(): DebugColliderMetadata[];
@@ -143,6 +160,7 @@ type PortfolioWindow = Window & {
     world?: TestWorldApi;
     debugColliders?: DebugColliderApi;
     debugCoordinates?: DebugCoordinatesApi;
+    debugSolids?: DebugSolidApi;
     poi?: {
       getTooltipState(): TooltipState;
     };
@@ -757,6 +775,106 @@ test('off-stair ground points near the upper stair top stay on ground', async ({
     sourceZone: 'outsideStairs',
     liftedZone: 'outsideStairs',
   });
+});
+
+test('intentional upper landing opening removes wall solid and blockers', async ({
+  page,
+}) => {
+  test.slow();
+  await waitForImmersiveReady(page);
+
+  const removed = await page.evaluate(() => {
+    const colliders = (window as PortfolioWindow).portfolio?.debugColliders;
+    const solids = (window as PortfolioWindow).portfolio?.debugSolids;
+    if (!colliders || !solids) {
+      throw new Error('Debug APIs unavailable');
+    }
+    colliders.setEnabled(true);
+    solids.setEnabled(true);
+    const allColliders = colliders.getColliders();
+    const allSolids = solids.getSolids();
+    const formerWallBounds = {
+      minX: 3.875,
+      maxX: 8.525,
+      minZ: -16.25,
+      maxZ: -15.75,
+    };
+    const formerVoidGuardBounds = {
+      minX: 8.9,
+      maxX: 8.9,
+      minZ: -16,
+      maxZ: -16,
+    };
+    const matchesBounds = (
+      bounds: DebugColliderBounds,
+      target: DebugColliderBounds
+    ) =>
+      Math.abs(bounds.minX - target.minX) < 0.01 &&
+      Math.abs(bounds.maxX - target.maxX) < 0.01 &&
+      Math.abs(bounds.minZ - target.minZ) < 0.01 &&
+      Math.abs(bounds.maxZ - target.maxZ) < 0.01;
+
+    return {
+      solidById: solids.getSolidById('DD4252'),
+      collider300A: colliders.getColliderById('300A'),
+      collider4005: colliders.getColliderById('4005'),
+      wallColliderMatches: allColliders.filter((collider) =>
+        matchesBounds(collider.bounds, formerWallBounds)
+      ),
+      voidGuardMatches: allColliders.filter((collider) =>
+        matchesBounds(collider.bounds, formerVoidGuardBounds)
+      ),
+      wallSolidMatches: allSolids.filter(
+        (solid) =>
+          solid.name === 'WallSegment' &&
+          solid.parentPath.endsWith('/UpperWallSegments') &&
+          Math.abs(solid.bounds.min.x - formerWallBounds.minX) < 0.01 &&
+          Math.abs(solid.bounds.max.x - formerWallBounds.maxX) < 0.01 &&
+          Math.abs(solid.bounds.min.z - formerWallBounds.minZ) < 0.01 &&
+          Math.abs(solid.bounds.max.z - formerWallBounds.maxZ) < 0.01
+      ),
+    };
+  });
+
+  expect(removed.solidById).toBeUndefined();
+  expect(removed.collider300A).toBeUndefined();
+  expect(removed.collider4005).toBeUndefined();
+  expect(removed.wallColliderMatches).toEqual([]);
+  expect(removed.voidGuardMatches).toEqual([]);
+  expect(removed.wallSolidMatches).toEqual([]);
+
+  const start = { x: 5.2, z: -17.2, floorId: 'upper' as const };
+  const opening = { x: 5.2, z: -15.45, floorId: 'upper' as const };
+  const beyond = { x: 5.2, z: -14.2, floorId: 'upper' as const };
+  for (const sample of [start, opening, beyond]) {
+    expect(await canOccupyPosition(page, sample)).toBe(true);
+    expect(await getBlockingColliderNames(page, sample)).toEqual([]);
+  }
+
+  await movePlayerTo(page, start);
+  const movement = await page.evaluate(
+    (target) => {
+      const world = (window as PortfolioWindow).portfolio?.world;
+      if (!world) {
+        throw new Error('World API unavailable');
+      }
+      const before = world.getPlayerPosition();
+      const first = world.stepPlayerForTest({
+        dx: 0,
+        dz: target.openingZ - before.z,
+      });
+      const second = world.stepPlayerForTest({
+        dx: 0,
+        dz: target.beyondZ - first.position.z,
+      });
+      return { first, second };
+    },
+    { openingZ: opening.z, beyondZ: beyond.z }
+  );
+
+  expect(movement.first.movedZ).toBe(true);
+  expect(movement.second.movedZ).toBe(true);
+  expect(movement.second.position.z).toBeGreaterThan(-14.35);
 });
 
 test('upper landing debug colliders exclude middle landing artifact', async ({

--- a/src/assets/floorPlan/index.ts
+++ b/src/assets/floorPlan/index.ts
@@ -137,6 +137,12 @@ const kitchenToBackyardDoorCenter = -9;
 const studioToBackyardDoorCenter = 7.5;
 const kitchenToStudioDoorCenterZ = 2;
 const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
+const upperLandingToLoftLibraryDoorway = {
+  // Intentionally starts at the west edge to omit the former landing-side wall
+  // segment and open the upstairs route between the stair landing and library.
+  start: 2,
+  end: 8.2,
+};
 
 const doorwayRange = (center: number) => ({
   start: center - DOOR_HALF_WIDTH,
@@ -247,7 +253,7 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
         },
         {
           wall: 'north',
-          ...doorwayRange(6.2),
+          ...upperLandingToLoftLibraryDoorway,
         },
       ],
     },
@@ -275,7 +281,7 @@ const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
       doorways: [
         {
           wall: 'south',
-          ...doorwayRange(6.2),
+          ...upperLandingToLoftLibraryDoorway,
         },
         {
           wall: 'west',

--- a/src/main.ts
+++ b/src/main.ts
@@ -2156,15 +2156,8 @@ function initializeImmersiveScene(
       stairLayout.directionMultiplier * PLAYER_RADIUS;
 
     [
-      {
-        name: 'UpperStairWestUpperVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.minX,
-          minZ: upperStairVoidMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
+      // UpperStairWestUpperVoidGuard is intentionally omitted with the adjacent
+      // landing-side wall segment so the upstairs route remains open.
       {
         name: 'UpperStairEastLowerVoidGuard',
         bounds: {
@@ -2336,6 +2329,10 @@ function initializeImmersiveScene(
   upperFloorGroup.add(upperWallMeshes.group);
   upperWallInstances.forEach((instance) => {
     upperFloorColliders.push(instance.collider);
+    namedColliderDebugNames.set(
+      instance.collider,
+      `UpperWallSegment:${instance.segmentId}`
+    );
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -19,7 +19,6 @@ const DECLARED_RUNTIME_COLLIDER_IDS = {
   GroundStairLowerCornerGuard: '4002',
   UpperStairTopGapBlockerWest: '4003',
   UpperStairTopGapBlockerEast: '4004',
-  UpperStairWestUpperVoidGuard: '4005',
   UpperStairEastLowerVoidGuard: '4006',
   UpperStairEastUpperVoidGuard: '4007',
   UpperStairHiddenRunVoidGuard: '4008',

--- a/src/tests/floorPlanDoorways.test.ts
+++ b/src/tests/floorPlanDoorways.test.ts
@@ -195,6 +195,46 @@ describe('upper landing west egress doorway', () => {
     );
   });
 
+  it('omits the former upper landing north wall segment for the open route', () => {
+    expect(upperLanding).toBeDefined();
+    if (!upperLanding) {
+      return;
+    }
+
+    const wallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    });
+    const colliders = wallInstances.map((instance) => instance.collider);
+    const openedRouteCenter = {
+      x: upperLanding.bounds.minX + PLAYER_RADIUS + 0.45,
+      z: upperLanding.bounds.maxZ + WALL_THICKNESS * 0.1,
+    };
+
+    expect(
+      collidesWithColliders(
+        openedRouteCenter.x,
+        openedRouteCenter.z,
+        PLAYER_RADIUS,
+        colliders
+      )
+    ).toBe(false);
+    expect(
+      wallInstances.some(
+        (instance) =>
+          instance.segment.orientation === 'horizontal' &&
+          Math.abs(instance.segment.start.z - upperLanding.bounds.maxZ) <
+            DOOR_EPSILON &&
+          instance.collider.minX < upperLanding.bounds.minX + PLAYER_RADIUS &&
+          instance.collider.maxX > upperLanding.bounds.minX + PLAYER_RADIUS
+      )
+    ).toBe(false);
+  });
+
   it('exposes a passage zone across the widened west egress band', () => {
     const normalized = resolveNormalizedDoorway({
       plan: UPPER_FLOOR_PLAN,


### PR DESCRIPTION
### Motivation
- Intentionally open the upstairs landing-side route by removing the specific wall segment that was visible as solid `DD4252` and the gameplay colliders that corresponded to `300A` and `4005`.
- Map debug IDs back to source and remove the exact source-level generators/registrations rather than hiding labels or adding debug-only filters.
- Add targeted tests so the removal is explicit and protected by automated regression checks.

### Description
- Widened the upper-landing ↔ loft doorway in `src/assets/floorPlan/index.ts` so the original landing-side wall segment is no longer generated (this omits the mesh that mapped to `DD4252`).
- Removed the `UpperStairWestUpperVoidGuard` source registration in `src/main.ts` (the collider that mapped to `4005`) and added a short local comment explaining the omission is intentional.
- Deleted the declared runtime debug ID for `UpperStairWestUpperVoidGuard` in `src/scene/debug/colliderDebugIds.ts` so `4005` is no longer declared, and added source-stable debug names for generated upper wall colliders in `src/main.ts` to avoid silent reuse of `300A` by a different generated collider.
- Added automated coverage: a unit test in `src/tests/floorPlanDoorways.test.ts` that verifies the opened route has no wall collider there, and a Playwright regression in `playwright/immersive-stairs-roundtrip.spec.ts` that asserts `DD4252`, `300A`, and `4005` are absent and the passage is traversable.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully.
- Ran targeted unit tests with `npm run test:ci -- src/tests/floorPlanDoorways.test.ts src/scene/debug/__tests__/colliderVisualizer.test.ts` and full test suite with `npm run test:ci`; the targeted tests and full Vitest run passed (all tests passed locally during the run reported here).
- Executed focused Playwright checks with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts -g "intentional upper landing opening"` and the full `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, and the added Playwright assertion passed (focused and full runs succeeded).
- Verified build and docs smoke: `npm run build`, `npm run docs:check`, and `npm run smoke` completed (build produced expected artifacts; docs link checks emitted external fetch warnings only); manual Playwright debug verification at `/?mode=immersive&disablePerformanceFailover=1&debugCoordinates=1&debugColliders=1&debugColliderIds=1&debugSolidIds=1&debugFps=1` confirmed `DD4252`, `300A`, and `4005` are absent and the opening is occupiable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3079197b10832fa6818b22d7a41987)