### PR TITLE
Add local ATS (pdftotext) smoke report to resume CI

### DIFF
--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -116,6 +116,159 @@ jobs:
             echo "docx_sha256=${docx_sha256}"
           } >>"${GITHUB_OUTPUT}"
 
+      - name: Run ATS smoke report
+        id: ats
+        shell: bash
+        env:
+          PDF: ${{ steps.resume.outputs.pdf }}
+          TEX_SOURCE: ${{ steps.resume.outputs.tex }}
+          VERSION: ${{ steps.resume.outputs.version }}
+          PDF_PAGES: ${{ steps.pdfinfo.outputs.pages }}
+        run: |
+          set -euo pipefail
+          ats_dir="${RUNNER_TEMP}/resume-ats"
+          mkdir -p "${ats_dir}"
+
+          plain_text="${ats_dir}/resume.txt"
+          layout_text="${ats_dir}/resume-layout.txt"
+          pdftotext "${PDF}" "${plain_text}"
+          pdftotext -layout "${PDF}" "${layout_text}"
+
+          plain_chars=$(wc -m <"${plain_text}" | tr -d '[:space:]')
+          layout_chars=$(wc -m <"${layout_text}" | tr -d '[:space:]')
+          echo "ats_dir=${ats_dir}" >>"${GITHUB_OUTPUT}"
+          echo "plain_text=${plain_text}" >>"${GITHUB_OUTPUT}"
+          echo "layout_text=${layout_text}" >>"${GITHUB_OUTPUT}"
+          echo "plain_chars=${plain_chars}" >>"${GITHUB_OUTPUT}"
+          echo "layout_chars=${layout_chars}" >>"${GITHUB_OUTPUT}"
+
+          python3 - <<'PY'
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          plain_path = Path(os.environ["RUNNER_TEMP"]) / "resume-ats" / "resume.txt"
+          layout_path = Path(os.environ["RUNNER_TEMP"]) / "resume-ats" / "resume-layout.txt"
+          plain = plain_path.read_text(encoding="utf-8", errors="replace")
+          layout = layout_path.read_text(encoding="utf-8", errors="replace")
+          failures = []
+          warnings = []
+          checklist = []
+
+          def check(label, passed, detail=""):
+              checklist.append((label, passed, detail))
+              if not passed:
+                  failures.append(label if not detail else f"{label}: {detail}")
+
+          plain_chars = len(plain)
+          layout_chars = len(layout)
+          check("Plain extracted text is non-empty", plain_chars > 0, f"{plain_chars} chars")
+          check("Plain extracted text is reasonably large", plain_chars >= 3000, f"{plain_chars} chars")
+          check("PDF page count is one", os.environ["PDF_PAGES"] == "1", os.environ["PDF_PAGES"])
+
+          required_terms = [
+              "Daniel Smith",
+              "daniel@danielsmith.io",
+              "Summary",
+              "Skills",
+              "Experience",
+              "Education",
+              "Independent Open Source Engineering",
+              "YouTube (Google)",
+              "Site Reliability Engineer, L4",
+              "The University of Southern Mississippi",
+              "Jones County Junior College",
+          ]
+          for term in required_terms:
+              check(f"Required text present: `{term}`", term in plain)
+
+          def pos(term):
+              return plain.find(term)
+
+          section_pairs = [("Summary", "Skills"), ("Skills", "Experience"), ("Experience", "Education")]
+          for before, after in section_pairs:
+              before_pos = pos(before)
+              after_pos = pos(after)
+              check(
+                  f"Section order: `{before}` before `{after}`",
+                  before_pos != -1 and after_pos != -1 and before_pos < after_pos,
+                  f"positions {before_pos}, {after_pos}",
+              )
+
+          # TODO: Make these Education pairing warnings blocking after the Education
+          # section is reformatted in a follow-up PR.
+          education_pairs = [
+              ("M.S. Computer Science", "Aug 2015"),
+              ("B.S. Computer Science", "May 2013"),
+              ("A.A.S. Information System Technology", "Aug 2011"),
+          ]
+          plain_lines = plain.splitlines()
+          for degree, date in education_pairs:
+              same_line = any(degree in line and date in line for line in plain_lines)
+              degree_pos = plain.find(degree)
+              date_pos = plain.find(date)
+              nearby = (
+                  degree_pos != -1
+                  and date_pos != -1
+                  and abs(degree_pos - date_pos) <= 240
+              )
+              if same_line:
+                  checklist.append((f"Education pair same line: `{degree}` / `{date}`", True, ""))
+              elif nearby:
+                  warnings.append(f"Education pair is nearby but detached: `{degree}` / `{date}`")
+                  checklist.append((f"Education pair nearby: `{degree}` / `{date}`", True, "warning only"))
+              else:
+                  warnings.append(f"Education pair not found nearby: `{degree}` / `{date}`")
+                  checklist.append((f"Education pair nearby: `{degree}` / `{date}`", True, "warning only"))
+
+          oddities = []
+          if re.search(r"[A-Za-z]-\n[A-Za-z]", plain):
+              oddities.append("Possible hyphenated line break found in plain extraction.")
+          if re.search(r"\b[A-Za-z]{1,2}\n[A-Za-z]{1,2}\n", plain):
+              oddities.append("Possible unusually short wrapped words found in plain extraction.")
+          warnings.extend(oddities)
+
+          preview = "\n".join(plain_lines[:120])
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a", encoding="utf-8") as fh:
+              fh.write("## ATS smoke report\n\n")
+              fh.write(f"- Selected TeX source: `{os.environ['TEX_SOURCE']}`\n")
+              fh.write(f"- Selected resume version: `{os.environ['VERSION']}`\n")
+              fh.write(f"- Generated PDF path: `{os.environ['PDF']}`\n")
+              fh.write(f"- PDF page count: `{os.environ['PDF_PAGES']}`\n")
+              fh.write(f"- Plain extracted character count: `{plain_chars}`\n")
+              fh.write(f"- Layout extracted character count: `{layout_chars}`\n\n")
+              fh.write("### Pass/fail checklist\n\n")
+              for label, passed, detail in checklist:
+                  suffix = f" — {detail}" if detail else ""
+                  fh.write(f"- {'✅' if passed else '❌'} {label}{suffix}\n")
+              if warnings:
+                  fh.write("\n### Non-blocking warnings\n\n")
+                  for warning in warnings:
+                      fh.write(f"- ⚠️ {warning}\n")
+              fh.write("\n<details>\n<summary>First 120 lines of plain extraction</summary>\n\n")
+              fh.write("```text\n")
+              fh.write(preview)
+              if preview and not preview.endswith("\n"):
+                  fh.write("\n")
+              fh.write("```\n\n</details>\n")
+
+          if failures:
+              for failure in failures:
+                  print(f"::error::{failure}")
+              sys.exit(1)
+          PY
+
+      - name: Upload ATS text artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume-${{ steps.resume.outputs.version }}-ats-text
+          path: |
+            ${{ steps.ats.outputs.plain_text }}
+            ${{ steps.ats.outputs.layout_text }}
+          if-no-files-found: error
+
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -124,6 +124,7 @@ jobs:
           TEX_SOURCE: ${{ steps.resume.outputs.tex }}
           VERSION: ${{ steps.resume.outputs.version }}
           PDF_PAGES: ${{ steps.pdfinfo.outputs.pages }}
+          ATS_CONFIG: docs/resume/ats-smoke.json
         run: |
           set -euo pipefail
           ats_dir="${RUNNER_TEMP}/resume-ats"
@@ -136,140 +137,21 @@ jobs:
 
           plain_chars=$(wc -m <"${plain_text}" | tr -d '[:space:]')
           layout_chars=$(wc -m <"${layout_text}" | tr -d '[:space:]')
-          export ats_dir
           echo "ats_dir=${ats_dir}" >>"${GITHUB_OUTPUT}"
           echo "plain_text=${plain_text}" >>"${GITHUB_OUTPUT}"
           echo "layout_text=${layout_text}" >>"${GITHUB_OUTPUT}"
           echo "plain_chars=${plain_chars}" >>"${GITHUB_OUTPUT}"
           echo "layout_chars=${layout_chars}" >>"${GITHUB_OUTPUT}"
 
-          python3 - <<'PY'
-          import os
-          import re
-          import sys
-          from pathlib import Path
-
-          ats_dir = Path(os.environ["ats_dir"])
-          plain_path = ats_dir / "resume.txt"
-          layout_path = ats_dir / "resume-layout.txt"
-          plain = plain_path.read_text(encoding="utf-8", errors="replace")
-          layout = layout_path.read_text(encoding="utf-8", errors="replace")
-          failures = []
-          warnings = []
-          checklist = []
-          education_observations = []
-
-          def check(label, passed, detail=""):
-              checklist.append((label, passed, detail))
-              if not passed:
-                  failures.append(label if not detail else f"{label}: {detail}")
-
-          plain_chars = len(plain)
-          layout_chars = len(layout)
-          check("Plain extracted text is non-empty", plain_chars > 0, f"{plain_chars} chars")
-          check("Plain extracted text is reasonably large", plain_chars >= 3000, f"{plain_chars} chars")
-          check("PDF page count is one", os.environ["PDF_PAGES"] == "1", os.environ["PDF_PAGES"])
-
-          required_terms = [
-              "Daniel Smith",
-              "daniel@danielsmith.io",
-              "Summary",
-              "Skills",
-              "Experience",
-              "Education",
-              "Independent Open Source Engineering",
-              "YouTube (Google)",
-              "Site Reliability Engineer, L4",
-              "The University of Southern Mississippi",
-              "Jones County Junior College",
-          ]
-          for term in required_terms:
-              check(f"Required text present: `{term}`", term in plain)
-
-          def pos(term):
-              return plain.find(term)
-
-          section_pairs = [("Summary", "Skills"), ("Skills", "Experience"), ("Experience", "Education")]
-          for before, after in section_pairs:
-              before_pos = pos(before)
-              after_pos = pos(after)
-              check(
-                  f"Section order: `{before}` before `{after}`",
-                  before_pos != -1 and after_pos != -1 and before_pos < after_pos,
-                  f"positions {before_pos}, {after_pos}",
-              )
-
-          # TODO: Make these Education pairing warnings blocking after the Education
-          # section is reformatted in a follow-up PR.
-          education_pairs = [
-              ("M.S. Computer Science", "Aug 2015"),
-              ("B.S. Computer Science", "May 2013"),
-              ("A.A.S. Information System Technology", "Aug 2011"),
-          ]
-          plain_lines = plain.splitlines()
-          for degree, date in education_pairs:
-              same_line = any(degree in line and date in line for line in plain_lines)
-              degree_pos = plain.find(degree)
-              date_pos = plain.find(date)
-              nearby = (
-                  degree_pos != -1
-                  and date_pos != -1
-                  and abs(degree_pos - date_pos) <= 240
-              )
-              if same_line:
-                  education_observations.append(
-                      f"✅ `{degree}` / `{date}` — same extracted line"
-                  )
-              elif nearby:
-                  education_observations.append(
-                      f"⚠️ `{degree}` / `{date}` — nearby text window"
-                  )
-              else:
-                  warning = f"Education pair detached / not found nearby: `{degree}` / `{date}`"
-                  warnings.append(warning)
-                  education_observations.append(f"⚠️ {warning}")
-
-          oddities = []
-          if re.search(r"[A-Za-z]-\n[A-Za-z]", plain):
-              oddities.append("Possible hyphenated line break found in plain extraction.")
-          if re.search(r"\b[A-Za-z]{1,2}\n[A-Za-z]{1,2}\n", plain):
-              oddities.append("Possible unusually short wrapped words found in plain extraction.")
-          warnings.extend(oddities)
-
-          preview = "\n".join(plain_lines[:120])
-          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
-          with summary.open("a", encoding="utf-8") as fh:
-              fh.write("## ATS smoke report\n\n")
-              fh.write(f"- Selected TeX source: `{os.environ['TEX_SOURCE']}`\n")
-              fh.write(f"- Selected resume version: `{os.environ['VERSION']}`\n")
-              fh.write(f"- Generated PDF path: `{os.environ['PDF']}`\n")
-              fh.write(f"- PDF page count: `{os.environ['PDF_PAGES']}`\n")
-              fh.write(f"- Plain extracted character count: `{plain_chars}`\n")
-              fh.write(f"- Layout extracted character count: `{layout_chars}`\n\n")
-              fh.write("### Pass/fail checklist\n\n")
-              for label, passed, detail in checklist:
-                  suffix = f" — {detail}" if detail else ""
-                  fh.write(f"- {'✅' if passed else '❌'} {label}{suffix}\n")
-              if education_observations:
-                  fh.write("\n### Education pairing observations\n\n")
-                  for observation in education_observations:
-                      fh.write(f"- {observation}\n")
-              if warnings:
-                  fh.write("\n### Non-blocking warnings\n\n")
-                  for warning in warnings:
-                      fh.write(f"- ⚠️ {warning}\n")
-              fh.write("\n<details>\n<summary>First 120 lines of plain extraction</summary>\n\n")
-              fh.write("```text\n")
-              fh.write(preview)
-              if preview and not preview.endswith("\n"):
-                  fh.write("\n")
-              fh.write("```\n\n</details>\n")
-
-          if failures:
-              for failure in failures:
-                  print(f"::error::{failure}")
-              sys.exit(1)
-          PY
+          scripts/resume-ats-smoke.py \
+            --pdf "${PDF}" \
+            --tex-source "${TEX_SOURCE}" \
+            --version "${VERSION}" \
+            --pdf-pages "${PDF_PAGES}" \
+            --plain-text "${plain_text}" \
+            --layout-text "${layout_text}" \
+            --summary "${GITHUB_STEP_SUMMARY}" \
+            --config "${ATS_CONFIG}"
 
       - name: Upload ATS text artifact
         if: always()

--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -136,6 +136,7 @@ jobs:
 
           plain_chars=$(wc -m <"${plain_text}" | tr -d '[:space:]')
           layout_chars=$(wc -m <"${layout_text}" | tr -d '[:space:]')
+          export ats_dir
           echo "ats_dir=${ats_dir}" >>"${GITHUB_OUTPUT}"
           echo "plain_text=${plain_text}" >>"${GITHUB_OUTPUT}"
           echo "layout_text=${layout_text}" >>"${GITHUB_OUTPUT}"
@@ -148,8 +149,9 @@ jobs:
           import sys
           from pathlib import Path
 
-          plain_path = Path(os.environ["RUNNER_TEMP"]) / "resume-ats" / "resume.txt"
-          layout_path = Path(os.environ["RUNNER_TEMP"]) / "resume-ats" / "resume-layout.txt"
+          ats_dir = Path(os.environ["ats_dir"])
+          plain_path = ats_dir / "resume.txt"
+          layout_path = ats_dir / "resume-layout.txt"
           plain = plain_path.read_text(encoding="utf-8", errors="replace")
           layout = layout_path.read_text(encoding="utf-8", errors="replace")
           failures = []
@@ -220,7 +222,11 @@ jobs:
                   checklist.append((f"Education pair nearby: `{degree}` / `{date}`", True, "warning only"))
               else:
                   warnings.append(f"Education pair not found nearby: `{degree}` / `{date}`")
-                  checklist.append((f"Education pair nearby: `{degree}` / `{date}`", True, "warning only"))
+                  checklist.append((
+                      f"Education pair not found nearby: `{degree}` / `{date}`",
+                      False,
+                      "warning only",
+                  ))
 
           oddities = []
           if re.search(r"[A-Za-z]-\n[A-Za-z]", plain):
@@ -261,6 +267,7 @@ jobs:
           PY
 
       - name: Upload ATS text artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: resume-${{ steps.resume.outputs.version }}-ats-text

--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -157,6 +157,7 @@ jobs:
           failures = []
           warnings = []
           checklist = []
+          education_observations = []
 
           def check(label, passed, detail=""):
               checklist.append((label, passed, detail))
@@ -216,17 +217,17 @@ jobs:
                   and abs(degree_pos - date_pos) <= 240
               )
               if same_line:
-                  checklist.append((f"Education pair same line: `{degree}` / `{date}`", True, ""))
+                  education_observations.append(
+                      f"✅ `{degree}` / `{date}` — same extracted line"
+                  )
               elif nearby:
-                  warnings.append(f"Education pair is nearby but detached: `{degree}` / `{date}`")
-                  checklist.append((f"Education pair nearby: `{degree}` / `{date}`", True, "warning only"))
+                  education_observations.append(
+                      f"⚠️ `{degree}` / `{date}` — nearby text window"
+                  )
               else:
-                  warnings.append(f"Education pair not found nearby: `{degree}` / `{date}`")
-                  checklist.append((
-                      f"Education pair not found nearby: `{degree}` / `{date}`",
-                      False,
-                      "warning only",
-                  ))
+                  warning = f"Education pair detached / not found nearby: `{degree}` / `{date}`"
+                  warnings.append(warning)
+                  education_observations.append(f"⚠️ {warning}")
 
           oddities = []
           if re.search(r"[A-Za-z]-\n[A-Za-z]", plain):
@@ -249,6 +250,10 @@ jobs:
               for label, passed, detail in checklist:
                   suffix = f" — {detail}" if detail else ""
                   fh.write(f"- {'✅' if passed else '❌'} {label}{suffix}\n")
+              if education_observations:
+                  fh.write("\n### Education pairing observations\n\n")
+                  for observation in education_observations:
+                      fh.write(f"- {observation}\n")
               if warnings:
                   fh.write("\n### Non-blocking warnings\n\n")
                   for warning in warnings:

--- a/docs/resume/README.md
+++ b/docs/resume/README.md
@@ -7,3 +7,10 @@
 - Runtime site links should use `/resume.pdf` as the canonical public résumé URL. The stable `/resume.docx` alias may be linked from documentation or download contexts where an editable copy is useful, but the primary UI should stay focused on the PDF.
 - Keep dated public artifacts such as `public/docs/resume/2026-06/resume.pdf` as immutable archives for source snapshots. Do not rewrite old source directories or outage records when the stable runtime alias changes.
 - The automated test suite compiles the latest dated résumé with [Tectonic](https://tectonic-typesetting.github.io/en-US/) and [Pandoc](https://pandoc.org/) to ensure both the PDF and DOCX outputs fit on a single A4 page. The check downloads pinned Linux binaries if they are not already on your `PATH` (other platforms should install the tools manually).
+
+## ATS smoke policy
+
+- The resume workflow keeps ATS smoke orchestration in `.github/workflows/resume.yml`
+  and delegates validation/reporting policy to `scripts/resume-ats-smoke.py`.
+- Update `docs/resume/ats-smoke.json` when required terms, section-order checks,
+  or Education degree/date pairing severity need to change.

--- a/docs/resume/ats-smoke.json
+++ b/docs/resume/ats-smoke.json
@@ -1,0 +1,30 @@
+{
+  "minimumPlainCharacters": 3000,
+  "requiredTerms": [
+    "Daniel Smith",
+    "daniel@danielsmith.io",
+    "Summary",
+    "Skills",
+    "Experience",
+    "Education",
+    "Independent Open Source Engineering",
+    "YouTube (Google)",
+    "Site Reliability Engineer, L4",
+    "The University of Southern Mississippi",
+    "Jones County Junior College"
+  ],
+  "sectionOrderPairs": [
+    ["Summary", "Skills"],
+    ["Skills", "Experience"],
+    ["Experience", "Education"]
+  ],
+  "educationPairing": {
+    "severity": "warning",
+    "nearbyWindowCharacters": 240,
+    "pairs": [
+      ["M.S. Computer Science", "Aug 2015"],
+      ["B.S. Computer Science", "May 2013"],
+      ["A.A.S. Information System Technology", "Aug 2011"]
+    ]
+  }
+}

--- a/scripts/resume-ats-smoke.py
+++ b/scripts/resume-ats-smoke.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Validate and summarize local pdftotext resume extraction quality."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    label: str
+    passed: bool
+    detail: str = ""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf", required=True, help="Generated PDF path.")
+    parser.add_argument("--tex-source", required=True, help="Selected TeX source path.")
+    parser.add_argument("--version", required=True, help="Selected resume version.")
+    parser.add_argument("--pdf-pages", required=True, help="Generated PDF page count.")
+    parser.add_argument("--plain-text", required=True, help="Plain pdftotext output path.")
+    parser.add_argument("--layout-text", required=True, help="Layout pdftotext output path.")
+    parser.add_argument("--summary", required=True, help="GitHub step summary path.")
+    parser.add_argument(
+        "--config",
+        default="docs/resume/ats-smoke.json",
+        help="Smoke policy JSON path.",
+    )
+    return parser.parse_args()
+
+
+def load_config(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def normalized_heading(line: str) -> str:
+    return re.sub(r"\s+", " ", line.strip()).strip(":")
+
+
+def heading_positions(lines: list[str], headings: set[str]) -> dict[str, int]:
+    positions: dict[str, int] = {}
+    offset = 0
+    for line in lines:
+        heading = normalized_heading(line)
+        if heading in headings and heading not in positions:
+            positions[heading] = offset + line.find(line.strip())
+        offset += len(line) + 1
+    return positions
+
+
+def fallback_position(text: str, positions: dict[str, int], term: str) -> int:
+    return positions.get(term, text.find(term))
+
+
+def section_slice(
+    text: str,
+    heading_positions_by_name: dict[str, int],
+    section: str,
+) -> str:
+    start = heading_positions_by_name.get(section, text.find(section))
+    if start == -1:
+        return ""
+    following = [
+        pos
+        for name, pos in heading_positions_by_name.items()
+        if pos > start and name != section
+    ]
+    end = min(following) if following else len(text)
+    return text[start:end]
+
+
+def education_pair_observations(
+    config: dict,
+    plain: str,
+    heading_positions_by_name: dict[str, int],
+) -> tuple[list[str], list[str], list[str]]:
+    education_config = config.get("educationPairing", {})
+    window = int(education_config.get("nearbyWindowCharacters", 240))
+    severity = education_config.get("severity", "warning")
+    prefix = "⚠️" if severity == "warning" else "❌"
+    education_text = section_slice(plain, heading_positions_by_name, "Education")
+    lines = education_text.splitlines()
+    observations: list[str] = []
+    warnings: list[str] = []
+    failures: list[str] = []
+
+    # TODO: Make these Education pairing warnings blocking after the Education
+    # section is reformatted in a follow-up PR.
+    for degree, date in education_config.get("pairs", []):
+        same_line = any(degree in line and date in line for line in lines)
+        degree_pos = education_text.find(degree)
+        date_pos = education_text.find(date)
+        nearby = (
+            degree_pos != -1
+            and date_pos != -1
+            and abs(degree_pos - date_pos) <= window
+        )
+        label = f"`{degree}` / `{date}`"
+        if same_line:
+            observations.append(f"✅ {label} — same extracted line")
+        elif nearby:
+            observations.append(f"{prefix} {label} — nearby text window")
+        else:
+            message = f"Education pair detached / not found nearby: {label}"
+            observations.append(f"{prefix} {message}")
+            if severity == "warning":
+                warnings.append(message)
+            else:
+                failures.append(message)
+    return observations, warnings, failures
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(Path(args.config))
+    plain_path = Path(args.plain_text)
+    layout_path = Path(args.layout_text)
+    plain = plain_path.read_text(encoding="utf-8", errors="replace")
+    layout = layout_path.read_text(encoding="utf-8", errors="replace")
+    plain_lines = plain.splitlines()
+    failures: list[str] = []
+    warnings: list[str] = []
+    checklist: list[CheckResult] = []
+
+    def check(label: str, passed: bool, detail: str = "") -> None:
+        checklist.append(CheckResult(label, passed, detail))
+        if not passed:
+            failures.append(label if not detail else f"{label}: {detail}")
+
+    plain_chars = len(plain)
+    layout_chars = len(layout)
+    min_plain_chars = int(config.get("minimumPlainCharacters", 3000))
+    check("Plain extracted text is non-empty", plain_chars > 0, f"{plain_chars} chars")
+    check(
+        "Plain extracted text is reasonably large",
+        plain_chars >= min_plain_chars,
+        f"{plain_chars} chars",
+    )
+    check("PDF page count is one", args.pdf_pages == "1", args.pdf_pages)
+
+    for term in config.get("requiredTerms", []):
+        check(f"Required text present: `{term}`", term in plain)
+
+    section_names = {
+        section for pair in config.get("sectionOrderPairs", []) for section in pair
+    }
+    headings = heading_positions(plain_lines, section_names)
+    for before, after in config.get("sectionOrderPairs", []):
+        before_pos = fallback_position(plain, headings, before)
+        after_pos = fallback_position(plain, headings, after)
+        check(
+            f"Section order: `{before}` before `{after}`",
+            before_pos != -1 and after_pos != -1 and before_pos < after_pos,
+            f"positions {before_pos}, {after_pos}",
+        )
+
+    education_observations, education_warnings, education_failures = (
+        education_pair_observations(config, plain, headings)
+    )
+    warnings.extend(education_warnings)
+    failures.extend(education_failures)
+
+    if re.search(r"[A-Za-z]-\n[A-Za-z]", plain):
+        warnings.append("Possible hyphenated line break found in plain extraction.")
+    if re.search(r"\b[A-Za-z]{1,2}\n[A-Za-z]{1,2}\n", plain):
+        warnings.append("Possible unusually short wrapped words found in plain extraction.")
+
+    preview = "\n".join(plain_lines[:120])
+    with Path(args.summary).open("a", encoding="utf-8") as fh:
+        fh.write("## ATS smoke report\n\n")
+        fh.write(f"- Selected TeX source: `{args.tex_source}`\n")
+        fh.write(f"- Selected resume version: `{args.version}`\n")
+        fh.write(f"- Generated PDF path: `{args.pdf}`\n")
+        fh.write(f"- PDF page count: `{args.pdf_pages}`\n")
+        fh.write(f"- Plain extracted character count: `{plain_chars}`\n")
+        fh.write(f"- Layout extracted character count: `{layout_chars}`\n\n")
+        fh.write("### Pass/fail checklist\n\n")
+        for result in checklist:
+            suffix = f" — {result.detail}" if result.detail else ""
+            fh.write(f"- {'✅' if result.passed else '❌'} {result.label}{suffix}\n")
+        if education_observations:
+            fh.write("\n### Education pairing observations\n\n")
+            for observation in education_observations:
+                fh.write(f"- {observation}\n")
+        if warnings:
+            fh.write("\n### Non-blocking warnings\n\n")
+            for warning in warnings:
+                fh.write(f"- ⚠️ {warning}\n")
+        fh.write("\n<details>\n<summary>First 120 lines of plain extraction</summary>\n\n")
+        fh.write("```text\n")
+        fh.write(preview)
+        if preview and not preview.endswith("\n"):
+            fh.write("\n")
+        fh.write("```\n\n</details>\n")
+
+    if failures:
+        for failure in failures:
+            print(f"::error::{failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Make resume parsing quality visible in PR CI by running a deterministic local ATS smoke check on the generated PDF before artifacts are uploaded.
- Fail early on empty/too-small extractions, missing required fields, broken section order, or non-one-page PDFs so formatting regressions are visible in PRs that touch resume sources or the workflow.

### Description

- Add a new step in `.github/workflows/resume.yml` called `Run ATS smoke report` that uses Poppler `pdftotext` to produce plain and `-layout` text extractions (`resume.txt` and `resume-layout.txt`) and records character counts and paths to `$GITHUB_OUTPUT`.
- Run a small Python-based checker that enforces: non-empty/plain extraction size, PDF page count equals one, presence of required terms, and sane section ordering (`Summary` → `Skills` → `Experience` → `Education`), and that writes a human-readable `ATS smoke report` to the GitHub Actions step summary.
- Detect Education degree/date pairings (`M.S. Computer Science` / `Aug 2015`, `B.S. Computer Science` / `May 2013`, `A.A.S. Information System Technology` / `Aug 2011`) and surface them as non-blocking warnings with a TODO comment to make them blocking in a follow-up PR after Education reformatting.
- Upload the extracted text files as a small workflow artifact named `resume-${{ steps.resume.outputs.version }}-ats-text` containing `resume.txt` and `resume-layout.txt` for offline inspection.

### Testing

- Ran `npm run format:write` and `npm run format:check`, both succeeded.
- Built and extracted locally with `latexmk -pdf -interaction=nonstopmode -outdir=/tmp/resume-build docs/resume/2026-06/resume.tex` then `pdftotext /tmp/resume-build/resume.pdf /tmp/resume.txt` and `pdftotext -layout /tmp/resume-build/resume.pdf /tmp/resume-layout.txt`, which produced a 1-page PDF and extractions (plain chars: `3606`, layout chars: `4404`).
- Verified CI-style checks: `npm run docs:check`, `npm run lint`, `npm run test:ci` (Vitest: 1213 tests passed), `npm run smoke`, `git diff --check`, `./scripts/scan-secrets.py`, and `actionlint .github/workflows/resume.yml` all completed without failures.
- The new smoke step will fail CI on the required-field / order / extraction-size / page-count conditions and will report Education pairing issues as warnings only (per the TODO to flip to blocking later).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a376738e970832fbf2bd52cba9e5a7e)