### PR TITLE
🪓 : – harden PR Reaper integration

### DIFF
--- a/docs/architecture/pr-reaper-holographic-reaper.md
+++ b/docs/architecture/pr-reaper-holographic-reaper.md
@@ -820,3 +820,36 @@ opacity, halo visibility, and particle travel/brightness; they do not pause the 
 The tabletop miniature remains static. Its proxy source list and manifest include the runtime
 kinematics/controller modules only for sync tracking, and the proxy continues to depict a static
 3-red/1-green hologram snapshot rather than running the stream, controller, laser, or particles.
+
+## P5e production hardening notes
+
+P5e keeps the P5b-P5d visual contract unchanged and treats the installation as a
+finished POI baseline rather than a redesign. The public builder remains
+`createPrReaperInstallation({ position, orientationRadians, detailPolicy, seed })`;
+`src/main.ts` passes the active `SceneDetailPolicy`, attaches the returned group through
+`addPoiStructure(...)`, registers only the returned physical floor collider with
+scene-object source metadata, updates the build every rendered frame, and calls
+`dispose()` from full and partial immersive teardown paths so quality reloads do not
+leave stale PR Reaper geometry, material, particle, collider, or timer state.
+
+The runtime update path is intentionally allocation-light: stream state writes into a
+preallocated circle snapshot, the controller scans that snapshot by bounded count
+instead of slicing/filtering/sorting arrays, beam transforms reuse scratch vectors and
+quaternions, particles reuse fixed `Points` pools, and no mesh, geometry, or material is
+created during updates or per fire. Debug snapshots may still allocate copied state for
+tests and diagnostics because they are not part of the rendered-frame hot path.
+
+Detail levels preserve identical stream semantics for a given seed. Cinematic,
+Balanced, Performance, Low, and Micro only reduce rendering cost: circle segments,
+projector/arm accents, beam halo visibility, fasteners, particle counts, and triangle
+counts step down monotonically or are removed where practical. The red-only target
+contract, green immunity, exact aperture-to-red-center beam endpoint, particle origin
+mapping, and seeded spawn schedule stay invariant across detail levels and
+accessibility settings.
+
+Manual QA for final PRs should launch the immersive scene with
+`?mode=immersive&disablePerformanceFailover=1`, inspect Cinematic/Balanced/Performance,
+verify the tall 9:21 hologram and marker clearance, confirm varied PR spawn positions,
+red reaping, green fall-through, aperture-aligned beam endpoint, brief particle burst at
+the destroyed red center, reduced-motion/reduced-flicker comfort, and ensure the tabletop
+miniature remains the static proxy only.

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "67dfca7d1c95dbc92bfe2cff295cdb2aee23a0790e61c5b9c71a8964ff86ae01",
+      "proxyFingerprint": "e401c1fd01919c3acf3c7b7cef5d715e86059bc3faa0001daff7e7a49a6f1e25",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -579,7 +579,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "3053f6e2a8ee799815a28bceb744faa218475941757bed0a2c6e30ba7458401f",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "be312aac26fac81617be4bf80d88bcfa3831b5c038b0ab483e02f6dbaa4c75cd"
     },
     {
@@ -594,7 +594,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -609,7 +609,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -624,7 +624,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -639,7 +639,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -669,11 +669,11 @@
         "src/scene/structures/prReaperStream.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 16,
-      "syncNote": "Laser muzzle-forward alignment contract keeps the static 3:1 miniature proxy representative.",
-      "sourceFingerprint": "e26a3b6f05b899b75b732b8747d417808bb8fef053503a4b363ac95c5c02558a",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
-      "metadataFingerprint": "019e56387066939842961589369d108f8461c7a8afbc64de77a507160eab2a83"
+      "syncRevision": 17,
+      "syncNote": "P5e hot-path and lifecycle hardening reviewed; static 3:1 miniature proxy remains representative.",
+      "sourceFingerprint": "b676b392084eb89127505712301c822ea88f0a85f149f58f44da5438c3a5258f",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
+      "metadataFingerprint": "a312dc5c887f45a4e206731c4f62e5cf51cc634e43e2d313e4a3dfd745417d54"
     },
     {
       "id": "poi:sigma-kitchen-workbench",
@@ -687,7 +687,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -702,7 +702,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -717,7 +717,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -732,7 +732,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "6b159cc3b39baa00f5af4faf2f8c0ae1103a1d4f9534ebd494de6a5b60a82dba",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -394,9 +394,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'pr-reaper-backyard-console',
     id: 'poi:pr-reaper-backyard-console',
     displayName: 'PR Reaper holographic reaper installation proxy',
-    syncRevision: 16,
+    syncRevision: 17,
     syncNote:
-      'Laser muzzle-forward alignment contract keeps the static 3:1 miniature proxy representative.',
+      'P5e hot-path and lifecycle hardening reviewed; static 3:1 miniature proxy remains representative.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/prReaperConsole.ts',

--- a/src/scene/structures/prReaperConsole.ts
+++ b/src/scene/structures/prReaperConsole.ts
@@ -603,7 +603,7 @@ export function createPrReaperInstallation(
   let lastLaserWorldStart: { x: number; y: number; z: number } | null = null;
   let lastLaserWorldEnd: { x: number; y: number; z: number } | null = null;
   const randomUnit = createPrReaperSeededRandom(`${seed}:particles`);
-  function copyVector(v: Vector3) {
+  function copyVector(v: { x: number; y: number; z: number }) {
     return { x: v.x, y: v.y, z: v.z };
   }
   function setBeamVisible(visible: boolean, flicker: number): void {
@@ -619,13 +619,14 @@ export function createPrReaperInstallation(
     midpoint.copy(localStart).add(localEnd).multiplyScalar(0.5);
     direction.copy(localEnd).sub(localStart);
     const length = Math.max(0.001, direction.length());
-    [laserCore, laserGlow].forEach((beam) => {
-      beam.position.copy(midpoint);
-      beam.scale.set(1, length, 1);
-      beam.quaternion.copy(
-        beamQuaternion.setFromUnitVectors(yAxis, direction.normalize())
-      );
-    });
+    direction.normalize();
+    beamQuaternion.setFromUnitVectors(yAxis, direction);
+    laserCore.position.copy(midpoint);
+    laserCore.scale.set(1, length, 1);
+    laserCore.quaternion.copy(beamQuaternion);
+    laserGlow.position.copy(midpoint);
+    laserGlow.scale.set(1, length, 1);
+    laserGlow.quaternion.copy(beamQuaternion);
     setBeamVisible(true, flicker);
   }
   function startBurst(origin: Vector3, flicker: number): void {
@@ -703,8 +704,9 @@ export function createPrReaperInstallation(
       aperture.getWorldPosition(worldStart);
       const step = controller.update({
         delta,
-        candidates: activeCandidateSnapshot.slice(0, activeCandidateCount),
-        fireOrigin: copyVector(worldStart),
+        candidates: activeCandidateSnapshot,
+        candidateCount: activeCandidateCount,
+        fireOrigin: worldStart,
       });
       const pose = controller.getPose();
       yawJoint.rotation.y = pose.yaw;
@@ -754,8 +756,9 @@ export function createPrReaperInstallation(
       } else {
         setBeamVisible(false, flicker);
       }
-      bursts.forEach((burst) => {
-        if (!burst.active) return;
+      for (let burstIndex = 0; burstIndex < bursts.length; burstIndex += 1) {
+        const burst = bursts[burstIndex];
+        if (!burst.active) continue;
         burst.age += delta;
         const progress = Math.min(1, burst.age / burst.duration);
         for (let i = 0; i < counts.particles; i += 1) {
@@ -772,7 +775,7 @@ export function createPrReaperInstallation(
           burst.active = false;
           burst.points.visible = false;
         }
-      });
+      }
     },
     getDebugState() {
       const streamDebug = stream.getDebugState();

--- a/src/scene/structures/prReaperReapingController.ts
+++ b/src/scene/structures/prReaperReapingController.ts
@@ -75,6 +75,7 @@ export class PrReaperReapingController {
   update(options: {
     delta: number;
     candidates: readonly PrReaperCircleState[];
+    candidateCount?: number;
     rootHeading?: number;
     fireOrigin?: { x: number; y: number; z: number } | null;
   }): PrReaperReapingControllerStep {
@@ -98,7 +99,10 @@ export class PrReaperReapingController {
 
     let fire: PrReaperControllerFireEvent | null = null;
     if (this.state === 'idle' || this.state === 'acquire') {
-      const selected = this.selectCandidate(options.candidates);
+      const selected = this.selectCandidate(
+        options.candidates,
+        options.candidateCount
+      );
       if (selected) {
         this.selectedCandidateId = selected.id;
         this.selectedTargetCenter = copy(selected.center);
@@ -111,9 +115,11 @@ export class PrReaperReapingController {
     }
 
     if (this.state === 'track') {
-      const selected =
-        options.candidates.find((c) => c.id === this.selectedCandidateId) ??
-        null;
+      const selected = this.findCandidateById(
+        options.candidates,
+        options.candidateCount,
+        this.selectedCandidateId
+      );
       if (!selected || !this.isTrackableCandidate(selected)) {
         this.releaseTarget();
       } else {
@@ -224,14 +230,37 @@ export class PrReaperReapingController {
     );
   }
 
-  private selectCandidate(
-    candidates: readonly PrReaperCircleState[]
+  private findCandidateById(
+    candidates: readonly PrReaperCircleState[],
+    candidateCount = candidates.length,
+    id: number | null
   ): PrReaperCircleState | null {
-    return (
-      [...candidates]
-        .filter((candidate) => this.isTrackableCandidate(candidate))
-        .sort((a, b) => b.progress - a.progress || a.id - b.id)[0] ?? null
-    );
+    if (id === null) return null;
+    const count = Math.min(candidateCount, candidates.length);
+    for (let i = 0; i < count; i += 1) {
+      if (candidates[i].id === id) return candidates[i];
+    }
+    return null;
+  }
+
+  private selectCandidate(
+    candidates: readonly PrReaperCircleState[],
+    candidateCount = candidates.length
+  ): PrReaperCircleState | null {
+    let selected: PrReaperCircleState | null = null;
+    const count = Math.min(candidateCount, candidates.length);
+    for (let i = 0; i < count; i += 1) {
+      const candidate = candidates[i];
+      if (!this.isTrackableCandidate(candidate)) continue;
+      if (
+        !selected ||
+        candidate.progress > selected.progress ||
+        (candidate.progress === selected.progress && candidate.id < selected.id)
+      ) {
+        selected = candidate;
+      }
+    }
+    return selected;
   }
 
   private releaseTarget(): void {


### PR DESCRIPTION
### Motivation
- Finalize P5e hardening to make the PR Reaper POI production-ready by focusing on lifecycle safety, hot-path allocation reduction, accessibility / detail-policy invariants, and tabletop miniature sync. 
- Preserve the P5b–P5d visual and semantic contract (9:21 hologram, 3:1 deterministic stream, two-axis arm, red-only laser, pooled particle bursts, and static miniature proxy) while removing runtime fragility and avoidable allocations. 
- Ensure the runtime is disposal-safe and that the miniature proxy and generated manifest reflect the final runtime sources.

### Description
- Reduce update-path allocations and stabilize controller inputs by passing the preallocated active candidate snapshot plus a bounded `candidateCount` into `PrReaperReapingController.update(...)` and by replacing `slice/filter/sort` with a bounded scan selection algorithm. 
- Add `findCandidateById(...)` and a bounded `selectCandidate(...)` implementation to avoid per-frame array copying and sorting while preserving deterministic priority rules (highest `progress` then lowest `id`). 
- Optimize beam updates to reuse scratch vectors/quaternions and avoid normalize/callback allocations by normalizing once and applying the resulting quaternion directly to both `PrReaperLaserCore` and `PrReaperLaserGlow`. 
- Keep particle bursts pooled and change active-burst iteration to an indexed loop with preallocated `Float32Array` attributes so particle velocities/positions are updated without per-frame allocations and burst slots are deterministically bounded. 
- Minor ergonomics/type safety tweak for `copyVector(...)` to accept plain `{x,y,z}` shapes and pass `fireOrigin` as an existing `Vector3` to avoid temporary object creation in the hot path. 
- Update the tabletop proxy `syncRevision` and `syncNote` and regenerate `miniatureManifest.generated.json` so the static miniature proxy is in sync with final runtime sources. 
- Add a compact P5e production hardening note to `docs/architecture/pr-reaper-holographic-reaper.md` documenting lifecycle, allocation, detail-policy and manual QA expectations.

### Testing
- Ran unit tests for the PR Reaper area with `npm run test:ci -- src/tests/prReaperStream.test.ts src/tests/prReaperArmKinematics.test.ts src/tests/prReaperReapingController.test.ts src/tests/prReaperConsole.test.ts` and all targeted tests passed. 
- Ran miniature and integration checks with `npm run miniature:manifest:update` and `npm run miniature:check` and then `npm run test:ci -- src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts` and those suites passed. 
- Ran repository checks: `npm run lint`, `npm run build`, `npm run docs:check`, `npm run smoke`, and `npm run format:check` and they completed successfully (link checks reported external fetch warnings but exited successfully). 
- Started a dev server with `npm run dev -- --host 127.0.0.1 --port 5173` to enable manual immersive QA (dev server started successfully for `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`), but interactive visual verification was not performed in this environment. 
- Ran `npm run typecheck` which still reports pre-existing, project-wide TypeScript errors unrelated to PR Reaper; these are noted as residual and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e07ce6918832fa7367561ff4cc9f9)