### PR TITLE
🧭 : – stabilize collider debug identities

### DIFF
--- a/scripts/__tests__/colliderRedundancyGate.test.ts
+++ b/scripts/__tests__/colliderRedundancyGate.test.ts
@@ -193,6 +193,56 @@ describe('evaluateColliderRedundancy', () => {
     ]);
   });
 
+  it('treats source-backed generated wall names as auditable identities', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({
+          id: 'ABC123',
+          debugId: undefined,
+          floor: 'ground',
+          name: 'GroundWallCollider:ground.living_room.south_wall',
+          sourceId: 'ground.living_room.south_wall',
+          sourceType: 'wall',
+        }),
+        collider({
+          id: 'DEF456',
+          debugId: undefined,
+          floor: 'upper',
+          name: 'UpperWallCollider:upper.focus_pods.north_wall',
+          sourceId: 'upper.focus_pods.north_wall',
+          sourceType: 'wall',
+        }),
+      ],
+      options
+    );
+
+    expect(report.findings).toEqual([]);
+  });
+
+  it('keeps ambiguous generated wall names as anonymous warnings', () => {
+    const report = evaluateColliderRedundancy(
+      [
+        collider({
+          id: '1008',
+          debugId: undefined,
+          floor: 'ground',
+          name: 'ground-collider-8',
+          sourceId: 'ground.living_room.south_wall',
+          sourceType: 'wall',
+        }),
+      ],
+      options
+    );
+
+    expect(report.findings).toMatchObject([
+      {
+        severity: 'warning',
+        classification: 'anonymous-generated',
+        collider: { id: '1008' },
+      },
+    ]);
+  });
+
   it('can opt in to failing anonymous generated colliders', () => {
     const report = evaluateColliderRedundancy(
       [collider({ id: 'ANON', debugId: undefined, sourceId: undefined })],

--- a/scripts/colliderRedundancyGate.ts
+++ b/scripts/colliderRedundancyGate.ts
@@ -124,11 +124,31 @@ const hasExplicitRuntimeIdentity = (
   collider: RuntimeColliderMetadata
 ): boolean => collider.debugId === collider.id;
 
+const hasSourceBackedGeneratedWallIdentity = (
+  collider: RuntimeColliderMetadata
+): boolean => {
+  if (collider.sourceType !== 'wall' || typeof collider.sourceId !== 'string') {
+    return false;
+  }
+  if (collider.floor !== 'ground' && collider.floor !== 'upper') {
+    return false;
+  }
+  const expectedPrefix =
+    collider.floor === 'upper' ? 'UpperWallCollider:' : 'GroundWallCollider:';
+  return collider.name === `${expectedPrefix}${collider.sourceId}`;
+};
+
+const hasAuditableRuntimeIdentity = (
+  collider: RuntimeColliderMetadata
+): boolean =>
+  hasExplicitRuntimeIdentity(collider) ||
+  hasSourceBackedGeneratedWallIdentity(collider);
+
 const isConcreteSourceBacked = (collider: RuntimeColliderMetadata): boolean =>
   isSourceBacked(collider) && hasExplicitRuntimeIdentity(collider);
 
 const isAnonymousGenerated = (collider: RuntimeColliderMetadata): boolean =>
-  !isSourceBacked(collider) || !hasExplicitRuntimeIdentity(collider);
+  !isSourceBacked(collider) || !hasAuditableRuntimeIdentity(collider);
 
 const isIntentionalException = (collider: RuntimeColliderMetadata): boolean =>
   INTENTIONAL_NON_REDUNDANT_INTENTS.has(collider.intent ?? '');
@@ -179,10 +199,10 @@ export const evaluateColliderRedundancy = (
         collider: candidate,
         classification: 'anonymous-generated',
         evidence:
-          'Collider is missing source metadata or uses a generated runtime ID.',
+          'Collider is missing source metadata or uses an anonymous generated runtime identity.',
         dominatingColliders: [],
         remediation:
-          'Add sourceId/debugId metadata so future audits can distinguish intentional colliders from generated runtime records.',
+          'Add sourceId/debugId metadata or a source-backed generated wall identity so future audits can distinguish intentional colliders from anonymous runtime records.',
       });
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1038,21 +1038,12 @@ const SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId(
 );
 const SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A');
 
-const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
-  `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-
-const getUpperWallSegmentDebugName = (
+const getWallSegmentColliderDebugName = (
+  floor: FloorId,
   instance: WallSegmentInstance
 ): string => {
-  const { segment } = instance;
-  const start = formatUpperWallDebugPoint(segment.start);
-  const end = formatUpperWallDebugPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-
-  return `UpperWallSegment:${segment.orientation}|${start}|${end}|${rooms || 'none'}`;
+  const prefix = floor === 'upper' ? 'UpperWallCollider' : 'GroundWallCollider';
+  return `${prefix}:${instance.sourceId}`;
 };
 
 const staticColliders: RectCollider[] = [];
@@ -1971,6 +1962,10 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
+    namedColliderDebugNames.set(
+      instance.collider,
+      getWallSegmentColliderDebugName('ground', instance)
+    );
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,
       sourceType: 'wall',
@@ -2354,7 +2349,7 @@ function initializeImmersiveScene(
     upperFloorColliders.push(instance.collider);
     namedColliderDebugNames.set(
       instance.collider,
-      getUpperWallSegmentDebugName(instance)
+      getWallSegmentColliderDebugName('upper', instance)
     );
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,


### PR DESCRIPTION
### Motivation
- Reduce noisy `anonymous-generated` warnings for generated wall/fence colliders that already carry durable `sourceId` provenance while making no geometry/behavior changes.
- Keep this change provenance-only and incremental so ambiguous/generated colliders without clear provenance remain warnings.

### Description
- Add `getWallSegmentColliderDebugName(floor, instance)` in `src/main.ts` and wire generated wall segment colliders to `namedColliderDebugNames.set(...)` using `GroundWallCollider:<sourceId>` / `UpperWallCollider:<sourceId>` runtime names.
- Teach the redundancy audit in `scripts/colliderRedundancyGate.ts` to treat those source-backed generated wall names as auditable identities via `hasSourceBackedGeneratedWallIdentity` and `hasAuditableRuntimeIdentity` and update the anonymous evidence/remediation text accordingly.
- Add focused tests in `scripts/__tests__/colliderRedundancyGate.test.ts` that assert source-backed generated wall names no longer trigger anonymous-generated warnings and that ambiguous generated labels still warn.
- All changes are metadata-only: no collider geometry, movement, POI, visuals, or gate strictness changes were made.

### Testing
- Ran formatting and checks: `npm run format:write` (ran), `npm run lint` (passed), and `git diff --check` (no issues).
- Ran unit tests and focused tests: `npm run test:ci` (full test suite passed) and `npm run test:ci -- scripts/__tests__/colliderRedundancyGate.test.ts` (focused tests passed).
- Ran docs and smoke checks: `npm run docs:check` (passed) and `npm run smoke` (passed).
- Ran redundancy audit before/after: `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-after.json` produced `Inspected 78/3000 colliders with tolerance 0.05; Failures: 0; warnings: 35`, reducing `anonymous-generated` warnings from 70 to 35 while keeping 0 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a403dcac0832f8185e165add68719)