### PR TITLE
🧱 : – Add source-backed collider contract

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -139,6 +139,21 @@ npx vitest run src/scene/level/__tests__/generateFloorSurfaces.test.ts
 npx playwright test playwright/immersive-stairs-roundtrip.spec.ts
 ```
 
+## Source-owned collision policies
+
+Stair safety and upper-stairwell landing guard colliders use the shared
+`SourceCollisionPolicy` / `ActiveSourceBackedCollider` contract under
+`src/scene/level/`. Active declarations carry their collision intent, purpose,
+runtime name, and optional stable debug ID beside the source ID that owns the
+collider. Visual-only declarations use `collision: 'none'` with a concise
+rationale so disabling collision does not require tombstones or a parallel
+runtime ledger.
+
+When removing or changing one of these source-backed colliders, edit the active
+declaration that emits it. Runtime registration consumes the emitted source
+metadata directly; do not reconstruct source IDs, purposes, or debug IDs in
+`src/main.ts`.
+
 ## Immersive test taxonomy
 
 Keep immersive Playwright assertions behavior-first unless a test is explicitly

--- a/src/main.ts
+++ b/src/main.ts
@@ -2095,7 +2095,7 @@ function initializeImmersiveScene(
     namedColliderDebugNames.set(collider.bounds, collider.name);
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
-      sourceType: 'safetyCollider',
+      sourceType: collider.sourceType,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
@@ -2137,15 +2137,16 @@ function initializeImmersiveScene(
     name: string;
     bounds: RectCollider;
     sourceId: LevelSourceId;
-    role: string;
+    sourceType: 'generatedCollider';
+    purpose: string;
     debugId?: string;
   }) => {
     upperFloorColliders.push(collider.bounds);
     namedColliderDebugNames.set(collider.bounds, collider.name);
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
-      sourceType: 'generatedCollider',
-      purpose: `upper stairwell landing ${collider.role} guard`,
+      sourceType: collider.sourceType,
+      purpose: collider.purpose,
       debugId: collider.debugId,
     });
   };

--- a/src/scene/level/sourceBackedColliders.ts
+++ b/src/scene/level/sourceBackedColliders.ts
@@ -1,0 +1,45 @@
+import type { RectCollider } from '../../systems/collision';
+import type { DebugColliderId } from '../debug/colliderDebugIds';
+
+import type { LevelSourceId, LevelSourceType } from './sourceIds';
+
+export type CollisionIntent =
+  | 'physical-boundary'
+  | 'safety-guard'
+  | 'interaction-footprint'
+  | 'secondary-backstop';
+
+export interface ActiveSourceCollisionPolicy {
+  collision: 'active';
+  intent: CollisionIntent;
+  purpose: string;
+  runtimeName?: string;
+  debugId?: DebugColliderId;
+}
+
+export interface NoSourceCollisionPolicy {
+  collision: 'none';
+  rationale: string;
+}
+
+export type SourceCollisionPolicy =
+  | ActiveSourceCollisionPolicy
+  | NoSourceCollisionPolicy;
+
+export interface ActiveSourceBackedCollider<
+  Role extends string,
+  ExtraFields extends object = object,
+> extends ExtraFields {
+  role: Role;
+  sourceId: LevelSourceId;
+  sourceType: LevelSourceType;
+  intent: CollisionIntent;
+  purpose: string;
+  bounds: RectCollider;
+  name: string;
+  debugId?: DebugColliderId;
+}
+
+export const isActiveSourceCollisionPolicy = (
+  policy: SourceCollisionPolicy
+): policy is ActiveSourceCollisionPolicy => policy.collision === 'active';

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -11,19 +11,20 @@ import {
   type DebugColliderId,
 } from '../debug/colliderDebugIds';
 
+import type { ActiveSourceBackedCollider } from './sourceBackedColliders';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type SafetyColliderCategory = 'stair' | 'landing' | 'void';
 
-export interface LevelSafetyCollider {
-  sourceId: LevelSourceId;
-  name: string;
-  floor: 'ground' | 'upper';
-  category: SafetyColliderCategory;
-  bounds: RectCollider;
-  purpose: string;
-  debugId: DebugColliderId;
-}
+export type LevelSafetyCollider = ActiveSourceBackedCollider<
+  'stair-safety',
+  {
+    sourceType: 'safetyCollider';
+    floor: 'ground' | 'upper';
+    category: SafetyColliderCategory;
+    debugId: DebugColliderId;
+  }
+>;
 
 export interface GroundStairSafetyColliderOptions {
   playerRadius: number;
@@ -54,19 +55,23 @@ const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
   GroundStairLowerCornerGuard: {
     sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
     category: 'stair',
+    intent: 'safety-guard',
     purpose: 'block raw lower-step occupancy',
     debugId: debugId('4002'),
   },
 } as const satisfies Record<
   string,
-  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose' | 'debugId'>
+  Pick<
+    LevelSafetyCollider,
+    'sourceId' | 'category' | 'purpose' | 'debugId' | 'intent'
+  >
 >;
 
 const getGroundStairSafetyColliderMetadata = (
   name: string
 ): Pick<
   LevelSafetyCollider,
-  'sourceId' | 'category' | 'purpose' | 'debugId'
+  'sourceId' | 'category' | 'purpose' | 'debugId' | 'intent'
 > => {
   const metadata =
     GROUND_STAIR_SAFETY_COLLIDER_METADATA[
@@ -89,7 +94,9 @@ export const createGroundStairSafetyColliders = (
 ): LevelSafetyCollider[] =>
   createGroundStairBoundaryColliders(geometry, behavior, options).map(
     ({ name, bounds }) => ({
+      role: 'stair-safety',
       name,
+      sourceType: 'safetyCollider',
       floor: 'ground',
       bounds,
       ...getGroundStairSafetyColliderMetadata(name),
@@ -173,7 +180,10 @@ export const createUpperStairSafetyColliders = ({
     upperStairwellOpening.maxX - upperStairBannisterThickness;
   return [
     {
+      role: 'stair-safety',
       name: 'UpperStairEastUpperVoidGuard',
+      sourceType: 'safetyCollider',
+      intent: 'safety-guard',
       debugId: debugId('4007'),
       sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
       floor: 'upper',
@@ -187,7 +197,10 @@ export const createUpperStairSafetyColliders = ({
       },
     },
     ...upperStairTopGapBlockers.map(({ name, bounds }) => ({
+      role: 'stair-safety' as const,
       name,
+      sourceType: 'safetyCollider' as const,
+      intent: 'safety-guard' as const,
       sourceId: sourceId(
         `upper.stairwell.topGap.${name.endsWith('West') ? 'west' : 'east'}.safetyCollider`
       ),
@@ -198,7 +211,10 @@ export const createUpperStairSafetyColliders = ({
       bounds,
     })),
     {
+      role: 'stair-safety',
       name: 'UpperStairWestBannisterGuard',
+      sourceType: 'safetyCollider',
+      intent: 'secondary-backstop',
       debugId: debugId('4009'),
       sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),
       floor: 'upper',
@@ -219,7 +235,10 @@ export const createUpperStairSafetyColliders = ({
       },
     },
     {
+      role: 'stair-safety',
       name: 'UpperStairNorthBannisterGuard',
+      sourceType: 'safetyCollider',
+      intent: 'secondary-backstop',
       debugId: debugId('400A'),
       sourceId: sourceId('upper.stairwell.northBannister.safetyCollider'),
       floor: 'upper',

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -3,6 +3,7 @@ import {
   type DebugColliderId,
 } from '../debug/colliderDebugIds';
 
+import type { SourceCollisionPolicy } from './sourceBackedColliders';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type UpperStairwellLandingSegmentRole =
@@ -15,10 +16,8 @@ export type UpperStairwellLandingSegmentRole =
 export interface UpperStairwellLandingSegmentPolicy {
   role: UpperStairwellLandingSegmentRole;
   render: boolean;
-  collision: boolean;
   sourceId: LevelSourceId;
-  colliderName?: string;
-  debugId?: DebugColliderId;
+  collision: SourceCollisionPolicy;
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
@@ -29,21 +28,32 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
   {
     role: 'side-east',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.sideEast'),
+    collision: {
+      collision: 'none',
+      rationale:
+        'visual guard; adjacent side is already blocked by the stairwell void guard',
+    },
   },
   {
     role: 'far',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.far'),
+    collision: {
+      collision: 'none',
+      rationale: 'visual guard; the far landing edge remains walkable floor',
+    },
   },
   {
     role: 'shoulder-east',
     render: true,
-    collision: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
-    colliderName: 'UpperStairwellLandingGuard-3',
-    debugId: debugId('400D'),
+    collision: {
+      collision: 'active',
+      intent: 'safety-guard',
+      purpose: 'upper stairwell landing shoulder-east guard',
+      runtimeName: 'UpperStairwellLandingGuard-3',
+      debugId: debugId('400D'),
+    },
   },
 ] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -23,9 +23,13 @@ const allSegmentPolicies = (): UpperStairwellLandingSegmentPolicy[] =>
   ALL_SEGMENT_ROLES.map((role) => ({
     role,
     render: true,
-    collision: true,
     sourceId: assertLevelSourceId(`upper.stairwell.landingGuard.test.${role}`),
-    colliderName: `UpperStairwellLandingTestGuard-${role}`,
+    collision: {
+      collision: 'active',
+      intent: 'safety-guard',
+      purpose: `upper stairwell landing ${role} guard`,
+      runtimeName: `UpperStairwellLandingTestGuard-${role}`,
+    },
   }));
 
 const overlaps = (
@@ -148,6 +152,9 @@ describe('createUpperStairwellLanding', () => {
       {
         role: 'shoulder-east',
         sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+        sourceType: 'generatedCollider',
+        intent: 'safety-guard',
+        purpose: 'upper stairwell landing shoulder-east guard',
         name: 'UpperStairwellLandingGuard-3',
         debugId: '400D',
         bounds: {

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -2,7 +2,8 @@ import type { MeshStandardMaterialParameters } from 'three';
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
-import type { RectCollider } from '../../systems/collision';
+import type { ActiveSourceBackedCollider } from '../level/sourceBackedColliders';
+import { isActiveSourceCollisionPolicy } from '../level/sourceBackedColliders';
 import type {
   UpperStairwellLandingSegmentPolicy,
   UpperStairwellLandingSegmentRole,
@@ -32,13 +33,10 @@ export interface UpperStairwellLandingConfig {
   segments: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
-export interface UpperStairwellLandingCollider {
-  role: UpperStairwellLandingSegmentRole;
-  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
-  name: string;
-  debugId?: UpperStairwellLandingSegmentPolicy['debugId'];
-  bounds: RectCollider;
-}
+export type UpperStairwellLandingCollider = ActiveSourceBackedCollider<
+  UpperStairwellLandingSegmentRole,
+  { sourceType: 'generatedCollider' }
+>;
 
 export interface UpperStairwellLandingBuild {
   group: Group;
@@ -110,18 +108,22 @@ const addGuard = (params: {
     params.group.add(guard);
   }
 
-  if (params.policy.collision) {
-    if (!params.policy.colliderName) {
+  const collision = params.policy.collision;
+  if (isActiveSourceCollisionPolicy(collision)) {
+    if (!collision.runtimeName) {
       throw new Error(
-        `Upper stairwell landing segment ${params.policy.role} enables collision without a collider name.`
+        `Upper stairwell landing segment ${params.policy.role} enables collision without a runtime name.`
       );
     }
 
     params.colliders.push({
       role: params.policy.role,
       sourceId: params.policy.sourceId,
-      name: params.policy.colliderName,
-      debugId: params.policy.debugId,
+      sourceType: 'generatedCollider',
+      intent: collision.intent,
+      purpose: collision.purpose,
+      name: collision.runtimeName,
+      debugId: collision.debugId,
       bounds: guardBounds,
     });
   }

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -43,7 +43,7 @@ describe('main module imports', () => {
     expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
     expect(source).toContain("sourceType: 'wall',");
     expect(source).toContain('colliderSourceMetadata.set(collider.bounds, {');
-    expect(source).toContain("sourceType: 'safetyCollider',");
+    expect(source).toContain('sourceType: collider.sourceType,');
     expect(source).toContain('purpose: collider.purpose,');
     expect(source).toContain(
       'sourceId: colliderSourceMetadata.get(bounds)?.sourceId,'


### PR DESCRIPTION
### Motivation
- Introduce a minimal, source-backed collider contract to centralize collision intent and remove duplicated metadata shapes for stair and landing colliders.
- Migrate existing stair safety and upper-stairwell landing declarations to prove the contract and enable incremental source-owned collision declarations.
- Preserve runtime geometry, collider names, source IDs, and explicit debug IDs exactly while replacing brittle boolean plumbing with a semantic policy.

### Description
- Add `src/scene/level/sourceBackedColliders.ts` declaring `CollisionIntent`, `SourceCollisionPolicy` (`active` / `none`), `ActiveSourceBackedCollider<T>`, and the `isActiveSourceCollisionPolicy` guard.
- Refactor `src/scene/level/stairSafetyColliders.ts` to emit `LevelSafetyCollider` values as `ActiveSourceBackedCollider<'stair-safety', ...>` and include `role`, `sourceType`, and `intent` while preserving original `name`, `bounds`, `sourceId`, and `debugId` values.
- Replace the `collision: boolean` shape in `src/scene/level/upperStairwellLandingSegments.ts` with `collision: SourceCollisionPolicy`, giving visual-only segments a `rationale` and active segments an explicit `runtimeName` and `intent` (preserving `400D`).
- Update `src/scene/structures/upperStairwellLanding.ts` to consume the new policy via `isActiveSourceCollisionPolicy(...)` and emit `ActiveSourceBackedCollider` records for active segments.
- Simplify runtime registration in `src/main.ts` to consume `sourceType` and `purpose` directly from emitted records instead of reconstructing them.
- Update focused unit tests and add a short docs entry in `docs/design/editing-level-data.md` describing source-owned collision policies.

### Testing
- Ran formatting with `npm run format:write` and formatting completed successfully.
- Ran lint with `npm run lint` and the final lint pass completed (non-blocking warnings were addressed during iteration).
- Ran focused unit tests with `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts` and both test files passed.
- Ran full unit suite with `npm run test:ci` and the suite completed successfully (all tests passed in CI run).
- Installed Playwright browsers (`npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell`) and executed the immersive stairs E2E with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed locally.
- Ran docs checks with `npm run docs:check` (passed; external-link checks produced only informational warnings) and smoke with `npm run smoke` (build and smoke checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a379e871f34832f9cbc1e8bc105e264)