### PR TITLE
Remove redundant upper stair colliders

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1184,18 +1184,6 @@ test('ascend stairs from spawn, roam, return and descend', async ({ page }) => {
     ).toEqual([]);
   }
 
-  const eastVoidGuardSample = {
-    x: stairCenterX + stairHalfWidth - PLAYER_RADIUS,
-    z: physicalLandingZ,
-    floorId: 'upper' as const,
-  };
-  expect(await canOccupyPosition(page, eastVoidGuardSample)).toBe(false);
-  await expectBlockingColliderSourceAt(
-    page,
-    eastVoidGuardSample,
-    'upper.stairwell.eastLowerVoid.safetyCollider'
-  );
-
   // Continue through the intended west upper-landing exit into an upstairs room
   // with the same step helper used by runtime movement instead of teleporting.
   const egressWalk = await walkUpperLandingWestExitToCreatorsStudio(page);

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -20,12 +20,9 @@ const DECLARED_RUNTIME_COLLIDER_IDS = {
   UpperStairTopGapBlockerWest: '4003',
   UpperStairTopGapBlockerEast: '4004',
   UpperStairWestUpperVoidGuard: '4005',
-  UpperStairEastLowerVoidGuard: '4006',
   UpperStairEastUpperVoidGuard: '4007',
   UpperStairWestBannisterGuard: '4009',
   UpperStairNorthBannisterGuard: '400A',
-  'UpperStairwellLandingGuard-1': '400B',
-  'UpperStairwellLandingGuard-2': '400C',
   'UpperStairwellLandingGuard-3': '400D',
   'UpperStairwellLandingGuard-4': '400E',
 } as const satisfies Record<string, string>;

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -74,16 +74,6 @@ describe('stair safety collider source definitions', () => {
 
     expect(
       colliders.find(
-        (collider) => collider.name === 'UpperStairEastLowerVoidGuard'
-      )?.bounds
-    ).toEqual({
-      minX: 14.75,
-      maxX: 16.4,
-      minZ: -31.1,
-      maxZ: -27.799999999999997,
-    });
-    expect(
-      colliders.find(
         (collider) => collider.name === 'UpperStairWestBannisterGuard'
       )?.bounds
     ).toEqual({
@@ -124,7 +114,6 @@ describe('stair safety collider source definitions', () => {
     [
       ['GroundStairEastBoundary', '4001'],
       ['GroundStairLowerCornerGuard', '4002'],
-      ['UpperStairEastLowerVoidGuard', '4006'],
       ['UpperStairEastUpperVoidGuard', '4007'],
       ['UpperStairWestBannisterGuard', '4009'],
       ['UpperStairNorthBannisterGuard', '400A'],

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -105,7 +105,6 @@ export const createUpperStairSafetyColliders = ({
   stairNavigationZones,
   upperStairBannisterThickness,
 }: UpperStairSafetyColliderArgs): LevelSafetyCollider[] => {
-  const upperStairVoidMinZ = upperStairwellOpening.minZ;
   const upperStairVoidMaxZ = upperStairwellOpening.maxZ;
   const upperLandingDoorwayClearanceZ =
     upperLandingRoomBounds.maxZ - doorwayDepth / 2 - playerRadius;
@@ -131,10 +130,6 @@ export const createUpperStairSafetyColliders = ({
   const hiddenStairTopGapBlockerMaxZ = Math.max(
     hiddenStairTopGapBlockerNearZ,
     hiddenStairTopGapBlockerFarZ
-  );
-  const upperStairLandingEntryMinZ = Math.max(
-    upperStairVoidMinZ,
-    hiddenStairTopGapBlockerMinZ - playerRadius
   );
   const upperStairLandingEntryMaxZ = Math.min(
     upperStairVoidMaxZ,
@@ -171,19 +166,6 @@ export const createUpperStairSafetyColliders = ({
   const upperStairNorthBannisterMaxX =
     upperStairwellOpening.maxX - upperStairBannisterThickness;
   return [
-    {
-      name: 'UpperStairEastLowerVoidGuard',
-      sourceId: sourceId('upper.stairwell.eastLowerVoid.safetyCollider'),
-      floor: 'upper',
-      category: 'void',
-      purpose: 'guard upper stairwell void edge',
-      bounds: {
-        minX: stairNavigationZones.explicitDescentCorridor.maxX,
-        maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
-        minZ: upperStairVoidMinZ,
-        maxZ: upperStairLandingEntryMinZ,
-      },
-    },
     {
       name: 'UpperStairEastUpperVoidGuard',
       sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),


### PR DESCRIPTION
### Motivation
- Remove redundant upper-stair/landing collider furniture (debug IDs `4006`, `400B`, `400C`) while preserving player-facing stair traversal and landing behavior.
- Keep tests focused on player-visible promises rather than internal collider names/IDs.

### Description
- Deleted the `UpperStairEastLowerVoidGuard` runtime collider from `createUpperStairSafetyColliders(...)` and removed the now-unused local calculations it required in `src/scene/level/stairSafetyColliders.ts`.
- Removed declared debug ID mappings for `4006`, `400B`, and `400C` from `src/scene/debug/colliderDebugIds.ts` without renumbering remaining IDs.
- Removed test assertions that pinned the removed collider by name/source/debug-ID from `src/scene/level/__tests__/stairSafetyColliders.test.ts` and removed the Playwright assertion that explicitly required the removed `upper.stairwell.eastLowerVoid.safetyCollider` in `playwright/immersive-stairs-roundtrip.spec.ts` while preserving traversal/egress checks.

### Testing
- Ran `npm run format:write` which completed successfully.
- Verified with `rg -n "4006|400B|400C|UpperStairEastLowerVoidGuard|UpperStairwellLandingGuard|eastLowerVoid|landingGuard" src playwright docs` and confirmed only the expected remaining landing guard entries and runtime naming template remain (no occurrences of the removed runtime collider mappings).
- Ran targeted unit tests with `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/systems/movement/stairs.test.ts src/tests/mainImports.test.ts` and observed all targeted tests passed.
- Installed Playwright browsers and host dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` which passed (`9 passed`).
- Ran `npm run lint` which completed with no lint errors after removing unused vars.
- Ran the full suite with `npm run test:ci` which completed successfully (all tests passed in this environment).
- Ran `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.

All automated checks listed above completed successfully in this environment; note that Playwright required explicit browser and host-dependency installation in CI-like environments before its tests could run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34fa8dcea0832fb2933ab7cce7455f)