### PR TITLE
Source-back generated wall collider debug IDs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,7 @@ import {
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
 import { assertDebugColliderId } from './scene/debug/colliderDebugIds';
+import { getSourceBackedWallColliderIdentity } from './scene/debug/colliderSourceIdentities';
 import {
   createColliderVisualizer,
   type DebugColliderMetadata,
@@ -1038,23 +1039,6 @@ const SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId(
 );
 const SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A');
 
-const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
-  `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-
-const getUpperWallSegmentDebugName = (
-  instance: WallSegmentInstance
-): string => {
-  const { segment } = instance;
-  const start = formatUpperWallDebugPoint(segment.start);
-  const end = formatUpperWallDebugPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-
-  return `UpperWallSegment:${segment.orientation}|${start}|${end}|${rooms || 'none'}`;
-};
-
 const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
 let backyardEnvironment: BackyardEnvironmentBuild | null = null;
@@ -1970,10 +1954,13 @@ function initializeImmersiveScene(
   });
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
+    const identity = getSourceBackedWallColliderIdentity('ground', instance);
     groundColliders.push(instance.collider);
+    namedColliderDebugNames.set(instance.collider, identity.name);
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,
       sourceType: 'wall',
+      debugId: identity.debugId,
     });
   });
 
@@ -2351,14 +2338,13 @@ function initializeImmersiveScene(
   });
   upperFloorGroup.add(upperWallMeshes.group);
   upperWallInstances.forEach((instance) => {
+    const identity = getSourceBackedWallColliderIdentity('upper', instance);
     upperFloorColliders.push(instance.collider);
-    namedColliderDebugNames.set(
-      instance.collider,
-      getUpperWallSegmentDebugName(instance)
-    );
+    namedColliderDebugNames.set(instance.collider, identity.name);
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,
       sourceType: 'wall',
+      debugId: identity.debugId,
     });
   });
 

--- a/src/scene/debug/__tests__/colliderSourceIdentities.test.ts
+++ b/src/scene/debug/__tests__/colliderSourceIdentities.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSourceBackedWallColliderIdentity } from '../colliderSourceIdentities';
+
+const wallInstance = {
+  sourceId: 'ground.living_room.north_wall' as const,
+  segmentId: 'horizontal|-10.000,10.000|10.000,10.000|livingRoom:north',
+  isFence: false,
+};
+
+describe('getSourceBackedWallColliderIdentity', () => {
+  it('derives deterministic ground wall names and explicit debug IDs from source metadata', () => {
+    const identity = getSourceBackedWallColliderIdentity(
+      'ground',
+      wallInstance
+    );
+
+    expect(identity).toEqual(
+      getSourceBackedWallColliderIdentity('ground', wallInstance)
+    );
+    expect(identity.name).toBe(
+      'GroundWallCollider:ground.living_room.north_wall:horizontal|-10.000,10.000|10.000,10.000|livingRoom:north'
+    );
+    expect(identity.debugId).toMatch(/^[0-9A-F]{6}$/);
+  });
+
+  it('keeps fence and upper wall identities source-backed without generated labels', () => {
+    expect(
+      getSourceBackedWallColliderIdentity('ground', {
+        ...wallInstance,
+        sourceId: 'ground.backyard.north_fence' as const,
+        isFence: true,
+      }).name
+    ).toMatch(/^GroundFenceCollider:ground\.backyard\.north_fence:/);
+
+    expect(
+      getSourceBackedWallColliderIdentity('upper', wallInstance).name
+    ).toMatch(/^UpperWallCollider:ground\.living_room\.north_wall:/);
+  });
+
+  it('uses segment IDs to distinguish split colliders with the same source ID', () => {
+    const first = getSourceBackedWallColliderIdentity('ground', wallInstance);
+    const second = getSourceBackedWallColliderIdentity('ground', {
+      ...wallInstance,
+      segmentId: 'horizontal|-20.000,10.000|-10.000,10.000|livingRoom:north',
+    });
+
+    expect(second.name).not.toBe(first.name);
+    expect(second.debugId).not.toBe(first.debugId);
+  });
+});

--- a/src/scene/debug/colliderSourceIdentities.ts
+++ b/src/scene/debug/colliderSourceIdentities.ts
@@ -1,0 +1,32 @@
+import type { WallSegmentInstance } from '../../assets/floorPlan/wallSegments';
+
+import { getDebugHash } from './debugIds';
+
+export type SourceBackedWallColliderFloor = 'ground' | 'upper';
+
+export interface SourceBackedWallColliderIdentity {
+  name: string;
+  debugId: string;
+}
+
+const formatWallColliderNamePrefix = (
+  floor: SourceBackedWallColliderFloor,
+  isFence: boolean
+): string => {
+  if (floor === 'upper') return 'UpperWallCollider';
+  return isFence ? 'GroundFenceCollider' : 'GroundWallCollider';
+};
+
+export const getSourceBackedWallColliderIdentity = (
+  floor: SourceBackedWallColliderFloor,
+  instance: Pick<WallSegmentInstance, 'sourceId' | 'segmentId' | 'isFence'>
+): SourceBackedWallColliderIdentity => {
+  const prefix = formatWallColliderNamePrefix(floor, instance.isFence);
+  const sourceKey = `${instance.sourceId}:${instance.segmentId}`;
+  const name = `${prefix}:${sourceKey}`;
+
+  return {
+    name,
+    debugId: getDebugHash(name),
+  };
+};


### PR DESCRIPTION
### Motivation
- Reduce the number of `anonymous-generated` findings from the redundancy audit for generated wall/fence colliders that already have durable `sourceId` provenance while preserving all runtime geometry and behavior. 
- Provide stable, human-readable debug identities for source-backed wall colliders so audits and debugging can deterministically reference those colliders instead of ephemeral runtime labels. 

### Description
- Add `src/scene/debug/colliderSourceIdentities.ts` which derives deterministic `name` and explicit `debugId` for source-backed wall/fence colliders using `sourceId` + `segmentId` and the existing stable debug hash helper. 
- Wire the helper into runtime collider registration in `src/main.ts` for both ground and upper generated wall instances so `namedColliderDebugNames` and `colliderSourceMetadata.debugId` are populated at registration time. 
- Remove the previous ad-hoc upper-wall debug-name use and replace it with the source-backed identity; do not change any collider geometry, placement, visuals, movement, or runtime semantics. 
- Add focused unit tests at `src/scene/debug/__tests__/colliderSourceIdentities.test.ts` validating deterministic names, debug ID shape, fence/upper naming, and disambiguation for split segments. 

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, and the repo formatting/lint checks passed. 
- Ran the unit test subset and full suite with `npm run test:ci`, and tests passed (focused test file passed and full `vitest` run completed with all tests passing). 
- Ran docs checks with `npm run docs:check` and `npm run links:check`, which passed (external link fetch warnings are informational). 
- Verified build/smoke with `npm run smoke`, which produced a successful dist build and smoke check. 
- Captured redundancy audit before/after and ran the gate: `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-main.json` (before showed 70 warnings) and `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-after.json` (after showed 0 failures and warnings reduced to 35), confirming the gate still passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a402f1e78832f8384efe70f872110)