### PR TITLE
🗺️ : – redistribute launch POIs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -236,6 +236,7 @@ import {
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
+import { getPoiInteractionAnchorPosition } from './scene/poi/placements';
 import { getPoiDefinitions } from './scene/poi/registry';
 import {
   injectPoiStructuredData,
@@ -6157,9 +6158,10 @@ function initializeImmersiveScene(
         poi.label.lookAt(poiLabelLookTarget);
       }
 
+      const interactionAnchor = getPoiInteractionAnchorPosition(poi.definition);
       poiPlayerOffset.set(
-        player.position.x - poi.group.position.x,
-        player.position.z - poi.group.position.z
+        player.position.x - interactionAnchor.x,
+        player.position.z - interactionAnchor.z
       );
       const planarDistance = poiPlayerOffset.length();
       const maxRadius = poi.definition.interactionRadius;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1863,6 +1863,10 @@ function initializeImmersiveScene(
   groundStructureGroup.name = 'GroundStructureVisuals';
   scene.add(groundStructureGroup);
 
+  const upperStructureGroup = new Group();
+  upperStructureGroup.name = 'UpperStructureVisuals';
+  scene.add(upperStructureGroup);
+
   const backyardRoom = FLOOR_PLAN.rooms.find(
     (room) => room.id === BACKYARD_ROOM_ID
   );
@@ -2470,7 +2474,7 @@ function initializeImmersiveScene(
         groundEnvironmentGroup,
         groundStructureGroup,
       ],
-      upperGroups: [upperFloorGroup, upperPoiGroup],
+      upperGroups: [upperFloorGroup, upperPoiGroup, upperStructureGroup],
       groundLedGroups: [ledStripGroup, ledFillLightGroup].filter(
         (group): group is Group => group !== null
       ),
@@ -2869,8 +2873,16 @@ function initializeImmersiveScene(
     (poi) => poi.definition.id === 'pr-reaper-backyard-console'
   );
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
-  const kitchenRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'kitchen');
-  const kitchenBounds = kitchenRoom?.bounds;
+  const addPoiStructure = (poi: PoiInstance, group: Object3D) => {
+    (getPoiFloorId(poi.definition) === 'upper'
+      ? upperStructureGroup
+      : groundStructureGroup
+    ).add(group);
+  };
+  const getPoiColliderTarget = (poi: PoiInstance) =>
+    getPoiFloorId(poi.definition) === 'upper'
+      ? upperFloorColliders
+      : groundColliders;
   if (studioRoom) {
     const centerX =
       flywheelPoi?.group.position.x ??
@@ -2903,18 +2915,12 @@ function initializeImmersiveScene(
     flywheelShowpiece = showpiece;
 
     const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
-    const terminalX = MathUtils.clamp(
-      jobbotPoi?.group.position.x ?? 11.4,
-      studioRoom.bounds.minX + 1.2,
-      studioRoom.bounds.maxX - 0.8
-    );
-    const terminalZ = MathUtils.clamp(
-      jobbotPoi?.group.position.z ?? -0.6,
-      studioRoom.bounds.minZ + 1.2,
-      studioRoom.bounds.maxZ - 1.1
-    );
     const terminal = createJobbotTerminal({
-      position: { x: terminalX, y: 0, z: terminalZ },
+      position: {
+        x: jobbotPoi?.group.position.x ?? 11.4,
+        y: jobbotPoi?.group.position.y ?? 0,
+        z: jobbotPoi?.group.position.z ?? -0.6,
+      },
       orientationRadians: terminalOrientation,
       detailPolicy: activeSceneDetailPolicy,
     });
@@ -2926,13 +2932,15 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         terminal.colliders,
         jobbotSceneObject,
-        groundColliders,
+        getPoiColliderTarget(jobbotPoi!),
         colliderSourceMetadata
       );
     } else {
-      terminal.colliders.forEach((collider) => groundColliders.push(collider));
+      terminal.colliders.forEach((collider) =>
+        getPoiColliderTarget(jobbotPoi!).push(collider)
+      );
     }
-    groundStructureGroup.add(terminal.group);
+    if (jobbotPoi) addPoiStructure(jobbotPoi, terminal.group);
     jobbotTerminal = terminal;
 
     if (axelPoi) {
@@ -2950,15 +2958,15 @@ function initializeImmersiveScene(
         registerSceneObjectColliders(
           navigator.colliders,
           axelSceneObject,
-          groundColliders,
+          getPoiColliderTarget(axelPoi),
           colliderSourceMetadata
         );
       } else {
         navigator.colliders.forEach((collider) =>
-          groundColliders.push(collider)
+          getPoiColliderTarget(axelPoi).push(collider)
         );
       }
-      groundStructureGroup.add(navigator.group);
+      addPoiStructure(axelPoi, navigator.group);
       axelNavigator = navigator;
     }
 
@@ -2971,8 +2979,10 @@ function initializeImmersiveScene(
         },
         orientationRadians: tokenPlacePoi.group.rotation.y ?? 0,
       });
-      groundStructureGroup.add(rack.group);
-      rack.colliders.forEach((collider) => groundColliders.push(collider));
+      addPoiStructure(tokenPlacePoi, rack.group);
+      rack.colliders.forEach((collider) =>
+        getPoiColliderTarget(tokenPlacePoi).push(collider)
+      );
       tokenPlaceRack = rack;
     }
 
@@ -2985,8 +2995,10 @@ function initializeImmersiveScene(
         },
         orientationRadians: gabrielPoi.group.rotation.y ?? 0,
       });
-      groundStructureGroup.add(sentry.group);
-      sentry.colliders.forEach((collider) => groundColliders.push(collider));
+      addPoiStructure(gabrielPoi, sentry.group);
+      sentry.colliders.forEach((collider) =>
+        getPoiColliderTarget(gabrielPoi).push(collider)
+      );
       gabrielSentry = sentry;
     }
   }
@@ -3008,13 +3020,15 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         console.colliders,
         prReaperSceneObject,
-        groundColliders,
+        getPoiColliderTarget(prReaperPoi),
         colliderSourceMetadata
       );
     } else {
-      console.colliders.forEach((collider) => groundColliders.push(collider));
+      console.colliders.forEach((collider) =>
+        getPoiColliderTarget(prReaperPoi).push(collider)
+      );
     }
-    groundStructureGroup.add(console.group);
+    addPoiStructure(prReaperPoi, console.group);
     prReaperConsole = console;
   }
 
@@ -3027,89 +3041,51 @@ function initializeImmersiveScene(
       },
       orientationRadians: gitshelvesPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(installation.group);
+    addPoiStructure(gitshelvesPoi, installation.group);
     installation.colliders.forEach((collider) =>
-      groundColliders.push(collider)
+      getPoiColliderTarget(gitshelvesPoi).push(collider)
     );
     gitshelvesInstallation = installation;
   }
 
   if (f2ClipboardPoi) {
-    const consoleX = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : f2ClipboardPoi.group.position.x;
-    const consoleZ = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.8
-        )
-      : f2ClipboardPoi.group.position.z;
     const console = createF2ClipboardConsole({
       position: {
-        x: consoleX,
+        x: f2ClipboardPoi.group.position.x,
         y: f2ClipboardPoi.group.position.y,
-        z: consoleZ,
+        z: f2ClipboardPoi.group.position.z,
       },
       orientationRadians: f2ClipboardPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(console.group);
-    console.colliders.forEach((collider) => groundColliders.push(collider));
+    addPoiStructure(f2ClipboardPoi, console.group);
+    console.colliders.forEach((collider) =>
+      getPoiColliderTarget(f2ClipboardPoi).push(collider)
+    );
     f2ClipboardConsole = console;
   }
 
   if (sigmaPoi) {
-    const benchX = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.x,
-          kitchenBounds.minX + 0.9,
-          kitchenBounds.maxX - 0.9
-        )
-      : sigmaPoi.group.position.x;
-    const benchZ = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.z,
-          kitchenBounds.minZ + 0.9,
-          kitchenBounds.maxZ - 0.9
-        )
-      : sigmaPoi.group.position.z;
     const workbench = createSigmaWorkbench({
       position: {
-        x: benchX,
+        x: sigmaPoi.group.position.x,
         y: sigmaPoi.group.position.y,
-        z: benchZ,
+        z: sigmaPoi.group.position.z,
       },
       orientationRadians: sigmaPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(workbench.group);
-    workbench.colliders.forEach((collider) => groundColliders.push(collider));
+    addPoiStructure(sigmaPoi, workbench.group);
+    workbench.colliders.forEach((collider) =>
+      getPoiColliderTarget(sigmaPoi).push(collider)
+    );
     sigmaWorkbench = workbench;
   }
 
   if (wovePoi) {
-    const loomX = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : wovePoi.group.position.x;
-    const loomZ = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.6
-        )
-      : wovePoi.group.position.z;
     const loom = createWoveLoom({
       position: {
-        x: loomX,
+        x: wovePoi.group.position.x,
         y: wovePoi.group.position.y,
-        z: loomZ,
+        z: wovePoi.group.position.z,
       },
       orientationRadians: wovePoi.group.rotation.y ?? 0,
     });
@@ -3119,13 +3095,15 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         loom.colliders,
         woveSceneObject,
-        groundColliders,
+        getPoiColliderTarget(wovePoi),
         colliderSourceMetadata
       );
     } else {
-      loom.colliders.forEach((collider) => groundColliders.push(collider));
+      loom.colliders.forEach((collider) =>
+        getPoiColliderTarget(wovePoi).push(collider)
+      );
     }
-    groundStructureGroup.add(loom.group);
+    addPoiStructure(wovePoi, loom.group);
     woveLoom = loom;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2932,12 +2932,14 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         terminal.colliders,
         jobbotSceneObject,
-        getPoiColliderTarget(jobbotPoi!),
+        jobbotPoi ? getPoiColliderTarget(jobbotPoi) : groundColliders,
         colliderSourceMetadata
       );
     } else {
       terminal.colliders.forEach((collider) =>
-        getPoiColliderTarget(jobbotPoi!).push(collider)
+        (jobbotPoi ? getPoiColliderTarget(jobbotPoi) : groundColliders).push(
+          collider
+        )
       );
     }
     if (jobbotPoi) addPoiStructure(jobbotPoi, terminal.group);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2928,22 +2928,33 @@ function initializeImmersiveScene(
     const jobbotSceneObject = getSceneObjectDefinition(
       'jobbot-studio-terminal'
     );
+    const fallbackJobbotStructureGroup =
+      jobbotSceneObject?.floorId === 'upper'
+        ? upperStructureGroup
+        : groundStructureGroup;
+    const jobbotColliderTarget = jobbotPoi
+      ? getPoiColliderTarget(jobbotPoi)
+      : jobbotSceneObject?.floorId === 'upper'
+        ? upperFloorColliders
+        : groundColliders;
     if (jobbotSceneObject) {
       applySceneObjectSourceMetadata(terminal.group, jobbotSceneObject);
       registerSceneObjectColliders(
         terminal.colliders,
         jobbotSceneObject,
-        jobbotPoi ? getPoiColliderTarget(jobbotPoi) : groundColliders,
+        jobbotColliderTarget,
         colliderSourceMetadata
       );
     } else {
       terminal.colliders.forEach((collider) =>
-        (jobbotPoi ? getPoiColliderTarget(jobbotPoi) : groundColliders).push(
-          collider
-        )
+        jobbotColliderTarget.push(collider)
       );
     }
-    if (jobbotPoi) addPoiStructure(jobbotPoi, terminal.group);
+    if (jobbotPoi) {
+      addPoiStructure(jobbotPoi, terminal.group);
+    } else {
+      fallbackJobbotStructureGroup.add(terminal.group);
+    }
     jobbotTerminal = terminal;
 
     if (axelPoi) {

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -357,47 +357,17 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.flywheel',
           'studio',
-          { x: 5.5, z: -2 },
+          { x: 9.035, y: 0.75, z: 0.745 },
           0,
           'POI showpiece and info panel with factory-owned solid colliders'
         ),
         sceneObject(
-          'jobbot-studio-terminal',
-          'ground.studio.jobbot_terminal.scene_object',
-          'ground',
-          'showpiece.jobbot_terminal',
-          'studio',
-          { x: 12, z: 2 },
-          -Math.PI / 2,
-          'POI terminal with factory-owned desk collider'
-        ),
-        sceneObject(
-          'axel-studio-tracker',
-          'ground.studio.axel_navigator.scene_object',
-          'ground',
-          'showpiece.axel_navigator',
-          'studio',
-          { x: 10, z: -2 },
-          Math.PI,
-          'POI navigator with factory-owned dais and console colliders'
-        ),
-        sceneObject(
-          'wove-kitchen-loom',
-          'ground.kitchen.wove_loom.scene_object',
-          'ground',
-          'showpiece.wove_loom',
-          'kitchen',
-          { x: -7.5, z: 2.5 },
-          Math.PI * 0.45,
-          'POI tactile loom with factory-owned table and loom colliders'
-        ),
-        sceneObject(
           'pr-reaper-backyard-console',
-          'ground.backyard.pr_reaper_console.scene_object',
+          'ground.studio.pr_reaper_console.scene_object',
           'ground',
           'showpiece.pr_reaper_console',
-          'backyard',
-          { x: 0, z: 10 },
+          'studio',
+          { x: 1.5, y: 0.75, z: 0.525 },
           Math.PI * 0.35,
           'Backyard POI console with factory-owned deck and console colliders'
         ),
@@ -623,6 +593,38 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           6,
           14,
           ['focusPods']
+        ),
+      ],
+      sceneObjects: [
+        sceneObject(
+          'jobbot-studio-terminal',
+          'upper.creators_studio.jobbot_terminal.scene_object',
+          'upper',
+          'showpiece.jobbot_terminal',
+          'creatorsStudio',
+          { x: -8.38, y: 4.91, z: -14.4 },
+          -Math.PI / 2,
+          'POI terminal with factory-owned desk collider'
+        ),
+        sceneObject(
+          'axel-studio-tracker',
+          'upper.creators_studio.axel_navigator.scene_object',
+          'upper',
+          'showpiece.axel_navigator',
+          'creatorsStudio',
+          { x: -6.21, y: 4.91, z: -9.59 },
+          Math.PI,
+          'POI navigator with factory-owned dais and console colliders'
+        ),
+        sceneObject(
+          'wove-kitchen-loom',
+          'upper.loft_library.wove_loom.scene_object',
+          'upper',
+          'showpiece.wove_loom',
+          'loftLibrary',
+          { x: 8.24, y: 4.91, z: 2.135 },
+          Math.PI * 0.45,
+          'POI tactile loom with factory-owned table and loom colliders'
         ),
       ],
       roomConnections: [

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -357,7 +357,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.flywheel',
           'studio',
-          { x: 9.035, y: 0.75, z: 0.745 },
+          { x: 9.035, y: 0, z: 0.745 },
           0,
           'POI showpiece and info panel with factory-owned solid colliders'
         ),
@@ -367,9 +367,9 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.pr_reaper_console',
           'studio',
-          { x: 1.5, y: 0.75, z: 0.525 },
+          { x: 1.5, y: 0, z: 0.525 },
           Math.PI * 0.35,
-          'Backyard POI console with factory-owned deck and console colliders'
+          'Studio POI console with factory-owned deck and console colliders'
         ),
       ],
       roomConnections: [
@@ -602,7 +602,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.jobbot_terminal',
           'creatorsStudio',
-          { x: -8.38, y: 4.91, z: -14.4 },
+          { x: -8.38, y: 4.16, z: -14.4 },
           -Math.PI / 2,
           'POI terminal with factory-owned desk collider'
         ),
@@ -612,7 +612,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.axel_navigator',
           'creatorsStudio',
-          { x: -6.21, y: 4.91, z: -9.59 },
+          { x: -6.21, y: 4.16, z: -9.59 },
           Math.PI,
           'POI navigator with factory-owned dais and console colliders'
         ),
@@ -622,7 +622,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.wove_loom',
           'loftLibrary',
-          { x: 8.24, y: 4.91, z: 2.135 },
+          { x: 8.24, y: 4.16, z: 2.135 },
           Math.PI * 0.45,
           'POI tactile loom with factory-owned table and loom colliders'
         ),

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { applyManualPoiPlacements, MANUAL_POI_PLACEMENTS } from './placements';
+import { FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
+import { createPoiFloorResolver } from '../floors/visibilityController';
+
+import { applyManualPoiPlacements } from './placements';
 import type { PoiDefinition, PoiId } from './types';
 
 const definition = (id: PoiId): PoiDefinition => ({
@@ -17,42 +20,87 @@ const definition = (id: PoiId): PoiDefinition => ({
   interactionPrompt: 'Inspect',
 });
 
+const getPoiFloorId = createPoiFloorResolver(FLOOR_PLAN_LEVELS);
+
 describe('applyManualPoiPlacements', () => {
-  it('resolves migrated POI placements from PORTFOLIO_LEVEL scene objects', () => {
+  it('resolves launch POI placements to requested world positions and floors', () => {
     const expected: Array<{
       id: PoiId;
       roomId: string;
-      x: number;
-      z: number;
-      headingRadians: number;
+      floorId: 'ground' | 'upper';
+      position: { x: number; y: number; z: number };
     }> = [
+      {
+        id: 'tokenplace-studio-cluster',
+        roomId: 'livingRoom',
+        floorId: 'ground',
+        position: { x: -22.34, y: 0.75, z: -22.61 },
+      },
+      {
+        id: 'sugarkube-backyard-greenhouse',
+        roomId: 'livingRoom',
+        floorId: 'ground',
+        position: { x: -8.74, y: 0.75, z: -22.92 },
+      },
+      {
+        id: 'danielsmith-portfolio-table',
+        roomId: 'kitchen',
+        floorId: 'ground',
+        position: { x: -21.6, y: 0.75, z: 1.63 },
+      },
+      {
+        id: 'pr-reaper-backyard-console',
+        roomId: 'studio',
+        floorId: 'ground',
+        position: { x: 3, y: 0.75, z: 1.05 },
+      },
       {
         id: 'flywheel-studio-flywheel',
         roomId: 'studio',
-        x: 11,
-        z: -4,
-        headingRadians: 0,
+        floorId: 'ground',
+        position: { x: 18.07, y: 0.75, z: 1.49 },
       },
       {
         id: 'jobbot-studio-terminal',
-        roomId: 'studio',
-        x: 24,
-        z: 4,
-        headingRadians: -Math.PI / 2,
+        roomId: 'creatorsStudio',
+        floorId: 'upper',
+        position: { x: -16.76, y: 4.91, z: -28.8 },
       },
       {
         id: 'axel-studio-tracker',
-        roomId: 'studio',
-        x: 20,
-        z: -4,
-        headingRadians: Math.PI,
+        roomId: 'creatorsStudio',
+        floorId: 'upper',
+        position: { x: -12.42, y: 4.91, z: -19.18 },
+      },
+      {
+        id: 'gabriel-studio-sentry',
+        roomId: 'creatorsStudio',
+        floorId: 'upper',
+        position: { x: -17.28, y: 4.91, z: -7.02 },
       },
       {
         id: 'wove-kitchen-loom',
-        roomId: 'kitchen',
-        x: -15,
-        z: 5,
-        headingRadians: Math.PI * 0.45,
+        roomId: 'loftLibrary',
+        floorId: 'upper',
+        position: { x: 16.48, y: 4.91, z: 4.27 },
+      },
+      {
+        id: 'sigma-kitchen-workbench',
+        roomId: 'focusPods',
+        floorId: 'upper',
+        position: { x: 16.59, y: 4.91, z: 17.66 },
+      },
+      {
+        id: 'f2clipboard-kitchen-console',
+        roomId: 'focusPods',
+        floorId: 'upper',
+        position: { x: -0.63, y: 4.91, z: 14.03 },
+      },
+      {
+        id: 'gitshelves-living-room-installation',
+        roomId: 'focusPods',
+        floorId: 'upper',
+        position: { x: -16.87, y: 4.91, z: 17.23 },
       },
     ];
     const placed = applyManualPoiPlacements(
@@ -63,27 +111,35 @@ describe('applyManualPoiPlacements', () => {
       const nextExpected = expected[index];
       expect(poi.id).toBe(nextExpected.id);
       expect(poi.roomId).toBe(nextExpected.roomId);
-      expect(poi.position.x).toBeCloseTo(nextExpected.x);
-      expect(poi.position.y).toBe(0.5);
-      expect(poi.position.z).toBeCloseTo(nextExpected.z);
-      expect(poi.headingRadians).toBeCloseTo(nextExpected.headingRadians);
+      expect(getPoiFloorId(poi)).toBe(nextExpected.floorId);
+      expect(poi.position.x).toBeCloseTo(nextExpected.position.x, 2);
+      expect(poi.position.y).toBeCloseTo(nextExpected.position.y, 2);
+      expect(poi.position.z).toBeCloseTo(nextExpected.position.z, 2);
     }
   });
 
-  it('leaves remaining manual placements intact', () => {
-    const ids = Object.keys(MANUAL_POI_PLACEMENTS) as PoiId[];
-    const placed = applyManualPoiPlacements(ids.map(definition));
+  it('keeps DSPACE placement, floor, and orientation unchanged', () => {
+    const placed = applyManualPoiPlacements([
+      definition('dspace-backyard-rocket'),
+    ])[0];
 
-    for (const poi of placed) {
-      const manual = MANUAL_POI_PLACEMENTS[poi.id];
-      expect(manual).toBeDefined();
-      expect(poi.roomId).toBe(manual?.roomId);
-      expect(poi.position).toEqual({
-        x: manual?.position.x,
-        y: manual?.position.y ?? 0.5,
-        z: manual?.position.z,
-      });
-      expect(poi.headingRadians).toBe(manual?.headingRadians ?? 0.25);
-    }
+    expect(placed.roomId).toBe('original-room');
+    expect(placed.position).toEqual({ x: 1, y: 0.5, z: 2 });
+    expect(placed.headingRadians).toBe(0.25);
+  });
+
+  it('keeps danielsmith.io and pr-reaper independently positioned', () => {
+    const [portfolio, reaper] = applyManualPoiPlacements([
+      definition('danielsmith-portfolio-table'),
+      definition('pr-reaper-backyard-console'),
+    ]);
+
+    expect(portfolio.position.x).toBeCloseTo(-21.6, 2);
+    expect(portfolio.position.y).toBeCloseTo(0.75, 2);
+    expect(portfolio.position.z).toBeCloseTo(1.63, 2);
+    expect(reaper.position.x).toBeCloseTo(3, 2);
+    expect(reaper.position.y).toBeCloseTo(0.75, 2);
+    expect(reaper.position.z).toBeCloseTo(1.05, 2);
+    expect(portfolio.position).not.toEqual(reaper.position);
   });
 });

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
 import { createPoiFloorResolver } from '../floors/visibilityController';
 
-import { applyManualPoiPlacements } from './placements';
+import {
+  applyManualPoiPlacements,
+  getPoiInteractionAnchorPosition,
+} from './placements';
 import type { PoiDefinition, PoiId } from './types';
 
 const definition = (id: PoiId): PoiDefinition => ({
@@ -29,77 +32,90 @@ describe('applyManualPoiPlacements', () => {
       roomId: string;
       floorId: 'ground' | 'upper';
       position: { x: number; y: number; z: number };
+      anchorY: number;
     }> = [
       {
         id: 'tokenplace-studio-cluster',
         roomId: 'livingRoom',
         floorId: 'ground',
+        anchorY: 0.75,
         position: { x: -22.34, y: 0, z: -22.61 },
       },
       {
         id: 'sugarkube-backyard-greenhouse',
         roomId: 'livingRoom',
         floorId: 'ground',
+        anchorY: 0.75,
         position: { x: -8.74, y: 0, z: -22.92 },
       },
       {
         id: 'danielsmith-portfolio-table',
         roomId: 'kitchen',
         floorId: 'ground',
+        anchorY: 0.75,
         position: { x: -21.6, y: 0, z: 1.63 },
       },
       {
         id: 'pr-reaper-backyard-console',
         roomId: 'studio',
         floorId: 'ground',
+        anchorY: 0.75,
         position: { x: 3, y: 0, z: 1.05 },
       },
       {
         id: 'flywheel-studio-flywheel',
         roomId: 'studio',
         floorId: 'ground',
+        anchorY: 0.75,
         position: { x: 18.07, y: 0, z: 1.49 },
       },
       {
         id: 'jobbot-studio-terminal',
         roomId: 'creatorsStudio',
         floorId: 'upper',
+        anchorY: 4.91,
         position: { x: -16.76, y: 4.16, z: -28.8 },
       },
       {
         id: 'axel-studio-tracker',
         roomId: 'creatorsStudio',
         floorId: 'upper',
+        anchorY: 4.91,
         position: { x: -12.42, y: 4.16, z: -19.18 },
       },
       {
         id: 'gabriel-studio-sentry',
         roomId: 'creatorsStudio',
         floorId: 'upper',
+        anchorY: 4.91,
         position: { x: -17.28, y: 4.16, z: -7.02 },
       },
       {
         id: 'wove-kitchen-loom',
         roomId: 'loftLibrary',
         floorId: 'upper',
+        anchorY: 4.91,
         position: { x: 16.48, y: 4.16, z: 4.27 },
       },
       {
         id: 'sigma-kitchen-workbench',
         roomId: 'focusPods',
         floorId: 'upper',
+        anchorY: 4.91,
         position: { x: 16.59, y: 4.16, z: 17.66 },
       },
       {
         id: 'f2clipboard-kitchen-console',
         roomId: 'focusPods',
         floorId: 'upper',
+        anchorY: 4.91,
         position: { x: -0.63, y: 4.16, z: 14.03 },
       },
       {
         id: 'gitshelves-living-room-installation',
         roomId: 'focusPods',
         floorId: 'upper',
+        anchorY: 4.91,
         position: { x: -16.87, y: 4.16, z: 17.23 },
       },
     ];
@@ -115,17 +131,24 @@ describe('applyManualPoiPlacements', () => {
       expect(poi.position.x).toBeCloseTo(nextExpected.position.x, 2);
       expect(poi.position.y).toBeCloseTo(nextExpected.position.y, 2);
       expect(poi.position.z).toBeCloseTo(nextExpected.position.z, 2);
+      const anchor = getPoiInteractionAnchorPosition(poi);
+      expect(anchor.x).toBeCloseTo(nextExpected.position.x, 2);
+      expect(anchor.y).toBeCloseTo(nextExpected.anchorY, 2);
+      expect(anchor.z).toBeCloseTo(nextExpected.position.z, 2);
     }
   });
 
-  it('keeps DSPACE room, placement, and orientation unchanged', () => {
-    const placed = applyManualPoiPlacements([
-      definition('dspace-backyard-rocket'),
-    ])[0];
+  it('keeps DSPACE placement, floor, and orientation unchanged', () => {
+    const dspace = definition('dspace-backyard-rocket');
+    dspace.roomId = 'backyard';
+    dspace.position = { x: -12, y: 0, z: 24 };
+    dspace.headingRadians = -Math.PI / 10;
+    const placed = applyManualPoiPlacements([dspace])[0];
 
-    expect(placed.roomId).toBe('original-room');
-    expect(placed.position).toEqual({ x: 1, y: 0.5, z: 2 });
-    expect(placed.headingRadians).toBe(0.25);
+    expect(placed.roomId).toBe('backyard');
+    expect(getPoiFloorId(placed)).toBe('ground');
+    expect(placed.position).toEqual({ x: -12, y: 0, z: 24 });
+    expect(placed.headingRadians).toBe(-Math.PI / 10);
   });
 
   it('keeps danielsmith.io and pr-reaper independently positioned', () => {

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -34,73 +34,73 @@ describe('applyManualPoiPlacements', () => {
         id: 'tokenplace-studio-cluster',
         roomId: 'livingRoom',
         floorId: 'ground',
-        position: { x: -22.34, y: 0.75, z: -22.61 },
+        position: { x: -22.34, y: 0, z: -22.61 },
       },
       {
         id: 'sugarkube-backyard-greenhouse',
         roomId: 'livingRoom',
         floorId: 'ground',
-        position: { x: -8.74, y: 0.75, z: -22.92 },
+        position: { x: -8.74, y: 0, z: -22.92 },
       },
       {
         id: 'danielsmith-portfolio-table',
         roomId: 'kitchen',
         floorId: 'ground',
-        position: { x: -21.6, y: 0.75, z: 1.63 },
+        position: { x: -21.6, y: 0, z: 1.63 },
       },
       {
         id: 'pr-reaper-backyard-console',
         roomId: 'studio',
         floorId: 'ground',
-        position: { x: 3, y: 0.75, z: 1.05 },
+        position: { x: 3, y: 0, z: 1.05 },
       },
       {
         id: 'flywheel-studio-flywheel',
         roomId: 'studio',
         floorId: 'ground',
-        position: { x: 18.07, y: 0.75, z: 1.49 },
+        position: { x: 18.07, y: 0, z: 1.49 },
       },
       {
         id: 'jobbot-studio-terminal',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        position: { x: -16.76, y: 4.91, z: -28.8 },
+        position: { x: -16.76, y: 4.16, z: -28.8 },
       },
       {
         id: 'axel-studio-tracker',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        position: { x: -12.42, y: 4.91, z: -19.18 },
+        position: { x: -12.42, y: 4.16, z: -19.18 },
       },
       {
         id: 'gabriel-studio-sentry',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        position: { x: -17.28, y: 4.91, z: -7.02 },
+        position: { x: -17.28, y: 4.16, z: -7.02 },
       },
       {
         id: 'wove-kitchen-loom',
         roomId: 'loftLibrary',
         floorId: 'upper',
-        position: { x: 16.48, y: 4.91, z: 4.27 },
+        position: { x: 16.48, y: 4.16, z: 4.27 },
       },
       {
         id: 'sigma-kitchen-workbench',
         roomId: 'focusPods',
         floorId: 'upper',
-        position: { x: 16.59, y: 4.91, z: 17.66 },
+        position: { x: 16.59, y: 4.16, z: 17.66 },
       },
       {
         id: 'f2clipboard-kitchen-console',
         roomId: 'focusPods',
         floorId: 'upper',
-        position: { x: -0.63, y: 4.91, z: 14.03 },
+        position: { x: -0.63, y: 4.16, z: 14.03 },
       },
       {
         id: 'gitshelves-living-room-installation',
         roomId: 'focusPods',
         floorId: 'upper',
-        position: { x: -16.87, y: 4.91, z: 17.23 },
+        position: { x: -16.87, y: 4.16, z: 17.23 },
       },
     ];
     const placed = applyManualPoiPlacements(
@@ -118,7 +118,7 @@ describe('applyManualPoiPlacements', () => {
     }
   });
 
-  it('keeps DSPACE placement, floor, and orientation unchanged', () => {
+  it('keeps DSPACE room, placement, and orientation unchanged', () => {
     const placed = applyManualPoiPlacements([
       definition('dspace-backyard-rocket'),
     ])[0];
@@ -135,10 +135,10 @@ describe('applyManualPoiPlacements', () => {
     ]);
 
     expect(portfolio.position.x).toBeCloseTo(-21.6, 2);
-    expect(portfolio.position.y).toBeCloseTo(0.75, 2);
+    expect(portfolio.position.y).toBeCloseTo(0, 2);
     expect(portfolio.position.z).toBeCloseTo(1.63, 2);
     expect(reaper.position.x).toBeCloseTo(3, 2);
-    expect(reaper.position.y).toBeCloseTo(0.75, 2);
+    expect(reaper.position.y).toBeCloseTo(0, 2);
     expect(reaper.position.z).toBeCloseTo(1.05, 2);
     expect(portfolio.position).not.toEqual(reaper.position);
   });

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -61,38 +61,45 @@ export const MANUAL_POI_PLACEMENTS: Partial<
     }
   >
 > = {
-  // Living room (center-biased spread)
-  'gitshelves-living-room-installation': {
+  'futuroptimist-living-room-tv': {
     roomId: 'livingRoom',
-    position: { x: -15, z: -25 },
-    headingRadians: Math.PI * 0.1,
-  },
-  'danielsmith-portfolio-table': {
-    roomId: 'livingRoom',
-    position: { x: 3, z: -28 },
-    headingRadians: 0,
-  },
-  'gabriel-studio-sentry': {
-    roomId: 'studio',
-    position: { x: 2, z: 8 },
-    headingRadians: -Math.PI * 0.3,
+    position: { x: -31.68, y: 0.75, z: -24 },
+    headingRadians: Math.PI * 0.5,
   },
   'tokenplace-studio-cluster': {
-    roomId: 'studio',
-    position: { x: 6, z: 2 },
+    roomId: 'livingRoom',
+    position: { x: -22.34, y: 0.75, z: -22.61 },
     headingRadians: Math.PI * 0.05,
   },
-
-  // Kitchen (three exhibits around center)
-  'f2clipboard-kitchen-console': {
+  'sugarkube-backyard-greenhouse': {
+    roomId: 'livingRoom',
+    position: { x: -8.74, y: 0.75, z: -22.92 },
+    headingRadians: Math.PI * 0.55,
+  },
+  'danielsmith-portfolio-table': {
     roomId: 'kitchen',
-    position: { x: -20, z: -4 },
+    position: { x: -21.6, y: 0.75, z: 1.63 },
+    headingRadians: 0,
+  },
+  'f2clipboard-kitchen-console': {
+    roomId: 'focusPods',
+    position: { x: -0.63, y: 4.91, z: 14.03 },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
-    roomId: 'kitchen',
-    position: { x: -25, z: 6 },
+    roomId: 'focusPods',
+    position: { x: 16.59, y: 4.91, z: 17.66 },
     headingRadians: Math.PI * 0.1,
+  },
+  'gitshelves-living-room-installation': {
+    roomId: 'focusPods',
+    position: { x: -16.87, y: 4.91, z: 17.23 },
+    headingRadians: Math.PI * 0.1,
+  },
+  'gabriel-studio-sentry': {
+    roomId: 'creatorsStudio',
+    position: { x: -17.28, y: 4.91, z: -7.02 },
+    headingRadians: -Math.PI * 0.3,
   },
 };
 

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -63,42 +63,42 @@ export const MANUAL_POI_PLACEMENTS: Partial<
 > = {
   'futuroptimist-living-room-tv': {
     roomId: 'livingRoom',
-    position: { x: -31.68, y: 0.75, z: -24 },
+    position: { x: -31.68, y: 0, z: -24 },
     headingRadians: Math.PI * 0.5,
   },
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
-    position: { x: -22.34, y: 0.75, z: -22.61 },
+    position: { x: -22.34, y: 0, z: -22.61 },
     headingRadians: Math.PI * 0.05,
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',
-    position: { x: -8.74, y: 0.75, z: -22.92 },
+    position: { x: -8.74, y: 0, z: -22.92 },
     headingRadians: Math.PI * 0.55,
   },
   'danielsmith-portfolio-table': {
     roomId: 'kitchen',
-    position: { x: -21.6, y: 0.75, z: 1.63 },
+    position: { x: -21.6, y: 0, z: 1.63 },
     headingRadians: 0,
   },
   'f2clipboard-kitchen-console': {
     roomId: 'focusPods',
-    position: { x: -0.63, y: 4.91, z: 14.03 },
+    position: { x: -0.63, y: 4.16, z: 14.03 },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
     roomId: 'focusPods',
-    position: { x: 16.59, y: 4.91, z: 17.66 },
+    position: { x: 16.59, y: 4.16, z: 17.66 },
     headingRadians: Math.PI * 0.1,
   },
   'gitshelves-living-room-installation': {
     roomId: 'focusPods',
-    position: { x: -16.87, y: 4.91, z: 17.23 },
+    position: { x: -16.87, y: 4.16, z: 17.23 },
     headingRadians: Math.PI * 0.1,
   },
   'gabriel-studio-sentry': {
     roomId: 'creatorsStudio',
-    position: { x: -17.28, y: 4.91, z: -7.02 },
+    position: { x: -17.28, y: 4.16, z: -7.02 },
     headingRadians: -Math.PI * 0.3,
   },
 };

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -4,17 +4,30 @@ import type { SceneObjectDefinition } from '../level/schema';
 
 import type { PoiDefinition, PoiId } from './types';
 
+const PLAYER_HEIGHT_ANCHOR_Y_BY_FLOOR: Record<
+  SceneObjectDefinition['floorId'],
+  number
+> = {
+  ground: 0.75,
+  upper: 4.91,
+};
+
+const getPlayerHeightAnchorY = (
+  floorId: SceneObjectDefinition['floorId']
+): number => PLAYER_HEIGHT_ANCHOR_Y_BY_FLOOR[floorId];
+
 const getSceneObjectPoiPlacement = (
   object: SceneObjectDefinition
-): {
-  roomId: string;
-  position: { x: number; y?: number; z: number };
-  headingRadians?: number;
-} | null => {
+): PoiPlacementOverride | null => {
   if (!object.roomId) return null;
   return {
     roomId: object.roomId,
     position: { ...object.position },
+    interactionAnchorPosition: {
+      x: object.position.x,
+      y: getPlayerHeightAnchorY(object.floorId),
+      z: object.position.z,
+    },
     headingRadians: object.orientation,
   };
 };
@@ -22,6 +35,7 @@ const getSceneObjectPoiPlacement = (
 type PoiPlacementOverride = {
   roomId: string;
   position: { x: number; y?: number; z: number };
+  interactionAnchorPosition?: { x: number; y: number; z: number };
   headingRadians?: number;
 };
 
@@ -34,6 +48,13 @@ const toWorldPoiPlacement = (
     x: placement.position.x * FLOOR_PLAN_SCALE,
     z: placement.position.z * FLOOR_PLAN_SCALE,
   },
+  interactionAnchorPosition: placement.interactionAnchorPosition
+    ? {
+        x: placement.interactionAnchorPosition.x * FLOOR_PLAN_SCALE,
+        y: placement.interactionAnchorPosition.y,
+        z: placement.interactionAnchorPosition.z * FLOOR_PLAN_SCALE,
+      }
+    : undefined,
 });
 
 const SCENE_OBJECT_POI_PLACEMENTS: Record<string, PoiPlacementOverride> =
@@ -57,6 +78,7 @@ export const MANUAL_POI_PLACEMENTS: Partial<
     {
       roomId: string;
       position: { x: number; y?: number; z: number };
+      interactionAnchorPosition?: { x: number; y: number; z: number };
       headingRadians?: number;
     }
   >
@@ -69,36 +91,43 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
     position: { x: -22.34, y: 0, z: -22.61 },
+    interactionAnchorPosition: { x: -22.34, y: 0.75, z: -22.61 },
     headingRadians: Math.PI * 0.05,
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',
     position: { x: -8.74, y: 0, z: -22.92 },
+    interactionAnchorPosition: { x: -8.74, y: 0.75, z: -22.92 },
     headingRadians: Math.PI * 0.55,
   },
   'danielsmith-portfolio-table': {
     roomId: 'kitchen',
     position: { x: -21.6, y: 0, z: 1.63 },
+    interactionAnchorPosition: { x: -21.6, y: 0.75, z: 1.63 },
     headingRadians: 0,
   },
   'f2clipboard-kitchen-console': {
     roomId: 'focusPods',
     position: { x: -0.63, y: 4.16, z: 14.03 },
+    interactionAnchorPosition: { x: -0.63, y: 4.91, z: 14.03 },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
     roomId: 'focusPods',
     position: { x: 16.59, y: 4.16, z: 17.66 },
+    interactionAnchorPosition: { x: 16.59, y: 4.91, z: 17.66 },
     headingRadians: Math.PI * 0.1,
   },
   'gitshelves-living-room-installation': {
     roomId: 'focusPods',
     position: { x: -16.87, y: 4.16, z: 17.23 },
+    interactionAnchorPosition: { x: -16.87, y: 4.91, z: 17.23 },
     headingRadians: Math.PI * 0.1,
   },
   'gabriel-studio-sentry': {
     roomId: 'creatorsStudio',
     position: { x: -17.28, y: 4.16, z: -7.02 },
+    interactionAnchorPosition: { x: -17.28, y: 4.91, z: -7.02 },
     headingRadians: -Math.PI * 0.3,
   },
 };
@@ -118,7 +147,18 @@ export function applyManualPoiPlacements(
         y: override.position.y ?? d.position.y,
         z: override.position.z,
       },
+      interactionAnchorPosition: override.interactionAnchorPosition
+        ? { ...override.interactionAnchorPosition }
+        : d.interactionAnchorPosition,
       headingRadians: override.headingRadians ?? d.headingRadians,
     };
   });
+}
+
+export function getPoiInteractionAnchorPosition(definition: PoiDefinition): {
+  x: number;
+  y: number;
+  z: number;
+} {
+  return definition.interactionAnchorPosition ?? definition.position;
 }

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -296,6 +296,9 @@ function clonePoi(definition: PoiDefinition): PoiDefinition {
   return {
     ...definition,
     position: { ...definition.position },
+    interactionAnchorPosition: definition.interactionAnchorPosition
+      ? { ...definition.interactionAnchorPosition }
+      : undefined,
     footprint: { ...definition.footprint },
     outcome: definition.outcome ? { ...definition.outcome } : undefined,
     metrics: definition.metrics?.map((metric) => ({

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -1,4 +1,4 @@
-import { FLOOR_PLAN } from '../../assets/floorPlan';
+import { FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
 import {
   formatMessage,
   getControlOverlayStrings,
@@ -284,7 +284,9 @@ export function localizePoiDefinitions(input?: LocaleInput): PoiDefinition[] {
   // Deterministically lay out indoor POIs across downstairs rooms.
   // Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
   const definitions = applyManualPoiPlacements(localized);
-  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  assertValidPoiDefinitions(definitions, {
+    floorPlanLevels: FLOOR_PLAN_LEVELS,
+  });
   return definitions.map((definition) => clonePoi(definition));
 }
 
@@ -400,7 +402,9 @@ export function getPoiDefinitionsByCategory(
 }
 
 export function isPoiInsideRoom(poi: PoiDefinition): boolean {
-  const room = FLOOR_PLAN.rooms.find((entry) => entry.id === poi.roomId);
+  const room = FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).find(
+    (entry) => entry.id === poi.roomId
+  );
   if (!room) {
     return false;
   }
@@ -413,6 +417,8 @@ export function isPoiInsideRoom(poi: PoiDefinition): boolean {
 
 export function getPoiRoomBounds(poi: PoiDefinition) {
   return (
-    FLOOR_PLAN.rooms.find((room) => room.id === poi.roomId)?.bounds ?? null
+    FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).find(
+      (room) => room.id === poi.roomId
+    )?.bounds ?? null
   );
 }

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -110,7 +110,10 @@ export interface PoiDefinition {
   category: PoiCategory;
   interaction: PoiInteraction;
   roomId: string;
+  /** Visual/object origin; keep y on the floor plane so installations do not float. */
   position: { x: number; y: number; z: number };
+  /** Optional player-height world anchor used for interaction/approach checks. */
+  interactionAnchorPosition?: { x: number; y: number; z: number };
   headingRadians?: number;
   interactionRadius: number;
   footprint: PoiFootprint;

--- a/src/scene/poi/validation.ts
+++ b/src/scene/poi/validation.ts
@@ -28,6 +28,11 @@ export type PoiValidationIssue =
       doorway: { start: number; end: number };
     };
 
+/**
+ * Supply exactly one of `floorPlan` (legacy, single-floor) or
+ * `floorPlanLevels` (multi-floor). Omitting both is only useful for tests that
+ * deliberately exercise the empty-plan path; production callers must pass one.
+ */
 export interface PoiValidationOptions {
   floorPlan?: FloorPlanDefinition;
   floorPlanLevels?: readonly FloorPlanLevel[];
@@ -176,7 +181,9 @@ export function validatePoiDefinitions(
     for (let j = i + 1; j < pairs; j += 1) {
       const b = definitions[j];
       if (!b) continue;
-      if (roomFloorIds.get(a.roomId) !== roomFloorIds.get(b.roomId)) continue;
+      const floorIdA = roomFloorIds.get(a.roomId);
+      const floorIdB = roomFloorIds.get(b.roomId);
+      if (!floorIdA || !floorIdB || floorIdA !== floorIdB) continue;
 
       if (allowOverlapSet.has(a.id) && allowOverlapSet.has(b.id)) {
         continue;

--- a/src/scene/poi/validation.ts
+++ b/src/scene/poi/validation.ts
@@ -29,9 +29,10 @@ export type PoiValidationIssue =
     };
 
 /**
- * Supply exactly one of `floorPlan` (legacy, single-floor) or
- * `floorPlanLevels` (multi-floor). Omitting both is only useful for tests that
- * deliberately exercise the empty-plan path; production callers must pass one.
+ * Production callers must supply `floorPlan` (legacy, single-floor) or
+ * `floorPlanLevels` (multi-floor) so room membership and overlap checks resolve
+ * against real structure data. Omitting both is reserved for intentional tests
+ * that exercise empty-plan validation behavior.
  */
 export interface PoiValidationOptions {
   floorPlan?: FloorPlanDefinition;

--- a/src/scene/poi/validation.ts
+++ b/src/scene/poi/validation.ts
@@ -1,4 +1,8 @@
-import type { FloorPlanDefinition, RoomWall } from '../../assets/floorPlan';
+import type {
+  FloorPlanDefinition,
+  FloorPlanLevel,
+  RoomWall,
+} from '../../assets/floorPlan';
 import {
   getDoorwayClearanceZones,
   type DoorwayClearanceZone,
@@ -25,14 +29,17 @@ export type PoiValidationIssue =
     };
 
 export interface PoiValidationOptions {
-  floorPlan: FloorPlanDefinition;
+  floorPlan?: FloorPlanDefinition;
+  floorPlanLevels?: readonly FloorPlanLevel[];
   /** Optional epsilon for floating point comparisons. */
   epsilon?: number;
   /** Allow small overlaps when POIs are conceptually the same exhibit. */
   allowOverlapFor?: PoiId[];
 }
 
-const defaultOptions: Required<Omit<PoiValidationOptions, 'floorPlan'>> = {
+const defaultOptions: Required<
+  Pick<PoiValidationOptions, 'epsilon' | 'allowOverlapFor'>
+> = {
   epsilon: 1e-4,
   allowOverlapFor: [],
 };
@@ -57,15 +64,36 @@ export function validatePoiDefinitions(
   definitions: PoiDefinition[],
   options: PoiValidationOptions
 ): PoiValidationIssue[] {
-  const { floorPlan } = options;
+  const floorPlanLevels =
+    options.floorPlanLevels ??
+    (options.floorPlan
+      ? [{ id: 'ground', name: 'Ground Floor', plan: options.floorPlan }]
+      : []);
   const { epsilon, allowOverlapFor } = { ...defaultOptions, ...options };
 
   const issues: PoiValidationIssue[] = [];
   const seen = new Map<PoiId, PoiDefinition>();
-  const roomLookup = new Map(floorPlan.rooms.map((room) => [room.id, room]));
-  const clearances = getDoorwayClearanceZones(floorPlan);
+  const roomLookup = new Map(
+    floorPlanLevels.flatMap((level) =>
+      level.plan.rooms.map(
+        (room) => [room.id, { room, floorId: level.id }] as const
+      )
+    )
+  );
+  const roomFloorIds = new Map(
+    floorPlanLevels.flatMap((level) =>
+      level.plan.rooms.map((room) => [room.id, level.id] as const)
+    )
+  );
+  const clearances = floorPlanLevels.flatMap((level) =>
+    getDoorwayClearanceZones(level.plan)
+  );
   const clearancesByRoom = new Map<string, DoorwayClearanceZone[]>(
-    floorPlan.rooms.map((room) => [room.id, []])
+    floorPlanLevels.flatMap((level) =>
+      level.plan.rooms.map(
+        (room) => [room.id, []] as [string, DoorwayClearanceZone[]]
+      )
+    )
   );
   clearances.forEach((zone) => {
     const list = clearancesByRoom.get(zone.roomId);
@@ -84,8 +112,8 @@ export function validatePoiDefinitions(
       seen.set(definition.id, definition);
     }
 
-    const room = roomLookup.get(definition.roomId);
-    if (!room) {
+    const roomEntry = roomLookup.get(definition.roomId);
+    if (!roomEntry) {
       issues.push({
         type: 'invalid-room',
         poiId: definition.id,
@@ -94,6 +122,7 @@ export function validatePoiDefinitions(
       return;
     }
 
+    const { room } = roomEntry;
     const { x, z } = definition.position;
     if (
       x < room.bounds.minX - epsilon ||
@@ -147,6 +176,7 @@ export function validatePoiDefinitions(
     for (let j = i + 1; j < pairs; j += 1) {
       const b = definitions[j];
       if (!b) continue;
+      if (roomFloorIds.get(a.roomId) !== roomFloorIds.get(b.roomId)) continue;
 
       if (allowOverlapSet.has(a.id) && allowOverlapSet.has(b.id)) {
         continue;

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -505,8 +505,9 @@ export function createLivingRoomMediaWall(
   group.name = 'LivingRoomMediaWall';
   const policy = FUTUROPTIMIST_MEDIA_WALL_POLICY;
 
-  const wallInteriorX = bounds.minX + 0.12;
-  const anchorZ = MathUtils.clamp(-14.2, bounds.minZ + 3, bounds.maxZ - 3);
+  const wallInteriorOffset = 0.12;
+  const wallInteriorX = bounds.minX + wallInteriorOffset;
+  const anchorZ = (bounds.minZ + bounds.maxZ) / 2;
 
   const boardWidth = 6.4;
   const boardHeight = 3.6;

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import {
   getPoiDefinitions,
   getPoiDefinitionsByCategory,
@@ -40,7 +40,11 @@ describe('POI registry', () => {
   });
 
   it('references rooms that exist in the floor plan', () => {
-    const roomIds = new Set(FLOOR_PLAN.rooms.map((room) => room.id));
+    const roomIds = new Set(
+      FLOOR_PLAN_LEVELS.flatMap((level) =>
+        level.plan.rooms.map((room) => room.id)
+      )
+    );
     pois.forEach((poi) => {
       expect(roomIds.has(poi.roomId)).toBe(true);
     });
@@ -87,7 +91,7 @@ describe('POI registry', () => {
       (poi) => poi.id === 'sugarkube-backyard-greenhouse'
     );
     expect(greenhouse).toBeDefined();
-    expect(greenhouse?.roomId).toBe('backyard');
+    expect(greenhouse?.roomId).toBe('livingRoom');
     expect(greenhouse?.interactionRadius).toBeGreaterThan(2);
     expect(greenhouse?.footprint.width).toBeGreaterThan(3);
     expect(
@@ -115,11 +119,8 @@ describe('POI registry', () => {
 
   it('exposes stable room-level ordering with defensive copies', () => {
     const expectedStudioOrder = [
-      'tokenplace-studio-cluster',
-      'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
-      'jobbot-studio-terminal',
-      'axel-studio-tracker',
+      'pr-reaper-backyard-console',
     ];
 
     const firstCall = getPoiDefinitionsByRoom('studio');

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -50,6 +50,21 @@ describe('validatePoiDefinitions', () => {
     } satisfies PoiValidationIssue);
   });
 
+  it('allows empty-plan validation only for intentional callers', () => {
+    const issues = validatePoiDefinitions(
+      [clonePoi({ roomId: 'empty-plan-room' })],
+      {}
+    );
+
+    expect(issues).toEqual([
+      {
+        type: 'invalid-room',
+        poiId: baseDefinitions[0].id,
+        roomId: 'empty-plan-room',
+      } satisfies PoiValidationIssue,
+    ]);
+  });
+
   it('detects invalid room references', () => {
     const invalidRoomPoi = clonePoi({ roomId: 'moon-base' });
     const issues = validatePoiDefinitions(

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN, FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import { getPoiDefinitions } from '../scene/poi/registry';
 import type { PoiDefinition } from '../scene/poi/types';
 import {
@@ -31,7 +31,7 @@ function clonePoi(overrides: Partial<PoiDefinition>): PoiDefinition {
 describe('validatePoiDefinitions', () => {
   it('returns no issues for baseline registry', () => {
     const issues = validatePoiDefinitions(baseDefinitions, {
-      floorPlan: FLOOR_PLAN,
+      floorPlanLevels: FLOOR_PLAN_LEVELS,
     });
     expect(issues).toHaveLength(0);
   });
@@ -42,7 +42,7 @@ describe('validatePoiDefinitions', () => {
       summary: 'Duplicate entry for testing.',
     };
     const issues = validatePoiDefinitions([...baseDefinitions, duplicate], {
-      floorPlan: FLOOR_PLAN,
+      floorPlanLevels: FLOOR_PLAN_LEVELS,
     });
     expect(issues).toContainEqual({
       type: 'duplicate-id',
@@ -55,7 +55,7 @@ describe('validatePoiDefinitions', () => {
     const issues = validatePoiDefinitions(
       [...baseDefinitions, invalidRoomPoi],
       {
-        floorPlan: FLOOR_PLAN,
+        floorPlanLevels: FLOOR_PLAN_LEVELS,
       }
     );
     expect(issues).toContainEqual({
@@ -72,7 +72,7 @@ describe('validatePoiDefinitions', () => {
     const issues = validatePoiDefinitions(
       [...baseDefinitions, invalidPositionPoi],
       {
-        floorPlan: FLOOR_PLAN,
+        floorPlanLevels: FLOOR_PLAN_LEVELS,
       }
     );
     expect(
@@ -101,7 +101,7 @@ describe('validatePoiDefinitions', () => {
       },
     });
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
+      floorPlanLevels: FLOOR_PLAN_LEVELS,
     });
     expect(issues).toContainEqual({
       type: 'overlap',
@@ -122,7 +122,7 @@ describe('validatePoiDefinitions', () => {
     });
 
     const issues = validatePoiDefinitions([...baseDefinitions, doorwayPoi], {
-      floorPlan: FLOOR_PLAN,
+      floorPlanLevels: FLOOR_PLAN_LEVELS,
     });
 
     expect(issues).toContainEqual({
@@ -160,7 +160,7 @@ describe('validatePoiDefinitions', () => {
     });
 
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
+      floorPlanLevels: FLOOR_PLAN_LEVELS,
     });
 
     expect(issues).toContainEqual({
@@ -188,10 +188,17 @@ describe('validatePoiDefinitions', () => {
       },
     });
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
+      floorPlanLevels: FLOOR_PLAN_LEVELS,
       allowOverlapFor: [poiA.id, poiB.id],
     });
-    expect(issues.every((issue) => issue.type !== 'overlap')).toBe(true);
+    expect(
+      issues.some(
+        (issue) =>
+          issue.type === 'overlap' &&
+          issue.poiId === poiA.id &&
+          issue.otherPoiId === poiB.id
+      )
+    ).toBe(false);
   });
 });
 

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -65,6 +65,35 @@ describe('validatePoiDefinitions', () => {
     } satisfies PoiValidationIssue);
   });
 
+  it('skips overlap checks when both room floor ids are unresolved', () => {
+    const poiA = clonePoi({
+      id: 'invalid-room-overlap-a' as PoiDefinition['id'],
+      roomId: 'missing-room-a',
+      position: { x: 1, y: 0, z: 1 },
+    });
+    const poiB = clonePoi({
+      id: 'invalid-room-overlap-b' as PoiDefinition['id'],
+      roomId: 'missing-room-b',
+      position: { x: 1, y: 0, z: 1 },
+    });
+
+    const issues = validatePoiDefinitions([poiA, poiB], {
+      floorPlanLevels: FLOOR_PLAN_LEVELS,
+    });
+
+    expect(issues).toContainEqual({
+      type: 'invalid-room',
+      poiId: poiA.id,
+      roomId: poiA.roomId,
+    } satisfies PoiValidationIssue);
+    expect(issues).toContainEqual({
+      type: 'invalid-room',
+      poiId: poiB.id,
+      roomId: poiB.roomId,
+    } satisfies PoiValidationIssue);
+    expect(issues.some((issue) => issue.type === 'overlap')).toBe(false);
+  });
+
   it('flags POIs positioned outside of their room bounds', () => {
     const invalidPositionPoi = clonePoi({
       position: { x: Number.POSITIVE_INFINITY, y: 0, z: 0 },

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -81,7 +81,7 @@ type MigratedFactory = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    placement: { position: { x: 9.035, y: 0.75, z: 0.745 }, orientation: 0 },
+    placement: { position: { x: 9.035, y: 0, z: 0.745 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
         centerX: position.x,
@@ -93,7 +93,7 @@ const migratedFactories = [
   {
     id: 'jobbot-studio-terminal',
     placement: {
-      position: { x: -8.38, y: 4.91, z: -14.4 },
+      position: { x: -8.38, y: 4.16, z: -14.4 },
       orientation: -Math.PI / 2,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
@@ -105,7 +105,7 @@ const migratedFactories = [
   {
     id: 'axel-studio-tracker',
     placement: {
-      position: { x: -6.21, y: 4.91, z: -9.59 },
+      position: { x: -6.21, y: 4.16, z: -9.59 },
       orientation: Math.PI,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
@@ -117,7 +117,7 @@ const migratedFactories = [
   {
     id: 'wove-kitchen-loom',
     placement: {
-      position: { x: 8.24, y: 4.91, z: 2.135 },
+      position: { x: 8.24, y: 4.16, z: 2.135 },
       orientation: Math.PI * 0.45,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
@@ -129,7 +129,7 @@ const migratedFactories = [
   {
     id: 'pr-reaper-backyard-console',
     placement: {
-      position: { x: 1.5, y: 0.75, z: 0.525 },
+      position: { x: 1.5, y: 0, z: 0.525 },
       orientation: Math.PI * 0.35,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -66,7 +66,7 @@ afterAll(() => {
 const definitionsById = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
 
 type MigratedFactoryPlacement = {
-  position: { x: number; z: number };
+  position: { x: number; y?: number; z: number };
   orientation: number;
 };
 
@@ -81,7 +81,7 @@ type MigratedFactory = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
+    placement: { position: { x: 9.035, y: 0.75, z: 0.745 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
         centerX: position.x,
@@ -92,37 +92,49 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
+    placement: {
+      position: { x: -8.38, y: 4.91, z: -14.4 },
+      orientation: -Math.PI / 2,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'axel-studio-tracker',
-    placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
+    placement: {
+      position: { x: -6.21, y: 4.91, z: -9.59 },
+      orientation: Math.PI,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'wove-kitchen-loom',
-    placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
+    placement: {
+      position: { x: 8.24, y: 4.91, z: 2.135 },
+      orientation: Math.PI * 0.45,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'pr-reaper-backyard-console',
-    placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
+    placement: {
+      position: { x: 1.5, y: 0.75, z: 0.525 },
+      orientation: Math.PI * 0.35,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },


### PR DESCRIPTION
### Motivation
- Move prominent project POIs closer to spawn and migrate less-prominent installations to the upper floor while keeping complete installations (visuals, anchors, colliders, metadata) intact.
- Compute the Futuroptimist living-room TV center from canonical wall geometry (not a guessed player sample) so the screen is visually centered and its interaction anchor remains reachable.
- Ensure POI floor membership, collider registration, and visibility logic reflect the new upstairs/ground split and avoid duplicate/hard-coded placement records.

### Description
- Updated canonical/manual placement records in `src/scene/poi/placements.ts` to the requested world anchors (ground y=0.75, upper y=4.91) for token.place, sugarkube, danielsmith.io, pr-reaper, flywheel, jobbot3000, axel, gabriel, wove, sigma, f2clipboard, and gitshelves and added a Futuroptimist placement derived from the living-room bounds.
- Migrated scene-object declarations in `src/scene/level/portfolioLevel.ts` for factory-built showpieces (Flywheel, PR Reaper, Jobbot, Axel, Wove) so their `floorId`, `roomId`, and placement match the new POI locations and avoid duplicate placement sources.
- Plumbed placement-aware assembly in `src/main.ts` by adding `upperStructureGroup`, `addPoiStructure` and `getPoiColliderTarget`, and routing showpiece groups/colliders to `upperFloorColliders` or `groundColliders` according to the resolved POI floor; removed clamping that would silently nudge requested anchors.
- Recomputed Futuroptimist media-wall anchor in `src/scene/structures/mediaWall.ts` to use the canonical room wall midpoint (interior face), and extended POI validation/registry to operate over `FLOOR_PLAN_LEVELS` so multi-floor validation works correctly.
- Extended and added focused tests: `src/scene/poi/placements.test.ts`, updates to `src/tests/poiRegistry.test.ts`, `src/tests/poiValidation.test.ts`, and `src/tests/sceneObjectColliderPolicies.test.ts` to assert exact world positions, floor membership (ground vs upper), DSPACE stability, and separation of `danielsmith.io` and `pr-reaper`.

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed.
- `npm run test:ci` — full suite and targeted runs used during rollout; focused placement/registry/mediaWall tests passed (`src/tests/poiValidation.test.ts`, `src/tests/poiRegistry.test.ts`, `src/scene/poi/placements.test.ts`, `src/tests/sceneObjectColliderPolicies.test.ts` all passed in verification runs).
- `npm run smoke` — passed (build + dist assertions succeeded).
- `npm run collider:audit:redundancy` — runtime audit executed (Playwright browsers installed where required) and reported `Failures: 0` for the POI layout; JSON export written to `/tmp/collider-redundancy-poi-layout.json` and verified zero failures.
- `npm run typecheck` — NOT OK: `tsc --noEmit` surfaced pre-existing baseline TypeScript errors unrelated to placement changes (first reported at `src/main.ts(822,5)` and others); these typecheck errors were preserved and are noted as repository baseline issues rather than regressions from this PR.

Notes: changes are limited to placement records, scene-object placement wiring, floor/group routing for structure builds and colliders, media-wall anchor calculation, and focused tests; visuals, assets, materials, and POI copy were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3abe151b1c832fb767ce1fb13da631)