### PR TITLE
🧭 Verify scene object collider provenance

### DIFF
--- a/src/scene/level/sceneObjects.test.ts
+++ b/src/scene/level/sceneObjects.test.ts
@@ -1,7 +1,12 @@
 import { Group, Mesh } from 'three';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import type { RectCollider } from '../../systems/collision';
+import { createAxelNavigator } from '../structures/axelNavigator';
+import { createFlywheelShowpiece } from '../structures/flywheel';
+import { createJobbotTerminal } from '../structures/jobbotTerminal';
+import { createPrReaperConsole } from '../structures/prReaperConsole';
+import { createWoveLoom } from '../structures/woveLoom';
 
 import { PORTFOLIO_LEVEL } from './portfolioLevel';
 import {
@@ -9,6 +14,46 @@ import {
   createSceneObjectDefinitionsById,
   registerSceneObjectColliders,
 } from './sceneObjects';
+
+const createCanvasContext = (canvas: HTMLCanvasElement) => {
+  const gradient = { addColorStop: vi.fn() };
+  const context = {
+    save: vi.fn(),
+    restore: vi.fn(),
+    scale: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    createLinearGradient: vi.fn(() => gradient),
+    fillText: vi.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
+    font: '',
+    globalAlpha: 1,
+    shadowBlur: 0,
+    shadowColor: '',
+  } as Partial<CanvasRenderingContext2D>;
+  Object.defineProperty(context, 'canvas', { value: canvas });
+  return context as CanvasRenderingContext2D;
+};
+
+beforeAll(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+    function (this: HTMLCanvasElement, type: string) {
+      return type === '2d' ? createCanvasContext(this) : null;
+    }
+  );
+});
 
 describe('scene object metadata helpers', () => {
   it('applies scene object source metadata to the root group and descendants', () => {
@@ -62,6 +107,66 @@ describe('scene object metadata helpers', () => {
         sourceType: 'sceneObject',
         purpose: 'factory-colliders',
       });
+    }
+  });
+
+  it('keeps migrated showpiece factory colliders source-backed without count changes', () => {
+    const definitions = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
+    const showpieces = [
+      {
+        id: 'flywheel-studio-flywheel',
+        build: createFlywheelShowpiece({
+          centerX: 5.5,
+          centerZ: -2,
+          roomBounds: { minX: 3, maxX: 14, minZ: -6, maxZ: 4 },
+        }),
+        colliderCount: 2,
+      },
+      {
+        id: 'jobbot-studio-terminal',
+        build: createJobbotTerminal({ position: { x: 12, z: 2 } }),
+        colliderCount: 1,
+      },
+      {
+        id: 'axel-studio-tracker',
+        build: createAxelNavigator({ position: { x: 10, z: -2 } }),
+        colliderCount: 2,
+      },
+      {
+        id: 'wove-kitchen-loom',
+        build: createWoveLoom({ position: { x: -7.5, z: 2.5 } }),
+        colliderCount: 2,
+      },
+      {
+        id: 'pr-reaper-backyard-console',
+        build: createPrReaperConsole({ position: { x: 0, z: 10 } }),
+        colliderCount: 2,
+      },
+    ] as const;
+
+    for (const { id, build, colliderCount } of showpieces) {
+      const definition = definitions.get(id);
+      expect(definition).toBeDefined();
+      expect(build.colliders).toHaveLength(colliderCount);
+
+      const registered: RectCollider[] = [];
+      const metadata = new Map<RectCollider, unknown>();
+
+      registerSceneObjectColliders(
+        build.colliders,
+        definition!,
+        registered,
+        metadata
+      );
+
+      expect(registered).toEqual(build.colliders);
+      expect([...metadata.values()]).toEqual(
+        Array.from({ length: colliderCount }, () => ({
+          sourceId: definition!.sourceId,
+          sourceType: 'sceneObject',
+          purpose: 'factory-colliders',
+        }))
+      );
     }
   });
 });


### PR DESCRIPTION
### Motivation
- Solidify the declarative scene-object collider migration by proving migrated showpieces still provide factory-owned colliders and carry stable source IDs/metadata.
- Allow instantiation of canvas-textured showpieces under the jsdom test environment so provenance assertions can run reliably.

### Description
- Adds a jsdom `HTMLCanvasElement.getContext` stub in `src/scene/level/sceneObjects.test.ts` to allow canvas-based textures to be created during tests.
- Imports and instantiates the migrated showpiece factories (`createFlywheelShowpiece`, `createJobbotTerminal`, `createAxelNavigator`, `createWoveLoom`, `createPrReaperConsole`) inside a new regression test.
- Adds a regression test that asserts each migrated showpiece retains its expected `collider` count and that `registerSceneObjectColliders(...)` attaches `sourceId`, `sourceType: 'sceneObject'`, and `purpose: 'factory-colliders'` metadata.
- Small test import reordering and bookkeeping only; no runtime behavior, visuals, or collider geometry were changed.

### Testing
- Ran `npm run format:write` — succeeded.
- Ran `npm run lint` — succeeded (no blocking errors).
- Ran focused unit tests: `npm run test:ci -- src/scene/level/sceneObjects.test.ts src/scene/structures/__tests__/axelNavigator.test.ts src/scene/structures/__tests__/woveLoom.test.ts src/tests/flywheelShowpiece.test.ts src/tests/jobbotTerminal.test.ts src/tests/prReaperConsole.test.ts` — succeeded after adding the canvas stub.
- Ran full suite `npm run test:ci` — succeeded (all suites passed in this environment).
- Attempted Playwright check `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — blocked (Playwright Chromium executable missing in the environment; not run here).
- Built the app with `npm run build` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a337b48f7c8832fbb8b1f9a5bc9b8bc)