### PR TITLE
Add secure resume GCS deployment workflow and runbook

### DIFF
--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -1,0 +1,259 @@
+name: Deploy resume to GCS
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - public/resume.pdf
+      - .github/workflows/resume-gcs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: resume-gcs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy stable resume PDF
+    runs-on: ubuntu-latest
+    env:
+      LOCAL_RESUME_PATH: public/resume.pdf
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
+      RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
+      RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
+      RESUME_CONTENT_DISPOSITION: inline; filename="Daniel_Smith_Resume.pdf"
+      RESUME_CACHE_CONTROL: public, max-age=300, must-revalidate
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate deployment inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for var_name in \
+            GCP_PROJECT_ID \
+            GCP_WORKLOAD_IDENTITY_PROVIDER \
+            GCP_SERVICE_ACCOUNT \
+            RESUME_GCS_DESTINATION \
+            RESUME_PUBLIC_URL \
+            RESUME_STORAGE_PUBLIC_URL; do
+            if [ -z "${!var_name:-}" ]; then
+              echo "::error::Missing required repository variable: ${var_name}"
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            echo "Configure the missing repository variables before deploying the resume."
+            exit 1
+          fi
+
+          if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
+            echo "::error::${LOCAL_RESUME_PATH} is missing or empty. P6 must run first and commit the stable resume PDF to main."
+            exit 1
+          fi
+
+          if [ "$(head -c 5 "${LOCAL_RESUME_PATH}")" != "%PDF-" ]; then
+            echo "::error::${LOCAL_RESUME_PATH} is not a PDF file. P6 must publish a valid stable resume PDF first."
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Upload resume PDF
+        id: upload
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
+
+          gcloud storage cp "${LOCAL_RESUME_PATH}" "${RESUME_GCS_DESTINATION}"
+          gcloud storage objects update "${RESUME_GCS_DESTINATION}" \
+            --content-type="application/pdf" \
+            --content-disposition="${RESUME_CONTENT_DISPOSITION}" \
+            --cache-control="${RESUME_CACHE_CONTROL}"
+          gcloud storage objects update "${RESUME_GCS_DESTINATION}" \
+            --add-acl-grant=entity=allUsers,role=READER
+
+          {
+            echo "local_sha256=${local_sha256}"
+            echo "public_read_acl=allUsers READER grant applied"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Verify public resume endpoints
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          append_cache_buster() {
+            local url="$1"
+            local buster="$2"
+            case "${url}" in
+              *\?*) printf '%s&resume_deploy_cache_bust=%s' "${url}" "${buster}" ;;
+              *) printf '%s?resume_deploy_cache_bust=%s' "${url}" "${buster}" ;;
+            esac
+          }
+
+          fetch_pdf() {
+            local label="$1"
+            local url="$2"
+            local body_path="$3"
+            local header_path="$4"
+            local busted_url
+            busted_url="$(append_cache_buster "${url}" "${GITHUB_SHA}-${GITHUB_RUN_ID}-${label}")"
+
+            curl --fail --silent --show-error --location \
+              --dump-header "${header_path}" \
+              --output "${body_path}" \
+              "${busted_url}"
+
+            if [ ! -s "${body_path}" ]; then
+              echo "::error::${label} response body was empty."
+              exit 1
+            fi
+
+            if [ "$(head -c 5 "${body_path}")" != "%PDF-" ]; then
+              echo "::error::${label} response was not a PDF byte stream."
+              exit 1
+            fi
+          }
+
+          header_value() {
+            local header_path="$1"
+            local header_name="$2"
+            awk -v name="${header_name}" '
+              BEGIN { IGNORECASE = 1 }
+              $0 ~ "^" name ":" {
+                sub("^[^:]*:[[:space:]]*", "")
+                value = $0
+                gsub("\r", "", value)
+              }
+              END { print value }
+            ' "${header_path}"
+          }
+
+          require_pdf_content_type() {
+            local label="$1"
+            local content_type="$2"
+            case "${content_type}" in
+              *application/pdf*) ;;
+              *)
+                echo "::error::${label} Content-Type must include application/pdf; observed '${content_type}'."
+                exit 1
+                ;;
+            esac
+          }
+
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "${tmp_dir}"' EXIT
+
+          storage_body="${tmp_dir}/storage.pdf"
+          storage_headers="${tmp_dir}/storage.headers"
+          canonical_body="${tmp_dir}/canonical.pdf"
+          canonical_headers="${tmp_dir}/canonical.headers"
+
+          fetch_pdf storage "${RESUME_STORAGE_PUBLIC_URL}" "${storage_body}" "${storage_headers}"
+          fetch_pdf canonical "${RESUME_PUBLIC_URL}" "${canonical_body}" "${canonical_headers}"
+
+          local_sha256="${{ steps.upload.outputs.local_sha256 }}"
+          storage_sha256="$(sha256sum "${storage_body}" | awk '{print $1}')"
+          canonical_sha256="$(sha256sum "${canonical_body}" | awk '{print $1}')"
+
+          if [ "${storage_sha256}" != "${local_sha256}" ]; then
+            echo "::error::Storage URL checksum ${storage_sha256} did not match local checksum ${local_sha256}."
+            exit 1
+          fi
+          if [ "${canonical_sha256}" != "${local_sha256}" ]; then
+            echo "::error::Canonical URL checksum ${canonical_sha256} did not match local checksum ${local_sha256}."
+            exit 1
+          fi
+
+          storage_content_type="$(header_value "${storage_headers}" Content-Type)"
+          canonical_content_type="$(header_value "${canonical_headers}" Content-Type)"
+          storage_content_disposition="$(header_value "${storage_headers}" Content-Disposition)"
+          canonical_content_disposition="$(header_value "${canonical_headers}" Content-Disposition)"
+
+          require_pdf_content_type storage "${storage_content_type}"
+          require_pdf_content_type canonical "${canonical_content_type}"
+
+          content_disposition_warning="none"
+          for observed in "storage:${storage_content_disposition}" "canonical:${canonical_content_disposition}"; do
+            label="${observed%%:*}"
+            value="${observed#*:}"
+            case "${value}" in
+              "" )
+                content_disposition_warning="${content_disposition_warning}; ${label} Content-Disposition absent"
+                ;;
+              inline*|Inline*|INLINE*) ;;
+              *)
+                echo "::error::${label} Content-Disposition must be inline when present; observed '${value}'."
+                exit 1
+                ;;
+            esac
+          done
+
+          if [ "${content_disposition_warning}" != "none" ]; then
+            echo "::warning::${content_disposition_warning#none; }"
+          fi
+
+          {
+            echo "storage_sha256=${storage_sha256}"
+            echo "canonical_sha256=${canonical_sha256}"
+            echo "storage_content_type=${storage_content_type}"
+            echo "canonical_content_type=${canonical_content_type}"
+            echo "storage_content_disposition=${storage_content_disposition:-absent}"
+            echo "canonical_content_disposition=${canonical_content_disposition:-absent}"
+            echo "content_disposition_warning=${content_disposition_warning}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Report deployment summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          final_status="success"
+          if [ "${{ job.status }}" != "success" ]; then
+            final_status="${{ job.status }}"
+          fi
+
+          {
+            echo "## Resume GCS deployment"
+            echo
+            echo "- Source commit SHA: \`${GITHUB_SHA}\`"
+            echo "- Local file path: \`${LOCAL_RESUME_PATH}\`"
+            echo "- Destination GCS URI: \`${RESUME_GCS_DESTINATION:-not configured}\`"
+            echo "- Storage URL: \`${RESUME_STORAGE_PUBLIC_URL:-not configured}\`"
+            echo "- Canonical public URL: \`${RESUME_PUBLIC_URL:-not configured}\`"
+            echo "- Local SHA-256: \`${{ steps.upload.outputs.local_sha256 || 'not computed' }}\`"
+            echo "- Storage URL SHA-256: \`${{ steps.verify.outputs.storage_sha256 || 'not verified' }}\`"
+            echo "- Canonical URL SHA-256: \`${{ steps.verify.outputs.canonical_sha256 || 'not verified' }}\`"
+            echo "- Storage Content-Type: \`${{ steps.verify.outputs.storage_content_type || 'not verified' }}\`"
+            echo "- Canonical Content-Type: \`${{ steps.verify.outputs.canonical_content_type || 'not verified' }}\`"
+            echo "- Storage Content-Disposition: \`${{ steps.verify.outputs.storage_content_disposition || 'not verified' }}\`"
+            echo "- Canonical Content-Disposition: \`${{ steps.verify.outputs.canonical_content_disposition || 'not verified' }}\`"
+            echo "- Object ACL/public-read verification: \`${{ steps.upload.outputs.public_read_acl || 'not applied' }}; unauthenticated public URL checksum verification ${{ steps.verify.outcome || 'not run' }}\`"
+            echo "- Final deployment status: \`${final_status}\`"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   URL for runtime links, while `/resume.docx` is the stable downloadable DOCX
   URL (served from `public/resume.docx`) when a word-processor copy is useful. The immutable
   dated PDF archive for this source snapshot lives at
-  `public/docs/resume/2026-06/resume.pdf`.
+  `public/docs/resume/2026-06/resume.pdf`. The resume hosting runbook documents the separate
+  GCS deployment path for `resume.danielsmith.io` in
+  [`docs/ops/resume-hosting.md`](docs/ops/resume-hosting.md).
 - **Prompt library** – Automation-ready Codex prompts are summarized in
   [`summary.md`][prompt-summary] and expanded across topical files in
   `docs/prompts/codex/` (automation, lighting, avatar, HUD, POIs, accessibility, and more).

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -1,0 +1,240 @@
+# Resume hosting runbook
+
+This runbook documents the stable resume artifact deployment path for
+`resume.danielsmith.io`. It only covers publishing the repository-owned PDF to
+the existing Google Cloud Storage object. It does not create buckets, change DNS,
+change Cloudflare, change load balancers, change certificates, alter bucket
+website settings, or modify the main `danielsmith.io` site deployment.
+
+## Current hosting model
+
+- Google Cloud project display name observed by the maintainer: `danielsmith io`.
+- Bucket: `resume.danielsmith.io`.
+- Object: `Daniel_Smith_Resume.pdf`.
+- Upload destination: `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`.
+- Public storage URL:
+  `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf`.
+- Canonical public URL: `https://resume.danielsmith.io`.
+- Public access is object-level. The object ACL includes `allUsers` with the
+  `Reader` role.
+- The buckets `danielsmith` and `danielsmith.io` are web-hosting buckets and are
+  out of scope for this resume deployment path.
+
+## Artifact lifecycle
+
+P6 builds the resume from `docs/resume/**` and persists the stable artifact at
+`public/resume.pdf` in the repository. P8 deploys that exact committed PDF
+byte-for-byte to `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf` without
+regenerating TeX, touching `public/resume.docx`, or changing the PDF bytes.
+
+The deployment workflow is `.github/workflows/resume-gcs.yml`. It runs on pushes
+to `main` that change `public/resume.pdf` or the workflow, and it also supports
+manual `workflow_dispatch` runs. Pull requests do not authenticate to Google
+Cloud and do not deploy.
+
+## Required repository variables
+
+Configure these GitHub repository variables before the first deployment:
+
+| Variable                         | Expected value                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| `GCP_PROJECT_ID`                 | Google Cloud project ID for the `danielsmith io` project                       |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name                                  |
+| `GCP_SERVICE_ACCOUNT`            | Deployment service account email                                               |
+| `RESUME_GCS_DESTINATION`         | `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`                           |
+| `RESUME_PUBLIC_URL`              | `https://resume.danielsmith.io`                                                |
+| `RESUME_STORAGE_PUBLIC_URL`      | `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` |
+
+The workflow fails before authentication or upload when any required variable is
+missing or when `public/resume.pdf` is absent, empty, or not a PDF. If
+`public/resume.pdf` is missing, run P6 first and let it commit the stable PDF to
+`main`.
+
+## Google Workload Identity Federation setup
+
+Use GitHub OIDC with Google Workload Identity Federation instead of storing a
+long-lived service-account JSON key in GitHub.
+
+At a high level:
+
+1. Create a dedicated Google service account for this resume deployment.
+2. Configure a GitHub OIDC Workload Identity Provider.
+3. Restrict provider trust to `futuroptimist/danielsmith.io` and the intended
+   branch/event claims.
+4. Allow that provider to impersonate the dedicated service account.
+5. Grant the service account only the bucket-scoped object permissions needed to
+   upload `Daniel_Smith_Resume.pdf`, update its metadata, and add or confirm the
+   object ACL grant for `allUsers` `Reader`.
+
+Prefer permissions scoped to the `resume.danielsmith.io` bucket. Do not use
+project-wide storage admin except as a temporary troubleshooting step. Do not
+store service-account JSON keys in GitHub secrets or variables.
+
+## Automated deployment behavior
+
+The workflow uploads only `public/resume.pdf` to
+`$RESUME_GCS_DESTINATION`. It then sets object metadata:
+
+- `Content-Type: application/pdf`
+- `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"`
+- `Cache-Control: public, max-age=300, must-revalidate`
+
+After upload, the workflow adds or confirms the object ACL grant with:
+
+```bash
+gcloud storage objects update "$RESUME_GCS_DESTINATION" \
+  --add-acl-grant=entity=allUsers,role=READER
+```
+
+This preserves the object-level public-read model without making the whole
+bucket public, granting public write access, changing bucket IAM, or changing
+uniform bucket-level access settings.
+
+The workflow computes the local SHA-256, downloads both public URLs with a
+cache-busting query parameter, verifies that both unauthenticated responses are
+non-empty PDF byte streams, checks that both content types include
+`application/pdf`, and requires both downloaded SHA-256 values to match the local
+file. `Content-Disposition` must be `inline` when present. If a public endpoint
+omits `Content-Disposition`, the workflow warns in the job summary instead of
+failing because Cloud Storage and custom-domain behavior can differ.
+
+## Manual break-glass deployment
+
+Use this only when the automated workflow is unavailable and you have already
+authenticated locally with `gcloud` as an operator permitted to update the resume
+object.
+
+```bash
+set -euo pipefail
+
+local_path="public/resume.pdf"
+destination="gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+storage_url="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+canonical_url="https://resume.danielsmith.io"
+
+if [ ! -s "${local_path}" ] || [ "$(head -c 5 "${local_path}")" != "%PDF-" ]; then
+  echo "${local_path} must exist and be a non-empty PDF. Run P6 first." >&2
+  exit 1
+fi
+
+local_sha256="$(sha256sum "${local_path}" | awk '{print $1}')"
+
+gcloud storage cp "${local_path}" "${destination}"
+gcloud storage objects update "${destination}" \
+  --content-type="application/pdf" \
+  --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
+  --cache-control="public, max-age=300, must-revalidate"
+gcloud storage objects update "${destination}" \
+  --add-acl-grant=entity=allUsers,role=READER
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+for label in storage canonical; do
+  if [ "${label}" = "storage" ]; then
+    url="${storage_url}"
+  else
+    url="${canonical_url}"
+  fi
+
+  case "${url}" in
+    *\?*) busted_url="${url}&manual_resume_deploy=$(date +%s)" ;;
+    *) busted_url="${url}?manual_resume_deploy=$(date +%s)" ;;
+  esac
+
+  body="${tmp_dir}/${label}.pdf"
+  headers="${tmp_dir}/${label}.headers"
+  curl --fail --silent --show-error --location \
+    --dump-header "${headers}" \
+    --output "${body}" \
+    "${busted_url}"
+
+  test -s "${body}"
+  test "$(head -c 5 "${body}")" = "%PDF-"
+  grep -i '^content-type:.*application/pdf' "${headers}"
+  test "$(sha256sum "${body}" | awk '{print $1}')" = "${local_sha256}"
+  sed -n '/^HTTP\//p;/^[Cc]ontent-[Tt]ype:/p;/^[Cc]ontent-[Dd]isposition:/p;/^[Cc]ache-[Cc]ontrol:/p' \
+    "${headers}"
+done
+```
+
+## Run `workflow_dispatch`
+
+1. Open the repository's **Actions** tab.
+2. Select **Deploy resume to GCS**.
+3. Choose **Run workflow** on `main`.
+4. Confirm the run summary lists matching local, storage URL, and canonical URL
+   SHA-256 values.
+
+## Verify deployment from a shell
+
+```bash
+set -euo pipefail
+
+local_path="public/resume.pdf"
+local_sha256="$(sha256sum "${local_path}" | awk '{print $1}')"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+for url in \
+  "https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf" \
+  "https://resume.danielsmith.io"; do
+  case "${url}" in
+    *\?*) busted_url="${url}&verify_resume=$(date +%s)" ;;
+    *) busted_url="${url}?verify_resume=$(date +%s)" ;;
+  esac
+  safe_name="$(printf '%s' "${url}" | tr -c 'A-Za-z0-9' '_')"
+  body="${tmp_dir}/${safe_name}.pdf"
+  headers="${tmp_dir}/${safe_name}.headers"
+  curl --fail --silent --show-error --location \
+    --dump-header "${headers}" \
+    --output "${body}" \
+    "${busted_url}"
+  test -s "${body}"
+  test "$(head -c 5 "${body}")" = "%PDF-"
+  grep -i '^content-type:.*application/pdf' "${headers}"
+  test "$(sha256sum "${body}" | awk '{print $1}')" = "${local_sha256}"
+done
+```
+
+## Rollback
+
+Use a normal pull request so the automated deployment path remains auditable:
+
+- Revert to a prior Git commit containing the previous `public/resume.pdf`, or
+- Copy a prior `public/docs/resume/<version>/resume.pdf` over the stable
+  `public/resume.pdf` in a rollback PR.
+
+After the rollback PR merges to `main`, the workflow redeploys that committed
+PDF to the existing GCS object.
+
+## Troubleshooting
+
+- **Missing repository variables:** the first workflow step fails with the exact
+  missing variable names. Configure all required `vars.*` values and rerun.
+- **Missing `public/resume.pdf`:** P6 has not produced the stable PDF yet. Run P6
+  first and wait for its commit to land on `main`.
+- **OIDC trust failures:** confirm the Workload Identity Provider accepts tokens
+  from `futuroptimist/danielsmith.io` for the intended branch and event.
+- **Service account impersonation failures:** confirm the provider principal has
+  permission to impersonate the deployment service account.
+- **Bucket permission failures:** confirm the service account can write objects,
+  update object metadata, and update object ACLs for `resume.danielsmith.io`.
+- **Object ACL/public-read failures:** confirm object ACLs are enabled for the
+  bucket and the service account can add `allUsers` `Reader` to the object.
+- **Content-Type mismatch:** rerun the deployment so the workflow resets
+  `Content-Type` to `application/pdf`. Check for intermediary header rewriting if
+  only the canonical URL is wrong.
+- **Content-Disposition mismatch:** the storage URL should expose the inline
+  disposition after metadata update. If the canonical URL omits it but still
+  serves `application/pdf`, treat the workflow warning as acceptable unless user
+  experience changes.
+- **Canonical URL not matching storage URL:** check custom-domain routing and
+  cache behavior outside this workflow. Do not change DNS, Cloudflare, load
+  balancers, certificates, or bucket website settings as part of this deployment
+  path.
+- **Cache propagation:** cache busters should bypass normal browser caches, but
+  intermediaries may lag briefly. Recheck after the five-minute cache window.
+- **Checksum mismatch:** stop deployments, compare the local committed
+  `public/resume.pdf` to both downloaded endpoints, and verify that no stale cache
+  or wrong object path is being served.


### PR DESCRIPTION
### Motivation
- Provide a secure, repeatable CI path to publish the repository-stable `public/resume.pdf` to the existing `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf` object using GitHub OIDC / Google Workload Identity Federation instead of long-lived keys. 
- Ensure uploads set proper PDF metadata, preserve or reapply the object-level public-read ACL, and verify byte-for-byte correctness of both the storage and canonical public URLs. 
- Document the deployment, required repository variables, WIF setup guidance, manual break-glass steps, verification, rollback, and troubleshooting in a discoverable runbook.

### Description
- Add `.github/workflows/resume-gcs.yml` which triggers on `push` to `main` when `public/resume.pdf` or the workflow changes and on `workflow_dispatch`, uses `contents: read` and `id-token: write`, validates required `vars.*` early, authenticates via `google-github-actions/auth@v2`, uses `google-github-actions/setup-gcloud@v2`, uploads with `gcloud storage cp`, updates object metadata (`Content-Type`, `Content-Disposition`, `Cache-Control`), and reapplies object ACL via `--add-acl-grant=entity=allUsers,role=READER`. 
- The workflow computes a local SHA-256, downloads both `RESUME_STORAGE_PUBLIC_URL` and `RESUME_PUBLIC_URL` with a cache-busting query string, verifies both responses are non-empty PDFs, confirms `Content-Type` includes `application/pdf`, checks `Content-Disposition` (warns if absent), and requires both remote SHA-256 sums to match the local file before marking success. 
- Add `docs/ops/resume-hosting.md` describing hosting model, required repository variables (`GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `RESUME_GCS_DESTINATION`, `RESUME_PUBLIC_URL`, `RESUME_STORAGE_PUBLIC_URL`), WIF setup notes, manual break-glass commands, verification/rollback instructions, and troubleshooting guidance. 
- Link the runbook from the README résumé section and confirm no binary artifacts (the committed `public/resume.pdf`) were modified by this change.

### Testing
- Ran formatting and linting: `npm run format:write` (applied formatting to the new files) and `npm run format:check` (passed), and `npm run lint` (passed). 
- Docs and link checks: `npm run docs:check` passed; the repo link checker emitted existing external reachability warnings (informational, pre-existing). 
- Unit and integration tests: `npm run test:ci` (Vitest) completed with all tests passing. 
- End-to-end smoke build: `npm run smoke` (build + `scripts/assert-dist.cjs`) passed. 
- Local verification: exercised the workflow’s checksum/header validation logic against the local `public/resume.pdf` using a temporary HTTP server to simulate public endpoints and validated header and SHA-256 checks (passed). 
- Security scan: `git diff --cached | ./scripts/scan-secrets.py` found no high-risk secrets. 
- Notes: `actionlint` and `shellcheck` were not installed in the environment so those optional checks were not run, and production upload verification requires the configured GitHub repository variables and an appropriately-scoped Google Workload Identity Federation / service account as documented in `docs/ops/resume-hosting.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37125fbfe0832fb193f1e46f9366c6)