### PR TITLE
Declare upper stairwell landing guard collision policy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -167,6 +167,7 @@ import {
   createUpperStairSafetyColliders,
   type LevelSafetyCollider,
 } from './scene/level/stairSafetyColliders';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from './scene/level/upperStairwellLandingSegments';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -2128,11 +2129,6 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const pushNamedUpperFloorCollider = (name: string, bounds: RectCollider) => {
-    upperFloorColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
-  };
-
   const upperStairWestEgressLaneX =
     stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
   const upperStairWestEgressBlockerMinX =
@@ -2242,8 +2238,7 @@ function initializeImmersiveScene(
       guard: {
         height: 0.56,
         thickness: toWorldUnits(0.12),
-        sideSides: ['east'],
-        shoulderSides: ['east'],
+        segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
         material: {
           color: 0x2a3241,
           roughness: 0.72,
@@ -2252,16 +2247,15 @@ function initializeImmersiveScene(
       },
     });
     upperFloorGroup.add(upperStairwellLanding.group);
-    upperStairwellLanding.namedColliders
-      .filter(({ name }) =>
-        name.startsWith('UpperStairwellLandingShoulderGuard')
-      )
-      .forEach(({ collider }, index) =>
-        pushNamedUpperFloorCollider(
-          `UpperStairwellLandingGuard-${index + 3}`,
-          collider
-        )
-      );
+    upperStairwellLanding.segments.forEach((segment) => {
+      upperFloorColliders.push(segment.bounds);
+      namedColliderDebugNames.set(segment.bounds, segment.name);
+      colliderSourceMetadata.set(segment.bounds, {
+        sourceId: segment.sourceId,
+        sourceType: 'safetyCollider',
+        purpose: `upper stairwell landing ${segment.role} guard`,
+      });
+    });
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -1,0 +1,42 @@
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type UpperStairwellLandingSegmentRole =
+  | 'side-east'
+  | 'side-west'
+  | 'far'
+  | 'shoulder-east'
+  | 'shoulder-west';
+
+export interface UpperStairwellLandingSegmentPolicy {
+  role: UpperStairwellLandingSegmentRole;
+  render: boolean;
+  collision: boolean;
+  sourceId: LevelSourceId;
+  colliderName?: string;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+
+export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
+  {
+    role: 'side-east',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landing.sideEast.generatedCollider'),
+  },
+  {
+    role: 'far',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landing.far.generatedCollider'),
+  },
+  {
+    role: 'shoulder-east',
+    render: true,
+    collision: true,
+    sourceId: sourceId(
+      'upper.stairwell.landing.shoulderEast.generatedCollider'
+    ),
+    colliderName: 'UpperStairwellLandingGuard-3',
+  },
+] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,6 +1,8 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
+import { assertLevelSourceId } from '../../level/sourceIds';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../../level/upperStairwellLandingSegments';
 import { createUpperStairwellLanding } from '../upperStairwellLanding';
 
 const overlaps = (
@@ -27,20 +29,20 @@ describe('createUpperStairwellLanding', () => {
     });
 
     expect(result.group.name).toBe('UpperStairwellLanding');
-    expect(result.colliders).toHaveLength(3);
-    expect(result.colliders).toContainEqual({
+    expect(result.segments.map((segment) => segment.bounds)).toHaveLength(3);
+    expect(result.segments.map((segment) => segment.bounds)).toContainEqual({
       minX: -2.2,
       maxX: -2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(result.segments.map((segment) => segment.bounds)).toContainEqual({
       minX: 2,
       maxX: 2.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(result.segments.map((segment) => segment.bounds)).toContainEqual({
       minX: -2,
       maxX: 2,
       minZ: -8,
@@ -49,7 +51,9 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.6, maxX: 1.6, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      result.segments
+        .map((segment) => segment.bounds)
+        .some((collider) => overlaps(collider, descentPath))
     ).toBe(false);
   });
 
@@ -73,14 +77,14 @@ describe('createUpperStairwellLanding', () => {
       },
     });
 
-    expect(result.colliders).toHaveLength(5);
-    expect(result.colliders).toContainEqual({
+    expect(result.segments.map((segment) => segment.bounds)).toHaveLength(5);
+    expect(result.segments.map((segment) => segment.bounds)).toContainEqual({
       minX: -2,
       maxX: -1.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(result.segments.map((segment) => segment.bounds)).toContainEqual({
       minX: 1.1,
       maxX: 2,
       minZ: -8,
@@ -89,11 +93,13 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.2, maxX: 1.1, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      result.segments
+        .map((segment) => segment.bounds)
+        .some((collider) => overlaps(collider, descentPath))
     ).toBe(false);
   });
 
-  it('exposes collider source guard names for stable runtime filtering', () => {
+  it('renders visual-only segments while emitting only policy-enabled colliders', () => {
     const result = createUpperStairwellLanding({
       roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
       openingBounds: { minX: -2, maxX: 2, minZ: -8, maxZ: 6 },
@@ -107,20 +113,90 @@ describe('createUpperStairwellLanding', () => {
       guard: {
         height: 0.56,
         thickness: 0.2,
-        sideSides: ['east'],
-        shoulderSides: ['east'],
+        segments: [
+          {
+            role: 'side-east',
+            render: true,
+            collision: false,
+            sourceId: assertLevelSourceId('test.upper.sideEast'),
+          },
+          {
+            role: 'far',
+            render: true,
+            collision: false,
+            sourceId: assertLevelSourceId('test.upper.far'),
+          },
+          {
+            role: 'shoulder-east',
+            render: true,
+            collision: true,
+            sourceId: assertLevelSourceId('test.upper.shoulderEast'),
+            colliderName: 'UpperStairwellLandingGuard-3',
+          },
+        ],
         material: { color: 0xff0000 },
       },
     });
 
-    expect(result.namedColliders.map(({ name }) => name)).toEqual([
+    expect(result.group.children.map((child) => child.name)).toEqual([
       'UpperStairwellLandingSideGuard-East',
       'UpperStairwellLandingFarGuard',
       'UpperStairwellLandingShoulderGuard-East',
     ]);
-    expect(result.namedColliders.map(({ collider }) => collider)).toStrictEqual(
-      result.colliders
-    );
+    expect(result.segments).toEqual([
+      {
+        role: 'shoulder-east',
+        sourceId: assertLevelSourceId('test.upper.shoulderEast'),
+        name: 'UpperStairwellLandingGuard-3',
+        bounds: {
+          minX: 1.1,
+          maxX: 2,
+          minZ: -8,
+          maxZ: 6,
+        },
+      },
+    ]);
+  });
+
+  it('emits only the production east shoulder collider with source metadata', () => {
+    const result = createUpperStairwellLanding({
+      roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
+      openingBounds: { minX: -2, maxX: 2, minZ: -8, maxZ: 6 },
+      descentCorridorBounds: {
+        minX: -1.2,
+        maxX: 1.1,
+        minZ: -7.6,
+        maxZ: 6,
+      },
+      elevation: 4,
+      guard: {
+        height: 0.56,
+        thickness: 0.2,
+        segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
+        material: { color: 0xff0000 },
+      },
+    });
+
+    expect(result.group.children.map((child) => child.name)).toEqual([
+      'UpperStairwellLandingSideGuard-East',
+      'UpperStairwellLandingFarGuard',
+      'UpperStairwellLandingShoulderGuard-East',
+    ]);
+    expect(result.segments).toEqual([
+      {
+        role: 'shoulder-east',
+        sourceId: assertLevelSourceId(
+          'upper.stairwell.landing.shoulderEast.generatedCollider'
+        ),
+        name: 'UpperStairwellLandingGuard-3',
+        bounds: {
+          minX: 1.1,
+          maxX: 2,
+          minZ: -8,
+          maxZ: 6,
+        },
+      },
+    ]);
   });
 
   it('clamps guard colliders to the landing room when the opening touches an edge', () => {
@@ -135,14 +211,16 @@ describe('createUpperStairwellLanding', () => {
       },
     });
 
-    expect(result.colliders).not.toContainEqual({
-      minX: -2.4,
-      maxX: -2,
-      minZ: -4,
-      maxZ: 4,
-    });
-    expect(result.colliders).toHaveLength(2);
-    for (const collider of result.colliders) {
+    expect(result.segments.map((segment) => segment.bounds)).not.toContainEqual(
+      {
+        minX: -2.4,
+        maxX: -2,
+        minZ: -4,
+        maxZ: 4,
+      }
+    );
+    expect(result.segments.map((segment) => segment.bounds)).toHaveLength(2);
+    for (const collider of result.segments.map((segment) => segment.bounds)) {
       expect(collider.minX).toBeGreaterThanOrEqual(-2);
       expect(collider.maxX).toBeLessThanOrEqual(4);
       expect(collider.minZ).toBeGreaterThanOrEqual(-6);

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -3,25 +3,20 @@ import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../../systems/collision';
+import type {
+  UpperStairwellLandingSegmentPolicy,
+  UpperStairwellLandingSegmentRole,
+} from '../level/upperStairwellLandingSegments';
 
 export interface UpperStairwellGuardConfig {
   /** Height of the guard rail measured from the upper-floor surface. */
   height: number;
   /** Physical thickness of each rail. */
   thickness: number;
-  /**
-   * Optional long side rail edges around the opening. Omitting west keeps the
-   * upstairs-room egress open while east can still protect the stair void edge.
-   */
-  sideSides?: ReadonlyArray<'east' | 'west'>;
-  /**
-   * Optional shoulder rail sides to add around the descent corridor. Omitting
-   * west keeps the upstairs-room egress open while east can still protect the
-   * stair void edge.
-   */
-  shoulderSides?: ReadonlyArray<'east' | 'west'>;
   /** Optional material overrides for the guard rails. */
   material?: MeshStandardMaterialParameters;
+  /** Source-owned policy declaring which semantic guard segments render/collide. */
+  segments?: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
 export interface UpperStairwellLandingConfig {
@@ -37,21 +32,66 @@ export interface UpperStairwellLandingConfig {
   guard: UpperStairwellGuardConfig;
 }
 
-export interface NamedUpperStairwellLandingCollider {
+export interface UpperStairwellLandingCollider {
+  role: UpperStairwellLandingSegmentRole;
+  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
   name: string;
-  collider: RectCollider;
+  bounds: RectCollider;
 }
 
 export interface UpperStairwellLandingBuild {
   group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
+  segments: UpperStairwellLandingCollider[];
 }
 
 const GROUP_NAME = 'UpperStairwellLanding';
 const SIDE_GUARD_NAME = 'UpperStairwellLandingSideGuard';
 const FAR_GUARD_NAME = 'UpperStairwellLandingFarGuard';
 const SHOULDER_GUARD_NAME = 'UpperStairwellLandingShoulderGuard';
+
+const DEFAULT_SEGMENT_POLICIES: readonly UpperStairwellLandingSegmentPolicy[] =
+  [
+    {
+      role: 'side-west',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.sideWest.generatedCollider' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SIDE_GUARD_NAME}-West`,
+    },
+    {
+      role: 'side-east',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.sideEast.generatedCollider' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SIDE_GUARD_NAME}-East`,
+    },
+    {
+      role: 'far',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.far.generatedCollider' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: FAR_GUARD_NAME,
+    },
+    {
+      role: 'shoulder-west',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.shoulderWest.generatedCollider' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SHOULDER_GUARD_NAME}-West`,
+    },
+    {
+      role: 'shoulder-east',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.shoulderEast.generatedCollider' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SHOULDER_GUARD_NAME}-East`,
+    },
+  ];
 
 const hasPositiveArea = (bounds: Bounds2D): boolean =>
   bounds.maxX > bounds.minX && bounds.maxZ > bounds.minZ;
@@ -66,37 +106,68 @@ const clampBoundsToRoom = (
   maxZ: Math.min(bounds.maxZ, roomBounds.maxZ),
 });
 
-const addGuard = (params: {
-  group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
-  material: MeshStandardMaterial;
-  name: string;
-  bounds: Bounds2D;
-  roomBounds: Bounds2D;
-  elevation: number;
-  height: number;
-}) => {
-  const guardBounds = clampBoundsToRoom(params.bounds, params.roomBounds);
-  const width = guardBounds.maxX - guardBounds.minX;
-  const depth = guardBounds.maxZ - guardBounds.minZ;
-  if (width <= 0 || depth <= 0 || params.height <= 0) {
-    return;
+const getSegmentMeshName = (role: UpperStairwellLandingSegmentRole): string => {
+  switch (role) {
+    case 'side-west':
+      return `${SIDE_GUARD_NAME}-West`;
+    case 'side-east':
+      return `${SIDE_GUARD_NAME}-East`;
+    case 'far':
+      return FAR_GUARD_NAME;
+    case 'shoulder-west':
+      return `${SHOULDER_GUARD_NAME}-West`;
+    case 'shoulder-east':
+      return `${SHOULDER_GUARD_NAME}-East`;
   }
+};
 
-  const guard = new Mesh(
-    new BoxGeometry(width, params.height, depth),
-    params.material
-  );
-  guard.name = params.name;
-  guard.position.set(
-    guardBounds.minX + width / 2,
-    params.elevation + params.height / 2,
-    guardBounds.minZ + depth / 2
-  );
-  params.group.add(guard);
-  params.colliders.push(guardBounds);
-  params.namedColliders.push({ name: params.name, collider: guardBounds });
+const getSegmentBounds = (
+  role: UpperStairwellLandingSegmentRole,
+  openingBounds: Bounds2D,
+  descentCorridorBounds: Bounds2D | undefined,
+  thickness: number
+): Bounds2D | undefined => {
+  switch (role) {
+    case 'side-west':
+      return {
+        minX: openingBounds.minX - thickness,
+        maxX: openingBounds.minX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      };
+    case 'side-east':
+      return {
+        minX: openingBounds.maxX,
+        maxX: openingBounds.maxX + thickness,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      };
+    case 'far':
+      return {
+        minX: openingBounds.minX,
+        maxX: openingBounds.maxX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.minZ + thickness,
+      };
+    case 'shoulder-west':
+      return descentCorridorBounds
+        ? {
+            minX: openingBounds.minX,
+            maxX: descentCorridorBounds.minX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          }
+        : undefined;
+    case 'shoulder-east':
+      return descentCorridorBounds
+        ? {
+            minX: descentCorridorBounds.maxX,
+            maxX: openingBounds.maxX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          }
+        : undefined;
+  }
 };
 
 /**
@@ -118,117 +189,60 @@ export function createUpperStairwellLanding(
 
   const group = new Group();
   group.name = GROUP_NAME;
-  const colliders: RectCollider[] = [];
-  const namedColliders: NamedUpperStairwellLandingCollider[] = [];
+  const segments: UpperStairwellLandingCollider[] = [];
   const thickness = Math.max(config.guard.thickness, 0);
   const guardMaterial = new MeshStandardMaterial(config.guard.material);
+  const segmentPolicies = config.guard.segments ?? DEFAULT_SEGMENT_POLICIES;
 
   if (thickness <= 0 || config.guard.height <= 0) {
-    return { group, colliders, namedColliders };
+    return { group, segments };
   }
 
-  const sideSides = config.guard.sideSides ?? ['east', 'west'];
+  const descentCorridorBounds = config.descentCorridorBounds
+    ? clampBoundsToRoom(config.descentCorridorBounds, openingBounds)
+    : undefined;
 
-  if (sideSides.includes('west')) {
-    addGuard({
-      group,
-      colliders,
-      namedColliders,
-      material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-West`,
-      bounds: {
-        minX: openingBounds.minX - thickness,
-        maxX: openingBounds.minX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-  }
-
-  if (sideSides.includes('east')) {
-    addGuard({
-      group,
-      colliders,
-      namedColliders,
-      material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-East`,
-      bounds: {
-        minX: openingBounds.maxX,
-        maxX: openingBounds.maxX + thickness,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-  }
-  addGuard({
-    group,
-    colliders,
-    namedColliders,
-    material: guardMaterial,
-    name: FAR_GUARD_NAME,
-    bounds: {
-      minX: openingBounds.minX,
-      maxX: openingBounds.maxX,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.minZ + thickness,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
-
-  const shoulderSides = config.guard.shoulderSides ?? ['east', 'west'];
-
-  if (config.descentCorridorBounds && shoulderSides.length > 0) {
-    const descentCorridorBounds = clampBoundsToRoom(
-      config.descentCorridorBounds,
-      openingBounds
+  for (const policy of segmentPolicies) {
+    const unclampedBounds = getSegmentBounds(
+      policy.role,
+      openingBounds,
+      descentCorridorBounds,
+      thickness
     );
-
-    if (shoulderSides.includes('west')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-West`,
-        bounds: {
-          minX: openingBounds.minX,
-          maxX: descentCorridorBounds.minX,
-          minZ: openingBounds.minZ,
-          maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
-      });
+    if (!unclampedBounds) {
+      continue;
     }
 
-    if (shoulderSides.includes('east')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-East`,
-        bounds: {
-          minX: descentCorridorBounds.maxX,
-          maxX: openingBounds.maxX,
-          minZ: openingBounds.minZ,
-          maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
+    const bounds = clampBoundsToRoom(unclampedBounds, config.roomBounds);
+    const width = bounds.maxX - bounds.minX;
+    const depth = bounds.maxZ - bounds.minZ;
+    if (width <= 0 || depth <= 0) {
+      continue;
+    }
+
+    if (policy.render) {
+      const guard = new Mesh(
+        new BoxGeometry(width, config.guard.height, depth),
+        guardMaterial
+      );
+      guard.name = getSegmentMeshName(policy.role);
+      guard.position.set(
+        bounds.minX + width / 2,
+        config.elevation + config.guard.height / 2,
+        bounds.minZ + depth / 2
+      );
+      group.add(guard);
+    }
+
+    if (policy.collision) {
+      segments.push({
+        role: policy.role,
+        sourceId: policy.sourceId,
+        name: policy.colliderName ?? getSegmentMeshName(policy.role),
+        bounds,
       });
     }
   }
 
-  return { group, colliders, namedColliders };
+  return { group, segments };
 }


### PR DESCRIPTION
### Motivation
- Make the production upper-stairwell landing collision policy declarative and source-owned so runtime assembly no longer selects colliders by name prefixes, array indices, or generated order.
- Preserve the current visible rails and the single production collider named `UpperStairwellLandingGuard-3` with its existing debug ID mapping.

### Description
- Add a new level-source module `src/scene/level/upperStairwellLandingSegments.ts` that declares semantic segment policies with `role`, `render`, `collision`, stable `sourceId`, and optional `colliderName` (keeps `UpperStairwellLandingGuard-3` as explicit compatibility metadata).
- Refactor `createUpperStairwellLanding` in `src/scene/structures/upperStairwellLanding.ts` to accept segment policies, render visual-only segments, omit zero-area segments, and emit one canonical `segments` array where each record contains `role`, `sourceId`, `name`, and `bounds`.
- Update `src/main.ts` to add the generated group and register every emitted segment record directly with provenance metadata (no `.slice`, `.filter`, `startsWith`, or index-derived naming remains in `src/main.ts`).
- Update focused tests in `src/scene/structures/__tests__/upperStairwellLanding.test.ts` to assert visual-only segments render, the east-shoulder segment is the sole production collider, and that its `sourceId` and stable runtime name are preserved.

### Testing
- Ran the repository search check `rg -n "namedColliders|\.slice\(|startsWith\('UpperStairwellLanding|index \+ 3|UpperStairwellLandingGuard-" src/main.ts src/scene` and confirmed no selection logic remains in `src/main.ts` (matches only in the new segment source and debug id map).
- Ran focused unit tests with `npm run test:ci -- src/scene/structures/__tests__/upperStairwellLanding.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts` which passed.
- Ran full test suite `npm run test:ci` which passed (1206 tests in CI run passed locally).
- Ran lint and format `npm run format:write` and `npm run lint` (lint produced only an import-order warning which was addressed), and `npm run docs:check` which passed.
- Ran smoke/build `npm run smoke` which produced a valid dist build artifact.
- Executed Playwright checks by installing browsers and dependencies (`npx playwright install chromium` and `npx playwright install-deps chromium`) and ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed locally after the environment setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bc397a9c832f88362f3b4a8cf8d7)