### PR TITLE
🧪 : – guard scene object collider metadata

### DIFF
--- a/src/scene/level/sceneObjects.test.ts
+++ b/src/scene/level/sceneObjects.test.ts
@@ -1,7 +1,12 @@
 import { Group, Mesh } from 'three';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import type { RectCollider } from '../../systems/collision';
+import { createAxelNavigator } from '../structures/axelNavigator';
+import { createFlywheelShowpiece } from '../structures/flywheel';
+import { createJobbotTerminal } from '../structures/jobbotTerminal';
+import { createPrReaperConsole } from '../structures/prReaperConsole';
+import { createWoveLoom } from '../structures/woveLoom';
 
 import { PORTFOLIO_LEVEL } from './portfolioLevel';
 import {
@@ -9,6 +14,44 @@ import {
   createSceneObjectDefinitionsById,
   registerSceneObjectColliders,
 } from './sceneObjects';
+
+beforeAll(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value(this: HTMLCanvasElement, type: string) {
+      if (type !== '2d') return null;
+      const gradient = { addColorStop: vi.fn() };
+      return {
+        save: vi.fn(),
+        restore: vi.fn(),
+        clearRect: vi.fn(),
+        beginPath: vi.fn(),
+        closePath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        quadraticCurveTo: vi.fn(),
+        fillRect: vi.fn(),
+        fill: vi.fn(),
+        stroke: vi.fn(),
+        strokeRect: vi.fn(),
+        scale: vi.fn(),
+        createLinearGradient: vi.fn(() => gradient),
+        fillText: vi.fn(),
+        measureText: vi.fn(() => ({ width: 100 })),
+        fillStyle: '',
+        strokeStyle: '',
+        lineWidth: 0,
+        textAlign: 'left',
+        textBaseline: 'alphabetic',
+        font: '',
+        globalAlpha: 1,
+        shadowBlur: 0,
+        shadowColor: '',
+        canvas: this,
+      } as Partial<CanvasRenderingContext2D>;
+    },
+  });
+});
 
 describe('scene object metadata helpers', () => {
   it('applies scene object source metadata to the root group and descendants', () => {
@@ -62,6 +105,71 @@ describe('scene object metadata helpers', () => {
         sourceType: 'sceneObject',
         purpose: 'factory-colliders',
       });
+    }
+  });
+
+  it('keeps migrated showpiece factory collider counts source-backed', () => {
+    const definitions = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
+    const builds = [
+      {
+        id: 'flywheel-studio-flywheel',
+        build: createFlywheelShowpiece({
+          centerX: 5.5,
+          centerZ: -2,
+          roomBounds: { minX: -2, maxX: 16, minZ: -4, maxZ: 8 },
+        }),
+      },
+      {
+        id: 'jobbot-studio-terminal',
+        build: createJobbotTerminal({
+          position: { x: 12, y: 0, z: 2 },
+          orientationRadians: -Math.PI / 2,
+        }),
+      },
+      {
+        id: 'axel-studio-tracker',
+        build: createAxelNavigator({
+          position: { x: 10, y: 0, z: -2 },
+          orientationRadians: Math.PI,
+        }),
+      },
+      {
+        id: 'wove-kitchen-loom',
+        build: createWoveLoom({
+          position: { x: -7.5, y: 0, z: 2.5 },
+          orientationRadians: Math.PI * 0.45,
+        }),
+      },
+      {
+        id: 'pr-reaper-backyard-console',
+        build: createPrReaperConsole({
+          position: { x: 0, y: 0, z: 10 },
+          orientationRadians: Math.PI * 0.35,
+        }),
+      },
+    ];
+
+    for (const { id, build } of builds) {
+      const definition = definitions.get(id);
+      expect(definition).toBeDefined();
+      expect(build.colliders.length).toBeGreaterThan(0);
+
+      const registered: RectCollider[] = [];
+      const metadata = new Map();
+      registerSceneObjectColliders(
+        build.colliders,
+        definition!,
+        registered,
+        metadata
+      );
+
+      expect(registered).toHaveLength(build.colliders.length);
+      for (const collider of build.colliders) {
+        expect(metadata.get(collider)).toMatchObject({
+          sourceId: definition!.sourceId,
+          sourceType: 'sceneObject',
+        });
+      }
     }
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure migrated POI/showpiece scene object colliders remain source-backed and expose stable source metadata as object placements and collider policies move into the declarative level layer. 
- Exercise factories that generate canvas textures in unit tests so we can assert factory-owned colliders are preserved without requiring native canvas bindings. 

### Description
- Added a focused jsdom `HTMLCanvasElement.getContext` mock to `src/scene/level/sceneObjects.test.ts` so texture-producing showpiece factories can run in tests. 
- Imported and invoked the migrated showpiece factories (`Flywheel`, `Jobbot`, `Axel`, `Wove`, `PR Reaper`) in the test and asserted each factory returns colliders. 
- Registered factory-returned colliders with `registerSceneObjectColliders(...)` and asserted collider metadata carries `sourceId`/`sourceType` provenance without changing runtime placement/collider bounds. 

### Testing
- Ran `npm run format:write` which completed successfully. 
- Ran `npm run lint` which completed successfully (minor import-order warning fixed during edits). 
- Ran focused tests via `npx vitest run src/scene/level/sceneObjects.test.ts src/scene/level/__tests__/portfolioLevel.test.ts src/scene/structures/__tests__/axelNavigator.test.ts src/scene/structures/__tests__/woveLoom.test.ts` and they passed. 
- Ran full unit suite via `npm run test:ci` and it passed (1197 tests). 
- Ran `npm run docs:check` which passed (external link fetch warnings due to network environment). 
- Ran `npm run smoke` (which executes `npm run build` + assertions) and it passed. 
- Executed Playwright checks: initial `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` failed due to missing browser artifacts in the test environment, then `npx playwright install chromium` and `npx playwright install-deps chromium` were run and the Playwright spec subsequently passed (9 tests). 
- Ran production build via `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a337b29c938832f81a2c7d144c35082)