### PR TITLE
🔎 : – add collider inspection CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Each floor has its own auto-generated diagram (regenerated locally with
 | `npm run smoke`                                 | Build and validate `dist/index.html`, bundled assets, and static refs. |
 | `npm run check`                                 | Convenience command chaining lint, test:ci, and docs:check.            |
 | `npm run press-kit`                             | Emit `docs/assets/press-kit.json` with POI and media manifest details. |
+| `npm run collider:inspect -- --id <debug-id>`   | Resolve a runtime collider from the immersive debug API.               |
 
 ### Local quality gates
 
@@ -148,6 +149,23 @@ npm run smoke
 Pre-commit mirrors these commands alongside formatting hooks. Compared to the full
 Flywheel stack, we skip the Python-heavy aggregate hook to keep this web-focused repo
 lightweight.
+
+### Collider inspection
+
+Before proposing a collider removal or replacement, first resolve the runtime
+record with the on-demand inspector instead of searching array positions:
+
+```bash
+npm run collider:inspect -- --id 400D
+npm run collider:inspect -- --source-id upper.stairwell.landingGuard.shoulderEast
+npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json
+```
+
+The command opens the real immersive runtime with performance failover disabled,
+uses `window.portfolio.debugColliders` as the source of truth, and leaves no
+repository artifacts unless you explicitly redirect the JSON output. Set
+`PLAYWRIGHT_BASE_URL` to reuse an already-running Vite server; otherwise the
+inspector starts and stops a local dev server for the collection.
 
 ## Testing & automation
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
     "links:check": "node scripts/check-links.cjs",
-    "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
+    "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
+    "collider:inspect": "tsx scripts/inspect-collider.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderInspect.test.ts
+++ b/scripts/__tests__/colliderInspect.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatColliderReport,
+  inspectColliders,
+  parseColliderInspectArgs,
+  type RuntimeColliderMetadata,
+} from '../colliderInspect';
+
+const colliders: RuntimeColliderMetadata[] = [
+  {
+    id: '400D',
+    debugId: '400D',
+    name: 'UpperStairNorthBannisterGuard',
+    sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+    sourceType: 'generatedCollider',
+    role: 'shoulder-east',
+    intent: 'safety-guard',
+    purpose: 'upper stairwell landing shoulder-east guard',
+    floor: 'upper',
+    category: 'upper',
+    bounds: { minX: 1, maxX: 2.23456, minZ: 3, maxZ: 4 },
+  },
+  {
+    id: '1007',
+    name: 'legacy-collider',
+    floor: 'ground',
+    category: 'static',
+    bounds: { minX: 1.5, maxX: 3, minZ: 3.5, maxZ: 5 },
+  },
+];
+
+describe('parseColliderInspectArgs', () => {
+  it('parses exactly one query and json output', () => {
+    expect(parseColliderInspectArgs(['--id', '400d', '--json'])).toEqual({
+      id: '400D',
+      json: true,
+    });
+  });
+
+  it('rejects missing or ambiguous queries', () => {
+    expect(() => parseColliderInspectArgs([])).toThrow('exactly one');
+    expect(() =>
+      parseColliderInspectArgs(['--id', '400D', '--name', 'x'])
+    ).toThrow('exactly one');
+  });
+});
+
+describe('inspectColliders', () => {
+  it('resolves by source ID with source metadata and overlap counts', () => {
+    const [match] = inspectColliders(colliders, {
+      sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+    });
+
+    expect(match).toMatchObject({
+      id: '400D',
+      sourceType: 'generatedCollider',
+      role: 'shoulder-east',
+      intent: 'safety-guard',
+      idKind: 'explicit',
+      overlapCount: 1,
+      dimensions: { width: 1.235, depth: 1, area: 1.235 },
+    });
+  });
+
+  it('reports generated legacy IDs when no explicit debug ID is exposed', () => {
+    const [match] = inspectColliders(colliders, { id: '1007' });
+
+    expect(match.idKind).toBe('generated');
+    expect(match.sourceId).toBeUndefined();
+  });
+});
+
+describe('formatColliderReport', () => {
+  it('prints a deterministic human readable report', () => {
+    const report = formatColliderReport(
+      inspectColliders(colliders, { id: '400D' })
+    );
+
+    expect(report).toContain('Collider 400D');
+    expect(report).toContain(
+      'source ID: upper.stairwell.landingGuard.shoulderEast'
+    );
+    expect(report).toContain('role/intent: shoulder-east / safety-guard');
+    expect(report).toContain('overlapping active colliders: 1');
+  });
+});

--- a/scripts/colliderInspect.ts
+++ b/scripts/colliderInspect.ts
@@ -1,0 +1,158 @@
+export type ColliderBounds = {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+};
+
+export type RuntimeColliderMetadata = {
+  id: string;
+  name: string;
+  floor: string;
+  category: string;
+  bounds: ColliderBounds;
+  sourceId?: string;
+  sourceType?: string;
+  role?: string;
+  intent?: string;
+  purpose?: string;
+  debugId?: string;
+};
+
+export type InspectOptions = {
+  id?: string;
+  sourceId?: string;
+  name?: string;
+  json: boolean;
+};
+
+export type InspectedCollider = RuntimeColliderMetadata & {
+  normalizedBounds: ColliderBounds;
+  dimensions: { width: number; depth: number; area: number };
+  idKind: 'explicit' | 'generated';
+  overlapCount: number;
+};
+
+const QUERY_FLAGS = new Set(['--id', '--source-id', '--name']);
+
+export function parseColliderInspectArgs(
+  args: readonly string[]
+): InspectOptions {
+  const options: InspectOptions = { json: false };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (!QUERY_FLAGS.has(arg)) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+    index += 1;
+
+    if (arg === '--id') options.id = value.toUpperCase();
+    if (arg === '--source-id') options.sourceId = value;
+    if (arg === '--name') options.name = value;
+  }
+
+  const queryCount = [options.id, options.sourceId, options.name].filter(
+    Boolean
+  ).length;
+  if (queryCount !== 1) {
+    throw new Error('Provide exactly one of --id, --source-id, or --name.');
+  }
+
+  return options;
+}
+
+const round = (value: number): number => Number(value.toFixed(3));
+
+export const normalizeBounds = (bounds: ColliderBounds): ColliderBounds => ({
+  minX: round(Math.min(bounds.minX, bounds.maxX)),
+  maxX: round(Math.max(bounds.minX, bounds.maxX)),
+  minZ: round(Math.min(bounds.minZ, bounds.maxZ)),
+  maxZ: round(Math.max(bounds.minZ, bounds.maxZ)),
+});
+
+const overlaps = (left: ColliderBounds, right: ColliderBounds): boolean =>
+  left.minX < right.maxX &&
+  left.maxX > right.minX &&
+  left.minZ < right.maxZ &&
+  left.maxZ > right.minZ;
+
+export function inspectColliders(
+  colliders: readonly RuntimeColliderMetadata[],
+  options: Pick<InspectOptions, 'id' | 'sourceId' | 'name'>
+): InspectedCollider[] {
+  const matches = colliders.filter((collider) => {
+    if (options.id)
+      return collider.id.toUpperCase() === options.id.toUpperCase();
+    if (options.sourceId) return collider.sourceId === options.sourceId;
+    return collider.name === options.name;
+  });
+
+  if (matches.length === 0) {
+    const query = options.id ?? options.sourceId ?? options.name;
+    throw new Error(`No collider matched ${query}.`);
+  }
+  if ((options.id || options.name) && matches.length > 1) {
+    throw new Error(
+      `Ambiguous collider match (${matches.length} matches). Use --source-id or --id.`
+    );
+  }
+
+  const normalizedColliders = colliders.map((collider) => ({
+    collider,
+    bounds: normalizeBounds(collider.bounds),
+  }));
+
+  return matches.map((collider) => {
+    const normalizedBounds = normalizeBounds(collider.bounds);
+    const width = round(normalizedBounds.maxX - normalizedBounds.minX);
+    const depth = round(normalizedBounds.maxZ - normalizedBounds.minZ);
+    return {
+      ...collider,
+      normalizedBounds,
+      dimensions: { width, depth, area: round(width * depth) },
+      idKind: collider.debugId === collider.id ? 'explicit' : 'generated',
+      overlapCount: normalizedColliders.filter(
+        (entry) =>
+          entry.collider !== collider &&
+          overlaps(normalizedBounds, entry.bounds)
+      ).length,
+    };
+  });
+}
+
+const formatOptional = (value: string | undefined): string => value ?? 'n/a';
+const formatBounds = (bounds: ColliderBounds): string =>
+  `x ${bounds.minX}..${bounds.maxX}, z ${bounds.minZ}..${bounds.maxZ}`;
+
+export function formatColliderReport(
+  matches: readonly InspectedCollider[]
+): string {
+  return matches
+    .map((collider) =>
+      [
+        `Collider ${collider.id}`,
+        `  runtime name: ${collider.name}`,
+        `  source ID: ${formatOptional(collider.sourceId)}`,
+        `  source type: ${formatOptional(collider.sourceType)}`,
+        `  role/intent: ${formatOptional(collider.role)} / ${formatOptional(collider.intent)}`,
+        `  purpose: ${formatOptional(collider.purpose)}`,
+        `  floor: ${collider.floor}`,
+        `  category: ${collider.category}`,
+        `  bounds: ${formatBounds(collider.normalizedBounds)}`,
+        `  dimensions: ${collider.dimensions.width} × ${collider.dimensions.depth} (area ${collider.dimensions.area})`,
+        `  ID kind: ${collider.idKind}`,
+        `  overlapping active colliders: ${collider.overlapCount}`,
+      ].join('\n')
+    )
+    .join('\n\n');
+}

--- a/scripts/inspect-collider.ts
+++ b/scripts/inspect-collider.ts
@@ -1,0 +1,25 @@
+import {
+  inspectColliders,
+  formatColliderReport,
+  parseColliderInspectArgs,
+} from './colliderInspect';
+import { collectRuntimeColliders } from './runtimeColliderCollector';
+
+async function main(): Promise<void> {
+  try {
+    const options = parseColliderInspectArgs(process.argv.slice(2));
+    const colliders = await collectRuntimeColliders();
+    const matches = inspectColliders(colliders, options);
+    process.stdout.write(
+      options.json
+        ? `${JSON.stringify(matches, null, 2)}\n`
+        : `${formatColliderReport(matches)}\n`
+    );
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`collider:inspect failed: ${message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+void main();

--- a/scripts/runtimeColliderCollector.ts
+++ b/scripts/runtimeColliderCollector.ts
@@ -1,0 +1,134 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import { chromium, type Browser, type Page } from '@playwright/test';
+
+import type { RuntimeColliderMetadata } from './colliderInspect';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:5173';
+
+type PortfolioWindow = Window & {
+  portfolio?: {
+    debugColliders?: {
+      getColliders(): RuntimeColliderMetadata[];
+    };
+  };
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function isServerReady(baseUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(baseUrl);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForServer(
+  baseUrl: string,
+  timeoutMs: number
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isServerReady(baseUrl)) {
+      return;
+    }
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for ${baseUrl}`);
+}
+
+async function collectFromImmersive(
+  page: Page,
+  baseUrl: string
+): Promise<RuntimeColliderMetadata[]> {
+  const url = new URL(baseUrl);
+  url.searchParams.set('mode', 'immersive');
+  url.searchParams.set('disablePerformanceFailover', '1');
+  try {
+    await page.goto(url.toString(), { waitUntil: 'domcontentloaded' });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes('net::ERR_ABORTED')) {
+      throw error;
+    }
+  }
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (page.isClosed()) {
+      throw new Error(
+        'Immersive runtime page closed before debug colliders loaded'
+      );
+    }
+    try {
+      const colliders = await page.evaluate(
+        () =>
+          (
+            window as PortfolioWindow
+          ).portfolio?.debugColliders?.getColliders() ?? null
+      );
+      if (colliders) {
+        return colliders;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes('Target page') ||
+        message.includes('has been closed')
+      ) {
+        throw new Error(
+          'Immersive runtime page closed before debug colliders loaded'
+        );
+      }
+      throw error;
+    }
+    await sleep(250);
+  }
+  throw new Error('Timed out waiting for debug colliders API');
+}
+
+export async function collectRuntimeColliders(
+  options: {
+    baseUrl?: string;
+    timeoutMs?: number;
+  } = {}
+): Promise<RuntimeColliderMetadata[]> {
+  const baseUrl =
+    options.baseUrl ?? process.env.PLAYWRIGHT_BASE_URL ?? DEFAULT_BASE_URL;
+  const ownsServer = !options.baseUrl && !process.env.PLAYWRIGHT_BASE_URL;
+  let server: ChildProcess | undefined;
+  let browser: Browser | undefined;
+
+  try {
+    if (ownsServer && !(await isServerReady(baseUrl))) {
+      server = spawn(
+        'npm',
+        ['run', 'dev', '--', '--host', '127.0.0.1', '--port', '5173'],
+        {
+          detached: process.platform !== 'win32',
+          stdio: 'ignore',
+          shell: process.platform === 'win32',
+        }
+      );
+    }
+    await waitForServer(baseUrl, options.timeoutMs ?? 120_000);
+
+    browser = await chromium.launch({
+      args: ['--use-gl=swiftshader', '--enable-unsafe-swiftshader'],
+    });
+    const page = await browser.newPage({
+      viewport: { width: 1280, height: 720 },
+    });
+    return await collectFromImmersive(page, baseUrl);
+  } finally {
+    await browser?.close();
+    if (server) {
+      if (process.platform === 'win32') {
+        server.kill();
+      } else if (server.pid) {
+        process.kill(-server.pid, 'SIGTERM');
+      }
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1000,6 +1000,8 @@ const colliderSourceMetadata = new Map<
       | SceneObjectDefinition['sourceId']
       | LevelSourceId;
     sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
+    role?: string;
+    intent?: string;
     purpose?: string;
     debugId?: string;
   }
@@ -2099,6 +2101,8 @@ function initializeImmersiveScene(
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
       sourceType: collider.sourceType,
+      role: collider.role,
+      intent: collider.intent,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
@@ -2144,6 +2148,8 @@ function initializeImmersiveScene(
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
       sourceType: collider.sourceType,
+      role: collider.role,
+      intent: collider.intent,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
@@ -4461,6 +4467,8 @@ function initializeImmersiveScene(
       elevation: options.elevation,
       sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
       sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
+      role: colliderSourceMetadata.get(bounds)?.role,
+      intent: colliderSourceMetadata.get(bounds)?.intent,
       purpose: colliderSourceMetadata.get(bounds)?.purpose,
       debugId: colliderSourceMetadata.get(bounds)?.debugId,
     }));

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -36,6 +36,8 @@ export interface DebugColliderMetadata {
   bounds: RectCollider;
   sourceId?: string;
   sourceType?: string;
+  role?: string;
+  intent?: string;
   purpose?: string;
   debugId?: string;
 }
@@ -50,6 +52,8 @@ export interface DebugColliderRegistration {
   color?: ColorRepresentation;
   sourceId?: string;
   sourceType?: string;
+  role?: string;
+  intent?: string;
   purpose?: string;
   debugId?: string;
 }
@@ -105,16 +109,23 @@ const cloneSourceMetadata = <
   T extends {
     sourceId?: string;
     sourceType?: string;
+    role?: string;
+    intent?: string;
     purpose?: string;
     debugId?: string;
   },
 >(
   input: T
-): Pick<T, 'sourceId' | 'sourceType' | 'purpose' | 'debugId'> => ({
+): Pick<
+  T,
+  'sourceId' | 'sourceType' | 'role' | 'intent' | 'purpose' | 'debugId'
+> => ({
   ...(typeof input.sourceId === 'string' ? { sourceId: input.sourceId } : {}),
   ...(typeof input.sourceType === 'string'
     ? { sourceType: input.sourceType }
     : {}),
+  ...(typeof input.role === 'string' ? { role: input.role } : {}),
+  ...(typeof input.intent === 'string' ? { intent: input.intent } : {}),
   ...(typeof input.purpose === 'string' ? { purpose: input.purpose } : {}),
   ...(typeof input.debugId === 'string' ? { debugId: input.debugId } : {}),
 });


### PR DESCRIPTION
### Motivation
- Provide maintainers an on-demand way to resolve a runtime collider debug ID/name/source-id without manually searching arrays or guessing ownership. 
- The tool must use the immersive runtime debug API (`window.portfolio.debugColliders`) as the source of truth so results match live scene state. 
- Surface source-backed metadata (role/intent/purpose) and geometric summaries to make removal or migration decisions safer.

### Description
- Add a new CLI command `npm run collider:inspect` (`scripts/inspect-collider.ts`) that supports `--id`, `--source-id`, `--name`, and `--json` and prints deterministic, human-readable reports.  
- Implement a reusable Playwright-backed runtime collector (`scripts/runtimeColliderCollector.ts`) that opens immersive mode with `disablePerformanceFailover=1`, reuses `PLAYWRIGHT_BASE_URL` when present, can start/stop a local Vite dev server, and cleanly tears down browser/server processes.  
- Add parsing, matching, normalization, dimensions/area calculation, explicit/generated ID classification, and overlap counting in `scripts/colliderInspect.ts`, and thread `role`/`intent` through debug metadata via `src/main.ts` and `src/scene/debug/colliderVisualizer.ts`.  
- Add unit tests `scripts/__tests__/colliderInspect.test.ts` for argument parsing, matching, formatting, and overlap logic, and update `README.md` and `package.json` with usage and `collider:inspect` script entry.

### Testing
- Ran the CLI against the local immersive runtime with example queries and JSON output, all succeeding: `npm run collider:inspect -- --id 400D` (human report), `npm run collider:inspect -- --source-id upper.stairwell.landingGuard.shoulderEast` (human report), and `npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json` (JSON output).  
- Installed Playwright browsers and host deps as needed (`npx playwright install chromium-headless-shell` and `npx playwright install-deps`) to make the runtime collector work in this environment.  
- Unit tests: ran `npm run test:ci -- scripts` and `npm run test:ci` and observed Vitest suites pass (focused script tests passed and full suite passed: 160 files, 1219 tests in this run).  
- Quality gates: ran `npm run lint` (passed with no errors), `npm run docs:check` (passed; external link probes emitted warnings), and `npm run smoke` (build/smoke passed).  

Notes: the inspector launches a headless browser and may require installing Playwright browsers and system dependencies in new environments; set `PLAYWRIGHT_BASE_URL` to reuse an existing dev server instead of starting one.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3825f9c670832f86b3d1880a0355e5)