### PR TITLE
Add runtime collider inspection CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Each floor has its own auto-generated diagram (regenerated locally with
 | `npm run smoke`                                 | Build and validate `dist/index.html`, bundled assets, and static refs. |
 | `npm run check`                                 | Convenience command chaining lint, test:ci, and docs:check.            |
 | `npm run press-kit`                             | Emit `docs/assets/press-kit.json` with POI and media manifest details. |
+| `npm run collider:inspect -- --id 400D`         | Inspect runtime collider metadata from the immersive debug API.        |
 
 ### Local quality gates
 

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -101,7 +101,18 @@ npm run preview -- --host 0.0.0.0
 # open http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
 ```
 
-In DevTools, enable and query debug APIs:
+Use the collider inspector as the first step before proposing a collider
+removal. It opens the real immersive runtime, reads
+`window.portfolio.debugColliders`, and prints the runtime ID, durable source
+metadata, bounds, dimensions, and overlap count without writing inventory files:
+
+```bash
+npm run collider:inspect -- --id 400D
+npm run collider:inspect -- --source-id upper.stairwell.landingGuard.shoulderEast
+npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json
+```
+
+In DevTools, you can still enable overlays and query debug APIs manually:
 
 ```js
 window.portfolio.debugSolids.setEnabled(true);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
     "links:check": "node scripts/check-links.cjs",
-    "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs"
+    "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
+    "collider:inspect": "tsx scripts/collider-inspect.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/collider-inspect.ts
+++ b/scripts/collider-inspect.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env tsx
+import {
+  findColliderMatches,
+  formatColliderInspection,
+  formatNoMatchError,
+  inspectColliderMatches,
+  parseColliderInspectArgs,
+} from './colliderInspection';
+import { collectRuntimeColliders } from './runtimeColliderCollector';
+
+const main = async () => {
+  const options = parseColliderInspectArgs(process.argv.slice(2));
+  const colliders = await collectRuntimeColliders();
+  const matches = findColliderMatches(colliders, options.query);
+
+  if (matches.length === 0) {
+    throw new Error(formatNoMatchError(options.query, colliders.length));
+  }
+
+  const inspected = inspectColliderMatches(matches, colliders);
+  if (options.json) {
+    console.log(JSON.stringify(inspected, null, 2));
+  } else {
+    console.log(formatColliderInspection(inspected));
+  }
+};
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/colliderInspection.test.ts
+++ b/scripts/colliderInspection.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findColliderMatches,
+  formatColliderInspection,
+  formatNoMatchError,
+  inspectColliderMatches,
+  parseColliderInspectArgs,
+  type RuntimeColliderMetadata,
+} from './colliderInspection';
+
+const colliders = [
+  {
+    id: '400D',
+    floor: 'upper',
+    category: 'upper',
+    name: 'UpperStairNorthBannisterGuard',
+    bounds: { minX: 1.1111, maxX: 2.2222, minZ: 3, maxZ: 4.5555 },
+    sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+    sourceType: 'safetyCollider',
+    role: 'shoulder-east',
+    intent: 'safety-guard',
+    purpose: 'upper stairwell landing shoulder-east guard',
+    debugId: '400D',
+  },
+  {
+    id: '1007',
+    floor: 'upper',
+    category: 'upper',
+    name: 'UpperGeneratedCollider',
+    bounds: { minX: 2, maxX: 3, minZ: 4, maxZ: 5 },
+  },
+] satisfies RuntimeColliderMetadata[];
+
+describe('collider inspection argument parsing', () => {
+  it('parses a single query and json flag', () => {
+    expect(parseColliderInspectArgs(['--id', '400d', '--json'])).toEqual({
+      query: { field: 'id', value: '400d' },
+      json: true,
+    });
+  });
+
+  it('rejects ambiguous query arguments', () => {
+    expect(() =>
+      parseColliderInspectArgs([
+        '--id',
+        '400D',
+        '--name',
+        'UpperGeneratedCollider',
+      ])
+    ).toThrow('Pass exactly one');
+  });
+});
+
+describe('collider inspection matching', () => {
+  it('matches ids case-insensitively and source ids exactly', () => {
+    expect(
+      findColliderMatches(colliders, { field: 'id', value: '400d' })
+    ).toEqual([colliders[0]]);
+    expect(
+      findColliderMatches(colliders, {
+        field: 'sourceId',
+        value: 'upper.stairwell.landingGuard.shoulderEast',
+      })
+    ).toEqual([colliders[0]]);
+  });
+
+  it('adds normalized dimensions and active overlap counts', () => {
+    expect(inspectColliderMatches([colliders[0]], colliders)).toEqual([
+      expect.objectContaining({
+        bounds: { minX: 1.111, maxX: 2.222, minZ: 3, maxZ: 4.556 },
+        dimensions: { width: 1.111, depth: 1.556, area: 1.729 },
+        debugIdKind: 'explicit',
+        overlapCount: 1,
+      }),
+    ]);
+  });
+});
+
+describe('collider inspection formatting', () => {
+  it('renders source metadata, intent, bounds, and debug id provenance', () => {
+    const output = formatColliderInspection(
+      inspectColliderMatches([colliders[0]], colliders)
+    );
+
+    expect(output).toContain('Debug ID: 400D');
+    expect(output).toContain(
+      'Source ID: upper.stairwell.landingGuard.shoulderEast'
+    );
+    expect(output).toContain('Semantic intent: safety-guard');
+    expect(output).toContain('Debug ID kind: explicit');
+    expect(output).toContain('Overlapping active colliders: 1');
+  });
+
+  it('renders no-match context', () => {
+    expect(formatNoMatchError({ field: 'name', value: 'Missing' }, 2)).toBe(
+      'No collider matched name=Missing. Searched 2 active colliders.'
+    );
+  });
+});

--- a/scripts/colliderInspection.ts
+++ b/scripts/colliderInspection.ts
@@ -1,0 +1,145 @@
+import type { DebugColliderMetadata } from '../src/scene/debug/colliderVisualizer';
+
+export type ColliderInspectQuery =
+  | { field: 'id'; value: string }
+  | { field: 'sourceId'; value: string }
+  | { field: 'name'; value: string };
+
+export interface ColliderInspectOptions {
+  query: ColliderInspectQuery;
+  json: boolean;
+}
+
+export type RuntimeColliderMetadata = DebugColliderMetadata;
+
+export interface InspectedCollider extends RuntimeColliderMetadata {
+  dimensions: { width: number; depth: number; area: number };
+  debugIdKind: 'explicit' | 'generated';
+  overlapCount: number;
+}
+
+const round = (value: number): number =>
+  Object.is(value, -0) ? 0 : Number(value.toFixed(3));
+
+const normalizeId = (value: string): string => value.toUpperCase();
+
+export const parseColliderInspectArgs = (
+  argv: readonly string[]
+): ColliderInspectOptions => {
+  let query: ColliderInspectQuery | undefined;
+  let json = false;
+
+  const setQuery = (field: ColliderInspectQuery['field'], value: string) => {
+    if (query) {
+      throw new Error('Pass exactly one of --id, --source-id, or --name.');
+    }
+    if (!value || value.startsWith('--')) {
+      throw new Error(
+        `Missing value for --${field === 'sourceId' ? 'source-id' : field}.`
+      );
+    }
+    query = { field, value } as ColliderInspectQuery;
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--id') {
+      setQuery('id', argv[++index] ?? '');
+    } else if (arg === '--source-id') {
+      setQuery('sourceId', argv[++index] ?? '');
+    } else if (arg === '--name') {
+      setQuery('name', argv[++index] ?? '');
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!query) {
+    throw new Error('Pass one of --id, --source-id, or --name.');
+  }
+
+  return { query, json };
+};
+
+export const findColliderMatches = (
+  colliders: readonly RuntimeColliderMetadata[],
+  query: ColliderInspectQuery
+): RuntimeColliderMetadata[] => {
+  if (query.field === 'id') {
+    const id = normalizeId(query.value);
+    return colliders.filter(
+      (collider) => collider.id === id || collider.debugId === id
+    );
+  }
+  if (query.field === 'sourceId') {
+    return colliders.filter((collider) => collider.sourceId === query.value);
+  }
+  return colliders.filter((collider) => collider.name === query.value);
+};
+
+const overlaps = (
+  a: RuntimeColliderMetadata,
+  b: RuntimeColliderMetadata
+): boolean =>
+  a.id !== b.id &&
+  a.bounds.minX < b.bounds.maxX &&
+  a.bounds.maxX > b.bounds.minX &&
+  a.bounds.minZ < b.bounds.maxZ &&
+  a.bounds.maxZ > b.bounds.minZ &&
+  (a.floor === b.floor || a.floor === 'all' || b.floor === 'all');
+
+export const inspectColliderMatches = (
+  matches: readonly RuntimeColliderMetadata[],
+  allColliders: readonly RuntimeColliderMetadata[]
+): InspectedCollider[] =>
+  matches.map((collider) => {
+    const width = round(collider.bounds.maxX - collider.bounds.minX);
+    const depth = round(collider.bounds.maxZ - collider.bounds.minZ);
+    return {
+      ...collider,
+      bounds: {
+        minX: round(collider.bounds.minX),
+        maxX: round(collider.bounds.maxX),
+        minZ: round(collider.bounds.minZ),
+        maxZ: round(collider.bounds.maxZ),
+      },
+      dimensions: { width, depth, area: round(width * depth) },
+      debugIdKind: collider.debugId ? 'explicit' : 'generated',
+      overlapCount: allColliders.filter((next) => overlaps(collider, next))
+        .length,
+    };
+  });
+
+export const formatColliderInspection = (
+  colliders: readonly InspectedCollider[]
+): string =>
+  colliders
+    .map((collider, index) => {
+      const lines =
+        colliders.length > 1 ? [`Match ${index + 1}/${colliders.length}`] : [];
+      lines.push(
+        `Debug ID: ${collider.id}`,
+        `Runtime name: ${collider.name}`,
+        `Source ID: ${collider.sourceId ?? '(unavailable)'}`,
+        `Source type: ${collider.sourceType ?? '(unavailable)'}`,
+        `Semantic role: ${collider.role ?? '(unavailable)'}`,
+        `Semantic intent: ${collider.intent ?? '(unavailable)'}`,
+        `Purpose: ${collider.purpose ?? '(unavailable)'}`,
+        `Floor: ${collider.floor}`,
+        `Category: ${collider.category}`,
+        `Bounds: minX=${collider.bounds.minX}, maxX=${collider.bounds.maxX}, minZ=${collider.bounds.minZ}, maxZ=${collider.bounds.maxZ}`,
+        `Dimensions: width=${collider.dimensions.width}, depth=${collider.dimensions.depth}, area=${collider.dimensions.area}`,
+        `Debug ID kind: ${collider.debugIdKind}`,
+        `Overlapping active colliders: ${collider.overlapCount}`
+      );
+      return lines.join('\n');
+    })
+    .join('\n\n');
+
+export const formatNoMatchError = (
+  query: ColliderInspectQuery,
+  colliderCount: number
+): string =>
+  `No collider matched ${query.field}=${query.value}. Searched ${colliderCount} active colliders.`;

--- a/scripts/runtimeColliderCollector.ts
+++ b/scripts/runtimeColliderCollector.ts
@@ -1,0 +1,90 @@
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+
+import { chromium } from '@playwright/test';
+
+import type { RuntimeColliderMetadata } from './colliderInspection';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:5173';
+const READY_TIMEOUT_MS = 120_000;
+
+const createImmersiveUrl = (baseUrl: string): string => {
+  const url = new URL(baseUrl);
+  url.searchParams.set('mode', 'immersive');
+  url.searchParams.set('disablePerformanceFailover', '1');
+  return url.toString();
+};
+
+const waitForServer = async (baseUrl: string): Promise<void> => {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(baseUrl);
+      if (response.ok || response.status === 404) return;
+    } catch {
+      // Retry until Vite has finished booting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Timed out waiting for Vite server at ${baseUrl}.`);
+};
+
+const startServer = (): ChildProcess =>
+  spawn('npm', ['run', 'dev', '--', '--host', '127.0.0.1', '--port', '5173'], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, BROWSER: 'none' },
+  });
+
+const stopServer = async (server: ChildProcess): Promise<void> => {
+  if (server.exitCode !== null || server.signalCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, 5_000);
+    server.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    try {
+      process.kill(-server.pid!, 'SIGTERM');
+    } catch {
+      server.kill('SIGTERM');
+    }
+  });
+};
+
+export const collectRuntimeColliders = async (
+  options: {
+    baseUrl?: string;
+  } = {}
+): Promise<RuntimeColliderMetadata[]> => {
+  const baseUrl =
+    options.baseUrl ?? process.env.PLAYWRIGHT_BASE_URL ?? DEFAULT_BASE_URL;
+  const ownsServer = !options.baseUrl && !process.env.PLAYWRIGHT_BASE_URL;
+  const server = ownsServer ? startServer() : undefined;
+  const browser = await chromium.launch();
+
+  try {
+    await waitForServer(baseUrl);
+    const page = await browser.newPage({
+      viewport: { width: 1280, height: 720 },
+    });
+    await page.goto(createImmersiveUrl(baseUrl), { waitUntil: 'networkidle' });
+    await page.waitForFunction(
+      () => Boolean(window.portfolio?.debugColliders),
+      null,
+      {
+        timeout: READY_TIMEOUT_MS,
+      }
+    );
+    return await page.evaluate(() =>
+      window.portfolio!.debugColliders!.getColliders()
+    );
+  } finally {
+    await browser.close();
+    if (server) {
+      await stopServer(server);
+    }
+  }
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1000,6 +1000,8 @@ const colliderSourceMetadata = new Map<
       | SceneObjectDefinition['sourceId']
       | LevelSourceId;
     sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
+    role?: string;
+    intent?: string;
     purpose?: string;
     debugId?: string;
   }
@@ -2099,6 +2101,8 @@ function initializeImmersiveScene(
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
       sourceType: collider.sourceType,
+      role: collider.role,
+      intent: collider.intent,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
@@ -2144,6 +2148,8 @@ function initializeImmersiveScene(
     colliderSourceMetadata.set(collider.bounds, {
       sourceId: collider.sourceId,
       sourceType: collider.sourceType,
+      role: collider.role,
+      intent: collider.intent,
       purpose: collider.purpose,
       debugId: collider.debugId,
     });
@@ -4461,6 +4467,8 @@ function initializeImmersiveScene(
       elevation: options.elevation,
       sourceId: colliderSourceMetadata.get(bounds)?.sourceId,
       sourceType: colliderSourceMetadata.get(bounds)?.sourceType,
+      role: colliderSourceMetadata.get(bounds)?.role,
+      intent: colliderSourceMetadata.get(bounds)?.intent,
       purpose: colliderSourceMetadata.get(bounds)?.purpose,
       debugId: colliderSourceMetadata.get(bounds)?.debugId,
     }));

--- a/src/scene/debug/colliderVisualizer.ts
+++ b/src/scene/debug/colliderVisualizer.ts
@@ -36,6 +36,8 @@ export interface DebugColliderMetadata {
   bounds: RectCollider;
   sourceId?: string;
   sourceType?: string;
+  role?: string;
+  intent?: string;
   purpose?: string;
   debugId?: string;
 }
@@ -50,6 +52,8 @@ export interface DebugColliderRegistration {
   color?: ColorRepresentation;
   sourceId?: string;
   sourceType?: string;
+  role?: string;
+  intent?: string;
   purpose?: string;
   debugId?: string;
 }
@@ -105,6 +109,8 @@ const cloneSourceMetadata = <
   T extends {
     sourceId?: string;
     sourceType?: string;
+    role?: string;
+    intent?: string;
     purpose?: string;
     debugId?: string;
   },
@@ -115,6 +121,8 @@ const cloneSourceMetadata = <
   ...(typeof input.sourceType === 'string'
     ? { sourceType: input.sourceType }
     : {}),
+  ...(typeof input.role === 'string' ? { role: input.role } : {}),
+  ...(typeof input.intent === 'string' ? { intent: input.intent } : {}),
   ...(typeof input.purpose === 'string' ? { purpose: input.purpose } : {}),
   ...(typeof input.debugId === 'string' ? { debugId: input.debugId } : {}),
 });


### PR DESCRIPTION
### Motivation
- Provide maintainers an on-demand way to resolve runtime collider debug IDs, source IDs, or runtime names against the real immersive runtime without scanning arrays or creating static manifests.
- Prefer consuming the existing `window.portfolio.debugColliders` debug API and reuse Playwright orchestration so future audit tools (Prompts 6/7) can share the browser collector.

### Description
- Add a CLI `npm run collider:inspect` (`scripts/collider-inspect.ts`) that supports `--id`, `--source-id`, `--name`, and `--json`, and prints deterministic human-readable or JSON reports including bounds, dimensions, area, debug-ID provenance, and overlap counts.
- Implement parsing/matching/formatting helpers in `scripts/colliderInspection.ts` and unit tests in `scripts/colliderInspection.test.ts` to validate parsing, matching, formatting, rounding, and overlap logic.
- Add a reusable Playwright-based runtime collector `scripts/runtimeColliderCollector.ts` that launches or reuses a local Vite preview (loads `?mode=immersive&disablePerformanceFailover=1`), waits for `window.portfolio.debugColliders`, collects collider metadata, and shuts down cleanly.
- Preserve and expose semantic source metadata (`role` and `intent`) through the debug path by adding optional `role`/`intent` to `DebugColliderMetadata` and plumbing them from `src/main.ts` into the visualizer registration.
- Document the inspector as the recommended first step before proposing collider removal in `docs/design/editing-level-data.md` and add the new `collider:inspect` script to `package.json`/`README.md`.

### Testing
- Ran unit tests for the new helpers with `npm run test:ci -- scripts`, and `scripts/colliderInspection.test.ts` passed (6 tests) — PASS.
- Exercised the CLI against the local runtime: `npm run collider:inspect -- --id 400D`, `npm run collider:inspect -- --source-id upper.stairwell.landingGuard.shoulderEast`, and `npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json`, which returned expected metadata and JSON output — PASS.
- Ran repo quality gates: `npm run format:write`, `npm run lint`, full `npm run test:ci` (160 files / 1220 tests), `npm run docs:check`, and `npm run smoke`, and all completed successfully in the run above — PASS.
- Note: the CLI uses Playwright and the headless shell; local runs may need `npx playwright install` (and `npx playwright install-deps` on Linux) to download browsers and host dependencies before invoking `npm run collider:inspect`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a385cb8a6dc832fbf491f315648be9a)