### PR TITLE
Add June 2026 LaTeX resume source and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,6 @@ performance, modes, animation, and more) provide ready-to-run task scaffolding f
 `npm run build` generates distributable assets, and CI asserts that `dist/index.html`
 exists as part of the smoke suite.
 
-[resume-src]: docs/resume/2025-09/resume.tex
+[resume-src]: docs/resume/2026-06/resume.tex
 [prompt-summary]: docs/prompts/summary.md
 [baseline-prompt]: docs/prompts/codex/baseline.md

--- a/docs/resume/2026-06/resume.tex
+++ b/docs/resume/2026-06/resume.tex
@@ -1,0 +1,74 @@
+\documentclass[10pt]{article}
+\usepackage[margin=0.55in]{geometry}
+\usepackage[hidelinks]{hyperref}
+\usepackage{enumitem}
+\usepackage{titlesec}
+\setlist[itemize]{leftmargin=*, itemsep=0.15mm, topsep=0.15mm}
+\titlespacing*{\section}{0pt}{1.5mm}{0.75mm}
+\setlength\parindent{0pt}
+\linespread{0.94}
+\pagestyle{empty}
+
+\begin{document}
+
+\begin{center}
+    {\LARGE \textbf{Daniel Smith}}\\[-1mm]
+    \href{mailto:daniel@danielsmith.io}{daniel@danielsmith.io} \,|\,
+    \href{https://danielsmith.io}{danielsmith.io} \,|\,
+    \href{https://github.com/futuroptimist}{github.com/futuroptimist} \,|\,
+    \href{https://linkedin.com/in/danielsmith4483}{linkedin.com/in/danielsmith4483}
+\end{center}
+
+\vspace{-3mm}
+\section*{Summary}
+Reliability and platform engineer with 6+ years at YouTube (Google) and 10+ years building
+production software. Builds Kubernetes and Helm platforms, privacy-focused AI infrastructure, and
+accessible full-stack products, with strengths in release engineering, operational automation, and
+incident response.
+
+\vspace{-2mm}
+\section*{Skills}
+\textbf{Languages \& Data:} Python, Go, TypeScript/JavaScript, SQL, C++, Bash, BigQuery/GoogleSQL \\
+\textbf{Platform \& Delivery:} Kubernetes, k3s, Helm, Docker/OCI, Linux, GitHub Actions, GHCR, Cloudflare, Google Cloud \\
+\textbf{Reliability:} SLOs, monitoring and alerting, dashboards, incident response, on-call, capacity and reliability reviews, runbooks, CI/CD, release engineering, automated testing \\
+\textbf{Application \& AI:} Astro, Svelte, React, Vite, Flask, REST and OpenAI-compatible APIs, Three.js/WebGL, local LLM inference, LLM application and infrastructure engineering
+
+\vspace{-2mm}
+\section*{Experience}
+\textbf{Independent Open Source Engineering} \hfill Remote \\
+\textit{Platform \& Reliability Engineer} \hfill Jun 2025 -- Present
+\begin{itemize}
+  \item Designed and operate \href{https://github.com/futuroptimist/sugarkube}{Sugarkube}, a reusable k3s and Helm platform for Raspberry Pi and SBC clusters, with automated image provisioning, environment-specific deployments, health verification, rollback paths, and recovery runbooks.
+  \item Standardized release engineering across \href{https://democratized.space}{DSPACE}, \href{https://token.place}{token.place}, and \href{https://danielsmith.io}{danielsmith.io} using GHCR container images, OCI Helm charts, immutable commit tags, staged promotion, and post-deployment verification.
+  \item Developed \href{https://token.place}{token.place}, a privacy-focused distributed AI platform with OpenAI-compatible APIs, local model inference, end-to-end encrypted relay flows, multi-relay failover, rate limiting, and cross-language security and integration testing.
+  \item Integrated DSPACE chat with token.place and shipped accessible Astro/Svelte and TypeScript/Three.js applications with offline behavior, SSR safeguards, WebGL-to-text failover, and automated browser testing.
+\end{itemize}
+
+\textbf{YouTube (Google)} \hfill San Bruno, CA \\
+\textit{Site Reliability Engineer, L4} \hfill Sep 2018 -- May 2025
+\begin{itemize}
+  \item Defined product-health metrics and leadership dashboards for high-traffic YouTube surfaces, giving product and engineering teams a shared basis for reliability reviews and prioritization.
+  \item Automated monitoring, anomaly analysis, and operational workflows in Python, Go, SQL, and C++, improving signal quality and reducing repetitive investigation for large-scale production systems.
+  \item Served on-call across Core, Trust \& Safety, and Search SRE; handled incidents and partnered with service owners to turn failure modes into runbooks, readiness checks, and follow-up improvements.
+  \item Advised teams across Alphabet on reliability metrics and review practices; authored reusable playbooks, mentored engineers, strengthened onboarding, and earned promotion to L4 in Dec 2021.
+\end{itemize}
+
+\textbf{Naval Research Laboratory} \hfill Stennis Space Center, MS \\
+\textit{Software Engineer} \hfill Jan 2017 -- Sep 2018
+\begin{itemize}
+  \item Built C++/Qt data-processing applications for research workflows and delivered iterative releases, demonstrations, and documentation in a distributed Scrum team.
+\end{itemize}
+
+\textbf{The University of Southern Mississippi} \hfill Hattiesburg, MS \\
+\textit{Software Developer} \hfill Mar 2014 -- Dec 2016
+\begin{itemize}
+  \item Built an Objective-C content-delivery and networking framework for university iOS applications, supporting real-time content updates.
+\end{itemize}
+
+\vspace{-2mm}
+\section*{Education}
+\textbf{The University of Southern Mississippi} - M.S. Computer Science, \textit{GPA: 4.0} \hfill Aug 2015 -- Aug 2016 \\
+\textbf{The University of Southern Mississippi} - B.S. Computer Science, \textit{GPA: 4.0} \hfill May 2013 -- May 2015 \\
+\textbf{Jones County Junior College} - A.A.S. Information System Technology, \textit{GPA: 4.0} \hfill Aug 2011 -- May 2013
+
+\end{document}


### PR DESCRIPTION
### Motivation
- Provide an updated, ATS-friendly one-page resume source for June 2026 using the existing one-page LaTeX layout while preserving historical sources and avoiding any binary artifacts.
- Keep the single-column, compact visual style and clickable links, and update repo docs so CI selects the new dated source directory.

### Description
- Add `docs/resume/2026-06/resume.tex`, a 10pt LaTeX one-page resume (margins adjusted to 0.55in) with the exact section order: Summary, Skills, Experience, Education, and tightened spacing for a single-page layout.
- Populate approved content: updated Summary and Skills, Independent Open Source Engineering bullets (with hyperlinks to Sugarkube, DSPACE, token.place, and danielsmith.io), four YouTube bullets (Gemini hackathon removed), Naval Research Laboratory bullet, and the historical Objective-C USM bullet; retain all three education entries including the A.A.S.
- Update `README.md` reference for the documented resume source to point to `docs/resume/2026-06/resume.tex` and do not modify CI workflow or produce any PDF/DOCX binaries.

### Testing
- Ran formatting and repo checks: `npm run format:write` passed and `npm run lint` passed.
- Ran the test and docs pipelines: `npm run test:ci` passed (Test Files: 158, Tests: 1205 passed) and `npm run docs:check` passed (link checker emitted reachable warnings but completed), and `npm run smoke` (build + smoke assertions) passed.
- Ran static validations: `git diff --check` passed and `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.
- Could not run PDF/TeX and document conversions in this environment: `latexmk`, `pdfinfo`, `pdftotext`, and `pandoc` are not installed so `latexmk -pdf ...`, `pdfinfo`, `pdftotext`, and `pandoc ...` were not run here (commands reported as `command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35c1cb60c0832f858168d838db6ba0)