### PR TITLE
🔎 : – expose debug source metadata

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -192,8 +192,11 @@ Source ID guidance:
   pieces.
 
 Short hex IDs may remain as debug display references for screenshot readability
-or compact overlays, but they are downstream labels. Debug labels should point
-back to semantic source IDs rather than becoming the source of truth.
+or compact overlays, but they are downstream labels. Debug APIs now expose
+optional `sourceId`, `sourceType`, and `purpose` metadata for colliders and
+solids so DevTools and future inventory reports can resolve a compact visible
+label back to its authoritative source object without changing label text or
+geometry.
 
 The foundation helpers for this migration live in
 `src/scene/level/sourceIds.ts`. New source-backed level data should use the

--- a/src/main.ts
+++ b/src/main.ts
@@ -619,12 +619,18 @@ declare global {
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+        getColliderBySourceId(
+          sourceId: unknown
+        ): DebugColliderMetadata | undefined;
+        getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
       };
       debugSolids?: {
         getState(): DebugSolidVisualizerState;
         setEnabled(enabled: boolean): void;
         getSolids(): DebugSolidMetadata[];
         getSolidById(id: unknown): DebugSolidMetadata | undefined;
+        getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+        getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
       };
       debugPerformance?: {
         getState(): DebugPerformanceState;
@@ -4987,6 +4993,10 @@ function initializeImmersiveScene(
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+    getColliderBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getColliderBySourceId(sourceId),
+    getCollidersBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getCollidersBySourceId(sourceId),
   };
 
   window.portfolio.debugSolids = {
@@ -5001,6 +5011,14 @@ function initializeImmersiveScene(
     getSolidById: (id: unknown) => {
       ensureSolidVisualizerRegistered();
       return solidVisualizer.getSolidById(id);
+    },
+    getSolidBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidBySourceId(sourceId);
+    },
+    getSolidsBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidsBySourceId(sourceId);
     },
   };
 

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -682,6 +682,75 @@ describe('createColliderVisualizer', () => {
     ).toBe(exposedLabelName);
   });
 
+  it('returns source metadata copies and supports source ID lookup', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    const wallRegistration = {
+      floor: 'ground' as const,
+      category: 'walls',
+      name: 'source-wall-0',
+      bounds: collider,
+      sourceId: 'ground.living_room.north_wall',
+      sourceType: 'wall',
+      purpose: 'room boundary',
+    };
+    const duplicateRegistration = {
+      ...wallRegistration,
+      name: 'source-wall-1',
+      bounds: { minX: 3, maxX: 4, minZ: 2, maxZ: 5 },
+    };
+
+    visualizer.register([wallRegistration, duplicateRegistration]);
+
+    const sourceMatches = visualizer.getCollidersBySourceId(
+      wallRegistration.sourceId
+    );
+    expect(sourceMatches).toHaveLength(2);
+    expect(sourceMatches[0]).toMatchObject({
+      sourceId: wallRegistration.sourceId,
+      sourceType: 'wall',
+      purpose: 'room boundary',
+    });
+    expect(visualizer.getColliderBySourceId(wallRegistration.sourceId)).toEqual(
+      sourceMatches[0]
+    );
+    sourceMatches[0].bounds.minX = 99;
+    expect(
+      visualizer.getColliderBySourceId(wallRegistration.sourceId)?.bounds.minX
+    ).toBe(collider.minX);
+    expect(visualizer.getColliderBySourceId('')).toBeUndefined();
+    expect(visualizer.getColliderBySourceId(null)).toBeUndefined();
+    expect(visualizer.getCollidersBySourceId('missing')).toEqual([]);
+  });
+
+  it('does not include source metadata in visible collider debug IDs', () => {
+    const visualizerWithoutSource = createColliderVisualizer({
+      activeFloorId: 'ground',
+    });
+    const visualizerWithSource = createColliderVisualizer({
+      activeFloorId: 'ground',
+    });
+    const registration = {
+      floor: 'ground' as const,
+      category: 'walls',
+      name: 'source-id-invariant',
+      bounds: collider,
+    };
+
+    visualizerWithoutSource.register([registration]);
+    visualizerWithSource.register([
+      {
+        ...registration,
+        sourceId: 'ground.study.west_wall',
+        sourceType: 'wall',
+        purpose: 'debug provenance',
+      },
+    ]);
+
+    expect(visualizerWithSource.getColliders()[0].id).toBe(
+      visualizerWithoutSource.getColliders()[0].id
+    );
+  });
+
   it('creates floor-aware labels that toggle with debug collider visibility', () => {
     const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
     visualizer.register([

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -271,6 +271,64 @@ describe('createSolidVisualizer', () => {
     });
   });
 
+  it('reads levelSourceId metadata and supports source ID lookup', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solidA = createSolid('SourceWallA');
+    const solidB = createSolid('SourceWallB');
+    solidB.position.x = 2;
+    solidA.userData.levelSourceId = 'ground.living_room.media_wall';
+    solidB.userData.levelSourceId = 'ground.living_room.media_wall';
+    scene.add(solidA, solidB);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const matches = visualizer.getSolidsBySourceId(
+      'ground.living_room.media_wall'
+    );
+    expect(matches).toHaveLength(2);
+    expect(matches.every((solid) => solid.sourceId)).toBe(true);
+    expect(
+      visualizer.getSolidBySourceId('ground.living_room.media_wall')
+    ).toEqual(matches[0]);
+    matches[0].bounds.min.x = 99;
+    expect(
+      visualizer.getSolidBySourceId('ground.living_room.media_wall')?.bounds.min
+        .x
+    ).not.toBe(99);
+    expect(visualizer.getSolidBySourceId('')).toBeUndefined();
+    expect(visualizer.getSolidBySourceId(null)).toBeUndefined();
+    expect(visualizer.getSolidsBySourceId('missing')).toEqual([]);
+  });
+
+  it('reads structured levelSource metadata without changing solid IDs', () => {
+    const sceneWithoutSource = new Group();
+    sceneWithoutSource.name = 'Scene';
+    sceneWithoutSource.add(createSolid('StructuredSourceWall'));
+    const sceneWithSource = new Group();
+    sceneWithSource.name = 'Scene';
+    const sourcedSolid = createSolid('StructuredSourceWall');
+    sourcedSolid.userData.levelSource = {
+      sourceId: 'upper.loft_library.south_wall.left',
+      sourceType: 'wall',
+      purpose: 'room boundary',
+    };
+    sceneWithSource.add(sourcedSolid);
+
+    const visualizerWithoutSource = createSolidVisualizer({ enabled: true });
+    const visualizerWithSource = createSolidVisualizer({ enabled: true });
+    visualizerWithoutSource.register(sceneWithoutSource);
+    visualizerWithSource.register(sceneWithSource);
+
+    expect(visualizerWithSource.getSolids()[0]).toMatchObject({
+      id: visualizerWithoutSource.getSolids()[0].id,
+      sourceId: 'upper.loft_library.south_wall.left',
+      sourceType: 'wall',
+      purpose: 'room boundary',
+    });
+  });
+
   it('does not duplicate overlays after repeated enable-disable cycles', () => {
     const scene = new Group();
     scene.name = 'Scene';

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -31,6 +31,9 @@ export interface DebugColliderMetadata {
   category: string;
   name: string;
   bounds: RectCollider;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderRegistration {
@@ -41,6 +44,9 @@ export interface DebugColliderRegistration {
   elevation?: number;
   height?: number;
   color?: ColorRepresentation;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderVisualizerState {
@@ -67,6 +73,8 @@ export interface ColliderVisualizer {
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
   getColliderById(id: unknown): DebugColliderMetadata | undefined;
+  getColliderBySourceId(sourceId: unknown): DebugColliderMetadata | undefined;
+  getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
   dispose(): void;
 }
 
@@ -94,6 +102,12 @@ const cloneBounds = (bounds: RectCollider): RectCollider => ({
   minZ: bounds.minZ,
   maxZ: bounds.maxZ,
 });
+
+const copyOptionalString = (value: string | undefined): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const isValidLookupId = (id: unknown): id is string =>
+  typeof id === 'string' && id.length > 0;
 
 const isVisibleOnFloor = (
   colliderFloor: DebugColliderFloor,
@@ -347,6 +361,9 @@ export function createColliderVisualizer(options: {
       category: collider.category,
       name: collider.name,
       bounds: cloneBounds(collider.bounds),
+      sourceId: copyOptionalString(collider.sourceId),
+      sourceType: copyOptionalString(collider.sourceType),
+      purpose: copyOptionalString(collider.purpose),
     }));
     const nextIds = allocateColliderDebugIds(metadataWithoutIds, existingIds);
 
@@ -431,6 +448,9 @@ export function createColliderVisualizer(options: {
     category: metadata.category,
     name: metadata.name,
     bounds: cloneBounds(metadata.bounds),
+    sourceId: metadata.sourceId,
+    sourceType: metadata.sourceType,
+    purpose: metadata.purpose,
   });
 
   return {
@@ -462,12 +482,27 @@ export function createColliderVisualizer(options: {
       return entries.map((entry) => cloneMetadata(entry.metadata));
     },
     getColliderById(id: unknown) {
-      if (typeof id !== 'string' || id.length === 0) {
+      if (!isValidLookupId(id)) {
         return undefined;
       }
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getColliderBySourceId(sourceId: unknown) {
+      if (!isValidLookupId(sourceId)) {
+        return undefined;
+      }
+      const entry = entries.find((next) => next.metadata.sourceId === sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getCollidersBySourceId(sourceId: unknown) {
+      if (!isValidLookupId(sourceId)) {
+        return [];
+      }
+      return entries
+        .filter((entry) => entry.metadata.sourceId === sourceId)
+        .map((entry) => cloneMetadata(entry.metadata));
     },
     dispose() {
       for (const entry of entries) {

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -39,6 +39,9 @@ export interface DebugSolidMetadata {
   meshType: string;
   bounds: DebugSolidBounds;
   material?: string;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugSolidVisualizerState {
@@ -63,11 +66,19 @@ export interface SolidVisualizer {
   getState(): DebugSolidVisualizerState;
   getSolids(): DebugSolidMetadata[];
   getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+  getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
   update(): void;
   dispose(): void;
 }
 
 const DEBUG_SOLID_PRIMARY_SALT = 'debug-solid-id:v1';
+
+const readOptionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const isValidLookupId = (id: unknown): id is string =>
+  typeof id === 'string' && id.length > 0;
 
 const round = (value: number): number => roundDebugValue(value);
 const format = (value: number): string =>
@@ -228,6 +239,24 @@ const getGeometrySignature = (geometry: BufferGeometry): string => {
   return signature;
 };
 
+const getSourceMetadata = (
+  object: Object3D
+): Pick<DebugSolidMetadata, 'sourceId' | 'sourceType' | 'purpose'> => {
+  const levelSource = object.userData.levelSource;
+  const sourceMetadata =
+    levelSource && typeof levelSource === 'object'
+      ? (levelSource as Record<string, unknown>)
+      : undefined;
+
+  return {
+    sourceId:
+      readOptionalString(object.userData.levelSourceId) ??
+      readOptionalString(sourceMetadata?.sourceId),
+    sourceType: readOptionalString(sourceMetadata?.sourceType),
+    purpose: readOptionalString(sourceMetadata?.purpose),
+  };
+};
+
 const getMaterialSummary = (
   material: Material | Material[]
 ): string | undefined => {
@@ -354,6 +383,7 @@ export const createSolidVisualizer = (
         meshType: object.type,
         bounds,
         material: getMaterialSummary(object.material),
+        ...getSourceMetadata(object),
       };
       meshes.push({
         mesh: object,
@@ -456,12 +486,27 @@ export const createSolidVisualizer = (
       return entries.map((entry) => cloneMetadata(entry.metadata));
     },
     getSolidById(id: unknown) {
-      if (typeof id !== 'string' || id.length === 0) {
+      if (!isValidLookupId(id)) {
         return undefined;
       }
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidBySourceId(sourceId: unknown) {
+      if (!isValidLookupId(sourceId)) {
+        return undefined;
+      }
+      const entry = entries.find((next) => next.metadata.sourceId === sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidsBySourceId(sourceId: unknown) {
+      if (!isValidLookupId(sourceId)) {
+        return [];
+      }
+      return entries
+        .filter((entry) => entry.metadata.sourceId === sourceId)
+        .map((entry) => cloneMetadata(entry.metadata));
     },
     update() {
       if (!enabled) {


### PR DESCRIPTION
### Motivation
- Surface upstream semantic provenance for debug overlays so downstream hex IDs remain compact screenshot anchors while DevTools and future tooling can resolve authoritative source objects.
- Prepare the declarative level migration by plumbing optional `sourceId`/`sourceType`/`purpose` through debug metadata without changing geometry or visible labels.

### Description
- Add optional `sourceId?: string`, `sourceType?: string`, and `purpose?: string` fields to `DebugColliderMetadata` / `DebugColliderRegistration` and to `DebugSolidMetadata`, and preserve all existing fields and behavior.
- Thread source metadata into collider registration and solid extraction (solids read `object.userData.levelSourceId` and structured `object.userData.levelSource`) and ensure returned metadata are cloned/serializable and do not expose Three.js objects.
- Add lookup helpers `getColliderBySourceId`, `getCollidersBySourceId`, `getSolidBySourceId`, and `getSolidsBySourceId`, and wire them through the existing `window.portfolio.debugColliders` and `window.portfolio.debugSolids` proxies.
- Update docs to note debug APIs now expose optional source provenance and add tests that assert metadata extraction, source-ID lookups, duplicate-source matches, and that visible debug IDs remain unchanged.

### Testing
- Ran formatting: `npm run format:write` which completed successfully.
- Ran lint: `npm run lint` which completed successfully.
- Ran focused tests: `npm run test:ci -- src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` and the targeted tests passed.
- Ran full test suite: `npm run test:ci` and all tests passed (`1137` tests in the CI run reported passing in this environment).
- Built and smoke-checked: `npm run build`, `npm run docs:check`, and `npm run smoke` all completed successfully (docs link checker produced external fetch warnings but the docs check passed); also ran `./scripts/scan-secrets.py` which found no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31a1d269f4832f97e24390fb81fb10)