### PR TITLE
📄 Tighten resume Education ATS pairing gate

### DIFF
--- a/docs/resume/2026-06/resume.tex
+++ b/docs/resume/2026-06/resume.tex
@@ -90,11 +90,11 @@ Three.js/WebGL, local LLM inference, LLM application and infrastructure engineer
 
 \vspace{-2mm}
 \section*{Education}
-\textbf{The University of Southern Mississippi} - M.S. Computer Science, \textit{GPA: 4.0}
-\hfill Aug 2015 -- Aug 2016 \\
-\textbf{The University of Southern Mississippi} - B.S. Computer Science, \textit{GPA: 4.0}
-\hfill May 2013 -- May 2015 \\
-\textbf{Jones County Junior College} - A.A.S. Information System Technology, \textit{GPA: 4.0}
-\hfill Aug 2011 -- May 2013
+\textbf{The University of Southern Mississippi} - M.S. Computer Science, \textit{GPA: 4.0} |
+Aug 2015 -- Aug 2016 \\
+\textbf{The University of Southern Mississippi} - B.S. Computer Science, \textit{GPA: 4.0} |
+May 2013 -- May 2015 \\
+\textbf{Jones County Junior College} - A.A.S. Information System Technology, \textit{GPA: 4.0} |
+Aug 2011 -- May 2013
 
 \end{document}

--- a/docs/resume/ats-smoke.json
+++ b/docs/resume/ats-smoke.json
@@ -19,7 +19,7 @@
     ["Experience", "Education"]
   ],
   "educationPairing": {
-    "severity": "warning",
+    "severity": "error",
     "nearbyWindowCharacters": 240,
     "pairs": [
       ["M.S. Computer Science", "Aug 2015"],

--- a/scripts/resume-ats-smoke.py
+++ b/scripts/resume-ats-smoke.py
@@ -91,8 +91,6 @@ def education_pair_observations(
     warnings: list[str] = []
     failures: list[str] = []
 
-    # TODO: Make these Education pairing warnings blocking after the Education
-    # section is reformatted in a follow-up PR.
     for degree, date in education_config.get("pairs", []):
         same_line = any(degree in line and date in line for line in lines)
         degree_pos = education_text.find(degree)


### PR DESCRIPTION
### Motivation
- Ensure each Education credential remains tightly bound to its date in plain `pdftotext` extraction by removing layout constructs that detach dates (e.g. `\hfill`) and using a parser-friendly inline format. 
- Make the ATS smoke policy enforce degree/date pairing as a blocking check so future regressions fail fast.

### Description
- Rewrote the Education entries in `docs/resume/2026-06/resume.tex` to remove `\hfill` and place degree/date on the same logical line (separator `|`) so `pdftotext` yields a single extracted line per entry. 
- Updated `docs/resume/ats-smoke.json` to promote `educationPairing.severity` from `warning` to `error` so detached pairs trigger a blocking failure. 
- Removed the obsolete follow-up TODO from `scripts/resume-ats-smoke.py` so the script honors the configured severity directly. 
- Kept all other resume content, layout goals (one page), and orchestration workflow unchanged.

### Testing
- Built PDF: `latexmk -pdf -interaction=nonstopmode -outdir=/tmp/resume-build docs/resume/2026-06/resume.tex` — succeeded and produced a 1-page PDF. ✅
- Extracted text: `pdftotext /tmp/resume-build/resume.pdf /tmp/resume.txt` and `pdftotext -layout /tmp/resume-build/resume.pdf /tmp/resume-layout.txt` — extraction shows each Education entry and date on the same line. ✅
- Ran ATS smoke script: `scripts/resume-ats-smoke.py --pdf /tmp/resume-build/resume.pdf --tex-source docs/resume/2026-06/resume.tex --version 2026-06 --pdf-pages 1 --plain-text /tmp/resume.txt --layout-text /tmp/resume-layout.txt --summary /tmp/resume-ats-smoke.md --config docs/resume/ats-smoke.json` — all required checks passed and Education pairings reported as same-line entries. ✅
- Generated DOCX via `pandoc docs/resume/2026-06/resume.tex -o /tmp/resume-build/resume.docx` and verified the file exists — succeeded. ✅
- Repository quality gates: `npm run format:write`, `npm run format:check`, `npm run docs:check`, `npm run lint`, `npm run test:ci`, `npm run smoke`, `git diff --check`, and `./scripts/scan-secrets.py` — all completed successfully in this environment (tests passed). ✅
- Note: `actionlint .github/workflows/resume.yml` was unavailable in the container (`actionlint: command not found`). ⚠️

If you'd like, I can follow up with a tiny README note in `docs/resume/README.md` describing the new blocking Education pairing policy; kept out of this PR to respect the scope lock.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a377f073344832fb4a0879c76ffd66c)