### PR TITLE
Add v0.1.0 launch plan and roadmap link

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,365 @@
+# danielsmith.io v0.1.0 launch plan
+
+This is the concrete launch checklist for promoting `danielsmith.io` v0.1.0
+from prototype/placeholder hosting to the static Vite + Three.js application in
+this repository. It is intentionally a release-planning document only: do not
+implement the launch page, metrics stack, dashboards, alerts, deployment
+changes, Git tags, or version bumps as part of this checklist.
+
+## Source evidence reviewed
+
+- [ ] Confirm this plan still matches `docs/roadmap.md`.
+- [ ] Confirm this plan still matches `docs/ops/sugarkube-release.md`.
+- [ ] Confirm this plan still matches `docs/k3s-sugarkube-staging.md` and
+      `docs/k3s-sugarkube-prod.md`.
+- [ ] Confirm this plan still matches `charts/danielsmith/`.
+- [ ] Confirm this plan still matches `docker/nginx/default.conf`.
+- [ ] Confirm this plan still matches the client performance/failover telemetry
+      code and docs.
+- [ ] Confirm this plan still treats `/runtime/github-metrics.json` as portfolio
+      content rather than operational observability.
+- [ ] Confirm this plan still matches the canonical Sugarkube observability
+      design.
+
+## Current behavior verified before planning
+
+As of this planning pass, public `https://danielsmith.io/` returned a legacy
+placeholder page rather than the built application from this repository. Public
+`/healthz` and `/resume.pdf` also returned HTML placeholder content instead of
+this repository's nginx JSON health response or a PDF. Therefore v0.1.0 must
+not assume production is already serving this repository.
+
+Repository evidence says the intended application is a static nginx site on port
+`8080`, with `/livez` and `/healthz` JSON responses from nginx, SPA fallback for
+browser routes, and an optional same-origin GitHub metrics cache at
+`/runtime/github-metrics.json`. The Sugarkube release runbook requires immutable
+`main-<shortsha>` images, staging validation, and promotion of the exact same
+image to production.
+
+## Release scope
+
+### In scope for v0.1.0
+
+- [ ] `https://danielsmith.io/` production serves the application built from
+      this repository rather than the legacy placeholder page.
+- [ ] A simple, accessible landing or text surface exposes clear links to:
+  - [ ] resume
+  - [ ] GitHub
+  - [ ] LinkedIn
+  - [ ] email
+  - [ ] DSPACE
+  - [ ] token.place
+- [ ] The immersive experience provides a usable route to every launch link.
+- [ ] The text fallback provides a usable route to every launch link.
+- [ ] The resume link uses the stable `/resume.pdf` path rather than a dated
+      runtime URL or separate resume host.
+- [ ] Keyboard navigation, visible focus, screen-reader labeling,
+      reduced-motion behavior, and text fallback remain release gates.
+- [ ] Staging is validated before the exact immutable image is promoted to
+      production.
+- [ ] Baseline production-promotion observability is present and backed by real
+      staging evidence.
+
+### Explicitly out of scope for this planning task
+
+- [ ] Do not implement the launch page or link surfaces in this document-only
+      change.
+- [ ] Do not add Prometheus, Grafana, blackbox exporter, dashboards, alerts,
+      exporters, ServiceMonitors, or deployment changes in this document-only
+      change.
+- [ ] Do not create a Git tag.
+- [ ] Do not alter package, chart, or image versions.
+- [ ] Do not treat GitHub stars, forks, workflow status, or browser-local
+      performance events as server health metrics.
+
+## Launch surface requirements
+
+- [ ] Root production (`https://danielsmith.io/`) serves this repository's app.
+- [ ] Root staging (`https://staging.danielsmith.io/`) serves the same build
+      artifact before production promotion.
+- [ ] `/livez` returns a successful lightweight liveness response from the
+      deployed application path.
+- [ ] `/healthz` returns a successful lightweight health response from the
+      deployed application path.
+- [ ] `/resume.pdf` returns a PDF response at the stable root path.
+- [ ] The old resume host or dated asset paths are not required for v0.1.0
+      navigation.
+- [ ] The text fallback is reachable with `?mode=text` and exposes the same core
+      contact/project links.
+- [ ] The immersive route keeps its explicit preview/review override available:
+      `?mode=immersive&disablePerformanceFailover=1`.
+- [ ] Link labels are human-readable and screen-reader friendly; icon-only links
+      have accessible names.
+- [ ] Focus indicators are visible on all launch links and controls.
+- [ ] Keyboard users can reach and activate all launch links without entering
+      the 3D controls trap.
+- [ ] Reduced-motion visitors are not required to use animated navigation to
+      reach resume/contact/project links.
+
+## Required v0.1.0 observability slice
+
+Keep the first production slice small because this is a static nginx
+application. Sugarkube owns the monitoring stack, blackbox exporter, TLS checks,
+cluster metrics, Alertmanager routing, and dashboard deployment. This app
+repository owns the release checklist and the application contract it promotes.
+
+### Public blackbox probes
+
+Configure staging and production blackbox probes for:
+
+- [ ] `/`
+- [ ] `/livez`
+- [ ] `/healthz`
+- [ ] `/resume.pdf`
+
+For each target, record:
+
+- [ ] public endpoint success rate from `probe_success`.
+- [ ] public latency history from `probe_duration_seconds`.
+- [ ] status/content expectation where practical, especially JSON for health
+      endpoints and PDF content type or PDF header for `/resume.pdf`.
+
+### TLS and Kubernetes health
+
+Require dashboard evidence for:
+
+- [ ] TLS certificate expiry.
+- [ ] Kubernetes deployment readiness.
+- [ ] pod restart count.
+- [ ] CPU saturation.
+- [ ] memory saturation.
+- [ ] current immutable image/release identity, preferably the `main-<shortsha>`
+      image tag visible from Kubernetes labels, annotations, deployment spec, or
+      dashboard annotation.
+- [ ] Prometheus scrape health.
+- [ ] blackbox target health.
+
+### Provisional thresholds
+
+Tune these after staging provides real data. Until then, use conservative,
+actionable defaults:
+
+- [ ] Public production endpoint down: `probe_success == 0` for 3 minutes.
+- [ ] Public staging endpoint down: `probe_success == 0` for 5 minutes.
+- [ ] Static public latency warning: p95 probe latency over 2 seconds for
+      15 minutes.
+- [ ] TLS warning: earliest certificate expiry under 14 days.
+- [ ] TLS critical: earliest certificate expiry under 3 days.
+- [ ] Pod restart warning: more than 3 restarts in 15 minutes or
+      `CrashLoopBackOff`.
+- [ ] Deployment unavailable: available replicas below desired replicas for
+      10 minutes after rollout starts.
+- [ ] Prometheus/blackbox scrape warning: required target `up == 0` or blackbox
+      target missing for 10 minutes.
+
+## Dashboard requirement
+
+Create a dedicated `danielsmith.io` dashboard before production promotion. It
+must include staging and production, either via variables or separate rows.
+
+Required panels:
+
+- [ ] Public endpoint status for `/`, `/livez`, `/healthz`, and `/resume.pdf`.
+- [ ] Latency history for the public endpoints.
+- [ ] TLS expiry.
+- [ ] Pod readiness.
+- [ ] Pod restarts.
+- [ ] CPU and memory usage/saturation.
+- [ ] Staging versus production comparison.
+- [ ] Deployed immutable tag/release identity.
+- [ ] Prometheus scrape health and blackbox target health.
+- [ ] If `/runtime/github-metrics.json` is retained, a separate clearly labeled
+      panel named "GitHub portfolio metadata" or equivalent. The panel must say
+      it is portfolio/content metadata, not uptime, health, success rate,
+      latency, or availability.
+
+## Alert requirement
+
+Enable only minimal, actionable alerts with runbook links and tested delivery.
+All alert checklist items begin unchecked until implemented and tested in
+Sugarkube staging.
+
+- [ ] Production root unavailable.
+- [ ] Health endpoint unavailable.
+- [ ] Resume PDF unavailable.
+- [ ] TLS expiry approaching.
+- [ ] Repeated pod restart or crash loop.
+- [ ] Deployment unavailable after rollout.
+
+Do not alert on GitHub stars, forks, profile metadata freshness, browser-local
+FPS, browser-local input latency, or a single transient staging probe.
+
+## Privacy boundaries
+
+- [ ] Existing browser performance and failover events may inform a future
+      privacy-reviewed telemetry design.
+- [ ] v0.1.0 does not add a public analytics collector as a hidden requirement.
+- [ ] No IP address, browser fingerprint, precise device identity, navigation
+      history, visitor identifier, request ID, raw URL, arbitrary error text, or
+      user/session identifier may enter Prometheus labels.
+- [ ] Client-side performance collection remains local by default unless a later
+      design defines aggregation, consent, retention, and deletion behavior.
+- [ ] `/runtime/github-metrics.json` remains portfolio content for public repo
+      metadata; it is not operational service health.
+
+## Promotion evidence checklist
+
+Record links, command output, screenshots, or pasted summaries in the release
+record before checking each item.
+
+### Artifact selection
+
+- [ ] Select a successful `main` image build from GitHub Actions.
+- [ ] Record the immutable image tag: `main-REPLACE_SHORTSHA`.
+- [ ] Confirm the chart reference is available:
+      `oci://ghcr.io/futuroptimist/charts/danielsmith`.
+- [ ] Confirm no local image rebuild is used as a release workaround.
+
+### Staging deployment
+
+- [ ] Deploy staging from the Sugarkube checkout with the immutable image:
+
+  ```bash
+  just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Record rollout status:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Record the deployed image from Kubernetes and confirm it matches the
+      selected immutable tag.
+
+### Staging endpoint checks
+
+- [ ] Root check succeeds:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/
+  ```
+
+- [ ] Liveness check succeeds:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/livez
+  ```
+
+- [ ] Health check succeeds:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/healthz
+  ```
+
+- [ ] Resume check succeeds and verifies the stable path:
+
+  ```bash
+  curl -fsSI https://staging.danielsmith.io/resume.pdf
+  ```
+
+### Staging UX and accessibility evidence
+
+- [ ] Keyboard navigation smoke evidence covers all launch links.
+- [ ] Visible focus evidence covers all launch links.
+- [ ] Screen-reader labeling evidence covers all launch links.
+- [ ] Reduced-motion smoke evidence confirms links remain usable.
+- [ ] Text fallback smoke evidence confirms `?mode=text` exposes all launch
+      links.
+- [ ] Immersive smoke evidence confirms a usable route to all launch links.
+
+### Staging observability evidence
+
+- [ ] Prometheus discovers required blackbox targets for staging.
+- [ ] Blackbox target health is visible for `/`, `/livez`, `/healthz`, and
+      `/resume.pdf`.
+- [ ] Dashboard shows staging endpoint status and latency.
+- [ ] Dashboard shows staging TLS expiry.
+- [ ] Dashboard shows staging pod readiness, restarts, CPU, and memory.
+- [ ] Dashboard shows staging immutable image/release identity.
+- [ ] Run one controlled alert test and record Alertmanager delivery evidence.
+- [ ] Confirm the GitHub portfolio metadata panel, if present, is separate from
+      operational health panels.
+
+### Production promotion
+
+Promote only the exact immutable image that passed staging.
+
+- [ ] Run the production promotion command from the Sugarkube checkout:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Record production rollout status:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Record the deployed production image from Kubernetes and confirm it
+      matches the staging image.
+
+### Post-promotion verification
+
+- [ ] Production root check succeeds and is not the legacy placeholder:
+
+  ```bash
+  curl -fsS https://danielsmith.io/
+  ```
+
+- [ ] Production liveness check succeeds:
+
+  ```bash
+  curl -fsS https://danielsmith.io/livez
+  ```
+
+- [ ] Production health check succeeds:
+
+  ```bash
+  curl -fsS https://danielsmith.io/healthz
+  ```
+
+- [ ] Production resume check succeeds at the stable path:
+
+  ```bash
+  curl -fsSI https://danielsmith.io/resume.pdf
+  ```
+
+- [ ] Prometheus discovers required production blackbox targets.
+- [ ] Dashboard shows production endpoint status, latency, TLS expiry,
+      readiness, restarts, CPU, memory, and immutable image/release identity.
+- [ ] Alerts are enabled only after the controlled alert test has a documented
+      receiver and runbook path.
+
+### Rollback
+
+- [ ] Record the prior known-good immutable image tag before promotion:
+      `main-PRIOR_SHORTSHA`.
+- [ ] Roll back by redeploying/promoting the prior immutable image tag rather
+      than rebuilding locally:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-PRIOR_SHORTSHA
+  ```
+
+- [ ] Verify rollback rollout status:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Repeat root, liveness, health, and resume checks after rollback.
+- [ ] Note that Helm revision rollback remains an additional cluster-side
+      option, but app-level rollback to a known immutable image is preferred.
+
+## Post-v0.1.0 candidates
+
+These are explicitly deferred and should not block v0.1.0 unless a later release
+owner re-scopes the work:
+
+- [ ] Privacy-safe aggregate browser performance telemetry.
+- [ ] nginx request metrics or an exporter.
+- [ ] Richer WebGL/failover dashboards.
+- [ ] Loki or centralized logs.
+- [ ] Distributed tracing.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,12 @@ colliders, scene objects, semantic connections, room-specific cutouts, and
 other generated runtime geometry should be extracted from imperative assembly
 into those files over the migration.
 
+## Release plans
+
+- [v0.1.0 launch plan](releases/v0.1.0.md) – production promotion checklist for
+  replacing the legacy placeholder with this repository, including launch-surface,
+  accessibility, baseline observability, verification, and rollback gates.
+
 ## Delivery scoreboard
 
 | Phase | Status         | Demo                | Key metrics                                               |


### PR DESCRIPTION
### Motivation
- Provide a concrete, actionable v0.1.0 release checklist that captures launch-surface, accessibility gates, baseline observability, promotion evidence, verification, and rollback for promoting the site from a legacy placeholder to the static app in this repo.
- Keep the first observability slice intentionally small for a static nginx application while specifying required blackbox probes, k8s health signals, TLS checks, dashboard panels, and minimal actionable alerts.
- Ensure staging validation and immutable-image promotion are explicit release gates and that portfolio GitHub cache remains treated as content, not operational health.

### Description
- Add a new release checklist at `docs/releases/v0.1.0.md` covering launch surface requirements, accessibility gates (keyboard, visible focus, ARIA, reduced-motion, text fallback), observability slice (blackbox probes for `/`, `/livez`, `/healthz`, `/resume.pdf`, TLS expiry, pod readiness/restarts, CPU/memory saturation, immutable image identity, Prometheus/blackbox health), dashboard panels, alert definitions, privacy boundaries, promotion evidence, verification commands, and rollback steps.
- Insert a short `v0.1.0` entry in `docs/roadmap.md` linking to the new plan so the roadmap indexes the release checklist.
- Explicitly keep implementation out of scope: this is documentation only and does not add dashboards, exporters, alerts, tags, or version bumps; it defers richer telemetry items to post-v0.1.0 candidates.

### Testing
- Ran formatting and style checks: `npm run format:write` (applied), `npm run format:check` (passed). 
- Docs and links: `npm run docs:check` (passed; link checker emitted transient external fetch warnings). 
- Lint: `npm run lint` (passed). 
- Unit tests/CI: `npm run test:ci` (Vitest run completed: 158 test files, 1208 tests passed). 
- Smoke/build: `npm run smoke` (build + distribution assertions passed). 
- Repo checks: `git diff --check` (no issues) and `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).

All automated checks above completed successfully; the docs link checker produced external fetch warnings (network reachability of external URLs) but the `docs:check` step itself passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35eed943dc832fa7496b957bfd62e5)