### PR TITLE
🏗️ Add declarative level schema and legacy compiler adapter

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -238,11 +238,13 @@ Wall authoring supports two current-state representations:
 - a current wall `run` with intentional `gaps` for doors or open passages when
   the run is easier to edit as one boundary.
 
-Those gaps describe present topology only. They are not removed-wall records, and
-validation rejects source IDs that contain tombstone-like segments such as
-`.former.`, `.removed.`, or `.debugOnlyRemoval.`. A visible door, arch, trim,
-threshold, or rail should be declared as a scene object or current wall/railing;
-a walkable opening does not need a former blocker record.
+Those gaps describe present topology only. They are not removed-wall records.
+Validation rejects source IDs with whole tombstone-like path segments such as
+`former`, `removed`, or `debugonlyremoval`, including when those words are the
+final segment. Doorway gaps must be finite, axis-aligned, within the wall run,
+non-overlapping, and wide enough for the legacy doorway checks. A visible door,
+arch, trim, threshold, or rail should be declared as a scene object or current
+wall/railing; a walkable opening does not need a former blocker record.
 
 The temporary adapter in `src/scene/level/compileLegacyFloorPlan.ts` compiles a
 declarative floor back to the existing `FloorPlanDefinition` shape for migration

--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -214,6 +214,44 @@ with no empty segments, whitespace, or slash-style paths, and
 `getLevelSourceDebugRef(...)` provides deterministic short uppercase hex
 references for future debug metadata without changing current visible debug IDs.
 
+## Declarative schema adapter (phase 5)
+
+The first code-level source contract lives in `src/scene/level/schema.ts`. It is
+not wired into runtime scene construction yet; `FLOOR_PLAN`,
+`UPPER_FLOOR_PLAN`, generated wall meshes, generated colliders, and compact debug
+IDs remain unchanged in this phase. The schema exists so future edits have a
+small, hand-authored shape to migrate toward before any runtime generator changes.
+
+The schema models a `LevelDefinition` with one or more `FloorDefinition` entries.
+Each floor has an outline plus explicit arrays for semantic rooms, current walls,
+floor surfaces, and optional safety colliders, scene objects, and semantic room
+connections. All source-backed entities carry a `sourceId` using the semantic ID
+helpers from `src/scene/level/sourceIds.ts`, and validation checks global source
+ID uniqueness across layers. Per-layer `id` fields are unique within their floor
+namespace so editor-friendly IDs can stay short while source IDs remain globally
+stable.
+
+Wall authoring supports two current-state representations:
+
+- explicit positive wall `segments` for authors who want to spell out each
+  visible/collidable piece;
+- a current wall `run` with intentional `gaps` for doors or open passages when
+  the run is easier to edit as one boundary.
+
+Those gaps describe present topology only. They are not removed-wall records, and
+validation rejects source IDs that contain tombstone-like segments such as
+`.former.`, `.removed.`, or `.debugOnlyRemoval.`. A visible door, arch, trim,
+threshold, or rail should be declared as a scene object or current wall/railing;
+a walkable opening does not need a former blocker record.
+
+The temporary adapter in `src/scene/level/compileLegacyFloorPlan.ts` compiles a
+declarative floor back to the existing `FloorPlanDefinition` shape for migration
+checks and narrow compatibility. By default it copies room metadata only. When
+`includeDoorwaysFromWallGaps` is explicitly enabled, it derives legacy room
+`doorways` from current wall-run gaps. That derivation is compatibility glue for
+old room-wall generators, not the canonical future scene-construction path, and
+semantic `roomConnections` intentionally do not create or remove geometry.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -241,8 +241,11 @@ Wall authoring supports two current-state representations:
 Those gaps describe present topology only. They are not removed-wall records.
 Validation rejects source IDs with whole tombstone-like path segments such as
 `former`, `removed`, or `debugonlyremoval`, including when those words are the
-final segment. Doorway gaps must be finite, axis-aligned, within the wall run,
-non-overlapping, and wide enough for the legacy doorway checks. A visible door,
+final segment. Doorway gaps use local distances measured from `run.start`
+toward `run.end`; the adapter projects those local distances into absolute
+legacy doorway ranges. Doorway gaps must be finite, positive, axis-aligned,
+within that local wall-run span, non-overlapping, sorted or normalizable, and
+wide enough for the legacy doorway checks. A visible door,
 arch, trim, threshold, or rail should be declared as a scene object or current
 wall/railing; a walkable opening does not need a former blocker record.
 

--- a/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
+++ b/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
@@ -43,7 +43,7 @@ const level: LevelDefinition = {
           run: {
             start: { x: 4, z: 0 },
             end: { x: 4, z: 4 },
-            gaps: [{ start: 1.5, end: 2.5 }],
+            gaps: [{ start: 1.3, end: 2.7 }],
           },
           rooms: ['left', 'right'],
         },
@@ -72,12 +72,22 @@ const level: LevelDefinition = {
 describe('compileLegacyFloorPlan', () => {
   it('compiles declarative rooms into the legacy floor plan shape', () => {
     expect(compileLegacyFloorPlan(level, 'ground')).toEqual({
-      outline: level.floors[0].outline,
+      outline: level.floors[0].outline.map(([x, z]) => [x, z]),
       rooms: [
         expect.objectContaining({ id: 'left', doorways: undefined }),
         expect.objectContaining({ id: 'right', doorways: undefined }),
       ],
     });
+  });
+
+  it('copies mutable legacy plan data away from the declarative source', () => {
+    const plan = compileLegacyFloorPlan(level, 'ground');
+
+    plan.outline[0][0] = 999;
+    plan.rooms[0].bounds.minX = 999;
+
+    expect(level.floors[0].outline[0][0]).toBe(0);
+    expect(level.floors[0].rooms[0].bounds.minX).toBe(0);
   });
 
   it('derives legacy doorway compatibility from current wall gaps when requested', () => {
@@ -86,8 +96,8 @@ describe('compileLegacyFloorPlan', () => {
     });
 
     expect(plan.rooms).toMatchObject([
-      { id: 'left', doorways: [{ wall: 'east', start: 1.5, end: 2.5 }] },
-      { id: 'right', doorways: [{ wall: 'west', start: 1.5, end: 2.5 }] },
+      { id: 'left', doorways: [{ wall: 'east', start: 1.3, end: 2.7 }] },
+      { id: 'right', doorways: [{ wall: 'west', start: 1.3, end: 2.7 }] },
     ]);
   });
 

--- a/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
+++ b/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { compileLegacyFloorPlan } from '../compileLegacyFloorPlan';
+import type { LevelDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const level: LevelDefinition = {
+  id: 'test-level',
+  floors: [
+    {
+      id: 'ground',
+      name: 'Ground',
+      outline: [
+        [0, 0],
+        [8, 0],
+        [8, 4],
+        [0, 4],
+      ],
+      rooms: [
+        {
+          id: 'left',
+          sourceId: sourceId('ground.left.room'),
+          name: 'Left',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+          ledColor: 0xffffff,
+        },
+        {
+          id: 'right',
+          sourceId: sourceId('ground.right.room'),
+          name: 'Right',
+          bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+          ledColor: 0xff00ff,
+        },
+      ],
+      walls: [
+        {
+          id: 'dividing-wall',
+          sourceId: sourceId('ground.dividing_wall'),
+          floorId: 'ground',
+          wallKind: 'wall',
+          run: {
+            start: { x: 4, z: 0 },
+            end: { x: 4, z: 4 },
+            gaps: [{ start: 1.5, end: 2.5 }],
+          },
+          rooms: ['left', 'right'],
+        },
+      ],
+      floorSurfaces: [
+        {
+          id: 'left-floor',
+          sourceId: sourceId('ground.left.floor_surface'),
+          floorId: 'ground',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+        },
+      ],
+      roomConnections: [
+        {
+          id: 'left-to-right',
+          sourceId: sourceId('ground.left_to_right.connection'),
+          floorId: 'ground',
+          rooms: ['left', 'right'],
+          purpose: 'semantic adjacency only',
+        },
+      ],
+    },
+  ],
+};
+
+describe('compileLegacyFloorPlan', () => {
+  it('compiles declarative rooms into the legacy floor plan shape', () => {
+    expect(compileLegacyFloorPlan(level, 'ground')).toEqual({
+      outline: level.floors[0].outline,
+      rooms: [
+        expect.objectContaining({ id: 'left', doorways: undefined }),
+        expect.objectContaining({ id: 'right', doorways: undefined }),
+      ],
+    });
+  });
+
+  it('derives legacy doorway compatibility from current wall gaps when requested', () => {
+    const plan = compileLegacyFloorPlan(level, 'ground', {
+      includeDoorwaysFromWallGaps: true,
+    });
+
+    expect(plan.rooms).toMatchObject([
+      { id: 'left', doorways: [{ wall: 'east', start: 1.5, end: 2.5 }] },
+      { id: 'right', doorways: [{ wall: 'west', start: 1.5, end: 2.5 }] },
+    ]);
+  });
+
+  it('proves semantic room connections alone do not generate or remove geometry', () => {
+    const withoutConnections = structuredClone(level);
+    withoutConnections.floors[0].roomConnections = [];
+
+    expect(compileLegacyFloorPlan(level, 'ground')).toEqual(
+      compileLegacyFloorPlan(withoutConnections, 'ground')
+    );
+  });
+});

--- a/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
+++ b/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
@@ -101,6 +101,82 @@ describe('compileLegacyFloorPlan', () => {
     ]);
   });
 
+  it('projects offset and reversed vertical wall gaps into absolute doorway ranges', () => {
+    const offset = structuredClone(level);
+    offset.floors[0].walls[0].run = {
+      start: { x: 4, z: 4 },
+      end: { x: 4, z: 0 },
+      gaps: [{ start: 1.3, end: 2.7 }],
+    };
+
+    const plan = compileLegacyFloorPlan(offset, 'ground', {
+      includeDoorwaysFromWallGaps: true,
+    });
+
+    expect(plan.rooms).toMatchObject([
+      { id: 'left', doorways: [{ wall: 'east', start: 1.3, end: 2.7 }] },
+      { id: 'right', doorways: [{ wall: 'west', start: 1.3, end: 2.7 }] },
+    ]);
+  });
+
+  it('projects offset and reversed horizontal wall gaps into absolute doorway ranges', () => {
+    const horizontal = structuredClone(level);
+    horizontal.floors[0].rooms = [
+      {
+        id: 'bottom',
+        sourceId: sourceId('ground.bottom.room'),
+        name: 'Bottom',
+        bounds: { minX: 0, maxX: 8, minZ: 0, maxZ: 2 },
+        ledColor: 0xffffff,
+      },
+      {
+        id: 'top',
+        sourceId: sourceId('ground.top.room'),
+        name: 'Top',
+        bounds: { minX: 0, maxX: 8, minZ: 2, maxZ: 4 },
+        ledColor: 0xff00ff,
+      },
+    ];
+    horizontal.floors[0].walls[0] = {
+      ...horizontal.floors[0].walls[0],
+      run: {
+        start: { x: 8, z: 2 },
+        end: { x: 0, z: 2 },
+        gaps: [{ start: 2, end: 4 }],
+      },
+      rooms: ['bottom', 'top'],
+    };
+    horizontal.floors[0].floorSurfaces[0].roomId = 'bottom';
+    horizontal.floors[0].roomConnections = [];
+
+    const plan = compileLegacyFloorPlan(horizontal, 'ground', {
+      includeDoorwaysFromWallGaps: true,
+    });
+
+    expect(plan.rooms).toMatchObject([
+      { id: 'bottom', doorways: [{ wall: 'north', start: 4, end: 6 }] },
+      { id: 'top', doorways: [{ wall: 'south', start: 4, end: 6 }] },
+    ]);
+  });
+
+  it('ignores wall gaps that do not overlap the referenced room boundary', () => {
+    const nonOverlapping = structuredClone(level);
+    nonOverlapping.floors[0].walls[0].run = {
+      start: { x: 4, z: 5 },
+      end: { x: 4, z: 7 },
+      gaps: [{ start: 0.1, end: 1.4 }],
+    };
+
+    const plan = compileLegacyFloorPlan(nonOverlapping, 'ground', {
+      includeDoorwaysFromWallGaps: true,
+    });
+
+    expect(plan.rooms).toMatchObject([
+      { id: 'left', doorways: undefined },
+      { id: 'right', doorways: undefined },
+    ]);
+  });
+
   it('proves semantic room connections alone do not generate or remove geometry', () => {
     const withoutConnections = structuredClone(level);
     withoutConnections.floors[0].roomConnections = [];

--- a/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
+++ b/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
@@ -159,6 +159,35 @@ describe('compileLegacyFloorPlan', () => {
     ]);
   });
 
+  it('clips projected wall gaps to the room edge and rechecks doorway width', () => {
+    const partialOverlap = structuredClone(level);
+    partialOverlap.floors[0].rooms[0].bounds.maxZ = 5;
+    partialOverlap.floors[0].rooms[1].bounds.maxZ = 5;
+    partialOverlap.floors[0].outline = [
+      [0, 0],
+      [8, 0],
+      [8, 5],
+      [0, 5],
+    ];
+    partialOverlap.floors[0].walls[0].run = {
+      start: { x: 4, z: 0 },
+      end: { x: 4, z: 10 },
+      gaps: [
+        { start: 4.1, end: 5.3 },
+        { start: 1.3, end: 2.7 },
+      ],
+    };
+
+    const plan = compileLegacyFloorPlan(partialOverlap, 'ground', {
+      includeDoorwaysFromWallGaps: true,
+    });
+
+    expect(plan.rooms).toMatchObject([
+      { id: 'left', doorways: [{ wall: 'east', start: 1.3, end: 2.7 }] },
+      { id: 'right', doorways: [{ wall: 'west', start: 1.3, end: 2.7 }] },
+    ]);
+  });
+
   it('ignores wall gaps that do not overlap the referenced room boundary', () => {
     const nonOverlapping = structuredClone(level);
     nonOverlapping.floors[0].walls[0].run = {

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -185,14 +185,18 @@ describe('declarative level schema validation', () => {
     const level = createLevel();
     level.floors[0].outline = [
       [0, 0],
+      null,
       [Number.NaN, 0],
+      undefined,
       [0, 0],
-    ];
+    ] as never;
     level.floors[0].rooms[0].bounds.maxX = Number.NaN;
 
     expect(validateLevelDefinition(level).errors).toEqual(
       expect.arrayContaining([
         expect.stringContaining('point 1 must use finite coordinates'),
+        expect.stringContaining('point 2 must use finite coordinates'),
+        expect.stringContaining('point 3 must use finite coordinates'),
         expect.stringContaining('must not contain repeated points'),
         expect.stringContaining('bounds must use finite coordinates'),
       ])
@@ -253,6 +257,31 @@ describe('declarative level schema validation', () => {
 
     expect(validateLevelDefinition(undefinedRun).errors).toContain(
       'wall "studio-west-wall" requires either segments or a run.'
+    );
+
+    const nullSegment = createLevel();
+    nullSegment.floors[0].walls[0].segments = [null] as never;
+
+    expect(validateLevelDefinition(nullSegment).errors).toContain(
+      'wall "gallery-south-wall" segment 0 must use finite coordinates.'
+    );
+
+    const missingSegmentStart = createLevel();
+    missingSegmentStart.floors[0].walls[0].segments = [
+      { end: { x: 5, z: 0 } },
+    ] as never;
+
+    expect(validateLevelDefinition(missingSegmentStart).errors).toContain(
+      'wall "gallery-south-wall" segment 0 must use finite coordinates.'
+    );
+
+    const missingRunStart = createLevel();
+    missingRunStart.floors[0].walls[1].run = {
+      end: { x: 5, z: 6 },
+    } as never;
+
+    expect(validateLevelDefinition(missingRunStart).errors).toContain(
+      'wall "studio-west-wall" run must use finite coordinates.'
     );
   });
 

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertValidLevelDefinition,
+  validateLevelDefinition,
+  type LevelDefinition,
+} from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const createLevel = (): LevelDefinition => ({
+  id: 'test-level',
+  floors: [
+    {
+      id: 'ground',
+      name: 'Ground',
+      outline: [
+        [0, 0],
+        [10, 0],
+        [10, 6],
+        [0, 6],
+      ],
+      rooms: [
+        {
+          id: 'gallery',
+          sourceId: sourceId('ground.gallery.room'),
+          name: 'Gallery',
+          bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 6 },
+          ledColor: 0xffffff,
+        },
+        {
+          id: 'studio',
+          sourceId: sourceId('ground.studio.room'),
+          name: 'Studio',
+          bounds: { minX: 5, maxX: 10, minZ: 0, maxZ: 6 },
+          ledColor: 0x58c4ff,
+        },
+      ],
+      walls: [
+        {
+          id: 'gallery-south-wall',
+          sourceId: sourceId('ground.gallery.south_wall'),
+          floorId: 'ground',
+          wallKind: 'wall',
+          segments: [{ start: { x: 0, z: 0 }, end: { x: 5, z: 0 } }],
+          rooms: ['gallery'],
+          purpose: 'room-boundary',
+        },
+        {
+          id: 'studio-west-wall',
+          sourceId: sourceId('ground.studio.west_wall'),
+          floorId: 'ground',
+          wallKind: 'wall',
+          run: {
+            start: { x: 5, z: 0 },
+            end: { x: 5, z: 6 },
+            gaps: [{ start: 2, end: 4, label: 'open passage' }],
+          },
+          rooms: ['gallery', 'studio'],
+        },
+      ],
+      floorSurfaces: [
+        {
+          id: 'gallery-floor',
+          sourceId: sourceId('ground.gallery.floor_surface'),
+          floorId: 'ground',
+          bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 6 },
+          roomId: 'gallery',
+          purpose: 'walkable floor',
+        },
+      ],
+      safetyColliders: [
+        {
+          id: 'stair-guard',
+          sourceId: sourceId('ground.stair_guard.safety_collider'),
+          floorId: 'ground',
+          bounds: { minX: 4, maxX: 6, minZ: 5, maxZ: 6 },
+          purpose: 'Prevent falls near test void.',
+        },
+      ],
+      sceneObjects: [
+        {
+          id: 'threshold',
+          sourceId: sourceId('ground.gallery_threshold.scene_object'),
+          floorId: 'ground',
+          kind: 'threshold',
+          position: { x: 5, z: 3 },
+          colliderPolicy: { kind: 'none', reason: 'walkable trim' },
+          roomId: 'gallery',
+        },
+      ],
+      roomConnections: [
+        {
+          id: 'gallery-to-studio',
+          sourceId: sourceId('ground.gallery_to_studio.connection'),
+          floorId: 'ground',
+          rooms: ['gallery', 'studio'],
+          label: 'Gallery to Studio',
+          purpose: 'semantic adjacency only',
+        },
+      ],
+    },
+  ],
+});
+
+describe('declarative level schema validation', () => {
+  it('validates a small declarative floor with rooms, walls, surfaces, colliders, objects, and connections', () => {
+    expect(() => assertValidLevelDefinition(createLevel())).not.toThrow();
+  });
+
+  it('allows intentional current-state wall gaps without former wall records', () => {
+    const result = validateLevelDefinition(createLevel());
+
+    expect(result.errors).toEqual([]);
+    expect(createLevel().floors[0].walls[1]).toMatchObject({
+      run: { gaps: [{ start: 2, end: 4 }] },
+    });
+  });
+
+  it('rejects invalid source IDs, duplicates, zero geometry, and missing room references', () => {
+    const level = createLevel();
+    level.floors[0].rooms[0].sourceId = 'Ground.Bad Room' as never;
+    level.floors[0].walls[1].sourceId = sourceId('ground.gallery.south_wall');
+    level.floors[0].walls[0].segments[0].end = { x: 0, z: 0 };
+    level.floors[0].floorSurfaces[0].bounds.maxX = 0;
+    level.floors[0].safetyColliders![0].purpose = '';
+    level.floors[0].roomConnections![0].rooms = ['gallery', 'missing'];
+
+    expect(validateLevelDefinition(level).errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('invalid sourceId'),
+        expect.stringContaining('Duplicate sourceId'),
+        expect.stringContaining('positive length'),
+        expect.stringContaining('positive area'),
+        expect.stringContaining('requires a purpose'),
+        expect.stringContaining('references missing room "missing"'),
+      ])
+    );
+  });
+
+  it('rejects source IDs that look like tombstone/debug-only removal records', () => {
+    const level = createLevel();
+    level.floors[0].walls[0].sourceId = sourceId('ground.gallery.former.wall');
+
+    expect(validateLevelDefinition(level).errors).toContain(
+      'wall "gallery-south-wall" sourceId "ground.gallery.former.wall" uses forbidden tombstone wording.'
+    );
+  });
+});

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -140,11 +140,44 @@ describe('declarative level schema validation', () => {
   });
 
   it('rejects source IDs that look like tombstone/debug-only removal records', () => {
+    for (const term of ['former', 'removed', 'debugonlyremoval']) {
+      const level = createLevel();
+      level.floors[0].walls[0].sourceId = sourceId(`ground.gallery.${term}`);
+
+      expect(validateLevelDefinition(level).errors).toContain(
+        `wall "gallery-south-wall" sourceId "ground.gallery.${term}" uses forbidden tombstone wording.`
+      );
+    }
+  });
+
+  it('rejects levels without floors', () => {
     const level = createLevel();
-    level.floors[0].walls[0].sourceId = sourceId('ground.gallery.removed');
+    level.floors = [];
 
     expect(validateLevelDefinition(level).errors).toContain(
-      'wall "gallery-south-wall" sourceId "ground.gallery.removed" uses forbidden tombstone wording.'
+      'level "test-level" requires at least one floor.'
+    );
+  });
+
+  it('rejects empty, too-small, non-finite, and duplicate floor outlines', () => {
+    const level = createLevel();
+    level.floors[0].outline = [];
+
+    expect(validateLevelDefinition(level).errors).toContain(
+      'floor "ground" outline requires at least three points.'
+    );
+
+    level.floors[0].outline = [
+      [0, 0],
+      [Number.POSITIVE_INFINITY, 0],
+      [0, 0],
+    ];
+
+    expect(validateLevelDefinition(level).errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('point 1 must use finite coordinates'),
+        expect.stringContaining('must not contain repeated points'),
+      ])
     );
   });
 
@@ -166,15 +199,60 @@ describe('declarative level schema validation', () => {
     );
   });
 
+  it('rejects infinite and inverted bounds', () => {
+    const infiniteBounds = createLevel();
+    infiniteBounds.floors[0].floorSurfaces[0].bounds.maxZ =
+      Number.POSITIVE_INFINITY;
+
+    expect(validateLevelDefinition(infiniteBounds).errors).toContain(
+      'floor surface "gallery-floor" bounds must use finite coordinates.'
+    );
+
+    const invertedBounds = createLevel();
+    invertedBounds.floors[0].rooms[0].bounds.minX = 5;
+    invertedBounds.floors[0].rooms[0].bounds.maxX = 4;
+
+    expect(validateLevelDefinition(invertedBounds).errors).toContain(
+      'room "gallery" bounds must have positive area.'
+    );
+  });
+
   it('reports malformed wall geometry instead of throwing', () => {
-    const level = createLevel();
-    level.floors[0].walls[0] = {
-      ...level.floors[0].walls[0],
+    const undefinedSegments = createLevel();
+    undefinedSegments.floors[0].walls[0] = {
+      ...undefinedSegments.floors[0].walls[0],
       segments: undefined,
     } as never;
 
-    expect(validateLevelDefinition(level).errors).toContain(
+    expect(validateLevelDefinition(undefinedSegments).errors).toContain(
       'wall "gallery-south-wall" requires either segments or a run.'
+    );
+
+    const bothKinds = createLevel();
+    bothKinds.floors[0].walls[0] = {
+      ...bothKinds.floors[0].walls[0],
+      run: { start: { x: 0, z: 0 }, end: { x: 5, z: 0 } },
+    } as never;
+
+    expect(validateLevelDefinition(bothKinds).errors).toContain(
+      'wall "gallery-south-wall" must define either segments or a run, not both.'
+    );
+
+    const neitherKind = createLevel();
+    delete (neitherKind.floors[0].walls[0] as { segments?: unknown }).segments;
+
+    expect(validateLevelDefinition(neitherKind).errors).toContain(
+      'wall "gallery-south-wall" requires either segments or a run.'
+    );
+
+    const undefinedRun = createLevel();
+    undefinedRun.floors[0].walls[1] = {
+      ...undefinedRun.floors[0].walls[1],
+      run: undefined,
+    } as never;
+
+    expect(validateLevelDefinition(undefinedRun).errors).toContain(
+      'wall "studio-west-wall" requires either segments or a run.'
     );
   });
 
@@ -187,6 +265,8 @@ describe('declarative level schema validation', () => {
         { start: Number.NaN, end: 2 },
         { start: -1, end: 1 },
         { start: 2, end: 2.5 },
+        { start: 3, end: 2 },
+        { start: 3.5, end: 5 },
       ],
     };
 
@@ -203,6 +283,8 @@ describe('declarative level schema validation', () => {
         { start: Number.NaN, end: 2 },
         { start: -1, end: 1 },
         { start: 2, end: 2.5 },
+        { start: 3, end: 2 },
+        { start: 3.5, end: 5 },
       ],
     };
 
@@ -211,6 +293,8 @@ describe('declarative level schema validation', () => {
         expect.stringContaining('gap 0 must use finite coordinates'),
         expect.stringContaining('gap 1 must stay within the run'),
         expect.stringContaining('gap 2 must be at least 1.2 units wide'),
+        expect.stringContaining('gap 3 must have positive length'),
+        expect.stringContaining('must not overlap another gap'),
       ])
     );
   });

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -141,10 +141,77 @@ describe('declarative level schema validation', () => {
 
   it('rejects source IDs that look like tombstone/debug-only removal records', () => {
     const level = createLevel();
-    level.floors[0].walls[0].sourceId = sourceId('ground.gallery.former.wall');
+    level.floors[0].walls[0].sourceId = sourceId('ground.gallery.removed');
 
     expect(validateLevelDefinition(level).errors).toContain(
-      'wall "gallery-south-wall" sourceId "ground.gallery.former.wall" uses forbidden tombstone wording.'
+      'wall "gallery-south-wall" sourceId "ground.gallery.removed" uses forbidden tombstone wording.'
+    );
+  });
+
+  it('rejects malformed floor outlines and non-finite room bounds', () => {
+    const level = createLevel();
+    level.floors[0].outline = [
+      [0, 0],
+      [Number.NaN, 0],
+      [0, 0],
+    ];
+    level.floors[0].rooms[0].bounds.maxX = Number.NaN;
+
+    expect(validateLevelDefinition(level).errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('point 1 must use finite coordinates'),
+        expect.stringContaining('must not contain repeated points'),
+        expect.stringContaining('bounds must use finite coordinates'),
+      ])
+    );
+  });
+
+  it('reports malformed wall geometry instead of throwing', () => {
+    const level = createLevel();
+    level.floors[0].walls[0] = {
+      ...level.floors[0].walls[0],
+      segments: undefined,
+    } as never;
+
+    expect(validateLevelDefinition(level).errors).toContain(
+      'wall "gallery-south-wall" requires either segments or a run.'
+    );
+  });
+
+  it('rejects wall gaps that cannot compile into bounded legacy doorways', () => {
+    const level = createLevel();
+    level.floors[0].walls[1].run = {
+      start: { x: 5, z: 0 },
+      end: { x: 9, z: 4 },
+      gaps: [
+        { start: Number.NaN, end: 2 },
+        { start: -1, end: 1 },
+        { start: 2, end: 2.5 },
+      ],
+    };
+
+    expect(validateLevelDefinition(level).errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('gaps require an axis-aligned run'),
+      ])
+    );
+
+    level.floors[0].walls[1].run = {
+      start: { x: 5, z: 0 },
+      end: { x: 5, z: 6 },
+      gaps: [
+        { start: Number.NaN, end: 2 },
+        { start: -1, end: 1 },
+        { start: 2, end: 2.5 },
+      ],
+    };
+
+    expect(validateLevelDefinition(level).errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('gap 0 must use finite coordinates'),
+        expect.stringContaining('gap 1 must stay within the run'),
+        expect.stringContaining('gap 2 must be at least 1.2 units wide'),
+      ])
     );
   });
 });

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -292,10 +292,12 @@ describe('declarative level schema validation', () => {
       end: { x: 9, z: 4 },
       gaps: [
         { start: Number.NaN, end: 2 },
+        null,
         { start: -1, end: 1 },
         { start: 2, end: 2.5 },
         { start: 3, end: 2 },
         { start: 3.5, end: 5 },
+        { start: 4, end: 5.5 },
       ],
     };
 
@@ -310,19 +312,22 @@ describe('declarative level schema validation', () => {
       end: { x: 5, z: 6 },
       gaps: [
         { start: Number.NaN, end: 2 },
+        null,
         { start: -1, end: 1 },
         { start: 2, end: 2.5 },
         { start: 3, end: 2 },
         { start: 3.5, end: 5 },
+        { start: 4, end: 5.5 },
       ],
     };
 
     expect(validateLevelDefinition(level).errors).toEqual(
       expect.arrayContaining([
         expect.stringContaining('gap 0 must use finite coordinates'),
-        expect.stringContaining('gap 1 must stay within the run'),
-        expect.stringContaining('gap 2 must be at least 1.2 units wide'),
-        expect.stringContaining('gap 3 must have positive length'),
+        expect.stringContaining('gap 1 must use finite coordinates'),
+        expect.stringContaining('gap 0 must stay within the run'),
+        expect.stringContaining('gap 1 must be at least 1.2 units wide'),
+        expect.stringContaining('gap 2 must have positive length'),
         expect.stringContaining('must not overlap another gap'),
       ])
     );

--- a/src/scene/level/compileLegacyFloorPlan.ts
+++ b/src/scene/level/compileLegacyFloorPlan.ts
@@ -63,11 +63,17 @@ function getDoorwaysForWall(
   const roomWall = getRoomWallForRun(room, wall.run);
   if (!roomWall) return [];
 
-  return wall.run.gaps.map((gap) => ({
-    wall: roomWall,
-    start: gap.start,
-    end: gap.end,
-  }));
+  return wall.run.gaps.flatMap((gap) => {
+    const doorwayRange = projectGapToDoorwayRange(wall.run, gap.start, gap.end);
+    if (
+      !doorwayRange ||
+      !doorwayOverlapsRoomWall(room, roomWall, doorwayRange)
+    ) {
+      return [];
+    }
+
+    return [{ wall: roomWall, ...doorwayRange }];
+  });
 }
 
 function getRoomWallForRun(
@@ -87,4 +93,66 @@ function getRoomWallForRun(
   }
 
   return undefined;
+}
+
+function projectGapToDoorwayRange(
+  run: WallDefinition['run'],
+  gapStart: number,
+  gapEnd: number
+): Pick<DoorwayDefinition, 'start' | 'end'> | undefined {
+  const deltaX = run.end.x - run.start.x;
+  const deltaZ = run.end.z - run.start.z;
+  const runLength = Math.hypot(deltaX, deltaZ);
+  if (runLength <= AXIS_EPSILON) return undefined;
+
+  const startRatio = gapStart / runLength;
+  const endRatio = gapEnd / runLength;
+  const projectedStart = {
+    x: run.start.x + deltaX * startRatio,
+    z: run.start.z + deltaZ * startRatio,
+  };
+  const projectedEnd = {
+    x: run.start.x + deltaX * endRatio,
+    z: run.start.z + deltaZ * endRatio,
+  };
+
+  if (Math.abs(deltaZ) <= AXIS_EPSILON) {
+    return normalizeDoorwayRange(projectedStart.x, projectedEnd.x);
+  }
+
+  if (Math.abs(deltaX) <= AXIS_EPSILON) {
+    return normalizeDoorwayRange(projectedStart.z, projectedEnd.z);
+  }
+
+  return undefined;
+}
+
+function normalizeDoorwayRange(
+  start: number,
+  end: number
+): Pick<DoorwayDefinition, 'start' | 'end'> {
+  return {
+    start: roundDoorwayCoordinate(Math.min(start, end)),
+    end: roundDoorwayCoordinate(Math.max(start, end)),
+  };
+}
+
+function roundDoorwayCoordinate(value: number): number {
+  return Number(value.toFixed(12));
+}
+
+function doorwayOverlapsRoomWall(
+  room: SemanticRoomDefinition,
+  wall: RoomWall,
+  doorway: Pick<DoorwayDefinition, 'start' | 'end'>
+): boolean {
+  const bounds =
+    wall === 'north' || wall === 'south'
+      ? { min: room.bounds.minX, max: room.bounds.maxX }
+      : { min: room.bounds.minZ, max: room.bounds.maxZ };
+
+  return (
+    doorway.end > bounds.min + AXIS_EPSILON &&
+    doorway.start < bounds.max - AXIS_EPSILON
+  );
 }

--- a/src/scene/level/compileLegacyFloorPlan.ts
+++ b/src/scene/level/compileLegacyFloorPlan.ts
@@ -29,11 +29,11 @@ export function compileLegacyFloorPlan(
     throw new Error(`Level "${level.id}" does not contain floor "${floorId}".`);
 
   return {
-    outline: floor.outline,
+    outline: floor.outline.map(([x, z]) => [x, z]),
     rooms: floor.rooms.map((room) => ({
       id: room.id,
       name: room.name,
-      bounds: room.bounds,
+      bounds: { ...room.bounds },
       ledColor: room.ledColor,
       category: room.category,
       doorways: options.includeDoorwaysFromWallGaps

--- a/src/scene/level/compileLegacyFloorPlan.ts
+++ b/src/scene/level/compileLegacyFloorPlan.ts
@@ -13,6 +13,7 @@ import {
 } from './schema';
 
 const AXIS_EPSILON = 1e-6;
+const LEGACY_DOORWAY_MIN_WIDTH = 1.2;
 
 export interface CompileLegacyFloorPlanOptions {
   includeDoorwaysFromWallGaps?: boolean;
@@ -65,14 +66,16 @@ function getDoorwaysForWall(
 
   return wall.run.gaps.flatMap((gap) => {
     const doorwayRange = projectGapToDoorwayRange(wall.run, gap.start, gap.end);
-    if (
-      !doorwayRange ||
-      !doorwayOverlapsRoomWall(room, roomWall, doorwayRange)
-    ) {
-      return [];
-    }
+    if (!doorwayRange) return [];
 
-    return [{ wall: roomWall, ...doorwayRange }];
+    const clippedDoorwayRange = clipDoorwayRangeToRoomWall(
+      room,
+      roomWall,
+      doorwayRange
+    );
+    if (!clippedDoorwayRange) return [];
+
+    return [{ wall: roomWall, ...clippedDoorwayRange }];
   });
 }
 
@@ -141,18 +144,24 @@ function roundDoorwayCoordinate(value: number): number {
   return Number(value.toFixed(12));
 }
 
-function doorwayOverlapsRoomWall(
+function clipDoorwayRangeToRoomWall(
   room: SemanticRoomDefinition,
   wall: RoomWall,
   doorway: Pick<DoorwayDefinition, 'start' | 'end'>
-): boolean {
+): Pick<DoorwayDefinition, 'start' | 'end'> | undefined {
   const bounds =
     wall === 'north' || wall === 'south'
       ? { min: room.bounds.minX, max: room.bounds.maxX }
       : { min: room.bounds.minZ, max: room.bounds.maxZ };
+  const clippedStart = Math.max(doorway.start, bounds.min);
+  const clippedEnd = Math.min(doorway.end, bounds.max);
+  if (clippedEnd - clippedStart <= AXIS_EPSILON) return undefined;
 
-  return (
-    doorway.end > bounds.min + AXIS_EPSILON &&
-    doorway.start < bounds.max - AXIS_EPSILON
-  );
+  const clipped = normalizeDoorwayRange(clippedStart, clippedEnd);
+
+  if (clipped.end - clipped.start + AXIS_EPSILON < LEGACY_DOORWAY_MIN_WIDTH) {
+    return undefined;
+  }
+
+  return clipped;
 }

--- a/src/scene/level/compileLegacyFloorPlan.ts
+++ b/src/scene/level/compileLegacyFloorPlan.ts
@@ -1,0 +1,90 @@
+import type {
+  DoorwayDefinition,
+  FloorPlanDefinition,
+  RoomWall,
+} from '../../assets/floorPlan';
+
+import {
+  assertValidLevelDefinition,
+  type FloorDefinition,
+  type LevelDefinition,
+  type SemanticRoomDefinition,
+  type WallDefinition,
+} from './schema';
+
+const AXIS_EPSILON = 1e-6;
+
+export interface CompileLegacyFloorPlanOptions {
+  includeDoorwaysFromWallGaps?: boolean;
+}
+
+export function compileLegacyFloorPlan(
+  level: LevelDefinition,
+  floorId: string,
+  options: CompileLegacyFloorPlanOptions = {}
+): FloorPlanDefinition {
+  assertValidLevelDefinition(level);
+  const floor = level.floors.find((candidate) => candidate.id === floorId);
+  if (!floor)
+    throw new Error(`Level "${level.id}" does not contain floor "${floorId}".`);
+
+  return {
+    outline: floor.outline,
+    rooms: floor.rooms.map((room) => ({
+      id: room.id,
+      name: room.name,
+      bounds: room.bounds,
+      ledColor: room.ledColor,
+      category: room.category,
+      doorways: options.includeDoorwaysFromWallGaps
+        ? deriveDoorwaysFromWallGaps(floor, room)
+        : undefined,
+    })),
+  };
+}
+
+function deriveDoorwaysFromWallGaps(
+  floor: FloorDefinition,
+  room: SemanticRoomDefinition
+): DoorwayDefinition[] | undefined {
+  const doorways = floor.walls.flatMap((wall) =>
+    getDoorwaysForWall(room, wall)
+  );
+  return doorways.length > 0 ? doorways : undefined;
+}
+
+function getDoorwaysForWall(
+  room: SemanticRoomDefinition,
+  wall: WallDefinition
+): DoorwayDefinition[] {
+  if (!('run' in wall) || !wall.rooms?.includes(room.id) || !wall.run.gaps)
+    return [];
+
+  const roomWall = getRoomWallForRun(room, wall.run);
+  if (!roomWall) return [];
+
+  return wall.run.gaps.map((gap) => ({
+    wall: roomWall,
+    start: gap.start,
+    end: gap.end,
+  }));
+}
+
+function getRoomWallForRun(
+  room: SemanticRoomDefinition,
+  run: WallDefinition['run']
+): RoomWall | undefined {
+  if (Math.abs(run.start.z - run.end.z) <= AXIS_EPSILON) {
+    if (Math.abs(run.start.z - room.bounds.maxZ) <= AXIS_EPSILON)
+      return 'north';
+    if (Math.abs(run.start.z - room.bounds.minZ) <= AXIS_EPSILON)
+      return 'south';
+  }
+
+  if (Math.abs(run.start.x - run.end.x) <= AXIS_EPSILON) {
+    if (Math.abs(run.start.x - room.bounds.maxX) <= AXIS_EPSILON) return 'east';
+    if (Math.abs(run.start.x - room.bounds.minX) <= AXIS_EPSILON) return 'west';
+  }
+
+  return undefined;
+}

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -63,7 +63,10 @@ export interface WallRunGapDefinition {
 export interface WallRunDefinition {
   start: Point2D;
   end: Point2D;
-  /** Intentional current topology gaps such as open passages, not tombstones. */
+  /**
+   * Intentional current topology gaps such as open passages, not tombstones.
+   * Gap start/end are local distances measured from run.start toward run.end.
+   */
   gaps?: WallRunGapDefinition[];
 }
 
@@ -140,6 +143,10 @@ export function validateLevelDefinition(
   const errors: string[] = [];
   const sourceIds = new Map<string, string>();
   const floorIds = new Set<string>();
+
+  if (level.floors.length === 0) {
+    errors.push(`level "${level.id}" requires at least one floor.`);
+  }
 
   const addNamespaceId = (namespace: string, id: string, ids: Set<string>) => {
     if (ids.has(id)) {
@@ -349,7 +356,17 @@ function validateOutline(
 }
 
 function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
-  if ('segments' in wall && wall.segments !== undefined) {
+  const hasSegments = 'segments' in wall && wall.segments !== undefined;
+  const hasRun = 'run' in wall && wall.run !== undefined;
+
+  if (hasSegments && hasRun) {
+    errors.push(
+      `wall "${wall.id}" must define either segments or a run, not both.`
+    );
+    return;
+  }
+
+  if (hasSegments) {
     if (wall.segments.length === 0)
       errors.push(`wall "${wall.id}" requires at least one segment.`);
     wall.segments.forEach((segment, index) => {
@@ -367,7 +384,7 @@ function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
     return;
   }
 
-  if (!('run' in wall) || wall.run === undefined) {
+  if (!hasRun) {
     errors.push(`wall "${wall.id}" requires either segments or a run.`);
     return;
   }
@@ -386,8 +403,8 @@ function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
 function validateWallRunGaps(wall: WallDefinition, errors: string[]): void {
   if (!('run' in wall) || !wall.run.gaps) return;
 
-  const axisRange = getWallRunAxisRange(wall.run);
-  if (!axisRange) {
+  const runLength = getSegmentLength(wall.run);
+  if (!isAxisAlignedRun(wall.run)) {
     errors.push(`wall "${wall.id}" gaps require an axis-aligned run.`);
     return;
   }
@@ -412,10 +429,7 @@ function validateWallRunGaps(wall: WallDefinition, errors: string[]): void {
       );
     }
 
-    if (
-      gap.start < axisRange.min - LENGTH_EPSILON ||
-      gap.end > axisRange.max + LENGTH_EPSILON
-    ) {
+    if (gap.start < -LENGTH_EPSILON || gap.end > runLength + LENGTH_EPSILON) {
       errors.push(`wall "${wall.id}" gap ${index} must stay within the run.`);
     }
 
@@ -428,24 +442,11 @@ function validateWallRunGaps(wall: WallDefinition, errors: string[]): void {
   });
 }
 
-function getWallRunAxisRange(
-  run: WallRunDefinition
-): { min: number; max: number } | undefined {
-  if (Math.abs(run.start.z - run.end.z) <= AXIS_EPSILON) {
-    return {
-      min: Math.min(run.start.x, run.end.x),
-      max: Math.max(run.start.x, run.end.x),
-    };
-  }
-
-  if (Math.abs(run.start.x - run.end.x) <= AXIS_EPSILON) {
-    return {
-      min: Math.min(run.start.z, run.end.z),
-      max: Math.max(run.start.z, run.end.z),
-    };
-  }
-
-  return undefined;
+function isAxisAlignedRun(run: WallRunDefinition): boolean {
+  return (
+    Math.abs(run.start.z - run.end.z) <= AXIS_EPSILON ||
+    Math.abs(run.start.x - run.end.x) <= AXIS_EPSILON
+  );
 }
 
 function segmentUsesFiniteCoordinates(segment: WallSegmentDefinition): boolean {

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -340,17 +340,14 @@ function validateOutline(
   }
 
   outline.forEach((point, index) => {
-    if (
-      point.length !== 2 ||
-      !Number.isFinite(point[0]) ||
-      !Number.isFinite(point[1])
-    ) {
+    if (!isFiniteOutlinePoint(point)) {
       errors.push(`${label} point ${index} must use finite coordinates.`);
     }
   });
 
-  const uniquePoints = new Set(outline.map(([x, z]) => `${x}:${z}`));
-  if (uniquePoints.size !== outline.length) {
+  const validPoints = outline.filter(isFiniteOutlinePoint);
+  const uniquePoints = new Set(validPoints.map(([x, z]) => `${x}:${z}`));
+  if (uniquePoints.size !== validPoints.length) {
     errors.push(`${label} must not contain repeated points.`);
   }
 }
@@ -367,6 +364,11 @@ function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
   }
 
   if (hasSegments) {
+    if (!Array.isArray(wall.segments)) {
+      errors.push(`wall "${wall.id}" segments must be an array.`);
+      return;
+    }
+
     if (wall.segments.length === 0)
       errors.push(`wall "${wall.id}" requires at least one segment.`);
     wall.segments.forEach((segment, index) => {
@@ -402,6 +404,11 @@ function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
 
 function validateWallRunGaps(wall: WallDefinition, errors: string[]): void {
   if (!('run' in wall) || !wall.run.gaps) return;
+
+  if (!Array.isArray(wall.run.gaps)) {
+    errors.push(`wall "${wall.id}" gaps must be an array.`);
+    return;
+  }
 
   const runLength = getSegmentLength(wall.run);
   if (!isAxisAlignedRun(wall.run)) {
@@ -449,10 +456,37 @@ function isAxisAlignedRun(run: WallRunDefinition): boolean {
   );
 }
 
-function segmentUsesFiniteCoordinates(segment: WallSegmentDefinition): boolean {
-  return [segment.start.x, segment.start.z, segment.end.x, segment.end.z].every(
-    Number.isFinite
+function isFiniteOutlinePoint(point: unknown): point is [number, number] {
+  return (
+    Array.isArray(point) &&
+    point.length === 2 &&
+    Number.isFinite(point[0]) &&
+    Number.isFinite(point[1])
   );
+}
+
+function segmentUsesFiniteCoordinates(
+  segment: WallSegmentDefinition | unknown
+): segment is WallSegmentDefinition {
+  if (
+    !isRecord(segment) ||
+    !isFinitePoint(segment.start) ||
+    !isFinitePoint(segment.end)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isFinitePoint(point: unknown): point is Point2D {
+  return (
+    isRecord(point) && Number.isFinite(point.x) && Number.isFinite(point.z)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function getSegmentLength(segment: WallSegmentDefinition): number {

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -129,12 +129,10 @@ export interface LevelValidationResult {
   errors: string[];
 }
 
-const FORBIDDEN_SOURCE_ID_PARTS = [
-  '.former.',
-  '.removed.',
-  '.debugOnlyRemoval.',
-];
+const FORBIDDEN_SOURCE_ID_PARTS = ['former', 'removed', 'debugonlyremoval'];
 const LENGTH_EPSILON = 1e-6;
+const LEGACY_DOORWAY_MIN_WIDTH = 1.2;
+const AXIS_EPSILON = 1e-6;
 
 export function validateLevelDefinition(
   level: LevelDefinition
@@ -158,7 +156,10 @@ export function validateLevelDefinition(
     }
 
     const rawSourceId = sourceId as string;
-    if (FORBIDDEN_SOURCE_ID_PARTS.some((part) => rawSourceId.includes(part))) {
+    const sourceIdParts = rawSourceId.split('.');
+    if (
+      FORBIDDEN_SOURCE_ID_PARTS.some((part) => sourceIdParts.includes(part))
+    ) {
       errors.push(
         `${owner} sourceId "${rawSourceId}" uses forbidden tombstone wording.`
       );
@@ -185,6 +186,8 @@ export function validateLevelDefinition(
     const safetyIds = new Set<string>();
     const objectIds = new Set<string>();
     const connectionIds = new Set<string>();
+
+    validateOutline(floor.outline, `floor "${floor.id}" outline`, errors);
 
     floor.rooms.forEach((room) => {
       addNamespaceId(`room on floor ${floor.id}`, room.id, roomIds);
@@ -306,6 +309,12 @@ function validateBounds(
   label: string,
   errors: string[]
 ): void {
+  const values = [bounds.minX, bounds.maxX, bounds.minZ, bounds.maxZ];
+  if (!values.every(Number.isFinite)) {
+    errors.push(`${label} must use finite coordinates.`);
+    return;
+  }
+
   if (
     bounds.maxX - bounds.minX <= LENGTH_EPSILON ||
     bounds.maxZ - bounds.minZ <= LENGTH_EPSILON
@@ -314,11 +323,42 @@ function validateBounds(
   }
 }
 
+function validateOutline(
+  outline: FloorDefinition['outline'],
+  label: string,
+  errors: string[]
+): void {
+  if (outline.length < 3) {
+    errors.push(`${label} requires at least three points.`);
+  }
+
+  outline.forEach((point, index) => {
+    if (
+      point.length !== 2 ||
+      !Number.isFinite(point[0]) ||
+      !Number.isFinite(point[1])
+    ) {
+      errors.push(`${label} point ${index} must use finite coordinates.`);
+    }
+  });
+
+  const uniquePoints = new Set(outline.map(([x, z]) => `${x}:${z}`));
+  if (uniquePoints.size !== outline.length) {
+    errors.push(`${label} must not contain repeated points.`);
+  }
+}
+
 function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
-  if ('segments' in wall) {
+  if ('segments' in wall && wall.segments !== undefined) {
     if (wall.segments.length === 0)
       errors.push(`wall "${wall.id}" requires at least one segment.`);
     wall.segments.forEach((segment, index) => {
+      if (!segmentUsesFiniteCoordinates(segment)) {
+        errors.push(
+          `wall "${wall.id}" segment ${index} must use finite coordinates.`
+        );
+        return;
+      }
       if (getSegmentLength(segment) <= LENGTH_EPSILON)
         errors.push(
           `wall "${wall.id}" segment ${index} must have positive length.`
@@ -327,13 +367,91 @@ function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
     return;
   }
 
+  if (!('run' in wall) || wall.run === undefined) {
+    errors.push(`wall "${wall.id}" requires either segments or a run.`);
+    return;
+  }
+
+  if (!segmentUsesFiniteCoordinates(wall.run)) {
+    errors.push(`wall "${wall.id}" run must use finite coordinates.`);
+    return;
+  }
+
   if (getSegmentLength(wall.run) <= LENGTH_EPSILON) {
     errors.push(`wall "${wall.id}" run must have positive length.`);
   }
-  wall.run.gaps?.forEach((gap, index) => {
-    if (gap.end - gap.start <= LENGTH_EPSILON)
+  validateWallRunGaps(wall, errors);
+}
+
+function validateWallRunGaps(wall: WallDefinition, errors: string[]): void {
+  if (!('run' in wall) || !wall.run.gaps) return;
+
+  const axisRange = getWallRunAxisRange(wall.run);
+  if (!axisRange) {
+    errors.push(`wall "${wall.id}" gaps require an axis-aligned run.`);
+    return;
+  }
+
+  const sortedGaps = [...wall.run.gaps].sort((a, b) => a.start - b.start);
+  sortedGaps.forEach((gap, index) => {
+    if (!Number.isFinite(gap.start) || !Number.isFinite(gap.end)) {
+      errors.push(
+        `wall "${wall.id}" gap ${index} must use finite coordinates.`
+      );
+      return;
+    }
+
+    if (gap.end - gap.start <= LENGTH_EPSILON) {
       errors.push(`wall "${wall.id}" gap ${index} must have positive length.`);
+      return;
+    }
+
+    if (gap.end - gap.start + LENGTH_EPSILON < LEGACY_DOORWAY_MIN_WIDTH) {
+      errors.push(
+        `wall "${wall.id}" gap ${index} must be at least ${LEGACY_DOORWAY_MIN_WIDTH} units wide.`
+      );
+    }
+
+    if (
+      gap.start < axisRange.min - LENGTH_EPSILON ||
+      gap.end > axisRange.max + LENGTH_EPSILON
+    ) {
+      errors.push(`wall "${wall.id}" gap ${index} must stay within the run.`);
+    }
+
+    const previousGap = sortedGaps[index - 1];
+    if (previousGap && gap.start < previousGap.end - LENGTH_EPSILON) {
+      errors.push(
+        `wall "${wall.id}" gap ${index} must not overlap another gap.`
+      );
+    }
   });
+}
+
+function getWallRunAxisRange(
+  run: WallRunDefinition
+): { min: number; max: number } | undefined {
+  if (Math.abs(run.start.z - run.end.z) <= AXIS_EPSILON) {
+    return {
+      min: Math.min(run.start.x, run.end.x),
+      max: Math.max(run.start.x, run.end.x),
+    };
+  }
+
+  if (Math.abs(run.start.x - run.end.x) <= AXIS_EPSILON) {
+    return {
+      min: Math.min(run.start.z, run.end.z),
+      max: Math.max(run.start.z, run.end.z),
+    };
+  }
+
+  return undefined;
+}
+
+function segmentUsesFiniteCoordinates(segment: WallSegmentDefinition): boolean {
+  return [segment.start.x, segment.start.z, segment.end.x, segment.end.z].every(
+    Number.isFinite
+  );
 }
 
 function getSegmentLength(segment: WallSegmentDefinition): number {

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -416,15 +416,20 @@ function validateWallRunGaps(wall: WallDefinition, errors: string[]): void {
     return;
   }
 
-  const sortedGaps = [...wall.run.gaps].sort((a, b) => a.start - b.start);
-  sortedGaps.forEach((gap, index) => {
-    if (!Number.isFinite(gap.start) || !Number.isFinite(gap.end)) {
+  const validGaps: WallRunGapDefinition[] = [];
+  wall.run.gaps.forEach((gap, index) => {
+    if (!isFiniteWallRunGap(gap)) {
       errors.push(
         `wall "${wall.id}" gap ${index} must use finite coordinates.`
       );
       return;
     }
 
+    validGaps.push(gap);
+  });
+
+  const sortedGaps = [...validGaps].sort((a, b) => a.start - b.start);
+  sortedGaps.forEach((gap, index) => {
     if (gap.end - gap.start <= LENGTH_EPSILON) {
       errors.push(`wall "${wall.id}" gap ${index} must have positive length.`);
       return;
@@ -447,6 +452,12 @@ function validateWallRunGaps(wall: WallDefinition, errors: string[]): void {
       );
     }
   });
+}
+
+function isFiniteWallRunGap(gap: unknown): gap is WallRunGapDefinition {
+  return (
+    isRecord(gap) && Number.isFinite(gap.start) && Number.isFinite(gap.end)
+  );
 }
 
 function isAxisAlignedRun(run: WallRunDefinition): boolean {

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -1,0 +1,344 @@
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export interface Point2D {
+  x: number;
+  z: number;
+}
+
+export interface Bounds2D {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}
+
+export interface LevelDefinition {
+  id: string;
+  floors: FloorDefinition[];
+}
+
+export interface FloorDefinition {
+  id: string;
+  name: string;
+  outline: Array<[number, number]>;
+  rooms: SemanticRoomDefinition[];
+  walls: WallDefinition[];
+  floorSurfaces: FloorSurfaceDefinition[];
+  safetyColliders?: SafetyColliderDefinition[];
+  sceneObjects?: SceneObjectDefinition[];
+  roomConnections?: RoomConnectionDefinition[];
+}
+
+export type RoomCategory = 'interior' | 'exterior';
+
+export interface SemanticRoomDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  name: string;
+  bounds: Bounds2D;
+  ledColor: number;
+  category?: RoomCategory;
+}
+
+export type WallKind = 'wall' | 'fence' | 'railing';
+
+export type WallPurpose =
+  | 'room-boundary'
+  | 'exterior-boundary'
+  | 'safety'
+  | 'decorative'
+  | string;
+
+export interface WallSegmentDefinition {
+  start: Point2D;
+  end: Point2D;
+}
+
+export interface WallRunGapDefinition {
+  start: number;
+  end: number;
+  label?: string;
+}
+
+export interface WallRunDefinition {
+  start: Point2D;
+  end: Point2D;
+  /** Intentional current topology gaps such as open passages, not tombstones. */
+  gaps?: WallRunGapDefinition[];
+}
+
+export type WallGeometryDefinition =
+  | { segments: WallSegmentDefinition[]; run?: never }
+  | { run: WallRunDefinition; segments?: never };
+
+export type WallDefinition = WallGeometryDefinition & {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  wallKind: WallKind;
+  height?: number;
+  thickness?: number;
+  rooms?: string[];
+  purpose?: WallPurpose;
+};
+
+export interface FloorSurfaceDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  bounds: Bounds2D;
+  roomId?: string;
+  elevation?: number;
+  purpose?: string;
+}
+
+export interface SafetyColliderDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  bounds: Bounds2D;
+  purpose: string;
+}
+
+export type ColliderPolicyDefinition =
+  | { kind: 'none'; reason?: string }
+  | { kind: 'footprint' }
+  | { kind: 'bounds'; bounds: Bounds2D; purpose?: string };
+
+export interface SceneObjectDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  kind: string;
+  position: Point2D & { y?: number };
+  orientation?: number;
+  colliderPolicy?: ColliderPolicyDefinition;
+  roomId?: string;
+}
+
+export interface RoomConnectionDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  rooms: [string, string, ...string[]];
+  label?: string;
+  purpose?: string;
+}
+
+export interface LevelValidationResult {
+  errors: string[];
+}
+
+const FORBIDDEN_SOURCE_ID_PARTS = [
+  '.former.',
+  '.removed.',
+  '.debugOnlyRemoval.',
+];
+const LENGTH_EPSILON = 1e-6;
+
+export function validateLevelDefinition(
+  level: LevelDefinition
+): LevelValidationResult {
+  const errors: string[] = [];
+  const sourceIds = new Map<string, string>();
+  const floorIds = new Set<string>();
+
+  const addNamespaceId = (namespace: string, id: string, ids: Set<string>) => {
+    if (ids.has(id)) {
+      errors.push(`Duplicate ${namespace} id "${id}".`);
+    }
+    ids.add(id);
+  };
+
+  const addSourceId = (sourceId: LevelSourceId, owner: string) => {
+    try {
+      assertLevelSourceId(sourceId);
+    } catch (error) {
+      errors.push(`${owner} has invalid sourceId: ${(error as Error).message}`);
+    }
+
+    const rawSourceId = sourceId as string;
+    if (FORBIDDEN_SOURCE_ID_PARTS.some((part) => rawSourceId.includes(part))) {
+      errors.push(
+        `${owner} sourceId "${rawSourceId}" uses forbidden tombstone wording.`
+      );
+    }
+
+    const existing = sourceIds.get(rawSourceId);
+    if (existing) {
+      errors.push(
+        `Duplicate sourceId "${rawSourceId}" used by ${existing} and ${owner}.`
+      );
+    }
+    sourceIds.set(rawSourceId, owner);
+  };
+
+  for (const floor of level.floors) {
+    if (floorIds.has(floor.id)) {
+      errors.push(`Duplicate floor id "${floor.id}".`);
+    }
+    floorIds.add(floor.id);
+
+    const roomIds = new Set<string>();
+    const wallIds = new Set<string>();
+    const surfaceIds = new Set<string>();
+    const safetyIds = new Set<string>();
+    const objectIds = new Set<string>();
+    const connectionIds = new Set<string>();
+
+    floor.rooms.forEach((room) => {
+      addNamespaceId(`room on floor ${floor.id}`, room.id, roomIds);
+      addSourceId(room.sourceId, `room "${room.id}"`);
+      validateBounds(room.bounds, `room "${room.id}" bounds`, errors);
+    });
+
+    floor.walls.forEach((wall) => {
+      addNamespaceId(`wall on floor ${floor.id}`, wall.id, wallIds);
+      addSourceId(wall.sourceId, `wall "${wall.id}"`);
+      if (wall.floorId !== floor.id) {
+        errors.push(
+          `wall "${wall.id}" floorId "${wall.floorId}" does not match floor "${floor.id}".`
+        );
+      }
+      wall.rooms?.forEach((roomId) => {
+        if (!roomIds.has(roomId))
+          errors.push(`wall "${wall.id}" references missing room "${roomId}".`);
+      });
+      validateWallGeometry(wall, errors);
+    });
+
+    floor.floorSurfaces.forEach((surface) => {
+      addNamespaceId(
+        `floor surface on floor ${floor.id}`,
+        surface.id,
+        surfaceIds
+      );
+      addSourceId(surface.sourceId, `floor surface "${surface.id}"`);
+      if (surface.floorId !== floor.id)
+        errors.push(
+          `floor surface "${surface.id}" floorId "${surface.floorId}" does not match floor "${floor.id}".`
+        );
+      if (surface.roomId && !roomIds.has(surface.roomId))
+        errors.push(
+          `floor surface "${surface.id}" references missing room "${surface.roomId}".`
+        );
+      validateBounds(
+        surface.bounds,
+        `floor surface "${surface.id}" bounds`,
+        errors
+      );
+    });
+
+    floor.safetyColliders?.forEach((collider) => {
+      addNamespaceId(
+        `safety collider on floor ${floor.id}`,
+        collider.id,
+        safetyIds
+      );
+      addSourceId(collider.sourceId, `safety collider "${collider.id}"`);
+      if (!collider.purpose.trim())
+        errors.push(`safety collider "${collider.id}" requires a purpose.`);
+      if (collider.floorId !== floor.id)
+        errors.push(
+          `safety collider "${collider.id}" floorId "${collider.floorId}" does not match floor "${floor.id}".`
+        );
+      validateBounds(
+        collider.bounds,
+        `safety collider "${collider.id}" bounds`,
+        errors
+      );
+    });
+
+    floor.sceneObjects?.forEach((object) => {
+      addNamespaceId(`scene object on floor ${floor.id}`, object.id, objectIds);
+      addSourceId(object.sourceId, `scene object "${object.id}"`);
+      if (object.floorId !== floor.id)
+        errors.push(
+          `scene object "${object.id}" floorId "${object.floorId}" does not match floor "${floor.id}".`
+        );
+      if (object.roomId && !roomIds.has(object.roomId))
+        errors.push(
+          `scene object "${object.id}" references missing room "${object.roomId}".`
+        );
+      if (object.colliderPolicy?.kind === 'bounds') {
+        validateBounds(
+          object.colliderPolicy.bounds,
+          `scene object "${object.id}" collider bounds`,
+          errors
+        );
+      }
+    });
+
+    floor.roomConnections?.forEach((connection) => {
+      addNamespaceId(
+        `room connection on floor ${floor.id}`,
+        connection.id,
+        connectionIds
+      );
+      addSourceId(connection.sourceId, `room connection "${connection.id}"`);
+      if (connection.floorId !== floor.id)
+        errors.push(
+          `room connection "${connection.id}" floorId "${connection.floorId}" does not match floor "${floor.id}".`
+        );
+      connection.rooms.forEach((roomId) => {
+        if (!roomIds.has(roomId))
+          errors.push(
+            `room connection "${connection.id}" references missing room "${roomId}".`
+          );
+      });
+    });
+  }
+
+  return { errors };
+}
+
+export function assertValidLevelDefinition(level: LevelDefinition): void {
+  const result = validateLevelDefinition(level);
+  if (result.errors.length > 0) {
+    throw new Error(
+      `Invalid level definition:\n- ${result.errors.join('\n- ')}`
+    );
+  }
+}
+
+function validateBounds(
+  bounds: Bounds2D,
+  label: string,
+  errors: string[]
+): void {
+  if (
+    bounds.maxX - bounds.minX <= LENGTH_EPSILON ||
+    bounds.maxZ - bounds.minZ <= LENGTH_EPSILON
+  ) {
+    errors.push(`${label} must have positive area.`);
+  }
+}
+
+function validateWallGeometry(wall: WallDefinition, errors: string[]): void {
+  if ('segments' in wall) {
+    if (wall.segments.length === 0)
+      errors.push(`wall "${wall.id}" requires at least one segment.`);
+    wall.segments.forEach((segment, index) => {
+      if (getSegmentLength(segment) <= LENGTH_EPSILON)
+        errors.push(
+          `wall "${wall.id}" segment ${index} must have positive length.`
+        );
+    });
+    return;
+  }
+
+  if (getSegmentLength(wall.run) <= LENGTH_EPSILON) {
+    errors.push(`wall "${wall.id}" run must have positive length.`);
+  }
+  wall.run.gaps?.forEach((gap, index) => {
+    if (gap.end - gap.start <= LENGTH_EPSILON)
+      errors.push(`wall "${wall.id}" gap ${index} must have positive length.`);
+  });
+}
+
+function getSegmentLength(segment: WallSegmentDefinition): number {
+  return Math.hypot(
+    segment.end.x - segment.start.x,
+    segment.end.z - segment.start.z
+  );
+}


### PR DESCRIPTION
### Motivation
- Introduce a phase-5 declarative level source contract to serve as a hand-editable source-of-truth for rooms, walls, floor surfaces, safety colliders, scene objects, and semantic room connections. 
- Provide stable semantic `sourceId` usage and validation to prevent tombstone/debug-only patterns and duplicate source identities across layers. 
- Ship a temporary adapter to compile declarative data back to the existing legacy `FloorPlanDefinition` shape for incremental migration and backward compatibility checks. 

### Description
- Add `src/scene/level/schema.ts` implementing typed schema interfaces (`LevelDefinition`, `FloorDefinition`, `SemanticRoomDefinition`, `WallDefinition`, `FloorSurfaceDefinition`, `SafetyColliderDefinition`, `SceneObjectDefinition`, `RoomConnectionDefinition`) plus validation helpers enforcing unique `sourceId`s, positive geometry, required purposes, and room/floor reference integrity. 
- Add `src/scene/level/compileLegacyFloorPlan.ts` which asserts schema validity, copies room metadata into the legacy `FloorPlanDefinition`, and optionally derives legacy `doorways` from intentional wall-run gaps when `includeDoorwaysFromWallGaps` is enabled. 
- Add unit tests in `src/scene/level/__tests__/schema.test.ts` and `src/scene/level/__tests__/compileLegacyFloorPlan.test.ts` that cover valid declarative floors, intentional wall gaps, invalid/duplicate source IDs, zero-length/area geometry, missing room references, tombstone-ID rejection, legacy compilation, and doorway derivation behavior. 
- Update `docs/design/declarative-level-source-of-truth.md` with a new "Declarative schema adapter (phase 5)" section that documents the schema, run/gap semantics, forbidden tombstone wording, and the adapter's compatibility-only role. 

### Testing
- Ran formatting with `npm run format:write`, lint with `npm run lint`, and fixed import-order warnings; these completed successfully. 
- Ran focused tests with `npm run test:ci -- src/scene/level/__tests__/schema.test.ts src/scene/level/__tests__/compileLegacyFloorPlan.test.ts` and all new tests passed. 
- Ran the full test suite with `npm run test:ci` and observed the repository tests pass (1156 tests passed in CI run). 
- Built and smoke-checked the production bundle with `npm run build` and `npm run smoke`; build succeeded though Vite emitted the existing large-chunk size warning, and `npm run docs:check` produced external fetch warnings from the link checker but reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3213b8afb8832f8c8564ca5ff6072c)