### PR TITLE
Source-back SelfieMirror collider 101A

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -110,6 +110,7 @@ import {
   type AvatarVariantId,
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
+import { assertDebugColliderId } from './scene/debug/colliderDebugIds';
 import {
   createColliderVisualizer,
   type DebugColliderMetadata,
@@ -163,7 +164,10 @@ import {
   registerSceneObjectColliders,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
-import type { LevelSourceId } from './scene/level/sourceIds';
+import {
+  assertLevelSourceId,
+  type LevelSourceId,
+} from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -978,6 +982,11 @@ const STAIRCASE_CONFIG = {
     },
   },
 } satisfies StaircaseConfig;
+
+const SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId(
+  'ground.living_room.selfie_mirror.scene_object'
+);
+const SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A');
 
 const LIGHTING_OPTIONS = {
   enableLedStrips: true,
@@ -2032,6 +2041,21 @@ function initializeImmersiveScene(
       height: 4.1,
     });
     groundFloorGroup.add(mirror.group);
+    namedColliderDebugNames.set(
+      mirror.collider,
+      'LivingRoomSelfieMirrorCollider'
+    );
+    colliderSourceMetadata.set(mirror.collider, {
+      sourceId: SELFIE_MIRROR_COLLIDER_SOURCE_ID,
+      sourceType: 'sceneObject',
+      intent: 'physical-boundary',
+      role: 'selfieMirror',
+      purpose: 'block the visible selfie mirror footprint',
+      debugId: SELFIE_MIRROR_COLLIDER_DEBUG_ID,
+    });
+    // Keep 101A source-backed: this collider intentionally blocks the visible
+    // SelfieMirror footprint. It is not redundant just because geometry/reachability
+    // audits classify it as isolated or ambiguous.
     groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -37,6 +37,27 @@ describe('main module imports', () => {
     );
   });
 
+  it('source-backs the SelfieMirror footprint collider while preserving debug ID 101A', () => {
+    const source = readMainSource();
+
+    expect(source).toContain("'ground.living_room.selfie_mirror.scene_object'");
+    expect(source).toContain(
+      "const SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A');"
+    );
+    expect(source).toContain(`namedColliderDebugNames.set(
+      mirror.collider,
+      'LivingRoomSelfieMirrorCollider'
+    );`);
+    expect(source).toContain("sourceType: 'sceneObject',");
+    expect(source).toContain("intent: 'physical-boundary',");
+    expect(source).toContain("role: 'selfieMirror',");
+    expect(source).toContain(
+      "purpose: 'block the visible selfie mirror footprint',"
+    );
+    expect(source).toContain('debugId: SELFIE_MIRROR_COLLIDER_DEBUG_ID,');
+    expect(source).toContain('Keep 101A source-backed');
+  });
+
   it('passes generated source IDs and purposes into debug collider metadata', () => {
     const source = readMainSource();
 


### PR DESCRIPTION
### Motivation
- Runtime debug collider `101A` was anonymous (generated) but corresponds to the SelfieMirror footprint and must be source-backed for provenance without deleting the collider.
- The change should be a narrow metadata-only fix so the interactive scene and collider geometry/behavior remain unchanged.

### Description
- Added validated constants and registration for the SelfieMirror collider: `SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId('ground.living_room.selfie_mirror.scene_object')` and `SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A')` in `src/main.ts`.
- Before pushing the mirror collider into `groundColliders`, set a human-readable runtime name via `namedColliderDebugNames.set(mirror.collider, 'LivingRoomSelfieMirrorCollider')` and register source metadata with `colliderSourceMetadata.set(...)` including `sourceType: 'sceneObject'`, `intent: 'physical-boundary'`, `role: 'selfieMirror'`, `purpose: 'block the visible selfie mirror footprint'`, and the explicit `debugId` to preserve `101A`.
- Added the requested retention comment near the registration explaining `101A` is intentionally retained as the SelfieMirror footprint blocker.
- Added a focused test in `src/tests/mainImports.test.ts` to assert the main source contains the new constants and the registration snippet.
- Files changed: `src/main.ts`, `src/tests/mainImports.test.ts`.

### Testing
- Ran formatting: `npm run format:write` (succeeded).
- Lint: `npm run lint` (succeeded; import ordering warning adjusted during change).
- Focused unit test: `npm run test:ci -- src/tests/mainImports.test.ts` (succeeded).
- Full unit suite: `npm run test:ci` (succeeded; 165 files, 1262 tests passed in this run).
- Docs check: `npm run docs:check` (succeeded; link checker emitted reachable/HTTP warnings but did not fail).
- Smoke build: `npm run smoke` (succeeded; build completed).
- Type check: `npm run typecheck` (failed due to pre-existing unrelated TypeScript issues elsewhere in the repo; failure is unrelated to this narrow metadata change).
- Runtime inspection and audits (local dev server + collider tools): started dev server and installed Playwright artifacts, then ran `unset PLAYWRIGHT_BASE_URL` and executed `npm --silent run collider:inspect -- --id 101A`, `npm --silent run collider:inspect -- --source-id ground.living_room.selfie_mirror.scene_object`, `npm --silent run collider:audit:geometry -- --id 101A`, and `npm --silent run collider:audit:reachability -- --id 101A --max-nodes 4000 --timeout-ms 180000`; all confirmed `101A` maps to the SelfieMirror footprint with the new human-readable name and source metadata (bounds and audits unchanged).

Residual risks / notes: the change is metadata-only and does not alter geometry, visuals, or run-time collision behavior; `npm run typecheck` still fails for unrelated pre-existing type issues in the repo and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38da1e2148832fafb7ea4563b4152e)