### PR TITLE
📄 : – publish resume artifacts from workflow

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -13,10 +13,18 @@ on:
       - '.github/workflows/resume.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-artifacts:
     name: Build resume artifacts
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resume.outputs.version }}
+      tex: ${{ steps.resume.outputs.tex }}
+      pdf-artifact: ${{ steps.artifacts.outputs.pdf }}
+      docx-artifact: ${{ steps.artifacts.outputs.docx }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,15 +32,28 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y texlive-full latexmk pandoc
+          sudo apt-get install -y texlive-full latexmk pandoc poppler-utils
 
       - name: Determine latest resume source
         id: resume
         run: |
           set -euo pipefail
-          latest_dir=$(find docs/resume -regextype posix-extended -maxdepth 1 -mindepth 1 -type d -regex '.*/[0-9]{4}-[0-9]{2}$' | sort | tail -n1)
+          latest_dir=$(find docs/resume \
+            -regextype posix-extended \
+            -maxdepth 1 \
+            -mindepth 1 \
+            -type d \
+            -regex '.*/[0-9]{4}-[0-9]{2}$' \
+            | sort \
+            | tail -n1)
           if [ -z "${latest_dir}" ]; then
             echo "No dated resume directories found." >&2
+            exit 1
+          fi
+
+          version=$(basename "${latest_dir}")
+          if [[ ! "${version}" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+            echo "Selected resume version '${version}' does not match YYYY-MM." >&2
             exit 1
           fi
 
@@ -43,32 +64,236 @@ jobs:
           fi
 
           base_name=$(basename "${tex_file}" .tex)
-          resume_dir=$(dirname "${tex_file}")
+          build_dir=$(mktemp -d "${RUNNER_TEMP}/resume-build-${version}.XXXXXX")
 
           {
-            echo "dir=${resume_dir}"
+            echo "dir=${latest_dir}"
             echo "tex=${tex_file}"
             echo "base=${base_name}"
+            echo "version=${version}"
+            echo "build_dir=${build_dir}"
+            echo "pdf_path=${build_dir}/${base_name}.pdf"
+            echo "docx_path=${build_dir}/${base_name}.docx"
           } >>"${GITHUB_OUTPUT}"
 
       - name: Generate PDF with latexmk
         run: |
           set -euo pipefail
-          latexmk -pdf -interaction=nonstopmode -outdir="${{ steps.resume.outputs.dir }}" "${{ steps.resume.outputs.tex }}"
+          latexmk -pdf \
+            -interaction=nonstopmode \
+            -outdir="${{ steps.resume.outputs.build_dir }}" \
+            "${{ steps.resume.outputs.tex }}"
 
       - name: Generate DOCX with pandoc
         run: |
           set -euo pipefail
-          pandoc "${{ steps.resume.outputs.tex }}" -o "${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.docx"
+          pandoc "${{ steps.resume.outputs.tex }}" -o "${{ steps.resume.outputs.docx_path }}"
+
+      - name: Inspect generated artifacts
+        id: inspect
+        run: |
+          set -euo pipefail
+          pdf="${{ steps.resume.outputs.pdf_path }}"
+          docx="${{ steps.resume.outputs.docx_path }}"
+          pdf_pages=$(pdfinfo "${pdf}" | awk '/^Pages:/ {print $2}')
+          pdf_sha=$(sha256sum "${pdf}" | awk '{print $1}')
+          docx_sha=$(sha256sum "${docx}" | awk '{print $1}')
+
+          {
+            echo "pdf_pages=${pdf_pages}"
+            echo "pdf_sha=${pdf_sha}"
+            echo "docx_sha=${docx_sha}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Name upload artifacts
+        id: artifacts
+        run: |
+          set -euo pipefail
+          {
+            echo "pdf=resume-${{ steps.resume.outputs.version }}-pdf"
+            echo "docx=resume-${{ steps.resume.outputs.version }}-docx"
+          } >>"${GITHUB_OUTPUT}"
 
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.resume.outputs.base }}.pdf
-          path: ${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.pdf
+          name: ${{ steps.artifacts.outputs.pdf }}
+          path: ${{ steps.resume.outputs.pdf_path }}
+          if-no-files-found: error
 
       - name: Upload DOCX artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.resume.outputs.base }}.docx
-          path: ${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.docx
+          name: ${{ steps.artifacts.outputs.docx }}
+          path: ${{ steps.resume.outputs.docx_path }}
+          if-no-files-found: error
+
+      - name: Summarize resume artifacts
+        run: |
+          set -euo pipefail
+          {
+            echo "## Resume artifacts"
+            echo ""
+            echo "- Selected TeX source: \`${{ steps.resume.outputs.tex }}\`"
+            echo "- Selected version: \`${{ steps.resume.outputs.version }}\`"
+            echo "- PDF page count: \`${{ steps.inspect.outputs.pdf_pages }}\`"
+            echo "- Output paths:"
+            echo "  - \`${{ steps.resume.outputs.pdf_path }}\`"
+            echo "  - \`${{ steps.resume.outputs.docx_path }}\`"
+            echo "- SHA-256 checksums:"
+            echo "  - PDF: \`${{ steps.inspect.outputs.pdf_sha }}\`"
+            echo "  - DOCX: \`${{ steps.inspect.outputs.docx_sha }}\`"
+            echo "- Repository files changed: not checked during build"
+            echo "- Generated commit SHA: not published by this job"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+  publish-artifacts:
+    name: Publish generated resume artifacts
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      github.actor != 'github-actions[bot]'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Validate selected version
+        run: |
+          set -euo pipefail
+          version="${{ needs.build-artifacts.outputs.version }}"
+          if [[ ! "${version}" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+            echo "Selected resume version '${version}' does not match YYYY-MM." >&2
+            exit 1
+          fi
+
+      - name: Download generated PDF
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-artifacts.outputs.pdf-artifact }}
+          path: ${{ runner.temp }}/resume-artifacts/pdf
+
+      - name: Download generated DOCX
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-artifacts.outputs.docx-artifact }}
+          path: ${{ runner.temp }}/resume-artifacts/docx
+
+      - name: Copy artifacts to public paths
+        id: publish
+        run: |
+          set -euo pipefail
+          version="${{ needs.build-artifacts.outputs.version }}"
+          pdf_source=$(find "${RUNNER_TEMP}/resume-artifacts/pdf" \
+            -maxdepth 1 \
+            -type f \
+            -name '*.pdf' \
+            | sort \
+            | head -n1)
+          docx_source=$(find "${RUNNER_TEMP}/resume-artifacts/docx" \
+            -maxdepth 1 \
+            -type f \
+            -name '*.docx' \
+            | sort \
+            | head -n1)
+
+          if [ -z "${pdf_source}" ] || [ -z "${docx_source}" ]; then
+            echo "Downloaded resume PDF or DOCX artifact was not found." >&2
+            exit 1
+          fi
+
+          version_dir="public/docs/resume/${version}"
+          mkdir -p "${version_dir}"
+          cp "${pdf_source}" "${version_dir}/resume.pdf"
+          cp "${docx_source}" "${version_dir}/resume.docx"
+          cp "${pdf_source}" public/resume.pdf
+          cp "${docx_source}" public/resume.docx
+
+          cmp -s "${version_dir}/resume.pdf" public/resume.pdf
+          cmp -s "${version_dir}/resume.docx" public/resume.docx
+
+          pdf_sha=$(sha256sum public/resume.pdf | awk '{print $1}')
+          docx_sha=$(sha256sum public/resume.docx | awk '{print $1}')
+          changed="false"
+          if ! git diff --quiet -- public/resume.pdf public/resume.docx "${version_dir}"; then
+            changed="true"
+          fi
+
+          {
+            echo "version_dir=${version_dir}"
+            echo "pdf_sha=${pdf_sha}"
+            echo "docx_sha=${docx_sha}"
+            echo "changed=${changed}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Commit and push generated artifacts
+        id: commit
+        if: steps.publish.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          version="${{ needs.build-artifacts.outputs.version }}"
+          version_dir="public/docs/resume/${version}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            public/resume.pdf \
+            public/resume.docx \
+            "${version_dir}/resume.pdf" \
+            "${version_dir}/resume.docx"
+
+          staged_files=$(git diff --cached --name-only)
+          allowed='^public/(docs/resume/[0-9]{4}-[0-9]{2}/resume\.(pdf|docx)|resume\.(pdf|docx))$'
+          unexpected=$(printf '%s\n' "${staged_files}" \
+            | awk -v allowed="${allowed}" 'NF && $0 !~ allowed')
+          if [ -n "${unexpected}" ]; then
+            echo "Refusing to commit unexpected files:" >&2
+            printf '%s\n' "${unexpected}" >&2
+            exit 1
+          fi
+
+          git commit -m "📄 : – refresh generated resume artifacts" \
+            -m "- Refresh PDF and DOCX outputs for ${version}." \
+            -m "- Preserve versioned public paths and stable aliases."
+
+          git pull --rebase origin main
+          if ! git push origin HEAD:main; then
+            echo "Unable to push generated resume artifacts to main." >&2
+            echo "If branch protection blocks GitHub Actions pushes, update the" >&2
+            echo "documented persistence strategy or allow this workflow to push." >&2
+            exit 1
+          fi
+
+          echo "sha=$(git rev-parse HEAD)" >>"${GITHUB_OUTPUT}"
+
+      - name: Summarize resume publication
+        run: |
+          set -euo pipefail
+          commit_sha="${{ steps.commit.outputs.sha }}"
+          if [ -z "${commit_sha}" ]; then
+            commit_sha="not created"
+          fi
+
+          {
+            echo "## Resume publication"
+            echo ""
+            echo "- Selected TeX source: \`${{ needs.build-artifacts.outputs.tex }}\`"
+            echo "- Selected version: \`${{ needs.build-artifacts.outputs.version }}\`"
+            echo "- PDF page count: see build summary"
+            echo "- Output paths:"
+            echo "  - \`${{ steps.publish.outputs.version_dir }}/resume.pdf\`"
+            echo "  - \`${{ steps.publish.outputs.version_dir }}/resume.docx\`"
+            echo "  - \`public/resume.pdf\`"
+            echo "  - \`public/resume.docx\`"
+            echo "- SHA-256 checksums:"
+            echo "  - PDF: \`${{ steps.publish.outputs.pdf_sha }}\`"
+            echo "  - DOCX: \`${{ steps.publish.outputs.docx_sha }}\`"
+            echo "- Repository files changed: \`${{ steps.publish.outputs.changed }}\`"
+            echo "- Generated commit SHA: \`${commit_sha}\`"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/docs/resume/README.md
+++ b/docs/resume/README.md
@@ -1,6 +1,22 @@
 # Résumé build notes
 
-- The LaTeX source (`.tex`) is the source of truth. Commit updates to the appropriate dated directory.
-- Build locally with [`latexmk`](https://ctan.org/pkg/latexmk) or [`pandoc`](https://pandoc.org/) if you need quick PDF or DOCX outputs.
-- Continuous Integration automatically builds both `.pdf` and `.docx` artifacts on every push that touches `docs/resume/**`.
-- The automated test suite compiles the latest dated résumé with [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux binaries if they are not already on your `PATH` (other platforms should install the tools manually).
+- The LaTeX source (`.tex`) is the source of truth. Commit updates to the appropriate dated
+  directory.
+- Build locally with [`latexmk`](https://ctan.org/pkg/latexmk) or
+  [`pandoc`](https://pandoc.org/) if you need quick PDF or DOCX outputs.
+- Continuous Integration automatically builds both `.pdf` and `.docx` artifacts on every pull
+  request or push that touches `docs/resume/**` or the résumé workflow.
+- The workflow selects the lexicographically latest `YYYY-MM` directory under `docs/resume/` as the
+  active source and builds into a temporary directory so generated files are not written beside the
+  source.
+- On pushes to `main`, the workflow publishes generated résumé artifacts to versioned public paths
+  (`public/docs/resume/<version>/resume.pdf` and `.docx`) plus stable aliases (`public/resume.pdf`
+  and `public/resume.docx`) when outputs change.
+- Generated binary artifacts under `public/` are committed by the GitHub Actions bot only after a
+  successful `main` build; do not manually create or commit résumé PDFs or DOCX files from
+  Codex-authored changes.
+- The automated test suite compiles the latest dated résumé with
+  [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to
+  ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux
+  binaries if they are not already on your `PATH` (other platforms should install the tools
+  manually).


### PR DESCRIPTION
### Motivation
- Keep CI-built résumé artifacts downloadable from GitHub Actions while also persisting generated PDF/DOCX into versioned public paths and stable aliases after successful `main` builds.
- Avoid writing generated binaries beside LaTeX sources under `docs/resume/` and prevent recursive workflow triggers or accidental commits from PRs/forks.

### Description
- Build the lexicographically latest `YYYY-MM` source from `docs/resume/` into a temporary directory and generate both PDF and DOCX with `latexmk` and `pandoc`, then upload them as Actions artifacts named with the version.
- Add a `publish-artifacts` job that runs only on successful `push` to `main`, uses least-privilege `contents: write`, downloads the build artifacts, copies them to `public/docs/resume/<version>/resume.pdf|.docx` and `public/resume.pdf|.docx`, and preserves older versioned outputs.
- Commit only changed generated files using the GitHub Actions bot identity with a subject of `📄 : – refresh generated resume artifacts`, run a safe `git pull --rebase` before push, and emit a clear error if branch protection prevents pushing.
- Add guards to avoid loops and PR/fork writes by restricting the publish job with `if:` checks and by validating staged files against an allowlist for `public/docs/resume/<YYYY-MM>/resume.(pdf|docx)` and `public/resume.(pdf|docx)`, and document the behavior in `docs/resume/README.md`.

### Testing
- Ran formatting and static checks with `npx prettier --check .github/workflows/resume.yml` and `git diff --check`, which passed with the workflow file formatted and no diff errors.
- Validated latest-source selection and local build by running the same shell logic to pick `docs/resume/2026-06`, then executed `latexmk` and `pandoc` into a temp dir producing a PDF and DOCX and confirmed `pdfinfo` reported `Pages: 1` and that both files produced SHA-256 checksums.
- Exercised repository checks: `npm run format:write`, `npm run lint`, `npm run test:ci` (Vitest: all tests passed), `npm run docs:check` (passed with external fetch warnings), `npm run smoke` (passed), and `git diff --cached | ./scripts/scan-secrets.py` (no secrets found).
- Note: `actionlint` was not installed in this environment and push-only publish/branch-protection behaviors require running the workflow on GitHub (these runtime push paths were guarded and cannot be fully exercised inside the Codex environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35cc3d6790832f87f98f43dcd0b2ad)