### PR TITLE
Add OIDC-based GitHub Actions workflow to deploy public/resume.pdf to GCS

### DIFF
--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -1,0 +1,252 @@
+name: Deploy resume to GCS
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'public/resume.pdf'
+      - '.github/workflows/resume-gcs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: resume-gcs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy stable resume PDF
+    runs-on: ubuntu-latest
+    env:
+      LOCAL_RESUME_PATH: public/resume.pdf
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
+      RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
+      RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate deployment configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for variable in \
+            GCP_PROJECT_ID \
+            GCP_WORKLOAD_IDENTITY_PROVIDER \
+            GCP_SERVICE_ACCOUNT \
+            RESUME_GCS_DESTINATION \
+            RESUME_PUBLIC_URL \
+            RESUME_STORAGE_PUBLIC_URL; do
+            if [ -z "${!variable:-}" ]; then
+              echo "::error::Repository variable ${variable} is required for resume deployment."
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            echo "Configure the missing repository variables before rerunning this workflow." >&2
+            exit 1
+          fi
+
+          if [ "${RESUME_GCS_DESTINATION}" != "gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf" ]; then
+            echo "::error::RESUME_GCS_DESTINATION must be gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf."
+            exit 1
+          fi
+
+          if [ "${RESUME_PUBLIC_URL}" != "https://resume.danielsmith.io" ]; then
+            echo "::error::RESUME_PUBLIC_URL must be https://resume.danielsmith.io."
+            exit 1
+          fi
+
+          expected_storage_url="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+          if [ "${RESUME_STORAGE_PUBLIC_URL}" != "${expected_storage_url}" ]; then
+            echo "::error::RESUME_STORAGE_PUBLIC_URL must be ${expected_storage_url}."
+            exit 1
+          fi
+
+          if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
+            echo "::error::${LOCAL_RESUME_PATH} is missing or empty. P6 must run first and commit the stable resume PDF to main."
+            exit 1
+          fi
+
+          if [ "$(head -c 5 "${LOCAL_RESUME_PATH}")" != "%PDF-" ]; then
+            echo "::error::${LOCAL_RESUME_PATH} is not a PDF. P6 must publish a valid stable resume PDF first."
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload resume PDF
+        id: upload
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
+          echo "local_sha256=${local_sha256}" >>"${GITHUB_OUTPUT}"
+
+          gcloud storage cp "${LOCAL_RESUME_PATH}" "${RESUME_GCS_DESTINATION}" \
+            --project="${GCP_PROJECT_ID}" \
+            --content-type="application/pdf" \
+            --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
+            --cache-control="public, max-age=300, must-revalidate"
+
+          gcloud storage objects update "${RESUME_GCS_DESTINATION}" \
+            --project="${GCP_PROJECT_ID}" \
+            --add-acl-grant=entity=allUsers,role=READER
+
+      - name: Verify public deployment
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          append_cache_buster() {
+            local url="$1"
+            local token="$2"
+            case "${url}" in
+              *\?*) printf '%s&resume_deploy_cache_bust=%s\n' "${url}" "${token}" ;;
+              *) printf '%s?resume_deploy_cache_bust=%s\n' "${url}" "${token}" ;;
+            esac
+          }
+
+          download_and_verify() {
+            local label="$1"
+            local url="$2"
+            local output_dir="$3"
+            local expected_sha="$4"
+            local cache_busted_url body_file headers_file status_file sha content_type content_disposition
+
+            cache_busted_url="$(append_cache_buster "${url}" "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}")"
+            body_file="${output_dir}/${label}.pdf"
+            headers_file="${output_dir}/${label}.headers"
+            status_file="${output_dir}/${label}.status"
+
+            http_code="$(curl --location --silent --show-error \
+              --dump-header "${headers_file}" \
+              --output "${body_file}" \
+              --write-out '%{http_code}' \
+              "${cache_busted_url}")"
+            printf '%s\n' "${http_code}" >"${status_file}"
+
+            if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+              echo "::error::${label} URL returned HTTP ${http_code}."
+              exit 1
+            fi
+
+            if [ ! -s "${body_file}" ]; then
+              echo "::error::${label} URL returned an empty body."
+              exit 1
+            fi
+
+            if [ "$(head -c 5 "${body_file}")" != "%PDF-" ]; then
+              echo "::error::${label} URL did not return PDF bytes."
+              exit 1
+            fi
+
+            sha="$(sha256sum "${body_file}" | awk '{print $1}')"
+            if [ "${sha}" != "${expected_sha}" ]; then
+              echo "::error::${label} SHA-256 ${sha} does not match local ${expected_sha}."
+              exit 1
+            fi
+
+            content_type="$(awk 'BEGIN{IGNORECASE=1} /^content-type:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}' "${headers_file}" | tr -d '\r')"
+            if ! printf '%s\n' "${content_type}" | grep -Eiq '(^|[[:space:];])application/pdf([[:space:];]|$)'; then
+              echo "::error::${label} Content-Type must include application/pdf; observed '${content_type}'."
+              exit 1
+            fi
+
+            content_disposition="$(awk 'BEGIN{IGNORECASE=1} /^content-disposition:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}' "${headers_file}" | tr -d '\r')"
+            if [ -n "${content_disposition}" ] && \
+              ! printf '%s\n' "${content_disposition}" | grep -Eiq '^inline([[:space:];]|$)'; then
+              echo "::error::${label} Content-Disposition must be inline or absent; observed '${content_disposition}'."
+              exit 1
+            fi
+
+            {
+              echo "${label}_sha256=${sha}"
+              echo "${label}_content_type=${content_type}"
+              echo "${label}_content_disposition=${content_disposition:-absent}"
+              echo "${label}_headers<<EOF_HEADERS_${label}"
+              sed -n '1,20p' "${headers_file}" | sed 's/[[:cntrl:]]$//'
+              echo "EOF_HEADERS_${label}"
+            } >>"${GITHUB_OUTPUT}"
+          }
+
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "${tmpdir}"' EXIT
+
+          local_sha256="${{ steps.upload.outputs.local_sha256 }}"
+          download_and_verify storage "${RESUME_STORAGE_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
+          download_and_verify canonical "${RESUME_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
+
+          acl_json="${tmpdir}/acl.json"
+          gcloud storage objects describe "${RESUME_GCS_DESTINATION}" \
+            --project="${GCP_PROJECT_ID}" \
+            --format=json >"${acl_json}"
+
+          public_acl="$(python3 -c 'import json, sys; metadata = json.load(open(sys.argv[1], encoding="utf-8")); acl = metadata.get("acl") or []; found = any(entry.get("entity") == "allUsers" and entry.get("role") in {"READER", "OWNER"} for entry in acl); print("allUsers Reader present" if found else "allUsers Reader missing"); sys.exit(0 if found else 1)' "${acl_json}")"
+          echo "public_acl=${public_acl}" >>"${GITHUB_OUTPUT}"
+
+      - name: Write deployment summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          storage_disposition='${{ steps.verify.outputs.storage_content_disposition }}'
+          canonical_disposition='${{ steps.verify.outputs.canonical_content_disposition }}'
+
+          {
+            echo "## Resume GCS deployment"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Source commit SHA | \`${GITHUB_SHA}\` |"
+            echo "| Local file path | \`${LOCAL_RESUME_PATH}\` |"
+            echo "| Destination GCS URI | \`${RESUME_GCS_DESTINATION}\` |"
+            echo "| Storage URL | ${RESUME_STORAGE_PUBLIC_URL} |"
+            echo "| Canonical public URL | ${RESUME_PUBLIC_URL} |"
+            echo "| Local SHA-256 | \`${{ steps.upload.outputs.local_sha256 }}\` |"
+            echo "| Storage URL SHA-256 | \`${{ steps.verify.outputs.storage_sha256 }}\` |"
+            echo "| Canonical URL SHA-256 | \`${{ steps.verify.outputs.canonical_sha256 }}\` |"
+            echo "| Storage Content-Type | \`${{ steps.verify.outputs.storage_content_type }}\` |"
+            echo "| Canonical Content-Type | \`${{ steps.verify.outputs.canonical_content_type }}\` |"
+            echo "| Object ACL/public-read verification | \`${{ steps.verify.outputs.public_acl }}\` |"
+            echo "| Final deployment status | \`${{ job.status }}\` |"
+            echo
+            if [ "${storage_disposition}" = "absent" ]; then
+              echo "> Warning: the storage URL did not expose Content-Disposition."
+              echo
+            fi
+            if [ "${canonical_disposition}" = "absent" ]; then
+              echo "> Warning: the canonical URL did not expose Content-Disposition."
+              echo
+            fi
+            echo "### Storage URL response headers"
+            echo '```'
+            printf '%s\n' '${{ steps.verify.outputs.storage_headers }}'
+            echo '```'
+            echo
+            echo "### Canonical URL response headers"
+            echo '```'
+            printf '%s\n' '${{ steps.verify.outputs.canonical_headers }}'
+            echo '```'
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -33,15 +33,33 @@ jobs:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      RESUME_GCS_DESTINATION: gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf
-      RESUME_PUBLIC_URL: https://resume.danielsmith.io
-      RESUME_STORAGE_PUBLIC_URL: https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf
+      RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
+      RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
+      RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
     if: >-
       ${{ github.event_name != 'workflow_run' ||
-        github.event.workflow_run.conclusion == 'success' }}
+        (github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'main') }}
     steps:
+      - name: Require main branch for manual deploys
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
+        shell: bash
+        run: |
+          echo "::error::Resume GCS deploys must run from main. Select the main branch before running this workflow manually."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
+
+      - name: Capture source commit
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >>"${GITHUB_OUTPUT}"
 
       - name: Validate deployment configuration
         shell: bash
@@ -52,7 +70,10 @@ jobs:
           for variable in \
             GCP_PROJECT_ID \
             GCP_WORKLOAD_IDENTITY_PROVIDER \
-            GCP_SERVICE_ACCOUNT; do
+            GCP_SERVICE_ACCOUNT \
+            RESUME_GCS_DESTINATION \
+            RESUME_PUBLIC_URL \
+            RESUME_STORAGE_PUBLIC_URL; do
             if [ -z "${!variable:-}" ]; then
               echo "::error::Repository variable ${variable} is required for resume deployment."
               missing=1
@@ -61,6 +82,21 @@ jobs:
 
           if [ "${missing}" -ne 0 ]; then
             echo "Configure the missing repository variables before rerunning this workflow." >&2
+            exit 1
+          fi
+
+          if [ "${RESUME_GCS_DESTINATION}" != "gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf" ]; then
+            echo "::error::RESUME_GCS_DESTINATION must target the production resume object."
+            exit 1
+          fi
+
+          if [ "${RESUME_PUBLIC_URL}" != "https://resume.danielsmith.io" ]; then
+            echo "::error::RESUME_PUBLIC_URL must target the production resume host."
+            exit 1
+          fi
+
+          if [ "${RESUME_STORAGE_PUBLIC_URL}" != "https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf" ]; then
+            echo "::error::RESUME_STORAGE_PUBLIC_URL must target the production storage URL."
             exit 1
           fi
 
@@ -198,13 +234,37 @@ jobs:
             --project="${GCP_PROJECT_ID}" \
             --format=json >"${acl_json}"
 
-          public_acl="$(python3 -c 'import json, sys; metadata = json.load(open(sys.argv[1], encoding="utf-8")); acl = metadata.get("acl") or []; found = any(entry.get("entity") == "allUsers" and entry.get("role") == "READER" for entry in acl); print("allUsers Reader present" if found else "allUsers Reader missing"); sys.exit(0 if found else 1)' "${acl_json}")"
+          public_acl="$(python3 - <<'PY' "${acl_json}"
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              metadata = json.load(handle)
+
+          public_write_roles = {"OWNER", "WRITER"}
+          acl = metadata.get("acl") or []
+          all_users_roles = [entry.get("role") for entry in acl if entry.get("entity") == "allUsers"]
+          public_write = sorted(role for role in all_users_roles if role in public_write_roles)
+          reader_present = "READER" in all_users_roles
+
+          if public_write:
+              print(f"allUsers unsafe public role(s): {', '.join(public_write)}")
+              sys.exit(1)
+
+          if not reader_present:
+              print("allUsers Reader missing")
+              sys.exit(1)
+
+          print("allUsers Reader present; no public write grants observed")
+          PY
+          )"
           echo "public_acl=${public_acl}" >>"${GITHUB_OUTPUT}"
 
       - name: Write deployment summary
         if: always()
         shell: bash
         env:
+          SOURCE_COMMIT_SHA: ${{ steps.source.outputs.sha }}
           LOCAL_SHA256: ${{ steps.upload.outputs.local_sha256 }}
           STORAGE_SHA256: ${{ steps.verify.outputs.storage_sha256 }}
           CANONICAL_SHA256: ${{ steps.verify.outputs.canonical_sha256 }}
@@ -224,7 +284,7 @@ jobs:
             echo
             echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| Source commit SHA | \`${GITHUB_SHA}\` |"
+            echo "| Source commit SHA | \`${SOURCE_COMMIT_SHA}\` |"
             echo "| Local file path | \`${LOCAL_RESUME_PATH}\` |"
             echo "| Destination GCS URI | \`${RESUME_GCS_DESTINATION}\` |"
             echo "| Storage URL | ${RESUME_STORAGE_PUBLIC_URL} |"

--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -7,6 +7,13 @@ on:
     paths:
       - 'public/resume.pdf'
       - '.github/workflows/resume-gcs.yml'
+  workflow_run:
+    workflows:
+      - Resume artifacts
+    branches:
+      - main
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -26,9 +33,12 @@ jobs:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
-      RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
-      RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
+      RESUME_GCS_DESTINATION: gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf
+      RESUME_PUBLIC_URL: https://resume.danielsmith.io
+      RESUME_STORAGE_PUBLIC_URL: https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf
+    if: >-
+      ${{ github.event_name != 'workflow_run' ||
+        github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,10 +52,7 @@ jobs:
           for variable in \
             GCP_PROJECT_ID \
             GCP_WORKLOAD_IDENTITY_PROVIDER \
-            GCP_SERVICE_ACCOUNT \
-            RESUME_GCS_DESTINATION \
-            RESUME_PUBLIC_URL \
-            RESUME_STORAGE_PUBLIC_URL; do
+            GCP_SERVICE_ACCOUNT; do
             if [ -z "${!variable:-}" ]; then
               echo "::error::Repository variable ${variable} is required for resume deployment."
               missing=1
@@ -57,29 +64,13 @@ jobs:
             exit 1
           fi
 
-          if [ "${RESUME_GCS_DESTINATION}" != "gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf" ]; then
-            echo "::error::RESUME_GCS_DESTINATION must be gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf."
-            exit 1
-          fi
-
-          if [ "${RESUME_PUBLIC_URL}" != "https://resume.danielsmith.io" ]; then
-            echo "::error::RESUME_PUBLIC_URL must be https://resume.danielsmith.io."
-            exit 1
-          fi
-
-          expected_storage_url="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf"
-          if [ "${RESUME_STORAGE_PUBLIC_URL}" != "${expected_storage_url}" ]; then
-            echo "::error::RESUME_STORAGE_PUBLIC_URL must be ${expected_storage_url}."
-            exit 1
-          fi
-
           if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
-            echo "::error::${LOCAL_RESUME_PATH} is missing or empty. P6 must run first and commit the stable resume PDF to main."
+            echo "::error::${LOCAL_RESUME_PATH} is missing or empty. Run the Resume artifacts workflow first so it commits the stable resume PDF to main."
             exit 1
           fi
 
           if [ "$(head -c 5 "${LOCAL_RESUME_PATH}")" != "%PDF-" ]; then
-            echo "::error::${LOCAL_RESUME_PATH} is not a PDF. P6 must publish a valid stable resume PDF first."
+            echo "::error::${LOCAL_RESUME_PATH} is not a PDF. Run the Resume artifacts workflow first so it publishes a valid stable resume PDF."
             exit 1
           fi
 
@@ -132,7 +123,7 @@ jobs:
             local url="$2"
             local output_dir="$3"
             local expected_sha="$4"
-            local cache_busted_url body_file headers_file status_file sha content_type content_disposition
+            local cache_busted_url body_file headers_file status_file http_code sha content_type content_disposition
 
             cache_busted_url="$(append_cache_buster "${url}" "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}")"
             body_file="${output_dir}/${label}.pdf"
@@ -140,6 +131,11 @@ jobs:
             status_file="${output_dir}/${label}.status"
 
             http_code="$(curl --location --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 60 \
+              --retry 3 \
+              --retry-delay 2 \
+              --retry-connrefused \
               --dump-header "${headers_file}" \
               --output "${body_file}" \
               --write-out '%{http_code}' \
@@ -202,17 +198,26 @@ jobs:
             --project="${GCP_PROJECT_ID}" \
             --format=json >"${acl_json}"
 
-          public_acl="$(python3 -c 'import json, sys; metadata = json.load(open(sys.argv[1], encoding="utf-8")); acl = metadata.get("acl") or []; found = any(entry.get("entity") == "allUsers" and entry.get("role") in {"READER", "OWNER"} for entry in acl); print("allUsers Reader present" if found else "allUsers Reader missing"); sys.exit(0 if found else 1)' "${acl_json}")"
+          public_acl="$(python3 -c 'import json, sys; metadata = json.load(open(sys.argv[1], encoding="utf-8")); acl = metadata.get("acl") or []; found = any(entry.get("entity") == "allUsers" and entry.get("role") == "READER" for entry in acl); print("allUsers Reader present" if found else "allUsers Reader missing"); sys.exit(0 if found else 1)' "${acl_json}")"
           echo "public_acl=${public_acl}" >>"${GITHUB_OUTPUT}"
 
       - name: Write deployment summary
         if: always()
         shell: bash
+        env:
+          LOCAL_SHA256: ${{ steps.upload.outputs.local_sha256 }}
+          STORAGE_SHA256: ${{ steps.verify.outputs.storage_sha256 }}
+          CANONICAL_SHA256: ${{ steps.verify.outputs.canonical_sha256 }}
+          STORAGE_CONTENT_TYPE: ${{ steps.verify.outputs.storage_content_type }}
+          CANONICAL_CONTENT_TYPE: ${{ steps.verify.outputs.canonical_content_type }}
+          STORAGE_CONTENT_DISPOSITION: ${{ steps.verify.outputs.storage_content_disposition }}
+          CANONICAL_CONTENT_DISPOSITION: ${{ steps.verify.outputs.canonical_content_disposition }}
+          PUBLIC_ACL: ${{ steps.verify.outputs.public_acl }}
+          STORAGE_HEADERS: ${{ steps.verify.outputs.storage_headers }}
+          CANONICAL_HEADERS: ${{ steps.verify.outputs.canonical_headers }}
+          JOB_STATUS: ${{ job.status }}
         run: |
           set -euo pipefail
-
-          storage_disposition='${{ steps.verify.outputs.storage_content_disposition }}'
-          canonical_disposition='${{ steps.verify.outputs.canonical_content_disposition }}'
 
           {
             echo "## Resume GCS deployment"
@@ -224,29 +229,29 @@ jobs:
             echo "| Destination GCS URI | \`${RESUME_GCS_DESTINATION}\` |"
             echo "| Storage URL | ${RESUME_STORAGE_PUBLIC_URL} |"
             echo "| Canonical public URL | ${RESUME_PUBLIC_URL} |"
-            echo "| Local SHA-256 | \`${{ steps.upload.outputs.local_sha256 }}\` |"
-            echo "| Storage URL SHA-256 | \`${{ steps.verify.outputs.storage_sha256 }}\` |"
-            echo "| Canonical URL SHA-256 | \`${{ steps.verify.outputs.canonical_sha256 }}\` |"
-            echo "| Storage Content-Type | \`${{ steps.verify.outputs.storage_content_type }}\` |"
-            echo "| Canonical Content-Type | \`${{ steps.verify.outputs.canonical_content_type }}\` |"
-            echo "| Object ACL/public-read verification | \`${{ steps.verify.outputs.public_acl }}\` |"
-            echo "| Final deployment status | \`${{ job.status }}\` |"
+            echo "| Local SHA-256 | \`${LOCAL_SHA256}\` |"
+            echo "| Storage URL SHA-256 | \`${STORAGE_SHA256}\` |"
+            echo "| Canonical URL SHA-256 | \`${CANONICAL_SHA256}\` |"
+            echo "| Storage Content-Type | \`${STORAGE_CONTENT_TYPE}\` |"
+            echo "| Canonical Content-Type | \`${CANONICAL_CONTENT_TYPE}\` |"
+            echo "| Object ACL/public-read verification | \`${PUBLIC_ACL}\` |"
+            echo "| Final deployment status | \`${JOB_STATUS}\` |"
             echo
-            if [ "${storage_disposition}" = "absent" ]; then
+            if [ "${STORAGE_CONTENT_DISPOSITION}" = "absent" ]; then
               echo "> Warning: the storage URL did not expose Content-Disposition."
               echo
             fi
-            if [ "${canonical_disposition}" = "absent" ]; then
+            if [ "${CANONICAL_CONTENT_DISPOSITION}" = "absent" ]; then
               echo "> Warning: the canonical URL did not expose Content-Disposition."
               echo
             fi
             echo "### Storage URL response headers"
             echo '```'
-            printf '%s\n' '${{ steps.verify.outputs.storage_headers }}'
+            printf '%s\n' "${STORAGE_HEADERS}"
             echo '```'
             echo
             echo "### Canonical URL response headers"
             echo '```'
-            printf '%s\n' '${{ steps.verify.outputs.canonical_headers }}'
+            printf '%s\n' "${CANONICAL_HEADERS}"
             echo '```'
           } >>"${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   URL for runtime links, while `/resume.docx` is the stable downloadable DOCX
   URL (served from `public/resume.docx`) when a word-processor copy is useful. The immutable
   dated PDF archive for this source snapshot lives at
-  `public/docs/resume/2026-06/resume.pdf`.
+  `public/docs/resume/2026-06/resume.pdf`. The separate
+  [resume hosting runbook](docs/ops/resume-hosting.md) documents how the stable
+  PDF is deployed to `resume.danielsmith.io`.
 - **Prompt library** – Automation-ready Codex prompts are summarized in
   [`summary.md`][prompt-summary] and expanded across topical files in
   `docs/prompts/codex/` (automation, lighting, avatar, HUD, POIs, accessibility, and more).

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -1,0 +1,217 @@
+# Resume hosting runbook
+
+This runbook documents the stable resume deployment path for `resume.danielsmith.io`.
+It only covers the resume object and must not be used to change the `danielsmith` or
+`danielsmith.io` web-hosting buckets, DNS, Cloudflare, load balancers, certificates,
+bucket website settings, or bucket-level IAM.
+
+## Current hosting model
+
+The resume host is an existing Google Cloud Storage bucket and object:
+
+- Bucket: `resume.danielsmith.io`
+- Object: `Daniel_Smith_Resume.pdf`
+- GCS destination: `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`
+- Public storage URL:
+  `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf`
+- Canonical URL: `https://resume.danielsmith.io`
+
+The bucket currently uses object-level ACLs instead of uniform bucket-level public
+access. The deployed object must include an object ACL grant for `allUsers` with the
+`Reader` role. Do not make the whole bucket public and never grant public write access.
+
+## Automated deployment model
+
+P6 produces and persists the stable repository artifact at `public/resume.pdf`. P8
+then deploys that exact PDF byte-for-byte to the existing GCS object named
+`Daniel_Smith_Resume.pdf`. The deploy workflow does not compile TeX, regenerate resume
+artifacts, deploy `public/resume.docx`, edit resume content, or edit generated PDF
+bytes.
+
+The deployment workflow is `.github/workflows/resume-gcs.yml`. It runs on pushes to
+`main` that change `public/resume.pdf` or the workflow itself, and it also supports
+manual `workflow_dispatch` runs. It does not run on `pull_request`, so pull requests
+never authenticate to Google Cloud or deploy.
+
+## Required GitHub repository variables
+
+Configure these repository variables before enabling the workflow:
+
+| Variable                         | Expected value or purpose                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| `GCP_PROJECT_ID`                 | Google Cloud project ID for the observed `danielsmith io` project.             |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name used by GitHub OIDC.             |
+| `GCP_SERVICE_ACCOUNT`            | Dedicated deploy service account email to impersonate.                         |
+| `RESUME_GCS_DESTINATION`         | `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`                           |
+| `RESUME_PUBLIC_URL`              | `https://resume.danielsmith.io`                                                |
+| `RESUME_STORAGE_PUBLIC_URL`      | `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` |
+
+The workflow fails before authentication or upload if any variable is missing. It also
+checks that the three resume destination variables match the known production target.
+
+## Google Workload Identity Federation setup
+
+Use GitHub OIDC through Google Workload Identity Federation; do not store a
+service-account JSON key in GitHub.
+
+At a high level, the setup should include:
+
+1. A dedicated service account for this resume deployment path.
+2. A GitHub OIDC Workload Identity Provider.
+3. A repository-scoped trust condition for `futuroptimist/danielsmith.io`.
+4. Service account impersonation by that trusted GitHub principal.
+5. Bucket-scoped object permissions on `resume.danielsmith.io` sufficient to upload the
+   object, set object metadata, describe the object, and add or confirm the object ACL.
+
+Prefer permissions scoped to the `resume.danielsmith.io` bucket. Do not grant
+project-wide Storage Admin except as a temporary troubleshooting step, and remove that
+broad access immediately after diagnosis.
+
+## Metadata and public-read behavior
+
+The workflow uploads only `public/resume.pdf` to
+`gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf` with this metadata:
+
+- `Content-Type: application/pdf`
+- `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"`
+- `Cache-Control: public, max-age=300, must-revalidate`
+
+After upload, it runs:
+
+```bash
+gcloud storage objects update \
+  "gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf" \
+  --add-acl-grant=entity=allUsers,role=READER
+```
+
+This preserves existing object ACL grants while adding or confirming public read access.
+Do not replace object ACLs with `--predefined-acl=publicRead` unless a future runbook
+change explicitly explains why replacing other object ACL grants is acceptable.
+
+## Running `workflow_dispatch`
+
+1. Open GitHub Actions for `futuroptimist/danielsmith.io`.
+2. Select **Deploy resume to GCS**.
+3. Choose **Run workflow** on `main`.
+4. Wait for the job summary to report matching local, storage URL, and canonical URL
+   SHA-256 values.
+
+## Manual break-glass deployment
+
+Use this only when GitHub Actions is unavailable. Authenticate locally with `gcloud`
+using an identity that has bucket-scoped object write and ACL permissions for
+`resume.danielsmith.io`.
+
+```bash
+set -euo pipefail
+
+LOCAL_RESUME_PATH="public/resume.pdf"
+DESTINATION="gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+STORAGE_URL="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+CANONICAL_URL="https://resume.danielsmith.io"
+
+if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
+  echo "${LOCAL_RESUME_PATH} is missing or empty. P6 must run first." >&2
+  exit 1
+fi
+
+local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
+
+gcloud storage cp "${LOCAL_RESUME_PATH}" "${DESTINATION}" \
+  --content-type="application/pdf" \
+  --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
+  --cache-control="public, max-age=300, must-revalidate"
+
+gcloud storage objects update "${DESTINATION}" \
+  --add-acl-grant=entity=allUsers,role=READER
+
+for url in "${STORAGE_URL}" "${CANONICAL_URL}"; do
+  tmp="$(mktemp)"
+  curl --location --fail --silent --show-error "${url}?resume_verify=$(date +%s)" \
+    --output "${tmp}"
+  test -s "${tmp}"
+  test "$(head -c 5 "${tmp}")" = "%PDF-"
+  remote_sha256="$(sha256sum "${tmp}" | awk '{print $1}')"
+  rm -f "${tmp}"
+  test "${remote_sha256}" = "${local_sha256}"
+done
+```
+
+## Shell verification
+
+After any deployment, verify both public endpoints are reachable without authentication
+and match the repository PDF:
+
+```bash
+set -euo pipefail
+
+LOCAL_RESUME_PATH="public/resume.pdf"
+STORAGE_URL="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+CANONICAL_URL="https://resume.danielsmith.io"
+local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
+
+for label in storage canonical; do
+  case "${label}" in
+    storage) url="${STORAGE_URL}" ;;
+    canonical) url="${CANONICAL_URL}" ;;
+  esac
+
+  tmpdir="$(mktemp -d)"
+  curl --location --fail --silent --show-error \
+    --dump-header "${tmpdir}/${label}.headers" \
+    --output "${tmpdir}/${label}.pdf" \
+    "${url}?resume_verify=$(date +%s)"
+
+  test -s "${tmpdir}/${label}.pdf"
+  test "$(head -c 5 "${tmpdir}/${label}.pdf")" = "%PDF-"
+  grep -Ei '^content-type:.*application/pdf' "${tmpdir}/${label}.headers"
+  remote_sha256="$(sha256sum "${tmpdir}/${label}.pdf" | awk '{print $1}')"
+  test "${remote_sha256}" = "${local_sha256}"
+  rm -rf "${tmpdir}"
+done
+```
+
+`Content-Disposition` should be `inline` when surfaced. Some Cloud Storage custom-domain
+paths may omit it; treat absence as a warning if the response is still a non-empty PDF
+with an `application/pdf` content type and matching SHA-256.
+
+## Rollback
+
+Rollback by restoring a prior stable resume artifact in Git, then letting the workflow
+redeploy it:
+
+- Revert or check out a prior Git commit that contains the previous `public/resume.pdf`,
+  or
+- Copy a prior `public/docs/resume/<version>/resume.pdf` over `public/resume.pdf` in a
+  rollback PR.
+
+Do not edit generated PDF bytes by hand. After the rollback PR merges to `main`, the
+workflow redeploys the restored file to the same GCS object.
+
+## Troubleshooting
+
+- **Missing repository variables:** the workflow fails before authentication and lists each
+  missing variable. Configure all required `vars.*` values and rerun.
+- **OIDC trust failures:** confirm the Workload Identity Provider resource name and the
+  repository-scoped trust condition for `futuroptimist/danielsmith.io`.
+- **Service account impersonation failures:** confirm the GitHub OIDC principal can
+  impersonate the dedicated service account.
+- **Bucket permission failures:** confirm the service account has bucket-scoped object
+  permissions for `resume.danielsmith.io`; avoid broad project roles except temporarily
+  during diagnosis.
+- **Object ACL/public-read failures:** confirm uniform bucket-level access is not blocking
+  object ACLs and that the deploy identity can update object ACLs. The target object must
+  have `allUsers` `Reader`, not public write access.
+- **Content-Type mismatch:** re-run the workflow and confirm the upload command sets
+  `application/pdf`. The verification step fails if either public endpoint lacks a PDF
+  content type.
+- **Content-Disposition mismatch:** the object should be uploaded as inline with the
+  `Daniel_Smith_Resume.pdf` filename. Absence may be tolerated for public endpoints, but a
+  non-inline value is a deployment failure.
+- **Canonical URL not matching storage URL:** compare both SHA-256 values in the workflow
+  summary. Check custom-domain routing and caching before changing the bucket or object.
+- **Cache propagation:** the workflow appends cache-busting query parameters and sets a
+  five-minute cache policy. If humans still see stale bytes, wait for cache expiry and
+  re-check with a cache-busting URL.
+- **Checksum mismatch:** stop and do not retry blindly. Confirm `public/resume.pdf` in the
+  checked-out commit, the GCS object destination, and any custom-domain cache behavior.

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -22,32 +22,34 @@ access. The deployed object must include an object ACL grant for `allUsers` with
 
 ## Automated deployment model
 
-P6 produces and persists the stable repository artifact at `public/resume.pdf`. P8
-then deploys that exact PDF byte-for-byte to the existing GCS object named
-`Daniel_Smith_Resume.pdf`. The deploy workflow does not compile TeX, regenerate resume
-artifacts, deploy `public/resume.docx`, edit resume content, or edit generated PDF
-bytes.
+The **Resume artifacts** workflow (`.github/workflows/resume.yml`) produces and
+persists the stable repository artifact at `public/resume.pdf`. The **Deploy resume
+to GCS** workflow then deploys that exact PDF byte-for-byte to the existing GCS object
+named `Daniel_Smith_Resume.pdf`. The deploy workflow does not compile TeX, regenerate
+resume artifacts, deploy `public/resume.docx`, edit resume content, or edit generated
+PDF bytes.
 
-The deployment workflow is `.github/workflows/resume-gcs.yml`. It runs on pushes to
-`main` that change `public/resume.pdf` or the workflow itself, and it also supports
-manual `workflow_dispatch` runs. It does not run on `pull_request`, so pull requests
-never authenticate to Google Cloud or deploy.
+The deployment workflow is `.github/workflows/resume-gcs.yml`. It runs on successful
+`Resume artifacts` workflow completions on `main`, direct pushes to `main` that change
+`public/resume.pdf` or the deployment workflow itself, and manual `workflow_dispatch`
+runs. The `workflow_run` handoff is required because GitHub suppresses follow-on
+workflow runs for commits that `Resume artifacts` pushes with `GITHUB_TOKEN`. It does
+not run on `pull_request`, so pull requests never authenticate to Google Cloud or
+deploy.
 
 ## Required GitHub repository variables
 
 Configure these repository variables before enabling the workflow:
 
-| Variable                         | Expected value or purpose                                                      |
-| -------------------------------- | ------------------------------------------------------------------------------ |
-| `GCP_PROJECT_ID`                 | Google Cloud project ID for the observed `danielsmith io` project.             |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name used by GitHub OIDC.             |
-| `GCP_SERVICE_ACCOUNT`            | Dedicated deploy service account email to impersonate.                         |
-| `RESUME_GCS_DESTINATION`         | `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`                           |
-| `RESUME_PUBLIC_URL`              | `https://resume.danielsmith.io`                                                |
-| `RESUME_STORAGE_PUBLIC_URL`      | `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` |
+| Variable                         | Expected value or purpose                                          |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `GCP_PROJECT_ID`                 | Google Cloud project ID for the observed `danielsmith io` project. |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name used by GitHub OIDC. |
+| `GCP_SERVICE_ACCOUNT`            | Dedicated deploy service account email to impersonate.             |
 
-The workflow fails before authentication or upload if any variable is missing. It also
-checks that the three resume destination variables match the known production target.
+The workflow fails before authentication or upload if any required variable is missing.
+The resume destination, canonical URL, and storage URL are production constants in the
+workflow so operators cannot accidentally point a deployment at another object.
 
 ## Google Workload Identity Federation setup
 
@@ -111,7 +113,7 @@ STORAGE_URL="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_R
 CANONICAL_URL="https://resume.danielsmith.io"
 
 if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
-  echo "${LOCAL_RESUME_PATH} is missing or empty. P6 must run first." >&2
+  echo "${LOCAL_RESUME_PATH} is missing or empty. Run Resume artifacts first." >&2
   exit 1
 fi
 
@@ -127,7 +129,13 @@ gcloud storage objects update "${DESTINATION}" \
 
 for url in "${STORAGE_URL}" "${CANONICAL_URL}"; do
   tmp="$(mktemp)"
-  curl --location --fail --silent --show-error "${url}?resume_verify=$(date +%s)" \
+  curl --location --fail --silent --show-error \
+    --connect-timeout 10 \
+    --max-time 60 \
+    --retry 3 \
+    --retry-delay 2 \
+    --retry-connrefused \
+    "${url}?resume_verify=$(date +%s)" \
     --output "${tmp}"
   test -s "${tmp}"
   test "$(head -c 5 "${tmp}")" = "%PDF-"
@@ -158,6 +166,11 @@ for label in storage canonical; do
 
   tmpdir="$(mktemp -d)"
   curl --location --fail --silent --show-error \
+    --connect-timeout 10 \
+    --max-time 60 \
+    --retry 3 \
+    --retry-delay 2 \
+    --retry-connrefused \
     --dump-header "${tmpdir}/${label}.headers" \
     --output "${tmpdir}/${label}.pdf" \
     "${url}?resume_verify=$(date +%s)"

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -26,30 +26,36 @@ The **Resume artifacts** workflow (`.github/workflows/resume.yml`) produces and
 persists the stable repository artifact at `public/resume.pdf`. The **Deploy resume
 to GCS** workflow then deploys that exact PDF byte-for-byte to the existing GCS object
 named `Daniel_Smith_Resume.pdf`. The deploy workflow does not compile TeX, regenerate
-resume artifacts, deploy `public/resume.docx`, edit resume content, or edit generated
-PDF bytes.
+resume artifacts, deploy other resume formats, edit resume content, or edit generated PDF bytes.
 
 The deployment workflow is `.github/workflows/resume-gcs.yml`. It runs on successful
-`Resume artifacts` workflow completions on `main`, direct pushes to `main` that change
-`public/resume.pdf` or the deployment workflow itself, and manual `workflow_dispatch`
-runs. The `workflow_run` handoff is required because GitHub suppresses follow-on
-workflow runs for commits that `Resume artifacts` pushes with `GITHUB_TOKEN`. It does
-not run on `pull_request`, so pull requests never authenticate to Google Cloud or
-deploy.
+`Resume artifacts` workflow completions that were started by a `push` to `main`, direct
+pushes to `main` that change `public/resume.pdf` or the deployment workflow itself,
+and manual `workflow_dispatch` runs from `main`. The `workflow_run` handoff is required
+because GitHub suppresses follow-on workflow runs for commits that `Resume artifacts`
+pushes with `GITHUB_TOKEN`. For `workflow_run` events, the deploy job checks out the
+current `main` branch after the artifact commit exists and records `git rev-parse HEAD`
+in the job summary as the deployed source commit SHA. It does not run on
+`pull_request`, so pull requests never authenticate to Google Cloud or deploy.
 
 ## Required GitHub repository variables
 
 Configure these repository variables before enabling the workflow:
 
-| Variable                         | Expected value or purpose                                          |
-| -------------------------------- | ------------------------------------------------------------------ |
-| `GCP_PROJECT_ID`                 | Google Cloud project ID for the observed `danielsmith io` project. |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name used by GitHub OIDC. |
-| `GCP_SERVICE_ACCOUNT`            | Dedicated deploy service account email to impersonate.             |
+| Variable                         | Expected value or purpose                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| `GCP_PROJECT_ID`                 | Google Cloud project ID for the observed `danielsmith io` project.             |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name used by GitHub OIDC.             |
+| `GCP_SERVICE_ACCOUNT`            | Dedicated deploy service account email to impersonate.                         |
+| `RESUME_GCS_DESTINATION`         | `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`                           |
+| `RESUME_PUBLIC_URL`              | `https://resume.danielsmith.io`                                                |
+| `RESUME_STORAGE_PUBLIC_URL`      | `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` |
 
 The workflow fails before authentication or upload if any required variable is missing.
-The resume destination, canonical URL, and storage URL are production constants in the
-workflow so operators cannot accidentally point a deployment at another object.
+Manual `workflow_dispatch` runs also fail before checkout or Google authentication
+unless the selected branch is `main`. The resume destination, canonical URL, and storage
+URL remain repository variables, but the workflow validates them against the production
+object and URLs so operators cannot accidentally point a deployment elsewhere.
 
 ## Google Workload Identity Federation setup
 
@@ -87,16 +93,18 @@ gcloud storage objects update \
 ```
 
 This preserves existing object ACL grants while adding or confirming public read access.
-Do not replace object ACLs with `--predefined-acl=publicRead` unless a future runbook
-change explicitly explains why replacing other object ACL grants is acceptable.
+Do not use canned public-read ACL replacement flags unless a future runbook change
+explicitly explains why replacing other object ACL grants is acceptable.
 
 ## Running `workflow_dispatch`
 
 1. Open GitHub Actions for `futuroptimist/danielsmith.io`.
 2. Select **Deploy resume to GCS**.
-3. Choose **Run workflow** on `main`.
-4. Wait for the job summary to report matching local, storage URL, and canonical URL
-   SHA-256 values.
+3. Choose **Run workflow** on `main`. A run started from any other branch is expected
+   to fail immediately with a `Resume GCS deploys must run from main` error before
+   checkout or Google authentication.
+4. Wait for the job summary to report the checked-out source commit SHA plus matching
+   local, storage URL, and canonical URL SHA-256 values.
 
 ## Manual break-glass deployment
 
@@ -190,16 +198,20 @@ with an `application/pdf` content type and matching SHA-256.
 
 ## Rollback
 
-Rollback by restoring a prior stable resume artifact in Git, then letting the workflow
-redeploy it:
+Rollback by restoring a prior stable resume artifact in Git, then letting the
+`Resume artifacts` to `Deploy resume to GCS` handoff redeploy it:
 
 - Revert or check out a prior Git commit that contains the previous `public/resume.pdf`,
   or
 - Copy a prior `public/docs/resume/<version>/resume.pdf` over `public/resume.pdf` in a
   rollback PR.
 
-Do not edit generated PDF bytes by hand. After the rollback PR merges to `main`, the
-workflow redeploys the restored file to the same GCS object.
+Do not edit generated PDF bytes by hand. After the rollback PR merges to `main`, wait
+for **Resume artifacts** to complete successfully, then confirm **Deploy resume to GCS**
+starts from that `workflow_run`. Verify the deploy summary source commit SHA matches
+the current `main` commit containing the restored `public/resume.pdf`, both public URL
+SHA-256 values match the local file, and object ACL verification reports
+`allUsers Reader present; no public write grants observed`.
 
 ## Troubleshooting
 
@@ -214,7 +226,8 @@ workflow redeploys the restored file to the same GCS object.
   during diagnosis.
 - **Object ACL/public-read failures:** confirm uniform bucket-level access is not blocking
   object ACLs and that the deploy identity can update object ACLs. The target object must
-  have `allUsers` `Reader`, not public write access.
+  have `allUsers` `Reader`. Any public `Owner`, `Writer`, or other public-write-like
+  grant is a deployment failure and must be removed before considering the object safe.
 - **Content-Type mismatch:** re-run the workflow and confirm the upload command sets
   `application/pdf`. The verification step fails if either public endpoint lacks a PDF
   content type.
@@ -227,4 +240,6 @@ workflow redeploys the restored file to the same GCS object.
   five-minute cache policy. If humans still see stale bytes, wait for cache expiry and
   re-check with a cache-busting URL.
 - **Checksum mismatch:** stop and do not retry blindly. Confirm `public/resume.pdf` in the
-  checked-out commit, the GCS object destination, and any custom-domain cache behavior.
+  checked-out source commit shown in the deploy summary, the GCS object destination, and
+  any custom-domain cache behavior. For generated artifact commits, compare the summary
+  source SHA to current `main` rather than the earlier `workflow_run` triggering SHA.


### PR DESCRIPTION
### Motivation
- Provide a secure, repeatable deployment path that publishes the stable repository resume (`public/resume.pdf`) to the existing GCS object `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf` using GitHub OIDC / Workload Identity Federation instead of long-lived keys. 
- Preserve public-read object ACLs and apply strict metadata (content type, disposition, cache-control) while avoiding bucket-level IAM or DNS changes. 
- Surface robust verification and an operations runbook so operators can validate uploads and troubleshoot checksum, header, and ACL mismatches.

### Description
- Add `.github/workflows/resume-gcs.yml`, a workflow that triggers on `push` to `main` when `public/resume.pdf` (or the workflow) changes and via `workflow_dispatch`, with `permissions: contents: read` and `id-token: write`, concurrency, and no `pull_request` deployments. 
- The workflow validates required `vars.*` repository variables (`GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `RESUME_GCS_DESTINATION`, `RESUME_PUBLIC_URL`, `RESUME_STORAGE_PUBLIC_URL`) before authenticating, then authenticates with `google-github-actions/auth@v2` and sets up `gcloud` with `google-github-actions/setup-gcloud@v2`. 
- Upload uses `gcloud storage cp` to write only `public/resume.pdf` to `$RESUME_GCS_DESTINATION` with `Content-Type: application/pdf`, `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"`, and `Cache-Control: public, max-age=300, must-revalidate`, then re-applies public read via `gcloud storage objects update --add-acl-grant=entity=allUsers,role=READER`. 
- Post-upload verification computes local SHA-256, fetches both the storage URL and canonical URL (with cache-busters), checks non-empty PDF bytes, `application/pdf` content-type, `inline` or absent content-disposition (warns if absent), verifies both remote SHA-256 match the local file, inspects object ACLs, and emits a detailed job summary with SHAs, headers, ACL result, and final status. 
- Add `docs/ops/resume-hosting.md` documenting hosting model, required repo variables, WIF setup guidance, metadata/ACL behavior, manual break-glass steps, verification commands, rollback instructions, and troubleshooting, and add a README pointer to the runbook.

### Testing
- Ran formatting and doc checks: `npm run format:write` (passed) and `npm run format:check` (passed), and `npm run docs:check` (passed with external fetch warnings reported by the link checker). 
- Ran repository checks and CI suites: `git diff --check` (passed), `npm run lint` (passed), `npm run test:ci` (Vitest full suite passed), and `npm run smoke` (build + smoke checks passed). 
- Security scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected). 
- Validation and environment notes: `actionlint` and `shellcheck` were not available in this environment so those checks were not run here, and `gcloud` is not available locally for live uploads. 
- Pre-deploy verification observation: a checksum mismatch was observed when comparing the committed `public/resume.pdf` SHA-256 (`ba938d6f...`) with the currently hosted storage object SHA-256 (`a185d8...`), which is expected prior to running the deployed workflow and indicates the workflow will replace the hosted object when run with valid repo variables and WIF credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3712671944832f85e9d294c821607a)