### PR TITLE
Declare upper landing guard collider policy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -167,6 +167,7 @@ import {
   createUpperStairSafetyColliders,
   type LevelSafetyCollider,
 } from './scene/level/stairSafetyColliders';
+import { PRODUCTION_UPPER_STAIRWELL_LANDING_SEGMENTS } from './scene/level/upperStairwellLandingSegments';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -993,7 +994,7 @@ const colliderSourceMetadata = new Map<
       | WallSegmentInstance['sourceId']
       | LevelSafetyCollider['sourceId']
       | SceneObjectDefinition['sourceId'];
-    sourceType: 'wall' | 'safetyCollider' | 'sceneObject';
+    sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
     purpose?: string;
   }
 >();
@@ -2128,11 +2129,6 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const pushNamedUpperFloorCollider = (name: string, bounds: RectCollider) => {
-    upperFloorColliders.push(bounds);
-    namedColliderDebugNames.set(bounds, name);
-  };
-
   const upperStairWestEgressLaneX =
     stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
   const upperStairWestEgressBlockerMinX =
@@ -2250,18 +2246,18 @@ function initializeImmersiveScene(
           metalness: 0.05,
         },
       },
+      segments: PRODUCTION_UPPER_STAIRWELL_LANDING_SEGMENTS,
     });
     upperFloorGroup.add(upperStairwellLanding.group);
-    upperStairwellLanding.namedColliders
-      .filter(({ name }) =>
-        name.startsWith('UpperStairwellLandingShoulderGuard')
-      )
-      .forEach(({ collider }, index) =>
-        pushNamedUpperFloorCollider(
-          `UpperStairwellLandingGuard-${index + 3}`,
-          collider
-        )
-      );
+    upperStairwellLanding.colliderSegments.forEach((segment) => {
+      upperFloorColliders.push(segment.bounds);
+      namedColliderDebugNames.set(segment.bounds, segment.name);
+      colliderSourceMetadata.set(segment.bounds, {
+        sourceId: segment.sourceId,
+        sourceType: 'generatedCollider',
+        purpose: `upper stairwell landing ${segment.role} guard`,
+      });
+    });
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -1,0 +1,40 @@
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type UpperStairwellLandingSegmentRole =
+  | 'side-west'
+  | 'side-east'
+  | 'far'
+  | 'shoulder-west'
+  | 'shoulder-east';
+
+export interface UpperStairwellLandingSegmentPolicy {
+  role: UpperStairwellLandingSegmentRole;
+  render: boolean;
+  collision: boolean;
+  sourceId: LevelSourceId;
+  colliderName?: string;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+
+export const PRODUCTION_UPPER_STAIRWELL_LANDING_SEGMENTS = [
+  {
+    role: 'side-east',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landing.sideEast.guard'),
+  },
+  {
+    role: 'far',
+    render: true,
+    collision: false,
+    sourceId: sourceId('upper.stairwell.landing.far.guard'),
+  },
+  {
+    role: 'shoulder-east',
+    render: true,
+    collision: true,
+    sourceId: sourceId('upper.stairwell.landing.shoulderEast.guard'),
+    colliderName: 'UpperStairwellLandingGuard-3',
+  },
+] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,6 +1,8 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
+import { getDeclaredColliderDebugId } from '../../debug/colliderDebugIds';
+import { PRODUCTION_UPPER_STAIRWELL_LANDING_SEGMENTS } from '../../level/upperStairwellLandingSegments';
 import { createUpperStairwellLanding } from '../upperStairwellLanding';
 
 const overlaps = (
@@ -27,20 +29,28 @@ describe('createUpperStairwellLanding', () => {
     });
 
     expect(result.group.name).toBe('UpperStairwellLanding');
-    expect(result.colliders).toHaveLength(3);
-    expect(result.colliders).toContainEqual({
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toHaveLength(3);
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toContainEqual({
       minX: -2.2,
       maxX: -2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toContainEqual({
       minX: 2,
       maxX: 2.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toContainEqual({
       minX: -2,
       maxX: 2,
       minZ: -8,
@@ -49,7 +59,9 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.6, maxX: 1.6, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      result.colliderSegments
+        .map((segment) => segment.bounds)
+        .some((collider) => overlaps(collider, descentPath))
     ).toBe(false);
   });
 
@@ -73,14 +85,20 @@ describe('createUpperStairwellLanding', () => {
       },
     });
 
-    expect(result.colliders).toHaveLength(5);
-    expect(result.colliders).toContainEqual({
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toHaveLength(5);
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toContainEqual({
       minX: -2,
       maxX: -1.2,
       minZ: -8,
       maxZ: 6,
     });
-    expect(result.colliders).toContainEqual({
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toContainEqual({
       minX: 1.1,
       maxX: 2,
       minZ: -8,
@@ -89,11 +107,13 @@ describe('createUpperStairwellLanding', () => {
 
     const descentPath = { minX: -1.2, maxX: 1.1, minZ: -7.5, maxZ: 6 };
     expect(
-      result.colliders.some((collider) => overlaps(collider, descentPath))
+      result.colliderSegments
+        .map((segment) => segment.bounds)
+        .some((collider) => overlaps(collider, descentPath))
     ).toBe(false);
   });
 
-  it('exposes collider source guard names for stable runtime filtering', () => {
+  it('renders visual-only production segments but emits only the shoulder collider', () => {
     const result = createUpperStairwellLanding({
       roomBounds: { minX: -6, maxX: 6, minZ: -10, maxZ: 8 },
       openingBounds: { minX: -2, maxX: 2, minZ: -8, maxZ: 6 },
@@ -111,16 +131,34 @@ describe('createUpperStairwellLanding', () => {
         shoulderSides: ['east'],
         material: { color: 0xff0000 },
       },
+      segments: PRODUCTION_UPPER_STAIRWELL_LANDING_SEGMENTS,
     });
 
-    expect(result.namedColliders.map(({ name }) => name)).toEqual([
+    expect(result.group.children.map((child) => child.name)).toEqual([
       'UpperStairwellLandingSideGuard-East',
       'UpperStairwellLandingFarGuard',
       'UpperStairwellLandingShoulderGuard-East',
     ]);
-    expect(result.namedColliders.map(({ collider }) => collider)).toStrictEqual(
-      result.colliders
-    );
+    expect(
+      getDeclaredColliderDebugId({
+        floor: 'upper',
+        category: 'upper',
+        name: 'UpperStairwellLandingGuard-3',
+      })
+    ).toBe('400D');
+    expect(result.colliderSegments).toEqual([
+      {
+        role: 'shoulder-east',
+        name: 'UpperStairwellLandingGuard-3',
+        sourceId: 'upper.stairwell.landing.shoulderEast.guard',
+        bounds: {
+          minX: 1.1,
+          maxX: 2,
+          minZ: -8,
+          maxZ: 6,
+        },
+      },
+    ]);
   });
 
   it('clamps guard colliders to the landing room when the opening touches an edge', () => {
@@ -135,14 +173,20 @@ describe('createUpperStairwellLanding', () => {
       },
     });
 
-    expect(result.colliders).not.toContainEqual({
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).not.toContainEqual({
       minX: -2.4,
       maxX: -2,
       minZ: -4,
       maxZ: 4,
     });
-    expect(result.colliders).toHaveLength(2);
-    for (const collider of result.colliders) {
+    expect(
+      result.colliderSegments.map((segment) => segment.bounds)
+    ).toHaveLength(2);
+    for (const collider of result.colliderSegments.map(
+      (segment) => segment.bounds
+    )) {
       expect(collider.minX).toBeGreaterThanOrEqual(-2);
       expect(collider.maxX).toBeLessThanOrEqual(4);
       expect(collider.minZ).toBeGreaterThanOrEqual(-6);

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -3,6 +3,10 @@ import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
 import type { RectCollider } from '../../systems/collision';
+import type {
+  UpperStairwellLandingSegmentPolicy,
+  UpperStairwellLandingSegmentRole,
+} from '../level/upperStairwellLandingSegments';
 
 export interface UpperStairwellGuardConfig {
   /** Height of the guard rail measured from the upper-floor surface. */
@@ -35,23 +39,70 @@ export interface UpperStairwellLandingConfig {
   elevation: number;
   /** Guard rail configuration. */
   guard: UpperStairwellGuardConfig;
+  /** Declarative guard segment policy controlling rendering and collisions. */
+  segments?: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
-export interface NamedUpperStairwellLandingCollider {
+export interface UpperStairwellLandingColliderSegment {
+  role: UpperStairwellLandingSegmentRole;
   name: string;
-  collider: RectCollider;
+  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
+  bounds: RectCollider;
 }
 
 export interface UpperStairwellLandingBuild {
   group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
+  colliderSegments: UpperStairwellLandingColliderSegment[];
 }
 
 const GROUP_NAME = 'UpperStairwellLanding';
 const SIDE_GUARD_NAME = 'UpperStairwellLandingSideGuard';
 const FAR_GUARD_NAME = 'UpperStairwellLandingFarGuard';
 const SHOULDER_GUARD_NAME = 'UpperStairwellLandingShoulderGuard';
+
+const DEFAULT_SEGMENT_POLICIES: readonly UpperStairwellLandingSegmentPolicy[] =
+  [
+    {
+      role: 'side-west',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.sideWest.guard' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SIDE_GUARD_NAME}-West`,
+    },
+    {
+      role: 'side-east',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.sideEast.guard' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SIDE_GUARD_NAME}-East`,
+    },
+    {
+      role: 'far',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.far.guard' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: FAR_GUARD_NAME,
+    },
+    {
+      role: 'shoulder-west',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.shoulderWest.guard' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SHOULDER_GUARD_NAME}-West`,
+    },
+    {
+      role: 'shoulder-east',
+      render: true,
+      collision: true,
+      sourceId:
+        'upper.stairwell.landing.shoulderEast.guard' as UpperStairwellLandingSegmentPolicy['sourceId'],
+      colliderName: `${SHOULDER_GUARD_NAME}-East`,
+    },
+  ];
 
 const hasPositiveArea = (bounds: Bounds2D): boolean =>
   bounds.maxX > bounds.minX && bounds.maxZ > bounds.minZ;
@@ -66,12 +117,77 @@ const clampBoundsToRoom = (
   maxZ: Math.min(bounds.maxZ, roomBounds.maxZ),
 });
 
-const addGuard = (params: {
+const getSegmentMeshName = (role: UpperStairwellLandingSegmentRole): string => {
+  switch (role) {
+    case 'side-west':
+      return `${SIDE_GUARD_NAME}-West`;
+    case 'side-east':
+      return `${SIDE_GUARD_NAME}-East`;
+    case 'far':
+      return FAR_GUARD_NAME;
+    case 'shoulder-west':
+      return `${SHOULDER_GUARD_NAME}-West`;
+    case 'shoulder-east':
+      return `${SHOULDER_GUARD_NAME}-East`;
+  }
+};
+
+const getSegmentBounds = (params: {
+  role: UpperStairwellLandingSegmentRole;
+  openingBounds: Bounds2D;
+  descentCorridorBounds?: Bounds2D;
+  thickness: number;
+}): Bounds2D | undefined => {
+  const { role, openingBounds, descentCorridorBounds, thickness } = params;
+
+  switch (role) {
+    case 'side-west':
+      return {
+        minX: openingBounds.minX - thickness,
+        maxX: openingBounds.minX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      };
+    case 'side-east':
+      return {
+        minX: openingBounds.maxX,
+        maxX: openingBounds.maxX + thickness,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.maxZ,
+      };
+    case 'far':
+      return {
+        minX: openingBounds.minX,
+        maxX: openingBounds.maxX,
+        minZ: openingBounds.minZ,
+        maxZ: openingBounds.minZ + thickness,
+      };
+    case 'shoulder-west':
+      return descentCorridorBounds
+        ? {
+            minX: openingBounds.minX,
+            maxX: descentCorridorBounds.minX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          }
+        : undefined;
+    case 'shoulder-east':
+      return descentCorridorBounds
+        ? {
+            minX: descentCorridorBounds.maxX,
+            maxX: openingBounds.maxX,
+            minZ: openingBounds.minZ,
+            maxZ: openingBounds.maxZ,
+          }
+        : undefined;
+  }
+};
+
+const addGuardSegment = (params: {
   group: Group;
-  colliders: RectCollider[];
-  namedColliders: NamedUpperStairwellLandingCollider[];
+  colliderSegments: UpperStairwellLandingColliderSegment[];
   material: MeshStandardMaterial;
-  name: string;
+  policy: UpperStairwellLandingSegmentPolicy;
   bounds: Bounds2D;
   roomBounds: Bounds2D;
   elevation: number;
@@ -84,19 +200,34 @@ const addGuard = (params: {
     return;
   }
 
-  const guard = new Mesh(
-    new BoxGeometry(width, params.height, depth),
-    params.material
-  );
-  guard.name = params.name;
-  guard.position.set(
-    guardBounds.minX + width / 2,
-    params.elevation + params.height / 2,
-    guardBounds.minZ + depth / 2
-  );
-  params.group.add(guard);
-  params.colliders.push(guardBounds);
-  params.namedColliders.push({ name: params.name, collider: guardBounds });
+  if (params.policy.render) {
+    const guard = new Mesh(
+      new BoxGeometry(width, params.height, depth),
+      params.material
+    );
+    guard.name = getSegmentMeshName(params.policy.role);
+    guard.position.set(
+      guardBounds.minX + width / 2,
+      params.elevation + params.height / 2,
+      guardBounds.minZ + depth / 2
+    );
+    params.group.add(guard);
+  }
+
+  if (params.policy.collision) {
+    if (!params.policy.colliderName) {
+      throw new Error(
+        `Upper stairwell landing segment ${params.policy.role} requires a collider name.`
+      );
+    }
+
+    params.colliderSegments.push({
+      role: params.policy.role,
+      name: params.policy.colliderName,
+      sourceId: params.policy.sourceId,
+      bounds: guardBounds,
+    });
+  }
 };
 
 /**
@@ -118,117 +249,58 @@ export function createUpperStairwellLanding(
 
   const group = new Group();
   group.name = GROUP_NAME;
-  const colliders: RectCollider[] = [];
-  const namedColliders: NamedUpperStairwellLandingCollider[] = [];
+  const colliderSegments: UpperStairwellLandingColliderSegment[] = [];
   const thickness = Math.max(config.guard.thickness, 0);
   const guardMaterial = new MeshStandardMaterial(config.guard.material);
 
   if (thickness <= 0 || config.guard.height <= 0) {
-    return { group, colliders, namedColliders };
+    return { group, colliderSegments };
   }
 
   const sideSides = config.guard.sideSides ?? ['east', 'west'];
-
-  if (sideSides.includes('west')) {
-    addGuard({
-      group,
-      colliders,
-      namedColliders,
-      material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-West`,
-      bounds: {
-        minX: openingBounds.minX - thickness,
-        maxX: openingBounds.minX,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-  }
-
-  if (sideSides.includes('east')) {
-    addGuard({
-      group,
-      colliders,
-      namedColliders,
-      material: guardMaterial,
-      name: `${SIDE_GUARD_NAME}-East`,
-      bounds: {
-        minX: openingBounds.maxX,
-        maxX: openingBounds.maxX + thickness,
-        minZ: openingBounds.minZ,
-        maxZ: openingBounds.maxZ,
-      },
-      roomBounds: config.roomBounds,
-      elevation: config.elevation,
-      height: config.guard.height,
-    });
-  }
-  addGuard({
-    group,
-    colliders,
-    namedColliders,
-    material: guardMaterial,
-    name: FAR_GUARD_NAME,
-    bounds: {
-      minX: openingBounds.minX,
-      maxX: openingBounds.maxX,
-      minZ: openingBounds.minZ,
-      maxZ: openingBounds.minZ + thickness,
-    },
-    roomBounds: config.roomBounds,
-    elevation: config.elevation,
-    height: config.guard.height,
-  });
-
   const shoulderSides = config.guard.shoulderSides ?? ['east', 'west'];
+  const descentCorridorBounds = config.descentCorridorBounds
+    ? clampBoundsToRoom(config.descentCorridorBounds, openingBounds)
+    : undefined;
+  const policies = config.segments ?? DEFAULT_SEGMENT_POLICIES;
 
-  if (config.descentCorridorBounds && shoulderSides.length > 0) {
-    const descentCorridorBounds = clampBoundsToRoom(
-      config.descentCorridorBounds,
-      openingBounds
-    );
-
-    if (shoulderSides.includes('west')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-West`,
-        bounds: {
-          minX: openingBounds.minX,
-          maxX: descentCorridorBounds.minX,
-          minZ: openingBounds.minZ,
-          maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
-      });
+  for (const policy of policies) {
+    if (policy.role.startsWith('side-')) {
+      const side = policy.role === 'side-east' ? 'east' : 'west';
+      if (!sideSides.includes(side)) {
+        continue;
+      }
     }
 
-    if (shoulderSides.includes('east')) {
-      addGuard({
-        group,
-        colliders,
-        namedColliders,
-        material: guardMaterial,
-        name: `${SHOULDER_GUARD_NAME}-East`,
-        bounds: {
-          minX: descentCorridorBounds.maxX,
-          maxX: openingBounds.maxX,
-          minZ: openingBounds.minZ,
-          maxZ: openingBounds.maxZ,
-        },
-        roomBounds: config.roomBounds,
-        elevation: config.elevation,
-        height: config.guard.height,
-      });
+    if (policy.role.startsWith('shoulder-')) {
+      const side = policy.role === 'shoulder-east' ? 'east' : 'west';
+      if (!shoulderSides.includes(side)) {
+        continue;
+      }
     }
+
+    const bounds = getSegmentBounds({
+      role: policy.role,
+      openingBounds,
+      descentCorridorBounds,
+      thickness,
+    });
+
+    if (!bounds) {
+      continue;
+    }
+
+    addGuardSegment({
+      group,
+      colliderSegments,
+      material: guardMaterial,
+      policy,
+      bounds,
+      roomBounds: config.roomBounds,
+      elevation: config.elevation,
+      height: config.guard.height,
+    });
   }
 
-  return { group, colliders, namedColliders };
+  return { group, colliderSegments };
 }


### PR DESCRIPTION
### Motivation
- Remove imperative runtime logic in `src/main.ts` that selected which upper-stairwell landing rails get colliders and make the active policy source-owned and declarative.
- Keep all visible landing rails unchanged while preserving the single production collider (east shoulder) runtime name `UpperStairwellLandingGuard-3` and debug ID `400D`.

### Description
- Add a small level-source module `src/scene/level/upperStairwellLandingSegments.ts` that declares `UpperStairwellLandingSegmentPolicy` and `PRODUCTION_UPPER_STAIRWELL_LANDING_SEGMENTS` with roles, `render`/`collision` flags, stable `sourceId`, and the explicit `colliderName` compatibility entry for the shoulder-east segment.
- Refactor `createUpperStairwellLanding(...)` in `src/scene/structures/upperStairwellLanding.ts` to accept segment policies, render visual meshes and emit one canonical `colliderSegments` array of semantic records (`role`, `name`, `sourceId`, `bounds`) while omitting zero-area segments.
- Update `src/main.ts` to pass the production policy into the generator, add the generated group, and register every emitted collider segment directly with `upperFloorColliders`, `namedColliderDebugNames`, and `colliderSourceMetadata` without `.slice`, `.filter`, `startsWith`, or index-derived naming.
- Update focused tests in `src/scene/structures/__tests__/upperStairwellLanding.test.ts` to assert rendered visual-only segments, that only the shoulder-east segment emits a collider, that the emitted collider carries its `sourceId` and runtime name, and that the declared debug ID `400D` remains stable.

### Testing
- Ran focused unit tests with `npm run test:ci -- src/scene/structures/__tests__/upperStairwellLanding.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts` and they passed (10/10 tests).
- Installed Playwright browsers (`npx playwright install` and `npx playwright install-deps`) and ran the immersive stairs Playwright suite `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed (9/9 tests) after installing browser deps.
- Ran the full JS test suite (`npm run test:ci`) and smoke/build checks (`npm run smoke`); automated tests and smoke check passed in this environment (1205 tests passed on full run, smoke build succeeded).
- Ran lint (`npm run lint`) and docs checks (`npm run docs:check`); lint produced only an import-order warning that was fixed and docs checks passed with expected external-link fetch warnings.
- `npm run typecheck` surfaced pre-existing repository-wide TypeScript issues; the change required widening the `sourceType` usage for generated colliders and that specific metadata typing was addressed, but the broader type errors are pre-existing and not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bc402bbc832f997fd8ffa69dc5c3)