### PR TITLE
🧹 Finish declarative source cleanup — remove legacy segmentId, add source-edit proof tests and docs

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-This document defines the migration path from the current floor-plan and
-scene-orchestration pipeline to a floor-plan-first declarative level source of
-truth. It is intentionally documentation-only: the current TypeScript runtime,
-rendered geometry, colliders, debug IDs, movement, stairs, POIs, and rendering
-must remain unchanged until later migration prompts.
+This document records the completed migration from the original floor-plan and
+scene-orchestration fragments to a floor-plan-first declarative level source of
+truth for migrated walls, floor surfaces, major safety colliders, and migrated
+scene-object placements. Runtime behavior, debug UI behavior, stair movement,
+POIs, and rendering remain intentionally preserved while source data now owns
+the current scene intent.
 
 The core principle is that authoritative level data describes the intended
 current scene. Generated meshes, gameplay colliders, debug metadata, validation,
@@ -15,10 +16,10 @@ split, clip, subtract, or batch geometry when that is the simplest way to build 
 runtime artifact, but production source data should not preserve former bounds,
 removed-ID lists, or higher-layer patches as the way to change layout.
 
-## Current pipeline
+## Current pipeline after migration
 
-The current level is assembled from several authoritative fragments plus runtime
-orchestration code:
+The current level is assembled from declarative source data plus downstream
+generators and a small amount of scene orchestration:
 
 1. `src/assets/floorPlan/index.ts`
    - Defines room bounds, room labels, LED colors, categories, and doorway ranges
@@ -325,8 +326,11 @@ semantic `roomConnections` intentionally do not create or remove geometry.
     their collider policies in declarative source data.
 11. **Add invariants and inventory tooling.** Prevent hidden overrides, duplicate
     source IDs, debug-ID tombstones, and unowned colliders or visible solids.
-12. **Remove legacy scaffolding.** Delete bridge code once direct source edits are
-    proven to regenerate final scene geometry and collision.
+12. **Remove legacy scaffolding.** Completed for migrated walls, floor
+    surfaces, major safety colliders, and migrated scene objects. Direct source
+    edit tests now prove that adding or deleting wall definitions changes final
+    generated meshes/colliders, and semantic room connections do not act as a
+    parallel geometry system.
 
 ## Migration risks
 
@@ -367,10 +371,20 @@ Future phases should add tests and tooling that make source ownership auditable:
 - Room connection checks assert semantic adjacency references real rooms and real
   current geometry or scene objects, without creating duplicate collision rules.
 
-## Definition of success
+## Completion status and remaining edges
 
-The migration is complete when a direct edit to declarative source data is enough
-to regenerate the final visual geometry, gameplay collision, and debug metadata;
-legacy patches, removed-ID lists, and manually pushed unowned colliders are gone;
-and inventory tooling can explain every runtime level artifact by semantic source
-ID.
+The migration is complete for current room definitions, wall/fence generation,
+floor surfaces, stair/void safety colliders, and the migrated scene-object
+placements with collider policies. Direct source edits regenerate generated wall
+meshes and colliders, browser debug APIs expose source IDs for known wall, floor,
+and safety-collider artifacts, and semantic room connections remain metadata
+rather than geometry.
+
+Remaining edge cases are limited to compatibility surfaces that still exist for
+comparison or non-level runtime systems: the legacy floor-plan wall adapter in
+`src/assets/floorPlan/wallSegments.ts` is retained for regression comparisons,
+not as the production authoring path, and compact hex debug IDs remain downstream
+labels. Hardcoded bounds that remain in production code should be either explicit
+source data, stair-derived safety geometry, or documented object-factory collider
+policies. See `docs/design/editing-level-data.md` for the current human editing
+workflow.

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -125,7 +125,9 @@ Run the standard checks before committing level-data edits:
 npm run format:write
 npm run lint
 npm run test:ci
+npx playwright test playwright/immersive-stairs-roundtrip.spec.ts
 npm run docs:check
+npm run build
 npm run smoke
 ```
 

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -1,0 +1,138 @@
+# Editing level data
+
+`src/scene/level/portfolioLevel.ts` is the human-edited source of truth for the
+current immersive level layout. The scene builders may split wall runs, clip
+floor surfaces, or derive compact debug IDs, but edits to intended rooms, walls,
+floors, safety colliders, scene objects, and room connections should start in
+that declarative file.
+
+## Naming and source IDs
+
+Use stable, dot-separated semantic source IDs:
+
+- Start with the floor or area: `ground`, `upper`, or `backyard`.
+- Add the room or zone in editor terms: `living_room`, `upperLanding`,
+  `stairwell`.
+- Add the authored thing: `south_wall`, `floor.main`, `scene_object`, or
+  `safetyCollider`.
+- Add a part only when the same source concept produces multiple authored
+  entries, for example `.left` or `.section03`.
+
+Examples:
+
+- `ground.living_room.south_wall`
+- `ground.livingRoom.floor.main`
+- `upper.stairwell.westBannister.safetyCollider`
+- `ground.flywheel.scene_object`
+
+Source IDs must remain unique across all level layers. Do not include words such
+as `former`, `removed`, or `tombstone`; open space is represented by the absence
+of wall/floor geometry or by an intentional current wall-run gap.
+
+## Rooms
+
+Edit room bounds, names, LED colors, and categories in the `rooms` array for the
+floor. Rooms are semantic zones and placement anchors. They do not implicitly
+create walls or floors by themselves; add those in the dedicated arrays.
+
+## Add or remove a wall
+
+Walls live in each floor's `walls` array.
+
+To add a wall:
+
+1. Add a `WallDefinition` with a stable `id` and `sourceId`.
+2. Set `floorId`, `wallKind`, and `rooms`.
+3. Use a `run` for a straight wall, or `segments` when spelling out pieces is
+   clearer.
+4. Add `run.gaps` only for current open passages or doorways.
+
+To remove a wall, delete the wall definition. Do not keep the old bounds in a
+removal list, debug filter, or visualizer skip list.
+
+## Add or remove a floor surface
+
+Floor surfaces live in `floorSurfaces`. Most room floors are created by
+`floorSurfaceForRoom(...)`, and special pieces can be appended in `buildFloor`.
+Add the source ID to `FLOOR_SURFACE_SOURCE_IDS`, then ensure the bounds describe
+the current walkable/rendered surface. The floor generator owns downstream
+splitting and stairwell clipping.
+
+## Add a safety collider
+
+Safety colliders live in `safetyColliders` for authored fixed colliders, and
+stair-derived colliders are defined in `src/scene/level/stairSafetyColliders.ts`.
+Every safety collider needs:
+
+- `id`
+- `sourceId`
+- `floorId`
+- `bounds`
+- a clear `purpose`
+
+Use safety colliders for invisible constraints such as stairwell void guards or
+approach-lane protection, not as a hidden substitute for visible wall geometry.
+
+## Add visible doors, trim, or showpieces
+
+Visible non-wall objects live in `sceneObjects`. Use a scene object for a door,
+trim, threshold, media wall, showpiece, or terminal that is visible or
+interactable. Pick an explicit `colliderPolicy`:
+
+- `custom` when an existing factory supplies colliders.
+- `bounds` or `solid` for straightforward blocking footprints.
+- `decorativeNoCollision` or `interactionOnly` when the object intentionally
+  should not block movement; include the reason.
+
+## Add semantic room connections
+
+Use `roomConnections` only for semantic adjacency, navigation, narration, or
+editor affordances. A room connection does not create or remove wall geometry or
+colliders. If the connection needs an opening, edit the wall run/gap or delete
+that wall source data. If it needs a visible threshold or door, add a scene
+object.
+
+## Inspect source IDs in the browser
+
+Launch immersive mode with performance failover disabled:
+
+```bash
+npm run preview -- --host 0.0.0.0
+# open http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
+```
+
+In DevTools, enable and query debug APIs:
+
+```js
+window.portfolio.debugSolids.setEnabled(true);
+window.portfolio.debugColliders.setEnabled(true);
+window.portfolio.debugSolids.getSolidsBySourceId(
+  'ground.livingRoom.floor.main'
+);
+window.portfolio.debugColliders.getCollidersBySourceId(
+  'upper.stairwell.westBannister.safetyCollider'
+);
+```
+
+Short hex IDs are useful overlay labels, but source IDs are the primary review
+and test assertions.
+
+## Verification commands
+
+Run the standard checks before committing level-data edits:
+
+```bash
+npm run format:write
+npm run lint
+npm run test:ci
+npm run docs:check
+npm run smoke
+```
+
+For source-ID and runtime metadata changes, also run focused tests:
+
+```bash
+npx vitest run src/scene/level/__tests__/generateWalls.test.ts
+npx vitest run src/scene/level/__tests__/generateFloorSurfaces.test.ts
+npx playwright test playwright/immersive-stairs-roundtrip.spec.ts
+```

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1101,6 +1101,7 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
     debugColliders.setEnabled(true);
 
     const knownWallSourceId = 'upper.upper_landing.south_wall';
+    const passageWallSourceId = 'upper.upper_landing_to_loft_library.wall';
     const knownFloorSourceId = 'upper.upperLanding.floor.main';
     const knownSafetySourceId = 'upper.stairwell.westBannister.safetyCollider';
     const knownWallSolids = debugSolids.getSolidsBySourceId(knownWallSourceId);
@@ -1110,33 +1111,37 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       debugSolids.getSolidsBySourceId(knownFloorSourceId);
     const knownSafetyColliders =
       debugColliders.getCollidersBySourceId(knownSafetySourceId);
-    const formerWallBounds = {
+    const passageWallSolids =
+      debugSolids.getSolidsBySourceId(passageWallSourceId);
+    const passageWallColliders =
+      debugColliders.getCollidersBySourceId(passageWallSourceId);
+    const openPassageBounds = {
       minX: 3.875,
       maxX: 8.525,
       minZ: -16.25,
       maxZ: -15.75,
     };
-    const matchingWallSolids = debugSolids
-      .getSolids()
-      .filter(
-        (solid) =>
-          solid.name === 'WallSegment' &&
-          solid.parentPath === 'Scene/Group/UpperWallSegments' &&
-          Math.abs(solid.bounds.min.x - formerWallBounds.minX) < 0.001 &&
-          Math.abs(solid.bounds.max.x - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(solid.bounds.min.z - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(solid.bounds.max.z - formerWallBounds.maxZ) < 0.001
-      );
-    const matchingColliderBounds = debugColliders
-      .getColliders()
-      .filter(
-        (collider) =>
-          collider.floor === 'upper' &&
-          Math.abs(collider.bounds.minX - formerWallBounds.minX) < 0.001 &&
-          Math.abs(collider.bounds.maxX - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(collider.bounds.minZ - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(collider.bounds.maxZ - formerWallBounds.maxZ) < 0.001
-      );
+    const overlapsOpenPassage = (bounds: {
+      minX: number;
+      maxX: number;
+      minZ: number;
+      maxZ: number;
+    }) =>
+      bounds.maxX > openPassageBounds.minX &&
+      bounds.minX < openPassageBounds.maxX &&
+      bounds.maxZ > openPassageBounds.minZ &&
+      bounds.minZ < openPassageBounds.maxZ;
+    const passageWallSolidsInOpening = passageWallSolids.filter((solid) =>
+      overlapsOpenPassage({
+        minX: solid.bounds.min.x,
+        maxX: solid.bounds.max.x,
+        minZ: solid.bounds.min.z,
+        maxZ: solid.bounds.max.z,
+      })
+    );
+    const passageWallCollidersInOpening = passageWallColliders.filter(
+      (collider) => overlapsOpenPassage(collider.bounds)
+    );
     const openingSamples = [
       { x: 5.5, z: -16, floorId: 'upper' as const },
       { x: 6.2, z: -16, floorId: 'upper' as const },
@@ -1157,6 +1162,8 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       collider4005: debugColliders.getColliderById('4005'),
       knownWallSolidCount: knownWallSolids.length,
       knownWallColliderCount: knownWallColliders.length,
+      passageWallSolidCount: passageWallSolids.length,
+      passageWallColliderCount: passageWallColliders.length,
       knownWallSolidSourceIds: knownWallSolids.map((solid) => solid.sourceId),
       knownWallColliderSourceIds: knownWallColliders.map(
         (collider) => collider.sourceId
@@ -1167,8 +1174,14 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       knownSafetyColliderSourceIds: knownSafetyColliders.map(
         (collider) => collider.sourceId
       ),
-      matchingWallSolidCount: matchingWallSolids.length,
-      matchingColliderBoundsCount: matchingColliderBounds.length,
+      passageWallSolidSourceIds: passageWallSolids.map(
+        (solid) => solid.sourceId
+      ),
+      passageWallColliderSourceIds: passageWallColliders.map(
+        (collider) => collider.sourceId
+      ),
+      passageWallSolidsInOpeningCount: passageWallSolidsInOpening.length,
+      passageWallCollidersInOpeningCount: passageWallCollidersInOpening.length,
       canOccupyOpeningSamples: openingSamples.map((sample) =>
         world.canOccupyPosition(sample)
       ),
@@ -1204,8 +1217,16 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
   expect(targetState.knownSafetyColliderSourceIds).toContain(
     'upper.stairwell.westBannister.safetyCollider'
   );
-  expect(targetState.matchingWallSolidCount).toBe(0);
-  expect(targetState.matchingColliderBoundsCount).toBe(0);
+  expect(targetState.passageWallSolidCount).toBeGreaterThan(0);
+  expect(targetState.passageWallColliderCount).toBeGreaterThan(0);
+  expect(targetState.passageWallSolidSourceIds).toContain(
+    'upper.upper_landing_to_loft_library.wall'
+  );
+  expect(targetState.passageWallColliderSourceIds).toContain(
+    'upper.upper_landing_to_loft_library.wall'
+  );
+  expect(targetState.passageWallSolidsInOpeningCount).toBe(0);
+  expect(targetState.passageWallCollidersInOpeningCount).toBe(0);
   expect(targetState.canOccupyOpeningSamples).toEqual([true, true, true]);
   expect(targetState.blockingAtOpeningSamples).toEqual([[], [], []]);
   expect(targetState.passageMovement.allStepsMoved).toBe(true);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -89,6 +89,7 @@ type DebugColliderMetadata = {
   category: string;
   name: string;
   bounds: DebugColliderBounds;
+  sourceId?: string;
 };
 
 type DebugColliderApi = {
@@ -100,6 +101,8 @@ type DebugColliderApi = {
     floorId?: FloorId;
   }): DebugColliderMetadata[];
   getColliderById(id: unknown): DebugColliderMetadata | undefined;
+  getColliderBySourceId(sourceId: unknown): DebugColliderMetadata | undefined;
+  getCollidersBySourceId(sourceId: unknown): DebugColliderMetadata[];
 };
 
 type DebugSolidMetadata = {
@@ -113,12 +116,15 @@ type DebugSolidMetadata = {
     max: { x: number; y: number; z: number };
   };
   material: string | null;
+  sourceId?: string;
 };
 
 type DebugSolidApi = {
   setEnabled(enabled: boolean): void;
   getSolids(): DebugSolidMetadata[];
   getSolidById(id: unknown): DebugSolidMetadata | undefined;
+  getSolidBySourceId(sourceId: unknown): DebugSolidMetadata | undefined;
+  getSolidsBySourceId(sourceId: unknown): DebugSolidMetadata[];
 };
 
 function expectCloseTo(
@@ -1097,7 +1103,6 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
     const knownWallSourceId = 'upper.upper_landing.south_wall';
     const knownFloorSourceId = 'upper.upperLanding.floor.main';
     const knownSafetySourceId = 'upper.stairwell.westBannister.safetyCollider';
-    const absentWallSourceId = 'upper.upper_landing.open_passage.wall';
     const knownWallSolids = debugSolids.getSolidsBySourceId(knownWallSourceId);
     const knownWallColliders =
       debugColliders.getCollidersBySourceId(knownWallSourceId);
@@ -1105,10 +1110,33 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       debugSolids.getSolidsBySourceId(knownFloorSourceId);
     const knownSafetyColliders =
       debugColliders.getCollidersBySourceId(knownSafetySourceId);
-    const absentWallSolids =
-      debugSolids.getSolidsBySourceId(absentWallSourceId);
-    const absentWallColliders =
-      debugColliders.getCollidersBySourceId(absentWallSourceId);
+    const formerWallBounds = {
+      minX: 3.875,
+      maxX: 8.525,
+      minZ: -16.25,
+      maxZ: -15.75,
+    };
+    const matchingWallSolids = debugSolids
+      .getSolids()
+      .filter(
+        (solid) =>
+          solid.name === 'WallSegment' &&
+          solid.parentPath === 'Scene/Group/UpperWallSegments' &&
+          Math.abs(solid.bounds.min.x - formerWallBounds.minX) < 0.001 &&
+          Math.abs(solid.bounds.max.x - formerWallBounds.maxX) < 0.001 &&
+          Math.abs(solid.bounds.min.z - formerWallBounds.minZ) < 0.001 &&
+          Math.abs(solid.bounds.max.z - formerWallBounds.maxZ) < 0.001
+      );
+    const matchingColliderBounds = debugColliders
+      .getColliders()
+      .filter(
+        (collider) =>
+          collider.floor === 'upper' &&
+          Math.abs(collider.bounds.minX - formerWallBounds.minX) < 0.001 &&
+          Math.abs(collider.bounds.maxX - formerWallBounds.maxX) < 0.001 &&
+          Math.abs(collider.bounds.minZ - formerWallBounds.minZ) < 0.001 &&
+          Math.abs(collider.bounds.maxZ - formerWallBounds.maxZ) < 0.001
+      );
     const openingSamples = [
       { x: 5.5, z: -16, floorId: 'upper' as const },
       { x: 6.2, z: -16, floorId: 'upper' as const },
@@ -1139,8 +1167,8 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       knownSafetyColliderSourceIds: knownSafetyColliders.map(
         (collider) => collider.sourceId
       ),
-      absentWallSolidCount: absentWallSolids.length,
-      absentWallColliderCount: absentWallColliders.length,
+      matchingWallSolidCount: matchingWallSolids.length,
+      matchingColliderBoundsCount: matchingColliderBounds.length,
       canOccupyOpeningSamples: openingSamples.map((sample) =>
         world.canOccupyPosition(sample)
       ),
@@ -1176,8 +1204,8 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
   expect(targetState.knownSafetyColliderSourceIds).toContain(
     'upper.stairwell.westBannister.safetyCollider'
   );
-  expect(targetState.absentWallSolidCount).toBe(0);
-  expect(targetState.absentWallColliderCount).toBe(0);
+  expect(targetState.matchingWallSolidCount).toBe(0);
+  expect(targetState.matchingColliderBoundsCount).toBe(0);
   expect(targetState.canOccupyOpeningSamples).toEqual([true, true, true]);
   expect(targetState.blockingAtOpeningSamples).toEqual([[], [], []]);
   expect(targetState.passageMovement.allStepsMoved).toBe(true);

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1095,37 +1095,20 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
     debugColliders.setEnabled(true);
 
     const knownWallSourceId = 'upper.upper_landing.south_wall';
+    const knownFloorSourceId = 'upper.upperLanding.floor.main';
+    const knownSafetySourceId = 'upper.stairwell.westBannister.safetyCollider';
+    const absentWallSourceId = 'upper.upper_landing.open_passage.wall';
     const knownWallSolids = debugSolids.getSolidsBySourceId(knownWallSourceId);
     const knownWallColliders =
       debugColliders.getCollidersBySourceId(knownWallSourceId);
-
-    const formerWallBounds = {
-      minX: 3.875,
-      maxX: 8.525,
-      minZ: -16.25,
-      maxZ: -15.75,
-    };
-    const matchingWallSolids = debugSolids
-      .getSolids()
-      .filter(
-        (solid) =>
-          solid.name === 'WallSegment' &&
-          solid.parentPath === 'Scene/Group/UpperWallSegments' &&
-          Math.abs(solid.bounds.min.x - formerWallBounds.minX) < 0.001 &&
-          Math.abs(solid.bounds.max.x - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(solid.bounds.min.z - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(solid.bounds.max.z - formerWallBounds.maxZ) < 0.001
-      );
-    const matchingColliderBounds = debugColliders
-      .getColliders()
-      .filter(
-        (collider) =>
-          collider.floor === 'upper' &&
-          Math.abs(collider.bounds.minX - formerWallBounds.minX) < 0.001 &&
-          Math.abs(collider.bounds.maxX - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(collider.bounds.minZ - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(collider.bounds.maxZ - formerWallBounds.maxZ) < 0.001
-      );
+    const knownFloorSolids =
+      debugSolids.getSolidsBySourceId(knownFloorSourceId);
+    const knownSafetyColliders =
+      debugColliders.getCollidersBySourceId(knownSafetySourceId);
+    const absentWallSolids =
+      debugSolids.getSolidsBySourceId(absentWallSourceId);
+    const absentWallColliders =
+      debugColliders.getCollidersBySourceId(absentWallSourceId);
     const openingSamples = [
       { x: 5.5, z: -16, floorId: 'upper' as const },
       { x: 6.2, z: -16, floorId: 'upper' as const },
@@ -1150,12 +1133,14 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       knownWallColliderSourceIds: knownWallColliders.map(
         (collider) => collider.sourceId
       ),
-      matchingWallSolidCount: matchingWallSolids.length,
-      matchingColliderBoundsCount: matchingColliderBounds.length,
-      formerVoidGuardNames: debugColliders
-        .getColliders()
-        .filter((collider) => collider.name === 'UpperStairWestUpperVoidGuard')
-        .map((collider) => collider.id),
+      knownFloorSolidCount: knownFloorSolids.length,
+      knownFloorSolidSourceIds: knownFloorSolids.map((solid) => solid.sourceId),
+      knownSafetyColliderCount: knownSafetyColliders.length,
+      knownSafetyColliderSourceIds: knownSafetyColliders.map(
+        (collider) => collider.sourceId
+      ),
+      absentWallSolidCount: absentWallSolids.length,
+      absentWallColliderCount: absentWallColliders.length,
       canOccupyOpeningSamples: openingSamples.map((sample) =>
         world.canOccupyPosition(sample)
       ),
@@ -1183,9 +1168,16 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
   expect(targetState.solidById).toBeUndefined();
   expect(targetState.collider300A).toBeUndefined();
   expect(targetState.collider4005).toBeUndefined();
-  expect(targetState.matchingWallSolidCount).toBe(0);
-  expect(targetState.matchingColliderBoundsCount).toBe(0);
-  expect(targetState.formerVoidGuardNames).toEqual([]);
+  expect(targetState.knownFloorSolidCount).toBeGreaterThan(0);
+  expect(targetState.knownFloorSolidSourceIds).toContain(
+    'upper.upperLanding.floor.main'
+  );
+  expect(targetState.knownSafetyColliderCount).toBeGreaterThan(0);
+  expect(targetState.knownSafetyColliderSourceIds).toContain(
+    'upper.stairwell.westBannister.safetyCollider'
+  );
+  expect(targetState.absentWallSolidCount).toBe(0);
+  expect(targetState.absentWallColliderCount).toBe(0);
   expect(targetState.canOccupyOpeningSamples).toEqual([true, true, true]);
   expect(targetState.blockingAtOpeningSamples).toEqual([[], [], []]);
   expect(targetState.passageMovement.allStepsMoved).toBe(true);

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -61,6 +61,77 @@ function compareSignatures(
   return JSON.stringify(a).localeCompare(JSON.stringify(b));
 }
 
+const sourceEditProofFloor = (): FloorDefinition => ({
+  id: 'proof',
+  name: 'Proof Floor',
+  outline: [
+    [0, 0],
+    [8, 0],
+    [8, 4],
+    [0, 4],
+  ],
+  rooms: [
+    {
+      id: 'left',
+      sourceId: 'proof.left.room' as never,
+      name: 'Left',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+      ledColor: 0xffffff,
+    },
+    {
+      id: 'right',
+      sourceId: 'proof.right.room' as never,
+      name: 'Right',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+      ledColor: 0xffffff,
+    },
+  ],
+  walls: [
+    {
+      id: 'left-west-wall',
+      sourceId: 'proof.left.west_wall' as never,
+      floorId: 'proof',
+      wallKind: 'wall',
+      rooms: ['left'],
+      run: { start: { x: 0, z: 0 }, end: { x: 0, z: 4 } },
+    },
+    {
+      id: 'divider-wall',
+      sourceId: 'proof.left_to_right.divider_wall' as never,
+      floorId: 'proof',
+      wallKind: 'wall',
+      rooms: ['left', 'right'],
+      run: { start: { x: 4, z: 0 }, end: { x: 4, z: 4 } },
+    },
+  ],
+  floorSurfaces: [
+    {
+      id: 'left-floor',
+      sourceId: 'proof.left.floor.main' as never,
+      floorId: 'proof',
+      roomId: 'left',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+    },
+    {
+      id: 'right-floor',
+      sourceId: 'proof.right.floor.main' as never,
+      floorId: 'proof',
+      roomId: 'right',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+    },
+  ],
+});
+
+const proofWallOptions = () => ({
+  coordinateScale: 1,
+  baseElevation: 0,
+  wallHeight: 3,
+  wallThickness: 0.25,
+  fenceHeight: 1,
+  fenceThickness: 0.1,
+  getRoomCategory: () => 'interior' as const,
+});
+
 function getFloor(level: LevelDefinition, floorId: string): FloorDefinition {
   const floor = level.floors.find((candidate) => candidate.id === floorId);
   if (!floor) throw new Error(`Missing test floor ${floorId}.`);
@@ -140,6 +211,100 @@ describe('generateWallSegmentInstances', () => {
     expect(JSON.stringify(PORTFOLIO_LEVEL)).not.toMatch(
       /skip|former|removed|tombstone/i
     );
+  });
+
+  it('regenerates wall meshes and colliders from direct source-data edits', () => {
+    const floor = sourceEditProofFloor();
+    const addedWallSourceId = 'proof.right.east_wall';
+    const withAddedWall: FloorDefinition = {
+      ...floor,
+      walls: [
+        ...floor.walls,
+        {
+          id: 'right-east-wall',
+          sourceId: addedWallSourceId as never,
+          floorId: 'proof',
+          wallKind: 'wall',
+          rooms: ['right'],
+          run: { start: { x: 8, z: 0 }, end: { x: 8, z: 4 } },
+        },
+      ],
+    };
+
+    const baseline = generateWallSegmentInstances(floor, proofWallOptions());
+    const edited = generateWallSegmentInstances(
+      withAddedWall,
+      proofWallOptions()
+    );
+
+    expect(baseline.some((wall) => wall.sourceId === addedWallSourceId)).toBe(
+      false
+    );
+    const generatedWall = edited.find(
+      (wall) => wall.sourceId === addedWallSourceId
+    );
+    expect(generatedWall).toBeDefined();
+    expect(generatedWall?.collider).toMatchObject({ minX: 8, maxX: 8.25 });
+
+    const material = new MeshBasicMaterial({ color: 0xffffff });
+    const { meshes } = createWallSegmentMeshes({
+      instances: edited,
+      getMaterial: () => material,
+    });
+    expect(
+      meshes.some((mesh) => mesh.userData.levelSourceId === addedWallSourceId)
+    ).toBe(true);
+    material.dispose();
+  });
+
+  it('removes generated wall meshes and colliders after a direct source-data deletion', () => {
+    const floor = sourceEditProofFloor();
+    const removedSourceId = 'proof.left_to_right.divider_wall';
+    const withoutDivider: FloorDefinition = {
+      ...floor,
+      walls: floor.walls.filter((wall) => wall.sourceId !== removedSourceId),
+    };
+
+    const baseline = generateWallSegmentInstances(floor, proofWallOptions());
+    const edited = generateWallSegmentInstances(
+      withoutDivider,
+      proofWallOptions()
+    );
+
+    expect(baseline.some((wall) => wall.sourceId === removedSourceId)).toBe(
+      true
+    );
+    expect(edited.some((wall) => wall.sourceId === removedSourceId)).toBe(
+      false
+    );
+  });
+
+  it('does not create or remove wall geometry for semantic room connections', () => {
+    const floor = sourceEditProofFloor();
+    const withConnection: FloorDefinition = {
+      ...floor,
+      roomConnections: [
+        {
+          id: 'left-right-opening',
+          sourceId: 'proof.left_to_right.connection' as never,
+          floorId: 'proof',
+          rooms: ['left', 'right'],
+        },
+      ],
+    };
+
+    const baseline = generateWallSegmentInstances(floor, proofWallOptions());
+    const edited = generateWallSegmentInstances(
+      withConnection,
+      proofWallOptions()
+    );
+
+    expect(edited.map(wallSignature).sort(compareSignatures)).toEqual(
+      baseline.map(wallSignature).sort(compareSignatures)
+    );
+    expect(
+      edited.some((wall) => wall.sourceId === 'proof.left_to_right.connection')
+    ).toBe(false);
   });
 
   it('responds to declarative wall edits without consuming semantic connections', () => {

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -12,6 +12,7 @@ import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
 import type { FloorDefinition, LevelDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
 
 const wallOptions = (baseElevation = 0) => ({
   coordinateScale: FLOOR_PLAN_SCALE,
@@ -61,6 +62,8 @@ function compareSignatures(
   return JSON.stringify(a).localeCompare(JSON.stringify(b));
 }
 
+const sourceId = (value: string) => assertLevelSourceId(value);
+
 const sourceEditProofFloor = (): FloorDefinition => ({
   id: 'proof',
   name: 'Proof Floor',
@@ -73,14 +76,14 @@ const sourceEditProofFloor = (): FloorDefinition => ({
   rooms: [
     {
       id: 'left',
-      sourceId: 'proof.left.room' as never,
+      sourceId: sourceId('proof.left.room'),
       name: 'Left',
       bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
       ledColor: 0xffffff,
     },
     {
       id: 'right',
-      sourceId: 'proof.right.room' as never,
+      sourceId: sourceId('proof.right.room'),
       name: 'Right',
       bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
       ledColor: 0xffffff,
@@ -89,7 +92,7 @@ const sourceEditProofFloor = (): FloorDefinition => ({
   walls: [
     {
       id: 'left-west-wall',
-      sourceId: 'proof.left.west_wall' as never,
+      sourceId: sourceId('proof.left.west_wall'),
       floorId: 'proof',
       wallKind: 'wall',
       rooms: ['left'],
@@ -97,7 +100,7 @@ const sourceEditProofFloor = (): FloorDefinition => ({
     },
     {
       id: 'divider-wall',
-      sourceId: 'proof.left_to_right.divider_wall' as never,
+      sourceId: sourceId('proof.left_to_right.divider_wall'),
       floorId: 'proof',
       wallKind: 'wall',
       rooms: ['left', 'right'],
@@ -107,14 +110,14 @@ const sourceEditProofFloor = (): FloorDefinition => ({
   floorSurfaces: [
     {
       id: 'left-floor',
-      sourceId: 'proof.left.floor.main' as never,
+      sourceId: sourceId('proof.left.floor.main'),
       floorId: 'proof',
       roomId: 'left',
       bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
     },
     {
       id: 'right-floor',
-      sourceId: 'proof.right.floor.main' as never,
+      sourceId: sourceId('proof.right.floor.main'),
       floorId: 'proof',
       roomId: 'right',
       bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
@@ -215,14 +218,14 @@ describe('generateWallSegmentInstances', () => {
 
   it('regenerates wall meshes and colliders from direct source-data edits', () => {
     const floor = sourceEditProofFloor();
-    const addedWallSourceId = 'proof.right.east_wall';
+    const addedWallSourceId = sourceId('proof.right.east_wall');
     const withAddedWall: FloorDefinition = {
       ...floor,
       walls: [
         ...floor.walls,
         {
           id: 'right-east-wall',
-          sourceId: addedWallSourceId as never,
+          sourceId: addedWallSourceId,
           floorId: 'proof',
           wallKind: 'wall',
           rooms: ['right'],
@@ -259,7 +262,7 @@ describe('generateWallSegmentInstances', () => {
 
   it('removes generated wall meshes and colliders after a direct source-data deletion', () => {
     const floor = sourceEditProofFloor();
-    const removedSourceId = 'proof.left_to_right.divider_wall';
+    const removedSourceId = sourceId('proof.left_to_right.divider_wall');
     const withoutDivider: FloorDefinition = {
       ...floor,
       walls: floor.walls.filter((wall) => wall.sourceId !== removedSourceId),
@@ -286,7 +289,7 @@ describe('generateWallSegmentInstances', () => {
       roomConnections: [
         {
           id: 'left-right-opening',
-          sourceId: 'proof.left_to_right.connection' as never,
+          sourceId: sourceId('proof.left_to_right.connection'),
           floorId: 'proof',
           rooms: ['left', 'right'],
         },
@@ -315,7 +318,7 @@ describe('generateWallSegmentInstances', () => {
         ...(ground.roomConnections ?? []),
         {
           id: 'test-only-connection',
-          sourceId: 'ground.test_only.connection' as never,
+          sourceId: sourceId('ground.test_only.connection'),
           floorId: 'ground',
           rooms: ['livingRoom', 'studio'],
         },
@@ -383,7 +386,7 @@ describe('generateWallSegmentInstances', () => {
         ...ground.walls,
         {
           id: 'test-diagonal-wall',
-          sourceId: 'ground.test.diagonal_wall' as never,
+          sourceId: sourceId('ground.test.diagonal_wall'),
           floorId: 'ground',
           rooms: ['livingRoom'],
           run: {

--- a/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
+++ b/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
@@ -86,7 +86,6 @@ describe('createWallSegmentMeshes', () => {
         instances[index]?.isSharedInterior ?? false
       );
       expect(mesh.userData.thickness).toBe(instances[index]?.thickness);
-      expect(mesh.userData.segmentId).toBe(instances[index]?.segmentId);
       expect(mesh.userData.levelSourceId).toBe(instances[index]?.sourceId);
       expect(mesh.userData.levelSource).toEqual({
         sourceId: instances[index]?.sourceId,

--- a/src/scene/structures/wallSegmentsMesh.ts
+++ b/src/scene/structures/wallSegmentsMesh.ts
@@ -49,9 +49,6 @@ export function createWallSegmentMeshes(
     mesh.name = instance.isFence ? FENCE_MESH_NAME : WALL_MESH_NAME;
     mesh.position.set(instance.center.x, instance.center.y, instance.center.z);
 
-    // Store a compact identifier instead of the full segment object to avoid
-    // retaining large or circular references in Three.js metadata.
-    mesh.userData.segmentId = instance.segmentId;
     mesh.userData.levelSourceId = instance.sourceId;
     mesh.userData.levelSource = {
       sourceId: instance.sourceId,


### PR DESCRIPTION
### Motivation
- Finalize the declarative level-source migration by removing leftover compatibility scaffolding and making it obvious where to edit rooms, walls, floors, safety colliders, and scene objects. 
- Prove with tests and browser assertions that direct edits to the declarative source regenerate generated meshes and colliders, and that semantic room connections are metadata-only. 
- Consolidate downstream provenance to semantic `levelSourceId`/`levelSource` and remove parallel segment/tombstone metadata that encouraged higher-layer hacks.

### Description
- Removed legacy `segmentId` assignment from wall mesh `userData` while preserving `levelSourceId` and `levelSource` provenance in `src/scene/structures/wallSegmentsMesh.ts`. 
- Added focused source-edit proof unit tests in `src/scene/level/__tests__/generateWalls.test.ts` that construct a two-room floor and assert wall add/remove flows and that `roomConnections` do not change geometry. 
- Strengthened Playwright assertions in `playwright/immersive-stairs-roundtrip.spec.ts` to verify known wall, floor, and safety-collider `sourceId` presence and to assert absence for an expected-open wall. 
- Added `docs/design/editing-level-data.md` and updated `docs/design/declarative-level-source-of-truth.md` to document the completed migration status, naming conventions, edit workflow, and verification steps.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully. 
- Ran unit tests with `npm run test:ci` (Vitest) and focused runs `npx vitest run src/scene/level/__tests__/generateWalls.test.ts src/scene/structures/__tests__/wallSegmentsMesh.test.ts`; all tests passed (new tests included). 
- Ran docs checks `npm run docs:check` which passed (link checker emitted external fetch warnings but did not fail). 
- Built and smoke-checked with `npm run build` and `npm run smoke`, both succeeded. 
- Ran Playwright end-to-end checks: initial Playwright run failed due to missing browser binaries, then `npx playwright install chromium` and `npx playwright install-deps chromium` were executed and `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` completed successfully (all Playwright steps passing after installing deps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a338c8da960832f9da41c9f9ca1b9b9)