### PR TITLE
🧱 : – source backyard boundaries

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -244,6 +244,16 @@ use `getColliderBySourceId(...)`, `getCollidersBySourceId(...)`,
 artifacts by authoritative source identity without reverse-engineering compact
 labels.
 
+Backyard perimeter collision now follows the same source-backed contract.
+`src/scene/level/backyardPerimeterPolicies.ts` declares the active left,
+right, and back fence boundaries plus the hologram barrier as semantic
+`physical-boundary` policies. `createBackyardEnvironment(...)` derives both
+the visible fence runs and their collider records from those declarations,
+so future fence changes happen at the policy source instead of by editing
+anonymous collider arrays or preserving array offsets. The back fence keeps
+its explicit stable debug ID (`1007`) because that boundary is a manual
+debugging anchor.
+
 The foundation helpers for this migration live in
 `src/scene/level/sourceIds.ts`. New source-backed level data should use the
 `LevelSourceId` branded type, `assertLevelSourceId(...)`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1873,6 +1873,15 @@ function initializeImmersiveScene(
     backyardEnvironment.colliders.forEach((collider) =>
       groundColliders.push(collider)
     );
+    backyardEnvironment.sourceBackedColliders.forEach((collider) => {
+      namedColliderDebugNames.set(collider.bounds, collider.name);
+      colliderSourceMetadata.set(collider.bounds, {
+        sourceId: collider.sourceId,
+        sourceType: collider.sourceType,
+        purpose: collider.purpose,
+        debugId: collider.debugId,
+      });
+    });
   }
 
   const groundFloorGroup = new Group();

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -44,6 +44,15 @@ import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import {
+  createBackyardFenceCollider,
+  createBackyardFenceSegments,
+  createBackyardHologramBarrierCollider,
+  type BackyardPerimeterRole,
+  type BackyardPerimeterSourceType,
+} from '../level/backyardPerimeterPolicies';
+import type { SourceBackedCollider } from '../level/sourceCollision';
+import type { LevelSourceId } from '../level/sourceIds';
+import {
   applySeasonalLightingPreset,
   type SeasonalLightingPreset,
   type SeasonalLightingTarget,
@@ -55,6 +64,11 @@ import { createMultiplayerProjection } from '../structures/multiplayerProjection
 export interface BackyardEnvironmentBuild {
   group: Group;
   colliders: RectCollider[];
+  sourceBackedColliders: SourceBackedCollider<
+    BackyardPerimeterRole,
+    LevelSourceId,
+    BackyardPerimeterSourceType
+  >[];
   update(context: { elapsed: number; delta: number }): void;
   ambientAudioBeds: BackyardAmbientAudioBed[];
   applySeasonalPreset(preset: SeasonalLightingPreset | null): void;
@@ -315,6 +329,11 @@ export function createBackyardEnvironment(
   const group = new Group();
   group.name = 'BackyardEnvironment';
   const colliders: RectCollider[] = [];
+  const sourceBackedColliders: SourceBackedCollider<
+    BackyardPerimeterRole,
+    LevelSourceId,
+    BackyardPerimeterSourceType
+  >[] = [];
   const updates: Array<(context: { elapsed: number; delta: number }) => void> =
     [];
   const ambientAudioBeds: BackyardAmbientAudioBed[] = [];
@@ -1529,45 +1548,26 @@ export function createBackyardEnvironment(
     fenceGroup.add(runGroup);
   };
 
-  const fenceRuns = [
-    {
-      start: new Vector3(bounds.minX + fenceInsetX, 0, fenceFrontZ),
-      end: new Vector3(bounds.minX + fenceInsetX, 0, fenceBackZ),
-    },
-    {
-      start: new Vector3(bounds.maxX - fenceInsetX, 0, fenceFrontZ),
-      end: new Vector3(bounds.maxX - fenceInsetX, 0, fenceBackZ),
-    },
-    {
-      start: new Vector3(bounds.minX + fenceInsetX, 0, fenceBackZ),
-      end: new Vector3(bounds.maxX - fenceInsetX, 0, fenceBackZ),
-    },
-  ];
+  const fenceSegments = createBackyardFenceSegments(bounds, {
+    fenceInsetX,
+    fenceFrontZ,
+    fenceBackZ,
+  });
 
-  fenceRuns.forEach(({ start, end }, index) => addFenceRun(index, start, end));
+  fenceSegments.forEach(({ start, end }, index) =>
+    addFenceRun(
+      index,
+      new Vector3(start.x, 0, start.z),
+      new Vector3(end.x, 0, end.z)
+    )
+  );
   group.add(fenceGroup);
 
-  const fenceColliders: RectCollider[] = [
-    {
-      minX: bounds.minX + fenceInsetX - 0.12,
-      maxX: bounds.minX + fenceInsetX + 0.18,
-      minZ: fenceFrontZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-    {
-      minX: bounds.maxX - fenceInsetX - 0.18,
-      maxX: bounds.maxX - fenceInsetX + 0.12,
-      minZ: fenceFrontZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-    {
-      minX: bounds.minX + fenceInsetX + 0.18,
-      maxX: bounds.maxX - fenceInsetX - 0.18,
-      minZ: fenceBackZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-  ];
-  fenceColliders.forEach((collider) => colliders.push(collider));
+  fenceSegments.forEach((segment) => {
+    const collider = createBackyardFenceCollider(segment);
+    colliders.push(collider.bounds);
+    sourceBackedColliders.push(collider);
+  });
 
   interface LanternAnimationTarget {
     glassMaterial: MeshStandardMaterial;
@@ -2055,12 +2055,17 @@ export function createBackyardEnvironment(
   const baseEmitterOpacity = emitterMaterial.opacity;
   const baseEmitterSize = emitterMaterial.size;
 
-  colliders.push({
+  const hologramBarrierBounds = {
     minX: barrier.position.x - barrierWidth / 2,
     maxX: barrier.position.x + barrierWidth / 2,
     minZ: barrier.position.z - barrierThickness / 2,
     maxZ: barrier.position.z + barrierThickness / 2,
-  });
+  };
+  const hologramBarrierCollider = createBackyardHologramBarrierCollider(
+    hologramBarrierBounds
+  );
+  colliders.push(hologramBarrierCollider.bounds);
+  sourceBackedColliders.push(hologramBarrierCollider);
 
   updates.push(({ elapsed }) => {
     const flickerScale = getFlickerScale();
@@ -2193,6 +2198,7 @@ export function createBackyardEnvironment(
   return {
     group,
     colliders,
+    sourceBackedColliders,
     update,
     ambientAudioBeds,
     applySeasonalPreset: applyBackyardSeasonalPreset,

--- a/src/scene/level/backyardPerimeterPolicies.ts
+++ b/src/scene/level/backyardPerimeterPolicies.ts
@@ -1,0 +1,167 @@
+import type { RectCollider } from '../../systems/collision';
+import {
+  assertDebugColliderId,
+  type DebugColliderId,
+} from '../debug/colliderDebugIds';
+
+import type { SourceBackedCollider } from './sourceCollision';
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type BackyardPerimeterRole =
+  | 'leftFenceBoundary'
+  | 'rightFenceBoundary'
+  | 'backFenceBoundary'
+  | 'hologramBarrier';
+
+export type BackyardPerimeterSourceType = 'generatedCollider';
+
+interface FenceSegmentPolicy {
+  role: Exclude<BackyardPerimeterRole, 'hologramBarrier'>;
+  sourceId: LevelSourceId;
+  runtimeName: string;
+  purpose: string;
+  debugId?: DebugColliderId;
+  side: 'left' | 'right' | 'back';
+}
+
+export interface BackyardFenceLayout {
+  fenceInsetX: number;
+  fenceFrontZ: number;
+  fenceBackZ: number;
+}
+
+export interface BackyardFenceSegment extends FenceSegmentPolicy {
+  start: { x: number; z: number };
+  end: { x: number; z: number };
+  bounds: RectCollider;
+}
+
+interface HologramBarrierPolicy {
+  role: 'hologramBarrier';
+  sourceId: LevelSourceId;
+  runtimeName: string;
+  purpose: string;
+}
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+const debugId = (value: string): DebugColliderId =>
+  assertDebugColliderId(value);
+
+const FENCE_COLLIDER_REACH = 0.3;
+const SIDE_FENCE_INNER_REACH = 0.18;
+const SIDE_FENCE_OUTER_REACH = 0.12;
+
+export const BACKYARD_FENCE_POLICIES: readonly FenceSegmentPolicy[] = [
+  {
+    role: 'leftFenceBoundary',
+    sourceId: sourceId('ground.backyard.perimeter.leftFenceBoundary'),
+    runtimeName: 'BackyardLeftFenceBoundary',
+    purpose: 'Blocks movement through the visible left backyard fence.',
+    side: 'left',
+  },
+  {
+    role: 'rightFenceBoundary',
+    sourceId: sourceId('ground.backyard.perimeter.rightFenceBoundary'),
+    runtimeName: 'BackyardRightFenceBoundary',
+    purpose: 'Blocks movement through the visible right backyard fence.',
+    side: 'right',
+  },
+  {
+    role: 'backFenceBoundary',
+    sourceId: sourceId('ground.backyard.perimeter.backFenceBoundary'),
+    runtimeName: 'BackyardBackFenceBoundary',
+    purpose:
+      'Preserves the visible back fence as an explicit physical boundary.',
+    debugId: debugId('1007'),
+    side: 'back',
+  },
+];
+
+export const BACKYARD_HOLOGRAM_BARRIER_POLICY: HologramBarrierPolicy = {
+  role: 'hologramBarrier',
+  sourceId: sourceId('ground.backyard.perimeter.hologramBarrier'),
+  runtimeName: 'BackyardHologramBarrierBoundary',
+  purpose: 'Blocks movement through the active hologram exhibit barrier.',
+};
+
+export const createBackyardFenceSegments = (
+  bounds: { minX: number; maxX: number },
+  layout: BackyardFenceLayout
+): readonly BackyardFenceSegment[] =>
+  BACKYARD_FENCE_POLICIES.map((policy) => {
+    const leftX = bounds.minX + layout.fenceInsetX;
+    const rightX = bounds.maxX - layout.fenceInsetX;
+
+    if (policy.side === 'left') {
+      return {
+        ...policy,
+        start: { x: leftX, z: layout.fenceFrontZ },
+        end: { x: leftX, z: layout.fenceBackZ },
+        bounds: {
+          minX: leftX - SIDE_FENCE_OUTER_REACH,
+          maxX: leftX + SIDE_FENCE_INNER_REACH,
+          minZ: layout.fenceFrontZ - FENCE_COLLIDER_REACH,
+          maxZ: layout.fenceBackZ + FENCE_COLLIDER_REACH,
+        },
+      };
+    }
+
+    if (policy.side === 'right') {
+      return {
+        ...policy,
+        start: { x: rightX, z: layout.fenceFrontZ },
+        end: { x: rightX, z: layout.fenceBackZ },
+        bounds: {
+          minX: rightX - SIDE_FENCE_INNER_REACH,
+          maxX: rightX + SIDE_FENCE_OUTER_REACH,
+          minZ: layout.fenceFrontZ - FENCE_COLLIDER_REACH,
+          maxZ: layout.fenceBackZ + FENCE_COLLIDER_REACH,
+        },
+      };
+    }
+
+    return {
+      ...policy,
+      start: { x: leftX, z: layout.fenceBackZ },
+      end: { x: rightX, z: layout.fenceBackZ },
+      bounds: {
+        minX: leftX + SIDE_FENCE_INNER_REACH,
+        maxX: rightX - SIDE_FENCE_INNER_REACH,
+        minZ: layout.fenceBackZ - FENCE_COLLIDER_REACH,
+        maxZ: layout.fenceBackZ + FENCE_COLLIDER_REACH,
+      },
+    };
+  });
+
+export const createBackyardFenceCollider = (
+  segment: BackyardFenceSegment
+): SourceBackedCollider<
+  BackyardPerimeterRole,
+  LevelSourceId,
+  BackyardPerimeterSourceType
+> => ({
+  role: segment.role,
+  sourceId: segment.sourceId,
+  sourceType: 'generatedCollider',
+  intent: 'physical-boundary',
+  purpose: segment.purpose,
+  bounds: segment.bounds,
+  name: segment.runtimeName,
+  ...(segment.debugId ? { debugId: segment.debugId } : {}),
+});
+
+export const createBackyardHologramBarrierCollider = (
+  bounds: RectCollider
+): SourceBackedCollider<
+  BackyardPerimeterRole,
+  LevelSourceId,
+  BackyardPerimeterSourceType
+> => ({
+  role: BACKYARD_HOLOGRAM_BARRIER_POLICY.role,
+  sourceId: BACKYARD_HOLOGRAM_BARRIER_POLICY.sourceId,
+  sourceType: 'generatedCollider',
+  intent: 'physical-boundary',
+  purpose: BACKYARD_HOLOGRAM_BARRIER_POLICY.purpose,
+  bounds,
+  name: BACKYARD_HOLOGRAM_BARRIER_POLICY.runtimeName,
+});

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -29,6 +29,7 @@ import {
   type SpyInstance,
 } from 'vitest';
 
+import { FLOOR_PLAN } from '../assets/floorPlan';
 import { createBackyardEnvironment } from '../scene/environments/backyard';
 import type { SeasonalLightingPreset } from '../scene/lighting/seasonalPresets';
 
@@ -38,6 +39,10 @@ const BACKYARD_BOUNDS = {
   minZ: 8,
   maxZ: 16,
 };
+
+const PRODUCTION_BACKYARD_BOUNDS = FLOOR_PLAN.rooms.find(
+  (room) => room.id === 'backyard'
+)!.bounds;
 
 function clonePositions(attribute: BufferAttribute): Float32Array {
   return new Float32Array(attribute.array as Float32Array);
@@ -1342,17 +1347,16 @@ describe('createBackyardEnvironment', () => {
       true
     );
 
-    const productionBackyardBounds = {
-      minX: -32,
-      maxX: 32,
-      minZ: 16,
-      maxZ: 32,
-    };
     const productionEnvironment = createBackyardEnvironment(
-      productionBackyardBounds
+      PRODUCTION_BACKYARD_BOUNDS
     );
     const productionBackFenceSamples = [
-      { x: 0, z: 30.2 },
+      {
+        x:
+          (PRODUCTION_BACKYARD_BOUNDS.minX + PRODUCTION_BACKYARD_BOUNDS.maxX) /
+          2,
+        z: PRODUCTION_BACKYARD_BOUNDS.maxZ - 1.8,
+      },
       { x: 5, z: 30.2 },
       { x: -5, z: 30.2 },
     ];
@@ -1366,6 +1370,41 @@ describe('createBackyardEnvironment', () => {
     const railMaterial = topRailMesh.material as MeshStandardMaterial;
     expect(railMaterial.envMap).toBeTruthy();
     expect(railMaterial.envMapIntensity).toBeGreaterThan(0);
+  });
+
+  it('exposes backyard perimeter semantic collision policies', () => {
+    const environment = createBackyardEnvironment(BACKYARD_BOUNDS);
+    const policiesByRole = new Map(
+      environment.sourceBackedColliders.map((collider) => [
+        collider.role,
+        collider,
+      ])
+    );
+
+    expect([...policiesByRole.keys()].sort()).toEqual([
+      'backFenceBoundary',
+      'hologramBarrier',
+      'leftFenceBoundary',
+      'rightFenceBoundary',
+    ]);
+
+    const backFence = policiesByRole.get('backFenceBoundary');
+    expect(backFence).toMatchObject({
+      sourceId: 'ground.backyard.perimeter.backFenceBoundary',
+      sourceType: 'generatedCollider',
+      intent: 'physical-boundary',
+      debugId: '1007',
+    });
+    expect(backFence?.purpose).toContain('physical boundary');
+    expect(environment.colliders).toContain(backFence?.bounds);
+
+    environment.sourceBackedColliders.forEach((collider) => {
+      expect(collider.sourceId).toMatch(/^ground\.backyard\.perimeter\./);
+      expect(collider.intent).toBe('physical-boundary');
+      expect(collider.purpose.trim().length).toBeGreaterThan(0);
+      expect(collider.bounds.maxX).toBeGreaterThan(collider.bounds.minX);
+      expect(collider.bounds.maxZ).toBeGreaterThan(collider.bounds.minZ);
+    });
   });
 
   it('dampens backyard pulses when the photosensitive safe scale is disabled', () => {


### PR DESCRIPTION
### Motivation
- Migrate the backyard perimeter fence and hologram barrier to the source-backed collision contract so visuals and collision share a single authoritative declaration. 
- Preserve the back fence as an explicit physical boundary with its stable debug ID (`1007`) so existing debugging and screenshots remain stable.

### Description
- Added `src/scene/level/backyardPerimeterPolicies.ts` declaring semantic policies for `leftFenceBoundary`, `rightFenceBoundary`, `backFenceBoundary` (with `debugId: '1007'`), and `hologramBarrier`, including purpose, intent, and bounds recipes. 
- Refactored the backyard builder in `src/scene/environments/backyard.ts` to derive fence visuals and collider records from the shared segment list via `createBackyardFenceSegments(...)` and to emit `sourceBackedColliders` using `createBackyardFenceCollider(...)` and `createBackyardHologramBarrierCollider(...)`. 
- Exposed `sourceBackedColliders` from `createBackyardEnvironment(...)` and registered their metadata in the central debug/registration path via `colliderSourceMetadata` and `namedColliderDebugNames` in `src/main.ts` so debug visualizer consumers see `sourceId`, `purpose`, `intent`, and `debugId`. 
- Updated tests and docs: `src/tests/backyardEnvironment.test.ts` now derives the production backyard bounds from the canonical floor plan and adds assertions that the perimeter colliders expose semantic metadata and preserve the physical-boundary promise; docs updated in `docs/design/declarative-level-source-of-truth.md` describing the contract.

### Testing
- Ran formatting: `npm run format:write` (files formatted). 
- Ran the focused unit test: `npm run test:ci -- src/tests/backyardEnvironment.test.ts` which completed successfully (29 tests passed). 
- Ran full test suite: `npm run test:ci` which completed successfully (159 test files, 1215 tests passed). 
- Ran lint: `npm run lint` (passed). 
- Ran docs check: `npm run docs:check` (passed; external-link warnings reported by the link checker are unchanged). 
- Ran smoke/build: `npm run smoke` which built successfully (Vite emitted a chunk-size warning only). 

All automated checks passed; the back fence remains a blocking physical boundary and keeps its stable debug identity `1007`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3825819e08832f8d1279a189dc303d)