### PR TITLE
Add opt-in collider geometry audit

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -110,6 +110,30 @@ npm run collider:inspect -- --name UpperStairNorthBannisterGuard --json
 
 Set `PLAYWRIGHT_BASE_URL` to reuse an already-running preview or dev server.
 
+## Audit collider geometry from the CLI
+
+Use the opt-in geometry audit when comparing a specific removal candidate to
+other active runtime colliders. The audit reuses the same runtime collector and
+selector semantics as `collider:inspect`, then limits comparisons to matching
+floors and categories so unrelated floors do not create false evidence.
+
+```bash
+npm run collider:audit:geometry -- --id 400D
+npm run collider:audit:geometry -- --source-id backyard.fence.back.physicalBoundary
+npm run collider:audit:geometry -- --id 1007 --json
+```
+
+The report prints candidate metadata first, then exact duplicate rectangles,
+containment in both directions, pairwise overlap percentages, deterministic
+sample-grid union coverage, uncovered samples, and edge adjacency within a small
+tolerance. Optional `--tolerance <number>` and `--samples <integer>` flags tune
+adjacency/containment tolerance and the per-axis union-coverage grid. Geometry
+labels such as `exact duplicate`, `fully contained`, or `highly overlapped` are
+supporting evidence only; geometry alone must not be treated as proof that a
+collider is safe to delete. Review source purpose, outer-wall intent, stair and
+void safety behavior, and secondary backstops before changing collider source
+data.
+
 ## Inspect source IDs in the browser
 
 Launch immersive mode with performance failover disabled:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:e2e": "playwright test",
     "links:check": "node scripts/check-links.cjs",
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
-    "collider:inspect": "tsx scripts/colliderInspect.ts"
+    "collider:inspect": "tsx scripts/colliderInspect.ts",
+    "collider:audit:geometry": "tsx scripts/colliderAuditGeometry.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderAuditGeometry.test.ts
+++ b/scripts/__tests__/colliderAuditGeometry.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  auditColliderGeometry,
+  formatGeometryAuditRecords,
+  parseColliderGeometryAuditArgs,
+} from '../colliderAuditGeometry';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const collider = (
+  id: string,
+  bounds: RuntimeColliderMetadata['bounds'],
+  floor = 'ground',
+  category = 'wall'
+): RuntimeColliderMetadata => ({
+  id,
+  bounds,
+  floor,
+  category,
+  name: `Collider${id}`,
+  sourceId: `source.${id}`,
+});
+
+const colliders: RuntimeColliderMetadata[] = [
+  collider('A', { minX: 0, maxX: 4, minZ: 0, maxZ: 4 }),
+  collider('B', { minX: 0, maxX: 4, minZ: 0, maxZ: 4 }),
+  collider('C', { minX: 1, maxX: 3, minZ: 1, maxZ: 3 }),
+  collider('D', { minX: 3, maxX: 5, minZ: 0, maxZ: 2 }),
+  collider('E', { minX: 4.02, maxX: 5, minZ: 2.2, maxZ: 3.2 }),
+  collider('F', { minX: 0, maxX: 4, minZ: 0, maxZ: 4 }, 'upper'),
+  collider('G', { minX: 0, maxX: 4, minZ: 0, maxZ: 4 }, 'ground', 'safety'),
+];
+
+describe('parseColliderGeometryAuditArgs', () => {
+  it('parses selector, json, samples, and tolerance', () => {
+    expect(
+      parseColliderGeometryAuditArgs([
+        '--source-id',
+        'source.A',
+        '--json',
+        '--samples',
+        '8',
+        '--tolerance',
+        '0.1',
+      ])
+    ).toEqual({
+      query: { kind: 'source-id', value: 'source.A' },
+      json: true,
+      samples: 8,
+      tolerance: 0.1,
+    });
+  });
+});
+
+describe('auditColliderGeometry', () => {
+  it('reports duplicates, containment, overlap, adjacency, and union coverage', () => {
+    const [record] = auditColliderGeometry(colliders, {
+      query: { kind: 'id', value: 'A' },
+      json: false,
+      samples: 4,
+      tolerance: 0.05,
+    });
+
+    expect(record.exactDuplicates.map((match) => match.id)).toEqual(['B']);
+    expect(record.candidateContainedBy.map((match) => match.id)).toEqual(['B']);
+    expect(record.containedByCandidate.map((match) => match.id)).toEqual([
+      'B',
+      'C',
+    ]);
+    expect(record.overlaps.map((overlap) => overlap.collider.id)).toEqual([
+      'B',
+      'C',
+      'D',
+    ]);
+    expect(record.adjacent.map((match) => match.collider.id)).toEqual(['E']);
+    expect(record.unionCoverage.coveragePercent).toBe(100);
+    expect(record.comparedColliderCount).toBe(4);
+    expect(record.labels).toContain('exact duplicate');
+    expect(record.labels).toContain('fully contained');
+  });
+
+  it('avoids cross-floor and cross-category false positives', () => {
+    const [record] = auditColliderGeometry(colliders, {
+      query: { kind: 'id', value: 'A' },
+      json: false,
+      samples: 2,
+      tolerance: 0,
+    });
+
+    expect(record.exactDuplicates.map((match) => match.id)).not.toContain('F');
+    expect(record.exactDuplicates.map((match) => match.id)).not.toContain('G');
+  });
+
+  it('prints candidate metadata before supporting-evidence note', () => {
+    const [record] = auditColliderGeometry(colliders, {
+      query: { kind: 'id', value: 'D' },
+      json: false,
+      samples: 2,
+      tolerance: 0.05,
+    });
+    const output = formatGeometryAuditRecords([record]);
+    expect(output.indexOf('runtime name: ColliderD')).toBeLessThan(
+      output.indexOf('note:')
+    );
+    expect(output).toContain('Geometry overlap is supporting evidence only');
+  });
+});

--- a/scripts/__tests__/rectGeometry.test.ts
+++ b/scripts/__tests__/rectGeometry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  rectArea,
+  rectContains,
+  rectDistance,
+  rectIntersection,
+  rectsAdjacentWithin,
+  rectsEqual,
+  sampleGridUnionCoverage,
+} from '../rectGeometry';
+
+describe('rectGeometry', () => {
+  it('detects duplicate rectangles with tolerance', () => {
+    expect(
+      rectsEqual(
+        { minX: 0, maxX: 2, minZ: 0, maxZ: 2 },
+        { minX: 0.01, maxX: 2.01, minZ: -0.01, maxZ: 1.99 },
+        0.02
+      )
+    ).toBe(true);
+  });
+
+  it('calculates containment and area', () => {
+    const outer = { minX: 0, maxX: 4, minZ: 0, maxZ: 4 };
+    const inner = { minX: 1, maxX: 3, minZ: 1, maxZ: 3 };
+    expect(rectContains(outer, inner)).toBe(true);
+    expect(rectContains(inner, outer)).toBe(false);
+    expect(rectArea(inner)).toBe(4);
+  });
+
+  it('returns partial intersections', () => {
+    expect(
+      rectIntersection(
+        { minX: 0, maxX: 3, minZ: 0, maxZ: 3 },
+        { minX: 2, maxX: 4, minZ: 1, maxZ: 4 }
+      )
+    ).toEqual({ minX: 2, maxX: 3, minZ: 1, maxZ: 3 });
+  });
+
+  it('measures disjoint distance and adjacency tolerance', () => {
+    const left = { minX: 0, maxX: 1, minZ: 0, maxZ: 1 };
+    const right = { minX: 1.04, maxX: 2, minZ: 0, maxZ: 1 };
+    expect(rectIntersection(left, right)).toBeUndefined();
+    expect(rectDistance(left, right)).toBeCloseTo(0.04);
+    expect(rectsAdjacentWithin(left, right, 0.05)).toBe(true);
+    expect(rectsAdjacentWithin(left, right, 0.01)).toBe(false);
+  });
+
+  it('estimates multi-collider union coverage deterministically', () => {
+    const coverage = sampleGridUnionCoverage(
+      { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+      [
+        { minX: 0, maxX: 2, minZ: 0, maxZ: 4 },
+        { minX: 2, maxX: 4, minZ: 0, maxZ: 2 },
+      ],
+      4
+    );
+
+    expect(coverage.totalSamples).toBe(16);
+    expect(coverage.coveredSamples).toBe(12);
+    expect(coverage.coverageRatio).toBe(0.75);
+    expect(coverage.uncoveredSamples).toEqual([
+      { x: 2.5, z: 2.5 },
+      { x: 3.5, z: 2.5 },
+      { x: 2.5, z: 3.5 },
+      { x: 3.5, z: 3.5 },
+    ]);
+  });
+});

--- a/scripts/colliderAuditGeometry.ts
+++ b/scripts/colliderAuditGeometry.ts
@@ -1,0 +1,351 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  findColliderMatches,
+  formatBounds,
+  formatOptional,
+  getDimensions,
+  type ColliderInspectQuery,
+} from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+import {
+  normalizeRect,
+  rectArea,
+  rectContains,
+  rectDistance,
+  rectIntersection,
+  rectsAdjacentWithin,
+  rectsEqual,
+  roundMetric,
+  sampleGridUnionCoverage,
+} from './rectGeometry';
+
+export type ColliderGeometryAuditOptions = {
+  query: ColliderInspectQuery;
+  json: boolean;
+  tolerance: number;
+  samples: number;
+};
+
+export type ColliderOverlapEvidence = {
+  collider: RuntimeColliderMetadata;
+  intersectionArea: number;
+  candidateCoveragePercent: number;
+  otherCoveragePercent: number;
+  labels: string[];
+};
+
+export type ColliderGeometryAuditRecord = {
+  candidate: RuntimeColliderMetadata & {
+    normalizedBounds: RuntimeColliderMetadata['bounds'];
+    dimensions: { width: number; depth: number; area: number };
+  };
+  comparedColliderCount: number;
+  labels: string[];
+  exactDuplicates: RuntimeColliderMetadata[];
+  candidateContainedBy: RuntimeColliderMetadata[];
+  containedByCandidate: RuntimeColliderMetadata[];
+  overlaps: ColliderOverlapEvidence[];
+  unionCoverage: ReturnType<typeof sampleGridUnionCoverage> & {
+    coveragePercent: number;
+  };
+  adjacent: { collider: RuntimeColliderMetadata; distance: number }[];
+  note: string;
+};
+
+const SUPPORTING_EVIDENCE_NOTE =
+  'Geometry overlap is supporting evidence only; this audit never proves a collider is safe to delete.';
+
+const DEFAULT_TOLERANCE = 0.05;
+const DEFAULT_SAMPLES = 10;
+
+const floorsCanCompare = (left: string, right: string): boolean =>
+  left === right || left === 'all' || right === 'all';
+
+const shouldCompare = (
+  candidate: RuntimeColliderMetadata,
+  other: RuntimeColliderMetadata
+): boolean =>
+  candidate.id !== other.id &&
+  floorsCanCompare(candidate.floor, other.floor) &&
+  candidate.category === other.category;
+
+const byRelevance = (
+  left: ColliderOverlapEvidence,
+  right: ColliderOverlapEvidence
+): number =>
+  right.candidateCoveragePercent - left.candidateCoveragePercent ||
+  right.intersectionArea - left.intersectionArea ||
+  left.collider.id.localeCompare(right.collider.id);
+
+const byIdentity = (
+  left: RuntimeColliderMetadata,
+  right: RuntimeColliderMetadata
+): number =>
+  left.id.localeCompare(right.id) || left.name.localeCompare(right.name);
+
+const classify = (
+  exactDuplicates: readonly RuntimeColliderMetadata[],
+  candidateContainedBy: readonly RuntimeColliderMetadata[],
+  overlaps: readonly ColliderOverlapEvidence[],
+  coveragePercent: number,
+  adjacentCount: number
+): string[] => {
+  const labels = new Set<string>();
+  if (exactDuplicates.length > 0) labels.add('exact duplicate');
+  if (candidateContainedBy.length > 0) labels.add('fully contained');
+  if (overlaps.some((overlap) => overlap.candidateCoveragePercent >= 80)) {
+    labels.add('highly overlapped');
+  }
+  if (coveragePercent > 0 && coveragePercent < 80)
+    labels.add('partially covered');
+  if (coveragePercent === 0 && adjacentCount === 0 && overlaps.length === 0)
+    labels.add('isolated');
+  if (labels.size === 0) labels.add('ambiguous');
+  return [...labels];
+};
+
+export const parseColliderGeometryAuditArgs = (
+  args: readonly string[]
+): ColliderGeometryAuditOptions => {
+  let query: ColliderInspectQuery | undefined;
+  let json = false;
+  let tolerance = DEFAULT_TOLERANCE;
+  let samples = DEFAULT_SAMPLES;
+
+  const readValue = (index: number, flag: string): string => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--id' || arg === '--source-id' || arg === '--name') {
+      if (query)
+        throw new Error('Provide exactly one of --id, --source-id, or --name.');
+      query = {
+        kind: arg.slice(2) as ColliderInspectQuery['kind'],
+        value: readValue(index, arg),
+      };
+      index += 1;
+    } else if (arg === '--tolerance') {
+      tolerance = Number(readValue(index, arg));
+      index += 1;
+    } else if (arg === '--samples') {
+      samples = Number(readValue(index, arg));
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!query)
+    throw new Error('Provide exactly one of --id, --source-id, or --name.');
+  if (!Number.isFinite(tolerance) || tolerance < 0)
+    throw new Error('--tolerance must be >= 0.');
+  if (!Number.isInteger(samples) || samples < 1)
+    throw new Error('--samples must be a positive integer.');
+  return { query, json, tolerance, samples };
+};
+
+export const auditColliderGeometry = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: ColliderGeometryAuditOptions
+): ColliderGeometryAuditRecord[] => {
+  const matches = findColliderMatches(colliders, options.query);
+  if (matches.length === 0)
+    throw new Error(
+      `No collider matched ${options.query.kind} "${options.query.value}".`
+    );
+  if (options.query.kind !== 'source-id' && matches.length > 1) {
+    throw new Error(
+      `Ambiguous collider ${options.query.kind} "${options.query.value}" matched ${matches.length} records.`
+    );
+  }
+
+  return matches.map((candidate) => {
+    const comparable = colliders.filter((other) =>
+      shouldCompare(candidate, other)
+    );
+    const candidateArea = rectArea(candidate.bounds);
+    const exactDuplicates = comparable
+      .filter((other) =>
+        rectsEqual(candidate.bounds, other.bounds, options.tolerance)
+      )
+      .sort(byIdentity);
+    const candidateContainedBy = comparable
+      .filter((other) =>
+        rectContains(other.bounds, candidate.bounds, options.tolerance)
+      )
+      .sort(byIdentity);
+    const containedByCandidate = comparable
+      .filter((other) =>
+        rectContains(candidate.bounds, other.bounds, options.tolerance)
+      )
+      .sort(byIdentity);
+    const overlaps = comparable
+      .map((other) => {
+        const intersection = rectIntersection(candidate.bounds, other.bounds);
+        if (!intersection) return undefined;
+        const intersectionArea = roundMetric(rectArea(intersection));
+        const otherArea = rectArea(other.bounds);
+        const candidateCoveragePercent = roundMetric(
+          (intersectionArea / candidateArea) * 100
+        );
+        const otherCoveragePercent = roundMetric(
+          (intersectionArea / otherArea) * 100
+        );
+        const labels: string[] = [];
+        if (rectsEqual(candidate.bounds, other.bounds, options.tolerance))
+          labels.push('exact duplicate');
+        if (rectContains(other.bounds, candidate.bounds, options.tolerance))
+          labels.push('candidate contained');
+        if (rectContains(candidate.bounds, other.bounds, options.tolerance))
+          labels.push('contains other');
+        if (candidateCoveragePercent >= 80) labels.push('highly overlapped');
+        if (labels.length === 0) labels.push('partial overlap');
+        return {
+          collider: other,
+          intersectionArea,
+          candidateCoveragePercent,
+          otherCoveragePercent,
+          labels,
+        };
+      })
+      .filter((overlap): overlap is ColliderOverlapEvidence => Boolean(overlap))
+      .sort(byRelevance);
+    const unionCoverage = sampleGridUnionCoverage(
+      candidate.bounds,
+      comparable.map((other) => other.bounds),
+      options.samples
+    );
+    const coveragePercent = roundMetric(unionCoverage.coverageRatio * 100);
+    const adjacent = comparable
+      .filter(
+        (other) =>
+          !rectIntersection(candidate.bounds, other.bounds) &&
+          rectsAdjacentWithin(candidate.bounds, other.bounds, options.tolerance)
+      )
+      .map((other) => ({
+        collider: other,
+        distance: roundMetric(rectDistance(candidate.bounds, other.bounds)),
+      }))
+      .sort(
+        (left, right) =>
+          left.distance - right.distance ||
+          left.collider.id.localeCompare(right.collider.id)
+      );
+
+    return {
+      candidate: {
+        ...candidate,
+        normalizedBounds: normalizeRect(candidate.bounds),
+        dimensions: getDimensions(candidate.bounds),
+      },
+      comparedColliderCount: comparable.length,
+      labels: classify(
+        exactDuplicates,
+        candidateContainedBy,
+        overlaps,
+        coveragePercent,
+        adjacent.length
+      ),
+      exactDuplicates,
+      candidateContainedBy,
+      containedByCandidate,
+      overlaps,
+      unionCoverage: { ...unionCoverage, coveragePercent },
+      adjacent,
+      note: SUPPORTING_EVIDENCE_NOTE,
+    };
+  });
+};
+
+const listIds = (colliders: readonly RuntimeColliderMetadata[]) =>
+  colliders.length === 0
+    ? 'none'
+    : colliders
+        .map((collider) => `${collider.id} (${collider.name})`)
+        .join(', ');
+
+export const formatGeometryAuditRecords = (
+  records: readonly ColliderGeometryAuditRecord[]
+): string =>
+  records
+    .map((record) =>
+      [
+        `Collider geometry audit for ${record.candidate.id}`,
+        `  runtime name: ${record.candidate.name}`,
+        `  source ID: ${formatOptional(record.candidate.sourceId)}`,
+        `  source type: ${formatOptional(record.candidate.sourceType)}`,
+        `  purpose: ${formatOptional(record.candidate.purpose)}`,
+        `  floor/category: ${record.candidate.floor}/${record.candidate.category}`,
+        `  normalized bounds: ${formatBounds(record.candidate.normalizedBounds)}`,
+        `  dimensions: width ${record.candidate.dimensions.width}, depth ${record.candidate.dimensions.depth}, area ${record.candidate.dimensions.area}`,
+        `  evidence labels: ${record.labels.join(', ')}`,
+        `  compared active same-floor/category colliders: ${record.comparedColliderCount}`,
+        `  exact duplicates: ${listIds(record.exactDuplicates)}`,
+        `  candidate contained by: ${listIds(record.candidateContainedBy)}`,
+        `  colliders contained by candidate: ${listIds(record.containedByCandidate)}`,
+        '  pairwise overlaps:',
+        ...(record.overlaps.length === 0
+          ? ['    none']
+          : record.overlaps.map(
+              (overlap) =>
+                `    ${overlap.collider.id} (${overlap.collider.name}): area ${overlap.intersectionArea}, candidate ${overlap.candidateCoveragePercent}%, other ${overlap.otherCoveragePercent}% [${overlap.labels.join(', ')}]`
+            )),
+        `  union coverage estimate: ${record.unionCoverage.coveragePercent}% (${record.unionCoverage.coveredSamples}/${record.unionCoverage.totalSamples} samples covered)`,
+        `  uncovered sample count: ${record.unionCoverage.uncoveredSamples.length}`,
+        `  first uncovered samples: ${
+          record.unionCoverage.uncoveredSamples
+            .slice(0, 8)
+            .map((sample) => `(${sample.x}, ${sample.z})`)
+            .join(', ') || 'none'
+        }`,
+        '  edge adjacency:',
+        ...(record.adjacent.length === 0
+          ? ['    none']
+          : record.adjacent.map(
+              (adjacent) =>
+                `    ${adjacent.collider.id} (${adjacent.collider.name}): distance ${adjacent.distance}`
+            )),
+        `  note: ${record.note}`,
+      ].join('\n')
+    )
+    .join('\n\n');
+
+export const runColliderGeometryAuditCli = async (args: readonly string[]) => {
+  const options = parseColliderGeometryAuditArgs(args);
+  const colliders = await collectRuntimeColliders();
+  const records = auditColliderGeometry(colliders, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(records, null, 2)}\n`
+      : `${formatGeometryAuditRecords(records)}\n`
+  );
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderGeometryAuditCli(process.argv.slice(2)).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/colliderInspect.ts
+++ b/scripts/colliderInspect.ts
@@ -26,14 +26,14 @@ export type ColliderInspectionRecord = RuntimeColliderMetadata & {
 
 const round = (value: number) => Number(value.toFixed(3));
 
-const normalizeBounds = (bounds: RuntimeColliderMetadata['bounds']) => ({
+export const normalizeBounds = (bounds: RuntimeColliderMetadata['bounds']) => ({
   minX: round(bounds.minX),
   maxX: round(bounds.maxX),
   minZ: round(bounds.minZ),
   maxZ: round(bounds.maxZ),
 });
 
-const getDimensions = (bounds: RuntimeColliderMetadata['bounds']) => {
+export const getDimensions = (bounds: RuntimeColliderMetadata['bounds']) => {
   const width = Math.max(0, bounds.maxX - bounds.minX);
   const depth = Math.max(0, bounds.maxZ - bounds.minZ);
   return {
@@ -43,10 +43,10 @@ const getDimensions = (bounds: RuntimeColliderMetadata['bounds']) => {
   };
 };
 
-const floorsCanOverlap = (left: string, right: string): boolean =>
+export const floorsCanOverlap = (left: string, right: string): boolean =>
   left === right || left === 'all' || right === 'all';
 
-const boundsOverlap = (
+export const boundsOverlap = (
   left: RuntimeColliderMetadata['bounds'],
   right: RuntimeColliderMetadata['bounds']
 ): boolean =>
@@ -147,10 +147,13 @@ export const toInspectionRecords = (
     overlappingActiveColliderCount: countOverlaps(collider, colliders),
   }));
 
-const formatBounds = (bounds: RuntimeColliderMetadata['bounds']): string =>
+export const formatBounds = (
+  bounds: RuntimeColliderMetadata['bounds']
+): string =>
   `x ${bounds.minX}..${bounds.maxX}, z ${bounds.minZ}..${bounds.maxZ}`;
 
-const formatOptional = (value: string | undefined): string => value ?? 'n/a';
+export const formatOptional = (value: string | undefined): string =>
+  value ?? 'n/a';
 
 export const formatInspectionRecords = (
   records: readonly ColliderInspectionRecord[]

--- a/scripts/rectGeometry.ts
+++ b/scripts/rectGeometry.ts
@@ -1,0 +1,128 @@
+export type RectBounds = {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+};
+
+export type SampleGridCoverage = {
+  totalSamples: number;
+  coveredSamples: number;
+  uncoveredSamples: { x: number; z: number }[];
+  coverageRatio: number;
+};
+
+export const roundMetric = (value: number): number => Number(value.toFixed(3));
+
+export const normalizeRect = (bounds: RectBounds): RectBounds => ({
+  minX: Math.min(bounds.minX, bounds.maxX),
+  maxX: Math.max(bounds.minX, bounds.maxX),
+  minZ: Math.min(bounds.minZ, bounds.maxZ),
+  maxZ: Math.max(bounds.minZ, bounds.maxZ),
+});
+
+export const rectArea = (bounds: RectBounds): number => {
+  const rect = normalizeRect(bounds);
+  return (
+    Math.max(0, rect.maxX - rect.minX) * Math.max(0, rect.maxZ - rect.minZ)
+  );
+};
+
+export const rectIntersection = (
+  left: RectBounds,
+  right: RectBounds
+): RectBounds | undefined => {
+  const a = normalizeRect(left);
+  const b = normalizeRect(right);
+  const intersection = {
+    minX: Math.max(a.minX, b.minX),
+    maxX: Math.min(a.maxX, b.maxX),
+    minZ: Math.max(a.minZ, b.minZ),
+    maxZ: Math.min(a.maxZ, b.maxZ),
+  };
+
+  return intersection.maxX > intersection.minX &&
+    intersection.maxZ > intersection.minZ
+    ? intersection
+    : undefined;
+};
+
+export const rectContains = (
+  outer: RectBounds,
+  inner: RectBounds,
+  tolerance = 0
+): boolean => {
+  const a = normalizeRect(outer);
+  const b = normalizeRect(inner);
+  return (
+    a.minX - tolerance <= b.minX &&
+    a.maxX + tolerance >= b.maxX &&
+    a.minZ - tolerance <= b.minZ &&
+    a.maxZ + tolerance >= b.maxZ
+  );
+};
+
+export const rectsEqual = (
+  left: RectBounds,
+  right: RectBounds,
+  tolerance = 0
+): boolean =>
+  rectContains(left, right, tolerance) && rectContains(right, left, tolerance);
+
+export const rectDistance = (left: RectBounds, right: RectBounds): number => {
+  const a = normalizeRect(left);
+  const b = normalizeRect(right);
+  const gapX = Math.max(0, Math.max(a.minX - b.maxX, b.minX - a.maxX));
+  const gapZ = Math.max(0, Math.max(a.minZ - b.maxZ, b.minZ - a.maxZ));
+  return Math.hypot(gapX, gapZ);
+};
+
+export const rectsAdjacentWithin = (
+  left: RectBounds,
+  right: RectBounds,
+  tolerance: number
+): boolean => rectDistance(left, right) <= tolerance;
+
+export const sampleGridUnionCoverage = (
+  target: RectBounds,
+  coveringRects: readonly RectBounds[],
+  samplesPerAxis: number
+): SampleGridCoverage => {
+  const targetRect = normalizeRect(target);
+  const sampleCount = Math.max(1, Math.floor(samplesPerAxis));
+  const totalSamples = sampleCount * sampleCount;
+  const uncoveredSamples: { x: number; z: number }[] = [];
+  let coveredSamples = 0;
+
+  for (let zIndex = 0; zIndex < sampleCount; zIndex += 1) {
+    for (let xIndex = 0; xIndex < sampleCount; xIndex += 1) {
+      const x =
+        targetRect.minX +
+        ((xIndex + 0.5) / sampleCount) * (targetRect.maxX - targetRect.minX);
+      const z =
+        targetRect.minZ +
+        ((zIndex + 0.5) / sampleCount) * (targetRect.maxZ - targetRect.minZ);
+      const covered = coveringRects.some((rect) => {
+        const cover = normalizeRect(rect);
+        return (
+          x >= cover.minX &&
+          x <= cover.maxX &&
+          z >= cover.minZ &&
+          z <= cover.maxZ
+        );
+      });
+      if (covered) {
+        coveredSamples += 1;
+      } else {
+        uncoveredSamples.push({ x: roundMetric(x), z: roundMetric(z) });
+      }
+    }
+  }
+
+  return {
+    totalSamples,
+    coveredSamples,
+    uncoveredSamples,
+    coverageRatio: totalSamples === 0 ? 0 : coveredSamples / totalSamples,
+  };
+};


### PR DESCRIPTION
### Motivation
- Provide an opt-in, candidate-focused geometric audit to help maintainers quantify overlap/containment evidence when evaluating collider-removal candidates.
- Reuse the existing runtime collector and selector semantics so the tool is non-invasive, not a CI gate, and does not modify runtime colliders.

### Description
- Add pure rectangle geometry helpers in `scripts/rectGeometry.ts` for normalization, intersection, containment/equality, distance/adjacency, and deterministic sample-grid union coverage. 
- Implement an audit CLI in `scripts/colliderAuditGeometry.ts` that reuses `collectRuntimeColliders()` and `findColliderMatches()` and accepts `--id|--source-id|--name`, `--json`, `--tolerance`, and `--samples` options. 
- Export small formatting/metric helpers from `scripts/colliderInspect.ts` (`normalizeBounds`, `getDimensions`, `formatBounds`, `formatOptional`, etc.) so the audit reuses the same presentation math rather than duplicating logic. 
- Add Vitest unit tests in `scripts/__tests__/rectGeometry.test.ts` and `scripts/__tests__/colliderAuditGeometry.test.ts`, and document CLI usage and limitations in `docs/design/editing-level-data.md`, plus add `collider:audit:geometry` to `package.json`.

### Testing
- Ran the audit CLI locally with a runtime preview: `npm run collider:audit:geometry -- --id 1007` (succeeded; printed human-readable audit). 
- Ran the audit CLI with JSON output: `npm run collider:audit:geometry -- --source-id upper.stairwell.landingGuard.shoulderEast --json` (succeeded; produced deterministic JSON). 
- Ran focused script tests: `npm run test:ci -- scripts` and `vitest` for the new script tests (all script tests passed). 
- Ran repository checks: `npm run lint` (no blocking errors), `npm run test:ci` (full test suite passed), `npm run docs:check` (passed with existing external-link warnings), and `npm run smoke` (build/smoke passed). 
- Note: the CLI drives a headless browser via Playwright; `npx playwright install` / `npx playwright install-deps` were used during verification to satisfy runtime browser requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38a14a2088832fa3247f92132adde4)