### PR TITLE
Implement physical Flywheel assembly and planetary gear train

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -682,3 +682,66 @@ only one short blue parabolic packet is visible at a time, five incoming packets
 precede one larger outgoing packet, reduced motion/flicker remains comfortable,
 the POI marker clears the machine, the miniature proxy is static and current, and
 there are no obvious frame spikes.
+
+## P6b implementation update — physical kinetic machine
+
+P6b replaces the abstract automation kiosk with the production physical assembly.
+The runtime builder now uses the shared `flywheelEnergyContract` constants and
+anchors `FlywheelEnergyInstallation` as a bottom-centered, unit-scale POI root at
+`position` with `orientationRadians` applied only to the root. Child meshes are
+authored in local coordinates.
+
+Final physical constants live in `src/scene/structures/flywheelEnergyContract.ts`:
+
+- intended bounds: 4.0w × 2.45d × 2.25h scene units;
+- base: 3.15w × 1.75d × 0.18h;
+- heavy wheel: 0.78 radius, 0.18 thickness, center height 1.18;
+- gearbox: fixed ring planetary train at the wheel axle height;
+- teeth: sun 18, planet 18, ring 54, three planets;
+- fixed-ring carrier ratio: `1 + ring / sun = 4:1`, so the carrier, output
+  shaft, and flywheel turn at one quarter of the crank/sun speed;
+- baseline crank speed: `Math.PI * 1.15` radians per second, with a small
+  emphasis boost that preserves the deterministic ratio.
+
+Final hierarchy:
+
+```text
+FlywheelEnergyInstallation
+├─ FlywheelBase
+├─ FlywheelBearingStandLeft
+├─ FlywheelBearingStandRight
+├─ FlywheelAxle
+├─ FlywheelWheelGroup
+│  ├─ FlywheelHeavyRim
+│  ├─ FlywheelInnerHub
+│  ├─ FlywheelSpoke-*
+│  ├─ FlywheelCounterweight-*
+│  └─ FlywheelEnergyGlowRing*
+├─ FlywheelCrankGroup
+│  ├─ FlywheelCrankDisc
+│  ├─ FlywheelCrankArm
+│  └─ FlywheelCrankHandle
+├─ FlywheelPlanetaryGearbox
+│  ├─ FlywheelRingGear
+│  ├─ FlywheelSunGear
+│  ├─ FlywheelPlanetCarrier
+│  ├─ FlywheelPlanetGear-*
+│  └─ FlywheelOutputShaft
+└─ FlywheelEnergyPort
+```
+
+Detail-level matrix for P6b:
+
+| Level       | Geometry strategy                                                                   |
+| ----------- | ----------------------------------------------------------------------------------- |
+| Cinematic   | Full tooth density, 8 spokes, 3 glow rings, high cylinder/torus segments.           |
+| Balanced    | Reduced tooth density, 6 spokes, 2 glow rings.                                      |
+| Performance | Coarser tooth density, 5 spokes, one glow ring.                                     |
+| Low         | Sparse teeth and 4-spoke silhouette.                                                |
+| Micro       | Minimal teeth and 3-spoke silhouette while preserving wheel/crank/gear readability. |
+
+The frame loop now calls the Flywheel update every rendered frame for the crank,
+sun, planets, carrier, output shaft, and heavy wheel. Decorative glow pulsing is
+passed a throttled `runDecorativeEffects` flag so performance modes can skip
+secondary effects without freezing the mechanical train. Cross-POI blue energy
+transfer arcs remain future P6c scope.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3023,15 +3023,17 @@ function initializeImmersiveScene(
       ? upperFloorColliders
       : groundColliders;
   if (studioRoom) {
-    const centerX =
-      flywheelPoi?.group.position.x ??
-      (studioRoom.bounds.minX + studioRoom.bounds.maxX) / 2;
-    const centerZ =
-      flywheelPoi?.group.position.z ??
-      (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2;
+    const position = {
+      x:
+        flywheelPoi?.group.position.x ??
+        (studioRoom.bounds.minX + studioRoom.bounds.maxX) / 2,
+      y: flywheelPoi?.group.position.y ?? 0,
+      z:
+        flywheelPoi?.group.position.z ??
+        (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2,
+    };
     const showpiece = createFlywheelShowpiece({
-      centerX,
-      centerZ,
+      position,
       roomBounds: studioRoom.bounds,
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
       detailPolicy: activeSceneDetailPolicy,
@@ -6979,7 +6981,10 @@ function initializeImmersiveScene(
       selfieMirror.dispose();
       selfieMirror = null;
     }
-    flywheelShowpiece = null;
+    if (flywheelShowpiece) {
+      flywheelShowpiece.dispose();
+      flywheelShowpiece = null;
+    }
     f2ClipboardConsole = null;
     sigmaWorkbench = null;
     woveLoom = null;
@@ -7140,19 +7145,17 @@ function initializeImmersiveScene(
       if (flywheelShowpiece) {
         const activation = flywheelPoi?.activation ?? 0;
         const focus = flywheelPoi?.focus ?? 0;
-        if (
-          sceneDetailController.shouldRunDecorativeUpdate(
+        const emphasis = Math.max(activation, focus);
+        flywheelShowpiece.update({
+          elapsed: elapsedTime,
+          delta,
+          emphasis,
+          runDecorativeEffects: sceneDetailController.shouldRunDecorativeUpdate(
             elapsedTime,
-            Math.max(activation, focus),
+            emphasis,
             'flywheel'
-          )
-        ) {
-          flywheelShowpiece.update({
-            elapsed: elapsedTime,
-            delta,
-            emphasis: Math.max(activation, focus),
-          });
-        }
+          ),
+        });
       }
       if (f2ClipboardConsole) {
         const activation = f2ClipboardPoi?.activation ?? 0;

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -313,11 +313,11 @@
       "id": "audit:src:scene:poi:physicalMetadata",
       "sourceFiles": ["src/scene/poi/physicalMetadata.ts"],
       "proxyFiles": [],
-      "syncRevision": 4,
-      "syncNote": "Audited support source; PR Reaper real-world dimensions and scene bounds now feed its holographic installation contract while tabletop geometry remains covered by the POI proxy.",
-      "sourceFingerprint": "c9511746aa83f377f440cc4f6cde42def70039cb136d9bb6edab7fc4b4d5cba3",
+      "syncRevision": 5,
+      "syncNote": "Audited support source; Flywheel physical metadata now follows the P6b shared kinetic installation contract while visible geometry is covered by its POI proxy.",
+      "sourceFingerprint": "53e8fab932b1768d1db98a812c1468cdd3a77d4fb92b61bee8ded55a476a0b1f",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "5292e4210f717e822a84d93d7ce1914ab0cad79f47de5b7ee7f13a53cdc1fc5e"
+      "metadataFingerprint": "f96f8052488b8d0e5309857687504c373f7d847376b65c76891cae524e3aeda3"
     },
     {
       "id": "audit:src:scene:poi:structuredData",
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "ac78de7048b2c3f23277ac748cf266bf966067a263b707f85b0fafe295af69b6",
+      "proxyFingerprint": "461adc03401ba65e50ead7e659d6b9cde421f778940be0ac51bbf758e57d4685",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -573,14 +573,15 @@
         "src/scene/poi/constants.ts",
         "src/scene/poi/placements.ts",
         "src/scene/poi/registry.ts",
-        "src/scene/structures/flywheel.ts"
+        "src/scene/structures/flywheel.ts",
+        "src/scene/structures/flywheelEnergyContract.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 3,
-      "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
-      "sourceFingerprint": "3053f6e2a8ee799815a28bceb744faa218475941757bed0a2c6e30ba7458401f",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
-      "metadataFingerprint": "be312aac26fac81617be4bf80d88bcfa3831b5c038b0ab483e02f6dbaa4c75cd"
+      "syncRevision": 4,
+      "syncNote": "Tracks the P6b physical flywheel, hand crank, planetary gearbox, base, bearings, and energy port silhouette.",
+      "sourceFingerprint": "e4d30e4013431859ce3a8cbbfbda4bfa51a62583df25ca9572777c6eb1c1ea31",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
+      "metadataFingerprint": "b893d90ab1b53998c91edf1e8b04841ebb35f1f4e6f012dbd70464381d4c326a"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -594,7 +595,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -609,7 +610,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -624,7 +625,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -639,7 +640,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -674,7 +675,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -689,7 +690,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -704,7 +705,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -719,7 +720,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -734,7 +735,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "e99482498dcf12e1c47d0a0419b4314aa6b51d1c2970f0e7ba3faeaaff425e26",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -89,29 +89,61 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 3,
+    syncRevision: 4,
     syncNote:
-      'Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.',
-    sourceFiles: [...baseFiles, 'src/scene/structures/flywheel.ts'],
+      'Tracks the P6b physical flywheel, hand crank, planetary gearbox, base, bearings, and energy port silhouette.',
+    sourceFiles: [
+      ...baseFiles,
+      'src/scene/structures/flywheel.ts',
+      'src/scene/structures/flywheelEnergyContract.ts',
+    ],
     proxyFiles: [SELF_FILE],
     primitives: [
-      cyl('flywheel-dais', 0.7, 0.18, [0, 0.09, 0], 0x0f766e),
+      box('flywheel-base', [1.45, 0.14, 0.72], [0, 0.07, 0], 0x1f2937),
+      box(
+        'flywheel-bearing-left',
+        [0.12, 0.62, 0.18],
+        [-0.34, 0.42, 0.05],
+        0x475569
+      ),
+      box(
+        'flywheel-bearing-right',
+        [0.12, 0.62, 0.18],
+        [0.34, 0.42, 0.05],
+        0x475569
+      ),
       {
         kind: 'ring',
-        name: 'flywheel-rotor-ring',
-        radius: 0.55,
-        tube: 0.08,
-        position: [0, 0.65, 0],
-        rotation: [Math.PI / 2, 0, 0],
-        color: 0x2dd4bf,
+        name: 'flywheel-heavy-wheel',
+        radius: 0.42,
+        tube: 0.055,
+        position: [0.12, 0.75, 0.05],
+        rotation: [0, 0, 0],
+        color: 0x94a3b8,
       },
-      box('flywheel-spoke', [1, 0.05, 0.06], [0, 0.65, 0], 0xccfbf1),
       box(
-        'flywheel-counterweight',
-        [0.18, 0.16, 0.18],
-        [0.44, 0.65, 0],
-        0xf59e0b
+        'flywheel-wheel-spoke',
+        [0.72, 0.04, 0.04],
+        [0.12, 0.75, 0.05],
+        0xe2e8f0
       ),
+      box(
+        'flywheel-crank-arm',
+        [0.3, 0.035, 0.035],
+        [-0.55, 0.75, -0.2],
+        0xe2e8f0
+      ),
+      cyl('flywheel-crank-handle', 0.05, 0.2, [-0.7, 0.75, -0.2], 0xfbbf24),
+      {
+        kind: 'ring',
+        name: 'flywheel-planetary-gear-cluster',
+        radius: 0.24,
+        tube: 0.035,
+        position: [-0.5, 0.75, 0.05],
+        rotation: [0, 0, 0],
+        color: 0x60a5fa,
+      },
+      cyl('flywheel-energy-port-glow', 0.11, 0.1, [-0.5, 1.05, 0.05], 0x38bdf8),
     ],
   },
   'jobbot-studio-terminal': {

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -364,9 +364,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'audit:src:scene:poi:physicalMetadata',
     kind: 'excluded',
     sourceFiles: ['src/scene/poi/physicalMetadata.ts'],
-    syncRevision: 4,
+    syncRevision: 5,
     reason:
-      'Audited support source; PR Reaper real-world dimensions and scene bounds now feed its holographic installation contract while tabletop geometry remains covered by the POI proxy.',
+      'Audited support source; Flywheel physical metadata now follows the P6b shared kinetic installation contract while visible geometry is covered by its POI proxy.',
   },
   {
     id: 'audit:src:scene:poi:structuredData',

--- a/src/scene/poi/physicalMetadata.ts
+++ b/src/scene/poi/physicalMetadata.ts
@@ -1,3 +1,4 @@
+import { FLYWHEEL_ENERGY_DIMENSIONS } from '../structures/flywheelEnergyContract';
 import { PORTFOLIO_MINIATURE_TABLE_DIMENSIONS } from '../structures/portfolioMiniatureTableContract';
 import {
   PR_REAPER_INTENDED_BOUNDS,
@@ -39,6 +40,18 @@ const RASPBERRY_PI_5_BOARD_FOOTPRINT_METERS = {
 };
 
 const physicalMetadata = {
+  'flywheel-studio-flywheel': {
+    realWorldReference:
+      'industrial hand-cranked kinetic flywheel with fixed-ring planetary gearbox',
+    realWorldDimensionsMeters:
+      FLYWHEEL_ENERGY_DIMENSIONS.realWorldDimensionsMeters,
+    intendedSceneBounds: FLYWHEEL_ENERGY_DIMENSIONS.installationBounds,
+    anchor: 'bottom-center',
+    clearances: {
+      markerMinHeight: FLYWHEEL_ENERGY_DIMENSIONS.markerClearance,
+      avatarPathRadius: FLYWHEEL_ENERGY_DIMENSIONS.avatarPathRadius,
+    },
+  },
   'tokenplace-studio-cluster': {
     realWorldReference: 'dual 27-inch 16:9 workstation',
     realWorldDimensionsMeters: {

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -1,19 +1,15 @@
 import {
   BoxGeometry,
-  CanvasTexture,
   Color,
   CylinderGeometry,
-  DoubleSide,
   Group,
   MathUtils,
   Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  PlaneGeometry,
-  RingGeometry,
-  SRGBColorSpace,
-  TorusGeometry,
+  Object3D,
   SphereGeometry,
+  TorusGeometry,
 } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
@@ -21,894 +17,524 @@ import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
+import {
+  FLYWHEEL_ANIMATION,
+  FLYWHEEL_ENERGY_DIMENSIONS,
+  FLYWHEEL_ENERGY_INSTALLATION_NAME,
+  FLYWHEEL_GEAR_RADII,
+  FLYWHEEL_GEAR_TEETH,
+  FLYWHEEL_PLANETARY_RATIO,
+  getFlywheelCarrierAngle,
+  getFlywheelLocalColliders,
+  getFlywheelPlanetSpinAngle,
+} from './flywheelEnergyContract';
+
 const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
+
+export interface FlywheelDebugState {
+  crankAngle: number;
+  sunAngle: number;
+  carrierAngle: number;
+  flywheelAngle: number;
+  planetAngles: { orbit: number; spin: number }[];
+  ratio: number;
+  disposed: boolean;
+}
 
 export interface FlywheelShowpieceBuild {
   group: Group;
   colliders: RectCollider[];
-  update(context: { elapsed: number; delta: number; emphasis: number }): void;
+  update(context: {
+    elapsed: number;
+    delta: number;
+    emphasis: number;
+    runDecorativeEffects?: boolean;
+  }): void;
+  getDebugState(): FlywheelDebugState;
+  dispose(): void;
 }
 
 export interface FlywheelShowpieceOptions {
-  centerX: number;
-  centerZ: number;
+  position?: { x: number; y?: number; z: number };
+  centerX?: number;
+  centerZ?: number;
   roomBounds: Bounds2D;
   orientationRadians?: number;
   detailPolicy?: SceneDetailPolicy;
 }
 
-interface AutomationPillar {
-  mesh: Mesh;
-  material: MeshStandardMaterial;
-  baseHeight: number;
-  phase: number;
+type DetailSpec = {
+  cylinderSegments: number;
+  torusRadialSegments: number;
+  torusTubularSegments: number;
+  toothEvery: number;
+  spokeCount: number;
+  glowLayers: number;
+};
+
+const detailSpecFor = (policy: SceneDetailPolicy): DetailSpec => {
+  const scale = [1, 0.75, 0.45, 0.28, 0.18][policy.detailIndex] ?? 0.45;
+  return {
+    cylinderSegments: Math.max(
+      6,
+      Math.round(policy.geometry.cylinderSegments * scale)
+    ),
+    torusRadialSegments: Math.max(
+      3,
+      Math.round(policy.geometry.torusRadialSegments * scale)
+    ),
+    torusTubularSegments: Math.max(
+      6,
+      Math.round(policy.geometry.torusTubularSegments * scale)
+    ),
+    toothEvery: [1, 2, 3, 6, 9][policy.detailIndex] ?? 3,
+    spokeCount: [8, 6, 5, 4, 3][policy.detailIndex] ?? 5,
+    glowLayers: [3, 2, 1, 1, 1][policy.detailIndex] ?? 1,
+  };
+};
+
+const ownedGeometries = new Set<{ dispose(): void }>();
+const ownedMaterials = new Set<{ dispose(): void }>();
+
+const trackGeometry = <T extends { dispose(): void }>(geometry: T): T => {
+  ownedGeometries.add(geometry);
+  return geometry;
+};
+
+const trackMaterial = <T extends { dispose(): void }>(material: T): T => {
+  ownedMaterials.add(material);
+  return material;
+};
+
+const std = (color: number, emissive = 0, intensity = 0) =>
+  trackMaterial(
+    new MeshStandardMaterial({
+      color: new Color(color),
+      emissive: new Color(emissive),
+      emissiveIntensity: intensity,
+      metalness: 0.72,
+      roughness: 0.28,
+    })
+  );
+
+const makeBox = (
+  name: string,
+  size: [number, number, number],
+  color: number
+) => {
+  const mesh = new Mesh(trackGeometry(new BoxGeometry(...size)), std(color));
+  mesh.name = name;
+  return mesh;
+};
+
+const makeCylinder = (
+  name: string,
+  radius: number,
+  height: number,
+  segments: number,
+  color: number,
+  openEnded = false
+) => {
+  const mesh = new Mesh(
+    trackGeometry(
+      new CylinderGeometry(radius, radius, height, segments, 1, openEnded)
+    ),
+    std(color)
+  );
+  mesh.name = name;
+  return mesh;
+};
+
+function addGearTeeth(
+  parent: Group,
+  name: string,
+  radius: number,
+  count: number,
+  toothEvery: number,
+  inward: boolean
+): void {
+  const toothCount = Math.max(3, Math.ceil(count / toothEvery));
+  for (let i = 0; i < toothCount; i += 1) {
+    const angle = (i / toothCount) * Math.PI * 2;
+    const tooth = makeBox(`${name}Tooth-${i}`, [0.045, 0.075, 0.055], 0xcbd5e1);
+    tooth.position.set(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+    tooth.rotation.z = angle + (inward ? 0 : Math.PI / 2);
+    parent.add(tooth);
+  }
 }
 
 export function createFlywheelShowpiece(
   options: FlywheelShowpieceOptions
 ): FlywheelShowpieceBuild {
   const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
-  const isPerformance = detailPolicy.level === 'performance';
-  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
-  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
-  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
-  const torusRadialSegments = detailPolicy.geometry.torusRadialSegments;
-  const torusTubularSegments = detailPolicy.geometry.torusTubularSegments;
-  const ringSegments = detailPolicy.geometry.ringSegments;
-
+  const spec = detailSpecFor(detailPolicy);
+  const position = options.position ?? {
+    x: options.centerX ?? 0,
+    y: 0,
+    z: options.centerZ ?? 0,
+  };
   const group = new Group();
-  group.name = 'FlywheelShowpiece';
+  group.name = FLYWHEEL_ENERGY_INSTALLATION_NAME;
+  group.position.set(position.x, position.y ?? 0, position.z);
+  group.rotation.y = options.orientationRadians ?? 0;
 
-  const colliders: RectCollider[] = [];
+  const colliders = getFlywheelLocalColliders().map((collider) => ({
+    minX: collider.minX + position.x,
+    maxX: collider.maxX + position.x,
+    minZ: collider.minZ + position.z,
+    maxZ: collider.maxZ + position.z,
+  }));
 
-  const selectionEventTarget = typeof window === 'undefined' ? null : window;
-  let selectionTarget = 0;
-  let selectionStrength = 0;
+  const d = FLYWHEEL_ENERGY_DIMENSIONS;
+  const base = makeBox(
+    'FlywheelBase',
+    [d.base.width, d.base.height, d.base.depth],
+    0x1f2937
+  );
+  base.position.y = d.base.height / 2;
+  group.add(base);
 
-  const handleSelection = (event: Event) => {
-    const poiId = getPoiIdFromEvent(event);
-    if (!poiId) {
-      return;
-    }
-    if (poiId === FLYWHEEL_POI_ID) {
-      selectionTarget = 1;
-    } else {
-      selectionTarget = 0;
-    }
-  };
-
-  const handleSelectionCleared = (event: Event) => {
-    const poiId = getPoiIdFromEvent(event);
-    if (!poiId || poiId === FLYWHEEL_POI_ID) {
-      selectionTarget = 0;
-    }
-  };
-
-  const removeSelectionListeners = () => {
-    if (!selectionEventTarget) {
-      return;
-    }
-    selectionEventTarget.removeEventListener('poi:selected', handleSelection);
-    selectionEventTarget.removeEventListener(
-      'poi:selected:analytics',
-      handleSelection
+  for (const [name, x] of [
+    ['FlywheelBearingStandLeft', -d.bearingStand.offsetX],
+    ['FlywheelBearingStandRight', d.bearingStand.offsetX],
+  ] as const) {
+    const stand = makeBox(
+      name,
+      [d.bearingStand.width, d.bearingStand.height, d.bearingStand.depth],
+      0x334155
     );
-    selectionEventTarget.removeEventListener(
-      'poi:selection-cleared',
-      handleSelectionCleared
+    stand.position.set(
+      x,
+      d.base.height + d.bearingStand.height / 2,
+      d.wheel.centerZ
     );
-  };
-
-  if (selectionEventTarget) {
-    selectionEventTarget.addEventListener('poi:selected', handleSelection);
-    selectionEventTarget.addEventListener(
-      'poi:selected:analytics',
-      handleSelection
-    );
-    selectionEventTarget.addEventListener(
-      'poi:selection-cleared',
-      handleSelectionCleared
-    );
-    const handleRemoval = () => {
-      removeSelectionListeners();
-      group.removeEventListener('removed', handleRemoval);
-    };
-    group.addEventListener('removed', handleRemoval);
+    group.add(stand);
   }
 
-  const daisRadius = 1.45;
-  const daisHeight = 0.16;
-  const daisGeometry = new CylinderGeometry(
-    daisRadius,
-    daisRadius,
-    daisHeight,
-    cylinderSegments
+  const axle = makeCylinder(
+    'FlywheelAxle',
+    d.axle.radius,
+    d.axle.length,
+    spec.cylinderSegments,
+    0xe2e8f0
   );
-  const daisMaterial = new MeshStandardMaterial({
-    color: new Color(0x14202c),
-    roughness: 0.48,
-    metalness: 0.18,
-  });
-  const dais = new Mesh(daisGeometry, daisMaterial);
-  dais.name = 'FlywheelDais';
-  dais.position.set(options.centerX, daisHeight / 2, options.centerZ);
-  group.add(dais);
+  axle.rotation.z = Math.PI / 2;
+  axle.position.set(0, d.wheel.centerY, d.wheel.centerZ);
+  group.add(axle);
 
-  const pedestalRadius = daisRadius * 0.68;
-  const pedestalHeight = 0.6;
-  const pedestalGeometry = new CylinderGeometry(
-    pedestalRadius,
-    pedestalRadius,
-    pedestalHeight,
-    cylinderSegments
+  const wheelGroup = new Group();
+  wheelGroup.name = 'FlywheelWheelGroup';
+  wheelGroup.position.set(0.28, d.wheel.centerY, d.wheel.centerZ);
+  group.add(wheelGroup);
+  const rim = new Mesh(
+    trackGeometry(
+      new TorusGeometry(
+        d.wheel.radius,
+        d.wheel.thickness / 2,
+        spec.torusRadialSegments,
+        spec.torusTubularSegments
+      )
+    ),
+    std(0x94a3b8, 0x1d4ed8, 0.12)
   );
-  const pedestalMaterial = new MeshStandardMaterial({
-    color: new Color(0x182634),
-    roughness: 0.32,
-    metalness: 0.24,
-  });
-  const pedestal = new Mesh(pedestalGeometry, pedestalMaterial);
-  pedestal.name = 'FlywheelPedestal';
-  pedestal.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight / 2,
-    options.centerZ
+  rim.name = 'FlywheelHeavyRim';
+  wheelGroup.add(rim);
+  const hub = makeCylinder(
+    'FlywheelInnerHub',
+    0.18,
+    d.wheel.thickness * 1.25,
+    spec.cylinderSegments,
+    0xcbd5e1
   );
-  group.add(pedestal);
+  hub.rotation.x = Math.PI / 2;
+  wheelGroup.add(hub);
+  for (let i = 0; i < spec.spokeCount; i += 1) {
+    const spoke = makeBox(
+      `FlywheelSpoke-${i}`,
+      [d.wheel.radius * 1.45, 0.045, 0.055],
+      0xe2e8f0
+    );
+    spoke.rotation.z = (i / spec.spokeCount) * Math.PI;
+    wheelGroup.add(spoke);
+  }
+  for (let i = 0; i < Math.min(4, spec.spokeCount); i += 1) {
+    const cw = makeBox(
+      `FlywheelCounterweight-${i}`,
+      [0.18, 0.12, 0.1],
+      0xf59e0b
+    );
+    const angle = (i / 4) * Math.PI * 2 + Math.PI / 4;
+    cw.position.set(Math.cos(angle) * 0.6, Math.sin(angle) * 0.6, 0);
+    cw.rotation.z = angle;
+    wheelGroup.add(cw);
+  }
+  for (let i = 0; i < spec.glowLayers; i += 1) {
+    const glow = new Mesh(
+      trackGeometry(
+        new TorusGeometry(
+          d.wheel.radius + 0.04 + i * 0.035,
+          0.012,
+          4,
+          spec.torusTubularSegments
+        )
+      ),
+      trackMaterial(
+        new MeshBasicMaterial({
+          color: 0x38bdf8,
+          transparent: true,
+          opacity: 0.24,
+        })
+      )
+    );
+    glow.name =
+      i === 0 ? 'FlywheelEnergyGlowRing' : `FlywheelEnergyGlowRing-${i}`;
+    wheelGroup.add(glow);
+  }
 
-  const accentHeight = 0.12;
-  const accentGeometry = new CylinderGeometry(
-    pedestalRadius * 1.02,
-    pedestalRadius * 1.02,
-    accentHeight,
-    cylinderSegments
+  const crankGroup = new Group();
+  crankGroup.name = 'FlywheelCrankGroup';
+  crankGroup.position.set(
+    d.gearbox.centerX - 0.14,
+    d.gearbox.centerY,
+    d.gearbox.centerZ - 0.22
   );
-  const accentMaterial = new MeshStandardMaterial({
-    color: new Color(0x5ad1ff),
-    emissive: new Color(0x178aff),
-    emissiveIntensity: 0.85,
-    roughness: 0.22,
-    metalness: 0.42,
-  });
-  const accent = new Mesh(accentGeometry, accentMaterial);
-  accent.name = 'FlywheelAccent';
-  accent.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + accentHeight / 2,
-    options.centerZ
+  group.add(crankGroup);
+  const crankDisc = makeCylinder(
+    'FlywheelCrankDisc',
+    0.16,
+    0.06,
+    spec.cylinderSegments,
+    0xcbd5e1
   );
-  group.add(accent);
+  crankDisc.rotation.x = Math.PI / 2;
+  crankGroup.add(crankDisc);
+  const crankArm = makeBox(
+    'FlywheelCrankArm',
+    [d.crank.armLength, 0.045, 0.045],
+    0xe2e8f0
+  );
+  crankArm.position.x = d.crank.armLength / 2;
+  crankGroup.add(crankArm);
+  const handle = makeCylinder(
+    'FlywheelCrankHandle',
+    d.crank.handleRadius,
+    d.crank.handleLength,
+    spec.cylinderSegments,
+    0xfbbf24
+  );
+  handle.rotation.x = Math.PI / 2;
+  handle.position.x = d.crank.armLength;
+  crankGroup.add(handle);
 
-  const glassHeight = 1.3;
-  const glassRadius = pedestalRadius * 0.92;
-  const glassGeometry = new CylinderGeometry(
-    glassRadius,
-    glassRadius,
-    glassHeight,
-    cylinderSegments,
-    1,
+  const gearbox = new Group();
+  gearbox.name = 'FlywheelPlanetaryGearbox';
+  gearbox.position.set(d.gearbox.centerX, d.gearbox.centerY, d.gearbox.centerZ);
+  group.add(gearbox);
+  const ringGear = new Mesh(
+    trackGeometry(
+      new TorusGeometry(
+        FLYWHEEL_GEAR_RADII.ringPitch,
+        0.045,
+        spec.torusRadialSegments,
+        spec.torusTubularSegments
+      )
+    ),
+    std(0x64748b)
+  );
+  ringGear.name = 'FlywheelRingGear';
+  gearbox.add(ringGear);
+  addGearTeeth(
+    gearbox,
+    'FlywheelRingGear',
+    FLYWHEEL_GEAR_RADII.ringPitch - 0.055,
+    FLYWHEEL_GEAR_TEETH.ring,
+    spec.toothEvery,
     true
   );
-  const glassMaterial = new MeshStandardMaterial({
-    color: new Color(0x1c2d3d),
-    transparent: true,
-    opacity: 0.18,
-    roughness: 0.08,
-    metalness: 0.05,
-  });
-  const glass = new Mesh(glassGeometry, glassMaterial);
-  glass.name = 'FlywheelGlass';
-  glass.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + glassHeight / 2,
-    options.centerZ
+  const sunGear = new Group();
+  sunGear.name = 'FlywheelSunGear';
+  gearbox.add(sunGear);
+  sunGear.add(
+    makeCylinder(
+      'FlywheelSunGearBody',
+      FLYWHEEL_GEAR_RADII.sun,
+      0.08,
+      spec.cylinderSegments,
+      0xfacc15
+    )
   );
-  glass.visible = detailPolicy.effects.glassTransmission;
-  group.add(glass);
-
-  const rotorGroup = new Group();
-  rotorGroup.name = 'FlywheelRotorGroup';
-  rotorGroup.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + glassHeight * 0.36,
-    options.centerZ
+  addGearTeeth(
+    sunGear,
+    'FlywheelSunGear',
+    FLYWHEEL_GEAR_RADII.sun + 0.035,
+    FLYWHEEL_GEAR_TEETH.sun,
+    spec.toothEvery,
+    false
   );
-  group.add(rotorGroup);
-
-  const rotorRingRadius = glassRadius * 0.85;
-  const rotorRingTube = 0.09;
-  const rotorRingGeometry = new TorusGeometry(
-    rotorRingRadius,
-    rotorRingTube,
-    torusRadialSegments,
-    torusTubularSegments
+  const carrier = new Group();
+  carrier.name = 'FlywheelPlanetCarrier';
+  gearbox.add(carrier);
+  const carrierPlate = makeCylinder(
+    'FlywheelPlanetCarrierPlate',
+    FLYWHEEL_GEAR_RADII.carrier,
+    0.035,
+    spec.cylinderSegments,
+    0x475569
   );
-  const rotorRingMaterial = new MeshStandardMaterial({
-    color: new Color(0x2c95ff),
-    emissive: new Color(0x65d0ff),
-    emissiveIntensity: 0.9,
-    roughness: 0.2,
-    metalness: 0.5,
-  });
-  const rotorRing = new Mesh(rotorRingGeometry, rotorRingMaterial);
-  rotorRing.name = 'FlywheelRotorRing';
-  rotorRing.rotation.x = Math.PI / 2;
-  rotorGroup.add(rotorRing);
-
-  const innerDiscGeometry = new CylinderGeometry(
-    0.38,
-    0.38,
-    0.06,
-    cylinderSegments
-  );
-  const innerDiscMaterial = new MeshStandardMaterial({
-    color: new Color(0x101822),
-    roughness: 0.34,
-    metalness: 0.3,
-  });
-  const innerDisc = new Mesh(innerDiscGeometry, innerDiscMaterial);
-  innerDisc.name = 'FlywheelInnerDisc';
-  innerDisc.rotation.x = Math.PI / 2;
-  rotorGroup.add(innerDisc);
-
-  const spokesGroup = new Group();
-  spokesGroup.name = 'FlywheelSpokesGroup';
-  rotorGroup.add(spokesGroup);
-  const spokeCount = 6;
-  const spokeLength = rotorRingRadius * 1.6;
-  const spokeGeometry = new BoxGeometry(spokeLength, 0.06, 0.08);
-  const spokeMaterial = new MeshStandardMaterial({
-    color: new Color(0x3fb8ff),
-    emissive: new Color(0x1d74ff),
-    emissiveIntensity: 0.75,
-    roughness: 0.26,
-    metalness: 0.46,
-  });
-  for (let i = 0; i < spokeCount; i += 1) {
-    const spoke = new Mesh(spokeGeometry, spokeMaterial);
-    spoke.position.x = spokeLength / 2 - 0.08;
-    spoke.rotation.z = Math.PI / 2;
-    const spokeWrapper = new Group();
-    spokeWrapper.rotation.y = (Math.PI * 2 * i) / spokeCount;
-    spokeWrapper.add(spoke);
-    spokesGroup.add(spokeWrapper);
-  }
-
-  const counterGroup = new Group();
-  counterGroup.name = 'FlywheelCounterGroup';
-  counterGroup.position.copy(rotorGroup.position);
-  group.add(counterGroup);
-
-  const counterRingGeometry = new TorusGeometry(
-    rotorRingRadius * 0.72,
-    0.07,
-    torusRadialSegments,
-    torusTubularSegments
-  );
-  const counterRingMaterial = new MeshStandardMaterial({
-    color: new Color(0x1f88ff),
-    emissive: new Color(0x2bbcff),
-    emissiveIntensity: 0.8,
-    roughness: 0.24,
-    metalness: 0.38,
-  });
-  const counterRing = new Mesh(counterRingGeometry, counterRingMaterial);
-  counterRing.name = 'FlywheelCounterRing';
-  counterRing.rotation.x = Math.PI / 2;
-  counterGroup.add(counterRing);
-
-  const glyphRingGeometry = new RingGeometry(
-    rotorRingRadius * 0.58,
-    rotorRingRadius * 0.72,
-    ringSegments,
-    1
-  );
-  const glyphRingMaterial = new MeshBasicMaterial({
-    color: new Color(0x8ad9ff),
-    transparent: true,
-    opacity: 0.22,
-    side: DoubleSide,
-    depthWrite: false,
-  });
-  const glyphRing = new Mesh(glyphRingGeometry, glyphRingMaterial);
-  glyphRing.name = 'FlywheelGlyphRing';
-  glyphRing.rotation.x = Math.PI / 2;
-  counterGroup.add(glyphRing);
-
-  const orbitGroup = new Group();
-  orbitGroup.name = 'FlywheelOrbitGroup';
-  orbitGroup.position.copy(rotorGroup.position);
-  orbitGroup.visible = !isPerformance;
-  group.add(orbitGroup);
-
-  const automationPillars: AutomationPillar[] = [];
-  const automationPillarGroup = new Group();
-  automationPillarGroup.name = 'FlywheelAutomationPillars';
-  automationPillarGroup.position.copy(rotorGroup.position);
-  automationPillarGroup.visible = !isPerformance;
-  group.add(automationPillarGroup);
-
-  const pillarCount = 4;
-  const pillarHeight = Math.min(1.05, pedestalHeight * 1.5);
-  const pillarRadius = rotorRingRadius * 0.94;
-  const pillarGeometry = new CylinderGeometry(
-    0.12,
-    0.18,
-    pillarHeight,
-    cylinderSegments
-  );
-  for (let index = 0; index < pillarCount; index += 1) {
-    const pillarMaterial = new MeshStandardMaterial({
-      color: new Color(0x102133),
-      emissive: new Color(0x3aaaff),
-      emissiveIntensity: 0.28,
-      roughness: 0.28,
-      metalness: 0.46,
-      transparent: true,
-      opacity: 0.12,
-    });
-    const pillar = new Mesh(pillarGeometry, pillarMaterial);
-    pillar.name = `FlywheelAutomationPillar-${index}`;
-    const angle = (Math.PI * 2 * index) / pillarCount;
-    const pillarBase = daisHeight + 0.04;
-    pillar.position.set(
-      Math.cos(angle) * pillarRadius,
-      pillarBase + pillarHeight / 2,
-      Math.sin(angle) * pillarRadius
+  carrier.add(carrierPlate);
+  const planetGroups: Group[] = [];
+  for (let i = 0; i < FLYWHEEL_GEAR_TEETH.planets; i += 1) {
+    const planet = new Group();
+    planet.name = `FlywheelPlanetGear-${i}`;
+    const angle = (i / FLYWHEEL_GEAR_TEETH.planets) * Math.PI * 2;
+    planet.position.set(
+      Math.cos(angle) * FLYWHEEL_GEAR_RADII.carrier,
+      Math.sin(angle) * FLYWHEEL_GEAR_RADII.carrier,
+      0.04
     );
-    automationPillarGroup.add(pillar);
-    automationPillars.push({
-      mesh: pillar,
-      material: pillarMaterial,
-      baseHeight: pillar.position.y,
-      phase: angle,
-    });
+    planet.add(
+      makeCylinder(
+        `FlywheelPlanetGearBody-${i}`,
+        FLYWHEEL_GEAR_RADII.planet,
+        0.08,
+        spec.cylinderSegments,
+        0x93c5fd
+      )
+    );
+    addGearTeeth(
+      planet,
+      `FlywheelPlanetGear-${i}`,
+      FLYWHEEL_GEAR_RADII.planet + 0.03,
+      FLYWHEEL_GEAR_TEETH.planet,
+      spec.toothEvery,
+      false
+    );
+    carrier.add(planet);
+    planetGroups.push(planet);
   }
-
-  const orbitRadius = rotorRingRadius * 1.12;
-  const orbitGeometry = new SphereGeometry(
-    0.08,
-    sphereWidthSegments,
-    sphereHeightSegments
+  const outputShaft = makeCylinder(
+    'FlywheelOutputShaft',
+    0.07,
+    0.95,
+    spec.cylinderSegments,
+    0xe2e8f0
   );
-  const orbitMaterial = new MeshStandardMaterial({
-    color: new Color(0xffffff),
-    emissive: new Color(0x7be9ff),
-    emissiveIntensity: 1.1,
-    roughness: 0.1,
-    metalness: 0.18,
-  });
-  const orbitCount = 3;
-  for (let i = 0; i < orbitCount; i += 1) {
-    const orb = new Mesh(orbitGeometry, orbitMaterial);
-    const wrapper = new Group();
-    wrapper.rotation.y = (Math.PI * 2 * i) / orbitCount;
-    orb.position.set(orbitRadius, 0, 0);
-    wrapper.add(orb);
-    orbitGroup.add(wrapper);
-  }
+  outputShaft.rotation.z = Math.PI / 2;
+  outputShaft.position.x = 0.5;
+  gearbox.add(outputShaft);
 
-  const techStackGroup = new Group();
-  techStackGroup.name = 'FlywheelTechStackGroup';
-  techStackGroup.position.copy(rotorGroup.position);
-  techStackGroup.visible = !isPerformance;
-  group.add(techStackGroup);
+  const port = new Mesh(
+    trackGeometry(
+      new SphereGeometry(
+        d.energyPort.radius,
+        spec.cylinderSegments,
+        Math.max(4, spec.cylinderSegments / 2)
+      )
+    ),
+    trackMaterial(new MeshBasicMaterial({ color: 0x38bdf8 }))
+  );
+  port.name = 'FlywheelEnergyPort';
+  port.position.set(d.energyPort.x, d.energyPort.y, d.energyPort.z);
+  group.add(port);
 
-  const techStackItems = [
-    {
-      label: 'CI templates',
-      caption: 'lint · test · deploy',
-      accent: '#56d7ff',
-    },
-    {
-      label: 'Typed prompts',
-      caption: 'codex-driven flows',
-      accent: '#63e1ff',
-    },
-    {
-      label: 'Scaffolds',
-      caption: 'vite · playwright',
-      accent: '#71e9ff',
-    },
-  ];
+  let selectionTarget = 0;
+  let selectionStrength = 0;
+  let crankAngle = 0;
+  let disposed = false;
+  const getPoiId = (event: Event) =>
+    (event as CustomEvent).detail?.poi?.id ?? (event as CustomEvent).detail?.id;
+  const onSelect = (event: Event) => {
+    selectionTarget = getPoiId(event) === FLYWHEEL_POI_ID ? 1 : 0;
+  };
+  const onClear = (event: Event) => {
+    if (!getPoiId(event) || getPoiId(event) === FLYWHEEL_POI_ID)
+      selectionTarget = 0;
+  };
+  const target = typeof window === 'undefined' ? null : window;
+  target?.addEventListener('poi:selected', onSelect);
+  target?.addEventListener('poi:selected:analytics', onSelect);
+  target?.addEventListener('poi:selection-cleared', onClear);
 
-  const techStackRadius = rotorRingRadius * 1.32;
-  const techStackGeometry = new PlaneGeometry(0.72, 0.28);
-  const techStackChips: {
-    wrapper: Group;
-    mesh: Mesh;
-    material: MeshBasicMaterial;
-  }[] = [];
-
-  techStackItems.forEach((item, index) => {
-    const texture = createFlywheelTechStackChipTexture(item);
-    const material = new MeshBasicMaterial({
-      map: texture,
-      transparent: true,
-      opacity: 0,
-      depthWrite: false,
+  const applyAngles = (angle: number) => {
+    const carrierAngle = getFlywheelCarrierAngle(angle);
+    crankGroup.rotation.z = angle;
+    sunGear.rotation.z = angle;
+    carrier.rotation.z = carrierAngle;
+    outputShaft.rotation.x = carrierAngle;
+    wheelGroup.rotation.z = carrierAngle;
+    planetGroups.forEach((planet) => {
+      planet.rotation.z = getFlywheelPlanetSpinAngle(angle);
     });
-    const mesh = new Mesh(techStackGeometry, material);
-    mesh.name = `FlywheelTechStackChip:${index}`;
-    mesh.position.set(techStackRadius, 0.22, 0);
-    mesh.lookAt(0, mesh.position.y, 0);
-    mesh.rotateY(Math.PI);
-    mesh.renderOrder = 18;
-    mesh.visible = false;
+  };
 
-    const wrapper = new Group();
-    wrapper.name = `FlywheelTechStackChipWrapper:${index}`;
-    wrapper.rotation.y = (Math.PI * 2 * index) / techStackItems.length;
-    wrapper.add(mesh);
-    techStackGroup.add(wrapper);
-
-    techStackChips.push({ wrapper, mesh, material });
-  });
-
-  const kioskWidth = 0.6;
-  const orientation = options.orientationRadians ?? 0;
-  const panelRadius = daisRadius + 0.48;
-  const targetPanelX = options.centerX + Math.cos(orientation) * panelRadius;
-  const targetPanelZ = options.centerZ + Math.sin(orientation) * panelRadius;
-  const clampedPanelX = MathUtils.clamp(
-    targetPanelX,
-    options.roomBounds.minX + kioskWidth / 2,
-    options.roomBounds.maxX - kioskWidth / 2
-  );
-  const clampedPanelZ = MathUtils.clamp(
-    targetPanelZ,
-    options.roomBounds.minZ + kioskWidth / 2,
-    options.roomBounds.maxZ - kioskWidth / 2
-  );
-  const infoPanelGroup = new Group();
-  infoPanelGroup.name = 'FlywheelInfoPanelGroup';
-  infoPanelGroup.position.set(clampedPanelX, daisHeight + 0.62, clampedPanelZ);
-  infoPanelGroup.lookAt(options.centerX, daisHeight + 0.62, options.centerZ);
-  infoPanelGroup.rotateY(Math.PI);
-  group.add(infoPanelGroup);
-
-  const panelTexture = createFlywheelTechStackTexture();
-  const panelMaterial = new MeshBasicMaterial({
-    map: panelTexture,
-    transparent: true,
-    opacity: 0.08,
-    depthWrite: false,
-  });
-  const panelGeometry = new PlaneGeometry(1.8, 1);
-  const panel = new Mesh(panelGeometry, panelMaterial);
-  panel.name = 'FlywheelInfoPanel';
-  panel.position.y = 0.4;
-  panel.renderOrder = 14;
-  infoPanelGroup.add(panel);
-
-  const panelBackerGeometry = new PlaneGeometry(1.84, 1.04);
-  const panelBackerMaterial = new MeshStandardMaterial({
-    color: new Color(0x0c141d),
-    emissive: new Color(0x1a2c3c),
-    emissiveIntensity: 0.4,
-    roughness: 0.4,
-    metalness: 0.12,
-  });
-  const panelBacker = new Mesh(panelBackerGeometry, panelBackerMaterial);
-  panelBacker.name = 'FlywheelInfoPanelBacker';
-  panelBacker.position.set(0, 0.4, -0.02);
-  infoPanelGroup.add(panelBacker);
-
-  const panelGlowGeometry = new PlaneGeometry(1.9, 1.08);
-  const panelGlowMaterial = new MeshBasicMaterial({
-    color: new Color(0x3ebaff),
-    transparent: true,
-    opacity: 0.06,
-    depthWrite: false,
-  });
-  const panelGlow = new Mesh(panelGlowGeometry, panelGlowMaterial);
-  panelGlow.name = 'FlywheelInfoPanelGlow';
-  panelGlow.position.set(0, 0.4, 0.02);
-  panelGlow.renderOrder = 13;
-  infoPanelGroup.add(panelGlow);
-
-  const plinthGeometry = new BoxGeometry(0.42, 0.5, 0.42);
-  const plinthMaterial = new MeshStandardMaterial({
-    color: new Color(0x101823),
-    roughness: 0.36,
-    metalness: 0.18,
-  });
-  const plinth = new Mesh(plinthGeometry, plinthMaterial);
-  plinth.name = 'FlywheelInfoPanelPlinth';
-  plinth.position.set(0, 0.25, 0);
-  infoPanelGroup.add(plinth);
-
-  const calloutTexture = createFlywheelDocsCalloutTexture();
-  const calloutMaterial = new MeshBasicMaterial({
-    map: calloutTexture,
-    transparent: true,
-    opacity: 0,
-    depthWrite: false,
-  });
-  const calloutGeometry = new PlaneGeometry(1, 0.46);
-  const callout = new Mesh(calloutGeometry, calloutMaterial);
-  callout.name = 'FlywheelDocsCallout';
-  callout.position.set(0, 0.78, 0.05);
-  callout.renderOrder = 16;
-  callout.visible = false;
-  infoPanelGroup.add(callout);
-
-  const calloutGlowGeometry = new PlaneGeometry(1.06, 0.52);
-  const calloutGlowMaterial = new MeshBasicMaterial({
-    color: new Color(0x4cd0ff),
-    transparent: true,
-    opacity: 0,
-    depthWrite: false,
-  });
-  const calloutGlow = new Mesh(calloutGlowGeometry, calloutGlowMaterial);
-  calloutGlow.name = 'FlywheelDocsCalloutGlow';
-  calloutGlow.position.set(0, callout.position.y, 0.06);
-  calloutGlow.renderOrder = 15;
-  calloutGlow.visible = false;
-  infoPanelGroup.add(calloutGlow);
-
-  colliders.push({
-    minX: options.centerX - daisRadius,
-    maxX: options.centerX + daisRadius,
-    minZ: options.centerZ - daisRadius,
-    maxZ: options.centerZ + daisRadius,
-  });
-
-  colliders.push({
-    minX: infoPanelGroup.position.x - kioskWidth / 2,
-    maxX: infoPanelGroup.position.x + kioskWidth / 2,
-    minZ: infoPanelGroup.position.z - kioskWidth / 2,
-    maxZ: infoPanelGroup.position.z + kioskWidth / 2,
-  });
-
-  let spinVelocity = 0.6;
-  let infoReveal = 0.08;
-  let calloutPhase = 0;
-  let techStackReveal = 0.04;
-
-  function update(context: {
-    elapsed: number;
-    delta: number;
-    emphasis: number;
-  }) {
-    const smoothing =
-      context.delta > 0 ? 1 - Math.exp(-context.delta * 3.8) : 1;
-    selectionStrength = MathUtils.lerp(
+  const update = ({
+    elapsed,
+    delta,
+    emphasis,
+    runDecorativeEffects = true,
+  }: Parameters<FlywheelShowpieceBuild['update']>[0]) => {
+    if (disposed) return;
+    selectionStrength = MathUtils.damp(
       selectionStrength,
       selectionTarget,
-      smoothing
+      5,
+      Math.max(0, delta)
     );
-    const selectionInfluence = MathUtils.clamp(selectionStrength, 0, 1);
-    if (
-      isPerformance &&
-      Math.max(context.emphasis, selectionInfluence) < 0.02
-    ) {
-      rotorGroup.rotation.y += 0.12 * context.delta;
-      return;
+    const boost =
+      1 +
+      MathUtils.clamp(Math.max(emphasis, selectionStrength), 0, 1) *
+        FLYWHEEL_ANIMATION.emphasisSpeedBoost;
+    crankAngle +=
+      FLYWHEEL_ANIMATION.crankRadiansPerSecond * boost * Math.max(0, delta);
+    applyAngles(crankAngle);
+    if (runDecorativeEffects) {
+      const glow =
+        0.25 +
+        Math.sin(elapsed * FLYWHEEL_ANIMATION.glowPulseRadiansPerSecond) *
+          0.08 +
+        selectionStrength * 0.25;
+      group.traverse((object: Object3D) => {
+        if (
+          object.name.startsWith('FlywheelEnergyGlowRing') &&
+          object instanceof Mesh
+        ) {
+          (object.material as MeshBasicMaterial).opacity = glow;
+        }
+      });
+      (port.material as MeshBasicMaterial).color
+        .setScalar(1)
+        .lerp(new Color(0x38bdf8), 0.65 - selectionStrength * 0.25);
     }
-    const targetVelocity =
-      MathUtils.lerp(0.55, 2.4, context.emphasis) +
-      MathUtils.lerp(0, 1.1, selectionInfluence);
-    spinVelocity = MathUtils.lerp(spinVelocity, targetVelocity, smoothing);
-    rotorGroup.rotation.y += spinVelocity * context.delta;
-    counterGroup.rotation.y -= spinVelocity * 0.42 * context.delta;
-    orbitGroup.rotation.y += spinVelocity * 0.3 * context.delta;
+  };
 
-    const targetEmissive = MathUtils.lerp(0.8, 2.4, context.emphasis);
-    accentMaterial.emissiveIntensity = MathUtils.lerp(
-      accentMaterial.emissiveIntensity,
-      targetEmissive + MathUtils.lerp(0, 0.6, selectionInfluence),
-      smoothing
-    );
-    rotorRingMaterial.emissiveIntensity = MathUtils.lerp(
-      rotorRingMaterial.emissiveIntensity,
-      MathUtils.lerp(0.9, 2.1, context.emphasis) +
-        MathUtils.lerp(0, 0.5, selectionInfluence),
-      smoothing
-    );
-    spokeMaterial.emissiveIntensity = MathUtils.lerp(
-      spokeMaterial.emissiveIntensity,
-      MathUtils.lerp(0.75, 1.8, context.emphasis) +
-        MathUtils.lerp(0, 0.45, selectionInfluence),
-      smoothing
-    );
-    counterRingMaterial.emissiveIntensity = MathUtils.lerp(
-      counterRingMaterial.emissiveIntensity,
-      MathUtils.lerp(0.8, 1.9, context.emphasis) +
-        MathUtils.lerp(0, 0.42, selectionInfluence),
-      smoothing
-    );
-
-    const pillarEmphasis = Math.max(context.emphasis, selectionInfluence);
-    const pillarMotionScale = MathUtils.lerp(0.2, 1, pillarEmphasis);
-    automationPillars.forEach((pillar) => {
-      const bob =
-        Math.sin(context.elapsed * 1.1 + pillar.phase) *
-        0.08 *
-        pillarMotionScale;
-      pillar.mesh.position.y = pillar.baseHeight + bob;
-      pillar.material.emissiveIntensity = MathUtils.lerp(
-        pillar.material.emissiveIntensity,
-        MathUtils.lerp(0.35, 1.7, pillarEmphasis) +
-          MathUtils.lerp(0, 0.9, selectionInfluence),
-        smoothing
-      );
-      pillar.material.opacity = MathUtils.lerp(
-        pillar.material.opacity,
-        MathUtils.lerp(0.18, 0.75, pillarEmphasis),
-        smoothing
-      );
-      pillar.mesh.visible = pillar.material.opacity > 0.02;
-    });
-
-    infoReveal = MathUtils.lerp(
-      infoReveal,
-      MathUtils.lerp(0.08, 1, context.emphasis),
-      smoothing
-    );
-    panelMaterial.opacity = infoReveal;
-    panelGlowMaterial.opacity = MathUtils.lerp(0.05, 0.32, context.emphasis);
-    panel.position.y = MathUtils.lerp(0.34, 0.56, context.emphasis);
-    panelBacker.position.y = panel.position.y - 0.02;
-    panelGlow.position.y = panel.position.y;
-    panel.visible = panelMaterial.opacity > 0.04;
-    panelGlow.visible = panel.visible;
-
-    calloutPhase +=
-      context.delta *
-      (MathUtils.lerp(0.55, 1.35, context.emphasis) +
-        MathUtils.lerp(0, 0.35, selectionInfluence));
-    const calloutBob = Math.sin(calloutPhase) * 0.05;
-    const panelReveal = MathUtils.clamp(infoReveal, 0, 1);
-    const calloutRevealBase = Math.pow(panelReveal, 0.8);
-    const selectionReveal = Math.pow(selectionInfluence, 0.85);
-    const combinedReveal = calloutRevealBase * selectionReveal;
-    const calloutOpacity =
-      combinedReveal * MathUtils.lerp(0.2, 0.95, context.emphasis);
-    calloutMaterial.opacity = calloutOpacity;
-    calloutGlowMaterial.opacity =
-      combinedReveal * MathUtils.lerp(0.05, 0.32, context.emphasis);
-    const baseCalloutHeight =
-      MathUtils.lerp(0.7, 0.94, context.emphasis) +
-      MathUtils.lerp(0, 0.08, selectionInfluence);
-    callout.position.y = baseCalloutHeight + calloutBob;
-    calloutGlow.position.y = callout.position.y;
-    callout.visible = calloutMaterial.opacity > 0.02;
-    calloutGlow.visible = callout.visible;
-
-    glyphRingMaterial.opacity = MathUtils.lerp(
-      0.18,
-      0.36,
-      Math.max(context.emphasis, selectionInfluence)
-    );
-    orbitGroup.children.forEach((wrapper, index) => {
-      wrapper.rotation.y =
-        context.elapsed * 0.65 + (Math.PI * 2 * index) / orbitCount;
-    });
-
-    techStackReveal = MathUtils.lerp(
-      techStackReveal,
-      Math.max(
-        MathUtils.lerp(0.02, 0.35, context.emphasis),
-        selectionInfluence
-      ),
-      smoothing
-    );
-    const chipOpacity = MathUtils.lerp(0, 0.96, techStackReveal);
-    const chipOrbitSpeed =
-      MathUtils.lerp(0.3, 0.75, context.emphasis) +
-      MathUtils.lerp(0, 0.35, selectionInfluence);
-    techStackChips.forEach((chip, index) => {
-      const baseAngle = (Math.PI * 2 * index) / techStackChips.length;
-      chip.wrapper.rotation.y = context.elapsed * chipOrbitSpeed + baseAngle;
-      chip.mesh.position.y =
-        MathUtils.lerp(0.18, 0.34, context.emphasis) +
-        Math.sin(context.elapsed * 1.2 + index) * 0.05;
-      const targetOpacity =
-        MathUtils.clamp(techStackReveal, 0, 1) * chipOpacity;
-      chip.material.opacity = MathUtils.lerp(
-        chip.material.opacity,
-        targetOpacity,
-        smoothing
-      );
-      chip.mesh.visible = chip.material.opacity > 0.02;
-    });
-  }
+  applyAngles(0);
 
   return {
     group,
     colliders,
     update,
+    getDebugState: () => ({
+      crankAngle,
+      sunAngle: crankAngle,
+      carrierAngle: getFlywheelCarrierAngle(crankAngle),
+      flywheelAngle: getFlywheelCarrierAngle(crankAngle),
+      planetAngles: planetGroups.map((planet, index) => ({
+        orbit:
+          getFlywheelCarrierAngle(crankAngle) +
+          (index / FLYWHEEL_GEAR_TEETH.planets) * Math.PI * 2,
+        spin: planet.rotation.z,
+      })),
+      ratio: FLYWHEEL_PLANETARY_RATIO,
+      disposed,
+    }),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      target?.removeEventListener('poi:selected', onSelect);
+      target?.removeEventListener('poi:selected:analytics', onSelect);
+      target?.removeEventListener('poi:selection-cleared', onClear);
+      ownedGeometries.forEach((geometry) => geometry.dispose());
+      ownedMaterials.forEach((material) => material.dispose());
+    },
   };
-}
-
-function createFlywheelTechStackTexture(): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 1024;
-  canvas.height = 512;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create tech stack canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-
-  const gradient = context.createLinearGradient(
-    0,
-    0,
-    canvas.width,
-    canvas.height
-  );
-  gradient.addColorStop(0, 'rgba(33, 139, 255, 0.92)');
-  gradient.addColorStop(1, 'rgba(18, 196, 255, 0.62)');
-
-  context.fillStyle = 'rgba(5, 16, 28, 0.85)';
-  roundRect(context, 40, 40, canvas.width - 80, canvas.height - 80, 28);
-  context.fill();
-
-  context.strokeStyle = 'rgba(77, 197, 255, 0.7)';
-  context.lineWidth = 6;
-  context.stroke();
-
-  context.fillStyle = gradient;
-  context.font = 'bold 96px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'top';
-  context.fillText('Flywheel Automation', 80, 86);
-
-  context.fillStyle = '#bde9ff';
-  context.font = '48px "Inter", "Segoe UI", sans-serif';
-  context.fillText(
-    'CI templates · typed prompts · reproducible scaffolds',
-    80,
-    200
-  );
-
-  context.font = '40px "Inter", "Segoe UI", sans-serif';
-  const bulletItems = [
-    'Scripts: lint · test · deploy hooks',
-    'Stacks: Node · Python · WebGL orchestrations',
-    'Runtime: GitHub Actions · pnpm/npm parity',
-  ];
-  bulletItems.forEach((item, index) => {
-    const y = 280 + index * 80;
-    context.fillStyle = 'rgba(117, 221, 255, 0.9)';
-    context.fillRect(80, y, 18, 18);
-    context.fillStyle = '#e2f6ff';
-    context.fillText(item, 120, y - 20);
-  });
-
-  context.fillStyle = '#ffffff';
-  context.font = 'bold 64px "Inter", "Segoe UI", sans-serif';
-  context.fillText('Docs →', canvas.width - 280, canvas.height - 120);
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function createFlywheelDocsCalloutTexture(): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create docs callout canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-  context.save();
-  context.fillStyle = 'rgba(8, 20, 34, 0.92)';
-  roundRect(context, 32, 24, canvas.width - 64, canvas.height - 48, 32);
-  context.fill();
-  context.strokeStyle = 'rgba(76, 208, 255, 0.7)';
-  context.lineWidth = 5;
-  context.stroke();
-  context.restore();
-
-  context.save();
-  context.fillStyle = '#ecfbff';
-  context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'alphabetic';
-  context.fillText('README', 64, canvas.height * 0.56);
-
-  context.font = '600 56px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#a8eeff';
-  context.fillText(
-    'github.com/futuroptimist/flywheel',
-    64,
-    canvas.height * 0.78
-  );
-
-  context.textAlign = 'right';
-  context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#67d2ff';
-  context.fillText('→', canvas.width - 64, canvas.height * 0.58);
-  context.restore();
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function createFlywheelTechStackChipTexture(item: {
-  label: string;
-  caption: string;
-  accent: string;
-}): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create tech stack chip canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-  context.save();
-  context.fillStyle = 'rgba(10, 24, 38, 0.92)';
-  roundRect(context, 28, 36, canvas.width - 56, canvas.height - 72, 42);
-  context.fill();
-  context.strokeStyle = `${item.accent}cc`;
-  context.lineWidth = 6;
-  context.stroke();
-  context.restore();
-
-  context.save();
-  context.fillStyle = item.accent;
-  context.fillRect(52, canvas.height - 78, canvas.width - 104, 12);
-  context.restore();
-
-  context.save();
-  context.fillStyle = '#e7f7ff';
-  context.font = 'bold 104px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'alphabetic';
-  context.fillText(item.label, 64, canvas.height * 0.56);
-
-  context.font = '600 52px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#a4ebff';
-  context.fillText(item.caption, 64, canvas.height * 0.78);
-  context.restore();
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function roundRect(
-  context: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  radius: number
-) {
-  const r = Math.min(radius, width / 2, height / 2);
-  context.beginPath();
-  context.moveTo(x + r, y);
-  context.lineTo(x + width - r, y);
-  context.quadraticCurveTo(x + width, y, x + width, y + r);
-  context.lineTo(x + width, y + height - r);
-  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-  context.lineTo(x + r, y + height);
-  context.quadraticCurveTo(x, y + height, x, y + height - r);
-  context.lineTo(x, y + r);
-  context.quadraticCurveTo(x, y, x + r, y);
-  context.closePath();
-}
-
-type PoiEventDetail = { poi?: { id?: string } };
-
-function getPoiIdFromEvent(event: Event): string | null {
-  const detail = (event as CustomEvent<PoiEventDetail>).detail;
-  if (!detail || typeof detail !== 'object') {
-    return null;
-  }
-  const poiId = detail.poi?.id;
-  return typeof poiId === 'string' ? poiId : null;
 }

--- a/src/scene/structures/flywheelEnergyContract.ts
+++ b/src/scene/structures/flywheelEnergyContract.ts
@@ -1,0 +1,78 @@
+import type { RectCollider } from '../collision';
+
+export const FLYWHEEL_ENERGY_INSTALLATION_NAME = 'FlywheelEnergyInstallation';
+
+export const FLYWHEEL_ENERGY_DIMENSIONS = {
+  installationBounds: { width: 4.0, depth: 2.45, height: 2.25 },
+  realWorldDimensionsMeters: { width: 2.6, depth: 1.8, height: 1.7 },
+  base: { width: 3.15, depth: 1.75, height: 0.18 },
+  wheel: { radius: 0.78, thickness: 0.18, centerY: 1.18, centerZ: 0.18 },
+  axle: { radius: 0.09, length: 2.2 },
+  bearingStand: { width: 0.22, depth: 0.34, height: 1.1, offsetX: 0.72 },
+  crank: {
+    radius: 0.38,
+    armLength: 0.38,
+    handleRadius: 0.055,
+    handleLength: 0.32,
+  },
+  gearbox: {
+    radius: 0.47,
+    depth: 0.22,
+    centerX: -1.05,
+    centerY: 1.18,
+    centerZ: 0.18,
+  },
+  energyPort: { radius: 0.16, x: -1.05, y: 1.72, z: 0.18 },
+  markerClearance: 2.35,
+  avatarPathRadius: 1.12,
+} as const;
+
+export const FLYWHEEL_GEAR_TEETH = {
+  sun: 18,
+  planet: 18,
+  ring: 54,
+  planets: 3,
+} as const;
+
+export const FLYWHEEL_GEAR_RADII = {
+  sun: 0.16,
+  planet: 0.16,
+  ringPitch: 0.48,
+  ringOuter: 0.57,
+  carrier: 0.32,
+} as const;
+
+export const FLYWHEEL_PLANETARY_RATIO =
+  1 + FLYWHEEL_GEAR_TEETH.ring / FLYWHEEL_GEAR_TEETH.sun;
+
+export const FLYWHEEL_ANIMATION = {
+  crankRadiansPerSecond: Math.PI * 1.15,
+  emphasisSpeedBoost: 0.12,
+  glowPulseRadiansPerSecond: Math.PI * 1.7,
+} as const;
+
+export function getFlywheelCarrierAngle(crankAngle: number): number {
+  return crankAngle / FLYWHEEL_PLANETARY_RATIO;
+}
+
+export function getFlywheelPlanetSpinAngle(crankAngle: number): number {
+  return -crankAngle * (FLYWHEEL_GEAR_TEETH.sun / FLYWHEEL_GEAR_TEETH.planet);
+}
+
+export function getFlywheelLocalColliders(): RectCollider[] {
+  const { base, crank, gearbox } = FLYWHEEL_ENERGY_DIMENSIONS;
+  return [
+    {
+      minX: -base.width / 2,
+      maxX: base.width / 2,
+      minZ: -base.depth / 2,
+      maxZ: base.depth / 2,
+    },
+    {
+      minX: gearbox.centerX - gearbox.radius - crank.radius,
+      maxX: gearbox.centerX + gearbox.radius + 0.18,
+      minZ: gearbox.centerZ - gearbox.radius - 0.12,
+      maxZ: gearbox.centerZ + gearbox.radius + 0.12,
+    },
+  ];
+}

--- a/src/tests/flywheelEnergyContract.test.ts
+++ b/src/tests/flywheelEnergyContract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLYWHEEL_ENERGY_DIMENSIONS,
+  FLYWHEEL_GEAR_RADII,
+  FLYWHEEL_GEAR_TEETH,
+  FLYWHEEL_PLANETARY_RATIO,
+  getFlywheelCarrierAngle,
+  getFlywheelLocalColliders,
+  getFlywheelPlanetSpinAngle,
+} from '../scene/structures/flywheelEnergyContract';
+
+describe('flywheel energy contract', () => {
+  it('exports finite plausible physical and gear constants', () => {
+    expect(FLYWHEEL_ENERGY_DIMENSIONS.installationBounds.width).toBeGreaterThan(
+      3
+    );
+    expect(FLYWHEEL_ENERGY_DIMENSIONS.wheel.radius).toBeGreaterThan(0.5);
+    Object.values(FLYWHEEL_GEAR_RADII).forEach((value) =>
+      expect(Number.isFinite(value)).toBe(true)
+    );
+    expect(FLYWHEEL_GEAR_TEETH.ring).toBe(
+      FLYWHEEL_GEAR_TEETH.sun + 2 * FLYWHEEL_GEAR_TEETH.planet
+    );
+    expect(FLYWHEEL_PLANETARY_RATIO).toBe(
+      1 + FLYWHEEL_GEAR_TEETH.ring / FLYWHEEL_GEAR_TEETH.sun
+    );
+    expect(FLYWHEEL_PLANETARY_RATIO).toBeGreaterThan(1);
+  });
+
+  it('keeps carrier and planet spin synchronized from a single crank angle', () => {
+    const crankAngle = Math.PI * 2;
+    expect(getFlywheelCarrierAngle(crankAngle)).toBeCloseTo(crankAngle / 4);
+    expect(getFlywheelPlanetSpinAngle(crankAngle)).toBeLessThan(0);
+  });
+
+  it('keeps local colliders inside intended bounds', () => {
+    const halfWidth = FLYWHEEL_ENERGY_DIMENSIONS.installationBounds.width / 2;
+    const halfDepth = FLYWHEEL_ENERGY_DIMENSIONS.installationBounds.depth / 2;
+    getFlywheelLocalColliders().forEach((collider) => {
+      expect(collider.minX).toBeGreaterThanOrEqual(-halfWidth);
+      expect(collider.maxX).toBeLessThanOrEqual(halfWidth);
+      expect(collider.minZ).toBeGreaterThanOrEqual(-halfDepth);
+      expect(collider.maxZ).toBeLessThanOrEqual(halfDepth);
+    });
+  });
+});

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -1,291 +1,158 @@
-import { Group, Mesh, MeshBasicMaterial, MeshStandardMaterial } from 'three';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Box3, Group, Mesh, Object3D, Vector3 } from 'three';
+import { describe, expect, it } from 'vitest';
 
+import {
+  ORDERED_SCENE_DETAIL_LEVELS,
+  getSceneDetailPolicy,
+} from '../scene/graphics/sceneDetailPolicy';
 import { createFlywheelShowpiece } from '../scene/structures/flywheel';
+import {
+  FLYWHEEL_ENERGY_DIMENSIONS,
+  FLYWHEEL_PLANETARY_RATIO,
+} from '../scene/structures/flywheelEnergyContract';
+import { countObjectTriangles } from '../scene/structures/triangleCount';
 
-type CapturingContext = CanvasRenderingContext2D & {
-  fillTextCalls: string[];
-};
-
-const contexts: CapturingContext[] = [];
-
-const createMockContext = (canvas: HTMLCanvasElement): CapturingContext => {
-  const fillTextCalls: string[] = [];
-  const gradient = { addColorStop: vi.fn() };
-  const context = {
-    save: vi.fn(),
-    restore: vi.fn(),
-    clearRect: vi.fn(),
-    beginPath: vi.fn(),
-    closePath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    quadraticCurveTo: vi.fn(),
-    fillRect: vi.fn(),
-    fill: vi.fn(),
-    stroke: vi.fn(),
-    createLinearGradient: vi.fn(() => gradient),
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 0,
-    textAlign: 'left',
-    textBaseline: 'alphabetic',
-    font: '',
-    globalAlpha: 1,
-    shadowBlur: 0,
-    shadowColor: '',
-    fillText: vi.fn((text: string) => {
-      fillTextCalls.push(text);
-    }),
-    fillTextCalls,
-  } as Partial<CapturingContext>;
-  Object.defineProperty(context, 'canvas', { value: canvas });
-  return context as CapturingContext;
-};
-
-beforeAll(() => {
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
-    configurable: true,
-    value(this: HTMLCanvasElement, type: string) {
-      if (type !== '2d') {
-        return null;
-      }
-      const context = createMockContext(this);
-      contexts.push(context);
-      return context;
-    },
-  });
-});
-
-beforeEach(() => {
-  contexts.length = 0;
-});
+const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
+const semanticNames = [
+  'FlywheelBase',
+  'FlywheelBearingStandLeft',
+  'FlywheelBearingStandRight',
+  'FlywheelAxle',
+  'FlywheelWheelGroup',
+  'FlywheelHeavyRim',
+  'FlywheelInnerHub',
+  'FlywheelCrankGroup',
+  'FlywheelCrankDisc',
+  'FlywheelCrankArm',
+  'FlywheelCrankHandle',
+  'FlywheelPlanetaryGearbox',
+  'FlywheelRingGear',
+  'FlywheelSunGear',
+  'FlywheelPlanetCarrier',
+  'FlywheelPlanetGear-0',
+  'FlywheelOutputShaft',
+  'FlywheelEnergyPort',
+];
 
 describe('createFlywheelShowpiece', () => {
-  const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
-
-  it('builds kinetic hub geometry with docs callout signage', () => {
+  it('anchors the root at the POI position without scaling or world-coordinate children', () => {
     const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
+      position: { x: 9, y: 0.25, z: 0.75 },
+      orientationRadians: 0.4,
       roomBounds,
     });
-
-    expect(build.group.name).toBe('FlywheelShowpiece');
-
-    const rotorGroup = build.group.getObjectByName('FlywheelRotorGroup');
-    expect(rotorGroup).toBeInstanceOf(Group);
-
-    const panel = build.group.getObjectByName('FlywheelInfoPanel');
-    expect(panel).toBeInstanceOf(Mesh);
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout');
-    expect(callout).toBeInstanceOf(Mesh);
-
-    const capturedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
-    expect(capturedText).toContain('Flywheel Automation');
-    expect(capturedText).toContain('README');
-    expect(capturedText).toContain('github.com/futuroptimist/flywheel');
-    expect(capturedText).toContain('CI templates');
-    expect(capturedText).toContain('Typed prompts');
-    expect(capturedText).toContain('Scaffolds');
-    expect(capturedText).toContain('lint · test · deploy');
-    expect(capturedText).toContain('codex-driven flows');
-    expect(capturedText).toContain('vite · playwright');
+    expect(build.group.name).toBe('FlywheelEnergyInstallation');
+    expect(build.group.position.toArray()).toEqual([9, 0.25, 0.75]);
+    expect(build.group.rotation.y).toBe(0.4);
+    expect(build.group.scale.toArray()).toEqual([1, 1, 1]);
+    build.group.traverse((object: Object3D) => {
+      if (object !== build.group) {
+        expect(Math.abs(object.position.x)).toBeLessThan(3);
+        expect(Math.abs(object.position.z)).toBeLessThan(3);
+      }
+    });
+    build.dispose();
   });
 
-  it('keeps the docs callout hidden when only emphasis is applied', () => {
+  it('builds the physical semantic hierarchy and removes obsolete abstract kiosk pieces', () => {
     const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
+      position: { x: 0, z: 0 },
       roomBounds,
     });
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-
-    build.update({ elapsed: 0.5, delta: 0.5, emphasis: 1 });
-    build.update({ elapsed: 1, delta: 0.5, emphasis: 1 });
-
-    expect(calloutMaterial.opacity).toBeLessThan(0.05);
-    expect(callout.visible).toBe(false);
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    semanticNames.forEach((name) =>
+      expect(build.group.getObjectByName(name)).toBeTruthy()
+    );
+    expect(build.group.getObjectByName('FlywheelInfoPanel')).toBeUndefined();
+    expect(
+      build.group.getObjectByName('FlywheelAutomationPillars')
+    ).toBeUndefined();
+    expect(build.group.getObjectByName('FlywheelRotorGroup')).toBeUndefined();
+    expect(build.group.getObjectByName('FlywheelSpoke-0')).toBeInstanceOf(Mesh);
+    expect(
+      build.group.getObjectByName('FlywheelCounterweight-0')
+    ).toBeInstanceOf(Mesh);
+    build.dispose();
   });
 
-  it('reveals docs callout when the flywheel POI is selected and hides when cleared', () => {
+  it('synchronizes crank, sun, planet carrier, planet counter-spin, output, and flywheel angles', () => {
     const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
+      position: { x: 0, z: 0 },
       roomBounds,
     });
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-    const calloutGlow = build.group.getObjectByName(
-      'FlywheelDocsCalloutGlow'
-    ) as Mesh;
-    const calloutGlowMaterial = calloutGlow.material as MeshBasicMaterial;
-    const rotorGroup = build.group.getObjectByName(
-      'FlywheelRotorGroup'
-    ) as Group;
-
-    const initialRotation = rotorGroup.rotation.y;
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
+    build.update({
+      elapsed: 1,
+      delta: 1,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const state = build.getDebugState();
+    expect(state.ratio).toBe(FLYWHEEL_PLANETARY_RATIO);
+    expect(state.sunAngle).toBeCloseTo(state.crankAngle);
+    expect(state.carrierAngle).toBeCloseTo(
+      state.crankAngle / FLYWHEEL_PLANETARY_RATIO
     );
-
-    build.update({ elapsed: 0.5, delta: 0.5, emphasis: 1 });
-    build.update({ elapsed: 1.1, delta: 0.6, emphasis: 1 });
-
-    expect(rotorGroup.rotation.y).toBeGreaterThan(initialRotation);
-    expect(calloutMaterial.opacity).toBeGreaterThan(0.3);
-    expect(calloutGlowMaterial.opacity).toBeGreaterThan(0.05);
-    expect(callout.visible).toBe(true);
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selection-cleared', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
+    expect(state.flywheelAngle).toBeCloseTo(state.carrierAngle);
+    expect(state.planetAngles[1].orbit).toBeGreaterThan(
+      state.planetAngles[0].orbit
     );
-
-    let elapsed = 1.6;
-    for (let i = 0; i < 6; i += 1) {
-      build.update({ elapsed, delta: 0.3, emphasis: 0.8 });
-      elapsed += 0.3;
-    }
-
-    expect(calloutMaterial.opacity).toBeLessThan(0.05);
-    expect(callout.visible).toBe(false);
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    expect(state.planetAngles[0].spin).toBeLessThan(0);
+    build.dispose();
   });
 
-  it('keeps the docs callout hidden when emphasis stays at zero', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
+  it('builds finite geometry at every detail level with decreasing triangle counts', () => {
+    const counts = ORDERED_SCENE_DETAIL_LEVELS.map((level) => {
+      const build = createFlywheelShowpiece({
+        position: { x: 0, z: 0 },
+        roomBounds,
+        detailPolicy: getSceneDetailPolicy(level),
+      });
+      const count = countObjectTriangles(build.group);
+      expect(count).toBeGreaterThan(0);
+      build.dispose();
+      return count;
     });
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-
-    for (let i = 0; i < 5; i += 1) {
-      build.update({ elapsed: i * 0.5, delta: 0.5, emphasis: 0 });
-    }
-
-    expect(calloutMaterial.opacity).toBe(0);
-    expect(callout.visible).toBe(false);
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    expect(counts[0]).toBeGreaterThan(counts[1]);
+    expect(counts[1]).toBeGreaterThan(counts[2]);
+    expect(counts[2]).toBeGreaterThan(counts[3]);
   });
 
-  it('reveals tech stack chips and animates their orbit after selection', () => {
+  it('keeps bounds, colliders, zero-emphasis update, allocation stability, and disposal safe', () => {
     const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
+      position: { x: 0, z: 0 },
       roomBounds,
     });
-
-    const techStackGroup = build.group.getObjectByName(
-      'FlywheelTechStackGroup'
-    ) as Group;
-    expect(techStackGroup).toBeInstanceOf(Group);
-
-    const wrappers = techStackGroup.children as Group[];
-    expect(wrappers).toHaveLength(3);
-
-    const initialRotations = wrappers.map((wrapper) => wrapper.rotation.y);
-    const materials = wrappers.map((wrapper) => {
-      const chip = wrapper.children[0] as Mesh;
-      return chip.material as MeshBasicMaterial;
-    });
-
-    build.update({ elapsed: 0.25, delta: 0.25, emphasis: 0.6 });
-    materials.forEach((material) => {
-      expect(material.opacity).toBeLessThan(0.1);
-    });
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected:analytics', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
+    const box = new Box3().setFromObject(build.group);
+    const size = new Vector3();
+    box.getSize(size);
+    expect(size.x).toBeLessThanOrEqual(
+      FLYWHEEL_ENERGY_DIMENSIONS.installationBounds.width + 0.05
     );
-
-    build.update({ elapsed: 0.9, delta: 0.65, emphasis: 1 });
-    build.update({ elapsed: 1.6, delta: 0.7, emphasis: 1 });
-
-    wrappers.forEach((wrapper, index) => {
-      expect(wrapper.rotation.y).not.toBeCloseTo(initialRotations[index]);
-      const chip = wrapper.children[0] as Mesh;
-      expect(chip.visible).toBe(true);
-    });
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeGreaterThan(0.3);
-    });
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
-  });
-
-  it('highlights automation pillars as emphasis and selection increase', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
-
-    const pillarGroup = build.group.getObjectByName(
-      'FlywheelAutomationPillars'
-    ) as Group;
-    expect(pillarGroup).toBeInstanceOf(Group);
-
-    const pillarMeshes = pillarGroup.children as Mesh[];
-    expect(pillarMeshes.length).toBeGreaterThan(0);
-
-    const initialHeights = pillarMeshes.map((mesh) => mesh.position.y);
-    const materials = pillarMeshes.map(
-      (mesh) => mesh.material as MeshStandardMaterial
+    expect(size.z).toBeLessThanOrEqual(
+      FLYWHEEL_ENERGY_DIMENSIONS.installationBounds.depth + 0.05
     );
-
-    build.update({ elapsed: 0.2, delta: 0.2, emphasis: 0.1 });
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeLessThan(0.3);
+    expect(size.y).toBeLessThanOrEqual(
+      FLYWHEEL_ENERGY_DIMENSIONS.installationBounds.height + 0.05
+    );
+    expect(build.colliders.length).toBeGreaterThan(0);
+    const meshCount = (() => {
+      let count = 0;
+      build.group.traverse((object) => {
+        if (object instanceof Mesh) count += 1;
+      });
+      return count;
+    })();
+    build.update({ elapsed: 0, delta: 0.16, emphasis: 0 });
+    build.update({ elapsed: 0.16, delta: 0.16, emphasis: 0 });
+    let nextMeshCount = 0;
+    build.group.traverse((object) => {
+      if (object instanceof Mesh) nextMeshCount += 1;
     });
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
+    expect(nextMeshCount).toBe(meshCount);
+    expect(build.group.getObjectByName('FlywheelWheelGroup')).toBeInstanceOf(
+      Group
     );
-
-    build.update({ elapsed: 0.9, delta: 0.7, emphasis: 1 });
-    build.update({ elapsed: 1.6, delta: 0.7, emphasis: 1 });
-
-    const finalHeights = pillarMeshes.map((mesh) => mesh.position.y);
-    const heightChanged = finalHeights.some(
-      (height, index) => Math.abs(height - initialHeights[index]) > 1e-4
-    );
-    expect(heightChanged).toBe(true);
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeGreaterThan(0.4);
-      expect(material.emissiveIntensity).toBeGreaterThan(0.5);
-    });
-
-    expect(pillarMeshes.every((mesh) => mesh.visible)).toBe(true);
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selection-cleared', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    build.dispose();
+    build.dispose();
+    expect(build.getDebugState().disposed).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- Replace the prior abstract Flywheel kiosk with a physically-plausible kinetic installation (heavy rim, crank, bearings, planetary gearbox) per P6b requirements. 
- Provide a single shared contract for dimensions, gear teeth/radii, ratios, speeds, and conservative colliders to avoid duplicated constants. 
- Make the mechanical train deterministic and always-updating while allowing decorative effects to be throttled for performance; leave cross-POI energy arcs to P6c.

### Description
- Add a shared contract `src/scene/structures/flywheelEnergyContract.ts` that exports installation dimensions, gear teeth/radii, `FLYWHEEL_PLANETARY_RATIO`, animation constants, and `getFlywheelLocalColliders()` and helper angle math. 
- Replace the old abstract builder with a physical assembly in `src/scene/structures/flywheel.ts` authored in local coordinates and anchored as a bottom-centered unit-scale POI root named `FlywheelEnergyInstallation`; build a clear semantic hierarchy (base, bearing stands, axle, wheel group, heavy rim, hub, spokes/counterweights, glow rings, crank, planetary gearbox, sun/planet/ring gears, carrier, output shaft, energy port). 
- Implement a fixed-ring planetary gear train with deterministic ratio math (carrier/output/flywheel = crank / (1 + ring/sun)), procedural tooth approximations that vary by detail level, synchronized angle application (`crank -> sun -> planets (counter-spin) -> carrier/output -> flywheel`), idempotent disposal, and tracked owned geometries/materials. 
- Runtime and metadata integration: `src/main.ts` now passes a `position` to the builder, disposes the flywheel on teardown, and calls `flywheelShowpiece.update(...)` each frame while passing a `runDecorativeEffects` boolean from `sceneDetailController.shouldRunDecorativeUpdate(...)`; `src/scene/poi/physicalMetadata.ts` and the miniature proxy (`src/scene/miniature/poiProxyRegistry.ts`) were updated to reference the shared contract and refreshed sync metadata/manifest; docs updated at `docs/architecture/flywheel-energy-transfer.md`. 

### Testing
- Ran formatting: `npm run format:write` (passed). 
- Bumped and refreshed miniature manifest: `npm run miniature:manifest:update` then `npm run miniature:check` (manifest updated and check passed). 
- Focused unit tests: `npm run test:ci -- src/tests/flywheelEnergyContract.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts src/tests/sceneObjectColliderPolicies.test.ts` (all selected test suites passed). 
- Lint and build: `npm run lint` (passed) and `npm run build` / `npm run smoke` (passed; build emitted normal chunk-size warnings). 
- Docs/link check: `npm run docs:check` (passed; link checker produced external fetch warnings from the environment). 
- Prettier/style check: `npm run format:check` (passed). 
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected). 
- Type-check: `npm run typecheck` reported existing project-wide TypeScript errors unrelated to this change (failures originate in other areas such as `src/main.ts`, avatar importer, and several legacy tests); these are pre-existing and not introduced by the Flywheel changes. 

If you want I can split follow-ups (P6c arcs, further detail-level triangle tuning, and additional test hardening) into focused PRs; the current changes are limited to P6b scope and include focused tests and documentation updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f31a5fd7c832f84461c3aae0b7ed5)