### PR TITLE
📄 : – refresh generated resume artifacts workflow

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -13,10 +13,22 @@ on:
       - '.github/workflows/resume.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-artifacts:
     name: Build resume artifacts
     runs-on: ubuntu-latest
+    outputs:
+      base: ${{ steps.resume.outputs.base }}
+      docx_artifact: ${{ steps.resume.outputs.docx_artifact }}
+      docx_sha256: ${{ steps.checksums.outputs.docx_sha256 }}
+      pdf_artifact: ${{ steps.resume.outputs.pdf_artifact }}
+      pdf_pages: ${{ steps.pdfinfo.outputs.pages }}
+      pdf_sha256: ${{ steps.checksums.outputs.pdf_sha256 }}
+      tex: ${{ steps.resume.outputs.tex }}
+      version: ${{ steps.resume.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,15 +36,28 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y texlive-full latexmk pandoc
+          sudo apt-get install -y texlive-full latexmk pandoc poppler-utils
 
       - name: Determine latest resume source
         id: resume
         run: |
           set -euo pipefail
-          latest_dir=$(find docs/resume -regextype posix-extended -maxdepth 1 -mindepth 1 -type d -regex '.*/[0-9]{4}-[0-9]{2}$' | sort | tail -n1)
+          latest_dir=$(find docs/resume \
+            -regextype posix-extended \
+            -maxdepth 1 \
+            -mindepth 1 \
+            -type d \
+            -regex '.*/[0-9]{4}-[0-9]{2}$' \
+            | sort \
+            | tail -n1)
           if [ -z "${latest_dir}" ]; then
             echo "No dated resume directories found." >&2
+            exit 1
+          fi
+
+          version=$(basename "${latest_dir}")
+          if ! [[ "${version}" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+            echo "Selected resume version must match YYYY-MM: ${version}" >&2
             exit 1
           fi
 
@@ -43,32 +68,213 @@ jobs:
           fi
 
           base_name=$(basename "${tex_file}" .tex)
-          resume_dir=$(dirname "${tex_file}")
+          pdf_artifact="${base_name}-${version}-pdf"
+          docx_artifact="${base_name}-${version}-docx"
 
           {
-            echo "dir=${resume_dir}"
+            echo "dir=${latest_dir}"
             echo "tex=${tex_file}"
             echo "base=${base_name}"
+            echo "version=${version}"
+            echo "pdf_artifact=${pdf_artifact}"
+            echo "docx_artifact=${docx_artifact}"
           } >>"${GITHUB_OUTPUT}"
 
-      - name: Generate PDF with latexmk
+      - name: Generate artifacts in temporary directory
         run: |
           set -euo pipefail
-          latexmk -pdf -interaction=nonstopmode -outdir="${{ steps.resume.outputs.dir }}" "${{ steps.resume.outputs.tex }}"
+          build_dir="${RUNNER_TEMP}/resume-artifacts"
+          mkdir -p "${build_dir}"
+          latexmk \
+            -pdf \
+            -interaction=nonstopmode \
+            -outdir="${build_dir}" \
+            "${{ steps.resume.outputs.tex }}"
+          pandoc \
+            "${{ steps.resume.outputs.tex }}" \
+            -o "${build_dir}/${{ steps.resume.outputs.base }}.docx"
+          if [ "${{ steps.resume.outputs.base }}" != "resume" ]; then
+            cp \
+              "${build_dir}/${{ steps.resume.outputs.base }}.pdf" \
+              "${build_dir}/resume.pdf"
+            cp \
+              "${build_dir}/${{ steps.resume.outputs.base }}.docx" \
+              "${build_dir}/resume.docx"
+          fi
 
-      - name: Generate DOCX with pandoc
+      - name: Inspect generated PDF
+        id: pdfinfo
         run: |
           set -euo pipefail
-          pandoc "${{ steps.resume.outputs.tex }}" -o "${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.docx"
+          pages=$(pdfinfo "${RUNNER_TEMP}/resume-artifacts/resume.pdf" | awk '/^Pages:/ {print $2}')
+          if [ -z "${pages}" ]; then
+            echo "Unable to determine PDF page count." >&2
+            exit 1
+          fi
+          if [ "${pages}" != "1" ]; then
+            echo "Expected generated resume PDF to be exactly one page; got ${pages}." >&2
+            exit 1
+          fi
+          echo "pages=${pages}" >>"${GITHUB_OUTPUT}"
+
+      - name: Calculate checksums
+        id: checksums
+        run: |
+          set -euo pipefail
+          cd "${RUNNER_TEMP}/resume-artifacts"
+          pdf_sha256=$(sha256sum resume.pdf | awk '{print $1}')
+          docx_sha256=$(sha256sum resume.docx | awk '{print $1}')
+          {
+            echo "pdf_sha256=${pdf_sha256}"
+            echo "docx_sha256=${docx_sha256}"
+          } >>"${GITHUB_OUTPUT}"
 
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.resume.outputs.base }}.pdf
-          path: ${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.pdf
+          name: ${{ steps.resume.outputs.pdf_artifact }}
+          path: ${{ runner.temp }}/resume-artifacts/resume.pdf
+          if-no-files-found: error
 
       - name: Upload DOCX artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.resume.outputs.base }}.docx
-          path: ${{ steps.resume.outputs.dir }}/${{ steps.resume.outputs.base }}.docx
+          name: ${{ steps.resume.outputs.docx_artifact }}
+          path: ${{ runner.temp }}/resume-artifacts/resume.docx
+          if-no-files-found: error
+
+      - name: Report build summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Resume artifacts"
+            echo "- Selected TeX source: \`${{ steps.resume.outputs.tex }}\`"
+            echo "- Selected version: \`${{ steps.resume.outputs.version }}\`"
+            echo "- PDF page count: \`${{ steps.pdfinfo.outputs.pages }}\`"
+            echo "- Artifact output paths:"
+            echo "  - \`${{ runner.temp }}/resume-artifacts/resume.pdf\`"
+            echo "  - \`${{ runner.temp }}/resume-artifacts/resume.docx\`"
+            echo "- SHA-256 checksums:"
+            echo "  - PDF: \`${{ steps.checksums.outputs.pdf_sha256 }}\`"
+            echo "  - DOCX: \`${{ steps.checksums.outputs.docx_sha256 }}\`"
+            echo "- Repository files changed: not checked in build job"
+            echo "- Generated commit SHA: not published from build job"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+  publish-artifacts:
+    name: Publish generated resume artifacts
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Validate selected version
+        run: |
+          set -euo pipefail
+          version="${{ needs.build-artifacts.outputs.version }}"
+          if ! [[ "${version}" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+            echo "Selected resume version must match YYYY-MM: ${version}" >&2
+            exit 1
+          fi
+
+      - name: Download PDF artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-artifacts.outputs.pdf_artifact }}
+          path: ${{ runner.temp }}/resume-pdf
+
+      - name: Download DOCX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-artifacts.outputs.docx_artifact }}
+          path: ${{ runner.temp }}/resume-docx
+
+      - name: Copy artifacts into public paths
+        run: |
+          set -euo pipefail
+          version="${{ needs.build-artifacts.outputs.version }}"
+          version_dir="public/docs/resume/${version}"
+          mkdir -p "${version_dir}"
+          cp "${RUNNER_TEMP}/resume-pdf/resume.pdf" "${version_dir}/resume.pdf"
+          cp "${RUNNER_TEMP}/resume-docx/resume.docx" "${version_dir}/resume.docx"
+          cp "${RUNNER_TEMP}/resume-pdf/resume.pdf" public/resume.pdf
+          cp "${RUNNER_TEMP}/resume-docx/resume.docx" public/resume.docx
+          cmp --silent public/resume.pdf "${version_dir}/resume.pdf"
+          cmp --silent public/resume.docx "${version_dir}/resume.docx"
+
+      - name: Commit and push changed artifacts
+        id: publish
+        run: |
+          set -euo pipefail
+          version="${{ needs.build-artifacts.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          changed_paths=$(git status --porcelain -- \
+            "public/docs/resume/${version}/resume.pdf" \
+            "public/docs/resume/${version}/resume.docx" \
+            public/resume.pdf \
+            public/resume.docx \
+            | awk '{print $2}')
+
+          if [ -z "${changed_paths}" ]; then
+            {
+              echo "changed=false"
+              echo "commit_sha="
+            } >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          unexpected_paths=$(git status --porcelain \
+            | awk '{print $2}' \
+            | grep -Ev \
+              '^(public/docs/resume/[0-9]{4}-[0-9]{2}/resume\.(pdf|docx)|public/resume\.(pdf|docx))$' \
+            || true)
+          if [ -n "${unexpected_paths}" ]; then
+            echo "Unexpected modified paths before publishing:" >&2
+            echo "${unexpected_paths}" >&2
+            exit 1
+          fi
+
+          git add ${changed_paths}
+          git commit -m "📄 : – refresh generated resume artifacts" \
+            -m "- Publish generated resume PDF/DOCX assets." \
+            -m "- Refresh versioned paths and stable aliases."
+          git pull --rebase --autostash origin main
+          if ! git push origin HEAD:main; then
+            echo "Unable to push generated resume artifacts to main." >&2
+            echo "Check branch protection allows github-actions[bot] to push this generated commit." >&2
+            exit 1
+          fi
+
+          {
+            echo "changed=true"
+            echo "commit_sha=$(git rev-parse HEAD)"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Report publish summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Resume publish"
+            echo "- Selected TeX source: \`${{ needs.build-artifacts.outputs.tex }}\`"
+            echo "- Selected version: \`${{ needs.build-artifacts.outputs.version }}\`"
+            echo "- PDF page count: \`${{ needs.build-artifacts.outputs.pdf_pages }}\`"
+            echo "- Repository output paths:"
+            echo "  - \`public/docs/resume/${{ needs.build-artifacts.outputs.version }}/resume.pdf\`"
+            echo "  - \`public/docs/resume/${{ needs.build-artifacts.outputs.version }}/resume.docx\`"
+            echo "  - \`public/resume.pdf\`"
+            echo "  - \`public/resume.docx\`"
+            echo "- SHA-256 checksums:"
+            echo "  - PDF: \`${{ needs.build-artifacts.outputs.pdf_sha256 }}\`"
+            echo "  - DOCX: \`${{ needs.build-artifacts.outputs.docx_sha256 }}\`"
+            echo "- Repository files changed: \`${{ steps.publish.outputs.changed }}\`"
+            echo "- Generated commit SHA: \`${{ steps.publish.outputs.commit_sha || 'none' }}\`"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/docs/resume/README.md
+++ b/docs/resume/README.md
@@ -1,6 +1,19 @@
 # Résumé build notes
 
-- The LaTeX source (`.tex`) is the source of truth. Commit updates to the appropriate dated directory.
-- Build locally with [`latexmk`](https://ctan.org/pkg/latexmk) or [`pandoc`](https://pandoc.org/) if you need quick PDF or DOCX outputs.
-- Continuous Integration automatically builds both `.pdf` and `.docx` artifacts on every push that touches `docs/resume/**`.
-- The automated test suite compiles the latest dated résumé with [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux binaries if they are not already on your `PATH` (other platforms should install the tools manually).
+- The LaTeX source (`.tex`) is the source of truth. Commit updates to the appropriate dated
+  directory.
+- Build locally with [`latexmk`](https://ctan.org/pkg/latexmk) or
+  [`pandoc`](https://pandoc.org/) if you need quick PDF or DOCX outputs.
+- Continuous Integration automatically builds both `.pdf` and `.docx` artifacts on pull requests
+  and pushes that touch `docs/resume/**` or the resume workflow. Pushes to `main` publish generated
+  outputs to `public/docs/resume/<version>/` and refresh the stable `public/resume.*` aliases; the
+  workflow preserves older versioned artifacts and does not write generated binaries back into
+  `docs/resume/`.
+- Vite copies files in `public/` to the production build root, so the published `public/resume.*`
+  aliases are served as `/resume.*` and versioned copies are served from
+  `/docs/resume/<version>/resume.*`.
+- The automated test suite compiles the latest dated résumé with
+  [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to
+  ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux
+  binaries if they are not already on your `PATH` (other platforms should install the tools
+  manually).


### PR DESCRIPTION
### Motivation
- Make CI produce downloadable PDF and DOCX artifacts for résumé PRs and pushes while persisting versioned public copies and stable aliases after main merges.
- Keep generated binaries out of the dated `docs/resume/*` source directories and ensure builds run in a temporary directory.
- Use least-privilege permissions by default and allow write access only in the publish job that runs on pushes to `main`.

### Description
- Reworked `.github/workflows/resume.yml` to build the lexicographically-latest `docs/resume/YYYY-MM` TeX source in a runner temp directory and generate both `resume.pdf` and `resume.docx` without writing into `docs/resume/`.
- Uploads versioned artifacts named with the selected source version (for example `resume-2026-06-pdf` / `-docx`) on PRs, pushes, and manual runs, and emits a build summary with source, version, page count, output paths, and SHA-256 checksums.
- Adds a push-to-`main` only `publish-artifacts` job (scoped `contents: write`) that downloads the build artifacts, copies them to `public/docs/resume/<version>/resume.{pdf,docx}` and stable aliases `public/resume.{pdf,docx}`, validates paths and byte-identity, and pushes changes as the GitHub Actions bot only when a diff exists and branch-protection allows it.
- Updated `docs/resume/README.md` to document the new publish behavior and note that Vite serves files from `public/` at the site root (so `public/resume.*` is served as `/resume.*`).

### Testing
- Ran `npx prettier --check .github/workflows/resume.yml` which passed. 
- Verified latest-source selection locally selected `docs/resume/2026-06` and validated the version matches `YYYY-MM` via the workflow logic. 
- Built artifacts locally with the same toolchain used in CI using `latexmk -pdf -interaction=nonstopmode -outdir="$tmp" docs/resume/2026-06/resume.tex` and `pandoc docs/resume/2026-06/resume.tex -o "$tmp/resume.docx"`, and `pdfinfo` reported `Pages: 1`. 
- Ran repo checks `npm run format:write`, `npm run lint`, `npm run test:ci`, `npm run docs:check` (docs/link checks emitted external fetch warnings), and `npm run smoke`, and those automated checks completed successfully in this environment. 
- `actionlint` was not available in the environment so `actionlint .github/workflows/resume.yml` was not executed here. 
- The push-only publish behavior (actual push to `main` and branch-protection interactions) cannot be fully exercised inside this Codex environment, so the workflow includes an explicit failure message if a push is blocked by branch-protection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35cc530e50832f9368bc9790f9ee04)