### PR TITLE
Add source-backed collider validation and production fixture helpers

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -196,3 +196,13 @@ the Futuroptimist media wall declares its wall-mounted visual media policy in
 highlight remain rendered while no floor-level collider is emitted. Emitted
 records should pass that source metadata through to runtime registration directly
 rather than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.
+Use `validateSourceCollisionPolicy(...)` and
+`validateSourceCollisionRecords(...)` from
+`src/scene/level/sourceCollisionValidation.ts` for focused family tests instead
+of repeating one-off policy shape checks or snapshotting the full scene.
+
+Production-coordinate regression tests should obtain canonical room or floor
+bounds through the narrow production fixture helpers in
+`src/tests/helpers/productionLevelFixtures.ts`. Request the semantic floor and
+room IDs needed by the test, and keep exact geometry literals limited to small
+synthetic fixtures where the generator output itself is under test.

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -5,11 +5,9 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from '../../../systems/movement/stairs';
-import {
-  assertDebugColliderIdsDoNotCollide,
-  isDebugColliderId,
-} from '../../debug/colliderDebugIds';
+import { assertDebugColliderIdsDoNotCollide } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
+import { validateSourceCollisionRecords } from '../sourceCollisionValidation';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -98,29 +96,16 @@ describe('stair safety collider source definitions', () => {
     });
   });
 
-  it('assigns every safety collider a source ID and purpose without duplicates', () => {
-    const colliders = collectSafetyColliders();
-    const sourceIds = colliders.map((collider) => String(collider.sourceId));
-
-    expect(
-      colliders.every(
-        (collider) => collider.sourceId && collider.purpose.trim()
-      )
-    ).toBe(true);
-    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+  it('satisfies the source-backed active collider contract', () => {
+    expect(validateSourceCollisionRecords(collectSafetyColliders())).toEqual(
+      []
+    );
   });
 
-  it('keeps active safety collider debug IDs valid, unique, and collision-free', () => {
+  it('keeps active safety collider debug IDs collision-free against generated IDs', () => {
     const colliders = collectSafetyColliders();
     const declaredIds = colliders.map(
       (collider) => [collider.name, collider.debugId] as const
-    );
-
-    colliders.forEach((collider) => {
-      expect(isDebugColliderId(collider.debugId)).toBe(true);
-    });
-    expect(new Set(colliders.map((collider) => collider.debugId)).size).toBe(
-      colliders.length
     );
     expect(() => assertDebugColliderIdsDoNotCollide(declaredIds)).not.toThrow();
   });
@@ -136,13 +121,6 @@ describe('stair safety collider source definitions', () => {
           debugId: collider.debugId,
         })
       ).toBe(collider.debugId);
-    });
-  });
-  it('keeps safety collider source IDs free of tombstone wording', () => {
-    collectSafetyColliders().forEach((collider) => {
-      expect(String(collider.sourceId)).not.toMatch(
-        /\.(former|removed|debugonlyremoval)\./i
-      );
     });
   });
 });

--- a/src/scene/level/sourceCollisionValidation.test.ts
+++ b/src/scene/level/sourceCollisionValidation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import type { CollisionIntent } from './sourceCollision';
 import {
+  getSourceRoleFamilyKey,
   validateSourceCollisionPolicy,
   validateSourceCollisionRecords,
   type SourceCollisionRecord,
@@ -59,6 +61,71 @@ describe('source collision validation', () => {
       );
     }
   );
+
+  it('rejects non-empty active policy intents outside the collision intent set', () => {
+    expect(
+      validateSourceCollisionPolicy({
+        role: 'guard',
+        sourceId: assertLevelSourceId('upper.stairwell.safetyCollider'),
+        collision: {
+          collision: 'active',
+          intent: 'safety-gaurd' as CollisionIntent,
+          purpose: 'Keep the player inside the playable stairwell path.',
+          runtimeName: 'UpperStairwellSafetyGuard',
+        },
+      })
+    ).toContain(
+      'Active policy upper.stairwell.safetyCollider has invalid intent "safety-gaurd".'
+    );
+  });
+
+  it('rejects non-empty emitted record intents outside the collision intent set', () => {
+    expect(
+      validateSourceCollisionRecords([
+        createRecord({
+          intent: 'safety-gaurd' as CollisionIntent,
+        }),
+      ])
+    ).toContain(
+      'upper.stairwell.safetyCollider (guard) has invalid intent "safety-gaurd".'
+    );
+  });
+
+  it('allows duplicate active records only for explicitly named source-role families', () => {
+    const sourceId = assertLevelSourceId('upper.stairwell.safetyCollider');
+    const otherSourceId = assertLevelSourceId(
+      'ground.stairwell.safetyCollider'
+    );
+
+    expect(
+      validateSourceCollisionRecords(
+        [
+          createRecord({ sourceId }),
+          createRecord({ sourceId, bounds: { ...bounds, minX: 2, maxX: 3 } }),
+        ],
+        {
+          allowMultipleBoundsFor: [getSourceRoleFamilyKey(sourceId, 'guard')],
+        }
+      )
+    ).toEqual([]);
+
+    expect(
+      validateSourceCollisionRecords(
+        [
+          createRecord({ sourceId: otherSourceId }),
+          createRecord({
+            sourceId: otherSourceId,
+            bounds: { ...bounds, minX: 2, maxX: 3 },
+          }),
+        ],
+        {
+          allowMultipleBoundsFor: [getSourceRoleFamilyKey(sourceId, 'guard')],
+        }
+      )
+    ).toContain(
+      'Duplicate active source/role ground.stairwell.safetyCollider (guard); already used by ground.stairwell.safetyCollider (guard).'
+    );
+  });
 
   it('rejects source types outside the known level source type set', () => {
     expect(

--- a/src/scene/level/sourceCollisionValidation.test.ts
+++ b/src/scene/level/sourceCollisionValidation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  validateSourceCollisionPolicy,
+  validateSourceCollisionRecords,
+  type SourceCollisionRecord,
+} from './sourceCollisionValidation';
+import { assertLevelSourceId } from './sourceIds';
+
+const bounds = {
+  minX: 0,
+  maxX: 1,
+  minZ: 0,
+  maxZ: 1,
+};
+
+const createRecord = (
+  overrides: Partial<SourceCollisionRecord<'guard'>> = {}
+): SourceCollisionRecord<'guard'> => ({
+  role: 'guard',
+  sourceId: assertLevelSourceId('upper.stairwell.safetyCollider'),
+  sourceType: 'safetyCollider',
+  intent: 'safety-guard',
+  purpose: 'Keep the player inside the playable stairwell path.',
+  bounds,
+  name: 'UpperStairwellSafetyGuard',
+  ...overrides,
+});
+
+describe('source collision validation', () => {
+  it.each(['former', 'removed', 'debugonlyremoval'])(
+    'rejects %s source ID segments for policies and records',
+    (term) => {
+      const sourceId = assertLevelSourceId(`upper.stairwell.${term}.guard`);
+
+      expect(
+        validateSourceCollisionPolicy({
+          role: 'guard',
+          sourceId,
+          collision: {
+            collision: 'active',
+            intent: 'safety-guard',
+            purpose: 'Keep the player inside the playable stairwell path.',
+            runtimeName: 'UpperStairwellSafetyGuard',
+          },
+        })
+      ).toContain(
+        `Policy guard sourceId "upper.stairwell.${term}.guard" uses forbidden tombstone wording.`
+      );
+
+      expect(
+        validateSourceCollisionRecords([
+          createRecord({
+            sourceId,
+          }),
+        ])
+      ).toContain(
+        `upper.stairwell.${term}.guard (guard) sourceId "upper.stairwell.${term}.guard" uses forbidden tombstone wording.`
+      );
+    }
+  );
+
+  it('rejects source types outside the known level source type set', () => {
+    expect(
+      validateSourceCollisionRecords([
+        createRecord({
+          sourceType: 'safetyColliders',
+        } as Partial<SourceCollisionRecord<'guard'>>),
+      ])
+    ).toContain(
+      'upper.stairwell.safetyCollider (guard) has invalid sourceType "safetyColliders".'
+    );
+  });
+});

--- a/src/scene/level/sourceCollisionValidation.ts
+++ b/src/scene/level/sourceCollisionValidation.ts
@@ -25,10 +25,8 @@ export type SourceCollisionRecord<Role extends string = string> =
   | (RectCollider &
       Omit<SourceBackedCollider<Role, LevelSourceId, string>, 'bounds'>);
 
-export interface SourceCollisionValidationOptions<
-  Role extends string = string,
-> {
-  multiBoundRoles?: ReadonlySet<Role> | readonly Role[];
+export interface SourceCollisionValidationOptions {
+  allowMultipleBoundsFor?: ReadonlySet<string> | readonly string[];
 }
 
 const isNonEmpty = (value: unknown): value is string =>
@@ -58,9 +56,10 @@ const describeRecord = (
 const getRecordBounds = (record: SourceCollisionRecord): RectCollider =>
   'bounds' in record ? record.bounds : record;
 
-const getMultiBoundRoles = <Role extends string>(
-  roles: SourceCollisionValidationOptions<Role>['multiBoundRoles']
-): ReadonlySet<Role> => (roles instanceof Set ? roles : new Set(roles ?? []));
+const getAllowMultipleBoundsFor = (
+  families: SourceCollisionValidationOptions['allowMultipleBoundsFor']
+): ReadonlySet<string> =>
+  families instanceof Set ? families : new Set(families ?? []);
 
 const usesForbiddenSourceIdPart = (sourceId: string): boolean =>
   sourceId
@@ -154,12 +153,14 @@ const validateBounds = (
 
 export const validateSourceCollisionRecords = <Role extends string>(
   records: readonly SourceCollisionRecord<Role>[],
-  options: SourceCollisionValidationOptions<Role> = {}
+  options: SourceCollisionValidationOptions = {}
 ): string[] => {
   const errors: string[] = [];
   const debugIds = new Map<string, string>();
   const sourceRolePairs = new Map<string, string>();
-  const multiBoundRoles = getMultiBoundRoles(options.multiBoundRoles);
+  const allowMultipleBoundsFor = getAllowMultipleBoundsFor(
+    options.allowMultipleBoundsFor
+  );
 
   for (const record of records) {
     const owner = describeRecord(record);
@@ -202,9 +203,10 @@ export const validateSourceCollisionRecords = <Role extends string>(
       debugIds.set(record.debugId, owner);
     }
 
+    const sourceRoleFamily = `${record.sourceId}::${record.role}`;
     const sourceRoleKey = `${record.sourceId}\u0000${record.role}`;
     const existing = sourceRolePairs.get(sourceRoleKey);
-    if (existing && !multiBoundRoles.has(record.role)) {
+    if (existing && !allowMultipleBoundsFor.has(sourceRoleFamily)) {
       errors.push(
         `Duplicate active source/role ${owner}; already used by ${existing}.`
       );

--- a/src/scene/level/sourceCollisionValidation.ts
+++ b/src/scene/level/sourceCollisionValidation.ts
@@ -3,6 +3,7 @@ import { isDebugColliderId } from '../debug/colliderDebugIds';
 
 import {
   isActiveSourceCollisionPolicy,
+  type CollisionIntent,
   type SourceBackedCollider,
   type SourceCollisionPolicy,
 } from './sourceCollision';
@@ -38,6 +39,13 @@ const FORBIDDEN_SOURCE_ID_PARTS = new Set([
   'debugonlyremoval',
 ]);
 
+const COLLISION_INTENTS = new Set<CollisionIntent>([
+  'physical-boundary',
+  'safety-guard',
+  'interaction-footprint',
+  'secondary-backstop',
+]);
+
 const LEVEL_SOURCE_TYPES = new Set<LevelSourceType>([
   'room',
   'wall',
@@ -55,6 +63,12 @@ const describeRecord = (
 
 const getRecordBounds = (record: SourceCollisionRecord): RectCollider =>
   'bounds' in record ? record.bounds : record;
+
+/** Builds the `${sourceId}::${role}` family key used by allowMultipleBoundsFor. */
+export const getSourceRoleFamilyKey = (
+  sourceId: LevelSourceId,
+  role: string
+): string => `${sourceId}::${role}`;
 
 const getAllowMultipleBoundsFor = (
   families: SourceCollisionValidationOptions['allowMultipleBoundsFor']
@@ -87,6 +101,9 @@ const validateSourceId = (
 const isLevelSourceType = (value: unknown): value is LevelSourceType =>
   typeof value === 'string' && LEVEL_SOURCE_TYPES.has(value as LevelSourceType);
 
+const isCollisionIntent = (value: unknown): value is CollisionIntent =>
+  typeof value === 'string' && COLLISION_INTENTS.has(value as CollisionIntent);
+
 export const validateSourceCollisionPolicy = <Role extends string>(
   declaration: SourceCollisionPolicyDeclaration<Role>
 ): string[] => {
@@ -107,6 +124,10 @@ export const validateSourceCollisionPolicy = <Role extends string>(
   if (isActiveSourceCollisionPolicy(declaration.collision)) {
     if (!isNonEmpty(declaration.collision.intent)) {
       errors.push(`Active policy ${declaration.sourceId} requires an intent.`);
+    } else if (!isCollisionIntent(declaration.collision.intent)) {
+      errors.push(
+        `Active policy ${declaration.sourceId} has invalid intent "${declaration.collision.intent}".`
+      );
     }
     if (!isNonEmpty(declaration.collision.purpose)) {
       errors.push(`Active policy ${declaration.sourceId} requires a purpose.`);
@@ -179,6 +200,8 @@ export const validateSourceCollisionRecords = <Role extends string>(
     }
     if (!isNonEmpty(record.intent)) {
       errors.push(`${owner} requires an intent.`);
+    } else if (!isCollisionIntent(record.intent)) {
+      errors.push(`${owner} has invalid intent "${record.intent}".`);
     }
     if (!isNonEmpty(record.purpose)) {
       errors.push(`${owner} requires a purpose.`);
@@ -203,7 +226,10 @@ export const validateSourceCollisionRecords = <Role extends string>(
       debugIds.set(record.debugId, owner);
     }
 
-    const sourceRoleFamily = `${record.sourceId}::${record.role}`;
+    const sourceRoleFamily = getSourceRoleFamilyKey(
+      record.sourceId,
+      record.role
+    );
     const sourceRoleKey = `${record.sourceId}\u0000${record.role}`;
     const existing = sourceRolePairs.get(sourceRoleKey);
     if (existing && !allowMultipleBoundsFor.has(sourceRoleFamily)) {

--- a/src/scene/level/sourceCollisionValidation.ts
+++ b/src/scene/level/sourceCollisionValidation.ts
@@ -6,7 +6,11 @@ import {
   type SourceBackedCollider,
   type SourceCollisionPolicy,
 } from './sourceCollision';
-import { isLevelSourceId, type LevelSourceId } from './sourceIds';
+import {
+  isLevelSourceId,
+  type LevelSourceId,
+  type LevelSourceType,
+} from './sourceIds';
 
 export interface SourceCollisionPolicyDeclaration<
   Role extends string = string,
@@ -30,6 +34,23 @@ export interface SourceCollisionValidationOptions<
 const isNonEmpty = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0;
 
+const FORBIDDEN_SOURCE_ID_PARTS = new Set([
+  'former',
+  'removed',
+  'debugonlyremoval',
+]);
+
+const LEVEL_SOURCE_TYPES = new Set<LevelSourceType>([
+  'room',
+  'wall',
+  'floorSurface',
+  'safetyCollider',
+  'sceneObject',
+  'roomConnection',
+  'generatedCollider',
+  'generatedSolid',
+]);
+
 const describeRecord = (
   record: Pick<SourceCollisionRecord, 'sourceId' | 'role'>
 ): string => `${record.sourceId} (${record.role})`;
@@ -41,16 +62,43 @@ const getMultiBoundRoles = <Role extends string>(
   roles: SourceCollisionValidationOptions<Role>['multiBoundRoles']
 ): ReadonlySet<Role> => (roles instanceof Set ? roles : new Set(roles ?? []));
 
+const usesForbiddenSourceIdPart = (sourceId: string): boolean =>
+  sourceId
+    .split('.')
+    .some((part) => FORBIDDEN_SOURCE_ID_PARTS.has(part.toLowerCase()));
+
+const validateSourceId = (
+  sourceId: LevelSourceId,
+  owner: string,
+  errors: string[],
+  invalidMessage: string
+): void => {
+  if (!isLevelSourceId(sourceId)) {
+    errors.push(invalidMessage);
+    return;
+  }
+
+  if (usesForbiddenSourceIdPart(sourceId)) {
+    errors.push(
+      `${owner} sourceId "${sourceId}" uses forbidden tombstone wording.`
+    );
+  }
+};
+
+const isLevelSourceType = (value: unknown): value is LevelSourceType =>
+  typeof value === 'string' && LEVEL_SOURCE_TYPES.has(value as LevelSourceType);
+
 export const validateSourceCollisionPolicy = <Role extends string>(
   declaration: SourceCollisionPolicyDeclaration<Role>
 ): string[] => {
   const errors: string[] = [];
 
-  if (!isLevelSourceId(declaration.sourceId)) {
-    errors.push(
-      `Policy ${declaration.role} has invalid sourceId "${declaration.sourceId}".`
-    );
-  }
+  validateSourceId(
+    declaration.sourceId,
+    `Policy ${declaration.role}`,
+    errors,
+    `Policy ${declaration.role} has invalid sourceId "${declaration.sourceId}".`
+  );
   if (!isNonEmpty(declaration.role)) {
     errors.push(
       `Policy ${declaration.sourceId} requires a nonempty semantic role.`
@@ -117,11 +165,16 @@ export const validateSourceCollisionRecords = <Role extends string>(
     const owner = describeRecord(record);
     validateBounds(getRecordBounds(record), owner, errors);
 
-    if (!isLevelSourceId(record.sourceId)) {
-      errors.push(`${owner} has invalid sourceId.`);
-    }
+    validateSourceId(
+      record.sourceId,
+      owner,
+      errors,
+      `${owner} has invalid sourceId.`
+    );
     if (!isNonEmpty(record.sourceType)) {
       errors.push(`${owner} requires a sourceType.`);
+    } else if (!isLevelSourceType(record.sourceType)) {
+      errors.push(`${owner} has invalid sourceType "${record.sourceType}".`);
     }
     if (!isNonEmpty(record.intent)) {
       errors.push(`${owner} requires an intent.`);

--- a/src/scene/level/sourceCollisionValidation.ts
+++ b/src/scene/level/sourceCollisionValidation.ts
@@ -1,0 +1,163 @@
+import type { RectCollider } from '../../systems/collision';
+import { isDebugColliderId } from '../debug/colliderDebugIds';
+
+import {
+  isActiveSourceCollisionPolicy,
+  type SourceBackedCollider,
+  type SourceCollisionPolicy,
+} from './sourceCollision';
+import { isLevelSourceId, type LevelSourceId } from './sourceIds';
+
+export interface SourceCollisionPolicyDeclaration<
+  Role extends string = string,
+> {
+  role: Role;
+  sourceId: LevelSourceId;
+  collision: SourceCollisionPolicy;
+}
+
+export type SourceCollisionRecord<Role extends string = string> =
+  | SourceBackedCollider<Role, LevelSourceId, string>
+  | (RectCollider &
+      Omit<SourceBackedCollider<Role, LevelSourceId, string>, 'bounds'>);
+
+export interface SourceCollisionValidationOptions<
+  Role extends string = string,
+> {
+  multiBoundRoles?: ReadonlySet<Role> | readonly Role[];
+}
+
+const isNonEmpty = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const describeRecord = (
+  record: Pick<SourceCollisionRecord, 'sourceId' | 'role'>
+): string => `${record.sourceId} (${record.role})`;
+
+const getRecordBounds = (record: SourceCollisionRecord): RectCollider =>
+  'bounds' in record ? record.bounds : record;
+
+const getMultiBoundRoles = <Role extends string>(
+  roles: SourceCollisionValidationOptions<Role>['multiBoundRoles']
+): ReadonlySet<Role> => (roles instanceof Set ? roles : new Set(roles ?? []));
+
+export const validateSourceCollisionPolicy = <Role extends string>(
+  declaration: SourceCollisionPolicyDeclaration<Role>
+): string[] => {
+  const errors: string[] = [];
+
+  if (!isLevelSourceId(declaration.sourceId)) {
+    errors.push(
+      `Policy ${declaration.role} has invalid sourceId "${declaration.sourceId}".`
+    );
+  }
+  if (!isNonEmpty(declaration.role)) {
+    errors.push(
+      `Policy ${declaration.sourceId} requires a nonempty semantic role.`
+    );
+  }
+
+  if (isActiveSourceCollisionPolicy(declaration.collision)) {
+    if (!isNonEmpty(declaration.collision.intent)) {
+      errors.push(`Active policy ${declaration.sourceId} requires an intent.`);
+    }
+    if (!isNonEmpty(declaration.collision.purpose)) {
+      errors.push(`Active policy ${declaration.sourceId} requires a purpose.`);
+    }
+    if (!isNonEmpty(declaration.collision.runtimeName)) {
+      errors.push(
+        `Active policy ${declaration.sourceId} requires a runtime name.`
+      );
+    }
+    if (
+      declaration.collision.debugId !== undefined &&
+      !isDebugColliderId(declaration.collision.debugId)
+    ) {
+      errors.push(
+        `Active policy ${declaration.sourceId} has invalid debugId "${declaration.collision.debugId}".`
+      );
+    }
+  } else if (!isNonEmpty(declaration.collision.rationale)) {
+    errors.push(
+      `No-collision policy ${declaration.sourceId} requires a rationale.`
+    );
+  }
+
+  return errors;
+};
+
+const validateBounds = (
+  bounds: RectCollider,
+  owner: string,
+  errors: string[]
+): void => {
+  for (const key of ['minX', 'maxX', 'minZ', 'maxZ'] as const) {
+    if (!Number.isFinite(bounds[key])) {
+      errors.push(`${owner} bounds.${key} must be finite.`);
+    }
+  }
+  if (!(bounds.minX < bounds.maxX)) {
+    errors.push(`${owner} bounds must be normalized on X.`);
+  }
+  if (!(bounds.minZ < bounds.maxZ)) {
+    errors.push(`${owner} bounds must be normalized on Z.`);
+  }
+};
+
+export const validateSourceCollisionRecords = <Role extends string>(
+  records: readonly SourceCollisionRecord<Role>[],
+  options: SourceCollisionValidationOptions<Role> = {}
+): string[] => {
+  const errors: string[] = [];
+  const debugIds = new Map<string, string>();
+  const sourceRolePairs = new Map<string, string>();
+  const multiBoundRoles = getMultiBoundRoles(options.multiBoundRoles);
+
+  for (const record of records) {
+    const owner = describeRecord(record);
+    validateBounds(getRecordBounds(record), owner, errors);
+
+    if (!isLevelSourceId(record.sourceId)) {
+      errors.push(`${owner} has invalid sourceId.`);
+    }
+    if (!isNonEmpty(record.sourceType)) {
+      errors.push(`${owner} requires a sourceType.`);
+    }
+    if (!isNonEmpty(record.intent)) {
+      errors.push(`${owner} requires an intent.`);
+    }
+    if (!isNonEmpty(record.purpose)) {
+      errors.push(`${owner} requires a purpose.`);
+    }
+    if (!isNonEmpty(record.role)) {
+      errors.push(`${owner} requires a semantic role.`);
+    }
+    if (!isNonEmpty(record.name)) {
+      errors.push(`${owner} requires a runtime name.`);
+    }
+
+    if (record.debugId !== undefined) {
+      if (!isDebugColliderId(record.debugId)) {
+        errors.push(`${owner} has invalid debugId "${record.debugId}".`);
+      }
+      const existing = debugIds.get(record.debugId);
+      if (existing) {
+        errors.push(
+          `Debug ID ${record.debugId} is used by both ${existing} and ${owner}.`
+        );
+      }
+      debugIds.set(record.debugId, owner);
+    }
+
+    const sourceRoleKey = `${record.sourceId}\u0000${record.role}`;
+    const existing = sourceRolePairs.get(sourceRoleKey);
+    if (existing && !multiBoundRoles.has(record.role)) {
+      errors.push(
+        `Duplicate active source/role ${owner}; already used by ${existing}.`
+      );
+    }
+    sourceRolePairs.set(sourceRoleKey, owner);
+  }
+
+  return errors;
+};

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,8 +1,11 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { isDebugColliderId } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
+import {
+  validateSourceCollisionPolicy,
+  validateSourceCollisionRecords,
+} from '../../level/sourceCollisionValidation';
 import { assertLevelSourceId } from '../../level/sourceIds';
 import {
   UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
@@ -186,12 +189,12 @@ describe('createUpperStairwellLanding', () => {
       segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
     });
 
-    const explicitDebugIds = result.colliders.flatMap((collider) =>
-      collider.debugId ? [collider.debugId] : []
-    );
-
-    expect(explicitDebugIds.every(isDebugColliderId)).toBe(true);
-    expect(new Set(explicitDebugIds).size).toBe(explicitDebugIds.length);
+    expect(
+      UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES.flatMap((policy) =>
+        validateSourceCollisionPolicy(policy)
+      )
+    ).toEqual([]);
+    expect(validateSourceCollisionRecords(result.colliders)).toEqual([]);
     result.colliders.forEach((collider) => {
       if (!collider.debugId) return;
       expect(

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -29,9 +29,11 @@ import {
   type SpyInstance,
 } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
 import { createBackyardEnvironment } from '../scene/environments/backyard';
+import { validateSourceCollisionRecords } from '../scene/level/sourceCollisionValidation';
 import type { SeasonalLightingPreset } from '../scene/lighting/seasonalPresets';
+
+import { getProductionRoomBounds } from './helpers/productionLevelFixtures';
 
 const BACKYARD_BOUNDS = {
   minX: -10,
@@ -1347,18 +1349,17 @@ describe('createBackyardEnvironment', () => {
       true
     );
 
-    const productionBackyardBounds = FLOOR_PLAN.rooms.find(
-      (room) => room.id === 'backyard'
-    )?.bounds;
-    expect(productionBackyardBounds).toBeDefined();
-    const productionEnvironment = createBackyardEnvironment(
-      productionBackyardBounds!
+    const productionBackyardBounds = getProductionRoomBounds(
+      'ground',
+      'backyard'
     );
-    const productionBackFenceSampleZ = productionBackyardBounds!.maxZ - 1.8;
+    const productionEnvironment = createBackyardEnvironment(
+      productionBackyardBounds
+    );
+    const productionBackFenceSampleZ = productionBackyardBounds.maxZ - 1.8;
     const productionBackFenceSamples = [
       {
-        x:
-          (productionBackyardBounds!.minX + productionBackyardBounds!.maxX) / 2,
+        x: (productionBackyardBounds.minX + productionBackyardBounds.maxX) / 2,
         z: productionBackFenceSampleZ,
       },
       { x: 5, z: productionBackFenceSampleZ },
@@ -1372,6 +1373,13 @@ describe('createBackyardEnvironment', () => {
         pointIsBlocked(productionEnvironment.colliders)
       )
     ).toBe(true);
+
+    const productionSourceColliders = productionEnvironment.colliders.filter(
+      (collider) => 'sourceId' in collider
+    );
+    expect(validateSourceCollisionRecords(productionSourceColliders)).toEqual(
+      []
+    );
 
     const productionBackFenceCollider = productionEnvironment.colliders.find(
       (collider) =>

--- a/src/tests/helpers/productionLevelFixtures.test.ts
+++ b/src/tests/helpers/productionLevelFixtures.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LevelDefinition } from '../../scene/level/schema';
+import { assertLevelSourceId } from '../../scene/level/sourceIds';
+
+import {
+  getProductionFloorBounds,
+  getProductionRoomBounds,
+} from './productionLevelFixtures';
+
+const expectBoundsToBeCloseTo = (
+  actual: ReturnType<typeof getProductionRoomBounds>,
+  expected: ReturnType<typeof getProductionRoomBounds>
+) => {
+  expect(actual.minX).toBeCloseTo(expected.minX);
+  expect(actual.maxX).toBeCloseTo(expected.maxX);
+  expect(actual.minZ).toBeCloseTo(expected.minZ);
+  expect(actual.maxZ).toBeCloseTo(expected.maxZ);
+};
+
+const fixtureLevel: LevelDefinition = {
+  id: 'fixture-level',
+  floors: [
+    {
+      id: 'ground',
+      name: 'Ground',
+      outline: [
+        [-1, -2],
+        [3, -2],
+        [3, 4],
+        [-1, 4],
+      ],
+      rooms: [
+        {
+          id: 'livingRoom',
+          sourceId: assertLevelSourceId('ground.livingRoom.room'),
+          name: 'Living Room',
+          bounds: { minX: -1, maxX: 3, minZ: -2, maxZ: 1 },
+          ledColor: 0xffffff,
+        },
+      ],
+      walls: [],
+      floorSurfaces: [],
+    },
+  ],
+};
+
+describe('production level fixture helpers', () => {
+  it('looks up room bounds by floor and room semantic IDs', () => {
+    expectBoundsToBeCloseTo(
+      getProductionRoomBounds('ground', 'livingRoom', fixtureLevel),
+      {
+        minX: -2,
+        maxX: 6,
+        minZ: -4,
+        maxZ: 2,
+      }
+    );
+  });
+
+  it('looks up floor bounds by floor ID', () => {
+    expectBoundsToBeCloseTo(getProductionFloorBounds('ground', fixtureLevel), {
+      minX: -2,
+      maxX: 6,
+      minZ: -4,
+      maxZ: 8,
+    });
+  });
+
+  it('returns cloned room bounds', () => {
+    const bounds = getProductionRoomBounds(
+      'ground',
+      'livingRoom',
+      fixtureLevel
+    );
+
+    bounds.minX = 999;
+
+    expect(
+      getProductionRoomBounds('ground', 'livingRoom', fixtureLevel).minX
+    ).toBeCloseTo(-2);
+  });
+
+  it('throws for missing floors', () => {
+    expect(() => getProductionFloorBounds('upper', fixtureLevel)).toThrow(
+      'Missing production floor "upper" in level "fixture-level".'
+    );
+  });
+
+  it('throws for missing rooms', () => {
+    expect(() =>
+      getProductionRoomBounds('ground', 'studio', fixtureLevel)
+    ).toThrow(
+      'Missing production room "studio" on floor "ground" in level "fixture-level".'
+    );
+  });
+});

--- a/src/tests/helpers/productionLevelFixtures.ts
+++ b/src/tests/helpers/productionLevelFixtures.ts
@@ -1,0 +1,56 @@
+import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import { compileLegacyFloorPlan } from '../../scene/level/compileLegacyFloorPlan';
+import { PORTFOLIO_LEVEL } from '../../scene/level/portfolioLevel';
+import type { Bounds2D, LevelDefinition } from '../../scene/level/schema';
+
+const cloneBounds = (bounds: Bounds2D): Bounds2D => ({ ...bounds });
+
+const scaleBounds = (bounds: Bounds2D): Bounds2D => ({
+  minX: bounds.minX * FLOOR_PLAN_SCALE,
+  maxX: bounds.maxX * FLOOR_PLAN_SCALE,
+  minZ: bounds.minZ * FLOOR_PLAN_SCALE,
+  maxZ: bounds.maxZ * FLOOR_PLAN_SCALE,
+});
+
+const getFloor = (level: LevelDefinition, floorId: string) => {
+  const floor = level.floors.find((candidate) => candidate.id === floorId);
+  if (!floor) {
+    throw new Error(
+      `Missing production floor "${floorId}" in level "${level.id}".`
+    );
+  }
+  return floor;
+};
+
+export const getProductionRoomBounds = (
+  floorId: string,
+  roomId: string,
+  level: LevelDefinition = PORTFOLIO_LEVEL
+): Bounds2D => {
+  getFloor(level, floorId);
+  const plan = compileLegacyFloorPlan(level, floorId, {
+    includeDoorwaysFromWallGaps: true,
+  });
+  const room = plan.rooms.find((candidate) => candidate.id === roomId);
+  if (!room) {
+    throw new Error(
+      `Missing production room "${roomId}" on floor "${floorId}" in level "${level.id}".`
+    );
+  }
+  return scaleBounds(room.bounds);
+};
+
+export const getProductionFloorBounds = (
+  floorId: string,
+  level: LevelDefinition = PORTFOLIO_LEVEL
+): Bounds2D => {
+  const floor = getFloor(level, floorId);
+  const xs = floor.outline.map(([x]) => x * FLOOR_PLAN_SCALE);
+  const zs = floor.outline.map(([, z]) => z * FLOOR_PLAN_SCALE);
+  return cloneBounds({
+    minX: Math.min(...xs),
+    maxX: Math.max(...xs),
+    minZ: Math.min(...zs),
+    maxZ: Math.max(...zs),
+  });
+};

--- a/src/tests/helpers/productionLevelFixtures.ts
+++ b/src/tests/helpers/productionLevelFixtures.ts
@@ -3,8 +3,6 @@ import { compileLegacyFloorPlan } from '../../scene/level/compileLegacyFloorPlan
 import { PORTFOLIO_LEVEL } from '../../scene/level/portfolioLevel';
 import type { Bounds2D, LevelDefinition } from '../../scene/level/schema';
 
-const cloneBounds = (bounds: Bounds2D): Bounds2D => ({ ...bounds });
-
 const scaleBounds = (bounds: Bounds2D): Bounds2D => ({
   minX: bounds.minX * FLOOR_PLAN_SCALE,
   maxX: bounds.maxX * FLOOR_PLAN_SCALE,
@@ -47,10 +45,10 @@ export const getProductionFloorBounds = (
   const floor = getFloor(level, floorId);
   const xs = floor.outline.map(([x]) => x * FLOOR_PLAN_SCALE);
   const zs = floor.outline.map(([, z]) => z * FLOOR_PLAN_SCALE);
-  return cloneBounds({
+  return {
     minX: Math.min(...xs),
     maxX: Math.max(...xs),
     minZ: Math.min(...zs),
     maxZ: Math.max(...zs),
-  });
+  };
 };

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -12,6 +12,8 @@ import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../scene/level/mediaWallPolicy'
 import { validateSourceCollisionPolicy } from '../scene/level/sourceCollisionValidation';
 import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
 
+import { getProductionRoomBounds } from './helpers/productionLevelFixtures';
+
 describe('createLivingRoomMediaWall', () => {
   type CapturingContext = CanvasRenderingContext2D & {
     fillTextCalls: Array<{ text: string; x: number; y: number }>;
@@ -78,7 +80,7 @@ describe('createLivingRoomMediaWall', () => {
   });
 
   it('includes a TV screen with YouTube text and exposes POI bindings', () => {
-    const bounds = { minX: -16, maxX: 16, minZ: -16, maxZ: -4 };
+    const bounds = getProductionRoomBounds('ground', 'livingRoom');
     const build = createLivingRoomMediaWall(bounds);
 
     const screen = build.group.getObjectByName('LivingRoomMediaWallScreen');
@@ -190,7 +192,7 @@ describe('createLivingRoomMediaWall', () => {
   });
 
   it('keeps the visual media POI visible without emitting floor colliders', () => {
-    const bounds = { minX: -16, maxX: 16, minZ: -16, maxZ: -4 };
+    const bounds = getProductionRoomBounds('ground', 'livingRoom');
     const build = createLivingRoomMediaWall(bounds);
 
     expect(build.policy).toBe(FUTUROPTIMIST_MEDIA_WALL_POLICY);

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'vitest';
 
 import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../scene/level/mediaWallPolicy';
+import { validateSourceCollisionPolicy } from '../scene/level/sourceCollisionValidation';
 import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
 
 describe('createLivingRoomMediaWall', () => {
@@ -180,6 +181,9 @@ describe('createLivingRoomMediaWall', () => {
       sourceId: 'ground.livingRoom.mediaWall.futuroptimist',
       collision: { collision: 'none' },
     });
+    expect(
+      validateSourceCollisionPolicy(FUTUROPTIMIST_MEDIA_WALL_POLICY)
+    ).toEqual([]);
     expect(FUTUROPTIMIST_MEDIA_WALL_POLICY.collision.rationale).toMatch(
       /wall-mounted.+no floor-level interaction footprint/i
     );


### PR DESCRIPTION
### Motivation
- Provide small, reusable validators for source-owned collider policies and emitted runtime records to replace repeated one-off test assertions. 
- Give tests a canonical, read-only way to obtain production room/floor bounds so tests stop copying or re-scaling production coordinates.

### Description
- Add `src/scene/level/sourceCollisionValidation.ts` with `validateSourceCollisionPolicy(...)` and `validateSourceCollisionRecords(...)` to check source ID format, semantic role, active/no-collision policy fields, normalized bounds, runtime name, debug IDs, and duplicate `(sourceId, role)` constraints. 
- Add `src/tests/helpers/productionLevelFixtures.ts` with `getProductionRoomBounds(...)` and `getProductionFloorBounds(...)` that derive and return cloned, scaled bounds from `PORTFOLIO_LEVEL` via `compileLegacyFloorPlan(...)`. 
- Replace bespoke assertions in stair, upper-landing, backyard, and media wall tests to use the new validators and production fixture helpers, and update `docs/design/editing-level-data.md` to recommend the shared validators and fixtures. 

### Testing
- Ran targeted tests with `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts src/tests/backyardEnvironment.test.ts src/tests/mediaWall.test.ts` and observed the focused runs pass. 
- Ran full suite `npm run test:ci` and observed all tests pass in CI run (160 test files, 1225 tests in this environment); lint passed via `npm run lint`; smoke passed via `npm run smoke`; docs check passed via `npm run docs:check` (link-check produced external fetch warnings but the docs check itself passed). 
- Pre-commit secret scan `git diff --cached | ./scripts/scan-secrets.py` was executed and reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a387950531c832f90fd83d07a9d8fab)