### PR TITLE
🏗️ Generate floor surfaces from declarative source data

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -111,11 +111,14 @@ not as old blockers that are removed later.
 
 ### Floor surfaces
 
-Floor surfaces describe current walkable and rendered floor pieces. They may be
+Floor surfaces describe current walkable and rendered floor pieces and now carry
+stable semantic source IDs through generated meshes and debug solids. They may be
 large source rectangles or polygons while the generator clips them into smaller
 renderable meshes around stairs, voids, thresholds, or material regions. Source
 floor data should describe the intended current surface, not the history of a
-former full floor plus a list of removed holes.
+former full floor plus a list of removed holes. Current stairwell clipping remains
+generator-owned so authored production data names the present landing surfaces
+rather than preserving historical missing-floor artifacts.
 
 ### Safety colliders
 
@@ -257,7 +260,7 @@ arch, trim, threshold, or rail should be declared as a scene object or current
 wall/railing; a walkable opening does not need a former blocker record.
 
 Current ground and upper room bounds, wall runs, intentional wall-run gaps,
-floor surfaces, and semantic room connections now live in
+floor surfaces with source IDs, and semantic room connections now live in
 `src/scene/level/portfolioLevel.ts`. The temporary adapter in
 `src/scene/level/compileLegacyFloorPlan.ts` compiles a declarative floor
 back to the existing `FloorPlanDefinition` shape for migration checks and
@@ -287,8 +290,11 @@ semantic `roomConnections` intentionally do not create or remove geometry.
    `src/scene/level/generateWalls.ts`; the legacy room-doorway wall generator is
    retained only as a compatibility reference while later phases migrate floors,
    safety colliders, and inventory tooling.
-8. **Generate floor outputs from source.** Derive floor surfaces from source data,
-   allowing generator-owned splitting and clipping where useful.
+8. **Generate floor outputs from source.** Floor meshes now derive from
+   `FloorDefinition.floorSurfaces` via
+   `src/scene/level/generateFloorSurfaces.ts`, with generator-owned splitting
+   and clipping preserving the current stairwell void while propagating
+   `floorSurface` source metadata to debug solids.
 9. **Move stair and void safety.** Convert stair, landing, and void guard
    colliders into purpose-labeled source-ID-backed safety colliders.
 10. **Move scene objects and policies.** Place visible/interactable objects and

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,7 +152,10 @@ import {
 } from './scene/graphics/sceneDetailPolicy';
 import { generateFloorSurfaces } from './scene/level/generateFloorSurfaces';
 import { generateWallSegmentInstances } from './scene/level/generateWalls';
-import { PORTFOLIO_LEVEL } from './scene/level/portfolioLevel';
+import {
+  PORTFOLIO_LEVEL,
+  UPPER_LANDING_FLOOR_MAIN_ID,
+} from './scene/level/portfolioLevel';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -2308,14 +2311,17 @@ function initializeImmersiveScene(
         }
       : undefined;
   const upperFloorSurfaceCutouts =
-    upperLandingCutouts && upperStairwellOpening && stairRunApproachFootprint
+    upperLandingCutouts &&
+    upperLandingRoom &&
+    upperStairwellOpening &&
+    stairRunApproachFootprint
       ? {
-          'upperLanding-floor-main': [
+          [UPPER_LANDING_FLOOR_MAIN_ID]: [
             ...upperLandingCutouts.upperLanding,
             {
               minX: stairRunApproachFootprint.minX,
               maxX: stairRunApproachFootprint.maxX,
-              minZ: upperLandingRoom!.bounds.minZ,
+              minZ: upperLandingRoom.bounds.minZ,
               maxZ: upperStairwellOpening.minZ,
             },
           ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,6 +150,7 @@ import {
   createSceneDetailController,
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
+import { generateFloorSurfaces } from './scene/level/generateFloorSurfaces';
 import { generateWallSegmentInstances } from './scene/level/generateWalls';
 import { PORTFOLIO_LEVEL } from './scene/level/portfolioLevel';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
@@ -236,7 +237,6 @@ import {
   createF2ClipboardConsole,
   type F2ClipboardConsoleBuild,
 } from './scene/structures/f2ClipboardConsole';
-import { createRoomFloorTiles } from './scene/structures/floorTiles';
 import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
@@ -1851,7 +1851,7 @@ function initializeImmersiveScene(
     roughness: 0.58,
     metalness: 0.18,
   });
-  const floorTiles = createRoomFloorTiles(FLOOR_PLAN.rooms, {
+  const floorTiles = generateFloorSurfaces(getLevelFloor('ground'), {
     material: floorMaterial,
     elevation: 0,
     groupName: 'GroundFloorTiles',
@@ -2307,12 +2307,26 @@ function initializeImmersiveScene(
           }),
         }
       : undefined;
-  const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+  const upperFloorSurfaceCutouts =
+    upperLandingCutouts && upperStairwellOpening && stairRunApproachFootprint
+      ? {
+          'upperLanding-floor-main': [
+            ...upperLandingCutouts.upperLanding,
+            {
+              minX: stairRunApproachFootprint.minX,
+              maxX: stairRunApproachFootprint.maxX,
+              minZ: upperLandingRoom!.bounds.minZ,
+              maxZ: upperStairwellOpening.minZ,
+            },
+          ],
+        }
+      : undefined;
+  const upperFloorTiles = generateFloorSurfaces(getLevelFloor('upper'), {
     material: upperFloorMaterial,
     elevation: upperFloorElevation,
     thickness: STAIRCASE_CONFIG.landing.thickness,
     groupName: 'UpperFloorTiles',
-    cutoutsByRoom: upperLandingCutouts,
+    cutoutsBySurfaceId: upperFloorSurfaceCutouts,
   });
   upperFloorGroup.add(upperFloorTiles.group);
 

--- a/src/scene/level/__tests__/generateFloorSurfaces.test.ts
+++ b/src/scene/level/__tests__/generateFloorSurfaces.test.ts
@@ -1,6 +1,7 @@
 import { MeshStandardMaterial } from 'three';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { createSolidVisualizer } from '../../debug/solidVisualizer';
 import { generateFloorSurfaces } from '../generateFloorSurfaces';
 import {
   PORTFOLIO_LEVEL,
@@ -50,6 +51,27 @@ describe('generateFloorSurfaces', () => {
         (tile) => tile.mesh.userData.levelSource?.sourceType === 'floorSurface'
       )
     ).toBe(true);
+  });
+
+  it('registers generated floor solids for debug lookup by source ID', () => {
+    const build = generateFloorSurfaces(getFloor('ground'), {
+      material: new MeshStandardMaterial(),
+      scale: 1,
+    });
+    const visualizer = createSolidVisualizer({ enabled: true });
+
+    visualizer.register(build.group);
+
+    const matches = visualizer.getSolidsBySourceId(
+      'ground.livingRoom.floor.main'
+    );
+
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches.every((solid) => solid.sourceType === 'floorSurface')).toBe(
+      true
+    );
+
+    visualizer.dispose();
   });
 
   it('uses the expected stable floor surface source IDs', () => {

--- a/src/scene/level/__tests__/generateFloorSurfaces.test.ts
+++ b/src/scene/level/__tests__/generateFloorSurfaces.test.ts
@@ -1,0 +1,103 @@
+import { MeshStandardMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { generateFloorSurfaces } from '../generateFloorSurfaces';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+
+const getFloor = (floorId: string) => {
+  const floor = PORTFOLIO_LEVEL.floors.find(
+    (candidate) => candidate.id === floorId
+  );
+  if (!floor) throw new Error(`Missing floor ${floorId}`);
+  return floor;
+};
+
+const sampleCoveredBy = (
+  tiles: ReturnType<typeof generateFloorSurfaces>['tiles'],
+  x: number,
+  z: number
+): boolean =>
+  tiles.some(
+    (tile) =>
+      tile.bounds.minX <= x &&
+      tile.bounds.maxX >= x &&
+      tile.bounds.minZ <= z &&
+      tile.bounds.maxZ >= z
+  );
+
+describe('generateFloorSurfaces', () => {
+  it('adds source metadata to every generated floor tile', () => {
+    const build = generateFloorSurfaces(getFloor('ground'), {
+      material: new MeshStandardMaterial(),
+      scale: 1,
+    });
+
+    expect(build.tiles.length).toBeGreaterThan(0);
+    expect(
+      build.tiles.every(
+        (tile) => typeof tile.mesh.userData.levelSourceId === 'string'
+      )
+    ).toBe(true);
+    expect(
+      build.tiles.every(
+        (tile) => tile.mesh.userData.levelSource?.sourceType === 'floorSurface'
+      )
+    ).toBe(true);
+  });
+
+  it('uses the expected stable floor surface source IDs', () => {
+    const sourceIds = PORTFOLIO_LEVEL.floors.flatMap((floor) =>
+      floor.floorSurfaces.map((surface) => String(surface.sourceId))
+    );
+
+    expect(sourceIds).toEqual(
+      expect.arrayContaining([
+        'ground.livingRoom.floor.main',
+        'upper.upperLanding.floor.main',
+        'upper.upperLanding.floor.stairEdgePiece',
+      ])
+    );
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+  });
+
+  it('regenerates changed bounds when source floor surfaces are edited', () => {
+    const floor = getFloor('ground');
+    const baseline = generateFloorSurfaces(floor, { scale: 1 }).tiles.find(
+      (tile) => tile.sourceId === 'ground.livingRoom.floor.main'
+    );
+    const editedFloor = {
+      ...floor,
+      floorSurfaces: floor.floorSurfaces.map((surface) =>
+        surface.sourceId === 'ground.livingRoom.floor.main'
+          ? {
+              ...surface,
+              bounds: { ...surface.bounds, maxX: surface.bounds.maxX - 2 },
+            }
+          : surface
+      ),
+    };
+    const edited = generateFloorSurfaces(editedFloor, { scale: 1 }).tiles.find(
+      (tile) => tile.sourceId === 'ground.livingRoom.floor.main'
+    );
+
+    expect(edited?.bounds.maxX).toBe((baseline?.bounds.maxX ?? 0) - 2);
+  });
+
+  it('keeps the source-backed upper stairwell void open while preserving egress samples', () => {
+    const upper = getFloor('upper');
+    const build = generateFloorSurfaces(upper, {
+      scale: 1,
+      cutoutsBySurfaceId: {
+        'upperLanding-floor-main': [
+          { minX: 4.65, maxX: 7.75, minZ: -15.95, maxZ: -8 },
+          { minX: 7.75, maxX: 7.95, minZ: -16, maxZ: -15.95 },
+        ],
+      },
+    });
+
+    expect(sampleCoveredBy(build.tiles, 6.2, -12)).toBe(false);
+    expect(sampleCoveredBy(build.tiles, 3, -12)).toBe(true);
+    expect(sampleCoveredBy(build.tiles, 8.5, -12)).toBe(true);
+    expect(sampleCoveredBy(build.tiles, 6.2, -15.975)).toBe(true);
+  });
+});

--- a/src/scene/level/__tests__/generateFloorSurfaces.test.ts
+++ b/src/scene/level/__tests__/generateFloorSurfaces.test.ts
@@ -1,8 +1,11 @@
 import { MeshStandardMaterial } from 'three';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { generateFloorSurfaces } from '../generateFloorSurfaces';
-import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import {
+  PORTFOLIO_LEVEL,
+  UPPER_LANDING_FLOOR_MAIN_ID,
+} from '../portfolioLevel';
 
 const getFloor = (floorId: string) => {
   const floor = PORTFOLIO_LEVEL.floors.find(
@@ -26,6 +29,10 @@ const sampleCoveredBy = (
   );
 
 describe('generateFloorSurfaces', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('adds source metadata to every generated floor tile', () => {
     const build = generateFloorSurfaces(getFloor('ground'), {
       material: new MeshStandardMaterial(),
@@ -88,7 +95,7 @@ describe('generateFloorSurfaces', () => {
     const build = generateFloorSurfaces(upper, {
       scale: 1,
       cutoutsBySurfaceId: {
-        'upperLanding-floor-main': [
+        [UPPER_LANDING_FLOOR_MAIN_ID]: [
           { minX: 4.65, maxX: 7.75, minZ: -15.95, maxZ: -8 },
           { minX: 7.75, maxX: 7.95, minZ: -16, maxZ: -15.95 },
         ],
@@ -99,5 +106,20 @@ describe('generateFloorSurfaces', () => {
     expect(sampleCoveredBy(build.tiles, 3, -12)).toBe(true);
     expect(sampleCoveredBy(build.tiles, 8.5, -12)).toBe(true);
     expect(sampleCoveredBy(build.tiles, 6.2, -15.975)).toBe(true);
+  });
+
+  it('warns when cutouts reference an unknown floor surface ID', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    generateFloorSurfaces(getFloor('upper'), {
+      scale: 1,
+      cutoutsBySurfaceId: {
+        staleSurfaceId: [{ minX: 0, maxX: 1, minZ: 0, maxZ: 1 }],
+      },
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      'Ignoring cutouts for unknown floor surface IDs: staleSurfaceId.'
+    );
   });
 });

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -144,9 +144,9 @@ describe('declarative level schema validation', () => {
       'former',
       'removed',
       'debugonlyremoval',
-      'Former',
-      'Removed',
-      'DebugOnlyRemoval',
+      'fOrmer',
+      'rEmoved',
+      'debugOnlyRemoval',
     ]) {
       const level = createLevel();
       level.floors[0].walls[0].sourceId = sourceId(`ground.gallery.${term}`);

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -140,7 +140,14 @@ describe('declarative level schema validation', () => {
   });
 
   it('rejects source IDs that look like tombstone/debug-only removal records', () => {
-    for (const term of ['former', 'removed', 'debugonlyremoval']) {
+    for (const term of [
+      'former',
+      'removed',
+      'debugonlyremoval',
+      'Former',
+      'Removed',
+      'DebugOnlyRemoval',
+    ]) {
       const level = createLevel();
       level.floors[0].walls[0].sourceId = sourceId(`ground.gallery.${term}`);
 

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -17,6 +17,7 @@ const validIds = [
   'backyard.greenhouse_path.east_fence.section03',
   'ground.room_01.wall-02.generated_collider',
   'ground.livingRoom.floor.main',
+  'upper.upperLanding.floor.stairEdgePiece',
 ];
 
 const invalidIds = [
@@ -26,6 +27,7 @@ const invalidIds = [
   '.ground.living_room',
   'ground.living_room.',
   '',
+  'Ground.living_room.north_wall',
 ];
 
 describe('level source ID validation', () => {
@@ -61,6 +63,9 @@ describe('level source ID composition', () => {
 
   it('fails instead of silently normalizing malformed parts', () => {
     expect(() => joinLevelSourceId('ground', '', 'northWall')).toThrow(/empty/);
+    expect(() => joinLevelSourceId('ground', 'LivingRoom')).toThrow(
+      /Invalid level source ID/
+    );
     expect(() => joinLevelSourceId('ground.living_room', 'north_wall')).toThrow(
       /dots/
     );

--- a/src/scene/level/__tests__/sourceIds.test.ts
+++ b/src/scene/level/__tests__/sourceIds.test.ts
@@ -16,11 +16,11 @@ const validIds = [
   'ground.living_room.media_wall.scene_object',
   'backyard.greenhouse_path.east_fence.section03',
   'ground.room_01.wall-02.generated_collider',
+  'ground.livingRoom.floor.main',
 ];
 
 const invalidIds = [
   'ground living_room.north_wall',
-  'Ground.living_room.north_wall',
   'ground..livingRoom',
   'ground/living_room/north_wall',
   '.ground.living_room',
@@ -63,9 +63,6 @@ describe('level source ID composition', () => {
     expect(() => joinLevelSourceId('ground', '', 'northWall')).toThrow(/empty/);
     expect(() => joinLevelSourceId('ground.living_room', 'north_wall')).toThrow(
       /dots/
-    );
-    expect(() => joinLevelSourceId('ground', 'LivingRoom')).toThrow(
-      /Invalid level source ID/
     );
   });
 });

--- a/src/scene/level/generateFloorSurfaces.ts
+++ b/src/scene/level/generateFloorSurfaces.ts
@@ -1,0 +1,99 @@
+import type { Bounds2D, RoomDefinition } from '../../assets/floorPlan';
+import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import {
+  createRoomFloorTiles,
+  type RoomFloorBuild,
+  type RoomFloorCutout,
+  type RoomFloorOptions,
+} from '../structures/floorTiles';
+
+import type { FloorDefinition, FloorSurfaceDefinition } from './schema';
+
+export interface FloorSurfaceGenerationOptions extends RoomFloorOptions {
+  readonly scale?: number;
+  readonly cutoutsBySurfaceId?: Readonly<Record<string, RoomFloorCutout[]>>;
+}
+
+export interface GeneratedFloorSurfaceTile {
+  readonly surfaceId: string;
+  readonly sourceId: FloorSurfaceDefinition['sourceId'];
+  readonly roomId?: string;
+  readonly mesh: RoomFloorBuild['tiles'][number]['mesh'];
+  readonly bounds: Bounds2D;
+}
+
+export interface GeneratedFloorSurfaceBuild {
+  readonly group: RoomFloorBuild['group'];
+  readonly tiles: GeneratedFloorSurfaceTile[];
+}
+
+const scaleBounds = (bounds: Bounds2D, scale: number): Bounds2D => ({
+  minX: bounds.minX * scale,
+  maxX: bounds.maxX * scale,
+  minZ: bounds.minZ * scale,
+  maxZ: bounds.maxZ * scale,
+});
+
+const makeRoomSurfaceKey = (surface: FloorSurfaceDefinition): string =>
+  `${surface.roomId ?? surface.id}:${surface.id}`;
+
+export function generateFloorSurfaces(
+  floor: FloorDefinition,
+  options: FloorSurfaceGenerationOptions = {}
+): GeneratedFloorSurfaceBuild {
+  const scale = options.scale ?? FLOOR_PLAN_SCALE;
+  const roomNames = new Map(floor.rooms.map((room) => [room.id, room.name]));
+  const surfacesByKey = new Map<string, FloorSurfaceDefinition>();
+
+  const surfaceRooms: RoomDefinition[] = floor.floorSurfaces.map((surface) => {
+    const roomId = surface.roomId ?? surface.id;
+    const key = makeRoomSurfaceKey(surface);
+    surfacesByKey.set(key, surface);
+
+    return {
+      id: key,
+      name: roomNames.get(roomId) ?? surface.id,
+      bounds: scaleBounds(surface.bounds, scale),
+      ledColor: 0,
+    };
+  });
+
+  const cutoutsByRoom = Object.fromEntries(
+    floor.floorSurfaces.map((surface) => [
+      makeRoomSurfaceKey(surface),
+      options.cutoutsBySurfaceId?.[surface.id] ?? [],
+    ])
+  );
+
+  const build = createRoomFloorTiles(surfaceRooms, {
+    ...options,
+    cutoutsByRoom,
+    includeExterior: true,
+  });
+
+  const tiles = build.tiles.map((tile): GeneratedFloorSurfaceTile => {
+    const surface = surfacesByKey.get(tile.roomId);
+    if (!surface) {
+      throw new Error(
+        `Generated floor tile references unknown surface "${tile.roomId}".`
+      );
+    }
+
+    tile.mesh.userData.levelSourceId = surface.sourceId;
+    tile.mesh.userData.levelSource = {
+      sourceId: surface.sourceId,
+      sourceType: 'floorSurface',
+      purpose: surface.purpose,
+    };
+
+    return {
+      surfaceId: surface.id,
+      sourceId: surface.sourceId,
+      roomId: surface.roomId,
+      mesh: tile.mesh,
+      bounds: tile.bounds,
+    };
+  });
+
+  return { group: build.group, tiles };
+}

--- a/src/scene/level/generateFloorSurfaces.ts
+++ b/src/scene/level/generateFloorSurfaces.ts
@@ -9,7 +9,8 @@ import {
 
 import type { FloorDefinition, FloorSurfaceDefinition } from './schema';
 
-export interface FloorSurfaceGenerationOptions extends RoomFloorOptions {
+export interface FloorSurfaceGenerationOptions
+  extends Omit<RoomFloorOptions, 'includeExterior' | 'cutoutsByRoom'> {
   readonly scale?: number;
   readonly cutoutsBySurfaceId?: Readonly<Record<string, RoomFloorCutout[]>>;
 }
@@ -41,7 +42,11 @@ export function generateFloorSurfaces(
   floor: FloorDefinition,
   options: FloorSurfaceGenerationOptions = {}
 ): GeneratedFloorSurfaceBuild {
-  const scale = options.scale ?? FLOOR_PLAN_SCALE;
+  const {
+    cutoutsBySurfaceId,
+    scale = FLOOR_PLAN_SCALE,
+    ...roomFloorOptions
+  } = options;
   const roomNames = new Map(floor.rooms.map((room) => [room.id, room.name]));
   const surfacesByKey = new Map<string, FloorSurfaceDefinition>();
 
@@ -58,16 +63,30 @@ export function generateFloorSurfaces(
     };
   });
 
+  const surfaceIds = new Set(floor.floorSurfaces.map((surface) => surface.id));
+  const unknownCutoutSurfaceIds = Object.keys(cutoutsBySurfaceId ?? {}).filter(
+    (surfaceId) => !surfaceIds.has(surfaceId)
+  );
+
+  if (unknownCutoutSurfaceIds.length > 0) {
+    console.warn(
+      `Ignoring cutouts for unknown floor surface IDs: ${unknownCutoutSurfaceIds.join(
+        ', '
+      )}.`
+    );
+  }
+
   const cutoutsByRoom = Object.fromEntries(
     floor.floorSurfaces.map((surface) => [
       makeRoomSurfaceKey(surface),
-      options.cutoutsBySurfaceId?.[surface.id] ?? [],
+      cutoutsBySurfaceId?.[surface.id] ?? [],
     ])
   );
 
   const build = createRoomFloorTiles(surfaceRooms, {
-    ...options,
+    ...roomFloorOptions,
     cutoutsByRoom,
+    // Surface definitions are already production-filtered; keep synthetic rooms renderable.
     includeExterior: true,
   });
 

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -93,6 +93,8 @@ const FLOOR_SURFACE_SOURCE_IDS: Readonly<Record<string, string>> = {
   'upper:focusPods': 'upper.focusPods.floor.main',
 };
 
+export const UPPER_LANDING_FLOOR_MAIN_ID = 'upperLanding-floor-main';
+
 const floorSurfaceForRoom = (
   floorId: FloorDefinition['id'],
   room: FloorDefinition['rooms'][number]
@@ -107,7 +109,10 @@ const floorSurfaceForRoom = (
   }
 
   return {
-    id: `${room.id}-floor-main`,
+    id:
+      room.id === 'upperLanding'
+        ? UPPER_LANDING_FLOOR_MAIN_ID
+        : `${room.id}-floor-main`,
     sourceId: sourceId(mappedSourceId),
     floorId,
     bounds: { ...room.bounds },
@@ -133,7 +138,7 @@ const buildFloor = (floor: FloorDefinitionInput): FloorDefinition => ({
               FLOOR_SURFACE_SOURCE_IDS['upper:upperLandingStairEdge']
             ),
             floorId: 'upper',
-            bounds: { minX: 4.65, maxX: 7.75, minZ: -16, maxZ: -15.95 },
+            bounds: { minX: 4.65, maxX: 7.75, minZ: -16, maxZ: -15.9 },
             roomId: 'upperLanding',
             purpose: 'stair-edge-floor',
           },

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -82,18 +82,33 @@ const centeredGap = (runStart: number, center: number, label: string) => {
   return gap(range.start - runStart, range.end - runStart, label);
 };
 
-const roomIdToSourceSegment = (roomId: string) =>
-  roomId.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+const FLOOR_SURFACE_SOURCE_IDS: Readonly<Record<string, string>> = {
+  'ground:livingRoom': 'ground.livingRoom.floor.main',
+  'ground:studio': 'ground.studio.floor.main',
+  'ground:kitchen': 'ground.kitchen.floor.main',
+  'upper:upperLanding': 'upper.upperLanding.floor.main',
+  'upper:upperLandingStairEdge': 'upper.upperLanding.floor.stairEdgePiece',
+  'upper:creatorsStudio': 'upper.creatorsStudio.floor.main',
+  'upper:loftLibrary': 'upper.loftLibrary.floor.main',
+  'upper:focusPods': 'upper.focusPods.floor.main',
+};
 
 const floorSurfaceForRoom = (
   floorId: FloorDefinition['id'],
   room: FloorDefinition['rooms'][number]
-): FloorDefinition['floorSurfaces'][number] => {
-  const roomSourceSegment = roomIdToSourceSegment(room.id);
+): FloorDefinition['floorSurfaces'][number] | undefined => {
+  if (room.category === 'exterior') return undefined;
+
+  const mappedSourceId = FLOOR_SURFACE_SOURCE_IDS[`${floorId}:${room.id}`];
+  if (!mappedSourceId) {
+    throw new Error(
+      `Missing floor surface source ID for ${floorId}:${room.id}.`
+    );
+  }
 
   return {
-    id: `${room.id}-floor-surface`,
-    sourceId: sourceId(`${floorId}.${roomSourceSegment}.floor_surface`),
+    id: `${room.id}-floor-main`,
+    sourceId: sourceId(mappedSourceId),
     floorId,
     bounds: { ...room.bounds },
     roomId: room.id,
@@ -105,7 +120,26 @@ type FloorDefinitionInput = Omit<FloorDefinition, 'floorSurfaces'>;
 
 const buildFloor = (floor: FloorDefinitionInput): FloorDefinition => ({
   ...floor,
-  floorSurfaces: floor.rooms.map((room) => floorSurfaceForRoom(floor.id, room)),
+  floorSurfaces: [
+    ...floor.rooms.flatMap((room) => {
+      const surface = floorSurfaceForRoom(floor.id, room);
+      return surface ? [surface] : [];
+    }),
+    ...(floor.id === 'upper'
+      ? [
+          {
+            id: 'upperLanding-floor-stair-edge-piece',
+            sourceId: sourceId(
+              FLOOR_SURFACE_SOURCE_IDS['upper:upperLandingStairEdge']
+            ),
+            floorId: 'upper',
+            bounds: { minX: 4.65, maxX: 7.75, minZ: -16, maxZ: -15.95 },
+            roomId: 'upperLanding',
+            purpose: 'stair-edge-floor',
+          },
+        ]
+      : []),
+  ],
 });
 
 export const PORTFOLIO_LEVEL: LevelDefinition = {

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -163,7 +163,9 @@ export function validateLevelDefinition(
     }
 
     const rawSourceId = sourceId as string;
-    const sourceIdParts = rawSourceId.split('.');
+    const sourceIdParts = rawSourceId
+      .split('.')
+      .map((part) => part.toLowerCase());
     if (
       FORBIDDEN_SOURCE_ID_PARTS.some((part) => sourceIdParts.includes(part))
     ) {

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -8,7 +8,8 @@ export type LevelSourceId = string & {
   readonly __levelSourceIdBrand: unique symbol;
 };
 
-export const LEVEL_SOURCE_ID_PATTERN = /^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$/;
+export const LEVEL_SOURCE_ID_PATTERN =
+  /^[a-z0-9_-][A-Za-z0-9_-]*(?:\.[a-z0-9_-][A-Za-z0-9_-]*)*$/;
 
 export type LevelSourceType =
   | 'room'
@@ -27,8 +28,9 @@ export interface LevelSourceMetadata {
 }
 
 const describeSourceIdFormat = (): string =>
-  'Level source IDs must be dot-separated segments containing only ' +
-  'letters (any case), digits, underscores, and hyphens.';
+  'Level source IDs must be dot-separated segments. Each segment must start ' +
+  'with a lowercase letter, digit, underscore, or hyphen and may then contain ' +
+  'uppercase or lowercase letters, digits, underscores, and hyphens.';
 
 export const isLevelSourceId = (value: unknown): value is LevelSourceId =>
   typeof value === 'string' && LEVEL_SOURCE_ID_PATTERN.test(value);

--- a/src/scene/level/sourceIds.ts
+++ b/src/scene/level/sourceIds.ts
@@ -8,7 +8,7 @@ export type LevelSourceId = string & {
   readonly __levelSourceIdBrand: unique symbol;
 };
 
-export const LEVEL_SOURCE_ID_PATTERN = /^[a-z0-9_-]+(?:\.[a-z0-9_-]+)*$/;
+export const LEVEL_SOURCE_ID_PATTERN = /^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$/;
 
 export type LevelSourceType =
   | 'room'
@@ -27,8 +27,8 @@ export interface LevelSourceMetadata {
 }
 
 const describeSourceIdFormat = (): string =>
-  'Level source IDs must be dot-separated lowercase segments containing only ' +
-  'letters, digits, underscores, and hyphens.';
+  'Level source IDs must be dot-separated segments containing only ' +
+  'letters (any case), digits, underscores, and hyphens.';
 
 export const isLevelSourceId = (value: unknown): value is LevelSourceId =>
   typeof value === 'string' && LEVEL_SOURCE_ID_PATTERN.test(value);


### PR DESCRIPTION
### Motivation
- Move rendered floor tile generation to declarative `FloorDefinition.floorSurfaces` so runtime meshes are traceable to stable semantic source IDs while preserving the existing floor layout and stairwell behavior.
- Ensure generators may split/clip source surfaces (generator-owned) rather than encoding subtractive ‘former’ tombstones in production source data.

### Description
- Added `src/scene/level/generateFloorSurfaces.ts` which maps `FloorDefinition.floorSurfaces` → renderable tiles (reusing `createRoomFloorTiles`) and stamps each mesh with `userData.levelSourceId` and `userData.levelSource.sourceType = 'floorSurface'` for debug lookups.
- Added explicit stable floor-surface source IDs in `src/scene/level/portfolioLevel.ts` (including `ground.livingRoom.floor.main`, `upper.upperLanding.floor.main`, and `upper.upperLanding.floor.stairEdgePiece`) and extended the level fixture to include those surfaces while excluding exterior floor surfaces from production surfaces.
- Switched runtime floor construction in `src/main.ts` to use `generateFloorSurfaces(...)` for ground and upper floors and wired generator-owned upper-landing cutouts through `cutoutsBySurfaceId` so stairwell voids and egress behaviors are preserved.
- Relaxed `LEVEL_SOURCE_ID_PATTERN` and help text in `src/scene/level/sourceIds.ts` to accept human-friendly camelCase path segments used for the stable IDs, added tests, and updated the design doc to document floor-surface provenance and generator-owned clipping.

### Testing
- Ran formatting: `npm run format:write` — succeeded.
- Ran lint: `npm run lint` — succeeded (initial import-order warning fixed during changes).
- Ran focused unit tests: `npm run test:ci -- src/scene/level/__tests__/generateFloorSurfaces.test.ts src/scene/level/__tests__/portfolioLevel.test.ts src/scene/level/__tests__/sourceIds.test.ts src/tests/upperLandingFloorCutouts.test.ts` — all focused tests passed.
- Ran full unit suite: `npm run test:ci` — all Vitest tests passed (all suites green).
- Docs check: `npm run docs:check` — passed (link checker emitted external fetch warnings but completed successfully).
- Smoke / build: `npm run smoke` and `npm run build` — build and smoke checks passed.
- Playwright: after installing browsers, `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell` were run and `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` completed successfully (Playwright stairs roundtrip spec passed).

All automated checks run during the rollout passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a333da94e94832f85c30f3ca3f698c1)