### PR TITLE
🏗️ Generate walls from declarative source

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -25,34 +25,41 @@ orchestration code:
      in `BASE_FLOOR_PLAN` before scaling them into `FLOOR_PLAN`.
    - Doorways are attached to room walls and are validated by width, but they are
      not first-class semantic connections.
-   - Wall generation starts from room bounds and doorways via room wall segments
-     and combined wall segments.
-2. `src/assets/floorPlan/wallSegments.ts`
-   - Converts combined wall segments into wall or fence instances.
+   - Legacy consumers can still derive room wall segments from room bounds and
+     doorway-compatible wall gaps.
+2. `src/scene/level/generateWalls.ts`
+   - Splits declarative wall runs around current topology gaps, room boundaries,
+     and seams, then emits wall/fence instances with source IDs.
+   - Computes wall/fence dimensions, center points, colliders, shared-interior
+     status, and generator-owned seam extension without requiring removed-bounds
+     lists or visualizer filters.
+3. `src/assets/floorPlan/wallSegments.ts`
+   - Retains the legacy combined-wall adapter for compatibility tests and
+     non-migrated consumers.
    - Computes wall/fence dimensions, center points, colliders, shared-interior
      status, and current `segmentId` values.
    - Current segment IDs are generated from segment data plus the segment order,
      so they are useful runtime correlation labels but are not yet stable source
      identities.
-3. `src/scene/structures/wallSegmentsMesh.ts`
+4. `src/scene/structures/wallSegmentsMesh.ts`
    - Builds Three.js wall and fence meshes from wall segment instances.
    - Copies compact metadata such as `segmentId`, `isFence`,
      `isSharedInterior`, and `thickness` into mesh `userData`.
-4. `src/scene/structures/floorTiles.ts`
+5. `src/scene/structures/floorTiles.ts`
    - Builds room floor tile meshes from room bounds.
    - Supports generator-owned cutout subtraction and room-specific cutouts, then
      emits renderable tile pieces.
-5. `src/main.ts`
+6. `src/main.ts`
    - Orchestrates the scene and stitches together generated assets with manual
      runtime additions.
-   - Creates floor tiles, wall segment instances, wall meshes, lightmaps,
+   - Creates floor tiles, source-generated wall segment instances, wall meshes, lightmaps,
      ceilings, backyard environment pieces, stair geometry, POIs, and showpieces.
    - Pushes manually assembled colliders into ground, upper, and static collider
      lists, including wall colliders, backyard colliders, stair guards, landing
      and stairwell constraints, mirrors, media wall/showpiece colliders, and
      other object policies.
    - Supplies names and debug registrations for generated and manual colliders.
-6. `src/scene/debug/colliderVisualizer.ts`,
+7. `src/scene/debug/colliderVisualizer.ts`,
    `src/scene/debug/solidVisualizer.ts`, and
    `src/scene/debug/colliderDebugIds.ts`
    - Consume collider and solid metadata after geometry and collider generation.
@@ -275,8 +282,11 @@ semantic `roomConnections` intentionally do not create or remove geometry.
 6. **Migrate room and wall data.** Current room and wall intent now lives in
    `src/scene/level/portfolioLevel.ts`; legacy floor-plan exports still compile
    through the adapter until downstream generators consume source data directly.
-7. **Generate wall outputs from source.** Derive wall meshes, wall colliders, and
-   wall debug metadata from source-backed wall definitions.
+7. **Generate wall outputs from source.** Wall meshes, wall colliders, and
+   wall debug metadata now derive from `FloorDefinition.walls` via
+   `src/scene/level/generateWalls.ts`; the legacy room-doorway wall generator is
+   retained only as a compatibility reference while later phases migrate floors,
+   safety colliders, and inventory tooling.
 8. **Generate floor outputs from source.** Derive floor surfaces from source data,
    allowing generator-owned splitting and clipping where useful.
 9. **Move stair and void safety.** Convert stair, landing, and void guard

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1094,6 +1094,11 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
     debugSolids.setEnabled(true);
     debugColliders.setEnabled(true);
 
+    const knownWallSourceId = 'upper.upper_landing.south_wall';
+    const knownWallSolids = debugSolids.getSolidsBySourceId(knownWallSourceId);
+    const knownWallColliders =
+      debugColliders.getCollidersBySourceId(knownWallSourceId);
+
     const formerWallBounds = {
       minX: 3.875,
       maxX: 8.525,
@@ -1139,6 +1144,12 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       solidById: debugSolids.getSolidById('DD4252'),
       collider300A: debugColliders.getColliderById('300A'),
       collider4005: debugColliders.getColliderById('4005'),
+      knownWallSolidCount: knownWallSolids.length,
+      knownWallColliderCount: knownWallColliders.length,
+      knownWallSolidSourceIds: knownWallSolids.map((solid) => solid.sourceId),
+      knownWallColliderSourceIds: knownWallColliders.map(
+        (collider) => collider.sourceId
+      ),
       matchingWallSolidCount: matchingWallSolids.length,
       matchingColliderBoundsCount: matchingColliderBounds.length,
       formerVoidGuardNames: debugColliders
@@ -1161,6 +1172,14 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
     };
   });
 
+  expect(targetState.knownWallSolidCount).toBeGreaterThan(0);
+  expect(targetState.knownWallColliderCount).toBeGreaterThan(0);
+  expect(targetState.knownWallSolidSourceIds).toContain(
+    'upper.upper_landing.south_wall'
+  );
+  expect(targetState.knownWallColliderSourceIds).toContain(
+    'upper.upper_landing.south_wall'
+  );
   expect(targetState.solidById).toBeUndefined();
   expect(targetState.collider300A).toBeUndefined();
   expect(targetState.collider4005).toBeUndefined();

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,10 +36,7 @@ import {
   WALL_THICKNESS,
   type RoomCategory,
 } from './assets/floorPlan';
-import {
-  createWallSegmentInstances,
-  type WallSegmentInstance,
-} from './assets/floorPlan/wallSegments';
+import type { WallSegmentInstance } from './assets/floorPlan/wallSegments';
 import {
   formatMessage,
   getAudioHudControlStrings,
@@ -153,6 +150,8 @@ import {
   createSceneDetailController,
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
+import { generateWallSegmentInstances } from './scene/level/generateWalls';
+import { PORTFOLIO_LEVEL } from './scene/level/portfolioLevel';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -1039,6 +1038,14 @@ function getRoomCategory(roomId: string): RoomCategory {
   return room?.category ?? 'interior';
 }
 
+function getLevelFloor(floorId: FloorId) {
+  const floor = PORTFOLIO_LEVEL.floors.find(
+    (candidate) => candidate.id === floorId
+  );
+  if (!floor) throw new Error(`Portfolio level is missing floor "${floorId}".`);
+  return floor;
+}
+
 const container = document.getElementById('app');
 
 if (!container) {
@@ -1873,15 +1880,18 @@ function initializeImmersiveScene(
   wallMaterial.lightMapIntensity = 0.68;
   fenceMaterial.lightMap = interiorLightmaps.wall;
   fenceMaterial.lightMapIntensity = 0.56;
-  const groundWallInstances = createWallSegmentInstances(FLOOR_PLAN, {
-    floorId: 'ground',
-    baseElevation: 0,
-    wallHeight: WALL_HEIGHT,
-    wallThickness: WALL_THICKNESS,
-    fenceHeight: FENCE_HEIGHT,
-    fenceThickness: FENCE_THICKNESS,
-    getRoomCategory,
-  });
+  const groundWallInstances = generateWallSegmentInstances(
+    getLevelFloor('ground'),
+    {
+      coordinateScale: FLOOR_PLAN_SCALE,
+      baseElevation: 0,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    }
+  );
   const groundWallMeshes = createWallSegmentMeshes({
     instances: groundWallInstances,
     groupName: 'GroundWallSegments',
@@ -2343,15 +2353,18 @@ function initializeImmersiveScene(
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
-  const upperWallInstances = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
-    floorId: 'upper',
-    baseElevation: upperFloorElevation,
-    wallHeight: WALL_HEIGHT,
-    wallThickness: WALL_THICKNESS,
-    fenceHeight: FENCE_HEIGHT,
-    fenceThickness: FENCE_THICKNESS,
-    getRoomCategory,
-  });
+  const upperWallInstances = generateWallSegmentInstances(
+    getLevelFloor('upper'),
+    {
+      coordinateScale: FLOOR_PLAN_SCALE,
+      baseElevation: upperFloorElevation,
+      wallHeight: WALL_HEIGHT,
+      wallThickness: WALL_THICKNESS,
+      fenceHeight: FENCE_HEIGHT,
+      fenceThickness: FENCE_THICKNESS,
+      getRoomCategory,
+    }
+  );
 
   const upperWallMeshes = createWallSegmentMeshes({
     instances: upperWallInstances,

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLOOR_PLAN,
+  FLOOR_PLAN_SCALE,
+  UPPER_FLOOR_PLAN,
+  WALL_THICKNESS,
+} from '../../../assets/floorPlan';
+import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { generateWallSegmentInstances } from '../generateWalls';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import type { FloorDefinition, LevelDefinition } from '../schema';
+
+const wallOptions = (baseElevation = 0) => ({
+  coordinateScale: FLOOR_PLAN_SCALE,
+  baseElevation,
+  wallHeight: 6,
+  wallThickness: WALL_THICKNESS,
+  fenceHeight: 2.4,
+  fenceThickness: 0.28,
+  getRoomCategory: (roomId: string) =>
+    roomId === 'backyard' ? ('exterior' as const) : ('interior' as const),
+});
+
+const wallSignature = (
+  instance: ReturnType<typeof generateWallSegmentInstances>[number]
+) => ({
+  collider: roundBounds(instance.collider),
+  dimensions: {
+    width: round(instance.dimensions.width),
+    height: round(instance.dimensions.height),
+    depth: round(instance.dimensions.depth),
+  },
+  isFence: instance.isFence,
+});
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function roundBounds(bounds: {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}) {
+  return {
+    minX: round(bounds.minX),
+    maxX: round(bounds.maxX),
+    minZ: round(bounds.minZ),
+    maxZ: round(bounds.maxZ),
+  };
+}
+
+function compareSignatures(
+  a: ReturnType<typeof wallSignature>,
+  b: ReturnType<typeof wallSignature>
+): number {
+  return JSON.stringify(a).localeCompare(JSON.stringify(b));
+}
+
+function getFloor(level: LevelDefinition, floorId: string): FloorDefinition {
+  const floor = level.floors.find((candidate) => candidate.id === floorId);
+  if (!floor) throw new Error(`Missing test floor ${floorId}.`);
+  return floor;
+}
+
+describe('generateWallSegmentInstances', () => {
+  it('matches legacy ground wall and fence bounds while using declarative source IDs', () => {
+    const generated = generateWallSegmentInstances(
+      getFloor(PORTFOLIO_LEVEL, 'ground'),
+      wallOptions()
+    );
+    const legacy = createWallSegmentInstances(FLOOR_PLAN, {
+      floorId: 'ground',
+      ...wallOptions(),
+    });
+
+    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
+      legacy.map(wallSignature).sort(compareSignatures)
+    );
+    expect(generated.every((instance) => instance.sourceId)).toBe(true);
+    expect(generated.map((instance) => instance.sourceId)).toContain(
+      'ground.living_room.south_wall'
+    );
+  });
+
+  it('matches legacy upper wall bounds without legacy room-doorway generation', () => {
+    const generated = generateWallSegmentInstances(
+      getFloor(PORTFOLIO_LEVEL, 'upper'),
+      wallOptions(9)
+    );
+    const legacy = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
+      floorId: 'upper',
+      ...wallOptions(9),
+    });
+
+    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
+      legacy.map(wallSignature).sort(compareSignatures)
+    );
+  });
+
+  it('responds to declarative wall edits without consuming semantic connections', () => {
+    const ground = getFloor(PORTFOLIO_LEVEL, 'ground');
+    const withoutSouthWall: FloorDefinition = {
+      ...ground,
+      roomConnections: [
+        ...(ground.roomConnections ?? []),
+        {
+          id: 'test-only-connection',
+          sourceId: 'ground.test_only.connection' as never,
+          floorId: 'ground',
+          rooms: ['livingRoom', 'studio'],
+        },
+      ],
+      walls: ground.walls.filter(
+        (wall) => wall.id !== 'living-room-south-wall'
+      ),
+    };
+
+    const baseline = generateWallSegmentInstances(ground, wallOptions());
+    const edited = generateWallSegmentInstances(
+      withoutSouthWall,
+      wallOptions()
+    );
+
+    expect(edited).toHaveLength(baseline.length - 1);
+    expect(
+      edited.some(
+        (instance) => instance.sourceId === 'ground.living_room.south_wall'
+      )
+    ).toBe(false);
+  });
+});

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -124,11 +124,71 @@ describe('generateWallSegmentInstances', () => {
       wallOptions()
     );
 
-    expect(edited).toHaveLength(baseline.length - 1);
+    const removedSourceId = 'ground.living_room.south_wall';
+
     expect(
-      edited.some(
-        (instance) => instance.sourceId === 'ground.living_room.south_wall'
-      )
+      baseline.some((instance) => instance.sourceId === removedSourceId)
+    ).toBe(true);
+    expect(
+      edited.some((instance) => instance.sourceId === removedSourceId)
     ).toBe(false);
+  });
+
+  it('uses per-wall thickness when offsetting exterior wall instances', () => {
+    const ground = getFloor(PORTFOLIO_LEVEL, 'ground');
+    const customThickness = WALL_THICKNESS * 2;
+    const thickenedSouthWall: FloorDefinition = {
+      ...ground,
+      walls: ground.walls.map((wall) =>
+        wall.id === 'living-room-south-wall'
+          ? { ...wall, thickness: customThickness }
+          : wall
+      ),
+    };
+
+    const sourceId = 'ground.living_room.south_wall';
+    const baselineSouthWalls = generateWallSegmentInstances(
+      ground,
+      wallOptions()
+    ).filter((instance) => instance.sourceId === sourceId);
+    const thickenedSouthWalls = generateWallSegmentInstances(
+      thickenedSouthWall,
+      wallOptions()
+    ).filter((instance) => instance.sourceId === sourceId);
+
+    expect(thickenedSouthWalls).toHaveLength(baselineSouthWalls.length);
+    expect(thickenedSouthWalls.length).toBeGreaterThan(0);
+    thickenedSouthWalls.forEach((instance, index) => {
+      expect(instance.thickness).toBe(customThickness);
+      expect(instance.dimensions.depth).toBe(customThickness);
+      expect(instance.center.z).toBeCloseTo(
+        baselineSouthWalls[index].center.z -
+          (customThickness - WALL_THICKNESS) / 2
+      );
+    });
+  });
+
+  it('rejects non-axis-aligned declarative walls instead of silently dropping them', () => {
+    const ground = getFloor(PORTFOLIO_LEVEL, 'ground');
+    const diagonalWall: FloorDefinition = {
+      ...ground,
+      walls: [
+        ...ground.walls,
+        {
+          id: 'test-diagonal-wall',
+          sourceId: 'ground.test.diagonal_wall' as never,
+          floorId: 'ground',
+          rooms: ['livingRoom'],
+          run: {
+            start: { x: 0, z: 0 },
+            end: { x: 1, z: 1 },
+          },
+        },
+      ],
+    };
+
+    expect(() =>
+      generateWallSegmentInstances(diagonalWall, wallOptions())
+    ).toThrow(/test-diagonal-wall.*non-axis-aligned segment/);
   });
 });

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,3 +1,4 @@
+import { MeshBasicMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -7,6 +8,7 @@ import {
   WALL_THICKNESS,
 } from '../../../assets/floorPlan';
 import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
 import type { FloorDefinition, LevelDefinition } from '../schema';
@@ -97,6 +99,46 @@ describe('generateWallSegmentInstances', () => {
 
     expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
       legacy.map(wallSignature).sort(compareSignatures)
+    );
+  });
+
+  it('adds stable source metadata to generated wall and fence meshes', () => {
+    const material = new MeshBasicMaterial({ color: 0xffffff });
+    const instances = [
+      ...generateWallSegmentInstances(
+        getFloor(PORTFOLIO_LEVEL, 'ground'),
+        wallOptions()
+      ),
+      ...generateWallSegmentInstances(
+        getFloor(PORTFOLIO_LEVEL, 'upper'),
+        wallOptions(9)
+      ),
+    ];
+
+    const { meshes } = createWallSegmentMeshes({
+      instances,
+      groupName: 'GeneratedWallMetadataTest',
+      getMaterial: () => material,
+    });
+
+    expect(meshes).toHaveLength(instances.length);
+    meshes.forEach((mesh, index) => {
+      const sourceId = instances[index]?.sourceId;
+
+      expect(typeof mesh.userData.levelSourceId).toBe('string');
+      expect(mesh.userData.levelSourceId).toBe(sourceId);
+      expect(mesh.userData.levelSource).toEqual({
+        sourceId,
+        sourceType: 'wall',
+      });
+    });
+
+    material.dispose();
+  });
+
+  it('keeps production declarative wall data free of wall-removal escape hatches', () => {
+    expect(JSON.stringify(PORTFOLIO_LEVEL)).not.toMatch(
+      /skip|former|removed|tombstone/i
     );
   });
 

--- a/src/scene/level/generateWalls.ts
+++ b/src/scene/level/generateWalls.ts
@@ -1,0 +1,405 @@
+import type { CombinedWallSegment, RoomWall } from '../../assets/floorPlan';
+import {
+  getWallOutwardDirection,
+  type WallSegmentInstance,
+  type WallSegmentOptions,
+} from '../../assets/floorPlan/wallSegments';
+import type { RectCollider } from '../../systems/collision';
+
+import type {
+  FloorDefinition,
+  SemanticRoomDefinition,
+  WallDefinition,
+} from './schema';
+
+const DEFAULT_INTERIOR_EXTENSION = 0.5;
+const DEFAULT_EXTERIOR_EXTENSION = 1;
+const AXIS_EPSILON = 1e-6;
+const LENGTH_EPSILON = 1e-4;
+
+type Axis = 'horizontal' | 'vertical';
+
+interface AtomicWallSegment {
+  wall: WallDefinition;
+  orientation: Axis;
+  start: { x: number; z: number };
+  end: { x: number; z: number };
+}
+
+interface WallCoverage {
+  wall: WallDefinition;
+  roomWalls: Array<{ id: string; wall: RoomWall }>;
+}
+
+export type DeclarativeWallGenerationOptions = Omit<
+  WallSegmentOptions,
+  'floorId' | 'levelId'
+> & {
+  coordinateScale?: number;
+};
+
+export function generateWallSegmentInstances(
+  floor: FloorDefinition,
+  options: DeclarativeWallGenerationOptions
+): WallSegmentInstance[] {
+  const segments = combineDeclarativeWallSegments(
+    scaleFloorDefinition(floor, options.coordinateScale ?? 1)
+  );
+  return segments.flatMap(
+    (segment) => createWallInstance(segment, floor, options) ?? []
+  );
+}
+
+function createWallInstance(
+  segment: CombinedWallSegment & { sourceWall: WallDefinition },
+  floor: FloorDefinition,
+  options: DeclarativeWallGenerationOptions
+): WallSegmentInstance | undefined {
+  const length =
+    segment.orientation === 'horizontal'
+      ? Math.abs(segment.end.x - segment.start.x)
+      : Math.abs(segment.end.z - segment.start.z);
+  if (length <= LENGTH_EPSILON) return undefined;
+
+  const roomCategories = segment.rooms.map((roomInfo) =>
+    options.getRoomCategory(roomInfo.id)
+  );
+  const hasExterior = roomCategories.some(
+    (category) => category === 'exterior'
+  );
+  const hasInterior = roomCategories.some(
+    (category) => category !== 'exterior'
+  );
+  const isMixed = hasExterior && hasInterior;
+  const isFence =
+    segment.sourceWall.wallKind === 'fence' || (hasExterior && !isMixed);
+  const thickness =
+    segment.sourceWall.thickness ??
+    (isFence ? options.fenceThickness : options.wallThickness);
+  const height =
+    segment.sourceWall.height ??
+    (isFence ? options.fenceHeight : options.wallHeight);
+  const isSharedInterior = segment.rooms.length > 1;
+  const extensionFactor = isSharedInterior
+    ? (options.interiorExtensionFactor ?? DEFAULT_INTERIOR_EXTENSION)
+    : (options.exteriorExtensionFactor ?? DEFAULT_EXTERIOR_EXTENSION);
+  const extension = thickness * extensionFactor;
+
+  const width =
+    segment.orientation === 'horizontal' ? length + extension : thickness;
+  const depth =
+    segment.orientation === 'horizontal' ? thickness : length + extension;
+  const baseX =
+    segment.orientation === 'horizontal'
+      ? (segment.start.x + segment.end.x) / 2
+      : segment.start.x;
+  const baseZ =
+    segment.orientation === 'horizontal'
+      ? segment.start.z
+      : (segment.start.z + segment.end.z) / 2;
+
+  let offsetX = 0;
+  let offsetZ = 0;
+  if (!isSharedInterior && segment.rooms.length > 0) {
+    const outward = getWallOutwardDirection(segment.rooms[0].wall);
+    offsetX = outward.x * (options.wallThickness / 2);
+    offsetZ = outward.z * (options.wallThickness / 2);
+  }
+
+  const center = {
+    x: baseX + offsetX,
+    y: options.baseElevation + height / 2,
+    z: baseZ + offsetZ,
+  };
+  const collider: RectCollider = {
+    minX: center.x - width / 2,
+    maxX: center.x + width / 2,
+    minZ: center.z - depth / 2,
+    maxZ: center.z + depth / 2,
+  };
+
+  return {
+    segment,
+    segmentId: createSegmentId(segment),
+    sourceId: segment.sourceWall.sourceId,
+    center,
+    dimensions: { width, height, depth },
+    collider,
+    isFence,
+    isSharedInterior,
+    thickness,
+  };
+}
+
+function combineDeclarativeWallSegments(
+  floor: FloorDefinition
+): Array<CombinedWallSegment & { sourceWall: WallDefinition }> {
+  const atomic = floor.walls.flatMap(expandWallDefinition);
+  return [
+    ...combineAxis(floor, atomic, 'horizontal'),
+    ...combineAxis(floor, atomic, 'vertical'),
+  ];
+}
+
+function combineAxis(
+  floor: FloorDefinition,
+  atomic: AtomicWallSegment[],
+  orientation: Axis
+): Array<CombinedWallSegment & { sourceWall: WallDefinition }> {
+  const grouped = new Map<string, AtomicWallSegment[]>();
+  atomic
+    .filter((segment) => segment.orientation === orientation)
+    .forEach((segment) => {
+      const key = formatKey(
+        orientation === 'horizontal' ? segment.start.z : segment.start.x
+      );
+      grouped.set(key, [...(grouped.get(key) ?? []), segment]);
+    });
+
+  const combined: Array<CombinedWallSegment & { sourceWall: WallDefinition }> =
+    [];
+  for (const [key, segments] of grouped) {
+    const breakpoints = new Set<number>();
+    segments.forEach((segment) => {
+      const [start, end] = getAxisRange(segment);
+      breakpoints.add(start);
+      breakpoints.add(end);
+      getRoomBreakpointsForSegment(floor, segment).forEach((point) =>
+        breakpoints.add(point)
+      );
+    });
+    const sorted = [...breakpoints].sort((a, b) => a - b);
+    for (let index = 0; index < sorted.length - 1; index += 1) {
+      const start = sorted[index];
+      const end = sorted[index + 1];
+      if (end - start <= LENGTH_EPSILON) continue;
+      const covering = segments.filter((segment) => {
+        const [segmentStart, segmentEnd] = getAxisRange(segment);
+        return (
+          segmentStart <= start + AXIS_EPSILON &&
+          segmentEnd >= end - AXIS_EPSILON
+        );
+      });
+      if (covering.length === 0) continue;
+      const sourceWall = covering[0].wall;
+      const rooms = uniqueRoomWalls(
+        covering.flatMap((coverage) =>
+          getRoomWallsForSpan(floor, coverage.wall, orientation, start, end)
+        )
+      );
+      combined.push({
+        orientation,
+        start:
+          orientation === 'horizontal'
+            ? { x: start, z: Number(key) }
+            : { x: Number(key), z: start },
+        end:
+          orientation === 'horizontal'
+            ? { x: end, z: Number(key) }
+            : { x: Number(key), z: end },
+        rooms,
+        sourceWall,
+      });
+    }
+  }
+  return combined;
+}
+
+function expandWallDefinition(wall: WallDefinition): AtomicWallSegment[] {
+  const segments = 'segments' in wall ? wall.segments : splitRun(wall.run);
+  return segments.flatMap((segment) => {
+    const orientation = getOrientation(segment.start, segment.end);
+    if (!orientation) return [];
+    return [{ wall, orientation, start: segment.start, end: segment.end }];
+  });
+}
+
+function splitRun(
+  run: WallDefinition['run']
+): Array<{ start: { x: number; z: number }; end: { x: number; z: number } }> {
+  const length = Math.hypot(run.end.x - run.start.x, run.end.z - run.start.z);
+  if (length <= AXIS_EPSILON) return [];
+  const gaps = [...(run.gaps ?? [])]
+    .map((gap) => ({
+      start: Math.max(0, Math.min(length, gap.start)),
+      end: Math.max(0, Math.min(length, gap.end)),
+    }))
+    .filter((gap) => gap.end - gap.start > AXIS_EPSILON)
+    .sort((a, b) => a.start - b.start);
+  const spans: Array<{ start: number; end: number }> = [];
+  let cursor = 0;
+  gaps.forEach((gap) => {
+    if (gap.start > cursor) spans.push({ start: cursor, end: gap.start });
+    cursor = Math.max(cursor, gap.end);
+  });
+  if (cursor < length) spans.push({ start: cursor, end: length });
+  return spans.map((span) => ({
+    start: interpolate(run, span.start / length),
+    end: interpolate(run, span.end / length),
+  }));
+}
+
+function interpolate(
+  run: WallDefinition['run'],
+  ratio: number
+): { x: number; z: number } {
+  return {
+    x: run.start.x + (run.end.x - run.start.x) * ratio,
+    z: run.start.z + (run.end.z - run.start.z) * ratio,
+  };
+}
+
+function getOrientation(
+  start: { x: number; z: number },
+  end: { x: number; z: number }
+): Axis | undefined {
+  if (Math.abs(start.z - end.z) <= AXIS_EPSILON) return 'horizontal';
+  if (Math.abs(start.x - end.x) <= AXIS_EPSILON) return 'vertical';
+  return undefined;
+}
+
+function getAxisRange(segment: AtomicWallSegment): [number, number] {
+  const a =
+    segment.orientation === 'horizontal' ? segment.start.x : segment.start.z;
+  const b =
+    segment.orientation === 'horizontal' ? segment.end.x : segment.end.z;
+  return [Math.min(a, b), Math.max(a, b)];
+}
+
+function getRoomBreakpointsForSegment(
+  floor: FloorDefinition,
+  segment: AtomicWallSegment
+): number[] {
+  return (segment.wall.rooms ?? []).flatMap((roomId) => {
+    const room = floor.rooms.find((candidate) => candidate.id === roomId);
+    const roomWall = room ? getRoomWallForWall(room, segment.wall) : undefined;
+    if (!room || !roomWall) return [];
+    return segment.orientation === 'horizontal'
+      ? [room.bounds.minX, room.bounds.maxX]
+      : [room.bounds.minZ, room.bounds.maxZ];
+  });
+}
+
+function getRoomWallsForSpan(
+  floor: FloorDefinition,
+  wall: WallDefinition,
+  orientation: Axis,
+  spanStart: number,
+  spanEnd: number
+): WallCoverage['roomWalls'] {
+  return (wall.rooms ?? []).flatMap((roomId) => {
+    const room = floor.rooms.find((candidate) => candidate.id === roomId);
+    const roomWall = room ? getRoomWallForWall(room, wall) : undefined;
+    if (!roomWall || !room) return [];
+    const roomStart =
+      orientation === 'horizontal' ? room.bounds.minX : room.bounds.minZ;
+    const roomEnd =
+      orientation === 'horizontal' ? room.bounds.maxX : room.bounds.maxZ;
+    if (
+      roomStart <= spanStart + AXIS_EPSILON &&
+      roomEnd >= spanEnd - AXIS_EPSILON
+    ) {
+      return [{ id: roomId, wall: roomWall }];
+    }
+    return [];
+  });
+}
+
+function getRoomWallForWall(
+  room: SemanticRoomDefinition,
+  wall: WallDefinition
+): RoomWall | undefined {
+  const start = 'run' in wall ? wall.run.start : wall.segments[0]?.start;
+  const end = 'run' in wall ? wall.run.end : wall.segments[0]?.end;
+  if (!start || !end) return undefined;
+  if (Math.abs(start.z - end.z) <= AXIS_EPSILON) {
+    if (Math.abs(start.z - room.bounds.maxZ) <= AXIS_EPSILON) return 'north';
+    if (Math.abs(start.z - room.bounds.minZ) <= AXIS_EPSILON) return 'south';
+  }
+  if (Math.abs(start.x - end.x) <= AXIS_EPSILON) {
+    if (Math.abs(start.x - room.bounds.maxX) <= AXIS_EPSILON) return 'east';
+    if (Math.abs(start.x - room.bounds.minX) <= AXIS_EPSILON) return 'west';
+  }
+  return undefined;
+}
+
+function uniqueRoomWalls(
+  rooms: Array<{ id: string; wall: RoomWall }>
+): Array<{ id: string; wall: RoomWall }> {
+  const seen = new Set<string>();
+  return rooms.filter((room) => {
+    const key = `${room.id}:${room.wall}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function createSegmentId(segment: CombinedWallSegment): string {
+  const rooms = segment.rooms
+    .map((room) => `${room.id}:${room.wall}`)
+    .sort()
+    .join('|');
+  return [
+    segment.orientation,
+    formatPoint(segment.start),
+    formatPoint(segment.end),
+    rooms || 'none',
+  ].join('|');
+}
+
+function formatPoint(point: { x: number; z: number }): string {
+  return `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
+}
+
+function formatKey(value: number): string {
+  return value.toFixed(3);
+}
+
+function scaleFloorDefinition(
+  floor: FloorDefinition,
+  scale: number
+): FloorDefinition {
+  if (scale === 1) return floor;
+  const scalePoint = (point: { x: number; z: number }) => ({
+    x: point.x * scale,
+    z: point.z * scale,
+  });
+  return {
+    ...floor,
+    outline: floor.outline.map(([x, z]) => [x * scale, z * scale]),
+    rooms: floor.rooms.map((room) => ({
+      ...room,
+      bounds: {
+        minX: room.bounds.minX * scale,
+        maxX: room.bounds.maxX * scale,
+        minZ: room.bounds.minZ * scale,
+        maxZ: room.bounds.maxZ * scale,
+      },
+    })),
+    walls: floor.walls.map((wall) => {
+      if ('run' in wall) {
+        return {
+          ...wall,
+          run: {
+            ...wall.run,
+            start: scalePoint(wall.run.start),
+            end: scalePoint(wall.run.end),
+            gaps: wall.run.gaps?.map((gap) => ({
+              ...gap,
+              start: gap.start * scale,
+              end: gap.end * scale,
+            })),
+          },
+        };
+      }
+      return {
+        ...wall,
+        segments: wall.segments.map((segment) => ({
+          start: scalePoint(segment.start),
+          end: scalePoint(segment.end),
+        })),
+      };
+    }),
+  };
+}

--- a/src/scene/level/generateWalls.ts
+++ b/src/scene/level/generateWalls.ts
@@ -26,11 +26,6 @@ interface AtomicWallSegment {
   end: { x: number; z: number };
 }
 
-interface WallCoverage {
-  wall: WallDefinition;
-  roomWalls: Array<{ id: string; wall: RoomWall }>;
-}
-
 export type DeclarativeWallGenerationOptions = Omit<
   WallSegmentOptions,
   'floorId' | 'levelId'
@@ -46,13 +41,12 @@ export function generateWallSegmentInstances(
     scaleFloorDefinition(floor, options.coordinateScale ?? 1)
   );
   return segments.flatMap(
-    (segment) => createWallInstance(segment, floor, options) ?? []
+    (segment) => createWallInstance(segment, options) ?? []
   );
 }
 
 function createWallInstance(
   segment: CombinedWallSegment & { sourceWall: WallDefinition },
-  floor: FloorDefinition,
   options: DeclarativeWallGenerationOptions
 ): WallSegmentInstance | undefined {
   const length =
@@ -102,8 +96,10 @@ function createWallInstance(
   let offsetZ = 0;
   if (!isSharedInterior && segment.rooms.length > 0) {
     const outward = getWallOutwardDirection(segment.rooms[0].wall);
-    offsetX = outward.x * (options.wallThickness / 2);
-    offsetZ = outward.z * (options.wallThickness / 2);
+    const offsetThickness =
+      segment.sourceWall.thickness ?? options.wallThickness;
+    offsetX = outward.x * (offsetThickness / 2);
+    offsetZ = outward.z * (offsetThickness / 2);
   }
 
   const center = {
@@ -209,7 +205,13 @@ function expandWallDefinition(wall: WallDefinition): AtomicWallSegment[] {
   const segments = 'segments' in wall ? wall.segments : splitRun(wall.run);
   return segments.flatMap((segment) => {
     const orientation = getOrientation(segment.start, segment.end);
-    if (!orientation) return [];
+    if (!orientation) {
+      throw new Error(
+        `Wall ${wall.id} contains a non-axis-aligned segment from ${formatPoint(
+          segment.start
+        )} to ${formatPoint(segment.end)}. Declarative wall generation only supports horizontal or vertical walls.`
+      );
+    }
     return [{ wall, orientation, start: segment.start, end: segment.end }];
   });
 }
@@ -286,7 +288,7 @@ function getRoomWallsForSpan(
   orientation: Axis,
   spanStart: number,
   spanEnd: number
-): WallCoverage['roomWalls'] {
+): Array<{ id: string; wall: RoomWall }> {
   return (wall.rooms ?? []).flatMap((roomId) => {
     const room = floor.rooms.find((candidate) => candidate.id === roomId);
     const roomWall = room ? getRoomWallForWall(room, wall) : undefined;


### PR DESCRIPTION
### Motivation
- Move wall/fence visual meshes and gameplay colliders off the legacy room-doorway adapter and make them originate from the declarative `FloorDefinition.walls` source so edits to source drive final geometry.
- Preserve current visible geometry, collider bounds, and seam/extension behavior while threading stable `sourceId` metadata downstream for debug and tooling.

### Description
- Add `src/scene/level/generateWalls.ts` implementing `generateWallSegmentInstances(...)` which expands `WallDefinition` runs/segments, splits around declared gaps and room seams, applies generator-owned seam extensions, and emits wall/fence instances with `segmentId`, `sourceId`, collider and dimension data.
- Wire `main.ts` to consume `PORTFOLIO_LEVEL` floors via a `getLevelFloor(...)` helper and call `generateWallSegmentInstances(...)` for ground and upper walls, pushing collider source metadata and setting mesh `userData.levelSourceId`.
- Add unit tests `src/scene/level/__tests__/generateWalls.test.ts` that compare generated output to the legacy adapter for ground and upper floors, assert every generated wall has a `sourceId`, and verify declarative edits add/remove generated walls without consuming semantic `roomConnections`.
- Update the design doc and extend the stairs Playwright spec to query known wall solids/colliders by semantic source ID so debug APIs expose source-backed metadata.

### Testing
- Ran `npm run format:write` — succeeded.
- Ran `npm run lint` — succeeded.
- Ran focused unit tests `npm run test:ci -- src/scene/level/__tests__/generateWalls.test.ts src/scene/structures/__tests__/wallSegmentsMesh.test.ts` — succeeded; the new tests pass and confirm parity with legacy bounds and presence of `sourceId`.
- Ran full `npm run test:ci` — succeeded (entire suite passed in this environment).
- Ran `npm run docs:check` — passed (link checker reported external fetch warnings but completed successfully).
- Ran `npm run smoke` and `npm run build` — succeeded (build artifacts produced).
- Playwright: ran `npx playwright install chromium` (download succeeded), but `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` could not run to completion in this environment because the host is missing required browser dependencies; install-time/download succeeded but test execution is blocked by missing system libs (e.g. `libatk1.0-0t64`, `libatk-bridge2.0-0t64`, `libatspi2.0-0t64`, `libxcomposite1`, `libxdamage1`, `libxfixes3`, `libxrandr2`, `libgbm1`, `libxkbcommon0`, `libasound2t64`).
- Residual: Playwright browser tests should be rerun in CI or a host with the listed native packages installed to fully verify runtime interactions and debug-collider queries by `sourceId`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a332fa89f98832fb20c71cfaaed2e04)