### PR TITLE
🧭 : – cover declarative PR Reaper POI placement

### DIFF
--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -54,6 +54,13 @@ describe('applyManualPoiPlacements', () => {
         z: 5,
         headingRadians: Math.PI * 0.45,
       },
+      {
+        id: 'pr-reaper-backyard-console',
+        roomId: 'backyard',
+        x: 0,
+        z: 20,
+        headingRadians: Math.PI * 0.35,
+      },
     ];
     const placed = applyManualPoiPlacements(
       expected.map(({ id }) => definition(id))


### PR DESCRIPTION
### Motivation
- Ensure the migrated declarative scene-object placement subset includes the PR Reaper POI so placement resolution and collider-source coverage remain complete for recurring showpiece pain points.

### Description
- Add the PR Reaper expected placement to the migrated POI placement test in `src/scene/poi/placements.test.ts` so `PORTFOLIO_LEVEL`-backed scene objects now include Flywheel, Jobbot, Axel, Wove, and PR Reaper in the asserted set.

### Testing
- Ran formatting, lint, focused and full test suites, docs checks, and builds: `npm run format:write` (passed), `npm run lint` (passed), `npm run test:ci -- src/scene/poi/placements.test.ts src/scene/level/portfolioLevel.test.ts src/scene/level/sceneObjects.test.ts` (passed), `npm run test:ci` (full suite passed), `npm run docs:check` (passed with external-link fetch warnings), `npm run smoke` / `npm run build` (passed); `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` was not executed successfully because Playwright browser binaries are missing in the environment (please run `npx playwright install` in CI where browsers are available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a337b3ec418832f82d6d5e9f1f9ad06)