### PR TITLE
Tighten resume Education ATS extraction gate

### DIFF
--- a/docs/resume/2026-06/resume.tex
+++ b/docs/resume/2026-06/resume.tex
@@ -90,11 +90,11 @@ Three.js/WebGL, local LLM inference, LLM application and infrastructure engineer
 
 \vspace{-2mm}
 \section*{Education}
-\textbf{The University of Southern Mississippi} - M.S. Computer Science, \textit{GPA: 4.0}
-\hfill Aug 2015 -- Aug 2016 \\
-\textbf{The University of Southern Mississippi} - B.S. Computer Science, \textit{GPA: 4.0}
-\hfill May 2013 -- May 2015 \\
-\textbf{Jones County Junior College} - A.A.S. Information System Technology, \textit{GPA: 4.0}
-\hfill Aug 2011 -- May 2013
+\textbf{The University of Southern Mississippi} - M.S. Computer Science,
+\textit{GPA: 4.0} | Aug 2015 -- Aug 2016 \\
+\textbf{The University of Southern Mississippi} - B.S. Computer Science,
+\textit{GPA: 4.0} | May 2013 -- May 2015 \\
+\textbf{Jones County Junior College} - A.A.S. Information System Technology,
+\textit{GPA: 4.0} | Aug 2011 -- May 2013
 
 \end{document}

--- a/docs/resume/ats-smoke.json
+++ b/docs/resume/ats-smoke.json
@@ -19,7 +19,7 @@
     ["Experience", "Education"]
   ],
   "educationPairing": {
-    "severity": "warning",
+    "severity": "error",
     "nearbyWindowCharacters": 240,
     "pairs": [
       ["M.S. Computer Science", "Aug 2015"],

--- a/scripts/resume-ats-smoke.py
+++ b/scripts/resume-ats-smoke.py
@@ -91,8 +91,6 @@ def education_pair_observations(
     warnings: list[str] = []
     failures: list[str] = []
 
-    # TODO: Make these Education pairing warnings blocking after the Education
-    # section is reformatted in a follow-up PR.
     for degree, date in education_config.get("pairs", []):
         same_line = any(degree in line and date in line for line in lines)
         degree_pos = education_text.find(degree)


### PR DESCRIPTION
### Motivation
- pdftotext was detaching Education dates from their degree lines (likely due to `\hfill`), which breaks ATS-friendly extraction and automated smoke checks.
- The resume ATS policy should block detached degree/date pairs to prevent regressions in future edits.

### Description
- Rewrote the Education block in `docs/resume/2026-06/resume.tex` to remove `\hfill` and place each degree, GPA, and date on a single logical line (using `|` as a compact separator). 
- Promoted the education pairing policy in `docs/resume/ats-smoke.json` by changing `educationPairing.severity` from `warning` to `error` so detachments become blocking failures. 
- Removed the stale TODO comment in `scripts/resume-ats-smoke.py` so the smoke script behavior is policy-driven and consistent with the new blocking setting.

### Testing
- Built the PDF with `latexmk -pdf -interaction=nonstopmode -outdir=/tmp/resume-build docs/resume/2026-06/resume.tex` and then extracted text with `pdftotext` (plain and `-layout`), and the commands completed successfully. (passed)
- Ran the updated ATS smoke script with `scripts/resume-ats-smoke.py --pdf /tmp/resume-build/resume.pdf --tex-source docs/resume/2026-06/resume.tex --version 2026-06 --pdf-pages 1 --plain-text /tmp/resume.txt --layout-text /tmp/resume-layout.txt --summary /tmp/resume-ats-summary.md --config docs/resume/ats-smoke.json` and it reported all three Education pairs as present on the same extracted line (passed).
- Ran repository checks `npm run format:write`, `npm run format:check`, `npm run docs:check`, `npm run lint`, `npm run test:ci`, `npm run smoke`, `git diff --check`, and `./scripts/scan-secrets.py`, all of which completed successfully in this environment. (passed)
- Generated DOCX with `pandoc docs/resume/2026-06/resume.tex -o /tmp/resume-build/resume.docx` which completed successfully, while `actionlint .github/workflows/resume.yml` was not available in this environment so it was not run. (pandoc: passed, actionlint: not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a377eee2068832fa532322d48d95c16)