### PR TITLE
Source-backed stair safety colliders

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -241,6 +241,14 @@ ID uniqueness across layers. Per-layer `id` fields are unique within their floor
 namespace so editor-friendly IDs can stay short while source IDs remain globally
 stable.
 
+Physical wall colliders and safety colliders are distinct source-backed outputs.
+Wall colliders represent visible or authored structural boundaries generated from
+wall definitions. Safety colliders represent intentional invisible constraints,
+such as stairwell void guards, landing edge preservation, and lower stair squeeze
+prevention. They must carry `sourceType: 'safetyCollider'`, a stable semantic
+`sourceId`, and a concise `purpose` explaining why the invisible constraint
+exists instead of pretending to be layout wall geometry.
+
 Wall authoring supports two current-state representations:
 
 - explicit positive wall `segments` for authors who want to spell out each

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,11 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+  type LevelSafetyCollider,
+} from './scene/level/stairSafetyColliders';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -404,7 +409,6 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
-  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -415,7 +419,6 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
-import { splitColliderAroundCorridor } from './systems/movement/upperStairLandingGuards';
 import {
   NARRATION_PREFERENCE_STORAGE_KEY,
   NarrationPreference,
@@ -977,9 +980,13 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
-const colliderSourceIds = new Map<
+const colliderSourceMetadata = new Map<
   RectCollider,
-  WallSegmentInstance['sourceId']
+  {
+    sourceId: WallSegmentInstance['sourceId'] | LevelSafetyCollider['sourceId'];
+    sourceType: 'wall' | 'safetyCollider';
+    purpose?: string;
+  }
 >();
 const upperFloorColliders: RectCollider[] = [];
 
@@ -1905,7 +1912,10 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
@@ -2058,7 +2068,7 @@ function initializeImmersiveScene(
     maxZ: stairGuardMaxZ,
   });
 
-  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
+  const groundStairSafetyColliders = createGroundStairSafetyColliders(
     stairGeometry,
     stairBehavior,
     {
@@ -2066,9 +2076,14 @@ function initializeImmersiveScene(
       guardThickness: stairGuardThickness,
     }
   );
-  groundStairBoundaryColliders.forEach(({ name, bounds }) => {
-    groundColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
+  groundStairSafetyColliders.forEach((collider) => {
+    groundColliders.push(collider.bounds);
+    namedColliderDebugNames.set(collider.bounds, collider.name);
+    colliderSourceMetadata.set(collider.bounds, {
+      sourceId: collider.sourceId,
+      sourceType: 'safetyCollider',
+      purpose: collider.purpose,
+    });
   });
 
   const upperFloorGroup = new Group();
@@ -2112,163 +2127,30 @@ function initializeImmersiveScene(
   // computeStairLayout result used by movement. It removes both the stair
   // landing void and the hidden ramp run below the landing lip.
   if (upperLandingRoom && upperStairwellOpening) {
-    const upperStairVoidMinZ = upperStairwellOpening.minZ;
-    const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperLandingDoorwayClearanceZ =
-      upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerNearZ =
-      stairTopZ +
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin);
-    const hiddenStairTopGapBlockerFarZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairBlockerStartZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin / 2);
-    // Invisible upper-floor guard rails flank the intentional descent corridor.
-    // They are scoped to the actual upper-floor cutout instead of the full ramp
-    // run so normal loft space beyond the landing remains occupiable.
-    // UpperStairDeepVoidBlocker is intentionally absent: it covered the visible
-    // physical StaircaseLanding slab, while the remaining top-gap, hidden-run,
-    // bannister, and void blockers still guard the true no-floor cutout edges.
-    // The hidden-run blocker starts one player radius beyond the explicit
-    // descent handoff band so legitimate upper-floor descent remains open.
-    const upperStairLandingEntryCorridor = {
-      // Keep the upper landing mouth open far enough for a real westward
-      // egress step after handoff; side guards still seal hidden void edges.
-      minX: upperStairwellOpening.minX,
-      // Size the east edge from the real upper-floor descent opening and add
-      // one collision radius because collider checks expand the blocker edge.
-      maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-    };
-    const hiddenStairTopGapBlockerMinZ = Math.min(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const hiddenStairTopGapBlockerMaxZ = Math.max(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const upperStairLandingEntryMinZ = Math.max(
-      upperStairVoidMinZ,
-      hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
-    );
-    const upperStairLandingEntryMaxZ = Math.min(
-      upperStairVoidMaxZ,
-      hiddenStairTopGapBlockerMaxZ + PLAYER_RADIUS
-    );
-    const hiddenStairTopGapBlockerEdgeMinX = Math.max(
-      upperStairwellOpening.minX,
-      hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
-    );
-    const upperStairTopGapBlockers = splitColliderAroundCorridor({
-      name: 'UpperStairTopGapBlocker',
-      bounds: {
-        minX: hiddenStairTopGapBlockerEdgeMinX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-        minZ: hiddenStairTopGapBlockerMinZ,
-        maxZ: hiddenStairTopGapBlockerMaxZ,
-      },
-      corridor: upperStairLandingEntryCorridor,
+    const upperStairSafetyColliders = createUpperStairSafetyColliders({
+      stairCenterX,
+      stairHalfWidth,
+      stairTopZ,
+      stairTransitionMargin,
+      stairLandingTriggerMargin,
+      stairwellMarginX,
+      playerRadius: PLAYER_RADIUS,
+      wallThickness: WALL_THICKNESS,
+      upperLandingRoomBounds: upperLandingRoom.bounds,
+      upperStairwellOpening,
+      stairNavigationZones,
+      stairLayoutDirectionMultiplier: stairLayout.directionMultiplier,
+      upperStairBannisterThickness: STAIRCASE_CONFIG.landing.guard.thickness,
     });
 
-    const upperStairBannisterThickness =
-      STAIRCASE_CONFIG.landing.guard.thickness;
-    const upperStairWestBannisterMinX = upperStairwellOpening.minX;
-    // Keep a full player-radius clearance between the side guard and the
-    // explicit descent lane; collision checks expand colliders by that radius.
-    const upperStairWestBannisterMaxX =
-      stairNavigationZones.explicitDescentCorridor.minX - PLAYER_RADIUS - 0.01;
-    const upperStairWestBannisterShiftX = 1;
-    const upperStairNorthBannisterMinX =
-      stairNavigationZones.explicitDescentCorridor.minX +
-      upperStairBannisterThickness * 1.5;
-    const upperStairNorthBannisterBaseCenterZ =
-      upperLandingDoorwayClearanceZ - WALL_THICKNESS;
-    const upperStairNorthBannisterCenterZ =
-      upperStairNorthBannisterBaseCenterZ + 2;
-    const upperStairWestBannisterSouthZ =
-      hiddenStairBlockerStartZ + upperStairBannisterThickness;
-    const upperStairNorthBannisterMaxX =
-      upperStairwellOpening.maxX - upperStairBannisterThickness;
-    const upperStairDescentHandoffFarZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (stairTransitionMargin + stairLandingTriggerMargin);
-    const upperStairHiddenRunGuardNearZ =
-      upperStairDescentHandoffFarZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-
-    [
-      // UpperStairWestUpperVoidGuard is intentionally omitted so the widened
-      // upstairs landing-side passage remains traversable.
-      {
-        name: 'UpperStairEastLowerVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairVoidMinZ,
-          maxZ: upperStairLandingEntryMinZ,
-        },
-      },
-      {
-        name: 'UpperStairEastUpperVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairLandingEntryMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
-      ...upperStairTopGapBlockers,
-      {
-        name: 'UpperStairHiddenRunVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.maxX,
-          minZ: Math.min(
-            upperStairHiddenRunGuardNearZ,
-            upperLandingDoorwayClearanceZ
-          ),
-          maxZ: Math.max(
-            upperStairHiddenRunGuardNearZ,
-            upperStairNorthBannisterBaseCenterZ -
-              upperStairBannisterThickness / 2 -
-              PLAYER_RADIUS -
-              0.01
-          ),
-        },
-      },
-      {
-        name: 'UpperStairWestBannisterGuard',
-        bounds: {
-          minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
-          maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
-          minZ: Math.min(
-            upperStairNorthBannisterBaseCenterZ,
-            upperStairWestBannisterSouthZ
-          ),
-          maxZ:
-            Math.max(
-              upperStairNorthBannisterBaseCenterZ,
-              upperStairWestBannisterSouthZ
-            ) + 2,
-        },
-      },
-      {
-        name: 'UpperStairNorthBannisterGuard',
-        bounds: {
-          minX: upperStairNorthBannisterMinX,
-          maxX: upperStairNorthBannisterMaxX,
-          minZ:
-            upperStairNorthBannisterCenterZ - upperStairBannisterThickness / 2,
-          maxZ:
-            upperStairNorthBannisterCenterZ + upperStairBannisterThickness / 2,
-        },
-      },
-    ].forEach(({ name, bounds }) => pushNamedUpperFloorCollider(name, bounds));
+    upperStairSafetyColliders.forEach((collider) => {
+      pushNamedUpperFloorCollider(collider.name, collider.bounds);
+      colliderSourceMetadata.set(collider.bounds, {
+        sourceId: collider.sourceId,
+        sourceType: 'safetyCollider',
+        purpose: collider.purpose,
+      });
+    });
   }
 
   const staircaseLandingFootprint = {
@@ -2400,7 +2282,10 @@ function initializeImmersiveScene(
       instance.collider,
       getUpperWallSegmentDebugName(instance)
     );
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {
@@ -4493,8 +4378,9 @@ function initializeImmersiveScene(
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
-      sourceId: colliderSourceIds.get(bounds),
-      sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,
+      sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
+      sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
+      purpose: colliderSourceMetadata.get(bounds)?.purpose,
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+} from '../stairSafetyColliders';
+
+const sourceIdTombstonePattern =
+  /(^|\.)(former|removed|debugonlyremoval)(\.|$)/;
+
+describe('stair safety collider source metadata', () => {
+  it('adds source IDs and purposes to ground stair safety colliders', () => {
+    const colliders = createGroundStairSafetyColliders(
+      {
+        centerX: 12.4,
+        halfWidth: 3.1,
+        bottomZ: -10.6,
+        topZ: -25.9,
+        landingMinZ: -31.1,
+        landingMaxZ: -25.9,
+        totalRise: 3.78,
+        direction: -1,
+      },
+      {
+        transitionMargin: 1.2,
+        landingTriggerMargin: 0.4,
+        stepRise: 0.42,
+        descentCorridorInset: 0.75,
+      },
+      {
+        playerRadius: 0.75,
+        guardThickness: 0.44,
+      }
+    );
+
+    expect(colliders).toMatchObject([
+      {
+        name: 'GroundStairEastBoundary',
+        sourceId: 'ground.stairwell.eastBoundary.safetyCollider',
+        purpose: 'prevent lower stair side squeeze',
+        bounds: {
+          minX: 15.94,
+          maxX: 22.18,
+          minZ: -25.9,
+          maxZ: -10.6,
+        },
+      },
+      {
+        name: 'GroundStairLowerCornerGuard',
+        sourceId: 'ground.stairwell.lowerCorner.safetyCollider',
+        purpose: 'block raw lower-step occupancy',
+        bounds: {
+          minX: 15.5,
+          maxX: 22.18,
+          minZ: -10.6,
+          maxZ: -9.4,
+        },
+      },
+    ]);
+  });
+
+  it('keeps upper stair guard names and source-backed purposes stable', () => {
+    const colliders = createUpperStairSafetyColliders({
+      stairCenterX: 12.4,
+      stairHalfWidth: 3.1,
+      stairTopZ: -25.9,
+      stairTransitionMargin: 1.2,
+      stairLandingTriggerMargin: 0.4,
+      stairwellMarginX: 1.25,
+      playerRadius: 0.75,
+      wallThickness: 0.36,
+      upperLandingRoomBounds: {
+        minX: 4,
+        maxX: 20,
+        minZ: -34,
+        maxZ: -20,
+      },
+      upperStairwellOpening: {
+        minX: 8.05,
+        maxX: 16.75,
+        minZ: -32.1,
+        maxZ: -24.65,
+      },
+      stairNavigationZones: {
+        lowerStairEntrance: { minX: 8.1, maxX: 16.7, minZ: -10.6, maxZ: -9.4 },
+        stairRampBody: { minX: 9.3, maxX: 15.5, minZ: -25.9, maxZ: -10.6 },
+        upperLanding: { minX: 9.3, maxX: 15.5, minZ: -31.1, maxZ: -25.9 },
+        explicitDescentCorridor: {
+          minX: 10.05,
+          maxX: 14.75,
+          minZ: -25.9,
+          maxZ: -10.6,
+        },
+      },
+      stairLayoutDirectionMultiplier: -1,
+      upperStairBannisterThickness: 0.32,
+    });
+
+    expect(colliders.map((collider) => collider.name)).toEqual([
+      'UpperStairEastLowerVoidGuard',
+      'UpperStairEastUpperVoidGuard',
+      'UpperStairHiddenRunVoidGuard',
+      'UpperStairWestBannisterGuard',
+      'UpperStairNorthBannisterGuard',
+    ]);
+    expect(colliders).toContainEqual(
+      expect.objectContaining({
+        name: 'UpperStairEastLowerVoidGuard',
+        sourceId: 'upper.stairwell.eastLowerVoid.safetyCollider',
+        purpose: 'guard upper stairwell void edge',
+        bounds: expect.objectContaining({
+          minX: 14.75,
+          maxX: 16.75,
+          minZ: -32.1,
+          maxZ: -27.799999999999997,
+        }),
+      })
+    );
+  });
+
+  it('requires unique current-state source IDs and non-empty purposes', () => {
+    const allColliders = [
+      ...createGroundStairSafetyColliders(
+        {
+          centerX: 12.4,
+          halfWidth: 3.1,
+          bottomZ: -10.6,
+          topZ: -25.9,
+          landingMinZ: -31.1,
+          landingMaxZ: -25.9,
+          totalRise: 3.78,
+          direction: -1,
+        },
+        {
+          transitionMargin: 1.2,
+          landingTriggerMargin: 0.4,
+          stepRise: 0.42,
+          descentCorridorInset: 0.75,
+        },
+        { playerRadius: 0.75, guardThickness: 0.44 }
+      ),
+    ];
+    const sourceIds = allColliders.map((collider) => collider.sourceId);
+
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(
+      allColliders.every((collider) => collider.purpose.trim().length > 0)
+    ).toBe(true);
+    expect(sourceIds).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(sourceIdTombstonePattern)])
+    );
+  });
+});

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -1,0 +1,261 @@
+import type { RectCollider } from '../../systems/collision';
+import {
+  createGroundStairBoundaryColliders,
+  type FloorId,
+  type StairBehavior,
+  type StairGeometry,
+  type StairNavigationZones,
+} from '../../systems/movement/stairs';
+import { splitColliderAroundCorridor } from '../../systems/movement/upperStairLandingGuards';
+
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type SafetyColliderCategory = 'stair' | 'landing' | 'void';
+
+export interface LevelSafetyCollider {
+  sourceId: LevelSourceId;
+  name: string;
+  floor: FloorId;
+  category: SafetyColliderCategory;
+  bounds: RectCollider;
+  purpose: string;
+}
+
+export interface GroundStairSafetyColliderOptions {
+  playerRadius: number;
+  guardThickness: number;
+}
+
+export interface UpperStairSafetyColliderArgs {
+  stairCenterX: number;
+  stairHalfWidth: number;
+  stairTopZ: number;
+  stairTransitionMargin: number;
+  stairLandingTriggerMargin: number;
+  stairwellMarginX: number;
+  playerRadius: number;
+  wallThickness: number;
+  upperLandingRoomBounds: RectCollider;
+  upperStairwellOpening: RectCollider;
+  stairNavigationZones: StairNavigationZones;
+  stairLayoutDirectionMultiplier: 1 | -1;
+  upperStairBannisterThickness: number;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+
+export const createGroundStairSafetyColliders = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  options: GroundStairSafetyColliderOptions
+): LevelSafetyCollider[] =>
+  createGroundStairBoundaryColliders(geometry, behavior, options).map(
+    (collider) => {
+      if (collider.name === 'GroundStairEastBoundary') {
+        return {
+          sourceId: sourceId('ground.stairwell.eastBoundary.safetyCollider'),
+          name: collider.name,
+          floor: 'ground',
+          category: 'stair',
+          bounds: collider.bounds,
+          purpose: 'prevent lower stair side squeeze',
+        };
+      }
+
+      return {
+        sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
+        name: collider.name,
+        floor: 'ground',
+        category: 'stair',
+        bounds: collider.bounds,
+        purpose: 'block raw lower-step occupancy',
+      };
+    }
+  );
+
+export const createUpperStairSafetyColliders = ({
+  stairCenterX,
+  stairHalfWidth,
+  stairTopZ,
+  stairTransitionMargin,
+  stairLandingTriggerMargin,
+  stairwellMarginX,
+  playerRadius,
+  wallThickness,
+  upperLandingRoomBounds,
+  upperStairwellOpening,
+  stairNavigationZones,
+  stairLayoutDirectionMultiplier,
+  upperStairBannisterThickness,
+}: UpperStairSafetyColliderArgs): LevelSafetyCollider[] => {
+  const upperStairVoidMinZ = upperStairwellOpening.minZ;
+  const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
+  const doorwayDepth = wallThickness + playerRadius * 2;
+  const upperLandingDoorwayClearanceZ =
+    upperLandingRoomBounds.maxZ - doorwayDepth / 2 - playerRadius;
+  const hiddenStairTopGapBlockerNearZ =
+    stairTopZ +
+    stairLayoutDirectionMultiplier * (playerRadius + stairLandingTriggerMargin);
+  const hiddenStairTopGapBlockerFarZ =
+    stairTopZ + stairLayoutDirectionMultiplier * playerRadius;
+  const hiddenStairTopGapBlockerMinX = stairCenterX - playerRadius;
+  const hiddenStairBlockerStartZ =
+    stairTopZ -
+    stairLayoutDirectionMultiplier *
+      (playerRadius + stairLandingTriggerMargin / 2);
+  const upperStairLandingEntryCorridor = {
+    minX: upperStairwellOpening.minX,
+    maxX: stairNavigationZones.explicitDescentCorridor.maxX + playerRadius,
+  };
+  const hiddenStairTopGapBlockerMinZ = Math.min(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const hiddenStairTopGapBlockerMaxZ = Math.max(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const upperStairLandingEntryMinZ = Math.max(
+    upperStairVoidMinZ,
+    hiddenStairTopGapBlockerMinZ - playerRadius
+  );
+  const upperStairLandingEntryMaxZ = Math.min(
+    upperStairVoidMaxZ,
+    hiddenStairTopGapBlockerMaxZ + playerRadius
+  );
+  const hiddenStairTopGapBlockerEdgeMinX = Math.max(
+    upperStairwellOpening.minX,
+    hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
+  );
+  const upperStairTopGapBlockers = splitColliderAroundCorridor({
+    name: 'UpperStairTopGapBlocker',
+    bounds: {
+      minX: hiddenStairTopGapBlockerEdgeMinX,
+      maxX: stairNavigationZones.explicitDescentCorridor.maxX + playerRadius,
+      minZ: hiddenStairTopGapBlockerMinZ,
+      maxZ: hiddenStairTopGapBlockerMaxZ,
+    },
+    corridor: upperStairLandingEntryCorridor,
+  });
+
+  const upperStairWestBannisterMinX = upperStairwellOpening.minX;
+  const upperStairWestBannisterMaxX =
+    stairNavigationZones.explicitDescentCorridor.minX - playerRadius - 0.01;
+  const upperStairWestBannisterShiftX = 1;
+  const upperStairNorthBannisterMinX =
+    stairNavigationZones.explicitDescentCorridor.minX +
+    upperStairBannisterThickness * 1.5;
+  const upperStairNorthBannisterBaseCenterZ =
+    upperLandingDoorwayClearanceZ - wallThickness;
+  const upperStairNorthBannisterCenterZ =
+    upperStairNorthBannisterBaseCenterZ + 2;
+  const upperStairWestBannisterSouthZ =
+    hiddenStairBlockerStartZ + upperStairBannisterThickness;
+  const upperStairNorthBannisterMaxX =
+    upperStairwellOpening.maxX - upperStairBannisterThickness;
+  const upperStairDescentHandoffFarZ =
+    stairTopZ -
+    stairLayoutDirectionMultiplier *
+      (stairTransitionMargin + stairLandingTriggerMargin);
+  const upperStairHiddenRunGuardNearZ =
+    upperStairDescentHandoffFarZ -
+    stairLayoutDirectionMultiplier * playerRadius;
+
+  const topGapColliders: LevelSafetyCollider[] = upperStairTopGapBlockers.map(
+    ({ name, bounds }, index) => ({
+      sourceId: sourceId(`upper.stairwell.topGap${index + 1}.safetyCollider`),
+      name,
+      floor: 'upper',
+      category: 'void',
+      bounds,
+      purpose: 'guard upper stairwell void edge',
+    })
+  );
+
+  return [
+    {
+      sourceId: sourceId('upper.stairwell.eastLowerVoid.safetyCollider'),
+      name: 'UpperStairEastLowerVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      bounds: {
+        minX: stairNavigationZones.explicitDescentCorridor.maxX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperStairVoidMinZ,
+        maxZ: upperStairLandingEntryMinZ,
+      },
+      purpose: 'guard upper stairwell void edge',
+    },
+    {
+      sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
+      name: 'UpperStairEastUpperVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      bounds: {
+        minX: stairNavigationZones.explicitDescentCorridor.maxX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperStairLandingEntryMaxZ,
+        maxZ: upperStairVoidMaxZ,
+      },
+      purpose: 'guard upper stairwell void edge',
+    },
+    ...topGapColliders,
+    {
+      sourceId: sourceId('upper.stairwell.hiddenRun.safetyCollider'),
+      name: 'UpperStairHiddenRunVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      bounds: {
+        minX: upperStairwellOpening.minX,
+        maxX: upperStairwellOpening.maxX,
+        minZ: Math.min(
+          upperStairHiddenRunGuardNearZ,
+          upperLandingDoorwayClearanceZ
+        ),
+        maxZ: Math.max(
+          upperStairHiddenRunGuardNearZ,
+          upperStairNorthBannisterBaseCenterZ -
+            upperStairBannisterThickness / 2 -
+            playerRadius -
+            0.01
+        ),
+      },
+      purpose: 'guard hidden stair run no-floor area',
+    },
+    {
+      sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),
+      name: 'UpperStairWestBannisterGuard',
+      floor: 'upper',
+      category: 'landing',
+      bounds: {
+        minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
+        maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
+        minZ: Math.min(
+          upperStairNorthBannisterBaseCenterZ,
+          upperStairWestBannisterSouthZ
+        ),
+        maxZ:
+          Math.max(
+            upperStairNorthBannisterBaseCenterZ,
+            upperStairWestBannisterSouthZ
+          ) + 2,
+      },
+      purpose: 'preserve descent corridor edge',
+    },
+    {
+      sourceId: sourceId('upper.stairwell.northBannister.safetyCollider'),
+      name: 'UpperStairNorthBannisterGuard',
+      floor: 'upper',
+      category: 'landing',
+      bounds: {
+        minX: upperStairNorthBannisterMinX,
+        maxX: upperStairNorthBannisterMaxX,
+        minZ:
+          upperStairNorthBannisterCenterZ - upperStairBannisterThickness / 2,
+        maxZ:
+          upperStairNorthBannisterCenterZ + upperStairBannisterThickness / 2,
+      },
+      purpose: 'preserve descent corridor edge',
+    },
+  ];
+};

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -37,15 +37,17 @@ describe('main module imports', () => {
     );
   });
 
-  it('passes generated wall source IDs into debug collider metadata', () => {
+  it('passes source IDs into debug collider metadata', () => {
     const source = readMainSource();
 
+    expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
+    expect(source).toContain("sourceType: 'wall',");
+    expect(source).toContain("sourceType: 'safetyCollider',");
     expect(source).toContain(
-      'colliderSourceIds.set(instance.collider, instance.sourceId);'
+      'sourceId: colliderSourceMetadata.get(bounds)?.sourceId,'
     );
-    expect(source).toContain('sourceId: colliderSourceIds.get(bounds),');
     expect(source).toContain(
-      "sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,"
+      'purpose: colliderSourceMetadata.get(bounds)?.purpose,'
     );
   });
 


### PR DESCRIPTION
### Motivation
- Move ad-hoc stair, landing, and void safety colliders out of anonymous lists in `main.ts` into source-backed generators so invisible safety constraints are first-class and auditable.
- Preserve runtime behavior and visible debug blocker names while attaching stable `sourceId` and concise `purpose` metadata for future declarative editing and validation.

### Description
- Added a typed safety-collider model and generators in `src/scene/level/stairSafetyColliders.ts` (`LevelSafetyCollider`, `createGroundStairSafetyColliders`, `createUpperStairSafetyColliders`).
- Replaced the inline anonymous upper/ground stair collider assembly in `src/main.ts` with calls to the new generators and registered each collider's `sourceId`, `sourceType: 'safetyCollider'`, and `purpose` into the debug metadata map used by the collider visualizer.
- Preserved existing blocker names (e.g. `UpperStairEastLowerVoidGuard`, `UpperStairHiddenRunVoidGuard`, `GroundStairEastBoundary`) and numeric bounds so collision behavior is unchanged.
- Added focused tests `src/scene/level/__tests__/stairSafetyColliders.test.ts` and updated `src/tests/mainImports.test.ts` to assert names, bounds, `sourceId`/`purpose` presence, uniqueness, and debug wiring; and updated the design doc `docs/design/declarative-level-source-of-truth.md` to explain safety-collider semantics.

### Testing
- Ran formatting and lint: `npm run format:write` and `npm run lint` — passed (one import-order warning fixed in the change set).
- Focused unit tests: `npm run test:ci -- src/systems/movement/stairs.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts` — passed.
- Full unit test suite: `npm run test:ci` — all tests passed (155 files, 1188 tests in this environment).
- Build and smoke checks: `npm run build` and `npm run smoke` — passed.
- Docs check: `npm run docs:check` — passed (link checker reported external fetch warnings but exited successfully).
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.
- Playwright e2e: attempted `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` but it failed to launch browsers in this environment with the error indicating Playwright browsers are not installed (suggested fix: run `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a335833d208832f9b1259160e5bcf90)