### PR TITLE
🧪 Move geometry exactness to fixture tests

### DIFF
--- a/src/scene/level/__tests__/generateWalls.test.ts
+++ b/src/scene/level/__tests__/generateWalls.test.ts
@@ -1,13 +1,7 @@
 import { MeshBasicMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import {
-  FLOOR_PLAN,
-  FLOOR_PLAN_SCALE,
-  UPPER_FLOOR_PLAN,
-  WALL_THICKNESS,
-} from '../../../assets/floorPlan';
-import { createWallSegmentInstances } from '../../../assets/floorPlan/wallSegments';
+import { FLOOR_PLAN_SCALE, WALL_THICKNESS } from '../../../assets/floorPlan';
 import { createWallSegmentMeshes } from '../../structures/wallSegmentsMesh';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
@@ -142,38 +136,40 @@ function getFloor(level: LevelDefinition, floorId: string): FloorDefinition {
 }
 
 describe('generateWallSegmentInstances', () => {
-  it('matches legacy ground wall and fence bounds while using declarative source IDs', () => {
-    const generated = generateWallSegmentInstances(
-      getFloor(PORTFOLIO_LEVEL, 'ground'),
-      wallOptions()
-    );
-    const legacy = createWallSegmentInstances(FLOOR_PLAN, {
-      floorId: 'ground',
-      ...wallOptions(),
-    });
+  it('generates source-backed ground wall and fence instances', () => {
+    const floor = getFloor(PORTFOLIO_LEVEL, 'ground');
+    const generated = generateWallSegmentInstances(floor, wallOptions());
+    const sourceIds = generated.map((instance) => instance.sourceId);
+    const declaredWallSourceIds = floor.walls.map((wall) => wall.sourceId);
 
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
+    expect(generated.length).toBeGreaterThan(0);
+    expect(sourceIds.every(Boolean)).toBe(true);
+    expect(new Set(declaredWallSourceIds).size).toBe(
+      declaredWallSourceIds.length
     );
-    expect(generated.every((instance) => instance.sourceId)).toBe(true);
-    expect(generated.map((instance) => instance.sourceId)).toContain(
-      'ground.living_room.south_wall'
-    );
+    expect(
+      sourceIds.every((sourceId) => declaredWallSourceIds.includes(sourceId))
+    ).toBe(true);
+    expect(sourceIds).toContain('ground.living_room.south_wall');
+    expect(generated.some((instance) => instance.isFence)).toBe(true);
+    expect(generated.some((instance) => !instance.isFence)).toBe(true);
   });
 
-  it('matches legacy upper wall bounds without legacy room-doorway generation', () => {
-    const generated = generateWallSegmentInstances(
-      getFloor(PORTFOLIO_LEVEL, 'upper'),
-      wallOptions(9)
-    );
-    const legacy = createWallSegmentInstances(UPPER_FLOOR_PLAN, {
-      floorId: 'upper',
-      ...wallOptions(9),
-    });
+  it('generates source-backed upper wall instances', () => {
+    const floor = getFloor(PORTFOLIO_LEVEL, 'upper');
+    const generated = generateWallSegmentInstances(floor, wallOptions(9));
+    const sourceIds = generated.map((instance) => instance.sourceId);
+    const declaredWallSourceIds = floor.walls.map((wall) => wall.sourceId);
 
-    expect(generated.map(wallSignature).sort(compareSignatures)).toEqual(
-      legacy.map(wallSignature).sort(compareSignatures)
+    expect(generated.length).toBeGreaterThan(0);
+    expect(sourceIds.every(Boolean)).toBe(true);
+    expect(new Set(declaredWallSourceIds).size).toBe(
+      declaredWallSourceIds.length
     );
+    expect(
+      sourceIds.every((sourceId) => declaredWallSourceIds.includes(sourceId))
+    ).toBe(true);
+    expect(sourceIds).toContain('upper.creators_studio.south_wall');
   });
 
   it('adds stable source metadata to generated wall and fence meshes', () => {
@@ -247,6 +243,9 @@ describe('generateWallSegmentInstances', () => {
       (wall) => wall.sourceId === addedWallSourceId
     );
     expect(generatedWall).toBeDefined();
+    // Exact collider geometry belongs in this tiny proof floor fixture because
+    // it exercises the wall generator directly rather than pinning production
+    // PORTFOLIO_LEVEL dimensions.
     expect(generatedWall?.collider).toMatchObject({ minX: 8, maxX: 8.25 });
 
     const material = new MeshBasicMaterial({ color: 0xffffff });

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -70,6 +70,8 @@ describe('stair safety collider source definitions', () => {
   it('preserves key generated upper stair guard bounds', () => {
     const colliders = createUpperStairSafetyColliders(upperArgs);
 
+    // This file uses synthetic stair geometry, so exact bounds stay here with
+    // the isolated generator rather than in production PORTFOLIO_LEVEL tests.
     expect(
       colliders.find(
         (collider) => collider.name === 'UpperStairEastLowerVoidGuard'
@@ -147,6 +149,21 @@ describe('stair safety collider source definitions', () => {
         name: 'UpperStairTopGapBlockerEast',
       })
     ).toBe('4004');
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairHiddenRunVoidGuard',
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not generate the removed hidden-run guard collider', () => {
+    expect(
+      collectSafetyColliders().some(
+        (collider) => collider.name === 'UpperStairHiddenRunVoidGuard'
+      )
+    ).toBe(false);
   });
 
   it('keeps safety collider source IDs free of tombstone wording', () => {

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs';
-
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
@@ -74,7 +72,6 @@ type MigratedFactoryPlacement = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    expectedColliderCount: 2,
     placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
@@ -86,7 +83,6 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    expectedColliderCount: 1,
     placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
@@ -96,7 +92,6 @@ const migratedFactories = [
   },
   {
     id: 'axel-studio-tracker',
-    expectedColliderCount: 2,
     placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
@@ -106,7 +101,6 @@ const migratedFactories = [
   },
   {
     id: 'wove-kitchen-loom',
-    expectedColliderCount: 2,
     placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
@@ -116,7 +110,6 @@ const migratedFactories = [
   },
   {
     id: 'pr-reaper-backyard-console',
-    expectedColliderCount: 2,
     placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
@@ -149,12 +142,7 @@ describe('migrated scene object collider policies', () => {
   });
 
   it('registers every existing factory collider with scene object source metadata', () => {
-    for (const {
-      id,
-      expectedColliderCount,
-      build,
-      placement,
-    } of migratedFactories) {
+    for (const { id, build, placement } of migratedFactories) {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
@@ -168,8 +156,8 @@ describe('migrated scene object collider policies', () => {
         metadata
       );
 
-      expect(factoryColliders, id).toHaveLength(expectedColliderCount);
-      expect(registered, id).toHaveLength(expectedColliderCount);
+      expect(factoryColliders.length, id).toBeGreaterThan(0);
+      expect(registered, id).toHaveLength(factoryColliders.length);
       for (const collider of factoryColliders) {
         expect(metadata.get(collider), id).toEqual({
           sourceId: definition!.sourceId,
@@ -178,25 +166,5 @@ describe('migrated scene object collider policies', () => {
         });
       }
     }
-  });
-
-  it('does not duplicate migrated placements as manual main-scene factory args', () => {
-    const mainSource = readFileSync('src/main.ts', 'utf8');
-
-    expect(mainSource).not.toMatch(
-      /createJobbotTerminal\(\{[\s\S]{0,500}x: 12,[\s\S]{0,200}z: 2/
-    );
-    expect(mainSource).not.toMatch(
-      /createAxelNavigator\(\{[\s\S]{0,500}x: 10,[\s\S]{0,200}z: -2/
-    );
-    expect(mainSource).not.toMatch(
-      /createWoveLoom\(\{[\s\S]{0,500}x: -7\.5,[\s\S]{0,200}z: 2\.5/
-    );
-    expect(mainSource).not.toMatch(
-      /createPrReaperConsole\(\{[\s\S]{0,500}x: 0,[\s\S]{0,200}z: 10/
-    );
-    expect(mainSource).not.toMatch(
-      /createFlywheelShowpiece\(\{[\s\S]{0,300}centerX: 5\.5/
-    );
   });
 });


### PR DESCRIPTION
### Motivation
- Reduce brittle, low-level pinning in production `PORTFOLIO_LEVEL` tests by asserting provenance/source contracts instead of exact geometry values.
- Keep exact geometry and bounds assertions in small, synthetic generator fixtures that intentionally exercise generator math.
- Remove expectations for deleted/removed debug-named colliders while preserving lightweight absence/cleanup checks.

### Description
- Replaced legacy bounds comparisons in `src/scene/level/__tests__/generateWalls.test.ts` with provenance-focused assertions that generated instances carry valid, unique `sourceId`s and that generated sourceIds are derived from declared floor `walls` (and preserved a small synthetic proof-floor check for exact collider geometry).
- Kept exact stair-bound assertions in the synthetic stair test `src/scene/level/__tests__/stairSafetyColliders.test.ts`, added a comment explaining why they belong there, and added an explicit absence check that `UpperStairHiddenRunVoidGuard` is not produced and has no declared debug ID.
- Relaxed `src/tests/sceneObjectColliderPolicies.test.ts` by removing brittle source-text grep and hard-coded `expectedColliderCount` pins, instead asserting factory colliders are non-empty and correctly registered with `sourceId` / `sourceType` / `purpose` metadata.
- Added short comments where exact assertions remain to document why they live in synthetic fixtures instead of production-level tests.

### Testing
- Ran formatting with `npm run format:write` (succeeded) and addressed formatting changes.
- Ran targeted unit tests with `npm run test:ci -- <files>` for the changed tests (initially fixed an expectation mismatch, then re-ran) and the targeted set passed: `src/scene/level/__tests__/generateWalls.test.ts`, `src/scene/level/__tests__/stairSafetyColliders.test.ts`, `src/scene/structures/__tests__/wallSegmentsMesh.test.ts`, `src/scene/level/sceneObjects.test.ts`, `src/tests/sceneObjectColliderPolicies.test.ts`, `src/tests/mainImports.test.ts` (all passed).
- Ran a full test run `npm run test:ci` which completed successfully (all tests passed in CI run shown: 158 files / 1203 tests in this environment).
- Ran `npm run lint` (succeeded), `npm run docs:check` (passed with external link warnings), and `npm run smoke` (passed).
- Attempted `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` but it was blocked in this environment because Playwright browsers were not installed (error: run `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e3791c98832f8a6479473886a5f3)