### PR TITLE
Add declarative level schema and legacy floor‑plan adapter

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -287,3 +287,50 @@ to regenerate the final visual geometry, gameplay collision, and debug metadata;
 legacy patches, removed-ID lists, and manually pushed unowned colliders are gone;
 and inventory tooling can explain every runtime level artifact by semantic source
 ID.
+
+## Declarative schema module
+
+Phase 5 introduces a TypeScript schema in `src/scene/level/schema.ts`. The
+schema is intentionally small enough for hand editing while broad enough to
+represent the current scene as future source data:
+
+- `LevelDefinition` owns one or more `FloorDefinition` entries.
+- `FloorDefinition` carries a human-readable name, outline, semantic rooms,
+  current walls, floor surfaces, and optional safety colliders, scene objects,
+  and semantic room connections.
+- `SemanticRoomDefinition` keeps room labels, bounds, LED colors, and optional
+  interior/exterior category metadata separate from generated wall geometry.
+- `WallDefinition` accepts either explicit current wall segments or a current
+  wall run with intentional gaps. Those gaps are authoring conveniences for
+  present-day topology, not deleted wall records or debug tombstones.
+- `FloorSurfaceDefinition` starts with rectangular bounds and can later feed a
+  generator that clips or splits output around stairs, thresholds, and voids.
+- `SafetyColliderDefinition` requires a purpose string so invisible constraints
+  explain why they exist in reviews and inventory checks.
+- `SceneObjectDefinition` captures visible/interactable placement plus an
+  explicit collider policy (`none`, `footprint`, or custom bounds).
+- `RoomConnectionDefinition` is semantic-only unless a later generator
+  intentionally consumes it; adding a connection does not generate, remove, or
+  patch geometry by itself.
+
+The validator enforces the phase-5 invariants before any runtime migration:
+source IDs must be valid and globally unique, object IDs must be unique within
+floor-local namespaces, wall segments and wall runs must have positive length,
+floor surfaces and safety colliders must have positive area, safety colliders
+must declare a purpose, and room references must resolve. Source IDs containing
+`.former.`, `.removed.`, or `.debugOnlyRemoval.` are rejected so the production
+schema cannot smuggle historical deletion records into the editor layer.
+
+## Transitional legacy floor-plan adapter
+
+`src/scene/level/compileLegacyFloorPlan.ts` provides a temporary adapter from a
+single declarative `FloorDefinition` into the existing `FloorPlanDefinition`
+shape. It copies rooms, outlines, colors, bounds, and categories exactly, then
+infers legacy room `doorways` only from current wall-run gaps that sit on a
+referenced room boundary. This is compatibility glue for room-focused legacy
+helpers; it is not the canonical scene-construction path.
+
+Semantic `roomConnections` are deliberately ignored by the adapter. A connection
+can describe adjacency for UI, navigation, narration, or editor affordances, but
+it does not create a doorway, remove a wall, or modify collision unless a future
+explicit generator is designed to consume it.

--- a/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
+++ b/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { compileLegacyFloorPlan } from '../compileLegacyFloorPlan';
+import type { FloorDefinition, LevelDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const floor: FloorDefinition = {
+  id: 'ground',
+  name: 'Ground Floor',
+  outline: [
+    [0, 0],
+    [10, 0],
+    [10, 5],
+    [0, 5],
+  ],
+  rooms: [
+    {
+      id: 'westRoom',
+      sourceId: sourceId('ground.west_room.room'),
+      name: 'West Room',
+      bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 5 },
+      ledColor: 0xffffff,
+    },
+    {
+      id: 'eastRoom',
+      sourceId: sourceId('ground.east_room.room'),
+      name: 'East Room',
+      bounds: { minX: 5, maxX: 10, minZ: 0, maxZ: 5 },
+      ledColor: 0x58c4ff,
+    },
+  ],
+  walls: [
+    {
+      id: 'dividingWall',
+      sourceId: sourceId('ground.dividing_wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      rooms: ['westRoom', 'eastRoom'],
+      run: {
+        start: { x: 5, z: 0 },
+        end: { x: 5, z: 5 },
+        gaps: [{ start: 2, end: 3, purpose: 'Current passage opening.' }],
+      },
+    },
+  ],
+  floorSurfaces: [
+    {
+      id: 'westFloor',
+      sourceId: sourceId('ground.west_room.floor_surface'),
+      floorId: 'ground',
+      roomId: 'westRoom',
+      bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 5 },
+    },
+  ],
+  roomConnections: [
+    {
+      id: 'semanticConnectionOnly',
+      sourceId: sourceId('ground.west_to_east.connection'),
+      floorId: 'ground',
+      rooms: ['westRoom', 'eastRoom'],
+      label: 'Semantic only',
+    },
+  ],
+};
+
+describe('compileLegacyFloorPlan', () => {
+  it('compiles declarative rooms to the legacy floor-plan shape', () => {
+    expect(compileLegacyFloorPlan(floor)).toEqual({
+      outline: floor.outline,
+      rooms: [
+        {
+          id: 'westRoom',
+          name: 'West Room',
+          bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 5 },
+          ledColor: 0xffffff,
+          doorways: [{ wall: 'east', start: 2, end: 3 }],
+        },
+        {
+          id: 'eastRoom',
+          name: 'East Room',
+          bounds: { minX: 5, maxX: 10, minZ: 0, maxZ: 5 },
+          ledColor: 0x58c4ff,
+          doorways: [{ wall: 'west', start: 2, end: 3 }],
+        },
+      ],
+    });
+  });
+
+  it('does not turn semantic room connections into doorways or geometry', () => {
+    const withoutGaps: FloorDefinition = { ...floor, walls: [] };
+
+    expect(compileLegacyFloorPlan(withoutGaps).rooms).toEqual([
+      expect.not.objectContaining({ doorways: expect.anything() }),
+      expect.not.objectContaining({ doorways: expect.anything() }),
+    ]);
+  });
+
+  it('validates the surrounding level when provided', () => {
+    const level: LevelDefinition = { id: 'level', floors: [floor] };
+
+    expect(() => compileLegacyFloorPlan(floor, { level })).not.toThrow();
+  });
+});

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertValidLevelDefinition, type LevelDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const createLevel = (): LevelDefinition => ({
+  id: 'testLevel',
+  floors: [
+    {
+      id: 'ground',
+      name: 'Ground Floor',
+      outline: [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
+      rooms: [
+        {
+          id: 'gallery',
+          sourceId: sourceId('ground.gallery.room'),
+          name: 'Gallery',
+          bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+          ledColor: 0xffffff,
+        },
+        {
+          id: 'studio',
+          sourceId: sourceId('ground.studio.room'),
+          name: 'Studio',
+          bounds: { minX: 5, maxX: 10, minZ: 0, maxZ: 10 },
+          ledColor: 0x58c4ff,
+        },
+      ],
+      walls: [
+        {
+          id: 'galleryNorthWall',
+          sourceId: sourceId('ground.gallery.north_wall'),
+          floorId: 'ground',
+          wallKind: 'wall',
+          rooms: ['gallery'],
+          segments: [{ start: { x: 0, z: 10 }, end: { x: 5, z: 10 } }],
+        },
+        {
+          id: 'centerWall',
+          sourceId: sourceId('ground.gallery.center_wall'),
+          floorId: 'ground',
+          wallKind: 'wall',
+          rooms: ['gallery', 'studio'],
+          run: {
+            start: { x: 5, z: 0 },
+            end: { x: 5, z: 10 },
+            gaps: [{ start: 4, end: 6, purpose: 'Current open passage.' }],
+          },
+        },
+      ],
+      floorSurfaces: [
+        {
+          id: 'galleryFloor',
+          sourceId: sourceId('ground.gallery.floor_surface'),
+          floorId: 'ground',
+          roomId: 'gallery',
+          bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+          purpose: 'Walkable gallery floor.',
+        },
+      ],
+      safetyColliders: [
+        {
+          id: 'guardRailSafety',
+          sourceId: sourceId('ground.gallery.guard_rail.safety_collider'),
+          floorId: 'ground',
+          bounds: { minX: 0, maxX: 1, minZ: 0, maxZ: 10 },
+          purpose: 'Keep traversal inside the playable gallery edge.',
+        },
+      ],
+      sceneObjects: [
+        {
+          id: 'thresholdTrim',
+          sourceId: sourceId('ground.gallery.threshold_trim.scene_object'),
+          floorId: 'ground',
+          kind: 'thresholdTrim',
+          position: { x: 5, z: 5 },
+          colliderPolicy: { kind: 'none' },
+          roomId: 'gallery',
+        },
+      ],
+      roomConnections: [
+        {
+          id: 'galleryToStudio',
+          sourceId: sourceId('ground.gallery_to_studio.connection'),
+          floorId: 'ground',
+          rooms: ['gallery', 'studio'],
+          label: 'Gallery to Studio',
+          purpose: 'Semantic adjacency only.',
+        },
+      ],
+    },
+  ],
+});
+
+describe('declarative level schema validation', () => {
+  it('accepts rooms, walls, floor surfaces, safety colliders, objects, and connections', () => {
+    expect(() => assertValidLevelDefinition(createLevel())).not.toThrow();
+  });
+
+  it('accepts intentional current-state wall-run gaps as authoring convenience', () => {
+    const level = createLevel();
+    const wall = level.floors[0]!.walls.find(
+      (entry) => entry.id === 'centerWall'
+    );
+
+    expect(wall).toMatchObject({
+      run: { gaps: [{ start: 4, end: 6, purpose: 'Current open passage.' }] },
+    });
+    expect(() => assertValidLevelDefinition(level)).not.toThrow();
+  });
+
+  it('rejects invalid source IDs and tombstone markers', () => {
+    const level = createLevel();
+    level.floors[0]!.rooms[0]!.sourceId = 'ground.gallery.former.room' as never;
+
+    expect(() => assertValidLevelDefinition(level)).toThrow(/former/);
+  });
+
+  it('rejects duplicate source IDs', () => {
+    const level = createLevel();
+    level.floors[0]!.rooms[1]!.sourceId = level.floors[0]!.rooms[0]!.sourceId;
+
+    expect(() => assertValidLevelDefinition(level)).toThrow(
+      /Duplicate level source ID/
+    );
+  });
+
+  it('rejects zero-length walls and zero-area floor surfaces', () => {
+    const level = createLevel();
+    level.floors[0]!.walls[0] = {
+      id: 'badWall',
+      sourceId: sourceId('ground.gallery.bad_wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      segments: [{ start: { x: 1, z: 1 }, end: { x: 1, z: 1 } }],
+    };
+    level.floors[0]!.floorSurfaces[0]!.bounds = {
+      minX: 0,
+      maxX: 0,
+      minZ: 0,
+      maxZ: 1,
+    };
+
+    expect(() => assertValidLevelDefinition(level)).toThrow(/positive length/);
+    expect(() => assertValidLevelDefinition(level)).toThrow(
+      /positive bounds area/
+    );
+  });
+
+  it('rejects safety colliders without area or purpose', () => {
+    const level = createLevel();
+    level.floors[0]!.safetyColliders![0]!.bounds = {
+      minX: 0,
+      maxX: 1,
+      minZ: 0,
+      maxZ: 0,
+    };
+    level.floors[0]!.safetyColliders![0]!.purpose = ' ';
+
+    expect(() => assertValidLevelDefinition(level)).toThrow(/Safety collider/);
+  });
+
+  it('rejects room connections that reference missing rooms', () => {
+    const level = createLevel();
+    level.floors[0]!.roomConnections![0]!.rooms = ['gallery', 'missingRoom'];
+
+    expect(() => assertValidLevelDefinition(level)).toThrow(/missingRoom/);
+  });
+});

--- a/src/scene/level/compileLegacyFloorPlan.ts
+++ b/src/scene/level/compileLegacyFloorPlan.ts
@@ -1,0 +1,120 @@
+import type {
+  DoorwayDefinition,
+  FloorPlanDefinition,
+  RoomWall,
+} from '../../assets/floorPlan';
+
+import {
+  assertValidLevelDefinition,
+  type FloorDefinition,
+  type LevelDefinition,
+  type WallRunDefinition,
+} from './schema';
+
+interface CompileLegacyFloorPlanOptions {
+  level?: LevelDefinition;
+}
+
+const EPSILON = 1e-6;
+
+const nearlyEqual = (a: number, b: number): boolean =>
+  Math.abs(a - b) <= EPSILON;
+
+const normalizeRange = (
+  start: number,
+  end: number
+): Pick<DoorwayDefinition, 'start' | 'end'> =>
+  start <= end ? { start, end } : { start: end, end: start };
+
+const getDoorwayFromRunGap = (
+  run: WallRunDefinition,
+  gap: { start: number; end: number },
+  room: FloorDefinition['rooms'][number]
+): DoorwayDefinition | null => {
+  const { bounds } = room;
+  const horizontal = nearlyEqual(run.start.z, run.end.z);
+  const vertical = nearlyEqual(run.start.x, run.end.x);
+
+  if (horizontal) {
+    if (nearlyEqual(run.start.z, bounds.maxZ)) {
+      return { wall: 'north', ...normalizeRange(gap.start, gap.end) };
+    }
+    if (nearlyEqual(run.start.z, bounds.minZ)) {
+      return { wall: 'south', ...normalizeRange(gap.start, gap.end) };
+    }
+  }
+
+  if (vertical) {
+    if (nearlyEqual(run.start.x, bounds.maxX)) {
+      return { wall: 'east', ...normalizeRange(gap.start, gap.end) };
+    }
+    if (nearlyEqual(run.start.x, bounds.minX)) {
+      return { wall: 'west', ...normalizeRange(gap.start, gap.end) };
+    }
+  }
+
+  return null;
+};
+
+const sortDoorways = (doorways: DoorwayDefinition[]): DoorwayDefinition[] => {
+  const wallOrder: Record<RoomWall, number> = {
+    north: 0,
+    east: 1,
+    south: 2,
+    west: 3,
+  };
+  return [...doorways].sort(
+    (a, b) => wallOrder[a.wall] - wallOrder[b.wall] || a.start - b.start
+  );
+};
+
+/**
+ * Transitional adapter from declarative floor data to the legacy room-focused
+ * FloorPlanDefinition shape. Doorways are inferred only from current wall-run
+ * gaps when a gap lies on one of the referenced room bounds; semantic
+ * roomConnections are intentionally ignored because they are not geometry.
+ */
+export const compileLegacyFloorPlan = (
+  floor: FloorDefinition,
+  options: CompileLegacyFloorPlanOptions = {}
+): FloorPlanDefinition => {
+  if (options.level) {
+    assertValidLevelDefinition(options.level);
+  }
+
+  const doorwaysByRoomId = new Map<string, DoorwayDefinition[]>();
+  floor.rooms.forEach((room) => doorwaysByRoomId.set(room.id, []));
+
+  for (const wall of floor.walls) {
+    if (!('run' in wall) || !wall.run.gaps || wall.run.gaps.length === 0) {
+      continue;
+    }
+
+    for (const roomId of wall.rooms ?? []) {
+      const room = floor.rooms.find((candidate) => candidate.id === roomId);
+      if (!room) continue;
+
+      for (const gap of wall.run.gaps) {
+        const doorway = getDoorwayFromRunGap(wall.run, gap, room);
+        if (doorway) {
+          doorwaysByRoomId.get(room.id)?.push(doorway);
+        }
+      }
+    }
+  }
+
+  return {
+    outline: floor.outline.map(([x, z]) => [x, z]),
+    rooms: floor.rooms.map((room) => {
+      const doorways = sortDoorways(doorwaysByRoomId.get(room.id) ?? []);
+      return {
+        id: room.id,
+        name: room.name,
+        bounds: { ...room.bounds },
+        ledColor: room.ledColor,
+        ...(doorways.length > 0 ? { doorways } : {}),
+        ...(room.category ? { category: room.category } : {}),
+      };
+    }),
+  };
+};

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -1,0 +1,333 @@
+import type { Bounds2D, RoomCategory } from '../../assets/floorPlan';
+
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export interface Point2D {
+  x: number;
+  z: number;
+}
+
+export type LevelObjectId = string;
+
+export interface LevelDefinition {
+  id: LevelObjectId;
+  floors: FloorDefinition[];
+}
+
+export interface FloorDefinition {
+  id: LevelObjectId;
+  name: string;
+  outline: Array<[number, number]>;
+  rooms: SemanticRoomDefinition[];
+  walls: WallDefinition[];
+  floorSurfaces: FloorSurfaceDefinition[];
+  safetyColliders?: SafetyColliderDefinition[];
+  sceneObjects?: SceneObjectDefinition[];
+  roomConnections?: RoomConnectionDefinition[];
+}
+
+export interface SemanticRoomDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  name: string;
+  bounds: Bounds2D;
+  ledColor: number;
+  category?: RoomCategory;
+}
+
+export type WallKind = 'wall' | 'fence' | 'railing';
+
+export interface WallGapDefinition {
+  start: number;
+  end: number;
+  purpose?: string;
+}
+
+export interface ExplicitWallSegmentDefinition {
+  start: Point2D;
+  end: Point2D;
+}
+
+export interface WallRunDefinition {
+  start: Point2D;
+  end: Point2D;
+  gaps?: WallGapDefinition[];
+}
+
+interface WallDefinitionBase {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: LevelObjectId;
+  wallKind: WallKind;
+  height?: number;
+  thickness?: number;
+  rooms?: string[];
+  purpose?: string;
+}
+
+export type WallDefinition = WallDefinitionBase &
+  (
+    | { segments: ExplicitWallSegmentDefinition[]; run?: never }
+    | { run: WallRunDefinition; segments?: never }
+  );
+
+export interface FloorSurfaceDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: LevelObjectId;
+  bounds: Bounds2D;
+  roomId?: string;
+  elevation?: number;
+  purpose?: string;
+}
+
+export interface SafetyColliderDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: LevelObjectId;
+  bounds: Bounds2D;
+  purpose: string;
+}
+
+export interface SceneObjectColliderPolicy {
+  kind: 'none' | 'footprint' | 'customBounds';
+  bounds?: Bounds2D;
+  purpose?: string;
+}
+
+export interface SceneObjectDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: LevelObjectId;
+  kind: string;
+  position: Point2D & { y?: number };
+  orientation?: number;
+  colliderPolicy?: SceneObjectColliderPolicy;
+  roomId?: string;
+}
+
+export interface RoomConnectionDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: LevelObjectId;
+  rooms: [string, string];
+  label?: string;
+  purpose?: string;
+}
+
+export interface LevelValidationResult {
+  errors: string[];
+}
+
+const TOMBSTONE_SOURCE_ID_PATTERNS = [
+  '.former.',
+  '.removed.',
+  '.debugOnlyRemoval.',
+];
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const EPSILON = 1e-6;
+
+const getBoundsArea = (bounds: Bounds2D): number =>
+  (bounds.maxX - bounds.minX) * (bounds.maxZ - bounds.minZ);
+
+const getSegmentLength = (segment: ExplicitWallSegmentDefinition): number =>
+  Math.hypot(segment.end.x - segment.start.x, segment.end.z - segment.start.z);
+
+const addId = (
+  errors: string[],
+  ids: Set<string>,
+  namespace: string,
+  id: string
+): void => {
+  if (!ID_PATTERN.test(id)) {
+    errors.push(
+      `${namespace} id "${id}" must contain only letters, digits, _, or -.`
+    );
+  }
+
+  if (ids.has(id)) {
+    errors.push(`Duplicate ${namespace} id "${id}".`);
+  }
+  ids.add(id);
+};
+
+const addSourceId = (
+  errors: string[],
+  sourceIds: Set<string>,
+  sourceId: string
+): void => {
+  try {
+    assertLevelSourceId(sourceId);
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+  }
+
+  for (const pattern of TOMBSTONE_SOURCE_ID_PATTERNS) {
+    if (sourceId.includes(pattern)) {
+      errors.push(
+        `Level source ID "${sourceId}" must not contain tombstone marker "${pattern}".`
+      );
+    }
+  }
+
+  if (sourceIds.has(sourceId)) {
+    errors.push(`Duplicate level source ID "${sourceId}".`);
+  }
+  sourceIds.add(sourceId);
+};
+
+export const validateLevelDefinition = (
+  level: LevelDefinition
+): LevelValidationResult => {
+  const errors: string[] = [];
+  const sourceIds = new Set<string>();
+  const levelIds = new Set<string>();
+  const floorIds = new Set<string>();
+
+  addId(errors, levelIds, 'level', level.id);
+
+  for (const floor of level.floors) {
+    addId(errors, floorIds, 'floor', floor.id);
+    const roomIds = new Set<string>();
+    const wallIds = new Set<string>();
+    const surfaceIds = new Set<string>();
+    const safetyIds = new Set<string>();
+    const objectIds = new Set<string>();
+    const connectionIds = new Set<string>();
+
+    for (const room of floor.rooms) {
+      addId(errors, roomIds, `floor "${floor.id}" room`, room.id);
+      addSourceId(errors, sourceIds, room.sourceId);
+      if (getBoundsArea(room.bounds) <= EPSILON) {
+        errors.push(`Room "${room.id}" must have positive bounds area.`);
+      }
+    }
+
+    for (const wall of floor.walls) {
+      addId(errors, wallIds, `floor "${floor.id}" wall`, wall.id);
+      addSourceId(errors, sourceIds, wall.sourceId);
+      if (wall.floorId !== floor.id)
+        errors.push(
+          `Wall "${wall.id}" references missing floor "${wall.floorId}".`
+        );
+      wall.rooms?.forEach((roomId) => {
+        if (!roomIds.has(roomId))
+          errors.push(`Wall "${wall.id}" references missing room "${roomId}".`);
+      });
+      if ('segments' in wall) {
+        if (wall.segments.length === 0)
+          errors.push(`Wall "${wall.id}" must include at least one segment.`);
+        wall.segments.forEach((segment, index) => {
+          if (getSegmentLength(segment) <= EPSILON)
+            errors.push(
+              `Wall "${wall.id}" segment ${index} must have positive length.`
+            );
+        });
+      } else {
+        const length = getSegmentLength(wall.run);
+        if (length <= EPSILON)
+          errors.push(`Wall "${wall.id}" run must have positive length.`);
+        wall.run.gaps?.forEach((gap, index) => {
+          if (gap.end - gap.start <= EPSILON)
+            errors.push(
+              `Wall "${wall.id}" gap ${index} must have positive length.`
+            );
+        });
+      }
+    }
+
+    for (const surface of floor.floorSurfaces) {
+      addId(
+        errors,
+        surfaceIds,
+        `floor "${floor.id}" floor surface`,
+        surface.id
+      );
+      addSourceId(errors, sourceIds, surface.sourceId);
+      if (surface.floorId !== floor.id)
+        errors.push(
+          `Floor surface "${surface.id}" references missing floor "${surface.floorId}".`
+        );
+      if (surface.roomId && !roomIds.has(surface.roomId))
+        errors.push(
+          `Floor surface "${surface.id}" references missing room "${surface.roomId}".`
+        );
+      if (getBoundsArea(surface.bounds) <= EPSILON)
+        errors.push(
+          `Floor surface "${surface.id}" must have positive bounds area.`
+        );
+    }
+
+    for (const collider of floor.safetyColliders ?? []) {
+      addId(
+        errors,
+        safetyIds,
+        `floor "${floor.id}" safety collider`,
+        collider.id
+      );
+      addSourceId(errors, sourceIds, collider.sourceId);
+      if (collider.floorId !== floor.id)
+        errors.push(
+          `Safety collider "${collider.id}" references missing floor "${collider.floorId}".`
+        );
+      if (getBoundsArea(collider.bounds) <= EPSILON)
+        errors.push(
+          `Safety collider "${collider.id}" must have positive bounds area.`
+        );
+      if (collider.purpose.trim().length === 0)
+        errors.push(`Safety collider "${collider.id}" must declare a purpose.`);
+    }
+
+    for (const object of floor.sceneObjects ?? []) {
+      addId(errors, objectIds, `floor "${floor.id}" scene object`, object.id);
+      addSourceId(errors, sourceIds, object.sourceId);
+      if (object.floorId !== floor.id)
+        errors.push(
+          `Scene object "${object.id}" references missing floor "${object.floorId}".`
+        );
+      if (object.roomId && !roomIds.has(object.roomId))
+        errors.push(
+          `Scene object "${object.id}" references missing room "${object.roomId}".`
+        );
+      if (
+        object.colliderPolicy?.kind === 'customBounds' &&
+        !object.colliderPolicy.bounds
+      ) {
+        errors.push(
+          `Scene object "${object.id}" custom collider policy requires bounds.`
+        );
+      }
+    }
+
+    for (const connection of floor.roomConnections ?? []) {
+      addId(
+        errors,
+        connectionIds,
+        `floor "${floor.id}" room connection`,
+        connection.id
+      );
+      addSourceId(errors, sourceIds, connection.sourceId);
+      if (connection.floorId !== floor.id)
+        errors.push(
+          `Room connection "${connection.id}" references missing floor "${connection.floorId}".`
+        );
+      connection.rooms.forEach((roomId) => {
+        if (!roomIds.has(roomId))
+          errors.push(
+            `Room connection "${connection.id}" references missing room "${roomId}".`
+          );
+      });
+    }
+  }
+
+  return { errors };
+};
+
+export const assertValidLevelDefinition = (level: LevelDefinition): void => {
+  const result = validateLevelDefinition(level);
+  if (result.errors.length > 0) {
+    throw new Error(
+      `Invalid level definition:\n- ${result.errors.join('\n- ')}`
+    );
+  }
+};


### PR DESCRIPTION
### Motivation
- Introduce a small, hand-editable declarative level schema as the phase‑5 source-of-truth for floors, rooms, walls, floor surfaces, safety colliders, scene objects, and semantic room connections while preserving current runtime outputs. 
- Provide a transitional adapter to compile the new declarative floor shape into the existing legacy `FloorPlanDefinition` shape so legacy room-focused helpers continue to work during migration.

### Description
- Added a typed declarative schema with validation helpers in `src/scene/level/schema.ts` supporting `LevelDefinition`, `FloorDefinition`, `SemanticRoomDefinition`, `WallDefinition` (explicit segments or wall runs with gaps), `FloorSurfaceDefinition`, `SafetyColliderDefinition`, `SceneObjectDefinition`, and `RoomConnectionDefinition`.
- Added robust validation rules that enforce unique source IDs, forbid tombstone markers (`.former.`, `.removed.`, `.debugOnlyRemoval.`), require positive geometry (wall lengths, surface areas), require safety collider purposes, and validate cross‑references.
- Added a transitional compiler adapter `src/scene/level/compileLegacyFloorPlan.ts` that copies rooms/outlines into the legacy `FloorPlanDefinition` and infers legacy `doorways` only from intentional current wall-run gaps; semantic room connections are explicitly non‑geometric.
- Added unit tests covering the schema and adapter under `src/scene/level/__tests__/schema.test.ts` and `src/scene/level/__tests__/compileLegacyFloorPlan.test.ts`, and documented the schema and adapter in `docs/design/declarative-level-source-of-truth.md`.

### Testing
- `npm run format:write` — completed successfully (Prettier applied to new files).
- `npm run lint` — completed successfully; import-order issues were auto-fixed where applicable.
- `npm run test:ci -- src/scene/level/__tests__/schema.test.ts src/scene/level/__tests__/compileLegacyFloorPlan.test.ts` — passed (both files and all assertions succeeded).
- `npm run test:ci` — full suite passed (151 files, 1159 tests passed).
- `npm run build` — production build completed successfully.
- `npm run docs:check` — docs checks passed; external link probes produced network fetch warnings but did not fail the check.
- `npm run smoke` — smoke/build assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3213c4b62c832fbcdfbf4f4224f959)