### PR TITLE
🧱: Stabilize generated wall source IDs

### DIFF
--- a/src/assets/floorPlan/wallSegments.ts
+++ b/src/assets/floorPlan/wallSegments.ts
@@ -1,3 +1,7 @@
+import {
+  makeLevelSourceId,
+  type LevelSourceId,
+} from '../../scene/level/sourceIds';
 import type { RectCollider } from '../../systems/collision';
 import {
   getCombinedWallSegments,
@@ -11,6 +15,8 @@ export interface WallSegmentInstance {
   segment: CombinedWallSegment;
   /** Stable identifier for correlating generated meshes with the source segment. */
   segmentId: string;
+  /** Order-independent semantic bridge ID for generated legacy wall segments. */
+  sourceId: LevelSourceId;
   center: { x: number; y: number; z: number };
   dimensions: { width: number; height: number; depth: number };
   collider: RectCollider;
@@ -32,6 +38,8 @@ export interface WallSegmentOptions {
   interiorExtensionFactor?: number;
   /** Additional overlap factor for exterior segments to prevent light leaks. */
   exteriorExtensionFactor?: number;
+  /** Floor/level namespace for generated segment source IDs. */
+  floorId?: string;
   getRoomCategory(roomId: string): RoomCategory;
 }
 
@@ -69,7 +77,7 @@ export function createWallSegmentInstances(
   const segments = getCombinedWallSegments(plan);
   const instances: WallSegmentInstance[] = [];
 
-  segments.forEach((segment, index) => {
+  segments.forEach((segment) => {
     const length =
       segment.orientation === 'horizontal'
         ? Math.abs(segment.end.x - segment.start.x)
@@ -135,7 +143,8 @@ export function createWallSegmentInstances(
 
     instances.push({
       segment,
-      segmentId: createSegmentId(segment, index),
+      segmentId: createSegmentId(segment),
+      sourceId: createWallSegmentSourceId(segment, options.floorId),
       center,
       dimensions: { width, height, depth },
       collider,
@@ -152,12 +161,64 @@ function formatPoint(point: { x: number; z: number }): string {
   return `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
 }
 
-function createSegmentId(segment: CombinedWallSegment, index: number): string {
-  const start = formatPoint(segment.start);
-  const end = formatPoint(segment.end);
+function normalizeSourcePart(value: string): string {
+  return (
+    value
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'none'
+  );
+}
+
+function formatSourceCoordinate(value: number): string {
+  const prefix = value < 0 ? 'n' : 'p';
+  return `${prefix}${Math.abs(value).toFixed(3).replace('.', '_')}`;
+}
+
+function formatSourcePoint(point: { x: number; z: number }): string {
+  return `x${formatSourceCoordinate(point.x)}_z${formatSourceCoordinate(point.z)}`;
+}
+
+function getNormalizedEndpoints(
+  segment: CombinedWallSegment
+): [{ x: number; z: number }, { x: number; z: number }] {
+  const shouldSwap =
+    segment.orientation === 'horizontal'
+      ? segment.start.x > segment.end.x
+      : segment.start.z > segment.end.z;
+  return shouldSwap
+    ? [segment.end, segment.start]
+    : [segment.start, segment.end];
+}
+
+function createSegmentId(segment: CombinedWallSegment): string {
+  const [startPoint, endPoint] = getNormalizedEndpoints(segment);
+  const start = formatPoint(startPoint);
+  const end = formatPoint(endPoint);
   const rooms = segment.rooms
     .map((room) => `${room.id}:${room.wall}`)
     .sort()
     .join('|');
-  return [segment.orientation, start, end, rooms || 'none', index].join('|');
+  return [segment.orientation, start, end, rooms || 'none'].join('|');
+}
+
+function createWallSegmentSourceId(
+  segment: CombinedWallSegment,
+  floorId = 'unknown'
+): LevelSourceId {
+  const [startPoint, endPoint] = getNormalizedEndpoints(segment);
+  const rooms = segment.rooms
+    .map((room) => `${normalizeSourcePart(room.id)}-${room.wall}`)
+    .sort()
+    .join('_');
+
+  return makeLevelSourceId([
+    normalizeSourcePart(floorId),
+    'generated-wall',
+    segment.orientation,
+    formatSourcePoint(startPoint),
+    formatSourcePoint(endPoint),
+    rooms || 'none',
+  ]);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -975,6 +975,7 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
+const wallColliderSourceIds = new Map<RectCollider, string>();
 const upperFloorColliders: RectCollider[] = [];
 
 const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
@@ -1870,6 +1871,7 @@ function initializeImmersiveScene(
   fenceMaterial.lightMap = interiorLightmaps.wall;
   fenceMaterial.lightMapIntensity = 0.56;
   const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
+    floorId: 'ground',
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -1887,6 +1889,7 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
+    wallColliderSourceIds.set(instance.collider, instance.sourceId);
   });
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
@@ -2338,6 +2341,7 @@ function initializeImmersiveScene(
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
   const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+    floorId: 'upper',
     baseElevation: upperFloorElevation,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -2360,6 +2364,7 @@ function initializeImmersiveScene(
       instance.collider,
       getUpperWallSegmentDebugName(instance)
     );
+    wallColliderSourceIds.set(instance.collider, instance.sourceId);
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {
@@ -4449,9 +4454,12 @@ function initializeImmersiveScene(
       category: options.category,
       name:
         namedColliderDebugNames.get(bounds) ??
+        wallColliderSourceIds.get(bounds) ??
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
+      sourceId: wallColliderSourceIds.get(bounds),
+      sourceType: wallColliderSourceIds.has(bounds) ? 'wall' : undefined,
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
+++ b/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
@@ -2,6 +2,7 @@ import { MeshBasicMaterial } from 'three';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { WallSegmentInstance } from '../../../assets/floorPlan/wallSegments';
+import { assertLevelSourceId } from '../../../scene/level/sourceIds';
 import { createWallSegmentMeshes } from '../wallSegmentsMesh';
 
 function createWallInstance(
@@ -15,6 +16,7 @@ function createWallInstance(
       rooms: [{ id: 'livingRoom', wall: 'north' }],
     },
     segmentId: 'segment-default',
+    sourceId: assertLevelSourceId('ground.generated-wall.horizontal.default'),
     center: { x: 2, y: 3, z: 0 },
     dimensions: { width: 4, height: 6, depth: 0.5 },
     collider: { minX: 0, maxX: 4, minZ: -0.25, maxZ: 0.25 },
@@ -33,6 +35,9 @@ describe('createWallSegmentMeshes', () => {
       createWallInstance({
         center: { x: -2, y: 3, z: 1 },
         segmentId: 'segment-vertical',
+        sourceId: assertLevelSourceId(
+          'ground.generated-wall.vertical.kitchen-east'
+        ),
         segment: {
           orientation: 'vertical',
           start: { x: -3, z: 0 },
@@ -48,6 +53,9 @@ describe('createWallSegmentMeshes', () => {
         isFence: true,
         thickness: 0.28,
         segmentId: 'segment-horizontal',
+        sourceId: assertLevelSourceId(
+          'ground.generated-wall.horizontal.backyard-south'
+        ),
         segment: {
           orientation: 'horizontal',
           start: { x: 4.5, z: -5.5 },
@@ -85,6 +93,11 @@ describe('createWallSegmentMeshes', () => {
       );
       expect(mesh.userData.thickness).toBe(instances[index]?.thickness);
       expect(mesh.userData.segmentId).toBe(instances[index]?.segmentId);
+      expect(mesh.userData.levelSourceId).toBe(instances[index]?.sourceId);
+      expect(mesh.userData.levelSource).toEqual({
+        sourceId: instances[index]?.sourceId,
+        sourceType: 'wall',
+      });
       expect(mesh.name).toBe(
         instances[index]?.isFence ? 'FenceSegment' : 'WallSegment'
       );

--- a/src/scene/structures/wallSegmentsMesh.ts
+++ b/src/scene/structures/wallSegmentsMesh.ts
@@ -52,6 +52,11 @@ export function createWallSegmentMeshes(
     // Store a compact identifier instead of the full segment object to avoid
     // retaining large or circular references in Three.js metadata.
     mesh.userData.segmentId = instance.segmentId;
+    mesh.userData.levelSourceId = instance.sourceId;
+    mesh.userData.levelSource = {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    };
     mesh.userData.isFence = instance.isFence;
     mesh.userData.isSharedInterior = instance.isSharedInterior;
     mesh.userData.thickness = instance.thickness;

--- a/src/tests/wallSegments.test.ts
+++ b/src/tests/wallSegments.test.ts
@@ -4,8 +4,10 @@ import {
   FLOOR_PLAN,
   WALL_THICKNESS,
   type DoorwayDefinition,
+  type FloorPlanDefinition,
 } from '../assets/floorPlan';
 import { createWallSegmentInstances } from '../assets/floorPlan/wallSegments';
+import { isLevelSourceId } from '../scene/level/sourceIds';
 import { collidesWithColliders } from '../systems/collision';
 
 const WALL_HEIGHT = 6;
@@ -36,6 +38,7 @@ function findSharedDoorway(
 
 describe('createWallSegmentInstances', () => {
   const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
+    floorId: 'ground',
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -44,6 +47,93 @@ describe('createWallSegmentInstances', () => {
     getRoomCategory,
   });
   const colliders = groundWallInstances.map((instance) => instance.collider);
+
+  it('assigns valid unique semantic source IDs without array suffixes', () => {
+    const sourceIds = groundWallInstances.map((instance) => instance.sourceId);
+
+    expect(sourceIds.every(isLevelSourceId)).toBe(true);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(sourceIds.every((sourceId) => !/\.\d+$/.test(sourceId))).toBe(true);
+  });
+
+  it('keeps geometry and collider bounds independent from source ID generation', () => {
+    const withoutSourceIds = groundWallInstances.map((instance) => ({
+      ...instance,
+      sourceId: undefined,
+    }));
+    const regenerated = createWallSegmentInstances(FLOOR_PLAN, {
+      floorId: 'ground',
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    }).map((instance) => ({
+      ...instance,
+      sourceId: undefined,
+    }));
+
+    expect(regenerated).toEqual(withoutSourceIds);
+  });
+
+  it('does not churn unaffected source IDs when unrelated segments are inserted', () => {
+    const basePlan: FloorPlanDefinition = {
+      outline: [
+        [0, 0],
+        [8, 0],
+        [8, 8],
+        [0, 8],
+      ],
+      rooms: [
+        {
+          id: 'alphaRoom',
+          name: 'Alpha Room',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+          ledColor: 0xffffff,
+        },
+        {
+          id: 'betaRoom',
+          name: 'Beta Room',
+          bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+          ledColor: 0xffffff,
+        },
+      ],
+    };
+    const insertedPlan: FloorPlanDefinition = {
+      ...basePlan,
+      rooms: [
+        {
+          id: 'insertedRoom',
+          name: 'Inserted Room',
+          bounds: { minX: 0, maxX: 4, minZ: 4, maxZ: 8 },
+          ledColor: 0xffffff,
+        },
+        ...basePlan.rooms,
+      ],
+    };
+    const createFixtureInstances = (plan: FloorPlanDefinition) =>
+      createWallSegmentInstances(plan, {
+        floorId: 'ground',
+        baseElevation: 0,
+        wallHeight: WALL_HEIGHT,
+        wallThickness: WALL_THICKNESS,
+        fenceHeight: FENCE_HEIGHT,
+        fenceThickness: FENCE_THICKNESS,
+        getRoomCategory: () => 'interior',
+      });
+    const findAlphaSouth = (plan: FloorPlanDefinition) =>
+      createFixtureInstances(plan).find(
+        (instance) =>
+          instance.segment.rooms.length === 1 &&
+          instance.segment.rooms[0]?.id === 'alphaRoom' &&
+          instance.segment.rooms[0]?.wall === 'south'
+      );
+
+    expect(findAlphaSouth(insertedPlan)?.sourceId).toBe(
+      findAlphaSouth(basePlan)?.sourceId
+    );
+  });
 
   it('leaves usable gaps for shared doorways', () => {
     const livingRoom = FLOOR_PLAN.rooms.find(


### PR DESCRIPTION
### Motivation
- Generated wall segment identities included array-index / generation-order details which caused ID churn when unrelated walls were added or removed.
- We need an interim, order-independent source ID for legacy generated walls so meshes and debug tooling can reference a stable semantic ID without changing geometry or collision behavior.
- This change implements a floor-scoped semantic source-ID bridge to make downstream diffs and debugging stable while leaving runtime geometry unchanged.

### Description
- Replace index-dependent segment IDs with an order-independent `sourceId: LevelSourceId` for `WallSegmentInstance` derived from floor, orientation, normalized endpoints, and sorted room metadata, and add an optional `floorId` option to `WallSegmentOptions` (files changed: `src/assets/floorPlan/wallSegments.ts`).
- Propagate the new source ID onto generated meshes as `mesh.userData.levelSourceId` and `mesh.userData.levelSource = { sourceId, sourceType: 'wall' }` while retaining existing `segmentId` (file changed: `src/scene/structures/wallSegmentsMesh.ts`).
- Track wall collider -> sourceId mapping and pass that metadata into debug collider registrations so collider labels/names prefer stable source references over order-dependent names (file changed: `src/main.ts`).
- Add tests asserting every instance has a valid unique `sourceId`, that `sourceId`s contain no array-index suffixes, that geometry/collider outputs are unchanged by source-id generation, and that wall meshes carry `levelSourceId` metadata (files changed: `src/tests/wallSegments.test.ts`, `src/scene/structures/__tests__/wallSegmentsMesh.test.ts`).
- Branch: `codex/stable-wall-source-ids`.

### Testing
- Ran `npm run format:write` and formatting completed successfully (no manual formatting required).
- Ran `npm run lint` and resolved issues until `eslint` completed with no remaining errors.
- Ran focused tests `npm run test:ci -- src/tests/wallSegments.test.ts src/scene/structures/__tests__/wallSegmentsMesh.test.ts` which passed (2 files, 8 tests passed).
- Ran full test suite `npm run test:ci` which completed successfully (149 files, 1145 tests passed).
- Ran `npm run build` which produced a production build without errors, and `./scripts/scan-secrets.py` on staged changes detected no secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ed23100c832fba8a19c071283ec1)