### PR TITLE
Expose source IDs through debug collider and solid metadata

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -195,6 +195,16 @@ Short hex IDs may remain as debug display references for screenshot readability
 or compact overlays, but they are downstream labels. Debug labels should point
 back to semantic source IDs rather than becoming the source of truth.
 
+The debug visualizer APIs now expose optional `sourceId`, `sourceType`, and
+`purpose` metadata on collider and solid metadata responses while preserving the
+existing visible hex IDs and label text. Collider registrations can pass those
+fields directly, and solid debug metadata reads them from
+`object.userData.levelSourceId` or `object.userData.levelSource`. Consumers can
+use `getColliderBySourceId(...)`, `getCollidersBySourceId(...)`,
+`getSolidBySourceId(...)`, and `getSolidsBySourceId(...)` to inspect downstream
+artifacts by authoritative source identity without reverse-engineering compact
+labels.
+
 The foundation helpers for this migration live in
 `src/scene/level/sourceIds.ts`. New source-backed level data should use the
 `LevelSourceId` branded type, `assertLevelSourceId(...)`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -619,12 +619,18 @@ declare global {
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+        getColliderBySourceId(
+          sourceId: unknown
+        ): DebugColliderMetadata | undefined;
+        getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
       };
       debugSolids?: {
         getState(): DebugSolidVisualizerState;
         setEnabled(enabled: boolean): void;
         getSolids(): DebugSolidMetadata[];
         getSolidById(id: unknown): DebugSolidMetadata | undefined;
+        getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+        getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
       };
       debugPerformance?: {
         getState(): DebugPerformanceState;
@@ -4987,6 +4993,10 @@ function initializeImmersiveScene(
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+    getColliderBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getColliderBySourceId(sourceId),
+    getCollidersBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getCollidersBySourceId(sourceId),
   };
 
   window.portfolio.debugSolids = {
@@ -5001,6 +5011,14 @@ function initializeImmersiveScene(
     getSolidById: (id: unknown) => {
       ensureSolidVisualizerRegistered();
       return solidVisualizer.getSolidById(id);
+    },
+    getSolidBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidBySourceId(sourceId);
+    },
+    getSolidsBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidsBySourceId(sourceId);
     },
   };
 

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -682,6 +682,60 @@ describe('createColliderVisualizer', () => {
     ).toBe(exposedLabelName);
   });
 
+  it('registers semantic source metadata without changing visible IDs', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    const baselineId = createColliderDebugId(metadata);
+
+    visualizer.register([
+      {
+        ...metadata,
+        sourceId: 'wall:studio-west',
+        sourceType: 'wall',
+        purpose: 'blocking',
+      },
+    ]);
+
+    const [registered] = visualizer.getColliders();
+    expect(registered).toEqual({
+      id: baselineId,
+      ...metadata,
+      sourceId: 'wall:studio-west',
+      sourceType: 'wall',
+      purpose: 'blocking',
+    });
+    expect(visualizer.getColliderById(baselineId)).toEqual(registered);
+    expect(
+      visualizer.group.children.find((child) => child.type === 'Mesh')?.userData
+        .colliderDebug
+    ).toMatchObject({
+      id: baselineId,
+      sourceId: 'wall:studio-west',
+      sourceType: 'wall',
+      purpose: 'blocking',
+    });
+  });
+
+  it('looks up colliders by source ID and returns duplicate matches', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    visualizer.register([
+      { ...metadata, name: 'source-a-0', sourceId: 'wall:shared' },
+      { ...metadata, name: 'source-a-1', sourceId: 'wall:shared' },
+      { ...metadata, name: 'source-b-0', sourceId: 'wall:other' },
+      { ...metadata, name: 'source-empty-0' },
+    ]);
+
+    const matches = visualizer.getCollidersBySourceId('wall:shared');
+    expect(matches.map((match) => match.name)).toEqual([
+      'source-a-0',
+      'source-a-1',
+    ]);
+    expect(visualizer.getColliderBySourceId('wall:shared')).toEqual(matches[0]);
+    expect(visualizer.getColliderBySourceId('missing')).toBeUndefined();
+    expect(visualizer.getColliderBySourceId(null)).toBeUndefined();
+    expect(visualizer.getCollidersBySourceId('missing')).toEqual([]);
+    expect(visualizer.getCollidersBySourceId(null)).toEqual([]);
+  });
+
   it('creates floor-aware labels that toggle with debug collider visibility', () => {
     const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
     visualizer.register([

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -123,6 +123,50 @@ describe('createSolidVisualizer', () => {
     });
   });
 
+  it('keeps visible debug IDs stable when otherwise identical solids add source metadata', () => {
+    const sceneWithoutSource = new Group();
+    sceneWithoutSource.name = 'Scene';
+    sceneWithoutSource.add(createSolid('StableSourceWall'));
+    const withoutSource = createSolidVisualizer({ enabled: true });
+    withoutSource.register(sceneWithoutSource);
+
+    const sceneWithSourceId = new Group();
+    sceneWithSourceId.name = 'Scene';
+    const withSourceId = createSolid('StableSourceWall');
+    withSourceId.userData.levelSourceId = 'wall:stable-source-id';
+    sceneWithSourceId.add(withSourceId);
+    const withSourceIdVisualizer = createSolidVisualizer({ enabled: true });
+    withSourceIdVisualizer.register(sceneWithSourceId);
+
+    const sceneWithLevelSource = new Group();
+    sceneWithLevelSource.name = 'Scene';
+    const withLevelSource = createSolid('StableSourceWall');
+    withLevelSource.userData.levelSource = {
+      sourceId: 'wall:stable-level-source',
+      sourceType: 'wall',
+      purpose: 'structure',
+    };
+    sceneWithLevelSource.add(withLevelSource);
+    const withLevelSourceVisualizer = createSolidVisualizer({ enabled: true });
+    withLevelSourceVisualizer.register(sceneWithLevelSource);
+
+    const [sourceLessMetadata] = withoutSource.getSolids();
+    const [sourceIdMetadata] = withSourceIdVisualizer.getSolids();
+    const [levelSourceMetadata] = withLevelSourceVisualizer.getSolids();
+
+    expect(sourceIdMetadata.id).toBe(sourceLessMetadata.id);
+    expect(levelSourceMetadata.id).toBe(sourceLessMetadata.id);
+    expect(
+      withSourceIdVisualizer.getSolidBySourceId('wall:stable-source-id')
+    ).toEqual(sourceIdMetadata);
+    expect(
+      withLevelSourceVisualizer.getSolidsBySourceId('wall:stable-level-source')
+    ).toEqual([levelSourceMetadata]);
+    expect(sourceLessMetadata).not.toHaveProperty('sourceId');
+    expect(sourceLessMetadata).not.toHaveProperty('sourceType');
+    expect(sourceLessMetadata).not.toHaveProperty('purpose');
+  });
+
   it('inherits source metadata from owning ancestors with child precedence', () => {
     const scene = new Group();
     scene.name = 'Scene';

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -74,6 +74,73 @@ describe('createSolidVisualizer', () => {
     expect(visualizer.getSolids()[0].bounds.min.x).not.toBe(99);
   });
 
+  it('reads source metadata from userData.levelSourceId', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solid = createSolid('SourceIdWall');
+    solid.userData.levelSourceId = 'wall:source-id';
+    scene.add(solid);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const [metadata] = visualizer.getSolids();
+    expect(metadata).toMatchObject({
+      name: 'SourceIdWall',
+      sourceId: 'wall:source-id',
+    });
+    expect(visualizer.getSolidBySourceId('wall:source-id')).toEqual(metadata);
+    expect(visualizer.getSolidsBySourceId('wall:source-id')).toEqual([
+      metadata,
+    ]);
+  });
+
+  it('reads source metadata from userData.levelSource', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const first = createSolid('SourceObjectWallA');
+    first.userData.levelSource = {
+      sourceId: 'wall:shared-source',
+      sourceType: 'wall',
+      purpose: 'render',
+    };
+    const second = createSolid('SourceObjectWallB');
+    second.userData.levelSource = { sourceId: 'wall:shared-source' };
+    scene.add(first, second);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const matches = visualizer.getSolidsBySourceId('wall:shared-source');
+    expect(matches).toHaveLength(2);
+    expect(visualizer.getSolidBySourceId('wall:shared-source')).toEqual(
+      matches[0]
+    );
+    expect(matches[0]).toMatchObject({
+      sourceId: 'wall:shared-source',
+      sourceType: 'wall',
+      purpose: 'render',
+    });
+  });
+
+  it('keeps objects without source metadata behaving as before', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    scene.add(createSolid('LegacyWall'));
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const [metadata] = visualizer.getSolids();
+    expect(metadata.sourceId).toBeUndefined();
+    expect(metadata.sourceType).toBeUndefined();
+    expect(metadata.purpose).toBeUndefined();
+    expect(visualizer.getSolidBySourceId('missing')).toBeUndefined();
+    expect(visualizer.getSolidBySourceId(null)).toBeUndefined();
+    expect(visualizer.getSolidsBySourceId('missing')).toEqual([]);
+    expect(visualizer.getSolidsBySourceId(null)).toEqual([]);
+  });
+
   it('creates matching non-raycasting debug wireframes and labels without ID collisions', () => {
     const scene = new Group();
     scene.name = 'Scene';

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -181,6 +181,9 @@ describe('createSolidVisualizer', () => {
     const childOverride = createSolid('ChildSourceWall');
     childOverride.userData.levelSourceId = 'wall:child-source';
     parent.add(childOverride);
+    const partialChild = createSolid('PartialChildSourceWall');
+    partialChild.userData.levelSource = { purpose: 'render' };
+    parent.add(partialChild);
     scene.add(parent);
 
     const visualizer = createSolidVisualizer({ enabled: true });
@@ -197,9 +200,19 @@ describe('createSolidVisualizer', () => {
       name: 'ChildSourceWall',
       sourceId: 'wall:child-source',
     });
-    expect(visualizer.getSolidsBySourceId('wall:parent-source')).toHaveLength(
-      1
-    );
+    expect(visualizer.getSolidsBySourceId('wall:parent-source')).toEqual([
+      expect.objectContaining({
+        name: 'InheritedSourceWall',
+        sourceId: 'wall:parent-source',
+        purpose: 'structure',
+      }),
+      expect.objectContaining({
+        name: 'PartialChildSourceWall',
+        sourceId: 'wall:parent-source',
+        sourceType: 'wall',
+        purpose: 'render',
+      }),
+    ]);
   });
 
   it('keeps direct source IDs coherent when nested source metadata differs', () => {

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -123,6 +123,80 @@ describe('createSolidVisualizer', () => {
     });
   });
 
+  it('inherits source metadata from owning ancestors with child precedence', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const parent = new Group();
+    parent.name = 'DeclarativeWallGroup';
+    parent.userData.levelSource = {
+      sourceId: 'wall:parent-source',
+      sourceType: 'wall',
+      purpose: 'structure',
+    };
+    parent.add(createSolid('InheritedSourceWall'));
+    const childOverride = createSolid('ChildSourceWall');
+    childOverride.userData.levelSourceId = 'wall:child-source';
+    parent.add(childOverride);
+    scene.add(parent);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const inherited = visualizer.getSolidBySourceId('wall:parent-source');
+    expect(inherited).toMatchObject({
+      name: 'InheritedSourceWall',
+      sourceId: 'wall:parent-source',
+      sourceType: 'wall',
+      purpose: 'structure',
+    });
+    expect(visualizer.getSolidBySourceId('wall:child-source')).toMatchObject({
+      name: 'ChildSourceWall',
+      sourceId: 'wall:child-source',
+    });
+    expect(visualizer.getSolidsBySourceId('wall:parent-source')).toHaveLength(
+      1
+    );
+  });
+
+  it('keeps direct source IDs coherent when nested source metadata differs', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const mismatched = createSolid('MigratedSourceWall');
+    mismatched.userData.levelSourceId = 'wall:new-source';
+    mismatched.userData.levelSource = {
+      sourceId: 'wall:old-source',
+      sourceType: 'wall',
+      purpose: 'legacy',
+    };
+    const matching = createSolid('MatchingSourceWall');
+    matching.userData.levelSourceId = 'wall:matching-source';
+    matching.userData.levelSource = {
+      sourceId: 'wall:matching-source',
+      sourceType: 'wall',
+      purpose: 'render',
+    };
+    scene.add(mismatched, matching);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const migrated = visualizer.getSolidBySourceId('wall:new-source');
+    expect(migrated).toMatchObject({
+      name: 'MigratedSourceWall',
+      sourceId: 'wall:new-source',
+    });
+    expect(migrated?.sourceType).toBeUndefined();
+    expect(migrated?.purpose).toBeUndefined();
+    expect(visualizer.getSolidBySourceId('wall:matching-source')).toMatchObject(
+      {
+        name: 'MatchingSourceWall',
+        sourceId: 'wall:matching-source',
+        sourceType: 'wall',
+        purpose: 'render',
+      }
+    );
+  });
+
   it('keeps objects without source metadata behaving as before', () => {
     const scene = new Group();
     scene.name = 'Scene';
@@ -166,6 +240,9 @@ describe('createSolidVisualizer', () => {
       (child) => child.type === 'Sprite'
     );
     expect(wireframe?.userData.debugOnly).toBe(true);
+    expect(wireframe?.userData.solidDebug).toEqual({
+      id: solids[0].id,
+    });
     expect(label?.userData.debugOnly).toBe(true);
     expect(wireframe?.raycast({} as never, [] as never)).toBeUndefined();
     expect(label?.raycast({} as never, [] as never)).toBeUndefined();
@@ -178,6 +255,32 @@ describe('createSolidVisualizer', () => {
         label as { material: { color: { getHex(): number } } }
       ).material.color.getHex()
     );
+  });
+
+  it('exposes solid source metadata on debug wireframe userData', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solid = createSolid('InspectableSourceWall');
+    solid.userData.levelSource = {
+      sourceId: 'wall:inspectable-source',
+      sourceType: 'wall',
+      purpose: 'inspect',
+    };
+    scene.add(solid);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const [metadata] = visualizer.getSolids();
+    const wireframe = visualizer.group.children.find(
+      (child) => child.type === 'LineSegments'
+    );
+    expect(wireframe?.userData.solidDebug).toEqual({
+      id: metadata.id,
+      sourceId: 'wall:inspectable-source',
+      sourceType: 'wall',
+      purpose: 'inspect',
+    });
   });
 
   it('registers stable scene solids while hiding currently ineffective entries', () => {

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -31,6 +31,9 @@ export interface DebugColliderMetadata {
   category: string;
   name: string;
   bounds: RectCollider;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderRegistration {
@@ -41,6 +44,9 @@ export interface DebugColliderRegistration {
   elevation?: number;
   height?: number;
   color?: ColorRepresentation;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderVisualizerState {
@@ -67,6 +73,8 @@ export interface ColliderVisualizer {
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
   getColliderById(id: unknown): DebugColliderMetadata | undefined;
+  getColliderBySourceId(sourceId: unknown): DebugColliderMetadata | undefined;
+  getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
   dispose(): void;
 }
 
@@ -88,6 +96,22 @@ export const DEBUG_LABEL_PALETTE = [
   '#BD93F9',
   '#FFB86C',
 ];
+const cloneSourceMetadata = <
+  T extends {
+    sourceId?: string;
+    sourceType?: string;
+    purpose?: string;
+  },
+>(
+  input: T
+): Pick<T, 'sourceId' | 'sourceType' | 'purpose'> => ({
+  ...(typeof input.sourceId === 'string' ? { sourceId: input.sourceId } : {}),
+  ...(typeof input.sourceType === 'string'
+    ? { sourceType: input.sourceType }
+    : {}),
+  ...(typeof input.purpose === 'string' ? { purpose: input.purpose } : {}),
+});
+
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
   minX: bounds.minX,
   maxX: bounds.maxX,
@@ -347,6 +371,7 @@ export function createColliderVisualizer(options: {
       category: collider.category,
       name: collider.name,
       bounds: cloneBounds(collider.bounds),
+      ...cloneSourceMetadata(collider),
     }));
     const nextIds = allocateColliderDebugIds(metadataWithoutIds, existingIds);
 
@@ -393,6 +418,7 @@ export function createColliderVisualizer(options: {
         floor: collider.floor,
         category: collider.category,
         name: collider.name,
+        ...cloneSourceMetadata(collider),
       };
       mesh.raycast = () => undefined;
 
@@ -431,6 +457,7 @@ export function createColliderVisualizer(options: {
     category: metadata.category,
     name: metadata.name,
     bounds: cloneBounds(metadata.bounds),
+    ...cloneSourceMetadata(metadata),
   });
 
   return {
@@ -468,6 +495,21 @@ export function createColliderVisualizer(options: {
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getColliderBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return undefined;
+      }
+      const entry = entries.find((next) => next.metadata.sourceId === sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getCollidersBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return [];
+      }
+      return entries
+        .filter((entry) => entry.metadata.sourceId === sourceId)
+        .map((entry) => cloneMetadata(entry.metadata));
     },
     dispose() {
       for (const entry of entries) {

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -39,6 +39,9 @@ export interface DebugSolidMetadata {
   meshType: string;
   bounds: DebugSolidBounds;
   material?: string;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugSolidVisualizerState {
@@ -63,6 +66,8 @@ export interface SolidVisualizer {
   getState(): DebugSolidVisualizerState;
   getSolids(): DebugSolidMetadata[];
   getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+  getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
   update(): void;
   dispose(): void;
 }
@@ -176,6 +181,45 @@ const getObjectPath = (object: Object3D): string => {
   return parts.reverse().join('/');
 };
 
+const cloneSourceMetadata = (metadata: {
+  sourceId?: unknown;
+  sourceType?: unknown;
+  purpose?: unknown;
+}) => ({
+  ...(typeof metadata.sourceId === 'string'
+    ? { sourceId: metadata.sourceId }
+    : {}),
+  ...(typeof metadata.sourceType === 'string'
+    ? { sourceType: metadata.sourceType }
+    : {}),
+  ...(typeof metadata.purpose === 'string'
+    ? { purpose: metadata.purpose }
+    : {}),
+});
+
+const getUserDataSourceMetadata = (
+  object: Object3D
+): Pick<DebugSolidMetadata, 'sourceId' | 'sourceType' | 'purpose'> => {
+  const levelSource = object.userData.levelSource;
+  const nestedSource =
+    levelSource && typeof levelSource === 'object'
+      ? (levelSource as {
+          sourceId?: unknown;
+          sourceType?: unknown;
+          purpose?: unknown;
+        })
+      : undefined;
+
+  return cloneSourceMetadata({
+    sourceId:
+      typeof object.userData.levelSourceId === 'string'
+        ? object.userData.levelSourceId
+        : nestedSource?.sourceId,
+    sourceType: nestedSource?.sourceType,
+    purpose: nestedSource?.purpose,
+  });
+};
+
 const cloneBounds = (bounds: DebugSolidBounds): DebugSolidBounds => ({
   min: { ...bounds.min },
   max: { ...bounds.max },
@@ -269,6 +313,7 @@ export const createSolidDebugId = (
 
 const cloneMetadata = (metadata: DebugSolidMetadata): DebugSolidMetadata => ({
   ...metadata,
+  ...cloneSourceMetadata(metadata),
   bounds: cloneBounds(metadata.bounds),
 });
 
@@ -354,6 +399,7 @@ export const createSolidVisualizer = (
         meshType: object.type,
         bounds,
         material: getMaterialSummary(object.material),
+        ...getUserDataSourceMetadata(object),
       };
       meshes.push({
         mesh: object,
@@ -462,6 +508,21 @@ export const createSolidVisualizer = (
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return undefined;
+      }
+      const entry = entries.find((next) => next.metadata.sourceId === sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidsBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return [];
+      }
+      return entries
+        .filter((entry) => entry.metadata.sourceId === sourceId)
+        .map((entry) => cloneMetadata(entry.metadata));
     },
     update() {
       if (!enabled) {

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -234,19 +234,24 @@ const getOwnUserDataSourceMetadata = (
 const getUserDataSourceMetadata = (
   object: Object3D
 ): Pick<DebugSolidMetadata, 'sourceId' | 'sourceType' | 'purpose'> => {
+  const metadata: Pick<
+    DebugSolidMetadata,
+    'sourceId' | 'sourceType' | 'purpose'
+  > = {};
   let current: Object3D | null = object;
   while (current) {
-    const metadata = getOwnUserDataSourceMetadata(current);
-    if (
-      metadata.sourceId !== undefined ||
-      metadata.sourceType !== undefined ||
-      metadata.purpose !== undefined
-    ) {
-      return metadata;
+    const ownMetadata = getOwnUserDataSourceMetadata(current);
+    metadata.sourceType ??= ownMetadata.sourceType;
+    metadata.purpose ??= ownMetadata.purpose;
+
+    if (ownMetadata.sourceId !== undefined) {
+      metadata.sourceId = ownMetadata.sourceId;
+      return cloneSourceMetadata(metadata);
     }
+
     current = current.parent;
   }
-  return {};
+  return cloneSourceMetadata(metadata);
 };
 
 const cloneBounds = (bounds: DebugSolidBounds): DebugSolidBounds => ({

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -197,7 +197,7 @@ const cloneSourceMetadata = (metadata: {
     : {}),
 });
 
-const getUserDataSourceMetadata = (
+const getOwnUserDataSourceMetadata = (
   object: Object3D
 ): Pick<DebugSolidMetadata, 'sourceId' | 'sourceType' | 'purpose'> => {
   const levelSource = object.userData.levelSource;
@@ -209,15 +209,44 @@ const getUserDataSourceMetadata = (
           purpose?: unknown;
         })
       : undefined;
+  const directSourceId = object.userData.levelSourceId;
+
+  if (typeof directSourceId === 'string') {
+    const nestedSourceId = nestedSource?.sourceId;
+    return cloneSourceMetadata({
+      sourceId: directSourceId,
+      ...(nestedSourceId === directSourceId
+        ? {
+            sourceType: nestedSource.sourceType,
+            purpose: nestedSource.purpose,
+          }
+        : {}),
+    });
+  }
 
   return cloneSourceMetadata({
-    sourceId:
-      typeof object.userData.levelSourceId === 'string'
-        ? object.userData.levelSourceId
-        : nestedSource?.sourceId,
+    sourceId: nestedSource?.sourceId,
     sourceType: nestedSource?.sourceType,
     purpose: nestedSource?.purpose,
   });
+};
+
+const getUserDataSourceMetadata = (
+  object: Object3D
+): Pick<DebugSolidMetadata, 'sourceId' | 'sourceType' | 'purpose'> => {
+  let current: Object3D | null = object;
+  while (current) {
+    const metadata = getOwnUserDataSourceMetadata(current);
+    if (
+      metadata.sourceId !== undefined ||
+      metadata.sourceType !== undefined ||
+      metadata.purpose !== undefined
+    ) {
+      return metadata;
+    }
+    current = current.parent;
+  }
+  return {};
 };
 
 const cloneBounds = (bounds: DebugSolidBounds): DebugSolidBounds => ({
@@ -448,7 +477,10 @@ export const createSolidVisualizer = (
       wireframe.renderOrder = 20_002;
       wireframe.frustumCulled = false;
       wireframe.userData.debugOnly = true;
-      wireframe.userData.solidDebug = { id };
+      wireframe.userData.solidDebug = {
+        id,
+        ...cloneSourceMetadata(item.metadata),
+      };
       wireframe.raycast = () => undefined;
 
       const label = createDebugIdLabel(id, color);


### PR DESCRIPTION
### Motivation
- Surface authoritative semantic `sourceId`/`sourceType`/`purpose` on downstream debug metadata so consumers can refer to source objects instead of reverse-engineering compact debug labels.
- Keep all visible debug IDs, label text, generated geometry, and runtime behavior unchanged while starting the declarative-level migration path.

### Description
- Add optional `sourceId?: string`, `sourceType?: string`, and `purpose?: string` fields to `DebugColliderMetadata`/`DebugColliderRegistration` and `DebugSolidMetadata` types and preserve serialization without exposing Three.js objects.
- Wire these fields into collider registration and mesh `userData.colliderDebug`, and extract solid source metadata from `object.userData.levelSourceId` and `object.userData.levelSource` during `createSolidVisualizer` registration.
- Add lookup helpers `getColliderBySourceId`, `getCollidersBySourceId`, `getSolidBySourceId`, and `getSolidsBySourceId`, and proxy them via `window.portfolio.debugColliders` and `window.portfolio.debugSolids`.
- Add cloning helpers so returned metadata is safe/serializable and update tests and docs to describe the new downstream source-metadata bridge while explicitly not altering debug-ID seed logic.

### Testing
- Ran formatting with `npm run format:write` which completed successfully.
- Ran lint with `npm run lint` which passed with no errors.
- Ran focused unit tests with `npm run test:ci -- src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` and both test files passed (`20` and `15` tests respectively) and the newly-added tests for source metadata succeeded.
- Ran full test suite with `npm run test:ci` which completed successfully (all tests passed in CI run reported: 1138 tests passed).
- Built the app with `npm run build` which succeeded, ran `npm run docs:check` which passed (link checker emitted external fetch warnings but exited successfully), and ran `npm run smoke` which passed.
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31a1af2144832f913c9a19752dcdf3)