### PR TITLE
Harden PR Reaper P5e — lifecycle, performance, accessibility, tests

### DIFF
--- a/docs/architecture/pr-reaper-holographic-reaper.md
+++ b/docs/architecture/pr-reaper-holographic-reaper.md
@@ -789,8 +789,8 @@ still has exactly two animated joint groups: `PrReaperYawJoint` and `PrReaperPit
 `src/scene/structures/prReaperReapingController.ts` owns the pure state machine:
 `idle -> acquire -> track -> fire -> burst -> recover`. It selects red circles only inside the
 shooting band (`PR_REAPER_TARGET_PROGRESS_MIN = 0.12`,
-`PR_REAPER_TARGET_PROGRESS_MAX = 0.9`), sorts by greatest progress and then smallest candidate
-ID, tracks the chosen circle as it descends, requires
+`PR_REAPER_TARGET_PROGRESS_MAX = 0.9`), selects by greatest progress and then smallest candidate
+ID without allocating per-frame sorted candidate arrays, tracks the chosen circle as it descends, requires
 `PR_REAPER_AIM_TOLERANCE_RADIANS = 0.035` for `PR_REAPER_AIM_HOLD_SECONDS = 0.04`, fires for
 `PR_REAPER_LASER_DURATION_SECONDS = 0.12`, and recovers for
 `PR_REAPER_RECOVER_SECONDS = 0.18`. Fired IDs are remembered so duplicate firing cannot remove
@@ -820,3 +820,104 @@ opacity, halo visibility, and particle travel/brightness; they do not pause the 
 The tabletop miniature remains static. Its proxy source list and manifest include the runtime
 kinematics/controller modules only for sync tracking, and the proxy continues to depict a static
 3-red/1-green hologram snapshot rather than running the stream, controller, laser, or particles.
+
+## P5e final hardening baseline
+
+P5e keeps the P5a-P5d visual contract intact and treats PR Reaper as a production POI
+baseline rather than a feature expansion.
+
+### Builder API and lifecycle
+
+`createPrReaperInstallation({ position, orientationRadians, detailPolicy, seed })` returns a
+`PrReaperInstallationBuild` with `group`, physical `colliders`, `update(...)`,
+`getDebugState()`, and idempotent `dispose()`. `src/main.ts` owns one module-level
+`prReaperInstallation`, passes the active `SceneDetailPolicy`, attaches the returned group via
+`addPoiStructure(...)`, applies scene-object source metadata, registers only the physical floor
+collider, updates the installation every rendered immersive frame, and calls
+`disposePrReaperInstallationBuild()` during both partial initialization cleanup and full immersive
+teardown. Emphasis is presentation-only; the stream/controller continue regardless of POI focus.
+
+### Contract constants and physical footprint
+
+The root remains unit scale and bottom-center/screen-plane anchored. The hologram is a vertical
+9:21 plane with near-ceiling top clearance. The declared intended bounds cover the visible screen,
+projector, robot, beam envelope, and marker clearance, while the registered collider covers only
+the asymmetric physical floor footprint (projector/base/robot), not the hologram screen. The marker
+minimum height intentionally clears the screen top.
+
+### Stream scheduler
+
+`PrReaperStreamState` remains the only scheduler. It emits exact shuffled 3-red/1-green batches,
+uses 0.5-1.5 second spawn intervals including the first interval, keeps seed/frame-sequence
+replays deterministic, separates red reaped counters from red/green expiry counters, rejects green
+reap attempts without hiding them, and caps large-delta catch-up to keep state finite. Reaping does
+not mutate the random stream or future spawn order/timing.
+
+### Reaping controller and arm kinematics
+
+The controller has the pure `idle -> acquire -> track -> fire -> burst -> recover` state machine
+and performs allocation-light red-target selection by scanning active candidates for greatest
+progress then smallest ID. Green candidates are never selected. Kinematics stay two-axis-only:
+`PrReaperYawJoint` and `PrReaperPitchJoint` are the only animated joints. The visible aperture,
+semantic muzzle-forward anchor, laser core, and laser glow are aligned from the same world-space
+start/end pair; tests cover nonzero installation headings, exact aperture starts, exact destroyed
+red-circle endpoints, and collinearity between the barrel forward vector and beam direction. There
+is no `lookAt()` path, hidden third-axis correction, extra animated elbow/wrist, or parented target
+object.
+
+### Particle burst pool
+
+Particle confirmation uses the fixed four-slot `PrReaperParticleBurstPool-*` pool. Each slot owns
+preallocated `BufferGeometry` and `PointsMaterial`; firing reuses a slot rather than creating
+meshes, geometries, or materials. The burst origin is the same world point as the laser endpoint and
+is converted through `PrReaperParticleRoot.worldToLocal(...)`, so transformed installation roots map
+correctly. Durations remain bounded from 0.25 to 0.50 seconds, and `dispose()` releases particle and
+shared mesh resources once.
+
+### Accessibility behavior
+
+`accessibilityPulseScale` and `accessibilityFlickerScale` only affect presentation. With pulse,
+flicker, or both at `0`, the stream continues, red-only reaping continues, one clear laser core
+confirmation remains, halo/flicker is softened or removed, particle opacity/travel is reduced, and
+spawn schedule, 3:1 ratio, target priority, and green immunity are unchanged.
+
+### Detail-level matrix
+
+All five internal detail levels preserve semantic parity for the same seed/frame sequence. Only
+rendering cost changes:
+
+| Detail level | Circle/projector/arm detail    | Beam/halo   | Particle count | Optional accents |
+| ------------ | ------------------------------ | ----------- | -------------- | ---------------- |
+| Cinematic    | highest shared policy segments | core + glow | 32             | full             |
+| Balanced     | high shared policy segments    | core + glow | 24             | reduced          |
+| Performance  | reduced policy segments        | core + glow | 14             | reduced          |
+| Low          | low policy segments            | core only   | 8              | minimal          |
+| Micro        | minimum policy segments        | core only   | 4              | none             |
+
+Tests assert descending triangle budgets and identical stream debug state across levels; the builder
+constructs only the active detail variant instead of building and hiding unused variants.
+
+### Miniature proxy rule
+
+The danielsmith.io tabletop miniature remains static. It does not run the PR stream, arm
+controller, laser, or particle system. The proxy depicts the projector base, tall blue 9:21 screen,
+three red hints, one green hint, two-axis arm silhouette, tool flange/laser gun, and optional static
+green beam hint. The proxy `sourceFiles`, `syncRevision`, and generated manifest track the final
+PR Reaper runtime structure modules; shared accessibility, detail, physical metadata, and
+`main.ts` integration stay covered by their own manifest audit entries.
+
+### Known non-goals
+
+No image generation, binary assets, external models, external textures, audio, network data, new
+visual modes, or stream-contract tuning are part of this baseline.
+
+### Manual QA checklist
+
+Use `npm run dev -- --host 127.0.0.1 --port 5173` and open
+`http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`. Inspect Cinematic,
+Balanced, and Performance. Confirm the hologram is tall/vertical; circles spawn at varied X
+positions; red/green stream readability is clear; red circles are reaped; green circles fall
+through; the arm points at the shot red circle; the laser starts at the aperture and ends at the
+circle center; the red circle disappears; a brief burst appears at the same location; reduced
+motion/flicker remains comfortable; the POI orb/label clears the installation; no frame spikes or
+runaway effects are obvious; and the tabletop miniature remains a static proxy only.

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "67dfca7d1c95dbc92bfe2cff295cdb2aee23a0790e61c5b9c71a8964ff86ae01",
+      "proxyFingerprint": "70904ef9fbfddb268c43cbc8825838b60377aef24970b46ae99b2a6d44e829b0",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -579,7 +579,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "3053f6e2a8ee799815a28bceb744faa218475941757bed0a2c6e30ba7458401f",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "be312aac26fac81617be4bf80d88bcfa3831b5c038b0ab483e02f6dbaa4c75cd"
     },
     {
@@ -594,7 +594,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -609,7 +609,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -624,7 +624,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -639,7 +639,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -669,11 +669,11 @@
         "src/scene/structures/prReaperStream.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 16,
-      "syncNote": "Laser muzzle-forward alignment contract keeps the static 3:1 miniature proxy representative.",
-      "sourceFingerprint": "e26a3b6f05b899b75b732b8747d417808bb8fef053503a4b363ac95c5c02558a",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
-      "metadataFingerprint": "019e56387066939842961589369d108f8461c7a8afbc64de77a507160eab2a83"
+      "syncRevision": 17,
+      "syncNote": "P5e runtime/accessibility/detail audit keeps the static 3:1 miniature proxy representative.",
+      "sourceFingerprint": "2873b1266bfe31dd16a042db4eacf7444c088caf9867c18ec994a03dc1552ee9",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
+      "metadataFingerprint": "65e1950abd08b9094944cc5708adbd505c2f11c5e842511e6aa069b3bc27b510"
     },
     {
       "id": "poi:sigma-kitchen-workbench",
@@ -687,7 +687,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -702,7 +702,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -717,7 +717,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -732,7 +732,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "b90951fa00f972541419ae6a1323ce1d1287c15d63cbf6dd66697e86b96c936a",
+      "proxyFingerprint": "e375f54d7312d2406a3eb08d6407c931cb1473ae50a4621a54362393935318bc",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -394,9 +394,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'pr-reaper-backyard-console',
     id: 'poi:pr-reaper-backyard-console',
     displayName: 'PR Reaper holographic reaper installation proxy',
-    syncRevision: 16,
+    syncRevision: 17,
     syncNote:
-      'Laser muzzle-forward alignment contract keeps the static 3:1 miniature proxy representative.',
+      'P5e runtime/accessibility/detail audit keeps the static 3:1 miniature proxy representative.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/prReaperConsole.ts',

--- a/src/scene/structures/prReaperConsole.ts
+++ b/src/scene/structures/prReaperConsole.ts
@@ -668,7 +668,8 @@ export function createPrReaperInstallation(
       screenMaterial.opacity = clampOpacity(0.22 + amount);
       edgeMaterial.opacity = clampOpacity(0.62 + amount);
       const activeCandidateCount = stream.writeActiveCandidates(
-        activeCandidateSnapshot
+        activeCandidateSnapshot,
+        true
       );
       circleRedMaterial.opacity = clampOpacity(
         0.72 + emphasis * 0.18 * flicker
@@ -703,7 +704,7 @@ export function createPrReaperInstallation(
       aperture.getWorldPosition(worldStart);
       const step = controller.update({
         delta,
-        candidates: activeCandidateSnapshot.slice(0, activeCandidateCount),
+        candidates: activeCandidateSnapshot,
         fireOrigin: copyVector(worldStart),
       });
       const pose = controller.getPose();
@@ -712,9 +713,14 @@ export function createPrReaperInstallation(
       group.updateWorldMatrix(true, true);
       let laserStartedThisFrame = false;
       if (step.fire) {
-        const targetMesh = circlePool.find(
-          (mesh) => mesh.userData.candidateId === step.fire!.candidateId
-        );
+        let targetMesh: Mesh | undefined;
+        for (let i = 0; i < activeCandidateCount; i += 1) {
+          const mesh = circlePool[i];
+          if (mesh.userData.candidateId === step.fire.candidateId) {
+            targetMesh = mesh;
+            break;
+          }
+        }
         if (targetMesh && targetMesh.userData.type === 'red') {
           targetMesh.updateWorldMatrix(true, false);
           aperture.updateWorldMatrix(true, false);

--- a/src/scene/structures/prReaperReapingController.ts
+++ b/src/scene/structures/prReaperReapingController.ts
@@ -227,11 +227,19 @@ export class PrReaperReapingController {
   private selectCandidate(
     candidates: readonly PrReaperCircleState[]
   ): PrReaperCircleState | null {
-    return (
-      [...candidates]
-        .filter((candidate) => this.isTrackableCandidate(candidate))
-        .sort((a, b) => b.progress - a.progress || a.id - b.id)[0] ?? null
-    );
+    let selected: PrReaperCircleState | null = null;
+    for (let i = 0; i < candidates.length; i += 1) {
+      const candidate = candidates[i];
+      if (!this.isTrackableCandidate(candidate)) continue;
+      if (
+        !selected ||
+        candidate.progress > selected.progress ||
+        (candidate.progress === selected.progress && candidate.id < selected.id)
+      ) {
+        selected = candidate;
+      }
+    }
+    return selected;
   }
 
   private releaseTarget(): void {

--- a/src/tests/prReaperConsole.test.ts
+++ b/src/tests/prReaperConsole.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import {
   Box3,
   BufferGeometry,
@@ -30,6 +32,7 @@ import {
   PR_REAPER_SCREEN_TO_EMITTER_STANDOFF,
   PR_REAPER_SCREEN_WIDTH,
 } from '../scene/structures/prReaperInstallationContract';
+import * as animationPreferences from '../ui/accessibility/animationPreferences';
 
 function names(root: Object3D): string[] {
   const found: string[] = [];
@@ -418,6 +421,28 @@ describe('createPrReaperInstallation', () => {
     });
   });
 
+  it('keeps the arm as a pure two-axis hierarchy without hidden lookAt helpers', () => {
+    const build = createPrReaperInstallation({ position: { x: 0, z: 0 } });
+    const animatedJoints: string[] = [];
+    build.group.traverse((object) => {
+      if (object.userData.animatedJoint) animatedJoints.push(object.name);
+      expect(object.name.toLowerCase()).not.toContain('correction');
+      expect(object.name.toLowerCase()).not.toContain('target');
+      expect(object.name.toLowerCase()).not.toContain('elbow');
+      expect(object.name.toLowerCase()).not.toContain('wrist');
+    });
+    expect(animatedJoints.sort()).toEqual([
+      'PrReaperPitchJoint',
+      'PrReaperYawJoint',
+    ]);
+
+    const source = readFileSync(
+      'src/scene/structures/prReaperConsole.ts',
+      'utf8'
+    );
+    expect(source).not.toContain('.lookAt(');
+  });
+
   it('does not add dynamic point lights', () => {
     const build = createPrReaperInstallation({ position: { x: 0, z: 0 } });
     const lights: PointLight[] = [];
@@ -425,6 +450,49 @@ describe('createPrReaperInstallation', () => {
       if (object instanceof PointLight) lights.push(object);
     });
     expect(lights).toHaveLength(0);
+  });
+
+  it('keeps reduced pulse and flicker accessible without changing stream semantics', () => {
+    const pulse = vi.spyOn(animationPreferences, 'getPulseScale');
+    const flicker = vi.spyOn(animationPreferences, 'getFlickerScale');
+    const scenarios = [
+      { pulse: 1, flicker: 1 },
+      { pulse: 0, flicker: 1 },
+      { pulse: 1, flicker: 0 },
+      { pulse: 0, flicker: 0 },
+    ];
+    const states = scenarios.map((scenario) => {
+      pulse.mockReturnValue(scenario.pulse);
+      flicker.mockReturnValue(scenario.flicker);
+      const build = createPrReaperInstallation({
+        position: { x: 0, z: 0 },
+        seed: 'accessibility-semantic-seed',
+      });
+      const fired = updateUntilLaserFires(build);
+      expect(fired.totalReapedRed).toBeGreaterThan(0);
+      expect(fired.attemptedGreenReapCount).toBe(0);
+      expect(fired.laserActive).toBe(true);
+      expect(fired.activeBurstCount).toBeGreaterThan(0);
+      const glow = build.group.getObjectByName('PrReaperLaserGlow') as Mesh;
+      const glowOpacity = (glow.material as MeshBasicMaterial).opacity;
+      const burstRoot = build.group.getObjectByName('PrReaperParticleRoot')!;
+      const activeBurst = burstRoot.children.find((child) => child.visible) as
+        | Points<BufferGeometry, PointsMaterial>
+        | undefined;
+      expect(activeBurst).toBeDefined();
+      const particleOpacity = activeBurst!.material.opacity;
+      build.dispose();
+      return { stream: fired.stream, glowOpacity, particleOpacity };
+    });
+
+    const baseline = states[0].stream;
+    states.forEach(({ stream }) => expect(stream).toEqual(baseline));
+    expect(states[2].glowOpacity).toBe(0);
+    expect(states[3].glowOpacity).toBe(0);
+    expect(states[2].particleOpacity).toBeLessThan(states[0].particleOpacity);
+    expect(states[3].particleOpacity).toBeLessThan(states[0].particleOpacity);
+    pulse.mockRestore();
+    flicker.mockRestore();
   });
 
   it('provides restrained update behavior and idempotent disposal', () => {


### PR DESCRIPTION
### Motivation

- Finalize the P5e hardening pass for the PR Reaper holographic installation to make it production-ready (lifecycle safety, accessibility, performance, particle/laser correctness, and QA). 
- Reduce hot-path allocations and remove per-frame array/filter/sort allocations while preserving P5a–P5d semantics (deterministic 3:1 stream, two-axis arm, red-only reaping, pooled bursts, static miniature proxy).

### Description

- Reduce hot-path allocations and deterministic selection: reuse the preallocated `activeCandidateSnapshot` (write+truncate) and pass it directly into the controller; replace per-frame `filter().sort()` with a single-pass scan that implements “greatest progress then smallest id”. (files: `src/scene/structures/prReaperConsole.ts`, `src/scene/structures/prReaperReapingController.ts`).
- Harden firing/beam/particle codepaths: limit candidate mesh lookup to the active pool range, compute world-space aperture/target positions before `reapCandidate(...)`, reuse fixed `PrReaperParticleBurstPool-*` `Points` with preallocated `BufferGeometry`, and ensure beam origin/endpoint and burst local/world mapping remain correct under transformed roots (file: `src/scene/structures/prReaperConsole.ts`).
- Tests and accessibility: add tests that assert two-axis-only arm hierarchy and absence of hidden `lookAt()` helpers, and scenarios that verify reduced-motion/flicker (`accessibilityPulseScale`/`accessibilityFlickerScale`) preserve stream semantics while softening presentation (file: `src/tests/prReaperConsole.test.ts`).
- Miniature / docs / manifest: update P5e documentation to reflect final builder API/lifecycle and semantics, bump PR Reaper miniature proxy `syncRevision` and regenerate the miniature manifest to keep the tabletop proxy static and representative (files: `docs/architecture/pr-reaper-holographic-reaper.md`, `src/scene/miniature/poiProxyRegistry.ts`, `src/scene/miniature/miniatureManifest.generated.json`).
- Resource lifecycle: ensure idempotent `dispose()` and centralized teardown paths remain intact and shared geometries/materials/points are disposed exactly once (file: `src/scene/structures/prReaperConsole.ts`).

### Testing

- Ran formatting and manifest tooling: `npm run format:write` (passed) and `npm run miniature:manifest:update` + `npm run miniature:check` (passed). 
- Unit tests run (Vitest) for PR Reaper surface: `npm run test:ci -- src/tests/prReaperStream.test.ts src/tests/prReaperArmKinematics.test.ts src/tests/prReaperReapingController.test.ts src/tests/prReaperConsole.test.ts` (all passed). 
- Wider test subset: `npm run test:ci -- src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts` (all passed). 
- Lint/build/docs/smoke: `npm run lint` (passed with one non-blocking import-order warning fixed), `npm run build` (passed), `npm run docs:check` (passed; external link checks emitted network fetch warnings), and `npm run smoke` (passed). 
- Format check and secret scan: `npm run format:check` (passed) and `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets). 
- Typecheck: `npm run typecheck` still reports pre-existing, project-wide TypeScript issues unrelated to PR Reaper (these were present before this change and were not introduced by this PR). 

Known limits / notes: manual browser visual inspection (Cinematic / Balanced / Performance) was not performed in a GUI here, but the server was started and an HTTP HEAD to the immersive URL returned 200 OK; the automated test coverage and added assertions validate the P5e invariants (beam/aperture alignment, particle origin mapping, pooled bursts, deterministic stream, two-axis-only joints, accessibility presentation behavior, disposal idempotency, and miniature manifest sync).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e07e217bc832f829c5881518ec617)