### PR TITLE
📐 Unify floor anchors and raise upper floor to Y=5

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -400,7 +400,7 @@ async function walkStairCenterlineToUpperLanding(page: Page) {
   expect(firstUpperZ).not.toBeNull();
   expect(walkResults.finalState.activeFloor).toBe('upper');
   expect(walkResults.finalState.position.y).toBeGreaterThanOrEqual(
-    PLAYER_RADIUS + upperFloorElevation - 0.01
+    upperFloorElevation - 0.01
   );
 
   return walkResults.finalState;

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,6 +152,10 @@ import {
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
 import { isBackyardSourceCollider } from './scene/level/backyardCollisionPolicies';
+import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from './scene/level/floorElevations';
 import { generateFloorSurfaces } from './scene/level/generateFloorSurfaces';
 import { generateWallSegmentInstances } from './scene/level/generateWalls';
 import {
@@ -947,13 +951,25 @@ const handleImmersiveFailure = (
   markDocumentReady('fallback', 'immersive-init-error');
 };
 
+const STAIRCASE_LANDING_THICKNESS = 0.38;
+const STAIRCASE_STEP_COUNT = 9;
+const STAIRCASE_STEP_RISE =
+  (UPPER_FLOOR_TOP_ELEVATION -
+    GROUND_FLOOR_TOP_ELEVATION -
+    STAIRCASE_LANDING_THICKNESS) /
+  STAIRCASE_STEP_COUNT;
+
 const STAIRCASE_CONFIG = {
   name: 'LivingRoomStaircase',
-  basePosition: new Vector3(toWorldUnits(6.2), 0, toWorldUnits(-5.3)),
+  basePosition: new Vector3(
+    toWorldUnits(6.2),
+    GROUND_FLOOR_TOP_ELEVATION,
+    toWorldUnits(-5.3)
+  ),
   direction: 'negativeZ',
   step: {
-    count: 9,
-    rise: 0.42,
+    count: STAIRCASE_STEP_COUNT,
+    rise: STAIRCASE_STEP_RISE,
     run: toWorldUnits(0.85),
     width: toWorldUnits(3.1),
     material: {
@@ -965,7 +981,7 @@ const STAIRCASE_CONFIG = {
   },
   landing: {
     depth: toWorldUnits(2.6),
-    thickness: 0.38,
+    thickness: STAIRCASE_LANDING_THICKNESS,
     material: {
       color: 0x5b6775,
       roughness: 0.55,
@@ -1746,7 +1762,7 @@ function initializeImmersiveScene(
   const initialRoom = FLOOR_PLAN.rooms[0];
   const initialPlayerPosition = new Vector3(
     (initialRoom.bounds.minX + initialRoom.bounds.maxX) / 2,
-    PLAYER_RADIUS,
+    GROUND_FLOOR_TOP_ELEVATION,
     (initialRoom.bounds.minZ + initialRoom.bounds.maxZ) / 2
   );
 
@@ -1783,7 +1799,10 @@ function initializeImmersiveScene(
   const cameraForwardPlanar = new Vector3();
   const cameraWorldUp = new Vector3();
 
-  const cameraCenter = initialPlayerPosition.clone();
+  const cameraFocusOffsetY = PLAYER_RADIUS;
+  const cameraCenter = initialPlayerPosition
+    .clone()
+    .add(new Vector3(0, cameraFocusOffsetY, 0));
   camera.position.copy(cameraCenter).add(cameraBaseOffset);
   camera.lookAt(cameraCenter.x, cameraCenter.y, cameraCenter.z);
   initialCameraFraming = resolveInitialAvatarCameraFraming({
@@ -1911,7 +1930,7 @@ function initializeImmersiveScene(
   });
   const floorTiles = generateFloorSurfaces(getLevelFloor('ground'), {
     material: floorMaterial,
-    elevation: 0,
+    elevation: GROUND_FLOOR_TOP_ELEVATION,
     groupName: 'GroundFloorTiles',
   });
   groundFloorGroup.add(floorTiles.group);
@@ -1942,7 +1961,7 @@ function initializeImmersiveScene(
     getLevelFloor('ground'),
     {
       coordinateScale: FLOOR_PLAN_SCALE,
-      baseElevation: 0,
+      baseElevation: GROUND_FLOOR_TOP_ELEVATION,
       wallHeight: WALL_HEIGHT,
       wallThickness: WALL_THICKNESS,
       fenceHeight: FENCE_HEIGHT,
@@ -1971,7 +1990,7 @@ function initializeImmersiveScene(
 
   const doorwayOpenings = createDoorwayOpenings(FLOOR_PLAN, {
     wallHeight: WALL_HEIGHT,
-    baseElevation: 0,
+    baseElevation: GROUND_FLOOR_TOP_ELEVATION,
     doorHeight: WALL_HEIGHT * 0.72,
     jambThickness: WALL_THICKNESS * 0.76,
     lintelThickness: 0.26,
@@ -2091,8 +2110,7 @@ function initializeImmersiveScene(
   const stairTopZ = stairLayout.topZ;
   const stairLandingMinZ = stairLayout.landingMinZ;
   const stairLandingMaxZ = stairLayout.landingMaxZ;
-  const upperFloorElevation =
-    stairTotalRise + STAIRCASE_CONFIG.landing.thickness;
+  const upperFloorElevation = UPPER_FLOOR_TOP_ELEVATION;
   const stairGeometry: StairGeometry = {
     centerX: stairCenterX,
     halfWidth: stairHalfWidth,
@@ -3205,7 +3223,10 @@ function initializeImmersiveScene(
   if (pendingPlayerPosition) {
     player.position.set(
       pendingPlayerPosition.x,
-      pendingPlayerPosition.y,
+      pendingPlayerPosition.y >=
+        (GROUND_FLOOR_TOP_ELEVATION + UPPER_FLOOR_TOP_ELEVATION) / 2
+        ? UPPER_FLOOR_TOP_ELEVATION
+        : GROUND_FLOOR_TOP_ELEVATION,
       pendingPlayerPosition.z
     );
   } else {
@@ -4345,7 +4366,7 @@ function initializeImmersiveScene(
       currentFloor: verticalSurfaceFloor,
       upperFloorElevation,
     });
-    player.position.y = PLAYER_RADIUS + baseHeight;
+    player.position.y = baseHeight;
   };
 
   const collidesWithCollider = (
@@ -6118,7 +6139,7 @@ function initializeImmersiveScene(
 
     cameraCenter.set(
       player.position.x + cameraPan.x,
-      player.position.y,
+      player.position.y + cameraFocusOffsetY,
       player.position.z + cameraPan.z
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3221,14 +3221,7 @@ function initializeImmersiveScene(
   const player = mannequin.group;
   const mannequinHeight = mannequin.height;
   if (pendingPlayerPosition) {
-    player.position.set(
-      pendingPlayerPosition.x,
-      pendingPlayerPosition.y >=
-        (GROUND_FLOOR_TOP_ELEVATION + UPPER_FLOOR_TOP_ELEVATION) / 2
-        ? UPPER_FLOOR_TOP_ELEVATION
-        : GROUND_FLOOR_TOP_ELEVATION,
-      pendingPlayerPosition.z
-    );
+    player.position.copy(pendingPlayerPosition);
   } else {
     player.position.copy(initialPlayerPosition);
   }

--- a/src/scene/avatar/mannequin.ts
+++ b/src/scene/avatar/mannequin.ts
@@ -114,11 +114,12 @@ export function createPortfolioMannequin(
   );
   collisionProxy.name = 'PortfolioMannequinCollisionProxy';
   collisionProxy.visible = false;
+  collisionProxy.position.y = collisionRadius;
   group.add(collisionProxy);
 
   const mannequinRoot = new Group();
   mannequinRoot.name = 'PortfolioMannequinVisual';
-  mannequinRoot.position.y = -collisionRadius;
+  mannequinRoot.position.y = 0;
   group.add(mannequinRoot);
 
   const platformMaterial = createStandardMaterial(

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-
 import {
   createStairNavigationZones,
   type StairBehavior,
@@ -8,7 +7,10 @@ import {
 } from '../../../systems/movement/stairs';
 import { assertDebugColliderIdsDoNotCollide } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
-import { UPPER_FLOOR_TOP_ELEVATION } from '../../level/floorElevations';
+import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from '../../level/floorElevations';
 import { validateSourceCollisionRecords } from '../sourceCollisionValidation';
 import {
   createGroundStairSafetyColliders,
@@ -20,7 +22,8 @@ const PLAYER_RADIUS = 0.75;
 const LANDING_THICKNESS = 0.38;
 const STAIR_STEP_COUNT = 9;
 const STAIR_STEP_RISE =
-  (UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) / STAIR_STEP_COUNT;
+  (UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) /
+  STAIR_STEP_COUNT;
 
 const geometry: StairGeometry = {
   centerX: 12.4,
@@ -29,7 +32,8 @@ const geometry: StairGeometry = {
   topZ: -25.9,
   landingMinZ: -31.1,
   landingMaxZ: -25.9,
-  totalRise: UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS,
+  totalRise:
+    UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - LANDING_THICKNESS,
   direction: -1,
 };
 

--- a/src/scene/level/__tests__/stairSafetyColliders.test.ts
+++ b/src/scene/level/__tests__/stairSafetyColliders.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+
 import {
   createStairNavigationZones,
   type StairBehavior,
@@ -7,6 +8,7 @@ import {
 } from '../../../systems/movement/stairs';
 import { assertDebugColliderIdsDoNotCollide } from '../../debug/colliderDebugIds';
 import { createColliderDebugId } from '../../debug/colliderVisualizer';
+import { UPPER_FLOOR_TOP_ELEVATION } from '../../level/floorElevations';
 import { validateSourceCollisionRecords } from '../sourceCollisionValidation';
 import {
   createGroundStairSafetyColliders,
@@ -15,6 +17,10 @@ import {
 } from '../stairSafetyColliders';
 
 const PLAYER_RADIUS = 0.75;
+const LANDING_THICKNESS = 0.38;
+const STAIR_STEP_COUNT = 9;
+const STAIR_STEP_RISE =
+  (UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) / STAIR_STEP_COUNT;
 
 const geometry: StairGeometry = {
   centerX: 12.4,
@@ -23,14 +29,14 @@ const geometry: StairGeometry = {
   topZ: -25.9,
   landingMinZ: -31.1,
   landingMaxZ: -25.9,
-  totalRise: 3.78,
+  totalRise: UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS,
   direction: -1,
 };
 
 const behavior: StairBehavior = {
   transitionMargin: 1.2,
   landingTriggerMargin: 0.4,
-  stepRise: 0.42,
+  stepRise: STAIR_STEP_RISE,
   descentCorridorInset: PLAYER_RADIUS,
 };
 

--- a/src/scene/level/floorElevations.ts
+++ b/src/scene/level/floorElevations.ts
@@ -1,0 +1,22 @@
+import type { FloorDefinition, SceneObjectDefinition } from './schema';
+
+export type FloorId = FloorDefinition['id'];
+
+export const FLOOR_TOP_ELEVATIONS = {
+  ground: 0,
+  upper: 5,
+} as const satisfies Record<string, number>;
+
+export const GROUND_FLOOR_TOP_ELEVATION = FLOOR_TOP_ELEVATIONS.ground;
+export const UPPER_FLOOR_TOP_ELEVATION = FLOOR_TOP_ELEVATIONS.upper;
+
+export const getFloorTopElevation = (
+  floorId: FloorId | SceneObjectDefinition['floorId']
+): number => {
+  const elevation =
+    FLOOR_TOP_ELEVATIONS[floorId as keyof typeof FLOOR_TOP_ELEVATIONS];
+  if (elevation === undefined) {
+    throw new Error(`Unknown floor elevation for floor '${floorId}'.`);
+  }
+  return elevation;
+};

--- a/src/scene/level/floorElevations.ts
+++ b/src/scene/level/floorElevations.ts
@@ -1,22 +1,24 @@
-import type { FloorDefinition, SceneObjectDefinition } from './schema';
-
-export type FloorId = FloorDefinition['id'];
+import type { SceneObjectDefinition } from './schema';
 
 export const FLOOR_TOP_ELEVATIONS = {
   ground: 0,
   upper: 5,
-} as const satisfies Record<string, number>;
+} as const;
+
+type FloorTopElevationId = keyof typeof FLOOR_TOP_ELEVATIONS;
 
 export const GROUND_FLOOR_TOP_ELEVATION = FLOOR_TOP_ELEVATIONS.ground;
 export const UPPER_FLOOR_TOP_ELEVATION = FLOOR_TOP_ELEVATIONS.upper;
 
+const isFloorTopElevationId = (
+  floorId: SceneObjectDefinition['floorId']
+): floorId is FloorTopElevationId => floorId in FLOOR_TOP_ELEVATIONS;
+
 export const getFloorTopElevation = (
-  floorId: FloorId | SceneObjectDefinition['floorId']
+  floorId: SceneObjectDefinition['floorId']
 ): number => {
-  const elevation =
-    FLOOR_TOP_ELEVATIONS[floorId as keyof typeof FLOOR_TOP_ELEVATIONS];
-  if (elevation === undefined) {
+  if (!isFloorTopElevationId(floorId)) {
     throw new Error(`Unknown floor elevation for floor '${floorId}'.`);
   }
-  return elevation;
+  return FLOOR_TOP_ELEVATIONS[floorId];
 };

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -1,3 +1,4 @@
+import { getFloorTopElevation } from './floorElevations';
 import type {
   FloorDefinition,
   LevelDefinition,
@@ -602,7 +603,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.jobbot_terminal',
           'creatorsStudio',
-          { x: -8.38, y: 4.16, z: -14.4 },
+          { x: -8.38, y: getFloorTopElevation('upper'), z: -14.4 },
           -Math.PI / 2,
           'POI terminal with factory-owned desk collider'
         ),
@@ -612,7 +613,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.axel_navigator',
           'creatorsStudio',
-          { x: -6.21, y: 4.16, z: -9.59 },
+          { x: -6.21, y: getFloorTopElevation('upper'), z: -9.59 },
           Math.PI,
           'POI navigator with factory-owned dais and console colliders'
         ),
@@ -622,7 +623,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.wove_loom',
           'loftLibrary',
-          { x: 8.24, y: 4.16, z: 2.135 },
+          { x: 8.24, y: getFloorTopElevation('upper'), z: 2.135 },
           Math.PI * 0.45,
           'POI tactile loom with factory-owned table and loom colliders'
         ),

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
 import { createPoiFloorResolver } from '../floors/visibilityController';
+import { UPPER_FLOOR_TOP_ELEVATION } from '../level/floorElevations';
 
 import {
   applyManualPoiPlacements,
@@ -73,50 +74,50 @@ describe('applyManualPoiPlacements', () => {
         id: 'jobbot-studio-terminal',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -16.76, y: 4.16, z: -28.8 },
+        anchorY: UPPER_FLOOR_TOP_ELEVATION + 0.75,
+        position: { x: -16.76, y: UPPER_FLOOR_TOP_ELEVATION, z: -28.8 },
       },
       {
         id: 'axel-studio-tracker',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -12.42, y: 4.16, z: -19.18 },
+        anchorY: UPPER_FLOOR_TOP_ELEVATION + 0.75,
+        position: { x: -12.42, y: UPPER_FLOOR_TOP_ELEVATION, z: -19.18 },
       },
       {
         id: 'gabriel-studio-sentry',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -17.28, y: 4.16, z: -7.02 },
+        anchorY: UPPER_FLOOR_TOP_ELEVATION + 0.75,
+        position: { x: -17.28, y: UPPER_FLOOR_TOP_ELEVATION, z: -7.02 },
       },
       {
         id: 'wove-kitchen-loom',
         roomId: 'loftLibrary',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: 16.48, y: 4.16, z: 4.27 },
+        anchorY: UPPER_FLOOR_TOP_ELEVATION + 0.75,
+        position: { x: 16.48, y: UPPER_FLOOR_TOP_ELEVATION, z: 4.27 },
       },
       {
         id: 'sigma-kitchen-workbench',
         roomId: 'focusPods',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: 16.59, y: 4.16, z: 17.66 },
+        anchorY: UPPER_FLOOR_TOP_ELEVATION + 0.75,
+        position: { x: 16.59, y: UPPER_FLOOR_TOP_ELEVATION, z: 17.66 },
       },
       {
         id: 'f2clipboard-kitchen-console',
         roomId: 'focusPods',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -0.63, y: 4.16, z: 14.03 },
+        anchorY: UPPER_FLOOR_TOP_ELEVATION + 0.75,
+        position: { x: -0.63, y: UPPER_FLOOR_TOP_ELEVATION, z: 14.03 },
       },
       {
         id: 'gitshelves-living-room-installation',
         roomId: 'focusPods',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -16.87, y: 4.16, z: 17.23 },
+        anchorY: UPPER_FLOOR_TOP_ELEVATION + 0.75,
+        position: { x: -16.87, y: UPPER_FLOOR_TOP_ELEVATION, z: 17.23 },
       },
     ];
     const placed = applyManualPoiPlacements(

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -1,20 +1,13 @@
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import { getFloorTopElevation } from '../level/floorElevations';
 import { PORTFOLIO_LEVEL } from '../level/portfolioLevel';
 import type { SceneObjectDefinition } from '../level/schema';
 
 import type { PoiDefinition, PoiId } from './types';
 
-const PLAYER_HEIGHT_ANCHOR_Y_BY_FLOOR: Record<
-  SceneObjectDefinition['floorId'],
-  number
-> = {
-  ground: 0.75,
-  upper: 4.91,
-};
-
-const getPlayerHeightAnchorY = (
+const getFloorStandingInteractionAnchorY = (
   floorId: SceneObjectDefinition['floorId']
-): number => PLAYER_HEIGHT_ANCHOR_Y_BY_FLOOR[floorId];
+): number => getFloorTopElevation(floorId) + 0.75;
 
 const getSceneObjectPoiPlacement = (
   object: SceneObjectDefinition
@@ -25,7 +18,7 @@ const getSceneObjectPoiPlacement = (
     position: { ...object.position },
     interactionAnchorPosition: {
       x: object.position.x,
-      y: getPlayerHeightAnchorY(object.floorId),
+      y: getFloorStandingInteractionAnchorY(object.floorId),
       z: object.position.z,
     },
     headingRadians: object.orientation,
@@ -91,43 +84,71 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
     position: { x: -22.34, y: 0, z: -22.61 },
-    interactionAnchorPosition: { x: -22.34, y: 0.75, z: -22.61 },
+    interactionAnchorPosition: {
+      x: -22.34,
+      y: getFloorStandingInteractionAnchorY('ground'),
+      z: -22.61,
+    },
     headingRadians: Math.PI * 0.05,
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',
     position: { x: -8.74, y: 0, z: -22.92 },
-    interactionAnchorPosition: { x: -8.74, y: 0.75, z: -22.92 },
+    interactionAnchorPosition: {
+      x: -8.74,
+      y: getFloorStandingInteractionAnchorY('ground'),
+      z: -22.92,
+    },
     headingRadians: Math.PI * 0.55,
   },
   'danielsmith-portfolio-table': {
     roomId: 'kitchen',
     position: { x: -21.6, y: 0, z: 1.63 },
-    interactionAnchorPosition: { x: -21.6, y: 0.75, z: 1.63 },
+    interactionAnchorPosition: {
+      x: -21.6,
+      y: getFloorStandingInteractionAnchorY('ground'),
+      z: 1.63,
+    },
     headingRadians: 0,
   },
   'f2clipboard-kitchen-console': {
     roomId: 'focusPods',
-    position: { x: -0.63, y: 4.16, z: 14.03 },
-    interactionAnchorPosition: { x: -0.63, y: 4.91, z: 14.03 },
+    position: { x: -0.63, y: getFloorTopElevation('upper'), z: 14.03 },
+    interactionAnchorPosition: {
+      x: -0.63,
+      y: getFloorStandingInteractionAnchorY('upper'),
+      z: 14.03,
+    },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
     roomId: 'focusPods',
-    position: { x: 16.59, y: 4.16, z: 17.66 },
-    interactionAnchorPosition: { x: 16.59, y: 4.91, z: 17.66 },
+    position: { x: 16.59, y: getFloorTopElevation('upper'), z: 17.66 },
+    interactionAnchorPosition: {
+      x: 16.59,
+      y: getFloorStandingInteractionAnchorY('upper'),
+      z: 17.66,
+    },
     headingRadians: Math.PI * 0.1,
   },
   'gitshelves-living-room-installation': {
     roomId: 'focusPods',
-    position: { x: -16.87, y: 4.16, z: 17.23 },
-    interactionAnchorPosition: { x: -16.87, y: 4.91, z: 17.23 },
+    position: { x: -16.87, y: getFloorTopElevation('upper'), z: 17.23 },
+    interactionAnchorPosition: {
+      x: -16.87,
+      y: getFloorStandingInteractionAnchorY('upper'),
+      z: 17.23,
+    },
     headingRadians: Math.PI * 0.1,
   },
   'gabriel-studio-sentry': {
     roomId: 'creatorsStudio',
-    position: { x: -17.28, y: 4.16, z: -7.02 },
-    interactionAnchorPosition: { x: -17.28, y: 4.91, z: -7.02 },
+    position: { x: -17.28, y: getFloorTopElevation('upper'), z: -7.02 },
+    interactionAnchorPosition: {
+      x: -17.28,
+      y: getFloorStandingInteractionAnchorY('upper'),
+      z: -7.02,
+    },
     headingRadians: -Math.PI * 0.3,
   },
 };

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -78,12 +78,12 @@ export const MANUAL_POI_PLACEMENTS: Partial<
 > = {
   'futuroptimist-living-room-tv': {
     roomId: 'livingRoom',
-    position: { x: -31.68, y: 0, z: -24 },
+    position: { x: -31.68, y: getFloorTopElevation('ground'), z: -24 },
     headingRadians: Math.PI * 0.5,
   },
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
-    position: { x: -22.34, y: 0, z: -22.61 },
+    position: { x: -22.34, y: getFloorTopElevation('ground'), z: -22.61 },
     interactionAnchorPosition: {
       x: -22.34,
       y: getFloorStandingInteractionAnchorY('ground'),
@@ -93,7 +93,7 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',
-    position: { x: -8.74, y: 0, z: -22.92 },
+    position: { x: -8.74, y: getFloorTopElevation('ground'), z: -22.92 },
     interactionAnchorPosition: {
       x: -8.74,
       y: getFloorStandingInteractionAnchorY('ground'),
@@ -103,7 +103,7 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   },
   'danielsmith-portfolio-table': {
     roomId: 'kitchen',
-    position: { x: -21.6, y: 0, z: 1.63 },
+    position: { x: -21.6, y: getFloorTopElevation('ground'), z: 1.63 },
     interactionAnchorPosition: {
       x: -21.6,
       y: getFloorStandingInteractionAnchorY('ground'),

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -110,7 +110,7 @@ export interface PoiDefinition {
   category: PoiCategory;
   interaction: PoiInteraction;
   roomId: string;
-  /** Visual/object origin; keep y on the floor plane so installations do not float. */
+  /** Bottom/base anchor for floor-standing POIs; wall-mounted POIs may use explicit display height. */
   position: { x: number; y: number; z: number };
   /** Optional player-height world anchor used for interaction/approach checks. */
   interactionAnchorPosition?: { x: number; y: number; z: number };

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { UPPER_FLOOR_TOP_ELEVATION } from '../../scene/level/floorElevations';
+import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from '../../scene/level/floorElevations';
 import { createGroundStairSafetyColliders } from '../../scene/level/stairSafetyColliders';
 import { collidesWithColliders } from '../collision';
 
@@ -14,7 +17,8 @@ const PLAYER_RADIUS = 0.75;
 const LANDING_THICKNESS = 0.38;
 const STAIR_STEP_COUNT = 9;
 const STAIR_STEP_RISE =
-  (UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) / STAIR_STEP_COUNT;
+  (UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) /
+  STAIR_STEP_COUNT;
 const EPSILON = 0.1;
 
 const geometry: StairGeometry = {
@@ -24,7 +28,8 @@ const geometry: StairGeometry = {
   topZ: -25.9,
   landingMinZ: -31.1,
   landingMaxZ: -25.9,
-  totalRise: UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS,
+  totalRise:
+    UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - LANDING_THICKNESS,
   direction: -1,
 };
 

--- a/src/systems/movement/stairs.test.ts
+++ b/src/systems/movement/stairs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { UPPER_FLOOR_TOP_ELEVATION } from '../../scene/level/floorElevations';
 import { createGroundStairSafetyColliders } from '../../scene/level/stairSafetyColliders';
 import { collidesWithColliders } from '../collision';
 
@@ -10,6 +11,10 @@ import {
 } from './stairs';
 
 const PLAYER_RADIUS = 0.75;
+const LANDING_THICKNESS = 0.38;
+const STAIR_STEP_COUNT = 9;
+const STAIR_STEP_RISE =
+  (UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) / STAIR_STEP_COUNT;
 const EPSILON = 0.1;
 
 const geometry: StairGeometry = {
@@ -19,14 +24,14 @@ const geometry: StairGeometry = {
   topZ: -25.9,
   landingMinZ: -31.1,
   landingMaxZ: -25.9,
-  totalRise: 3.78,
+  totalRise: UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS,
   direction: -1,
 };
 
 const behavior: StairBehavior = {
   transitionMargin: 1.2,
   landingTriggerMargin: 0.4,
-  stepRise: 0.42,
+  stepRise: STAIR_STEP_RISE,
   descentCorridorInset: PLAYER_RADIUS,
 };
 

--- a/src/tests/avatarMannequin.test.ts
+++ b/src/tests/avatarMannequin.test.ts
@@ -28,13 +28,14 @@ describe('createPortfolioMannequin', () => {
       throw new Error('Collision proxy mesh missing.');
     }
     expect(collisionProxy.visible).toBe(false);
+    expect(collisionProxy.position.y).toBeCloseTo(build.collisionRadius);
 
     const visualRoot = build.group.getObjectByName('PortfolioMannequinVisual');
     expect(visualRoot).toBeInstanceOf(Group);
     if (!(visualRoot instanceof Group)) {
       throw new Error('Visual root missing.');
     }
-    expect(visualRoot.position.y).toBeCloseTo(-build.collisionRadius);
+    expect(visualRoot.position.y).toBeCloseTo(0);
 
     const crest = build.group.getObjectByName('PortfolioMannequinCrest');
     expect(crest).toBeInstanceOf(Mesh);
@@ -74,7 +75,7 @@ describe('createPortfolioMannequin', () => {
     if (!(visualRoot instanceof Group)) {
       throw new Error('Visual root missing.');
     }
-    expect(visualRoot.position.y).toBeCloseTo(-options.collisionRadius);
+    expect(visualRoot.position.y).toBeCloseTo(0);
 
     const visor = build.group.getObjectByName('PortfolioMannequinVisor');
     expect(visor).toBeInstanceOf(Mesh);

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -21,7 +21,7 @@ describe('computeStairLayout', () => {
 
     expect(
       GROUND_FLOOR_TOP_ELEVATION + stepRise * stepCount + landingThickness
-    ).toBe(UPPER_FLOOR_TOP_ELEVATION);
+    ).toBeCloseTo(UPPER_FLOOR_TOP_ELEVATION, 10);
   });
 
   it('derives layout metrics for negative Z staircases', () => {

--- a/src/tests/movement/stairLayout.test.ts
+++ b/src/tests/movement/stairLayout.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from '../../scene/level/floorElevations';
+import {
   computeStairLayout,
   computeStairwellOpeningBounds,
 } from '../../systems/movement/stairLayout';
 
 describe('computeStairLayout', () => {
+  it('derives stair rise from canonical floor elevations', () => {
+    const landingThickness = 0.38;
+    const stepCount = 9;
+    const stepRise =
+      (UPPER_FLOOR_TOP_ELEVATION -
+        GROUND_FLOOR_TOP_ELEVATION -
+        landingThickness) /
+      stepCount;
+
+    expect(
+      GROUND_FLOOR_TOP_ELEVATION + stepRise * stepCount + landingThickness
+    ).toBe(UPPER_FLOOR_TOP_ELEVATION);
+  });
+
   it('derives layout metrics for negative Z staircases', () => {
     const layout = computeStairLayout({
       baseZ: 0,

--- a/src/tests/movement/stairSurfaceHeight.test.ts
+++ b/src/tests/movement/stairSurfaceHeight.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
-import { UPPER_FLOOR_TOP_ELEVATION } from '../../scene/level/floorElevations';
+import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from '../../scene/level/floorElevations';
 import {
   computeRampHeight,
   sampleStairSurfaceHeight,
@@ -19,14 +22,14 @@ const geometry: StairGeometry = {
   topZ: toWorldUnits(0.85) * 9,
   landingMinZ: toWorldUnits(0.85) * 9,
   landingMaxZ: toWorldUnits(0.85) * 9 + toWorldUnits(2.6),
-  totalRise: UPPER_FLOOR_TOP_ELEVATION - 0.38,
+  totalRise: UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - 0.38,
   direction: 1,
 };
 
 const behavior: StairBehavior = {
   transitionMargin: toWorldUnits(0.6),
   landingTriggerMargin: toWorldUnits(0.2),
-  stepRise: (UPPER_FLOOR_TOP_ELEVATION - 0.38) / 9,
+  stepRise: (UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - 0.38) / 9,
 };
 
 const upperFloorElevation = UPPER_FLOOR_TOP_ELEVATION;

--- a/src/tests/movement/stairSurfaceHeight.test.ts
+++ b/src/tests/movement/stairSurfaceHeight.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import { UPPER_FLOOR_TOP_ELEVATION } from '../../scene/level/floorElevations';
 import {
   computeRampHeight,
   sampleStairSurfaceHeight,
@@ -18,17 +19,17 @@ const geometry: StairGeometry = {
   topZ: toWorldUnits(0.85) * 9,
   landingMinZ: toWorldUnits(0.85) * 9,
   landingMaxZ: toWorldUnits(0.85) * 9 + toWorldUnits(2.6),
-  totalRise: 0.42 * 9,
+  totalRise: UPPER_FLOOR_TOP_ELEVATION - 0.38,
   direction: 1,
 };
 
 const behavior: StairBehavior = {
   transitionMargin: toWorldUnits(0.6),
   landingTriggerMargin: toWorldUnits(0.2),
-  stepRise: 0.42,
+  stepRise: (UPPER_FLOOR_TOP_ELEVATION - 0.38) / 9,
 };
 
-const upperFloorElevation = geometry.totalRise + 0.38;
+const upperFloorElevation = UPPER_FLOOR_TOP_ELEVATION;
 
 const sample = (params: { x: number; z: number; currentFloor: FloorId }) =>
   sampleStairSurfaceHeight({

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import { UPPER_FLOOR_TOP_ELEVATION } from '../../scene/level/floorElevations';
 import {
   classifyStairTransitionZone,
   createStairNavAreaRect,
@@ -29,20 +30,20 @@ const createStairGeometry = (direction: 1 | -1): StairGeometry => {
     topZ,
     landingMinZ: Math.min(topZ, landingFarZ),
     landingMaxZ: Math.max(topZ, landingFarZ),
-    totalRise: 0.42 * 9,
+    totalRise: UPPER_FLOOR_TOP_ELEVATION - 0.38,
     direction,
   };
 };
 
 const NEGATIVE_Z_STAIRS = createStairGeometry(-1);
-const UPPER_FLOOR_ELEVATION = NEGATIVE_Z_STAIRS.totalRise + 0.38;
+const UPPER_FLOOR_ELEVATION = UPPER_FLOOR_TOP_ELEVATION;
 const SCREENSHOT_4_SOURCE_POINT = { x: 7.4, z: -25.27 };
 const SCREENSHOT_4_LIFT_POINT = { x: 8.14, z: -25.36 };
 
 const STAIR_BEHAVIOR: StairBehavior = {
   transitionMargin: toWorldUnits(0.6),
   landingTriggerMargin: toWorldUnits(0.2),
-  stepRise: 0.42,
+  stepRise: (UPPER_FLOOR_TOP_ELEVATION - 0.38) / 9,
   descentCorridorInset: 0.75,
 };
 

--- a/src/tests/movement/stairTransitions.test.ts
+++ b/src/tests/movement/stairTransitions.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
-import { UPPER_FLOOR_TOP_ELEVATION } from '../../scene/level/floorElevations';
+import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from '../../scene/level/floorElevations';
 import {
   classifyStairTransitionZone,
   createStairNavAreaRect,
@@ -30,7 +33,7 @@ const createStairGeometry = (direction: 1 | -1): StairGeometry => {
     topZ,
     landingMinZ: Math.min(topZ, landingFarZ),
     landingMaxZ: Math.max(topZ, landingFarZ),
-    totalRise: UPPER_FLOOR_TOP_ELEVATION - 0.38,
+    totalRise: UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - 0.38,
     direction,
   };
 };
@@ -43,7 +46,7 @@ const SCREENSHOT_4_LIFT_POINT = { x: 8.14, z: -25.36 };
 const STAIR_BEHAVIOR: StairBehavior = {
   transitionMargin: toWorldUnits(0.6),
   landingTriggerMargin: toWorldUnits(0.2),
-  stepRise: (UPPER_FLOOR_TOP_ELEVATION - 0.38) / 9,
+  stepRise: (UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - 0.38) / 9,
   descentCorridorInset: 0.75,
 };
 

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { UPPER_FLOOR_TOP_ELEVATION } from '../scene/level/floorElevations';
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
 import {
   createSceneObjectDefinitionsById,
@@ -93,7 +94,7 @@ const migratedFactories = [
   {
     id: 'jobbot-studio-terminal',
     placement: {
-      position: { x: -8.38, y: 4.16, z: -14.4 },
+      position: { x: -8.38, y: UPPER_FLOOR_TOP_ELEVATION, z: -14.4 },
       orientation: -Math.PI / 2,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
@@ -105,7 +106,7 @@ const migratedFactories = [
   {
     id: 'axel-studio-tracker',
     placement: {
-      position: { x: -6.21, y: 4.16, z: -9.59 },
+      position: { x: -6.21, y: UPPER_FLOOR_TOP_ELEVATION, z: -9.59 },
       orientation: Math.PI,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
@@ -117,7 +118,7 @@ const migratedFactories = [
   {
     id: 'wove-kitchen-loom',
     placement: {
-      position: { x: 8.24, y: 4.16, z: 2.135 },
+      position: { x: 8.24, y: UPPER_FLOOR_TOP_ELEVATION, z: 2.135 },
       orientation: Math.PI * 0.45,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -1,8 +1,10 @@
 import { MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
+
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../assets/floorPlan';
 import type { Bounds2D } from '../assets/floorPlan';
+import { UPPER_FLOOR_TOP_ELEVATION } from '../scene/level/floorElevations';
 import { createRoomFloorTiles } from '../scene/structures/floorTiles';
 import {
   createUpperLandingFloorCutouts,
@@ -25,6 +27,9 @@ const STAIR_HALF_WIDTH = toWorldUnits(3.1) / 2;
 const STAIR_BOTTOM_Z = toWorldUnits(-5.3);
 const STAIR_RUN = toWorldUnits(0.85);
 const STAIR_STEP_COUNT = 9;
+const LANDING_THICKNESS = 0.38;
+const STAIR_STEP_RISE =
+  (UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) / STAIR_STEP_COUNT;
 const STAIR_LANDING_DEPTH = toWorldUnits(2.6);
 const STAIRWELL_MARGIN_X = toWorldUnits(0.2);
 const STAIRWELL_MARGIN_Z = toWorldUnits(0.4);
@@ -83,13 +88,13 @@ const createProductionUpperLandingCutoutFixture = () => {
     topZ: stairLayout.topZ,
     landingMinZ: stairLayout.landingMinZ,
     landingMaxZ: stairLayout.landingMaxZ,
-    totalRise: STAIR_STEP_COUNT * 0.42,
+    totalRise: STAIR_STEP_COUNT * STAIR_STEP_RISE,
     direction: stairLayout.directionMultiplier,
   };
   const stairBehavior: StairBehavior = {
     transitionMargin: toWorldUnits(0.6),
     landingTriggerMargin: toWorldUnits(0.2),
-    stepRise: 0.42,
+    stepRise: STAIR_STEP_RISE,
     descentCorridorInset: PLAYER_RADIUS,
   };
   const stairNavigationZones = createStairNavigationZones(
@@ -139,7 +144,7 @@ describe('createUpperLandingFloorCutouts', () => {
     });
     const floorTiles = createRoomFloorTiles([upperLandingRoom], {
       material: new MeshStandardMaterial(),
-      elevation: 4.16,
+      elevation: UPPER_FLOOR_TOP_ELEVATION,
       thickness: 0.38,
       cutoutsByRoom: { upperLanding: cutouts },
     });
@@ -167,8 +172,8 @@ describe('createUpperLandingFloorCutouts', () => {
         .every((tile) => !overlaps(tile.bounds, stairRunApproachFootprint))
     ).toBe(true);
 
-    const upperFloorTileBottomY = 4.16 - 0.38;
-    const finalStairStepTopY = STAIR_STEP_COUNT * 0.42;
+    const upperFloorTileBottomY = UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS;
+    const finalStairStepTopY = STAIR_STEP_COUNT * STAIR_STEP_RISE;
     expect(upperFloorTileBottomY).toBeCloseTo(finalStairStepTopY);
   });
 
@@ -229,13 +234,14 @@ describe('createUpperLandingFloorCutouts', () => {
         {
           id: 'upperLanding',
           name: 'Upper Landing',
+          ledColor: 0x58c4ff,
           bounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
           doorways: [],
         },
       ],
       {
         material: new MeshStandardMaterial(),
-        elevation: 4.16,
+        elevation: UPPER_FLOOR_TOP_ELEVATION,
         thickness: 0.38,
         cutoutsByRoom: { upperLanding: cutouts },
       }
@@ -265,7 +271,7 @@ describe('createUpperLandingFloorCutouts', () => {
 
     const floorTiles = createRoomFloorTiles([upperLandingRoom], {
       material: new MeshStandardMaterial(),
-      elevation: 4.16,
+      elevation: UPPER_FLOOR_TOP_ELEVATION,
       thickness: 0.38,
       cutoutsByRoom: { upperLanding: cutouts },
     });

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../assets/floorPlan';
 import type { Bounds2D } from '../assets/floorPlan';
-import { UPPER_FLOOR_TOP_ELEVATION } from '../scene/level/floorElevations';
+import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from '../scene/level/floorElevations';
 import { createRoomFloorTiles } from '../scene/structures/floorTiles';
 import {
   createUpperLandingFloorCutouts,
@@ -28,7 +31,8 @@ const STAIR_RUN = toWorldUnits(0.85);
 const STAIR_STEP_COUNT = 9;
 const LANDING_THICKNESS = 0.38;
 const STAIR_STEP_RISE =
-  (UPPER_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) / STAIR_STEP_COUNT;
+  (UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - LANDING_THICKNESS) /
+  STAIR_STEP_COUNT;
 const STAIR_LANDING_DEPTH = toWorldUnits(2.6);
 const STAIRWELL_MARGIN_X = toWorldUnits(0.2);
 const STAIRWELL_MARGIN_Z = toWorldUnits(0.4);

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -1,7 +1,6 @@
 import { MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
-
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../assets/floorPlan';
 import type { Bounds2D } from '../assets/floorPlan';
 import { UPPER_FLOOR_TOP_ELEVATION } from '../scene/level/floorElevations';


### PR DESCRIPTION
### Motivation
- Establish a single, explicit vertical-coordinate convention so player roots and floor-standing POIs share a bottom/floor anchor with ground Y=0 and upper Y=5.
- Remove duplicated hard-coded upper-floor/stair height logic and make stair rise derive from canonical floor elevations and landing thickness.

### Description
- Add `src/scene/level/floorElevations.ts` exporting `GROUND_FLOOR_TOP_ELEVATION = 0`, `UPPER_FLOOR_TOP_ELEVATION = 5`, and `getFloorTopElevation(...)` as the canonical source.
- Re-anchor the player root so `player.position.y` is the sampled floor surface, move the invisible collision proxy to `y = PLAYER_RADIUS`, and make the mannequin visual root floor-relative to preserve appearance and foot placement.
- Derive staircase `step.rise` from `UPPER_FLOOR_TOP_ELEVATION`, `GROUND_FLOOR_TOP_ELEVATION`, landing thickness, and step count, and assert the total rise + landing thickness equals the canonical upper-floor elevation.
- Treat `PoiDefinition.position.y` as the floor/base anchor and update POI/showpiece placements and interaction anchors to call `getFloorTopElevation(...)` (preserving all X/Z, headings, rooms, and models from the prior PR).
- Update targeted tests and fixtures to reference the new floor-elevation helpers and to assert the new anchoring semantics (mannequin, POI roots, stair metrics, upper-landing cutouts, and stair sampling/transitions).

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed (lint emitted only import-order warnings that were auto-fixed with `--fix`).
- Ran focused unit tests and the full suite via `npx vitest run` and `npm run test:ci`, which completed successfully (focused files plus full `test:ci` passed in this environment).
- Built and smoke-checked with `npm run smoke`, which produced a valid `dist` artifact and passed the smoke assertions.
- Installed Playwright browsers and dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium`, then ran `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts`, which passed (all spec checks for stair roundtrip succeeded).
- Ran the collider redundancy gate with `npm run collider:audit:redundancy`, which completed and reported zero failures (warnings only for missing source metadata as before).
- Ran `npm run docs:check`, which passed (link checks produced external fetch warnings only).
- `npm run typecheck` was executed and reported pre-existing repository-wide TypeScript errors unrelated to this change; these baseline type issues were not modified as out-of-scope for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae0c66fa0832f862fe54a29986cb9)