### PR TITLE
🧱 Add conservative collider redundancy gate

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -22,6 +22,8 @@ jobs:
         run: npm run test:ci
       - name: Smoke test
         run: npm run smoke
+      - name: Collider redundancy gate
+        run: npm run collider:audit:redundancy
 
   docker-runtime-smoke:
     runs-on: ubuntu-latest

--- a/docs/design/editing-level-data.md
+++ b/docs/design/editing-level-data.md
@@ -153,6 +153,39 @@ tested approach samples. It is review evidence only: it does not scan every
 collider in CI, delete anything, persist snapshots, or replace screenshots and
 maintainer judgment when the result is ambiguous.
 
+## Run the conservative redundancy gate
+
+For PR-safe regression coverage, run the full-scene redundancy gate. The gate
+launches or reuses the local immersive runtime with performance failover
+disabled, reads the active debug collider inventory, and fails only when it finds
+high-confidence redundant colliders: source-backed exact duplicates or smaller
+source-backed colliders fully contained by larger source-backed colliders on a
+compatible floor/category. It is conservative by design and is not a substitute
+for maintainer judgment on ambiguous collision behavior.
+
+```bash
+npm run collider:audit:redundancy
+npm run collider:audit:redundancy -- --json
+npm run collider:audit:redundancy -- --max-nodes 3000 --timeout-ms 120000
+```
+
+Ambiguous, isolated, outside-reachable-navmesh, source-less, and anonymous
+generated colliders do not fail by default. Anonymous/generated records produce
+warnings with provenance remediation instead, because missing metadata is a
+follow-up signal rather than proof that the collider is unnecessary. Use the
+opt-in stricter mode only when intentionally enforcing that migration locally:
+
+```bash
+npm run collider:audit:redundancy -- --fail-on-anonymous
+```
+
+Failure output names the candidate collider, source ID when available,
+classification, dominating or duplicate evidence, and a suggested remediation:
+remove the duplicate, source-back the collider, or mark an intentional
+secondary/backstop policy in source metadata. The default CI profile is bounded
+with `--timeout-ms` and `--max-nodes`, starts a local Vite runtime when no
+`PLAYWRIGHT_BASE_URL` is provided, and does not depend on staging.
+
 ## Lightweight collider removal workflow
 
 For a possible removal, keep the review centered on the active source policy:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "helm:cache:test": "node scripts/check-helm-github-metrics-cache.cjs",
     "collider:inspect": "tsx scripts/colliderInspect.ts",
     "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
-    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts"
+    "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts",
+    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/__tests__/colliderRedundancyGate.test.ts
+++ b/scripts/__tests__/colliderRedundancyGate.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateColliderRedundancy } from '../colliderRedundancyGate';
+import type { RuntimeColliderMetadata } from '../colliderRuntimeCollector';
+
+const collider = (
+  overrides: Partial<RuntimeColliderMetadata> = {}
+): RuntimeColliderMetadata => ({
+  id: '1000',
+  floor: 'ground',
+  category: 'wall',
+  name: 'Collider',
+  bounds: { minX: 0, maxX: 1, minZ: 0, maxZ: 1 },
+  sourceId: 'ground.test.collider',
+  debugId: overrides.id ?? '1000',
+  ...overrides,
+});
+
+const classifications = (colliders: RuntimeColliderMetadata[]) =>
+  evaluateColliderRedundancy(colliders, {
+    tolerance: 0.01,
+    failOnAnonymous: false,
+  }).map((finding) => [
+    finding.severity,
+    finding.classification,
+    finding.candidate.id,
+  ]);
+
+describe('evaluateColliderRedundancy', () => {
+  it('fails exact duplicate source-backed active colliders', () => {
+    expect(
+      classifications([
+        collider({ id: '1000', sourceId: 'ground.a' }),
+        collider({ id: '1001', name: 'Duplicate', sourceId: 'ground.b' }),
+      ])
+    ).toContainEqual(['failure', 'exact-duplicate', '1000']);
+  });
+
+  it('fails contained source-backed colliders dominated by larger source-backed colliders', () => {
+    expect(
+      classifications([
+        collider({ id: '1000', sourceId: 'ground.inner' }),
+        collider({
+          id: '1001',
+          name: 'Outer',
+          sourceId: 'ground.outer',
+          bounds: { minX: -1, maxX: 2, minZ: -1, maxZ: 2 },
+        }),
+      ])
+    ).toContainEqual(['failure', 'fully-contained-source-backed', '1000']);
+  });
+
+  it('does not fail contained colliders emitted by the same source object', () => {
+    expect(
+      classifications([
+        collider({ id: '1000', sourceId: 'ground.object.scene_object' }),
+        collider({
+          id: '1001',
+          name: 'Outer',
+          sourceId: 'ground.object.scene_object',
+          bounds: { minX: -1, maxX: 2, minZ: -1, maxZ: 2 },
+        }),
+      ])
+    ).toEqual([]);
+  });
+
+  it('does not fail source-less colliders by default', () => {
+    expect(
+      classifications([
+        collider({ id: '1000', sourceId: undefined }),
+        collider({ id: '1001', name: 'Duplicate', sourceId: 'ground.b' }),
+      ])
+    ).toEqual([['warning', 'anonymous-generated', '1000']]);
+  });
+
+  it('does not fail intentional secondary backstops', () => {
+    expect(
+      classifications([
+        collider({
+          id: '1000',
+          sourceId: 'ground.a',
+          intent: 'secondary-backstop',
+        }),
+        collider({ id: '1001', name: 'Duplicate', sourceId: 'ground.b' }),
+      ])
+    ).toEqual([]);
+  });
+
+  it('can opt in to failing anonymous generated colliders', () => {
+    const findings = evaluateColliderRedundancy(
+      [collider({ debugId: 'source-generated-0' })],
+      {
+        tolerance: 0.01,
+        failOnAnonymous: true,
+      }
+    );
+
+    expect(findings).toMatchObject([
+      {
+        severity: 'failure',
+        classification: 'anonymous-generated',
+        candidate: { id: '1000' },
+      },
+    ]);
+  });
+});

--- a/scripts/colliderRedundancyGate.ts
+++ b/scripts/colliderRedundancyGate.ts
@@ -1,0 +1,334 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { floorsCanOverlap, formatOptional } from './colliderInspect';
+import {
+  collectRuntimeColliders,
+  type RuntimeColliderMetadata,
+} from './colliderRuntimeCollector';
+import {
+  containsRectangle,
+  rectangleArea,
+  rectanglesEqual,
+} from './rectangleGeometry';
+
+export type ColliderRedundancyGateOptions = {
+  json: boolean;
+  tolerance: number;
+  timeoutMs: number;
+  maxNodes: number;
+  failOnAnonymous: boolean;
+  baseUrl?: string;
+};
+
+export type RedundancyClassification =
+  | 'exact-duplicate'
+  | 'fully-contained-source-backed'
+  | 'anonymous-generated';
+
+export type RedundancySeverity = 'failure' | 'warning';
+
+export type ColliderRedundancyFinding = {
+  severity: RedundancySeverity;
+  classification: RedundancyClassification;
+  candidate: RuntimeColliderMetadata;
+  evidence: Array<
+    Pick<
+      RuntimeColliderMetadata,
+      'id' | 'name' | 'sourceId' | 'intent' | 'role'
+    >
+  >;
+  message: string;
+  remediation: string;
+};
+
+export type ColliderRedundancyGateReport = {
+  status: 'passed' | 'failed';
+  totals: {
+    inspectedColliders: number;
+    failures: number;
+    warnings: number;
+  };
+  options: Omit<ColliderRedundancyGateOptions, 'json'>;
+  findings: ColliderRedundancyFinding[];
+};
+
+const INTENTIONAL_INTENTS = new Set([
+  'secondary-backstop',
+  'visual-only-by-policy',
+]);
+const INTENTIONAL_ROLES = new Set([
+  'secondary-backstop',
+  'visual-only-by-policy',
+]);
+const GENERIC_BLOCKERS = new Set(['groundCollider']);
+
+const hasSourceMetadata = (collider: RuntimeColliderMetadata): boolean =>
+  typeof collider.sourceId === 'string' && collider.sourceId.length > 0;
+
+const isGeneratedId = (collider: RuntimeColliderMetadata): boolean =>
+  collider.debugId !== undefined && collider.debugId !== collider.id;
+
+const isIntentionalException = (collider: RuntimeColliderMetadata): boolean =>
+  INTENTIONAL_INTENTS.has(collider.intent ?? '') ||
+  INTENTIONAL_ROLES.has(collider.role ?? '');
+
+const samePolicyGroup = (
+  left: RuntimeColliderMetadata,
+  right: RuntimeColliderMetadata
+): boolean =>
+  left.id !== right.id &&
+  floorsCanOverlap(left.floor, right.floor) &&
+  left.category === right.category;
+
+const stableColliderKey = (collider: RuntimeColliderMetadata): string =>
+  [collider.id, collider.sourceId ?? '', collider.name].join('\0');
+
+const toEvidence = (collider: RuntimeColliderMetadata) => ({
+  id: collider.id,
+  name: collider.name,
+  sourceId: collider.sourceId,
+  intent: collider.intent,
+  role: collider.role,
+});
+
+const findExactDuplicateFailures = (
+  colliders: readonly RuntimeColliderMetadata[],
+  tolerance: number
+): ColliderRedundancyFinding[] => {
+  const findings: ColliderRedundancyFinding[] = [];
+  const sorted = [...colliders].sort((left, right) =>
+    stableColliderKey(left).localeCompare(stableColliderKey(right))
+  );
+
+  for (let index = 0; index < sorted.length; index += 1) {
+    const candidate = sorted[index];
+    if (!hasSourceMetadata(candidate) || isIntentionalException(candidate))
+      continue;
+    const duplicates = sorted.filter(
+      (other) =>
+        stableColliderKey(other) > stableColliderKey(candidate) &&
+        samePolicyGroup(candidate, other) &&
+        hasSourceMetadata(other) &&
+        !isIntentionalException(other) &&
+        rectanglesEqual(candidate.bounds, other.bounds, tolerance)
+    );
+    if (duplicates.length === 0) continue;
+    findings.push({
+      severity: 'failure',
+      classification: 'exact-duplicate',
+      candidate,
+      evidence: duplicates.map(toEvidence),
+      message:
+        'Active source-backed collider has exact duplicate bounds on the same floor/category.',
+      remediation:
+        'Remove the duplicate collider or mark the intentional secondary/backstop policy in source metadata.',
+    });
+  }
+  return findings;
+};
+
+const findContainedFailures = (
+  colliders: readonly RuntimeColliderMetadata[],
+  tolerance: number
+): ColliderRedundancyFinding[] =>
+  colliders.flatMap((candidate) => {
+    if (!hasSourceMetadata(candidate) || isIntentionalException(candidate))
+      return [];
+    const candidateArea = rectangleArea(candidate.bounds);
+    if (candidateArea <= 0) return [];
+    const dominators = colliders.filter(
+      (other) =>
+        samePolicyGroup(candidate, other) &&
+        hasSourceMetadata(other) &&
+        other.sourceId !== candidate.sourceId &&
+        !isIntentionalException(other) &&
+        !GENERIC_BLOCKERS.has(other.id) &&
+        rectangleArea(other.bounds) > candidateArea + tolerance &&
+        containsRectangle(other.bounds, candidate.bounds, tolerance)
+    );
+    if (dominators.length === 0) return [];
+    return [
+      {
+        severity: 'failure' as const,
+        classification: 'fully-contained-source-backed' as const,
+        candidate,
+        evidence: dominators.map(toEvidence),
+        message:
+          'Source-backed collider is fully contained by larger source-backed collider(s).',
+        remediation:
+          'Remove the contained collider, add missing source metadata to explain it, or mark it as an intentional secondary/backstop policy.',
+      },
+    ];
+  });
+
+const findAnonymousWarnings = (
+  colliders: readonly RuntimeColliderMetadata[],
+  failOnAnonymous: boolean
+): ColliderRedundancyFinding[] =>
+  colliders
+    .filter(
+      (collider) => !hasSourceMetadata(collider) || isGeneratedId(collider)
+    )
+    .map((candidate) => ({
+      severity: failOnAnonymous ? ('failure' as const) : ('warning' as const),
+      classification: 'anonymous-generated' as const,
+      candidate,
+      evidence: [],
+      message:
+        'Collider is anonymous or uses a generated runtime ID, so redundancy is not high-confidence.',
+      remediation:
+        'Add sourceId/debugId provenance, or rerun with --fail-on-anonymous when enforcing a stricter migration.',
+    }));
+
+export const evaluateColliderRedundancy = (
+  colliders: readonly RuntimeColliderMetadata[],
+  options: Pick<ColliderRedundancyGateOptions, 'tolerance' | 'failOnAnonymous'>
+): ColliderRedundancyFinding[] => [
+  ...findExactDuplicateFailures(colliders, options.tolerance),
+  ...findContainedFailures(colliders, options.tolerance),
+  ...findAnonymousWarnings(colliders, options.failOnAnonymous),
+];
+
+export const parseColliderRedundancyGateArgs = (
+  args: readonly string[]
+): ColliderRedundancyGateOptions => {
+  let json = false;
+  let tolerance = 0.01;
+  let timeoutMs = 120_000;
+  let maxNodes = 3_000;
+  let failOnAnonymous = false;
+  let baseUrl: string | undefined;
+  const readValue = (index: number, flag: string) => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--'))
+      throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') json = true;
+    else if (arg === '--fail-on-anonymous') failOnAnonymous = true;
+    else if (arg === '--base-url') {
+      baseUrl = readValue(index, arg);
+      index += 1;
+    } else if (
+      arg === '--tolerance' ||
+      arg === '--timeout-ms' ||
+      arg === '--max-nodes'
+    ) {
+      const value = Number(readValue(index, arg));
+      if (!Number.isFinite(value) || value <= 0)
+        throw new Error(`${arg} must be positive.`);
+      if (arg === '--tolerance') tolerance = value;
+      if (arg === '--timeout-ms') timeoutMs = Math.floor(value);
+      if (arg === '--max-nodes') maxNodes = Math.floor(value);
+      index += 1;
+    } else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return { json, tolerance, timeoutMs, maxNodes, failOnAnonymous, baseUrl };
+};
+
+const buildReport = (
+  colliders: readonly RuntimeColliderMetadata[],
+  findings: readonly ColliderRedundancyFinding[],
+  options: ColliderRedundancyGateOptions
+): ColliderRedundancyGateReport => {
+  const failures = findings.filter(
+    (finding) => finding.severity === 'failure'
+  ).length;
+  const warnings = findings.filter(
+    (finding) => finding.severity === 'warning'
+  ).length;
+  return {
+    status: failures > 0 ? 'failed' : 'passed',
+    totals: { inspectedColliders: colliders.length, failures, warnings },
+    options: {
+      tolerance: options.tolerance,
+      timeoutMs: options.timeoutMs,
+      maxNodes: options.maxNodes,
+      failOnAnonymous: options.failOnAnonymous,
+      baseUrl: options.baseUrl,
+    },
+    findings: [...findings],
+  };
+};
+
+const formatFinding = (finding: ColliderRedundancyFinding): string =>
+  [
+    `${finding.severity === 'failure' ? 'FAIL' : 'WARN'} ${finding.candidate.id} ${finding.candidate.name}`,
+    `  source ID: ${formatOptional(finding.candidate.sourceId)}`,
+    `  classification: ${finding.classification}`,
+    `  evidence: ${
+      finding.evidence.length > 0
+        ? finding.evidence
+            .map(
+              (item) =>
+                `${item.id} ${item.name} (${formatOptional(item.sourceId)})`
+            )
+            .join('; ')
+        : 'none'
+    }`,
+    `  message: ${finding.message}`,
+    `  remediation: ${finding.remediation}`,
+  ].join('\n');
+
+export const formatColliderRedundancyGateReport = (
+  report: ColliderRedundancyGateReport
+): string =>
+  [
+    `Collider redundancy gate ${report.status.toUpperCase()}`,
+    `Inspected ${report.totals.inspectedColliders} colliders; failures ${report.totals.failures}; warnings ${report.totals.warnings}.`,
+    'Conservative policy: ambiguous, isolated, outside-navmesh, anonymous, or source-less colliders are warnings only unless --fail-on-anonymous is set.',
+    report.findings.length > 0
+      ? report.findings.map(formatFinding).join('\n\n')
+      : 'No high-confidence redundant colliders found.',
+  ].join('\n');
+
+export const runColliderRedundancyGateCli = async (args: readonly string[]) => {
+  const options = parseColliderRedundancyGateArgs(args);
+  let colliders: RuntimeColliderMetadata[];
+  try {
+    colliders = await collectRuntimeColliders({
+      baseUrl: options.baseUrl,
+      timeoutMs: options.timeoutMs,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to inspect runtime colliders within ${options.timeoutMs}ms: ${message}`
+    );
+  }
+  if (colliders.length > options.maxNodes) {
+    throw new Error(
+      `Runtime returned ${colliders.length} colliders, exceeding --max-nodes ${options.maxNodes}. Increase the bound intentionally if needed.`
+    );
+  }
+  const findings = evaluateColliderRedundancy(colliders, options);
+  const report = buildReport(colliders, findings, options);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : `${formatColliderRedundancyGateReport(report)}\n`
+  );
+  if (report.status === 'failed') process.exitCode = 1;
+};
+
+const isDirectExecution = () => {
+  const invokedPath = process.argv[1];
+  return Boolean(
+    invokedPath &&
+      path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))
+  );
+};
+
+if (isDirectExecution()) {
+  runColliderRedundancyGateCli(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a PR-safe CI check that detects only high-confidence redundant runtime colliders so reviewers can remove or justify extraneous colliders before merge.
- Be conservative: ambiguous, isolated, anonymous, or source-less colliders should not cause hard failures; they produce warnings or require opt-in strict mode.

### Description

- Add `scripts/colliderRedundancyGate.ts`, a CI-friendly redundancy gate that reuses `collectRuntimeColliders` and geometry helpers and supports `--json`, `--timeout-ms`, `--max-nodes`, `--base-url`, `--tolerance`, and opt-in `--fail-on-anonymous` strict mode.
- Decision rules fail only on high-confidence cases: `exact-duplicate` source-backed colliders and `fully-contained` candidates dominated by other source-backed colliders from a different `sourceId`; intentional exceptions (`secondary-backstop`, `visual-only-by-policy`) are ignored.
- Anonymous or source-less colliders produce warnings by default (or failures only when `--fail-on-anonymous` is supplied); evidence and actionable remediation text (candidate id, sourceId/name, classification, evidence, remediation suggestions) are emitted.
- Add deterministic unit tests at `scripts/__tests__/colliderRedundancyGate.test.ts` for duplicate, containment, same-source exemptions, anonymous warnings, intentional-exception behavior, and opt-in anonymous failure.
- Add `collider:audit:redundancy` npm script, document usage in `docs/design/editing-level-data.md`, and wire the stable gate into the existing `Tests` workflow (`.github/workflows/02-tests.yml`) after the smoke step.

### Testing

- `npm run lint` — passed.
- `npm run test:ci` — full test suite `vitest` ran and passed (166 files, 1269 tests reported in transcript); added unit tests passed (`scripts/__tests__/colliderRedundancyGate.test.ts`).
- `npm run docs:check` / `npm run links:check` — passed (link checker returned external fetch warnings but completed successfully).
- `npm run smoke` — passed (build + `assert-dist`).
- `npm run collider:audit:redundancy` — executed in CI-like environment: gate reported `PASSED` for current repo state, inspected 78 colliders, `failures: 0`, `warnings: 24` and printed actionable diagnostics; `npm run collider:audit:redundancy -- --json` produced a machine-readable report (JSON) with the same results.
- `npm run typecheck` — not completed for this change because `tsc --noEmit` fails on pre-existing repository TypeScript issues unrelated to the new files; this gate is implemented as standalone scripts and types are limited to the script surface to avoid widening repo type changes.

Note: secrets scan (`git diff --cached | ./scripts/scan-secrets.py`) was run and reported no high-risk secrets. The gate is conservative by design and was only wired into the Tests workflow after confirming it passes against the current runtime state; maintainers should review any failure findings and either remove, source-back, or mark intentional colliders as appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38ee14fa9c832f967c1b1e296023e9)