### PR TITLE
Canonicalize runtime résumé URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ lightweight.
 - **Launch smoke** – `npm run smoke` builds once, validates bundled output references, and reports
   manual static binary assets (resume/favicon) as warnings by default.
 - **Strict manual static verification** – run `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` after
-  Daniel manually adds binary assets (for example `favicon.ico` and resume PDFs) so missing source
-  or `dist/` artifacts fail fast.
+  Daniel manually adds binary assets (for example `favicon.ico`, the stable `public/resume.pdf`,
+  and dated résumé archives such as `public/docs/resume/2026-06/resume.pdf`) so missing source or
+  `dist/` artifacts fail fast.
 - **Link preview heuristics** – Automated user-agent checks steer social/chat crawlers
   (Facebook, Twitter, Slack, Discord, LinkedIn, Telegram, WhatsApp, Skype, GPTBot,
   ClaudeBot, ByteSpider, and others) to the text tour so share cards render without

--- a/docs/resume/README.md
+++ b/docs/resume/README.md
@@ -4,4 +4,7 @@
 - Build locally with [`latexmk`](https://ctan.org/pkg/latexmk) or [`pandoc`](https://pandoc.org/) if you need quick PDF or DOCX outputs.
 - Continuous Integration automatically builds both `.pdf` and `.docx` artifacts on pull requests and pushes to `main` that touch `docs/resume/**` or the resume workflow.
 - The workflow treats the lexicographically latest `YYYY-MM` directory under `docs/resume/` as the active source. On `main`, it publishes generated files to `public/docs/resume/<version>/` and refreshes the stable `public/resume.*` aliases without writing build outputs back into `docs/resume/`.
+- `/resume.pdf` is the canonical runtime résumé URL used by the site UI, text fallback, no-script fallback, tests, and smoke checks.
+- `/resume.docx` is available as a stable downloadable document alias when a DOCX is useful, but primary résumé links should stay focused on `/resume.pdf`.
+- `public/docs/resume/2026-06/resume.pdf` is the immutable dated PDF archive for the June 2026 résumé publication; keep dated archives available for historical references without making them active runtime links.
 - The automated test suite compiles the latest dated résumé with [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux binaries if they are not already on your `PATH` (other platforms should install the tools manually).

--- a/src/tests/resumeRuntimeLinks.test.ts
+++ b/src/tests/resumeRuntimeLinks.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { getSiteStrings } from '../assets/i18n';
+
+const require = createRequire(import.meta.url);
+const { runtimeAssetExpectations } =
+  require('../../scripts/static-asset-expectations.cjs') as {
+    runtimeAssetExpectations: Array<{ path: string; reason: string }>;
+  };
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(currentDir, '..', '..');
+const legacyResumeVersion = ['2025', '09'].join('-');
+const legacyResumePdfPath = `/docs/resume/${legacyResumeVersion}/resume.pdf`;
+
+const activeSourceFiles = [
+  'index.html',
+  'src/assets/i18n/locales/en.ts',
+  'src/assets/i18n/locales/en-x-pseudo.ts',
+  'src/assets/i18n/locales/zh-Hans.ts',
+  'src/assets/i18n/locales/ar.ts',
+  'src/assets/i18n/locales/ja.ts',
+  'src/systems/failover/index.ts',
+  'scripts/static-asset-expectations.cjs',
+];
+
+const readProjectFile = (relativePath: string) =>
+  readFileSync(path.join(projectRoot, relativePath), 'utf8');
+
+describe('runtime résumé links', () => {
+  it('keeps localized runtime contact links on the stable PDF alias', () => {
+    for (const locale of ['en', 'zh-Hans', 'ar', 'ja'] as const) {
+      expect(getSiteStrings(locale).textFallback.contact.resumeUrl).toBe(
+        '/resume.pdf'
+      );
+    }
+  });
+
+  it('keeps the no-script fallback on the stable PDF alias', () => {
+    const indexHtml = readProjectFile('index.html');
+
+    expect(indexHtml).toContain('href="/resume.pdf"');
+    expect(indexHtml).not.toContain(legacyResumePdfPath);
+  });
+
+  it('requires the stable PDF alias before strict static smoke validation runs', () => {
+    expect(runtimeAssetExpectations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: '/resume.pdf',
+        }),
+      ])
+    );
+    expect(runtimeAssetExpectations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: legacyResumePdfPath,
+        }),
+      ])
+    );
+  });
+
+  it('does not reference the September 2025 PDF from active runtime sources', () => {
+    for (const relativePath of activeSourceFiles) {
+      expect(readProjectFile(relativePath), relativePath).not.toContain(
+        legacyResumePdfPath
+      );
+    }
+  });
+
+  it('keeps the stable PDF present for strict smoke validation', async () => {
+    await expect(
+      access(path.join(projectRoot, 'public', 'resume.pdf'))
+    ).resolves.toBeUndefined();
+  });
+
+  it('permits immutable dated résumé archives alongside the stable alias', async () => {
+    await expect(
+      access(
+        path.join(
+          projectRoot,
+          'public',
+          'docs',
+          'resume',
+          '2026-06',
+          'resume.pdf'
+        )
+      )
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Motivation
- Make `/resume.pdf` the canonical runtime résumé URL used by the UI, text fallback, and no-script fallback while preserving dated generated archives as historical artifacts.
- Ensure runtime checks, tests, and smoke validation expect the stable `/resume.pdf` alias instead of a dated PDF path.

### Description
- Document `/resume.pdf` (stable runtime alias), `/resume.docx` (downloadable alias), and `public/docs/resume/2026-06/resume.pdf` (immutable dated archive) in `docs/resume/README.md`.
- Clarify strict manual static verification guidance in `README.md` to reference the stable `public/resume.pdf` and dated archives.
- Add focused regression tests in `src/tests/resumeRuntimeLinks.test.ts` that assert localized runtime links, the no-script fallback, `scripts/static-asset-expectations.cjs` expectations, the absence of the `2025-09` dated PDF in active runtime sources, the presence of `public/resume.pdf`, and allowance of dated archives.
- Make no changes to resume content, generated PDF/DOCX binaries, or the resume artifact workflow.

### Testing
- Ran `npm run format:write` and it completed successfully.
- Ran `npm run lint` and it passed with no reported lint failures.
- Ran `npm run test:ci` which executed the full Vitest suite and completed successfully (all tests passed; `1214` tests across `159` files).
- Ran `npm run docs:check` which passed (link checker emitted external fetch warnings but returned success).
- Ran `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` and the smoke validation passed with `public/resume.pdf` present.
- Verified repository search with `rg -n "/docs/resume/2025-09/resume\.pdf|2025-09" index.html src scripts README.md docs --glob '!docs/resume/2025-09/**' --glob '!outages/**'` returned no active matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d44d83f8832f86d168d9f03e5647)