### PR TITLE
🛡️ : – Add collider redundancy gate

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -20,6 +20,10 @@ jobs:
         run: npm ci
       - name: Unit tests
         run: npm run test:ci
+      - name: Install Playwright browser for collider audits
+        run: npx playwright install --with-deps chromium-headless-shell
+      - name: Collider redundancy gate
+        run: npm run collider:audit:redundancy
       - name: Smoke test
         run: npm run smoke
 

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -153,6 +153,33 @@ tested approach samples. It is review evidence only: it does not scan every
 collider in CI, delete anything, persist snapshots, or replace screenshots and
 maintainer judgment when the result is ambiguous.
 
+## Conservative collider redundancy gate
+
+Run the CI-safe redundancy gate before merging collider-heavy changes:
+
+```bash
+npm run collider:audit:redundancy
+npm run collider:audit:redundancy -- --json
+npm run collider:audit:redundancy -- --max-nodes 3000 --timeout-ms 120000
+```
+
+The gate starts or reuses the local immersive runtime, collects active debug
+colliders, and scans a bounded number of records for high-confidence redundancy.
+It fails only when the finding is source-backed and actionable, such as exact
+duplicate active colliders with equivalent floor/category/source semantics or a
+source-backed collider fully contained by source-backed collider(s) in the same
+review group. Anonymous/generated colliders, isolated colliders, ambiguous edge
+adjacency, and runtime-only reachability uncertainty remain warnings or manual
+follow-up by default. Use `--fail-on-anonymous` only for an explicit stricter
+local audit; CI should not enable it unless the current source tree already
+passes.
+
+A failure names the candidate collider, source ID when available,
+classification, dominating colliders, evidence, and remediation: remove the
+duplicate, merge the source policy, mark an intentional secondary/backstop
+collider, or add missing source metadata. This gate is deliberately conservative
+and is not a substitute for maintainer judgment on ambiguous collision behavior.
+
 ## Lightweight collider removal workflow
 
 For a possible removal, keep the review centered on the active source policy:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
     "collider:inspect": "tsx scripts/colliderInspect.ts",
     "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
-    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts"
+    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts",
+    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderRedundancyGate.test.ts
+++ b/scripts/__tests__/colliderRedundancyGate.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateColliderRedundancy,
+  formatColliderRedundancyGateReport,
+  parseColliderRedundancyGateArgs,
+} from '../colliderRedundancyGate';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const collider = (
+  overrides: Partial<RuntimeColliderMetadata>
+): RuntimeColliderMetadata => ({
+  id: 'A',
+  debugId: 'A',
+  floor: 'ground',
+  category: 'wall',
+  name: 'Collider A',
+  sourceId: 'ground.wall.a',
+  sourceType: 'wall',
+  intent: 'physical-boundary',
+  role: 'guard',
+  purpose: 'blocks the room edge',
+  bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+  ...overrides,
+});
+
+const options = { tolerance: 0.05, maxNodes: 3000, failOnAnonymous: false };
+
+describe('parseColliderRedundancyGateArgs', () => {
+  it('parses CI bounds, JSON, base URL, and optional anonymous strictness', () => {
+    expect(
+      parseColliderRedundancyGateArgs([
+        '--json',
+        '--max-nodes',
+        '120',
+        '--timeout-ms',
+        '5000',
+        '--tolerance',
+        '0.01',
+        '--base-url',
+        'http://127.0.0.1:5173',
+        '--fail-on-anonymous',
+      ])
+    ).toEqual({
+      json: true,
+      maxNodes: 120,
+      timeoutMs: 5000,
+      tolerance: 0.01,
+      baseUrl: 'http://127.0.0.1:5173',
+      failOnAnonymous: true,
+    });
+  });
+});
+
+describe('evaluateColliderRedundancy', () => {
+  it('fails for exact duplicate source-backed active colliders', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({ id: 'A', debugId: 'A' }),
+        collider({ id: 'B', debugId: 'B' }),
+      ],
+      options
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.findings).toMatchObject([
+      {
+        severity: 'failure',
+        classification: 'exact-duplicate',
+        collider: { id: 'B' },
+      },
+    ]);
+  });
+
+  it('fails for source-backed colliders fully contained by a concrete collider', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({
+          id: 'OUTER',
+          debugId: 'OUTER',
+          sourceId: 'ground.wall.outer',
+        }),
+        collider({
+          id: 'INNER',
+          debugId: 'INNER',
+          sourceId: 'ground.wall.inner',
+          bounds: { minX: 1, maxX: 2, minZ: 1, maxZ: 2 },
+        }),
+      ],
+      options
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.findings).toMatchObject([
+      {
+        severity: 'failure',
+        classification: 'fully-contained',
+        collider: { id: 'INNER' },
+        dominatingColliders: [{ id: 'OUTER' }],
+      },
+    ]);
+  });
+
+  it('does not fail ambiguous adjacent, isolated, anonymous, source-backed generated, or intentional backstop cases', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({ id: 'A', debugId: 'A' }),
+        collider({
+          id: 'ADJ',
+          debugId: 'ADJ',
+          sourceId: 'ground.wall.adjacent',
+          bounds: { minX: 4.02, maxX: 5, minZ: 0, maxZ: 4 },
+        }),
+        collider({
+          id: 'ISO',
+          debugId: 'ISO',
+          sourceId: 'ground.wall.isolated',
+          bounds: { minX: 20, maxX: 21, minZ: 20, maxZ: 21 },
+        }),
+        collider({
+          id: 'ANON',
+          debugId: undefined,
+          sourceId: undefined,
+          bounds: { minX: 30, maxX: 31, minZ: 30, maxZ: 31 },
+        }),
+        collider({
+          id: 'GEN',
+          debugId: undefined,
+          sourceId: 'ground.wall.generated',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+        }),
+        collider({
+          id: 'BACKSTOP',
+          debugId: 'BACKSTOP',
+          sourceId: 'ground.wall.backstop',
+          intent: 'secondary-backstop',
+          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+        }),
+      ],
+      options
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.findings).toMatchObject([
+      {
+        severity: 'warning',
+        classification: 'anonymous-generated',
+        collider: { id: 'ANON' },
+      },
+      {
+        severity: 'warning',
+        classification: 'anonymous-generated',
+        collider: { id: 'GEN' },
+      },
+    ]);
+  });
+
+  it('can opt in to failing anonymous generated colliders', () => {
+    const report = evaluateColliderRedundancy(
+      [collider({ id: 'ANON', debugId: undefined, sourceId: undefined })],
+      { ...options, failOnAnonymous: true }
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.findings[0]).toMatchObject({
+      severity: 'failure',
+      classification: 'anonymous-generated',
+    });
+  });
+
+  it('formats actionable remediation fields', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({ id: 'A', debugId: 'A' }),
+        collider({ id: 'B', debugId: 'B' }),
+      ],
+      options
+    );
+    const output = formatColliderRedundancyGateReport(report);
+
+    expect(output).toContain('Collider redundancy gate failed');
+    expect(output).toContain('exact-duplicate: B Collider A');
+    expect(output).toContain('dominating colliders: A Collider A');
+    expect(output).toContain('remediation: Remove the duplicate collider');
+  });
+});

--- a/scripts/__tests__/colliderRedundancyGate.test.ts
+++ b/scripts/__tests__/colliderRedundancyGate.test.ts
@@ -50,6 +50,15 @@ describe('parseColliderRedundancyGateArgs', () => {
       failOnAnonymous: true,
     });
   });
+
+  it('rejects fractional CI bounds before they can floor to unsafe values', () => {
+    expect(() =>
+      parseColliderRedundancyGateArgs(['--max-nodes', '0.5'])
+    ).toThrow('--max-nodes must be a positive integer.');
+    expect(() =>
+      parseColliderRedundancyGateArgs(['--timeout-ms', '10.5'])
+    ).toThrow('--timeout-ms must be a positive integer.');
+  });
 });
 
 describe('evaluateColliderRedundancy', () => {
@@ -70,6 +79,35 @@ describe('evaluateColliderRedundancy', () => {
         collider: { id: 'B' },
       },
     ]);
+  });
+
+  it('does not treat distinct source policies as exact duplicates when semantics are omitted', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({
+          id: 'ENTRANCE',
+          debugId: 'ENTRANCE',
+          sourceId: 'policy.entrance',
+          sourceType: undefined,
+          intent: undefined,
+          role: undefined,
+          purpose: undefined,
+        }),
+        collider({
+          id: 'EXIT',
+          debugId: 'EXIT',
+          sourceId: 'policy.exit',
+          sourceType: undefined,
+          intent: undefined,
+          role: undefined,
+          purpose: undefined,
+        }),
+      ],
+      options
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.findings).toEqual([]);
   });
 
   it('fails for source-backed colliders fully contained by a concrete collider', () => {

--- a/scripts/colliderRedundancyGate.ts
+++ b/scripts/colliderRedundancyGate.ts
@@ -1,0 +1,292 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { floorsCanOverlap, formatOptional } from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+import { containsRectangle, rectanglesEqual } from './rectangleGeometry';
+
+export type ColliderRedundancyGateOptions = {
+  json: boolean;
+  tolerance: number;
+  maxNodes: number;
+  timeoutMs: number;
+  baseUrl?: string;
+  failOnAnonymous: boolean;
+};
+
+export type ColliderRedundancyFinding = {
+  severity: 'failure' | 'warning';
+  collider: RuntimeColliderMetadata;
+  classification: 'exact-duplicate' | 'fully-contained' | 'anonymous-generated';
+  evidence: string;
+  dominatingColliders: RuntimeColliderMetadata[];
+  remediation: string;
+};
+
+export type ColliderRedundancyGateReport = {
+  ok: boolean;
+  summary: {
+    inspectedColliders: number;
+    failures: number;
+    warnings: number;
+    maxNodes: number;
+    tolerance: number;
+  };
+  findings: ColliderRedundancyFinding[];
+};
+
+const INTENTIONAL_NON_REDUNDANT_INTENTS = new Set([
+  'secondary-backstop',
+  'visual-only-by-policy',
+]);
+
+const DEFAULT_OPTIONS: ColliderRedundancyGateOptions = {
+  json: false,
+  tolerance: 0.05,
+  maxNodes: 3_000,
+  timeoutMs: 120_000,
+  failOnAnonymous: false,
+};
+
+const readValue = (args: readonly string[], index: number, flag: string) => {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--'))
+    throw new Error(`${flag} requires a value.`);
+  return value;
+};
+
+export const parseColliderRedundancyGateArgs = (
+  args: readonly string[]
+): ColliderRedundancyGateOptions => {
+  const options = { ...DEFAULT_OPTIONS };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--fail-on-anonymous') {
+      options.failOnAnonymous = true;
+    } else if (
+      arg === '--tolerance' ||
+      arg === '--max-nodes' ||
+      arg === '--timeout-ms'
+    ) {
+      const value = Number(readValue(args, index, arg));
+      if (!Number.isFinite(value) || value <= 0)
+        throw new Error(`${arg} must be positive.`);
+      if (arg === '--tolerance') options.tolerance = value;
+      if (arg === '--max-nodes') options.maxNodes = Math.floor(value);
+      if (arg === '--timeout-ms') options.timeoutMs = Math.floor(value);
+      index += 1;
+    } else if (arg === '--base-url') {
+      options.baseUrl = readValue(args, index, arg);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+};
+
+const isSourceBacked = (collider: RuntimeColliderMetadata): boolean =>
+  typeof collider.sourceId === 'string' && collider.sourceId.length > 0;
+
+const hasExplicitRuntimeIdentity = (
+  collider: RuntimeColliderMetadata
+): boolean => collider.debugId === collider.id;
+
+const isConcreteSourceBacked = (collider: RuntimeColliderMetadata): boolean =>
+  isSourceBacked(collider) && hasExplicitRuntimeIdentity(collider);
+
+const isAnonymousGenerated = (collider: RuntimeColliderMetadata): boolean =>
+  !isSourceBacked(collider) || !hasExplicitRuntimeIdentity(collider);
+
+const isIntentionalException = (collider: RuntimeColliderMetadata): boolean =>
+  INTENTIONAL_NON_REDUNDANT_INTENTS.has(collider.intent ?? '');
+
+const sameReviewGroup = (
+  candidate: RuntimeColliderMetadata,
+  other: RuntimeColliderMetadata
+): boolean =>
+  candidate.id !== other.id &&
+  floorsCanOverlap(candidate.floor, other.floor) &&
+  candidate.category === other.category;
+
+const sameSourceSemantics = (
+  left: RuntimeColliderMetadata,
+  right: RuntimeColliderMetadata
+): boolean =>
+  left.sourceId === right.sourceId ||
+  (left.sourceType === right.sourceType &&
+    left.intent === right.intent &&
+    left.role === right.role &&
+    left.purpose === right.purpose);
+
+const byStableIdentity = (
+  left: RuntimeColliderMetadata,
+  right: RuntimeColliderMetadata
+): number =>
+  left.id.localeCompare(right.id) ||
+  left.name.localeCompare(right.name) ||
+  (left.sourceId ?? '').localeCompare(right.sourceId ?? '');
+
+export const evaluateColliderRedundancy = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: Pick<
+    ColliderRedundancyGateOptions,
+    'tolerance' | 'maxNodes' | 'failOnAnonymous'
+  >
+): ColliderRedundancyGateReport => {
+  const inspected = colliders.slice(0, options.maxNodes).sort(byStableIdentity);
+  const findings: ColliderRedundancyFinding[] = [];
+
+  for (const candidate of inspected) {
+    if (isAnonymousGenerated(candidate)) {
+      findings.push({
+        severity: options.failOnAnonymous ? 'failure' : 'warning',
+        collider: candidate,
+        classification: 'anonymous-generated',
+        evidence:
+          'Collider is missing source metadata or uses a generated runtime ID.',
+        dominatingColliders: [],
+        remediation:
+          'Add sourceId/debugId metadata so future audits can distinguish intentional colliders from generated runtime records.',
+      });
+    }
+
+    if (!isConcreteSourceBacked(candidate) || isIntentionalException(candidate))
+      continue;
+    const others = inspected.filter(
+      (other) =>
+        sameReviewGroup(candidate, other) &&
+        isConcreteSourceBacked(other) &&
+        !isIntentionalException(other)
+    );
+    const exactDuplicates = others.filter(
+      (other) =>
+        rectanglesEqual(candidate.bounds, other.bounds, options.tolerance) &&
+        sameSourceSemantics(candidate, other)
+    );
+    const canonical = [candidate, ...exactDuplicates].sort(byStableIdentity)[0];
+    if (exactDuplicates.length > 0 && canonical.id !== candidate.id) {
+      findings.push({
+        severity: 'failure',
+        collider: candidate,
+        classification: 'exact-duplicate',
+        evidence:
+          'Active explicit source-backed collider has equivalent floor/category/source semantics and identical bounds to another explicit active collider.',
+        dominatingColliders: exactDuplicates,
+        remediation:
+          'Remove the duplicate collider, merge the source policy, or mark an intentional secondary/backstop collider with explicit metadata.',
+      });
+      continue;
+    }
+
+    const containers = others.filter(
+      (other) =>
+        !rectanglesEqual(candidate.bounds, other.bounds, options.tolerance) &&
+        containsRectangle(other.bounds, candidate.bounds, options.tolerance)
+    );
+    if (containers.length > 0) {
+      findings.push({
+        severity: 'failure',
+        collider: candidate,
+        classification: 'fully-contained',
+        evidence:
+          'Active explicit source-backed collider is fully contained by explicit source-backed collider(s) in the same floor/category review group.',
+        dominatingColliders: containers,
+        remediation:
+          'Remove the contained collider, document why it is a secondary/backstop collider, or add missing source metadata to clarify intent.',
+      });
+    }
+  }
+
+  const failures = findings.filter(
+    (finding) => finding.severity === 'failure'
+  ).length;
+  const warnings = findings.length - failures;
+  return {
+    ok: failures === 0,
+    summary: {
+      inspectedColliders: inspected.length,
+      failures,
+      warnings,
+      maxNodes: options.maxNodes,
+      tolerance: options.tolerance,
+    },
+    findings,
+  };
+};
+
+const formatCollider = (collider: RuntimeColliderMetadata): string =>
+  `${collider.id} ${collider.name} (${formatOptional(collider.sourceId)})`;
+
+export const formatColliderRedundancyGateReport = (
+  report: ColliderRedundancyGateReport
+): string => {
+  const lines = [
+    report.ok
+      ? 'Collider redundancy gate passed.'
+      : 'Collider redundancy gate failed: high-confidence redundant colliders found.',
+    `Inspected ${report.summary.inspectedColliders}/${report.summary.maxNodes} colliders with tolerance ${report.summary.tolerance}.`,
+    `Failures: ${report.summary.failures}; warnings: ${report.summary.warnings}.`,
+  ];
+  if (report.findings.length === 0) return `${lines.join('\n')}\n`;
+  const textFindings = report.ok
+    ? report.findings.slice(0, 20)
+    : report.findings.filter((finding) => finding.severity === 'failure');
+  lines.push('', report.ok ? 'Warnings (first 20):' : 'Failures:');
+  for (const finding of textFindings) {
+    lines.push(
+      `- [${finding.severity}] ${finding.classification}: ${formatCollider(finding.collider)}`,
+      `  evidence: ${finding.evidence}`,
+      `  dominating colliders: ${finding.dominatingColliders.map(formatCollider).join('; ') || 'none'}`,
+      `  remediation: ${finding.remediation}`
+    );
+  }
+  if (report.ok && report.findings.length > textFindings.length) {
+    lines.push(
+      `- ${report.findings.length - textFindings.length} additional warning(s) omitted from text output; rerun with --json for complete diagnostics.`
+    );
+  }
+  return `${lines.join('\n')}\n`;
+};
+
+export const runColliderRedundancyGateCli = async (args: readonly string[]) => {
+  const options = parseColliderRedundancyGateArgs(args);
+  const colliders = await collectRuntimeColliders({
+    baseUrl: options.baseUrl,
+    timeoutMs: options.timeoutMs,
+  });
+  const report = evaluateColliderRedundancy(colliders, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : formatColliderRedundancyGateReport(report)
+  );
+  if (!report.ok) process.exitCode = 1;
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderRedundancyGateCli(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Unable to inspect runtime colliders: ${message}\n`);
+      process.stderr.write(
+        'Run with --timeout-ms to allow a slower local Vite startup, or --base-url to inspect an already-running preview.\n'
+      );
+      process.exitCode = 1;
+    }
+  );
+}

--- a/scripts/colliderRedundancyGate.ts
+++ b/scripts/colliderRedundancyGate.ts
@@ -59,6 +59,29 @@ const readValue = (args: readonly string[], index: number, flag: string) => {
   return value;
 };
 
+const parsePositiveNumber = (
+  args: readonly string[],
+  index: number,
+  flag: string
+) => {
+  const value = Number(readValue(args, index, flag));
+  if (!Number.isFinite(value) || value <= 0)
+    throw new Error(`${flag} must be positive.`);
+  return value;
+};
+
+const parsePositiveInteger = (
+  args: readonly string[],
+  index: number,
+  flag: string
+) => {
+  const rawValue = readValue(args, index, flag);
+  const value = Number(rawValue);
+  if (!Number.isInteger(value) || value < 1)
+    throw new Error(`${flag} must be a positive integer.`);
+  return value;
+};
+
 export const parseColliderRedundancyGateArgs = (
   args: readonly string[]
 ): ColliderRedundancyGateOptions => {
@@ -74,12 +97,15 @@ export const parseColliderRedundancyGateArgs = (
       arg === '--max-nodes' ||
       arg === '--timeout-ms'
     ) {
-      const value = Number(readValue(args, index, arg));
-      if (!Number.isFinite(value) || value <= 0)
-        throw new Error(`${arg} must be positive.`);
-      if (arg === '--tolerance') options.tolerance = value;
-      if (arg === '--max-nodes') options.maxNodes = Math.floor(value);
-      if (arg === '--timeout-ms') options.timeoutMs = Math.floor(value);
+      if (arg === '--tolerance') {
+        options.tolerance = parsePositiveNumber(args, index, arg);
+      }
+      if (arg === '--max-nodes') {
+        options.maxNodes = parsePositiveInteger(args, index, arg);
+      }
+      if (arg === '--timeout-ms') {
+        options.timeoutMs = parsePositiveInteger(args, index, arg);
+      }
       index += 1;
     } else if (arg === '--base-url') {
       options.baseUrl = readValue(args, index, arg);
@@ -118,12 +144,15 @@ const sameReviewGroup = (
 const sameSourceSemantics = (
   left: RuntimeColliderMetadata,
   right: RuntimeColliderMetadata
-): boolean =>
-  left.sourceId === right.sourceId ||
-  (left.sourceType === right.sourceType &&
+): boolean => {
+  if (left.sourceId && right.sourceId) return left.sourceId === right.sourceId;
+  return (
+    left.sourceType === right.sourceType &&
     left.intent === right.intent &&
     left.role === right.role &&
-    left.purpose === right.purpose);
+    left.purpose === right.purpose
+  );
+};
 
 const byStableIdentity = (
   left: RuntimeColliderMetadata,
@@ -257,10 +286,18 @@ export const formatColliderRedundancyGateReport = (
 
 export const runColliderRedundancyGateCli = async (args: readonly string[]) => {
   const options = parseColliderRedundancyGateArgs(args);
-  const colliders = await collectRuntimeColliders({
-    baseUrl: options.baseUrl,
-    timeoutMs: options.timeoutMs,
-  });
+  let colliders: RuntimeColliderMetadata[];
+  try {
+    colliders = await collectRuntimeColliders({
+      baseUrl: options.baseUrl,
+      timeoutMs: options.timeoutMs,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to inspect runtime colliders: ${message}`, {
+      cause: error,
+    });
+  }
   const report = evaluateColliderRedundancy(colliders, options);
   process.stdout.write(
     options.json
@@ -282,10 +319,12 @@ if (isDirectExecution()) {
   runColliderRedundancyGateCli(process.argv.slice(2)).catch(
     (error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
-      process.stderr.write(`Unable to inspect runtime colliders: ${message}\n`);
-      process.stderr.write(
-        'Run with --timeout-ms to allow a slower local Vite startup, or --base-url to inspect an already-running preview.\n'
-      );
+      process.stderr.write(`${message}\n`);
+      if (message.startsWith('Unable to inspect runtime colliders:')) {
+        process.stderr.write(
+          'Run with --timeout-ms to allow a slower local Vite startup, or --base-url to inspect an already-running preview.\n'
+        );
+      }
       process.exitCode = 1;
     }
   );


### PR DESCRIPTION
### Motivation
- Provide a conservative, PR-safe CI gate that detects only high-confidence redundant colliders so reviewers get actionable remediation without noisy, ambiguous failures.
- Reuse existing runtime collection/audit helpers and keep runtime/CI bounds (timeout, max nodes) to avoid flaky or expensive CI runs.

### Description
- Add `scripts/colliderRedundancyGate.ts`, a CLI that reuses `collectRuntimeColliders` and evaluates redundancy with a conservative policy (fails only on explicit source-backed `exact-duplicate` or `fully-contained` findings, warns on anonymous/generated or ambiguous cases).
- Expose CLI flags: `--json`, `--tolerance`, `--max-nodes`, `--timeout-ms`, `--base-url`, and `--fail-on-anonymous` (opt-in stricter behavior); add `npm run collider:audit:redundancy` to `package.json`.
- Add pure logic unit tests at `scripts/__tests__/colliderRedundancyGate.test.ts` covering duplicates, containment, anonymous/generated, isolated/adjacent, and intentional `secondary-backstop` exceptions.
- Document the gate in `docs/design/editing-level-data.md` and wire a stable CI invocation into the Tests workflow that first installs Playwright browsers (`npx playwright install --with-deps chromium-headless-shell`) then runs the redundancy audit.
- Text output is limited to the most relevant warnings/failures; full diagnostics are available via `--json` for machine-readable consumption.

### Testing
- Ran formatting and style checks: `npm run format:check` (ok) and `npm run lint` (ok).
- Ran unit and integration tests: `npm run test:ci` (all tests passed, including the new redundancy unit tests).
- Verified docs and build: `npm run docs:check` (ok) and `npm run smoke` (ok).
- Exercised the runtime audit locally in CI-like mode: `npm run collider:audit:redundancy -- --timeout-ms 120000` (ran Playwright installation when required, collected runtime colliders, reported warnings for anonymous/generated colliders but returned OK) and `npm run collider:audit:redundancy -- --json --timeout-ms 120000` (produced JSON report; `ok: true`).
- Notes and limits: `npm run typecheck` still reports pre-existing repository-wide TypeScript errors unrelated to this change; the gate itself is covered by deterministic unit tests and a bounded runtime smoke run, and CI now installs Playwright dependencies before invoking the audit.

Commands used during verification: `npm run format:write`, `npm run lint`, `npm run test:ci`, `npm run docs:check`, `npm run smoke`, `npx playwright install --with-deps chromium-headless-shell` (CI step), `npm run collider:audit:redundancy -- --timeout-ms 120000`, and `npm run collider:audit:redundancy -- --json --timeout-ms 120000`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38ee04e510832f9e8b71fbf0c0ba04)