### PR TITLE
🚀 : – Add resume GCS deployment

### DIFF
--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -1,0 +1,240 @@
+name: Deploy resume to GCS
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'public/resume.pdf'
+      - '.github/workflows/resume-gcs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: resume-gcs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy stable resume PDF
+    runs-on: ubuntu-latest
+    env:
+      LOCAL_RESUME_PATH: public/resume.pdf
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
+      RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
+      RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate deployment configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for variable in \
+            GCP_PROJECT_ID \
+            GCP_WORKLOAD_IDENTITY_PROVIDER \
+            GCP_SERVICE_ACCOUNT \
+            RESUME_GCS_DESTINATION \
+            RESUME_PUBLIC_URL \
+            RESUME_STORAGE_PUBLIC_URL; do
+            if [ -z "${!variable:-}" ]; then
+              echo "::error::Missing required repository variable: ${variable}"
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            echo "Configure the missing repository variables before deploying the resume PDF." >&2
+            exit 1
+          fi
+
+          if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
+            echo "::error::${LOCAL_RESUME_PATH} is missing or empty. P6 must run first and commit public/resume.pdf to main."
+            exit 1
+          fi
+
+          if [ "${RESUME_GCS_DESTINATION}" != "gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf" ]; then
+            echo "::error::RESUME_GCS_DESTINATION must remain gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf for this deployment path."
+            exit 1
+          fi
+
+      - name: Calculate local checksum
+        id: local
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha256=$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')
+          echo "sha256=${sha256}" >>"${GITHUB_OUTPUT}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Upload resume PDF
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage cp "${LOCAL_RESUME_PATH}" "${RESUME_GCS_DESTINATION}" \
+            --content-type="application/pdf" \
+            --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
+            --cache-control="public, max-age=300, must-revalidate"
+
+      - name: Confirm public object ACL
+        id: acl
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage objects update "${RESUME_GCS_DESTINATION}" \
+            --add-acl-grant=entity=allUsers,role=READER
+          echo "result=allUsers READER object ACL applied" >>"${GITHUB_OUTPUT}"
+
+      - name: Verify public endpoints
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          append_cache_buster() {
+            local url="$1"
+            local token="$2"
+            if [[ "${url}" == *\?* ]]; then
+              printf '%s&resume_deploy_cache_bust=%s' "${url}" "${token}"
+            else
+              printf '%s?resume_deploy_cache_bust=%s' "${url}" "${token}"
+            fi
+          }
+
+          header_value() {
+            local headers="$1"
+            local name="$2"
+            awk -v wanted="${name}" 'BEGIN { IGNORECASE=1 } $0 ~ "^" wanted ":" { sub(/^[^:]*:[[:space:]]*/, ""); sub(/\r$/, ""); value=$0 } END { print value }' "${headers}"
+          }
+
+          verify_pdf_url() {
+            local label="$1"
+            local url="$2"
+            local body="$3"
+            local headers="$4"
+            local cache_busted_url
+            cache_busted_url=$(append_cache_buster "${url}" "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${label}")
+
+            curl --fail --silent --show-error --location \
+              --dump-header "${headers}" \
+              --output "${body}" \
+              "${cache_busted_url}"
+
+            if [ ! -s "${body}" ]; then
+              echo "::error::${label} response body is empty."
+              exit 1
+            fi
+
+            if ! head -c 5 "${body}" | grep -q '%PDF-'; then
+              echo "::error::${label} response is not a PDF byte stream."
+              exit 1
+            fi
+
+            local content_type
+            content_type=$(header_value "${headers}" "content-type")
+            if [[ "${content_type}" != *application/pdf* ]]; then
+              echo "::error::${label} Content-Type must include application/pdf; observed '${content_type}'."
+              exit 1
+            fi
+
+            local checksum
+            checksum=$(sha256sum "${body}" | awk '{print $1}')
+            if [ "${checksum}" != "${{ steps.local.outputs.sha256 }}" ]; then
+              echo "::error::${label} SHA-256 ${checksum} does not match local ${{ steps.local.outputs.sha256 }}."
+              exit 1
+            fi
+
+            local content_disposition
+            content_disposition=$(header_value "${headers}" "content-disposition")
+            local disposition_result="${content_disposition}"
+            if [ -z "${content_disposition}" ]; then
+              disposition_result="absent (warning: endpoint did not surface Content-Disposition)"
+              echo "::warning::${label} response did not include Content-Disposition."
+            elif [[ "${content_disposition,,}" != inline* ]]; then
+              echo "::error::${label} Content-Disposition must be inline when present; observed '${content_disposition}'."
+              exit 1
+            fi
+
+            {
+              echo "${label}_sha256=${checksum}"
+              echo "${label}_content_type=${content_type}"
+              echo "${label}_content_disposition=${disposition_result}"
+            } >>"${GITHUB_OUTPUT}"
+          }
+
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
+
+          verify_pdf_url storage "${RESUME_STORAGE_PUBLIC_URL}" \
+            "${tmpdir}/storage.pdf" "${tmpdir}/storage.headers"
+          verify_pdf_url canonical "${RESUME_PUBLIC_URL}" \
+            "${tmpdir}/canonical.pdf" "${tmpdir}/canonical.headers"
+
+          {
+            echo 'storage_headers<<EOF'
+            sed -e 's/[[:cntrl:]]$//' "${tmpdir}/storage.headers"
+            echo 'EOF'
+            echo 'canonical_headers<<EOF'
+            sed -e 's/[[:cntrl:]]$//' "${tmpdir}/canonical.headers"
+            echo 'EOF'
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Write deployment summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          status="success"
+          if [ "${{ job.status }}" != "success" ]; then
+            status="${{ job.status }}"
+          fi
+
+          {
+            echo "## Resume GCS deployment"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Source commit | \`${GITHUB_SHA}\` |"
+            echo "| Local file path | \`${LOCAL_RESUME_PATH}\` |"
+            echo "| Destination GCS URI | \`${RESUME_GCS_DESTINATION:-unset}\` |"
+            echo "| Storage URL | ${RESUME_STORAGE_PUBLIC_URL:-unset} |"
+            echo "| Canonical public URL | ${RESUME_PUBLIC_URL:-unset} |"
+            echo "| Local SHA-256 | \`${{ steps.local.outputs.sha256 || 'not calculated' }}\` |"
+            echo "| Storage URL SHA-256 | \`${{ steps.verify.outputs.storage_sha256 || 'not verified' }}\` |"
+            echo "| Canonical URL SHA-256 | \`${{ steps.verify.outputs.canonical_sha256 || 'not verified' }}\` |"
+            echo "| Storage Content-Type | \`${{ steps.verify.outputs.storage_content_type || 'not verified' }}\` |"
+            echo "| Canonical Content-Type | \`${{ steps.verify.outputs.canonical_content_type || 'not verified' }}\` |"
+            echo "| Storage Content-Disposition | \`${{ steps.verify.outputs.storage_content_disposition || 'not verified' }}\` |"
+            echo "| Canonical Content-Disposition | \`${{ steps.verify.outputs.canonical_content_disposition || 'not verified' }}\` |"
+            echo "| Object ACL/public-read verification | \`${{ steps.acl.outputs.result || 'not applied' }}\` |"
+            echo "| Final deployment status | \`${status}\` |"
+            echo
+            echo "### Storage URL response headers"
+            echo '```'
+            echo "${{ steps.verify.outputs.storage_headers || 'not captured' }}"
+            echo '```'
+            echo
+            echo "### Canonical URL response headers"
+            echo '```'
+            echo "${{ steps.verify.outputs.canonical_headers || 'not captured' }}"
+            echo '```'
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Avatar facing is computed from the camera-relative movement vector; see
   URL for runtime links, while `/resume.docx` is the stable downloadable DOCX
   URL (served from `public/resume.docx`) when a word-processor copy is useful. The immutable
   dated PDF archive for this source snapshot lives at
-  `public/docs/resume/2026-06/resume.pdf`.
+  `public/docs/resume/2026-06/resume.pdf`. Operators can deploy the stable PDF to
+  `resume.danielsmith.io` with the
+  [résumé hosting runbook](docs/ops/resume-hosting.md).
 - **Prompt library** – Automation-ready Codex prompts are summarized in
   [`summary.md`][prompt-summary] and expanded across topical files in
   `docs/prompts/codex/` (automation, lighting, avatar, HUD, POIs, accessibility, and more).

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -1,0 +1,208 @@
+# Résumé hosting runbook
+
+This runbook covers the dedicated résumé host at `resume.danielsmith.io`. It does
+not change the `danielsmith` or `danielsmith.io` website buckets, DNS,
+Cloudflare, load balancers, certificates, bucket website settings, bucket-level
+IAM, or the static-site deployment.
+
+## Current hosting model
+
+- Cloud Storage bucket: `resume.danielsmith.io`.
+- Deployed object: `Daniel_Smith_Resume.pdf`.
+- GCS destination: `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`.
+- Public storage URL:
+  `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf`.
+- Canonical public URL: `https://resume.danielsmith.io`.
+- Public access is object-level. The object ACL includes `allUsers` with the
+  `READER` role.
+
+P6 produces and persists `public/resume.pdf` in this repository. P8 deploys that
+exact PDF byte-for-byte to the existing GCS object above. The deployment does not
+compile TeX, regenerate artifacts, deploy `public/resume.docx`, or edit the PDF
+bytes.
+
+## Automated deployment
+
+The **Deploy resume to GCS** workflow (`.github/workflows/resume-gcs.yml`) runs
+on:
+
+- pushes to `main` that change `public/resume.pdf` or the workflow itself; and
+- manual `workflow_dispatch` runs.
+
+Pull requests never authenticate to Google Cloud and never deploy. The workflow
+uses GitHub OIDC with Google Workload Identity Federation, `gcloud storage`, and
+repository variables only. It does not use `gsutil`, long-lived service account
+JSON keys, or `contents: write`.
+
+The workflow uploads only `public/resume.pdf` to
+`gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf` with this metadata:
+
+```text
+Content-Type: application/pdf
+Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"
+Cache-Control: public, max-age=300, must-revalidate
+```
+
+After upload, it adds or confirms the object ACL grant with:
+
+```bash
+gcloud storage objects update \
+  "gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf" \
+  --add-acl-grant=entity=allUsers,role=READER
+```
+
+This preserves the object-level public-read model without making the bucket
+public, granting public write access, changing bucket IAM, or replacing other
+object ACL grants with `--predefined-acl=publicRead`.
+
+## Required repository variables
+
+Configure these repository variables before running the deployment workflow:
+
+| Variable                         | Expected value                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| `GCP_PROJECT_ID`                 | Google Cloud project ID for the `danielsmith io` project                       |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Workload Identity Provider resource name                                  |
+| `GCP_SERVICE_ACCOUNT`            | Dedicated deploy service account email                                         |
+| `RESUME_GCS_DESTINATION`         | `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf`                           |
+| `RESUME_PUBLIC_URL`              | `https://resume.danielsmith.io`                                                |
+| `RESUME_STORAGE_PUBLIC_URL`      | `https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` |
+
+Missing variables fail before any authentication or upload step.
+
+## Workload Identity Federation setup
+
+At a high level, Google Cloud should have:
+
+1. A dedicated service account for résumé deployment.
+2. A GitHub OIDC Workload Identity Provider.
+3. A repository-scoped trust condition for `futuroptimist/danielsmith.io`.
+4. Permission for the trusted GitHub principal to impersonate the service
+   account.
+5. Bucket-scoped object write permissions for `resume.danielsmith.io`.
+
+Prefer least privilege scoped to the `resume.danielsmith.io` bucket. Do not use
+project-wide Storage Admin except as a temporary troubleshooting step, and do not
+store service-account JSON keys in GitHub.
+
+## Manual break-glass deployment
+
+Use this only when the workflow cannot run and an operator has authenticated
+locally with `gcloud`.
+
+```bash
+set -euo pipefail
+
+local_pdf="public/resume.pdf"
+destination="gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+storage_url="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf"
+canonical_url="https://resume.danielsmith.io"
+
+local_sha256=$(sha256sum "${local_pdf}" | awk '{print $1}')
+
+gcloud storage cp "${local_pdf}" "${destination}" \
+  --content-type="application/pdf" \
+  --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
+  --cache-control="public, max-age=300, must-revalidate"
+
+gcloud storage objects update "${destination}" \
+  --add-acl-grant=entity=allUsers,role=READER
+
+for url in "${storage_url}" "${canonical_url}"; do
+  separator='?'
+  case "${url}" in *\?*) separator='&' ;; esac
+  tmp_pdf=$(mktemp)
+  tmp_headers=$(mktemp)
+  curl --fail --silent --show-error --location \
+    --dump-header "${tmp_headers}" \
+    --output "${tmp_pdf}" \
+    "${url}${separator}resume_manual_cache_bust=$(date +%s)"
+  test -s "${tmp_pdf}"
+  head -c 5 "${tmp_pdf}" | grep -q '%PDF-'
+  grep -i '^content-type:.*application/pdf' "${tmp_headers}"
+  remote_sha256=$(sha256sum "${tmp_pdf}" | awk '{print $1}')
+  test "${remote_sha256}" = "${local_sha256}"
+  rm -f "${tmp_pdf}" "${tmp_headers}"
+done
+```
+
+## Run `workflow_dispatch`
+
+1. Open **Actions** in GitHub.
+2. Select **Deploy resume to GCS**.
+3. Choose **Run workflow** on `main`.
+4. Confirm the job summary reports matching SHA-256 values for the local file,
+   storage URL, and canonical URL.
+
+## Verify from a shell
+
+```bash
+set -euo pipefail
+
+local_pdf="public/resume.pdf"
+local_sha256=$(sha256sum "${local_pdf}" | awk '{print $1}')
+
+for url in \
+  "https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf" \
+  "https://resume.danielsmith.io"; do
+  separator='?'
+  case "${url}" in *\?*) separator='&' ;; esac
+  tmp_pdf=$(mktemp)
+  tmp_headers=$(mktemp)
+  curl --fail --silent --show-error --location \
+    --dump-header "${tmp_headers}" \
+    --output "${tmp_pdf}" \
+    "${url}${separator}resume_verify_cache_bust=$(date +%s)"
+  test -s "${tmp_pdf}"
+  head -c 5 "${tmp_pdf}" | grep -q '%PDF-'
+  grep -i '^content-type:.*application/pdf' "${tmp_headers}"
+  remote_sha256=$(sha256sum "${tmp_pdf}" | awk '{print $1}')
+  test "${remote_sha256}" = "${local_sha256}"
+  printf '%s %s\n' "${remote_sha256}" "${url}"
+  rm -f "${tmp_pdf}" "${tmp_headers}"
+done
+```
+
+`Content-Disposition` should be `inline; filename="Daniel_Smith_Resume.pdf"`
+when surfaced. Some custom-domain paths may omit it; treat that as a warning if
+the response is otherwise an unauthenticated non-empty PDF with matching bytes.
+
+## Rollback
+
+Rollback by changing the stable repository artifact and letting the workflow
+redeploy it:
+
+- restore `public/resume.pdf` from a prior Git commit that contained the desired
+  PDF; or
+- copy a prior `public/docs/resume/<version>/resume.pdf` over the stable
+  `public/resume.pdf` in a rollback PR.
+
+Do not edit generated PDF bytes manually. Merge the rollback PR to `main`; the
+workflow will publish the restored stable PDF to the existing GCS object.
+
+## Troubleshooting
+
+- **Missing repository variables:** the first validation step lists every missing
+  variable and exits before authentication.
+- **OIDC trust failures:** confirm the provider resource in
+  `GCP_WORKLOAD_IDENTITY_PROVIDER` and the repository-scoped condition for
+  `futuroptimist/danielsmith.io`.
+- **Service account impersonation failures:** confirm the GitHub OIDC principal
+  can impersonate `GCP_SERVICE_ACCOUNT`.
+- **Bucket permission failures:** grant only the bucket-scoped object permissions
+  needed to write `resume.danielsmith.io/Daniel_Smith_Resume.pdf`.
+- **Object ACL/public-read failures:** confirm uniform bucket-level access is not
+  blocking object ACLs and rerun the `gcloud storage objects update` ACL grant.
+- **Content-Type mismatch:** reapply the upload metadata and verify the storage
+  URL headers before debugging the canonical URL.
+- **Content-Disposition mismatch:** reapply metadata. If only the canonical URL
+  omits the header but the bytes and PDF content type match, treat it as custom
+  domain behavior rather than a failed deployment.
+- **Canonical URL not matching storage URL:** compare checksums from both public
+  endpoints and inspect cache or custom-domain routing before changing storage.
+- **Cache propagation:** wait at least the five-minute cache window implied by
+  `Cache-Control: public, max-age=300, must-revalidate`, then verify with a new
+  cache-busting query parameter.
+- **Checksum mismatch:** stop and compare the local `public/resume.pdf` SHA-256
+  with both downloaded files. Do not deploy `public/resume.docx` or regenerate
+  artifacts in this workflow.


### PR DESCRIPTION
### Motivation
- Provide a secure, repeatable GitHub Actions path that publishes the committed stable resume at `public/resume.pdf` to the existing Cloud Storage object `gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf` while preserving the current object-level public-read ACL model.
- Use short-lived credentials via GitHub OIDC / Google Workload Identity Federation (WIF) rather than committing long-lived keys and avoid changing buckets, DNS, or any hosting configuration.

### Description
- Added a new workflow at `.github/workflows/resume-gcs.yml` that triggers on push to `main` when `public/resume.pdf` or the workflow changes and supports `workflow_dispatch`, uses `permissions: contents: read` and `id-token: write`, enforces concurrency, and explicitly does not run on `pull_request`.
- The workflow reads all configuration from repository variables (`vars.*`), fails early if any required variable is missing, computes the local SHA-256 of `public/resume.pdf`, authenticates via `google-github-actions/auth@v2` (OIDC/WIF) and `google-github-actions/setup-gcloud@v2`, uploads the single file with `gcloud storage cp` and the requested metadata (`Content-Type`, `Content-Disposition`, `Cache-Control`), then reapplies/ensures the `allUsers` Reader object ACL with `gcloud storage objects update --add-acl-grant=entity=allUsers,role=READER`.
- Verification steps download both the storage URL and the canonical URL with a cache-busting query param, validate non-empty PDF bytes and `application/pdf` content type, check (and warn if absent) `Content-Disposition`, compare SHA-256 for byte-for-byte parity with the local file, and emit a detailed job summary (commit SHA, paths/URIs, checksums, content-type/disposition observations, ACL result, and response headers).
- Added `docs/ops/resume-hosting.md` documenting the hosting model, required repository variables, WIF setup guidance, manual break-glass `gcloud` instructions, verification commands, rollback guidance, and troubleshooting notes, and added a README link to the runbook.

### Testing
- Ran repository checks locally: `npm run format:write` (ok), `npm run format:check` (ok), `npm run docs:check` (ok; link checker emitted existing external fetch warnings), and `git diff --check` (ok).
- Ran code/test checks: `npm run lint` (ok), `npm run test:ci` (Vitest suite passed), and `npm run smoke` (build + smoke assertions passed).
- Validated workflow/shell fragments and artifact presence: `bash -n` of extracted `run:` blocks (syntax-checked), `sha256sum public/resume.pdf` and PDF magic-byte check (local checksum and PDF validation succeeded), and `git diff --cached | ./scripts/scan-secrets.py` (no secrets found).
- Not run in this environment: `actionlint` and `shellcheck` were not available so they were not executed here (the workflow shell was syntax-checked with `bash -n`).

Production upload and live URL verification require the configured repository variables (`GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `RESUME_GCS_DESTINATION`, `RESUME_PUBLIC_URL`, `RESUME_STORAGE_PUBLIC_URL`) and a proper Google WIF/service-account setup; the workflow is intentionally designed to fail early if those are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37126d3930832f8f8f0402c5c43874)