### PR TITLE
📄 : – refresh resume workflow artifacts

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -13,10 +13,22 @@ on:
       - '.github/workflows/resume.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-artifacts:
     name: Build resume artifacts
     runs-on: ubuntu-latest
+    outputs:
+      base: ${{ steps.resume.outputs.base }}
+      pdf_artifact: ${{ steps.artifact-names.outputs.pdf_artifact }}
+      pdf_checksum: ${{ steps.checksums.outputs.pdf_checksum }}
+      pdf_pages: ${{ steps.inspect.outputs.pdf_pages }}
+      source: ${{ steps.resume.outputs.tex }}
+      version: ${{ steps.resume.outputs.version }}
+      docx_artifact: ${{ steps.artifact-names.outputs.docx_artifact }}
+      docx_checksum: ${{ steps.checksums.outputs.docx_checksum }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,13 +36,20 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y texlive-full latexmk pandoc
+          sudo apt-get install -y latexmk pandoc poppler-utils texlive-full
 
       - name: Determine latest resume source
         id: resume
         run: |
           set -euo pipefail
-          latest_dir=$(find docs/resume -regextype posix-extended -maxdepth 1 -mindepth 1 -type d -regex '.*/[0-9]{4}-[0-9]{2}$' | sort | tail -n1)
+          latest_dir=$(find docs/resume \
+            -regextype posix-extended \
+            -maxdepth 1 \
+            -mindepth 1 \
+            -type d \
+            -regex '.*/[0-9]{4}-[0-9]{2}$' \
+            | sort \
+            | tail -n1)
           if [ -z "${latest_dir}" ]; then
             echo "No dated resume directories found." >&2
             exit 1
@@ -43,32 +62,236 @@ jobs:
           fi
 
           base_name=$(basename "${tex_file}" .tex)
-          resume_dir=$(dirname "${tex_file}")
+          version=$(basename "${latest_dir}")
+          if ! [[ "${version}" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+            echo "Selected resume version '${version}' does not match YYYY-MM." >&2
+            exit 1
+          fi
 
           {
-            echo "dir=${resume_dir}"
-            echo "tex=${tex_file}"
             echo "base=${base_name}"
+            echo "tex=${tex_file}"
+            echo "version=${version}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Prepare temporary output directory
+        id: output
+        run: |
+          set -euo pipefail
+          build_dir=$(mktemp -d "${RUNNER_TEMP}/resume.XXXXXX")
+          {
+            echo "dir=${build_dir}"
+            echo "pdf=${build_dir}/${{ steps.resume.outputs.base }}.pdf"
+            echo "docx=${build_dir}/${{ steps.resume.outputs.base }}.docx"
           } >>"${GITHUB_OUTPUT}"
 
       - name: Generate PDF with latexmk
         run: |
           set -euo pipefail
-          latexmk -pdf -interaction=nonstopmode -outdir="${{ steps.resume.outputs.dir }}" "${{ steps.resume.outputs.tex }}"
+          latexmk \
+            -pdf \
+            -interaction=nonstopmode \
+            -outdir="${{ steps.output.outputs.dir }}" \
+            "${{ steps.resume.outputs.tex }}"
 
       - name: Generate DOCX with pandoc
         run: |
           set -euo pipefail
-          pandoc "${{ steps.resume.outputs.tex }}" -o "${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.docx"
+          pandoc \
+            "${{ steps.resume.outputs.tex }}" \
+            -o "${{ steps.output.outputs.docx }}"
+
+      - name: Inspect generated PDF
+        id: inspect
+        run: |
+          set -euo pipefail
+          pages=$(pdfinfo "${{ steps.output.outputs.pdf }}" | awk '/^Pages:/ {print $2}')
+          if [ -z "${pages}" ]; then
+            echo "Unable to determine PDF page count." >&2
+            exit 1
+          fi
+          echo "pdf_pages=${pages}" >>"${GITHUB_OUTPUT}"
+
+      - name: Compute checksums
+        id: checksums
+        run: |
+          set -euo pipefail
+          pdf_checksum=$(sha256sum "${{ steps.output.outputs.pdf }}" | awk '{print $1}')
+          docx_checksum=$(sha256sum "${{ steps.output.outputs.docx }}" | awk '{print $1}')
+          {
+            echo "pdf_checksum=${pdf_checksum}"
+            echo "docx_checksum=${docx_checksum}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Set artifact names
+        id: artifact-names
+        run: |
+          set -euo pipefail
+          {
+            echo "pdf_artifact=resume-${{ steps.resume.outputs.version }}-pdf"
+            echo "docx_artifact=resume-${{ steps.resume.outputs.version }}-docx"
+          } >>"${GITHUB_OUTPUT}"
 
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.resume.outputs.base }}.pdf
-          path: ${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.pdf
+          name: ${{ steps.artifact-names.outputs.pdf_artifact }}
+          path: ${{ steps.output.outputs.pdf }}
+          if-no-files-found: error
 
       - name: Upload DOCX artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.resume.outputs.base }}.docx
-          path: ${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.docx
+          name: ${{ steps.artifact-names.outputs.docx_artifact }}
+          path: ${{ steps.output.outputs.docx }}
+          if-no-files-found: error
+
+      - name: Summarize build
+        run: |
+          set -euo pipefail
+          cat <<'SUMMARY' >>"${GITHUB_STEP_SUMMARY}"
+          ## Resume artifact build
+
+          | Field | Value |
+          | --- | --- |
+          | Selected TeX source | `${{ steps.resume.outputs.tex }}` |
+          | Selected version | `${{ steps.resume.outputs.version }}` |
+          | PDF page count | `${{ steps.inspect.outputs.pdf_pages }}` |
+          | PDF artifact | `${{ steps.artifact-names.outputs.pdf_artifact }}` |
+          | DOCX artifact | `${{ steps.artifact-names.outputs.docx_artifact }}` |
+          | PDF SHA-256 | `${{ steps.checksums.outputs.pdf_checksum }}` |
+          | DOCX SHA-256 | `${{ steps.checksums.outputs.docx_checksum }}` |
+          | Repository files changed | `not checked in build job` |
+          | Generated commit SHA | `not applicable` |
+          SUMMARY
+
+  publish-artifacts:
+    name: Publish resume artifacts
+    needs: build-artifacts
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate selected version
+        run: |
+          set -euo pipefail
+          version='${{ needs.build-artifacts.outputs.version }}'
+          if ! [[ "${version}" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+            echo "Selected resume version '${version}' does not match YYYY-MM." >&2
+            exit 1
+          fi
+
+      - name: Download PDF artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-artifacts.outputs.pdf_artifact }}
+          path: ${{ runner.temp }}/resume-pdf
+
+      - name: Download DOCX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-artifacts.outputs.docx_artifact }}
+          path: ${{ runner.temp }}/resume-docx
+
+      - name: Publish generated files
+        id: publish
+        run: |
+          set -euo pipefail
+          version='${{ needs.build-artifacts.outputs.version }}'
+          base='${{ needs.build-artifacts.outputs.base }}'
+          pdf_source="${RUNNER_TEMP}/resume-pdf/${base}.pdf"
+          docx_source="${RUNNER_TEMP}/resume-docx/${base}.docx"
+
+          if [ ! -f "${pdf_source}" ] || [ ! -f "${docx_source}" ]; then
+            echo "Downloaded resume artifacts are missing." >&2
+            exit 1
+          fi
+
+          git pull --ff-only origin main || {
+            echo "Unable to fast-forward main before publishing resume artifacts." >&2
+            echo "Re-run the workflow after main settles; no files were pushed." >&2
+            exit 1
+          }
+
+          versioned_dir="public/docs/resume/${version}"
+          mkdir -p "${versioned_dir}"
+          cp "${pdf_source}" "${versioned_dir}/resume.pdf"
+          cp "${docx_source}" "${versioned_dir}/resume.docx"
+          cp "${pdf_source}" public/resume.pdf
+          cp "${docx_source}" public/resume.docx
+
+          cmp -s public/resume.pdf "${versioned_dir}/resume.pdf"
+          cmp -s public/resume.docx "${versioned_dir}/resume.docx"
+
+          changed_files=$(git status --porcelain -- \
+            public/resume.pdf \
+            public/resume.docx \
+            "${versioned_dir}/resume.pdf" \
+            "${versioned_dir}/resume.docx")
+          if [ -z "${changed_files}" ]; then
+            echo "changed=false" >>"${GITHUB_OUTPUT}"
+            echo "commit_sha=" >>"${GITHUB_OUTPUT}"
+            echo "No generated resume artifact changes to commit."
+            exit 0
+          fi
+
+          unexpected=$(git status --porcelain \
+            | awk '{print $2}' \
+            | grep -vE "^(public/resume\.(pdf|docx)|public/docs/resume/${version}/resume\.(pdf|docx))$" \
+            || true)
+          if [ -n "${unexpected}" ]; then
+            echo "Unexpected files changed during resume artifact publishing:" >&2
+            echo "${unexpected}" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            public/resume.pdf \
+            public/resume.docx \
+            "${versioned_dir}/resume.pdf" \
+            "${versioned_dir}/resume.docx"
+          git commit -m "📄 : – refresh generated resume artifacts"
+
+          if ! git push origin HEAD:main; then
+            echo "Failed to push generated resume artifacts to main." >&2
+            echo "If main is protected against GitHub Actions pushes, this repository" >&2
+            echo "must either allow the GitHub Actions bot to push generated public" >&2
+            echo "resume artifacts or use a different documented persistence path." >&2
+            exit 1
+          fi
+
+          commit_sha=$(git rev-parse HEAD)
+          {
+            echo "changed=true"
+            echo "commit_sha=${commit_sha}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Summarize publish
+        run: |
+          set -euo pipefail
+          version='${{ needs.build-artifacts.outputs.version }}'
+          cat <<'SUMMARY' >>"${GITHUB_STEP_SUMMARY}"
+          ## Resume artifact publish
+
+          | Field | Value |
+          | --- | --- |
+          | Selected TeX source | `${{ needs.build-artifacts.outputs.source }}` |
+          | Selected version | `${{ needs.build-artifacts.outputs.version }}` |
+          | PDF page count | `${{ needs.build-artifacts.outputs.pdf_pages }}` |
+          | Versioned PDF path | `public/docs/resume/${{ needs.build-artifacts.outputs.version }}/resume.pdf` |
+          | Versioned DOCX path | `public/docs/resume/${{ needs.build-artifacts.outputs.version }}/resume.docx` |
+          | Stable PDF path | `public/resume.pdf` |
+          | Stable DOCX path | `public/resume.docx` |
+          | PDF SHA-256 | `${{ needs.build-artifacts.outputs.pdf_checksum }}` |
+          | DOCX SHA-256 | `${{ needs.build-artifacts.outputs.docx_checksum }}` |
+          | Repository files changed | `${{ steps.publish.outputs.changed }}` |
+          | Generated commit SHA | `${{ steps.publish.outputs.commit_sha || 'not applicable' }}` |
+          SUMMARY

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Avatar facing is computed from the camera-relative movement vector; see
   [docs/guides/in-world-vs-overlay.md](docs/guides/in-world-vs-overlay.md).
 - **Résumé** – Latest résumé source is
   [`resume.tex`][resume-src].
-  CI renders PDF and DOCX artifacts.
+  CI renders PDF and DOCX artifacts for each run, then publishes generated
+  public copies after source changes land on `main`.
 - **Prompt library** – Automation-ready Codex prompts are summarized in
   [`summary.md`][prompt-summary] and expanded across topical files in
   `docs/prompts/codex/` (automation, lighting, avatar, HUD, POIs, accessibility, and more).


### PR DESCRIPTION
### Motivation
- Ensure PDF and DOCX résumé artifacts are produced for PRs and manual runs as downloadable GitHub Actions artifacts while persisting canonical, versioned public copies only from `main` pushes.
- Move generation out of `docs/resume` into a temporary build directory to avoid committing binaries beside source and to preserve older versioned artifacts.

### Description
- Update `.github/workflows/resume.yml` to build PDF and DOCX in a temporary runner directory, compute page counts and SHA-256 checksums, and upload both as artifacts named with the selected `YYYY-MM` version.
- Add a separate `publish-artifacts` job (runs only on `push` to `main`) with `contents: write` scoped to that job which downloads the artifacts, validates the `YYYY-MM` version, copies files to `public/docs/resume/<version>/resume.pdf|.docx` and `public/resume.pdf|.docx`, and commits/pushes only when those four public files differ.
- Use guards to fast‑forward-pull before pushing, prevent unexpected file changes from being committed, configure the GitHub Actions bot identity for commits, and emit a clear error if pushing fails due to branch protection.
- Keep workflow least-privilege by setting default `permissions: contents: read`, document the new publish behavior in `README.md`, and ensure no generated files are written under `docs/resume`.

### Testing
- Ran formatting and style checks with `npm run format:write` and `npx prettier --check` which passed.
- Verified source selection and local build with `latexmk -pdf -interaction=nonstopmode -outdir="$build_dir" docs/resume/2026-06/resume.tex` and `pandoc docs/resume/2026-06/resume.tex -o "$build_dir/resume.docx"`, and `pdfinfo "$build_dir/resume.pdf"` reported `Pages: 1` (success).
- Computed SHA-256 checksums of generated outputs with `sha256sum` and confirmed no résumé binaries exist under `docs/resume` after the build (success).
- Ran repository checks `npm run lint`, `npm run test:ci`, `npm run docs:check`, and `npm run smoke`, all of which completed successfully in this environment, and executed `git diff --cached | ./scripts/scan-secrets.py` with no high-risk secrets found.
- Note: `actionlint` was not available in this environment so `actionlint .github/workflows/resume.yml` was not executed, and the attempted `npm run test:ci -- --runInBand` failed because Vitest does not accept `--runInBand`; the canonical `npm run test:ci` run succeeded.
- Limitation: the publish-to-`main` push path (push-authenticated commit and branch-protection behavior) cannot be fully exercised here and must be validated on an actual GitHub Actions push-to-`main` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35cc02b24c832f841c77875f6973c4)