### PR TITLE
🧱 : – declare media wall visual policy

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -172,6 +172,8 @@ about debug provenance, generator output, or debug-ID registry behavior:
 Source-owned collider declarations should use the shared policy contract in
 `src/scene/level/sourceCollision.ts` when they need stable runtime provenance.
 Active policies carry intent, purpose, required runtime name, and optional debug
-ID; visual-only policies carry a concise no-collision rationale. Emitted records
+ID; visual-only policies carry a concise no-collision rationale. For example,
+the Futuroptimist media wall declares its wall-mounted visual POI policy in
+`src/scene/structures/mediaWall.ts` and emits no floor collider. Emitted records
 should pass that source metadata through to runtime registration directly rather
 than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1970,7 +1970,6 @@ function initializeImmersiveScene(
       activeSceneDetailPolicy
     );
     groundFloorGroup.add(mediaWall.group);
-    mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
 

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -17,9 +17,10 @@ import {
   getFlickerScale,
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
-import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import type { SourceCollisionPolicy } from '../level/sourceCollision';
+import { assertLevelSourceId, type LevelSourceId } from '../level/sourceIds';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
@@ -31,6 +32,24 @@ const CLEARANCE_BASE_OPACITY = 0.16;
 const CLEARANCE_MAX_OPACITY = 0.52;
 const CLEARANCE_BASE_COLOR = 0x10283b;
 const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
+
+export interface MediaWallComponentPolicy {
+  sourceId: LevelSourceId;
+  subsystemRole: 'futuroptimist-media-display';
+  renderIntent: 'visual-poi-affordance';
+  collision: SourceCollisionPolicy;
+}
+
+export const FUTUROPTIMIST_MEDIA_WALL_POLICY: MediaWallComponentPolicy = {
+  sourceId: assertLevelSourceId('ground.living_room.futuroptimist_media_wall'),
+  subsystemRole: 'futuroptimist-media-display',
+  renderIntent: 'visual-poi-affordance',
+  collision: {
+    collision: 'none',
+    rationale:
+      'Wall-mounted media component; intentionally has no floor-level interaction footprint.',
+  },
+};
 
 interface MediaWallScreenRendererOptions {
   starCount: number | null;
@@ -364,7 +383,7 @@ export interface LivingRoomMediaWallController {
 
 export interface LivingRoomMediaWallBuild {
   group: Group;
-  colliders: RectCollider[];
+  policy: MediaWallComponentPolicy;
   poiBindings: LivingRoomMediaWallPoiBindings;
   controller: LivingRoomMediaWallController;
 }
@@ -500,7 +519,8 @@ export function createLivingRoomMediaWall(
 ): LivingRoomMediaWallBuild {
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
-  const colliders: RectCollider[] = [];
+  group.userData.levelSourceId = FUTUROPTIMIST_MEDIA_WALL_POLICY.sourceId;
+  group.userData.mediaWallPolicy = FUTUROPTIMIST_MEDIA_WALL_POLICY;
 
   const wallInteriorX = bounds.minX + 0.12;
   const anchorZ = MathUtils.clamp(-14.2, bounds.minZ + 3, bounds.maxZ - 3);
@@ -607,8 +627,6 @@ export function createLivingRoomMediaWall(
     anchorZ
   );
   group.add(shelf);
-  // This Futuroptimist media POI is wall-mounted, so the visual shelf and
-  // clearance affordance intentionally do not add a floor-level blocker.
 
   const consoleMaterial = new MeshStandardMaterial({
     color: 0x0f1724,
@@ -745,5 +763,10 @@ export function createLivingRoomMediaWall(
     detailPolicy,
   });
 
-  return { group, colliders, poiBindings, controller };
+  return {
+    group,
+    policy: FUTUROPTIMIST_MEDIA_WALL_POLICY,
+    poiBindings,
+    controller,
+  };
 }

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -8,7 +8,10 @@ import {
   vi,
 } from 'vitest';
 
-import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
+import {
+  FUTUROPTIMIST_MEDIA_WALL_POLICY,
+  createLivingRoomMediaWall,
+} from '../scene/structures/mediaWall';
 
 describe('createLivingRoomMediaWall', () => {
   type CapturingContext = CanvasRenderingContext2D & {
@@ -180,6 +183,20 @@ describe('createLivingRoomMediaWall', () => {
     expect(
       build.group.getObjectByName('LivingRoomMediaWallClearance')
     ).toBeTruthy();
-    expect(build.colliders).toHaveLength(0);
+    expect(build.policy).toBe(FUTUROPTIMIST_MEDIA_WALL_POLICY);
+    expect(build.policy.collision.collision).toBe('none');
+
+    if (build.policy.collision.collision !== 'none') {
+      throw new Error('Expected media wall policy to be visual-only.');
+    }
+
+    expect(build.policy.sourceId).toBe(
+      'ground.living_room.futuroptimist_media_wall'
+    );
+    expect(build.policy.subsystemRole).toBe('futuroptimist-media-display');
+    expect(build.policy.renderIntent).toBe('visual-poi-affordance');
+    expect(build.policy.collision.rationale.trim()).toContain('Wall-mounted');
+    expect(build.policy.collision.rationale.trim()).toContain('floor-level');
+    expect('colliders' in build).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Make the Futuroptimist media wall's no-floor-collider behavior an explicit, source-owned visual-only policy so the exception is durable and discoverable in source.

### Description
- Add a `MediaWallComponentPolicy` and `FUTUROPTIMIST_MEDIA_WALL_POLICY` with a stable `sourceId`, `subsystemRole`, `renderIntent`, and `collision: 'none'` plus a concise rationale in `src/scene/structures/mediaWall.ts`.
- Replace the legacy always-empty `colliders` return value with a `policy` returned from `createLivingRoomMediaWall`, attach `levelSourceId` and the policy to `group.userData`, and remove the media-wall collider registration path from `src/main.ts`.
- Update `src/tests/mediaWall.test.ts` to assert the active visual-only policy, the continued presence of visual POI bindings, and that the legacy `colliders` property is no longer present.
- Update docs (`docs/design/editing-level-data.md`) to cite the media wall as an example of a visual-only source policy.

### Testing
- Ran formatter: `npm run format:write -- src/scene/structures/mediaWall.ts src/tests/mediaWall.test.ts src/main.ts docs/design/editing-level-data.md` and applied formatting successfully.
- Ran focused unit tests: `npm run test:ci -- src/tests/mediaWall.test.ts src/tests/mediaWallStarBridge.test.ts` — both test files passed.
- Ran full test suite: `npm run test:ci` — all tests passed (159 files, 1214 tests) in CI run shown.
- Ran lint: `npm run lint` — lint completed (no blocking errors after import order fix).
- Ran docs checks: `npm run docs:check` — docs check passed; link checker reported external fetch warnings but exited successfully.
- Ran smoke build: `npm run smoke` — smoke check passed (production build succeeded).
- Ran secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3825c355cc832fb62d1990886347ee)