### PR TITLE
Add source-backed collider contract and migrate stair/landing colliders

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -62,13 +62,21 @@ splitting and stairwell clipping.
 
 Safety colliders live in `safetyColliders` for authored fixed colliders, and
 stair-derived colliders are defined in `src/scene/level/stairSafetyColliders.ts`.
-Every safety collider needs:
+Every active source-backed safety collider needs:
 
-- `id`
+- a subsystem role or category owned by that subsystem
 - `sourceId`
-- `floorId`
+- `sourceType`
+- collision `intent`
 - `bounds`
+- runtime `name`
 - a clear `purpose`
+- any stable explicit `debugId` required by the declaration
+
+Visual-only source declarations should use a no-collision policy with a concise
+current rationale instead of carrying inactive collider names or debug IDs.
+Future stair or landing collider removals should happen at the active source
+declaration so the runtime collider and debug identity disappear together.
 
 Use safety colliders for invisible constraints such as stairwell void guards or
 approach-lane protection, not as a hidden substitute for visible wall geometry.

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,6 +162,7 @@ import {
   registerSceneObjectColliders,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
+import type { SourceBackedColliderRecord } from './scene/level/sourceBackedColliders';
 import type { LevelSourceId } from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
@@ -2088,17 +2089,24 @@ function initializeImmersiveScene(
     maxZ: stairGuardMaxZ,
   });
 
-  const registerSafetyCollider = (collider: LevelSafetyCollider) => {
-    const targetColliders =
-      collider.floor === 'ground' ? groundColliders : upperFloorColliders;
+  const registerSourceBackedCollider = (
+    collider: SourceBackedColliderRecord,
+    targetColliders: RectCollider[]
+  ) => {
     targetColliders.push(collider.bounds);
     namedColliderDebugNames.set(collider.bounds, collider.name);
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
-      sourceType: 'safetyCollider',
+      sourceType: collider.sourceType,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
+  };
+
+  const registerSafetyCollider = (collider: LevelSafetyCollider) => {
+    const targetColliders =
+      collider.floor === 'ground' ? groundColliders : upperFloorColliders;
+    registerSourceBackedCollider(collider, targetColliders);
   };
 
   createGroundStairSafetyColliders(stairGeometry, stairBehavior, {
@@ -2133,22 +2141,9 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const registerUpperFloorGeneratedCollider = (collider: {
-    name: string;
-    bounds: RectCollider;
-    sourceId: LevelSourceId;
-    role: string;
-    debugId?: string;
-  }) => {
-    upperFloorColliders.push(collider.bounds);
-    namedColliderDebugNames.set(collider.bounds, collider.name);
-    colliderSourceMetadata.set(collider.bounds, {
-      sourceId: collider.sourceId,
-      sourceType: 'generatedCollider',
-      purpose: `upper stairwell landing ${collider.role} guard`,
-      debugId: collider.debugId,
-    });
-  };
+  const registerUpperFloorGeneratedCollider = (
+    collider: SourceBackedColliderRecord<string, 'generatedCollider'>
+  ) => registerSourceBackedCollider(collider, upperFloorColliders);
 
   const upperStairWestEgressLaneX =
     stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;

--- a/src/scene/level/sourceBackedColliders.ts
+++ b/src/scene/level/sourceBackedColliders.ts
@@ -1,0 +1,41 @@
+import type { RectCollider } from '../../systems/collision';
+import type { DebugColliderId } from '../debug/colliderDebugIds';
+
+import type { LevelSourceId } from './sourceIds';
+
+export type CollisionIntent =
+  | 'physical-boundary'
+  | 'safety-guard'
+  | 'interaction-footprint'
+  | 'secondary-backstop';
+
+export interface ActiveSourceCollisionPolicy {
+  collision: 'active';
+  intent: CollisionIntent;
+  purpose: string;
+  runtimeName?: string;
+  debugId?: DebugColliderId;
+}
+
+export interface NoSourceCollisionPolicy {
+  collision: 'none';
+  rationale: string;
+}
+
+export type SourceCollisionPolicy =
+  | ActiveSourceCollisionPolicy
+  | NoSourceCollisionPolicy;
+
+export interface SourceBackedColliderRecord<
+  Role extends string = string,
+  SourceType extends string = string,
+> {
+  role: Role;
+  sourceId: LevelSourceId;
+  sourceType: SourceType;
+  intent: CollisionIntent;
+  purpose: string;
+  bounds: RectCollider;
+  name: string;
+  debugId?: DebugColliderId;
+}

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -11,19 +11,19 @@ import {
   type DebugColliderId,
 } from '../debug/colliderDebugIds';
 
+import type { SourceBackedColliderRecord } from './sourceBackedColliders';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type SafetyColliderCategory = 'stair' | 'landing' | 'void';
 
-export interface LevelSafetyCollider {
-  sourceId: LevelSourceId;
-  name: string;
+export type LevelSafetyCollider = SourceBackedColliderRecord<
+  SafetyColliderCategory,
+  'safetyCollider'
+> & {
   floor: 'ground' | 'upper';
   category: SafetyColliderCategory;
-  bounds: RectCollider;
-  purpose: string;
   debugId: DebugColliderId;
-}
+};
 
 export interface GroundStairSafetyColliderOptions {
   playerRadius: number;
@@ -55,18 +55,22 @@ const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
     sourceId: sourceId('ground.stairwell.lowerCorner.safetyCollider'),
     category: 'stair',
     purpose: 'block raw lower-step occupancy',
+    intent: 'safety-guard',
     debugId: debugId('4002'),
   },
 } as const satisfies Record<
   string,
-  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose' | 'debugId'>
+  Pick<
+    LevelSafetyCollider,
+    'sourceId' | 'category' | 'purpose' | 'intent' | 'debugId'
+  >
 >;
 
 const getGroundStairSafetyColliderMetadata = (
   name: string
 ): Pick<
   LevelSafetyCollider,
-  'sourceId' | 'category' | 'purpose' | 'debugId'
+  'sourceId' | 'category' | 'purpose' | 'intent' | 'debugId'
 > => {
   const metadata =
     GROUND_STAIR_SAFETY_COLLIDER_METADATA[
@@ -90,6 +94,8 @@ export const createGroundStairSafetyColliders = (
   createGroundStairBoundaryColliders(geometry, behavior, options).map(
     ({ name, bounds }) => ({
       name,
+      role: 'stair',
+      sourceType: 'safetyCollider',
       floor: 'ground',
       bounds,
       ...getGroundStairSafetyColliderMetadata(name),
@@ -174,6 +180,9 @@ export const createUpperStairSafetyColliders = ({
   return [
     {
       name: 'UpperStairEastUpperVoidGuard',
+      role: 'void',
+      sourceType: 'safetyCollider',
+      intent: 'safety-guard',
       debugId: debugId('4007'),
       sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
       floor: 'upper',
@@ -188,6 +197,9 @@ export const createUpperStairSafetyColliders = ({
     },
     ...upperStairTopGapBlockers.map(({ name, bounds }) => ({
       name,
+      role: 'void' as const,
+      sourceType: 'safetyCollider' as const,
+      intent: 'safety-guard' as const,
       sourceId: sourceId(
         `upper.stairwell.topGap.${name.endsWith('West') ? 'west' : 'east'}.safetyCollider`
       ),
@@ -199,6 +211,9 @@ export const createUpperStairSafetyColliders = ({
     })),
     {
       name: 'UpperStairWestBannisterGuard',
+      role: 'landing',
+      sourceType: 'safetyCollider',
+      intent: 'safety-guard',
       debugId: debugId('4009'),
       sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),
       floor: 'upper',
@@ -220,6 +235,9 @@ export const createUpperStairSafetyColliders = ({
     },
     {
       name: 'UpperStairNorthBannisterGuard',
+      role: 'landing',
+      sourceType: 'safetyCollider',
+      intent: 'safety-guard',
       debugId: debugId('400A'),
       sourceId: sourceId('upper.stairwell.northBannister.safetyCollider'),
       floor: 'upper',

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -3,6 +3,7 @@ import {
   type DebugColliderId,
 } from '../debug/colliderDebugIds';
 
+import type { SourceCollisionPolicy } from './sourceBackedColliders';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type UpperStairwellLandingSegmentRole =
@@ -15,10 +16,8 @@ export type UpperStairwellLandingSegmentRole =
 export interface UpperStairwellLandingSegmentPolicy {
   role: UpperStairwellLandingSegmentRole;
   render: boolean;
-  collision: boolean;
   sourceId: LevelSourceId;
-  colliderName?: string;
-  debugId?: DebugColliderId;
+  collision: SourceCollisionPolicy;
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
@@ -29,21 +28,33 @@ export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
   {
     role: 'side-east',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.sideEast'),
+    collision: {
+      collision: 'none',
+      rationale:
+        'visual guard only; side edge is already blocked by stair void safety colliders',
+    },
   },
   {
     role: 'far',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.far'),
+    collision: {
+      collision: 'none',
+      rationale:
+        'visual guard only; far edge remains walkable landing approach',
+    },
   },
   {
     role: 'shoulder-east',
     render: true,
-    collision: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
-    colliderName: 'UpperStairwellLandingGuard-3',
-    debugId: debugId('400D'),
+    collision: {
+      collision: 'active',
+      intent: 'safety-guard',
+      purpose: 'upper stairwell landing shoulder-east guard',
+      runtimeName: 'UpperStairwellLandingGuard-3',
+      debugId: debugId('400D'),
+    },
   },
 ] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -23,9 +23,13 @@ const allSegmentPolicies = (): UpperStairwellLandingSegmentPolicy[] =>
   ALL_SEGMENT_ROLES.map((role) => ({
     role,
     render: true,
-    collision: true,
     sourceId: assertLevelSourceId(`upper.stairwell.landingGuard.test.${role}`),
-    colliderName: `UpperStairwellLandingTestGuard-${role}`,
+    collision: {
+      collision: 'active',
+      intent: 'safety-guard',
+      purpose: `test ${role} guard`,
+      runtimeName: `UpperStairwellLandingTestGuard-${role}`,
+    },
   }));
 
 const overlaps = (
@@ -148,6 +152,9 @@ describe('createUpperStairwellLanding', () => {
       {
         role: 'shoulder-east',
         sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+        sourceType: 'generatedCollider',
+        intent: 'safety-guard',
+        purpose: 'upper stairwell landing shoulder-east guard',
         name: 'UpperStairwellLandingGuard-3',
         debugId: '400D',
         bounds: {

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -2,7 +2,7 @@ import type { MeshStandardMaterialParameters } from 'three';
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
-import type { RectCollider } from '../../systems/collision';
+import type { SourceBackedColliderRecord } from '../level/sourceBackedColliders';
 import type {
   UpperStairwellLandingSegmentPolicy,
   UpperStairwellLandingSegmentRole,
@@ -32,13 +32,10 @@ export interface UpperStairwellLandingConfig {
   segments: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
-export interface UpperStairwellLandingCollider {
-  role: UpperStairwellLandingSegmentRole;
-  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
-  name: string;
-  debugId?: UpperStairwellLandingSegmentPolicy['debugId'];
-  bounds: RectCollider;
-}
+export type UpperStairwellLandingCollider = SourceBackedColliderRecord<
+  UpperStairwellLandingSegmentRole,
+  'generatedCollider'
+>;
 
 export interface UpperStairwellLandingBuild {
   group: Group;
@@ -110,18 +107,22 @@ const addGuard = (params: {
     params.group.add(guard);
   }
 
-  if (params.policy.collision) {
-    if (!params.policy.colliderName) {
+  if (params.policy.collision.collision === 'active') {
+    const runtimeName = params.policy.collision.runtimeName;
+    if (!runtimeName) {
       throw new Error(
-        `Upper stairwell landing segment ${params.policy.role} enables collision without a collider name.`
+        `Upper stairwell landing segment ${params.policy.role} enables collision without a runtime name.`
       );
     }
 
     params.colliders.push({
       role: params.policy.role,
       sourceId: params.policy.sourceId,
-      name: params.policy.colliderName,
-      debugId: params.policy.debugId,
+      sourceType: 'generatedCollider',
+      intent: params.policy.collision.intent,
+      purpose: params.policy.collision.purpose,
+      name: runtimeName,
+      debugId: params.policy.collision.debugId,
       bounds: guardBounds,
     });
   }

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -43,7 +43,7 @@ describe('main module imports', () => {
     expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
     expect(source).toContain("sourceType: 'wall',");
     expect(source).toContain('colliderSourceMetadata.set(collider.bounds, {');
-    expect(source).toContain("sourceType: 'safetyCollider',");
+    expect(source).toContain('sourceType: collider.sourceType,');
     expect(source).toContain('purpose: collider.purpose,');
     expect(source).toContain(
       'sourceId: colliderSourceMetadata.get(bounds)?.sourceId,'


### PR DESCRIPTION
### Motivation
- Introduce a minimal, shared source-backed collider contract to unify collision intent and emitted runtime metadata for source-owned colliders.
- Replace duplicated stair/landing metadata reconstruction so runtime registration consumes canonical emitted records while preserving names, bounds, and explicit debug IDs (`4002`,`4003`,`4004`,`4005`,`4007`,`4009`,`400A`,`400D`).

### Description
- Add `src/scene/level/sourceBackedColliders.ts` with a collision intent taxonomy, `SourceCollisionPolicy` (active/no-collision), and `SourceBackedColliderRecord` as the canonical emitted record.
- Refactor `LevelSafetyCollider` in `src/scene/level/stairSafetyColliders.ts` to be a `SourceBackedColliderRecord` and update stair-generated records to include `role`, `sourceType`, `intent`, `purpose`, and preserve `debugId` and `name` unchanged.
- Replace boolean `collision` in `src/scene/level/upperStairwellLandingSegments.ts` with `SourceCollisionPolicy` and give visual-only segments a `rationale`; update `src/scene/structures/upperStairwellLanding.ts` to emit active source-backed collider records from the active policy branch.
- Simplify runtime registration in `src/main.ts` by adding `registerSourceBackedCollider` and consuming emitted `sourceType`, `purpose`, and `debugId` directly instead of rebuilding them.
- Update focused tests and `docs/design/editing-level-data.md` to document the new active/no-collision pattern and the expectations for source-backed safety colliders.

### Testing
- Ran formatting with `npm run format:write` which completed successfully.
- Ran lint with `npm run lint` which completed successfully (initial warning was resolved during edits).
- Ran focused unit tests with `npm run test:ci -- src/tests/mainImports.test.ts src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts` and all focused tests passed.
- Ran full unit suite with `npm run test:ci` and all Vitest tests passed (159 files, 1214 tests in this environment).
- Ran docs checks with `npm run docs:check` which passed; link checker reported expected external fetch warnings.
- Ran smoke with `npm run smoke` which built and validated `dist` successfully.
- Playwright E2E (`npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`) could not complete in-container due to missing host browser dependencies after browser download; Playwright requested `npx playwright install-deps` (blocked by container host environment).
- Secret scan `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a379e986428832fb18cc1d618365794)