### PR TITLE
🧭 : – add POI debug model diagnostics

### DIFF
--- a/src/assets/i18n/locales/ar.ts
+++ b/src/assets/i18n/locales/ar.ts
@@ -334,6 +334,9 @@ export const AR_OVERRIDES: LocaleOverrides = {
       closeDetails: 'إغلاق تفاصيل نقطة الاهتمام',
       relatedCaseStudies: 'دراسات حالة ذات صلة',
       outcomeFallbackLabel: 'النتيجة',
+      debugDetailsLabel: 'Debug details',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
       discoveryAnnouncementTemplate: 'تم اكتشاف {title}. {summary}',
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/en-x-pseudo.ts
+++ b/src/assets/i18n/locales/en-x-pseudo.ts
@@ -460,6 +460,9 @@ export const EN_X_PSEUDO_OVERRIDES: LocaleOverrides = {
       closeDetails: wrap('Close POI details'),
       relatedCaseStudies: wrap('Related case studies'),
       outcomeFallbackLabel: wrap('Outcome'),
+      debugDetailsLabel: 'Debug details',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
       discoveryAnnouncementTemplate: wrap('{title} discovered. {summary}'),
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/en.ts
+++ b/src/assets/i18n/locales/en.ts
@@ -464,6 +464,9 @@ export const EN_LOCALE_STRINGS: LocaleStrings = {
       relatedCaseStudies: 'Related case studies',
       outcomeFallbackLabel: 'Outcome',
       discoveryAnnouncementTemplate: '{title} discovered. {summary}',
+      debugDetailsLabel: 'Debug details',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
     },
     narrativeLog: {
       heading: 'Creator story log',

--- a/src/assets/i18n/locales/ja.ts
+++ b/src/assets/i18n/locales/ja.ts
@@ -334,6 +334,9 @@ export const JA_OVERRIDES: LocaleOverrides = {
       closeDetails: 'POI の詳細を閉じる',
       relatedCaseStudies: '関連ケーススタディ',
       outcomeFallbackLabel: '成果',
+      debugDetailsLabel: 'Debug details',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
       discoveryAnnouncementTemplate: '{title} を発見しました。{summary}',
     },
     narrativeLog: {

--- a/src/assets/i18n/locales/zh-Hans.ts
+++ b/src/assets/i18n/locales/zh-Hans.ts
@@ -362,6 +362,9 @@ export const ZH_HANS_OVERRIDES: LocaleOverrides = {
       closeDetails: '关闭兴趣点详情',
       relatedCaseStudies: '相关案例研究',
       outcomeFallbackLabel: '成果',
+      debugDetailsLabel: 'Debug details',
+      debugAnchorLabel: 'POI anchor',
+      debugTrianglesLabel: 'Model triangles',
       discoveryAnnouncementTemplate: '已发现 {title}。{summary}',
     },
     narrativeLog: {

--- a/src/assets/i18n/types.ts
+++ b/src/assets/i18n/types.ts
@@ -301,6 +301,9 @@ export interface PoiOverlayChromeStrings {
   relatedCaseStudies: string;
   outcomeFallbackLabel: string;
   discoveryAnnouncementTemplate: string;
+  debugDetailsLabel: string;
+  debugAnchorLabel: string;
+  debugTrianglesLabel: string;
 }
 
 export interface PoiNarrativeLogStrings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,6 +240,7 @@ import {
   type PoiInstance,
   type PoiInstanceOverrides,
 } from './scene/poi/markers';
+import { countRenderedPoiModelTriangles } from './scene/poi/modelTriangles';
 import { getPoiInteractionAnchorPosition } from './scene/poi/placements';
 import { getPoiDefinitions } from './scene/poi/registry';
 import {
@@ -2512,6 +2513,11 @@ function initializeImmersiveScene(
     (layoutOverride ?? hudLayoutManager?.getLayout()) === 'mobile';
   const poiTooltipOverlay = new PoiTooltipOverlay({
     container,
+    getModelTriangleCount: (poi) =>
+      countRenderedPoiModelTriangles(
+        poiInstances.find((instance) => instance.definition.id === poi.id)
+          ?.modelRoots ?? []
+      ),
     interactionTimeline,
     guidedTourPreference,
     discoveryAnnouncer: {
@@ -2526,6 +2532,7 @@ function initializeImmersiveScene(
     },
   });
   poiTooltipOverlay.setStrings(poiOverlayStrings);
+  poiTooltipOverlay.setDebugDetailsEnabled(debugCoordinatesEnabled);
   const poiWorldTooltip = new PoiWorldTooltip({
     parent: scene,
     camera,
@@ -2893,6 +2900,7 @@ function initializeImmersiveScene(
   );
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
   const addPoiStructure = (poi: PoiInstance, group: Object3D) => {
+    poi.modelRoots.push(group);
     (getPoiFloorId(poi.definition) === 'upper'
       ? upperStructureGroup
       : groundStructureGroup
@@ -2930,7 +2938,11 @@ function initializeImmersiveScene(
     } else {
       showpiece.colliders.forEach((collider) => groundColliders.push(collider));
     }
-    groundStructureGroup.add(showpiece.group);
+    if (flywheelPoi) {
+      addPoiStructure(flywheelPoi, showpiece.group);
+    } else {
+      groundStructureGroup.add(showpiece.group);
+    }
     flywheelShowpiece = showpiece;
 
     const terminalOrientation = jobbotPoi?.group.rotation.y ?? -Math.PI / 2;
@@ -4226,6 +4238,7 @@ function initializeImmersiveScene(
     tourGuideToggleControl?.setStrings(tourGuideToggleStrings);
     tourResetControl?.setStrings(tourResetControlStrings);
     poiTooltipOverlay.setStrings(poiOverlayStrings);
+    poiTooltipOverlay.setDebugDetailsEnabled(debugCoordinatesEnabled);
     updateHelpButtonLabel();
     localeToggleControl?.refresh();
     syncPoiRecommendation();
@@ -4936,6 +4949,7 @@ function initializeImmersiveScene(
     options: { persist?: boolean } = { persist: true }
   ) => {
     debugCoordinatesEnabled = enabled;
+    poiTooltipOverlay.setDebugDetailsEnabled(enabled);
     syncDebugCoordinatesOverlayVisibility();
     refreshDebugCoordinatesControl();
     if (enabled) {

--- a/src/scene/graphics/qualityManager.ts
+++ b/src/scene/graphics/qualityManager.ts
@@ -23,7 +23,8 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
     {
       id: 'cinematic',
       label: 'Cinematic',
-      description: 'Full post-processing with cinematic bloom and lighting.',
+      description:
+        'Full post-processing, highest-detail 3D models, cinematic bloom and lighting.',
       pixelRatioScale: 1,
       exposure: 1.1,
       bloom: {
@@ -41,7 +42,7 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
       id: 'balanced',
       label: 'Balanced',
       description:
-        'Moderate bloom with slightly reduced resolution for laptops.',
+        'Moderate bloom, reduced resolution, and medium-detail 3D models for laptops.',
       pixelRatioScale: 0.85,
       exposure: 1.02,
       bloom: {
@@ -58,7 +59,8 @@ export const GRAPHICS_QUALITY_PRESETS: readonly GraphicsQualityPresetDefinition[
     {
       id: 'performance',
       label: 'Performance',
-      description: 'Disables bloom and lowers resolution to prioritize FPS.',
+      description:
+        'Disables bloom, lowers resolution, and uses lowest-detail 3D models to prioritize FPS.',
       pixelRatioScale: 0.7,
       exposure: 0.96,
       bloom: {

--- a/src/scene/poi/markers.ts
+++ b/src/scene/poi/markers.ts
@@ -87,6 +87,7 @@ export interface PoiInstance {
     material: MeshBasicMaterial;
   };
   visitedBadge?: PoiVisitedBadge;
+  modelRoots: Object3D[];
 }
 
 export function createPoiInstances(
@@ -420,6 +421,7 @@ function createPedestalPoiInstance(
     visitedStrength: 0,
     visitedHighlight: { mesh: visitedRing, material: visitedRingMaterial },
     visitedBadge,
+    modelRoots: [],
   };
 }
 
@@ -483,6 +485,7 @@ function createDisplayPoiInstance(
     displayHighlight: override.highlight,
     visited: false,
     visitedStrength: 0,
+    modelRoots: [],
   };
 }
 

--- a/src/scene/poi/modelTriangles.ts
+++ b/src/scene/poi/modelTriangles.ts
@@ -1,0 +1,65 @@
+import { BufferGeometry, InstancedMesh, Mesh, Object3D } from 'three';
+
+const getFiniteNonnegativeInteger = (value: number): number =>
+  Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+
+function countGeometryTriangles(geometry: BufferGeometry): number {
+  const drawRangeStart = getFiniteNonnegativeInteger(geometry.drawRange.start);
+  const rawDrawRangeCount = geometry.drawRange.count;
+  const hasFiniteDrawRange = Number.isFinite(rawDrawRangeCount);
+  const drawRangeCount = hasFiniteDrawRange
+    ? getFiniteNonnegativeInteger(rawDrawRangeCount)
+    : Infinity;
+
+  if (geometry.index) {
+    const indexCount = getFiniteNonnegativeInteger(geometry.index.count);
+    const effectiveCount = Math.max(
+      0,
+      Math.min(indexCount, drawRangeStart + drawRangeCount) - drawRangeStart
+    );
+    return Math.floor(effectiveCount / 3);
+  }
+
+  const positionCount = getFiniteNonnegativeInteger(
+    geometry.getAttribute('position')?.count ?? 0
+  );
+  const effectiveCount = Math.max(
+    0,
+    Math.min(positionCount, drawRangeStart + drawRangeCount) - drawRangeStart
+  );
+  return Math.floor(effectiveCount / 3);
+}
+
+export function countRenderedPoiModelTriangles(
+  roots: readonly Object3D[]
+): number {
+  const visited = new Set<Object3D>();
+  let triangles = 0;
+
+  for (const root of roots) {
+    root.traverseVisible((object) => {
+      if (visited.has(object)) {
+        return;
+      }
+      visited.add(object);
+
+      if (!(object instanceof Mesh)) {
+        return;
+      }
+
+      const geometry = object.geometry;
+      if (!(geometry instanceof BufferGeometry)) {
+        return;
+      }
+
+      const geometryTriangles = countGeometryTriangles(geometry);
+      const instanceCount =
+        object instanceof InstancedMesh
+          ? getFiniteNonnegativeInteger(object.count)
+          : 1;
+      triangles += geometryTriangles * instanceCount;
+    });
+  }
+
+  return getFiniteNonnegativeInteger(triangles);
+}

--- a/src/scene/poi/tooltipOverlay.ts
+++ b/src/scene/poi/tooltipOverlay.ts
@@ -26,6 +26,7 @@ export interface PoiTooltipOverlayOptions {
   };
   interactionTimeline?: InteractionTimeline;
   guidedTourPreference?: GuidedTourPreference;
+  getModelTriangleCount?: (poi: PoiDefinition) => number;
 }
 
 interface RenderState {
@@ -54,6 +55,9 @@ export class PoiTooltipOverlay {
   private readonly outcomeValue: HTMLSpanElement;
   private readonly metricsList: HTMLUListElement;
   private readonly linksList: HTMLUListElement;
+  private readonly debugDetails: HTMLDListElement;
+  private readonly debugAnchorValue: HTMLElement;
+  private readonly debugTrianglesValue: HTMLElement;
   private readonly statusBadge: HTMLSpanElement;
   private readonly visitedBadge: HTMLSpanElement;
   private readonly recommendationBadge: HTMLSpanElement;
@@ -81,6 +85,8 @@ export class PoiTooltipOverlay {
   private focusOnNextUpdate = false;
   private readonly onDismiss: (() => void) | null;
   private strings: PoiOverlayChromeStrings;
+  private debugDetailsEnabled = false;
+  private readonly getModelTriangleCount: (poi: PoiDefinition) => number;
 
   constructor(options: PoiTooltipOverlayOptions) {
     const {
@@ -89,6 +95,7 @@ export class PoiTooltipOverlay {
       discoveryAnnouncer,
       interactionTimeline,
       guidedTourPreference = defaultGuidedTourPreference,
+      getModelTriangleCount,
     } = options;
     const documentTarget = container.ownerDocument ?? document;
 
@@ -99,6 +106,7 @@ export class PoiTooltipOverlay {
     this.interactionTimeline = interactionTimeline ?? null;
     this.guidedTourPreference = guidedTourPreference;
     this.onDismiss = onDismiss ?? null;
+    this.getModelTriangleCount = getModelTriangleCount ?? (() => 0);
     this.instanceId = generateTooltipInstanceId();
 
     this.root = documentTarget.createElement('section');
@@ -182,6 +190,31 @@ export class PoiTooltipOverlay {
     this.linksList.setAttribute('aria-label', this.strings.relatedCaseStudies);
     this.root.appendChild(this.linksList);
 
+    this.debugDetails = documentTarget.createElement('dl');
+    this.debugDetails.className = 'poi-tooltip-overlay__debug';
+    this.debugDetails.id = `${this.instanceId}-debug`;
+    this.debugDetails.dataset.poiDebug = '';
+    this.debugDetails.hidden = true;
+    this.debugDetails.setAttribute(
+      'aria-label',
+      this.strings.debugDetailsLabel
+    );
+    this.root.appendChild(this.debugDetails);
+
+    const anchorTerm = documentTarget.createElement('dt');
+    anchorTerm.textContent = this.strings.debugAnchorLabel;
+    this.debugDetails.appendChild(anchorTerm);
+    this.debugAnchorValue = documentTarget.createElement('dd');
+    this.debugAnchorValue.dataset.poiDebugAnchor = '';
+    this.debugDetails.appendChild(this.debugAnchorValue);
+
+    const trianglesTerm = documentTarget.createElement('dt');
+    trianglesTerm.textContent = this.strings.debugTrianglesLabel;
+    this.debugDetails.appendChild(trianglesTerm);
+    this.debugTrianglesValue = documentTarget.createElement('dd');
+    this.debugTrianglesValue.dataset.poiDebugTriangles = '';
+    this.debugDetails.appendChild(this.debugTrianglesValue);
+
     container.appendChild(this.root);
 
     this.liveRegion = documentTarget.createElement('div');
@@ -209,6 +242,16 @@ export class PoiTooltipOverlay {
     this.recommendationBadge.textContent = strings.nextHighlight;
     this.closeButton.setAttribute('aria-label', strings.closeDetails);
     this.linksList.setAttribute('aria-label', strings.relatedCaseStudies);
+    this.debugDetails.setAttribute('aria-label', strings.debugDetailsLabel);
+    this.renderState = { poiId: null, poiRef: null, contentKey: null };
+    this.update();
+  }
+
+  setDebugDetailsEnabled(enabled: boolean): void {
+    if (this.debugDetailsEnabled === enabled) {
+      return;
+    }
+    this.debugDetailsEnabled = enabled;
     this.renderState = { poiId: null, poiRef: null, contentKey: null };
     this.update();
   }
@@ -358,6 +401,9 @@ export class PoiTooltipOverlay {
     if (!this.linksList.hidden) {
       describedByIds.push(this.linksList.id);
     }
+    if (!this.debugDetails.hidden) {
+      describedByIds.push(this.debugDetails.id);
+    }
     if (describedByIds.length > 0) {
       this.root.setAttribute('aria-describedby', describedByIds.join(' '));
     } else {
@@ -414,6 +460,7 @@ export class PoiTooltipOverlay {
     this.renderOutcome(poi);
     this.renderMetrics(poi);
     this.renderLinks(poi);
+    this.renderDebugDetails(poi);
   }
 
   private renderOutcome(poi: PoiDefinition) {
@@ -496,6 +543,30 @@ export class PoiTooltipOverlay {
       item.appendChild(anchor);
       this.linksList.appendChild(item);
     }
+  }
+
+  private renderDebugDetails(poi: PoiDefinition) {
+    if (!this.debugDetailsEnabled) {
+      this.debugDetails.hidden = true;
+      this.debugAnchorValue.textContent = '';
+      this.debugTrianglesValue.textContent = '';
+      return;
+    }
+
+    const locale = this.root.ownerDocument?.documentElement.lang || undefined;
+    const decimalFormatter = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    const integerFormatter = new Intl.NumberFormat(locale, {
+      maximumFractionDigits: 0,
+    });
+    const { x, y, z } = poi.position;
+    this.debugAnchorValue.textContent = `X ${decimalFormatter.format(x)} · Y ${decimalFormatter.format(y)} · Z ${decimalFormatter.format(z)}`;
+    this.debugTrianglesValue.textContent = integerFormatter.format(
+      this.getModelTriangleCount(poi)
+    );
+    this.debugDetails.hidden = false;
   }
 
   private announceDiscovery(poi: PoiDefinition) {

--- a/src/tests/graphicsQualityControl.test.ts
+++ b/src/tests/graphicsQualityControl.test.ts
@@ -112,3 +112,10 @@ describe('createGraphicsQualityControl', () => {
     ).toThrow(/requires at least one preset/i);
   });
 });
+
+it('mentions 3D model detail in every graphics quality description', () => {
+  for (const preset of GRAPHICS_QUALITY_PRESETS) {
+    expect(preset.description).toMatch(/3D models/);
+    expect(preset.description).toMatch(/detail/i);
+  }
+});

--- a/src/tests/graphicsQualityManager.test.ts
+++ b/src/tests/graphicsQualityManager.test.ts
@@ -232,3 +232,10 @@ describe('createGraphicsQualityManager', () => {
     expect(ids).toEqual(['cinematic', 'balanced', 'performance']);
   });
 });
+
+it('mentions 3D model detail in every graphics quality description', () => {
+  for (const preset of GRAPHICS_QUALITY_PRESETS) {
+    expect(preset.description).toMatch(/3D models/);
+    expect(preset.description).toMatch(/detail/i);
+  }
+});

--- a/src/tests/poiInteractionManager.test.ts
+++ b/src/tests/poiInteractionManager.test.ts
@@ -85,6 +85,7 @@ function createMockPoi(definition: PoiDefinition): PoiInstance {
     visualMode: 'pedestal',
     visited: false,
     visitedStrength: 0,
+    modelRoots: [],
   } satisfies PoiInstance;
 }
 

--- a/src/tests/poiModelTriangles.test.ts
+++ b/src/tests/poiModelTriangles.test.ts
@@ -1,0 +1,100 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Group,
+  InstancedMesh,
+  Line,
+  LineBasicMaterial,
+  Mesh,
+  MeshBasicMaterial,
+  Object3D,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { countRenderedPoiModelTriangles } from '../scene/poi/modelTriangles';
+
+const material = new MeshBasicMaterial();
+
+function nonIndexedGeometry(vertexCount: number): BufferGeometry {
+  const geometry = new BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new BufferAttribute(new Float32Array(vertexCount * 3), 3)
+  );
+  return geometry;
+}
+
+function indexedGeometry(indexCount: number): BufferGeometry {
+  const geometry = nonIndexedGeometry(indexCount);
+  geometry.setIndex(Array.from({ length: indexCount }, (_, index) => index));
+  return geometry;
+}
+
+describe('countRenderedPoiModelTriangles', () => {
+  it('counts indexed mesh geometry from effective index counts', () => {
+    expect(
+      countRenderedPoiModelTriangles([new Mesh(indexedGeometry(6), material)])
+    ).toBe(2);
+  });
+
+  it('counts non-indexed mesh geometry from position attributes', () => {
+    expect(
+      countRenderedPoiModelTriangles([
+        new Mesh(nonIndexedGeometry(9), material),
+      ])
+    ).toBe(3);
+  });
+
+  it('respects finite draw ranges', () => {
+    const geometry = indexedGeometry(12);
+    geometry.setDrawRange(3, 6);
+
+    expect(countRenderedPoiModelTriangles([new Mesh(geometry, material)])).toBe(
+      2
+    );
+  });
+
+  it('multiplies instanced mesh geometry by the active instance count', () => {
+    const mesh = new InstancedMesh(indexedGeometry(6), material, 5);
+    mesh.count = 4;
+
+    expect(countRenderedPoiModelTriangles([mesh])).toBe(8);
+  });
+
+  it('ignores hidden descendants and non-mesh renderables', () => {
+    const root = new Group();
+    const hidden = new Mesh(indexedGeometry(6), material);
+    hidden.visible = false;
+    root.add(hidden);
+    root.add(new Line(nonIndexedGeometry(6), new LineBasicMaterial()));
+
+    expect(countRenderedPoiModelTriangles([root])).toBe(0);
+  });
+
+  it('handles malformed geometry safely', () => {
+    expect(
+      countRenderedPoiModelTriangles([new Mesh(new BufferGeometry(), material)])
+    ).toBe(0);
+  });
+
+  it('counts separate meshes that share the same geometry', () => {
+    const geometry = indexedGeometry(6);
+
+    expect(
+      countRenderedPoiModelTriangles([
+        new Mesh(geometry, material),
+        new Mesh(geometry, material),
+      ])
+    ).toBe(4);
+  });
+
+  it('does not double-count the same object through overlapping roots', () => {
+    const parent = new Group();
+    const childRoot = new Object3D();
+    const mesh = new Mesh(indexedGeometry(6), material);
+    childRoot.add(mesh);
+    parent.add(childRoot);
+
+    expect(countRenderedPoiModelTriangles([parent, childRoot])).toBe(2);
+  });
+});

--- a/src/tests/poiTooltipOverlay.test.ts
+++ b/src/tests/poiTooltipOverlay.test.ts
@@ -188,6 +188,67 @@ describe('PoiTooltipOverlay', () => {
     expect(describedIds).toContain(linksList.id);
   });
 
+  it('hides debug details by default', () => {
+    overlay.setSelected(basePoi);
+
+    const debug = container.querySelector<HTMLElement>('[data-poi-debug]');
+    const root = container.querySelector('.poi-tooltip-overlay') as HTMLElement;
+
+    expect(debug?.hidden).toBe(true);
+    expect(root.getAttribute('aria-describedby')).not.toContain('debug');
+  });
+
+  it('shows localized anchor and model triangles when debug details are enabled', () => {
+    overlay.dispose();
+    overlay = new PoiTooltipOverlay({
+      container,
+      interactionTimeline: timelineHarness.timeline,
+      guidedTourPreference: preference,
+      getModelTriangleCount: () => 12345,
+    });
+    const poi: PoiDefinition = {
+      ...basePoi,
+      position: { x: -8.74, y: 0, z: -22.92 },
+    };
+
+    overlay.setDebugDetailsEnabled(true);
+    overlay.setSelected(poi);
+
+    expect(container.querySelector('[data-poi-debug]')?.textContent).toContain(
+      'POI anchor'
+    );
+    expect(
+      container.querySelector('[data-poi-debug-anchor]')?.textContent
+    ).toBe('X -8.74 · Y 0.00 · Z -22.92');
+    expect(
+      container.querySelector('[data-poi-debug-triangles]')?.textContent
+    ).toBe('12,345');
+    expect(
+      (
+        container.querySelector('.poi-tooltip-overlay') as HTMLElement
+      ).getAttribute('aria-describedby')
+    ).toContain('debug');
+  });
+
+  it('removes debug details immediately without changing normal metrics', () => {
+    overlay.setDebugDetailsEnabled(true);
+    overlay.setSelected(basePoi);
+
+    overlay.setDebugDetailsEnabled(false);
+
+    expect(
+      container.querySelector<HTMLElement>('[data-poi-debug]')?.hidden
+    ).toBe(true);
+    expect(
+      container.querySelectorAll('.poi-tooltip-overlay__metric')
+    ).toHaveLength(basePoi.metrics?.length ?? 0);
+    expect(
+      (
+        container.querySelector('.poi-tooltip-overlay') as HTMLElement
+      ).getAttribute('aria-describedby')
+    ).not.toContain('debug');
+  });
+
   it('renders selected POI metadata without a hover target', () => {
     overlay.setSelected(basePoi, { inputMethod: 'pointer' });
 
@@ -455,6 +516,9 @@ describe('PoiTooltipOverlay', () => {
       relatedCaseStudies: '⟦Related case studies⟧',
       outcomeFallbackLabel: '⟦Outcome⟧',
       discoveryAnnouncementTemplate: '⟦{title} discovered. {summary}⟧',
+      debugDetailsLabel: '⟦Debug details⟧',
+      debugAnchorLabel: '⟦POI anchor⟧',
+      debugTrianglesLabel: '⟦Model triangles⟧',
     });
     overlay.setSelected(localizedPoi);
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2355,3 +2355,28 @@ html[data-hud-layout='mobile'] .performance-recovery-popup {
   width: min(18rem, calc(100vw - 1.5rem));
   padding: 0.7rem;
 }
+
+.poi-tooltip-overlay__debug {
+  border-top: 1px solid rgb(148 215 255 / 28%);
+  display: grid;
+  gap: 0.25rem 0.75rem;
+  grid-template-columns: max-content 1fr;
+  margin: 0.65rem 0 0;
+  padding-top: 0.55rem;
+  font-size: 0.72rem;
+  color: rgb(211 235 255 / 82%);
+}
+
+.poi-tooltip-overlay__debug[hidden] {
+  display: none;
+}
+
+.poi-tooltip-overlay__debug dt {
+  font-weight: 700;
+  color: rgb(232 246 255 / 92%);
+}
+
+.poi-tooltip-overlay__debug dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
### Motivation
- Surface optional, per-POI model diagnostics when the existing Debug coordinates toggle is enabled so operators can inspect POI anchors and active model triangle counts.
- Make graphics-quality preset descriptions explicit that model detail changes across presets.

### Description
- Track runtime model roots on each `PoiInstance` via a new `modelRoots: Object3D[]` field and register dedicated roots through the existing `addPoiStructure(...)` helper so only unambiguous POI structures are counted.
- Add `countRenderedPoiModelTriangles(roots: Object3D[])` utility that traverses visible descendants, handles indexed/non-indexed geometry, respects draw range and `InstancedMesh` counts, avoids double-counting overlapping roots, and safely ignores non-mesh/malformed geometry.
- Add a semantic, localized debug `<dl>` to the POI overlay (hidden by default) which shows the POI anchor formatted to two locale-aware decimals and the localized integer triangle count, with stable selectors `data-poi-debug`, `data-poi-debug-anchor`, and `data-poi-debug-triangles`, and included in `aria-describedby` only while visible.
- Wire `PoiTooltipOverlay` to accept a `getModelTriangleCount` callback and a `setDebugDetailsEnabled()` method so the existing `debugCoordinatesEnabled` setting is reused and toggles overlay content immediately; locale string updates also refresh the debug copy.
- Add i18n keys (`debugDetailsLabel`, `debugAnchorLabel`, `debugTrianglesLabel`) and English/local override entries, update graphics-quality preset descriptions to mention 3D model detail, and add focused unit tests for triangle counting and tooltip debug behavior.

### Testing
- `npm run typecheck` — reported pre-existing, repo-wide TypeScript errors unrelated to this change (not caused by these edits); this repository has known type issues outside the scope of this PR.
- `npm run format:write` — succeeded and files were formatted.
- `npm run lint` — succeeded (ESLint reported a fixable import ordering warning that was addressed during the rollout).
- `npm run test:ci -- src/tests/poiModelTriangles.test.ts src/tests/poiTooltipOverlay.test.ts src/tests/i18n.test.ts src/tests/graphicsQualityControl.test.ts src/tests/graphicsQualityManager.test.ts` — all selected test files passed (added tests cover indexed, non-indexed, instanced, hidden/malformed/shared-geometry, and overlapping-root cases; POI overlay tests verify visibility, formatting, metrics preservation, and accessibility relationship).
- `npm run build` — succeeded and produced a dist bundle; smoke checks passed.
- `npm run format:check` and `npm run docs:check` — both succeeded (link checker emitted network warnings for external links but the docs check passed).

If you want, I can split follow-ups (e.g., register other structure groups where appropriate, or add the Sugarkube model changes from Prompt 2) into separate PRs to keep scope minimal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b70acd6f8832f8ebd8cff882bad6e)