### PR TITLE
Add resume GCS deployment workflow

### DIFF
--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -1,0 +1,223 @@
+name: Deploy resume to GCS
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'public/resume.pdf'
+      - '.github/workflows/resume-gcs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: resume-gcs-deploy
+  cancel-in-progress: false
+
+env:
+  LOCAL_RESUME_PATH: public/resume.pdf
+
+jobs:
+  deploy:
+    name: Deploy stable resume PDF
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate repository variables and source PDF
+        id: config
+        shell: bash
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
+          RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
+          RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for name in \
+            GCP_PROJECT_ID \
+            GCP_WORKLOAD_IDENTITY_PROVIDER \
+            GCP_SERVICE_ACCOUNT \
+            RESUME_GCS_DESTINATION \
+            RESUME_PUBLIC_URL \
+            RESUME_STORAGE_PUBLIC_URL; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Required repository variable ${name} is not configured."
+              missing=1
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            echo "Configure the missing repository variables before deploying the resume." >&2
+            exit 1
+          fi
+
+          if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
+            echo "::error::${LOCAL_RESUME_PATH} is missing or empty. P6 must run first and commit the stable resume PDF to main."
+            exit 1
+          fi
+          if ! head -c 5 "${LOCAL_RESUME_PATH}" | grep -q '%PDF-'; then
+            echo "::error::${LOCAL_RESUME_PATH} is not a PDF byte stream. P6 must publish the stable PDF before this deployment can run."
+            exit 1
+          fi
+
+          local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
+          {
+            echo "gcp_project_id=${GCP_PROJECT_ID}"
+            echo "gcp_workload_identity_provider=${GCP_WORKLOAD_IDENTITY_PROVIDER}"
+            echo "gcp_service_account=${GCP_SERVICE_ACCOUNT}"
+            echo "resume_gcs_destination=${RESUME_GCS_DESTINATION}"
+            echo "resume_public_url=${RESUME_PUBLIC_URL}"
+            echo "resume_storage_public_url=${RESUME_STORAGE_PUBLIC_URL}"
+            echo "local_sha256=${local_sha256}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ steps.config.outputs.gcp_project_id }}
+          workload_identity_provider: ${{ steps.config.outputs.gcp_workload_identity_provider }}
+          service_account: ${{ steps.config.outputs.gcp_service_account }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload stable resume PDF
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          destination='${{ steps.config.outputs.resume_gcs_destination }}'
+          gcloud storage cp "${LOCAL_RESUME_PATH}" "${destination}" \
+            --content-type='application/pdf' \
+            --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
+            --cache-control='public, max-age=300, must-revalidate'
+
+          # Preserve existing object ACLs and add/confirm the public read grant required by
+          # resume.danielsmith.io. Do not change bucket IAM or uniform bucket-level access.
+          gcloud storage objects update "${destination}" \
+            --add-acl-grant=entity=allUsers,role=READER
+
+      - name: Verify deployed public PDF
+        id: verify
+        shell: bash
+        env:
+          LOCAL_SHA256: ${{ steps.config.outputs.local_sha256 }}
+          RESUME_GCS_DESTINATION: ${{ steps.config.outputs.resume_gcs_destination }}
+          RESUME_PUBLIC_URL: ${{ steps.config.outputs.resume_public_url }}
+          RESUME_STORAGE_PUBLIC_URL: ${{ steps.config.outputs.resume_storage_public_url }}
+        run: |
+          set -euo pipefail
+
+          append_cache_buster() {
+            case "$1" in
+              *\?*) printf '%s&cb=%s' "$1" "$2" ;;
+              *) printf '%s?cb=%s' "$1" "$2" ;;
+            esac
+          }
+
+          check_pdf_response() {
+            local label="$1"
+            local url="$2"
+            local output="$3"
+            local headers="$4"
+            local busted_url
+            local sha
+            local content_type
+            local content_disposition
+
+            busted_url="$(append_cache_buster "${url}" "${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}")"
+            curl --fail --silent --show-error --location \
+              --dump-header "${headers}" \
+              --output "${output}" \
+              "${busted_url}"
+
+            if [ ! -s "${output}" ]; then
+              echo "::error::${label} returned an empty response."
+              exit 1
+            fi
+            if ! head -c 5 "${output}" | grep -q '%PDF-'; then
+              echo "::error::${label} did not return a PDF byte stream."
+              exit 1
+            fi
+
+            content_type="$(awk 'BEGIN{IGNORECASE=1} /^content-type:/ {sub(/^[^:]*:[[:space:]]*/, ""); sub(/\r$/, ""); value=$0} END{print value}' "${headers}")"
+            content_disposition="$(awk 'BEGIN{IGNORECASE=1} /^content-disposition:/ {sub(/^[^:]*:[[:space:]]*/, ""); sub(/\r$/, ""); value=$0} END{print value}' "${headers}")"
+            if [[ ! "${content_type}" =~ application/pdf ]]; then
+              echo "::error::${label} Content-Type must include application/pdf; observed '${content_type:-<missing>}'."
+              exit 1
+            fi
+            if [ -n "${content_disposition}" ] && [[ ! "${content_disposition}" =~ (^|[[:space:];])inline($|[[:space:];]) ]]; then
+              echo "::error::${label} Content-Disposition must be inline when present; observed '${content_disposition}'."
+              exit 1
+            fi
+
+            sha="$(sha256sum "${output}" | awk '{print $1}')"
+            if [ "${sha}" != "${LOCAL_SHA256}" ]; then
+              echo "::error::${label} SHA-256 ${sha} does not match local SHA-256 ${LOCAL_SHA256}."
+              exit 1
+            fi
+
+            {
+              echo "${label}_sha256=${sha}"
+              echo "${label}_content_type=${content_type}"
+              echo "${label}_content_disposition=${content_disposition:-<absent>}"
+            } >>"${GITHUB_OUTPUT}"
+
+            if [ -z "${content_disposition}" ]; then
+              echo "::warning::${label} did not surface Content-Disposition; continuing because public Cloud Storage/custom-domain responses may omit it."
+            fi
+          }
+
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "${tmpdir}"' EXIT
+
+          check_pdf_response storage "${RESUME_STORAGE_PUBLIC_URL}" \
+            "${tmpdir}/storage.pdf" "${tmpdir}/storage.headers"
+          check_pdf_response canonical "${RESUME_PUBLIC_URL}" \
+            "${tmpdir}/canonical.pdf" "${tmpdir}/canonical.headers"
+
+          acl_roles="$(
+            gcloud storage objects describe "${RESUME_GCS_DESTINATION}" \
+              --format='value(acl[?entity=allUsers].role)'
+          )"
+          if printf '%s\n' "${acl_roles}" | grep -Eq '(^|[[:space:]])(READER|Reader)([[:space:]]|$)'; then
+            acl_status='allUsers Reader object ACL present'
+          else
+            echo "::error::Uploaded object does not report allUsers Reader in its object ACL."
+            exit 1
+          fi
+          echo "acl_status=${acl_status}" >>"${GITHUB_OUTPUT}"
+
+      - name: Write deployment summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Resume GCS deployment"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Source commit | \`${GITHUB_SHA}\` |"
+            echo "| Local file | \`${LOCAL_RESUME_PATH}\` |"
+            echo "| Destination GCS URI | \`${{ steps.config.outputs.resume_gcs_destination }}\` |"
+            echo "| Storage URL | ${{ steps.config.outputs.resume_storage_public_url }} |"
+            echo "| Canonical public URL | ${{ steps.config.outputs.resume_public_url }} |"
+            echo "| Local SHA-256 | \`${{ steps.config.outputs.local_sha256 }}\` |"
+            echo "| Storage URL SHA-256 | \`${{ steps.verify.outputs.storage_sha256 || 'not verified' }}\` |"
+            echo "| Canonical URL SHA-256 | \`${{ steps.verify.outputs.canonical_sha256 || 'not verified' }}\` |"
+            echo "| Storage Content-Type | \`${{ steps.verify.outputs.storage_content_type || 'not observed' }}\` |"
+            echo "| Canonical Content-Type | \`${{ steps.verify.outputs.canonical_content_type || 'not observed' }}\` |"
+            echo "| Storage Content-Disposition | \`${{ steps.verify.outputs.storage_content_disposition || 'not observed' }}\` |"
+            echo "| Canonical Content-Disposition | \`${{ steps.verify.outputs.canonical_content_disposition || 'not observed' }}\` |"
+            echo "| Object ACL/public-read | \`${{ steps.verify.outputs.acl_status || 'not verified' }}\` |"
+            echo "| Final deployment status | \`${{ job.status }}\` |"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   URL for runtime links, while `/resume.docx` is the stable downloadable DOCX
   URL (served from `public/resume.docx`) when a word-processor copy is useful. The immutable
   dated PDF archive for this source snapshot lives at
-  `public/docs/resume/2026-06/resume.pdf`.
+  `public/docs/resume/2026-06/resume.pdf`. Resume custom-domain hosting and GCS
+  deployment operations are documented in
+  [`docs/ops/resume-hosting.md`](docs/ops/resume-hosting.md).
 - **Prompt library** – Automation-ready Codex prompts are summarized in
   [`summary.md`][prompt-summary] and expanded across topical files in
   `docs/prompts/codex/` (automation, lighting, avatar, HUD, POIs, accessibility, and more).

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -1,0 +1,187 @@
+# Resume custom-domain hosting runbook
+
+This runbook covers the dedicated resume host at `resume.danielsmith.io`. It does not cover the
+main `danielsmith.io` static-site deployment, Cloudflare DNS, load balancers, certificates, bucket
+website settings, or any bucket creation.
+
+## Current hosting model
+
+- Google Cloud Storage bucket: `resume.danielsmith.io`.
+- Deployed object: `Daniel_Smith_Resume.pdf`.
+- Upload destination: `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`.
+- Public Cloud Storage URL:
+  `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf`.
+- Canonical public URL: `https://resume.danielsmith.io`.
+- Public access is object-level. The object ACL includes `allUsers` with `Reader` access.
+- The `danielsmith` and `danielsmith.io` buckets are separate web-hosting targets and are out of
+  scope for this workflow.
+
+P6 produces and persists the stable `public/resume.pdf` artifact in this repository. P8 deploys
+that exact PDF byte-for-byte to the existing Cloud Storage object above. The deployment must not
+compile TeX, regenerate resume artifacts, deploy `public/resume.docx`, rename the Cloud Storage
+object, or edit generated PDF bytes.
+
+## Automated deployment
+
+The **Deploy resume to GCS** workflow (`.github/workflows/resume-gcs.yml`) runs on:
+
+- pushes to `main` that change `public/resume.pdf` or the workflow file; and
+- manual `workflow_dispatch` runs.
+
+The workflow never runs on `pull_request`. It checks that `public/resume.pdf` exists before Google
+Cloud authentication so a missing stable artifact fails with a clear message that P6 must run first.
+It authenticates with GitHub OIDC and Google Workload Identity Federation, uploads only
+`public/resume.pdf`, sets PDF metadata, adds or confirms the `allUsers` `Reader` object ACL, and
+verifies both public URLs by downloading them without authentication and comparing SHA-256 checksums
+against the committed file.
+
+Required repository variables:
+
+| Variable                         | Expected value                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| `GCP_PROJECT_ID`                 | Google Cloud project ID for the observed `danielsmith io` project              |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name                                  |
+| `GCP_SERVICE_ACCOUNT`            | Deployment service account email                                               |
+| `RESUME_GCS_DESTINATION`         | `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`                           |
+| `RESUME_PUBLIC_URL`              | `https://resume.danielsmith.io`                                                |
+| `RESUME_STORAGE_PUBLIC_URL`      | `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` |
+
+### Google Workload Identity Federation setup
+
+At a high level, configure:
+
+1. A dedicated Google service account for this resume deployment.
+2. A GitHub OIDC Workload Identity Provider.
+3. A repository-scoped trust condition for `futuroptimist/danielsmith.io`.
+4. Service account impersonation from that provider to the dedicated service account.
+5. Bucket-scoped permissions sufficient to write and update the object in
+   `resume.danielsmith.io`, including object ACL updates.
+
+Least-privilege guidance:
+
+- Prefer permissions scoped only to bucket `resume.danielsmith.io`.
+- Do not use project-wide Storage Admin except as a temporary troubleshooting measure.
+- Do not store service-account JSON keys or access tokens in GitHub.
+- Do not grant public write access.
+- Do not change bucket IAM or uniform bucket-level public access settings from this workflow.
+
+## Manual break-glass deployment
+
+Use this only when GitHub Actions is unavailable. Authenticate locally with `gcloud` as an identity
+that has bucket-scoped object write and ACL update permissions, then run from the repository root:
+
+```bash
+set -euo pipefail
+
+destination='gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf'
+storage_url='https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf'
+canonical_url='https://resume.danielsmith.io'
+local_pdf='public/resume.pdf'
+
+[ -s "${local_pdf}" ]
+head -c 5 "${local_pdf}" | grep -q '%PDF-'
+local_sha256="$(sha256sum "${local_pdf}" | awk '{print $1}')"
+
+gcloud storage cp "${local_pdf}" "${destination}" \
+  --content-type='application/pdf' \
+  --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
+  --cache-control='public, max-age=300, must-revalidate'
+
+gcloud storage objects update "${destination}" \
+  --add-acl-grant=entity=allUsers,role=READER
+
+for url in "${storage_url}" "${canonical_url}"; do
+  separator='?'
+  case "${url}" in *\?*) separator='&' ;; esac
+  tmp_pdf="$(mktemp)"
+  tmp_headers="$(mktemp)"
+  curl --fail --silent --show-error --location \
+    --dump-header "${tmp_headers}" \
+    --output "${tmp_pdf}" \
+    "${url}${separator}cb=$(date +%s)"
+  grep -i '^content-type:.*application/pdf' "${tmp_headers}"
+  head -c 5 "${tmp_pdf}" | grep -q '%PDF-'
+  test "$(sha256sum "${tmp_pdf}" | awk '{print $1}')" = "${local_sha256}"
+  rm -f "${tmp_pdf}" "${tmp_headers}"
+done
+```
+
+The upload command sets:
+
+- `Content-Type: application/pdf`
+- `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"`
+- `Cache-Control: public, max-age=300, must-revalidate`
+
+The ACL command adds or confirms `allUsers` `Reader` on the object without intentionally replacing
+other object ACL grants.
+
+## Run `workflow_dispatch`
+
+1. Open GitHub Actions for `futuroptimist/danielsmith.io`.
+2. Select **Deploy resume to GCS**.
+3. Choose **Run workflow** on `main`.
+4. Confirm the summary reports matching local, storage URL, and canonical URL SHA-256 values.
+
+## Verify from a shell
+
+```bash
+set -euo pipefail
+local_pdf='public/resume.pdf'
+local_sha256="$(sha256sum "${local_pdf}" | awk '{print $1}')"
+for url in \
+  'https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf' \
+  'https://resume.danielsmith.io'; do
+  tmp_pdf="$(mktemp)"
+  tmp_headers="$(mktemp)"
+  separator='?'
+  case "${url}" in *\?*) separator='&' ;; esac
+  curl --fail --silent --show-error --location \
+    --dump-header "${tmp_headers}" \
+    --output "${tmp_pdf}" \
+    "${url}${separator}cb=$(date +%s)"
+  grep -i '^content-type:.*application/pdf' "${tmp_headers}"
+  head -c 5 "${tmp_pdf}" | grep -q '%PDF-'
+  test "$(sha256sum "${tmp_pdf}" | awk '{print $1}')" = "${local_sha256}"
+  rm -f "${tmp_pdf}" "${tmp_headers}"
+done
+```
+
+`Content-Disposition` should be `inline` when surfaced. Some public Cloud Storage or custom-domain
+paths may omit that header; treat absence as a warning if the response is a non-empty PDF with the
+expected checksum and `application/pdf` content type.
+
+## Rollback
+
+Rollback by changing the repository artifact and letting the workflow redeploy:
+
+- revert or cherry-pick a prior Git commit that contains the previous `public/resume.pdf`; or
+- copy a prior `public/docs/resume/<version>/resume.pdf` over `public/resume.pdf` in a rollback PR.
+
+After merge to `main`, the deployment workflow uploads that committed PDF byte-for-byte to the
+existing object. Do not roll back by editing the GCS object name, DNS, bucket settings, or resume
+custom-domain behavior.
+
+## Troubleshooting
+
+- **Missing repository variables**: the first workflow step fails before authentication and lists
+  each missing variable. Configure the variables in repository settings.
+- **OIDC trust failures**: confirm the Workload Identity Provider resource name and the trust
+  condition for `futuroptimist/danielsmith.io`.
+- **Service account impersonation failures**: confirm the GitHub principal set can impersonate the
+  deployment service account.
+- **Bucket permission failures**: confirm the service account has bucket-scoped object write and
+  metadata update permissions on `resume.danielsmith.io`.
+- **Object ACL/public-read failures**: confirm the bucket allows object-level ACLs and that the
+  service account can update object ACLs. The workflow should add `allUsers` `Reader`, not bucket
+  IAM.
+- **Content-Type mismatch**: rerun the workflow or manual upload so the object metadata is set to
+  `application/pdf`.
+- **Content-Disposition mismatch**: rerun upload metadata updates. Absence can be a warning for
+  some public paths, but a non-inline value should be fixed.
+- **Canonical URL does not match storage URL**: check custom-domain routing and cache layers outside
+  this repo; do not change DNS or Cloudflare as part of this workflow.
+- **Cache propagation**: the workflow appends cache-busting query parameters and sets
+  `Cache-Control: public, max-age=300, must-revalidate`; wait for short-lived caches to expire if a
+  browser still sees old bytes.
+- **Checksum mismatch**: stop rollout, compare the downloaded files with `public/resume.pdf`, and
+  redeploy the committed stable artifact once the source of byte drift is understood.


### PR DESCRIPTION
### Motivation
- Provide a secure, repeatable GitHub Actions path to publish the committed `public/resume.pdf` artifact to the existing `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf` object. 
- Use GitHub OIDC Workload Identity Federation rather than long-lived JSON keys to follow least-privilege security practices. 
- Ensure uploads preserve public readability and are verified byte-for-byte against the committed PDF before treating a deployment as successful.

### Description
- Add `.github/workflows/resume-gcs.yml`, a `main`-only + `workflow_dispatch` job that validates required repository `vars.*` before authenticating, uses `google-github-actions/auth@v2` + `google-github-actions/setup-gcloud@v2`, and uploads only `public/resume.pdf` to the configured `RESUME_GCS_DESTINATION` with metadata: `Content-Type: application/pdf`, `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"`, and `Cache-Control: public, max-age=300, must-revalidate`.
- Preserve/reapply object-level public readability by running `gcloud storage objects update "$DEST" --add-acl-grant=entity=allUsers,role=READER` and avoid changing bucket IAM or using predefined public-read ACLs.
- Add verification steps that compute local SHA-256, fetch both `RESUME_STORAGE_PUBLIC_URL` and `RESUME_PUBLIC_URL` with a cache-busting query param, validate non-empty PDF bytes and `application/pdf` content type (allowing absent Content-Disposition as a warning), compare remote SHA-256 to local SHA-256, check object ACL evidence, and emit a detailed job summary with the evidence fields required by the runbook.
- Add `docs/ops/resume-hosting.md` documenting the hosting model, required repository variables, WIF setup guidance, manual break-glass `gcloud` commands, verification scripts, rollback instructions, and troubleshooting; and link that runbook from the README for discoverability.

### Testing
- Ran formatting and lint checks: `npm run format:write` (applied), `npm run format:check` (passed), and `npm run lint` (passed). 
- Ran unit and smoke suites: `npm run test:ci` (Vitest; test run completed: tests passed), and `npm run smoke` (build + smoke assertions passed). 
- Ran docs checks and repository validations: `npm run docs:check` (passed; emitted existing external-link reachability warnings), `git diff --check` (no issues), and `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets found). 
- Exercised the workflow’s verification logic locally by computing the local PDF SHA-256 and fetching both public endpoints using the same cache-busting and header inspection logic; local file validated as a PDF and both public endpoints were fetched, but the fetched public object bytes currently do not match the committed `public/resume.pdf` SHA-256 (this is an observation of the live object prior to running the workflow and is expected to be resolved by an authorised deployment). 

Notes: `actionlint` and `shellcheck` were not available in the environment and were skipped; production upload/verification requires the repository variables (`GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `RESUME_GCS_DESTINATION`, `RESUME_PUBLIC_URL`, `RESUME_STORAGE_PUBLIC_URL`) and a correctly-configured Google WIF/service account as documented in `docs/ops/resume-hosting.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371249801c832fac785ae9d98e06b8)