### PR TITLE
Document v0.1.0 launch plan and baseline observability requirement

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,255 @@
+# danielsmith.io v0.1.0 launch plan
+
+This is the concrete launch checklist for promoting `danielsmith.io` v0.1.0 on
+Sugarkube. It is intentionally documentation-only: do not implement the launch page, metrics
+stack, dashboards, alerts, deployment changes, package versions, chart versions, or Git tags as part
+of this plan.
+
+## Current-state verification
+
+- [ ] Confirm the public production root is serving the immutable application image from this
+      repository, not the legacy placeholder page.
+  - Evidence command:
+    `curl -fsSL https://danielsmith.io/ | sed -n '1,80p'`
+  - 2026-06-20 spot check: `https://danielsmith.io/` returned a static
+    `Daniel Smith | Software Engineer` placeholder page, so production must not be treated as
+    already launched from this repository.
+- [ ] Confirm the runtime image exposes nginx health endpoints before release sign-off.
+  - Source evidence: `docker/nginx/default.conf` defines `/livez` and `/healthz` as no-store JSON
+    `200` responses.
+  - Staging/prod evidence command:
+    `curl -fsS https://staging.danielsmith.io/livez && curl -fsS https://staging.danielsmith.io/healthz`
+- [ ] Confirm the planned stable resume URL is the public contract.
+  - Source evidence: `public/resume.pdf` exists in this repo and the fallback code defaults to
+    `/resume.pdf`.
+  - Staging/prod evidence command: `curl -fsSI https://staging.danielsmith.io/resume.pdf`
+- [ ] Confirm `/runtime/github-metrics.json`, if enabled, is portfolio content only.
+      It may support POI content and dashboard context, but it is not uptime, latency, readiness,
+      saturation, or dependency-health evidence.
+
+## Launch surface requirements
+
+- [ ] Production `https://danielsmith.io/` serves the application from this repository rather than
+      the legacy placeholder page.
+- [ ] A simple, accessible landing or text surface exposes clear links to all launch CTAs:
+  - [ ] Resume at `/resume.pdf`.
+  - [ ] GitHub.
+  - [ ] LinkedIn.
+  - [ ] Email.
+  - [ ] DSPACE.
+  - [ ] token.place.
+- [ ] The immersive experience provides a usable route to every launch CTA above.
+- [ ] The text fallback provides a usable route to every launch CTA above.
+- [ ] The resume link uses the stable `/resume.pdf` path, not a dated runtime URL.
+- [ ] Keyboard navigation remains a gate: all launch CTAs are reachable without a pointer.
+- [ ] Visible focus remains a gate for all interactive controls and links.
+- [ ] Screen-reader labels remain a gate for the landing surface, HUD, POI/contact links, and
+      fallback controls.
+- [ ] Reduced-motion behavior remains a gate for immersive and fallback surfaces.
+- [ ] Text fallback remains a gate for low-capability browsers, explicit `?mode=text`, bot/social
+      previews, and runtime failover paths.
+- [ ] Staging is validated before promoting the exact same immutable image to production.
+
+## Required v0.1.0 observability slice
+
+Baseline observability should stay small because this is a static nginx application. The v0.1.0
+promotion gate requires the following signals in staging and production before production sign-off:
+
+- [ ] Blackbox probes for public paths:
+  - [ ] `/`
+  - [ ] `/livez`
+  - [ ] `/healthz`
+  - [ ] `/resume.pdf`
+- [ ] Public endpoint latency and success rate from blackbox probe data.
+- [ ] TLS certificate expiry from blackbox TLS probing.
+- [ ] Kubernetes deployment readiness from kube-state-metrics.
+- [ ] Pod restart count.
+- [ ] CPU saturation.
+- [ ] Memory saturation.
+- [ ] Current immutable image/release identity, preferably from Kubernetes image labels/fields and
+      dashboard annotations; use `danielsmith_build_info` only if a later app metrics endpoint is
+      explicitly designed.
+- [ ] Prometheus scrape health and blackbox target health.
+
+### Provisional thresholds
+
+Staging data must replace these provisional values before they become long-term production policy:
+
+| Signal               | Provisional v0.1.0 threshold                           | Window | Action                                                                       |
+| -------------------- | ------------------------------------------------------ | ------ | ---------------------------------------------------------------------------- |
+| Root success         | `probe_success == 0` for production `/`                | 3m     | Check ingress/Cloudflare, then app rollout.                                  |
+| Health success       | `probe_success == 0` for `/healthz` or `/livez`        | 3m     | Check pod readiness and nginx config.                                        |
+| Resume success       | `probe_success == 0` for `/resume.pdf`                 | 5m     | Check image contents, nginx static serving, and rollback if release-related. |
+| Public latency       | p95 `probe_duration_seconds > 2s`                      | 15m    | Compare staging baseline; inspect Cloudflare and node saturation.            |
+| TLS expiry           | `<14d` warning, `<3d` critical                         | 1h     | Use Cloudflare/cert-manager runbook; do not roll back app image by default.  |
+| Deployment readiness | available replicas below desired                       | 10m    | Inspect events/logs; rollback image if release-related.                      |
+| Pod restarts         | restart increase `>3` or CrashLoopBackOff              | 15m    | Inspect logs/events; rollback if new image caused failures.                  |
+| CPU saturation       | sustained container CPU near limit                     | 15m    | Check traffic/probes; tune resources only after evidence.                    |
+| Memory saturation    | sustained working set near limit or OOMKilled          | 15m    | Inspect asset/image regression; rollback if release-related.                 |
+| Scrape/target health | Prometheus target `up == 0` or blackbox target missing | 10m    | Fix discovery/monitoring; do not treat as app outage if probes still pass.   |
+
+## Dashboard requirement
+
+- [ ] Create a `danielsmith.io` dashboard with environment variables for `staging` and `prod`.
+- [ ] Include public endpoint status for `/`, `/livez`, `/healthz`, and `/resume.pdf`.
+- [ ] Include latency history, including p50/p95 or equivalent blackbox duration views.
+- [ ] Include TLS expiry.
+- [ ] Include pod readiness and restart count.
+- [ ] Include CPU and memory usage/saturation.
+- [ ] Include side-by-side or filterable staging versus production views.
+- [ ] Include deployed immutable tag/revision or current image identity.
+- [ ] If GitHub portfolio metadata is retained on the dashboard, keep it in a separate panel clearly
+      labeled `Portfolio metadata (not service health)`.
+
+## Alert requirement
+
+Define only actionable alerts for v0.1.0. Keep all checklist items unchecked until the alert is
+implemented, routed, and tested in staging:
+
+- [ ] Production root unavailable.
+- [ ] Health endpoint unavailable.
+- [ ] Resume PDF unavailable.
+- [ ] TLS expiry approaching.
+- [ ] Repeated pod restart.
+- [ ] Deployment unavailable after rollout.
+
+## Privacy boundaries
+
+- [ ] Existing browser performance and failover events may inform a future privacy-reviewed
+      telemetry design, but they are not a v0.1.0 production-promotion dependency.
+- [ ] v0.1.0 must not add a public analytics collector as a hidden requirement.
+- [ ] No IP address, browser fingerprint, precise device identity, navigation history, or visitor
+      identifier may enter Prometheus labels.
+- [ ] Client-side performance collection remains local by default unless a later design defines
+      aggregation, consent, retention, and deletion behavior.
+- [ ] GitHub stars, repo metadata, and `/runtime/github-metrics.json` remain portfolio/product
+      metadata; do not page or claim service health from them.
+
+## Promotion evidence checklist
+
+Record evidence in release notes, a PR comment, or the release issue before checking off each item.
+Every command should use the immutable `main-<shortsha>` image selected from the successful
+GitHub Actions image workflow.
+
+### 1. Select immutable artifacts
+
+- [ ] Record the immutable image tag: `ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA`.
+- [ ] Record the chart reference: `oci://ghcr.io/futuroptimist/charts/danielsmith`.
+- [ ] Record the prior known-good production immutable image tag for rollback.
+
+### 2. Deploy staging
+
+- [ ] Deploy staging from the Sugarkube checkout:
+
+  ```bash
+  just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Capture rollout status:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  kubectl -n danielsmith get deploy,po,svc,ingress
+  ```
+
+### 3. Verify staging launch surface
+
+- [ ] Root check succeeds and shows the app from this repository:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/
+  ```
+
+- [ ] Health checks succeed:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/livez
+  curl -fsS https://staging.danielsmith.io/healthz
+  ```
+
+- [ ] Stable resume check succeeds:
+
+  ```bash
+  curl -fsSI https://staging.danielsmith.io/resume.pdf
+  ```
+
+- [ ] Accessibility smoke evidence is captured for keyboard navigation, visible focus,
+      screen-reader labels, reduced motion, and text fallback.
+- [ ] Text fallback smoke evidence is captured with `https://staging.danielsmith.io/?mode=text`.
+- [ ] Immersive smoke evidence is captured with
+      `https://staging.danielsmith.io/?mode=immersive&disablePerformanceFailover=1`.
+
+### 4. Verify staging observability
+
+- [ ] Prometheus discovers the required danielsmith.io scrape and blackbox targets.
+- [ ] Blackbox targets for `/`, `/livez`, `/healthz`, and `/resume.pdf` are healthy.
+- [ ] Dashboard shows staging endpoint status, latency history, TLS expiry, pod readiness,
+      restarts, resource usage, and immutable image identity.
+- [ ] One controlled alert test is run and resolved. Prefer a safe staging-only blackbox or alert
+      rule test; do not break production traffic.
+- [ ] GitHub metadata, if shown, appears only in the separate portfolio-metadata panel.
+
+### 5. Promote production
+
+- [ ] Promote the exact staging-validated immutable image from the Sugarkube checkout:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-REPLACE_SHORTSHA
+  ```
+
+- [ ] Capture the production promotion command output.
+- [ ] Capture production rollout status:
+
+  ```bash
+  kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+  kubectl -n danielsmith get deploy,po,svc,ingress
+  ```
+
+### 6. Post-promotion verification
+
+- [ ] Root check succeeds and no legacy placeholder remains:
+
+  ```bash
+  curl -fsS https://danielsmith.io/
+  ```
+
+- [ ] Health checks succeed:
+
+  ```bash
+  curl -fsS https://danielsmith.io/livez
+  curl -fsS https://danielsmith.io/healthz
+  ```
+
+- [ ] Stable resume check succeeds:
+
+  ```bash
+  curl -fsSI https://danielsmith.io/resume.pdf
+  ```
+
+- [ ] Production blackbox targets are healthy.
+- [ ] Production dashboard shows the promoted immutable image and healthy pod/resource state.
+- [ ] Production alert state is clean after rollout.
+
+### 7. Rollback plan
+
+- [ ] Record the prior immutable image before promotion.
+- [ ] If production verification fails for an app-image cause, roll back to the prior immutable
+      image from the Sugarkube checkout:
+
+  ```bash
+  just danielsmith-oci-promote-prod tag=main-PRIOR_SHORTSHA
+  ```
+
+- [ ] Re-run production root, health, resume, blackbox, dashboard, and alert checks after rollback.
+- [ ] If the failure is Cloudflare, DNS, TLS, or the observability stack rather than the app image,
+      use the platform runbook and avoid unnecessary app rollback.
+
+## Explicit post-v0.1.0 candidates
+
+These are not required for v0.1.0 promotion and must not be introduced as hidden launch blockers:
+
+- [ ] Privacy-safe aggregate browser performance telemetry.
+- [ ] nginx request metrics or an exporter.
+- [ ] Richer WebGL/failover dashboards.
+- [ ] Loki or centralized logs.
+- [ ] Distributed tracing.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,6 +27,13 @@ _Actions:_ cut a git tag + screenshot/GIF when each phase slices, update the tab
 metrics snapshot (Lighthouse CI, WebPageTest, telemetry). Numbers are privacy-respecting lab
 captures; keep artifacts in `docs/metrics/`.
 
+## v0.1.0 launch plan
+
+- 🗓️ Planned: [v0.1.0 launch plan](releases/v0.1.0.md) defines the production
+  launch surface, accessibility gates, Sugarkube promotion evidence, rollback path,
+  and the minimal observability requirement for promoting the portfolio from the
+  legacy placeholder to this repository's static nginx application.
+
 ## Global success criteria
 
 - **Performance budgets** – p95 FPS ≥90 on desktop class hardware and ≥60 on mid-range mobile;


### PR DESCRIPTION
### Motivation
- Provide a concrete, actionable v0.1.0 launch checklist for promoting `danielsmith.io` on Sugarkube so promotion work is governed by documented gates rather than ad-hoc steps. 
- Make a small, appropriate baseline observability slice a production-promotion requirement for this static nginx app without adding runtime instrumentation or changing images/versions. 
- Keep GitHub metrics/runtime cache scoped as portfolio metadata and ensure accessibility, text-fallback, and staging validation remain hard gates.

### Description
- Add `docs/releases/v0.1.0.md` containing a step-by-step launch checklist covering current-state verification, launch surface requirements, accessibility gates, required blackbox/probe signals, dashboard and alert requirements, privacy boundaries, promotion evidence, verification, and rollback instructions. 
- Add a concise v0.1.0 entry to `docs/roadmap.md` that links to the new release plan at `docs/releases/v0.1.0.md`. 
- No runtime, chart, image, package, or CI workflow changes are made; the PR is documentation-only and leaves all implementation for follow-up work.

### Testing
- Ran formatting and style checks with `npm run format:write` and `npm run format:check` and they passed. 
- Ran docs validation with `npm run docs:check` and `npm run links:check`, which passed the repo docs check and emitted expected external-link reachability warnings. 
- Ran lint and unit tests with `npm run lint` and `npm run test:ci` (Vitest), and the test suite completed successfully (`1208 tests passed` in this environment). 
- Ran `npm run smoke` (build + `scripts/assert-dist.cjs`) and `git diff --check` and both passed; pre-commit secret scans (`git diff | ./scripts/scan-secrets.py` and staged scan) reported no high-risk secrets. 
- Performed a production spot-check with `curl -fsSL https://danielsmith.io/` on 2026-06-20 which returned the existing placeholder page and is recorded in the release checklist as a current-state verification item.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d35ef8fc832f945f45f78df68007)