### PR TITLE
🏗️ Generate floor surfaces from source data

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -45,10 +45,13 @@ orchestration code:
    - Builds Three.js wall and fence meshes from wall segment instances.
    - Copies compact metadata such as `segmentId`, `isFence`,
      `isSharedInterior`, and `thickness` into mesh `userData`.
-5. `src/scene/structures/floorTiles.ts`
-   - Builds room floor tile meshes from room bounds.
-   - Supports generator-owned cutout subtraction and room-specific cutouts, then
-     emits renderable tile pieces.
+5. `src/scene/structures/floorTiles.ts` and
+   `src/scene/level/generateFloorSurfaces.ts`
+   - Build source-backed floor tile meshes from declarative floor surface
+     bounds, while retaining the legacy room-bound helper for compatibility
+     tests.
+   - Support generator-owned cutout subtraction and room-specific cutouts, then
+     emit renderable tile pieces that carry floor-surface source metadata.
 6. `src/main.ts`
    - Orchestrates the scene and stitches together generated assets with manual
      runtime additions.
@@ -258,7 +261,11 @@ wall/railing; a walkable opening does not need a former blocker record.
 
 Current ground and upper room bounds, wall runs, intentional wall-run gaps,
 floor surfaces, and semantic room connections now live in
-`src/scene/level/portfolioLevel.ts`. The temporary adapter in
+`src/scene/level/portfolioLevel.ts`. Floor surfaces use stable source IDs
+such as `ground.living_room.floor.main` and
+`upper.upper_landing.floor.main`; the runtime floor generator may split or clip
+those source rectangles into multiple renderable pieces around the current
+stairwell void without adding production tombstones for old removed strips. The temporary adapter in
 `src/scene/level/compileLegacyFloorPlan.ts` compiles a declarative floor
 back to the existing `FloorPlanDefinition` shape for migration checks and
 narrow compatibility. By default it copies room metadata only. When
@@ -287,8 +294,13 @@ semantic `roomConnections` intentionally do not create or remove geometry.
    `src/scene/level/generateWalls.ts`; the legacy room-doorway wall generator is
    retained only as a compatibility reference while later phases migrate floors,
    safety colliders, and inventory tooling.
-8. **Generate floor outputs from source.** Derive floor surfaces from source data,
-   allowing generator-owned splitting and clipping where useful.
+8. **Generate floor outputs from source.** Floor tiles now derive from
+   `FloorDefinition.floorSurfaces` via `generateFloorSurfaces(...)`, and each
+   generated mesh carries `userData.levelSourceId` plus
+   `userData.levelSource.sourceType = 'floorSurface'`. Generator-owned
+   splitting and clipping preserve the current stairwell void and landing
+   coverage without encoding former or removed floor artifacts as production
+   source data.
 9. **Move stair and void safety.** Convert stair, landing, and void guard
    colliders into purpose-labeled source-ID-backed safety colliders.
 10. **Move scene objects and policies.** Place visible/interactable objects and

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,8 +29,8 @@ import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPa
 
 import {
   FLOOR_PLAN,
-  FLOOR_PLAN_LEVELS,
   FLOOR_PLAN_SCALE,
+  FLOOR_PLAN_LEVELS,
   UPPER_FLOOR_PLAN,
   getFloorBounds,
   WALL_THICKNESS,
@@ -150,6 +150,7 @@ import {
   createSceneDetailController,
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
+import { generateFloorSurfaces } from './scene/level/generateFloorSurfaces';
 import { generateWallSegmentInstances } from './scene/level/generateWalls';
 import { PORTFOLIO_LEVEL } from './scene/level/portfolioLevel';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
@@ -236,7 +237,6 @@ import {
   createF2ClipboardConsole,
   type F2ClipboardConsoleBuild,
 } from './scene/structures/f2ClipboardConsole';
-import { createRoomFloorTiles } from './scene/structures/floorTiles';
 import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
@@ -1851,10 +1851,17 @@ function initializeImmersiveScene(
     roughness: 0.58,
     metalness: 0.18,
   });
-  const floorTiles = createRoomFloorTiles(FLOOR_PLAN.rooms, {
+  const groundFloorDefinition = PORTFOLIO_LEVEL.floors.find(
+    (floor) => floor.id === 'ground'
+  );
+  if (!groundFloorDefinition) {
+    throw new Error('Expected ground floor source definition to exist.');
+  }
+  const floorTiles = generateFloorSurfaces(groundFloorDefinition, {
     material: floorMaterial,
     elevation: 0,
     groupName: 'GroundFloorTiles',
+    coordinateScale: FLOOR_PLAN_SCALE,
   });
   groundFloorGroup.add(floorTiles.group);
 
@@ -2307,11 +2314,18 @@ function initializeImmersiveScene(
           }),
         }
       : undefined;
-  const upperFloorTiles = createRoomFloorTiles(UPPER_FLOOR_PLAN.rooms, {
+  const upperFloorDefinition = PORTFOLIO_LEVEL.floors.find(
+    (floor) => floor.id === 'upper'
+  );
+  if (!upperFloorDefinition) {
+    throw new Error('Expected upper floor source definition to exist.');
+  }
+  const upperFloorTiles = generateFloorSurfaces(upperFloorDefinition, {
     material: upperFloorMaterial,
     elevation: upperFloorElevation,
     thickness: STAIRCASE_CONFIG.landing.thickness,
     groupName: 'UpperFloorTiles',
+    coordinateScale: FLOOR_PLAN_SCALE,
     cutoutsByRoom: upperLandingCutouts,
   });
   upperFloorGroup.add(upperFloorTiles.group);

--- a/src/scene/level/__tests__/generateFloorSurfaces.test.ts
+++ b/src/scene/level/__tests__/generateFloorSurfaces.test.ts
@@ -1,0 +1,124 @@
+import { MeshStandardMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN_SCALE } from '../../../assets/floorPlan';
+import { createSolidVisualizer } from '../../debug/solidVisualizer';
+import { generateFloorSurfaces } from '../generateFloorSurfaces';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import type { FloorDefinition } from '../schema';
+
+const getFloor = (id: string): FloorDefinition => {
+  const floor = PORTFOLIO_LEVEL.floors.find((candidate) => candidate.id === id);
+  if (!floor) throw new Error(`Missing floor ${id}`);
+  return floor;
+};
+
+const containsPoint = (
+  bounds: { minX: number; maxX: number; minZ: number; maxZ: number },
+  point: { x: number; z: number }
+): boolean =>
+  point.x >= bounds.minX &&
+  point.x <= bounds.maxX &&
+  point.z >= bounds.minZ &&
+  point.z <= bounds.maxZ;
+
+const scaled = (value: number): number => value * FLOOR_PLAN_SCALE;
+
+describe('generateFloorSurfaces', () => {
+  it('adds floor source metadata to every generated tile mesh', () => {
+    const build = generateFloorSurfaces(getFloor('ground'), {
+      material: new MeshStandardMaterial(),
+      coordinateScale: FLOOR_PLAN_SCALE,
+    });
+
+    expect(build.tiles.length).toBeGreaterThan(0);
+    for (const tile of build.tiles) {
+      expect(typeof tile.sourceId).toBe('string');
+      expect(tile.mesh.userData.levelSourceId).toBe(tile.sourceId);
+      expect(tile.mesh.userData.levelSource).toEqual({
+        sourceId: tile.sourceId,
+        sourceType: 'floorSurface',
+        purpose: 'room-floor',
+      });
+    }
+  });
+
+  it('lets debug solids find generated floors by source ID', () => {
+    const build = generateFloorSurfaces(getFloor('ground'), {
+      material: new MeshStandardMaterial(),
+      coordinateScale: FLOOR_PLAN_SCALE,
+    });
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(build.group);
+
+    expect(
+      visualizer.getSolidsBySourceId('ground.living_room.floor.main')
+    ).toHaveLength(1);
+  });
+
+  it('keeps source IDs valid and unique for floor surfaces', () => {
+    const sourceIds = PORTFOLIO_LEVEL.floors.flatMap((floor) =>
+      floor.floorSurfaces.map((surface) => String(surface.sourceId))
+    );
+
+    expect(sourceIds).toContain('ground.living_room.floor.main');
+    expect(sourceIds).toContain('upper.upper_landing.floor.main');
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+  });
+
+  it('regenerates changed output when a floor surface fixture changes', () => {
+    const floor = getFloor('ground');
+    const changed: FloorDefinition = {
+      ...floor,
+      floorSurfaces: floor.floorSurfaces.map((surface) =>
+        surface.id === 'living-room-floor-main'
+          ? {
+              ...surface,
+              bounds: { ...surface.bounds, maxX: surface.bounds.maxX - 2 },
+            }
+          : surface
+      ),
+    };
+
+    const original = generateFloorSurfaces(floor, {
+      material: new MeshStandardMaterial(),
+      coordinateScale: FLOOR_PLAN_SCALE,
+    });
+    const updated = generateFloorSurfaces(changed, {
+      material: new MeshStandardMaterial(),
+      coordinateScale: FLOOR_PLAN_SCALE,
+    });
+
+    expect(updated.tiles[0].bounds.maxX).toBe(
+      original.tiles[0].bounds.maxX - 4
+    );
+  });
+
+  it('preserves upper stairwell void and landing egress samples with generator-owned cutouts', () => {
+    const stairwellVoid = {
+      minX: scaled(4.65),
+      maxX: scaled(7.95),
+      minZ: scaled(-15.95),
+      maxZ: scaled(-12.1),
+    };
+    const egressSample = { x: scaled(4.25), z: scaled(-11) };
+    const librarySample = { x: scaled(5), z: scaled(-6) };
+    const build = generateFloorSurfaces(getFloor('upper'), {
+      material: new MeshStandardMaterial(),
+      coordinateScale: FLOOR_PLAN_SCALE,
+      cutoutsByRoom: { upperLanding: [stairwellVoid] },
+    });
+
+    expect(
+      build.tiles.some((tile) =>
+        containsPoint(tile.bounds, { x: scaled(6), z: scaled(-14) })
+      )
+    ).toBe(false);
+    expect(
+      build.tiles.some((tile) => containsPoint(tile.bounds, egressSample))
+    ).toBe(true);
+    expect(
+      build.tiles.some((tile) => containsPoint(tile.bounds, librarySample))
+    ).toBe(true);
+  });
+});

--- a/src/scene/level/generateFloorSurfaces.ts
+++ b/src/scene/level/generateFloorSurfaces.ts
@@ -1,0 +1,49 @@
+import {
+  createFloorSurfaceTiles,
+  type FloorSurfaceOptions,
+  type RoomFloorBuild,
+} from '../structures/floorTiles';
+
+import type { FloorDefinition, FloorSurfaceDefinition } from './schema';
+
+export interface GenerateFloorSurfacesOptions extends FloorSurfaceOptions {
+  readonly floorId?: string;
+  readonly coordinateScale?: number;
+}
+
+const getSurfacesForFloor = (
+  floor: FloorDefinition,
+  floorId?: string
+): FloorSurfaceDefinition[] => {
+  if (!floorId || floor.id === floorId) {
+    return [...floor.floorSurfaces];
+  }
+
+  return [];
+};
+
+export function generateFloorSurfaces(
+  floor: FloorDefinition,
+  options: GenerateFloorSurfacesOptions = {}
+): RoomFloorBuild {
+  const coordinateScale = options.coordinateScale ?? 1;
+  const surfaces = getSurfacesForFloor(floor, options.floorId).map(
+    (surface) => ({
+      ...surface,
+      bounds: {
+        minX: surface.bounds.minX * coordinateScale,
+        maxX: surface.bounds.maxX * coordinateScale,
+        minZ: surface.bounds.minZ * coordinateScale,
+        maxZ: surface.bounds.maxZ * coordinateScale,
+      },
+      elevation:
+        typeof surface.elevation === 'number'
+          ? surface.elevation * coordinateScale
+          : undefined,
+    })
+  );
+
+  return createFloorSurfaceTiles(surfaces, {
+    ...options,
+  });
+}

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -82,31 +82,24 @@ const centeredGap = (runStart: number, center: number, label: string) => {
   return gap(range.start - runStart, range.end - runStart, label);
 };
 
-const roomIdToSourceSegment = (roomId: string) =>
-  roomId.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
-
-const floorSurfaceForRoom = (
+const floorSurface = (
+  id: string,
+  source: string,
   floorId: FloorDefinition['id'],
-  room: FloorDefinition['rooms'][number]
-): FloorDefinition['floorSurfaces'][number] => {
-  const roomSourceSegment = roomIdToSourceSegment(room.id);
-
-  return {
-    id: `${room.id}-floor-surface`,
-    sourceId: sourceId(`${floorId}.${roomSourceSegment}.floor_surface`),
-    floorId,
-    bounds: { ...room.bounds },
-    roomId: room.id,
-    purpose: 'room-floor',
-  };
-};
-
-type FloorDefinitionInput = Omit<FloorDefinition, 'floorSurfaces'>;
-
-const buildFloor = (floor: FloorDefinitionInput): FloorDefinition => ({
-  ...floor,
-  floorSurfaces: floor.rooms.map((room) => floorSurfaceForRoom(floor.id, room)),
+  bounds: FloorDefinition['rooms'][number]['bounds'],
+  roomId: string
+): FloorDefinition['floorSurfaces'][number] => ({
+  id,
+  sourceId: sourceId(source),
+  floorId,
+  bounds: { ...bounds },
+  roomId,
+  purpose: 'room-floor',
 });
+
+type FloorDefinitionInput = FloorDefinition;
+
+const buildFloor = (floor: FloorDefinitionInput): FloorDefinition => floor;
 
 export const PORTFOLIO_LEVEL: LevelDefinition = {
   id: 'portfolio',
@@ -150,6 +143,29 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           ledColor: 0x274f37,
           category: 'exterior',
         },
+      ],
+      floorSurfaces: [
+        floorSurface(
+          'living-room-floor-main',
+          'ground.living_room.floor.main',
+          'ground',
+          { minX: -16, maxX: 16, minZ: -16, maxZ: -4 },
+          'livingRoom'
+        ),
+        floorSurface(
+          'kitchen-floor-main',
+          'ground.kitchen.floor.main',
+          'ground',
+          { minX: -16, maxX: -2, minZ: -4, maxZ: 8 },
+          'kitchen'
+        ),
+        floorSurface(
+          'studio-floor-main',
+          'ground.studio.floor.main',
+          'ground',
+          { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
+          'studio'
+        ),
       ],
       walls: [
         horizontalWall(
@@ -347,6 +363,36 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           bounds: { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
           ledColor: 0x9cf7c7,
         },
+      ],
+      floorSurfaces: [
+        floorSurface(
+          'upper-landing-floor-main',
+          'upper.upper_landing.floor.main',
+          'upper',
+          { minX: 2, maxX: 10.4, minZ: -16, maxZ: -8 },
+          'upperLanding'
+        ),
+        floorSurface(
+          'creators-studio-floor-main',
+          'upper.creators_studio.floor.main',
+          'upper',
+          { minX: -10, maxX: 2, minZ: -16, maxZ: 0 },
+          'creatorsStudio'
+        ),
+        floorSurface(
+          'loft-library-floor-main',
+          'upper.loft_library.floor.main',
+          'upper',
+          { minX: 2, maxX: 12, minZ: -8, maxZ: 6 },
+          'loftLibrary'
+        ),
+        floorSurface(
+          'focus-pods-floor-main',
+          'upper.focus_pods.floor.main',
+          'upper',
+          { minX: -10, maxX: 12, minZ: 6, maxZ: 14 },
+          'focusPods'
+        ),
       ],
       walls: [
         horizontalWall(

--- a/src/scene/structures/floorTiles.ts
+++ b/src/scene/structures/floorTiles.ts
@@ -1,12 +1,15 @@
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial, Texture } from 'three';
 
 import type { Bounds2D, RoomDefinition } from '../../assets/floorPlan';
+import type { FloorSurfaceDefinition } from '../level/schema';
 import { applyLightmapUv2 } from '../lighting/bakedLightmaps';
 
 export interface RoomFloorTile {
   readonly roomId: string;
   readonly mesh: Mesh;
   readonly bounds: Bounds2D;
+  readonly sourceId?: FloorSurfaceDefinition['sourceId'];
+  readonly surfaceId?: string;
 }
 
 export interface RoomFloorBuild {
@@ -46,6 +49,16 @@ export interface RoomFloorOptions {
   readonly cutoutsByRoom?: Readonly<Record<string, RoomFloorCutout[]>>;
 }
 
+export interface FloorSurfaceOptions
+  extends Omit<RoomFloorOptions, 'includeExterior' | 'materialFactory'> {
+  /** Optional factory for bespoke materials per floor surface. */
+  readonly materialFactory?: (
+    surface: FloorSurfaceDefinition
+  ) => MeshStandardMaterial;
+  /** World-space openings removed only from a matching floor surface id. */
+  readonly cutoutsBySurface?: Readonly<Record<string, RoomFloorCutout[]>>;
+}
+
 const DEFAULT_GROUP_NAME = 'RoomFloorTiles';
 const DEFAULT_THICKNESS = 0.12;
 const DEFAULT_INSET = 0;
@@ -54,7 +67,7 @@ const DEFAULT_COLOR = 0x2a3547;
 
 function applyLightMapOptions(
   material: MeshStandardMaterial,
-  options: RoomFloorOptions
+  options: Pick<RoomFloorOptions, 'lightMap' | 'lightMapIntensity'>
 ) {
   if (options.lightMap) {
     material.lightMap = options.lightMap;
@@ -73,6 +86,26 @@ function resolveMaterial(
 ): MeshStandardMaterial {
   if (options.materialFactory) {
     const customMaterial = options.materialFactory(room);
+    applyLightMapOptions(customMaterial, options);
+    return customMaterial;
+  }
+
+  if (options.material) {
+    applyLightMapOptions(options.material, options);
+    return options.material;
+  }
+
+  applyLightMapOptions(defaultMaterial, options);
+  return defaultMaterial;
+}
+
+function resolveFloorSurfaceMaterial(
+  surface: FloorSurfaceDefinition,
+  options: FloorSurfaceOptions,
+  defaultMaterial: MeshStandardMaterial
+): MeshStandardMaterial {
+  if (options.materialFactory) {
+    const customMaterial = options.materialFactory(surface);
     applyLightMapOptions(customMaterial, options);
     return customMaterial;
   }
@@ -143,6 +176,16 @@ const subtractCutout = (
   return pieces.filter(hasPositiveArea);
 };
 
+const subtractCutouts = (
+  bounds: Bounds2D,
+  cutouts: readonly RoomFloorCutout[]
+): Bounds2D[] =>
+  cutouts.reduce<Bounds2D[]>(
+    (pieces, cutout) =>
+      pieces.flatMap((piece) => subtractCutout(piece, cutout)),
+    [bounds]
+  );
+
 const getRoomTileBounds = (
   room: RoomDefinition,
   options: RoomFloorOptions,
@@ -164,12 +207,105 @@ const getRoomTileBounds = (
     ...(options.cutoutsByRoom?.[room.id] ?? []),
   ];
 
-  return cutouts.reduce<Bounds2D[]>(
-    (pieces, cutout) =>
-      pieces.flatMap((piece) => subtractCutout(piece, cutout)),
-    [roomBounds]
-  );
+  return subtractCutouts(roomBounds, cutouts);
 };
+
+const createTileMesh = (
+  bounds: Bounds2D,
+  thickness: number,
+  elevation: number,
+  material: MeshStandardMaterial
+): Mesh => {
+  const width = bounds.maxX - bounds.minX;
+  const depth = bounds.maxZ - bounds.minZ;
+  const geometry = new BoxGeometry(width, thickness, depth);
+  applyLightmapUv2(geometry);
+
+  const mesh = new Mesh(geometry, material);
+  mesh.position.set(
+    (bounds.minX + bounds.maxX) / 2,
+    elevation - thickness / 2,
+    (bounds.minZ + bounds.maxZ) / 2
+  );
+  mesh.receiveShadow = true;
+
+  return mesh;
+};
+
+export function createFloorSurfaceTiles(
+  surfaces: FloorSurfaceDefinition[],
+  options: FloorSurfaceOptions = {}
+): RoomFloorBuild {
+  const group = new Group();
+  group.name = options.groupName ?? DEFAULT_GROUP_NAME;
+
+  const tiles: RoomFloorTile[] = [];
+  const inset = Math.max(options.inset ?? DEFAULT_INSET, 0);
+  const thickness = Math.max(
+    options.thickness ?? DEFAULT_THICKNESS,
+    MIN_DIMENSION
+  );
+  const defaultElevation = options.elevation ?? 0;
+
+  const defaultMaterial =
+    options.material ??
+    new MeshStandardMaterial({
+      color: DEFAULT_COLOR,
+      roughness: 0.58,
+      metalness: 0.18,
+    });
+
+  surfaces.forEach((surface) => {
+    const surfaceBounds = {
+      minX: surface.bounds.minX + inset,
+      maxX: surface.bounds.maxX - inset,
+      minZ: surface.bounds.minZ + inset,
+      maxZ: surface.bounds.maxZ - inset,
+    };
+
+    if (!hasPositiveArea(surfaceBounds)) {
+      return;
+    }
+
+    const cutouts = [
+      ...(options.cutouts ?? []),
+      ...(surface.roomId
+        ? (options.cutoutsByRoom?.[surface.roomId] ?? [])
+        : []),
+      ...(options.cutoutsBySurface?.[surface.id] ?? []),
+    ];
+
+    subtractCutouts(surfaceBounds, cutouts).forEach((bounds, index) => {
+      const mesh = createTileMesh(
+        bounds,
+        thickness,
+        surface.elevation ?? defaultElevation,
+        resolveFloorSurfaceMaterial(surface, options, defaultMaterial)
+      );
+      mesh.name =
+        index === 0
+          ? `${surface.id} Floor`
+          : `${surface.id} Floor ${index + 1}`;
+      mesh.userData.levelSourceId = surface.sourceId;
+      mesh.userData.levelSource = {
+        sourceId: surface.sourceId,
+        sourceType: 'floorSurface',
+        purpose: surface.purpose,
+      };
+
+      group.add(mesh);
+      tiles.push({
+        roomId: surface.roomId ?? surface.id,
+        mesh,
+        bounds,
+        sourceId: surface.sourceId,
+        surfaceId: surface.id,
+      });
+    });
+  });
+
+  return { group, tiles };
+}
 
 export function createRoomFloorTiles(
   rooms: RoomDefinition[],
@@ -200,23 +336,14 @@ export function createRoomFloorTiles(
     }
 
     getRoomTileBounds(room, options, inset).forEach((bounds, index) => {
-      const width = bounds.maxX - bounds.minX;
-      const depth = bounds.maxZ - bounds.minZ;
-      const geometry = new BoxGeometry(width, thickness, depth);
-      applyLightmapUv2(geometry);
-
-      const mesh = new Mesh(
-        geometry,
+      const mesh = createTileMesh(
+        bounds,
+        thickness,
+        elevation,
         resolveMaterial(room, options, defaultMaterial)
-      );
-      mesh.position.set(
-        (bounds.minX + bounds.maxX) / 2,
-        elevation - thickness / 2,
-        (bounds.minZ + bounds.maxZ) / 2
       );
       mesh.name =
         index === 0 ? `${room.name} Floor` : `${room.name} Floor ${index + 1}`;
-      mesh.receiveShadow = true;
 
       group.add(mesh);
       tiles.push({ roomId: room.id, mesh, bounds });


### PR DESCRIPTION
### Motivation
- Move rendered floor tiles to a declarative source model so floor geometry is traceable to semantic source IDs. 
- Preserve exact current floor coverage and the upstairs stairwell/landing behavior while allowing generator-owned splitting/clipping. 
- Expose floor source provenance to debug tooling and tests so downstream artifacts can be audited by `sourceId`.

### Description
- Add `generateFloorSurfaces(...)` which maps `FloorDefinition.floorSurfaces` into renderable tiles and scales coordinates for runtime via `coordinateScale`. (`src/scene/level/generateFloorSurfaces.ts`).
- Extend `createFloorSurfaceTiles(...)` inside `src/scene/structures/floorTiles.ts` to emit tiles from `FloorSurfaceDefinition[]`, support per-surface cutouts, and attach provenance: `mesh.userData.levelSourceId` and `mesh.userData.levelSource.sourceType = 'floorSurface'`.
- Declare stable floor-surface source items in the level source (`PORTFOLIO_LEVEL.floorSurfaces`) for ground and upper floors and wire the runtime to use the new generator instead of the legacy room-only helper (`src/scene/level/portfolioLevel.ts`, `src/main.ts`).
- Add unit tests for generation, metadata, debug lookup, uniqueness, and fixture-driven regeneration (`src/scene/level/__tests__/generateFloorSurfaces.test.ts`) and update the design doc to describe source-backed floor generation (`docs/design/declarative-level-source-of-truth.md`).

### Testing
- Ran formatting and lint: `npm run format:write` (ok) and `npm run lint` (ok; minor import-order warnings earlier were addressed). 
- Ran focused and full unit suites: `npm run test:ci -- src/scene/level/__tests__/generateFloorSurfaces.test.ts src/tests/upperLandingFloorCutouts.test.ts` (passed) and `npm run test:ci` (full test run passed: 154 files, all tests green). 
- Built and smoke-checked the app: `npm run build` (ok) and `npm run smoke` (ok). 
- Docs and links: `npm run docs:check` completed; external link fetch warnings were emitted by the checker but the docs check completed. 
- Playwright end-to-end: initially blocked by missing browsers, then `npx playwright install chromium` and `npx playwright install-deps chromium` were run and `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` passed (9 tests). 
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` found no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a333db88220832fbe08bd8520deef7a)