### PR TITLE
🧹 Finalize declarative level cleanup

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-This document defines the migration path from the current floor-plan and
-scene-orchestration pipeline to a floor-plan-first declarative level source of
-truth. It is intentionally documentation-only: the current TypeScript runtime,
-rendered geometry, colliders, debug IDs, movement, stairs, POIs, and rendering
-must remain unchanged until later migration prompts.
+This document defines the completed architecture for migrated immersive level
+data and records the migration path from the prior floor-plan/runtime
+orchestration pipeline to a floor-plan-first declarative source of truth. The
+current TypeScript runtime, rendered geometry, colliders, debug IDs, movement,
+stairs, POIs, and rendering remain behaviorally unchanged; the upstream authoring
+contract is now declarative current-state level data.
 
 The core principle is that authoritative level data describes the intended
 current scene. Generated meshes, gameplay colliders, debug metadata, validation,
@@ -37,13 +38,10 @@ orchestration code:
    - Retains the legacy combined-wall adapter for compatibility tests and
      non-migrated consumers.
    - Computes wall/fence dimensions, center points, colliders, shared-interior
-     status, and current `segmentId` values.
-   - Current segment IDs are generated from segment data plus the segment order,
-     so they are useful runtime correlation labels but are not yet stable source
-     identities.
+     status, and current semantic source IDs.
 4. `src/scene/structures/wallSegmentsMesh.ts`
    - Builds Three.js wall and fence meshes from wall segment instances.
-   - Copies compact metadata such as `segmentId`, `isFence`,
+   - Copies compact metadata such as `sourceId`, `isFence`,
      `isSharedInterior`, and `thickness` into mesh `userData`.
 5. `src/scene/structures/floorTiles.ts`
    - Builds room floor tile meshes from room bounds.

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -1,0 +1,121 @@
+# Editing level data
+
+The immersive house layout is authored from declarative current-state data in
+`src/scene/level/portfolioLevel.ts`. Edit that file first when changing rooms,
+walls, floor surfaces, safety colliders, visible scene objects, or semantic room
+connections. Generators may split, clip, or derive render/collision artifacts,
+but source files should describe what exists now rather than keeping deleted
+bounds or debug IDs for later removal.
+
+## Naming and source IDs
+
+Every authored entity has a stable `sourceId` validated by
+`src/scene/level/sourceIds.ts`:
+
+- Use dot-separated semantic paths: `<floor>.<area>.<feature>`.
+- Prefer existing floor and room terms, such as `ground.livingRoom` and
+  `upper.upperLanding`, when extending nearby data.
+- End IDs with a useful type hint when it improves readability:
+  `.room`, `.floor.main`, `.safetyCollider`, `.scene_object`, or `.connection`.
+- Do not use tombstone wording such as `former`, `removed`, or
+  `debugonlyremoval` in source IDs. A missing wall or collider should be absent
+  from source data.
+
+## Add or remove a wall
+
+Walls live in each floor's `walls` array. Add a `WallDefinition` with:
+
+- `id`: kebab-case local name.
+- `sourceId`: semantic ID for debug lookup and generated colliders.
+- `floorId`: the owning floor.
+- `wallKind`: `wall`, `fence`, or `railing`.
+- `rooms`: adjacent room IDs when known.
+- `run`: an axis-aligned start/end pair, plus optional current-state `gaps` for
+  openings.
+
+Remove a wall by deleting its wall definition. Do not leave a skip list, old
+bounds record, visualizer filter, or room connection to cancel it. Semantic
+`roomConnections` are documentation/navigation metadata only; they do not create
+or remove wall geometry.
+
+## Add or remove a floor surface
+
+Floor surfaces live in `floorSurfaces`. Add a `FloorSurfaceDefinition` with
+`id`, `sourceId`, `floorId`, `bounds`, and optional `roomId`/`purpose`. The floor
+surface generator owns downstream tile splitting and cutouts. Remove floor area
+by editing current surface bounds or cutout source data, not by storing a former
+full floor and subtracting it later.
+
+## Add a safety collider
+
+Safety colliders live in `safetyColliders` for source-authored level blockers or
+in `src/scene/level/stairSafetyColliders.ts` for stair-derived guard geometry.
+Use `sourceId`, `floorId`, `bounds`, and a short `purpose`. Hardcoded bounds are
+acceptable only when they are explicit current safety geometry and are covered by
+focused tests.
+
+## Add visible doors, trim, or props
+
+Visible non-wall details live in `sceneObjects`. Add a scene object with
+`sourceId`, `kind`, `position`, optional `orientation`, and a `colliderPolicy`.
+Use `decorativeNoCollision` for visual trim/doors that should not block the
+player, `bounds` for explicit blocking footprints, or `interactionOnly` for POI
+objects that are selectable without physical collision.
+
+## Add a room connection
+
+Use `roomConnections` for semantic adjacency, navigation intent, or docs. A
+connection can describe why rooms relate, but it must not be relied on as wall or
+floor geometry. If an opening should exist, model the wall as absent or add a
+current-state wall `gap`; if a blocker should exist, add a wall or safety
+collider.
+
+## Inspect source IDs in the browser
+
+Launch the immersive scene with the required preview overrides:
+
+```bash
+npm run preview
+# Open http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
+```
+
+Then inspect debug metadata from DevTools:
+
+```js
+window.portfolio.debugSolids.setEnabled(true);
+window.portfolio.debugColliders.setEnabled(true);
+window.portfolio.debugSolids.getSolidsBySourceId(
+  'upper.upper_landing.south_wall'
+);
+window.portfolio.debugColliders.getCollidersBySourceId(
+  'upper.stairwell.hiddenRun.safetyCollider'
+);
+window.portfolio.debugColliders.getBlockingCollidersAt({
+  x: 6.2,
+  z: -16,
+  floorId: 'upper',
+});
+```
+
+Source IDs are the primary review handles. Short hexadecimal debug IDs are
+secondary references for screenshots and low-level debugging.
+
+## Verification commands
+
+Run the standard checks before opening a PR:
+
+```bash
+npm run format:write
+npm run lint
+npm run test:ci
+npm run docs:check
+npm run build
+npm run smoke
+```
+
+For source-ID and stair-focused review, also run:
+
+```bash
+npx vitest run src/scene/level/__tests__/sourceEditProof.test.ts src/scene/level/__tests__/generateWalls.test.ts src/scene/level/__tests__/generateFloorSurfaces.test.ts
+npx playwright test playwright/immersive-stairs-roundtrip.spec.ts
+```

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1076,7 +1076,7 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   }
 });
 
-test('upper landing-side passage removes targeted wall and colliders', async ({
+test('upper landing-side passage exposes source IDs and stays open', async ({
   page,
 }) => {
   test.slow();
@@ -1099,7 +1099,7 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
     const knownWallColliders =
       debugColliders.getCollidersBySourceId(knownWallSourceId);
 
-    const formerWallBounds = {
+    const openPassageWallBounds = {
       minX: 3.875,
       maxX: 8.525,
       minZ: -16.25,
@@ -1111,20 +1111,20 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
         (solid) =>
           solid.name === 'WallSegment' &&
           solid.parentPath === 'Scene/Group/UpperWallSegments' &&
-          Math.abs(solid.bounds.min.x - formerWallBounds.minX) < 0.001 &&
-          Math.abs(solid.bounds.max.x - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(solid.bounds.min.z - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(solid.bounds.max.z - formerWallBounds.maxZ) < 0.001
+          Math.abs(solid.bounds.min.x - openPassageWallBounds.minX) < 0.001 &&
+          Math.abs(solid.bounds.max.x - openPassageWallBounds.maxX) < 0.001 &&
+          Math.abs(solid.bounds.min.z - openPassageWallBounds.minZ) < 0.001 &&
+          Math.abs(solid.bounds.max.z - openPassageWallBounds.maxZ) < 0.001
       );
     const matchingColliderBounds = debugColliders
       .getColliders()
       .filter(
         (collider) =>
           collider.floor === 'upper' &&
-          Math.abs(collider.bounds.minX - formerWallBounds.minX) < 0.001 &&
-          Math.abs(collider.bounds.maxX - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(collider.bounds.minZ - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(collider.bounds.maxZ - formerWallBounds.maxZ) < 0.001
+          Math.abs(collider.bounds.minX - openPassageWallBounds.minX) < 0.001 &&
+          Math.abs(collider.bounds.maxX - openPassageWallBounds.maxX) < 0.001 &&
+          Math.abs(collider.bounds.minZ - openPassageWallBounds.minZ) < 0.001 &&
+          Math.abs(collider.bounds.maxZ - openPassageWallBounds.maxZ) < 0.001
       );
     const openingSamples = [
       { x: 5.5, z: -16, floorId: 'upper' as const },
@@ -1152,7 +1152,7 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       ),
       matchingWallSolidCount: matchingWallSolids.length,
       matchingColliderBoundsCount: matchingColliderBounds.length,
-      formerVoidGuardNames: debugColliders
+      absentVoidGuardNames: debugColliders
         .getColliders()
         .filter((collider) => collider.name === 'UpperStairWestUpperVoidGuard')
         .map((collider) => collider.id),
@@ -1185,7 +1185,7 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
   expect(targetState.collider4005).toBeUndefined();
   expect(targetState.matchingWallSolidCount).toBe(0);
   expect(targetState.matchingColliderBoundsCount).toBe(0);
-  expect(targetState.formerVoidGuardNames).toEqual([]);
+  expect(targetState.absentVoidGuardNames).toEqual([]);
   expect(targetState.canOccupyOpeningSamples).toEqual([true, true, true]);
   expect(targetState.blockingAtOpeningSamples).toEqual([[], [], []]);
   expect(targetState.passageMovement.allStepsMoved).toBe(true);

--- a/src/assets/floorPlan/wallSegments.ts
+++ b/src/assets/floorPlan/wallSegments.ts
@@ -13,9 +13,7 @@ import {
 
 export interface WallSegmentInstance {
   segment: CombinedWallSegment;
-  /** Stable identifier for correlating generated meshes with the source segment. */
-  segmentId: string;
-  /** Semantic source identifier for generated legacy wall segments. */
+  /** Semantic source identifier for generated wall segments. */
   sourceId: LevelSourceId;
   center: { x: number; y: number; z: number };
   dimensions: { width: number; height: number; depth: number };
@@ -158,7 +156,6 @@ export function createWallSegmentInstances(
 
     instances.push({
       segment,
-      segmentId: createSegmentId(segment),
       sourceId: createSegmentSourceId(segment, options),
       center,
       dimensions: { width, height, depth },
@@ -170,20 +167,6 @@ export function createWallSegmentInstances(
   });
 
   return instances;
-}
-
-function formatPoint(point: { x: number; z: number }): string {
-  return `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-}
-
-function createSegmentId(segment: CombinedWallSegment): string {
-  const start = formatPoint(segment.start);
-  const end = formatPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-  return [segment.orientation, start, end, rooms || 'none'].join('|');
 }
 
 function formatSourceCoordinate(value: number): string {

--- a/src/scene/level/__tests__/sourceEditProof.test.ts
+++ b/src/scene/level/__tests__/sourceEditProof.test.ts
@@ -1,0 +1,159 @@
+import { MeshBasicMaterial } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createSolidVisualizer } from '../../debug/solidVisualizer';
+import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
+import { generateWallSegmentInstances } from '../generateWalls';
+import type { FloorDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const floor: FloorDefinition = {
+  id: 'test',
+  name: 'Test Floor',
+  outline: [
+    [0, 0],
+    [8, 0],
+    [8, 4],
+    [0, 4],
+  ],
+  rooms: [
+    {
+      id: 'left',
+      sourceId: sourceId('test.left.room'),
+      name: 'Left',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+      ledColor: 0xffffff,
+    },
+    {
+      id: 'right',
+      sourceId: sourceId('test.right.room'),
+      name: 'Right',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+      ledColor: 0xeeeeee,
+    },
+  ],
+  walls: [
+    {
+      id: 'left-west-wall',
+      sourceId: sourceId('test.left.west_wall'),
+      floorId: 'test',
+      wallKind: 'wall',
+      rooms: ['left'],
+      run: { start: { x: 0, z: 0 }, end: { x: 0, z: 4 } },
+    },
+  ],
+  floorSurfaces: [
+    {
+      id: 'left-floor',
+      sourceId: sourceId('test.left.floor.main'),
+      floorId: 'test',
+      roomId: 'left',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+    },
+    {
+      id: 'right-floor',
+      sourceId: sourceId('test.right.floor.main'),
+      floorId: 'test',
+      roomId: 'right',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+    },
+  ],
+};
+
+const options = {
+  coordinateScale: 1,
+  baseElevation: 0,
+  wallHeight: 3,
+  wallThickness: 0.5,
+  fenceHeight: 1,
+  fenceThickness: 0.25,
+  getRoomCategory: () => 'interior' as const,
+};
+
+const buildWalls = (definition: FloorDefinition) =>
+  generateWallSegmentInstances(definition, options);
+
+const hasWallSource = (definition: FloorDefinition, id: string) =>
+  buildWalls(definition).some((wall) => wall.sourceId === id);
+
+describe('declarative source edit proof', () => {
+  it('adds wall mesh and collider output when a wall is added to source data', () => {
+    const addedSourceId = sourceId('test.left_to_right.dividing_wall');
+    const edited: FloorDefinition = {
+      ...floor,
+      walls: [
+        ...floor.walls,
+        {
+          id: 'left-right-dividing-wall',
+          sourceId: addedSourceId,
+          floorId: 'test',
+          wallKind: 'wall',
+          rooms: ['left', 'right'],
+          run: { start: { x: 4, z: 0 }, end: { x: 4, z: 4 } },
+        },
+      ],
+    };
+
+    expect(hasWallSource(floor, addedSourceId)).toBe(false);
+
+    const instances = buildWalls(edited);
+    const added = instances.find((wall) => wall.sourceId === addedSourceId);
+    expect(added).toBeDefined();
+
+    const colliders = instances.map((wall) => ({
+      ...wall.collider,
+      sourceId: wall.sourceId,
+      sourceType: 'wall',
+    }));
+    expect(
+      colliders.filter(
+        (collider) =>
+          collider.minX <= 4 &&
+          collider.maxX >= 4 &&
+          collider.minZ <= 2 &&
+          collider.maxZ >= 2
+      )
+    ).toEqual([expect.objectContaining({ sourceId: addedSourceId })]);
+
+    const material = new MeshBasicMaterial();
+    const { group } = createWallSegmentMeshes({
+      instances,
+      getMaterial: () => material,
+    });
+    const visualizer = createSolidVisualizer({ enabled: true });
+    visualizer.register(group);
+    expect(visualizer.getSolidsBySourceId(addedSourceId)).toHaveLength(1);
+    visualizer.dispose();
+    material.dispose();
+  });
+
+  it('removes wall mesh and collider output when a wall is removed from source data', () => {
+    const removedSourceId = sourceId('test.left.west_wall');
+    const edited: FloorDefinition = {
+      ...floor,
+      walls: floor.walls.filter((wall) => wall.sourceId !== removedSourceId),
+    };
+
+    expect(hasWallSource(floor, removedSourceId)).toBe(true);
+    expect(hasWallSource(edited, removedSourceId)).toBe(false);
+  });
+
+  it('keeps semantic room connections from creating or removing wall geometry', () => {
+    const connected: FloorDefinition = {
+      ...floor,
+      roomConnections: [
+        {
+          id: 'left-to-right',
+          sourceId: sourceId('test.left_to_right.connection'),
+          floorId: 'test',
+          rooms: ['left', 'right'],
+          purpose: 'Authoring metadata only; geometry is declared by walls.',
+        },
+      ],
+    };
+
+    expect(buildWalls(connected)).toEqual(buildWalls(floor));
+  });
+});

--- a/src/scene/level/generateWalls.ts
+++ b/src/scene/level/generateWalls.ts
@@ -116,7 +116,6 @@ function createWallInstance(
 
   return {
     segment,
-    segmentId: createSegmentId(segment),
     sourceId: segment.sourceWall.sourceId,
     center,
     dimensions: { width, height, depth },
@@ -335,19 +334,6 @@ function uniqueRoomWalls(
     seen.add(key);
     return true;
   });
-}
-
-function createSegmentId(segment: CombinedWallSegment): string {
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-  return [
-    segment.orientation,
-    formatPoint(segment.start),
-    formatPoint(segment.end),
-    rooms || 'none',
-  ].join('|');
 }
 
 function formatPoint(point: { x: number; z: number }): string {

--- a/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
+++ b/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
@@ -14,7 +14,6 @@ function createWallInstance(
       end: { x: 4, z: 0 },
       rooms: [{ id: 'livingRoom', wall: 'north' }],
     },
-    segmentId: 'segment-default',
     sourceId:
       'ground.generated_wall.horizontal.xp0_zp0_to_xp4000_zp0.living_room_north' as WallSegmentInstance['sourceId'],
     center: { x: 2, y: 3, z: 0 },
@@ -34,7 +33,6 @@ describe('createWallSegmentMeshes', () => {
     const instances: WallSegmentInstance[] = [
       createWallInstance({
         center: { x: -2, y: 3, z: 1 },
-        segmentId: 'segment-vertical',
         segment: {
           orientation: 'vertical',
           start: { x: -3, z: 0 },
@@ -49,7 +47,6 @@ describe('createWallSegmentMeshes', () => {
         dimensions: { width: 0.28, height: 2.4, depth: 3 },
         isFence: true,
         thickness: 0.28,
-        segmentId: 'segment-horizontal',
         segment: {
           orientation: 'horizontal',
           start: { x: 4.5, z: -5.5 },
@@ -86,7 +83,6 @@ describe('createWallSegmentMeshes', () => {
         instances[index]?.isSharedInterior ?? false
       );
       expect(mesh.userData.thickness).toBe(instances[index]?.thickness);
-      expect(mesh.userData.segmentId).toBe(instances[index]?.segmentId);
       expect(mesh.userData.levelSourceId).toBe(instances[index]?.sourceId);
       expect(mesh.userData.levelSource).toEqual({
         sourceId: instances[index]?.sourceId,

--- a/src/scene/structures/wallSegmentsMesh.ts
+++ b/src/scene/structures/wallSegmentsMesh.ts
@@ -49,9 +49,6 @@ export function createWallSegmentMeshes(
     mesh.name = instance.isFence ? FENCE_MESH_NAME : WALL_MESH_NAME;
     mesh.position.set(instance.center.x, instance.center.y, instance.center.z);
 
-    // Store a compact identifier instead of the full segment object to avoid
-    // retaining large or circular references in Three.js metadata.
-    mesh.userData.segmentId = instance.segmentId;
     mesh.userData.levelSourceId = instance.sourceId;
     mesh.userData.levelSource = {
       sourceId: instance.sourceId,

--- a/src/tests/wallSegments.test.ts
+++ b/src/tests/wallSegments.test.ts
@@ -125,16 +125,9 @@ describe('createWallSegmentInstances', () => {
 
   it('assigns valid unique semantic source IDs without array index suffixes', () => {
     const sourceIds = groundWallInstances.map((instance) => instance.sourceId);
-    const segmentIds = groundWallInstances.map(
-      (instance) => instance.segmentId
-    );
-
     expect(sourceIds.every(isLevelSourceId)).toBe(true);
     expect(new Set(sourceIds).size).toBe(sourceIds.length);
     expect(sourceIds.every((sourceId) => !/[.|_-]\d+$/.test(sourceId))).toBe(
-      true
-    );
-    expect(segmentIds.every((segmentId) => !/[.|_-]\d+$/.test(segmentId))).toBe(
       true
     );
   });


### PR DESCRIPTION
### Motivation

- Remove legacy transient wall-segment plumbing and debug tombstone paths so the declarative semantic `sourceId` is the primary handle for generated walls, colliders, and debug metadata.
- Consolidate mesh/userData metadata to a single, consistent `levelSourceId`/`levelSource` shape and make it obvious where to edit rooms, walls, floors, safety colliders, and scene objects.
- Prove the authoring contract by adding focused tests and browser-level checks that editing declarative source data directly updates generated geometry/collision.

### Description

- Removed the transient `segmentId` pathway and helper functions from wall generation and assets so generated wall instances and meshes carry only semantic `sourceId` metadata and generator-owned fields such as `isFence`/`thickness` remain.
- Stopped writing `mesh.userData.segmentId` and standardized wall mesh metadata to include `levelSourceId` and `levelSource` (sourceId + sourceType) for debug lookup and collider correlation.
- Added a unit test `src/scene/level/__tests__/sourceEditProof.test.ts` that demonstrates adding/removing walls in declarative floor data creates/removes generated wall instances, colliders, and solids while semantic `roomConnections` remain metadata-only.
- Updated the Playwright stair/debug test to assert by `sourceId` and renamed variables to reflect open-passage validation, and added `docs/design/editing-level-data.md` plus small clarifying edits to the main declarative doc to document the final editing workflow.

### Testing

- Ran formatting and static checks with `npm run format:write` and `npm run lint`, both of which completed successfully.
- Ran unit tests with `npm run test:ci` (including the new `sourceEditProof` test and related wall/floor tests) and observed all tests pass (`1203` tests in the full run); targeted runs of the modified tests also passed.
- Verified docs and build with `npm run docs:check`, `npm run build`, and `npm run smoke` which completed successfully (link checker emitted external fetch warnings only), and executed Playwright checks by installing browsers and deps with `npx playwright install chromium` and `npx playwright install-deps chromium` followed by `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed after installing the Playwright runtime and host deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a338ca1839c832fa6563e6617570ed8)