### PR TITLE
Stabilize generated wall source IDs

### DIFF
--- a/src/assets/floorPlan/wallSegments.ts
+++ b/src/assets/floorPlan/wallSegments.ts
@@ -1,3 +1,7 @@
+import {
+  makeLevelSourceId,
+  type LevelSourceId,
+} from '../../scene/level/sourceIds';
 import type { RectCollider } from '../../systems/collision';
 import {
   getCombinedWallSegments,
@@ -11,6 +15,8 @@ export interface WallSegmentInstance {
   segment: CombinedWallSegment;
   /** Stable identifier for correlating generated meshes with the source segment. */
   segmentId: string;
+  /** Stable semantic source ID for legacy generated wall/fence segments. */
+  sourceId: LevelSourceId;
   center: { x: number; y: number; z: number };
   dimensions: { width: number; height: number; depth: number };
   collider: RectCollider;
@@ -28,6 +34,8 @@ export interface WallSegmentOptions {
   wallThickness: number;
   fenceHeight: number;
   fenceThickness: number;
+  /** Floor/level namespace for source IDs generated from legacy wall data. */
+  floorId?: string;
   /** Additional overlap factor for interior segments to hide seams. */
   interiorExtensionFactor?: number;
   /** Additional overlap factor for exterior segments to prevent light leaks. */
@@ -69,7 +77,7 @@ export function createWallSegmentInstances(
   const segments = getCombinedWallSegments(plan);
   const instances: WallSegmentInstance[] = [];
 
-  segments.forEach((segment, index) => {
+  segments.forEach((segment) => {
     const length =
       segment.orientation === 'horizontal'
         ? Math.abs(segment.end.x - segment.start.x)
@@ -135,7 +143,8 @@ export function createWallSegmentInstances(
 
     instances.push({
       segment,
-      segmentId: createSegmentId(segment, index),
+      segmentId: createSegmentId(segment),
+      sourceId: createWallSegmentSourceId(segment, options.floorId),
       center,
       dimensions: { width, height, depth },
       collider,
@@ -152,12 +161,53 @@ function formatPoint(point: { x: number; z: number }): string {
   return `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
 }
 
-function createSegmentId(segment: CombinedWallSegment, index: number): string {
+function formatSourceCoordinate(value: number): string {
+  const normalized = Object.is(value, -0) ? 0 : value;
+  return normalized.toFixed(3).replace('-', 'm').replace('.', 'p');
+}
+
+function formatSourcePoint(point: { x: number; z: number }): string {
+  return `x${formatSourceCoordinate(point.x)}_z${formatSourceCoordinate(point.z)}`;
+}
+
+function slugSourcePart(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function formatSourceRooms(segment: CombinedWallSegment): string {
+  const rooms = segment.rooms
+    .map((room) => `${slugSourcePart(room.id)}-${room.wall}`)
+    .sort();
+
+  return rooms.length > 0 ? rooms.join('_') : 'none';
+}
+
+function createSegmentId(segment: CombinedWallSegment): string {
   const start = formatPoint(segment.start);
   const end = formatPoint(segment.end);
   const rooms = segment.rooms
     .map((room) => `${room.id}:${room.wall}`)
     .sort()
     .join('|');
-  return [segment.orientation, start, end, rooms || 'none', index].join('|');
+  return [segment.orientation, start, end, rooms || 'none'].join('|');
+}
+
+function createWallSegmentSourceId(
+  segment: CombinedWallSegment,
+  floorId = 'level'
+): LevelSourceId {
+  return makeLevelSourceId([
+    slugSourcePart(floorId),
+    'generated-walls',
+    segment.orientation,
+    formatSourcePoint(segment.start),
+    'to',
+    formatSourcePoint(segment.end),
+    'rooms',
+    formatSourceRooms(segment),
+  ]);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -975,24 +975,14 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
+const colliderSourceMetadata = new Map<
+  RectCollider,
+  { sourceId: string; sourceType: 'wall' }
+>();
 const upperFloorColliders: RectCollider[] = [];
 
-const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
-  `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-
-const getUpperWallSegmentDebugName = (
-  instance: WallSegmentInstance
-): string => {
-  const { segment } = instance;
-  const start = formatUpperWallDebugPoint(segment.start);
-  const end = formatUpperWallDebugPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-
-  return `UpperWallSegment:${segment.orientation}|${start}|${end}|${rooms || 'none'}`;
-};
+const getUpperWallSegmentDebugName = (instance: WallSegmentInstance): string =>
+  `UpperWallSegment:${instance.sourceId}`;
 
 const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
@@ -1870,6 +1860,7 @@ function initializeImmersiveScene(
   fenceMaterial.lightMap = interiorLightmaps.wall;
   fenceMaterial.lightMapIntensity = 0.56;
   const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
+    floorId: 'ground',
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -1887,6 +1878,14 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
+    namedColliderDebugNames.set(
+      instance.collider,
+      `GroundWallSegment:${instance.sourceId}`
+    );
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
@@ -2338,6 +2337,7 @@ function initializeImmersiveScene(
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
   const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+    floorId: 'upper',
     baseElevation: upperFloorElevation,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -2360,6 +2360,10 @@ function initializeImmersiveScene(
       instance.collider,
       getUpperWallSegmentDebugName(instance)
     );
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {
@@ -4452,6 +4456,7 @@ function initializeImmersiveScene(
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
+      ...colliderSourceMetadata.get(bounds),
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
+++ b/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
@@ -15,6 +15,8 @@ function createWallInstance(
       rooms: [{ id: 'livingRoom', wall: 'north' }],
     },
     segmentId: 'segment-default',
+    sourceId:
+      'ground.generated-walls.horizontal.x0p000_z0p000.to.x4p000_z0p000.rooms.living-room-north' as WallSegmentInstance['sourceId'],
     center: { x: 2, y: 3, z: 0 },
     dimensions: { width: 4, height: 6, depth: 0.5 },
     collider: { minX: 0, maxX: 4, minZ: -0.25, maxZ: 0.25 },
@@ -33,6 +35,8 @@ describe('createWallSegmentMeshes', () => {
       createWallInstance({
         center: { x: -2, y: 3, z: 1 },
         segmentId: 'segment-vertical',
+        sourceId:
+          'ground.generated-walls.vertical.xm3p000_z0p000.to.xm3p000_z2p000.rooms.kitchen-east' as WallSegmentInstance['sourceId'],
         segment: {
           orientation: 'vertical',
           start: { x: -3, z: 0 },
@@ -48,6 +52,8 @@ describe('createWallSegmentMeshes', () => {
         isFence: true,
         thickness: 0.28,
         segmentId: 'segment-horizontal',
+        sourceId:
+          'ground.generated-walls.horizontal.x4p500_zm5p500.to.x7p500_zm5p500.rooms.backyard-south' as WallSegmentInstance['sourceId'],
         segment: {
           orientation: 'horizontal',
           start: { x: 4.5, z: -5.5 },
@@ -58,11 +64,10 @@ describe('createWallSegmentMeshes', () => {
       }),
     ];
 
-    const getMaterial = vi
-      .fn<(instance: WallSegmentInstance) => MeshBasicMaterial>()
-      .mockImplementation((instance) =>
+    const getMaterial = vi.fn(
+      (instance: WallSegmentInstance): MeshBasicMaterial =>
         instance.isFence ? fenceMaterial : wallMaterial
-      );
+    );
 
     const build = createWallSegmentMeshes({
       instances,
@@ -85,6 +90,11 @@ describe('createWallSegmentMeshes', () => {
       );
       expect(mesh.userData.thickness).toBe(instances[index]?.thickness);
       expect(mesh.userData.segmentId).toBe(instances[index]?.segmentId);
+      expect(mesh.userData.levelSourceId).toBe(instances[index]?.sourceId);
+      expect(mesh.userData.levelSource).toEqual({
+        sourceId: instances[index]?.sourceId,
+        sourceType: 'wall',
+      });
       expect(mesh.name).toBe(
         instances[index]?.isFence ? 'FenceSegment' : 'WallSegment'
       );

--- a/src/scene/structures/wallSegmentsMesh.ts
+++ b/src/scene/structures/wallSegmentsMesh.ts
@@ -52,6 +52,11 @@ export function createWallSegmentMeshes(
     // Store a compact identifier instead of the full segment object to avoid
     // retaining large or circular references in Three.js metadata.
     mesh.userData.segmentId = instance.segmentId;
+    mesh.userData.levelSourceId = instance.sourceId;
+    mesh.userData.levelSource = {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    };
     mesh.userData.isFence = instance.isFence;
     mesh.userData.isSharedInterior = instance.isSharedInterior;
     mesh.userData.thickness = instance.thickness;

--- a/src/tests/wallSegments.test.ts
+++ b/src/tests/wallSegments.test.ts
@@ -4,8 +4,10 @@ import {
   FLOOR_PLAN,
   WALL_THICKNESS,
   type DoorwayDefinition,
+  type FloorPlanDefinition,
 } from '../assets/floorPlan';
 import { createWallSegmentInstances } from '../assets/floorPlan/wallSegments';
+import { isLevelSourceId } from '../scene/level/sourceIds';
 import { collidesWithColliders } from '../systems/collision';
 
 const WALL_HEIGHT = 6;
@@ -41,9 +43,109 @@ describe('createWallSegmentInstances', () => {
     wallThickness: WALL_THICKNESS,
     fenceHeight: FENCE_HEIGHT,
     fenceThickness: FENCE_THICKNESS,
+    floorId: 'ground',
     getRoomCategory,
   });
   const colliders = groundWallInstances.map((instance) => instance.collider);
+
+  it('creates valid unique floor-scoped source IDs without array indexes', () => {
+    const sourceIds = groundWallInstances.map((instance) => instance.sourceId);
+    expect(sourceIds.every(isLevelSourceId)).toBe(true);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(sourceIds.every((sourceId) => sourceId.startsWith('ground.'))).toBe(
+      true
+    );
+    expect(
+      sourceIds.every((sourceId) => !/[.|-](?:0|[1-9]\d*)$/.test(sourceId))
+    ).toBe(true);
+  });
+
+  it('keeps source IDs stable when an unrelated fixture segment is inserted', () => {
+    const fixture: FloorPlanDefinition = {
+      outline: [
+        [0, 0],
+        [8, 0],
+        [8, 4],
+        [0, 4],
+      ],
+      rooms: [
+        {
+          id: 'alphaRoom',
+          name: 'Alpha Room',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+          ledColor: 0xffffff,
+        },
+        {
+          id: 'betaRoom',
+          name: 'Beta Room',
+          bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+          ledColor: 0xffffff,
+        },
+      ],
+    };
+    const withInsertedRoom: FloorPlanDefinition = {
+      ...fixture,
+      rooms: [
+        {
+          id: 'insertedRoom',
+          name: 'Inserted Room',
+          bounds: { minX: 20, maxX: 24, minZ: 20, maxZ: 24 },
+          ledColor: 0xffffff,
+        },
+        ...fixture.rooms,
+      ],
+    };
+    const options = {
+      floorId: 'ground',
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory: () => 'interior' as const,
+    };
+
+    const before = createWallSegmentInstances(fixture, options);
+    const after = createWallSegmentInstances(withInsertedRoom, options);
+    const beforeIdsBySegment = new Map(
+      before.map((instance) => [instance.segmentId, instance.sourceId])
+    );
+
+    for (const instance of after.filter(
+      (candidate) => !candidate.sourceId.includes('inserted-room')
+    )) {
+      expect(instance.sourceId).toBe(
+        beforeIdsBySegment.get(instance.segmentId)
+      );
+    }
+  });
+
+  it('does not change geometry or collider bounds when floor source context is added', () => {
+    const withoutFloor = createWallSegmentInstances(FLOOR_PLAN, {
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    });
+
+    expect(
+      groundWallInstances.map((instance) => ({
+        segmentId: instance.segmentId,
+        center: instance.center,
+        dimensions: instance.dimensions,
+        collider: instance.collider,
+      }))
+    ).toEqual(
+      withoutFloor.map((instance) => ({
+        segmentId: instance.segmentId,
+        center: instance.center,
+        dimensions: instance.dimensions,
+        collider: instance.collider,
+      }))
+    );
+  });
 
   it('leaves usable gaps for shared doorways', () => {
     const livingRoom = FLOOR_PLAN.rooms.find(


### PR DESCRIPTION
### Motivation
- Wall segment identifiers included generation-order details which caused unrelated edits to churn IDs and noisy downstream diffs.
- Introduce a deterministic, semantic interim source ID for generated legacy walls so meshes and debug metadata can be correlated order-independently.

### Description
- Add a floor-scoped `sourceId: LevelSourceId` to `WallSegmentInstance` and a `floorId?: string` option on `WallSegmentOptions`, and stop using the array index in `segmentId` generation (`src/assets/floorPlan/wallSegments.ts`).
- Build `LevelSourceId` values from stable facts (floor, orientation, normalized start/end coords, sorted room coverage) via `createWallSegmentSourceId(...)` and retain legacy `segmentId` for compatibility.
- Propagate source metadata to generated meshes by setting `mesh.userData.levelSourceId` and `mesh.userData.levelSource = { sourceId, sourceType: 'wall' }` (`src/scene/structures/wallSegmentsMesh.ts`).
- Propagate source metadata into collider debug registrations and use floor context when creating wall instances for ground/upper floors (`src/main.ts`).
- Add and update focused tests to assert `sourceId` validity/uniqueness/stability and to ensure meshes and debug collider metadata include the source IDs (`src/tests/wallSegments.test.ts`, `src/scene/structures/__tests__/wallSegmentsMesh.test.ts`).

### Testing
- Ran `npm run format:write` which completed successfully.
- Ran `npm run lint` which completed successfully after a trivial import-order fix.
- Ran focused tests `npm run test:ci -- src/tests/wallSegments.test.ts src/scene/structures/__tests__/wallSegmentsMesh.test.ts` and the full test suite `npm run test:ci`, both of which passed (focused tests passed and full suite passed).
- Ran `npm run docs:check` which passed (link checker reported existing external URL warnings) and `npm run smoke` / `npm run build` which both succeeded.
- Ran the repo secret scan (`git diff --cached | ./scripts/scan-secrets.py`) which reported no high-risk secrets.
- Note: `npm run typecheck` (full repo `tsc --noEmit`) still reports existing repository-wide TypeScript errors outside the change set and is therefore not passing; these errors predated and are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ed29e644832f81968d8789dd8743)