### PR TITLE
Prevent stale resume cache after GCS deploys

### DIFF
--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -36,6 +36,7 @@ jobs:
       RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
       RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
       RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
+      RESUME_CACHE_CONTROL: no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate
     if: >-
       ${{ github.event_name != 'workflow_run' ||
         (github.event.workflow_run.conclusion == 'success' &&
@@ -133,7 +134,7 @@ jobs:
             --project="${GCP_PROJECT_ID}" \
             --content-type="application/pdf" \
             --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
-            --cache-control="public, max-age=300, must-revalidate"
+            --cache-control="${RESUME_CACHE_CONTROL}"
 
           gcloud storage objects update "${RESUME_GCS_DESTINATION}" \
             --project="${GCP_PROJECT_ID}" \
@@ -154,17 +155,55 @@ jobs:
             esac
           }
 
-          download_and_verify() {
+          header_value() {
+            local header="$1"
+            local headers_file="$2"
+            awk -v header="${header}" '
+              BEGIN{IGNORECASE=1}
+              index($0, header ":") == 1 {sub(/^[^:]+:[[:space:]]*/, ""); value=$0}
+              END{print value}
+            ' "${headers_file}" | tr -d '\r'
+          }
+
+          cache_control_is_no_stale() {
+            local cache_control="$1"
+            [ "${cache_control}" = "${RESUME_CACHE_CONTROL}" ] || \
+              printf '%s\n' "${cache_control}" | grep -Eiq '(^|[,[:space:]])(no-cache|max-age=0)([,[:space:]]|$)'
+          }
+
+          record_headers() {
+            local output_prefix="$1"
+            local headers_file="$2"
+            {
+              echo "${output_prefix}_cache_control=$(header_value cache-control "${headers_file}")"
+              echo "${output_prefix}_age=$(header_value age "${headers_file}")"
+              echo "${output_prefix}_etag=$(header_value etag "${headers_file}")"
+              echo "${output_prefix}_last_modified=$(header_value last-modified "${headers_file}")"
+              echo "${output_prefix}_cf_cache_status=$(header_value cf-cache-status "${headers_file}")"
+              echo "${output_prefix}_server=$(header_value server "${headers_file}")"
+              echo "${output_prefix}_headers<<EOF_HEADERS_${output_prefix}"
+              sed -n '1,30p' "${headers_file}" | sed 's/[[:cntrl:]]$//'
+              echo "EOF_HEADERS_${output_prefix}"
+            } >>"${GITHUB_OUTPUT}"
+          }
+
+          print_cache_headers() {
+            local headers_file="$1"
+            awk 'BEGIN{IGNORECASE=1} /^(cache-control|age|etag|last-modified|cf-cache-status|server):/ {print}' \
+              "${headers_file}" | sed 's/[[:cntrl:]]$//'
+          }
+
+          fetch_and_verify() {
             local label="$1"
             local url="$2"
             local output_dir="$3"
             local expected_sha="$4"
-            local cache_busted_url body_file headers_file status_file http_code sha content_type content_disposition
+            local output_prefix="$5"
+            local body_file headers_file status_file http_code sha content_type content_disposition cache_control
 
-            cache_busted_url="$(append_cache_buster "${url}" "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}")"
-            body_file="${output_dir}/${label}.pdf"
-            headers_file="${output_dir}/${label}.headers"
-            status_file="${output_dir}/${label}.status"
+            body_file="${output_dir}/${output_prefix}.pdf"
+            headers_file="${output_dir}/${output_prefix}.headers"
+            status_file="${output_dir}/${output_prefix}.status"
 
             http_code="$(curl --location --silent --show-error \
               --connect-timeout 10 \
@@ -175,59 +214,118 @@ jobs:
               --dump-header "${headers_file}" \
               --output "${body_file}" \
               --write-out '%{http_code}' \
-              "${cache_busted_url}")"
+              "${url}")"
             printf '%s\n' "${http_code}" >"${status_file}"
 
             if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
               echo "::error::${label} URL returned HTTP ${http_code}."
-              exit 1
+              print_cache_headers "${headers_file}"
+              return 1
             fi
 
             if [ ! -s "${body_file}" ]; then
               echo "::error::${label} URL returned an empty body."
-              exit 1
+              print_cache_headers "${headers_file}"
+              return 1
             fi
 
             if [ "$(head -c 5 "${body_file}")" != "%PDF-" ]; then
               echo "::error::${label} URL did not return PDF bytes."
-              exit 1
+              print_cache_headers "${headers_file}"
+              return 1
             fi
 
             sha="$(sha256sum "${body_file}" | awk '{print $1}')"
             if [ "${sha}" != "${expected_sha}" ]; then
               echo "::error::${label} SHA-256 ${sha} does not match local ${expected_sha}."
-              exit 1
+              print_cache_headers "${headers_file}"
+              return 1
             fi
 
-            content_type="$(awk 'BEGIN{IGNORECASE=1} /^content-type:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}' "${headers_file}" | tr -d '\r')"
+            content_type="$(header_value content-type "${headers_file}")"
             if ! printf '%s\n' "${content_type}" | grep -Eiq '(^|[[:space:];])application/pdf([[:space:];]|$)'; then
               echo "::error::${label} Content-Type must include application/pdf; observed '${content_type}'."
-              exit 1
+              print_cache_headers "${headers_file}"
+              return 1
             fi
 
-            content_disposition="$(awk 'BEGIN{IGNORECASE=1} /^content-disposition:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}' "${headers_file}" | tr -d '\r')"
+            cache_control="$(header_value cache-control "${headers_file}")"
+            if ! cache_control_is_no_stale "${cache_control}"; then
+              echo "::error::${label} Cache-Control must be no-stale; observed '${cache_control}'."
+              print_cache_headers "${headers_file}"
+              return 1
+            fi
+
+            content_disposition="$(header_value content-disposition "${headers_file}")"
             if [ -n "${content_disposition}" ] && \
               ! printf '%s\n' "${content_disposition}" | grep -Eiq '^inline([[:space:];]|$)'; then
               echo "::error::${label} Content-Disposition must be inline or absent; observed '${content_disposition}'."
-              exit 1
+              return 1
             fi
 
             {
-              echo "${label}_sha256=${sha}"
-              echo "${label}_content_type=${content_type}"
-              echo "${label}_content_disposition=${content_disposition:-absent}"
-              echo "${label}_headers<<EOF_HEADERS_${label}"
-              sed -n '1,20p' "${headers_file}" | sed 's/[[:cntrl:]]$//'
-              echo "EOF_HEADERS_${label}"
+              echo "${output_prefix}_sha256=${sha}"
+              echo "${output_prefix}_content_type=${content_type}"
+              echo "${output_prefix}_content_disposition=${content_disposition:-absent}"
             } >>"${GITHUB_OUTPUT}"
+            record_headers "${output_prefix}" "${headers_file}"
+          }
+
+          retry_bare_url() {
+            local label="$1"
+            local url="$2"
+            local output_dir="$3"
+            local expected_sha="$4"
+            local output_prefix="$5"
+            local deadline=$((SECONDS + 600))
+            local attempt=1
+
+            while true; do
+              echo "Checking bare ${label} URL attempt ${attempt}: ${url}"
+              if fetch_and_verify "bare ${label}" "${url}" "${output_dir}" "${expected_sha}" "${output_prefix}"; then
+                return 0
+              fi
+
+              if [ "${SECONDS}" -ge "${deadline}" ]; then
+                local body_file="${output_dir}/${output_prefix}.pdf"
+                local headers_file="${output_dir}/${output_prefix}.headers"
+                local observed_sha="missing"
+                if [ -s "${body_file}" ]; then
+                  observed_sha="$(sha256sum "${body_file}" | awk '{print $1}')"
+                fi
+                echo "::error::Bare ${label} URL did not return the new PDF before timeout. Observed SHA-256: ${observed_sha}; expected: ${expected_sha}."
+                print_cache_headers "${headers_file}"
+                return 1
+              fi
+
+              sleep 10
+              attempt=$((attempt + 1))
+            done
           }
 
           tmpdir="$(mktemp -d)"
           trap 'rm -rf "${tmpdir}"' EXIT
 
           local_sha256="${{ steps.upload.outputs.local_sha256 }}"
-          download_and_verify storage "${RESUME_STORAGE_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
-          download_and_verify canonical "${RESUME_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
+
+          # Cache-busted storage URL verifies the uploaded object bytes.
+          fetch_and_verify \
+            "cache-busted storage" \
+            "$(append_cache_buster "${RESUME_STORAGE_PUBLIC_URL}" "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}")" \
+            "${tmpdir}" \
+            "${local_sha256}" \
+            "cache_busted_storage"
+
+          # Cache-busted canonical URL verifies routing can fetch the new object bytes.
+          fetch_and_verify \
+            "cache-busted canonical" \
+            "$(append_cache_buster "${RESUME_PUBLIC_URL}" "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}")" \
+            "${tmpdir}" \
+            "${local_sha256}" \
+            "cache_busted_canonical"
+
+          retry_bare_url "storage" "${RESUME_STORAGE_PUBLIC_URL}" "${tmpdir}" "${local_sha256}" "bare_storage"
+          retry_bare_url "canonical" "${RESUME_PUBLIC_URL}" "${tmpdir}" "${local_sha256}" "bare_canonical"
 
           acl_json="${tmpdir}/acl.json"
           gcloud storage objects describe "${RESUME_GCS_DESTINATION}" \
@@ -266,15 +364,31 @@ jobs:
         env:
           SOURCE_COMMIT_SHA: ${{ steps.source.outputs.sha }}
           LOCAL_SHA256: ${{ steps.upload.outputs.local_sha256 }}
-          STORAGE_SHA256: ${{ steps.verify.outputs.storage_sha256 }}
-          CANONICAL_SHA256: ${{ steps.verify.outputs.canonical_sha256 }}
-          STORAGE_CONTENT_TYPE: ${{ steps.verify.outputs.storage_content_type }}
-          CANONICAL_CONTENT_TYPE: ${{ steps.verify.outputs.canonical_content_type }}
-          STORAGE_CONTENT_DISPOSITION: ${{ steps.verify.outputs.storage_content_disposition }}
-          CANONICAL_CONTENT_DISPOSITION: ${{ steps.verify.outputs.canonical_content_disposition }}
+          CACHE_BUSTED_STORAGE_SHA256: ${{ steps.verify.outputs.cache_busted_storage_sha256 }}
+          CACHE_BUSTED_CANONICAL_SHA256: ${{ steps.verify.outputs.cache_busted_canonical_sha256 }}
+          BARE_STORAGE_SHA256: ${{ steps.verify.outputs.bare_storage_sha256 }}
+          BARE_CANONICAL_SHA256: ${{ steps.verify.outputs.bare_canonical_sha256 }}
+          BARE_STORAGE_CONTENT_TYPE: ${{ steps.verify.outputs.bare_storage_content_type }}
+          BARE_CANONICAL_CONTENT_TYPE: ${{ steps.verify.outputs.bare_canonical_content_type }}
+          BARE_STORAGE_CONTENT_DISPOSITION: ${{ steps.verify.outputs.bare_storage_content_disposition }}
+          BARE_CANONICAL_CONTENT_DISPOSITION: ${{ steps.verify.outputs.bare_canonical_content_disposition }}
+          BARE_STORAGE_CACHE_CONTROL: ${{ steps.verify.outputs.bare_storage_cache_control }}
+          BARE_CANONICAL_CACHE_CONTROL: ${{ steps.verify.outputs.bare_canonical_cache_control }}
+          BARE_STORAGE_AGE: ${{ steps.verify.outputs.bare_storage_age }}
+          BARE_CANONICAL_AGE: ${{ steps.verify.outputs.bare_canonical_age }}
+          BARE_STORAGE_ETAG: ${{ steps.verify.outputs.bare_storage_etag }}
+          BARE_CANONICAL_ETAG: ${{ steps.verify.outputs.bare_canonical_etag }}
+          BARE_STORAGE_LAST_MODIFIED: ${{ steps.verify.outputs.bare_storage_last_modified }}
+          BARE_CANONICAL_LAST_MODIFIED: ${{ steps.verify.outputs.bare_canonical_last_modified }}
+          BARE_STORAGE_CF_CACHE_STATUS: ${{ steps.verify.outputs.bare_storage_cf_cache_status }}
+          BARE_CANONICAL_CF_CACHE_STATUS: ${{ steps.verify.outputs.bare_canonical_cf_cache_status }}
+          BARE_STORAGE_SERVER: ${{ steps.verify.outputs.bare_storage_server }}
+          BARE_CANONICAL_SERVER: ${{ steps.verify.outputs.bare_canonical_server }}
           PUBLIC_ACL: ${{ steps.verify.outputs.public_acl }}
-          STORAGE_HEADERS: ${{ steps.verify.outputs.storage_headers }}
-          CANONICAL_HEADERS: ${{ steps.verify.outputs.canonical_headers }}
+          CACHE_BUSTED_STORAGE_HEADERS: ${{ steps.verify.outputs.cache_busted_storage_headers }}
+          CACHE_BUSTED_CANONICAL_HEADERS: ${{ steps.verify.outputs.cache_busted_canonical_headers }}
+          BARE_STORAGE_HEADERS: ${{ steps.verify.outputs.bare_storage_headers }}
+          BARE_CANONICAL_HEADERS: ${{ steps.verify.outputs.bare_canonical_headers }}
           JOB_STATUS: ${{ job.status }}
         run: |
           set -euo pipefail
@@ -289,29 +403,56 @@ jobs:
             echo "| Destination GCS URI | \`${RESUME_GCS_DESTINATION}\` |"
             echo "| Storage URL | ${RESUME_STORAGE_PUBLIC_URL} |"
             echo "| Canonical public URL | ${RESUME_PUBLIC_URL} |"
+            echo "| Expected Cache-Control | \`${RESUME_CACHE_CONTROL}\` |"
             echo "| Local SHA-256 | \`${LOCAL_SHA256}\` |"
-            echo "| Storage URL SHA-256 | \`${STORAGE_SHA256}\` |"
-            echo "| Canonical URL SHA-256 | \`${CANONICAL_SHA256}\` |"
-            echo "| Storage Content-Type | \`${STORAGE_CONTENT_TYPE}\` |"
-            echo "| Canonical Content-Type | \`${CANONICAL_CONTENT_TYPE}\` |"
+            echo "| Cache-busted storage SHA-256 | \`${CACHE_BUSTED_STORAGE_SHA256}\` |"
+            echo "| Cache-busted canonical SHA-256 | \`${CACHE_BUSTED_CANONICAL_SHA256}\` |"
+            echo "| Bare storage SHA-256 | \`${BARE_STORAGE_SHA256}\` |"
+            echo "| Bare canonical SHA-256 | \`${BARE_CANONICAL_SHA256}\` |"
+            echo "| Bare storage Content-Type | \`${BARE_STORAGE_CONTENT_TYPE}\` |"
+            echo "| Bare canonical Content-Type | \`${BARE_CANONICAL_CONTENT_TYPE}\` |"
+            echo "| Bare storage Cache-Control | \`${BARE_STORAGE_CACHE_CONTROL}\` |"
+            echo "| Bare canonical Cache-Control | \`${BARE_CANONICAL_CACHE_CONTROL}\` |"
+            echo "| Bare storage Age | \`${BARE_STORAGE_AGE:-absent}\` |"
+            echo "| Bare canonical Age | \`${BARE_CANONICAL_AGE:-absent}\` |"
+            echo "| Bare storage ETag | \`${BARE_STORAGE_ETAG:-absent}\` |"
+            echo "| Bare canonical ETag | \`${BARE_CANONICAL_ETAG:-absent}\` |"
+            echo "| Bare storage Last-Modified | \`${BARE_STORAGE_LAST_MODIFIED:-absent}\` |"
+            echo "| Bare canonical Last-Modified | \`${BARE_CANONICAL_LAST_MODIFIED:-absent}\` |"
+            echo "| Bare storage CF-Cache-Status | \`${BARE_STORAGE_CF_CACHE_STATUS:-absent}\` |"
+            echo "| Bare canonical CF-Cache-Status | \`${BARE_CANONICAL_CF_CACHE_STATUS:-absent}\` |"
+            echo "| Bare storage Server | \`${BARE_STORAGE_SERVER:-absent}\` |"
+            echo "| Bare canonical Server | \`${BARE_CANONICAL_SERVER:-absent}\` |"
             echo "| Object ACL/public-read verification | \`${PUBLIC_ACL}\` |"
             echo "| Final deployment status | \`${JOB_STATUS}\` |"
             echo
-            if [ "${STORAGE_CONTENT_DISPOSITION}" = "absent" ]; then
-              echo "> Warning: the storage URL did not expose Content-Disposition."
+            echo "The bare canonical URL is live only when its SHA-256 matches the local file SHA-256."
+            echo
+            if [ "${BARE_STORAGE_CONTENT_DISPOSITION}" = "absent" ]; then
+              echo "> Warning: the bare storage URL did not expose Content-Disposition."
               echo
             fi
-            if [ "${CANONICAL_CONTENT_DISPOSITION}" = "absent" ]; then
-              echo "> Warning: the canonical URL did not expose Content-Disposition."
+            if [ "${BARE_CANONICAL_CONTENT_DISPOSITION}" = "absent" ]; then
+              echo "> Warning: the bare canonical URL did not expose Content-Disposition."
               echo
             fi
-            echo "### Storage URL response headers"
+            echo "### Cache-busted storage URL response headers"
             echo '```'
-            printf '%s\n' "${STORAGE_HEADERS}"
+            printf '%s\n' "${CACHE_BUSTED_STORAGE_HEADERS}"
             echo '```'
             echo
-            echo "### Canonical URL response headers"
+            echo "### Cache-busted canonical URL response headers"
             echo '```'
-            printf '%s\n' "${CANONICAL_HEADERS}"
+            printf '%s\n' "${CACHE_BUSTED_CANONICAL_HEADERS}"
+            echo '```'
+            echo
+            echo "### Bare storage URL response headers"
+            echo '```'
+            printf '%s\n' "${BARE_STORAGE_HEADERS}"
+            echo '```'
+            echo
+            echo "### Bare canonical URL response headers"
+            echo '```'
+            printf '%s\n' "${BARE_CANONICAL_HEADERS}"
             echo '```'
           } >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -222,7 +222,18 @@ jobs:
               echo "No response headers captured."
               return 0
             fi
-            final_response_headers "${headers_file}" | awk 'BEGIN{IGNORECASE=1} /^(cache-control|age|etag|last-modified|cf-cache-status|server):/ {print}'
+            final_response_headers "${headers_file}" | awk '
+              /^[[:space:]]*$/ {next}
+              {
+                name=$0
+                sub(/:.*/, "", name)
+                name=tolower(name)
+                if (name == "cache-control" || name == "age" || name == "etag" || \
+                    name == "last-modified" || name == "cf-cache-status" || name == "server") {
+                  print
+                }
+              }
+            '
           }
 
           fetch_and_verify() {
@@ -296,6 +307,7 @@ jobs:
             if [ -n "${content_disposition}" ] && \
               ! printf '%s\n' "${content_disposition}" | grep -Eiq '^inline([[:space:];]|$)'; then
               echo "::error::${label} Content-Disposition must be inline or absent; observed '${content_disposition}'."
+              print_cache_headers "${headers_file}"
               return 1
             fi
 

--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -159,9 +159,26 @@ jobs:
             local header="$1"
             local headers_file="$2"
             awk -v header="${header}" '
-              BEGIN{IGNORECASE=1}
-              index($0, header ":") == 1 {sub(/^[^:]+:[[:space:]]*/, ""); value=$0}
-              END{print value}
+              BEGIN{IGNORECASE=1; target=tolower(header)}
+              /^HTTP\// {
+                in_headers=1
+                delete values
+                next
+              }
+              in_headers && /^[[:space:]]*$/ {
+                in_headers=0
+                next
+              }
+              in_headers {
+                name=$0
+                sub(/:.*/, "", name)
+                if (tolower(name) == target) {
+                  value=$0
+                  sub(/^[^:]+:[[:space:]]*/, "", value)
+                  values[target]=value
+                }
+              }
+              END{print values[target]}
             ' "${headers_file}" | tr -d '\r'
           }
 
@@ -189,6 +206,10 @@ jobs:
 
           print_cache_headers() {
             local headers_file="$1"
+            if [ ! -s "${headers_file}" ]; then
+              echo "No response headers captured."
+              return 0
+            fi
             awk 'BEGIN{IGNORECASE=1} /^(cache-control|age|etag|last-modified|cf-cache-status|server):/ {print}' \
               "${headers_file}" | sed 's/[[:cntrl:]]$//'
           }
@@ -205,7 +226,7 @@ jobs:
             headers_file="${output_dir}/${output_prefix}.headers"
             status_file="${output_dir}/${output_prefix}.status"
 
-            http_code="$(curl --location --silent --show-error \
+            if ! http_code="$(curl --location --silent --show-error \
               --connect-timeout 10 \
               --max-time 60 \
               --retry 3 \
@@ -214,7 +235,11 @@ jobs:
               --dump-header "${headers_file}" \
               --output "${body_file}" \
               --write-out '%{http_code}' \
-              "${url}")"
+              "${url}")"; then
+              echo "::error::${label} URL could not be fetched."
+              print_cache_headers "${headers_file}"
+              return 1
+            fi
             printf '%s\n' "${http_code}" >"${status_file}"
 
             if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then

--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -155,21 +155,33 @@ jobs:
             esac
           }
 
-          header_value() {
-            local header="$1"
-            local headers_file="$2"
-            awk -v header="${header}" '
-              BEGIN{IGNORECASE=1; target=tolower(header)}
+          final_response_headers() {
+            local headers_file="$1"
+            awk '
+              BEGIN{block=""}
               /^HTTP\// {
                 in_headers=1
-                delete values
-                next
-              }
-              in_headers && /^[[:space:]]*$/ {
-                in_headers=0
+                block=$0 "\n"
                 next
               }
               in_headers {
+                block=block $0 "\n"
+                if ($0 ~ /^[[:space:]]*$/) {
+                  last_block=block
+                  in_headers=0
+                }
+              }
+              END{printf "%s", last_block}
+            ' "${headers_file}" | sed 's/[[:cntrl:]]$//'
+          }
+
+          header_value() {
+            local header="$1"
+            local headers_file="$2"
+            final_response_headers "${headers_file}" | awk -v header="${header}" '
+              BEGIN{IGNORECASE=1; target=tolower(header)}
+              /^[[:space:]]*$/ {next}
+              {
                 name=$0
                 sub(/:.*/, "", name)
                 if (tolower(name) == target) {
@@ -179,7 +191,7 @@ jobs:
                 }
               }
               END{print values[target]}
-            ' "${headers_file}" | tr -d '\r'
+            '
           }
 
           cache_control_is_no_stale() {
@@ -199,7 +211,7 @@ jobs:
               echo "${output_prefix}_cf_cache_status=$(header_value cf-cache-status "${headers_file}")"
               echo "${output_prefix}_server=$(header_value server "${headers_file}")"
               echo "${output_prefix}_headers<<EOF_HEADERS_${output_prefix}"
-              sed -n '1,30p' "${headers_file}" | sed 's/[[:cntrl:]]$//'
+              final_response_headers "${headers_file}" | sed -n '1,30p'
               echo "EOF_HEADERS_${output_prefix}"
             } >>"${GITHUB_OUTPUT}"
           }
@@ -210,8 +222,7 @@ jobs:
               echo "No response headers captured."
               return 0
             fi
-            awk 'BEGIN{IGNORECASE=1} /^(cache-control|age|etag|last-modified|cf-cache-status|server):/ {print}' \
-              "${headers_file}" | sed 's/[[:cntrl:]]$//'
+            final_response_headers "${headers_file}" | awk 'BEGIN{IGNORECASE=1} /^(cache-control|age|etag|last-modified|cf-cache-status|server):/ {print}'
           }
 
           fetch_and_verify() {

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -82,7 +82,7 @@ The workflow uploads only `public/resume.pdf` to
 
 - `Content-Type: application/pdf`
 - `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"`
-- `Cache-Control: public, max-age=300, must-revalidate`
+- `Cache-Control: no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate`
 
 After upload, it runs:
 
@@ -95,6 +95,16 @@ gcloud storage objects update \
 This preserves existing object ACL grants while adding or confirming public read access.
 Do not use canned public-read ACL replacement flags unless a future runbook change
 explicitly explains why replacing other object ACL grants is acceptable.
+
+Because `resume.danielsmith.io` is a stable URL whose PDF bytes can change after a
+resume update, it intentionally uses a no-stale cache policy:
+`no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate`. Do not replace
+this with a short positive `max-age` policy for the stable alias. A previous object
+response with `cache-control: public, max-age=3600` can remain stale at the bare URL
+even after a successful upload. Cache-busted URLs can show the new object while
+`https://resume.danielsmith.io/` still serves the old object, and Cloudflare purge may
+not help when `cf-cache-status` is `DYNAMIC` because the stale response can be coming
+from GCS, Google edge, or other origin-side public-object caching.
 
 ## Running `workflow_dispatch`
 
@@ -119,6 +129,7 @@ LOCAL_RESUME_PATH="public/resume.pdf"
 DESTINATION="gs://resume.danielsmith.io/Daniel_Smith_Resume.pdf"
 STORAGE_URL="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf"
 CANONICAL_URL="https://resume.danielsmith.io"
+CACHE_CONTROL="no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate"
 
 if [ ! -s "${LOCAL_RESUME_PATH}" ]; then
   echo "${LOCAL_RESUME_PATH} is missing or empty. Run Resume artifacts first." >&2
@@ -130,33 +141,44 @@ local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
 gcloud storage cp "${LOCAL_RESUME_PATH}" "${DESTINATION}" \
   --content-type="application/pdf" \
   --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
-  --cache-control="public, max-age=300, must-revalidate"
+  --cache-control="${CACHE_CONTROL}"
 
 gcloud storage objects update "${DESTINATION}" \
   --add-acl-grant=entity=allUsers,role=READER
 
-for url in "${STORAGE_URL}" "${CANONICAL_URL}"; do
-  tmp="$(mktemp)"
-  curl --location --fail --silent --show-error \
-    --connect-timeout 10 \
-    --max-time 60 \
-    --retry 3 \
-    --retry-delay 2 \
-    --retry-connrefused \
-    "${url}?resume_verify=$(date +%s)" \
-    --output "${tmp}"
-  test -s "${tmp}"
-  test "$(head -c 5 "${tmp}")" = "%PDF-"
-  remote_sha256="$(sha256sum "${tmp}" | awk '{print $1}')"
-  rm -f "${tmp}"
-  test "${remote_sha256}" = "${local_sha256}"
+for mode in cache-busted bare; do
+  for url in "${STORAGE_URL}" "${CANONICAL_URL}"; do
+    tmpdir="$(mktemp -d)"
+    verify_url="${url}"
+    if [ "${mode}" = "cache-busted" ]; then
+      verify_url="${url}?resume_verify=$(date +%s)"
+    fi
+
+    curl --location --fail --silent --show-error \
+      --connect-timeout 10 \
+      --max-time 60 \
+      --retry 3 \
+      --retry-delay 2 \
+      --retry-connrefused \
+      --dump-header "${tmpdir}/headers" \
+      --output "${tmpdir}/resume.pdf" \
+      "${verify_url}"
+    test -s "${tmpdir}/resume.pdf"
+    test "$(head -c 5 "${tmpdir}/resume.pdf")" = "%PDF-"
+    grep -Ei '^content-type:.*application/pdf' "${tmpdir}/headers"
+    grep -Ei '^cache-control:.*(no-cache|max-age=0)' "${tmpdir}/headers"
+    remote_sha256="$(sha256sum "${tmpdir}/resume.pdf" | awk '{print $1}')"
+    test "${remote_sha256}" = "${local_sha256}"
+    rm -rf "${tmpdir}"
+  done
 done
 ```
 
 ## Shell verification
 
-After any deployment, verify both public endpoints are reachable without authentication
-and match the repository PDF:
+After any deployment, verify cache-busted URLs for immediate object integrity and
+bare URLs for actual public readiness. The bare canonical URL is not live until its
+SHA-256 matches the local file SHA-256:
 
 ```bash
 set -euo pipefail
@@ -172,23 +194,33 @@ for label in storage canonical; do
     canonical) url="${CANONICAL_URL}" ;;
   esac
 
-  tmpdir="$(mktemp -d)"
-  curl --location --fail --silent --show-error \
-    --connect-timeout 10 \
-    --max-time 60 \
-    --retry 3 \
-    --retry-delay 2 \
-    --retry-connrefused \
-    --dump-header "${tmpdir}/${label}.headers" \
-    --output "${tmpdir}/${label}.pdf" \
-    "${url}?resume_verify=$(date +%s)"
+  for mode in cache-busted bare; do
+    tmpdir="$(mktemp -d)"
+    verify_url="${url}"
+    if [ "${mode}" = "cache-busted" ]; then
+      verify_url="${url}?resume_verify=$(date +%s)"
+    fi
 
-  test -s "${tmpdir}/${label}.pdf"
-  test "$(head -c 5 "${tmpdir}/${label}.pdf")" = "%PDF-"
-  grep -Ei '^content-type:.*application/pdf' "${tmpdir}/${label}.headers"
-  remote_sha256="$(sha256sum "${tmpdir}/${label}.pdf" | awk '{print $1}')"
-  test "${remote_sha256}" = "${local_sha256}"
-  rm -rf "${tmpdir}"
+    curl --location --fail --silent --show-error \
+      --connect-timeout 10 \
+      --max-time 60 \
+      --retry 3 \
+      --retry-delay 2 \
+      --retry-connrefused \
+      --dump-header "${tmpdir}/${label}-${mode}.headers" \
+      --output "${tmpdir}/${label}-${mode}.pdf" \
+      "${verify_url}"
+
+    test -s "${tmpdir}/${label}-${mode}.pdf"
+    test "$(head -c 5 "${tmpdir}/${label}-${mode}.pdf")" = "%PDF-"
+    grep -Ei '^content-type:.*application/pdf' "${tmpdir}/${label}-${mode}.headers"
+    grep -Ei '^cache-control:.*(no-cache|max-age=0)' "${tmpdir}/${label}-${mode}.headers"
+    grep -Ei '^(cache-control|age|etag|last-modified|cf-cache-status|server):' \
+      "${tmpdir}/${label}-${mode}.headers" || true
+    remote_sha256="$(sha256sum "${tmpdir}/${label}-${mode}.pdf" | awk '{print $1}')"
+    test "${remote_sha256}" = "${local_sha256}"
+    rm -rf "${tmpdir}"
+  done
 done
 ```
 
@@ -236,9 +268,12 @@ SHA-256 values match the local file, and object ACL verification reports
   non-inline value is a deployment failure.
 - **Canonical URL not matching storage URL:** compare both SHA-256 values in the workflow
   summary. Check custom-domain routing and caching before changing the bucket or object.
-- **Cache propagation:** the workflow appends cache-busting query parameters and sets a
-  five-minute cache policy. If humans still see stale bytes, wait for cache expiry and
-  re-check with a cache-busting URL.
+- **Stale bare URL after a successful upload:** compare the cache-busted and bare SHA-256
+  values in the workflow summary. A matching cache-busted SHA with a stale bare SHA means
+  cache-busted verification proved object integrity, but public readiness has not
+  propagated. Inspect `cache-control`, `age`, `etag`, `last-modified`, `cf-cache-status`,
+  and `server` in the bare URL headers before changing DNS, Cloudflare, bucket website
+  settings, or bucket IAM.
 - **Checksum mismatch:** stop and do not retry blindly. Confirm `public/resume.pdf` in the
   checked-out source commit shown in the deploy summary, the GCS object destination, and
   any custom-domain cache behavior. For generated artifact commits, compare the summary


### PR DESCRIPTION
### Motivation
- The bare canonical URL `https://resume.danielsmith.io/` was serving stale PDF bytes after successful uploads because origin-side/public-object caches can hold a prior positive TTL; cache-busted verification alone proved upload integrity but not public readiness. 
- The deployment needs a no-stale cache policy and explicit verification that the bare public URLs return the new bytes before the workflow declares success.

### Description
- Introduce a single `RESUME_CACHE_CONTROL` env value set to `no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate` and apply it to the `gcloud storage cp` upload while preserving `Content-Type: application/pdf` and `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"` and the existing `--add-acl-grant=entity=allUsers,role=READER` behavior. 
- Keep the existing cache-busted verification but clarify its purpose: cache-busted storage verifies uploaded object bytes and cache-busted canonical verifies routed retrieval of the new bytes. 
- Add a bounded retry verification phase for the bare URLs (`https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` and `https://resume.danielsmith.io`) that retries up to 10 minutes with a 10s interval, requires non-empty PDF bytes, `application/pdf` content type, matching SHA-256 to the local `public/resume.pdf`, and checks that `Cache-Control` is the no-stale policy (or at minimum contains `max-age=0` / `no-cache`); on timeout the job fails and prints observed SHA plus cache-relevant headers (`cache-control`, `age`, `etag`, `last-modified`, `cf-cache-status`, `server`). 
- Expand the job summary and `docs/ops/resume-hosting.md` runbook to report both cache-busted and bare SHA/header results, explain the no-stale policy and the failure mode, and update manual break-glass and verification commands to check both cache-busted and bare URLs.

### Testing
- Ran `npm run format:write` and `npm run format:check` with no formatting failures. 
- Ran `npm run docs:check` which passed; the link checker emitted existing network fetch warnings but reported success. 
- Ran `npm run lint` which passed. 
- Ran `npm run test:ci` (Vitest) where all test files completed: `Test Files 159 passed (159)` and `Tests 1213 passed (1213)`. 
- Ran `npm run smoke` (build + smoke assertions) which passed. 
- Ran repository checks `git diff --check` and `./scripts/scan-secrets.py` which passed. 
- Optional checks `actionlint .github/workflows/resume-gcs.yml` and `shellcheck` were not run because `actionlint`/`shellcheck` were not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37446621a4832faaa6e74fc0909315)