### PR TITLE
POI: add debug model diagnostics and clarify graphics-quality wording

### DIFF
--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -334,6 +334,9 @@ export const AR_OVERRIDES: LocaleOverrides = {
       closeDetails: 'إغلاق تفاصيل نقطة الاهتمام',
       relatedCaseStudies: 'دراسات حالة ذات صلة',
       outcomeFallbackLabel: 'النتيجة',
+      debugDetailsLabel: 'Debug details',
+      debugPoiAnchor: 'POI anchor',
+      debugModelTriangles: 'Model triangles',
       discoveryAnnouncementTemplate: 'تم اكتشاف {title}. {summary}',
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -460,6 +460,9 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       closeDetails: wrap('Close POI details'),
       relatedCaseStudies: wrap('Related case studies'),
       outcomeFallbackLabel: wrap('Outcome'),
+      debugDetailsLabel: 'Debug details',
+      debugPoiAnchor: 'POI anchor',
+      debugModelTriangles: 'Model triangles',
       discoveryAnnouncementTemplate: wrap('{title} discovered. {summary}'),
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -460,9 +460,9 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       closeDetails: wrap('Close POI details'),
       relatedCaseStudies: wrap('Related case studies'),
       outcomeFallbackLabel: wrap('Outcome'),
-      debugDetailsLabel: 'Debug details',
-      debugPoiAnchor: 'POI anchor',
-      debugModelTriangles: 'Model triangles',
+      debugDetailsLabel: wrap('Debug details'),
+      debugPoiAnchor: wrap('POI anchor'),
+      debugModelTriangles: wrap('Model triangles'),
       discoveryAnnouncementTemplate: wrap('{title} discovered. {summary}'),
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -463,6 +463,9 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       closeDetails: 'Close POI details',
       relatedCaseStudies: 'Related case studies',
       outcomeFallbackLabel: 'Outcome',
+      debugDetailsLabel: 'Debug details',
+      debugPoiAnchor: 'POI anchor',
+      debugModelTriangles: 'Model triangles',
       discoveryAnnouncementTemplate: '{title} discovered. {summary}',
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -334,6 +334,9 @@ export const JA_OVERRIDES: LocaleOverrides = {
       closeDetails: 'POI の詳細を閉じる',
       relatedCaseStudies: '関連ケーススタディ',
       outcomeFallbackLabel: '成果',
+      debugDetailsLabel: 'Debug details',
+      debugPoiAnchor: 'POI anchor',
+      debugModelTriangles: 'Model triangles',
       discoveryAnnouncementTemplate: '{title} を発見しました。{summary}',
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/latinLocaleOverrides.ts
+++ b/src/assets/i18n/locales/latinLocaleOverrides.ts
@@ -832,6 +832,9 @@ export function buildLatinLocaleOverrides(
         relatedCaseStudies: s.related,
         outcomeFallbackLabel: s.outcome,
         discoveryAnnouncementTemplate: s.discovered,
+        debugDetailsLabel: 'Debug details',
+        debugPoiAnchor: 'POI anchor',
+        debugModelTriangles: 'Model triangles',
       },
       narrativeLog: {
         heading:

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -362,6 +362,9 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       closeDetails: '关闭兴趣点详情',
       relatedCaseStudies: '相关案例研究',
       outcomeFallbackLabel: '成果',
+      debugDetailsLabel: 'Debug details',
+      debugPoiAnchor: 'POI anchor',
+      debugModelTriangles: 'Model triangles',
       discoveryAnnouncementTemplate: '已发现 {title}。{summary}',
     },
     narrativeLog: {

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -301,6 +301,9 @@ export interface PoiOverlayChromeStrings {
   relatedCaseStudies: string;
   outcomeFallbackLabel: string;
   discoveryAnnouncementTemplate: string;
+  debugDetailsLabel: string;
+  debugPoiAnchor: string;
+  debugModelTriangles: string;
 }
 
 export interface PoiNarrativeLogStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,6 +240,7 @@ import {
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
+import { countPoiModelTriangles } from './scene/poi/modelTriangles';
 import { getPoiInteractionAnchorPosition } from './scene/poi/placements';
 import { getPoiDefinitions } from './scene/poi/registry';
 import {
@@ -2512,6 +2513,16 @@ function initializeImmersiveScene(
     (layoutOverride ?? hudLayoutManager?.getLayout()) === 'mobile';
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
+    locale,
+    getDebugDetails: (definition) => {
+      const poi = poiInstances.find(
+        (candidate) => candidate.definition.id === definition.id
+      );
+      return {
+        anchor: definition.position,
+        modelTriangles: poi ? countPoiModelTriangles(poi.modelRoots) : 0,
+      };
+    },
     interactionTimeline,
     guidedTourPreference,
     discoveryAnnouncer: {
@@ -2525,7 +2536,7 @@ function initializeImmersiveScene(
       dismissActivePoiDetail();
     },
   });
-  poiTooltipOverlay.setStrings(poiOverlayStrings);
+  poiTooltipOverlay.setStrings(poiOverlayStrings, locale);
   const poiWorldTooltip = new PoiWorldTooltip({
     parent: scene,
     camera,
@@ -2897,6 +2908,7 @@ function initializeImmersiveScene(
       ? upperStructureGroup
       : groundStructureGroup
     ).add(group);
+    poi.modelRoots.push(group);
   };
   const getPoiColliderTarget = (poi: PoiInstance) =>
     getPoiFloorId(poi.definition) === 'upper'
@@ -4219,13 +4231,13 @@ function initializeImmersiveScene(
     hudCustomizationSection?.setStrings(hudCustomizationStrings);
     localeToggleControl?.setStrings(localeToggleStrings);
     poiNarrativeLog?.setStrings(narrativeLogStrings);
+    poiTooltipOverlay.setStrings(poiOverlayStrings, locale);
     audioSubtitles?.setLabels(audioSubtitleStrings);
     narrationToggleControl?.setStrings(narrationToggleStrings);
     refreshDebugCoordinatesStrings();
     refreshDebugCollidersStrings();
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
-    poiTooltipOverlay.setStrings(poiOverlayStrings);
     updateHelpButtonLabel();
     localeToggleControl?.refresh();
     syncPoiRecommendation();
@@ -4938,6 +4950,7 @@ function initializeImmersiveScene(
     debugCoordinatesEnabled = enabled;
     syncDebugCoordinatesOverlayVisibility();
     refreshDebugCoordinatesControl();
+    poiTooltipOverlay.setDebugDetailsEnabled(enabled);
     if (enabled) {
       updateDebugCoordinatesOverlay();
     }
@@ -4965,6 +4978,8 @@ function initializeImmersiveScene(
     refreshDebugSolidIdsControl();
     refreshDebugFpsControl();
   };
+
+  poiTooltipOverlay.setDebugDetailsEnabled(debugCoordinatesEnabled);
 
   debugCoordinatesOverlay = document.createElement('aside');
   debugCoordinatesOverlay.className = 'debug-coordinates';

--- a/src/main.ts
+++ b/src/main.ts
@@ -2519,7 +2519,7 @@ function initializeImmersiveScene(
         (candidate) => candidate.definition.id === definition.id
       );
       return {
-        anchor: definition.position,
+        anchor: getPoiInteractionAnchorPosition(definition),
         modelTriangles: poi ? countPoiModelTriangles(poi.modelRoots) : 0,
       };
     },
@@ -2942,7 +2942,11 @@ function initializeImmersiveScene(
     } else {
       showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     }
-    groundStructureGroup.add(showpiece.group);
+    if (flywheelPoi) {
+      addPoiStructure(flywheelPoi, showpiece.group);
+    } else {
+      groundStructureGroup.add(showpiece.group);
+    }
     flywheelShowpiece = showpiece;
 
     const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1072,6 +1072,7 @@ let gabrielSentry: GabrielSentryBuild | null = null;
 let gitshelvesInstallation: GitshelvesInstallationBuild | null = null;
 const mediaWallStarBridge = createMediaWallStarBridge();
 let livingRoomMediaWall: LivingRoomMediaWallBuild | null = null;
+let futuroptimistTvModelRoot: Object3D | null = null;
 let selfieMirror: SelfieMirrorBuild | null = null;
 let ledStripGroup: Group | null = null;
 let ledFillLightGroup: Group | null = null;
@@ -2034,6 +2035,7 @@ function initializeImmersiveScene(
     tvHitArea.visible = true;
     tvHitArea.renderOrder = tvBinding.glow.renderOrder + 1;
     mediaWall.group.add(tvHitArea);
+    futuroptimistTvModelRoot = tvBinding.glow;
 
     poiOverrides['futuroptimist-living-room-tv'] = {
       mode: 'display',
@@ -2519,7 +2521,7 @@ function initializeImmersiveScene(
         (candidate) => candidate.definition.id === definition.id
       );
       return {
-        anchor: getPoiInteractionAnchorPosition(definition),
+        anchor: definition.position,
         modelTriangles: poi ? countPoiModelTriangles(poi.modelRoots) : 0,
       };
     },
@@ -2875,6 +2877,10 @@ function initializeImmersiveScene(
   const flywheelPoi = poiInstances.find(
     (poi) => poi.definition.id === 'flywheel-studio-flywheel'
   );
+  if (futuroptimistPoi && futuroptimistTvModelRoot) {
+    futuroptimistPoi.modelRoots = [futuroptimistTvModelRoot];
+  }
+
   const jobbotPoi = poiInstances.find(
     (poi) => poi.definition.id === 'jobbot-studio-terminal'
   );

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -23,7 +23,8 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
     {
       id: 'cinematic',
       label: 'Cinematic',
-      description: 'Full post-processing with cinematic bloom and lighting.',
+      description:
+        'Full post-processing, highest-detail 3D models, cinematic bloom and lighting.',
       pixelRatioScale: 1,
       exposure: 1.1,
       bloom: {
@@ -41,7 +42,7 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
       id: 'balanced',
       label: 'Balanced',
       description:
-        'Moderate bloom with slightly reduced resolution for laptops.',
+        'Moderate bloom, reduced resolution, and medium-detail 3D models for laptops.',
       pixelRatioScale: 0.85,
       exposure: 1.02,
       bloom: {
@@ -58,7 +59,8 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
     {
       id: 'performance',
       label: 'Performance',
-      description: 'Disables bloom and lowers resolution to prioritize FPS.',
+      description:
+        'Disables bloom, lowers resolution, and uses lowest-detail 3D models to prioritize FPS.',
       pixelRatioScale: 0.7,
       exposure: 0.96,
       bloom: {

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -485,7 +485,7 @@ function createDisplayPoiInstance(
     displayHighlight: override.highlight,
     visited: false,
     visitedStrength: 0,
-    modelRoots: [],
+    modelRoots: [override.highlight.mesh],
   };
 }
 

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -87,6 +87,7 @@ export interface PoiInstance {
     material: MeshBasicMaterial;
   };
   visitedBadge?: PoiVisitedBadge;
+  modelRoots: Object3D[];
 }
 
 export function createPoiInstances(
@@ -420,6 +421,7 @@ function createPedestalPoiInstance(
     visitedStrength: 0,
     visitedHighlight: { mesh: visitedRing, material: visitedRingMaterial },
     visitedBadge,
+    modelRoots: [],
   };
 }
 
@@ -483,6 +485,7 @@ function createDisplayPoiInstance(
     displayHighlight: override.highlight,
     visited: false,
     visitedStrength: 0,
+    modelRoots: [],
   };
 }
 

--- a/src/scene/poi/modelTriangles.ts
+++ b/src/scene/poi/modelTriangles.ts
@@ -1,0 +1,62 @@
+import { BufferGeometry, InstancedMesh, Mesh, Object3D } from 'three';
+
+const isFiniteNonnegative = (value: number): boolean =>
+  Number.isFinite(value) && value >= 0;
+
+function getGeometryTriangleCount(geometry: BufferGeometry): number {
+  const drawRangeStart = isFiniteNonnegative(geometry.drawRange.start)
+    ? Math.floor(geometry.drawRange.start)
+    : 0;
+  const drawRangeCount = isFiniteNonnegative(geometry.drawRange.count)
+    ? Math.floor(geometry.drawRange.count)
+    : Infinity;
+  if (drawRangeCount <= 0) {
+    return 0;
+  }
+
+  const indexCount = geometry.index?.count;
+  const positionCount = geometry.getAttribute('position')?.count;
+  const sourceCount = Number.isFinite(indexCount)
+    ? indexCount
+    : Number.isFinite(positionCount)
+      ? positionCount
+      : 0;
+  if (!sourceCount || sourceCount < 3) {
+    return 0;
+  }
+
+  const effectiveCount = Math.max(
+    0,
+    Math.min(sourceCount - drawRangeStart, drawRangeCount)
+  );
+  return Math.floor(effectiveCount / 3);
+}
+
+export function countPoiModelTriangles(roots: readonly Object3D[]): number {
+  const visited = new Set<Object3D>();
+  let total = 0;
+
+  for (const root of roots) {
+    root.traverseVisible((object) => {
+      if (visited.has(object)) {
+        return;
+      }
+      visited.add(object);
+      if (!(object instanceof Mesh)) {
+        return;
+      }
+      const geometry = object.geometry;
+      if (!(geometry instanceof BufferGeometry)) {
+        return;
+      }
+      const geometryTriangles = getGeometryTriangleCount(geometry);
+      const instanceCount =
+        object instanceof InstancedMesh
+          ? Math.max(0, Math.floor(object.count))
+          : 1;
+      total += geometryTriangles * instanceCount;
+    });
+  }
+
+  return Number.isFinite(total) ? Math.max(0, Math.floor(total)) : 0;
+}

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -386,6 +386,7 @@ export class PoiTooltipOverlay {
       };
       this.renderPoi(poi);
     }
+    this.renderDebugDetails(poi);
 
     const describedByIds = [this.summary.id];
     if (!this.outcome.hidden) {
@@ -456,7 +457,6 @@ export class PoiTooltipOverlay {
     this.renderOutcome(poi);
     this.renderMetrics(poi);
     this.renderLinks(poi);
-    this.renderDebugDetails(poi);
   }
 
   private renderOutcome(poi: PoiDefinition) {

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -17,6 +17,13 @@ type DiscoveryFormatter = (
   strings: PoiOverlayChromeStrings
 ) => string;
 
+export interface PoiDebugDetails {
+  anchor: { x: number; y: number; z: number };
+  modelTriangles: number;
+}
+
+type PoiDebugDetailsProvider = (poi: PoiDefinition) => PoiDebugDetails;
+
 export interface PoiTooltipOverlayOptions {
   container: HTMLElement;
   onDismiss?: () => void;
@@ -26,6 +33,8 @@ export interface PoiTooltipOverlayOptions {
   };
   interactionTimeline?: InteractionTimeline;
   guidedTourPreference?: GuidedTourPreference;
+  getDebugDetails?: PoiDebugDetailsProvider;
+  locale?: string;
 }
 
 interface RenderState {
@@ -54,6 +63,7 @@ export class PoiTooltipOverlay {
   private readonly outcomeValue: HTMLSpanElement;
   private readonly metricsList: HTMLUListElement;
   private readonly linksList: HTMLUListElement;
+  private readonly debugDetails: HTMLDListElement;
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
   private readonly recommendationBadge: HTMLSpanElement;
@@ -80,6 +90,9 @@ export class PoiTooltipOverlay {
   private unsubscribeGuidedTour: (() => void) | null = null;
   private focusOnNextUpdate = false;
   private readonly onDismiss: (() => void) | null;
+  private readonly getDebugDetails: PoiDebugDetailsProvider;
+  private debugDetailsEnabled = false;
+  private locale: string;
   private strings: PoiOverlayChromeStrings;
 
   constructor(options: PoiTooltipOverlayOptions) {
@@ -89,8 +102,11 @@ export class PoiTooltipOverlay {
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
+      getDebugDetails = defaultDebugDetailsProvider,
     } = options;
     const documentTarget = container.ownerDocument ?? document;
+    const locale =
+      options.locale ?? (documentTarget.documentElement.lang || 'en');
 
     this.strings = getPoiOverlayChromeStrings();
     this.discoveryPoliteness = discoveryAnnouncer?.politeness ?? 'polite';
@@ -99,6 +115,8 @@ export class PoiTooltipOverlay {
     this.interactionTimeline = interactionTimeline ?? null;
     this.guidedTourPreference = guidedTourPreference;
     this.onDismiss = onDismiss ?? null;
+    this.getDebugDetails = getDebugDetails;
+    this.locale = locale;
     this.instanceId = generateTooltipInstanceId();
 
     this.root = documentTarget.createElement('section');
@@ -182,6 +200,13 @@ export class PoiTooltipOverlay {
     this.linksList.setAttribute('aria-label', this.strings.relatedCaseStudies);
     this.root.appendChild(this.linksList);
 
+    this.debugDetails = documentTarget.createElement('dl');
+    this.debugDetails.className = 'poi-tooltip-overlay__debug';
+    this.debugDetails.id = `${this.instanceId}-debug`;
+    this.debugDetails.dataset.poiDebug = 'true';
+    this.debugDetails.hidden = true;
+    this.root.appendChild(this.debugDetails);
+
     container.appendChild(this.root);
 
     this.liveRegion = documentTarget.createElement('div');
@@ -203,12 +228,24 @@ export class PoiTooltipOverlay {
     );
   }
 
-  setStrings(strings: PoiOverlayChromeStrings): void {
+  setStrings(strings: PoiOverlayChromeStrings, locale?: string): void {
     this.strings = strings;
     this.visitedBadge.textContent = strings.visited;
     this.recommendationBadge.textContent = strings.nextHighlight;
     this.closeButton.setAttribute('aria-label', strings.closeDetails);
     this.linksList.setAttribute('aria-label', strings.relatedCaseStudies);
+    if (locale) {
+      this.locale = locale;
+    }
+    this.renderState = { poiId: null, poiRef: null, contentKey: null };
+    this.update();
+  }
+
+  setDebugDetailsEnabled(enabled: boolean): void {
+    if (this.debugDetailsEnabled === enabled) {
+      return;
+    }
+    this.debugDetailsEnabled = enabled;
     this.renderState = { poiId: null, poiRef: null, contentKey: null };
     this.update();
   }
@@ -310,6 +347,8 @@ export class PoiTooltipOverlay {
       this.visitedBadge.hidden = true;
       this.recommendationBadge.hidden = true;
       this.liveRegion.textContent = '';
+      this.debugDetails.hidden = true;
+      this.debugDetails.innerHTML = '';
       this.focusOnNextUpdate = false;
       return;
     }
@@ -357,6 +396,9 @@ export class PoiTooltipOverlay {
     }
     if (!this.linksList.hidden) {
       describedByIds.push(this.linksList.id);
+    }
+    if (!this.debugDetails.hidden) {
+      describedByIds.push(this.debugDetails.id);
     }
     if (describedByIds.length > 0) {
       this.root.setAttribute('aria-describedby', describedByIds.join(' '));
@@ -414,6 +456,7 @@ export class PoiTooltipOverlay {
     this.renderOutcome(poi);
     this.renderMetrics(poi);
     this.renderLinks(poi);
+    this.renderDebugDetails(poi);
   }
 
   private renderOutcome(poi: PoiDefinition) {
@@ -471,6 +514,55 @@ export class PoiTooltipOverlay {
       item.appendChild(value);
       this.metricsList.appendChild(item);
     }
+  }
+
+  private renderDebugDetails(poi: PoiDefinition) {
+    this.debugDetails.innerHTML = '';
+    if (!this.debugDetailsEnabled) {
+      this.debugDetails.hidden = true;
+      return;
+    }
+
+    const details = this.getDebugDetails(poi);
+    const axisFormatter = new Intl.NumberFormat(this.locale, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    const integerFormatter = new Intl.NumberFormat(this.locale, {
+      maximumFractionDigits: 0,
+    });
+    this.debugDetails.setAttribute(
+      'aria-label',
+      this.strings.debugDetailsLabel
+    );
+    this.appendDebugRow(
+      this.strings.debugPoiAnchor,
+      `X ${axisFormatter.format(details.anchor.x)} · Y ${axisFormatter.format(
+        details.anchor.y
+      )} · Z ${axisFormatter.format(details.anchor.z)}`,
+      'anchor'
+    );
+    this.appendDebugRow(
+      this.strings.debugModelTriangles,
+      integerFormatter.format(Math.max(0, Math.floor(details.modelTriangles))),
+      'triangles'
+    );
+    this.debugDetails.hidden = false;
+  }
+
+  private appendDebugRow(labelText: string, valueText: string, key: string) {
+    const term = document.createElement('dt');
+    term.className = 'poi-tooltip-overlay__debug-label';
+    term.textContent = labelText;
+    const detail = document.createElement('dd');
+    detail.className = 'poi-tooltip-overlay__debug-value';
+    detail.textContent = valueText;
+    if (key === 'anchor') {
+      detail.dataset.poiDebugAnchor = 'true';
+    } else if (key === 'triangles') {
+      detail.dataset.poiDebugTriangles = 'true';
+    }
+    this.debugDetails.append(term, detail);
   }
 
   private renderLinks(poi: PoiDefinition) {
@@ -533,6 +625,10 @@ function applyVisuallyHiddenStyles(element: HTMLElement): void {
   element.style.clipPath = 'inset(50%)';
   element.style.whiteSpace = 'nowrap';
   element.style.pointerEvents = 'none';
+}
+
+function defaultDebugDetailsProvider(poi: PoiDefinition): PoiDebugDetails {
+  return { anchor: poi.position, modelTriangles: 0 };
 }
 
 function defaultDiscoveryFormatter(

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -9,6 +9,16 @@ import {
 } from '../scene/graphics/qualityManager';
 
 describe('createGraphicsQualityManager', () => {
+  it('documents model detail in every preset description', () => {
+    expect(
+      GRAPHICS_QUALITY_PRESETS.every((preset) =>
+        /detail 3D models|3D model detail|detail 3D model/i.test(
+          preset.description
+        )
+      )
+    ).toBe(true);
+  });
+
   const baseBloom = {
     strength: 0.55,
     radius: 0.85,

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -29,6 +29,15 @@ import {
 } from '../assets/i18n';
 import { getPoiDefinitions } from '../scene/poi/registry';
 
+it('provides POI debug detail labels for every locale', () => {
+  for (const locale of AVAILABLE_LOCALES) {
+    const strings = getPoiOverlayChromeStrings(locale);
+    expect(strings.debugDetailsLabel.trim()).not.toBe('');
+    expect(strings.debugPoiAnchor.trim()).not.toBe('');
+    expect(strings.debugModelTriangles.trim()).not.toBe('');
+  }
+});
+
 describe('i18n utilities', () => {
   it('exposes available locales including pseudo locale scaffolding', () => {
     expect(AVAILABLE_LOCALES).toContain('en');

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -38,6 +38,18 @@ it('provides POI debug detail labels for every locale', () => {
   }
 });
 
+it('pseudo-localizes POI debug detail labels', () => {
+  const english = getPoiOverlayChromeStrings('en');
+  const pseudo = getPoiOverlayChromeStrings('en-x-pseudo');
+
+  expect(pseudo.debugDetailsLabel).not.toBe(english.debugDetailsLabel);
+  expect(pseudo.debugPoiAnchor).not.toBe(english.debugPoiAnchor);
+  expect(pseudo.debugModelTriangles).not.toBe(english.debugModelTriangles);
+  expect(pseudo.debugDetailsLabel).toMatch(/^⟦.*⟧$/);
+  expect(pseudo.debugPoiAnchor).toMatch(/^⟦.*⟧$/);
+  expect(pseudo.debugModelTriangles).toMatch(/^⟦.*⟧$/);
+});
+
 describe('i18n utilities', () => {
   it('exposes available locales including pseudo locale scaffolding', () => {
     expect(AVAILABLE_LOCALES).toContain('en');

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -85,6 +85,7 @@ function createMockPoi(definition: PoiDefinition): PoiInstance {
     visualMode: 'pedestal',
     visited: false,
     visitedStrength: 0,
+    modelRoots: [],
   } satisfies PoiInstance;
 }
 

--- a/src/tests/poiMarkers.test.ts
+++ b/src/tests/poiMarkers.test.ts
@@ -1,7 +1,10 @@
 import {
   Color,
   CylinderGeometry,
+  Mesh,
+  MeshBasicMaterial,
   MeshStandardMaterial,
+  PlaneGeometry,
   SphereGeometry,
 } from 'three';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -163,6 +166,35 @@ describe('createPoiInstances', () => {
 
     expect(instance.definition.title).toBe('⟦Gitshelves⟧');
     expect(fillTextLog.join(' ')).toBe('⟦Gitshelves⟧');
+  });
+
+  it('seeds display POI model roots from the highlighted model mesh', () => {
+    const hitArea = new Mesh(
+      new PlaneGeometry(2, 1),
+      new MeshBasicMaterial({ transparent: true, opacity: 0 })
+    );
+    const highlightMesh = new Mesh(
+      new PlaneGeometry(2, 1),
+      new MeshBasicMaterial()
+    );
+    const [instance] = createPoiInstances(
+      [createDefinition({ id: 'futuroptimist-living-room-tv' })],
+      {
+        'futuroptimist-living-room-tv': {
+          mode: 'display',
+          hitArea,
+          highlight: {
+            mesh: highlightMesh,
+            material: highlightMesh.material,
+            baseOpacity: 0.1,
+            focusOpacity: 0.55,
+          },
+        },
+      }
+    );
+
+    expect(instance.visualMode).toBe('display');
+    expect(instance.modelRoots).toEqual([highlightMesh]);
   });
 
   it('preserves existing title-only marker labels without ellipsizing them', () => {

--- a/src/tests/poiModelTriangles.test.ts
+++ b/src/tests/poiModelTriangles.test.ts
@@ -1,0 +1,88 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Group,
+  InstancedMesh,
+  Line,
+  Mesh,
+  MeshBasicMaterial,
+  Object3D,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { countPoiModelTriangles } from '../scene/poi/modelTriangles';
+
+const material = new MeshBasicMaterial();
+
+function nonIndexedGeometry(vertexCount: number): BufferGeometry {
+  const geometry = new BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new BufferAttribute(new Float32Array(vertexCount * 3), 3)
+  );
+  return geometry;
+}
+
+function indexedGeometry(indexCount: number): BufferGeometry {
+  const geometry = nonIndexedGeometry(indexCount);
+  geometry.setIndex(Array.from({ length: indexCount }, (_, index) => index));
+  return geometry;
+}
+
+describe('countPoiModelTriangles', () => {
+  it('counts indexed mesh triangles from index count', () => {
+    expect(
+      countPoiModelTriangles([new Mesh(indexedGeometry(6), material)])
+    ).toBe(2);
+  });
+
+  it('counts non-indexed mesh triangles from position count', () => {
+    expect(
+      countPoiModelTriangles([new Mesh(nonIndexedGeometry(9), material)])
+    ).toBe(3);
+  });
+
+  it('multiplies instanced mesh triangles by active instance count', () => {
+    const mesh = new InstancedMesh(indexedGeometry(6), material, 5);
+    mesh.count = 3;
+    expect(countPoiModelTriangles([mesh])).toBe(6);
+  });
+
+  it('skips hidden descendants', () => {
+    const group = new Group();
+    const visible = new Mesh(nonIndexedGeometry(3), material);
+    const hidden = new Mesh(nonIndexedGeometry(6), material);
+    hidden.visible = false;
+    group.add(visible, hidden);
+    expect(countPoiModelTriangles([group])).toBe(1);
+  });
+
+  it('ignores malformed geometry safely', () => {
+    expect(
+      countPoiModelTriangles([new Mesh(new BufferGeometry(), material)])
+    ).toBe(0);
+  });
+
+  it('counts separate meshes that share geometry', () => {
+    const geometry = nonIndexedGeometry(3);
+    const group = new Group();
+    group.add(new Mesh(geometry, material), new Mesh(geometry, material));
+    expect(countPoiModelTriangles([group])).toBe(2);
+  });
+
+  it('does not double-count overlapping registered roots', () => {
+    const group = new Group();
+    const mesh = new Mesh(nonIndexedGeometry(6), material);
+    group.add(mesh);
+    expect(countPoiModelTriangles([group, mesh])).toBe(2);
+  });
+
+  it('respects finite draw ranges and ignores non-mesh objects', () => {
+    const geometry = nonIndexedGeometry(12);
+    geometry.setDrawRange(3, 6);
+    const group = new Group();
+    group.add(new Line(nonIndexedGeometry(6), material), new Object3D());
+    group.add(new Mesh(geometry, material));
+    expect(countPoiModelTriangles([group])).toBe(2);
+  });
+});

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -188,6 +188,87 @@ describe('PoiTooltipOverlay', () => {
     expect(describedIds).toContain(linksList.id);
   });
 
+  it('hides debug details by default and keeps metrics unchanged', () => {
+    overlay.setHovered(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.querySelector('[data-poi-debug]')).toHaveProperty(
+      'hidden',
+      true
+    );
+    expect(root.querySelectorAll('.poi-tooltip-overlay__metric')).toHaveLength(
+      1
+    );
+    expect(root.getAttribute('aria-describedby')).not.toContain('debug');
+  });
+
+  it('toggles localized anchor and triangle debug details immediately', () => {
+    overlay.dispose();
+    overlay = new PoiTooltipOverlay({
+      container,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+      locale: 'en-US',
+      getDebugDetails: () => ({
+        anchor: { x: -8.735, y: 0, z: -22.924 },
+        modelTriangles: 1234,
+      }),
+    });
+    overlay.setStrings(getPoiOverlayChromeStrings('en'), 'en-US');
+    overlay.setHovered(basePoi);
+
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.querySelector('[data-poi-debug]')).toHaveProperty(
+      'hidden',
+      true
+    );
+
+    overlay.setDebugDetailsEnabled(true);
+
+    const debug = root.querySelector('[data-poi-debug]') as HTMLElement;
+    expect(debug.hidden).toBe(false);
+    expect(root.querySelector('[data-poi-debug-anchor]')?.textContent).toBe(
+      'X -8.74 · Y 0.00 · Z -22.92'
+    );
+    expect(root.querySelector('[data-poi-debug-triangles]')?.textContent).toBe(
+      '1,234'
+    );
+    expect(root.getAttribute('aria-describedby')?.split(' ')).toContain(
+      debug.id
+    );
+    expect(root.querySelectorAll('.poi-tooltip-overlay__metric')).toHaveLength(
+      1
+    );
+
+    overlay.setDebugDetailsEnabled(false);
+
+    expect(debug.hidden).toBe(true);
+    expect(root.getAttribute('aria-describedby')?.split(' ')).not.toContain(
+      debug.id
+    );
+  });
+
+  it('shows debug details for selected and recommended card states', () => {
+    overlay.setDebugDetailsEnabled(true);
+    overlay.setSelected(basePoi, { inputMethod: 'pointer' });
+    let root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('selected');
+    expect(root.querySelector('[data-poi-debug]')).toHaveProperty(
+      'hidden',
+      false
+    );
+
+    overlay.setSelected(null);
+    overlay.setRecommendation(basePoi);
+    overlay.setIdleState(true);
+    root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+    expect(root.dataset.state).toBe('recommended');
+    expect(root.querySelector('[data-poi-debug]')).toHaveProperty(
+      'hidden',
+      false
+    );
+  });
+
   it('renders selected POI metadata without a hover target', () => {
     overlay.setSelected(basePoi, { inputMethod: 'pointer' });
 
@@ -455,6 +536,9 @@ describe('PoiTooltipOverlay', () => {
       relatedCaseStudies: '⟦Related case studies⟧',
       outcomeFallbackLabel: '⟦Outcome⟧',
       discoveryAnnouncementTemplate: '⟦{title} discovered. {summary}⟧',
+      debugDetailsLabel: '⟦Debug details⟧',
+      debugPoiAnchor: '⟦POI anchor⟧',
+      debugModelTriangles: '⟦Model triangles⟧',
     });
     overlay.setSelected(localizedPoi);
 

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -204,6 +204,7 @@ describe('PoiTooltipOverlay', () => {
 
   it('toggles localized anchor and triangle debug details immediately', () => {
     overlay.dispose();
+    let modelTriangles = 1234;
     overlay = new PoiTooltipOverlay({
       container,
       interactionTimeline: timelineHarness.timeline,
@@ -211,7 +212,7 @@ describe('PoiTooltipOverlay', () => {
       locale: 'en-US',
       getDebugDetails: () => ({
         anchor: { x: -8.735, y: 0, z: -22.924 },
-        modelTriangles: 1234,
+        modelTriangles,
       }),
     });
     overlay.setStrings(getPoiOverlayChromeStrings('en'), 'en-US');
@@ -238,6 +239,12 @@ describe('PoiTooltipOverlay', () => {
     );
     expect(root.querySelectorAll('.poi-tooltip-overlay__metric')).toHaveLength(
       1
+    );
+
+    modelTriangles = 4321;
+    overlay.setHovered(basePoi);
+    expect(root.querySelector('[data-poi-debug-triangles]')?.textContent).toBe(
+      '4,321'
     );
 
     overlay.setDebugDetailsEnabled(false);

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2355,3 +2355,29 @@ html[data-hud-layout='mobile'] .performance-recovery-popup {
   width: min(18rem, calc(100vw - 1.5rem));
   padding: 0.7rem;
 }
+
+.poi-tooltip-overlay__debug {
+  margin: 0;
+  padding: 0.6rem 0 0;
+  border-top: 1px solid rgba(143, 214, 255, 0.18);
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.32rem 0.65rem;
+  color: rgba(188, 230, 255, 0.86);
+  font-size: 0.74rem;
+}
+
+.poi-tooltip-overlay__debug[hidden] {
+  display: none;
+}
+
+.poi-tooltip-overlay__debug-label {
+  margin: 0;
+  color: rgba(141, 217, 255, 0.92);
+  font-weight: 600;
+}
+
+.poi-tooltip-overlay__debug-value {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
### Motivation
- Surface POI model diagnostics (anchor and active model triangle count) behind the existing `Debug coordinates` setting so developers can inspect model placement and geometry detail without changing UX policies.
- Make graphics-quality preset copy explicit that presets change 3D model detail to reduce confusion about visual differences between levels.

### Description
- Register dedicated POI model roots by adding `modelRoots: Object3D[]` to `PoiInstance` and pushing structure groups in the central `addPoiStructure(...)` helper so only dedicated model geometry is counted (no Three.js objects on `PoiDefinition`).
- Add `countPoiModelTriangles(roots)` in `src/scene/poi/modelTriangles.ts` that traverses visible descendants and counts triangles for `Mesh` and `InstancedMesh` (indexed/non-indexed, respects draw ranges, multiplies instanced counts, avoids double-counting overlapping roots, ignores non-mesh and malformed geometry).
- Extend `PoiTooltipOverlay` to render a localized, accessible debug `<dl>` with stable selectors `data-poi-debug`, `data-poi-debug-anchor`, and `data-poi-debug-triangles`; expose `setDebugDetailsEnabled()` to force rerenders when the debug setting or locale changes; include the debug section in `aria-describedby` only while visible.
- Wire overlay to the existing `debugCoordinatesEnabled` control in `src/main.ts`, add i18n keys (`debugDetailsLabel`, `debugPoiAnchor`, `debugModelTriangles`), add compact styling, and update `GRAPHICS_QUALITY_PRESETS` descriptions to mention model detail.
- Add focused tests: `src/tests/poiModelTriangles.test.ts`, updates to `src/tests/poiTooltipOverlay.test.ts`, `src/tests/i18n.test.ts`, and a small graphics-quality assertion in `src/tests/graphicsQualityManager.test.ts`.

### Testing
- Unit tests: `npm run test:ci -- src/tests/poiModelTriangles.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/i18n.test.ts src/tests/graphicsQualityControl.test.ts src/tests/graphicsQualityManager.test.ts` — ran the five focused suites and they all passed (test runner output: all provided test files passed; total 87 tests passed in the run).
- Lint: `npm run lint` — completed successfully with 2 warnings (import/order) and no errors.
- Build: `npm run build` — succeeded and produced `dist/` artifacts.
- Formatting: `npm run format:write` then `npm run format:check` — formatting applied and check passed.
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.
- Typecheck: `npm run typecheck` — failed due to existing repository-wide TypeScript errors unrelated to these changes (first reported issues start at `src/main.ts(828)`, `src/scene/avatar/importer.ts(80)`, and multiple `src/scene/level/*`).

Notes: the implementation intentionally leaves the relocated Sugarkube POI unregistered (its legacy BackyardGreenhouse geometry remains unregistered), so its POI debug triangles report `0` until model deployment work in the follow-up task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b70a635d4832fa281c9229fe5f329)