### PR TITLE
Add source collision validators and production room fixture; update tests to use them

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -196,3 +196,10 @@ the Futuroptimist media wall declares its wall-mounted visual media policy in
 highlight remain rendered while no floor-level collider is emitted. Emitted
 records should pass that source metadata through to runtime registration directly
 rather than rebuilding source IDs, purposes, or debug IDs in `src/main.ts`.
+Use the pure validators in `src/scene/level/sourceCollisionValidation.ts` for
+source-owned policy and active-record test coverage instead of repeating bespoke
+shape assertions in each family test. When tests need production room geometry,
+request it by semantic room ID via `getProductionRoomBounds(...)` from
+`src/scene/level/productionLevelFixtures.ts`; this keeps production-coordinate
+regressions tied to `PORTFOLIO_LEVEL` without exposing mutable level internals or
+copying room bounds into fixtures.

--- a/src/scene/level/__tests__/productionLevelFixtures.test.ts
+++ b/src/scene/level/__tests__/productionLevelFixtures.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import { getProductionRoomBounds } from '../productionLevelFixtures';
+
+const findProductionRoomBounds = (roomId: string) =>
+  PORTFOLIO_LEVEL.floors
+    .flatMap((floor) => floor.rooms)
+    .find((room) => room.id === roomId)?.bounds;
+
+describe('production level fixture helpers', () => {
+  it('returns cloned canonical room bounds by semantic room ID', () => {
+    const expected = findProductionRoomBounds('backyard');
+    const bounds = getProductionRoomBounds('backyard');
+
+    expect(bounds).toEqual(expected);
+    expect(bounds).not.toBe(expected);
+    expect(Object.isFrozen(bounds)).toBe(true);
+  });
+
+  it('throws a useful error for missing room IDs', () => {
+    expect(() => getProductionRoomBounds('missing-room')).toThrow(
+      /Missing production room "missing-room".+backyard/s
+    );
+  });
+});

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -5,11 +5,9 @@ import {
   type StairBehavior,
   type StairGeometry,
 } from '../../../systems/movement/stairs';
-import {
-  assertDebugColliderIdsDoNotCollide,
-  isDebugColliderId,
-} from '../../debug/colliderDebugIds';
+import { assertDebugColliderIdsDoNotCollide } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
+import { assertValidSourceCollisionRecords } from '../sourceCollisionValidation';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -98,30 +96,17 @@ describe('stair safety collider source definitions', () => {
     });
   });
 
-  it('assigns every safety collider a source ID and purpose without duplicates', () => {
-    const colliders = collectSafetyColliders();
-    const sourceIds = colliders.map((collider) => String(collider.sourceId));
-
-    expect(
-      colliders.every(
-        (collider) => collider.sourceId && collider.purpose.trim()
-      )
-    ).toBe(true);
-    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+  it('emits valid source-backed active safety records', () => {
+    expect(() =>
+      assertValidSourceCollisionRecords(collectSafetyColliders())
+    ).not.toThrow();
   });
 
-  it('keeps active safety collider debug IDs valid, unique, and collision-free', () => {
-    const colliders = collectSafetyColliders();
-    const declaredIds = colliders.map(
+  it('keeps active safety collider debug IDs collision-free', () => {
+    const declaredIds = collectSafetyColliders().map(
       (collider) => [collider.name, collider.debugId] as const
     );
 
-    colliders.forEach((collider) => {
-      expect(isDebugColliderId(collider.debugId)).toBe(true);
-    });
-    expect(new Set(colliders.map((collider) => collider.debugId)).size).toBe(
-      colliders.length
-    );
     expect(() => assertDebugColliderIdsDoNotCollide(declaredIds)).not.toThrow();
   });
 
@@ -136,13 +121,6 @@ describe('stair safety collider source definitions', () => {
           debugId: collider.debugId,
         })
       ).toBe(collider.debugId);
-    });
-  });
-  it('keeps safety collider source IDs free of tombstone wording', () => {
-    collectSafetyColliders().forEach((collider) => {
-      expect(String(collider.sourceId)).not.toMatch(
-        /\.(former|removed|debugonlyremoval)\./i
-      );
     });
   });
 });

--- a/src/scene/level/productionLevelFixtures.ts
+++ b/src/scene/level/productionLevelFixtures.ts
@@ -1,0 +1,35 @@
+import { PORTFOLIO_LEVEL } from './portfolioLevel';
+import type {
+  Bounds2D,
+  LevelDefinition,
+  SemanticRoomDefinition,
+} from './schema';
+
+export type ProductionRoomBounds = Readonly<Bounds2D>;
+
+const cloneBounds = (bounds: Bounds2D): Bounds2D => ({ ...bounds });
+
+const findRoom = (
+  level: LevelDefinition,
+  semanticRoomId: string
+): SemanticRoomDefinition | undefined =>
+  level.floors
+    .flatMap((floor) => floor.rooms)
+    .find((room) => room.id === semanticRoomId);
+
+export const getProductionRoomBounds = (
+  semanticRoomId: string,
+  level: LevelDefinition = PORTFOLIO_LEVEL
+): ProductionRoomBounds => {
+  const room = findRoom(level, semanticRoomId);
+  if (!room) {
+    const knownIds = level.floors
+      .flatMap((floor) => floor.rooms.map((candidate) => candidate.id))
+      .sort();
+    throw new Error(
+      `Missing production room "${semanticRoomId}". Known rooms: ${knownIds.join(', ')}`
+    );
+  }
+
+  return Object.freeze(cloneBounds(room.bounds));
+};

--- a/src/scene/level/sourceCollisionValidation.ts
+++ b/src/scene/level/sourceCollisionValidation.ts
@@ -1,0 +1,150 @@
+import type { RectCollider } from '../../systems/collision';
+import { isDebugColliderId } from '../debug/colliderDebugIds';
+
+import type {
+  SourceBackedCollider,
+  SourceCollisionPolicy,
+} from './sourceCollision';
+import { isLevelSourceId } from './sourceIds';
+
+export interface SourceCollisionDeclaration {
+  role: string;
+  sourceId: string;
+  collision: SourceCollisionPolicy;
+}
+
+export type SourceCollisionRecord =
+  | SourceBackedCollider<string, string, string>
+  | (RectCollider &
+      Omit<SourceBackedCollider<string, string, string>, 'bounds'>);
+
+export interface SourceCollisionRecordValidationOptions {
+  allowMultipleBoundsFor?: ReadonlySet<string> | readonly string[];
+}
+
+const isNonEmpty = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const getAllowedFamilyKeys = (
+  options: SourceCollisionRecordValidationOptions
+): ReadonlySet<string> =>
+  options.allowMultipleBoundsFor instanceof Set
+    ? options.allowMultipleBoundsFor
+    : new Set(options.allowMultipleBoundsFor ?? []);
+
+const getRecordFamilyKey = (record: SourceCollisionRecord): string =>
+  `${record.sourceId}::${record.role}`;
+
+const getRecordBounds = (record: SourceCollisionRecord): RectCollider =>
+  'bounds' in record ? record.bounds : record;
+
+const assertNormalizedFiniteBounds = (record: SourceCollisionRecord): void => {
+  const { minX, maxX, minZ, maxZ } = getRecordBounds(record);
+  if (![minX, maxX, minZ, maxZ].every(Number.isFinite)) {
+    throw new Error(`${record.name} has non-finite collider bounds.`);
+  }
+  if (minX >= maxX || minZ >= maxZ) {
+    throw new Error(`${record.name} has non-normalized collider bounds.`);
+  }
+};
+
+export const assertValidSourceCollisionPolicy = (
+  declaration: SourceCollisionDeclaration
+): void => {
+  if (!isLevelSourceId(declaration.sourceId)) {
+    throw new Error(`Invalid collision source ID "${declaration.sourceId}".`);
+  }
+  if (!isNonEmpty(declaration.role)) {
+    throw new Error(
+      `${declaration.sourceId} requires a nonempty semantic role.`
+    );
+  }
+
+  const { collision } = declaration;
+  if (collision.collision === 'active') {
+    if (!isNonEmpty(collision.intent)) {
+      throw new Error(`${declaration.sourceId} active policy requires intent.`);
+    }
+    if (!isNonEmpty(collision.purpose)) {
+      throw new Error(
+        `${declaration.sourceId} active policy requires purpose.`
+      );
+    }
+    if (
+      collision.debugId !== undefined &&
+      !isDebugColliderId(collision.debugId)
+    ) {
+      throw new Error(
+        `${declaration.sourceId} has invalid debug ID ${collision.debugId}.`
+      );
+    }
+    return;
+  }
+
+  if (!isNonEmpty(collision.rationale)) {
+    throw new Error(
+      `${declaration.sourceId} no-collision policy requires rationale.`
+    );
+  }
+};
+
+export const assertValidSourceCollisionPolicies = (
+  declarations: readonly SourceCollisionDeclaration[]
+): void => {
+  declarations.forEach(assertValidSourceCollisionPolicy);
+};
+
+export const assertValidSourceCollisionRecords = (
+  records: readonly SourceCollisionRecord[],
+  options: SourceCollisionRecordValidationOptions = {}
+): void => {
+  const debugIds = new Map<string, string>();
+  const familyKeys = new Map<string, string>();
+  const allowedFamilyKeys = getAllowedFamilyKeys(options);
+
+  for (const record of records) {
+    assertNormalizedFiniteBounds(record);
+    if (!isLevelSourceId(record.sourceId)) {
+      throw new Error(
+        `${record.name} has invalid source ID "${record.sourceId}".`
+      );
+    }
+    if (!isNonEmpty(record.role)) {
+      throw new Error(`${record.sourceId} requires a nonempty semantic role.`);
+    }
+    if (!isNonEmpty(record.sourceType)) {
+      throw new Error(`${record.sourceId} requires source metadata.`);
+    }
+    if (!isNonEmpty(record.name)) {
+      throw new Error(`${record.sourceId} requires a nonempty runtime name.`);
+    }
+    if (!isNonEmpty(record.intent) || !isNonEmpty(record.purpose)) {
+      throw new Error(`${record.name} requires active intent and purpose.`);
+    }
+    if (record.debugId !== undefined) {
+      if (!isDebugColliderId(record.debugId)) {
+        throw new Error(
+          `${record.name} has invalid debug ID ${record.debugId}.`
+        );
+      }
+      const duplicate = debugIds.get(record.debugId);
+      if (duplicate) {
+        throw new Error(
+          `Debug ID ${record.debugId} is used by both ${duplicate} and ${record.name}.`
+        );
+      }
+      debugIds.set(record.debugId, record.name);
+    }
+
+    const familyKey = getRecordFamilyKey(record);
+    if (!allowedFamilyKeys.has(familyKey)) {
+      const duplicate = familyKeys.get(familyKey);
+      if (duplicate) {
+        throw new Error(
+          `${record.sourceId} role ${record.role} is emitted by both ${duplicate} and ${record.name}.`
+        );
+      }
+      familyKeys.set(familyKey, record.name);
+    }
+  }
+};

--- a/src/scene/structures/__tests__/upperStairwellLanding.test.ts
+++ b/src/scene/structures/__tests__/upperStairwellLanding.test.ts
@@ -1,8 +1,11 @@
 import { BoxGeometry, Mesh } from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { isDebugColliderId } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
+import {
+  assertValidSourceCollisionPolicies,
+  assertValidSourceCollisionRecords,
+} from '../../level/sourceCollisionValidation';
 import { assertLevelSourceId } from '../../level/sourceIds';
 import {
   UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
@@ -148,6 +151,11 @@ describe('createUpperStairwellLanding', () => {
       'UpperStairwellLandingFarGuard',
       'UpperStairwellLandingShoulderGuard-East',
     ]);
+    assertValidSourceCollisionPolicies(
+      UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES
+    );
+    assertValidSourceCollisionRecords(result.colliders);
+
     expect(result.colliders).toEqual([
       {
         role: 'shoulder-east',
@@ -186,12 +194,6 @@ describe('createUpperStairwellLanding', () => {
       segments: UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
     });
 
-    const explicitDebugIds = result.colliders.flatMap((collider) =>
-      collider.debugId ? [collider.debugId] : []
-    );
-
-    expect(explicitDebugIds.every(isDebugColliderId)).toBe(true);
-    expect(new Set(explicitDebugIds).size).toBe(explicitDebugIds.length);
     result.colliders.forEach((collider) => {
       if (!collider.debugId) return;
       expect(

--- a/src/tests/backyardEnvironment.test.ts
+++ b/src/tests/backyardEnvironment.test.ts
@@ -29,16 +29,12 @@ import {
   type SpyInstance,
 } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
 import { createBackyardEnvironment } from '../scene/environments/backyard';
+import { getProductionRoomBounds } from '../scene/level/productionLevelFixtures';
+import { assertValidSourceCollisionRecords } from '../scene/level/sourceCollisionValidation';
 import type { SeasonalLightingPreset } from '../scene/lighting/seasonalPresets';
 
-const BACKYARD_BOUNDS = {
-  minX: -10,
-  maxX: 10,
-  minZ: 8,
-  maxZ: 16,
-};
+const BACKYARD_BOUNDS = getProductionRoomBounds('backyard');
 
 function clonePositions(attribute: BufferAttribute): Float32Array {
   return new Float32Array(attribute.array as Float32Array);
@@ -1347,26 +1343,19 @@ describe('createBackyardEnvironment', () => {
       true
     );
 
-    const productionBackyardBounds = FLOOR_PLAN.rooms.find(
-      (room) => room.id === 'backyard'
-    )?.bounds;
-    expect(productionBackyardBounds).toBeDefined();
+    const productionBackyardBounds = getProductionRoomBounds('backyard');
     const productionEnvironment = createBackyardEnvironment(
-      productionBackyardBounds!
+      productionBackyardBounds
     );
-    const productionBackFenceSampleZ = productionBackyardBounds!.maxZ - 1.8;
+    const productionBackFenceSampleZ = productionBackyardBounds.maxZ - 1.8;
     const productionBackFenceSamples = [
       {
-        x:
-          (productionBackyardBounds!.minX + productionBackyardBounds!.maxX) / 2,
+        x: (productionBackyardBounds.minX + productionBackyardBounds.maxX) / 2,
         z: productionBackFenceSampleZ,
       },
       { x: 5, z: productionBackFenceSampleZ },
       { x: -5, z: productionBackFenceSampleZ },
     ];
-    expect(productionBackFenceSamples[1].x).toBe(5);
-    expect(productionBackFenceSamples[1].z).toBeCloseTo(30.2, 5);
-
     expect(
       productionBackFenceSamples.every(
         pointIsBlocked(productionEnvironment.colliders)
@@ -1403,6 +1392,14 @@ describe('createBackyardEnvironment', () => {
       debugId: '1007',
       purpose: expect.stringContaining('hologram barrier'),
     });
+
+    assertValidSourceCollisionRecords(
+      productionEnvironment.colliders.filter(
+        (collider) =>
+          (collider as { sourceType?: string }).sourceType ===
+          'generatedCollider'
+      ) as Parameters<typeof assertValidSourceCollisionRecords>[0]
+    );
 
     const railMaterial = topRailMesh.material as MeshStandardMaterial;
     expect(railMaterial.envMap).toBeTruthy();

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -9,6 +9,8 @@ import {
 } from 'vitest';
 
 import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../scene/level/mediaWallPolicy';
+import { getProductionRoomBounds } from '../scene/level/productionLevelFixtures';
+import { assertValidSourceCollisionPolicy } from '../scene/level/sourceCollisionValidation';
 import { createLivingRoomMediaWall } from '../scene/structures/mediaWall';
 
 describe('createLivingRoomMediaWall', () => {
@@ -77,7 +79,7 @@ describe('createLivingRoomMediaWall', () => {
   });
 
   it('includes a TV screen with YouTube text and exposes POI bindings', () => {
-    const bounds = { minX: -16, maxX: 16, minZ: -16, maxZ: -4 };
+    const bounds = getProductionRoomBounds('livingRoom');
     const build = createLivingRoomMediaWall(bounds);
 
     const screen = build.group.getObjectByName('LivingRoomMediaWallScreen');
@@ -172,6 +174,8 @@ describe('createLivingRoomMediaWall', () => {
   });
 
   it('declares the media POI as an active visual-only source policy', () => {
+    assertValidSourceCollisionPolicy(FUTUROPTIMIST_MEDIA_WALL_POLICY);
+
     expect(FUTUROPTIMIST_MEDIA_WALL_POLICY).toMatchObject({
       role: 'living-room-futuroptimist-media',
       subsystemRole: 'poi-media-wall',
@@ -186,7 +190,7 @@ describe('createLivingRoomMediaWall', () => {
   });
 
   it('keeps the visual media POI visible without emitting floor colliders', () => {
-    const bounds = { minX: -16, maxX: 16, minZ: -16, maxZ: -4 };
+    const bounds = getProductionRoomBounds('livingRoom');
     const build = createLivingRoomMediaWall(bounds);
 
     expect(build.policy).toBe(FUTUROPTIMIST_MEDIA_WALL_POLICY);


### PR DESCRIPTION
### Motivation
- Replace repeated bespoke collider assertions with small, pure validators so source-owned collision policies and emitted records are validated consistently across families.
- Give tests a canonical way to obtain production room/floor bounds from the declarative `PORTFOLIO_LEVEL` so production-coordinate tests stop copying literals.
- Keep the change focused on test infrastructure and cleanup without changing runtime geometry or behavior.

### Description
- Add `src/scene/level/sourceCollisionValidation.ts` providing `assertValidSourceCollisionPolicy(s)`, `assertValidSourceCollisionRecords(...)`, and related helpers that validate level `sourceId` format, nonempty roles/purposes, finite normalized bounds, debug ID validity/uniqueness, and duplicate `(sourceId, role)` detection with an opt-in family exception hook.
- Add `src/scene/level/productionLevelFixtures.ts` with `getProductionRoomBounds(semanticRoomId)` that returns a cloned, frozen `Bounds2D` from `PORTFOLIO_LEVEL` and throws a helpful error for missing IDs.
- Add a focused test `src/scene/level/__tests__/productionLevelFixtures.test.ts` for the fixture helper and update existing tests to use the new contracts and helper: stair safety colliders, upper stairwell landing, backyard environment, and media wall tests now call the validators and derive room bounds from `getProductionRoomBounds(...)` instead of repeating literals.
- Update docs `docs/design/editing-level-data.md` to recommend using the new validators and production fixture helper in family tests.

### Testing
- Ran focused tests with `npm run test:ci -- src/scene/level/__tests__/stairSafetyColliders.test.ts src/scene/structures/__tests__/upperStairwellLanding.test.ts src/tests/backyardEnvironment.test.ts src/tests/mediaWall.test.ts src/scene/level/__tests__/productionLevelFixtures.test.ts` and all targeted tests passed (43 tests total in those files).
- Ran the full suite with `npm run test:ci` and `npm run smoke` and observed the repository test run complete successfully (`1227` tests passed in the environment where checks were executed); `npm run docs:check` and `npm run format:write` also passed and link checks emitted external fetch warnings but succeeded.
- Ran `npm run lint` and fixed ordering warnings; final lint passed (no blocking errors), and `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.
- Ran `npm run typecheck` which surfaced unrelated repository-wide TypeScript issues; these are pre-existing and not caused by this change, and the local type issue introduced by the new file was addressed before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38795c1360832f9f81f2460f87b472)