### PR TITLE
Co-locate collider debug IDs with source declarations

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -137,7 +137,13 @@ Stair and landing safety colliders are source-backed even when their bounds are
 generated from stair layout measurements. Their source IDs should stay stable
 across refactors, and their purpose strings should explain the constraint (for
 example preserving a descent corridor edge or guarding a hidden stair-run
-no-floor area) without masquerading as room-wall geometry.
+no-floor area) without masquerading as room-wall geometry. Stable compact debug
+IDs for active stair and landing colliders live beside the active collider
+declarations or segment policies that emit them. Deleting or disabling one of
+these source declarations removes its runtime collider and debug ID together; do
+not preserve deleted colliders as tombstones, negative tests, or manual debug-ID
+registries. Behavior tests should pin player-facing promises, while generator
+and registry tests validate active declarations generically.
 
 ### Scene objects
 

--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -1087,8 +1087,6 @@ test('ground stair east boundary blocks squeeze corners but preserves the stair 
   });
   expect(debugColliders).toContain('GroundStairEastBoundary');
   expect(debugColliders).toContain('GroundStairLowerCornerGuard');
-  expect(debugColliders).toContain('UpperStairwellLandingGuard-3');
-  expect(debugColliders).not.toContain('UpperStairwellLandingGuard-4');
   expect(debugColliders).not.toContain('GroundStairEastRunSeal');
   expect(debugColliders).not.toContain('GroundStairEastRunSealLowerCap');
   expect(debugColliders).not.toContain('GroundStairEastRunSealUpperCap');

--- a/src/main.ts
+++ b/src/main.ts
@@ -998,6 +998,7 @@ const colliderSourceMetadata = new Map<
       | LevelSourceId;
     sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
     purpose?: string;
+    debugId?: string;
   }
 >();
 const upperFloorColliders: RectCollider[] = [];
@@ -2096,6 +2097,7 @@ function initializeImmersiveScene(
       sourceId: collider.sourceId,
       sourceType: 'safetyCollider',
       purpose: collider.purpose,
+      debugId: collider.debugId,
     });
   };
 
@@ -2136,6 +2138,7 @@ function initializeImmersiveScene(
     bounds: RectCollider;
     sourceId: LevelSourceId;
     role: string;
+    debugId?: string;
   }) => {
     upperFloorColliders.push(collider.bounds);
     namedColliderDebugNames.set(collider.bounds, collider.name);
@@ -2143,6 +2146,7 @@ function initializeImmersiveScene(
       sourceId: collider.sourceId,
       sourceType: 'generatedCollider',
       purpose: `upper stairwell landing ${collider.role} guard`,
+      debugId: collider.debugId,
     });
   };
 
@@ -4459,6 +4463,7 @@ function initializeImmersiveScene(
       sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
       sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
       purpose: colliderSourceMetadata.get(bounds)?.purpose,
+      debugId: colliderSourceMetadata.get(bounds)?.debugId,
     }));
 
   const colliderVisualizer = createColliderVisualizer({

--- a/src/scene/debug/__tests__/colliderVisualizer.test.ts
+++ b/src/scene/debug/__tests__/colliderVisualizer.test.ts
@@ -43,7 +43,7 @@ describe('createColliderDebugId', () => {
     expect(createColliderDebugId(metadata)).toMatch(/^[0-9A-F]{6}$/);
   });
 
-  it('uses declared IDs for generated and named runtime colliders', () => {
+  it('uses declared IDs for generated, regression, and source-backed colliders', () => {
     expect(
       createColliderDebugId({
         floor: 'ground',
@@ -74,6 +74,7 @@ describe('createColliderDebugId', () => {
         category: 'upper',
         name: 'UpperStairNorthBannisterGuard',
         bounds: collider,
+        debugId: '400A',
       })
     ).toBe('400A');
     expect(

--- a/src/scene/debug/colliderDebugIds.ts
+++ b/src/scene/debug/colliderDebugIds.ts
@@ -6,25 +6,13 @@ export interface DebugColliderIdLookupInput {
   name: string;
 }
 
-const DEBUG_COLLIDER_ID_PATTERN = /^[0-9A-F]{4,6}$/;
+export const DEBUG_COLLIDER_ID_PATTERN = /^[0-9A-F]{4,6}$/;
 
 const GENERATED_COLLIDER_ID_PREFIXES = {
   ground: '1',
   static: '2',
   upper: '3',
 } as const;
-
-const DECLARED_RUNTIME_COLLIDER_IDS = {
-  GroundStairEastBoundary: '4001',
-  GroundStairLowerCornerGuard: '4002',
-  UpperStairTopGapBlockerWest: '4003',
-  UpperStairTopGapBlockerEast: '4004',
-  UpperStairWestUpperVoidGuard: '4005',
-  UpperStairEastUpperVoidGuard: '4007',
-  UpperStairWestBannisterGuard: '4009',
-  UpperStairNorthBannisterGuard: '400A',
-  'UpperStairwellLandingGuard-3': '400D',
-} as const satisfies Record<string, string>;
 
 const DECLARED_REGRESSION_COLLIDER_IDS = {
   // Greptile regression pair: these names historically shared fallback primary
@@ -35,11 +23,10 @@ const DECLARED_REGRESSION_COLLIDER_IDS = {
 } as const satisfies Record<string, string>;
 
 const DECLARED_NAMED_COLLIDER_IDS = {
-  ...DECLARED_RUNTIME_COLLIDER_IDS,
   ...DECLARED_REGRESSION_COLLIDER_IDS,
 } as const satisfies Record<string, string>;
 
-const getGeneratedColliderId = ({
+export const getGeneratedColliderId = ({
   category,
   name,
 }: DebugColliderIdLookupInput): string | undefined => {

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -14,7 +14,10 @@ import {
 import type { RectCollider } from '../../systems/collision';
 import type { FloorId } from '../../systems/movement/stairs';
 
-import { getDeclaredColliderDebugId } from './colliderDebugIds';
+import {
+  DEBUG_COLLIDER_ID_PATTERN,
+  getDeclaredColliderDebugId,
+} from './colliderDebugIds';
 import {
   DEBUG_ID_PRECISION,
   allocateDebugId,
@@ -34,6 +37,7 @@ export interface DebugColliderMetadata {
   sourceId?: string;
   sourceType?: string;
   purpose?: string;
+  debugId?: string;
 }
 
 export interface DebugColliderRegistration {
@@ -47,6 +51,7 @@ export interface DebugColliderRegistration {
   sourceId?: string;
   sourceType?: string;
   purpose?: string;
+  debugId?: string;
 }
 
 export interface DebugColliderVisualizerState {
@@ -101,15 +106,17 @@ const cloneSourceMetadata = <
     sourceId?: string;
     sourceType?: string;
     purpose?: string;
+    debugId?: string;
   },
 >(
   input: T
-): Pick<T, 'sourceId' | 'sourceType' | 'purpose'> => ({
+): Pick<T, 'sourceId' | 'sourceType' | 'purpose' | 'debugId'> => ({
   ...(typeof input.sourceId === 'string' ? { sourceId: input.sourceId } : {}),
   ...(typeof input.sourceType === 'string'
     ? { sourceType: input.sourceType }
     : {}),
   ...(typeof input.purpose === 'string' ? { purpose: input.purpose } : {}),
+  ...(typeof input.debugId === 'string' ? { debugId: input.debugId } : {}),
 });
 
 const cloneBounds = (bounds: RectCollider): RectCollider => ({
@@ -146,6 +153,7 @@ const getColliderDebugPrimaryId = (
   metadata: Omit<DebugColliderMetadata, 'id'>,
   seed: string
 ): string =>
+  metadata.debugId ??
   getDeclaredColliderDebugId(metadata) ??
   getDebugHash(`${seed}|${DEBUG_ID_PRIMARY_SALT}`);
 
@@ -176,7 +184,24 @@ const allocateColliderDebugIds = (
   const usedIds = new Set(existingIds);
   const seedCounts = new Map<string, number>();
 
+  const explicitIds = new Map<string, string>();
+
   const allocationItems = metadataList.map((metadata, index) => {
+    if (metadata.debugId) {
+      if (!DEBUG_COLLIDER_ID_PATTERN.test(metadata.debugId)) {
+        throw new Error(
+          `Invalid debug collider ID ${metadata.debugId} declared for ${metadata.name}`
+        );
+      }
+      const existingName = explicitIds.get(metadata.debugId);
+      if (existingName || existingIds.has(metadata.debugId)) {
+        throw new Error(
+          `Debug collider ID ${metadata.debugId} is declared for both ${existingName ?? 'an existing collider'} and ${metadata.name}`
+        );
+      }
+      explicitIds.set(metadata.debugId, metadata.name);
+    }
+
     const seed = getColliderDebugSeed(metadata);
     const seedOccurrence = seedCounts.get(seed) ?? 0;
     seedCounts.set(seed, seedOccurrence + 1);

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -5,12 +5,17 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from '../../../systems/movement/stairs';
-import { getDeclaredColliderDebugId } from '../../debug/colliderDebugIds';
+import {
+  DEBUG_COLLIDER_ID_PATTERN,
+  getGeneratedColliderId,
+} from '../../debug/colliderDebugIds';
+import { createColliderVisualizer } from '../../debug/colliderVisualizer';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
   type LevelSafetyCollider,
 } from '../stairSafetyColliders';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../upperStairwellLandingSegments';
 
 const PLAYER_RADIUS = 0.75;
 
@@ -106,51 +111,63 @@ describe('stair safety collider source definitions', () => {
     expect(new Set(sourceIds).size).toBe(sourceIds.length);
   });
 
-  it('keeps declared debug IDs mapped to existing safety collider names', () => {
-    const names = new Set(
-      collectSafetyColliders().map((collider) => collider.name)
+  it('keeps active source-backed debug IDs valid, unique, and non-generated', () => {
+    const debugIds = collectSafetyColliders().flatMap((collider) =>
+      collider.debugId ? [collider.debugId] : []
     );
+    const landingDebugIds = UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES.flatMap(
+      (policy) => (policy.collision && policy.debugId ? [policy.debugId] : [])
+    );
+    const activeDebugIds = [...debugIds, ...landingDebugIds];
 
-    [
-      ['GroundStairEastBoundary', '4001'],
-      ['GroundStairLowerCornerGuard', '4002'],
-      ['UpperStairEastUpperVoidGuard', '4007'],
-      ['UpperStairWestBannisterGuard', '4009'],
-      ['UpperStairNorthBannisterGuard', '400A'],
-    ].forEach(([name, id]) => {
-      expect(names.has(name)).toBe(true);
+    expect([...activeDebugIds].sort()).toEqual([
+      '4001',
+      '4002',
+      '4007',
+      '4009',
+      '400A',
+      '400D',
+    ]);
+    expect(new Set(activeDebugIds).size).toBe(activeDebugIds.length);
+
+    activeDebugIds.forEach((debugId) => {
+      expect(DEBUG_COLLIDER_ID_PATTERN.test(debugId)).toBe(true);
       expect(
-        getDeclaredColliderDebugId({ floor: 'upper', category: 'upper', name })
-      ).toBe(id);
+        getGeneratedColliderId({
+          floor: 'upper',
+          category: debugId.startsWith('1') ? 'ground' : 'upper',
+          name: `${debugId.startsWith('1') ? 'ground' : 'upper'}-collider-${Number.parseInt(debugId.slice(1), 16)}`,
+        })
+      ).not.toBe(debugId);
     });
-
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairTopGapBlockerWest',
-      })
-    ).toBe('4003');
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairTopGapBlockerEast',
-      })
-    ).toBe('4004');
-    expect(
-      getDeclaredColliderDebugId({
-        floor: 'upper',
-        category: 'upper',
-        name: 'UpperStairHiddenRunVoidGuard',
-      })
-    ).toBeUndefined();
   });
 
-  it('does not regenerate the removed hidden-run void guard', () => {
-    const names = collectSafetyColliders().map((collider) => collider.name);
+  it('exposes source-backed debug IDs unchanged at runtime registration', () => {
+    const colliders = collectSafetyColliders();
+    const visualizer = createColliderVisualizer({ activeFloorId: 'upper' });
 
-    expect(names).not.toContain('UpperStairHiddenRunVoidGuard');
+    visualizer.register(
+      colliders.map((collider) => ({
+        floor: collider.floor,
+        category: collider.floor,
+        name: collider.name,
+        bounds: collider.bounds,
+        sourceId: collider.sourceId,
+        sourceType: 'safetyCollider',
+        purpose: collider.purpose,
+        debugId: collider.debugId,
+      }))
+    );
+
+    colliders.forEach((collider) => {
+      if (!collider.debugId) return;
+
+      expect(visualizer.getColliderBySourceId(collider.sourceId)?.id).toBe(
+        collider.debugId
+      );
+    });
+
+    visualizer.dispose();
   });
 
   it('keeps safety collider source IDs free of tombstone wording', () => {

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -18,6 +18,7 @@ export interface LevelSafetyCollider {
   category: SafetyColliderCategory;
   bounds: RectCollider;
   purpose: string;
+  debugId?: string;
 }
 
 export interface GroundStairSafetyColliderOptions {
@@ -48,20 +49,25 @@ const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
     sourceId: sourceId('ground.stairwell.eastBoundary.safetyCollider'),
     category: 'stair',
     purpose: 'prevent lower stair side squeeze',
+    debugId: '4001',
   },
   GroundStairLowerCornerGuard: {
     sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
     category: 'stair',
     purpose: 'block raw lower-step occupancy',
+    debugId: '4002',
   },
 } as const satisfies Record<
   string,
-  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'>
+  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose' | 'debugId'>
 >;
 
 const getGroundStairSafetyColliderMetadata = (
   name: string
-): Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose'> => {
+): Pick<
+  LevelSafetyCollider,
+  'sourceId' | 'category' | 'purpose' | 'debugId'
+> => {
   const metadata =
     GROUND_STAIR_SAFETY_COLLIDER_METADATA[
       name as keyof typeof GROUND_STAIR_SAFETY_COLLIDER_METADATA
@@ -172,6 +178,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'void',
       purpose: 'guard upper stairwell void edge',
+      debugId: '4007',
       bounds: {
         minX: stairNavigationZones.explicitDescentCorridor.maxX,
         maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
@@ -187,6 +194,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper' as const,
       category: 'void' as const,
       purpose: 'guard upper stairwell void edge',
+      debugId: name.endsWith('West') ? '4003' : '4004',
       bounds,
     })),
     {
@@ -195,6 +203,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      debugId: '4009',
       bounds: {
         minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
         maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
@@ -215,6 +224,7 @@ export const createUpperStairSafetyColliders = ({
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      debugId: '400A',
       bounds: {
         minX: upperStairNorthBannisterMinX,
         maxX: upperStairNorthBannisterMaxX,

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -13,6 +13,7 @@ export interface UpperStairwellLandingSegmentPolicy {
   collision: boolean;
   sourceId: LevelSourceId;
   colliderName?: string;
+  debugId?: string;
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
@@ -36,5 +37,6 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
     collision: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
     colliderName: 'UpperStairwellLandingGuard-3',
+    debugId: '400D',
   },
 ] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -153,6 +153,7 @@ describe('createUpperStairwellLanding', () => {
           minZ: -8,
           maxZ: 6,
         },
+        debugId: '400D',
       },
     ]);
   });

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -37,6 +37,7 @@ export interface UpperStairwellLandingCollider {
   sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
   name: string;
   bounds: RectCollider;
+  debugId?: string;
 }
 
 export interface UpperStairwellLandingBuild {
@@ -121,6 +122,7 @@ const addGuard = (params: {
       sourceId: params.policy.sourceId,
       name: params.policy.colliderName,
       bounds: guardBounds,
+      debugId: params.policy.debugId,
     });
   }
 };


### PR DESCRIPTION
### Motivation
- Make stable stair and landing debug IDs part of the active source-backed collider declarations so deleting or disabling a source item removes its runtime collider and compact debug ID together. 
- Avoid a separate, manually-maintained runtime inventory and eliminate the need to edit debug maps, `main.ts`, or Playwright inventory assertions when removing an active collider.

### Description
- Added an optional `debugId?: string` to `LevelSafetyCollider`, `UpperStairwellLandingSegmentPolicy`, and emitted landing collider records and assigned the preserved stair/landing IDs (`4001`, `4002`, `4003`, `4004`, `4007`, `4009`, `400A`, `400D`) next to their active declarations. 
- Threaded `debugId` through runtime registration by storing `debugId` in `colliderSourceMetadata` and including it in `createDebugColliderRegistrations(...)` so the visualizer receives explicit IDs from source-backed records. 
- Removed the migrated stair/landing entries from the manual lookup in `src/scene/debug/colliderDebugIds.ts` while preserving generated-ID prefixes and regression IDs. 
- Updated the debug visualizer to prefer an explicit `debugId` on metadata, validate declared IDs against the allowed pattern and uniqueness, and allocate fallbacks only when no explicit ID exists. 
- Replaced hand-written name→ID unit assertions with declaration-driven tests and removed Playwright assertions that depended on implementation-inventory (specifically the landing guard existence/absence assertions). 
- Small doc update in `docs/design/declarative-level-source-of-truth.md` describing that compact stable debug IDs live beside active source declarations and that deleted colliders should not be preserved as tombstones. 

### Testing
- `npm run format:write` — succeeded. 
- `npm run lint` — completed (one non-blocking import-order warning surfaced earlier during development but no blocking errors). 
- Focused unit runs: `npm run test:ci -- src/scene/debug/__tests__/colliderVisualizer.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts` — succeeded. 
- Full unit suite: `npm run test:ci` — succeeded (all tests passed). 
- Docs and build checks: `npm run docs:check` and `npm run smoke` — succeeded. 
- Playwright: `npx playwright install chromium` and `npx playwright install-deps chromium` were run to provision browsers and deps, then `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` — succeeded (the spec passed after installing browsers/deps). 
- Inventory/regression grep: `rg -n "DECLARED_RUNTIME_COLLIDER_IDS|getDeclaredColliderDebugId|UpperStairHiddenRunVoidGuard|4008|UpperStairwellLandingGuard-4" src playwright docs` — confirmed only the compatibility fallback reference remains and migrated entries were removed. 
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

All automated checks required by the repo passed in this run; follow-ups: keep an eye on any visualizer allocation edge-cases when new source-backed `debugId` values are added and update documentation if more collider families are migrated next.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35c92c8734832f9829fac4a664f393)