### PR TITLE
Implement physical Flywheel assembly with planetary gearbox and shared contract

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -682,3 +682,74 @@ only one short blue parabolic packet is visible at a time, five incoming packets
 precede one larger outgoing packet, reduced motion/flicker remains comfortable,
 the POI marker clears the machine, the miniature proxy is static and current, and
 there are no obvious frame spikes.
+
+## 8. P6b physical assembly implementation
+
+P6b replaces the abstract kiosk with a bottom-centered physical installation root
+named `FlywheelEnergyInstallation`. Production code now passes a `position`
+anchor resolved from the Flywheel POI; the root owns the POI heading and remains
+unit scale, while all visible machine parts are authored in local coordinates.
+
+Final implementation constants live in
+`src/scene/structures/flywheelEnergyContract.ts` and are shared by the builder,
+metadata, miniature proxy, and tests:
+
+- installation bounds: 3.4w × 2.4d × 2.75h scene units;
+- base: 3.25w × 1.55d × 0.22h;
+- flywheel: 0.92 radius, 0.12 rim tube, 0.24 thickness, centered at local
+  `(-0.58, 1.35, 0)`;
+- gearbox: centered at local `(0.78, 1.24, 0)` with a 0.52 radius and 0.26
+  depth;
+- crank: centered at local `(1.18, 1.24, 0.42)` with a 0.36 crank radius;
+- energy port: local `(1.32, 1.62, 0.62)` with a 0.13 radius;
+- marker minimum height: 2.95; avatar path radius: 1.2.
+
+The planetary train uses a fixed 48-tooth ring gear, an 18-tooth sun gear, and
+three 15-tooth planet gears. The fixed-ring reduction is:
+
+```ts
+carrier = sun / (1 + ringTeeth / sunTeeth);
+```
+
+This yields a 3.6667:1 crank-to-carrier torque multiplication. The hand crank
+and sun gear share the deterministic crank angle. The planet carrier, output
+shaft, and heavy wheel use the carrier angle. Planet gears orbit on the carrier
+and counter-spin by `-crank * (sunTeeth / planetTeeth)`; emphasis may boost the
+single crank speed slightly and intensify glows, but it does not alter the gear
+ratio.
+
+The stable physical hierarchy is:
+
+```text
+FlywheelEnergyInstallation
+├─ FlywheelBase
+├─ FlywheelBearingStandLeft / FlywheelBearingStandRight
+├─ FlywheelAxle
+├─ FlywheelWheelGroup
+│  ├─ FlywheelHeavyRim
+│  ├─ FlywheelInnerHub
+│  ├─ FlywheelSpoke-*
+│  ├─ FlywheelCounterweight-*
+│  └─ FlywheelEnergyGlowRing
+├─ FlywheelCrankGroup
+│  ├─ FlywheelCrankDisc
+│  ├─ FlywheelCrankArm
+│  └─ FlywheelCrankHandle
+├─ FlywheelPlanetaryGearbox
+│  ├─ FlywheelRingGear
+│  ├─ FlywheelSunGear
+│  ├─ FlywheelPlanetCarrier
+│  ├─ FlywheelPlanetGear-*
+│  └─ FlywheelOutputShaft
+└─ FlywheelEnergyPort
+```
+
+Detail levels build only the selected variant. Cinematic uses every procedural
+gear tooth and the highest segment counts. Balanced halves visible tooth blocks
+while keeping high segments. Performance reduces tooth blocks and uses the
+performance geometry policy. Low and Micro keep the base, bearings, wheel,
+crank, gearbox, and port silhouettes while aggressively reducing segments and
+visible tooth blocks.
+
+Cross-POI blue energy-transfer arcs remain future P6c scope; P6b does not add arc
+geometry or arc colliders.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3023,15 +3023,17 @@ function initializeImmersiveScene(
       ? upperFloorColliders
       : groundColliders;
   if (studioRoom) {
-    const centerX =
-      flywheelPoi?.group.position.x ??
-      (studioRoom.bounds.minX + studioRoom.bounds.maxX) / 2;
-    const centerZ =
-      flywheelPoi?.group.position.z ??
-      (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2;
+    const position = {
+      x:
+        flywheelPoi?.group.position.x ??
+        (studioRoom.bounds.minX + studioRoom.bounds.maxX) / 2,
+      y: flywheelPoi?.group.position.y ?? 0,
+      z:
+        flywheelPoi?.group.position.z ??
+        (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2,
+    };
     const showpiece = createFlywheelShowpiece({
-      centerX,
-      centerZ,
+      position,
       roomBounds: studioRoom.bounds,
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
       detailPolicy: activeSceneDetailPolicy,
@@ -6979,7 +6981,10 @@ function initializeImmersiveScene(
       selfieMirror.dispose();
       selfieMirror = null;
     }
-    flywheelShowpiece = null;
+    if (flywheelShowpiece) {
+      flywheelShowpiece.dispose();
+      flywheelShowpiece = null;
+    }
     f2ClipboardConsole = null;
     sigmaWorkbench = null;
     woveLoom = null;
@@ -7140,19 +7145,17 @@ function initializeImmersiveScene(
       if (flywheelShowpiece) {
         const activation = flywheelPoi?.activation ?? 0;
         const focus = flywheelPoi?.focus ?? 0;
-        if (
-          sceneDetailController.shouldRunDecorativeUpdate(
+        const emphasis = Math.max(activation, focus);
+        flywheelShowpiece.update({
+          elapsed: elapsedTime,
+          delta,
+          emphasis,
+          runDecorativeEffects: sceneDetailController.shouldRunDecorativeUpdate(
             elapsedTime,
-            Math.max(activation, focus),
+            emphasis,
             'flywheel'
-          )
-        ) {
-          flywheelShowpiece.update({
-            elapsed: elapsedTime,
-            delta,
-            emphasis: Math.max(activation, focus),
-          });
-        }
+          ),
+        });
       }
       if (f2ClipboardConsole) {
         const activation = f2ClipboardPoi?.activation ?? 0;

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -313,11 +313,11 @@
       "id": "audit:src:scene:poi:physicalMetadata",
       "sourceFiles": ["src/scene/poi/physicalMetadata.ts"],
       "proxyFiles": [],
-      "syncRevision": 4,
-      "syncNote": "Audited support source; PR Reaper real-world dimensions and scene bounds now feed its holographic installation contract while tabletop geometry remains covered by the POI proxy.",
-      "sourceFingerprint": "c9511746aa83f377f440cc4f6cde42def70039cb136d9bb6edab7fc4b4d5cba3",
+      "syncRevision": 6,
+      "syncNote": "Audited support source; formatted Flywheel physical metadata references the shared kinetic installation contract while tabletop geometry remains covered by its POI proxy.",
+      "sourceFingerprint": "ddda89231812fdb0ab87e0fd461c363506cb5287db15feea7c0ce26e17d675d1",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "5292e4210f717e822a84d93d7ce1914ab0cad79f47de5b7ee7f13a53cdc1fc5e"
+      "metadataFingerprint": "e9cf4717c033bb38dced0123855c4d0e1782c67dd1acffe5611744eab147d0d4"
     },
     {
       "id": "audit:src:scene:poi:structuredData",
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "ac78de7048b2c3f23277ac748cf266bf966067a263b707f85b0fafe295af69b6",
+      "proxyFingerprint": "0af601e5fa4eae0f92a3f4328e672f713923c02b75ed8dff0e44f7fad7a0dab0",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -573,14 +573,15 @@
         "src/scene/poi/constants.ts",
         "src/scene/poi/placements.ts",
         "src/scene/poi/registry.ts",
-        "src/scene/structures/flywheel.ts"
+        "src/scene/structures/flywheel.ts",
+        "src/scene/structures/flywheelEnergyContract.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 3,
-      "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
-      "sourceFingerprint": "3053f6e2a8ee799815a28bceb744faa218475941757bed0a2c6e30ba7458401f",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
-      "metadataFingerprint": "be312aac26fac81617be4bf80d88bcfa3831b5c038b0ab483e02f6dbaa4c75cd"
+      "syncRevision": 5,
+      "syncNote": "Tracks formatted P6b physical flywheel assembly with static wheel, crank, gearbox, bearings, and energy port.",
+      "sourceFingerprint": "1fe322a10f28791bd4bcdf9f4f88e747d2b9913646d9a177c1179ae5d44eb98f",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
+      "metadataFingerprint": "1020e2c6b618bcaf4325c51bd450c9a26ead866d878adb31ba329b6bc75b54ca"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -594,7 +595,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -609,7 +610,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -624,7 +625,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -639,7 +640,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -674,7 +675,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -689,7 +690,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -704,7 +705,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -719,7 +720,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -734,7 +735,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "f91212e97426aabb809c79fd54a273243a856ac50e98b8a91761f784899caf69",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -1,4 +1,9 @@
 import type { PoiId } from '../poi/types';
+import {
+  FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_GEARBOX,
+  FLYWHEEL_WHEEL,
+} from '../structures/flywheelEnergyContract';
 import { PORTFOLIO_MINIATURE_TABLE_DIMENSIONS } from '../structures/portfolioMiniatureTableContract';
 
 import type {
@@ -89,29 +94,63 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 3,
+    syncRevision: 5,
     syncNote:
-      'Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.',
-    sourceFiles: [...baseFiles, 'src/scene/structures/flywheel.ts'],
+      'Tracks formatted P6b physical flywheel assembly with static wheel, crank, gearbox, bearings, and energy port.',
+    sourceFiles: [
+      ...baseFiles,
+      'src/scene/structures/flywheel.ts',
+      'src/scene/structures/flywheelEnergyContract.ts',
+    ],
     proxyFiles: [SELF_FILE],
     primitives: [
-      cyl('flywheel-dais', 0.7, 0.18, [0, 0.09, 0], 0x0f766e),
+      box(
+        'flywheel-base',
+        [
+          FLYWHEEL_BASE_DIMENSIONS.width * 0.35,
+          0.08,
+          FLYWHEEL_BASE_DIMENSIONS.depth * 0.35,
+        ],
+        [0, 0.04, 0],
+        0x172033
+      ),
+      box(
+        'flywheel-bearing-left',
+        [0.08, 0.5, 0.18],
+        [-0.42, 0.33, 0],
+        0x64748b
+      ),
+      box(
+        'flywheel-bearing-right',
+        [0.08, 0.5, 0.18],
+        [0.42, 0.33, 0],
+        0x64748b
+      ),
       {
         kind: 'ring',
-        name: 'flywheel-rotor-ring',
-        radius: 0.55,
-        tube: 0.08,
-        position: [0, 0.65, 0],
-        rotation: [Math.PI / 2, 0, 0],
-        color: 0x2dd4bf,
+        name: 'flywheel-heavy-wheel',
+        radius: FLYWHEEL_WHEEL.radius * 0.25,
+        tube: FLYWHEEL_WHEEL.rimTube * 0.35,
+        position: [-0.2, 0.48, 0],
+        rotation: [0, Math.PI / 2, 0],
+        color: 0x94a3b8,
       },
-      box('flywheel-spoke', [1, 0.05, 0.06], [0, 0.65, 0], 0xccfbf1),
+      box('flywheel-spoke', [0.42, 0.025, 0.025], [-0.2, 0.48, 0], 0xe2e8f0),
+      cyl(
+        'flywheel-gear-cluster',
+        FLYWHEEL_GEARBOX.radius * 0.22,
+        0.08,
+        [0.25, 0.45, 0],
+        0xc08422
+      ),
       box(
-        'flywheel-counterweight',
-        [0.18, 0.16, 0.18],
-        [0.44, 0.65, 0],
+        'flywheel-crank-arm',
+        [0.26, 0.025, 0.025],
+        [0.42, 0.58, 0.16],
         0xf59e0b
       ),
+      sphere('flywheel-crank-handle', 0.045, [0.55, 0.58, 0.2], 0x111827),
+      sphere('flywheel-energy-port', 0.055, [0.5, 0.66, 0.24], 0x38bdf8),
     ],
   },
   'jobbot-studio-terminal': {

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -364,9 +364,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'audit:src:scene:poi:physicalMetadata',
     kind: 'excluded',
     sourceFiles: ['src/scene/poi/physicalMetadata.ts'],
-    syncRevision: 4,
+    syncRevision: 6,
     reason:
-      'Audited support source; PR Reaper real-world dimensions and scene bounds now feed its holographic installation contract while tabletop geometry remains covered by the POI proxy.',
+      'Audited support source; formatted Flywheel physical metadata references the shared kinetic installation contract while tabletop geometry remains covered by its POI proxy.',
   },
   {
     id: 'audit:src:scene:poi:structuredData',

--- a/src/scene/poi/physicalMetadata.ts
+++ b/src/scene/poi/physicalMetadata.ts
@@ -1,3 +1,8 @@
+import {
+  FLYWHEEL_AVATAR_PATH_RADIUS,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_MARKER_MIN_HEIGHT,
+} from '../structures/flywheelEnergyContract';
 import { PORTFOLIO_MINIATURE_TABLE_DIMENSIONS } from '../structures/portfolioMiniatureTableContract';
 import {
   PR_REAPER_INTENDED_BOUNDS,
@@ -39,6 +44,21 @@ const RASPBERRY_PI_5_BOARD_FOOTPRINT_METERS = {
 };
 
 const physicalMetadata = {
+  'flywheel-studio-flywheel': {
+    realWorldReference:
+      'industrial hand-cranked flywheel kinetic sculpture with planetary gear reducer',
+    realWorldDimensionsMeters: {
+      width: 1.8,
+      depth: 1.25,
+      height: 1.55,
+    },
+    intendedSceneBounds: FLYWHEEL_INSTALLATION_BOUNDS,
+    anchor: 'bottom-center',
+    clearances: {
+      markerMinHeight: FLYWHEEL_MARKER_MIN_HEIGHT,
+      avatarPathRadius: FLYWHEEL_AVATAR_PATH_RADIUS,
+    },
+  },
   'tokenplace-studio-cluster': {
     realWorldReference: 'dual 27-inch 16:9 workstation',
     realWorldDimensionsMeters: {

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -1,19 +1,14 @@
 import {
   BoxGeometry,
-  CanvasTexture,
   Color,
   CylinderGeometry,
-  DoubleSide,
   Group,
   MathUtils,
   Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  PlaneGeometry,
-  RingGeometry,
-  SRGBColorSpace,
-  TorusGeometry,
   SphereGeometry,
+  TorusGeometry,
 } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
@@ -21,894 +16,564 @@ import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
+import {
+  FLYWHEEL_ANIMATION,
+  FLYWHEEL_AXLE,
+  FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_BEARING_STAND,
+  FLYWHEEL_CRANK,
+  FLYWHEEL_DETAIL_TOOTH_STRIDE,
+  FLYWHEEL_ENERGY_PORT,
+  FLYWHEEL_GEARBOX,
+  FLYWHEEL_GEAR_RADII,
+  FLYWHEEL_GEAR_TEETH,
+  FLYWHEEL_PLANETARY_RATIO,
+  FLYWHEEL_WHEEL,
+  getFlywheelCarrierAngle,
+  getFlywheelPlanetSpinAngle,
+} from './flywheelEnergyContract';
+
 const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
+
+interface FlywheelUpdateContext {
+  elapsed: number;
+  delta: number;
+  emphasis: number;
+  runDecorativeEffects?: boolean;
+}
+
+export interface FlywheelDebugState {
+  crankAngle: number;
+  sunAngle: number;
+  carrierAngle: number;
+  flywheelAngle: number;
+  planetAngles: { orbitAngle: number; spinAngle: number }[];
+  triangleCount: number;
+  disposed: boolean;
+}
 
 export interface FlywheelShowpieceBuild {
   group: Group;
   colliders: RectCollider[];
-  update(context: { elapsed: number; delta: number; emphasis: number }): void;
+  update(context: FlywheelUpdateContext): void;
+  getDebugState(): FlywheelDebugState;
+  dispose(): void;
 }
 
 export interface FlywheelShowpieceOptions {
-  centerX: number;
-  centerZ: number;
+  position?: { x: number; y?: number; z: number };
+  centerX?: number;
+  centerZ?: number;
   roomBounds: Bounds2D;
   orientationRadians?: number;
   detailPolicy?: SceneDetailPolicy;
 }
 
-interface AutomationPillar {
-  mesh: Mesh;
-  material: MeshStandardMaterial;
-  baseHeight: number;
-  phase: number;
-}
+type Owned = Mesh<
+  BoxGeometry | CylinderGeometry | TorusGeometry | SphereGeometry
+>;
 
 export function createFlywheelShowpiece(
   options: FlywheelShowpieceOptions
 ): FlywheelShowpieceBuild {
   const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
-  const isPerformance = detailPolicy.level === 'performance';
-  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
-  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
-  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
-  const torusRadialSegments = detailPolicy.geometry.torusRadialSegments;
-  const torusTubularSegments = detailPolicy.geometry.torusTubularSegments;
-  const ringSegments = detailPolicy.geometry.ringSegments;
-
-  const group = new Group();
-  group.name = 'FlywheelShowpiece';
-
-  const colliders: RectCollider[] = [];
-
+  const anchor = {
+    x: options.position?.x ?? options.centerX ?? 0,
+    y: options.position?.y ?? 0,
+    z: options.position?.z ?? options.centerZ ?? 0,
+  };
+  const segmentScale = Math.max(0.3, detailPolicy.modelDetailScale);
+  const cylinderSegments = Math.max(
+    6,
+    Math.round(detailPolicy.geometry.cylinderSegments)
+  );
+  const torusRadialSegments = Math.max(
+    4,
+    Math.round(detailPolicy.geometry.torusRadialSegments)
+  );
+  const torusTubularSegments = Math.max(
+    8,
+    Math.round(detailPolicy.geometry.torusTubularSegments)
+  );
+  const toothStride = FLYWHEEL_DETAIL_TOOTH_STRIDE[detailPolicy.level];
+  const spokeCount = Math.max(
+    4,
+    Math.round(FLYWHEEL_WHEEL.spokeCount * segmentScale)
+  );
+  const owned: Owned[] = [];
+  const materials: (MeshStandardMaterial | MeshBasicMaterial)[] = [];
   const selectionEventTarget = typeof window === 'undefined' ? null : window;
+  let disposed = false;
   let selectionTarget = 0;
   let selectionStrength = 0;
+  let crankAngle = 0;
+  let decorativePhase = 0;
 
-  const handleSelection = (event: Event) => {
-    const poiId = getPoiIdFromEvent(event);
-    if (!poiId) {
-      return;
-    }
-    if (poiId === FLYWHEEL_POI_ID) {
-      selectionTarget = 1;
-    } else {
-      selectionTarget = 0;
-    }
-  };
+  const metal = material({ color: 0x64748b, metalness: 0.78, roughness: 0.24 });
+  const darkMetal = material({
+    color: 0x172033,
+    metalness: 0.68,
+    roughness: 0.3,
+  });
+  const brass = material({ color: 0xc08422, metalness: 0.74, roughness: 0.22 });
+  const glow = material({
+    color: 0x38bdf8,
+    emissive: 0x0ea5e9,
+    emissiveIntensity: 0.7,
+  });
+  const rubber = material({
+    color: 0x111827,
+    metalness: 0.15,
+    roughness: 0.55,
+  });
 
-  const handleSelectionCleared = (event: Event) => {
-    const poiId = getPoiIdFromEvent(event);
-    if (!poiId || poiId === FLYWHEEL_POI_ID) {
-      selectionTarget = 0;
-    }
-  };
+  const group = new Group();
+  group.name = 'FlywheelEnergyInstallation';
+  group.position.set(anchor.x, anchor.y, anchor.z);
+  group.rotation.y = options.orientationRadians ?? 0;
+  group.scale.set(1, 1, 1);
 
-  const removeSelectionListeners = () => {
-    if (!selectionEventTarget) {
-      return;
-    }
-    selectionEventTarget.removeEventListener('poi:selected', handleSelection);
-    selectionEventTarget.removeEventListener(
-      'poi:selected:analytics',
-      handleSelection
-    );
-    selectionEventTarget.removeEventListener(
-      'poi:selection-cleared',
-      handleSelectionCleared
-    );
-  };
+  const base = mesh(
+    'FlywheelBase',
+    new BoxGeometry(
+      FLYWHEEL_BASE_DIMENSIONS.width,
+      FLYWHEEL_BASE_DIMENSIONS.height,
+      FLYWHEEL_BASE_DIMENSIONS.depth
+    ),
+    darkMetal
+  );
+  base.position.y = FLYWHEEL_BASE_DIMENSIONS.height / 2;
+  group.add(base);
 
-  if (selectionEventTarget) {
-    selectionEventTarget.addEventListener('poi:selected', handleSelection);
-    selectionEventTarget.addEventListener(
-      'poi:selected:analytics',
-      handleSelection
+  for (const [name, x] of [
+    ['FlywheelBearingStandLeft', -FLYWHEEL_BEARING_STAND.xOffset],
+    ['FlywheelBearingStandRight', FLYWHEEL_BEARING_STAND.xOffset],
+  ] as const) {
+    const stand = mesh(
+      name,
+      new BoxGeometry(
+        FLYWHEEL_BEARING_STAND.width,
+        FLYWHEEL_BEARING_STAND.height,
+        FLYWHEEL_BEARING_STAND.depth
+      ),
+      metal
     );
-    selectionEventTarget.addEventListener(
-      'poi:selection-cleared',
-      handleSelectionCleared
+    stand.position.set(
+      x,
+      FLYWHEEL_BASE_DIMENSIONS.height + FLYWHEEL_BEARING_STAND.height / 2,
+      0
     );
-    const handleRemoval = () => {
-      removeSelectionListeners();
-      group.removeEventListener('removed', handleRemoval);
-    };
-    group.addEventListener('removed', handleRemoval);
+    group.add(stand);
   }
 
-  const daisRadius = 1.45;
-  const daisHeight = 0.16;
-  const daisGeometry = new CylinderGeometry(
-    daisRadius,
-    daisRadius,
-    daisHeight,
-    cylinderSegments
+  const axle = mesh(
+    'FlywheelAxle',
+    new CylinderGeometry(
+      FLYWHEEL_AXLE.radius,
+      FLYWHEEL_AXLE.radius,
+      FLYWHEEL_AXLE.length,
+      cylinderSegments
+    ),
+    brass
   );
-  const daisMaterial = new MeshStandardMaterial({
-    color: new Color(0x14202c),
-    roughness: 0.48,
-    metalness: 0.18,
-  });
-  const dais = new Mesh(daisGeometry, daisMaterial);
-  dais.name = 'FlywheelDais';
-  dais.position.set(options.centerX, daisHeight / 2, options.centerZ);
-  group.add(dais);
+  axle.rotation.z = Math.PI / 2;
+  axle.position.set(0, FLYWHEEL_WHEEL.centerY, 0);
+  group.add(axle);
 
-  const pedestalRadius = daisRadius * 0.68;
-  const pedestalHeight = 0.6;
-  const pedestalGeometry = new CylinderGeometry(
-    pedestalRadius,
-    pedestalRadius,
-    pedestalHeight,
-    cylinderSegments
+  const wheelGroup = new Group();
+  wheelGroup.name = 'FlywheelWheelGroup';
+  wheelGroup.position.set(
+    FLYWHEEL_WHEEL.centerX,
+    FLYWHEEL_WHEEL.centerY,
+    FLYWHEEL_WHEEL.centerZ
   );
-  const pedestalMaterial = new MeshStandardMaterial({
-    color: new Color(0x182634),
-    roughness: 0.32,
-    metalness: 0.24,
-  });
-  const pedestal = new Mesh(pedestalGeometry, pedestalMaterial);
-  pedestal.name = 'FlywheelPedestal';
-  pedestal.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight / 2,
-    options.centerZ
+  group.add(wheelGroup);
+  const rim = mesh(
+    'FlywheelHeavyRim',
+    new TorusGeometry(
+      FLYWHEEL_WHEEL.radius,
+      FLYWHEEL_WHEEL.rimTube,
+      torusRadialSegments,
+      torusTubularSegments
+    ),
+    metal
   );
-  group.add(pedestal);
-
-  const accentHeight = 0.12;
-  const accentGeometry = new CylinderGeometry(
-    pedestalRadius * 1.02,
-    pedestalRadius * 1.02,
-    accentHeight,
-    cylinderSegments
+  rim.rotation.y = Math.PI / 2;
+  wheelGroup.add(rim);
+  const hub = mesh(
+    'FlywheelInnerHub',
+    new CylinderGeometry(
+      0.22,
+      0.22,
+      FLYWHEEL_WHEEL.thickness,
+      cylinderSegments
+    ),
+    brass
   );
-  const accentMaterial = new MeshStandardMaterial({
-    color: new Color(0x5ad1ff),
-    emissive: new Color(0x178aff),
-    emissiveIntensity: 0.85,
-    roughness: 0.22,
-    metalness: 0.42,
-  });
-  const accent = new Mesh(accentGeometry, accentMaterial);
-  accent.name = 'FlywheelAccent';
-  accent.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + accentHeight / 2,
-    options.centerZ
-  );
-  group.add(accent);
-
-  const glassHeight = 1.3;
-  const glassRadius = pedestalRadius * 0.92;
-  const glassGeometry = new CylinderGeometry(
-    glassRadius,
-    glassRadius,
-    glassHeight,
-    cylinderSegments,
-    1,
-    true
-  );
-  const glassMaterial = new MeshStandardMaterial({
-    color: new Color(0x1c2d3d),
-    transparent: true,
-    opacity: 0.18,
-    roughness: 0.08,
-    metalness: 0.05,
-  });
-  const glass = new Mesh(glassGeometry, glassMaterial);
-  glass.name = 'FlywheelGlass';
-  glass.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + glassHeight / 2,
-    options.centerZ
-  );
-  glass.visible = detailPolicy.effects.glassTransmission;
-  group.add(glass);
-
-  const rotorGroup = new Group();
-  rotorGroup.name = 'FlywheelRotorGroup';
-  rotorGroup.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + glassHeight * 0.36,
-    options.centerZ
-  );
-  group.add(rotorGroup);
-
-  const rotorRingRadius = glassRadius * 0.85;
-  const rotorRingTube = 0.09;
-  const rotorRingGeometry = new TorusGeometry(
-    rotorRingRadius,
-    rotorRingTube,
-    torusRadialSegments,
-    torusTubularSegments
-  );
-  const rotorRingMaterial = new MeshStandardMaterial({
-    color: new Color(0x2c95ff),
-    emissive: new Color(0x65d0ff),
-    emissiveIntensity: 0.9,
-    roughness: 0.2,
-    metalness: 0.5,
-  });
-  const rotorRing = new Mesh(rotorRingGeometry, rotorRingMaterial);
-  rotorRing.name = 'FlywheelRotorRing';
-  rotorRing.rotation.x = Math.PI / 2;
-  rotorGroup.add(rotorRing);
-
-  const innerDiscGeometry = new CylinderGeometry(
-    0.38,
-    0.38,
-    0.06,
-    cylinderSegments
-  );
-  const innerDiscMaterial = new MeshStandardMaterial({
-    color: new Color(0x101822),
-    roughness: 0.34,
-    metalness: 0.3,
-  });
-  const innerDisc = new Mesh(innerDiscGeometry, innerDiscMaterial);
-  innerDisc.name = 'FlywheelInnerDisc';
-  innerDisc.rotation.x = Math.PI / 2;
-  rotorGroup.add(innerDisc);
-
-  const spokesGroup = new Group();
-  spokesGroup.name = 'FlywheelSpokesGroup';
-  rotorGroup.add(spokesGroup);
-  const spokeCount = 6;
-  const spokeLength = rotorRingRadius * 1.6;
-  const spokeGeometry = new BoxGeometry(spokeLength, 0.06, 0.08);
-  const spokeMaterial = new MeshStandardMaterial({
-    color: new Color(0x3fb8ff),
-    emissive: new Color(0x1d74ff),
-    emissiveIntensity: 0.75,
-    roughness: 0.26,
-    metalness: 0.46,
-  });
+  hub.rotation.x = Math.PI / 2;
+  wheelGroup.add(hub);
   for (let i = 0; i < spokeCount; i += 1) {
-    const spoke = new Mesh(spokeGeometry, spokeMaterial);
-    spoke.position.x = spokeLength / 2 - 0.08;
-    spoke.rotation.z = Math.PI / 2;
-    const spokeWrapper = new Group();
-    spokeWrapper.rotation.y = (Math.PI * 2 * i) / spokeCount;
-    spokeWrapper.add(spoke);
-    spokesGroup.add(spokeWrapper);
-  }
-
-  const counterGroup = new Group();
-  counterGroup.name = 'FlywheelCounterGroup';
-  counterGroup.position.copy(rotorGroup.position);
-  group.add(counterGroup);
-
-  const counterRingGeometry = new TorusGeometry(
-    rotorRingRadius * 0.72,
-    0.07,
-    torusRadialSegments,
-    torusTubularSegments
-  );
-  const counterRingMaterial = new MeshStandardMaterial({
-    color: new Color(0x1f88ff),
-    emissive: new Color(0x2bbcff),
-    emissiveIntensity: 0.8,
-    roughness: 0.24,
-    metalness: 0.38,
-  });
-  const counterRing = new Mesh(counterRingGeometry, counterRingMaterial);
-  counterRing.name = 'FlywheelCounterRing';
-  counterRing.rotation.x = Math.PI / 2;
-  counterGroup.add(counterRing);
-
-  const glyphRingGeometry = new RingGeometry(
-    rotorRingRadius * 0.58,
-    rotorRingRadius * 0.72,
-    ringSegments,
-    1
-  );
-  const glyphRingMaterial = new MeshBasicMaterial({
-    color: new Color(0x8ad9ff),
-    transparent: true,
-    opacity: 0.22,
-    side: DoubleSide,
-    depthWrite: false,
-  });
-  const glyphRing = new Mesh(glyphRingGeometry, glyphRingMaterial);
-  glyphRing.name = 'FlywheelGlyphRing';
-  glyphRing.rotation.x = Math.PI / 2;
-  counterGroup.add(glyphRing);
-
-  const orbitGroup = new Group();
-  orbitGroup.name = 'FlywheelOrbitGroup';
-  orbitGroup.position.copy(rotorGroup.position);
-  orbitGroup.visible = !isPerformance;
-  group.add(orbitGroup);
-
-  const automationPillars: AutomationPillar[] = [];
-  const automationPillarGroup = new Group();
-  automationPillarGroup.name = 'FlywheelAutomationPillars';
-  automationPillarGroup.position.copy(rotorGroup.position);
-  automationPillarGroup.visible = !isPerformance;
-  group.add(automationPillarGroup);
-
-  const pillarCount = 4;
-  const pillarHeight = Math.min(1.05, pedestalHeight * 1.5);
-  const pillarRadius = rotorRingRadius * 0.94;
-  const pillarGeometry = new CylinderGeometry(
-    0.12,
-    0.18,
-    pillarHeight,
-    cylinderSegments
-  );
-  for (let index = 0; index < pillarCount; index += 1) {
-    const pillarMaterial = new MeshStandardMaterial({
-      color: new Color(0x102133),
-      emissive: new Color(0x3aaaff),
-      emissiveIntensity: 0.28,
-      roughness: 0.28,
-      metalness: 0.46,
-      transparent: true,
-      opacity: 0.12,
-    });
-    const pillar = new Mesh(pillarGeometry, pillarMaterial);
-    pillar.name = `FlywheelAutomationPillar-${index}`;
-    const angle = (Math.PI * 2 * index) / pillarCount;
-    const pillarBase = daisHeight + 0.04;
-    pillar.position.set(
-      Math.cos(angle) * pillarRadius,
-      pillarBase + pillarHeight / 2,
-      Math.sin(angle) * pillarRadius
+    const spoke = mesh(
+      `FlywheelSpoke-${i}`,
+      new BoxGeometry(FLYWHEEL_WHEEL.radius * 1.5, 0.055, 0.06),
+      metal
     );
-    automationPillarGroup.add(pillar);
-    automationPillars.push({
-      mesh: pillar,
-      material: pillarMaterial,
-      baseHeight: pillar.position.y,
-      phase: angle,
-    });
+    spoke.rotation.z = (i / spokeCount) * Math.PI * 2;
+    wheelGroup.add(spoke);
   }
-
-  const orbitRadius = rotorRingRadius * 1.12;
-  const orbitGeometry = new SphereGeometry(
-    0.08,
-    sphereWidthSegments,
-    sphereHeightSegments
-  );
-  const orbitMaterial = new MeshStandardMaterial({
-    color: new Color(0xffffff),
-    emissive: new Color(0x7be9ff),
-    emissiveIntensity: 1.1,
-    roughness: 0.1,
-    metalness: 0.18,
-  });
-  const orbitCount = 3;
-  for (let i = 0; i < orbitCount; i += 1) {
-    const orb = new Mesh(orbitGeometry, orbitMaterial);
-    const wrapper = new Group();
-    wrapper.rotation.y = (Math.PI * 2 * i) / orbitCount;
-    orb.position.set(orbitRadius, 0, 0);
-    wrapper.add(orb);
-    orbitGroup.add(wrapper);
+  for (let i = 0; i < FLYWHEEL_WHEEL.counterweightCount; i += 1) {
+    const weight = mesh(
+      `FlywheelCounterweight-${i}`,
+      new BoxGeometry(0.2, 0.22, 0.16),
+      brass
+    );
+    const angle = i * Math.PI;
+    weight.position.set(Math.cos(angle) * 0.72, Math.sin(angle) * 0.72, 0);
+    weight.rotation.z = angle;
+    wheelGroup.add(weight);
   }
-
-  const techStackGroup = new Group();
-  techStackGroup.name = 'FlywheelTechStackGroup';
-  techStackGroup.position.copy(rotorGroup.position);
-  techStackGroup.visible = !isPerformance;
-  group.add(techStackGroup);
-
-  const techStackItems = [
-    {
-      label: 'CI templates',
-      caption: 'lint · test · deploy',
-      accent: '#56d7ff',
-    },
-    {
-      label: 'Typed prompts',
-      caption: 'codex-driven flows',
-      accent: '#63e1ff',
-    },
-    {
-      label: 'Scaffolds',
-      caption: 'vite · playwright',
-      accent: '#71e9ff',
-    },
-  ];
-
-  const techStackRadius = rotorRingRadius * 1.32;
-  const techStackGeometry = new PlaneGeometry(0.72, 0.28);
-  const techStackChips: {
-    wrapper: Group;
-    mesh: Mesh;
-    material: MeshBasicMaterial;
-  }[] = [];
-
-  techStackItems.forEach((item, index) => {
-    const texture = createFlywheelTechStackChipTexture(item);
-    const material = new MeshBasicMaterial({
-      map: texture,
-      transparent: true,
-      opacity: 0,
-      depthWrite: false,
-    });
-    const mesh = new Mesh(techStackGeometry, material);
-    mesh.name = `FlywheelTechStackChip:${index}`;
-    mesh.position.set(techStackRadius, 0.22, 0);
-    mesh.lookAt(0, mesh.position.y, 0);
-    mesh.rotateY(Math.PI);
-    mesh.renderOrder = 18;
-    mesh.visible = false;
-
-    const wrapper = new Group();
-    wrapper.name = `FlywheelTechStackChipWrapper:${index}`;
-    wrapper.rotation.y = (Math.PI * 2 * index) / techStackItems.length;
-    wrapper.add(mesh);
-    techStackGroup.add(wrapper);
-
-    techStackChips.push({ wrapper, mesh, material });
-  });
-
-  const kioskWidth = 0.6;
-  const orientation = options.orientationRadians ?? 0;
-  const panelRadius = daisRadius + 0.48;
-  const targetPanelX = options.centerX + Math.cos(orientation) * panelRadius;
-  const targetPanelZ = options.centerZ + Math.sin(orientation) * panelRadius;
-  const clampedPanelX = MathUtils.clamp(
-    targetPanelX,
-    options.roomBounds.minX + kioskWidth / 2,
-    options.roomBounds.maxX - kioskWidth / 2
+  const glowRing = mesh(
+    'FlywheelEnergyGlowRing',
+    new TorusGeometry(
+      FLYWHEEL_WHEEL.radius * 0.78,
+      0.018,
+      torusRadialSegments,
+      torusTubularSegments
+    ),
+    glow
   );
-  const clampedPanelZ = MathUtils.clamp(
-    targetPanelZ,
-    options.roomBounds.minZ + kioskWidth / 2,
-    options.roomBounds.maxZ - kioskWidth / 2
+  glowRing.rotation.y = Math.PI / 2;
+  wheelGroup.add(glowRing);
+
+  const crankGroup = new Group();
+  crankGroup.name = 'FlywheelCrankGroup';
+  crankGroup.position.set(
+    FLYWHEEL_CRANK.centerX,
+    FLYWHEEL_CRANK.centerY,
+    FLYWHEEL_CRANK.centerZ
   );
-  const infoPanelGroup = new Group();
-  infoPanelGroup.name = 'FlywheelInfoPanelGroup';
-  infoPanelGroup.position.set(clampedPanelX, daisHeight + 0.62, clampedPanelZ);
-  infoPanelGroup.lookAt(options.centerX, daisHeight + 0.62, options.centerZ);
-  infoPanelGroup.rotateY(Math.PI);
-  group.add(infoPanelGroup);
+  group.add(crankGroup);
+  const crankDisc = mesh(
+    'FlywheelCrankDisc',
+    new CylinderGeometry(
+      FLYWHEEL_CRANK.discRadius,
+      FLYWHEEL_CRANK.discRadius,
+      0.06,
+      cylinderSegments
+    ),
+    brass
+  );
+  crankDisc.rotation.x = Math.PI / 2;
+  crankGroup.add(crankDisc);
+  const crankArm = mesh(
+    'FlywheelCrankArm',
+    new BoxGeometry(FLYWHEEL_CRANK.armLength, FLYWHEEL_CRANK.armWidth, 0.045),
+    brass
+  );
+  crankArm.position.x = FLYWHEEL_CRANK.armLength / 2;
+  crankGroup.add(crankArm);
+  const crankHandle = mesh(
+    'FlywheelCrankHandle',
+    new CylinderGeometry(
+      FLYWHEEL_CRANK.handleRadius,
+      FLYWHEEL_CRANK.handleRadius,
+      FLYWHEEL_CRANK.handleLength,
+      cylinderSegments
+    ),
+    rubber
+  );
+  crankHandle.rotation.x = Math.PI / 2;
+  crankHandle.position.x = FLYWHEEL_CRANK.radius;
+  crankGroup.add(crankHandle);
 
-  const panelTexture = createFlywheelTechStackTexture();
-  const panelMaterial = new MeshBasicMaterial({
-    map: panelTexture,
-    transparent: true,
-    opacity: 0.08,
-    depthWrite: false,
-  });
-  const panelGeometry = new PlaneGeometry(1.8, 1);
-  const panel = new Mesh(panelGeometry, panelMaterial);
-  panel.name = 'FlywheelInfoPanel';
-  panel.position.y = 0.4;
-  panel.renderOrder = 14;
-  infoPanelGroup.add(panel);
+  const gearbox = new Group();
+  gearbox.name = 'FlywheelPlanetaryGearbox';
+  gearbox.position.set(
+    FLYWHEEL_GEARBOX.centerX,
+    FLYWHEEL_GEARBOX.centerY,
+    FLYWHEEL_GEARBOX.centerZ
+  );
+  group.add(gearbox);
+  const ringGear = makeGear(
+    'FlywheelRingGear',
+    FLYWHEEL_GEAR_RADII.ring,
+    FLYWHEEL_GEAR_TEETH.ring,
+    true,
+    darkMetal
+  );
+  gearbox.add(ringGear);
+  const sunGear = makeGear(
+    'FlywheelSunGear',
+    FLYWHEEL_GEAR_RADII.sun,
+    FLYWHEEL_GEAR_TEETH.sun,
+    false,
+    brass
+  );
+  gearbox.add(sunGear);
+  const carrier = new Group();
+  carrier.name = 'FlywheelPlanetCarrier';
+  gearbox.add(carrier);
+  const carrierBar = mesh(
+    'FlywheelPlanetCarrierBar',
+    new BoxGeometry(FLYWHEEL_GEARBOX.planetOrbitRadius * 2.2, 0.04, 0.04),
+    metal
+  );
+  carrier.add(carrierBar);
+  const planetGears: Group[] = [];
+  for (let i = 0; i < FLYWHEEL_GEAR_TEETH.planets; i += 1) {
+    const planet = makeGear(
+      `FlywheelPlanetGear-${i}`,
+      FLYWHEEL_GEAR_RADII.planet,
+      FLYWHEEL_GEAR_TEETH.planet,
+      false,
+      metal
+    );
+    carrier.add(planet);
+    planetGears.push(planet);
+  }
+  const outputShaft = mesh(
+    'FlywheelOutputShaft',
+    new CylinderGeometry(0.06, 0.06, 1.05, cylinderSegments),
+    brass
+  );
+  outputShaft.rotation.x = Math.PI / 2;
+  gearbox.add(outputShaft);
 
-  const panelBackerGeometry = new PlaneGeometry(1.84, 1.04);
-  const panelBackerMaterial = new MeshStandardMaterial({
-    color: new Color(0x0c141d),
-    emissive: new Color(0x1a2c3c),
-    emissiveIntensity: 0.4,
-    roughness: 0.4,
-    metalness: 0.12,
-  });
-  const panelBacker = new Mesh(panelBackerGeometry, panelBackerMaterial);
-  panelBacker.name = 'FlywheelInfoPanelBacker';
-  panelBacker.position.set(0, 0.4, -0.02);
-  infoPanelGroup.add(panelBacker);
+  const energyPort = mesh(
+    'FlywheelEnergyPort',
+    new SphereGeometry(
+      FLYWHEEL_ENERGY_PORT.radius,
+      cylinderSegments,
+      Math.max(4, Math.round(cylinderSegments / 2))
+    ),
+    glow
+  );
+  energyPort.position.set(
+    FLYWHEEL_ENERGY_PORT.x,
+    FLYWHEEL_ENERGY_PORT.y,
+    FLYWHEEL_ENERGY_PORT.z
+  );
+  group.add(energyPort);
 
-  const panelGlowGeometry = new PlaneGeometry(1.9, 1.08);
-  const panelGlowMaterial = new MeshBasicMaterial({
-    color: new Color(0x3ebaff),
-    transparent: true,
-    opacity: 0.06,
-    depthWrite: false,
-  });
-  const panelGlow = new Mesh(panelGlowGeometry, panelGlowMaterial);
-  panelGlow.name = 'FlywheelInfoPanelGlow';
-  panelGlow.position.set(0, 0.4, 0.02);
-  panelGlow.renderOrder = 13;
-  infoPanelGroup.add(panelGlow);
+  const colliders = createColliders(anchor);
+  attachSelectionListeners();
 
-  const plinthGeometry = new BoxGeometry(0.42, 0.5, 0.42);
-  const plinthMaterial = new MeshStandardMaterial({
-    color: new Color(0x101823),
-    roughness: 0.36,
-    metalness: 0.18,
-  });
-  const plinth = new Mesh(plinthGeometry, plinthMaterial);
-  plinth.name = 'FlywheelInfoPanelPlinth';
-  plinth.position.set(0, 0.25, 0);
-  infoPanelGroup.add(plinth);
-
-  const calloutTexture = createFlywheelDocsCalloutTexture();
-  const calloutMaterial = new MeshBasicMaterial({
-    map: calloutTexture,
-    transparent: true,
-    opacity: 0,
-    depthWrite: false,
-  });
-  const calloutGeometry = new PlaneGeometry(1, 0.46);
-  const callout = new Mesh(calloutGeometry, calloutMaterial);
-  callout.name = 'FlywheelDocsCallout';
-  callout.position.set(0, 0.78, 0.05);
-  callout.renderOrder = 16;
-  callout.visible = false;
-  infoPanelGroup.add(callout);
-
-  const calloutGlowGeometry = new PlaneGeometry(1.06, 0.52);
-  const calloutGlowMaterial = new MeshBasicMaterial({
-    color: new Color(0x4cd0ff),
-    transparent: true,
-    opacity: 0,
-    depthWrite: false,
-  });
-  const calloutGlow = new Mesh(calloutGlowGeometry, calloutGlowMaterial);
-  calloutGlow.name = 'FlywheelDocsCalloutGlow';
-  calloutGlow.position.set(0, callout.position.y, 0.06);
-  calloutGlow.renderOrder = 15;
-  calloutGlow.visible = false;
-  infoPanelGroup.add(calloutGlow);
-
-  colliders.push({
-    minX: options.centerX - daisRadius,
-    maxX: options.centerX + daisRadius,
-    minZ: options.centerZ - daisRadius,
-    maxZ: options.centerZ + daisRadius,
-  });
-
-  colliders.push({
-    minX: infoPanelGroup.position.x - kioskWidth / 2,
-    maxX: infoPanelGroup.position.x + kioskWidth / 2,
-    minZ: infoPanelGroup.position.z - kioskWidth / 2,
-    maxZ: infoPanelGroup.position.z + kioskWidth / 2,
-  });
-
-  let spinVelocity = 0.6;
-  let infoReveal = 0.08;
-  let calloutPhase = 0;
-  let techStackReveal = 0.04;
-
-  function update(context: {
-    elapsed: number;
-    delta: number;
-    emphasis: number;
-  }) {
-    const smoothing =
-      context.delta > 0 ? 1 - Math.exp(-context.delta * 3.8) : 1;
-    selectionStrength = MathUtils.lerp(
+  function update(context: FlywheelUpdateContext) {
+    if (disposed) return;
+    const emphasis = MathUtils.clamp(
+      Math.max(context.emphasis, selectionStrength),
+      0,
+      1
+    );
+    selectionStrength = MathUtils.damp(
       selectionStrength,
       selectionTarget,
-      smoothing
+      7,
+      context.delta
     );
-    const selectionInfluence = MathUtils.clamp(selectionStrength, 0, 1);
-    if (
-      isPerformance &&
-      Math.max(context.emphasis, selectionInfluence) < 0.02
-    ) {
-      rotorGroup.rotation.y += 0.12 * context.delta;
-      return;
+    const speed =
+      FLYWHEEL_ANIMATION.crankRadiansPerSecond *
+      (1 + emphasis * FLYWHEEL_ANIMATION.emphasisSpeedBoost);
+    crankAngle += speed * Math.max(0, context.delta);
+    const carrierAngle = getFlywheelCarrierAngle(crankAngle);
+    const planetSpinAngle = getFlywheelPlanetSpinAngle(crankAngle);
+    crankGroup.rotation.z = crankAngle;
+    sunGear.rotation.z = crankAngle;
+    carrier.rotation.z = carrierAngle;
+    wheelGroup.rotation.z = carrierAngle;
+    outputShaft.rotation.z = carrierAngle;
+    planetGears.forEach((planet, index) => {
+      const orbitAngle = (index / planetGears.length) * Math.PI * 2;
+      planet.position.set(
+        Math.cos(orbitAngle) * FLYWHEEL_GEARBOX.planetOrbitRadius,
+        Math.sin(orbitAngle) * FLYWHEEL_GEARBOX.planetOrbitRadius,
+        0.03
+      );
+      planet.rotation.z = planetSpinAngle;
+    });
+    if (context.runDecorativeEffects ?? true) {
+      decorativePhase = context.elapsed;
+      const glowIntensity =
+        FLYWHEEL_ANIMATION.glowBaseIntensity +
+        emphasis * FLYWHEEL_ANIMATION.glowEmphasisIntensity;
+      glow.emissiveIntensity =
+        glowIntensity + Math.sin(decorativePhase * 3) * 0.08;
+      energyPort.scale.setScalar(
+        1 + emphasis * 0.25 + Math.sin(decorativePhase * 4) * 0.04
+      );
     }
-    const targetVelocity =
-      MathUtils.lerp(0.55, 2.4, context.emphasis) +
-      MathUtils.lerp(0, 1.1, selectionInfluence);
-    spinVelocity = MathUtils.lerp(spinVelocity, targetVelocity, smoothing);
-    rotorGroup.rotation.y += spinVelocity * context.delta;
-    counterGroup.rotation.y -= spinVelocity * 0.42 * context.delta;
-    orbitGroup.rotation.y += spinVelocity * 0.3 * context.delta;
+  }
 
-    const targetEmissive = MathUtils.lerp(0.8, 2.4, context.emphasis);
-    accentMaterial.emissiveIntensity = MathUtils.lerp(
-      accentMaterial.emissiveIntensity,
-      targetEmissive + MathUtils.lerp(0, 0.6, selectionInfluence),
-      smoothing
-    );
-    rotorRingMaterial.emissiveIntensity = MathUtils.lerp(
-      rotorRingMaterial.emissiveIntensity,
-      MathUtils.lerp(0.9, 2.1, context.emphasis) +
-        MathUtils.lerp(0, 0.5, selectionInfluence),
-      smoothing
-    );
-    spokeMaterial.emissiveIntensity = MathUtils.lerp(
-      spokeMaterial.emissiveIntensity,
-      MathUtils.lerp(0.75, 1.8, context.emphasis) +
-        MathUtils.lerp(0, 0.45, selectionInfluence),
-      smoothing
-    );
-    counterRingMaterial.emissiveIntensity = MathUtils.lerp(
-      counterRingMaterial.emissiveIntensity,
-      MathUtils.lerp(0.8, 1.9, context.emphasis) +
-        MathUtils.lerp(0, 0.42, selectionInfluence),
-      smoothing
-    );
+  function getDebugState(): FlywheelDebugState {
+    const carrierAngle = getFlywheelCarrierAngle(crankAngle);
+    return {
+      crankAngle,
+      sunAngle: sunGear.rotation.z,
+      carrierAngle,
+      flywheelAngle: wheelGroup.rotation.z,
+      planetAngles: planetGears.map((planet, index) => ({
+        orbitAngle: (index / planetGears.length) * Math.PI * 2 + carrierAngle,
+        spinAngle: planet.rotation.z,
+      })),
+      triangleCount: countTriangles(group),
+      disposed,
+    };
+  }
 
-    const pillarEmphasis = Math.max(context.emphasis, selectionInfluence);
-    const pillarMotionScale = MathUtils.lerp(0.2, 1, pillarEmphasis);
-    automationPillars.forEach((pillar) => {
-      const bob =
-        Math.sin(context.elapsed * 1.1 + pillar.phase) *
-        0.08 *
-        pillarMotionScale;
-      pillar.mesh.position.y = pillar.baseHeight + bob;
-      pillar.material.emissiveIntensity = MathUtils.lerp(
-        pillar.material.emissiveIntensity,
-        MathUtils.lerp(0.35, 1.7, pillarEmphasis) +
-          MathUtils.lerp(0, 0.9, selectionInfluence),
-        smoothing
-      );
-      pillar.material.opacity = MathUtils.lerp(
-        pillar.material.opacity,
-        MathUtils.lerp(0.18, 0.75, pillarEmphasis),
-        smoothing
-      );
-      pillar.mesh.visible = pillar.material.opacity > 0.02;
+  function dispose() {
+    if (disposed) return;
+    disposed = true;
+    removeSelectionListeners();
+    owned.forEach((item) => item.geometry.dispose());
+    materials.forEach((item) => item.dispose());
+  }
+
+  function material(options: {
+    color: number;
+    metalness?: number;
+    roughness?: number;
+    emissive?: number;
+    emissiveIntensity?: number;
+  }) {
+    const created = new MeshStandardMaterial({
+      color: new Color(options.color),
+      metalness: options.metalness ?? 0.4,
+      roughness: options.roughness ?? 0.28,
+      emissive: new Color(options.emissive ?? 0x000000),
+      emissiveIntensity: options.emissiveIntensity ?? 0,
     });
+    materials.push(created);
+    return created;
+  }
 
-    infoReveal = MathUtils.lerp(
-      infoReveal,
-      MathUtils.lerp(0.08, 1, context.emphasis),
-      smoothing
-    );
-    panelMaterial.opacity = infoReveal;
-    panelGlowMaterial.opacity = MathUtils.lerp(0.05, 0.32, context.emphasis);
-    panel.position.y = MathUtils.lerp(0.34, 0.56, context.emphasis);
-    panelBacker.position.y = panel.position.y - 0.02;
-    panelGlow.position.y = panel.position.y;
-    panel.visible = panelMaterial.opacity > 0.04;
-    panelGlow.visible = panel.visible;
+  function mesh(
+    name: string,
+    geometry: Owned['geometry'],
+    meshMaterial: MeshStandardMaterial | MeshBasicMaterial
+  ): Owned {
+    const created = new Mesh(geometry, meshMaterial) as Owned;
+    created.name = name;
+    owned.push(created);
+    return created;
+  }
 
-    calloutPhase +=
-      context.delta *
-      (MathUtils.lerp(0.55, 1.35, context.emphasis) +
-        MathUtils.lerp(0, 0.35, selectionInfluence));
-    const calloutBob = Math.sin(calloutPhase) * 0.05;
-    const panelReveal = MathUtils.clamp(infoReveal, 0, 1);
-    const calloutRevealBase = Math.pow(panelReveal, 0.8);
-    const selectionReveal = Math.pow(selectionInfluence, 0.85);
-    const combinedReveal = calloutRevealBase * selectionReveal;
-    const calloutOpacity =
-      combinedReveal * MathUtils.lerp(0.2, 0.95, context.emphasis);
-    calloutMaterial.opacity = calloutOpacity;
-    calloutGlowMaterial.opacity =
-      combinedReveal * MathUtils.lerp(0.05, 0.32, context.emphasis);
-    const baseCalloutHeight =
-      MathUtils.lerp(0.7, 0.94, context.emphasis) +
-      MathUtils.lerp(0, 0.08, selectionInfluence);
-    callout.position.y = baseCalloutHeight + calloutBob;
-    calloutGlow.position.y = callout.position.y;
-    callout.visible = calloutMaterial.opacity > 0.02;
-    calloutGlow.visible = callout.visible;
-
-    glyphRingMaterial.opacity = MathUtils.lerp(
-      0.18,
-      0.36,
-      Math.max(context.emphasis, selectionInfluence)
-    );
-    orbitGroup.children.forEach((wrapper, index) => {
-      wrapper.rotation.y =
-        context.elapsed * 0.65 + (Math.PI * 2 * index) / orbitCount;
-    });
-
-    techStackReveal = MathUtils.lerp(
-      techStackReveal,
-      Math.max(
-        MathUtils.lerp(0.02, 0.35, context.emphasis),
-        selectionInfluence
+  function makeGear(
+    name: string,
+    radius: number,
+    teeth: number,
+    internal: boolean,
+    gearMaterial: MeshStandardMaterial
+  ): Group {
+    const gear = new Group();
+    gear.name = name;
+    const body = mesh(
+      `${name}Body`,
+      new CylinderGeometry(
+        radius,
+        radius,
+        FLYWHEEL_GEAR_RADII.depth,
+        cylinderSegments
       ),
-      smoothing
+      gearMaterial
     );
-    const chipOpacity = MathUtils.lerp(0, 0.96, techStackReveal);
-    const chipOrbitSpeed =
-      MathUtils.lerp(0.3, 0.75, context.emphasis) +
-      MathUtils.lerp(0, 0.35, selectionInfluence);
-    techStackChips.forEach((chip, index) => {
-      const baseAngle = (Math.PI * 2 * index) / techStackChips.length;
-      chip.wrapper.rotation.y = context.elapsed * chipOrbitSpeed + baseAngle;
-      chip.mesh.position.y =
-        MathUtils.lerp(0.18, 0.34, context.emphasis) +
-        Math.sin(context.elapsed * 1.2 + index) * 0.05;
-      const targetOpacity =
-        MathUtils.clamp(techStackReveal, 0, 1) * chipOpacity;
-      chip.material.opacity = MathUtils.lerp(
-        chip.material.opacity,
-        targetOpacity,
-        smoothing
+    body.rotation.x = Math.PI / 2;
+    gear.add(body);
+    const visibleTeeth = Math.max(4, Math.ceil(teeth / toothStride));
+    for (let i = 0; i < visibleTeeth; i += 1) {
+      const angle = (i / visibleTeeth) * Math.PI * 2;
+      const tooth = mesh(
+        `${name}Tooth-${i}`,
+        new BoxGeometry(
+          0.045,
+          FLYWHEEL_GEAR_RADII.toothDepth,
+          FLYWHEEL_GEAR_RADII.depth * 1.1
+        ),
+        gearMaterial
       );
-      chip.mesh.visible = chip.material.opacity > 0.02;
-    });
+      const direction = internal ? -1 : 1;
+      const toothRadius =
+        radius + direction * FLYWHEEL_GEAR_RADII.toothDepth * 0.45;
+      tooth.position.set(
+        Math.cos(angle) * toothRadius,
+        Math.sin(angle) * toothRadius,
+        0
+      );
+      tooth.rotation.z = angle + (internal ? 0 : Math.PI / 2);
+      gear.add(tooth);
+    }
+    return gear;
   }
 
-  return {
-    group,
-    colliders,
-    update,
-  };
+  function getPoiIdFromEvent(event: Event): string | null {
+    const detail = (
+      event as CustomEvent<{ poi?: { id?: string }; poiId?: string }>
+    ).detail;
+    return detail?.poi?.id ?? detail?.poiId ?? null;
+  }
+
+  function handleSelection(event: Event) {
+    selectionTarget = getPoiIdFromEvent(event) === FLYWHEEL_POI_ID ? 1 : 0;
+  }
+  function handleSelectionCleared(event: Event) {
+    const poiId = getPoiIdFromEvent(event);
+    if (!poiId || poiId === FLYWHEEL_POI_ID) selectionTarget = 0;
+  }
+  function attachSelectionListeners() {
+    selectionEventTarget?.addEventListener('poi:selected', handleSelection);
+    selectionEventTarget?.addEventListener(
+      'poi:selected:analytics',
+      handleSelection
+    );
+    selectionEventTarget?.addEventListener(
+      'poi:selection-cleared',
+      handleSelectionCleared
+    );
+  }
+  function removeSelectionListeners() {
+    selectionEventTarget?.removeEventListener('poi:selected', handleSelection);
+    selectionEventTarget?.removeEventListener(
+      'poi:selected:analytics',
+      handleSelection
+    );
+    selectionEventTarget?.removeEventListener(
+      'poi:selection-cleared',
+      handleSelectionCleared
+    );
+  }
+
+  return { group, colliders, update, getDebugState, dispose };
 }
 
-function createFlywheelTechStackTexture(): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 1024;
-  canvas.height = 512;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create tech stack canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-
-  const gradient = context.createLinearGradient(
-    0,
-    0,
-    canvas.width,
-    canvas.height
-  );
-  gradient.addColorStop(0, 'rgba(33, 139, 255, 0.92)');
-  gradient.addColorStop(1, 'rgba(18, 196, 255, 0.62)');
-
-  context.fillStyle = 'rgba(5, 16, 28, 0.85)';
-  roundRect(context, 40, 40, canvas.width - 80, canvas.height - 80, 28);
-  context.fill();
-
-  context.strokeStyle = 'rgba(77, 197, 255, 0.7)';
-  context.lineWidth = 6;
-  context.stroke();
-
-  context.fillStyle = gradient;
-  context.font = 'bold 96px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'top';
-  context.fillText('Flywheel Automation', 80, 86);
-
-  context.fillStyle = '#bde9ff';
-  context.font = '48px "Inter", "Segoe UI", sans-serif';
-  context.fillText(
-    'CI templates · typed prompts · reproducible scaffolds',
-    80,
-    200
-  );
-
-  context.font = '40px "Inter", "Segoe UI", sans-serif';
-  const bulletItems = [
-    'Scripts: lint · test · deploy hooks',
-    'Stacks: Node · Python · WebGL orchestrations',
-    'Runtime: GitHub Actions · pnpm/npm parity',
+function createColliders(anchor: { x: number; z: number }): RectCollider[] {
+  const baseHalfWidth = FLYWHEEL_BASE_DIMENSIONS.width / 2;
+  const baseHalfDepth = FLYWHEEL_BASE_DIMENSIONS.depth / 2;
+  return [
+    {
+      minX: anchor.x - baseHalfWidth,
+      maxX: anchor.x + baseHalfWidth,
+      minZ: anchor.z - baseHalfDepth,
+      maxZ: anchor.z + baseHalfDepth,
+    },
+    {
+      minX: anchor.x + FLYWHEEL_GEARBOX.centerX - 0.62,
+      maxX: anchor.x + FLYWHEEL_CRANK.centerX + 0.45,
+      minZ: anchor.z - 0.55,
+      maxZ: anchor.z + FLYWHEEL_CRANK.centerZ + 0.25,
+    },
   ];
-  bulletItems.forEach((item, index) => {
-    const y = 280 + index * 80;
-    context.fillStyle = 'rgba(117, 221, 255, 0.9)';
-    context.fillRect(80, y, 18, 18);
-    context.fillStyle = '#e2f6ff';
-    context.fillText(item, 120, y - 20);
+}
+
+function countTriangles(group: Group): number {
+  let total = 0;
+  group.traverse((object) => {
+    const maybeMesh = object as Mesh;
+    const geometry = maybeMesh.geometry;
+    if (!geometry) return;
+    const index = geometry.getIndex();
+    const position = geometry.getAttribute('position');
+    total += index ? index.count / 3 : position.count / 3;
   });
-
-  context.fillStyle = '#ffffff';
-  context.font = 'bold 64px "Inter", "Segoe UI", sans-serif';
-  context.fillText('Docs →', canvas.width - 280, canvas.height - 120);
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
+  return total;
 }
 
-function createFlywheelDocsCalloutTexture(): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create docs callout canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-  context.save();
-  context.fillStyle = 'rgba(8, 20, 34, 0.92)';
-  roundRect(context, 32, 24, canvas.width - 64, canvas.height - 48, 32);
-  context.fill();
-  context.strokeStyle = 'rgba(76, 208, 255, 0.7)';
-  context.lineWidth = 5;
-  context.stroke();
-  context.restore();
-
-  context.save();
-  context.fillStyle = '#ecfbff';
-  context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'alphabetic';
-  context.fillText('README', 64, canvas.height * 0.56);
-
-  context.font = '600 56px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#a8eeff';
-  context.fillText(
-    'github.com/futuroptimist/flywheel',
-    64,
-    canvas.height * 0.78
-  );
-
-  context.textAlign = 'right';
-  context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#67d2ff';
-  context.fillText('→', canvas.width - 64, canvas.height * 0.58);
-  context.restore();
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function createFlywheelTechStackChipTexture(item: {
-  label: string;
-  caption: string;
-  accent: string;
-}): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create tech stack chip canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-  context.save();
-  context.fillStyle = 'rgba(10, 24, 38, 0.92)';
-  roundRect(context, 28, 36, canvas.width - 56, canvas.height - 72, 42);
-  context.fill();
-  context.strokeStyle = `${item.accent}cc`;
-  context.lineWidth = 6;
-  context.stroke();
-  context.restore();
-
-  context.save();
-  context.fillStyle = item.accent;
-  context.fillRect(52, canvas.height - 78, canvas.width - 104, 12);
-  context.restore();
-
-  context.save();
-  context.fillStyle = '#e7f7ff';
-  context.font = 'bold 104px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'alphabetic';
-  context.fillText(item.label, 64, canvas.height * 0.56);
-
-  context.font = '600 52px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#a4ebff';
-  context.fillText(item.caption, 64, canvas.height * 0.78);
-  context.restore();
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function roundRect(
-  context: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  radius: number
-) {
-  const r = Math.min(radius, width / 2, height / 2);
-  context.beginPath();
-  context.moveTo(x + r, y);
-  context.lineTo(x + width - r, y);
-  context.quadraticCurveTo(x + width, y, x + width, y + r);
-  context.lineTo(x + width, y + height - r);
-  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-  context.lineTo(x + r, y + height);
-  context.quadraticCurveTo(x, y + height, x, y + height - r);
-  context.lineTo(x, y + r);
-  context.quadraticCurveTo(x, y, x + r, y);
-  context.closePath();
-}
-
-type PoiEventDetail = { poi?: { id?: string } };
-
-function getPoiIdFromEvent(event: Event): string | null {
-  const detail = (event as CustomEvent<PoiEventDetail>).detail;
-  if (!detail || typeof detail !== 'object') {
-    return null;
-  }
-  const poiId = detail.poi?.id;
-  return typeof poiId === 'string' ? poiId : null;
-}
+export { FLYWHEEL_PLANETARY_RATIO, FLYWHEEL_GEAR_TEETH };

--- a/src/scene/structures/flywheelEnergyContract.ts
+++ b/src/scene/structures/flywheelEnergyContract.ts
@@ -1,0 +1,108 @@
+import type { SceneDetailLevel } from '../graphics/sceneDetailPolicy';
+
+export const FLYWHEEL_INSTALLATION_BOUNDS = {
+  width: 3.4,
+  depth: 2.4,
+  height: 2.75,
+} as const;
+
+export const FLYWHEEL_BASE_DIMENSIONS = {
+  width: 3.25,
+  depth: 1.55,
+  height: 0.22,
+} as const;
+
+export const FLYWHEEL_WHEEL = {
+  radius: 0.92,
+  rimTube: 0.12,
+  thickness: 0.24,
+  centerX: -0.58,
+  centerY: 1.35,
+  centerZ: 0,
+  spokeCount: 8,
+  counterweightCount: 2,
+} as const;
+
+export const FLYWHEEL_AXLE = {
+  radius: 0.09,
+  length: 2.25,
+} as const;
+
+export const FLYWHEEL_BEARING_STAND = {
+  width: 0.22,
+  depth: 0.5,
+  height: 1.25,
+  xOffset: 1.18,
+} as const;
+
+export const FLYWHEEL_CRANK = {
+  radius: 0.36,
+  discRadius: 0.18,
+  armLength: 0.36,
+  armWidth: 0.055,
+  handleRadius: 0.055,
+  handleLength: 0.32,
+  centerX: 1.18,
+  centerY: 1.24,
+  centerZ: 0.42,
+} as const;
+
+export const FLYWHEEL_GEAR_TEETH = {
+  sun: 18,
+  planet: 15,
+  ring: 48,
+  planets: 3,
+} as const;
+
+export const FLYWHEEL_GEAR_RADII = {
+  sun: 0.18,
+  planet: 0.15,
+  ring: 0.48,
+  toothDepth: 0.035,
+  depth: 0.1,
+} as const;
+
+export const FLYWHEEL_GEARBOX = {
+  centerX: 0.78,
+  centerY: 1.24,
+  centerZ: 0,
+  radius: 0.52,
+  depth: 0.26,
+  planetOrbitRadius: FLYWHEEL_GEAR_RADII.sun + FLYWHEEL_GEAR_RADII.planet,
+} as const;
+
+export const FLYWHEEL_ENERGY_PORT = {
+  x: 1.32,
+  y: 1.62,
+  z: 0.62,
+  radius: 0.13,
+} as const;
+
+export const FLYWHEEL_MARKER_MIN_HEIGHT = 2.95;
+export const FLYWHEEL_AVATAR_PATH_RADIUS = 1.2;
+
+export const FLYWHEEL_PLANETARY_RATIO =
+  1 + FLYWHEEL_GEAR_TEETH.ring / FLYWHEEL_GEAR_TEETH.sun;
+
+export const FLYWHEEL_ANIMATION = {
+  crankRadiansPerSecond: Math.PI * 1.35,
+  emphasisSpeedBoost: 0.12,
+  glowBaseIntensity: 0.45,
+  glowEmphasisIntensity: 1.35,
+} as const;
+
+export const FLYWHEEL_DETAIL_TOOTH_STRIDE: Record<SceneDetailLevel, number> = {
+  cinematic: 1,
+  balanced: 2,
+  performance: 3,
+  low: 6,
+  micro: 12,
+};
+
+export function getFlywheelCarrierAngle(crankAngle: number): number {
+  return crankAngle / FLYWHEEL_PLANETARY_RATIO;
+}
+
+export function getFlywheelPlanetSpinAngle(crankAngle: number): number {
+  return -crankAngle * (FLYWHEEL_GEAR_TEETH.sun / FLYWHEEL_GEAR_TEETH.planet);
+}

--- a/src/tests/flywheelEnergyContract.test.ts
+++ b/src/tests/flywheelEnergyContract.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLYWHEEL_GEARBOX,
+  FLYWHEEL_GEAR_RADII,
+  FLYWHEEL_GEAR_TEETH,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_PLANETARY_RATIO,
+  getFlywheelCarrierAngle,
+  getFlywheelPlanetSpinAngle,
+} from '../scene/structures/flywheelEnergyContract';
+
+describe('flywheel energy contract', () => {
+  it('exports finite physical dimensions and plausible gear constants', () => {
+    expect(FLYWHEEL_INSTALLATION_BOUNDS.width).toBeGreaterThan(3);
+    expect(FLYWHEEL_INSTALLATION_BOUNDS.height).toBeGreaterThan(2);
+    expect(FLYWHEEL_GEAR_TEETH.ring).toBe(
+      FLYWHEEL_GEAR_TEETH.sun + 2 * FLYWHEEL_GEAR_TEETH.planet
+    );
+    expect(FLYWHEEL_GEAR_RADII.ring).toBeCloseTo(
+      FLYWHEEL_GEAR_RADII.sun + 2 * FLYWHEEL_GEAR_RADII.planet
+    );
+    expect(FLYWHEEL_GEARBOX.planetOrbitRadius).toBeCloseTo(
+      FLYWHEEL_GEAR_RADII.sun + FLYWHEEL_GEAR_RADII.planet
+    );
+    expect(Number.isFinite(FLYWHEEL_PLANETARY_RATIO)).toBe(true);
+    expect(FLYWHEEL_PLANETARY_RATIO).toBeCloseTo(
+      1 + FLYWHEEL_GEAR_TEETH.ring / FLYWHEEL_GEAR_TEETH.sun
+    );
+  });
+
+  it('keeps carrier and planet spin synchronized from one crank angle', () => {
+    const crank = Math.PI * 3;
+    expect(getFlywheelCarrierAngle(crank)).toBeCloseTo(
+      crank / FLYWHEEL_PLANETARY_RATIO
+    );
+    expect(getFlywheelPlanetSpinAngle(crank)).toBeCloseTo(
+      -crank * (FLYWHEEL_GEAR_TEETH.sun / FLYWHEEL_GEAR_TEETH.planet)
+    );
+  });
+});

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -1,291 +1,186 @@
-import { Group, Mesh, MeshBasicMaterial, MeshStandardMaterial } from 'three';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Box3, Vector3 } from 'three';
+import { describe, expect, it } from 'vitest';
 
+import { getSceneDetailPolicy } from '../scene/graphics/sceneDetailPolicy';
+import { MINIATURE_POI_PROXY_REGISTRY } from '../scene/miniature/poiProxyRegistry';
+import { getPoiPhysicalMetadata } from '../scene/poi/physicalMetadata';
 import { createFlywheelShowpiece } from '../scene/structures/flywheel';
+import {
+  FLYWHEEL_ANIMATION,
+  FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_MARKER_MIN_HEIGHT,
+  FLYWHEEL_PLANETARY_RATIO,
+} from '../scene/structures/flywheelEnergyContract';
 
-type CapturingContext = CanvasRenderingContext2D & {
-  fillTextCalls: string[];
-};
+const roomBounds = { minX: 0, maxX: 16, minZ: -16, maxZ: 16 };
+const anchor = { x: 10, y: 0, z: -2 };
 
-const contexts: CapturingContext[] = [];
+function build(level = 'balanced' as const) {
+  return createFlywheelShowpiece({
+    position: anchor,
+    orientationRadians: Math.PI / 4,
+    roomBounds,
+    detailPolicy: getSceneDetailPolicy(level),
+  });
+}
 
-const createMockContext = (canvas: HTMLCanvasElement): CapturingContext => {
-  const fillTextCalls: string[] = [];
-  const gradient = { addColorStop: vi.fn() };
-  const context = {
-    save: vi.fn(),
-    restore: vi.fn(),
-    clearRect: vi.fn(),
-    beginPath: vi.fn(),
-    closePath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    quadraticCurveTo: vi.fn(),
-    fillRect: vi.fn(),
-    fill: vi.fn(),
-    stroke: vi.fn(),
-    createLinearGradient: vi.fn(() => gradient),
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 0,
-    textAlign: 'left',
-    textBaseline: 'alphabetic',
-    font: '',
-    globalAlpha: 1,
-    shadowBlur: 0,
-    shadowColor: '',
-    fillText: vi.fn((text: string) => {
-      fillTextCalls.push(text);
-    }),
-    fillTextCalls,
-  } as Partial<CapturingContext>;
-  Object.defineProperty(context, 'canvas', { value: canvas });
-  return context as CapturingContext;
-};
+describe('createFlywheelShowpiece physical assembly', () => {
+  it('anchors a unit-scale bottom-centered root at the POI position', () => {
+    const flywheel = build();
+    expect(flywheel.group.name).toBe('FlywheelEnergyInstallation');
+    expect(flywheel.group.position.toArray()).toEqual([
+      anchor.x,
+      anchor.y,
+      anchor.z,
+    ]);
+    expect(flywheel.group.rotation.y).toBeCloseTo(Math.PI / 4);
+    expect(flywheel.group.scale.toArray()).toEqual([1, 1, 1]);
+    flywheel.dispose();
+  });
 
-beforeAll(() => {
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
-    configurable: true,
-    value(this: HTMLCanvasElement, type: string) {
-      if (type !== '2d') {
-        return null;
+  it('creates the semantic physical hierarchy and omits obsolete abstract parts', () => {
+    const flywheel = build();
+    for (const name of [
+      'FlywheelBase',
+      'FlywheelBearingStandLeft',
+      'FlywheelBearingStandRight',
+      'FlywheelAxle',
+      'FlywheelWheelGroup',
+      'FlywheelHeavyRim',
+      'FlywheelInnerHub',
+      'FlywheelSpoke-0',
+      'FlywheelCounterweight-0',
+      'FlywheelEnergyGlowRing',
+      'FlywheelCrankGroup',
+      'FlywheelCrankDisc',
+      'FlywheelCrankArm',
+      'FlywheelCrankHandle',
+      'FlywheelPlanetaryGearbox',
+      'FlywheelRingGear',
+      'FlywheelSunGear',
+      'FlywheelPlanetCarrier',
+      'FlywheelPlanetGear-0',
+      'FlywheelOutputShaft',
+      'FlywheelEnergyPort',
+    ]) {
+      expect(flywheel.group.getObjectByName(name), name).toBeTruthy();
+    }
+    for (const obsolete of [
+      'FlywheelRotorGroup',
+      'FlywheelInfoPanel',
+      'FlywheelAutomationPillars',
+    ]) {
+      expect(flywheel.group.getObjectByName(obsolete)).toBeUndefined();
+    }
+    flywheel.dispose();
+  });
+
+  it('keeps core geometry local instead of baking world coordinates into children', () => {
+    const flywheel = build();
+    flywheel.group.traverse((object) => {
+      if (object === flywheel.group) return;
+      expect(Math.abs(object.position.x)).toBeLessThan(3);
+      expect(Math.abs(object.position.z)).toBeLessThan(3);
+    });
+    flywheel.dispose();
+  });
+
+  it('synchronizes crank, sun, carrier, planet gears, and flywheel without allocations', () => {
+    const flywheel = build();
+    const initialTriangleCount = flywheel.getDebugState().triangleCount;
+    flywheel.update({
+      elapsed: 1,
+      delta: 1,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const state = flywheel.getDebugState();
+    expect(state.crankAngle).toBeCloseTo(
+      FLYWHEEL_ANIMATION.crankRadiansPerSecond
+    );
+    expect(state.sunAngle).toBeCloseTo(state.crankAngle);
+    expect(state.carrierAngle).toBeCloseTo(
+      state.crankAngle / FLYWHEEL_PLANETARY_RATIO
+    );
+    expect(state.flywheelAngle).toBeCloseTo(state.carrierAngle);
+    expect(state.planetAngles[0].orbitAngle).toBeCloseTo(state.carrierAngle);
+    expect(state.planetAngles[0].spinAngle).toBeLessThan(0);
+    expect(flywheel.getDebugState().triangleCount).toBe(initialTriangleCount);
+    flywheel.update({
+      elapsed: 2,
+      delta: 0,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    expect(flywheel.getDebugState().crankAngle).toBeCloseTo(state.crankAngle);
+    flywheel.dispose();
+  });
+
+  it('builds all detail levels with meaningfully decreasing triangle counts', () => {
+    const counts = ['cinematic', 'balanced', 'performance', 'low', 'micro'].map(
+      (level) => {
+        const flywheel = createFlywheelShowpiece({
+          position: anchor,
+          roomBounds,
+          detailPolicy: getSceneDetailPolicy(level as never),
+        });
+        const count = flywheel.getDebugState().triangleCount;
+        flywheel.dispose();
+        return count;
       }
-      const context = createMockContext(this);
-      contexts.push(context);
-      return context;
-    },
-  });
-});
-
-beforeEach(() => {
-  contexts.length = 0;
-});
-
-describe('createFlywheelShowpiece', () => {
-  const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
-
-  it('builds kinetic hub geometry with docs callout signage', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
-
-    expect(build.group.name).toBe('FlywheelShowpiece');
-
-    const rotorGroup = build.group.getObjectByName('FlywheelRotorGroup');
-    expect(rotorGroup).toBeInstanceOf(Group);
-
-    const panel = build.group.getObjectByName('FlywheelInfoPanel');
-    expect(panel).toBeInstanceOf(Mesh);
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout');
-    expect(callout).toBeInstanceOf(Mesh);
-
-    const capturedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
-    expect(capturedText).toContain('Flywheel Automation');
-    expect(capturedText).toContain('README');
-    expect(capturedText).toContain('github.com/futuroptimist/flywheel');
-    expect(capturedText).toContain('CI templates');
-    expect(capturedText).toContain('Typed prompts');
-    expect(capturedText).toContain('Scaffolds');
-    expect(capturedText).toContain('lint · test · deploy');
-    expect(capturedText).toContain('codex-driven flows');
-    expect(capturedText).toContain('vite · playwright');
+    );
+    counts.forEach((count) => expect(Number.isFinite(count)).toBe(true));
+    expect(counts[0]).toBeGreaterThan(counts[1]);
+    expect(counts[1]).toBeGreaterThan(counts[2]);
+    expect(counts[2]).toBeGreaterThan(counts[3]);
+    expect(counts[3]).toBeGreaterThanOrEqual(counts[4]);
   });
 
-  it('keeps the docs callout hidden when only emphasis is applied', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
+  it('keeps colliders and physical metadata aligned with the visible bounds', () => {
+    const flywheel = build();
+    expect(flywheel.colliders[0]).toMatchObject({
+      minX: anchor.x - FLYWHEEL_BASE_DIMENSIONS.width / 2,
+      maxX: anchor.x + FLYWHEEL_BASE_DIMENSIONS.width / 2,
     });
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-
-    build.update({ elapsed: 0.5, delta: 0.5, emphasis: 1 });
-    build.update({ elapsed: 1, delta: 0.5, emphasis: 1 });
-
-    expect(calloutMaterial.opacity).toBeLessThan(0.05);
-    expect(callout.visible).toBe(false);
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    const bounds = new Box3().setFromObject(flywheel.group);
+    const size = bounds.getSize(new Vector3());
+    expect(size.x).toBeLessThanOrEqual(
+      FLYWHEEL_INSTALLATION_BOUNDS.width + 0.2
+    );
+    expect(size.y).toBeLessThanOrEqual(
+      FLYWHEEL_INSTALLATION_BOUNDS.height + 0.2
+    );
+    const metadata = getPoiPhysicalMetadata('flywheel-studio-flywheel');
+    expect(metadata?.anchor).toBe('bottom-center');
+    expect(metadata?.clearances?.markerMinHeight).toBe(
+      FLYWHEEL_MARKER_MIN_HEIGHT
+    );
+    flywheel.dispose();
   });
 
-  it('reveals docs callout when the flywheel POI is selected and hides when cleared', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-    const calloutGlow = build.group.getObjectByName(
-      'FlywheelDocsCalloutGlow'
-    ) as Mesh;
-    const calloutGlowMaterial = calloutGlow.material as MeshBasicMaterial;
-    const rotorGroup = build.group.getObjectByName(
-      'FlywheelRotorGroup'
-    ) as Group;
-
-    const initialRotation = rotorGroup.rotation.y;
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    build.update({ elapsed: 0.5, delta: 0.5, emphasis: 1 });
-    build.update({ elapsed: 1.1, delta: 0.6, emphasis: 1 });
-
-    expect(rotorGroup.rotation.y).toBeGreaterThan(initialRotation);
-    expect(calloutMaterial.opacity).toBeGreaterThan(0.3);
-    expect(calloutGlowMaterial.opacity).toBeGreaterThan(0.05);
-    expect(callout.visible).toBe(true);
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selection-cleared', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    let elapsed = 1.6;
-    for (let i = 0; i < 6; i += 1) {
-      build.update({ elapsed, delta: 0.3, emphasis: 0.8 });
-      elapsed += 0.3;
-    }
-
-    expect(calloutMaterial.opacity).toBeLessThan(0.05);
-    expect(callout.visible).toBe(false);
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+  it('disposes idempotently', () => {
+    const flywheel = build();
+    flywheel.dispose();
+    flywheel.dispose();
+    expect(flywheel.getDebugState().disposed).toBe(true);
   });
 
-  it('keeps the docs callout hidden when emphasis stays at zero', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-
-    for (let i = 0; i < 5; i += 1) {
-      build.update({ elapsed: i * 0.5, delta: 0.5, emphasis: 0 });
-    }
-
-    expect(calloutMaterial.opacity).toBe(0);
-    expect(callout.visible).toBe(false);
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
-  });
-
-  it('reveals tech stack chips and animates their orbit after selection', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
-
-    const techStackGroup = build.group.getObjectByName(
-      'FlywheelTechStackGroup'
-    ) as Group;
-    expect(techStackGroup).toBeInstanceOf(Group);
-
-    const wrappers = techStackGroup.children as Group[];
-    expect(wrappers).toHaveLength(3);
-
-    const initialRotations = wrappers.map((wrapper) => wrapper.rotation.y);
-    const materials = wrappers.map((wrapper) => {
-      const chip = wrapper.children[0] as Mesh;
-      return chip.material as MeshBasicMaterial;
-    });
-
-    build.update({ elapsed: 0.25, delta: 0.25, emphasis: 0.6 });
-    materials.forEach((material) => {
-      expect(material.opacity).toBeLessThan(0.1);
-    });
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected:analytics', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
+  it('keeps the miniature proxy in sync with physical machine semantics', () => {
+    const proxy = MINIATURE_POI_PROXY_REGISTRY['flywheel-studio-flywheel'];
+    expect(proxy.syncRevision).toBe(5);
+    expect(proxy.sourceFiles).toContain(
+      'src/scene/structures/flywheelEnergyContract.ts'
     );
-
-    build.update({ elapsed: 0.9, delta: 0.65, emphasis: 1 });
-    build.update({ elapsed: 1.6, delta: 0.7, emphasis: 1 });
-
-    wrappers.forEach((wrapper, index) => {
-      expect(wrapper.rotation.y).not.toBeCloseTo(initialRotations[index]);
-      const chip = wrapper.children[0] as Mesh;
-      expect(chip.visible).toBe(true);
-    });
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeGreaterThan(0.3);
-    });
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
-  });
-
-  it('highlights automation pillars as emphasis and selection increase', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
-
-    const pillarGroup = build.group.getObjectByName(
-      'FlywheelAutomationPillars'
-    ) as Group;
-    expect(pillarGroup).toBeInstanceOf(Group);
-
-    const pillarMeshes = pillarGroup.children as Mesh[];
-    expect(pillarMeshes.length).toBeGreaterThan(0);
-
-    const initialHeights = pillarMeshes.map((mesh) => mesh.position.y);
-    const materials = pillarMeshes.map(
-      (mesh) => mesh.material as MeshStandardMaterial
+    const names = proxy.primitives.map((primitive) => primitive.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'flywheel-base',
+        'flywheel-heavy-wheel',
+        'flywheel-gear-cluster',
+        'flywheel-crank-arm',
+        'flywheel-energy-port',
+      ])
     );
-
-    build.update({ elapsed: 0.2, delta: 0.2, emphasis: 0.1 });
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeLessThan(0.3);
-    });
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    build.update({ elapsed: 0.9, delta: 0.7, emphasis: 1 });
-    build.update({ elapsed: 1.6, delta: 0.7, emphasis: 1 });
-
-    const finalHeights = pillarMeshes.map((mesh) => mesh.position.y);
-    const heightChanged = finalHeights.some(
-      (height, index) => Math.abs(height - initialHeights[index]) > 1e-4
-    );
-    expect(heightChanged).toBe(true);
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeGreaterThan(0.4);
-      expect(material.emissiveIntensity).toBeGreaterThan(0.5);
-    });
-
-    expect(pillarMeshes.every((mesh) => mesh.visible)).toBe(true);
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selection-cleared', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
   });
 });

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -85,8 +85,7 @@ const migratedFactories = [
     placement: { position: { x: 9.035, y: 0, z: 0.745 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
-        centerX: position.x,
-        centerZ: position.z,
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
         roomBounds: { minX: 0, maxX: 16, minZ: -16, maxZ: 16 },
       }),


### PR DESCRIPTION
### Motivation
- Replace the old abstract holographic flywheel with a grounded, camera-friendly physical installation that reads as a heavy kinetic machine. 
- Centralize dimensional and mechanical constants to avoid duplication and keep builder, metadata, miniature proxy, and tests in sync. 
- Provide a deterministic, plausible fixed‑ring planetary gearbox and runtime contract so crank → sun → planet → carrier → flywheel motion remains synchronized across detail levels and emphasis states.

### Description
- Add `src/scene/structures/flywheelEnergyContract.ts` exporting installation bounds, base/wheel/axle/crank/gear constants, planetary ratio math, animation constants, and detail-tooth stride utilities. 
- Rework `createFlywheelShowpiece` in `src/scene/structures/flywheel.ts` to return a bottom-centered, unit-scale `FlywheelEnergyInstallation` root and implement the full semantic hierarchy (base, bearing stands, axle, heavy rim/hub/spokes/counterweights, crank, planetary gearbox with ring/sun/planet gears, carrier/output shaft, energy port), procedural teeth (detail-aware), colliders, `update(...)`, `getDebugState()`, and idempotent `dispose()`. 
- Update runtime wiring in `src/main.ts` to pass a resolved `position` into the builder, call `flywheelShowpiece.update(...)` every frame, and pass a `runDecorativeEffects` boolean derived from `sceneDetailController.shouldRunDecorativeUpdate(...)`; teardown now calls `dispose()` when present. 
- Update `src/scene/poi/physicalMetadata.ts` to include Flywheel physical metadata referencing the shared contract, and refresh the miniature proxy in `src/scene/miniature/poiProxyRegistry.ts` plus the generated `miniatureManifest`. 
- Add focused tests `src/tests/flywheelEnergyContract.test.ts` and `src/tests/flywheelShowpiece.test.ts` and update `src/tests/sceneObjectColliderPolicies.test.ts` to reflect the new `position` API, and document final constants/hierarchy in `docs/architecture/flywheel-energy-transfer.md`.

### Testing
- `npm run format:write` — succeeded. 
- `npm run miniature:manifest:update` and `npm run miniature:check` — succeeded (manifest regenerated and is current after bumping proxy `syncRevision`).
- Focused unit tests: `npm run test:ci -- src/tests/flywheelEnergyContract.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts src/tests/sceneObjectColliderPolicies.test.ts` — all targeted suites passed (6 files, 31 tests total). 
- `npm run lint` — passed after small import/name fixes; reported minor warnings that were addressed in the change. 
- `npm run build` and `npm run smoke` — succeeded (production build completed; smoke check passed). 
- `npm run docs:check` — passed (link checker produced external fetch warnings unrelated to this change). 
- `npm run format:check` — passed. 
- `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected. 
- `timeout 8s npm run dev -- --host 127.0.0.1 --port 5173` — Vite started successfully (local server reachable); the wrapper command exited with `124` because the timeout intentionally terminated the long-running dev server. 
- `npm run typecheck` — intentionally run and reports pre-existing, project-wide TypeScript errors unrelated to this Flywheel change; these were not introduced by this PR and are noted as residual typecheck noise.

Notes / residual risks: the PR intentionally avoids adding cross-POI energy arcs (P6c scope) and centralizes constants so follow-ups can safely tune visual proportions; the TypeScript project still has unrelated typing issues that remain outside this change and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f319ec480832f9168ff0f1b14abf5)