### PR TITLE
Add v0.1.0 launch plan and baseline observability gates

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,251 @@
+# danielsmith.io v0.1.0 launch plan
+
+This checklist is the concrete release gate for the first production promotion of the
+`danielsmith.io` application from this repository. It is a planning document only: do not implement
+landing-page changes, metrics exporters, dashboards, alerts, deployment changes, Git tags, package
+version changes, or chart version changes as part of this plan.
+
+## Current-state evidence to preserve
+
+- [ ] Confirm the production root is no longer the legacy placeholder before declaring v0.1.0
+      launched. A pre-plan check on 2026-06-20 showed `https://danielsmith.io/healthz` returning the
+      legacy HTML page instead of the nginx JSON health endpoint expected from this repository.
+- [ ] Confirm `/livez` and `/healthz` return the static nginx JSON health responses from this
+      repository in staging and production.
+- [ ] Confirm `/resume.pdf` is served or redirected as the stable resume contract before making it
+      a paging/release-blocking content probe.
+- [ ] Treat `/runtime/github-metrics.json` as portfolio content only. It can support public project
+      metadata panels, but it is not uptime, latency, saturation, readiness, scrape-health, or release
+      identity evidence.
+- [ ] Keep all browser performance and failover telemetry local by default unless a future
+      privacy-reviewed design defines aggregation, consent, retention, deletion, and operator access.
+
+## Launch surface requirements
+
+- [ ] Production `https://danielsmith.io/` serves the application built from this repository rather
+      than the legacy placeholder page.
+- [ ] A simple, accessible landing surface or text surface exposes clear links to:
+  - [ ] Resume.
+  - [ ] GitHub.
+  - [ ] LinkedIn.
+  - [ ] Email.
+  - [ ] DSPACE.
+  - [ ] token.place.
+- [ ] The immersive experience provides a usable route to every launch link.
+- [ ] The text fallback provides a usable route to every launch link.
+- [ ] The resume link uses stable `/resume.pdf`, not a dated runtime URL or external placeholder.
+- [ ] Keyboard navigation reaches every launch link without traps.
+- [ ] Focus is visible on every interactive control and link.
+- [ ] Screen-reader labels distinguish destination and purpose for each launch link.
+- [ ] Reduced-motion preferences are honored by the launch surface and immersive entry points.
+- [ ] Text fallback remains available through automatic failover and explicit text-mode routing.
+- [ ] Staging is validated before promoting the exact same immutable `main-<shortsha>` image to
+      production.
+
+## Required v0.1.0 observability slice
+
+Keep the first slice small because the app is a static nginx site with no backend, database, queue,
+or worker. Use Sugarkube's Prometheus, Grafana, blackbox exporter, kube-state-metrics, kubelet or
+cAdvisor resource metrics, and Kubernetes release metadata where available.
+
+### Public blackbox probes
+
+- [ ] Probe `https://staging.danielsmith.io/` and `https://danielsmith.io/`.
+- [ ] Probe `https://staging.danielsmith.io/livez` and `https://danielsmith.io/livez`.
+- [ ] Probe `https://staging.danielsmith.io/healthz` and `https://danielsmith.io/healthz`.
+- [ ] Probe `https://staging.danielsmith.io/resume.pdf` and
+      `https://danielsmith.io/resume.pdf` after the stable path exists.
+- [ ] Record public endpoint success rate from `probe_success` or an equivalent blackbox signal.
+- [ ] Record public latency from `probe_duration_seconds` or an equivalent blackbox signal.
+- [ ] Record TLS certificate expiry from `probe_ssl_earliest_cert_expiry` or equivalent.
+
+### Kubernetes and resource health
+
+- [ ] Show Kubernetes deployment readiness for the `danielsmith` release in staging and production.
+- [ ] Show pod restart count and recent restart increase.
+- [ ] Show CPU saturation against requested/limited CPU.
+- [ ] Show memory saturation against requested/limited memory.
+- [ ] Show current immutable image or release identity, preferably the deployed
+      `main-<shortsha>` tag plus Helm release metadata.
+- [ ] Show Prometheus scrape health for relevant Kubernetes/app targets.
+- [ ] Show blackbox target health for every required public probe.
+
+### Provisional thresholds
+
+Tune these after staging supplies real data. They are release gates, not long-term SLOs.
+
+| Signal                       | Provisional threshold                                 | Window     | Action                                                                                    |
+| ---------------------------- | ----------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
+| Production root availability | `probe_success == 0`                                  | 3 minutes  | Check app pod, ingress, DNS, and Cloudflare path; rollback only when app image caused it. |
+| Staging root availability    | `probe_success == 0`                                  | 5 minutes  | Investigate before promotion; do not page production receivers.                           |
+| Static public latency        | p95 > 2 seconds                                       | 15 minutes | Compare staging/prod and Cloudflare path before changing app assets.                      |
+| TLS expiry                   | warning < 14 days, critical < 3 days                  | 1 hour     | Follow cert-manager or Cloudflare runbook; app rollback is usually not appropriate.       |
+| Deployment readiness         | available replicas below desired                      | 10 minutes | Inspect rollout, probes, image pull, and events; rollback if release-related.             |
+| Pod restarts                 | > 3 restarts in 15 minutes or CrashLoopBackOff        | 15 minutes | Inspect logs/events and resource limits; rollback if release-related.                     |
+| CPU saturation               | sustained > 80% of limit or throttling above baseline | 15 minutes | Validate traffic/probes and tune resources after staging evidence.                        |
+| Memory saturation            | sustained > 80% of limit or OOMKill                   | 15 minutes | Inspect pod memory and static asset serving behavior; rollback if release-related.        |
+| Prometheus scrape health     | `up == 0` for expected target                         | 10 minutes | Fix discovery/scrape config; do not rollback if public probes are healthy.                |
+
+## Dashboard requirement
+
+Create a dedicated `danielsmith.io` Grafana dashboard before production promotion. Mark panels
+complete only when backed by live staging data.
+
+- [ ] Public endpoint status for `/`, `/livez`, `/healthz`, and `/resume.pdf`.
+- [ ] Public latency history for required blackbox probes.
+- [ ] TLS certificate expiry.
+- [ ] Pod readiness and deployment availability.
+- [ ] Pod restarts and CrashLoopBackOff status.
+- [ ] CPU and memory resource usage against requests/limits.
+- [ ] Staging versus production comparison, using an `environment` variable or equivalent label.
+- [ ] Deployed immutable tag or release identity for each environment.
+- [ ] Prometheus scrape and blackbox target health.
+- [ ] If retained, a separate clearly labeled "GitHub portfolio metadata" panel for
+      `/runtime/github-metrics.json` freshness or cache shape. The panel must not appear in health,
+      uptime, latency, saturation, or alert rows.
+
+## Alert requirement
+
+Enable only actionable alerts with runbook notes and a tested receiver path. Use provisional
+thresholds until staging baselines are available.
+
+- [ ] Production root unavailable: `https://danielsmith.io/` blackbox success is 0 for 3 minutes.
+- [ ] Health endpoint unavailable: production `/healthz` blackbox success is 0 for 3 minutes.
+- [ ] Resume PDF unavailable: production `/resume.pdf` blackbox success is 0 for 5 minutes after
+      the stable path is implemented.
+- [ ] TLS expiry approaching: warning below 14 days and critical below 3 days.
+- [ ] Repeated pod restart: restart increase exceeds 3 in 15 minutes or pod enters
+      CrashLoopBackOff.
+- [ ] Deployment unavailable after rollout: available replicas remain below desired for 10 minutes.
+
+## Privacy boundaries
+
+- [ ] Do not add a public analytics collector as a hidden v0.1.0 requirement.
+- [ ] Do not put IP address, browser fingerprint, precise device identity, navigation history, or
+      visitor identifier values in Prometheus labels.
+- [ ] Do not label metrics with raw URLs, request IDs, arbitrary errors, or user-controlled values.
+- [ ] Keep client-side performance collection local by default for v0.1.0.
+- [ ] Use existing browser performance and failover events only as input to a future
+      privacy-reviewed telemetry design.
+- [ ] Any later client telemetry design must define aggregation, consent, retention, deletion, and
+      the minimum safe dimensions before data leaves the browser.
+
+## Promotion evidence checklist
+
+Record commands, timestamps, immutable tags, dashboard links or screenshots, and rollback target in
+the release notes or deployment record. All new items start unchecked.
+
+### Staging
+
+- [ ] Immutable image selected from a successful `main` GitHub Actions image build:
+      `ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA`.
+- [ ] Staging deployment from the immutable image completed:
+
+  ```bash
+  just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Staging rollout completed:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Staging root curl passed:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/
+  ```
+
+- [ ] Staging liveness curl passed:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/livez
+  ```
+
+- [ ] Staging health curl passed:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/healthz
+  ```
+
+- [ ] Staging resume curl passed after `/resume.pdf` exists:
+
+  ```bash
+  curl -fsSI https://staging.danielsmith.io/resume.pdf
+  ```
+
+- [ ] Prometheus target discovery shows expected Kubernetes and blackbox targets for staging.
+- [ ] Dashboard evidence shows staging public probes, latency, TLS, pod readiness, restarts,
+      resource usage, scrape health, and deployed immutable tag.
+- [ ] One controlled staging alert test was triggered, received, acknowledged, and restored.
+- [ ] Accessibility smoke evidence covers keyboard navigation, visible focus, screen-reader labels,
+      reduced motion, and text fallback.
+
+### Production promotion
+
+- [ ] Promote the exact immutable image that passed staging:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Production rollout completed:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Production root curl passed:
+
+  ```bash
+  curl -fsS https://danielsmith.io/
+  ```
+
+- [ ] Production liveness curl passed:
+
+  ```bash
+  curl -fsS https://danielsmith.io/livez
+  ```
+
+- [ ] Production health curl passed:
+
+  ```bash
+  curl -fsS https://danielsmith.io/healthz
+  ```
+
+- [ ] Production resume curl passed:
+
+  ```bash
+  curl -fsSI https://danielsmith.io/resume.pdf
+  ```
+
+- [ ] Dashboard evidence shows production public probes, latency, TLS, pod readiness, restarts,
+      resource usage, scrape health, and deployed immutable tag.
+- [ ] Blackbox and Prometheus target health remain green after promotion.
+- [ ] Text fallback and accessibility smoke evidence still pass against production.
+
+### Rollback
+
+- [ ] Prior known-good immutable image tag is recorded before promotion:
+      `main-PREVIOUS_SHORTSHA`.
+- [ ] Rollback command is ready from the Sugarkube repository:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-PREVIOUS_SHORTSHA
+  ```
+
+- [ ] Post-rollback verification commands are the same root, liveness, health, resume, dashboard,
+      and target-health checks listed above.
+- [ ] Helm revision rollback is documented as a secondary cluster-side fallback, but the preferred
+      app rollback is the prior immutable GHCR image tag.
+
+## Explicit post-v0.1.0 candidates
+
+Do not block v0.1.0 on these unless a later release plan explicitly promotes them into scope.
+
+- [ ] Privacy-safe aggregate browser performance telemetry.
+- [ ] nginx request metrics or an nginx exporter.
+- [ ] Richer WebGL and failover dashboards.
+- [ ] Loki or centralized logs.
+- [ ] Distributed tracing.

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -117,6 +117,9 @@ thresholds until staging baselines are available.
 - [ ] Repeated pod restart: restart increase exceeds 3 in 15 minutes or pod enters
       CrashLoopBackOff.
 - [ ] Deployment unavailable after rollout: available replicas remain below desired for 10 minutes.
+- [ ] Prometheus scrape target unavailable: `up == 0` for an expected production target for
+      10 minutes; route to the operator receiver and fix discovery or scrape configuration before
+      relying on resource, readiness, or restart panels.
 
 ## Privacy boundaries
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -7,13 +7,24 @@ version changes, or chart version changes as part of this plan.
 
 ## Current-state evidence to preserve
 
-- [ ] Confirm the production root is no longer the legacy placeholder before declaring v0.1.0
-      launched. A pre-plan check on 2026-06-20 showed `https://danielsmith.io/healthz` returning the
-      legacy HTML page instead of the nginx JSON health endpoint expected from this repository.
-- [ ] Confirm `/livez` and `/healthz` return the static nginx JSON health responses from this
-      repository in staging and production.
-- [ ] Confirm `/resume.pdf` is served or redirected as the stable resume contract before making it
-      a paging/release-blocking content probe.
+Do not treat current production as launched until explicit evidence proves the promoted immutable
+image is serving the root, health, and resume contracts below. Record the response status, key
+headers, body or redirect target, timestamp, and immutable tag where applicable. A pre-plan check on
+2026-06-20 showed `https://danielsmith.io/healthz` returning the legacy HTML page instead of the
+nginx JSON health endpoint expected from this repository.
+
+- [ ] `https://danielsmith.io/` returns the application built from this repository, not a legacy
+      placeholder page. Preserve enough response evidence to distinguish the promoted immutable
+      image from any prior prototype or static holding page.
+- [ ] `https://danielsmith.io/livez` returns this repository's static nginx JSON liveness response,
+      with no legacy HTML/runtime placeholder body.
+- [ ] `https://danielsmith.io/healthz` returns this repository's static nginx JSON health response,
+      with no legacy HTML/runtime placeholder body.
+- [ ] `https://danielsmith.io/resume.pdf` returns or redirects to the stable PDF contract, not a
+      legacy HTML/runtime placeholder response. Preserve redirect target and final content type when
+      redirects are involved.
+- [ ] Confirm `/livez` and `/healthz` return the same static nginx JSON health responses from this
+      repository in staging before production promotion.
 - [ ] Treat `/runtime/github-metrics.json` as portfolio content only. It can support public project
       metadata panels, but it is not uptime, latency, saturation, readiness, scrape-health, or release
       identity evidence.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,6 +27,14 @@ _Actions:_ cut a git tag + screenshot/GIF when each phase slices, update the tab
 metrics snapshot (Lighthouse CI, WebPageTest, telemetry). Numbers are privacy-respecting lab
 captures; keep artifacts in `docs/metrics/`.
 
+## v0.1.0 production launch
+
+- 🗓️ Planned: publish the first production release from this repository with a minimal accessible
+  link surface, stable `/resume.pdf` contract, immutable staging-to-production promotion, and
+  baseline Sugarkube observability gates. See [`docs/releases/v0.1.0.md`](releases/v0.1.0.md)
+  for the launch checklist, dashboard/alert requirements, privacy boundaries, promotion evidence,
+  and rollback plan.
+
 ## Global success criteria
 
 - **Performance budgets** – p95 FPS ≥90 on desktop class hardware and ≥60 on mid-range mobile;


### PR DESCRIPTION
### Motivation

- Provide a concrete, actionable v0.1.0 release checklist that can be followed to promote an immutable image from staging to production and to record promotion evidence. 
- Make a small, appropriate baseline observability slice a promotion requirement for this static nginx Vite site so operators can validate uptime, latency, TLS, readiness, restarts, and resource health before promoting. 
- Preserve privacy boundaries by explicitly prohibiting new public analytics collection and keeping client-side performance telemetry local by default.

### Description

- Add `docs/releases/v0.1.0.md`, a detailed v0.1.0 launch plan and checklist covering launch surface gates, required blackbox probes, Kubernetes/resource signals, dashboard panels, alert definitions, privacy boundaries, promotion evidence, verification commands, and rollback steps. 
- Add a concise v0.1.0 entry to `docs/roadmap.md` that links to the new release plan. 
- No runtime code, deployment, chart, package version, or implementation changes were made as part of this PR.

### Testing

- Ran `npm run format:write` and `npm run format:check`, both passed. 
- Ran `npm run docs:check`, which passed (link checker emitted external fetch warnings but completed successfully). 
- Ran `npm run lint`, which completed without errors. 
- Ran `npm run test:ci`, which completed successfully (all tests passed: 1208 tests). 
- Ran `npm run smoke` (build + `scripts/assert-dist.cjs`), which passed; Vite emitted an informational large-chunk warning. 
- Ran `git diff --check` and repository secret scan via `./scripts/scan-secrets.py`, both returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d33ad0ac832f83c04db8fbf8c012)