### PR TITLE
Add opt-in collider geometry audit

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -110,6 +110,29 @@ npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json
 
 Set `PLAYWRIGHT_BASE_URL` to reuse an already-running preview or dev server.
 
+## Audit collider geometry on demand
+
+Use the geometry audit when a collider looks removable but needs quantified
+spatial evidence. It reuses the same runtime debug collector as
+`collider:inspect`, filters comparisons to the selected collider's floor and
+category, and reports exact duplicates, containment, pairwise overlap, union
+coverage from a deterministic sample grid, and nearby edge adjacency.
+
+```bash
+npm run collider:audit:geometry -- --id 400D
+npm run collider:audit:geometry -- --source-id backyard.fence.back.physicalBoundary
+npm run collider:audit:geometry -- --id 1007 --json
+```
+
+Optional knobs are intentionally small: `--samples <n>` controls the per-axis
+sample grid for the union coverage estimate, and `--tolerance <meters>` controls
+edge-adjacency reporting. The output may label evidence as exact duplicate,
+fully contained, highly overlapped, partially covered, isolated, or ambiguous,
+but geometry alone is supporting evidence only. It must not be treated as proof
+that a collider is safe to delete because outer walls, secondary safety
+backstops, traversal affordances, and source-owned intent can all be more
+important than rectangle overlap.
+
 ## Inspect source IDs in the browser
 
 Launch immersive mode with performance failover disabled:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:e2e": "playwright test",
     "links:check": "node scripts/check-links.cjs",
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
-    "collider:inspect": "tsx scripts/colliderInspect.ts"
+    "collider:inspect": "tsx scripts/colliderInspect.ts",
+    "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderGeometry.test.ts
+++ b/scripts/__tests__/colliderGeometry.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  estimateUnionCoverage,
+  rectangleArea,
+  rectangleContains,
+  rectangleDistance,
+  rectangleIntersection,
+  rectanglesAreAdjacent,
+  type Rectangle,
+} from '../colliderGeometry';
+
+const rect = (
+  minX: number,
+  maxX: number,
+  minZ: number,
+  maxZ: number
+): Rectangle => ({
+  minX,
+  maxX,
+  minZ,
+  maxZ,
+});
+
+describe('collider geometry helpers', () => {
+  it('detects duplicate rectangles through equal intersection area and containment', () => {
+    const left = rect(0, 2, 0, 3);
+    const right = rect(0, 2, 0, 3);
+
+    expect(rectangleIntersection(left, right)).toEqual(left);
+    expect(rectangleArea(left)).toBe(6);
+    expect(rectangleContains(left, right)).toBe(true);
+    expect(rectangleContains(right, left)).toBe(true);
+  });
+
+  it('detects full containment without requiring equal bounds', () => {
+    const outer = rect(-1, 3, -1, 3);
+    const inner = rect(0, 1, 0, 1);
+
+    expect(rectangleContains(outer, inner)).toBe(true);
+    expect(rectangleContains(inner, outer)).toBe(false);
+    expect(rectangleArea(rectangleIntersection(outer, inner)!)).toBe(1);
+  });
+
+  it('measures partial overlap area', () => {
+    const left = rect(0, 2, 0, 2);
+    const right = rect(1, 3, 0.5, 1.5);
+
+    expect(rectangleIntersection(left, right)).toEqual(rect(1, 2, 0.5, 1.5));
+    expect(rectangleArea(rectangleIntersection(left, right)!)).toBe(1);
+  });
+
+  it('distinguishes disjoint rectangles from adjacent rectangles within tolerance', () => {
+    const left = rect(0, 1, 0, 1);
+    const near = rect(1.04, 2, 0, 1);
+    const far = rect(3, 4, 0, 1);
+
+    expect(rectangleIntersection(left, near)).toBeUndefined();
+    expect(rectangleDistance(left, near)).toBe(0.04);
+    expect(rectanglesAreAdjacent(left, near, 0.05)).toBe(true);
+    expect(rectanglesAreAdjacent(left, far, 0.05)).toBe(false);
+  });
+
+  it('estimates multi-collider union coverage on a deterministic sample grid', () => {
+    const candidate = rect(0, 2, 0, 2);
+    const coverage = estimateUnionCoverage(
+      candidate,
+      [rect(0, 1, 0, 2), rect(1, 2, 0, 1)],
+      2
+    );
+
+    expect(coverage.totalSamples).toBe(4);
+    expect(coverage.coveredSamples).toBe(3);
+    expect(coverage.coverageRatio).toBe(0.75);
+    expect(coverage.uncoveredSamples).toEqual([{ x: 1.5, z: 1.5 }]);
+  });
+});

--- a/scripts/__tests__/colliderGeometryAudit.test.ts
+++ b/scripts/__tests__/colliderGeometryAudit.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  auditColliderGeometry,
+  parseColliderGeometryAuditArgs,
+} from '../colliderGeometryAudit';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const collider = (
+  id: string,
+  bounds: RuntimeColliderMetadata['bounds'],
+  floor = 'ground',
+  category = 'active'
+): RuntimeColliderMetadata => ({
+  id,
+  debugId: id,
+  name: `Collider${id}`,
+  sourceId: `source.${id}`,
+  sourceType: 'generatedCollider',
+  floor,
+  category,
+  bounds,
+});
+
+describe('parseColliderGeometryAuditArgs', () => {
+  it('parses the candidate query and simple audit options', () => {
+    expect(
+      parseColliderGeometryAuditArgs([
+        '--source-id',
+        'upper.stairwell.landingGuard.shoulderEast',
+        '--samples',
+        '8',
+        '--tolerance',
+        '0.1',
+        '--json',
+      ])
+    ).toEqual({
+      query: {
+        kind: 'source-id',
+        value: 'upper.stairwell.landingGuard.shoulderEast',
+      },
+      samples: 8,
+      tolerance: 0.1,
+      json: true,
+    });
+  });
+});
+
+describe('auditColliderGeometry', () => {
+  it('keeps floor and category filtering out of geometric evidence', () => {
+    const records = auditColliderGeometry(
+      [
+        collider('1007', { minX: 0, maxX: 2, minZ: 0, maxZ: 2 }),
+        collider('DUP', { minX: 0, maxX: 2, minZ: 0, maxZ: 2 }),
+        collider('UP', { minX: 0, maxX: 2, minZ: 0, maxZ: 2 }, 'upper'),
+        collider(
+          'STATIC',
+          { minX: 0, maxX: 2, minZ: 0, maxZ: 2 },
+          'ground',
+          'static'
+        ),
+      ],
+      {
+        query: { kind: 'id', value: '1007' },
+        json: false,
+        samples: 2,
+        tolerance: 0.05,
+      }
+    );
+
+    expect(records).toHaveLength(1);
+    expect(records[0].exactDuplicates.map((item) => item.id)).toEqual(['DUP']);
+    expect(records[0].pairwiseOverlaps.map((item) => item.collider.id)).toEqual(
+      ['DUP']
+    );
+    expect(records[0].unionCoverage.coverageRatio).toBe(1);
+  });
+
+  it('separates pairwise partial overlap from union coverage', () => {
+    const [record] = auditColliderGeometry(
+      [
+        collider('CANDIDATE', { minX: 0, maxX: 2, minZ: 0, maxZ: 2 }),
+        collider('LEFT', { minX: 0, maxX: 1, minZ: 0, maxZ: 2 }),
+        collider('BOTTOM_RIGHT', { minX: 1, maxX: 2, minZ: 0, maxZ: 1 }),
+      ],
+      {
+        query: { kind: 'id', value: 'CANDIDATE' },
+        json: false,
+        samples: 2,
+        tolerance: 0.05,
+      }
+    );
+
+    expect(record.pairwiseOverlaps).toHaveLength(2);
+    expect(
+      record.pairwiseOverlaps.map((item) => item.candidateCoverage)
+    ).toEqual([0.5, 0.25]);
+    expect(record.unionCoverage.coverageRatio).toBe(0.75);
+    expect(record.contains.map((item) => item.id)).toEqual([
+      'LEFT',
+      'BOTTOM_RIGHT',
+    ]);
+  });
+});

--- a/scripts/colliderGeometry.ts
+++ b/scripts/colliderGeometry.ts
@@ -1,0 +1,105 @@
+import type { RuntimeColliderBounds } from './colliderRuntimeCollector';
+
+export type Rectangle = RuntimeColliderBounds;
+
+export type SamplePoint = {
+  x: number;
+  z: number;
+};
+
+export type UnionCoverageEstimate = {
+  totalSamples: number;
+  coveredSamples: number;
+  uncoveredSamples: SamplePoint[];
+  coverageRatio: number;
+};
+
+export const roundGeometry = (value: number): number =>
+  Number(value.toFixed(6));
+
+export const rectangleArea = (rect: Rectangle): number =>
+  roundGeometry(
+    Math.max(0, rect.maxX - rect.minX) * Math.max(0, rect.maxZ - rect.minZ)
+  );
+
+export const rectangleIntersection = (
+  left: Rectangle,
+  right: Rectangle
+): Rectangle | undefined => {
+  const intersection = {
+    minX: Math.max(left.minX, right.minX),
+    maxX: Math.min(left.maxX, right.maxX),
+    minZ: Math.max(left.minZ, right.minZ),
+    maxZ: Math.min(left.maxZ, right.maxZ),
+  };
+
+  return rectangleArea(intersection) > 0 ? intersection : undefined;
+};
+
+export const rectangleContains = (
+  outer: Rectangle,
+  inner: Rectangle
+): boolean =>
+  outer.minX <= inner.minX &&
+  outer.maxX >= inner.maxX &&
+  outer.minZ <= inner.minZ &&
+  outer.maxZ >= inner.maxZ;
+
+export const rectangleDistance = (
+  left: Rectangle,
+  right: Rectangle
+): number => {
+  const xGap = Math.max(0, right.minX - left.maxX, left.minX - right.maxX);
+  const zGap = Math.max(0, right.minZ - left.maxZ, left.minZ - right.maxZ);
+  return roundGeometry(Math.hypot(xGap, zGap));
+};
+
+export const rectanglesAreAdjacent = (
+  left: Rectangle,
+  right: Rectangle,
+  tolerance: number
+): boolean => {
+  if (rectangleIntersection(left, right)) {
+    return false;
+  }
+  return rectangleDistance(left, right) <= tolerance;
+};
+
+export const estimateUnionCoverage = (
+  candidate: Rectangle,
+  others: readonly Rectangle[],
+  samplesPerAxis: number
+): UnionCoverageEstimate => {
+  const sampleCount = Math.max(1, Math.floor(samplesPerAxis));
+  const width = candidate.maxX - candidate.minX;
+  const depth = candidate.maxZ - candidate.minZ;
+  const uncoveredSamples: SamplePoint[] = [];
+  let coveredSamples = 0;
+
+  for (let xIndex = 0; xIndex < sampleCount; xIndex += 1) {
+    const x = candidate.minX + ((xIndex + 0.5) / sampleCount) * width;
+    for (let zIndex = 0; zIndex < sampleCount; zIndex += 1) {
+      const z = candidate.minZ + ((zIndex + 0.5) / sampleCount) * depth;
+      const covered = others.some(
+        (other) =>
+          x >= other.minX &&
+          x <= other.maxX &&
+          z >= other.minZ &&
+          z <= other.maxZ
+      );
+      if (covered) {
+        coveredSamples += 1;
+      } else {
+        uncoveredSamples.push({ x: roundGeometry(x), z: roundGeometry(z) });
+      }
+    }
+  }
+
+  const totalSamples = sampleCount * sampleCount;
+  return {
+    totalSamples,
+    coveredSamples,
+    uncoveredSamples,
+    coverageRatio: roundGeometry(coveredSamples / totalSamples),
+  };
+};

--- a/scripts/colliderGeometryAudit.ts
+++ b/scripts/colliderGeometryAudit.ts
@@ -1,0 +1,333 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  estimateUnionCoverage,
+  rectangleArea,
+  rectangleContains,
+  rectangleDistance,
+  rectangleIntersection,
+  rectanglesAreAdjacent,
+  type Rectangle,
+} from './colliderGeometry';
+import {
+  findColliderMatches,
+  type ColliderInspectQuery,
+} from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+
+export type ColliderGeometryAuditOptions = {
+  query: ColliderInspectQuery;
+  json: boolean;
+  tolerance: number;
+  samples: number;
+};
+
+type PairwiseEvidence = {
+  collider: RuntimeColliderMetadata;
+  labels: string[];
+  intersectionArea: number;
+  candidateCoverage: number;
+  otherCoverage: number;
+  distance: number;
+};
+
+export type ColliderGeometryAuditRecord = {
+  candidate: RuntimeColliderMetadata;
+  disclaimer: string;
+  filters: {
+    floor: string;
+    category: string;
+    tolerance: number;
+    samplesPerAxis: number;
+  };
+  exactDuplicates: RuntimeColliderMetadata[];
+  containedBy: RuntimeColliderMetadata[];
+  contains: RuntimeColliderMetadata[];
+  pairwiseOverlaps: PairwiseEvidence[];
+  adjacent: PairwiseEvidence[];
+  unionCoverage: ReturnType<typeof estimateUnionCoverage>;
+  label: string;
+};
+
+const DISCLAIMER =
+  'Geometry overlap is supporting evidence only; this audit never proves a collider is safe to delete.';
+
+const roundPercent = (value: number): number =>
+  Number((value * 100).toFixed(2));
+
+const sameBounds = (left: Rectangle, right: Rectangle): boolean =>
+  left.minX === right.minX &&
+  left.maxX === right.maxX &&
+  left.minZ === right.minZ &&
+  left.maxZ === right.maxZ;
+
+const sameComparableScope = (
+  candidate: RuntimeColliderMetadata,
+  other: RuntimeColliderMetadata
+): boolean =>
+  candidate.id !== other.id &&
+  candidate.floor === other.floor &&
+  candidate.category === other.category;
+
+const byRelevance = (left: PairwiseEvidence, right: PairwiseEvidence): number =>
+  right.candidateCoverage - left.candidateCoverage ||
+  right.otherCoverage - left.otherCoverage ||
+  left.distance - right.distance ||
+  left.collider.id.localeCompare(right.collider.id);
+
+const classify = (
+  record: Omit<ColliderGeometryAuditRecord, 'label'>
+): string => {
+  if (record.exactDuplicates.length > 0) {
+    return 'exact duplicate';
+  }
+  if (record.containedBy.length > 0 || record.contains.length > 0) {
+    return 'fully contained';
+  }
+  if (record.unionCoverage.coverageRatio >= 0.95) {
+    return 'highly overlapped';
+  }
+  if (record.unionCoverage.coverageRatio > 0) {
+    return 'partially covered';
+  }
+  if (record.adjacent.length === 0) {
+    return 'isolated';
+  }
+  return 'ambiguous';
+};
+
+export const parseColliderGeometryAuditArgs = (
+  args: readonly string[]
+): ColliderGeometryAuditOptions => {
+  let query: ColliderInspectQuery | undefined;
+  let json = false;
+  let tolerance = 0.05;
+  let samples = 20;
+
+  const readValue = (index: number, flag: string): string => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`${flag} requires a value.`);
+    }
+    return value;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+    if (arg === '--id' || arg === '--source-id' || arg === '--name') {
+      if (query) {
+        throw new Error('Provide exactly one of --id, --source-id, or --name.');
+      }
+      const value = readValue(index, arg);
+      index += 1;
+      query = { kind: arg.slice(2) as ColliderInspectQuery['kind'], value };
+      continue;
+    }
+    if (arg === '--tolerance' || arg === '--samples') {
+      const value = Number(readValue(index, arg));
+      index += 1;
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`${arg} requires a positive number.`);
+      }
+      if (arg === '--tolerance') {
+        tolerance = value;
+      } else {
+        samples = Math.floor(value);
+      }
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!query) {
+    throw new Error('Provide exactly one of --id, --source-id, or --name.');
+  }
+
+  return { query, json, tolerance, samples };
+};
+
+const findAuditCandidates = (
+  colliders: readonly RuntimeColliderMetadata[],
+  query: ColliderInspectQuery
+): RuntimeColliderMetadata[] => {
+  const matches = findColliderMatches(colliders, query);
+  if (matches.length === 0) {
+    throw new Error(`No collider matched ${query.kind} "${query.value}".`);
+  }
+  if (query.kind !== 'source-id' && matches.length > 1) {
+    throw new Error(
+      `Ambiguous collider ${query.kind} "${query.value}" matched ${matches.length} records: ${matches
+        .map((match) => match.id)
+        .join(', ')}.`
+    );
+  }
+  return matches;
+};
+
+export const auditColliderGeometry = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: ColliderGeometryAuditOptions
+): ColliderGeometryAuditRecord[] =>
+  findAuditCandidates(colliders, options.query).map((candidate) => {
+    const candidateArea = rectangleArea(candidate.bounds);
+    const comparable = colliders.filter((other) =>
+      sameComparableScope(candidate, other)
+    );
+    const pairwise = comparable
+      .map<PairwiseEvidence | undefined>((other) => {
+        const intersection = rectangleIntersection(
+          candidate.bounds,
+          other.bounds
+        );
+        const intersectionArea = intersection ? rectangleArea(intersection) : 0;
+        const otherArea = rectangleArea(other.bounds);
+        const labels: string[] = [];
+        if (sameBounds(candidate.bounds, other.bounds))
+          labels.push('exact duplicate');
+        if (rectangleContains(other.bounds, candidate.bounds))
+          labels.push('candidate contained');
+        if (rectangleContains(candidate.bounds, other.bounds))
+          labels.push('contains other');
+        if (intersectionArea > 0) labels.push('overlap');
+        if (
+          rectanglesAreAdjacent(
+            candidate.bounds,
+            other.bounds,
+            options.tolerance
+          )
+        ) {
+          labels.push('edge adjacency');
+        }
+        if (labels.length === 0) return undefined;
+        return {
+          collider: other,
+          labels,
+          intersectionArea,
+          candidateCoverage:
+            candidateArea > 0 ? intersectionArea / candidateArea : 0,
+          otherCoverage: otherArea > 0 ? intersectionArea / otherArea : 0,
+          distance: rectangleDistance(candidate.bounds, other.bounds),
+        };
+      })
+      .filter((item): item is PairwiseEvidence => Boolean(item))
+      .sort(byRelevance);
+
+    const baseRecord = {
+      candidate,
+      disclaimer: DISCLAIMER,
+      filters: {
+        floor: candidate.floor,
+        category: candidate.category,
+        tolerance: options.tolerance,
+        samplesPerAxis: options.samples,
+      },
+      exactDuplicates: comparable.filter((other) =>
+        sameBounds(candidate.bounds, other.bounds)
+      ),
+      containedBy: comparable.filter((other) =>
+        rectangleContains(other.bounds, candidate.bounds)
+      ),
+      contains: comparable.filter((other) =>
+        rectangleContains(candidate.bounds, other.bounds)
+      ),
+      pairwiseOverlaps: pairwise.filter((item) => item.intersectionArea > 0),
+      adjacent: pairwise.filter((item) =>
+        item.labels.includes('edge adjacency')
+      ),
+      unionCoverage: estimateUnionCoverage(
+        candidate.bounds,
+        comparable.map((other) => other.bounds),
+        options.samples
+      ),
+    };
+    return { ...baseRecord, label: classify(baseRecord) };
+  });
+
+const formatCollider = (collider: RuntimeColliderMetadata): string =>
+  `${collider.id} ${collider.name} (${collider.sourceId ?? 'no source'})`;
+
+const formatPair = (item: PairwiseEvidence): string =>
+  `  - ${formatCollider(item.collider)}: ${item.labels.join(', ')}; intersection area ${item.intersectionArea.toFixed(3)}; candidate ${roundPercent(item.candidateCoverage)}%; other ${roundPercent(item.otherCoverage)}%; distance ${item.distance.toFixed(3)}`;
+
+export const formatGeometryAuditRecords = (
+  records: readonly ColliderGeometryAuditRecord[]
+): string =>
+  records
+    .map((record) => {
+      const uncoveredPreview = record.unionCoverage.uncoveredSamples.slice(
+        0,
+        8
+      );
+      return [
+        `Collider ${record.candidate.id}`,
+        `  runtime name: ${record.candidate.name}`,
+        `  source ID: ${record.candidate.sourceId ?? 'n/a'}`,
+        `  source type: ${record.candidate.sourceType ?? 'n/a'}`,
+        `  intent: ${record.candidate.intent ?? 'n/a'}`,
+        `  role: ${record.candidate.role ?? 'n/a'}`,
+        `  purpose: ${record.candidate.purpose ?? 'n/a'}`,
+        `  floor/category filter: ${record.filters.floor}/${record.filters.category}`,
+        `  evidence label: ${record.label}`,
+        `  note: ${record.disclaimer}`,
+        `Exact duplicates: ${record.exactDuplicates.length}`,
+        ...record.exactDuplicates.map(
+          (collider) => `  - ${formatCollider(collider)}`
+        ),
+        `Full containment:`,
+        `  candidate contained by: ${record.containedBy.length}`,
+        ...record.containedBy.map(
+          (collider) => `  - ${formatCollider(collider)}`
+        ),
+        `  candidate contains: ${record.contains.length}`,
+        ...record.contains.map((collider) => `  - ${formatCollider(collider)}`),
+        `Pairwise overlaps: ${record.pairwiseOverlaps.length}`,
+        ...record.pairwiseOverlaps.map(formatPair),
+        `Union coverage estimate: ${roundPercent(record.unionCoverage.coverageRatio)}% (${record.unionCoverage.coveredSamples}/${record.unionCoverage.totalSamples} deterministic samples)`,
+        `  uncovered sample count: ${record.unionCoverage.uncoveredSamples.length}`,
+        ...uncoveredPreview.map((sample) => `  - x ${sample.x}, z ${sample.z}`),
+        record.unionCoverage.uncoveredSamples.length > uncoveredPreview.length
+          ? `  - ...${record.unionCoverage.uncoveredSamples.length - uncoveredPreview.length} more`
+          : undefined,
+        `Edge adjacency within ${record.filters.tolerance}: ${record.adjacent.length}`,
+        ...record.adjacent.map(formatPair),
+      ]
+        .filter((line): line is string => Boolean(line))
+        .join('\n');
+    })
+    .join('\n\n');
+
+export const runColliderGeometryAuditCli = async (args: readonly string[]) => {
+  const options = parseColliderGeometryAuditArgs(args);
+  const colliders = await collectRuntimeColliders();
+  const records = auditColliderGeometry(colliders, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(records, null, 2)}\n`
+      : `${formatGeometryAuditRecords(records)}\n`
+  );
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderGeometryAuditCli(process.argv.slice(2)).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide maintainers deterministic, opt-in geometric evidence to evaluate collider-removal candidates without asserting deletion safety.
- Reuse the existing runtime collider collector and matching primitives so the audit stays read-only, scoped, and consistent with the inspector.

### Description
- Add pure geometry helpers in `scripts/colliderGeometry.ts` for rectangle intersection, area, containment, distance/adjacency, and deterministic sample-grid union coverage.
- Add a new CLI `scripts/colliderGeometryAudit.ts` exposed as `npm run collider:audit:geometry` that reuses the runtime collector and inspector matching, supports `--id|--source-id|--name`, and optional `--tolerance`, `--samples`, and `--json` flags, and reports duplicates, containment, pairwise overlap, union coverage, and edge adjacency filtered by floor/category.
- Add synthetic Vitest tests in `scripts/__tests__/colliderGeometry.test.ts` and `scripts/__tests__/colliderGeometryAudit.test.ts` that validate duplicates, containment, partial overlap, adjacency, and deterministic union-coverage behavior.
- Document usage and limitations in `docs/design/editing-level-data.md` and wire the command into `package.json` as `collider:audit:geometry`.

### Testing
- Ran the audit CLI locally with `npm run collider:audit:geometry -- --id 1007` and `npm run collider:audit:geometry -- --source-id upper.stairwell.landingGuard.shoulderEast --json`, which produced human-readable and JSON output respectively (Playwright browsers were installed during verification to run the runtime collector).
- Unit tests: `npm run test:ci` completed successfully with all suites passing (final run: 1245 tests passed across the repo) and `npm run test:ci -- scripts` passed during development.
- Lint and formatting: `npm run lint` passed after auto-fixing an import-order warning, and `npm run format:write` was applied to new files.
- Docs & smoke: `npm run docs:check` passed (link checker produced existing external-host warnings only) and `npm run smoke` (build + dist checks) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38a141f744832fbce805fa295f6f46)