### PR TITLE
Add declarative level schema, validation, and legacy compiler adapter

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -287,3 +287,37 @@ to regenerate the final visual geometry, gameplay collision, and debug metadata;
 legacy patches, removed-ID lists, and manually pushed unowned colliders are gone;
 and inventory tooling can explain every runtime level artifact by semantic source
 ID.
+
+## Declarative schema adapter added in phase 5
+
+The first TypeScript schema now lives in `src/scene/level/schema.ts`. It defines
+`LevelDefinition` and per-floor source layers for semantic rooms, current walls,
+floor surfaces, safety colliders, scene objects, and optional room connections.
+Every source-backed item carries a stable semantic `sourceId`, while local `id`
+values stay unique within their layer on a floor so hand-edited diffs remain
+small and readable.
+
+Walls can be authored as explicit segment lists or as one current-state run with
+intentional gaps. A gap means “this opening exists now”; it is not a former wall,
+removed bounds record, or debug-ID tombstone. Visible doors, trims, thresholds,
+rails, and similar passage details should be declared as current wall geometry or
+scene objects. Purely walkable openings can remain as absences in the wall layer,
+with an optional `RoomConnectionDefinition` for semantic adjacency.
+
+`validateLevelDefinition(...)` enforces the initial source invariants:
+
+- valid, unique semantic source IDs across all source layers;
+- unique local object IDs inside each floor/layer namespace;
+- positive wall segment or run length;
+- positive floor-surface and safety-collider area;
+- non-empty safety-collider purpose text;
+- room references that resolve on the owning floor; and
+- no source IDs containing `.former.`, `.removed.`, or `.debugOnlyRemoval.`.
+
+The temporary compatibility adapter in
+`src/scene/level/compileLegacyFloorPlan.ts` compiles declarative rooms into the
+existing `FloorPlanDefinition` shape for transitional tests and legacy helpers.
+It derives legacy room `doorways` only from intentional wall-run gaps so current
+room-wall splitting can continue during migration. This is compatibility glue,
+not canonical scene construction: semantic `roomConnections` are ignored by the
+adapter and must not create, remove, or patch geometry by themselves.

--- a/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
+++ b/src/scene/level/__tests__/compileLegacyFloorPlan.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCombinedWallSegments } from '../../../assets/floorPlan';
+import { compileLegacyFloorPlan } from '../compileLegacyFloorPlan';
+import type { FloorDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sid = assertLevelSourceId;
+
+const createFloor = (withConnection = true): FloorDefinition => ({
+  id: 'ground',
+  name: 'Ground Floor',
+  outline: [
+    [0, 0],
+    [10, 0],
+    [10, 10],
+    [0, 10],
+  ],
+  rooms: [
+    {
+      id: 'leftRoom',
+      sourceId: sid('ground.left_room.room'),
+      name: 'Left Room',
+      bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+      ledColor: 0xffffff,
+    },
+    {
+      id: 'rightRoom',
+      sourceId: sid('ground.right_room.room'),
+      name: 'Right Room',
+      bounds: { minX: 5, maxX: 10, minZ: 0, maxZ: 10 },
+      ledColor: 0x00ffff,
+    },
+  ],
+  walls: [
+    {
+      id: 'sharedRun',
+      sourceId: sid('ground.shared_wall.wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      run: {
+        start: { x: 5, z: 0 },
+        end: { x: 5, z: 10 },
+        gaps: [{ start: 4, end: 6, purpose: 'current open passage' }],
+      },
+      rooms: [
+        { roomId: 'leftRoom', wall: 'east' },
+        { roomId: 'rightRoom', wall: 'west' },
+      ],
+    },
+  ],
+  floorSurfaces: [
+    {
+      id: 'leftFloor',
+      sourceId: sid('ground.left_room.floor_surface'),
+      floorId: 'ground',
+      bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+      roomId: 'leftRoom',
+    },
+  ],
+  roomConnections: withConnection
+    ? [
+        {
+          id: 'semanticOnlyConnection',
+          sourceId: sid('ground.left_to_right.connection'),
+          floorId: 'ground',
+          rooms: ['leftRoom', 'rightRoom'],
+          purpose: 'semantic adjacency only',
+        },
+      ]
+    : [],
+});
+
+describe('compileLegacyFloorPlan', () => {
+  it('compiles declarative rooms and intentional wall-run gaps to legacy doorways', () => {
+    const plan = compileLegacyFloorPlan(createFloor());
+
+    expect(plan.rooms).toMatchObject([
+      { id: 'leftRoom', doorways: [{ wall: 'east', start: 4, end: 6 }] },
+      { id: 'rightRoom', doorways: [{ wall: 'west', start: 4, end: 6 }] },
+    ]);
+  });
+
+  it('does not let roomConnections alone generate or remove geometry', () => {
+    const withConnection = compileLegacyFloorPlan(createFloor(true));
+    const withoutConnection = compileLegacyFloorPlan(createFloor(false));
+
+    expect(getCombinedWallSegments(withConnection)).toEqual(
+      getCombinedWallSegments(withoutConnection)
+    );
+  });
+});

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import { type LevelDefinition, validateLevelDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sid = assertLevelSourceId;
+
+const createLevel = (): LevelDefinition => ({
+  id: 'testLevel',
+  floors: [
+    {
+      id: 'ground',
+      name: 'Ground Floor',
+      outline: [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
+      rooms: [
+        {
+          id: 'livingRoom',
+          sourceId: sid('ground.living_room.room'),
+          name: 'Living Room',
+          bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+          ledColor: 0xffffff,
+        },
+        {
+          id: 'kitchen',
+          sourceId: sid('ground.kitchen.room'),
+          name: 'Kitchen',
+          bounds: { minX: 5, maxX: 10, minZ: 0, maxZ: 10 },
+          ledColor: 0xffaa00,
+        },
+      ],
+      walls: [
+        {
+          id: 'sharedWall',
+          sourceId: sid('ground.living_room.east_wall'),
+          floorId: 'ground',
+          wallKind: 'wall',
+          run: {
+            start: { x: 5, z: 0 },
+            end: { x: 5, z: 10 },
+            gaps: [{ start: 4, end: 6, purpose: 'open passage' }],
+          },
+          rooms: [
+            { roomId: 'livingRoom', wall: 'east' },
+            { roomId: 'kitchen', wall: 'west' },
+          ],
+        },
+        {
+          id: 'northFence',
+          sourceId: sid('ground.kitchen.north_fence'),
+          floorId: 'ground',
+          wallKind: 'fence',
+          segments: [{ start: { x: 5, z: 10 }, end: { x: 10, z: 10 } }],
+          rooms: [{ roomId: 'kitchen', wall: 'north' }],
+        },
+      ],
+      floorSurfaces: [
+        {
+          id: 'livingFloor',
+          sourceId: sid('ground.living_room.floor_surface'),
+          floorId: 'ground',
+          bounds: { minX: 0, maxX: 5, minZ: 0, maxZ: 10 },
+          roomId: 'livingRoom',
+        },
+      ],
+      safetyColliders: [
+        {
+          id: 'voidGuard',
+          sourceId: sid('ground.stair.void_guard.safety_collider'),
+          floorId: 'ground',
+          bounds: { minX: 1, maxX: 2, minZ: 1, maxZ: 2 },
+          purpose: 'prevent falling into the stair void',
+        },
+      ],
+      sceneObjects: [
+        {
+          id: 'thresholdTrim',
+          sourceId: sid('ground.living_room.threshold.scene_object'),
+          floorId: 'ground',
+          kind: 'thresholdTrim',
+          position: { x: 5, z: 5 },
+          colliderPolicy: { kind: 'none' },
+          roomId: 'livingRoom',
+        },
+      ],
+      roomConnections: [
+        {
+          id: 'livingToKitchen',
+          sourceId: sid('ground.living_room_to_kitchen.connection'),
+          floorId: 'ground',
+          rooms: ['livingRoom', 'kitchen'],
+          label: 'Open passage',
+        },
+      ],
+    },
+  ],
+});
+
+describe('validateLevelDefinition', () => {
+  it('accepts a small declarative floor with rooms, walls, surfaces, and connections', () => {
+    expect(() => validateLevelDefinition(createLevel())).not.toThrow();
+  });
+
+  it('accepts intentional wall gaps on current-state wall runs', () => {
+    const level = createLevel();
+    const wall = level.floors[0]!.walls[0]!;
+
+    expect('run' in wall ? wall.run.gaps : []).toEqual([
+      { start: 4, end: 6, purpose: 'open passage' },
+    ]);
+    expect(() => validateLevelDefinition(level)).not.toThrow();
+  });
+
+  it('rejects invalid source IDs, duplicates, zero geometry, and missing references', () => {
+    const duplicate = createLevel();
+    duplicate.floors[0]!.floorSurfaces[0]!.sourceId =
+      duplicate.floors[0]!.rooms[0]!.sourceId;
+    expect(() => validateLevelDefinition(duplicate)).toThrow(
+      /Duplicate source ID/
+    );
+
+    const zeroWall = createLevel();
+    zeroWall.floors[0]!.walls[1]!.segments = [
+      { start: { x: 1, z: 1 }, end: { x: 1, z: 1 } },
+    ];
+    expect(() => validateLevelDefinition(zeroWall)).toThrow(/zero-length/);
+
+    const zeroSurface = createLevel();
+    zeroSurface.floors[0]!.floorSurfaces[0]!.bounds.maxX = 0;
+    expect(() => validateLevelDefinition(zeroSurface)).toThrow(/zero area/);
+
+    const missingRoom = createLevel();
+    missingRoom.floors[0]!.roomConnections![0]!.rooms = [
+      'livingRoom',
+      'missingRoom',
+    ];
+    expect(() => validateLevelDefinition(missingRoom)).toThrow(/missing room/);
+
+    const tombstone = createLevel();
+    tombstone.floors[0]!.walls[0]!.sourceId = sid('ground.former.wall');
+    expect(() => validateLevelDefinition(tombstone)).toThrow(/tombstone/);
+  });
+});

--- a/src/scene/level/compileLegacyFloorPlan.ts
+++ b/src/scene/level/compileLegacyFloorPlan.ts
@@ -1,0 +1,81 @@
+import type {
+  DoorwayDefinition,
+  FloorPlanDefinition,
+  RoomDefinition,
+  RoomWall,
+} from '../../assets/floorPlan';
+
+import type {
+  FloorDefinition,
+  WallDefinition,
+  WallRunDefinition,
+} from './schema';
+
+const isHorizontalRun = (run: WallRunDefinition): boolean =>
+  run.start.z === run.end.z;
+const isVerticalRun = (run: WallRunDefinition): boolean =>
+  run.start.x === run.end.x;
+
+const toDoorwayWall = (wall: RoomWall): RoomWall => wall;
+
+const gapToDoorway = (
+  run: WallRunDefinition,
+  wall: RoomWall
+): DoorwayDefinition[] => {
+  if (!run.gaps || run.gaps.length === 0) {
+    return [];
+  }
+
+  if (!isHorizontalRun(run) && !isVerticalRun(run)) {
+    return [];
+  }
+
+  return run.gaps.map((gap) => ({
+    wall: toDoorwayWall(wall),
+    start: gap.start,
+    end: gap.end,
+  }));
+};
+
+const getLegacyDoorwaysForRoom = (
+  walls: WallDefinition[],
+  roomId: string
+): DoorwayDefinition[] =>
+  walls.flatMap((wall) => {
+    if (!('run' in wall)) {
+      return [];
+    }
+
+    return (wall.rooms ?? [])
+      .filter((room) => room.roomId === roomId)
+      .flatMap((room) => gapToDoorway(wall.run, room.wall));
+  });
+
+/**
+ * Transitional adapter for legacy systems that still consume FloorPlanDefinition.
+ *
+ * Rooms are copied from declarative semantic rooms. Doorways are derived only
+ * from intentional current-state gaps on wall runs so legacy room-wall helpers
+ * can keep splitting wall segments; semantic roomConnections do not create or
+ * remove geometry and are intentionally ignored here.
+ */
+export function compileLegacyFloorPlan(
+  floor: FloorDefinition
+): FloorPlanDefinition {
+  const rooms: RoomDefinition[] = floor.rooms.map((room) => {
+    const doorways = getLegacyDoorwaysForRoom(floor.walls, room.id);
+    return {
+      id: room.id,
+      name: room.name,
+      bounds: { ...room.bounds },
+      ledColor: room.ledColor,
+      category: room.category,
+      ...(doorways.length > 0 ? { doorways } : {}),
+    };
+  });
+
+  return {
+    outline: floor.outline.map(([x, z]) => [x, z]),
+    rooms,
+  };
+}

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -1,0 +1,262 @@
+import type { Bounds2D, RoomCategory, RoomWall } from '../../assets/floorPlan';
+
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type Point2D = { x: number; z: number };
+export type RectangleBounds = Bounds2D;
+
+export interface LevelDefinition {
+  id: string;
+  floors: FloorDefinition[];
+}
+
+export interface FloorDefinition {
+  id: string;
+  name: string;
+  outline: Array<[number, number]>;
+  rooms: SemanticRoomDefinition[];
+  walls: WallDefinition[];
+  floorSurfaces: FloorSurfaceDefinition[];
+  safetyColliders?: SafetyColliderDefinition[];
+  sceneObjects?: SceneObjectDefinition[];
+  roomConnections?: RoomConnectionDefinition[];
+}
+
+export interface SemanticRoomDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  name: string;
+  bounds: RectangleBounds;
+  ledColor: number;
+  category?: RoomCategory;
+}
+
+export interface WallRoomReference {
+  roomId: string;
+  wall: RoomWall;
+}
+
+export interface WallSegmentDefinition {
+  start: Point2D;
+  end: Point2D;
+}
+
+export interface WallRunGapDefinition {
+  start: number;
+  end: number;
+  purpose?: string;
+}
+
+export interface WallRunDefinition {
+  start: Point2D;
+  end: Point2D;
+  /** Intentional current-state openings; transitional compilers may emit legacy doorways. */
+  gaps?: WallRunGapDefinition[];
+}
+
+export type WallGeometryDefinition =
+  | { segments: WallSegmentDefinition[]; run?: never }
+  | { run: WallRunDefinition; segments?: never };
+
+export type WallDefinition = WallGeometryDefinition & {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  wallKind: 'wall' | 'fence' | 'railing';
+  height?: number;
+  thickness?: number;
+  rooms?: WallRoomReference[];
+  purpose?: string;
+};
+
+export interface FloorSurfaceDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  bounds: RectangleBounds;
+  roomId?: string;
+  elevation?: number;
+  purpose?: string;
+}
+
+export interface SafetyColliderDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  bounds: RectangleBounds;
+  purpose: string;
+}
+
+export interface SceneObjectColliderPolicy {
+  kind: 'none' | 'footprint' | 'customBounds';
+  bounds?: RectangleBounds;
+  purpose?: string;
+}
+
+export interface SceneObjectDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  kind: string;
+  position: Point2D & { y?: number };
+  orientation?: number;
+  colliderPolicy?: SceneObjectColliderPolicy;
+  roomId?: string;
+}
+
+export interface RoomConnectionDefinition {
+  id: string;
+  sourceId: LevelSourceId;
+  floorId: string;
+  rooms: [string, string, ...string[]];
+  label?: string;
+  purpose?: string;
+}
+
+const TOMBSTONE_SOURCE_ID_PARTS = [
+  '.former.',
+  '.removed.',
+  '.debugOnlyRemoval.',
+];
+const MIN_POSITIVE = 1e-6;
+
+const isPositiveArea = (bounds: RectangleBounds): boolean =>
+  bounds.maxX - bounds.minX > MIN_POSITIVE &&
+  bounds.maxZ - bounds.minZ > MIN_POSITIVE;
+
+const segmentLength = (segment: WallSegmentDefinition): number =>
+  Math.hypot(segment.end.x - segment.start.x, segment.end.z - segment.start.z);
+
+const runLength = (run: WallRunDefinition): number =>
+  segmentLength({ start: run.start, end: run.end });
+
+const assertUnique = (ids: string[], label: string): void => {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (seen.has(id)) {
+      throw new Error(`Duplicate ${label} ID "${id}".`);
+    }
+    seen.add(id);
+  }
+};
+
+const validateSourceId = (sourceId: LevelSourceId): void => {
+  assertLevelSourceId(sourceId);
+  if (TOMBSTONE_SOURCE_ID_PARTS.some((part) => sourceId.includes(part))) {
+    throw new Error(`Level source ID "${sourceId}" looks like tombstone data.`);
+  }
+};
+
+export function validateLevelDefinition(level: LevelDefinition): void {
+  assertUnique(
+    level.floors.map((floor) => floor.id),
+    'floor'
+  );
+
+  const sourceIds: string[] = [];
+  for (const floor of level.floors) {
+    assertUnique(
+      floor.rooms.map((room) => room.id),
+      `${floor.id} room`
+    );
+    assertUnique(
+      floor.walls.map((wall) => wall.id),
+      `${floor.id} wall`
+    );
+    assertUnique(
+      floor.floorSurfaces.map((surface) => surface.id),
+      `${floor.id} floor surface`
+    );
+    assertUnique(
+      (floor.safetyColliders ?? []).map((collider) => collider.id),
+      `${floor.id} safety collider`
+    );
+    assertUnique(
+      (floor.sceneObjects ?? []).map((object) => object.id),
+      `${floor.id} scene object`
+    );
+    assertUnique(
+      (floor.roomConnections ?? []).map((connection) => connection.id),
+      `${floor.id} room connection`
+    );
+
+    const roomIds = new Set(floor.rooms.map((room) => room.id));
+    const addSourceId = (sourceId: LevelSourceId) => {
+      validateSourceId(sourceId);
+      sourceIds.push(sourceId);
+    };
+
+    floor.rooms.forEach((room) => addSourceId(room.sourceId));
+
+    for (const wall of floor.walls) {
+      addSourceId(wall.sourceId);
+      if (wall.floorId !== floor.id)
+        throw new Error(
+          `Wall "${wall.id}" references floor "${wall.floorId}".`
+        );
+      if ('segments' in wall) {
+        if (wall.segments.length === 0)
+          throw new Error(`Wall "${wall.id}" requires segments.`);
+        wall.segments.forEach((segment) => {
+          if (segmentLength(segment) <= MIN_POSITIVE)
+            throw new Error(`Wall "${wall.id}" has a zero-length segment.`);
+        });
+      } else if (runLength(wall.run) <= MIN_POSITIVE) {
+        throw new Error(`Wall "${wall.id}" has a zero-length run.`);
+      }
+      wall.rooms?.forEach(({ roomId }) => {
+        if (!roomIds.has(roomId))
+          throw new Error(
+            `Wall "${wall.id}" references missing room "${roomId}".`
+          );
+      });
+    }
+
+    for (const surface of floor.floorSurfaces) {
+      addSourceId(surface.sourceId);
+      if (!isPositiveArea(surface.bounds))
+        throw new Error(`Floor surface "${surface.id}" has zero area.`);
+      if (surface.roomId && !roomIds.has(surface.roomId))
+        throw new Error(
+          `Floor surface "${surface.id}" references missing room "${surface.roomId}".`
+        );
+    }
+
+    for (const collider of floor.safetyColliders ?? []) {
+      addSourceId(collider.sourceId);
+      if (!isPositiveArea(collider.bounds))
+        throw new Error(`Safety collider "${collider.id}" has zero area.`);
+      if (collider.purpose.trim().length === 0)
+        throw new Error(`Safety collider "${collider.id}" requires purpose.`);
+    }
+
+    for (const object of floor.sceneObjects ?? []) {
+      addSourceId(object.sourceId);
+      if (object.roomId && !roomIds.has(object.roomId))
+        throw new Error(
+          `Scene object "${object.id}" references missing room "${object.roomId}".`
+        );
+      if (
+        object.colliderPolicy?.kind === 'customBounds' &&
+        (!object.colliderPolicy.bounds ||
+          !isPositiveArea(object.colliderPolicy.bounds))
+      ) {
+        throw new Error(
+          `Scene object "${object.id}" custom collider bounds require positive area.`
+        );
+      }
+    }
+
+    for (const connection of floor.roomConnections ?? []) {
+      addSourceId(connection.sourceId);
+      connection.rooms.forEach((roomId) => {
+        if (!roomIds.has(roomId))
+          throw new Error(
+            `Room connection "${connection.id}" references missing room "${roomId}".`
+          );
+      });
+    }
+  }
+
+  assertUnique(sourceIds, 'source');
+}


### PR DESCRIPTION
### Motivation

- Introduce a first-class, declarative level source layer so future editor workflows can author rooms, walls, floor surfaces, safety colliders, scene objects, and semantic connections as the authoritative source-of-truth.
- Provide stable semantic source-ID primitives and validation to avoid tombstones, duplicate IDs, and hidden geometry drift during migration.
- Add a minimal transitional adapter so existing runtime code that expects `FloorPlanDefinition` can continue to operate while migration proceeds.

### Description

- Added a typed declarative schema in `src/scene/level/schema.ts` that defines `LevelDefinition`, `FloorDefinition`, `SemanticRoomDefinition`, `WallDefinition` (segments or run+gaps), `FloorSurfaceDefinition`, `SafetyColliderDefinition`, `SceneObjectDefinition`, and `RoomConnectionDefinition`, plus validation helpers and invariant checks via `validateLevelDefinition(...)`.
- Added the transitional compiler adapter `src/scene/level/compileLegacyFloorPlan.ts` which compiles a `FloorDefinition` into the existing `FloorPlanDefinition` shape and derives legacy room `doorways` only from intentional current-state wall-run gaps (semantic `roomConnections` are intentionally ignored by the adapter).
- Added focused Vitest suites `src/scene/level/__tests__/schema.test.ts` and `src/scene/level/__tests__/compileLegacyFloorPlan.test.ts` that cover valid declarative floors, wall-run gaps, duplicate source IDs, zero-length/zero-area rejects, missing room references, tombstone ID rejects, and legacy-plan compilation behavior.
- Updated design documentation at `docs/design/declarative-level-source-of-truth.md` to describe the new schema, gap semantics, validation invariants, and the temporary nature of the legacy adapter; threading through existing `sourceIds` helpers for stable IDs and debug refs.
- This work is intentionally additive and does not change runtime scene construction, generated geometry/colliders, or visible debug IDs.

### Testing

- Ran formatting: `npm run format:write` (applied) and ESLint: `npm run lint` (warnings auto-fixed where applicable and final lint run passed without errors). 
- Ran focused unit tests: `npm run test:ci -- src/scene/level/__tests__/schema.test.ts src/scene/level/__tests__/compileLegacyFloorPlan.test.ts` and observed both test files pass (all tests in those files succeeded).
- Ran full test suite: `npm run test:ci` and observed the full Vitest run completed successfully (all suites executed; existing external-link/network warnings reported by docs/link checker do not block the docs validation). 
- Built and smoke-checked artifacts: `npm run build`, `npm run docs:check`, and `npm run smoke` all completed successfully (link checks reported external fetch warnings but not failures that block the docs check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3213dbd8a4832f9cc7b41d3ba48df1)