### PR TITLE
Add conservative collider redundancy gate

### DIFF
--- a/.github/workflows/06-collider-redundancy.yml
+++ b/.github/workflows/06-collider-redundancy.yml
@@ -1,0 +1,24 @@
+name: Collider redundancy gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  collider-redundancy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium-headless-shell
+      - name: Run conservative collider redundancy gate
+        run: npm run collider:audit:redundancy -- --max-nodes 3000 --timeout-ms 120000

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -153,6 +153,34 @@ tested approach samples. It is review evidence only: it does not scan every
 collider in CI, delete anything, persist snapshots, or replace screenshots and
 maintainer judgment when the result is ambiguous.
 
+## Conservative collider redundancy CI gate
+
+Pull requests also run a conservative redundancy gate that reuses the runtime
+debug collider collector and inspects the local immersive scene without staging.
+The gate is intentionally narrower than the geometry and reachability audit
+tools: it fails only for high-confidence, actionable redundancy such as exact
+duplicate active source-backed colliders, or source-backed colliders fully
+contained by a different source-backed collider on a compatible floor/category.
+Compound colliders emitted by the same source, isolated colliders, ambiguous
+runtime evidence, outside-navmesh cases, and anonymous generated colliders are
+not hard failures by default. Anonymous colliders produce provenance warnings so
+maintainers can source-back them over time without making PR CI flaky.
+
+```bash
+npm run collider:audit:redundancy
+npm run collider:audit:redundancy -- --json
+npm run collider:audit:redundancy -- --max-nodes 3000 --timeout-ms 120000
+npm run collider:audit:redundancy -- --fail-on-anonymous
+```
+
+Failure output names the candidate collider, source ID when available,
+classification, dominating or duplicate collider evidence, and a suggested
+remediation: remove the redundant collider, add missing source metadata, or mark
+the collider with intentional secondary/backstop policy metadata. The gate is
+not a substitute for maintainer judgment on ambiguous collision behavior. Use
+the targeted geometry or reachability audits above when a warning needs deeper
+review.
+
 ## Lightweight collider removal workflow
 
 For a possible removal, keep the review centered on the active source policy:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
     "collider:inspect": "tsx scripts/colliderInspect.ts",
     "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
-    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts"
+    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts",
+    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderRedundancyGate.test.ts
+++ b/scripts/__tests__/colliderRedundancyGate.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateColliderRedundancy,
+  parseColliderRedundancyGateArgs,
+} from '../colliderRedundancyGate';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const collider = (
+  overrides: Partial<RuntimeColliderMetadata>
+): RuntimeColliderMetadata => ({
+  id: 'A',
+  floor: 'ground',
+  category: 'wall',
+  name: 'Wall',
+  sourceId: 'ground.wall.a',
+  bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+  ...overrides,
+});
+
+describe('parseColliderRedundancyGateArgs', () => {
+  it('parses ci bounds, json output, base URL, and strict provenance', () => {
+    expect(
+      parseColliderRedundancyGateArgs([
+        '--json',
+        '--max-nodes',
+        '3000',
+        '--timeout-ms',
+        '120000',
+        '--base-url',
+        'http://127.0.0.1:5173',
+        '--fail-on-anonymous',
+      ])
+    ).toEqual({
+      json: true,
+      tolerance: 0.05,
+      timeoutMs: 120000,
+      maxNodes: 3000,
+      baseUrl: 'http://127.0.0.1:5173',
+      failOnAnonymous: true,
+    });
+  });
+});
+
+describe('evaluateColliderRedundancy', () => {
+  const options = {
+    tolerance: 0.05,
+    maxNodes: 3000,
+    timeoutMs: 120000,
+    failOnAnonymous: false,
+  };
+
+  it('fails on exact duplicate source-backed colliders', () => {
+    const report = evaluateColliderRedundancy(
+      [collider({ id: 'A' }), collider({ id: 'B' })],
+      options
+    );
+
+    expect(report.passed).toBe(false);
+    expect(report.failures).toMatchObject([
+      { kind: 'exact-duplicate', candidate: { id: 'B' } },
+    ]);
+  });
+
+  it('fails on source-backed contained colliders dominated by a larger collider', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({ id: 'A', bounds: { minX: 0, maxX: 10, minZ: 0, maxZ: 10 } }),
+        collider({
+          id: 'B',
+          sourceId: 'ground.wall.b',
+          bounds: { minX: 2, maxX: 3, minZ: 2, maxZ: 3 },
+        }),
+      ],
+      options
+    );
+
+    expect(report.passed).toBe(false);
+    expect(report.failures).toMatchObject([
+      {
+        kind: 'fully-contained',
+        candidate: { id: 'B' },
+        evidence: [{ id: 'A' }],
+      },
+    ]);
+  });
+
+  it('warns but does not fail for anonymous colliders by default', () => {
+    const report = evaluateColliderRedundancy(
+      [collider({ id: 'anonymous', sourceId: undefined })],
+      options
+    );
+
+    expect(report.passed).toBe(true);
+    expect(report.warnings).toMatchObject([
+      { kind: 'anonymous-collider', candidate: { id: 'anonymous' } },
+    ]);
+  });
+
+  it('supports opt-in strict failures for anonymous colliders', () => {
+    const report = evaluateColliderRedundancy(
+      [collider({ id: 'anonymous', sourceId: undefined })],
+      { ...options, failOnAnonymous: true }
+    );
+
+    expect(report.passed).toBe(false);
+    expect(report.failures).toMatchObject([
+      { kind: 'anonymous-collider', candidate: { id: 'anonymous' } },
+    ]);
+  });
+
+  it('does not fail intentional secondary backstops', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({ id: 'A' }),
+        collider({
+          id: 'B',
+          sourceId: 'ground.wall.b',
+          intent: 'secondary-backstop',
+        }),
+      ],
+      options
+    );
+
+    expect(report.passed).toBe(true);
+  });
+
+  it('ignores duplicate geometry when source semantics differ', () => {
+    const report = evaluateColliderRedundancy(
+      [collider({ id: 'A' }), collider({ id: 'B', sourceId: 'ground.wall.b' })],
+      options
+    );
+
+    expect(
+      report.failures.filter((finding) => finding.kind === 'exact-duplicate')
+    ).toEqual([]);
+  });
+});

--- a/scripts/colliderRedundancyGate.ts
+++ b/scripts/colliderRedundancyGate.ts
@@ -1,0 +1,270 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { floorsCanOverlap, formatOptional } from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+import { containsRectangle, rectanglesEqual } from './rectangleGeometry';
+
+export type ColliderRedundancyGateOptions = {
+  json: boolean;
+  tolerance: number;
+  timeoutMs: number;
+  maxNodes: number;
+  baseUrl?: string;
+  failOnAnonymous: boolean;
+};
+
+export type ColliderRedundancyFindingKind =
+  | 'exact-duplicate'
+  | 'fully-contained';
+export type ColliderRedundancySeverity = 'failure' | 'warning';
+
+export type ColliderRedundancyFinding = {
+  severity: ColliderRedundancySeverity;
+  kind: ColliderRedundancyFindingKind | 'anonymous-collider';
+  candidate: RuntimeColliderMetadata;
+  evidence: RuntimeColliderMetadata[];
+  message: string;
+  remediation: string;
+};
+
+export type ColliderRedundancyGateReport = {
+  passed: boolean;
+  limits: {
+    tolerance: number;
+    timeoutMs: number;
+    maxNodes: number;
+    inspectedColliders: number;
+    failOnAnonymous: boolean;
+  };
+  failures: ColliderRedundancyFinding[];
+  warnings: ColliderRedundancyFinding[];
+};
+
+const INTENTIONAL_INTENTS = new Set([
+  'secondary-backstop',
+  'visual-only-by-policy',
+  'physical-boundary',
+]);
+
+export const parseColliderRedundancyGateArgs = (
+  args: readonly string[]
+): ColliderRedundancyGateOptions => {
+  let json = false;
+  let tolerance = 0.05;
+  let timeoutMs = 120_000;
+  let maxNodes = 3_000;
+  let baseUrl: string | undefined;
+  let failOnAnonymous = false;
+  const readValue = (index: number, flag: string) => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') json = true;
+    else if (arg === '--fail-on-anonymous') failOnAnonymous = true;
+    else if (arg === '--base-url') {
+      baseUrl = readValue(index, arg);
+      index += 1;
+    } else if (
+      arg === '--tolerance' ||
+      arg === '--timeout-ms' ||
+      arg === '--max-nodes'
+    ) {
+      const value = Number(readValue(index, arg));
+      if (!Number.isFinite(value) || value <= 0)
+        throw new Error(`${arg} must be positive.`);
+      if (arg === '--tolerance') tolerance = value;
+      if (arg === '--timeout-ms') timeoutMs = Math.floor(value);
+      if (arg === '--max-nodes') maxNodes = Math.floor(value);
+      index += 1;
+    } else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return { json, tolerance, timeoutMs, maxNodes, baseUrl, failOnAnonymous };
+};
+
+const sameReviewGroup = (
+  left: RuntimeColliderMetadata,
+  right: RuntimeColliderMetadata
+) =>
+  left.id !== right.id &&
+  floorsCanOverlap(left.floor, right.floor) &&
+  left.category === right.category;
+
+const hasSource = (collider: RuntimeColliderMetadata) =>
+  Boolean(collider.sourceId);
+
+const isIntentionalException = (collider: RuntimeColliderMetadata) =>
+  Boolean(collider.intent && INTENTIONAL_INTENTS.has(collider.intent));
+
+const byId = (left: RuntimeColliderMetadata, right: RuntimeColliderMetadata) =>
+  left.id.localeCompare(right.id);
+
+const summarize = (collider: RuntimeColliderMetadata) =>
+  `${collider.id} ${collider.name} (${formatOptional(collider.sourceId)})`;
+
+const exactDuplicateKey = (collider: RuntimeColliderMetadata) =>
+  [
+    collider.floor,
+    collider.category,
+    collider.sourceId ?? '',
+    collider.bounds.minX,
+    collider.bounds.maxX,
+    collider.bounds.minZ,
+    collider.bounds.maxZ,
+  ].join('|');
+
+export const evaluateColliderRedundancy = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: Pick<
+    ColliderRedundancyGateOptions,
+    'tolerance' | 'maxNodes' | 'timeoutMs' | 'failOnAnonymous'
+  >
+): ColliderRedundancyGateReport => {
+  const inspected = colliders.slice(0, options.maxNodes);
+  const findings: ColliderRedundancyFinding[] = [];
+  for (const collider of inspected) {
+    if (!hasSource(collider)) {
+      findings.push({
+        severity: options.failOnAnonymous ? 'failure' : 'warning',
+        kind: 'anonymous-collider',
+        candidate: collider,
+        evidence: [],
+        message:
+          'Active collider is missing source metadata, so redundancy cannot be proven safely.',
+        remediation:
+          'Add sourceId/purpose metadata or rerun with --fail-on-anonymous for strict provenance enforcement.',
+      });
+    }
+  }
+
+  const duplicateGroups = new Map<string, RuntimeColliderMetadata[]>();
+  for (const collider of inspected.filter(hasSource)) {
+    const key = exactDuplicateKey(collider);
+    duplicateGroups.set(key, [...(duplicateGroups.get(key) ?? []), collider]);
+  }
+  for (const group of duplicateGroups.values()) {
+    if (group.length < 2) continue;
+    const sorted = [...group].sort(byId);
+    const keeper = sorted[0];
+    for (const candidate of sorted.slice(1)) {
+      if (isIntentionalException(candidate)) continue;
+      findings.push({
+        severity: 'failure',
+        kind: 'exact-duplicate',
+        candidate,
+        evidence: [keeper],
+        message: `Exact duplicate of source-backed collider ${summarize(keeper)}.`,
+        remediation:
+          'Remove the duplicate collider or mark it with intentional secondary/backstop policy metadata.',
+      });
+    }
+  }
+
+  for (const candidate of inspected.filter(
+    (collider) => hasSource(collider) && !isIntentionalException(collider)
+  )) {
+    const dominators = inspected
+      .filter(
+        (other) =>
+          sameReviewGroup(candidate, other) &&
+          hasSource(other) &&
+          candidate.sourceId !== other.sourceId &&
+          rectanglesEqual(candidate.bounds, other.bounds, options.tolerance) ===
+            false &&
+          containsRectangle(other.bounds, candidate.bounds, options.tolerance)
+      )
+      .sort(byId);
+    if (dominators.length === 0) continue;
+    findings.push({
+      severity: 'failure',
+      kind: 'fully-contained',
+      candidate,
+      evidence: dominators,
+      message: `Fully contained by source-backed collider(s): ${dominators.map(summarize).join('; ')}.`,
+      remediation:
+        'Remove the contained collider, source-back a narrower purpose, or mark it as an intentional secondary/backstop.',
+    });
+  }
+
+  const failures = findings.filter((finding) => finding.severity === 'failure');
+  const warnings = findings.filter((finding) => finding.severity === 'warning');
+  return {
+    passed: failures.length === 0,
+    limits: {
+      tolerance: options.tolerance,
+      timeoutMs: options.timeoutMs,
+      maxNodes: options.maxNodes,
+      inspectedColliders: inspected.length,
+      failOnAnonymous: options.failOnAnonymous,
+    },
+    failures,
+    warnings,
+  };
+};
+
+const formatFinding = (finding: ColliderRedundancyFinding) =>
+  [
+    `- ${finding.severity.toUpperCase()} ${finding.kind}: ${finding.candidate.id} ${finding.candidate.name}`,
+    `  source ID: ${formatOptional(finding.candidate.sourceId)}`,
+    `  classification: ${finding.kind}`,
+    `  evidence: ${finding.evidence.length > 0 ? finding.evidence.map(summarize).join('; ') : finding.message}`,
+    `  remediation: ${finding.remediation}`,
+  ].join('\n');
+
+export const formatColliderRedundancyGateReport = (
+  report: ColliderRedundancyGateReport
+) =>
+  [
+    report.passed
+      ? 'Collider redundancy gate passed: no high-confidence redundant colliders found.'
+      : 'Collider redundancy gate failed: high-confidence redundant colliders found.',
+    `Inspected ${report.limits.inspectedColliders}/${report.limits.maxNodes} active colliders with tolerance ${report.limits.tolerance}.`,
+    report.failures.length > 0
+      ? '\nFailures:\n' + report.failures.map(formatFinding).join('\n')
+      : '\nFailures: none',
+    report.warnings.length > 0
+      ? '\nWarnings:\n' + report.warnings.map(formatFinding).join('\n')
+      : '\nWarnings: none',
+    '\nConservative policy: ambiguous, isolated, outside-navmesh, and anonymous provenance cases are warnings unless an explicit strict flag is enabled.',
+  ].join('\n');
+
+export const runColliderRedundancyGateCli = async (args: readonly string[]) => {
+  const options = parseColliderRedundancyGateArgs(args);
+  const colliders = await collectRuntimeColliders({
+    baseUrl: options.baseUrl,
+    timeoutMs: options.timeoutMs,
+  });
+  const report = evaluateColliderRedundancy(colliders, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : `${formatColliderRedundancyGateReport(report)}\n`
+  );
+  if (!report.passed) process.exitCode = 1;
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderRedundancyGateCli(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Unable to inspect runtime colliders: ${message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a PR-safe CI gate that detects only high-confidence redundant colliders so reviewers get actionable guidance before merge. 
- Be conservative: avoid failing on ambiguous/isolated/anonymous cases and require source-backed evidence for hard failures. 
- Reuse existing runtime collection and deterministic geometry/reachability helpers to avoid duplicating browser/runtime logic. 

### Description

- Add a new CLI script `scripts/colliderRedundancyGate.ts` that reuses `collectRuntimeColliders`, emits clear human-readable output and `--json`, and supports bounded CI options (`--max-nodes`, `--timeout-ms`, `--tolerance`, `--base-url`) plus opt-in `--fail-on-anonymous` strict mode. 
- Implement conservative failure rules: fail only for high-confidence `exact-duplicate` (source-backed and matching semantics) and `fully-contained` dominated-by-different-source cases, and warn for anonymous provenance by default. 
- Add deterministic unit tests `scripts/__tests__/colliderRedundancyGate.test.ts` covering arg parsing, exact-duplicate, fully-contained, anonymous warning/strict modes, intentional secondary backstops, and source-semantic differences. 
- Wire an npm script `collider:audit:redundancy`, add a PR-targeted workflow `.github/workflows/06-collider-redundancy.yml` that installs Playwright headless shell for runtime collection, and document the gate and remediation guidance in `docs/design/editing-level-data.md`.

### Testing

- Ran formatting and linters with `npm run format:write` (passed) and `npm run lint` (passed). 
- Ran the test suite with `npm run test:ci` and the new redundancy unit tests (`scripts/__tests__/colliderRedundancyGate.test.ts`); all ran and passed in this environment. 
- Exercised the runtime gate with `npm run collider:audit:redundancy` and `npm run collider:audit:redundancy -- --json` (Playwright browser install was required and performed via `npx playwright install --with-deps chromium-headless-shell` and `npx playwright install-deps`, after which the gate ran successfully and produced human-readable and JSON diagnostics). 
- Note: `npm run typecheck` failed due to pre-existing TypeScript errors elsewhere in the repository unrelated to this change; this gate and its tests are pure-logic / unit-tested and do not introduce the type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38ee0cd2c8832f9fcfef8bd4414ff0)