### PR TITLE
Build Sugarkube deployment POI

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -303,6 +303,10 @@ import {
   type StaircaseConfig,
 } from './scene/structures/staircase';
 import {
+  createSugarkubeDeployment,
+  type SugarkubeDeploymentBuild,
+} from './scene/structures/sugarkubeDeployment';
+import {
   createTokenPlaceRack,
   type TokenPlaceRackBuild,
 } from './scene/structures/tokenPlaceRack';
@@ -1066,6 +1070,7 @@ let woveLoom: WoveLoomBuild | null = null;
 let jobbotTerminal: JobbotTerminalBuild | null = null;
 let axelNavigator: AxelNavigatorBuild | null = null;
 let tokenPlaceRack: TokenPlaceRackBuild | null = null;
+let sugarkubeDeployment: SugarkubeDeploymentBuild | null = null;
 let prReaperConsole: PrReaperConsoleBuild | null = null;
 let gabrielSentry: GabrielSentryBuild | null = null;
 let gitshelvesInstallation: GitshelvesInstallationBuild | null = null;
@@ -2891,6 +2896,9 @@ function initializeImmersiveScene(
   const prReaperPoi = poiInstances.find(
     (poi) => poi.definition.id === 'pr-reaper-backyard-console'
   );
+  const sugarkubePoi = poiInstances.find(
+    (poi) => poi.definition.id === 'sugarkube-backyard-greenhouse'
+  );
   const studioRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'studio');
   const addPoiStructure = (poi: PoiInstance, group: Object3D) => {
     (getPoiFloorId(poi.definition) === 'upper'
@@ -3062,6 +3070,36 @@ function initializeImmersiveScene(
     }
     addPoiStructure(prReaperPoi, console.group);
     prReaperConsole = console;
+  }
+
+  if (sugarkubePoi && livingRoom) {
+    const wallInset = 0.06;
+    const cornerClearance = 1.2;
+    const outletX = MathUtils.clamp(
+      sugarkubePoi.group.position.x,
+      livingRoom.bounds.minX + cornerClearance,
+      livingRoom.bounds.maxX - cornerClearance
+    );
+    const deployment = createSugarkubeDeployment({
+      position: {
+        x: sugarkubePoi.group.position.x,
+        y: sugarkubePoi.group.position.y,
+        z: sugarkubePoi.group.position.z,
+      },
+      orientationRadians: sugarkubePoi.group.rotation.y ?? 0,
+      detailPolicy: activeSceneDetailPolicy,
+      wallEndpoint: {
+        x: outletX,
+        y: sugarkubePoi.group.position.y,
+        z: livingRoom.bounds.minZ + wallInset,
+        orientationRadians: 0,
+      },
+    });
+    addPoiStructure(sugarkubePoi, deployment.group);
+    deployment.colliders.forEach((collider) =>
+      getPoiColliderTarget(sugarkubePoi).push(collider)
+    );
+    sugarkubeDeployment = deployment;
   }
 
   if (gitshelvesPoi) {
@@ -6698,6 +6736,7 @@ function initializeImmersiveScene(
     jobbotTerminal = null;
     axelNavigator = null;
     tokenPlaceRack = null;
+    sugarkubeDeployment = null;
     prReaperConsole = null;
     gabrielSentry = null;
     gitshelvesInstallation = null;
@@ -6920,6 +6959,23 @@ function initializeImmersiveScene(
           delta,
           emphasis: Math.max(activation, focus),
         });
+      }
+      if (sugarkubeDeployment) {
+        const activation = sugarkubePoi?.activation ?? 0;
+        const focus = sugarkubePoi?.focus ?? 0;
+        if (
+          sceneDetailController.shouldRunDecorativeUpdate(
+            elapsedTime,
+            Math.max(activation, focus),
+            'sugarkube'
+          )
+        ) {
+          sugarkubeDeployment.update({
+            elapsed: elapsedTime,
+            delta,
+            emphasis: Math.max(activation, focus),
+          });
+        }
       }
       if (gabrielSentry) {
         const activation = gabrielPoi?.activation ?? 0;

--- a/src/scene/graphics/triangleCount.ts
+++ b/src/scene/graphics/triangleCount.ts
@@ -1,0 +1,19 @@
+import type { BufferGeometry, Object3D } from 'three';
+import { InstancedMesh, Mesh } from 'three';
+
+function countGeometryTriangles(geometry: BufferGeometry): number {
+  if (geometry.index) return geometry.index.count / 3;
+  const position = geometry.getAttribute('position');
+  return position ? position.count / 3 : 0;
+}
+
+export function countObjectTriangles(root: Object3D): number {
+  let triangles = 0;
+  root.traverse((object) => {
+    if (object instanceof Mesh && object.visible) {
+      const instanceCount = object instanceof InstancedMesh ? object.count : 1;
+      triangles += countGeometryTriangles(object.geometry) * instanceCount;
+    }
+  });
+  return Math.round(triangles);
+}

--- a/src/scene/structures/sugarkubeDeployment.ts
+++ b/src/scene/structures/sugarkubeDeployment.ts
@@ -1,0 +1,504 @@
+import {
+  BoxGeometry,
+  CatmullRomCurve3,
+  Color,
+  CylinderGeometry,
+  Group,
+  MathUtils,
+  Mesh,
+  MeshStandardMaterial,
+  Object3D,
+  TubeGeometry,
+  Vector3,
+} from 'three';
+
+import type { RectCollider } from '../collision';
+import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
+
+export interface SugarkubeWallEndpoint {
+  x: number;
+  y?: number;
+  z: number;
+  orientationRadians?: number;
+}
+
+export interface SugarkubeDeploymentOptions {
+  position: { x: number; y?: number; z: number };
+  orientationRadians?: number;
+  detailPolicy?: SceneDetailPolicy;
+  wallEndpoint: SugarkubeWallEndpoint;
+}
+
+export interface SugarkubeDeploymentBuild {
+  group: Group;
+  colliders: RectCollider[];
+  update(context: { elapsed: number; delta: number; emphasis: number }): void;
+}
+
+interface DetailSpec {
+  cableRadialSegments: number;
+  cableTubularSegments: number;
+  cylinderSegments: number;
+  sphereSegments: number;
+  richPiDetails: boolean;
+  trayRibs: number;
+}
+
+const TABLE_WIDTH = 2.8;
+const TABLE_DEPTH = 2.08;
+const TABLE_HEIGHT = 0.86;
+const TABLE_TOP_THICKNESS = 0.16;
+const SWITCH_WIDTH = 1.55;
+const SWITCH_DEPTH = 0.76;
+const SWITCH_HEIGHT = 0.18;
+const RACK_WIDTH = 1.28;
+const RACK_DEPTH = 0.7;
+const RACK_TIER_GAP = 0.34;
+const RACK_BASE_Y = TABLE_HEIGHT + SWITCH_HEIGHT + 0.08;
+const PI_WIDTH = 0.32;
+const PI_DEPTH = 0.48;
+
+const detailSpecs: Record<SceneDetailPolicy['level'], DetailSpec> = {
+  cinematic: {
+    cableRadialSegments: 10,
+    cableTubularSegments: 24,
+    cylinderSegments: 18,
+    sphereSegments: 12,
+    richPiDetails: true,
+    trayRibs: 4,
+  },
+  balanced: {
+    cableRadialSegments: 6,
+    cableTubularSegments: 12,
+    cylinderSegments: 10,
+    sphereSegments: 8,
+    richPiDetails: false,
+    trayRibs: 2,
+  },
+  performance: {
+    cableRadialSegments: 4,
+    cableTubularSegments: 5,
+    cylinderSegments: 5,
+    sphereSegments: 4,
+    richPiDetails: false,
+    trayRibs: 0,
+  },
+};
+
+function createRotatedCollider(
+  center: Vector3,
+  width: number,
+  depth: number,
+  rotation: number,
+  debugName: string
+): RectCollider {
+  const halfWidth = width / 2;
+  const halfDepth = depth / 2;
+  const cos = Math.cos(rotation);
+  const sin = Math.sin(rotation);
+  const corners = [
+    new Vector3(-halfWidth, 0, -halfDepth),
+    new Vector3(halfWidth, 0, -halfDepth),
+    new Vector3(halfWidth, 0, halfDepth),
+    new Vector3(-halfWidth, 0, halfDepth),
+  ];
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+  corners.forEach((corner) => {
+    const x = center.x + corner.x * cos - corner.z * sin;
+    const z = center.z + corner.x * sin + corner.z * cos;
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minZ = Math.min(minZ, z);
+    maxZ = Math.max(maxZ, z);
+  });
+  return { minX, maxX, minZ, maxZ, debugName } as RectCollider;
+}
+
+function addBox(
+  parent: Object3D,
+  name: string,
+  size: [number, number, number],
+  position: [number, number, number],
+  material: MeshStandardMaterial
+): Mesh {
+  const mesh = new Mesh(new BoxGeometry(...size), material);
+  mesh.name = name;
+  mesh.position.set(...position);
+  parent.add(mesh);
+  return mesh;
+}
+
+function addCable(
+  parent: Object3D,
+  name: string,
+  points: Vector3[],
+  spec: DetailSpec,
+  material: MeshStandardMaterial,
+  radius = 0.022
+): Mesh {
+  const curve = new CatmullRomCurve3(points, false, 'centripetal');
+  const cable = new Mesh(
+    new TubeGeometry(
+      curve,
+      spec.cableTubularSegments,
+      radius,
+      spec.cableRadialSegments,
+      false
+    ),
+    material
+  );
+  cable.name = name;
+  parent.add(cable);
+  return cable;
+}
+
+export function createSugarkubeDeployment(
+  options: SugarkubeDeploymentOptions
+): SugarkubeDeploymentBuild {
+  const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
+  const spec = detailSpecs[detailPolicy.level];
+  const position = new Vector3(
+    options.position.x,
+    options.position.y ?? 0,
+    options.position.z
+  );
+  const orientationRadians = options.orientationRadians ?? 0;
+  const group = new Group();
+  group.name = 'SugarkubeDeployment';
+  group.position.copy(position);
+  group.rotation.y = orientationRadians;
+
+  const wood = new MeshStandardMaterial({
+    color: new Color(0x6b3f22),
+    roughness: 0.68,
+  });
+  const dark = new MeshStandardMaterial({
+    color: new Color(0x15191d),
+    roughness: 0.5,
+    metalness: 0.35,
+  });
+  const yellow = new MeshStandardMaterial({
+    color: new Color(0xf5c21a),
+    roughness: 0.5,
+  });
+  const pcb = new MeshStandardMaterial({
+    color: new Color(0x0f6b47),
+    roughness: 0.48,
+  });
+  const metal = new MeshStandardMaterial({
+    color: new Color(0xbcc1bf),
+    roughness: 0.26,
+    metalness: 0.65,
+  });
+  const black = new MeshStandardMaterial({
+    color: new Color(0x101113),
+    roughness: 0.55,
+  });
+  const cableMat = new MeshStandardMaterial({
+    color: new Color(0x3ba0ff),
+    roughness: 0.34,
+  });
+  const uplinkMat = new MeshStandardMaterial({
+    color: new Color(0xffb23b),
+    roughness: 0.34,
+  });
+  const ledMaterials: MeshStandardMaterial[] = [];
+
+  const table = new Group();
+  table.name = 'SugarkubeTable';
+  group.add(table);
+  addBox(
+    table,
+    'SugarkubeTableTop',
+    [TABLE_WIDTH, TABLE_TOP_THICKNESS, TABLE_DEPTH],
+    [0, TABLE_HEIGHT, 0],
+    wood
+  );
+  for (const x of [-1, 1])
+    for (const z of [-1, 1])
+      addBox(
+        table,
+        `SugarkubeTableLeg-${x}-${z}`,
+        [0.16, TABLE_HEIGHT, 0.16],
+        [
+          x * (TABLE_WIDTH / 2 - 0.2),
+          TABLE_HEIGHT / 2,
+          z * (TABLE_DEPTH / 2 - 0.2),
+        ],
+        wood
+      );
+  addBox(
+    table,
+    'SugarkubeTableRearBrace',
+    [TABLE_WIDTH - 0.42, 0.08, 0.08],
+    [0, 0.38, TABLE_DEPTH / 2 - 0.2],
+    wood
+  );
+
+  const switchY = TABLE_HEIGHT + TABLE_TOP_THICKNESS / 2 + SWITCH_HEIGHT / 2;
+  const networkSwitch = new Group();
+  networkSwitch.name = 'SugarkubeNetworkSwitch';
+  networkSwitch.position.y = switchY;
+  group.add(networkSwitch);
+  addBox(
+    networkSwitch,
+    'SugarkubeSwitchHousing',
+    [SWITCH_WIDTH, SWITCH_HEIGHT, SWITCH_DEPTH],
+    [0, 0, 0],
+    dark
+  );
+  for (let port = 0; port < 10; port += 1) {
+    const x = (port - 4.5) * 0.13;
+    addBox(
+      networkSwitch,
+      `SugarkubeSwitchPort-${port}`,
+      [0.09, 0.052, 0.035],
+      [x, 0.02, -SWITCH_DEPTH / 2 - 0.012],
+      black
+    );
+    const led = new MeshStandardMaterial({
+      color: new Color(0x78ff65),
+      emissive: new Color(0x1eff00),
+      emissiveIntensity: port % 2 ? 0.45 : 0.8,
+    });
+    ledMaterials.push(led);
+    addBox(
+      networkSwitch,
+      `SugarkubeSwitchLed-${port}`,
+      [0.025, 0.018, 0.012],
+      [x + 0.035, 0.065, -SWITCH_DEPTH / 2 - 0.018],
+      led
+    );
+  }
+  addBox(
+    networkSwitch,
+    'SugarkubeNameplate',
+    [0.42, 0.045, 0.012],
+    [0, 0.075, SWITCH_DEPTH / 2 + 0.012],
+    yellow
+  );
+
+  const rack = new Group();
+  rack.name = 'SugarkubeRack';
+  group.add(rack);
+  const tierYs = [
+    RACK_BASE_Y,
+    RACK_BASE_Y + RACK_TIER_GAP,
+    RACK_BASE_Y + RACK_TIER_GAP * 2,
+  ];
+  tierYs.forEach((y, tier) => {
+    addBox(
+      rack,
+      `SugarkubeRackTier-${tier}`,
+      [RACK_WIDTH, 0.055, RACK_DEPTH],
+      [0, y, 0],
+      yellow
+    );
+    addBox(
+      rack,
+      `SugarkubeRackTierLip-${tier}-front`,
+      [RACK_WIDTH, 0.045, 0.035],
+      [0, y + 0.04, -RACK_DEPTH / 2],
+      yellow
+    );
+    addBox(
+      rack,
+      `SugarkubeRackTierLip-${tier}-rear`,
+      [RACK_WIDTH, 0.045, 0.035],
+      [0, y + 0.04, RACK_DEPTH / 2],
+      yellow
+    );
+    for (let rib = 0; rib < spec.trayRibs; rib += 1)
+      addBox(
+        rack,
+        `SugarkubeRackLayerRib-${tier}-${rib}`,
+        [RACK_WIDTH, 0.012, 0.012],
+        [0, y + 0.06 + rib * 0.018, -RACK_DEPTH / 2 - 0.018],
+        yellow
+      );
+  });
+  const pillarGeometry = new CylinderGeometry(
+    0.04,
+    0.04,
+    RACK_TIER_GAP * 2 + 0.22,
+    spec.cylinderSegments
+  );
+  for (const [index, x, z] of [
+    [0, -1, -1],
+    [1, 1, -1],
+    [2, -1, 1],
+    [3, 1, 1],
+  ] as const) {
+    const pillar = new Mesh(pillarGeometry, yellow);
+    pillar.name = `SugarkubeRackCornerPillar-${index}`;
+    pillar.position.set(
+      x * (RACK_WIDTH / 2 - 0.08),
+      RACK_BASE_Y + RACK_TIER_GAP + 0.04,
+      z * (RACK_DEPTH / 2 - 0.08)
+    );
+    rack.add(pillar);
+  }
+
+  for (let tier = 0; tier < 3; tier += 1) {
+    for (let slot = 0; slot < 3; slot += 1) {
+      const pi = new Group();
+      pi.name = `SugarkubePi-${tier}-${slot}`;
+      pi.position.set((slot - 1) * 0.38, tierYs[tier] + 0.065, 0.03);
+      rack.add(pi);
+      addBox(
+        pi,
+        `SugarkubePiBoard-${tier}-${slot}`,
+        [PI_WIDTH, 0.035, PI_DEPTH],
+        [0, 0, 0],
+        pcb
+      );
+      addBox(
+        pi,
+        `SugarkubePiEthernetJack-${tier}-${slot}`,
+        [0.12, 0.07, 0.1],
+        [0.1, 0.045, -PI_DEPTH / 2 - 0.015],
+        metal
+      );
+      addBox(
+        pi,
+        `SugarkubePiUsbBlock-${tier}-${slot}`,
+        [0.12, 0.06, 0.12],
+        [-0.1, 0.04, -PI_DEPTH / 2],
+        metal
+      );
+      addBox(
+        pi,
+        `SugarkubePiHeatsink-${tier}-${slot}`,
+        [0.13, 0.045, 0.14],
+        [0, 0.055, 0.04],
+        black
+      );
+      if (spec.richPiDetails)
+        addBox(
+          pi,
+          `SugarkubePiFan-${tier}-${slot}`,
+          [0.11, 0.025, 0.11],
+          [0, 0.09, 0.12],
+          black
+        );
+      const led = new MeshStandardMaterial({
+        color: new Color(slot % 2 ? 0xff4949 : 0x58ff58),
+        emissive: new Color(slot % 2 ? 0xff1212 : 0x19ff19),
+        emissiveIntensity: 0.65,
+      });
+      ledMaterials.push(led);
+      addBox(
+        pi,
+        `SugarkubePiStatusLed-${tier}-${slot}`,
+        [0.025, 0.015, 0.025],
+        [-0.13, 0.06, 0.18],
+        led
+      );
+      addBox(
+        pi,
+        `SugarkubePiStandoffs-${tier}-${slot}`,
+        [0.24, 0.025, 0.025],
+        [0, -0.035, 0.18],
+        metal
+      );
+    }
+  }
+
+  for (let index = 0; index < 9; index += 1) {
+    const tier = Math.floor(index / 3);
+    const slot = index % 3;
+    const piX = (slot - 1) * 0.38 + 0.1;
+    const piY = tierYs[tier] + 0.14;
+    const portX = (index - 4) * 0.13;
+    addCable(
+      group,
+      `SugarkubeEthernetCable-${index}`,
+      [
+        new Vector3(piX, piY, -0.24),
+        new Vector3(piX, RACK_BASE_Y - 0.07, -0.55 - tier * 0.04),
+        new Vector3(portX, switchY + 0.08, -SWITCH_DEPTH / 2 - 0.08),
+      ],
+      spec,
+      cableMat,
+      0.018
+    );
+  }
+  addBox(
+    group,
+    'SugarkubeCableComb',
+    [1.15, 0.04, 0.05],
+    [0, RACK_BASE_Y - 0.05, -0.55],
+    black
+  );
+
+  const wallLocal = group.worldToLocal(
+    new Vector3(
+      options.wallEndpoint.x,
+      options.wallEndpoint.y ?? position.y,
+      options.wallEndpoint.z
+    )
+  );
+  addCable(
+    group,
+    'SugarkubeUplinkCable',
+    [
+      new Vector3(0.585, switchY + 0.08, -SWITCH_DEPTH / 2 - 0.08),
+      new Vector3(1.1, TABLE_HEIGHT * 0.5, -0.82),
+      new Vector3(1.1, 0.04, -0.82),
+      new Vector3(wallLocal.x, 0.04, wallLocal.z + 0.22),
+      new Vector3(wallLocal.x, 0.42, wallLocal.z + 0.04),
+    ],
+    spec,
+    uplinkMat,
+    0.02
+  );
+  const plate = new Group();
+  plate.name = 'SugarkubeWallPlate';
+  plate.position.copy(wallLocal);
+  plate.rotation.y =
+    (options.wallEndpoint.orientationRadians ?? 0) - orientationRadians;
+  group.add(plate);
+  addBox(
+    plate,
+    'SugarkubeWallPlateFace',
+    [0.34, 0.44, 0.035],
+    [0, 0.48, 0],
+    metal
+  );
+  addBox(
+    plate,
+    'SugarkubeWallPlateRJ45',
+    [0.16, 0.1, 0.04],
+    [0, 0.48, -0.025],
+    black
+  );
+
+  const colliders = [
+    createRotatedCollider(
+      position,
+      TABLE_WIDTH,
+      TABLE_DEPTH,
+      orientationRadians,
+      'SugarkubeDeploymentCollider'
+    ),
+  ];
+  const update = ({
+    elapsed,
+    emphasis,
+  }: {
+    elapsed: number;
+    delta: number;
+    emphasis: number;
+  }) => {
+    ledMaterials.forEach((material, index) => {
+      const pulse = Math.max(0, Math.sin(elapsed * 3.5 + index * 0.71));
+      material.emissiveIntensity =
+        MathUtils.lerp(0.35, 0.95, pulse) * MathUtils.lerp(1, 1.4, emphasis);
+    });
+  };
+  return { group, colliders, update };
+}

--- a/src/tests/poiModelTriangles.test.ts
+++ b/src/tests/poiModelTriangles.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN } from '../assets/floorPlan';
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
+import { countObjectTriangles } from '../scene/graphics/triangleCount';
+import { createSugarkubeDeployment } from '../scene/structures/sugarkubeDeployment';
+
+describe('POI model triangle reporting helpers', () => {
+  it('counts the selected Sugarkube deployment variant rather than greenhouse geometry', () => {
+    const livingRoom = FLOOR_PLAN.rooms.find(
+      (room) => room.id === 'livingRoom'
+    )!;
+    const balanced = createSugarkubeDeployment({
+      position: { x: -8.74, y: 0, z: -22.92 },
+      orientationRadians: Math.PI * 0.55,
+      detailPolicy: getSceneDetailPolicy('balanced'),
+      wallEndpoint: {
+        x: -8.74,
+        y: 0,
+        z: livingRoom.bounds.minZ + 0.06,
+        orientationRadians: 0,
+      },
+    });
+
+    expect(balanced.group.name).toBe('SugarkubeDeployment');
+    expect(
+      balanced.group.getObjectByName('SugarkubeWallPlateRJ45')
+    ).toBeTruthy();
+    expect(balanced.group.getObjectByName('GreenhouseFrame')).toBeUndefined();
+    expect(countObjectTriangles(balanced.group)).toBe(2800);
+  });
+});

--- a/src/tests/sugarkubeDeployment.test.ts
+++ b/src/tests/sugarkubeDeployment.test.ts
@@ -1,0 +1,136 @@
+import { Box3, Mesh, Object3D } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { FLOOR_PLAN } from '../assets/floorPlan';
+import {
+  getSceneDetailPolicy,
+  type SceneDetailLevel,
+} from '../scene/graphics/sceneDetailPolicy';
+import { countObjectTriangles } from '../scene/graphics/triangleCount';
+import { createSugarkubeDeployment } from '../scene/structures/sugarkubeDeployment';
+
+const levels: SceneDetailLevel[] = ['cinematic', 'balanced', 'performance'];
+const position = { x: -8.74, y: 0.2, z: -22.92 };
+const orientationRadians = Math.PI * 0.55;
+const livingRoom = FLOOR_PLAN.rooms.find((room) => room.id === 'livingRoom')!;
+const wallEndpoint = {
+  x: position.x,
+  y: position.y,
+  z: livingRoom.bounds.minZ + 0.06,
+  orientationRadians: 0,
+};
+
+function build(level: SceneDetailLevel) {
+  return createSugarkubeDeployment({
+    position,
+    orientationRadians,
+    detailPolicy: getSceneDetailPolicy(level),
+    wallEndpoint,
+  });
+}
+
+function find(root: Object3D, name: string): Object3D {
+  const object = root.getObjectByName(name);
+  expect(object, name).toBeTruthy();
+  return object!;
+}
+
+function byPrefix(root: Object3D, prefix: string): Object3D[] {
+  const matches: Object3D[] = [];
+  root.traverse((object) => {
+    if (object.name.startsWith(prefix)) matches.push(object);
+  });
+  return matches;
+}
+
+function expectFiniteObject(root: Object3D) {
+  root.traverse((object) => {
+    for (const value of [
+      object.position.x,
+      object.position.y,
+      object.position.z,
+      object.rotation.x,
+      object.rotation.y,
+      object.rotation.z,
+      object.scale.x,
+      object.scale.y,
+      object.scale.z,
+    ]) {
+      expect(Number.isFinite(value), object.name).toBe(true);
+    }
+    if (object instanceof Mesh) {
+      const positionAttribute = object.geometry.getAttribute('position');
+      expect(positionAttribute?.count ?? 0, object.name).toBeGreaterThan(0);
+      const values = positionAttribute.array;
+      for (let index = 0; index < values.length; index += 1) {
+        expect(Number.isFinite(values[index]), object.name).toBe(true);
+      }
+    }
+  });
+}
+
+describe('createSugarkubeDeployment', () => {
+  it.each(levels)('builds the full semantic deployment in %s mode', (level) => {
+    const deployment = build(level);
+    expect(deployment.group.name).toBe('SugarkubeDeployment');
+    expect(deployment.group.position.toArray()).toEqual([
+      position.x,
+      position.y,
+      position.z,
+    ]);
+    expect(deployment.group.rotation.y).toBeCloseTo(orientationRadians);
+
+    expect(find(deployment.group, 'SugarkubeTable').position.x).toBeCloseTo(0);
+    expect(
+      find(deployment.group, 'SugarkubeNetworkSwitch').position.x
+    ).toBeCloseTo(0);
+    expect(
+      find(deployment.group, 'SugarkubeNetworkSwitch').position.z
+    ).toBeCloseTo(0);
+    expect(byPrefix(deployment.group, 'SugarkubeRackTier-')).toHaveLength(3);
+    expect(
+      byPrefix(deployment.group, 'SugarkubeRackCornerPillar-')
+    ).toHaveLength(4);
+
+    for (let tier = 0; tier < 3; tier += 1) {
+      const tierPis = byPrefix(deployment.group, `SugarkubePi-${tier}-`);
+      expect(tierPis).toHaveLength(3);
+    }
+    expect(byPrefix(deployment.group, 'SugarkubePi-')).toHaveLength(9);
+    expect(byPrefix(deployment.group, 'SugarkubeEthernetCable-')).toHaveLength(
+      9
+    );
+    expect(find(deployment.group, 'SugarkubeUplinkCable')).toBeTruthy();
+    expect(find(deployment.group, 'SugarkubeWallPlate')).toBeTruthy();
+    expect(find(deployment.group, 'SugarkubeWallPlateRJ45')).toBeTruthy();
+    expect(byPrefix(deployment.group, 'TokenPlace')).toHaveLength(0);
+
+    expect(deployment.colliders).toHaveLength(1);
+    expect(
+      deployment.colliders[0]!.maxX - deployment.colliders[0]!.minX
+    ).toBeGreaterThan(2);
+    expectFiniteObject(deployment.group);
+  });
+
+  it('uses real geometry budgets for the active detail level', () => {
+    const counts = Object.fromEntries(
+      levels.map((level) => [level, countObjectTriangles(build(level).group)])
+    ) as Record<SceneDetailLevel, number>;
+
+    expect(counts.cinematic).toBeGreaterThan(counts.balanced);
+    expect(counts.balanced).toBeGreaterThan(counts.performance);
+    expect(counts.balanced / counts.cinematic).toBeGreaterThanOrEqual(0.4);
+    expect(counts.balanced / counts.cinematic).toBeLessThanOrEqual(0.6);
+    expect(counts.performance / counts.balanced).toBeGreaterThanOrEqual(0.4);
+    expect(counts.performance / counts.balanced).toBeLessThanOrEqual(0.6);
+  });
+
+  it('keeps the table bottom-centered on the root anchor', () => {
+    const deployment = build('balanced');
+    const table = find(deployment.group, 'SugarkubeTable');
+    const box = new Box3().setFromObject(table);
+    expect((box.min.x + box.max.x) / 2).toBeCloseTo(position.x);
+    expect((box.min.z + box.max.z) / 2).toBeCloseTo(position.z);
+    expect(box.min.y).toBeCloseTo(position.y);
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace the empty Sugarkube POI placeholder with a procedurally-generated, camera-legible representation of the real deployment while preserving the existing POI id/placement and routing the visible uplink to the living-room south wall.

### Description
- Add a dedicated procedural builder `createSugarkubeDeployment` in `src/scene/structures/sugarkubeDeployment.ts` that constructs a bottom-centered root group, wooden table, PoE switch, yellow three-tier 3D-printed rack (4 pillars), 9 Pi assemblies (3×3), 9 Pi-to-switch cable tubes, a separate uplink cable, a wall plate/RJ45, one conservative rotated table footprint collider named `SugarkubeDeploymentCollider`, and an emissive-only LED `update()` hook; the builder honors the supplied `detailPolicy` and builds a single variant per policy (cinematic / balanced / performance).
- Add a triangle-count helper `countObjectTriangles` in `src/scene/graphics/triangleCount.ts` that counts visible mesh and `InstancedMesh` triangles for diagnostics and tests.
- Integrate the builder into the POI flow in `src/main.ts` so the Sugarkube model is attached to the preserved POI (`sugarkube-backyard-greenhouse`) using the POI group position/heading, and the uplink wall endpoint is derived from `FLOOR_PLAN` living-room `minZ` with X clamped inside room bounds; the model root is added via the existing `addPoiStructure` helper and its collider registered to the correct floor collider list.
- Add deterministic tests: `src/tests/sugarkubeDeployment.test.ts` (semantic presence, finite geometry, one collider, triangle-ratio assertions, bottom-centered anchor) and `src/tests/poiModelTriangles.test.ts` (ensures triangle registry counts the Sugarkube model not the old greenhouse).

### Testing
- Formatting and lint: ran `npm run format:write` and `npm run lint` (both completed; a minor import-order warning was fixed during test file import ordering adjustments). — PASSED
- Unit tests: ran `npm run test:ci -- src/tests/sugarkubeDeployment.test.ts src/tests/poiModelTriangles.test.ts src/tests/poiTooltipOverlay.test.ts src/scene/poi/placements.test.ts` and all selected tests passed (total 43 tests across those files). — PASSED
- Triangle budgets (spot-check): measured triangle counts from the build run: `cinematic = 7268`, `balanced = 2800`, `performance = 1608`, and the test asserts the required ordering and ratios (balanced ≈ 40–60% of cinematic, performance ≈ 40–60% of balanced) — PASS after tuning.
- Build and smoke: ran `npm run build` and `npm run smoke` (both completed; Vite build produced warning about large chunks but build succeeded). — PASSED
- Docs/link check: ran `npm run docs:check` (link-check reported unreachable external URLs but the docs check completed successfully). — PASSED (with warnings)
- Secrets scan: ran `git diff --cached | ./scripts/scan-secrets.py`. — PASSED (no high-risk secrets detected)
- Typecheck: ran `npm run typecheck`; it fails on pre-existing, repository-wide TypeScript issues unrelated to this change (errors originate outside new files). — NOT RUN / FAIL (pre-existing repo type errors)

Notes/Risks: the PR intentionally uses only Three.js primitives (no external assets) and preserves the POI id/placement; `npm run typecheck` currently reports pre-existing type errors in unrelated modules, so CI typecheck will need repo-wide fixes before that command shows green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b71328328832f8dc6964647ee50eb)