### PR TITLE
Co-locate collider debug IDs with source declarations

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -69,6 +69,14 @@ Every safety collider needs:
 - `floorId`
 - `bounds`
 - a clear `purpose`
+- a stable `debugId` when the collider is part of a source-backed family that
+  needs a durable browser debug label
+
+Stable debug IDs live beside active collider declarations or segment policies.
+Deleting or disabling a collider should remove its runtime collider and debug ID
+without adding tombstones, historical absence tests, or registry-only records.
+Behavior tests should pin player promises, while generator and registry tests
+validate active declarations generically.
 
 Use safety colliders for invisible constraints such as stairwell void guards or
 approach-lane protection, not as a hidden substitute for visible wall geometry.

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1087,8 +1087,6 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   });
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
-  expect(debugColliders).toContain('UpperStairwellLandingGuard-3');
-  expect(debugColliders).not.toContain('UpperStairwellLandingGuard-4');
   expect(debugColliders).not.toContain('GroundStairEastRunSeal');
   expect(debugColliders).not.toContain('GroundStairEastRunSealLowerCap');
   expect(debugColliders).not.toContain('GroundStairEastRunSealUpperCap');

--- a/src/main.ts
+++ b/src/main.ts
@@ -988,6 +988,7 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
+const explicitColliderDebugIds = new Map<RectCollider, string>();
 const colliderSourceMetadata = new Map<
   RectCollider,
   {
@@ -2092,6 +2093,7 @@ function initializeImmersiveScene(
       collider.floor === 'ground' ? groundColliders : upperFloorColliders;
     targetColliders.push(collider.bounds);
     namedColliderDebugNames.set(collider.bounds, collider.name);
+    explicitColliderDebugIds.set(collider.bounds, collider.debugId);
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
       sourceType: 'safetyCollider',
@@ -2136,9 +2138,13 @@ function initializeImmersiveScene(
     bounds: RectCollider;
     sourceId: LevelSourceId;
     role: string;
+    debugId?: string;
   }) => {
     upperFloorColliders.push(collider.bounds);
     namedColliderDebugNames.set(collider.bounds, collider.name);
+    if (collider.debugId) {
+      explicitColliderDebugIds.set(collider.bounds, collider.debugId);
+    }
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
       sourceType: 'generatedCollider',
@@ -4459,6 +4465,7 @@ function initializeImmersiveScene(
       sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
       sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
       purpose: colliderSourceMetadata.get(bounds)?.purpose,
+      debugId: explicitColliderDebugIds.get(bounds),
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -43,7 +43,7 @@ describe('createColliderDebugId', () => {
     expect(createColliderDebugId(metadata)).toMatch(/^[0-9A-F]{6}$/);
   });
 
-  it('uses declared IDs for generated and named runtime colliders', () => {
+  it('uses declared IDs for generated and regression colliders', () => {
     expect(
       createColliderDebugId({
         floor: 'ground',
@@ -68,14 +68,6 @@ describe('createColliderDebugId', () => {
         bounds: collider,
       })
     ).toBe('3002');
-    expect(
-      createColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairNorthBannisterGuard',
-        bounds: collider,
-      })
-    ).toBe('400A');
     expect(
       createColliderDebugId({
         floor: 'ground',
@@ -127,6 +119,27 @@ describe('createColliderDebugId', () => {
       firstRetryId
     );
   });
+});
+
+it('uses explicit source-backed debug IDs before fallback allocation', () => {
+  const visualizer = createColliderVisualizer({ activeFloorId: 'upper' });
+  visualizer.register([
+    {
+      floor: 'upper',
+      category: 'upper',
+      name: 'UpperStairNorthBannisterGuard',
+      bounds: collider,
+      debugId: '400A',
+    },
+  ]);
+
+  expect(visualizer.getColliders()).toEqual([
+    expect.objectContaining({
+      name: 'UpperStairNorthBannisterGuard',
+      id: '400A',
+      debugId: '400A',
+    }),
+  ]);
 });
 
 describe('createColliderVisualizer', () => {

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -6,25 +6,28 @@ export interface DebugColliderIdLookupInput {
   name: string;
 }
 
+export type DebugColliderId = string & {
+  readonly __debugColliderId: unique symbol;
+};
+
 const DEBUG_COLLIDER_ID_PATTERN = /^[0-9A-F]{4,6}$/;
+
+export const isDebugColliderId = (value: string): boolean =>
+  DEBUG_COLLIDER_ID_PATTERN.test(value);
+
+export const assertDebugColliderId = (value: string): DebugColliderId => {
+  if (!isDebugColliderId(value)) {
+    throw new Error(`Invalid debug collider ID ${value}`);
+  }
+
+  return value as DebugColliderId;
+};
 
 const GENERATED_COLLIDER_ID_PREFIXES = {
   ground: '1',
   static: '2',
   upper: '3',
 } as const;
-
-const DECLARED_RUNTIME_COLLIDER_IDS = {
-  GroundStairEastBoundary: '4001',
-  GroundStairLowerCornerGuard: '4002',
-  UpperStairTopGapBlockerWest: '4003',
-  UpperStairTopGapBlockerEast: '4004',
-  UpperStairWestUpperVoidGuard: '4005',
-  UpperStairEastUpperVoidGuard: '4007',
-  UpperStairWestBannisterGuard: '4009',
-  UpperStairNorthBannisterGuard: '400A',
-  'UpperStairwellLandingGuard-3': '400D',
-} as const satisfies Record<string, string>;
 
 const DECLARED_REGRESSION_COLLIDER_IDS = {
   // Greptile regression pair: these names historically shared fallback primary
@@ -35,7 +38,6 @@ const DECLARED_REGRESSION_COLLIDER_IDS = {
 } as const satisfies Record<string, string>;
 
 const DECLARED_NAMED_COLLIDER_IDS = {
-  ...DECLARED_RUNTIME_COLLIDER_IDS,
   ...DECLARED_REGRESSION_COLLIDER_IDS,
 } as const satisfies Record<string, string>;
 

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -14,7 +14,10 @@ import {
 import type { RectCollider } from '../../systems/collision';
 import type { FloorId } from '../../systems/movement/stairs';
 
-import { getDeclaredColliderDebugId } from './colliderDebugIds';
+import {
+  assertDebugColliderId,
+  getDeclaredColliderDebugId,
+} from './colliderDebugIds';
 import {
   DEBUG_ID_PRECISION,
   allocateDebugId,
@@ -34,6 +37,7 @@ export interface DebugColliderMetadata {
   sourceId?: string;
   sourceType?: string;
   purpose?: string;
+  debugId?: string;
 }
 
 export interface DebugColliderRegistration {
@@ -47,6 +51,7 @@ export interface DebugColliderRegistration {
   sourceId?: string;
   sourceType?: string;
   purpose?: string;
+  debugId?: string;
 }
 
 export interface DebugColliderVisualizerState {
@@ -101,15 +106,24 @@ const cloneSourceMetadata = <
     sourceId?: string;
     sourceType?: string;
     purpose?: string;
+    debugId?: string;
   },
 >(
   input: T
-): Pick<T, 'sourceId' | 'sourceType' | 'purpose'> => ({
+): {
+  sourceId?: string;
+  sourceType?: string;
+  purpose?: string;
+  debugId?: string;
+} => ({
   ...(typeof input.sourceId === 'string' ? { sourceId: input.sourceId } : {}),
   ...(typeof input.sourceType === 'string'
     ? { sourceType: input.sourceType }
     : {}),
   ...(typeof input.purpose === 'string' ? { purpose: input.purpose } : {}),
+  ...(typeof input.debugId === 'string'
+    ? { debugId: assertDebugColliderId(input.debugId) }
+    : {}),
 });
 
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
@@ -146,6 +160,7 @@ const getColliderDebugPrimaryId = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
   seed: string
 ): string =>
+  metadata.debugId ??
   getDeclaredColliderDebugId(metadata) ??
   getDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`);
 

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -5,7 +5,10 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from '../../../systems/movement/stairs';
-import { getDeclaredColliderDebugId } from '../../debug/colliderDebugIds';
+import {
+  getDeclaredColliderDebugId,
+  isDebugColliderId,
+} from '../../debug/colliderDebugIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -106,51 +109,36 @@ describe('stair safety collider source definitions', () => {
     expect(new Set(sourceIds).size).toBe(sourceIds.length);
   });
 
-  it('keeps declared debug IDs mapped to existing safety collider names', () => {
-    const names = new Set(
-      collectSafetyColliders().map((collider) => collider.name)
-    );
+  it('keeps source-backed debug IDs valid, unique, and source-owned', () => {
+    const colliders = collectSafetyColliders();
+    const debugIds = colliders.map((collider) => collider.debugId);
 
-    [
-      ['GroundStairEastBoundary', '4001'],
-      ['GroundStairLowerCornerGuard', '4002'],
-      ['UpperStairEastUpperVoidGuard', '4007'],
-      ['UpperStairWestBannisterGuard', '4009'],
-      ['UpperStairNorthBannisterGuard', '400A'],
-    ].forEach(([name, id]) => {
-      expect(names.has(name)).toBe(true);
+    expect(debugIds.every(isDebugColliderId)).toBe(true);
+    expect(new Set(debugIds).size).toBe(debugIds.length);
+    colliders.forEach((collider) => {
       expect(
-        getDeclaredColliderDebugId({ floor: 'upper', category: 'upper', name })
-      ).toBe(id);
+        getDeclaredColliderDebugId({
+          floor: collider.floor,
+          category: collider.floor,
+          name: collider.name,
+        })
+      ).not.toBe(collider.debugId);
     });
-
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairTopGapBlockerWest',
-      })
-    ).toBe('4003');
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairTopGapBlockerEast',
-      })
-    ).toBe('4004');
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairHiddenRunVoidGuard',
-      })
-    ).toBeUndefined();
   });
 
-  it('does not regenerate the removed hidden-run void guard', () => {
-    const names = collectSafetyColliders().map((collider) => collider.name);
+  it('preserves the active stair safety debug ID set from declarations', () => {
+    const idsByName = new Map(
+      collectSafetyColliders().map((collider) => [
+        collider.name,
+        collider.debugId,
+      ])
+    );
 
-    expect(names).not.toContain('UpperStairHiddenRunVoidGuard');
+    expect(idsByName.get('GroundStairEastBoundary')).toBe('4001');
+    expect(idsByName.get('GroundStairLowerCornerGuard')).toBe('4002');
+    expect(idsByName.get('UpperStairEastUpperVoidGuard')).toBe('4007');
+    expect(idsByName.get('UpperStairWestBannisterGuard')).toBe('4009');
+    expect(idsByName.get('UpperStairNorthBannisterGuard')).toBe('400A');
   });
 
   it('keeps safety collider source IDs free of tombstone wording', () => {

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -6,6 +6,10 @@ import {
   createGroundStairBoundaryColliders,
 } from '../../systems/movement/stairs';
 import { splitColliderAroundCorridor } from '../../systems/movement/upperStairLandingGuards';
+import {
+  assertDebugColliderId,
+  type DebugColliderId,
+} from '../debug/colliderDebugIds';
 
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
@@ -18,6 +22,7 @@ export interface LevelSafetyCollider {
   category: SafetyColliderCategory;
   bounds: RectCollider;
   purpose: string;
+  debugId: DebugColliderId;
 }
 
 export interface GroundStairSafetyColliderOptions {
@@ -42,26 +47,33 @@ export interface UpperStairSafetyColliderArgs {
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+const debugId = (value: string): DebugColliderId =>
+  assertDebugColliderId(value);
 
 const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
   GroundStairEastBoundary: {
     sourceId: sourceId('ground.stairwell.eastBoundary.safetyCollider'),
     category: 'stair',
     purpose: 'prevent lower stair side squeeze',
+    debugId: debugId('4001'),
   },
   GroundStairLowerCornerGuard: {
     sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
     category: 'stair',
     purpose: 'block raw lower-step occupancy',
+    debugId: debugId('4002'),
   },
 } as const satisfies Record<
   string,
-  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'>
+  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose' | 'debugId'>
 >;
 
 const getGroundStairSafetyColliderMetadata = (
   name: string
-): Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'> => {
+): Pick<
+  LevelSafetyCollider,
+  'sourceId' | 'category' | 'purpose' | 'debugId'
+> => {
   const metadata =
     GROUND_STAIR_SAFETY_COLLIDER_METADATA[
       name as keyof typeof GROUND_STAIR_SAFETY_COLLIDER_METADATA
@@ -172,6 +184,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'void',
       purpose: 'guard upper stairwell void edge',
+      debugId: debugId('4007'),
       bounds: {
         minX: stairNavigationZones.explicitDescentCorridor.maxX,
         maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
@@ -187,6 +200,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper' as const,
       category: 'void' as const,
       purpose: 'guard upper stairwell void edge',
+      debugId: debugId(name.endsWith('West') ? '4003' : '4004'),
       bounds,
     })),
     {
@@ -195,6 +209,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      debugId: debugId('4009'),
       bounds: {
         minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
         maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
@@ -215,6 +230,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      debugId: debugId('400A'),
       bounds: {
         minX: upperStairNorthBannisterMinX,
         maxX: upperStairNorthBannisterMaxX,

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -1,3 +1,8 @@
+import {
+  assertDebugColliderId,
+  type DebugColliderId,
+} from '../debug/colliderDebugIds';
+
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type UpperStairwellLandingSegmentRole =
@@ -13,9 +18,12 @@ export interface UpperStairwellLandingSegmentPolicy {
   collision: boolean;
   sourceId: LevelSourceId;
   colliderName?: string;
+  debugId?: DebugColliderId;
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+const debugId = (value: string): DebugColliderId =>
+  assertDebugColliderId(value);
 
 export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
   {
@@ -36,5 +44,6 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
     collision: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
     colliderName: 'UpperStairwellLandingGuard-3',
+    debugId: debugId('400D'),
   },
 ] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -147,6 +147,7 @@ describe('createUpperStairwellLanding', () => {
         role: 'shoulder-east',
         sourceId: 'upper.stairwell.landingGuard.shoulderEast',
         name: 'UpperStairwellLandingGuard-3',
+        debugId: '400D',
         bounds: {
           minX: 1.1,
           maxX: 2,

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -36,6 +36,7 @@ export interface UpperStairwellLandingCollider {
   role: UpperStairwellLandingSegmentRole;
   sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
   name: string;
+  debugId?: UpperStairwellLandingSegmentPolicy['debugId'];
   bounds: RectCollider;
 }
 
@@ -120,6 +121,7 @@ const addGuard = (params: {
       role: params.policy.role,
       sourceId: params.policy.sourceId,
       name: params.policy.colliderName,
+      ...(params.policy.debugId ? { debugId: params.policy.debugId } : {}),
       bounds: guardBounds,
     });
   }


### PR DESCRIPTION
### Motivation
- Replace the brittle, separately maintained runtime name→ID inventory with explicit stable `debugId`s colocated on the source-owned collider declarations so deleting or disabling a collider removes both runtime collider and debug ID without touching a sidecar registry. 
- Preserve the visible/regression ID allocation rules and existing player-facing behavior while making stair/landing IDs part of the canonical source model.
- Avoid reintroducing deleted/historical IDs and keep the registration fallback for unrelated generated/regression colliders.

### Description
- Add a typed `DebugColliderId` and `assertDebugColliderId` helper and remove stair/landing entries from the prior `DECLARED_RUNTIME_COLLIDER_IDS` map, preserving only regression IDs such as `C1104`/`C2488`. (`src/scene/debug/colliderDebugIds.ts`)
- Add a `debugId` field to the source-backed collider model and segment policy, and assign the active stable IDs at the declaration site for stair safety colliders and the upper-stairwell shoulder (`4001`,`4002`,`4003`,`4004`,`4007`,`4009`,`400A`,`400D`). (`src/scene/level/stairSafetyColliders.ts`, `src/scene/level/upperStairwellLandingSegments.ts`, `src/scene/structures/upperStairwellLanding.ts`)
- Propagate explicit `debugId` values through runtime registration by tracking `explicitColliderDebugIds` during scene initialization and exposing them to the debug visualizer registrations. (`src/main.ts`)
- Update the debug visualizer to prefer an explicit `metadata.debugId` first, then the declared registry fallback, then generated hashes; validate debug-ID format during registration. (`src/scene/debug/colliderVisualizer.ts`)
- Replace hand-maintained inventory assertions with declaration-driven tests and add a focused contract test asserting explicit registration preserves source-backed IDs; remove implementation-inventory assertions from the Playwright stair roundtrip test. (`src/scene/level/__tests__/stairSafetyColliders.test.ts`, `src/scene/debug/__tests__/colliderVisualizer.test.ts`, `playwright/immersive-stairs-roundtrip.spec.ts`)
- Brief docs note clarifying stable debug IDs live beside active declarations and must not be represented as tombstones or negative tests. (`docs/design/editing-level-data.md`)

### Testing
- Ran focused unit tests: `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts` and then including the debug visualizer tests `src/scene/debug/__tests__/colliderVisualizer.test.ts`; these targeted suites passed.
- Ran full unit suite: `npm run test:ci` (all Vitest tests) — result: passed (all tests green in CI run shown).
- Ran build/docs/smoke: `npm run docs:check` — passed (link checker emitted external fetch warnings), and `npm run smoke` — passed (build + smoke checks OK).
- Playwright E2E: attempted `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` but browser runs were blocked by missing host system dependencies; `npx playwright install chromium` downloaded browsers but Playwright reported missing system libs (requires `npx playwright install-deps` / OS packages), so full browser E2E could not be executed in this environment.
- Typecheck: `npm run typecheck` was executed during rollout and reported many unrelated repo-wide TypeScript errors (existing issues outside this change); the targeted tests, lint, format, docs and smoke checks used for validation passed.

Preserved active stable debug IDs colocated with declarations: `4001`, `4002`, `4003`, `4004`, `4007`, `4009`, `400A`, and `400D`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35c9419438832fab4bd70a53225617)