### PR TITLE
Source stair safety colliders

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -126,7 +126,12 @@ Safety colliders are invisible constraints that should exist, each with a stated
 purpose such as preventing stairwell falls, preserving stair approach lanes,
 blocking unfinished zones, or protecting showpiece footprints. They should carry
 source IDs, floor assignment, bounds, and purpose text so reviewers can tell why
-the invisible constraint exists.
+the invisible constraint exists. Physical wall colliders remain generated from
+wall/fence source geometry; safety colliders are separate source-backed
+constraints and must not masquerade as layout wall geometry or hidden post-hoc
+patches. Stair, landing, and void guards now flow through
+`src/scene/level/stairSafetyColliders.ts`, which preserves current bounds while
+attaching concise purposes to debug collider metadata.
 
 ### Scene objects
 
@@ -295,8 +300,9 @@ semantic `roomConnections` intentionally do not create or remove geometry.
    `src/scene/level/generateFloorSurfaces.ts`, with generator-owned splitting
    and clipping preserving the current stairwell void while propagating
    `floorSurface` source metadata to debug solids.
-9. **Move stair and void safety.** Convert stair, landing, and void guard
-   colliders into purpose-labeled source-ID-backed safety colliders.
+9. **Move stair and void safety.** Stair, landing, and void guard colliders now
+   come from `src/scene/level/stairSafetyColliders.ts` as purpose-labeled,
+   source-ID-backed safety colliders while preserving their runtime bounds.
 10. **Move scene objects and policies.** Place visible/interactable objects and
     their collider policies in declarative source data.
 11. **Add invariants and inventory tooling.** Prevent hidden overrides, duplicate

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,11 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+  type LevelSafetyCollider,
+} from './scene/level/stairSafetyColliders';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -404,7 +409,6 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
-  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -415,7 +419,6 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
-import { splitColliderAroundCorridor } from './systems/movement/upperStairLandingGuards';
 import {
   NARRATION_PREFERENCE_STORAGE_KEY,
   NarrationPreference,
@@ -977,9 +980,12 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
-const colliderSourceIds = new Map<
+const colliderSourceMetadata = new Map<
   RectCollider,
-  WallSegmentInstance['sourceId']
+  Pick<LevelSafetyCollider, 'sourceId'> & {
+    sourceType: 'wall' | 'safetyCollider';
+    purpose?: LevelSafetyCollider['purpose'];
+  }
 >();
 const upperFloorColliders: RectCollider[] = [];
 
@@ -1905,7 +1911,10 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
@@ -2058,18 +2067,27 @@ function initializeImmersiveScene(
     maxZ: stairGuardMaxZ,
   });
 
-  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
-    stairGeometry,
-    stairBehavior,
-    {
-      playerRadius: PLAYER_RADIUS,
-      guardThickness: stairGuardThickness,
-    }
-  );
-  groundStairBoundaryColliders.forEach(({ name, bounds }) => {
-    groundColliders.push(bounds);
+  const pushNamedUpperFloorCollider = (name: string, bounds: RectCollider) => {
+    upperFloorColliders.push(bounds);
     namedColliderDebugNames.set(bounds, name);
-  });
+  };
+
+  const registerSafetyCollider = (collider: LevelSafetyCollider) => {
+    const colliders =
+      collider.floor === 'upper' ? upperFloorColliders : groundColliders;
+    colliders.push(collider.bounds);
+    namedColliderDebugNames.set(collider.bounds, collider.name);
+    colliderSourceMetadata.set(collider.bounds, {
+      sourceId: collider.sourceId,
+      sourceType: 'safetyCollider',
+      purpose: collider.purpose,
+    });
+  };
+
+  createGroundStairSafetyColliders(stairGeometry, stairBehavior, {
+    playerRadius: PLAYER_RADIUS,
+    guardThickness: stairGuardThickness,
+  }).forEach(registerSafetyCollider);
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;
@@ -2098,11 +2116,6 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const pushNamedUpperFloorCollider = (name: string, bounds: RectCollider) => {
-    upperFloorColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
-  };
-
   const upperStairWestEgressLaneX =
     stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
   const upperStairWestEgressBlockerMinX =
@@ -2110,165 +2123,26 @@ function initializeImmersiveScene(
 
   // The upper-floor stairwell cutout intentionally comes from the same
   // computeStairLayout result used by movement. It removes both the stair
-  // landing void and the hidden ramp run below the landing lip.
+  // landing void and the hidden ramp run below the landing lip. Invisible
+  // source-backed safety colliders then guard the true no-floor cutout edges
+  // without masquerading as physical wall geometry.
   if (upperLandingRoom && upperStairwellOpening) {
-    const upperStairVoidMinZ = upperStairwellOpening.minZ;
-    const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperLandingDoorwayClearanceZ =
-      upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerNearZ =
-      stairTopZ +
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin);
-    const hiddenStairTopGapBlockerFarZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairBlockerStartZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin / 2);
-    // Invisible upper-floor guard rails flank the intentional descent corridor.
-    // They are scoped to the actual upper-floor cutout instead of the full ramp
-    // run so normal loft space beyond the landing remains occupiable.
-    // UpperStairDeepVoidBlocker is intentionally absent: it covered the visible
-    // physical StaircaseLanding slab, while the remaining top-gap, hidden-run,
-    // bannister, and void blockers still guard the true no-floor cutout edges.
-    // The hidden-run blocker starts one player radius beyond the explicit
-    // descent handoff band so legitimate upper-floor descent remains open.
-    const upperStairLandingEntryCorridor = {
-      // Keep the upper landing mouth open far enough for a real westward
-      // egress step after handoff; side guards still seal hidden void edges.
-      minX: upperStairwellOpening.minX,
-      // Size the east edge from the real upper-floor descent opening and add
-      // one collision radius because collider checks expand the blocker edge.
-      maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-    };
-    const hiddenStairTopGapBlockerMinZ = Math.min(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const hiddenStairTopGapBlockerMaxZ = Math.max(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const upperStairLandingEntryMinZ = Math.max(
-      upperStairVoidMinZ,
-      hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
-    );
-    const upperStairLandingEntryMaxZ = Math.min(
-      upperStairVoidMaxZ,
-      hiddenStairTopGapBlockerMaxZ + PLAYER_RADIUS
-    );
-    const hiddenStairTopGapBlockerEdgeMinX = Math.max(
-      upperStairwellOpening.minX,
-      hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
-    );
-    const upperStairTopGapBlockers = splitColliderAroundCorridor({
-      name: 'UpperStairTopGapBlocker',
-      bounds: {
-        minX: hiddenStairTopGapBlockerEdgeMinX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-        minZ: hiddenStairTopGapBlockerMinZ,
-        maxZ: hiddenStairTopGapBlockerMaxZ,
-      },
-      corridor: upperStairLandingEntryCorridor,
-    });
-
-    const upperStairBannisterThickness =
-      STAIRCASE_CONFIG.landing.guard.thickness;
-    const upperStairWestBannisterMinX = upperStairwellOpening.minX;
-    // Keep a full player-radius clearance between the side guard and the
-    // explicit descent lane; collision checks expand colliders by that radius.
-    const upperStairWestBannisterMaxX =
-      stairNavigationZones.explicitDescentCorridor.minX - PLAYER_RADIUS - 0.01;
-    const upperStairWestBannisterShiftX = 1;
-    const upperStairNorthBannisterMinX =
-      stairNavigationZones.explicitDescentCorridor.minX +
-      upperStairBannisterThickness * 1.5;
-    const upperStairNorthBannisterBaseCenterZ =
-      upperLandingDoorwayClearanceZ - WALL_THICKNESS;
-    const upperStairNorthBannisterCenterZ =
-      upperStairNorthBannisterBaseCenterZ + 2;
-    const upperStairWestBannisterSouthZ =
-      hiddenStairBlockerStartZ + upperStairBannisterThickness;
-    const upperStairNorthBannisterMaxX =
-      upperStairwellOpening.maxX - upperStairBannisterThickness;
-    const upperStairDescentHandoffFarZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (stairTransitionMargin + stairLandingTriggerMargin);
-    const upperStairHiddenRunGuardNearZ =
-      upperStairDescentHandoffFarZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-
-    [
-      // UpperStairWestUpperVoidGuard is intentionally omitted so the widened
-      // upstairs landing-side passage remains traversable.
-      {
-        name: 'UpperStairEastLowerVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairVoidMinZ,
-          maxZ: upperStairLandingEntryMinZ,
-        },
-      },
-      {
-        name: 'UpperStairEastUpperVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairLandingEntryMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
-      ...upperStairTopGapBlockers,
-      {
-        name: 'UpperStairHiddenRunVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.maxX,
-          minZ: Math.min(
-            upperStairHiddenRunGuardNearZ,
-            upperLandingDoorwayClearanceZ
-          ),
-          maxZ: Math.max(
-            upperStairHiddenRunGuardNearZ,
-            upperStairNorthBannisterBaseCenterZ -
-              upperStairBannisterThickness / 2 -
-              PLAYER_RADIUS -
-              0.01
-          ),
-        },
-      },
-      {
-        name: 'UpperStairWestBannisterGuard',
-        bounds: {
-          minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
-          maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
-          minZ: Math.min(
-            upperStairNorthBannisterBaseCenterZ,
-            upperStairWestBannisterSouthZ
-          ),
-          maxZ:
-            Math.max(
-              upperStairNorthBannisterBaseCenterZ,
-              upperStairWestBannisterSouthZ
-            ) + 2,
-        },
-      },
-      {
-        name: 'UpperStairNorthBannisterGuard',
-        bounds: {
-          minX: upperStairNorthBannisterMinX,
-          maxX: upperStairNorthBannisterMaxX,
-          minZ:
-            upperStairNorthBannisterCenterZ - upperStairBannisterThickness / 2,
-          maxZ:
-            upperStairNorthBannisterCenterZ + upperStairBannisterThickness / 2,
-        },
-      },
-    ].forEach(({ name, bounds }) => pushNamedUpperFloorCollider(name, bounds));
+    createUpperStairSafetyColliders({
+      stairCenterX,
+      stairHalfWidth,
+      stairTopZ,
+      stairwellMarginX,
+      doorwayDepth,
+      playerRadius: PLAYER_RADIUS,
+      stairLandingTriggerMargin,
+      stairTransitionMargin,
+      wallThickness: WALL_THICKNESS,
+      upperLandingRoomBounds: upperLandingRoom.bounds,
+      upperStairwellOpening,
+      stairNavigationZones,
+      stairLayoutDirectionMultiplier: stairLayout.directionMultiplier,
+      upperStairBannisterThickness: STAIRCASE_CONFIG.landing.guard.thickness,
+    }).forEach(registerSafetyCollider);
   }
 
   const staircaseLandingFootprint = {
@@ -2400,7 +2274,10 @@ function initializeImmersiveScene(
       instance.collider,
       getUpperWallSegmentDebugName(instance)
     );
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {
@@ -4493,8 +4370,9 @@ function initializeImmersiveScene(
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
-      sourceId: colliderSourceIds.get(bounds),
-      sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,
+      sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
+      sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
+      purpose: colliderSourceMetadata.get(bounds)?.purpose,
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createStairNavigationZones,
+  type StairBehavior,
+  type StairGeometry,
+} from '../../../systems/movement/stairs';
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+} from '../stairSafetyColliders';
+
+const PLAYER_RADIUS = 0.75;
+
+const geometry: StairGeometry = {
+  centerX: 12.4,
+  halfWidth: 3.1,
+  bottomZ: -10.6,
+  topZ: -25.9,
+  landingMinZ: -31.1,
+  landingMaxZ: -25.9,
+  totalRise: 3.78,
+  direction: -1,
+};
+
+const behavior: StairBehavior = {
+  transitionMargin: 1.2,
+  landingTriggerMargin: 0.4,
+  stepRise: 0.42,
+  descentCorridorInset: PLAYER_RADIUS,
+};
+
+const expectSourceBackedSafetyColliders = (
+  colliders: ReturnType<typeof createGroundStairSafetyColliders>
+) => {
+  expect(colliders.every((collider) => collider.sourceId)).toBe(true);
+  expect(colliders.every((collider) => collider.purpose.trim())).toBe(true);
+  expect(new Set(colliders.map((collider) => collider.sourceId)).size).toBe(
+    colliders.length
+  );
+  expect(colliders.map((collider) => collider.sourceId)).not.toEqual(
+    expect.arrayContaining([expect.stringMatching(/\.(former|removed)\./i)])
+  );
+};
+
+describe('stair safety colliders', () => {
+  it('wraps ground stair boundary colliders with source IDs and purposes', () => {
+    const colliders = createGroundStairSafetyColliders(geometry, behavior, {
+      playerRadius: PLAYER_RADIUS,
+      guardThickness: 0.44,
+    });
+
+    expect(colliders).toMatchObject([
+      {
+        name: 'GroundStairEastBoundary',
+        floor: 'ground',
+        category: 'stair',
+        sourceId: 'ground.stair.eastBoundary.safetyCollider',
+        purpose: 'prevent lower stair side squeeze',
+        bounds: {
+          minX: 15.94,
+          maxX: 22.18,
+          minZ: -25.9,
+          maxZ: -10.6,
+        },
+      },
+      {
+        name: 'GroundStairLowerCornerGuard',
+        sourceId: 'ground.stair.lowerCorner.safetyCollider',
+        purpose: 'block raw lower-step occupancy',
+        bounds: {
+          minX: 15.5,
+          maxX: 22.18,
+          minZ: -10.6,
+          maxZ: -9.4,
+        },
+      },
+    ]);
+    expectSourceBackedSafetyColliders(colliders);
+  });
+
+  it('generates stable source-backed upper stair guard metadata and bounds', () => {
+    const colliders = createUpperStairSafetyColliders({
+      stairCenterX: geometry.centerX,
+      stairHalfWidth: geometry.halfWidth,
+      stairTopZ: geometry.topZ,
+      stairwellMarginX: 0.4,
+      doorwayDepth: 1.9,
+      playerRadius: PLAYER_RADIUS,
+      stairLandingTriggerMargin: behavior.landingTriggerMargin,
+      stairTransitionMargin: behavior.transitionMargin,
+      wallThickness: 0.32,
+      upperLandingRoomBounds: {
+        minX: -28,
+        maxX: 28,
+        minZ: -32,
+        maxZ: 28,
+      },
+      upperStairwellOpening: {
+        minX: 8.9,
+        maxX: 15.9,
+        minZ: -31.5,
+        maxZ: -23.8,
+      },
+      stairNavigationZones: createStairNavigationZones(geometry, behavior),
+      stairLayoutDirectionMultiplier: geometry.direction,
+      upperStairBannisterThickness: 0.28,
+    });
+
+    expect(
+      colliders.map((collider) => [collider.name, collider.sourceId])
+    ).toEqual([
+      [
+        'UpperStairEastLowerVoidGuard',
+        'upper.stairwell.eastLowerVoid.safetyCollider',
+      ],
+      [
+        'UpperStairEastUpperVoidGuard',
+        'upper.stairwell.eastUpperVoid.safetyCollider',
+      ],
+      [
+        'UpperStairHiddenRunVoidGuard',
+        'upper.stairwell.hiddenRun.safetyCollider',
+      ],
+      [
+        'UpperStairWestBannisterGuard',
+        'upper.stairwell.westBannister.safetyCollider',
+      ],
+      [
+        'UpperStairNorthBannisterGuard',
+        'upper.stairwell.northBannister.safetyCollider',
+      ],
+    ]);
+    expect(
+      colliders.find(
+        (collider) => collider.name === 'UpperStairEastLowerVoidGuard'
+      )?.bounds
+    ).toEqual({
+      minX: 14.75,
+      maxX: 15.9,
+      minZ: -31.5,
+      maxZ: -27.799999999999997,
+    });
+    expect(
+      colliders.find(
+        (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
+      )?.purpose
+    ).toBe('guard hidden stair run no-floor area');
+    expectSourceBackedSafetyColliders(colliders);
+  });
+});

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -1,0 +1,247 @@
+import type { RectCollider } from '../../systems/collision';
+import {
+  createGroundStairBoundaryColliders,
+  type GroundStairBoundaryColliderOptions,
+  type StairBehavior,
+  type StairGeometry,
+  type StairNavigationZones,
+} from '../../systems/movement/stairs';
+import { splitColliderAroundCorridor } from '../../systems/movement/upperStairLandingGuards';
+
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type LevelSafetyColliderCategory = 'stair' | 'landing' | 'void';
+export type LevelSafetyColliderFloor = 'ground' | 'upper';
+
+export interface LevelSafetyCollider {
+  sourceId: LevelSourceId;
+  name: string;
+  floor: LevelSafetyColliderFloor;
+  category: LevelSafetyColliderCategory;
+  bounds: RectCollider;
+  purpose: string;
+}
+
+export interface UpperStairSafetyColliderArgs {
+  stairCenterX: number;
+  stairHalfWidth: number;
+  stairTopZ: number;
+  stairwellMarginX: number;
+  doorwayDepth: number;
+  playerRadius: number;
+  stairLandingTriggerMargin: number;
+  stairTransitionMargin: number;
+  wallThickness: number;
+  upperLandingRoomBounds: RectCollider;
+  upperStairwellOpening: RectCollider;
+  stairNavigationZones: Pick<StairNavigationZones, 'explicitDescentCorridor'>;
+  stairLayoutDirectionMultiplier: 1 | -1;
+  upperStairBannisterThickness: number;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+
+export const createGroundStairSafetyColliders = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  options: GroundStairBoundaryColliderOptions
+): LevelSafetyCollider[] =>
+  createGroundStairBoundaryColliders(geometry, behavior, options).map(
+    (collider): LevelSafetyCollider => ({
+      ...collider,
+      floor: 'ground',
+      category: 'stair',
+      sourceId:
+        collider.name === 'GroundStairLowerCornerGuard'
+          ? sourceId('ground.stair.lowerCorner.safetyCollider')
+          : sourceId('ground.stair.eastBoundary.safetyCollider'),
+      purpose:
+        collider.name === 'GroundStairLowerCornerGuard'
+          ? 'block raw lower-step occupancy'
+          : 'prevent lower stair side squeeze',
+    })
+  );
+
+export const createUpperStairSafetyColliders = ({
+  stairCenterX,
+  stairHalfWidth,
+  stairTopZ,
+  stairwellMarginX,
+  doorwayDepth,
+  playerRadius,
+  stairLandingTriggerMargin,
+  stairTransitionMargin,
+  wallThickness,
+  upperLandingRoomBounds,
+  upperStairwellOpening,
+  stairNavigationZones,
+  stairLayoutDirectionMultiplier,
+  upperStairBannisterThickness,
+}: UpperStairSafetyColliderArgs): LevelSafetyCollider[] => {
+  const upperStairVoidMinZ = upperStairwellOpening.minZ;
+  const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
+  const upperLandingDoorwayClearanceZ =
+    upperLandingRoomBounds.maxZ - doorwayDepth / 2 - playerRadius;
+  const hiddenStairTopGapBlockerNearZ =
+    stairTopZ +
+    stairLayoutDirectionMultiplier * (playerRadius + stairLandingTriggerMargin);
+  const hiddenStairTopGapBlockerFarZ =
+    stairTopZ + stairLayoutDirectionMultiplier * playerRadius;
+  const hiddenStairTopGapBlockerMinX = stairCenterX - playerRadius;
+  const hiddenStairBlockerStartZ =
+    stairTopZ -
+    stairLayoutDirectionMultiplier *
+      (playerRadius + stairLandingTriggerMargin / 2);
+  const upperStairLandingEntryCorridor = {
+    minX: upperStairwellOpening.minX,
+    maxX: stairNavigationZones.explicitDescentCorridor.maxX + playerRadius,
+  };
+  const hiddenStairTopGapBlockerMinZ = Math.min(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const hiddenStairTopGapBlockerMaxZ = Math.max(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const upperStairLandingEntryMinZ = Math.max(
+    upperStairVoidMinZ,
+    hiddenStairTopGapBlockerMinZ - playerRadius
+  );
+  const upperStairLandingEntryMaxZ = Math.min(
+    upperStairVoidMaxZ,
+    hiddenStairTopGapBlockerMaxZ + playerRadius
+  );
+  const hiddenStairTopGapBlockerEdgeMinX = Math.max(
+    upperStairwellOpening.minX,
+    hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
+  );
+  const upperStairTopGapBlockers = splitColliderAroundCorridor({
+    name: 'UpperStairTopGapBlocker',
+    bounds: {
+      minX: hiddenStairTopGapBlockerEdgeMinX,
+      maxX: stairNavigationZones.explicitDescentCorridor.maxX + playerRadius,
+      minZ: hiddenStairTopGapBlockerMinZ,
+      maxZ: hiddenStairTopGapBlockerMaxZ,
+    },
+    corridor: upperStairLandingEntryCorridor,
+  });
+
+  const upperStairWestBannisterMinX = upperStairwellOpening.minX;
+  const upperStairWestBannisterMaxX =
+    stairNavigationZones.explicitDescentCorridor.minX - playerRadius - 0.01;
+  const upperStairWestBannisterShiftX = 1;
+  const upperStairNorthBannisterMinX =
+    stairNavigationZones.explicitDescentCorridor.minX +
+    upperStairBannisterThickness * 1.5;
+  const upperStairNorthBannisterBaseCenterZ =
+    upperLandingDoorwayClearanceZ - wallThickness;
+  const upperStairNorthBannisterCenterZ =
+    upperStairNorthBannisterBaseCenterZ + 2;
+  const upperStairWestBannisterSouthZ =
+    hiddenStairBlockerStartZ + upperStairBannisterThickness;
+  const upperStairNorthBannisterMaxX =
+    upperStairwellOpening.maxX - upperStairBannisterThickness;
+  const upperStairDescentHandoffFarZ =
+    stairTopZ -
+    stairLayoutDirectionMultiplier *
+      (stairTransitionMargin + stairLandingTriggerMargin);
+  const upperStairHiddenRunGuardNearZ =
+    upperStairDescentHandoffFarZ -
+    stairLayoutDirectionMultiplier * playerRadius;
+
+  return [
+    {
+      name: 'UpperStairEastLowerVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      sourceId: sourceId('upper.stairwell.eastLowerVoid.safetyCollider'),
+      purpose: 'guard upper stairwell void edge',
+      bounds: {
+        minX: stairNavigationZones.explicitDescentCorridor.maxX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperStairVoidMinZ,
+        maxZ: upperStairLandingEntryMinZ,
+      },
+    },
+    {
+      name: 'UpperStairEastUpperVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
+      purpose: 'guard upper stairwell void edge',
+      bounds: {
+        minX: stairNavigationZones.explicitDescentCorridor.maxX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperStairLandingEntryMaxZ,
+        maxZ: upperStairVoidMaxZ,
+      },
+    },
+    ...upperStairTopGapBlockers.map(
+      (collider, index): LevelSafetyCollider => ({
+        ...collider,
+        floor: 'upper',
+        category: 'landing',
+        sourceId: sourceId(`upper.stairwell.topGap${index + 1}.safetyCollider`),
+        purpose: 'preserve descent corridor edge',
+      })
+    ),
+    {
+      name: 'UpperStairHiddenRunVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      sourceId: sourceId('upper.stairwell.hiddenRun.safetyCollider'),
+      purpose: 'guard hidden stair run no-floor area',
+      bounds: {
+        minX: upperStairwellOpening.minX,
+        maxX: upperStairwellOpening.maxX,
+        minZ: Math.min(
+          upperStairHiddenRunGuardNearZ,
+          upperLandingDoorwayClearanceZ
+        ),
+        maxZ: Math.max(
+          upperStairHiddenRunGuardNearZ,
+          upperStairNorthBannisterBaseCenterZ -
+            upperStairBannisterThickness / 2 -
+            playerRadius -
+            0.01
+        ),
+      },
+    },
+    {
+      name: 'UpperStairWestBannisterGuard',
+      floor: 'upper',
+      category: 'stair',
+      sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),
+      purpose: 'preserve descent corridor edge',
+      bounds: {
+        minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
+        maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
+        minZ: Math.min(
+          upperStairNorthBannisterBaseCenterZ,
+          upperStairWestBannisterSouthZ
+        ),
+        maxZ:
+          Math.max(
+            upperStairNorthBannisterBaseCenterZ,
+            upperStairWestBannisterSouthZ
+          ) + 2,
+      },
+    },
+    {
+      name: 'UpperStairNorthBannisterGuard',
+      floor: 'upper',
+      category: 'stair',
+      sourceId: sourceId('upper.stairwell.northBannister.safetyCollider'),
+      purpose: 'block raw lower-step occupancy',
+      bounds: {
+        minX: upperStairNorthBannisterMinX,
+        maxX: upperStairNorthBannisterMaxX,
+        minZ:
+          upperStairNorthBannisterCenterZ - upperStairBannisterThickness / 2,
+        maxZ:
+          upperStairNorthBannisterCenterZ + upperStairBannisterThickness / 2,
+      },
+    },
+  ];
+};

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -40,12 +40,14 @@ describe('main module imports', () => {
   it('passes generated wall source IDs into debug collider metadata', () => {
     const source = readMainSource();
 
+    expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
+    expect(source).toContain('sourceId: instance.sourceId,');
+    expect(source).toContain("sourceType: 'wall',");
     expect(source).toContain(
-      'colliderSourceIds.set(instance.collider, instance.sourceId);'
+      'sourceId: colliderSourceMetadata.get(bounds)?.sourceId,'
     );
-    expect(source).toContain('sourceId: colliderSourceIds.get(bounds),');
     expect(source).toContain(
-      "sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,"
+      'sourceType: colliderSourceMetadata.get(bounds)?.sourceType,'
     );
   });
 


### PR DESCRIPTION
### Motivation
- Move ad-hoc upper and ground stair/landing/void safety colliders out of inline `main.ts` lists into a small source-backed generator so safety constraints carry stable semantic `sourceId` and `purpose` metadata. 
- Preserve exact runtime collider geometry and names used by gameplay and debug tooling while making safety colliders distinguishable from physical wall/fence geometry. 
- Expose safety collider `sourceId`/`sourceType`/`purpose` through existing debug APIs so reviewers and tests can assert intent for invisible constraints. 

### Description
- Add a typed safety collider model and generators in `src/scene/level/stairSafetyColliders.ts` (`LevelSafetyCollider`, `createGroundStairSafetyColliders`, `createUpperStairSafetyColliders`) that wrap existing calculations and attach `LevelSourceId` and concise `purpose` strings. 
- Replace the anonymous stair safety collider assembly in `src/main.ts` with calls to the new generators and record `sourceId`/`sourceType`/`purpose` in debug metadata via a new `colliderSourceMetadata` map without changing final collider bounds or visible geometry. 
- Add focused tests `src/scene/level/__tests__/stairSafetyColliders.test.ts` to assert generated bounds, stable source IDs, non-duplicated IDs, presence of `purpose`, and forbidden tombstone wording; update `src/tests/mainImports.test.ts` to reflect the new debug metadata wiring. 
- Update docs `docs/design/declarative-level-source-of-truth.md` to clarify the distinction between physical wall colliders and source-backed safety colliders and note the new implementation location. 

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed (lint emitted a single import-order warning which was fixed). 
- Ran focused unit tests with `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/systems/movement/stairs.test.ts` and `npm run test:ci -- src/tests/mainImports.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts src/systems/movement/stairs.test.ts`, and these tests passed. 
- Built and smoke-checked the app with `npm run build` and `npm run smoke`, both succeeded. 
- Attempted browser E2E `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` but it was blocked in this environment because Playwright browsers are not installed (`npx playwright install` required). 
- Note: an initial full `npm run test:ci` surfaced a test assertion expecting the old `colliderSourceIds` string, that assertion was updated to the new `colliderSourceMetadata` wiring and the affected tests were rerun and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3358248fd8832fa542d3e87900eb25)