### PR TITLE
🧭 : – Redistribute launch POIs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2869,8 +2869,6 @@ function initializeImmersiveScene(
     (poi) => poi.definition.id === 'pr-reaper-backyard-console'
   );
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
-  const kitchenRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'kitchen');
-  const kitchenBounds = kitchenRoom?.bounds;
   if (studioRoom) {
     const centerX =
       flywheelPoi?.group.position.x ??
@@ -2893,26 +2891,23 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         showpiece.colliders,
         flywheelSceneObject,
-        groundColliders,
+        getPoiFloorId(flywheelPoi!.definition) === 'upper'
+          ? upperFloorColliders
+          : groundColliders,
         colliderSourceMetadata
       );
     } else {
       showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     }
-    groundStructureGroup.add(showpiece.group);
+    (getPoiFloorId(flywheelPoi!.definition) === 'upper'
+      ? upperPoiGroup
+      : groundStructureGroup
+    ).add(showpiece.group);
     flywheelShowpiece = showpiece;
 
     const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
-    const terminalX = MathUtils.clamp(
-      jobbotPoi?.group.position.x ?? 11.4,
-      studioRoom.bounds.minX + 1.2,
-      studioRoom.bounds.maxX - 0.8
-    );
-    const terminalZ = MathUtils.clamp(
-      jobbotPoi?.group.position.z ?? -0.6,
-      studioRoom.bounds.minZ + 1.2,
-      studioRoom.bounds.maxZ - 1.1
-    );
+    const terminalX = jobbotPoi?.group.position.x ?? 11.4;
+    const terminalZ = jobbotPoi?.group.position.z ?? -0.6;
     const terminal = createJobbotTerminal({
       position: { x: terminalX, y: 0, z: terminalZ },
       orientationRadians: terminalOrientation,
@@ -2926,13 +2921,18 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         terminal.colliders,
         jobbotSceneObject,
-        groundColliders,
+        getPoiFloorId(jobbotPoi!.definition) === 'upper'
+          ? upperFloorColliders
+          : groundColliders,
         colliderSourceMetadata
       );
     } else {
       terminal.colliders.forEach((collider) => groundColliders.push(collider));
     }
-    groundStructureGroup.add(terminal.group);
+    (getPoiFloorId(jobbotPoi!.definition) === 'upper'
+      ? upperPoiGroup
+      : groundStructureGroup
+    ).add(terminal.group);
     jobbotTerminal = terminal;
 
     if (axelPoi) {
@@ -2950,7 +2950,9 @@ function initializeImmersiveScene(
         registerSceneObjectColliders(
           navigator.colliders,
           axelSceneObject,
-          groundColliders,
+          getPoiFloorId(axelPoi.definition) === 'upper'
+            ? upperFloorColliders
+            : groundColliders,
           colliderSourceMetadata
         );
       } else {
@@ -2958,7 +2960,10 @@ function initializeImmersiveScene(
           groundColliders.push(collider)
         );
       }
-      groundStructureGroup.add(navigator.group);
+      (getPoiFloorId(axelPoi.definition) === 'upper'
+        ? upperPoiGroup
+        : groundStructureGroup
+      ).add(navigator.group);
       axelNavigator = navigator;
     }
 
@@ -2971,8 +2976,16 @@ function initializeImmersiveScene(
         },
         orientationRadians: tokenPlacePoi.group.rotation.y ?? 0,
       });
-      groundStructureGroup.add(rack.group);
-      rack.colliders.forEach((collider) => groundColliders.push(collider));
+      (getPoiFloorId(tokenPlacePoi.definition) === 'upper'
+        ? upperPoiGroup
+        : groundStructureGroup
+      ).add(rack.group);
+      rack.colliders.forEach((collider) =>
+        (getPoiFloorId(tokenPlacePoi.definition) === 'upper'
+          ? upperFloorColliders
+          : groundColliders
+        ).push(collider)
+      );
       tokenPlaceRack = rack;
     }
 
@@ -2985,8 +2998,16 @@ function initializeImmersiveScene(
         },
         orientationRadians: gabrielPoi.group.rotation.y ?? 0,
       });
-      groundStructureGroup.add(sentry.group);
-      sentry.colliders.forEach((collider) => groundColliders.push(collider));
+      (getPoiFloorId(gabrielPoi.definition) === 'upper'
+        ? upperPoiGroup
+        : groundStructureGroup
+      ).add(sentry.group);
+      sentry.colliders.forEach((collider) =>
+        (getPoiFloorId(gabrielPoi.definition) === 'upper'
+          ? upperFloorColliders
+          : groundColliders
+        ).push(collider)
+      );
       gabrielSentry = sentry;
     }
   }
@@ -3008,13 +3029,18 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         console.colliders,
         prReaperSceneObject,
-        groundColliders,
+        getPoiFloorId(prReaperPoi.definition) === 'upper'
+          ? upperFloorColliders
+          : groundColliders,
         colliderSourceMetadata
       );
     } else {
       console.colliders.forEach((collider) => groundColliders.push(collider));
     }
-    groundStructureGroup.add(console.group);
+    (getPoiFloorId(prReaperPoi.definition) === 'upper'
+      ? upperPoiGroup
+      : groundStructureGroup
+    ).add(console.group);
     prReaperConsole = console;
   }
 
@@ -3027,28 +3053,22 @@ function initializeImmersiveScene(
       },
       orientationRadians: gitshelvesPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(installation.group);
+    (getPoiFloorId(gitshelvesPoi.definition) === 'upper'
+      ? upperPoiGroup
+      : groundStructureGroup
+    ).add(installation.group);
     installation.colliders.forEach((collider) =>
-      groundColliders.push(collider)
+      (getPoiFloorId(gitshelvesPoi.definition) === 'upper'
+        ? upperFloorColliders
+        : groundColliders
+      ).push(collider)
     );
     gitshelvesInstallation = installation;
   }
 
   if (f2ClipboardPoi) {
-    const consoleX = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : f2ClipboardPoi.group.position.x;
-    const consoleZ = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.8
-        )
-      : f2ClipboardPoi.group.position.z;
+    const consoleX = f2ClipboardPoi.group.position.x;
+    const consoleZ = f2ClipboardPoi.group.position.z;
     const console = createF2ClipboardConsole({
       position: {
         x: consoleX,
@@ -3057,26 +3077,22 @@ function initializeImmersiveScene(
       },
       orientationRadians: f2ClipboardPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(console.group);
-    console.colliders.forEach((collider) => groundColliders.push(collider));
+    (getPoiFloorId(f2ClipboardPoi.definition) === 'upper'
+      ? upperPoiGroup
+      : groundStructureGroup
+    ).add(console.group);
+    console.colliders.forEach((collider) =>
+      (getPoiFloorId(f2ClipboardPoi.definition) === 'upper'
+        ? upperFloorColliders
+        : groundColliders
+      ).push(collider)
+    );
     f2ClipboardConsole = console;
   }
 
   if (sigmaPoi) {
-    const benchX = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.x,
-          kitchenBounds.minX + 0.9,
-          kitchenBounds.maxX - 0.9
-        )
-      : sigmaPoi.group.position.x;
-    const benchZ = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.z,
-          kitchenBounds.minZ + 0.9,
-          kitchenBounds.maxZ - 0.9
-        )
-      : sigmaPoi.group.position.z;
+    const benchX = sigmaPoi.group.position.x;
+    const benchZ = sigmaPoi.group.position.z;
     const workbench = createSigmaWorkbench({
       position: {
         x: benchX,
@@ -3085,26 +3101,22 @@ function initializeImmersiveScene(
       },
       orientationRadians: sigmaPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(workbench.group);
-    workbench.colliders.forEach((collider) => groundColliders.push(collider));
+    (getPoiFloorId(sigmaPoi.definition) === 'upper'
+      ? upperPoiGroup
+      : groundStructureGroup
+    ).add(workbench.group);
+    workbench.colliders.forEach((collider) =>
+      (getPoiFloorId(sigmaPoi.definition) === 'upper'
+        ? upperFloorColliders
+        : groundColliders
+      ).push(collider)
+    );
     sigmaWorkbench = workbench;
   }
 
   if (wovePoi) {
-    const loomX = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : wovePoi.group.position.x;
-    const loomZ = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.6
-        )
-      : wovePoi.group.position.z;
+    const loomX = wovePoi.group.position.x;
+    const loomZ = wovePoi.group.position.z;
     const loom = createWoveLoom({
       position: {
         x: loomX,
@@ -3119,13 +3131,18 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         loom.colliders,
         woveSceneObject,
-        groundColliders,
+        getPoiFloorId(wovePoi.definition) === 'upper'
+          ? upperFloorColliders
+          : groundColliders,
         colliderSourceMetadata
       );
     } else {
       loom.colliders.forEach((collider) => groundColliders.push(collider));
     }
-    groundStructureGroup.add(loom.group);
+    (getPoiFloorId(wovePoi.definition) === 'upper'
+      ? upperPoiGroup
+      : groundStructureGroup
+    ).add(loom.group);
     woveLoom = loom;
   }
 

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -357,47 +357,17 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.flywheel',
           'studio',
-          { x: 5.5, z: -2 },
+          { x: 9.035, y: 0.75, z: 0.745 },
           0,
           'POI showpiece and info panel with factory-owned solid colliders'
         ),
         sceneObject(
-          'jobbot-studio-terminal',
-          'ground.studio.jobbot_terminal.scene_object',
-          'ground',
-          'showpiece.jobbot_terminal',
-          'studio',
-          { x: 12, z: 2 },
-          -Math.PI / 2,
-          'POI terminal with factory-owned desk collider'
-        ),
-        sceneObject(
-          'axel-studio-tracker',
-          'ground.studio.axel_navigator.scene_object',
-          'ground',
-          'showpiece.axel_navigator',
-          'studio',
-          { x: 10, z: -2 },
-          Math.PI,
-          'POI navigator with factory-owned dais and console colliders'
-        ),
-        sceneObject(
-          'wove-kitchen-loom',
-          'ground.kitchen.wove_loom.scene_object',
-          'ground',
-          'showpiece.wove_loom',
-          'kitchen',
-          { x: -7.5, z: 2.5 },
-          Math.PI * 0.45,
-          'POI tactile loom with factory-owned table and loom colliders'
-        ),
-        sceneObject(
           'pr-reaper-backyard-console',
-          'ground.backyard.pr_reaper_console.scene_object',
+          'ground.studio.pr_reaper_console.scene_object',
           'ground',
           'showpiece.pr_reaper_console',
-          'backyard',
-          { x: 0, z: 10 },
+          'studio',
+          { x: 1.5, y: 0.75, z: 0.525 },
           Math.PI * 0.35,
           'Backyard POI console with factory-owned deck and console colliders'
         ),
@@ -623,6 +593,38 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           6,
           14,
           ['focusPods']
+        ),
+      ],
+      sceneObjects: [
+        sceneObject(
+          'jobbot-studio-terminal',
+          'upper.creators_studio.jobbot_terminal.scene_object',
+          'upper',
+          'showpiece.jobbot_terminal',
+          'creatorsStudio',
+          { x: -8.38, y: 4.91, z: -14.4 },
+          -Math.PI / 2,
+          'POI terminal with factory-owned desk collider'
+        ),
+        sceneObject(
+          'axel-studio-tracker',
+          'upper.creators_studio.axel_navigator.scene_object',
+          'upper',
+          'showpiece.axel_navigator',
+          'creatorsStudio',
+          { x: -6.21, y: 4.91, z: -9.59 },
+          Math.PI,
+          'POI navigator with factory-owned dais and console colliders'
+        ),
+        sceneObject(
+          'wove-kitchen-loom',
+          'upper.loft_library.wove_loom.scene_object',
+          'upper',
+          'showpiece.wove_loom',
+          'loftLibrary',
+          { x: 8.24, y: 4.91, z: 2.135 },
+          Math.PI * 0.45,
+          'POI tactile loom with factory-owned table and loom colliders'
         ),
       ],
       roomConnections: [

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -23,35 +23,40 @@ describe('applyManualPoiPlacements', () => {
       id: PoiId;
       roomId: string;
       x: number;
+      y: number;
       z: number;
       headingRadians: number;
     }> = [
       {
         id: 'flywheel-studio-flywheel',
         roomId: 'studio',
-        x: 11,
-        z: -4,
+        x: 18.07,
+        y: 0.75,
+        z: 1.49,
         headingRadians: 0,
       },
       {
         id: 'jobbot-studio-terminal',
-        roomId: 'studio',
-        x: 24,
-        z: 4,
+        roomId: 'creatorsStudio',
+        x: -16.76,
+        y: 4.91,
+        z: -28.8,
         headingRadians: -Math.PI / 2,
       },
       {
         id: 'axel-studio-tracker',
-        roomId: 'studio',
-        x: 20,
-        z: -4,
+        roomId: 'creatorsStudio',
+        x: -12.42,
+        y: 4.91,
+        z: -19.18,
         headingRadians: Math.PI,
       },
       {
         id: 'wove-kitchen-loom',
-        roomId: 'kitchen',
-        x: -15,
-        z: 5,
+        roomId: 'loftLibrary',
+        x: 16.48,
+        y: 4.91,
+        z: 4.27,
         headingRadians: Math.PI * 0.45,
       },
     ];
@@ -64,7 +69,7 @@ describe('applyManualPoiPlacements', () => {
       expect(poi.id).toBe(nextExpected.id);
       expect(poi.roomId).toBe(nextExpected.roomId);
       expect(poi.position.x).toBeCloseTo(nextExpected.x);
-      expect(poi.position.y).toBe(0.5);
+      expect(poi.position.y).toBe(nextExpected.y);
       expect(poi.position.z).toBeCloseTo(nextExpected.z);
       expect(poi.headingRadians).toBeCloseTo(nextExpected.headingRadians);
     }

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -61,37 +61,44 @@ export const MANUAL_POI_PLACEMENTS: Partial<
     }
   >
 > = {
-  // Living room (center-biased spread)
-  'gitshelves-living-room-installation': {
+  'futuroptimist-living-room-tv': {
     roomId: 'livingRoom',
-    position: { x: -15, z: -25 },
-    headingRadians: Math.PI * 0.1,
+    position: { x: -30.94, y: 0.75, z: -20 },
+    headingRadians: Math.PI * 0.5,
+  },
+  'tokenplace-studio-cluster': {
+    roomId: 'livingRoom',
+    position: { x: -22.34, y: 0.75, z: -22.61 },
+    headingRadians: Math.PI * 0.05,
+  },
+  'sugarkube-backyard-greenhouse': {
+    roomId: 'livingRoom',
+    position: { x: -8.74, y: 0.75, z: -22.92 },
+    headingRadians: Math.PI * 0.55,
   },
   'danielsmith-portfolio-table': {
-    roomId: 'livingRoom',
-    position: { x: 3, z: -28 },
+    roomId: 'kitchen',
+    position: { x: -21.6, y: 0.75, z: 1.63 },
     headingRadians: 0,
   },
   'gabriel-studio-sentry': {
-    roomId: 'studio',
-    position: { x: 2, z: 8 },
+    roomId: 'creatorsStudio',
+    position: { x: -17.28, y: 4.91, z: -7.02 },
     headingRadians: -Math.PI * 0.3,
   },
-  'tokenplace-studio-cluster': {
-    roomId: 'studio',
-    position: { x: 6, z: 2 },
-    headingRadians: Math.PI * 0.05,
+  'gitshelves-living-room-installation': {
+    roomId: 'focusPods',
+    position: { x: -16.87, y: 4.91, z: 17.23 },
+    headingRadians: Math.PI * 0.1,
   },
-
-  // Kitchen (three exhibits around center)
   'f2clipboard-kitchen-console': {
-    roomId: 'kitchen',
-    position: { x: -20, z: -4 },
+    roomId: 'focusPods',
+    position: { x: -0.63, y: 4.91, z: 14.03 },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
-    roomId: 'kitchen',
-    position: { x: -25, z: 6 },
+    roomId: 'focusPods',
+    position: { x: 16.59, y: 4.91, z: 17.66 },
     headingRadians: Math.PI * 0.1,
   },
 };

--- a/src/scene/poi/productionPlacements.test.ts
+++ b/src/scene/poi/productionPlacements.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPoiFloorResolver } from '../floors/visibilityController';
+import { PORTFOLIO_LEVEL } from '../level/portfolioLevel';
+import { createSceneObjectDefinitionsById } from '../level/sceneObjects';
+
+import { getPoiDefinitions } from './registry';
+import type { PoiDefinition, PoiId } from './types';
+
+const getPoiFloorId = createPoiFloorResolver(
+  PORTFOLIO_LEVEL.floors.map((floor) => ({
+    id: floor.id,
+    name: floor.name,
+    plan: { outline: floor.outline, rooms: floor.rooms },
+  }))
+);
+
+const definitions = new Map(getPoiDefinitions().map((poi) => [poi.id, poi]));
+const sceneObjects = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
+
+const expectPosition = (
+  poi: PoiDefinition,
+  expected: { x: number; y: number; z: number }
+) => {
+  expect(poi.position.x).toBeCloseTo(expected.x, 2);
+  expect(poi.position.y).toBeCloseTo(expected.y, 2);
+  expect(poi.position.z).toBeCloseTo(expected.z, 2);
+};
+
+describe('production POI placements', () => {
+  it('resolves launch POIs to requested world positions and floors', () => {
+    const expected: Array<{
+      id: PoiId;
+      floor: 'ground' | 'upper';
+      position: { x: number; y: number; z: number };
+    }> = [
+      {
+        id: 'tokenplace-studio-cluster',
+        floor: 'ground',
+        position: { x: -22.34, y: 0.75, z: -22.61 },
+      },
+      {
+        id: 'sugarkube-backyard-greenhouse',
+        floor: 'ground',
+        position: { x: -8.74, y: 0.75, z: -22.92 },
+      },
+      {
+        id: 'danielsmith-portfolio-table',
+        floor: 'ground',
+        position: { x: -21.6, y: 0.75, z: 1.63 },
+      },
+      {
+        id: 'pr-reaper-backyard-console',
+        floor: 'ground',
+        position: { x: 3, y: 0.75, z: 1.05 },
+      },
+      {
+        id: 'flywheel-studio-flywheel',
+        floor: 'ground',
+        position: { x: 18.07, y: 0.75, z: 1.49 },
+      },
+      {
+        id: 'jobbot-studio-terminal',
+        floor: 'upper',
+        position: { x: -16.76, y: 4.91, z: -28.8 },
+      },
+      {
+        id: 'axel-studio-tracker',
+        floor: 'upper',
+        position: { x: -12.42, y: 4.91, z: -19.18 },
+      },
+      {
+        id: 'gabriel-studio-sentry',
+        floor: 'upper',
+        position: { x: -17.28, y: 4.91, z: -7.02 },
+      },
+      {
+        id: 'wove-kitchen-loom',
+        floor: 'upper',
+        position: { x: 16.48, y: 4.91, z: 4.27 },
+      },
+      {
+        id: 'sigma-kitchen-workbench',
+        floor: 'upper',
+        position: { x: 16.59, y: 4.91, z: 17.66 },
+      },
+      {
+        id: 'f2clipboard-kitchen-console',
+        floor: 'upper',
+        position: { x: -0.63, y: 4.91, z: 14.03 },
+      },
+      {
+        id: 'gitshelves-living-room-installation',
+        floor: 'upper',
+        position: { x: -16.87, y: 4.91, z: 17.23 },
+      },
+    ];
+
+    for (const { id, floor, position } of expected) {
+      const poi = definitions.get(id);
+      expect(poi, id).toBeDefined();
+      expect(getPoiFloorId(poi!), id).toBe(floor);
+      expectPosition(poi!, position);
+    }
+  });
+
+  it('keeps DSPACE placement, floor, and orientation unchanged', () => {
+    const dspace = definitions.get('dspace-backyard-rocket');
+    expect(dspace).toBeDefined();
+    expect(getPoiFloorId(dspace!)).toBe('ground');
+    expectPosition(dspace!, { x: -12, y: 0, z: 24 });
+    expect(dspace!.headingRadians).toBeCloseTo(-Math.PI / 10);
+  });
+
+  it('keeps danielsmith.io and pr-reaper independently reachable', () => {
+    const portfolio = definitions.get('danielsmith-portfolio-table');
+    const reaper = definitions.get('pr-reaper-backyard-console');
+    expect(portfolio).toBeDefined();
+    expect(reaper).toBeDefined();
+    expect(portfolio!.position).not.toEqual(reaper!.position);
+    expect(portfolio!.interactionRadius).toBeGreaterThan(0);
+    expect(reaper!.interactionRadius).toBeGreaterThan(0);
+  });
+
+  it('preserves canonical POI IDs and external links', () => {
+    expect(definitions.has('tokenplace-studio-cluster')).toBe(true);
+    expect(definitions.has('pr-reaper-backyard-console')).toBe(true);
+    expect(definitions.get('tokenplace-studio-cluster')?.links?.[0]?.href).toBe(
+      'https://token.place'
+    );
+    expect(
+      definitions.get('pr-reaper-backyard-console')?.links?.[0]?.href
+    ).toBe('https://github.com/futuroptimist/pr-reaper');
+  });
+
+  it('keeps moved showpiece scene objects on matching floors', () => {
+    const expectations = new Map<PoiId, 'ground' | 'upper'>([
+      ['flywheel-studio-flywheel', 'ground'],
+      ['jobbot-studio-terminal', 'upper'],
+      ['axel-studio-tracker', 'upper'],
+      ['wove-kitchen-loom', 'upper'],
+      ['pr-reaper-backyard-console', 'ground'],
+    ]);
+
+    for (const [id, floor] of expectations) {
+      expect(sceneObjects.get(id)?.floorId).toBe(floor);
+      expect(getPoiFloorId(definitions.get(id)!)).toBe(floor);
+    }
+  });
+});

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -1,4 +1,4 @@
-import { FLOOR_PLAN } from '../../assets/floorPlan';
+import { FLOOR_PLAN, FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
 import {
   formatMessage,
   getControlOverlayStrings,
@@ -284,7 +284,10 @@ export function localizePoiDefinitions(input?: LocaleInput): PoiDefinition[] {
   // Deterministically lay out indoor POIs across downstairs rooms.
   // Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
   const definitions = applyManualPoiPlacements(localized);
-  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  assertValidPoiDefinitions(definitions, {
+    floorPlan: FLOOR_PLAN,
+    floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
+  });
   return definitions.map((definition) => clonePoi(definition));
 }
 
@@ -400,7 +403,9 @@ export function getPoiDefinitionsByCategory(
 }
 
 export function isPoiInsideRoom(poi: PoiDefinition): boolean {
-  const room = FLOOR_PLAN.rooms.find((entry) => entry.id === poi.roomId);
+  const room = FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).find(
+    (entry) => entry.id === poi.roomId
+  );
   if (!room) {
     return false;
   }
@@ -413,6 +418,8 @@ export function isPoiInsideRoom(poi: PoiDefinition): boolean {
 
 export function getPoiRoomBounds(poi: PoiDefinition) {
   return (
-    FLOOR_PLAN.rooms.find((room) => room.id === poi.roomId)?.bounds ?? null
+    FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).find(
+      (room) => room.id === poi.roomId
+    )?.bounds ?? null
   );
 }

--- a/src/scene/poi/validation.ts
+++ b/src/scene/poi/validation.ts
@@ -26,6 +26,7 @@ export type PoiValidationIssue =
 
 export interface PoiValidationOptions {
   floorPlan: FloorPlanDefinition;
+  floorPlans?: readonly FloorPlanDefinition[];
   /** Optional epsilon for floating point comparisons. */
   epsilon?: number;
   /** Allow small overlaps when POIs are conceptually the same exhibit. */
@@ -57,17 +58,27 @@ export function validatePoiDefinitions(
   definitions: PoiDefinition[],
   options: PoiValidationOptions
 ): PoiValidationIssue[] {
-  const { floorPlan } = options;
+  const floorPlans = options.floorPlans ?? [options.floorPlan];
   const { epsilon, allowOverlapFor } = { ...defaultOptions, ...options };
 
   const issues: PoiValidationIssue[] = [];
   const seen = new Map<PoiId, PoiDefinition>();
-  const roomLookup = new Map(floorPlan.rooms.map((room) => [room.id, room]));
-  const clearances = getDoorwayClearanceZones(floorPlan);
-  const clearancesByRoom = new Map<string, DoorwayClearanceZone[]>(
-    floorPlan.rooms.map((room) => [room.id, []])
+  const roomLookup = new Map(
+    floorPlans.flatMap((plan) =>
+      plan.rooms.map((room) => [room.id, room] as const)
+    )
   );
-  clearances.forEach((zone) => {
+  const floorByRoom = new Map(
+    floorPlans.flatMap((plan, floorIndex) =>
+      plan.rooms.map((room) => [room.id, floorIndex] as const)
+    )
+  );
+  const clearancesByRoom = new Map<string, DoorwayClearanceZone[]>(
+    floorPlans.flatMap((plan) =>
+      plan.rooms.map((room) => [room.id, []] as const)
+    )
+  );
+  floorPlans.flatMap(getDoorwayClearanceZones).forEach((zone) => {
     const list = clearancesByRoom.get(zone.roomId);
     if (list) {
       list.push(zone);
@@ -147,6 +158,10 @@ export function validatePoiDefinitions(
     for (let j = i + 1; j < pairs; j += 1) {
       const b = definitions[j];
       if (!b) continue;
+
+      if (floorByRoom.get(a.roomId) !== floorByRoom.get(b.roomId)) {
+        continue;
+      }
 
       if (allowOverlapSet.has(a.id) && allowOverlapSet.has(b.id)) {
         continue;

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -506,7 +506,7 @@ export function createLivingRoomMediaWall(
   const policy = FUTUROPTIMIST_MEDIA_WALL_POLICY;
 
   const wallInteriorX = bounds.minX + 0.12;
-  const anchorZ = MathUtils.clamp(-14.2, bounds.minZ + 3, bounds.maxZ - 3);
+  const anchorZ = (bounds.minZ + bounds.maxZ) / 2;
 
   const boardWidth = 6.4;
   const boardHeight = 3.6;

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import {
   getPoiDefinitions,
   getPoiDefinitionsByCategory,
@@ -40,7 +40,11 @@ describe('POI registry', () => {
   });
 
   it('references rooms that exist in the floor plan', () => {
-    const roomIds = new Set(FLOOR_PLAN.rooms.map((room) => room.id));
+    const roomIds = new Set(
+      FLOOR_PLAN_LEVELS.flatMap((level) =>
+        level.plan.rooms.map((room) => room.id)
+      )
+    );
     pois.forEach((poi) => {
       expect(roomIds.has(poi.roomId)).toBe(true);
     });
@@ -87,7 +91,7 @@ describe('POI registry', () => {
       (poi) => poi.id === 'sugarkube-backyard-greenhouse'
     );
     expect(greenhouse).toBeDefined();
-    expect(greenhouse?.roomId).toBe('backyard');
+    expect(greenhouse?.roomId).toBe('livingRoom');
     expect(greenhouse?.interactionRadius).toBeGreaterThan(2);
     expect(greenhouse?.footprint.width).toBeGreaterThan(3);
     expect(
@@ -115,11 +119,8 @@ describe('POI registry', () => {
 
   it('exposes stable room-level ordering with defensive copies', () => {
     const expectedStudioOrder = [
-      'tokenplace-studio-cluster',
-      'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
-      'jobbot-studio-terminal',
-      'axel-studio-tracker',
+      'pr-reaper-backyard-console',
     ];
 
     const firstCall = getPoiDefinitionsByRoom('studio');

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN, FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import { getPoiDefinitions } from '../scene/poi/registry';
 import type { PoiDefinition } from '../scene/poi/types';
 import {
@@ -32,6 +32,7 @@ describe('validatePoiDefinitions', () => {
   it('returns no issues for baseline registry', () => {
     const issues = validatePoiDefinitions(baseDefinitions, {
       floorPlan: FLOOR_PLAN,
+      floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
     });
     expect(issues).toHaveLength(0);
   });
@@ -43,6 +44,7 @@ describe('validatePoiDefinitions', () => {
     };
     const issues = validatePoiDefinitions([...baseDefinitions, duplicate], {
       floorPlan: FLOOR_PLAN,
+      floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
     });
     expect(issues).toContainEqual({
       type: 'duplicate-id',
@@ -56,6 +58,7 @@ describe('validatePoiDefinitions', () => {
       [...baseDefinitions, invalidRoomPoi],
       {
         floorPlan: FLOOR_PLAN,
+        floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
       }
     );
     expect(issues).toContainEqual({
@@ -73,6 +76,7 @@ describe('validatePoiDefinitions', () => {
       [...baseDefinitions, invalidPositionPoi],
       {
         floorPlan: FLOOR_PLAN,
+        floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
       }
     );
     expect(
@@ -102,6 +106,7 @@ describe('validatePoiDefinitions', () => {
     });
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
       floorPlan: FLOOR_PLAN,
+      floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
     });
     expect(issues).toContainEqual({
       type: 'overlap',
@@ -123,6 +128,7 @@ describe('validatePoiDefinitions', () => {
 
     const issues = validatePoiDefinitions([...baseDefinitions, doorwayPoi], {
       floorPlan: FLOOR_PLAN,
+      floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
     });
 
     expect(issues).toContainEqual({
@@ -161,6 +167,7 @@ describe('validatePoiDefinitions', () => {
 
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
       floorPlan: FLOOR_PLAN,
+      floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
     });
 
     expect(issues).toContainEqual({
@@ -189,9 +196,17 @@ describe('validatePoiDefinitions', () => {
     });
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
       floorPlan: FLOOR_PLAN,
+      floorPlans: FLOOR_PLAN_LEVELS.map((level) => level.plan),
       allowOverlapFor: [poiA.id, poiB.id],
     });
-    expect(issues.every((issue) => issue.type !== 'overlap')).toBe(true);
+    expect(
+      issues.some(
+        (issue) =>
+          issue.type === 'overlap' &&
+          issue.poiId === poiA.id &&
+          issue.otherPoiId === poiB.id
+      )
+    ).toBe(false);
   });
 });
 

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -66,7 +66,7 @@ afterAll(() => {
 const definitionsById = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
 
 type MigratedFactoryPlacement = {
-  position: { x: number; z: number };
+  position: { x: number; y?: number; z: number };
   orientation: number;
 };
 
@@ -81,7 +81,7 @@ type MigratedFactory = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
+    placement: { position: { x: 9.035, y: 0.75, z: 0.745 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
         centerX: position.x,
@@ -92,37 +92,49 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
+    placement: {
+      position: { x: -8.38, y: 4.91, z: -14.4 },
+      orientation: -Math.PI / 2,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'axel-studio-tracker',
-    placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
+    placement: {
+      position: { x: -6.21, y: 4.91, z: -9.59 },
+      orientation: Math.PI,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'wove-kitchen-loom',
-    placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
+    placement: {
+      position: { x: 8.24, y: 4.91, z: 2.135 },
+      orientation: Math.PI * 0.45,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'pr-reaper-backyard-console',
-    placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
+    placement: {
+      position: { x: 1.5, y: 0.75, z: 0.525 },
+      orientation: Math.PI * 0.35,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },


### PR DESCRIPTION
### Motivation
- Redistribute prominent launch POIs so important projects are closer to spawn and less-prominent projects occupy the sparse upper floor, while moving each complete installation (visuals, anchors, colliders, metadata) together and preserving DSPACE exactly.

### Description
- Update canonical placement records by modifying `MANUAL_POI_PLACEMENTS` and declarative `sceneObject(...)` entries so POIs resolve to the requested world-space anchors and floors (ground y=0.75, upper y=4.91) without creating new POI ids.
- Move scene-object-backed showpieces between floors in `src/scene/level/portfolioLevel.ts` (Jobbot/Axel/Wove -> upper; Flywheel/Pr-Reaper -> ground) and keep orientations unchanged.
- Make runtime assembly floor-aware in `src/main.ts` so groups and colliders are added to `upperPoiGroup` / `upperFloorColliders` when `getPoiFloorId(...)` resolves to upper, ensuring full installations (models, colliders, lights, audio) migrate together.
- Compute the Futuroptimist TV anchor from canonical living-room wall geometry by centering the media wall Z anchor from room bounds in `src/scene/structures/mediaWall.ts` instead of using the previous sampled value.
- Extend POI validation and registry to be multi-floor aware and keep overlap checks floor-local in `src/scene/poi/validation.ts` and `src/scene/poi/registry.ts` so upstairs vs ground placements do not conflict across floors.
- Add focused production placement regression tests (`src/scene/poi/productionPlacements.test.ts`) and adjust placement tests to assert exact world positions, floor affiliation, and that DSPACE remains unchanged.

### Testing
- `npm run lint` — passed.
- `npm run test:ci` — Vitest suites executed; focused placement tests and full test run passed (focused suites and full test run succeeded in CI invocation reported in the transcript).
- `npm run docs:check` — passed (link-check issued external fetch warnings but no blocking failures).
- `npm run smoke` — passed (production `vite build` and `scripts/assert-dist.cjs` checks passed).
- `npm run collider:audit:redundancy` and `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-poi-layout.json` — redundancy gate passed with `Failures: 0` and reported warnings (33) about anonymous/generated colliders; JSON output produced.
- Visual preview: started Vite preview and loaded `http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1` with Playwright; screenshot saved to `/tmp/poi-layout-immersive.png` and no browser console errors were observed.
- `npm run typecheck` — reported pre-existing baseline TypeScript errors unrelated to these placement changes; those baseline issues were preserved and reported rather than being introduced by this PR.

If reviewers want follow-ups: I can (a) add source/debug metadata to the anonymous colliders to clear collider-audit warnings, and (b) break the typecheck baseline fixes into a separate PR so this placement change remains minimal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3abe03a6d0832fa89bf4a3a034e0e6)