### PR TITLE
Declare upper-stairwell landing collider policy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -167,6 +167,7 @@ import {
   createUpperStairSafetyColliders,
   type LevelSafetyCollider,
 } from './scene/level/stairSafetyColliders';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from './scene/level/upperStairwellLandingPolicy';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -993,7 +994,7 @@ const colliderSourceMetadata = new Map<
       | WallSegmentInstance['sourceId']
       | LevelSafetyCollider['sourceId']
       | SceneObjectDefinition['sourceId'];
-    sourceType: 'wall' | 'safetyCollider' | 'sceneObject';
+    sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
     purpose?: string;
   }
 >();
@@ -2128,11 +2129,6 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const pushNamedUpperFloorCollider = (name: string, bounds: RectCollider) => {
-    upperFloorColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
-  };
-
   const upperStairWestEgressLaneX =
     stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
   const upperStairWestEgressBlockerMinX =
@@ -2242,26 +2238,24 @@ function initializeImmersiveScene(
       guard: {
         height: 0.56,
         thickness: toWorldUnits(0.12),
-        sideSides: ['east'],
-        shoulderSides: ['east'],
         material: {
           color: 0x2a3241,
           roughness: 0.72,
           metalness: 0.05,
         },
       },
+      segmentPolicies: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
     });
     upperFloorGroup.add(upperStairwellLanding.group);
-    upperStairwellLanding.namedColliders
-      .filter(({ name }) =>
-        name.startsWith('UpperStairwellLandingShoulderGuard')
-      )
-      .forEach(({ collider }, index) =>
-        pushNamedUpperFloorCollider(
-          `UpperStairwellLandingGuard-${index + 3}`,
-          collider
-        )
-      );
+    upperStairwellLanding.colliders.forEach((collider) => {
+      upperFloorColliders.push(collider.bounds);
+      namedColliderDebugNames.set(collider.bounds, collider.name);
+      colliderSourceMetadata.set(collider.bounds, {
+        sourceId: collider.sourceId,
+        sourceType: 'generatedCollider',
+        purpose: `upper stairwell landing guard ${collider.role}`,
+      });
+    });
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });

--- a/src/scene/level/upperStairwellLandingPolicy.ts
+++ b/src/scene/level/upperStairwellLandingPolicy.ts
@@ -1,0 +1,42 @@
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type UpperStairwellLandingSegmentRole =
+  | 'side-east'
+  | 'side-west'
+  | 'far'
+  | 'shoulder-east'
+  | 'shoulder-west';
+
+export interface UpperStairwellLandingSegmentPolicy {
+  role: UpperStairwellLandingSegmentRole;
+  render: boolean;
+  collision: boolean;
+  sourceId: LevelSourceId;
+  colliderName?: string;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+
+export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
+  {
+    role: 'side-east',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landingGuard.sideEast.generatedSolid'),
+  },
+  {
+    role: 'far',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landingGuard.far.generatedSolid'),
+  },
+  {
+    role: 'shoulder-east',
+    render: true,
+    collision: true,
+    sourceId: sourceId(
+      'upper.stairwell.landingGuard.shoulderEast.generatedCollider'
+    ),
+    colliderName: 'UpperStairwellLandingGuard-3',
+  },
+] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,6 +1,8 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
+import { assertLevelSourceId } from '../../level/sourceIds';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../../level/upperStairwellLandingPolicy';
 import { createUpperStairwellLanding } from '../upperStairwellLanding';
 
 const overlaps = (
@@ -11,6 +13,44 @@ const overlaps = (
   first.maxX > second.minX &&
   first.minZ < second.maxZ &&
   first.maxZ > second.minZ;
+
+const allSegments = [
+  {
+    role: 'side-west',
+    render: true,
+    collision: true,
+    sourceId: assertLevelSourceId('test.upper.sideWest.generatedCollider'),
+    colliderName: 'TestSideWest',
+  },
+  {
+    role: 'side-east',
+    render: true,
+    collision: true,
+    sourceId: assertLevelSourceId('test.upper.sideEast.generatedCollider'),
+    colliderName: 'TestSideEast',
+  },
+  {
+    role: 'far',
+    render: true,
+    collision: true,
+    sourceId: assertLevelSourceId('test.upper.far.generatedCollider'),
+    colliderName: 'TestFar',
+  },
+  {
+    role: 'shoulder-west',
+    render: true,
+    collision: true,
+    sourceId: assertLevelSourceId('test.upper.shoulderWest.generatedCollider'),
+    colliderName: 'TestShoulderWest',
+  },
+  {
+    role: 'shoulder-east',
+    render: true,
+    collision: true,
+    sourceId: assertLevelSourceId('test.upper.shoulderEast.generatedCollider'),
+    colliderName: 'TestShoulderEast',
+  },
+] as const;
 
 describe('createUpperStairwellLanding', () => {
   it('adds guard colliders around sealed stairwell edges but not across the stair path', () => {
@@ -24,23 +64,29 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.2,
         material: { color: 0xff0000 },
       },
+      segmentPolicies: allSegments,
     });
 
+    const colliderBounds = result.colliders.map(({ bounds }) => bounds);
     expect(result.group.name).toBe('UpperStairwellLanding');
-    expect(result.colliders).toHaveLength(3);
-    expect(result.colliders).toContainEqual({
+    expect(result.colliders.map(({ role }) => role)).toEqual([
+      'side-west',
+      'side-east',
+      'far',
+    ]);
+    expect(colliderBounds).toContainEqual({
       minX: -2.2,
       maxX: -2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(colliderBounds).toContainEqual({
       minX: 2,
       maxX: 2.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(colliderBounds).toContainEqual({
       minX: -2,
       maxX: 2,
       minZ: -8,
@@ -49,7 +95,7 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.6, maxX: 1.6, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      colliderBounds.some((collider) => overlaps(collider, descentPath))
     ).toBe(false);
   });
 
@@ -71,16 +117,24 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.2,
         material: { color: 0xff0000 },
       },
+      segmentPolicies: allSegments,
     });
 
-    expect(result.colliders).toHaveLength(5);
-    expect(result.colliders).toContainEqual({
+    const colliderBounds = result.colliders.map(({ bounds }) => bounds);
+    expect(result.colliders.map(({ role }) => role)).toEqual([
+      'side-west',
+      'side-east',
+      'far',
+      'shoulder-west',
+      'shoulder-east',
+    ]);
+    expect(colliderBounds).toContainEqual({
       minX: -2,
       maxX: -1.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(colliderBounds).toContainEqual({
       minX: 1.1,
       maxX: 2,
       minZ: -8,
@@ -89,11 +143,11 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.2, maxX: 1.1, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      colliderBounds.some((collider) => overlaps(collider, descentPath))
     ).toBe(false);
   });
 
-  it('exposes collider source guard names for stable runtime filtering', () => {
+  it('renders visual-only segments without emitting colliders', () => {
     const result = createUpperStairwellLanding({
       roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
       openingBounds: { minX: -2, maxX: 2, minZ: -8, maxZ: 6 },
@@ -107,20 +161,84 @@ describe('createUpperStairwellLanding', () => {
       guard: {
         height: 0.56,
         thickness: 0.2,
-        sideSides: ['east'],
-        shoulderSides: ['east'],
         material: { color: 0xff0000 },
       },
+      segmentPolicies: [
+        {
+          role: 'side-east',
+          render: true,
+          collision: false,
+          sourceId: assertLevelSourceId('test.upper.visualOnly.generatedSolid'),
+        },
+      ],
     });
 
-    expect(result.namedColliders.map(({ name }) => name)).toEqual([
+    expect(result.group.children.map((child) => child.name)).toEqual([
+      'UpperStairwellLandingSideGuard-East',
+    ]);
+    expect(result.segments).toEqual([
+      {
+        role: 'side-east',
+        sourceId: assertLevelSourceId('test.upper.visualOnly.generatedSolid'),
+        bounds: { minX: 2, maxX: 2.2, minZ: -8, maxZ: 6 },
+        rendered: true,
+      },
+    ]);
+    expect(result.colliders).toEqual([]);
+  });
+
+  it('emits the production east shoulder collider with source ID and stable runtime name', () => {
+    const result = createUpperStairwellLanding({
+      roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
+      openingBounds: { minX: -2, maxX: 2, minZ: -8, maxZ: 6 },
+      descentCorridorBounds: {
+        minX: -1.2,
+        maxX: 1.1,
+        minZ: -7.6,
+        maxZ: 6,
+      },
+      elevation: 4,
+      guard: {
+        height: 0.56,
+        thickness: 0.2,
+        material: { color: 0xff0000 },
+      },
+      segmentPolicies: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
+    });
+
+    expect(result.group.children.map((child) => child.name)).toEqual([
       'UpperStairwellLandingSideGuard-East',
       'UpperStairwellLandingFarGuard',
       'UpperStairwellLandingShoulderGuard-East',
     ]);
-    expect(result.namedColliders.map(({ collider }) => collider)).toStrictEqual(
-      result.colliders
-    );
+    expect(
+      result.segments.map(({ role, rendered, collider }) => ({
+        role,
+        rendered,
+        colliderName: collider?.name,
+      }))
+    ).toEqual([
+      { role: 'side-east', rendered: true, colliderName: undefined },
+      { role: 'far', rendered: true, colliderName: undefined },
+      {
+        role: 'shoulder-east',
+        rendered: true,
+        colliderName: 'UpperStairwellLandingGuard-3',
+      },
+    ]);
+    expect(result.colliders).toEqual([
+      {
+        role: 'shoulder-east',
+        sourceId: 'upper.stairwell.landingGuard.shoulderEast.generatedCollider',
+        name: 'UpperStairwellLandingGuard-3',
+        bounds: {
+          minX: 1.1,
+          maxX: 2,
+          minZ: -8,
+          maxZ: 6,
+        },
+      },
+    ]);
   });
 
   it('clamps guard colliders to the landing room when the opening touches an edge', () => {
@@ -133,16 +251,18 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.4,
         material: { color: 0xff0000 },
       },
+      segmentPolicies: allSegments,
     });
 
-    expect(result.colliders).not.toContainEqual({
+    const colliderBounds = result.colliders.map(({ bounds }) => bounds);
+    expect(colliderBounds).not.toContainEqual({
       minX: -2.4,
       maxX: -2,
       minZ: -4,
       maxZ: 4,
     });
     expect(result.colliders).toHaveLength(2);
-    for (const collider of result.colliders) {
+    for (const collider of colliderBounds) {
       expect(collider.minX).toBeGreaterThanOrEqual(-2);
       expect(collider.maxX).toBeLessThanOrEqual(4);
       expect(collider.minZ).toBeGreaterThanOrEqual(-6);
@@ -161,6 +281,7 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.2,
         material: { color: 0xff0000 },
       },
+      segmentPolicies: allSegments,
     });
 
     const slab = result.group.children.find((child) =>

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -3,23 +3,16 @@ import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../../systems/collision';
+import type {
+  UpperStairwellLandingSegmentPolicy,
+  UpperStairwellLandingSegmentRole,
+} from '../level/upperStairwellLandingPolicy';
 
 export interface UpperStairwellGuardConfig {
   /** Height of the guard rail measured from the upper-floor surface. */
   height: number;
   /** Physical thickness of each rail. */
   thickness: number;
-  /**
-   * Optional long side rail edges around the opening. Omitting west keeps the
-   * upstairs-room egress open while east can still protect the stair void edge.
-   */
-  sideSides?: ReadonlyArray<'east' | 'west'>;
-  /**
-   * Optional shoulder rail sides to add around the descent corridor. Omitting
-   * west keeps the upstairs-room egress open while east can still protect the
-   * stair void edge.
-   */
-  shoulderSides?: ReadonlyArray<'east' | 'west'>;
   /** Optional material overrides for the guard rails. */
   material?: MeshStandardMaterialParameters;
 }
@@ -35,17 +28,29 @@ export interface UpperStairwellLandingConfig {
   elevation: number;
   /** Guard rail configuration. */
   guard: UpperStairwellGuardConfig;
+  /** Declarative source-owned segment render/collision policy. */
+  segmentPolicies: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
-export interface NamedUpperStairwellLandingCollider {
+export interface UpperStairwellLandingColliderRecord {
+  role: UpperStairwellLandingSegmentRole;
+  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
   name: string;
-  collider: RectCollider;
+  bounds: RectCollider;
+}
+
+export interface UpperStairwellLandingSegmentRecord {
+  role: UpperStairwellLandingSegmentRole;
+  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
+  bounds: Bounds2D;
+  rendered: boolean;
+  collider?: UpperStairwellLandingColliderRecord;
 }
 
 export interface UpperStairwellLandingBuild {
   group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
+  segments: UpperStairwellLandingSegmentRecord[];
+  colliders: UpperStairwellLandingColliderRecord[];
 }
 
 const GROUP_NAME = 'UpperStairwellLanding';
@@ -66,12 +71,78 @@ const clampBoundsToRoom = (
   maxZ: Math.min(bounds.maxZ, roomBounds.maxZ),
 });
 
-const addGuard = (params: {
+const getSegmentName = (role: UpperStairwellLandingSegmentRole): string => {
+  switch (role) {
+    case 'side-east':
+      return `${SIDE_GUARD_NAME}-East`;
+    case 'side-west':
+      return `${SIDE_GUARD_NAME}-West`;
+    case 'far':
+      return FAR_GUARD_NAME;
+    case 'shoulder-east':
+      return `${SHOULDER_GUARD_NAME}-East`;
+    case 'shoulder-west':
+      return `${SHOULDER_GUARD_NAME}-West`;
+  }
+};
+
+const getSegmentBounds = (params: {
+  role: UpperStairwellLandingSegmentRole;
+  openingBounds: Bounds2D;
+  descentCorridorBounds?: Bounds2D;
+  thickness: number;
+}): Bounds2D | undefined => {
+  const { openingBounds, descentCorridorBounds, thickness } = params;
+
+  switch (params.role) {
+    case 'side-west':
+      return {
+        minX: openingBounds.minX - thickness,
+        maxX: openingBounds.minX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      };
+    case 'side-east':
+      return {
+        minX: openingBounds.maxX,
+        maxX: openingBounds.maxX + thickness,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      };
+    case 'far':
+      return {
+        minX: openingBounds.minX,
+        maxX: openingBounds.maxX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.minZ + thickness,
+      };
+    case 'shoulder-west':
+      return descentCorridorBounds
+        ? {
+            minX: openingBounds.minX,
+            maxX: descentCorridorBounds.minX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          }
+        : undefined;
+    case 'shoulder-east':
+      return descentCorridorBounds
+        ? {
+            minX: descentCorridorBounds.maxX,
+            maxX: openingBounds.maxX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          }
+        : undefined;
+  }
+};
+
+const addSegment = (params: {
   group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
+  colliders: UpperStairwellLandingColliderRecord[];
+  segments: UpperStairwellLandingSegmentRecord[];
   material: MeshStandardMaterial;
-  name: string;
+  policy: UpperStairwellLandingSegmentPolicy;
   bounds: Bounds2D;
   roomBounds: Bounds2D;
   elevation: number;
@@ -84,19 +155,46 @@ const addGuard = (params: {
     return;
   }
 
-  const guard = new Mesh(
-    new BoxGeometry(width, params.height, depth),
-    params.material
-  );
-  guard.name = params.name;
-  guard.position.set(
-    guardBounds.minX + width / 2,
-    params.elevation + params.height / 2,
-    guardBounds.minZ + depth / 2
-  );
-  params.group.add(guard);
-  params.colliders.push(guardBounds);
-  params.namedColliders.push({ name: params.name, collider: guardBounds });
+  let rendered = false;
+  if (params.policy.render) {
+    const guard = new Mesh(
+      new BoxGeometry(width, params.height, depth),
+      params.material
+    );
+    guard.name = getSegmentName(params.policy.role);
+    guard.userData.levelSourceId = params.policy.sourceId;
+    guard.userData.levelSource = {
+      sourceId: params.policy.sourceId,
+      sourceType: 'generatedSolid',
+      purpose: 'render upper stairwell landing guard segment',
+    };
+    guard.position.set(
+      guardBounds.minX + width / 2,
+      params.elevation + params.height / 2,
+      guardBounds.minZ + depth / 2
+    );
+    params.group.add(guard);
+    rendered = true;
+  }
+
+  const collider = params.policy.collision
+    ? {
+        role: params.policy.role,
+        sourceId: params.policy.sourceId,
+        name: params.policy.colliderName ?? getSegmentName(params.policy.role),
+        bounds: guardBounds,
+      }
+    : undefined;
+  if (collider) {
+    params.colliders.push(collider);
+  }
+  params.segments.push({
+    role: params.policy.role,
+    sourceId: params.policy.sourceId,
+    bounds: guardBounds,
+    rendered,
+    ...(collider ? { collider } : {}),
+  });
 };
 
 /**
@@ -118,117 +216,42 @@ export function createUpperStairwellLanding(
 
   const group = new Group();
   group.name = GROUP_NAME;
-  const colliders: RectCollider[] = [];
-  const namedColliders: NamedUpperStairwellLandingCollider[] = [];
+  const colliders: UpperStairwellLandingColliderRecord[] = [];
+  const segments: UpperStairwellLandingSegmentRecord[] = [];
   const thickness = Math.max(config.guard.thickness, 0);
   const guardMaterial = new MeshStandardMaterial(config.guard.material);
 
   if (thickness <= 0 || config.guard.height <= 0) {
-    return { group, colliders, namedColliders };
+    return { group, segments, colliders };
   }
 
-  const sideSides = config.guard.sideSides ?? ['east', 'west'];
+  const descentCorridorBounds = config.descentCorridorBounds
+    ? clampBoundsToRoom(config.descentCorridorBounds, openingBounds)
+    : undefined;
 
-  if (sideSides.includes('west')) {
-    addGuard({
+  for (const policy of config.segmentPolicies) {
+    const bounds = getSegmentBounds({
+      role: policy.role,
+      openingBounds,
+      descentCorridorBounds,
+      thickness,
+    });
+    if (!bounds) {
+      continue;
+    }
+
+    addSegment({
       group,
       colliders,
-      namedColliders,
+      segments,
       material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-West`,
-      bounds: {
-        minX: openingBounds.minX - thickness,
-        maxX: openingBounds.minX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
+      policy,
+      bounds,
       roomBounds: config.roomBounds,
       elevation: config.elevation,
       height: config.guard.height,
     });
   }
 
-  if (sideSides.includes('east')) {
-    addGuard({
-      group,
-      colliders,
-      namedColliders,
-      material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-East`,
-      bounds: {
-        minX: openingBounds.maxX,
-        maxX: openingBounds.maxX + thickness,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-  }
-  addGuard({
-    group,
-    colliders,
-    namedColliders,
-    material: guardMaterial,
-    name: FAR_GUARD_NAME,
-    bounds: {
-      minX: openingBounds.minX,
-      maxX: openingBounds.maxX,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.minZ + thickness,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
-
-  const shoulderSides = config.guard.shoulderSides ?? ['east', 'west'];
-
-  if (config.descentCorridorBounds && shoulderSides.length > 0) {
-    const descentCorridorBounds = clampBoundsToRoom(
-      config.descentCorridorBounds,
-      openingBounds
-    );
-
-    if (shoulderSides.includes('west')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-West`,
-        bounds: {
-          minX: openingBounds.minX,
-          maxX: descentCorridorBounds.minX,
-          minZ: openingBounds.minZ,
-          maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
-      });
-    }
-
-    if (shoulderSides.includes('east')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-East`,
-        bounds: {
-          minX: descentCorridorBounds.maxX,
-          maxX: openingBounds.maxX,
-          minZ: openingBounds.minZ,
-          maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
-      });
-    }
-  }
-
-  return { group, colliders, namedColliders };
+  return { group, segments, colliders };
 }


### PR DESCRIPTION
### Motivation
- Remove runtime glue in `main.ts` that selected which upper-stair landing rails get colliders and make the active collision policy source-owned and declarative to preserve provenance and make future edits source-first.
- Preserve the current scene: same visible rails, only the east shoulder remains collidable, its runtime name stays `UpperStairwellLandingGuard-3`, and debug ID `400D` remains stable. 

### Description
- Add a source-owned policy module `src/scene/level/upperStairwellLandingPolicy.ts` declaring semantic segment policies (role, render, collision, stable `sourceId`, and optional `colliderName`) and include the explicit compatibility name `UpperStairwellLandingGuard-3` for the production east-shoulder segment.
- Refactor `createUpperStairwellLanding(...)` in `src/scene/structures/upperStairwellLanding.ts` to accept `segmentPolicies`, derive both visual meshes and collider records from the same policy list, omit zero-area segments, annotate rendered meshes with source metadata, and return a single canonical set of `segments` and `colliders` (each collider carries role/source/name/bounds).
- Update runtime assembly in `src/main.ts` to consume the new `UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES`, add the generated group, and register each emitted collider record directly with its stable name and source metadata without any `slice`/`filter`/`startsWith`/index-derived naming logic.
- Update focused tests in `src/scene/structures/__tests__/upperStairwellLanding.test.ts` to assert segment roles/bounds, verify visual-only segments render without colliders, and verify the production east-shoulder emits the sole collider with its `sourceId` and stable runtime name.

### Testing
- Ran formatting: `npm run format:write` — succeeded.
- Confirmed no remaining runtime selection logic with `rg -n "namedColliders|\.slice\(|startsWith\('UpperStairwellLanding|index \+ 3|UpperStairwellLandingGuard-" src/main.ts src/scene` — the only remaining matches are unrelated slices and the explicit compatibility name in the new policy file and tests.
- Ran targeted unit tests: `npm run test:ci -- src/scene/structures/__tests__/upperStairwellLanding.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts` — passed.
- Installed Playwright browsers and deps: `npx playwright install chromium` and `npx playwright install-deps chromium` — succeeded.
- Ran end-to-end Playwright spec: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — passed.
- Ran full lint: `npm run lint` — passed (no blocking errors after import ordering fix).
- Ran full unit suite: `npm run test:ci` — passed (all tests in the suite passed in this run).
- Docs check: `npm run docs:check` — passed (link checks reported pre-existing external fetch warnings only).
- Smoke build: `npm run smoke` — passed (dist build and assertions OK).
- Typecheck: `npm run typecheck` — failed due to many repo-wide TypeScript errors unrelated to this narrow change; these are pre-existing/ambient type issues and not part of the landing-policy refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bc22843c832f8dd889ec66599eb2)