### PR TITLE
Declare upper-stairwell landing guard collider policy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2255,8 +2255,6 @@ function initializeImmersiveScene(
       guard: {
         height: 0.56,
         thickness: toWorldUnits(0.12),
-        sideSides: ['east'],
-        shoulderSides: ['east'],
         material: {
           color: 0x2a3241,
           roughness: 0.72,

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,13 +160,16 @@ import {
   applySceneObjectSourceMetadata,
   createSceneObjectDefinitionsById,
   registerSceneObjectColliders,
+  type SceneObjectColliderSourceMetadata,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
+import type { LevelSourceId } from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
   type LevelSafetyCollider,
 } from './scene/level/stairSafetyColliders';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from './scene/level/upperStairwellLandingSegments';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -992,12 +995,17 @@ const colliderSourceMetadata = new Map<
     sourceId:
       | WallSegmentInstance['sourceId']
       | LevelSafetyCollider['sourceId']
-      | SceneObjectDefinition['sourceId'];
-    sourceType: 'wall' | 'safetyCollider' | 'sceneObject';
+      | SceneObjectDefinition['sourceId']
+      | LevelSourceId;
+    sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
     purpose?: string;
   }
 >();
 const upperFloorColliders: RectCollider[] = [];
+const sceneObjectColliderSourceMetadata = colliderSourceMetadata as Map<
+  RectCollider,
+  SceneObjectColliderSourceMetadata
+>;
 
 const sceneObjectDefinitionsById =
   createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
@@ -2128,9 +2136,19 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const pushNamedUpperFloorCollider = (name: string, bounds: RectCollider) => {
-    upperFloorColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
+  const registerUpperFloorGeneratedCollider = (collider: {
+    name: string;
+    bounds: RectCollider;
+    sourceId: LevelSourceId;
+    role: string;
+  }) => {
+    upperFloorColliders.push(collider.bounds);
+    namedColliderDebugNames.set(collider.bounds, collider.name);
+    colliderSourceMetadata.set(collider.bounds, {
+      sourceId: collider.sourceId,
+      sourceType: 'generatedCollider',
+      purpose: `upper stairwell landing ${collider.role} guard`,
+    });
   };
 
   const upperStairWestEgressLaneX =
@@ -2250,18 +2268,12 @@ function initializeImmersiveScene(
           metalness: 0.05,
         },
       },
+      segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
     });
     upperFloorGroup.add(upperStairwellLanding.group);
-    upperStairwellLanding.namedColliders
-      .filter(({ name }) =>
-        name.startsWith('UpperStairwellLandingShoulderGuard')
-      )
-      .forEach(({ collider }, index) =>
-        pushNamedUpperFloorCollider(
-          `UpperStairwellLandingGuard-${index + 3}`,
-          collider
-        )
-      );
+    upperStairwellLanding.colliders.forEach(
+      registerUpperFloorGeneratedCollider
+    );
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });
@@ -2844,7 +2856,7 @@ function initializeImmersiveScene(
         showpiece.colliders,
         flywheelSceneObject,
         groundColliders,
-        colliderSourceMetadata
+        sceneObjectColliderSourceMetadata
       );
     } else {
       showpiece.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2877,7 +2889,7 @@ function initializeImmersiveScene(
         terminal.colliders,
         jobbotSceneObject,
         groundColliders,
-        colliderSourceMetadata
+        sceneObjectColliderSourceMetadata
       );
     } else {
       terminal.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2901,7 +2913,7 @@ function initializeImmersiveScene(
           navigator.colliders,
           axelSceneObject,
           groundColliders,
-          colliderSourceMetadata
+          sceneObjectColliderSourceMetadata
         );
       } else {
         navigator.colliders.forEach((collider) =>
@@ -2959,7 +2971,7 @@ function initializeImmersiveScene(
         console.colliders,
         prReaperSceneObject,
         groundColliders,
-        colliderSourceMetadata
+        sceneObjectColliderSourceMetadata
       );
     } else {
       console.colliders.forEach((collider) => groundColliders.push(collider));
@@ -3070,7 +3082,7 @@ function initializeImmersiveScene(
         loom.colliders,
         woveSceneObject,
         groundColliders,
-        colliderSourceMetadata
+        sceneObjectColliderSourceMetadata
       );
     } else {
       loom.colliders.forEach((collider) => groundColliders.push(collider));

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,7 +160,6 @@ import {
   applySceneObjectSourceMetadata,
   createSceneObjectDefinitionsById,
   registerSceneObjectColliders,
-  type SceneObjectColliderSourceMetadata,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
 import type { LevelSourceId } from './scene/level/sourceIds';
@@ -1002,10 +1001,6 @@ const colliderSourceMetadata = new Map<
   }
 >();
 const upperFloorColliders: RectCollider[] = [];
-const sceneObjectColliderSourceMetadata = colliderSourceMetadata as Map<
-  RectCollider,
-  SceneObjectColliderSourceMetadata
->;
 
 const sceneObjectDefinitionsById =
   createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
@@ -2856,7 +2851,7 @@ function initializeImmersiveScene(
         showpiece.colliders,
         flywheelSceneObject,
         groundColliders,
-        sceneObjectColliderSourceMetadata
+        colliderSourceMetadata
       );
     } else {
       showpiece.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2889,7 +2884,7 @@ function initializeImmersiveScene(
         terminal.colliders,
         jobbotSceneObject,
         groundColliders,
-        sceneObjectColliderSourceMetadata
+        colliderSourceMetadata
       );
     } else {
       terminal.colliders.forEach((collider) => groundColliders.push(collider));
@@ -2913,7 +2908,7 @@ function initializeImmersiveScene(
           navigator.colliders,
           axelSceneObject,
           groundColliders,
-          sceneObjectColliderSourceMetadata
+          colliderSourceMetadata
         );
       } else {
         navigator.colliders.forEach((collider) =>
@@ -2971,7 +2966,7 @@ function initializeImmersiveScene(
         console.colliders,
         prReaperSceneObject,
         groundColliders,
-        sceneObjectColliderSourceMetadata
+        colliderSourceMetadata
       );
     } else {
       console.colliders.forEach((collider) => groundColliders.push(collider));
@@ -3082,7 +3077,7 @@ function initializeImmersiveScene(
         loom.colliders,
         woveSceneObject,
         groundColliders,
-        sceneObjectColliderSourceMetadata
+        colliderSourceMetadata
       );
     } else {
       loom.colliders.forEach((collider) => groundColliders.push(collider));

--- a/src/scene/level/sceneObjects.ts
+++ b/src/scene/level/sceneObjects.ts
@@ -57,11 +57,18 @@ export function applySceneObjectSourceMetadata(
   });
 }
 
+type SceneObjectColliderMetadataSink = {
+  set(
+    collider: RectCollider,
+    metadata: SceneObjectColliderSourceMetadata
+  ): unknown;
+};
+
 export function registerSceneObjectColliders(
   colliders: readonly RectCollider[],
   definition: SceneObjectDefinition,
   target: RectCollider[],
-  colliderSourceMetadata: Map<RectCollider, SceneObjectColliderSourceMetadata>
+  colliderSourceMetadata: SceneObjectColliderMetadataSink
 ): void {
   colliders.forEach((collider) => {
     target.push(collider);

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -1,0 +1,40 @@
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type UpperStairwellLandingSegmentRole =
+  | 'side-west'
+  | 'side-east'
+  | 'far'
+  | 'shoulder-west'
+  | 'shoulder-east';
+
+export interface UpperStairwellLandingSegmentPolicy {
+  role: UpperStairwellLandingSegmentRole;
+  render: boolean;
+  collision: boolean;
+  sourceId: LevelSourceId;
+  colliderName?: string;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+
+export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
+  {
+    role: 'side-east',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landingGuard.sideEast'),
+  },
+  {
+    role: 'far',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landingGuard.far'),
+  },
+  {
+    role: 'shoulder-east',
+    render: true,
+    collision: true,
+    sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
+    colliderName: 'UpperStairwellLandingGuard-3',
+  },
+] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,8 +1,30 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../../level/upperStairwellLandingSegments';
+import { assertLevelSourceId } from '../../level/sourceIds';
+import {
+  UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
+  type UpperStairwellLandingSegmentPolicy,
+  type UpperStairwellLandingSegmentRole,
+} from '../../level/upperStairwellLandingSegments';
 import { createUpperStairwellLanding } from '../upperStairwellLanding';
+
+const ALL_SEGMENT_ROLES: readonly UpperStairwellLandingSegmentRole[] = [
+  'side-west',
+  'side-east',
+  'far',
+  'shoulder-west',
+  'shoulder-east',
+];
+
+const allSegmentPolicies = (): UpperStairwellLandingSegmentPolicy[] =>
+  ALL_SEGMENT_ROLES.map((role) => ({
+    role,
+    render: true,
+    collision: true,
+    sourceId: assertLevelSourceId(`upper.stairwell.landingGuard.test.${role}`),
+    colliderName: `UpperStairwellLandingTestGuard-${role}`,
+  }));
 
 const overlaps = (
   first: { minX: number; maxX: number; minZ: number; maxZ: number },
@@ -25,6 +47,7 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.2,
         material: { color: 0xff0000 },
       },
+      segments: allSegmentPolicies(),
     });
 
     expect(result.group.name).toBe('UpperStairwellLanding');
@@ -72,6 +95,7 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.2,
         material: { color: 0xff0000 },
       },
+      segments: allSegmentPolicies(),
     });
 
     expect(result.colliders).toHaveLength(5);
@@ -143,6 +167,7 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.4,
         material: { color: 0xff0000 },
       },
+      segments: allSegmentPolicies(),
     });
 
     expect(result.colliders.map(({ bounds }) => bounds)).not.toContainEqual({
@@ -171,6 +196,7 @@ describe('createUpperStairwellLanding', () => {
         thickness: 0.2,
         material: { color: 0xff0000 },
       },
+      segments: allSegmentPolicies(),
     });
 
     const slab = result.group.children.find((child) =>

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,6 +1,7 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../../level/upperStairwellLandingSegments';
 import { createUpperStairwellLanding } from '../upperStairwellLanding';
 
 const overlaps = (
@@ -28,19 +29,19 @@ describe('createUpperStairwellLanding', () => {
 
     expect(result.group.name).toBe('UpperStairwellLanding');
     expect(result.colliders).toHaveLength(3);
-    expect(result.colliders).toContainEqual({
+    expect(result.colliders.map(({ bounds }) => bounds)).toContainEqual({
       minX: -2.2,
       maxX: -2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(result.colliders.map(({ bounds }) => bounds)).toContainEqual({
       minX: 2,
       maxX: 2.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(result.colliders.map(({ bounds }) => bounds)).toContainEqual({
       minX: -2,
       maxX: 2,
       minZ: -8,
@@ -49,7 +50,7 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.6, maxX: 1.6, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      result.colliders.some(({ bounds }) => overlaps(bounds, descentPath))
     ).toBe(false);
   });
 
@@ -74,13 +75,13 @@ describe('createUpperStairwellLanding', () => {
     });
 
     expect(result.colliders).toHaveLength(5);
-    expect(result.colliders).toContainEqual({
+    expect(result.colliders.map(({ bounds }) => bounds)).toContainEqual({
       minX: -2,
       maxX: -1.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(result.colliders.map(({ bounds }) => bounds)).toContainEqual({
       minX: 1.1,
       maxX: 2,
       minZ: -8,
@@ -89,11 +90,11 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.2, maxX: 1.1, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      result.colliders.some(({ bounds }) => overlaps(bounds, descentPath))
     ).toBe(false);
   });
 
-  it('exposes collider source guard names for stable runtime filtering', () => {
+  it('renders visual-only production segments but emits only the east shoulder collider', () => {
     const result = createUpperStairwellLanding({
       roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
       openingBounds: { minX: -2, maxX: 2, minZ: -8, maxZ: 6 },
@@ -107,20 +108,29 @@ describe('createUpperStairwellLanding', () => {
       guard: {
         height: 0.56,
         thickness: 0.2,
-        sideSides: ['east'],
-        shoulderSides: ['east'],
         material: { color: 0xff0000 },
       },
+      segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
     });
 
-    expect(result.namedColliders.map(({ name }) => name)).toEqual([
+    expect(result.group.children.map((child) => child.name)).toEqual([
       'UpperStairwellLandingSideGuard-East',
       'UpperStairwellLandingFarGuard',
       'UpperStairwellLandingShoulderGuard-East',
     ]);
-    expect(result.namedColliders.map(({ collider }) => collider)).toStrictEqual(
-      result.colliders
-    );
+    expect(result.colliders).toEqual([
+      {
+        role: 'shoulder-east',
+        sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+        name: 'UpperStairwellLandingGuard-3',
+        bounds: {
+          minX: 1.1,
+          maxX: 2,
+          minZ: -8,
+          maxZ: 6,
+        },
+      },
+    ]);
   });
 
   it('clamps guard colliders to the landing room when the opening touches an edge', () => {
@@ -135,14 +145,14 @@ describe('createUpperStairwellLanding', () => {
       },
     });
 
-    expect(result.colliders).not.toContainEqual({
+    expect(result.colliders.map(({ bounds }) => bounds)).not.toContainEqual({
       minX: -2.4,
       maxX: -2,
       minZ: -4,
       maxZ: 4,
     });
     expect(result.colliders).toHaveLength(2);
-    for (const collider of result.colliders) {
+    for (const { bounds: collider } of result.colliders) {
       expect(collider.minX).toBeGreaterThanOrEqual(-2);
       expect(collider.maxX).toBeLessThanOrEqual(4);
       expect(collider.minZ).toBeGreaterThanOrEqual(-6);

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -3,7 +3,6 @@ import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../../systems/collision';
-import { assertLevelSourceId } from '../level/sourceIds';
 import type {
   UpperStairwellLandingSegmentPolicy,
   UpperStairwellLandingSegmentRole,
@@ -14,17 +13,6 @@ export interface UpperStairwellGuardConfig {
   height: number;
   /** Physical thickness of each rail. */
   thickness: number;
-  /**
-   * Optional long side rail edges around the opening. Omitting west keeps the
-   * upstairs-room egress open while east can still protect the stair void edge.
-   */
-  sideSides?: ReadonlyArray<'east' | 'west'>;
-  /**
-   * Optional shoulder rail sides to add around the descent corridor. Omitting
-   * west keeps the upstairs-room egress open while east can still protect the
-   * stair void edge.
-   */
-  shoulderSides?: ReadonlyArray<'east' | 'west'>;
   /** Optional material overrides for the guard rails. */
   material?: MeshStandardMaterialParameters;
 }
@@ -41,7 +29,7 @@ export interface UpperStairwellLandingConfig {
   /** Guard rail configuration. */
   guard: UpperStairwellGuardConfig;
   /** Declarative render/collision policy for semantic guard segments. */
-  segments?: readonly UpperStairwellLandingSegmentPolicy[];
+  segments: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
 export interface UpperStairwellLandingCollider {
@@ -61,24 +49,6 @@ const SIDE_GUARD_NAME = 'UpperStairwellLandingSideGuard';
 const FAR_GUARD_NAME = 'UpperStairwellLandingFarGuard';
 const SHOULDER_GUARD_NAME = 'UpperStairwellLandingShoulderGuard';
 
-const DEFAULT_SEGMENT_SOURCE_IDS = {
-  'side-west': 'upper.stairwell.landingGuard.sideWest',
-  'side-east': 'upper.stairwell.landingGuard.sideEast',
-  far: 'upper.stairwell.landingGuard.far',
-  'shoulder-west': 'upper.stairwell.landingGuard.shoulderWest',
-  'shoulder-east': 'upper.stairwell.landingGuard.shoulderEast',
-} as const satisfies Record<UpperStairwellLandingSegmentRole, string>;
-
-const createDefaultSegmentPolicy = (
-  role: UpperStairwellLandingSegmentRole
-): UpperStairwellLandingSegmentPolicy => ({
-  role,
-  render: true,
-  collision: true,
-  sourceId: assertLevelSourceId(DEFAULT_SEGMENT_SOURCE_IDS[role]),
-  colliderName: getMeshNameForRole(role),
-});
-
 const getMeshNameForRole = (role: UpperStairwellLandingSegmentRole): string => {
   switch (role) {
     case 'side-west':
@@ -92,22 +62,6 @@ const getMeshNameForRole = (role: UpperStairwellLandingSegmentRole): string => {
     case 'shoulder-east':
       return `${SHOULDER_GUARD_NAME}-East`;
   }
-};
-
-const getDefaultSegmentPolicies = (
-  config: UpperStairwellLandingConfig
-): UpperStairwellLandingSegmentPolicy[] => {
-  const sideSides = config.guard.sideSides ?? ['east', 'west'];
-  const shoulderSides = config.guard.shoulderSides ?? ['east', 'west'];
-  const roles: UpperStairwellLandingSegmentRole[] = [
-    ...sideSides.map((side) => `side-${side}` as const),
-    'far',
-    ...(config.descentCorridorBounds
-      ? shoulderSides.map((side) => `shoulder-${side}` as const)
-      : []),
-  ];
-
-  return roles.map(createDefaultSegmentPolicy);
 };
 
 const hasPositiveArea = (bounds: Bounds2D): boolean =>
@@ -201,9 +155,7 @@ export function createUpperStairwellLanding(
   const descentCorridorBounds = config.descentCorridorBounds
     ? clampBoundsToRoom(config.descentCorridorBounds, openingBounds)
     : undefined;
-  const segmentPolicies = config.segments ?? getDefaultSegmentPolicies(config);
-
-  for (const policy of segmentPolicies) {
+  for (const policy of config.segments) {
     let bounds: Bounds2D | undefined;
 
     switch (policy.role) {

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -3,6 +3,11 @@ import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../../systems/collision';
+import { assertLevelSourceId } from '../level/sourceIds';
+import type {
+  UpperStairwellLandingSegmentPolicy,
+  UpperStairwellLandingSegmentRole,
+} from '../level/upperStairwellLandingSegments';
 
 export interface UpperStairwellGuardConfig {
   /** Height of the guard rail measured from the upper-floor surface. */
@@ -35,23 +40,75 @@ export interface UpperStairwellLandingConfig {
   elevation: number;
   /** Guard rail configuration. */
   guard: UpperStairwellGuardConfig;
+  /** Declarative render/collision policy for semantic guard segments. */
+  segments?: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
-export interface NamedUpperStairwellLandingCollider {
+export interface UpperStairwellLandingCollider {
+  role: UpperStairwellLandingSegmentRole;
+  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
   name: string;
-  collider: RectCollider;
+  bounds: RectCollider;
 }
 
 export interface UpperStairwellLandingBuild {
   group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
+  colliders: UpperStairwellLandingCollider[];
 }
 
 const GROUP_NAME = 'UpperStairwellLanding';
 const SIDE_GUARD_NAME = 'UpperStairwellLandingSideGuard';
 const FAR_GUARD_NAME = 'UpperStairwellLandingFarGuard';
 const SHOULDER_GUARD_NAME = 'UpperStairwellLandingShoulderGuard';
+
+const DEFAULT_SEGMENT_SOURCE_IDS = {
+  'side-west': 'upper.stairwell.landingGuard.sideWest',
+  'side-east': 'upper.stairwell.landingGuard.sideEast',
+  far: 'upper.stairwell.landingGuard.far',
+  'shoulder-west': 'upper.stairwell.landingGuard.shoulderWest',
+  'shoulder-east': 'upper.stairwell.landingGuard.shoulderEast',
+} as const satisfies Record<UpperStairwellLandingSegmentRole, string>;
+
+const createDefaultSegmentPolicy = (
+  role: UpperStairwellLandingSegmentRole
+): UpperStairwellLandingSegmentPolicy => ({
+  role,
+  render: true,
+  collision: true,
+  sourceId: assertLevelSourceId(DEFAULT_SEGMENT_SOURCE_IDS[role]),
+  colliderName: getMeshNameForRole(role),
+});
+
+const getMeshNameForRole = (role: UpperStairwellLandingSegmentRole): string => {
+  switch (role) {
+    case 'side-west':
+      return `${SIDE_GUARD_NAME}-West`;
+    case 'side-east':
+      return `${SIDE_GUARD_NAME}-East`;
+    case 'far':
+      return FAR_GUARD_NAME;
+    case 'shoulder-west':
+      return `${SHOULDER_GUARD_NAME}-West`;
+    case 'shoulder-east':
+      return `${SHOULDER_GUARD_NAME}-East`;
+  }
+};
+
+const getDefaultSegmentPolicies = (
+  config: UpperStairwellLandingConfig
+): UpperStairwellLandingSegmentPolicy[] => {
+  const sideSides = config.guard.sideSides ?? ['east', 'west'];
+  const shoulderSides = config.guard.shoulderSides ?? ['east', 'west'];
+  const roles: UpperStairwellLandingSegmentRole[] = [
+    ...sideSides.map((side) => `side-${side}` as const),
+    'far',
+    ...(config.descentCorridorBounds
+      ? shoulderSides.map((side) => `shoulder-${side}` as const)
+      : []),
+  ];
+
+  return roles.map(createDefaultSegmentPolicy);
+};
 
 const hasPositiveArea = (bounds: Bounds2D): boolean =>
   bounds.maxX > bounds.minX && bounds.maxZ > bounds.minZ;
@@ -68,10 +125,10 @@ const clampBoundsToRoom = (
 
 const addGuard = (params: {
   group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
+  colliders: UpperStairwellLandingCollider[];
   material: MeshStandardMaterial;
-  name: string;
+  policy: UpperStairwellLandingSegmentPolicy;
+  meshName: string;
   bounds: Bounds2D;
   roomBounds: Bounds2D;
   elevation: number;
@@ -84,19 +141,34 @@ const addGuard = (params: {
     return;
   }
 
-  const guard = new Mesh(
-    new BoxGeometry(width, params.height, depth),
-    params.material
-  );
-  guard.name = params.name;
-  guard.position.set(
-    guardBounds.minX + width / 2,
-    params.elevation + params.height / 2,
-    guardBounds.minZ + depth / 2
-  );
-  params.group.add(guard);
-  params.colliders.push(guardBounds);
-  params.namedColliders.push({ name: params.name, collider: guardBounds });
+  if (params.policy.render) {
+    const guard = new Mesh(
+      new BoxGeometry(width, params.height, depth),
+      params.material
+    );
+    guard.name = params.meshName;
+    guard.position.set(
+      guardBounds.minX + width / 2,
+      params.elevation + params.height / 2,
+      guardBounds.minZ + depth / 2
+    );
+    params.group.add(guard);
+  }
+
+  if (params.policy.collision) {
+    if (!params.policy.colliderName) {
+      throw new Error(
+        `Upper stairwell landing segment ${params.policy.role} enables collision without a collider name.`
+      );
+    }
+
+    params.colliders.push({
+      role: params.policy.role,
+      sourceId: params.policy.sourceId,
+      name: params.policy.colliderName,
+      bounds: guardBounds,
+    });
+  }
 };
 
 /**
@@ -118,117 +190,83 @@ export function createUpperStairwellLanding(
 
   const group = new Group();
   group.name = GROUP_NAME;
-  const colliders: RectCollider[] = [];
-  const namedColliders: NamedUpperStairwellLandingCollider[] = [];
+  const colliders: UpperStairwellLandingCollider[] = [];
   const thickness = Math.max(config.guard.thickness, 0);
   const guardMaterial = new MeshStandardMaterial(config.guard.material);
 
   if (thickness <= 0 || config.guard.height <= 0) {
-    return { group, colliders, namedColliders };
+    return { group, colliders };
   }
 
-  const sideSides = config.guard.sideSides ?? ['east', 'west'];
+  const descentCorridorBounds = config.descentCorridorBounds
+    ? clampBoundsToRoom(config.descentCorridorBounds, openingBounds)
+    : undefined;
+  const segmentPolicies = config.segments ?? getDefaultSegmentPolicies(config);
 
-  if (sideSides.includes('west')) {
-    addGuard({
-      group,
-      colliders,
-      namedColliders,
-      material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-West`,
-      bounds: {
-        minX: openingBounds.minX - thickness,
-        maxX: openingBounds.minX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-  }
+  for (const policy of segmentPolicies) {
+    let bounds: Bounds2D | undefined;
 
-  if (sideSides.includes('east')) {
-    addGuard({
-      group,
-      colliders,
-      namedColliders,
-      material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-East`,
-      bounds: {
-        minX: openingBounds.maxX,
-        maxX: openingBounds.maxX + thickness,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-  }
-  addGuard({
-    group,
-    colliders,
-    namedColliders,
-    material: guardMaterial,
-    name: FAR_GUARD_NAME,
-    bounds: {
-      minX: openingBounds.minX,
-      maxX: openingBounds.maxX,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.minZ + thickness,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
-
-  const shoulderSides = config.guard.shoulderSides ?? ['east', 'west'];
-
-  if (config.descentCorridorBounds && shoulderSides.length > 0) {
-    const descentCorridorBounds = clampBoundsToRoom(
-      config.descentCorridorBounds,
-      openingBounds
-    );
-
-    if (shoulderSides.includes('west')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-West`,
-        bounds: {
-          minX: openingBounds.minX,
-          maxX: descentCorridorBounds.minX,
+    switch (policy.role) {
+      case 'side-west':
+        bounds = {
+          minX: openingBounds.minX - thickness,
+          maxX: openingBounds.minX,
           minZ: openingBounds.minZ,
           maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
-      });
-    }
-
-    if (shoulderSides.includes('east')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-East`,
-        bounds: {
-          minX: descentCorridorBounds.maxX,
+        };
+        break;
+      case 'side-east':
+        bounds = {
+          minX: openingBounds.maxX,
+          maxX: openingBounds.maxX + thickness,
+          minZ: openingBounds.minZ,
+          maxZ: openingBounds.maxZ,
+        };
+        break;
+      case 'far':
+        bounds = {
+          minX: openingBounds.minX,
           maxX: openingBounds.maxX,
           minZ: openingBounds.minZ,
-          maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
-      });
+          maxZ: openingBounds.minZ + thickness,
+        };
+        break;
+      case 'shoulder-west':
+        if (descentCorridorBounds) {
+          bounds = {
+            minX: openingBounds.minX,
+            maxX: descentCorridorBounds.minX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          };
+        }
+        break;
+      case 'shoulder-east':
+        if (descentCorridorBounds) {
+          bounds = {
+            minX: descentCorridorBounds.maxX,
+            maxX: openingBounds.maxX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          };
+        }
+        break;
     }
+
+    if (!bounds) continue;
+
+    addGuard({
+      group,
+      colliders,
+      material: guardMaterial,
+      policy,
+      meshName: getMeshNameForRole(policy.role),
+      bounds,
+      roomBounds: config.roomBounds,
+      elevation: config.elevation,
+      height: config.guard.height,
+    });
   }
 
-  return { group, colliders, namedColliders };
+  return { group, colliders };
 }


### PR DESCRIPTION
### Motivation

- Move the production policy that decides which upper-stairwell landing rails get colliders out of runtime assembly and into a source-owned, declarative representation.  
- Make visual rendering and collision registration derive from the same semantic segment policy so future collider changes are made in source data rather than in `src/main.ts` glue.

### Description

- Add `src/scene/level/upperStairwellLandingSegments.ts` which declares `UpperStairwellLandingSegmentPolicy` records (role, `render`, `collision`, `sourceId`, and optional `colliderName`) and exposes the production policy that keeps `UpperStairwellLandingGuard-3` as the explicit active collider name.  
- Refactor `createUpperStairwellLanding(...)` in `src/scene/structures/upperStairwellLanding.ts` to accept segment policies (or generate defaults), render meshes for policies with `render: true`, and emit one canonical collider record per collision-enabled segment with `role`, `sourceId`, stable `name`, and `bounds` (replacing the parallel `colliders`/`namedColliders` arrays).  
- Update `src/main.ts` to pass the declarative production policy into the generator and to register each emitted collider record directly (preserving source/provenance metadata and the stable runtime name) without any `.slice(...)`, `.filter(...)`, `startsWith(...)`, or index-derived naming.  
- Update focused tests in `src/scene/structures/__tests__/upperStairwellLanding.test.ts` to assert that visual-only segments still render while only the east-shoulder segment emits the single production collider with `name: 'UpperStairwellLandingGuard-3'` and the matching `sourceId`.

### Testing

- Ran formatting: `npm run format:write` — OK.  
- Confirmed search for prior runtime-selection patterns: `rg -n "namedColliders|\.slice\(|startsWith\('UpperStairwellLanding|index \+ 3|UpperStairwellLandingGuard-" src/main.ts src/scene` — no remaining selection logic in `src/main.ts` (matches only the new declarative file and test expectations).  
- Focused unit tests: `npm run test:ci -- src/scene/structures/__tests__/upperStairwellLanding.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts` — both files passed.  
- Full unit test suite: `npm run test:ci` — reported `158` test files / `1205` tests passed.  
- Playwright: initial run failed due to missing browser binaries; installed browsers and deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — all 9 Playwright stairs-roundtrip tests passed.  
- Lint: `npm run lint` — warnings addressed; linter passed.  
- Docs & smoke: `npm run docs:check` (link checker reported transient external fetch warnings) and `npm run smoke` (build + dist assertions) — passed.  
- Typecheck: `npm run typecheck` — noted that unrelated repo-wide TypeScript issues remain; the change fixed the local map-type mismatch but full repo typecheck shows existing unrelated errors outside this change.  
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

Residual notes: this PR is an architectural cleanup that preserves current runtime behavior and debug compatibility (`UpperStairwellLandingGuard-3` and debug IDs remain intact); further migration of debug ID assignment is intentionally deferred to the follow-up task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bc2d6218832f8eacb850498a97f8)