### PR TITLE
Redistribute production POI layout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2871,6 +2871,10 @@ function initializeImmersiveScene(
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
   const kitchenRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'kitchen');
   const kitchenBounds = kitchenRoom?.bounds;
+  const getPoiStructureTargets = (poi: PoiInstance) =>
+    getPoiFloorId(poi.definition) === 'upper'
+      ? { group: upperFloorGroup, colliders: upperFloorColliders }
+      : { group: groundStructureGroup, colliders: groundColliders };
   if (studioRoom) {
     const centerX =
       flywheelPoi?.group.position.x ??
@@ -2903,18 +2907,11 @@ function initializeImmersiveScene(
     flywheelShowpiece = showpiece;
 
     const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
-    const terminalX = MathUtils.clamp(
-      jobbotPoi?.group.position.x ?? 11.4,
-      studioRoom.bounds.minX + 1.2,
-      studioRoom.bounds.maxX - 0.8
-    );
-    const terminalZ = MathUtils.clamp(
-      jobbotPoi?.group.position.z ?? -0.6,
-      studioRoom.bounds.minZ + 1.2,
-      studioRoom.bounds.maxZ - 1.1
-    );
+    const terminalX = jobbotPoi?.group.position.x ?? 11.4;
+    const terminalY = jobbotPoi?.group.position.y ?? 0;
+    const terminalZ = jobbotPoi?.group.position.z ?? -0.6;
     const terminal = createJobbotTerminal({
-      position: { x: terminalX, y: 0, z: terminalZ },
+      position: { x: terminalX, y: terminalY, z: terminalZ },
       orientationRadians: terminalOrientation,
       detailPolicy: activeSceneDetailPolicy,
     });
@@ -2926,13 +2923,23 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         terminal.colliders,
         jobbotSceneObject,
-        groundColliders,
+        jobbotPoi
+          ? getPoiStructureTargets(jobbotPoi).colliders
+          : groundColliders,
         colliderSourceMetadata
       );
     } else {
-      terminal.colliders.forEach((collider) => groundColliders.push(collider));
+      terminal.colliders.forEach((collider) =>
+        (jobbotPoi
+          ? getPoiStructureTargets(jobbotPoi).colliders
+          : groundColliders
+        ).push(collider)
+      );
     }
-    groundStructureGroup.add(terminal.group);
+    (jobbotPoi
+      ? getPoiStructureTargets(jobbotPoi).group
+      : groundStructureGroup
+    ).add(terminal.group);
     jobbotTerminal = terminal;
 
     if (axelPoi) {
@@ -2950,15 +2957,15 @@ function initializeImmersiveScene(
         registerSceneObjectColliders(
           navigator.colliders,
           axelSceneObject,
-          groundColliders,
+          getPoiStructureTargets(axelPoi).colliders,
           colliderSourceMetadata
         );
       } else {
         navigator.colliders.forEach((collider) =>
-          groundColliders.push(collider)
+          getPoiStructureTargets(axelPoi).colliders.push(collider)
         );
       }
-      groundStructureGroup.add(navigator.group);
+      getPoiStructureTargets(axelPoi).group.add(navigator.group);
       axelNavigator = navigator;
     }
 
@@ -2985,8 +2992,10 @@ function initializeImmersiveScene(
         },
         orientationRadians: gabrielPoi.group.rotation.y ?? 0,
       });
-      groundStructureGroup.add(sentry.group);
-      sentry.colliders.forEach((collider) => groundColliders.push(collider));
+      getPoiStructureTargets(gabrielPoi).group.add(sentry.group);
+      sentry.colliders.forEach((collider) =>
+        getPoiStructureTargets(gabrielPoi).colliders.push(collider)
+      );
       gabrielSentry = sentry;
     }
   }
@@ -3027,28 +3036,32 @@ function initializeImmersiveScene(
       },
       orientationRadians: gitshelvesPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(installation.group);
+    getPoiStructureTargets(gitshelvesPoi).group.add(installation.group);
     installation.colliders.forEach((collider) =>
-      groundColliders.push(collider)
+      getPoiStructureTargets(gitshelvesPoi).colliders.push(collider)
     );
     gitshelvesInstallation = installation;
   }
 
   if (f2ClipboardPoi) {
-    const consoleX = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : f2ClipboardPoi.group.position.x;
-    const consoleZ = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.8
-        )
-      : f2ClipboardPoi.group.position.z;
+    const f2Targets = getPoiStructureTargets(f2ClipboardPoi);
+    const isF2Upper = getPoiFloorId(f2ClipboardPoi.definition) === 'upper';
+    const consoleX =
+      kitchenBounds && !isF2Upper
+        ? MathUtils.clamp(
+            f2ClipboardPoi.group.position.x,
+            kitchenBounds.minX + 0.8,
+            kitchenBounds.maxX - 0.8
+          )
+        : f2ClipboardPoi.group.position.x;
+    const consoleZ =
+      kitchenBounds && !isF2Upper
+        ? MathUtils.clamp(
+            f2ClipboardPoi.group.position.z,
+            kitchenBounds.minZ + 0.8,
+            kitchenBounds.maxZ - 0.8
+          )
+        : f2ClipboardPoi.group.position.z;
     const console = createF2ClipboardConsole({
       position: {
         x: consoleX,
@@ -3057,26 +3070,30 @@ function initializeImmersiveScene(
       },
       orientationRadians: f2ClipboardPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(console.group);
-    console.colliders.forEach((collider) => groundColliders.push(collider));
+    f2Targets.group.add(console.group);
+    console.colliders.forEach((collider) => f2Targets.colliders.push(collider));
     f2ClipboardConsole = console;
   }
 
   if (sigmaPoi) {
-    const benchX = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.x,
-          kitchenBounds.minX + 0.9,
-          kitchenBounds.maxX - 0.9
-        )
-      : sigmaPoi.group.position.x;
-    const benchZ = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.z,
-          kitchenBounds.minZ + 0.9,
-          kitchenBounds.maxZ - 0.9
-        )
-      : sigmaPoi.group.position.z;
+    const sigmaTargets = getPoiStructureTargets(sigmaPoi);
+    const isSigmaUpper = getPoiFloorId(sigmaPoi.definition) === 'upper';
+    const benchX =
+      kitchenBounds && !isSigmaUpper
+        ? MathUtils.clamp(
+            sigmaPoi.group.position.x,
+            kitchenBounds.minX + 0.9,
+            kitchenBounds.maxX - 0.9
+          )
+        : sigmaPoi.group.position.x;
+    const benchZ =
+      kitchenBounds && !isSigmaUpper
+        ? MathUtils.clamp(
+            sigmaPoi.group.position.z,
+            kitchenBounds.minZ + 0.9,
+            kitchenBounds.maxZ - 0.9
+          )
+        : sigmaPoi.group.position.z;
     const workbench = createSigmaWorkbench({
       position: {
         x: benchX,
@@ -3085,26 +3102,32 @@ function initializeImmersiveScene(
       },
       orientationRadians: sigmaPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(workbench.group);
-    workbench.colliders.forEach((collider) => groundColliders.push(collider));
+    sigmaTargets.group.add(workbench.group);
+    workbench.colliders.forEach((collider) =>
+      sigmaTargets.colliders.push(collider)
+    );
     sigmaWorkbench = workbench;
   }
 
   if (wovePoi) {
-    const loomX = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : wovePoi.group.position.x;
-    const loomZ = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.6
-        )
-      : wovePoi.group.position.z;
+    const woveTargets = getPoiStructureTargets(wovePoi);
+    const isWoveUpper = getPoiFloorId(wovePoi.definition) === 'upper';
+    const loomX =
+      kitchenBounds && !isWoveUpper
+        ? MathUtils.clamp(
+            wovePoi.group.position.x,
+            kitchenBounds.minX + 0.8,
+            kitchenBounds.maxX - 0.8
+          )
+        : wovePoi.group.position.x;
+    const loomZ =
+      kitchenBounds && !isWoveUpper
+        ? MathUtils.clamp(
+            wovePoi.group.position.z,
+            kitchenBounds.minZ + 0.8,
+            kitchenBounds.maxZ - 0.6
+          )
+        : wovePoi.group.position.z;
     const loom = createWoveLoom({
       position: {
         x: loomX,
@@ -3119,13 +3142,15 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         loom.colliders,
         woveSceneObject,
-        groundColliders,
+        woveTargets.colliders,
         colliderSourceMetadata
       );
     } else {
-      loom.colliders.forEach((collider) => groundColliders.push(collider));
+      loom.colliders.forEach((collider) =>
+        woveTargets.colliders.push(collider)
+      );
     }
-    groundStructureGroup.add(loom.group);
+    woveTargets.group.add(loom.group);
     woveLoom = loom;
   }
 

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -357,47 +357,17 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.flywheel',
           'studio',
-          { x: 5.5, z: -2 },
+          { x: 9.035, y: 0.75, z: 0.745 },
           0,
           'POI showpiece and info panel with factory-owned solid colliders'
         ),
         sceneObject(
-          'jobbot-studio-terminal',
-          'ground.studio.jobbot_terminal.scene_object',
-          'ground',
-          'showpiece.jobbot_terminal',
-          'studio',
-          { x: 12, z: 2 },
-          -Math.PI / 2,
-          'POI terminal with factory-owned desk collider'
-        ),
-        sceneObject(
-          'axel-studio-tracker',
-          'ground.studio.axel_navigator.scene_object',
-          'ground',
-          'showpiece.axel_navigator',
-          'studio',
-          { x: 10, z: -2 },
-          Math.PI,
-          'POI navigator with factory-owned dais and console colliders'
-        ),
-        sceneObject(
-          'wove-kitchen-loom',
-          'ground.kitchen.wove_loom.scene_object',
-          'ground',
-          'showpiece.wove_loom',
-          'kitchen',
-          { x: -7.5, z: 2.5 },
-          Math.PI * 0.45,
-          'POI tactile loom with factory-owned table and loom colliders'
-        ),
-        sceneObject(
           'pr-reaper-backyard-console',
-          'ground.backyard.pr_reaper_console.scene_object',
+          'ground.studio.pr_reaper_console.scene_object',
           'ground',
           'showpiece.pr_reaper_console',
-          'backyard',
-          { x: 0, z: 10 },
+          'studio',
+          { x: 1.5, y: 0.75, z: 0.525 },
           Math.PI * 0.35,
           'Backyard POI console with factory-owned deck and console colliders'
         ),
@@ -623,6 +593,38 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           6,
           14,
           ['focusPods']
+        ),
+      ],
+      sceneObjects: [
+        sceneObject(
+          'jobbot-studio-terminal',
+          'upper.creators_studio.jobbot_terminal.scene_object',
+          'upper',
+          'showpiece.jobbot_terminal',
+          'creatorsStudio',
+          { x: -8.38, y: 4.91, z: -14.4 },
+          -Math.PI / 2,
+          'POI terminal with factory-owned desk collider'
+        ),
+        sceneObject(
+          'axel-studio-tracker',
+          'upper.creators_studio.axel_navigator.scene_object',
+          'upper',
+          'showpiece.axel_navigator',
+          'creatorsStudio',
+          { x: -6.21, y: 4.91, z: -9.59 },
+          Math.PI,
+          'POI navigator with factory-owned dais and console colliders'
+        ),
+        sceneObject(
+          'wove-kitchen-loom',
+          'upper.loft_library.wove_loom.scene_object',
+          'upper',
+          'showpiece.wove_loom',
+          'loftLibrary',
+          { x: 8.24, y: 4.91, z: 2.135 },
+          Math.PI * 0.45,
+          'POI tactile loom with factory-owned table and loom colliders'
         ),
       ],
       roomConnections: [

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import { FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
+import { createPoiFloorResolver } from '../floors/visibilityController';
+
 import { applyManualPoiPlacements, MANUAL_POI_PLACEMENTS } from './placements';
+import { getPoiDefinitions } from './registry';
 import type { PoiDefinition, PoiId } from './types';
 
 const definition = (id: PoiId): PoiDefinition => ({
@@ -17,42 +21,64 @@ const definition = (id: PoiId): PoiDefinition => ({
   interactionPrompt: 'Inspect',
 });
 
+const expectPosition = (
+  poi: PoiDefinition,
+  expected: { x: number; y: number; z: number }
+) => {
+  expect(poi.position.x).toBeCloseTo(expected.x, 2);
+  expect(poi.position.y).toBeCloseTo(expected.y, 2);
+  expect(poi.position.z).toBeCloseTo(expected.z, 2);
+};
+
 describe('applyManualPoiPlacements', () => {
   it('resolves migrated POI placements from PORTFOLIO_LEVEL scene objects', () => {
     const expected: Array<{
       id: PoiId;
       roomId: string;
       x: number;
+      y: number;
       z: number;
       headingRadians: number;
     }> = [
       {
         id: 'flywheel-studio-flywheel',
         roomId: 'studio',
-        x: 11,
-        z: -4,
+        x: 18.07,
+        y: 0.75,
+        z: 1.49,
         headingRadians: 0,
       },
       {
         id: 'jobbot-studio-terminal',
-        roomId: 'studio',
-        x: 24,
-        z: 4,
+        roomId: 'creatorsStudio',
+        x: -16.76,
+        y: 4.91,
+        z: -28.8,
         headingRadians: -Math.PI / 2,
       },
       {
         id: 'axel-studio-tracker',
-        roomId: 'studio',
-        x: 20,
-        z: -4,
+        roomId: 'creatorsStudio',
+        x: -12.42,
+        y: 4.91,
+        z: -19.18,
         headingRadians: Math.PI,
       },
       {
         id: 'wove-kitchen-loom',
-        roomId: 'kitchen',
-        x: -15,
-        z: 5,
+        roomId: 'loftLibrary',
+        x: 16.48,
+        y: 4.91,
+        z: 4.27,
         headingRadians: Math.PI * 0.45,
+      },
+      {
+        id: 'pr-reaper-backyard-console',
+        roomId: 'studio',
+        x: 3,
+        y: 0.75,
+        z: 1.05,
+        headingRadians: Math.PI * 0.35,
       },
     ];
     const placed = applyManualPoiPlacements(
@@ -63,9 +89,7 @@ describe('applyManualPoiPlacements', () => {
       const nextExpected = expected[index];
       expect(poi.id).toBe(nextExpected.id);
       expect(poi.roomId).toBe(nextExpected.roomId);
-      expect(poi.position.x).toBeCloseTo(nextExpected.x);
-      expect(poi.position.y).toBe(0.5);
-      expect(poi.position.z).toBeCloseTo(nextExpected.z);
+      expectPosition(poi, nextExpected);
       expect(poi.headingRadians).toBeCloseTo(nextExpected.headingRadians);
     }
   });
@@ -85,5 +109,82 @@ describe('applyManualPoiPlacements', () => {
       });
       expect(poi.headingRadians).toBe(manual?.headingRadians ?? 0.25);
     }
+  });
+});
+
+describe('production POI placement contract', () => {
+  const definitions = getPoiDefinitions();
+  const byId = new Map(definitions.map((poi) => [poi.id, poi]));
+  const getPoiFloorId = createPoiFloorResolver(FLOOR_PLAN_LEVELS);
+
+  const poi = (id: PoiId): PoiDefinition => {
+    const definition = byId.get(id);
+    if (!definition) throw new Error(`Missing POI ${id}`);
+    return definition;
+  };
+
+  it('places non-derived POIs at their requested world anchors', () => {
+    const expected: Array<[PoiId, { x: number; y: number; z: number }]> = [
+      ['tokenplace-studio-cluster', { x: -22.34, y: 0.75, z: -22.61 }],
+      ['sugarkube-backyard-greenhouse', { x: -8.74, y: 0.75, z: -22.92 }],
+      ['danielsmith-portfolio-table', { x: -21.6, y: 0.75, z: 1.63 }],
+      ['pr-reaper-backyard-console', { x: 3, y: 0.75, z: 1.05 }],
+      ['flywheel-studio-flywheel', { x: 18.07, y: 0.75, z: 1.49 }],
+      ['jobbot-studio-terminal', { x: -16.76, y: 4.91, z: -28.8 }],
+      ['axel-studio-tracker', { x: -12.42, y: 4.91, z: -19.18 }],
+      ['gabriel-studio-sentry', { x: -17.28, y: 4.91, z: -7.02 }],
+      ['wove-kitchen-loom', { x: 16.48, y: 4.91, z: 4.27 }],
+      ['sigma-kitchen-workbench', { x: 16.59, y: 4.91, z: 17.66 }],
+      ['f2clipboard-kitchen-console', { x: -0.63, y: 4.91, z: 14.03 }],
+      ['gitshelves-living-room-installation', { x: -16.87, y: 4.91, z: 17.23 }],
+    ];
+
+    for (const [id, position] of expected) {
+      expectPosition(poi(id), position);
+    }
+  });
+
+  it('keeps ground and upper POIs associated with their intended floor', () => {
+    const ground: PoiId[] = [
+      'tokenplace-studio-cluster',
+      'futuroptimist-living-room-tv',
+      'sugarkube-backyard-greenhouse',
+      'danielsmith-portfolio-table',
+      'dspace-backyard-rocket',
+      'pr-reaper-backyard-console',
+      'flywheel-studio-flywheel',
+    ];
+    const upper: PoiId[] = [
+      'jobbot-studio-terminal',
+      'axel-studio-tracker',
+      'gabriel-studio-sentry',
+      'wove-kitchen-loom',
+      'sigma-kitchen-workbench',
+      'f2clipboard-kitchen-console',
+      'gitshelves-living-room-installation',
+    ];
+
+    for (const id of ground) expect(getPoiFloorId(poi(id))).toBe('ground');
+    for (const id of upper) expect(getPoiFloorId(poi(id))).toBe('upper');
+  });
+
+  it('keeps DSPACE placement, floor, and orientation unchanged', () => {
+    const dspace = poi('dspace-backyard-rocket');
+    expect(dspace.roomId).toBe('backyard');
+    expectPosition(dspace, { x: -12, y: 0, z: 24 });
+    expect(dspace.headingRadians).toBeCloseTo(-Math.PI / 10);
+    expect(getPoiFloorId(dspace)).toBe('ground');
+  });
+
+  it('keeps danielsmith.io and pr-reaper independently reachable', () => {
+    const portfolio = poi('danielsmith-portfolio-table');
+    const reaper = poi('pr-reaper-backyard-console');
+    expectPosition(portfolio, { x: -21.6, y: 0.75, z: 1.63 });
+    expectPosition(reaper, { x: 3, y: 0.75, z: 1.05 });
+    expect(portfolio.position.x).not.toBeCloseTo(reaper.position.x, 2);
+    expect(portfolio.position.z).not.toBeCloseTo(reaper.position.z, 2);
+    expect((portfolio.links ?? []).map((link) => link.href)).not.toEqual(
+      (reaper.links ?? []).map((link) => link.href)
+    );
   });
 });

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -61,37 +61,44 @@ export const MANUAL_POI_PLACEMENTS: Partial<
     }
   >
 > = {
-  // Living room (center-biased spread)
-  'gitshelves-living-room-installation': {
+  'futuroptimist-living-room-tv': {
     roomId: 'livingRoom',
-    position: { x: -15, z: -25 },
-    headingRadians: Math.PI * 0.1,
+    position: { x: -31.68, y: 0.75, z: -20 },
+    headingRadians: Math.PI * 0.5,
+  },
+  'tokenplace-studio-cluster': {
+    roomId: 'livingRoom',
+    position: { x: -22.34, y: 0.75, z: -22.61 },
+    headingRadians: Math.PI * 0.05,
+  },
+  'sugarkube-backyard-greenhouse': {
+    roomId: 'livingRoom',
+    position: { x: -8.74, y: 0.75, z: -22.92 },
+    headingRadians: Math.PI * 0.55,
   },
   'danielsmith-portfolio-table': {
-    roomId: 'livingRoom',
-    position: { x: 3, z: -28 },
+    roomId: 'kitchen',
+    position: { x: -21.6, y: 0.75, z: 1.63 },
     headingRadians: 0,
   },
   'gabriel-studio-sentry': {
-    roomId: 'studio',
-    position: { x: 2, z: 8 },
+    roomId: 'creatorsStudio',
+    position: { x: -17.28, y: 4.91, z: -7.02 },
     headingRadians: -Math.PI * 0.3,
   },
-  'tokenplace-studio-cluster': {
-    roomId: 'studio',
-    position: { x: 6, z: 2 },
-    headingRadians: Math.PI * 0.05,
+  'gitshelves-living-room-installation': {
+    roomId: 'focusPods',
+    position: { x: -16.87, y: 4.91, z: 17.23 },
+    headingRadians: Math.PI * 0.1,
   },
-
-  // Kitchen (three exhibits around center)
   'f2clipboard-kitchen-console': {
-    roomId: 'kitchen',
-    position: { x: -20, z: -4 },
+    roomId: 'focusPods',
+    position: { x: -0.63, y: 4.91, z: 14.03 },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
-    roomId: 'kitchen',
-    position: { x: -25, z: 6 },
+    roomId: 'focusPods',
+    position: { x: 16.59, y: 4.91, z: 17.66 },
     headingRadians: Math.PI * 0.1,
   },
 };

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -1,4 +1,4 @@
-import { FLOOR_PLAN } from '../../assets/floorPlan';
+import { FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
 import {
   formatMessage,
   getControlOverlayStrings,
@@ -227,6 +227,10 @@ const baseDefinitions: PoiStaticDefinition[] = [
   },
 ];
 
+const POI_FLOOR_PLAN_ROOMS = FLOOR_PLAN_LEVELS.flatMap(
+  (level) => level.plan.rooms
+);
+
 function localizeBaseDefinitions(input?: LocaleInput): PoiDefinition[] {
   const poiCopy = getPoiCopy(input);
   const controlOverlayStrings = getControlOverlayStrings(input);
@@ -284,7 +288,12 @@ export function localizePoiDefinitions(input?: LocaleInput): PoiDefinition[] {
   // Deterministically lay out indoor POIs across downstairs rooms.
   // Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
   const definitions = applyManualPoiPlacements(localized);
-  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  assertValidPoiDefinitions(definitions, {
+    floorPlan: {
+      outline: [],
+      rooms: POI_FLOOR_PLAN_ROOMS,
+    },
+  });
   return definitions.map((definition) => clonePoi(definition));
 }
 
@@ -400,7 +409,7 @@ export function getPoiDefinitionsByCategory(
 }
 
 export function isPoiInsideRoom(poi: PoiDefinition): boolean {
-  const room = FLOOR_PLAN.rooms.find((entry) => entry.id === poi.roomId);
+  const room = POI_FLOOR_PLAN_ROOMS.find((entry) => entry.id === poi.roomId);
   if (!room) {
     return false;
   }
@@ -413,6 +422,6 @@ export function isPoiInsideRoom(poi: PoiDefinition): boolean {
 
 export function getPoiRoomBounds(poi: PoiDefinition) {
   return (
-    FLOOR_PLAN.rooms.find((room) => room.id === poi.roomId)?.bounds ?? null
+    POI_FLOOR_PLAN_ROOMS.find((room) => room.id === poi.roomId)?.bounds ?? null
   );
 }

--- a/src/scene/poi/validation.ts
+++ b/src/scene/poi/validation.ts
@@ -146,7 +146,7 @@ export function validatePoiDefinitions(
 
     for (let j = i + 1; j < pairs; j += 1) {
       const b = definitions[j];
-      if (!b) continue;
+      if (!b || a.roomId !== b.roomId) continue;
 
       if (allowOverlapSet.has(a.id) && allowOverlapSet.has(b.id)) {
         continue;

--- a/src/scene/structures/mediaWall.ts
+++ b/src/scene/structures/mediaWall.ts
@@ -506,7 +506,12 @@ export function createLivingRoomMediaWall(
   const policy = FUTUROPTIMIST_MEDIA_WALL_POLICY;
 
   const wallInteriorX = bounds.minX + 0.12;
-  const anchorZ = MathUtils.clamp(-14.2, bounds.minZ + 3, bounds.maxZ - 3);
+  const wallCenterZ = (bounds.minZ + bounds.maxZ) / 2;
+  const anchorZ = MathUtils.clamp(
+    wallCenterZ,
+    bounds.minZ + 3,
+    bounds.maxZ - 3
+  );
 
   const boardWidth = 6.4;
   const boardHeight = 3.6;

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -86,6 +86,11 @@ describe('createLivingRoomMediaWall', () => {
     const screen = build.group.getObjectByName('LivingRoomMediaWallScreen');
     expect(screen).toBeTruthy();
 
+    const wallCenterZ = (bounds.minZ + bounds.maxZ) / 2;
+    expect(screen?.position.x).toBeCloseTo(bounds.minX + 0.32);
+    expect(screen?.position.z).toBeCloseTo(wallCenterZ);
+    expect(screen?.rotation.y).toBeCloseTo(Math.PI / 2);
+
     const badge = build.group.getObjectByName('LivingRoomMediaWallBadge');
     expect(badge).toBeTruthy();
 

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import {
   getPoiDefinitions,
   getPoiDefinitionsByCategory,
@@ -40,7 +40,11 @@ describe('POI registry', () => {
   });
 
   it('references rooms that exist in the floor plan', () => {
-    const roomIds = new Set(FLOOR_PLAN.rooms.map((room) => room.id));
+    const roomIds = new Set(
+      FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).map(
+        (room) => room.id
+      )
+    );
     pois.forEach((poi) => {
       expect(roomIds.has(poi.roomId)).toBe(true);
     });
@@ -87,7 +91,7 @@ describe('POI registry', () => {
       (poi) => poi.id === 'sugarkube-backyard-greenhouse'
     );
     expect(greenhouse).toBeDefined();
-    expect(greenhouse?.roomId).toBe('backyard');
+    expect(greenhouse?.roomId).toBe('livingRoom');
     expect(greenhouse?.interactionRadius).toBeGreaterThan(2);
     expect(greenhouse?.footprint.width).toBeGreaterThan(3);
     expect(
@@ -115,11 +119,8 @@ describe('POI registry', () => {
 
   it('exposes stable room-level ordering with defensive copies', () => {
     const expectedStudioOrder = [
-      'tokenplace-studio-cluster',
-      'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
-      'jobbot-studio-terminal',
-      'axel-studio-tracker',
+      'pr-reaper-backyard-console',
     ];
 
     const firstCall = getPoiDefinitionsByRoom('studio');

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN, FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import { getPoiDefinitions } from '../scene/poi/registry';
 import type { PoiDefinition } from '../scene/poi/types';
 import {
@@ -10,6 +10,10 @@ import {
 } from '../scene/poi/validation';
 
 const baseDefinitions = getPoiDefinitions();
+const ALL_FLOOR_PLAN = {
+  outline: [],
+  rooms: FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms),
+};
 const livingRoomBounds = FLOOR_PLAN.rooms.find(
   (room) => room.id === baseDefinitions[0].roomId
 )!.bounds;
@@ -31,7 +35,7 @@ function clonePoi(overrides: Partial<PoiDefinition>): PoiDefinition {
 describe('validatePoiDefinitions', () => {
   it('returns no issues for baseline registry', () => {
     const issues = validatePoiDefinitions(baseDefinitions, {
-      floorPlan: FLOOR_PLAN,
+      floorPlan: ALL_FLOOR_PLAN,
     });
     expect(issues).toHaveLength(0);
   });
@@ -42,7 +46,7 @@ describe('validatePoiDefinitions', () => {
       summary: 'Duplicate entry for testing.',
     };
     const issues = validatePoiDefinitions([...baseDefinitions, duplicate], {
-      floorPlan: FLOOR_PLAN,
+      floorPlan: ALL_FLOOR_PLAN,
     });
     expect(issues).toContainEqual({
       type: 'duplicate-id',
@@ -55,7 +59,7 @@ describe('validatePoiDefinitions', () => {
     const issues = validatePoiDefinitions(
       [...baseDefinitions, invalidRoomPoi],
       {
-        floorPlan: FLOOR_PLAN,
+        floorPlan: ALL_FLOOR_PLAN,
       }
     );
     expect(issues).toContainEqual({
@@ -72,7 +76,7 @@ describe('validatePoiDefinitions', () => {
     const issues = validatePoiDefinitions(
       [...baseDefinitions, invalidPositionPoi],
       {
-        floorPlan: FLOOR_PLAN,
+        floorPlan: ALL_FLOOR_PLAN,
       }
     );
     expect(
@@ -101,7 +105,7 @@ describe('validatePoiDefinitions', () => {
       },
     });
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
+      floorPlan: ALL_FLOOR_PLAN,
     });
     expect(issues).toContainEqual({
       type: 'overlap',
@@ -122,7 +126,7 @@ describe('validatePoiDefinitions', () => {
     });
 
     const issues = validatePoiDefinitions([...baseDefinitions, doorwayPoi], {
-      floorPlan: FLOOR_PLAN,
+      floorPlan: ALL_FLOOR_PLAN,
     });
 
     expect(issues).toContainEqual({
@@ -160,7 +164,7 @@ describe('validatePoiDefinitions', () => {
     });
 
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
+      floorPlan: ALL_FLOOR_PLAN,
     });
 
     expect(issues).toContainEqual({
@@ -188,10 +192,17 @@ describe('validatePoiDefinitions', () => {
       },
     });
     const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
+      floorPlan: ALL_FLOOR_PLAN,
       allowOverlapFor: [poiA.id, poiB.id],
     });
-    expect(issues.every((issue) => issue.type !== 'overlap')).toBe(true);
+    expect(
+      issues.some(
+        (issue) =>
+          issue.type === 'overlap' &&
+          issue.poiId === poiA.id &&
+          issue.otherPoiId === poiB.id
+      )
+    ).toBe(false);
   });
 });
 

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -45,7 +45,7 @@ const createCanvasContext = (
   } as unknown as CanvasRenderingContext2D;
 };
 
-let getContextSpy: ReturnType<typeof vi.spyOn>;
+let getContextSpy: { mockRestore: () => void };
 
 beforeAll(() => {
   getContextSpy = vi
@@ -66,7 +66,7 @@ afterAll(() => {
 const definitionsById = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
 
 type MigratedFactoryPlacement = {
-  position: { x: number; z: number };
+  position: { x: number; y?: number; z: number };
   orientation: number;
 };
 
@@ -81,7 +81,7 @@ type MigratedFactory = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
+    placement: { position: { x: 9.035, y: 0.75, z: 0.745 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
         centerX: position.x,
@@ -92,37 +92,49 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
+    placement: {
+      position: { x: -8.38, y: 4.91, z: -14.4 },
+      orientation: -Math.PI / 2,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'axel-studio-tracker',
-    placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
+    placement: {
+      position: { x: -6.21, y: 4.91, z: -9.59 },
+      orientation: Math.PI,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'wove-kitchen-loom',
-    placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
+    placement: {
+      position: { x: 8.24, y: 4.91, z: 2.135 },
+      orientation: Math.PI * 0.45,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'pr-reaper-backyard-console',
-    placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
+    placement: {
+      position: { x: 1.5, y: 0.75, z: 0.525 },
+      orientation: Math.PI * 0.35,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y, z: position.z },
         orientationRadians: orientation,
       }),
   },
@@ -155,8 +167,8 @@ describe('migrated scene object collider policies', () => {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
-      const registered = [];
-      const metadata = new Map();
+      const registered: RectCollider[] = [];
+      const metadata = new Map<RectCollider, unknown>();
 
       registerSceneObjectColliders(
         factoryColliders,


### PR DESCRIPTION
### Motivation
- Rearrange the canonical POI placements so prominent projects are nearer spawn and less-prominent projects occupy the upper floor while moving full installations (visuals, anchors, colliders, metadata) together.
- Center the Futuroptimist living-room TV using canonical wall geometry instead of a guessed player sample to avoid z-fighting and embedding the interaction anchor in the wall.
- Ensure scene-object showpieces register their colliders and visual groups with the correct floor (ground vs upper) so runtime placement, interaction, and collision logic remain consistent.

### Description
- Updated manual POI placements in `src/scene/poi/placements.ts` to the requested world coordinates and updated room affiliations for moved POIs (ground vs upper), keeping original yaw by default.
- Rehomed scene-object declarations in `src/scene/level/portfolioLevel.ts` for Flywheel, Jobbot, Axel, Wove, and Pr-Reaper to the requested floors/rooms and positions, preserving factory source IDs and orientation.
- Added runtime routing in `src/main.ts` (`getPoiStructureTargets`) so each POI's rendered group and factory colliders are attached to the correct floor group and collider collection (avoids doubling Y offsets and stale ground registrations).
- Recalculated Futuroptimist media-wall center in `src/scene/structures/mediaWall.ts` to derive the screen anchor from `bounds` (wall-centered midpoint) and adjusted the media-wall tests to assert the new derived center and orientation.
- Hardened POI validation and registry usage: `src/scene/poi/registry.ts` now validates against a rooms list derived from `FLOOR_PLAN_LEVELS` and `src/scene/poi/validation.ts` restricts overlap checks to POIs in the same room to avoid false cross-room overlap flags.
- Added and updated focused tests to assert exact world anchors, floor affiliation, DSPACE preservation, danielsmith.io vs pr-reaper separation, media-wall centering, and that migrated scene-object factory args remain aligned; test files changed include `src/scene/poi/placements.test.ts`, `src/tests/mediaWall.test.ts`, `src/tests/sceneObjectColliderPolicies.test.ts`, and related small test typing fixes.

### Testing
- Ran formatting and linting: `npm run format:write` and `npm run lint` (both succeeded).
- Ran focused unit tests: `npm run test -- src/scene/poi/placements.test.ts src/tests/sceneObjectColliderPolicies.test.ts src/tests/mainImports.test.ts --run` and they passed.
- Ran full test CI: `npm run test:ci` and the full suite passed (all tests executed in CI-local run succeeded in this environment).
- Verified docs and smoke: `npm run docs:check` (passed with link fetch warnings) and `npm run smoke` (passed build and dist assertions).
- Ran collider redundancy audit: `npm run collider:audit:redundancy` and exported JSON via `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-poi-layout.json`; the audit reported `Failures: 0` (warnings present but not failures).
- Playwright / preview checks: `npx playwright install chromium` and `npx playwright install-deps chromium` were run, local preview was opened at `http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1`, and a Playwright-driven visit/screenshot reported `0` browser console errors.
- Typecheck: `npm run typecheck` failed due to pre-existing TypeScript baseline issues unrelated to these placement changes (the failures are existing repository baseline type errors; no new placement-specific typecheck regressions were introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3abe0b0308832fb3f2952839015c52)