### PR TITLE
🧱 : – source stair safety colliders

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -124,9 +124,19 @@ rather than preserving historical missing-floor artifacts.
 
 Safety colliders are invisible constraints that should exist, each with a stated
 purpose such as preventing stairwell falls, preserving stair approach lanes,
-blocking unfinished zones, or protecting showpiece footprints. They should carry
-source IDs, floor assignment, bounds, and purpose text so reviewers can tell why
-the invisible constraint exists.
+blocking unfinished zones, or protecting showpiece footprints. They are distinct
+from physical wall colliders: walls describe visible layout boundaries and emit
+wall meshes/debug metadata, while safety colliders describe intentional invisible
+runtime constraints that keep traversal safe around voids, stairs, landings, and
+other no-floor areas. They should carry source IDs, floor assignment, bounds, and
+purpose text so reviewers can tell why the invisible constraint exists instead of
+mistaking it for hidden post-hoc layout geometry.
+
+Stair and landing safety colliders are source-backed even when their bounds are
+generated from stair layout measurements. Their source IDs should stay stable
+across refactors, and their purpose strings should explain the constraint (for
+example preserving a descent corridor edge or guarding a hidden stair-run
+no-floor area) without masquerading as room-wall geometry.
 
 ### Scene objects
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,11 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+  type LevelSafetyCollider,
+} from './scene/level/stairSafetyColliders';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -404,7 +409,6 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
-  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -415,7 +419,6 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
-import { splitColliderAroundCorridor } from './systems/movement/upperStairLandingGuards';
 import {
   NARRATION_PREFERENCE_STORAGE_KEY,
   NarrationPreference,
@@ -977,9 +980,13 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
-const colliderSourceIds = new Map<
+const colliderSourceMetadata = new Map<
   RectCollider,
-  WallSegmentInstance['sourceId']
+  {
+    sourceId: WallSegmentInstance['sourceId'] | LevelSafetyCollider['sourceId'];
+    sourceType: 'wall' | 'safetyCollider';
+    purpose?: string;
+  }
 >();
 const upperFloorColliders: RectCollider[] = [];
 
@@ -1905,7 +1912,10 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
@@ -2058,18 +2068,22 @@ function initializeImmersiveScene(
     maxZ: stairGuardMaxZ,
   });
 
-  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
-    stairGeometry,
-    stairBehavior,
-    {
-      playerRadius: PLAYER_RADIUS,
-      guardThickness: stairGuardThickness,
-    }
-  );
-  groundStairBoundaryColliders.forEach(({ name, bounds }) => {
-    groundColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
-  });
+  const registerSafetyCollider = (collider: LevelSafetyCollider) => {
+    const targetColliders =
+      collider.floor === 'ground' ? groundColliders : upperFloorColliders;
+    targetColliders.push(collider.bounds);
+    namedColliderDebugNames.set(collider.bounds, collider.name);
+    colliderSourceMetadata.set(collider.bounds, {
+      sourceId: collider.sourceId,
+      sourceType: 'safetyCollider',
+      purpose: collider.purpose,
+    });
+  };
+
+  createGroundStairSafetyColliders(stairGeometry, stairBehavior, {
+    playerRadius: PLAYER_RADIUS,
+    guardThickness: stairGuardThickness,
+  }).forEach(registerSafetyCollider);
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;
@@ -2112,163 +2126,22 @@ function initializeImmersiveScene(
   // computeStairLayout result used by movement. It removes both the stair
   // landing void and the hidden ramp run below the landing lip.
   if (upperLandingRoom && upperStairwellOpening) {
-    const upperStairVoidMinZ = upperStairwellOpening.minZ;
-    const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperLandingDoorwayClearanceZ =
-      upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerNearZ =
-      stairTopZ +
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin);
-    const hiddenStairTopGapBlockerFarZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairBlockerStartZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin / 2);
-    // Invisible upper-floor guard rails flank the intentional descent corridor.
-    // They are scoped to the actual upper-floor cutout instead of the full ramp
-    // run so normal loft space beyond the landing remains occupiable.
-    // UpperStairDeepVoidBlocker is intentionally absent: it covered the visible
-    // physical StaircaseLanding slab, while the remaining top-gap, hidden-run,
-    // bannister, and void blockers still guard the true no-floor cutout edges.
-    // The hidden-run blocker starts one player radius beyond the explicit
-    // descent handoff band so legitimate upper-floor descent remains open.
-    const upperStairLandingEntryCorridor = {
-      // Keep the upper landing mouth open far enough for a real westward
-      // egress step after handoff; side guards still seal hidden void edges.
-      minX: upperStairwellOpening.minX,
-      // Size the east edge from the real upper-floor descent opening and add
-      // one collision radius because collider checks expand the blocker edge.
-      maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-    };
-    const hiddenStairTopGapBlockerMinZ = Math.min(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const hiddenStairTopGapBlockerMaxZ = Math.max(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const upperStairLandingEntryMinZ = Math.max(
-      upperStairVoidMinZ,
-      hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
-    );
-    const upperStairLandingEntryMaxZ = Math.min(
-      upperStairVoidMaxZ,
-      hiddenStairTopGapBlockerMaxZ + PLAYER_RADIUS
-    );
-    const hiddenStairTopGapBlockerEdgeMinX = Math.max(
-      upperStairwellOpening.minX,
-      hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
-    );
-    const upperStairTopGapBlockers = splitColliderAroundCorridor({
-      name: 'UpperStairTopGapBlocker',
-      bounds: {
-        minX: hiddenStairTopGapBlockerEdgeMinX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-        minZ: hiddenStairTopGapBlockerMinZ,
-        maxZ: hiddenStairTopGapBlockerMaxZ,
-      },
-      corridor: upperStairLandingEntryCorridor,
-    });
-
-    const upperStairBannisterThickness =
-      STAIRCASE_CONFIG.landing.guard.thickness;
-    const upperStairWestBannisterMinX = upperStairwellOpening.minX;
-    // Keep a full player-radius clearance between the side guard and the
-    // explicit descent lane; collision checks expand colliders by that radius.
-    const upperStairWestBannisterMaxX =
-      stairNavigationZones.explicitDescentCorridor.minX - PLAYER_RADIUS - 0.01;
-    const upperStairWestBannisterShiftX = 1;
-    const upperStairNorthBannisterMinX =
-      stairNavigationZones.explicitDescentCorridor.minX +
-      upperStairBannisterThickness * 1.5;
-    const upperStairNorthBannisterBaseCenterZ =
-      upperLandingDoorwayClearanceZ - WALL_THICKNESS;
-    const upperStairNorthBannisterCenterZ =
-      upperStairNorthBannisterBaseCenterZ + 2;
-    const upperStairWestBannisterSouthZ =
-      hiddenStairBlockerStartZ + upperStairBannisterThickness;
-    const upperStairNorthBannisterMaxX =
-      upperStairwellOpening.maxX - upperStairBannisterThickness;
-    const upperStairDescentHandoffFarZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (stairTransitionMargin + stairLandingTriggerMargin);
-    const upperStairHiddenRunGuardNearZ =
-      upperStairDescentHandoffFarZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-
-    [
-      // UpperStairWestUpperVoidGuard is intentionally omitted so the widened
-      // upstairs landing-side passage remains traversable.
-      {
-        name: 'UpperStairEastLowerVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairVoidMinZ,
-          maxZ: upperStairLandingEntryMinZ,
-        },
-      },
-      {
-        name: 'UpperStairEastUpperVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairLandingEntryMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
-      ...upperStairTopGapBlockers,
-      {
-        name: 'UpperStairHiddenRunVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.maxX,
-          minZ: Math.min(
-            upperStairHiddenRunGuardNearZ,
-            upperLandingDoorwayClearanceZ
-          ),
-          maxZ: Math.max(
-            upperStairHiddenRunGuardNearZ,
-            upperStairNorthBannisterBaseCenterZ -
-              upperStairBannisterThickness / 2 -
-              PLAYER_RADIUS -
-              0.01
-          ),
-        },
-      },
-      {
-        name: 'UpperStairWestBannisterGuard',
-        bounds: {
-          minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
-          maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
-          minZ: Math.min(
-            upperStairNorthBannisterBaseCenterZ,
-            upperStairWestBannisterSouthZ
-          ),
-          maxZ:
-            Math.max(
-              upperStairNorthBannisterBaseCenterZ,
-              upperStairWestBannisterSouthZ
-            ) + 2,
-        },
-      },
-      {
-        name: 'UpperStairNorthBannisterGuard',
-        bounds: {
-          minX: upperStairNorthBannisterMinX,
-          maxX: upperStairNorthBannisterMaxX,
-          minZ:
-            upperStairNorthBannisterCenterZ - upperStairBannisterThickness / 2,
-          maxZ:
-            upperStairNorthBannisterCenterZ + upperStairBannisterThickness / 2,
-        },
-      },
-    ].forEach(({ name, bounds }) => pushNamedUpperFloorCollider(name, bounds));
+    createUpperStairSafetyColliders({
+      stairCenterX,
+      stairHalfWidth,
+      playerRadius: PLAYER_RADIUS,
+      wallThickness: WALL_THICKNESS,
+      doorwayDepth,
+      stairwellMarginX,
+      stairTopZ,
+      stairTransitionMargin,
+      stairLandingTriggerMargin,
+      stairLayoutDirectionMultiplier: stairLayout.directionMultiplier,
+      upperLandingRoomBounds: upperLandingRoom.bounds,
+      upperStairwellOpening,
+      stairNavigationZones,
+      upperStairBannisterThickness: STAIRCASE_CONFIG.landing.guard.thickness,
+    }).forEach(registerSafetyCollider);
   }
 
   const staircaseLandingFootprint = {
@@ -2400,7 +2273,10 @@ function initializeImmersiveScene(
       instance.collider,
       getUpperWallSegmentDebugName(instance)
     );
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {
@@ -4493,8 +4369,9 @@ function initializeImmersiveScene(
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
-      sourceId: colliderSourceIds.get(bounds),
-      sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,
+      sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
+      sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
+      purpose: colliderSourceMetadata.get(bounds)?.purpose,
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createStairNavigationZones,
+  type StairBehavior,
+  type StairGeometry,
+} from '../../../systems/movement/stairs';
+import { getDeclaredColliderDebugId } from '../../debug/colliderDebugIds';
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+  type LevelSafetyCollider,
+} from '../stairSafetyColliders';
+
+const PLAYER_RADIUS = 0.75;
+
+const geometry: StairGeometry = {
+  centerX: 12.4,
+  halfWidth: 3.1,
+  bottomZ: -10.6,
+  topZ: -25.9,
+  landingMinZ: -31.1,
+  landingMaxZ: -25.9,
+  totalRise: 3.78,
+  direction: -1,
+};
+
+const behavior: StairBehavior = {
+  transitionMargin: 1.2,
+  landingTriggerMargin: 0.4,
+  stepRise: 0.42,
+  descentCorridorInset: PLAYER_RADIUS,
+};
+
+const upperArgs = {
+  stairCenterX: geometry.centerX,
+  stairHalfWidth: geometry.halfWidth,
+  playerRadius: PLAYER_RADIUS,
+  wallThickness: 0.42,
+  doorwayDepth: 1.92,
+  stairwellMarginX: 0.9,
+  stairTopZ: geometry.topZ,
+  stairTransitionMargin: behavior.transitionMargin,
+  stairLandingTriggerMargin: behavior.landingTriggerMargin,
+  stairLayoutDirectionMultiplier: -1 as const,
+  upperLandingRoomBounds: {
+    minX: 6,
+    maxX: 24,
+    minZ: -34,
+    maxZ: -18,
+  },
+  upperStairwellOpening: {
+    minX: 8.4,
+    maxX: 16.4,
+    minZ: -31.1,
+    maxZ: -24.7,
+  },
+  stairNavigationZones: createStairNavigationZones(geometry, behavior),
+  upperStairBannisterThickness: 0.28,
+};
+
+const collectSafetyColliders = (): LevelSafetyCollider[] => [
+  ...createGroundStairSafetyColliders(geometry, behavior, {
+    playerRadius: PLAYER_RADIUS,
+    guardThickness: 0.44,
+  }),
+  ...createUpperStairSafetyColliders(upperArgs),
+];
+
+describe('stair safety collider source definitions', () => {
+  it('preserves key generated upper stair guard bounds', () => {
+    const colliders = createUpperStairSafetyColliders(upperArgs);
+
+    expect(
+      colliders.find(
+        (collider) => collider.name === 'UpperStairEastLowerVoidGuard'
+      )?.bounds
+    ).toEqual({
+      minX: 14.75,
+      maxX: 16.4,
+      minZ: -31.1,
+      maxZ: -27.799999999999997,
+    });
+    expect(
+      colliders.find(
+        (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
+      )?.bounds
+    ).toEqual({
+      minX: 8.4,
+      maxX: 16.4,
+      minZ: -23.549999999999997,
+      maxZ: -21.030000000000005,
+    });
+    expect(
+      colliders.find(
+        (collider) => collider.name === 'UpperStairWestBannisterGuard'
+      )?.bounds
+    ).toEqual({
+      minX: 9.4,
+      maxX: 10.290000000000001,
+      minZ: -24.669999999999998,
+      maxZ: -18.130000000000003,
+    });
+    expect(
+      colliders.find(
+        (collider) => collider.name === 'UpperStairNorthBannisterGuard'
+      )?.bounds
+    ).toEqual({
+      minX: 10.47,
+      maxX: 16.119999999999997,
+      minZ: -18.270000000000003,
+      maxZ: -17.990000000000002,
+    });
+  });
+
+  it('assigns every safety collider a source ID and purpose without duplicates', () => {
+    const colliders = collectSafetyColliders();
+    const sourceIds = colliders.map((collider) => String(collider.sourceId));
+
+    expect(
+      colliders.every(
+        (collider) => collider.sourceId && collider.purpose.trim()
+      )
+    ).toBe(true);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+  });
+
+  it('keeps declared debug IDs mapped to existing safety collider names', () => {
+    const names = new Set(
+      collectSafetyColliders().map((collider) => collider.name)
+    );
+
+    [
+      ['GroundStairEastBoundary', '4001'],
+      ['GroundStairLowerCornerGuard', '4002'],
+      ['UpperStairEastLowerVoidGuard', '4006'],
+      ['UpperStairEastUpperVoidGuard', '4007'],
+      ['UpperStairHiddenRunVoidGuard', '4008'],
+      ['UpperStairWestBannisterGuard', '4009'],
+      ['UpperStairNorthBannisterGuard', '400A'],
+    ].forEach(([name, id]) => {
+      expect(names.has(name)).toBe(true);
+      expect(
+        getDeclaredColliderDebugId({ floor: 'upper', category: 'upper', name })
+      ).toBe(id);
+    });
+
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairTopGapBlockerWest',
+      })
+    ).toBe('4003');
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairTopGapBlockerEast',
+      })
+    ).toBe('4004');
+  });
+
+  it('keeps safety collider source IDs free of tombstone wording', () => {
+    collectSafetyColliders().forEach((collider) => {
+      expect(String(collider.sourceId)).not.toMatch(
+        /\.(former|removed|debugonlyremoval)\./i
+      );
+    });
+  });
+});

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -1,0 +1,263 @@
+import type { RectCollider } from '../../systems/collision';
+import {
+  type StairBehavior,
+  type StairGeometry,
+  type StairNavigationZones,
+  createGroundStairBoundaryColliders,
+} from '../../systems/movement/stairs';
+import { splitColliderAroundCorridor } from '../../systems/movement/upperStairLandingGuards';
+
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type SafetyColliderCategory = 'stair' | 'landing' | 'void';
+
+export interface LevelSafetyCollider {
+  sourceId: LevelSourceId;
+  name: string;
+  floor: 'ground' | 'upper';
+  category: SafetyColliderCategory;
+  bounds: RectCollider;
+  purpose: string;
+}
+
+export interface GroundStairSafetyColliderOptions {
+  playerRadius: number;
+  guardThickness: number;
+}
+
+export interface UpperStairSafetyColliderArgs {
+  stairCenterX: number;
+  stairHalfWidth: number;
+  playerRadius: number;
+  wallThickness: number;
+  doorwayDepth: number;
+  stairwellMarginX: number;
+  stairTopZ: number;
+  stairTransitionMargin: number;
+  stairLandingTriggerMargin: number;
+  stairLayoutDirectionMultiplier: 1 | -1;
+  upperLandingRoomBounds: RectCollider;
+  upperStairwellOpening: RectCollider;
+  stairNavigationZones: StairNavigationZones;
+  upperStairBannisterThickness: number;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+
+const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
+  GroundStairEastBoundary: {
+    sourceId: sourceId('ground.stairwell.eastBoundary.safetyCollider'),
+    category: 'stair',
+    purpose: 'prevent lower stair side squeeze',
+  },
+  GroundStairLowerCornerGuard: {
+    sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
+    category: 'stair',
+    purpose: 'block raw lower-step occupancy',
+  },
+} as const satisfies Record<
+  string,
+  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'>
+>;
+
+export const createGroundStairSafetyColliders = (
+  geometry: StairGeometry,
+  behavior: StairBehavior,
+  options: GroundStairSafetyColliderOptions
+): LevelSafetyCollider[] =>
+  createGroundStairBoundaryColliders(geometry, behavior, options).map(
+    ({ name, bounds }) => ({
+      name,
+      floor: 'ground',
+      bounds,
+      ...GROUND_STAIR_SAFETY_COLLIDER_METADATA[
+        name as keyof typeof GROUND_STAIR_SAFETY_COLLIDER_METADATA
+      ],
+    })
+  );
+
+export const createUpperStairSafetyColliders = ({
+  stairCenterX,
+  stairHalfWidth,
+  playerRadius,
+  wallThickness,
+  doorwayDepth,
+  stairwellMarginX,
+  stairTopZ,
+  stairTransitionMargin,
+  stairLandingTriggerMargin,
+  stairLayoutDirectionMultiplier,
+  upperLandingRoomBounds,
+  upperStairwellOpening,
+  stairNavigationZones,
+  upperStairBannisterThickness,
+}: UpperStairSafetyColliderArgs): LevelSafetyCollider[] => {
+  const upperStairVoidMinZ = upperStairwellOpening.minZ;
+  const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
+  const upperLandingDoorwayClearanceZ =
+    upperLandingRoomBounds.maxZ - doorwayDepth / 2 - playerRadius;
+  const hiddenStairTopGapBlockerNearZ =
+    stairTopZ +
+    stairLayoutDirectionMultiplier * (playerRadius + stairLandingTriggerMargin);
+  const hiddenStairTopGapBlockerFarZ =
+    stairTopZ + stairLayoutDirectionMultiplier * playerRadius;
+  const hiddenStairTopGapBlockerMinX = stairCenterX - playerRadius;
+  const hiddenStairBlockerStartZ =
+    stairTopZ -
+    stairLayoutDirectionMultiplier *
+      (playerRadius + stairLandingTriggerMargin / 2);
+
+  const upperStairLandingEntryCorridor = {
+    minX: upperStairwellOpening.minX,
+    maxX: stairNavigationZones.explicitDescentCorridor.maxX + playerRadius,
+  };
+  const hiddenStairTopGapBlockerMinZ = Math.min(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const hiddenStairTopGapBlockerMaxZ = Math.max(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const upperStairLandingEntryMinZ = Math.max(
+    upperStairVoidMinZ,
+    hiddenStairTopGapBlockerMinZ - playerRadius
+  );
+  const upperStairLandingEntryMaxZ = Math.min(
+    upperStairVoidMaxZ,
+    hiddenStairTopGapBlockerMaxZ + playerRadius
+  );
+  const hiddenStairTopGapBlockerEdgeMinX = Math.max(
+    upperStairwellOpening.minX,
+    hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
+  );
+  const upperStairTopGapBlockers = splitColliderAroundCorridor({
+    name: 'UpperStairTopGapBlocker',
+    bounds: {
+      minX: hiddenStairTopGapBlockerEdgeMinX,
+      maxX: stairNavigationZones.explicitDescentCorridor.maxX + playerRadius,
+      minZ: hiddenStairTopGapBlockerMinZ,
+      maxZ: hiddenStairTopGapBlockerMaxZ,
+    },
+    corridor: upperStairLandingEntryCorridor,
+  });
+
+  const upperStairWestBannisterMinX = upperStairwellOpening.minX;
+  const upperStairWestBannisterMaxX =
+    stairNavigationZones.explicitDescentCorridor.minX - playerRadius - 0.01;
+  const upperStairWestBannisterShiftX = 1;
+  const upperStairNorthBannisterMinX =
+    stairNavigationZones.explicitDescentCorridor.minX +
+    upperStairBannisterThickness * 1.5;
+  const upperStairNorthBannisterBaseCenterZ =
+    upperLandingDoorwayClearanceZ - wallThickness;
+  const upperStairNorthBannisterCenterZ =
+    upperStairNorthBannisterBaseCenterZ + 2;
+  const upperStairWestBannisterSouthZ =
+    hiddenStairBlockerStartZ + upperStairBannisterThickness;
+  const upperStairNorthBannisterMaxX =
+    upperStairwellOpening.maxX - upperStairBannisterThickness;
+  const upperStairDescentHandoffFarZ =
+    stairTopZ -
+    stairLayoutDirectionMultiplier *
+      (stairTransitionMargin + stairLandingTriggerMargin);
+  const upperStairHiddenRunGuardNearZ =
+    upperStairDescentHandoffFarZ -
+    stairLayoutDirectionMultiplier * playerRadius;
+
+  return [
+    {
+      name: 'UpperStairEastLowerVoidGuard',
+      sourceId: sourceId('upper.stairwell.eastLowerVoid.safetyCollider'),
+      floor: 'upper',
+      category: 'void',
+      purpose: 'guard upper stairwell void edge',
+      bounds: {
+        minX: stairNavigationZones.explicitDescentCorridor.maxX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperStairVoidMinZ,
+        maxZ: upperStairLandingEntryMinZ,
+      },
+    },
+    {
+      name: 'UpperStairEastUpperVoidGuard',
+      sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
+      floor: 'upper',
+      category: 'void',
+      purpose: 'guard upper stairwell void edge',
+      bounds: {
+        minX: stairNavigationZones.explicitDescentCorridor.maxX,
+        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
+        minZ: upperStairLandingEntryMaxZ,
+        maxZ: upperStairVoidMaxZ,
+      },
+    },
+    ...upperStairTopGapBlockers.map(({ name, bounds }, index) => ({
+      name,
+      sourceId: sourceId(
+        `upper.stairwell.topGap.${index === 0 ? 'west' : 'east'}.safetyCollider`
+      ),
+      floor: 'upper' as const,
+      category: 'void' as const,
+      purpose: 'guard upper stairwell void edge',
+      bounds,
+    })),
+    {
+      name: 'UpperStairHiddenRunVoidGuard',
+      sourceId: sourceId('upper.stairwell.hiddenRun.safetyCollider'),
+      floor: 'upper',
+      category: 'void',
+      purpose: 'guard hidden stair run no-floor area',
+      bounds: {
+        minX: upperStairwellOpening.minX,
+        maxX: upperStairwellOpening.maxX,
+        minZ: Math.min(
+          upperStairHiddenRunGuardNearZ,
+          upperLandingDoorwayClearanceZ
+        ),
+        maxZ: Math.max(
+          upperStairHiddenRunGuardNearZ,
+          upperStairNorthBannisterBaseCenterZ -
+            upperStairBannisterThickness / 2 -
+            playerRadius -
+            0.01
+        ),
+      },
+    },
+    {
+      name: 'UpperStairWestBannisterGuard',
+      sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),
+      floor: 'upper',
+      category: 'landing',
+      purpose: 'preserve descent corridor edge',
+      bounds: {
+        minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
+        maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
+        minZ: Math.min(
+          upperStairNorthBannisterBaseCenterZ,
+          upperStairWestBannisterSouthZ
+        ),
+        maxZ:
+          Math.max(
+            upperStairNorthBannisterBaseCenterZ,
+            upperStairWestBannisterSouthZ
+          ) + 2,
+      },
+    },
+    {
+      name: 'UpperStairNorthBannisterGuard',
+      sourceId: sourceId('upper.stairwell.northBannister.safetyCollider'),
+      floor: 'upper',
+      category: 'landing',
+      purpose: 'preserve descent corridor edge',
+      bounds: {
+        minX: upperStairNorthBannisterMinX,
+        maxX: upperStairNorthBannisterMaxX,
+        minZ:
+          upperStairNorthBannisterCenterZ - upperStairBannisterThickness / 2,
+        maxZ:
+          upperStairNorthBannisterCenterZ + upperStairBannisterThickness / 2,
+      },
+    },
+  ];
+};

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -60,6 +60,23 @@ const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
   Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'>
 >;
 
+const getGroundStairSafetyColliderMetadata = (
+  name: string
+): Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'> => {
+  const metadata =
+    GROUND_STAIR_SAFETY_COLLIDER_METADATA[
+      name as keyof typeof GROUND_STAIR_SAFETY_COLLIDER_METADATA
+    ];
+
+  if (!metadata) {
+    throw new Error(
+      `Missing ground stair safety collider metadata for ${name}`
+    );
+  }
+
+  return metadata;
+};
+
 export const createGroundStairSafetyColliders = (
   geometry: StairGeometry,
   behavior: StairBehavior,
@@ -70,9 +87,7 @@ export const createGroundStairSafetyColliders = (
       name,
       floor: 'ground',
       bounds,
-      ...GROUND_STAIR_SAFETY_COLLIDER_METADATA[
-        name as keyof typeof GROUND_STAIR_SAFETY_COLLIDER_METADATA
-      ],
+      ...getGroundStairSafetyColliderMetadata(name),
     })
   );
 
@@ -192,10 +207,10 @@ export const createUpperStairSafetyColliders = ({
         maxZ: upperStairVoidMaxZ,
       },
     },
-    ...upperStairTopGapBlockers.map(({ name, bounds }, index) => ({
+    ...upperStairTopGapBlockers.map(({ name, bounds }) => ({
       name,
       sourceId: sourceId(
-        `upper.stairwell.topGap.${index === 0 ? 'west' : 'east'}.safetyCollider`
+        `upper.stairwell.topGap.${name.endsWith('West') ? 'west' : 'east'}.safetyCollider`
       ),
       floor: 'upper' as const,
       category: 'void' as const,

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { createGroundStairSafetyColliders } from '../../scene/level/stairSafetyColliders';
 import { collidesWithColliders } from '../collision';
 
 import {
-  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   type StairBehavior,
   type StairGeometry,
@@ -30,14 +30,10 @@ const behavior: StairBehavior = {
   descentCorridorInset: PLAYER_RADIUS,
 };
 
-const boundaryColliders = createGroundStairBoundaryColliders(
-  geometry,
-  behavior,
-  {
-    playerRadius: PLAYER_RADIUS,
-    guardThickness: 0.44,
-  }
-);
+const boundaryColliders = createGroundStairSafetyColliders(geometry, behavior, {
+  playerRadius: PLAYER_RADIUS,
+  guardThickness: 0.44,
+});
 const boundaryBounds = boundaryColliders.map((collider) => collider.bounds);
 
 const stairEastX = geometry.centerX + geometry.halfWidth;
@@ -59,6 +55,23 @@ describe('createGroundStairBoundaryColliders', () => {
       'GroundStairLowerCornerGuard',
     ]);
     expect(names).not.toContain('GroundStairEastRunSeal');
+  });
+
+  it('adds source metadata to raw blockers for reported stair-side squeeze samples', () => {
+    expect(boundaryColliders).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'GroundStairEastBoundary',
+          sourceId: 'ground.stairwell.eastBoundary.safetyCollider',
+          purpose: 'prevent lower stair side squeeze',
+        }),
+        expect.objectContaining({
+          name: 'GroundStairLowerCornerGuard',
+          sourceId: 'ground.stairwell.lowerCorner.safetyCollider',
+          purpose: 'block raw lower-step occupancy',
+        }),
+      ])
+    );
   });
 
   it('blocks the reported stair-side squeeze samples', () => {

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -46,7 +46,7 @@ const eastBoundaryMaxX = Math.max(
   ...boundaryColliders.map((collider) => collider.bounds.maxX)
 );
 
-describe('createGroundStairBoundaryColliders', () => {
+describe('createGroundStairSafetyColliders', () => {
   it('names the local ground stair blockers for debug visualization', () => {
     const names = boundaryColliders.map((collider) => collider.name);
 

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -37,15 +37,22 @@ describe('main module imports', () => {
     );
   });
 
-  it('passes generated wall source IDs into debug collider metadata', () => {
+  it('passes generated source IDs and purposes into debug collider metadata', () => {
     const source = readMainSource();
 
+    expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
+    expect(source).toContain("sourceType: 'wall',");
+    expect(source).toContain('colliderSourceMetadata.set(collider.bounds, {');
+    expect(source).toContain("sourceType: 'safetyCollider',");
+    expect(source).toContain('purpose: collider.purpose,');
     expect(source).toContain(
-      'colliderSourceIds.set(instance.collider, instance.sourceId);'
+      'sourceId: colliderSourceMetadata.get(bounds)?.sourceId,'
     );
-    expect(source).toContain('sourceId: colliderSourceIds.get(bounds),');
     expect(source).toContain(
-      "sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,"
+      'sourceType: colliderSourceMetadata.get(bounds)?.sourceType,'
+    );
+    expect(source).toContain(
+      'purpose: colliderSourceMetadata.get(bounds)?.purpose,'
     );
   });
 


### PR DESCRIPTION
### Motivation
- Move ad-hoc stair/landing/void safety colliders out of anonymous runtime lists and into source-backed definitions with stable `sourceId` primitives and explicit `purpose` text so reviewers can distinguish intentional safety constraints from layout walls.
- Preserve existing gameplay and collision behavior while exposing source metadata to debug visualizers for better traceability.

### Description
- Added a typed safety collider model and generators in `src/scene/level/stairSafetyColliders.ts` (`LevelSafetyCollider`) and exported `createGroundStairSafetyColliders` and `createUpperStairSafetyColliders` that produce source-ID-backed colliders with concise `purpose` strings.
- Replaced the large anonymous stair safety collider creation in `src/main.ts` with generator calls and a `registerSafetyCollider` helper that records `sourceId`/`sourceType`/`purpose` into the debug metadata map (`colliderSourceMetadata`) without changing final bounds or runtime behavior.
- Preserved existing blocker names and declared debug IDs (for example `UpperStairEastLowerVoidGuard`, `UpperStairHiddenRunVoidGuard`, `UpperStairWestBannisterGuard`, `UpperStairNorthBannisterGuard`) and added corresponding source IDs such as `upper.stairwell.hiddenRun.safetyCollider`.
- Added tests and small test updates: new `src/scene/level/__tests__/stairSafetyColliders.test.ts`, adapted `src/systems/movement/stairs.test.ts` to assert source metadata, and updated `src/tests/mainImports.test.ts` to assert the new metadata plumbing; and updated design doc `docs/design/declarative-level-source-of-truth.md` to document the distinction between wall colliders and safety colliders.

### Testing
- Ran formatter and linter: `npm run format:write` (applied), `npm run lint` (passed with no blocking errors).
- Unit tests: `npm run test:ci` and focused runs `npm run test:ci -- src/tests/mainImports.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts src/systems/movement/stairs.test.ts` — all Vitest suites passed (final run: 155 test files, 1190 tests passed).
- End-to-end: installed Playwright browsers and deps (`npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell`) and ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — all Playwright stairs roundtrip tests passed (9/9).
- Build & docs: `npm run build` succeeded, `npm run docs:check` passed (link checker produced expected external reachability warnings), and `npm run smoke` passed.
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.

Files of interest: `src/scene/level/stairSafetyColliders.ts` (new), `src/main.ts` (metadata registration + generator usage), `src/scene/level/__tests__/stairSafetyColliders.test.ts` (new), `src/systems/movement/stairs.test.ts` (updated), `src/tests/mainImports.test.ts` (updated), and `docs/design/declarative-level-source-of-truth.md` (doc update).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33583ca220832f9a986324ae9b9fcd)