### PR TITLE
Add opt-in collider geometry audit

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -124,7 +124,7 @@ safety guards, and secondary backstops that protect traversal edge cases.
 
 ```bash
 npm run collider:audit:geometry -- --id 400D
-npm run collider:audit:geometry -- --source-id backyard.fence.back.physicalBoundary
+npm run collider:audit:geometry -- --source-id ground.backyard.perimeter.backFence.boundary
 npm run collider:audit:geometry -- --id 1007 --json
 ```
 

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -110,6 +110,28 @@ npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json
 
 Set `PLAYWRIGHT_BASE_URL` to reuse an already-running preview or dev server.
 
+## Audit collider geometry from the CLI
+
+When two colliders look redundant, run the opt-in geometry audit against one
+candidate at a time. The audit reuses the same runtime debug collector and
+selector matching as the inspector, then compares only colliders on compatible
+floors and in the same category so unrelated floors do not create false
+evidence. It reports exact duplicates, containment in either direction,
+pairwise overlap percentages, deterministic sample-grid union coverage, and
+nearby edge adjacency. The labels are review evidence only: geometry overlap
+does not prove a collider is safe to delete, especially for outer walls, stair
+safety guards, and secondary backstops that protect traversal edge cases.
+
+```bash
+npm run collider:audit:geometry -- --id 400D
+npm run collider:audit:geometry -- --source-id backyard.fence.back.physicalBoundary
+npm run collider:audit:geometry -- --id 1007 --json
+```
+
+Use `--samples <count>` to tune the deterministic per-axis union-coverage grid
+and `--tolerance <world-units>` to adjust nearby-edge or nearly-identical bounds
+matching. Audit output is not persisted and is not part of required CI.
+
 ## Inspect source IDs in the browser
 
 Launch immersive mode with performance failover disabled:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:e2e": "playwright test",
     "links:check": "node scripts/check-links.cjs",
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
-    "collider:inspect": "tsx scripts/colliderInspect.ts"
+    "collider:inspect": "tsx scripts/colliderInspect.ts",
+    "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderGeometryAudit.test.ts
+++ b/scripts/__tests__/colliderGeometryAudit.test.ts
@@ -38,6 +38,13 @@ const colliders: RuntimeColliderMetadata[] = [
     bounds: { minX: 4.02, maxX: 5, minZ: 0, maxZ: 4 },
   },
   {
+    id: 'ALL',
+    floor: 'all',
+    category: 'stair',
+    name: 'AllFloorDuplicate',
+    bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+  },
+  {
     id: 'GROUND',
     floor: 'ground',
     category: 'stair',
@@ -76,11 +83,17 @@ describe('parseColliderGeometryAuditArgs', () => {
     });
   });
 
-  it('allows exact-match tolerance and rejects fractional sample counts', () => {
+  it('allows exact-match tolerance and valid integer sample counts', () => {
     expect(
       parseColliderGeometryAuditArgs(['--id', '1007', '--tolerance', '0'])
     ).toMatchObject({ tolerance: 0 });
 
+    expect(
+      parseColliderGeometryAuditArgs(['--id', '1007', '--samples', '1'])
+    ).toMatchObject({ samples: 1 });
+  });
+
+  it('rejects fractional sample counts before they can be floored', () => {
     expect(() =>
       parseColliderGeometryAuditArgs(['--id', '1007', '--samples', '0.5'])
     ).toThrow('--samples must be a positive integer.');
@@ -98,12 +111,14 @@ describe('auditColliderGeometry', () => {
 
     expect(report.filters).toMatchObject({ floor: 'upper', category: 'stair' });
     expect(report.evidence.map((item) => item.collider.id)).toEqual([
+      'ALL',
       'DUP1',
       'EDGE',
     ]);
     expect(report.evidence[0].labels).toContain('exact duplicate');
     expect(report.evidence[0].labels).toContain('candidate fully contained');
-    expect(report.evidence[1].labels).toEqual(['edge adjacent']);
+    expect(report.evidence[1].labels).toContain('exact duplicate');
+    expect(report.evidence[2].labels).toEqual(['edge adjacent']);
     expect(report.unionCoverage.coveragePercent).toBe(100);
     expect(report.classification).toBe('exact duplicate');
   });
@@ -129,7 +144,22 @@ describe('auditColliderGeometry', () => {
       }
     );
 
+    expect(report.evidence[0].candidateCoveragePercent).toBe(0);
     expect(report.evidence[0].otherCoveragePercent).toBe(0);
+    expect(JSON.stringify(report)).not.toContain('null');
+  });
+
+  it('uses all-floor colliders as comparable evidence for specific floors', () => {
+    const [report] = auditColliderGeometry(colliders, {
+      query: { kind: 'id', value: '1007' },
+      json: false,
+      tolerance: 0.05,
+      samples: 4,
+    });
+
+    expect(report.evidence.some((item) => item.collider.id === 'ALL')).toBe(
+      true
+    );
   });
 
   it('includes matched IDs in ambiguous match errors', () => {

--- a/scripts/__tests__/colliderGeometryAudit.test.ts
+++ b/scripts/__tests__/colliderGeometryAudit.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  auditColliderGeometry,
+  formatColliderGeometryAuditReports,
+  parseColliderGeometryAuditArgs,
+} from '../colliderGeometryAudit';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const colliders: RuntimeColliderMetadata[] = [
+  {
+    id: '1007',
+    floor: 'upper',
+    category: 'stair',
+    name: 'Candidate',
+    sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+    bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+  },
+  {
+    id: 'DUP1',
+    floor: 'upper',
+    category: 'stair',
+    name: 'Duplicate',
+    bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+  },
+  {
+    id: 'EDGE',
+    floor: 'upper',
+    category: 'stair',
+    name: 'Neighbor',
+    bounds: { minX: 4.02, maxX: 5, minZ: 0, maxZ: 4 },
+  },
+  {
+    id: 'GROUND',
+    floor: 'ground',
+    category: 'stair',
+    name: 'DifferentFloor',
+    bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+  },
+  {
+    id: 'WALL',
+    floor: 'upper',
+    category: 'wall',
+    name: 'DifferentCategory',
+    bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+  },
+];
+
+describe('parseColliderGeometryAuditArgs', () => {
+  it('parses selector, json, samples, and tolerance', () => {
+    expect(
+      parseColliderGeometryAuditArgs([
+        '--source-id',
+        'upper.stairwell.landingGuard.shoulderEast',
+        '--json',
+        '--samples',
+        '8',
+        '--tolerance',
+        '0.1',
+      ])
+    ).toEqual({
+      query: {
+        kind: 'source-id',
+        value: 'upper.stairwell.landingGuard.shoulderEast',
+      },
+      json: true,
+      samples: 8,
+      tolerance: 0.1,
+    });
+  });
+});
+
+describe('auditColliderGeometry', () => {
+  it('orders duplicate, containment, overlap, union coverage, and adjacency evidence', () => {
+    const [report] = auditColliderGeometry(colliders, {
+      query: { kind: 'id', value: '1007' },
+      json: false,
+      tolerance: 0.05,
+      samples: 4,
+    });
+
+    expect(report.filters).toMatchObject({ floor: 'upper', category: 'stair' });
+    expect(report.evidence.map((item) => item.collider.id)).toEqual([
+      'DUP1',
+      'EDGE',
+    ]);
+    expect(report.evidence[0].labels).toContain('exact duplicate');
+    expect(report.evidence[0].labels).toContain('candidate fully contained');
+    expect(report.evidence[1].labels).toEqual(['edge adjacent']);
+    expect(report.unionCoverage.coveragePercent).toBe(100);
+    expect(report.classification).toBe('exact duplicate');
+  });
+
+  it('formats limitation language without safe-delete claims', () => {
+    const [report] = auditColliderGeometry(colliders, {
+      query: { kind: 'id', value: '1007' },
+      json: false,
+      tolerance: 0.05,
+      samples: 4,
+    });
+    const output = formatColliderGeometryAuditReports([report]);
+    expect(output).toContain('supporting evidence only');
+    expect(output).not.toContain('safe to delete');
+  });
+});

--- a/scripts/__tests__/colliderGeometryAudit.test.ts
+++ b/scripts/__tests__/colliderGeometryAudit.test.ts
@@ -17,6 +17,13 @@ const colliders: RuntimeColliderMetadata[] = [
     bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
   },
   {
+    id: 'AMBIG',
+    floor: 'upper',
+    category: 'stair',
+    name: 'Candidate',
+    bounds: { minX: 10, maxX: 12, minZ: 10, maxZ: 12 },
+  },
+  {
     id: 'DUP1',
     floor: 'upper',
     category: 'stair',
@@ -68,6 +75,16 @@ describe('parseColliderGeometryAuditArgs', () => {
       tolerance: 0.1,
     });
   });
+
+  it('allows exact-match tolerance and rejects fractional sample counts', () => {
+    expect(
+      parseColliderGeometryAuditArgs(['--id', '1007', '--tolerance', '0'])
+    ).toMatchObject({ tolerance: 0 });
+
+    expect(() =>
+      parseColliderGeometryAuditArgs(['--id', '1007', '--samples', '0.5'])
+    ).toThrow('--samples must be a positive integer.');
+  });
 });
 
 describe('auditColliderGeometry', () => {
@@ -89,6 +106,41 @@ describe('auditColliderGeometry', () => {
     expect(report.evidence[1].labels).toEqual(['edge adjacent']);
     expect(report.unionCoverage.coveragePercent).toBe(100);
     expect(report.classification).toBe('exact duplicate');
+  });
+
+  it('reports zero coverage for degenerate colliders instead of NaN', () => {
+    const [candidate] = colliders;
+    const [report] = auditColliderGeometry(
+      [
+        candidate,
+        {
+          id: 'LINE',
+          floor: 'upper',
+          category: 'stair',
+          name: 'Line',
+          bounds: { minX: 1, maxX: 1, minZ: 0, maxZ: 4 },
+        },
+      ],
+      {
+        query: { kind: 'id', value: '1007' },
+        json: false,
+        tolerance: 0.05,
+        samples: 4,
+      }
+    );
+
+    expect(report.evidence[0].otherCoveragePercent).toBe(0);
+  });
+
+  it('includes matched IDs in ambiguous match errors', () => {
+    expect(() =>
+      auditColliderGeometry(colliders, {
+        query: { kind: 'name', value: 'Candidate' },
+        json: false,
+        tolerance: 0.05,
+        samples: 4,
+      })
+    ).toThrow('matched 2 records: 1007, AMBIG.');
   });
 
   it('formats limitation language without safe-delete claims', () => {

--- a/scripts/__tests__/rectangleGeometry.test.ts
+++ b/scripts/__tests__/rectangleGeometry.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  areRectanglesAdjacent,
+  containsRectangle,
+  estimateUnionCoverage,
+  rectangleArea,
+  rectangleIntersection,
+  rectangleSeparationDistance,
+  rectanglesEqual,
+} from '../rectangleGeometry';
+
+describe('rectangle geometry helpers', () => {
+  it('detects exact duplicate rectangles with tolerance', () => {
+    expect(
+      rectanglesEqual(
+        { minX: 0, maxX: 2, minZ: 0, maxZ: 2 },
+        { minX: 0, maxX: 2, minZ: 0, maxZ: 2 }
+      )
+    ).toBe(true);
+    expect(
+      rectanglesEqual(
+        { minX: 0, maxX: 2, minZ: 0, maxZ: 2 },
+        { minX: 0.01, maxX: 2, minZ: 0, maxZ: 2 },
+        0.02
+      )
+    ).toBe(true);
+  });
+
+  it('computes area, intersection, and containment', () => {
+    const outer = { minX: 0, maxX: 4, minZ: 0, maxZ: 4 };
+    const inner = { minX: 1, maxX: 3, minZ: 1, maxZ: 3 };
+    expect(rectangleArea(outer)).toBe(16);
+    expect(rectangleIntersection(outer, inner)).toEqual({ ...inner, area: 4 });
+    expect(containsRectangle(outer, inner)).toBe(true);
+    expect(containsRectangle(inner, outer)).toBe(false);
+  });
+
+  it('distinguishes partial overlap from disjoint rectangles', () => {
+    const left = { minX: 0, maxX: 2, minZ: 0, maxZ: 2 };
+    expect(
+      rectangleIntersection(left, { minX: 1, maxX: 3, minZ: 1, maxZ: 3 })?.area
+    ).toBe(1);
+    expect(
+      rectangleIntersection(left, { minX: 3, maxX: 4, minZ: 3, maxZ: 4 })
+    ).toBeUndefined();
+  });
+
+  it('reports edge adjacency within tolerance', () => {
+    const left = { minX: 0, maxX: 1, minZ: 0, maxZ: 1 };
+    const right = { minX: 1.03, maxX: 2, minZ: 0, maxZ: 1 };
+    expect(rectangleSeparationDistance(left, right)).toBeCloseTo(0.03);
+    expect(areRectanglesAdjacent(left, right, 0.05)).toBe(true);
+    expect(areRectanglesAdjacent(left, right, 0.01)).toBe(false);
+  });
+
+  it('estimates multi-collider union coverage deterministically', () => {
+    const candidate = { minX: 0, maxX: 4, minZ: 0, maxZ: 4 };
+    const coverage = estimateUnionCoverage(
+      candidate,
+      [
+        { minX: 0, maxX: 2, minZ: 0, maxZ: 4 },
+        { minX: 2, maxX: 4, minZ: 0, maxZ: 2 },
+      ],
+      4
+    );
+    expect(coverage.totalSamples).toBe(16);
+    expect(coverage.coveredSamples).toBe(12);
+    expect(coverage.coverageRatio).toBe(0.75);
+    expect(coverage.uncoveredSamples).toEqual([
+      { x: 2.5, z: 2.5, covered: false },
+      { x: 3.5, z: 2.5, covered: false },
+      { x: 2.5, z: 3.5, covered: false },
+      { x: 3.5, z: 3.5, covered: false },
+    ]);
+  });
+});

--- a/scripts/colliderGeometryAudit.ts
+++ b/scripts/colliderGeometryAudit.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   findColliderMatches,
+  floorsCanOverlap,
   formatOptional,
   type ColliderInspectQuery,
 } from './colliderInspect';
@@ -62,9 +63,6 @@ const percent = (ratio: number) => round(ratio * 100);
 const NOTE =
   'Geometry overlap is supporting evidence only; this tool never proves safe deletion.';
 
-const floorsCanOverlap = (left: string, right: string): boolean =>
-  left === right || left === 'all' || right === 'all';
-
 const sameReviewGroup = (
   candidate: RuntimeColliderMetadata,
   other: RuntimeColliderMetadata
@@ -96,10 +94,16 @@ export const parseColliderGeometryAuditArgs = (
     }
     if (arg === '--tolerance' || arg === '--samples') {
       const value = Number(readValue(index, arg));
-      if (!Number.isFinite(value) || value <= 0)
-        throw new Error(`${arg} must be positive.`);
-      if (arg === '--tolerance') tolerance = value;
-      if (arg === '--samples') samples = Math.floor(value);
+      if (!Number.isFinite(value)) throw new Error(`${arg} must be a number.`);
+      if (arg === '--tolerance') {
+        if (value < 0) throw new Error(`${arg} must be zero or positive.`);
+        tolerance = value;
+      }
+      if (arg === '--samples') {
+        if (!Number.isInteger(value) || value < 1)
+          throw new Error(`${arg} must be a positive integer.`);
+        samples = value;
+      }
       index += 1;
       continue;
     }
@@ -149,7 +153,7 @@ export const auditColliderGeometry = (
     );
   if (options.query.kind !== 'source-id' && matches.length > 1) {
     throw new Error(
-      `Ambiguous collider ${options.query.kind} "${options.query.value}" matched ${matches.length} records.`
+      `Ambiguous collider ${options.query.kind} "${options.query.value}" matched ${matches.length} records: ${matches.map((match) => match.id).join(', ')}.`
     );
   }
 
@@ -191,15 +195,15 @@ export const auditColliderGeometry = (
         )
           labels.push('edge adjacent');
         if (labels.length === 0) return undefined;
+        const otherArea = rectangleArea(other.bounds);
         return {
           collider: other,
           labels,
           intersectionArea: round(intersectionArea),
           candidateCoveragePercent:
             candidateArea > 0 ? percent(intersectionArea / candidateArea) : 0,
-          otherCoveragePercent: percent(
-            intersectionArea / rectangleArea(other.bounds)
-          ),
+          otherCoveragePercent:
+            otherArea > 0 ? percent(intersectionArea / otherArea) : 0,
           separationDistance: round(
             rectangleSeparationDistance(candidate.bounds, other.bounds)
           ),

--- a/scripts/colliderGeometryAudit.ts
+++ b/scripts/colliderGeometryAudit.ts
@@ -1,0 +1,308 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  findColliderMatches,
+  formatOptional,
+  type ColliderInspectQuery,
+} from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+import {
+  areRectanglesAdjacent,
+  containsRectangle,
+  estimateUnionCoverage,
+  rectangleArea,
+  rectangleIntersection,
+  rectangleSeparationDistance,
+  rectanglesEqual,
+} from './rectangleGeometry';
+
+export type ColliderGeometryAuditOptions = {
+  query: ColliderInspectQuery;
+  json: boolean;
+  tolerance: number;
+  samples: number;
+};
+
+type RelatedColliderEvidence = {
+  collider: RuntimeColliderMetadata;
+  labels: string[];
+  intersectionArea: number;
+  candidateCoveragePercent: number;
+  otherCoveragePercent: number;
+  separationDistance: number;
+};
+
+export type ColliderGeometryAuditReport = {
+  candidate: RuntimeColliderMetadata;
+  candidateArea: number;
+  filters: {
+    floor: string;
+    category: string;
+    tolerance: number;
+    samplesPerAxis: number;
+  };
+  evidence: RelatedColliderEvidence[];
+  unionCoverage: {
+    coveredSamples: number;
+    totalSamples: number;
+    coveragePercent: number;
+    uncoveredSamples: { x: number; z: number }[];
+  };
+  classification: string;
+  note: string;
+};
+
+const round = (value: number) => Number(value.toFixed(3));
+const percent = (ratio: number) => round(ratio * 100);
+const NOTE =
+  'Geometry overlap is supporting evidence only; this tool never proves safe deletion.';
+
+const floorsCanOverlap = (left: string, right: string): boolean =>
+  left === right || left === 'all' || right === 'all';
+
+const sameReviewGroup = (
+  candidate: RuntimeColliderMetadata,
+  other: RuntimeColliderMetadata
+): boolean =>
+  candidate.id !== other.id &&
+  floorsCanOverlap(candidate.floor, other.floor) &&
+  candidate.category === other.category;
+
+export const parseColliderGeometryAuditArgs = (
+  args: readonly string[]
+): ColliderGeometryAuditOptions => {
+  let query: ColliderInspectQuery | undefined;
+  let json = false;
+  let tolerance = 0.05;
+  let samples = 16;
+
+  const readValue = (index: number, flag: string): string => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+    if (arg === '--tolerance' || arg === '--samples') {
+      const value = Number(readValue(index, arg));
+      if (!Number.isFinite(value) || value <= 0)
+        throw new Error(`${arg} must be positive.`);
+      if (arg === '--tolerance') tolerance = value;
+      if (arg === '--samples') samples = Math.floor(value);
+      index += 1;
+      continue;
+    }
+    if (arg === '--id' || arg === '--source-id' || arg === '--name') {
+      if (query)
+        throw new Error('Provide exactly one of --id, --source-id, or --name.');
+      query = {
+        kind: arg.slice(2) as ColliderInspectQuery['kind'],
+        value: readValue(index, arg),
+      };
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!query)
+    throw new Error('Provide exactly one of --id, --source-id, or --name.');
+  return { query, json, tolerance, samples };
+};
+
+const classify = (
+  evidence: readonly RelatedColliderEvidence[],
+  coveragePercent: number
+): string => {
+  if (evidence.some((item) => item.labels.includes('exact duplicate')))
+    return 'exact duplicate';
+  if (
+    evidence.some((item) => item.labels.includes('candidate fully contained'))
+  )
+    return 'fully contained';
+  if (coveragePercent >= 95) return 'highly overlapped';
+  if (coveragePercent > 0) return 'partially covered';
+  if (evidence.some((item) => item.labels.includes('edge adjacent')))
+    return 'ambiguous';
+  return 'isolated';
+};
+
+export const auditColliderGeometry = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: ColliderGeometryAuditOptions
+): ColliderGeometryAuditReport[] => {
+  const matches = findColliderMatches(colliders, options.query);
+  if (matches.length === 0)
+    throw new Error(
+      `No collider matched ${options.query.kind} "${options.query.value}".`
+    );
+  if (options.query.kind !== 'source-id' && matches.length > 1) {
+    throw new Error(
+      `Ambiguous collider ${options.query.kind} "${options.query.value}" matched ${matches.length} records.`
+    );
+  }
+
+  return matches.map((candidate) => {
+    const candidateArea = rectangleArea(candidate.bounds);
+    const others = colliders.filter((other) =>
+      sameReviewGroup(candidate, other)
+    );
+    const evidence = others
+      .map((other): RelatedColliderEvidence | undefined => {
+        const intersection = rectangleIntersection(
+          candidate.bounds,
+          other.bounds
+        );
+        const intersectionArea = intersection?.area ?? 0;
+        const labels: string[] = [];
+        if (rectanglesEqual(candidate.bounds, other.bounds, options.tolerance))
+          labels.push('exact duplicate');
+        if (
+          containsRectangle(other.bounds, candidate.bounds, options.tolerance)
+        )
+          labels.push('candidate fully contained');
+        if (
+          containsRectangle(candidate.bounds, other.bounds, options.tolerance)
+        )
+          labels.push('contains other collider');
+        if (intersectionArea > 0)
+          labels.push(
+            intersectionArea / candidateArea >= 0.8
+              ? 'highly overlapped'
+              : 'partially covered'
+          );
+        if (
+          areRectanglesAdjacent(
+            candidate.bounds,
+            other.bounds,
+            options.tolerance
+          )
+        )
+          labels.push('edge adjacent');
+        if (labels.length === 0) return undefined;
+        return {
+          collider: other,
+          labels,
+          intersectionArea: round(intersectionArea),
+          candidateCoveragePercent:
+            candidateArea > 0 ? percent(intersectionArea / candidateArea) : 0,
+          otherCoveragePercent: percent(
+            intersectionArea / rectangleArea(other.bounds)
+          ),
+          separationDistance: round(
+            rectangleSeparationDistance(candidate.bounds, other.bounds)
+          ),
+        };
+      })
+      .filter((item): item is RelatedColliderEvidence => Boolean(item))
+      .sort(
+        (left, right) =>
+          right.candidateCoveragePercent - left.candidateCoveragePercent ||
+          left.separationDistance - right.separationDistance ||
+          left.collider.id.localeCompare(right.collider.id)
+      );
+
+    const coverage = estimateUnionCoverage(
+      candidate.bounds,
+      others.map((other) => other.bounds),
+      options.samples
+    );
+    const coveragePercent = percent(coverage.coverageRatio);
+    return {
+      candidate,
+      candidateArea: round(candidateArea),
+      filters: {
+        floor: candidate.floor,
+        category: candidate.category,
+        tolerance: options.tolerance,
+        samplesPerAxis: options.samples,
+      },
+      evidence,
+      unionCoverage: {
+        coveredSamples: coverage.coveredSamples,
+        totalSamples: coverage.totalSamples,
+        coveragePercent,
+        uncoveredSamples: coverage.uncoveredSamples
+          .slice(0, 12)
+          .map((sample) => ({ x: round(sample.x), z: round(sample.z) })),
+      },
+      classification: classify(evidence, coveragePercent),
+      note: NOTE,
+    };
+  });
+};
+
+const formatEvidence = (evidence: RelatedColliderEvidence): string =>
+  [
+    `  - ${evidence.collider.id} ${evidence.collider.name}`,
+    `    labels: ${evidence.labels.join(', ')}`,
+    `    source ID: ${formatOptional(evidence.collider.sourceId)}`,
+    `    intersection area: ${evidence.intersectionArea}`,
+    `    candidate coverage: ${evidence.candidateCoveragePercent}%`,
+    `    other coverage: ${evidence.otherCoveragePercent}%`,
+    `    separation distance: ${evidence.separationDistance}`,
+  ].join('\n');
+
+export const formatColliderGeometryAuditReports = (
+  reports: readonly ColliderGeometryAuditReport[]
+): string =>
+  reports
+    .map((report) =>
+      [
+        `Candidate ${report.candidate.id}`,
+        `  runtime name: ${report.candidate.name}`,
+        `  source ID: ${formatOptional(report.candidate.sourceId)}`,
+        `  floor/category filter: ${report.filters.floor}/${report.filters.category}`,
+        `  bounds: x ${report.candidate.bounds.minX}..${report.candidate.bounds.maxX}, z ${report.candidate.bounds.minZ}..${report.candidate.bounds.maxZ}`,
+        `  area: ${report.candidateArea}`,
+        `  classification: ${report.classification}`,
+        `  note: ${report.note}`,
+        'Evidence:',
+        report.evidence.length > 0
+          ? report.evidence.map(formatEvidence).join('\n')
+          : '  - none',
+        'Union coverage estimate:',
+        `  samples: ${report.unionCoverage.coveredSamples}/${report.unionCoverage.totalSamples}`,
+        `  candidate coverage: ${report.unionCoverage.coveragePercent}%`,
+        `  uncovered sample points: ${report.unionCoverage.uncoveredSamples.length > 0 ? JSON.stringify(report.unionCoverage.uncoveredSamples) : 'none in sample grid'}`,
+      ].join('\n')
+    )
+    .join('\n\n');
+
+export const runColliderGeometryAuditCli = async (args: readonly string[]) => {
+  const options = parseColliderGeometryAuditArgs(args);
+  const colliders = await collectRuntimeColliders();
+  const reports = auditColliderGeometry(colliders, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(reports, null, 2)}\n`
+      : `${formatColliderGeometryAuditReports(reports)}\n`
+  );
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderGeometryAuditCli(process.argv.slice(2)).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/colliderInspect.ts
+++ b/scripts/colliderInspect.ts
@@ -150,7 +150,8 @@ export const toInspectionRecords = (
 const formatBounds = (bounds: RuntimeColliderMetadata['bounds']): string =>
   `x ${bounds.minX}..${bounds.maxX}, z ${bounds.minZ}..${bounds.maxZ}`;
 
-const formatOptional = (value: string | undefined): string => value ?? 'n/a';
+export const formatOptional = (value: string | undefined): string =>
+  value ?? 'n/a';
 
 export const formatInspectionRecords = (
   records: readonly ColliderInspectionRecord[]

--- a/scripts/colliderInspect.ts
+++ b/scripts/colliderInspect.ts
@@ -43,7 +43,7 @@ const getDimensions = (bounds: RuntimeColliderMetadata['bounds']) => {
   };
 };
 
-const floorsCanOverlap = (left: string, right: string): boolean =>
+export const floorsCanOverlap = (left: string, right: string): boolean =>
   left === right || left === 'all' || right === 'all';
 
 const boundsOverlap = (

--- a/scripts/rectangleGeometry.ts
+++ b/scripts/rectangleGeometry.ts
@@ -1,0 +1,118 @@
+export type RectangleBounds = {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+};
+
+export type RectangleIntersection = RectangleBounds & { area: number };
+
+export type UnionCoverageSample = {
+  x: number;
+  z: number;
+  covered: boolean;
+};
+
+export type UnionCoverageEstimate = {
+  totalSamples: number;
+  coveredSamples: number;
+  uncoveredSamples: UnionCoverageSample[];
+  coverageRatio: number;
+};
+
+export const rectangleArea = (bounds: RectangleBounds): number =>
+  Math.max(0, bounds.maxX - bounds.minX) *
+  Math.max(0, bounds.maxZ - bounds.minZ);
+
+export const rectanglesEqual = (
+  left: RectangleBounds,
+  right: RectangleBounds,
+  tolerance = 0
+): boolean =>
+  Math.abs(left.minX - right.minX) <= tolerance &&
+  Math.abs(left.maxX - right.maxX) <= tolerance &&
+  Math.abs(left.minZ - right.minZ) <= tolerance &&
+  Math.abs(left.maxZ - right.maxZ) <= tolerance;
+
+export const rectangleIntersection = (
+  left: RectangleBounds,
+  right: RectangleBounds
+): RectangleIntersection | undefined => {
+  const intersection = {
+    minX: Math.max(left.minX, right.minX),
+    maxX: Math.min(left.maxX, right.maxX),
+    minZ: Math.max(left.minZ, right.minZ),
+    maxZ: Math.min(left.maxZ, right.maxZ),
+  };
+  const area = rectangleArea(intersection);
+  return area > 0 ? { ...intersection, area } : undefined;
+};
+
+export const containsRectangle = (
+  outer: RectangleBounds,
+  inner: RectangleBounds,
+  tolerance = 0
+): boolean =>
+  outer.minX <= inner.minX + tolerance &&
+  outer.maxX >= inner.maxX - tolerance &&
+  outer.minZ <= inner.minZ + tolerance &&
+  outer.maxZ >= inner.maxZ - tolerance;
+
+export const rectangleSeparationDistance = (
+  left: RectangleBounds,
+  right: RectangleBounds
+): number => {
+  const gapX = Math.max(0, left.minX - right.maxX, right.minX - left.maxX);
+  const gapZ = Math.max(0, left.minZ - right.maxZ, right.minZ - left.maxZ);
+  return Math.hypot(gapX, gapZ);
+};
+
+export const areRectanglesAdjacent = (
+  left: RectangleBounds,
+  right: RectangleBounds,
+  tolerance: number
+): boolean =>
+  !rectangleIntersection(left, right) &&
+  rectangleSeparationDistance(left, right) <= tolerance;
+
+const pointInRectangle = (
+  point: { x: number; z: number },
+  bounds: RectangleBounds
+): boolean =>
+  point.x >= bounds.minX &&
+  point.x <= bounds.maxX &&
+  point.z >= bounds.minZ &&
+  point.z <= bounds.maxZ;
+
+export const estimateUnionCoverage = (
+  candidate: RectangleBounds,
+  others: readonly RectangleBounds[],
+  samplesPerAxis: number
+): UnionCoverageEstimate => {
+  const safeSamples = Math.max(1, Math.floor(samplesPerAxis));
+  const width = candidate.maxX - candidate.minX;
+  const depth = candidate.maxZ - candidate.minZ;
+  const uncoveredSamples: UnionCoverageSample[] = [];
+  let coveredSamples = 0;
+
+  for (let zIndex = 0; zIndex < safeSamples; zIndex += 1) {
+    for (let xIndex = 0; xIndex < safeSamples; xIndex += 1) {
+      const x = candidate.minX + ((xIndex + 0.5) / safeSamples) * width;
+      const z = candidate.minZ + ((zIndex + 0.5) / safeSamples) * depth;
+      const covered = others.some((other) => pointInRectangle({ x, z }, other));
+      if (covered) {
+        coveredSamples += 1;
+      } else {
+        uncoveredSamples.push({ x, z, covered });
+      }
+    }
+  }
+
+  const totalSamples = safeSamples * safeSamples;
+  return {
+    totalSamples,
+    coveredSamples,
+    uncoveredSamples,
+    coverageRatio: totalSamples === 0 ? 0 : coveredSamples / totalSamples,
+  };
+};


### PR DESCRIPTION
### Motivation
- Give maintainers a deterministic, candidate-focused tool to quantify geometric evidence when evaluating collider-removal candidates without claiming geometry alone proves redundancy.
- Keep the audit opt-in and candidate-specific so it does not become a CI gate and does not change runtime colliders or scene state.
- Reuse the existing runtime collider collector and selector matching to avoid duplicating runtime metadata plumbing.

### Description
- Add a new CLI `scripts/colliderGeometryAudit.ts` and npm script `collider:audit:geometry` that accepts `--id`, `--source-id`, `--name`, `--json`, `--tolerance`, and `--samples` and prints candidate metadata followed by ordered evidence (duplicates, containment, pairwise overlap, union coverage estimate, and edge adjacency).
- Implement pure rectangle helpers in `scripts/rectangleGeometry.ts` for `intersection`, `area`, `contains`, `distance/adjacency`, and deterministic sample-grid `estimateUnionCoverage` and use them from the audit.
- Share matching/collection/formatting primitives with the existing inspector by reusing `collectRuntimeColliders`, `findColliderMatches`, and exporting `formatOptional` from `scripts/colliderInspect.ts` instead of creating parallel formatters.
- Add synthetic Vitest tests: rectangle math tests (`scripts/__tests__/rectangleGeometry.test.ts`) and audit tests (`scripts/__tests__/colliderGeometryAudit.test.ts`) that exercise duplicates, containment, partial overlap, adjacency, and multi-collider union coverage.
- Document usage and limitations in `docs/design/editing-level-data.md`; no runtime colliders were changed, no new deps added, and audit output is not persisted.

### Testing
- Ran `npm run format:write` and `npm run format:check` with no formatting failures (success).
- Executed the new CLI end-to-end (required installing Playwright browsers and host deps); after `npx playwright install chromium-headless-shell` and `npx playwright install-deps chromium-headless-shell` the audit ran successfully for real candidates: `npm run collider:audit:geometry -- --id 1007` and `npm run collider:audit:geometry -- --source-id upper.stairwell.landingGuard.shoulderEast --json` (success).
- Ran targeted script tests: `npm run test:ci -- scripts` which passed the new script tests (all script tests passed).
- Ran full suite: `npm run test:ci` (Vitest) which completed successfully (all tests passed in CI run used here).
- Ran `npm run lint` (warning fixed during development) and `npm run docs:check` and `npm run smoke`; all completed successfully.
- Performed a secrets check via `git diff --cached | ./scripts/scan-secrets.py` with no high-risk secrets found.

All automated checks listed above passed in this environment; Playwright browser and OS-level deps were installed locally to enable runtime collection for the CLI runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38a16277bc832f8632cd6661ffeb9b)