### PR TITLE
Add v0.1.0 launch plan

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,305 @@
+# danielsmith.io v0.1.0 launch plan
+
+This checklist is the concrete release plan for promoting `danielsmith.io` v0.1.0 from a
+prototype/static app artifact into the public production site. It is documentation and release
+planning only: do not implement the launch page, observability stack, dashboards, alerts, or
+deployment changes from this document, do not create a Git tag, and do not alter package, image,
+or chart versions as part of planning.
+
+Current public behavior was verified on 2026-06-20 before writing this plan: `https://danielsmith.io/`
+served a legacy placeholder-style HTML page with a dated/runtime resume destination, and
+`https://danielsmith.io/resume.pdf` did not return a PDF response. Treat production service from
+this repository as incomplete until the evidence checklist below proves otherwise.
+
+## Release scope
+
+### In scope for v0.1.0
+
+- [ ] Production `danielsmith.io` serves the application built from this repository instead of the
+      legacy placeholder page.
+- [ ] A simple, accessible landing or text surface exposes clear links to:
+  - [ ] résumé at `/resume.pdf`
+  - [ ] GitHub
+  - [ ] LinkedIn
+  - [ ] email
+  - [ ] DSPACE
+  - [ ] token.place
+- [ ] The immersive experience provides a usable route to every launch link.
+- [ ] The text fallback provides a usable route to every launch link.
+- [ ] The résumé link uses the stable `/resume.pdf` path, not a dated runtime URL.
+- [ ] Keyboard navigation, visible focus, screen-reader labels, reduced-motion behavior, and text
+      fallback behavior are release gates.
+- [ ] Staging is validated before promoting the exact same immutable image to production.
+- [ ] Baseline Sugarkube observability exists and is part of the production-promotion gate.
+
+### Out of scope for v0.1.0
+
+- [ ] No public analytics collector is required or added as a hidden launch dependency.
+- [ ] No WebGL/failover browser telemetry aggregation is required before launch.
+- [ ] No nginx request metrics exporter is required before launch.
+- [ ] No Loki, centralized logs, or distributed tracing is required before launch.
+- [ ] GitHub repository stars, forks, and the `/runtime/github-metrics.json` cache remain portfolio
+      content and release context, not operational health metrics.
+
+## Launch surface checklist
+
+- [ ] Confirm `npm run build` produces the deployable static application for the selected commit.
+- [ ] Confirm the runtime container serves the Vite app over nginx on port `8080`.
+- [ ] Confirm `/livez` and `/healthz` return successful responses from the selected image.
+- [ ] Confirm `/resume.pdf` exists in the selected image and is served as a PDF.
+- [ ] Confirm SPA fallback remains enabled for browser navigation without hiding health or résumé
+      failures.
+- [ ] Confirm the landing/text surface can be understood without WebGL.
+- [ ] Confirm immersive navigation exposes the same launch destinations as the text fallback.
+- [ ] Confirm all external links have accessible names and clear destination text.
+- [ ] Confirm email contact uses an intentional, reviewable link format.
+- [ ] Confirm the launch surface works with JavaScript disabled or forced text mode where expected.
+
+## Accessibility and fallback gates
+
+- [ ] Keyboard users can reach every launch link and mode control.
+- [ ] Focus indicators are visible against the launch surface background.
+- [ ] Screen-reader labels describe the résumé, GitHub, LinkedIn, email, DSPACE, and token.place
+      links without relying only on visual layout.
+- [ ] Reduced-motion preferences suppress or soften non-essential animation.
+- [ ] `?mode=text` provides a usable text fallback route to every launch link.
+- [ ] `?mode=immersive&disablePerformanceFailover=1` loads the immersive scene for review without
+      disabling normal production failover behavior in the default URL.
+- [ ] Existing failover triggers still route unsupported, low-memory, data-saver, or runtime-error
+      sessions to the text experience.
+
+## Required v0.1.0 observability slice
+
+Use the canonical Sugarkube observability design as the source of truth. The v0.1.0 slice is
+intentionally small because `danielsmith.io` is a static nginx application with no backend,
+database, queue, or application-owned metrics endpoint.
+
+### Blackbox probes
+
+Configure Sugarkube-owned blackbox probes for both staging and production:
+
+- [ ] `https://staging.danielsmith.io/`
+- [ ] `https://staging.danielsmith.io/livez`
+- [ ] `https://staging.danielsmith.io/healthz`
+- [ ] `https://staging.danielsmith.io/resume.pdf`
+- [ ] `https://danielsmith.io/`
+- [ ] `https://danielsmith.io/livez`
+- [ ] `https://danielsmith.io/healthz`
+- [ ] `https://danielsmith.io/resume.pdf`
+
+### Signals required before production promotion
+
+- [ ] Public endpoint success rate from blackbox probes.
+- [ ] Public endpoint latency from blackbox probes.
+- [ ] TLS certificate expiry for public hosts.
+- [ ] Kubernetes Deployment availability/readiness.
+- [ ] Pod restart count.
+- [ ] CPU saturation.
+- [ ] Memory saturation.
+- [ ] Current immutable image or release identity for staging and production.
+- [ ] Prometheus scrape health.
+- [ ] Blackbox target health.
+
+### Provisional thresholds
+
+Staging data must replace or tune these thresholds before they become durable production SLOs.
+Start conservative and keep alerts actionable:
+
+- [ ] Root, health, and résumé blackbox probes: alert after 2 consecutive failed probes over about
+      5 minutes.
+- [ ] Public latency: watch p95 over 1 second for the static root path; do not page on latency
+      until staging establishes a real baseline.
+- [ ] TLS expiry: warn below 14 days, urgent below 7 days.
+- [ ] Deployment availability: alert when desired replicas are unavailable for 10 minutes after a
+      rollout starts.
+- [ ] Pod restarts: alert on repeated restarts, provisionally more than 2 restarts in 15 minutes for
+      the app container.
+- [ ] CPU saturation: warn above 80% of requested CPU for 15 minutes after staging confirms request
+      sizing.
+- [ ] Memory saturation: warn above 80% of requested or limited memory for 15 minutes after staging
+      confirms request sizing.
+- [ ] Prometheus/blackbox health: alert when the scrape target or blackbox module is down for
+      10 minutes.
+
+## Dashboard requirement
+
+Create a `danielsmith.io` dashboard in Sugarkube/Grafana before production promotion. It must make
+staging versus production explicit and must not represent portfolio metadata as server health.
+
+Required panels:
+
+- [ ] Public endpoint status for `/`, `/livez`, `/healthz`, and `/resume.pdf`.
+- [ ] Latency history for the public probes.
+- [ ] TLS certificate expiry.
+- [ ] Pod readiness and unavailable replicas.
+- [ ] Pod restart history.
+- [ ] CPU usage and saturation.
+- [ ] Memory usage and saturation.
+- [ ] Staging versus production environment selector or side-by-side rows.
+- [ ] Deployed immutable tag, digest, or release identity.
+- [ ] Prometheus scrape health and blackbox target health.
+- [ ] If retained, a separate panel clearly labeled `GitHub portfolio metadata` for
+      `/runtime/github-metrics.json` freshness or content status. This panel must be visually and
+      semantically separate from availability, latency, and saturation panels.
+
+## Minimal alerts
+
+Define only actionable alerts for v0.1.0. Alert names can follow the final Sugarkube convention,
+but the release gate must cover these conditions:
+
+- [ ] Production root unavailable.
+- [ ] Production `/healthz` unavailable.
+- [ ] Production `/resume.pdf` unavailable.
+- [ ] TLS certificate expiry approaching.
+- [ ] Repeated pod restart.
+- [ ] Deployment unavailable after rollout.
+
+## Privacy boundaries
+
+- [ ] Existing browser performance and failover events may inform a future privacy-reviewed
+      telemetry design.
+- [ ] v0.1.0 does not require or add a public analytics collector.
+- [ ] No IP address, browser fingerprint, precise device identity, navigation history, or visitor
+      identifier may enter Prometheus labels.
+- [ ] Client-side performance collection remains local by default unless a later design defines
+      aggregation, consent, retention, and deletion behavior.
+- [ ] Metrics labels stay low-cardinality and operational: environment, namespace, app, endpoint,
+      status class, probe module, release/image identity, and Kubernetes object names are enough.
+
+## Explicit post-v0.1.0 candidates
+
+- [ ] Privacy-safe aggregate browser performance telemetry.
+- [ ] nginx request metrics or an exporter.
+- [ ] Richer WebGL/failover dashboards.
+- [ ] Loki or centralized logs.
+- [ ] Distributed tracing.
+
+## Promotion evidence checklist
+
+Record the selected immutable image tag, staging evidence, production evidence, and rollback target
+in the release notes before marking v0.1.0 complete.
+
+### Artifact selection
+
+- [ ] Select a successful `main` image workflow run.
+- [ ] Record immutable image tag: `main-REPLACE_SHORTSHA`.
+- [ ] Record image reference: `ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA`.
+- [ ] Record chart reference: `oci://ghcr.io/futuroptimist/charts/danielsmith`.
+- [ ] Record previous known-good immutable production tag for rollback.
+
+### Staging deployment and verification
+
+Run from the Sugarkube repository checkout unless noted otherwise.
+
+- [ ] Deploy staging from the immutable image:
+
+  ```bash
+  just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Verify rollout readiness:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Verify root response:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/
+  ```
+
+- [ ] Verify liveness response:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/livez
+  ```
+
+- [ ] Verify health response:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/healthz
+  ```
+
+- [ ] Verify résumé PDF response:
+
+  ```bash
+  curl -fsSI https://staging.danielsmith.io/resume.pdf
+  ```
+
+- [ ] Verify Prometheus discovers the app or platform scrape targets needed for the dashboard.
+- [ ] Verify blackbox targets exist and are healthy for staging.
+- [ ] Capture dashboard evidence for staging public status, latency, TLS, pod readiness, restarts,
+      resource usage, target health, and deployed immutable tag.
+- [ ] Run one controlled alert test and record the result and cleanup.
+- [ ] Capture accessibility smoke evidence.
+- [ ] Capture text-fallback smoke evidence with `?mode=text`.
+
+### Production promotion and verification
+
+- [ ] Promote the same immutable image to production:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Verify production rollout readiness:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Verify production root response:
+
+  ```bash
+  curl -fsS https://danielsmith.io/
+  ```
+
+- [ ] Verify production liveness response:
+
+  ```bash
+  curl -fsS https://danielsmith.io/livez
+  ```
+
+- [ ] Verify production health response:
+
+  ```bash
+  curl -fsS https://danielsmith.io/healthz
+  ```
+
+- [ ] Verify production résumé PDF response:
+
+  ```bash
+  curl -fsSI https://danielsmith.io/resume.pdf
+  ```
+
+- [ ] Verify production blackbox targets are healthy.
+- [ ] Verify production dashboard panels show the promoted immutable tag.
+- [ ] Verify production accessibility and text-fallback smoke evidence.
+
+### Rollback plan
+
+Use the prior known-good immutable image tag. Do not rebuild locally as a rollback workaround.
+
+- [ ] Record rollback target: `main-PREVIOUS_SHORTSHA`.
+- [ ] Roll production back to the prior immutable image:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-PREVIOUS_SHORTSHA
+  ```
+
+- [ ] Verify rollback rollout readiness:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  ```
+
+- [ ] Verify root, health, and résumé responses after rollback.
+- [ ] Verify dashboard release identity returns to the rollback tag.
+- [ ] Record why rollback was needed and what follow-up blocks re-promotion.
+
+## Completion rule
+
+Do not mark v0.1.0 complete until repository and release evidence prove every launch,
+accessibility, observability, promotion, verification, and rollback gate above is either complete or
+explicitly superseded by a reviewed follow-up plan.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,6 +27,13 @@ _Actions:_ cut a git tag + screenshot/GIF when each phase slices, update the tab
 metrics snapshot (Lighthouse CI, WebPageTest, telemetry). Numbers are privacy-respecting lab
 captures; keep artifacts in `docs/metrics/`.
 
+## Release plans
+
+- [ ] [v0.1.0 launch plan](releases/v0.1.0.md) promotes the repository-backed
+      static app to production only after launch-surface, accessibility, baseline
+      Sugarkube observability, staging validation, production verification, and
+      rollback evidence are recorded.
+
 ## Global success criteria
 
 - **Performance budgets** – p95 FPS ≥90 on desktop class hardware and ≥60 on mid-range mobile;


### PR DESCRIPTION
### Motivation
- Establish a concrete, followable v0.1.0 launch checklist that gates production promotion on accessibility, a minimal Sugarkube observability slice, staging validation, promotion evidence, and rollback readiness.
- Capture current production verification (placeholder page served; `/resume.pdf` not returning a PDF) so the plan reflects observed state and does not assume the prototype is already serving production.

### Description
- Added `docs/releases/v0.1.0.md` containing the v0.1.0 launch checklist with launch-surface, accessibility, observability (blackbox probes, signals, provisional thresholds), dashboard, alert, privacy, promotion, verification, and rollback gates.
- Linked the new release plan from `docs/roadmap.md` under a new "Release plans" section so the roadmap references the checklist.
- No runtime, chart, image, tag, or implementation changes were made; this is docs-only and intentionally leaves all checklist items unchecked.
- The plan references the canonical Sugarkube observability design and keeps GitHub metrics cache content as portfolio metadata (not operational health metrics).

### Testing
- Ran `npm run format:write` to format new files and `npm run format:check` and both completed successfully (Prettier OK). ✅
- Ran `npm run docs:check` which passed; the link checker emitted non-fatal external fetch warnings for some outbound URLs (these are noted and did not block the docs check). ✅
- Ran `npm run lint` (ESLint) which completed without introducing new lint failures. ✅
- Ran `npm run test:ci` (Vitest) and unit tests passed: `Test Files 158 passed`, `Tests 1208 passed`. ✅
- Ran `npm run smoke` (build + `scripts/assert-dist.cjs`) and the smoke check passed; `dist/` contains a `resume.pdf` entry in the build artifact list but production verification remains part of the checklist. ✅
- Ran repository checks: `git diff --check` (no issues) and `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets found). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d354839c832f91854bbbe38790f0)