### PR TITLE
Remove redundant upper stair safety collider (4008)

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -813,7 +813,7 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   }
   expect(debugColliderNames).toContain('UpperStairWestBannisterGuard');
   expect(debugColliderNames).toContain('UpperStairNorthBannisterGuard');
-  expect(debugColliderNames).toContain('UpperStairHiddenRunVoidGuard');
+  expect(debugColliderNames).not.toContain('UpperStairHiddenRunVoidGuard');
 
   const debugColliderIds = debugColliders.map((collider) => collider.id);
   expect(debugColliderIds.length).toBeGreaterThan(0);
@@ -856,13 +856,17 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   }, '400A');
   expect(northBannisterById?.id).toBe('400A');
   expect(northBannisterById?.name).toBe('UpperStairNorthBannisterGuard');
-  const hiddenRunGuard = debugColliders.find(
-    (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
-  );
+  const hiddenRunGuardById = await page.evaluate((id) => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    return debugApi.getColliderById(id);
+  }, '4008');
+  expect(hiddenRunGuardById).toBeUndefined();
   expect(westBannister).toBeDefined();
   expect(northBannister).toBeDefined();
-  expect(hiddenRunGuard).toBeDefined();
-  if (!westBannister || !northBannister || !hiddenRunGuard) {
+  if (!westBannister || !northBannister) {
     throw new Error('Missing upper stair guard debug collider');
   }
 
@@ -945,11 +949,6 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
     0.08,
     'north bannister max x'
   );
-  expect(hiddenRunGuard.bounds.minZ).toBeGreaterThan(-24);
-  expect(hiddenRunGuard.bounds.minZ).toBeLessThan(-23.2);
-  expect(hiddenRunGuard.bounds.maxZ).toBeGreaterThan(-19.3);
-  expect(hiddenRunGuard.bounds.maxZ).toBeLessThan(-19.0);
-
   const stairMetrics = await getStairMetrics(page);
   const visibleMiddleLandingArtifactSamples: NamedPosition[] = [
     {
@@ -999,11 +998,6 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
       name: 'south no-floor cutout beyond StaircaseLanding slab',
       target: { x: 12.99, z: -31.35, floorId: 'upper' as const },
       expectedBlocker: 'UpperStairwellLandingGuard-2',
-    },
-    {
-      name: 'west side-entry hidden-run guard beside stair cutout',
-      target: { x: 10.59, z: -23.72, floorId: 'upper' as const },
-      expectedBlocker: 'UpperStairHiddenRunVoidGuard',
     },
     {
       name: 'raw lower-step upper-floor occupancy probe at descent centerline',
@@ -1636,16 +1630,6 @@ test('upper landing opens west into upstairs rooms and blocks side/back stair en
   expect(await canOccupyPosition(page, westEdgeFloorClearance)).toBe(true);
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(true);
   expect(await getBlockingColliderNames(page, hiddenStairTopRun)).toEqual([]);
-  expect(
-    await canOccupyPosition(page, { x: 12.7, z: -23.72, floorId: 'upper' })
-  ).toBe(false);
-  expect(
-    await getBlockingColliderNames(page, {
-      x: 12.7,
-      z: -23.72,
-      floorId: 'upper',
-    })
-  ).toContain('UpperStairHiddenRunVoidGuard');
   for (const sample of formerLandingArtifactSamples) {
     expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
     expect(await canOccupyPosition(page, sample.target), sample.name).toBe(

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -22,7 +22,6 @@ const DECLARED_RUNTIME_COLLIDER_IDS = {
   UpperStairWestUpperVoidGuard: '4005',
   UpperStairEastLowerVoidGuard: '4006',
   UpperStairEastUpperVoidGuard: '4007',
-  UpperStairHiddenRunVoidGuard: '4008',
   UpperStairWestBannisterGuard: '4009',
   UpperStairNorthBannisterGuard: '400A',
   'UpperStairwellLandingGuard-1': '400B',

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -84,13 +84,8 @@ describe('stair safety collider source definitions', () => {
     expect(
       colliders.find(
         (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
-      )?.bounds
-    ).toEqual({
-      minX: 8.4,
-      maxX: 16.4,
-      minZ: -23.549999999999997,
-      maxZ: -21.030000000000005,
-    });
+      )
+    ).toBeUndefined();
     expect(
       colliders.find(
         (collider) => collider.name === 'UpperStairWestBannisterGuard'
@@ -135,7 +130,6 @@ describe('stair safety collider source definitions', () => {
       ['GroundStairLowerCornerGuard', '4002'],
       ['UpperStairEastLowerVoidGuard', '4006'],
       ['UpperStairEastUpperVoidGuard', '4007'],
-      ['UpperStairHiddenRunVoidGuard', '4008'],
       ['UpperStairWestBannisterGuard', '4009'],
       ['UpperStairNorthBannisterGuard', '400A'],
     ].forEach(([name, id]) => {
@@ -144,6 +138,15 @@ describe('stair safety collider source definitions', () => {
         getDeclaredColliderDebugId({ floor: 'upper', category: 'upper', name })
       ).toBe(id);
     });
+
+    expect(names.has('UpperStairHiddenRunVoidGuard')).toBe(false);
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairHiddenRunVoidGuard',
+      })
+    ).toBeUndefined();
 
     expect(
       getDeclaredColliderDebugId({

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -99,7 +99,6 @@ export const createUpperStairSafetyColliders = ({
   doorwayDepth,
   stairwellMarginX,
   stairTopZ,
-  stairTransitionMargin,
   stairLandingTriggerMargin,
   stairLayoutDirectionMultiplier,
   upperLandingRoomBounds,
@@ -172,14 +171,6 @@ export const createUpperStairSafetyColliders = ({
     hiddenStairBlockerStartZ + upperStairBannisterThickness;
   const upperStairNorthBannisterMaxX =
     upperStairwellOpening.maxX - upperStairBannisterThickness;
-  const upperStairDescentHandoffFarZ =
-    stairTopZ -
-    stairLayoutDirectionMultiplier *
-      (stairTransitionMargin + stairLandingTriggerMargin);
-  const upperStairHiddenRunGuardNearZ =
-    upperStairDescentHandoffFarZ -
-    stairLayoutDirectionMultiplier * playerRadius;
-
   return [
     {
       name: 'UpperStairEastLowerVoidGuard',
@@ -217,28 +208,6 @@ export const createUpperStairSafetyColliders = ({
       purpose: 'guard upper stairwell void edge',
       bounds,
     })),
-    {
-      name: 'UpperStairHiddenRunVoidGuard',
-      sourceId: sourceId('upper.stairwell.hiddenRun.safetyCollider'),
-      floor: 'upper',
-      category: 'void',
-      purpose: 'guard hidden stair run no-floor area',
-      bounds: {
-        minX: upperStairwellOpening.minX,
-        maxX: upperStairwellOpening.maxX,
-        minZ: Math.min(
-          upperStairHiddenRunGuardNearZ,
-          upperLandingDoorwayClearanceZ
-        ),
-        maxZ: Math.max(
-          upperStairHiddenRunGuardNearZ,
-          upperStairNorthBannisterBaseCenterZ -
-            upperStairBannisterThickness / 2 -
-            playerRadius -
-            0.01
-        ),
-      },
-    },
     {
       name: 'UpperStairWestBannisterGuard',
       sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),


### PR DESCRIPTION
### Motivation

- The cyan hidden-run stair safety collider (debug ID `4008`, `UpperStairHiddenRunVoidGuard`) is redundant after the declarative source migration because other safety colliders already bound the same void area.
- Remove the duplicate guard to simplify source data and prevent stale debug artifacts while keeping remaining stair guards intact.

### Description

- Removed the generated `UpperStairHiddenRunVoidGuard` entry from the output of `createUpperStairSafetyColliders(...)` in `src/scene/level/stairSafetyColliders.ts` and eliminated now-unused locals used only for that collider.
- Removed the declared debug ID mapping for `UpperStairHiddenRunVoidGuard: '4008'` from `src/scene/debug/colliderDebugIds.ts` and left subsequent IDs (`4009`, `400A`, etc.) unchanged.
- Updated unit tests in `src/scene/level/__tests__/stairSafetyColliders.test.ts` to assert the collider is absent and that `getDeclaredColliderDebugId(...)` for that name is `undefined`, while preserving assertions for `4006`, `4007`, `4009`, `400A`, and top-gap guards.
- Updated the Playwright spec `playwright/immersive-stairs-roundtrip.spec.ts` to assert the debug collider list does not contain `UpperStairHiddenRunVoidGuard` and that `debugColliders.getColliderById('4008')` returns `undefined`, while preserving remaining stair guard checks and traversal assertions.

### Testing

- Formatted files with `npm run format:write` (completed).
- Ran focused unit tests with `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/systems/movement/stairs.test.ts src/tests/mainImports.test.ts` and they passed.
- Ran full unit suite with `npm run test:ci` and observed all tests passed (`158 files`, `1203 tests`).
- Ran Playwright UI tests after installing browsers and deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, then `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, and the spec passed (`9 passed`).
- Ran lint with `npm run lint`, docs checks with `npm run docs:check`, and smoke with `npm run smoke`, all of which completed successfully.

Residual notes: Playwright required installing browser binaries and host deps during the run; no debug ID renumbering or tombstone records were added and remaining stair colliders and their declared IDs were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a2bdf3b4832fb4592ebd5c353935)