### PR TITLE
Add v0.1.0 launch plan and require baseline observability

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,291 @@
+# danielsmith.io v0.1.0 launch plan
+
+This is the release checklist for promoting `danielsmith.io` v0.1.0 from a prototype/static
+site candidate to the first public production launch on Sugarkube. It is intentionally a
+planning document: do not implement the launch page, metrics stack, dashboards, alerts,
+deployment changes, version bumps, or tags as part of this plan-only work.
+
+## Source evidence and current behavior
+
+- [ ] Confirm this repository is the production artifact source, not the legacy placeholder page.
+- [ ] Confirm a successful `main` image workflow published the immutable tag selected for launch:
+      `ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA`.
+- [ ] Confirm the Helm chart is available as `oci://ghcr.io/futuroptimist/charts/danielsmith`.
+- [ ] Confirm nginx serves the static Vite app on port `8080` with SPA fallback and the current
+      `/livez` and `/healthz` JSON endpoints.
+- [ ] Confirm the chart deploys the static nginx container, readiness/liveness probes, resource
+      requests/limits, and immutable image override support.
+- [ ] Confirm `/runtime/github-metrics.json`, if enabled, is portfolio metadata only. It must not
+      be used as a health, latency, success-rate, or uptime signal.
+- [ ] Confirm the root `/resume.pdf` contract is implemented before treating the resume probe as
+      release-blocking. Any dated resume artifact path remains interim evidence only.
+
+Reference material for this plan:
+
+- [`docs/roadmap.md`](../roadmap.md)
+- [`docs/ops/sugarkube-release.md`](../ops/sugarkube-release.md)
+- [`docs/k3s-sugarkube-staging.md`](../k3s-sugarkube-staging.md)
+- [`docs/k3s-sugarkube-prod.md`](../k3s-sugarkube-prod.md)
+- [`charts/danielsmith/`](../../charts/danielsmith/)
+- [`docker/nginx/default.conf`](../../docker/nginx/default.conf)
+- [`docs/architecture/performance-budgets.md`](../architecture/performance-budgets.md)
+- [`docs/architecture/scene-stack.md`](../architecture/scene-stack.md)
+- [Sugarkube observability design](https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-design.md)
+
+## Launch surface requirements
+
+All launch-surface items are release gates and start unchecked until the repository and deployed
+staging evidence prove them.
+
+- [ ] `https://danielsmith.io/` serves this repository's application, not a legacy placeholder.
+- [ ] A simple, accessible landing or text surface exposes clear links to:
+  - [ ] the resume
+  - [ ] GitHub
+  - [ ] LinkedIn
+  - [ ] email
+  - [ ] DSPACE
+  - [ ] token.place
+- [ ] The resume link uses the stable `/resume.pdf` path rather than a dated runtime URL.
+- [ ] The immersive experience provides a usable route to the same links.
+- [ ] The text fallback provides a usable route to the same links.
+- [ ] Keyboard navigation reaches every required launch link without pointer input.
+- [ ] Visible focus indicators remain clear against the landing, HUD, overlays, and text fallback.
+- [ ] Screen-reader labels identify the required links and any launch controls unambiguously.
+- [ ] Reduced-motion behavior avoids mandatory animation and does not hide required links.
+- [ ] Text fallback remains available through explicit `?mode=text` and automatic failover paths.
+- [ ] Staging is validated before promoting the exact same immutable image tag to production.
+
+## Required v0.1.0 observability slice
+
+Baseline observability should stay small because this is a static nginx application. It must prove
+public reachability, Kubernetes rollout health, basic resource saturation, and the deployed release
+identity without adding hidden analytics or a new app metrics stack.
+
+### Public blackbox probes
+
+Create Sugarkube-owned blackbox probes for staging and production:
+
+- [ ] `https://staging.danielsmith.io/`
+- [ ] `https://staging.danielsmith.io/livez`
+- [ ] `https://staging.danielsmith.io/healthz`
+- [ ] `https://staging.danielsmith.io/resume.pdf`
+- [ ] `https://danielsmith.io/`
+- [ ] `https://danielsmith.io/livez`
+- [ ] `https://danielsmith.io/healthz`
+- [ ] `https://danielsmith.io/resume.pdf`
+
+Release-blocking `/resume.pdf` probing starts only after staging proves the stable root path is
+served or redirected correctly.
+
+### Signals required before production promotion
+
+- [ ] Public endpoint success rate from blackbox `probe_success`.
+- [ ] Public latency from blackbox `probe_duration_seconds`.
+- [ ] TLS certificate expiry from `probe_ssl_earliest_cert_expiry`.
+- [ ] Kubernetes deployment readiness from kube-state-metrics.
+- [ ] Pod restart count from kube-state-metrics.
+- [ ] CPU saturation from container/node metrics.
+- [ ] Memory saturation from container/node metrics.
+- [ ] Current immutable image/release identity from Kubernetes labels, image tag, or equivalent
+      low-cardinality release metadata.
+- [ ] Prometheus scrape health for required Kubernetes/blackbox targets.
+- [ ] Blackbox target health for every staging and production URL above.
+
+### Provisional thresholds
+
+Use conservative provisional thresholds until staging provides real measurements:
+
+| Signal                  | Provisional threshold            | Window              | Notes                                                         |
+| ----------------------- | -------------------------------- | ------------------- | ------------------------------------------------------------- |
+| Public endpoint success | `probe_success == 0`             | 5m staging, 3m prod | Separate app failure from DNS, Cloudflare, or tunnel failure. |
+| Public latency          | static route p95 > 2s            | 15m                 | Tune after staging baseline.                                  |
+| TLS expiry              | warning < 14d, critical < 3d     | 1h                  | Platform/networking fix, not app rollback by default.         |
+| Deployment readiness    | available replicas below desired | 10m                 | Roll back only if release-related.                            |
+| Pod restarts            | > 3 restarts                     | 15m                 | Inspect events/logs before rollback.                          |
+| CPU saturation          | > 80% of limit or node pressure  | 15m                 | Static nginx should be low-use; validate on Pi hardware.      |
+| Memory saturation       | > 80% of limit or node pressure  | 15m                 | Check container and node memory together.                     |
+| Scrape/blackbox health  | required target down             | 10m                 | Warn first if public probes remain healthy.                   |
+
+## Dashboard requirement
+
+Create a dedicated `danielsmith.io` dashboard in Sugarkube/Grafana before production promotion.
+It should have staging/production variables or side-by-side rows and include:
+
+- [ ] Public endpoint status for `/`, `/livez`, `/healthz`, and `/resume.pdf`.
+- [ ] Latency history for each public probe.
+- [ ] TLS certificate expiry.
+- [ ] Pod readiness and restart history.
+- [ ] CPU and memory resource usage.
+- [ ] Staging versus production comparison.
+- [ ] Deployed immutable tag or release identity.
+- [ ] Prometheus scrape health and blackbox target health.
+- [ ] A separate, clearly labeled GitHub portfolio metadata panel if
+      `/runtime/github-metrics.json` is retained. The panel label must state that repository stars,
+      forks, and cache freshness are portfolio content, not operational health.
+
+## Alert requirement
+
+Enable only alerts with an immediate response path. Use provisional thresholds until staging data
+establishes baseline behavior.
+
+- [ ] Production root unavailable: `https://danielsmith.io/` blackbox probe fails for 3m.
+- [ ] Health endpoint unavailable: production `/healthz` blackbox probe fails for 3m.
+- [ ] Resume PDF unavailable: production `/resume.pdf` blackbox probe fails for 3m after the stable
+      root resume path is verified.
+- [ ] TLS expiry approaching: certificate expires in <14d warning and <3d critical.
+- [ ] Repeated pod restart: production pod restarts increase by >3 in 15m or enters CrashLoopBackOff.
+- [ ] Deployment unavailable after rollout: available replicas below desired for 10m.
+
+Do not alert on GitHub star counts, GitHub metrics cache content, low traffic, browser-local
+telemetry, or one-off staging probe blips.
+
+## Privacy boundaries
+
+- [ ] Existing browser performance and failover events may inform a future privacy-reviewed
+      telemetry design, but they are not a v0.1.0 production-promotion dependency.
+- [ ] v0.1.0 must not add a public analytics collector as a hidden requirement.
+- [ ] No IP address, browser fingerprint, precise device identity, navigation history, request ID,
+      session ID, or visitor identifier may enter Prometheus labels.
+- [ ] Client-side performance collection remains local by default unless a later design defines
+      aggregation, consent, retention, deletion behavior, access controls, and label cardinality.
+- [ ] Metrics labels must remain bounded to route groups, status classes, app/environment/cluster,
+      namespace, and immutable release identity.
+
+## Promotion evidence checklist
+
+Capture links, command output, screenshots, or pasted summaries in the release issue/PR before
+checking off these items.
+
+### Staging deployment
+
+- [ ] Record selected immutable tag: `main-REPLACE_SHORTSHA`.
+- [ ] Deploy staging from the Sugarkube repo:
+
+  ```bash
+  just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] If wrappers are unavailable, use the documented Helm OCI staging fallback in
+      [`docs/ops/sugarkube-release.md`](../ops/sugarkube-release.md).
+- [ ] Record successful rollout:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Verify the running staging image is the selected immutable tag:
+
+  ```bash
+  kubectl -n danielsmith get deploy/danielsmith -o jsonpath='{.spec.template.spec.containers[?(@.name=="danielsmith")].image}'
+  ```
+
+### Staging checks
+
+- [ ] Root check passes:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/
+  ```
+
+- [ ] Liveness check passes:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/livez
+  ```
+
+- [ ] Readiness/health check passes:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/healthz
+  ```
+
+- [ ] Stable resume check passes:
+
+  ```bash
+  curl -fsSI https://staging.danielsmith.io/resume.pdf
+  ```
+
+- [ ] Prometheus target discovery shows the required blackbox targets and Kubernetes metrics.
+- [ ] Dashboard evidence shows staging endpoint status, latency, TLS, pod readiness/restarts,
+      resources, scrape health, and deployed immutable tag.
+- [ ] One controlled alert test reaches the expected receiver and includes a useful runbook link.
+- [ ] Accessibility smoke evidence covers keyboard navigation, visible focus, screen-reader labels,
+      reduced motion, and required launch links.
+- [ ] Text-fallback smoke evidence covers `?mode=text` and the required launch links.
+
+### Production promotion
+
+- [ ] Promote the same immutable image tag from the Sugarkube repo:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] If wrappers are unavailable, use the documented Helm OCI production fallback in
+      [`docs/ops/sugarkube-release.md`](../ops/sugarkube-release.md).
+- [ ] Record successful production rollout:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Verify the running production image is the same immutable tag staged earlier:
+
+  ```bash
+  kubectl -n danielsmith get deploy/danielsmith -o jsonpath='{.spec.template.spec.containers[?(@.name=="danielsmith")].image}'
+  ```
+
+### Post-promotion verification
+
+- [ ] Production root check passes:
+
+  ```bash
+  curl -fsS https://danielsmith.io/
+  ```
+
+- [ ] Production liveness check passes:
+
+  ```bash
+  curl -fsS https://danielsmith.io/livez
+  ```
+
+- [ ] Production readiness/health check passes:
+
+  ```bash
+  curl -fsS https://danielsmith.io/healthz
+  ```
+
+- [ ] Production resume check passes:
+
+  ```bash
+  curl -fsSI https://danielsmith.io/resume.pdf
+  ```
+
+- [ ] Dashboard shows production endpoint success, acceptable latency, TLS expiry, pod readiness,
+      no unexpected restarts, resource headroom, scrape health, blackbox health, and the promoted
+      immutable tag.
+- [ ] Alert state is clean after the controlled alert test is resolved.
+
+### Rollback
+
+- [ ] Record the prior known-good immutable tag before promotion: `main-PREVIOUS_SHORTSHA`.
+- [ ] Roll back by redeploying or promoting the prior immutable image tag:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-PREVIOUS_SHORTSHA
+  ```
+
+- [ ] If wrapper rollback is unavailable, run the documented production Helm OCI upgrade fallback
+      with `default_tag=main-PREVIOUS_SHORTSHA`.
+- [ ] Verify the rollback image tag, root, health, live, resume, dashboard, and alert state using
+      the same post-promotion checks above.
+
+## Explicit post-v0.1.0 candidates
+
+These are intentionally not required for v0.1.0 promotion:
+
+- [ ] Privacy-safe aggregate browser performance telemetry.
+- [ ] nginx request metrics or an exporter.
+- [ ] Richer WebGL/failover dashboards.
+- [ ] Loki or centralized logs.
+- [ ] Distributed tracing.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,12 @@ colliders, scene objects, semantic connections, room-specific cutouts, and
 other generated runtime geometry should be extracted from imperative assembly
 into those files over the migration.
 
+## Release plans
+
+- [v0.1.0 launch plan](releases/v0.1.0.md) — first public production launch checklist requiring
+  the repository-backed production surface, accessibility/text-fallback gates, immutable staging
+  promotion, and a small Sugarkube observability baseline before production promotion.
+
 ## Delivery scoreboard
 
 | Phase | Status         | Demo                | Key metrics                                               |


### PR DESCRIPTION
### Motivation
- Provide a concrete, actionable v0.1.0 release checklist to promote danielsmith.io from prototype to public production with clear release, accessibility, observability, promotion, verification, and rollback gates. 
- Ensure baseline observability and accessibility are treated as production-promotion requirements while keeping this change documentation-only (no code, image, chart, or tag changes). 

### Description
- Added `docs/releases/v0.1.0.md` containing launch-surface gates (stable `/resume.pdf`, links, keyboard/focus/screen-reader/reduced-motion/text-fallback requirements), a minimal Sugarkube observability slice (blackbox probes for `/`, `/livez`, `/healthz`, `/resume.pdf`, public latency/success metrics, TLS expiry, kube deployment readiness, pod restarts, CPU/memory saturation, deployed immutable image identity, and Prometheus/blackbox scrape health), dashboard and alert requirements, privacy boundaries, promotion evidence checklist, and rollback instructions. 
- Updated `docs/roadmap.md` to link the new v0.1.0 release plan from a new Release plans section. 
- Explicitly retained `/runtime/github-metrics.json` as portfolio metadata (not an operational health signal) and referenced the Sugarkube observability design and existing Sugarkube runbooks for implementers. 

### Testing
- Ran formatting and linting: `npm run format:write`, `npm run format:check`, and `npm run lint`, all succeeded. 
- Ran docs validation and link checks: `npm run docs:check` passed (link checker produced external-fetch warnings only). 
- Ran tests: `npm run test:ci` completed successfully (all tests passed: 158 files, 1208 tests). 
- Ran build and smoke: `npm run smoke` succeeded and `git diff --check` plus `./scripts/scan-secrets.py` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35eeb21468832fbdb65dc91c4ab4d2)