### PR TITLE
📝 : – Add v0.1.0 launch plan and link from roadmap

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,255 @@
+# danielsmith.io v0.1.0 launch plan
+
+This checklist is the concrete release gate for the first production launch of
+`danielsmith.io` from this repository. It is planning only: do not implement the launch page,
+metrics stack, dashboards, alerts, deployment wiring, tags, package versions, or chart versions as
+part of this plan.
+
+## Current verified baseline
+
+- The app is a static Vite/Three.js site served by nginx on port `8080`.
+- nginx currently exposes `/livez` and `/healthz` as JSON `200` endpoints.
+- nginx serves static files and falls back browser routes to `index.html`.
+- The Helm chart deploys the nginx container with liveness and readiness probes for `/livez` and
+  `/healthz`, using `main-latest` only as a render/lint default and requiring immutable
+  `main-<shortsha>` tags for Sugarkube sign-off.
+- The optional GitHub metrics cache sidecar writes same-origin public portfolio metadata to
+  `/runtime/github-metrics.json`; this is product content, not operational observability.
+- The committed resume PDF is currently under a dated path. The stable `/resume.pdf` path is a
+  v0.1.0 launch requirement and must be implemented before release promotion.
+- Client performance/failover hooks currently emit local browser events and summaries for runtime
+  UX decisions. They are not a public analytics collector and must not be treated as Prometheus
+  service health.
+
+## Release scope
+
+### In scope for v0.1.0
+
+- [ ] Production `https://danielsmith.io/` serves the application from this repository instead of a
+      legacy placeholder page.
+- [ ] Staging deploys the exact immutable image intended for production before any production
+      promotion.
+- [ ] Production promotion uses the same immutable `main-<shortsha>` image validated in staging.
+- [ ] Baseline Sugarkube observability exists and is verified before production promotion.
+- [ ] Accessibility, text fallback, observability, promotion, verification, and rollback evidence
+      are attached to the release record.
+
+### Explicitly out of scope for this documentation task
+
+- [ ] Do not implement or redesign the launch page.
+- [ ] Do not add a Prometheus, Grafana, blackbox exporter, Loki, tracing, nginx exporter, or browser
+      analytics implementation.
+- [ ] Do not change deployment commands, Helm templates, chart versions, package versions, image
+      tags, or Git tags.
+- [ ] Do not treat GitHub stars, forks, workflow status, or browser-local telemetry as operational
+      service health.
+
+## Launch surface requirements
+
+- [ ] The production host serves this repository's static application at `/`.
+- [ ] A simple, accessible landing or text surface exposes clear links to:
+  - [ ] the resume at `/resume.pdf`,
+  - [ ] GitHub,
+  - [ ] LinkedIn,
+  - [ ] email,
+  - [ ] DSPACE,
+  - [ ] token.place.
+- [ ] The immersive experience provides a usable route to the same links.
+- [ ] The text fallback provides a usable route to the same links without requiring WebGL.
+- [ ] The resume link uses stable `/resume.pdf`, not a dated runtime URL.
+- [ ] Keyboard navigation reaches each launch link in a predictable order.
+- [ ] Visible focus is present for every interactive control and link.
+- [ ] Screen-reader labels describe the links and mode/fallback controls.
+- [ ] Reduced-motion preferences are honored for launch-critical surfaces.
+- [ ] Text fallback remains a release gate for low-capability browsers, explicit `?mode=text`,
+      automated-client heuristics, and performance failover.
+
+## Required v0.1.0 observability slice
+
+Keep the first production slice intentionally small for a static nginx application.
+
+### Public blackbox probes
+
+Create staging and production blackbox targets for:
+
+- [ ] `/`
+- [ ] `/livez`
+- [ ] `/healthz`
+- [ ] `/resume.pdf`
+
+The `/resume.pdf` target is release-blocking only after the stable path exists. Until then, dated
+resume paths may provide manual content evidence but must not satisfy the v0.1.0 contract.
+
+### Signals required before production promotion
+
+- [ ] Public endpoint success rate from blackbox `probe_success`.
+- [ ] Public endpoint latency from blackbox `probe_duration_seconds`.
+- [ ] TLS certificate expiry from `probe_ssl_earliest_cert_expiry`.
+- [ ] Kubernetes deployment readiness from kube-state-metrics.
+- [ ] Pod restart count and crash-loop state.
+- [ ] CPU saturation for the nginx pod/container.
+- [ ] Memory saturation for the nginx pod/container.
+- [ ] Current immutable image and release identity from Kubernetes labels, image tag, Helm release,
+      or an equivalent low-cardinality release panel.
+- [ ] Prometheus scrape health for required jobs.
+- [ ] Blackbox target health for each required public target.
+
+### Label and privacy constraints
+
+- [ ] Required labels stay bounded: `app=danielsmith`, `environment`, `cluster`, `namespace`, and
+      release/image identity.
+- [ ] Route labels use fixed route groups such as `/`, `/livez`, `/healthz`, `/resume.pdf`,
+      `static`, or `unknown`; never raw URLs.
+- [ ] Status labels use bounded status classes and optional fixed status codes.
+- [ ] No IP address, browser fingerprint, precise device identity, navigation history, request ID,
+      session ID, visitor identifier, or arbitrary URL enters Prometheus labels.
+- [ ] No browser-local performance event is exported unless a later privacy-reviewed design defines
+      aggregation, consent, retention, access, and deletion behavior.
+
+## Dashboard requirement
+
+Create a `danielsmith.io` dashboard with staging and production selectors or rows. Panels must be
+backed by real Prometheus/Kubernetes/blackbox data before being marked complete.
+
+- [ ] Public endpoint status for `/`, `/livez`, `/healthz`, and `/resume.pdf`.
+- [ ] Latency history for the public targets.
+- [ ] TLS certificate expiry.
+- [ ] Pod readiness and deployment availability.
+- [ ] Pod restart count and crash-loop state.
+- [ ] CPU and memory usage compared with requests/limits.
+- [ ] Staging versus production comparison.
+- [ ] Deployed immutable tag, image digest if available, Helm release, and revision/commit identity.
+- [ ] Prometheus scrape health and blackbox target health.
+- [ ] A separate clearly labeled `GitHub portfolio metadata` panel if the runtime GitHub metrics
+      cache is retained. This panel must be visually separated from service-health rows and labeled
+      as product/content metadata rather than uptime, latency, or error-rate evidence.
+
+## Alert requirement
+
+Use provisional thresholds until staging provides real data. Alerts must include a runbook link and
+an operator action before they page or block promotion.
+
+| Alert                                | Provisional signal and threshold                          | Window | Action                                                                                      |
+| ------------------------------------ | --------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------- |
+| Production root unavailable          | `probe_success{target="/",environment="prod"} == 0`       | 3m     | Separate app, ingress, DNS, and Cloudflare causes; rollback only for app regressions.       |
+| Health endpoint unavailable          | `/healthz` probe fails in production                      | 3m     | Check pod readiness, service, ingress, and latest rollout.                                  |
+| Resume PDF unavailable               | `/resume.pdf` probe fails after stable path ships         | 5m     | Verify static asset path, nginx routing, and release artifact; rollback if release-related. |
+| TLS expiry approaching               | Certificate expiry below 14 days warning, 3 days critical | 1h     | Fix Cloudflare/cert-manager/DNS; do not roll back the app unless app routing changed it.    |
+| Repeated pod restart                 | Restart increase greater than 3 or CrashLoopBackOff       | 15m    | Inspect events/logs and resource limits; rollback if tied to the promoted image.            |
+| Deployment unavailable after rollout | Available replicas below desired                          | 10m    | Inspect image pull, probes, and scheduling; rollback to previous immutable image if needed. |
+
+## Privacy boundaries
+
+- [ ] Existing browser performance and failover events may inform a future privacy-reviewed
+      telemetry design.
+- [ ] v0.1.0 does not add a public analytics collector as an explicit or hidden release
+      requirement.
+- [ ] Prometheus labels never include IP address, browser fingerprint, precise device identity,
+      navigation history, visitor identifier, session ID, request ID, arbitrary URL, user agent, or
+      free-form exception text.
+- [ ] Client-side performance collection remains local by default unless a later design defines
+      aggregation, consent, retention, access, deletion, and user-facing disclosure.
+
+## Promotion evidence checklist
+
+Record the immutable tag, commit SHA, staging evidence, dashboard links or screenshots, alert test,
+production commands, verification outputs, and rollback target in the release issue or notes.
+
+### Artifact selection
+
+- [ ] GitHub Actions image workflow succeeded on `main` for commit: `REPLACE_FULL_SHA`.
+- [ ] Immutable image selected: `ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA`.
+- [ ] Previous known-good immutable image recorded for rollback: `main-REPLACE_PREVIOUS_SHORTSHA`.
+- [ ] Helm chart version intentionally unchanged unless a separate chart-content PR required it.
+
+### Staging deployment and checks
+
+- [ ] Deploy staging from the Sugarkube checkout:
+
+  ```bash
+  just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Confirm Kubernetes rollout:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  kubectl -n danielsmith get deploy,po,svc,ingress
+  ```
+
+- [ ] Run staging curl checks:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/
+  curl -fsS https://staging.danielsmith.io/livez
+  curl -fsS https://staging.danielsmith.io/healthz
+  curl -fsS https://staging.danielsmith.io/resume.pdf
+  ```
+
+- [ ] Verify Prometheus target discovery for the staging blackbox targets.
+- [ ] Verify Prometheus scrape health for kube-state/container signals needed by the dashboard.
+- [ ] Capture dashboard evidence showing staging public probes, TLS, readiness, restarts,
+      resources, and immutable image identity.
+- [ ] Run one controlled alert test in staging, such as a temporary non-production blackbox target
+      failure or Alertmanager test route, and record notification or Prometheus firing evidence.
+- [ ] Run accessibility and text-fallback smoke evidence for staging, including keyboard
+      navigation, visible focus, screen-reader labels, reduced motion, and `?mode=text`.
+
+### Production promotion and verification
+
+- [ ] Promote the exact staging image from the Sugarkube checkout:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Confirm production rollout:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  kubectl -n danielsmith get deploy,po,svc,ingress
+  ```
+
+- [ ] Run production curl checks:
+
+  ```bash
+  curl -fsS https://danielsmith.io/
+  curl -fsS https://danielsmith.io/livez
+  curl -fsS https://danielsmith.io/healthz
+  curl -fsS https://danielsmith.io/resume.pdf
+  ```
+
+- [ ] Verify production blackbox targets are healthy.
+- [ ] Verify production dashboard panels show public status, latency, TLS expiry, readiness,
+      restarts, resources, staging-versus-production context, and deployed immutable tag.
+- [ ] Verify no dashboard row uses GitHub stars/cache or browser-local telemetry as service-health
+      evidence.
+
+### Rollback
+
+- [ ] If production verification fails because of this application release, redeploy or promote the
+      previous known-good immutable image from the Sugarkube checkout:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-REPLACE_PREVIOUS_SHORTSHA
+  ```
+
+- [ ] Confirm rollback rollout and public endpoints:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  curl -fsS https://danielsmith.io/
+  curl -fsS https://danielsmith.io/livez
+  curl -fsS https://danielsmith.io/healthz
+  curl -fsS https://danielsmith.io/resume.pdf
+  ```
+
+- [ ] Record the failed image, rollback image, cause, mitigation, and follow-up issue.
+
+## Post-v0.1.0 candidates
+
+- [ ] Privacy-safe aggregate browser performance telemetry.
+- [ ] nginx request metrics or an nginx exporter.
+- [ ] Richer WebGL/failover dashboards.
+- [ ] Loki or centralized logs.
+- [ ] Distributed tracing.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,13 @@ colliders, scene objects, semantic connections, room-specific cutouts, and
 other generated runtime geometry should be extracted from imperative assembly
 into those files over the migration.
 
+## Release plans
+
+- [v0.1.0 launch plan](releases/v0.1.0.md) — production launch checklist requiring the
+  repository-backed site, accessible launch links, stable `/resume.pdf`, staging-to-production
+  immutable image promotion, baseline blackbox/Kubernetes observability, dashboard evidence,
+  actionable alerts, privacy boundaries, verification, and rollback.
+
 ## Delivery scoreboard
 
 | Phase | Status         | Demo                | Key metrics                                               |


### PR DESCRIPTION
### Motivation

- Provide a concrete, actionable v0.1.0 launch checklist that converts the documented Sugarkube runbooks and observability guidance into a minimal, reviewable release gate for this static nginx-served site. 
- Make baseline observability and accessibility explicit release requirements while preserving strong privacy boundaries appropriate for a static portfolio site.

### Description

- Add `docs/releases/v0.1.0.md` with a step-by-step launch checklist covering launch surface requirements, accessibility gates, required blackbox probes, a bounded Prometheus/Kubernetes observability slice, dashboard panels, alert definitions, privacy constraints, promotion evidence, verification steps, and rollback commands. 
- Link the new v0.1.0 plan from the roadmap by adding a short `Release plans` section entry in `docs/roadmap.md`. 
- Keep the plan intentionally non-implementational and leave every checklist item unchecked so the document is a real, followable release checklist. 

### Testing

- Ran repository quality gates: `npm run format:write` (ok), `npm run format:check` (ok), `npm run docs:check` (ok, link checker emitted remote-reachability warnings but passed), `npm run lint` (ok), `npm run test:ci` (ok — Vitest ran and reported all tests passing: 1208 tests passed), and `npm run smoke` (ok — production build and `scripts/assert-dist.cjs` smoke check passed). 
- Performed secrets scan via `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets. 
- No implementation, Helm, image, or runtime changes were made as part of this PR; the edits are documentation-only and intended to be used as the authoritative v0.1.0 release checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35eee3ce04832fa2d3a26b723aa56e)