### PR TITLE
Add declarative level schema and legacy adapter

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -214,6 +214,42 @@ with no empty segments, whitespace, or slash-style paths, and
 `getLevelSourceDebugRef(...)` provides deterministic short uppercase hex
 references for future debug metadata without changing current visible debug IDs.
 
+## Declarative schema and transitional adapter
+
+Phase 5 introduces the first TypeScript schema in `src/scene/level/schema.ts`.
+The schema is intentionally hand-editable and mirrors the future editor layers:
+
+- `LevelDefinition` owns a set of floors.
+- `FloorDefinition` owns floor `outline`, semantic `rooms`, current `walls`,
+  `floorSurfaces`, optional `safetyColliders`, optional `sceneObjects`, and
+  optional semantic `roomConnections`.
+- Rooms, walls, surfaces, safety colliders, scene objects, and connections each
+  carry stable `sourceId` values using the semantic source-ID helpers.
+- Walls may be literal segments or axis-aligned current-state runs with
+  intentional `gaps`. Those gaps represent present topology, such as an open
+  passage or doorway; they are not former-wall records or deletion tombstones.
+- Floor surfaces start as rectangles. Generators may later split or clip them
+  into renderable pieces, but the source data remains the current intended
+  surface.
+- Room connections are semantic only unless a later generator explicitly consumes
+  them. They do not create or remove walls, floors, or colliders by themselves.
+
+Validation enforces uniqueness for source IDs across the level data it checks and
+for object IDs within each floor namespace. It also rejects invalid semantic
+source IDs, tombstone-style markers such as `.former.`, `.removed.`, and
+`.debugOnlyRemoval.`, zero-length wall segments or runs, zero-area floor
+surfaces and safety colliders, safety colliders without purpose text, bad floor
+references, and room connections or object references that point at missing
+rooms.
+
+`src/scene/level/compileLegacyFloorPlan.ts` is a temporary compatibility adapter.
+It compiles declarative rooms into the existing `FloorPlanDefinition` shape and
+derives legacy room doorway ranges from intentional gaps on current wall runs.
+That doorway derivation exists only so old room-first consumers can keep working
+during migration; canonical scene construction should move toward direct
+consumption of declarative wall, floor-surface, safety-collider, scene-object,
+and connection data.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
+++ b/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { compileLegacyFloorPlan } from '../compileLegacyFloorPlan';
+import type { FloorDefinition } from '../schema';
+import { makeLevelSourceId } from '../sourceIds';
+
+const sourceId = (...parts: string[]) => makeLevelSourceId(parts);
+
+const createFloor = (includeConnection = true): FloorDefinition => ({
+  id: 'ground',
+  name: 'Ground Floor',
+  outline: [
+    [0, 0],
+    [8, 0],
+    [8, 4],
+    [0, 4],
+  ],
+  rooms: [
+    {
+      id: 'leftRoom',
+      sourceId: sourceId('ground', 'left_room', 'room'),
+      name: 'Left Room',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+      ledColor: 0x111111,
+    },
+    {
+      id: 'rightRoom',
+      sourceId: sourceId('ground', 'right_room', 'room'),
+      name: 'Right Room',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+      ledColor: 0x222222,
+    },
+  ],
+  walls: [
+    {
+      id: 'sharedWall',
+      sourceId: sourceId('ground', 'left_right', 'wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      geometry: {
+        kind: 'run',
+        start: { x: 4, z: 0 },
+        end: { x: 4, z: 4 },
+        gaps: [{ start: 1.25, end: 2.75, purpose: 'current open doorway' }],
+      },
+      rooms: [
+        { id: 'leftRoom', wall: 'east' },
+        { id: 'rightRoom', wall: 'west' },
+      ],
+    },
+    {
+      id: 'northLeft',
+      sourceId: sourceId('ground', 'left_room', 'north_wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      geometry: { kind: 'segment', start: { x: 0, z: 4 }, end: { x: 4, z: 4 } },
+      rooms: [{ id: 'leftRoom', wall: 'north' }],
+    },
+  ],
+  floorSurfaces: [
+    {
+      id: 'leftFloor',
+      sourceId: sourceId('ground', 'left_room', 'floor_surface'),
+      floorId: 'ground',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+      roomId: 'leftRoom',
+    },
+    {
+      id: 'rightFloor',
+      sourceId: sourceId('ground', 'right_room', 'floor_surface'),
+      floorId: 'ground',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+      roomId: 'rightRoom',
+    },
+  ],
+  roomConnections: includeConnection
+    ? [
+        {
+          id: 'leftToRight',
+          sourceId: sourceId('ground', 'left_right', 'connection'),
+          floorId: 'ground',
+          rooms: ['leftRoom', 'rightRoom'],
+          label: 'Semantic adjacency',
+        },
+      ]
+    : undefined,
+});
+
+describe('compileLegacyFloorPlan', () => {
+  it('compiles declarative rooms and wall-run gaps into the legacy FloorPlanDefinition shape', () => {
+    const plan = compileLegacyFloorPlan(createFloor());
+
+    expect(plan.outline).toEqual([
+      [0, 0],
+      [8, 0],
+      [8, 4],
+      [0, 4],
+    ]);
+    expect(plan.rooms).toEqual([
+      {
+        id: 'leftRoom',
+        name: 'Left Room',
+        bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+        ledColor: 0x111111,
+        category: undefined,
+        doorways: [{ wall: 'east', start: 1.25, end: 2.75 }],
+      },
+      {
+        id: 'rightRoom',
+        name: 'Right Room',
+        bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+        ledColor: 0x222222,
+        category: undefined,
+        doorways: [{ wall: 'west', start: 1.25, end: 2.75 }],
+      },
+    ]);
+  });
+
+  it('proves roomConnections alone do not generate or remove legacy geometry', () => {
+    const withConnection = compileLegacyFloorPlan(createFloor(true));
+    const withoutConnection = compileLegacyFloorPlan(createFloor(false));
+
+    expect(withConnection).toEqual(withoutConnection);
+  });
+});

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type FloorDefinition,
+  validateFloorDefinition,
+  validateLevelDefinition,
+} from '../schema';
+import { makeLevelSourceId } from '../sourceIds';
+
+const sourceId = (...parts: string[]) => makeLevelSourceId(parts);
+
+const createFloor = (
+  overrides: Partial<FloorDefinition> = {}
+): FloorDefinition => ({
+  id: 'ground',
+  name: 'Ground Floor',
+  outline: [
+    [0, 0],
+    [10, 0],
+    [10, 10],
+    [0, 10],
+  ],
+  rooms: [
+    {
+      id: 'roomA',
+      sourceId: sourceId('ground', 'room_a', 'room'),
+      name: 'Room A',
+      bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+      ledColor: 0xffffff,
+    },
+    {
+      id: 'roomB',
+      sourceId: sourceId('ground', 'room_b', 'room'),
+      name: 'Room B',
+      bounds: { minX: 5, maxX: 10, minZ: 0, maxZ: 10 },
+      ledColor: 0xff00ff,
+    },
+  ],
+  walls: [
+    {
+      id: 'sharedWall',
+      sourceId: sourceId('ground', 'room_a_room_b', 'wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      geometry: {
+        kind: 'run',
+        start: { x: 5, z: 0 },
+        end: { x: 5, z: 10 },
+        gaps: [{ start: 4, end: 6, purpose: 'open passage' }],
+      },
+      rooms: [
+        { id: 'roomA', wall: 'east' },
+        { id: 'roomB', wall: 'west' },
+      ],
+    },
+    {
+      id: 'northWall',
+      sourceId: sourceId('ground', 'room_a', 'north_wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      geometry: {
+        kind: 'segment',
+        start: { x: 0, z: 10 },
+        end: { x: 5, z: 10 },
+      },
+      rooms: [{ id: 'roomA', wall: 'north' }],
+    },
+  ],
+  floorSurfaces: [
+    {
+      id: 'roomAFloor',
+      sourceId: sourceId('ground', 'room_a', 'floor_surface'),
+      floorId: 'ground',
+      bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+      roomId: 'roomA',
+      purpose: 'walkable room floor',
+    },
+  ],
+  safetyColliders: [
+    {
+      id: 'voidGuard',
+      sourceId: sourceId('ground', 'stair_void', 'safety_collider'),
+      floorId: 'ground',
+      bounds: { minX: 1, maxX: 2, minZ: 1, maxZ: 2 },
+      purpose: 'keeps players out of the stair void',
+    },
+  ],
+  sceneObjects: [
+    {
+      id: 'thresholdTrim',
+      sourceId: sourceId('ground', 'room_a_room_b', 'threshold_trim'),
+      floorId: 'ground',
+      kind: 'threshold',
+      position: { x: 5, z: 5 },
+      colliderPolicy: { kind: 'none' },
+      roomId: 'roomA',
+    },
+  ],
+  roomConnections: [
+    {
+      id: 'roomAToRoomB',
+      sourceId: sourceId('ground', 'room_a_room_b', 'connection'),
+      floorId: 'ground',
+      rooms: ['roomA', 'roomB'],
+      label: 'Open passage',
+      purpose: 'semantic adjacency only',
+    },
+  ],
+  ...overrides,
+});
+
+describe('declarative level schema validation', () => {
+  it('validates a small declarative floor with rooms, walls, surfaces, objects, and connections', () => {
+    const floor = createFloor();
+
+    expect(() => validateFloorDefinition(floor)).not.toThrow();
+    expect(() =>
+      validateLevelDefinition({ id: 'testLevel', floors: [floor] })
+    ).not.toThrow();
+  });
+
+  it('accepts intentional current-state wall gaps in wall runs', () => {
+    const floor = createFloor({
+      walls: [
+        {
+          id: 'southWallWithDoor',
+          sourceId: sourceId('ground', 'room_a', 'south_wall'),
+          floorId: 'ground',
+          wallKind: 'wall',
+          geometry: {
+            kind: 'run',
+            start: { x: 0, z: 0 },
+            end: { x: 5, z: 0 },
+            gaps: [{ start: 2, end: 3, purpose: 'doorway' }],
+          },
+          rooms: [{ id: 'roomA', wall: 'south' }],
+        },
+      ],
+    });
+
+    expect(() => validateFloorDefinition(floor)).not.toThrow();
+  });
+
+  it('rejects invalid source IDs and tombstone markers', () => {
+    const invalidSourceFloor = createFloor({
+      rooms: [
+        {
+          ...createFloor().rooms[0],
+          sourceId: 'Ground.Room' as ReturnType<typeof sourceId>,
+        },
+      ],
+    });
+
+    expect(() => validateFloorDefinition(invalidSourceFloor)).toThrow(
+      /Invalid level source ID/
+    );
+
+    const tombstoneFloor = createFloor({
+      rooms: [
+        {
+          ...createFloor().rooms[0],
+          sourceId: 'ground.former.room' as ReturnType<typeof sourceId>,
+        },
+      ],
+    });
+
+    expect(() => validateFloorDefinition(tombstoneFloor)).toThrow(
+      /forbidden tombstone marker/
+    );
+  });
+
+  it('rejects duplicate source IDs', () => {
+    const floor = createFloor({
+      floorSurfaces: [
+        {
+          id: 'duplicateSourceSurface',
+          sourceId: sourceId('ground', 'room_a', 'room'),
+          floorId: 'ground',
+          bounds: { minX: 0, maxX: 1, minZ: 0, maxZ: 1 },
+        },
+      ],
+    });
+
+    expect(() => validateFloorDefinition(floor)).toThrow(/Duplicate source ID/);
+  });
+
+  it('rejects zero-length walls, zero-area surfaces, and missing room references', () => {
+    expect(() =>
+      validateFloorDefinition(
+        createFloor({
+          walls: [
+            {
+              id: 'zeroWall',
+              sourceId: sourceId('ground', 'zero_wall'),
+              floorId: 'ground',
+              wallKind: 'wall',
+              geometry: {
+                kind: 'segment',
+                start: { x: 1, z: 1 },
+                end: { x: 1, z: 1 },
+              },
+            },
+          ],
+        })
+      )
+    ).toThrow(/positive length/);
+
+    expect(() =>
+      validateFloorDefinition(
+        createFloor({
+          floorSurfaces: [
+            {
+              id: 'zeroSurface',
+              sourceId: sourceId('ground', 'zero_surface'),
+              floorId: 'ground',
+              bounds: { minX: 0, maxX: 0, minZ: 0, maxZ: 1 },
+            },
+          ],
+        })
+      )
+    ).toThrow(/positive area/);
+
+    expect(() =>
+      validateFloorDefinition(
+        createFloor({
+          roomConnections: [
+            {
+              id: 'missingConnection',
+              sourceId: sourceId('ground', 'missing_connection'),
+              floorId: 'ground',
+              rooms: ['roomA', 'missingRoom'],
+            },
+          ],
+        })
+      )
+    ).toThrow(/missing room/);
+  });
+});

--- a/src/scene/level/compileLegacyFloorPlan.ts
+++ b/src/scene/level/compileLegacyFloorPlan.ts
@@ -1,0 +1,67 @@
+import type {
+  DoorwayDefinition,
+  FloorPlanDefinition,
+  RoomWall,
+} from '../../assets/floorPlan';
+
+import type {
+  FloorDefinition,
+  SemanticRoomDefinition,
+  WallDefinition,
+  WallRunGeometry,
+} from './schema';
+import { validateFloorDefinition } from './schema';
+
+const EPSILON = 1e-6;
+
+/**
+ * Transitional adapter from declarative floor data to the legacy room-first
+ * FloorPlanDefinition shape. Doorways are derived from intentional current-state
+ * gaps in wall runs only for compatibility with old consumers; roomConnections
+ * remain semantic and do not create or remove geometry.
+ */
+export function compileLegacyFloorPlan(
+  floor: FloorDefinition
+): FloorPlanDefinition {
+  validateFloorDefinition(floor);
+
+  return {
+    outline: floor.outline.map(([x, z]) => [x, z]),
+    rooms: floor.rooms.map((room) => ({
+      id: room.id,
+      name: room.name,
+      bounds: { ...room.bounds },
+      ledColor: room.ledColor,
+      category: room.category,
+      doorways: deriveDoorways(room, floor.walls),
+    })),
+  };
+}
+
+function deriveDoorways(
+  room: SemanticRoomDefinition,
+  walls: WallDefinition[]
+): DoorwayDefinition[] | undefined {
+  const doorways = walls.flatMap((wall) => {
+    const roomWall = wall.rooms?.find((entry) => entry.id === room.id)?.wall;
+    if (!roomWall || wall.geometry.kind !== 'run') return [];
+    return gapsToDoorways(roomWall, wall.geometry);
+  });
+
+  if (doorways.length === 0) return undefined;
+  return doorways.sort(
+    (a, b) => a.wall.localeCompare(b.wall) || a.start - b.start
+  );
+}
+
+function gapsToDoorways(
+  wall: RoomWall,
+  run: WallRunGeometry
+): DoorwayDefinition[] {
+  if (!run.gaps || run.gaps.length === 0) return [];
+  const horizontal = Math.abs(run.end.x - run.start.x) > EPSILON;
+  const axisMatchesWall =
+    wall === 'north' || wall === 'south' ? horizontal : !horizontal;
+  if (!axisMatchesWall) return [];
+  return run.gaps.map((gap) => ({ wall, start: gap.start, end: gap.end }));
+}

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -1,0 +1,319 @@
+import type { Bounds2D, RoomCategory, RoomWall } from '../../assets/floorPlan';
+
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export interface Point2D {
+  x: number;
+  z: number;
+}
+
+export type LevelObjectId = string;
+
+export interface LevelDefinition {
+  id: LevelObjectId;
+  floors: FloorDefinition[];
+}
+
+export interface FloorDefinition {
+  id: LevelObjectId;
+  name: string;
+  outline: Array<[number, number]>;
+  rooms: SemanticRoomDefinition[];
+  walls: WallDefinition[];
+  floorSurfaces: FloorSurfaceDefinition[];
+  safetyColliders?: SafetyColliderDefinition[];
+  sceneObjects?: SceneObjectDefinition[];
+  roomConnections?: RoomConnectionDefinition[];
+}
+
+export interface SemanticRoomDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  name: string;
+  bounds: Bounds2D;
+  ledColor: number;
+  category?: RoomCategory;
+}
+
+export type WallKind = 'wall' | 'fence' | 'railing';
+
+export interface WallSegmentGeometry {
+  kind: 'segment';
+  start: Point2D;
+  end: Point2D;
+}
+
+export interface WallRunGap {
+  start: number;
+  end: number;
+  /** Optional current-topology intent label, such as doorway or open passage. */
+  purpose?: string;
+}
+
+export interface WallRunGeometry {
+  kind: 'run';
+  start: Point2D;
+  end: Point2D;
+  /** Intentional current-state openings in the run, measured along the run axis. */
+  gaps?: WallRunGap[];
+}
+
+export type WallGeometry = WallSegmentGeometry | WallRunGeometry;
+
+export interface WallRoomReference {
+  id: string;
+  wall?: RoomWall;
+}
+
+export interface WallDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: string;
+  geometry: WallGeometry;
+  wallKind: WallKind;
+  height?: number;
+  thickness?: number;
+  rooms?: WallRoomReference[];
+  purpose?: string;
+}
+
+export interface FloorSurfaceDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: string;
+  bounds: Bounds2D;
+  roomId?: string;
+  elevation?: number;
+  purpose?: string;
+}
+
+export interface SafetyColliderDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: string;
+  bounds: Bounds2D;
+  purpose: string;
+}
+
+export interface ColliderPolicyDefinition {
+  kind: 'none' | 'footprint' | 'customBounds';
+  bounds?: Bounds2D;
+  purpose?: string;
+}
+
+export interface SceneObjectDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: string;
+  kind: string;
+  position: Point2D & { y?: number };
+  orientation?: number;
+  colliderPolicy?: ColliderPolicyDefinition;
+  roomId?: string;
+}
+
+export interface RoomConnectionDefinition {
+  id: LevelObjectId;
+  sourceId: LevelSourceId;
+  floorId: string;
+  rooms: [string, string];
+  label?: string;
+  purpose?: string;
+}
+
+const FORBIDDEN_SOURCE_ID_PARTS = [
+  '.former.',
+  '.removed.',
+  '.debugOnlyRemoval.',
+];
+const EPSILON = 1e-6;
+
+export function validateLevelDefinition(level: LevelDefinition): void {
+  const sourceIds = new Set<string>();
+  const floorIds = new Set<string>();
+  assertUniqueId(level.id, new Set(), 'level');
+
+  level.floors.forEach((floor) => {
+    assertUniqueId(floor.id, floorIds, 'floor');
+    validateFloorDefinition(floor, sourceIds);
+  });
+}
+
+export function validateFloorDefinition(
+  floor: FloorDefinition,
+  sourceIds = new Set<string>()
+): void {
+  const namespaceIds = {
+    room: new Set<string>(),
+    wall: new Set<string>(),
+    floorSurface: new Set<string>(),
+    safetyCollider: new Set<string>(),
+    sceneObject: new Set<string>(),
+    roomConnection: new Set<string>(),
+  };
+  const roomIds = new Set(floor.rooms.map((room) => room.id));
+
+  floor.rooms.forEach((room) => {
+    assertUniqueId(room.id, namespaceIds.room, 'room');
+    assertSourceId(room.sourceId, sourceIds);
+    assertPositiveBounds(room.bounds, `room "${room.id}"`);
+  });
+
+  floor.walls.forEach((wall) => {
+    assertUniqueId(wall.id, namespaceIds.wall, 'wall');
+    assertSourceId(wall.sourceId, sourceIds);
+    assertFloorReference(wall.floorId, floor.id, `wall "${wall.id}"`);
+    assertPositiveWallGeometry(wall);
+    wall.rooms?.forEach((room) =>
+      assertRoomReference(room.id, roomIds, `wall "${wall.id}"`)
+    );
+  });
+
+  floor.floorSurfaces.forEach((surface) => {
+    assertUniqueId(surface.id, namespaceIds.floorSurface, 'floor surface');
+    assertSourceId(surface.sourceId, sourceIds);
+    assertFloorReference(
+      surface.floorId,
+      floor.id,
+      `floor surface "${surface.id}"`
+    );
+    assertPositiveBounds(surface.bounds, `floor surface "${surface.id}"`);
+    if (surface.roomId)
+      assertRoomReference(
+        surface.roomId,
+        roomIds,
+        `floor surface "${surface.id}"`
+      );
+  });
+
+  floor.safetyColliders?.forEach((collider) => {
+    assertUniqueId(collider.id, namespaceIds.safetyCollider, 'safety collider');
+    assertSourceId(collider.sourceId, sourceIds);
+    assertFloorReference(
+      collider.floorId,
+      floor.id,
+      `safety collider "${collider.id}"`
+    );
+    assertPositiveBounds(collider.bounds, `safety collider "${collider.id}"`);
+    if (collider.purpose.trim().length === 0)
+      throw new Error(`safety collider "${collider.id}" requires a purpose.`);
+  });
+
+  floor.sceneObjects?.forEach((object) => {
+    assertUniqueId(object.id, namespaceIds.sceneObject, 'scene object');
+    assertSourceId(object.sourceId, sourceIds);
+    assertFloorReference(
+      object.floorId,
+      floor.id,
+      `scene object "${object.id}"`
+    );
+    if (object.roomId)
+      assertRoomReference(
+        object.roomId,
+        roomIds,
+        `scene object "${object.id}"`
+      );
+    if (object.colliderPolicy?.kind === 'customBounds') {
+      if (!object.colliderPolicy.bounds)
+        throw new Error(
+          `scene object "${object.id}" custom collider policy requires bounds.`
+        );
+      assertPositiveBounds(
+        object.colliderPolicy.bounds,
+        `scene object "${object.id}" custom collider`
+      );
+    }
+  });
+
+  floor.roomConnections?.forEach((connection) => {
+    assertUniqueId(
+      connection.id,
+      namespaceIds.roomConnection,
+      'room connection'
+    );
+    assertSourceId(connection.sourceId, sourceIds);
+    assertFloorReference(
+      connection.floorId,
+      floor.id,
+      `room connection "${connection.id}"`
+    );
+    connection.rooms.forEach((roomId) =>
+      assertRoomReference(roomId, roomIds, `room connection "${connection.id}"`)
+    );
+  });
+}
+
+function assertUniqueId(id: string, ids: Set<string>, label: string): void {
+  if (id.trim().length === 0)
+    throw new Error(`${label} IDs must not be empty.`);
+  if (ids.has(id)) throw new Error(`Duplicate ${label} ID "${id}".`);
+  ids.add(id);
+}
+
+function assertSourceId(sourceId: LevelSourceId, sourceIds: Set<string>): void {
+  assertLevelSourceId(sourceId);
+  FORBIDDEN_SOURCE_ID_PARTS.forEach((part) => {
+    if (sourceId.includes(part))
+      throw new Error(
+        `Source ID "${sourceId}" contains forbidden tombstone marker "${part}".`
+      );
+  });
+  if (sourceIds.has(sourceId))
+    throw new Error(`Duplicate source ID "${sourceId}".`);
+  sourceIds.add(sourceId);
+}
+
+function assertFloorReference(
+  actual: string,
+  expected: string,
+  label: string
+): void {
+  if (actual !== expected)
+    throw new Error(
+      `${label} references floor "${actual}" but belongs to floor "${expected}".`
+    );
+}
+
+function assertRoomReference(
+  roomId: string,
+  roomIds: Set<string>,
+  label: string
+): void {
+  if (!roomIds.has(roomId))
+    throw new Error(`${label} references missing room "${roomId}".`);
+}
+
+function assertPositiveBounds(bounds: Bounds2D, label: string): void {
+  if (
+    bounds.maxX - bounds.minX <= EPSILON ||
+    bounds.maxZ - bounds.minZ <= EPSILON
+  ) {
+    throw new Error(`${label} must have positive area.`);
+  }
+}
+
+function assertPositiveWallGeometry(wall: WallDefinition): void {
+  const { start, end } = wall.geometry;
+  const dx = end.x - start.x;
+  const dz = end.z - start.z;
+  if (Math.hypot(dx, dz) <= EPSILON)
+    throw new Error(`wall "${wall.id}" must have positive length.`);
+  if (wall.geometry.kind === 'run') {
+    const horizontal = Math.abs(dx) > EPSILON && Math.abs(dz) <= EPSILON;
+    const vertical = Math.abs(dz) > EPSILON && Math.abs(dx) <= EPSILON;
+    if (!horizontal && !vertical)
+      throw new Error(`wall "${wall.id}" runs must be axis-aligned.`);
+    const min = horizontal
+      ? Math.min(start.x, end.x)
+      : Math.min(start.z, end.z);
+    const max = horizontal
+      ? Math.max(start.x, end.x)
+      : Math.max(start.z, end.z);
+    wall.geometry.gaps?.forEach((gap) => {
+      if (gap.end - gap.start <= EPSILON)
+        throw new Error(`wall "${wall.id}" gap must have positive length.`);
+      if (gap.start < min - EPSILON || gap.end > max + EPSILON)
+        throw new Error(`wall "${wall.id}" gap must stay within the wall run.`);
+    });
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce a hand-editable declarative level schema to serve as the authoritative source-of-truth for rooms, walls, floor surfaces, safety colliders, scene objects, and semantic room connections. 
- Provide stable semantic source-ID primitives and validation to prevent tombstone/removed-ID patterns and make downstream artifacts auditable. 
- Offer a transitional compatibility path so existing consumers that expect the legacy room-first `FloorPlanDefinition` shape keep working during migration. 

### Description
- Add `src/scene/level/schema.ts` which defines `LevelDefinition`, `FloorDefinition`, `SemanticRoomDefinition`, `WallDefinition` (segments and runs with intentional gaps), `FloorSurfaceDefinition`, `SafetyColliderDefinition`, `SceneObjectDefinition`, `RoomConnectionDefinition`, and validation helpers. 
- Add `src/scene/level/compileLegacyFloorPlan.ts` which validates declarative floors and compiles them to the legacy `FloorPlanDefinition`, deriving legacy doorways from intentional wall-run gaps while keeping `roomConnections` semantic-only. 
- Add unit tests in `src/scene/level/__tests__/schema.test.ts` and `src/scene/level/__tests__/compileLegacyFloorPlan.test.ts` that cover a valid small floor, gap handling, invalid source IDs/tombstones, duplicate source IDs, zero-length/zero-area geometry, missing room references, and legacy adapter behavior. 
- Update the design doc `docs/design/declarative-level-source-of-truth.md` with the schema summary, validation rules, gap semantics, and adapter caveats. 

### Testing
- Ran `npm run format:write` and `npm run lint` and the formatter/linter completed successfully (auto-fixes applied where appropriate). 
- Ran targeted tests with `npm run test:ci -- src/scene/level/__tests__/schema.test.ts src/scene/level/__tests__/compileLegacyFloorPlan.test.ts` and they passed. 
- Ran the full test suite with `npm run test:ci` and all tests passed (`151` files, `1156` tests). 
- Ran docs and build verification with `npm run docs:check`, `npm run smoke`, and `npm run build` and they completed successfully (link checker emitted external fetch warnings but the docs check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3213d3d828832f979198f8aa507fce)