### PR TITLE
Add declarative scene object collider policies and source tagging for migrated showpieces

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -360,3 +360,20 @@ to regenerate the final visual geometry, gameplay collision, and debug metadata;
 legacy patches, removed-ID lists, and manually pushed unowned colliders are gone;
 and inventory tooling can explain every runtime level artifact by semantic source
 ID.
+
+## Scene object placements and collider policies (phase 10)
+
+Scene object declarations now cover the first recurring collider-debug pain
+points: Flywheel, Jobbot, Axel, Wove, and PR Reaper. Each declaration carries a
+stable `sourceId`, runtime `id`, `floorId`, object `kind`, room/purpose metadata,
+and an explicit `colliderPolicy`. The current safe subset uses `custom` policies
+because the structure factories still own their exact collider geometry; `main.ts`
+attaches the source metadata to the generated group and maps each returned
+collider to `sourceType: 'sceneObject'` at registration time.
+
+Visible solid-looking objects should not rely on accidental omission. If an
+object is solid, its source row should say so with `solid`, `bounds`, or `custom`.
+If an object is intentionally passable, use `decorativeNoCollision` with a reason
+or `interactionOnly` for POI/hit-area-only affordances. Future collider cleanup
+should happen by editing the declarative policy first, then updating the factory
+or registration adapter to match.

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,7 @@ import {
   PORTFOLIO_LEVEL,
   UPPER_LANDING_FLOOR_MAIN_ID,
 } from './scene/level/portfolioLevel';
+import type { LevelSceneObjectDefinition } from './scene/level/schema';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -983,8 +984,11 @@ const namedColliderDebugNames = new Map<RectCollider, string>();
 const colliderSourceMetadata = new Map<
   RectCollider,
   {
-    sourceId: WallSegmentInstance['sourceId'] | LevelSafetyCollider['sourceId'];
-    sourceType: 'wall' | 'safetyCollider';
+    sourceId:
+      | WallSegmentInstance['sourceId']
+      | LevelSafetyCollider['sourceId']
+      | LevelSceneObjectDefinition['sourceId'];
+    sourceType: 'wall' | 'safetyCollider' | 'sceneObject';
     purpose?: string;
   }
 >();
@@ -1054,6 +1058,42 @@ function getLevelFloor(floorId: FloorId) {
   );
   if (!floor) throw new Error(`Portfolio level is missing floor "${floorId}".`);
   return floor;
+}
+
+function getLevelSceneObject(
+  id: string
+): LevelSceneObjectDefinition | undefined {
+  for (const floor of PORTFOLIO_LEVEL.floors) {
+    const object = floor.sceneObjects?.find((candidate) => candidate.id === id);
+    if (object) return object;
+  }
+  return undefined;
+}
+
+function tagSceneObjectSource(
+  group: Object3D,
+  object: LevelSceneObjectDefinition
+): void {
+  group.userData.levelSourceId = object.sourceId;
+  group.userData.levelSource = {
+    sourceId: object.sourceId,
+    sourceType: 'sceneObject',
+    purpose: object.purpose ?? object.colliderPolicy?.kind,
+  };
+}
+
+function registerSceneObjectColliders(
+  object: LevelSceneObjectDefinition,
+  colliders: readonly RectCollider[]
+): void {
+  colliders.forEach((collider, index) => {
+    namedColliderDebugNames.set(collider, `${object.id}-collider-${index + 1}`);
+    colliderSourceMetadata.set(collider, {
+      sourceId: object.sourceId,
+      sourceType: 'sceneObject',
+      purpose: object.colliderPolicy?.kind ?? object.purpose,
+    });
+  });
 }
 
 const container = document.getElementById('app');
@@ -2799,6 +2839,11 @@ function initializeImmersiveScene(
   const prReaperPoi = poiInstances.find(
     (poi) => poi.definition.id === 'pr-reaper-backyard-console'
   );
+  const flywheelSceneObject = getLevelSceneObject('flywheel-studio-flywheel');
+  const jobbotSceneObject = getLevelSceneObject('jobbot-studio-terminal');
+  const axelSceneObject = getLevelSceneObject('axel-studio-tracker');
+  const woveSceneObject = getLevelSceneObject('wove-kitchen-loom');
+  const prReaperSceneObject = getLevelSceneObject('pr-reaper-backyard-console');
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
   const kitchenRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'kitchen');
   const kitchenBounds = kitchenRoom?.bounds;
@@ -2816,6 +2861,10 @@ function initializeImmersiveScene(
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
       detailPolicy: activeSceneDetailPolicy,
     });
+    if (flywheelSceneObject) {
+      tagSceneObjectSource(showpiece.group, flywheelSceneObject);
+      registerSceneObjectColliders(flywheelSceneObject, showpiece.colliders);
+    }
     groundStructureGroup.add(showpiece.group);
     showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     flywheelShowpiece = showpiece;
@@ -2836,6 +2885,10 @@ function initializeImmersiveScene(
       orientationRadians: terminalOrientation,
       detailPolicy: activeSceneDetailPolicy,
     });
+    if (jobbotSceneObject) {
+      tagSceneObjectSource(terminal.group, jobbotSceneObject);
+      registerSceneObjectColliders(jobbotSceneObject, terminal.colliders);
+    }
     groundStructureGroup.add(terminal.group);
     terminal.colliders.forEach((collider) => groundColliders.push(collider));
     jobbotTerminal = terminal;
@@ -2849,6 +2902,10 @@ function initializeImmersiveScene(
         },
         orientationRadians: axelPoi.group.rotation.y ?? 0,
       });
+      if (axelSceneObject) {
+        tagSceneObjectSource(navigator.group, axelSceneObject);
+        registerSceneObjectColliders(axelSceneObject, navigator.colliders);
+      }
       groundStructureGroup.add(navigator.group);
       navigator.colliders.forEach((collider) => groundColliders.push(collider));
       axelNavigator = navigator;
@@ -2892,6 +2949,10 @@ function initializeImmersiveScene(
       },
       orientationRadians: prReaperPoi.group.rotation.y ?? 0,
     });
+    if (prReaperSceneObject) {
+      tagSceneObjectSource(console.group, prReaperSceneObject);
+      registerSceneObjectColliders(prReaperSceneObject, console.colliders);
+    }
     groundStructureGroup.add(console.group);
     console.colliders.forEach((collider) => groundColliders.push(collider));
     prReaperConsole = console;
@@ -2992,6 +3053,10 @@ function initializeImmersiveScene(
       },
       orientationRadians: wovePoi.group.rotation.y ?? 0,
     });
+    if (woveSceneObject) {
+      tagSceneObjectSource(loom.group, woveSceneObject);
+      registerSceneObjectColliders(woveSceneObject, loom.colliders);
+    }
     groundStructureGroup.add(loom.group);
     loom.colliders.forEach((collider) => groundColliders.push(collider));
     woveLoom = loom;

--- a/src/scene/level/__tests__/portfolioLevel.test.ts
+++ b/src/scene/level/__tests__/portfolioLevel.test.ts
@@ -58,6 +58,30 @@ describe('PORTFOLIO_LEVEL', () => {
     );
   });
 
+  it('declares collider policies for migrated visible scene objects', () => {
+    const objects = PORTFOLIO_LEVEL.floors.flatMap(
+      (floor) => floor.sceneObjects ?? []
+    );
+    const migratedIds = [
+      'flywheel-studio-flywheel',
+      'jobbot-studio-terminal',
+      'axel-studio-tracker',
+      'wove-kitchen-loom',
+      'pr-reaper-backyard-console',
+    ];
+
+    expect(objects.map((object) => object.id)).toEqual(
+      expect.arrayContaining(migratedIds)
+    );
+
+    for (const id of migratedIds) {
+      const object = objects.find((candidate) => candidate.id === id);
+      expect(object?.sourceId).toMatch(/\.scene_object$/);
+      expect(object?.colliderPolicy?.kind).toBe('custom');
+      expect(object?.purpose).toEqual(expect.stringMatching(/\S/));
+    }
+  });
+
   it('compiles compatibility room bounds and doorways for the current floors', () => {
     expect(
       compileLegacyFloorPlan(PORTFOLIO_LEVEL, 'ground', {

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -121,6 +121,74 @@ const floorSurfaceForRoom = (
   };
 };
 
+const sceneObject = (
+  id: string,
+  source: string,
+  kind: string,
+  roomId: string,
+  position: { x: number; z: number },
+  orientation: number,
+  purpose: string
+): FloorDefinition['sceneObjects'][number] => ({
+  id,
+  sourceId: sourceId(source),
+  floorId: 'ground',
+  kind,
+  position,
+  orientation,
+  roomId,
+  colliderPolicy: { kind: 'custom', purpose, colliderCount: 1 },
+  purpose,
+});
+
+const SCENE_OBJECTS: NonNullable<FloorDefinition['sceneObjects']> = [
+  sceneObject(
+    'flywheel-studio-flywheel',
+    'ground.studio.flywheel.scene_object',
+    'flywheelShowpiece',
+    'studio',
+    { x: 11, z: -4 },
+    0,
+    'Kinetic Flywheel exhibit with custom dais and info-panel colliders.'
+  ),
+  sceneObject(
+    'jobbot-studio-terminal',
+    'ground.studio.jobbot_terminal.scene_object',
+    'jobbotTerminal',
+    'studio',
+    { x: 24, z: 4 },
+    -Math.PI / 2,
+    'Jobbot terminal desk keeps its factory-owned solid footprint.'
+  ),
+  sceneObject(
+    'axel-studio-tracker',
+    'ground.studio.axel_navigator.scene_object',
+    'axelNavigator',
+    'studio',
+    { x: 20, z: -4 },
+    Math.PI,
+    'Axel navigator tabletop uses custom table and console colliders.'
+  ),
+  sceneObject(
+    'wove-kitchen-loom',
+    'ground.kitchen.wove_loom.scene_object',
+    'woveLoom',
+    'kitchen',
+    { x: -15, z: 5 },
+    Math.PI * 0.45,
+    'Wove loom table and shuttle zone remain solid via custom colliders.'
+  ),
+  sceneObject(
+    'pr-reaper-backyard-console',
+    'ground.backyard.pr_reaper_console.scene_object',
+    'prReaperConsole',
+    'backyard',
+    { x: 12, z: 26 },
+    Math.PI * 0.55,
+    'PR Reaper triage console preserves deck and intake collision policy.'
+  ),
+];
+
 type FloorDefinitionInput = Omit<FloorDefinition, 'floorSurfaces'>;
 
 const buildFloor = (floor: FloorDefinitionInput): FloorDefinition => ({
@@ -310,6 +378,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'fence'
         ),
       ],
+      sceneObjects: SCENE_OBJECTS,
       roomConnections: [
         {
           id: 'living-to-kitchen',

--- a/src/scene/level/schema.ts
+++ b/src/scene/level/schema.ts
@@ -25,7 +25,7 @@ export interface FloorDefinition {
   walls: WallDefinition[];
   floorSurfaces: FloorSurfaceDefinition[];
   safetyColliders?: SafetyColliderDefinition[];
-  sceneObjects?: SceneObjectDefinition[];
+  sceneObjects?: LevelSceneObjectDefinition[];
   roomConnections?: RoomConnectionDefinition[];
 }
 
@@ -103,21 +103,26 @@ export interface SafetyColliderDefinition {
   purpose: string;
 }
 
-export type ColliderPolicyDefinition =
-  | { kind: 'none'; reason?: string }
-  | { kind: 'footprint' }
+export type SceneObjectColliderPolicy =
+  | { kind: 'solid'; purpose?: string }
+  | { kind: 'decorativeNoCollision'; reason: string }
+  | { kind: 'interactionOnly'; reason?: string }
+  | { kind: 'custom'; purpose?: string; colliderCount?: number }
   | { kind: 'bounds'; bounds: Bounds2D; purpose?: string };
 
-export interface SceneObjectDefinition {
+export interface LevelSceneObjectDefinition {
   id: string;
   sourceId: LevelSourceId;
   floorId: string;
   kind: string;
   position: Point2D & { y?: number };
   orientation?: number;
-  colliderPolicy?: ColliderPolicyDefinition;
+  colliderPolicy?: SceneObjectColliderPolicy;
   roomId?: string;
+  purpose?: string;
 }
+
+export type SceneObjectDefinition = LevelSceneObjectDefinition;
 
 export interface RoomConnectionDefinition {
   id: string;
@@ -272,6 +277,19 @@ export function validateLevelDefinition(
         errors.push(
           `scene object "${object.id}" references missing room "${object.roomId}".`
         );
+      if (!object.purpose?.trim() && !object.colliderPolicy) {
+        errors.push(
+          `scene object "${object.id}" requires a purpose or collider policy.`
+        );
+      }
+      if (
+        object.colliderPolicy?.kind === 'decorativeNoCollision' &&
+        !object.colliderPolicy.reason.trim()
+      ) {
+        errors.push(
+          `scene object "${object.id}" decorativeNoCollision policy requires a reason.`
+        );
+      }
       if (object.colliderPolicy?.kind === 'bounds') {
         validateBounds(
           object.colliderPolicy.bounds,


### PR DESCRIPTION
### Motivation
- Move recurring scene-object collision intent out of scattered runtime code and into the declarative level source so POI/showpiece colliders are intentional data.
- Ensure visible scene objects carry stable `sourceId` metadata so debug tooling and inventory can trace colliders/solids back to a semantic source.
- Preserve existing visuals and collision geometry while making it explicit when an object is decorative, interactive-only, or solid.

### Description
- Expanded the level schema with `LevelSceneObjectDefinition` and `SceneObjectColliderPolicy` variants (`solid`, `decorativeNoCollision`, `interactionOnly`, `custom`, `bounds`) and validation rules requiring either a `purpose` or an explicit collider policy. (`src/scene/level/schema.ts`)
- Added a safe migrated subset of scene objects to the portfolio level for recurring pain points: Flywheel, Jobbot terminal, Axel navigator, Wove loom, and PR Reaper console, including stable `sourceId`, placement, `orientation`, `purpose`, and `custom` collider policies. (`src/scene/level/portfolioLevel.ts`)
- Wired runtime tagging and registration: added `getLevelSceneObject`, `tagSceneObjectSource`, and `registerSceneObjectColliders` helpers and invoked them when creating migrated showpieces so `group.userData.levelSourceId` / `group.userData.levelSource` are set and returned colliders are registered with `sourceType: 'sceneObject'`. This preserves collider bounds while exposing source metadata to debug visualizers. (`src/main.ts`)
- Added a focused test asserting migrated scene objects exist with `.scene_object` source IDs, explicit `colliderPolicy: 'custom'`, and non-empty `purpose`. (`src/scene/level/__tests__/portfolioLevel.test.ts`)
- Documented the change in the declarative-level design doc to state collider policy and scene object placement are source data and that absence of a collider must be explicit. (`docs/design/declarative-level-source-of-truth.md`)

### Testing
- Ran formatting and linting: `npm run format:write` and `npm run lint` — passed.
- Unit test suite: `npm run test:ci` (Vitest) — all tests passed (full suite run showed 1191 tests passing).
- Focused Vitest runs for touched tests: portfolio and showpiece/structure tests — passed (`npx vitest run ...` for selected files succeeded).
- Docs check: `npm run docs:check` — passed (link checker reported external fetch warnings but exited successfully).
- Build and smoke: `npm run build` and `npm run smoke` — passed and produced expected artifacts.
- Playwright: initial `npx playwright test` required browser install; installed browsers and host deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — all Playwright scenarios passed after installing browsers/deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336b6e7650832fad2a3c93a0be8580)