### PR TITLE
Guard scene object collider policy migration

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -151,7 +151,11 @@ The first migrated subset covers the Flywheel showpiece/info panel, Axel
 navigator, Jobbot terminal, PR Reaper console, and Wove loom. Scene-object
 positions are authored in level-space coordinates and validated against their
 declared room bounds; POI placement adapters scale them to the runtime world
-coordinates used by the current immersive scene. These objects continue to use
+coordinates used by the current immersive scene. Scene object placement and
+collider policy are declarative source data rather than shadow runtime constants.
+Objects that intentionally have no collider must
+be explicitly marked with a no-collider policy and authored reason instead of
+silently disappearing from collider generation. These objects continue to use
 their existing structure-factory collider bounds, but the source object owns the
 stable source ID, room/floor placement, purpose, and `custom`
 `factory-colliders` policy that debug collider and solid metadata can expose.

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
 import {
@@ -11,10 +11,12 @@ import { createJobbotTerminal } from '../scene/structures/jobbotTerminal';
 import { createPrReaperConsole } from '../scene/structures/prReaperConsole';
 import { createWoveLoom } from '../scene/structures/woveLoom';
 
-const createCanvasContext = (): CanvasRenderingContext2D => {
+const createCanvasContext = (
+  canvas: HTMLCanvasElement
+): CanvasRenderingContext2D => {
   const gradient = { addColorStop: vi.fn() };
   return {
-    canvas: document.createElement('canvas'),
+    canvas,
     fillStyle: '',
     strokeStyle: '',
     font: '',
@@ -42,10 +44,22 @@ const createCanvasContext = (): CanvasRenderingContext2D => {
   } as unknown as CanvasRenderingContext2D;
 };
 
+let getContextSpy: ReturnType<typeof vi.spyOn>;
+
 beforeAll(() => {
-  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() =>
-    createCanvasContext()
-  );
+  getContextSpy = vi
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockImplementation(function (this: HTMLCanvasElement, contextId: string) {
+      if (contextId !== '2d') {
+        return null;
+      }
+
+      return createCanvasContext(this);
+    });
+});
+
+afterAll(() => {
+  getContextSpy.mockRestore();
 });
 
 const definitionsById = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
@@ -103,18 +117,19 @@ describe('migrated scene object collider policies', () => {
   it('keeps each migrated visible showpiece on a custom factory-collider policy', () => {
     for (const { id } of migratedFactories) {
       const definition = definitionsById.get(id);
-      expect(definition?.colliderPolicy).toEqual({
+      expect(definition, id).toBeDefined();
+      expect(definition!.colliderPolicy).toEqual({
         kind: 'custom',
         purpose: 'factory-colliders',
       });
-      expect(definition?.sourceId).toMatch(/\.scene_object$/);
+      expect(definition!.sourceId).toMatch(/\.scene_object$/);
     }
   });
 
   it('registers every existing factory collider with scene object source metadata', () => {
     for (const { id, expectedColliderCount, build } of migratedFactories) {
       const definition = definitionsById.get(id);
-      expect(definition).toBeDefined();
+      expect(definition, id).toBeDefined();
       const factoryColliders = build().colliders;
       const registered = [];
       const metadata = new Map();

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,0 +1,140 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
+import {
+  createSceneObjectDefinitionsById,
+  registerSceneObjectColliders,
+} from '../scene/level/sceneObjects';
+import { createAxelNavigator } from '../scene/structures/axelNavigator';
+import { createFlywheelShowpiece } from '../scene/structures/flywheel';
+import { createJobbotTerminal } from '../scene/structures/jobbotTerminal';
+import { createPrReaperConsole } from '../scene/structures/prReaperConsole';
+import { createWoveLoom } from '../scene/structures/woveLoom';
+
+const createCanvasContext = (): CanvasRenderingContext2D => {
+  const gradient = { addColorStop: vi.fn() };
+  return {
+    canvas: document.createElement('canvas'),
+    fillStyle: '',
+    strokeStyle: '',
+    font: '',
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
+    lineWidth: 0,
+    globalAlpha: 1,
+    shadowBlur: 0,
+    shadowColor: '',
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn(() => ({ width: 0 })),
+    createLinearGradient: vi.fn(() => gradient),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+};
+
+beforeAll(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() =>
+    createCanvasContext()
+  );
+});
+
+const definitionsById = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
+
+const migratedFactories = [
+  {
+    id: 'flywheel-studio-flywheel',
+    expectedColliderCount: 2,
+    build: () =>
+      createFlywheelShowpiece({
+        centerX: 5.5,
+        centerZ: -2,
+        roomBounds: { minX: 0, maxX: 16, minZ: -16, maxZ: 16 },
+      }),
+  },
+  {
+    id: 'jobbot-studio-terminal',
+    expectedColliderCount: 1,
+    build: () =>
+      createJobbotTerminal({
+        position: { x: 12, y: 0, z: 2 },
+        orientationRadians: -Math.PI / 2,
+      }),
+  },
+  {
+    id: 'axel-studio-tracker',
+    expectedColliderCount: 2,
+    build: () =>
+      createAxelNavigator({
+        position: { x: 10, y: 0, z: -2 },
+        orientationRadians: Math.PI,
+      }),
+  },
+  {
+    id: 'wove-kitchen-loom',
+    expectedColliderCount: 2,
+    build: () =>
+      createWoveLoom({
+        position: { x: -7.5, y: 0, z: 2.5 },
+        orientationRadians: Math.PI * 0.45,
+      }),
+  },
+  {
+    id: 'pr-reaper-backyard-console',
+    expectedColliderCount: 2,
+    build: () =>
+      createPrReaperConsole({
+        position: { x: 0, y: 0, z: 10 },
+        orientationRadians: Math.PI * 0.35,
+      }),
+  },
+] as const;
+
+describe('migrated scene object collider policies', () => {
+  it('keeps each migrated visible showpiece on a custom factory-collider policy', () => {
+    for (const { id } of migratedFactories) {
+      const definition = definitionsById.get(id);
+      expect(definition?.colliderPolicy).toEqual({
+        kind: 'custom',
+        purpose: 'factory-colliders',
+      });
+      expect(definition?.sourceId).toMatch(/\.scene_object$/);
+    }
+  });
+
+  it('registers every existing factory collider with scene object source metadata', () => {
+    for (const { id, expectedColliderCount, build } of migratedFactories) {
+      const definition = definitionsById.get(id);
+      expect(definition).toBeDefined();
+      const factoryColliders = build().colliders;
+      const registered = [];
+      const metadata = new Map();
+
+      registerSceneObjectColliders(
+        factoryColliders,
+        definition!,
+        registered,
+        metadata
+      );
+
+      expect(factoryColliders, id).toHaveLength(expectedColliderCount);
+      expect(registered, id).toHaveLength(expectedColliderCount);
+      for (const collider of factoryColliders) {
+        expect(metadata.get(collider), id).toEqual({
+          sourceId: definition!.sourceId,
+          sourceType: 'sceneObject',
+          purpose: 'factory-colliders',
+        });
+      }
+    }
+  });
+});

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
@@ -64,51 +66,62 @@ afterAll(() => {
 
 const definitionsById = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
 
+type MigratedFactoryPlacement = {
+  position: { x: number; z: number };
+  orientation: number;
+};
+
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
     expectedColliderCount: 2,
-    build: () =>
+    placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
+    build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
-        centerX: 5.5,
-        centerZ: -2,
+        centerX: position.x,
+        centerZ: position.z,
+        orientationRadians: orientation,
         roomBounds: { minX: 0, maxX: 16, minZ: -16, maxZ: 16 },
       }),
   },
   {
     id: 'jobbot-studio-terminal',
     expectedColliderCount: 1,
-    build: () =>
+    placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
+    build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
-        position: { x: 12, y: 0, z: 2 },
-        orientationRadians: -Math.PI / 2,
+        position: { x: position.x, y: 0, z: position.z },
+        orientationRadians: orientation,
       }),
   },
   {
     id: 'axel-studio-tracker',
     expectedColliderCount: 2,
-    build: () =>
+    placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
+    build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
-        position: { x: 10, y: 0, z: -2 },
-        orientationRadians: Math.PI,
+        position: { x: position.x, y: 0, z: position.z },
+        orientationRadians: orientation,
       }),
   },
   {
     id: 'wove-kitchen-loom',
     expectedColliderCount: 2,
-    build: () =>
+    placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
+    build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
-        position: { x: -7.5, y: 0, z: 2.5 },
-        orientationRadians: Math.PI * 0.45,
+        position: { x: position.x, y: 0, z: position.z },
+        orientationRadians: orientation,
       }),
   },
   {
     id: 'pr-reaper-backyard-console',
     expectedColliderCount: 2,
-    build: () =>
+    placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
+    build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
-        position: { x: 0, y: 0, z: 10 },
-        orientationRadians: Math.PI * 0.35,
+        position: { x: position.x, y: 0, z: position.z },
+        orientationRadians: orientation,
       }),
   },
 ] as const;
@@ -126,11 +139,25 @@ describe('migrated scene object collider policies', () => {
     }
   });
 
-  it('registers every existing factory collider with scene object source metadata', () => {
-    for (const { id, expectedColliderCount, build } of migratedFactories) {
+  it('keeps factory args aligned with declarative placement data', () => {
+    for (const { id, placement } of migratedFactories) {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
-      const factoryColliders = build().colliders;
+      expect(definition!.position, id).toEqual(placement.position);
+      expect(definition!.orientation, id).toBe(placement.orientation);
+    }
+  });
+
+  it('registers every existing factory collider with scene object source metadata', () => {
+    for (const {
+      id,
+      expectedColliderCount,
+      build,
+      placement,
+    } of migratedFactories) {
+      const definition = definitionsById.get(id);
+      expect(definition, id).toBeDefined();
+      const factoryColliders = build(placement).colliders;
       const registered = [];
       const metadata = new Map();
 
@@ -151,5 +178,25 @@ describe('migrated scene object collider policies', () => {
         });
       }
     }
+  });
+
+  it('does not duplicate migrated placements as manual main-scene factory args', () => {
+    const mainSource = readFileSync('src/main.ts', 'utf8');
+
+    expect(mainSource).not.toMatch(
+      /createJobbotTerminal\(\{[\s\S]{0,500}x: 12,[\s\S]{0,200}z: 2/
+    );
+    expect(mainSource).not.toMatch(
+      /createAxelNavigator\(\{[\s\S]{0,500}x: 10,[\s\S]{0,200}z: -2/
+    );
+    expect(mainSource).not.toMatch(
+      /createWoveLoom\(\{[\s\S]{0,500}x: -7\.5,[\s\S]{0,200}z: 2\.5/
+    );
+    expect(mainSource).not.toMatch(
+      /createPrReaperConsole\(\{[\s\S]{0,500}x: 0,[\s\S]{0,200}z: 10/
+    );
+    expect(mainSource).not.toMatch(
+      /createFlywheelShowpiece\(\{[\s\S]{0,300}centerX: 5\.5/
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure migrated declarative scene objects (Flywheel, Jobbot, Axel, Wove, PR Reaper) explicitly own their collider policies and stable source IDs so visible showpieces do not accidentally become pass-through. 

### Description
- Add a focused Vitest regression suite at `src/tests/sceneObjectColliderPolicies.test.ts` that verifies each migrated scene object uses a `colliderPolicy: { kind: 'custom', purpose: 'factory-colliders' }` and a `.scene_object` `sourceId`.
- Assert each factory (`createFlywheelShowpiece`, `createJobbotTerminal`, `createAxelNavigator`, `createWoveLoom`, `createPrReaperConsole`) still returns the expected collider count and that `registerSceneObjectColliders` attaches scene-object source metadata (`sourceId`, `sourceType: 'sceneObject'`, `purpose`).
- Tests mock `HTMLCanvasElement.getContext` to avoid DOM canvas plumbing during texture generation and do not change any runtime factories or visual/collision behavior.

### Testing
- Ran `npm run format:write` — passed.
- Ran `npm run lint` — passed.
- Ran focused tests: `npm run test:ci -- src/tests/sceneObjectColliderPolicies.test.ts src/tests/flywheelShowpiece.test.ts src/tests/jobbotTerminal.test.ts src/scene/structures/__tests__/axelNavigator.test.ts src/scene/structures/__tests__/woveLoom.test.ts src/tests/prReaperConsole.test.ts` — passed.
- Ran full suite: `npm run test:ci` — passed (all tests green).
- Docs and build checks: `npm run docs:check` — passed (link checker reported external fetch warnings), `npm run build` — passed, `npm run smoke` — passed.
- Playwright: initial `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` failed due to missing browser; after `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell`, the spec run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a337b391f20832f95773058256c220c)