### PR TITLE
Move exact geometry assertions to fixtures

### DIFF
--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,18 +1,12 @@
 import { MeshBasicMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import {
-  FLOOR_PLAN,
-  FLOOR_PLAN_SCALE,
-  UPPER_FLOOR_PLAN,
-  WALL_THICKNESS,
-} from '../../../assets/floorPlan';
-import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { FLOOR_PLAN_SCALE, WALL_THICKNESS } from '../../../assets/floorPlan';
 import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
 import type { FloorDefinition, LevelDefinition } from '../schema';
-import { assertLevelSourceId } from '../sourceIds';
+import { LEVEL_SOURCE_ID_PATTERN, assertLevelSourceId } from '../sourceIds';
 
 const wallOptions = (baseElevation = 0) => ({
   coordinateScale: FLOOR_PLAN_SCALE,
@@ -142,38 +136,44 @@ function getFloor(level: LevelDefinition, floorId: string): FloorDefinition {
 }
 
 describe('generateWallSegmentInstances', () => {
-  it('matches legacy ground wall and fence bounds while using declarative source IDs', () => {
+  it('generates source-backed ground wall and fence inventory', () => {
     const generated = generateWallSegmentInstances(
       getFloor(PORTFOLIO_LEVEL, 'ground'),
       wallOptions()
     );
-    const legacy = createWallSegmentInstances(FLOOR_PLAN, {
-      floorId: 'ground',
-      ...wallOptions(),
-    });
+    const sourceIds = generated.map((instance) => instance.sourceId);
+    const sourceInventory = getFloor(PORTFOLIO_LEVEL, 'ground').walls.map(
+      (wall) => wall.sourceId
+    );
 
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
+    expect(generated.length).toBeGreaterThan(0);
+    expect(new Set(sourceInventory).size).toBe(sourceInventory.length);
+    expect(sourceIds.every((id) => LEVEL_SOURCE_ID_PATTERN.test(id))).toBe(
+      true
     );
-    expect(generated.every((instance) => instance.sourceId)).toBe(true);
-    expect(generated.map((instance) => instance.sourceId)).toContain(
-      'ground.living_room.south_wall'
-    );
+    expect(new Set(sourceIds)).toEqual(new Set(sourceInventory));
+    expect(generated.some((instance) => instance.isFence)).toBe(true);
+    expect(generated.some((instance) => !instance.isFence)).toBe(true);
+    expect(sourceIds).toContain('ground.living_room.south_wall');
   });
 
-  it('matches legacy upper wall bounds without legacy room-doorway generation', () => {
+  it('generates source-backed upper wall inventory', () => {
     const generated = generateWallSegmentInstances(
       getFloor(PORTFOLIO_LEVEL, 'upper'),
       wallOptions(9)
     );
-    const legacy = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
-      floorId: 'upper',
-      ...wallOptions(9),
-    });
-
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
+    const sourceIds = generated.map((instance) => instance.sourceId);
+    const sourceInventory = getFloor(PORTFOLIO_LEVEL, 'upper').walls.map(
+      (wall) => wall.sourceId
     );
+
+    expect(generated.length).toBeGreaterThan(0);
+    expect(new Set(sourceInventory).size).toBe(sourceInventory.length);
+    expect(sourceIds.every((id) => LEVEL_SOURCE_ID_PATTERN.test(id))).toBe(
+      true
+    );
+    expect(new Set(sourceIds)).toEqual(new Set(sourceInventory));
+    expect(generated.every((instance) => !instance.isFence)).toBe(true);
   });
 
   it('adds stable source metadata to generated wall and fence meshes', () => {
@@ -247,6 +247,8 @@ describe('generateWallSegmentInstances', () => {
       (wall) => wall.sourceId === addedWallSourceId
     );
     expect(generatedWall).toBeDefined();
+    // Exact collider geometry belongs here because this tiny proof floor isolates
+    // the wall generator from production floor-plan inventory churn.
     expect(generatedWall?.collider).toMatchObject({ minX: 8, maxX: 8.25 });
 
     const material = new MeshBasicMaterial({ color: 0xffffff });

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -70,6 +70,8 @@ describe('stair safety collider source definitions', () => {
   it('preserves key generated upper stair guard bounds', () => {
     const colliders = createUpperStairSafetyColliders(upperArgs);
 
+    // Exact bounds stay in this synthetic fixture because it exercises the
+    // isolated safety-collider generator without pinning PORTFOLIO_LEVEL data.
     expect(
       colliders.find(
         (collider) => collider.name === 'UpperStairEastLowerVoidGuard'
@@ -147,6 +149,19 @@ describe('stair safety collider source definitions', () => {
         name: 'UpperStairTopGapBlockerEast',
       })
     ).toBe('4004');
+  });
+
+  it('does not resurrect the removed upper hidden-run guard', () => {
+    const names = collectSafetyColliders().map((collider) => collider.name);
+
+    expect(names).not.toContain('UpperStairHiddenRunVoidGuard');
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairHiddenRunVoidGuard',
+      })
+    ).toBeUndefined();
   });
 
   it('keeps safety collider source IDs free of tombstone wording', () => {

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -74,7 +74,6 @@ type MigratedFactoryPlacement = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    expectedColliderCount: 2,
     placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
@@ -86,7 +85,6 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    expectedColliderCount: 1,
     placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
@@ -96,7 +94,6 @@ const migratedFactories = [
   },
   {
     id: 'axel-studio-tracker',
-    expectedColliderCount: 2,
     placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
@@ -106,7 +103,6 @@ const migratedFactories = [
   },
   {
     id: 'wove-kitchen-loom',
-    expectedColliderCount: 2,
     placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
@@ -116,7 +112,6 @@ const migratedFactories = [
   },
   {
     id: 'pr-reaper-backyard-console',
-    expectedColliderCount: 2,
     placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
@@ -149,12 +144,7 @@ describe('migrated scene object collider policies', () => {
   });
 
   it('registers every existing factory collider with scene object source metadata', () => {
-    for (const {
-      id,
-      expectedColliderCount,
-      build,
-      placement,
-    } of migratedFactories) {
+    for (const { id, build, placement } of migratedFactories) {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
@@ -168,8 +158,8 @@ describe('migrated scene object collider policies', () => {
         metadata
       );
 
-      expect(factoryColliders, id).toHaveLength(expectedColliderCount);
-      expect(registered, id).toHaveLength(expectedColliderCount);
+      expect(factoryColliders.length, id).toBeGreaterThan(0);
+      expect(registered, id).toHaveLength(factoryColliders.length);
       for (const collider of factoryColliders) {
         expect(metadata.get(collider), id).toEqual({
           sourceId: definition!.sourceId,


### PR DESCRIPTION
### Motivation
- Reduce brittleness by keeping production `PORTFOLIO_LEVEL` tests focused on provenance/inventory contracts rather than pinning exact geometry or bounds.
- Ensure deleted debug concepts (e.g., the removed upper hidden-run guard) are not accidentally resurrected by tests while preserving exact-geometry checks in small synthetic generator fixtures.

### Description
- Replace legacy-geometry parity checks with source-backed inventory and source-ID invariants in `src/scene/level/__tests__/generateWalls.test.ts` and validate IDs with `LEVEL_SOURCE_ID_PATTERN`.
- Keep exact collider/bounds assertions only in the isolated proof/synthetic generator test (documented via inline comments) in `generateWalls.test.ts` and `stairSafetyColliders.test.ts`.
- Add a lightweight absence check confirming `UpperStairHiddenRunVoidGuard` and its debug ID are not present in safety-collider collections and debug-ID registry in `stairSafetyColliders.test.ts`.
- Remove hard-count expectations for migrated factory collider counts and instead assert registration/provenance in `src/tests/sceneObjectColliderPolicies.test.ts`.

### Testing
- Ran formatting on changed files with `npm run format:write -- src/scene/level/__tests__/generateWalls.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts src/tests/sceneObjectColliderPolicies.test.ts` and it completed successfully.
- Ran targeted unit tests with `npm run test:ci -- src/scene/level/__tests__/generateWalls.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/wallSegmentsMesh.test.ts src/scene/level/sceneObjects.test.ts src/tests/sceneObjectColliderPolicies.test.ts src/tests/mainImports.test.ts` and they passed.
- Installed Playwright browsers and deps with `npx playwright install chromium` and `npx playwright install-deps chromium` and ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed.
- Ran repository checks `npm run lint` and a full `npm run test:ci`, with the full test suite completing successfully (`158 files, 1204 tests passed`), and `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e369638c832fabb1c54078d6cf8c)