### PR TITLE
📄 : – Canonicalize runtime résumé URL to /resume.pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ Avatar facing is computed from the camera-relative movement vector; see
   [docs/backlog.md](docs/backlog.md).
 - **UI placement guide** – Compare in-world vs. overlay treatments in
   [docs/guides/in-world-vs-overlay.md](docs/guides/in-world-vs-overlay.md).
-- **Résumé** – Latest résumé source is
-  [`resume.tex`][resume-src].
-  CI renders PDF and DOCX artifacts.
+- **Résumé** – Latest résumé source stays in
+  [`resume.tex`][resume-src]. Runtime links use the stable [`/resume.pdf`](public/resume.pdf)
+  artifact, while [`public/docs/resume/2026-06/resume.pdf`](public/docs/resume/2026-06/resume.pdf)
+  remains the immutable dated PDF archive. CI also refreshes [`/resume.docx`](public/resume.docx)
+  as a stable downloadable DOCX artifact.
 - **Prompt library** – Automation-ready Codex prompts are summarized in
   [`summary.md`][prompt-summary] and expanded across topical files in
   `docs/prompts/codex/` (automation, lighting, avatar, HUD, POIs, accessibility, and more).
@@ -156,8 +158,8 @@ lightweight.
 - **Launch smoke** – `npm run smoke` builds once, validates bundled output references, and reports
   manual static binary assets (resume/favicon) as warnings by default.
 - **Strict manual static verification** – run `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` after
-  Daniel manually adds binary assets (for example `favicon.ico` and resume PDFs) so missing source
-  or `dist/` artifacts fail fast.
+  Daniel manually adds binary assets (for example `favicon.ico`, stable `/resume.pdf`, and
+  dated resume archives) so missing source or `dist/` artifacts fail fast.
 - **Link preview heuristics** – Automated user-agent checks steer social/chat crawlers
   (Facebook, Twitter, Slack, Discord, LinkedIn, Telegram, WhatsApp, Skype, GPTBot,
   ClaudeBot, ByteSpider, and others) to the text tour so share cards render without

--- a/docs/resume/README.md
+++ b/docs/resume/README.md
@@ -4,4 +4,6 @@
 - Build locally with [`latexmk`](https://ctan.org/pkg/latexmk) or [`pandoc`](https://pandoc.org/) if you need quick PDF or DOCX outputs.
 - Continuous Integration automatically builds both `.pdf` and `.docx` artifacts on pull requests and pushes to `main` that touch `docs/resume/**` or the resume workflow.
 - The workflow treats the lexicographically latest `YYYY-MM` directory under `docs/resume/` as the active source. On `main`, it publishes generated files to `public/docs/resume/<version>/` and refreshes the stable `public/resume.*` aliases without writing build outputs back into `docs/resume/`.
+- Runtime site links should target `/resume.pdf`, the stable public PDF artifact. Use `/resume.docx` only when a DOCX download is specifically helpful.
+- Keep `public/docs/resume/2026-06/resume.pdf` as the immutable dated PDF archive for this source version; older dated archives remain historical references and should not drive active runtime links.
 - The automated test suite compiles the latest dated résumé with [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux binaries if they are not already on your `PATH` (other platforms should install the tools manually).

--- a/src/tests/resumeRuntime.test.ts
+++ b/src/tests/resumeRuntime.test.ts
@@ -1,0 +1,127 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { AVAILABLE_LOCALES, getSiteStrings } from '../assets/i18n';
+
+const require = createRequire(import.meta.url);
+const PROJECT_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..'
+);
+const INDEX_HTML = path.join(PROJECT_ROOT, 'index.html');
+const STABLE_RESUME_PDF = '/resume.pdf';
+const LEGACY_RESUME_VERSION = ['2025', '09'].join('-');
+const LEGACY_SEPTEMBER_RESUME = [
+  '/docs/resume',
+  LEGACY_RESUME_VERSION,
+  'resume.pdf',
+].join('/');
+const ACTIVE_SOURCE_ROOTS = [
+  'index.html',
+  'src',
+  'scripts',
+  'README.md',
+  'docs',
+];
+const ARCHIVE_RESUME_PDF = '/docs/resume/2026-06/resume.pdf';
+
+const { runtimeAssetExpectations } =
+  require('../../scripts/static-asset-expectations.cjs') as {
+    runtimeAssetExpectations: Array<{ path: string; reason: string }>;
+  };
+
+function collectTextFiles(entry: string): string[] {
+  const absoluteEntry = path.join(PROJECT_ROOT, entry);
+  if (!existsSync(absoluteEntry)) {
+    return [];
+  }
+  const stat = statSync(absoluteEntry);
+  if (stat.isFile()) {
+    return [absoluteEntry];
+  }
+  return readdirSync(absoluteEntry, { withFileTypes: true }).flatMap((item) => {
+    const relativePath = path.join(entry, item.name);
+    if (relativePath === path.join('docs', 'resume', LEGACY_RESUME_VERSION)) {
+      return [];
+    }
+    if (item.isDirectory()) {
+      return collectTextFiles(relativePath);
+    }
+    return item.isFile() ? [path.join(PROJECT_ROOT, relativePath)] : [];
+  });
+}
+
+describe('runtime resume URL contract', () => {
+  it('uses the stable resume PDF in the no-script fallback', () => {
+    const html = readFileSync(INDEX_HTML, 'utf8');
+
+    expect(html).toContain(`href="${STABLE_RESUME_PDF}"`);
+    expect(html).not.toContain(LEGACY_SEPTEMBER_RESUME);
+  });
+
+  it('uses the stable resume PDF in localized runtime link definitions', () => {
+    const runtimeResumeUrls = AVAILABLE_LOCALES.map(
+      (locale) => getSiteStrings(locale).textFallback.contact.resumeUrl
+    );
+
+    for (const resumeUrl of runtimeResumeUrls) {
+      expect(resumeUrl).toContain(STABLE_RESUME_PDF);
+      expect(resumeUrl).not.toContain(LEGACY_RESUME_VERSION);
+    }
+  });
+
+  it('requires the stable resume PDF during static smoke validation', () => {
+    expect(runtimeAssetExpectations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: STABLE_RESUME_PDF }),
+      ])
+    );
+    expect(existsSync(path.join(PROJECT_ROOT, 'public', 'resume.pdf'))).toBe(
+      true
+    );
+  });
+
+  it('keeps active source files off the September 2025 resume archive', () => {
+    const offenders = collectTextFilesFromActiveSources()
+      .filter((filePath) => !isBinary(filePath))
+      .filter((filePath) =>
+        readFileSync(filePath, 'utf8').includes(LEGACY_SEPTEMBER_RESUME)
+      );
+
+    expect(
+      offenders.map((filePath) => path.relative(PROJECT_ROOT, filePath))
+    ).toEqual([]);
+  });
+
+  it('permits immutable dated resume archives alongside stable artifacts', () => {
+    expect(
+      existsSync(path.join(PROJECT_ROOT, 'public', ARCHIVE_RESUME_PDF))
+    ).toBe(true);
+    expect(existsSync(path.join(PROJECT_ROOT, 'public', 'resume.docx'))).toBe(
+      true
+    );
+  });
+});
+
+function collectTextFilesFromActiveSources(): string[] {
+  return ACTIVE_SOURCE_ROOTS.flatMap(collectTextFiles);
+}
+
+function isBinary(filePath: string): boolean {
+  return [
+    '.pdf',
+    '.docx',
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.ico',
+    '.webp',
+    '.avif',
+    '.gif',
+  ].includes(path.extname(filePath).toLowerCase());
+}


### PR DESCRIPTION
### Motivation
- Make `/resume.pdf` the canonical runtime résumé URL across active site surfaces while preserving dated generated archives as immutable history. 
- Keep the résumé source pointer unchanged (dated `docs/resume/` source) and avoid changing generated binaries or the artifact workflow.

### Description
- Document the stable runtime artifact by updating `README.md` to reference `/resume.pdf` as the canonical runtime link and mention `/resume.docx` as an available download. 
- Clarify `docs/resume/README.md` to instruct runtime links target `/resume.pdf` and to keep `public/docs/resume/2026-06/resume.pdf` as the immutable dated archive. 
- Add focused regression coverage in `src/tests/resumeRuntime.test.ts` that validates the no-script fallback, localized runtime link definitions, static-asset expectations include `/resume.pdf`, active sources do not reference the 2025-09 dated PDF, and dated archives remain present in `public/`.

### Testing
- Ran `npm run format:write` and formatting was applied successfully. 
- Ran `npm run lint` and it completed successfully (no blocking errors; only non-blocking warnings during earlier iterations). 
- Ran `npm run test:ci` and the full Vitest suite completed successfully; the new `src/tests/resumeRuntime.test.ts` also passed when run directly. 
- Ran `npm run docs:check` which passed (external reachability warnings are treated as warnings by the checker). 
- Ran `REQUIRE_MANUAL_STATIC_ASSETS=1 npm run smoke` and the strict smoke check passed with `public/resume.pdf` and dated archives present. 
- Verified with ripgrep that no active runtime files reference `/docs/resume/2025-09/resume.pdf` or `2025-09` outside the intentional archive paths using `rg -n "/docs/resume/2025-09/resume\.pdf|2025-09" index.html src scripts README.md docs --glob '!docs/resume/2025-09/**' --glob '!outages/**'` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d4634d3c832fb335ea90aacdeeb2)