### PR TITLE
Add opt-in collider reachability audit CLI and tests

### DIFF
--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -228,3 +228,26 @@ bounds through the narrow production fixture helpers in
 `src/tests/helpers/productionLevelFixtures.ts`. Request the semantic floor and
 room IDs needed by the test, and keep exact geometry literals limited to small
 synthetic fixtures where the generator output itself is under test.
+
+## Collider removal evidence workflow
+
+When reviewing a collider-removal candidate, gather only the evidence needed for
+that candidate rather than creating historical ledgers or full-scene snapshots:
+
+1. Inspect the runtime record with `npm run collider:inspect -- --source-id <source-id>`
+   or `--id <debug-id>` to confirm identity, provenance, policy, and bounds.
+2. Run geometric supporting evidence with
+   `npm run collider:audit:geometry -- --source-id <source-id>` when overlap,
+   containment, adjacency, or coverage loss would clarify the review.
+3. Run reachability evidence with
+   `npm run collider:audit:reachability -- --source-id <source-id>` when the
+   player-facing question is whether a legal approach encounters that collider
+   as the first meaningful blocker. Treat `ambiguous` as a prompt for maintainer
+   judgment, screenshots, or a narrower manual route check rather than as a
+   deletion approval.
+4. Edit the active source policy that emits the collider, or change that source
+   to an intentional visual-only policy when the component should render without
+   a floor-level footprint.
+5. Rely on behavior tests and the generic declaration contracts to keep the
+   scene honest; do not add tombstones, mandatory all-collider audits, or
+   permanent historical deletion records for the removed runtime collider.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "links:check": "node scripts/check-links.cjs",
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
     "collider:inspect": "tsx scripts/colliderInspect.ts",
-    "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts"
+    "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
+    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/playwright/collider-reachability-audit.spec.ts
+++ b/playwright/collider-reachability-audit.spec.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from 'node:child_process';
+
+import { expect, test } from '@playwright/test';
+
+const runAudit = (args: string[]) =>
+  JSON.parse(
+    execFileSync(
+      'npx',
+      ['tsx', 'scripts/colliderReachabilityAudit.ts', ...args, '--json'],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          PLAYWRIGHT_BASE_URL:
+            process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:5173',
+        },
+        encoding: 'utf8',
+        timeout: 120_000,
+      }
+    )
+  );
+
+test('reports a semantic physical boundary as directly load-bearing', () => {
+  const [report] = runAudit([
+    '--source-id',
+    'ground.backyard.perimeter.backFence.boundary',
+  ]);
+  expect(report.classification).toBe('directly-load-bearing');
+  expect(report.candidate.sourceId).toBe(
+    'ground.backyard.perimeter.backFence.boundary'
+  );
+});
+
+test('reports a semantic visual-only source from policy intent', () => {
+  const [report] = runAudit([
+    '--source-id',
+    'ground.livingRoom.mediaWall.futuroptimist',
+  ]);
+  expect(report.classification).toBe('visual-only-by-policy');
+  expect(report.note).toContain(
+    'intentionally has no floor-level interaction footprint'
+  );
+});

--- a/scripts/__tests__/colliderReachabilityAudit.test.ts
+++ b/scripts/__tests__/colliderReachabilityAudit.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyReachabilityEvidence,
+  parseColliderReachabilityAuditArgs,
+} from '../colliderReachabilityAudit';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const candidate: RuntimeColliderMetadata = {
+  id: '400D',
+  floor: 'upper',
+  category: 'stair',
+  name: 'UpperStairwellLandingGuard-3',
+  sourceId: 'upper.stairwell.landingGuard.shoulderEast',
+  intent: 'safety-guard',
+  bounds: { minX: 0, maxX: 1, minZ: 0, maxZ: 1 },
+};
+
+const attempt = (firstBlockers: string[], reachable = true) => ({
+  direction: 'north' as const,
+  target: { x: 0, z: 0, floorId: 'upper' as const },
+  reachable,
+  confirmed: firstBlockers.length === 0,
+  firstBlockers,
+});
+
+describe('parseColliderReachabilityAuditArgs', () => {
+  it('parses source selectors, json, and explicit limits', () => {
+    expect(
+      parseColliderReachabilityAuditArgs([
+        '--source-id',
+        'upper.stairwell.landingGuard.shoulderEast',
+        '--json',
+        '--grid-resolution',
+        '0.25',
+        '--max-explored-nodes',
+        '100',
+      ])
+    ).toEqual({
+      query: {
+        kind: 'source-id',
+        value: 'upper.stairwell.landingGuard.shoulderEast',
+      },
+      json: true,
+      gridResolution: 0.25,
+      maxExploredNodes: 100,
+    });
+  });
+});
+
+describe('classifyReachabilityEvidence', () => {
+  it('classifies candidates first hit by runtime movement as directly load-bearing', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        attempts: [attempt(['UpperStairwellLandingGuard-3'])],
+        exploredNodes: 4,
+        nodeLimitHit: false,
+      })
+    ).toBe('directly-load-bearing');
+  });
+
+  it('classifies reachable approaches blocked first by other colliders as dominated', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        attempts: [attempt(['OtherBoundary']), attempt(['OtherBoundary'])],
+        exploredNodes: 8,
+        nodeLimitHit: false,
+      })
+    ).toBe('dominated');
+  });
+
+  it('keeps unreachable candidates distinct from dominance', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        attempts: [attempt([], false)],
+        exploredNodes: 8,
+        nodeLimitHit: false,
+      })
+    ).toBe('outside-reachable-navmesh');
+  });
+
+  it('honors explicit source intent for visual-only and secondary backstops', () => {
+    expect(
+      classifyReachabilityEvidence({
+        sourcePolicy: { collision: 'none', rationale: 'visual component' },
+        attempts: [],
+        exploredNodes: 0,
+        nodeLimitHit: false,
+      })
+    ).toBe('visual-only-by-policy');
+
+    expect(
+      classifyReachabilityEvidence({
+        candidate: { ...candidate, intent: 'secondary-backstop' },
+        attempts: [attempt(['OtherBoundary'])],
+        exploredNodes: 2,
+        nodeLimitHit: false,
+      })
+    ).toBe('secondary-backstop');
+  });
+
+  it('does not silently weaken node-limit uncertainty into a confident result', () => {
+    expect(
+      classifyReachabilityEvidence({
+        candidate,
+        attempts: [attempt([], false)],
+        exploredNodes: 100,
+        nodeLimitHit: true,
+      })
+    ).toBe('ambiguous');
+  });
+});

--- a/scripts/colliderReachabilityAudit.ts
+++ b/scripts/colliderReachabilityAudit.ts
@@ -1,0 +1,470 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { FLOOR_PLAN_LEVELS } from '../src/assets/floorPlan';
+import { FUTUROPTIMIST_MEDIA_WALL_POLICY } from '../src/scene/level/mediaWallPolicy';
+import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from '../src/scene/level/upperStairwellLandingSegments';
+
+import { auditColliderGeometry } from './colliderGeometryAudit';
+import {
+  findColliderMatches,
+  formatOptional,
+  type ColliderInspectQuery,
+} from './colliderInspect';
+import {
+  collectRuntimeCollidersWithPage,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+
+type FloorId = 'ground' | 'upper';
+type Point = { x: number; z: number; floorId: FloorId };
+type ReachabilityClassification =
+  | 'directly-load-bearing'
+  | 'dominated'
+  | 'outside-reachable-navmesh'
+  | 'visual-only-by-policy'
+  | 'secondary-backstop'
+  | 'ambiguous';
+
+type Attempt = {
+  direction: 'north' | 'south' | 'east' | 'west';
+  target: Point;
+  reachable: boolean;
+  confirmed: boolean;
+  firstBlockers: string[];
+};
+
+export type ReachabilityAggregationInput = {
+  candidate?: RuntimeColliderMetadata;
+  sourcePolicy?: {
+    collision: 'none' | 'active';
+    intent?: string;
+    rationale?: string;
+  };
+  attempts: readonly Attempt[];
+  exploredNodes: number;
+  nodeLimitHit: boolean;
+};
+
+export type ColliderReachabilityReport = {
+  candidate?: RuntimeColliderMetadata;
+  sourceId?: string;
+  classification: ReachabilityClassification;
+  attempts: Attempt[];
+  dominatingColliders: Array<{
+    id: string;
+    sourceId?: string;
+    directions: string[];
+  }>;
+  limits: {
+    gridResolution: number;
+    maxExploredNodes: number;
+    testedStarts: number;
+    testedApproachSamples: number;
+  };
+  staticEvidence?: string;
+  note: string;
+};
+
+type Options = {
+  query: ColliderInspectQuery;
+  json: boolean;
+  gridResolution: number;
+  maxExploredNodes: number;
+};
+
+const PLAYER_RADIUS = 0.35;
+const STEP_SIZE = 0.18;
+const NOTE =
+  'Reachability is bounded evidence for review; screenshots and maintainer judgment may override ambiguous results.';
+
+const noCollisionPolicies = [
+  FUTUROPTIMIST_MEDIA_WALL_POLICY,
+  ...UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES,
+].filter((policy) => policy.collision.collision === 'none');
+
+const sourcePolicyFor = (sourceId: string) =>
+  noCollisionPolicies.find((policy) => policy.sourceId === sourceId)?.collision;
+
+export const parseColliderReachabilityAuditArgs = (
+  args: readonly string[]
+): Options => {
+  let query: ColliderInspectQuery | undefined;
+  let json = false;
+  let gridResolution = 0.5;
+  let maxExploredNodes = 5_000;
+  const readValue = (index: number, flag: string) => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+    if (arg === '--grid-resolution' || arg === '--max-explored-nodes') {
+      const value = Number(readValue(index, arg));
+      if (!Number.isFinite(value) || value <= 0)
+        throw new Error(`${arg} must be positive.`);
+      if (arg === '--grid-resolution') gridResolution = value;
+      else maxExploredNodes = Math.floor(value);
+      index += 1;
+      continue;
+    }
+    if (arg === '--id' || arg === '--source-id' || arg === '--name') {
+      if (query)
+        throw new Error('Provide exactly one of --id, --source-id, or --name.');
+      query = {
+        kind: arg.slice(2) as ColliderInspectQuery['kind'],
+        value: readValue(index, arg),
+      };
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!query)
+    throw new Error('Provide exactly one of --id, --source-id, or --name.');
+  return { query, json, gridResolution, maxExploredNodes };
+};
+
+const blockerIdentity = (collider: RuntimeColliderMetadata) =>
+  new Set([collider.id, collider.name]);
+
+export const classifyReachabilityEvidence = (
+  input: ReachabilityAggregationInput
+): ReachabilityClassification => {
+  if (input.sourcePolicy?.collision === 'none') return 'visual-only-by-policy';
+  if (input.candidate?.intent === 'secondary-backstop')
+    return 'secondary-backstop';
+  const candidateNames = input.candidate
+    ? blockerIdentity(input.candidate)
+    : new Set<string>();
+  if (
+    input.attempts.some((attempt) =>
+      attempt.firstBlockers.some((id) => candidateNames.has(id))
+    )
+  ) {
+    return 'directly-load-bearing';
+  }
+  const reachable = input.attempts.filter((attempt) => attempt.reachable);
+  if (reachable.length === 0)
+    return input.nodeLimitHit ? 'ambiguous' : 'outside-reachable-navmesh';
+  if (reachable.every((attempt) => attempt.firstBlockers.length > 0))
+    return 'dominated';
+  return 'ambiguous';
+};
+
+const approachSamples = (candidate: RuntimeColliderMetadata): Attempt[] => {
+  const { bounds, floor } = candidate;
+  const floorId = floor === 'upper' ? 'upper' : 'ground';
+  const midX = (bounds.minX + bounds.maxX) / 2;
+  const midZ = (bounds.minZ + bounds.maxZ) / 2;
+  const offset = PLAYER_RADIUS + 0.08;
+  return [
+    {
+      direction: 'north',
+      target: { x: midX, z: bounds.maxZ + offset, floorId },
+      reachable: false,
+      confirmed: false,
+      firstBlockers: [],
+    },
+    {
+      direction: 'south',
+      target: { x: midX, z: bounds.minZ - offset, floorId },
+      reachable: false,
+      confirmed: false,
+      firstBlockers: [],
+    },
+    {
+      direction: 'east',
+      target: { x: bounds.maxX + offset, z: midZ, floorId },
+      reachable: false,
+      confirmed: false,
+      firstBlockers: [],
+    },
+    {
+      direction: 'west',
+      target: { x: bounds.minX - offset, z: midZ, floorId },
+      reachable: false,
+      confirmed: false,
+      firstBlockers: [],
+    },
+  ];
+};
+
+const roomCenterStarts = (): Point[] =>
+  FLOOR_PLAN_LEVELS.flatMap((level) =>
+    level.plan.rooms.map((room) => ({
+      x: (room.bounds.minX + room.bounds.maxX) / 2,
+      z: (room.bounds.minZ + room.bounds.maxZ) / 2,
+      floorId: level.id as FloorId,
+    }))
+  );
+
+const findGridPath = async (
+  page: import('@playwright/test').Page,
+  starts: readonly Point[],
+  target: Point,
+  resolution: number,
+  maxNodes: number
+) => {
+  return page.evaluate(
+    ({
+      starts: nextStarts,
+      target: nextTarget,
+      resolution: nextResolution,
+      maxNodes: limit,
+    }) => {
+      const world = window.portfolio!.world!;
+      const queue: Array<{ point: Point; path: Point[] }> = nextStarts
+        .filter((start) => start.floorId === nextTarget.floorId)
+        .filter((start) => world.canOccupyPosition(start))
+        .map((point) => ({ point, path: [point] }));
+      const makeKey = (point: Point) =>
+        `${point.floorId}:${point.x.toFixed(2)}:${point.z.toFixed(2)}`;
+      const seen = new Set(queue.map((item) => makeKey(item.point)));
+      let explored = 0;
+      while (queue.length > 0 && explored < limit) {
+        const current = queue.shift()!;
+        explored += 1;
+        if (
+          Math.hypot(
+            current.point.x - nextTarget.x,
+            current.point.z - nextTarget.z
+          ) <= nextResolution
+        ) {
+          return {
+            path: [...current.path, nextTarget],
+            explored,
+            limitHit: false,
+          };
+        }
+        for (const [dx, dz] of [
+          [nextResolution, 0],
+          [-nextResolution, 0],
+          [0, nextResolution],
+          [0, -nextResolution],
+        ]) {
+          const next = {
+            x: current.point.x + dx,
+            z: current.point.z + dz,
+            floorId: nextTarget.floorId,
+          };
+          const nextKey = makeKey(next);
+          if (seen.has(nextKey)) continue;
+          seen.add(nextKey);
+          if (world.canOccupyPosition(next)) {
+            queue.push({ point: next, path: [...current.path, next] });
+          }
+        }
+      }
+      return { path: undefined, explored, limitHit: queue.length > 0 };
+    },
+    { starts, target, resolution, maxNodes }
+  );
+};
+
+const confirmPath = async (
+  page: import('@playwright/test').Page,
+  path: readonly Point[]
+) =>
+  page.evaluate(
+    ({ path: nextPath, stepSize }) => {
+      const world = window.portfolio!.world!;
+      const first = nextPath[0];
+      world.movePlayerTo(first);
+      for (const waypoint of nextPath.slice(1)) {
+        for (let index = 0; index < 420; index += 1) {
+          const pos = world.getPlayerPosition();
+          const remainingX = waypoint.x - pos.x;
+          const remainingZ = waypoint.z - pos.z;
+          if (Math.abs(remainingX) < 0.04 && Math.abs(remainingZ) < 0.04) break;
+          const dx = Math.max(-stepSize, Math.min(stepSize, remainingX));
+          const dz = Math.max(-stepSize, Math.min(stepSize, remainingZ));
+          const result = world.stepPlayerForTest({ dx, dz });
+          if ((dx !== 0 && !result.movedX) || (dz !== 0 && !result.movedZ)) {
+            return { confirmed: false, firstBlockers: result.blockedBy ?? [] };
+          }
+        }
+      }
+      return { confirmed: true, firstBlockers: [] };
+    },
+    { path, stepSize: STEP_SIZE }
+  );
+
+const summarizeDominators = (
+  attempts: readonly Attempt[],
+  colliders: readonly RuntimeColliderMetadata[]
+) => {
+  const byName = new Map(
+    colliders.flatMap((collider) =>
+      [...blockerIdentity(collider)].map((id) => [id, collider] as const)
+    )
+  );
+  const directions = new Map<string, Set<string>>();
+  attempts.forEach((attempt) => {
+    attempt.firstBlockers.forEach((blocker) => {
+      const collider = byName.get(blocker);
+      if (!collider) return;
+      const entry = directions.get(collider.id) ?? new Set<string>();
+      entry.add(attempt.direction);
+      directions.set(collider.id, entry);
+    });
+  });
+  return [...directions].map(([id, dirs]) => {
+    const collider = colliders.find((item) => item.id === id)!;
+    return { id, sourceId: collider.sourceId, directions: [...dirs].sort() };
+  });
+};
+
+export const runReachabilityAudit = async (
+  options: Options
+): Promise<ColliderReachabilityReport[]> => {
+  const visualPolicy =
+    options.query.kind === 'source-id'
+      ? sourcePolicyFor(options.query.value)
+      : undefined;
+  if (visualPolicy?.collision === 'none') {
+    return [
+      {
+        sourceId: options.query.value,
+        classification: 'visual-only-by-policy',
+        attempts: [],
+        dominatingColliders: [],
+        limits: {
+          gridResolution: options.gridResolution,
+          maxExploredNodes: options.maxExploredNodes,
+          testedStarts: 0,
+          testedApproachSamples: 0,
+        },
+        note: visualPolicy.rationale,
+      },
+    ];
+  }
+
+  return collectRuntimeCollidersWithPage(async (page, colliders) => {
+    const matches = findColliderMatches(colliders, options.query);
+    if (matches.length === 0)
+      throw new Error(
+        `No collider matched ${options.query.kind} "${options.query.value}".`
+      );
+    if (options.query.kind !== 'source-id' && matches.length > 1)
+      throw new Error(
+        `Ambiguous collider ${options.query.kind} "${options.query.value}" matched ${matches.length} records: ${matches.map((match) => match.id).join(', ')}.`
+      );
+    const starts = roomCenterStarts();
+    const reports: ColliderReachabilityReport[] = [];
+    for (const candidate of matches) {
+      const attempts = approachSamples(candidate);
+      let exploredNodes = 0;
+      let nodeLimitHit = false;
+      for (const attempt of attempts) {
+        const pathResult = await findGridPath(
+          page,
+          starts,
+          attempt.target,
+          options.gridResolution,
+          options.maxExploredNodes
+        );
+        exploredNodes += pathResult.explored;
+        nodeLimitHit ||= pathResult.limitHit;
+        if (!pathResult.path) continue;
+        attempt.reachable = true;
+        const confirmation = await confirmPath(page, pathResult.path);
+        attempt.confirmed = confirmation.confirmed;
+        attempt.firstBlockers = confirmation.firstBlockers;
+      }
+      const classification = classifyReachabilityEvidence({
+        candidate,
+        attempts,
+        exploredNodes,
+        nodeLimitHit,
+      });
+      const [geometry] = auditColliderGeometry(colliders, {
+        query: { kind: 'id', value: candidate.id },
+        json: true,
+        tolerance: 0.05,
+        samples: 12,
+      });
+      reports.push({
+        candidate,
+        classification,
+        attempts,
+        dominatingColliders: summarizeDominators(attempts, colliders),
+        limits: {
+          gridResolution: options.gridResolution,
+          maxExploredNodes: options.maxExploredNodes,
+          testedStarts: starts.length,
+          testedApproachSamples: attempts.length,
+        },
+        staticEvidence: geometry.classification,
+        note: NOTE,
+      });
+    }
+    return reports;
+  });
+};
+
+const formatReport = (report: ColliderReachabilityReport) =>
+  [
+    `Candidate ${report.candidate?.id ?? report.sourceId}`,
+    `  runtime name: ${formatOptional(report.candidate?.name)}`,
+    `  source ID: ${formatOptional(report.candidate?.sourceId ?? report.sourceId)}`,
+    `  classification: ${report.classification}`,
+    `  static geometry evidence: ${formatOptional(report.staticEvidence)}`,
+    `  limits: grid ${report.limits.gridResolution}, max nodes ${report.limits.maxExploredNodes}, starts ${report.limits.testedStarts}, approaches ${report.limits.testedApproachSamples}`,
+    '  attempts:',
+    report.attempts.length
+      ? report.attempts
+          .map(
+            (attempt) =>
+              `    - ${attempt.direction}: reachable=${attempt.reachable}, confirmed=${attempt.confirmed}, first blockers=${attempt.firstBlockers.join(', ') || 'none'}`
+          )
+          .join('\n')
+      : '    - none',
+    '  dominating colliders:',
+    report.dominatingColliders.length
+      ? report.dominatingColliders
+          .map(
+            (item) =>
+              `    - ${item.id} source=${formatOptional(item.sourceId)} directions=${item.directions.join(',')}`
+          )
+          .join('\n')
+      : '    - none',
+    `  note: ${report.note}`,
+  ].join('\n');
+
+export const runColliderReachabilityAuditCli = async (
+  args: readonly string[]
+) => {
+  const options = parseColliderReachabilityAuditArgs(args);
+  const reports = await runReachabilityAudit(options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(reports, null, 2)}\n`
+      : `${reports.map(formatReport).join('\n\n')}\n`
+  );
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderReachabilityAuditCli(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}

--- a/scripts/colliderRuntimeCollector.ts
+++ b/scripts/colliderRuntimeCollector.ts
@@ -189,9 +189,10 @@ const readCollidersFromPage = async (page: Page, timeoutMs: number) => {
   });
 };
 
-export const collectRuntimeColliders = async (
+export const collectRuntimeCollidersWithPage = async <T>(
+  action: (page: Page, colliders: RuntimeColliderMetadata[]) => Promise<T>,
   options: RuntimeColliderCollectorOptions = {}
-): Promise<RuntimeColliderMetadata[]> => {
+): Promise<T> => {
   const suppliedBaseUrl = options.baseUrl ?? process.env.PLAYWRIGHT_BASE_URL;
   const baseUrl = suppliedBaseUrl ?? DEFAULT_COLLIDER_RUNTIME_BASE_URL;
   const timeoutMs = options.timeoutMs ?? 120_000;
@@ -210,9 +211,22 @@ export const collectRuntimeColliders = async (
       waitUntil: 'domcontentloaded',
       timeout: timeoutMs,
     });
-    return await readCollidersFromPage(page, timeoutMs);
+    await page.evaluate(() => {
+      const target = window as unknown as { __name?: <T>(value: T) => T };
+      target.__name ??= (value) => value;
+    });
+    const colliders = await readCollidersFromPage(page, timeoutMs);
+    return await action(page, colliders);
   } finally {
     await browser?.close().catch(() => undefined);
     await closeStartedServer(server).catch(() => undefined);
   }
 };
+
+export const collectRuntimeColliders = async (
+  options: RuntimeColliderCollectorOptions = {}
+): Promise<RuntimeColliderMetadata[]> =>
+  collectRuntimeCollidersWithPage(
+    async (_page, colliders) => colliders,
+    options
+  );


### PR DESCRIPTION
### Motivation

- Finish the collider-simplification arc by adding an opt-in, candidate-scoped runtime reachability audit to answer whether a legal approach is first-blocked by a given collider.
- Provide deterministic bounded sampling and conservative classification (including `ambiguous`) so the tool aids reviewer judgment without auto-deleting colliders or becoming a CI gate.
- Reuse existing runtime collector and movement helpers to avoid duplicating browser/session or movement logic.

### Description

- Add a new CLI: `scripts/colliderReachabilityAudit.ts` which supports `--id`, `--source-id`, `--name`, `--json`, `--grid-resolution`, and `--max-explored-nodes`, and emits classifications such as `directly-load-bearing`, `dominated`, `outside-reachable-navmesh`, `visual-only-by-policy`, `secondary-backstop`, and `ambiguous`.
- Reuse the runtime page flow by adding `collectRuntimeCollidersWithPage` and wire `collectRuntimeColliders` to call it, avoiding duplicate browser-launch code (`scripts/colliderRuntimeCollector.ts`).
- Add unit tests for classification and CLI argument parsing at `scripts/__tests__/colliderReachabilityAudit.test.ts` and a narrow Playwright smoke spec at `playwright/collider-reachability-audit.spec.ts` that uses semantic source IDs (one physical boundary and one visual-only policy).
- Add `npm` script `collider:audit:reachability` to `package.json` and document a short, non-mandatory collider removal evidence workflow in `docs/design/editing-level-data.md` referencing inspect → geometry audit → reachability audit → edit source policy.

### Testing

- Ran the new script manually and via CI helpers and smoke tests; example commands executed successfully: `npm run collider:audit:reachability -- --source-id ground.backyard.perimeter.backFence.boundary`, `npm run collider:audit:reachability -- --source-id upper.stairwell.landingGuard.shoulderEast --json`, and `npm run collider:audit:reachability -- --source-id ground.livingRoom.mediaWall.futuroptimist --json` (all returned expected classifications).
- Unit tests: `npm run test:ci -- scripts` — passed (scripts tests including new classification tests passed).
- Playwright smoke: `npx playwright test playwright/collider-reachability-audit.spec.ts` — passed (2 tests).
- Lint: `npm run lint` — passed after minor ordering fixes.
- Docs check: `npm run docs:check` — passed (link-check reported existing external warnings unrelated to this change).
- Smoke build: `npm run smoke` — passed.
- Typecheck: `npm run typecheck` — informational check still reports existing, unrelated project-wide TypeScript issues; these are unchanged by this PR and reported as a known repo-level constraint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38ae5edd78832fa437102c6328dd89)