### PR TITLE
🧭 Unify floor anchoring at Y=0 and Y=5

### DIFF
--- a/playwright/immersive-stairs-roundtrip.spec.ts
+++ b/playwright/immersive-stairs-roundtrip.spec.ts
@@ -400,7 +400,7 @@ async function walkStairCenterlineToUpperLanding(page: Page) {
   expect(firstUpperZ).not.toBeNull();
   expect(walkResults.finalState.activeFloor).toBe('upper');
   expect(walkResults.finalState.position.y).toBeGreaterThanOrEqual(
-    PLAYER_RADIUS + upperFloorElevation - 0.01
+    upperFloorElevation - 0.01
   );
 
   return walkResults.finalState;

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,6 +152,11 @@ import {
   getSceneDetailPolicy,
 } from './scene/graphics/sceneDetailPolicy';
 import { isBackyardSourceCollider } from './scene/level/backyardCollisionPolicies';
+import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+  getFloorTopElevation,
+} from './scene/level/floorElevation';
 import { generateFloorSurfaces } from './scene/level/generateFloorSurfaces';
 import { generateWallSegmentInstances } from './scene/level/generateWalls';
 import {
@@ -738,6 +743,7 @@ declare global {
 }
 
 const PLAYER_RADIUS = 0.75;
+const PLAYER_PRESENTATION_FOCUS_Y_OFFSET = PLAYER_RADIUS;
 const PLAYER_SPEED = 12;
 const MOVEMENT_SMOOTHING = 8;
 const CAMERA_PAN_SMOOTHING = 6;
@@ -947,13 +953,23 @@ const handleImmersiveFailure = (
   markDocumentReady('fallback', 'immersive-init-error');
 };
 
+const STAIRCASE_LANDING_THICKNESS = 0.38;
+
 const STAIRCASE_CONFIG = {
   name: 'LivingRoomStaircase',
-  basePosition: new Vector3(toWorldUnits(6.2), 0, toWorldUnits(-5.3)),
+  basePosition: new Vector3(
+    toWorldUnits(6.2),
+    GROUND_FLOOR_TOP_ELEVATION,
+    toWorldUnits(-5.3)
+  ),
   direction: 'negativeZ',
   step: {
     count: 9,
-    rise: 0.42,
+    rise:
+      (UPPER_FLOOR_TOP_ELEVATION -
+        GROUND_FLOOR_TOP_ELEVATION -
+        STAIRCASE_LANDING_THICKNESS) /
+      9,
     run: toWorldUnits(0.85),
     width: toWorldUnits(3.1),
     material: {
@@ -965,7 +981,7 @@ const STAIRCASE_CONFIG = {
   },
   landing: {
     depth: toWorldUnits(2.6),
-    thickness: 0.38,
+    thickness: STAIRCASE_LANDING_THICKNESS,
     material: {
       color: 0x5b6775,
       roughness: 0.55,
@@ -1746,7 +1762,7 @@ function initializeImmersiveScene(
   const initialRoom = FLOOR_PLAN.rooms[0];
   const initialPlayerPosition = new Vector3(
     (initialRoom.bounds.minX + initialRoom.bounds.maxX) / 2,
-    PLAYER_RADIUS,
+    getFloorTopElevation('ground'),
     (initialRoom.bounds.minZ + initialRoom.bounds.maxZ) / 2
   );
 
@@ -1784,6 +1800,7 @@ function initializeImmersiveScene(
   const cameraWorldUp = new Vector3();
 
   const cameraCenter = initialPlayerPosition.clone();
+  cameraCenter.y += PLAYER_PRESENTATION_FOCUS_Y_OFFSET;
   camera.position.copy(cameraCenter).add(cameraBaseOffset);
   camera.lookAt(cameraCenter.x, cameraCenter.y, cameraCenter.z);
   initialCameraFraming = resolveInitialAvatarCameraFraming({
@@ -2091,8 +2108,16 @@ function initializeImmersiveScene(
   const stairTopZ = stairLayout.topZ;
   const stairLandingMinZ = stairLayout.landingMinZ;
   const stairLandingMaxZ = stairLayout.landingMaxZ;
-  const upperFloorElevation =
-    stairTotalRise + STAIRCASE_CONFIG.landing.thickness;
+  const upperFloorElevation = UPPER_FLOOR_TOP_ELEVATION;
+  const resolvedStairLandingTop =
+    STAIRCASE_CONFIG.basePosition.y +
+    stairTotalRise +
+    STAIRCASE_CONFIG.landing.thickness;
+  if (Math.abs(resolvedStairLandingTop - upperFloorElevation) > 1e-9) {
+    throw new Error(
+      `Stair landing top ${resolvedStairLandingTop} must match upper floor ${upperFloorElevation}.`
+    );
+  }
   const stairGeometry: StairGeometry = {
     centerX: stairCenterX,
     halfWidth: stairHalfWidth,
@@ -4345,7 +4370,7 @@ function initializeImmersiveScene(
       currentFloor: verticalSurfaceFloor,
       upperFloorElevation,
     });
-    player.position.y = PLAYER_RADIUS + baseHeight;
+    player.position.y = baseHeight;
   };
 
   const collidesWithCollider = (
@@ -6118,7 +6143,7 @@ function initializeImmersiveScene(
 
     cameraCenter.set(
       player.position.x + cameraPan.x,
-      player.position.y,
+      player.position.y + PLAYER_PRESENTATION_FOCUS_Y_OFFSET,
       player.position.z + cameraPan.z
     );
 

--- a/src/scene/avatar/mannequin.ts
+++ b/src/scene/avatar/mannequin.ts
@@ -46,7 +46,7 @@ export interface PortfolioMannequinPalette {
 
 export interface PortfolioMannequinBuild {
   /**
-   * Root group containing the hidden collision proxy and visible meshes.
+   * Floor-anchored root group containing the hidden collision proxy and visible meshes.
    */
   group: Group;
   /**
@@ -114,11 +114,12 @@ export function createPortfolioMannequin(
   );
   collisionProxy.name = 'PortfolioMannequinCollisionProxy';
   collisionProxy.visible = false;
+  collisionProxy.position.y = collisionRadius;
   group.add(collisionProxy);
 
   const mannequinRoot = new Group();
   mannequinRoot.name = 'PortfolioMannequinVisual';
-  mannequinRoot.position.y = -collisionRadius;
+  mannequinRoot.position.y = 0;
   group.add(mannequinRoot);
 
   const platformMaterial = createStandardMaterial(

--- a/src/scene/level/floorElevation.ts
+++ b/src/scene/level/floorElevation.ts
@@ -1,0 +1,21 @@
+export type FloorElevationId = 'ground' | 'upper';
+
+export const FLOOR_TOP_ELEVATIONS: Readonly<Record<FloorElevationId, number>> =
+  {
+    ground: 0,
+    upper: 5,
+  };
+
+export const GROUND_FLOOR_TOP_ELEVATION = FLOOR_TOP_ELEVATIONS.ground;
+export const UPPER_FLOOR_TOP_ELEVATION = FLOOR_TOP_ELEVATIONS.upper;
+
+export const isFloorElevationId = (
+  floorId: string
+): floorId is FloorElevationId => floorId === 'ground' || floorId === 'upper';
+
+export const getFloorTopElevation = (floorId: string): number => {
+  if (!isFloorElevationId(floorId)) {
+    throw new Error(`Unknown floor elevation id: ${floorId}`);
+  }
+  return FLOOR_TOP_ELEVATIONS[floorId];
+};

--- a/src/scene/level/portfolioLevel.ts
+++ b/src/scene/level/portfolioLevel.ts
@@ -1,3 +1,4 @@
+import { getFloorTopElevation } from './floorElevation';
 import type {
   FloorDefinition,
   LevelDefinition,
@@ -602,7 +603,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.jobbot_terminal',
           'creatorsStudio',
-          { x: -8.38, y: 4.16, z: -14.4 },
+          { x: -8.38, y: getFloorTopElevation('upper'), z: -14.4 },
           -Math.PI / 2,
           'POI terminal with factory-owned desk collider'
         ),
@@ -612,7 +613,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.axel_navigator',
           'creatorsStudio',
-          { x: -6.21, y: 4.16, z: -9.59 },
+          { x: -6.21, y: getFloorTopElevation('upper'), z: -9.59 },
           Math.PI,
           'POI navigator with factory-owned dais and console colliders'
         ),
@@ -622,7 +623,7 @@ export const PORTFOLIO_LEVEL: LevelDefinition = {
           'upper',
           'showpiece.wove_loom',
           'loftLibrary',
-          { x: 8.24, y: 4.16, z: 2.135 },
+          { x: 8.24, y: getFloorTopElevation('upper'), z: 2.135 },
           Math.PI * 0.45,
           'POI tactile loom with factory-owned table and loom colliders'
         ),

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_LEVELS } from '../../assets/floorPlan';
 import { createPoiFloorResolver } from '../floors/visibilityController';
+import { getFloorTopElevation } from '../level/floorElevation';
 
 import {
   applyManualPoiPlacements,
@@ -73,50 +74,50 @@ describe('applyManualPoiPlacements', () => {
         id: 'jobbot-studio-terminal',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -16.76, y: 4.16, z: -28.8 },
+        anchorY: getFloorTopElevation('upper') + 0.75,
+        position: { x: -16.76, y: getFloorTopElevation('upper'), z: -28.8 },
       },
       {
         id: 'axel-studio-tracker',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -12.42, y: 4.16, z: -19.18 },
+        anchorY: getFloorTopElevation('upper') + 0.75,
+        position: { x: -12.42, y: getFloorTopElevation('upper'), z: -19.18 },
       },
       {
         id: 'gabriel-studio-sentry',
         roomId: 'creatorsStudio',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -17.28, y: 4.16, z: -7.02 },
+        anchorY: getFloorTopElevation('upper') + 0.75,
+        position: { x: -17.28, y: getFloorTopElevation('upper'), z: -7.02 },
       },
       {
         id: 'wove-kitchen-loom',
         roomId: 'loftLibrary',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: 16.48, y: 4.16, z: 4.27 },
+        anchorY: getFloorTopElevation('upper') + 0.75,
+        position: { x: 16.48, y: getFloorTopElevation('upper'), z: 4.27 },
       },
       {
         id: 'sigma-kitchen-workbench',
         roomId: 'focusPods',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: 16.59, y: 4.16, z: 17.66 },
+        anchorY: getFloorTopElevation('upper') + 0.75,
+        position: { x: 16.59, y: getFloorTopElevation('upper'), z: 17.66 },
       },
       {
         id: 'f2clipboard-kitchen-console',
         roomId: 'focusPods',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -0.63, y: 4.16, z: 14.03 },
+        anchorY: getFloorTopElevation('upper') + 0.75,
+        position: { x: -0.63, y: getFloorTopElevation('upper'), z: 14.03 },
       },
       {
         id: 'gitshelves-living-room-installation',
         roomId: 'focusPods',
         floorId: 'upper',
-        anchorY: 4.91,
-        position: { x: -16.87, y: 4.16, z: 17.23 },
+        anchorY: getFloorTopElevation('upper') + 0.75,
+        position: { x: -16.87, y: getFloorTopElevation('upper'), z: 17.23 },
       },
     ];
     const placed = applyManualPoiPlacements(

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -1,20 +1,15 @@
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
+import { getFloorTopElevation } from '../level/floorElevation';
 import { PORTFOLIO_LEVEL } from '../level/portfolioLevel';
 import type { SceneObjectDefinition } from '../level/schema';
 
 import type { PoiDefinition, PoiId } from './types';
 
-const PLAYER_HEIGHT_ANCHOR_Y_BY_FLOOR: Record<
-  SceneObjectDefinition['floorId'],
-  number
-> = {
-  ground: 0.75,
-  upper: 4.91,
-};
+const INTERACTION_ANCHOR_OFFSET_Y = 0.75;
 
-const getPlayerHeightAnchorY = (
+const getInteractionAnchorY = (
   floorId: SceneObjectDefinition['floorId']
-): number => PLAYER_HEIGHT_ANCHOR_Y_BY_FLOOR[floorId];
+): number => getFloorTopElevation(floorId) + INTERACTION_ANCHOR_OFFSET_Y;
 
 const getSceneObjectPoiPlacement = (
   object: SceneObjectDefinition
@@ -22,10 +17,13 @@ const getSceneObjectPoiPlacement = (
   if (!object.roomId) return null;
   return {
     roomId: object.roomId,
-    position: { ...object.position },
+    position: {
+      ...object.position,
+      y: object.position.y ?? getFloorTopElevation(object.floorId),
+    },
     interactionAnchorPosition: {
       x: object.position.x,
-      y: getPlayerHeightAnchorY(object.floorId),
+      y: getInteractionAnchorY(object.floorId),
       z: object.position.z,
     },
     headingRadians: object.orientation,
@@ -91,43 +89,71 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
     position: { x: -22.34, y: 0, z: -22.61 },
-    interactionAnchorPosition: { x: -22.34, y: 0.75, z: -22.61 },
+    interactionAnchorPosition: {
+      x: -22.34,
+      y: getInteractionAnchorY('ground'),
+      z: -22.61,
+    },
     headingRadians: Math.PI * 0.05,
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',
     position: { x: -8.74, y: 0, z: -22.92 },
-    interactionAnchorPosition: { x: -8.74, y: 0.75, z: -22.92 },
+    interactionAnchorPosition: {
+      x: -8.74,
+      y: getInteractionAnchorY('ground'),
+      z: -22.92,
+    },
     headingRadians: Math.PI * 0.55,
   },
   'danielsmith-portfolio-table': {
     roomId: 'kitchen',
     position: { x: -21.6, y: 0, z: 1.63 },
-    interactionAnchorPosition: { x: -21.6, y: 0.75, z: 1.63 },
+    interactionAnchorPosition: {
+      x: -21.6,
+      y: getInteractionAnchorY('ground'),
+      z: 1.63,
+    },
     headingRadians: 0,
   },
   'f2clipboard-kitchen-console': {
     roomId: 'focusPods',
-    position: { x: -0.63, y: 4.16, z: 14.03 },
-    interactionAnchorPosition: { x: -0.63, y: 4.91, z: 14.03 },
+    position: { x: -0.63, y: getFloorTopElevation('upper'), z: 14.03 },
+    interactionAnchorPosition: {
+      x: -0.63,
+      y: getInteractionAnchorY('upper'),
+      z: 14.03,
+    },
     headingRadians: Math.PI * 0.5,
   },
   'sigma-kitchen-workbench': {
     roomId: 'focusPods',
-    position: { x: 16.59, y: 4.16, z: 17.66 },
-    interactionAnchorPosition: { x: 16.59, y: 4.91, z: 17.66 },
+    position: { x: 16.59, y: getFloorTopElevation('upper'), z: 17.66 },
+    interactionAnchorPosition: {
+      x: 16.59,
+      y: getInteractionAnchorY('upper'),
+      z: 17.66,
+    },
     headingRadians: Math.PI * 0.1,
   },
   'gitshelves-living-room-installation': {
     roomId: 'focusPods',
-    position: { x: -16.87, y: 4.16, z: 17.23 },
-    interactionAnchorPosition: { x: -16.87, y: 4.91, z: 17.23 },
+    position: { x: -16.87, y: getFloorTopElevation('upper'), z: 17.23 },
+    interactionAnchorPosition: {
+      x: -16.87,
+      y: getInteractionAnchorY('upper'),
+      z: 17.23,
+    },
     headingRadians: Math.PI * 0.1,
   },
   'gabriel-studio-sentry': {
     roomId: 'creatorsStudio',
-    position: { x: -17.28, y: 4.16, z: -7.02 },
-    interactionAnchorPosition: { x: -17.28, y: 4.91, z: -7.02 },
+    position: { x: -17.28, y: getFloorTopElevation('upper'), z: -7.02 },
+    interactionAnchorPosition: {
+      x: -17.28,
+      y: getInteractionAnchorY('upper'),
+      z: -7.02,
+    },
     headingRadians: -Math.PI * 0.3,
   },
 };

--- a/src/scene/poi/types.ts
+++ b/src/scene/poi/types.ts
@@ -110,9 +110,9 @@ export interface PoiDefinition {
   category: PoiCategory;
   interaction: PoiInteraction;
   roomId: string;
-  /** Visual/object origin; keep y on the floor plane so installations do not float. */
+  /** Bottom/base anchor for floor-standing POIs; elevated parts use local offsets. */
   position: { x: number; y: number; z: number };
-  /** Optional player-height world anchor used for interaction/approach checks. */
+  /** Optional world anchor used for interaction/approach checks above the base. */
   interactionAnchorPosition?: { x: number; y: number; z: number };
   headingRadians?: number;
   interactionRadius: number;

--- a/src/tests/avatarMannequin.test.ts
+++ b/src/tests/avatarMannequin.test.ts
@@ -28,13 +28,14 @@ describe('createPortfolioMannequin', () => {
       throw new Error('Collision proxy mesh missing.');
     }
     expect(collisionProxy.visible).toBe(false);
+    expect(collisionProxy.position.y).toBeCloseTo(build.collisionRadius);
 
     const visualRoot = build.group.getObjectByName('PortfolioMannequinVisual');
     expect(visualRoot).toBeInstanceOf(Group);
     if (!(visualRoot instanceof Group)) {
       throw new Error('Visual root missing.');
     }
-    expect(visualRoot.position.y).toBeCloseTo(-build.collisionRadius);
+    expect(visualRoot.position.y).toBeCloseTo(0);
 
     const crest = build.group.getObjectByName('PortfolioMannequinCrest');
     expect(crest).toBeInstanceOf(Mesh);
@@ -74,7 +75,7 @@ describe('createPortfolioMannequin', () => {
     if (!(visualRoot instanceof Group)) {
       throw new Error('Visual root missing.');
     }
-    expect(visualRoot.position.y).toBeCloseTo(-options.collisionRadius);
+    expect(visualRoot.position.y).toBeCloseTo(0);
 
     const visor = build.group.getObjectByName('PortfolioMannequinVisor');
     expect(visor).toBeInstanceOf(Mesh);

--- a/src/tests/movement/stairSurfaceHeight.test.ts
+++ b/src/tests/movement/stairSurfaceHeight.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import { FLOOR_PLAN_SCALE } from '../../assets/floorPlan';
 import {
+  GROUND_FLOOR_TOP_ELEVATION,
+  UPPER_FLOOR_TOP_ELEVATION,
+} from '../../scene/level/floorElevation';
+import {
   computeRampHeight,
   sampleStairSurfaceHeight,
   type FloorId,
@@ -11,24 +15,30 @@ import {
 
 const toWorldUnits = (value: number) => value * FLOOR_PLAN_SCALE;
 
+const landingThickness = 0.38;
+const stepCount = 9;
+const stepRise =
+  (UPPER_FLOOR_TOP_ELEVATION - GROUND_FLOOR_TOP_ELEVATION - landingThickness) /
+  stepCount;
+
 const geometry: StairGeometry = {
   centerX: 0,
   halfWidth: toWorldUnits(3.1) / 2,
   bottomZ: 0,
-  topZ: toWorldUnits(0.85) * 9,
-  landingMinZ: toWorldUnits(0.85) * 9,
-  landingMaxZ: toWorldUnits(0.85) * 9 + toWorldUnits(2.6),
-  totalRise: 0.42 * 9,
+  topZ: toWorldUnits(0.85) * stepCount,
+  landingMinZ: toWorldUnits(0.85) * stepCount,
+  landingMaxZ: toWorldUnits(0.85) * stepCount + toWorldUnits(2.6),
+  totalRise: stepRise * stepCount,
   direction: 1,
 };
 
 const behavior: StairBehavior = {
   transitionMargin: toWorldUnits(0.6),
   landingTriggerMargin: toWorldUnits(0.2),
-  stepRise: 0.42,
+  stepRise,
 };
 
-const upperFloorElevation = geometry.totalRise + 0.38;
+const upperFloorElevation = UPPER_FLOOR_TOP_ELEVATION;
 
 const sample = (params: { x: number; z: number; currentFloor: FloorId }) =>
   sampleStairSurfaceHeight({
@@ -39,6 +49,11 @@ const sample = (params: { x: number; z: number; currentFloor: FloorId }) =>
   });
 
 describe('sampleStairSurfaceHeight', () => {
+  it('derives stair total rise from the canonical upper floor elevation', () => {
+    expect(
+      GROUND_FLOOR_TOP_ELEVATION + geometry.totalRise + landingThickness
+    ).toBe(UPPER_FLOOR_TOP_ELEVATION);
+  });
   it('returns the interpolated ramp height along the stair run', () => {
     const midRampZ = geometry.topZ / 2;
     const height = sample({ x: 0, z: midRampZ, currentFloor: 'ground' });

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { getFloorTopElevation } from '../scene/level/floorElevation';
 import { PORTFOLIO_LEVEL } from '../scene/level/portfolioLevel';
 import {
   createSceneObjectDefinitionsById,
@@ -93,7 +94,7 @@ const migratedFactories = [
   {
     id: 'jobbot-studio-terminal',
     placement: {
-      position: { x: -8.38, y: 4.16, z: -14.4 },
+      position: { x: -8.38, y: getFloorTopElevation('upper'), z: -14.4 },
       orientation: -Math.PI / 2,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
@@ -105,7 +106,7 @@ const migratedFactories = [
   {
     id: 'axel-studio-tracker',
     placement: {
-      position: { x: -6.21, y: 4.16, z: -9.59 },
+      position: { x: -6.21, y: getFloorTopElevation('upper'), z: -9.59 },
       orientation: Math.PI,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
@@ -117,7 +118,7 @@ const migratedFactories = [
   {
     id: 'wove-kitchen-loom',
     placement: {
-      position: { x: 8.24, y: 4.16, z: 2.135 },
+      position: { x: 8.24, y: getFloorTopElevation('upper'), z: 2.135 },
       orientation: Math.PI * 0.45,
     },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>

--- a/src/tests/upperLandingFloorCutouts.test.ts
+++ b/src/tests/upperLandingFloorCutouts.test.ts
@@ -1,8 +1,10 @@
 import { MeshStandardMaterial } from 'three';
 import { describe, expect, it } from 'vitest';
 
+
 import { FLOOR_PLAN_SCALE, UPPER_FLOOR_PLAN } from '../assets/floorPlan';
 import type { Bounds2D } from '../assets/floorPlan';
+import { UPPER_FLOOR_TOP_ELEVATION } from '../scene/level/floorElevation';
 import { createRoomFloorTiles } from '../scene/structures/floorTiles';
 import {
   createUpperLandingFloorCutouts,
@@ -25,6 +27,10 @@ const STAIR_HALF_WIDTH = toWorldUnits(3.1) / 2;
 const STAIR_BOTTOM_Z = toWorldUnits(-5.3);
 const STAIR_RUN = toWorldUnits(0.85);
 const STAIR_STEP_COUNT = 9;
+const STAIR_LANDING_THICKNESS = 0.38;
+const STAIR_STEP_RISE =
+  UPPER_FLOOR_TOP_ELEVATION / STAIR_STEP_COUNT -
+  STAIR_LANDING_THICKNESS / STAIR_STEP_COUNT;
 const STAIR_LANDING_DEPTH = toWorldUnits(2.6);
 const STAIRWELL_MARGIN_X = toWorldUnits(0.2);
 const STAIRWELL_MARGIN_Z = toWorldUnits(0.4);
@@ -83,7 +89,7 @@ const createProductionUpperLandingCutoutFixture = () => {
     topZ: stairLayout.topZ,
     landingMinZ: stairLayout.landingMinZ,
     landingMaxZ: stairLayout.landingMaxZ,
-    totalRise: STAIR_STEP_COUNT * 0.42,
+    totalRise: STAIR_STEP_COUNT * STAIR_STEP_RISE,
     direction: stairLayout.directionMultiplier,
   };
   const stairBehavior: StairBehavior = {
@@ -139,8 +145,8 @@ describe('createUpperLandingFloorCutouts', () => {
     });
     const floorTiles = createRoomFloorTiles([upperLandingRoom], {
       material: new MeshStandardMaterial(),
-      elevation: 4.16,
-      thickness: 0.38,
+      elevation: UPPER_FLOOR_TOP_ELEVATION,
+      thickness: STAIR_LANDING_THICKNESS,
       cutoutsByRoom: { upperLanding: cutouts },
     });
 
@@ -167,8 +173,9 @@ describe('createUpperLandingFloorCutouts', () => {
         .every((tile) => !overlaps(tile.bounds, stairRunApproachFootprint))
     ).toBe(true);
 
-    const upperFloorTileBottomY = 4.16 - 0.38;
-    const finalStairStepTopY = STAIR_STEP_COUNT * 0.42;
+    const upperFloorTileBottomY =
+      UPPER_FLOOR_TOP_ELEVATION - STAIR_LANDING_THICKNESS;
+    const finalStairStepTopY = STAIR_STEP_COUNT * STAIR_STEP_RISE;
     expect(upperFloorTileBottomY).toBeCloseTo(finalStairStepTopY);
   });
 
@@ -230,13 +237,13 @@ describe('createUpperLandingFloorCutouts', () => {
           id: 'upperLanding',
           name: 'Upper Landing',
           bounds: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
-          doorways: [],
+          ledColor: 0xffffff,
         },
       ],
       {
         material: new MeshStandardMaterial(),
-        elevation: 4.16,
-        thickness: 0.38,
+        elevation: UPPER_FLOOR_TOP_ELEVATION,
+        thickness: STAIR_LANDING_THICKNESS,
         cutoutsByRoom: { upperLanding: cutouts },
       }
     );
@@ -265,8 +272,8 @@ describe('createUpperLandingFloorCutouts', () => {
 
     const floorTiles = createRoomFloorTiles([upperLandingRoom], {
       material: new MeshStandardMaterial(),
-      elevation: 4.16,
-      thickness: 0.38,
+      elevation: UPPER_FLOOR_TOP_ELEVATION,
+      thickness: STAIR_LANDING_THICKNESS,
       cutoutsByRoom: { upperLanding: cutouts },
     });
 


### PR DESCRIPTION
### Motivation
- Adopt a single bottom-anchor convention so player roots and floor-standing POIs share the same world Y anchor (ground = `0`, upper = `5`).
- Eliminate scattered hard-coded upper-floor/stair-derived elevations and preserve the appearance, collision behavior, and POI X/Z placement introduced by the previous layout work.

### Description
- Added a shared elevation module `src/scene/level/floorElevation.ts` exposing `GROUND_FLOOR_TOP_ELEVATION = 0`, `UPPER_FLOOR_TOP_ELEVATION = 5`, and `getFloorTopElevation(...)` used across placement and structure code.
- Re-anchored the player root so `player.position.y` is the surface/floor sample (ground `0`, upper `5`, stairs sampled); moved the invisible collision proxy to local `y = PLAYER_RADIUS` and adjusted the mannequin visual root to be floor-relative to preserve world-space visuals.
- Re-derived stair step rise from the canonical upper-floor elevation and added an invariant check ensuring `stair base Y + total step rise + landing thickness === 5` so landing and upper slab remain coplanar.
- Converted floor-standing POI/showpiece Y handling to derive from floor identity via `getFloorTopElevation(...)` and documented `PoiDefinition.position.y` as the bottom/base anchor while preserving all X/Z, headings, room assignments, and wall-mounted exceptions.

### Testing
- Ran formatting and linting via `npm run format:write` and `npm run lint` which succeeded (ESLint emitted 5 fixable warnings only).
- Ran focused unit tests and full CI suite via `npx vitest` / `npm run test:ci` and observed all Vitest suites pass (targeted tests and the full `test:ci` run succeeded: 1280 tests passed).
- Executed the immersive stair Playwright scenario with `npx playwright test playwright/immersive-stairs-roundtrip.spec.ts` (browsers installed during the run) and the end-to-end stair roundtrip passed (9/9 Playwright checks passed after installing Playwright browsers and dependencies).
- Verified smoke build with `npm run smoke` and collider redundancy audit via `npm run collider:audit:redundancy`; smoke passed and collider audit reported 0 failures (warnings are existing metadata notes).
- Docs check via `npm run docs:check` passed (link checker emitted fetch warnings but completed successfully).
- `npm run typecheck` reported existing baseline TypeScript errors unrelated to this change (several preexisting test/type issues and importer typing failures); these typecheck failures are unchanged in scope and were not introduced by this change.

Residual notes: runtime preview confirmed `window.portfolio.world.getPlayerPosition().y` reports `0` at ground spawn and stair metrics expose `upperFloorElevation === 5`; focused visual and collision behavior were preserved by offsetting the collision proxy and using an explicit camera presentation offset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae0d589e4832fa053aade843f1a6d)