### PR TITLE
Add semantic level source-ID primitives

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -195,6 +195,16 @@ Short hex IDs may remain as debug display references for screenshot readability
 or compact overlays, but they are downstream labels. Debug labels should point
 back to semantic source IDs rather than becoming the source of truth.
 
+The initial foundation for this identity layer lives in
+`src/scene/level/sourceIds.ts`. It defines the branded `LevelSourceId` type,
+runtime validation, composition helpers, short deterministic debug-reference
+hashing, and `LevelSourceMetadata` for downstream generated artifacts. New
+level-source data should use these helpers instead of raw strings so malformed
+IDs fail close to the authoring boundary. The current canonical helper format is
+dot-separated lowercase hierarchy segments containing letters, digits, `_`, or
+`-`; helper functions intentionally do not case-normalize or trim inputs because
+reviewable source IDs should be written explicitly.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertLevelSourceId,
+  getLevelSourceDebugRef,
+  isLevelSourceId,
+  joinLevelSourceId,
+  makeLevelSourceId,
+} from '../sourceIds';
+
+const validSourceIds = [
+  'ground.living-room.north-wall.left',
+  'upper.loft-library.south-wall.right',
+  'upper.stairwell.hidden-run.safety-collider',
+  'ground.living_room.media_wall.scene_object',
+  'backyard.greenhouse-path.east-fence.section03',
+];
+
+const invalidSourceIds = [
+  'ground.living room.north-wall',
+  'ground.livingRoom.northWall',
+  'ground..living-room',
+  'ground/living-room/north-wall',
+  '.ground.living-room',
+  'ground.living-room.',
+];
+
+describe('level source IDs', () => {
+  it('accepts valid human-readable hierarchy paths', () => {
+    for (const sourceId of validSourceIds) {
+      expect(isLevelSourceId(sourceId)).toBe(true);
+      expect(assertLevelSourceId(sourceId)).toBe(sourceId);
+    }
+  });
+
+  it('rejects malformed source IDs with helpful errors', () => {
+    for (const sourceId of invalidSourceIds) {
+      expect(isLevelSourceId(sourceId)).toBe(false);
+      expect(() => assertLevelSourceId(sourceId)).toThrow(
+        /Invalid level source ID/
+      );
+    }
+  });
+
+  it('joins source ID parts without silently normalizing them', () => {
+    expect(
+      joinLevelSourceId('ground', 'living-room', 'north-wall', 'left')
+    ).toBe('ground.living-room.north-wall.left');
+    expect(makeLevelSourceId(['upper', 'stairwell', 'safety-collider'])).toBe(
+      'upper.stairwell.safety-collider'
+    );
+    expect(() => joinLevelSourceId('ground', 'LivingRoom')).toThrow(
+      /Invalid level source ID/
+    );
+    expect(() => makeLevelSourceId([])).toThrow(
+      /at least one hierarchy segment/
+    );
+  });
+
+  it('creates deterministic uppercase hex debug references', () => {
+    const sourceId = assertLevelSourceId(
+      'ground.living-room.media-wall.scene-object'
+    );
+
+    expect(getLevelSourceDebugRef(sourceId)).toBe(
+      getLevelSourceDebugRef(sourceId)
+    );
+    expect(getLevelSourceDebugRef(sourceId)).toMatch(/^[0-9A-F]{6}$/);
+    expect(getLevelSourceDebugRef(sourceId, 4)).toMatch(/^[0-9A-F]{4}$/);
+  });
+
+  it('produces distinct debug references for representative source IDs', () => {
+    const sourceIds = validSourceIds.map(assertLevelSourceId);
+    const refs = sourceIds.map((sourceId) => getLevelSourceDebugRef(sourceId));
+
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  it('keeps helper names focused on current source concepts', () => {
+    const helperNames = [
+      'isLevelSourceId',
+      'assertLevelSourceId',
+      'joinLevelSourceId',
+      'makeLevelSourceId',
+      'getLevelSourceDebugRef',
+    ];
+
+    expect(helperNames.join(' ')).not.toMatch(/former|removed|skip/i);
+  });
+});

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -1,0 +1,71 @@
+import { getDebugHash } from '../debug/debugIds';
+
+const LEVEL_SOURCE_ID_PATTERN = /^[a-z0-9_-]+(?:\.[a-z0-9_-]+)*$/;
+const LEVEL_SOURCE_DEBUG_REF_MIN_LENGTH = 1;
+const LEVEL_SOURCE_DEBUG_REF_MAX_LENGTH = 6;
+
+declare const levelSourceIdBrand: unique symbol;
+
+export type LevelSourceId = string & { readonly [levelSourceIdBrand]: true };
+
+export type LevelSourceType =
+  | 'room'
+  | 'wall'
+  | 'floorSurface'
+  | 'safetyCollider'
+  | 'sceneObject'
+  | 'roomConnection'
+  | 'generatedCollider'
+  | 'generatedSolid';
+
+export interface LevelSourceMetadata {
+  readonly sourceId: LevelSourceId;
+  readonly sourceType: LevelSourceType;
+  readonly purpose?: string;
+}
+
+export const isLevelSourceId = (value: unknown): value is LevelSourceId =>
+  typeof value === 'string' && LEVEL_SOURCE_ID_PATTERN.test(value);
+
+export const assertLevelSourceId = (value: string): LevelSourceId => {
+  if (isLevelSourceId(value)) {
+    return value;
+  }
+
+  throw new Error(
+    `Invalid level source ID "${value}". Use dot-separated lowercase segments ` +
+      'containing only letters, digits, underscores, or hyphens.'
+  );
+};
+
+export const makeLevelSourceId = (parts: readonly string[]): LevelSourceId => {
+  if (parts.length === 0) {
+    throw new Error('Level source IDs require at least one hierarchy segment.');
+  }
+
+  return assertLevelSourceId(parts.join('.'));
+};
+
+export const joinLevelSourceId = (...parts: string[]): LevelSourceId =>
+  makeLevelSourceId(parts);
+
+export const getLevelSourceDebugRef = (
+  sourceId: LevelSourceId,
+  length = 6
+): string => {
+  if (!Number.isInteger(length)) {
+    throw new Error('Level source debug reference length must be an integer.');
+  }
+
+  if (
+    length < LEVEL_SOURCE_DEBUG_REF_MIN_LENGTH ||
+    length > LEVEL_SOURCE_DEBUG_REF_MAX_LENGTH
+  ) {
+    throw new Error(
+      `Level source debug reference length must be between ${LEVEL_SOURCE_DEBUG_REF_MIN_LENGTH} ` +
+        `and ${LEVEL_SOURCE_DEBUG_REF_MAX_LENGTH}.`
+    );
+  }
+
+  return getDebugHash(sourceId).slice(0, length);
+};


### PR DESCRIPTION
### Motivation
- Provide a small, type-safe foundation for future declarative level source work by introducing stable semantic source-ID primitives and metadata without changing runtime scene behavior.

### Description
- Add `src/scene/level/sourceIds.ts` which defines a branded `LevelSourceId` type, `isLevelSourceId`, `assertLevelSourceId`, `joinLevelSourceId`, `makeLevelSourceId`, `getLevelSourceDebugRef`, `LevelSourceType`, and `LevelSourceMetadata` using the existing `getDebugHash` helper for deterministic uppercase hex refs.
- Add unit tests at `src/scene/level/__tests__/sourceIds.test.ts` covering valid/invalid ID formats, join/make semantics, debug-ref determinism, distinct refs for representative IDs, and naming guardrails.
- Update `docs/design/declarative-level-source-of-truth.md` to reference the new module and document the canonical dot-separated lowercase hierarchy format and no-normalization rule.

### Testing
- Ran formatting and lint: `npm run format:write` (passed) and `npm run lint` (passed).
- Ran focused tests: `npm run test:ci -- src/scene/level/__tests__/sourceIds.test.ts` (6 tests passed).
- Ran full test suite: `npm run test:ci` (149 test files, 1130 tests passed; non-blocking stderr warnings observed from unrelated tests and environment fetches). 
- Docs check: `npm run docs:check` (passed; link checker produced external fetch warnings but no failures).
- Build and smoke: `npm run build` and `npm run smoke` (both passed; Vite produced non-blocking warnings about chunk size and CJS API deprecation).
- Secrets scan: `./scripts/scan-secrets.py` on diffs passed with no high-risk secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31029d4ca8832fbf8d745fe13dcb97)