### PR TITLE
Fix resume GCS cache verification (no-stale Cache-Control + bare URL checks)

### DIFF
--- a/.github/workflows/resume-gcs.yml
+++ b/.github/workflows/resume-gcs.yml
@@ -36,6 +36,7 @@ jobs:
       RESUME_GCS_DESTINATION: ${{ vars.RESUME_GCS_DESTINATION }}
       RESUME_PUBLIC_URL: ${{ vars.RESUME_PUBLIC_URL }}
       RESUME_STORAGE_PUBLIC_URL: ${{ vars.RESUME_STORAGE_PUBLIC_URL }}
+      RESUME_CACHE_CONTROL: no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate
     if: >-
       ${{ github.event_name != 'workflow_run' ||
         (github.event.workflow_run.conclusion == 'success' &&
@@ -133,7 +134,7 @@ jobs:
             --project="${GCP_PROJECT_ID}" \
             --content-type="application/pdf" \
             --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
-            --cache-control="public, max-age=300, must-revalidate"
+            --cache-control="${RESUME_CACHE_CONTROL}"
 
           gcloud storage objects update "${RESUME_GCS_DESTINATION}" \
             --project="${GCP_PROJECT_ID}" \
@@ -154,19 +155,79 @@ jobs:
             esac
           }
 
-          download_and_verify() {
+          header_value() {
+            local headers_file="$1"
+            local header_name="$2"
+            awk -v name="${header_name}" '
+              BEGIN { IGNORECASE = 1 }
+              index($0, ":") {
+                key = substr($0, 1, index($0, ":") - 1)
+                if (tolower(key) == tolower(name)) {
+                  value = substr($0, index($0, ":") + 1)
+                  sub(/^[[:space:]]*/, "", value)
+                  found = value
+                }
+              }
+              END { print found }
+            ' "${headers_file}" | tr -d '\r'
+          }
+
+          header_summary() {
+            local headers_file="$1"
+            awk '
+              BEGIN { IGNORECASE = 1 }
+              /^(cache-control|age|etag|last-modified|cf-cache-status|server):/ {
+                sub(/[[:cntrl:]]$/, "")
+                print
+              }
+            ' "${headers_file}"
+          }
+
+          verify_pdf_response() {
             local label="$1"
-            local url="$2"
-            local output_dir="$3"
+            local body_file="$2"
+            local headers_file="$3"
             local expected_sha="$4"
-            local cache_busted_url body_file headers_file status_file http_code sha content_type content_disposition
+            local cache_policy_required="$5"
+            local sha content_type cache_control
 
-            cache_busted_url="$(append_cache_buster "${url}" "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}")"
-            body_file="${output_dir}/${label}.pdf"
-            headers_file="${output_dir}/${label}.headers"
-            status_file="${output_dir}/${label}.status"
+            if [ ! -s "${body_file}" ]; then
+              echo "::error::${label} URL returned an empty body."
+              return 1
+            fi
 
-            http_code="$(curl --location --silent --show-error \
+            if [ "$(head -c 5 "${body_file}")" != "%PDF-" ]; then
+              echo "::error::${label} URL did not return PDF bytes."
+              return 1
+            fi
+
+            sha="$(sha256sum "${body_file}" | awk '{print $1}')"
+            if [ "${sha}" != "${expected_sha}" ]; then
+              echo "::error::${label} SHA-256 ${sha} does not match local ${expected_sha}."
+              return 1
+            fi
+
+            content_type="$(header_value "${headers_file}" content-type)"
+            if ! printf '%s\n' "${content_type}" | grep -Eiq '(^|[[:space:];])application/pdf([[:space:];]|$)'; then
+              echo "::error::${label} Content-Type must include application/pdf; observed '${content_type}'."
+              return 1
+            fi
+
+            cache_control="$(header_value "${headers_file}" cache-control)"
+            if [ "${cache_policy_required}" = "required" ]; then
+              if ! printf '%s\n' "${cache_control}" | grep -Fqx "${RESUME_CACHE_CONTROL}" && \
+                ! printf '%s\n' "${cache_control}" | grep -Eiq '(^|,)[[:space:]]*(no-cache|max-age=0)([[:space:]],|$)'; then
+                echo "::error::${label} Cache-Control must be no-stale; observed '${cache_control}'."
+                return 1
+              fi
+            fi
+          }
+
+          fetch_url() {
+            local url="$1"
+            local body_file="$2"
+            local headers_file="$3"
+            curl --location --silent --show-error \
               --connect-timeout 10 \
               --max-time 60 \
               --retry 3 \
@@ -175,59 +236,120 @@ jobs:
               --dump-header "${headers_file}" \
               --output "${body_file}" \
               --write-out '%{http_code}' \
-              "${cache_busted_url}")"
+              "${url}"
+          }
+
+          verify_once() {
+            local label="$1"
+            local url="$2"
+            local output_dir="$3"
+            local expected_sha="$4"
+            local cache_policy_required="$5"
+            local body_file headers_file status_file http_code sha content_type content_disposition
+            local cache_control age etag last_modified cf_cache_status server
+
+            body_file="${output_dir}/${label}.pdf"
+            headers_file="${output_dir}/${label}.headers"
+            status_file="${output_dir}/${label}.status"
+
+            http_code="$(fetch_url "${url}" "${body_file}" "${headers_file}")"
             printf '%s\n' "${http_code}" >"${status_file}"
 
             if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
               echo "::error::${label} URL returned HTTP ${http_code}."
-              exit 1
+              return 1
             fi
 
-            if [ ! -s "${body_file}" ]; then
-              echo "::error::${label} URL returned an empty body."
-              exit 1
-            fi
-
-            if [ "$(head -c 5 "${body_file}")" != "%PDF-" ]; then
-              echo "::error::${label} URL did not return PDF bytes."
-              exit 1
-            fi
+            verify_pdf_response "${label}" "${body_file}" "${headers_file}" \
+              "${expected_sha}" "${cache_policy_required}" || return 1
 
             sha="$(sha256sum "${body_file}" | awk '{print $1}')"
-            if [ "${sha}" != "${expected_sha}" ]; then
-              echo "::error::${label} SHA-256 ${sha} does not match local ${expected_sha}."
-              exit 1
-            fi
+            content_type="$(header_value "${headers_file}" content-type)"
+            content_disposition="$(header_value "${headers_file}" content-disposition)"
+            cache_control="$(header_value "${headers_file}" cache-control)"
+            age="$(header_value "${headers_file}" age)"
+            etag="$(header_value "${headers_file}" etag)"
+            last_modified="$(header_value "${headers_file}" last-modified)"
+            cf_cache_status="$(header_value "${headers_file}" cf-cache-status)"
+            server="$(header_value "${headers_file}" server)"
 
-            content_type="$(awk 'BEGIN{IGNORECASE=1} /^content-type:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}' "${headers_file}" | tr -d '\r')"
-            if ! printf '%s\n' "${content_type}" | grep -Eiq '(^|[[:space:];])application/pdf([[:space:];]|$)'; then
-              echo "::error::${label} Content-Type must include application/pdf; observed '${content_type}'."
-              exit 1
-            fi
-
-            content_disposition="$(awk 'BEGIN{IGNORECASE=1} /^content-disposition:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}' "${headers_file}" | tr -d '\r')"
             if [ -n "${content_disposition}" ] && \
               ! printf '%s\n' "${content_disposition}" | grep -Eiq '^inline([[:space:];]|$)'; then
               echo "::error::${label} Content-Disposition must be inline or absent; observed '${content_disposition}'."
-              exit 1
+              return 1
             fi
 
             {
               echo "${label}_sha256=${sha}"
               echo "${label}_content_type=${content_type}"
               echo "${label}_content_disposition=${content_disposition:-absent}"
+              echo "${label}_cache_control=${cache_control:-absent}"
+              echo "${label}_age=${age:-absent}"
+              echo "${label}_etag=${etag:-absent}"
+              echo "${label}_last_modified=${last_modified:-absent}"
+              echo "${label}_cf_cache_status=${cf_cache_status:-absent}"
+              echo "${label}_server=${server:-absent}"
               echo "${label}_headers<<EOF_HEADERS_${label}"
               sed -n '1,20p' "${headers_file}" | sed 's/[[:cntrl:]]$//'
               echo "EOF_HEADERS_${label}"
             } >>"${GITHUB_OUTPUT}"
           }
 
+          verify_bare_with_retry() {
+            local label="$1"
+            local url="$2"
+            local output_dir="$3"
+            local expected_sha="$4"
+            local max_attempts=60
+            local attempt headers_file body_file observed_sha
+
+            for attempt in $(seq 1 "${max_attempts}"); do
+              echo "Verifying bare ${label} URL, attempt ${attempt}/${max_attempts}."
+              if verify_once "${label}" "${url}" "${output_dir}" "${expected_sha}" required; then
+                return 0
+              fi
+
+              body_file="${output_dir}/${label}.pdf"
+              headers_file="${output_dir}/${label}.headers"
+              observed_sha="unavailable"
+              if [ -s "${body_file}" ]; then
+                observed_sha="$(sha256sum "${body_file}" | awk '{print $1}')"
+              fi
+
+              if [ "${attempt}" -eq "${max_attempts}" ]; then
+                echo "::error::Bare ${label} URL did not return the deployed PDF before timeout."
+                echo "Expected SHA-256: ${expected_sha}"
+                echo "Observed SHA-256: ${observed_sha}"
+                echo "Cache-relevant headers:"
+                header_summary "${headers_file}" || true
+                return 1
+              fi
+
+              sleep 10
+            done
+          }
+
           tmpdir="$(mktemp -d)"
           trap 'rm -rf "${tmpdir}"' EXIT
 
           local_sha256="${{ steps.upload.outputs.local_sha256 }}"
-          download_and_verify storage "${RESUME_STORAGE_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
-          download_and_verify canonical "${RESUME_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
+          cache_buster="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          # Cache-busted storage URL verifies the uploaded object bytes immediately.
+          verify_once cache_busted_storage \
+            "$(append_cache_buster "${RESUME_STORAGE_PUBLIC_URL}" "${cache_buster}")" \
+            "${tmpdir}" "${local_sha256}" optional
+
+          # Cache-busted canonical URL verifies the routed path can fetch the new bytes.
+          verify_once cache_busted_canonical \
+            "$(append_cache_buster "${RESUME_PUBLIC_URL}" "${cache_buster}")" \
+            "${tmpdir}" "${local_sha256}" optional
+
+          # Bare URL verification proves the stable public aliases are actually live.
+          verify_bare_with_retry bare_storage \
+            "${RESUME_STORAGE_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
+          verify_bare_with_retry bare_canonical \
+            "${RESUME_PUBLIC_URL}" "${tmpdir}" "${local_sha256}"
 
           acl_json="${tmpdir}/acl.json"
           gcloud storage objects describe "${RESUME_GCS_DESTINATION}" \
@@ -266,15 +388,29 @@ jobs:
         env:
           SOURCE_COMMIT_SHA: ${{ steps.source.outputs.sha }}
           LOCAL_SHA256: ${{ steps.upload.outputs.local_sha256 }}
-          STORAGE_SHA256: ${{ steps.verify.outputs.storage_sha256 }}
-          CANONICAL_SHA256: ${{ steps.verify.outputs.canonical_sha256 }}
-          STORAGE_CONTENT_TYPE: ${{ steps.verify.outputs.storage_content_type }}
-          CANONICAL_CONTENT_TYPE: ${{ steps.verify.outputs.canonical_content_type }}
-          STORAGE_CONTENT_DISPOSITION: ${{ steps.verify.outputs.storage_content_disposition }}
-          CANONICAL_CONTENT_DISPOSITION: ${{ steps.verify.outputs.canonical_content_disposition }}
+          CACHE_BUSTED_STORAGE_SHA256: ${{ steps.verify.outputs.cache_busted_storage_sha256 }}
+          CACHE_BUSTED_CANONICAL_SHA256: ${{ steps.verify.outputs.cache_busted_canonical_sha256 }}
+          BARE_STORAGE_SHA256: ${{ steps.verify.outputs.bare_storage_sha256 }}
+          BARE_CANONICAL_SHA256: ${{ steps.verify.outputs.bare_canonical_sha256 }}
+          BARE_STORAGE_CONTENT_TYPE: ${{ steps.verify.outputs.bare_storage_content_type }}
+          BARE_CANONICAL_CONTENT_TYPE: ${{ steps.verify.outputs.bare_canonical_content_type }}
+          BARE_STORAGE_CONTENT_DISPOSITION: ${{ steps.verify.outputs.bare_storage_content_disposition }}
+          BARE_CANONICAL_CONTENT_DISPOSITION: ${{ steps.verify.outputs.bare_canonical_content_disposition }}
+          BARE_STORAGE_CACHE_CONTROL: ${{ steps.verify.outputs.bare_storage_cache_control }}
+          BARE_CANONICAL_CACHE_CONTROL: ${{ steps.verify.outputs.bare_canonical_cache_control }}
+          BARE_STORAGE_AGE: ${{ steps.verify.outputs.bare_storage_age }}
+          BARE_CANONICAL_AGE: ${{ steps.verify.outputs.bare_canonical_age }}
+          BARE_STORAGE_ETAG: ${{ steps.verify.outputs.bare_storage_etag }}
+          BARE_CANONICAL_ETAG: ${{ steps.verify.outputs.bare_canonical_etag }}
+          BARE_STORAGE_LAST_MODIFIED: ${{ steps.verify.outputs.bare_storage_last_modified }}
+          BARE_CANONICAL_LAST_MODIFIED: ${{ steps.verify.outputs.bare_canonical_last_modified }}
+          BARE_STORAGE_CF_CACHE_STATUS: ${{ steps.verify.outputs.bare_storage_cf_cache_status }}
+          BARE_CANONICAL_CF_CACHE_STATUS: ${{ steps.verify.outputs.bare_canonical_cf_cache_status }}
+          BARE_STORAGE_SERVER: ${{ steps.verify.outputs.bare_storage_server }}
+          BARE_CANONICAL_SERVER: ${{ steps.verify.outputs.bare_canonical_server }}
           PUBLIC_ACL: ${{ steps.verify.outputs.public_acl }}
-          STORAGE_HEADERS: ${{ steps.verify.outputs.storage_headers }}
-          CANONICAL_HEADERS: ${{ steps.verify.outputs.canonical_headers }}
+          BARE_STORAGE_HEADERS: ${{ steps.verify.outputs.bare_storage_headers }}
+          BARE_CANONICAL_HEADERS: ${{ steps.verify.outputs.bare_canonical_headers }}
           JOB_STATUS: ${{ job.status }}
         run: |
           set -euo pipefail
@@ -289,29 +425,46 @@ jobs:
             echo "| Destination GCS URI | \`${RESUME_GCS_DESTINATION}\` |"
             echo "| Storage URL | ${RESUME_STORAGE_PUBLIC_URL} |"
             echo "| Canonical public URL | ${RESUME_PUBLIC_URL} |"
+            echo "| Upload Cache-Control | \`${RESUME_CACHE_CONTROL}\` |"
             echo "| Local SHA-256 | \`${LOCAL_SHA256}\` |"
-            echo "| Storage URL SHA-256 | \`${STORAGE_SHA256}\` |"
-            echo "| Canonical URL SHA-256 | \`${CANONICAL_SHA256}\` |"
-            echo "| Storage Content-Type | \`${STORAGE_CONTENT_TYPE}\` |"
-            echo "| Canonical Content-Type | \`${CANONICAL_CONTENT_TYPE}\` |"
+            echo "| Cache-busted storage SHA-256 | \`${CACHE_BUSTED_STORAGE_SHA256}\` |"
+            echo "| Cache-busted canonical SHA-256 | \`${CACHE_BUSTED_CANONICAL_SHA256}\` |"
+            echo "| Bare storage SHA-256 | \`${BARE_STORAGE_SHA256}\` |"
+            echo "| Bare canonical SHA-256 | \`${BARE_CANONICAL_SHA256}\` |"
+            echo "| Bare storage Content-Type | \`${BARE_STORAGE_CONTENT_TYPE}\` |"
+            echo "| Bare canonical Content-Type | \`${BARE_CANONICAL_CONTENT_TYPE}\` |"
+            echo "| Bare storage Cache-Control | \`${BARE_STORAGE_CACHE_CONTROL}\` |"
+            echo "| Bare canonical Cache-Control | \`${BARE_CANONICAL_CACHE_CONTROL}\` |"
+            echo "| Bare storage Age | \`${BARE_STORAGE_AGE}\` |"
+            echo "| Bare canonical Age | \`${BARE_CANONICAL_AGE}\` |"
+            echo "| Bare storage ETag | \`${BARE_STORAGE_ETAG}\` |"
+            echo "| Bare canonical ETag | \`${BARE_CANONICAL_ETAG}\` |"
+            echo "| Bare storage Last-Modified | \`${BARE_STORAGE_LAST_MODIFIED}\` |"
+            echo "| Bare canonical Last-Modified | \`${BARE_CANONICAL_LAST_MODIFIED}\` |"
+            echo "| Bare storage CF-Cache-Status | \`${BARE_STORAGE_CF_CACHE_STATUS}\` |"
+            echo "| Bare canonical CF-Cache-Status | \`${BARE_CANONICAL_CF_CACHE_STATUS}\` |"
+            echo "| Bare storage Server | \`${BARE_STORAGE_SERVER}\` |"
+            echo "| Bare canonical Server | \`${BARE_CANONICAL_SERVER}\` |"
             echo "| Object ACL/public-read verification | \`${PUBLIC_ACL}\` |"
             echo "| Final deployment status | \`${JOB_STATUS}\` |"
             echo
-            if [ "${STORAGE_CONTENT_DISPOSITION}" = "absent" ]; then
-              echo "> Warning: the storage URL did not expose Content-Disposition."
+            echo "Bare canonical URL is live only when its SHA-256 matches the local SHA-256."
+            echo
+            if [ "${BARE_STORAGE_CONTENT_DISPOSITION}" = "absent" ]; then
+              echo "> Warning: the bare storage URL did not expose Content-Disposition."
               echo
             fi
-            if [ "${CANONICAL_CONTENT_DISPOSITION}" = "absent" ]; then
-              echo "> Warning: the canonical URL did not expose Content-Disposition."
+            if [ "${BARE_CANONICAL_CONTENT_DISPOSITION}" = "absent" ]; then
+              echo "> Warning: the bare canonical URL did not expose Content-Disposition."
               echo
             fi
-            echo "### Storage URL response headers"
+            echo "### Bare storage URL response headers"
             echo '```'
-            printf '%s\n' "${STORAGE_HEADERS}"
+            printf '%s\n' "${BARE_STORAGE_HEADERS}"
             echo '```'
             echo
-            echo "### Canonical URL response headers"
+            echo "### Bare canonical URL response headers"
             echo '```'
-            printf '%s\n' "${CANONICAL_HEADERS}"
+            printf '%s\n' "${BARE_CANONICAL_HEADERS}"
             echo '```'
           } >>"${GITHUB_STEP_SUMMARY}"

--- a/docs/ops/resume-hosting.md
+++ b/docs/ops/resume-hosting.md
@@ -82,7 +82,13 @@ The workflow uploads only `public/resume.pdf` to
 
 - `Content-Type: application/pdf`
 - `Content-Disposition: inline; filename="Daniel_Smith_Resume.pdf"`
-- `Cache-Control: public, max-age=300, must-revalidate`
+- `Cache-Control: no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate`
+
+`resume.danielsmith.io` is a stable alias: the URL is intentionally stable while
+its PDF bytes can change after a new resume artifact is deployed. Because shared
+caches can otherwise keep serving an older object response for the bare URL, the
+object uses a no-stale cache policy:
+`no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate`.
 
 After upload, it runs:
 
@@ -104,7 +110,8 @@ explicitly explains why replacing other object ACL grants is acceptable.
    to fail immediately with a `Resume GCS deploys must run from main` error before
    checkout or Google authentication.
 4. Wait for the job summary to report the checked-out source commit SHA plus matching
-   local, storage URL, and canonical URL SHA-256 values.
+   local, cache-busted storage/canonical, and bare storage/canonical SHA-256 values.
+   Treat the bare canonical URL as live only when its SHA-256 matches the local PDF.
 
 ## Manual break-glass deployment
 
@@ -130,26 +137,38 @@ local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
 gcloud storage cp "${LOCAL_RESUME_PATH}" "${DESTINATION}" \
   --content-type="application/pdf" \
   --content-disposition='inline; filename="Daniel_Smith_Resume.pdf"' \
-  --cache-control="public, max-age=300, must-revalidate"
+  --cache-control="no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate"
 
 gcloud storage objects update "${DESTINATION}" \
   --add-acl-grant=entity=allUsers,role=READER
 
-for url in "${STORAGE_URL}" "${CANONICAL_URL}"; do
-  tmp="$(mktemp)"
-  curl --location --fail --silent --show-error \
-    --connect-timeout 10 \
-    --max-time 60 \
-    --retry 3 \
-    --retry-delay 2 \
-    --retry-connrefused \
-    "${url}?resume_verify=$(date +%s)" \
-    --output "${tmp}"
-  test -s "${tmp}"
-  test "$(head -c 5 "${tmp}")" = "%PDF-"
-  remote_sha256="$(sha256sum "${tmp}" | awk '{print $1}')"
-  rm -f "${tmp}"
-  test "${remote_sha256}" = "${local_sha256}"
+for mode in cache_busted bare; do
+  for url in "${STORAGE_URL}" "${CANONICAL_URL}"; do
+    tmpdir="$(mktemp -d)"
+    case "${mode}" in
+      cache_busted) verify_url="${url}?resume_verify=$(date +%s)" ;;
+      bare) verify_url="${url}" ;;
+    esac
+
+    curl --location --fail --silent --show-error \
+      --connect-timeout 10 \
+      --max-time 60 \
+      --retry 3 \
+      --retry-delay 2 \
+      --retry-connrefused \
+      --dump-header "${tmpdir}/headers" \
+      --output "${tmpdir}/resume.pdf" \
+      "${verify_url}"
+    test -s "${tmpdir}/resume.pdf"
+    test "$(head -c 5 "${tmpdir}/resume.pdf")" = "%PDF-"
+    grep -Ei '^content-type:.*application/pdf' "${tmpdir}/headers"
+    if [ "${mode}" = "bare" ]; then
+      grep -Ei '^cache-control:.*(no-cache|max-age=0)' "${tmpdir}/headers"
+    fi
+    remote_sha256="$(sha256sum "${tmpdir}/resume.pdf" | awk '{print $1}')"
+    rm -rf "${tmpdir}"
+    test "${remote_sha256}" = "${local_sha256}"
+  done
 done
 ```
 
@@ -166,29 +185,40 @@ STORAGE_URL="https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_R
 CANONICAL_URL="https://resume.danielsmith.io"
 local_sha256="$(sha256sum "${LOCAL_RESUME_PATH}" | awk '{print $1}')"
 
-for label in storage canonical; do
-  case "${label}" in
-    storage) url="${STORAGE_URL}" ;;
-    canonical) url="${CANONICAL_URL}" ;;
-  esac
+for mode in cache_busted bare; do
+  for label in storage canonical; do
+    case "${label}" in
+      storage) url="${STORAGE_URL}" ;;
+      canonical) url="${CANONICAL_URL}" ;;
+    esac
+    case "${mode}" in
+      cache_busted) verify_url="${url}?resume_verify=$(date +%s)" ;;
+      bare) verify_url="${url}" ;;
+    esac
 
-  tmpdir="$(mktemp -d)"
-  curl --location --fail --silent --show-error \
-    --connect-timeout 10 \
-    --max-time 60 \
-    --retry 3 \
-    --retry-delay 2 \
-    --retry-connrefused \
-    --dump-header "${tmpdir}/${label}.headers" \
-    --output "${tmpdir}/${label}.pdf" \
-    "${url}?resume_verify=$(date +%s)"
+    tmpdir="$(mktemp -d)"
+    curl --location --fail --silent --show-error \
+      --connect-timeout 10 \
+      --max-time 60 \
+      --retry 3 \
+      --retry-delay 2 \
+      --retry-connrefused \
+      --dump-header "${tmpdir}/${mode}-${label}.headers" \
+      --output "${tmpdir}/${mode}-${label}.pdf" \
+      "${verify_url}"
 
-  test -s "${tmpdir}/${label}.pdf"
-  test "$(head -c 5 "${tmpdir}/${label}.pdf")" = "%PDF-"
-  grep -Ei '^content-type:.*application/pdf' "${tmpdir}/${label}.headers"
-  remote_sha256="$(sha256sum "${tmpdir}/${label}.pdf" | awk '{print $1}')"
-  test "${remote_sha256}" = "${local_sha256}"
-  rm -rf "${tmpdir}"
+    test -s "${tmpdir}/${mode}-${label}.pdf"
+    test "$(head -c 5 "${tmpdir}/${mode}-${label}.pdf")" = "%PDF-"
+    grep -Ei '^content-type:.*application/pdf' "${tmpdir}/${mode}-${label}.headers"
+    if [ "${mode}" = "bare" ]; then
+      grep -Ei '^cache-control:.*(no-cache|max-age=0)' "${tmpdir}/${mode}-${label}.headers"
+      grep -Ei '^(cache-control|age|etag|last-modified|cf-cache-status|server):' \
+        "${tmpdir}/${mode}-${label}.headers" || true
+    fi
+    remote_sha256="$(sha256sum "${tmpdir}/${mode}-${label}.pdf" | awk '{print $1}')"
+    test "${remote_sha256}" = "${local_sha256}"
+    rm -rf "${tmpdir}"
+  done
 done
 ```
 
@@ -209,8 +239,8 @@ Rollback by restoring a prior stable resume artifact in Git, then letting the
 Do not edit generated PDF bytes by hand. After the rollback PR merges to `main`, wait
 for **Resume artifacts** to complete successfully, then confirm **Deploy resume to GCS**
 starts from that `workflow_run`. Verify the deploy summary source commit SHA matches
-the current `main` commit containing the restored `public/resume.pdf`, both public URL
-SHA-256 values match the local file, and object ACL verification reports
+the current `main` commit containing the restored `public/resume.pdf`, cache-busted
+and bare public URL SHA-256 values match the local file, and object ACL verification reports
 `allUsers Reader present; no public write grants observed`.
 
 ## Troubleshooting
@@ -236,9 +266,14 @@ SHA-256 values match the local file, and object ACL verification reports
   non-inline value is a deployment failure.
 - **Canonical URL not matching storage URL:** compare both SHA-256 values in the workflow
   summary. Check custom-domain routing and caching before changing the bucket or object.
-- **Cache propagation:** the workflow appends cache-busting query parameters and sets a
-  five-minute cache policy. If humans still see stale bytes, wait for cache expiry and
-  re-check with a cache-busting URL.
+- **Bare URL stale while cache-busted URL is fresh:** an older object response with
+  `cache-control: public, max-age=3600` can remain stale at the bare URL even after a
+  successful upload. A cache-busted storage or canonical URL can show the new object
+  while `https://resume.danielsmith.io/` still serves the old object. Cloudflare purge
+  may not help when `cf-cache-status` is `DYNAMIC`, because the stale response can be
+  coming from GCS, Google edge, or origin-side public-object caching. The deployment
+  workflow now waits for the bare storage and canonical URLs to return the new SHA-256
+  with no-stale cache headers before declaring success.
 - **Checksum mismatch:** stop and do not retry blindly. Confirm `public/resume.pdf` in the
   checked-out source commit shown in the deploy summary, the GCS object destination, and
   any custom-domain cache behavior. For generated artifact commits, compare the summary


### PR DESCRIPTION
### Motivation
- Prevent the stable public alias `https://resume.danielsmith.io` from serving stale PDF bytes after uploads by using a no-stale cache policy. 
- Make deployment success depend on the bare public URLs actually serving the new bytes instead of only verifying cache-busted URLs.

### Description
- Add a single workflow env `RESUME_CACHE_CONTROL` set to `no-cache, max-age=0, s-maxage=0, must-revalidate, proxy-revalidate` and apply it to the `gcloud storage cp` upload while preserving `Content-Type` and `Content-Disposition` and the existing `--add-acl-grant=entity=allUsers,role=READER` ACL update. 
- Keep the cache-busted verification (renamed/commented) to verify immediate uploaded object integrity, and add bounded retry verification for the bare URLs (`https://storage.googleapis.com/resume.danielsmith.io/Daniel_Smith_Resume.pdf` and `https://resume.danielsmith.io`) that retries up to 10 minutes (60 attempts, 10s interval). 
- For each bare-URL attempt verify the response is non-empty PDF bytes, `Content-Type` includes `application/pdf`, the observed SHA-256 matches the local `public/resume.pdf`, and the observed `Cache-Control` contains the no-stale policy or at minimum `no-cache`/`max-age=0`; on timeout the step fails and prints observed SHA plus cache-relevant headers (`cache-control`, `age`, `etag`, `last-modified`, `cf-cache-status`, `server`). 
- Expand the job summary to include cache-busted and bare storage/canonical SHA results plus bare URL cache headers and diagnostics, and update `docs/ops/resume-hosting.md` to document the no-stale policy, the bare-vs-cache-busted failure mode, and updated manual break-glass verification and upload commands.

### Testing
- Ran `npm run format:write` and `npm run format:check` and both succeeded. 
- Ran `npm run docs:check` and it passed (link checker emitted external fetch warnings unrelated to these changes). 
- Ran `npm run lint` and `npm run test:ci` and the test suite passed. 
- Ran `npm run smoke`, `git diff --check`, `./scripts/scan-secrets.py`, and `bash -n` against the extracted workflow snippets; all checks passed; note `actionlint` and `shellcheck` were not installed in the environment so they were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37447ef7e8832fad28b6c3a9e69f14)