### PR TITLE
Source backyard boundary colliders

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -175,3 +175,9 @@ Active policies carry intent, purpose, required runtime name, and optional debug
 ID; visual-only policies carry a concise no-collision rationale. Emitted records
 should pass that source metadata through to runtime registration directly rather
 than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.
+
+Backyard perimeter fence and hologram-barrier collision policies are declared in
+`src/scene/level/backyardCollisionPolicies.ts`. The perimeter segment list owns
+both the visible fence run endpoints and the physical-boundary collider bounds,
+so removing or changing a fence boundary should happen in that source policy
+rather than through anonymous collider arrays or registration-order ID maps.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1873,6 +1873,15 @@ function initializeImmersiveScene(
     backyardEnvironment.colliders.forEach((collider) =>
       groundColliders.push(collider)
     );
+    backyardEnvironment.sourceBackedColliders.forEach((collider) => {
+      namedColliderDebugNames.set(collider.bounds, collider.name);
+      colliderSourceMetadata.set(collider.bounds, {
+        sourceId: collider.sourceId,
+        sourceType: collider.sourceType,
+        purpose: collider.purpose,
+        debugId: collider.debugId,
+      });
+    });
   }
 
   const groundFloorGroup = new Group();

--- a/src/scene/environments/backyard.ts
+++ b/src/scene/environments/backyard.ts
@@ -44,6 +44,11 @@ import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import {
+  BACKYARD_PERIMETER_SEGMENT_POLICIES,
+  createBackyardHologramBarrierCollider,
+  type BackyardSourceBackedCollider,
+} from '../level/backyardCollisionPolicies';
+import {
   applySeasonalLightingPreset,
   type SeasonalLightingPreset,
   type SeasonalLightingTarget,
@@ -55,6 +60,7 @@ import { createMultiplayerProjection } from '../structures/multiplayerProjection
 export interface BackyardEnvironmentBuild {
   group: Group;
   colliders: RectCollider[];
+  sourceBackedColliders: BackyardSourceBackedCollider[];
   update(context: { elapsed: number; delta: number }): void;
   ambientAudioBeds: BackyardAmbientAudioBed[];
   applySeasonalPreset(preset: SeasonalLightingPreset | null): void;
@@ -315,6 +321,7 @@ export function createBackyardEnvironment(
   const group = new Group();
   group.name = 'BackyardEnvironment';
   const colliders: RectCollider[] = [];
+  const sourceBackedColliders: BackyardSourceBackedCollider[] = [];
   const updates: Array<(context: { elapsed: number; delta: number }) => void> =
     [];
   const ambientAudioBeds: BackyardAmbientAudioBed[] = [];
@@ -1480,9 +1487,9 @@ export function createBackyardEnvironment(
     envMapIntensity: 0.2,
   });
 
-  const addFenceRun = (runIndex: number, start: Vector3, end: Vector3) => {
+  const addFenceRun = (runName: string, start: Vector3, end: Vector3) => {
     const runGroup = new Group();
-    runGroup.name = `BackyardFenceRun-${runIndex}`;
+    runGroup.name = runName;
     const direction = new Vector3().subVectors(end, start);
     const runLength = direction.length();
     const normalizedDirection = direction.clone().normalize();
@@ -1499,7 +1506,7 @@ export function createBackyardEnvironment(
         .copy(start)
         .add(normalizedDirection.clone().multiplyScalar(runLength * ratio));
       const post = new Mesh(fencePostGeometry, fencePostMaterial);
-      post.name = `BackyardFencePost-${runIndex}-${postIndex}`;
+      post.name = `BackyardFencePost-${runName}-${postIndex}`;
       post.position.set(position.x, fenceHeight / 2, position.z);
       runGroup.add(post);
     }
@@ -1515,7 +1522,7 @@ export function createBackyardEnvironment(
 
       const createRail = (tier: 'Top' | 'Mid', height: number) => {
         const rail = new Mesh(fenceRailGeometry, fenceRailMaterial);
-        rail.name = `BackyardFenceRail-${tier}-${runIndex}-${segmentIndex}`;
+        rail.name = `BackyardFenceRail-${tier}-${runName}-${segmentIndex}`;
         rail.scale.x = segmentDistance;
         rail.position.set(center.x, height, center.z);
         rail.quaternion.copy(orientation);
@@ -1529,45 +1536,37 @@ export function createBackyardEnvironment(
     fenceGroup.add(runGroup);
   };
 
-  const fenceRuns = [
-    {
-      start: new Vector3(bounds.minX + fenceInsetX, 0, fenceFrontZ),
-      end: new Vector3(bounds.minX + fenceInsetX, 0, fenceBackZ),
-    },
-    {
-      start: new Vector3(bounds.maxX - fenceInsetX, 0, fenceFrontZ),
-      end: new Vector3(bounds.maxX - fenceInsetX, 0, fenceBackZ),
-    },
-    {
-      start: new Vector3(bounds.minX + fenceInsetX, 0, fenceBackZ),
-      end: new Vector3(bounds.maxX - fenceInsetX, 0, fenceBackZ),
-    },
-  ];
+  const perimeterLayout = {
+    bounds,
+    fenceInsetX,
+    fenceFrontZ,
+    fenceBackZ,
+  };
+  const perimeterColliderBounds = BACKYARD_PERIMETER_SEGMENT_POLICIES.map(
+    (policy) => {
+      const { start, end } = policy.getEndpoints(perimeterLayout);
+      addFenceRun(
+        policy.visualRunName,
+        new Vector3(start.x, 0, start.z),
+        new Vector3(end.x, 0, end.z)
+      );
 
-  fenceRuns.forEach(({ start, end }, index) => addFenceRun(index, start, end));
+      const sourceBackedCollider: BackyardSourceBackedCollider = {
+        role: policy.role,
+        sourceId: policy.sourceId,
+        sourceType: 'generatedCollider',
+        intent: policy.intent,
+        purpose: policy.purpose,
+        bounds: policy.getBounds(perimeterLayout),
+        name: policy.runtimeName,
+        ...(policy.debugId ? { debugId: policy.debugId } : {}),
+      };
+      sourceBackedColliders.push(sourceBackedCollider);
+      return sourceBackedCollider.bounds;
+    }
+  );
   group.add(fenceGroup);
-
-  const fenceColliders: RectCollider[] = [
-    {
-      minX: bounds.minX + fenceInsetX - 0.12,
-      maxX: bounds.minX + fenceInsetX + 0.18,
-      minZ: fenceFrontZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-    {
-      minX: bounds.maxX - fenceInsetX - 0.18,
-      maxX: bounds.maxX - fenceInsetX + 0.12,
-      minZ: fenceFrontZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-    {
-      minX: bounds.minX + fenceInsetX + 0.18,
-      maxX: bounds.maxX - fenceInsetX - 0.18,
-      minZ: fenceBackZ - 0.3,
-      maxZ: fenceBackZ + 0.3,
-    },
-  ];
-  fenceColliders.forEach((collider) => colliders.push(collider));
+  colliders.push(...perimeterColliderBounds);
 
   interface LanternAnimationTarget {
     glassMaterial: MeshStandardMaterial;
@@ -2055,12 +2054,14 @@ export function createBackyardEnvironment(
   const baseEmitterOpacity = emitterMaterial.opacity;
   const baseEmitterSize = emitterMaterial.size;
 
-  colliders.push({
-    minX: barrier.position.x - barrierWidth / 2,
-    maxX: barrier.position.x + barrierWidth / 2,
-    minZ: barrier.position.z - barrierThickness / 2,
-    maxZ: barrier.position.z + barrierThickness / 2,
+  const barrierCollider = createBackyardHologramBarrierCollider({
+    centerX: barrier.position.x,
+    barrierZ: barrier.position.z,
+    barrierWidth,
+    barrierThickness,
   });
+  sourceBackedColliders.push(barrierCollider);
+  colliders.push(barrierCollider.bounds);
 
   updates.push(({ elapsed }) => {
     const flickerScale = getFlickerScale();
@@ -2193,6 +2194,7 @@ export function createBackyardEnvironment(
   return {
     group,
     colliders,
+    sourceBackedColliders,
     update,
     ambientAudioBeds,
     applySeasonalPreset: applyBackyardSeasonalPreset,

--- a/src/scene/level/backyardCollisionPolicies.ts
+++ b/src/scene/level/backyardCollisionPolicies.ts
@@ -1,0 +1,132 @@
+import type { Bounds2D } from '../../assets/floorPlan';
+import { assertDebugColliderId } from '../debug/colliderDebugIds';
+import type { DebugColliderId } from '../debug/colliderDebugIds';
+
+import type { SourceBackedCollider } from './sourceCollision';
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type BackyardCollisionRole =
+  | 'left-fence-boundary'
+  | 'right-fence-boundary'
+  | 'back-fence-boundary'
+  | 'hologram-barrier';
+
+export interface BackyardPerimeterSegmentPolicy {
+  role: Exclude<BackyardCollisionRole, 'hologram-barrier'>;
+  sourceId: LevelSourceId;
+  runtimeName: string;
+  visualRunName: string;
+  intent: 'physical-boundary';
+  purpose: string;
+  debugId?: DebugColliderId;
+  getEndpoints(layout: BackyardPerimeterLayout): {
+    start: { x: number; z: number };
+    end: { x: number; z: number };
+  };
+  getBounds(layout: BackyardPerimeterLayout): {
+    minX: number;
+    maxX: number;
+    minZ: number;
+    maxZ: number;
+  };
+}
+
+export interface BackyardPerimeterLayout {
+  bounds: Bounds2D;
+  fenceInsetX: number;
+  fenceFrontZ: number;
+  fenceBackZ: number;
+}
+
+export type BackyardSourceBackedCollider = SourceBackedCollider<
+  BackyardCollisionRole,
+  LevelSourceId,
+  'generatedCollider'
+>;
+
+const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
+const debugId = (value: string): DebugColliderId =>
+  assertDebugColliderId(value);
+
+export const BACKYARD_PERIMETER_SEGMENT_POLICIES = [
+  {
+    role: 'left-fence-boundary',
+    sourceId: sourceId('ground.backyard.perimeter.leftFenceBoundary'),
+    runtimeName: 'BackyardLeftFenceBoundary',
+    visualRunName: 'BackyardFenceRun-left-fence-boundary',
+    intent: 'physical-boundary',
+    purpose: 'block the west backyard perimeter fence line',
+    getEndpoints: ({ bounds, fenceInsetX, fenceFrontZ, fenceBackZ }) => ({
+      start: { x: bounds.minX + fenceInsetX, z: fenceFrontZ },
+      end: { x: bounds.minX + fenceInsetX, z: fenceBackZ },
+    }),
+    getBounds: ({ bounds, fenceInsetX, fenceFrontZ, fenceBackZ }) => ({
+      minX: bounds.minX + fenceInsetX - 0.12,
+      maxX: bounds.minX + fenceInsetX + 0.18,
+      minZ: fenceFrontZ - 0.3,
+      maxZ: fenceBackZ + 0.3,
+    }),
+  },
+  {
+    role: 'right-fence-boundary',
+    sourceId: sourceId('ground.backyard.perimeter.rightFenceBoundary'),
+    runtimeName: 'BackyardRightFenceBoundary',
+    visualRunName: 'BackyardFenceRun-right-fence-boundary',
+    intent: 'physical-boundary',
+    purpose: 'block the east backyard perimeter fence line',
+    getEndpoints: ({ bounds, fenceInsetX, fenceFrontZ, fenceBackZ }) => ({
+      start: { x: bounds.maxX - fenceInsetX, z: fenceFrontZ },
+      end: { x: bounds.maxX - fenceInsetX, z: fenceBackZ },
+    }),
+    getBounds: ({ bounds, fenceInsetX, fenceFrontZ, fenceBackZ }) => ({
+      minX: bounds.maxX - fenceInsetX - 0.18,
+      maxX: bounds.maxX - fenceInsetX + 0.12,
+      minZ: fenceFrontZ - 0.3,
+      maxZ: fenceBackZ + 0.3,
+    }),
+  },
+  {
+    role: 'back-fence-boundary',
+    sourceId: sourceId('ground.backyard.perimeter.backFenceBoundary'),
+    runtimeName: 'BackyardBackFenceBoundary',
+    visualRunName: 'BackyardFenceRun-back-fence-boundary',
+    intent: 'physical-boundary',
+    purpose: 'preserve the north backyard back-fence boundary',
+    debugId: debugId('1007'),
+    getEndpoints: ({ bounds, fenceInsetX, fenceBackZ }) => ({
+      start: { x: bounds.minX + fenceInsetX, z: fenceBackZ },
+      end: { x: bounds.maxX - fenceInsetX, z: fenceBackZ },
+    }),
+    getBounds: ({ bounds, fenceInsetX, fenceBackZ }) => ({
+      minX: bounds.minX + fenceInsetX + 0.18,
+      maxX: bounds.maxX - fenceInsetX - 0.18,
+      minZ: fenceBackZ - 0.3,
+      maxZ: fenceBackZ + 0.3,
+    }),
+  },
+] as const satisfies readonly BackyardPerimeterSegmentPolicy[];
+
+export const createBackyardHologramBarrierCollider = ({
+  centerX,
+  barrierZ,
+  barrierWidth,
+  barrierThickness,
+}: {
+  centerX: number;
+  barrierZ: number;
+  barrierWidth: number;
+  barrierThickness: number;
+}): BackyardSourceBackedCollider => ({
+  role: 'hologram-barrier',
+  sourceId: sourceId('ground.backyard.hologramBarrier.physicalBoundary'),
+  sourceType: 'generatedCollider',
+  intent: 'physical-boundary',
+  purpose: 'block traversal through the backyard hologram barrier',
+  name: 'BackyardHologramBarrierBoundary',
+  bounds: {
+    minX: centerX - barrierWidth / 2,
+    maxX: centerX + barrierWidth / 2,
+    minZ: barrierZ - barrierThickness / 2,
+    maxZ: barrierZ + barrierThickness / 2,
+  },
+});

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -29,6 +29,7 @@ import {
   type SpyInstance,
 } from 'vitest';
 
+import { FLOOR_PLAN } from '../assets/floorPlan';
 import { createBackyardEnvironment } from '../scene/environments/backyard';
 import type { SeasonalLightingPreset } from '../scene/lighting/seasonalPresets';
 
@@ -1264,19 +1265,25 @@ describe('createBackyardEnvironment', () => {
     expect(fenceGroup).toBeInstanceOf(Group);
 
     const leftRun = (fenceGroup as Group).getObjectByName(
-      'BackyardFenceRun-0'
+      'BackyardFenceRun-left-fence-boundary'
     ) as Group | null;
     expect(leftRun).toBeInstanceOf(Group);
 
     const leftPosts = (leftRun as Group).children.filter((child) =>
-      child.name.startsWith('BackyardFencePost-0-')
+      child.name.startsWith(
+        'BackyardFencePost-BackyardFenceRun-left-fence-boundary-'
+      )
     );
     expect(leftPosts.length).toBeGreaterThan(2);
 
-    const firstTopRail = leftRun?.getObjectByName('BackyardFenceRail-Top-0-0');
+    const firstTopRail = leftRun?.getObjectByName(
+      'BackyardFenceRail-Top-BackyardFenceRun-left-fence-boundary-0'
+    );
     expect(firstTopRail).toBeInstanceOf(Mesh);
 
-    const firstMidRail = leftRun?.getObjectByName('BackyardFenceRail-Mid-0-0');
+    const firstMidRail = leftRun?.getObjectByName(
+      'BackyardFenceRail-Mid-BackyardFenceRun-left-fence-boundary-0'
+    );
     expect(firstMidRail).toBeInstanceOf(Mesh);
 
     const topRailMesh = firstTopRail as Mesh;
@@ -1290,12 +1297,12 @@ describe('createBackyardEnvironment', () => {
     expect(Math.abs(verticalOrientation.z)).toBeCloseTo(1, 5);
 
     const backRun = (fenceGroup as Group).getObjectByName(
-      'BackyardFenceRun-2'
+      'BackyardFenceRun-back-fence-boundary'
     ) as Group | null;
     expect(backRun).toBeInstanceOf(Group);
 
     const backTopRail = backRun?.getObjectByName(
-      'BackyardFenceRail-Top-2-0'
+      'BackyardFenceRail-Top-BackyardFenceRun-back-fence-boundary-0'
     ) as Mesh | null;
     expect(backTopRail).toBeInstanceOf(Mesh);
 
@@ -1342,14 +1349,12 @@ describe('createBackyardEnvironment', () => {
       true
     );
 
-    const productionBackyardBounds = {
-      minX: -32,
-      maxX: 32,
-      minZ: 16,
-      maxZ: 32,
-    };
+    const productionBackyardBounds = FLOOR_PLAN.rooms.find(
+      (room) => room.id === 'backyard'
+    )?.bounds;
+    expect(productionBackyardBounds).toBeDefined();
     const productionEnvironment = createBackyardEnvironment(
-      productionBackyardBounds
+      productionBackyardBounds!
     );
     const productionBackFenceSamples = [
       { x: 0, z: 30.2 },
@@ -1362,6 +1367,27 @@ describe('createBackyardEnvironment', () => {
         pointIsBlocked(productionEnvironment.colliders)
       )
     ).toBe(true);
+
+    const backFenceCollider = environment.sourceBackedColliders.find(
+      (collider) => collider.role === 'back-fence-boundary'
+    );
+    expect(backFenceCollider).toMatchObject({
+      sourceId: 'ground.backyard.perimeter.backFenceBoundary',
+      sourceType: 'generatedCollider',
+      intent: 'physical-boundary',
+      purpose: 'preserve the north backyard back-fence boundary',
+      debugId: '1007',
+      name: 'BackyardBackFenceBoundary',
+    });
+
+    const fenceRoles = environment.sourceBackedColliders
+      .filter((collider) => collider.role.includes('fence-boundary'))
+      .map((collider) => collider.role);
+    expect(fenceRoles).toEqual([
+      'left-fence-boundary',
+      'right-fence-boundary',
+      'back-fence-boundary',
+    ]);
 
     const railMaterial = topRailMesh.material as MeshStandardMaterial;
     expect(railMaterial.envMap).toBeTruthy();


### PR DESCRIPTION
### Motivation
- Migrate the backyard perimeter fence and hologram barrier collision to source-backed semantic policies so visuals and physics share a single authoritative declaration. 
- Preserve the physical back-fence as a true blocking boundary and retain its stable debug ID `1007` for debugging and regression anchors. 
- Reduce anonymous collider ledgers and avoid deriving runtime identity from array positions by emitting source-backed collider records from the environment builder.

### Description
- Added `src/scene/level/backyardCollisionPolicies.ts` which declares perimeter segment policies for `left-fence-boundary`, `right-fence-boundary`, `back-fence-boundary` (with debug ID `1007`) and a `hologram-barrier` factory, including `sourceId`, role, intent, purpose, visual/run names, and bounds recipes. 
- Refactored `createBackyardEnvironment(...)` in `src/scene/environments/backyard.ts` so fence visual runs are generated from the same policy list and the environment emits `sourceBackedColliders` alongside the existing `colliders` array. 
- Replaced the anonymous `fenceColliders` ledger with bounds derived from the policy list and created the hologram barrier collider via `createBackyardHologramBarrierCollider(...)`. 
- Plumbed source-backed collider metadata into runtime registration in `src/main.ts` so `colliderSourceMetadata` and `namedColliderDebugNames` receive the sourceId/sourceType/purpose/debugId from the environment. 
- Updated `src/tests/backyardEnvironment.test.ts` to derive the production backyard bounds from `FLOOR_PLAN` (instead of hard-coded `-32..32`), to assert back-fence blocking at center and non-center positions, and to assert the presence and metadata of the source-backed fence roles. 
- Added a short docs note to `docs/design/editing-level-data.md` pointing to the new policy owner file and clarifying that perimeter edits should happen in the policy source.

### Testing
- Ran formatting: `npm run format:write` and applied formatting to modified files (succeeded). 
- Ran lint: `npm run lint` and addressed an import-order warning; final lint passed (no errors). 
- Ran focused unit test: `npm run test:ci -- src/tests/backyardEnvironment.test.ts` and it passed (28 tests). 
- Ran full test suite: `npm run test:ci` and all tests passed (159 files, 1214 tests). 
- Ran docs and build checks: `npm run docs:check` (docs checks passed; link checker reported external-fetch warnings) and `npm run smoke` (build/smoke passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38258d8a88832fae0088332059c33c)