### PR TITLE
🧱 : – Source stair safety colliders

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -128,6 +128,15 @@ blocking unfinished zones, or protecting showpiece footprints. They should carry
 source IDs, floor assignment, bounds, and purpose text so reviewers can tell why
 the invisible constraint exists.
 
+Physical wall colliders come from authored wall or fence geometry and should
+represent visible layout boundaries. Safety colliders are separate
+source-backed constraints: they may guard stairwell void edges, seal hidden
+no-floor stair runs, or preserve a descent corridor, but they are not layout
+walls and should not be reviewed as hidden post-hoc wall patches. The stair
+safety generators now return `LevelSafetyCollider` records with semantic
+`.safetyCollider` source IDs and concise purpose strings before those records
+are registered with runtime collision and debug metadata.
+
 ### Scene objects
 
 Scene objects describe visible or interactable objects and their collider

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -89,6 +89,9 @@ type DebugColliderMetadata = {
   category: string;
   name: string;
   bounds: DebugColliderBounds;
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
 };
 
 type DebugColliderApi = {
@@ -834,6 +837,11 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   expect(westBannisterById?.name).toBe('UpperStairWestBannisterGuard');
   expect(westBannisterById?.floor).toBe('upper');
   expect(westBannisterById?.category).toBe('upper');
+  expect(westBannisterById?.sourceId).toBe(
+    'upper.stairwell.westBannister.safetyCollider'
+  );
+  expect(westBannisterById?.sourceType).toBe('safetyCollider');
+  expect(westBannisterById?.purpose).toBe('preserve descent corridor edge');
 
   const westBannister = debugColliders.find(
     (collider) => collider.name === 'UpperStairWestBannisterGuard'
@@ -850,6 +858,9 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   }, '400A');
   expect(northBannisterById?.id).toBe('400A');
   expect(northBannisterById?.name).toBe('UpperStairNorthBannisterGuard');
+  expect(northBannisterById?.sourceId).toBe(
+    'upper.stairwell.northBannister.safetyCollider'
+  );
   const hiddenRunGuard = debugColliders.find(
     (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
   );
@@ -1072,6 +1083,25 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
     expect(blockingColliderIds.every((id) => /^[0-9A-F]{4,6}$/.test(id))).toBe(
       true
     );
+    const expectedBlockingCollider = await page.evaluate(
+      (target) => {
+        const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+        if (!debugApi) {
+          throw new Error('Debug colliders API unavailable');
+        }
+        return debugApi
+          .getBlockingCollidersAt(target)
+          .find((collider) => collider.name === target.expectedBlocker);
+      },
+      { ...sample.target, expectedBlocker: sample.expectedBlocker }
+    );
+    expect(expectedBlockingCollider?.sourceId, sample.name).toMatch(
+      /\.safetyCollider$/
+    );
+    expect(expectedBlockingCollider?.sourceType, sample.name).toBe(
+      'safetyCollider'
+    );
+    expect(expectedBlockingCollider?.purpose, sample.name).toBeTruthy();
     expect(blockingColliderNames.length, sample.name).toBeGreaterThan(0);
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,15 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import {
+  assertLevelSourceId,
+  type LevelSourceMetadata,
+} from './scene/level/sourceIds';
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+  type LevelSafetyCollider,
+} from './scene/level/stairSafetyColliders';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -404,7 +413,6 @@ import {
 } from './systems/movement/stairLayout';
 import {
   classifyStairTransitionZone,
-  createGroundStairBoundaryColliders,
   createStairNavigationZones,
   isWithinLanding,
   isWithinStairWidth,
@@ -415,7 +423,6 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from './systems/movement/stairs';
-import { splitColliderAroundCorridor } from './systems/movement/upperStairLandingGuards';
 import {
   NARRATION_PREFERENCE_STORAGE_KEY,
   NarrationPreference,
@@ -977,10 +984,7 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
-const colliderSourceIds = new Map<
-  RectCollider,
-  WallSegmentInstance['sourceId']
->();
+const colliderSourceMetadata = new Map<RectCollider, LevelSourceMetadata>();
 const upperFloorColliders: RectCollider[] = [];
 
 const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
@@ -1905,7 +1909,10 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
@@ -2058,18 +2065,24 @@ function initializeImmersiveScene(
     maxZ: stairGuardMaxZ,
   });
 
-  const groundStairBoundaryColliders = createGroundStairBoundaryColliders(
-    stairGeometry,
-    stairBehavior,
-    {
-      playerRadius: PLAYER_RADIUS,
-      guardThickness: stairGuardThickness,
-    }
-  );
-  groundStairBoundaryColliders.forEach(({ name, bounds }) => {
-    groundColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
-  });
+  const registerSafetyCollider = (collider: LevelSafetyCollider) => {
+    const targetColliders =
+      collider.floor === 'ground' ? groundColliders : upperFloorColliders;
+    targetColliders.push(collider.bounds);
+    namedColliderDebugNames.set(collider.bounds, collider.name);
+    colliderSourceMetadata.set(collider.bounds, {
+      sourceId: collider.sourceId,
+      sourceType: 'safetyCollider',
+      purpose: collider.purpose,
+    });
+  };
+
+  createGroundStairSafetyColliders({
+    geometry: stairGeometry,
+    behavior: stairBehavior,
+    playerRadius: PLAYER_RADIUS,
+    guardThickness: stairGuardThickness,
+  }).forEach(registerSafetyCollider);
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;
@@ -2098,177 +2111,34 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const pushNamedUpperFloorCollider = (name: string, bounds: RectCollider) => {
+  const pushNamedUpperFloorCollider = (
+    name: string,
+    bounds: RectCollider,
+    sourceMetadata?: LevelSourceMetadata
+  ) => {
     upperFloorColliders.push(bounds);
     namedColliderDebugNames.set(bounds, name);
+    if (sourceMetadata) {
+      colliderSourceMetadata.set(bounds, sourceMetadata);
+    }
   };
-
-  const upperStairWestEgressLaneX =
-    stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
-  const upperStairWestEgressBlockerMinX =
-    upperStairWestEgressLaneX + PLAYER_RADIUS + 0.01;
 
   // The upper-floor stairwell cutout intentionally comes from the same
   // computeStairLayout result used by movement. It removes both the stair
   // landing void and the hidden ramp run below the landing lip.
   if (upperLandingRoom && upperStairwellOpening) {
-    const upperStairVoidMinZ = upperStairwellOpening.minZ;
-    const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
-    const upperLandingDoorwayClearanceZ =
-      upperLandingRoom.bounds.maxZ - doorwayDepth / 2 - PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerNearZ =
-      stairTopZ +
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin);
-    const hiddenStairTopGapBlockerFarZ =
-      stairTopZ + stairLayout.directionMultiplier * PLAYER_RADIUS;
-    const hiddenStairTopGapBlockerMinX = stairCenterX - PLAYER_RADIUS;
-    const hiddenStairBlockerStartZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (PLAYER_RADIUS + stairLandingTriggerMargin / 2);
-    // Invisible upper-floor guard rails flank the intentional descent corridor.
-    // They are scoped to the actual upper-floor cutout instead of the full ramp
-    // run so normal loft space beyond the landing remains occupiable.
-    // UpperStairDeepVoidBlocker is intentionally absent: it covered the visible
-    // physical StaircaseLanding slab, while the remaining top-gap, hidden-run,
-    // bannister, and void blockers still guard the true no-floor cutout edges.
-    // The hidden-run blocker starts one player radius beyond the explicit
-    // descent handoff band so legitimate upper-floor descent remains open.
-    const upperStairLandingEntryCorridor = {
-      // Keep the upper landing mouth open far enough for a real westward
-      // egress step after handoff; side guards still seal hidden void edges.
-      minX: upperStairwellOpening.minX,
-      // Size the east edge from the real upper-floor descent opening and add
-      // one collision radius because collider checks expand the blocker edge.
-      maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-    };
-    const hiddenStairTopGapBlockerMinZ = Math.min(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const hiddenStairTopGapBlockerMaxZ = Math.max(
-      hiddenStairTopGapBlockerNearZ,
-      hiddenStairTopGapBlockerFarZ
-    );
-    const upperStairLandingEntryMinZ = Math.max(
-      upperStairVoidMinZ,
-      hiddenStairTopGapBlockerMinZ - PLAYER_RADIUS
-    );
-    const upperStairLandingEntryMaxZ = Math.min(
-      upperStairVoidMaxZ,
-      hiddenStairTopGapBlockerMaxZ + PLAYER_RADIUS
-    );
-    const hiddenStairTopGapBlockerEdgeMinX = Math.max(
-      upperStairwellOpening.minX,
-      hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
-    );
-    const upperStairTopGapBlockers = splitColliderAroundCorridor({
-      name: 'UpperStairTopGapBlocker',
-      bounds: {
-        minX: hiddenStairTopGapBlockerEdgeMinX,
-        maxX: stairNavigationZones.explicitDescentCorridor.maxX + PLAYER_RADIUS,
-        minZ: hiddenStairTopGapBlockerMinZ,
-        maxZ: hiddenStairTopGapBlockerMaxZ,
-      },
-      corridor: upperStairLandingEntryCorridor,
-    });
-
-    const upperStairBannisterThickness =
-      STAIRCASE_CONFIG.landing.guard.thickness;
-    const upperStairWestBannisterMinX = upperStairwellOpening.minX;
-    // Keep a full player-radius clearance between the side guard and the
-    // explicit descent lane; collision checks expand colliders by that radius.
-    const upperStairWestBannisterMaxX =
-      stairNavigationZones.explicitDescentCorridor.minX - PLAYER_RADIUS - 0.01;
-    const upperStairWestBannisterShiftX = 1;
-    const upperStairNorthBannisterMinX =
-      stairNavigationZones.explicitDescentCorridor.minX +
-      upperStairBannisterThickness * 1.5;
-    const upperStairNorthBannisterBaseCenterZ =
-      upperLandingDoorwayClearanceZ - WALL_THICKNESS;
-    const upperStairNorthBannisterCenterZ =
-      upperStairNorthBannisterBaseCenterZ + 2;
-    const upperStairWestBannisterSouthZ =
-      hiddenStairBlockerStartZ + upperStairBannisterThickness;
-    const upperStairNorthBannisterMaxX =
-      upperStairwellOpening.maxX - upperStairBannisterThickness;
-    const upperStairDescentHandoffFarZ =
-      stairTopZ -
-      stairLayout.directionMultiplier *
-        (stairTransitionMargin + stairLandingTriggerMargin);
-    const upperStairHiddenRunGuardNearZ =
-      upperStairDescentHandoffFarZ -
-      stairLayout.directionMultiplier * PLAYER_RADIUS;
-
-    [
-      // UpperStairWestUpperVoidGuard is intentionally omitted so the widened
-      // upstairs landing-side passage remains traversable.
-      {
-        name: 'UpperStairEastLowerVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairVoidMinZ,
-          maxZ: upperStairLandingEntryMinZ,
-        },
-      },
-      {
-        name: 'UpperStairEastUpperVoidGuard',
-        bounds: {
-          minX: stairNavigationZones.explicitDescentCorridor.maxX,
-          maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-          minZ: upperStairLandingEntryMaxZ,
-          maxZ: upperStairVoidMaxZ,
-        },
-      },
-      ...upperStairTopGapBlockers,
-      {
-        name: 'UpperStairHiddenRunVoidGuard',
-        bounds: {
-          minX: upperStairwellOpening.minX,
-          maxX: upperStairwellOpening.maxX,
-          minZ: Math.min(
-            upperStairHiddenRunGuardNearZ,
-            upperLandingDoorwayClearanceZ
-          ),
-          maxZ: Math.max(
-            upperStairHiddenRunGuardNearZ,
-            upperStairNorthBannisterBaseCenterZ -
-              upperStairBannisterThickness / 2 -
-              PLAYER_RADIUS -
-              0.01
-          ),
-        },
-      },
-      {
-        name: 'UpperStairWestBannisterGuard',
-        bounds: {
-          minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
-          maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
-          minZ: Math.min(
-            upperStairNorthBannisterBaseCenterZ,
-            upperStairWestBannisterSouthZ
-          ),
-          maxZ:
-            Math.max(
-              upperStairNorthBannisterBaseCenterZ,
-              upperStairWestBannisterSouthZ
-            ) + 2,
-        },
-      },
-      {
-        name: 'UpperStairNorthBannisterGuard',
-        bounds: {
-          minX: upperStairNorthBannisterMinX,
-          maxX: upperStairNorthBannisterMaxX,
-          minZ:
-            upperStairNorthBannisterCenterZ - upperStairBannisterThickness / 2,
-          maxZ:
-            upperStairNorthBannisterCenterZ + upperStairBannisterThickness / 2,
-        },
-      },
-    ].forEach(({ name, bounds }) => pushNamedUpperFloorCollider(name, bounds));
+    createUpperStairSafetyColliders({
+      stairGeometry,
+      stairBehavior,
+      stairLayout,
+      upperLandingRoomBounds: upperLandingRoom.bounds,
+      upperStairwellOpening,
+      playerRadius: PLAYER_RADIUS,
+      doorwayDepth,
+      wallThickness: WALL_THICKNESS,
+      stairwellMarginX,
+      bannisterThickness: STAIRCASE_CONFIG.landing.guard.thickness,
+    }).forEach(registerSafetyCollider);
   }
 
   const staircaseLandingFootprint = {
@@ -2289,6 +2159,10 @@ function initializeImmersiveScene(
       stairTopZ - stairLayout.directionMultiplier * stairRun
     ),
   };
+  const upperStairWestEgressLaneX =
+    stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
+  const upperStairWestEgressBlockerMinX =
+    upperStairWestEgressLaneX + PLAYER_RADIUS + 0.01;
   const stairRunApproachFootprint =
     upperLandingRoom && upperStairwellOpening
       ? createUpperLandingStairRunApproachFootprint({
@@ -2367,7 +2241,14 @@ function initializeImmersiveScene(
     upperStairwellLanding.colliders.forEach((collider, index) =>
       pushNamedUpperFloorCollider(
         `UpperStairwellLandingGuard-${index + 1}`,
-        collider
+        collider,
+        {
+          sourceId: assertLevelSourceId(
+            `upper.stairwell.landingGuard${index + 1}.safetyCollider`
+          ),
+          sourceType: 'safetyCollider',
+          purpose: 'guard upper stairwell void edge',
+        }
       )
     );
   }
@@ -2400,7 +2281,10 @@ function initializeImmersiveScene(
       instance.collider,
       getUpperWallSegmentDebugName(instance)
     );
-    colliderSourceIds.set(instance.collider, instance.sourceId);
+    colliderSourceMetadata.set(instance.collider, {
+      sourceId: instance.sourceId,
+      sourceType: 'wall',
+    });
   });
 
   const floorColliders: Record<FloorId, RectCollider[]> = {
@@ -4493,8 +4377,7 @@ function initializeImmersiveScene(
         `${options.namePrefix}-${index + 1}`,
       bounds,
       elevation: options.elevation,
-      sourceId: colliderSourceIds.get(bounds),
-      sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,
+      ...colliderSourceMetadata.get(bounds),
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/level/stairSafetyColliders.test.ts
+++ b/src/scene/level/stairSafetyColliders.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeStairLayout,
+  computeStairwellOpeningBounds,
+} from '../../systems/movement/stairLayout';
+import {
+  createStairNavigationZones,
+  type StairBehavior,
+  type StairGeometry,
+} from '../../systems/movement/stairs';
+
+import {
+  createGroundStairSafetyColliders,
+  createUpperStairSafetyColliders,
+  type LevelSafetyCollider,
+} from './stairSafetyColliders';
+
+const PLAYER_RADIUS = 0.75;
+const stairGeometry: StairGeometry = {
+  centerX: 12.4,
+  halfWidth: 3.1,
+  bottomZ: -10.6,
+  topZ: -25.9,
+  landingMinZ: -31.1,
+  landingMaxZ: -25.9,
+  totalRise: 3.78,
+  direction: -1,
+};
+const stairBehavior: StairBehavior = {
+  transitionMargin: 1.2,
+  landingTriggerMargin: 0.4,
+  stepRise: 0.42,
+  descentCorridorInset: PLAYER_RADIUS,
+};
+const stairLayout = computeStairLayout({
+  baseZ: stairGeometry.bottomZ,
+  stepRun: 1.275,
+  stepCount: 12,
+  landingDepth: 5.2,
+  direction: 'negativeZ',
+  guardMargin: stairBehavior.transitionMargin,
+  stairwellMargin: 0.8,
+});
+const upperLandingRoomBounds = {
+  minX: 7,
+  maxX: 20,
+  minZ: -34,
+  maxZ: -18,
+};
+const upperStairwellOpening = computeStairwellOpeningBounds({
+  centerX: stairGeometry.centerX,
+  halfWidth: stairGeometry.halfWidth,
+  marginX: 0.4,
+  roomBounds: upperLandingRoomBounds,
+  layout: stairLayout,
+});
+
+const upperSafetyColliders = createUpperStairSafetyColliders({
+  stairGeometry,
+  stairBehavior,
+  stairLayout,
+  upperLandingRoomBounds,
+  upperStairwellOpening,
+  playerRadius: PLAYER_RADIUS,
+  doorwayDepth: 2.4,
+  wallThickness: 0.4,
+  stairwellMarginX: 0.4,
+  bannisterThickness: 0.24,
+});
+const groundSafetyColliders = createGroundStairSafetyColliders({
+  geometry: stairGeometry,
+  behavior: stairBehavior,
+  playerRadius: PLAYER_RADIUS,
+  guardThickness: 0.44,
+});
+const allSafetyColliders = [...groundSafetyColliders, ...upperSafetyColliders];
+
+const byName = (name: string): LevelSafetyCollider => {
+  const collider = allSafetyColliders.find(
+    (candidate) => candidate.name === name
+  );
+  if (!collider) {
+    throw new Error(`Missing safety collider ${name}`);
+  }
+
+  return collider;
+};
+
+describe('stair safety collider source generation', () => {
+  it('preserves declared stair safety collider names', () => {
+    expect(allSafetyColliders.map((collider) => collider.name)).toEqual([
+      'GroundStairEastBoundary',
+      'GroundStairLowerCornerGuard',
+      'UpperStairEastLowerVoidGuard',
+      'UpperStairEastUpperVoidGuard',
+      'UpperStairHiddenRunVoidGuard',
+      'UpperStairWestBannisterGuard',
+      'UpperStairNorthBannisterGuard',
+    ]);
+  });
+
+  it('generates bounds matching the pre-extraction stair guard math', () => {
+    expect(byName('GroundStairEastBoundary').bounds).toEqual({
+      minX: 15.94,
+      maxX: 22.18,
+      minZ: -25.9,
+      maxZ: -10.6,
+    });
+    expect(byName('GroundStairLowerCornerGuard').bounds).toEqual({
+      minX: 15.5,
+      maxX: 22.18,
+      minZ: -10.6,
+      maxZ: -9.4,
+    });
+    expect(byName('UpperStairEastLowerVoidGuard').bounds).toEqual({
+      minX: 14.75,
+      maxX: 15.9,
+      minZ: -31.9,
+      maxZ: -27.799999999999997,
+    });
+    expect(byName('UpperStairHiddenRunVoidGuard').bounds).toEqual({
+      minX: 8.9,
+      maxX: 15.9,
+      minZ: -23.549999999999997,
+      maxZ: -21.23,
+    });
+    expect(byName('UpperStairWestBannisterGuard').bounds).toEqual({
+      minX: 9.9,
+      maxX: 10.290000000000001,
+      minZ: -24.71,
+      maxZ: -18.349999999999998,
+    });
+    expect(byName('UpperStairNorthBannisterGuard').bounds).toEqual({
+      minX: 10.41,
+      maxX: 15.66,
+      minZ: -18.47,
+      maxZ: -18.229999999999997,
+    });
+  });
+
+  it('adds source IDs and concise purposes without duplicate or tombstoned IDs', () => {
+    const sourceIds = allSafetyColliders.map((collider) => collider.sourceId);
+
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    allSafetyColliders.forEach((collider) => {
+      expect(collider.sourceId).toMatch(/\.safetyCollider$/);
+      expect(collider.purpose.length).toBeGreaterThan(0);
+      expect(collider.sourceId).not.toMatch(
+        /\.former\.|\.removed\.|debug.*remov/i
+      );
+    });
+  });
+
+  it('keeps upper safety colliders clear of the explicit descent corridor', () => {
+    const navigationZones = createStairNavigationZones(
+      stairGeometry,
+      stairBehavior
+    );
+    const westBannister = byName('UpperStairWestBannisterGuard').bounds;
+    const eastVoidGuard = byName('UpperStairEastLowerVoidGuard').bounds;
+
+    expect(westBannister.maxX - 1).toBeLessThan(
+      navigationZones.explicitDescentCorridor.minX
+    );
+    expect(eastVoidGuard.minX).toBe(
+      navigationZones.explicitDescentCorridor.maxX
+    );
+  });
+});

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -1,0 +1,286 @@
+import type { RectCollider } from '../../systems/collision';
+import type { StairLayoutResult } from '../../systems/movement/stairLayout';
+import type {
+  FloorId,
+  NamedStairBoundaryCollider,
+  StairBehavior,
+  StairGeometry,
+} from '../../systems/movement/stairs';
+import { createGroundStairBoundaryColliders } from '../../systems/movement/stairs';
+import { splitColliderAroundCorridor } from '../../systems/movement/upperStairLandingGuards';
+
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type LevelSafetyColliderCategory = 'stair' | 'landing' | 'void';
+
+export interface LevelSafetyCollider {
+  sourceId: LevelSourceId;
+  name: string;
+  floor: FloorId;
+  category: LevelSafetyColliderCategory;
+  bounds: RectCollider;
+  purpose: string;
+}
+
+export interface CreateGroundStairSafetyCollidersOptions {
+  geometry: StairGeometry;
+  behavior: StairBehavior;
+  playerRadius: number;
+  guardThickness: number;
+}
+
+export interface CreateUpperStairSafetyCollidersOptions {
+  stairGeometry: StairGeometry;
+  stairBehavior: StairBehavior;
+  stairLayout: StairLayoutResult;
+  upperLandingRoomBounds: RectCollider;
+  upperStairwellOpening: RectCollider;
+  playerRadius: number;
+  doorwayDepth: number;
+  wallThickness: number;
+  stairwellMarginX: number;
+  bannisterThickness: number;
+}
+
+const safetySourceId = (sourceId: string): LevelSourceId =>
+  assertLevelSourceId(sourceId);
+
+const GROUND_STAIR_SOURCE_IDS: Record<
+  NamedStairBoundaryCollider['name'],
+  LevelSourceId
+> = {
+  GroundStairEastBoundary: safetySourceId(
+    'ground.stairwell.eastBoundary.safetyCollider'
+  ),
+  GroundStairLowerCornerGuard: safetySourceId(
+    'ground.stairwell.lowerCorner.safetyCollider'
+  ),
+};
+
+const getGroundStairPurpose = (name: string): string => {
+  switch (name) {
+    case 'GroundStairEastBoundary':
+      return 'prevent lower stair side squeeze';
+    case 'GroundStairLowerCornerGuard':
+      return 'block raw lower-step occupancy';
+    default:
+      return 'preserve descent corridor edge';
+  }
+};
+
+export const createGroundStairSafetyColliders = ({
+  geometry,
+  behavior,
+  playerRadius,
+  guardThickness,
+}: CreateGroundStairSafetyCollidersOptions): LevelSafetyCollider[] =>
+  createGroundStairBoundaryColliders(geometry, behavior, {
+    playerRadius,
+    guardThickness,
+  }).map(({ name, bounds }) => ({
+    sourceId:
+      GROUND_STAIR_SOURCE_IDS[name] ??
+      safetySourceId(`ground.stairwell.${name}.safetyCollider`),
+    name,
+    floor: 'ground',
+    category: 'stair',
+    bounds,
+    purpose: getGroundStairPurpose(name),
+  }));
+
+export const createUpperStairSafetyColliders = ({
+  stairGeometry,
+  stairBehavior,
+  stairLayout,
+  upperLandingRoomBounds,
+  upperStairwellOpening,
+  playerRadius,
+  doorwayDepth,
+  wallThickness,
+  stairwellMarginX,
+  bannisterThickness,
+}: CreateUpperStairSafetyCollidersOptions): LevelSafetyCollider[] => {
+  const upperStairVoidMinZ = upperStairwellOpening.minZ;
+  const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
+  const upperLandingDoorwayClearanceZ =
+    upperLandingRoomBounds.maxZ - doorwayDepth / 2 - playerRadius;
+  const hiddenStairTopGapBlockerNearZ =
+    stairGeometry.topZ +
+    stairLayout.directionMultiplier *
+      (playerRadius + stairBehavior.landingTriggerMargin);
+  const hiddenStairTopGapBlockerFarZ =
+    stairGeometry.topZ + stairLayout.directionMultiplier * playerRadius;
+  const hiddenStairTopGapBlockerMinX = stairGeometry.centerX - playerRadius;
+  const hiddenStairBlockerStartZ =
+    stairGeometry.topZ -
+    stairLayout.directionMultiplier *
+      (playerRadius + stairBehavior.landingTriggerMargin / 2);
+  const upperStairLandingEntryCorridor = {
+    minX: upperStairwellOpening.minX,
+    maxX: stairBehavior.descentCorridorInset
+      ? stairGeometry.centerX +
+        Math.max(
+          stairGeometry.halfWidth - stairBehavior.descentCorridorInset,
+          stairGeometry.halfWidth * 0.55
+        ) +
+        playerRadius
+      : stairGeometry.centerX + stairGeometry.halfWidth + playerRadius,
+  };
+  const hiddenStairTopGapBlockerMinZ = Math.min(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const hiddenStairTopGapBlockerMaxZ = Math.max(
+    hiddenStairTopGapBlockerNearZ,
+    hiddenStairTopGapBlockerFarZ
+  );
+  const upperStairLandingEntryMinZ = Math.max(
+    upperStairVoidMinZ,
+    hiddenStairTopGapBlockerMinZ - playerRadius
+  );
+  const upperStairLandingEntryMaxZ = Math.min(
+    upperStairVoidMaxZ,
+    hiddenStairTopGapBlockerMaxZ + playerRadius
+  );
+  const hiddenStairTopGapBlockerEdgeMinX = Math.max(
+    upperStairwellOpening.minX,
+    hiddenStairTopGapBlockerMinX - stairwellMarginX * 0.1
+  );
+  const upperStairTopGapBlockers = splitColliderAroundCorridor({
+    name: 'UpperStairTopGapBlocker',
+    bounds: {
+      minX: hiddenStairTopGapBlockerEdgeMinX,
+      maxX: upperStairLandingEntryCorridor.maxX,
+      minZ: hiddenStairTopGapBlockerMinZ,
+      maxZ: hiddenStairTopGapBlockerMaxZ,
+    },
+    corridor: upperStairLandingEntryCorridor,
+  });
+
+  const upperStairWestBannisterMinX = upperStairwellOpening.minX;
+  const descentCorridorHalfWidth = Math.max(
+    stairGeometry.halfWidth -
+      (stairBehavior.descentCorridorInset ??
+        stairBehavior.transitionMargin * 0.25),
+    stairGeometry.halfWidth * 0.55
+  );
+  const descentCorridorMinX = stairGeometry.centerX - descentCorridorHalfWidth;
+  const descentCorridorMaxX = stairGeometry.centerX + descentCorridorHalfWidth;
+  const upperStairWestBannisterMaxX = descentCorridorMinX - playerRadius - 0.01;
+  const upperStairWestBannisterShiftX = 1;
+  const upperStairNorthBannisterMinX =
+    descentCorridorMinX + bannisterThickness * 1.5;
+  const upperStairNorthBannisterBaseCenterZ =
+    upperLandingDoorwayClearanceZ - wallThickness;
+  const upperStairNorthBannisterCenterZ =
+    upperStairNorthBannisterBaseCenterZ + 2;
+  const upperStairWestBannisterSouthZ =
+    hiddenStairBlockerStartZ + bannisterThickness;
+  const upperStairNorthBannisterMaxX =
+    upperStairwellOpening.maxX - bannisterThickness;
+  const upperStairDescentHandoffFarZ =
+    stairGeometry.topZ -
+    stairLayout.directionMultiplier *
+      (stairBehavior.transitionMargin + stairBehavior.landingTriggerMargin);
+  const upperStairHiddenRunGuardNearZ =
+    upperStairDescentHandoffFarZ -
+    stairLayout.directionMultiplier * playerRadius;
+
+  const colliders: LevelSafetyCollider[] = [
+    {
+      sourceId: safetySourceId('upper.stairwell.eastLowerVoid.safetyCollider'),
+      name: 'UpperStairEastLowerVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      bounds: {
+        minX: descentCorridorMaxX,
+        maxX:
+          stairGeometry.centerX + stairGeometry.halfWidth + stairwellMarginX,
+        minZ: upperStairVoidMinZ,
+        maxZ: upperStairLandingEntryMinZ,
+      },
+      purpose: 'guard upper stairwell void edge',
+    },
+    {
+      sourceId: safetySourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
+      name: 'UpperStairEastUpperVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      bounds: {
+        minX: descentCorridorMaxX,
+        maxX:
+          stairGeometry.centerX + stairGeometry.halfWidth + stairwellMarginX,
+        minZ: upperStairLandingEntryMaxZ,
+        maxZ: upperStairVoidMaxZ,
+      },
+      purpose: 'guard upper stairwell void edge',
+    },
+    ...upperStairTopGapBlockers.map(({ name, bounds }) => ({
+      sourceId: safetySourceId(
+        `upper.stairwell.${name === 'UpperStairTopGapBlockerWest' ? 'topGapWest' : 'topGapEast'}.safetyCollider`
+      ),
+      name,
+      floor: 'upper' as const,
+      category: 'landing' as const,
+      bounds,
+      purpose: 'preserve descent corridor edge',
+    })),
+    {
+      sourceId: safetySourceId('upper.stairwell.hiddenRun.safetyCollider'),
+      name: 'UpperStairHiddenRunVoidGuard',
+      floor: 'upper',
+      category: 'void',
+      bounds: {
+        minX: upperStairwellOpening.minX,
+        maxX: upperStairwellOpening.maxX,
+        minZ: Math.min(
+          upperStairHiddenRunGuardNearZ,
+          upperLandingDoorwayClearanceZ
+        ),
+        maxZ: Math.max(
+          upperStairHiddenRunGuardNearZ,
+          upperStairNorthBannisterBaseCenterZ -
+            bannisterThickness / 2 -
+            playerRadius -
+            0.01
+        ),
+      },
+      purpose: 'guard hidden stair run no-floor area',
+    },
+    {
+      sourceId: safetySourceId('upper.stairwell.westBannister.safetyCollider'),
+      name: 'UpperStairWestBannisterGuard',
+      floor: 'upper',
+      category: 'landing',
+      bounds: {
+        minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
+        maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
+        minZ: Math.min(
+          upperStairNorthBannisterBaseCenterZ,
+          upperStairWestBannisterSouthZ
+        ),
+        maxZ:
+          Math.max(
+            upperStairNorthBannisterBaseCenterZ,
+            upperStairWestBannisterSouthZ
+          ) + 2,
+      },
+      purpose: 'preserve descent corridor edge',
+    },
+    {
+      sourceId: safetySourceId('upper.stairwell.northBannister.safetyCollider'),
+      name: 'UpperStairNorthBannisterGuard',
+      floor: 'upper',
+      category: 'landing',
+      bounds: {
+        minX: upperStairNorthBannisterMinX,
+        maxX: upperStairNorthBannisterMaxX,
+        minZ: upperStairNorthBannisterCenterZ - bannisterThickness / 2,
+        maxZ: upperStairNorthBannisterCenterZ + bannisterThickness / 2,
+      },
+      purpose: 'preserve descent corridor edge',
+    },
+  ];
+
+  return colliders;
+};

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -40,13 +40,10 @@ describe('main module imports', () => {
   it('passes generated wall source IDs into debug collider metadata', () => {
     const source = readMainSource();
 
-    expect(source).toContain(
-      'colliderSourceIds.set(instance.collider, instance.sourceId);'
-    );
-    expect(source).toContain('sourceId: colliderSourceIds.get(bounds),');
-    expect(source).toContain(
-      "sourceType: colliderSourceIds.has(bounds) ? 'wall' : undefined,"
-    );
+    expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
+    expect(source).toContain('sourceId: instance.sourceId,');
+    expect(source).toContain("sourceType: 'wall',");
+    expect(source).toContain('...colliderSourceMetadata.get(bounds),');
   });
 
   it('does not wire runtime adaptive quality into immersive mode', () => {


### PR DESCRIPTION
### Motivation
- Move ad-hoc stair, landing, and void safety colliders out of inline `main.ts` lists into declarative, source-backed generators so invisible navigation constraints carry provable provenance and purpose while preserving runtime behavior.
- Expose stable semantic source IDs and concise purpose strings for safety colliders so debug tooling, tests, and reviews can distinguish intentional safety constraints from layout walls.

### Description
- Add `LevelSafetyCollider` and two generators in `src/scene/level/stairSafetyColliders.ts`: `createGroundStairSafetyColliders(...)` and `createUpperStairSafetyColliders(...)`, each returning source-backed records with `sourceId`, `name`, `floor`, `category`, `bounds`, and `purpose`.
- Replace the inline stair safety collider assembly in `src/main.ts` with a registration flow that calls the generators, pushes bounds into runtime collider arrays, records debug names, and stores `colliderSourceMetadata` (including `sourceId`, `sourceType`, and `purpose`) for downstream debug registrations.
- Thread source metadata through the debug visualizer path by spreading `...colliderSourceMetadata.get(bounds)` in `createDebugColliderRegistrations(...)`, and add source-aware assertions to Playwright tests to verify `sourceId`/`sourceType`/`purpose` are exposed.
- Add unit tests `src/scene/level/stairSafetyColliders.test.ts` validating names, generated bounds (matching pre-extraction math), unique non-tombstoned `.safetyCollider` IDs, and descent-corridor clearance, and update docs and Playwright expectations accordingly.

### Testing
- Ran `npm run format:write` (success) and `npm run lint` (success; no blocking errors; minor import-order warnings were addressed).
- Ran focused and full unit suites with `npm run test:ci -- src/systems/movement/stairs.test.ts src/scene/level/stairSafetyColliders.test.ts` and then `npm run test:ci` (all tests passed after small test adjustments introduced to match numeric tolerance from extraction math).
- Verified end-to-end with Playwright by running `npx playwright install chromium`, `npx playwright install-deps chromium`, and `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (Playwright stairs roundtrip passed after installing browsers and host deps), and ran `npm run build`, `npm run docs:check` (docs check passed; some external link fetch warnings are pre-existing), and `npm run smoke` (success).
- Ran `npm run typecheck` which surfaced pre-existing TypeScript issues across the repo; no regressions from this change were left open and the single change-related missing variable was fixed during the rollout, but the repo has broader type issues outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a335843c738832fb18afacef6cf76ea)