### PR TITLE
Remove redundant upper-stair hidden-run safety collider (4008)

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -813,7 +813,7 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   }
   expect(debugColliderNames).toContain('UpperStairWestBannisterGuard');
   expect(debugColliderNames).toContain('UpperStairNorthBannisterGuard');
-  expect(debugColliderNames).toContain('UpperStairHiddenRunVoidGuard');
+  expect(debugColliderNames).not.toContain('UpperStairHiddenRunVoidGuard');
 
   const debugColliderIds = debugColliders.map((collider) => collider.id);
   expect(debugColliderIds.length).toBeGreaterThan(0);
@@ -841,6 +841,15 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   expect(westBannisterById?.floor).toBe('upper');
   expect(westBannisterById?.category).toBe('upper');
 
+  const removedHiddenRunGuardById = await page.evaluate((id) => {
+    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
+    if (!debugApi) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    return debugApi.getColliderById(id);
+  }, '4008');
+  expect(removedHiddenRunGuardById).toBeUndefined();
+
   const westBannister = debugColliders.find(
     (collider) => collider.name === 'UpperStairWestBannisterGuard'
   );
@@ -856,13 +865,9 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   }, '400A');
   expect(northBannisterById?.id).toBe('400A');
   expect(northBannisterById?.name).toBe('UpperStairNorthBannisterGuard');
-  const hiddenRunGuard = debugColliders.find(
-    (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
-  );
   expect(westBannister).toBeDefined();
   expect(northBannister).toBeDefined();
-  expect(hiddenRunGuard).toBeDefined();
-  if (!westBannister || !northBannister || !hiddenRunGuard) {
+  if (!westBannister || !northBannister) {
     throw new Error('Missing upper stair guard debug collider');
   }
 
@@ -945,11 +950,6 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
     0.08,
     'north bannister max x'
   );
-  expect(hiddenRunGuard.bounds.minZ).toBeGreaterThan(-24);
-  expect(hiddenRunGuard.bounds.minZ).toBeLessThan(-23.2);
-  expect(hiddenRunGuard.bounds.maxZ).toBeGreaterThan(-19.3);
-  expect(hiddenRunGuard.bounds.maxZ).toBeLessThan(-19.0);
-
   const stairMetrics = await getStairMetrics(page);
   const visibleMiddleLandingArtifactSamples: NamedPosition[] = [
     {
@@ -999,11 +999,6 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
       name: 'south no-floor cutout beyond StaircaseLanding slab',
       target: { x: 12.99, z: -31.35, floorId: 'upper' as const },
       expectedBlocker: 'UpperStairwellLandingGuard-2',
-    },
-    {
-      name: 'west side-entry hidden-run guard beside stair cutout',
-      target: { x: 10.59, z: -23.72, floorId: 'upper' as const },
-      expectedBlocker: 'UpperStairHiddenRunVoidGuard',
     },
     {
       name: 'raw lower-step upper-floor occupancy probe at descent centerline',
@@ -1637,15 +1632,12 @@ test('upper landing opens west into upstairs rooms and blocks side/back stair en
   expect(await canOccupyPosition(page, hiddenStairTopRun)).toBe(true);
   expect(await getBlockingColliderNames(page, hiddenStairTopRun)).toEqual([]);
   expect(
-    await canOccupyPosition(page, { x: 12.7, z: -23.72, floorId: 'upper' })
-  ).toBe(false);
-  expect(
     await getBlockingColliderNames(page, {
       x: 12.7,
       z: -23.72,
       floorId: 'upper',
     })
-  ).toContain('UpperStairHiddenRunVoidGuard');
+  ).not.toContain('UpperStairHiddenRunVoidGuard');
   for (const sample of formerLandingArtifactSamples) {
     expectSampleOnPhysicalStaircaseLanding(sample, stairMetrics);
     expect(await canOccupyPosition(page, sample.target), sample.name).toBe(

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -22,7 +22,6 @@ const DECLARED_RUNTIME_COLLIDER_IDS = {
   UpperStairWestUpperVoidGuard: '4005',
   UpperStairEastLowerVoidGuard: '4006',
   UpperStairEastUpperVoidGuard: '4007',
-  UpperStairHiddenRunVoidGuard: '4008',
   UpperStairWestBannisterGuard: '4009',
   UpperStairNorthBannisterGuard: '400A',
   'UpperStairwellLandingGuard-1': '400B',

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -82,15 +82,10 @@ describe('stair safety collider source definitions', () => {
       maxZ: -27.799999999999997,
     });
     expect(
-      colliders.find(
+      colliders.some(
         (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
-      )?.bounds
-    ).toEqual({
-      minX: 8.4,
-      maxX: 16.4,
-      minZ: -23.549999999999997,
-      maxZ: -21.030000000000005,
-    });
+      )
+    ).toBe(false);
     expect(
       colliders.find(
         (collider) => collider.name === 'UpperStairWestBannisterGuard'
@@ -135,7 +130,6 @@ describe('stair safety collider source definitions', () => {
       ['GroundStairLowerCornerGuard', '4002'],
       ['UpperStairEastLowerVoidGuard', '4006'],
       ['UpperStairEastUpperVoidGuard', '4007'],
-      ['UpperStairHiddenRunVoidGuard', '4008'],
       ['UpperStairWestBannisterGuard', '4009'],
       ['UpperStairNorthBannisterGuard', '400A'],
     ].forEach(([name, id]) => {
@@ -144,6 +138,15 @@ describe('stair safety collider source definitions', () => {
         getDeclaredColliderDebugId({ floor: 'upper', category: 'upper', name })
       ).toBe(id);
     });
+
+    expect(names.has('UpperStairHiddenRunVoidGuard')).toBe(false);
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairHiddenRunVoidGuard',
+      })
+    ).not.toBe('4008');
 
     expect(
       getDeclaredColliderDebugId({

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -99,7 +99,6 @@ export const createUpperStairSafetyColliders = ({
   doorwayDepth,
   stairwellMarginX,
   stairTopZ,
-  stairTransitionMargin,
   stairLandingTriggerMargin,
   stairLayoutDirectionMultiplier,
   upperLandingRoomBounds,
@@ -172,14 +171,6 @@ export const createUpperStairSafetyColliders = ({
     hiddenStairBlockerStartZ + upperStairBannisterThickness;
   const upperStairNorthBannisterMaxX =
     upperStairwellOpening.maxX - upperStairBannisterThickness;
-  const upperStairDescentHandoffFarZ =
-    stairTopZ -
-    stairLayoutDirectionMultiplier *
-      (stairTransitionMargin + stairLandingTriggerMargin);
-  const upperStairHiddenRunGuardNearZ =
-    upperStairDescentHandoffFarZ -
-    stairLayoutDirectionMultiplier * playerRadius;
-
   return [
     {
       name: 'UpperStairEastLowerVoidGuard',
@@ -217,28 +208,6 @@ export const createUpperStairSafetyColliders = ({
       purpose: 'guard upper stairwell void edge',
       bounds,
     })),
-    {
-      name: 'UpperStairHiddenRunVoidGuard',
-      sourceId: sourceId('upper.stairwell.hiddenRun.safetyCollider'),
-      floor: 'upper',
-      category: 'void',
-      purpose: 'guard hidden stair run no-floor area',
-      bounds: {
-        minX: upperStairwellOpening.minX,
-        maxX: upperStairwellOpening.maxX,
-        minZ: Math.min(
-          upperStairHiddenRunGuardNearZ,
-          upperLandingDoorwayClearanceZ
-        ),
-        maxZ: Math.max(
-          upperStairHiddenRunGuardNearZ,
-          upperStairNorthBannisterBaseCenterZ -
-            upperStairBannisterThickness / 2 -
-            playerRadius -
-            0.01
-        ),
-      },
-    },
     {
       name: 'UpperStairWestBannisterGuard',
       sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),


### PR DESCRIPTION
### Motivation
- Collider 4008 / `UpperStairHiddenRunVoidGuard` was a redundant safety collider guarding the upper stair hidden-run/landing void and is no longer needed after the declarative source migration.
- Keep remaining upper stair guards and their debug IDs stable so stair edges and traversal remain protected.

### Description
- Removed the generated `UpperStairHiddenRunVoidGuard` entry from `createUpperStairSafetyColliders(...)` in `src/scene/level/stairSafetyColliders.ts` and removed now-unused locals used only by that collider.
- Removed the declared debug ID mapping for `UpperStairHiddenRunVoidGuard` / `4008` from `src/scene/debug/colliderDebugIds.ts` without renumbering other IDs.
- Updated unit tests in `src/scene/level/__tests__/stairSafetyColliders.test.ts` to assert the collider is absent and that `getDeclaredColliderDebugId(...)` does not return `4008` for that name while keeping assertions for `4006`, `4007`, `4009`, `400A`, and top-gap blockers.
- Updated the Playwright spec `playwright/immersive-stairs-roundtrip.spec.ts` to assert `UpperStairHiddenRunVoidGuard` / `4008` is absent and added a targeted `debugColliders.getColliderById('4008')` check while preserving traversal and remaining-guard checks.

### Testing
- Ran `npm run format:write` — succeeded.
- Ran `rg -n "4008|UpperStairHiddenRunVoidGuard|upper\.stairwell\.hiddenRun\.safetyCollider|hiddenRun" src playwright docs` — references updated to reflect removal.
- Ran focused unit tests: `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/systems/movement/stairs.test.ts src/tests/mainImports.test.ts` — all passed.
- Attempted E2E: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — initial run failed due to missing Playwright browser executable; after `npx playwright install chromium` the run aborted because host system is missing required browser dependencies (Playwright install succeeded but the environment lacks required OS libs), so the Playwright E2E could not be fully executed here.
- Ran full test suite: `npm run test:ci` — all Vitest tests passed (158 files, 1203 tests in this environment).
- Ran `npm run lint`, `npm run docs:check`, and `npm run smoke` — all succeeded.

Residual risk: Playwright E2E verification of runtime behavior (walking the stairs in a real browser environment) is blocked by missing host browser dependencies here; recommend running the updated Playwright spec in CI or a dev machine with Playwright deps installed to confirm runtime traversal and debug-collider visuals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a2ca0778832fa685d6c1f3d6eb22)