### PR TITLE
Declare Futuroptimist media wall visual-only policy

### DIFF
--- a/docs/design/declarative-level-source-of-truth.md
+++ b/docs/design/declarative-level-source-of-truth.md
@@ -158,11 +158,14 @@ positions are authored in level-space coordinates and validated against their
 declared room bounds; POI placement adapters scale them to the runtime world
 coordinates used by the current immersive scene. Scene object placement and
 collider policy are declarative source data rather than shadow runtime constants.
-Objects that intentionally have no collider must
-be explicitly marked with a no-collider policy and authored reason instead of
-silently disappearing from collider generation. These objects continue to use
-their existing structure-factory collider bounds, but the source object owns the
-stable source ID, room/floor placement, purpose, and `custom`
+Objects that intentionally have no collider must be explicitly marked with a
+no-collider policy and authored reason instead of silently disappearing from
+collider generation. The Futuroptimist media wall is the canonical visual-only
+exception: its source-owned policy declares the wall-mounted render intent and a
+`collision: 'none'` rationale, so the visual POI remains rendered without a
+floor-level interaction footprint. Objects with factory colliders continue to
+use their existing structure-factory collider bounds, but the source object owns
+the stable source ID, room/floor placement, purpose, and `custom`
 `factory-colliders` policy that debug collider and solid metadata can expose.
 
 ### Room connections

--- a/src/main.ts
+++ b/src/main.ts
@@ -1970,7 +1970,6 @@ function initializeImmersiveScene(
       activeSceneDetailPolicy
     );
     groundFloorGroup.add(mediaWall.group);
-    mediaWall.colliders.forEach((collider) => staticColliders.push(collider));
     livingRoomMediaWall = mediaWall;
     mediaWallStarBridge.attach(mediaWall.controller);
 

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -17,9 +17,10 @@ import {
   getFlickerScale,
   getPulseScale,
 } from '../../ui/accessibility/animationPreferences';
-import type { RectCollider } from '../collision';
-import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import type { SourceCollisionPolicy } from '../level/sourceCollision';
+import { assertLevelSourceId, type LevelSourceId } from '../level/sourceIds';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
@@ -31,6 +32,24 @@ const CLEARANCE_BASE_OPACITY = 0.16;
 const CLEARANCE_MAX_OPACITY = 0.52;
 const CLEARANCE_BASE_COLOR = 0x10283b;
 const CLEARANCE_HIGHLIGHT_COLOR = 0x3ec9ff;
+
+export interface LivingRoomMediaWallPolicy {
+  sourceId: LevelSourceId;
+  subsystemRole: 'futuroptimist-media';
+  renderIntent: 'wall-mounted-visual-poi';
+  collision: SourceCollisionPolicy;
+}
+
+export const FUTUROPTIMIST_MEDIA_WALL_POLICY = {
+  sourceId: assertLevelSourceId('ground.livingRoom.mediaWall.futuroptimist'),
+  subsystemRole: 'futuroptimist-media',
+  renderIntent: 'wall-mounted-visual-poi',
+  collision: {
+    collision: 'none',
+    rationale:
+      'Wall-mounted media component; intentionally has no floor-level interaction footprint.',
+  },
+} as const satisfies LivingRoomMediaWallPolicy;
 
 interface MediaWallScreenRendererOptions {
   starCount: number | null;
@@ -364,7 +383,6 @@ export interface LivingRoomMediaWallController {
 
 export interface LivingRoomMediaWallBuild {
   group: Group;
-  colliders: RectCollider[];
   poiBindings: LivingRoomMediaWallPoiBindings;
   controller: LivingRoomMediaWallController;
 }
@@ -500,7 +518,7 @@ export function createLivingRoomMediaWall(
 ): LivingRoomMediaWallBuild {
   const group = new Group();
   group.name = 'LivingRoomMediaWall';
-  const colliders: RectCollider[] = [];
+  group.userData.sourcePolicy = FUTUROPTIMIST_MEDIA_WALL_POLICY;
 
   const wallInteriorX = bounds.minX + 0.12;
   const anchorZ = MathUtils.clamp(-14.2, bounds.minZ + 3, bounds.maxZ - 3);
@@ -607,8 +625,6 @@ export function createLivingRoomMediaWall(
     anchorZ
   );
   group.add(shelf);
-  // This Futuroptimist media POI is wall-mounted, so the visual shelf and
-  // clearance affordance intentionally do not add a floor-level blocker.
 
   const consoleMaterial = new MeshStandardMaterial({
     color: 0x0f1724,
@@ -745,5 +761,5 @@ export function createLivingRoomMediaWall(
     detailPolicy,
   });
 
-  return { group, colliders, poiBindings, controller };
+  return { group, poiBindings, controller };
 }

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -8,7 +8,10 @@ import {
   vi,
 } from 'vitest';
 
-import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
+import {
+  FUTUROPTIMIST_MEDIA_WALL_POLICY,
+  createLivingRoomMediaWall,
+} from '../scene/structures/mediaWall';
 
 describe('createLivingRoomMediaWall', () => {
   type CapturingContext = CanvasRenderingContext2D & {
@@ -170,7 +173,23 @@ describe('createLivingRoomMediaWall', () => {
     expect(() => build.controller.dispose()).not.toThrow();
   });
 
-  it('keeps the wall-mounted media POI visible without adding floor blockers', () => {
+  it('declares the active media wall policy as visual-only', () => {
+    expect(String(FUTUROPTIMIST_MEDIA_WALL_POLICY.sourceId)).toBe(
+      'ground.livingRoom.mediaWall.futuroptimist'
+    );
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.subsystemRole).toBe(
+      'futuroptimist-media'
+    );
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.renderIntent).toBe(
+      'wall-mounted-visual-poi'
+    );
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.collision.collision).toBe('none');
+    expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.collision.rationale).toMatch(
+      /wall-mounted.*no floor-level interaction footprint/i
+    );
+  });
+
+  it('keeps the media POI visuals visible without adding floor blockers', () => {
     const bounds = { minX: -16, maxX: 16, minZ: -16, maxZ: -4 };
     const build = createLivingRoomMediaWall(bounds);
 
@@ -180,6 +199,9 @@ describe('createLivingRoomMediaWall', () => {
     expect(
       build.group.getObjectByName('LivingRoomMediaWallClearance')
     ).toBeTruthy();
-    expect(build.colliders).toHaveLength(0);
+    expect(build.group.userData.sourcePolicy).toBe(
+      FUTUROPTIMIST_MEDIA_WALL_POLICY
+    );
+    expect('colliders' in build).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Make the Futuroptimist media-wall collider exception explicit and source-owned so the visual POI remains rendered while owning the rationale for no floor-level interaction footprint. 
- Remove always-empty media-wall collider plumbing to simplify the media-wall build API and avoid misleading legacy fields. 
- Ensure future changes from visual-only to collidable are a single local policy edit plus bounds, rather than scattered test/main edits. 

### Description
- Add `FUTUROPTIMIST_MEDIA_WALL_POLICY` (stable `sourceId`, `subsystemRole`, `renderIntent`, and `collision: 'none'` with a concise rationale) in `src/scene/structures/mediaWall.ts`. 
- Attach the policy to the media wall group via `group.userData.sourcePolicy` and remove the always-empty `colliders` property from `LivingRoomMediaWallBuild`. 
- Stop registering media-wall colliders in `src/main.ts` so no floor-level collider is emitted. 
- Update `src/tests/mediaWall.test.ts` to assert the new visual-only source policy, preserve visual POI bindings, and verify no `colliders` field is present; and update docs in `docs/design/declarative-level-source-of-truth.md` to document the media wall as the canonical visual-only exception. 

### Testing
- Ran the focused tests with `npm run test:ci -- src/tests/mediaWall.test.ts src/tests/mediaWallStarBridge.test.ts` and the media-wall tests passed (2 files, 7 tests total). 
- Ran lint and fixed an import-order warning; final `npm run lint` completed without errors. 
- Ran the full test suite with `npm run test:ci` and all tests passed (159 files, 1215 tests). 
- Ran docs check with `npm run docs:check`; docs check passed although external link fetches produced benign warnings. 
- Ran smoke and build with `npm run smoke` and the production build/smoke check passed. 
- Ran the secret scan `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3825d2f4d0832fa2638d2f61a55d8a)