### PR TITLE
🧱 Generate walls from declarative source data

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -275,8 +275,10 @@ semantic `roomConnections` intentionally do not create or remove geometry.
 6. **Migrate room and wall data.** Current room and wall intent now lives in
    `src/scene/level/portfolioLevel.ts`; legacy floor-plan exports still compile
    through the adapter until downstream generators consume source data directly.
-7. **Generate wall outputs from source.** Derive wall meshes, wall colliders, and
-   wall debug metadata from source-backed wall definitions.
+7. **Generate wall outputs from source.** Wall meshes, wall colliders, and
+   wall debug metadata are now derived from source-backed wall definitions via
+   `src/scene/level/generateWalls.ts`, with source IDs flowing through mesh
+   userData and collider debug metadata.
 8. **Generate floor outputs from source.** Derive floor surfaces from source data,
    allowing generator-owned splitting and clipping where useful.
 9. **Move stair and void safety.** Convert stair, landing, and void guard

--- a/src/assets/floorPlan/wallSegments.ts
+++ b/src/assets/floorPlan/wallSegments.ts
@@ -84,12 +84,20 @@ export function createWallSegmentInstances(
   plan: FloorPlanDefinition,
   options: WallSegmentOptions
 ): WallSegmentInstance[] {
+  return createWallSegmentInstancesFromCombinedSegments(
+    getCombinedWallSegments(plan),
+    options
+  );
+}
+
+export function createWallSegmentInstancesFromCombinedSegments(
+  segments: readonly CombinedWallSegment[],
+  options: WallSegmentOptions
+): WallSegmentInstance[] {
   const interiorExtension =
     options.interiorExtensionFactor ?? DEFAULT_INTERIOR_EXTENSION;
   const exteriorExtension =
     options.exteriorExtensionFactor ?? DEFAULT_EXTERIOR_EXTENSION;
-
-  const segments = getCombinedWallSegments(plan);
   const instances: WallSegmentInstance[] = [];
 
   segments.forEach((segment) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,10 +36,7 @@ import {
   WALL_THICKNESS,
   type RoomCategory,
 } from './assets/floorPlan';
-import {
-  createWallSegmentInstances,
-  type WallSegmentInstance,
-} from './assets/floorPlan/wallSegments';
+import { type WallSegmentInstance } from './assets/floorPlan/wallSegments';
 import {
   formatMessage,
   getAudioHudControlStrings,
@@ -153,6 +150,8 @@ import {
   createSceneDetailController,
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
+import { generateWallInstances } from './scene/level/generateWalls';
+import { PORTFOLIO_LEVEL } from './scene/level/portfolioLevel';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -1873,8 +1872,9 @@ function initializeImmersiveScene(
   wallMaterial.lightMapIntensity = 0.68;
   fenceMaterial.lightMap = interiorLightmaps.wall;
   fenceMaterial.lightMapIntensity = 0.56;
-  const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
+  const groundWallInstances = generateWallInstances(PORTFOLIO_LEVEL, {
     floorId: 'ground',
+    coordinateScale: FLOOR_PLAN_SCALE,
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -2343,8 +2343,9 @@ function initializeImmersiveScene(
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
-  const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+  const upperWallInstances = generateWallInstances(PORTFOLIO_LEVEL, {
     floorId: 'upper',
+    coordinateScale: FLOOR_PLAN_SCALE,
     baseElevation: upperFloorElevation,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,0 +1,146 @@
+import { MeshBasicMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN, FLOOR_PLAN_SCALE } from '../../../assets/floorPlan';
+import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
+import { generateWallInstances } from '../generateWalls';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import type { LevelDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const wallOptions = {
+  baseElevation: 0,
+  wallHeight: 3,
+  wallThickness: 0.5,
+  fenceHeight: 1.2,
+  fenceThickness: 0.25,
+  getRoomCategory(roomId: string) {
+    return roomId === 'backyard' ? 'exterior' : 'interior';
+  },
+} as const;
+
+describe('generateWallInstances', () => {
+  it('matches legacy ground wall bounds while using source wall IDs', () => {
+    for (const [floorId, plan] of [['ground', FLOOR_PLAN]] as const) {
+      const legacy = createWallSegmentInstances(plan, {
+        ...wallOptions,
+        floorId,
+      });
+      const generated = generateWallInstances(PORTFOLIO_LEVEL, {
+        ...wallOptions,
+        floorId,
+        coordinateScale: FLOOR_PLAN_SCALE,
+      });
+
+      expect(generated.map(snapshotInstance).sort(compareSnapshots)).toEqual(
+        legacy.map(snapshotInstance).sort(compareSnapshots)
+      );
+      expect(
+        generated.every(
+          (instance) => !String(instance.sourceId).includes('generated_wall')
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('attaches source IDs to every generated wall mesh', () => {
+    const material = new MeshBasicMaterial();
+    const build = createWallSegmentMeshes({
+      instances: generateWallInstances(PORTFOLIO_LEVEL, {
+        ...wallOptions,
+        floorId: 'ground',
+        coordinateScale: FLOOR_PLAN_SCALE,
+      }),
+      getMaterial: () => material,
+    });
+
+    expect(build.meshes.length).toBeGreaterThan(0);
+    expect(build.meshes.every((mesh) => mesh.userData.levelSourceId)).toBe(
+      true
+    );
+    expect(
+      build.meshes.every(
+        (mesh) => mesh.userData.levelSource?.sourceType === 'wall'
+      )
+    ).toBe(true);
+    material.dispose();
+  });
+
+  it('reflects declarative wall additions and removals without consuming connections', () => {
+    const edited: LevelDefinition = structuredClone(PORTFOLIO_LEVEL);
+    const ground = edited.floors.find((floor) => floor.id === 'ground');
+    expect(ground).toBeDefined();
+    ground!.walls = ground!.walls.filter(
+      (wall) => wall.id !== 'living-room-south-wall'
+    );
+    ground!.walls.push({
+      id: 'fixture-short-wall',
+      sourceId: assertLevelSourceId('ground.fixture.short_wall'),
+      floorId: 'ground',
+      wallKind: 'wall',
+      rooms: ['livingRoom'],
+      segments: [{ start: { x: -4, z: -16 }, end: { x: 0, z: -16 } }],
+    });
+    ground!.roomConnections = [
+      ...(ground!.roomConnections ?? []),
+      {
+        id: 'fixture-connection',
+        sourceId: assertLevelSourceId('ground.fixture.connection'),
+        floorId: 'ground',
+        rooms: ['livingRoom', 'kitchen'],
+      },
+    ];
+
+    const generated = generateWallInstances(edited, {
+      ...wallOptions,
+      floorId: 'ground',
+      coordinateScale: FLOOR_PLAN_SCALE,
+    });
+
+    expect(
+      generated.some(
+        (instance) => instance.sourceId === 'ground.living_room.south_wall'
+      )
+    ).toBe(false);
+    expect(
+      generated.filter(
+        (instance) => instance.sourceId === 'ground.fixture.short_wall'
+      )
+    ).toHaveLength(1);
+    expect(
+      generated.some(
+        (instance) => instance.sourceId === 'ground.fixture.connection'
+      )
+    ).toBe(false);
+  });
+});
+
+function snapshotInstance(
+  instance: ReturnType<typeof createWallSegmentInstances>[number]
+) {
+  return {
+    center: roundObject(instance.center),
+    dimensions: roundObject(instance.dimensions),
+    collider: roundObject(instance.collider),
+    isFence: instance.isFence,
+    isSharedInterior: instance.isSharedInterior,
+    thickness: instance.thickness,
+  };
+}
+
+function roundObject<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      Number((entry as number).toFixed(6)),
+    ])
+  ) as T;
+}
+
+function compareSnapshots(
+  a: ReturnType<typeof snapshotInstance>,
+  b: ReturnType<typeof snapshotInstance>
+): number {
+  return JSON.stringify(a).localeCompare(JSON.stringify(b));
+}

--- a/src/scene/level/generateWalls.ts
+++ b/src/scene/level/generateWalls.ts
@@ -1,0 +1,235 @@
+import type {
+  CombinedWallSegment,
+  RoomCategory,
+  RoomWall,
+} from '../../assets/floorPlan';
+import {
+  createWallSegmentInstancesFromCombinedSegments,
+  type WallSegmentInstance,
+  type WallSegmentOptions,
+} from '../../assets/floorPlan/wallSegments';
+
+import type {
+  FloorDefinition,
+  LevelDefinition,
+  SemanticRoomDefinition,
+  WallDefinition,
+} from './schema';
+import { assertValidLevelDefinition } from './schema';
+
+export interface GenerateWallInstancesOptions
+  extends Omit<WallSegmentOptions, 'floorId' | 'levelId' | 'getRoomCategory'> {
+  floorId: string;
+  coordinateScale?: number;
+  getRoomCategory?(roomId: string): RoomCategory;
+}
+
+const AXIS_EPSILON = 1e-6;
+const LENGTH_EPSILON = 1e-4;
+
+export function generateWallInstances(
+  level: LevelDefinition,
+  options: GenerateWallInstancesOptions
+): WallSegmentInstance[] {
+  assertValidLevelDefinition(level);
+  const floor = level.floors.find(
+    (candidate) => candidate.id === options.floorId
+  );
+  if (!floor)
+    throw new Error(
+      `Level "${level.id}" does not contain floor "${options.floorId}".`
+    );
+
+  const declarativeSegments = createDeclarativeCombinedSegments(floor, options);
+  return createWallSegmentInstancesFromCombinedSegments(
+    declarativeSegments.map((entry) => entry.segment),
+    {
+      ...options,
+      floorId: options.floorId,
+      getRoomCategory:
+        options.getRoomCategory ??
+        ((roomId) =>
+          floor.rooms.find((room) => room.id === roomId)?.category ??
+          'interior'),
+    }
+  ).map((instance, index) => ({
+    ...instance,
+    sourceId: declarativeSegments[index].sourceId,
+  }));
+}
+
+function createDeclarativeCombinedSegments(
+  floor: FloorDefinition,
+  options: GenerateWallInstancesOptions
+): Array<{
+  segment: CombinedWallSegment;
+  sourceId: WallDefinition['sourceId'];
+}> {
+  return floor.walls.flatMap((wall) => {
+    const segments = getWallPieces(wall).flatMap((piece) => {
+      const splitPieces =
+        (wall.rooms?.length ?? 0) > 1
+          ? splitAtRoomBoundaries(piece, floor.rooms)
+          : [piece];
+      return splitPieces.flatMap((splitPiece) => {
+        const rooms = getRoomsForPiece(splitPiece, floor.rooms);
+        if (rooms.length === 0) return [];
+        const scaledSegment: CombinedWallSegment = {
+          orientation: splitPiece.orientation,
+          start: {
+            x: scale(splitPiece.start.x, options),
+            z: scale(splitPiece.start.z, options),
+          },
+          end: {
+            x: scale(splitPiece.end.x, options),
+            z: scale(splitPiece.end.z, options),
+          },
+          rooms,
+        };
+        return [{ segment: scaledSegment, sourceId: wall.sourceId }];
+      });
+    });
+    return segments;
+  });
+}
+
+type AxisPiece = CombinedWallSegment & { rooms: [] };
+
+function hasSegments(wall: WallDefinition): wall is WallDefinition & {
+  segments: NonNullable<WallDefinition['segments']>;
+} {
+  return Array.isArray((wall as { segments?: unknown }).segments);
+}
+
+function getWallPieces(wall: WallDefinition): AxisPiece[] {
+  const rawSegments = hasSegments(wall) ? wall.segments : splitRun(wall.run);
+  return rawSegments.flatMap((segment) => {
+    const orientation = getOrientation(segment.start, segment.end);
+    if (!orientation) return [];
+    return [{ orientation, start: segment.start, end: segment.end, rooms: [] }];
+  });
+}
+
+function splitRun(
+  run: NonNullable<WallDefinition['run']>
+): Array<{ start: { x: number; z: number }; end: { x: number; z: number } }> {
+  const length = Math.hypot(run.end.x - run.start.x, run.end.z - run.start.z);
+  if (length <= AXIS_EPSILON) return [];
+  const gaps = [...(run.gaps ?? [])].sort((a, b) => a.start - b.start);
+  const ranges: Array<{ start: number; end: number }> = [];
+  let cursor = 0;
+  for (const gap of gaps) {
+    const gapStart = Math.max(0, Math.min(length, gap.start));
+    const gapEnd = Math.max(0, Math.min(length, gap.end));
+    if (gapStart > cursor) ranges.push({ start: cursor, end: gapStart });
+    cursor = Math.max(cursor, gapEnd);
+  }
+  if (cursor < length) ranges.push({ start: cursor, end: length });
+  return ranges
+    .filter((range) => range.end - range.start > LENGTH_EPSILON)
+    .map((range) => ({
+      start: pointAt(run, range.start / length),
+      end: pointAt(run, range.end / length),
+    }));
+}
+
+function pointAt(run: NonNullable<WallDefinition['run']>, ratio: number) {
+  return {
+    x: run.start.x + (run.end.x - run.start.x) * ratio,
+    z: run.start.z + (run.end.z - run.start.z) * ratio,
+  };
+}
+
+function getOrientation(
+  start: { x: number; z: number },
+  end: { x: number; z: number }
+): 'horizontal' | 'vertical' | undefined {
+  if (Math.abs(start.z - end.z) <= AXIS_EPSILON) return 'horizontal';
+  if (Math.abs(start.x - end.x) <= AXIS_EPSILON) return 'vertical';
+  return undefined;
+}
+
+function splitAtRoomBoundaries(
+  piece: AxisPiece,
+  rooms: readonly SemanticRoomDefinition[]
+): AxisPiece[] {
+  const points = new Set<number>();
+  const start =
+    piece.orientation === 'horizontal' ? piece.start.x : piece.start.z;
+  const end = piece.orientation === 'horizontal' ? piece.end.x : piece.end.z;
+  const min = Math.min(start, end);
+  const max = Math.max(start, end);
+  points.add(min);
+  points.add(max);
+  rooms.forEach((room) => {
+    const a =
+      piece.orientation === 'horizontal' ? room.bounds.minX : room.bounds.minZ;
+    const b =
+      piece.orientation === 'horizontal' ? room.bounds.maxX : room.bounds.maxZ;
+    if (a > min + AXIS_EPSILON && a < max - AXIS_EPSILON) points.add(a);
+    if (b > min + AXIS_EPSILON && b < max - AXIS_EPSILON) points.add(b);
+  });
+  const sorted = [...points].sort((a, b) => a - b);
+  return sorted.slice(0, -1).flatMap((value, index) => {
+    const next = sorted[index + 1];
+    if (next - value <= LENGTH_EPSILON) return [];
+    return [
+      { ...piece, start: toPoint(piece, value), end: toPoint(piece, next) },
+    ];
+  });
+}
+
+function toPoint(piece: AxisPiece, value: number) {
+  return piece.orientation === 'horizontal'
+    ? { x: value, z: piece.start.z }
+    : { x: piece.start.x, z: value };
+}
+
+function getRoomsForPiece(
+  piece: AxisPiece,
+  rooms: readonly SemanticRoomDefinition[]
+): Array<{ id: string; wall: RoomWall }> {
+  return rooms.flatMap((room) => {
+    const wall = getRoomWallForPiece(piece, room);
+    return wall ? [{ id: room.id, wall }] : [];
+  });
+}
+
+function getRoomWallForPiece(
+  piece: AxisPiece,
+  room: SemanticRoomDefinition
+): RoomWall | undefined {
+  const min =
+    piece.orientation === 'horizontal'
+      ? Math.min(piece.start.x, piece.end.x)
+      : Math.min(piece.start.z, piece.end.z);
+  const max =
+    piece.orientation === 'horizontal'
+      ? Math.max(piece.start.x, piece.end.x)
+      : Math.max(piece.start.z, piece.end.z);
+  const roomMin =
+    piece.orientation === 'horizontal' ? room.bounds.minX : room.bounds.minZ;
+  const roomMax =
+    piece.orientation === 'horizontal' ? room.bounds.maxX : room.bounds.maxZ;
+  if (min < roomMin - AXIS_EPSILON || max > roomMax + AXIS_EPSILON)
+    return undefined;
+  if (piece.orientation === 'horizontal') {
+    if (Math.abs(piece.start.z - room.bounds.maxZ) <= AXIS_EPSILON)
+      return 'north';
+    if (Math.abs(piece.start.z - room.bounds.minZ) <= AXIS_EPSILON)
+      return 'south';
+  } else {
+    if (Math.abs(piece.start.x - room.bounds.maxX) <= AXIS_EPSILON)
+      return 'east';
+    if (Math.abs(piece.start.x - room.bounds.minX) <= AXIS_EPSILON)
+      return 'west';
+  }
+  return undefined;
+}
+
+function scale(
+  value: number,
+  options: Pick<GenerateWallInstancesOptions, 'coordinateScale'>
+): number {
+  return value * (options.coordinateScale ?? 1);
+}


### PR DESCRIPTION
### Motivation
- Move migrated wall and fence visual meshes and gameplay colliders from the legacy room-doorway pipeline to the declarative level source-of-truth so edits originate in `LevelDefinition` data.
- Preserve existing geometry, collider bounds, fence/wall sizing, seam extension behavior, and downstream APIs while exposing stable `levelSourceId` metadata for meshes and colliders.

### Description
- Add `src/scene/level/generateWalls.ts` which expands declarative `WallDefinition` runs/segments (with gaps) into axis-aligned combined segments, splits at room boundaries, infers room-side orientation, scales coordinates, and emits `WallSegmentInstance[]` carrying the declarative `sourceId`.
- Factor wall-sizing/collider logic into `createWallSegmentInstancesFromCombinedSegments(...)` in `src/assets/floorPlan/wallSegments.ts` and reuse it from the new generator so generated outputs preserve existing thickness/height/extension behavior.
- Wire `main.ts` to build ground and upper walls from `generateWallInstances(PORTFOLIO_LEVEL, ...)` (using `FLOOR_PLAN_SCALE`) and flow `sourceId` into mesh `userData.levelSourceId` and collider debug metadata maps instead of relying on legacy generated IDs.
- Add focused tests `src/scene/level/__tests__/generateWalls.test.ts` that assert generated ground wall bounds match the legacy adapter, every generated mesh has a `levelSourceId` and `levelSource.sourceType === 'wall'`, and that editing declarative wall data adds/removes generated output without consuming semantic `roomConnections`.
- Update design doc `docs/design/declarative-level-source-of-truth.md` to record that wall meshes/colliders/debug metadata now derive from declarative source data.

### Testing
- Ran formatting: `npm run format:write` — succeeded.
- Ran lint: `npm run lint` — succeeded (warnings fixed where applicable during development).
- Ran focused unit tests: `npm run test:ci -- src/scene/level/__tests__/generateWalls.test.ts src/scene/structures/__tests__/wallSegmentsMesh.test.ts src/tests/wallSegments.test.ts` — succeeded.
- Ran full unit test suite: `npm run test:ci` — succeeded (all tests passed; final run showed 1175 tests passing).
- Documentation check: `npm run docs:check` — succeeded (link check produced reachable/unreachable warnings unrelated to this change).
- Build and smoke checks: `npm run build` and `npm run smoke` — succeeded.
- Playwright end-to-end: attempted `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`; initial run failed because Playwright browsers were not installed; `npx playwright install chromium` downloaded browsers but the host lacked required native dependencies (Playwright requested `npx playwright install-deps`), so browser-driven Playwright tests are blocked by host environment dependencies and were not fully exercised here.

Branch: `codex/declarative-wall-generation` (changes committed and ready for review).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a332f90a544832f8a891df6b2be080b)