### PR TITLE
Source-back SelfieMirror collider (preserve debug ID 101A)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,10 @@ import {
   registerSceneObjectColliders,
 } from './scene/level/sceneObjects';
 import type { SceneObjectDefinition } from './scene/level/schema';
-import type { LevelSourceId } from './scene/level/sourceIds';
+import {
+  assertLevelSourceId,
+  type LevelSourceId,
+} from './scene/level/sourceIds';
 import {
   createGroundStairSafetyColliders,
   createUpperStairSafetyColliders,
@@ -1008,6 +1011,11 @@ const colliderSourceMetadata = new Map<
   }
 >();
 const upperFloorColliders: RectCollider[] = [];
+
+const SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId(
+  'ground.living_room.selfie_mirror.scene_object'
+);
+const SELFIE_MIRROR_COLLIDER_DEBUG_ID = '101A';
 
 const sceneObjectDefinitionsById =
   createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
@@ -2032,6 +2040,21 @@ function initializeImmersiveScene(
       height: 4.1,
     });
     groundFloorGroup.add(mirror.group);
+    namedColliderDebugNames.set(
+      mirror.collider,
+      'LivingRoomSelfieMirrorCollider'
+    );
+    colliderSourceMetadata.set(mirror.collider, {
+      sourceId: SELFIE_MIRROR_COLLIDER_SOURCE_ID,
+      sourceType: 'sceneObject',
+      intent: 'physical-boundary',
+      role: 'selfieMirror',
+      purpose: 'block the visible selfie mirror footprint',
+      debugId: SELFIE_MIRROR_COLLIDER_DEBUG_ID,
+    });
+    // Keep 101A source-backed: this collider intentionally blocks the visible
+    // SelfieMirror footprint. It is not redundant just because geometry/reachability
+    // audits classify it as isolated or ambiguous.
     groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -37,6 +37,28 @@ describe('main module imports', () => {
     );
   });
 
+  it('source-backs the SelfieMirror footprint collider while preserving debug ID 101A', () => {
+    const source = readMainSource();
+
+    expect(source).toContain("'ground.living_room.selfie_mirror.scene_object'");
+    expect(source).toContain("const SELFIE_MIRROR_COLLIDER_DEBUG_ID = '101A';");
+    expect(source).toMatch(
+      /namedColliderDebugNames\.set\(\s*mirror\.collider,\s*'LivingRoomSelfieMirrorCollider'\s*\);/
+    );
+    expect(source).toContain('sourceId: SELFIE_MIRROR_COLLIDER_SOURCE_ID,');
+    expect(source).toContain("sourceType: 'sceneObject',");
+    expect(source).toContain("intent: 'physical-boundary',");
+    expect(source).toContain("role: 'selfieMirror',");
+    expect(source).toContain(
+      "purpose: 'block the visible selfie mirror footprint',"
+    );
+    expect(source).toContain('debugId: SELFIE_MIRROR_COLLIDER_DEBUG_ID,');
+    expect(source).toContain('Keep 101A source-backed');
+    expect(source).toMatch(
+      /colliderSourceMetadata\.set\(mirror\.collider,[\s\S]*groundColliders\.push\(mirror\.collider\);/
+    );
+  });
+
   it('passes generated source IDs and purposes into debug collider metadata', () => {
     const source = readMainSource();
 


### PR DESCRIPTION
### Motivation
- Runtime debug collider `101A` appeared as an anonymous/generated ground collider; it maps to the SelfieMirror footprint and needs stable provenance so audits/inspections are human-readable without removing the collider.

### Description
- Add a validated level source ID and explicit debug ID for the SelfieMirror collider via `SELFIE_MIRROR_COLLIDER_SOURCE_ID` and `SELFIE_MIRROR_COLLIDER_DEBUG_ID` in `src/main.ts` using `assertLevelSourceId`.
- Attach human-readable debug name and source metadata to the mirror collider with `namedColliderDebugNames.set(mirror.collider, 'LivingRoomSelfieMirrorCollider')` and `colliderSourceMetadata.set(mirror.collider, { sourceId: ..., sourceType: 'sceneObject', intent: 'physical-boundary', role: 'selfieMirror', purpose: 'block the visible selfie mirror footprint', debugId: ... })`, and preserve the existing `groundColliders.push(mirror.collider)` placement so runtime blocking/behavior is unchanged.
- Add the requested explanatory comment above the push explaining `101A` is intentionally retained as the SelfieMirror footprint blocker.
- Add a focused source-wiring check to `src/tests/mainImports.test.ts` that verifies the SelfieMirror collider metadata/debug ID are present in `src/main.ts` (no visual or geometry changes were made).

### Testing
- Ran formatting: `npm run format:write` — passed.
- Type-check: `npm run typecheck` — observed baseline TypeScript errors unrelated to this change (existing project-wide issues); these are not introduced by this PR.
- Lint: `npm run lint` — passed.
- Unit tests: `npm run test:ci` — all tests passed (`1262` tests reported as passing in the run log).
- Docs and smoke: `npm run docs:check` — passed (link checker emitted external fetch warnings); `npm run smoke` — passed.
- Playwright/browser support: `npx playwright install chromium` and `npx playwright install-deps chromium` — performed to enable runtime inspection.
- Runtime verification (inspector/audits): ran `unset PLAYWRIGHT_BASE_URL; npm --silent run collider:inspect -- --id 101A` and `-- --source-id ground.living_room.selfie_mirror.scene_object` and the collider inspector now reports the expected human-readable metadata (runtime name `LivingRoomSelfieMirrorCollider`, `sourceId: ground.living_room.selfie_mirror.scene_object`, `sourceType: sceneObject`, `intent: physical-boundary`, `role: selfieMirror`, `purpose: block the visible selfie mirror footprint`, debug ID `101A`, correct bounds). Geometry and scene behaviour were not changed.
- Audits: `npm --silent run collider:audit:geometry -- --id 101A` and `npm --silent run collider:audit:reachability -- --id 101A --max-nodes 4000 --timeout-ms 180000` were run and returned the expected coverage/classification output while preserving provenance information.

Notes/risks: the change is narrowly scoped to debug/provenance metadata and tests; TypeScript baseline errors exist in the repo but are unrelated to this PR and were noted during `npm run typecheck`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38da394d9c832f84cc0e0fdad29e68)