### PR TITLE
🧱 : – Generate walls from declarative source

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -275,8 +275,10 @@ semantic `roomConnections` intentionally do not create or remove geometry.
 6. **Migrate room and wall data.** Current room and wall intent now lives in
    `src/scene/level/portfolioLevel.ts`; legacy floor-plan exports still compile
    through the adapter until downstream generators consume source data directly.
-7. **Generate wall outputs from source.** Derive wall meshes, wall colliders, and
-   wall debug metadata from source-backed wall definitions.
+7. **Generate wall outputs from source.** Wall meshes, wall colliders, and
+   wall debug metadata now route through a declarative wall adapter so generated
+   wall/fence solids carry source-owned wall IDs while preserving the current
+   legacy-compatible segment splitting and seam expansion.
 8. **Generate floor outputs from source.** Derive floor surfaces from source data,
    allowing generator-owned splitting and clipping where useful.
 9. **Move stair and void safety.** Convert stair, landing, and void guard

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,10 +36,7 @@ import {
   WALL_THICKNESS,
   type RoomCategory,
 } from './assets/floorPlan';
-import {
-  createWallSegmentInstances,
-  type WallSegmentInstance,
-} from './assets/floorPlan/wallSegments';
+import type { WallSegmentInstance } from './assets/floorPlan/wallSegments';
 import {
   formatMessage,
   getAudioHudControlStrings,
@@ -153,6 +150,8 @@ import {
   createSceneDetailController,
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
+import { generateWallInstances } from './scene/level/generateWalls';
+import { PORTFOLIO_LEVEL } from './scene/level/portfolioLevel';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -502,6 +501,15 @@ const DEBUG_SOLID_IDS_STORAGE_KEY = 'danielsmith.io::debugSolidIds::v1';
 const DEBUG_FPS_STORAGE_KEY = 'danielsmith.io::debugFpsCounter::v1';
 const DEBUG_URL_TRUTHY_VALUES = ['1', 'true', 'yes', 'on'] as const;
 const DEBUG_URL_FALSY_VALUES = ['0', 'false', 'no', 'off'] as const;
+const getPortfolioFloor = (floorId: 'ground' | 'upper') => {
+  const floor = PORTFOLIO_LEVEL.floors.find(
+    (candidate) => candidate.id === floorId
+  );
+  if (!floor) {
+    throw new Error(`Missing declarative portfolio floor: ${floorId}`);
+  }
+  return floor;
+};
 const isDebugUrlValueIn = (
   value: string | null | undefined,
   candidates: readonly string[]
@@ -1873,8 +1881,9 @@ function initializeImmersiveScene(
   wallMaterial.lightMapIntensity = 0.68;
   fenceMaterial.lightMap = interiorLightmaps.wall;
   fenceMaterial.lightMapIntensity = 0.56;
-  const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
-    floorId: 'ground',
+  const groundLevelFloor = getPortfolioFloor('ground');
+  const groundWallInstances = generateWallInstances(groundLevelFloor, {
+    scale: FLOOR_PLAN_SCALE,
     baseElevation: 0,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,
@@ -2343,8 +2352,9 @@ function initializeImmersiveScene(
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
-  const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
-    floorId: 'upper',
+  const upperLevelFloor = getPortfolioFloor('upper');
+  const upperWallInstances = generateWallInstances(upperLevelFloor, {
+    scale: FLOOR_PLAN_SCALE,
     baseElevation: upperFloorElevation,
     wallHeight: WALL_HEIGHT,
     wallThickness: WALL_THICKNESS,

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLOOR_PLAN,
+  UPPER_FLOOR_PLAN,
+  FLOOR_PLAN_SCALE,
+  WALL_THICKNESS,
+} from '../../../assets/floorPlan';
+import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
+import { generateWallInstances } from '../generateWalls';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import type { FloorDefinition } from '../schema';
+
+const options = {
+  scale: FLOOR_PLAN_SCALE,
+  baseElevation: 0,
+  wallHeight: 6,
+  wallThickness: WALL_THICKNESS,
+  fenceHeight: 2.4,
+  fenceThickness: 0.28,
+  getRoomCategory(roomId: string) {
+    return roomId === 'backyard'
+      ? ('exterior' as const)
+      : ('interior' as const);
+  },
+};
+
+const floor = (id: 'ground' | 'upper') => {
+  const definition = PORTFOLIO_LEVEL.floors.find(
+    (candidate) => candidate.id === id
+  );
+  if (!definition) throw new Error(`Missing test floor ${id}`);
+  return definition;
+};
+
+const bounds = (instances: ReturnType<typeof generateWallInstances>) =>
+  instances
+    .map((instance) => ({
+      collider: instance.collider,
+      dimensions: instance.dimensions,
+      isFence: instance.isFence,
+    }))
+    .sort(
+      (a, b) =>
+        a.collider.minX - b.collider.minX ||
+        a.collider.minZ - b.collider.minZ ||
+        a.collider.maxX - b.collider.maxX ||
+        a.collider.maxZ - b.collider.maxZ
+    );
+
+describe('generateWallInstances', () => {
+  it('matches legacy ground wall and fence bounds', () => {
+    expect(bounds(generateWallInstances(floor('ground'), options))).toEqual(
+      bounds(
+        createWallSegmentInstances(FLOOR_PLAN, {
+          ...options,
+          floorId: 'ground',
+        })
+      )
+    );
+  });
+
+  it('matches legacy upper wall bounds', () => {
+    expect(bounds(generateWallInstances(floor('upper'), options))).toEqual(
+      bounds(
+        createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+          ...options,
+          floorId: 'upper',
+        })
+      )
+    );
+  });
+
+  it('adds and removes output when declarative wall data changes', () => {
+    const ground = floor('ground');
+    const withoutFirstWall: FloorDefinition = {
+      ...ground,
+      walls: ground.walls.slice(1),
+    };
+    expect(
+      generateWallInstances(withoutFirstWall, options).length
+    ).toBeLessThan(generateWallInstances(ground, options).length);
+  });
+
+  it('does not consume semantic room connections as wall geometry', () => {
+    const ground = floor('ground');
+    const withoutConnections: FloorDefinition = {
+      ...ground,
+      roomConnections: [],
+    };
+    expect(bounds(generateWallInstances(withoutConnections, options))).toEqual(
+      bounds(generateWallInstances(ground, options))
+    );
+  });
+
+  it('emits source IDs for every wall mesh', () => {
+    const material = { dispose() {} } as never;
+    const instances = generateWallInstances(floor('ground'), options);
+    const { meshes } = createWallSegmentMeshes({
+      instances,
+      getMaterial: () => material,
+    });
+    expect(
+      meshes.every((mesh) => typeof mesh.userData.levelSourceId === 'string')
+    ).toBe(true);
+    expect(
+      meshes.every((mesh) => mesh.userData.levelSource?.sourceType === 'wall')
+    ).toBe(true);
+  });
+});

--- a/src/scene/level/generateWalls.ts
+++ b/src/scene/level/generateWalls.ts
@@ -1,0 +1,131 @@
+import type { FloorPlanDefinition } from '../../assets/floorPlan';
+import {
+  createWallSegmentInstances,
+  type WallSegmentOptions,
+} from '../../assets/floorPlan/wallSegments';
+
+import { compileLegacyFloorPlan } from './compileLegacyFloorPlan';
+import type {
+  FloorDefinition,
+  LevelDefinition,
+  Point2D,
+  WallDefinition,
+} from './schema';
+
+export type GenerateWallInstancesOptions = Omit<
+  WallSegmentOptions,
+  'floorId' | 'levelId'
+> & {
+  /** Multiplier applied when declarative source units differ from world units. */
+  scale?: number;
+};
+
+const LENGTH_EPSILON = 1e-4;
+
+export function generateWallInstances(
+  floor: FloorDefinition,
+  options: GenerateWallInstancesOptions
+) {
+  const plan = compileFloor(floor, options.scale ?? 1);
+  return createWallSegmentInstances(plan, {
+    ...options,
+    floorId: floor.id,
+  }).flatMap((instance) => {
+    const sourceWall = findSourceWall(
+      floor,
+      instance.segment,
+      options.scale ?? 1
+    );
+    return sourceWall ? [{ ...instance, sourceId: sourceWall.sourceId }] : [];
+  });
+}
+
+function compileFloor(
+  floor: FloorDefinition,
+  scale: number
+): FloorPlanDefinition {
+  const level: LevelDefinition = {
+    id: 'generated-wall-level',
+    floors: [floor],
+  };
+  return scaleFloorPlan(
+    compileLegacyFloorPlan(level, floor.id, {
+      includeDoorwaysFromWallGaps: true,
+    }),
+    scale
+  );
+}
+
+function findSourceWall(
+  floor: FloorDefinition,
+  segment: ReturnType<typeof createWallSegmentInstances>[number]['segment'],
+  scale: number
+): WallDefinition | undefined {
+  const midpoint = {
+    x: (segment.start.x + segment.end.x) / 2,
+    z: (segment.start.z + segment.end.z) / 2,
+  };
+  return floor.walls.find((wall) => wallContainsPoint(wall, midpoint, scale));
+}
+
+function wallContainsPoint(
+  wall: WallDefinition,
+  point: Point2D,
+  scale: number
+): boolean {
+  const segments =
+    'segments' in wall && wall.segments
+      ? wall.segments
+      : 'run' in wall && wall.run
+        ? [wall.run]
+        : [];
+  return segments.some((segment) =>
+    pointOnSegment(
+      scalePoint(segment.start, scale),
+      scalePoint(segment.end, scale),
+      point
+    )
+  );
+}
+
+function pointOnSegment(start: Point2D, end: Point2D, point: Point2D): boolean {
+  const cross =
+    (point.z - start.z) * (end.x - start.x) -
+    (point.x - start.x) * (end.z - start.z);
+  if (Math.abs(cross) > LENGTH_EPSILON) return false;
+  return (
+    point.x >= Math.min(start.x, end.x) - LENGTH_EPSILON &&
+    point.x <= Math.max(start.x, end.x) + LENGTH_EPSILON &&
+    point.z >= Math.min(start.z, end.z) - LENGTH_EPSILON &&
+    point.z <= Math.max(start.z, end.z) + LENGTH_EPSILON
+  );
+}
+
+function scalePoint(point: Point2D, scale: number): Point2D {
+  return { x: point.x * scale, z: point.z * scale };
+}
+
+function scaleFloorPlan(
+  plan: FloorPlanDefinition,
+  scale: number
+): FloorPlanDefinition {
+  if (Math.abs(scale - 1) <= LENGTH_EPSILON) return plan;
+  const scaleValue = (value: number) => value * scale;
+  return {
+    outline: plan.outline.map(([x, z]) => [scaleValue(x), scaleValue(z)]),
+    rooms: plan.rooms.map((room) => ({
+      ...room,
+      bounds: {
+        minX: scaleValue(room.bounds.minX),
+        maxX: scaleValue(room.bounds.maxX),
+        minZ: scaleValue(room.bounds.minZ),
+        maxZ: scaleValue(room.bounds.maxZ),
+      },
+      doorways: room.doorways?.map((doorway) => ({
+        ...doorway,
+        start: scaleValue(doorway.start),
+        end: scaleValue(doorway.end),
+      })),
+    })),
+  };
+}


### PR DESCRIPTION
### Motivation
- Move wall/fence visual meshes and gameplay colliders off the legacy room-doorway generator and onto a declarative wall source so edits are owned by walls in `portfolioLevel`.
- Preserve existing geometry, seam/split behavior, thickness/height rules, and debug metadata while introducing stable source-owned IDs for meshes and colliders.
- Provide a minimal migration adapter that keeps legacy-compatible outputs for downstream consumers while enabling direct source-driven generation.

### Description
- Add a declarative wall generation adapter `src/scene/level/generateWalls.ts` that compiles a `FloorDefinition` to a `FloorPlanDefinition` and emits `WallSegmentInstance[]` compatible with existing mesh/collider builders.
- Wire `main.ts` to use the new adapter for ground and upper walls via `PORTFOLIO_LEVEL` (use `getPortfolioFloor(...)` and `generateWallInstances(...)`), and flow `sourceId` into mesh `userData.levelSourceId` and collider debug metadata.
- Add focused tests `src/scene/level/__tests__/generateWalls.test.ts` that assert legacy bounds parity with `createWallSegmentInstances(...)`, verify source ID propagation, confirm edits to declarative walls add/remove output, and ensure semantic `roomConnections` are not consumed as geometry.
- Update docs `docs/design/declarative-level-source-of-truth.md` to record that wall solids/colliders/debug metadata are generated from declarative wall source data.

### Testing
- Ran `npm run format:write` and formatting completed successfully.
- Ran `npm run lint` and fixed import-order warnings; linter ended with no blocking errors (warnings were addressed with `--fix`).
- Ran focused wall tests `npx vitest run src/scene/level/__tests__/generateWalls.test.ts` and they passed (5 tests).
- Ran full unit suite `npm run test:ci` and observed all tests complete (1177 passed, 0 failed in this environment).
- Ran `npm run docs:check` and `npm run links:check` (docs check passed; link checker reported unreachable external links as warnings due to network fetch limitations).
- Built production bundle `npm run build` which completed successfully (Vite chunk-size warning present but unchanged).
- Attempted Playwright acceptance `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` but it could not run because Playwright browsers are not installed in this environment; Playwright reported `npx playwright install` is required (not run here).

Branch/commit: change is on branch `codex/declarative-wall-generation` with commit message `🧱 : – Generate walls from declarative source`.

Known limitations / follow-ups: Playwright E2E requires `npx playwright install` in CI/runner to validate the immersive stairs spec; no runtime geometry or collider bounds were intentionally changed in this PR and adapter preserves legacy splitting/scale behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a332fa1b79c832fb57452a735c855bd)