### PR TITLE
🧱 : – Add conservative collider redundancy gate

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -22,6 +22,10 @@ jobs:
         run: npm run test:ci
       - name: Smoke test
         run: npm run smoke
+      - name: Install Playwright browsers for collider audit
+        run: npx playwright install --with-deps chromium-headless-shell
+      - name: Collider redundancy gate
+        run: npm run collider:audit:redundancy
 
   docker-runtime-smoke:
     runs-on: ubuntu-latest

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -153,6 +153,33 @@ tested approach samples. It is review evidence only: it does not scan every
 collider in CI, delete anything, persist snapshots, or replace screenshots and
 maintainer judgment when the result is ambiguous.
 
+## Run the conservative collider redundancy gate
+
+Use the redundancy gate before merging collider-heavy changes or when reviewing
+new source-backed boundaries. The gate launches or reuses the local immersive
+runtime, collects active debug colliders, and fails only on high-confidence,
+actionable redundancy evidence: exact duplicate source-backed colliders with
+matching floor/category/source semantics, or smaller source-backed colliders
+fully contained by a larger source-backed collider with no intentional exception
+intent. It deliberately does not fail ambiguous, isolated, outside-navmesh,
+anonymous, or source-less cases; those are warnings or provenance follow-ups
+unless a stricter policy is added later. The check is a CI guardrail, not a
+substitute for maintainer judgment on collision behavior.
+
+```bash
+npm run collider:audit:redundancy
+npm run collider:audit:redundancy -- --json
+npm run collider:audit:redundancy -- --max-nodes 3000 --timeout-ms 120000
+npm run collider:audit:redundancy -- --fail-on-anonymous # opt-in only
+```
+
+Failure output names the candidate collider, source ID when available,
+classification, evidence colliders, and remediation. Prefer removing the
+redundant source-backed collider or marking intentional secondary/backstop
+metadata over adding ad hoc allowlists. The default profile is PR-safe: it has a
+120 second timeout, inspects at most 3000 runtime colliders, and starts local
+Vite when `PLAYWRIGHT_BASE_URL` is not set, so it does not depend on staging.
+
 ## Lightweight collider removal workflow
 
 For a possible removal, keep the review centered on the active source policy:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
     "collider:inspect": "tsx scripts/colliderInspect.ts",
     "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
-    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts"
+    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts",
+    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderRedundancyGate.test.ts
+++ b/scripts/__tests__/colliderRedundancyGate.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateColliderRedundancy,
+  formatColliderRedundancyGateReport,
+  parseColliderRedundancyGateArgs,
+} from '../colliderRedundancyGate';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const base = {
+  floor: 'ground',
+  category: 'wall',
+  sourceType: 'wall',
+  bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+} satisfies Partial<RuntimeColliderMetadata>;
+
+const collider = (
+  input: Partial<RuntimeColliderMetadata> & Pick<RuntimeColliderMetadata, 'id'>
+): RuntimeColliderMetadata => ({
+  ...base,
+  name: input.id,
+  floor: base.floor!,
+  category: base.category!,
+  bounds: base.bounds!,
+  debugId: input.id,
+  sourceId: `source.${input.id}`,
+  ...input,
+});
+
+const options = parseColliderRedundancyGateArgs([]);
+
+describe('collider redundancy gate decisions', () => {
+  it('fails exact duplicates only when source-backed semantics match', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({ id: 'A', sourceId: 'wall.shared' }),
+        collider({ id: 'B', sourceId: 'wall.shared' }),
+        collider({ id: 'C', sourceId: 'wall.other' }),
+      ],
+      options
+    );
+
+    expect(report.failures).toHaveLength(1);
+    expect(report.failures[0]).toMatchObject({
+      classification: 'exact-duplicate',
+      candidate: { id: 'A' },
+      evidence: [{ collider: { id: 'B' } }],
+    });
+  });
+
+  it('fails contained source-backed colliders unless the candidate has exception intent', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({
+          id: 'INNER',
+          bounds: { minX: 1, maxX: 2, minZ: 1, maxZ: 2 },
+        }),
+        collider({
+          id: 'OUTER',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+        }),
+        collider({
+          id: 'BACKSTOP',
+          bounds: { minX: 1, maxX: 2, minZ: 1, maxZ: 2 },
+          intent: 'secondary-backstop',
+        }),
+      ],
+      options
+    );
+
+    expect(report.failures.map((failure) => failure.candidate.id)).toEqual([
+      'INNER',
+    ]);
+    expect(report.failures[0].classification).toBe('fully-contained');
+  });
+
+  it('warns on anonymous generated colliders by default', () => {
+    const report = evaluateColliderRedundancy(
+      [collider({ id: 'GEN', debugId: undefined, sourceId: undefined })],
+      options
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0].classification).toBe('anonymous-generated');
+  });
+
+  it('can opt in to failing anonymous generated colliders', () => {
+    const report = evaluateColliderRedundancy(
+      [collider({ id: 'GEN', debugId: undefined, sourceId: undefined })],
+      { ...options, failOnAnonymous: true }
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.failures[0].classification).toBe('anonymous-generated');
+  });
+
+  it('parses bounded CI runtime flags and formats actionable output', () => {
+    const parsed = parseColliderRedundancyGateArgs([
+      '--json',
+      '--max-nodes',
+      '3000',
+      '--timeout-ms',
+      '120000',
+      '--fail-on-anonymous',
+    ]);
+    expect(parsed).toMatchObject({
+      json: true,
+      maxNodes: 3000,
+      timeoutMs: 120000,
+      failOnAnonymous: true,
+    });
+
+    const output = formatColliderRedundancyGateReport(
+      evaluateColliderRedundancy(
+        [
+          collider({ id: 'A', sourceId: 'wall.shared' }),
+          collider({ id: 'B', sourceId: 'wall.shared' }),
+        ],
+        options
+      )
+    );
+    expect(output).toContain('candidate: A');
+    expect(output).toContain('classification: exact-duplicate');
+    expect(output).toContain('suggested remediation:');
+  });
+});

--- a/scripts/colliderRedundancyGate.ts
+++ b/scripts/colliderRedundancyGate.ts
@@ -1,0 +1,326 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { floorsCanOverlap, formatOptional } from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+import {
+  containsRectangle,
+  rectangleArea,
+  rectanglesEqual,
+} from './rectangleGeometry';
+
+export type ColliderRedundancyGateOptions = {
+  json: boolean;
+  tolerance: number;
+  timeoutMs: number;
+  maxNodes: number;
+  failOnAnonymous: boolean;
+};
+
+export type ColliderRedundancyClassification =
+  | 'exact-duplicate'
+  | 'fully-contained'
+  | 'anonymous-generated';
+
+export type ColliderRedundancyDiagnostic = {
+  severity: 'failure' | 'warning';
+  classification: ColliderRedundancyClassification;
+  candidate: RuntimeColliderMetadata;
+  evidence: Array<{
+    collider: RuntimeColliderMetadata;
+    reason: string;
+  }>;
+  message: string;
+  remediation: string;
+};
+
+export type ColliderRedundancyGateReport = {
+  ok: boolean;
+  limits: {
+    tolerance: number;
+    timeoutMs: number;
+    maxNodes: number;
+    failOnAnonymous: boolean;
+    inspectedColliders: number;
+    truncated: boolean;
+  };
+  failures: ColliderRedundancyDiagnostic[];
+  warnings: ColliderRedundancyDiagnostic[];
+  note: string;
+};
+
+const NOTE =
+  'Conservative CI gate: ambiguous, isolated, anonymous, and source-less cases warn only unless explicitly configured otherwise.';
+const MAX_FORMATTED_WARNINGS = 12;
+
+const INTENTIONAL_INTENTS = new Set([
+  'secondary-backstop',
+  'visual-only-by-policy',
+  'physical-boundary',
+]);
+
+const hasSource = (collider: Pick<RuntimeColliderMetadata, 'sourceId'>) =>
+  typeof collider.sourceId === 'string' && collider.sourceId.length > 0;
+
+const isGeneratedOrAnonymous = (collider: RuntimeColliderMetadata): boolean =>
+  !hasSource(collider) || !collider.debugId || collider.debugId !== collider.id;
+
+const isIntentionalException = (collider: RuntimeColliderMetadata): boolean =>
+  Boolean(collider.intent && INTENTIONAL_INTENTS.has(collider.intent));
+
+const sameHighConfidenceReviewGroup = (
+  candidate: RuntimeColliderMetadata,
+  other: RuntimeColliderMetadata
+): boolean =>
+  candidate.id !== other.id &&
+  floorsCanOverlap(candidate.floor, other.floor) &&
+  candidate.category === other.category &&
+  hasSource(candidate) &&
+  hasSource(other) &&
+  !isIntentionalException(candidate) &&
+  !isIntentionalException(other);
+
+const sameSourceSemantics = (
+  candidate: RuntimeColliderMetadata,
+  other: RuntimeColliderMetadata
+): boolean =>
+  candidate.floor === other.floor &&
+  candidate.category === other.category &&
+  candidate.sourceId === other.sourceId;
+
+const byCandidateId = (
+  left: ColliderRedundancyDiagnostic,
+  right: ColliderRedundancyDiagnostic
+) =>
+  left.candidate.id.localeCompare(right.candidate.id) ||
+  left.classification.localeCompare(right.classification);
+
+const makeDuplicateDiagnostic = (
+  candidate: RuntimeColliderMetadata,
+  duplicates: RuntimeColliderMetadata[]
+): ColliderRedundancyDiagnostic => ({
+  severity: 'failure',
+  classification: 'exact-duplicate',
+  candidate,
+  evidence: duplicates.map((collider) => ({
+    collider,
+    reason: 'same source-backed floor/category/sourceId and equivalent bounds',
+  })),
+  message: `Collider ${candidate.id} duplicates another active source-backed collider.`,
+  remediation:
+    'Remove the duplicate collider, or mark one source as an intentional secondary/backstop policy if it really needs to remain.',
+});
+
+const makeContainedDiagnostic = (
+  candidate: RuntimeColliderMetadata,
+  containers: RuntimeColliderMetadata[]
+): ColliderRedundancyDiagnostic => ({
+  severity: 'failure',
+  classification: 'fully-contained',
+  candidate,
+  evidence: containers.map((collider) => ({
+    collider,
+    reason:
+      'candidate bounds are fully contained by this source-backed collider',
+  })),
+  message: `Collider ${candidate.id} is fully contained by source-backed collider evidence.`,
+  remediation:
+    'Remove the contained collider, or mark it with intentional secondary/backstop source metadata if it is load-bearing by design.',
+});
+
+const makeAnonymousDiagnostic = (
+  collider: RuntimeColliderMetadata,
+  failOnAnonymous: boolean
+): ColliderRedundancyDiagnostic => ({
+  severity: failOnAnonymous ? 'failure' : 'warning',
+  classification: 'anonymous-generated',
+  candidate: collider,
+  evidence: [],
+  message: `Collider ${collider.id} is missing source provenance or uses a generated runtime ID.`,
+  remediation:
+    'Add stable sourceId/debugId metadata before using CI to make redundancy decisions about this collider.',
+});
+
+export const parseColliderRedundancyGateArgs = (
+  args: readonly string[]
+): ColliderRedundancyGateOptions => {
+  let json = false;
+  let tolerance = 0.05;
+  let timeoutMs = 120_000;
+  let maxNodes = 3_000;
+  let failOnAnonymous = false;
+  const readValue = (index: number, flag: string) => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') json = true;
+    else if (arg === '--fail-on-anonymous') failOnAnonymous = true;
+    else if (
+      arg === '--tolerance' ||
+      arg === '--timeout-ms' ||
+      arg === '--max-nodes'
+    ) {
+      const value = Number(readValue(index, arg));
+      if (!Number.isFinite(value) || value <= 0)
+        throw new Error(`${arg} must be positive.`);
+      if (arg === '--tolerance') tolerance = value;
+      if (arg === '--timeout-ms') timeoutMs = Math.floor(value);
+      if (arg === '--max-nodes') maxNodes = Math.floor(value);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { json, tolerance, timeoutMs, maxNodes, failOnAnonymous };
+};
+
+export const evaluateColliderRedundancy = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: ColliderRedundancyGateOptions
+): ColliderRedundancyGateReport => {
+  const inspected = colliders.slice(0, options.maxNodes);
+  const failures: ColliderRedundancyDiagnostic[] = [];
+  const warnings: ColliderRedundancyDiagnostic[] = [];
+
+  for (const candidate of inspected) {
+    if (isGeneratedOrAnonymous(candidate)) {
+      const diagnostic = makeAnonymousDiagnostic(
+        candidate,
+        options.failOnAnonymous
+      );
+      (diagnostic.severity === 'failure' ? failures : warnings).push(
+        diagnostic
+      );
+    }
+
+    const comparable = inspected.filter((other) =>
+      sameHighConfidenceReviewGroup(candidate, other)
+    );
+    const duplicates = comparable.filter(
+      (other) =>
+        candidate.id.localeCompare(other.id) < 0 &&
+        sameSourceSemantics(candidate, other) &&
+        rectanglesEqual(candidate.bounds, other.bounds, options.tolerance)
+    );
+    if (duplicates.length > 0)
+      failures.push(makeDuplicateDiagnostic(candidate, duplicates));
+
+    const containers = comparable.filter(
+      (other) =>
+        !sameSourceSemantics(candidate, other) &&
+        rectangleArea(other.bounds) > rectangleArea(candidate.bounds) &&
+        containsRectangle(other.bounds, candidate.bounds, options.tolerance)
+    );
+    if (containers.length > 0)
+      failures.push(makeContainedDiagnostic(candidate, containers));
+  }
+
+  failures.sort(byCandidateId);
+  warnings.sort(byCandidateId);
+  return {
+    ok: failures.length === 0,
+    limits: {
+      tolerance: options.tolerance,
+      timeoutMs: options.timeoutMs,
+      maxNodes: options.maxNodes,
+      failOnAnonymous: options.failOnAnonymous,
+      inspectedColliders: inspected.length,
+      truncated: colliders.length > inspected.length,
+    },
+    failures,
+    warnings,
+    note: NOTE,
+  };
+};
+
+const formatCollider = (collider: RuntimeColliderMetadata) =>
+  `${collider.id} ${collider.name} (sourceId: ${formatOptional(collider.sourceId)}, intent: ${formatOptional(collider.intent)})`;
+
+const formatDiagnostic = (diagnostic: ColliderRedundancyDiagnostic): string =>
+  [
+    `${diagnostic.severity.toUpperCase()}: ${diagnostic.classification}`,
+    `  candidate: ${formatCollider(diagnostic.candidate)}`,
+    `  classification: ${diagnostic.classification}`,
+    `  message: ${diagnostic.message}`,
+    '  evidence:',
+    diagnostic.evidence.length > 0
+      ? diagnostic.evidence
+          .map(
+            (item) => `    - ${formatCollider(item.collider)}; ${item.reason}`
+          )
+          .join('\n')
+      : '    - none',
+    `  suggested remediation: ${diagnostic.remediation}`,
+  ].join('\n');
+
+export const formatColliderRedundancyGateReport = (
+  report: ColliderRedundancyGateReport
+): string =>
+  [
+    report.ok
+      ? 'Collider redundancy gate passed.'
+      : 'Collider redundancy gate failed.',
+    `Inspected ${report.limits.inspectedColliders} collider(s) with tolerance ${report.limits.tolerance}, timeout ${report.limits.timeoutMs}ms, max nodes ${report.limits.maxNodes}.`,
+    report.limits.truncated
+      ? 'WARNING: Collider list was truncated by --max-nodes; increase the limit for full coverage.'
+      : undefined,
+    `Failures: ${report.failures.length}`,
+    report.failures.map(formatDiagnostic).join('\n\n'),
+    `Warnings: ${report.warnings.length}`,
+    report.warnings
+      .slice(0, MAX_FORMATTED_WARNINGS)
+      .map(formatDiagnostic)
+      .join('\n\n'),
+    report.warnings.length > MAX_FORMATTED_WARNINGS
+      ? `... ${report.warnings.length - MAX_FORMATTED_WARNINGS} additional warning(s) omitted from text output; rerun with --json for full diagnostics.`
+      : undefined,
+    `Note: ${report.note}`,
+  ]
+    .filter((part) => part !== undefined && part !== '')
+    .join('\n\n');
+
+export const runColliderRedundancyGateCli = async (args: readonly string[]) => {
+  const options = parseColliderRedundancyGateArgs(args);
+  let colliders: RuntimeColliderMetadata[];
+  try {
+    colliders = await collectRuntimeColliders({ timeoutMs: options.timeoutMs });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to inspect runtime colliders within ${options.timeoutMs}ms: ${message}`
+    );
+  }
+  const report = evaluateColliderRedundancy(colliders, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : `${formatColliderRedundancyGateReport(report)}\n`
+  );
+  if (!report.ok) process.exitCode = 1;
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderRedundancyGateCli(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a PR-safe, conservative CI gate that detects only high-confidence redundant colliders (to prompt removal or justification) while avoiding flaky failures on ambiguous cases.
- Reuse existing runtime collectors and audits and keep the gate actionable and opt-in for stricter behaviors (anonymous failures).

### Description
- Add a new CLI script `scripts/colliderRedundancyGate.ts` and package script `collider:audit:redundancy` that reuses `colliderRuntimeCollector` and geometry helpers to detect high-confidence redundancy (exact duplicate and fully-contained source-backed colliders) and emit actionable diagnostics.
- Conservative default behavior: anonymous or source-less colliders produce warnings only, `--fail-on-anonymous` is available as an opt-in stricter flag, and intentional intents (e.g. `secondary-backstop`, `visual-only-by-policy`, `physical-boundary`) are excluded from failure rules.
- Output supports human-readable text and `--json` machine-readable diagnostics, and the CLI enforces bounded CI runtime parameters: `--timeout-ms`, `--max-nodes`, and a default Vite/Playwright-friendly profile.
- Add deterministic unit tests `scripts/__tests__/colliderRedundancyGate.test.ts` for duplication, containment, anonymous behavior, and CLI arg parsing.
- Document the gate and recommended commands in `docs/design/editing-level-data.md` and wire the stable gate into the main tests workflow (`.github/workflows/02-tests.yml`) behind a Playwright browser install step so the audit runs after unit/smoke tests.

### Testing
- `npm run test:ci -- scripts/__tests__/colliderRedundancyGate.test.ts` — passed (5 tests).
- `npx eslint scripts/colliderRedundancyGate.ts scripts/__tests__/colliderRedundancyGate.test.ts` — passed.
- `npm run collider:audit:redundancy -- --timeout-ms 120000` — executed; gate reported no failures and printed warnings for anonymous/generated colliders (warnings are expected and conservative by design).
- `npm run --silent collider:audit:redundancy -- --json --timeout-ms 120000` — executed and produced JSON report (`ok: true, failures: 0, warnings: 70`).
- Full repo checks: `npm run lint`, `npm run test:ci`, `npm run docs:check`, and `npm run smoke` — all passed in this environment (note: `docs:check` reported external link fetch warnings which are informational).
- `npm run typecheck` — failed due to pre-existing, repo-wide TypeScript errors unrelated to this change; the redundancy gate and its tests are type-correct and deterministic.

Note: The gate is purposely conservative and intended as an assistive CI guardrail; ambiguous/isolated/outside-navmesh cases are not auto-failed and require maintainer judgment or source-backup metadata before turning into hard CI errors. Follow-up: maintainers may opt into stricter flags or a source-backed policy later if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38edf4a8dc832fbfcb00f2992a9f39)