### PR TITLE
Stabilize generated wall/fence collider debug identities

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -175,6 +175,7 @@ import {
   type LevelSafetyCollider,
 } from './scene/level/stairSafetyColliders';
 import { UPPER_STAIRWELL_LANDING_SEGMENT_POLICIES } from './scene/level/upperStairwellLandingSegments';
+import { getWallColliderDebugIdentity } from './scene/level/wallColliderDebugIdentity';
 import { createInteriorLightmapTextures } from './scene/lighting/bakedLightmaps';
 import {
   createLightingDebugController,
@@ -1037,23 +1038,6 @@ const SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId(
   SELFIE_MIRROR_SCENE_OBJECT_DEFINITION.sourceId
 );
 const SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A');
-
-const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
-  `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-
-const getUpperWallSegmentDebugName = (
-  instance: WallSegmentInstance
-): string => {
-  const { segment } = instance;
-  const start = formatUpperWallDebugPoint(segment.start);
-  const end = formatUpperWallDebugPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-
-  return `UpperWallSegment:${segment.orientation}|${start}|${end}|${rooms || 'none'}`;
-};
 
 const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
@@ -1970,10 +1954,13 @@ function initializeImmersiveScene(
   });
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
+    const debugIdentity = getWallColliderDebugIdentity('ground', instance);
     groundColliders.push(instance.collider);
+    namedColliderDebugNames.set(instance.collider, debugIdentity.name);
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,
       sourceType: 'wall',
+      debugId: debugIdentity.debugId,
     });
   });
 
@@ -2351,14 +2338,13 @@ function initializeImmersiveScene(
   });
   upperFloorGroup.add(upperWallMeshes.group);
   upperWallInstances.forEach((instance) => {
+    const debugIdentity = getWallColliderDebugIdentity('upper', instance);
     upperFloorColliders.push(instance.collider);
-    namedColliderDebugNames.set(
-      instance.collider,
-      getUpperWallSegmentDebugName(instance)
-    );
+    namedColliderDebugNames.set(instance.collider, debugIdentity.name);
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,
       sourceType: 'wall',
+      debugId: debugIdentity.debugId,
     });
   });
 

--- a/src/scene/level/__tests__/wallColliderDebugIdentity.test.ts
+++ b/src/scene/level/__tests__/wallColliderDebugIdentity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { WALL_THICKNESS } from '../../../assets/floorPlan';
+import type { RoomCategory } from '../../../assets/floorPlan';
+import { generateWallSegmentInstances } from '../generateWalls';
+import { PORTFOLIO_LEVEL } from '../portfolioLevel';
+import { getWallColliderDebugIdentity } from '../wallColliderDebugIdentity';
+
+const getRoomCategory = (
+  roomId: string,
+  floorId: 'ground' | 'upper'
+): RoomCategory => {
+  return (
+    PORTFOLIO_LEVEL.floors
+      .find((floor) => floor.id === floorId)
+      ?.rooms.find((room) => room.id === roomId)?.category ?? 'interior'
+  );
+};
+
+const wallOptions = (floorId: 'ground' | 'upper') => ({
+  coordinateScale: 0.5,
+  baseElevation: floorId === 'ground' ? 0 : 6,
+  wallHeight: 6,
+  wallThickness: WALL_THICKNESS,
+  fenceHeight: 2.4,
+  fenceThickness: 0.28,
+  getRoomCategory: (roomId: string) => getRoomCategory(roomId, floorId),
+});
+
+describe('wall collider debug identities', () => {
+  it('derives deterministic names from wall source IDs', () => {
+    const floor = PORTFOLIO_LEVEL.floors.find(
+      (candidate) => candidate.id === 'ground'
+    );
+    expect(floor).toBeDefined();
+    if (!floor) return;
+
+    const [instance] = generateWallSegmentInstances(
+      floor,
+      wallOptions('ground')
+    );
+    expect(instance).toBeDefined();
+    if (!instance) return;
+
+    const identity = getWallColliderDebugIdentity('ground', instance);
+
+    expect(identity).toEqual(getWallColliderDebugIdentity('ground', instance));
+    expect(identity.name).toBe(`GroundWallCollider:${instance.sourceId}`);
+    expect(identity.debugId).toMatch(/^[0-9A-F]{6}$/);
+  });
+
+  it('keeps split wall segments explicit without colliding debug IDs', () => {
+    const identities = PORTFOLIO_LEVEL.floors.flatMap((floor) => {
+      const floorId = floor.id as 'ground' | 'upper';
+      return generateWallSegmentInstances(floor, wallOptions(floorId)).map(
+        (instance) => getWallColliderDebugIdentity(floorId, instance)
+      );
+    });
+
+    expect(identities.length).toBeGreaterThan(0);
+    expect(new Set(identities.map((identity) => identity.debugId)).size).toBe(
+      identities.length
+    );
+    expect(
+      identities.some((identity) =>
+        identity.name.startsWith(
+          'GroundWallCollider:ground.living_room.north_wall'
+        )
+      )
+    ).toBe(true);
+    expect(
+      identities.some((identity) =>
+        identity.name.startsWith(
+          'UpperWallCollider:upper.upper_landing_to_loft_library.wall'
+        )
+      )
+    ).toBe(true);
+  });
+});

--- a/src/scene/level/__tests__/wallColliderDebugIdentity.test.ts
+++ b/src/scene/level/__tests__/wallColliderDebugIdentity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { WALL_THICKNESS } from '../../../assets/floorPlan';
+import { FLOOR_PLAN_SCALE, WALL_THICKNESS } from '../../../assets/floorPlan';
 import type { RoomCategory } from '../../../assets/floorPlan';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
@@ -18,7 +18,7 @@ const getRoomCategory = (
 };
 
 const wallOptions = (floorId: 'ground' | 'upper') => ({
-  coordinateScale: 0.5,
+  coordinateScale: FLOOR_PLAN_SCALE,
   baseElevation: floorId === 'ground' ? 0 : 6,
   wallHeight: 6,
   wallThickness: WALL_THICKNESS,
@@ -45,7 +45,9 @@ describe('wall collider debug identities', () => {
     const identity = getWallColliderDebugIdentity('ground', instance);
 
     expect(identity).toEqual(getWallColliderDebugIdentity('ground', instance));
-    expect(identity.name).toBe(`GroundWallCollider:${instance.sourceId}`);
+    expect(identity.name).toBe(
+      `GroundWallCollider:${instance.sourceId}:${identity.debugId}`
+    );
     expect(identity.debugId).toMatch(/^[0-9A-F]{6}$/);
   });
 
@@ -58,6 +60,9 @@ describe('wall collider debug identities', () => {
     });
 
     expect(identities.length).toBeGreaterThan(0);
+    expect(new Set(identities.map((identity) => identity.name)).size).toBe(
+      identities.length
+    );
     expect(new Set(identities.map((identity) => identity.debugId)).size).toBe(
       identities.length
     );

--- a/src/scene/level/__tests__/wallColliderDebugIdentity.test.ts
+++ b/src/scene/level/__tests__/wallColliderDebugIdentity.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE, WALL_THICKNESS } from '../../../assets/floorPlan';
 import type { RoomCategory } from '../../../assets/floorPlan';
+import {
+  BACKYARD_FENCE_SEGMENT_POLICIES,
+  BACKYARD_HOLOGRAM_BARRIER_POLICY,
+} from '../backyardCollisionPolicies';
 import { generateWallSegmentInstances } from '../generateWalls';
 import { PORTFOLIO_LEVEL } from '../portfolioLevel';
 import { getWallColliderDebugIdentity } from '../wallColliderDebugIdentity';
@@ -27,6 +31,18 @@ const wallOptions = (floorId: 'ground' | 'upper') => ({
   getRoomCategory: (roomId: string) => getRoomCategory(roomId, floorId),
 });
 
+const generatedWallColliderIdentities = () =>
+  PORTFOLIO_LEVEL.floors.flatMap((floor) => {
+    const floorId = floor.id as 'ground' | 'upper';
+    return generateWallSegmentInstances(floor, wallOptions(floorId)).map(
+      (instance) => ({
+        floorId,
+        instance,
+        identity: getWallColliderDebugIdentity(floorId, instance),
+      })
+    );
+  });
+
 describe('wall collider debug identities', () => {
   it('derives deterministic names from wall source IDs', () => {
     const floor = PORTFOLIO_LEVEL.floors.find(
@@ -51,34 +67,104 @@ describe('wall collider debug identities', () => {
     expect(identity.debugId).toMatch(/^[0-9A-F]{6}$/);
   });
 
-  it('keeps split wall segments explicit without colliding debug IDs', () => {
-    const identities = PORTFOLIO_LEVEL.floors.flatMap((floor) => {
-      const floorId = floor.id as 'ground' | 'upper';
-      return generateWallSegmentInstances(floor, wallOptions(floorId)).map(
-        (instance) => getWallColliderDebugIdentity(floorId, instance)
-      );
-    });
+  it('covers generated fence instances with deterministic source identities', () => {
+    const generatedIdentities = generatedWallColliderIdentities();
+    const fenceIdentity = generatedIdentities.find(
+      ({ instance }) => instance.isFence
+    );
 
-    expect(identities.length).toBeGreaterThan(0);
-    expect(new Set(identities.map((identity) => identity.name)).size).toBe(
-      identities.length
+    expect(fenceIdentity).toBeDefined();
+    if (!fenceIdentity) return;
+
+    const prefix =
+      fenceIdentity.floorId === 'ground'
+        ? 'GroundWallCollider'
+        : 'UpperWallCollider';
+    expect(fenceIdentity?.identity.name).toBe(
+      `${prefix}:${fenceIdentity.instance.sourceId}:${fenceIdentity.identity.debugId}`
     );
-    expect(new Set(identities.map((identity) => identity.debugId)).size).toBe(
-      identities.length
-    );
+    expect(fenceIdentity.identity.debugId).toMatch(/^[0-9A-F]{6}$/);
+  });
+
+  it('keeps generated wall and fence debug identities deterministic and unique', () => {
+    const generatedIdentities = generatedWallColliderIdentities();
+
+    expect(generatedIdentities.length).toBeGreaterThan(0);
     expect(
-      identities.some((identity) =>
+      new Set(generatedIdentities.map(({ identity }) => identity.name)).size
+    ).toBe(generatedIdentities.length);
+    expect(
+      new Set(generatedIdentities.map(({ identity }) => identity.debugId)).size
+    ).toBe(generatedIdentities.length);
+    expect(
+      generatedIdentities.every(({ floorId, identity, instance }) => {
+        const prefix =
+          floorId === 'ground' ? 'GroundWallCollider' : 'UpperWallCollider';
+        return (
+          identity.name ===
+            `${prefix}:${instance.sourceId}:${identity.debugId}` &&
+          identity.name ===
+            getWallColliderDebugIdentity(floorId, instance).name &&
+          identity.debugId ===
+            getWallColliderDebugIdentity(floorId, instance).debugId
+        );
+      })
+    ).toBe(true);
+  });
+
+  it('keeps generated wall and fence names source-derived', () => {
+    const generatedIdentities = generatedWallColliderIdentities();
+
+    expect(generatedIdentities.length).toBeGreaterThan(0);
+    expect(
+      generatedIdentities.every(
+        ({ identity }) =>
+          !identity.name.startsWith('ground-collider-') &&
+          !identity.name.startsWith('upper-collider-')
+      )
+    ).toBe(true);
+    expect(
+      generatedIdentities.some(({ identity }) =>
         identity.name.startsWith(
           'GroundWallCollider:ground.living_room.north_wall'
         )
       )
     ).toBe(true);
     expect(
-      identities.some((identity) =>
+      generatedIdentities.some(({ identity }) =>
         identity.name.startsWith(
           'UpperWallCollider:upper.upper_landing_to_loft_library.wall'
         )
       )
     ).toBe(true);
+  });
+
+  it('assigns valid non-colliding backyard side fence boundary debug IDs', () => {
+    const sideFencePolicies = BACKYARD_FENCE_SEGMENT_POLICIES.filter(
+      (policy) =>
+        policy.role === 'leftFenceBoundary' ||
+        policy.role === 'rightFenceBoundary'
+    );
+    const existingDebugIds = new Set([
+      BACKYARD_FENCE_SEGMENT_POLICIES.find(
+        (policy) => policy.role === 'backFenceBoundary'
+      )?.debugId,
+      BACKYARD_HOLOGRAM_BARRIER_POLICY.debugId,
+    ]);
+
+    expect(sideFencePolicies).toHaveLength(2);
+    expect(
+      sideFencePolicies.every((policy) =>
+        /^[0-9A-F]{4,6}$/.test(policy.debugId ?? '')
+      )
+    ).toBe(true);
+    expect(
+      sideFencePolicies.every(
+        (policy) => policy.debugId && !existingDebugIds.has(policy.debugId)
+      )
+    ).toBe(true);
+    expect(
+      new Set(sideFencePolicies.map((policy) => policy.debugId)).size
+    ).toBe(sideFencePolicies.length);
   });
 });

--- a/src/scene/level/backyardCollisionPolicies.ts
+++ b/src/scene/level/backyardCollisionPolicies.ts
@@ -6,7 +6,11 @@ import {
 } from '../debug/colliderDebugIds';
 
 import type { SourceBackedCollider } from './sourceCollision';
-import { assertLevelSourceId, type LevelSourceId } from './sourceIds';
+import {
+  assertLevelSourceId,
+  getLevelSourceDebugRef,
+  type LevelSourceId,
+} from './sourceIds';
 
 export type BackyardCollisionRole =
   | 'leftFenceBoundary'
@@ -53,6 +57,8 @@ export type BackyardSourceCollider = RectCollider &
 const sourceId = (value: string): LevelSourceId => assertLevelSourceId(value);
 const debugId = (value: string): DebugColliderId =>
   assertDebugColliderId(value);
+const debugIdFromSource = (value: LevelSourceId): DebugColliderId =>
+  assertDebugColliderId(getLevelSourceDebugRef(value));
 
 export const BACKYARD_FENCE_LAYOUT = {
   fenceInsetX: 0.35,
@@ -67,12 +73,18 @@ export const BACKYARD_FENCE_SEGMENT_POLICIES = [
     sourceId: sourceId('ground.backyard.perimeter.leftFence.boundary'),
     name: 'BackyardLeftFenceBoundary',
     purpose: 'block the west edge of the backyard perimeter fence',
+    debugId: debugIdFromSource(
+      sourceId('ground.backyard.perimeter.leftFence.boundary')
+    ),
   },
   {
     role: 'rightFenceBoundary',
     sourceId: sourceId('ground.backyard.perimeter.rightFence.boundary'),
     name: 'BackyardRightFenceBoundary',
     purpose: 'block the east edge of the backyard perimeter fence',
+    debugId: debugIdFromSource(
+      sourceId('ground.backyard.perimeter.rightFence.boundary')
+    ),
   },
   {
     role: 'backFenceBoundary',

--- a/src/scene/level/backyardCollisionPolicies.ts
+++ b/src/scene/level/backyardCollisionPolicies.ts
@@ -60,6 +60,16 @@ const debugId = (value: string): DebugColliderId =>
 const debugIdFromSource = (value: LevelSourceId): DebugColliderId =>
   assertDebugColliderId(getLevelSourceDebugRef(value));
 
+const leftFenceBoundarySourceId = sourceId(
+  'ground.backyard.perimeter.leftFence.boundary'
+);
+const rightFenceBoundarySourceId = sourceId(
+  'ground.backyard.perimeter.rightFence.boundary'
+);
+const backFenceBoundarySourceId = sourceId(
+  'ground.backyard.perimeter.backFence.boundary'
+);
+
 export const BACKYARD_FENCE_LAYOUT = {
   fenceInsetX: 0.35,
   fenceFrontPadding: 0.9,
@@ -70,27 +80,25 @@ export const BACKYARD_FENCE_LAYOUT = {
 export const BACKYARD_FENCE_SEGMENT_POLICIES = [
   {
     role: 'leftFenceBoundary',
-    sourceId: sourceId('ground.backyard.perimeter.leftFence.boundary'),
+    sourceId: leftFenceBoundarySourceId,
     name: 'BackyardLeftFenceBoundary',
     purpose: 'block the west edge of the backyard perimeter fence',
-    debugId: debugIdFromSource(
-      sourceId('ground.backyard.perimeter.leftFence.boundary')
-    ),
+    debugId: debugIdFromSource(leftFenceBoundarySourceId),
   },
   {
     role: 'rightFenceBoundary',
-    sourceId: sourceId('ground.backyard.perimeter.rightFence.boundary'),
+    sourceId: rightFenceBoundarySourceId,
     name: 'BackyardRightFenceBoundary',
     purpose: 'block the east edge of the backyard perimeter fence',
-    debugId: debugIdFromSource(
-      sourceId('ground.backyard.perimeter.rightFence.boundary')
-    ),
+    debugId: debugIdFromSource(rightFenceBoundarySourceId),
   },
   {
     role: 'backFenceBoundary',
-    sourceId: sourceId('ground.backyard.perimeter.backFence.boundary'),
+    sourceId: backFenceBoundarySourceId,
     name: 'BackyardBackFenceBoundary',
     purpose: 'preserve the visible back fence as a physical boundary',
+    // Retain the existing audit-registered anchor while newer side fences
+    // use source-derived IDs.
     debugId: debugId('1006'),
   },
 ] as const satisfies readonly BackyardFenceSegmentPolicy[];

--- a/src/scene/level/wallColliderDebugIdentity.ts
+++ b/src/scene/level/wallColliderDebugIdentity.ts
@@ -1,0 +1,31 @@
+import type { WallSegmentInstance } from '../../assets/floorPlan/wallSegments';
+import {
+  assertDebugColliderId,
+  type DebugColliderId,
+} from '../debug/colliderDebugIds';
+import { getDebugHash } from '../debug/debugIds';
+
+export type WallColliderDebugFloor = 'ground' | 'upper';
+
+export interface WallColliderDebugIdentity {
+  name: string;
+  debugId: DebugColliderId;
+}
+
+const WALL_COLLIDER_NAME_PREFIX = {
+  ground: 'GroundWallCollider',
+  upper: 'UpperWallCollider',
+} as const satisfies Record<WallColliderDebugFloor, string>;
+
+export function getWallColliderDebugIdentity(
+  floor: WallColliderDebugFloor,
+  instance: Pick<WallSegmentInstance, 'sourceId' | 'segmentId'>
+): WallColliderDebugIdentity {
+  const sourceId = String(instance.sourceId);
+  const identitySeed = `${floor}|${sourceId}|${instance.segmentId}`;
+
+  return {
+    name: `${WALL_COLLIDER_NAME_PREFIX[floor]}:${sourceId}`,
+    debugId: assertDebugColliderId(getDebugHash(identitySeed)),
+  };
+}

--- a/src/scene/level/wallColliderDebugIdentity.ts
+++ b/src/scene/level/wallColliderDebugIdentity.ts
@@ -23,9 +23,10 @@ export function getWallColliderDebugIdentity(
 ): WallColliderDebugIdentity {
   const sourceId = String(instance.sourceId);
   const identitySeed = `${floor}|${sourceId}|${instance.segmentId}`;
+  const debugId = assertDebugColliderId(getDebugHash(identitySeed));
 
   return {
-    name: `${WALL_COLLIDER_NAME_PREFIX[floor]}:${sourceId}`,
-    debugId: assertDebugColliderId(getDebugHash(identitySeed)),
+    name: `${WALL_COLLIDER_NAME_PREFIX[floor]}:${sourceId}:${debugId}`,
+    debugId,
   };
 }


### PR DESCRIPTION
### Motivation
- Reduce `anonymous-generated` redundancy-audit warnings by giving source-backed generated wall/fence colliders stable, source-derived debug identities without touching geometry or runtime semantics. 
- Prefer systematic, deterministic names/IDs derived from existing `sourceId` and wall segment identity so audits and DevTools can reliably link runtime colliders back to their source declarations. 

### Description
- Added `src/scene/level/wallColliderDebugIdentity.ts` with `getWallColliderDebugIdentity(...)` to derive deterministic human-readable names and explicit debug IDs from `floor`, `sourceId`, and `segmentId` (e.g. `GroundWallCollider:<sourceId>`). 
- Wired generated wall colliders to expose the new metadata when registering runtime debug metadata in `src/main.ts` for both ground and upper floors, preserving collider bounds and behavior. 
- Assigned source-derived explicit debug IDs to the backyard left/right fence boundary policies in `src/scene/level/backyardCollisionPolicies.ts` using `getLevelSourceDebugRef(...)`. 
- Added focused tests `src/scene/level/__tests__/wallColliderDebugIdentity.test.ts` that assert deterministic naming and non-colliding debug IDs for split/generated wall segments. 

### Testing
- Ran format, lint, unit/integration tests, docs check, smoke build and the redundancy gate; all commands completed successfully: `npm run format:write` (applied), `npm run lint` (passed), `npm run test:ci` (passed), and `npm run docs:check` (passed; link-check produced external-reachability warnings but returned success). 
- Baseline redundancy audit (pre-change) was captured with `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-main.json` reporting `inspectedColliders: 78`, `failures: 0`, `warnings: 70`. 
- Post-change redundancy audit run with `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-after.json` shows `inspectedColliders: 78`, `failures: 0`, `warnings: 33`, demonstrating a substantial reduction in `anonymous-generated` warnings for source-backed colliders. 
- Focused unit test `src/scene/level/__tests__/wallColliderDebugIdentity.test.ts` and existing redundancy gate tests passed under `npm run test:ci`; `npm run smoke` build also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a4044740c832fb81ba9701d78863c)