### PR TITLE
🧪 : – Rebalance geometry provenance tests

### DIFF
--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -140,11 +140,14 @@ function expectGeneratedWallSourceIdsToMatchDeclaredInventory(
   generated: ReturnType<typeof generateWallSegmentInstances>
 ) {
   const declaredSourceIds = floor.walls.map((wall) => wall.sourceId);
-  const generatedSourceIds = generated.map((instance) => instance.sourceId);
+  const generatedSourceIds = [
+    ...new Set(generated.map((instance) => instance.sourceId)),
+  ];
 
   expect(new Set(declaredSourceIds).size).toBe(declaredSourceIds.length);
+  expect(new Set(generatedSourceIds).size).toBe(generatedSourceIds.length);
   generatedSourceIds.forEach((id) => expect(() => sourceId(id)).not.toThrow());
-  expect(new Set(generatedSourceIds)).toEqual(new Set(declaredSourceIds));
+  expect(generatedSourceIds.toSorted()).toEqual(declaredSourceIds.toSorted());
 }
 
 describe('generateWallSegmentInstances', () => {
@@ -153,6 +156,7 @@ describe('generateWallSegmentInstances', () => {
     const generated = generateWallSegmentInstances(ground, wallOptions());
     expect(generated.length).toBeGreaterThan(0);
     expect(generated.some((instance) => instance.isFence)).toBe(true);
+    expect(generated.some((instance) => !instance.isFence)).toBe(true);
     expectGeneratedWallSourceIdsToMatchDeclaredInventory(ground, generated);
   });
 

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -135,38 +135,32 @@ function getFloor(level: LevelDefinition, floorId: string): FloorDefinition {
   return floor;
 }
 
+function expectGeneratedWallSourceIdsToMatchDeclaredInventory(
+  floor: FloorDefinition,
+  generated: ReturnType<typeof generateWallSegmentInstances>
+) {
+  const declaredSourceIds = floor.walls.map((wall) => wall.sourceId);
+  const generatedSourceIds = generated.map((instance) => instance.sourceId);
+
+  expect(new Set(declaredSourceIds).size).toBe(declaredSourceIds.length);
+  generatedSourceIds.forEach((id) => expect(() => sourceId(id)).not.toThrow());
+  expect(new Set(generatedSourceIds)).toEqual(new Set(declaredSourceIds));
+}
+
 describe('generateWallSegmentInstances', () => {
   it('generates source-backed ground walls and fences from declarative inventory', () => {
     const ground = getFloor(PORTFOLIO_LEVEL, 'ground');
     const generated = generateWallSegmentInstances(ground, wallOptions());
-    const generatedSourceIds = generated.map((instance) => instance.sourceId);
-
     expect(generated.length).toBeGreaterThan(0);
     expect(generated.some((instance) => instance.isFence)).toBe(true);
-    const declaredSourceIds = ground.walls.map((wall) => wall.sourceId);
-    expect(new Set(declaredSourceIds).size).toBe(declaredSourceIds.length);
-    generatedSourceIds.forEach((id) =>
-      expect(() => sourceId(id)).not.toThrow()
-    );
-    ground.walls.forEach((wall) => {
-      expect(generatedSourceIds, wall.id).toContain(wall.sourceId);
-    });
+    expectGeneratedWallSourceIdsToMatchDeclaredInventory(ground, generated);
   });
 
   it('generates source-backed upper walls without legacy room-doorway generation', () => {
     const upper = getFloor(PORTFOLIO_LEVEL, 'upper');
     const generated = generateWallSegmentInstances(upper, wallOptions(9));
-    const generatedSourceIds = generated.map((instance) => instance.sourceId);
-
     expect(generated.length).toBeGreaterThan(0);
-    const declaredSourceIds = upper.walls.map((wall) => wall.sourceId);
-    expect(new Set(declaredSourceIds).size).toBe(declaredSourceIds.length);
-    generatedSourceIds.forEach((id) =>
-      expect(() => sourceId(id)).not.toThrow()
-    );
-    upper.walls.forEach((wall) => {
-      expect(generatedSourceIds, wall.id).toContain(wall.sourceId);
-    });
+    expectGeneratedWallSourceIdsToMatchDeclaredInventory(upper, generated);
   });
 
   it('adds stable source metadata to generated wall and fence meshes', () => {

--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,13 +1,7 @@
 import { MeshBasicMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import {
-  FLOOR_PLAN,
-  FLOOR_PLAN_SCALE,
-  UPPER_FLOOR_PLAN,
-  WALL_THICKNESS,
-} from '../../../assets/floorPlan';
-import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { FLOOR_PLAN_SCALE, WALL_THICKNESS } from '../../../assets/floorPlan';
 import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
@@ -142,38 +136,37 @@ function getFloor(level: LevelDefinition, floorId: string): FloorDefinition {
 }
 
 describe('generateWallSegmentInstances', () => {
-  it('matches legacy ground wall and fence bounds while using declarative source IDs', () => {
-    const generated = generateWallSegmentInstances(
-      getFloor(PORTFOLIO_LEVEL, 'ground'),
-      wallOptions()
-    );
-    const legacy = createWallSegmentInstances(FLOOR_PLAN, {
-      floorId: 'ground',
-      ...wallOptions(),
-    });
+  it('generates source-backed ground walls and fences from declarative inventory', () => {
+    const ground = getFloor(PORTFOLIO_LEVEL, 'ground');
+    const generated = generateWallSegmentInstances(ground, wallOptions());
+    const generatedSourceIds = generated.map((instance) => instance.sourceId);
 
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
+    expect(generated.length).toBeGreaterThan(0);
+    expect(generated.some((instance) => instance.isFence)).toBe(true);
+    const declaredSourceIds = ground.walls.map((wall) => wall.sourceId);
+    expect(new Set(declaredSourceIds).size).toBe(declaredSourceIds.length);
+    generatedSourceIds.forEach((id) =>
+      expect(() => sourceId(id)).not.toThrow()
     );
-    expect(generated.every((instance) => instance.sourceId)).toBe(true);
-    expect(generated.map((instance) => instance.sourceId)).toContain(
-      'ground.living_room.south_wall'
-    );
+    ground.walls.forEach((wall) => {
+      expect(generatedSourceIds, wall.id).toContain(wall.sourceId);
+    });
   });
 
-  it('matches legacy upper wall bounds without legacy room-doorway generation', () => {
-    const generated = generateWallSegmentInstances(
-      getFloor(PORTFOLIO_LEVEL, 'upper'),
-      wallOptions(9)
-    );
-    const legacy = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
-      floorId: 'upper',
-      ...wallOptions(9),
-    });
+  it('generates source-backed upper walls without legacy room-doorway generation', () => {
+    const upper = getFloor(PORTFOLIO_LEVEL, 'upper');
+    const generated = generateWallSegmentInstances(upper, wallOptions(9));
+    const generatedSourceIds = generated.map((instance) => instance.sourceId);
 
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
+    expect(generated.length).toBeGreaterThan(0);
+    const declaredSourceIds = upper.walls.map((wall) => wall.sourceId);
+    expect(new Set(declaredSourceIds).size).toBe(declaredSourceIds.length);
+    generatedSourceIds.forEach((id) =>
+      expect(() => sourceId(id)).not.toThrow()
     );
+    upper.walls.forEach((wall) => {
+      expect(generatedSourceIds, wall.id).toContain(wall.sourceId);
+    });
   });
 
   it('adds stable source metadata to generated wall and fence meshes', () => {
@@ -247,6 +240,8 @@ describe('generateWallSegmentInstances', () => {
       (wall) => wall.sourceId === addedWallSourceId
     );
     expect(generatedWall).toBeDefined();
+    // Exact bounds belong in this tiny proof floor fixture; production-scene
+    // coverage above only asserts source inventory/provenance contracts.
     expect(generatedWall?.collider).toMatchObject({ minX: 8, maxX: 8.25 });
 
     const material = new MeshBasicMaterial({ color: 0xffffff });

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -68,6 +68,8 @@ const collectSafetyColliders = (): LevelSafetyCollider[] => [
 
 describe('stair safety collider source definitions', () => {
   it('preserves key generated upper stair guard bounds', () => {
+    // Exact bounds stay here because this is a small synthetic generator fixture,
+    // not the production PORTFOLIO_LEVEL scene inventory.
     const colliders = createUpperStairSafetyColliders(upperArgs);
 
     expect(
@@ -147,6 +149,19 @@ describe('stair safety collider source definitions', () => {
         name: 'UpperStairTopGapBlockerEast',
       })
     ).toBe('4004');
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairHiddenRunVoidGuard',
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not regenerate the removed hidden-run void guard', () => {
+    const names = collectSafetyColliders().map((collider) => collider.name);
+
+    expect(names).not.toContain('UpperStairHiddenRunVoidGuard');
   });
 
   it('keeps safety collider source IDs free of tombstone wording', () => {

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs';
-
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
@@ -74,21 +72,15 @@ type MigratedFactoryPlacement = {
 
 type MigratedFactory = {
   id: string;
-  factoryName: string;
-  expectedColliderCount: number;
   placement: MigratedFactoryPlacement;
   build: (placement: MigratedFactoryPlacement) => {
     colliders: readonly RectCollider[];
   };
 };
 
-const mainSource = readFileSync('src/main.ts', 'utf8');
-
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    factoryName: 'createFlywheelShowpiece',
-    expectedColliderCount: 2,
     placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
@@ -100,8 +92,6 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    factoryName: 'createJobbotTerminal',
-    expectedColliderCount: 1,
     placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
@@ -111,8 +101,6 @@ const migratedFactories = [
   },
   {
     id: 'axel-studio-tracker',
-    factoryName: 'createAxelNavigator',
-    expectedColliderCount: 2,
     placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
@@ -122,8 +110,6 @@ const migratedFactories = [
   },
   {
     id: 'wove-kitchen-loom',
-    factoryName: 'createWoveLoom',
-    expectedColliderCount: 2,
     placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
@@ -133,8 +119,6 @@ const migratedFactories = [
   },
   {
     id: 'pr-reaper-backyard-console',
-    factoryName: 'createPrReaperConsole',
-    expectedColliderCount: 2,
     placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
@@ -167,12 +151,7 @@ describe('migrated scene object collider policies', () => {
   });
 
   it('registers every existing factory collider with scene object source metadata', () => {
-    for (const {
-      id,
-      build,
-      expectedColliderCount,
-      placement,
-    } of migratedFactories) {
+    for (const { id, build, placement } of migratedFactories) {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
@@ -186,7 +165,7 @@ describe('migrated scene object collider policies', () => {
         metadata
       );
 
-      expect(factoryColliders, id).toHaveLength(expectedColliderCount);
+      expect(factoryColliders.length, id).toBeGreaterThan(0);
       expect(registered, id).toHaveLength(factoryColliders.length);
       for (const collider of factoryColliders) {
         expect(metadata.get(collider), id).toEqual({
@@ -198,21 +177,9 @@ describe('migrated scene object collider policies', () => {
     }
   });
 
-  it('keeps runtime assembly paths singular for migrated factory placements', () => {
-    for (const { id, factoryName } of migratedFactories) {
-      const factoryCalls =
-        mainSource.match(new RegExp(`\\b${factoryName}\\(`, 'g')) ?? [];
-      const sceneObjectLookups =
-        mainSource.match(
-          new RegExp(`getSceneObjectDefinition\\(\\n?\\s*['"]${id}['"]`, 'g')
-        ) ?? [];
-
-      expect(factoryCalls, factoryName).toHaveLength(1);
-      expect(sceneObjectLookups, id).toHaveLength(1);
-    }
-  });
-
   it('keeps migrated placements unique in the declarative scene object inventory', () => {
+    // This inventory-level uniqueness check replaces the removed implementation-wiring
+    // grep; runtime duplicate-assembly coverage belongs in a public/helper contract.
     const placements = migratedFactories.map(({ id }) => {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs';
-
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
@@ -74,7 +72,6 @@ type MigratedFactoryPlacement = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    expectedColliderCount: 2,
     placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
@@ -86,7 +83,6 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    expectedColliderCount: 1,
     placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
@@ -96,7 +92,6 @@ const migratedFactories = [
   },
   {
     id: 'axel-studio-tracker',
-    expectedColliderCount: 2,
     placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
@@ -106,7 +101,6 @@ const migratedFactories = [
   },
   {
     id: 'wove-kitchen-loom',
-    expectedColliderCount: 2,
     placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
@@ -116,7 +110,6 @@ const migratedFactories = [
   },
   {
     id: 'pr-reaper-backyard-console',
-    expectedColliderCount: 2,
     placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
@@ -149,12 +142,7 @@ describe('migrated scene object collider policies', () => {
   });
 
   it('registers every existing factory collider with scene object source metadata', () => {
-    for (const {
-      id,
-      expectedColliderCount,
-      build,
-      placement,
-    } of migratedFactories) {
+    for (const { id, build, placement } of migratedFactories) {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
@@ -168,8 +156,8 @@ describe('migrated scene object collider policies', () => {
         metadata
       );
 
-      expect(factoryColliders, id).toHaveLength(expectedColliderCount);
-      expect(registered, id).toHaveLength(expectedColliderCount);
+      expect(factoryColliders.length, id).toBeGreaterThan(0);
+      expect(registered, id).toHaveLength(factoryColliders.length);
       for (const collider of factoryColliders) {
         expect(metadata.get(collider), id).toEqual({
           sourceId: definition!.sourceId,
@@ -180,23 +168,14 @@ describe('migrated scene object collider policies', () => {
     }
   });
 
-  it('does not duplicate migrated placements as manual main-scene factory args', () => {
-    const mainSource = readFileSync('src/main.ts', 'utf8');
+  it('keeps migrated placements unique in the declarative scene object inventory', () => {
+    const placements = migratedFactories.map(({ id }) => {
+      const definition = definitionsById.get(id);
+      expect(definition, id).toBeDefined();
 
-    expect(mainSource).not.toMatch(
-      /createJobbotTerminal\(\{[\s\S]{0,500}x: 12,[\s\S]{0,200}z: 2/
-    );
-    expect(mainSource).not.toMatch(
-      /createAxelNavigator\(\{[\s\S]{0,500}x: 10,[\s\S]{0,200}z: -2/
-    );
-    expect(mainSource).not.toMatch(
-      /createWoveLoom\(\{[\s\S]{0,500}x: -7\.5,[\s\S]{0,200}z: 2\.5/
-    );
-    expect(mainSource).not.toMatch(
-      /createPrReaperConsole\(\{[\s\S]{0,500}x: 0,[\s\S]{0,200}z: 10/
-    );
-    expect(mainSource).not.toMatch(
-      /createFlywheelShowpiece\(\{[\s\S]{0,300}centerX: 5\.5/
-    );
+      return `${definition!.position.x},${definition!.position.z},${definition!.orientation}`;
+    });
+
+    expect(new Set(placements).size).toBe(placements.length);
   });
 });

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
@@ -10,6 +12,7 @@ import { createFlywheelShowpiece } from '../scene/structures/flywheel';
 import { createJobbotTerminal } from '../scene/structures/jobbotTerminal';
 import { createPrReaperConsole } from '../scene/structures/prReaperConsole';
 import { createWoveLoom } from '../scene/structures/woveLoom';
+import type { RectCollider } from '../systems/collision';
 
 const createCanvasContext = (
   canvas: HTMLCanvasElement
@@ -69,9 +72,23 @@ type MigratedFactoryPlacement = {
   orientation: number;
 };
 
+type MigratedFactory = {
+  id: string;
+  factoryName: string;
+  expectedColliderCount: number;
+  placement: MigratedFactoryPlacement;
+  build: (placement: MigratedFactoryPlacement) => {
+    colliders: readonly RectCollider[];
+  };
+};
+
+const mainSource = readFileSync('src/main.ts', 'utf8');
+
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
+    factoryName: 'createFlywheelShowpiece',
+    expectedColliderCount: 2,
     placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
@@ -83,6 +100,8 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
+    factoryName: 'createJobbotTerminal',
+    expectedColliderCount: 1,
     placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
@@ -92,6 +111,8 @@ const migratedFactories = [
   },
   {
     id: 'axel-studio-tracker',
+    factoryName: 'createAxelNavigator',
+    expectedColliderCount: 2,
     placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
@@ -101,6 +122,8 @@ const migratedFactories = [
   },
   {
     id: 'wove-kitchen-loom',
+    factoryName: 'createWoveLoom',
+    expectedColliderCount: 2,
     placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
@@ -110,6 +133,8 @@ const migratedFactories = [
   },
   {
     id: 'pr-reaper-backyard-console',
+    factoryName: 'createPrReaperConsole',
+    expectedColliderCount: 2,
     placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
@@ -117,7 +142,7 @@ const migratedFactories = [
         orientationRadians: orientation,
       }),
   },
-] as const;
+] satisfies readonly MigratedFactory[];
 
 describe('migrated scene object collider policies', () => {
   it('keeps each migrated visible showpiece on a custom factory-collider policy', () => {
@@ -142,7 +167,12 @@ describe('migrated scene object collider policies', () => {
   });
 
   it('registers every existing factory collider with scene object source metadata', () => {
-    for (const { id, build, placement } of migratedFactories) {
+    for (const {
+      id,
+      build,
+      expectedColliderCount,
+      placement,
+    } of migratedFactories) {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
@@ -156,7 +186,7 @@ describe('migrated scene object collider policies', () => {
         metadata
       );
 
-      expect(factoryColliders.length, id).toBeGreaterThan(0);
+      expect(factoryColliders, id).toHaveLength(expectedColliderCount);
       expect(registered, id).toHaveLength(factoryColliders.length);
       for (const collider of factoryColliders) {
         expect(metadata.get(collider), id).toEqual({
@@ -165,6 +195,20 @@ describe('migrated scene object collider policies', () => {
           purpose: 'factory-colliders',
         });
       }
+    }
+  });
+
+  it('keeps runtime assembly paths singular for migrated factory placements', () => {
+    for (const { id, factoryName } of migratedFactories) {
+      const factoryCalls =
+        mainSource.match(new RegExp(`\\b${factoryName}\\(`, 'g')) ?? [];
+      const sceneObjectLookups =
+        mainSource.match(
+          new RegExp(`getSceneObjectDefinition\\(\\n?\\s*['"]${id}['"]`, 'g')
+        ) ?? [];
+
+      expect(factoryCalls, factoryName).toHaveLength(1);
+      expect(sceneObjectLookups, id).toHaveLength(1);
     }
   });
 


### PR DESCRIPTION
### Motivation
- Reduce brittle production-scene geometry assertions so inventory/provenance contracts are asserted at the scene level and exact geometry remains in small synthetic generator fixtures.
- Remove test assertions that depended on removed debug colliders (`UpperStairHiddenRunVoidGuard` / legacy `4008`) and implementation-furniture (pinned factory collider counts / grepped `src/main.ts`).

### Description
- Adjusted `src/scene/level/__tests__/generateWalls.test.ts` to assert source-backed generation invariants (non-empty generation, valid/unique `sourceId`s, declared walls are represented) and removed direct comparisons against legacy geometry generators.
- Kept exact geometry assertions in the small proof-floor generator test and added comments explaining why exactness belongs at the fixture layer.
- Updated `src/scene/level/__tests__/stairSafetyColliders.test.ts` to (a) keep exact bounds only in the synthetic generator fixture (with a clarifying comment), (b) assert that the removed `UpperStairHiddenRunVoidGuard` has no declared debug ID, and (c) assert no regenerated collider name for that removed guard.
- Simplified `src/tests/sceneObjectColliderPolicies.test.ts` by removing pinned `expectedColliderCount` values and `readFileSync('src/main.ts')` greps; the test now verifies that factory builders return >0 colliders, that `registerSceneObjectColliders` registers them with correct `levelSource` metadata, and that declarative placements are unique.
- Added short comments where exact assertions remain to document why they belong at the synthetic fixture layer.

### Testing
- Ran format: `npm run format:write -- src/scene/level/__tests__/generateWalls.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts src/tests/sceneObjectColliderPolicies.test.ts` (succeeded).
- Ran grep checks for removed/debug names: `rg -n "4008|UpperStairHiddenRunVoidGuard|upper\.stairwell\.hiddenRun\.safetyCollider|hidden-run" src playwright docs` (remaining matches are intentional docs/source references; removed test expectations cleared).
- Ran targeted Vitest: `npm run test:ci -- <modified test files + related suites>` and then full `npm run test:ci`; targeted runs and final full `vitest run` completed successfully (Vitest: 158 files, 1204 tests passed in this environment).
- Ran `npm run lint` (succeeded) and `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets found).
- Attempted Playwright verification: `npx playwright install chromium` (downloaded), but `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` was blocked by missing host browser dependencies on the runner (message suggests `npx playwright install-deps` or apt packages); this is an environment limitation and not a test regression.

Residual risk / follow-ups: run the full Playwright immersive stairs roundtrip spec in CI or a host with Playwright browser deps installed to validate end-to-end stair/landing runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e3703c78832fa1afbbfed5f4649c)