### PR TITLE
Declare scene object collider policies

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -360,3 +360,28 @@ to regenerate the final visual geometry, gameplay collision, and debug metadata;
 legacy patches, removed-ID lists, and manually pushed unowned colliders are gone;
 and inventory tooling can explain every runtime level artifact by semantic source
 ID.
+
+## Scene objects and collider policies (phase 10)
+
+Scene object placement intent is now part of the declarative level source. A
+safe subset of POI/showpiece objects in `src/scene/level/portfolioLevel.ts`
+uses `sceneObjects` records with stable `sourceId`, runtime `kind`, floor,
+optional room, placement defaults, purpose text, and explicit collider policy.
+The first migrated objects are the recurring collider-debug pain points:
+Flywheel showpiece, Jobbot terminal, Axel navigator, PR Reaper console, and Wove
+loom.
+
+Collider policy is intentional data rather than an implicit side effect of a
+structure factory. Solid-looking migrated objects declare `solid` with a purpose
+for the retained collider footprint. Decorative or interaction-only future
+objects should use `decorativeNoCollision` or `interactionOnly` with a reason;
+therefore, the absence of a collider should be reviewed as an explicit policy,
+not treated as an accidental omission.
+
+Runtime construction still preserves current POI-driven positions and existing
+collider bounds. During registration, migrated object groups and descendants get
+`userData.levelSourceId` plus `userData.levelSource.sourceType = 'sceneObject'`,
+and each retained rectangle collider is mapped to the same source metadata so
+debug collider APIs can find object colliders by source ID. Future cleanup can
+move additional object-specific positions, clamps, and custom collider bounds
+into the same source records without changing the debug metadata contract.

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,8 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import type { SceneObjectDefinition } from './scene/level/schema';
+import type { LevelSourceMetadata } from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -980,14 +982,7 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
-const colliderSourceMetadata = new Map<
-  RectCollider,
-  {
-    sourceId: WallSegmentInstance['sourceId'] | LevelSafetyCollider['sourceId'];
-    sourceType: 'wall' | 'safetyCollider';
-    purpose?: string;
-  }
->();
+const colliderSourceMetadata = new Map<RectCollider, LevelSourceMetadata>();
 const upperFloorColliders: RectCollider[] = [];
 
 const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
@@ -1055,6 +1050,43 @@ function getLevelFloor(floorId: FloorId) {
   if (!floor) throw new Error(`Portfolio level is missing floor "${floorId}".`);
   return floor;
 }
+
+const getSceneObjectDefinition = (
+  floorId: FloorId,
+  kind: string
+): SceneObjectDefinition | undefined =>
+  getLevelFloor(floorId).sceneObjects?.find((object) => object.kind === kind);
+
+const applySceneObjectSourceMetadata = (
+  group: Object3D,
+  definition: SceneObjectDefinition
+): LevelSourceMetadata => {
+  const metadata: LevelSourceMetadata = {
+    sourceId: definition.sourceId,
+    sourceType: 'sceneObject',
+    purpose: definition.colliderPolicy?.purpose ?? definition.purpose,
+  };
+  group.traverse((object) => {
+    object.userData.levelSourceId = definition.sourceId;
+    object.userData.levelSource = metadata;
+  });
+  return metadata;
+};
+
+const registerSceneObjectColliders = (
+  colliders: readonly RectCollider[],
+  metadata: LevelSourceMetadata,
+  targetColliders: RectCollider[]
+) => {
+  colliders.forEach((collider, index) => {
+    targetColliders.push(collider);
+    namedColliderDebugNames.set(
+      collider,
+      `${metadata.sourceId}:collider-${index + 1}`
+    );
+    colliderSourceMetadata.set(collider, metadata);
+  });
+};
 
 const container = document.getElementById('app');
 
@@ -2809,20 +2841,41 @@ function initializeImmersiveScene(
     const centerZ =
       flywheelPoi?.group.position.z ??
       (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2;
+    const flywheelSceneObject = getSceneObjectDefinition(
+      'ground',
+      'flywheelShowpiece'
+    );
     const showpiece = createFlywheelShowpiece({
       centerX,
       centerZ,
       roomBounds: studioRoom.bounds,
-      orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
+      orientationRadians:
+        flywheelPoi?.group.rotation.y ?? flywheelSceneObject?.orientation ?? 0,
       detailPolicy: activeSceneDetailPolicy,
     });
     groundStructureGroup.add(showpiece.group);
-    showpiece.colliders.forEach((collider) => groundColliders.push(collider));
+    registerSceneObjectColliders(
+      showpiece.colliders,
+      flywheelSceneObject
+        ? applySceneObjectSourceMetadata(showpiece.group, flywheelSceneObject)
+        : {
+            sourceId: 'runtime.flywheelShowpiece.sceneObject' as never,
+            sourceType: 'sceneObject',
+          },
+      groundColliders
+    );
     flywheelShowpiece = showpiece;
 
-    const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
+    const jobbotSceneObject = getSceneObjectDefinition(
+      'ground',
+      'jobbotTerminal'
+    );
+    const terminalOrientation =
+      jobbotPoi?.group.rotation.y ??
+      jobbotSceneObject?.orientation ??
+      -Math.PI / 2;
     const terminalX = MathUtils.clamp(
-      jobbotPoi?.group.position.x ?? 11.4,
+      jobbotPoi?.group.position.x ?? jobbotSceneObject?.position.x ?? 11.4,
       studioRoom.bounds.minX + 1.2,
       studioRoom.bounds.maxX - 0.8
     );
@@ -2837,7 +2890,15 @@ function initializeImmersiveScene(
       detailPolicy: activeSceneDetailPolicy,
     });
     groundStructureGroup.add(terminal.group);
-    terminal.colliders.forEach((collider) => groundColliders.push(collider));
+    if (jobbotSceneObject) {
+      registerSceneObjectColliders(
+        terminal.colliders,
+        applySceneObjectSourceMetadata(terminal.group, jobbotSceneObject),
+        groundColliders
+      );
+    } else {
+      terminal.colliders.forEach((collider) => groundColliders.push(collider));
+    }
     jobbotTerminal = terminal;
 
     if (axelPoi) {
@@ -2849,8 +2910,22 @@ function initializeImmersiveScene(
         },
         orientationRadians: axelPoi.group.rotation.y ?? 0,
       });
+      const axelSceneObject = getSceneObjectDefinition(
+        'ground',
+        'axelNavigator'
+      );
       groundStructureGroup.add(navigator.group);
-      navigator.colliders.forEach((collider) => groundColliders.push(collider));
+      if (axelSceneObject) {
+        registerSceneObjectColliders(
+          navigator.colliders,
+          applySceneObjectSourceMetadata(navigator.group, axelSceneObject),
+          groundColliders
+        );
+      } else {
+        navigator.colliders.forEach((collider) =>
+          groundColliders.push(collider)
+        );
+      }
       axelNavigator = navigator;
     }
 
@@ -2892,8 +2967,20 @@ function initializeImmersiveScene(
       },
       orientationRadians: prReaperPoi.group.rotation.y ?? 0,
     });
+    const prReaperSceneObject = getSceneObjectDefinition(
+      'ground',
+      'prReaperConsole'
+    );
     groundStructureGroup.add(console.group);
-    console.colliders.forEach((collider) => groundColliders.push(collider));
+    if (prReaperSceneObject) {
+      registerSceneObjectColliders(
+        console.colliders,
+        applySceneObjectSourceMetadata(console.group, prReaperSceneObject),
+        groundColliders
+      );
+    } else {
+      console.colliders.forEach((collider) => groundColliders.push(collider));
+    }
     prReaperConsole = console;
   }
 
@@ -2992,8 +3079,17 @@ function initializeImmersiveScene(
       },
       orientationRadians: wovePoi.group.rotation.y ?? 0,
     });
+    const woveSceneObject = getSceneObjectDefinition('ground', 'woveLoom');
     groundStructureGroup.add(loom.group);
-    loom.colliders.forEach((collider) => groundColliders.push(collider));
+    if (woveSceneObject) {
+      registerSceneObjectColliders(
+        loom.colliders,
+        applySceneObjectSourceMetadata(loom.group, woveSceneObject),
+        groundColliders
+      );
+    } else {
+      loom.colliders.forEach((collider) => groundColliders.push(collider));
+    }
     woveLoom = loom;
   }
 

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -58,6 +58,34 @@ describe('PORTFOLIO_LEVEL', () => {
     );
   });
 
+  it('declares collider policies for migrated solid-like scene objects', () => {
+    const groundObjects = PORTFOLIO_LEVEL.floors.find(
+      (floor) => floor.id === 'ground'
+    )?.sceneObjects;
+    const migratedKinds = [
+      'flywheelShowpiece',
+      'jobbotTerminal',
+      'axelNavigator',
+      'prReaperConsole',
+      'woveLoom',
+    ];
+
+    expect(
+      groundObjects?.filter((object) => migratedKinds.includes(object.kind))
+    ).toHaveLength(migratedKinds.length);
+    migratedKinds.forEach((kind) => {
+      const object = groundObjects?.find(
+        (candidate) => candidate.kind === kind
+      );
+      expect(object).toMatchObject({
+        sourceId: expect.stringContaining('.sceneObject'),
+        colliderPolicy: { kind: 'solid' },
+      });
+      expect(object?.purpose).toBeTruthy();
+      expect(object?.colliderPolicy?.purpose).toBeTruthy();
+    });
+  });
+
   it('compiles compatibility room bounds and doorways for the current floors', () => {
     expect(
       compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -310,6 +310,73 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'fence'
         ),
       ],
+
+      sceneObjects: [
+        {
+          id: 'flywheel-studio-showpiece',
+          sourceId: sourceId('ground.studio.flywheelShowpiece.sceneObject'),
+          floorId: 'ground',
+          kind: 'flywheelShowpiece',
+          position: { x: 0, z: 0 },
+          roomId: 'studio',
+          colliderPolicy: {
+            kind: 'solid',
+            purpose: 'showpiece dais and info panel',
+          },
+          purpose: 'Studio Flywheel automation showpiece anchored to its POI.',
+        },
+        {
+          id: 'jobbot-studio-terminal',
+          sourceId: sourceId('ground.studio.jobbotTerminal.sceneObject'),
+          floorId: 'ground',
+          kind: 'jobbotTerminal',
+          position: { x: 11.4, z: -0.6 },
+          orientation: -Math.PI / 2,
+          roomId: 'studio',
+          colliderPolicy: { kind: 'solid', purpose: 'terminal desk footprint' },
+          purpose: 'Jobbot automation terminal placement and collider policy.',
+        },
+        {
+          id: 'axel-studio-navigator',
+          sourceId: sourceId('ground.studio.axelNavigator.sceneObject'),
+          floorId: 'ground',
+          kind: 'axelNavigator',
+          position: { x: 0, z: 0 },
+          roomId: 'studio',
+          colliderPolicy: {
+            kind: 'solid',
+            purpose: 'navigator table and quest card',
+          },
+          purpose: 'Axel quest navigator placement follows the Axel POI.',
+        },
+        {
+          id: 'pr-reaper-backyard-console',
+          sourceId: sourceId('ground.backyard.prReaperConsole.sceneObject'),
+          floorId: 'ground',
+          kind: 'prReaperConsole',
+          position: { x: 0, z: 0 },
+          roomId: 'backyard',
+          colliderPolicy: {
+            kind: 'solid',
+            purpose: 'console deck and walkway',
+          },
+          purpose:
+            'PR Reaper operations console placement follows the PR Reaper POI.',
+        },
+        {
+          id: 'wove-kitchen-loom',
+          sourceId: sourceId('ground.kitchen.woveLoom.sceneObject'),
+          floorId: 'ground',
+          kind: 'woveLoom',
+          position: { x: 0, z: 0 },
+          roomId: 'kitchen',
+          colliderPolicy: {
+            kind: 'solid',
+            purpose: 'loom table and shuttle rail',
+          },
+          purpose: 'Wove loom placement follows the Wove POI.',
+        },
+      ],
       roomConnections: [
         {
           id: 'living-to-kitchen',

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -104,6 +104,10 @@ export interface SafetyColliderDefinition {
 }
 
 export type ColliderPolicyDefinition =
+  | { kind: 'solid'; purpose?: string }
+  | { kind: 'decorativeNoCollision'; reason: string }
+  | { kind: 'interactionOnly'; reason?: string }
+  | { kind: 'custom'; bounds?: Bounds2D; purpose?: string }
   | { kind: 'none'; reason?: string }
   | { kind: 'footprint' }
   | { kind: 'bounds'; bounds: Bounds2D; purpose?: string };
@@ -116,6 +120,7 @@ export interface SceneObjectDefinition {
   position: Point2D & { y?: number };
   orientation?: number;
   colliderPolicy?: ColliderPolicyDefinition;
+  purpose?: string;
   roomId?: string;
 }
 
@@ -272,7 +277,11 @@ export function validateLevelDefinition(
         errors.push(
           `scene object "${object.id}" references missing room "${object.roomId}".`
         );
-      if (object.colliderPolicy?.kind === 'bounds') {
+      if (
+        object.colliderPolicy?.kind === 'bounds' ||
+        (object.colliderPolicy?.kind === 'custom' &&
+          object.colliderPolicy.bounds)
+      ) {
         validateBounds(
           object.colliderPolicy.bounds,
           `scene object "${object.id}" collider bounds`,


### PR DESCRIPTION
### Motivation
- Move recurring POI/showpiece collider intent into the declarative level source so colliders are intentional data rather than implicit side-effects of structure factories.
- Make scene objects addressable with stable `sourceId` metadata so debug collider/solid visualizers can trace colliders back to a human-editable source.
- Preserve current visuals and collision behavior while enabling future cleanup and policy-driven collider changes.

### Description
- Extend the declarative level schema by expanding `ColliderPolicyDefinition` and adding `purpose` to `SceneObjectDefinition` in `src/scene/level/schema.ts` so scene objects can declare `solid`, `decorativeNoCollision`, `interactionOnly`, `custom`, and legacy options.
- Add a safe subset of migrated scene object records in `PORTFOLIO_LEVEL` for Flywheel, Jobbot, Axel, PR Reaper, and Wove with stable `sourceId` and explicit `colliderPolicy: { kind: 'solid' }` in `src/scene/level/portfolioLevel.ts`.
- Propagate source metadata at runtime by adding `getSceneObjectDefinition`, `applySceneObjectSourceMetadata`, and `registerSceneObjectColliders` in `src/main.ts`, setting `userData.levelSourceId` / `userData.levelSource` on groups and mapping retained rectangle colliders to the same source metadata for debug lookup.
- Add an invariant test asserting migrated objects exist and declare `solid` collider policies, and document the phase in `docs/design/declarative-level-source-of-truth.md`.

### Testing
- Ran formatting: `npm run format:write` and lint: `npm run lint` (lint produced a reorder warning which was addressed; final lint passed).
- Ran focused unit tests: `npm run test:ci -- src/scene/level/__tests__/portfolioLevel.test.ts src/tests/flywheelShowpiece.test.ts src/scene/structures/__tests__/axelNavigator.test.ts src/tests/jobbotTerminal.test.ts src/tests/prReaperConsole.test.ts src/scene/structures/__tests__/woveLoom.test.ts` and observed all focused tests passed.
- Ran full test suite: `npm run test:ci` which completed successfully (1191 tests passed), and ran `npm run docs:check`, `npm run build`, and `npm run smoke` which all passed (docs link-check emits external fetch warnings but the docs check succeeded).
- Attempted Playwright verification with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`; Playwright browser download (`npx playwright install chromium`) completed but the test run was blocked by missing host browser dependencies, so the Playwright suite could not be executed in this environment (suggest running `npx playwright install-deps` or installing the listed system packages and re-running the Playwright tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336b81dfc4832fb03913f972d83f63)