### PR TITLE
Add Playwright immersive test helpers and apply behavior-first taxonomy

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -138,3 +138,26 @@ npx vitest run src/scene/level/__tests__/generateWalls.test.ts
 npx vitest run src/scene/level/__tests__/generateFloorSurfaces.test.ts
 npx playwright test playwright/immersive-stairs-roundtrip.spec.ts
 ```
+
+## Immersive test taxonomy
+
+Keep immersive coverage behavior-first unless a test is explicitly validating debug or generator
+contracts:
+
+1. **Behavior / interaction tests** assert player promises: intended paths remain traversable,
+   meaningful voids or blocked regions stay unoccupiable, and openings stay open. These tests should
+   prefer occupancy/path helpers over exact collider names, raw debug IDs, or production-scene solid
+   bounds unless the name or ID is itself the user-facing contract.
+2. **Debug/provenance tests** assert that representative source IDs and source metadata remain
+   exposed through debug APIs. Keep these checks narrow and separate from movement behavior so debug
+   refactors do not look like product regressions.
+3. **Generator tests** may assert exact bounds and geometry for tiny synthetic fixtures. Avoid exact
+   production-scene collider or solid pinning unless the assertion is a deliberate regression test
+   and the test explains why.
+4. **Registry/ID tests** may assert raw debug IDs only for declared debug-ID registry behavior. Do
+   not use raw IDs to prove player movement, openings, or blocked regions.
+
+For Playwright stair coverage, prefer the thin helpers in
+`playwright/helpers/immersiveAssertions.ts` for occupancy, blocking, path traversal, and
+source-backed provenance assertions. Helpers that accept raw debug IDs are intentionally labelled as
+registry-only entry points.

--- a/playwright/helpers/immersiveAssertions.ts
+++ b/playwright/helpers/immersiveAssertions.ts
@@ -1,0 +1,233 @@
+import { expect, type Page } from '@playwright/test';
+
+export type ImmersiveFloorId = 'ground' | 'upper';
+
+export type ImmersiveSample = {
+  name: string;
+  target: { x: number; z: number; floorId?: ImmersiveFloorId };
+};
+
+type StepResult = {
+  movedX: boolean;
+  movedZ: boolean;
+  activeFloor: ImmersiveFloorId;
+  position: { x: number; y: number; z: number };
+  blockedBy?: string[];
+};
+
+type DebugSourceResult = {
+  id: string;
+  sourceId?: string;
+};
+
+declare global {
+  interface Window {
+    portfolio?: {
+      world?: {
+        movePlayerTo(target: {
+          x: number;
+          z: number;
+          floorId?: ImmersiveFloorId;
+        }): void;
+        stepPlayerForTest(step: { dx: number; dz: number }): StepResult;
+        getActiveFloor(): ImmersiveFloorId;
+        canOccupyPosition(target: {
+          x: number;
+          z: number;
+          floorId?: ImmersiveFloorId;
+        }): boolean;
+        getPlayerPosition(): { x: number; y: number; z: number };
+      };
+      debugColliders?: {
+        setEnabled(enabled: boolean): void;
+        getBlockingCollidersAt(target: {
+          x: number;
+          z: number;
+          floorId?: ImmersiveFloorId;
+        }): Array<{ id: string; name: string; sourceId?: string }>;
+        getColliderById(id: unknown): unknown;
+        getCollidersBySourceId(sourceId: unknown): DebugSourceResult[];
+      };
+      debugSolids?: {
+        setEnabled(enabled: boolean): void;
+        getSolidById(id: unknown): unknown;
+        getSolidsBySourceId(sourceId: unknown): DebugSourceResult[];
+      };
+    };
+  }
+}
+
+async function getCanOccupyResults(page: Page, samples: ImmersiveSample[]) {
+  return page.evaluate((nextSamples) => {
+    const world = window.portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+
+    return nextSamples.map((sample) => ({
+      name: sample.name,
+      canOccupy: world.canOccupyPosition(sample.target),
+    }));
+  }, samples);
+}
+
+export async function expectSamplesOccupiable(
+  page: Page,
+  samples: ImmersiveSample[]
+) {
+  const results = await getCanOccupyResults(page, samples);
+  for (const result of results) {
+    expect(result.canOccupy, result.name).toBe(true);
+  }
+}
+
+export async function expectSamplesBlocked(
+  page: Page,
+  samples: ImmersiveSample[]
+) {
+  const results = await getCanOccupyResults(page, samples);
+  for (const result of results) {
+    expect(result.canOccupy, result.name).toBe(false);
+  }
+}
+
+export async function expectNoBlockingCollidersAt(
+  page: Page,
+  samples: ImmersiveSample[]
+) {
+  const blockingCollidersBySample = await page.evaluate((nextSamples) => {
+    const debugColliders = window.portfolio?.debugColliders;
+    if (!debugColliders) {
+      throw new Error('Debug colliders API unavailable');
+    }
+
+    return nextSamples.map((sample) => ({
+      name: sample.name,
+      colliders: debugColliders
+        .getBlockingCollidersAt(sample.target)
+        .map((collider) => collider.name),
+    }));
+  }, samples);
+
+  for (const sample of blockingCollidersBySample) {
+    expect(sample.colliders, sample.name).toEqual([]);
+  }
+}
+
+export async function expectPathTraversable(
+  page: Page,
+  path: {
+    start: { x: number; z: number; floorId?: ImmersiveFloorId };
+    steps: { dx: number; dz: number; count: number }[];
+    expectedFloor?: ImmersiveFloorId;
+  }
+) {
+  const result = await page.evaluate((nextPath) => {
+    const world = window.portfolio?.world;
+    if (!world) {
+      throw new Error('World API unavailable');
+    }
+
+    world.movePlayerTo(nextPath.start);
+    const steps: StepResult[] = [];
+    for (const sequence of nextPath.steps) {
+      for (let index = 0; index < sequence.count; index += 1) {
+        const step = world.stepPlayerForTest({
+          dx: sequence.dx,
+          dz: sequence.dz,
+        });
+        steps.push(step);
+        const blockedAxis =
+          (sequence.dx !== 0 && !step.movedX) ||
+          (sequence.dz !== 0 && !step.movedZ);
+        if (blockedAxis) {
+          return { traversable: false, blockedStep: step, steps };
+        }
+        if (
+          nextPath.expectedFloor &&
+          step.activeFloor !== nextPath.expectedFloor
+        ) {
+          return { traversable: false, wrongFloorStep: step, steps };
+        }
+      }
+    }
+
+    return {
+      traversable: true,
+      finalPosition: world.getPlayerPosition(),
+      activeFloor: world.getActiveFloor(),
+      steps,
+    };
+  }, path);
+
+  expect(result.traversable, JSON.stringify(result)).toBe(true);
+  return result;
+}
+
+export async function expectSourceBackedColliderPresent(
+  page: Page,
+  sourceId: string
+) {
+  const colliders = await page.evaluate((nextSourceId) => {
+    const debugColliders = window.portfolio?.debugColliders;
+    if (!debugColliders) {
+      throw new Error('Debug colliders API unavailable');
+    }
+
+    debugColliders.setEnabled(true);
+    return debugColliders.getCollidersBySourceId(nextSourceId);
+  }, sourceId);
+
+  expect(colliders.length, sourceId).toBeGreaterThan(0);
+  expect(
+    colliders.map((collider) => collider.sourceId),
+    sourceId
+  ).toContain(sourceId);
+  return colliders;
+}
+
+export async function expectSourceBackedSolidPresent(
+  page: Page,
+  sourceId: string
+) {
+  const solids = await page.evaluate((nextSourceId) => {
+    const debugSolids = window.portfolio?.debugSolids;
+    if (!debugSolids) {
+      throw new Error('Debug solids API unavailable');
+    }
+
+    debugSolids.setEnabled(true);
+    return debugSolids.getSolidsBySourceId(nextSourceId);
+  }, sourceId);
+
+  expect(solids.length, sourceId).toBeGreaterThan(0);
+  expect(
+    solids.map((solid) => solid.sourceId),
+    sourceId
+  ).toContain(sourceId);
+  return solids;
+}
+
+// Raw debug IDs are reserved for debug registry tests only. Player behavior
+// tests should assert paths, occupancy, openings, or source-backed provenance.
+export async function getDebugColliderByRegistryId(page: Page, id: string) {
+  return page.evaluate((nextId) => {
+    const debugColliders = window.portfolio?.debugColliders;
+    if (!debugColliders) {
+      throw new Error('Debug colliders API unavailable');
+    }
+    return debugColliders.getColliderById(nextId);
+  }, id);
+}
+
+// Raw debug IDs are reserved for debug registry tests only. Player behavior
+// tests should assert paths, occupancy, openings, or source-backed provenance.
+export async function getDebugSolidByRegistryId(page: Page, id: string) {
+  return page.evaluate((nextId) => {
+    const debugSolids = window.portfolio?.debugSolids;
+    if (!debugSolids) {
+      throw new Error('Debug solids API unavailable');
+    }
+    return debugSolids.getSolidById(nextId);
+  }, id);
+}

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -2,6 +2,16 @@ import { expect, test, type Page } from '@playwright/test';
 
 import { UPPER_FLOOR_PLAN } from '../src/assets/floorPlan';
 
+import {
+  expectNoBlockingCollidersAt,
+  expectSamplesBlocked,
+  expectSamplesOccupiable,
+  expectSourceBackedColliderPresent,
+  expectSourceBackedSolidPresent,
+  getDebugColliderByRegistryId,
+  type ImmersiveSample,
+} from './helpers/immersiveAssertions';
+
 const IMMERSIVE_PREVIEW_URL = '/?mode=immersive&disablePerformanceFailover=1';
 const IMMERSIVE_READY_TIMEOUT_MS = 45_000;
 const PLAYER_RADIUS = 0.75;
@@ -230,10 +240,7 @@ function getUpperRoomCenter(roomId: string) {
   };
 }
 
-type NamedPosition = {
-  name: string;
-  target: { x: number; z: number; floorId?: FloorId };
-};
+type NamedPosition = ImmersiveSample;
 
 function expectSampleOnPhysicalStaircaseLanding(
   sample: NamedPosition,
@@ -820,22 +827,13 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   expect(new Set(debugColliderIds).size).toBe(debugColliderIds.length);
   expect(debugColliderIds.every((id) => /^[0-9A-F]{4,6}$/.test(id))).toBe(true);
   const firstDebugCollider = debugColliders[0];
-  const foundById = await page.evaluate((id) => {
-    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
-    if (!debugApi) {
-      throw new Error('Debug colliders API unavailable');
-    }
-    return debugApi.getColliderById(id);
-  }, firstDebugCollider.id);
+  const foundById = await getDebugColliderByRegistryId(
+    page,
+    firstDebugCollider.id
+  );
   expect(foundById).toEqual(firstDebugCollider);
 
-  const westBannisterById = await page.evaluate((id) => {
-    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
-    if (!debugApi) {
-      throw new Error('Debug colliders API unavailable');
-    }
-    return debugApi.getColliderById(id);
-  }, '4009');
+  const westBannisterById = await getDebugColliderByRegistryId(page, '4009');
   expect(westBannisterById?.id).toBe('4009');
   expect(westBannisterById?.name).toBe('UpperStairWestBannisterGuard');
   expect(westBannisterById?.floor).toBe('upper');
@@ -847,22 +845,10 @@ test('upper landing debug colliders exclude middle landing artifact', async ({
   const northBannister = debugColliders.find(
     (collider) => collider.name === 'UpperStairNorthBannisterGuard'
   );
-  const northBannisterById = await page.evaluate((id) => {
-    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
-    if (!debugApi) {
-      throw new Error('Debug colliders API unavailable');
-    }
-    return debugApi.getColliderById(id);
-  }, '400A');
+  const northBannisterById = await getDebugColliderByRegistryId(page, '400A');
   expect(northBannisterById?.id).toBe('400A');
   expect(northBannisterById?.name).toBe('UpperStairNorthBannisterGuard');
-  const hiddenRunGuardById = await page.evaluate((id) => {
-    const debugApi = (window as PortfolioWindow).portfolio?.debugColliders;
-    if (!debugApi) {
-      throw new Error('Debug colliders API unavailable');
-    }
-    return debugApi.getColliderById(id);
-  }, '4008');
+  const hiddenRunGuardById = await getDebugColliderByRegistryId(page, '4008');
   expect(hiddenRunGuardById).toBeUndefined();
   expect(westBannister).toBeDefined();
   expect(northBannister).toBeDefined();
@@ -1083,6 +1069,25 @@ test('upper landing-side passage removes targeted wall and colliders', async ({
   await waitForImmersiveReady(page);
   await walkStairCenterlineToUpperLanding(page);
 
+  await expectSourceBackedSolidPresent(page, 'upper.upper_landing.south_wall');
+  await expectSourceBackedColliderPresent(
+    page,
+    'upper.upper_landing.south_wall'
+  );
+  await expectSourceBackedSolidPresent(page, 'upper.upperLanding.floor.main');
+  await expectSourceBackedColliderPresent(
+    page,
+    'upper.stairwell.westBannister.safetyCollider'
+  );
+  await expectSourceBackedSolidPresent(
+    page,
+    'upper.upper_landing_to_loft_library.wall'
+  );
+  await expectSourceBackedColliderPresent(
+    page,
+    'upper.upper_landing_to_loft_library.wall'
+  );
+
   const targetState = await page.evaluate(() => {
     const debugSolids = (window as PortfolioWindow).portfolio?.debugSolids;
     const debugColliders = (window as PortfolioWindow).portfolio
@@ -1272,17 +1277,29 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
     floorId: 'ground' as const,
   };
 
+  await expectSamplesBlocked(
+    page,
+    blockedSamples.map((target, index) => ({
+      name: `ground stair squeeze corner ${index}`,
+      target,
+    }))
+  );
   for (const sample of blockedSamples) {
-    expect(await canOccupyPosition(page, sample)).toBe(false);
     await expect(async () => movePlayerTo(page, sample)).rejects.toThrow(
       /Cannot occupy/
     );
   }
 
-  for (const sample of livingRoomSamples) {
-    expect(await canOccupyPosition(page, sample)).toBe(true);
-  }
-  expect(await canOccupyPosition(page, lowerEntrance)).toBe(true);
+  await expectSamplesOccupiable(
+    page,
+    [...livingRoomSamples, lowerEntrance].map((target, index) => ({
+      name:
+        index < livingRoomSamples.length
+          ? `living room ${index}`
+          : 'lower entrance',
+      target,
+    }))
+  );
   await movePlayerTo(page, lowerEntrance);
   await expect(html).toHaveAttribute('data-active-floor', 'ground');
 
@@ -1331,17 +1348,16 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
   await walkStairCenterlineToUpperLanding(page);
   await expect(html).toHaveAttribute('data-active-floor', 'upper');
 
-  for (const landingOffset of [0.05, 0.4, 0.8]) {
-    const landingHandoffSample = {
+  const landingHandoffSamples = [0.05, 0.4, 0.8].map((landingOffset) => ({
+    name: `upper landing handoff offset ${landingOffset}`,
+    target: {
       x: stairCenterX,
       z: stairTopZ + stairDirection * landingOffset,
       floorId: 'upper' as const,
-    };
-    expect(await canOccupyPosition(page, landingHandoffSample)).toBe(true);
-    expect(await getBlockingColliderNames(page, landingHandoffSample)).toEqual(
-      []
-    );
-  }
+    },
+  }));
+  await expectSamplesOccupiable(page, landingHandoffSamples);
+  await expectNoBlockingCollidersAt(page, landingHandoffSamples);
 
   const westDescentLaneClearanceX =
     stairCenterX - stairHalfWidth + PLAYER_RADIUS + 1.05;


### PR DESCRIPTION
### Motivation
- Reduce test friction by separating player-behavior assertions from debug/provenance and raw registry assertions so implementation refactors (collider id/name changes) don't break behavior tests.
- Provide thin, reusable helpers for common occupancy, blocking, and path-traversal checks to make Playwright stair coverage easier to read and maintain.

### Description
- Add `playwright/helpers/immersiveAssertions.ts` providing thin wrappers: `expectSamplesOccupiable`, `expectSamplesBlocked`, `expectNoBlockingCollidersAt`, `expectPathTraversable`, `expectSourceBackedColliderPresent`, `expectSourceBackedSolidPresent`, and registry helpers `getDebugColliderByRegistryId` / `getDebugSolidByRegistryId` (registry-ID helpers are annotated as registry-only).
- Rewire `playwright/immersive-stairs-roundtrip.spec.ts` to use the new helpers for occupancy/blocking/path and to centralize provenance checks while leaving runtime scene and level geometry unchanged.
- Document the behavior-first test taxonomy in `docs/design/editing-level-data.md` describing when to use behavior, debug/provenance, generator, and registry/ID tests.

### Testing
- Formatted changed files with `npm run format:write` (files: helpers, spec, docs) — completed.
- Linted with `npm run lint` — passed (no blocking errors).
- Ran unit suite with `npm run test:ci` (Vitest) — passed (`1203 tests, 1203 passed`).
- Installed Playwright browsers and host deps with `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell` — completed.
- Ran the focused Playwright spec with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — passed (`9 passed`).
- Docs check with `npm run docs:check` — passed (link checker emitted fetch warnings for some external targets but did not fail).
- Smoke build with `npm run smoke` — passed.
- Secret scan `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3463f983cc832fbafd74bc807e7afb)