### PR TITLE
🏗️ : – migrate rooms and walls to declarative source

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -252,8 +252,9 @@ wall/railing; a walkable opening does not need a former blocker record.
 Current ground and upper room bounds, wall runs, intentional wall-run gaps,
 floor surfaces, and semantic room connections now live in
 `src/scene/level/portfolioLevel.ts`. The temporary adapter in
-`src/scene/level/compileLegacyFloorPlan.ts` compiles a declarative floor back to the existing `FloorPlanDefinition` shape for migration
-checks and narrow compatibility. By default it copies room metadata only. When
+`src/scene/level/compileLegacyFloorPlan.ts` compiles a declarative floor
+back to the existing `FloorPlanDefinition` shape for migration checks and
+narrow compatibility. By default it copies room metadata only. When
 `includeDoorwaysFromWallGaps` is explicitly enabled, it derives legacy room
 `doorways` from current wall-run gaps. That derivation is compatibility glue for
 old room-wall generators, not the canonical future scene-construction path, and

--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -249,8 +249,10 @@ wide enough for the legacy doorway checks. A visible door,
 arch, trim, threshold, or rail should be declared as a scene object or current
 wall/railing; a walkable opening does not need a former blocker record.
 
-The temporary adapter in `src/scene/level/compileLegacyFloorPlan.ts` compiles a
-declarative floor back to the existing `FloorPlanDefinition` shape for migration
+Current ground and upper room bounds, wall runs, intentional wall-run gaps,
+floor surfaces, and semantic room connections now live in
+`src/scene/level/portfolioLevel.ts`. The temporary adapter in
+`src/scene/level/compileLegacyFloorPlan.ts` compiles a declarative floor back to the existing `FloorPlanDefinition` shape for migration
 checks and narrow compatibility. By default it copies room metadata only. When
 `includeDoorwaysFromWallGaps` is explicitly enabled, it derives legacy room
 `doorways` from current wall-run gaps. That derivation is compatibility glue for
@@ -269,8 +271,9 @@ semantic `roomConnections` intentionally do not create or remove geometry.
    IDs so debug references do not churn while source IDs are introduced.
 5. **Add the declarative schema.** Define rooms, walls, floor surfaces, safety
    colliders, scene objects, and room connections as source data.
-6. **Migrate room and wall data.** Move current room and wall intent into the
-   declarative source while proving generated output remains equivalent.
+6. **Migrate room and wall data.** Current room and wall intent now lives in
+   `src/scene/level/portfolioLevel.ts`; legacy floor-plan exports still compile
+   through the adapter until downstream generators consume source data directly.
 7. **Generate wall outputs from source.** Derive wall meshes, wall colliders, and
    wall debug metadata from source-backed wall definitions.
 8. **Generate floor outputs from source.** Derive floor surfaces from source data,

--- a/src/assets/floorPlan/index.ts
+++ b/src/assets/floorPlan/index.ts
@@ -1,3 +1,6 @@
+import { compileLegacyFloorPlan } from '../../scene/level/compileLegacyFloorPlan';
+import { PORTFOLIO_LEVEL } from '../../scene/level/portfolioLevel';
+
 export type RoomWall = 'north' | 'south' | 'east' | 'west';
 
 export interface Bounds2D {
@@ -128,182 +131,19 @@ export interface CombinedWallSegment {
 
 export const WALL_THICKNESS = 0.5;
 
-const DOOR_WIDTH = 4;
-const DOOR_HALF_WIDTH = DOOR_WIDTH / 2;
+// Compatibility floor-plan exports are compiled from the declarative level source.
+// Doorways remain adapter-only glue for legacy room-wall consumers during migration.
+const BASE_FLOOR_PLAN: FloorPlanDefinition = compileLegacyFloorPlan(
+  PORTFOLIO_LEVEL,
+  'ground',
+  { includeDoorwaysFromWallGaps: true }
+);
 
-const livingToKitchenDoorCenter = -9;
-const livingToStudioDoorCenter = 7.5;
-const kitchenToBackyardDoorCenter = -9;
-const studioToBackyardDoorCenter = 7.5;
-const kitchenToStudioDoorCenterZ = 2;
-const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
-const upperLandingToLoftLibraryDoorway = { start: 2, end: 8.2 };
-
-const doorwayRange = (center: number) => ({
-  start: center - DOOR_HALF_WIDTH,
-  end: center + DOOR_HALF_WIDTH,
-});
-
-const BASE_FLOOR_PLAN: FloorPlanDefinition = {
-  outline: [
-    [-16, -16],
-    [16, -16],
-    [16, 16],
-    [-16, 16],
-  ],
-  rooms: [
-    {
-      id: 'livingRoom',
-      name: 'Living Room',
-      bounds: { minX: -16, maxX: 16, minZ: -16, maxZ: -4 },
-      ledColor: 0x4cf889,
-      doorways: [
-        {
-          wall: 'north',
-          ...doorwayRange(livingToKitchenDoorCenter),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(livingToStudioDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'studio',
-      name: 'Studio',
-      bounds: { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
-      ledColor: 0x58c4ff,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(livingToStudioDoorCenter),
-        },
-        {
-          wall: 'west',
-          ...doorwayRange(kitchenToStudioDoorCenterZ),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(studioToBackyardDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'kitchen',
-      name: 'Kitchen',
-      bounds: { minX: -16, maxX: -2, minZ: -4, maxZ: 8 },
-      ledColor: 0xffb347,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(livingToKitchenDoorCenter),
-        },
-        {
-          wall: 'east',
-          ...doorwayRange(kitchenToStudioDoorCenterZ),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(kitchenToBackyardDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'backyard',
-      name: 'Backyard',
-      bounds: { minX: -16, maxX: 16, minZ: 8, maxZ: 16 },
-      ledColor: 0x274f37,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(kitchenToBackyardDoorCenter),
-        },
-        {
-          wall: 'south',
-          ...doorwayRange(studioToBackyardDoorCenter),
-        },
-      ],
-      category: 'exterior',
-    },
-  ],
-};
-
-const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
-  outline: [
-    [-14, -16],
-    [14, -16],
-    [14, 14],
-    [-14, 14],
-  ],
-  rooms: [
-    {
-      id: 'upperLanding',
-      name: 'Upper Landing',
-      bounds: { minX: 2, maxX: 10.4, minZ: -16, maxZ: -8 },
-      ledColor: 0xffba52,
-      doorways: [
-        {
-          wall: 'west',
-          ...upperLandingToCreatorsStudioDoorway,
-        },
-        {
-          wall: 'north',
-          // Intentionally starts at the landing's west edge to open the
-          // upstairs landing-side passage formerly sealed by this wall run.
-          ...upperLandingToLoftLibraryDoorway,
-        },
-      ],
-    },
-    {
-      id: 'creatorsStudio',
-      name: 'Creators Studio',
-      bounds: { minX: -10, maxX: 2, minZ: -16, maxZ: 0 },
-      ledColor: 0x7bd5ff,
-      doorways: [
-        {
-          wall: 'east',
-          ...upperLandingToCreatorsStudioDoorway,
-        },
-        {
-          wall: 'east',
-          ...doorwayRange(-4),
-        },
-      ],
-    },
-    {
-      id: 'loftLibrary',
-      name: 'Loft Library',
-      bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
-      ledColor: 0xc3a7ff,
-      doorways: [
-        {
-          wall: 'south',
-          ...upperLandingToLoftLibraryDoorway,
-        },
-        {
-          wall: 'west',
-          ...doorwayRange(-4),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(4),
-        },
-      ],
-    },
-    {
-      id: 'focusPods',
-      name: 'Focus Pods',
-      bounds: { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
-      ledColor: 0x9cf7c7,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(4),
-        },
-      ],
-    },
-  ],
-};
+const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = compileLegacyFloorPlan(
+  PORTFOLIO_LEVEL,
+  'upper',
+  { includeDoorwaysFromWallGaps: true }
+);
 
 export const FLOOR_PLAN: FloorPlanDefinition =
   scaleFloorPlanDefinition(BASE_FLOOR_PLAN);

--- a/src/scene/level/__tests__/__snapshots__/portfolioLevel.test.ts.snap
+++ b/src/scene/level/__tests__/__snapshots__/portfolioLevel.test.ts.snap
@@ -1,0 +1,768 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PORTFOLIO_LEVEL > compiles compatibility room bounds and doorways for the current floors 1`] = `
+{
+  "outline": [
+    [
+      -16,
+      -16,
+    ],
+    [
+      16,
+      -16,
+    ],
+    [
+      16,
+      16,
+    ],
+    [
+      -16,
+      16,
+    ],
+  ],
+  "rooms": [
+    {
+      "bounds": {
+        "maxX": 16,
+        "maxZ": -4,
+        "minX": -16,
+        "minZ": -16,
+      },
+      "category": undefined,
+      "doorways": [
+        {
+          "end": -7,
+          "start": -11,
+          "wall": "north",
+        },
+        {
+          "end": 9.5,
+          "start": 5.5,
+          "wall": "north",
+        },
+      ],
+      "id": "livingRoom",
+      "ledColor": 5044361,
+      "name": "Living Room",
+    },
+    {
+      "bounds": {
+        "maxX": 16,
+        "maxZ": 8,
+        "minX": -2,
+        "minZ": -4,
+      },
+      "category": undefined,
+      "doorways": [
+        {
+          "end": 9.5,
+          "start": 5.5,
+          "wall": "south",
+        },
+        {
+          "end": 4,
+          "start": 0,
+          "wall": "west",
+        },
+        {
+          "end": 9.5,
+          "start": 5.5,
+          "wall": "north",
+        },
+      ],
+      "id": "studio",
+      "ledColor": 5817599,
+      "name": "Studio",
+    },
+    {
+      "bounds": {
+        "maxX": -2,
+        "maxZ": 8,
+        "minX": -16,
+        "minZ": -4,
+      },
+      "category": undefined,
+      "doorways": [
+        {
+          "end": -7,
+          "start": -11,
+          "wall": "south",
+        },
+        {
+          "end": 4,
+          "start": 0,
+          "wall": "east",
+        },
+        {
+          "end": -7,
+          "start": -11,
+          "wall": "north",
+        },
+      ],
+      "id": "kitchen",
+      "ledColor": 16757575,
+      "name": "Kitchen",
+    },
+    {
+      "bounds": {
+        "maxX": 16,
+        "maxZ": 16,
+        "minX": -16,
+        "minZ": 8,
+      },
+      "category": "exterior",
+      "doorways": [
+        {
+          "end": -7,
+          "start": -11,
+          "wall": "south",
+        },
+        {
+          "end": 9.5,
+          "start": 5.5,
+          "wall": "south",
+        },
+      ],
+      "id": "backyard",
+      "ledColor": 2576183,
+      "name": "Backyard",
+    },
+  ],
+}
+`;
+
+exports[`PORTFOLIO_LEVEL > compiles compatibility room bounds and doorways for the current floors 2`] = `
+{
+  "outline": [
+    [
+      -14,
+      -16,
+    ],
+    [
+      14,
+      -16,
+    ],
+    [
+      14,
+      14,
+    ],
+    [
+      -14,
+      14,
+    ],
+  ],
+  "rooms": [
+    {
+      "bounds": {
+        "maxX": 10.4,
+        "maxZ": -8,
+        "minX": 2,
+        "minZ": -16,
+      },
+      "category": undefined,
+      "doorways": [
+        {
+          "end": -13.07,
+          "start": -16,
+          "wall": "west",
+        },
+        {
+          "end": 8.2,
+          "start": 2,
+          "wall": "north",
+        },
+      ],
+      "id": "upperLanding",
+      "ledColor": 16759378,
+      "name": "Upper Landing",
+    },
+    {
+      "bounds": {
+        "maxX": 2,
+        "maxZ": 0,
+        "minX": -10,
+        "minZ": -16,
+      },
+      "category": undefined,
+      "doorways": [
+        {
+          "end": -13.07,
+          "start": -16,
+          "wall": "east",
+        },
+        {
+          "end": -2,
+          "start": -6,
+          "wall": "east",
+        },
+      ],
+      "id": "creatorsStudio",
+      "ledColor": 8115711,
+      "name": "Creators Studio",
+    },
+    {
+      "bounds": {
+        "maxX": 12,
+        "maxZ": 6,
+        "minX": 2,
+        "minZ": -8,
+      },
+      "category": undefined,
+      "doorways": [
+        {
+          "end": -2,
+          "start": -6,
+          "wall": "west",
+        },
+        {
+          "end": 8.2,
+          "start": 2,
+          "wall": "south",
+        },
+        {
+          "end": 6,
+          "start": 2,
+          "wall": "north",
+        },
+      ],
+      "id": "loftLibrary",
+      "ledColor": 12822527,
+      "name": "Loft Library",
+    },
+    {
+      "bounds": {
+        "maxX": 12,
+        "maxZ": 14,
+        "minX": -10,
+        "minZ": 6,
+      },
+      "category": undefined,
+      "doorways": [
+        {
+          "end": 6,
+          "start": 2,
+          "wall": "south",
+        },
+      ],
+      "id": "focusPods",
+      "ledColor": 10287047,
+      "name": "Focus Pods",
+    },
+  ],
+}
+`;
+
+exports[`PORTFOLIO_LEVEL > keeps current generated wall bounds stable for compatibility consumers 1`] = `
+[
+  {
+    "end": {
+      "x": -4.000000000000001,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "kitchen:south",
+      "livingRoom:north",
+    ],
+    "start": {
+      "x": -14.000000000000004,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": -4.000000000000001,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "backyard:south",
+      "kitchen:north",
+    ],
+    "start": {
+      "x": -14.000000000000004,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": -32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "livingRoom:south",
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": -32,
+    },
+  },
+  {
+    "end": {
+      "x": -22.000000000000004,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "kitchen:south",
+      "livingRoom:north",
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": -22.000000000000004,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "backyard:south",
+      "kitchen:north",
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": 32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "backyard:north",
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": 32,
+    },
+  },
+  {
+    "end": {
+      "x": 11.000000000000002,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "livingRoom:north",
+      "studio:south",
+    ],
+    "start": {
+      "x": -4.000000000000001,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": 11.000000000000002,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "backyard:south",
+      "studio:north",
+    ],
+    "start": {
+      "x": -4.000000000000001,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "livingRoom:north",
+      "studio:south",
+    ],
+    "start": {
+      "x": 19.000000000000004,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "backyard:south",
+      "studio:north",
+    ],
+    "start": {
+      "x": 19.000000000000004,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": -32,
+      "z": -8.000000000000002,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "livingRoom:west",
+    ],
+    "start": {
+      "x": -32,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": -32,
+      "z": 16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "kitchen:west",
+    ],
+    "start": {
+      "x": -32,
+      "z": -8.000000000000002,
+    },
+  },
+  {
+    "end": {
+      "x": -32,
+      "z": 32.00000000000001,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "backyard:west",
+    ],
+    "start": {
+      "x": -32,
+      "z": 16.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": -4,
+      "z": 0,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "kitchen:east",
+      "studio:west",
+    ],
+    "start": {
+      "x": -4,
+      "z": -8.000000000000002,
+    },
+  },
+  {
+    "end": {
+      "x": -4,
+      "z": 16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "kitchen:east",
+      "studio:west",
+    ],
+    "start": {
+      "x": -4,
+      "z": 8.000000000000002,
+    },
+  },
+  {
+    "end": {
+      "x": 32,
+      "z": -8.000000000000002,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "livingRoom:east",
+    ],
+    "start": {
+      "x": 32,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": 32,
+      "z": 16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "studio:east",
+    ],
+    "start": {
+      "x": 32,
+      "z": -8.000000000000002,
+    },
+  },
+  {
+    "end": {
+      "x": 32,
+      "z": 32.00000000000001,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "backyard:east",
+    ],
+    "start": {
+      "x": 32,
+      "z": 16.000000000000004,
+    },
+  },
+]
+`;
+
+exports[`PORTFOLIO_LEVEL > keeps current generated wall bounds stable for compatibility consumers 2`] = `
+[
+  {
+    "end": {
+      "x": 4.000000000000001,
+      "z": -32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "creatorsStudio:south",
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": -32,
+    },
+  },
+  {
+    "end": {
+      "x": 4.000000000000001,
+      "z": 0,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "creatorsStudio:north",
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": 0,
+    },
+  },
+  {
+    "end": {
+      "x": 4.000000000000001,
+      "z": 12,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "focusPods:south",
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": 12,
+    },
+  },
+  {
+    "end": {
+      "x": 24.000000000000007,
+      "z": 28,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "focusPods:north",
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": 28,
+    },
+  },
+  {
+    "end": {
+      "x": 24.000000000000007,
+      "z": 12,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "focusPods:south",
+      "loftLibrary:north",
+    ],
+    "start": {
+      "x": 12.000000000000004,
+      "z": 12,
+    },
+  },
+  {
+    "end": {
+      "x": 20.800000000000004,
+      "z": -16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "loftLibrary:south",
+      "upperLanding:north",
+    ],
+    "start": {
+      "x": 16.400000000000002,
+      "z": -16,
+    },
+  },
+  {
+    "end": {
+      "x": 24.000000000000007,
+      "z": -16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "loftLibrary:south",
+    ],
+    "start": {
+      "x": 20.800000000000004,
+      "z": -16,
+    },
+  },
+  {
+    "end": {
+      "x": 20.800000000000004,
+      "z": -32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      "upperLanding:south",
+    ],
+    "start": {
+      "x": 4.000000000000001,
+      "z": -32,
+    },
+  },
+  {
+    "end": {
+      "x": -20,
+      "z": 0,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "creatorsStudio:west",
+    ],
+    "start": {
+      "x": -20,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": -20,
+      "z": 28.000000000000007,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "focusPods:west",
+    ],
+    "start": {
+      "x": -20,
+      "z": 12.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": 20.8,
+      "z": -16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "upperLanding:east",
+    ],
+    "start": {
+      "x": 20.8,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": 24,
+      "z": 12.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "loftLibrary:east",
+    ],
+    "start": {
+      "x": 24,
+      "z": -16.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": 24,
+      "z": 28.000000000000007,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "focusPods:east",
+    ],
+    "start": {
+      "x": 24,
+      "z": 12.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": -12.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "creatorsStudio:east",
+      "loftLibrary:west",
+    ],
+    "start": {
+      "x": 4,
+      "z": -16.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": -16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "creatorsStudio:east",
+      "upperLanding:west",
+    ],
+    "start": {
+      "x": 4,
+      "z": -26.140000000000008,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": 0,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "creatorsStudio:east",
+      "loftLibrary:west",
+    ],
+    "start": {
+      "x": 4,
+      "z": -4.000000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": 12.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      "loftLibrary:west",
+    ],
+    "start": {
+      "x": 4,
+      "z": 0,
+    },
+  },
+]
+`;

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLOOR_PLAN,
+  FLOOR_PLAN_SCALE,
+  UPPER_FLOOR_PLAN,
+  getCombinedWallSegments,
+  getFloorBounds,
+} from '../../../assets/floorPlan';
+import { compileLegacyFloorPlan } from '../compileLegacyFloorPlan';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import { validateLevelDefinition } from '../schema';
+
+const toWorld = (value: number) => value * FLOOR_PLAN_SCALE;
+
+const normalizeSegments = (plan: typeof FLOOR_PLAN) =>
+  getCombinedWallSegments(plan)
+    .map((segment) => ({
+      orientation: segment.orientation,
+      start: segment.start,
+      end: segment.end,
+      rooms: segment.rooms.map((room) => `${room.id}:${room.wall}`).sort(),
+    }))
+    .sort((a, b) =>
+      [a.orientation, a.start.x, a.start.z, a.end.x, a.end.z, a.rooms.join('|')]
+        .join('|')
+        .localeCompare(
+          [
+            b.orientation,
+            b.start.x,
+            b.start.z,
+            b.end.x,
+            b.end.z,
+            b.rooms.join('|'),
+          ].join('|')
+        )
+    );
+
+const collectSourceIds = () =>
+  PORTFOLIO_LEVEL.floors.flatMap((floor) => [
+    ...floor.rooms.map((room) => room.sourceId),
+    ...floor.walls.map((wall) => wall.sourceId),
+    ...floor.floorSurfaces.map((surface) => surface.sourceId),
+    ...(floor.safetyColliders ?? []).map((collider) => collider.sourceId),
+    ...(floor.sceneObjects ?? []).map((object) => object.sourceId),
+    ...(floor.roomConnections ?? []).map((connection) => connection.sourceId),
+  ]);
+
+describe('PORTFOLIO_LEVEL', () => {
+  it('uses valid, unique production source IDs', () => {
+    expect(validateLevelDefinition(PORTFOLIO_LEVEL).errors).toEqual([]);
+    const sourceIds = collectSourceIds().map(String);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(sourceIds).not.toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/(^|\.)(former|removed|debugonlyremoval)(\.|$)/),
+      ])
+    );
+  });
+
+  it('compiles compatibility room bounds and doorways for the current floors', () => {
+    expect(
+      compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    ).toMatchSnapshot();
+    expect(
+      compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'upper', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    ).toMatchSnapshot();
+  });
+
+  it('keeps current compatibility floor bounds unchanged', () => {
+    expect(getFloorBounds(FLOOR_PLAN)).toEqual({
+      minX: toWorld(-16),
+      maxX: toWorld(16),
+      minZ: toWorld(-16),
+      maxZ: toWorld(16),
+    });
+    expect(getFloorBounds(UPPER_FLOOR_PLAN)).toEqual({
+      minX: toWorld(-14),
+      maxX: toWorld(14),
+      minZ: toWorld(-16),
+      maxZ: toWorld(14),
+    });
+  });
+
+  it('keeps current generated wall bounds stable for compatibility consumers', () => {
+    expect(normalizeSegments(FLOOR_PLAN)).toMatchSnapshot();
+    expect(normalizeSegments(UPPER_FLOOR_PLAN)).toMatchSnapshot();
+  });
+
+  it('does not let semantic room connections affect legacy room or wall generation', () => {
+    const withoutConnections = {
+      ...PORTFOLIO_LEVEL,
+      floors: PORTFOLIO_LEVEL.floors.map((floor) => ({
+        ...floor,
+        roomConnections: [],
+      })),
+    };
+
+    expect(
+      compileLegacyFloorPlan(withoutConnections, 'ground', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    ).toEqual(
+      compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    );
+    expect(
+      compileLegacyFloorPlan(withoutConnections, 'upper', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    ).toEqual(
+      compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'upper', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    );
+  });
+});

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -101,9 +101,9 @@ const floorSurfaceForRoom = (
   };
 };
 
-const buildFloor = (
-  floor: Omit<FloorDefinition, 'floorSurfaces'>
-): FloorDefinition => ({
+type FloorDefinitionInput = Omit<FloorDefinition, 'floorSurfaces'>;
+
+const buildFloor = (floor: FloorDefinitionInput): FloorDefinition => ({
   ...floor,
   floorSurfaces: floor.rooms.map((room) => floorSurfaceForRoom(floor.id, room)),
 });

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -1,0 +1,492 @@
+import type { LevelDefinition, WallDefinition } from './schema';
+import { assertLevelSourceId } from './sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const DOOR_WIDTH = 4;
+const DOOR_HALF_WIDTH = DOOR_WIDTH / 2;
+
+const doorwayRange = (center: number) => ({
+  start: center - DOOR_HALF_WIDTH,
+  end: center + DOOR_HALF_WIDTH,
+});
+
+const gap = (start: number, end: number, label: string) => ({
+  start,
+  end,
+  label,
+});
+
+const horizontalWall = (
+  id: string,
+  source: string,
+  floorId: 'ground' | 'upper',
+  z: number,
+  startX: number,
+  endX: number,
+  rooms: string[],
+  gaps: Array<{ start: number; end: number; label: string }> = [],
+  wallKind: WallDefinition['wallKind'] = 'wall'
+): WallDefinition => ({
+  id,
+  sourceId: sourceId(source),
+  floorId,
+  wallKind,
+  rooms,
+  purpose: rooms.length === 1 ? 'exterior-boundary' : 'room-boundary',
+  run: {
+    start: { x: startX, z },
+    end: { x: endX, z },
+    ...(gaps.length > 0 ? { gaps } : {}),
+  },
+});
+
+const verticalWall = (
+  id: string,
+  source: string,
+  floorId: 'ground' | 'upper',
+  x: number,
+  startZ: number,
+  endZ: number,
+  rooms: string[],
+  gaps: Array<{ start: number; end: number; label: string }> = [],
+  wallKind: WallDefinition['wallKind'] = 'wall'
+): WallDefinition => ({
+  id,
+  sourceId: sourceId(source),
+  floorId,
+  wallKind,
+  rooms,
+  purpose: rooms.length === 1 ? 'exterior-boundary' : 'room-boundary',
+  run: {
+    start: { x, z: startZ },
+    end: { x, z: endZ },
+    ...(gaps.length > 0 ? { gaps } : {}),
+  },
+});
+
+const livingToKitchenDoorCenter = -9;
+const livingToStudioDoorCenter = 7.5;
+const kitchenToBackyardDoorCenter = -9;
+const studioToBackyardDoorCenter = 7.5;
+const kitchenToStudioDoorCenterZ = 2;
+const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
+const upperLandingToLoftLibraryDoorway = { start: 2, end: 8.2 };
+
+const centeredGap = (runStart: number, center: number, label: string) => {
+  const range = doorwayRange(center);
+  return gap(range.start - runStart, range.end - runStart, label);
+};
+
+export const PORTFOLIO_LEVEL: LevelDefinition = {
+  id: 'portfolio',
+  floors: [
+    {
+      id: 'ground',
+      name: 'Ground Floor',
+      outline: [
+        [-16, -16],
+        [16, -16],
+        [16, 16],
+        [-16, 16],
+      ],
+      rooms: [
+        {
+          id: 'livingRoom',
+          sourceId: sourceId('ground.living_room.room'),
+          name: 'Living Room',
+          bounds: { minX: -16, maxX: 16, minZ: -16, maxZ: -4 },
+          ledColor: 0x4cf889,
+        },
+        {
+          id: 'studio',
+          sourceId: sourceId('ground.studio.room'),
+          name: 'Studio',
+          bounds: { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
+          ledColor: 0x58c4ff,
+        },
+        {
+          id: 'kitchen',
+          sourceId: sourceId('ground.kitchen.room'),
+          name: 'Kitchen',
+          bounds: { minX: -16, maxX: -2, minZ: -4, maxZ: 8 },
+          ledColor: 0xffb347,
+        },
+        {
+          id: 'backyard',
+          sourceId: sourceId('ground.backyard.room'),
+          name: 'Backyard',
+          bounds: { minX: -16, maxX: 16, minZ: 8, maxZ: 16 },
+          ledColor: 0x274f37,
+          category: 'exterior',
+        },
+      ],
+      walls: [
+        horizontalWall(
+          'living-room-south-wall',
+          'ground.living_room.south_wall',
+          'ground',
+          -16,
+          -16,
+          16,
+          ['livingRoom']
+        ),
+        verticalWall(
+          'living-room-west-wall',
+          'ground.living_room.west_wall',
+          'ground',
+          -16,
+          -16,
+          -4,
+          ['livingRoom']
+        ),
+        verticalWall(
+          'living-room-east-wall',
+          'ground.living_room.east_wall',
+          'ground',
+          16,
+          -16,
+          -4,
+          ['livingRoom']
+        ),
+        horizontalWall(
+          'living-room-north-wall',
+          'ground.living_room.north_wall',
+          'ground',
+          -4,
+          -16,
+          16,
+          ['livingRoom', 'kitchen', 'studio'],
+          [
+            centeredGap(-16, livingToKitchenDoorCenter, 'living-to-kitchen'),
+            centeredGap(-16, livingToStudioDoorCenter, 'living-to-studio'),
+          ]
+        ),
+        verticalWall(
+          'kitchen-studio-wall',
+          'ground.kitchen_studio.wall',
+          'ground',
+          -2,
+          -4,
+          8,
+          ['kitchen', 'studio'],
+          [centeredGap(-4, kitchenToStudioDoorCenterZ, 'kitchen-to-studio')]
+        ),
+        verticalWall(
+          'kitchen-west-wall',
+          'ground.kitchen.west_wall',
+          'ground',
+          -16,
+          -4,
+          8,
+          ['kitchen']
+        ),
+        verticalWall(
+          'studio-east-wall',
+          'ground.studio.east_wall',
+          'ground',
+          16,
+          -4,
+          8,
+          ['studio']
+        ),
+        horizontalWall(
+          'kitchen-studio-backyard-wall',
+          'ground.backyard.south_wall',
+          'ground',
+          8,
+          -16,
+          16,
+          ['kitchen', 'studio', 'backyard'],
+          [
+            centeredGap(
+              -16,
+              kitchenToBackyardDoorCenter,
+              'kitchen-to-backyard'
+            ),
+            centeredGap(-16, studioToBackyardDoorCenter, 'studio-to-backyard'),
+          ],
+          'fence'
+        ),
+        verticalWall(
+          'backyard-west-fence',
+          'ground.backyard.west_fence',
+          'ground',
+          -16,
+          8,
+          16,
+          ['backyard'],
+          [],
+          'fence'
+        ),
+        verticalWall(
+          'backyard-east-fence',
+          'ground.backyard.east_fence',
+          'ground',
+          16,
+          8,
+          16,
+          ['backyard'],
+          [],
+          'fence'
+        ),
+        horizontalWall(
+          'backyard-north-fence',
+          'ground.backyard.north_fence',
+          'ground',
+          16,
+          -16,
+          16,
+          ['backyard'],
+          [],
+          'fence'
+        ),
+      ],
+      floorSurfaces: [],
+      roomConnections: [
+        {
+          id: 'living-to-kitchen',
+          sourceId: sourceId('ground.living_room_to_kitchen.connection'),
+          floorId: 'ground',
+          rooms: ['livingRoom', 'kitchen'],
+          label: 'Living room to kitchen',
+        },
+        {
+          id: 'living-to-studio',
+          sourceId: sourceId('ground.living_room_to_studio.connection'),
+          floorId: 'ground',
+          rooms: ['livingRoom', 'studio'],
+          label: 'Living room to studio',
+        },
+        {
+          id: 'kitchen-to-studio',
+          sourceId: sourceId('ground.kitchen_to_studio.connection'),
+          floorId: 'ground',
+          rooms: ['kitchen', 'studio'],
+          label: 'Kitchen to studio',
+        },
+        {
+          id: 'kitchen-to-backyard',
+          sourceId: sourceId('ground.kitchen_to_backyard.connection'),
+          floorId: 'ground',
+          rooms: ['kitchen', 'backyard'],
+          label: 'Kitchen to backyard',
+        },
+        {
+          id: 'studio-to-backyard',
+          sourceId: sourceId('ground.studio_to_backyard.connection'),
+          floorId: 'ground',
+          rooms: ['studio', 'backyard'],
+          label: 'Studio to backyard',
+        },
+      ],
+    },
+    {
+      id: 'upper',
+      name: 'Upper Floor',
+      outline: [
+        [-14, -16],
+        [14, -16],
+        [14, 14],
+        [-14, 14],
+      ],
+      rooms: [
+        {
+          id: 'upperLanding',
+          sourceId: sourceId('upper.upper_landing.room'),
+          name: 'Upper Landing',
+          bounds: { minX: 2, maxX: 10.4, minZ: -16, maxZ: -8 },
+          ledColor: 0xffba52,
+        },
+        {
+          id: 'creatorsStudio',
+          sourceId: sourceId('upper.creators_studio.room'),
+          name: 'Creators Studio',
+          bounds: { minX: -10, maxX: 2, minZ: -16, maxZ: 0 },
+          ledColor: 0x7bd5ff,
+        },
+        {
+          id: 'loftLibrary',
+          sourceId: sourceId('upper.loft_library.room'),
+          name: 'Loft Library',
+          bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
+          ledColor: 0xc3a7ff,
+        },
+        {
+          id: 'focusPods',
+          sourceId: sourceId('upper.focus_pods.room'),
+          name: 'Focus Pods',
+          bounds: { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
+          ledColor: 0x9cf7c7,
+        },
+      ],
+      walls: [
+        horizontalWall(
+          'creators-studio-south-wall',
+          'upper.creators_studio.south_wall',
+          'upper',
+          -16,
+          -10,
+          2,
+          ['creatorsStudio']
+        ),
+        verticalWall(
+          'creators-studio-west-wall',
+          'upper.creators_studio.west_wall',
+          'upper',
+          -10,
+          -16,
+          0,
+          ['creatorsStudio']
+        ),
+        verticalWall(
+          'creators-studio-upper-landing-wall',
+          'upper.creators_studio_to_upper_landing.wall',
+          'upper',
+          2,
+          -16,
+          0,
+          ['creatorsStudio', 'upperLanding', 'loftLibrary'],
+          [
+            gap(
+              0,
+              upperLandingToCreatorsStudioDoorway.end -
+                upperLandingToCreatorsStudioDoorway.start,
+              'creators-studio-to-landing'
+            ),
+            centeredGap(-16, -4, 'creators-studio-to-library'),
+          ]
+        ),
+        horizontalWall(
+          'upper-landing-south-wall',
+          'upper.upper_landing.south_wall',
+          'upper',
+          -16,
+          2,
+          10.4,
+          ['upperLanding']
+        ),
+        verticalWall(
+          'upper-landing-east-wall',
+          'upper.upper_landing.east_wall',
+          'upper',
+          10.4,
+          -16,
+          -8,
+          ['upperLanding']
+        ),
+        horizontalWall(
+          'upper-landing-loft-library-wall',
+          'upper.upper_landing_to_loft_library.wall',
+          'upper',
+          -8,
+          2,
+          12,
+          ['upperLanding', 'loftLibrary'],
+          [
+            gap(
+              0,
+              upperLandingToLoftLibraryDoorway.end -
+                upperLandingToLoftLibraryDoorway.start,
+              'landing-to-library'
+            ),
+          ]
+        ),
+        verticalWall(
+          'loft-library-east-wall',
+          'upper.loft_library.east_wall',
+          'upper',
+          12,
+          -8,
+          6,
+          ['loftLibrary']
+        ),
+        horizontalWall(
+          'loft-library-focus-pods-wall',
+          'upper.loft_library_to_focus_pods.wall',
+          'upper',
+          6,
+          2,
+          12,
+          ['loftLibrary', 'focusPods'],
+          [centeredGap(2, 4, 'library-to-focus-pods')]
+        ),
+        horizontalWall(
+          'focus-pods-north-wall',
+          'upper.focus_pods.north_wall',
+          'upper',
+          14,
+          -10,
+          12,
+          ['focusPods']
+        ),
+        verticalWall(
+          'focus-pods-west-wall',
+          'upper.focus_pods.west_wall',
+          'upper',
+          -10,
+          6,
+          14,
+          ['focusPods']
+        ),
+        verticalWall(
+          'focus-pods-east-wall',
+          'upper.focus_pods.east_wall',
+          'upper',
+          12,
+          6,
+          14,
+          ['focusPods']
+        ),
+      ],
+      floorSurfaces: [],
+      roomConnections: [
+        {
+          id: 'upper-landing-to-creators-studio',
+          sourceId: sourceId(
+            'upper.upper_landing_to_creators_studio.connection'
+          ),
+          floorId: 'upper',
+          rooms: ['upperLanding', 'creatorsStudio'],
+          label: 'Upper landing to creators studio',
+        },
+        {
+          id: 'upper-landing-to-loft-library',
+          sourceId: sourceId('upper.upper_landing_to_loft_library.connection'),
+          floorId: 'upper',
+          rooms: ['upperLanding', 'loftLibrary'],
+          label: 'Upper landing to loft library',
+        },
+        {
+          id: 'creators-studio-to-loft-library',
+          sourceId: sourceId(
+            'upper.creators_studio_to_loft_library.connection'
+          ),
+          floorId: 'upper',
+          rooms: ['creatorsStudio', 'loftLibrary'],
+          label: 'Creators studio to loft library',
+        },
+        {
+          id: 'loft-library-to-focus-pods',
+          sourceId: sourceId('upper.loft_library_to_focus_pods.connection'),
+          floorId: 'upper',
+          rooms: ['loftLibrary', 'focusPods'],
+          label: 'Loft library to focus pods',
+        },
+      ],
+    },
+  ],
+};
+
+PORTFOLIO_LEVEL.floors.forEach((floor) => {
+  floor.floorSurfaces = floor.rooms.map((room) => ({
+    id: `${room.id}-floor-surface`,
+    sourceId: sourceId(
+      `${floor.id}.${room.id.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()}.floor_surface`
+    ),
+    floorId: floor.id,
+    bounds: { ...room.bounds },
+    roomId: room.id,
+    purpose: 'room-floor',
+  }));
+});

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -1,4 +1,8 @@
-import type { LevelDefinition, WallDefinition } from './schema';
+import type {
+  FloorDefinition,
+  LevelDefinition,
+  WallDefinition,
+} from './schema';
 import { assertLevelSourceId } from './sourceIds';
 
 const sourceId = (value: string) => assertLevelSourceId(value);
@@ -78,10 +82,36 @@ const centeredGap = (runStart: number, center: number, label: string) => {
   return gap(range.start - runStart, range.end - runStart, label);
 };
 
+const roomIdToSourceSegment = (roomId: string) =>
+  roomId.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+
+const floorSurfaceForRoom = (
+  floorId: FloorDefinition['id'],
+  room: FloorDefinition['rooms'][number]
+): FloorDefinition['floorSurfaces'][number] => {
+  const roomSourceSegment = roomIdToSourceSegment(room.id);
+
+  return {
+    id: `${room.id}-floor-surface`,
+    sourceId: sourceId(`${floorId}.${roomSourceSegment}.floor_surface`),
+    floorId,
+    bounds: { ...room.bounds },
+    roomId: room.id,
+    purpose: 'room-floor',
+  };
+};
+
+const buildFloor = (
+  floor: Omit<FloorDefinition, 'floorSurfaces'>
+): FloorDefinition => ({
+  ...floor,
+  floorSurfaces: floor.rooms.map((room) => floorSurfaceForRoom(floor.id, room)),
+});
+
 export const PORTFOLIO_LEVEL: LevelDefinition = {
   id: 'portfolio',
   floors: [
-    {
+    buildFloor({
       id: 'ground',
       name: 'Ground Floor',
       outline: [
@@ -205,8 +235,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
               'kitchen-to-backyard'
             ),
             centeredGap(-16, studioToBackyardDoorCenter, 'studio-to-backyard'),
-          ],
-          'fence'
+          ]
         ),
         verticalWall(
           'backyard-west-fence',
@@ -242,7 +271,6 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'fence'
         ),
       ],
-      floorSurfaces: [],
       roomConnections: [
         {
           id: 'living-to-kitchen',
@@ -280,8 +308,8 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           label: 'Studio to backyard',
         },
       ],
-    },
-    {
+    }),
+    buildFloor({
       id: 'upper',
       name: 'Upper Floor',
       outline: [
@@ -356,6 +384,33 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
             ),
             centeredGap(-16, -4, 'creators-studio-to-library'),
           ]
+        ),
+        horizontalWall(
+          'creators-studio-north-wall',
+          'upper.creators_studio.north_wall',
+          'upper',
+          0,
+          -10,
+          2,
+          ['creatorsStudio']
+        ),
+        verticalWall(
+          'loft-library-west-wall',
+          'upper.loft_library.west_wall',
+          'upper',
+          2,
+          0,
+          6,
+          ['loftLibrary']
+        ),
+        horizontalWall(
+          'focus-pods-south-wall',
+          'upper.focus_pods.south_wall',
+          'upper',
+          6,
+          -10,
+          2,
+          ['focusPods']
         ),
         horizontalWall(
           'upper-landing-south-wall',
@@ -439,7 +494,6 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           ['focusPods']
         ),
       ],
-      floorSurfaces: [],
       roomConnections: [
         {
           id: 'upper-landing-to-creators-studio',
@@ -474,19 +528,6 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           label: 'Loft library to focus pods',
         },
       ],
-    },
+    }),
   ],
 };
-
-PORTFOLIO_LEVEL.floors.forEach((floor) => {
-  floor.floorSurfaces = floor.rooms.map((room) => ({
-    id: `${room.id}-floor-surface`,
-    sourceId: sourceId(
-      `${floor.id}.${room.id.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()}.floor_surface`
-    ),
-    floorId: floor.id,
-    bounds: { ...room.bounds },
-    roomId: room.id,
-    purpose: 'room-floor',
-  }));
-});


### PR DESCRIPTION
### Motivation
- Introduce a canonical, declarative source-of-truth for the current ground and upper floor rooms, walls, intentional wall-run gaps, floor surfaces, and semantic room connections.
- Preserve existing runtime outputs and legacy consumers by compiling the compatibility `FLOOR_PLAN`/`UPPER_FLOOR_PLAN` exports from the new declarative source via an adapter.
- Add validation and invariants to ensure stable, unique source IDs and prevent tombstone-style removal patterns while enabling a safe migration path.

### Description
- Add `PORTFOLIO_LEVEL` as a declarative `LevelDefinition` containing `ground` and `upper` floors with semantic rooms, wall runs (with intentional `gaps` for passages), floor surfaces, fences, and `roomConnections` in `src/scene/level/portfolioLevel.ts`.
- Change `src/assets/floorPlan/index.ts` to compile the legacy `BASE_FLOOR_PLAN`/`UPPER_FLOOR_BASE_PLAN` from the declarative source using `compileLegacyFloorPlan(...)` so legacy doorway ranges remain available as adapter-only compatibility.
- Add tests and snapshots in `src/scene/level/__tests__/portfolioLevel.test.ts` (plus generated snapshots) that validate source ID uniqueness/format, that compiled legacy floor plans match expected room bounds/doorways, that generated combined wall segments remain stable, and that `roomConnections` do not affect geometry.
- Update the design doc `docs/design/declarative-level-source-of-truth.md` to note that current rooms/walls live in `portfolioLevel.ts` and that legacy exports are temporarily adapter-compiled.

### Testing
- Ran `npm run format:write` which completed successfully.
- Ran `npm run lint` which passed after fixing an import ordering warning.
- Ran targeted tests `npm run test:ci -- src/scene/level/__tests__/portfolioLevel.test.ts src/tests/floorPlanDoorways.test.ts src/tests/wallSegments.test.ts` and they passed.
- Ran the full unit suite with `npm run test:ci` which completed successfully (152 files, 1172 tests passed).
- Ran `npm run docs:check` which passed but emitted external link fetch warnings (network reachability warnings only).
- Ran `npm run smoke` and `npm run build` which succeeded and produced valid `dist` artifacts.
- Installed Playwright browsers with `npx playwright install chromium` which succeeded, but running `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` in this environment failed due to missing host browser libraries; missing system packages include `libatk1.0-0t64`, `libatk-bridge2.0-0t64`, `libatspi2.0-0t64`, `libxcomposite1`, `libxdamage1`, `libxfixes3`, `libxrandr2`, `libgbm1`, `libxkbcommon0`, and `libasound2t64` preventing Playwright from launching Chromium here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32cc81c09c832fb4f42127dd324e05)