### PR TITLE
🧭 : – add collider reachability audit

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -132,6 +132,41 @@ Use `--samples <count>` to tune the deterministic per-axis union-coverage grid
 and `--tolerance <world-units>` to adjust nearby-edge or nearly-identical bounds
 matching. Audit output is not persisted and is not part of required CI.
 
+## Audit collider reachability from the CLI
+
+When static geometry is not enough, run the opt-in reachability audit for one
+candidate. The audit asks whether a player starting from known legal anchors can
+reach an approach region and encounter the candidate as the first meaningful
+blocker. It combines bounded occupancy path proposals with normal runtime
+movement stepping, then reports direct load-bearing hits, dominating blockers,
+outside-navmesh evidence, visual-only source policies, secondary backstop intent,
+or ambiguity.
+
+```bash
+npm run collider:audit:reachability -- --id 400D
+npm run collider:audit:reachability -- --source-id ground.backyard.perimeter.backFence.boundary
+npm run collider:audit:reachability -- --id 1007 --json
+```
+
+The output includes grid resolution, maximum explored nodes, tested starts, and
+tested approach samples. It is review evidence only: it does not scan every
+collider in CI, delete anything, persist snapshots, or replace screenshots and
+maintainer judgment when the result is ambiguous.
+
+## Lightweight collider removal workflow
+
+For a possible removal, keep the review centered on the active source policy:
+
+1. Inspect the candidate with `npm run collider:inspect` to confirm identity,
+   provenance, intent, and bounds.
+2. Run `npm run collider:audit:geometry` when overlap, containment, or coverage
+   evidence would clarify whether nearby colliders describe the same space.
+3. Run `npm run collider:audit:reachability` when player-facing first-blocker
+   evidence would clarify direct load-bearing or domination.
+4. Edit the active source policy or declaration that emits the collider.
+5. Rely on behavior checks and generic declaration contracts; do not add
+   historical deletion records or full-scene snapshots for the removal itself.
+
 ## Inspect source IDs in the browser
 
 Launch immersive mode with performance failover disabled:

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -145,7 +145,7 @@ or ambiguity.
 ```bash
 npm run collider:audit:reachability -- --id 400D
 npm run collider:audit:reachability -- --source-id ground.backyard.perimeter.backFence.boundary
-npm run collider:audit:reachability -- --id 1007 --json
+npm run collider:audit:reachability -- --id 1007 --json --max-explored-nodes 1400
 ```
 
 The output includes grid resolution, maximum explored nodes, tested starts, and

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "links:check": "node scripts/check-links.cjs",
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
     "collider:inspect": "tsx scripts/colliderInspect.ts",
-    "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts"
+    "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
+    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/playwright/collider-reachability-audit.spec.ts
+++ b/playwright/collider-reachability-audit.spec.ts
@@ -5,13 +5,16 @@ import { expect, test } from '@playwright/test';
 
 const execFileAsync = promisify(execFile);
 
+const AUDIT_SUBPROCESS_TIMEOUT_MS = 120_000;
+const AUDIT_PLAYWRIGHT_TIMEOUT_MS = 150_000;
+
 const runAudit = async (args: string[]) => {
   const { stdout } = await execFileAsync(
     'npx',
     ['tsx', 'scripts/colliderReachabilityAudit.ts', ...args],
     {
       env: { ...process.env, PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:5173' },
-      timeout: 120_000,
+      timeout: AUDIT_SUBPROCESS_TIMEOUT_MS,
     }
   );
   return JSON.parse(stdout) as Array<{
@@ -25,6 +28,7 @@ const runAudit = async (args: string[]) => {
 };
 
 test.describe('collider reachability audit CLI', () => {
+  test.describe.configure({ timeout: AUDIT_PLAYWRIGHT_TIMEOUT_MS });
   test('reports a semantic physical boundary as directly load-bearing', async () => {
     const [report] = await runAudit([
       '--source-id',

--- a/playwright/collider-reachability-audit.spec.ts
+++ b/playwright/collider-reachability-audit.spec.ts
@@ -1,0 +1,45 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { expect, test } from '@playwright/test';
+
+const execFileAsync = promisify(execFile);
+
+const runAudit = async (args: string[]) => {
+  const { stdout } = await execFileAsync(
+    'npx',
+    ['tsx', 'scripts/colliderReachabilityAudit.ts', ...args],
+    {
+      env: { ...process.env, PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:5173' },
+      timeout: 120_000,
+    }
+  );
+  return JSON.parse(stdout) as Array<{
+    classification: string;
+    approaches: unknown[];
+  }>;
+};
+
+test.describe('collider reachability audit CLI', () => {
+  test('reports a semantic physical boundary as directly load-bearing', async () => {
+    const [report] = await runAudit([
+      '--source-id',
+      'ground.backyard.perimeter.backFence.boundary',
+      '--json',
+    ]);
+
+    expect(report.classification).toBe('directly-load-bearing');
+    expect(report.approaches.length).toBeGreaterThan(0);
+  });
+
+  test('reports a visual-only policy from source intent without a fake collider', async () => {
+    const [report] = await runAudit([
+      '--source-id',
+      'ground.livingRoom.mediaWall.futuroptimist',
+      '--json',
+    ]);
+
+    expect(report.classification).toBe('visual-only-by-policy');
+    expect(report.approaches).toEqual([]);
+  });
+});

--- a/playwright/collider-reachability-audit.spec.ts
+++ b/playwright/collider-reachability-audit.spec.ts
@@ -16,7 +16,11 @@ const runAudit = async (args: string[]) => {
   );
   return JSON.parse(stdout) as Array<{
     classification: string;
-    approaches: unknown[];
+    approaches: Array<{
+      status: string;
+      pathLength: number;
+      start?: { x: number; z: number; floorId: string };
+    }>;
   }>;
 };
 
@@ -29,7 +33,14 @@ test.describe('collider reachability audit CLI', () => {
     ]);
 
     expect(report.classification).toBe('directly-load-bearing');
-    expect(report.approaches.length).toBeGreaterThan(0);
+    expect(
+      report.approaches.some(
+        (approach) =>
+          approach.status === 'candidate-first' &&
+          approach.pathLength > 0 &&
+          Boolean(approach.start)
+      )
+    ).toBe(true);
   });
 
   test('reports a visual-only policy from source intent without a fake collider', async () => {

--- a/scripts/__tests__/colliderReachabilityAudit.test.ts
+++ b/scripts/__tests__/colliderReachabilityAudit.test.ts
@@ -4,6 +4,7 @@ import {
   classifyReachabilityEvidence,
   collectDominatingColliderEvidence,
   parseColliderReachabilityAuditArgs,
+  preferRuntimeApproachResult,
 } from '../colliderReachabilityAudit';
 
 const candidate = {
@@ -170,6 +171,40 @@ describe('collider reachability audit aggregation', () => {
         blockedDirections: ['west'],
       },
     ]);
+  });
+
+  it('keeps blocked-by-other fallback while scanning for candidate-first evidence', () => {
+    const blockedFallback = {
+      direction: 'north',
+      sample: { x: 0, z: 0, floorId: 'ground' },
+      status: 'blocked-by-other',
+      blockers: ['2001'],
+      blockerSourceIds: [],
+      exploredNodes: 8,
+      pathLength: 3,
+    } as const;
+    const ambiguousLater = {
+      ...blockedFallback,
+      status: 'ambiguous',
+      blockers: [],
+      exploredNodes: 10,
+    } as const;
+    const candidateFirstLater = {
+      ...blockedFallback,
+      status: 'candidate-first',
+      blockers: ['1006'],
+      exploredNodes: 12,
+    } as const;
+
+    expect(preferRuntimeApproachResult(undefined, blockedFallback)).toBe(
+      blockedFallback
+    );
+    expect(preferRuntimeApproachResult(blockedFallback, ambiguousLater)).toBe(
+      blockedFallback
+    );
+    expect(
+      preferRuntimeApproachResult(blockedFallback, candidateFirstLater)
+    ).toBe(candidateFirstLater);
   });
 
   it('reports secondary backstops from active source intent', () => {

--- a/scripts/__tests__/colliderReachabilityAudit.test.ts
+++ b/scripts/__tests__/colliderReachabilityAudit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   classifyReachabilityEvidence,
+  collectDominatingColliderEvidence,
   parseColliderReachabilityAuditArgs,
 } from '../colliderReachabilityAudit';
 
@@ -57,6 +58,90 @@ describe('collider reachability audit aggregation', () => {
     ).toBe('ambiguous');
   });
 
+  it('keeps diagnostic blockers on unreached approaches out of confident direct evidence', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        approaches: [
+          { status: 'unreachable', blockers: ['1006'] },
+          { status: 'unreachable', blockers: ['2001'] },
+        ],
+      })
+    ).toBe('outside-reachable-navmesh');
+  });
+
+  it('keeps mixed reachable and unreached evidence ambiguous without a confirmed hit', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        approaches: [
+          { status: 'blocked-by-other', blockers: ['2001'] },
+          { status: 'unreachable', blockers: ['1006'] },
+          { status: 'ambiguous', blockers: [] },
+        ],
+      })
+    ).toBe('ambiguous');
+  });
+
+  it('reports direction evidence per dominating collider only for dominated results', () => {
+    const colliders = [
+      { id: '1006', name: 'Candidate', sourceId: candidate.sourceId },
+      { id: '2001', name: 'NorthWall', sourceId: 'wall.north' },
+      { id: '2002', name: 'SouthWall', sourceId: 'wall.south' },
+    ] as never;
+    const approaches = [
+      {
+        direction: 'north',
+        status: 'blocked-by-other',
+        blockers: ['NorthWall'],
+        blockerSourceIds: ['wall.north'],
+      },
+      {
+        direction: 'south',
+        status: 'blocked-by-other',
+        blockers: ['2002'],
+        blockerSourceIds: [],
+      },
+      {
+        direction: 'east',
+        status: 'blocked-by-other',
+        blockers: ['2001'],
+        blockerSourceIds: ['wall.north'],
+      },
+    ] as const;
+
+    expect(
+      collectDominatingColliderEvidence(
+        'dominated',
+        { ...candidate, name: 'Candidate' },
+        colliders,
+        approaches
+      )
+    ).toEqual([
+      {
+        id: '2001',
+        name: 'NorthWall',
+        sourceId: 'wall.north',
+        blockedDirections: ['north', 'east'],
+      },
+      {
+        id: '2002',
+        name: 'SouthWall',
+        sourceId: 'wall.south',
+        blockedDirections: ['south'],
+      },
+    ]);
+
+    expect(
+      collectDominatingColliderEvidence(
+        'ambiguous',
+        { ...candidate, name: 'Candidate' },
+        colliders,
+        approaches
+      )
+    ).toEqual([]);
+  });
+
   it('reports secondary backstops from active source intent', () => {
     expect(
       classifyReachabilityEvidence({
@@ -74,7 +159,7 @@ describe('collider reachability audit aggregation', () => {
         '--json',
         '--grid-resolution',
         '0.4',
-        '--max-nodes',
+        '--max-explored-nodes',
         '42',
       ])
     ).toMatchObject({

--- a/scripts/__tests__/colliderReachabilityAudit.test.ts
+++ b/scripts/__tests__/colliderReachabilityAudit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyReachabilityEvidence,
+  parseColliderReachabilityAuditArgs,
+} from '../colliderReachabilityAudit';
+
+const candidate = {
+  id: '1006',
+  sourceId: 'ground.backyard.perimeter.backFence.boundary',
+};
+
+describe('collider reachability audit aggregation', () => {
+  it('classifies visual-only source policies before runtime sampling', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        approaches: [],
+        visualOnlyRationale: 'wall-mounted visual only',
+      })
+    ).toBe('visual-only-by-policy');
+  });
+
+  it('classifies candidates hit first by any legal approach as directly load-bearing', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        approaches: [
+          { status: 'unreachable', blockers: [] },
+          { status: 'candidate-first', blockers: ['1006'] },
+        ],
+      })
+    ).toBe('directly-load-bearing');
+  });
+
+  it('classifies consistently blocked reachable approaches as dominated', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        approaches: [
+          { status: 'blocked-by-other', blockers: ['2001'] },
+          { status: 'blocked-by-other', blockers: ['2002'] },
+        ],
+      })
+    ).toBe('dominated');
+  });
+
+  it('does not weaken mixed or sampled-limit evidence into a confident result', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        approaches: [
+          { status: 'blocked-by-other', blockers: ['2001'] },
+          { status: 'unreachable', blockers: [] },
+        ],
+      })
+    ).toBe('ambiguous');
+  });
+
+  it('reports secondary backstops from active source intent', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate: { ...candidate, intent: 'secondary-backstop' },
+        approaches: [{ status: 'candidate-first', blockers: ['1006'] }],
+      })
+    ).toBe('secondary-backstop');
+  });
+
+  it('parses deterministic runtime limits and json output', () => {
+    expect(
+      parseColliderReachabilityAuditArgs([
+        '--source-id',
+        'ground.backyard.perimeter.backFence.boundary',
+        '--json',
+        '--grid-resolution',
+        '0.4',
+        '--max-nodes',
+        '42',
+      ])
+    ).toMatchObject({
+      query: {
+        kind: 'source-id',
+        value: 'ground.backyard.perimeter.backFence.boundary',
+      },
+      json: true,
+      gridResolution: 0.4,
+      maxExploredNodes: 42,
+    });
+  });
+});

--- a/scripts/__tests__/colliderReachabilityAudit.test.ts
+++ b/scripts/__tests__/colliderReachabilityAudit.test.ts
@@ -142,6 +142,36 @@ describe('collider reachability audit aggregation', () => {
     ).toEqual([]);
   });
 
+  it('keeps dominating evidence when candidate and dominator both omit source IDs', () => {
+    const colliders = [
+      { id: '1006', name: 'Candidate' },
+      { id: '2001', name: 'UnnamedSourceDominator' },
+    ] as never;
+
+    expect(
+      collectDominatingColliderEvidence(
+        'dominated',
+        { id: '1006', name: 'Candidate' },
+        colliders,
+        [
+          {
+            direction: 'west',
+            status: 'blocked-by-other',
+            blockers: ['2001'],
+            blockerSourceIds: [],
+          },
+        ]
+      )
+    ).toEqual([
+      {
+        id: '2001',
+        name: 'UnnamedSourceDominator',
+        sourceId: undefined,
+        blockedDirections: ['west'],
+      },
+    ]);
+  });
+
   it('reports secondary backstops from active source intent', () => {
     expect(
       classifyReachabilityEvidence({

--- a/scripts/colliderReachabilityAudit.ts
+++ b/scripts/colliderReachabilityAudit.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url';
 import type { Page } from '@playwright/test';
 
 import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../src/scene/level/mediaWallPolicy';
-import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../src/scene/level/upperStairwellLandingSegments';
 
 import { auditColliderGeometry } from './colliderGeometryAudit';
 import {
@@ -49,6 +48,13 @@ type RuntimeApproachResult = {
   message?: string;
 };
 
+type DominatingColliderEvidence = Pick<
+  RuntimeColliderMetadata,
+  'id' | 'sourceId' | 'name'
+> & {
+  blockedDirections: ApproachDirection[];
+};
+
 export type ReachabilityAggregationInput = {
   candidate: Pick<RuntimeColliderMetadata, 'id' | 'sourceId' | 'intent'>;
   approaches: readonly Pick<RuntimeApproachResult, 'status' | 'blockers'>[];
@@ -66,28 +72,22 @@ export type ColliderReachabilityAuditReport = {
     testedApproachSamples: number;
   };
   approaches: RuntimeApproachResult[];
-  dominatingColliders: Array<
-    Pick<RuntimeColliderMetadata, 'id' | 'sourceId' | 'name'>
-  >;
+  dominatingColliders: DominatingColliderEvidence[];
   staticEvidence?: ReturnType<typeof auditColliderGeometry>[number];
   note: string;
 };
 
-const SOURCE_COLLISION_POLICIES = [
-  FUTUROPTIMIST_MEDIA_WALL_POLICY,
-  ...UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
-];
-
-const VISUAL_ONLY_POLICIES = SOURCE_COLLISION_POLICIES.flatMap((policy) =>
-  policy.collision.collision === 'none'
-    ? [
-        {
-          sourceId: policy.sourceId,
-          collision: policy.collision.collision,
-          rationale: policy.collision.rationale,
-        },
-      ]
-    : []
+const VISUAL_ONLY_POLICIES = [FUTUROPTIMIST_MEDIA_WALL_POLICY].flatMap(
+  (policy) =>
+    policy.collision.collision === 'none'
+      ? [
+          {
+            sourceId: policy.sourceId,
+            collision: policy.collision.collision,
+            rationale: policy.collision.rationale,
+          },
+        ]
+      : []
 );
 
 export const parseColliderReachabilityAuditArgs = (
@@ -119,6 +119,7 @@ export const parseColliderReachabilityAuditArgs = (
       index += 1;
     } else if (
       arg === '--grid-resolution' ||
+      arg === '--max-explored-nodes' ||
       arg === '--max-nodes' ||
       arg === '--timeout-ms'
     ) {
@@ -126,7 +127,9 @@ export const parseColliderReachabilityAuditArgs = (
       if (!Number.isFinite(value) || value <= 0)
         throw new Error(`${arg} must be positive.`);
       if (arg === '--grid-resolution') gridResolution = value;
-      if (arg === '--max-nodes') maxExploredNodes = Math.floor(value);
+      if (arg === '--max-explored-nodes' || arg === '--max-nodes') {
+        maxExploredNodes = Math.floor(value);
+      }
       if (arg === '--timeout-ms') timeoutMs = Math.floor(value);
       index += 1;
     } else if (arg === '--base-url') {
@@ -163,6 +166,48 @@ export const classifyReachabilityEvidence = ({
     return 'outside-reachable-navmesh';
   }
   return 'ambiguous';
+};
+
+export const collectDominatingColliderEvidence = (
+  classification: ReachabilityClassification,
+  candidate: Pick<RuntimeColliderMetadata, 'id' | 'sourceId' | 'name'>,
+  colliders: readonly RuntimeColliderMetadata[],
+  approaches: readonly Pick<
+    RuntimeApproachResult,
+    'status' | 'direction' | 'blockers' | 'blockerSourceIds'
+  >[]
+): DominatingColliderEvidence[] => {
+  if (classification !== 'dominated') return [];
+  const directionsByColliderId = new Map<string, Set<ApproachDirection>>();
+  for (const approach of approaches) {
+    if (approach.status !== 'blocked-by-other') continue;
+    for (const collider of colliders) {
+      const refs = [collider.id, collider.name, collider.sourceId].filter(
+        Boolean
+      );
+      const blocked = [...approach.blockers, ...approach.blockerSourceIds];
+      if (
+        refs.some((ref) => blocked.includes(ref)) &&
+        collider.id !== candidate.id &&
+        collider.name !== candidate.name &&
+        collider.sourceId !== candidate.sourceId
+      ) {
+        const directions =
+          directionsByColliderId.get(collider.id) ??
+          new Set<ApproachDirection>();
+        directions.add(approach.direction);
+        directionsByColliderId.set(collider.id, directions);
+      }
+    }
+  }
+  return colliders
+    .filter((collider) => directionsByColliderId.has(collider.id))
+    .map(({ id, sourceId, name }) => ({
+      id,
+      sourceId,
+      name,
+      blockedDirections: [...directionsByColliderId.get(id)!],
+    }));
 };
 
 const runRuntimeApproaches = async (
@@ -387,18 +432,17 @@ const runRuntimeApproaches = async (
               z: Number(sample.z.toFixed(3)),
               floorId,
             },
-            status:
-              blockers.length === 0
-                ? 'unreachable'
-                : blockers.some((blocker) => blocker.id === nextCandidate.id)
-                  ? 'candidate-first'
-                  : 'blocked-by-other',
+            status: 'unreachable',
             blockers: blockers.map((blocker) => blocker.id),
             blockerSourceIds: blockers
               .map((blocker) => blocker.sourceId)
               .filter(Boolean) as string[],
             exploredNodes: 0,
             pathLength: 0,
+            message:
+              blockers.length > 0
+                ? 'Approach sample is not occupiable; blockers are diagnostic only until confirmed from a legal start.'
+                : 'Approach sample is not occupiable and no legal runtime path was confirmed.',
           };
         }
         let best: RuntimeApproachResult | undefined;
@@ -550,19 +594,6 @@ export const auditColliderReachability = async (
           candidate,
           approaches: runtime.approaches,
         });
-        const blockerRefs = new Set(
-          runtime.approaches
-            .flatMap((approach) => [
-              ...approach.blockers,
-              ...approach.blockerSourceIds,
-            ])
-            .filter(
-              (id) =>
-                id !== candidate.id &&
-                id !== candidate.sourceId &&
-                id !== candidate.name
-            )
-        );
         reports.push({
           candidate,
           classification,
@@ -573,14 +604,12 @@ export const auditColliderReachability = async (
             testedApproachSamples: runtime.approaches.length,
           },
           approaches: runtime.approaches,
-          dominatingColliders: colliders
-            .filter(
-              (collider) =>
-                blockerRefs.has(collider.id) ||
-                blockerRefs.has(collider.name) ||
-                blockerRefs.has(collider.sourceId ?? '')
-            )
-            .map(({ id, sourceId, name }) => ({ id, sourceId, name })),
+          dominatingColliders: collectDominatingColliderEvidence(
+            classification,
+            candidate,
+            colliders,
+            runtime.approaches
+          ),
           staticEvidence: auditColliderGeometry(colliders, {
             query: { kind: 'id', value: candidate.id },
             json: true,
@@ -621,7 +650,7 @@ const formatReport = (report: ColliderReachabilityAuditReport) => {
       ? report.dominatingColliders
           .map(
             (collider) =>
-              `  - ${collider.id} ${collider.name} (${formatOptional(collider.sourceId)})`
+              `  - ${collider.id} ${collider.name} (${formatOptional(collider.sourceId)}); directions ${collider.blockedDirections.join(', ')}`
           )
           .join('\n')
       : '  - none',

--- a/scripts/colliderReachabilityAudit.ts
+++ b/scripts/colliderReachabilityAudit.ts
@@ -188,9 +188,7 @@ export const collectDominatingColliderEvidence = (
       const blocked = [...approach.blockers, ...approach.blockerSourceIds];
       if (
         refs.some((ref) => blocked.includes(ref)) &&
-        collider.id !== candidate.id &&
-        collider.name !== candidate.name &&
-        collider.sourceId !== candidate.sourceId
+        collider.id !== candidate.id
       ) {
         const directions =
           directionsByColliderId.get(collider.id) ??

--- a/scripts/colliderReachabilityAudit.ts
+++ b/scripts/colliderReachabilityAudit.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import type { Page } from '@playwright/test';
 
 import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../src/scene/level/mediaWallPolicy';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../src/scene/level/upperStairwellLandingSegments';
 
 import { auditColliderGeometry } from './colliderGeometryAudit';
 import {
@@ -72,14 +73,21 @@ export type ColliderReachabilityAuditReport = {
   note: string;
 };
 
-const round = (value: number) => Number(value.toFixed(3));
+const SOURCE_COLLISION_POLICIES = [
+  FUTUROPTIMIST_MEDIA_WALL_POLICY,
+  ...UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
+];
 
-const VISUAL_ONLY_POLICIES = [FUTUROPTIMIST_MEDIA_WALL_POLICY].map(
-  (policy) => ({
-    sourceId: policy.sourceId,
-    collision: policy.collision.collision,
-    rationale: policy.collision.rationale,
-  })
+const VISUAL_ONLY_POLICIES = SOURCE_COLLISION_POLICIES.flatMap((policy) =>
+  policy.collision.collision === 'none'
+    ? [
+        {
+          sourceId: policy.sourceId,
+          collision: policy.collision.collision,
+          rationale: policy.collision.rationale,
+        },
+      ]
+    : []
 );
 
 export const parseColliderReachabilityAuditArgs = (
@@ -205,7 +213,8 @@ const runRuntimeApproaches = async (
       const floorId = (
         nextCandidate.floor === 'upper' ? 'upper' : 'ground'
       ) as FloorId;
-      const radius = 0.38;
+      const playerRadius = 0.75;
+      const radius = playerRadius;
       const center = {
         x: (nextCandidate.bounds.minX + nextCandidate.bounds.maxX) / 2,
         z: (nextCandidate.bounds.minZ + nextCandidate.bounds.maxZ) / 2,
@@ -241,6 +250,22 @@ const runRuntimeApproaches = async (
         { x: 0, z: -23 },
         { x: 12.4, z: -25.2 },
       ];
+      for (let x = center.x - 10; x <= center.x + 10; x += gridResolution * 2) {
+        for (
+          let z = center.z - 10;
+          z <= center.z + 10;
+          z += gridResolution * 2
+        ) {
+          const candidateStart = {
+            x: Number(x.toFixed(3)),
+            z: Number(z.toFixed(3)),
+            floorId,
+          };
+          if (world.canOccupyPosition(candidateStart)) {
+            startCandidates.push(candidateStart);
+          }
+        }
+      }
       const starts = startCandidates
         .map((start) => ({ x: start.x, z: start.z, floorId }))
         .filter(
@@ -290,8 +315,8 @@ const runRuntimeApproaches = async (
             [0, -gridResolution],
           ]) {
             const next = {
-              x: round(node.x + dx),
-              z: round(node.z + dz),
+              x: Number((node.x + dx).toFixed(3)),
+              z: Number((node.z + dz).toFixed(3)),
               floorId,
             };
             const nextKey = key(next.x, next.z);
@@ -309,8 +334,7 @@ const runRuntimeApproaches = async (
       };
       const confirm = (
         start: { x: number; z: number; floorId: FloorId },
-        path: Array<{ x: number; z: number }>,
-        sample: { x: number; z: number }
+        path: Array<{ x: number; z: number }>
       ) => {
         world.movePlayerTo(start);
         const waypoints = [...path, center];
@@ -322,17 +346,17 @@ const runRuntimeApproaches = async (
             if (Math.hypot(remainingX, remainingZ) < 0.03) break;
             const length = Math.max(0.001, Math.hypot(remainingX, remainingZ));
             const amount = Math.min(0.16, length);
-            const result = world.stepPlayerForTest({
-              dx: (remainingX / length) * amount,
-              dz: (remainingZ / length) * amount,
-            });
+            const dx = (remainingX / length) * amount;
+            const dz = (remainingZ / length) * amount;
+            const result = world.stepPlayerForTest({ dx, dz });
             const blocked = result.blockedBy ?? [];
             if (blocked.length > 0 || (!result.movedX && !result.movedZ)) {
-              const atPoint = debug.getBlockingCollidersAt({
-                x: sample.x,
-                z: sample.z,
-                floorId,
-              });
+              const afterStep = world.getPlayerPosition();
+              const probe =
+                result.movedX || result.movedZ
+                  ? { x: afterStep.x + dx, z: afterStep.z + dz, floorId }
+                  : { x: position.x + dx, z: position.z + dz, floorId };
+              const atPoint = debug.getBlockingCollidersAt(probe);
               return {
                 blockers: blocked,
                 blockerSourceIds: atPoint
@@ -363,9 +387,12 @@ const runRuntimeApproaches = async (
               z: Number(sample.z.toFixed(3)),
               floorId,
             },
-            status: blockers.some((blocker) => blocker.id === nextCandidate.id)
-              ? 'candidate-first'
-              : 'blocked-by-other',
+            status:
+              blockers.length === 0
+                ? 'unreachable'
+                : blockers.some((blocker) => blocker.id === nextCandidate.id)
+                  ? 'candidate-first'
+                  : 'blocked-by-other',
             blockers: blockers.map((blocker) => blocker.id),
             blockerSourceIds: blockers
               .map((blocker) => blocker.sourceId)
@@ -394,12 +421,20 @@ const runRuntimeApproaches = async (
             };
             continue;
           }
-          const blocked = confirm(start, found.path, sample);
-          const status = blocked.blockers.includes(nextCandidate.id)
-            ? 'candidate-first'
-            : blocked.blockers.length > 0
-              ? 'blocked-by-other'
-              : 'ambiguous';
+          const blocked = confirm(start, found.path);
+          const candidateRefs = [
+            nextCandidate.id,
+            nextCandidate.name,
+            nextCandidate.sourceId,
+          ].filter(Boolean);
+          const status =
+            blocked.blockers.some((blocker) =>
+              candidateRefs.includes(blocker)
+            ) || blocked.blockerSourceIds.includes(nextCandidate.sourceId ?? '')
+              ? 'candidate-first'
+              : blocked.blockers.length > 0
+                ? 'blocked-by-other'
+                : 'ambiguous';
           best = {
             direction: sample.direction,
             sample: {
@@ -473,6 +508,18 @@ export const auditColliderReachability = async (
   return withRuntimePage(
     { baseUrl, timeoutMs: options.timeoutMs },
     async (page) => {
+      await page.waitForFunction(
+        () => {
+          const api = (
+            window as typeof window & {
+              portfolio?: { debugColliders?: { getColliders(): unknown[] } };
+            }
+          ).portfolio?.debugColliders;
+          return Boolean(api && api.getColliders().length > 0);
+        },
+        undefined,
+        { timeout: options.timeoutMs }
+      );
       const colliders = await page.evaluate(() => {
         const api = (
           window as typeof window & {
@@ -503,10 +550,18 @@ export const auditColliderReachability = async (
           candidate,
           approaches: runtime.approaches,
         });
-        const blockerIds = new Set(
+        const blockerRefs = new Set(
           runtime.approaches
-            .flatMap((approach) => approach.blockers)
-            .filter((id) => id !== candidate.id)
+            .flatMap((approach) => [
+              ...approach.blockers,
+              ...approach.blockerSourceIds,
+            ])
+            .filter(
+              (id) =>
+                id !== candidate.id &&
+                id !== candidate.sourceId &&
+                id !== candidate.name
+            )
         );
         reports.push({
           candidate,
@@ -519,7 +574,12 @@ export const auditColliderReachability = async (
           },
           approaches: runtime.approaches,
           dominatingColliders: colliders
-            .filter((collider) => blockerIds.has(collider.id))
+            .filter(
+              (collider) =>
+                blockerRefs.has(collider.id) ||
+                blockerRefs.has(collider.name) ||
+                blockerRefs.has(collider.sourceId ?? '')
+            )
             .map(({ id, sourceId, name }) => ({ id, sourceId, name })),
           staticEvidence: auditColliderGeometry(colliders, {
             query: { kind: 'id', value: candidate.id },

--- a/scripts/colliderReachabilityAudit.ts
+++ b/scripts/colliderReachabilityAudit.ts
@@ -36,7 +36,7 @@ export type ColliderReachabilityAuditOptions = {
 
 type ApproachDirection = 'north' | 'south' | 'east' | 'west';
 
-type RuntimeApproachResult = {
+export type RuntimeApproachResult = {
   direction: ApproachDirection;
   sample: { x: number; z: number; floorId: string };
   status: 'candidate-first' | 'blocked-by-other' | 'unreachable' | 'ambiguous';
@@ -166,6 +166,21 @@ export const classifyReachabilityEvidence = ({
     return 'outside-reachable-navmesh';
   }
   return 'ambiguous';
+};
+
+export const preferRuntimeApproachResult = (
+  current: RuntimeApproachResult | undefined,
+  next: RuntimeApproachResult
+): RuntimeApproachResult => {
+  if (!current) return next;
+  if (next.status === 'candidate-first') return next;
+  if (current.status === 'candidate-first') return current;
+  if (next.status === 'blocked-by-other') return next;
+  if (current.status === 'blocked-by-other') return current;
+  if (next.status === 'ambiguous' && current.status === 'unreachable') {
+    return next;
+  }
+  return current;
 };
 
 export const collectDominatingColliderEvidence = (
@@ -411,6 +426,20 @@ const runRuntimeApproaches = async (
         }
         return { blockers: [] as string[], blockerSourceIds: [] as string[] };
       };
+      const preferRuntimeApproachResultInPage = (
+        current: RuntimeApproachResult | undefined,
+        next: RuntimeApproachResult
+      ) => {
+        if (!current) return next;
+        if (next.status === 'candidate-first') return next;
+        if (current.status === 'candidate-first') return current;
+        if (next.status === 'blocked-by-other') return next;
+        if (current.status === 'blocked-by-other') return current;
+        if (next.status === 'ambiguous' && current.status === 'unreachable') {
+          return next;
+        }
+        return current;
+      };
       const approaches = samples.map((sample) => {
         const occupied = world.canOccupyPosition({
           x: sample.x,
@@ -477,7 +506,7 @@ const runRuntimeApproaches = async (
               : blocked.blockers.length > 0
                 ? 'blocked-by-other'
                 : 'ambiguous';
-          best = {
+          const result = {
             direction: sample.direction,
             sample: {
               x: Number(sample.x.toFixed(3)),
@@ -490,9 +519,9 @@ const runRuntimeApproaches = async (
             blockerSourceIds: blocked.blockerSourceIds,
             exploredNodes: found.exploredNodes,
             pathLength: found.path.length,
-          };
-          if (status === 'candidate-first' || status === 'blocked-by-other')
-            break;
+          } satisfies RuntimeApproachResult;
+          best = preferRuntimeApproachResultInPage(best, result);
+          if (status === 'candidate-first') break;
         }
         return (
           best ?? {

--- a/scripts/colliderReachabilityAudit.ts
+++ b/scripts/colliderReachabilityAudit.ts
@@ -1,0 +1,601 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import type { Page } from '@playwright/test';
+
+import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../src/scene/level/mediaWallPolicy';
+
+import { auditColliderGeometry } from './colliderGeometryAudit';
+import {
+  findColliderMatches,
+  formatOptional,
+  type ColliderInspectQuery,
+} from './colliderInspect';
+import {
+  type RuntimeColliderMetadata,
+  withRuntimePage,
+} from './colliderRuntimeCollector';
+
+export type ReachabilityClassification =
+  | 'directly-load-bearing'
+  | 'dominated'
+  | 'outside-reachable-navmesh'
+  | 'visual-only-by-policy'
+  | 'secondary-backstop'
+  | 'ambiguous';
+
+export type ColliderReachabilityAuditOptions = {
+  query: ColliderInspectQuery;
+  json: boolean;
+  gridResolution: number;
+  maxExploredNodes: number;
+  timeoutMs: number;
+  baseUrl?: string;
+};
+
+type ApproachDirection = 'north' | 'south' | 'east' | 'west';
+
+type RuntimeApproachResult = {
+  direction: ApproachDirection;
+  sample: { x: number; z: number; floorId: string };
+  status: 'candidate-first' | 'blocked-by-other' | 'unreachable' | 'ambiguous';
+  start?: { x: number; z: number; floorId: string };
+  blockers: string[];
+  blockerSourceIds: string[];
+  exploredNodes: number;
+  pathLength: number;
+  message?: string;
+};
+
+export type ReachabilityAggregationInput = {
+  candidate: Pick<RuntimeColliderMetadata, 'id' | 'sourceId' | 'intent'>;
+  approaches: readonly Pick<RuntimeApproachResult, 'status' | 'blockers'>[];
+  visualOnlyRationale?: string;
+};
+
+export type ColliderReachabilityAuditReport = {
+  candidate?: RuntimeColliderMetadata;
+  sourcePolicy?: { sourceId: string; collision: 'none'; rationale: string };
+  classification: ReachabilityClassification;
+  limits: {
+    gridResolution: number;
+    maximumExploredNodes: number;
+    testedStarts: number;
+    testedApproachSamples: number;
+  };
+  approaches: RuntimeApproachResult[];
+  dominatingColliders: Array<
+    Pick<RuntimeColliderMetadata, 'id' | 'sourceId' | 'name'>
+  >;
+  staticEvidence?: ReturnType<typeof auditColliderGeometry>[number];
+  note: string;
+};
+
+const round = (value: number) => Number(value.toFixed(3));
+
+const VISUAL_ONLY_POLICIES = [FUTUROPTIMIST_MEDIA_WALL_POLICY].map(
+  (policy) => ({
+    sourceId: policy.sourceId,
+    collision: policy.collision.collision,
+    rationale: policy.collision.rationale,
+  })
+);
+
+export const parseColliderReachabilityAuditArgs = (
+  args: readonly string[]
+): ColliderReachabilityAuditOptions => {
+  let query: ColliderInspectQuery | undefined;
+  let json = false;
+  let gridResolution = 0.55;
+  let maxExploredNodes = 1400;
+  let timeoutMs = 120_000;
+  let baseUrl: string | undefined;
+  const readValue = (index: number, flag: string) => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--id' || arg === '--source-id' || arg === '--name') {
+      if (query)
+        throw new Error('Provide exactly one of --id, --source-id, or --name.');
+      query = {
+        kind: arg.slice(2) as ColliderInspectQuery['kind'],
+        value: readValue(index, arg),
+      };
+      index += 1;
+    } else if (
+      arg === '--grid-resolution' ||
+      arg === '--max-nodes' ||
+      arg === '--timeout-ms'
+    ) {
+      const value = Number(readValue(index, arg));
+      if (!Number.isFinite(value) || value <= 0)
+        throw new Error(`${arg} must be positive.`);
+      if (arg === '--grid-resolution') gridResolution = value;
+      if (arg === '--max-nodes') maxExploredNodes = Math.floor(value);
+      if (arg === '--timeout-ms') timeoutMs = Math.floor(value);
+      index += 1;
+    } else if (arg === '--base-url') {
+      baseUrl = readValue(index, arg);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!query)
+    throw new Error('Provide exactly one of --id, --source-id, or --name.');
+  return { query, json, gridResolution, maxExploredNodes, timeoutMs, baseUrl };
+};
+
+export const classifyReachabilityEvidence = ({
+  candidate,
+  approaches,
+  visualOnlyRationale,
+}: ReachabilityAggregationInput): ReachabilityClassification => {
+  if (visualOnlyRationale) return 'visual-only-by-policy';
+  if (candidate.intent === 'secondary-backstop') return 'secondary-backstop';
+  if (approaches.some((approach) => approach.status === 'candidate-first')) {
+    return 'directly-load-bearing';
+  }
+  const reachable = approaches.filter(
+    (approach) => approach.status === 'blocked-by-other'
+  );
+  if (reachable.length > 0 && reachable.length === approaches.length)
+    return 'dominated';
+  if (
+    approaches.length > 0 &&
+    approaches.every((approach) => approach.status === 'unreachable')
+  ) {
+    return 'outside-reachable-navmesh';
+  }
+  return 'ambiguous';
+};
+
+const runRuntimeApproaches = async (
+  page: Page,
+  candidate: RuntimeColliderMetadata,
+  options: ColliderReachabilityAuditOptions
+): Promise<{ approaches: RuntimeApproachResult[]; testedStarts: number }> => {
+  await page.evaluate(() => {
+    (globalThis as typeof globalThis & { __name?: <T>(value: T) => T }).__name =
+      (value) => value;
+  });
+  return page.evaluate(
+    ({ candidate: nextCandidate, gridResolution, maxExploredNodes }) => {
+      type FloorId = 'ground' | 'upper';
+      type World = {
+        canOccupyPosition(target: {
+          x: number;
+          z: number;
+          floorId?: FloorId;
+        }): boolean;
+        movePlayerTo(target: { x: number; z: number; floorId?: FloorId }): void;
+        stepPlayerForTest(step: { dx: number; dz: number }): {
+          movedX: boolean;
+          movedZ: boolean;
+          blockedBy?: string[];
+        };
+        getPlayerPosition(): { x: number; y: number; z: number };
+      };
+      type DebugApi = {
+        getBlockingCollidersAt(target: {
+          x: number;
+          z: number;
+          floorId?: FloorId;
+        }): Array<{
+          id: string;
+          sourceId?: string;
+        }>;
+      };
+      const portfolio = (
+        window as typeof window & {
+          portfolio?: { world?: World; debugColliders?: DebugApi };
+        }
+      ).portfolio;
+      const world = portfolio?.world;
+      const debug = portfolio?.debugColliders;
+      if (!world || !debug)
+        throw new Error('World/debug collider APIs unavailable.');
+      const floorId = (
+        nextCandidate.floor === 'upper' ? 'upper' : 'ground'
+      ) as FloorId;
+      const radius = 0.38;
+      const center = {
+        x: (nextCandidate.bounds.minX + nextCandidate.bounds.maxX) / 2,
+        z: (nextCandidate.bounds.minZ + nextCandidate.bounds.maxZ) / 2,
+      };
+      const samples = [
+        {
+          direction: 'north',
+          x: center.x,
+          z: nextCandidate.bounds.maxZ + radius,
+        },
+        {
+          direction: 'south',
+          x: center.x,
+          z: nextCandidate.bounds.minZ - radius,
+        },
+        {
+          direction: 'east',
+          x: nextCandidate.bounds.maxX + radius,
+          z: center.z,
+        },
+        {
+          direction: 'west',
+          x: nextCandidate.bounds.minX - radius,
+          z: center.z,
+        },
+      ] as const;
+      const startCandidates = [
+        world.getPlayerPosition(),
+        { x: 0, z: 0 },
+        { x: -5, z: -6 },
+        { x: 6, z: -7 },
+        { x: 0, z: -14 },
+        { x: 0, z: -23 },
+        { x: 12.4, z: -25.2 },
+      ];
+      const starts = startCandidates
+        .map((start) => ({ x: start.x, z: start.z, floorId }))
+        .filter(
+          (start, index, all) =>
+            world.canOccupyPosition(start) &&
+            all.findIndex(
+              (other) => Math.hypot(other.x - start.x, other.z - start.z) < 0.1
+            ) === index
+        );
+      const key = (x: number, z: number) =>
+        `${Math.round(x / gridResolution)},${Math.round(z / gridResolution)}`;
+      const snap = (value: number) =>
+        Math.round(value / gridResolution) * gridResolution;
+      const findPath = (
+        start: { x: number; z: number },
+        goal: { x: number; z: number }
+      ) => {
+        const startNode = { x: snap(start.x), z: snap(start.z) };
+        const goalKey = key(goal.x, goal.z);
+        const queue = [startNode];
+        const parents = new Map<string, string>();
+        const nodes = new Map([[key(startNode.x, startNode.z), startNode]]);
+        parents.set(key(startNode.x, startNode.z), '');
+        for (
+          let cursor = 0;
+          cursor < queue.length && cursor < maxExploredNodes;
+          cursor += 1
+        ) {
+          const node = queue[cursor];
+          if (
+            key(node.x, node.z) === goalKey ||
+            Math.hypot(node.x - goal.x, node.z - goal.z) <= gridResolution
+          ) {
+            const path = [{ x: goal.x, z: goal.z }];
+            let walkKey = key(node.x, node.z);
+            while (walkKey && parents.get(walkKey) !== '') {
+              const item = nodes.get(walkKey)!;
+              path.push(item);
+              walkKey = parents.get(walkKey)!;
+            }
+            return { path: path.reverse(), exploredNodes: cursor + 1 };
+          }
+          for (const [dx, dz] of [
+            [gridResolution, 0],
+            [-gridResolution, 0],
+            [0, gridResolution],
+            [0, -gridResolution],
+          ]) {
+            const next = {
+              x: round(node.x + dx),
+              z: round(node.z + dz),
+              floorId,
+            };
+            const nextKey = key(next.x, next.z);
+            if (parents.has(nextKey) || !world.canOccupyPosition(next))
+              continue;
+            parents.set(nextKey, key(node.x, node.z));
+            nodes.set(nextKey, next);
+            queue.push(next);
+          }
+        }
+        return {
+          path: [] as Array<{ x: number; z: number }>,
+          exploredNodes: Math.min(queue.length, maxExploredNodes),
+        };
+      };
+      const confirm = (
+        start: { x: number; z: number; floorId: FloorId },
+        path: Array<{ x: number; z: number }>,
+        sample: { x: number; z: number }
+      ) => {
+        world.movePlayerTo(start);
+        const waypoints = [...path, center];
+        for (const waypoint of waypoints) {
+          for (let step = 0; step < 220; step += 1) {
+            const position = world.getPlayerPosition();
+            const remainingX = waypoint.x - position.x;
+            const remainingZ = waypoint.z - position.z;
+            if (Math.hypot(remainingX, remainingZ) < 0.03) break;
+            const length = Math.max(0.001, Math.hypot(remainingX, remainingZ));
+            const amount = Math.min(0.16, length);
+            const result = world.stepPlayerForTest({
+              dx: (remainingX / length) * amount,
+              dz: (remainingZ / length) * amount,
+            });
+            const blocked = result.blockedBy ?? [];
+            if (blocked.length > 0 || (!result.movedX && !result.movedZ)) {
+              const atPoint = debug.getBlockingCollidersAt({
+                x: sample.x,
+                z: sample.z,
+                floorId,
+              });
+              return {
+                blockers: blocked,
+                blockerSourceIds: atPoint
+                  .map((item) => item.sourceId)
+                  .filter(Boolean) as string[],
+              };
+            }
+          }
+        }
+        return { blockers: [] as string[], blockerSourceIds: [] as string[] };
+      };
+      const approaches = samples.map((sample) => {
+        const occupied = world.canOccupyPosition({
+          x: sample.x,
+          z: sample.z,
+          floorId,
+        });
+        if (!occupied) {
+          const blockers = debug.getBlockingCollidersAt({
+            x: sample.x,
+            z: sample.z,
+            floorId,
+          });
+          return {
+            direction: sample.direction,
+            sample: {
+              x: Number(sample.x.toFixed(3)),
+              z: Number(sample.z.toFixed(3)),
+              floorId,
+            },
+            status: blockers.some((blocker) => blocker.id === nextCandidate.id)
+              ? 'candidate-first'
+              : 'blocked-by-other',
+            blockers: blockers.map((blocker) => blocker.id),
+            blockerSourceIds: blockers
+              .map((blocker) => blocker.sourceId)
+              .filter(Boolean) as string[],
+            exploredNodes: 0,
+            pathLength: 0,
+          };
+        }
+        let best: RuntimeApproachResult | undefined;
+        for (const start of starts) {
+          const found = findPath(start, sample);
+          if (found.path.length === 0) {
+            best = best ?? {
+              direction: sample.direction,
+              sample: {
+                x: Number(sample.x.toFixed(3)),
+                z: Number(sample.z.toFixed(3)),
+                floorId,
+              },
+              status: 'unreachable',
+              start,
+              blockers: [],
+              blockerSourceIds: [],
+              exploredNodes: found.exploredNodes,
+              pathLength: 0,
+            };
+            continue;
+          }
+          const blocked = confirm(start, found.path, sample);
+          const status = blocked.blockers.includes(nextCandidate.id)
+            ? 'candidate-first'
+            : blocked.blockers.length > 0
+              ? 'blocked-by-other'
+              : 'ambiguous';
+          best = {
+            direction: sample.direction,
+            sample: {
+              x: Number(sample.x.toFixed(3)),
+              z: Number(sample.z.toFixed(3)),
+              floorId,
+            },
+            status,
+            start,
+            blockers: blocked.blockers,
+            blockerSourceIds: blocked.blockerSourceIds,
+            exploredNodes: found.exploredNodes,
+            pathLength: found.path.length,
+          };
+          if (status === 'candidate-first' || status === 'blocked-by-other')
+            break;
+        }
+        return (
+          best ?? {
+            direction: sample.direction,
+            sample: {
+              x: Number(sample.x.toFixed(3)),
+              z: Number(sample.z.toFixed(3)),
+              floorId,
+            },
+            status: 'unreachable',
+            blockers: [],
+            blockerSourceIds: [],
+            exploredNodes: 0,
+            pathLength: 0,
+          }
+        );
+      });
+      return { approaches, testedStarts: starts.length };
+    },
+    {
+      candidate,
+      gridResolution: options.gridResolution,
+      maxExploredNodes: options.maxExploredNodes,
+    }
+  );
+};
+
+export const auditColliderReachability = async (
+  options: ColliderReachabilityAuditOptions
+): Promise<ColliderReachabilityAuditReport[]> => {
+  if (options.query.kind === 'source-id') {
+    const visualOnly = VISUAL_ONLY_POLICIES.find(
+      (policy) => policy.sourceId === options.query.value
+    );
+    if (visualOnly) {
+      return [
+        {
+          sourcePolicy: visualOnly,
+          classification: 'visual-only-by-policy',
+          limits: {
+            gridResolution: options.gridResolution,
+            maximumExploredNodes: options.maxExploredNodes,
+            testedStarts: 0,
+            testedApproachSamples: 0,
+          },
+          approaches: [],
+          dominatingColliders: [],
+          note: 'Source policy intentionally emits no runtime collider; no fake collider was sampled.',
+        },
+      ];
+    }
+  }
+
+  const baseUrl = options.baseUrl ?? process.env.PLAYWRIGHT_BASE_URL;
+  return withRuntimePage(
+    { baseUrl, timeoutMs: options.timeoutMs },
+    async (page) => {
+      const colliders = await page.evaluate(() => {
+        const api = (
+          window as typeof window & {
+            portfolio?: {
+              debugColliders?: { getColliders(): RuntimeColliderMetadata[] };
+            };
+          }
+        ).portfolio?.debugColliders;
+        if (!api)
+          throw new Error('window.portfolio.debugColliders is unavailable.');
+        return api.getColliders();
+      });
+      const matches = findColliderMatches(colliders, options.query);
+      if (matches.length === 0)
+        throw new Error(
+          `No collider matched ${options.query.kind} "${options.query.value}".`
+        );
+      if (options.query.kind !== 'source-id' && matches.length > 1)
+        throw new Error(
+          `Ambiguous collider ${options.query.kind} "${options.query.value}" matched ${
+            matches.length
+          } records: ${matches.map((match) => match.id).join(', ')}.`
+        );
+      const reports: ColliderReachabilityAuditReport[] = [];
+      for (const candidate of matches) {
+        const runtime = await runRuntimeApproaches(page, candidate, options);
+        const classification = classifyReachabilityEvidence({
+          candidate,
+          approaches: runtime.approaches,
+        });
+        const blockerIds = new Set(
+          runtime.approaches
+            .flatMap((approach) => approach.blockers)
+            .filter((id) => id !== candidate.id)
+        );
+        reports.push({
+          candidate,
+          classification,
+          limits: {
+            gridResolution: options.gridResolution,
+            maximumExploredNodes: options.maxExploredNodes,
+            testedStarts: runtime.testedStarts,
+            testedApproachSamples: runtime.approaches.length,
+          },
+          approaches: runtime.approaches,
+          dominatingColliders: colliders
+            .filter((collider) => blockerIds.has(collider.id))
+            .map(({ id, sourceId, name }) => ({ id, sourceId, name })),
+          staticEvidence: auditColliderGeometry(colliders, {
+            query: { kind: 'id', value: candidate.id },
+            json: true,
+            tolerance: 0.05,
+            samples: 16,
+          })[0],
+          note: 'Opt-in evidence only. Screenshots and maintainer judgment may override ambiguous results.',
+        });
+      }
+      return reports;
+    }
+  );
+};
+
+const formatReport = (report: ColliderReachabilityAuditReport) => {
+  const subject = report.candidate
+    ? `Candidate ${report.candidate.id}\n  runtime name: ${report.candidate.name}\n  source ID: ${formatOptional(report.candidate.sourceId)}`
+    : `Source policy ${report.sourcePolicy?.sourceId}`;
+  return [
+    subject,
+    `  classification: ${report.classification}`,
+    `  limits: grid ${report.limits.gridResolution}, max nodes ${report.limits.maximumExploredNodes}, starts ${report.limits.testedStarts}, approaches ${report.limits.testedApproachSamples}`,
+    `  note: ${report.note}`,
+    report.sourcePolicy
+      ? `  rationale: ${report.sourcePolicy.rationale}`
+      : undefined,
+    'Approaches:',
+    report.approaches.length > 0
+      ? report.approaches
+          .map(
+            (approach) =>
+              `  - ${approach.direction}: ${approach.status}; blockers ${approach.blockers.join(', ') || 'none'}; source IDs ${approach.blockerSourceIds.join(', ') || 'n/a'}; path nodes ${approach.pathLength}; explored ${approach.exploredNodes}`
+          )
+          .join('\n')
+      : '  - none',
+    'Dominating colliders:',
+    report.dominatingColliders.length > 0
+      ? report.dominatingColliders
+          .map(
+            (collider) =>
+              `  - ${collider.id} ${collider.name} (${formatOptional(collider.sourceId)})`
+          )
+          .join('\n')
+      : '  - none',
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+export const runColliderReachabilityAuditCli = async (
+  args: readonly string[]
+) => {
+  const options = parseColliderReachabilityAuditArgs(args);
+  const reports = await auditColliderReachability(options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(reports, null, 2)}\n`
+      : `${reports.map(formatReport).join('\n\n')}\n`
+  );
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderReachabilityAuditCli(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}

--- a/scripts/colliderRuntimeCollector.ts
+++ b/scripts/colliderRuntimeCollector.ts
@@ -38,6 +38,8 @@ export type RuntimeColliderCollectorOptions = {
   timeoutMs?: number;
 };
 
+export type RuntimePageOptions = RuntimeColliderCollectorOptions;
+
 export const DEFAULT_COLLIDER_RUNTIME_BASE_URL = 'http://127.0.0.1:5173';
 
 const wait = (milliseconds: number) =>
@@ -189,9 +191,10 @@ const readCollidersFromPage = async (page: Page, timeoutMs: number) => {
   });
 };
 
-export const collectRuntimeColliders = async (
-  options: RuntimeColliderCollectorOptions = {}
-): Promise<RuntimeColliderMetadata[]> => {
+export const withRuntimePage = async <T>(
+  options: RuntimePageOptions = {},
+  action: (page: Page) => Promise<T>
+): Promise<T> => {
   const suppliedBaseUrl = options.baseUrl ?? process.env.PLAYWRIGHT_BASE_URL;
   const baseUrl = suppliedBaseUrl ?? DEFAULT_COLLIDER_RUNTIME_BASE_URL;
   const timeoutMs = options.timeoutMs ?? 120_000;
@@ -210,9 +213,16 @@ export const collectRuntimeColliders = async (
       waitUntil: 'domcontentloaded',
       timeout: timeoutMs,
     });
-    return await readCollidersFromPage(page, timeoutMs);
+    return await action(page);
   } finally {
     await browser?.close().catch(() => undefined);
     await closeStartedServer(server).catch(() => undefined);
   }
 };
+
+export const collectRuntimeColliders = async (
+  options: RuntimeColliderCollectorOptions = {}
+): Promise<RuntimeColliderMetadata[]> =>
+  withRuntimePage(options, (page) =>
+    readCollidersFromPage(page, options.timeoutMs ?? 120_000)
+  );


### PR DESCRIPTION
### Motivation
- Provide an opt-in runtime reachability audit to answer whether a player starting from legal anchors can encounter a candidate collider as the first meaningful blocker, reducing manual review friction in the collider-simplification workflow.
- Integrate the audit as review-only tooling (not CI-mandatory) that complements existing geometry evidence and respects source-declared visual-only and backstop intents.

### Description
- Add a new CLI script `scripts/colliderReachabilityAudit.ts` and package script `collider:audit:reachability` that accepts `--id|--source-id|--name`, supports `--json`, and exposes deterministic runtime limits (`--grid-resolution`, `--max-nodes`, `--timeout-ms`).
- Reuse the existing runtime collector lifecycle by introducing `withRuntimePage` in `scripts/colliderRuntimeCollector.ts` and call it from the reachability audit to avoid duplicating browser/server launch code.
- Implement deterministic approach sampling, bounded occupancy path proposals, runtime movement confirmation via `stepPlayerForTest`, first-blocker classification (including `directly-load-bearing`, `dominated`, `outside-reachable-navmesh`, `visual-only-by-policy`, `secondary-backstop`, and `ambiguous`), and include static geometry evidence from the geometry audit.
- Add tests and docs: pure aggregation/unit tests in `scripts/__tests__/colliderReachabilityAudit.test.ts`, a focused Playwright smoke spec `playwright/collider-reachability-audit.spec.ts`, and documentation updates in `docs/design/editing-level-data.md` with a lightweight removal workflow; update `package.json` to expose the new npm script.

### Testing
- Ran unit tests for the new scripts: `npm run test:ci -- scripts` (passed).
- Executed the new CLI against representative candidates: `npm run collider:audit:reachability -- --source-id ground.backyard.perimeter.backFence.boundary --json` and `npm run collider:audit:reachability -- --source-id upper.stairwell.landingGuard.shoulderEast --json` (both produced expected JSON reports).
- Ran the Playwright smoke spec: `npx playwright test playwright/collider-reachability-audit.spec.ts` (passed after Playwright browsers and OS deps were installed during the run).
- Ran full repository checks: `npm run lint` (passed with no blocking errors), `npm run docs:check` (passed; external link fetch warnings logged), and `npm run smoke` (build/smoke passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38ae51b3c0832f988932cbb96666c8)