### PR TITLE
Co-locate collider debug IDs with declarations

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -134,10 +134,16 @@ purpose text so reviewers can tell why the invisible constraint exists instead o
 mistaking it for hidden post-hoc layout geometry.
 
 Stair and landing safety colliders are source-backed even when their bounds are
-generated from stair layout measurements. Their source IDs should stay stable
-across refactors, and their purpose strings should explain the constraint (for
-example preserving a descent corridor edge or guarding a hidden stair-run
-no-floor area) without masquerading as room-wall geometry.
+generated from stair layout measurements. Their source IDs and any stable debug
+collider IDs live beside the active collider declaration or segment policy that
+emits the runtime collider. Deleting or disabling that active source declaration
+removes both the runtime collider and its debug ID; deleted colliders should not
+leave tombstones, negative registries, or historical absence tests. Behavior
+tests pin player-facing promises such as traversal, blocked regions, and usable
+openings, while generator and registry tests validate the currently active
+source-backed declarations generically. Purpose strings should explain the
+constraint (for example preserving a descent corridor edge or guarding a hidden
+stair-run no-floor area) without masquerading as room-wall geometry.
 
 ### Scene objects
 

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1087,8 +1087,6 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   });
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
-  expect(debugColliders).toContain('UpperStairwellLandingGuard-3');
-  expect(debugColliders).not.toContain('UpperStairwellLandingGuard-4');
   expect(debugColliders).not.toContain('GroundStairEastRunSeal');
   expect(debugColliders).not.toContain('GroundStairEastRunSealLowerCap');
   expect(debugColliders).not.toContain('GroundStairEastRunSealUpperCap');

--- a/src/main.ts
+++ b/src/main.ts
@@ -988,6 +988,7 @@ const LIGHTING_OPTIONS = {
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
+const colliderDebugIds = new Map<RectCollider, string>();
 const colliderSourceMetadata = new Map<
   RectCollider,
   {
@@ -2097,6 +2098,9 @@ function initializeImmersiveScene(
       sourceType: 'safetyCollider',
       purpose: collider.purpose,
     });
+    if (collider.debugId) {
+      colliderDebugIds.set(collider.bounds, collider.debugId);
+    }
   };
 
   createGroundStairSafetyColliders(stairGeometry, stairBehavior, {
@@ -2136,6 +2140,7 @@ function initializeImmersiveScene(
     bounds: RectCollider;
     sourceId: LevelSourceId;
     role: string;
+    debugId?: string;
   }) => {
     upperFloorColliders.push(collider.bounds);
     namedColliderDebugNames.set(collider.bounds, collider.name);
@@ -2144,6 +2149,9 @@ function initializeImmersiveScene(
       sourceType: 'generatedCollider',
       purpose: `upper stairwell landing ${collider.role} guard`,
     });
+    if (collider.debugId) {
+      colliderDebugIds.set(collider.bounds, collider.debugId);
+    }
   };
 
   const upperStairWestEgressLaneX =
@@ -4459,6 +4467,7 @@ function initializeImmersiveScene(
       sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
       sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
       purpose: colliderSourceMetadata.get(bounds)?.purpose,
+      debugId: colliderDebugIds.get(bounds),
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -72,8 +72,9 @@ describe('createColliderDebugId', () => {
       createColliderDebugId({
         floor: 'upper',
         category: 'upper',
-        name: 'UpperStairNorthBannisterGuard',
+        name: 'SourceBackedCollider',
         bounds: collider,
+        debugId: '400A',
       })
     ).toBe('400A');
     expect(

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -6,7 +6,15 @@ export interface DebugColliderIdLookupInput {
   name: string;
 }
 
-const DEBUG_COLLIDER_ID_PATTERN = /^[0-9A-F]{4,6}$/;
+export const DEBUG_COLLIDER_ID_PATTERN = /^[0-9A-F]{4,6}$/;
+
+export const assertDebugColliderId = (value: string): string => {
+  if (!DEBUG_COLLIDER_ID_PATTERN.test(value)) {
+    throw new Error(`Invalid debug collider ID ${value}`);
+  }
+
+  return value;
+};
 
 const GENERATED_COLLIDER_ID_PREFIXES = {
   ground: '1',
@@ -14,17 +22,10 @@ const GENERATED_COLLIDER_ID_PREFIXES = {
   upper: '3',
 } as const;
 
-const DECLARED_RUNTIME_COLLIDER_IDS = {
-  GroundStairEastBoundary: '4001',
-  GroundStairLowerCornerGuard: '4002',
-  UpperStairTopGapBlockerWest: '4003',
-  UpperStairTopGapBlockerEast: '4004',
-  UpperStairWestUpperVoidGuard: '4005',
-  UpperStairEastUpperVoidGuard: '4007',
-  UpperStairWestBannisterGuard: '4009',
-  UpperStairNorthBannisterGuard: '400A',
-  'UpperStairwellLandingGuard-3': '400D',
-} as const satisfies Record<string, string>;
+const DECLARED_RUNTIME_COLLIDER_IDS = {} as const satisfies Record<
+  string,
+  string
+>;
 
 const DECLARED_REGRESSION_COLLIDER_IDS = {
   // Greptile regression pair: these names historically shared fallback primary

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -34,6 +34,7 @@ export interface DebugColliderMetadata {
   sourceId?: string;
   sourceType?: string;
   purpose?: string;
+  debugId?: string;
 }
 
 export interface DebugColliderRegistration {
@@ -47,6 +48,7 @@ export interface DebugColliderRegistration {
   sourceId?: string;
   sourceType?: string;
   purpose?: string;
+  debugId?: string;
 }
 
 export interface DebugColliderVisualizerState {
@@ -101,15 +103,17 @@ const cloneSourceMetadata = <
     sourceId?: string;
     sourceType?: string;
     purpose?: string;
+    debugId?: string;
   },
 >(
   input: T
-): Pick<T, 'sourceId' | 'sourceType' | 'purpose'> => ({
+): Pick<T, 'sourceId' | 'sourceType' | 'purpose' | 'debugId'> => ({
   ...(typeof input.sourceId === 'string' ? { sourceId: input.sourceId } : {}),
   ...(typeof input.sourceType === 'string'
     ? { sourceType: input.sourceType }
     : {}),
   ...(typeof input.purpose === 'string' ? { purpose: input.purpose } : {}),
+  ...(typeof input.debugId === 'string' ? { debugId: input.debugId } : {}),
 });
 
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
@@ -146,6 +150,7 @@ const getColliderDebugPrimaryId = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
   seed: string
 ): string =>
+  metadata.debugId ??
   getDeclaredColliderDebugId(metadata) ??
   getDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`);
 

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -5,7 +5,8 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from '../../../systems/movement/stairs';
-import { getDeclaredColliderDebugId } from '../../debug/colliderDebugIds';
+import { DEBUG_COLLIDER_ID_PATTERN } from '../../debug/colliderDebugIds';
+import { createColliderVisualizer } from '../../debug/colliderVisualizer';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -106,51 +107,43 @@ describe('stair safety collider source definitions', () => {
     expect(new Set(sourceIds).size).toBe(sourceIds.length);
   });
 
-  it('keeps declared debug IDs mapped to existing safety collider names', () => {
-    const names = new Set(
-      collectSafetyColliders().map((collider) => collider.name)
+  it('keeps source-backed debug IDs valid and attached to active safety colliders', () => {
+    const colliders = collectSafetyColliders();
+    const debugIds = colliders.flatMap((collider) =>
+      collider.debugId ? [collider.debugId] : []
     );
 
-    [
-      ['GroundStairEastBoundary', '4001'],
-      ['GroundStairLowerCornerGuard', '4002'],
-      ['UpperStairEastUpperVoidGuard', '4007'],
-      ['UpperStairWestBannisterGuard', '4009'],
-      ['UpperStairNorthBannisterGuard', '400A'],
-    ].forEach(([name, id]) => {
-      expect(names.has(name)).toBe(true);
-      expect(
-        getDeclaredColliderDebugId({ floor: 'upper', category: 'upper', name })
-      ).toBe(id);
+    expect(debugIds).toHaveLength(colliders.length);
+    expect(new Set(debugIds).size).toBe(debugIds.length);
+    debugIds.forEach((debugId) => {
+      expect(debugId).toMatch(DEBUG_COLLIDER_ID_PATTERN);
+      expect(debugId).not.toMatch(/^[123][0-9A-F]{3}$/);
+      expect(debugId).not.toMatch(/^C1104$|^C2488$/);
     });
-
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairTopGapBlockerWest',
-      })
-    ).toBe('4003');
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairTopGapBlockerEast',
-      })
-    ).toBe('4004');
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairHiddenRunVoidGuard',
-      })
-    ).toBeUndefined();
   });
 
-  it('does not regenerate the removed hidden-run void guard', () => {
-    const names = collectSafetyColliders().map((collider) => collider.name);
+  it('registers source-backed debug IDs without name lookup indirection', () => {
+    const visualizer = createColliderVisualizer({
+      activeFloorId: 'upper',
+      enabled: true,
+    });
+    const colliders = collectSafetyColliders();
 
-    expect(names).not.toContain('UpperStairHiddenRunVoidGuard');
+    visualizer.register(
+      colliders.map((collider) => ({
+        floor: collider.floor,
+        category: collider.category,
+        name: collider.name,
+        bounds: collider.bounds,
+        debugId: collider.debugId,
+      }))
+    );
+
+    expect(visualizer.getColliders().map((collider) => collider.id)).toEqual(
+      colliders.map((collider) => collider.debugId)
+    );
+
+    visualizer.dispose();
   });
 
   it('keeps safety collider source IDs free of tombstone wording', () => {

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -6,6 +6,7 @@ import {
   createGroundStairBoundaryColliders,
 } from '../../systems/movement/stairs';
 import { splitColliderAroundCorridor } from '../../systems/movement/upperStairLandingGuards';
+import { assertDebugColliderId } from '../debug/colliderDebugIds';
 
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
@@ -18,6 +19,7 @@ export interface LevelSafetyCollider {
   category: SafetyColliderCategory;
   bounds: RectCollider;
   purpose: string;
+  debugId?: string;
 }
 
 export interface GroundStairSafetyColliderOptions {
@@ -42,26 +44,32 @@ export interface UpperStairSafetyColliderArgs {
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+const debugId = (value: string): string => assertDebugColliderId(value);
 
 const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
   GroundStairEastBoundary: {
     sourceId: sourceId('ground.stairwell.eastBoundary.safetyCollider'),
     category: 'stair',
     purpose: 'prevent lower stair side squeeze',
+    debugId: debugId('4001'),
   },
   GroundStairLowerCornerGuard: {
     sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
     category: 'stair',
     purpose: 'block raw lower-step occupancy',
+    debugId: debugId('4002'),
   },
 } as const satisfies Record<
   string,
-  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'>
+  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose' | 'debugId'>
 >;
 
 const getGroundStairSafetyColliderMetadata = (
   name: string
-): Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'> => {
+): Pick<
+  LevelSafetyCollider,
+  'sourceId' | 'category' | 'purpose' | 'debugId'
+> => {
   const metadata =
     GROUND_STAIR_SAFETY_COLLIDER_METADATA[
       name as keyof typeof GROUND_STAIR_SAFETY_COLLIDER_METADATA
@@ -172,6 +180,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'void',
       purpose: 'guard upper stairwell void edge',
+      debugId: debugId('4007'),
       bounds: {
         minX: stairNavigationZones.explicitDescentCorridor.maxX,
         maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
@@ -187,6 +196,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper' as const,
       category: 'void' as const,
       purpose: 'guard upper stairwell void edge',
+      debugId: debugId(name.endsWith('West') ? '4003' : '4004'),
       bounds,
     })),
     {
@@ -195,6 +205,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      debugId: debugId('4009'),
       bounds: {
         minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
         maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
@@ -215,6 +226,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      debugId: debugId('400A'),
       bounds: {
         minX: upperStairNorthBannisterMinX,
         maxX: upperStairNorthBannisterMaxX,

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -1,3 +1,5 @@
+import { assertDebugColliderId } from '../debug/colliderDebugIds';
+
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type UpperStairwellLandingSegmentRole =
@@ -13,9 +15,11 @@ export interface UpperStairwellLandingSegmentPolicy {
   collision: boolean;
   sourceId: LevelSourceId;
   colliderName?: string;
+  debugId?: string;
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+const debugId = (value: string): string => assertDebugColliderId(value);
 
 export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
   {
@@ -36,5 +40,6 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
     collision: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
     colliderName: 'UpperStairwellLandingGuard-3',
+    debugId: debugId('400D'),
   },
 ] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -153,6 +153,7 @@ describe('createUpperStairwellLanding', () => {
           minZ: -8,
           maxZ: 6,
         },
+        debugId: '400D',
       },
     ]);
   });

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -37,6 +37,7 @@ export interface UpperStairwellLandingCollider {
   sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
   name: string;
   bounds: RectCollider;
+  debugId?: string;
 }
 
 export interface UpperStairwellLandingBuild {
@@ -121,6 +122,7 @@ const addGuard = (params: {
       sourceId: params.policy.sourceId,
       name: params.policy.colliderName,
       bounds: guardBounds,
+      ...(params.policy.debugId ? { debugId: params.policy.debugId } : {}),
     });
   }
 };


### PR DESCRIPTION
### Motivation
- Move stable stair/landing debug IDs out of a separate hand-maintained map and colocate them with the active source declarations that emit those colliders so removing a collider only requires deleting/disabling its source declaration.
- Preserve generated-ID and regression-ID fallback behavior while ensuring runtime receives any explicit source-backed `debugId` unchanged.

### Description
- Add optional `debugId` to the canonical source-backed collider types and to the upper-landing segment policy, validate values with `assertDebugColliderId`, and attach the explicit IDs to emitted colliders; key files changed: `src/scene/level/stairSafetyColliders.ts`, `src/scene/level/upperStairwellLandingSegments.ts`, and `src/scene/structures/upperStairwellLanding.ts`.
- Remove the migrated stair/landing entries from the manual runtime registry and keep generated/regression IDs intact by replacing `DECLARED_RUNTIME_COLLIDER_IDS` with an empty source-backed set in `src/scene/debug/colliderDebugIds.ts`.
- Thread declared `debugId` through runtime registration and the debug visualizer so the visual ID selection prefers `metadata.debugId` then declared lookups then generated fallbacks, and the runtime stores per-collider debug IDs for registration (`src/main.ts`, `src/scene/debug/colliderVisualizer.ts`).
- Replace brittle, hand-written inventory assertions with declaration-driven tests and a visualizer contract test that asserts the visualizer receives the declared IDs; update Playwright test to remove the implementation-inventory assertions for the landing guard name and retain behavior assertions; update docs to note debug IDs live beside source declarations (`docs/design/declarative-level-source-of-truth.md`).

### Testing
- Ran formatting: `npm run format:write` (completed).
- Ran lint: `npm run lint` (completed; minor warnings auto-fixed where applicable).
- Focused unit tests: `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts src/scene/debug/__tests__/colliderVisualizer.test.ts` — all passed.
- Full unit test suite: `npm run test:ci` — passed (158 test files / 1205 tests passing in CI run).
- Playwright E2E: installed browsers and deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — passed (9 tests).
- Docs and smoke: `npm run docs:check` passed (link checker produced existing external fetch warnings) and `npm run smoke` passed (dist build assertions OK).
- Typecheck: attempted `npm run typecheck` / `tsc --noEmit`, which surfaced many unrelated baseline TypeScript errors outside the scope of this change; these are repo-wide issues and not caused by this focused change.

Notes: changes are limited to the allowed scope (safety collider types/declarations, landing segment policy, runtime registration helpers, debug visualizer, tests, Playwright spec adjustment, and a short docs note). The active stair/landing stable IDs remain exactly the preserved values (4001, 4002, 4003, 4004, 4007, 4009, 400A, 400D) and removed historical IDs were not reintroduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35c91d73ec832f89a3cfe99e8d362d)