### PR TITLE
Declare scene object collider policies and migrate key POI placements

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -148,9 +148,12 @@ policies are source data: a visible solid-looking object should declare a
 declare `decorativeNoCollision` or `interactionOnly` with a reason. Absence of
 a collider is therefore an explicit authored policy, not an accidental omission.
 The first migrated subset covers the Flywheel showpiece/info panel, Axel
-navigator, Jobbot terminal, PR Reaper console, and Wove loom. These continue to
-use their existing structure-factory collider bounds, but the source object owns
-the stable source ID, room/floor placement, purpose, and `custom`
+navigator, Jobbot terminal, PR Reaper console, and Wove loom. Scene-object
+positions are authored in level-space coordinates and validated against their
+declared room bounds; POI placement adapters scale them to the runtime world
+coordinates used by the current immersive scene. These objects continue to use
+their existing structure-factory collider bounds, but the source object owns the
+stable source ID, room/floor placement, purpose, and `custom`
 `factory-colliders` policy that debug collider and solid metadata can expose.
 
 ### Room connections

--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -143,8 +143,15 @@ no-floor area) without masquerading as room-wall geometry.
 Scene objects describe visible or interactable objects and their collider
 policies. Examples include media walls, mirrors, POI pedestals, showpieces,
 barriers, and decorative objects that influence navigation. Object collider
-policies should define whether colliders are generated from the object footprint,
-custom declarative bounds, or intentionally absent.
+policies are source data: a visible solid-looking object should declare a
+`solid`, `custom`, or other blocking policy, while pass-through exhibits must
+declare `decorativeNoCollision` or `interactionOnly` with a reason. Absence of
+a collider is therefore an explicit authored policy, not an accidental omission.
+The first migrated subset covers the Flywheel showpiece/info panel, Axel
+navigator, Jobbot terminal, PR Reaper console, and Wove loom. These continue to
+use their existing structure-factory collider bounds, but the source object owns
+the stable source ID, room/floor placement, purpose, and `custom`
+`factory-colliders` policy that debug collider and solid metadata can expose.
 
 ### Room connections
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,7 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import type { SceneObjectDefinition } from './scene/level/schema';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -983,12 +984,55 @@ const namedColliderDebugNames = new Map<RectCollider, string>();
 const colliderSourceMetadata = new Map<
   RectCollider,
   {
-    sourceId: WallSegmentInstance['sourceId'] | LevelSafetyCollider['sourceId'];
-    sourceType: 'wall' | 'safetyCollider';
+    sourceId:
+      | WallSegmentInstance['sourceId']
+      | LevelSafetyCollider['sourceId']
+      | SceneObjectDefinition['sourceId'];
+    sourceType: 'wall' | 'safetyCollider' | 'sceneObject';
     purpose?: string;
   }
 >();
 const upperFloorColliders: RectCollider[] = [];
+
+const sceneObjectDefinitionsById = new Map(
+  PORTFOLIO_LEVEL.floors.flatMap((floor) =>
+    (floor.sceneObjects ?? []).map((object) => [object.id, object] as const)
+  )
+);
+
+const getSceneObjectDefinition = (
+  id: string
+): SceneObjectDefinition | undefined => sceneObjectDefinitionsById.get(id);
+
+const applySceneObjectSourceMetadata = (
+  object: Object3D,
+  definition: SceneObjectDefinition
+): void => {
+  object.userData.levelSourceId = definition.sourceId;
+  object.userData.levelSource = {
+    sourceId: definition.sourceId,
+    sourceType: 'sceneObject',
+    purpose: definition.purpose ?? definition.colliderPolicy?.kind,
+  };
+};
+
+const registerSceneObjectColliders = (
+  colliders: readonly RectCollider[],
+  definition: SceneObjectDefinition,
+  target: RectCollider[]
+): void => {
+  colliders.forEach((collider) => {
+    target.push(collider);
+    colliderSourceMetadata.set(collider, {
+      sourceId: definition.sourceId,
+      sourceType: 'sceneObject',
+      purpose:
+        definition.colliderPolicy?.kind === 'custom'
+          ? definition.colliderPolicy.purpose
+          : definition.colliderPolicy?.kind,
+    });
+  });
+};
 
 const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
   `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
@@ -2816,8 +2860,20 @@ function initializeImmersiveScene(
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
       detailPolicy: activeSceneDetailPolicy,
     });
+    const flywheelSceneObject = getSceneObjectDefinition(
+      'flywheel-studio-flywheel'
+    );
+    if (flywheelSceneObject) {
+      applySceneObjectSourceMetadata(showpiece.group, flywheelSceneObject);
+      registerSceneObjectColliders(
+        showpiece.colliders,
+        flywheelSceneObject,
+        groundColliders
+      );
+    } else {
+      showpiece.colliders.forEach((collider) => groundColliders.push(collider));
+    }
     groundStructureGroup.add(showpiece.group);
-    showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     flywheelShowpiece = showpiece;
 
     const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
@@ -2836,8 +2892,20 @@ function initializeImmersiveScene(
       orientationRadians: terminalOrientation,
       detailPolicy: activeSceneDetailPolicy,
     });
+    const jobbotSceneObject = getSceneObjectDefinition(
+      'jobbot-studio-terminal'
+    );
+    if (jobbotSceneObject) {
+      applySceneObjectSourceMetadata(terminal.group, jobbotSceneObject);
+      registerSceneObjectColliders(
+        terminal.colliders,
+        jobbotSceneObject,
+        groundColliders
+      );
+    } else {
+      terminal.colliders.forEach((collider) => groundColliders.push(collider));
+    }
     groundStructureGroup.add(terminal.group);
-    terminal.colliders.forEach((collider) => groundColliders.push(collider));
     jobbotTerminal = terminal;
 
     if (axelPoi) {
@@ -2849,8 +2917,20 @@ function initializeImmersiveScene(
         },
         orientationRadians: axelPoi.group.rotation.y ?? 0,
       });
+      const axelSceneObject = getSceneObjectDefinition('axel-studio-tracker');
+      if (axelSceneObject) {
+        applySceneObjectSourceMetadata(navigator.group, axelSceneObject);
+        registerSceneObjectColliders(
+          navigator.colliders,
+          axelSceneObject,
+          groundColliders
+        );
+      } else {
+        navigator.colliders.forEach((collider) =>
+          groundColliders.push(collider)
+        );
+      }
       groundStructureGroup.add(navigator.group);
-      navigator.colliders.forEach((collider) => groundColliders.push(collider));
       axelNavigator = navigator;
     }
 
@@ -2892,8 +2972,20 @@ function initializeImmersiveScene(
       },
       orientationRadians: prReaperPoi.group.rotation.y ?? 0,
     });
+    const prReaperSceneObject = getSceneObjectDefinition(
+      'pr-reaper-backyard-console'
+    );
+    if (prReaperSceneObject) {
+      applySceneObjectSourceMetadata(console.group, prReaperSceneObject);
+      registerSceneObjectColliders(
+        console.colliders,
+        prReaperSceneObject,
+        groundColliders
+      );
+    } else {
+      console.colliders.forEach((collider) => groundColliders.push(collider));
+    }
     groundStructureGroup.add(console.group);
-    console.colliders.forEach((collider) => groundColliders.push(collider));
     prReaperConsole = console;
   }
 
@@ -2992,8 +3084,18 @@ function initializeImmersiveScene(
       },
       orientationRadians: wovePoi.group.rotation.y ?? 0,
     });
+    const woveSceneObject = getSceneObjectDefinition('wove-kitchen-loom');
+    if (woveSceneObject) {
+      applySceneObjectSourceMetadata(loom.group, woveSceneObject);
+      registerSceneObjectColliders(
+        loom.colliders,
+        woveSceneObject,
+        groundColliders
+      );
+    } else {
+      loom.colliders.forEach((collider) => groundColliders.push(collider));
+    }
     groundStructureGroup.add(loom.group);
-    loom.colliders.forEach((collider) => groundColliders.push(collider));
     woveLoom = loom;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -994,11 +994,27 @@ const colliderSourceMetadata = new Map<
 >();
 const upperFloorColliders: RectCollider[] = [];
 
-const sceneObjectDefinitionsById = new Map(
-  PORTFOLIO_LEVEL.floors.flatMap((floor) =>
-    (floor.sceneObjects ?? []).map((object) => [object.id, object] as const)
-  )
-);
+const createSceneObjectDefinitionsById = (): Map<
+  string,
+  SceneObjectDefinition
+> => {
+  const definitionsById = new Map<string, SceneObjectDefinition>();
+  for (const floor of PORTFOLIO_LEVEL.floors) {
+    for (const object of floor.sceneObjects ?? []) {
+      const existing = definitionsById.get(object.id);
+      if (existing) {
+        throw new Error(
+          `Duplicate scene object id "${object.id}" used by source IDs ` +
+            `"${existing.sourceId}" and "${object.sourceId}".`
+        );
+      }
+      definitionsById.set(object.id, object);
+    }
+  }
+  return definitionsById;
+};
+
+const sceneObjectDefinitionsById = createSceneObjectDefinitionsById();
 
 const getSceneObjectDefinition = (
   id: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,11 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import {
+  applySceneObjectSourceMetadata,
+  createSceneObjectDefinitionsById,
+  registerSceneObjectColliders,
+} from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
 import {
   createGroundStairSafetyColliders,
@@ -994,61 +999,12 @@ const colliderSourceMetadata = new Map<
 >();
 const upperFloorColliders: RectCollider[] = [];
 
-const createSceneObjectDefinitionsById = (): Map<
-  string,
-  SceneObjectDefinition
-> => {
-  const definitionsById = new Map<string, SceneObjectDefinition>();
-  for (const floor of PORTFOLIO_LEVEL.floors) {
-    for (const object of floor.sceneObjects ?? []) {
-      const existing = definitionsById.get(object.id);
-      if (existing) {
-        throw new Error(
-          `Duplicate scene object id "${object.id}" used by source IDs ` +
-            `"${existing.sourceId}" and "${object.sourceId}".`
-        );
-      }
-      definitionsById.set(object.id, object);
-    }
-  }
-  return definitionsById;
-};
-
-const sceneObjectDefinitionsById = createSceneObjectDefinitionsById();
+const sceneObjectDefinitionsById =
+  createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
 
 const getSceneObjectDefinition = (
   id: string
 ): SceneObjectDefinition | undefined => sceneObjectDefinitionsById.get(id);
-
-const applySceneObjectSourceMetadata = (
-  object: Object3D,
-  definition: SceneObjectDefinition
-): void => {
-  object.userData.levelSourceId = definition.sourceId;
-  object.userData.levelSource = {
-    sourceId: definition.sourceId,
-    sourceType: 'sceneObject',
-    purpose: definition.purpose ?? definition.colliderPolicy?.kind,
-  };
-};
-
-const registerSceneObjectColliders = (
-  colliders: readonly RectCollider[],
-  definition: SceneObjectDefinition,
-  target: RectCollider[]
-): void => {
-  colliders.forEach((collider) => {
-    target.push(collider);
-    colliderSourceMetadata.set(collider, {
-      sourceId: definition.sourceId,
-      sourceType: 'sceneObject',
-      purpose:
-        definition.colliderPolicy?.kind === 'custom'
-          ? definition.colliderPolicy.purpose
-          : definition.colliderPolicy?.kind,
-    });
-  });
-};
 
 const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
   `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
@@ -2884,7 +2840,8 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         showpiece.colliders,
         flywheelSceneObject,
-        groundColliders
+        groundColliders,
+        colliderSourceMetadata
       );
     } else {
       showpiece.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2916,7 +2873,8 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         terminal.colliders,
         jobbotSceneObject,
-        groundColliders
+        groundColliders,
+        colliderSourceMetadata
       );
     } else {
       terminal.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2939,7 +2897,8 @@ function initializeImmersiveScene(
         registerSceneObjectColliders(
           navigator.colliders,
           axelSceneObject,
-          groundColliders
+          groundColliders,
+          colliderSourceMetadata
         );
       } else {
         navigator.colliders.forEach((collider) =>
@@ -2996,7 +2955,8 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         console.colliders,
         prReaperSceneObject,
-        groundColliders
+        groundColliders,
+        colliderSourceMetadata
       );
     } else {
       console.colliders.forEach((collider) => groundColliders.push(collider));
@@ -3106,7 +3066,8 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         loom.colliders,
         woveSceneObject,
-        groundColliders
+        groundColliders,
+        colliderSourceMetadata
       );
     } else {
       loom.colliders.forEach((collider) => groundColliders.push(collider));

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -70,20 +70,24 @@ describe('PORTFOLIO_LEVEL', () => {
       (floor) => floor.sceneObjects ?? []
     );
 
-    expect(sceneObjects.map((object) => object.id)).toEqual(
-      expect.arrayContaining(migratedIds)
+    const migratedObjects = migratedIds.map((id) =>
+      sceneObjects.find((object) => object.id === id)
     );
+    expect(migratedObjects).not.toContain(undefined);
 
-    for (const object of sceneObjects.filter((next) =>
-      migratedIds.includes(next.id)
-    )) {
-      expect(object.sourceId).toMatch(/\.scene_object$/);
-      expect(object.colliderPolicy).toMatchObject({
+    const migratedSourceIds = migratedObjects.map((object) =>
+      String(object!.sourceId)
+    );
+    expect(new Set(migratedSourceIds).size).toBe(migratedSourceIds.length);
+
+    for (const object of migratedObjects) {
+      expect(object!.sourceId).toMatch(/\.scene_object$/);
+      expect(object!.colliderPolicy).toEqual({
         kind: 'custom',
         purpose: 'factory-colliders',
       });
-      expect(object.purpose).toEqual(expect.any(String));
-      expect(object.purpose?.trim()).not.toBe('');
+      expect(object!.purpose).toEqual(expect.any(String));
+      expect(object!.purpose?.trim()).not.toBe('');
     }
   });
 

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -87,6 +87,38 @@ describe('PORTFOLIO_LEVEL', () => {
     }
   });
 
+  it('rejects scene objects outside their declared room or missing custom purpose', () => {
+    const invalidLevel = {
+      ...PORTFOLIO_LEVEL,
+      floors: PORTFOLIO_LEVEL.floors.map((floor) =>
+        floor.id === 'ground'
+          ? {
+              ...floor,
+              sceneObjects: [
+                ...(floor.sceneObjects ?? []),
+                {
+                  id: 'invalid-studio-object',
+                  sourceId: floor.sceneObjects![0].sourceId,
+                  floorId: 'ground',
+                  kind: 'showpiece.invalid',
+                  roomId: 'studio',
+                  position: { x: 99, z: 99 },
+                  colliderPolicy: { kind: 'custom' as const },
+                },
+              ],
+            }
+          : floor
+      ),
+    };
+
+    expect(validateLevelDefinition(invalidLevel).errors).toEqual(
+      expect.arrayContaining([
+        'scene object "invalid-studio-object" position must stay within room "studio" bounds.',
+        'scene object "invalid-studio-object" custom collider policy requires a purpose.',
+      ])
+    );
+  });
+
   it('compiles compatibility room bounds and doorways for the current floors', () => {
     expect(
       compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -58,6 +58,35 @@ describe('PORTFOLIO_LEVEL', () => {
     );
   });
 
+  it('declares collider policies for migrated solid-like scene objects', () => {
+    const migratedIds = [
+      'flywheel-studio-flywheel',
+      'jobbot-studio-terminal',
+      'axel-studio-tracker',
+      'wove-kitchen-loom',
+      'pr-reaper-backyard-console',
+    ];
+    const sceneObjects = PORTFOLIO_LEVEL.floors.flatMap(
+      (floor) => floor.sceneObjects ?? []
+    );
+
+    expect(sceneObjects.map((object) => object.id)).toEqual(
+      expect.arrayContaining(migratedIds)
+    );
+
+    for (const object of sceneObjects.filter((next) =>
+      migratedIds.includes(next.id)
+    )) {
+      expect(object.sourceId).toMatch(/\.scene_object$/);
+      expect(object.colliderPolicy).toMatchObject({
+        kind: 'custom',
+        purpose: 'factory-colliders',
+      });
+      expect(object.purpose).toEqual(expect.any(String));
+      expect(object.purpose?.trim()).not.toBe('');
+    }
+  });
+
   it('compiles compatibility room bounds and doorways for the current floors', () => {
     expect(
       compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -1,6 +1,7 @@
 import type {
   FloorDefinition,
   LevelDefinition,
+  SceneObjectDefinition,
   WallDefinition,
 } from './schema';
 import { assertLevelSourceId } from './sourceIds';
@@ -81,6 +82,31 @@ const centeredGap = (runStart: number, center: number, label: string) => {
   const range = doorwayRange(center);
   return gap(range.start - runStart, range.end - runStart, label);
 };
+
+const sceneObject = (
+  id: string,
+  source: string,
+  floorId: 'ground' | 'upper',
+  kind: string,
+  roomId: string,
+  position: { x: number; y?: number; z: number },
+  orientation: number,
+  purpose: string,
+  colliderPolicy: SceneObjectDefinition['colliderPolicy'] = {
+    kind: 'custom',
+    purpose: 'factory-colliders',
+  }
+): SceneObjectDefinition => ({
+  id,
+  sourceId: sourceId(source),
+  floorId,
+  kind,
+  roomId,
+  position,
+  orientation,
+  purpose,
+  colliderPolicy,
+});
 
 const FLOOR_SURFACE_SOURCE_IDS: Readonly<Record<string, string>> = {
   'ground:livingRoom': 'ground.livingRoom.floor.main',
@@ -308,6 +334,58 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           ['backyard'],
           [],
           'fence'
+        ),
+      ],
+      sceneObjects: [
+        sceneObject(
+          'flywheel-studio-flywheel',
+          'ground.studio.flywheel_showpiece.scene_object',
+          'ground',
+          'showpiece.flywheel',
+          'studio',
+          { x: 11, z: -4 },
+          0,
+          'POI showpiece and info panel with factory-owned solid colliders'
+        ),
+        sceneObject(
+          'jobbot-studio-terminal',
+          'ground.studio.jobbot_terminal.scene_object',
+          'ground',
+          'showpiece.jobbot_terminal',
+          'studio',
+          { x: 24, z: 4 },
+          -Math.PI / 2,
+          'POI terminal with factory-owned desk collider'
+        ),
+        sceneObject(
+          'axel-studio-tracker',
+          'ground.studio.axel_navigator.scene_object',
+          'ground',
+          'showpiece.axel_navigator',
+          'studio',
+          { x: 20, z: -4 },
+          Math.PI,
+          'POI navigator with factory-owned dais and console colliders'
+        ),
+        sceneObject(
+          'wove-kitchen-loom',
+          'ground.kitchen.wove_loom.scene_object',
+          'ground',
+          'showpiece.wove_loom',
+          'kitchen',
+          { x: -15, z: 5 },
+          Math.PI * 0.45,
+          'POI tactile loom with factory-owned table and loom colliders'
+        ),
+        sceneObject(
+          'pr-reaper-backyard-console',
+          'ground.backyard.pr_reaper_console.scene_object',
+          'ground',
+          'showpiece.pr_reaper_console',
+          'backyard',
+          { x: 0, z: 20 },
+          Math.PI * 0.35,
+          'Backyard POI console with factory-owned deck and console colliders'
         ),
       ],
       roomConnections: [

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -343,7 +343,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.flywheel',
           'studio',
-          { x: 11, z: -4 },
+          { x: 5.5, z: -2 },
           0,
           'POI showpiece and info panel with factory-owned solid colliders'
         ),
@@ -353,7 +353,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.jobbot_terminal',
           'studio',
-          { x: 24, z: 4 },
+          { x: 12, z: 2 },
           -Math.PI / 2,
           'POI terminal with factory-owned desk collider'
         ),
@@ -363,7 +363,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.axel_navigator',
           'studio',
-          { x: 20, z: -4 },
+          { x: 10, z: -2 },
           Math.PI,
           'POI navigator with factory-owned dais and console colliders'
         ),
@@ -373,7 +373,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.wove_loom',
           'kitchen',
-          { x: -15, z: 5 },
+          { x: -7.5, z: 2.5 },
           Math.PI * 0.45,
           'POI tactile loom with factory-owned table and loom colliders'
         ),
@@ -383,7 +383,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.pr_reaper_console',
           'backyard',
-          { x: 0, z: 20 },
+          { x: 0, z: 10 },
           Math.PI * 0.35,
           'Backyard POI console with factory-owned deck and console colliders'
         ),

--- a/src/scene/level/sceneObjects.test.ts
+++ b/src/scene/level/sceneObjects.test.ts
@@ -1,0 +1,67 @@
+import { Group, Mesh } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import type { RectCollider } from '../../systems/collision';
+
+import { PORTFOLIO_LEVEL } from './portfolioLevel';
+import {
+  applySceneObjectSourceMetadata,
+  createSceneObjectDefinitionsById,
+  registerSceneObjectColliders,
+} from './sceneObjects';
+
+describe('scene object metadata helpers', () => {
+  it('applies scene object source metadata to the root group and descendants', () => {
+    const definition = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL).get(
+      'flywheel-studio-flywheel'
+    );
+    expect(definition).toBeDefined();
+
+    const group = new Group();
+    const child = new Mesh();
+    const grandchild = new Mesh();
+    child.add(grandchild);
+    group.add(child);
+
+    applySceneObjectSourceMetadata(group, definition!);
+
+    for (const object of [group, child, grandchild]) {
+      expect(object.userData.levelSourceId).toBe(definition!.sourceId);
+      expect(object.userData.levelSource).toEqual({
+        sourceId: definition!.sourceId,
+        sourceType: 'sceneObject',
+        purpose: definition!.purpose,
+      });
+    }
+  });
+
+  it('registers all factory-returned colliders with scene object source metadata', () => {
+    const definition = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL).get(
+      'flywheel-studio-flywheel'
+    );
+    expect(definition).toBeDefined();
+    const factoryColliders: RectCollider[] = [
+      { minX: 0, maxX: 1, minZ: 2, maxZ: 3 },
+      { minX: 4, maxX: 5, minZ: 6, maxZ: 7 },
+    ];
+    const registered: RectCollider[] = [];
+    const metadata = new Map();
+
+    registerSceneObjectColliders(
+      factoryColliders,
+      definition!,
+      registered,
+      metadata
+    );
+
+    expect(registered).toHaveLength(factoryColliders.length);
+    expect(registered).toEqual(factoryColliders);
+    for (const collider of factoryColliders) {
+      expect(metadata.get(collider)).toEqual({
+        sourceId: definition!.sourceId,
+        sourceType: 'sceneObject',
+        purpose: 'factory-colliders',
+      });
+    }
+  });
+});

--- a/src/scene/level/sceneObjects.ts
+++ b/src/scene/level/sceneObjects.ts
@@ -1,0 +1,74 @@
+import type { Object3D } from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+
+import type { LevelDefinition, SceneObjectDefinition } from './schema';
+
+export type SceneObjectColliderSourceMetadata = {
+  sourceId: SceneObjectDefinition['sourceId'];
+  sourceType: 'sceneObject';
+  purpose?: string;
+};
+
+export function createSceneObjectDefinitionsById(
+  level: LevelDefinition
+): Map<string, SceneObjectDefinition> {
+  const definitionsById = new Map<string, SceneObjectDefinition>();
+  for (const floor of level.floors) {
+    for (const object of floor.sceneObjects ?? []) {
+      const existing = definitionsById.get(object.id);
+      if (existing) {
+        throw new Error(
+          `Duplicate scene object id "${object.id}" used by source IDs ` +
+            `"${existing.sourceId}" and "${object.sourceId}".`
+        );
+      }
+      definitionsById.set(object.id, object);
+    }
+  }
+  return definitionsById;
+}
+
+export function getSceneObjectSourcePurpose(
+  definition: SceneObjectDefinition
+): string | undefined {
+  return definition.purpose ?? definition.colliderPolicy?.kind;
+}
+
+export function getSceneObjectColliderSourcePurpose(
+  definition: SceneObjectDefinition
+): string | undefined {
+  return definition.colliderPolicy?.kind === 'custom'
+    ? definition.colliderPolicy.purpose
+    : definition.colliderPolicy?.kind;
+}
+
+export function applySceneObjectSourceMetadata(
+  object: Object3D,
+  definition: SceneObjectDefinition
+): void {
+  object.traverse((node) => {
+    node.userData.levelSourceId = definition.sourceId;
+    node.userData.levelSource = {
+      sourceId: definition.sourceId,
+      sourceType: 'sceneObject',
+      purpose: getSceneObjectSourcePurpose(definition),
+    };
+  });
+}
+
+export function registerSceneObjectColliders(
+  colliders: readonly RectCollider[],
+  definition: SceneObjectDefinition,
+  target: RectCollider[],
+  colliderSourceMetadata: Map<RectCollider, SceneObjectColliderSourceMetadata>
+): void {
+  colliders.forEach((collider) => {
+    target.push(collider);
+    colliderSourceMetadata.set(collider, {
+      sourceId: definition.sourceId,
+      sourceType: 'sceneObject',
+      purpose: getSceneObjectColliderSourcePurpose(definition),
+    });
+  });
+}

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -112,6 +112,8 @@ export type ColliderPolicyDefinition =
   | { kind: 'footprint' }
   | { kind: 'bounds'; bounds: Bounds2D; purpose?: string };
 
+export type LevelSceneObjectDefinition = SceneObjectDefinition;
+
 export interface SceneObjectDefinition {
   id: string;
   sourceId: LevelSourceId;

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -195,6 +195,7 @@ export function validateLevelDefinition(
     floorIds.add(floor.id);
 
     const roomIds = new Set<string>();
+    const roomsById = new Map<string, SemanticRoomDefinition>();
     const wallIds = new Set<string>();
     const surfaceIds = new Set<string>();
     const safetyIds = new Set<string>();
@@ -205,6 +206,7 @@ export function validateLevelDefinition(
 
     floor.rooms.forEach((room) => {
       addNamespaceId(`room on floor ${floor.id}`, room.id, roomIds);
+      roomsById.set(room.id, room);
       addSourceId(room.sourceId, `room "${room.id}"`);
       validateBounds(room.bounds, `room "${room.id}" bounds`, errors);
     });
@@ -279,7 +281,7 @@ export function validateLevelDefinition(
         );
       if (!object.kind.trim())
         errors.push(`scene object "${object.id}" requires a kind.`);
-      validateSceneObjectPosition(object, errors);
+      validateSceneObjectPosition(object, errors, roomsById);
       validateColliderPolicy(object, errors);
     });
 
@@ -513,7 +515,8 @@ function getSegmentLength(segment: WallSegmentDefinition): number {
 
 function validateSceneObjectPosition(
   object: SceneObjectDefinition,
-  errors: string[]
+  errors: string[],
+  roomsById: ReadonlyMap<string, SemanticRoomDefinition>
 ): void {
   const values = [object.position.x, object.position.z];
   if (object.position.y !== undefined) values.push(object.position.y);
@@ -521,6 +524,14 @@ function validateSceneObjectPosition(
   if (!values.every(Number.isFinite)) {
     errors.push(
       `scene object "${object.id}" position/orientation must use finite values.`
+    );
+    return;
+  }
+
+  const room = object.roomId ? roomsById.get(object.roomId) : undefined;
+  if (room && !pointIsWithinBounds(object.position, room.bounds)) {
+    errors.push(
+      `scene object "${object.id}" position must stay within room "${room.id}" bounds.`
     );
   }
 }
@@ -543,4 +554,18 @@ function validateColliderPolicy(
       `scene object "${object.id}" decorativeNoCollision policy requires a reason.`
     );
   }
+  if (policy.kind === 'custom' && !policy.purpose?.trim()) {
+    errors.push(
+      `scene object "${object.id}" custom collider policy requires a purpose.`
+    );
+  }
+}
+
+function pointIsWithinBounds(point: Point2D, bounds: Bounds2D): boolean {
+  return (
+    point.x >= bounds.minX - LENGTH_EPSILON &&
+    point.x <= bounds.maxX + LENGTH_EPSILON &&
+    point.z >= bounds.minZ - LENGTH_EPSILON &&
+    point.z <= bounds.maxZ + LENGTH_EPSILON
+  );
 }

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -104,6 +104,10 @@ export interface SafetyColliderDefinition {
 }
 
 export type ColliderPolicyDefinition =
+  | { kind: 'solid'; reason?: string }
+  | { kind: 'decorativeNoCollision'; reason: string }
+  | { kind: 'interactionOnly'; reason?: string }
+  | { kind: 'custom'; purpose?: string }
   | { kind: 'none'; reason?: string }
   | { kind: 'footprint' }
   | { kind: 'bounds'; bounds: Bounds2D; purpose?: string };
@@ -117,6 +121,7 @@ export interface SceneObjectDefinition {
   orientation?: number;
   colliderPolicy?: ColliderPolicyDefinition;
   roomId?: string;
+  purpose?: string;
 }
 
 export interface RoomConnectionDefinition {
@@ -272,13 +277,10 @@ export function validateLevelDefinition(
         errors.push(
           `scene object "${object.id}" references missing room "${object.roomId}".`
         );
-      if (object.colliderPolicy?.kind === 'bounds') {
-        validateBounds(
-          object.colliderPolicy.bounds,
-          `scene object "${object.id}" collider bounds`,
-          errors
-        );
-      }
+      if (!object.kind.trim())
+        errors.push(`scene object "${object.id}" requires a kind.`);
+      validateSceneObjectPosition(object, errors);
+      validateColliderPolicy(object, errors);
     });
 
     floor.roomConnections?.forEach((connection) => {
@@ -507,4 +509,38 @@ function getSegmentLength(segment: WallSegmentDefinition): number {
     segment.end.x - segment.start.x,
     segment.end.z - segment.start.z
   );
+}
+
+function validateSceneObjectPosition(
+  object: SceneObjectDefinition,
+  errors: string[]
+): void {
+  const values = [object.position.x, object.position.z];
+  if (object.position.y !== undefined) values.push(object.position.y);
+  if (object.orientation !== undefined) values.push(object.orientation);
+  if (!values.every(Number.isFinite)) {
+    errors.push(
+      `scene object "${object.id}" position/orientation must use finite values.`
+    );
+  }
+}
+
+function validateColliderPolicy(
+  object: SceneObjectDefinition,
+  errors: string[]
+): void {
+  const policy = object.colliderPolicy;
+  if (!policy) return;
+  if (policy.kind === 'bounds') {
+    validateBounds(
+      policy.bounds,
+      `scene object "${object.id}" collider bounds`,
+      errors
+    );
+  }
+  if (policy.kind === 'decorativeNoCollision' && !policy.reason.trim()) {
+    errors.push(
+      `scene object "${object.id}" decorativeNoCollision policy requires a reason.`
+    );
+  }
 }

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyManualPoiPlacements, MANUAL_POI_PLACEMENTS } from './placements';
+import type { PoiDefinition, PoiId } from './types';
+
+const definition = (id: PoiId): PoiDefinition => ({
+  id,
+  title: id,
+  summary: 'Test POI summary',
+  category: 'project',
+  interaction: 'inspect',
+  roomId: 'original-room',
+  position: { x: 1, y: 0.5, z: 2 },
+  headingRadians: 0.25,
+  interactionRadius: 2,
+  footprint: { width: 1, depth: 1 },
+  interactionPrompt: 'Inspect',
+});
+
+describe('applyManualPoiPlacements', () => {
+  it('resolves migrated POI placements from PORTFOLIO_LEVEL scene objects', () => {
+    const expected: Array<{
+      id: PoiId;
+      roomId: string;
+      x: number;
+      z: number;
+      headingRadians: number;
+    }> = [
+      {
+        id: 'flywheel-studio-flywheel',
+        roomId: 'studio',
+        x: 11,
+        z: -4,
+        headingRadians: 0,
+      },
+      {
+        id: 'jobbot-studio-terminal',
+        roomId: 'studio',
+        x: 24,
+        z: 4,
+        headingRadians: -Math.PI / 2,
+      },
+      {
+        id: 'axel-studio-tracker',
+        roomId: 'studio',
+        x: 20,
+        z: -4,
+        headingRadians: Math.PI,
+      },
+      {
+        id: 'wove-kitchen-loom',
+        roomId: 'kitchen',
+        x: -15,
+        z: 5,
+        headingRadians: Math.PI * 0.45,
+      },
+    ];
+    const placed = applyManualPoiPlacements(
+      expected.map(({ id }) => definition(id))
+    );
+
+    for (const [index, poi] of placed.entries()) {
+      const nextExpected = expected[index];
+      expect(poi.id).toBe(nextExpected.id);
+      expect(poi.roomId).toBe(nextExpected.roomId);
+      expect(poi.position.x).toBeCloseTo(nextExpected.x);
+      expect(poi.position.y).toBe(0.5);
+      expect(poi.position.z).toBeCloseTo(nextExpected.z);
+      expect(poi.headingRadians).toBeCloseTo(nextExpected.headingRadians);
+    }
+  });
+
+  it('leaves remaining manual placements intact', () => {
+    const ids = Object.keys(MANUAL_POI_PLACEMENTS) as PoiId[];
+    const placed = applyManualPoiPlacements(ids.map(definition));
+
+    for (const poi of placed) {
+      const manual = MANUAL_POI_PLACEMENTS[poi.id];
+      expect(manual).toBeDefined();
+      expect(poi.roomId).toBe(manual?.roomId);
+      expect(poi.position).toEqual({
+        x: manual?.position.x,
+        y: manual?.position.y ?? 0.5,
+        z: manual?.position.z,
+      });
+      expect(poi.headingRadians).toBe(manual?.headingRadians ?? 0.25);
+    }
+  });
+});

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -1,4 +1,40 @@
+import { PORTFOLIO_LEVEL } from '../level/portfolioLevel';
+import type { SceneObjectDefinition } from '../level/schema';
+
 import type { PoiDefinition, PoiId } from './types';
+
+const getSceneObjectPoiPlacement = (
+  object: SceneObjectDefinition
+): {
+  roomId: string;
+  position: { x: number; y?: number; z: number };
+  headingRadians?: number;
+} | null => {
+  if (!object.roomId) return null;
+  return {
+    roomId: object.roomId,
+    position: { ...object.position },
+    headingRadians: object.orientation,
+  };
+};
+
+const SCENE_OBJECT_POI_PLACEMENTS = Object.fromEntries(
+  PORTFOLIO_LEVEL.floors.flatMap((floor) =>
+    (floor.sceneObjects ?? []).flatMap((object) => {
+      const placement = getSceneObjectPoiPlacement(object);
+      return placement ? [[object.id, placement]] : [];
+    })
+  )
+) as Partial<
+  Record<
+    PoiId,
+    {
+      roomId: string;
+      position: { x: number; y?: number; z: number };
+      headingRadians?: number;
+    }
+  >
+>;
 
 // Manual downstairs placements (world units). TV remains a wall display and is left as-is.
 export const MANUAL_POI_PLACEMENTS: Partial<
@@ -22,27 +58,10 @@ export const MANUAL_POI_PLACEMENTS: Partial<
     position: { x: 3, z: -28 },
     headingRadians: 0,
   },
-
-  // Studio (three exhibits near center, spaced apart)
-  'flywheel-studio-flywheel': {
-    roomId: 'studio',
-    position: { x: 11, z: -4 },
-    headingRadians: 0,
-  },
-  'jobbot-studio-terminal': {
-    roomId: 'studio',
-    position: { x: 24, z: 4 },
-    headingRadians: -Math.PI / 2,
-  },
   'gabriel-studio-sentry': {
     roomId: 'studio',
     position: { x: 2, z: 8 },
     headingRadians: -Math.PI * 0.3,
-  },
-  'axel-studio-tracker': {
-    roomId: 'studio',
-    position: { x: 20, z: -4 },
-    headingRadians: Math.PI,
   },
   'tokenplace-studio-cluster': {
     roomId: 'studio',
@@ -61,18 +80,14 @@ export const MANUAL_POI_PLACEMENTS: Partial<
     position: { x: -25, z: 6 },
     headingRadians: Math.PI * 0.1,
   },
-  'wove-kitchen-loom': {
-    roomId: 'kitchen',
-    position: { x: -15, z: 5 },
-    headingRadians: Math.PI * 0.45,
-  },
 };
 
 export function applyManualPoiPlacements(
   defs: PoiDefinition[]
 ): PoiDefinition[] {
   return defs.map((d) => {
-    const override = MANUAL_POI_PLACEMENTS[d.id];
+    const override =
+      SCENE_OBJECT_POI_PLACEMENTS[d.id] ?? MANUAL_POI_PLACEMENTS[d.id];
     if (!override) return d;
     return {
       ...d,

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -1,3 +1,4 @@
+import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
 import { PORTFOLIO_LEVEL } from '../level/portfolioLevel';
 import type { SceneObjectDefinition } from '../level/schema';
 
@@ -18,23 +19,36 @@ const getSceneObjectPoiPlacement = (
   };
 };
 
-const SCENE_OBJECT_POI_PLACEMENTS = Object.fromEntries(
-  PORTFOLIO_LEVEL.floors.flatMap((floor) =>
-    (floor.sceneObjects ?? []).flatMap((object) => {
-      const placement = getSceneObjectPoiPlacement(object);
-      return placement ? [[object.id, placement]] : [];
-    })
-  )
-) as Partial<
-  Record<
-    PoiId,
-    {
-      roomId: string;
-      position: { x: number; y?: number; z: number };
-      headingRadians?: number;
-    }
-  >
->;
+type PoiPlacementOverride = {
+  roomId: string;
+  position: { x: number; y?: number; z: number };
+  headingRadians?: number;
+};
+
+const toWorldPoiPlacement = (
+  placement: PoiPlacementOverride
+): PoiPlacementOverride => ({
+  ...placement,
+  position: {
+    ...placement.position,
+    x: placement.position.x * FLOOR_PLAN_SCALE,
+    z: placement.position.z * FLOOR_PLAN_SCALE,
+  },
+});
+
+const SCENE_OBJECT_POI_PLACEMENTS: Record<string, PoiPlacementOverride> =
+  Object.fromEntries(
+    PORTFOLIO_LEVEL.floors.flatMap((floor) =>
+      (floor.sceneObjects ?? []).flatMap((object) => {
+        const placement = getSceneObjectPoiPlacement(object);
+        return placement ? [[object.id, toWorldPoiPlacement(placement)]] : [];
+      })
+    )
+  );
+
+const getSceneObjectPoiPlacementOverride = (
+  id: PoiId
+): PoiPlacementOverride | undefined => SCENE_OBJECT_POI_PLACEMENTS[id];
 
 // Manual downstairs placements (world units). TV remains a wall display and is left as-is.
 export const MANUAL_POI_PLACEMENTS: Partial<
@@ -87,7 +101,7 @@ export function applyManualPoiPlacements(
 ): PoiDefinition[] {
   return defs.map((d) => {
     const override =
-      SCENE_OBJECT_POI_PLACEMENTS[d.id] ?? MANUAL_POI_PLACEMENTS[d.id];
+      getSceneObjectPoiPlacementOverride(d.id) ?? MANUAL_POI_PLACEMENTS[d.id];
     if (!override) return d;
     return {
       ...d,


### PR DESCRIPTION
### Motivation
- Move recurring POI/showpiece collider intent into the declarative level source so visible objects have explicit collider policies and stable source IDs. 
- Preserve existing visuals and collision behavior while surfacing source provenance for debug tooling. 
- Start with a safe subset of recurring collider pain points (Flywheel, Jobbot, Axel, Wove, PR Reaper) to avoid broad churn.

### Description
- Extended the level schema to include `ColliderPolicyDefinition` variants (`solid`, `decorativeNoCollision`, `interactionOnly`, `custom`, plus legacy forms) and added `purpose` metadata and validation for `SceneObjectDefinition` (finite positions/orientations and policy checks). 
- Added `sceneObjects` to `PORTFOLIO_LEVEL` and declared source-backed scene entries for the migrated subset with `sourceId`, `kind`, `floorId`, placement, `purpose`, and a `custom` `factory-colliders` policy so factories keep their existing collider bounds. 
- Derived POI placements from the declarative `sceneObjects` (merged with remaining manual placements) and threaded source metadata into runtime objects and colliders by setting `userData.levelSourceId` / `userData.levelSource` and registering scene-object colliders into the existing collider debug metadata. 
- Added an invariant test asserting migrated scene objects exist, use `.scene_object` source IDs, and declare explicit factory collider policies, and updated the design doc to state collider policy is authored source data.

### Testing
- `npm run format:write` — passed. 
- `npm run lint` — passed after import-group fixes and ESLint auto-fixes. 
- `npm run test:ci` — full Vitest run passed (155 test files, 1191 tests passed). 
- `npm run docs:check` — passed (link checker produced existing external-fetch warnings only). 
- `npm run smoke` and `npm run build` — passed; smoke build artifact checks passed. 
- `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected. 
- `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — attempted but blocked by missing Playwright Chromium executable in the environment; no app-level failures were observed prior to the browser-launch error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336b87d0ec832faebfc317a73f568c)