### PR TITLE
Reload scene when graphics quality changes and preserve player position

### DIFF
--- a/docs/architecture/performance-budgets.md
+++ b/docs/architecture/performance-budgets.md
@@ -76,12 +76,10 @@ The popup owns the runtime recovery path:
 - **Dismiss** hides the popup and starts its cooldown without changing quality or
   mode.
 - **Switch to Balanced/Performance** applies the next lower graphics quality only
-  after the visitor chooses it. Balanced changes stay in place without a page
-  reload. Popup-owned Performance recovery intentionally uses the scene-detail
-  reload handoff so high-detail POI, mannequin, backyard, media-wall, and
-  showpiece assets are rebuilt under the low-detail policy while the player's
-  position is restored. Ordinary HUD or API graphics changes still apply
-  in-place and do not reload the immersive scene.
+  after the visitor chooses it. HUD, API, and popup-owned graphics changes use
+  the scene-detail reload handoff so POI, mannequin, backyard, media-wall, and
+  showpiece assets are rebuilt under the selected policy while the player's
+  position is restored.
 - **Use non-immersive mode** switches to the text portfolio only after the
   visitor explicitly clicks that action.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -759,6 +759,9 @@ const PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY =
 const PENDING_SCENE_DETAIL_RELOAD_PARAM = 'sceneDetailReloadLevel';
 const PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM = 'sceneDetailAdaptiveLock';
 const PENDING_PLAYER_POSITION_KEY = 'portfolio::pending-player-position';
+const PENDING_PLAYER_POSITION_X_PARAM = 'pendingPlayerX';
+const PENDING_PLAYER_POSITION_Y_PARAM = 'pendingPlayerY';
+const PENDING_PLAYER_POSITION_Z_PARAM = 'pendingPlayerZ';
 
 interface PendingSceneDetailReload {
   level: GraphicsQualityLevel;
@@ -804,14 +807,17 @@ function consumePendingSceneDetailReload(): PendingSceneDetailReload | null {
   }
 }
 
-function persistPendingPlayerPosition(position: PendingPlayerPosition): void {
+function persistPendingPlayerPosition(
+  position: PendingPlayerPosition
+): boolean {
   try {
     window.sessionStorage.setItem(
       PENDING_PLAYER_POSITION_KEY,
       JSON.stringify(position)
     );
+    return window.sessionStorage.getItem(PENDING_PLAYER_POSITION_KEY) !== null;
   } catch {
-    // Best-effort only; quality reloads can still proceed without a position handoff.
+    return false;
   }
 }
 
@@ -824,6 +830,27 @@ function consumePendingPlayerPosition(): PendingPlayerPosition | null {
     }
     const parsed = JSON.parse(stored) as Partial<PendingPlayerPosition>;
     const { x, y, z } = parsed;
+    return typeof x === 'number' &&
+      typeof y === 'number' &&
+      typeof z === 'number' &&
+      Number.isFinite(x) &&
+      Number.isFinite(y) &&
+      Number.isFinite(z)
+      ? { x, y, z }
+      : null;
+  } catch {
+    // Fall through to the URL handoff used when sessionStorage is unavailable.
+  }
+
+  try {
+    const url = new URL(window.location.href);
+    const x = Number(url.searchParams.get(PENDING_PLAYER_POSITION_X_PARAM));
+    const y = Number(url.searchParams.get(PENDING_PLAYER_POSITION_Y_PARAM));
+    const z = Number(url.searchParams.get(PENDING_PLAYER_POSITION_Z_PARAM));
+    url.searchParams.delete(PENDING_PLAYER_POSITION_X_PARAM);
+    url.searchParams.delete(PENDING_PLAYER_POSITION_Y_PARAM);
+    url.searchParams.delete(PENDING_PLAYER_POSITION_Z_PARAM);
+    window.history.replaceState(window.history.state, '', url);
     return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)
       ? { x, y, z }
       : null;
@@ -856,7 +883,8 @@ function persistPendingSceneDetailReload(
 }
 
 function reloadWithPendingSceneDetailParam(
-  pendingReload: PendingSceneDetailReload
+  pendingReload: PendingSceneDetailReload,
+  playerPosition?: PendingPlayerPosition
 ): boolean {
   try {
     const url = new URL(window.location.href);
@@ -864,6 +892,20 @@ function reloadWithPendingSceneDetailParam(
       PENDING_SCENE_DETAIL_RELOAD_PARAM,
       pendingReload.level
     );
+    if (playerPosition) {
+      url.searchParams.set(
+        PENDING_PLAYER_POSITION_X_PARAM,
+        String(playerPosition.x)
+      );
+      url.searchParams.set(
+        PENDING_PLAYER_POSITION_Y_PARAM,
+        String(playerPosition.y)
+      );
+      url.searchParams.set(
+        PENDING_PLAYER_POSITION_Z_PARAM,
+        String(playerPosition.z)
+      );
+    }
     if (pendingReload.adaptivePerformanceRecoveryLocked) {
       url.searchParams.set(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM, '1');
     } else {
@@ -1208,18 +1250,27 @@ function initializeImmersiveScene(
         adaptivePerformanceRecoveryLocked:
           options.adaptivePerformanceRecoveryLocked === true,
       } satisfies PendingSceneDetailReload;
-      if (typeof player !== 'undefined') {
-        persistPendingPlayerPosition({
-          x: player.position.x,
-          y: player.position.y,
-          z: player.position.z,
-        });
-      }
+      const playerPosition =
+        typeof player !== 'undefined'
+          ? {
+              x: player.position.x,
+              y: player.position.y,
+              z: player.position.z,
+            }
+          : undefined;
+      const didPersistPlayerPosition = playerPosition
+        ? persistPendingPlayerPosition(playerPosition)
+        : false;
       if (persistPendingSceneDetailReload(pendingReload)) {
         window.location.reload();
         return;
       }
-      if (reloadWithPendingSceneDetailParam(pendingReload)) {
+      if (
+        reloadWithPendingSceneDetailParam(
+          pendingReload,
+          didPersistPlayerPosition ? undefined : playerPosition
+        )
+      ) {
         return;
       }
       console.warn(
@@ -5792,7 +5843,12 @@ function initializeImmersiveScene(
 
   let pendingLowFpsPerformanceRecoveryReload = false;
 
-  const applyFeaturePolicy = (options: { reloadScene?: boolean } = {}) => {
+  const applyFeaturePolicy = (
+    options: {
+      reloadScene?: boolean;
+      adaptivePerformanceRecoveryLocked?: boolean;
+    } = {}
+  ) => {
     const policy = getQualityFeaturePolicy(
       graphicsQualityManager?.getLevel() ?? initialQualityPolicy.initialLevel,
       rendererInfo.isSoftwareRenderer
@@ -5803,7 +5859,11 @@ function initializeImmersiveScene(
       renderTargetSize: policy.mirrorTargetSize,
     });
     const level = graphicsQualityManager?.getLevel() ?? initialSceneDetailLevel;
-    applySceneDetailLevel(level, { reloadScene: options.reloadScene ?? false });
+    applySceneDetailLevel(level, {
+      reloadScene: options.reloadScene ?? false,
+      adaptivePerformanceRecoveryLocked:
+        options.adaptivePerformanceRecoveryLocked === true,
+    });
   };
 
   const getActivePostprocessingPassCount = () => {
@@ -5822,12 +5882,11 @@ function initializeImmersiveScene(
 
   unsubscribeGraphicsQuality = graphicsQualityManager.onChange((level) => {
     const previousSceneDetailLevel = sceneDetailController.getLevel();
-    const reloadScene =
-      pendingLowFpsPerformanceRecoveryReload &&
-      level === 'performance' &&
-      previousSceneDetailLevel !== 'performance';
+    const reloadScene = previousSceneDetailLevel !== level;
+    const adaptivePerformanceRecoveryLocked =
+      pendingLowFpsPerformanceRecoveryReload && level === 'performance';
     pendingLowFpsPerformanceRecoveryReload = false;
-    applyFeaturePolicy({ reloadScene });
+    applyFeaturePolicy({ reloadScene, adaptivePerformanceRecoveryLocked });
     composer?.setSize(window.innerWidth, window.innerHeight);
     bloomPass?.setSize(window.innerWidth, window.innerHeight);
     graphicsQualityControl?.refresh();

--- a/src/main.ts
+++ b/src/main.ts
@@ -844,13 +844,19 @@ function consumePendingPlayerPosition(): PendingPlayerPosition | null {
 
   try {
     const url = new URL(window.location.href);
-    const x = Number(url.searchParams.get(PENDING_PLAYER_POSITION_X_PARAM));
-    const y = Number(url.searchParams.get(PENDING_PLAYER_POSITION_Y_PARAM));
-    const z = Number(url.searchParams.get(PENDING_PLAYER_POSITION_Z_PARAM));
+    const storedX = url.searchParams.get(PENDING_PLAYER_POSITION_X_PARAM);
+    const storedY = url.searchParams.get(PENDING_PLAYER_POSITION_Y_PARAM);
+    const storedZ = url.searchParams.get(PENDING_PLAYER_POSITION_Z_PARAM);
     url.searchParams.delete(PENDING_PLAYER_POSITION_X_PARAM);
     url.searchParams.delete(PENDING_PLAYER_POSITION_Y_PARAM);
     url.searchParams.delete(PENDING_PLAYER_POSITION_Z_PARAM);
     window.history.replaceState(window.history.state, '', url);
+    if (storedX === null || storedY === null || storedZ === null) {
+      return null;
+    }
+    const x = Number(storedX);
+    const y = Number(storedY);
+    const z = Number(storedZ);
     return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)
       ? { x, y, z }
       : null;
@@ -1242,7 +1248,7 @@ function initializeImmersiveScene(
   ) => {
     if (level === sceneDetailController.getLevel()) {
       activeSceneDetailPolicy = sceneDetailController.getPolicy();
-      return;
+      return false;
     }
     if (options.reloadScene) {
       const pendingReload = {
@@ -1263,7 +1269,7 @@ function initializeImmersiveScene(
         : false;
       if (persistPendingSceneDetailReload(pendingReload)) {
         window.location.reload();
-        return;
+        return true;
       }
       if (
         reloadWithPendingSceneDetailParam(
@@ -1271,7 +1277,7 @@ function initializeImmersiveScene(
           didPersistPlayerPosition ? undefined : playerPosition
         )
       ) {
-        return;
+        return true;
       }
       console.warn(
         '[performance] scene detail reload handoff unavailable; applying policy without reload'
@@ -1279,6 +1285,7 @@ function initializeImmersiveScene(
     }
     sceneDetailController.setLevel(level);
     activeSceneDetailPolicy = sceneDetailController.getPolicy();
+    return false;
   };
   const maxPolicyPixelRatioCap = rendererInfo.isDangerousSoftwareRenderer
     ? initialQualityPolicy.basePixelRatioCap
@@ -5859,7 +5866,7 @@ function initializeImmersiveScene(
       renderTargetSize: policy.mirrorTargetSize,
     });
     const level = graphicsQualityManager?.getLevel() ?? initialSceneDetailLevel;
-    applySceneDetailLevel(level, {
+    return applySceneDetailLevel(level, {
       reloadScene: options.reloadScene ?? false,
       adaptivePerformanceRecoveryLocked:
         options.adaptivePerformanceRecoveryLocked === true,
@@ -5886,7 +5893,13 @@ function initializeImmersiveScene(
     const adaptivePerformanceRecoveryLocked =
       pendingLowFpsPerformanceRecoveryReload && level === 'performance';
     pendingLowFpsPerformanceRecoveryReload = false;
-    applyFeaturePolicy({ reloadScene, adaptivePerformanceRecoveryLocked });
+    const didScheduleSceneReload = applyFeaturePolicy({
+      reloadScene,
+      adaptivePerformanceRecoveryLocked,
+    });
+    if (didScheduleSceneReload) {
+      return;
+    }
     composer?.setSize(window.innerWidth, window.innerHeight);
     bloomPass?.setSize(window.innerWidth, window.innerHeight);
     graphicsQualityControl?.refresh();

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -33,7 +33,7 @@ describe('main module imports', () => {
     );
     expect(source).toContain('window.location.assign(url.toString());');
     expect(source).toContain(
-      'if (reloadWithPendingSceneDetailParam(pendingReload))'
+      'reloadWithPendingSceneDetailParam(\n          pendingReload,'
     );
   });
 
@@ -97,7 +97,7 @@ describe('main module imports', () => {
     expect(source).toContain('adaptiveRecoveryCount: 0');
   });
 
-  it('limits Performance scene-detail rebuilds to explicit popup recovery', () => {
+  it('rebuilds scene detail when graphics quality changes', () => {
     const source = readMainSource();
 
     expect(source).toContain(
@@ -105,14 +105,16 @@ describe('main module imports', () => {
     );
     expect(source).toContain("if (nextLevel === 'performance') {");
     expect(source).toContain('pendingLowFpsPerformanceRecoveryReload = true;');
-    expect(source).not.toContain(
-      "const reloadScene =\n      level === 'performance' && previousSceneDetailLevel !== 'performance';"
+    expect(source).toContain(
+      'const reloadScene = previousSceneDetailLevel !== level;'
     );
     expect(source).toContain(
-      "const reloadScene =\n      pendingLowFpsPerformanceRecoveryReload &&\n      level === 'performance' &&\n      previousSceneDetailLevel !== 'performance';"
+      "pendingLowFpsPerformanceRecoveryReload && level === 'performance';"
     );
     expect(source).toContain('pendingLowFpsPerformanceRecoveryReload = false;');
-    expect(source).toContain('applyFeaturePolicy({ reloadScene });');
+    expect(source).toContain(
+      'applyFeaturePolicy({ reloadScene, adaptivePerformanceRecoveryLocked });'
+    );
   });
 
   it('does not reload when no scene-detail handoff can be persisted', () => {

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -32,9 +32,12 @@ describe('main module imports', () => {
       "url.searchParams.set(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_PARAM, '1');"
     );
     expect(source).toContain('window.location.assign(url.toString());');
-    expect(source).toContain(
-      'reloadWithPendingSceneDetailParam(\n          pendingReload,'
+    expect(source).toMatch(
+      /reloadWithPendingSceneDetailParam\(\s*pendingReload,/
     );
+    expect(source).toContain('storedX === null');
+    expect(source).toContain('storedY === null');
+    expect(source).toContain('storedZ === null');
   });
 
   it('passes generated source IDs and purposes into debug collider metadata', () => {
@@ -112,9 +115,10 @@ describe('main module imports', () => {
       "pendingLowFpsPerformanceRecoveryReload && level === 'performance';"
     );
     expect(source).toContain('pendingLowFpsPerformanceRecoveryReload = false;');
-    expect(source).toContain(
-      'applyFeaturePolicy({ reloadScene, adaptivePerformanceRecoveryLocked });'
+    expect(source).toMatch(
+      /const didScheduleSceneReload = applyFeaturePolicy\(\{\s*reloadScene,\s*adaptivePerformanceRecoveryLocked,\s*\}\);/
     );
+    expect(source).toMatch(/if \(didScheduleSceneReload\) \{\s*return;\s*\}/);
   });
 
   it('does not reload when no scene-detail handoff can be persisted', () => {
@@ -127,7 +131,7 @@ describe('main module imports', () => {
       'window.sessionStorage.getItem(PENDING_SCENE_DETAIL_ADAPTIVE_LOCK_KEY) ==='
     );
     expect(source).toMatch(
-      /if \(persistPendingSceneDetailReload\(pendingReload\)\) \{\s*window\.location\.reload\(\);\s*return;\s*\}/
+      /if \(persistPendingSceneDetailReload\(pendingReload\)\) \{\s*window\.location\.reload\(\);\s*return true;\s*\}/
     );
     expect(source).toContain(
       '[performance] scene detail reload handoff unavailable; applying policy without reload'


### PR DESCRIPTION
### Motivation
- Changing the graphics quality in the HUD did not rebuild scene-detail assets immediately, requiring the user to manually refresh the page to see the selected preset take effect.  
- When a scene reload was required, the player's in-world position was not preserved, returning them to spawn on reload.  

### Description
- Trigger scene-detail rebuild whenever the active graphics quality level changes by treating any level change as a candidate for the reload handoff (changes in `src/main.ts`).  
- Persist the player's current position to `sessionStorage` before attempting a reload and, when sessionStorage is unavailable, fall back to a URL query-parameter handoff so the position can be restored on load (added helpers and URL param plumbing in `src/main.ts`).  
- Add an optional `adaptivePerformanceRecoveryLocked` handoff flag and thread it through `applyFeaturePolicy` → `applySceneDetailLevel` → reload logic; update the composer/refresh flow to apply the new policy immediately.  
- Update unit/source-string tests and documentation to reflect the new behavior (`src/tests/mainImports.test.ts`, `src/tests/graphicsQuality*`, and `docs/architecture/performance-budgets.md`).  

### Testing
- Ran `npm run format:write` and formatting completed successfully.  
- Ran `npm run lint` and ESLint passed after the change.  
- Ran focused unit tests with `npm run test:ci -- src/tests/graphicsQualityManager.test.ts src/tests/graphicsQualityControl.test.ts` and `npm run test:ci -- src/tests/mainImports.test.ts`, both passed.  
- Ran the full test suite with `npm run test:ci` and all tests completed successfully (`167` files, `1280` tests passed).  
- Ran docs and smoke checks with `npm run docs:check` and `npm run smoke`, both passed.  
- Ran the pre-push secret scan `git diff --cached | ./scripts/scan-secrets.py` which reported no high-risk secrets.  

All automated checks listed in the repo playbook (format, lint, test:ci, docs:check, smoke) passed on the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b704cd090832faec4e626ae283a3b)