### PR TITLE
Add miniature proxy infra and five-level scene detail policy

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -18,6 +18,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Miniature proxy sync guard
+        run: npm run miniature:check
       - name: Unit tests
         run: npm run test:ci
       - name: Install Playwright browser for collider audits

--- a/data/miniature/source-manifest.json
+++ b/data/miniature/source-manifest.json
@@ -1,0 +1,180 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "axel-studio-tracker",
+      "sourceHash": "290e407dc801b92e2c52d79a22870a5dfcf94cab52d10bf1272e69199c4c5b13",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "backyard-bounds-environment",
+      "sourceHash": "1954dd519b2e7e8e2b2de797eefdce8ed73bc5a857101d8810caad00b185af06",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Backyard terrain, path, fence, shrubs, and fixtures require simplified non-POI proxies."
+    },
+    {
+      "id": "ceiling-panels-and-floor-tiles",
+      "sourceHash": "26de54452e417b07e1231fd8a16a0b78271474beb8e93310583d0fa7566970f9",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Generated from shared house surface data where miniature floors and cutouts are built."
+    },
+    {
+      "id": "danielsmith-portfolio-table",
+      "sourceHash": "21daf5e0a2d41f9b2f595bca1f71c7b9477bf334173beea69e92020fc213cfeb",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Recursion boundary: nonrecursive white-table proxy only."
+    },
+    {
+      "id": "dspace-backyard-rocket",
+      "sourceHash": "71dce294e811ccf46b63e560f2be2ca8d0324e45dbf2853e13cc1e55e3626264",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "f2clipboard-kitchen-console",
+      "sourceHash": "3c6faf02c77237947ad80ea78315cb01b76a74ef4bda2f91fafc7d24a4638cca",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "flywheel-studio-flywheel",
+      "sourceHash": "bc8e689238b697030298b8acb5a488f406a017ee65a0c341867027f84d5f71fb",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "futuroptimist-living-room-tv",
+      "sourceHash": "65c014e5fafc9667f0890dd8a0ff9864f57d17da2bdcb04128d1d7f9ed866231",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "gabriel-studio-sentry",
+      "sourceHash": "e59debf5414bfe6863d71ea8b2b73a42663af4f7c2bd0da03676cb0e192684e0",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "gitshelves-living-room-installation",
+      "sourceHash": "9fac025a30dac6971f223e425e5bcc62672cd97f0494a34463e52392c3b332b5",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "greenhouse-environment-structure",
+      "sourceHash": "f28a6a4dddb3b5f6cafb3f9b1151b2158c154757bdbcc0774d562255ca874d36",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Visible greenhouse shell receives a simplified miniature proxy."
+    },
+    {
+      "id": "house-topology-floors-rooms-walls-doors",
+      "sourceHash": "91a264472154e7fb142e2d097762fc8fbfb7df825d1c35550c8a930843ca7e27",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Prompt 4b generates floor slabs, room bounds, walls, and door openings from shared topology."
+    },
+    {
+      "id": "jobbot-studio-terminal",
+      "sourceHash": "ae59aa75ceacb0cf497fa8126f25f7a6233120e40d9f8bf6c2c8fe90539c8afb",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "media-wall-star-bridge",
+      "sourceHash": "12623cffaa92a13d72effe59fecbd0106c8ca58e603560da12e879607030a682",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Decorative star bridge represented as simplified accent rails."
+    },
+    {
+      "id": "multiplayer-projection-decor",
+      "sourceHash": "b9c9517d85a174c8e0edb931b53ae0cf0c4ace6b7f9f8553aa649b9d03bbce5d",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Visible projection dais/screen represented by noninteractive proxy geometry."
+    },
+    {
+      "id": "poi-markers-and-labels",
+      "sourceHash": "80a64d1c4a7012d40a8a541ed5568e98fdd193fd7157eeba0d16f7610e9f4c0c",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "POI orbs, halos, labels, badges, hit areas, and tooltips are interaction UI, not miniature geometry."
+    },
+    {
+      "id": "pr-reaper-backyard-console",
+      "sourceHash": "5ade14ba1f5f3e09222eac35fdef9399b620e1075403e643b8bf7a045d5a4f56",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "selfie-mirror-decor",
+      "sourceHash": "53b44278acbbd73bb96a7dcf2a45968a100c0cc70265c0b285f31e2df05257be",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Visible mirror fixture represented by a static miniature proxy."
+    },
+    {
+      "id": "sigma-kitchen-workbench",
+      "sourceHash": "c09064e7063f31f024da5c8fe45de457f4078129f064ea5cd2be3732a9d4384f",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "staircase-upper-landing",
+      "sourceHash": "07f0069c7003c8ea58092b5ce558ab62b987ed92d92a964963e7b6b069cbef93",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Miniature staircase and landing are generated from shared stair builder dimensions."
+    },
+    {
+      "id": "sugarkube-backyard-greenhouse",
+      "sourceHash": "7f8357815daa8cadc05a110e3004a3efa2baa8c68b4c9fc63d15f6b6d6bb3ecc",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "tokenplace-studio-cluster",
+      "sourceHash": "e209e731eda4e0c3e6204151f16c4afb96fd22213b789acc822c5612e0319e47",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    },
+    {
+      "id": "visible-avatar",
+      "sourceHash": "f2bd7f9306faea9e92e99914d25be6ef8f72e8851fcec28a424ec03b0765d002",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Excluded because Prompt 4b will add a dedicated live miniature avatar."
+    },
+    {
+      "id": "visible-lighting-fixtures",
+      "sourceHash": "b1adb0c3116e791d69893ed49af1a8bacd2f925aa954990042fabbe74b5412ad",
+      "proxyHash": "557b88d3a68f2a3f46aef3736deae392369162e300952ba41f5027e1272cd3f3",
+      "syncRevision": 1,
+      "syncNote": "Visible LED strips are represented as simplified fixture strips; light objects themselves are excluded."
+    },
+    {
+      "id": "wove-kitchen-loom",
+      "sourceHash": "04c8c701b6e8fddb364e62f3025ad0fc517dfa499a1e0c86e90acc99f66b0a59",
+      "proxyHash": "b1c6d2871e09cabde4724e6501ab64b58fb12efe950651cbc83d6af5b52cc46d",
+      "syncRevision": 1,
+      "syncNote": "Initial miniature proxy coverage."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:check": "node scripts/check-docs.cjs && npm run links:check",
     "smoke": "npm run build && node scripts/assert-dist.cjs",
     "press-kit": "tsx scripts/generate-press-kit.ts",
-    "check": "npm run lint && npm run test:ci && npm run docs:check",
+    "check": "npm run lint && npm run miniature:check && npm run test:ci && npm run docs:check",
     "floorplan:diagram": "tsx scripts/generate-floorplan-diagram.ts",
     "favicon": "tsx scripts/generate-favicon.ts",
     "test:e2e": "playwright test",
@@ -27,7 +27,9 @@
     "collider:inspect": "tsx scripts/colliderInspect.ts",
     "collider:audit:geometry": "tsx scripts/colliderGeometryAudit.ts",
     "collider:audit:reachability": "tsx scripts/colliderReachabilityAudit.ts",
-    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts"
+    "collider:audit:redundancy": "tsx scripts/colliderRedundancyGate.ts",
+    "miniature:manifest:update": "tsx scripts/miniature-manifest.ts update",
+    "miniature:check": "tsx scripts/miniature-manifest.ts check"
   },
   "dependencies": {
     "stats.js": "^0.17.0",

--- a/scripts/miniature-manifest.ts
+++ b/scripts/miniature-manifest.ts
@@ -1,0 +1,149 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { relative } from 'node:path';
+import ts from 'typescript';
+import { MINIATURE_POI_PROXY_ENTRIES } from '../src/scene/miniature/poiProxyRegistry';
+import { MINIATURE_SCENE_COMPONENT_COVERAGE } from '../src/scene/miniature/sceneComponentRegistry';
+import { getPoiDefinitions } from '../src/scene/poi/registry';
+
+const MANIFEST = 'data/miniature/source-manifest.json';
+export interface MiniatureManifestEntry {
+  id: string;
+  sourceHash: string;
+  proxyHash: string;
+  syncRevision: number;
+  syncNote?: string;
+}
+export interface MiniatureManifest {
+  version: 1;
+  entries: MiniatureManifestEntry[];
+}
+
+export function normalizedTypeScriptTokens(source: string): string {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    true,
+    ts.LanguageVariant.Standard,
+    source
+  );
+  const tokens: string[] = [];
+  for (
+    let kind = scanner.scan();
+    kind !== ts.SyntaxKind.EndOfFileToken;
+    kind = scanner.scan()
+  ) {
+    tokens.push(`${ts.SyntaxKind[kind]}:${scanner.getTokenText()}`);
+  }
+  return tokens.join('\n');
+}
+
+function hashFiles(files: readonly string[]) {
+  const hash = createHash('sha256');
+  for (const file of files) {
+    if (!existsSync(file))
+      throw new Error(`Missing miniature sync file: ${file}`);
+    hash.update(file);
+    hash.update('\0');
+    hash.update(normalizedTypeScriptTokens(readFileSync(file, 'utf8')));
+  }
+  return hash.digest('hex');
+}
+
+function assertRegistry() {
+  const pois = getPoiDefinitions()
+    .map((p) => p.id)
+    .sort();
+  const proxies = MINIATURE_POI_PROXY_ENTRIES.map((p) => p.id).sort();
+  if (JSON.stringify(pois) !== JSON.stringify(proxies))
+    throw new Error(`POI/proxy mismatch: ${pois} vs ${proxies}`);
+  const seen = new Set<string>();
+  for (const entry of [
+    ...MINIATURE_POI_PROXY_ENTRIES,
+    ...MINIATURE_SCENE_COMPONENT_COVERAGE,
+  ]) {
+    if (seen.has(entry.id))
+      throw new Error(`Duplicate miniature registry id: ${entry.id}`);
+    seen.add(entry.id);
+    if (entry.syncRevision < 1)
+      throw new Error(`Invalid syncRevision for ${entry.id}`);
+    entry.sourceFiles.forEach((f) => {
+      if (!existsSync(f))
+        throw new Error(`Missing source file for ${entry.id}: ${f}`);
+    });
+    entry.proxyFiles.forEach((f) => {
+      if (!existsSync(f))
+        throw new Error(`Missing proxy file for ${entry.id}: ${f}`);
+    });
+  }
+  const self = MINIATURE_POI_PROXY_ENTRIES.find(
+    (p) => p.id === 'danielsmith-portfolio-table'
+  );
+  if (!self?.recursionBoundary)
+    throw new Error(
+      'danielsmith-portfolio-table proxy must be a recursion boundary'
+    );
+}
+
+export function buildManifest(): MiniatureManifest {
+  assertRegistry();
+  const all = [
+    ...MINIATURE_POI_PROXY_ENTRIES,
+    ...MINIATURE_SCENE_COMPONENT_COVERAGE,
+  ];
+  return {
+    version: 1,
+    entries: all
+      .map((entry) => ({
+        id: entry.id,
+        sourceHash: hashFiles(entry.sourceFiles),
+        proxyHash: hashFiles(entry.proxyFiles),
+        syncRevision: entry.syncRevision,
+        syncNote: entry.syncNote,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+export function validateSourceChangeAcknowledged(
+  oldEntry: MiniatureManifestEntry,
+  nextEntry: MiniatureManifestEntry
+): boolean {
+  if (oldEntry.sourceHash === nextEntry.sourceHash) return true;
+  return (
+    oldEntry.proxyHash !== nextEntry.proxyHash ||
+    oldEntry.syncRevision !== nextEntry.syncRevision
+  );
+}
+
+export function checkManifest() {
+  const next = buildManifest();
+  if (!existsSync(MANIFEST))
+    throw new Error(`Missing manifest: run npm run miniature:manifest:update`);
+  const old = JSON.parse(readFileSync(MANIFEST, 'utf8')) as MiniatureManifest;
+  const oldById = new Map(old.entries.map((entry) => [entry.id, entry]));
+  for (const entry of next.entries) {
+    const previous = oldById.get(entry.id);
+    if (previous && !validateSourceChangeAcknowledged(previous, entry))
+      throw new Error(
+        `Source changed for ${entry.id} without proxy update or syncRevision bump.`
+      );
+  }
+  const expected = JSON.stringify(next, null, 2) + '\n';
+  const actual = readFileSync(MANIFEST, 'utf8');
+  if (actual !== expected)
+    throw new Error(
+      `Miniature manifest is stale: run npm run miniature:manifest:update`
+    );
+}
+
+if (
+  process.argv[1]?.endsWith(
+    relative(process.cwd(), import.meta.url.replace('file://', ''))
+  )
+) {
+  // noop for path quirks
+}
+const command = process.argv[2];
+if (command === 'update')
+  writeFileSync(MANIFEST, JSON.stringify(buildManifest(), null, 2) + '\n');
+else if (command === 'check') checkManifest();

--- a/src/scene/graphics/sceneDetailPolicy.ts
+++ b/src/scene/graphics/sceneDetailPolicy.ts
@@ -1,9 +1,20 @@
 import type { GraphicsQualityLevel } from './qualityManager';
 
-export type SceneDetailLevel = GraphicsQualityLevel;
+export const SCENE_DETAIL_LEVELS = [
+  'cinematic',
+  'balanced',
+  'performance',
+  'low',
+  'micro',
+] as const;
+
+export type SceneDetailLevel = (typeof SCENE_DETAIL_LEVELS)[number];
+export type OverworldSceneDetailLevel = GraphicsQualityLevel;
 
 export interface SceneDetailPolicy {
   level: SceneDetailLevel;
+  detailIndex: number;
+  modelDetailScale: number;
   geometry: {
     cylinderSegments: number;
     sphereWidthSegments: number;
@@ -15,6 +26,7 @@ export interface SceneDetailPolicy {
   };
   textures: {
     canvasScale: number;
+    maxTextureSize: number;
     jobbotScreen: { width: number; height: number };
     jobbotTelemetry: { width: number; height: number };
     mediaWallScreen: { width: number; height: number };
@@ -36,6 +48,8 @@ export interface SceneDetailPolicy {
     skipUnfocusedDecorations: boolean;
   };
   budgets: {
+    triangleHint: number;
+    drawCallHint: number;
     transparentShaderLayers: number;
     dynamicPointLights: number;
     decorativeDrawCalls: number;
@@ -44,50 +58,47 @@ export interface SceneDetailPolicy {
   };
 }
 
-const HIGH_DETAIL_GEOMETRY = {
-  cylinderSegments: 48,
-  sphereWidthSegments: 32,
-  sphereHeightSegments: 32,
-  ringSegments: 64,
-  torusRadialSegments: 24,
-  torusTubularSegments: 64,
-  terrainSegments: 24,
-} as const;
-
-const HIGH_DETAIL_TEXTURES = {
-  canvasScale: 1,
-  jobbotScreen: { width: 2048, height: 1024 },
-  jobbotTelemetry: { width: 1024, height: 512 },
-  mediaWallScreen: { width: 2048, height: 1024 },
-  mediaWallBadge: { width: 512, height: 256 },
-} as const;
-
-const HIGH_DETAIL_EFFECTS = {
-  transparentShaders: true,
-  mist: true,
-  pondRippleShader: true,
-  glassTransmission: true,
-  decorativeHalos: true,
-  telemetryPanels: true,
-  decorativeShards: true,
-  dynamicPointLights: true,
-} as const;
-
-export const SCENE_DETAIL_POLICIES: Record<
+const POLICY_DATA: Record<
   SceneDetailLevel,
-  SceneDetailPolicy
+  Omit<SceneDetailPolicy, 'level' | 'detailIndex'>
 > = {
   cinematic: {
-    level: 'cinematic',
-    geometry: HIGH_DETAIL_GEOMETRY,
-    textures: HIGH_DETAIL_TEXTURES,
-    effects: HIGH_DETAIL_EFFECTS,
+    modelDetailScale: 1,
+    geometry: {
+      cylinderSegments: 48,
+      sphereWidthSegments: 32,
+      sphereHeightSegments: 32,
+      ringSegments: 64,
+      torusRadialSegments: 24,
+      torusTubularSegments: 64,
+      terrainSegments: 24,
+    },
+    textures: {
+      canvasScale: 1,
+      maxTextureSize: 2048,
+      jobbotScreen: { width: 2048, height: 1024 },
+      jobbotTelemetry: { width: 1024, height: 512 },
+      mediaWallScreen: { width: 2048, height: 1024 },
+      mediaWallBadge: { width: 512, height: 256 },
+    },
+    effects: {
+      transparentShaders: true,
+      mist: true,
+      pondRippleShader: true,
+      glassTransmission: true,
+      decorativeHalos: true,
+      telemetryPanels: true,
+      decorativeShards: true,
+      dynamicPointLights: true,
+    },
     updates: {
       decorativeThrottleMs: 0,
       canvasRedrawThrottleMs: 0,
       skipUnfocusedDecorations: false,
     },
     budgets: {
+      triangleHint: 120000,
+      drawCallHint: 900,
       transparentShaderLayers: 8,
       dynamicPointLights: 12,
       decorativeDrawCalls: 160,
@@ -96,25 +107,51 @@ export const SCENE_DETAIL_POLICIES: Record<
     },
   },
   balanced: {
-    level: 'balanced',
-    geometry: HIGH_DETAIL_GEOMETRY,
-    textures: HIGH_DETAIL_TEXTURES,
-    effects: HIGH_DETAIL_EFFECTS,
+    modelDetailScale: 0.5,
+    geometry: {
+      cylinderSegments: 48,
+      sphereWidthSegments: 32,
+      sphereHeightSegments: 32,
+      ringSegments: 64,
+      torusRadialSegments: 24,
+      torusTubularSegments: 64,
+      terrainSegments: 24,
+    },
+    textures: {
+      canvasScale: 1,
+      maxTextureSize: 2048,
+      jobbotScreen: { width: 2048, height: 1024 },
+      jobbotTelemetry: { width: 1024, height: 512 },
+      mediaWallScreen: { width: 2048, height: 1024 },
+      mediaWallBadge: { width: 512, height: 256 },
+    },
+    effects: {
+      transparentShaders: true,
+      mist: true,
+      pondRippleShader: true,
+      glassTransmission: true,
+      decorativeHalos: true,
+      telemetryPanels: true,
+      decorativeShards: true,
+      dynamicPointLights: true,
+    },
     updates: {
       decorativeThrottleMs: 0,
       canvasRedrawThrottleMs: 0,
       skipUnfocusedDecorations: false,
     },
     budgets: {
-      transparentShaderLayers: 8,
-      dynamicPointLights: 12,
-      decorativeDrawCalls: 160,
-      poiTriangleScale: 1,
-      structureTriangleScale: 1,
+      triangleHint: 60000,
+      drawCallHint: 450,
+      transparentShaderLayers: 6,
+      dynamicPointLights: 8,
+      decorativeDrawCalls: 96,
+      poiTriangleScale: 0.5,
+      structureTriangleScale: 0.5,
     },
   },
   performance: {
-    level: 'performance',
+    modelDetailScale: 0.25,
     geometry: {
       cylinderSegments: 8,
       sphereWidthSegments: 8,
@@ -126,6 +163,7 @@ export const SCENE_DETAIL_POLICIES: Record<
     },
     textures: {
       canvasScale: 0.25,
+      maxTextureSize: 512,
       jobbotScreen: { width: 512, height: 256 },
       jobbotTelemetry: { width: 256, height: 128 },
       mediaWallScreen: { width: 512, height: 256 },
@@ -147,14 +185,141 @@ export const SCENE_DETAIL_POLICIES: Record<
       skipUnfocusedDecorations: true,
     },
     budgets: {
+      triangleHint: 30000,
+      drawCallHint: 225,
       transparentShaderLayers: 0,
       dynamicPointLights: 1,
       decorativeDrawCalls: 24,
-      poiTriangleScale: 0.12,
-      structureTriangleScale: 0.18,
+      poiTriangleScale: 0.25,
+      structureTriangleScale: 0.25,
+    },
+  },
+  low: {
+    modelDetailScale: 0.125,
+    geometry: {
+      cylinderSegments: 6,
+      sphereWidthSegments: 6,
+      sphereHeightSegments: 4,
+      ringSegments: 8,
+      torusRadialSegments: 4,
+      torusTubularSegments: 8,
+      terrainSegments: 2,
+    },
+    textures: {
+      canvasScale: 0.125,
+      maxTextureSize: 256,
+      jobbotScreen: { width: 256, height: 128 },
+      jobbotTelemetry: { width: 128, height: 64 },
+      mediaWallScreen: { width: 256, height: 128 },
+      mediaWallBadge: { width: 128, height: 64 },
+    },
+    effects: {
+      transparentShaders: false,
+      mist: false,
+      pondRippleShader: false,
+      glassTransmission: false,
+      decorativeHalos: false,
+      telemetryPanels: false,
+      decorativeShards: false,
+      dynamicPointLights: false,
+    },
+    updates: {
+      decorativeThrottleMs: 500,
+      canvasRedrawThrottleMs: 1500,
+      skipUnfocusedDecorations: true,
+    },
+    budgets: {
+      triangleHint: 15000,
+      drawCallHint: 112,
+      transparentShaderLayers: 0,
+      dynamicPointLights: 0,
+      decorativeDrawCalls: 12,
+      poiTriangleScale: 0.125,
+      structureTriangleScale: 0.125,
+    },
+  },
+  micro: {
+    modelDetailScale: 0.0625,
+    geometry: {
+      cylinderSegments: 3,
+      sphereWidthSegments: 4,
+      sphereHeightSegments: 3,
+      ringSegments: 3,
+      torusRadialSegments: 3,
+      torusTubularSegments: 6,
+      terrainSegments: 1,
+    },
+    textures: {
+      canvasScale: 0.0625,
+      maxTextureSize: 128,
+      jobbotScreen: { width: 128, height: 64 },
+      jobbotTelemetry: { width: 64, height: 32 },
+      mediaWallScreen: { width: 128, height: 64 },
+      mediaWallBadge: { width: 64, height: 32 },
+    },
+    effects: {
+      transparentShaders: false,
+      mist: false,
+      pondRippleShader: false,
+      glassTransmission: false,
+      decorativeHalos: false,
+      telemetryPanels: false,
+      decorativeShards: false,
+      dynamicPointLights: false,
+    },
+    updates: {
+      decorativeThrottleMs: 1000,
+      canvasRedrawThrottleMs: 2500,
+      skipUnfocusedDecorations: true,
+    },
+    budgets: {
+      triangleHint: 7500,
+      drawCallHint: 56,
+      transparentShaderLayers: 0,
+      dynamicPointLights: 0,
+      decorativeDrawCalls: 6,
+      poiTriangleScale: 0.0625,
+      structureTriangleScale: 0.0625,
     },
   },
 };
+
+export const SCENE_DETAIL_POLICIES = Object.fromEntries(
+  SCENE_DETAIL_LEVELS.map((level, detailIndex) => [
+    level,
+    { level, detailIndex, ...POLICY_DATA[level] },
+  ])
+) as Record<SceneDetailLevel, SceneDetailPolicy>;
+
+export function mapGraphicsQualityToOverworldDetailLevel(
+  level: GraphicsQualityLevel
+): OverworldSceneDetailLevel {
+  return level;
+}
+
+export function stepSceneDetailLevel(
+  level: SceneDetailLevel,
+  steps: number
+): SceneDetailLevel {
+  const index = SCENE_DETAIL_LEVELS.indexOf(level);
+  const next = Math.min(
+    SCENE_DETAIL_LEVELS.length - 1,
+    Math.max(0, index + steps)
+  );
+  return SCENE_DETAIL_LEVELS[next];
+}
+
+export function getMiniatureDetailLevel(
+  level: SceneDetailLevel
+): SceneDetailLevel {
+  return stepSceneDetailLevel(level, 2);
+}
+
+export function getMiniatureSceneDetailPolicy(
+  level: SceneDetailLevel
+): SceneDetailPolicy {
+  return getSceneDetailPolicy(getMiniatureDetailLevel(level));
+}
 
 export function getSceneDetailPolicy(
   level: SceneDetailLevel
@@ -184,14 +349,9 @@ export function createSceneDetailController(
   let level = initialLevel;
   let policy = getSceneDetailPolicy(level);
   const lastDecorativeUpdateMsByChannel = new Map<string, number>();
-
   return {
-    getLevel() {
-      return level;
-    },
-    getPolicy() {
-      return policy;
-    },
+    getLevel: () => level,
+    getPolicy: () => policy,
     setLevel(nextLevel) {
       level = nextLevel;
       policy = getSceneDetailPolicy(nextLevel);
@@ -201,34 +361,20 @@ export function createSceneDetailController(
       emphasis = 0,
       channel = 'default'
     ) {
-      if (policy.updates.decorativeThrottleMs <= 0) {
-        return true;
-      }
+      if (policy.updates.decorativeThrottleMs <= 0) return true;
       if (
         policy.updates.skipUnfocusedDecorations &&
         Math.max(0, emphasis) < 0.02
-      ) {
+      )
         return false;
-      }
       const elapsedMs = elapsedSeconds * 1000;
-      const lastDecorativeUpdateMs =
+      const last =
         lastDecorativeUpdateMsByChannel.get(channel) ??
         Number.NEGATIVE_INFINITY;
-      if (
-        elapsedMs - lastDecorativeUpdateMs <
-        policy.updates.decorativeThrottleMs
-      ) {
-        return false;
-      }
+      if (elapsedMs - last < policy.updates.decorativeThrottleMs) return false;
       lastDecorativeUpdateMsByChannel.set(channel, elapsedMs);
       return true;
     },
-    getSnapshot() {
-      return {
-        level,
-        policy,
-        theoreticalBudget: policy.budgets,
-      };
-    },
+    getSnapshot: () => ({ level, policy, theoreticalBudget: policy.budgets }),
   };
 }

--- a/src/scene/miniature/catalog.ts
+++ b/src/scene/miniature/catalog.ts
@@ -1,0 +1,30 @@
+import { Group } from 'three';
+import {
+  SCENE_DETAIL_LEVELS,
+  getSceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+import { countObjectTriangles } from '../structures/triangleCount';
+import { MINIATURE_POI_PROXY_ENTRIES } from './poiProxyRegistry';
+import { buildMiniatureProxy } from './proxyBuilder';
+
+import type { SceneDetailLevel } from '../graphics/sceneDetailPolicy';
+
+export function buildMiniatureProxyCatalog(
+  level: SceneDetailLevel = 'balanced'
+): Group {
+  const group = new Group();
+  const detailPolicy = getSceneDetailPolicy(level);
+  MINIATURE_POI_PROXY_ENTRIES.forEach((entry) =>
+    group.add(buildMiniatureProxy(entry, { detailPolicy }))
+  );
+  return group;
+}
+
+export function getMiniatureProxyTriangleCounts(): Record<string, number> {
+  return Object.fromEntries(
+    SCENE_DETAIL_LEVELS.map((level) => [
+      level,
+      countObjectTriangles(buildMiniatureProxyCatalog(level)),
+    ])
+  );
+}

--- a/src/scene/miniature/detailPolicy.ts
+++ b/src/scene/miniature/detailPolicy.ts
@@ -1,0 +1,5 @@
+export {
+  getMiniatureDetailLevel,
+  getMiniatureSceneDetailPolicy,
+  stepSceneDetailLevel,
+} from '../graphics/sceneDetailPolicy';

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -1,0 +1,330 @@
+import type { PoiId } from '../poi/types';
+import { buildMiniatureProxy } from './proxyBuilder';
+import type {
+  MiniaturePart,
+  MiniatureProxyDefinition,
+  MiniatureBuildOptions,
+} from './types';
+
+const proxyFile = 'src/scene/miniature/poiProxyRegistry.ts';
+const part = (
+  name: string,
+  kind: MiniaturePart['kind'],
+  material: MiniaturePart['material'],
+  extra: Partial<MiniaturePart> = {}
+): MiniaturePart => ({ name, kind, material, ...extra });
+const generic = (
+  id: PoiId,
+  sourceFiles: string[],
+  icon: MiniaturePart[]
+): MiniatureProxyDefinition => ({
+  id,
+  label: id,
+  sourceFiles,
+  proxyFiles: [proxyFile],
+  syncRevision: 1,
+  syncNote: 'Initial miniature proxy coverage.',
+  parts: [
+    part('base-plinth', 'box', 'base', {
+      size: [1.4, 0.1, 1],
+      color: 0x293241,
+    }),
+    ...icon,
+  ],
+});
+
+export const MINIATURE_POI_PROXY_REGISTRY = {
+  'futuroptimist-living-room-tv': generic(
+    'futuroptimist-living-room-tv',
+    ['src/scene/structures/mediaWall.ts'],
+    [
+      part('tv-screen', 'box', 'screen', {
+        size: [1.2, 0.55, 0.06],
+        position: [0, 0.45, 0],
+        color: 0x101820,
+      }),
+      part('soundbar', 'box', 'accent', {
+        size: [0.8, 0.08, 0.08],
+        position: [0, 0.17, 0.35],
+        color: 0x5acbff,
+      }),
+    ]
+  ),
+  'flywheel-studio-flywheel': generic(
+    'flywheel-studio-flywheel',
+    ['src/scene/structures/flywheel.ts'],
+    [
+      part('flywheel-ring', 'ring', 'accent', {
+        innerRadius: 0.32,
+        outerRadius: 0.44,
+        position: [0, 0.55, 0],
+        rotation: [-Math.PI / 2, 0, 0],
+        color: 0x48ffd4,
+      }),
+      part('flywheel-axle', 'cylinder', 'metal', {
+        radius: 0.12,
+        height: 0.24,
+        position: [0, 0.55, 0],
+        color: 0xcfd8dc,
+      }),
+    ]
+  ),
+  'jobbot-studio-terminal': generic(
+    'jobbot-studio-terminal',
+    ['src/scene/structures/jobbotTerminal.ts'],
+    [
+      part('terminal-screen', 'box', 'screen', {
+        size: [0.95, 0.5, 0.05],
+        position: [0, 0.55, -0.18],
+        color: 0x6ee7ff,
+      }),
+      part('terminal-keyboard', 'box', 'accent', {
+        size: [0.8, 0.06, 0.35],
+        position: [0, 0.16, 0.28],
+        color: 0x222222,
+      }),
+    ]
+  ),
+  'dspace-backyard-rocket': generic(
+    'dspace-backyard-rocket',
+    ['src/scene/structures/modelRocket.ts'],
+    [
+      part('rocket-body', 'cylinder', 'white', {
+        radius: 0.18,
+        height: 1.05,
+        position: [0, 0.65, 0],
+        color: 0xf5f5f5,
+      }),
+      part('rocket-flame', 'cylinder', 'accent', {
+        radius: 0.12,
+        height: 0.24,
+        position: [0, 0.08, 0],
+        color: 0xff8a00,
+      }),
+    ]
+  ),
+  'sugarkube-backyard-greenhouse': generic(
+    'sugarkube-backyard-greenhouse',
+    ['src/scene/structures/sugarkubeDeployment.ts'],
+    [
+      part('sugarkube-table', 'box', 'wood', {
+        size: [1.1, 0.16, 0.75],
+        position: [0, 0.25, 0],
+        color: 0x6b3f21,
+      }),
+      part('sugarkube-switch', 'box', 'metal', {
+        size: [0.5, 0.12, 0.3],
+        position: [-0.25, 0.43, 0],
+        color: 0x15191d,
+      }),
+      part('sugarkube-yellow-three-tier-rack', 'box', 'accent', {
+        size: [0.55, 0.06, 0.35],
+        position: [0.28, 0.52, 0],
+        repeat: { count: 3, offset: [0, 0.17, 0] },
+        color: 0xf3c623,
+      }),
+      part('sugarkube-node', 'box', 'base', {
+        size: [0.16, 0.08, 0.12],
+        position: [0.1, 0.63, -0.18],
+        repeat: { count: 3, offset: [0.16, 0.02, 0.16] },
+        color: 0x2f80ed,
+      }),
+      part('sugarkube-cable-silhouette', 'tube', 'cable', {
+        points: [
+          [-0.25, 0.5, 0],
+          [0.32, 0.74, 0.22],
+        ],
+        radius: 0.018,
+        color: 0x111111,
+      }),
+    ]
+  ),
+  'tokenplace-studio-cluster': generic(
+    'tokenplace-studio-cluster',
+    ['src/scene/structures/tokenPlaceWorkstation.ts'],
+    [
+      part('tokenplace-desk', 'box', 'wood', {
+        size: [1.25, 0.12, 0.65],
+        position: [0, 0.32, 0],
+        color: 0x664022,
+      }),
+      part('tokenplace-pc-tower', 'box', 'metal', {
+        size: [0.28, 0.58, 0.38],
+        position: [-0.55, 0.42, 0.18],
+        color: 0x15191d,
+      }),
+      part('tokenplace-gaming-chair', 'cylinder', 'accent', {
+        radius: 0.22,
+        height: 0.45,
+        position: [0, 0.38, 0.72],
+        color: 0x8b1e3f,
+      }),
+      part('tokenplace-left-monitor', 'box', 'screen', {
+        size: [0.5, 0.32, 0.04],
+        position: [-0.27, 0.62, -0.24],
+        color: 0x39ff88,
+      }),
+      part('tokenplace-right-monitor', 'box', 'screen', {
+        size: [0.5, 0.32, 0.04],
+        position: [0.27, 0.62, -0.24],
+        color: 0x39ff88,
+      }),
+      part('tokenplace-keyboard', 'box', 'base', {
+        size: [0.55, 0.035, 0.18],
+        position: [0, 0.41, 0.08],
+        color: 0x222222,
+      }),
+      part('tokenplace-mouse', 'sphere', 'base', {
+        radius: 0.07,
+        position: [0.42, 0.43, 0.1],
+        color: 0x222222,
+      }),
+    ]
+  ),
+  'gabriel-studio-sentry': generic(
+    'gabriel-studio-sentry',
+    ['src/scene/structures/gabrielSentry.ts'],
+    [
+      part('sentry-body', 'cylinder', 'metal', {
+        radius: 0.28,
+        height: 0.9,
+        position: [0, 0.55, 0],
+        color: 0x607d8b,
+      }),
+      part('sentry-eye', 'sphere', 'accent', {
+        radius: 0.13,
+        position: [0, 0.82, -0.2],
+        color: 0xff3344,
+      }),
+    ]
+  ),
+  'f2clipboard-kitchen-console': generic(
+    'f2clipboard-kitchen-console',
+    ['src/scene/structures/f2ClipboardConsole.ts'],
+    [
+      part('clipboard-console', 'box', 'screen', {
+        size: [0.85, 0.45, 0.08],
+        position: [0, 0.5, 0],
+        color: 0x00d1ff,
+      }),
+      part('clipboard-sheet', 'plane', 'white', {
+        size: [0.4, 0, 0.55],
+        position: [0.32, 0.75, 0],
+        color: 0xffffff,
+      }),
+    ]
+  ),
+  'axel-studio-tracker': generic(
+    'axel-studio-tracker',
+    ['src/scene/structures/axelNavigator.ts'],
+    [
+      part('tracker-table', 'cylinder', 'wood', {
+        radius: 0.45,
+        height: 0.18,
+        position: [0, 0.28, 0],
+        color: 0x553311,
+      }),
+      part('tracker-ring', 'ring', 'accent', {
+        innerRadius: 0.22,
+        outerRadius: 0.34,
+        position: [0, 0.42, 0],
+        rotation: [-Math.PI / 2, 0, 0],
+        color: 0xffc857,
+      }),
+    ]
+  ),
+  'sigma-kitchen-workbench': generic(
+    'sigma-kitchen-workbench',
+    ['src/scene/structures/sigmaWorkbench.ts'],
+    [
+      part('sigma-bench', 'box', 'wood', {
+        size: [1.15, 0.16, 0.72],
+        position: [0, 0.28, 0],
+        color: 0x6d4c41,
+      }),
+      part('sigma-spool', 'ring', 'accent', {
+        innerRadius: 0.14,
+        outerRadius: 0.24,
+        position: [0.28, 0.48, 0],
+        rotation: [Math.PI / 2, 0, 0],
+        color: 0x80cbc4,
+      }),
+    ]
+  ),
+  'gitshelves-living-room-installation': generic(
+    'gitshelves-living-room-installation',
+    ['src/scene/structures/gitshelves.ts'],
+    [
+      part('gitshelves-case', 'box', 'wood', {
+        size: [0.95, 0.9, 0.25],
+        position: [0, 0.55, 0],
+        color: 0x4e342e,
+      }),
+      part('gitshelves-commit-block', 'box', 'accent', {
+        size: [0.16, 0.1, 0.12],
+        position: [-0.3, 0.45, 0],
+        repeat: { count: 4, offset: [0.2, 0.08, 0] },
+        color: 0x7e57c2,
+      }),
+    ]
+  ),
+  'wove-kitchen-loom': generic(
+    'wove-kitchen-loom',
+    ['src/scene/structures/woveLoom.ts'],
+    [
+      part('loom-frame', 'box', 'wood', {
+        size: [0.9, 0.75, 0.12],
+        position: [0, 0.55, 0],
+        color: 0x8d6e63,
+      }),
+      part('loom-thread', 'box', 'accent', {
+        size: [0.04, 0.65, 0.04],
+        position: [-0.3, 0.56, 0],
+        repeat: { count: 5, offset: [0.15, 0, 0] },
+        color: 0xff80ab,
+      }),
+    ]
+  ),
+  'pr-reaper-backyard-console': generic(
+    'pr-reaper-backyard-console',
+    ['src/scene/structures/prReaperConsole.ts'],
+    [
+      part('reaper-console', 'box', 'metal', {
+        size: [0.9, 0.4, 0.5],
+        position: [0, 0.35, 0],
+        color: 0x263238,
+      }),
+      part('reaper-scythe', 'tube', 'accent', {
+        points: [
+          [-0.35, 0.45, 0],
+          [0.35, 0.85, 0],
+        ],
+        radius: 0.02,
+        color: 0xe0e0e0,
+      }),
+    ]
+  ),
+  'danielsmith-portfolio-table': {
+    ...generic(
+      'danielsmith-portfolio-table',
+      ['src/main.ts'],
+      [
+        part('portfolio-nonrecursive-white-table', 'box', 'white', {
+          size: [1.05, 0.12, 0.72],
+          position: [0, 0.35, 0],
+          color: 0xffffff,
+        }),
+      ]
+    ),
+    recursionBoundary: true,
+    syncNote: 'Recursion boundary: nonrecursive white-table proxy only.',
+  },
+} satisfies Record<PoiId, MiniatureProxyDefinition>;
+
+export const MINIATURE_POI_PROXY_ENTRIES = Object.values(
+  MINIATURE_POI_PROXY_REGISTRY
+);
+export const buildPoiMiniatureProxy = (
+  id: PoiId,
+  options: MiniatureBuildOptions
+) => buildMiniatureProxy(MINIATURE_POI_PROXY_REGISTRY[id], options);

--- a/src/scene/miniature/proxyBuilder.ts
+++ b/src/scene/miniature/proxyBuilder.ts
@@ -1,0 +1,122 @@
+import {
+  BoxGeometry,
+  BufferGeometry,
+  CylinderGeometry,
+  Group,
+  LineCurve3,
+  Mesh,
+  MeshBasicMaterial,
+  PlaneGeometry,
+  RingGeometry,
+  SphereGeometry,
+  TubeGeometry,
+  Vector3,
+} from 'three';
+import { SCENE_DETAIL_LEVELS } from '../graphics/sceneDetailPolicy';
+import type {
+  MiniaturePart,
+  MiniatureProxyDefinition,
+  MiniatureBuildOptions,
+} from './types';
+
+const materials = new Map<string, MeshBasicMaterial>();
+function material(role: string, color = 0xdddddd) {
+  const key = `${role}:${color}`;
+  const cached = materials.get(key);
+  if (cached) return cached;
+  const mat = new MeshBasicMaterial({ color });
+  mat.name = `miniature-material-${role}`;
+  materials.set(key, mat);
+  return mat;
+}
+
+function included(part: MiniaturePart, level: string) {
+  const i = SCENE_DETAIL_LEVELS.indexOf(level as never);
+  const min = part.minDetail ? SCENE_DETAIL_LEVELS.indexOf(part.minDetail) : 0;
+  const max = part.maxDetail
+    ? SCENE_DETAIL_LEVELS.indexOf(part.maxDetail)
+    : SCENE_DETAIL_LEVELS.length - 1;
+  return i >= min && i <= max;
+}
+
+function geometry(part: MiniaturePart, seg: number): BufferGeometry {
+  switch (part.kind) {
+    case 'box':
+      return new BoxGeometry(...(part.size ?? [1, 1, 1]));
+    case 'plane':
+      return new PlaneGeometry(
+        part.size?.[0] ?? 1,
+        part.size?.[2] ?? part.size?.[1] ?? 1
+      );
+    case 'cylinder':
+      return new CylinderGeometry(
+        part.radius ?? 0.2,
+        part.radius ?? 0.2,
+        part.height ?? 1,
+        Math.max(3, seg)
+      );
+    case 'sphere':
+      return new SphereGeometry(
+        part.radius ?? 0.2,
+        Math.max(4, seg),
+        Math.max(3, Math.ceil(seg / 2))
+      );
+    case 'ring':
+      return new RingGeometry(
+        part.innerRadius ?? 0.2,
+        part.outerRadius ?? 0.3,
+        Math.max(3, seg)
+      );
+    case 'tube': {
+      const pts = (
+        part.points ?? [
+          [0, 0, 0],
+          [0, 0, 1],
+        ]
+      ).map((p) => new Vector3(...p));
+      return new TubeGeometry(
+        new LineCurve3(pts[0], pts[pts.length - 1]),
+        Math.max(1, Math.floor(seg / 2)),
+        part.radius ?? 0.025,
+        Math.max(3, Math.floor(seg / 2)),
+        false
+      );
+    }
+  }
+}
+
+export function buildMiniatureProxy(
+  definition: MiniatureProxyDefinition,
+  options: MiniatureBuildOptions
+): Group {
+  const group = new Group();
+  group.name = `miniature-poi-${definition.id}`;
+  group.userData.miniatureProxyId = definition.id;
+  group.userData.recursionBoundary = definition.recursionBoundary === true;
+  const level = options.detailPolicy.level;
+  const seg = Math.max(
+    3,
+    Math.round(48 * options.detailPolicy.modelDetailScale)
+  );
+  for (const part of definition.parts) {
+    if (!included(part, level)) continue;
+    const count = part.repeat?.count ?? 1;
+    for (let index = 0; index < count; index += 1) {
+      const mesh = new Mesh(
+        geometry(part, seg),
+        material(part.material, Number(part.color ?? 0xdddddd))
+      );
+      mesh.name = count > 1 ? `${part.name}-${index + 1}` : part.name;
+      const p = part.position ?? [0, 0, 0];
+      const o = part.repeat?.offset ?? [0, 0, 0];
+      mesh.position.set(
+        p[0] + o[0] * index,
+        p[1] + o[1] * index,
+        p[2] + o[2] * index
+      );
+      if (part.rotation) mesh.rotation.set(...part.rotation);
+      group.add(mesh);
+    }
+  }
+  return group;
+}

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -1,0 +1,138 @@
+export type MiniatureCoverageKind = 'shared-source' | 'proxy' | 'excluded';
+export interface MiniatureSceneComponentCoverage {
+  id: string;
+  kind: MiniatureCoverageKind;
+  sourceFiles: readonly string[];
+  proxyFiles: readonly string[];
+  syncRevision: number;
+  syncNote: string;
+}
+
+export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
+  {
+    id: 'house-topology-floors-rooms-walls-doors',
+    kind: 'shared-source',
+    sourceFiles: [
+      'src/scene/level/portfolioLevel.ts',
+      'src/scene/structures/wallSegmentsMesh.ts',
+      'src/scene/structures/doorwayOpenings.ts',
+    ],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'Prompt 4b generates floor slabs, room bounds, walls, and door openings from shared topology.',
+  },
+  {
+    id: 'staircase-upper-landing',
+    kind: 'shared-source',
+    sourceFiles: [
+      'src/scene/structures/staircase.ts',
+      'src/scene/structures/upperStairwellLanding.ts',
+    ],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'Miniature staircase and landing are generated from shared stair builder dimensions.',
+  },
+  {
+    id: 'backyard-bounds-environment',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/environments/backyard.ts'],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'Backyard terrain, path, fence, shrubs, and fixtures require simplified non-POI proxies.',
+  },
+
+  {
+    id: 'ceiling-panels-and-floor-tiles',
+    kind: 'shared-source',
+    sourceFiles: [
+      'src/scene/structures/ceilingPanels.ts',
+      'src/scene/structures/floorTiles.ts',
+      'src/scene/structures/upperLandingFloorCutouts.ts',
+    ],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'Generated from shared house surface data where miniature floors and cutouts are built.',
+  },
+  {
+    id: 'greenhouse-environment-structure',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/structures/greenhouse.ts'],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote: 'Visible greenhouse shell receives a simplified miniature proxy.',
+  },
+  {
+    id: 'multiplayer-projection-decor',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/structures/multiplayerProjection.ts'],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'Visible projection dais/screen represented by noninteractive proxy geometry.',
+  },
+  {
+    id: 'selfie-mirror-decor',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/structures/selfieMirror.ts'],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote: 'Visible mirror fixture represented by a static miniature proxy.',
+  },
+  {
+    id: 'media-wall-star-bridge',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/structures/mediaWallStarBridge.ts'],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote: 'Decorative star bridge represented as simplified accent rails.',
+  },
+  {
+    id: 'visible-avatar',
+    kind: 'excluded',
+    sourceFiles: ['src/scene/avatar/mannequin.ts'],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'Excluded because Prompt 4b will add a dedicated live miniature avatar.',
+  },
+  {
+    id: 'visible-lighting-fixtures',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/lighting/ledStrips.ts'],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'Visible LED strips are represented as simplified fixture strips; light objects themselves are excluded.',
+  },
+  {
+    id: 'poi-markers-and-labels',
+    kind: 'excluded',
+    sourceFiles: [
+      'src/scene/poi/markers.ts',
+      'src/scene/poi/worldTooltip.ts',
+      'src/scene/poi/visitedBadge.ts',
+    ],
+    proxyFiles: ['src/scene/miniature/sceneComponentRegistry.ts'],
+    syncRevision: 1,
+    syncNote:
+      'POI orbs, halos, labels, badges, hit areas, and tooltips are interaction UI, not miniature geometry.',
+  },
+] as const satisfies readonly MiniatureSceneComponentCoverage[];
+
+export const AUDITED_MINIATURE_SOURCE_DIRS = [
+  'src/scene/structures',
+  'src/scene/environments',
+  'src/scene/level',
+  'src/scene/avatar',
+  'src/scene/poi',
+  'src/scene/lighting',
+] as const;
+
+export const MINIATURE_EXCLUDED_SOURCE_FILES = [
+  'src/scene/structures/triangleCount.ts',
+  'src/scene/structures/colliderHelpers.ts',
+] as const;

--- a/src/scene/miniature/types.ts
+++ b/src/scene/miniature/types.ts
@@ -1,0 +1,60 @@
+import type { ColorRepresentation, Object3D } from 'three';
+import type {
+  SceneDetailLevel,
+  SceneDetailPolicy,
+} from '../graphics/sceneDetailPolicy';
+import type { PoiId } from '../poi/types';
+
+export type MiniatureMaterialRole =
+  | 'base'
+  | 'accent'
+  | 'screen'
+  | 'metal'
+  | 'glass'
+  | 'wood'
+  | 'cable'
+  | 'plant'
+  | 'white';
+export type MiniaturePrimitiveKind =
+  | 'box'
+  | 'plane'
+  | 'cylinder'
+  | 'sphere'
+  | 'ring'
+  | 'tube';
+
+export interface MiniaturePart {
+  kind: MiniaturePrimitiveKind;
+  name: string;
+  material: MiniatureMaterialRole;
+  color?: ColorRepresentation;
+  size?: [number, number, number];
+  radius?: number;
+  innerRadius?: number;
+  outerRadius?: number;
+  height?: number;
+  points?: [number, number, number][];
+  position?: [number, number, number];
+  rotation?: [number, number, number];
+  minDetail?: SceneDetailLevel;
+  maxDetail?: SceneDetailLevel;
+  repeat?: { count: number; offset: [number, number, number] };
+}
+
+export interface MiniatureProxyDefinition {
+  id: PoiId;
+  label: string;
+  recursionBoundary?: boolean;
+  parts: readonly MiniaturePart[];
+  sourceFiles: readonly string[];
+  proxyFiles: readonly string[];
+  syncRevision: number;
+  syncNote?: string;
+}
+
+export interface MiniatureBuildOptions {
+  detailPolicy: SceneDetailPolicy;
+}
+export type MiniatureProxyBuilder = (
+  options: MiniatureBuildOptions
+) => Object3D;

--- a/src/scene/structures/tokenPlaceWorkstation.ts
+++ b/src/scene/structures/tokenPlaceWorkstation.ts
@@ -129,6 +129,30 @@ const DETAIL_CONFIG: Record<SceneDetailPolicy['level'], DetailConfig> = {
     pcVentCount: 2,
     wheelCount: 3,
   },
+  low: {
+    level: 'low',
+    terminalWidth: 128,
+    terminalHeight: 64,
+    redrawFps: 2,
+    monitorSegments: 4,
+    chairSegments: 4,
+    keyRows: 1,
+    keyColumns: 3,
+    pcVentCount: 1,
+    wheelCount: 0,
+  },
+  micro: {
+    level: 'micro',
+    terminalWidth: 64,
+    terminalHeight: 32,
+    redrawFps: 1,
+    monitorSegments: 3,
+    chairSegments: 3,
+    keyRows: 1,
+    keyColumns: 2,
+    pcVentCount: 0,
+    wheelCount: 0,
+  },
 };
 
 function mulberry32(seed: number): () => number {

--- a/src/tests/miniatureDetailPolicy.test.ts
+++ b/src/tests/miniatureDetailPolicy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { GRAPHICS_QUALITY_PRESETS } from '../scene/graphics/qualityManager';
+import {
+  SCENE_DETAIL_LEVELS,
+  getMiniatureDetailLevel,
+  getMiniatureSceneDetailPolicy,
+  getSceneDetailPolicy,
+  mapGraphicsQualityToOverworldDetailLevel,
+  stepSceneDetailLevel,
+} from '../scene/graphics/sceneDetailPolicy';
+
+describe('miniature detail policy', () => {
+  it('keeps five internal levels and three public qualities', () => {
+    expect(SCENE_DETAIL_LEVELS).toEqual([
+      'cinematic',
+      'balanced',
+      'performance',
+      'low',
+      'micro',
+    ]);
+    expect(GRAPHICS_QUALITY_PRESETS.map((p) => p.id)).toEqual([
+      'cinematic',
+      'balanced',
+      'performance',
+    ]);
+  });
+  it('maps public overworld levels two steps down for miniatures', () => {
+    expect(mapGraphicsQualityToOverworldDetailLevel('cinematic')).toBe(
+      'cinematic'
+    );
+    expect(getMiniatureDetailLevel('cinematic')).toBe('performance');
+    expect(getMiniatureDetailLevel('balanced')).toBe('low');
+    expect(getMiniatureDetailLevel('performance')).toBe('micro');
+    expect(stepSceneDetailLevel('performance', 99)).toBe('micro');
+    expect(getMiniatureSceneDetailPolicy('balanced').level).toBe('low');
+  });
+  it('decreases policy budgets monotonically and keeps primitives constructible', () => {
+    const policies = SCENE_DETAIL_LEVELS.map(getSceneDetailPolicy);
+    for (let index = 1; index < policies.length; index += 1) {
+      expect(policies[index].detailIndex).toBe(index);
+      expect(policies[index].modelDetailScale).toBeLessThan(
+        policies[index - 1].modelDetailScale
+      );
+      expect(policies[index].textures.maxTextureSize).toBeLessThanOrEqual(
+        policies[index - 1].textures.maxTextureSize
+      );
+      expect(policies[index].budgets.triangleHint).toBeLessThan(
+        policies[index - 1].budgets.triangleHint
+      );
+    }
+    for (const policy of policies) {
+      expect(policy.geometry.cylinderSegments).toBeGreaterThanOrEqual(3);
+      expect(policy.geometry.sphereWidthSegments).toBeGreaterThanOrEqual(4);
+      expect(policy.geometry.sphereHeightSegments).toBeGreaterThanOrEqual(3);
+      if (policy.level === 'low' || policy.level === 'micro') {
+        expect(policy.effects.dynamicPointLights).toBe(false);
+        expect(policy.effects.decorativeShards).toBe(false);
+        expect(policy.effects.telemetryPanels).toBe(false);
+      }
+    }
+  });
+});

--- a/src/tests/miniatureManifest.test.ts
+++ b/src/tests/miniatureManifest.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildManifest,
+  normalizedTypeScriptTokens,
+  validateSourceChangeAcknowledged,
+} from '../../scripts/miniature-manifest';
+
+describe('miniature manifest', () => {
+  it('ignores comments and formatting in token fingerprints', () => {
+    expect(normalizedTypeScriptTokens('const x=1; // hi')).toBe(
+      normalizedTypeScriptTokens('const   x = 1;\n/* bye */')
+    );
+    expect(normalizedTypeScriptTokens('const x=1;')).not.toBe(
+      normalizedTypeScriptTokens('const x=2;')
+    );
+  });
+  it('requires source changes to be acknowledged by proxy changes or revision bumps', () => {
+    const oldEntry = {
+      id: 'x',
+      sourceHash: 'a',
+      proxyHash: 'p',
+      syncRevision: 1,
+    };
+    expect(
+      validateSourceChangeAcknowledged(oldEntry, {
+        ...oldEntry,
+        sourceHash: 'b',
+      })
+    ).toBe(false);
+    expect(
+      validateSourceChangeAcknowledged(oldEntry, {
+        ...oldEntry,
+        sourceHash: 'b',
+        proxyHash: 'q',
+      })
+    ).toBe(true);
+    expect(
+      validateSourceChangeAcknowledged(oldEntry, {
+        ...oldEntry,
+        sourceHash: 'b',
+        syncRevision: 2,
+      })
+    ).toBe(true);
+  });
+  it('builds a deterministic registry manifest', () => {
+    const manifest = buildManifest();
+    expect(manifest.version).toBe(1);
+    expect(manifest.entries.length).toBeGreaterThan(14);
+    expect(new Set(manifest.entries.map((entry) => entry.id)).size).toBe(
+      manifest.entries.length
+    );
+  });
+});

--- a/src/tests/miniatureProxyRegistry.test.ts
+++ b/src/tests/miniatureProxyRegistry.test.ts
@@ -1,0 +1,77 @@
+import { Camera, Light, Object3D } from 'three';
+import { describe, expect, it } from 'vitest';
+import {
+  SCENE_DETAIL_LEVELS,
+  getSceneDetailPolicy,
+} from '../scene/graphics/sceneDetailPolicy';
+import {
+  MINIATURE_POI_PROXY_ENTRIES,
+  MINIATURE_POI_PROXY_REGISTRY,
+} from '../scene/miniature/poiProxyRegistry';
+import { buildMiniatureProxy } from '../scene/miniature/proxyBuilder';
+import { MINIATURE_SCENE_COMPONENT_COVERAGE } from '../scene/miniature/sceneComponentRegistry';
+import { countObjectTriangles } from '../scene/structures/triangleCount';
+import { getPoiDefinitions } from '../scene/poi/registry';
+
+describe('miniature proxy registry', () => {
+  it('covers every POI exactly once', () => {
+    expect(MINIATURE_POI_PROXY_ENTRIES.map((p) => p.id).sort()).toEqual(
+      getPoiDefinitions()
+        .map((p) => p.id)
+        .sort()
+    );
+  });
+  it('contains required semantic parts and recursion boundary', () => {
+    const names = (id: keyof typeof MINIATURE_POI_PROXY_REGISTRY) =>
+      MINIATURE_POI_PROXY_REGISTRY[id].parts.map((p) => p.name);
+    expect(names('sugarkube-backyard-greenhouse')).toEqual(
+      expect.arrayContaining([
+        'sugarkube-table',
+        'sugarkube-switch',
+        'sugarkube-yellow-three-tier-rack',
+        'sugarkube-node',
+        'sugarkube-cable-silhouette',
+      ])
+    );
+    expect(names('tokenplace-studio-cluster')).toEqual(
+      expect.arrayContaining([
+        'tokenplace-desk',
+        'tokenplace-pc-tower',
+        'tokenplace-gaming-chair',
+        'tokenplace-left-monitor',
+        'tokenplace-right-monitor',
+        'tokenplace-keyboard',
+        'tokenplace-mouse',
+      ])
+    );
+    expect(
+      MINIATURE_POI_PROXY_REGISTRY['danielsmith-portfolio-table']
+        .recursionBoundary
+    ).toBe(true);
+    expect(names('danielsmith-portfolio-table')).toContain(
+      'portfolio-nonrecursive-white-table'
+    );
+  });
+  it('builds finite visible noninteractive geometry at all levels', () => {
+    for (const level of SCENE_DETAIL_LEVELS)
+      for (const entry of MINIATURE_POI_PROXY_ENTRIES) {
+        const root = buildMiniatureProxy(entry, {
+          detailPolicy: getSceneDetailPolicy(level),
+        });
+        expect(countObjectTriangles(root)).toBeGreaterThan(0);
+        root.traverse((object: Object3D) => {
+          expect(object).not.toBeInstanceOf(Light);
+          expect(object).not.toBeInstanceOf(Camera);
+          expect(object.name.toLowerCase()).not.toContain('collider');
+          expect(object.name.toLowerCase()).not.toContain('hitarea');
+          expect(object.name.toLowerCase()).not.toContain('label');
+        });
+      }
+  });
+  it('classifies visible non-POI coverage', () => {
+    expect(MINIATURE_SCENE_COMPONENT_COVERAGE.length).toBeGreaterThan(5);
+    expect(
+      MINIATURE_SCENE_COMPONENT_COVERAGE.map((entry) => entry.kind)
+    ).toEqual(expect.arrayContaining(['shared-source', 'proxy', 'excluded']));
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce the reusable miniature infrastructure so a future tabletop miniature can be deterministic, low-cost, and reviewable. 
- Expand internal detail bookkeeping so miniature LODs can be derived reliably from overworld quality settings. 
- Provide a small, declarative proxy vocabulary so POIs can be represented as visible, noninteractive geometry. 
- Add a manifest/check guard to force review when overworld source geometry changes without proxy acknowledgement.

### Description
- Add a centralized five-level internal detail system (`cinematic`, `balanced`, `performance`, `low`, `micro`) with metadata (detailIndex, modelDetailScale, geometry/texture/effects/updates/budgets) and helpers for stepping and miniature two-level-down mapping in `src/scene/graphics/sceneDetailPolicy.ts`. 
- Implement a miniature proxy domain (types, detail shim, builder, POI registry, scene-component coverage, catalog) under `src/scene/miniature/` providing deterministic, material-cached, noninteractive primitives and repeat transforms; include full proxy coverage for all current `PoiId`s (including Sugarkube and token.place) and a nonrecursive danielsmith.io white-table proxy. 
- Add a deterministic TypeScript-token-based manifest and check utility in `scripts/miniature-manifest.ts` that fingerprints declared source and proxy files, enforces proxy-per-POI, recursion boundaries, missing-file checks, syncRevision rules, and emits a committed `data/miniature/source-manifest.json`. 
- Wire the miniature sync guard into the PR test workflow and expose `npm` scripts `miniature:manifest:update` and `miniature:check`, plus a small proxy triangle catalog helper for validation.

### Testing
- Built and exercised the manifest utilities and focused tests: ran `npm run miniature:manifest:update` (manifest generated) and `npm run miniature:check` (check passed). 
- Ran focused Vitest suite for the new assets and related consumers with `npm run test:ci -- src/tests/miniatureDetailPolicy.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/sugarkubeDeployment.test.ts src/tests/tokenPlaceWorkstation.test.ts src/tests/poiModelTriangles.test.ts src/tests/performanceOptimization.test.ts`, and all specified tests passed. 
- Ran `npm run lint` (passed with import-order warnings only), `npm run build` (production build succeeded), and `npm run format:check` (Prettier clean). 
- Ran `npm run typecheck` and observed repository-wide baseline TypeScript diagnostics unrelated to these changes; no miniature files were implicated by the reported diagnostics (this PR does not introduce new typecheck failures).

Notes: CI now includes a `Miniature proxy sync guard` step which will fail PRs when a tracked overworld source changes without an accompanying proxy update or `syncRevision` bump, enforcing the intended review discipline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b9712f160832f8545c6f89d35447a)