### PR TITLE
🧹 Remove redundant upper stair colliders 4006 / 400B / 400C

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1190,11 +1190,10 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     floorId: 'upper' as const,
   };
   expect(await canOccupyPosition(page, eastVoidGuardSample)).toBe(false);
-  await expectBlockingColliderSourceAt(
-    page,
-    eastVoidGuardSample,
-    'upper.stairwell.eastLowerVoid.safetyCollider'
-  );
+  expect(
+    await getBlockingColliderNames(page, eastVoidGuardSample),
+    'upper landing east void remains blocked by nearby active geometry'
+  ).not.toEqual([]);
 
   // Continue through the intended west upper-landing exit into an upstairs room
   // with the same step helper used by runtime movement instead of teleporting.

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -20,12 +20,9 @@ const DECLARED_RUNTIME_COLLIDER_IDS = {
   UpperStairTopGapBlockerWest: '4003',
   UpperStairTopGapBlockerEast: '4004',
   UpperStairWestUpperVoidGuard: '4005',
-  UpperStairEastLowerVoidGuard: '4006',
   UpperStairEastUpperVoidGuard: '4007',
   UpperStairWestBannisterGuard: '4009',
   UpperStairNorthBannisterGuard: '400A',
-  'UpperStairwellLandingGuard-1': '400B',
-  'UpperStairwellLandingGuard-2': '400C',
   'UpperStairwellLandingGuard-3': '400D',
   'UpperStairwellLandingGuard-4': '400E',
 } as const satisfies Record<string, string>;

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -74,16 +74,6 @@ describe('stair safety collider source definitions', () => {
 
     expect(
       colliders.find(
-        (collider) => collider.name === 'UpperStairEastLowerVoidGuard'
-      )?.bounds
-    ).toEqual({
-      minX: 14.75,
-      maxX: 16.4,
-      minZ: -31.1,
-      maxZ: -27.799999999999997,
-    });
-    expect(
-      colliders.find(
         (collider) => collider.name === 'UpperStairWestBannisterGuard'
       )?.bounds
     ).toEqual({
@@ -124,7 +114,6 @@ describe('stair safety collider source definitions', () => {
     [
       ['GroundStairEastBoundary', '4001'],
       ['GroundStairLowerCornerGuard', '4002'],
-      ['UpperStairEastLowerVoidGuard', '4006'],
       ['UpperStairEastUpperVoidGuard', '4007'],
       ['UpperStairWestBannisterGuard', '4009'],
       ['UpperStairNorthBannisterGuard', '400A'],

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -105,7 +105,6 @@ export const createUpperStairSafetyColliders = ({
   stairNavigationZones,
   upperStairBannisterThickness,
 }: UpperStairSafetyColliderArgs): LevelSafetyCollider[] => {
-  const upperStairVoidMinZ = upperStairwellOpening.minZ;
   const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
   const upperLandingDoorwayClearanceZ =
     upperLandingRoomBounds.maxZ - doorwayDepth / 2 - playerRadius;
@@ -131,10 +130,6 @@ export const createUpperStairSafetyColliders = ({
   const hiddenStairTopGapBlockerMaxZ = Math.max(
     hiddenStairTopGapBlockerNearZ,
     hiddenStairTopGapBlockerFarZ
-  );
-  const upperStairLandingEntryMinZ = Math.max(
-    upperStairVoidMinZ,
-    hiddenStairTopGapBlockerMinZ - playerRadius
   );
   const upperStairLandingEntryMaxZ = Math.min(
     upperStairVoidMaxZ,
@@ -171,19 +166,6 @@ export const createUpperStairSafetyColliders = ({
   const upperStairNorthBannisterMaxX =
     upperStairwellOpening.maxX - upperStairBannisterThickness;
   return [
-    {
-      name: 'UpperStairEastLowerVoidGuard',
-      sourceId: sourceId('upper.stairwell.eastLowerVoid.safetyCollider'),
-      floor: 'upper',
-      category: 'void',
-      purpose: 'guard upper stairwell void edge',
-      bounds: {
-        minX: stairNavigationZones.explicitDescentCorridor.maxX,
-        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-        minZ: upperStairVoidMinZ,
-        maxZ: upperStairLandingEntryMinZ,
-      },
-    },
     {
       name: 'UpperStairEastUpperVoidGuard',
       sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),


### PR DESCRIPTION
### Motivation
- Remove three redundant upper-stair safety colliders (debug IDs `4006`, `400B`, `400C`) that duplicated blocking at the upper stair/landing edge while preserving runtime traversal behavior and nearby guards.

### Description
- Deleted the runtime collider definition for `UpperStairEastLowerVoidGuard` from `createUpperStairSafetyColliders(...)` in `src/scene/level/stairSafetyColliders.ts` and removed now-unused local calculations tied only to that piece.
- Removed declared debug ID entries for `4006`, `400B`, and `400C` from `src/scene/debug/colliderDebugIds.ts` without renumbering any remaining IDs.
- Updated tests to avoid pinning the removed colliders: removed direct assertions that referenced the deleted collider/debug IDs in `src/scene/level/__tests__/stairSafetyColliders.test.ts` and changed the Playwright expectation in `playwright/immersive-stairs-roundtrip.spec.ts` to assert that the east landing void remains blocked by nearby active geometry without requiring a specific source ID.
- Kept all other stair geometry, navmesh, and remaining safety colliders intact.

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed.
- `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/systems/movement/stairs.test.ts src/tests/mainImports.test.ts` — passed (targeted vitest run succeeded).
- `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — could not run in this environment because Playwright's browser binaries are not installed (error: "Please run npx playwright install").
- `npm run test:ci` (full suite) — passed (all vitest tests in this environment passed).
- `npm run docs:check` — passed.
- `npm run smoke` — passed.
- `git diff --cached | ./scripts/scan-secrets.py` — ran and found no high-risk secrets.

Notes: Playwright E2E verification is blocked here by missing browser binaries; the Playwright test was adapted to stop depending on the removed collider's source ID so the player-facing promise remains asserted in CI where Playwright is available. No debug ID renumbering or tombstones were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34faaa0180832faea6f5fab94348e6)