### PR TITLE
Stabilize generated wall source IDs

### DIFF
--- a/src/assets/floorPlan/wallSegments.ts
+++ b/src/assets/floorPlan/wallSegments.ts
@@ -1,3 +1,7 @@
+import {
+  makeLevelSourceId,
+  type LevelSourceId,
+} from '../../scene/level/sourceIds';
 import type { RectCollider } from '../../systems/collision';
 import {
   getCombinedWallSegments,
@@ -9,6 +13,8 @@ import {
 
 export interface WallSegmentInstance {
   segment: CombinedWallSegment;
+  /** Stable semantic source ID for generated legacy wall/fence segments. */
+  sourceId: LevelSourceId;
   /** Stable identifier for correlating generated meshes with the source segment. */
   segmentId: string;
   center: { x: number; y: number; z: number };
@@ -23,6 +29,8 @@ export interface WallSegmentInstance {
 }
 
 export interface WallSegmentOptions {
+  /** Floor context included in generated legacy wall source IDs. */
+  floorId?: string;
   baseElevation: number;
   wallHeight: number;
   wallThickness: number;
@@ -69,7 +77,7 @@ export function createWallSegmentInstances(
   const segments = getCombinedWallSegments(plan);
   const instances: WallSegmentInstance[] = [];
 
-  segments.forEach((segment, index) => {
+  segments.forEach((segment) => {
     const length =
       segment.orientation === 'horizontal'
         ? Math.abs(segment.end.x - segment.start.x)
@@ -133,9 +141,12 @@ export function createWallSegmentInstances(
       maxZ: center.z + depth / 2,
     };
 
+    const sourceId = createSegmentSourceId(segment, options.floorId);
+
     instances.push({
       segment,
-      segmentId: createSegmentId(segment, index),
+      sourceId,
+      segmentId: sourceId,
       center,
       dimensions: { width, height, depth },
       collider,
@@ -148,16 +159,44 @@ export function createWallSegmentInstances(
   return instances;
 }
 
-function formatPoint(point: { x: number; z: number }): string {
-  return `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
+function formatCoordinate(value: number): string {
+  const normalized = Object.is(value, -0) ? 0 : value;
+  return normalized
+    .toFixed(3)
+    .replace(/^-/, 'n')
+    .replace('.', 'p')
+    .replace(/p?0+$/, '');
 }
 
-function createSegmentId(segment: CombinedWallSegment, index: number): string {
-  const start = formatPoint(segment.start);
-  const end = formatPoint(segment.end);
+function formatPointToken(point: { x: number; z: number }): string {
+  return `x${formatCoordinate(point.x)}_z${formatCoordinate(point.z)}`;
+}
+
+function formatSourceToken(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function createSegmentSourceId(
+  segment: CombinedWallSegment,
+  floorId = 'ground'
+): LevelSourceId {
   const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
+    .map(
+      (room) => `${formatSourceToken(room.id)}-${formatSourceToken(room.wall)}`
+    )
     .sort()
-    .join('|');
-  return [segment.orientation, start, end, rooms || 'none', index].join('|');
+    .join('__');
+
+  return makeLevelSourceId([
+    formatSourceToken(floorId),
+    'generated-walls',
+    formatSourceToken(segment.orientation),
+    formatPointToken(segment.start),
+    formatPointToken(segment.end),
+    rooms || 'none',
+  ]);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,10 +36,7 @@ import {
   WALL_THICKNESS,
   type RoomCategory,
 } from './assets/floorPlan';
-import {
-  createWallSegmentInstances,
-  type WallSegmentInstance,
-} from './assets/floorPlan/wallSegments';
+import { createWallSegmentInstances } from './assets/floorPlan/wallSegments';
 import {
   formatMessage,
   getAudioHudControlStrings,
@@ -977,23 +974,6 @@ const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
 const upperFloorColliders: RectCollider[] = [];
 
-const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
-  `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-
-const getUpperWallSegmentDebugName = (
-  instance: WallSegmentInstance
-): string => {
-  const { segment } = instance;
-  const start = formatUpperWallDebugPoint(segment.start);
-  const end = formatUpperWallDebugPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-
-  return `UpperWallSegment:${segment.orientation}|${start}|${end}|${rooms || 'none'}`;
-};
-
 const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
 let backyardEnvironment: BackyardEnvironmentBuild | null = null;
@@ -1870,6 +1850,7 @@ function initializeImmersiveScene(
   fenceMaterial.lightMap = interiorLightmaps.wall;
   fenceMaterial.lightMapIntensity = 0.56;
   const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
+    floorId: 'ground',
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -1887,6 +1868,7 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
+    namedColliderDebugNames.set(instance.collider, instance.sourceId);
   });
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
@@ -2338,6 +2320,7 @@ function initializeImmersiveScene(
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
   const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+    floorId: 'upper',
     baseElevation: upperFloorElevation,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -2356,10 +2339,7 @@ function initializeImmersiveScene(
   upperFloorGroup.add(upperWallMeshes.group);
   upperWallInstances.forEach((instance) => {
     upperFloorColliders.push(instance.collider);
-    namedColliderDebugNames.set(
-      instance.collider,
-      getUpperWallSegmentDebugName(instance)
-    );
+    namedColliderDebugNames.set(instance.collider, instance.sourceId);
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {
@@ -4442,6 +4422,7 @@ function initializeImmersiveScene(
       category: string;
       namePrefix: string;
       elevation?: number;
+      sourceIds?: ReadonlyMap<RectCollider, string>;
     }
   ): DebugColliderRegistration[] =>
     colliders.map((bounds, index) => ({
@@ -4452,6 +4433,8 @@ function initializeImmersiveScene(
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
+      sourceId: options.sourceIds?.get(bounds),
+      sourceType: options.sourceIds?.has(bounds) ? 'wall' : undefined,
     }));
 
   const colliderVisualizer = createColliderVisualizer({
@@ -4459,11 +4442,17 @@ function initializeImmersiveScene(
     enabled: debugCollidersEnabled,
   });
   colliderVisualizer.setIdsEnabled(debugColliderIdsEnabled);
+  const generatedWallColliderSourceIds = new Map<RectCollider, string>();
+  for (const instance of [...groundWallInstances, ...upperWallInstances]) {
+    generatedWallColliderSourceIds.set(instance.collider, instance.sourceId);
+  }
+
   colliderVisualizer.register([
     ...createDebugColliderRegistrations(groundColliders, {
       floor: 'ground',
       category: 'ground',
       namePrefix: 'ground-collider',
+      sourceIds: generatedWallColliderSourceIds,
     }),
     ...createDebugColliderRegistrations(staticColliders, {
       floor: 'ground',
@@ -4475,6 +4464,7 @@ function initializeImmersiveScene(
       category: 'upper',
       namePrefix: 'upper-collider',
       elevation: upperFloorElevation,
+      sourceIds: generatedWallColliderSourceIds,
     }),
   ]);
   scene.add(colliderVisualizer.group);

--- a/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
+++ b/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
@@ -14,6 +14,8 @@ function createWallInstance(
       end: { x: 4, z: 0 },
       rooms: [{ id: 'livingRoom', wall: 'north' }],
     },
+    sourceId:
+      'ground.generated-walls.horizontal.x0_z0.x4_z0.living-room-north' as WallSegmentInstance['sourceId'],
     segmentId: 'segment-default',
     center: { x: 2, y: 3, z: 0 },
     dimensions: { width: 4, height: 6, depth: 0.5 },
@@ -32,6 +34,8 @@ describe('createWallSegmentMeshes', () => {
     const instances: WallSegmentInstance[] = [
       createWallInstance({
         center: { x: -2, y: 3, z: 1 },
+        sourceId:
+          'ground.generated-walls.vertical.xn3_z0.xn3_z2.kitchen-east' as WallSegmentInstance['sourceId'],
         segmentId: 'segment-vertical',
         segment: {
           orientation: 'vertical',
@@ -47,6 +51,8 @@ describe('createWallSegmentMeshes', () => {
         dimensions: { width: 0.28, height: 2.4, depth: 3 },
         isFence: true,
         thickness: 0.28,
+        sourceId:
+          'ground.generated-walls.horizontal.x4p5_zn5p5.x7p5_zn5p5.backyard-south' as WallSegmentInstance['sourceId'],
         segmentId: 'segment-horizontal',
         segment: {
           orientation: 'horizontal',
@@ -85,6 +91,11 @@ describe('createWallSegmentMeshes', () => {
       );
       expect(mesh.userData.thickness).toBe(instances[index]?.thickness);
       expect(mesh.userData.segmentId).toBe(instances[index]?.segmentId);
+      expect(mesh.userData.levelSourceId).toBe(instances[index]?.sourceId);
+      expect(mesh.userData.levelSource).toEqual({
+        sourceId: instances[index]?.sourceId,
+        sourceType: 'wall',
+      });
       expect(mesh.name).toBe(
         instances[index]?.isFence ? 'FenceSegment' : 'WallSegment'
       );

--- a/src/scene/structures/wallSegmentsMesh.ts
+++ b/src/scene/structures/wallSegmentsMesh.ts
@@ -52,6 +52,11 @@ export function createWallSegmentMeshes(
     // Store a compact identifier instead of the full segment object to avoid
     // retaining large or circular references in Three.js metadata.
     mesh.userData.segmentId = instance.segmentId;
+    mesh.userData.levelSourceId = instance.sourceId;
+    mesh.userData.levelSource = {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    };
     mesh.userData.isFence = instance.isFence;
     mesh.userData.isSharedInterior = instance.isSharedInterior;
     mesh.userData.thickness = instance.thickness;

--- a/src/tests/wallSegments.test.ts
+++ b/src/tests/wallSegments.test.ts
@@ -4,8 +4,10 @@ import {
   FLOOR_PLAN,
   WALL_THICKNESS,
   type DoorwayDefinition,
+  type FloorPlanDefinition,
 } from '../assets/floorPlan';
 import { createWallSegmentInstances } from '../assets/floorPlan/wallSegments';
+import { isLevelSourceId } from '../scene/level/sourceIds';
 import { collidesWithColliders } from '../systems/collision';
 
 const WALL_HEIGHT = 6;
@@ -36,6 +38,7 @@ function findSharedDoorway(
 
 describe('createWallSegmentInstances', () => {
   const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
+    floorId: 'ground',
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -44,6 +47,100 @@ describe('createWallSegmentInstances', () => {
     getRoomCategory,
   });
   const colliders = groundWallInstances.map((instance) => instance.collider);
+
+  it('assigns valid unique semantic source IDs without index suffixes', () => {
+    const sourceIds = groundWallInstances.map((instance) => instance.sourceId);
+
+    expect(sourceIds.every(isLevelSourceId)).toBe(true);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(sourceIds.every((sourceId) => !/\.\d+$/.test(sourceId))).toBe(true);
+    expect(sourceIds.every((sourceId) => sourceId.startsWith('ground.'))).toBe(
+      true
+    );
+  });
+
+  it('keeps source IDs stable when unrelated rooms are inserted', () => {
+    const fixture: FloorPlanDefinition = {
+      outline: [
+        [0, 0],
+        [8, 0],
+        [8, 8],
+        [0, 8],
+      ],
+      rooms: [
+        {
+          id: 'alphaRoom',
+          name: 'Alpha Room',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+          ledColor: 0xffffff,
+        },
+      ],
+    };
+    const withInsertedRoom: FloorPlanDefinition = {
+      ...fixture,
+      rooms: [
+        {
+          id: 'insertedRoom',
+          name: 'Inserted Room',
+          bounds: { minX: 5, maxX: 8, minZ: 5, maxZ: 8 },
+          ledColor: 0xffffff,
+        },
+        ...fixture.rooms,
+      ],
+    };
+
+    const createFixtureInstances = (plan: FloorPlanDefinition) =>
+      createWallSegmentInstances(plan, {
+        floorId: 'ground',
+        baseElevation: 0,
+        wallHeight: WALL_HEIGHT,
+        wallThickness: WALL_THICKNESS,
+        fenceHeight: FENCE_HEIGHT,
+        fenceThickness: FENCE_THICKNESS,
+        getRoomCategory: () => 'interior',
+      }).filter((instance) =>
+        instance.segment.rooms.some((room) => room.id === 'alphaRoom')
+      );
+
+    expect(
+      createFixtureInstances(withInsertedRoom).map(
+        (instance) => instance.sourceId
+      )
+    ).toEqual(
+      createFixtureInstances(fixture).map((instance) => instance.sourceId)
+    );
+  });
+
+  it('keeps generated geometry and collider bounds unchanged from source ID metadata', () => {
+    const withoutFloorId = createWallSegmentInstances(FLOOR_PLAN, {
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    });
+
+    expect(
+      groundWallInstances.map((instance) => ({
+        center: instance.center,
+        dimensions: instance.dimensions,
+        collider: instance.collider,
+        isFence: instance.isFence,
+        isSharedInterior: instance.isSharedInterior,
+        thickness: instance.thickness,
+      }))
+    ).toEqual(
+      withoutFloorId.map((instance) => ({
+        center: instance.center,
+        dimensions: instance.dimensions,
+        collider: instance.collider,
+        isFence: instance.isFence,
+        isSharedInterior: instance.isSharedInterior,
+        thickness: instance.thickness,
+      }))
+    );
+  });
 
   it('leaves usable gaps for shared doorways', () => {
     const livingRoom = FLOOR_PLAN.rooms.find(


### PR DESCRIPTION
### Motivation
- Generated wall/fence segment identifiers previously included generation-order data which caused unrelated ID churn when walls changed.  
- Provide an interim, deterministic semantic source ID for legacy-generated walls so downstream debug tooling and diffs are stable.  
- Surface those stable source IDs through meshes and collider debug metadata without changing runtime geometry or collision behavior.  

### Description
- Add a `sourceId: LevelSourceId` to `WallSegmentInstance` and an optional `floorId?: string` to `WallSegmentOptions`, and alias the existing `segmentId` to the new `sourceId` for compatibility in `src/assets/floorPlan/wallSegments.ts`.  
- Implement deterministic, order-independent ID generation (`createSegmentSourceId`) based on `floorId`, orientation, normalized start/end tokens, and sorted room/wall coverage, producing valid `LevelSourceId`s.  
- Propagate source metadata to meshes by setting `mesh.userData.levelSourceId` and `mesh.userData.levelSource = { sourceId, sourceType: 'wall' }` in `src/scene/structures/wallSegmentsMesh.ts` while preserving existing `segmentId` userData.  
- Propagate source metadata to generated wall colliders in `src/main.ts` by attaching source IDs to `namedColliderDebugNames` and passing a `sourceIds` map into `createDebugColliderRegistrations` so debug collider registrations include `sourceId`/`sourceType`.  

### Testing
- Ran formatting with `npm run format:write` which completed successfully.  
- Ran lint with `npm run lint` which passed after ordering import fix and produced no blocking errors.  
- Ran focused tests with `npm run test:ci -- src/tests/wallSegments.test.ts src/scene/structures/__tests__/wallSegmentsMesh.test.ts` and observed both test files pass, and then ran the full suite with `npm run test:ci` which completed with all tests passing.  
- Ran `npm run docs:check` (passed with external link fetch warnings) and `npm run smoke` / `npm run build` which both completed successfully (build reported existing large-chunk warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ed169e54832f8963232293fac99d)