### PR TITLE
🧪 Add collider declaration contracts

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -196,3 +196,15 @@ the Futuroptimist media wall declares its wall-mounted visual media policy in
 highlight remain rendered while no floor-level collider is emitted. Emitted
 records should pass that source metadata through to runtime registration directly
 rather than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.
+
+Regression tests for migrated collider families should reuse the pure validators
+in `src/scene/level/colliderDeclarationContracts.ts` instead of copying policy
+shape checks into each suite. Keep family expectations focused on meaningful
+behavior: physical-boundary families should prove their semantic records are
+emitted, visual-only policies should prove no collider is emitted, and synthetic
+generator tests may keep exact geometry when the numbers are local fixtures.
+Tests that need production room or floor bounds should request them from
+`src/tests/helpers/productionLevelTestHelpers.ts`, which clones the canonical
+`PORTFOLIO_LEVEL` data by semantic ID and throws when an ID is missing. Avoid
+proportional scaling or repeated production coordinate literals in regression
+tests.

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -5,11 +5,9 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from '../../../systems/movement/stairs';
-import {
-  assertDebugColliderIdsDoNotCollide,
-  isDebugColliderId,
-} from '../../debug/colliderDebugIds';
+import { assertDebugColliderIdsDoNotCollide } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
+import { validateActiveSourceColliderRecords } from '../colliderDeclarationContracts';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -98,30 +96,18 @@ describe('stair safety collider source definitions', () => {
     });
   });
 
-  it('assigns every safety collider a source ID and purpose without duplicates', () => {
+  it('satisfies the shared active source-backed collider contract', () => {
     const colliders = collectSafetyColliders();
-    const sourceIds = colliders.map((collider) => String(collider.sourceId));
 
-    expect(
-      colliders.every(
-        (collider) => collider.sourceId && collider.purpose.trim()
-      )
-    ).toBe(true);
-    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(() => validateActiveSourceColliderRecords(colliders)).not.toThrow();
   });
 
-  it('keeps active safety collider debug IDs valid, unique, and collision-free', () => {
+  it('keeps active safety collider debug IDs collision-free', () => {
     const colliders = collectSafetyColliders();
     const declaredIds = colliders.map(
       (collider) => [collider.name, collider.debugId] as const
     );
 
-    colliders.forEach((collider) => {
-      expect(isDebugColliderId(collider.debugId)).toBe(true);
-    });
-    expect(new Set(colliders.map((collider) => collider.debugId)).size).toBe(
-      colliders.length
-    );
     expect(() => assertDebugColliderIdsDoNotCollide(declaredIds)).not.toThrow();
   });
 

--- a/src/scene/level/colliderDeclarationContracts.ts
+++ b/src/scene/level/colliderDeclarationContracts.ts
@@ -1,0 +1,168 @@
+import type { RectCollider } from '../../systems/collision';
+import { isDebugColliderId } from '../debug/colliderDebugIds';
+
+import type {
+  SourceBackedCollider,
+  SourceCollisionPolicy,
+} from './sourceCollision';
+import { isActiveSourceCollisionPolicy } from './sourceCollision';
+import { isLevelSourceId } from './sourceIds';
+
+export interface SourcePolicyContractInput {
+  readonly sourceId: unknown;
+  readonly role: unknown;
+  readonly collision: SourceCollisionPolicy;
+}
+
+export type SourceBackedColliderRecord = SourceBackedCollider<
+  string,
+  string,
+  string
+> &
+  Partial<RectCollider>;
+
+export interface ActiveRecordValidationOptions {
+  readonly allowMultipleBoundsFor?: ReadonlySet<string> | readonly string[];
+}
+
+const hasText = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const validateBounds = (bounds: RectCollider, label: string): string[] => {
+  const errors: string[] = [];
+  const values = [bounds.minX, bounds.maxX, bounds.minZ, bounds.maxZ];
+
+  if (values.some((value) => !Number.isFinite(value))) {
+    errors.push(`${label} bounds must be finite.`);
+  }
+  if (!(bounds.minX < bounds.maxX) || !(bounds.minZ < bounds.maxZ)) {
+    errors.push(`${label} bounds must be normalized.`);
+  }
+
+  return errors;
+};
+
+const assertNoErrors = (errors: string[], label: string): void => {
+  if (errors.length > 0) {
+    throw new Error(
+      `${label} failed collider contract validation:\n- ${errors.join('\n- ')}`
+    );
+  }
+};
+
+export const validateSourceCollisionPolicy = (
+  policy: SourcePolicyContractInput,
+  label = String(policy.role || policy.sourceId || 'source policy')
+): void => {
+  const errors: string[] = [];
+
+  if (!isLevelSourceId(policy.sourceId)) {
+    errors.push(
+      `${label} sourceId must be a valid hierarchical level source ID.`
+    );
+  }
+  if (!hasText(policy.role)) {
+    errors.push(`${label} role must be nonempty.`);
+  }
+
+  if (isActiveSourceCollisionPolicy(policy.collision)) {
+    if (!hasText(policy.collision.intent)) {
+      errors.push(`${label} active collision policy requires intent.`);
+    }
+    if (!hasText(policy.collision.purpose)) {
+      errors.push(`${label} active collision policy requires purpose.`);
+    }
+    if (!hasText(policy.collision.runtimeName)) {
+      errors.push(`${label} active collision policy requires runtimeName.`);
+    }
+    if (
+      policy.collision.debugId !== undefined &&
+      !isDebugColliderId(policy.collision.debugId)
+    ) {
+      errors.push(
+        `${label} explicit debugId must be a valid debug collider ID.`
+      );
+    }
+  } else if (!hasText(policy.collision.rationale)) {
+    errors.push(`${label} no-collision policy requires a nonempty rationale.`);
+  }
+
+  assertNoErrors(errors, label);
+};
+
+export const validateSourceCollisionPolicies = (
+  policies: readonly SourcePolicyContractInput[],
+  label = 'source policies'
+): void => {
+  const errors: string[] = [];
+  policies.forEach((policy) => {
+    try {
+      validateSourceCollisionPolicy(policy);
+    } catch (error) {
+      errors.push((error as Error).message);
+    }
+  });
+  assertNoErrors(errors, label);
+};
+
+export const validateActiveSourceColliderRecords = (
+  records: readonly SourceBackedColliderRecord[],
+  options: ActiveRecordValidationOptions = {},
+  label = 'active collider records'
+): void => {
+  const errors: string[] = [];
+  const debugIds = new Map<string, string>();
+  const sourceRoleKeys = new Map<string, string>();
+  const multiBoundFamilies = new Set(options.allowMultipleBoundsFor ?? []);
+
+  records.forEach((record) => {
+    const recordLabel = record.name || `${record.sourceId}:${record.role}`;
+    const bounds = record.bounds ?? record;
+    errors.push(...validateBounds(bounds, recordLabel));
+
+    if (!isLevelSourceId(record.sourceId)) {
+      errors.push(`${recordLabel} sourceId must be valid source metadata.`);
+    }
+    if (!hasText(record.sourceType)) {
+      errors.push(`${recordLabel} sourceType must be valid source metadata.`);
+    }
+    if (!hasText(record.role)) {
+      errors.push(`${recordLabel} role must be nonempty.`);
+    }
+    if (!hasText(record.intent)) {
+      errors.push(`${recordLabel} intent must be nonempty.`);
+    }
+    if (!hasText(record.purpose)) {
+      errors.push(`${recordLabel} purpose must be nonempty.`);
+    }
+    if (!hasText(record.name)) {
+      errors.push(`${recordLabel} runtime name must be nonempty.`);
+    }
+
+    if (record.debugId !== undefined) {
+      if (!isDebugColliderId(record.debugId)) {
+        errors.push(`${recordLabel} explicit debugId must be valid.`);
+      }
+      const prior = debugIds.get(record.debugId);
+      if (prior) {
+        errors.push(
+          `${recordLabel} duplicates explicit debugId ${record.debugId} from ${prior}.`
+        );
+      }
+      debugIds.set(record.debugId, recordLabel);
+    }
+
+    const sourceRoleKey = `${record.sourceId}::${record.role}`;
+    if (!multiBoundFamilies.has(sourceRoleKey)) {
+      const prior = sourceRoleKeys.get(sourceRoleKey);
+      if (prior) {
+        errors.push(
+          `${recordLabel} duplicates source/role ${sourceRoleKey} from ${prior}.`
+        );
+      }
+      sourceRoleKeys.set(sourceRoleKey, recordLabel);
+    }
+  });
+
+  assertNoErrors(errors, label);
+};

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,8 +1,11 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { isDebugColliderId } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
+import {
+  validateActiveSourceColliderRecords,
+  validateSourceCollisionPolicies,
+} from '../../level/colliderDeclarationContracts';
 import { assertLevelSourceId } from '../../level/sourceIds';
 import {
   UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
@@ -148,6 +151,12 @@ describe('createUpperStairwellLanding', () => {
       'UpperStairwellLandingFarGuard',
       'UpperStairwellLandingShoulderGuard-East',
     ]);
+    expect(() =>
+      validateSourceCollisionPolicies(UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES)
+    ).not.toThrow();
+    expect(() =>
+      validateActiveSourceColliderRecords(result.colliders)
+    ).not.toThrow();
     expect(result.colliders).toEqual([
       {
         role: 'shoulder-east',
@@ -186,12 +195,9 @@ describe('createUpperStairwellLanding', () => {
       segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
     });
 
-    const explicitDebugIds = result.colliders.flatMap((collider) =>
-      collider.debugId ? [collider.debugId] : []
-    );
-
-    expect(explicitDebugIds.every(isDebugColliderId)).toBe(true);
-    expect(new Set(explicitDebugIds).size).toBe(explicitDebugIds.length);
+    expect(() =>
+      validateActiveSourceColliderRecords(result.colliders)
+    ).not.toThrow();
     result.colliders.forEach((collider) => {
       if (!collider.debugId) return;
       expect(

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -29,9 +29,11 @@ import {
   type SpyInstance,
 } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
 import { createBackyardEnvironment } from '../scene/environments/backyard';
+import { validateActiveSourceColliderRecords } from '../scene/level/colliderDeclarationContracts';
 import type { SeasonalLightingPreset } from '../scene/lighting/seasonalPresets';
+
+import { getProductionRoomBounds } from './helpers/productionLevelTestHelpers';
 
 const BACKYARD_BOUNDS = {
   minX: -10,
@@ -1347,25 +1349,32 @@ describe('createBackyardEnvironment', () => {
       true
     );
 
-    const productionBackyardBounds = FLOOR_PLAN.rooms.find(
-      (room) => room.id === 'backyard'
-    )?.bounds;
-    expect(productionBackyardBounds).toBeDefined();
+    const productionBackyardBounds = getProductionRoomBounds('backyard');
     const productionEnvironment = createBackyardEnvironment(
-      productionBackyardBounds!
+      productionBackyardBounds
     );
-    const productionBackFenceSampleZ = productionBackyardBounds!.maxZ - 1.8;
+    expect(() =>
+      validateActiveSourceColliderRecords(
+        productionEnvironment.colliders.filter((collider) =>
+          String((collider as { sourceId?: string }).sourceId ?? '').startsWith(
+            'ground.backyard.'
+          )
+        ) as Parameters<typeof validateActiveSourceColliderRecords>[0]
+      )
+    ).not.toThrow();
+    const productionBackFenceSampleZ = productionBackyardBounds.maxZ - 1.8;
     const productionBackFenceSamples = [
       {
-        x:
-          (productionBackyardBounds!.minX + productionBackyardBounds!.maxX) / 2,
+        x: (productionBackyardBounds.minX + productionBackyardBounds.maxX) / 2,
         z: productionBackFenceSampleZ,
       },
       { x: 5, z: productionBackFenceSampleZ },
       { x: -5, z: productionBackFenceSampleZ },
     ];
     expect(productionBackFenceSamples[1].x).toBe(5);
-    expect(productionBackFenceSamples[1].z).toBeCloseTo(30.2, 5);
+    expect(productionBackFenceSamples[1].z).toBe(
+      productionBackyardBounds.maxZ - 1.8
+    );
 
     expect(
       productionBackFenceSamples.every(

--- a/src/tests/helpers/productionLevelTestHelpers.ts
+++ b/src/tests/helpers/productionLevelTestHelpers.ts
@@ -1,0 +1,33 @@
+import { PORTFOLIO_LEVEL } from '../../scene/level/portfolioLevel';
+import type { Bounds2D } from '../../scene/level/schema';
+
+const cloneBounds = (bounds: Bounds2D): Bounds2D => ({ ...bounds });
+
+export const getProductionRoomBounds = (roomId: string): Bounds2D => {
+  for (const floor of PORTFOLIO_LEVEL.floors) {
+    const room = floor.rooms.find((candidate) => candidate.id === roomId);
+    if (room) return cloneBounds(room.bounds);
+  }
+
+  throw new Error(`Missing production room "${roomId}" in PORTFOLIO_LEVEL.`);
+};
+
+export const getProductionFloorBounds = (floorId: string): Bounds2D => {
+  const floor = PORTFOLIO_LEVEL.floors.find(
+    (candidate) => candidate.id === floorId
+  );
+  if (!floor) {
+    throw new Error(
+      `Missing production floor "${floorId}" in PORTFOLIO_LEVEL.`
+    );
+  }
+
+  const xs = floor.outline.map(([x]) => x);
+  const zs = floor.outline.map(([, z]) => z);
+  return {
+    minX: Math.min(...xs),
+    maxX: Math.max(...xs),
+    minZ: Math.min(...zs),
+    maxZ: Math.max(...zs),
+  };
+};

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -8,6 +8,7 @@ import {
   vi,
 } from 'vitest';
 
+import { validateSourceCollisionPolicy } from '../scene/level/colliderDeclarationContracts';
 import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../scene/level/mediaWallPolicy';
 import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
 
@@ -172,6 +173,9 @@ describe('createLivingRoomMediaWall', () => {
   });
 
   it('declares the media POI as an active visual-only source policy', () => {
+    expect(() =>
+      validateSourceCollisionPolicy(FUTUROPTIMIST_MEDIA_WALL_POLICY)
+    ).not.toThrow();
     expect(FUTUROPTIMIST_MEDIA_WALL_POLICY).toMatchObject({
       role: 'living-room-futuroptimist-media',
       subsystemRole: 'poi-media-wall',


### PR DESCRIPTION
### Motivation
- Replace repeated, bespoke collider policy and record assertions with small reusable, pure validators to simplify migrated source-owned collision tests.
- Provide a canonical way for tests to obtain production room/floor bounds from `PORTFOLIO_LEVEL` so suites stop copying or proportionally scaling production coordinates.
- Keep family-specific behavior checks (stair, landing, backyard, media wall) while removing fragile inventory/count assertions and raw production literals.

### Description
- Add `src/scene/level/colliderDeclarationContracts.ts` implementing `validateSourceCollisionPolicy`, `validateSourceCollisionPolicies`, and `validateActiveSourceColliderRecords` to enforce sourceId format, policy shape, finite/normalized bounds, debug-id uniqueness, and `(sourceId, role)` uniqueness with an opt-in multi-bound escape hatch.
- Add `src/tests/helpers/productionLevelTestHelpers.ts` with `getProductionRoomBounds` and `getProductionFloorBounds` that clone values from `PORTFOLIO_LEVEL` and throw useful errors when missing.
- Migrate targeted tests to use the new contracts and helpers in `src/scene/level/__tests__/stairSafetyColliders.test.ts`, `src/scene/structures/__tests__/upperStairwellLanding.test.ts`, `src/tests/backyardEnvironment.test.ts`, and `src/tests/mediaWall.test.ts` while preserving generator- and behavior-specific expectations.
- Update docs (`docs/design/editing-level-data.md`) to recommend using the validators and production helpers for migrated collider-family regression tests.

### Testing
- Ran formatting: `npm run format:write` (succeeded).
- Ran focused tests: `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts src/tests/backyardEnvironment.test.ts src/tests/mediaWall.test.ts` (succeeded after small fixes).
- Ran full CI test suite: `npm run test:ci` which completed with all tests passing (`1226` tests passed in the run reported by CI).
- Lint and docs/smoke checks: `npm run lint` (passed after minor test-file tweaks), `npm run docs:check` (passed; link checker printed network warnings for external URLs), and `npm run smoke` (build + artifact assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38793fb34c832fa9c7c06fd70e9918)