### PR TITLE
Introduce source-backed collider contract and migrate stair/landing colliders

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -62,16 +62,23 @@ splitting and stairwell clipping.
 
 Safety colliders live in `safetyColliders` for authored fixed colliders, and
 stair-derived colliders are defined in `src/scene/level/stairSafetyColliders.ts`.
-Every safety collider needs:
+Every active source-owned safety collider needs a single emitted record with:
 
-- `id`
-- `sourceId`
-- `floorId`
+- a subsystem-specific role or category
+- `sourceId` and source type
+- collision intent, such as `safety-guard` or `physical-boundary`
 - `bounds`
+- the stable runtime name used by debug tooling
 - a clear `purpose`
+- an explicit debug ID when the collider has a stable short label
 
 Use safety colliders for invisible constraints such as stairwell void guards or
 approach-lane protection, not as a hidden substitute for visible wall geometry.
+For source-owned visible segments that intentionally do not block movement, use
+a no-collision policy with a concise rationale instead of a boolean flag. Stair
+and upper-stairwell landing declarations are the first migrated examples: active
+policies own their runtime names, purposes, intents, and debug IDs; visual-only
+landing rails emit no collider.
 
 ## Add visible doors, trim, or showpieces
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,7 +162,6 @@ import {
   registerSceneObjectColliders,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
-import type { LevelSourceId } from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -994,8 +993,7 @@ const colliderSourceMetadata = new Map<
     sourceId:
       | WallSegmentInstance['sourceId']
       | LevelSafetyCollider['sourceId']
-      | SceneObjectDefinition['sourceId']
-      | LevelSourceId;
+      | SceneObjectDefinition['sourceId'];
     sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
     purpose?: string;
     debugId?: string;
@@ -2095,7 +2093,7 @@ function initializeImmersiveScene(
     namedColliderDebugNames.set(collider.bounds, collider.name);
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
-      sourceType: 'safetyCollider',
+      sourceType: collider.sourceType,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
@@ -2133,22 +2131,6 @@ function initializeImmersiveScene(
         layout: stairLayout,
       })
     : undefined;
-  const registerUpperFloorGeneratedCollider = (collider: {
-    name: string;
-    bounds: RectCollider;
-    sourceId: LevelSourceId;
-    role: string;
-    debugId?: string;
-  }) => {
-    upperFloorColliders.push(collider.bounds);
-    namedColliderDebugNames.set(collider.bounds, collider.name);
-    colliderSourceMetadata.set(collider.bounds, {
-      sourceId: collider.sourceId,
-      sourceType: 'generatedCollider',
-      purpose: `upper stairwell landing ${collider.role} guard`,
-      debugId: collider.debugId,
-    });
-  };
 
   const upperStairWestEgressLaneX =
     stairCenterX - stairHalfWidth + PLAYER_RADIUS * 0.75;
@@ -2268,9 +2250,16 @@ function initializeImmersiveScene(
       segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
     });
     upperFloorGroup.add(upperStairwellLanding.group);
-    upperStairwellLanding.colliders.forEach(
-      registerUpperFloorGeneratedCollider
-    );
+    upperStairwellLanding.colliders.forEach((collider) => {
+      upperFloorColliders.push(collider.bounds);
+      namedColliderDebugNames.set(collider.bounds, collider.name);
+      colliderSourceMetadata.set(collider.bounds, {
+        sourceId: collider.sourceId,
+        sourceType: collider.sourceType,
+        purpose: collider.purpose,
+        debugId: collider.debugId,
+      });
+    });
   }
 
   const upperWallMaterial = new MeshStandardMaterial({ color: 0x46536a });

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -104,7 +104,10 @@ describe('stair safety collider source definitions', () => {
 
     expect(
       colliders.every(
-        (collider) => collider.sourceId && collider.purpose.trim()
+        (collider) =>
+          collider.sourceId &&
+          collider.intent === 'safety-guard' &&
+          collider.purpose.trim()
       )
     ).toBe(true);
     expect(new Set(sourceIds).size).toBe(sourceIds.length);

--- a/src/scene/level/sourceBackedColliders.ts
+++ b/src/scene/level/sourceBackedColliders.ts
@@ -1,0 +1,45 @@
+import type { RectCollider } from '../../systems/collision';
+import type { DebugColliderId } from '../debug/colliderDebugIds';
+
+export type CollisionIntent =
+  | 'physical-boundary'
+  | 'safety-guard'
+  | 'interaction-footprint'
+  | 'secondary-backstop';
+
+export interface ActiveSourceCollisionPolicy {
+  collision: 'active';
+  intent: CollisionIntent;
+  purpose: string;
+  runtimeName?: string;
+  debugId?: DebugColliderId;
+}
+
+export interface NoSourceCollisionPolicy {
+  collision: 'none';
+  rationale: string;
+}
+
+export type SourceCollisionPolicy =
+  | ActiveSourceCollisionPolicy
+  | NoSourceCollisionPolicy;
+
+export type SourceBackedColliderRecord<
+  Role extends string,
+  SourceId extends string,
+  SourceType extends string,
+  ExtraFields extends object = object,
+> = ExtraFields & {
+  role: Role;
+  sourceId: SourceId;
+  sourceType: SourceType;
+  intent: CollisionIntent;
+  purpose: string;
+  bounds: RectCollider;
+  name: string;
+  debugId?: DebugColliderId;
+};
+
+export const isActiveSourceCollisionPolicy = (
+  policy: SourceCollisionPolicy
+): policy is ActiveSourceCollisionPolicy => policy.collision === 'active';

--- a/src/scene/level/stairSafetyColliders.ts
+++ b/src/scene/level/stairSafetyColliders.ts
@@ -11,19 +11,21 @@ import {
   type DebugColliderId,
 } from '../debug/colliderDebugIds';
 
+import type { SourceBackedColliderRecord } from './sourceBackedColliders';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type SafetyColliderCategory = 'stair' | 'landing' | 'void';
 
-export interface LevelSafetyCollider {
-  sourceId: LevelSourceId;
-  name: string;
-  floor: 'ground' | 'upper';
-  category: SafetyColliderCategory;
-  bounds: RectCollider;
-  purpose: string;
-  debugId: DebugColliderId;
-}
+export type LevelSafetyCollider = SourceBackedColliderRecord<
+  SafetyColliderCategory,
+  LevelSourceId,
+  'safetyCollider',
+  {
+    floor: 'ground' | 'upper';
+    category: SafetyColliderCategory;
+    debugId: DebugColliderId;
+  }
+>;
 
 export interface GroundStairSafetyColliderOptions {
   playerRadius: number;
@@ -56,17 +58,21 @@ const GROUND_STAIR_SAFETY_COLLIDER_METADATA = {
     category: 'stair',
     purpose: 'block raw lower-step occupancy',
     debugId: debugId('4002'),
+    intent: 'safety-guard',
   },
 } as const satisfies Record<
   string,
-  Pick<LevelSafetyCollider, 'sourceId' | 'category' | 'purpose' | 'debugId'>
+  Pick<
+    LevelSafetyCollider,
+    'sourceId' | 'category' | 'purpose' | 'debugId' | 'intent'
+  >
 >;
 
 const getGroundStairSafetyColliderMetadata = (
   name: string
 ): Pick<
   LevelSafetyCollider,
-  'sourceId' | 'category' | 'purpose' | 'debugId'
+  'sourceId' | 'category' | 'purpose' | 'debugId' | 'intent'
 > => {
   const metadata =
     GROUND_STAIR_SAFETY_COLLIDER_METADATA[
@@ -89,6 +95,8 @@ export const createGroundStairSafetyColliders = (
 ): LevelSafetyCollider[] =>
   createGroundStairBoundaryColliders(geometry, behavior, options).map(
     ({ name, bounds }) => ({
+      role: 'stair',
+      sourceType: 'safetyCollider',
       name,
       floor: 'ground',
       bounds,
@@ -173,12 +181,15 @@ export const createUpperStairSafetyColliders = ({
     upperStairwellOpening.maxX - upperStairBannisterThickness;
   return [
     {
+      role: 'void',
+      sourceType: 'safetyCollider',
       name: 'UpperStairEastUpperVoidGuard',
       debugId: debugId('4007'),
       sourceId: sourceId('upper.stairwell.eastUpperVoid.safetyCollider'),
       floor: 'upper',
       category: 'void',
       purpose: 'guard upper stairwell void edge',
+      intent: 'safety-guard',
       bounds: {
         minX: stairNavigationZones.explicitDescentCorridor.maxX,
         maxX: stairCenterX + stairHalfWidth + stairwellMarginX,
@@ -187,6 +198,8 @@ export const createUpperStairSafetyColliders = ({
       },
     },
     ...upperStairTopGapBlockers.map(({ name, bounds }) => ({
+      role: 'void',
+      sourceType: 'safetyCollider',
       name,
       sourceId: sourceId(
         `upper.stairwell.topGap.${name.endsWith('West') ? 'west' : 'east'}.safetyCollider`
@@ -195,15 +208,19 @@ export const createUpperStairSafetyColliders = ({
       category: 'void' as const,
       purpose: 'guard upper stairwell void edge',
       debugId: debugId(name.endsWith('West') ? '4003' : '4004'),
+      intent: 'safety-guard',
       bounds,
     })),
     {
+      role: 'landing',
+      sourceType: 'safetyCollider',
       name: 'UpperStairWestBannisterGuard',
       debugId: debugId('4009'),
       sourceId: sourceId('upper.stairwell.westBannister.safetyCollider'),
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      intent: 'safety-guard',
       bounds: {
         minX: upperStairWestBannisterMinX + upperStairWestBannisterShiftX,
         maxX: upperStairWestBannisterMaxX + upperStairWestBannisterShiftX,
@@ -219,12 +236,15 @@ export const createUpperStairSafetyColliders = ({
       },
     },
     {
+      role: 'landing',
+      sourceType: 'safetyCollider',
       name: 'UpperStairNorthBannisterGuard',
       debugId: debugId('400A'),
       sourceId: sourceId('upper.stairwell.northBannister.safetyCollider'),
       floor: 'upper',
       category: 'landing',
       purpose: 'preserve descent corridor edge',
+      intent: 'safety-guard',
       bounds: {
         minX: upperStairNorthBannisterMinX,
         maxX: upperStairNorthBannisterMaxX,

--- a/src/scene/level/upperStairwellLandingSegments.ts
+++ b/src/scene/level/upperStairwellLandingSegments.ts
@@ -1,8 +1,6 @@
-import {
-  assertDebugColliderId,
-  type DebugColliderId,
-} from '../debug/colliderDebugIds';
+import { assertDebugColliderId } from '../debug/colliderDebugIds';
 
+import type { SourceCollisionPolicy } from './sourceBackedColliders';
 import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
 
 export type UpperStairwellLandingSegmentRole =
@@ -15,35 +13,41 @@ export type UpperStairwellLandingSegmentRole =
 export interface UpperStairwellLandingSegmentPolicy {
   role: UpperStairwellLandingSegmentRole;
   render: boolean;
-  collision: boolean;
   sourceId: LevelSourceId;
-  colliderName?: string;
-  debugId?: DebugColliderId;
+  collision: SourceCollisionPolicy;
 }
 
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
-const debugId = (value: string): DebugColliderId =>
-  assertDebugColliderId(value);
 
 export const UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES = [
   {
     role: 'side-east',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.sideEast'),
+    collision: {
+      collision: 'none',
+      rationale: 'visual rail only; stair safety colliders own this edge',
+    },
   },
   {
     role: 'far',
     render: true,
-    collision: false,
     sourceId: sourceId('upper.stairwell.landingGuard.far'),
+    collision: {
+      collision: 'none',
+      rationale: 'visual rail only; upper void guards own player blocking',
+    },
   },
   {
     role: 'shoulder-east',
     render: true,
-    collision: true,
     sourceId: sourceId('upper.stairwell.landingGuard.shoulderEast'),
-    colliderName: 'UpperStairwellLandingGuard-3',
-    debugId: debugId('400D'),
+    collision: {
+      collision: 'active',
+      intent: 'safety-guard',
+      purpose: 'upper stairwell landing shoulder-east guard',
+      runtimeName: 'UpperStairwellLandingGuard-3',
+      debugId: assertDebugColliderId('400D'),
+    },
   },
 ] as const satisfies readonly UpperStairwellLandingSegmentPolicy[];

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,7 +1,10 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { isDebugColliderId } from '../../debug/colliderDebugIds';
+import {
+  assertDebugColliderId,
+  isDebugColliderId,
+} from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
 import { assertLevelSourceId } from '../../level/sourceIds';
 import {
@@ -23,9 +26,16 @@ const allSegmentPolicies = (): UpperStairwellLandingSegmentPolicy[] =>
   ALL_SEGMENT_ROLES.map((role) => ({
     role,
     render: true,
-    collision: true,
     sourceId: assertLevelSourceId(`upper.stairwell.landingGuard.test.${role}`),
-    colliderName: `UpperStairwellLandingTestGuard-${role}`,
+    collision: {
+      collision: 'active',
+      intent: 'safety-guard',
+      purpose: `test upper stairwell landing ${role} guard`,
+      runtimeName: `UpperStairwellLandingTestGuard-${role}`,
+      debugId: assertDebugColliderId(
+        `9${ALL_SEGMENT_ROLES.indexOf(role).toString().padStart(3, '0')}`
+      ),
+    },
   }));
 
 const overlaps = (
@@ -148,6 +158,9 @@ describe('createUpperStairwellLanding', () => {
       {
         role: 'shoulder-east',
         sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+        sourceType: 'generatedCollider',
+        intent: 'safety-guard',
+        purpose: 'upper stairwell landing shoulder-east guard',
         name: 'UpperStairwellLandingGuard-3',
         debugId: '400D',
         bounds: {
@@ -158,6 +171,17 @@ describe('createUpperStairwellLanding', () => {
         },
       },
     ]);
+  });
+
+  it('documents visual-only production segment collision rationale', () => {
+    const visualOnlyPolicies = UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES.filter(
+      (policy) => policy.collision.collision === 'none'
+    );
+
+    expect(visualOnlyPolicies).toHaveLength(2);
+    visualOnlyPolicies.forEach((policy) => {
+      expect(policy.collision.rationale.trim()).not.toBe('');
+    });
   });
 
   it('emits source-owned production landing debug IDs unchanged', () => {

--- a/src/scene/structures/upperStairwellLanding.ts
+++ b/src/scene/structures/upperStairwellLanding.ts
@@ -2,7 +2,8 @@ import type { MeshStandardMaterialParameters } from 'three';
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
-import type { RectCollider } from '../../systems/collision';
+import { isActiveSourceCollisionPolicy } from '../level/sourceBackedColliders';
+import type { SourceBackedColliderRecord } from '../level/sourceBackedColliders';
 import type {
   UpperStairwellLandingSegmentPolicy,
   UpperStairwellLandingSegmentRole,
@@ -32,13 +33,11 @@ export interface UpperStairwellLandingConfig {
   segments: readonly UpperStairwellLandingSegmentPolicy[];
 }
 
-export interface UpperStairwellLandingCollider {
-  role: UpperStairwellLandingSegmentRole;
-  sourceId: UpperStairwellLandingSegmentPolicy['sourceId'];
-  name: string;
-  debugId?: UpperStairwellLandingSegmentPolicy['debugId'];
-  bounds: RectCollider;
-}
+export type UpperStairwellLandingCollider = SourceBackedColliderRecord<
+  UpperStairwellLandingSegmentRole,
+  UpperStairwellLandingSegmentPolicy['sourceId'],
+  'generatedCollider'
+>;
 
 export interface UpperStairwellLandingBuild {
   group: Group;
@@ -110,18 +109,22 @@ const addGuard = (params: {
     params.group.add(guard);
   }
 
-  if (params.policy.collision) {
-    if (!params.policy.colliderName) {
+  const collisionPolicy = params.policy.collision;
+  if (isActiveSourceCollisionPolicy(collisionPolicy)) {
+    if (!collisionPolicy.runtimeName) {
       throw new Error(
-        `Upper stairwell landing segment ${params.policy.role} enables collision without a collider name.`
+        `Upper stairwell landing segment ${params.policy.role} enables collision without a runtime name.`
       );
     }
 
     params.colliders.push({
       role: params.policy.role,
       sourceId: params.policy.sourceId,
-      name: params.policy.colliderName,
-      debugId: params.policy.debugId,
+      sourceType: 'generatedCollider',
+      intent: collisionPolicy.intent,
+      purpose: collisionPolicy.purpose,
+      name: collisionPolicy.runtimeName,
+      debugId: collisionPolicy.debugId,
       bounds: guardBounds,
     });
   }

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -43,7 +43,7 @@ describe('main module imports', () => {
     expect(source).toContain('colliderSourceMetadata.set(instance.collider, {');
     expect(source).toContain("sourceType: 'wall',");
     expect(source).toContain('colliderSourceMetadata.set(collider.bounds, {');
-    expect(source).toContain("sourceType: 'safetyCollider',");
+    expect(source).toContain('sourceType: collider.sourceType,');
     expect(source).toContain('purpose: collider.purpose,');
     expect(source).toContain(
       'sourceId: colliderSourceMetadata.get(bounds)?.sourceId,'


### PR DESCRIPTION
### Motivation
- Introduce a minimal, source-owned collider contract so semantic collision intent and provenance are first-class and duplicated metadata/registration paths can be removed. 
- Migrate the existing stair safety and upper-stairwell landing declarations to prove the contract while preserving runtime names, debug IDs, source IDs, bounds, and registration order. 

### Description
- Add `src/scene/level/sourceBackedColliders.ts` defining a small `CollisionIntent` taxonomy, an `ActiveSourceCollisionPolicy` / `NoSourceCollisionPolicy` discriminated union, `SourceCollisionPolicy` type guard, and a generic `SourceBackedColliderRecord` record shape. 
- Refactor `LevelSafetyCollider` in `src/scene/level/stairSafetyColliders.ts` to be a `SourceBackedColliderRecord` and emit `role`, `sourceType`, and `intent` alongside existing `sourceId`, `purpose`, `debugId`, `name`, and `bounds`. 
- Replace boolean `collision` and scattered `colliderName`/`debugId` plumbing in `src/scene/level/upperStairwellLandingSegments.ts` with the new `SourceCollisionPolicy` and migrate the shoulder-east segment to an active policy that preserves `runtimeName` (`UpperStairwellLandingGuard-3`) and debug ID `400D`. 
- Update `createUpperStairwellLanding(...)` in `src/scene/structures/upperStairwellLanding.ts` to emit `SourceBackedColliderRecord` instances for active policies and to skip emitting colliders for visual-only (no-collision) policies with explicit rationales. 
- Simplify runtime registration in `src/main.ts` to consume emitted `sourceType`, `purpose`, and `debugId` directly (removed the family-specific reconstruction path and redundant helper). 
- Update focused tests and `docs/design/editing-level-data.md` to reflect the source-backed contract and to assert intent/rationale preservation. 

### Testing
- Ran formatting: `npm run format:write` (succeeded) and lint: `npm run lint` (succeeded after import-order fixes). 
- Ran focused unit tests: `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts` (both passed). 
- Ran full Vitest suite: `npm run test:ci` (all tests passed: 159 files, 1215 tests). 
- Attempted Playwright E2E: `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (blocked in CI environment because Playwright browsers were not installed: executable missing). 
- Docs and smoke: `npm run docs:check` and `npm run smoke` (docs check and smoke/build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a379e9e4200832fa08e3a79836f037c)