### PR TITLE
Add semantic level source ID primitives

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -195,6 +195,14 @@ Short hex IDs may remain as debug display references for screenshot readability
 or compact overlays, but they are downstream labels. Debug labels should point
 back to semantic source IDs rather than becoming the source of truth.
 
+The foundational source-ID primitives live in
+`src/scene/level/sourceIds.ts`. Use that module to validate and compose
+dot-separated semantic source IDs, attach `LevelSourceMetadata` to future source
+and generated artifacts, and derive deterministic short debug references when a
+compact review label is needed. The helper layer is intentionally not wired into
+visible debug IDs yet, so it can be adopted by later migration phases without
+changing current scene output.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import * as sourceIds from '../sourceIds';
+import {
+  assertLevelSourceId,
+  getLevelSourceDebugRef,
+  isLevelSourceId,
+  joinLevelSourceId,
+  makeLevelSourceId,
+  type LevelSourceMetadata,
+} from '../sourceIds';
+
+describe('level source IDs', () => {
+  it('accepts semantic hierarchical IDs', () => {
+    const validIds = [
+      'ground.livingRoom.northWall.left',
+      'upper.loftLibrary.southWall.right',
+      'upper.stairwell.hiddenRun.safetyCollider',
+      'ground.livingRoom.mediaWall.sceneObject',
+      'backyard.greenhousePath.eastFence.section03',
+      'ground.living_room.media-wall.scene_object',
+    ];
+
+    for (const id of validIds) {
+      expect(isLevelSourceId(id)).toBe(true);
+      expect(assertLevelSourceId(id)).toBe(id);
+    }
+  });
+
+  it('rejects malformed IDs with helpful errors', () => {
+    const invalidIds = [
+      'ground livingRoom.northWall',
+      'Ground.livingRoom.northWall',
+      'ground..livingRoom',
+      'ground/livingRoom/northWall',
+      '.ground.livingRoom',
+      'ground.livingRoom.',
+      '',
+    ];
+
+    for (const id of invalidIds) {
+      expect(isLevelSourceId(id)).toBe(false);
+      expect(() => assertLevelSourceId(id)).toThrow(/Invalid level source ID/);
+    }
+  });
+
+  it('composes source IDs from explicit parts without silent normalization', () => {
+    expect(joinLevelSourceId('ground', 'livingRoom', 'northWall', 'left')).toBe(
+      'ground.livingRoom.northWall.left'
+    );
+    expect(
+      makeLevelSourceId(['upper', 'stairwell', 'hiddenRun', 'safetyCollider'])
+    ).toBe('upper.stairwell.hiddenRun.safetyCollider');
+    expect(() => joinLevelSourceId('ground', 'living room')).toThrow(
+      /Invalid level source ID/
+    );
+  });
+
+  it('creates deterministic uppercase hex debug references', () => {
+    const sourceId = assertLevelSourceId('ground.livingRoom.northWall.left');
+
+    expect(getLevelSourceDebugRef(sourceId)).toBe(
+      getLevelSourceDebugRef(sourceId)
+    );
+    expect(getLevelSourceDebugRef(sourceId)).toMatch(/^[0-9A-F]{6}$/);
+    expect(getLevelSourceDebugRef(sourceId, 8)).toMatch(/^[0-9A-F]{8}$/);
+    expect(() => getLevelSourceDebugRef(sourceId, 0)).toThrow(
+      /debug ref length/i
+    );
+  });
+
+  it('distinguishes representative source IDs with short debug refs', () => {
+    const ids = [
+      'ground.livingRoom.northWall.left',
+      'ground.livingRoom.northWall.right',
+      'upper.loftLibrary.southWall.right',
+      'upper.stairwell.hiddenRun.safetyCollider',
+      'ground.livingRoom.mediaWall.sceneObject',
+    ].map(assertLevelSourceId);
+
+    const refs = ids.map((id) => getLevelSourceDebugRef(id));
+
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  it('exports current-source helpers instead of tombstone-oriented helpers', () => {
+    const forbiddenNamePattern = /(former|removed|skip)/i;
+
+    expect(
+      Object.keys(sourceIds).filter((name) => forbiddenNamePattern.test(name))
+    ).toEqual([]);
+  });
+
+  it('types source metadata around current source ownership', () => {
+    const metadata: LevelSourceMetadata = {
+      sourceId: assertLevelSourceId('ground.livingRoom.mediaWall.sceneObject'),
+      sourceType: 'sceneObject',
+      purpose: 'Blocks avatar movement through the media wall footprint.',
+    };
+
+    expect(metadata.sourceType).toBe('sceneObject');
+  });
+});

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -1,0 +1,117 @@
+import { getStableDebugHashValue } from '../debug/debugIds';
+
+const LEVEL_SOURCE_ID_SEGMENT_PATTERN = /^[a-z0-9][A-Za-z0-9_-]*$/;
+const LEVEL_SOURCE_DEBUG_REF_MIN_LENGTH = 1;
+const LEVEL_SOURCE_DEBUG_REF_MAX_LENGTH = 12;
+
+declare const levelSourceIdBrand: unique symbol;
+
+/**
+ * Semantic identity for an intended level concept or a generated child artifact.
+ *
+ * Source IDs are dot-separated, human-readable paths. They may use lower camel
+ * case within a segment, but every segment must start with a lowercase letter or
+ * digit and may only contain ASCII letters, digits, underscores, or hyphens.
+ */
+export type LevelSourceId = string & { readonly [levelSourceIdBrand]: true };
+
+export type LevelSourceType =
+  | 'room'
+  | 'wall'
+  | 'floorSurface'
+  | 'safetyCollider'
+  | 'sceneObject'
+  | 'roomConnection'
+  | 'generatedCollider'
+  | 'generatedSolid';
+
+export interface LevelSourceMetadata {
+  sourceId: LevelSourceId;
+  sourceType: LevelSourceType;
+  purpose?: string;
+}
+
+export const isLevelSourceId = (value: unknown): value is LevelSourceId =>
+  typeof value === 'string' && getLevelSourceIdValidationError(value) === null;
+
+export const assertLevelSourceId = (value: string): LevelSourceId => {
+  const validationError = getLevelSourceIdValidationError(value);
+  if (validationError !== null) {
+    throw new Error(`Invalid level source ID "${value}": ${validationError}`);
+  }
+
+  return value as LevelSourceId;
+};
+
+export const makeLevelSourceId = (parts: readonly string[]): LevelSourceId => {
+  if (parts.length === 0) {
+    throw new Error('Level source ID requires at least one part');
+  }
+
+  return assertLevelSourceId(parts.join('.'));
+};
+
+export const joinLevelSourceId = (...parts: string[]): LevelSourceId =>
+  makeLevelSourceId(parts);
+
+export const getLevelSourceDebugRef = (
+  sourceId: LevelSourceId,
+  length = 6
+): string => {
+  assertDebugRefLength(length);
+
+  return Math.floor(getStableDebugHashValue(sourceId) % 16 ** length)
+    .toString(16)
+    .toUpperCase()
+    .padStart(length, '0');
+};
+
+const getLevelSourceIdValidationError = (value: string): string | null => {
+  if (value.length === 0) {
+    return 'source IDs cannot be empty';
+  }
+
+  if (/\s/.test(value)) {
+    return 'source IDs cannot contain whitespace';
+  }
+
+  if (value.includes('/')) {
+    return 'source IDs must use dot hierarchy, not slash paths';
+  }
+
+  if (value.startsWith('.') || value.endsWith('.')) {
+    return 'source IDs cannot start or end with a dot';
+  }
+
+  if (value.includes('..')) {
+    return 'source IDs cannot contain empty segments';
+  }
+
+  const invalidSegment = value
+    .split('.')
+    .find((segment) => !LEVEL_SOURCE_ID_SEGMENT_PATTERN.test(segment));
+  if (invalidSegment !== undefined) {
+    return [
+      `invalid segment "${invalidSegment}"`,
+      'segments must start with lowercase ASCII or a digit',
+      'and contain only ASCII letters, digits, underscores, or hyphens',
+    ].join('; ');
+  }
+
+  return null;
+};
+
+const assertDebugRefLength = (length: number): void => {
+  if (
+    !Number.isInteger(length) ||
+    length < LEVEL_SOURCE_DEBUG_REF_MIN_LENGTH ||
+    length > LEVEL_SOURCE_DEBUG_REF_MAX_LENGTH
+  ) {
+    throw new Error(
+      [
+        'Level source debug ref length must be an integer from',
+        `${LEVEL_SOURCE_DEBUG_REF_MIN_LENGTH} to ${LEVEL_SOURCE_DEBUG_REF_MAX_LENGTH}`,
+      ].join(' ')
+    );
+  }
+};


### PR DESCRIPTION
### Motivation
- Introduce a small, typed foundation for human-readable semantic source IDs to support the declarative level source-of-truth migration without changing runtime scene behavior. 
- Keep compact debug labels downstream and provide deterministic short refs for review while preserving existing debug/visual output.

### Description
- Add a new helper module `src/scene/level/sourceIds.ts` that defines a branded `LevelSourceId` type, `LevelSourceType`, `LevelSourceMetadata`, validation (`isLevelSourceId`, `assertLevelSourceId`), composition helpers (`makeLevelSourceId`, `joinLevelSourceId`), and deterministic uppercase hex debug refs (`getLevelSourceDebugRef`).
- Use existing `src/scene/debug/debugIds.ts` hashing helper for deterministic short refs and enforce segment/format rules (dot-separated segments, no whitespace/slashes/empty segments, lowercase-starting segments, only ASCII letters/digits/_/- allowed).
- Add unit tests `src/scene/level/__tests__/sourceIds.test.ts` covering valid/invalid IDs, composition behavior, debug-ref determinism, representative uniqueness, metadata typing, and ensuring no tombstone-oriented helper names are exported.
- Document the new module and intended usage in `docs/design/declarative-level-source-of-truth.md` with a note that the helper is intentionally not wired into visible debug IDs yet.

### Testing
- Ran formatting with `npm run format:write` and lint with `npm run lint`, both completed successfully. 
- Ran focused unit tests with `npm run test:ci -- src/scene/level/__tests__/sourceIds.test.ts` and they passed (7 tests). 
- Ran full test suite with `npm run test:ci` and it passed (149 files, 1131 tests) with existing test-suite warnings printed by some tests but no failures. 
- Verified docs and links with `npm run docs:check`, which passed the docs checks while the link checker produced external fetch warnings (non-blocking). 
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`, both succeeded, and the repository secret scan `./scripts/scan-secrets.py` reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31028b1a2c832fb1387a7432174a55)