### PR TITLE
Expose debug source metadata for colliders & solids

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -204,6 +204,13 @@ with no empty segments, whitespace, or slash-style paths, and
 `getLevelSourceDebugRef(...)` provides deterministic short uppercase hex
 references for future debug metadata without changing current visible debug IDs.
 
+Current debug visualizer APIs now accept and return optional source provenance
+for this migration phase. Debug collider registrations may include `sourceId`,
+`sourceType`, and `purpose`; debug solids read the same semantic fields from
+`object.userData.levelSourceId` or `object.userData.levelSource`. The visible
+hex debug IDs and label text remain downstream labels, while the source metadata
+is exposed through lookup helpers for future inventory and editor workflows.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/src/main.ts
+++ b/src/main.ts
@@ -619,12 +619,18 @@ declare global {
           floorId?: FloorId;
         }): DebugColliderMetadata[];
         getColliderById(id: unknown): DebugColliderMetadata | undefined;
+        getColliderBySourceId(
+          sourceId: unknown
+        ): DebugColliderMetadata | undefined;
+        getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
       };
       debugSolids?: {
         getState(): DebugSolidVisualizerState;
         setEnabled(enabled: boolean): void;
         getSolids(): DebugSolidMetadata[];
         getSolidById(id: unknown): DebugSolidMetadata | undefined;
+        getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+        getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
       };
       debugPerformance?: {
         getState(): DebugPerformanceState;
@@ -4987,6 +4993,10 @@ function initializeImmersiveScene(
     getColliders: () => colliderVisualizer.getColliders(),
     getBlockingCollidersAt: getBlockingDebugCollidersAt,
     getColliderById: (id: unknown) => colliderVisualizer.getColliderById(id),
+    getColliderBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getColliderBySourceId(sourceId),
+    getCollidersBySourceId: (sourceId: unknown) =>
+      colliderVisualizer.getCollidersBySourceId(sourceId),
   };
 
   window.portfolio.debugSolids = {
@@ -5001,6 +5011,14 @@ function initializeImmersiveScene(
     getSolidById: (id: unknown) => {
       ensureSolidVisualizerRegistered();
       return solidVisualizer.getSolidById(id);
+    },
+    getSolidBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidBySourceId(sourceId);
+    },
+    getSolidsBySourceId: (sourceId: unknown) => {
+      ensureSolidVisualizerRegistered();
+      return solidVisualizer.getSolidsBySourceId(sourceId);
     },
   };
 

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -243,6 +243,72 @@ describe('createColliderVisualizer', () => {
     expect(labelMaterial.depthWrite).toBe(false);
   });
 
+  it('exposes optional source metadata without changing visible debug IDs', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    const expectedId = createColliderDebugId({
+      floor: 'ground',
+      category: 'walls',
+      name: 'source-wall',
+      bounds: collider,
+    });
+
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'source-wall',
+        bounds: collider,
+        sourceId: 'wall:living-room:north',
+        sourceType: 'wall',
+        purpose: 'collision',
+      },
+    ]);
+
+    expect(visualizer.getColliders()[0]).toEqual({
+      id: expectedId,
+      floor: 'ground',
+      category: 'walls',
+      name: 'source-wall',
+      bounds: collider,
+      sourceId: 'wall:living-room:north',
+      sourceType: 'wall',
+      purpose: 'collision',
+    });
+    expect(visualizer.getColliderBySourceId('wall:living-room:north')).toEqual(
+      visualizer.getColliders()[0]
+    );
+  });
+
+  it('returns all collider metadata matches for duplicate source IDs', () => {
+    const visualizer = createColliderVisualizer({ activeFloorId: 'ground' });
+    visualizer.register([
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'source-wall-a',
+        bounds: collider,
+        sourceId: 'wall:shared',
+      },
+      {
+        floor: 'ground',
+        category: 'walls',
+        name: 'source-wall-b',
+        bounds: { minX: 5, maxX: 6, minZ: 7, maxZ: 8 },
+        sourceId: 'wall:shared',
+      },
+    ]);
+
+    expect(
+      visualizer
+        .getCollidersBySourceId('wall:shared')
+        .map((entry) => entry.name)
+    ).toEqual(['source-wall-a', 'source-wall-b']);
+    expect(visualizer.getColliderBySourceId('')).toBeUndefined();
+    expect(visualizer.getColliderBySourceId(null)).toBeUndefined();
+    expect(visualizer.getCollidersBySourceId('missing')).toEqual([]);
+    expect(visualizer.getCollidersBySourceId(1234)).toEqual([]);
+  });
+
   it('hides collider ID labels independently from wireframes', () => {
     const visualizer = createColliderVisualizer({
       activeFloorId: 'ground',

--- a/src/scene/debug/__tests__/solidVisualizer.test.ts
+++ b/src/scene/debug/__tests__/solidVisualizer.test.ts
@@ -74,6 +74,73 @@ describe('createSolidVisualizer', () => {
     expect(visualizer.getSolids()[0].bounds.min.x).not.toBe(99);
   });
 
+  it('reads levelSourceId userData and looks up solid metadata by source ID', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solid = createSolid('SourceWall');
+    solid.userData.levelSourceId = 'wall:gallery:east';
+    scene.add(solid);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    expect(visualizer.getSolids()[0]).toMatchObject({
+      name: 'SourceWall',
+      sourceId: 'wall:gallery:east',
+    });
+    expect(visualizer.getSolidBySourceId('wall:gallery:east')).toEqual(
+      visualizer.getSolids()[0]
+    );
+    expect(visualizer.getSolidsBySourceId('wall:gallery:east')).toEqual([
+      visualizer.getSolids()[0],
+    ]);
+  });
+
+  it('reads nested levelSource userData metadata without changing solid IDs', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    const solid = createSolid('NestedSourceWall');
+    solid.userData.levelSource = {
+      sourceId: 'floor:studio:main',
+      sourceType: 'floor-surface',
+      purpose: 'rendering',
+    };
+    scene.add(solid);
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    const [solidMetadata] = visualizer.getSolids();
+    const comparisonScene = new Group();
+    comparisonScene.name = 'Scene';
+    comparisonScene.add(createSolid('NestedSourceWall'));
+    const comparisonVisualizer = createSolidVisualizer({ enabled: true });
+    comparisonVisualizer.register(comparisonScene);
+
+    const { sourceId, sourceType, purpose } = solidMetadata;
+    expect(solidMetadata.id).toBe(comparisonVisualizer.getSolids()[0].id);
+    expect({ sourceId, sourceType, purpose }).toEqual({
+      sourceId: 'floor:studio:main',
+      sourceType: 'floor-surface',
+      purpose: 'rendering',
+    });
+  });
+
+  it('keeps objects without source IDs compatible with existing lookups', () => {
+    const scene = new Group();
+    scene.name = 'Scene';
+    scene.add(createSolid('OrdinaryWall'));
+
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(scene);
+
+    expect(visualizer.getSolids()[0]).not.toHaveProperty('sourceId');
+    expect(visualizer.getSolidBySourceId('')).toBeUndefined();
+    expect(visualizer.getSolidBySourceId(null)).toBeUndefined();
+    expect(visualizer.getSolidBySourceId('missing')).toBeUndefined();
+    expect(visualizer.getSolidsBySourceId(1234)).toEqual([]);
+  });
+
   it('creates matching non-raycasting debug wireframes and labels without ID collisions', () => {
     const scene = new Group();
     scene.name = 'Scene';

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -31,6 +31,9 @@ export interface DebugColliderMetadata {
   category: string;
   name: string;
   bounds: RectCollider;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderRegistration {
@@ -41,6 +44,9 @@ export interface DebugColliderRegistration {
   elevation?: number;
   height?: number;
   color?: ColorRepresentation;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugColliderVisualizerState {
@@ -67,6 +73,8 @@ export interface ColliderVisualizer {
   getState(): DebugColliderVisualizerState;
   getColliders(): DebugColliderMetadata[];
   getColliderById(id: unknown): DebugColliderMetadata | undefined;
+  getColliderBySourceId(sourceId: unknown): DebugColliderMetadata | undefined;
+  getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
   dispose(): void;
 }
 
@@ -88,6 +96,31 @@ export const DEBUG_LABEL_PALETTE = [
   '#BD93F9',
   '#FFB86C',
 ];
+const normalizeSourceMetadataValue = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const getRegistrationSourceMetadata = (
+  collider: DebugColliderRegistration
+): Pick<DebugColliderMetadata, 'sourceId' | 'sourceType' | 'purpose'> => {
+  const metadata: Pick<
+    DebugColliderMetadata,
+    'sourceId' | 'sourceType' | 'purpose'
+  > = {};
+  const sourceId = normalizeSourceMetadataValue(collider.sourceId);
+  const sourceType = normalizeSourceMetadataValue(collider.sourceType);
+  const purpose = normalizeSourceMetadataValue(collider.purpose);
+  if (sourceId) {
+    metadata.sourceId = sourceId;
+  }
+  if (sourceType) {
+    metadata.sourceType = sourceType;
+  }
+  if (purpose) {
+    metadata.purpose = purpose;
+  }
+  return metadata;
+};
+
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
   minX: bounds.minX,
   maxX: bounds.maxX,
@@ -347,6 +380,7 @@ export function createColliderVisualizer(options: {
       category: collider.category,
       name: collider.name,
       bounds: cloneBounds(collider.bounds),
+      ...getRegistrationSourceMetadata(collider),
     }));
     const nextIds = allocateColliderDebugIds(metadataWithoutIds, existingIds);
 
@@ -393,6 +427,9 @@ export function createColliderVisualizer(options: {
         floor: collider.floor,
         category: collider.category,
         name: collider.name,
+        sourceId: metadataWithoutId.sourceId,
+        sourceType: metadataWithoutId.sourceType,
+        purpose: metadataWithoutId.purpose,
       };
       mesh.raycast = () => undefined;
 
@@ -431,6 +468,9 @@ export function createColliderVisualizer(options: {
     category: metadata.category,
     name: metadata.name,
     bounds: cloneBounds(metadata.bounds),
+    ...(metadata.sourceId ? { sourceId: metadata.sourceId } : {}),
+    ...(metadata.sourceType ? { sourceType: metadata.sourceType } : {}),
+    ...(metadata.purpose ? { purpose: metadata.purpose } : {}),
   });
 
   return {
@@ -468,6 +508,21 @@ export function createColliderVisualizer(options: {
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getColliderBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return undefined;
+      }
+      const entry = entries.find((next) => next.metadata.sourceId === sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getCollidersBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return [];
+      }
+      return entries
+        .filter((entry) => entry.metadata.sourceId === sourceId)
+        .map((entry) => cloneMetadata(entry.metadata));
     },
     dispose() {
       for (const entry of entries) {

--- a/src/scene/debug/solidVisualizer.ts
+++ b/src/scene/debug/solidVisualizer.ts
@@ -39,6 +39,9 @@ export interface DebugSolidMetadata {
   meshType: string;
   bounds: DebugSolidBounds;
   material?: string;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 }
 
 export interface DebugSolidVisualizerState {
@@ -63,11 +66,16 @@ export interface SolidVisualizer {
   getState(): DebugSolidVisualizerState;
   getSolids(): DebugSolidMetadata[];
   getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+  getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
   update(): void;
   dispose(): void;
 }
 
 const DEBUG_SOLID_PRIMARY_SALT = 'debug-solid-id:v1';
+
+const normalizeSourceMetadataValue = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
 
 const round = (value: number): number => roundDebugValue(value);
 const format = (value: number): string =>
@@ -165,6 +173,42 @@ const hasFiniteBounds = (bounds: DebugSolidBounds): boolean =>
   Number.isFinite(bounds.max.x) &&
   Number.isFinite(bounds.max.y) &&
   Number.isFinite(bounds.max.z);
+
+const getObjectSourceMetadata = (object: Object3D) => {
+  const levelSource = object.userData.levelSource;
+  const metadata: Pick<
+    DebugSolidMetadata,
+    'sourceId' | 'sourceType' | 'purpose'
+  > = {};
+  const sourceId =
+    normalizeSourceMetadataValue(object.userData.levelSourceId) ??
+    (levelSource && typeof levelSource === 'object'
+      ? normalizeSourceMetadataValue(
+          (levelSource as { sourceId?: unknown }).sourceId
+        )
+      : undefined);
+
+  if (sourceId) {
+    metadata.sourceId = sourceId;
+  }
+
+  if (levelSource && typeof levelSource === 'object') {
+    const sourceType = normalizeSourceMetadataValue(
+      (levelSource as { sourceType?: unknown }).sourceType
+    );
+    const purpose = normalizeSourceMetadataValue(
+      (levelSource as { purpose?: unknown }).purpose
+    );
+    if (sourceType) {
+      metadata.sourceType = sourceType;
+    }
+    if (purpose) {
+      metadata.purpose = purpose;
+    }
+  }
+
+  return metadata;
+};
 
 const getObjectPath = (object: Object3D): string => {
   const parts: string[] = [];
@@ -354,6 +398,7 @@ export const createSolidVisualizer = (
         meshType: object.type,
         bounds,
         material: getMaterialSummary(object.material),
+        ...getObjectSourceMetadata(object),
       };
       meshes.push({
         mesh: object,
@@ -462,6 +507,21 @@ export const createSolidVisualizer = (
       const normalizedId = id.toUpperCase();
       const entry = entries.find((next) => next.metadata.id === normalizedId);
       return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return undefined;
+      }
+      const entry = entries.find((next) => next.metadata.sourceId === sourceId);
+      return entry ? cloneMetadata(entry.metadata) : undefined;
+    },
+    getSolidsBySourceId(sourceId: unknown) {
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return [];
+      }
+      return entries
+        .filter((entry) => entry.metadata.sourceId === sourceId)
+        .map((entry) => cloneMetadata(entry.metadata));
     },
     update() {
       if (!enabled) {


### PR DESCRIPTION
### Motivation
- Surface authoritative source provenance (`sourceId`, `sourceType`, `purpose`) in debug metadata so downstream tools and editors can map debug artifacts back to the declarative source without changing runtime geometry or visible debug IDs.
- Make source metadata discoverable via debugger APIs and DOM proxies to support future inventory, editor, and migration tooling while preserving existing debug-label behavior.

### Description
- Added optional `sourceId?: string`, `sourceType?: string`, and `purpose?: string` to `DebugColliderMetadata`, `DebugColliderRegistration`, and `DebugSolidMetadata` and preserved all existing fields and behaviors.
- Collider registrations now normalize and copy these source fields into registered metadata and `mesh.userData.colliderDebug`, and `cloneMetadata` only includes source fields when present to keep outputs serializable.
- Solid visualizer extracts source provenance from `object.userData.levelSourceId` and `object.userData.levelSource` and includes that data in returned `DebugSolidMetadata` while leaving visible hex IDs unchanged.
- Exposed new lookup helpers `getColliderBySourceId`, `getCollidersBySourceId`, `getSolidBySourceId`, and `getSolidsBySourceId` on the visualizers and wired them through `window.portfolio.debugColliders` and `window.portfolio.debugSolids`.

### Testing
- Formatting was applied with `npm run format:write` and linting passed with `npm run lint`.
- Targeted unit tests were run with `npm run test:ci -- src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/debug/__tests__/solidVisualizer.test.ts` and passed.
- Full test suite was run with `npm run test:ci` and all tests passed.
- Production build, docs check, and smoke were verified with `npm run build`, `npm run docs:check`, and `npm run smoke`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31a1d9c614832fbdaf5294a8607f48)