### PR TITLE
Add semantic level source ID primitives

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -172,11 +172,11 @@ labels, test failures, and inventory reports.
 
 Examples:
 
-- `upper.loftLibrary.southWall.left`
-- `upper.stairwell.westBannister.safetyCollider`
-- `ground.livingRoom.mediaWall.sceneObject`
-- `ground.kitchen.northThreshold.floorSurface`
-- `backyard.greenhousePath.eastFence.section03`
+- `upper.loft_library.south_wall.left`
+- `upper.stairwell.west_bannister.safety_collider`
+- `ground.living_room.media_wall.scene_object`
+- `ground.kitchen.north_threshold.floor_surface`
+- `backyard.greenhouse_path.east_fence.section03`
 
 Source ID guidance:
 
@@ -188,12 +188,21 @@ Source ID guidance:
 - Require uniqueness across all source layers unless a child artifact is using an
   explicit suffix derived from its owning source item.
 - Allow downstream artifacts to append generated suffixes such as `.mesh.0`,
-  `.collider.1`, or `.debugLabel` when a source item produces multiple runtime
+  `.collider.1`, or `.debug_label` when a source item produces multiple runtime
   pieces.
 
 Short hex IDs may remain as debug display references for screenshot readability
 or compact overlays, but they are downstream labels. Debug labels should point
 back to semantic source IDs rather than becoming the source of truth.
+
+The foundation helpers for this migration live in
+`src/scene/level/sourceIds.ts`. New source-backed level data should use the
+`LevelSourceId` branded type, `assertLevelSourceId(...)`,
+`joinLevelSourceId(...)`, and `makeLevelSourceId(...)` instead of passing raw
+strings through generators. The helper validates lowercase dot-separated paths
+with no empty segments, whitespace, or slash-style paths, and
+`getLevelSourceDebugRef(...)` provides deterministic short uppercase hex
+references for future debug metadata without changing current visible debug IDs.
 
 ## Migration phases
 

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { DEBUG_ID_MAX_LENGTH } from '../../debug/debugIds';
 import {
   assertLevelSourceId,
   getLevelSourceDebugRef,
@@ -76,8 +77,24 @@ describe('level source debug references', () => {
     expect(getLevelSourceDebugRef(sourceId)).toBe(
       getLevelSourceDebugRef(sourceId)
     );
-    expect(getLevelSourceDebugRef(sourceId)).toMatch(/^[0-9A-F]{6}$/);
+    expect(getLevelSourceDebugRef(sourceId)).toMatch(
+      new RegExp(`^[0-9A-F]{${DEBUG_ID_MAX_LENGTH}}$`)
+    );
     expect(getLevelSourceDebugRef(sourceId, 4)).toMatch(/^[0-9A-F]{4}$/);
+  });
+
+  it('rejects unsupported debug reference lengths', () => {
+    const sourceId = assertLevelSourceId('ground.living_room.north_wall.left');
+
+    const lengthError = new RegExp(
+      `integer length from 1 to ${DEBUG_ID_MAX_LENGTH}`
+    );
+
+    expect(() => getLevelSourceDebugRef(sourceId, 0)).toThrow(lengthError);
+    expect(() =>
+      getLevelSourceDebugRef(sourceId, DEBUG_ID_MAX_LENGTH + 1)
+    ).toThrow(lengthError);
+    expect(() => getLevelSourceDebugRef(sourceId, 1.5)).toThrow(lengthError);
   });
 
   it('produces different refs for representative different source IDs', () => {
@@ -93,6 +110,6 @@ describe('level source helper names', () => {
   it('avoid tombstone-oriented helper names', async () => {
     const helperNames = Object.keys(await import('../sourceIds'));
 
-    expect(helperNames.join(' ')).not.toMatch(/former|removed|skip/i);
+    expect(helperNames.join(' ')).not.toMatch(/former|removed|tombstone/i);
   });
 });

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertLevelSourceId,
+  getLevelSourceDebugRef,
+  isLevelSourceId,
+  joinLevelSourceId,
+  makeLevelSourceId,
+} from '../sourceIds';
+
+const validIds = [
+  'ground.living_room.north_wall.left',
+  'upper.loft_library.south_wall.right',
+  'upper.stairwell.hidden_run.safety_collider',
+  'ground.living_room.media_wall.scene_object',
+  'backyard.greenhouse_path.east_fence.section03',
+  'ground.room_01.wall-02.generated_collider',
+];
+
+const invalidIds = [
+  'ground living_room.north_wall',
+  'Ground.living_room.north_wall',
+  'ground..livingRoom',
+  'ground/living_room/north_wall',
+  '.ground.living_room',
+  'ground.living_room.',
+  '',
+];
+
+describe('level source ID validation', () => {
+  it('accepts valid human-readable hierarchical IDs', () => {
+    for (const sourceId of validIds) {
+      expect(isLevelSourceId(sourceId)).toBe(true);
+      expect(assertLevelSourceId(sourceId)).toBe(sourceId);
+    }
+  });
+
+  it('rejects malformed source IDs', () => {
+    for (const sourceId of invalidIds) {
+      expect(isLevelSourceId(sourceId)).toBe(false);
+      expect(() => assertLevelSourceId(sourceId)).toThrow(
+        /Invalid level source ID/
+      );
+    }
+  });
+});
+
+describe('level source ID composition', () => {
+  it('joins source ID parts with dots', () => {
+    expect(
+      joinLevelSourceId('ground', 'living_room', 'north_wall', 'left')
+    ).toBe('ground.living_room.north_wall.left');
+  });
+
+  it('builds source IDs from readonly part arrays', () => {
+    expect(
+      makeLevelSourceId(['upper', 'loft_library', 'south_wall', 'right'])
+    ).toBe('upper.loft_library.south_wall.right');
+  });
+
+  it('fails instead of silently normalizing malformed parts', () => {
+    expect(() => joinLevelSourceId('ground', '', 'northWall')).toThrow(/empty/);
+    expect(() => joinLevelSourceId('ground.living_room', 'north_wall')).toThrow(
+      /dots/
+    );
+    expect(() => joinLevelSourceId('ground', 'LivingRoom')).toThrow(
+      /Invalid level source ID/
+    );
+  });
+});
+
+describe('level source debug references', () => {
+  it('returns deterministic uppercase hexadecimal references', () => {
+    const sourceId = assertLevelSourceId('ground.living_room.north_wall.left');
+
+    expect(getLevelSourceDebugRef(sourceId)).toBe(
+      getLevelSourceDebugRef(sourceId)
+    );
+    expect(getLevelSourceDebugRef(sourceId)).toMatch(/^[0-9A-F]{6}$/);
+    expect(getLevelSourceDebugRef(sourceId, 4)).toMatch(/^[0-9A-F]{4}$/);
+  });
+
+  it('produces different refs for representative different source IDs', () => {
+    const refs = validIds.map((sourceId) =>
+      getLevelSourceDebugRef(assertLevelSourceId(sourceId))
+    );
+
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+});
+
+describe('level source helper names', () => {
+  it('avoid tombstone-oriented helper names', async () => {
+    const helperNames = Object.keys(await import('../sourceIds'));
+
+    expect(helperNames.join(' ')).not.toMatch(/former|removed|skip/i);
+  });
+});

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEBUG_ID_MAX_LENGTH } from '../../debug/debugIds';
+import { DEBUG_ID_MAX_LENGTH, DEBUG_ID_MIN_LENGTH } from '../../debug/debugIds';
 import {
   assertLevelSourceId,
   getLevelSourceDebugRef,
@@ -87,10 +87,12 @@ describe('level source debug references', () => {
     const sourceId = assertLevelSourceId('ground.living_room.north_wall.left');
 
     const lengthError = new RegExp(
-      `integer length from 1 to ${DEBUG_ID_MAX_LENGTH}`
+      `integer length from ${DEBUG_ID_MIN_LENGTH} to ${DEBUG_ID_MAX_LENGTH}`
     );
 
-    expect(() => getLevelSourceDebugRef(sourceId, 0)).toThrow(lengthError);
+    expect(() =>
+      getLevelSourceDebugRef(sourceId, DEBUG_ID_MIN_LENGTH - 1)
+    ).toThrow(lengthError);
     expect(() =>
       getLevelSourceDebugRef(sourceId, DEBUG_ID_MAX_LENGTH + 1)
     ).toThrow(lengthError);

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -1,0 +1,76 @@
+import { getDebugHash } from '../debug/debugIds';
+
+export type LevelSourceId = string & {
+  readonly __levelSourceIdBrand: unique symbol;
+};
+
+export const LEVEL_SOURCE_ID_PATTERN = /^[a-z0-9_-]+(?:\.[a-z0-9_-]+)*$/;
+
+export type LevelSourceType =
+  | 'room'
+  | 'wall'
+  | 'floorSurface'
+  | 'safetyCollider'
+  | 'sceneObject'
+  | 'roomConnection'
+  | 'generatedCollider'
+  | 'generatedSolid';
+
+export interface LevelSourceMetadata {
+  sourceId: LevelSourceId;
+  sourceType: LevelSourceType;
+  purpose?: string;
+}
+
+const describeSourceIdFormat = (): string =>
+  'Level source IDs must be dot-separated lowercase segments containing only ' +
+  'letters, digits, underscores, and hyphens.';
+
+export const isLevelSourceId = (value: unknown): value is LevelSourceId =>
+  typeof value === 'string' && LEVEL_SOURCE_ID_PATTERN.test(value);
+
+export const assertLevelSourceId = (value: string): LevelSourceId => {
+  if (isLevelSourceId(value)) {
+    return value;
+  }
+
+  throw new Error(
+    `Invalid level source ID "${value}". ${describeSourceIdFormat()}`
+  );
+};
+
+export const makeLevelSourceId = (parts: readonly string[]): LevelSourceId => {
+  if (parts.length === 0) {
+    throw new Error('Level source IDs require at least one path segment.');
+  }
+
+  for (const part of parts) {
+    if (part.length === 0) {
+      throw new Error('Level source ID segments must not be empty.');
+    }
+
+    if (part.includes('.')) {
+      throw new Error(
+        `Level source ID segment "${part}" must not contain dots; pass hierarchy as parts.`
+      );
+    }
+  }
+
+  return assertLevelSourceId(parts.join('.'));
+};
+
+export const joinLevelSourceId = (...parts: string[]): LevelSourceId =>
+  makeLevelSourceId(parts);
+
+export const getLevelSourceDebugRef = (
+  sourceId: LevelSourceId,
+  length = 6
+): string => {
+  if (!Number.isInteger(length) || length < 1 || length > 6) {
+    throw new Error(
+      'Level source debug refs must request an integer length from 1 to 6.'
+    );
+  }
+
+  return getDebugHash(sourceId).slice(0, length);
+};

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -1,4 +1,8 @@
-import { DEBUG_ID_MAX_LENGTH, getDebugHash } from '../debug/debugIds';
+import {
+  DEBUG_ID_MAX_LENGTH,
+  DEBUG_ID_MIN_LENGTH,
+  getDebugHash,
+} from '../debug/debugIds';
 
 export type LevelSourceId = string & {
   readonly __levelSourceIdBrand: unique symbol;
@@ -66,9 +70,13 @@ export const getLevelSourceDebugRef = (
   sourceId: LevelSourceId,
   length = DEBUG_ID_MAX_LENGTH
 ): string => {
-  if (!Number.isInteger(length) || length < 1 || length > DEBUG_ID_MAX_LENGTH) {
+  if (
+    !Number.isInteger(length) ||
+    length < DEBUG_ID_MIN_LENGTH ||
+    length > DEBUG_ID_MAX_LENGTH
+  ) {
     throw new Error(
-      `Level source debug refs must request an integer length from 1 to ${DEBUG_ID_MAX_LENGTH}.`
+      `Level source debug refs must request an integer length from ${DEBUG_ID_MIN_LENGTH} to ${DEBUG_ID_MAX_LENGTH}.`
     );
   }
 

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -1,4 +1,4 @@
-import { getDebugHash } from '../debug/debugIds';
+import { DEBUG_ID_MAX_LENGTH, getDebugHash } from '../debug/debugIds';
 
 export type LevelSourceId = string & {
   readonly __levelSourceIdBrand: unique symbol;
@@ -64,11 +64,11 @@ export const joinLevelSourceId = (...parts: string[]): LevelSourceId =>
 
 export const getLevelSourceDebugRef = (
   sourceId: LevelSourceId,
-  length = 6
+  length = DEBUG_ID_MAX_LENGTH
 ): string => {
-  if (!Number.isInteger(length) || length < 1 || length > 6) {
+  if (!Number.isInteger(length) || length < 1 || length > DEBUG_ID_MAX_LENGTH) {
     throw new Error(
-      'Level source debug refs must request an integer length from 1 to 6.'
+      `Level source debug refs must request an integer length from 1 to ${DEBUG_ID_MAX_LENGTH}.`
     );
   }
 


### PR DESCRIPTION
### Motivation
- Introduce a small, typed foundation for declarative level source IDs so future level-generation work can attach stable, human-readable provenance to generated geometry and colliders without changing runtime scene behavior. 
- Make source IDs hard to misuse by adding deterministic validation, composition helpers, a short debug-ref helper, and lightweight metadata types referenced from the design doc.

### Description
- Add `src/scene/level/sourceIds.ts` implementing the `LevelSourceId` branded type, `isLevelSourceId`, `assertLevelSourceId`, `makeLevelSourceId`, `joinLevelSourceId`, `getLevelSourceDebugRef`, `LevelSourceType`, and `LevelSourceMetadata`.
- Add unit tests `src/scene/level/__tests__/sourceIds.test.ts` covering valid/invalid IDs, composition errors, deterministic uppercase hex debug refs, distinct refs for different IDs, and ensuring helper names avoid tombstone-oriented words.
- Update `docs/design/declarative-level-source-of-truth.md` to show lowercase dot-separated examples and reference the new helper module as the recommended primitive for future source-backed data.
- No runtime scene, collider, or visible debug-ID behavior was changed as part of this PR.

### Testing
- Ran formatting with `npm run format:write` and it completed successfully.
- Ran lint with `npm run lint` and it passed.
- Ran targeted tests with `npm run test:ci -- src/scene/level/__tests__/sourceIds.test.ts` and they passed.
- Ran the full unit suite with `npm run test:ci` and it passed (the repo shows a large passing test run output).
- Ran docs validation `npm run docs:check` which passed; the link checker reported unreachable external URLs as warnings but did not fail the check.
- Built and validated the production bundle with `npm run build` and `npm run smoke` and both completed successfully.
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a310274bca8832f9bddfa27e3d51340)