### PR TITLE
🧹 Finalize declarative level source cleanup

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -294,6 +294,21 @@ narrow compatibility. By default it copies room metadata only. When
 old room-wall generators, not the canonical future scene-construction path, and
 semantic `roomConnections` intentionally do not create or remove geometry.
 
+## Migration status
+
+The migration is complete for the authored immersive house layout: rooms, walls,
+floor surfaces, stair/void safety colliders, migrated scene objects, and semantic
+room connections now originate from declarative current-state source data.
+Compatibility floor-plan exports remain for older consumers and tests, but they
+compile from `src/scene/level/portfolioLevel.ts` instead of acting as the source
+of truth. Human editing guidance lives in
+[`editing-level-data.md`](./editing-level-data.md).
+
+Remaining edge cases are adapter-oriented rather than layout-authoring paths:
+legacy floor-plan doorway exports still support consumers that have not moved to
+source-aware APIs, and stair geometry continues to derive several safety bounds
+from the staircase configuration so movement behavior stays unchanged.
+
 ## Migration phases
 
 1. **Document the architecture.** Establish this source-of-truth model and the
@@ -325,17 +340,19 @@ semantic `roomConnections` intentionally do not create or remove geometry.
     their collider policies in declarative source data.
 11. **Add invariants and inventory tooling.** Prevent hidden overrides, duplicate
     source IDs, debug-ID tombstones, and unowned colliders or visible solids.
-12. **Remove legacy scaffolding.** Delete bridge code once direct source edits are
-    proven to regenerate final scene geometry and collision.
+12. **Remove legacy scaffolding.** Completed for migrated wall metadata: direct
+    source-edit proof tests now show wall additions/removals and semantic
+    connections regenerate final wall geometry/collision without segment-ID
+    bridge metadata.
 
 ## Migration risks
 
 - **Debug ID churn:** Compact labels and screenshot anchors may change when
   allocation order changes. Mitigation: carry semantic source IDs through debug
   metadata first, then stabilize or regenerate compact references deliberately.
-- **Order-dependent wall segment IDs:** Current segment IDs depend partly on
-  generated segment order. Mitigation: add semantic IDs before changing wall
-  generation order and assert bridge mappings during migration.
+- **Source-ID stability:** Semantic IDs must stay stable even when generator-owned
+  wall splitting changes. Mitigation: assert source IDs and debug metadata rather
+  than compact debug labels or generation order.
 - **Stair safety regressions:** Stair and landing colliders protect traversal and
   fall prevention. Mitigation: migrate them behind invariant tests that cover
   stair approach lanes, landing bounds, and stairwell void guards.
@@ -349,7 +366,7 @@ semantic `roomConnections` intentionally do not create or remove geometry.
 
 ## Testing and invariant goals
 
-Future phases should add tests and tooling that make source ownership auditable:
+Current tests and tooling make source ownership auditable:
 
 - Every generated mesh, gameplay collider, debug collider, and debug solid has a
   semantic source ID or an explicit generated-child ID derived from one.
@@ -369,8 +386,9 @@ Future phases should add tests and tooling that make source ownership auditable:
 
 ## Definition of success
 
-The migration is complete when a direct edit to declarative source data is enough
-to regenerate the final visual geometry, gameplay collision, and debug metadata;
-legacy patches, removed-ID lists, and manually pushed unowned colliders are gone;
-and inventory tooling can explain every runtime level artifact by semantic source
-ID.
+The migrated layout now meets this success definition for rooms, walls, floor
+surfaces, major safety colliders, and migrated scene objects: direct edits to
+declarative source data regenerate final visual geometry, gameplay collision, and
+debug metadata; deleted generated debug IDs are not preserved as production
+removal records; and runtime debug APIs explain level artifacts by semantic
+source ID.

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -1,0 +1,93 @@
+# Editing declarative level data
+
+The immersive house layout is authored from current-state declarative data in
+`src/scene/level/portfolioLevel.ts`. Runtime generators may split, clip, or
+derive meshes and colliders, but level intent should be edited in source data,
+not by adding removal lists, former bounds, visualizer filters, or debug-ID
+hacks.
+
+## Source ID conventions
+
+Use `sourceId(...)` with dot-separated semantic IDs:
+
+- Rooms: `<floor>.<room>.room`
+- Walls: `<floor>.<room-or-area>.<direction-or-feature>_wall`
+- Floor surfaces: `<floor>.<room>.floor.main` or another descriptive suffix
+- Safety colliders: `<floor>.<area>.<purpose>.safetyCollider`
+- Scene objects: `<floor>.<object>.scene_object`
+- Room connections: `<floor>.<room_a>_to_<room_b>.connection`
+
+IDs must be stable and human-readable. Do not use whole path segments such as
+`former`, `removed`, or `debugonlyremoval`; current openings are represented by
+the absence of a wall span or by a current wall `gaps` range.
+
+## Add or remove a wall
+
+Edit the target floor's `walls` array. A wall definition needs an `id`,
+`sourceId`, `floorId`, `wallKind`, optional `rooms`, and either a `run` or
+explicit `segments`. Use `run.gaps` for current open passages. Removing a wall
+means deleting that source wall definition; do not keep a tombstone or a hidden
+skip entry.
+
+The wall generator in `src/scene/level/generateWalls.ts` owns downstream splits
+and produces wall meshes, gameplay colliders, and debug metadata with the same
+wall source ID.
+
+## Add or remove a floor surface
+
+Edit the floor's `floorSurfaces` array. Each surface has bounds, a source ID,
+and optional `roomId`, `elevation`, and `purpose`. Removing a floor surface means
+removing that source entry. Generator-owned cutouts are allowed when they derive
+from current source data such as stairwell openings.
+
+## Add a safety collider
+
+Prefer source-backed definitions in `stairSafetyColliders.ts` for stair and void
+protection. Give every collider a precise `purpose` and a
+`*.safetyCollider` source ID. Hardcoded bounds are acceptable only when they are
+the explicit collider definition or derived from stair geometry.
+
+## Add a visible door, trim, or object
+
+Add visible, non-wall affordances as `sceneObjects` with a `*.scene_object`
+source ID and an explicit `colliderPolicy`. A semantic `roomConnection` can
+explain adjacency, but it must not be relied on to create or remove collision
+geometry.
+
+## Inspect runtime source IDs
+
+Open the immersive scene with the required overrides:
+
+```text
+http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
+```
+
+Then use the browser console:
+
+```js
+window.portfolio.debugSolids.setEnabled(true);
+window.portfolio.debugColliders.setEnabled(true);
+window.portfolio.debugSolids.getSolidsBySourceId(
+  'upper.upper_landing.south_wall'
+);
+window.portfolio.debugColliders.getCollidersBySourceId(
+  'upper.stairwell.northBannister.safetyCollider'
+);
+```
+
+Hex debug IDs are useful labels, but source IDs are the primary assertions for
+walls, floors, safety colliders, and scene-object colliders.
+
+## Verification commands
+
+Run these before opening a PR:
+
+```bash
+npm run format:write
+npm run lint
+npm run test:ci
+npx playwright test playwright/immersive-stairs-roundtrip.spec.ts
+npm run docs:check
+npm run build
+npm run smoke
+```

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1076,7 +1076,7 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   }
 });
 
-test('upper landing-side passage removes targeted wall and colliders', async ({
+test('debug APIs expose source IDs and leave the upper passage open', async ({
   page,
 }) => {
   test.slow();
@@ -1098,8 +1098,10 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
     const knownWallSolids = debugSolids.getSolidsBySourceId(knownWallSourceId);
     const knownWallColliders =
       debugColliders.getCollidersBySourceId(knownWallSourceId);
+    const knownFloorSourceId = 'upper.upperLanding.floor.main';
+    const knownSafetySourceId = 'upper.stairwell.northBannister.safetyCollider';
 
-    const formerWallBounds = {
+    const openPassageWallBounds = {
       minX: 3.875,
       maxX: 8.525,
       minZ: -16.25,
@@ -1111,20 +1113,20 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
         (solid) =>
           solid.name === 'WallSegment' &&
           solid.parentPath === 'Scene/Group/UpperWallSegments' &&
-          Math.abs(solid.bounds.min.x - formerWallBounds.minX) < 0.001 &&
-          Math.abs(solid.bounds.max.x - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(solid.bounds.min.z - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(solid.bounds.max.z - formerWallBounds.maxZ) < 0.001
+          Math.abs(solid.bounds.min.x - openPassageWallBounds.minX) < 0.001 &&
+          Math.abs(solid.bounds.max.x - openPassageWallBounds.maxX) < 0.001 &&
+          Math.abs(solid.bounds.min.z - openPassageWallBounds.minZ) < 0.001 &&
+          Math.abs(solid.bounds.max.z - openPassageWallBounds.maxZ) < 0.001
       );
     const matchingColliderBounds = debugColliders
       .getColliders()
       .filter(
         (collider) =>
           collider.floor === 'upper' &&
-          Math.abs(collider.bounds.minX - formerWallBounds.minX) < 0.001 &&
-          Math.abs(collider.bounds.maxX - formerWallBounds.maxX) < 0.001 &&
-          Math.abs(collider.bounds.minZ - formerWallBounds.minZ) < 0.001 &&
-          Math.abs(collider.bounds.maxZ - formerWallBounds.maxZ) < 0.001
+          Math.abs(collider.bounds.minX - openPassageWallBounds.minX) < 0.001 &&
+          Math.abs(collider.bounds.maxX - openPassageWallBounds.maxX) < 0.001 &&
+          Math.abs(collider.bounds.minZ - openPassageWallBounds.minZ) < 0.001 &&
+          Math.abs(collider.bounds.maxZ - openPassageWallBounds.maxZ) < 0.001
       );
     const openingSamples = [
       { x: 5.5, z: -16, floorId: 'upper' as const },
@@ -1150,6 +1152,12 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
       knownWallColliderSourceIds: knownWallColliders.map(
         (collider) => collider.sourceId
       ),
+      knownFloorSolidSourceIds: debugSolids
+        .getSolidsBySourceId(knownFloorSourceId)
+        .map((solid) => solid.sourceId),
+      knownSafetyColliderSourceIds: debugColliders
+        .getCollidersBySourceId(knownSafetySourceId)
+        .map((collider) => collider.sourceId),
       matchingWallSolidCount: matchingWallSolids.length,
       matchingColliderBoundsCount: matchingColliderBounds.length,
       formerVoidGuardNames: debugColliders
@@ -1179,6 +1187,12 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
   );
   expect(targetState.knownWallColliderSourceIds).toContain(
     'upper.upper_landing.south_wall'
+  );
+  expect(targetState.knownFloorSolidSourceIds).toContain(
+    'upper.upperLanding.floor.main'
+  );
+  expect(targetState.knownSafetyColliderSourceIds).toContain(
+    'upper.stairwell.northBannister.safetyCollider'
   );
   expect(targetState.solidById).toBeUndefined();
   expect(targetState.collider300A).toBeUndefined();

--- a/src/assets/floorPlan/wallSegments.ts
+++ b/src/assets/floorPlan/wallSegments.ts
@@ -13,8 +13,6 @@ import {
 
 export interface WallSegmentInstance {
   segment: CombinedWallSegment;
-  /** Stable identifier for correlating generated meshes with the source segment. */
-  segmentId: string;
   /** Semantic source identifier for generated legacy wall segments. */
   sourceId: LevelSourceId;
   center: { x: number; y: number; z: number };
@@ -158,7 +156,6 @@ export function createWallSegmentInstances(
 
     instances.push({
       segment,
-      segmentId: createSegmentId(segment),
       sourceId: createSegmentSourceId(segment, options),
       center,
       dimensions: { width, height, depth },
@@ -170,20 +167,6 @@ export function createWallSegmentInstances(
   });
 
   return instances;
-}
-
-function formatPoint(point: { x: number; z: number }): string {
-  return `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-}
-
-function createSegmentId(segment: CombinedWallSegment): string {
-  const start = formatPoint(segment.start);
-  const end = formatPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-  return [segment.orientation, start, end, rooms || 'none'].join('|');
 }
 
 function formatSourceCoordinate(value: number): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,6 +162,7 @@ import {
   registerSceneObjectColliders,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
+import type { LevelSourceMetadata } from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -988,13 +989,8 @@ const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
 const colliderSourceMetadata = new Map<
   RectCollider,
-  {
-    sourceId:
-      | WallSegmentInstance['sourceId']
-      | LevelSafetyCollider['sourceId']
-      | SceneObjectDefinition['sourceId'];
+  LevelSourceMetadata & {
     sourceType: 'wall' | 'safetyCollider' | 'sceneObject';
-    purpose?: string;
   }
 >();
 const upperFloorColliders: RectCollider[] = [];

--- a/src/scene/level/__tests__/sourceEditProof.test.ts
+++ b/src/scene/level/__tests__/sourceEditProof.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import { WALL_THICKNESS } from '../../../assets/floorPlan';
+import { generateFloorSurfaces } from '../generateFloorSurfaces';
+import { generateWallSegmentInstances } from '../generateWalls';
+import type { FloorDefinition } from '../schema';
+import { assertLevelSourceId } from '../sourceIds';
+
+const sourceId = (value: string) => assertLevelSourceId(value);
+
+const testFloor = (): FloorDefinition => ({
+  id: 'test',
+  name: 'Test Floor',
+  outline: [
+    [0, 0],
+    [8, 0],
+    [8, 4],
+    [0, 4],
+  ],
+  rooms: [
+    {
+      id: 'left',
+      sourceId: sourceId('test.left.room'),
+      name: 'Left',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+      ledColor: 0xffffff,
+    },
+    {
+      id: 'right',
+      sourceId: sourceId('test.right.room'),
+      name: 'Right',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+      ledColor: 0xffffff,
+    },
+  ],
+  walls: [
+    {
+      id: 'left-north-wall',
+      sourceId: sourceId('test.left.north_wall'),
+      floorId: 'test',
+      wallKind: 'wall',
+      rooms: ['left'],
+      run: { start: { x: 0, z: 4 }, end: { x: 4, z: 4 } },
+    },
+    {
+      id: 'right-north-wall',
+      sourceId: sourceId('test.right.north_wall'),
+      floorId: 'test',
+      wallKind: 'wall',
+      rooms: ['right'],
+      run: { start: { x: 4, z: 4 }, end: { x: 8, z: 4 } },
+    },
+  ],
+  floorSurfaces: [
+    {
+      id: 'left-floor',
+      sourceId: sourceId('test.left.floor_surface'),
+      floorId: 'test',
+      roomId: 'left',
+      bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+    },
+    {
+      id: 'right-floor',
+      sourceId: sourceId('test.right.floor_surface'),
+      floorId: 'test',
+      roomId: 'right',
+      bounds: { minX: 4, maxX: 8, minZ: 0, maxZ: 4 },
+    },
+  ],
+});
+
+const options = {
+  coordinateScale: 1,
+  baseElevation: 0,
+  wallHeight: 3,
+  wallThickness: WALL_THICKNESS,
+  fenceHeight: 1,
+  fenceThickness: 0.25,
+  getRoomCategory: () => 'interior' as const,
+};
+
+describe('declarative source edit proof', () => {
+  it('adds and removes generated wall meshes and colliders from wall source data', () => {
+    const base = testFloor();
+    const addedSourceId = sourceId('test.left.south_wall');
+    const withWall: FloorDefinition = {
+      ...base,
+      walls: [
+        ...base.walls,
+        {
+          id: 'left-south-wall',
+          sourceId: addedSourceId,
+          floorId: 'test',
+          wallKind: 'wall',
+          rooms: ['left'],
+          run: { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        },
+      ],
+    };
+
+    const baseline = generateWallSegmentInstances(base, options);
+    const added = generateWallSegmentInstances(withWall, options);
+    const removedAgain = generateWallSegmentInstances(
+      {
+        ...withWall,
+        walls: withWall.walls.filter((wall) => wall.sourceId !== addedSourceId),
+      },
+      options
+    );
+
+    expect(baseline.some((wall) => wall.sourceId === addedSourceId)).toBe(
+      false
+    );
+    expect(added.some((wall) => wall.sourceId === addedSourceId)).toBe(true);
+    expect(
+      added.find((wall) => wall.sourceId === addedSourceId)?.collider
+    ).toMatchObject({
+      minX: -0.25,
+      maxX: 4.25,
+      minZ: -0.5,
+      maxZ: 0,
+    });
+    expect(removedAgain.some((wall) => wall.sourceId === addedSourceId)).toBe(
+      false
+    );
+  });
+
+  it('keeps semantic room connections from generating or removing wall geometry', () => {
+    const base = testFloor();
+    const connected: FloorDefinition = {
+      ...base,
+      roomConnections: [
+        {
+          id: 'left-to-right',
+          sourceId: sourceId('test.left_to_right.connection'),
+          floorId: 'test',
+          rooms: ['left', 'right'],
+          purpose: 'semantic adjacency only',
+        },
+      ],
+    };
+
+    expect(generateWallSegmentInstances(connected, options)).toEqual(
+      generateWallSegmentInstances(base, options)
+    );
+  });
+
+  it('adds floor surface output from floorSurface source data', () => {
+    const base = testFloor();
+    const extraSourceId = sourceId('test.threshold.floor_surface');
+    const withSurface: FloorDefinition = {
+      ...base,
+      floorSurfaces: [
+        ...base.floorSurfaces,
+        {
+          id: 'threshold-floor',
+          sourceId: extraSourceId,
+          floorId: 'test',
+          bounds: { minX: 3.75, maxX: 4.25, minZ: 1, maxZ: 3 },
+          purpose: 'authoring proof threshold surface',
+        },
+      ],
+    };
+
+    const baseline = generateFloorSurfaces(base, { scale: 1 });
+    const edited = generateFloorSurfaces(withSurface, { scale: 1 });
+
+    expect(baseline.tiles.some((tile) => tile.sourceId === extraSourceId)).toBe(
+      false
+    );
+    expect(edited.tiles.some((tile) => tile.sourceId === extraSourceId)).toBe(
+      true
+    );
+  });
+});

--- a/src/scene/level/generateWalls.ts
+++ b/src/scene/level/generateWalls.ts
@@ -116,7 +116,6 @@ function createWallInstance(
 
   return {
     segment,
-    segmentId: createSegmentId(segment),
     sourceId: segment.sourceWall.sourceId,
     center,
     dimensions: { width, height, depth },
@@ -335,19 +334,6 @@ function uniqueRoomWalls(
     seen.add(key);
     return true;
   });
-}
-
-function createSegmentId(segment: CombinedWallSegment): string {
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-  return [
-    segment.orientation,
-    formatPoint(segment.start),
-    formatPoint(segment.end),
-    rooms || 'none',
-  ].join('|');
 }
 
 function formatPoint(point: { x: number; z: number }): string {

--- a/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
+++ b/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
@@ -14,7 +14,6 @@ function createWallInstance(
       end: { x: 4, z: 0 },
       rooms: [{ id: 'livingRoom', wall: 'north' }],
     },
-    segmentId: 'segment-default',
     sourceId:
       'ground.generated_wall.horizontal.xp0_zp0_to_xp4000_zp0.living_room_north' as WallSegmentInstance['sourceId'],
     center: { x: 2, y: 3, z: 0 },
@@ -34,7 +33,6 @@ describe('createWallSegmentMeshes', () => {
     const instances: WallSegmentInstance[] = [
       createWallInstance({
         center: { x: -2, y: 3, z: 1 },
-        segmentId: 'segment-vertical',
         segment: {
           orientation: 'vertical',
           start: { x: -3, z: 0 },
@@ -49,7 +47,6 @@ describe('createWallSegmentMeshes', () => {
         dimensions: { width: 0.28, height: 2.4, depth: 3 },
         isFence: true,
         thickness: 0.28,
-        segmentId: 'segment-horizontal',
         segment: {
           orientation: 'horizontal',
           start: { x: 4.5, z: -5.5 },
@@ -86,7 +83,6 @@ describe('createWallSegmentMeshes', () => {
         instances[index]?.isSharedInterior ?? false
       );
       expect(mesh.userData.thickness).toBe(instances[index]?.thickness);
-      expect(mesh.userData.segmentId).toBe(instances[index]?.segmentId);
       expect(mesh.userData.levelSourceId).toBe(instances[index]?.sourceId);
       expect(mesh.userData.levelSource).toEqual({
         sourceId: instances[index]?.sourceId,

--- a/src/scene/structures/wallSegmentsMesh.ts
+++ b/src/scene/structures/wallSegmentsMesh.ts
@@ -49,9 +49,6 @@ export function createWallSegmentMeshes(
     mesh.name = instance.isFence ? FENCE_MESH_NAME : WALL_MESH_NAME;
     mesh.position.set(instance.center.x, instance.center.y, instance.center.z);
 
-    // Store a compact identifier instead of the full segment object to avoid
-    // retaining large or circular references in Three.js metadata.
-    mesh.userData.segmentId = instance.segmentId;
     mesh.userData.levelSourceId = instance.sourceId;
     mesh.userData.levelSource = {
       sourceId: instance.sourceId,

--- a/src/tests/wallSegments.test.ts
+++ b/src/tests/wallSegments.test.ts
@@ -125,16 +125,10 @@ describe('createWallSegmentInstances', () => {
 
   it('assigns valid unique semantic source IDs without array index suffixes', () => {
     const sourceIds = groundWallInstances.map((instance) => instance.sourceId);
-    const segmentIds = groundWallInstances.map(
-      (instance) => instance.segmentId
-    );
 
     expect(sourceIds.every(isLevelSourceId)).toBe(true);
     expect(new Set(sourceIds).size).toBe(sourceIds.length);
     expect(sourceIds.every((sourceId) => !/[.|_-]\d+$/.test(sourceId))).toBe(
-      true
-    );
-    expect(segmentIds.every((segmentId) => !/[.|_-]\d+$/.test(segmentId))).toBe(
       true
     );
   });


### PR DESCRIPTION
### Motivation
- Remove remaining migration compatibility scaffolding so the declarative level source is the single authoring surface for rooms, walls, floors, safety colliders and scene objects.
- Prove by test and debug assertions that direct edits to source data regenerate final geometry and collision without relying on legacy segment/tombstone bridges.

### Description
- Removed legacy wall `segmentId` bridge and stopped writing `segmentId` into mesh `userData`, and now rely on the stable `sourceId`/`levelSource` metadata shape for tracing generated wall geometry. (`src/assets/floorPlan/wallSegments.ts`, `src/scene/structures/wallSegmentsMesh.ts`, `src/scene/level/generateWalls.ts`)
- Consolidated collider/source metadata typing to use a single `LevelSourceMetadata` shape for wall, safety-collider, and scene-object entries. (`src/main.ts`)
- Added focused source-edit proof unit tests that assert adding/removing walls and adding floor surfaces updates generated meshes/colliders and that semantic `roomConnections` do not create/remove geometry. (`src/scene/level/__tests__/sourceEditProof.test.ts`)
- Strengthened Playwright debug coverage to assert runtime debug solids/colliders by `sourceId` for walls, floors, and safety colliders while keeping the open upper passage behavior intact. (`playwright/immersive-stairs-roundtrip.spec.ts`)
- Added final human-facing editing workflow docs and updated the design doc to mark migrated areas complete and list adapter-oriented edge cases. (`docs/design/editing-level-data.md`, `docs/design/declarative-level-source-of-truth.md`)

### Testing
- Ran formatting: `npm run format:write` — passed.
- Ran lint: `npm run lint` — passed.
- Ran focused unit tests then full suite: `npm run test:ci` — passed (all tests in suite passed).
- Ran docs check: `npm run docs:check` — passed (link checker produced external reachability warnings but no failures).
- Built and smoke-tested: `npm run build` and `npm run smoke` — passed.
- Playwright browser setup and end-to-end debug checks: `npx playwright install chromium`, `npx playwright install-deps chromium`, `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — passed (Playwright stairs/debug spec passed).
- Performed repository checks: `git diff --check` and `./scripts/scan-secrets.py` — no high-risk issues detected.

If you want, I can open a PR using the branch pattern `codex/<short-slug>` and include a short reviewer checklist for manual QA of the immersive preview.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a338cab88e8832f9d2b47ffc6214734)