### PR TITLE
Add POI debug metadata and model-detail quality copy

### DIFF
--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -335,6 +335,8 @@ export const AR_OVERRIDES: LocaleOverrides = {
       relatedCaseStudies: 'دراسات حالة ذات صلة',
       outcomeFallbackLabel: 'النتيجة',
       discoveryAnnouncementTemplate: 'تم اكتشاف {title}. {summary}',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
     },
     narrativeLog: {
       heading: 'سجل القصة',

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -461,6 +461,8 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       relatedCaseStudies: wrap('Related case studies'),
       outcomeFallbackLabel: wrap('Outcome'),
       discoveryAnnouncementTemplate: wrap('{title} discovered. {summary}'),
+      debugAnchorLabel: wrap('POI anchor'),
+      debugTrianglesLabel: wrap('Model triangles'),
     },
     narrativeLog: {
       heading: wrap('Creator story log'),

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -464,6 +464,8 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       relatedCaseStudies: 'Related case studies',
       outcomeFallbackLabel: 'Outcome',
       discoveryAnnouncementTemplate: '{title} discovered. {summary}',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
     },
     narrativeLog: {
       heading: 'Creator story log',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -335,6 +335,8 @@ export const JA_OVERRIDES: LocaleOverrides = {
       relatedCaseStudies: '関連ケーススタディ',
       outcomeFallbackLabel: '成果',
       discoveryAnnouncementTemplate: '{title} を発見しました。{summary}',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
     },
     narrativeLog: {
       heading: 'クリエイターストーリーログ',

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -832,6 +832,8 @@ export function buildLatinLocaleOverrides(
         relatedCaseStudies: s.related,
         outcomeFallbackLabel: s.outcome,
         discoveryAnnouncementTemplate: s.discovered,
+        debugAnchorLabel: 'POI anchor',
+        debugTrianglesLabel: 'Model triangles',
       },
       narrativeLog: {
         heading:

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -363,6 +363,8 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       relatedCaseStudies: '相关案例研究',
       outcomeFallbackLabel: '成果',
       discoveryAnnouncementTemplate: '已发现 {title}。{summary}',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
     },
     narrativeLog: {
       heading: '创作者故事日志',

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -301,6 +301,8 @@ export interface PoiOverlayChromeStrings {
   relatedCaseStudies: string;
   outcomeFallbackLabel: string;
   discoveryAnnouncementTemplate: string;
+  debugAnchorLabel: string;
+  debugTrianglesLabel: string;
 }
 
 export interface PoiNarrativeLogStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,6 +240,7 @@ import {
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
+import { countPoiModelTriangles } from './scene/poi/modelTriangles';
 import { getPoiInteractionAnchorPosition } from './scene/poi/placements';
 import { getPoiDefinitions } from './scene/poi/registry';
 import {
@@ -2512,6 +2513,12 @@ function initializeImmersiveScene(
     (layoutOverride ?? hudLayoutManager?.getLayout()) === 'mobile';
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
+    getModelTriangleCount: (poi) => {
+      const instance = poiInstances.find(
+        (candidate) => candidate.definition.id === poi.id
+      );
+      return instance ? countPoiModelTriangles(instance.modelRoots) : 0;
+    },
     interactionTimeline,
     guidedTourPreference,
     discoveryAnnouncer: {
@@ -2526,6 +2533,7 @@ function initializeImmersiveScene(
     },
   });
   poiTooltipOverlay.setStrings(poiOverlayStrings);
+  poiTooltipOverlay.setDebugDetailsEnabled(debugCoordinatesEnabled);
   const poiWorldTooltip = new PoiWorldTooltip({
     parent: scene,
     camera,
@@ -2897,6 +2905,7 @@ function initializeImmersiveScene(
       ? upperStructureGroup
       : groundStructureGroup
     ).add(group);
+    poi.modelRoots.push(group);
   };
   const getPoiColliderTarget = (poi: PoiInstance) =>
     getPoiFloorId(poi.definition) === 'upper'
@@ -4936,6 +4945,7 @@ function initializeImmersiveScene(
     options: { persist?: boolean } = { persist: true }
   ) => {
     debugCoordinatesEnabled = enabled;
+    poiTooltipOverlay.setDebugDetailsEnabled(enabled);
     syncDebugCoordinatesOverlayVisibility();
     refreshDebugCoordinatesControl();
     if (enabled) {

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -23,7 +23,8 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
     {
       id: 'cinematic',
       label: 'Cinematic',
-      description: 'Full post-processing with cinematic bloom and lighting.',
+      description:
+        'Full post-processing, highest-detail 3D models, cinematic bloom and lighting.',
       pixelRatioScale: 1,
       exposure: 1.1,
       bloom: {
@@ -41,7 +42,7 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
       id: 'balanced',
       label: 'Balanced',
       description:
-        'Moderate bloom with slightly reduced resolution for laptops.',
+        'Moderate bloom, reduced resolution, and medium-detail 3D models for laptops.',
       pixelRatioScale: 0.85,
       exposure: 1.02,
       bloom: {
@@ -58,7 +59,8 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
     {
       id: 'performance',
       label: 'Performance',
-      description: 'Disables bloom and lowers resolution to prioritize FPS.',
+      description:
+        'Disables bloom, lowers resolution, and uses lowest-detail 3D models to prioritize FPS.',
       pixelRatioScale: 0.7,
       exposure: 0.96,
       bloom: {

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -53,6 +53,7 @@ export interface PoiInstanceOptions {
 export interface PoiInstance {
   definition: PoiDefinition;
   group: Object3D;
+  modelRoots: Object3D[];
   orb?: Mesh;
   orbMaterial?: MeshStandardMaterial;
   orbBaseHeight?: number;
@@ -390,6 +391,7 @@ function createPedestalPoiInstance(
   return {
     definition,
     group,
+    modelRoots: [],
     orb,
     orbMaterial,
     orbBaseHeight,
@@ -469,6 +471,7 @@ function createDisplayPoiInstance(
   return {
     definition,
     group: override.hitArea,
+    modelRoots: [],
     collider,
     activation: 0,
     pulseOffset: 0,

--- a/src/scene/poi/modelTriangles.ts
+++ b/src/scene/poi/modelTriangles.ts
@@ -1,0 +1,58 @@
+import { InstancedMesh, Mesh, Object3D } from 'three';
+import type { BufferGeometry } from 'three';
+
+const getFiniteCount = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : null;
+
+function countGeometryTriangles(geometry: BufferGeometry): number {
+  const indexCount = getFiniteCount(geometry.index?.count);
+  const positionCount = getFiniteCount(
+    geometry.getAttribute('position')?.count
+  );
+  const sourceCount = indexCount ?? positionCount;
+  if (sourceCount === null) {
+    return 0;
+  }
+
+  const drawRangeStart = Math.max(
+    0,
+    getFiniteCount(geometry.drawRange.start) ?? 0
+  );
+  const drawRangeCount = getFiniteCount(geometry.drawRange.count);
+  const effectiveCount =
+    drawRangeCount === null
+      ? sourceCount
+      : Math.min(sourceCount, drawRangeStart + drawRangeCount) - drawRangeStart;
+
+  return Math.max(0, Math.floor(effectiveCount / 3));
+}
+
+export function countPoiModelTriangles(roots: readonly Object3D[]): number {
+  const visited = new Set<Object3D>();
+  let total = 0;
+
+  for (const root of roots) {
+    if (visited.has(root)) {
+      continue;
+    }
+    root.traverseVisible((object) => {
+      if (visited.has(object)) {
+        return;
+      }
+      visited.add(object);
+      if (!(object instanceof Mesh)) {
+        return;
+      }
+      const baseTriangles = countGeometryTriangles(object.geometry);
+      const instanceCount =
+        object instanceof InstancedMesh
+          ? (getFiniteCount(object.count) ?? 0)
+          : 1;
+      total += baseTriangles * instanceCount;
+    });
+  }
+
+  return Number.isFinite(total) ? Math.max(0, Math.floor(total)) : 0;
+}

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -26,6 +26,7 @@ export interface PoiTooltipOverlayOptions {
   };
   interactionTimeline?: InteractionTimeline;
   guidedTourPreference?: GuidedTourPreference;
+  getModelTriangleCount?: (poi: PoiDefinition) => number;
 }
 
 interface RenderState {
@@ -53,6 +54,9 @@ export class PoiTooltipOverlay {
   private readonly outcomeSeparator: HTMLSpanElement;
   private readonly outcomeValue: HTMLSpanElement;
   private readonly metricsList: HTMLUListElement;
+  private readonly debugDetails: HTMLDListElement;
+  private readonly debugAnchorValue: HTMLElement;
+  private readonly debugTrianglesValue: HTMLElement;
   private readonly linksList: HTMLUListElement;
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
@@ -60,6 +64,7 @@ export class PoiTooltipOverlay {
   private readonly closeButton: HTMLButtonElement;
   private readonly liveRegion: HTMLElement;
   private readonly interactionTimeline: InteractionTimeline | null;
+  private readonly getModelTriangleCount: (poi: PoiDefinition) => number;
   private readonly guidedTourPreference: GuidedTourPreference;
   private readonly instanceId: string;
   private discoveryFormatter: DiscoveryFormatter;
@@ -76,6 +81,7 @@ export class PoiTooltipOverlay {
   private visitedPoiIds: ReadonlySet<string> = new Set();
   private guidedTourEnabled = true;
   private passiveRecommendationsEnabled = true;
+  private debugDetailsEnabled = false;
   private isIdle = false;
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
@@ -89,6 +95,7 @@ export class PoiTooltipOverlay {
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
+      getModelTriangleCount,
     } = options;
     const documentTarget = container.ownerDocument ?? document;
 
@@ -97,6 +104,7 @@ export class PoiTooltipOverlay {
     this.discoveryFormatter =
       discoveryAnnouncer?.format ?? defaultDiscoveryFormatter;
     this.interactionTimeline = interactionTimeline ?? null;
+    this.getModelTriangleCount = getModelTriangleCount ?? (() => 0);
     this.guidedTourPreference = guidedTourPreference;
     this.onDismiss = onDismiss ?? null;
     this.instanceId = generateTooltipInstanceId();
@@ -176,6 +184,34 @@ export class PoiTooltipOverlay {
     this.metricsList.id = `${this.instanceId}-metrics`;
     this.root.appendChild(this.metricsList);
 
+    this.debugDetails = documentTarget.createElement('dl');
+    this.debugDetails.className = 'poi-tooltip-overlay__debug';
+    this.debugDetails.id = `${this.instanceId}-debug`;
+    this.debugDetails.dataset.poiDebug = 'true';
+    this.debugDetails.hidden = true;
+
+    const anchorTerm = documentTarget.createElement('dt');
+    anchorTerm.textContent = this.strings.debugAnchorLabel;
+    const anchorDetail = documentTarget.createElement('dd');
+    this.debugAnchorValue = documentTarget.createElement('span');
+    this.debugAnchorValue.dataset.poiDebugAnchor = 'true';
+    anchorDetail.appendChild(this.debugAnchorValue);
+
+    const trianglesTerm = documentTarget.createElement('dt');
+    trianglesTerm.textContent = this.strings.debugTrianglesLabel;
+    const trianglesDetail = documentTarget.createElement('dd');
+    this.debugTrianglesValue = documentTarget.createElement('span');
+    this.debugTrianglesValue.dataset.poiDebugTriangles = 'true';
+    trianglesDetail.appendChild(this.debugTrianglesValue);
+
+    this.debugDetails.append(
+      anchorTerm,
+      anchorDetail,
+      trianglesTerm,
+      trianglesDetail
+    );
+    this.root.appendChild(this.debugDetails);
+
     this.linksList = documentTarget.createElement('ul');
     this.linksList.className = 'poi-tooltip-overlay__links';
     this.linksList.id = `${this.instanceId}-links`;
@@ -209,6 +245,10 @@ export class PoiTooltipOverlay {
     this.recommendationBadge.textContent = strings.nextHighlight;
     this.closeButton.setAttribute('aria-label', strings.closeDetails);
     this.linksList.setAttribute('aria-label', strings.relatedCaseStudies);
+    this.debugDetails.querySelectorAll('dt')[0].textContent =
+      strings.debugAnchorLabel;
+    this.debugDetails.querySelectorAll('dt')[1].textContent =
+      strings.debugTrianglesLabel;
     this.renderState = { poiId: null, poiRef: null, contentKey: null };
     this.update();
   }
@@ -244,6 +284,14 @@ export class PoiTooltipOverlay {
 
   setRecommendation(poi: PoiDefinition | null) {
     this.recommendation = poi;
+    this.update();
+  }
+
+  setDebugDetailsEnabled(enabled: boolean): void {
+    if (this.debugDetailsEnabled === enabled) {
+      return;
+    }
+    this.debugDetailsEnabled = enabled;
     this.update();
   }
 
@@ -308,6 +356,7 @@ export class PoiTooltipOverlay {
       this.root.removeAttribute('aria-describedby');
       this.renderState = { poiId: null, poiRef: null, contentKey: null };
       this.visitedBadge.hidden = true;
+      this.debugDetails.hidden = true;
       this.recommendationBadge.hidden = true;
       this.liveRegion.textContent = '';
       this.focusOnNextUpdate = false;
@@ -347,6 +396,7 @@ export class PoiTooltipOverlay {
       };
       this.renderPoi(poi);
     }
+    this.renderDebugDetails(poi);
 
     const describedByIds = [this.summary.id];
     if (!this.outcome.hidden) {
@@ -357,6 +407,9 @@ export class PoiTooltipOverlay {
     }
     if (!this.linksList.hidden) {
       describedByIds.push(this.linksList.id);
+    }
+    if (!this.debugDetails.hidden) {
+      describedByIds.push(this.debugDetails.id);
     }
     if (describedByIds.length > 0) {
       this.root.setAttribute('aria-describedby', describedByIds.join(' '));
@@ -471,6 +524,37 @@ export class PoiTooltipOverlay {
       item.appendChild(value);
       this.metricsList.appendChild(item);
     }
+  }
+
+  private renderDebugDetails(poi: PoiDefinition) {
+    this.debugDetails.hidden = !this.debugDetailsEnabled;
+    if (!this.debugDetailsEnabled) {
+      this.debugAnchorValue.textContent = '';
+      this.debugTrianglesValue.textContent = '';
+      return;
+    }
+
+    const locale = this.getFormattingLocale();
+    const coordinateFormatter = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    const integerFormatter = new Intl.NumberFormat(locale, {
+      maximumFractionDigits: 0,
+    });
+    this.debugAnchorValue.textContent = [
+      `X ${coordinateFormatter.format(poi.position.x)}`,
+      `Y ${coordinateFormatter.format(poi.position.y)}`,
+      `Z ${coordinateFormatter.format(poi.position.z)}`,
+    ].join(' · ');
+    this.debugTrianglesValue.textContent = integerFormatter.format(
+      Math.max(0, Math.floor(this.getModelTriangleCount(poi)))
+    );
+  }
+
+  private getFormattingLocale(): string {
+    const lang = this.root.ownerDocument.documentElement.lang;
+    return lang && lang !== 'en-x-pseudo' ? lang : 'en';
   }
 
   private renderLinks(poi: PoiDefinition) {

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -9,6 +9,25 @@ import {
 } from '../scene/graphics/qualityManager';
 
 describe('createGraphicsQualityManager', () => {
+  it('describes model detail across every graphics quality preset', () => {
+    expect(GRAPHICS_QUALITY_PRESETS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'cinematic',
+          description: expect.stringMatching(/highest-detail 3D models/),
+        }),
+        expect.objectContaining({
+          id: 'balanced',
+          description: expect.stringMatching(/medium-detail 3D models/),
+        }),
+        expect.objectContaining({
+          id: 'performance',
+          description: expect.stringMatching(/lowest-detail 3D models/),
+        }),
+      ])
+    );
+  });
+
   const baseBloom = {
     strength: 0.55,
     radius: 0.85,

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -57,6 +57,7 @@ function createMockPoi(definition: PoiDefinition): PoiInstance {
   return {
     definition,
     group,
+    modelRoots: [],
     orb,
     orbMaterial,
     orbBaseHeight: 1,

--- a/src/tests/poiModelTriangles.test.ts
+++ b/src/tests/poiModelTriangles.test.ts
@@ -1,0 +1,79 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Group,
+  InstancedMesh,
+  Line,
+  Mesh,
+  MeshBasicMaterial,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { countPoiModelTriangles } from '../scene/poi/modelTriangles';
+
+const triangleGeometry = () => {
+  const geometry = new BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new BufferAttribute(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 3)
+  );
+  return geometry;
+};
+
+describe('countPoiModelTriangles', () => {
+  it('counts indexed geometry from the index count', () => {
+    const geometry = triangleGeometry();
+    geometry.setIndex([0, 1, 2, 2, 1, 0]);
+    expect(countPoiModelTriangles([new Mesh(geometry)])).toBe(2);
+  });
+
+  it('counts non-indexed geometry from the position attribute count', () => {
+    expect(countPoiModelTriangles([new Mesh(triangleGeometry())])).toBe(1);
+  });
+
+  it('multiplies instanced mesh geometry by active instance count', () => {
+    const mesh = new InstancedMesh(
+      triangleGeometry(),
+      new MeshBasicMaterial(),
+      4
+    );
+    mesh.count = 3;
+    expect(countPoiModelTriangles([mesh])).toBe(3);
+  });
+
+  it('ignores hidden descendants', () => {
+    const group = new Group();
+    const mesh = new Mesh(triangleGeometry());
+    mesh.visible = false;
+    group.add(mesh);
+    expect(countPoiModelTriangles([group])).toBe(0);
+  });
+
+  it('ignores malformed and non-mesh geometry safely', () => {
+    const group = new Group();
+    group.add(new Mesh(new BufferGeometry()));
+    group.add(new Line(triangleGeometry()));
+    expect(countPoiModelTriangles([group])).toBe(0);
+  });
+
+  it('counts separate meshes sharing a geometry as separate rendered instances', () => {
+    const geometry = triangleGeometry();
+    expect(
+      countPoiModelTriangles([new Mesh(geometry), new Mesh(geometry)])
+    ).toBe(2);
+  });
+
+  it('avoids double-counting overlapping registered roots', () => {
+    const group = new Group();
+    const mesh = new Mesh(triangleGeometry());
+    group.add(mesh);
+    expect(countPoiModelTriangles([group, mesh])).toBe(1);
+  });
+
+  it('respects finite draw ranges', () => {
+    const geometry = triangleGeometry();
+    geometry.setIndex([0, 1, 2, 2, 1, 0]);
+    geometry.setDrawRange(0, 3);
+    expect(countPoiModelTriangles([new Mesh(geometry)])).toBe(1);
+  });
+});

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -455,6 +455,8 @@ describe('PoiTooltipOverlay', () => {
       relatedCaseStudies: '⟦Related case studies⟧',
       outcomeFallbackLabel: '⟦Outcome⟧',
       discoveryAnnouncementTemplate: '⟦{title} discovered. {summary}⟧',
+      debugAnchorLabel: '⟦POI anchor⟧',
+      debugTrianglesLabel: '⟦Model triangles⟧',
     });
     overlay.setSelected(localizedPoi);
 
@@ -953,5 +955,90 @@ describe('PoiTooltipOverlay', () => {
       '.poi-tooltip-overlay__live-region'
     ) as HTMLElement;
     expect(liveRegion.textContent).toBe('');
+  });
+});
+
+describe('PoiTooltipOverlay debug details', () => {
+  let container: HTMLElement;
+  let overlay: PoiTooltipOverlay;
+  const poi: PoiDefinition = {
+    id: 'sugarkube-backyard-greenhouse',
+    title: 'Sugarkube',
+    summary: 'Relocated deployment marker.',
+    interactionPrompt: 'Inspect Sugarkube',
+    category: 'project',
+    interaction: 'inspect',
+    roomId: 'backyard',
+    position: { x: -8.74, y: 0, z: -22.92 },
+    interactionRadius: 2,
+    footprint: { width: 1, depth: 1 },
+    metrics: [{ label: 'Status', value: 'Relocated' }],
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    overlay = new PoiTooltipOverlay({
+      container,
+      getModelTriangleCount: () => 1234,
+    });
+    overlay.setStrings(getPoiOverlayChromeStrings('en'));
+  });
+
+  afterEach(() => {
+    overlay.dispose();
+    container.remove();
+    document.documentElement.lang = '';
+  });
+
+  it('hides debug content by default while preserving normal metrics', () => {
+    overlay.setSelected(poi);
+    expect(
+      container.querySelector<HTMLElement>('[data-poi-debug]')?.hidden
+    ).toBe(true);
+    expect(
+      container.querySelector('.poi-tooltip-overlay__metrics')?.textContent
+    ).toContain('Relocated');
+  });
+
+  it('shows bottom-center anchor and active model triangle count when enabled', () => {
+    document.documentElement.lang = 'en';
+    overlay.setSelected(poi);
+    overlay.setDebugDetailsEnabled(true);
+
+    expect(
+      container.querySelector('[data-poi-debug-anchor]')?.textContent
+    ).toBe('X -8.74 · Y 0.00 · Z -22.92');
+    expect(
+      container.querySelector('[data-poi-debug-triangles]')?.textContent
+    ).toBe('1,234');
+  });
+
+  it('removes debug details from accessibility relationships immediately when disabled', () => {
+    overlay.setSelected(poi);
+    overlay.setDebugDetailsEnabled(true);
+    const region = container.querySelector<HTMLElement>('.poi-tooltip-overlay');
+    const debug = container.querySelector<HTMLElement>('[data-poi-debug]');
+    expect(region?.getAttribute('aria-describedby')).toContain(debug?.id);
+
+    overlay.setDebugDetailsEnabled(false);
+    expect(
+      container.querySelector<HTMLElement>('[data-poi-debug]')?.hidden
+    ).toBe(true);
+    expect(region?.getAttribute('aria-describedby')).not.toContain(debug?.id);
+  });
+
+  it('appears for hovered and recommended card states', () => {
+    overlay.setDebugDetailsEnabled(true);
+    overlay.setHovered(poi);
+    expect(
+      container.querySelector('[data-poi-debug-triangles]')?.textContent
+    ).toBe('1,234');
+    overlay.setHovered(null);
+    overlay.setRecommendation(poi);
+    overlay.setIdleState(true);
+    expect(
+      container.querySelector('[data-poi-debug-triangles]')?.textContent
+    ).toBe('1,234');
   });
 });

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2355,3 +2355,29 @@ html[data-hud-layout='mobile'] .performance-recovery-popup {
   width: min(18rem, calc(100vw - 1.5rem));
   padding: 0.7rem;
 }
+
+.poi-tooltip-overlay__debug {
+  margin: 0.15rem 0 0;
+  padding: 0.55rem 0 0;
+  border-top: 1px solid rgba(125, 210, 255, 0.22);
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.6rem;
+  color: rgba(195, 236, 255, 0.86);
+  font-size: 0.76rem;
+}
+
+.poi-tooltip-overlay__debug[hidden] {
+  display: none;
+}
+
+.poi-tooltip-overlay__debug dt {
+  margin: 0;
+  font-weight: 600;
+  color: rgba(141, 217, 255, 0.95);
+}
+
+.poi-tooltip-overlay__debug dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
### Motivation
- Surface POI diagnostics (anchor + model triangle count) behind the existing Debug coordinates toggle to help inspect model placement and runtime model complexity.
- Track runtime POI model roots without mutating `PoiDefinition` so diagnostics exclude orphaned/environment geometry.
- Make Graphics Quality descriptions explicit about 3D model detail differences between presets.

### Description
- Add `modelRoots: Object3D[]` to `PoiInstance` and register roots via the `addPoiStructure(poi, group)` helper so dedicated POI structures contribute to diagnostics without changing `PoiDefinition`.
- Introduce `src/scene/poi/modelTriangles.ts` with `countPoiModelTriangles(...)` that traverses visible descendants, respects draw ranges, handles `InstancedMesh`, and avoids double-counting overlapping roots.
- Extend `PoiTooltipOverlay` to render a localized, semantic `<dl>` debug section (selectors: `data-poi-debug`, `data-poi-debug-anchor`, `data-poi-debug-triangles`), add `setDebugDetailsEnabled()` to force rerenders, and accept a `getModelTriangleCount` callback for triangle values.
- Wire the existing `debugCoordinatesEnabled` state and `window.portfolio.debugCoordinates` flow to call `poiTooltipOverlay.setDebugDetailsEnabled(...)`, and provide triangle counts from registered model roots in `main.ts`.
- Add i18n keys (`debugAnchorLabel`, `debugTrianglesLabel`) and CSS styles for the compact debug panel; update `GRAPHICS_QUALITY_PRESETS` descriptions to mention model detail.
- Tests and fixtures: add `src/tests/poiModelTriangles.test.ts`, update `src/tests/poiTooltipOverlay.test.ts` to cover visibility/accessibility/locale/formatting, update `graphicsQualityManager` test to assert model-detail wording, and update `poiInteractionManager` test fixture to include `modelRoots`.

### Testing
- Ran formatting and linting: `npm run format:write` and `npm run lint` (completed; lint produced only fixable warnings reported and no blocking errors).
- Ran focused test suite: `npm run test:ci -- src/tests/poiModelTriangles.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/i18n.test.ts src/tests/graphicsQualityControl.test.ts src/tests/graphicsQualityManager.test.ts`, and all specified tests passed (all tests in those files succeeded).
- Built the app: `npm run build` (Vite build succeeded).
- Verified formatting: `npm run format:check` (passed) and ran repository secret scan `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).
- Typecheck: `npm run typecheck` reports existing, broad TypeScript errors in unrelated parts of the repo; these are pre-existing and outside this PR’s narrow changes (I updated the new POI test fixture to include `modelRoots`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b709c1284832f94356686f65d1d3d)