### PR TITLE
Make resume artifact publish path-aware (allow unrelated main advances)

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -178,12 +178,42 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          check_resume_stale_paths() {
+            local base_sha="$1"
+            local head_sha="$2"
+            local context="$3"
+            local blocking_paths
+
+            blocking_paths="$(
+              git diff --name-only "${base_sha}" "${head_sha}" -- \
+                docs/resume \
+                .github/workflows/resume.yml
+            )"
+            if [ -n "${blocking_paths}" ]; then
+              {
+                echo "::error::Refusing to publish stale resume artifacts after ${context}."
+                echo "::error::Resume-affecting paths changed between:"
+                echo "::error::  base: ${base_sha}"
+                echo "::error::  head: ${head_sha}"
+                while IFS= read -r path; do
+                  echo "::error::  - ${path}"
+                done <<<"${blocking_paths}"
+              } >&2
+              exit 1
+            fi
+          }
+
           git fetch origin main
           current_main="$(git rev-parse origin/main)"
           if [ "${GITHUB_SHA}" != "${current_main}" ]; then
-            echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_main}."
-            exit 1
+            check_resume_stale_paths \
+              "${GITHUB_SHA}" \
+              "${current_main}" \
+              "main advanced before artifact persistence"
+            git checkout "${current_main}"
           fi
+          publish_base="${current_main}"
 
           version="${{ needs.build-artifacts.outputs.version }}"
           base="${{ needs.build-artifacts.outputs.base }}"
@@ -231,6 +261,7 @@ jobs:
             echo "versioned_docx=${version_dir}/resume.docx"
             echo "stable_pdf=public/resume.pdf"
             echo "stable_docx=public/resume.docx"
+            echo "publish_base=${publish_base}"
           } >>"${GITHUB_OUTPUT}"
 
       - name: Commit and push generated artifacts
@@ -239,6 +270,32 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          check_resume_stale_paths() {
+            local base_sha="$1"
+            local head_sha="$2"
+            local context="$3"
+            local blocking_paths
+
+            blocking_paths="$(
+              git diff --name-only "${base_sha}" "${head_sha}" -- \
+                docs/resume \
+                .github/workflows/resume.yml
+            )"
+            if [ -n "${blocking_paths}" ]; then
+              {
+                echo "::error::Refusing to publish stale resume artifacts after ${context}."
+                echo "::error::Resume-affecting paths changed between:"
+                echo "::error::  base: ${base_sha}"
+                echo "::error::  head: ${head_sha}"
+                while IFS= read -r path; do
+                  echo "::error::  - ${path}"
+                done <<<"${blocking_paths}"
+              } >&2
+              exit 1
+            fi
+          }
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add \
@@ -249,9 +306,13 @@ jobs:
           git commit -m "📄 : – refresh generated resume artifacts"
           git fetch origin main
           current_main="$(git rev-parse origin/main)"
-          if [ "${GITHUB_SHA}" != "${current_main}" ]; then
-            echo "::error::Refusing to publish stale resume artifacts for ${GITHUB_SHA}; current main is ${current_main}."
-            exit 1
+          publish_base="${{ steps.persist.outputs.publish_base }}"
+          if [ "${publish_base}" != "${current_main}" ]; then
+            check_resume_stale_paths \
+              "${publish_base}" \
+              "${current_main}" \
+              "main advanced before final push"
+            git rebase origin/main
           fi
           if ! git push origin HEAD:main; then
             echo "::error::Unable to push generated resume artifacts to main. If branch protection blocks GitHub Actions pushes, update the documented persistence strategy or allow this workflow to write these generated files."


### PR DESCRIPTION
### Motivation
- The existing publish job refused to proceed whenever `origin/main` had advanced from the triggering `${GITHUB_SHA}`, which blocked publishing when `main` advanced only via unrelated changes (for example the automated launch screenshot). 
- We need to keep the safety invariant that resume-source or workflow changes must block publishing, while allowing unrelated advances on `main` to be rebased onto before pushing.

### Description
- Add a small shell helper `check_resume_stale_paths` in the `Persist generated artifacts` step and the `Commit and push generated artifacts` step of `.github/workflows/resume.yml` that checks `git diff --name-only <base> <head> -- docs/resume .github/workflows/resume.yml` and fails with a clear error listing blocking paths if any are present. 
- Replace the strict `${GITHUB_SHA} == origin/main` exit with a path-aware flow: after `git fetch origin main` compute `current_main`, run the path check between `${GITHUB_SHA}` and `current_main`, and if only unrelated paths changed, `git checkout` the `current_main` and copy the generated artifacts; record `publish_base` for later comparison. 
- Before the final push re-fetch `origin/main`, re-run the path-aware check between `publish_base` and the current `origin/main`, fail if resume-affecting paths changed, otherwise `git rebase origin/main` the generated-artifact commit and push using the existing bot identity and commit subject `📄 : – refresh generated resume artifacts`. 
- Preserve artifact output locations (`public/docs/resume/<version>/resume.pdf`, `public/docs/resume/<version>/resume.docx`, `public/resume.pdf`, `public/resume.docx`) and the `github.actor != 'github-actions[bot]'` guard.

### Testing
- Ran `npx prettier --check .github/workflows/resume.yml` and `npm run format:check` (both passed). 
- Ran documentation checks with `npm run docs:check` (passed; external link fetch warnings only). 
- Ran `npm run format:write`, `npm run lint`, `npm run test:ci` (Vitest test suite passed) and `npm run smoke` (passed with the existing manual static-asset warning); all completed successfully. 
- Executed a local shell simulation of the path-aware guard using a temporary git repo which confirmed that an unrelated `docs/assets/game-launch.png` advance is allowed while a later change to `docs/resume/**` is blocked. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` to ensure no secrets were introduced (no high-risk secrets detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3615301e84832fa9f7d69f64bd7975)