### PR TITLE
Add opt-in collider geometry audit

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -110,6 +110,34 @@ npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json
 
 Set `PLAYWRIGHT_BASE_URL` to reuse an already-running preview or dev server.
 
+## Audit candidate collider geometry from the CLI
+
+Use the opt-in geometry audit when two active runtime colliders look redundant
+and you need quantitative evidence before a human review. The audit reuses the
+same runtime collector and selectors as `collider:inspect`, then narrows
+comparison evidence to compatible floor, category, and source-family metadata so
+upper-floor or unrelated collider families do not create false positives.
+
+```bash
+npm run collider:audit:geometry -- --id 400D
+npm run collider:audit:geometry -- --source-id backyard.fence.back.physicalBoundary
+npm run collider:audit:geometry -- --id 1007 --json
+```
+
+The report prints candidate metadata first, then exact duplicate rectangles,
+full containment in both directions, pairwise overlap percentages, deterministic
+sample-grid union coverage, uncovered sample points, and nearby edge adjacency.
+Use `--tolerance <world-units>` for adjacency and containment slack, and
+`--samples <count>` to set the sample-grid density per axis.
+
+Geometry is supporting evidence only. The tool may label evidence as exact
+duplicate, fully contained, highly overlapped, partially covered, isolated, or
+ambiguous, but it must not be treated as proof that a collider is safe to delete.
+Outer walls, stair guards, void protection, and secondary safety backstops can
+look geometrically covered while still encoding intentional gameplay or safety
+constraints. Confirm source intent and runtime reachability before removing any
+collider.
+
 ## Inspect source IDs in the browser
 
 Launch immersive mode with performance failover disabled:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:e2e": "playwright test",
     "links:check": "node scripts/check-links.cjs",
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
-    "collider:inspect": "tsx scripts/colliderInspect.ts"
+    "collider:inspect": "tsx scripts/colliderInspect.ts",
+    "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderGeometry.test.ts
+++ b/scripts/__tests__/colliderGeometry.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  areRectanglesAdjacent,
+  containsRectangle,
+  estimateUnionCoverage,
+  getIntersection,
+  getRectangleArea,
+  getRectangleDistance,
+  rectanglesEqual,
+} from '../colliderGeometry';
+import { auditColliderGeometry } from '../colliderGeometryAudit';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const base = {
+  floor: 'ground',
+  category: 'wall',
+  sourceType: 'test',
+} satisfies Partial<RuntimeColliderMetadata>;
+
+const collider = (
+  id: string,
+  bounds: RuntimeColliderMetadata['bounds'],
+  floor = 'ground'
+): RuntimeColliderMetadata =>
+  ({
+    ...base,
+    id,
+    floor,
+    name: `Collider${id}`,
+    bounds,
+  }) as RuntimeColliderMetadata;
+
+describe('rectangle geometry helpers', () => {
+  it('detects exact duplicates and full containment', () => {
+    const target = { minX: 0, maxX: 4, minZ: 0, maxZ: 4 };
+    const duplicate = { minX: 0, maxX: 4, minZ: 0, maxZ: 4 };
+    const contained = { minX: 1, maxX: 2, minZ: 1, maxZ: 2 };
+
+    expect(rectanglesEqual(target, duplicate)).toBe(true);
+    expect(containsRectangle(target, contained)).toBe(true);
+    expect(getRectangleArea(target)).toBe(16);
+  });
+
+  it('calculates partial overlap intersections', () => {
+    expect(
+      getIntersection(
+        { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+        { minX: 2, maxX: 6, minZ: 1, maxZ: 3 }
+      )
+    ).toEqual({ minX: 2, maxX: 4, minZ: 1, maxZ: 3 });
+  });
+
+  it('measures disjoint rectangle distance and adjacency', () => {
+    const left = { minX: 0, maxX: 1, minZ: 0, maxZ: 1 };
+    const right = { minX: 1.04, maxX: 2, minZ: 0, maxZ: 1 };
+
+    expect(getIntersection(left, right)).toBeUndefined();
+    expect(getRectangleDistance(left, right)).toBeCloseTo(0.04);
+    expect(areRectanglesAdjacent(left, right, 0.05)).toBe(true);
+    expect(areRectanglesAdjacent(left, right, 0.01)).toBe(false);
+  });
+
+  it('estimates deterministic multi-collider union coverage', () => {
+    const target = { minX: 0, maxX: 4, minZ: 0, maxZ: 4 };
+    const coverage = estimateUnionCoverage(
+      target,
+      [
+        { minX: 0, maxX: 2, minZ: 0, maxZ: 4 },
+        { minX: 2, maxX: 4, minZ: 0, maxZ: 2 },
+      ],
+      4
+    );
+
+    expect(coverage.coveredSamples).toBe(12);
+    expect(coverage.totalSamples).toBe(16);
+    expect(coverage.coveragePercent).toBe(75);
+    expect(coverage.uncoveredSamples).toEqual([
+      { x: 2.5, z: 2.5, covered: false },
+      { x: 3.5, z: 2.5, covered: false },
+      { x: 2.5, z: 3.5, covered: false },
+      { x: 3.5, z: 3.5, covered: false },
+    ]);
+  });
+});
+
+describe('auditColliderGeometry', () => {
+  it('filters unrelated floors and reports duplicate, containment, overlap, and adjacency evidence', () => {
+    const colliders = [
+      collider('candidate', { minX: 0, maxX: 4, minZ: 0, maxZ: 4 }),
+      collider('duplicate', { minX: 0, maxX: 4, minZ: 0, maxZ: 4 }),
+      collider('contained', { minX: 1, maxX: 2, minZ: 1, maxZ: 2 }),
+      collider('partial', { minX: 3, maxX: 5, minZ: 0, maxZ: 4 }),
+      collider('adjacent', { minX: 4.02, maxX: 5, minZ: 0, maxZ: 4 }),
+      collider(
+        'upperDuplicate',
+        { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+        'upper'
+      ),
+    ];
+
+    const report = auditColliderGeometry(colliders, {
+      query: { kind: 'id', value: 'candidate' },
+      tolerance: 0.05,
+      samples: 4,
+    });
+
+    expect(report.consideredColliderCount).toBe(4);
+    expect(report.exactDuplicates.map((peer) => peer.id)).toEqual([
+      'duplicate',
+    ]);
+    expect(report.containsCandidate.map((peer) => peer.id)).toContain(
+      'contained'
+    );
+    expect(report.overlaps.map((peer) => peer.id)).toContain('partial');
+    expect(report.adjacent.map((peer) => peer.id)).toEqual(['adjacent']);
+    expect(report.unionCoverage.coveragePercent).toBe(100);
+    expect(report.labels).toContain('exact duplicate');
+  });
+});

--- a/scripts/colliderGeometry.ts
+++ b/scripts/colliderGeometry.ts
@@ -1,0 +1,117 @@
+import type { RuntimeColliderBounds } from './colliderRuntimeCollector';
+
+export type Rectangle = RuntimeColliderBounds;
+
+export type CoverageSample = {
+  x: number;
+  z: number;
+  covered: boolean;
+};
+
+export type UnionCoverage = {
+  coveredSamples: number;
+  totalSamples: number;
+  coveragePercent: number;
+  uncoveredSamples: CoverageSample[];
+};
+
+const round = (value: number, digits = 6): number =>
+  Number(value.toFixed(digits));
+
+export const getRectangleArea = (rectangle: Rectangle): number =>
+  Math.max(0, rectangle.maxX - rectangle.minX) *
+  Math.max(0, rectangle.maxZ - rectangle.minZ);
+
+export const getIntersection = (
+  left: Rectangle,
+  right: Rectangle
+): Rectangle | undefined => {
+  const intersection = {
+    minX: Math.max(left.minX, right.minX),
+    maxX: Math.min(left.maxX, right.maxX),
+    minZ: Math.max(left.minZ, right.minZ),
+    maxZ: Math.min(left.maxZ, right.maxZ),
+  };
+  return getRectangleArea(intersection) > 0 ? intersection : undefined;
+};
+
+export const rectanglesEqual = (
+  left: Rectangle,
+  right: Rectangle,
+  tolerance = 0
+): boolean =>
+  Math.abs(left.minX - right.minX) <= tolerance &&
+  Math.abs(left.maxX - right.maxX) <= tolerance &&
+  Math.abs(left.minZ - right.minZ) <= tolerance &&
+  Math.abs(left.maxZ - right.maxZ) <= tolerance;
+
+export const containsRectangle = (
+  outer: Rectangle,
+  inner: Rectangle,
+  tolerance = 0
+): boolean =>
+  outer.minX <= inner.minX + tolerance &&
+  outer.maxX >= inner.maxX - tolerance &&
+  outer.minZ <= inner.minZ + tolerance &&
+  outer.maxZ >= inner.maxZ - tolerance;
+
+export const getRectangleDistance = (
+  left: Rectangle,
+  right: Rectangle
+): number => {
+  const dx = Math.max(0, left.minX - right.maxX, right.minX - left.maxX);
+  const dz = Math.max(0, left.minZ - right.maxZ, right.minZ - left.maxZ);
+  return Math.hypot(dx, dz);
+};
+
+export const areRectanglesAdjacent = (
+  left: Rectangle,
+  right: Rectangle,
+  tolerance: number
+): boolean => getRectangleDistance(left, right) <= tolerance;
+
+export const pointInRectangle = (
+  point: { x: number; z: number },
+  rectangle: Rectangle
+): boolean =>
+  point.x >= rectangle.minX &&
+  point.x <= rectangle.maxX &&
+  point.z >= rectangle.minZ &&
+  point.z <= rectangle.maxZ;
+
+export const estimateUnionCoverage = (
+  target: Rectangle,
+  coveringRectangles: readonly Rectangle[],
+  samplesPerAxis: number
+): UnionCoverage => {
+  const safeSamplesPerAxis = Math.max(1, Math.floor(samplesPerAxis));
+  const totalSamples = safeSamplesPerAxis * safeSamplesPerAxis;
+  const width = target.maxX - target.minX;
+  const depth = target.maxZ - target.minZ;
+  let coveredSamples = 0;
+  const uncoveredSamples: CoverageSample[] = [];
+
+  for (let zIndex = 0; zIndex < safeSamplesPerAxis; zIndex += 1) {
+    for (let xIndex = 0; xIndex < safeSamplesPerAxis; xIndex += 1) {
+      const point = {
+        x: round(target.minX + ((xIndex + 0.5) / safeSamplesPerAxis) * width),
+        z: round(target.minZ + ((zIndex + 0.5) / safeSamplesPerAxis) * depth),
+      };
+      const covered = coveringRectangles.some((rectangle) =>
+        pointInRectangle(point, rectangle)
+      );
+      if (covered) {
+        coveredSamples += 1;
+      } else {
+        uncoveredSamples.push({ ...point, covered });
+      }
+    }
+  }
+
+  return {
+    coveredSamples,
+    totalSamples,
+    coveragePercent: round((coveredSamples / totalSamples) * 100, 3),
+    uncoveredSamples,
+  };
+};

--- a/scripts/colliderGeometryAudit.ts
+++ b/scripts/colliderGeometryAudit.ts
@@ -1,0 +1,304 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  areRectanglesAdjacent,
+  containsRectangle,
+  estimateUnionCoverage,
+  getIntersection,
+  getRectangleArea,
+  getRectangleDistance,
+  rectanglesEqual,
+} from './colliderGeometry';
+import {
+  findColliderMatches,
+  formatInspectionRecords,
+  toInspectionRecords,
+  type ColliderInspectQuery,
+} from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+
+type GeometryAuditOptions = {
+  query: ColliderInspectQuery;
+  tolerance: number;
+  samples: number;
+  json: boolean;
+};
+
+type AuditPeer = RuntimeColliderMetadata & {
+  label: string;
+  intersectionArea: number;
+  candidateCoveragePercent: number;
+  peerCoveragePercent: number;
+  distance: number;
+};
+
+export type GeometryAuditReport = {
+  candidate: RuntimeColliderMetadata;
+  note: string;
+  tolerance: number;
+  samples: number;
+  consideredColliderCount: number;
+  exactDuplicates: AuditPeer[];
+  candidateContainedBy: AuditPeer[];
+  containsCandidate: AuditPeer[];
+  overlaps: AuditPeer[];
+  adjacent: AuditPeer[];
+  unionCoverage: ReturnType<typeof estimateUnionCoverage>;
+  labels: string[];
+};
+
+const round = (value: number): number => Number(value.toFixed(3));
+const DEFAULT_TOLERANCE = 0.05;
+const DEFAULT_SAMPLES = 16;
+
+const floorsCanOverlap = (left: string, right: string): boolean =>
+  left === right || left === 'all' || right === 'all';
+
+const sameSourceFamily = (
+  candidate: RuntimeColliderMetadata,
+  peer: RuntimeColliderMetadata
+): boolean =>
+  !candidate.sourceType ||
+  !peer.sourceType ||
+  candidate.sourceType === peer.sourceType;
+
+const sameEvidenceScope = (
+  candidate: RuntimeColliderMetadata,
+  peer: RuntimeColliderMetadata
+): boolean =>
+  floorsCanOverlap(candidate.floor, peer.floor) &&
+  candidate.category === peer.category &&
+  sameSourceFamily(candidate, peer);
+
+const byRelevance = (left: AuditPeer, right: AuditPeer): number =>
+  right.candidateCoveragePercent - left.candidateCoveragePercent ||
+  right.intersectionArea - left.intersectionArea ||
+  left.id.localeCompare(right.id);
+
+const toAuditPeer = (
+  candidate: RuntimeColliderMetadata,
+  peer: RuntimeColliderMetadata,
+  tolerance: number
+): AuditPeer => {
+  const intersection = getIntersection(candidate.bounds, peer.bounds);
+  const intersectionArea = getRectangleArea(
+    intersection ?? { minX: 0, maxX: 0, minZ: 0, maxZ: 0 }
+  );
+  const candidateArea = getRectangleArea(candidate.bounds);
+  const peerArea = getRectangleArea(peer.bounds);
+  const candidateCoveragePercent =
+    candidateArea === 0 ? 0 : (intersectionArea / candidateArea) * 100;
+  const peerCoveragePercent =
+    peerArea === 0 ? 0 : (intersectionArea / peerArea) * 100;
+  let label = 'ambiguous';
+  if (rectanglesEqual(candidate.bounds, peer.bounds)) {
+    label = 'exact duplicate';
+  } else if (containsRectangle(peer.bounds, candidate.bounds, tolerance)) {
+    label = 'fully contained';
+  } else if (candidateCoveragePercent >= 80 || peerCoveragePercent >= 80) {
+    label = 'highly overlapped';
+  } else if (intersectionArea > 0) {
+    label = 'partially covered';
+  } else if (areRectanglesAdjacent(candidate.bounds, peer.bounds, tolerance)) {
+    label = 'isolated adjacency';
+  }
+  return {
+    ...peer,
+    label,
+    intersectionArea: round(intersectionArea),
+    candidateCoveragePercent: round(candidateCoveragePercent),
+    peerCoveragePercent: round(peerCoveragePercent),
+    distance: round(getRectangleDistance(candidate.bounds, peer.bounds)),
+  };
+};
+
+export const parseGeometryAuditArgs = (
+  args: readonly string[]
+): GeometryAuditOptions => {
+  let query: ColliderInspectQuery | undefined;
+  let json = false;
+  let tolerance = DEFAULT_TOLERANCE;
+  let samples = DEFAULT_SAMPLES;
+
+  const readValue = (index: number, flag: string): string => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--id' || arg === '--source-id' || arg === '--name') {
+      if (query)
+        throw new Error('Provide exactly one of --id, --source-id, or --name.');
+      query = {
+        kind: arg.slice(2) as ColliderInspectQuery['kind'],
+        value: readValue(index, arg),
+      };
+      index += 1;
+    } else if (arg === '--tolerance') {
+      tolerance = Number(readValue(index, arg));
+      index += 1;
+    } else if (arg === '--samples') {
+      samples = Number(readValue(index, arg));
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!query)
+    throw new Error('Provide exactly one of --id, --source-id, or --name.');
+  if (!Number.isFinite(tolerance) || tolerance < 0)
+    throw new Error('--tolerance must be >= 0.');
+  if (!Number.isInteger(samples) || samples < 1)
+    throw new Error('--samples must be a positive integer.');
+  return { query, tolerance, samples, json };
+};
+
+export const auditColliderGeometry = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: Omit<GeometryAuditOptions, 'json'>
+): GeometryAuditReport => {
+  const matches = findColliderMatches(colliders, options.query);
+  if (matches.length !== 1) {
+    throw new Error(
+      `Geometry audit requires one candidate; matched ${matches.length}.`
+    );
+  }
+  const candidate = matches[0];
+  const peers = colliders.filter(
+    (peer) => peer.id !== candidate.id && sameEvidenceScope(candidate, peer)
+  );
+  const auditPeers = peers.map((peer) =>
+    toAuditPeer(candidate, peer, options.tolerance)
+  );
+  const exactDuplicates = auditPeers.filter((peer) =>
+    rectanglesEqual(candidate.bounds, peer.bounds)
+  );
+  const candidateContainedBy = auditPeers.filter((peer) =>
+    containsRectangle(peer.bounds, candidate.bounds, options.tolerance)
+  );
+  const containsCandidate = auditPeers.filter((peer) =>
+    containsRectangle(candidate.bounds, peer.bounds, options.tolerance)
+  );
+  const overlaps = auditPeers
+    .filter((peer) => peer.intersectionArea > 0)
+    .sort(byRelevance);
+  const adjacent = auditPeers
+    .filter(
+      (peer) =>
+        peer.intersectionArea === 0 &&
+        areRectanglesAdjacent(candidate.bounds, peer.bounds, options.tolerance)
+    )
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const unionCoverage = estimateUnionCoverage(
+    candidate.bounds,
+    peers.map((peer) => peer.bounds),
+    options.samples
+  );
+  const labels = new Set<string>();
+  if (exactDuplicates.length) labels.add('exact duplicate');
+  if (candidateContainedBy.length || containsCandidate.length)
+    labels.add('fully contained');
+  if (overlaps.some((peer) => peer.candidateCoveragePercent >= 80))
+    labels.add('highly overlapped');
+  if (overlaps.some((peer) => peer.candidateCoveragePercent < 80))
+    labels.add('partially covered');
+  if (!overlaps.length && !adjacent.length) labels.add('isolated');
+  if (!labels.size) labels.add('ambiguous');
+
+  return {
+    candidate,
+    note: 'Geometry overlap is supporting evidence only; this tool never declares safe deletion.',
+    tolerance: options.tolerance,
+    samples: options.samples,
+    consideredColliderCount: peers.length,
+    exactDuplicates,
+    candidateContainedBy,
+    containsCandidate,
+    overlaps,
+    adjacent,
+    unionCoverage,
+    labels: [...labels],
+  };
+};
+
+const formatPeer = (peer: AuditPeer): string =>
+  `  - ${peer.id} ${peer.name} (${peer.label}): intersection ${peer.intersectionArea}, candidate ${peer.candidateCoveragePercent}%, other ${peer.peerCoveragePercent}%`;
+
+export const formatGeometryAuditReport = (
+  report: GeometryAuditReport
+): string =>
+  [
+    formatInspectionRecords(
+      toInspectionRecords([report.candidate], [report.candidate])
+    ),
+    '',
+    `Note: ${report.note}`,
+    `Evidence labels: ${report.labels.join(', ')}`,
+    `Filtered evidence scope: floor ${report.candidate.floor}, category ${report.candidate.category}`,
+    `Considered active colliders: ${report.consideredColliderCount}`,
+    `Union coverage: ${report.unionCoverage.coveragePercent}% (${report.unionCoverage.coveredSamples}/${report.unionCoverage.totalSamples} samples covered)`,
+    `Uncovered sample preview: ${
+      report.unionCoverage.uncoveredSamples
+        .slice(0, 8)
+        .map((sample) => `(${sample.x}, ${sample.z})`)
+        .join(', ') || 'none'
+    }`,
+    'Exact duplicates:',
+    ...(report.exactDuplicates.length
+      ? report.exactDuplicates.map(formatPeer)
+      : ['  - none']),
+    'Candidate contained by:',
+    ...(report.candidateContainedBy.length
+      ? report.candidateContainedBy.map(formatPeer)
+      : ['  - none']),
+    'Other colliders contained by candidate:',
+    ...(report.containsCandidate.length
+      ? report.containsCandidate.map(formatPeer)
+      : ['  - none']),
+    'Pairwise overlaps:',
+    ...(report.overlaps.length
+      ? report.overlaps.map(formatPeer)
+      : ['  - none']),
+    'Edge adjacency:',
+    ...(report.adjacent.length
+      ? report.adjacent.map(formatPeer)
+      : ['  - none']),
+  ].join('\n');
+
+export const runColliderGeometryAuditCli = async (args: readonly string[]) => {
+  const options = parseGeometryAuditArgs(args);
+  const colliders = await collectRuntimeColliders();
+  const report = auditColliderGeometry(colliders, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : `${formatGeometryAuditReport(report)}\n`
+  );
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderGeometryAuditCli(process.argv.slice(2)).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide maintainers a lightweight, opt-in tool to gather quantitative geometric evidence when evaluating collider-removal candidates without changing runtime colliders or making deletion decisions automatically.
- Reuse the existing runtime collector and matching logic so the audit reflects real runtime collider identities and provenance while avoiding scene snapshots or new persistent models.

### Description
- Add pure rectangle geometry helpers in `scripts/colliderGeometry.ts` for intersection, area, containment, distance/adjacency, point tests, and deterministic sample-grid union coverage.
- Add a candidate-scoped audit CLI `scripts/colliderGeometryAudit.ts` that reuses `collectRuntimeColliders` and `findColliderMatches`, filters evidence by floor/category/source-family, and reports duplicates, containment, pairwise overlap, union coverage samples, and nearby adjacency with non-deletion language.
- Add synthetic Vitest tests at `scripts/__tests__/colliderGeometry.test.ts` covering duplicates, containment, partial overlap, disjoint adjacency, and deterministic union coverage; add `npm` script `collider:audit:geometry` to `package.json` and document usage in `docs/design/editing-level-data.md`.

### Testing
- Ran formatting: `npm run format:write -- scripts/colliderGeometry.ts scripts/colliderGeometryAudit.ts scripts/__tests__/colliderGeometry.test.ts package.json` (succeeded).
- Exercised the CLI: `npm run collider:audit:geometry -- --id 1007` and `npm run collider:audit:geometry -- --source-id upper.stairwell.landingGuard.shoulderEast --json`, installing required Playwright browsers during the run; both invocations completed and produced human and JSON reports respectively.
- Unit/test suite: `npm run test:ci -- scripts` passed (scripts tests), `npm run test:ci` ran the full suite and passed (all tests green in the run shown).
- Lint/docs/smoke: `npm run lint` completed with a fixable warning only, `npm run docs:check` passed (link checker emitted existing external fetch warnings), and `npm run smoke` (build + dist assertions) passed; `./scripts/scan-secrets.py` returned no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38a1537df4832f98bdcc2626d95272)