### PR TITLE
🧭 : – Redistribute launch POIs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2440,6 +2440,10 @@ function initializeImmersiveScene(
   scene.add(upperPoiGroup);
 
   const getPoiFloorId = createPoiFloorResolver(FLOOR_PLAN_LEVELS);
+  const getPoiStructureTargets = (poi: PoiDefinition) =>
+    getPoiFloorId(poi) === 'upper'
+      ? { group: upperFloorGroup, colliders: upperFloorColliders }
+      : { group: groundStructureGroup, colliders: groundColliders };
   const builtPoiInstances = createPoiInstances(poiDefinitions, poiOverrides, {
     detailPolicy: activeSceneDetailPolicy,
   });
@@ -2869,8 +2873,6 @@ function initializeImmersiveScene(
     (poi) => poi.definition.id === 'pr-reaper-backyard-console'
   );
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
-  const kitchenRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'kitchen');
-  const kitchenBounds = kitchenRoom?.bounds;
   if (studioRoom) {
     const centerX =
       flywheelPoi?.group.position.x ??
@@ -2902,38 +2904,38 @@ function initializeImmersiveScene(
     groundStructureGroup.add(showpiece.group);
     flywheelShowpiece = showpiece;
 
-    const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
-    const terminalX = MathUtils.clamp(
-      jobbotPoi?.group.position.x ?? 11.4,
-      studioRoom.bounds.minX + 1.2,
-      studioRoom.bounds.maxX - 0.8
-    );
-    const terminalZ = MathUtils.clamp(
-      jobbotPoi?.group.position.z ?? -0.6,
-      studioRoom.bounds.minZ + 1.2,
-      studioRoom.bounds.maxZ - 1.1
-    );
-    const terminal = createJobbotTerminal({
-      position: { x: terminalX, y: 0, z: terminalZ },
-      orientationRadians: terminalOrientation,
-      detailPolicy: activeSceneDetailPolicy,
-    });
-    const jobbotSceneObject = getSceneObjectDefinition(
-      'jobbot-studio-terminal'
-    );
-    if (jobbotSceneObject) {
-      applySceneObjectSourceMetadata(terminal.group, jobbotSceneObject);
-      registerSceneObjectColliders(
-        terminal.colliders,
-        jobbotSceneObject,
-        groundColliders,
-        colliderSourceMetadata
+    if (jobbotPoi) {
+      const terminalOrientation = jobbotPoi.group.rotation.y ?? -Math.PI / 2;
+      const terminalX = jobbotPoi.group.position.x;
+      const terminalZ = jobbotPoi.group.position.z;
+      const terminal = createJobbotTerminal({
+        position: {
+          x: terminalX,
+          y: jobbotPoi.group.position.y,
+          z: terminalZ,
+        },
+        orientationRadians: terminalOrientation,
+        detailPolicy: activeSceneDetailPolicy,
+      });
+      const jobbotSceneObject = getSceneObjectDefinition(
+        'jobbot-studio-terminal'
       );
-    } else {
-      terminal.colliders.forEach((collider) => groundColliders.push(collider));
+      if (jobbotSceneObject) {
+        applySceneObjectSourceMetadata(terminal.group, jobbotSceneObject);
+        registerSceneObjectColliders(
+          terminal.colliders,
+          jobbotSceneObject,
+          getPoiStructureTargets(jobbotPoi.definition).colliders,
+          colliderSourceMetadata
+        );
+      } else {
+        terminal.colliders.forEach((collider) =>
+          getPoiStructureTargets(jobbotPoi.definition).colliders.push(collider)
+        );
+      }
+      getPoiStructureTargets(jobbotPoi.definition).group.add(terminal.group);
+      jobbotTerminal = terminal;
     }
-    groundStructureGroup.add(terminal.group);
-    jobbotTerminal = terminal;
 
     if (axelPoi) {
       const navigator = createAxelNavigator({
@@ -2950,15 +2952,15 @@ function initializeImmersiveScene(
         registerSceneObjectColliders(
           navigator.colliders,
           axelSceneObject,
-          groundColliders,
+          getPoiStructureTargets(axelPoi.definition).colliders,
           colliderSourceMetadata
         );
       } else {
         navigator.colliders.forEach((collider) =>
-          groundColliders.push(collider)
+          getPoiStructureTargets(axelPoi.definition).colliders.push(collider)
         );
       }
-      groundStructureGroup.add(navigator.group);
+      getPoiStructureTargets(axelPoi.definition).group.add(navigator.group);
       axelNavigator = navigator;
     }
 
@@ -2971,8 +2973,12 @@ function initializeImmersiveScene(
         },
         orientationRadians: tokenPlacePoi.group.rotation.y ?? 0,
       });
-      groundStructureGroup.add(rack.group);
-      rack.colliders.forEach((collider) => groundColliders.push(collider));
+      getPoiStructureTargets(tokenPlacePoi.definition).group.add(rack.group);
+      rack.colliders.forEach((collider) =>
+        getPoiStructureTargets(tokenPlacePoi.definition).colliders.push(
+          collider
+        )
+      );
       tokenPlaceRack = rack;
     }
 
@@ -2985,8 +2991,10 @@ function initializeImmersiveScene(
         },
         orientationRadians: gabrielPoi.group.rotation.y ?? 0,
       });
-      groundStructureGroup.add(sentry.group);
-      sentry.colliders.forEach((collider) => groundColliders.push(collider));
+      getPoiStructureTargets(gabrielPoi.definition).group.add(sentry.group);
+      sentry.colliders.forEach((collider) =>
+        getPoiStructureTargets(gabrielPoi.definition).colliders.push(collider)
+      );
       gabrielSentry = sentry;
     }
   }
@@ -3008,13 +3016,15 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         console.colliders,
         prReaperSceneObject,
-        groundColliders,
+        getPoiStructureTargets(prReaperPoi.definition).colliders,
         colliderSourceMetadata
       );
     } else {
-      console.colliders.forEach((collider) => groundColliders.push(collider));
+      console.colliders.forEach((collider) =>
+        getPoiStructureTargets(prReaperPoi.definition).colliders.push(collider)
+      );
     }
-    groundStructureGroup.add(console.group);
+    getPoiStructureTargets(prReaperPoi.definition).group.add(console.group);
     prReaperConsole = console;
   }
 
@@ -3027,28 +3037,18 @@ function initializeImmersiveScene(
       },
       orientationRadians: gitshelvesPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(installation.group);
+    getPoiStructureTargets(gitshelvesPoi.definition).group.add(
+      installation.group
+    );
     installation.colliders.forEach((collider) =>
-      groundColliders.push(collider)
+      getPoiStructureTargets(gitshelvesPoi.definition).colliders.push(collider)
     );
     gitshelvesInstallation = installation;
   }
 
   if (f2ClipboardPoi) {
-    const consoleX = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : f2ClipboardPoi.group.position.x;
-    const consoleZ = kitchenBounds
-      ? MathUtils.clamp(
-          f2ClipboardPoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.8
-        )
-      : f2ClipboardPoi.group.position.z;
+    const consoleX = f2ClipboardPoi.group.position.x;
+    const consoleZ = f2ClipboardPoi.group.position.z;
     const console = createF2ClipboardConsole({
       position: {
         x: consoleX,
@@ -3057,26 +3057,16 @@ function initializeImmersiveScene(
       },
       orientationRadians: f2ClipboardPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(console.group);
-    console.colliders.forEach((collider) => groundColliders.push(collider));
+    getPoiStructureTargets(f2ClipboardPoi.definition).group.add(console.group);
+    console.colliders.forEach((collider) =>
+      getPoiStructureTargets(f2ClipboardPoi.definition).colliders.push(collider)
+    );
     f2ClipboardConsole = console;
   }
 
   if (sigmaPoi) {
-    const benchX = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.x,
-          kitchenBounds.minX + 0.9,
-          kitchenBounds.maxX - 0.9
-        )
-      : sigmaPoi.group.position.x;
-    const benchZ = kitchenBounds
-      ? MathUtils.clamp(
-          sigmaPoi.group.position.z,
-          kitchenBounds.minZ + 0.9,
-          kitchenBounds.maxZ - 0.9
-        )
-      : sigmaPoi.group.position.z;
+    const benchX = sigmaPoi.group.position.x;
+    const benchZ = sigmaPoi.group.position.z;
     const workbench = createSigmaWorkbench({
       position: {
         x: benchX,
@@ -3085,26 +3075,16 @@ function initializeImmersiveScene(
       },
       orientationRadians: sigmaPoi.group.rotation.y ?? 0,
     });
-    groundStructureGroup.add(workbench.group);
-    workbench.colliders.forEach((collider) => groundColliders.push(collider));
+    getPoiStructureTargets(sigmaPoi.definition).group.add(workbench.group);
+    workbench.colliders.forEach((collider) =>
+      getPoiStructureTargets(sigmaPoi.definition).colliders.push(collider)
+    );
     sigmaWorkbench = workbench;
   }
 
   if (wovePoi) {
-    const loomX = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.x,
-          kitchenBounds.minX + 0.8,
-          kitchenBounds.maxX - 0.8
-        )
-      : wovePoi.group.position.x;
-    const loomZ = kitchenBounds
-      ? MathUtils.clamp(
-          wovePoi.group.position.z,
-          kitchenBounds.minZ + 0.8,
-          kitchenBounds.maxZ - 0.6
-        )
-      : wovePoi.group.position.z;
+    const loomX = wovePoi.group.position.x;
+    const loomZ = wovePoi.group.position.z;
     const loom = createWoveLoom({
       position: {
         x: loomX,
@@ -3119,13 +3099,15 @@ function initializeImmersiveScene(
       registerSceneObjectColliders(
         loom.colliders,
         woveSceneObject,
-        groundColliders,
+        getPoiStructureTargets(wovePoi.definition).colliders,
         colliderSourceMetadata
       );
     } else {
-      loom.colliders.forEach((collider) => groundColliders.push(collider));
+      loom.colliders.forEach((collider) =>
+        getPoiStructureTargets(wovePoi.definition).colliders.push(collider)
+      );
     }
-    groundStructureGroup.add(loom.group);
+    getPoiStructureTargets(wovePoi.definition).group.add(loom.group);
     woveLoom = loom;
   }
 

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -357,47 +357,17 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'ground',
           'showpiece.flywheel',
           'studio',
-          { x: 5.5, z: -2 },
+          { x: 9.035, y: 0.75, z: 0.745 },
           0,
           'POI showpiece and info panel with factory-owned solid colliders'
         ),
         sceneObject(
-          'jobbot-studio-terminal',
-          'ground.studio.jobbot_terminal.scene_object',
-          'ground',
-          'showpiece.jobbot_terminal',
-          'studio',
-          { x: 12, z: 2 },
-          -Math.PI / 2,
-          'POI terminal with factory-owned desk collider'
-        ),
-        sceneObject(
-          'axel-studio-tracker',
-          'ground.studio.axel_navigator.scene_object',
-          'ground',
-          'showpiece.axel_navigator',
-          'studio',
-          { x: 10, z: -2 },
-          Math.PI,
-          'POI navigator with factory-owned dais and console colliders'
-        ),
-        sceneObject(
-          'wove-kitchen-loom',
-          'ground.kitchen.wove_loom.scene_object',
-          'ground',
-          'showpiece.wove_loom',
-          'kitchen',
-          { x: -7.5, z: 2.5 },
-          Math.PI * 0.45,
-          'POI tactile loom with factory-owned table and loom colliders'
-        ),
-        sceneObject(
           'pr-reaper-backyard-console',
-          'ground.backyard.pr_reaper_console.scene_object',
+          'ground.studio.pr_reaper_console.scene_object',
           'ground',
           'showpiece.pr_reaper_console',
-          'backyard',
-          { x: 0, z: 10 },
+          'studio',
+          { x: 1.5, y: 0.75, z: 0.525 },
           Math.PI * 0.35,
           'Backyard POI console with factory-owned deck and console colliders'
         ),
@@ -623,6 +593,38 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           6,
           14,
           ['focusPods']
+        ),
+      ],
+      sceneObjects: [
+        sceneObject(
+          'jobbot-studio-terminal',
+          'upper.creators_studio.jobbot_terminal.scene_object',
+          'upper',
+          'showpiece.jobbot_terminal',
+          'creatorsStudio',
+          { x: -8.38, y: 4.91, z: -14.4 },
+          -Math.PI / 2,
+          'POI terminal with factory-owned desk collider'
+        ),
+        sceneObject(
+          'axel-studio-tracker',
+          'upper.creators_studio.axel_navigator.scene_object',
+          'upper',
+          'showpiece.axel_navigator',
+          'creatorsStudio',
+          { x: -6.21, y: 4.91, z: -9.59 },
+          Math.PI,
+          'POI navigator with factory-owned dais and console colliders'
+        ),
+        sceneObject(
+          'wove-kitchen-loom',
+          'upper.loft_library.wove_loom.scene_object',
+          'upper',
+          'showpiece.wove_loom',
+          'loftLibrary',
+          { x: 8.24, y: 4.91, z: 2.135 },
+          Math.PI * 0.45,
+          'POI tactile loom with factory-owned table and loom colliders'
         ),
       ],
       roomConnections: [

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -23,35 +23,40 @@ describe('applyManualPoiPlacements', () => {
       id: PoiId;
       roomId: string;
       x: number;
+      y: number;
       z: number;
       headingRadians: number;
     }> = [
       {
         id: 'flywheel-studio-flywheel',
         roomId: 'studio',
-        x: 11,
-        z: -4,
+        x: 18.07,
+        y: 0.75,
+        z: 1.49,
         headingRadians: 0,
       },
       {
         id: 'jobbot-studio-terminal',
-        roomId: 'studio',
-        x: 24,
-        z: 4,
+        roomId: 'creatorsStudio',
+        x: -16.76,
+        y: 4.91,
+        z: -28.8,
         headingRadians: -Math.PI / 2,
       },
       {
         id: 'axel-studio-tracker',
-        roomId: 'studio',
-        x: 20,
-        z: -4,
+        roomId: 'creatorsStudio',
+        x: -12.42,
+        y: 4.91,
+        z: -19.18,
         headingRadians: Math.PI,
       },
       {
         id: 'wove-kitchen-loom',
-        roomId: 'kitchen',
-        x: -15,
-        z: 5,
+        roomId: 'loftLibrary',
+        x: 16.48,
+        y: 4.91,
+        z: 4.27,
         headingRadians: Math.PI * 0.45,
       },
     ];
@@ -64,7 +69,7 @@ describe('applyManualPoiPlacements', () => {
       expect(poi.id).toBe(nextExpected.id);
       expect(poi.roomId).toBe(nextExpected.roomId);
       expect(poi.position.x).toBeCloseTo(nextExpected.x);
-      expect(poi.position.y).toBe(0.5);
+      expect(poi.position.y).toBeCloseTo(nextExpected.y);
       expect(poi.position.z).toBeCloseTo(nextExpected.z);
       expect(poi.headingRadians).toBeCloseTo(nextExpected.headingRadians);
     }

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -61,37 +61,44 @@ export const MANUAL_POI_PLACEMENTS: Partial<
     }
   >
 > = {
-  // Living room (center-biased spread)
-  'gitshelves-living-room-installation': {
+  'futuroptimist-living-room-tv': {
     roomId: 'livingRoom',
-    position: { x: -15, z: -25 },
-    headingRadians: Math.PI * 0.1,
-  },
-  'danielsmith-portfolio-table': {
-    roomId: 'livingRoom',
-    position: { x: 3, z: -28 },
-    headingRadians: 0,
-  },
-  'gabriel-studio-sentry': {
-    roomId: 'studio',
-    position: { x: 2, z: 8 },
-    headingRadians: -Math.PI * 0.3,
+    position: { x: -31.52, y: 0.75, z: -28.4 },
+    headingRadians: Math.PI * 0.5,
   },
   'tokenplace-studio-cluster': {
-    roomId: 'studio',
-    position: { x: 6, z: 2 },
+    roomId: 'livingRoom',
+    position: { x: -22.34, y: 0.75, z: -22.61 },
     headingRadians: Math.PI * 0.05,
   },
-
-  // Kitchen (three exhibits around center)
-  'f2clipboard-kitchen-console': {
+  'sugarkube-backyard-greenhouse': {
+    roomId: 'livingRoom',
+    position: { x: -8.74, y: 0.75, z: -22.92 },
+    headingRadians: Math.PI * 0.55,
+  },
+  'danielsmith-portfolio-table': {
     roomId: 'kitchen',
-    position: { x: -20, z: -4 },
+    position: { x: -21.6, y: 0.75, z: 1.63 },
+    headingRadians: 0,
+  },
+  'f2clipboard-kitchen-console': {
+    roomId: 'focusPods',
+    position: { x: -0.63, y: 4.91, z: 14.03 },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
-    roomId: 'kitchen',
-    position: { x: -25, z: 6 },
+    roomId: 'focusPods',
+    position: { x: 16.59, y: 4.91, z: 17.66 },
+    headingRadians: Math.PI * 0.1,
+  },
+  'gabriel-studio-sentry': {
+    roomId: 'creatorsStudio',
+    position: { x: -17.28, y: 4.91, z: -7.02 },
+    headingRadians: -Math.PI * 0.3,
+  },
+  'gitshelves-living-room-installation': {
+    roomId: 'focusPods',
+    position: { x: -16.87, y: 4.91, z: 17.23 },
     headingRadians: Math.PI * 0.1,
   },
 };

--- a/src/scene/poi/registry.ts
+++ b/src/scene/poi/registry.ts
@@ -1,4 +1,4 @@
-import { FLOOR_PLAN } from '../../assets/floorPlan';
+import { FLOOR_PLAN, FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
 import {
   formatMessage,
   getControlOverlayStrings,
@@ -284,7 +284,13 @@ export function localizePoiDefinitions(input?: LocaleInput): PoiDefinition[] {
   // Deterministically lay out indoor POIs across downstairs rooms.
   // Apply only manual placements for downstairs. Simple, explicit, and easy to tweak.
   const definitions = applyManualPoiPlacements(localized);
-  assertValidPoiDefinitions(definitions, { floorPlan: FLOOR_PLAN });
+  assertValidPoiDefinitions(definitions, {
+    floorPlan: FLOOR_PLAN,
+    floorPlans: FLOOR_PLAN_LEVELS.map((level) => ({
+      id: level.id,
+      plan: level.plan,
+    })),
+  });
   return definitions.map((definition) => clonePoi(definition));
 }
 
@@ -400,7 +406,9 @@ export function getPoiDefinitionsByCategory(
 }
 
 export function isPoiInsideRoom(poi: PoiDefinition): boolean {
-  const room = FLOOR_PLAN.rooms.find((entry) => entry.id === poi.roomId);
+  const room = FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).find(
+    (entry) => entry.id === poi.roomId
+  );
   if (!room) {
     return false;
   }
@@ -413,6 +421,8 @@ export function isPoiInsideRoom(poi: PoiDefinition): boolean {
 
 export function getPoiRoomBounds(poi: PoiDefinition) {
   return (
-    FLOOR_PLAN.rooms.find((room) => room.id === poi.roomId)?.bounds ?? null
+    FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).find(
+      (room) => room.id === poi.roomId
+    )?.bounds ?? null
   );
 }

--- a/src/scene/poi/validation.ts
+++ b/src/scene/poi/validation.ts
@@ -26,13 +26,16 @@ export type PoiValidationIssue =
 
 export interface PoiValidationOptions {
   floorPlan: FloorPlanDefinition;
+  floorPlans?: ReadonlyArray<{ id: string; plan: FloorPlanDefinition }>;
   /** Optional epsilon for floating point comparisons. */
   epsilon?: number;
   /** Allow small overlaps when POIs are conceptually the same exhibit. */
   allowOverlapFor?: PoiId[];
 }
 
-const defaultOptions: Required<Omit<PoiValidationOptions, 'floorPlan'>> = {
+const defaultOptions: Required<
+  Omit<PoiValidationOptions, 'floorPlan' | 'floorPlans'>
+> = {
   epsilon: 1e-4,
   allowOverlapFor: [],
 };
@@ -57,23 +60,30 @@ export function validatePoiDefinitions(
   definitions: PoiDefinition[],
   options: PoiValidationOptions
 ): PoiValidationIssue[] {
-  const { floorPlan } = options;
+  const floorPlans = options.floorPlans ?? [
+    { id: 'ground', plan: options.floorPlan },
+  ];
   const { epsilon, allowOverlapFor } = { ...defaultOptions, ...options };
 
   const issues: PoiValidationIssue[] = [];
   const seen = new Map<PoiId, PoiDefinition>();
-  const roomLookup = new Map(floorPlan.rooms.map((room) => [room.id, room]));
-  const clearances = getDoorwayClearanceZones(floorPlan);
-  const clearancesByRoom = new Map<string, DoorwayClearanceZone[]>(
-    floorPlan.rooms.map((room) => [room.id, []])
-  );
-  clearances.forEach((zone) => {
-    const list = clearancesByRoom.get(zone.roomId);
-    if (list) {
-      list.push(zone);
-    } else {
-      clearancesByRoom.set(zone.roomId, [zone]);
-    }
+  const roomLookup = new Map<string, FloorPlanDefinition['rooms'][number]>();
+  const roomFloorIds = new Map<string, string>();
+  const clearancesByRoom = new Map<string, DoorwayClearanceZone[]>();
+  floorPlans.forEach(({ id, plan }) => {
+    plan.rooms.forEach((room) => {
+      roomLookup.set(room.id, room);
+      roomFloorIds.set(room.id, id);
+      clearancesByRoom.set(room.id, []);
+    });
+    getDoorwayClearanceZones(plan).forEach((zone) => {
+      const list = clearancesByRoom.get(zone.roomId);
+      if (list) {
+        list.push(zone);
+      } else {
+        clearancesByRoom.set(zone.roomId, [zone]);
+      }
+    });
   });
 
   definitions.forEach((definition) => {
@@ -149,6 +159,10 @@ export function validatePoiDefinitions(
       if (!b) continue;
 
       if (allowOverlapSet.has(a.id) && allowOverlapSet.has(b.id)) {
+        continue;
+      }
+
+      if (roomFloorIds.get(a.roomId) !== roomFloorIds.get(b.roomId)) {
         continue;
       }
 

--- a/src/tests/mediaWall.test.ts
+++ b/src/tests/mediaWall.test.ts
@@ -174,6 +174,31 @@ describe('createLivingRoomMediaWall', () => {
     expect(() => build.controller.dispose()).not.toThrow();
   });
 
+  it('centers the TV on the derived living-room west wall bay', () => {
+    const bounds = getProductionRoomBounds('ground', 'livingRoom');
+    const build = createLivingRoomMediaWall(bounds);
+    const screen = build.group.getObjectByName('LivingRoomMediaWallScreen');
+    const clearance = build.group.getObjectByName(
+      'LivingRoomMediaWallClearance'
+    );
+
+    if (!screen || !clearance) {
+      throw new Error('Missing media wall screen or clearance anchor');
+    }
+
+    const expectedInteriorX = bounds.minX + 0.12;
+    const expectedBayCenterZ = Math.max(
+      bounds.minZ + 3,
+      Math.min(-14.2, bounds.maxZ - 3)
+    );
+
+    expect(screen.position.x).toBeCloseTo(expectedInteriorX + 0.2, 2);
+    expect(screen.position.z).toBeCloseTo(expectedBayCenterZ, 2);
+    expect(screen.rotation.y).toBeCloseTo(Math.PI / 2, 6);
+    expect(clearance.position.x).toBeGreaterThan(expectedInteriorX + 0.18);
+    expect(clearance.position.z).toBeCloseTo(expectedBayCenterZ, 2);
+  });
+
   it('declares the media POI as an active visual-only source policy', () => {
     expect(FUTUROPTIMIST_MEDIA_WALL_POLICY).toMatchObject({
       role: 'living-room-futuroptimist-media',

--- a/src/tests/poiProductionPlacement.test.ts
+++ b/src/tests/poiProductionPlacement.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
+import { createPoiFloorResolver } from '../scene/floors/visibilityController';
+import { getPoiDefinitions } from '../scene/poi/registry';
+import type { PoiDefinition, PoiId } from '../scene/poi/types';
+
+const getPoi = (definitions: PoiDefinition[], id: PoiId): PoiDefinition => {
+  const poi = definitions.find((candidate) => candidate.id === id);
+  if (!poi) {
+    throw new Error(`Missing POI ${id}`);
+  }
+  return poi;
+};
+
+const expectPosition = (
+  actual: { x: number; y: number; z: number },
+  expected: { x: number; y: number; z: number }
+) => {
+  expect(actual.x).toBeCloseTo(expected.x, 2);
+  expect(actual.y).toBeCloseTo(expected.y, 2);
+  expect(actual.z).toBeCloseTo(expected.z, 2);
+};
+
+describe('production POI placement', () => {
+  const definitions = getPoiDefinitions();
+  const getPoiFloorId = createPoiFloorResolver(FLOOR_PLAN_LEVELS);
+
+  it('resolves requested ground-floor POIs to their world anchors', () => {
+    const expected = new Map<PoiId, { x: number; y: number; z: number }>([
+      ['tokenplace-studio-cluster', { x: -22.34, y: 0.75, z: -22.61 }],
+      ['sugarkube-backyard-greenhouse', { x: -8.74, y: 0.75, z: -22.92 }],
+      ['danielsmith-portfolio-table', { x: -21.6, y: 0.75, z: 1.63 }],
+      ['pr-reaper-backyard-console', { x: 3, y: 0.75, z: 1.05 }],
+      ['flywheel-studio-flywheel', { x: 18.07, y: 0.75, z: 1.49 }],
+    ]);
+
+    expected.forEach((position, id) => {
+      const poi = getPoi(definitions, id);
+      expect(getPoiFloorId(poi)).toBe('ground');
+      expectPosition(poi.position, position);
+    });
+  });
+
+  it('resolves requested upper-floor POIs to their world anchors', () => {
+    const expected = new Map<PoiId, { x: number; y: number; z: number }>([
+      ['jobbot-studio-terminal', { x: -16.76, y: 4.91, z: -28.8 }],
+      ['axel-studio-tracker', { x: -12.42, y: 4.91, z: -19.18 }],
+      ['gabriel-studio-sentry', { x: -17.28, y: 4.91, z: -7.02 }],
+      ['wove-kitchen-loom', { x: 16.48, y: 4.91, z: 4.27 }],
+      ['sigma-kitchen-workbench', { x: 16.59, y: 4.91, z: 17.66 }],
+      ['f2clipboard-kitchen-console', { x: -0.63, y: 4.91, z: 14.03 }],
+      ['gitshelves-living-room-installation', { x: -16.87, y: 4.91, z: 17.23 }],
+    ]);
+
+    expected.forEach((position, id) => {
+      const poi = getPoi(definitions, id);
+      expect(getPoiFloorId(poi)).toBe('upper');
+      expectPosition(poi.position, position);
+    });
+  });
+
+  it('keeps DSPACE placement, floor, and orientation unchanged', () => {
+    const dspace = getPoi(definitions, 'dspace-backyard-rocket');
+
+    expect(getPoiFloorId(dspace)).toBe('ground');
+    expectPosition(dspace.position, { x: -12, y: 0, z: 24 });
+    expect(dspace.headingRadians).toBeCloseTo(-Math.PI / 10, 6);
+  });
+
+  it('keeps danielsmith.io and pr-reaper independently reachable', () => {
+    const danielsmith = getPoi(definitions, 'danielsmith-portfolio-table');
+    const prReaper = getPoi(definitions, 'pr-reaper-backyard-console');
+
+    expectPosition(danielsmith.position, { x: -21.6, y: 0.75, z: 1.63 });
+    expectPosition(prReaper.position, { x: 3, y: 0.75, z: 1.05 });
+    expect(
+      Math.hypot(
+        danielsmith.position.x - prReaper.position.x,
+        danielsmith.position.z - prReaper.position.z
+      )
+    ).toBeGreaterThan(20);
+    expect(danielsmith.links?.map((link) => link.href)).toContain(
+      'https://danielsmith.io'
+    );
+    expect(prReaper.links?.map((link) => link.href)).toContain(
+      'https://github.com/futuroptimist/pr-reaper'
+    );
+  });
+});

--- a/src/tests/poiRegistry.test.ts
+++ b/src/tests/poiRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import {
   getPoiDefinitions,
   getPoiDefinitionsByCategory,
@@ -40,7 +40,11 @@ describe('POI registry', () => {
   });
 
   it('references rooms that exist in the floor plan', () => {
-    const roomIds = new Set(FLOOR_PLAN.rooms.map((room) => room.id));
+    const roomIds = new Set(
+      FLOOR_PLAN_LEVELS.flatMap((level) => level.plan.rooms).map(
+        (room) => room.id
+      )
+    );
     pois.forEach((poi) => {
       expect(roomIds.has(poi.roomId)).toBe(true);
     });
@@ -87,7 +91,7 @@ describe('POI registry', () => {
       (poi) => poi.id === 'sugarkube-backyard-greenhouse'
     );
     expect(greenhouse).toBeDefined();
-    expect(greenhouse?.roomId).toBe('backyard');
+    expect(greenhouse?.roomId).toBe('livingRoom');
     expect(greenhouse?.interactionRadius).toBeGreaterThan(2);
     expect(greenhouse?.footprint.width).toBeGreaterThan(3);
     expect(
@@ -115,11 +119,8 @@ describe('POI registry', () => {
 
   it('exposes stable room-level ordering with defensive copies', () => {
     const expectedStudioOrder = [
-      'tokenplace-studio-cluster',
-      'gabriel-studio-sentry',
       'flywheel-studio-flywheel',
-      'jobbot-studio-terminal',
-      'axel-studio-tracker',
+      'pr-reaper-backyard-console',
     ];
 
     const firstCall = getPoiDefinitionsByRoom('studio');

--- a/src/tests/poiValidation.test.ts
+++ b/src/tests/poiValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOOR_PLAN } from '../assets/floorPlan';
+import { FLOOR_PLAN, FLOOR_PLAN_LEVELS } from '../assets/floorPlan';
 import { getPoiDefinitions } from '../scene/poi/registry';
 import type { PoiDefinition } from '../scene/poi/types';
 import {
@@ -10,6 +10,16 @@ import {
 } from '../scene/poi/validation';
 
 const baseDefinitions = getPoiDefinitions();
+const productionFloorPlans = FLOOR_PLAN_LEVELS.map((level) => ({
+  id: level.id,
+  plan: level.plan,
+}));
+
+const validationOptions = {
+  floorPlan: FLOOR_PLAN,
+  floorPlans: productionFloorPlans,
+};
+
 const livingRoomBounds = FLOOR_PLAN.rooms.find(
   (room) => room.id === baseDefinitions[0].roomId
 )!.bounds;
@@ -30,9 +40,7 @@ function clonePoi(overrides: Partial<PoiDefinition>): PoiDefinition {
 
 describe('validatePoiDefinitions', () => {
   it('returns no issues for baseline registry', () => {
-    const issues = validatePoiDefinitions(baseDefinitions, {
-      floorPlan: FLOOR_PLAN,
-    });
+    const issues = validatePoiDefinitions(baseDefinitions, validationOptions);
     expect(issues).toHaveLength(0);
   });
 
@@ -41,9 +49,10 @@ describe('validatePoiDefinitions', () => {
       ...baseDefinitions[1],
       summary: 'Duplicate entry for testing.',
     };
-    const issues = validatePoiDefinitions([...baseDefinitions, duplicate], {
-      floorPlan: FLOOR_PLAN,
-    });
+    const issues = validatePoiDefinitions(
+      [...baseDefinitions, duplicate],
+      validationOptions
+    );
     expect(issues).toContainEqual({
       type: 'duplicate-id',
       poiId: duplicate.id,
@@ -100,9 +109,10 @@ describe('validatePoiDefinitions', () => {
         z: livingRoomBounds.minZ + 2,
       },
     });
-    const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
-    });
+    const issues = validatePoiDefinitions(
+      [...baseDefinitions, poiA, poiB],
+      validationOptions
+    );
     expect(issues).toContainEqual({
       type: 'overlap',
       poiId: poiA.id,
@@ -121,9 +131,10 @@ describe('validatePoiDefinitions', () => {
       footprint: { width: 3.2, depth: 2.4 },
     });
 
-    const issues = validatePoiDefinitions([...baseDefinitions, doorwayPoi], {
-      floorPlan: FLOOR_PLAN,
-    });
+    const issues = validatePoiDefinitions(
+      [...baseDefinitions, doorwayPoi],
+      validationOptions
+    );
 
     expect(issues).toContainEqual({
       type: 'doorway-blocked',
@@ -159,9 +170,10 @@ describe('validatePoiDefinitions', () => {
       interactionRadius: 2,
     });
 
-    const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
-    });
+    const issues = validatePoiDefinitions(
+      [...baseDefinitions, poiA, poiB],
+      validationOptions
+    );
 
     expect(issues).toContainEqual({
       type: 'overlap',
@@ -187,8 +199,8 @@ describe('validatePoiDefinitions', () => {
         z: livingRoomBounds.minZ + 4,
       },
     });
-    const issues = validatePoiDefinitions([...baseDefinitions, poiA, poiB], {
-      floorPlan: FLOOR_PLAN,
+    const issues = validatePoiDefinitions([poiA, poiB], {
+      ...validationOptions,
       allowOverlapFor: [poiA.id, poiB.id],
     });
     expect(issues.every((issue) => issue.type !== 'overlap')).toBe(true);
@@ -243,11 +255,11 @@ describe('assertValidPoiDefinitions', () => {
     ];
 
     expect(() =>
-      assertValidPoiDefinitions(problematicList, { floorPlan: FLOOR_PLAN })
+      assertValidPoiDefinitions(problematicList, validationOptions)
     ).toThrowError(/Duplicate POI id detected/);
 
     try {
-      assertValidPoiDefinitions(problematicList, { floorPlan: FLOOR_PLAN });
+      assertValidPoiDefinitions(problematicList, validationOptions);
     } catch (error) {
       if (error instanceof Error) {
         expect(error.message).toContain('unknown room');

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -45,7 +45,7 @@ const createCanvasContext = (
   } as unknown as CanvasRenderingContext2D;
 };
 
-let getContextSpy: ReturnType<typeof vi.spyOn>;
+let getContextSpy: { mockRestore: () => void };
 
 beforeAll(() => {
   getContextSpy = vi
@@ -66,7 +66,7 @@ afterAll(() => {
 const definitionsById = createSceneObjectDefinitionsById(PORTFOLIO_LEVEL);
 
 type MigratedFactoryPlacement = {
-  position: { x: number; z: number };
+  position: { x: number; y?: number; z: number };
   orientation: number;
 };
 
@@ -81,7 +81,7 @@ type MigratedFactory = {
 const migratedFactories = [
   {
     id: 'flywheel-studio-flywheel',
-    placement: { position: { x: 5.5, z: -2 }, orientation: 0 },
+    placement: { position: { x: 9.035, y: 0.75, z: 0.745 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
         centerX: position.x,
@@ -92,37 +92,49 @@ const migratedFactories = [
   },
   {
     id: 'jobbot-studio-terminal',
-    placement: { position: { x: 12, z: 2 }, orientation: -Math.PI / 2 },
+    placement: {
+      position: { x: -8.38, y: 4.91, z: -14.4 },
+      orientation: -Math.PI / 2,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createJobbotTerminal({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'axel-studio-tracker',
-    placement: { position: { x: 10, z: -2 }, orientation: Math.PI },
+    placement: {
+      position: { x: -6.21, y: 4.91, z: -9.59 },
+      orientation: Math.PI,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createAxelNavigator({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'wove-kitchen-loom',
-    placement: { position: { x: -7.5, z: 2.5 }, orientation: Math.PI * 0.45 },
+    placement: {
+      position: { x: 8.24, y: 4.91, z: 2.135 },
+      orientation: Math.PI * 0.45,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createWoveLoom({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
   {
     id: 'pr-reaper-backyard-console',
-    placement: { position: { x: 0, z: 10 }, orientation: Math.PI * 0.35 },
+    placement: {
+      position: { x: 1.5, y: 0.75, z: 0.525 },
+      orientation: Math.PI * 0.35,
+    },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createPrReaperConsole({
-        position: { x: position.x, y: 0, z: position.z },
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
       }),
   },
@@ -155,8 +167,8 @@ describe('migrated scene object collider policies', () => {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
       const factoryColliders = build(placement).colliders;
-      const registered = [];
-      const metadata = new Map();
+      const registered: RectCollider[] = [];
+      const metadata = new Map<RectCollider, unknown>();
 
       registerSceneObjectColliders(
         factoryColliders,
@@ -184,7 +196,7 @@ describe('migrated scene object collider policies', () => {
       const definition = definitionsById.get(id);
       expect(definition, id).toBeDefined();
 
-      return `${definition!.position.x},${definition!.position.z},${definition!.orientation}`;
+      return `${definition!.position.x},${definition!.position.y ?? 0},${definition!.position.z},${definition!.orientation}`;
     });
 
     expect(new Set(placements).size).toBe(placements.length);


### PR DESCRIPTION
### Motivation
- Bring prominent project POIs closer to spawn and populate the sparse upper floor while moving complete installations (visuals, anchors, colliders, metadata) as a single unit.
- Keep DSPACE unchanged, preserve Sugarkube visuals, and ensure the Futuroptimist media wall is centered using canonical wall geometry rather than a guessed sample.

### Description
- Updated canonical placement overrides in `src/scene/poi/placements.ts` to place requested POIs at the specified world anchors and to assign upstairs POIs to the upper rooms (world y targets preserved at `0.75` for ground and `4.91` for upper). 
- Moved scene-object declarations in `src/scene/level/portfolioLevel.ts` so factory-backed showpieces are declared on the correct floor/room and use the requested positions for Jobbot, Axel, Wove, Flywheel, PR Reaper, and others.
- Routed showpiece visuals and collider registration through a floor-aware helper in `src/main.ts` (`getPoiStructureTargets`) so built showpieces, colliders, groups, and children attach to the resolved floor group and collider collection instead of leaving ghost colliders on the old floor.
- Extended POI registry/validation to be floor-aware by feeding `FLOOR_PLAN_LEVELS` into validation and room lookup logic in `src/scene/poi/registry.ts` and `src/scene/poi/validation.ts`, and restricted overlap checks to POIs on the same floor.
- Added focused tests and adjustments: new `src/tests/poiProductionPlacement.test.ts`, updated `src/tests/mediaWall.test.ts`, `src/tests/poiValidation.test.ts`, and other tests to assert exact world anchors, DSPACE regression, separation of `danielsmith.io` vs `pr-reaper`, and that the Futuroptimist TV is centered on the derived wall bay.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both passed.
- Ran unit test suite with `npm run test:ci`, which completed successfully (suite run: 168 test files; all tests passed in the end).
- Ran `npm run docs:check`, which passed but the link checker emitted external fetch warnings unrelated to these changes.
- Executed `npm run smoke` (build + assertions) and it passed.
- Ran the collider redundancy gate with `npm run collider:audit:redundancy` and exported JSON via `npm --silent run collider:audit:redundancy -- --json > /tmp/collider-redundancy-poi-layout.json`, the audit reported `Failures: 0`.
- `npm run typecheck` was executed and reported TypeScript errors from existing baseline areas (examples: `src/main.ts`, `src/scene/avatar/importer.ts`), these are existing repository type issues not introduced by this PR and therefore not widened here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3abe1aa854832fa76af09aaf04664f)