### PR TITLE
🔎 : – Source-back SelfieMirror collider 101A

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -110,6 +110,7 @@ import {
   type AvatarVariantId,
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
+import { assertDebugColliderId } from './scene/debug/colliderDebugIds';
 import {
   createColliderVisualizer,
   type DebugColliderMetadata,
@@ -163,7 +164,10 @@ import {
   registerSceneObjectColliders,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
-import type { LevelSourceId } from './scene/level/sourceIds';
+import {
+  assertLevelSourceId,
+  type LevelSourceId,
+} from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -989,6 +993,12 @@ const LIGHTING_OPTIONS = {
   bloomRadius: 0.45,
   bloomThreshold: 0.78,
 } as const;
+
+const SELFIE_MIRROR_COLLIDER_DEBUG_NAME = 'LivingRoomSelfieMirrorCollider';
+const SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId(
+  'ground.living_room.selfie_mirror.scene_object'
+);
+const SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A');
 
 const groundColliders: RectCollider[] = [];
 const namedColliderDebugNames = new Map<RectCollider, string>();
@@ -2032,6 +2042,21 @@ function initializeImmersiveScene(
       height: 4.1,
     });
     groundFloorGroup.add(mirror.group);
+    namedColliderDebugNames.set(
+      mirror.collider,
+      SELFIE_MIRROR_COLLIDER_DEBUG_NAME
+    );
+    colliderSourceMetadata.set(mirror.collider, {
+      sourceId: SELFIE_MIRROR_COLLIDER_SOURCE_ID,
+      sourceType: 'sceneObject',
+      intent: 'physical-boundary',
+      role: 'selfieMirror',
+      purpose: 'block the visible selfie mirror footprint',
+      debugId: SELFIE_MIRROR_COLLIDER_DEBUG_ID,
+    });
+    // Keep 101A source-backed: this collider intentionally blocks the visible
+    // SelfieMirror footprint. It is not redundant just because geometry/reachability
+    // audits classify it as isolated or ambiguous.
     groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }


### PR DESCRIPTION
### Motivation
- Runtime inspection found anonymous generated collider `101A` covering the SelfieMirror footprint; the change gives it stable provenance without removing the collider.

### Description
- Set an explicit debug name and source metadata for the living-room SelfieMirror footprint collider in `src/main.ts` so the collider is reported as `LivingRoomSelfieMirrorCollider` with `sourceId: ground.living_room.selfie_mirror.scene_object` and `sourceType: sceneObject`.
- Preserve the visible debug ID by assigning explicit `debugId: '101A'` and add the requested maintenance comment explaining that this collider intentionally blocks the SelfieMirror footprint and should not be deleted due to isolated/ambiguous audit classifications.

### Testing
- Ran formatting with `npm run format:write` which completed successfully.
- Ran `npm run typecheck` which failed due to pre-existing, repository-wide TypeScript issues unrelated to the SelfieMirror metadata; the change itself compiles where its types are asserted.
- Ran `npm run lint`, `npm run test:ci` (all tests passed: 1261 tests), `npm run docs:check`, and `npm run smoke`, all of which completed successfully.
- Runtime verification performed with the inspector/audit scripts succeeded and shows the human-readable provenance for `101A`: `npm --silent run collider:inspect -- --id 101A` and `npm --silent run collider:inspect -- --source-id ground.living_room.selfie_mirror.scene_object` both report the new metadata, and `npm --silent run collider:audit:geometry -- --id 101A` + `npm --silent run collider:audit:reachability -- --id 101A --max-nodes 4000 --timeout-ms 180000` executed (geometry reported `isolated`, reachability ran as expected) indicating provenance is present while the collider remains in-place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38da283b90832fb730ff07c4628d84)