### PR TITLE
✨ : – Implement Flywheel energy-transfer arcs

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -723,3 +723,46 @@ gearbox, and energy port without individual tooth blocks. The core update runs
 every rendered frame, while decorative glow updates can still be throttled by the
 scene detail controller. Cross-POI blue transfer arcs remain future P6c scope and
 are not implemented here.
+
+## 10. P6c implementation notes
+
+The runtime energy-transfer layer is implemented by the pure
+`src/scene/structures/flywheelEnergyNetwork.ts` module and the rendering adapter
+inside `src/scene/structures/flywheel.ts`. The pure network owns seeded target
+selection, deterministic cycle state, active transfer phase, visible-window
+math, and parabolic arc sampling. It does not import Three.js, the DOM, or
+`main.ts`.
+
+`src/main.ts` resolves live targets after all ground-floor POI structures have
+registered their visual anchors. It walks `poiInstances`, filters with the same
+`createPoiFloorResolver(FLOOR_PLAN_LEVELS)` scene floor resolver, excludes
+`flywheel-studio-flywheel`, prefers `resolvePoiVisualAnchor(...)`, and reads
+world-space positions through `Object3D.getWorldPosition(...)`. Missing optional
+anchors fail open through diagnostics instead of blocking immersive startup.
+
+The network repeats a deterministic 5-in / 1-out sequence. Five incoming
+transfers move from seeded random ground-floor POIs into the Flywheel energy
+port, then one outgoing transfer moves from the port to another seeded target.
+Immediate repeats are avoided when multiple targets are available. Incoming
+packets use an approximately `0.10` phase window; outgoing packets use a wider
+`0.16` window with higher strength so the packet renders thicker and brighter.
+No runtime `Math.random()` is used by the network.
+
+Rendering intentionally shows only one moving packet group, not the full arc and
+not a spiderweb of all possible routes. The showpiece preallocates packet node
+meshes and repositions/scales them along the visible subsection of the sampled
+parabolic curve each frame. Detail levels only change rendering cost by changing
+the pooled node count and glow presentation; target order, phase progression,
+direction, transfer durations, and the 5-in / 1-out rhythm are preserved.
+
+Accessibility preferences are presentation-only. `getPulseScale()` and
+`getFlickerScale()` soften port pulse and packet opacity without pausing the
+network, changing target selection, altering counts, or changing incoming versus
+outgoing semantics. The layer uses smooth opacity changes and no dynamic point
+lights or strobing flashes.
+
+`getDebugState().energy` reports target count, diagnostics, cycle count,
+direction, selected target id, phase, visible-window bounds, incoming/outgoing
+completion counts, current source/destination world and local positions, active
+node count, detail level, and reduced pulse/flicker scales. Returned arrays and
+position records are copied so callers cannot mutate internal state.

--- a/src/main.ts
+++ b/src/main.ts
@@ -280,6 +280,7 @@ import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
 } from './scene/structures/flywheel';
+import type { FlywheelEnergyTarget } from './scene/structures/flywheelEnergyNetwork';
 import {
   createGabrielSentry,
   type GabrielSentryBuild,
@@ -3324,6 +3325,42 @@ function initializeImmersiveScene(
     }
     addPoiStructure(wovePoi, loom.group);
     woveLoom = loom;
+  }
+
+  const resolveFlywheelRuntimeEnergyTargets = (): FlywheelEnergyTarget[] => {
+    const targets: FlywheelEnergyTarget[] = [];
+    const missing: string[] = [];
+    poiInstances.forEach((poi) => {
+      if (poi.definition.id === 'flywheel-studio-flywheel') return;
+      if (getPoiFloorId(poi.definition) !== 'ground') return;
+      const anchor = resolvePoiVisualAnchor(poi.definition.id);
+      const object = anchor?.object ?? poi.group;
+      if (!object) {
+        missing.push(poi.definition.id);
+        return;
+      }
+      object.updateMatrixWorld(true);
+      const world = object.getWorldPosition(new Vector3());
+      targets.push({
+        poiId: poi.definition.id,
+        label: poi.definition.title ?? poi.definition.id,
+        floorId: 'ground',
+        worldPosition: { x: world.x, y: world.y, z: world.z },
+      });
+    });
+    if (missing.length > 0) {
+      crashBreadcrumbs.record({
+        type: 'snapshot',
+        message: 'flywheel-energy-missing-targets:' + missing.join(','),
+        renderer: rendererInfo,
+        softwareRendererPolicy,
+      });
+    }
+    return targets;
+  };
+
+  if (flywheelShowpiece) {
+    flywheelShowpiece.setEnergyTargets(resolveFlywheelRuntimeEnergyTargets());
   }
 
   // Keep tabletop construction after all POI visual-anchor producers so

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "c35e134ca28c1414da7edefdda9afa4c0614d730fb72862516295e77cfc42b6c",
+      "proxyFingerprint": "c97da07e8039f1406093617e31bdc3a1f60daacf6ac033692d9a0dd653d0aae7",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -574,14 +574,15 @@
         "src/scene/poi/placements.ts",
         "src/scene/poi/registry.ts",
         "src/scene/structures/flywheel.ts",
-        "src/scene/structures/flywheelEnergyContract.ts"
+        "src/scene/structures/flywheelEnergyContract.ts",
+        "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.",
-      "sourceFingerprint": "d3e1970e2658dd17f500590a86ba91d4cf1804d3cf1e2ce5cf614288716582bc",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
-      "metadataFingerprint": "5b6d936a1b778dcba5f2b4f08afff8969f07ad60dc6f9dfe915bf13f5ba02980"
+      "syncRevision": 8,
+      "syncNote": "Adds pooled runtime Flywheel transfer arcs to source tracking while keeping static incoming/outgoing blue arc hints.",
+      "sourceFingerprint": "99758083d462819667f2e1113415448e0efec1db38481545a3d24169f133a4bb",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
+      "metadataFingerprint": "603aa80f97868a420f6abd96a94c495e59e6edcf73146a403b3e8469c9ce6171"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -595,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -610,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -625,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -640,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -675,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -690,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -705,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -720,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -735,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "7ffa37854142b5122412cb00698f5376431cf2e610957e9ebc80e088b4af95ef",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,13 +90,14 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 6,
+    syncRevision: 8,
     syncNote:
-      'Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.',
+      'Adds pooled runtime Flywheel transfer arcs to source tracking while keeping static incoming/outgoing blue arc hints.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
       'src/scene/structures/flywheelEnergyContract.ts',
+      'src/scene/structures/flywheelEnergyNetwork.ts',
     ],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -137,6 +138,28 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         0xd1d5db
       ),
       sphere('flywheel-energy-port', 0.07, [0.56, 0.8, 0.28], 0x38bdf8),
+      {
+        kind: 'tube',
+        name: 'flywheel-thin-incoming-blue-arc-hint',
+        radius: 0.012,
+        points: [
+          [-0.78, 0.46, -0.44],
+          [-0.26, 1.04, -0.08],
+          [0.56, 0.8, 0.28],
+        ],
+        color: 0x38bdf8,
+      },
+      {
+        kind: 'tube',
+        name: 'flywheel-thick-outgoing-blue-arc-hint',
+        radius: 0.024,
+        points: [
+          [0.56, 0.82, 0.28],
+          [0.18, 1.22, 0.48],
+          [0.86, 0.5, 0.56],
+        ],
+        color: 0x7dd3fc,
+      },
     ],
   },
   'jobbot-studio-terminal': {

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -9,10 +9,15 @@ import {
   MeshStandardMaterial,
   Object3D,
   SphereGeometry,
+  Vector3,
   TorusGeometry,
 } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
+import {
+  getFlickerScale,
+  getPulseScale,
+} from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
@@ -40,6 +45,11 @@ import {
   getFlywheelCarrierAngle,
   getFlywheelPlanetLocalSpin,
 } from './flywheelEnergyContract';
+import {
+  createFlywheelEnergyNetwork,
+  sampleFlywheelEnergyArc,
+  type FlywheelEnergyTarget,
+} from './flywheelEnergyNetwork';
 
 export interface FlywheelShowpieceBuild {
   group: Group;
@@ -50,6 +60,7 @@ export interface FlywheelShowpieceBuild {
     emphasis: number;
     runDecorativeEffects?: boolean;
   }): void;
+  setEnergyTargets(targets: readonly FlywheelEnergyTarget[]): void;
   getDebugState(): FlywheelDebugState;
   dispose(): void;
 }
@@ -71,6 +82,26 @@ export interface FlywheelDebugState {
   planetLocalSpin: number;
   torqueRatio: number;
   triangleCount: number;
+  energy: {
+    targetCount: number;
+    missingTargetDiagnostics: string[];
+    currentCycleCount: number;
+    direction: 'incoming' | 'outgoing' | null;
+    selectedTargetId: string | null;
+    phase: number;
+    visibleWindowStart: number;
+    visibleWindowEnd: number;
+    incomingCompletedCount: number;
+    outgoingCompletedCount: number;
+    sourceWorldPosition: { x: number; y: number; z: number } | null;
+    destinationWorldPosition: { x: number; y: number; z: number } | null;
+    sourceLocalPosition: { x: number; y: number; z: number } | null;
+    destinationLocalPosition: { x: number; y: number; z: number } | null;
+    activeNodeCount: number;
+    detailLevel: string;
+    pulseScale: number;
+    flickerScale: number;
+  };
 }
 
 const MATERIALS = {
@@ -417,6 +448,45 @@ export function createFlywheelShowpiece(
   );
   group.add(port);
 
+  const energyNetwork = createFlywheelEnergyNetwork([], {
+    seed: 'flywheel-studio-energy-arcs',
+  });
+  let missingTargetDiagnostics: string[] = [
+    'flywheel-energy-targets-not-resolved',
+  ];
+  const packetNodeCount =
+    detailPolicy.level === 'cinematic'
+      ? 14
+      : detailPolicy.level === 'balanced'
+        ? 11
+        : detailPolicy.level === 'performance'
+          ? 8
+          : detailPolicy.level === 'low'
+            ? 6
+            : 4;
+  const packetGroup = new Group();
+  packetGroup.name = 'FlywheelEnergyTransferPacket';
+  group.add(packetGroup);
+  const nodeGeometry = own(
+    new SphereGeometry(1, Math.max(6, cylSeg), Math.max(4, cylSeg / 2))
+  );
+  const packetNodes: Mesh[] = [];
+  for (let i = 0; i < packetNodeCount; i += 1) {
+    const material = mat(
+      new MeshBasicMaterial({
+        color: MATERIALS.glow,
+        transparent: true,
+        opacity: 0,
+        depthWrite: false,
+      })
+    );
+    const node = new Mesh(nodeGeometry, material);
+    node.name = `FlywheelEnergyPacketNode-${i}`;
+    node.visible = false;
+    packetGroup.add(node);
+    packetNodes.push(node);
+  }
+
   const colliders = createFlywheelColliders(
     position.x,
     position.z,
@@ -430,6 +500,26 @@ export function createFlywheelShowpiece(
     planetLocalSpin: 0,
     torqueRatio: FLYWHEEL_TORQUE_RATIO,
     triangleCount: countTriangles(group),
+    energy: {
+      targetCount: 0,
+      missingTargetDiagnostics: ['flywheel-energy-targets-not-resolved'],
+      currentCycleCount: 0,
+      direction: null,
+      selectedTargetId: null,
+      phase: 0,
+      visibleWindowStart: 0,
+      visibleWindowEnd: 0,
+      incomingCompletedCount: 0,
+      outgoingCompletedCount: 0,
+      sourceWorldPosition: null,
+      destinationWorldPosition: null,
+      sourceLocalPosition: null,
+      destinationLocalPosition: null,
+      activeNodeCount: 0,
+      detailLevel: detailPolicy.level,
+      pulseScale: 1,
+      flickerScale: 1,
+    },
   };
   let disposed = false;
   let crankAngle = 0;
@@ -460,6 +550,26 @@ export function createFlywheelShowpiece(
         glow.opacity =
           0.45 + Math.min(0.4, emphasis * 0.35) + Math.sin(elapsed * 2) * 0.05;
       }
+      energyNetwork.update(Math.max(0, delta));
+      const energy = updateEnergyPacket(
+        packetNodes,
+        group,
+        port,
+        energyNetwork,
+        detailPolicy.level
+      );
+      if (runDecorativeEffects) {
+        const pulseScale = getPulseScale();
+        const flickerScale = getFlickerScale();
+        const portScale = 1 + Math.sin(elapsed * 1.7) * 0.08 * pulseScale;
+        port.scale.setScalar(portScale);
+        glow.opacity = Math.max(
+          0.22,
+          glow.opacity * (0.75 + 0.25 * flickerScale)
+        );
+        energy.pulseScale = pulseScale;
+        energy.flickerScale = flickerScale;
+      }
       state = {
         crankAngle,
         sunAngle: crankAngle,
@@ -468,9 +578,38 @@ export function createFlywheelShowpiece(
         planetLocalSpin,
         torqueRatio: FLYWHEEL_TORQUE_RATIO,
         triangleCount: state.triangleCount,
+        energy: {
+          ...energy,
+          targetCount: energyNetwork.getSnapshot().targetCount,
+          missingTargetDiagnostics: [...missingTargetDiagnostics],
+          detailLevel: detailPolicy.level,
+        },
       };
     },
-    getDebugState: () => ({ ...state }),
+    setEnergyTargets(targets) {
+      missingTargetDiagnostics =
+        targets.length === 0 ? ['flywheel-energy-no-ground-targets'] : [];
+      energyNetwork.setTargets(targets);
+    },
+    getDebugState: () => ({
+      ...state,
+      energy: {
+        ...state.energy,
+        missingTargetDiagnostics: [...state.energy.missingTargetDiagnostics],
+        sourceWorldPosition: state.energy.sourceWorldPosition
+          ? { ...state.energy.sourceWorldPosition }
+          : null,
+        destinationWorldPosition: state.energy.destinationWorldPosition
+          ? { ...state.energy.destinationWorldPosition }
+          : null,
+        sourceLocalPosition: state.energy.sourceLocalPosition
+          ? { ...state.energy.sourceLocalPosition }
+          : null,
+        destinationLocalPosition: state.energy.destinationLocalPosition
+          ? { ...state.energy.destinationLocalPosition }
+          : null,
+      },
+    }),
     dispose() {
       if (disposed) return;
       disposed = true;
@@ -478,6 +617,101 @@ export function createFlywheelShowpiece(
       ownedMaterials.forEach((m) => m.dispose());
     },
   };
+}
+
+function updateEnergyPacket(
+  packetNodes: readonly Mesh[],
+  root: Group,
+  port: Object3D,
+  network: ReturnType<typeof createFlywheelEnergyNetwork>,
+  detailLevel: string
+): FlywheelDebugState['energy'] {
+  const snapshot = network.getSnapshot();
+  const transfer = network.getActiveTransfer();
+  const inactive = {
+    targetCount: snapshot.targetCount,
+    missingTargetDiagnostics: [],
+    currentCycleCount: snapshot.currentCycleCount,
+    direction: snapshot.direction,
+    selectedTargetId: snapshot.selectedTargetId,
+    phase: snapshot.phase,
+    visibleWindowStart: snapshot.visibleWindowStart,
+    visibleWindowEnd: snapshot.visibleWindowEnd,
+    incomingCompletedCount: snapshot.incomingCompletedCount,
+    outgoingCompletedCount: snapshot.outgoingCompletedCount,
+    sourceWorldPosition: null,
+    destinationWorldPosition: null,
+    sourceLocalPosition: null,
+    destinationLocalPosition: null,
+    activeNodeCount: 0,
+    detailLevel,
+    pulseScale: getPulseScale(),
+    flickerScale: getFlickerScale(),
+  };
+  if (!transfer) {
+    packetNodes.forEach((node) => {
+      node.visible = false;
+    });
+    return inactive;
+  }
+  const target = network.getTarget(transfer.targetPoiId);
+  if (!target) return inactive;
+  const portWorld = port.getWorldPosition(new Vector3());
+  const targetWorld = new Vector3(
+    target.worldPosition.x,
+    target.worldPosition.y + 0.85,
+    target.worldPosition.z
+  );
+  const liftedPort = new Vector3(portWorld.x, portWorld.y, portWorld.z);
+  const sourceWorldVector =
+    transfer.direction === 'incoming' ? targetWorld : liftedPort;
+  const destinationWorldVector =
+    transfer.direction === 'incoming' ? liftedPort : targetWorld;
+  const sourceWorldPosition = toPoint(sourceWorldVector);
+  const destinationWorldPosition = toPoint(destinationWorldVector);
+  const sourceLocal = root.worldToLocal(sourceWorldVector.clone());
+  const destinationLocal = root.worldToLocal(destinationWorldVector.clone());
+  const sourceLocalPosition = toPoint(sourceLocal);
+  const destinationLocalPosition = toPoint(destinationLocal);
+  let activeNodeCount = 0;
+  packetNodes.forEach((node, index) => {
+    const amount =
+      packetNodes.length === 1 ? 0.5 : index / (packetNodes.length - 1);
+    const t =
+      snapshot.visibleWindowStart +
+      (snapshot.visibleWindowEnd - snapshot.visibleWindowStart) * amount;
+    const local = sampleFlywheelEnergyArc(
+      sourceLocalPosition,
+      destinationLocalPosition,
+      t
+    );
+    const fade = Math.sin(Math.PI * amount);
+    const scale =
+      (transfer.direction === 'outgoing' ? 0.105 : 0.07) *
+      transfer.strength *
+      (0.55 + fade * 0.45);
+    node.position.set(local.x, local.y, local.z);
+    node.scale.setScalar(scale);
+    node.visible = t >= 0 && t <= 1;
+    const material = node.material as MeshBasicMaterial;
+    material.opacity =
+      (transfer.direction === 'outgoing' ? 0.82 : 0.58) *
+      fade *
+      getFlickerScale();
+    if (node.visible) activeNodeCount += 1;
+  });
+  return {
+    ...inactive,
+    sourceWorldPosition,
+    destinationWorldPosition,
+    sourceLocalPosition,
+    destinationLocalPosition,
+    activeNodeCount,
+  };
+}
+
+function toPoint(vector: Vector3): { x: number; y: number; z: number } {
+  return { x: vector.x, y: vector.y, z: vector.z };
 }
 
 function addTeeth(

--- a/src/scene/structures/flywheelEnergyNetwork.ts
+++ b/src/scene/structures/flywheelEnergyNetwork.ts
@@ -1,0 +1,254 @@
+export type FlywheelEnergyDirection = 'incoming' | 'outgoing';
+
+export interface FlywheelEnergyPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface FlywheelEnergyTarget {
+  poiId: string;
+  label: string;
+  worldPosition: FlywheelEnergyPoint;
+  floorId?: 'ground' | 'upper';
+}
+
+export interface FlywheelEnergyTransfer {
+  direction: FlywheelEnergyDirection;
+  targetPoiId: string;
+  phase: number;
+  duration: number;
+  window: number;
+  strength: number;
+}
+
+export interface FlywheelEnergyNetworkSnapshot {
+  targetCount: number;
+  currentCycleCount: number;
+  direction: FlywheelEnergyDirection | null;
+  selectedTargetId: string | null;
+  phase: number;
+  visibleWindowStart: number;
+  visibleWindowEnd: number;
+  incomingCompletedCount: number;
+  outgoingCompletedCount: number;
+  transfer: FlywheelEnergyTransfer | null;
+  targetOrder: string[];
+}
+
+export interface FlywheelEnergyNetworkOptions {
+  seed?: number | string;
+  incomingPerCycle?: number;
+  incomingDuration?: number;
+  outgoingDuration?: number;
+  incomingWindow?: number;
+  outgoingWindow?: number;
+  incomingStrength?: number;
+  outgoingStrength?: number;
+}
+
+const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
+const DEFAULTS = {
+  seed: 'flywheel-energy-network',
+  incomingPerCycle: 5,
+  incomingDuration: 2.8,
+  outgoingDuration: 2.35,
+  incomingWindow: 0.1,
+  outgoingWindow: 0.16,
+  incomingStrength: 1,
+  outgoingStrength: 1.65,
+} as const;
+
+export function resolveFlywheelEnergyTargets(
+  targets: readonly FlywheelEnergyTarget[]
+): FlywheelEnergyTarget[] {
+  return targets
+    .filter((target) => target.poiId !== FLYWHEEL_POI_ID)
+    .filter((target) => target.floorId !== 'upper')
+    .filter((target) => isFinitePoint(target.worldPosition))
+    .map(cloneTarget);
+}
+
+export function createFlywheelEnergyNetwork(
+  rawTargets: readonly FlywheelEnergyTarget[] = [],
+  options: FlywheelEnergyNetworkOptions = {}
+) {
+  const config = { ...DEFAULTS, ...options };
+  const rng = mulberry32(hashSeed(config.seed));
+  let targets = resolveFlywheelEnergyTargets(rawTargets);
+  let incomingCompletedCount = 0;
+  let outgoingCompletedCount = 0;
+  let currentCycleCount = 0;
+  let lastTargetId: string | null = null;
+  let active: FlywheelEnergyTransfer | null = null;
+  const targetOrder: string[] = [];
+
+  const chooseTarget = (): FlywheelEnergyTarget | null => {
+    if (targets.length === 0) return null;
+    const candidates =
+      targets.length > 1 && lastTargetId
+        ? targets.filter((target) => target.poiId !== lastTargetId)
+        : targets;
+    const target =
+      candidates[Math.floor(rng() * candidates.length)] ?? candidates[0];
+    lastTargetId = target.poiId;
+    targetOrder.push(target.poiId);
+    return target;
+  };
+
+  const startTransfer = () => {
+    const target = chooseTarget();
+    if (!target) {
+      active = null;
+      return;
+    }
+    const outgoing = incomingCompletedCount >= config.incomingPerCycle;
+    active = {
+      direction: outgoing ? 'outgoing' : 'incoming',
+      targetPoiId: target.poiId,
+      phase: 0,
+      duration: outgoing ? config.outgoingDuration : config.incomingDuration,
+      window: outgoing ? config.outgoingWindow : config.incomingWindow,
+      strength: outgoing ? config.outgoingStrength : config.incomingStrength,
+    };
+  };
+
+  const completeTransfer = () => {
+    if (!active) return;
+    if (active.direction === 'incoming') {
+      incomingCompletedCount += 1;
+    } else {
+      outgoingCompletedCount += 1;
+      currentCycleCount += 1;
+      incomingCompletedCount = 0;
+    }
+    startTransfer();
+  };
+
+  startTransfer();
+
+  return {
+    setTargets(nextTargets: readonly FlywheelEnergyTarget[]) {
+      targets = resolveFlywheelEnergyTargets(nextTargets);
+      lastTargetId = targets.some((target) => target.poiId === lastTargetId)
+        ? lastTargetId
+        : null;
+      active = null;
+      startTransfer();
+    },
+    update(delta: number) {
+      if (!active) return null;
+      const safeDelta = Math.max(0, Number.isFinite(delta) ? delta : 0);
+      active = {
+        ...active,
+        phase: Math.min(1, active.phase + safeDelta / active.duration),
+      };
+      if (active.phase >= 1) completeTransfer();
+      return active ? { ...active } : null;
+    },
+    getActiveTransfer() {
+      return active ? { ...active } : null;
+    },
+    getTarget(poiId: string) {
+      const target = targets.find((item) => item.poiId === poiId);
+      return target ? cloneTarget(target) : null;
+    },
+    getTargets() {
+      return targets.map(cloneTarget);
+    },
+    getSnapshot(): FlywheelEnergyNetworkSnapshot {
+      const window = active
+        ? getFlywheelEnergyVisibleWindow(active.phase, active.window)
+        : { start: 0, end: 0 };
+      return {
+        targetCount: targets.length,
+        currentCycleCount,
+        direction: active?.direction ?? null,
+        selectedTargetId: active?.targetPoiId ?? null,
+        phase: active?.phase ?? 0,
+        visibleWindowStart: window.start,
+        visibleWindowEnd: window.end,
+        incomingCompletedCount,
+        outgoingCompletedCount,
+        transfer: active ? { ...active } : null,
+        targetOrder: [...targetOrder],
+      };
+    },
+  };
+}
+
+export function getFlywheelEnergyVisibleWindow(phase: number, size: number) {
+  const clampedSize = clamp(size, 0.01, 1);
+  const center = clamp(phase, 0, 1);
+  return {
+    start: clamp(center - clampedSize / 2, 0, 1),
+    end: clamp(center + clampedSize / 2, 0, 1),
+  };
+}
+
+export function sampleFlywheelEnergyArc(
+  source: FlywheelEnergyPoint,
+  destination: FlywheelEnergyPoint,
+  t: number
+): FlywheelEnergyPoint {
+  const clamped = clamp(t, 0, 1);
+  const lift = Math.min(
+    1.35,
+    Math.max(0.45, distance(source, destination) * 0.18)
+  );
+  const mid = {
+    x: (source.x + destination.x) / 2,
+    y: Math.max(source.y, destination.y) + lift,
+    z: (source.z + destination.z) / 2,
+  };
+  const a = lerpPoint(source, mid, clamped);
+  const b = lerpPoint(mid, destination, clamped);
+  return lerpPoint(a, b, clamped);
+}
+
+function cloneTarget(target: FlywheelEnergyTarget): FlywheelEnergyTarget {
+  return {
+    poiId: target.poiId,
+    label: target.label,
+    floorId: target.floorId,
+    worldPosition: { ...target.worldPosition },
+  };
+}
+function isFinitePoint(point: FlywheelEnergyPoint): boolean {
+  return (
+    Number.isFinite(point.x) &&
+    Number.isFinite(point.y) &&
+    Number.isFinite(point.z)
+  );
+}
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Number.isFinite(value) ? value : min));
+}
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+function lerpPoint(a: FlywheelEnergyPoint, b: FlywheelEnergyPoint, t: number) {
+  return { x: lerp(a.x, b.x, t), y: lerp(a.y, b.y, t), z: lerp(a.z, b.z, t) };
+}
+function distance(a: FlywheelEnergyPoint, b: FlywheelEnergyPoint): number {
+  return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+function hashSeed(seed: number | string): number {
+  const text = String(seed);
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/tests/flywheelEnergyNetwork.test.ts
+++ b/src/tests/flywheelEnergyNetwork.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createFlywheelEnergyNetwork,
+  getFlywheelEnergyVisibleWindow,
+  resolveFlywheelEnergyTargets,
+  sampleFlywheelEnergyArc,
+  type FlywheelEnergyTarget,
+} from '../scene/structures/flywheelEnergyNetwork';
+
+const targets: FlywheelEnergyTarget[] = [
+  {
+    poiId: 'a',
+    label: 'A',
+    floorId: 'ground',
+    worldPosition: { x: 0, y: 0, z: 0 },
+  },
+  {
+    poiId: 'b',
+    label: 'B',
+    floorId: 'ground',
+    worldPosition: { x: 2, y: 0, z: 0 },
+  },
+  {
+    poiId: 'c',
+    label: 'C',
+    floorId: 'ground',
+    worldPosition: { x: 4, y: 0, z: 0 },
+  },
+  {
+    poiId: 'flywheel-studio-flywheel',
+    label: 'Flywheel',
+    floorId: 'ground',
+    worldPosition: { x: 5, y: 0, z: 0 },
+  },
+  {
+    poiId: 'upper',
+    label: 'Upper',
+    floorId: 'upper',
+    worldPosition: { x: 6, y: 0, z: 0 },
+  },
+];
+
+function finishOne(network: ReturnType<typeof createFlywheelEnergyNetwork>) {
+  network.update(99);
+  return network.getSnapshot();
+}
+
+describe('flywheel energy network', () => {
+  it('selects deterministic target sequences for the same seed', () => {
+    const first = createFlywheelEnergyNetwork(targets, { seed: 'same' });
+    const second = createFlywheelEnergyNetwork(targets, { seed: 'same' });
+    for (let i = 0; i < 8; i += 1) {
+      finishOne(first);
+      finishOne(second);
+    }
+    expect(first.getSnapshot().targetOrder).toEqual(
+      second.getSnapshot().targetOrder
+    );
+  });
+
+  it('uses different target order for different seeds', () => {
+    const first = createFlywheelEnergyNetwork(targets, { seed: 'one' });
+    const second = createFlywheelEnergyNetwork(targets, { seed: 'two' });
+    for (let i = 0; i < 8; i += 1) {
+      finishOne(first);
+      finishOne(second);
+    }
+    expect(first.getSnapshot().targetOrder).not.toEqual(
+      second.getSnapshot().targetOrder
+    );
+  });
+
+  it('runs exactly five incoming transfers before one stronger outgoing transfer', () => {
+    const network = createFlywheelEnergyNetwork(targets, { seed: 'cycle' });
+    for (let i = 0; i < 5; i += 1) {
+      expect(network.getActiveTransfer()?.direction).toBe('incoming');
+      expect(network.getActiveTransfer()?.window).toBeCloseTo(0.1);
+      finishOne(network);
+    }
+    const outgoing = network.getActiveTransfer();
+    expect(outgoing?.direction).toBe('outgoing');
+    expect(outgoing?.window).toBeGreaterThan(0.1);
+    expect(outgoing?.strength).toBeGreaterThan(1);
+    finishOne(network);
+    expect(network.getSnapshot().incomingCompletedCount).toBe(0);
+    expect(network.getSnapshot().outgoingCompletedCount).toBe(1);
+  });
+
+  it('excludes Flywheel and upper-floor targets and avoids immediate repeats', () => {
+    const resolved = resolveFlywheelEnergyTargets(targets);
+    expect(resolved.map((target) => target.poiId)).toEqual(['a', 'b', 'c']);
+    const network = createFlywheelEnergyNetwork(targets, { seed: 'no-repeat' });
+    for (let i = 0; i < 10; i += 1) finishOne(network);
+    const order = network.getSnapshot().targetOrder;
+    for (let i = 1; i < order.length; i += 1)
+      expect(order[i]).not.toBe(order[i - 1]);
+  });
+
+  it('progresses phase, samples a lifted parabolic arc, and does not mutate inputs', () => {
+    const original = structuredClone(targets);
+    const network = createFlywheelEnergyNetwork(targets, { seed: 'phase' });
+    network.update(0.7);
+    expect(network.getSnapshot().phase).toBeGreaterThan(0);
+    const window = getFlywheelEnergyVisibleWindow(0.5, 0.1);
+    expect(window.end - window.start).toBeCloseTo(0.1);
+    const mid = sampleFlywheelEnergyArc(
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 0 },
+      0.5
+    );
+    expect(mid.y).toBeGreaterThan(0);
+    expect(targets).toEqual(original);
+  });
+});

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -215,4 +215,65 @@ describe('createFlywheelShowpiece', () => {
       ])
     );
   });
+  it('accepts runtime energy targets and exposes a bounded single packet', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 1, z: 2 },
+      orientationRadians: Math.PI / 4,
+      roomBounds,
+      detailPolicy: SCENE_DETAIL_POLICIES.balanced,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'target-a',
+        label: 'Target A',
+        worldPosition: { x: 4, y: 0, z: 2 },
+      },
+      {
+        poiId: 'target-b',
+        label: 'Target B',
+        worldPosition: { x: -3, y: 0, z: 5 },
+      },
+    ]);
+    build.update({
+      elapsed: 1,
+      delta: 0.5,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const state = build.getDebugState().energy;
+    expect(state.targetCount).toBe(2);
+    expect(state.missingTargetDiagnostics).toEqual([]);
+    expect(state.direction).toBe('incoming');
+    expect(state.sourceWorldPosition?.x).not.toBeCloseTo(
+      state.destinationWorldPosition?.x ?? 0
+    );
+    expect(
+      state.visibleWindowEnd - state.visibleWindowStart
+    ).toBeLessThanOrEqual(0.101);
+    expect(state.activeNodeCount).toBeGreaterThan(0);
+    expect(state.activeNodeCount).toBeLessThanOrEqual(11);
+    expect(
+      build.group.getObjectByName('FlywheelEnergyTransferPacket')
+    ).toBeInstanceOf(Object3D);
+    build.dispose();
+  });
+
+  it('fails open with diagnostics when no energy targets are available', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.setEnergyTargets([]);
+    build.update({
+      elapsed: 1,
+      delta: 0.5,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    expect(build.getDebugState().energy.missingTargetDiagnostics).toContain(
+      'flywheel-energy-no-ground-targets'
+    );
+    expect(build.getDebugState().energy.activeNodeCount).toBe(0);
+    build.dispose();
+  });
 });


### PR DESCRIPTION
### Motivation
- Implement P6c: add the metaphorical Flywheel energy-transfer layer that shows deterministic 5-in / 1-out blue parabolic transfer packets between ground-floor POIs and the Flywheel while preserving the physical crank/gear/flywheel motion from P6b.
- Keep the network deterministic and pure (no DOM/Three.js dependence or runtime `Math.random()`), and make presentation obey scene detail and accessibility preferences.

### Description
- Added a pure deterministic energy network module `src/scene/structures/flywheelEnergyNetwork.ts` that provides seeded target selection, 5-in / 1-out cycle state, active transfer state, visible-window math, deterministic RNG, arc sampling (`sampleFlywheelEnergyArc`), and debug snapshots.
- Extended the Flywheel showpiece in `src/scene/structures/flywheel.ts` with `setEnergyTargets(...)`, expanded debug state, and a pooled packet renderer (preallocated node meshes + per-frame transforms) that renders one moving, faded subsection of a parabolic arc per active transfer; presentation respects `getPulseScale()` / `getFlickerScale()` and detail policy.
- Integrated runtime target resolution into `src/main.ts` by walking `poiInstances`, filtering with the same floor resolver, preferring `resolvePoiVisualAnchor(...)`, reading `Object3D.getWorldPosition(...)`, excluding the Flywheel POI, and calling `flywheelShowpiece.setEnergyTargets(...)` after visual anchors are available.
- Updated the Flywheel miniature proxy (`src/scene/miniature/poiProxyRegistry.ts`) and regenerated the manifest with static thin incoming and thicker outgoing blue arc hints; added focused tests for the pure network and showpiece integration (`src/tests/flywheelEnergyNetwork.test.ts` and updated `src/tests/flywheelShowpiece.test.ts`).

### Testing
- Ran formatting and linting: `npm run format:write` and `npm run lint` (both passed with only a minor import-order warning fixed during the rollout).
- Updated/validated miniatures: `npm run miniature:manifest:update` and `npm run miniature:check` (manifest regenerated and validated successfully).
- Ran focused and integration tests: `npm run test:ci -- src/tests/flywheelEnergyNetwork.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts` and `npm run test:ci -- src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts` (all specified test files passed).
- Built and verified artifacts: `npm run build`, `npm run docs:check` (link checker emitted external fetch warnings but passed), `npm run smoke`, and `npm run format:check` (all succeeded); `git diff --cached | ./scripts/scan-secrets.py` returned no high-risk secrets.
- Notes and residuals: attempted `npm run typecheck` (reported unrelated pre-existing TypeScript errors elsewhere in the repo) and an automated Playwright-based screenshot failed because Playwright browsers are not installed in the environment (`npx playwright install` is required to run that capture).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f1eb958832f9ee06403c38e30ed)