### PR TITLE
🧱 : – Declare media wall visual-only collision policy

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -172,6 +172,9 @@ about debug provenance, generator output, or debug-ID registry behavior:
 Source-owned collider declarations should use the shared policy contract in
 `src/scene/level/sourceCollision.ts` when they need stable runtime provenance.
 Active policies carry intent, purpose, required runtime name, and optional debug
-ID; visual-only policies carry a concise no-collision rationale. Emitted records
-should pass that source metadata through to runtime registration directly rather
-than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.
+ID; visual-only policies carry a concise no-collision rationale. For example,
+the Futuroptimist media wall declares its wall-mounted visual media policy in
+`src/scene/level/mediaWallPolicy.ts`, so its shelf, screen, and clearance
+highlight remain rendered while no floor-level collider is emitted. Emitted
+records should pass that source metadata through to runtime registration directly
+rather than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1970,7 +1970,6 @@ function initializeImmersiveScene(
       activeSceneDetailPolicy
     );
     groundFloorGroup.add(mediaWall.group);
-    mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
 

--- a/src/scene/level/mediaWallPolicy.ts
+++ b/src/scene/level/mediaWallPolicy.ts
@@ -1,0 +1,28 @@
+import type { SourceCollisionPolicy } from './sourceCollision';
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type MediaWallPolicyRole = 'living-room-futuroptimist-media';
+export type MediaWallSubsystemRole = 'poi-media-wall';
+export type MediaWallRenderIntent = 'visual-media-poi';
+
+export interface MediaWallPolicy {
+  role: MediaWallPolicyRole;
+  subsystemRole: MediaWallSubsystemRole;
+  renderIntent: MediaWallRenderIntent;
+  render: true;
+  sourceId: LevelSourceId;
+  collision: SourceCollisionPolicy;
+}
+
+export const FUTUROPTIMIST_MEDIA_WALL_POLICY = {
+  role: 'living-room-futuroptimist-media',
+  subsystemRole: 'poi-media-wall',
+  renderIntent: 'visual-media-poi',
+  render: true,
+  sourceId: assertLevelSourceId('ground.livingRoom.mediaWall.futuroptimist'),
+  collision: {
+    collision: 'none',
+    rationale:
+      'Wall-mounted media component intentionally has no floor-level interaction footprint.',
+  },
+} as const satisfies MediaWallPolicy;

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -17,9 +17,9 @@ import {
   getFlickerScale,
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
-import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../level/mediaWallPolicy';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
@@ -364,7 +364,7 @@ export interface LivingRoomMediaWallController {
 
 export interface LivingRoomMediaWallBuild {
   group: Group;
-  colliders: RectCollider[];
+  policy: typeof FUTUROPTIMIST_MEDIA_WALL_POLICY;
   poiBindings: LivingRoomMediaWallPoiBindings;
   controller: LivingRoomMediaWallController;
 }
@@ -500,7 +500,7 @@ export function createLivingRoomMediaWall(
 ): LivingRoomMediaWallBuild {
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
-  const colliders: RectCollider[] = [];
+  const policy = FUTUROPTIMIST_MEDIA_WALL_POLICY;
 
   const wallInteriorX = bounds.minX + 0.12;
   const anchorZ = MathUtils.clamp(-14.2, bounds.minZ + 3, bounds.maxZ - 3);
@@ -607,8 +607,6 @@ export function createLivingRoomMediaWall(
     anchorZ
   );
   group.add(shelf);
-  // This Futuroptimist media POI is wall-mounted, so the visual shelf and
-  // clearance affordance intentionally do not add a floor-level blocker.
 
   const consoleMaterial = new MeshStandardMaterial({
     color: 0x0f1724,
@@ -745,5 +743,5 @@ export function createLivingRoomMediaWall(
     detailPolicy,
   });
 
-  return { group, colliders, poiBindings, controller };
+  return { group, policy, poiBindings, controller };
 }

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -19,7 +19,10 @@ import {
 } from '../../ui/accessibility/animationPreferences';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
-import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../level/mediaWallPolicy';
+import {
+  FUTUROPTIMIST_MEDIA_WALL_POLICY,
+  type MediaWallPolicy,
+} from '../level/mediaWallPolicy';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
@@ -364,7 +367,7 @@ export interface LivingRoomMediaWallController {
 
 export interface LivingRoomMediaWallBuild {
   group: Group;
-  policy: typeof FUTUROPTIMIST_MEDIA_WALL_POLICY;
+  policy: MediaWallPolicy;
   poiBindings: LivingRoomMediaWallPoiBindings;
   controller: LivingRoomMediaWallController;
 }

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -8,6 +8,7 @@ import {
   vi,
 } from 'vitest';
 
+import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../scene/level/mediaWallPolicy';
 import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
 
 describe('createLivingRoomMediaWall', () => {
@@ -170,16 +171,31 @@ describe('createLivingRoomMediaWall', () => {
     expect(() => build.controller.dispose()).not.toThrow();
   });
 
-  it('keeps the wall-mounted media POI visible without adding floor blockers', () => {
+  it('declares the media POI as an active visual-only source policy', () => {
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY).toMatchObject({
+      role: 'living-room-futuroptimist-media',
+      subsystemRole: 'poi-media-wall',
+      renderIntent: 'visual-media-poi',
+      render: true,
+      sourceId: 'ground.livingRoom.mediaWall.futuroptimist',
+      collision: { collision: 'none' },
+    });
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.collision.rationale).toMatch(
+      /wall-mounted.+no floor-level interaction footprint/i
+    );
+  });
+
+  it('keeps the visual media POI visible without emitting floor colliders', () => {
     const bounds = { minX: -16, maxX: 16, minZ: -16, maxZ: -4 };
     const build = createLivingRoomMediaWall(bounds);
 
+    expect(build.policy).toBe(FUTUROPTIMIST_MEDIA_WALL_POLICY);
     expect(
       build.group.getObjectByName('LivingRoomMediaWallScreen')
     ).toBeTruthy();
     expect(
       build.group.getObjectByName('LivingRoomMediaWallClearance')
     ).toBeTruthy();
-    expect(build.colliders).toHaveLength(0);
+    expect('colliders' in build).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Make the Futuroptimist media wall's no-collider exception explicit and source-owned so reviewers can see intent in policy rather than ad-hoc comments. 
- Remove the always-empty collider plumbing for the media wall to reduce dead API surface while preserving existing visuals and POI behavior. 

### Description
- Add a semantic visual-only policy at `src/scene/level/mediaWallPolicy.ts` exposing a stable `sourceId`, subsystem role, render intent, and `collision: 'none'` with a concise rationale. 
- Change `createLivingRoomMediaWall(...)` in `src/scene/structures/mediaWall.ts` to return the policy (`policy`) instead of the legacy `colliders` array and preserve `group`, `poiBindings`, and `controller`. 
- Stop registering media-wall colliders in the scene initializer by removing the now-redundant `mediaWall.colliders.forEach(...)` call in `src/main.ts`. 
- Update tests and docs by adding assertions in `src/tests/mediaWall.test.ts` that the policy is present, visuals remain rendered, and no `colliders` property is emitted, and by documenting the media wall example in `docs/design/editing-level-data.md`. 

### Testing
- Ran `npm run test:ci -- src/tests/mediaWall.test.ts src/tests/mediaWallStarBridge.test.ts` and both test files passed. 
- Ran full `npm run test:ci` and the suite completed with all tests passing. 
- Ran `npm run lint`, `npm run format:write`, `npm run docs:check`, and `npm run smoke` and they completed successfully (link checker reported external fetch warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3825bd0784832fa3f5fb1e606b7876)