### PR TITLE
Rebalance geometry provenance tests

### DIFF
--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,13 +1,7 @@
 import { MeshBasicMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import {
-  FLOOR_PLAN,
-  FLOOR_PLAN_SCALE,
-  UPPER_FLOOR_PLAN,
-  WALL_THICKNESS,
-} from '../../../assets/floorPlan';
-import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { FLOOR_PLAN_SCALE, WALL_THICKNESS } from '../../../assets/floorPlan';
 import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
@@ -142,37 +136,37 @@ function getFloor(level: LevelDefinition, floorId: string): FloorDefinition {
 }
 
 describe('generateWallSegmentInstances', () => {
-  it('matches legacy ground wall and fence bounds while using declarative source IDs', () => {
-    const generated = generateWallSegmentInstances(
-      getFloor(PORTFOLIO_LEVEL, 'ground'),
-      wallOptions()
+  it('generates source-backed production wall and fence categories', () => {
+    const generated = [
+      ...generateWallSegmentInstances(
+        getFloor(PORTFOLIO_LEVEL, 'ground'),
+        wallOptions()
+      ),
+      ...generateWallSegmentInstances(
+        getFloor(PORTFOLIO_LEVEL, 'upper'),
+        wallOptions(9)
+      ),
+    ];
+    const sourceIds = generated.map((instance) => instance.sourceId);
+    const declaredWallSourceIds = PORTFOLIO_LEVEL.floors.flatMap((floor) =>
+      floor.walls.map((wall) => wall.sourceId)
     );
-    const legacy = createWallSegmentInstances(FLOOR_PLAN, {
-      floorId: 'ground',
-      ...wallOptions(),
-    });
 
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
-    );
+    expect(generated.length).toBeGreaterThan(0);
     expect(generated.every((instance) => instance.sourceId)).toBe(true);
-    expect(generated.map((instance) => instance.sourceId)).toContain(
-      'ground.living_room.south_wall'
+    expect(new Set(declaredWallSourceIds).size).toBe(
+      declaredWallSourceIds.length
     );
-  });
-
-  it('matches legacy upper wall bounds without legacy room-doorway generation', () => {
-    const generated = generateWallSegmentInstances(
-      getFloor(PORTFOLIO_LEVEL, 'upper'),
-      wallOptions(9)
-    );
-    const legacy = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
-      floorId: 'upper',
-      ...wallOptions(9),
-    });
-
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
+    expect(
+      sourceIds.every((sourceId) => declaredWallSourceIds.includes(sourceId))
+    ).toBe(true);
+    expect(generated.some((instance) => instance.isFence)).toBe(true);
+    expect(generated.some((instance) => !instance.isFence)).toBe(true);
+    expect(sourceIds).toEqual(
+      expect.arrayContaining([
+        'ground.living_room.south_wall',
+        'upper.upper_landing.south_wall',
+      ])
     );
   });
 
@@ -247,6 +241,7 @@ describe('generateWallSegmentInstances', () => {
       (wall) => wall.sourceId === addedWallSourceId
     );
     expect(generatedWall).toBeDefined();
+    // Synthetic proof floor keeps exactness close to the generator math.
     expect(generatedWall?.collider).toMatchObject({ minX: 8, maxX: 8.25 });
 
     const material = new MeshBasicMaterial({ color: 0xffffff });

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -67,9 +67,11 @@ const collectSafetyColliders = (): LevelSafetyCollider[] => [
 ];
 
 describe('stair safety collider source definitions', () => {
-  it('preserves key generated upper stair guard bounds', () => {
+  it('preserves key generated upper stair guard bounds for synthetic stair inputs', () => {
     const colliders = createUpperStairSafetyColliders(upperArgs);
 
+    // These exact bounds belong here because the test uses a tiny synthetic
+    // stair fixture instead of pinning the production PORTFOLIO_LEVEL scene.
     expect(
       colliders.find(
         (collider) => collider.name === 'UpperStairEastLowerVoidGuard'
@@ -147,6 +149,21 @@ describe('stair safety collider source definitions', () => {
         name: 'UpperStairTopGapBlockerEast',
       })
     ).toBe('4004');
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairHiddenRunVoidGuard',
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not generate the removed hidden-run safety collider', () => {
+    expect(
+      collectSafetyColliders().some(
+        (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
+      )
+    ).toBe(false);
   });
 
   it('keeps safety collider source IDs free of tombstone wording', () => {

--- a/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
+++ b/src/scene/structures/__tests__/wallSegmentsMesh.test.ts
@@ -29,6 +29,7 @@ function createWallInstance(
 
 describe('createWallSegmentMeshes', () => {
   it('creates wall and fence meshes with UV2 coordinates and metadata', () => {
+    // Synthetic wall instances keep segment/source exactness at the mesh adapter layer.
     const wallMaterial = new MeshBasicMaterial({ color: 0xffffff });
     const fenceMaterial = new MeshBasicMaterial({ color: 0x888888 });
     const instances: WallSegmentInstance[] = [

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs';
-
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
@@ -74,7 +72,6 @@ type MigratedFactoryPlacement = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    expectedColliderCount: 2,
     placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
@@ -86,7 +83,6 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    expectedColliderCount: 1,
     placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
@@ -96,7 +92,6 @@ const migratedFactories = [
   },
   {
     id: 'axel-studio-tracker',
-    expectedColliderCount: 2,
     placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
@@ -106,7 +101,6 @@ const migratedFactories = [
   },
   {
     id: 'wove-kitchen-loom',
-    expectedColliderCount: 2,
     placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
@@ -116,7 +110,6 @@ const migratedFactories = [
   },
   {
     id: 'pr-reaper-backyard-console',
-    expectedColliderCount: 2,
     placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
@@ -149,12 +142,7 @@ describe('migrated scene object collider policies', () => {
   });
 
   it('registers every existing factory collider with scene object source metadata', () => {
-    for (const {
-      id,
-      expectedColliderCount,
-      build,
-      placement,
-    } of migratedFactories) {
+    for (const { id, build, placement } of migratedFactories) {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
@@ -168,8 +156,8 @@ describe('migrated scene object collider policies', () => {
         metadata
       );
 
-      expect(factoryColliders, id).toHaveLength(expectedColliderCount);
-      expect(registered, id).toHaveLength(expectedColliderCount);
+      expect(factoryColliders.length, id).toBeGreaterThan(0);
+      expect(registered, id).toHaveLength(factoryColliders.length);
       for (const collider of factoryColliders) {
         expect(metadata.get(collider), id).toEqual({
           sourceId: definition!.sourceId,
@@ -178,25 +166,5 @@ describe('migrated scene object collider policies', () => {
         });
       }
     }
-  });
-
-  it('does not duplicate migrated placements as manual main-scene factory args', () => {
-    const mainSource = readFileSync('src/main.ts', 'utf8');
-
-    expect(mainSource).not.toMatch(
-      /createJobbotTerminal\(\{[\s\S]{0,500}x: 12,[\s\S]{0,200}z: 2/
-    );
-    expect(mainSource).not.toMatch(
-      /createAxelNavigator\(\{[\s\S]{0,500}x: 10,[\s\S]{0,200}z: -2/
-    );
-    expect(mainSource).not.toMatch(
-      /createWoveLoom\(\{[\s\S]{0,500}x: -7\.5,[\s\S]{0,200}z: 2\.5/
-    );
-    expect(mainSource).not.toMatch(
-      /createPrReaperConsole\(\{[\s\S]{0,500}x: 0,[\s\S]{0,200}z: 10/
-    );
-    expect(mainSource).not.toMatch(
-      /createFlywheelShowpiece\(\{[\s\S]{0,300}centerX: 5\.5/
-    );
   });
 });


### PR DESCRIPTION
### Motivation
- Reduce brittleness in production-level tests by moving exact geometry assertions into small synthetic fixtures. 
- Ensure PORTFOLIO_LEVEL tests focus on provenance invariants (source IDs, metadata, and categories) rather than pinning implementation geometry. 
- Remove expectations that referenced a removed hidden-run safety collider and other implementation-furniture assertions that over-constrain the runtime import/text surface.

### Description
- Replace legacy wall-vs-legacy-generator equality checks with provenance assertions in `src/scene/level/__tests__/generateWalls.test.ts`, verifying generated walls are source-backed, declared source IDs are unique, and wall/fence categories exist. 
- Preserve exact collider bounds only in synthetic proof-floor generator assertions and add a comment clarifying why exactness belongs there. 
- Mark the stair safety collider bounds test as a synthetic fixture in `src/scene/level/__tests__/stairSafetyColliders.test.ts`, assert the removed `UpperStairHiddenRunVoidGuard` has no declared debug ID, and verify it is not generated. 
- Remove brittle implementation-furniture assertions from `src/tests/sceneObjectColliderPolicies.test.ts` (drop fixed expected collider counts and main-source grep checks), while keeping policy, placement, and metadata registration assertions. 
- Add clarifying comment in `src/scene/structures/__tests__/wallSegmentsMesh.test.ts` that segment/source exactness there is synthetic adapter-layer exactness. 

### Testing
- Ran the targeted unit tests with `npm run test:ci -- <files>` (the modified tests: `generateWalls.test.ts`, `stairSafetyColliders.test.ts`, `wallSegmentsMesh.test.ts`, `sceneObjects.test.ts`, `sceneObjectColliderPolicies.test.ts`, `mainImports.test.ts`) and they passed. 
- Executed the stairs end-to-end spec with Playwright after installing browsers via `npx playwright install chromium` and `npx playwright install-deps chromium`, and `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` passed. 
- Ran repository checks `npm run lint`, `npm run docs:check`, and `npm run smoke` and they passed (link checker emitted external fetch warnings only). 
- Ran a full `npm run test:ci` and observed the test suite complete successfully (all tests passed in the verification run). 

If you'd like, I can open a follow-up to reintroduce any narrow generator-level geometry regression tests as dedicated synthetic fixtures for future CI stability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e337eea4832f96210cdc0c58a724)