### PR TITLE
Add declarative portfolio level source and legacy floor-plan adapter

### DIFF
--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -48,6 +48,11 @@ layer without guessing where functionality lives.
 
 - [`src/assets/`](../../src/assets/) – floor plans, localisation, theme, and
   performance budgets. Also exposes POI copy consumed across systems and UI.
+  Current room bounds and wall runs are now canonically declared in
+  [`src/scene/level/portfolioLevel.ts`](../../src/scene/level/portfolioLevel.ts);
+  [`src/assets/floorPlan/index.ts`](../../src/assets/floorPlan/index.ts) remains a
+  compatibility adapter that compiles those records into the legacy floor-plan exports
+  during the migration.
 - [`src/systems/`](../../src/systems/) – keyboard controls, audio pipelines,
   movement prediction, collision detection, mode failover, HUD control handles,
   and the GitHub repo stats service that reads pod-local runtime metrics into POIs.

--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -257,6 +257,21 @@ checks and narrow compatibility. By default it copies room metadata only. When
 old room-wall generators, not the canonical future scene-construction path, and
 semantic `roomConnections` intentionally do not create or remove geometry.
 
+## Current room and wall source (phase 6)
+
+The current ground and upper room bounds, wall runs, wall-run gaps, floor
+surfaces, and semantic room adjacencies now live in
+`src/scene/level/portfolioLevel.ts`. `src/assets/floorPlan/index.ts` remains as
+compatibility scaffolding: it compiles that declarative source into the legacy
+`FLOOR_PLAN`, `UPPER_FLOOR_PLAN`, and `FLOOR_PLAN_LEVELS` exports so runtime wall,
+floor, stair, POI, and showpiece behavior stays unchanged while later prompts
+move generators over one layer at a time.
+
+Open passages are represented as current wall-run gaps or by absent current wall
+segments rather than production tombstones. The source can document semantic
+`roomConnections`, but those records are adjacency metadata only and are covered
+by tests that prove they do not add or remove wall/floor geometry.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the

--- a/src/assets/floorPlan/index.ts
+++ b/src/assets/floorPlan/index.ts
@@ -1,3 +1,6 @@
+import { compileLegacyFloorPlan } from '../../scene/level/compileLegacyFloorPlan';
+import { PORTFOLIO_LEVEL } from '../../scene/level/portfolioLevel';
+
 export type RoomWall = 'north' | 'south' | 'east' | 'west';
 
 export interface Bounds2D {
@@ -128,183 +131,15 @@ export interface CombinedWallSegment {
 
 export const WALL_THICKNESS = 0.5;
 
-const DOOR_WIDTH = 4;
-const DOOR_HALF_WIDTH = DOOR_WIDTH / 2;
-
-const livingToKitchenDoorCenter = -9;
-const livingToStudioDoorCenter = 7.5;
-const kitchenToBackyardDoorCenter = -9;
-const studioToBackyardDoorCenter = 7.5;
-const kitchenToStudioDoorCenterZ = 2;
-const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
-const upperLandingToLoftLibraryDoorway = { start: 2, end: 8.2 };
-
-const doorwayRange = (center: number) => ({
-  start: center - DOOR_HALF_WIDTH,
-  end: center + DOOR_HALF_WIDTH,
+const BASE_FLOOR_PLAN = compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {
+  includeDoorwaysFromWallGaps: true,
+});
+const UPPER_FLOOR_BASE_PLAN = compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'upper', {
+  includeDoorwaysFromWallGaps: true,
 });
 
-const BASE_FLOOR_PLAN: FloorPlanDefinition = {
-  outline: [
-    [-16, -16],
-    [16, -16],
-    [16, 16],
-    [-16, 16],
-  ],
-  rooms: [
-    {
-      id: 'livingRoom',
-      name: 'Living Room',
-      bounds: { minX: -16, maxX: 16, minZ: -16, maxZ: -4 },
-      ledColor: 0x4cf889,
-      doorways: [
-        {
-          wall: 'north',
-          ...doorwayRange(livingToKitchenDoorCenter),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(livingToStudioDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'studio',
-      name: 'Studio',
-      bounds: { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
-      ledColor: 0x58c4ff,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(livingToStudioDoorCenter),
-        },
-        {
-          wall: 'west',
-          ...doorwayRange(kitchenToStudioDoorCenterZ),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(studioToBackyardDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'kitchen',
-      name: 'Kitchen',
-      bounds: { minX: -16, maxX: -2, minZ: -4, maxZ: 8 },
-      ledColor: 0xffb347,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(livingToKitchenDoorCenter),
-        },
-        {
-          wall: 'east',
-          ...doorwayRange(kitchenToStudioDoorCenterZ),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(kitchenToBackyardDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'backyard',
-      name: 'Backyard',
-      bounds: { minX: -16, maxX: 16, minZ: 8, maxZ: 16 },
-      ledColor: 0x274f37,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(kitchenToBackyardDoorCenter),
-        },
-        {
-          wall: 'south',
-          ...doorwayRange(studioToBackyardDoorCenter),
-        },
-      ],
-      category: 'exterior',
-    },
-  ],
-};
-
-const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
-  outline: [
-    [-14, -16],
-    [14, -16],
-    [14, 14],
-    [-14, 14],
-  ],
-  rooms: [
-    {
-      id: 'upperLanding',
-      name: 'Upper Landing',
-      bounds: { minX: 2, maxX: 10.4, minZ: -16, maxZ: -8 },
-      ledColor: 0xffba52,
-      doorways: [
-        {
-          wall: 'west',
-          ...upperLandingToCreatorsStudioDoorway,
-        },
-        {
-          wall: 'north',
-          // Intentionally starts at the landing's west edge to open the
-          // upstairs landing-side passage formerly sealed by this wall run.
-          ...upperLandingToLoftLibraryDoorway,
-        },
-      ],
-    },
-    {
-      id: 'creatorsStudio',
-      name: 'Creators Studio',
-      bounds: { minX: -10, maxX: 2, minZ: -16, maxZ: 0 },
-      ledColor: 0x7bd5ff,
-      doorways: [
-        {
-          wall: 'east',
-          ...upperLandingToCreatorsStudioDoorway,
-        },
-        {
-          wall: 'east',
-          ...doorwayRange(-4),
-        },
-      ],
-    },
-    {
-      id: 'loftLibrary',
-      name: 'Loft Library',
-      bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
-      ledColor: 0xc3a7ff,
-      doorways: [
-        {
-          wall: 'south',
-          ...upperLandingToLoftLibraryDoorway,
-        },
-        {
-          wall: 'west',
-          ...doorwayRange(-4),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(4),
-        },
-      ],
-    },
-    {
-      id: 'focusPods',
-      name: 'Focus Pods',
-      bounds: { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
-      ledColor: 0x9cf7c7,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(4),
-        },
-      ],
-    },
-  ],
-};
-
+// Compatibility exports below keep legacy room/floor-plan consumers stable while
+// canonical rooms and current-state wall runs live in src/scene/level/portfolioLevel.ts.
 export const FLOOR_PLAN: FloorPlanDefinition =
   scaleFloorPlanDefinition(BASE_FLOOR_PLAN);
 

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLOOR_PLAN,
+  FLOOR_PLAN_SCALE,
+  UPPER_FLOOR_PLAN,
+  getCombinedWallSegments,
+} from '../../../assets/floorPlan';
+import { compileLegacyFloorPlan } from '../compileLegacyFloorPlan';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import { assertValidLevelDefinition } from '../schema';
+
+const scalePlan = (plan: ReturnType<typeof compileLegacyFloorPlan>) => ({
+  outline: plan.outline.map(([x, z]) => [
+    x * FLOOR_PLAN_SCALE,
+    z * FLOOR_PLAN_SCALE,
+  ]),
+  rooms: plan.rooms.map((room) => ({
+    ...room,
+    bounds: {
+      minX: room.bounds.minX * FLOOR_PLAN_SCALE,
+      maxX: room.bounds.maxX * FLOOR_PLAN_SCALE,
+      minZ: room.bounds.minZ * FLOOR_PLAN_SCALE,
+      maxZ: room.bounds.maxZ * FLOOR_PLAN_SCALE,
+    },
+    doorways: room.doorways?.map((doorway) => ({
+      ...doorway,
+      start: doorway.start * FLOOR_PLAN_SCALE,
+      end: doorway.end * FLOOR_PLAN_SCALE,
+    })),
+  })),
+});
+
+const canonicalSourceRecords = () =>
+  PORTFOLIO_LEVEL.floors.flatMap((floor) => [
+    ...floor.rooms,
+    ...floor.walls,
+    ...floor.floorSurfaces,
+    ...(floor.safetyColliders ?? []),
+    ...(floor.sceneObjects ?? []),
+    ...(floor.roomConnections ?? []),
+  ]);
+
+describe('portfolio declarative level source', () => {
+  it('validates source IDs and keeps them globally unique', () => {
+    expect(() => assertValidLevelDefinition(PORTFOLIO_LEVEL)).not.toThrow();
+
+    const sourceIds = canonicalSourceRecords().map((record) => record.sourceId);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+  });
+
+  it('does not use tombstone/debug-deletion wording in production source records', () => {
+    const serialized = JSON.stringify(canonicalSourceRecords()).toLowerCase();
+
+    expect(serialized).not.toMatch(
+      /former|removed|debug-id-driven|debugonlyremoval/
+    );
+  });
+
+  it('compiles ground and upper rooms into the stable compatibility exports', () => {
+    const ground = compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {
+      includeDoorwaysFromWallGaps: true,
+    });
+    const upper = compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'upper', {
+      includeDoorwaysFromWallGaps: true,
+    });
+
+    expect(scalePlan(ground)).toEqual(FLOOR_PLAN);
+    expect(scalePlan(upper)).toEqual(UPPER_FLOOR_PLAN);
+  });
+
+  it('keeps current floor bounds unchanged', () => {
+    expect(FLOOR_PLAN.outline).toEqual([
+      [expect.closeTo(-32), expect.closeTo(-32)],
+      [expect.closeTo(32), expect.closeTo(-32)],
+      [expect.closeTo(32), expect.closeTo(32)],
+      [expect.closeTo(-32), expect.closeTo(32)],
+    ]);
+    expect(UPPER_FLOOR_PLAN.outline).toEqual([
+      [expect.closeTo(-28), expect.closeTo(-32)],
+      [expect.closeTo(28), expect.closeTo(-32)],
+      [expect.closeTo(28), expect.closeTo(28)],
+      [expect.closeTo(-28), expect.closeTo(28)],
+    ]);
+  });
+
+  it('preserves current generated wall segment inventory', () => {
+    expect(getCombinedWallSegments(FLOOR_PLAN)).toHaveLength(18);
+    expect(getCombinedWallSegments(UPPER_FLOOR_PLAN)).toHaveLength(17);
+  });
+
+  it('proves semantic room connections do not affect compatibility floor output', () => {
+    const withoutConnections = structuredClone(PORTFOLIO_LEVEL);
+    withoutConnections.floors.forEach((floor) => {
+      floor.roomConnections = [];
+    });
+
+    expect(
+      compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    ).toEqual(
+      compileLegacyFloorPlan(withoutConnections, 'ground', {
+        includeDoorwaysFromWallGaps: true,
+      })
+    );
+  });
+});

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -1,0 +1,293 @@
+import type { LevelDefinition, WallDefinition } from './schema';
+import { assertLevelSourceId } from './sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const runGap = (start: number, end: number, label: string) => ({
+  start,
+  end,
+  label,
+});
+
+const horizontalWall = (
+  floorId: string,
+  id: string,
+  z: number,
+  minX: number,
+  maxX: number,
+  rooms: string[],
+  gaps: Array<{ start: number; end: number; label: string }> = []
+): WallDefinition => ({
+  id,
+  sourceId: sourceId(`${floorId}.${id.replaceAll('-', '_')}.wall`),
+  floorId,
+  wallKind: rooms.includes('backyard') ? 'fence' : 'wall',
+  purpose: rooms.length > 1 ? 'room-boundary' : 'exterior-boundary',
+  rooms,
+  run: {
+    start: { x: minX, z },
+    end: { x: maxX, z },
+    gaps,
+  },
+});
+
+const verticalWall = (
+  floorId: string,
+  id: string,
+  x: number,
+  minZ: number,
+  maxZ: number,
+  rooms: string[],
+  gaps: Array<{ start: number; end: number; label: string }> = []
+): WallDefinition => ({
+  id,
+  sourceId: sourceId(`${floorId}.${id.replaceAll('-', '_')}.wall`),
+  floorId,
+  wallKind: rooms.includes('backyard') ? 'fence' : 'wall',
+  purpose: rooms.length > 1 ? 'room-boundary' : 'exterior-boundary',
+  rooms,
+  run: {
+    start: { x, z: minZ },
+    end: { x, z: maxZ },
+    gaps,
+  },
+});
+
+export const PORTFOLIO_LEVEL: LevelDefinition = {
+  id: 'portfolio-home',
+  floors: [
+    {
+      id: 'ground',
+      name: 'Ground floor',
+      outline: [
+        [-16, -16],
+        [16, -16],
+        [16, 16],
+        [-16, 16],
+      ],
+      rooms: [
+        {
+          id: 'livingRoom',
+          sourceId: sourceId('ground.living_room.room'),
+          name: 'Living Room',
+          bounds: { minX: -16, maxX: 16, minZ: -16, maxZ: -4 },
+          ledColor: 0x4cf889,
+        },
+        {
+          id: 'studio',
+          sourceId: sourceId('ground.studio.room'),
+          name: 'Studio',
+          bounds: { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
+          ledColor: 0x58c4ff,
+        },
+        {
+          id: 'kitchen',
+          sourceId: sourceId('ground.kitchen.room'),
+          name: 'Kitchen',
+          bounds: { minX: -16, maxX: -2, minZ: -4, maxZ: 8 },
+          ledColor: 0xffb347,
+        },
+        {
+          id: 'backyard',
+          sourceId: sourceId('ground.backyard.room'),
+          name: 'Backyard',
+          bounds: { minX: -16, maxX: 16, minZ: 8, maxZ: 16 },
+          ledColor: 0x274f37,
+          category: 'exterior',
+        },
+      ],
+      walls: [
+        horizontalWall('ground', 'living-room-south', -16, -16, 16, [
+          'livingRoom',
+        ]),
+        verticalWall('ground', 'living-room-west', -16, -16, -4, [
+          'livingRoom',
+        ]),
+        verticalWall('ground', 'living-room-east', 16, -16, -4, ['livingRoom']),
+        horizontalWall(
+          'ground',
+          'living-kitchen-studio',
+          -4,
+          -16,
+          16,
+          ['livingRoom', 'kitchen', 'studio'],
+          [
+            runGap(5, 9, 'living room to studio passage'),
+            runGap(21.5, 25.5, 'living room to kitchen passage'),
+          ]
+        ),
+        verticalWall(
+          'ground',
+          'kitchen-studio',
+          -2,
+          -4,
+          8,
+          ['kitchen', 'studio'],
+          [runGap(4, 8, 'kitchen to studio passage')]
+        ),
+        verticalWall('ground', 'kitchen-west', -16, -4, 8, ['kitchen']),
+        verticalWall('ground', 'studio-east', 16, -4, 8, ['studio']),
+        horizontalWall(
+          'ground',
+          'kitchen-studio-backyard',
+          8,
+          -16,
+          16,
+          ['kitchen', 'studio', 'backyard'],
+          [
+            runGap(5, 9, 'kitchen to backyard passage'),
+            runGap(21.5, 25.5, 'studio to backyard passage'),
+          ]
+        ),
+        verticalWall('ground', 'backyard-west', -16, 8, 16, ['backyard']),
+        verticalWall('ground', 'backyard-east', 16, 8, 16, ['backyard']),
+        horizontalWall('ground', 'backyard-north', 16, -16, 16, ['backyard']),
+      ],
+      floorSurfaces: [],
+      roomConnections: [
+        {
+          id: 'living-room-to-kitchen',
+          sourceId: sourceId('ground.living_room_to_kitchen.connection'),
+          floorId: 'ground',
+          rooms: ['livingRoom', 'kitchen'],
+          purpose: 'semantic adjacency only',
+        },
+        {
+          id: 'living-room-to-studio',
+          sourceId: sourceId('ground.living_room_to_studio.connection'),
+          floorId: 'ground',
+          rooms: ['livingRoom', 'studio'],
+          purpose: 'semantic adjacency only',
+        },
+      ],
+    },
+    {
+      id: 'upper',
+      name: 'Upper floor',
+      outline: [
+        [-14, -16],
+        [14, -16],
+        [14, 14],
+        [-14, 14],
+      ],
+      rooms: [
+        {
+          id: 'upperLanding',
+          sourceId: sourceId('upper.upper_landing.room'),
+          name: 'Upper Landing',
+          bounds: { minX: 2, maxX: 10.4, minZ: -16, maxZ: -8 },
+          ledColor: 0xffba52,
+        },
+        {
+          id: 'creatorsStudio',
+          sourceId: sourceId('upper.creators_studio.room'),
+          name: 'Creators Studio',
+          bounds: { minX: -10, maxX: 2, minZ: -16, maxZ: 0 },
+          ledColor: 0x7bd5ff,
+        },
+        {
+          id: 'loftLibrary',
+          sourceId: sourceId('upper.loft_library.room'),
+          name: 'Loft Library',
+          bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
+          ledColor: 0xc3a7ff,
+        },
+        {
+          id: 'focusPods',
+          sourceId: sourceId('upper.focus_pods.room'),
+          name: 'Focus Pods',
+          bounds: { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
+          ledColor: 0x9cf7c7,
+        },
+      ],
+      walls: [
+        horizontalWall('upper', 'upper-landing-south', -16, 2, 10.4, [
+          'upperLanding',
+        ]),
+        verticalWall('upper', 'upper-landing-east', 10.4, -16, -8, [
+          'upperLanding',
+        ]),
+        verticalWall(
+          'upper',
+          'upper-landing-creators-studio',
+          2,
+          -16,
+          -8,
+          ['upperLanding', 'creatorsStudio'],
+          [runGap(0, 2.93, 'upper landing to creators studio passage')]
+        ),
+        horizontalWall(
+          'upper',
+          'upper-landing-loft-library',
+          -8,
+          2,
+          10.4,
+          ['upperLanding', 'loftLibrary'],
+          [runGap(0, 6.2, 'upper landing to loft library passage')]
+        ),
+        horizontalWall('upper', 'creators-studio-south', -16, -10, 2, [
+          'creatorsStudio',
+        ]),
+        verticalWall('upper', 'creators-studio-west', -10, -16, 0, [
+          'creatorsStudio',
+        ]),
+        horizontalWall('upper', 'creators-studio-north', 0, -10, 2, [
+          'creatorsStudio',
+        ]),
+        verticalWall(
+          'upper',
+          'creators-studio-loft-library',
+          2,
+          -8,
+          6,
+          ['creatorsStudio', 'loftLibrary'],
+          [runGap(2, 6, 'creators studio to loft library passage')]
+        ),
+        verticalWall('upper', 'loft-library-east', 12, -8, 6, ['loftLibrary']),
+        horizontalWall(
+          'upper',
+          'loft-library-focus-pods',
+          6,
+          2,
+          12,
+          ['loftLibrary', 'focusPods'],
+          [runGap(0, 4, 'loft library to focus pods passage')]
+        ),
+        horizontalWall('upper', 'focus-pods-south-west', 6, -10, 2, [
+          'focusPods',
+        ]),
+        verticalWall('upper', 'focus-pods-west', -10, 6, 14, ['focusPods']),
+        verticalWall('upper', 'focus-pods-east', 12, 6, 14, ['focusPods']),
+        horizontalWall('upper', 'focus-pods-north', 14, -10, 12, ['focusPods']),
+      ],
+      floorSurfaces: [],
+      roomConnections: [
+        {
+          id: 'upper-landing-to-creators-studio',
+          sourceId: sourceId(
+            'upper.upper_landing_to_creators_studio.connection'
+          ),
+          floorId: 'upper',
+          rooms: ['upperLanding', 'creatorsStudio'],
+          purpose: 'semantic adjacency only',
+        },
+      ],
+    },
+  ],
+};
+
+for (const floor of PORTFOLIO_LEVEL.floors) {
+  floor.floorSurfaces = floor.rooms.map((room) => ({
+    id: `${room.id}-floor`,
+    sourceId: sourceId(
+      `${floor.id}.${room.id.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()}.floor_surface`
+    ),
+    floorId: floor.id,
+    roomId: room.id,
+    bounds: { ...room.bounds },
+    purpose: 'walkable floor',
+  }));
+}
+
+export const PORTFOLIO_GROUND_FLOOR = PORTFOLIO_LEVEL.floors[0];
+export const PORTFOLIO_UPPER_FLOOR = PORTFOLIO_LEVEL.floors[1];


### PR DESCRIPTION
### Motivation
- Introduce a canonical declarative source for the current ground and upper floors so room/wall intent is editable and auditable.
- Preserve existing runtime output and legacy consumers by compiling the new declarative source into the current `FLOOR_PLAN` compatibility shape.
- Provide stable semantic source-ID primitives, validate source records, and prevent tombstone-style identifiers in production data.

### Description
- Added `PORTFOLIO_LEVEL` (canonical `LevelDefinition`) with ground/upper floors, semantic room `sourceId`s, current wall `run`s and `gaps`, floor surfaces, and `roomConnections` in `src/scene/level/portfolioLevel.ts`.
- Adapted `src/assets/floorPlan/index.ts` to compile `FLOOR_PLAN`, `UPPER_FLOOR_PLAN`, and `FLOOR_PLAN_LEVELS` from `PORTFOLIO_LEVEL` using `compileLegacyFloorPlan(...)` so legacy exports remain stable as a compatibility bridge.
- Added tests `src/scene/level/__tests__/portfolioLevel.test.ts` to assert source-ID validity/uniqueness, forbid tombstone wording, verify compiled compatibility parity, preserve current floor bounds, and check wall-segment inventory and room-connection non-interference.
- Updated design and architecture docs to note the phase-6 declarative source and the compatibility adapter, and kept generator behavior unchanged (adapter derives legacy `doorways` only when requested).

### Testing
- Ran formatting and lint: `npm run format:write` (success) and `npm run lint` (success).
- Ran unit tests: `npm run test:ci` and focused runs including `src/scene/level/__tests__/portfolioLevel.test.ts`, `src/scene/level/__tests__/compileLegacyFloorPlan.test.ts`, `src/tests/floorPlanDoorways.test.ts`, `src/tests/floorPlanDoorwayWidths.test.ts`, `src/tests/wallSegments.test.ts`, which all passed in the final run (Vitest: 152 files, 1173 tests; final status: all tests passed).
- Ran docs check and link check: `npm run docs:check` (passed; external link probes emitted network warnings but completed successfully).
- Ran smoke and build: `npm run smoke` (passed) and `npm run build` (passed).
- Ran Playwright stairs roundtrip: after installing browsers and deps via `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell`, `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` passed (9 tests passing).

Notes/risks: compatibility adapter preserves existing runtime geometry and doorway derivation is opt-in (`includeDoorwaysFromWallGaps`); follow-up work will wire generators to consume the declarative source directly and add inventory/invariant tooling to trace every generated artifact back to a `sourceId`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32cc8e8338832f8a3ec154c003cfae)