### PR TITLE
Migrate rooms and walls to declarative PORTFOLIO_LEVEL

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -249,6 +249,14 @@ wide enough for the legacy doorway checks. A visible door,
 arch, trim, threshold, or rail should be declared as a scene object or current
 wall/railing; a walkable opening does not need a former blocker record.
 
+Current ground and upper room bounds plus wall runs now live in
+`src/scene/level/portfolioLevel.ts` as `PORTFOLIO_LEVEL`. The legacy exports in
+`src/assets/floorPlan/index.ts` intentionally remain available, but they are now
+compatibility products compiled from that declarative source and scaled into the
+existing runtime coordinate space. Open passages are represented as current
+wall-run gaps; optional `roomConnections` document adjacency only and are not used
+to remove or create wall or floor geometry.
+
 The temporary adapter in `src/scene/level/compileLegacyFloorPlan.ts` compiles a
 declarative floor back to the existing `FloorPlanDefinition` shape for migration
 checks and narrow compatibility. By default it copies room metadata only. When

--- a/src/assets/floorPlan/index.ts
+++ b/src/assets/floorPlan/index.ts
@@ -1,3 +1,6 @@
+import { compileLegacyFloorPlan } from '../../scene/level/compileLegacyFloorPlan';
+import { PORTFOLIO_LEVEL } from '../../scene/level/portfolioLevel';
+
 export type RoomWall = 'north' | 'south' | 'east' | 'west';
 
 export interface Bounds2D {
@@ -91,7 +94,7 @@ export function assertDoorwayWidths(
   }
 }
 
-const scaleFloorPlanDefinition = (
+export const scaleFloorPlanDefinition = (
   plan: FloorPlanDefinition
 ): FloorPlanDefinition => ({
   outline: plan.outline.map(([x, z]) => [scaleValue(x), scaleValue(z)]),
@@ -128,182 +131,21 @@ export interface CombinedWallSegment {
 
 export const WALL_THICKNESS = 0.5;
 
-const DOOR_WIDTH = 4;
-const DOOR_HALF_WIDTH = DOOR_WIDTH / 2;
+// Compatibility exports: legacy consumers still import scaled FloorPlanDefinition
+// objects with derived doorway arrays. The canonical room and wall source of truth
+// lives in PORTFOLIO_LEVEL, where current openings are wall-run gaps rather than
+// standalone room records.
+const BASE_FLOOR_PLAN: FloorPlanDefinition = compileLegacyFloorPlan(
+  PORTFOLIO_LEVEL,
+  'ground',
+  { includeDoorwaysFromWallGaps: true }
+);
 
-const livingToKitchenDoorCenter = -9;
-const livingToStudioDoorCenter = 7.5;
-const kitchenToBackyardDoorCenter = -9;
-const studioToBackyardDoorCenter = 7.5;
-const kitchenToStudioDoorCenterZ = 2;
-const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
-const upperLandingToLoftLibraryDoorway = { start: 2, end: 8.2 };
-
-const doorwayRange = (center: number) => ({
-  start: center - DOOR_HALF_WIDTH,
-  end: center + DOOR_HALF_WIDTH,
-});
-
-const BASE_FLOOR_PLAN: FloorPlanDefinition = {
-  outline: [
-    [-16, -16],
-    [16, -16],
-    [16, 16],
-    [-16, 16],
-  ],
-  rooms: [
-    {
-      id: 'livingRoom',
-      name: 'Living Room',
-      bounds: { minX: -16, maxX: 16, minZ: -16, maxZ: -4 },
-      ledColor: 0x4cf889,
-      doorways: [
-        {
-          wall: 'north',
-          ...doorwayRange(livingToKitchenDoorCenter),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(livingToStudioDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'studio',
-      name: 'Studio',
-      bounds: { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
-      ledColor: 0x58c4ff,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(livingToStudioDoorCenter),
-        },
-        {
-          wall: 'west',
-          ...doorwayRange(kitchenToStudioDoorCenterZ),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(studioToBackyardDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'kitchen',
-      name: 'Kitchen',
-      bounds: { minX: -16, maxX: -2, minZ: -4, maxZ: 8 },
-      ledColor: 0xffb347,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(livingToKitchenDoorCenter),
-        },
-        {
-          wall: 'east',
-          ...doorwayRange(kitchenToStudioDoorCenterZ),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(kitchenToBackyardDoorCenter),
-        },
-      ],
-    },
-    {
-      id: 'backyard',
-      name: 'Backyard',
-      bounds: { minX: -16, maxX: 16, minZ: 8, maxZ: 16 },
-      ledColor: 0x274f37,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(kitchenToBackyardDoorCenter),
-        },
-        {
-          wall: 'south',
-          ...doorwayRange(studioToBackyardDoorCenter),
-        },
-      ],
-      category: 'exterior',
-    },
-  ],
-};
-
-const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = {
-  outline: [
-    [-14, -16],
-    [14, -16],
-    [14, 14],
-    [-14, 14],
-  ],
-  rooms: [
-    {
-      id: 'upperLanding',
-      name: 'Upper Landing',
-      bounds: { minX: 2, maxX: 10.4, minZ: -16, maxZ: -8 },
-      ledColor: 0xffba52,
-      doorways: [
-        {
-          wall: 'west',
-          ...upperLandingToCreatorsStudioDoorway,
-        },
-        {
-          wall: 'north',
-          // Intentionally starts at the landing's west edge to open the
-          // upstairs landing-side passage formerly sealed by this wall run.
-          ...upperLandingToLoftLibraryDoorway,
-        },
-      ],
-    },
-    {
-      id: 'creatorsStudio',
-      name: 'Creators Studio',
-      bounds: { minX: -10, maxX: 2, minZ: -16, maxZ: 0 },
-      ledColor: 0x7bd5ff,
-      doorways: [
-        {
-          wall: 'east',
-          ...upperLandingToCreatorsStudioDoorway,
-        },
-        {
-          wall: 'east',
-          ...doorwayRange(-4),
-        },
-      ],
-    },
-    {
-      id: 'loftLibrary',
-      name: 'Loft Library',
-      bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
-      ledColor: 0xc3a7ff,
-      doorways: [
-        {
-          wall: 'south',
-          ...upperLandingToLoftLibraryDoorway,
-        },
-        {
-          wall: 'west',
-          ...doorwayRange(-4),
-        },
-        {
-          wall: 'north',
-          ...doorwayRange(4),
-        },
-      ],
-    },
-    {
-      id: 'focusPods',
-      name: 'Focus Pods',
-      bounds: { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
-      ledColor: 0x9cf7c7,
-      doorways: [
-        {
-          wall: 'south',
-          ...doorwayRange(4),
-        },
-      ],
-    },
-  ],
-};
+const UPPER_FLOOR_BASE_PLAN: FloorPlanDefinition = compileLegacyFloorPlan(
+  PORTFOLIO_LEVEL,
+  'upper',
+  { includeDoorwaysFromWallGaps: true }
+);
 
 export const FLOOR_PLAN: FloorPlanDefinition =
   scaleFloorPlanDefinition(BASE_FLOOR_PLAN);

--- a/src/scene/level/__tests__/__snapshots__/portfolioLevel.test.ts.snap
+++ b/src/scene/level/__tests__/__snapshots__/portfolioLevel.test.ts.snap
@@ -1,0 +1,666 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PORTFOLIO_LEVEL > compiles declarative wall runs to the current expected wall bounds 1`] = `
+[
+  {
+    "end": {
+      "x": -22.000000000000004,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "livingRoom",
+        "wall": "north",
+      },
+      {
+        "id": "kitchen",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": -4.000000000000001,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "livingRoom",
+        "wall": "north",
+      },
+      {
+        "id": "kitchen",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -14.000000000000004,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": 11.000000000000002,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "livingRoom",
+        "wall": "north",
+      },
+      {
+        "id": "studio",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -4.000000000000001,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": -8,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "livingRoom",
+        "wall": "north",
+      },
+      {
+        "id": "studio",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": 19.000000000000004,
+      "z": -8,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": -32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "livingRoom",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": -32,
+    },
+  },
+  {
+    "end": {
+      "x": -22.000000000000004,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "kitchen",
+        "wall": "north",
+      },
+      {
+        "id": "backyard",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": -4.000000000000001,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "kitchen",
+        "wall": "north",
+      },
+      {
+        "id": "backyard",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -14.000000000000004,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": 11.000000000000002,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "studio",
+        "wall": "north",
+      },
+      {
+        "id": "backyard",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -4.000000000000001,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": 16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "studio",
+        "wall": "north",
+      },
+      {
+        "id": "backyard",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": 19.000000000000004,
+      "z": 16,
+    },
+  },
+  {
+    "end": {
+      "x": 32.00000000000001,
+      "z": 32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "backyard",
+        "wall": "north",
+      },
+    ],
+    "start": {
+      "x": -32.00000000000001,
+      "z": 32,
+    },
+  },
+  {
+    "end": {
+      "x": 32,
+      "z": -8.000000000000002,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "livingRoom",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": 32,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": 32,
+      "z": 16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "studio",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": 32,
+      "z": -8.000000000000002,
+    },
+  },
+  {
+    "end": {
+      "x": 32,
+      "z": 32.00000000000001,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "backyard",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": 32,
+      "z": 16.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": -32,
+      "z": -8.000000000000002,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "livingRoom",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": -32,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": -32,
+      "z": 16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "kitchen",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": -32,
+      "z": -8.000000000000002,
+    },
+  },
+  {
+    "end": {
+      "x": -32,
+      "z": 32.00000000000001,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "backyard",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": -32,
+      "z": 16.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": -4,
+      "z": 0,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "studio",
+        "wall": "west",
+      },
+      {
+        "id": "kitchen",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": -4,
+      "z": -8.000000000000002,
+    },
+  },
+  {
+    "end": {
+      "x": -4,
+      "z": 16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "studio",
+        "wall": "west",
+      },
+      {
+        "id": "kitchen",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": -4,
+      "z": 8.000000000000002,
+    },
+  },
+]
+`;
+
+exports[`PORTFOLIO_LEVEL > compiles declarative wall runs to the current expected wall bounds 2`] = `
+[
+  {
+    "end": {
+      "x": 20.800000000000004,
+      "z": -16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "upperLanding",
+        "wall": "north",
+      },
+      {
+        "id": "loftLibrary",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": 16.400000000000002,
+      "z": -16,
+    },
+  },
+  {
+    "end": {
+      "x": 24.000000000000007,
+      "z": -16,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "loftLibrary",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": 20.800000000000004,
+      "z": -16,
+    },
+  },
+  {
+    "end": {
+      "x": 4.000000000000001,
+      "z": -32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "creatorsStudio",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": -32,
+    },
+  },
+  {
+    "end": {
+      "x": 20.800000000000004,
+      "z": -32,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "upperLanding",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": 4.000000000000001,
+      "z": -32,
+    },
+  },
+  {
+    "end": {
+      "x": 4.000000000000001,
+      "z": 0,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "creatorsStudio",
+        "wall": "north",
+      },
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": 0,
+    },
+  },
+  {
+    "end": {
+      "x": 4.000000000000001,
+      "z": 12,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "focusPods",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": 12,
+    },
+  },
+  {
+    "end": {
+      "x": 24.000000000000007,
+      "z": 12,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "loftLibrary",
+        "wall": "north",
+      },
+      {
+        "id": "focusPods",
+        "wall": "south",
+      },
+    ],
+    "start": {
+      "x": 12.000000000000004,
+      "z": 12,
+    },
+  },
+  {
+    "end": {
+      "x": 24.000000000000007,
+      "z": 28,
+    },
+    "orientation": "horizontal",
+    "rooms": [
+      {
+        "id": "focusPods",
+        "wall": "north",
+      },
+    ],
+    "start": {
+      "x": -20.000000000000004,
+      "z": 28,
+    },
+  },
+  {
+    "end": {
+      "x": 20.8,
+      "z": -16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "upperLanding",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": 20.8,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": -16.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "upperLanding",
+        "wall": "west",
+      },
+      {
+        "id": "creatorsStudio",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": 4,
+      "z": -26.140000000000008,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": -12.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "creatorsStudio",
+        "wall": "east",
+      },
+      {
+        "id": "loftLibrary",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": 4,
+      "z": -16.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": 0,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "creatorsStudio",
+        "wall": "east",
+      },
+      {
+        "id": "loftLibrary",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": 4,
+      "z": -4.000000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": 4,
+      "z": 12.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "loftLibrary",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": 4,
+      "z": 0,
+    },
+  },
+  {
+    "end": {
+      "x": -20,
+      "z": 0,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "creatorsStudio",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": -20,
+      "z": -32.00000000000001,
+    },
+  },
+  {
+    "end": {
+      "x": -20,
+      "z": 28.000000000000007,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "focusPods",
+        "wall": "west",
+      },
+    ],
+    "start": {
+      "x": -20,
+      "z": 12.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": 24,
+      "z": 12.000000000000004,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "loftLibrary",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": 24,
+      "z": -16.000000000000004,
+    },
+  },
+  {
+    "end": {
+      "x": 24,
+      "z": 28.000000000000007,
+    },
+    "orientation": "vertical",
+    "rooms": [
+      {
+        "id": "focusPods",
+        "wall": "east",
+      },
+    ],
+    "start": {
+      "x": 24,
+      "z": 12.000000000000004,
+    },
+  },
+]
+`;

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -1,0 +1,95 @@
+import {
+  FLOOR_PLAN,
+  FLOOR_PLAN_SCALE,
+  UPPER_FLOOR_PLAN,
+  getCombinedWallSegments,
+  getFloorBounds,
+  scaleFloorPlanDefinition,
+} from '../../../assets/floorPlan';
+import { compileLegacyFloorPlan } from '../compileLegacyFloorPlan';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import { assertValidLevelDefinition } from '../schema';
+
+const scaledCompiledPlan = (floorId: string) =>
+  scaleFloorPlanDefinition(
+    compileLegacyFloorPlan(PORTFOLIO_LEVEL, floorId, {
+      includeDoorwaysFromWallGaps: true,
+    })
+  );
+
+const wallSnapshot = (floorId: string) =>
+  getCombinedWallSegments(scaledCompiledPlan(floorId)).map((segment) => ({
+    orientation: segment.orientation,
+    start: segment.start,
+    end: segment.end,
+    rooms: segment.rooms,
+  }));
+
+describe('PORTFOLIO_LEVEL', () => {
+  it('is valid and uses unique source IDs for current production records', () => {
+    expect(() => assertValidLevelDefinition(PORTFOLIO_LEVEL)).not.toThrow();
+
+    const ids = PORTFOLIO_LEVEL.floors.flatMap((floor) => [
+      ...floor.rooms.map((room) => room.sourceId),
+      ...floor.walls.map((wall) => wall.sourceId),
+      ...floor.floorSurfaces.map((surface) => surface.sourceId),
+      ...(floor.safetyColliders ?? []).map((collider) => collider.sourceId),
+      ...(floor.sceneObjects ?? []).map((object) => object.sourceId),
+      ...(floor.roomConnections ?? []).map((connection) => connection.sourceId),
+    ]);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.join(' ')).not.toMatch(/\b(former|removed|debugonlyremoval)\b/);
+  });
+
+  it('compiles compatibility floor plans with the current room bounds and doorway data', () => {
+    expect(scaledCompiledPlan('ground')).toEqual(FLOOR_PLAN);
+    expect(scaledCompiledPlan('upper')).toEqual(UPPER_FLOOR_PLAN);
+  });
+
+  it('keeps current floor bounds unchanged', () => {
+    expect(getFloorBounds(FLOOR_PLAN)).toEqual({
+      minX: -16 * FLOOR_PLAN_SCALE,
+      maxX: 16 * FLOOR_PLAN_SCALE,
+      minZ: -16 * FLOOR_PLAN_SCALE,
+      maxZ: 16 * FLOOR_PLAN_SCALE,
+    });
+    expect(getFloorBounds(UPPER_FLOOR_PLAN)).toEqual({
+      minX: -14 * FLOOR_PLAN_SCALE,
+      maxX: 14 * FLOOR_PLAN_SCALE,
+      minZ: -16 * FLOOR_PLAN_SCALE,
+      maxZ: 14 * FLOOR_PLAN_SCALE,
+    });
+    expect(FLOOR_PLAN_SCALE).toBe(2.0000000000000004);
+  });
+
+  it('compiles declarative wall runs to the current expected wall bounds', () => {
+    expect(wallSnapshot('ground')).toMatchSnapshot();
+    expect(wallSnapshot('upper')).toMatchSnapshot();
+  });
+
+  it('does not use room connections to generate legacy walls or floors', () => {
+    const withoutConnections = {
+      ...PORTFOLIO_LEVEL,
+      floors: PORTFOLIO_LEVEL.floors.map((floor) => ({
+        ...floor,
+        roomConnections: [],
+      })),
+    };
+
+    expect(
+      scaleFloorPlanDefinition(
+        compileLegacyFloorPlan(withoutConnections, 'ground', {
+          includeDoorwaysFromWallGaps: true,
+        })
+      )
+    ).toEqual(FLOOR_PLAN);
+    expect(
+      scaleFloorPlanDefinition(
+        compileLegacyFloorPlan(withoutConnections, 'upper', {
+          includeDoorwaysFromWallGaps: true,
+        })
+      )
+    ).toEqual(UPPER_FLOOR_PLAN);
+  });
+});

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -1,0 +1,306 @@
+import type { DoorwayDefinition, RoomWall } from '../../assets/floorPlan';
+
+import type {
+  Bounds2D,
+  FloorDefinition,
+  LevelDefinition,
+  RoomCategory,
+  SemanticRoomDefinition,
+  WallDefinition,
+} from './schema';
+import { assertLevelSourceId } from './sourceIds';
+
+type RoomSeed = Omit<SemanticRoomDefinition, 'sourceId'> & {
+  doorways?: DoorwayDefinition[];
+};
+
+const DOOR_WIDTH = 4;
+const DOOR_HALF_WIDTH = DOOR_WIDTH / 2;
+const WALL_ORDER: RoomWall[] = ['north', 'east', 'south', 'west'];
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+const doorwayRange = (center: number) => ({
+  start: center - DOOR_HALF_WIDTH,
+  end: center + DOOR_HALF_WIDTH,
+});
+
+const livingToKitchenDoorCenter = -9;
+const livingToStudioDoorCenter = 7.5;
+const kitchenToBackyardDoorCenter = -9;
+const studioToBackyardDoorCenter = 7.5;
+const kitchenToStudioDoorCenterZ = 2;
+const upperLandingToCreatorsStudioDoorway = { start: -16, end: -13.07 };
+const upperLandingToLoftLibraryDoorway = { start: 2, end: 8.2 };
+
+const groundRooms: RoomSeed[] = [
+  {
+    id: 'livingRoom',
+    name: 'Living Room',
+    bounds: { minX: -16, maxX: 16, minZ: -16, maxZ: -4 },
+    ledColor: 0x4cf889,
+    doorways: [
+      { wall: 'north', ...doorwayRange(livingToKitchenDoorCenter) },
+      { wall: 'north', ...doorwayRange(livingToStudioDoorCenter) },
+    ],
+  },
+  {
+    id: 'studio',
+    name: 'Studio',
+    bounds: { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
+    ledColor: 0x58c4ff,
+    doorways: [
+      { wall: 'south', ...doorwayRange(livingToStudioDoorCenter) },
+      { wall: 'west', ...doorwayRange(kitchenToStudioDoorCenterZ) },
+      { wall: 'north', ...doorwayRange(studioToBackyardDoorCenter) },
+    ],
+  },
+  {
+    id: 'kitchen',
+    name: 'Kitchen',
+    bounds: { minX: -16, maxX: -2, minZ: -4, maxZ: 8 },
+    ledColor: 0xffb347,
+    doorways: [
+      { wall: 'south', ...doorwayRange(livingToKitchenDoorCenter) },
+      { wall: 'east', ...doorwayRange(kitchenToStudioDoorCenterZ) },
+      { wall: 'north', ...doorwayRange(kitchenToBackyardDoorCenter) },
+    ],
+  },
+  {
+    id: 'backyard',
+    name: 'Backyard',
+    bounds: { minX: -16, maxX: 16, minZ: 8, maxZ: 16 },
+    ledColor: 0x274f37,
+    doorways: [
+      { wall: 'south', ...doorwayRange(kitchenToBackyardDoorCenter) },
+      { wall: 'south', ...doorwayRange(studioToBackyardDoorCenter) },
+    ],
+    category: 'exterior',
+  },
+];
+
+const upperRooms: RoomSeed[] = [
+  {
+    id: 'upperLanding',
+    name: 'Upper Landing',
+    bounds: { minX: 2, maxX: 10.4, minZ: -16, maxZ: -8 },
+    ledColor: 0xffba52,
+    doorways: [
+      { wall: 'west', ...upperLandingToCreatorsStudioDoorway },
+      { wall: 'north', ...upperLandingToLoftLibraryDoorway },
+    ],
+  },
+  {
+    id: 'creatorsStudio',
+    name: 'Creators Studio',
+    bounds: { minX: -10, maxX: 2, minZ: -16, maxZ: 0 },
+    ledColor: 0x7bd5ff,
+    doorways: [
+      { wall: 'east', ...upperLandingToCreatorsStudioDoorway },
+      { wall: 'east', ...doorwayRange(-4) },
+    ],
+  },
+  {
+    id: 'loftLibrary',
+    name: 'Loft Library',
+    bounds: { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
+    ledColor: 0xc3a7ff,
+    doorways: [
+      { wall: 'south', ...upperLandingToLoftLibraryDoorway },
+      { wall: 'west', ...doorwayRange(-4) },
+      { wall: 'north', ...doorwayRange(4) },
+    ],
+  },
+  {
+    id: 'focusPods',
+    name: 'Focus Pods',
+    bounds: { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
+    ledColor: 0x9cf7c7,
+    doorways: [{ wall: 'south', ...doorwayRange(4) }],
+  },
+];
+
+function toSemanticRooms(
+  floorId: string,
+  rooms: RoomSeed[]
+): SemanticRoomDefinition[] {
+  return rooms.map((seed) => {
+    const room: Omit<SemanticRoomDefinition, 'sourceId'> = {
+      id: seed.id,
+      name: seed.name,
+      bounds: seed.bounds,
+      ledColor: seed.ledColor,
+      category: seed.category,
+    };
+
+    return {
+      ...room,
+      sourceId: sourceId(`${floorId}.${toSourcePart(room.id)}.room`),
+    };
+  });
+}
+
+function createFloorSurfaces(floorId: string, rooms: RoomSeed[]) {
+  return rooms.map((room) => ({
+    id: `${room.id}-floor-surface`,
+    sourceId: sourceId(`${floorId}.${toSourcePart(room.id)}.floor_surface`),
+    floorId,
+    roomId: room.id,
+    bounds: { ...room.bounds },
+    purpose: room.category === 'exterior' ? 'exterior-floor' : 'room-floor',
+  }));
+}
+
+function createWalls(floorId: string, rooms: RoomSeed[]): WallDefinition[] {
+  return rooms.flatMap((room) =>
+    WALL_ORDER.map((wall) => ({
+      id: `${room.id}-${wall}-wall`,
+      sourceId: sourceId(`${floorId}.${toSourcePart(room.id)}.${wall}_wall`),
+      floorId,
+      wallKind: room.category === 'exterior' ? 'fence' : 'wall',
+      rooms: [room.id],
+      purpose:
+        room.category === 'exterior' ? 'exterior-boundary' : 'room-boundary',
+      run: createWallRun(
+        room.bounds,
+        wall,
+        room.doorways?.filter((doorway) => doorway.wall === wall)
+      ),
+    }))
+  );
+}
+
+function createWallRun(
+  bounds: Bounds2D,
+  wall: RoomWall,
+  doorways: DoorwayDefinition[] = []
+) {
+  const gaps = doorways.map((doorway) => ({
+    start:
+      Math.min(doorway.start, doorway.end) - getWallAxisStart(bounds, wall),
+    end: Math.max(doorway.start, doorway.end) - getWallAxisStart(bounds, wall),
+    label: 'current-open-passage',
+  }));
+
+  const run = (() => {
+    switch (wall) {
+      case 'north':
+        return {
+          start: { x: bounds.minX, z: bounds.maxZ },
+          end: { x: bounds.maxX, z: bounds.maxZ },
+        };
+      case 'south':
+        return {
+          start: { x: bounds.minX, z: bounds.minZ },
+          end: { x: bounds.maxX, z: bounds.minZ },
+        };
+      case 'east':
+        return {
+          start: { x: bounds.maxX, z: bounds.minZ },
+          end: { x: bounds.maxX, z: bounds.maxZ },
+        };
+      case 'west':
+        return {
+          start: { x: bounds.minX, z: bounds.minZ },
+          end: { x: bounds.minX, z: bounds.maxZ },
+        };
+    }
+  })();
+
+  return gaps.length > 0 ? { ...run, gaps } : run;
+}
+
+function getWallAxisStart(bounds: Bounds2D, wall: RoomWall): number {
+  return wall === 'north' || wall === 'south' ? bounds.minX : bounds.minZ;
+}
+
+function toSourcePart(value: string): string {
+  return value.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}
+
+function createFloor(
+  id: 'ground' | 'upper',
+  name: string,
+  outline: Array<[number, number]>,
+  rooms: RoomSeed[]
+): FloorDefinition {
+  return {
+    id,
+    name,
+    outline,
+    rooms: toSemanticRooms(id, rooms),
+    walls: createWalls(id, rooms),
+    floorSurfaces: createFloorSurfaces(id, rooms),
+    roomConnections: createRoomConnections(id, rooms),
+  };
+}
+
+function createRoomConnections(floorId: string, rooms: RoomSeed[]) {
+  const pairs = new Map<string, [string, string]>();
+  rooms.forEach((room) => {
+    room.doorways?.forEach((doorway) => {
+      const neighbor = rooms.find(
+        (candidate) =>
+          candidate.id !== room.id &&
+          candidate.doorways?.some(
+            (candidateDoorway) =>
+              candidateDoorway.wall === oppositeWall(doorway.wall) &&
+              rangesOverlap(doorway, candidateDoorway)
+          )
+      );
+      if (!neighbor) return;
+      const sorted = [room.id, neighbor.id].sort() as [string, string];
+      pairs.set(sorted.map(toSourcePart).join('__'), sorted);
+    });
+  });
+
+  return [...pairs.entries()].map(([key, roomsForConnection]) => ({
+    id: `${key.replace('__', '-')}-connection`,
+    sourceId: sourceId(`${floorId}.${key.replace('__', '.')}.connection`),
+    floorId,
+    rooms: roomsForConnection,
+    purpose: 'documentation-only-adjacency',
+  }));
+}
+
+function oppositeWall(wall: RoomWall): RoomWall {
+  return { north: 'south', south: 'north', east: 'west', west: 'east' }[wall];
+}
+
+function rangesOverlap(a: DoorwayDefinition, b: DoorwayDefinition): boolean {
+  return Math.min(a.end, b.end) - Math.max(a.start, b.start) > 0;
+}
+
+export const PORTFOLIO_LEVEL: LevelDefinition = {
+  id: 'portfolio-home',
+  floors: [
+    createFloor(
+      'ground',
+      'Ground Floor',
+      [
+        [-16, -16],
+        [16, -16],
+        [16, 16],
+        [-16, 16],
+      ],
+      groundRooms
+    ),
+    createFloor(
+      'upper',
+      'Upper Floor',
+      [
+        [-14, -16],
+        [14, -16],
+        [14, 14],
+        [-14, 14],
+      ],
+      upperRooms
+    ),
+  ],
+};
+
+export const PORTFOLIO_LEVEL_ROOM_CATEGORIES: Record<
+  string,
+  RoomCategory | undefined
+> = Object.fromEntries(
+  [...groundRooms, ...upperRooms].map((room) => [room.id, room.category])
+);


### PR DESCRIPTION
### Motivation
- Provide a canonical, declarative source-of-truth for the current ground and upper floors so room and wall intent are authored as stable source-backed data while preserving runtime output. 
- Keep legacy consumers working by retaining `FLOOR_PLAN`, `UPPER_FLOOR_PLAN`, and `FLOOR_PLAN_LEVELS` as compatibility exports compiled from the new declarative source. 
- Add validation and tests to prevent tombstone/removed source IDs and to assert that declarative data compiles to the exact current wall/floor geometry.

### Description
- Add `src/scene/level/portfolioLevel.ts` which exports `PORTFOLIO_LEVEL` containing semantic rooms, wall runs with intentional gaps, floor surfaces, roomConnections (documentation-only), and stable `sourceId` values. 
- Adapt `src/assets/floorPlan/index.ts` so the legacy `BASE_FLOOR_PLAN` and `UPPER_FLOOR_BASE_PLAN` are produced by `compileLegacyFloorPlan(PORTFOLIO_LEVEL, ...)` and kept scaled into the existing runtime coordinate space for compatibility. 
- Add `src/scene/level/__tests__/portfolioLevel.test.ts` and snapshots to assert unique source IDs, no tombstone wording, exact floor bounds, that declarative wall runs compile to existing wall segments, and that `roomConnections` do not affect geometry. 
- Update design doc (`docs/design/declarative-level-source-of-truth.md`) to document that current rooms/walls now live in `PORTFOLIO_LEVEL` and that `src/assets/floorPlan` exports are compatibility products during migration.

### Testing
- Ran the Vitest suite with `npm run test:ci` and all tests passed (Vitest: 152 files, 1172 tests passed). 
- Ran focused unit tests `src/scene/level/__tests__/portfolioLevel.test.ts`, `src/tests/wallSegments.test.ts`, `src/tests/floorPlanDoorways.test.ts`, and `src/tests/floorPlanDoorwayWidths.test.ts` via `npm run test:ci` and they passed. 
- Executed Playwright end-to-end `playwright/immersive-stairs-roundtrip.spec.ts` which initially failed due to missing browser binaries, then after `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium` the spec completed successfully (9 tests passed). 
- Verified production build and smoke with `npm run build` and `npm run smoke`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32cc9fc0c8832f9d5da25e7ebb71c7)