### PR TITLE
Add source-backed collider contract and migrate stair/landing colliders

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -171,7 +171,7 @@ about debug provenance, generator output, or debug-ID registry behavior:
 
 Source-owned collider declarations should use the shared policy contract in
 `src/scene/level/sourceCollision.ts` when they need stable runtime provenance.
-Active policies carry intent, purpose, optional runtime name, and optional debug
+Active policies carry intent, purpose, required runtime name, and optional debug
 ID; visual-only policies carry a concise no-collision rationale. Emitted records
 should pass that source metadata through to runtime registration directly rather
 than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -168,3 +168,10 @@ about debug provenance, generator output, or debug-ID registry behavior:
    Playwright inventory edits. Do not use raw IDs to prove normal movement
    behavior; player-facing tests should describe the route, open area, blocked
    void, or source-backed feature instead.
+
+Source-owned collider declarations should use the shared policy contract in
+`src/scene/level/sourceCollision.ts` when they need stable runtime provenance.
+Active policies carry intent, purpose, optional runtime name, and optional debug
+ID; visual-only policies carry a concise no-collision rationale. Emitted records
+should pass that source metadata through to runtime registration directly rather
+than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,7 +298,10 @@ import {
   createUpperLandingFloorCutouts,
   createUpperLandingStairRunApproachFootprint,
 } from './scene/structures/upperLandingFloorCutouts';
-import { createUpperStairwellLanding } from './scene/structures/upperStairwellLanding';
+import {
+  createUpperStairwellLanding,
+  type UpperStairwellLandingCollider,
+} from './scene/structures/upperStairwellLanding';
 import { createWallSegmentMeshes } from './scene/structures/wallSegmentsMesh';
 import {
   createWoveLoom,
@@ -2095,7 +2098,7 @@ function initializeImmersiveScene(
     namedColliderDebugNames.set(collider.bounds, collider.name);
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
-      sourceType: 'safetyCollider',
+      sourceType: collider.sourceType,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
@@ -2133,19 +2136,15 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const registerUpperFloorGeneratedCollider = (collider: {
-    name: string;
-    bounds: RectCollider;
-    sourceId: LevelSourceId;
-    role: string;
-    debugId?: string;
-  }) => {
+  const registerUpperFloorGeneratedCollider = (
+    collider: UpperStairwellLandingCollider
+  ) => {
     upperFloorColliders.push(collider.bounds);
     namedColliderDebugNames.set(collider.bounds, collider.name);
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
-      sourceType: 'generatedCollider',
-      purpose: `upper stairwell landing ${collider.role} guard`,
+      sourceType: collider.sourceType,
+      purpose: collider.purpose,
       debugId: collider.debugId,
     });
   };

--- a/src/scene/level/sourceCollision.ts
+++ b/src/scene/level/sourceCollision.ts
@@ -1,0 +1,43 @@
+import type { RectCollider } from '../../systems/collision';
+
+export type CollisionIntent =
+  | 'physical-boundary'
+  | 'safety-guard'
+  | 'interaction-footprint'
+  | 'secondary-backstop';
+
+export interface ActiveSourceCollisionPolicy {
+  kind: 'active';
+  intent: CollisionIntent;
+  purpose: string;
+  name?: string;
+  debugId?: string;
+}
+
+export interface NoSourceCollisionPolicy {
+  kind: 'none';
+  rationale: string;
+}
+
+export type SourceCollisionPolicy =
+  | ActiveSourceCollisionPolicy
+  | NoSourceCollisionPolicy;
+
+export interface SourceBackedCollider<
+  Role extends string,
+  SourceId extends string,
+  SourceType extends string,
+> {
+  role: Role;
+  sourceId: SourceId;
+  sourceType: SourceType;
+  intent: CollisionIntent;
+  purpose: string;
+  bounds: RectCollider;
+  name: string;
+  debugId?: string;
+}
+
+export const isActiveSourceCollisionPolicy = (
+  policy: SourceCollisionPolicy
+): policy is ActiveSourceCollisionPolicy => policy.kind === 'active';

--- a/src/scene/level/sourceCollision.ts
+++ b/src/scene/level/sourceCollision.ts
@@ -1,4 +1,5 @@
 import type { RectCollider } from '../../systems/collision';
+import type { DebugColliderId } from '../debug/colliderDebugIds';
 
 export type CollisionIntent =
   | 'physical-boundary'
@@ -10,8 +11,8 @@ export interface ActiveSourceCollisionPolicy {
   kind: 'active';
   intent: CollisionIntent;
   purpose: string;
-  name?: string;
-  debugId?: string;
+  name: string;
+  debugId?: DebugColliderId;
 }
 
 export interface NoSourceCollisionPolicy {
@@ -35,7 +36,7 @@ export interface SourceBackedCollider<
   purpose: string;
   bounds: RectCollider;
   name: string;
-  debugId?: string;
+  debugId?: DebugColliderId;
 }
 
 export const isActiveSourceCollisionPolicy = (

--- a/src/scene/level/sourceCollision.ts
+++ b/src/scene/level/sourceCollision.ts
@@ -11,7 +11,7 @@ export interface ActiveSourceCollisionPolicy {
   collision: 'active';
   intent: CollisionIntent;
   purpose: string;
-  runtimeName?: string;
+  runtimeName: string;
   debugId?: DebugColliderId;
 }
 

--- a/src/scene/level/sourceCollision.ts
+++ b/src/scene/level/sourceCollision.ts
@@ -8,15 +8,15 @@ export type CollisionIntent =
   | 'secondary-backstop';
 
 export interface ActiveSourceCollisionPolicy {
-  kind: 'active';
+  collision: 'active';
   intent: CollisionIntent;
   purpose: string;
-  name: string;
+  runtimeName?: string;
   debugId?: DebugColliderId;
 }
 
 export interface NoSourceCollisionPolicy {
-  kind: 'none';
+  collision: 'none';
   rationale: string;
 }
 
@@ -41,4 +41,4 @@ export interface SourceBackedCollider<
 
 export const isActiveSourceCollisionPolicy = (
   policy: SourceCollisionPolicy
-): policy is ActiveSourceCollisionPolicy => policy.kind === 'active';
+): policy is ActiveSourceCollisionPolicy => policy.collision === 'active';

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -11,17 +11,20 @@ import {
   type DebugColliderId,
 } from '../debug/colliderDebugIds';
 
+import type { SourceBackedCollider } from './sourceCollision';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type SafetyColliderCategory = 'stair' | 'landing' | 'void';
+export type LevelSafetyColliderRole = SafetyColliderCategory;
 
-export interface LevelSafetyCollider {
-  sourceId: LevelSourceId;
-  name: string;
+export interface LevelSafetyCollider
+  extends SourceBackedCollider<
+    LevelSafetyColliderRole,
+    LevelSourceId,
+    'safetyCollider'
+  > {
   floor: 'ground' | 'upper';
   category: SafetyColliderCategory;
-  bounds: RectCollider;
-  purpose: string;
   debugId: DebugColliderId;
 }
 
@@ -54,19 +57,23 @@ const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
   GroundStairLowerCornerGuard: {
     sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
     category: 'stair',
+    intent: 'safety-guard',
     purpose: 'block raw lower-step occupancy',
     debugId: debugId('4002'),
   },
 } as const satisfies Record<
   string,
-  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose' | 'debugId'>
+  Pick<
+    LevelSafetyCollider,
+    'sourceId' | 'category' | 'purpose' | 'debugId' | 'intent'
+  >
 >;
 
 const getGroundStairSafetyColliderMetadata = (
   name: string
 ): Pick<
   LevelSafetyCollider,
-  'sourceId' | 'category' | 'purpose' | 'debugId'
+  'sourceId' | 'category' | 'purpose' | 'debugId' | 'intent'
 > => {
   const metadata =
     GROUND_STAIR_SAFETY_COLLIDER_METADATA[
@@ -91,6 +98,8 @@ export const createGroundStairSafetyColliders = (
     ({ name, bounds }) => ({
       name,
       floor: 'ground',
+      role: 'stair',
+      sourceType: 'safetyCollider',
       bounds,
       ...getGroundStairSafetyColliderMetadata(name),
     })
@@ -176,8 +185,11 @@ export const createUpperStairSafetyColliders = ({
       name: 'UpperStairEastUpperVoidGuard',
       debugId: debugId('4007'),
       sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
+      sourceType: 'safetyCollider',
       floor: 'upper',
+      role: 'void',
       category: 'void',
+      intent: 'safety-guard',
       purpose: 'guard upper stairwell void edge',
       bounds: {
         minX: stairNavigationZones.explicitDescentCorridor.maxX,
@@ -191,8 +203,11 @@ export const createUpperStairSafetyColliders = ({
       sourceId: sourceId(
         `upper.stairwell.topGap.${name.endsWith('West') ? 'west' : 'east'}.safetyCollider`
       ),
+      sourceType: 'safetyCollider' as const,
       floor: 'upper' as const,
+      role: 'void' as const,
       category: 'void' as const,
+      intent: 'safety-guard' as const,
       purpose: 'guard upper stairwell void edge',
       debugId: debugId(name.endsWith('West') ? '4003' : '4004'),
       bounds,
@@ -201,8 +216,11 @@ export const createUpperStairSafetyColliders = ({
       name: 'UpperStairWestBannisterGuard',
       debugId: debugId('4009'),
       sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),
+      sourceType: 'safetyCollider',
       floor: 'upper',
+      role: 'landing',
       category: 'landing',
+      intent: 'safety-guard',
       purpose: 'preserve descent corridor edge',
       bounds: {
         minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
@@ -222,8 +240,11 @@ export const createUpperStairSafetyColliders = ({
       name: 'UpperStairNorthBannisterGuard',
       debugId: debugId('400A'),
       sourceId: sourceId('upper.stairwell.northBannister.safetyCollider'),
+      sourceType: 'safetyCollider',
       floor: 'upper',
+      role: 'landing',
       category: 'landing',
+      intent: 'safety-guard',
       purpose: 'preserve descent corridor edge',
       bounds: {
         minX: upperStairNorthBannisterMinX,

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -3,6 +3,7 @@ import {
   type DebugColliderId,
 } from '../debug/colliderDebugIds';
 
+import type { SourceCollisionPolicy } from './sourceCollision';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type UpperStairwellLandingSegmentRole =
@@ -15,10 +16,8 @@ export type UpperStairwellLandingSegmentRole =
 export interface UpperStairwellLandingSegmentPolicy {
   role: UpperStairwellLandingSegmentRole;
   render: boolean;
-  collision: boolean;
   sourceId: LevelSourceId;
-  colliderName?: string;
-  debugId?: DebugColliderId;
+  collision: SourceCollisionPolicy & { debugId?: DebugColliderId };
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
@@ -29,21 +28,31 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
   {
     role: 'side-east',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.sideEast'),
+    collision: {
+      kind: 'none',
+      rationale: 'visual rail outside the active east-shoulder collision strip',
+    },
   },
   {
     role: 'far',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.far'),
+    collision: {
+      kind: 'none',
+      rationale: 'visual rail leaves the descent approach open',
+    },
   },
   {
     role: 'shoulder-east',
     render: true,
-    collision: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
-    colliderName: 'UpperStairwellLandingGuard-3',
-    debugId: debugId('400D'),
+    collision: {
+      kind: 'active',
+      intent: 'safety-guard',
+      purpose: 'upper stairwell landing shoulder-east guard',
+      name: 'UpperStairwellLandingGuard-3',
+      debugId: debugId('400D'),
+    },
   },
 ] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -17,7 +17,7 @@ export interface UpperStairwellLandingSegmentPolicy {
   role: UpperStairwellLandingSegmentRole;
   render: boolean;
   sourceId: LevelSourceId;
-  collision: SourceCollisionPolicy & { debugId?: DebugColliderId };
+  collision: SourceCollisionPolicy;
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -30,7 +30,7 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
     render: true,
     sourceId: sourceId('upper.stairwell.landingGuard.sideEast'),
     collision: {
-      kind: 'none',
+      collision: 'none',
       rationale: 'visual rail outside the active east-shoulder collision strip',
     },
   },
@@ -39,7 +39,7 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
     render: true,
     sourceId: sourceId('upper.stairwell.landingGuard.far'),
     collision: {
-      kind: 'none',
+      collision: 'none',
       rationale: 'visual rail leaves the descent approach open',
     },
   },
@@ -48,10 +48,10 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
     render: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
     collision: {
-      kind: 'active',
+      collision: 'active',
       intent: 'safety-guard',
       purpose: 'upper stairwell landing shoulder-east guard',
-      name: 'UpperStairwellLandingGuard-3',
+      runtimeName: 'UpperStairwellLandingGuard-3',
       debugId: debugId('400D'),
     },
   },

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -25,10 +25,10 @@ const allSegmentPolicies = (): UpperStairwellLandingSegmentPolicy[] =>
     render: true,
     sourceId: assertLevelSourceId(`upper.stairwell.landingGuard.test.${role}`),
     collision: {
-      kind: 'active',
+      collision: 'active',
       intent: 'safety-guard',
       purpose: `upper stairwell landing test ${role} guard`,
-      name: `UpperStairwellLandingTestGuard-${role}`,
+      runtimeName: `UpperStairwellLandingTestGuard-${role}`,
     },
   }));
 

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -23,9 +23,13 @@ const allSegmentPolicies = (): UpperStairwellLandingSegmentPolicy[] =>
   ALL_SEGMENT_ROLES.map((role) => ({
     role,
     render: true,
-    collision: true,
     sourceId: assertLevelSourceId(`upper.stairwell.landingGuard.test.${role}`),
-    colliderName: `UpperStairwellLandingTestGuard-${role}`,
+    collision: {
+      kind: 'active',
+      intent: 'safety-guard',
+      purpose: `upper stairwell landing test ${role} guard`,
+      name: `UpperStairwellLandingTestGuard-${role}`,
+    },
   }));
 
 const overlaps = (
@@ -148,6 +152,9 @@ describe('createUpperStairwellLanding', () => {
       {
         role: 'shoulder-east',
         sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+        sourceType: 'generatedCollider',
+        intent: 'safety-guard',
+        purpose: 'upper stairwell landing shoulder-east guard',
         name: 'UpperStairwellLandingGuard-3',
         debugId: '400D',
         bounds: {

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -2,7 +2,10 @@ import type { MeshStandardMaterialParameters } from 'three';
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
-import type { RectCollider } from '../../systems/collision';
+import {
+  isActiveSourceCollisionPolicy,
+  type SourceBackedCollider,
+} from '../level/sourceCollision';
 import type {
   UpperStairwellLandingSegmentPolicy,
   UpperStairwellLandingSegmentRole,
@@ -32,13 +35,11 @@ export interface UpperStairwellLandingConfig {
   segments: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
-export interface UpperStairwellLandingCollider {
-  role: UpperStairwellLandingSegmentRole;
-  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
-  name: string;
-  debugId?: UpperStairwellLandingSegmentPolicy['debugId'];
-  bounds: RectCollider;
-}
+export type UpperStairwellLandingCollider = SourceBackedCollider<
+  UpperStairwellLandingSegmentRole,
+  UpperStairwellLandingSegmentPolicy['sourceId'],
+  'generatedCollider'
+>;
 
 export interface UpperStairwellLandingBuild {
   group: Group;
@@ -110,8 +111,9 @@ const addGuard = (params: {
     params.group.add(guard);
   }
 
-  if (params.policy.collision) {
-    if (!params.policy.colliderName) {
+  const collision = params.policy.collision;
+  if (isActiveSourceCollisionPolicy(collision)) {
+    if (!collision.name) {
       throw new Error(
         `Upper stairwell landing segment ${params.policy.role} enables collision without a collider name.`
       );
@@ -120,8 +122,11 @@ const addGuard = (params: {
     params.colliders.push({
       role: params.policy.role,
       sourceId: params.policy.sourceId,
-      name: params.policy.colliderName,
-      debugId: params.policy.debugId,
+      sourceType: 'generatedCollider',
+      intent: collision.intent,
+      purpose: collision.purpose,
+      name: collision.name,
+      debugId: collision.debugId,
       bounds: guardBounds,
     });
   }

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -113,12 +113,6 @@ const addGuard = (params: {
 
   const collision = params.policy.collision;
   if (isActiveSourceCollisionPolicy(collision)) {
-    if (!collision.name) {
-      throw new Error(
-        `Upper stairwell landing segment ${params.policy.role} enables collision without a collider name.`
-      );
-    }
-
     params.colliders.push({
       role: params.policy.role,
       sourceId: params.policy.sourceId,

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -113,13 +113,19 @@ const addGuard = (params: {
 
   const collision = params.policy.collision;
   if (isActiveSourceCollisionPolicy(collision)) {
+    if (!collision.runtimeName) {
+      throw new Error(
+        'Active upper stairwell landing collisions require a runtimeName.'
+      );
+    }
+
     params.colliders.push({
       role: params.policy.role,
       sourceId: params.policy.sourceId,
       sourceType: 'generatedCollider',
       intent: collision.intent,
       purpose: collision.purpose,
-      name: collision.name,
+      name: collision.runtimeName,
       debugId: collision.debugId,
       bounds: guardBounds,
     });

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -113,12 +113,6 @@ const addGuard = (params: {
 
   const collision = params.policy.collision;
   if (isActiveSourceCollisionPolicy(collision)) {
-    if (!collision.runtimeName) {
-      throw new Error(
-        'Active upper stairwell landing collisions require a runtimeName.'
-      );
-    }
-
     params.colliders.push({
       role: params.policy.role,
       sourceId: params.policy.sourceId,

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -43,7 +43,7 @@ describe('main module imports', () => {
     expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
     expect(source).toContain("sourceType: 'wall',");
     expect(source).toContain('colliderSourceMetadata.set(collider.bounds, {');
-    expect(source).toContain("sourceType: 'safetyCollider',");
+    expect(source).toContain('sourceType: collider.sourceType,');
     expect(source).toContain('purpose: collider.purpose,');
     expect(source).toContain(
       'sourceId: colliderSourceMetadata.get(bounds)?.sourceId,'


### PR DESCRIPTION
### Motivation
- Introduce a minimal, source-owned collider contract to centralize collision intent and source-backed runtime metadata and remove duplicated metadata shapes.
- Migrate the stair safety and upper-stairwell landing declarations to prove the contract while preserving all runtime geometry, names, source IDs, debug IDs, and registration order.

### Description
- Add `src/scene/level/sourceCollision.ts` with `CollisionIntent`, `SourceCollisionPolicy`, `SourceBackedCollider` and `isActiveSourceCollisionPolicy` as the shared contract.
- Refactor `LevelSafetyCollider` (`src/scene/level/stairSafetyColliders.ts`) to extend `SourceBackedCollider` and emit `role`, `sourceType`, and `intent` alongside existing `sourceId`, `name`, `bounds`, and `debugId` without changing geometry or IDs.
- Replace the boolean `collision` on `UpperStairwellLandingSegmentPolicy` with the `SourceCollisionPolicy` shape and migrate `src/scene/structures/upperStairwellLanding.ts` to emit `SourceBackedCollider` records for active policies while leaving visual-only segments as `kind: 'none'` with a rationale.
- Update runtime registration in `src/main.ts` to consume embedded `sourceType`, `purpose`, and `debugId` from emitted records instead of reconstructing family-specific metadata.
- Update focused unit tests and `docs/design/editing-level-data.md` to reflect the new contract and the expectation that source-owned colliders carry provenance through to runtime.

### Testing
- Ran formatting with `npm run format:write` (succeeded). 
- Ran focused unit tests with `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts` (succeeded). 
- Installed Playwright browsers with `npx playwright install --with-deps chromium-headless-shell` and ran the immersive stairs E2E with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (succeeded after browser install). 
- Ran full repository checks: `npm run lint` (passed, earlier import-order warning fixed), `npm run test:ci` (full suite passed: 159 test files, 1214 tests), `npm run docs:check` (passed), and `npm run smoke` (build/smoke passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a379e927b44832f8ec756f235389082)