### PR TITLE
🧭 Stabilize source-backed collider debug identities

### DIFF
--- a/scripts/__tests__/colliderRedundancyGate.test.ts
+++ b/scripts/__tests__/colliderRedundancyGate.test.ts
@@ -139,7 +139,7 @@ describe('evaluateColliderRedundancy', () => {
     ]);
   });
 
-  it('does not fail ambiguous adjacent, isolated, anonymous, source-backed generated, or intentional backstop cases', () => {
+  it('does not fail ambiguous adjacent, isolated, anonymous, source-backed stable-name, or intentional backstop cases', () => {
     const report = evaluateColliderRedundancy(
       [
         collider({ id: 'A', debugId: 'A' }),
@@ -162,10 +162,18 @@ describe('evaluateColliderRedundancy', () => {
           bounds: { minX: 30, maxX: 31, minZ: 30, maxZ: 31 },
         }),
         collider({
+          id: 'STABLE',
+          debugId: undefined,
+          name: 'GroundWallCollider:ground.wall.generated:segment-a',
+          sourceId: 'ground.wall.generated',
+          bounds: { minX: 6, maxX: 7, minZ: 0, maxZ: 4 },
+        }),
+        collider({
           id: 'GEN',
           debugId: undefined,
-          sourceId: 'ground.wall.generated',
-          bounds: { minX: 0, maxX: 4, minZ: 0, maxZ: 4 },
+          name: 'ground-collider-8',
+          sourceId: 'ground.wall.generated_name',
+          bounds: { minX: 40, maxX: 41, minZ: 40, maxZ: 41 },
         }),
         collider({
           id: 'BACKSTOP',

--- a/scripts/colliderRedundancyGate.ts
+++ b/scripts/colliderRedundancyGate.ts
@@ -120,9 +120,18 @@ export const parseColliderRedundancyGateArgs = (
 const isSourceBacked = (collider: RuntimeColliderMetadata): boolean =>
   typeof collider.sourceId === 'string' && collider.sourceId.length > 0;
 
+const GENERATED_RUNTIME_NAME_PATTERN = /^(ground|static|upper)-collider-\d+$/;
+
+const hasSourceBackedStableName = (
+  collider: RuntimeColliderMetadata
+): boolean =>
+  isSourceBacked(collider) &&
+  !GENERATED_RUNTIME_NAME_PATTERN.test(collider.name);
+
 const hasExplicitRuntimeIdentity = (
   collider: RuntimeColliderMetadata
-): boolean => collider.debugId === collider.id;
+): boolean =>
+  collider.debugId === collider.id || hasSourceBackedStableName(collider);
 
 const isConcreteSourceBacked = (collider: RuntimeColliderMetadata): boolean =>
   isSourceBacked(collider) && hasExplicitRuntimeIdentity(collider);
@@ -179,10 +188,10 @@ export const evaluateColliderRedundancy = (
         collider: candidate,
         classification: 'anonymous-generated',
         evidence:
-          'Collider is missing source metadata or uses a generated runtime ID.',
+          'Collider is missing source metadata or still uses a generated runtime identity.',
         dominatingColliders: [],
         remediation:
-          'Add sourceId/debugId metadata so future audits can distinguish intentional colliders from generated runtime records.',
+          'Add sourceId metadata and a stable source-backed debug name or debugId so future audits can distinguish intentional colliders from generated runtime records.',
       });
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,6 +110,7 @@ import {
   type AvatarVariantId,
 } from './scene/avatar/variants';
 import { resolveInitialAvatarCameraFraming } from './scene/camera/initialFraming';
+import { getWallSegmentColliderDebugName } from './scene/debug/colliderDebugIdentity';
 import { assertDebugColliderId } from './scene/debug/colliderDebugIds';
 import {
   createColliderVisualizer,
@@ -1038,23 +1039,6 @@ const SELFIE_MIRROR_COLLIDER_SOURCE_ID = assertLevelSourceId(
 );
 const SELFIE_MIRROR_COLLIDER_DEBUG_ID = assertDebugColliderId('101A');
 
-const formatUpperWallDebugPoint = (point: { x: number; z: number }): string =>
-  `${point.x.toFixed(3)},${point.z.toFixed(3)}`;
-
-const getUpperWallSegmentDebugName = (
-  instance: WallSegmentInstance
-): string => {
-  const { segment } = instance;
-  const start = formatUpperWallDebugPoint(segment.start);
-  const end = formatUpperWallDebugPoint(segment.end);
-  const rooms = segment.rooms
-    .map((room) => `${room.id}:${room.wall}`)
-    .sort()
-    .join('|');
-
-  return `UpperWallSegment:${segment.orientation}|${start}|${end}|${rooms || 'none'}`;
-};
-
 const staticColliders: RectCollider[] = [];
 const poiInstances: PoiInstance[] = [];
 let backyardEnvironment: BackyardEnvironmentBuild | null = null;
@@ -1971,6 +1955,10 @@ function initializeImmersiveScene(
   groundFloorGroup.add(groundWallMeshes.group);
   groundWallInstances.forEach((instance) => {
     groundColliders.push(instance.collider);
+    namedColliderDebugNames.set(
+      instance.collider,
+      getWallSegmentColliderDebugName('ground', instance)
+    );
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,
       sourceType: 'wall',
@@ -2354,7 +2342,7 @@ function initializeImmersiveScene(
     upperFloorColliders.push(instance.collider);
     namedColliderDebugNames.set(
       instance.collider,
-      getUpperWallSegmentDebugName(instance)
+      getWallSegmentColliderDebugName('upper', instance)
     );
     colliderSourceMetadata.set(instance.collider, {
       sourceId: instance.sourceId,

--- a/src/scene/debug/__tests__/colliderDebugIdentity.test.ts
+++ b/src/scene/debug/__tests__/colliderDebugIdentity.test.ts
@@ -1,0 +1,34 @@
+import type { WallSegmentInstance } from '../../../assets/floorPlan/wallSegments';
+import { makeLevelSourceId } from '../../level/sourceIds';
+import { getWallSegmentColliderDebugName } from '../colliderDebugIdentity';
+
+const wallInstance = (
+  overrides: Partial<Pick<WallSegmentInstance, 'sourceId' | 'segmentId'>> = {}
+): Pick<WallSegmentInstance, 'sourceId' | 'segmentId'> => ({
+  sourceId: makeLevelSourceId(['ground', 'living_room', 'north_wall']),
+  segmentId: 'horizontal|-10.000,20.000|10.000,20.000|livingRoom:north',
+  ...overrides,
+});
+
+describe('getWallSegmentColliderDebugName', () => {
+  it('derives ground wall collider names from source metadata', () => {
+    expect(getWallSegmentColliderDebugName('ground', wallInstance())).toBe(
+      'GroundWallCollider:ground.living_room.north_wall:' +
+        'horizontal|-10.000,20.000|10.000,20.000|livingRoom:north'
+    );
+  });
+
+  it('derives upper wall collider names from the same stable segment identity', () => {
+    expect(
+      getWallSegmentColliderDebugName(
+        'upper',
+        wallInstance({
+          sourceId: makeLevelSourceId(['upper', 'focus_pods', 'north_wall']),
+        })
+      )
+    ).toBe(
+      'UpperWallCollider:upper.focus_pods.north_wall:' +
+        'horizontal|-10.000,20.000|10.000,20.000|livingRoom:north'
+    );
+  });
+});

--- a/src/scene/debug/colliderDebugIdentity.ts
+++ b/src/scene/debug/colliderDebugIdentity.ts
@@ -1,0 +1,13 @@
+import type { WallSegmentInstance } from '../../assets/floorPlan/wallSegments';
+import type { FloorId } from '../../systems/movement/stairs';
+
+const WALL_COLLIDER_NAME_PREFIXES = {
+  ground: 'GroundWallCollider',
+  upper: 'UpperWallCollider',
+} as const satisfies Record<FloorId, string>;
+
+export const getWallSegmentColliderDebugName = (
+  floorId: FloorId,
+  instance: Pick<WallSegmentInstance, 'sourceId' | 'segmentId'>
+): string =>
+  `${WALL_COLLIDER_NAME_PREFIXES[floorId]}:${instance.sourceId}:${instance.segmentId}`;


### PR DESCRIPTION
### Motivation
- Reduce `anonymous-generated` redundancy warnings for generated wall/fence colliders that already have durable `sourceId` provenance without changing any collider geometry or runtime semantics. 
- Provide deterministic, human-readable debug identities for source-backed generated walls so audits and developer tooling can reliably link runtime colliders to their level declarations.

### Description
- Add a small helper `getWallSegmentColliderDebugName` in `src/scene/debug/colliderDebugIdentity.ts` that builds stable debug names like `GroundWallCollider:<sourceId>:<segmentId>` / `UpperWallCollider:<sourceId>:<segmentId>`. 
- Wire that helper into runtime registrations in `src/main.ts` to set `namedColliderDebugNames` for generated ground and upper wall/fence colliders while preserving existing `colliderSourceMetadata` and all geometry/behavior. 
- Relax the redundancy gate in `scripts/colliderRedundancyGate.ts` to treat source-backed colliders with a non-generated runtime name as having an explicit identity (it still warns for classic generated labels like `ground-collider-*`). 
- Add focused tests: `src/scene/debug/__tests__/colliderDebugIdentity.test.ts` (naming convention) and adjust `scripts/__tests__/colliderRedundancyGate.test.ts` to cover the stable-name case.

### Testing
- Ran the runtime redundancy audit: `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-after.json` and observed the gate still passes with `0` failures and warnings reduced from `70` to `33` (tolerance `0.05`).
- Ran unit and integration tests: `npm run test:ci` (Vitest) and the selected/test-suite run completed successfully (new and existing tests passed). 
- Ran repository checks: `npm run format:write`, `npm run lint`, `npm run docs:check`, `npm run build`, and `npm run smoke`, all of which completed successfully in this environment (no behavioral or visual changes introduced).

Residual notes: this is an incremental provenance-only change that preserves scene geometry and behavior; remaining `anonymous-generated` warnings are left where provenance is unclear (scene objects, static colliders, or truly anonymous runtime records). Further passes can extend source-backing for other safe buckets if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a4058fe58832f9da69777a9bad6ad)