### PR TITLE
Tighten resume Education ATS pairing gate

### DIFF
--- a/docs/resume/2026-06/resume.tex
+++ b/docs/resume/2026-06/resume.tex
@@ -90,11 +90,11 @@ Three.js/WebGL, local LLM inference, LLM application and infrastructure engineer
 
 \vspace{-2mm}
 \section*{Education}
-\textbf{The University of Southern Mississippi} - M.S. Computer Science, \textit{GPA: 4.0}
-\hfill Aug 2015 -- Aug 2016 \\
-\textbf{The University of Southern Mississippi} - B.S. Computer Science, \textit{GPA: 4.0}
-\hfill May 2013 -- May 2015 \\
-\textbf{Jones County Junior College} - A.A.S. Information System Technology, \textit{GPA: 4.0}
-\hfill Aug 2011 -- May 2013
+\textbf{The University of Southern Mississippi} - M.S. Computer Science, \textit{GPA: 4.0} |
+Aug 2015 -- Aug 2016 \\
+\textbf{The University of Southern Mississippi} - B.S. Computer Science, \textit{GPA: 4.0} |
+May 2013 -- May 2015 \\
+\textbf{Jones County Junior College} - A.A.S. Information System Technology, \textit{GPA: 4.0} |
+Aug 2011 -- May 2013
 
 \end{document}

--- a/docs/resume/ats-smoke.json
+++ b/docs/resume/ats-smoke.json
@@ -19,7 +19,7 @@
     ["Experience", "Education"]
   ],
   "educationPairing": {
-    "severity": "warning",
+    "severity": "error",
     "nearbyWindowCharacters": 240,
     "pairs": [
       ["M.S. Computer Science", "Aug 2015"],

--- a/scripts/resume-ats-smoke.py
+++ b/scripts/resume-ats-smoke.py
@@ -91,8 +91,6 @@ def education_pair_observations(
     warnings: list[str] = []
     failures: list[str] = []
 
-    # TODO: Make these Education pairing warnings blocking after the Education
-    # section is reformatted in a follow-up PR.
     for degree, date in education_config.get("pairs", []):
         same_line = any(degree in line and date in line for line in lines)
         degree_pos = education_text.find(degree)


### PR DESCRIPTION
### Motivation
- Prevent `pdftotext` from detaching Education dates from their matching degrees by removing `\hfill` and producing ATS-friendly single-line credential/date entries. 
- Make Education pairing failures block the ATS smoke gate so future regressions fail CI instead of only warning.

### Description
- Reformat the `Education` block in `docs/resume/2026-06/resume.tex` to remove `\hfill` and emit each entry as a single logical line (uses an inline separator so degree and date remain adjacent). 
- Update the ATS smoke policy in `docs/resume/ats-smoke.json` by changing `educationPairing.severity` from `"warning"` to `"error"` so detached pairs become blocking failures. 
- Remove the stale follow-up `TODO` comment from `scripts/resume-ats-smoke.py` so behavior is fully policy-driven and no longer relies on a future manual change. 
- Preserved visual compactness and the one-page resume target and avoided edits to Summary, Skills, Experience, or experience bullets.

### Testing
- Built the PDF with `latexmk -pdf -interaction=nonstopmode -outdir=/tmp/resume-build docs/resume/2026-06/resume.tex` and extracted text with `pdftotext` and `pdftotext -layout`; extraction shows each degree/date pair on the same line. 
- Ran the ATS smoke script `python3 scripts/resume-ats-smoke.py ... --config docs/resume/ats-smoke.json` which reported the three Education pairs as "same extracted line" (all passed) under the new `error` policy. 
- Generated DOCX via `pandoc docs/resume/2026-06/resume.tex -o /tmp/resume-build/resume.docx` and verified the file is non-empty. 
- Ran repository checks `npm run format:write`, `npm run format:check`, `npm run docs:check` (passed; link checker emitted external fetch warnings), `npm run lint`, `npm run test:ci` (all tests passed), `npm run smoke` (dist checks passed), `git diff --check`, and `./scripts/scan-secrets.py` (no secrets); all completed successfully in this environment. 
- Note: `actionlint .github/workflows/resume.yml` was skipped because `actionlint` is not installed in the environment used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a377f0e2350832f952d04fee238e97a)