### PR TITLE
Declare Futuroptimist media wall visual-only collision policy

### DIFF
--- a/docs/architecture/scene-stack.md
+++ b/docs/architecture/scene-stack.md
@@ -132,6 +132,12 @@ layer without guessing where functionality lives.
   [`src/ui/accessibility`](../../src/ui/accessibility) subscribe to key binding, accessibility
   preset, and POI selection handles. Each overlay follows the
   [accessibility checklist](../guides/accessibility-overlays.md).
+- **Visual-only collision policy** – The Futuroptimist media wall declares its
+  wall-mounted visual source in
+  [`src/scene/level/mediaWallPolicy.ts`](../../src/scene/level/mediaWallPolicy.ts).
+  The scene builder applies that source metadata to the visible screen, shelf,
+  and clearance affordance while the policy's `collision: 'none'` rationale
+  keeps it from emitting any floor-level collider.
 - **POI orchestration** – The registry at
   [`src/scene/poi/registry.ts`](../../src/scene/poi/registry.ts) now includes
   room-scoped helpers such as `getPoiDefinitionsByRoom(...)`. Interactions in

--- a/src/main.ts
+++ b/src/main.ts
@@ -1970,7 +1970,6 @@ function initializeImmersiveScene(
       activeSceneDetailPolicy
     );
     groundFloorGroup.add(mediaWall.group);
-    mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
 

--- a/src/scene/level/mediaWallPolicy.ts
+++ b/src/scene/level/mediaWallPolicy.ts
@@ -1,0 +1,25 @@
+import type { SourceCollisionPolicy } from './sourceCollision';
+import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export type MediaWallComponentRole = 'futuroptimist-media-wall';
+export type MediaWallRenderIntent = 'wall-mounted-visual-media-poi';
+
+export interface MediaWallComponentPolicy {
+  sourceId: LevelSourceId;
+  subsystem: 'living-room-media-wall';
+  role: MediaWallComponentRole;
+  renderIntent: MediaWallRenderIntent;
+  collision: SourceCollisionPolicy;
+}
+
+export const FUTUROPTIMIST_MEDIA_WALL_POLICY = {
+  sourceId: assertLevelSourceId('ground.living_room.mediaWall.futuroptimist'),
+  subsystem: 'living-room-media-wall',
+  role: 'futuroptimist-media-wall',
+  renderIntent: 'wall-mounted-visual-media-poi',
+  collision: {
+    collision: 'none',
+    rationale:
+      'Wall-mounted media component; intentionally no floor-level interaction footprint.',
+  },
+} as const satisfies MediaWallComponentPolicy;

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -17,9 +17,11 @@ import {
   getFlickerScale,
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
-import type { RectCollider } from '../collision';
-import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
-import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../level/mediaWallPolicy';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
@@ -31,6 +33,16 @@ const CLEARANCE_BASE_OPACITY = 0.16;
 const CLEARANCE_MAX_OPACITY = 0.52;
 const CLEARANCE_BASE_COLOR = 0x10283b;
 const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
+
+const applyMediaWallPolicy = (mesh: Mesh) => {
+  mesh.userData.levelSourceId = FUTUROPTIMIST_MEDIA_WALL_POLICY.sourceId;
+  mesh.userData.levelSource = {
+    sourceId: FUTUROPTIMIST_MEDIA_WALL_POLICY.sourceId,
+    sourceType: 'generatedSolid',
+    purpose: FUTUROPTIMIST_MEDIA_WALL_POLICY.renderIntent,
+  };
+  mesh.userData.collisionPolicy = FUTUROPTIMIST_MEDIA_WALL_POLICY.collision;
+};
 
 interface MediaWallScreenRendererOptions {
   starCount: number | null;
@@ -364,7 +376,6 @@ export interface LivingRoomMediaWallController {
 
 export interface LivingRoomMediaWallBuild {
   group: Group;
-  colliders: RectCollider[];
   poiBindings: LivingRoomMediaWallPoiBindings;
   controller: LivingRoomMediaWallController;
 }
@@ -500,7 +511,6 @@ export function createLivingRoomMediaWall(
 ): LivingRoomMediaWallBuild {
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
-  const colliders: RectCollider[] = [];
 
   const wallInteriorX = bounds.minX + 0.12;
   const anchorZ = MathUtils.clamp(-14.2, bounds.minZ + 3, bounds.maxZ - 3);
@@ -554,6 +564,7 @@ export function createLivingRoomMediaWall(
   screenMesh.position.set(wallInteriorX + boardDepth + 0.02, 2.36, anchorZ);
   screenMesh.rotation.y = Math.PI / 2;
   screenMesh.renderOrder = 10;
+  applyMediaWallPolicy(screenMesh);
   group.add(screenMesh);
 
   const screenGlowMaterial = new MeshBasicMaterial({
@@ -606,9 +617,8 @@ export function createLivingRoomMediaWall(
     shelfThickness / 2 + 0.46,
     anchorZ
   );
+  applyMediaWallPolicy(shelf);
   group.add(shelf);
-  // This Futuroptimist media POI is wall-mounted, so the visual shelf and
-  // clearance affordance intentionally do not add a floor-level blocker.
 
   const consoleMaterial = new MeshStandardMaterial({
     color: 0x0f1724,
@@ -717,6 +727,7 @@ export function createLivingRoomMediaWall(
     anchorZ
   );
   clearance.renderOrder = 4;
+  applyMediaWallPolicy(clearance);
   group.add(clearance);
 
   const poiBindings: LivingRoomMediaWallPoiBindings = {
@@ -745,5 +756,5 @@ export function createLivingRoomMediaWall(
     detailPolicy,
   });
 
-  return { group, colliders, poiBindings, controller };
+  return { group, poiBindings, controller };
 }

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -8,6 +8,7 @@ import {
   vi,
 } from 'vitest';
 
+import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../scene/level/mediaWallPolicy';
 import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
 
 describe('createLivingRoomMediaWall', () => {
@@ -170,16 +171,39 @@ describe('createLivingRoomMediaWall', () => {
     expect(() => build.controller.dispose()).not.toThrow();
   });
 
-  it('keeps the wall-mounted media POI visible without adding floor blockers', () => {
+  it('declares the Futuroptimist media wall as visual-only source policy', () => {
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY).toMatchObject({
+      sourceId: 'ground.living_room.mediaWall.futuroptimist',
+      subsystem: 'living-room-media-wall',
+      role: 'futuroptimist-media-wall',
+      renderIntent: 'wall-mounted-visual-media-poi',
+      collision: { collision: 'none' },
+    });
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.collision.rationale).toContain(
+      'Wall-mounted media component'
+    );
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.collision.rationale).toContain(
+      'no floor-level interaction footprint'
+    );
+  });
+
+  it('keeps the media POI visible without emitting floor colliders', () => {
     const bounds = { minX: -16, maxX: 16, minZ: -16, maxZ: -4 };
     const build = createLivingRoomMediaWall(bounds);
 
-    expect(
-      build.group.getObjectByName('LivingRoomMediaWallScreen')
-    ).toBeTruthy();
-    expect(
-      build.group.getObjectByName('LivingRoomMediaWallClearance')
-    ).toBeTruthy();
-    expect(build.colliders).toHaveLength(0);
+    const screen = build.group.getObjectByName('LivingRoomMediaWallScreen');
+    const clearance = build.group.getObjectByName(
+      'LivingRoomMediaWallClearance'
+    );
+
+    expect(screen).toBeTruthy();
+    expect(clearance).toBeTruthy();
+    expect(screen?.userData.levelSourceId).toBe(
+      FUTUROPTIMIST_MEDIA_WALL_POLICY.sourceId
+    );
+    expect(clearance?.userData.collisionPolicy).toEqual(
+      FUTUROPTIMIST_MEDIA_WALL_POLICY.collision
+    );
+    expect('colliders' in build).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Make the Futuroptimist media-wall collision exception explicit and source-owned instead of relying on an in-code explanatory comment.  
- Keep the visual POI rendered and interactive while guaranteeing it emits no floor-level collider.  
- Simplify the builder API by removing permanently-empty collider plumbing that served only as legacy scaffolding.  

### Description
- Add `src/scene/level/mediaWallPolicy.ts` declaring a stable `sourceId`, `subsystem`, `role`, `renderIntent`, and `collision: 'none'` with a non-empty rationale explaining the wall-mounted/no-floor-footprint intent.  
- Apply the policy to the media wall visuals by tagging the screen, shelf, and clearance meshes (`mesh.userData.levelSourceId`, `mesh.userData.levelSource`, and `mesh.userData.collisionPolicy`) via an `applyMediaWallPolicy` helper in `src/scene/structures/mediaWall.ts`.  
- Remove the always-empty `colliders` return value from `createLivingRoomMediaWall` and stop registering media-wall colliders at scene boot in `src/main.ts`.  
- Update unit tests (`src/tests/mediaWall.test.ts`) to assert the new source policy, ensure visuals and POI bindings remain present, and verify no floor collider is emitted; and update architecture docs (`docs/architecture/scene-stack.md`) to reference the new policy.  

### Testing
- Ran formatting: `npm run format:write` (applied).  
- Ran lint: `npm run lint` (warnings addressed; final lint passed).  
- Ran focused unit tests: `npm run test:ci -- src/tests/mediaWall.test.ts src/tests/mediaWallStarBridge.test.ts` (passed).  
- Ran full Vitest suite: `npm run test:ci` which completed with all test files passing (159 files, 1215 tests passed).  
- Docs validation: `npm run docs:check` (passed; link checker reported external fetch warnings only).  
- Smoke build: `npm run smoke` (build + smoke checks passed).  
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3825cb6e68832f8c6193cd02d0121e)