### PR TITLE
🧩 : – Add miniature detail proxy infrastructure

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -18,6 +18,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Miniature drift guard
+        run: npm run miniature:check
       - name: Unit tests
         run: npm run test:ci
       - name: Install Playwright browser for collider audits

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:check": "node scripts/check-docs.cjs && npm run links:check",
     "smoke": "npm run build && node scripts/assert-dist.cjs",
     "press-kit": "tsx scripts/generate-press-kit.ts",
-    "check": "npm run lint && npm run test:ci && npm run docs:check",
+    "check": "npm run lint && npm run miniature:check && npm run test:ci && npm run docs:check",
     "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
@@ -27,7 +27,9 @@
     "collider:inspect": "tsx scripts/colliderInspect.ts",
     "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
     "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts",
-    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts"
+    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts",
+    "miniature:manifest:update": "tsx scripts/miniature-manifest.ts update",
+    "miniature:check": "tsx scripts/miniature-manifest.ts check"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/miniature-manifest.ts
+++ b/scripts/miniature-manifest.ts
@@ -1,0 +1,212 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { relative } from 'node:path';
+
+import {
+  LanguageVariant,
+  ScriptTarget,
+  SyntaxKind,
+  createScanner,
+} from 'typescript';
+
+import { POI_MINIATURE_PROXIES } from '../src/scene/miniature/poiProxyRegistry';
+import { MINIATURE_SCENE_COMPONENT_COVERAGE } from '../src/scene/miniature/sceneComponentRegistry';
+import { getPoiDefinitions } from '../src/scene/poi/registry';
+
+export interface ManifestEntry {
+  id: string;
+  syncRevision: number;
+  syncNote?: string;
+  sourceFiles: string[];
+  proxyFiles: string[];
+  sourceFingerprint: string;
+  proxyFingerprint: string;
+}
+
+export interface MiniatureManifest {
+  version: 1;
+  generatedBy: 'scripts/miniature-manifest.ts';
+  entries: ManifestEntry[];
+}
+
+const manifestPath = 'src/scene/miniature/miniatureManifest.generated.json';
+const geometrySourceFiles = [
+  'src/scene/environments/backyard.ts',
+  'src/scene/level/portfolioLevel.ts',
+  'src/scene/level/generateFloorSurfaces.ts',
+  'src/scene/level/generateWalls.ts',
+  'src/scene/structures/ceilingPanels.ts',
+  'src/scene/structures/doorwayOpenings.ts',
+  'src/scene/structures/floorTiles.ts',
+  'src/scene/structures/mediaWall.ts',
+  'src/scene/structures/mediaWallStarBridge.ts',
+  'src/scene/structures/selfieMirror.ts',
+  'src/scene/structures/staircase.ts',
+  'src/scene/structures/upperLandingFloorCutouts.ts',
+  'src/scene/structures/upperStairwellLanding.ts',
+  'src/scene/structures/wallSegmentsMesh.ts',
+  'src/scene/lighting/ledStrips.ts',
+  'src/scene/avatar/mannequin.ts',
+  'src/scene/avatar/accessories.ts',
+];
+
+export function normalizeTypeScriptTokens(sourceText: string): string {
+  const scanner = createScanner(
+    ScriptTarget.Latest,
+    true,
+    LanguageVariant.Standard,
+    sourceText
+  );
+  const tokens: string[] = [];
+  let token = scanner.scan();
+  while (token !== SyntaxKind.EndOfFileToken) {
+    tokens.push(`${SyntaxKind[token]}:${scanner.getTokenText()}`);
+    token = scanner.scan();
+  }
+  return tokens.join('\n');
+}
+
+function hashText(text: string) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function hashFiles(files: readonly string[], metadata: object) {
+  const chunks = [JSON.stringify(metadata)];
+  for (const file of [...files].sort()) {
+    if (!existsSync(file))
+      throw new Error(`Missing miniature manifest file: ${file}`);
+    chunks.push(file, normalizeTypeScriptTokens(readFileSync(file, 'utf8')));
+  }
+  return hashText(chunks.join('\n---\n'));
+}
+
+export function buildMiniatureManifest(): MiniatureManifest {
+  const allEntries = [
+    ...POI_MINIATURE_PROXIES,
+    ...MINIATURE_SCENE_COMPONENT_COVERAGE,
+  ];
+  const ids = new Set<string>();
+  for (const entry of allEntries) {
+    if (ids.has(entry.id))
+      throw new Error(`Duplicate miniature registry id: ${entry.id}`);
+    ids.add(entry.id);
+    for (const file of [...entry.sourceFiles, ...entry.proxyFiles]) {
+      if (!existsSync(file))
+        throw new Error(`Miniature registry file does not exist: ${file}`);
+    }
+  }
+
+  const poiIds = new Set(getPoiDefinitions().map((poi) => poi.id));
+  const proxyPoiIds = new Set(
+    POI_MINIATURE_PROXIES.map((proxy) => proxy.poiId)
+  );
+  for (const poiId of poiIds) {
+    if (!proxyPoiIds.has(poiId))
+      throw new Error(`Missing miniature POI proxy for ${poiId}`);
+  }
+  for (const proxy of POI_MINIATURE_PROXIES) {
+    if (!poiIds.has(proxy.poiId))
+      throw new Error(`Miniature proxy references unknown POI ${proxy.poiId}`);
+    if (
+      proxy.poiId === 'danielsmith-portfolio-table' &&
+      !proxy.recursionBoundary
+    ) {
+      throw new Error(
+        'danielsmith.io miniature proxy must be a recursion boundary'
+      );
+    }
+  }
+
+  const ownedSources = new Map<string, string>();
+  for (const entry of allEntries) {
+    for (const sourceFile of entry.sourceFiles) {
+      const owner = ownedSources.get(sourceFile);
+      if (owner && owner !== entry.id && sourceFile.includes('/structures/')) {
+        throw new Error(
+          `Duplicate miniature source ownership for ${sourceFile}: ${owner} and ${entry.id}`
+        );
+      }
+      ownedSources.set(sourceFile, entry.id);
+    }
+  }
+  for (const sourceFile of geometrySourceFiles) {
+    if (!ownedSources.has(sourceFile)) {
+      throw new Error(
+        `Audited geometry source is not classified for miniature coverage: ${sourceFile}`
+      );
+    }
+  }
+
+  if (/new\s+\w+Geometry\s*\(/.test(readFileSync('src/main.ts', 'utf8'))) {
+    throw new Error(
+      'Move inline Geometry construction out of src/main.ts before updating miniature coverage.'
+    );
+  }
+
+  return {
+    version: 1,
+    generatedBy: 'scripts/miniature-manifest.ts',
+    entries: allEntries.map((entry) => ({
+      id: entry.id,
+      syncRevision: entry.syncRevision,
+      syncNote: entry.syncNote,
+      sourceFiles: [...entry.sourceFiles].sort(),
+      proxyFiles: [...entry.proxyFiles].sort(),
+      sourceFingerprint: hashFiles(entry.sourceFiles, {
+        id: entry.id,
+        revision: entry.syncRevision,
+        note: entry.syncNote,
+      }),
+      proxyFingerprint: hashFiles(entry.proxyFiles, {
+        id: entry.id,
+        revision: entry.syncRevision,
+        note: entry.syncNote,
+      }),
+    })),
+  };
+}
+
+export function validateMiniatureManifest(
+  committed: MiniatureManifest,
+  next: MiniatureManifest
+) {
+  const previousById = new Map(
+    committed.entries.map((entry) => [entry.id, entry])
+  );
+  for (const entry of next.entries) {
+    const previous = previousById.get(entry.id);
+    if (!previous) continue;
+    if (
+      previous.sourceFingerprint !== entry.sourceFingerprint &&
+      previous.proxyFingerprint === entry.proxyFingerprint &&
+      previous.syncRevision === entry.syncRevision
+    ) {
+      throw new Error(
+        `Miniature source changed without proxy update or syncRevision bump: ${entry.id}`
+      );
+    }
+  }
+  if (JSON.stringify(committed, null, 2) !== JSON.stringify(next, null, 2)) {
+    throw new Error(
+      'Committed miniature manifest is stale. Run npm run miniature:manifest:update.'
+    );
+  }
+}
+
+function main() {
+  const mode = process.argv[2] ?? 'check';
+  const manifest = buildMiniatureManifest();
+  if (mode === 'update') {
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    console.log(`Updated ${relative(process.cwd(), manifestPath)}`);
+    return;
+  }
+  if (!existsSync(manifestPath)) throw new Error(`Missing ${manifestPath}`);
+  const committed = JSON.parse(
+    readFileSync(manifestPath, 'utf8')
+  ) as MiniatureManifest;
+  validateMiniatureManifest(committed, manifest);
+  console.log('Miniature manifest is current.');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/src/scene/graphics/sceneDetailPolicy.ts
+++ b/src/scene/graphics/sceneDetailPolicy.ts
@@ -1,9 +1,20 @@
 import type { GraphicsQualityLevel } from './qualityManager';
 
-export type SceneDetailLevel = GraphicsQualityLevel;
+export const SCENE_DETAIL_LEVELS = [
+  'cinematic',
+  'balanced',
+  'performance',
+  'low',
+  'micro',
+] as const;
+
+export type SceneDetailLevel = (typeof SCENE_DETAIL_LEVELS)[number];
+export type OverworldSceneDetailLevel = GraphicsQualityLevel;
 
 export interface SceneDetailPolicy {
   level: SceneDetailLevel;
+  detailIndex: number;
+  modelDetailScale: number;
   geometry: {
     cylinderSegments: number;
     sphereWidthSegments: number;
@@ -15,6 +26,7 @@ export interface SceneDetailPolicy {
   };
   textures: {
     canvasScale: number;
+    maxResolution: number;
     jobbotScreen: { width: number; height: number };
     jobbotTelemetry: { width: number; height: number };
     mediaWallScreen: { width: number; height: number };
@@ -34,6 +46,7 @@ export interface SceneDetailPolicy {
     decorativeThrottleMs: number;
     canvasRedrawThrottleMs: number;
     skipUnfocusedDecorations: boolean;
+    animationCadence: 'realtime' | 'throttled' | 'static';
   };
   budgets: {
     transparentShaderLayers: number;
@@ -41,125 +54,235 @@ export interface SceneDetailPolicy {
     decorativeDrawCalls: number;
     poiTriangleScale: number;
     structureTriangleScale: number;
+    triangleBudgetHint: number;
+    drawCallBudgetHint: number;
   };
 }
 
-const HIGH_DETAIL_GEOMETRY = {
-  cylinderSegments: 48,
-  sphereWidthSegments: 32,
-  sphereHeightSegments: 32,
-  ringSegments: 64,
-  torusRadialSegments: 24,
-  torusTubularSegments: 64,
-  terrainSegments: 24,
-} as const;
+const entries = [
+  [
+    'cinematic',
+    1,
+    48,
+    32,
+    32,
+    64,
+    24,
+    64,
+    24,
+    1,
+    2048,
+    true,
+    0,
+    8,
+    12,
+    160,
+    120000,
+    650,
+  ],
+  [
+    'balanced',
+    0.5,
+    48,
+    32,
+    32,
+    64,
+    24,
+    64,
+    24,
+    1,
+    2048,
+    true,
+    0,
+    8,
+    12,
+    160,
+    90000,
+    500,
+  ],
+  [
+    'performance',
+    0.25,
+    8,
+    8,
+    6,
+    10,
+    6,
+    12,
+    4,
+    0.25,
+    512,
+    false,
+    250,
+    0,
+    1,
+    24,
+    22000,
+    180,
+  ],
+  [
+    'low',
+    0.125,
+    6,
+    6,
+    4,
+    8,
+    4,
+    8,
+    2,
+    0.125,
+    256,
+    false,
+    750,
+    0,
+    0,
+    12,
+    11000,
+    90,
+  ],
+  [
+    'micro',
+    0.0625,
+    3,
+    4,
+    3,
+    6,
+    3,
+    6,
+    1,
+    0.0625,
+    128,
+    false,
+    1500,
+    0,
+    0,
+    6,
+    5500,
+    45,
+  ],
+] as const;
 
-const HIGH_DETAIL_TEXTURES = {
-  canvasScale: 1,
-  jobbotScreen: { width: 2048, height: 1024 },
-  jobbotTelemetry: { width: 1024, height: 512 },
-  mediaWallScreen: { width: 2048, height: 1024 },
-  mediaWallBadge: { width: 512, height: 256 },
-} as const;
+export const SCENE_DETAIL_POLICIES = Object.fromEntries(
+  entries.map(
+    (
+      [
+        level,
+        scale,
+        cyl,
+        sw,
+        sh,
+        ring,
+        torusR,
+        torusT,
+        terrain,
+        canvas,
+        max,
+        fx,
+        throttle,
+        layers,
+        lights,
+        draws,
+        tris,
+        drawCalls,
+      ],
+      detailIndex
+    ) => [
+      level,
+      {
+        level,
+        detailIndex,
+        modelDetailScale: scale,
+        geometry: {
+          cylinderSegments: cyl,
+          sphereWidthSegments: sw,
+          sphereHeightSegments: sh,
+          ringSegments: ring,
+          torusRadialSegments: torusR,
+          torusTubularSegments: torusT,
+          terrainSegments: terrain,
+        },
+        textures: {
+          canvasScale: canvas,
+          maxResolution: max,
+          jobbotScreen: { width: max, height: max / 2 },
+          jobbotTelemetry: {
+            width: Math.max(64, max / 2),
+            height: Math.max(32, max / 4),
+          },
+          mediaWallScreen: { width: max, height: max / 2 },
+          mediaWallBadge: {
+            width: Math.max(64, max / 4),
+            height: Math.max(32, max / 8),
+          },
+        },
+        effects: {
+          transparentShaders: fx,
+          mist: fx,
+          pondRippleShader: fx,
+          glassTransmission: fx,
+          decorativeHalos: fx,
+          telemetryPanels: fx,
+          decorativeShards: fx,
+          dynamicPointLights: fx,
+        },
+        updates: {
+          decorativeThrottleMs: throttle,
+          canvasRedrawThrottleMs: throttle === 0 ? 0 : Math.max(1000, throttle),
+          skipUnfocusedDecorations: !fx,
+          animationCadence: fx
+            ? 'realtime'
+            : level === 'performance'
+              ? 'throttled'
+              : 'static',
+        },
+        budgets: {
+          transparentShaderLayers: layers,
+          dynamicPointLights: lights,
+          decorativeDrawCalls: draws,
+          poiTriangleScale: scale,
+          structureTriangleScale: scale,
+          triangleBudgetHint: tris,
+          drawCallBudgetHint: drawCalls,
+        },
+      } satisfies SceneDetailPolicy,
+    ]
+  )
+) as Record<SceneDetailLevel, SceneDetailPolicy>;
 
-const HIGH_DETAIL_EFFECTS = {
-  transparentShaders: true,
-  mist: true,
-  pondRippleShader: true,
-  glassTransmission: true,
-  decorativeHalos: true,
-  telemetryPanels: true,
-  decorativeShards: true,
-  dynamicPointLights: true,
-} as const;
+export function mapGraphicsQualityToOverworldDetailLevel(
+  level: GraphicsQualityLevel
+): OverworldSceneDetailLevel {
+  return level;
+}
 
-export const SCENE_DETAIL_POLICIES: Record<
-  SceneDetailLevel,
-  SceneDetailPolicy
-> = {
-  cinematic: {
-    level: 'cinematic',
-    geometry: HIGH_DETAIL_GEOMETRY,
-    textures: HIGH_DETAIL_TEXTURES,
-    effects: HIGH_DETAIL_EFFECTS,
-    updates: {
-      decorativeThrottleMs: 0,
-      canvasRedrawThrottleMs: 0,
-      skipUnfocusedDecorations: false,
-    },
-    budgets: {
-      transparentShaderLayers: 8,
-      dynamicPointLights: 12,
-      decorativeDrawCalls: 160,
-      poiTriangleScale: 1,
-      structureTriangleScale: 1,
-    },
-  },
-  balanced: {
-    level: 'balanced',
-    geometry: HIGH_DETAIL_GEOMETRY,
-    textures: HIGH_DETAIL_TEXTURES,
-    effects: HIGH_DETAIL_EFFECTS,
-    updates: {
-      decorativeThrottleMs: 0,
-      canvasRedrawThrottleMs: 0,
-      skipUnfocusedDecorations: false,
-    },
-    budgets: {
-      transparentShaderLayers: 8,
-      dynamicPointLights: 12,
-      decorativeDrawCalls: 160,
-      poiTriangleScale: 1,
-      structureTriangleScale: 1,
-    },
-  },
-  performance: {
-    level: 'performance',
-    geometry: {
-      cylinderSegments: 8,
-      sphereWidthSegments: 8,
-      sphereHeightSegments: 6,
-      ringSegments: 10,
-      torusRadialSegments: 6,
-      torusTubularSegments: 12,
-      terrainSegments: 4,
-    },
-    textures: {
-      canvasScale: 0.25,
-      jobbotScreen: { width: 512, height: 256 },
-      jobbotTelemetry: { width: 256, height: 128 },
-      mediaWallScreen: { width: 512, height: 256 },
-      mediaWallBadge: { width: 256, height: 128 },
-    },
-    effects: {
-      transparentShaders: false,
-      mist: false,
-      pondRippleShader: false,
-      glassTransmission: false,
-      decorativeHalos: false,
-      telemetryPanels: false,
-      decorativeShards: false,
-      dynamicPointLights: false,
-    },
-    updates: {
-      decorativeThrottleMs: 250,
-      canvasRedrawThrottleMs: 1000,
-      skipUnfocusedDecorations: true,
-    },
-    budgets: {
-      transparentShaderLayers: 0,
-      dynamicPointLights: 1,
-      decorativeDrawCalls: 24,
-      poiTriangleScale: 0.12,
-      structureTriangleScale: 0.18,
-    },
-  },
-};
+export function stepSceneDetailLevelDown(
+  level: SceneDetailLevel,
+  steps: number
+): SceneDetailLevel {
+  const index = SCENE_DETAIL_LEVELS.indexOf(level);
+  const nextIndex = Math.min(
+    SCENE_DETAIL_LEVELS.length - 1,
+    Math.max(0, index + Math.max(0, Math.floor(steps)))
+  );
+  return SCENE_DETAIL_LEVELS[nextIndex];
+}
+
+export function getMiniatureDetailLevel(
+  level: SceneDetailLevel
+): SceneDetailLevel {
+  return stepSceneDetailLevelDown(level, 2);
+}
 
 export function getSceneDetailPolicy(
   level: SceneDetailLevel
 ): SceneDetailPolicy {
-  return SCENE_DETAIL_POLICIES[level] ?? SCENE_DETAIL_POLICIES.balanced;
+  return SCENE_DETAIL_POLICIES[level];
+}
+
+export function getMiniatureSceneDetailPolicy(
+  level: SceneDetailLevel
+): SceneDetailPolicy {
+  return getSceneDetailPolicy(getMiniatureDetailLevel(level));
 }
 
 export interface SceneDetailController {
@@ -184,14 +307,9 @@ export function createSceneDetailController(
   let level = initialLevel;
   let policy = getSceneDetailPolicy(level);
   const lastDecorativeUpdateMsByChannel = new Map<string, number>();
-
   return {
-    getLevel() {
-      return level;
-    },
-    getPolicy() {
-      return policy;
-    },
+    getLevel: () => level,
+    getPolicy: () => policy,
     setLevel(nextLevel) {
       level = nextLevel;
       policy = getSceneDetailPolicy(nextLevel);
@@ -201,34 +319,20 @@ export function createSceneDetailController(
       emphasis = 0,
       channel = 'default'
     ) {
-      if (policy.updates.decorativeThrottleMs <= 0) {
-        return true;
-      }
+      if (policy.updates.decorativeThrottleMs <= 0) return true;
       if (
         policy.updates.skipUnfocusedDecorations &&
         Math.max(0, emphasis) < 0.02
-      ) {
+      )
         return false;
-      }
       const elapsedMs = elapsedSeconds * 1000;
-      const lastDecorativeUpdateMs =
+      const last =
         lastDecorativeUpdateMsByChannel.get(channel) ??
         Number.NEGATIVE_INFINITY;
-      if (
-        elapsedMs - lastDecorativeUpdateMs <
-        policy.updates.decorativeThrottleMs
-      ) {
-        return false;
-      }
+      if (elapsedMs - last < policy.updates.decorativeThrottleMs) return false;
       lastDecorativeUpdateMsByChannel.set(channel, elapsedMs);
       return true;
     },
-    getSnapshot() {
-      return {
-        level,
-        policy,
-        theoreticalBudget: policy.budgets,
-      };
-    },
+    getSnapshot: () => ({ level, policy, theoreticalBudget: policy.budgets }),
   };
 }

--- a/src/scene/miniature/detailPolicy.ts
+++ b/src/scene/miniature/detailPolicy.ts
@@ -1,0 +1,6 @@
+export {
+  getMiniatureDetailLevel,
+  getMiniatureSceneDetailPolicy,
+  mapGraphicsQualityToOverworldDetailLevel,
+  stepSceneDetailLevelDown,
+} from '../graphics/sceneDetailPolicy';

--- a/src/scene/miniature/index.ts
+++ b/src/scene/miniature/index.ts
@@ -1,0 +1,5 @@
+export * from './detailPolicy';
+export * from './poiProxyRegistry';
+export * from './proxyBuilder';
+export * from './sceneComponentRegistry';
+export * from './types';

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -1,0 +1,202 @@
+{
+  "version": 1,
+  "generatedBy": "scripts/miniature-manifest.ts",
+  "entries": [
+    {
+      "id": "poi:futuroptimist-living-room-tv",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "5ae0c335ad80e351dd6abe42b008a9b9d8a37655cec8ade60920b91319ec1cf3",
+      "proxyFingerprint": "f5bb1ffb3d99e75736a91b3c4042b250ba5eb38895afadb4bb14d691c53177f7"
+    },
+    {
+      "id": "poi:flywheel-studio-flywheel",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "6822f8a1521806afc6e7f4fab869e8e8d3bd58e8a6df86d5124c636587d94a16",
+      "proxyFingerprint": "891bc2683ab55e90269538744503ae30566f0444f592b7eb7cb330518b458279"
+    },
+    {
+      "id": "poi:jobbot-studio-terminal",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "b7b25bb4264851c4265f18012be51714fe6e08a4d1014fad49c57853c459071b",
+      "proxyFingerprint": "48884848c41917be2b42ddb21fe6f37c03918e4dbb533d20ce534b2e8bf44c12"
+    },
+    {
+      "id": "poi:dspace-backyard-rocket",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "300f5646148d01529c7170a5e86f536ed78d1427049f227eb5c51bc4a85b51b4",
+      "proxyFingerprint": "3e3715543657df2dc0dca51ff9e391d8b005d14093bfd85c4060751720715c94"
+    },
+    {
+      "id": "poi:sugarkube-backyard-greenhouse",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": [
+        "src/scene/poi/registry.ts",
+        "src/scene/poi/types.ts",
+        "src/scene/structures/sugarkubeDeployment.ts"
+      ],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "cc7bee2d5c608519c846bdbe944ef3e9a0d81a4899a79d57127824b7382d6aba",
+      "proxyFingerprint": "9ef9ba1c079a3f6aced96ad03f8cebf9a5022962122b1d6d3b7240cc4fbbfd6e"
+    },
+    {
+      "id": "poi:tokenplace-studio-cluster",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": [
+        "src/scene/poi/registry.ts",
+        "src/scene/poi/types.ts",
+        "src/scene/structures/tokenPlaceWorkstation.ts"
+      ],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "9fa16753464d85ac7ad6ec712205493e4b9db50b23dd41754a742c1dd75e88b2",
+      "proxyFingerprint": "b60a9f918e54aa9871645ec2608a4fa85b3b5f1376fb3d88ac1c71cc9c463ba7"
+    },
+    {
+      "id": "poi:gabriel-studio-sentry",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "639262b046272844abc9e333924a494181c1f1b5abfa4ede6511350f5d69b19a",
+      "proxyFingerprint": "73f84b84da243946296f3cf9713d3108738ca933518ee9d8cbfe30da48f06531"
+    },
+    {
+      "id": "poi:f2clipboard-kitchen-console",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "f7a694928d00114051a4744877b04b6e074c6da018ec645cbcbe3efac7eeb28a",
+      "proxyFingerprint": "8bc2fd64358e92899caca021ee6bd0be9de84530091f01add45ef0d5832f3317"
+    },
+    {
+      "id": "poi:axel-studio-tracker",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "6ebdf21454b5fd62bc15f24df233489d820bc965f865ee57da6ab4bf1a23645d",
+      "proxyFingerprint": "cf81f5d79d57d5fdd2bacb2413bb980e76153b660b2f3853fb6c6b78b2c69320"
+    },
+    {
+      "id": "poi:sigma-kitchen-workbench",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "16371e9bfd5b7a2b6185d68d0c4b2b3672c2c3da0a83b643dda54e9d38750676",
+      "proxyFingerprint": "52684ba5b18cc18aabe8496b210703b5c36aa032a1aa2cd0bd98534e040e80ad"
+    },
+    {
+      "id": "poi:gitshelves-living-room-installation",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "abe6340fd4967b53abac8b7b76bc005f9899a57cd52396ae316d4a6b097c54ad",
+      "proxyFingerprint": "72836e4afcfe418ec06527503c89c3ca1a6d714f8da4f6856b5a983a03c93f89"
+    },
+    {
+      "id": "poi:wove-kitchen-loom",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "7f3793453dc85fb1da5f99e6ac2ab5261b7c3dad6240a3a0f51928a1b45bccd7",
+      "proxyFingerprint": "d65fe31697ba9904b237e1badb792f53a7ea37522c7a620974496fe5ca5927bb"
+    },
+    {
+      "id": "poi:pr-reaper-backyard-console",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage for tabletop infrastructure.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "758fe62b9b8a1fb51e21bcce25dcd9433d1f4b0c77a4c72db32a3abddb1cc155",
+      "proxyFingerprint": "6b0f297a8a162be5e715ad647368bd0b1dfbba9f8e39bb973785a7604826d81e"
+    },
+    {
+      "id": "poi:danielsmith-portfolio-table",
+      "syncRevision": 1,
+      "syncNote": "Recursion boundary: build only a simple nonrecursive white table proxy.",
+      "sourceFiles": ["src/scene/poi/registry.ts", "src/scene/poi/types.ts"],
+      "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
+      "sourceFingerprint": "ad528fcd21dab6d4ddd195f957eeff2c813377a6f9b3f5927f33e5a647b2a6b3",
+      "proxyFingerprint": "46d827d85aadc25832bb0340373ea13e8b2d1e8854398c18fce192d76587f9bc"
+    },
+    {
+      "id": "shared:floor-plan-levels",
+      "syncRevision": 1,
+      "syncNote": "Prompt 4b should derive topology directly from shared level data.",
+      "sourceFiles": [
+        "src/scene/level/generateFloorSurfaces.ts",
+        "src/scene/level/generateWalls.ts",
+        "src/scene/level/portfolioLevel.ts",
+        "src/scene/structures/staircase.ts",
+        "src/scene/structures/upperLandingFloorCutouts.ts",
+        "src/scene/structures/upperStairwellLanding.ts"
+      ],
+      "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
+      "sourceFingerprint": "19ed1b94ff8a65ed9bfc01f4da317e16a4ac165bb984ec8bbd9f45a48f2e3306",
+      "proxyFingerprint": "8102df8dd76bad301028c6038b816038bba93d233d38724835b487ee64321f75"
+    },
+    {
+      "id": "shared:backyard-environment",
+      "syncRevision": 1,
+      "syncNote": "Miniature should derive bounds and major environment features from backyard source data.",
+      "sourceFiles": ["src/scene/environments/backyard.ts"],
+      "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
+      "sourceFingerprint": "1cca0bd553dffe1b0cdc54f308da8ab60a8a91aa25a6d9c341c855b9a258e328",
+      "proxyFingerprint": "dadd793007a43f76e5116a067c9d841ca53223b88187a943dd5622d2ba6ac227"
+    },
+    {
+      "id": "proxy:house-visible-fixtures",
+      "syncRevision": 1,
+      "syncNote": "Visible fixtures that are not pure topology get simplified proxy coverage.",
+      "sourceFiles": [
+        "src/scene/lighting/ledStrips.ts",
+        "src/scene/structures/ceilingPanels.ts",
+        "src/scene/structures/doorwayOpenings.ts",
+        "src/scene/structures/floorTiles.ts",
+        "src/scene/structures/mediaWall.ts",
+        "src/scene/structures/mediaWallStarBridge.ts",
+        "src/scene/structures/selfieMirror.ts",
+        "src/scene/structures/wallSegmentsMesh.ts"
+      ],
+      "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
+      "sourceFingerprint": "82c21057899b76ed42b06fcfcd05868a1c75c61739ab51e05700739d73893c69",
+      "proxyFingerprint": "15dca9edd526f4075e0c6ab144977fc947c631ac3fbf1a05f5965192b01b2d06"
+    },
+    {
+      "id": "excluded:runtime-non-geometry",
+      "syncRevision": 1,
+      "syncNote": "The live miniature player is deferred to Prompt 4b.",
+      "sourceFiles": [
+        "src/scene/avatar/accessories.ts",
+        "src/scene/avatar/mannequin.ts",
+        "src/scene/collision.ts",
+        "src/scene/debug/colliderVisualizer.ts",
+        "src/scene/debug/solidVisualizer.ts",
+        "src/scene/poi/markers.ts",
+        "src/scene/poi/tooltipOverlay.ts",
+        "src/scene/poi/visitedBadge.ts",
+        "src/scene/poi/worldTooltip.ts"
+      ],
+      "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
+      "sourceFingerprint": "a5fc190f3fd3d2f2e3d9e7cca89dbc4786786f0290212aae6b1b1fa8b1cd99dc",
+      "proxyFingerprint": "ee76ced7aae0cee97aa6f2bfa572fbb56f1d6e8beae08edb5075eec732ae17eb"
+    }
+  ]
+}

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -1,0 +1,331 @@
+import type { PoiId } from '../poi/types';
+
+import type { MiniaturePrimitive, PoiMiniatureProxyDefinition } from './types';
+
+const proxyFile = 'src/scene/miniature/poiProxyRegistry.ts';
+
+const baseSourceFiles = ['src/scene/poi/types.ts', 'src/scene/poi/registry.ts'];
+
+const box = (
+  name: string,
+  size: readonly [number, number, number],
+  position: readonly [number, number, number],
+  color?: number
+): MiniaturePrimitive => ({
+  kind: 'box',
+  name,
+  material: 'base',
+  size,
+  position,
+  color,
+});
+const cyl = (
+  name: string,
+  radius: number,
+  height: number,
+  position: readonly [number, number, number],
+  color?: number
+): MiniaturePrimitive => ({
+  kind: 'cylinder',
+  name,
+  material: 'metal',
+  radius,
+  height,
+  position,
+  color,
+});
+const screen = (
+  name: string,
+  position: readonly [number, number, number]
+): MiniaturePrimitive => ({
+  kind: 'box',
+  name,
+  material: 'screen',
+  size: [0.62, 0.38, 0.04],
+  position,
+});
+const detailRing = (name: string, radius = 0.42): MiniaturePrimitive => ({
+  kind: 'ring',
+  name,
+  material: 'accent',
+  radius,
+  tubeRadius: 0.04,
+  position: [0, 0.62, 0],
+  rotation: [-Math.PI / 2, 0, 0],
+  maxDetail: 'performance',
+});
+
+function simpleProxy(
+  poiId: PoiId,
+  label: string,
+  primitives: readonly MiniaturePrimitive[],
+  sourceFiles: readonly string[] = baseSourceFiles
+): PoiMiniatureProxyDefinition {
+  return {
+    id: `poi:${poiId}`,
+    poiId,
+    label,
+    primitives,
+    sourceFiles,
+    proxyFiles: [proxyFile],
+    syncRevision: 1,
+    syncNote: 'Initial miniature proxy coverage for tabletop infrastructure.',
+  };
+}
+
+export const POI_MINIATURE_PROXY_REGISTRY = {
+  'futuroptimist-living-room-tv': simpleProxy(
+    'futuroptimist-living-room-tv',
+    'Futur Optimist TV',
+    [
+      box('tv-console', [1.4, 0.18, 0.38], [0, 0.09, 0]),
+      screen('large-tv-screen', [0, 0.75, -0.12]),
+      detailRing('optimist-signal-ring'),
+    ]
+  ),
+  'flywheel-studio-flywheel': simpleProxy(
+    'flywheel-studio-flywheel',
+    'Flywheel',
+    [
+      cyl('flywheel-base', 0.36, 0.18, [0, 0.09, 0]),
+      {
+        kind: 'ring',
+        name: 'upright-flywheel-ring',
+        material: 'accent',
+        radius: 0.48,
+        tubeRadius: 0.06,
+        position: [0, 0.58, 0],
+        rotation: [0, 0, Math.PI / 2],
+      },
+      cyl('flywheel-axle', 0.08, 0.74, [0, 0.58, 0], 0x202833),
+    ]
+  ),
+  'jobbot-studio-terminal': simpleProxy(
+    'jobbot-studio-terminal',
+    'JobBot terminal',
+    [
+      box('terminal-desk', [1.1, 0.18, 0.62], [0, 0.09, 0]),
+      screen('terminal-screen', [0, 0.58, -0.2]),
+      box('terminal-keyboard', [0.62, 0.04, 0.2], [0, 0.22, 0.18], 0x222936),
+      detailRing('jobbot-telemetry-ring'),
+    ]
+  ),
+  'dspace-backyard-rocket': simpleProxy(
+    'dspace-backyard-rocket',
+    'Democratized Space rocket',
+    [
+      cyl('rocket-body', 0.18, 1.2, [0, 0.68, 0], 0xf1f4f8),
+      {
+        kind: 'cylinder',
+        name: 'rocket-nose',
+        material: 'warning',
+        radius: 0.2,
+        height: 0.28,
+        position: [0, 1.42, 0],
+      },
+      box('rocket-fin-left', [0.08, 0.26, 0.3], [-0.22, 0.24, 0]),
+      box('rocket-fin-right', [0.08, 0.26, 0.3], [0.22, 0.24, 0]),
+    ]
+  ),
+  'sugarkube-backyard-greenhouse': simpleProxy(
+    'sugarkube-backyard-greenhouse',
+    'Sugarkube deployment',
+    [
+      box('sugarkube-table', [1.25, 0.16, 0.72], [0, 0.32, 0], 0x6b4a2f),
+      box('sugarkube-switch', [0.52, 0.08, 0.28], [-0.22, 0.46, 0], 0x273545),
+      box(
+        'sugarkube-yellow-rack-tier',
+        [0.58, 0.05, 0.34],
+        [0.32, 0.54, 0],
+        0xffd447
+      ),
+      {
+        kind: 'box',
+        name: 'sugarkube-yellow-rack-tier',
+        material: 'warning',
+        size: [0.58, 0.05, 0.34],
+        position: [0.32, 0.7, 0],
+        repeat: {
+          count: 2,
+          offset: [0, 0.16, 0],
+          namePrefix: 'sugarkube-yellow-rack-tier',
+        },
+      },
+      {
+        kind: 'sphere',
+        name: 'sugarkube-node',
+        material: 'accent',
+        radius: 0.08,
+        position: [0.12, 0.58, 0.24],
+        repeat: {
+          count: 4,
+          offset: [0.14, 0.08, -0.14],
+          namePrefix: 'sugarkube-node',
+        },
+      },
+      {
+        kind: 'tube',
+        name: 'sugarkube-cable-silhouette',
+        material: 'cable',
+        tubeRadius: 0.018,
+        points: [
+          [-0.2, 0.52, 0],
+          [0.12, 0.66, 0.18],
+          [0.46, 0.82, -0.12],
+        ],
+      },
+    ],
+    [...baseSourceFiles, 'src/scene/structures/sugarkubeDeployment.ts']
+  ),
+  'tokenplace-studio-cluster': simpleProxy(
+    'tokenplace-studio-cluster',
+    'token.place workstation',
+    [
+      box('tokenplace-desk', [1.35, 0.16, 0.72], [0, 0.32, 0], 0x5c4032),
+      box(
+        'tokenplace-pc-tower',
+        [0.28, 0.62, 0.42],
+        [-0.62, 0.42, 0.05],
+        0x151a22
+      ),
+      cyl('tokenplace-gaming-chair', 0.26, 0.42, [0.58, 0.4, 0.24], 0x252b38),
+      screen('tokenplace-monitor-left', [-0.23, 0.64, -0.24]),
+      screen('tokenplace-monitor-right', [0.39, 0.64, -0.24]),
+      box(
+        'tokenplace-keyboard',
+        [0.58, 0.04, 0.18],
+        [0.05, 0.43, 0.12],
+        0x0f1720
+      ),
+      box('tokenplace-mouse', [0.14, 0.04, 0.2], [0.48, 0.43, 0.13], 0x0f1720),
+    ],
+    [...baseSourceFiles, 'src/scene/structures/tokenPlaceWorkstation.ts']
+  ),
+  'gabriel-studio-sentry': simpleProxy(
+    'gabriel-studio-sentry',
+    'Gabriel sentry',
+    [
+      cyl('sentry-base', 0.3, 0.14, [0, 0.07, 0]),
+      cyl('sentry-column', 0.12, 0.74, [0, 0.48, 0]),
+      screen('sentry-face-screen', [0, 0.88, -0.08]),
+    ]
+  ),
+  'f2clipboard-kitchen-console': simpleProxy(
+    'f2clipboard-kitchen-console',
+    'F2Clipboard console',
+    [
+      box('clipboard-console', [0.95, 0.18, 0.55], [0, 0.18, 0]),
+      screen('clipboard-screen', [0, 0.52, -0.16]),
+      box(
+        'clipboard-sheet-stack',
+        [0.42, 0.06, 0.32],
+        [0.2, 0.32, 0.12],
+        0xf6f0dc
+      ),
+    ]
+  ),
+  'axel-studio-tracker': simpleProxy('axel-studio-tracker', 'Axel tracker', [
+    box('tracker-plinth', [0.84, 0.16, 0.52], [0, 0.08, 0]),
+    {
+      kind: 'sphere',
+      name: 'tracker-orbit-node',
+      material: 'accent',
+      radius: 0.14,
+      position: [0, 0.48, 0],
+    },
+    detailRing('tracker-orbit-ring', 0.36),
+  ]),
+  'sigma-kitchen-workbench': simpleProxy(
+    'sigma-kitchen-workbench',
+    'Sigma workbench',
+    [
+      box('sigma-bench', [1.15, 0.16, 0.7], [0, 0.32, 0]),
+      cyl('sigma-vessel', 0.16, 0.28, [-0.3, 0.54, 0]),
+      {
+        kind: 'tube',
+        name: 'sigma-arm',
+        material: 'metal',
+        tubeRadius: 0.025,
+        points: [
+          [0.2, 0.48, 0.2],
+          [0.32, 0.72, 0],
+          [0.1, 0.78, -0.18],
+        ],
+      },
+    ]
+  ),
+  'gitshelves-living-room-installation': simpleProxy(
+    'gitshelves-living-room-installation',
+    'Git shelves',
+    [
+      box('git-shelf-frame', [1.1, 0.72, 0.18], [0, 0.44, 0]),
+      {
+        kind: 'box',
+        name: 'git-shelf-row',
+        material: 'accent',
+        size: [0.96, 0.05, 0.2],
+        position: [0, 0.24, 0],
+        repeat: { count: 4, offset: [0, 0.15, 0], namePrefix: 'git-shelf-row' },
+      },
+    ]
+  ),
+  'wove-kitchen-loom': simpleProxy('wove-kitchen-loom', 'Wove loom', [
+    box('loom-frame', [1, 0.72, 0.16], [0, 0.42, 0]),
+    {
+      kind: 'tube',
+      name: 'loom-thread-arc',
+      material: 'accent',
+      tubeRadius: 0.018,
+      points: [
+        [-0.4, 0.25, 0],
+        [0, 0.7, 0],
+        [0.4, 0.25, 0],
+      ],
+    },
+  ]),
+  'pr-reaper-backyard-console': simpleProxy(
+    'pr-reaper-backyard-console',
+    'PR Reaper console',
+    [
+      box('reaper-console', [1, 0.16, 0.58], [0, 0.18, 0]),
+      screen('reaper-dashboard', [0, 0.52, -0.16]),
+      {
+        kind: 'cylinder',
+        name: 'reaper-scythe-arc',
+        material: 'metal',
+        radius: 0.38,
+        height: 0.035,
+        position: [0.36, 0.64, 0],
+        rotation: [Math.PI / 2, 0, 0],
+        maxDetail: 'performance',
+      },
+    ]
+  ),
+  'danielsmith-portfolio-table': {
+    ...simpleProxy(
+      'danielsmith-portfolio-table',
+      'danielsmith.io recursion boundary table',
+      [
+        box(
+          'portfolio-white-table',
+          [1.05, 0.14, 0.74],
+          [0, 0.34, 0],
+          0xf8f5ee
+        ),
+        box(
+          'portfolio-nonrecursive-miniature-marker',
+          [0.42, 0.04, 0.28],
+          [0, 0.45, 0],
+          0xd9e1ea
+        ),
+      ]
+    ),
+    recursionBoundary: true,
+    syncNote:
+      'Recursion boundary: build only a simple nonrecursive white table proxy.',
+  },
+} satisfies Record<PoiId, PoiMiniatureProxyDefinition>;
+
+export const POI_MINIATURE_PROXIES = Object.values(
+  POI_MINIATURE_PROXY_REGISTRY
+);

--- a/src/scene/miniature/proxyBuilder.ts
+++ b/src/scene/miniature/proxyBuilder.ts
@@ -1,0 +1,176 @@
+import {
+  BoxGeometry,
+  BufferGeometry,
+  CatmullRomCurve3,
+  Color,
+  CylinderGeometry,
+  DoubleSide,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  RingGeometry,
+  SphereGeometry,
+  TubeGeometry,
+  Vector3,
+} from 'three';
+
+import {
+  SCENE_DETAIL_LEVELS,
+  type SceneDetailLevel,
+} from '../graphics/sceneDetailPolicy';
+
+import type {
+  MiniatureBuildContext,
+  MiniatureMaterialRole,
+  MiniaturePrimitive,
+  MiniatureProxyBuildResult,
+  MiniatureProxyDefinition,
+} from './types';
+
+const roleColors: Record<MiniatureMaterialRole, number> = {
+  base: 0x5f6f7a,
+  accent: 0x49d7ff,
+  screen: 0x102040,
+  metal: 0x9aa0a6,
+  glass: 0x8fe8ff,
+  plant: 0x3baa63,
+  cable: 0x151923,
+  warning: 0xffd447,
+  white: 0xf8f5ee,
+};
+
+const materialCache = new Map<string, MeshStandardMaterial>();
+
+function detailIndex(level: SceneDetailLevel) {
+  return SCENE_DETAIL_LEVELS.indexOf(level);
+}
+
+function includesPrimitive(
+  primitive: MiniaturePrimitive,
+  level: SceneDetailLevel
+) {
+  const index = detailIndex(level);
+  const min = primitive.minDetail ? detailIndex(primitive.minDetail) : 0;
+  const max = primitive.maxDetail
+    ? detailIndex(primitive.maxDetail)
+    : SCENE_DETAIL_LEVELS.length - 1;
+  return index >= min && index <= max;
+}
+
+function materialFor(role: MiniatureMaterialRole, color?: number) {
+  const actual = color ?? roleColors[role];
+  const key = `${role}:${actual}`;
+  let material = materialCache.get(key);
+  if (!material) {
+    material = new MeshStandardMaterial({
+      color: new Color(actual),
+      roughness: role === 'screen' || role === 'glass' ? 0.36 : 0.72,
+      metalness: role === 'metal' ? 0.55 : 0.05,
+      ...(role === 'screen' || role === 'glass' ? { side: DoubleSide } : {}),
+    });
+    materialCache.set(key, material);
+  }
+  return material;
+}
+
+function geometryFor(
+  primitive: MiniaturePrimitive,
+  context: MiniatureBuildContext
+): BufferGeometry {
+  const g = context.detailPolicy.geometry;
+  switch (primitive.kind) {
+    case 'box': {
+      const [x, y, z] = primitive.size ?? [1, 1, 1];
+      return new BoxGeometry(x, y, z);
+    }
+    case 'plane': {
+      const [x, , z] = primitive.size ?? [1, 0, 1];
+      return new PlaneGeometry(x, z);
+    }
+    case 'cylinder':
+      return new CylinderGeometry(
+        primitive.radius ?? 0.5,
+        primitive.radius ?? 0.5,
+        primitive.height ?? 1,
+        Math.max(3, g.cylinderSegments)
+      );
+    case 'sphere':
+      return new SphereGeometry(
+        primitive.radius ?? 0.5,
+        Math.max(3, g.sphereWidthSegments),
+        Math.max(2, g.sphereHeightSegments)
+      );
+    case 'ring':
+      return new RingGeometry(
+        Math.max(
+          0.01,
+          (primitive.radius ?? 0.5) - (primitive.tubeRadius ?? 0.04)
+        ),
+        primitive.radius ?? 0.5,
+        Math.max(3, g.ringSegments)
+      );
+    case 'tube': {
+      const points = (
+        primitive.points ?? [
+          [0, 0, 0],
+          [0, 0, 1],
+        ]
+      ).map(([x, y, z]) => new Vector3(x, y, z));
+      return new TubeGeometry(
+        new CatmullRomCurve3(points),
+        Math.max(1, g.torusTubularSegments),
+        primitive.tubeRadius ?? 0.025,
+        Math.max(3, g.torusRadialSegments),
+        false
+      );
+    }
+  }
+}
+
+function applyTransform(
+  mesh: Mesh,
+  primitive: MiniaturePrimitive,
+  offset: readonly [number, number, number]
+) {
+  const [x, y, z] = primitive.position ?? [0, 0, 0];
+  mesh.position.set(x + offset[0], y + offset[1], z + offset[2]);
+  const [rx, ry, rz] = primitive.rotation ?? [0, 0, 0];
+  mesh.rotation.set(rx, ry, rz);
+  const [sx, sy, sz] = primitive.scale ?? [1, 1, 1];
+  mesh.scale.set(sx, sy, sz);
+}
+
+export function buildMiniatureProxy(
+  definition: MiniatureProxyDefinition,
+  context: MiniatureBuildContext
+): MiniatureProxyBuildResult {
+  const root = new Group();
+  root.name = `MiniatureProxy:${definition.id}`;
+  const semanticNames: string[] = [];
+
+  for (const primitive of definition.primitives) {
+    if (!includesPrimitive(primitive, context.detailLevel)) continue;
+    const count = primitive.repeat?.count ?? 1;
+    const repeatOffset = primitive.repeat?.offset ?? [0, 0, 0];
+    for (let index = 0; index < count; index += 1) {
+      const geometry = geometryFor(primitive, context);
+      const mesh = new Mesh(
+        geometry,
+        materialFor(primitive.material, primitive.color)
+      );
+      mesh.name = primitive.repeat?.namePrefix
+        ? `${primitive.repeat.namePrefix}-${index + 1}`
+        : primitive.name;
+      applyTransform(mesh, primitive, [
+        repeatOffset[0] * index,
+        repeatOffset[1] * index,
+        repeatOffset[2] * index,
+      ]);
+      root.add(mesh);
+      semanticNames.push(mesh.name);
+    }
+  }
+
+  return { root, semanticNames };
+}

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -1,0 +1,101 @@
+import type { SceneComponentCoverageEntry } from './types';
+
+const proxyFile = 'src/scene/miniature/sceneComponentRegistry.ts';
+
+export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
+  {
+    id: 'shared:floor-plan-levels',
+    label:
+      'House floors, rooms, walls, doors, stair openings, and upper landing',
+    kind: 'shared-source',
+    sourceFiles: [
+      'src/scene/level/portfolioLevel.ts',
+      'src/scene/level/generateFloorSurfaces.ts',
+      'src/scene/level/generateWalls.ts',
+      'src/scene/structures/staircase.ts',
+      'src/scene/structures/upperLandingFloorCutouts.ts',
+      'src/scene/structures/upperStairwellLanding.ts',
+    ],
+    proxyFiles: [proxyFile],
+    primitives: [],
+    syncRevision: 1,
+    syncNote:
+      'Prompt 4b should derive topology directly from shared level data.',
+  },
+  {
+    id: 'shared:backyard-environment',
+    label:
+      'Backyard bounds, terrain, path, fence, shrubs, lantern fixtures, and barrier',
+    kind: 'shared-source',
+    sourceFiles: ['src/scene/environments/backyard.ts'],
+    proxyFiles: [proxyFile],
+    primitives: [],
+    syncRevision: 1,
+    syncNote:
+      'Miniature should derive bounds and major environment features from backyard source data.',
+  },
+  {
+    id: 'proxy:house-visible-fixtures',
+    label: 'Visible house fixtures and decor',
+    kind: 'proxy',
+    sourceFiles: [
+      'src/scene/structures/ceilingPanels.ts',
+      'src/scene/structures/doorwayOpenings.ts',
+      'src/scene/structures/floorTiles.ts',
+      'src/scene/structures/mediaWall.ts',
+      'src/scene/structures/mediaWallStarBridge.ts',
+      'src/scene/structures/selfieMirror.ts',
+      'src/scene/structures/wallSegmentsMesh.ts',
+      'src/scene/lighting/ledStrips.ts',
+    ],
+    proxyFiles: [proxyFile],
+    primitives: [
+      {
+        kind: 'box',
+        name: 'miniature-media-wall-fixture',
+        material: 'screen',
+        size: [1.2, 0.08, 0.52],
+        position: [0, 0.4, 0],
+      },
+      {
+        kind: 'box',
+        name: 'miniature-led-strip-fixture',
+        material: 'accent',
+        size: [1.4, 0.04, 0.04],
+        position: [0, 0.82, -0.34],
+      },
+      {
+        kind: 'box',
+        name: 'miniature-selfie-mirror-fixture',
+        material: 'glass',
+        size: [0.42, 0.04, 0.7],
+        position: [0.72, 0.48, 0],
+      },
+    ],
+    syncRevision: 1,
+    syncNote:
+      'Visible fixtures that are not pure topology get simplified proxy coverage.',
+  },
+  {
+    id: 'excluded:runtime-non-geometry',
+    label: 'Runtime systems without miniature geometry',
+    kind: 'excluded',
+    reason:
+      'Collision, debug visualizers, HUD/DOM, audio, cameras, invisible interaction meshes, POI markers, labels, badges, and the overworld player are intentionally not miniature proxy geometry.',
+    sourceFiles: [
+      'src/scene/collision.ts',
+      'src/scene/debug/colliderVisualizer.ts',
+      'src/scene/debug/solidVisualizer.ts',
+      'src/scene/poi/markers.ts',
+      'src/scene/poi/tooltipOverlay.ts',
+      'src/scene/poi/visitedBadge.ts',
+      'src/scene/poi/worldTooltip.ts',
+      'src/scene/avatar/mannequin.ts',
+      'src/scene/avatar/accessories.ts',
+    ],
+    proxyFiles: [proxyFile],
+    primitives: [],
+    syncRevision: 1,
+    syncNote: 'The live miniature player is deferred to Prompt 4b.',
+  },
+] as const satisfies readonly SceneComponentCoverageEntry[];

--- a/src/scene/miniature/types.ts
+++ b/src/scene/miniature/types.ts
@@ -1,0 +1,83 @@
+import type { Object3D } from 'three';
+
+import type {
+  SceneDetailLevel,
+  SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+import type { PoiId } from '../poi/types';
+
+export type MiniatureMaterialRole =
+  | 'base'
+  | 'accent'
+  | 'screen'
+  | 'metal'
+  | 'glass'
+  | 'plant'
+  | 'cable'
+  | 'warning'
+  | 'white';
+
+export interface MiniatureTransform {
+  position?: readonly [number, number, number];
+  rotation?: readonly [number, number, number];
+  scale?: readonly [number, number, number];
+}
+
+export type MiniaturePrimitiveKind =
+  | 'box'
+  | 'plane'
+  | 'cylinder'
+  | 'sphere'
+  | 'ring'
+  | 'tube';
+
+export interface MiniaturePrimitive extends MiniatureTransform {
+  kind: MiniaturePrimitiveKind;
+  name: string;
+  material: MiniatureMaterialRole;
+  color?: number;
+  size?: readonly [number, number, number];
+  radius?: number;
+  tubeRadius?: number;
+  height?: number;
+  points?: readonly (readonly [number, number, number])[];
+  minDetail?: SceneDetailLevel;
+  maxDetail?: SceneDetailLevel;
+  repeat?: {
+    count: number;
+    offset: readonly [number, number, number];
+    namePrefix?: string;
+  };
+}
+
+export interface MiniatureProxyDefinition {
+  id: string;
+  label: string;
+  primitives: readonly MiniaturePrimitive[];
+  syncRevision: number;
+  syncNote?: string;
+  sourceFiles: readonly string[];
+  proxyFiles: readonly string[];
+}
+
+export interface PoiMiniatureProxyDefinition extends MiniatureProxyDefinition {
+  poiId: PoiId;
+  recursionBoundary?: boolean;
+}
+
+export type SceneComponentCoverageKind = 'shared-source' | 'proxy' | 'excluded';
+
+export interface SceneComponentCoverageEntry extends MiniatureProxyDefinition {
+  kind: SceneComponentCoverageKind;
+  reason?: string;
+}
+
+export interface MiniatureBuildContext {
+  detailLevel: SceneDetailLevel;
+  detailPolicy: SceneDetailPolicy;
+}
+
+export interface MiniatureProxyBuildResult {
+  root: Object3D;
+  semanticNames: string[];
+}

--- a/src/scene/structures/sugarkubeDeployment.ts
+++ b/src/scene/structures/sugarkubeDeployment.ts
@@ -126,6 +126,12 @@ const detailSettings = (level: SceneDetailPolicy['level']) => {
   if (level === 'performance') {
     return { cableSeg: 4, cableRad: 3, cyl: 5, extras: false, mid: false };
   }
+  if (level === 'low') {
+    return { cableSeg: 3, cableRad: 3, cyl: 4, extras: false, mid: false };
+  }
+  if (level === 'micro') {
+    return { cableSeg: 2, cableRad: 3, cyl: 3, extras: false, mid: false };
+  }
   return { cableSeg: 12, cableRad: 6, cyl: 10, extras: false, mid: true };
 };
 

--- a/src/scene/structures/tokenPlaceWorkstation.ts
+++ b/src/scene/structures/tokenPlaceWorkstation.ts
@@ -129,6 +129,30 @@ const DETAIL_CONFIG: Record<SceneDetailPolicy['level'], DetailConfig> = {
     pcVentCount: 2,
     wheelCount: 3,
   },
+  low: {
+    level: 'low',
+    terminalWidth: 160,
+    terminalHeight: 80,
+    redrawFps: 1,
+    monitorSegments: 4,
+    chairSegments: 4,
+    keyRows: 1,
+    keyColumns: 3,
+    pcVentCount: 1,
+    wheelCount: 0,
+  },
+  micro: {
+    level: 'micro',
+    terminalWidth: 96,
+    terminalHeight: 48,
+    redrawFps: 0,
+    monitorSegments: 3,
+    chairSegments: 3,
+    keyRows: 1,
+    keyColumns: 2,
+    pcVentCount: 0,
+    wheelCount: 0,
+  },
 };
 
 function mulberry32(seed: number): () => number {

--- a/src/tests/miniatureDetailPolicy.test.ts
+++ b/src/tests/miniatureDetailPolicy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { GRAPHICS_QUALITY_PRESETS } from '../scene/graphics/qualityManager';
+import {
+  SCENE_DETAIL_LEVELS,
+  getMiniatureDetailLevel,
+  getMiniatureSceneDetailPolicy,
+  getSceneDetailPolicy,
+  mapGraphicsQualityToOverworldDetailLevel,
+  stepSceneDetailLevelDown,
+} from '../scene/graphics/sceneDetailPolicy';
+
+describe('miniature detail policy', () => {
+  it('keeps three public graphics quality levels while defining five ordered detail levels', () => {
+    expect(GRAPHICS_QUALITY_PRESETS.map((preset) => preset.id)).toEqual([
+      'cinematic',
+      'balanced',
+      'performance',
+    ]);
+    expect(SCENE_DETAIL_LEVELS).toEqual([
+      'cinematic',
+      'balanced',
+      'performance',
+      'low',
+      'micro',
+    ]);
+  });
+
+  it('maps overworld graphics levels to miniature levels exactly two levels lower', () => {
+    expect(mapGraphicsQualityToOverworldDetailLevel('cinematic')).toBe(
+      'cinematic'
+    );
+    expect(getMiniatureDetailLevel('cinematic')).toBe('performance');
+    expect(getMiniatureDetailLevel('balanced')).toBe('low');
+    expect(getMiniatureDetailLevel('performance')).toBe('micro');
+    expect(stepSceneDetailLevelDown('low', 99)).toBe('micro');
+    expect(getMiniatureSceneDetailPolicy('balanced').level).toBe('low');
+  });
+
+  it('decreases policy scale, geometry, textures, effects, and budgets monotonically', () => {
+    let previous = getSceneDetailPolicy('cinematic');
+    for (const level of SCENE_DETAIL_LEVELS.slice(1)) {
+      const policy = getSceneDetailPolicy(level);
+      expect(policy.detailIndex).toBeGreaterThan(previous.detailIndex);
+      expect(policy.modelDetailScale).toBeLessThanOrEqual(
+        previous.modelDetailScale
+      );
+      expect(policy.geometry.cylinderSegments).toBeGreaterThanOrEqual(3);
+      expect(policy.geometry.cylinderSegments).toBeLessThanOrEqual(
+        previous.geometry.cylinderSegments
+      );
+      expect(policy.textures.maxResolution).toBeLessThanOrEqual(
+        previous.textures.maxResolution
+      );
+      expect(policy.budgets.triangleBudgetHint).toBeLessThan(
+        previous.budgets.triangleBudgetHint
+      );
+      expect(Number(policy.effects.dynamicPointLights)).toBeLessThanOrEqual(
+        Number(previous.effects.dynamicPointLights)
+      );
+      previous = policy;
+    }
+    expect(getSceneDetailPolicy('low').effects.dynamicPointLights).toBe(false);
+    expect(getSceneDetailPolicy('micro').effects.telemetryPanels).toBe(false);
+  });
+});

--- a/src/tests/miniatureManifest.test.ts
+++ b/src/tests/miniatureManifest.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMiniatureManifest,
+  normalizeTypeScriptTokens,
+  validateMiniatureManifest,
+} from '../../scripts/miniature-manifest';
+
+describe('miniature manifest', () => {
+  it('token fingerprints ignore comments and formatting trivia', () => {
+    expect(normalizeTypeScriptTokens('const value = 1; // comment')).toBe(
+      normalizeTypeScriptTokens('const   value=1;\n/* block */')
+    );
+  });
+
+  it('builds a deterministic manifest for current proxies and coverage', () => {
+    const manifest = buildMiniatureManifest();
+    expect(manifest.entries.length).toBeGreaterThan(10);
+    expect(new Set(manifest.entries.map((entry) => entry.id)).size).toBe(
+      manifest.entries.length
+    );
+  });
+
+  it('rejects source changes when proxy fingerprint and sync revision do not change', () => {
+    const manifest = buildMiniatureManifest();
+    const changed = structuredClone(manifest);
+    changed.entries[0].sourceFingerprint = 'changed';
+    expect(() => validateMiniatureManifest(manifest, changed)).toThrow(
+      /source changed/i
+    );
+  });
+
+  it('allows explicit revision acknowledgements for source-only changes', () => {
+    const manifest = buildMiniatureManifest();
+    const changed = structuredClone(manifest);
+    changed.entries[0].sourceFingerprint = 'changed';
+    changed.entries[0].syncRevision += 1;
+    changed.entries[0].syncNote = 'Reviewed source-only miniature impact.';
+    expect(() => validateMiniatureManifest(changed, changed)).not.toThrow();
+  });
+});

--- a/src/tests/miniatureProxyRegistry.test.ts
+++ b/src/tests/miniatureProxyRegistry.test.ts
@@ -1,0 +1,113 @@
+import { Object3D } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  SCENE_DETAIL_LEVELS,
+  getSceneDetailPolicy,
+} from '../scene/graphics/sceneDetailPolicy';
+import { POI_MINIATURE_PROXY_REGISTRY } from '../scene/miniature/poiProxyRegistry';
+import { buildMiniatureProxy } from '../scene/miniature/proxyBuilder';
+import { MINIATURE_SCENE_COMPONENT_COVERAGE } from '../scene/miniature/sceneComponentRegistry';
+import { getPoiDefinitions } from '../scene/poi/registry';
+import { countObjectTriangles } from '../scene/structures/triangleCount';
+
+describe('miniature POI proxy registry', () => {
+  it('covers every current POI exactly once', () => {
+    expect(Object.keys(POI_MINIATURE_PROXY_REGISTRY).sort()).toEqual(
+      getPoiDefinitions()
+        .map((poi) => poi.id)
+        .sort()
+    );
+  });
+
+  it('marks danielsmith.io as a nonrecursive recursion boundary', () => {
+    const proxy = POI_MINIATURE_PROXY_REGISTRY['danielsmith-portfolio-table'];
+    expect(proxy.recursionBoundary).toBe(true);
+    expect(
+      proxy.primitives.map((primitive) => primitive.name).join(' ')
+    ).toContain('white-table');
+  });
+
+  it('includes required Sugarkube and token.place semantic components', () => {
+    const sugarkube = POI_MINIATURE_PROXY_REGISTRY[
+      'sugarkube-backyard-greenhouse'
+    ].primitives.map((primitive) => primitive.name);
+    expect(sugarkube.join(' ')).toContain('table');
+    expect(sugarkube.join(' ')).toContain('switch');
+    expect(sugarkube.join(' ')).toContain('yellow-rack-tier');
+    expect(sugarkube.join(' ')).toContain('node');
+    expect(sugarkube.join(' ')).toContain('cable');
+
+    const tokenplace = POI_MINIATURE_PROXY_REGISTRY[
+      'tokenplace-studio-cluster'
+    ].primitives.map((primitive) => primitive.name);
+    for (const name of [
+      'desk',
+      'pc-tower',
+      'gaming-chair',
+      'monitor-left',
+      'monitor-right',
+      'keyboard',
+      'mouse',
+    ]) {
+      expect(tokenplace.join(' ')).toContain(name);
+    }
+  });
+
+  it('builds finite, visible, noninteractive geometry at every detail level', () => {
+    for (const level of SCENE_DETAIL_LEVELS) {
+      const context = {
+        detailLevel: level,
+        detailPolicy: getSceneDetailPolicy(level),
+      };
+      for (const proxy of Object.values(POI_MINIATURE_PROXY_REGISTRY)) {
+        const { root } = buildMiniatureProxy(proxy, context);
+        expect(countObjectTriangles(root)).toBeGreaterThan(0);
+        root.traverse((object: Object3D) => {
+          expect(object.type).not.toMatch(/Light|Camera|Audio/);
+          expect(object.name).not.toMatch(
+            /collider|hit-area|label|badge|halo/i
+          );
+          expect(Number.isFinite(object.position.x)).toBe(true);
+          expect(Number.isFinite(object.position.y)).toBe(true);
+          expect(Number.isFinite(object.position.z)).toBe(true);
+        });
+      }
+    }
+  });
+
+  it('classifies current visible non-POI scene geometry sources', () => {
+    const classified = new Set<string>(
+      MINIATURE_SCENE_COMPONENT_COVERAGE.flatMap((entry) => [
+        ...entry.sourceFiles,
+      ])
+    );
+    for (const expected of [
+      'src/scene/level/portfolioLevel.ts',
+      'src/scene/environments/backyard.ts',
+      'src/scene/structures/staircase.ts',
+      'src/scene/lighting/ledStrips.ts',
+      'src/scene/avatar/mannequin.ts',
+    ]) {
+      expect(classified.has(expected)).toBe(true);
+    }
+  });
+
+  it('keeps proxy triangle totals decreasing across all five levels', () => {
+    const totals = SCENE_DETAIL_LEVELS.map((level) => {
+      const context = {
+        detailLevel: level,
+        detailPolicy: getSceneDetailPolicy(level),
+      };
+      return Object.values(POI_MINIATURE_PROXY_REGISTRY).reduce(
+        (sum, proxy) =>
+          sum + countObjectTriangles(buildMiniatureProxy(proxy, context).root),
+        0
+      );
+    });
+    expect(totals).toEqual([...totals].sort((a, b) => b - a));
+    for (let index = 1; index < totals.length; index += 1) {
+      expect(totals[index]).toBeLessThanOrEqual(totals[index - 1]);
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide reusable tabletop-miniature infrastructure: a richer internal detail system, deterministic miniature mapping, simple proxy builders, full POI proxy coverage, non-POI coverage inventory, and a manifest-based drift guard so miniature proxies stay in sync with overworld geometry.
- Preserve public behavior: keep the three public Graphics Quality options and avoid instantiating Low/Micro in the overworld while enabling two-level-lower miniature mapping.

### Description
- Add five ordered internal detail levels and rich policy metadata with helpers: `SCENE_DETAIL_LEVELS`, `SCENE_DETAIL_POLICIES`, `getMiniatureDetailLevel`, `stepSceneDetailLevelDown`, and `getMiniatureSceneDetailPolicy`. (src/scene/graphics/sceneDetailPolicy.ts)
- Implement a small typed miniature system: proxy types, deterministic primitive vocabulary, detail filtering, material cache, and a builder that produces visible, noninteractive Three.js geometry. (src/scene/miniature/types.ts, proxyBuilder.ts)
- Add a type-safe POI proxy registry covering every current `PoiId` including Sugarkube and token.place semantic pieces, and mark danielsmith.io as a recursion boundary (nonrecursive white-table). (src/scene/miniature/poiProxyRegistry.ts)
- Add a miniature scene-component coverage inventory classifying shared-source, proxy, and explicit exclusions for non-geometry runtime systems. (src/scene/miniature/sceneComponentRegistry.ts)
- Add a tokenized manifest/check script that tokenizes TypeScript source, produces fingerprints, enforces proxy coverage and ownership rules, and exposes `npm run miniature:manifest:update` and `npm run miniature:check`. Integrate the drift guard into CI. (scripts/miniature-manifest.ts, package.json, .github/workflows/02-tests.yml)
- Add focused Vitest tests validating detail ordering/mapping/monotonicity, proxy registry completeness and safety, and manifest semantics. (src/tests/miniatureDetailPolicy.test.ts, src/tests/miniatureProxyRegistry.test.ts, src/tests/miniatureManifest.test.ts)
- Small safety updates to Sugarkube and token.place detail settings so Low/Micro do not fall through to higher-detail branches. (src/scene/structures/sugarkubeDeployment.ts, src/scene/structures/tokenPlaceWorkstation.ts)

### Testing
- Ran manifest generation and check: `npm run miniature:manifest:update` then `npm run miniature:check` — succeeded and updated/validated `src/scene/miniature/miniatureManifest.generated.json`.
- Ran focused test suite as requested: `npm run test:ci -- src/tests/miniatureDetailPolicy.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/sugarkubeDeployment.test.ts src/tests/tokenPlaceWorkstation.test.ts src/tests/poiModelTriangles.test.ts src/tests/performanceOptimization.test.ts` — all tests passed (54 tests across the requested suites).
- Lint, build, and format checks: `npm run lint` (no blocking errors, warnings only), `npm run build` (success), `npm run format:check` (success).
- Typecheck: `npm run typecheck` shows repository-wide baseline diagnostics unrelated to this change; I executed a targeted validation to confirm that no new TypeScript diagnostics were introduced by the miniature files (no errors matching `miniature|sceneDetailPolicy|tokenPlaceWorkstation|sugarkubeDeployment`).

Notes and follow-ups
- This PR provides the infrastructure only; Prompt 4b will consume these primitives to build/place the white table, miniature house, and live miniature player as requested by the original plan.
- The manifest enforces intentional `syncRevision` bumps for source-only changes; follow the manifest flow (`miniature:manifest:update`) when updating proxies after changing source geometry.
- Files changed/added include: scene detail policy, miniature types/registry/builder/scene-coverage, the manifest script and generated manifest, tests, and CI/script wiring (see diff for full list).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b9706aab4832fba8d515dc6277662)