### PR TITLE
⚙️ : – implement physical Flywheel assembly

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -682,3 +682,68 @@ only one short blue parabolic packet is visible at a time, five incoming packets
 precede one larger outgoing packet, reduced motion/flicker remains comfortable,
 the POI marker clears the machine, the miniature proxy is static and current, and
 there are no obvious frame spikes.
+
+## P6b implementation update: physical assembly
+
+P6b replaced the abstract kiosk with `FlywheelEnergyInstallation`, a bottom-centered
+unit-scale POI root anchored at the resolved Flywheel POI position. Production callers
+now pass `position`, `orientationRadians`, `roomBounds`, and `detailPolicy`; the
+legacy `centerX`/`centerZ` compatibility path is retained only for older tests or
+callers during migration. Child meshes are authored in installation-local coordinates.
+
+Final shared constants live in `src/scene/structures/flywheelEnergyContract.ts`:
+
+- installation bounds: `3.4 x 2.4 x 2.75` scene units;
+- base: `3.25 x 1.55 x 0.22` scene units;
+- wheel: radius `0.92`, rim tube `0.12`, thickness `0.24`, centered at
+  `(-0.58, 1.35, 0)`;
+- gearbox: centered at `(0.78, 1.24, 0)`, radius `0.52`, depth `0.26`;
+- energy port: `(1.32, 1.62, 0.62)`, radius `0.13`;
+- marker minimum height: `2.95`; avatar path radius: `1.2`.
+
+The implemented hierarchy is the physical-machine contract:
+
+```text
+FlywheelEnergyInstallation
+├─ FlywheelBase
+├─ FlywheelBearingStandLeft / FlywheelBearingStandRight
+├─ FlywheelAxle
+├─ FlywheelWheelGroup
+│  ├─ FlywheelHeavyRim
+│  ├─ FlywheelInnerHub
+│  ├─ FlywheelSpoke-*
+│  ├─ FlywheelCounterweight-*
+│  └─ FlywheelEnergyGlowRing
+├─ FlywheelCrankGroup
+│  ├─ FlywheelCrankDisc
+│  ├─ FlywheelCrankArm
+│  └─ FlywheelCrankHandle
+├─ FlywheelPlanetaryGearbox
+│  ├─ FlywheelRingGear
+│  ├─ FlywheelSunGear
+│  ├─ FlywheelPlanetCarrier
+│  ├─ FlywheelPlanetGear-*
+│  └─ FlywheelOutputShaft
+└─ FlywheelEnergyPort
+```
+
+The fixed-ring planetary train uses `18` sun teeth, `24` planet teeth, and `66`
+ring teeth. The carrier/output/flywheel angle is `crankAngle / 4.666666...`, and
+planet meshes counter-spin locally with
+`-(sunTeeth / planetTeeth) * (sunAngle - carrierAngle)`. The crank, sun, carrier,
+planet spin, output shaft, and flywheel are updated every rendered frame from the
+same deterministic crank angle. Focus/emphasis may increase the shared speed scale
+and glow intensity, but never changes the ratio math.
+
+Detail levels now build only the selected physical variant:
+
+| Detail level | Physical simplification                              |
+| ------------ | ---------------------------------------------------- |
+| Cinematic    | all tooth hints, 8 spokes, 16 bolts, two glow layers |
+| Balanced     | all tooth hints, 6 spokes, 12 bolts, one glow layer  |
+| Performance  | every third tooth, 5 spokes, 6 bolts, one glow layer |
+| Low          | grooved/disc gear silhouettes, 4 spokes, no bolts    |
+| Micro        | iconic base, wheel, crank, and gear silhouettes only |
+
+P6b intentionally does not implement cross-POI blue energy-transfer arcs. Those
+remain P6c future scope.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3023,15 +3023,17 @@ function initializeImmersiveScene(
       ? upperFloorColliders
       : groundColliders;
   if (studioRoom) {
-    const centerX =
-      flywheelPoi?.group.position.x ??
-      (studioRoom.bounds.minX + studioRoom.bounds.maxX) / 2;
-    const centerZ =
-      flywheelPoi?.group.position.z ??
-      (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2;
+    const position = {
+      x:
+        flywheelPoi?.group.position.x ??
+        (studioRoom.bounds.minX + studioRoom.bounds.maxX) / 2,
+      y: flywheelPoi?.group.position.y ?? 0,
+      z:
+        flywheelPoi?.group.position.z ??
+        (studioRoom.bounds.minZ + studioRoom.bounds.maxZ) / 2,
+    };
     const showpiece = createFlywheelShowpiece({
-      centerX,
-      centerZ,
+      position,
       roomBounds: studioRoom.bounds,
       orientationRadians: flywheelPoi?.group.rotation.y ?? 0,
       detailPolicy: activeSceneDetailPolicy,
@@ -6979,7 +6981,10 @@ function initializeImmersiveScene(
       selfieMirror.dispose();
       selfieMirror = null;
     }
-    flywheelShowpiece = null;
+    if (flywheelShowpiece) {
+      flywheelShowpiece.dispose();
+      flywheelShowpiece = null;
+    }
     f2ClipboardConsole = null;
     sigmaWorkbench = null;
     woveLoom = null;
@@ -7140,19 +7145,17 @@ function initializeImmersiveScene(
       if (flywheelShowpiece) {
         const activation = flywheelPoi?.activation ?? 0;
         const focus = flywheelPoi?.focus ?? 0;
-        if (
-          sceneDetailController.shouldRunDecorativeUpdate(
+        const emphasis = Math.max(activation, focus);
+        flywheelShowpiece.update({
+          elapsed: elapsedTime,
+          delta,
+          emphasis,
+          runDecorativeEffects: sceneDetailController.shouldRunDecorativeUpdate(
             elapsedTime,
-            Math.max(activation, focus),
+            emphasis,
             'flywheel'
-          )
-        ) {
-          flywheelShowpiece.update({
-            elapsed: elapsedTime,
-            delta,
-            emphasis: Math.max(activation, focus),
-          });
-        }
+          ),
+        });
       }
       if (f2ClipboardConsole) {
         const activation = f2ClipboardPoi?.activation ?? 0;

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -313,11 +313,11 @@
       "id": "audit:src:scene:poi:physicalMetadata",
       "sourceFiles": ["src/scene/poi/physicalMetadata.ts"],
       "proxyFiles": [],
-      "syncRevision": 4,
-      "syncNote": "Audited support source; PR Reaper real-world dimensions and scene bounds now feed its holographic installation contract while tabletop geometry remains covered by the POI proxy.",
-      "sourceFingerprint": "c9511746aa83f377f440cc4f6cde42def70039cb136d9bb6edab7fc4b4d5cba3",
+      "syncRevision": 5,
+      "syncNote": "Audited support source; Flywheel P6b physical bounds and marker clearances now use the shared flywheel contract while geometry is covered by the Flywheel proxy.",
+      "sourceFingerprint": "025c64f2bea6a373ec2ad3da5d8caaffb8929e648ac2d226cca8f5854518eb04",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "5292e4210f717e822a84d93d7ce1914ab0cad79f47de5b7ee7f13a53cdc1fc5e"
+      "metadataFingerprint": "518439c92f8c2cc9c6e848c042c92a98fc7fc67651962be108556ab37a521b06"
     },
     {
       "id": "audit:src:scene:poi:structuredData",
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "ac78de7048b2c3f23277ac748cf266bf966067a263b707f85b0fafe295af69b6",
+      "proxyFingerprint": "e784810e1d83ff6d11b5249a69140f8220289e72df082f9f099674d40e7ea51d",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -573,14 +573,15 @@
         "src/scene/poi/constants.ts",
         "src/scene/poi/placements.ts",
         "src/scene/poi/registry.ts",
-        "src/scene/structures/flywheel.ts"
+        "src/scene/structures/flywheel.ts",
+        "src/scene/structures/flywheelEnergyContract.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 3,
-      "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
-      "sourceFingerprint": "3053f6e2a8ee799815a28bceb744faa218475941757bed0a2c6e30ba7458401f",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
-      "metadataFingerprint": "be312aac26fac81617be4bf80d88bcfa3831b5c038b0ab483e02f6dbaa4c75cd"
+      "syncRevision": 5,
+      "syncNote": "Physical P6b proxy: heavy flywheel, base bearings, hand crank, planetary gear cluster, and energy port glow.",
+      "sourceFingerprint": "68ae6ac973307b94fcdc6c27a1b72542447460a01ab19a460533d0265fd750cf",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
+      "metadataFingerprint": "c6c74512e8a98a38519057d5b25b0313ff810da1b1b2c6d938e2892be83f1ed5"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -594,7 +595,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -609,7 +610,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -624,7 +625,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -639,7 +640,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -674,7 +675,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -689,7 +690,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -704,7 +705,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -719,7 +720,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -734,7 +735,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "829bbd3d5af282d49e1da754e35e63fb0832e899f4db3cf41752181cba0a9134",
+      "proxyFingerprint": "a00a97e796e2a082e19391630a2e347ceb9c7ee974574afd386e542de0f9325a",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -89,29 +89,48 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 3,
+    syncRevision: 5,
     syncNote:
-      'Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.',
-    sourceFiles: [...baseFiles, 'src/scene/structures/flywheel.ts'],
+      'Physical P6b proxy: heavy flywheel, base bearings, hand crank, planetary gear cluster, and energy port glow.',
+    sourceFiles: [
+      ...baseFiles,
+      'src/scene/structures/flywheel.ts',
+      'src/scene/structures/flywheelEnergyContract.ts',
+    ],
     proxyFiles: [SELF_FILE],
     primitives: [
-      cyl('flywheel-dais', 0.7, 0.18, [0, 0.09, 0], 0x0f766e),
+      box('flywheel-base', [1.45, 0.14, 0.7], [0, 0.07, 0], 0x1f2937),
+      box(
+        'flywheel-bearing-left',
+        [0.08, 0.58, 0.22],
+        [-0.52, 0.43, 0],
+        0x64748b
+      ),
+      box(
+        'flywheel-bearing-right',
+        [0.08, 0.58, 0.22],
+        [-0.16, 0.43, 0],
+        0x64748b
+      ),
       {
         kind: 'ring',
-        name: 'flywheel-rotor-ring',
-        radius: 0.55,
-        tube: 0.08,
-        position: [0, 0.65, 0],
-        rotation: [Math.PI / 2, 0, 0],
-        color: 0x2dd4bf,
+        name: 'flywheel-heavy-wheel',
+        radius: 0.42,
+        tube: 0.065,
+        position: [-0.34, 0.72, 0],
+        rotation: [0, Math.PI / 2, 0],
+        color: 0x334155,
       },
-      box('flywheel-spoke', [1, 0.05, 0.06], [0, 0.65, 0], 0xccfbf1),
+      box('flywheel-spoke', [0.72, 0.035, 0.04], [-0.34, 0.72, 0], 0xcbd5e1),
+      cyl('flywheel-gear-cluster', 0.22, 0.1, [0.36, 0.68, 0], 0x94a3b8),
+      cyl('flywheel-crank-disc', 0.13, 0.06, [0.36, 0.68, 0.22], 0xe2e8f0),
       box(
-        'flywheel-counterweight',
-        [0.18, 0.16, 0.18],
-        [0.44, 0.65, 0],
-        0xf59e0b
+        'flywheel-crank-arm',
+        [0.28, 0.035, 0.035],
+        [0.49, 0.68, 0.22],
+        0xe2e8f0
       ),
+      cyl('flywheel-energy-port', 0.08, 0.07, [0.62, 0.88, 0.32], 0x38bdf8),
     ],
   },
   'jobbot-studio-terminal': {

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -364,9 +364,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'audit:src:scene:poi:physicalMetadata',
     kind: 'excluded',
     sourceFiles: ['src/scene/poi/physicalMetadata.ts'],
-    syncRevision: 4,
+    syncRevision: 5,
     reason:
-      'Audited support source; PR Reaper real-world dimensions and scene bounds now feed its holographic installation contract while tabletop geometry remains covered by the POI proxy.',
+      'Audited support source; Flywheel P6b physical bounds and marker clearances now use the shared flywheel contract while geometry is covered by the Flywheel proxy.',
   },
   {
     id: 'audit:src:scene:poi:structuredData',

--- a/src/scene/poi/physicalMetadata.ts
+++ b/src/scene/poi/physicalMetadata.ts
@@ -1,3 +1,8 @@
+import {
+  FLYWHEEL_AVATAR_PATH_RADIUS,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_MARKER_MIN_HEIGHT,
+} from '../structures/flywheelEnergyContract';
 import { PORTFOLIO_MINIATURE_TABLE_DIMENSIONS } from '../structures/portfolioMiniatureTableContract';
 import {
   PR_REAPER_INTENDED_BOUNDS,
@@ -39,6 +44,22 @@ const RASPBERRY_PI_5_BOARD_FOOTPRINT_METERS = {
 };
 
 const physicalMetadata = {
+  'flywheel-studio-flywheel': {
+    realWorldReference:
+      'industrial hand-cranked flywheel with fixed-ring planetary gearbox',
+    realWorldDimensionsMeters: {
+      width: 2.2,
+      depth: 1.35,
+      height: 1.85,
+    },
+    intendedSceneBounds: FLYWHEEL_INSTALLATION_BOUNDS,
+    anchor: 'bottom-center',
+    clearances: {
+      markerMinHeight: FLYWHEEL_MARKER_MIN_HEIGHT,
+      avatarPathRadius: FLYWHEEL_AVATAR_PATH_RADIUS,
+    },
+  },
+
   'tokenplace-studio-cluster': {
     realWorldReference: 'dual 27-inch 16:9 workstation',
     realWorldDimensionsMeters: {

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -1,19 +1,15 @@
 import {
   BoxGeometry,
-  CanvasTexture,
   Color,
   CylinderGeometry,
-  DoubleSide,
   Group,
   MathUtils,
   Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  PlaneGeometry,
   RingGeometry,
-  SRGBColorSpace,
   TorusGeometry,
-  SphereGeometry,
+  Object3D,
 } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
@@ -21,894 +17,538 @@ import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 
-const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
+import {
+  FLYWHEEL_AVATAR_PATH_RADIUS,
+  FLYWHEEL_AXLE,
+  FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_BEARING_STAND,
+  FLYWHEEL_CRANK,
+  FLYWHEEL_CRANK_RAD_PER_SECOND,
+  FLYWHEEL_EMPHASIS_SPEED_BOOST,
+  FLYWHEEL_ENERGY_PORT,
+  FLYWHEEL_GEAR_RADII,
+  FLYWHEEL_GEARBOX,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_PLANET_TEETH,
+  FLYWHEEL_RING_TEETH,
+  FLYWHEEL_SUN_TEETH,
+  FLYWHEEL_TORQUE_RATIO,
+  FLYWHEEL_WHEEL,
+  getFlywheelCarrierAngle,
+  getFlywheelPlanetLocalSpin,
+} from './flywheelEnergyContract';
+
+export interface FlywheelDebugState {
+  crankAngle: number;
+  sunAngle: number;
+  carrierAngle: number;
+  planetOrbitAngle: number;
+  planetLocalSpin: number;
+  outputShaftAngle: number;
+  flywheelAngle: number;
+  speedScale: number;
+  runDecorativeEffects: boolean;
+}
 
 export interface FlywheelShowpieceBuild {
   group: Group;
   colliders: RectCollider[];
-  update(context: { elapsed: number; delta: number; emphasis: number }): void;
+  update(context: {
+    elapsed: number;
+    delta: number;
+    emphasis: number;
+    runDecorativeEffects?: boolean;
+  }): void;
+  getDebugState(): FlywheelDebugState;
+  dispose(): void;
 }
 
 export interface FlywheelShowpieceOptions {
-  centerX: number;
-  centerZ: number;
+  position?: { x: number; y?: number; z: number };
+  centerX?: number;
+  centerZ?: number;
   roomBounds: Bounds2D;
   orientationRadians?: number;
   detailPolicy?: SceneDetailPolicy;
 }
 
-interface AutomationPillar {
-  mesh: Mesh;
-  material: MeshStandardMaterial;
-  baseHeight: number;
-  phase: number;
-}
+type Disposable = { dispose: () => void };
+
+const detailConfig = (level: SceneDetailPolicy['level']) => {
+  switch (level) {
+    case 'cinematic':
+      return {
+        teethStride: 1,
+        spokes: 8,
+        bolts: 16,
+        glowLayers: 2,
+        toothDepth: 0.05,
+      };
+    case 'balanced':
+      return {
+        teethStride: 1,
+        spokes: 6,
+        bolts: 12,
+        glowLayers: 1,
+        toothDepth: 0.04,
+      };
+    case 'performance':
+      return {
+        teethStride: 3,
+        spokes: 5,
+        bolts: 6,
+        glowLayers: 1,
+        toothDepth: 0.035,
+      };
+    case 'low':
+      return {
+        teethStride: Infinity,
+        spokes: 4,
+        bolts: 0,
+        glowLayers: 1,
+        toothDepth: 0,
+      };
+    case 'micro':
+      return {
+        teethStride: Infinity,
+        spokes: 3,
+        bolts: 0,
+        glowLayers: 0,
+        toothDepth: 0,
+      };
+  }
+};
 
 export function createFlywheelShowpiece(
   options: FlywheelShowpieceOptions
 ): FlywheelShowpieceBuild {
   const detailPolicy = options.detailPolicy ?? getSceneDetailPolicy('balanced');
-  const isPerformance = detailPolicy.level === 'performance';
-  const cylinderSegments = detailPolicy.geometry.cylinderSegments;
-  const sphereWidthSegments = detailPolicy.geometry.sphereWidthSegments;
-  const sphereHeightSegments = detailPolicy.geometry.sphereHeightSegments;
-  const torusRadialSegments = detailPolicy.geometry.torusRadialSegments;
-  const torusTubularSegments = detailPolicy.geometry.torusTubularSegments;
-  const ringSegments = detailPolicy.geometry.ringSegments;
+  const config = detailConfig(detailPolicy.level);
+  const position = options.position ?? {
+    x: options.centerX ?? 0,
+    y: 0,
+    z: options.centerZ ?? 0,
+  };
+  const cylinderSegments = Math.max(6, detailPolicy.geometry.cylinderSegments);
+  const torusRadialSegments = Math.max(
+    4,
+    detailPolicy.geometry.torusRadialSegments
+  );
+  const torusTubularSegments = Math.max(
+    8,
+    detailPolicy.geometry.torusTubularSegments
+  );
 
   const group = new Group();
-  group.name = 'FlywheelShowpiece';
+  group.name = 'FlywheelEnergyInstallation';
+  group.position.set(position.x, position.y ?? 0, position.z);
+  group.rotation.y = options.orientationRadians ?? 0;
+  group.scale.set(1, 1, 1);
 
-  const colliders: RectCollider[] = [];
-
-  const selectionEventTarget = typeof window === 'undefined' ? null : window;
-  let selectionTarget = 0;
-  let selectionStrength = 0;
-
-  const handleSelection = (event: Event) => {
-    const poiId = getPoiIdFromEvent(event);
-    if (!poiId) {
-      return;
-    }
-    if (poiId === FLYWHEEL_POI_ID) {
-      selectionTarget = 1;
-    } else {
-      selectionTarget = 0;
-    }
+  const disposables = new Set<Disposable>();
+  const own = <T extends Disposable>(item: T): T => {
+    disposables.add(item);
+    return item;
   };
-
-  const handleSelectionCleared = (event: Event) => {
-    const poiId = getPoiIdFromEvent(event);
-    if (!poiId || poiId === FLYWHEEL_POI_ID) {
-      selectionTarget = 0;
-    }
-  };
-
-  const removeSelectionListeners = () => {
-    if (!selectionEventTarget) {
-      return;
-    }
-    selectionEventTarget.removeEventListener('poi:selected', handleSelection);
-    selectionEventTarget.removeEventListener(
-      'poi:selected:analytics',
-      handleSelection
-    );
-    selectionEventTarget.removeEventListener(
-      'poi:selection-cleared',
-      handleSelectionCleared
-    );
-  };
-
-  if (selectionEventTarget) {
-    selectionEventTarget.addEventListener('poi:selected', handleSelection);
-    selectionEventTarget.addEventListener(
-      'poi:selected:analytics',
-      handleSelection
-    );
-    selectionEventTarget.addEventListener(
-      'poi:selection-cleared',
-      handleSelectionCleared
-    );
-    const handleRemoval = () => {
-      removeSelectionListeners();
-      group.removeEventListener('removed', handleRemoval);
-    };
-    group.addEventListener('removed', handleRemoval);
-  }
-
-  const daisRadius = 1.45;
-  const daisHeight = 0.16;
-  const daisGeometry = new CylinderGeometry(
-    daisRadius,
-    daisRadius,
-    daisHeight,
-    cylinderSegments
-  );
-  const daisMaterial = new MeshStandardMaterial({
-    color: new Color(0x14202c),
-    roughness: 0.48,
-    metalness: 0.18,
-  });
-  const dais = new Mesh(daisGeometry, daisMaterial);
-  dais.name = 'FlywheelDais';
-  dais.position.set(options.centerX, daisHeight / 2, options.centerZ);
-  group.add(dais);
-
-  const pedestalRadius = daisRadius * 0.68;
-  const pedestalHeight = 0.6;
-  const pedestalGeometry = new CylinderGeometry(
-    pedestalRadius,
-    pedestalRadius,
-    pedestalHeight,
-    cylinderSegments
-  );
-  const pedestalMaterial = new MeshStandardMaterial({
-    color: new Color(0x182634),
-    roughness: 0.32,
-    metalness: 0.24,
-  });
-  const pedestal = new Mesh(pedestalGeometry, pedestalMaterial);
-  pedestal.name = 'FlywheelPedestal';
-  pedestal.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight / 2,
-    options.centerZ
-  );
-  group.add(pedestal);
-
-  const accentHeight = 0.12;
-  const accentGeometry = new CylinderGeometry(
-    pedestalRadius * 1.02,
-    pedestalRadius * 1.02,
-    accentHeight,
-    cylinderSegments
-  );
-  const accentMaterial = new MeshStandardMaterial({
-    color: new Color(0x5ad1ff),
-    emissive: new Color(0x178aff),
-    emissiveIntensity: 0.85,
-    roughness: 0.22,
-    metalness: 0.42,
-  });
-  const accent = new Mesh(accentGeometry, accentMaterial);
-  accent.name = 'FlywheelAccent';
-  accent.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + accentHeight / 2,
-    options.centerZ
-  );
-  group.add(accent);
-
-  const glassHeight = 1.3;
-  const glassRadius = pedestalRadius * 0.92;
-  const glassGeometry = new CylinderGeometry(
-    glassRadius,
-    glassRadius,
-    glassHeight,
-    cylinderSegments,
-    1,
-    true
-  );
-  const glassMaterial = new MeshStandardMaterial({
-    color: new Color(0x1c2d3d),
-    transparent: true,
-    opacity: 0.18,
-    roughness: 0.08,
-    metalness: 0.05,
-  });
-  const glass = new Mesh(glassGeometry, glassMaterial);
-  glass.name = 'FlywheelGlass';
-  glass.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + glassHeight / 2,
-    options.centerZ
-  );
-  glass.visible = detailPolicy.effects.glassTransmission;
-  group.add(glass);
-
-  const rotorGroup = new Group();
-  rotorGroup.name = 'FlywheelRotorGroup';
-  rotorGroup.position.set(
-    options.centerX,
-    daisHeight + pedestalHeight + glassHeight * 0.36,
-    options.centerZ
-  );
-  group.add(rotorGroup);
-
-  const rotorRingRadius = glassRadius * 0.85;
-  const rotorRingTube = 0.09;
-  const rotorRingGeometry = new TorusGeometry(
-    rotorRingRadius,
-    rotorRingTube,
-    torusRadialSegments,
-    torusTubularSegments
-  );
-  const rotorRingMaterial = new MeshStandardMaterial({
-    color: new Color(0x2c95ff),
-    emissive: new Color(0x65d0ff),
-    emissiveIntensity: 0.9,
-    roughness: 0.2,
-    metalness: 0.5,
-  });
-  const rotorRing = new Mesh(rotorRingGeometry, rotorRingMaterial);
-  rotorRing.name = 'FlywheelRotorRing';
-  rotorRing.rotation.x = Math.PI / 2;
-  rotorGroup.add(rotorRing);
-
-  const innerDiscGeometry = new CylinderGeometry(
-    0.38,
-    0.38,
-    0.06,
-    cylinderSegments
-  );
-  const innerDiscMaterial = new MeshStandardMaterial({
-    color: new Color(0x101822),
-    roughness: 0.34,
-    metalness: 0.3,
-  });
-  const innerDisc = new Mesh(innerDiscGeometry, innerDiscMaterial);
-  innerDisc.name = 'FlywheelInnerDisc';
-  innerDisc.rotation.x = Math.PI / 2;
-  rotorGroup.add(innerDisc);
-
-  const spokesGroup = new Group();
-  spokesGroup.name = 'FlywheelSpokesGroup';
-  rotorGroup.add(spokesGroup);
-  const spokeCount = 6;
-  const spokeLength = rotorRingRadius * 1.6;
-  const spokeGeometry = new BoxGeometry(spokeLength, 0.06, 0.08);
-  const spokeMaterial = new MeshStandardMaterial({
-    color: new Color(0x3fb8ff),
-    emissive: new Color(0x1d74ff),
-    emissiveIntensity: 0.75,
-    roughness: 0.26,
-    metalness: 0.46,
-  });
-  for (let i = 0; i < spokeCount; i += 1) {
-    const spoke = new Mesh(spokeGeometry, spokeMaterial);
-    spoke.position.x = spokeLength / 2 - 0.08;
-    spoke.rotation.z = Math.PI / 2;
-    const spokeWrapper = new Group();
-    spokeWrapper.rotation.y = (Math.PI * 2 * i) / spokeCount;
-    spokeWrapper.add(spoke);
-    spokesGroup.add(spokeWrapper);
-  }
-
-  const counterGroup = new Group();
-  counterGroup.name = 'FlywheelCounterGroup';
-  counterGroup.position.copy(rotorGroup.position);
-  group.add(counterGroup);
-
-  const counterRingGeometry = new TorusGeometry(
-    rotorRingRadius * 0.72,
-    0.07,
-    torusRadialSegments,
-    torusTubularSegments
-  );
-  const counterRingMaterial = new MeshStandardMaterial({
-    color: new Color(0x1f88ff),
-    emissive: new Color(0x2bbcff),
-    emissiveIntensity: 0.8,
-    roughness: 0.24,
-    metalness: 0.38,
-  });
-  const counterRing = new Mesh(counterRingGeometry, counterRingMaterial);
-  counterRing.name = 'FlywheelCounterRing';
-  counterRing.rotation.x = Math.PI / 2;
-  counterGroup.add(counterRing);
-
-  const glyphRingGeometry = new RingGeometry(
-    rotorRingRadius * 0.58,
-    rotorRingRadius * 0.72,
-    ringSegments,
-    1
-  );
-  const glyphRingMaterial = new MeshBasicMaterial({
-    color: new Color(0x8ad9ff),
-    transparent: true,
-    opacity: 0.22,
-    side: DoubleSide,
-    depthWrite: false,
-  });
-  const glyphRing = new Mesh(glyphRingGeometry, glyphRingMaterial);
-  glyphRing.name = 'FlywheelGlyphRing';
-  glyphRing.rotation.x = Math.PI / 2;
-  counterGroup.add(glyphRing);
-
-  const orbitGroup = new Group();
-  orbitGroup.name = 'FlywheelOrbitGroup';
-  orbitGroup.position.copy(rotorGroup.position);
-  orbitGroup.visible = !isPerformance;
-  group.add(orbitGroup);
-
-  const automationPillars: AutomationPillar[] = [];
-  const automationPillarGroup = new Group();
-  automationPillarGroup.name = 'FlywheelAutomationPillars';
-  automationPillarGroup.position.copy(rotorGroup.position);
-  automationPillarGroup.visible = !isPerformance;
-  group.add(automationPillarGroup);
-
-  const pillarCount = 4;
-  const pillarHeight = Math.min(1.05, pedestalHeight * 1.5);
-  const pillarRadius = rotorRingRadius * 0.94;
-  const pillarGeometry = new CylinderGeometry(
-    0.12,
-    0.18,
-    pillarHeight,
-    cylinderSegments
-  );
-  for (let index = 0; index < pillarCount; index += 1) {
-    const pillarMaterial = new MeshStandardMaterial({
-      color: new Color(0x102133),
-      emissive: new Color(0x3aaaff),
-      emissiveIntensity: 0.28,
+  const metal = own(
+    new MeshStandardMaterial({
+      color: 0x55606a,
+      metalness: 0.82,
       roughness: 0.28,
-      metalness: 0.46,
-      transparent: true,
-      opacity: 0.12,
-    });
-    const pillar = new Mesh(pillarGeometry, pillarMaterial);
-    pillar.name = `FlywheelAutomationPillar-${index}`;
-    const angle = (Math.PI * 2 * index) / pillarCount;
-    const pillarBase = daisHeight + 0.04;
-    pillar.position.set(
-      Math.cos(angle) * pillarRadius,
-      pillarBase + pillarHeight / 2,
-      Math.sin(angle) * pillarRadius
-    );
-    automationPillarGroup.add(pillar);
-    automationPillars.push({
-      mesh: pillar,
-      material: pillarMaterial,
-      baseHeight: pillar.position.y,
-      phase: angle,
-    });
-  }
-
-  const orbitRadius = rotorRingRadius * 1.12;
-  const orbitGeometry = new SphereGeometry(
-    0.08,
-    sphereWidthSegments,
-    sphereHeightSegments
+    })
   );
-  const orbitMaterial = new MeshStandardMaterial({
-    color: new Color(0xffffff),
-    emissive: new Color(0x7be9ff),
-    emissiveIntensity: 1.1,
-    roughness: 0.1,
-    metalness: 0.18,
-  });
-  const orbitCount = 3;
-  for (let i = 0; i < orbitCount; i += 1) {
-    const orb = new Mesh(orbitGeometry, orbitMaterial);
-    const wrapper = new Group();
-    wrapper.rotation.y = (Math.PI * 2 * i) / orbitCount;
-    orb.position.set(orbitRadius, 0, 0);
-    wrapper.add(orb);
-    orbitGroup.add(wrapper);
+  const darkMetal = own(
+    new MeshStandardMaterial({
+      color: 0x1b2430,
+      metalness: 0.9,
+      roughness: 0.24,
+    })
+  );
+  const glow = own(
+    new MeshStandardMaterial({
+      color: 0x37bdf8,
+      emissive: new Color(0x1d9bf0),
+      emissiveIntensity: 1.1,
+      roughness: 0.18,
+      metalness: 0.35,
+    })
+  );
+  const glowBasic = own(
+    new MeshBasicMaterial({ color: 0x7dd3fc, transparent: true, opacity: 0.48 })
+  );
+
+  const addMesh = (
+    name: string,
+    geometry: Disposable,
+    material: Mesh['material'],
+    parent = group
+  ) => {
+    own(geometry);
+    const mesh = new Mesh(geometry as never, material);
+    mesh.name = name;
+    parent.add(mesh);
+    return mesh;
+  };
+
+  const base = addMesh(
+    'FlywheelBase',
+    new BoxGeometry(
+      FLYWHEEL_BASE_DIMENSIONS.width,
+      FLYWHEEL_BASE_DIMENSIONS.height,
+      FLYWHEEL_BASE_DIMENSIONS.depth
+    ),
+    darkMetal
+  );
+  base.position.y = FLYWHEEL_BASE_DIMENSIONS.height / 2;
+
+  for (const [name, sx] of [
+    ['FlywheelBearingStandLeft', -1],
+    ['FlywheelBearingStandRight', 1],
+  ] as const) {
+    const stand = addMesh(
+      name,
+      new BoxGeometry(
+        FLYWHEEL_BEARING_STAND.width,
+        FLYWHEEL_BEARING_STAND.height,
+        FLYWHEEL_BEARING_STAND.depth
+      ),
+      metal
+    );
+    stand.position.set(
+      FLYWHEEL_WHEEL.centerX + sx * FLYWHEEL_BEARING_STAND.centerOffsetX,
+      FLYWHEEL_BEARING_STAND.height / 2 + FLYWHEEL_BASE_DIMENSIONS.height,
+      0
+    );
   }
 
-  const techStackGroup = new Group();
-  techStackGroup.name = 'FlywheelTechStackGroup';
-  techStackGroup.position.copy(rotorGroup.position);
-  techStackGroup.visible = !isPerformance;
-  group.add(techStackGroup);
+  const axle = addMesh(
+    'FlywheelAxle',
+    new CylinderGeometry(
+      FLYWHEEL_AXLE.radius,
+      FLYWHEEL_AXLE.radius,
+      FLYWHEEL_AXLE.length,
+      cylinderSegments
+    ),
+    metal
+  );
+  axle.rotation.z = Math.PI / 2;
+  axle.position.set(FLYWHEEL_WHEEL.centerX + 0.35, FLYWHEEL_WHEEL.centerY, 0);
 
-  const techStackItems = [
+  const wheelGroup = new Group();
+  wheelGroup.name = 'FlywheelWheelGroup';
+  wheelGroup.position.set(FLYWHEEL_WHEEL.centerX, FLYWHEEL_WHEEL.centerY, 0);
+  group.add(wheelGroup);
+  const rim = addMesh(
+    'FlywheelHeavyRim',
+    new TorusGeometry(
+      FLYWHEEL_WHEEL.radius,
+      FLYWHEEL_WHEEL.rimTube,
+      torusRadialSegments,
+      torusTubularSegments
+    ),
+    darkMetal,
+    wheelGroup
+  );
+  rim.rotation.y = Math.PI / 2;
+  const hub = addMesh(
+    'FlywheelInnerHub',
+    new CylinderGeometry(0.2, 0.2, FLYWHEEL_WHEEL.thickness, cylinderSegments),
+    metal,
+    wheelGroup
+  );
+  hub.rotation.z = Math.PI / 2;
+  for (let i = 0; i < config.spokes; i += 1) {
+    const spoke = addMesh(
+      `FlywheelSpoke-${i}`,
+      new BoxGeometry(FLYWHEEL_WHEEL.radius * 1.42, 0.045, 0.055),
+      metal,
+      wheelGroup
+    );
+    spoke.rotation.z = (i / config.spokes) * Math.PI;
+  }
+  for (let i = 0; i < Math.min(4, config.spokes); i += 1) {
+    const weight = addMesh(
+      `FlywheelCounterweight-${i}`,
+      new BoxGeometry(0.2, 0.1, 0.28),
+      metal,
+      wheelGroup
+    );
+    const a = (i / Math.min(4, config.spokes)) * Math.PI * 2 + Math.PI / 8;
+    weight.position.set(
+      Math.cos(a) * FLYWHEEL_WHEEL.radius * 0.68,
+      Math.sin(a) * FLYWHEEL_WHEEL.radius * 0.68,
+      0
+    );
+    weight.rotation.z = a;
+  }
+  if (config.glowLayers > 0) {
+    const ring = addMesh(
+      'FlywheelEnergyGlowRing',
+      new TorusGeometry(
+        FLYWHEEL_WHEEL.radius * 0.78,
+        0.015,
+        4,
+        torusTubularSegments
+      ),
+      glow,
+      wheelGroup
+    );
+    ring.rotation.y = Math.PI / 2;
+  }
+
+  const crankGroup = new Group();
+  crankGroup.name = 'FlywheelCrankGroup';
+  crankGroup.position.set(
+    FLYWHEEL_GEARBOX.centerX,
+    FLYWHEEL_GEARBOX.centerY,
+    FLYWHEEL_GEARBOX.centerZ + FLYWHEEL_GEARBOX.depth * 0.72
+  );
+  group.add(crankGroup);
+  const crankDisc = addMesh(
+    'FlywheelCrankDisc',
+    new CylinderGeometry(
+      FLYWHEEL_CRANK.discRadius,
+      FLYWHEEL_CRANK.discRadius,
+      0.05,
+      cylinderSegments
+    ),
+    metal,
+    crankGroup
+  );
+  crankDisc.rotation.x = Math.PI / 2;
+  const crankArm = addMesh(
+    'FlywheelCrankArm',
+    new BoxGeometry(FLYWHEEL_CRANK.armLength, 0.045, 0.04),
+    metal,
+    crankGroup
+  );
+  crankArm.position.x = FLYWHEEL_CRANK.armLength / 2;
+  const crankHandle = addMesh(
+    'FlywheelCrankHandle',
+    new CylinderGeometry(
+      FLYWHEEL_CRANK.handleRadius,
+      FLYWHEEL_CRANK.handleRadius,
+      FLYWHEEL_CRANK.handleLength,
+      cylinderSegments
+    ),
+    metal,
+    crankGroup
+  );
+  crankHandle.rotation.x = Math.PI / 2;
+  crankHandle.position.x = FLYWHEEL_CRANK.radius;
+
+  const gearbox = new Group();
+  gearbox.name = 'FlywheelPlanetaryGearbox';
+  gearbox.position.set(
+    FLYWHEEL_GEARBOX.centerX,
+    FLYWHEEL_GEARBOX.centerY,
+    FLYWHEEL_GEARBOX.centerZ
+  );
+  group.add(gearbox);
+  addGear(
+    'FlywheelRingGear',
+    FLYWHEEL_GEAR_RADII.ring,
+    FLYWHEEL_RING_TEETH,
+    true,
+    gearbox
+  );
+  const sunGear = addGear(
+    'FlywheelSunGear',
+    FLYWHEEL_GEAR_RADII.sun,
+    FLYWHEEL_SUN_TEETH,
+    false,
+    gearbox
+  );
+  const carrier = new Group();
+  carrier.name = 'FlywheelPlanetCarrier';
+  gearbox.add(carrier);
+  const planets: Group[] = [];
+  for (let i = 0; i < 3; i += 1) {
+    const planetPivot = new Group();
+    planetPivot.name = `FlywheelPlanetGear-${i}`;
+    const a = (i / 3) * Math.PI * 2;
+    planetPivot.position.set(
+      Math.cos(a) * FLYWHEEL_GEAR_RADII.planetOrbit,
+      Math.sin(a) * FLYWHEEL_GEAR_RADII.planetOrbit,
+      0
+    );
+    const planetMesh = addGear(
+      `FlywheelPlanetGear-${i}-Mesh`,
+      FLYWHEEL_GEAR_RADII.planet,
+      FLYWHEEL_PLANET_TEETH,
+      false,
+      planetPivot
+    );
+    planetMesh.userData.phase = a;
+    carrier.add(planetPivot);
+    planets.push(planetPivot);
+  }
+  const outputShaft = addMesh(
+    'FlywheelOutputShaft',
+    new CylinderGeometry(0.065, 0.065, 1.2, cylinderSegments),
+    metal,
+    gearbox
+  );
+  outputShaft.rotation.y = Math.PI / 2;
+  outputShaft.position.x = -0.55;
+
+  const port = addMesh(
+    'FlywheelEnergyPort',
+    new CylinderGeometry(
+      FLYWHEEL_ENERGY_PORT.radius,
+      FLYWHEEL_ENERGY_PORT.radius,
+      0.08,
+      cylinderSegments
+    ),
+    glow,
+    group
+  );
+  port.rotation.x = Math.PI / 2;
+  port.position.set(
+    FLYWHEEL_ENERGY_PORT.x,
+    FLYWHEEL_ENERGY_PORT.y,
+    FLYWHEEL_ENERGY_PORT.z
+  );
+  if (config.glowLayers > 1) {
+    const halo = addMesh(
+      'FlywheelEnergyPortHalo',
+      new RingGeometry(
+        FLYWHEEL_ENERGY_PORT.radius * 1.2,
+        FLYWHEEL_ENERGY_PORT.radius * 2.3,
+        detailPolicy.geometry.ringSegments
+      ),
+      glowBasic,
+      group
+    );
+    halo.position.copy(port.position);
+  }
+
+  for (let i = 0; i < config.bolts; i += 1) {
+    const bolt = addMesh(
+      `FlywheelBaseBolt-${i}`,
+      new CylinderGeometry(0.025, 0.025, 0.025, 8),
+      metal,
+      group
+    );
+    const side = i % 2 === 0 ? -1 : 1;
+    bolt.position.set(
+      -1.45 + Math.floor(i / 2) * (2.9 / Math.max(1, config.bolts / 2 - 1)),
+      FLYWHEEL_BASE_DIMENSIONS.height + 0.014,
+      side * 0.62
+    );
+  }
+
+  function addGear(
+    name: string,
+    radius: number,
+    teeth: number,
+    internal: boolean,
+    parent: Object3D
+  ): Group {
+    const gear = new Group();
+    gear.name = name;
+    parent.add(gear);
+    const body = addMesh(
+      `${name}Body`,
+      new CylinderGeometry(radius, radius, 0.065, cylinderSegments),
+      internal ? darkMetal : metal,
+      gear
+    );
+    body.rotation.x = Math.PI / 2;
+    const toothCount = Number.isFinite(config.teethStride)
+      ? Math.ceil(teeth / config.teethStride)
+      : 0;
+    for (let i = 0; i < toothCount; i += 1) {
+      const a = (i / toothCount) * Math.PI * 2;
+      const tooth = addMesh(
+        `${name}Tooth-${i}`,
+        new BoxGeometry(0.035, config.toothDepth, 0.075),
+        metal,
+        gear
+      );
+      const r =
+        radius + (internal ? -config.toothDepth / 2 : config.toothDepth / 2);
+      tooth.position.set(Math.cos(a) * r, Math.sin(a) * r, 0);
+      tooth.rotation.z = a + (internal ? Math.PI / 2 : 0);
+    }
+    return gear;
+  }
+
+  const colliders: RectCollider[] = [
     {
-      label: 'CI templates',
-      caption: 'lint · test · deploy',
-      accent: '#56d7ff',
+      minX: position.x - FLYWHEEL_BASE_DIMENSIONS.width / 2,
+      maxX: position.x + FLYWHEEL_BASE_DIMENSIONS.width / 2,
+      minZ: position.z - FLYWHEEL_BASE_DIMENSIONS.depth / 2,
+      maxZ: position.z + FLYWHEEL_BASE_DIMENSIONS.depth / 2,
     },
     {
-      label: 'Typed prompts',
-      caption: 'codex-driven flows',
-      accent: '#63e1ff',
-    },
-    {
-      label: 'Scaffolds',
-      caption: 'vite · playwright',
-      accent: '#71e9ff',
+      minX: position.x + FLYWHEEL_GEARBOX.centerX - 0.62,
+      maxX: position.x + FLYWHEEL_GEARBOX.centerX + 0.62,
+      minZ: position.z + 0.35 - 0.58,
+      maxZ: position.z + 0.35 + 0.58,
     },
   ];
 
-  const techStackRadius = rotorRingRadius * 1.32;
-  const techStackGeometry = new PlaneGeometry(0.72, 0.28);
-  const techStackChips: {
-    wrapper: Group;
-    mesh: Mesh;
-    material: MeshBasicMaterial;
-  }[] = [];
-
-  techStackItems.forEach((item, index) => {
-    const texture = createFlywheelTechStackChipTexture(item);
-    const material = new MeshBasicMaterial({
-      map: texture,
-      transparent: true,
-      opacity: 0,
-      depthWrite: false,
-    });
-    const mesh = new Mesh(techStackGeometry, material);
-    mesh.name = `FlywheelTechStackChip:${index}`;
-    mesh.position.set(techStackRadius, 0.22, 0);
-    mesh.lookAt(0, mesh.position.y, 0);
-    mesh.rotateY(Math.PI);
-    mesh.renderOrder = 18;
-    mesh.visible = false;
-
-    const wrapper = new Group();
-    wrapper.name = `FlywheelTechStackChipWrapper:${index}`;
-    wrapper.rotation.y = (Math.PI * 2 * index) / techStackItems.length;
-    wrapper.add(mesh);
-    techStackGroup.add(wrapper);
-
-    techStackChips.push({ wrapper, mesh, material });
-  });
-
-  const kioskWidth = 0.6;
-  const orientation = options.orientationRadians ?? 0;
-  const panelRadius = daisRadius + 0.48;
-  const targetPanelX = options.centerX + Math.cos(orientation) * panelRadius;
-  const targetPanelZ = options.centerZ + Math.sin(orientation) * panelRadius;
-  const clampedPanelX = MathUtils.clamp(
-    targetPanelX,
-    options.roomBounds.minX + kioskWidth / 2,
-    options.roomBounds.maxX - kioskWidth / 2
-  );
-  const clampedPanelZ = MathUtils.clamp(
-    targetPanelZ,
-    options.roomBounds.minZ + kioskWidth / 2,
-    options.roomBounds.maxZ - kioskWidth / 2
-  );
-  const infoPanelGroup = new Group();
-  infoPanelGroup.name = 'FlywheelInfoPanelGroup';
-  infoPanelGroup.position.set(clampedPanelX, daisHeight + 0.62, clampedPanelZ);
-  infoPanelGroup.lookAt(options.centerX, daisHeight + 0.62, options.centerZ);
-  infoPanelGroup.rotateY(Math.PI);
-  group.add(infoPanelGroup);
-
-  const panelTexture = createFlywheelTechStackTexture();
-  const panelMaterial = new MeshBasicMaterial({
-    map: panelTexture,
-    transparent: true,
-    opacity: 0.08,
-    depthWrite: false,
-  });
-  const panelGeometry = new PlaneGeometry(1.8, 1);
-  const panel = new Mesh(panelGeometry, panelMaterial);
-  panel.name = 'FlywheelInfoPanel';
-  panel.position.y = 0.4;
-  panel.renderOrder = 14;
-  infoPanelGroup.add(panel);
-
-  const panelBackerGeometry = new PlaneGeometry(1.84, 1.04);
-  const panelBackerMaterial = new MeshStandardMaterial({
-    color: new Color(0x0c141d),
-    emissive: new Color(0x1a2c3c),
-    emissiveIntensity: 0.4,
-    roughness: 0.4,
-    metalness: 0.12,
-  });
-  const panelBacker = new Mesh(panelBackerGeometry, panelBackerMaterial);
-  panelBacker.name = 'FlywheelInfoPanelBacker';
-  panelBacker.position.set(0, 0.4, -0.02);
-  infoPanelGroup.add(panelBacker);
-
-  const panelGlowGeometry = new PlaneGeometry(1.9, 1.08);
-  const panelGlowMaterial = new MeshBasicMaterial({
-    color: new Color(0x3ebaff),
-    transparent: true,
-    opacity: 0.06,
-    depthWrite: false,
-  });
-  const panelGlow = new Mesh(panelGlowGeometry, panelGlowMaterial);
-  panelGlow.name = 'FlywheelInfoPanelGlow';
-  panelGlow.position.set(0, 0.4, 0.02);
-  panelGlow.renderOrder = 13;
-  infoPanelGroup.add(panelGlow);
-
-  const plinthGeometry = new BoxGeometry(0.42, 0.5, 0.42);
-  const plinthMaterial = new MeshStandardMaterial({
-    color: new Color(0x101823),
-    roughness: 0.36,
-    metalness: 0.18,
-  });
-  const plinth = new Mesh(plinthGeometry, plinthMaterial);
-  plinth.name = 'FlywheelInfoPanelPlinth';
-  plinth.position.set(0, 0.25, 0);
-  infoPanelGroup.add(plinth);
-
-  const calloutTexture = createFlywheelDocsCalloutTexture();
-  const calloutMaterial = new MeshBasicMaterial({
-    map: calloutTexture,
-    transparent: true,
-    opacity: 0,
-    depthWrite: false,
-  });
-  const calloutGeometry = new PlaneGeometry(1, 0.46);
-  const callout = new Mesh(calloutGeometry, calloutMaterial);
-  callout.name = 'FlywheelDocsCallout';
-  callout.position.set(0, 0.78, 0.05);
-  callout.renderOrder = 16;
-  callout.visible = false;
-  infoPanelGroup.add(callout);
-
-  const calloutGlowGeometry = new PlaneGeometry(1.06, 0.52);
-  const calloutGlowMaterial = new MeshBasicMaterial({
-    color: new Color(0x4cd0ff),
-    transparent: true,
-    opacity: 0,
-    depthWrite: false,
-  });
-  const calloutGlow = new Mesh(calloutGlowGeometry, calloutGlowMaterial);
-  calloutGlow.name = 'FlywheelDocsCalloutGlow';
-  calloutGlow.position.set(0, callout.position.y, 0.06);
-  calloutGlow.renderOrder = 15;
-  calloutGlow.visible = false;
-  infoPanelGroup.add(calloutGlow);
-
-  colliders.push({
-    minX: options.centerX - daisRadius,
-    maxX: options.centerX + daisRadius,
-    minZ: options.centerZ - daisRadius,
-    maxZ: options.centerZ + daisRadius,
-  });
-
-  colliders.push({
-    minX: infoPanelGroup.position.x - kioskWidth / 2,
-    maxX: infoPanelGroup.position.x + kioskWidth / 2,
-    minZ: infoPanelGroup.position.z - kioskWidth / 2,
-    maxZ: infoPanelGroup.position.z + kioskWidth / 2,
-  });
-
-  let spinVelocity = 0.6;
-  let infoReveal = 0.08;
-  let calloutPhase = 0;
-  let techStackReveal = 0.04;
-
-  function update(context: {
-    elapsed: number;
-    delta: number;
-    emphasis: number;
-  }) {
-    const smoothing =
-      context.delta > 0 ? 1 - Math.exp(-context.delta * 3.8) : 1;
-    selectionStrength = MathUtils.lerp(
-      selectionStrength,
-      selectionTarget,
-      smoothing
-    );
-    const selectionInfluence = MathUtils.clamp(selectionStrength, 0, 1);
-    if (
-      isPerformance &&
-      Math.max(context.emphasis, selectionInfluence) < 0.02
-    ) {
-      rotorGroup.rotation.y += 0.12 * context.delta;
-      return;
-    }
-    const targetVelocity =
-      MathUtils.lerp(0.55, 2.4, context.emphasis) +
-      MathUtils.lerp(0, 1.1, selectionInfluence);
-    spinVelocity = MathUtils.lerp(spinVelocity, targetVelocity, smoothing);
-    rotorGroup.rotation.y += spinVelocity * context.delta;
-    counterGroup.rotation.y -= spinVelocity * 0.42 * context.delta;
-    orbitGroup.rotation.y += spinVelocity * 0.3 * context.delta;
-
-    const targetEmissive = MathUtils.lerp(0.8, 2.4, context.emphasis);
-    accentMaterial.emissiveIntensity = MathUtils.lerp(
-      accentMaterial.emissiveIntensity,
-      targetEmissive + MathUtils.lerp(0, 0.6, selectionInfluence),
-      smoothing
-    );
-    rotorRingMaterial.emissiveIntensity = MathUtils.lerp(
-      rotorRingMaterial.emissiveIntensity,
-      MathUtils.lerp(0.9, 2.1, context.emphasis) +
-        MathUtils.lerp(0, 0.5, selectionInfluence),
-      smoothing
-    );
-    spokeMaterial.emissiveIntensity = MathUtils.lerp(
-      spokeMaterial.emissiveIntensity,
-      MathUtils.lerp(0.75, 1.8, context.emphasis) +
-        MathUtils.lerp(0, 0.45, selectionInfluence),
-      smoothing
-    );
-    counterRingMaterial.emissiveIntensity = MathUtils.lerp(
-      counterRingMaterial.emissiveIntensity,
-      MathUtils.lerp(0.8, 1.9, context.emphasis) +
-        MathUtils.lerp(0, 0.42, selectionInfluence),
-      smoothing
-    );
-
-    const pillarEmphasis = Math.max(context.emphasis, selectionInfluence);
-    const pillarMotionScale = MathUtils.lerp(0.2, 1, pillarEmphasis);
-    automationPillars.forEach((pillar) => {
-      const bob =
-        Math.sin(context.elapsed * 1.1 + pillar.phase) *
-        0.08 *
-        pillarMotionScale;
-      pillar.mesh.position.y = pillar.baseHeight + bob;
-      pillar.material.emissiveIntensity = MathUtils.lerp(
-        pillar.material.emissiveIntensity,
-        MathUtils.lerp(0.35, 1.7, pillarEmphasis) +
-          MathUtils.lerp(0, 0.9, selectionInfluence),
-        smoothing
-      );
-      pillar.material.opacity = MathUtils.lerp(
-        pillar.material.opacity,
-        MathUtils.lerp(0.18, 0.75, pillarEmphasis),
-        smoothing
-      );
-      pillar.mesh.visible = pillar.material.opacity > 0.02;
-    });
-
-    infoReveal = MathUtils.lerp(
-      infoReveal,
-      MathUtils.lerp(0.08, 1, context.emphasis),
-      smoothing
-    );
-    panelMaterial.opacity = infoReveal;
-    panelGlowMaterial.opacity = MathUtils.lerp(0.05, 0.32, context.emphasis);
-    panel.position.y = MathUtils.lerp(0.34, 0.56, context.emphasis);
-    panelBacker.position.y = panel.position.y - 0.02;
-    panelGlow.position.y = panel.position.y;
-    panel.visible = panelMaterial.opacity > 0.04;
-    panelGlow.visible = panel.visible;
-
-    calloutPhase +=
-      context.delta *
-      (MathUtils.lerp(0.55, 1.35, context.emphasis) +
-        MathUtils.lerp(0, 0.35, selectionInfluence));
-    const calloutBob = Math.sin(calloutPhase) * 0.05;
-    const panelReveal = MathUtils.clamp(infoReveal, 0, 1);
-    const calloutRevealBase = Math.pow(panelReveal, 0.8);
-    const selectionReveal = Math.pow(selectionInfluence, 0.85);
-    const combinedReveal = calloutRevealBase * selectionReveal;
-    const calloutOpacity =
-      combinedReveal * MathUtils.lerp(0.2, 0.95, context.emphasis);
-    calloutMaterial.opacity = calloutOpacity;
-    calloutGlowMaterial.opacity =
-      combinedReveal * MathUtils.lerp(0.05, 0.32, context.emphasis);
-    const baseCalloutHeight =
-      MathUtils.lerp(0.7, 0.94, context.emphasis) +
-      MathUtils.lerp(0, 0.08, selectionInfluence);
-    callout.position.y = baseCalloutHeight + calloutBob;
-    calloutGlow.position.y = callout.position.y;
-    callout.visible = calloutMaterial.opacity > 0.02;
-    calloutGlow.visible = callout.visible;
-
-    glyphRingMaterial.opacity = MathUtils.lerp(
-      0.18,
-      0.36,
-      Math.max(context.emphasis, selectionInfluence)
-    );
-    orbitGroup.children.forEach((wrapper, index) => {
-      wrapper.rotation.y =
-        context.elapsed * 0.65 + (Math.PI * 2 * index) / orbitCount;
-    });
-
-    techStackReveal = MathUtils.lerp(
-      techStackReveal,
-      Math.max(
-        MathUtils.lerp(0.02, 0.35, context.emphasis),
-        selectionInfluence
-      ),
-      smoothing
-    );
-    const chipOpacity = MathUtils.lerp(0, 0.96, techStackReveal);
-    const chipOrbitSpeed =
-      MathUtils.lerp(0.3, 0.75, context.emphasis) +
-      MathUtils.lerp(0, 0.35, selectionInfluence);
-    techStackChips.forEach((chip, index) => {
-      const baseAngle = (Math.PI * 2 * index) / techStackChips.length;
-      chip.wrapper.rotation.y = context.elapsed * chipOrbitSpeed + baseAngle;
-      chip.mesh.position.y =
-        MathUtils.lerp(0.18, 0.34, context.emphasis) +
-        Math.sin(context.elapsed * 1.2 + index) * 0.05;
-      const targetOpacity =
-        MathUtils.clamp(techStackReveal, 0, 1) * chipOpacity;
-      chip.material.opacity = MathUtils.lerp(
-        chip.material.opacity,
-        targetOpacity,
-        smoothing
-      );
-      chip.mesh.visible = chip.material.opacity > 0.02;
-    });
-  }
+  let debug: FlywheelDebugState = {
+    crankAngle: 0,
+    sunAngle: 0,
+    carrierAngle: 0,
+    planetOrbitAngle: 0,
+    planetLocalSpin: 0,
+    outputShaftAngle: 0,
+    flywheelAngle: 0,
+    speedScale: 1,
+    runDecorativeEffects: true,
+  };
+  let disposed = false;
 
   return {
     group,
     colliders,
-    update,
+    update({ elapsed, emphasis, runDecorativeEffects = true }) {
+      const speedScale =
+        1 + MathUtils.clamp(emphasis, 0, 1) * FLYWHEEL_EMPHASIS_SPEED_BOOST;
+      const crankAngle = elapsed * FLYWHEEL_CRANK_RAD_PER_SECOND * speedScale;
+      const carrierAngle = getFlywheelCarrierAngle(crankAngle);
+      const planetLocalSpin = getFlywheelPlanetLocalSpin(
+        crankAngle,
+        carrierAngle
+      );
+      crankGroup.rotation.z = crankAngle;
+      sunGear.rotation.z = crankAngle;
+      carrier.rotation.z = carrierAngle;
+      for (const planet of planets) planet.rotation.z = planetLocalSpin;
+      outputShaft.rotation.x = carrierAngle;
+      wheelGroup.rotation.z = carrierAngle;
+      const glowIntensity = 0.85 + MathUtils.clamp(emphasis, 0, 1) * 0.85;
+      glow.emissiveIntensity = runDecorativeEffects ? glowIntensity : 0.75;
+      glowBasic.opacity = runDecorativeEffects ? 0.28 + emphasis * 0.36 : 0.18;
+      debug = {
+        crankAngle,
+        sunAngle: crankAngle,
+        carrierAngle,
+        planetOrbitAngle: carrierAngle,
+        planetLocalSpin,
+        outputShaftAngle: carrierAngle,
+        flywheelAngle: carrierAngle,
+        speedScale,
+        runDecorativeEffects,
+      };
+    },
+    getDebugState() {
+      return { ...debug };
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      disposables.forEach((item) => item.dispose());
+      disposables.clear();
+    },
   };
 }
 
-function createFlywheelTechStackTexture(): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 1024;
-  canvas.height = 512;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create tech stack canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-
-  const gradient = context.createLinearGradient(
-    0,
-    0,
-    canvas.width,
-    canvas.height
-  );
-  gradient.addColorStop(0, 'rgba(33, 139, 255, 0.92)');
-  gradient.addColorStop(1, 'rgba(18, 196, 255, 0.62)');
-
-  context.fillStyle = 'rgba(5, 16, 28, 0.85)';
-  roundRect(context, 40, 40, canvas.width - 80, canvas.height - 80, 28);
-  context.fill();
-
-  context.strokeStyle = 'rgba(77, 197, 255, 0.7)';
-  context.lineWidth = 6;
-  context.stroke();
-
-  context.fillStyle = gradient;
-  context.font = 'bold 96px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'top';
-  context.fillText('Flywheel Automation', 80, 86);
-
-  context.fillStyle = '#bde9ff';
-  context.font = '48px "Inter", "Segoe UI", sans-serif';
-  context.fillText(
-    'CI templates · typed prompts · reproducible scaffolds',
-    80,
-    200
-  );
-
-  context.font = '40px "Inter", "Segoe UI", sans-serif';
-  const bulletItems = [
-    'Scripts: lint · test · deploy hooks',
-    'Stacks: Node · Python · WebGL orchestrations',
-    'Runtime: GitHub Actions · pnpm/npm parity',
-  ];
-  bulletItems.forEach((item, index) => {
-    const y = 280 + index * 80;
-    context.fillStyle = 'rgba(117, 221, 255, 0.9)';
-    context.fillRect(80, y, 18, 18);
-    context.fillStyle = '#e2f6ff';
-    context.fillText(item, 120, y - 20);
-  });
-
-  context.fillStyle = '#ffffff';
-  context.font = 'bold 64px "Inter", "Segoe UI", sans-serif';
-  context.fillText('Docs →', canvas.width - 280, canvas.height - 120);
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function createFlywheelDocsCalloutTexture(): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create docs callout canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-  context.save();
-  context.fillStyle = 'rgba(8, 20, 34, 0.92)';
-  roundRect(context, 32, 24, canvas.width - 64, canvas.height - 48, 32);
-  context.fill();
-  context.strokeStyle = 'rgba(76, 208, 255, 0.7)';
-  context.lineWidth = 5;
-  context.stroke();
-  context.restore();
-
-  context.save();
-  context.fillStyle = '#ecfbff';
-  context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'alphabetic';
-  context.fillText('README', 64, canvas.height * 0.56);
-
-  context.font = '600 56px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#a8eeff';
-  context.fillText(
-    'github.com/futuroptimist/flywheel',
-    64,
-    canvas.height * 0.78
-  );
-
-  context.textAlign = 'right';
-  context.font = 'bold 120px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#67d2ff';
-  context.fillText('→', canvas.width - 64, canvas.height * 0.58);
-  context.restore();
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function createFlywheelTechStackChipTexture(item: {
-  label: string;
-  caption: string;
-  accent: string;
-}): CanvasTexture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
-  const context = canvas.getContext('2d');
-  if (!context) {
-    throw new Error('Unable to create tech stack chip canvas.');
-  }
-
-  context.clearRect(0, 0, canvas.width, canvas.height);
-  context.save();
-  context.fillStyle = 'rgba(10, 24, 38, 0.92)';
-  roundRect(context, 28, 36, canvas.width - 56, canvas.height - 72, 42);
-  context.fill();
-  context.strokeStyle = `${item.accent}cc`;
-  context.lineWidth = 6;
-  context.stroke();
-  context.restore();
-
-  context.save();
-  context.fillStyle = item.accent;
-  context.fillRect(52, canvas.height - 78, canvas.width - 104, 12);
-  context.restore();
-
-  context.save();
-  context.fillStyle = '#e7f7ff';
-  context.font = 'bold 104px "Inter", "Segoe UI", sans-serif';
-  context.textAlign = 'left';
-  context.textBaseline = 'alphabetic';
-  context.fillText(item.label, 64, canvas.height * 0.56);
-
-  context.font = '600 52px "Inter", "Segoe UI", sans-serif';
-  context.fillStyle = '#a4ebff';
-  context.fillText(item.caption, 64, canvas.height * 0.78);
-  context.restore();
-
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function roundRect(
-  context: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  radius: number
-) {
-  const r = Math.min(radius, width / 2, height / 2);
-  context.beginPath();
-  context.moveTo(x + r, y);
-  context.lineTo(x + width - r, y);
-  context.quadraticCurveTo(x + width, y, x + width, y + r);
-  context.lineTo(x + width, y + height - r);
-  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-  context.lineTo(x + r, y + height);
-  context.quadraticCurveTo(x, y + height, x, y + height - r);
-  context.lineTo(x, y + r);
-  context.quadraticCurveTo(x, y, x + r, y);
-  context.closePath();
-}
-
-type PoiEventDetail = { poi?: { id?: string } };
-
-function getPoiIdFromEvent(event: Event): string | null {
-  const detail = (event as CustomEvent<PoiEventDetail>).detail;
-  if (!detail || typeof detail !== 'object') {
-    return null;
-  }
-  const poiId = detail.poi?.id;
-  return typeof poiId === 'string' ? poiId : null;
-}
+export {
+  FLYWHEEL_AVATAR_PATH_RADIUS,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_TORQUE_RATIO,
+};

--- a/src/scene/structures/flywheelEnergyContract.ts
+++ b/src/scene/structures/flywheelEnergyContract.ts
@@ -1,0 +1,90 @@
+export const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel' as const;
+
+export const FLYWHEEL_INSTALLATION_BOUNDS = {
+  width: 3.4,
+  depth: 2.4,
+  height: 2.75,
+} as const;
+
+export const FLYWHEEL_BASE_DIMENSIONS = {
+  width: 3.25,
+  depth: 1.55,
+  height: 0.22,
+} as const;
+
+export const FLYWHEEL_WHEEL = {
+  radius: 0.92,
+  rimTube: 0.12,
+  thickness: 0.24,
+  centerY: 1.35,
+  centerX: -0.58,
+  centerZ: 0,
+  spokes: 8,
+} as const;
+
+export const FLYWHEEL_AXLE = {
+  radius: 0.08,
+  length: 2.1,
+} as const;
+
+export const FLYWHEEL_BEARING_STAND = {
+  width: 0.16,
+  depth: 0.68,
+  height: 1.3,
+  centerOffsetX: 0.48,
+} as const;
+
+export const FLYWHEEL_CRANK = {
+  radius: 0.34,
+  discRadius: 0.2,
+  armLength: 0.34,
+  handleRadius: 0.045,
+  handleLength: 0.28,
+} as const;
+
+export const FLYWHEEL_GEARBOX = {
+  centerX: 0.78,
+  centerY: 1.24,
+  centerZ: 0,
+  radius: 0.52,
+  depth: 0.26,
+} as const;
+
+export const FLYWHEEL_ENERGY_PORT = {
+  x: 1.32,
+  y: 1.62,
+  z: 0.62,
+  radius: 0.13,
+} as const;
+
+export const FLYWHEEL_SUN_TEETH = 18;
+export const FLYWHEEL_PLANET_TEETH = 24;
+export const FLYWHEEL_RING_TEETH =
+  FLYWHEEL_SUN_TEETH + FLYWHEEL_PLANET_TEETH * 2;
+export const FLYWHEEL_TORQUE_RATIO =
+  1 + FLYWHEEL_RING_TEETH / FLYWHEEL_SUN_TEETH;
+export const FLYWHEEL_CRANK_RAD_PER_SECOND = 1.2;
+export const FLYWHEEL_EMPHASIS_SPEED_BOOST = 0.18;
+
+export const FLYWHEEL_GEAR_RADII = {
+  sun: 0.15,
+  planet: 0.2,
+  ring: 0.55,
+  planetOrbit: 0.35,
+} as const;
+
+export const FLYWHEEL_MARKER_MIN_HEIGHT = 2.95;
+export const FLYWHEEL_AVATAR_PATH_RADIUS = 1.2;
+
+export function getFlywheelCarrierAngle(crankAngle: number): number {
+  return crankAngle / FLYWHEEL_TORQUE_RATIO;
+}
+
+export function getFlywheelPlanetLocalSpin(
+  sunAngle: number,
+  carrierAngle: number
+): number {
+  return (
+    -(FLYWHEEL_SUN_TEETH / FLYWHEEL_PLANET_TEETH) * (sunAngle - carrierAngle)
+  );
+}

--- a/src/tests/flywheelEnergyContract.test.ts
+++ b/src/tests/flywheelEnergyContract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLYWHEEL_GEAR_RADII,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_PLANET_TEETH,
+  FLYWHEEL_RING_TEETH,
+  FLYWHEEL_SUN_TEETH,
+  FLYWHEEL_TORQUE_RATIO,
+  getFlywheelCarrierAngle,
+  getFlywheelPlanetLocalSpin,
+} from '../scene/structures/flywheelEnergyContract';
+
+describe('flywheel energy contract', () => {
+  it('exports finite physical bounds and gear dimensions', () => {
+    expect(
+      Object.values(FLYWHEEL_INSTALLATION_BOUNDS).every(Number.isFinite)
+    ).toBe(true);
+    expect(
+      Object.values(FLYWHEEL_GEAR_RADII).every(
+        (value) => Number.isFinite(value) && value > 0
+      )
+    ).toBe(true);
+  });
+
+  it('keeps planetary tooth counts and torque ratio mechanically plausible', () => {
+    expect(FLYWHEEL_RING_TEETH).toBe(
+      FLYWHEEL_SUN_TEETH + FLYWHEEL_PLANET_TEETH * 2
+    );
+    expect(FLYWHEEL_TORQUE_RATIO).toBe(
+      1 + FLYWHEEL_RING_TEETH / FLYWHEEL_SUN_TEETH
+    );
+    expect(FLYWHEEL_TORQUE_RATIO).toBeGreaterThan(1);
+  });
+
+  it('derives carrier and planet spin from one sun angle', () => {
+    const sunAngle = 4.2;
+    const carrierAngle = getFlywheelCarrierAngle(sunAngle);
+    const planetLocalSpin = getFlywheelPlanetLocalSpin(sunAngle, carrierAngle);
+    const fromRing =
+      -(FLYWHEEL_RING_TEETH / FLYWHEEL_PLANET_TEETH) * carrierAngle;
+
+    expect(carrierAngle).toBeCloseTo(sunAngle / FLYWHEEL_TORQUE_RATIO, 6);
+    expect(planetLocalSpin).toBeCloseTo(fromRing, 6);
+    expect(planetLocalSpin).toBeLessThan(0);
+  });
+});

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -1,291 +1,191 @@
-import { Group, Mesh, MeshBasicMaterial, MeshStandardMaterial } from 'three';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Mesh, Object3D } from 'three';
+import { describe, expect, it } from 'vitest';
 
+import {
+  getSceneDetailPolicy,
+  ORDERED_SCENE_DETAIL_LEVELS,
+} from '../scene/graphics/sceneDetailPolicy';
+import { MINIATURE_POI_PROXY_REGISTRY } from '../scene/miniature/poiProxyRegistry';
+import { getPoiPhysicalMetadata } from '../scene/poi/physicalMetadata';
 import { createFlywheelShowpiece } from '../scene/structures/flywheel';
+import {
+  FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_POI_ID,
+  FLYWHEEL_TORQUE_RATIO,
+} from '../scene/structures/flywheelEnergyContract';
+import { countObjectTriangles } from '../scene/structures/triangleCount';
 
-type CapturingContext = CanvasRenderingContext2D & {
-  fillTextCalls: string[];
+const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
+const anchor = { x: 10, y: 0.25, z: -2 };
+
+const collectNames = (root: Object3D) => {
+  const names = new Set<string>();
+  root.traverse((child) => names.add(child.name));
+  return names;
 };
-
-const contexts: CapturingContext[] = [];
-
-const createMockContext = (canvas: HTMLCanvasElement): CapturingContext => {
-  const fillTextCalls: string[] = [];
-  const gradient = { addColorStop: vi.fn() };
-  const context = {
-    save: vi.fn(),
-    restore: vi.fn(),
-    clearRect: vi.fn(),
-    beginPath: vi.fn(),
-    closePath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    quadraticCurveTo: vi.fn(),
-    fillRect: vi.fn(),
-    fill: vi.fn(),
-    stroke: vi.fn(),
-    createLinearGradient: vi.fn(() => gradient),
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 0,
-    textAlign: 'left',
-    textBaseline: 'alphabetic',
-    font: '',
-    globalAlpha: 1,
-    shadowBlur: 0,
-    shadowColor: '',
-    fillText: vi.fn((text: string) => {
-      fillTextCalls.push(text);
-    }),
-    fillTextCalls,
-  } as Partial<CapturingContext>;
-  Object.defineProperty(context, 'canvas', { value: canvas });
-  return context as CapturingContext;
-};
-
-beforeAll(() => {
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
-    configurable: true,
-    value(this: HTMLCanvasElement, type: string) {
-      if (type !== '2d') {
-        return null;
-      }
-      const context = createMockContext(this);
-      contexts.push(context);
-      return context;
-    },
-  });
-});
-
-beforeEach(() => {
-  contexts.length = 0;
-});
 
 describe('createFlywheelShowpiece', () => {
-  const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
-
-  it('builds kinetic hub geometry with docs callout signage', () => {
+  it('uses a bottom-centered unit-scale root at the POI anchor', () => {
     const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
+      position: anchor,
       roomBounds,
+      orientationRadians: 0.4,
     });
 
-    expect(build.group.name).toBe('FlywheelShowpiece');
+    expect(build.group.name).toBe('FlywheelEnergyInstallation');
+    expect(build.group.position.toArray()).toEqual([
+      anchor.x,
+      anchor.y,
+      anchor.z,
+    ]);
+    expect(build.group.rotation.y).toBeCloseTo(0.4);
+    expect(build.group.scale.toArray()).toEqual([1, 1, 1]);
 
-    const rotorGroup = build.group.getObjectByName('FlywheelRotorGroup');
-    expect(rotorGroup).toBeInstanceOf(Group);
-
-    const panel = build.group.getObjectByName('FlywheelInfoPanel');
-    expect(panel).toBeInstanceOf(Mesh);
-
-    const callout = build.group.getObjectByName('FlywheelDocsCallout');
-    expect(callout).toBeInstanceOf(Mesh);
-
-    const capturedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
-    expect(capturedText).toContain('Flywheel Automation');
-    expect(capturedText).toContain('README');
-    expect(capturedText).toContain('github.com/futuroptimist/flywheel');
-    expect(capturedText).toContain('CI templates');
-    expect(capturedText).toContain('Typed prompts');
-    expect(capturedText).toContain('Scaffolds');
-    expect(capturedText).toContain('lint · test · deploy');
-    expect(capturedText).toContain('codex-driven flows');
-    expect(capturedText).toContain('vite · playwright');
+    build.dispose();
   });
 
-  it('keeps the docs callout hidden when only emphasis is applied', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
+  it('authors core geometry in local coordinates rather than world-coordinate child placement', () => {
+    const build = createFlywheelShowpiece({ position: anchor, roomBounds });
+
+    build.group.traverse((child) => {
+      if (child !== build.group && child instanceof Mesh) {
+        expect(Math.abs(child.position.x)).toBeLessThan(
+          FLYWHEEL_INSTALLATION_BOUNDS.width
+        );
+        expect(Math.abs(child.position.z)).toBeLessThan(
+          FLYWHEEL_INSTALLATION_BOUNDS.depth
+        );
+      }
     });
 
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-
-    build.update({ elapsed: 0.5, delta: 0.5, emphasis: 1 });
-    build.update({ elapsed: 1, delta: 0.5, emphasis: 1 });
-
-    expect(calloutMaterial.opacity).toBeLessThan(0.05);
-    expect(callout.visible).toBe(false);
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    build.dispose();
   });
 
-  it('reveals docs callout when the flywheel POI is selected and hides when cleared', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
+  it('builds the physical semantic hierarchy and removes obsolete abstract kiosk names', () => {
+    const build = createFlywheelShowpiece({ position: anchor, roomBounds });
+    const names = collectNames(build.group);
 
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
-    const calloutGlow = build.group.getObjectByName(
-      'FlywheelDocsCalloutGlow'
-    ) as Mesh;
-    const calloutGlowMaterial = calloutGlow.material as MeshBasicMaterial;
-    const rotorGroup = build.group.getObjectByName(
-      'FlywheelRotorGroup'
-    ) as Group;
-
-    const initialRotation = rotorGroup.rotation.y;
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    build.update({ elapsed: 0.5, delta: 0.5, emphasis: 1 });
-    build.update({ elapsed: 1.1, delta: 0.6, emphasis: 1 });
-
-    expect(rotorGroup.rotation.y).toBeGreaterThan(initialRotation);
-    expect(calloutMaterial.opacity).toBeGreaterThan(0.3);
-    expect(calloutGlowMaterial.opacity).toBeGreaterThan(0.05);
-    expect(callout.visible).toBe(true);
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selection-cleared', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    let elapsed = 1.6;
-    for (let i = 0; i < 6; i += 1) {
-      build.update({ elapsed, delta: 0.3, emphasis: 0.8 });
-      elapsed += 0.3;
+    for (const name of [
+      'FlywheelBase',
+      'FlywheelBearingStandLeft',
+      'FlywheelBearingStandRight',
+      'FlywheelAxle',
+      'FlywheelWheelGroup',
+      'FlywheelHeavyRim',
+      'FlywheelInnerHub',
+      'FlywheelSpoke-0',
+      'FlywheelCounterweight-0',
+      'FlywheelEnergyGlowRing',
+      'FlywheelCrankGroup',
+      'FlywheelCrankDisc',
+      'FlywheelCrankArm',
+      'FlywheelCrankHandle',
+      'FlywheelPlanetaryGearbox',
+      'FlywheelRingGear',
+      'FlywheelSunGear',
+      'FlywheelPlanetCarrier',
+      'FlywheelPlanetGear-0',
+      'FlywheelOutputShaft',
+      'FlywheelEnergyPort',
+    ]) {
+      expect(names.has(name)).toBe(true);
     }
 
-    expect(calloutMaterial.opacity).toBeLessThan(0.05);
-    expect(callout.visible).toBe(false);
+    expect(names.has('FlywheelRotorGroup')).toBe(false);
+    expect(names.has('FlywheelAutomationPillars')).toBe(false);
+    expect(names.has('FlywheelInfoPanel')).toBe(false);
 
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    build.dispose();
   });
 
-  it('keeps the docs callout hidden when emphasis stays at zero', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
+  it('keeps crank, sun, carrier, planets, output, and flywheel synchronized', () => {
+    const build = createFlywheelShowpiece({ position: anchor, roomBounds });
 
-    const callout = build.group.getObjectByName('FlywheelDocsCallout') as Mesh;
-    const calloutMaterial = callout.material as MeshBasicMaterial;
+    build.update({ elapsed: 3, delta: 1 / 60, emphasis: 0 });
+    const debug = build.getDebugState();
 
-    for (let i = 0; i < 5; i += 1) {
-      build.update({ elapsed: i * 0.5, delta: 0.5, emphasis: 0 });
-    }
+    expect(debug.sunAngle).toBeCloseTo(debug.crankAngle, 6);
+    expect(debug.carrierAngle).toBeCloseTo(
+      debug.crankAngle / FLYWHEEL_TORQUE_RATIO,
+      6
+    );
+    expect(debug.planetOrbitAngle).toBeCloseTo(debug.carrierAngle, 6);
+    expect(debug.outputShaftAngle).toBeCloseTo(debug.carrierAngle, 6);
+    expect(debug.flywheelAngle).toBeCloseTo(debug.carrierAngle, 6);
+    expect(debug.planetLocalSpin).toBeLessThan(0);
 
-    expect(calloutMaterial.opacity).toBe(0);
-    expect(callout.visible).toBe(false);
+    const carrier = build.group.getObjectByName('FlywheelPlanetCarrier');
+    const planet = build.group.getObjectByName('FlywheelPlanetGear-0');
+    expect(carrier?.rotation.z).toBeCloseTo(debug.carrierAngle, 6);
+    expect(planet?.rotation.z).toBeCloseTo(debug.planetLocalSpin, 6);
 
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    build.dispose();
   });
 
-  it('reveals tech stack chips and animates their orbit after selection', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
+  it('builds finite decreasing geometry across all detail levels without update allocations', () => {
+    const triangleCounts = ORDERED_SCENE_DETAIL_LEVELS.map((level) => {
+      const build = createFlywheelShowpiece({
+        position: anchor,
+        roomBounds,
+        detailPolicy: getSceneDetailPolicy(level),
+      });
+      const beforeChildren = build.group.children.length;
+      const beforeTriangles = countObjectTriangles(build.group);
+      build.update({ elapsed: 1, delta: 1 / 60, emphasis: 0 });
+      build.update({
+        elapsed: 2,
+        delta: 1 / 60,
+        emphasis: 0.8,
+        runDecorativeEffects: false,
+      });
+      expect(build.group.children.length).toBe(beforeChildren);
+      expect(countObjectTriangles(build.group)).toBe(beforeTriangles);
+      expect(beforeTriangles).toBeGreaterThan(0);
+      build.dispose();
+      build.dispose();
+      return beforeTriangles;
     });
 
-    const techStackGroup = build.group.getObjectByName(
-      'FlywheelTechStackGroup'
-    ) as Group;
-    expect(techStackGroup).toBeInstanceOf(Group);
-
-    const wrappers = techStackGroup.children as Group[];
-    expect(wrappers).toHaveLength(3);
-
-    const initialRotations = wrappers.map((wrapper) => wrapper.rotation.y);
-    const materials = wrappers.map((wrapper) => {
-      const chip = wrapper.children[0] as Mesh;
-      return chip.material as MeshBasicMaterial;
-    });
-
-    build.update({ elapsed: 0.25, delta: 0.25, emphasis: 0.6 });
-    materials.forEach((material) => {
-      expect(material.opacity).toBeLessThan(0.1);
-    });
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected:analytics', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
-    );
-
-    build.update({ elapsed: 0.9, delta: 0.65, emphasis: 1 });
-    build.update({ elapsed: 1.6, delta: 0.7, emphasis: 1 });
-
-    wrappers.forEach((wrapper, index) => {
-      expect(wrapper.rotation.y).not.toBeCloseTo(initialRotations[index]);
-      const chip = wrapper.children[0] as Mesh;
-      expect(chip.visible).toBe(true);
-    });
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeGreaterThan(0.3);
-    });
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
+    expect(triangleCounts[0]).toBeGreaterThan(triangleCounts[1]);
+    expect(triangleCounts[1]).toBeGreaterThan(triangleCounts[2]);
+    expect(triangleCounts[2]).toBeGreaterThan(triangleCounts[3]);
   });
 
-  it('highlights automation pillars as emphasis and selection increase', () => {
-    const build = createFlywheelShowpiece({
-      centerX: 0,
-      centerZ: 0,
-      roomBounds,
-    });
+  it('returns conservative physical colliders and matching physical metadata', () => {
+    const build = createFlywheelShowpiece({ position: anchor, roomBounds });
+    const baseCollider = build.colliders[0];
+    const metadata = getPoiPhysicalMetadata(FLYWHEEL_POI_ID);
 
-    const pillarGroup = build.group.getObjectByName(
-      'FlywheelAutomationPillars'
-    ) as Group;
-    expect(pillarGroup).toBeInstanceOf(Group);
-
-    const pillarMeshes = pillarGroup.children as Mesh[];
-    expect(pillarMeshes.length).toBeGreaterThan(0);
-
-    const initialHeights = pillarMeshes.map((mesh) => mesh.position.y);
-    const materials = pillarMeshes.map(
-      (mesh) => mesh.material as MeshStandardMaterial
+    expect((baseCollider.minX + baseCollider.maxX) / 2).toBe(anchor.x);
+    expect((baseCollider.minZ + baseCollider.maxZ) / 2).toBe(anchor.z);
+    expect(baseCollider.maxX - baseCollider.minX).toBeCloseTo(
+      FLYWHEEL_BASE_DIMENSIONS.width
     );
-
-    build.update({ elapsed: 0.2, delta: 0.2, emphasis: 0.1 });
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeLessThan(0.3);
-    });
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selected', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
+    expect(baseCollider.maxZ - baseCollider.minZ).toBeCloseTo(
+      FLYWHEEL_BASE_DIMENSIONS.depth
     );
+    expect(metadata?.anchor).toBe('bottom-center');
+    expect(metadata?.intendedSceneBounds).toEqual(FLYWHEEL_INSTALLATION_BOUNDS);
 
-    build.update({ elapsed: 0.9, delta: 0.7, emphasis: 1 });
-    build.update({ elapsed: 1.6, delta: 0.7, emphasis: 1 });
+    build.dispose();
+  });
 
-    const finalHeights = pillarMeshes.map((mesh) => mesh.position.y);
-    const heightChanged = finalHeights.some(
-      (height, index) => Math.abs(height - initialHeights[index]) > 1e-4
+  it('keeps the miniature proxy synchronized with physical wheel/crank/gear semantics', () => {
+    const proxy = MINIATURE_POI_PROXY_REGISTRY[FLYWHEEL_POI_ID];
+    const names = proxy.primitives.map((primitive) => primitive.name);
+
+    expect(proxy.syncRevision).toBeGreaterThanOrEqual(4);
+    expect(proxy.sourceFiles).toContain(
+      'src/scene/structures/flywheelEnergyContract.ts'
     );
-    expect(heightChanged).toBe(true);
-
-    materials.forEach((material) => {
-      expect(material.opacity).toBeGreaterThan(0.4);
-      expect(material.emissiveIntensity).toBeGreaterThan(0.5);
-    });
-
-    expect(pillarMeshes.every((mesh) => mesh.visible)).toBe(true);
-
-    window.dispatchEvent(
-      new CustomEvent('poi:selection-cleared', {
-        detail: { poi: { id: 'flywheel-studio-flywheel' } },
-      })
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'flywheel-heavy-wheel',
+        'flywheel-crank-arm',
+        'flywheel-gear-cluster',
+        'flywheel-energy-port',
+      ])
     );
-
-    build.group.dispatchEvent({ type: 'removed' } as Event);
   });
 });

--- a/src/tests/sceneObjectColliderPolicies.test.ts
+++ b/src/tests/sceneObjectColliderPolicies.test.ts
@@ -85,8 +85,7 @@ const migratedFactories = [
     placement: { position: { x: 9.035, y: 0, z: 0.745 }, orientation: 0 },
     build: ({ position, orientation }: MigratedFactoryPlacement) =>
       createFlywheelShowpiece({
-        centerX: position.x,
-        centerZ: position.z,
+        position: { x: position.x, y: position.y ?? 0, z: position.z },
         orientationRadians: orientation,
         roomBounds: { minX: 0, maxX: 16, minZ: -16, maxZ: 16 },
       }),


### PR DESCRIPTION
### Motivation
- Replace the old abstract Flywheel kiosk with a grounded, physically plausible kinetic installation anchored at the POI position so model roots, colliders, miniature proxy, and triangle accounting are correct.
- Provide a single shared source of truth for dimensions, gear teeth, ratios, animation speeds, and clearances to avoid duplicated constants across builder, metadata, tests, and miniature proxies.
- Implement a deterministic, mechanically-plausible planetary gear train driven by a constant-rate hand crank where decorative effects can be throttled without desynchronizing mechanical ratios.

### Description
- Add `src/scene/structures/flywheelEnergyContract.ts` exporting installation bounds, base/wheel/axle/bearing/crank/gearbox dimensions, gear teeth/radii, torque ratio, and helper math such as `getFlywheelCarrierAngle` and `getFlywheelPlanetLocalSpin`.
- Replace the previous builder with a physical assembly in `src/scene/structures/flywheel.ts` that returns a bottom-centered `FlywheelEnergyInstallation` root at the resolved `position`, a full semantic hierarchy (base, bearing stands, axle, heavy rim, hub, spokes/counterweights, crank, gearbox, ring/sun/planet gears, carrier/output shaft, energy port), conservative colliders, `update(...)`, `getDebugState()`, and idempotent `dispose()`.
- Implement a fixed-ring planetary gear train where the crank drives the sun gear, planets orbit/counter-spin on a carrier, and the carrier/output/flywheel angle = `crankAngle / FLYWHEEL_TORQUE_RATIO`, with procedural tooth hints that respect scene detail policy and avoid per-frame geometry rebuilds.
- Wire runtime integration in `src/main.ts` to build using a resolved `position`, to call `flywheelShowpiece.update(...)` every rendered frame while passing a `runDecorativeEffects` flag, and to call `dispose()` during teardown; update POI physical metadata and miniature proxy/manifest to match the new physical assembly; document the P6b changes in `docs/architecture/flywheel-energy-transfer.md`.

### Testing
- Ran focused unit tests: `npm run test:ci -- src/tests/flywheelEnergyContract.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts src/tests/sceneObjectColliderPolicies.test.ts` and all specified tests passed (31 tests across the run passed).
- Ran repository gates: `npm run format:write`, `npm run miniature:manifest:update`, `npm run miniature:check`, `npm run lint`, `npm run build`, `npm run docs:check`, `npm run smoke`, and `npm run format:check`, and these completed successfully (link checker emitted fetch warnings for external URLs but passed); miniature manifest was updated and validated.
- Ran `npm run typecheck` and observed pre-existing project-wide TypeScript errors unrelated to this change; the Flywheel-specific collider typing issue found while preparing the PR was fixed before commit, but full project typecheck still reports unrelated errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f31b9af80832fa645c23b50bf653e)