### PR TITLE
Migrate backyard perimeter colliders to source-backed policies

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -392,3 +392,17 @@ labels. Hardcoded bounds that remain in production code should be either explici
 source data, stair-derived safety geometry, or documented object-factory collider
 policies. See `docs/design/editing-level-data.md` for the current human editing
 workflow.
+
+### Backyard perimeter collision policies
+
+The backyard perimeter fence now uses semantic source-owned collision policies in
+`src/scene/level/backyardPerimeterColliders.ts`. The left, right, and back fence
+roles drive both the visible fence runs and their physical-boundary colliders so
+visual geometry and collision coverage cannot drift through separate ledgers. The
+back fence keeps its explicit debug ID `1007` because that boundary is a retained
+manual-debugging anchor.
+
+The hologram barrier is declared in the same module as an active
+`physical-boundary` policy with a source ID, role, intent, and purpose. Other
+backyard objects, including rockets, greenhouse internals, projections, and
+lanterns, remain on their existing collider paths until their own migrations.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1873,6 +1873,15 @@ function initializeImmersiveScene(
     backyardEnvironment.colliders.forEach((collider) =>
       groundColliders.push(collider)
     );
+    backyardEnvironment.sourceBackedColliders.forEach((collider) => {
+      namedColliderDebugNames.set(collider.bounds, collider.name);
+      colliderSourceMetadata.set(collider.bounds, {
+        sourceId: collider.sourceId,
+        sourceType: collider.sourceType,
+        purpose: collider.purpose,
+        debugId: collider.debugId,
+      });
+    });
   }
 
   const groundFloorGroup = new Group();

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -44,6 +44,13 @@ import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import {
+  createBackyardFenceColliders,
+  createBackyardFenceLayout,
+  createBackyardFenceSegments,
+  createBackyardHologramBarrierCollider,
+  type BackyardPerimeterCollider,
+} from '../level/backyardPerimeterColliders';
+import {
   applySeasonalLightingPreset,
   type SeasonalLightingPreset,
   type SeasonalLightingTarget,
@@ -55,6 +62,7 @@ import { createMultiplayerProjection } from '../structures/multiplayerProjection
 export interface BackyardEnvironmentBuild {
   group: Group;
   colliders: RectCollider[];
+  sourceBackedColliders: BackyardPerimeterCollider[];
   update(context: { elapsed: number; delta: number }): void;
   ambientAudioBeds: BackyardAmbientAudioBed[];
   applySeasonalPreset(preset: SeasonalLightingPreset | null): void;
@@ -315,6 +323,7 @@ export function createBackyardEnvironment(
   const group = new Group();
   group.name = 'BackyardEnvironment';
   const colliders: RectCollider[] = [];
+  const sourceBackedColliders: BackyardPerimeterCollider[] = [];
   const updates: Array<(context: { elapsed: number; delta: number }) => void> =
     [];
   const ambientAudioBeds: BackyardAmbientAudioBed[] = [];
@@ -1452,16 +1461,12 @@ export function createBackyardEnvironment(
     });
   }
 
-  const barrierZ = bounds.maxZ - 1.2;
+  const fenceLayout = createBackyardFenceLayout(bounds);
+  const barrierZ = fenceLayout.barrierZ;
 
   const fenceGroup = new Group();
   fenceGroup.name = 'BackyardPerimeterFence';
-  const fenceHeight = 1.5;
-  const fenceInsetX = 0.35;
-  const fenceFrontPadding = 0.9;
-  const fenceBackGap = 0.6;
-  const fenceFrontZ = bounds.minZ + fenceFrontPadding;
-  const fenceBackZ = barrierZ - fenceBackGap;
+  const fenceHeight = fenceLayout.fenceHeight;
 
   const fencePostGeometry = new CylinderGeometry(0.07, 0.09, fenceHeight, 10);
   const fenceRailGeometry = new BoxGeometry(1, 0.08, 0.12);
@@ -1529,45 +1534,21 @@ export function createBackyardEnvironment(
     fenceGroup.add(runGroup);
   };
 
-  const fenceRuns = [
-    {
-      start: new Vector3(bounds.minX + fenceInsetX, 0, fenceFrontZ),
-      end: new Vector3(bounds.minX + fenceInsetX, 0, fenceBackZ),
-    },
-    {
-      start: new Vector3(bounds.maxX - fenceInsetX, 0, fenceFrontZ),
-      end: new Vector3(bounds.maxX - fenceInsetX, 0, fenceBackZ),
-    },
-    {
-      start: new Vector3(bounds.minX + fenceInsetX, 0, fenceBackZ),
-      end: new Vector3(bounds.maxX - fenceInsetX, 0, fenceBackZ),
-    },
-  ];
+  const fenceSegments = createBackyardFenceSegments(bounds, fenceLayout);
 
-  fenceRuns.forEach(({ start, end }, index) => addFenceRun(index, start, end));
+  fenceSegments.forEach(({ start, end }, index) =>
+    addFenceRun(
+      index,
+      new Vector3(start.x, 0, start.z),
+      new Vector3(end.x, 0, end.z)
+    )
+  );
   group.add(fenceGroup);
 
-  const fenceColliders: RectCollider[] = [
-    {
-      minX: bounds.minX + fenceInsetX - 0.12,
-      maxX: bounds.minX + fenceInsetX + 0.18,
-      minZ: fenceFrontZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-    {
-      minX: bounds.maxX - fenceInsetX - 0.18,
-      maxX: bounds.maxX - fenceInsetX + 0.12,
-      minZ: fenceFrontZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-    {
-      minX: bounds.minX + fenceInsetX + 0.18,
-      maxX: bounds.maxX - fenceInsetX - 0.18,
-      minZ: fenceBackZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-  ];
-  fenceColliders.forEach((collider) => colliders.push(collider));
+  createBackyardFenceColliders(fenceSegments).forEach((collider) => {
+    sourceBackedColliders.push(collider);
+    colliders.push(collider.bounds);
+  });
 
   interface LanternAnimationTarget {
     glassMaterial: MeshStandardMaterial;
@@ -2055,12 +2036,14 @@ export function createBackyardEnvironment(
   const baseEmitterOpacity = emitterMaterial.opacity;
   const baseEmitterSize = emitterMaterial.size;
 
-  colliders.push({
-    minX: barrier.position.x - barrierWidth / 2,
-    maxX: barrier.position.x + barrierWidth / 2,
-    minZ: barrier.position.z - barrierThickness / 2,
-    maxZ: barrier.position.z + barrierThickness / 2,
+  const barrierCollider = createBackyardHologramBarrierCollider({
+    centerX: barrier.position.x,
+    barrierZ,
+    barrierWidth,
+    barrierThickness,
   });
+  sourceBackedColliders.push(barrierCollider);
+  colliders.push(barrierCollider.bounds);
 
   updates.push(({ elapsed }) => {
     const flickerScale = getFlickerScale();
@@ -2193,6 +2176,7 @@ export function createBackyardEnvironment(
   return {
     group,
     colliders,
+    sourceBackedColliders,
     update,
     ambientAudioBeds,
     applySeasonalPreset: applyBackyardSeasonalPreset,

--- a/src/scene/level/backyardPerimeterColliders.ts
+++ b/src/scene/level/backyardPerimeterColliders.ts
@@ -1,0 +1,184 @@
+import type { Bounds2D } from '../../assets/floorPlan';
+import type { RectCollider } from '../../systems/collision';
+import {
+  assertDebugColliderId,
+  type DebugColliderId,
+} from '../debug/colliderDebugIds';
+
+import type { SourceBackedCollider } from './sourceCollision';
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type BackyardPerimeterRole =
+  | 'leftFenceBoundary'
+  | 'rightFenceBoundary'
+  | 'backFenceBoundary'
+  | 'hologramBarrier';
+
+export interface BackyardFenceSegmentPolicy {
+  role: Exclude<BackyardPerimeterRole, 'hologramBarrier'>;
+  sourceId: LevelSourceId;
+  purpose: string;
+  debugId?: DebugColliderId;
+}
+
+export interface BackyardFenceLayout {
+  fenceHeight: number;
+  fenceInsetX: number;
+  fenceFrontPadding: number;
+  fenceBackGap: number;
+  fenceFrontZ: number;
+  fenceBackZ: number;
+  barrierZ: number;
+}
+
+export interface BackyardFenceSegment extends BackyardFenceSegmentPolicy {
+  start: { x: number; z: number };
+  end: { x: number; z: number };
+  bounds: RectCollider;
+  name: string;
+}
+
+export type BackyardPerimeterCollider = SourceBackedCollider<
+  BackyardPerimeterRole,
+  LevelSourceId,
+  'generatedCollider'
+>;
+
+export interface BackyardBarrierPolicy {
+  role: 'hologramBarrier';
+  sourceId: LevelSourceId;
+  purpose: string;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+const debugId = (value: string): DebugColliderId =>
+  assertDebugColliderId(value);
+
+export const BACKYARD_FENCE_POLICIES: readonly BackyardFenceSegmentPolicy[] = [
+  {
+    role: 'leftFenceBoundary',
+    sourceId: sourceId('ground.backyard.perimeter.leftFenceBoundary'),
+    purpose: 'Block the west edge of the backyard perimeter fence.',
+  },
+  {
+    role: 'rightFenceBoundary',
+    sourceId: sourceId('ground.backyard.perimeter.rightFenceBoundary'),
+    purpose: 'Block the east edge of the backyard perimeter fence.',
+  },
+  {
+    role: 'backFenceBoundary',
+    sourceId: sourceId('ground.backyard.perimeter.backFenceBoundary'),
+    purpose: 'Keep the visible back fence as an explicit backyard boundary.',
+    debugId: debugId('1007'),
+  },
+] as const;
+
+export const BACKYARD_HOLOGRAM_BARRIER_POLICY: BackyardBarrierPolicy = {
+  role: 'hologramBarrier',
+  sourceId: sourceId('ground.backyard.perimeter.hologramBarrier'),
+  purpose: 'Keep visitors in front of the active hologram gate.',
+};
+
+export const createBackyardFenceLayout = (
+  bounds: Bounds2D
+): BackyardFenceLayout => {
+  const barrierZ = bounds.maxZ - 1.2;
+  const fenceBackGap = 0.6;
+
+  return {
+    fenceHeight: 1.5,
+    fenceInsetX: 0.35,
+    fenceFrontPadding: 0.9,
+    fenceBackGap,
+    fenceFrontZ: bounds.minZ + 0.9,
+    fenceBackZ: barrierZ - fenceBackGap,
+    barrierZ,
+  };
+};
+
+export const createBackyardFenceSegments = (
+  bounds: Bounds2D,
+  layout: BackyardFenceLayout = createBackyardFenceLayout(bounds)
+): readonly BackyardFenceSegment[] => {
+  const leftX = bounds.minX + layout.fenceInsetX;
+  const rightX = bounds.maxX - layout.fenceInsetX;
+
+  return BACKYARD_FENCE_POLICIES.map((policy) => {
+    if (policy.role === 'leftFenceBoundary') {
+      return {
+        ...policy,
+        name: 'backyard-left-fence-boundary',
+        start: { x: leftX, z: layout.fenceFrontZ },
+        end: { x: leftX, z: layout.fenceBackZ },
+        bounds: {
+          minX: leftX - 0.12,
+          maxX: leftX + 0.18,
+          minZ: layout.fenceFrontZ - 0.3,
+          maxZ: layout.fenceBackZ + 0.3,
+        },
+      };
+    }
+
+    if (policy.role === 'rightFenceBoundary') {
+      return {
+        ...policy,
+        name: 'backyard-right-fence-boundary',
+        start: { x: rightX, z: layout.fenceFrontZ },
+        end: { x: rightX, z: layout.fenceBackZ },
+        bounds: {
+          minX: rightX - 0.18,
+          maxX: rightX + 0.12,
+          minZ: layout.fenceFrontZ - 0.3,
+          maxZ: layout.fenceBackZ + 0.3,
+        },
+      };
+    }
+
+    return {
+      ...policy,
+      name: 'backyard-back-fence-boundary',
+      start: { x: leftX, z: layout.fenceBackZ },
+      end: { x: rightX, z: layout.fenceBackZ },
+      bounds: {
+        minX: leftX + 0.18,
+        maxX: rightX - 0.18,
+        minZ: layout.fenceBackZ - 0.3,
+        maxZ: layout.fenceBackZ + 0.3,
+      },
+    };
+  });
+};
+
+export const createBackyardFenceColliders = (
+  segments: readonly BackyardFenceSegment[]
+): readonly BackyardPerimeterCollider[] =>
+  segments.map((segment) => ({
+    role: segment.role,
+    sourceId: segment.sourceId,
+    sourceType: 'generatedCollider',
+    intent: 'physical-boundary',
+    purpose: segment.purpose,
+    bounds: segment.bounds,
+    name: segment.name,
+    debugId: segment.debugId,
+  }));
+
+export const createBackyardHologramBarrierCollider = (params: {
+  centerX: number;
+  barrierZ: number;
+  barrierWidth: number;
+  barrierThickness: number;
+}): BackyardPerimeterCollider => ({
+  role: BACKYARD_HOLOGRAM_BARRIER_POLICY.role,
+  sourceId: BACKYARD_HOLOGRAM_BARRIER_POLICY.sourceId,
+  sourceType: 'generatedCollider',
+  intent: 'physical-boundary',
+  purpose: BACKYARD_HOLOGRAM_BARRIER_POLICY.purpose,
+  name: 'backyard-hologram-barrier-boundary',
+  bounds: {
+    minX: params.centerX - params.barrierWidth / 2,
+    maxX: params.centerX + params.barrierWidth / 2,
+    minZ: params.barrierZ - params.barrierThickness / 2,
+    maxZ: params.barrierZ + params.barrierThickness / 2,
+  },
+});

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -29,6 +29,7 @@ import {
   type SpyInstance,
 } from 'vitest';
 
+import { FLOOR_PLAN } from '../assets/floorPlan';
 import { createBackyardEnvironment } from '../scene/environments/backyard';
 import type { SeasonalLightingPreset } from '../scene/lighting/seasonalPresets';
 
@@ -37,6 +38,14 @@ const BACKYARD_BOUNDS = {
   maxX: 10,
   minZ: 8,
   maxZ: 16,
+};
+
+const getProductionBackyardBounds = () => {
+  const backyard = FLOOR_PLAN.rooms.find((room) => room.id === 'backyard');
+  if (!backyard) {
+    throw new Error('Production floor plan is missing the backyard room.');
+  }
+  return backyard.bounds;
 };
 
 function clonePositions(attribute: BufferAttribute): Float32Array {
@@ -1342,20 +1351,46 @@ describe('createBackyardEnvironment', () => {
       true
     );
 
-    const productionBackyardBounds = {
-      minX: -32,
-      maxX: 32,
-      minZ: 16,
-      maxZ: 32,
-    };
+    const backFencePolicy = environment.sourceBackedColliders.find(
+      (collider) => collider.role === 'backFenceBoundary'
+    );
+    expect(backFencePolicy).toMatchObject({
+      sourceId: 'ground.backyard.perimeter.backFenceBoundary',
+      sourceType: 'generatedCollider',
+      intent: 'physical-boundary',
+      purpose: 'Keep the visible back fence as an explicit backyard boundary.',
+      debugId: '1007',
+    });
+    expect(backFencePolicy?.bounds.minZ).toBeLessThanOrEqual(backMostPostZ);
+    expect(backFencePolicy?.bounds.maxZ).toBeGreaterThanOrEqual(backMostPostZ);
+
+    expect(
+      environment.sourceBackedColliders.filter(
+        (collider) => collider.intent === 'physical-boundary'
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'leftFenceBoundary' }),
+        expect.objectContaining({ role: 'rightFenceBoundary' }),
+        expect.objectContaining({ role: 'backFenceBoundary' }),
+        expect.objectContaining({ role: 'hologramBarrier' }),
+      ])
+    );
+
+    const productionBackyardBounds = getProductionBackyardBounds();
     const productionEnvironment = createBackyardEnvironment(
       productionBackyardBounds
     );
+    const productionCenterX =
+      (productionBackyardBounds.minX + productionBackyardBounds.maxX) / 2;
+    const productionBackFenceSampleZ = productionBackyardBounds.maxZ - 1.8;
     const productionBackFenceSamples = [
-      { x: 0, z: 30.2 },
-      { x: 5, z: 30.2 },
-      { x: -5, z: 30.2 },
+      { x: productionCenterX, z: productionBackFenceSampleZ },
+      { x: productionCenterX + 5, z: productionBackFenceSampleZ },
+      { x: productionCenterX - 5, z: productionBackFenceSampleZ },
     ];
+    expect(productionBackFenceSamples[1]?.x).toBe(5);
+    expect(productionBackFenceSamples[1]?.z).toBeCloseTo(30.2, 5);
 
     expect(
       productionBackFenceSamples.every(


### PR DESCRIPTION
### Motivation
- Move the backyard perimeter fence and hologram barrier collision to the new source-backed semantic policy model so visuals and collision are driven from the same canonical declarations. 
- Preserve the existing physical boundary behaviour for the back fence and retain the stable debug ID `1007` as an explicit, manual debugging anchor. 

### Description
- Add `src/scene/level/backyardPerimeterColliders.ts` which declares semantic policies for `leftFenceBoundary`, `rightFenceBoundary`, `backFenceBoundary`, and `hologramBarrier`, includes `sourceId`, `intent: 'physical-boundary'`, purpose, bounds recipes, and preserves debug ID `1007` for the back fence. 
- Refactor `createBackyardEnvironment(...)` in `src/scene/environments/backyard.ts` so a single semantic segment list drives both visible fence runs and the collision records and emit `sourceBackedColliders` alongside `colliders`. 
- Wire source-backed collider metadata into central debug/registration in `src/main.ts` so the debug visualizer and runtime metadata expose `sourceId`, `sourceType`, `purpose`, and `debugId`. 
- Update `src/tests/backyardEnvironment.test.ts` to derive production backyard bounds from `FLOOR_PLAN`, assert physical-boundary policies (including the retained back-fence debug ID), and include production-coordinate regression samples (center and non-center `x=5, z≈30.2`) with tolerant numeric assertions. 
- Document the change in `docs/design/declarative-level-source-of-truth.md` and leave unrelated backyard colliders (rockets, greenhouse internals, projections, lanterns) on their existing paths. 

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`; lint completed (only non-blocking import-order warnings surfaced and were addressed). 
- Exercised the targeted unit tests with `npm run test:ci -- src/tests/backyardEnvironment.test.ts` and then ran the full suite with `npm run test:ci`; the backyard test file passed (28 tests) and the full test run passed (1214 tests total). 
- Verified docs and links with `npm run docs:check` (passed; external fetch warnings reported by the link checker but not blocking). 
- Performed the smoke build with `npm run smoke` (build and dist checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382573d00c832fb2e61001c7ac1bdf)