### PR TITLE
Fix resume artifact stale publish guard

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -178,11 +178,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          report_blocking_resume_changes() {
+            local base_sha="$1"
+            local current_sha="$2"
+            local blocking_paths
+            blocking_paths="$(git diff --name-only "${base_sha}" "${current_sha}" -- \
+              docs/resume .github/workflows/resume.yml)"
+
+            if [ -n "${blocking_paths}" ]; then
+              echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_sha}. Resume-affecting paths changed:"
+              while IFS= read -r path; do
+                echo "::error::  ${path}"
+              done <<<"${blocking_paths}"
+              return 1
+            fi
+
+            return 0
+          }
+
           git fetch origin main
           current_main="$(git rev-parse origin/main)"
           if [ "${GITHUB_SHA}" != "${current_main}" ]; then
-            echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_main}."
-            exit 1
+            report_blocking_resume_changes "${GITHUB_SHA}" "${current_main}"
+            echo "Main advanced to ${current_main} with only unrelated changes; publishing there."
+            git checkout --detach "${current_main}"
           fi
 
           version="${{ needs.build-artifacts.outputs.version }}"
@@ -227,6 +246,7 @@ jobs:
 
           {
             echo "changed=${changed}"
+            echo "publish_base=$(git rev-parse HEAD)"
             echo "versioned_pdf=${version_dir}/resume.pdf"
             echo "versioned_docx=${version_dir}/resume.docx"
             echo "stable_pdf=public/resume.pdf"
@@ -247,11 +267,32 @@ jobs:
             "${{ steps.persist.outputs.stable_pdf }}" \
             "${{ steps.persist.outputs.stable_docx }}"
           git commit -m "📄 : – refresh generated resume artifacts"
+
+          report_blocking_resume_changes() {
+            local base_sha="$1"
+            local current_sha="$2"
+            local blocking_paths
+            blocking_paths="$(git diff --name-only "${base_sha}" "${current_sha}" -- \
+              docs/resume .github/workflows/resume.yml)"
+
+            if [ -n "${blocking_paths}" ]; then
+              echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_sha}. Resume-affecting paths changed:"
+              while IFS= read -r path; do
+                echo "::error::  ${path}"
+              done <<<"${blocking_paths}"
+              return 1
+            fi
+
+            return 0
+          }
+
+          publish_base="${{ steps.persist.outputs.publish_base }}"
           git fetch origin main
           current_main="$(git rev-parse origin/main)"
-          if [ "${GITHUB_SHA}" != "${current_main}" ]; then
-            echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_main}."
-            exit 1
+          if [ "${publish_base}" != "${current_main}" ]; then
+            report_blocking_resume_changes "${publish_base}" "${current_main}"
+            echo "Main advanced to ${current_main} with only unrelated changes; rebasing."
+            git rebase origin/main
           fi
           if ! git push origin HEAD:main; then
             echo "::error::Unable to push generated resume artifacts to main. If branch protection blocks GitHub Actions pushes, update the documented persistence strategy or allow this workflow to write these generated files."


### PR DESCRIPTION
### Motivation
- The previous publish guard refused to publish if `origin/main` had advanced from the triggering SHA even when changes were unrelated, which blocked valid artifact publications (for example a bot-generated `docs/assets/game-launch.png`).
- The workflow must still refuse to publish artifacts built from an obsolete resume source, so changes to resume sources or the resume workflow must continue to block publishing.

### Description
- Add an in-job shell helper `report_blocking_resume_changes()` that uses `git diff --name-only` to detect resume-affecting changes limited to `docs/resume/**` and `.github/workflows/resume.yml` and prints the blocking paths on error.
- On initial persist, `git fetch origin main` and if `origin/main` advanced run the path-aware check and, if only unrelated paths changed, `git checkout --detach <origin/main>` before copying artifacts and record `publish_base=$(git rev-parse HEAD)` for later comparison.
- Before pushing the generated-artifact commit re-fetch `origin/main`, run the same path-aware check between `publish_base` and current `origin/main`, and if only unrelated changes occurred run `git rebase origin/main` before `git push`; if resume-affecting paths changed, fail with a clear error that lists the blocking files.
- Preserve artifact targets (`public/docs/resume/<version>/resume.pdf|docx` and `public/resume.pdf|docx`), the bot identity, and the commit subject `📄 : – refresh generated resume artifacts`, and follow explicit `git fetch`/`git diff`/`git rebase` steps per guidance.

### Testing
- Ran `npx prettier --check .github/workflows/resume.yml` and `npm run format:check`, which passed.
- Ran `npm run docs:check` (link reachability produced warnings but the docs check passed) and `git diff --check` with no issues.
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py`, which reported no high-risk secrets.
- Simulated the path-aware guard locally in a temporary git repo to verify that an unrelated `docs/assets/game-launch.png` commit does not block publishing while a later `docs/resume/.../resume.tex` change does block publishing, and the simulation passed.
- `actionlint .github/workflows/resume.yml` was not run because `actionlint` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3615396564832fb57e38572cd4e05a)