### PR TITLE
🧱 Generate walls from declarative source

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -25,8 +25,8 @@ orchestration code:
      in `BASE_FLOOR_PLAN` before scaling them into `FLOOR_PLAN`.
    - Doorways are attached to room walls and are validated by width, but they are
      not first-class semantic connections.
-   - Wall generation starts from room bounds and doorways via room wall segments
-     and combined wall segments.
+   - Legacy compatibility wall helpers still exist for consumers that have not migrated,
+     but runtime wall meshes and colliders now come from declarative wall data.
 2. `src/assets/floorPlan/wallSegments.ts`
    - Converts combined wall segments into wall or fence instances.
    - Computes wall/fence dimensions, center points, colliders, shared-interior
@@ -275,8 +275,10 @@ semantic `roomConnections` intentionally do not create or remove geometry.
 6. **Migrate room and wall data.** Current room and wall intent now lives in
    `src/scene/level/portfolioLevel.ts`; legacy floor-plan exports still compile
    through the adapter until downstream generators consume source data directly.
-7. **Generate wall outputs from source.** Derive wall meshes, wall colliders, and
-   wall debug metadata from source-backed wall definitions.
+7. **Generate wall outputs from source.** ✅ Wall meshes, wall colliders, and
+   wall debug metadata are now derived from source-backed wall definitions. The
+   generator may split wall runs at room seams and declared gaps, but authors edit
+   current declarative wall data rather than downstream filters or removal lists.
 8. **Generate floor outputs from source.** Derive floor surfaces from source data,
    allowing generator-owned splitting and clipping where useful.
 9. **Move stair and void safety.** Convert stair, landing, and void guard

--- a/src/assets/floorPlan/wallSegments.ts
+++ b/src/assets/floorPlan/wallSegments.ts
@@ -15,8 +15,10 @@ export interface WallSegmentInstance {
   segment: CombinedWallSegment;
   /** Stable identifier for correlating generated meshes with the source segment. */
   segmentId: string;
-  /** Semantic source identifier for generated legacy wall segments. */
+  /** Semantic source identifier for generated wall segments. */
   sourceId: LevelSourceId;
+  /** Semantic source type for debug solid/collider metadata. */
+  sourceType?: 'wall';
   center: { x: number; y: number; z: number };
   dimensions: { width: number; height: number; depth: number };
   collider: RectCollider;

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,10 +36,7 @@ import {
   WALL_THICKNESS,
   type RoomCategory,
 } from './assets/floorPlan';
-import {
-  createWallSegmentInstances,
-  type WallSegmentInstance,
-} from './assets/floorPlan/wallSegments';
+import { type WallSegmentInstance } from './assets/floorPlan/wallSegments';
 import {
   formatMessage,
   getAudioHudControlStrings,
@@ -153,6 +150,8 @@ import {
   createSceneDetailController,
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
+import { generateWallInstancesFromLevel } from './scene/level/generateWalls';
+import { PORTFOLIO_LEVEL } from './scene/level/portfolioLevel';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -1873,8 +1872,9 @@ function initializeImmersiveScene(
   wallMaterial.lightMapIntensity = 0.68;
   fenceMaterial.lightMap = interiorLightmaps.wall;
   fenceMaterial.lightMapIntensity = 0.56;
-  const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
+  const groundWallInstances = generateWallInstancesFromLevel(PORTFOLIO_LEVEL, {
     floorId: 'ground',
+    scale: FLOOR_PLAN_SCALE,
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -2343,8 +2343,9 @@ function initializeImmersiveScene(
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
-  const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+  const upperWallInstances = generateWallInstancesFromLevel(PORTFOLIO_LEVEL, {
     floorId: 'upper',
+    scale: FLOOR_PLAN_SCALE,
     baseElevation: upperFloorElevation,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -2363,11 +2364,11 @@ function initializeImmersiveScene(
   upperFloorGroup.add(upperWallMeshes.group);
   upperWallInstances.forEach((instance) => {
     upperFloorColliders.push(instance.collider);
+    colliderSourceIds.set(instance.collider, instance.sourceId);
     namedColliderDebugNames.set(
       instance.collider,
       getUpperWallSegmentDebugName(instance)
     );
-    colliderSourceIds.set(instance.collider, instance.sourceId);
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,0 +1,188 @@
+import { MeshStandardMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLOOR_PLAN,
+  FLOOR_PLAN_SCALE,
+  UPPER_FLOOR_PLAN,
+  getCombinedWallSegments,
+} from '../../../assets/floorPlan';
+import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
+import { generateWallInstancesFromLevel } from '../generateWalls';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import type { LevelDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const WALL_HEIGHT = 3.2;
+const WALL_THICKNESS = 0.5;
+const FENCE_HEIGHT = 1.2;
+const FENCE_THICKNESS = 0.22;
+
+const getRoomCategory = (roomId: string) =>
+  roomId === 'backyard' ? ('exterior' as const) : ('interior' as const);
+
+const legacyOptions = {
+  baseElevation: 0,
+  wallHeight: WALL_HEIGHT,
+  wallThickness: WALL_THICKNESS,
+  fenceHeight: FENCE_HEIGHT,
+  fenceThickness: FENCE_THICKNESS,
+  getRoomCategory,
+};
+
+const normalize = (instances: ReturnType<typeof createWallSegmentInstances>) =>
+  instances
+    .map((instance) => ({
+      collider: roundRect(instance.collider),
+      center: roundPoint(instance.center),
+      dimensions: roundPoint(instance.dimensions),
+      isFence: instance.isFence,
+      isSharedInterior: instance.isSharedInterior,
+      thickness: round(instance.thickness),
+    }))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+
+const round = (value: number) => Math.round(value * 1_000_000) / 1_000_000;
+const roundPoint = <T extends Record<string, number>>(point: T) =>
+  Object.fromEntries(
+    Object.entries(point).map(([key, value]) => [key, round(value)])
+  );
+const roundRect = (rect: {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}) => roundPoint(rect);
+
+describe('generateWallInstancesFromLevel', () => {
+  it('matches legacy generated wall and fence bounds for ground and upper floors', () => {
+    expect(
+      normalize(
+        generateWallInstancesFromLevel(PORTFOLIO_LEVEL, {
+          ...legacyOptions,
+          floorId: 'ground',
+          scale: FLOOR_PLAN_SCALE,
+        })
+      )
+    ).toEqual(
+      normalize(
+        createWallSegmentInstances(FLOOR_PLAN, {
+          ...legacyOptions,
+          floorId: 'ground',
+        })
+      )
+    );
+
+    expect(
+      normalize(
+        generateWallInstancesFromLevel(PORTFOLIO_LEVEL, {
+          ...legacyOptions,
+          floorId: 'upper',
+          scale: FLOOR_PLAN_SCALE,
+        })
+      )
+    ).toEqual(
+      normalize(
+        createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+          ...legacyOptions,
+          floorId: 'upper',
+        })
+      )
+    );
+  });
+
+  it('adds wall source metadata to every generated mesh and collider', () => {
+    const instances = generateWallInstancesFromLevel(PORTFOLIO_LEVEL, {
+      ...legacyOptions,
+      floorId: 'ground',
+      scale: FLOOR_PLAN_SCALE,
+    });
+    const { meshes } = createWallSegmentMeshes({
+      instances,
+      getMaterial: () => new MeshStandardMaterial(),
+    });
+
+    expect(meshes.length).toBe(instances.length);
+    expect(
+      meshes.every((mesh) => typeof mesh.userData.levelSourceId === 'string')
+    ).toBe(true);
+    expect(instances.every((instance) => instance.sourceType === 'wall')).toBe(
+      true
+    );
+    expect(
+      instances.every((instance) => typeof instance.sourceId === 'string')
+    ).toBe(true);
+  });
+
+  it('responds directly to declarative wall edits', () => {
+    const extraWall = {
+      id: 'fixture-wall',
+      sourceId: assertLevelSourceId('ground.fixture.wall'),
+      floorId: 'ground',
+      wallKind: 'wall' as const,
+      rooms: ['livingRoom'],
+      segments: [{ start: { x: 0, z: 0 }, end: { x: 2, z: 0 } }],
+    };
+    const edited: LevelDefinition = {
+      ...PORTFOLIO_LEVEL,
+      floors: PORTFOLIO_LEVEL.floors.map((floor) =>
+        floor.id === 'ground'
+          ? { ...floor, walls: [...floor.walls, extraWall] }
+          : floor
+      ),
+    };
+
+    const before = generateWallInstancesFromLevel(PORTFOLIO_LEVEL, {
+      ...legacyOptions,
+      floorId: 'ground',
+      scale: FLOOR_PLAN_SCALE,
+    });
+    const after = generateWallInstancesFromLevel(edited, {
+      ...legacyOptions,
+      floorId: 'ground',
+      scale: FLOOR_PLAN_SCALE,
+    });
+
+    expect(after).toHaveLength(before.length + 1);
+    expect(
+      after.some((instance) => instance.sourceId === extraWall.sourceId)
+    ).toBe(true);
+  });
+
+  it('ignores semantic room connections unless wall geometry changes', () => {
+    const withoutConnections: LevelDefinition = {
+      ...PORTFOLIO_LEVEL,
+      floors: PORTFOLIO_LEVEL.floors.map((floor) => ({
+        ...floor,
+        roomConnections: [],
+      })),
+    };
+
+    expect(
+      normalize(
+        generateWallInstancesFromLevel(withoutConnections, {
+          ...legacyOptions,
+          floorId: 'upper',
+          scale: FLOOR_PLAN_SCALE,
+        })
+      )
+    ).toEqual(
+      normalize(
+        generateWallInstancesFromLevel(PORTFOLIO_LEVEL, {
+          ...legacyOptions,
+          floorId: 'upper',
+          scale: FLOOR_PLAN_SCALE,
+        })
+      )
+    );
+  });
+
+  it('does not introduce wall skip lists or former-bounds production data', () => {
+    const wallSegments = getCombinedWallSegments(FLOOR_PLAN);
+    expect(wallSegments.length).toBeGreaterThan(0);
+    expect(JSON.stringify(PORTFOLIO_LEVEL)).not.toMatch(
+      /skip|former|removed|tombstone/i
+    );
+  });
+});

--- a/src/scene/level/generateWalls.ts
+++ b/src/scene/level/generateWalls.ts
@@ -1,0 +1,262 @@
+import type {
+  CombinedWallSegment,
+  RoomCategory,
+  RoomWall,
+} from '../../assets/floorPlan';
+import {
+  getWallOutwardDirection,
+  type WallSegmentInstance,
+} from '../../assets/floorPlan/wallSegments';
+import type { RectCollider } from '../../systems/collision';
+
+import type {
+  FloorDefinition,
+  LevelDefinition,
+  Point2D,
+  WallDefinition,
+} from './schema';
+
+interface GenerateWallInstancesOptions {
+  floorId: string;
+  baseElevation: number;
+  wallHeight: number;
+  wallThickness: number;
+  fenceHeight: number;
+  fenceThickness: number;
+  getRoomCategory(roomId: string): RoomCategory;
+  scale?: number;
+  interiorExtensionFactor?: number;
+  exteriorExtensionFactor?: number;
+}
+
+const DEFAULT_INTERIOR_EXTENSION = 0.5;
+const DEFAULT_EXTERIOR_EXTENSION = 1;
+const LENGTH_EPSILON = 1e-4;
+
+export function generateWallInstancesFromLevel(
+  level: LevelDefinition,
+  options: GenerateWallInstancesOptions
+): WallSegmentInstance[] {
+  const floor = level.floors.find(
+    (candidate) => candidate.id === options.floorId
+  );
+  if (!floor) throw new Error(`Unknown level floor "${options.floorId}".`);
+
+  return generateWallInstancesForFloor(floor, options);
+}
+
+export function generateWallInstancesForFloor(
+  floor: FloorDefinition,
+  options: GenerateWallInstancesOptions
+): WallSegmentInstance[] {
+  const scale = options.scale ?? 1;
+  const interiorExtension =
+    options.interiorExtensionFactor ?? DEFAULT_INTERIOR_EXTENSION;
+  const exteriorExtension =
+    options.exteriorExtensionFactor ?? DEFAULT_EXTERIOR_EXTENSION;
+
+  return floor.walls.flatMap((wall) =>
+    getWallSourceSegments(floor, wall).flatMap(
+      (sourceSegment, segmentIndex) => {
+        const start = scalePoint(sourceSegment.start, scale);
+        const end = scalePoint(sourceSegment.end, scale);
+        const orientation = getOrientation(start, end);
+        const length =
+          orientation === 'horizontal'
+            ? Math.abs(end.x - start.x)
+            : Math.abs(end.z - start.z);
+        if (length <= LENGTH_EPSILON) return [];
+
+        const roomRefs = (wall.rooms ?? [])
+          .filter((roomId) => segmentTouchesRoom(floor, sourceSegment, roomId))
+          .map((roomId) => ({
+            id: roomId,
+            wall: inferRoomWall(floor, wall, sourceSegment, roomId),
+          }));
+        const roomCategories = roomRefs.map((roomInfo) =>
+          options.getRoomCategory(roomInfo.id)
+        );
+        const hasExterior = roomCategories.some(
+          (category) => category === 'exterior'
+        );
+        const hasInterior = roomCategories.some(
+          (category) => category !== 'exterior'
+        );
+        const isMixed = hasExterior && hasInterior;
+        const isFence = wall.wallKind === 'fence' || (hasExterior && !isMixed);
+        const thickness =
+          wall.thickness ??
+          (isFence ? options.fenceThickness : options.wallThickness);
+        const height =
+          wall.height ?? (isFence ? options.fenceHeight : options.wallHeight);
+        const isSharedInterior = roomRefs.length > 1;
+        const extension =
+          thickness *
+          (isSharedInterior ? interiorExtension : exteriorExtension);
+        const width =
+          orientation === 'horizontal' ? length + extension : thickness;
+        const depth =
+          orientation === 'horizontal' ? thickness : length + extension;
+        const baseX =
+          orientation === 'horizontal' ? (start.x + end.x) / 2 : start.x;
+        const baseZ =
+          orientation === 'horizontal' ? start.z : (start.z + end.z) / 2;
+        const outward =
+          !isSharedInterior && roomRefs.length > 0
+            ? getWallOutwardDirection(roomRefs[0].wall)
+            : { x: 0, z: 0 };
+        const center = {
+          x: baseX + outward.x * (options.wallThickness / 2),
+          y: options.baseElevation + height / 2,
+          z: baseZ + outward.z * (options.wallThickness / 2),
+        };
+        const collider: RectCollider = {
+          minX: center.x - width / 2,
+          maxX: center.x + width / 2,
+          minZ: center.z - depth / 2,
+          maxZ: center.z + depth / 2,
+        };
+        const segment: CombinedWallSegment = {
+          orientation,
+          start,
+          end,
+          rooms: roomRefs,
+        };
+
+        return [
+          {
+            segment,
+            segmentId: `${wall.sourceId}#${segmentIndex + 1}`,
+            sourceId: wall.sourceId,
+            sourceType: 'wall' as const,
+            center,
+            dimensions: { width, height, depth },
+            collider,
+            isFence,
+            isSharedInterior,
+            thickness,
+          },
+        ];
+      }
+    )
+  );
+}
+
+function getWallSourceSegments(
+  floor: FloorDefinition,
+  wall: WallDefinition
+): Array<{ start: Point2D; end: Point2D }> {
+  if ('segments' in wall && wall.segments) return wall.segments;
+
+  const run = wall.run;
+  const runLength = getLength(run.start, run.end);
+  const breakpoints = new Set([0, runLength]);
+  for (const gap of run.gaps ?? []) {
+    breakpoints.add(gap.start);
+    breakpoints.add(gap.end);
+  }
+
+  const horizontal = Math.abs(run.start.z - run.end.z) <= LENGTH_EPSILON;
+  for (const roomId of wall.rooms ?? []) {
+    const room = floor.rooms.find((candidate) => candidate.id === roomId);
+    if (!room) continue;
+    const bounds = room.bounds;
+    const candidates = horizontal
+      ? [bounds.minX, bounds.maxX]
+      : [bounds.minZ, bounds.maxZ];
+    for (const candidate of candidates) {
+      const offset = candidate - (horizontal ? run.start.x : run.start.z);
+      if (offset > 0 && offset < runLength) breakpoints.add(offset);
+    }
+  }
+
+  const sorted = [...breakpoints].sort((a, b) => a - b);
+  return sorted.flatMap((start, index) => {
+    const end = sorted[index + 1];
+    if (end === undefined || end - start <= LENGTH_EPSILON) return [];
+    const midpoint = (start + end) / 2;
+    const insideGap = (run.gaps ?? []).some(
+      (gap) => midpoint > gap.start && midpoint < gap.end
+    );
+    return insideGap
+      ? []
+      : [sliceRun(run.start, run.end, start, end, runLength)];
+  });
+}
+
+function sliceRun(
+  start: Point2D,
+  end: Point2D,
+  from: number,
+  to: number,
+  length: number
+) {
+  const dx = (end.x - start.x) / length;
+  const dz = (end.z - start.z) / length;
+  return {
+    start: { x: start.x + dx * from, z: start.z + dz * from },
+    end: { x: start.x + dx * to, z: start.z + dz * to },
+  };
+}
+
+function getLength(start: Point2D, end: Point2D) {
+  return Math.hypot(end.x - start.x, end.z - start.z);
+}
+
+function scalePoint(point: Point2D, scale: number): Point2D {
+  return { x: point.x * scale, z: point.z * scale };
+}
+
+function getOrientation(
+  start: Point2D,
+  end: Point2D
+): CombinedWallSegment['orientation'] {
+  return Math.abs(start.z - end.z) <= LENGTH_EPSILON
+    ? 'horizontal'
+    : 'vertical';
+}
+
+function inferRoomWall(
+  floor: FloorDefinition,
+  wall: WallDefinition,
+  segment: { start: Point2D; end: Point2D },
+  roomId: string
+): RoomWall {
+  const room = floor.rooms.find((candidate) => candidate.id === roomId);
+  const orientation = getOrientation(segment.start, segment.end);
+  if (!room) return orientation === 'horizontal' ? 'north' : 'east';
+  const value =
+    orientation === 'horizontal' ? segment.start.z : segment.start.x;
+  const { bounds } = room;
+  if (orientation === 'horizontal') {
+    if (Math.abs(value - bounds.minZ) <= 1e-3) return 'south';
+    if (Math.abs(value - bounds.maxZ) <= 1e-3) return 'north';
+    return wall.id.includes('south') ? 'south' : 'north';
+  }
+  if (Math.abs(value - bounds.minX) <= 1e-3) return 'west';
+  if (Math.abs(value - bounds.maxX) <= 1e-3) return 'east';
+  return wall.id.includes('west') ? 'west' : 'east';
+}
+
+function segmentTouchesRoom(
+  floor: FloorDefinition,
+  segment: { start: Point2D; end: Point2D },
+  roomId: string
+): boolean {
+  const room = floor.rooms.find((candidate) => candidate.id === roomId);
+  if (!room) return true;
+  const orientation = getOrientation(segment.start, segment.end);
+  const min =
+    orientation === 'horizontal'
+      ? Math.min(segment.start.x, segment.end.x)
+      : Math.min(segment.start.z, segment.end.z);
+  const max =
+    orientation === 'horizontal'
+      ? Math.max(segment.start.x, segment.end.x)
+      : Math.max(segment.start.z, segment.end.z);
+  const boundsMin =
+    orientation === 'horizontal' ? room.bounds.minX : room.bounds.minZ;
+  const boundsMax =
+    orientation === 'horizontal' ? room.bounds.maxX : room.bounds.maxZ;
+  return Math.min(max, boundsMax) - Math.max(min, boundsMin) > LENGTH_EPSILON;
+}


### PR DESCRIPTION
### Motivation
- Move runtime wall meshes and gameplay colliders off the legacy room-doorway adapter and make declarative level wall data the authoritative source for walls and fences.
- Preserve existing scene geometry, collider bounds, and runtime behavior while surfacing stable source IDs through debug solids and collider metadata.

### Description
- Add a declarative wall generator (`src/scene/level/generateWalls.ts`) that splits runs at declared gaps and room seams and emits wall/fence instances with `sourceId` and `sourceType` metadata.
- Wire ground and upper wall generation in `src/main.ts` to use `generateWallInstancesFromLevel(PORTFOLIO_LEVEL, { scale: FLOOR_PLAN_SCALE, ... })` and propagate `sourceId` into collider registrations and mesh `userData.levelSourceId`.
- Extend the wall instance type in `src/assets/floorPlan/wallSegments.ts` to include `sourceType?: 'wall'` and ensure runtime meshes keep `userData.levelSource` metadata.
- Add focused tests (`src/scene/level/__tests__/generateWalls.test.ts`) and update the design doc (`docs/design/declarative-level-source-of-truth.md`) to document that runtime walls/colliders are generated from declarative source data.

### Testing
- `npm run format:write` — succeeded.
- `npm run lint` — succeeded (4 warnings fixed where applicable during the rollout).
- `npm run test:ci -- src/scene/level/__tests__/generateWalls.test.ts` — succeeded (focused generator tests passed: 5 tests).
- `npm run test:ci` — succeeded (full suite run completed: 153 test files, 1177 tests passed).
- `npm run docs:check` — succeeded (link checker reported external fetch warnings but the docs check exited successfully).
- `npm run smoke` (build + dist assertions) — succeeded.
- `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — attempted but failed to run in this environment because Playwright browsers are not installed; error: `Please run npx playwright install` (Playwright executable missing).
- `npm run typecheck` (`tsc --noEmit`) — attempted but reported existing repository-wide TypeScript errors unrelated to this change set; this repository-wide typecheck failure is pre-existing and outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a332f863b28832f9e65360a49031834)