### PR TITLE
Declarative scene object source IDs & collider policies

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -360,3 +360,22 @@ to regenerate the final visual geometry, gameplay collision, and debug metadata;
 legacy patches, removed-ID lists, and manually pushed unowned colliders are gone;
 and inventory tooling can explain every runtime level artifact by semantic source
 ID.
+
+## Scene object placements and collider policy (phase 10)
+
+Scene object definitions now cover the first source-backed subset of POI
+showpieces whose colliders historically required manual tracing through
+`main.ts` and structure factories: Flywheel, Jobbot, Axel, Wove, and PR Reaper.
+Each definition records `sourceId`, `id`, `floorId`, `kind`, `position`, optional
+`orientation`, optional `roomId`, `purpose`, and an explicit `colliderPolicy`.
+The policy is current intentional data: visible solid-like objects use `solid`
+or `custom`, and future decorative objects must use `decorativeNoCollision` with
+a reason rather than silently omitting collision.
+
+Runtime factories can receive the source metadata without changing their visual
+placement logic. Generated root groups receive `userData.levelSourceId` plus a
+`userData.levelSource` object with `sourceType: 'sceneObject'`; collider
+registration maps returned rectangle colliders back to the same source metadata
+for debug overlays. This preserves the current geometry and collision bounds
+while making future object collider cleanup an edit to declarative source data
+instead of a hidden override in construction code.

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,6 +157,12 @@ import {
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
 import {
+  createSceneObjectDefinitionLookup,
+  getSceneObjectSourceMetadata,
+  registerSceneObjectColliderMetadata,
+} from './scene/level/sceneObjects';
+import type { LevelSourceId } from './scene/level/sourceIds';
+import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
   type LevelSafetyCollider,
@@ -983,8 +989,11 @@ const namedColliderDebugNames = new Map<RectCollider, string>();
 const colliderSourceMetadata = new Map<
   RectCollider,
   {
-    sourceId: WallSegmentInstance['sourceId'] | LevelSafetyCollider['sourceId'];
-    sourceType: 'wall' | 'safetyCollider';
+    sourceId:
+      | WallSegmentInstance['sourceId']
+      | LevelSafetyCollider['sourceId']
+      | LevelSourceId;
+    sourceType: 'wall' | 'safetyCollider' | 'sceneObject';
     purpose?: string;
   }
 >();
@@ -1046,6 +1055,12 @@ const roomDefinitions = new Map(
 function getRoomCategory(roomId: string): RoomCategory {
   const room = roomDefinitions.get(roomId);
   return room?.category ?? 'interior';
+}
+
+function getGroundSceneObjectLookup() {
+  return createSceneObjectDefinitionLookup(
+    getLevelFloor('ground').sceneObjects ?? []
+  );
 }
 
 function getLevelFloor(floorId: FloorId) {
@@ -2802,32 +2817,63 @@ function initializeImmersiveScene(
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
   const kitchenRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'kitchen');
   const kitchenBounds = kitchenRoom?.bounds;
+  const sceneObjectDefinitions = getGroundSceneObjectLookup();
+  const flywheelSceneObject = sceneObjectDefinitions.require(
+    'flywheel-studio-showpiece'
+  );
+  const jobbotSceneObject = sceneObjectDefinitions.require(
+    'jobbot-studio-terminal'
+  );
+  const axelSceneObject = sceneObjectDefinitions.require(
+    'axel-studio-navigator'
+  );
+  const woveSceneObject = sceneObjectDefinitions.require('wove-kitchen-loom');
+  const prReaperSceneObject = sceneObjectDefinitions.require(
+    'pr-reaper-backyard-console'
+  );
+  const registerSceneObjectColliders = (
+    colliders: readonly RectCollider[],
+    objectId: string
+  ) => {
+    registerSceneObjectColliderMetadata(
+      colliders,
+      getSceneObjectSourceMetadata(sceneObjectDefinitions.require(objectId)),
+      (collider, metadata) => colliderSourceMetadata.set(collider, metadata)
+    );
+  };
   if (studioRoom) {
     const centerX =
-      flywheelPoi?.group.position.x ??
-      (studioRoom.bounds.minX + studioRoom.bounds.maxX) / 2;
+      flywheelPoi?.group.position.x ?? flywheelSceneObject.position.x;
     const centerZ =
-      flywheelPoi?.group.position.z ??
-      (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2;
+      flywheelPoi?.group.position.z ?? flywheelSceneObject.position.z;
     const showpiece = createFlywheelShowpiece({
       centerX,
       centerZ,
       roomBounds: studioRoom.bounds,
-      orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
+      orientationRadians:
+        flywheelPoi?.group.rotation.y ?? flywheelSceneObject.orientation ?? 0,
       detailPolicy: activeSceneDetailPolicy,
+      levelSource: getSceneObjectSourceMetadata(flywheelSceneObject),
     });
     groundStructureGroup.add(showpiece.group);
+    registerSceneObjectColliders(
+      showpiece.colliders,
+      'flywheel-studio-showpiece'
+    );
     showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     flywheelShowpiece = showpiece;
 
-    const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
+    const terminalOrientation =
+      jobbotPoi?.group.rotation.y ??
+      jobbotSceneObject.orientation ??
+      -Math.PI / 2;
     const terminalX = MathUtils.clamp(
-      jobbotPoi?.group.position.x ?? 11.4,
+      jobbotPoi?.group.position.x ?? jobbotSceneObject.position.x,
       studioRoom.bounds.minX + 1.2,
       studioRoom.bounds.maxX - 0.8
     );
     const terminalZ = MathUtils.clamp(
-      jobbotPoi?.group.position.z ?? -0.6,
+      jobbotPoi?.group.position.z ?? jobbotSceneObject.position.z,
       studioRoom.bounds.minZ + 1.2,
       studioRoom.bounds.maxZ - 1.1
     );
@@ -2835,8 +2881,10 @@ function initializeImmersiveScene(
       position: { x: terminalX, y: 0, z: terminalZ },
       orientationRadians: terminalOrientation,
       detailPolicy: activeSceneDetailPolicy,
+      levelSource: getSceneObjectSourceMetadata(jobbotSceneObject),
     });
     groundStructureGroup.add(terminal.group);
+    registerSceneObjectColliders(terminal.colliders, 'jobbot-studio-terminal');
     terminal.colliders.forEach((collider) => groundColliders.push(collider));
     jobbotTerminal = terminal;
 
@@ -2848,8 +2896,13 @@ function initializeImmersiveScene(
           z: axelPoi.group.position.z,
         },
         orientationRadians: axelPoi.group.rotation.y ?? 0,
+        levelSource: getSceneObjectSourceMetadata(axelSceneObject),
       });
       groundStructureGroup.add(navigator.group);
+      registerSceneObjectColliders(
+        navigator.colliders,
+        'axel-studio-navigator'
+      );
       navigator.colliders.forEach((collider) => groundColliders.push(collider));
       axelNavigator = navigator;
     }
@@ -2891,8 +2944,13 @@ function initializeImmersiveScene(
         z: prReaperPoi.group.position.z,
       },
       orientationRadians: prReaperPoi.group.rotation.y ?? 0,
+      levelSource: getSceneObjectSourceMetadata(prReaperSceneObject),
     });
     groundStructureGroup.add(console.group);
+    registerSceneObjectColliders(
+      console.colliders,
+      'pr-reaper-backyard-console'
+    );
     console.colliders.forEach((collider) => groundColliders.push(collider));
     prReaperConsole = console;
   }
@@ -2991,8 +3049,10 @@ function initializeImmersiveScene(
         z: loomZ,
       },
       orientationRadians: wovePoi.group.rotation.y ?? 0,
+      levelSource: getSceneObjectSourceMetadata(woveSceneObject),
     });
     groundStructureGroup.add(loom.group);
+    registerSceneObjectColliders(loom.colliders, 'wove-kitchen-loom');
     loom.colliders.forEach((collider) => groundColliders.push(collider));
     woveLoom = loom;
   }

--- a/src/scene/level/__tests__/sceneObjects.test.ts
+++ b/src/scene/level/__tests__/sceneObjects.test.ts
@@ -1,0 +1,53 @@
+import { Group } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import {
+  applySceneObjectSourceMetadata,
+  createSceneObjectDefinitionLookup,
+  getSceneObjectSourceMetadata,
+} from '../sceneObjects';
+
+const migratedObjectIds = [
+  'flywheel-studio-showpiece',
+  'jobbot-studio-terminal',
+  'axel-studio-navigator',
+  'wove-kitchen-loom',
+  'pr-reaper-backyard-console',
+];
+
+describe('declarative scene object source data', () => {
+  const ground = PORTFOLIO_LEVEL.floors.find((floor) => floor.id === 'ground');
+  const lookup = createSceneObjectDefinitionLookup(ground?.sceneObjects ?? []);
+
+  it('defines migrated showpieces with unique source IDs and explicit collider policies', () => {
+    const objects = migratedObjectIds.map((id) => lookup.require(id));
+
+    expect(new Set(objects.map((object) => object.sourceId)).size).toBe(
+      objects.length
+    );
+    expect(objects.every((object) => object.colliderPolicy)).toBe(true);
+    expect(objects.map((object) => object.colliderPolicy?.kind)).toEqual([
+      'custom',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+    ]);
+    expect(objects.every((object) => object.purpose?.trim())).toBe(true);
+  });
+
+  it('applies scene object source metadata to generated object userData', () => {
+    const object = lookup.require('flywheel-studio-showpiece');
+    const group = new Group();
+
+    applySceneObjectSourceMetadata(group, getSceneObjectSourceMetadata(object));
+
+    expect(group.userData.levelSourceId).toBe(object.sourceId);
+    expect(group.userData.levelSource).toMatchObject({
+      sourceId: object.sourceId,
+      sourceType: 'sceneObject',
+      purpose: object.purpose,
+    });
+  });
+});

--- a/src/scene/level/__tests__/schema.test.ts
+++ b/src/scene/level/__tests__/schema.test.ts
@@ -86,8 +86,12 @@ const createLevel = (): LevelDefinition => ({
           floorId: 'ground',
           kind: 'threshold',
           position: { x: 5, z: 3 },
-          colliderPolicy: { kind: 'none', reason: 'walkable trim' },
+          colliderPolicy: {
+            kind: 'decorativeNoCollision',
+            reason: 'walkable trim',
+          },
           roomId: 'gallery',
+          purpose: 'Decorative threshold trim with no collision.',
         },
       ],
       roomConnections: [

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -310,6 +310,70 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'fence'
         ),
       ],
+
+      sceneObjects: [
+        {
+          id: 'flywheel-studio-showpiece',
+          sourceId: sourceId('ground.studio.flywheel.showpiece'),
+          floorId: 'ground',
+          kind: 'flywheelShowpiece',
+          position: { x: 10, y: 0, z: -2 },
+          orientation: 0,
+          roomId: 'studio',
+          colliderPolicy: {
+            kind: 'custom',
+            purpose: 'showpiece dais and info panel blockers',
+          },
+          purpose:
+            'Studio Flywheel visible showpiece and information panel collision source.',
+        },
+        {
+          id: 'jobbot-studio-terminal',
+          sourceId: sourceId('ground.studio.jobbot.terminal'),
+          floorId: 'ground',
+          kind: 'jobbotTerminal',
+          position: { x: 14, y: 0, z: 6 },
+          orientation: -Math.PI / 2,
+          roomId: 'studio',
+          colliderPolicy: { kind: 'solid' },
+          purpose:
+            'Studio Jobbot terminal desk remains a visible solid object.',
+        },
+        {
+          id: 'axel-studio-navigator',
+          sourceId: sourceId('ground.studio.axel.navigator'),
+          floorId: 'ground',
+          kind: 'axelNavigator',
+          position: { x: 2, y: 0, z: -3 },
+          orientation: Math.PI,
+          roomId: 'studio',
+          colliderPolicy: { kind: 'solid' },
+          purpose:
+            'Studio Axel navigator table remains a visible solid object.',
+        },
+        {
+          id: 'wove-kitchen-loom',
+          sourceId: sourceId('ground.kitchen.wove.loom'),
+          floorId: 'ground',
+          kind: 'woveLoom',
+          position: { x: -10, y: 0, z: -1.8 },
+          orientation: Math.PI * 0.45,
+          roomId: 'kitchen',
+          colliderPolicy: { kind: 'solid' },
+          purpose: 'Kitchen Wove loom remains a visible solid worktable.',
+        },
+        {
+          id: 'pr-reaper-backyard-console',
+          sourceId: sourceId('ground.backyard.pr_reaper.console'),
+          floorId: 'ground',
+          kind: 'prReaperConsole',
+          position: { x: 0, y: 0, z: 20 },
+          orientation: Math.PI * 0.35,
+          roomId: 'backyard',
+          colliderPolicy: { kind: 'solid' },
+          purpose: 'Backyard PR Reaper console remains a visible solid object.',
+        },
+      ],
       roomConnections: [
         {
           id: 'living-to-kitchen',

--- a/src/scene/level/sceneObjects.ts
+++ b/src/scene/level/sceneObjects.ts
@@ -1,0 +1,77 @@
+import type { Object3D } from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+
+import type { Bounds2D, SceneObjectDefinition } from './schema';
+import type { LevelSourceMetadata, LevelSourceId } from './sourceIds';
+
+export type SceneObjectColliderPolicyKind =
+  | 'solid'
+  | 'decorativeNoCollision'
+  | 'interactionOnly'
+  | 'custom';
+
+export interface SceneObjectLevelSourceMetadata {
+  sourceId: LevelSourceId;
+  sourceType: 'sceneObject';
+  purpose?: string;
+}
+
+export interface SourceBackedSceneObjectOptions {
+  levelSource?: SceneObjectLevelSourceMetadata;
+}
+
+export interface SceneObjectDefinitionLookup {
+  byId: ReadonlyMap<string, SceneObjectDefinition>;
+  require(id: string): SceneObjectDefinition;
+}
+
+export const createSceneObjectDefinitionLookup = (
+  sceneObjects: readonly SceneObjectDefinition[]
+): SceneObjectDefinitionLookup => {
+  const byId = new Map(sceneObjects.map((object) => [object.id, object]));
+
+  return {
+    byId,
+    require(id) {
+      const object = byId.get(id);
+      if (!object) throw new Error(`Missing scene object definition "${id}".`);
+      return object;
+    },
+  };
+};
+
+export const getSceneObjectSourceMetadata = (
+  object: SceneObjectDefinition
+): SceneObjectLevelSourceMetadata => ({
+  sourceId: object.sourceId,
+  sourceType: 'sceneObject',
+  ...(object.purpose ? { purpose: object.purpose } : {}),
+});
+
+export const applySceneObjectSourceMetadata = (
+  object: Object3D,
+  metadata: SceneObjectLevelSourceMetadata
+): void => {
+  object.userData.levelSourceId = metadata.sourceId;
+  object.userData.levelSource = {
+    sourceId: metadata.sourceId,
+    sourceType: metadata.sourceType,
+    ...(metadata.purpose ? { purpose: metadata.purpose } : {}),
+  } satisfies LevelSourceMetadata;
+};
+
+export const registerSceneObjectColliderMetadata = (
+  colliders: readonly RectCollider[],
+  metadata: SceneObjectLevelSourceMetadata,
+  register: (
+    collider: RectCollider,
+    metadata: SceneObjectLevelSourceMetadata
+  ) => void
+): void => {
+  colliders.forEach((collider) => register(collider, metadata));
+};
+
+export const boundsToRectCollider = (bounds: Bounds2D): RectCollider => ({
+  ...bounds,
+});

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -104,6 +104,10 @@ export interface SafetyColliderDefinition {
 }
 
 export type ColliderPolicyDefinition =
+  | { kind: 'solid'; reason?: string }
+  | { kind: 'decorativeNoCollision'; reason: string }
+  | { kind: 'interactionOnly'; reason?: string }
+  | { kind: 'custom'; bounds?: Bounds2D; purpose?: string; reason?: string }
   | { kind: 'none'; reason?: string }
   | { kind: 'footprint' }
   | { kind: 'bounds'; bounds: Bounds2D; purpose?: string };
@@ -117,7 +121,10 @@ export interface SceneObjectDefinition {
   orientation?: number;
   colliderPolicy?: ColliderPolicyDefinition;
   roomId?: string;
+  purpose?: string;
 }
+
+export type LevelSceneObjectDefinition = SceneObjectDefinition;
 
 export interface RoomConnectionDefinition {
   id: string;
@@ -272,10 +279,30 @@ export function validateLevelDefinition(
         errors.push(
           `scene object "${object.id}" references missing room "${object.roomId}".`
         );
+      if (!object.purpose?.trim())
+        errors.push(`scene object "${object.id}" requires a purpose.`);
+      if (
+        object.colliderPolicy?.kind === 'decorativeNoCollision' &&
+        !object.colliderPolicy.reason.trim()
+      ) {
+        errors.push(
+          `scene object "${object.id}" decorativeNoCollision policy requires a reason.`
+        );
+      }
       if (object.colliderPolicy?.kind === 'bounds') {
         validateBounds(
           object.colliderPolicy.bounds,
           `scene object "${object.id}" collider bounds`,
+          errors
+        );
+      }
+      if (
+        object.colliderPolicy?.kind === 'custom' &&
+        object.colliderPolicy.bounds
+      ) {
+        validateBounds(
+          object.colliderPolicy.bounds,
+          `scene object "${object.id}" custom collider bounds`,
           errors
         );
       }

--- a/src/scene/structures/__tests__/axelNavigator.test.ts
+++ b/src/scene/structures/__tests__/axelNavigator.test.ts
@@ -1,6 +1,7 @@
 import { Group, Mesh, MeshBasicMaterial, MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
+import { assertLevelSourceId } from '../../level/sourceIds';
 import { createAxelNavigator, QUEST_MOMENTUM_PRESETS } from '../axelNavigator';
 
 describe('createAxelNavigator', () => {
@@ -101,5 +102,25 @@ describe('createAxelNavigator', () => {
     expect(indicatorMaterial.opacity).toBeGreaterThan(initialOpacity);
     expect(haloMaterial.opacity).toBeGreaterThan(initialHaloOpacity);
     expect(halo.position.y).toBeLessThan(indicator.position.y);
+  });
+
+  it('exposes scene object source metadata on its root group', () => {
+    const build = createAxelNavigator({
+      position: { x: 0, y: 0, z: 0 },
+      levelSource: {
+        sourceId: assertLevelSourceId('ground.studio.axel.navigator'),
+        sourceType: 'sceneObject',
+        purpose: 'test source metadata',
+      },
+    });
+
+    expect(build.group.userData.levelSourceId).toBe(
+      'ground.studio.axel.navigator'
+    );
+    expect(build.group.userData.levelSource).toMatchObject({
+      sourceId: 'ground.studio.axel.navigator',
+      sourceType: 'sceneObject',
+      purpose: 'test source metadata',
+    });
   });
 });

--- a/src/scene/structures/__tests__/woveLoom.test.ts
+++ b/src/scene/structures/__tests__/woveLoom.test.ts
@@ -1,6 +1,7 @@
 import { Mesh, MeshBasicMaterial, MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
+import { assertLevelSourceId } from '../../level/sourceIds';
 import { createWoveLoom } from '../woveLoom';
 
 describe('createWoveLoom', () => {
@@ -74,5 +75,23 @@ describe('createWoveLoom', () => {
     expect(Math.abs(threadWeaveHigh - threadWeaveLow)).toBeGreaterThan(1e-4);
     expect(threadScaleHigh).not.toBe(threadScaleLow);
     expect(glowOpacityHigh).toBeGreaterThan(glowOpacityLow);
+  });
+
+  it('exposes scene object source metadata on its root group', () => {
+    const build = createWoveLoom({
+      position: { x: 0, y: 0, z: 0 },
+      levelSource: {
+        sourceId: assertLevelSourceId('ground.kitchen.wove.loom'),
+        sourceType: 'sceneObject',
+        purpose: 'test source metadata',
+      },
+    });
+
+    expect(build.group.userData.levelSourceId).toBe('ground.kitchen.wove.loom');
+    expect(build.group.userData.levelSource).toMatchObject({
+      sourceId: 'ground.kitchen.wove.loom',
+      sourceType: 'sceneObject',
+      purpose: 'test source metadata',
+    });
   });
 });

--- a/src/scene/structures/axelNavigator.ts
+++ b/src/scene/structures/axelNavigator.ts
@@ -16,6 +16,10 @@ import {
 } from 'three';
 
 import type { RectCollider } from '../collision';
+import {
+  applySceneObjectSourceMetadata,
+  type SourceBackedSceneObjectOptions,
+} from '../level/sceneObjects';
 
 export interface AxelNavigatorBuild {
   group: Group;
@@ -23,7 +27,7 @@ export interface AxelNavigatorBuild {
   update(context: { elapsed: number; delta: number; emphasis: number }): void;
 }
 
-export interface AxelNavigatorOptions {
+export interface AxelNavigatorOptions extends SourceBackedSceneObjectOptions {
   position: { x: number; y?: number; z: number };
   orientationRadians?: number;
 }
@@ -138,6 +142,9 @@ export function createAxelNavigator(
   group.name = 'AxelQuestNavigator';
   group.position.copy(basePosition);
   group.rotation.y = orientationRadians;
+  if (options.levelSource) {
+    applySceneObjectSourceMetadata(group, options.levelSource);
+  }
 
   const colliders: RectCollider[] = [];
 

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -20,6 +20,10 @@ import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import {
+  applySceneObjectSourceMetadata,
+  type SourceBackedSceneObjectOptions,
+} from '../level/sceneObjects';
 
 const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
 
@@ -29,7 +33,8 @@ export interface FlywheelShowpieceBuild {
   update(context: { elapsed: number; delta: number; emphasis: number }): void;
 }
 
-export interface FlywheelShowpieceOptions {
+export interface FlywheelShowpieceOptions
+  extends SourceBackedSceneObjectOptions {
   centerX: number;
   centerZ: number;
   roomBounds: Bounds2D;
@@ -58,6 +63,9 @@ export function createFlywheelShowpiece(
 
   const group = new Group();
   group.name = 'FlywheelShowpiece';
+  if (options.levelSource) {
+    applySceneObjectSourceMetadata(group, options.levelSource);
+  }
 
   const colliders: RectCollider[] = [];
 

--- a/src/scene/structures/jobbotTerminal.ts
+++ b/src/scene/structures/jobbotTerminal.ts
@@ -17,6 +17,10 @@ import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import {
+  applySceneObjectSourceMetadata,
+  type SourceBackedSceneObjectOptions,
+} from '../level/sceneObjects';
 
 const JOBBOT_SCREEN_WIDTH = 2048;
 const JOBBOT_SCREEN_HEIGHT = 1024;
@@ -35,7 +39,7 @@ export interface JobbotTerminalBuild {
   }): void;
 }
 
-export interface JobbotTerminalOptions {
+export interface JobbotTerminalOptions extends SourceBackedSceneObjectOptions {
   position: { x: number; z: number; y?: number };
   orientationRadians?: number;
   desk?: {
@@ -261,6 +265,9 @@ export function createJobbotTerminal(
   group.name = 'JobbotTerminal';
   group.position.set(position.x, baseY, position.z);
   group.rotation.y = orientationRadians;
+  if (options.levelSource) {
+    applySceneObjectSourceMetadata(group, options.levelSource);
+  }
 
   const colliders: RectCollider[] = [];
 

--- a/src/scene/structures/prReaperConsole.ts
+++ b/src/scene/structures/prReaperConsole.ts
@@ -19,6 +19,10 @@ import {
 
 import { getPulseScale } from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
+import {
+  applySceneObjectSourceMetadata,
+  type SourceBackedSceneObjectOptions,
+} from '../level/sceneObjects';
 
 export interface PrReaperConsoleBuild {
   group: Group;
@@ -26,7 +30,7 @@ export interface PrReaperConsoleBuild {
   update(context: { elapsed: number; delta: number; emphasis: number }): void;
 }
 
-export interface PrReaperConsoleOptions {
+export interface PrReaperConsoleOptions extends SourceBackedSceneObjectOptions {
   position: { x: number; y?: number; z: number };
   orientationRadians?: number;
 }
@@ -388,6 +392,9 @@ export function createPrReaperConsole(
   group.name = 'PrReaperConsole';
   group.position.copy(basePosition);
   group.rotation.y = orientationRadians;
+  if (options.levelSource) {
+    applySceneObjectSourceMetadata(group, options.levelSource);
+  }
 
   const right = new Vector3(
     Math.cos(orientationRadians),

--- a/src/scene/structures/woveLoom.ts
+++ b/src/scene/structures/woveLoom.ts
@@ -12,6 +12,10 @@ import {
 } from 'three';
 
 import type { RectCollider } from '../collision';
+import {
+  applySceneObjectSourceMetadata,
+  type SourceBackedSceneObjectOptions,
+} from '../level/sceneObjects';
 
 export interface WoveLoomBuild {
   group: Group;
@@ -19,7 +23,7 @@ export interface WoveLoomBuild {
   update(context: { elapsed: number; delta: number; emphasis: number }): void;
 }
 
-export interface WoveLoomOptions {
+export interface WoveLoomOptions extends SourceBackedSceneObjectOptions {
   position: { x: number; z: number; y?: number };
   orientationRadians?: number;
 }
@@ -91,6 +95,9 @@ export function createWoveLoom(options: WoveLoomOptions): WoveLoomBuild {
   group.name = 'WoveLoom';
   group.position.set(position.x, baseY, position.z);
   group.rotation.y = orientationRadians;
+  if (options.levelSource) {
+    applySceneObjectSourceMetadata(group, options.levelSource);
+  }
 
   const colliders: RectCollider[] = [];
   const emissiveSurfaces: EmissiveSurface[] = [];

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -1,6 +1,7 @@
 import { Group, Mesh, MeshBasicMaterial, MeshStandardMaterial } from 'three';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { assertLevelSourceId } from '../scene/level/sourceIds';
 import { createFlywheelShowpiece } from '../scene/structures/flywheel';
 
 type CapturingContext = CanvasRenderingContext2D & {
@@ -287,5 +288,27 @@ describe('createFlywheelShowpiece', () => {
     );
 
     build.group.dispatchEvent({ type: 'removed' } as Event);
+  });
+
+  it('exposes scene object source metadata on its root group', () => {
+    const build = createFlywheelShowpiece({
+      centerX: 0,
+      centerZ: 0,
+      roomBounds: { minX: -2, maxX: 2, minZ: -2, maxZ: 2 },
+      levelSource: {
+        sourceId: assertLevelSourceId('ground.studio.flywheel.showpiece'),
+        sourceType: 'sceneObject',
+        purpose: 'test source metadata',
+      },
+    });
+
+    expect(build.group.userData.levelSourceId).toBe(
+      'ground.studio.flywheel.showpiece'
+    );
+    expect(build.group.userData.levelSource).toMatchObject({
+      sourceId: 'ground.studio.flywheel.showpiece',
+      sourceType: 'sceneObject',
+      purpose: 'test source metadata',
+    });
   });
 });

--- a/src/tests/jobbotTerminal.test.ts
+++ b/src/tests/jobbotTerminal.test.ts
@@ -10,6 +10,7 @@ import {
   type SpyInstance,
 } from 'vitest';
 
+import { assertLevelSourceId } from '../scene/level/sourceIds';
 import { createJobbotTerminal } from '../scene/structures/jobbotTerminal';
 
 function createMockContext(): CanvasRenderingContext2D {
@@ -229,5 +230,25 @@ describe('JobbotTerminal structure', () => {
 
     expect(shardMaterial.emissiveIntensity).toBeGreaterThan(baselineIntensity);
     expect(Math.abs(shard.position.y - baselineHeight)).toBeGreaterThan(0.001);
+  });
+
+  it('exposes scene object source metadata on its root group', () => {
+    const build = createJobbotTerminal({
+      position: { x: 0, y: 0, z: 0 },
+      levelSource: {
+        sourceId: assertLevelSourceId('ground.studio.jobbot.terminal'),
+        sourceType: 'sceneObject',
+        purpose: 'test source metadata',
+      },
+    });
+
+    expect(build.group.userData.levelSourceId).toBe(
+      'ground.studio.jobbot.terminal'
+    );
+    expect(build.group.userData.levelSource).toMatchObject({
+      sourceId: 'ground.studio.jobbot.terminal',
+      sourceType: 'sceneObject',
+      purpose: 'test source metadata',
+    });
   });
 });

--- a/src/tests/prReaperConsole.test.ts
+++ b/src/tests/prReaperConsole.test.ts
@@ -11,6 +11,7 @@ import {
   type SpyInstance,
 } from 'vitest';
 
+import { assertLevelSourceId } from '../scene/level/sourceIds';
 import { createPrReaperConsole } from '../scene/structures/prReaperConsole';
 
 const gradientStub = { addColorStop: vi.fn() };
@@ -407,5 +408,25 @@ describe('createPrReaperConsole', () => {
       calmTickerCalls
     );
     expect(logGlowMaterial.opacity).toBeGreaterThanOrEqual(calmRefreshGlow);
+  });
+
+  it('exposes scene object source metadata on its root group', () => {
+    const build = createPrReaperConsole({
+      position: { x: 0, y: 0, z: 0 },
+      levelSource: {
+        sourceId: assertLevelSourceId('ground.backyard.pr_reaper.console'),
+        sourceType: 'sceneObject',
+        purpose: 'test source metadata',
+      },
+    });
+
+    expect(build.group.userData.levelSourceId).toBe(
+      'ground.backyard.pr_reaper.console'
+    );
+    expect(build.group.userData.levelSource).toMatchObject({
+      sourceId: 'ground.backyard.pr_reaper.console',
+      sourceType: 'sceneObject',
+      purpose: 'test source metadata',
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Move recurring showpiece collider policies and authoritative source IDs out of ad-hoc code paths and into the declarative level source so POI/showpiece colliders are intentional data. 
- Preserve current visuals and collision bounds while making collider ownership and debug metadata traceable by source ID. 
- Target the recurring pain points (Flywheel, Jobbot, Axel, Wove, PR Reaper) without changing runtime positions/orientations or altering collision behavior.

### Description
- Expand the level schema with explicit `ColliderPolicyDefinition` variants (`solid`, `decorativeNoCollision`, `interactionOnly`, `custom`), add optional `purpose` on scene objects, and provide a `LevelSceneObjectDefinition` alias (file: `src/scene/level/schema.ts`).
- Add a scene object helpers module (`src/scene/level/sceneObjects.ts`) to create lookups, produce `sceneObject` level source metadata, apply that metadata to `Object3D.userData` (`userData.levelSourceId` and `userData.levelSource`), and register collider metadata mappings.
- Migrate a safe subset into the declarative portfolio level: add scene object entries for Flywheel, Jobbot, Axel, Wove, and PR Reaper with stable `sourceId`, explicit `colliderPolicy`, `purpose`, and placement (file: `src/scene/level/portfolioLevel.ts`).
- Propagate source metadata to factories and colliders: factories accept optional `levelSource` via `SourceBackedSceneObjectOptions` and call `applySceneObjectSourceMetadata(...)`; `main.ts` now resolves scene object definitions, passes source metadata into showpiece factories, and registers returned rectangle colliders back to the same source metadata for debug overlays (files: `src/scene/structures/*`, `src/main.ts`).
- Add focused tests validating migrated definitions, unique source IDs, explicit collider policies, and that factories expose source metadata on root groups (file: `src/scene/level/__tests__/sceneObjects.test.ts` and updates to several structure tests). 
- Update the design doc to record that scene object placement and collider policy are declarative source data and that absence of collision must be explicit (file: `docs/design/declarative-level-source-of-truth.md`).

### Testing
- Ran formatter: `npm run format:write` — completed successfully. 
- Ran linter: `npm run lint` — completed successfully (fixes applied where appropriate). 
- Ran focused unit tests for the touched level/showpiece code: `npm run test:ci -- src/scene/level/__tests__/sceneObjects.test.ts src/scene/level/__tests__/schema.test.ts src/tests/mainImports.test.ts` — passed. 
- Ran full unit test suite: `npm run test:ci` — all tests passed (156 files, 1197 tests passed). 
- Docs and links: `npm run docs:check` — docs check passed (link checker reported external fetch warnings but completed). 
- Build and smoke checks: `npm run build` and `npm run smoke` — both passed (dist artifact built and smoke assertions passed). 
- Playwright immersive stairs spec: attempted `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — could not run in this environment because Playwright Chromium browsers are not installed (error: "Please run `npx playwright install`").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336b7b7390832fa97e2209696236d5)