### PR TITLE
Expose debug source metadata

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -204,6 +204,13 @@ with no empty segments, whitespace, or slash-style paths, and
 `getLevelSourceDebugRef(...)` provides deterministic short uppercase hex
 references for future debug metadata without changing current visible debug IDs.
 
+Debug collider and solid APIs now expose optional `sourceId`, `sourceType`, and
+`purpose` fields alongside the existing compact hex labels. These fields are
+metadata-only: they are not part of the visible debug ID seed, label text, wall
+or floor geometry, movement behavior, or collision behavior. Use them to trace a
+downstream collider or solid back to its authoritative source item while keeping
+the compact hex IDs as screenshot-friendly downstream labels during migration.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/src/main.ts
+++ b/src/main.ts
@@ -619,12 +619,18 @@ declare global {
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+        getColliderBySourceId(
+          sourceId: unknown
+        ): DebugColliderMetadata | undefined;
+        getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
       };
       debugSolids?: {
         getState(): DebugSolidVisualizerState;
         setEnabled(enabled: boolean): void;
         getSolids(): DebugSolidMetadata[];
         getSolidById(id: unknown): DebugSolidMetadata | undefined;
+        getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+        getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
       };
       debugPerformance?: {
         getState(): DebugPerformanceState;
@@ -4987,6 +4993,10 @@ function initializeImmersiveScene(
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+    getColliderBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getColliderBySourceId(sourceId),
+    getCollidersBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getCollidersBySourceId(sourceId),
   };
 
   window.portfolio.debugSolids = {
@@ -5001,6 +5011,14 @@ function initializeImmersiveScene(
     getSolidById: (id: unknown) => {
       ensureSolidVisualizerRegistered();
       return solidVisualizer.getSolidById(id);
+    },
+    getSolidBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidBySourceId(sourceId);
+    },
+    getSolidsBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidsBySourceId(sourceId);
     },
   };
 

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -243,6 +243,68 @@ describe('createColliderVisualizer', () => {
     expect(labelMaterial.depthWrite).toBe(false);
   });
 
+  it('registers source metadata and supports source ID lookups', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'source-wall-a',
+        bounds: collider,
+        sourceId: 'ground.living_room.north_wall',
+        sourceType: 'wall',
+        purpose: 'room boundary',
+      },
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'source-wall-b',
+        bounds: { minX: 4, maxX: 5, minZ: 6, maxZ: 7 },
+        sourceId: 'ground.living_room.north_wall',
+        sourceType: 'wall',
+        purpose: 'split collider segment',
+      },
+    ]);
+
+    const colliders = visualizer.getColliders();
+
+    expect(colliders[0]).toMatchObject({
+      sourceId: 'ground.living_room.north_wall',
+      sourceType: 'wall',
+      purpose: 'room boundary',
+    });
+    expect(
+      visualizer.getColliderBySourceId('ground.living_room.north_wall')
+    ).toEqual(colliders[0]);
+    expect(
+      visualizer.getCollidersBySourceId('ground.living_room.north_wall')
+    ).toEqual(colliders);
+    expect(visualizer.getColliderBySourceId('')).toBeUndefined();
+    expect(visualizer.getColliderBySourceId(1234)).toBeUndefined();
+    expect(visualizer.getCollidersBySourceId('missing')).toEqual([]);
+  });
+
+  it('keeps visible IDs unchanged when registrations add no source metadata', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    const registration = {
+      floor: 'ground' as const,
+      category: 'walls',
+      name: 'stable-without-source-id',
+      bounds: collider,
+    };
+
+    visualizer.register([registration]);
+
+    expect(visualizer.getColliders()[0]).toEqual({
+      id: createColliderDebugId(registration),
+      floor: 'ground',
+      category: 'walls',
+      name: 'stable-without-source-id',
+      bounds: collider,
+    });
+  });
+
   it('hides collider ID labels independently from wireframes', () => {
     const visualizer = createColliderVisualizer({
       activeFloorId: 'ground',

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -74,6 +74,69 @@ describe('createSolidVisualizer', () => {
     expect(visualizer.getSolids()[0].bounds.min.x).not.toBe(99);
   });
 
+  it('reads levelSourceId metadata and supports source ID lookups', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const first = createSolid('WallPartA');
+    first.userData.levelSourceId = 'ground.living_room.north_wall';
+    const second = createSolid('WallPartB');
+    second.userData.levelSourceId = 'ground.living_room.north_wall';
+    scene.add(first, second);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const solids = visualizer.getSolids();
+
+    expect(solids).toHaveLength(2);
+    expect(
+      solids.every(
+        (solid) => solid.sourceId === 'ground.living_room.north_wall'
+      )
+    ).toBe(true);
+    expect(
+      visualizer.getSolidBySourceId('ground.living_room.north_wall')
+    ).toEqual(solids[0]);
+    expect(
+      visualizer.getSolidsBySourceId('ground.living_room.north_wall')
+    ).toEqual(solids);
+    expect(visualizer.getSolidBySourceId('')).toBeUndefined();
+    expect(visualizer.getSolidBySourceId(1234)).toBeUndefined();
+    expect(visualizer.getSolidsBySourceId('missing')).toEqual([]);
+  });
+
+  it('reads structured levelSource metadata without changing source-less metadata', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const sourced = createSolid('LandingGuard');
+    sourced.userData.levelSource = {
+      sourceId: 'upper.stairwell.landing_guard',
+      sourceType: 'safety_collider',
+      purpose: 'prevent stairwell falls',
+    };
+    const ordinary = createSolid('OrdinarySceneWall');
+    scene.add(sourced, ordinary);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const sourcedMetadata = visualizer.getSolidBySourceId(
+      'upper.stairwell.landing_guard'
+    );
+    const ordinaryMetadata = visualizer
+      .getSolids()
+      .find((solid) => solid.name === 'OrdinarySceneWall');
+
+    expect(sourcedMetadata).toMatchObject({
+      sourceId: 'upper.stairwell.landing_guard',
+      sourceType: 'safety_collider',
+      purpose: 'prevent stairwell falls',
+    });
+    expect(ordinaryMetadata).not.toHaveProperty('sourceId');
+    expect(ordinaryMetadata).not.toHaveProperty('sourceType');
+    expect(ordinaryMetadata).not.toHaveProperty('purpose');
+  });
+
   it('creates matching non-raycasting debug wireframes and labels without ID collisions', () => {
     const scene = new Group();
     scene.name = 'Scene';

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -31,6 +31,9 @@ export interface DebugColliderMetadata {
   category: string;
   name: string;
   bounds: RectCollider;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderRegistration {
@@ -41,6 +44,9 @@ export interface DebugColliderRegistration {
   elevation?: number;
   height?: number;
   color?: ColorRepresentation;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderVisualizerState {
@@ -67,6 +73,8 @@ export interface ColliderVisualizer {
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
   getColliderById(id: unknown): DebugColliderMetadata | undefined;
+  getColliderBySourceId(sourceId: unknown): DebugColliderMetadata | undefined;
+  getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
   dispose(): void;
 }
 
@@ -88,6 +96,24 @@ export const DEBUG_LABEL_PALETTE = [
   '#BD93F9',
   '#FFB86C',
 ];
+const cloneOptionalMetadataString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const withOptionalSourceMetadata = <T extends object>(
+  base: T,
+  metadata: { sourceId?: unknown; sourceType?: unknown; purpose?: unknown }
+): T & Pick<DebugColliderMetadata, 'sourceId' | 'sourceType' | 'purpose'> => {
+  const sourceId = cloneOptionalMetadataString(metadata.sourceId);
+  const sourceType = cloneOptionalMetadataString(metadata.sourceType);
+  const purpose = cloneOptionalMetadataString(metadata.purpose);
+  return {
+    ...base,
+    ...(sourceId ? { sourceId } : {}),
+    ...(sourceType ? { sourceType } : {}),
+    ...(purpose ? { purpose } : {}),
+  };
+};
+
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
   minX: bounds.minX,
   maxX: bounds.maxX,
@@ -342,12 +368,17 @@ export function createColliderVisualizer(options: {
 
   const register = (colliders: readonly DebugColliderRegistration[]) => {
     const existingIds = new Set(entries.map((entry) => entry.metadata.id));
-    const metadataWithoutIds = colliders.map((collider) => ({
-      floor: collider.floor,
-      category: collider.category,
-      name: collider.name,
-      bounds: cloneBounds(collider.bounds),
-    }));
+    const metadataWithoutIds = colliders.map((collider) =>
+      withOptionalSourceMetadata(
+        {
+          floor: collider.floor,
+          category: collider.category,
+          name: collider.name,
+          bounds: cloneBounds(collider.bounds),
+        },
+        collider
+      )
+    );
     const nextIds = allocateColliderDebugIds(metadataWithoutIds, existingIds);
 
     for (const [colliderIndex, collider] of colliders.entries()) {
@@ -393,6 +424,9 @@ export function createColliderVisualizer(options: {
         floor: collider.floor,
         category: collider.category,
         name: collider.name,
+        sourceId: metadataWithoutId.sourceId,
+        sourceType: metadataWithoutId.sourceType,
+        purpose: metadataWithoutId.purpose,
       };
       mesh.raycast = () => undefined;
 
@@ -425,13 +459,24 @@ export function createColliderVisualizer(options: {
 
   const cloneMetadata = (
     metadata: DebugColliderMetadata
-  ): DebugColliderMetadata => ({
-    id: metadata.id,
-    floor: metadata.floor,
-    category: metadata.category,
-    name: metadata.name,
-    bounds: cloneBounds(metadata.bounds),
-  });
+  ): DebugColliderMetadata =>
+    withOptionalSourceMetadata(
+      {
+        id: metadata.id,
+        floor: metadata.floor,
+        category: metadata.category,
+        name: metadata.name,
+        bounds: cloneBounds(metadata.bounds),
+      },
+      metadata
+    );
+
+  const findEntriesBySourceId = (sourceId: unknown) => {
+    if (typeof sourceId !== 'string' || sourceId.length === 0) {
+      return [];
+    }
+    return entries.filter((entry) => entry.metadata.sourceId === sourceId);
+  };
 
   return {
     group,
@@ -468,6 +513,15 @@ export function createColliderVisualizer(options: {
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getColliderBySourceId(sourceId: unknown) {
+      const [entry] = findEntriesBySourceId(sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getCollidersBySourceId(sourceId: unknown) {
+      return findEntriesBySourceId(sourceId).map((entry) =>
+        cloneMetadata(entry.metadata)
+      );
     },
     dispose() {
       for (const entry of entries) {

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -39,6 +39,9 @@ export interface DebugSolidMetadata {
   meshType: string;
   bounds: DebugSolidBounds;
   material?: string;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugSolidVisualizerState {
@@ -63,6 +66,8 @@ export interface SolidVisualizer {
   getState(): DebugSolidVisualizerState;
   getSolids(): DebugSolidMetadata[];
   getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+  getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
   update(): void;
   dispose(): void;
 }
@@ -70,6 +75,8 @@ export interface SolidVisualizer {
 const DEBUG_SOLID_PRIMARY_SALT = 'debug-solid-id:v1';
 
 const round = (value: number): number => roundDebugValue(value);
+const getOptionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
 const format = (value: number): string =>
   round(value).toFixed(DEBUG_ID_PRECISION);
 
@@ -174,6 +181,22 @@ const getObjectPath = (object: Object3D): string => {
     current = current.parent;
   }
   return parts.reverse().join('/');
+};
+
+const getLevelSourceMetadata = (object: Object3D) => {
+  const levelSource = object.userData.levelSource;
+  const sourceRecord =
+    typeof levelSource === 'object' && levelSource !== null ? levelSource : {};
+  const sourceId =
+    getOptionalString(object.userData.levelSourceId) ??
+    getOptionalString(sourceRecord.sourceId);
+  const sourceType = getOptionalString(sourceRecord.sourceType);
+  const purpose = getOptionalString(sourceRecord.purpose);
+  return {
+    ...(sourceId ? { sourceId } : {}),
+    ...(sourceType ? { sourceType } : {}),
+    ...(purpose ? { purpose } : {}),
+  };
 };
 
 const cloneBounds = (bounds: DebugSolidBounds): DebugSolidBounds => ({
@@ -312,6 +335,13 @@ export const createSolidVisualizer = (
     });
   };
 
+  const findEntriesBySourceId = (sourceId: unknown) => {
+    if (typeof sourceId !== 'string' || sourceId.length === 0) {
+      return [];
+    }
+    return entries.filter((entry) => entry.metadata.sourceId === sourceId);
+  };
+
   const clear = () => {
     entries.forEach((entry) => {
       group.remove(entry.wireframe, entry.label);
@@ -354,6 +384,7 @@ export const createSolidVisualizer = (
         meshType: object.type,
         bounds,
         material: getMaterialSummary(object.material),
+        ...getLevelSourceMetadata(object),
       };
       meshes.push({
         mesh: object,
@@ -462,6 +493,15 @@ export const createSolidVisualizer = (
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidBySourceId(sourceId: unknown) {
+      const [entry] = findEntriesBySourceId(sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidsBySourceId(sourceId: unknown) {
+      return findEntriesBySourceId(sourceId).map((entry) =>
+        cloneMetadata(entry.metadata)
+      );
     },
     update() {
       if (!enabled) {


### PR DESCRIPTION
### Motivation
- Continue the declarative level migration by exposing semantic source provenance for downstream debug artifacts while keeping current compact debug IDs and runtime geometry unchanged.
- Allow editors and tooling to point at authoritative source items (sourceId/sourceType/purpose) instead of reverse-engineering from hex debug labels.

### Description
- Added optional `sourceId?: string`, `sourceType?: string`, and `purpose?: string` fields to `DebugColliderMetadata`/`DebugColliderRegistration` and `DebugSolidMetadata` types and preserved all existing fields and behavior.
- Propagated collider registration metadata into `mesh.userData.colliderDebug` and cloned/returned serializable metadata copies (no Three.js objects exposed) via `getColliders()`/`getSolids()`.
- Added lookup helpers `getColliderBySourceId`, `getCollidersBySourceId`, `getSolidBySourceId`, and `getSolidsBySourceId` and wired them through `window.portfolio.debugColliders` and `window.portfolio.debugSolids` proxies.
- Extracted solid source metadata from `object.userData.levelSourceId` and `object.userData.levelSource` (structured record) in `solidVisualizer` without affecting visible hex solid IDs.
- Documented the change in `docs/design/declarative-level-source-of-truth.md` and added focused tests for metadata propagation and lookup while preserving existing behavior.

### Testing
- Ran formatting: `npm run format:write` (ran successfully).
- Lint: `npm run lint` (passed).
- Focused test run: `npm run test:ci -- src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` (both test files passed).
- Full test suite: `npm run test:ci` (all tests passed; full suite reported 149 test files, 1137 tests passing).
- Build: `npm run build` (production build succeeded with standard chunk-size warnings only).
- Docs check: `npm run docs:check` (passed; link checker emitted network fetch warnings but completed successfully).
- Smoke: `npm run smoke` (passed).
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).

All automated checks listed above completed successfully; the change is limited to debug metadata, lookups, docs, and tests and does not change visible debug ID generation, mesh geometry, collision behavior, or overlay appearance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31a1caf6e8832f97d4d95279fbe6a7)