### PR TITLE
Add semantic level source-ID primitives

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -195,6 +195,18 @@ Short hex IDs may remain as debug display references for screenshot readability
 or compact overlays, but they are downstream labels. Debug labels should point
 back to semantic source IDs rather than becoming the source of truth.
 
+`src/scene/level/sourceIds.ts` provides the foundation primitives for this
+migration phase. Use `LevelSourceId` plus `assertLevelSourceId(...)`,
+`isLevelSourceId(...)`, `makeLevelSourceId(...)`, and `joinLevelSourceId(...)`
+when declaring or deriving semantic source IDs. The helper validates readable
+hierarchical IDs, rejects empty segments, whitespace, and slash paths, and keeps
+composition explicit rather than silently normalizing malformed values.
+`LevelSourceMetadata` pairs a source ID with a source type and optional purpose
+text for future generated colliders, solids, and inventory reports.
+`getLevelSourceDebugRef(...)` can derive deterministic uppercase hex references
+for compact downstream debug metadata, but visible debug IDs are not wired to
+these source IDs yet.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertLevelSourceId,
+  getLevelSourceDebugRef,
+  isLevelSourceId,
+  joinLevelSourceId,
+  makeLevelSourceId,
+} from '../sourceIds';
+
+const validSourceIds = [
+  'ground.livingRoom.northWall.left',
+  'upper.loftLibrary.southWall.right',
+  'upper.stairwell.hiddenRun.safetyCollider',
+  'ground.livingRoom.mediaWall.sceneObject',
+  'backyard.greenhousePath.eastFence.section03',
+];
+
+const invalidSourceIds = [
+  'ground.living room.northWall.left',
+  'Ground.livingRoom.northWall.left',
+  'ground..livingRoom.northWall.left',
+  'ground/livingRoom/northWall/left',
+  '.ground.livingRoom.northWall.left',
+  'ground.livingRoom.northWall.left.',
+];
+
+describe('level source IDs', () => {
+  it('accepts valid hierarchical IDs', () => {
+    for (const sourceId of validSourceIds) {
+      expect(isLevelSourceId(sourceId)).toBe(true);
+      expect(assertLevelSourceId(sourceId)).toBe(sourceId);
+    }
+  });
+
+  it('rejects malformed IDs', () => {
+    for (const sourceId of invalidSourceIds) {
+      expect(isLevelSourceId(sourceId)).toBe(false);
+      expect(() => assertLevelSourceId(sourceId)).toThrow(
+        /Invalid level source ID/
+      );
+    }
+  });
+
+  it('joins source ID parts without silently normalizing malformed input', () => {
+    expect(joinLevelSourceId('ground', 'livingRoom', 'northWall', 'left')).toBe(
+      'ground.livingRoom.northWall.left'
+    );
+    expect(
+      makeLevelSourceId(['upper', 'stairwell', 'hiddenRun', 'safetyCollider'])
+    ).toBe('upper.stairwell.hiddenRun.safetyCollider');
+    expect(() => joinLevelSourceId('ground', 'livingRoom.northWall')).toThrow(
+      /dots/
+    );
+  });
+
+  it('returns deterministic uppercase hex debug references', () => {
+    const sourceId = assertLevelSourceId(
+      'ground.livingRoom.mediaWall.sceneObject'
+    );
+    const debugRef = getLevelSourceDebugRef(sourceId);
+
+    expect(debugRef).toBe(getLevelSourceDebugRef(sourceId));
+    expect(debugRef).toMatch(/^[0-9A-F]{6}$/);
+    expect(getLevelSourceDebugRef(sourceId, 4)).toMatch(/^[0-9A-F]{4}$/);
+  });
+
+  it('returns different debug references for representative source IDs', () => {
+    const debugRefs = validSourceIds.map((sourceId) =>
+      getLevelSourceDebugRef(assertLevelSourceId(sourceId))
+    );
+
+    expect(new Set(debugRefs).size).toBe(debugRefs.length);
+  });
+
+  it('does not expose tombstone-oriented helper names', async () => {
+    const helperNames = Object.keys(await import('../sourceIds'));
+
+    expect(helperNames.join(' ')).not.toMatch(/former|removed|skip/i);
+  });
+});

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -1,0 +1,101 @@
+import { getDebugHash } from '../debug/debugIds';
+
+const LEVEL_SOURCE_ID_PATTERN =
+  /^[a-z0-9][A-Za-z0-9_-]*(?:\.[a-z0-9][A-Za-z0-9_-]*)*$/;
+const DEBUG_REF_MIN_LENGTH = 1;
+const DEBUG_REF_MAX_LENGTH = 6;
+
+export type LevelSourceId = string & {
+  readonly __levelSourceId: unique symbol;
+};
+
+export type LevelSourceType =
+  | 'room'
+  | 'wall'
+  | 'floorSurface'
+  | 'safetyCollider'
+  | 'sceneObject'
+  | 'roomConnection'
+  | 'generatedCollider'
+  | 'generatedSolid';
+
+export interface LevelSourceMetadata {
+  sourceId: LevelSourceId;
+  sourceType: LevelSourceType;
+  purpose?: string;
+}
+
+export const isLevelSourceId = (value: unknown): value is LevelSourceId =>
+  typeof value === 'string' && LEVEL_SOURCE_ID_PATTERN.test(value);
+
+const describeLevelSourceIdError = (value: string): string => {
+  if (value.length === 0) {
+    return 'Source IDs must not be empty.';
+  }
+
+  if (value.includes('/')) {
+    return 'Use dot-separated hierarchy instead of slash paths.';
+  }
+
+  if (/\s/.test(value)) {
+    return 'Source IDs must not contain whitespace.';
+  }
+
+  if (value.startsWith('.') || value.endsWith('.') || value.includes('..')) {
+    return 'Source IDs must not contain empty hierarchy segments.';
+  }
+
+  if (/[A-Z]/.test(value)) {
+    return 'Source ID hierarchy segments must start with a lowercase letter or digit.';
+  }
+
+  return 'Allowed characters are letters, digits, dot, underscore, and hyphen; each segment must start lowercase or numeric.';
+};
+
+export const assertLevelSourceId = (value: string): LevelSourceId => {
+  if (!isLevelSourceId(value)) {
+    throw new Error(
+      `Invalid level source ID "${value}": ${describeLevelSourceIdError(value)}`
+    );
+  }
+
+  return value;
+};
+
+export const makeLevelSourceId = (parts: readonly string[]): LevelSourceId => {
+  if (parts.length === 0) {
+    throw new Error('Level source IDs require at least one hierarchy part.');
+  }
+
+  for (const part of parts) {
+    if (part.length === 0) {
+      throw new Error('Level source ID hierarchy parts must not be empty.');
+    }
+
+    if (part.includes('.')) {
+      throw new Error(`Level source ID part "${part}" must not contain dots.`);
+    }
+  }
+
+  return assertLevelSourceId(parts.join('.'));
+};
+
+export const joinLevelSourceId = (...parts: string[]): LevelSourceId =>
+  makeLevelSourceId(parts);
+
+export const getLevelSourceDebugRef = (
+  sourceId: LevelSourceId,
+  length = 6
+): string => {
+  if (
+    !Number.isInteger(length) ||
+    length < DEBUG_REF_MIN_LENGTH ||
+    length > DEBUG_REF_MAX_LENGTH
+  ) {
+    throw new Error(
+      `Level source debug reference length must be an integer from ${DEBUG_REF_MIN_LENGTH} to ${DEBUG_REF_MAX_LENGTH}.`
+    );
+  }
+
+  return getDebugHash(sourceId).slice(0, length);
+};


### PR DESCRIPTION
### Motivation
- Introduce a minimal, type-safe foundation for human-readable semantic level source IDs to enable the declarative level migration without changing runtime scene behavior.
- Provide deterministic short debug references and metadata types so downstream debug/collider/solid producers can reference stable source identities in future phases.

### Description
- Added `src/scene/level/sourceIds.ts` which defines the branded `LevelSourceId`, `isLevelSourceId`, `assertLevelSourceId`, `makeLevelSourceId`, `joinLevelSourceId`, `getLevelSourceDebugRef`, `LevelSourceType`, and `LevelSourceMetadata`.
- Added unit tests `src/scene/level/__tests__/sourceIds.test.ts` covering valid/invalid formats, composition helpers, deterministic uppercase hex debug refs, uniqueness for representative IDs, and ensuring no tombstone-oriented helper names are exported.
- Updated `docs/design/declarative-level-source-of-truth.md` to mention the new module and intended usage; no runtime behavior, debug visuals, or collider generation logic was changed.

### Testing
- Ran formatting: `npm run format:write` (passed).
- Ran linter: `npm run lint` (passed).
- Ran focused unit test: `npm run test:ci -- src/scene/level/__tests__/sourceIds.test.ts` (6 tests passed).
- Ran full test suite: `npm run test:ci` (149 files, 1130 tests passed).
- Verified docs and links: `npm run docs:check` (passed with existing external fetch warnings reported by the docs checker).
- Built and smoke-checked the app: `npm run build` and `npm run smoke` (both passed; Vite chunk-size warning observed but did not fail the build).
- Notes: test logs include non-fatal warnings such as `THREE.Color` messages in some environment tests and the Vite large-chunk warning, but these did not cause test or build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3102a53228832f8b6f14749ce040ad)