### PR TITLE
📄 : – relax resume publish stale guard

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -178,11 +178,36 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          blocks_resume_publish() {
+            local base_ref="$1"
+            local head_ref="$2"
+            local changed_paths
+            changed_paths="$(git diff --name-only "${base_ref}" "${head_ref}" -- \
+              docs/resume \
+              .github/workflows/resume.yml)"
+
+            if [ -n "${changed_paths}" ]; then
+              echo "::error::Refusing to publish stale resume artifacts because resume-affecting paths changed between ${base_ref} and ${head_ref}."
+              while IFS= read -r changed_path; do
+                echo "::error::Blocking changed path: ${changed_path}"
+              done <<<"${changed_paths}"
+              return 0
+            fi
+
+            return 1
+          }
+
           git fetch origin main
           current_main="$(git rev-parse origin/main)"
+          publish_base="${GITHUB_SHA}"
           if [ "${GITHUB_SHA}" != "${current_main}" ]; then
-            echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_main}."
-            exit 1
+            if blocks_resume_publish "${GITHUB_SHA}" "${current_main}"; then
+              exit 1
+            fi
+
+            echo "origin/main advanced to ${current_main} with only unrelated changes; publishing on the newer base."
+            publish_base="${current_main}"
+            git checkout --detach "${publish_base}"
           fi
 
           version="${{ needs.build-artifacts.outputs.version }}"
@@ -231,6 +256,7 @@ jobs:
             echo "versioned_docx=${version_dir}/resume.docx"
             echo "stable_pdf=public/resume.pdf"
             echo "stable_docx=public/resume.docx"
+            echo "publish_base=${publish_base}"
           } >>"${GITHUB_OUTPUT}"
 
       - name: Commit and push generated artifacts
@@ -247,11 +273,36 @@ jobs:
             "${{ steps.persist.outputs.stable_pdf }}" \
             "${{ steps.persist.outputs.stable_docx }}"
           git commit -m "📄 : – refresh generated resume artifacts"
+
+          blocks_resume_publish() {
+            local base_ref="$1"
+            local head_ref="$2"
+            local changed_paths
+            changed_paths="$(git diff --name-only "${base_ref}" "${head_ref}" -- \
+              docs/resume \
+              .github/workflows/resume.yml)"
+
+            if [ -n "${changed_paths}" ]; then
+              echo "::error::Refusing to publish stale resume artifacts because resume-affecting paths changed between ${base_ref} and ${head_ref}."
+              while IFS= read -r changed_path; do
+                echo "::error::Blocking changed path: ${changed_path}"
+              done <<<"${changed_paths}"
+              return 0
+            fi
+
+            return 1
+          }
+
           git fetch origin main
           current_main="$(git rev-parse origin/main)"
-          if [ "${GITHUB_SHA}" != "${current_main}" ]; then
-            echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_main}."
-            exit 1
+          publish_base="${{ steps.persist.outputs.publish_base }}"
+          if [ "${publish_base}" != "${current_main}" ]; then
+            if blocks_resume_publish "${publish_base}" "${current_main}"; then
+              exit 1
+            fi
+
+            echo "origin/main advanced to ${current_main} with only unrelated changes; rebasing generated artifacts."
+            git rebase "${current_main}"
           fi
           if ! git push origin HEAD:main; then
             echo "::error::Unable to push generated resume artifacts to main. If branch protection blocks GitHub Actions pushes, update the documented persistence strategy or allow this workflow to write these generated files."


### PR DESCRIPTION
### Motivation

- The previous publish guard refused to publish whenever `origin/main` advanced from the triggering `${GITHUB_SHA}`, which blocked valid publishes when unrelated bot-generated commits landed (for example `docs/assets/game-launch.png`).
- The workflow must still refuse to publish when resume source or the resume workflow change to avoid publishing stale artifacts.

### Description

- Add a small shell helper `blocks_resume_publish(base, head)` in the `publish-artifacts` job that uses `git diff --name-only` to detect changes limited to `docs/resume/**` and `.github/workflows/resume.yml`, and emits clear `::error::` lines listing each blocking path.
- At the start of `Persist generated artifacts` the job now runs `git fetch origin main`, computes `current_main` and when `current_main != ${GITHUB_SHA}` it checks only the blocking paths; if only unrelated paths changed it checks out the newer `origin/main` (`git checkout --detach`) and sets `publish_base` to the commit used for publishing; if blocking paths changed it fails with an explicit error.
- The step writes `publish_base` to the job outputs and the final `Commit and push generated artifacts` step re-fetches `origin/main`, re-checks the blocking paths between `publish_base` and the new `origin/main`, and either fails (if resume-affecting paths changed) or rebases the generated-artifact commit onto `origin/main` before pushing (`git rebase "${current_main}"`).
- Preserve the existing artifact destinations, bot identity (`github-actions[bot]`), commit subject (`📄 : – refresh generated resume artifacts`), and the `github.actor != 'github-actions[bot]'` prevention.

### Testing

- Ran `npx prettier --check .github/workflows/resume.yml` and `npm run format:check`; both passed.
- Ran `npm run docs:check` (link checker reported transient fetch warnings) and `git diff --check`; both completed successfully.
- `actionlint .github/workflows/resume.yml` was not run because `actionlint` is not installed in the environment.
- Simulated the path-aware guard in a temporary git repo to verify that an unrelated `docs/assets/game-launch.png` advance is allowed and that a subsequent change under `docs/resume/**` blocks publishing, and the simulation passed.
- Ran repository checks: `npm run format:write`, `npm run lint`, `npm run test:ci` (Vitest: 1208 tests passed), `npm run smoke` (passed with the existing manual-static-asset warning), and `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a361531d9a8832fb3117ee69fef62f3)