### PR TITLE
Implement Flywheel energy-transfer arcs

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -723,3 +723,39 @@ gearbox, and energy port without individual tooth blocks. The core update runs
 every rendered frame, while decorative glow updates can still be throttled by the
 scene detail controller. Cross-POI blue transfer arcs remain future P6c scope and
 are not implemented here.
+
+## 8. P6c implementation notes
+
+The production implementation now splits the deterministic transfer state from
+Three.js rendering:
+
+- `src/scene/structures/flywheelEnergyNetwork.ts` is the pure module. It owns the
+  seeded PRNG, filters out the Flywheel POI and upper-floor targets, avoids
+  immediate repeats when multiple targets exist, advances the five-in/one-out
+  cycle, exposes debug snapshots, and provides parabolic arc/window sampling
+  helpers.
+- `src/main.ts` resolves runtime energy targets after POI structures and visual
+  anchors are registered. It iterates `poiInstances`, uses the scene's
+  `getPoiFloorId(...)` resolver to keep only ground-floor POIs, excludes
+  `flywheel-studio-flywheel`, prefers `resolvePoiVisualAnchor(...)`, and falls
+  back to the POI group with a diagnostic when an optional anchor is absent.
+- `src/scene/structures/flywheel.ts` owns the pooled packet rendering. It keeps a
+  single `FlywheelEnergyTransferPacket` group with preallocated node and
+  connector meshes, so frame updates only move and fade existing objects.
+
+Transfer timing is deterministic and detail-independent: five incoming transfers
+use a short `0.10` visible phase window and then one outgoing transfer uses a
+larger `0.16` window with higher strength. Detail policy changes only rendering
+cost (node count, connector visibility, opacity), not target order, direction,
+phase, duration, or cycle counts.
+
+Accessibility preferences from `getPulseScale()` and `getFlickerScale()` are
+presentation-only. Reduced settings soften glow and opacity but do not pause the
+network or alter transfer semantics. The Flywheel update still runs every
+rendered frame so the crank, planetary gears, wheel, and active packet phase stay
+synchronized; `runDecorativeEffects` gates only secondary glow updates.
+
+`getDebugState().energy` returns copied diagnostics and state, including target
+count, current cycle, direction, selected target, phase, visible window,
+incoming/outgoing completion counts, source/destination world and local
+positions, active node count, detail level, and current accessibility scales.

--- a/src/main.ts
+++ b/src/main.ts
@@ -280,6 +280,7 @@ import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
 } from './scene/structures/flywheel';
+import type { FlywheelEnergyTarget } from './scene/structures/flywheelEnergyNetwork';
 import {
   createGabrielSentry,
   type GabrielSentryBuild,
@@ -3325,6 +3326,42 @@ function initializeImmersiveScene(
     addPoiStructure(wovePoi, loom.group);
     woveLoom = loom;
   }
+
+  const resolveFlywheelEnergyTargets = (): FlywheelEnergyTarget[] => {
+    const targets: FlywheelEnergyTarget[] = [];
+    const diagnostics: string[] = [];
+    poiInstances.forEach((poi) => {
+      if (poi.definition.id === 'flywheel-studio-flywheel') return;
+      if (getPoiFloorId(poi.definition) !== 'ground') return;
+      const anchor = resolvePoiVisualAnchor(poi.definition.id);
+      const source = anchor?.object ?? poi.group;
+      if (!anchor) {
+        diagnostics.push(
+          `Missing visual anchor for ${poi.definition.id}; using POI group.`
+        );
+      }
+      const worldPosition = source.getWorldPosition(new Vector3());
+      targets.push({
+        poiId: poi.definition.id,
+        label: poi.definition.title ?? poi.definition.id,
+        floorId: 'ground',
+        worldPosition: {
+          x: worldPosition.x,
+          y: worldPosition.y,
+          z: worldPosition.z,
+        },
+      });
+    });
+    if (diagnostics.length > 0) {
+      console.info(
+        '[flywheel] Energy target resolution used fallbacks.',
+        diagnostics
+      );
+    }
+    return targets;
+  };
+
+  flywheelShowpiece?.setEnergyTargets(resolveFlywheelEnergyTargets());
 
   // Keep tabletop construction after all POI visual-anchor producers so
   // ground-floor miniature placement can resolve every rendered anchor.

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "c35e134ca28c1414da7edefdda9afa4c0614d730fb72862516295e77cfc42b6c",
+      "proxyFingerprint": "580e95d528e73b1f5703f6be56af9b8acb84a681ca76853ed368a17ed27f6110",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -574,14 +574,15 @@
         "src/scene/poi/placements.ts",
         "src/scene/poi/registry.ts",
         "src/scene/structures/flywheel.ts",
-        "src/scene/structures/flywheelEnergyContract.ts"
+        "src/scene/structures/flywheelEnergyContract.ts",
+        "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.",
-      "sourceFingerprint": "d3e1970e2658dd17f500590a86ba91d4cf1804d3cf1e2ce5cf614288716582bc",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
-      "metadataFingerprint": "5b6d936a1b778dcba5f2b4f08afff8969f07ad60dc6f9dfe915bf13f5ba02980"
+      "syncRevision": 9,
+      "syncNote": "Finalizes P6c static incoming/outgoing blue arc hints after formatting and manifest regeneration.",
+      "sourceFingerprint": "1c2abe8ba6f07338e948cd7d2cfad4c4683ee47880fe7c503a2f047de2026f13",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
+      "metadataFingerprint": "2e8a9cc4859ad3f2e18ce70d6f43f9ead19da13d32bd29e88230b5b328089a10"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -595,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -610,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -625,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -640,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -675,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -690,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -705,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -720,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -735,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "5125a8770a58790b07e46523f28d1107214970781c6312ac5dd41eb28c985755",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,13 +90,14 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 6,
+    syncRevision: 9,
     syncNote:
-      'Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.',
+      'Finalizes P6c static incoming/outgoing blue arc hints after formatting and manifest regeneration.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
       'src/scene/structures/flywheelEnergyContract.ts',
+      'src/scene/structures/flywheelEnergyNetwork.ts',
     ],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -137,6 +138,28 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         0xd1d5db
       ),
       sphere('flywheel-energy-port', 0.07, [0.56, 0.8, 0.28], 0x38bdf8),
+      {
+        kind: 'tube',
+        name: 'flywheel-incoming-arc-hint',
+        radius: 0.012,
+        points: [
+          [-0.95, 0.34, -0.34],
+          [-0.22, 1.08, -0.08],
+          [0.56, 0.8, 0.28],
+        ],
+        color: 0x38bdf8,
+      },
+      {
+        kind: 'tube',
+        name: 'flywheel-outgoing-arc-hint',
+        radius: 0.022,
+        points: [
+          [0.56, 0.8, 0.28],
+          [0.16, 1.22, 0.52],
+          [0.92, 0.38, 0.66],
+        ],
+        color: 0x7dd3fc,
+      },
     ],
   },
   'jobbot-studio-terminal': {

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -9,10 +9,15 @@ import {
   MeshStandardMaterial,
   Object3D,
   SphereGeometry,
+  Vector3,
   TorusGeometry,
 } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
+import {
+  getFlickerScale,
+  getPulseScale,
+} from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
@@ -40,6 +45,12 @@ import {
   getFlywheelCarrierAngle,
   getFlywheelPlanetLocalSpin,
 } from './flywheelEnergyContract';
+import {
+  FlywheelEnergyNetwork,
+  type FlywheelEnergyTarget,
+  getFlywheelEnergyVisibleWindow,
+  sampleFlywheelEnergyArc,
+} from './flywheelEnergyNetwork';
 
 export interface FlywheelShowpieceBuild {
   group: Group;
@@ -50,6 +61,7 @@ export interface FlywheelShowpieceBuild {
     emphasis: number;
     runDecorativeEffects?: boolean;
   }): void;
+  setEnergyTargets(targets: readonly FlywheelEnergyTarget[]): void;
   getDebugState(): FlywheelDebugState;
   dispose(): void;
 }
@@ -71,6 +83,26 @@ export interface FlywheelDebugState {
   planetLocalSpin: number;
   torqueRatio: number;
   triangleCount: number;
+  energy: {
+    targetCount: number;
+    missingTargetDiagnostics: string[];
+    cycleCount: number;
+    direction: 'incoming' | 'outgoing' | null;
+    selectedTargetId: string | null;
+    phase: number;
+    visibleWindowStart: number;
+    visibleWindowEnd: number;
+    incomingCompletedCount: number;
+    outgoingCompletedCount: number;
+    sourceWorldPosition: { x: number; y: number; z: number } | null;
+    destinationWorldPosition: { x: number; y: number; z: number } | null;
+    sourceLocalPosition: { x: number; y: number; z: number } | null;
+    destinationLocalPosition: { x: number; y: number; z: number } | null;
+    activeNodeCount: number;
+    detailLevel: SceneDetailPolicy['level'];
+    pulseScale: number;
+    flickerScale: number;
+  };
 }
 
 const MATERIALS = {
@@ -417,6 +449,66 @@ export function createFlywheelShowpiece(
   );
   group.add(port);
 
+  const energyNetwork = new FlywheelEnergyNetwork(
+    'flywheel-studio-flywheel:v1'
+  );
+  const packetRoot = new Group();
+  packetRoot.name = 'FlywheelEnergyTransferPacket';
+  group.add(packetRoot);
+  const packetNodeCount =
+    detailPolicy.level === 'cinematic'
+      ? 12
+      : detailPolicy.level === 'balanced'
+        ? 10
+        : detailPolicy.level === 'performance'
+          ? 7
+          : detailPolicy.level === 'low'
+            ? 5
+            : 4;
+  const connectorCount = Math.max(0, packetNodeCount - 1);
+  const packetNodeGeometry = own(new SphereGeometry(0.055, 8, 5));
+  const packetConnectorGeometry = own(new CylinderGeometry(0.018, 0.018, 1, 6));
+  const packetMaterial = mat(
+    new MeshBasicMaterial({ color: 0x38bdf8, transparent: true, opacity: 0 })
+  );
+  const connectorMaterial = mat(
+    new MeshBasicMaterial({ color: 0x7dd3fc, transparent: true, opacity: 0 })
+  );
+  const packetNodes = Array.from({ length: packetNodeCount }, (_, index) => {
+    const node = new Mesh(packetNodeGeometry, packetMaterial.clone());
+    ownedMaterials.add(node.material as MeshBasicMaterial);
+    node.name = `FlywheelEnergyPacketNode-${index}`;
+    node.visible = false;
+    packetRoot.add(node);
+    return node;
+  });
+  const packetConnectors = Array.from(
+    { length: connectorCount },
+    (_, index) => {
+      const connector = new Mesh(
+        packetConnectorGeometry,
+        connectorMaterial.clone()
+      );
+      ownedMaterials.add(connector.material as MeshBasicMaterial);
+      connector.name = `FlywheelEnergyPacketConnector-${index}`;
+      connector.visible = false;
+      packetRoot.add(connector);
+      return connector;
+    }
+  );
+  const worldToLocal = (point: { x: number; y: number; z: number }) =>
+    group.worldToLocal(new Vector3(point.x, point.y, point.z));
+  const localToWorld = (point: { x: number; y: number; z: number }) =>
+    group.localToWorld(new Vector3(point.x, point.y, point.z));
+  let missingTargetDiagnostics: string[] = [];
+  let currentSourceWorld: { x: number; y: number; z: number } | null = null;
+  let currentDestinationWorld: { x: number; y: number; z: number } | null =
+    null;
+  let currentSourceLocal: { x: number; y: number; z: number } | null = null;
+  let currentDestinationLocal: { x: number; y: number; z: number } | null =
+    null;
+  let activeNodeCount = 0;
+
   const colliders = createFlywheelColliders(
     position.x,
     position.z,
@@ -430,13 +522,118 @@ export function createFlywheelShowpiece(
     planetLocalSpin: 0,
     torqueRatio: FLYWHEEL_TORQUE_RATIO,
     triangleCount: countTriangles(group),
+    energy: createEnergyDebugState(
+      energyNetwork,
+      missingTargetDiagnostics,
+      currentSourceWorld,
+      currentDestinationWorld,
+      currentSourceLocal,
+      currentDestinationLocal,
+      activeNodeCount,
+      detailPolicy.level
+    ),
   };
   let disposed = false;
   let crankAngle = 0;
 
+  const hideEnergyPacket = () => {
+    activeNodeCount = 0;
+    currentSourceWorld = null;
+    currentDestinationWorld = null;
+    currentSourceLocal = null;
+    currentDestinationLocal = null;
+    packetNodes.forEach((node) => {
+      node.visible = false;
+    });
+    packetConnectors.forEach((connector) => {
+      connector.visible = false;
+    });
+  };
+
+  const updateEnergyPacket = (deltaSeconds: number) => {
+    const transfer = energyNetwork.update(deltaSeconds);
+    if (!transfer) {
+      hideEnergyPacket();
+      return;
+    }
+    const target = energyNetwork.getTarget(transfer.targetPoiId);
+    if (!target) {
+      hideEnergyPacket();
+      return;
+    }
+    const portWorld = localToWorld(FLYWHEEL_ENERGY_PORT);
+    const targetWorld = {
+      x: target.worldPosition.x,
+      y: Math.max(0.55, target.worldPosition.y + 0.9),
+      z: target.worldPosition.z,
+    };
+    const portPoint = { x: portWorld.x, y: portWorld.y, z: portWorld.z };
+    const source = transfer.direction === 'incoming' ? targetWorld : portPoint;
+    const destination =
+      transfer.direction === 'incoming' ? portPoint : targetWorld;
+    currentSourceWorld = { ...source };
+    currentDestinationWorld = { ...destination };
+    const sourceLocal = worldToLocal(source);
+    const destinationLocal = worldToLocal(destination);
+    currentSourceLocal = {
+      x: sourceLocal.x,
+      y: sourceLocal.y,
+      z: sourceLocal.z,
+    };
+    currentDestinationLocal = {
+      x: destinationLocal.x,
+      y: destinationLocal.y,
+      z: destinationLocal.z,
+    };
+    const visibleWindow = getFlywheelEnergyVisibleWindow(transfer);
+    activeNodeCount = packetNodeCount;
+    packetNodes.forEach((node, index) => {
+      const ratio = index / (packetNodeCount - 1);
+      const t =
+        visibleWindow.start + (visibleWindow.end - visibleWindow.start) * ratio;
+      const point = sampleFlywheelEnergyArc(source, destination, t);
+      const local = worldToLocal(point);
+      const fade = Math.sin(ratio * Math.PI);
+      const scale =
+        (transfer.direction === 'incoming' ? 1 : 1.38) * (0.55 + fade * 0.55);
+      node.position.copy(local);
+      node.scale.setScalar(scale);
+      node.visible = true;
+      (node.material as MeshBasicMaterial).opacity =
+        (0.28 + fade * 0.42) *
+        transfer.strength *
+        Math.max(0.45, getFlickerScale());
+    });
+    packetConnectors.forEach((connector, index) => {
+      const start = packetNodes[index].position;
+      const end = packetNodes[index + 1].position;
+      const midpoint = start.clone().add(end).multiplyScalar(0.5);
+      const length = start.distanceTo(end);
+      connector.position.copy(midpoint);
+      connector.scale.set(transfer.strength, length, transfer.strength);
+      connector.quaternion.setFromUnitVectors(
+        new Vector3(0, 1, 0),
+        end.clone().sub(start).normalize()
+      );
+      connector.visible = detailPolicy.level !== 'micro';
+      (connector.material as MeshBasicMaterial).opacity =
+        transfer.direction === 'incoming' ? 0.2 : 0.34;
+    });
+  };
+
   return {
     group,
     colliders,
+    setEnergyTargets(targets) {
+      energyNetwork.setTargets(targets);
+      const accepted = energyNetwork.getSnapshot().targetCount;
+      missingTargetDiagnostics =
+        targets.length === accepted
+          ? []
+          : [
+              `Accepted ${accepted} of ${targets.length} Flywheel energy targets.`,
+            ];
+    },
     update({ elapsed, delta = 0, emphasis, runDecorativeEffects = true }) {
       const emphasisBoost = Math.min(1, Math.max(0, emphasis));
       const angularVelocity =
@@ -456,9 +653,14 @@ export function createFlywheelShowpiece(
       planetGears.forEach((planet) => {
         planet.rotation.z = planetLocalSpin;
       });
+      const pulseScale = getPulseScale();
+      const flickerScale = getFlickerScale();
+      updateEnergyPacket(delta);
       if (runDecorativeEffects) {
         glow.opacity =
-          0.45 + Math.min(0.4, emphasis * 0.35) + Math.sin(elapsed * 2) * 0.05;
+          0.45 +
+          Math.min(0.4, emphasis * 0.35) * pulseScale +
+          Math.sin(elapsed * 2) * 0.05 * flickerScale;
       }
       state = {
         crankAngle,
@@ -468,6 +670,16 @@ export function createFlywheelShowpiece(
         planetLocalSpin,
         torqueRatio: FLYWHEEL_TORQUE_RATIO,
         triangleCount: state.triangleCount,
+        energy: createEnergyDebugState(
+          energyNetwork,
+          missingTargetDiagnostics,
+          currentSourceWorld,
+          currentDestinationWorld,
+          currentSourceLocal,
+          currentDestinationLocal,
+          activeNodeCount,
+          detailPolicy.level
+        ),
       };
     },
     getDebugState: () => ({ ...state }),
@@ -571,4 +783,41 @@ function countTriangles(root: Object3D): number {
     count += index ? index.count / 3 : position.count / 3;
   });
   return count;
+}
+
+function copyDebugPoint(point: { x: number; y: number; z: number } | null) {
+  return point ? { x: point.x, y: point.y, z: point.z } : null;
+}
+
+function createEnergyDebugState(
+  network: FlywheelEnergyNetwork,
+  diagnostics: readonly string[],
+  sourceWorld: { x: number; y: number; z: number } | null,
+  destinationWorld: { x: number; y: number; z: number } | null,
+  sourceLocal: { x: number; y: number; z: number } | null,
+  destinationLocal: { x: number; y: number; z: number } | null,
+  activeNodeCount: number,
+  detailLevel: SceneDetailPolicy['level']
+): FlywheelDebugState['energy'] {
+  const snapshot = network.getSnapshot();
+  return {
+    targetCount: snapshot.targetCount,
+    missingTargetDiagnostics: [...diagnostics],
+    cycleCount: snapshot.cycleCount,
+    direction: snapshot.direction,
+    selectedTargetId: snapshot.selectedTargetId,
+    phase: snapshot.phase,
+    visibleWindowStart: snapshot.visibleWindowStart,
+    visibleWindowEnd: snapshot.visibleWindowEnd,
+    incomingCompletedCount: snapshot.incomingCompletedCount,
+    outgoingCompletedCount: snapshot.outgoingCompletedCount,
+    sourceWorldPosition: copyDebugPoint(sourceWorld),
+    destinationWorldPosition: copyDebugPoint(destinationWorld),
+    sourceLocalPosition: copyDebugPoint(sourceLocal),
+    destinationLocalPosition: copyDebugPoint(destinationLocal),
+    activeNodeCount,
+    detailLevel,
+    pulseScale: getPulseScale(),
+    flickerScale: getFlickerScale(),
+  };
 }

--- a/src/scene/structures/flywheelEnergyNetwork.ts
+++ b/src/scene/structures/flywheelEnergyNetwork.ts
@@ -1,0 +1,254 @@
+export type FlywheelEnergyDirection = 'incoming' | 'outgoing';
+
+export interface FlywheelEnergyPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface FlywheelEnergyTarget {
+  poiId: string;
+  label: string;
+  worldPosition: FlywheelEnergyPoint;
+  floorId?: 'ground' | 'upper';
+}
+
+export interface FlywheelEnergyTransfer {
+  direction: FlywheelEnergyDirection;
+  targetPoiId: string;
+  phase: number;
+  duration: number;
+  window: number;
+  strength: number;
+}
+
+export interface FlywheelEnergyNetworkSnapshot {
+  seed: number;
+  targetCount: number;
+  cycleCount: number;
+  direction: FlywheelEnergyDirection | null;
+  selectedTargetId: string | null;
+  phase: number;
+  visibleWindowStart: number;
+  visibleWindowEnd: number;
+  incomingCompletedCount: number;
+  outgoingCompletedCount: number;
+  activeTransfer: FlywheelEnergyTransfer | null;
+  targets: FlywheelEnergyTarget[];
+}
+
+export const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
+export const FLYWHEEL_INCOMING_PER_CYCLE = 5;
+export const FLYWHEEL_INCOMING_WINDOW = 0.1;
+export const FLYWHEEL_OUTGOING_WINDOW = 0.16;
+export const FLYWHEEL_INCOMING_DURATION = 2.4;
+export const FLYWHEEL_OUTGOING_DURATION = 2.0;
+export const FLYWHEEL_INCOMING_STRENGTH = 1;
+export const FLYWHEEL_OUTGOING_STRENGTH = 1.65;
+
+const copyPoint = (point: FlywheelEnergyPoint): FlywheelEnergyPoint => ({
+  x: point.x,
+  y: point.y,
+  z: point.z,
+});
+
+const copyTarget = (target: FlywheelEnergyTarget): FlywheelEnergyTarget => ({
+  poiId: target.poiId,
+  label: target.label,
+  worldPosition: copyPoint(target.worldPosition),
+  floorId: target.floorId,
+});
+
+function normalizeSeed(seed: number | string): number {
+  if (typeof seed === 'number' && Number.isFinite(seed)) return seed >>> 0;
+  const text = String(seed);
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function nextRandom(state: number): [number, number] {
+  let next = state + 0x6d2b79f5;
+  next = Math.imul(next ^ (next >>> 15), next | 1);
+  next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+  return [((next ^ (next >>> 14)) >>> 0) / 4294967296, next >>> 0];
+}
+
+export function filterFlywheelEnergyTargets(
+  targets: readonly FlywheelEnergyTarget[]
+): FlywheelEnergyTarget[] {
+  return targets
+    .filter(
+      (target) =>
+        target.poiId !== FLYWHEEL_POI_ID &&
+        target.floorId !== 'upper' &&
+        Number.isFinite(target.worldPosition.x) &&
+        Number.isFinite(target.worldPosition.y) &&
+        Number.isFinite(target.worldPosition.z)
+    )
+    .map(copyTarget);
+}
+
+export function getFlywheelEnergyVisibleWindow(
+  transfer: FlywheelEnergyTransfer
+): {
+  start: number;
+  end: number;
+} {
+  const half = transfer.window / 2;
+  return {
+    start: Math.max(0, transfer.phase - half),
+    end: Math.min(1, transfer.phase + half),
+  };
+}
+
+export function sampleFlywheelEnergyArc(
+  source: FlywheelEnergyPoint,
+  destination: FlywheelEnergyPoint,
+  t: number
+): FlywheelEnergyPoint {
+  const clamped = Math.max(0, Math.min(1, t));
+  const distance = Math.hypot(
+    destination.x - source.x,
+    destination.z - source.z
+  );
+  const lift = Math.min(2.1, Math.max(0.75, distance * 0.18));
+  const mid = {
+    x: (source.x + destination.x) / 2,
+    y: Math.max(source.y, destination.y) + lift,
+    z: (source.z + destination.z) / 2,
+  };
+  const a = (1 - clamped) * (1 - clamped);
+  const b = 2 * (1 - clamped) * clamped;
+  const c = clamped * clamped;
+  return {
+    x: a * source.x + b * mid.x + c * destination.x,
+    y: a * source.y + b * mid.y + c * destination.y,
+    z: a * source.z + b * mid.z + c * destination.z,
+  };
+}
+
+export class FlywheelEnergyNetwork {
+  private targets: FlywheelEnergyTarget[] = [];
+  private randomState: number;
+  private lastTargetId: string | null = null;
+  private incomingCompletedCount = 0;
+  private outgoingCompletedCount = 0;
+  private cycleCount = 0;
+  private active: FlywheelEnergyTransfer | null = null;
+
+  constructor(seed: number | string = 'flywheel-energy-network') {
+    this.randomState = normalizeSeed(seed);
+  }
+
+  setTargets(targets: readonly FlywheelEnergyTarget[]): void {
+    this.targets = filterFlywheelEnergyTargets(targets);
+    if (
+      this.active &&
+      !this.targets.some((target) => target.poiId === this.active?.targetPoiId)
+    ) {
+      this.active = null;
+    }
+  }
+
+  update(delta: number): FlywheelEnergyTransfer | null {
+    if (this.targets.length === 0) return null;
+    if (!this.active) this.active = this.createTransfer();
+    if (!this.active) return null;
+    this.active.phase += Math.max(0, delta) / this.active.duration;
+    while (this.active.phase >= 1) {
+      this.completeActiveTransfer();
+      this.active = this.targets.length > 0 ? this.createTransfer() : null;
+      if (!this.active) break;
+    }
+    return this.getActiveTransfer();
+  }
+
+  getActiveTransfer(): FlywheelEnergyTransfer | null {
+    return this.active ? { ...this.active } : null;
+  }
+
+  getTarget(poiId: string): FlywheelEnergyTarget | null {
+    const target = this.targets.find((candidate) => candidate.poiId === poiId);
+    return target ? copyTarget(target) : null;
+  }
+
+  getSnapshot(): FlywheelEnergyNetworkSnapshot {
+    const active = this.getActiveTransfer();
+    const window = active
+      ? getFlywheelEnergyVisibleWindow(active)
+      : { start: 0, end: 0 };
+    return {
+      seed: this.randomState,
+      targetCount: this.targets.length,
+      cycleCount: this.cycleCount,
+      direction: active?.direction ?? null,
+      selectedTargetId: active?.targetPoiId ?? null,
+      phase: active?.phase ?? 0,
+      visibleWindowStart: window.start,
+      visibleWindowEnd: window.end,
+      incomingCompletedCount: this.incomingCompletedCount,
+      outgoingCompletedCount: this.outgoingCompletedCount,
+      activeTransfer: active,
+      targets: this.targets.map(copyTarget),
+    };
+  }
+
+  private createTransfer(): FlywheelEnergyTransfer | null {
+    const target = this.pickTarget();
+    if (!target) return null;
+    const direction =
+      this.incomingCompletedCount < FLYWHEEL_INCOMING_PER_CYCLE
+        ? 'incoming'
+        : 'outgoing';
+    return {
+      direction,
+      targetPoiId: target.poiId,
+      phase: 0,
+      duration:
+        direction === 'incoming'
+          ? FLYWHEEL_INCOMING_DURATION
+          : FLYWHEEL_OUTGOING_DURATION,
+      window:
+        direction === 'incoming'
+          ? FLYWHEEL_INCOMING_WINDOW
+          : FLYWHEEL_OUTGOING_WINDOW,
+      strength:
+        direction === 'incoming'
+          ? FLYWHEEL_INCOMING_STRENGTH
+          : FLYWHEEL_OUTGOING_STRENGTH,
+    };
+  }
+
+  private pickTarget(): FlywheelEnergyTarget | null {
+    if (this.targets.length === 0) return null;
+    let index = 0;
+    [index, this.randomState] = this.nextIndex(this.targets.length);
+    let target = this.targets[index];
+    if (this.targets.length > 1 && target.poiId === this.lastTargetId) {
+      index = (index + 1) % this.targets.length;
+      target = this.targets[index];
+    }
+    this.lastTargetId = target.poiId;
+    return target;
+  }
+
+  private nextIndex(length: number): [number, number] {
+    const [value, state] = nextRandom(this.randomState);
+    return [Math.floor(value * length), state];
+  }
+
+  private completeActiveTransfer(): void {
+    if (!this.active) return;
+    if (this.active.direction === 'incoming') {
+      this.incomingCompletedCount += 1;
+      return;
+    }
+    this.outgoingCompletedCount += 1;
+    this.incomingCompletedCount = 0;
+    this.cycleCount += 1;
+  }
+}

--- a/src/tests/flywheelEnergyNetwork.test.ts
+++ b/src/tests/flywheelEnergyNetwork.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLYWHEEL_INCOMING_PER_CYCLE,
+  FLYWHEEL_INCOMING_WINDOW,
+  FLYWHEEL_OUTGOING_STRENGTH,
+  FLYWHEEL_OUTGOING_WINDOW,
+  FlywheelEnergyNetwork,
+  filterFlywheelEnergyTargets,
+  getFlywheelEnergyVisibleWindow,
+  sampleFlywheelEnergyArc,
+  type FlywheelEnergyTarget,
+} from '../scene/structures/flywheelEnergyNetwork';
+
+const targets: FlywheelEnergyTarget[] = [
+  {
+    poiId: 'alpha',
+    label: 'Alpha',
+    floorId: 'ground',
+    worldPosition: { x: 0, y: 0, z: 0 },
+  },
+  {
+    poiId: 'beta',
+    label: 'Beta',
+    floorId: 'ground',
+    worldPosition: { x: 2, y: 0, z: 0 },
+  },
+  {
+    poiId: 'gamma',
+    label: 'Gamma',
+    floorId: 'ground',
+    worldPosition: { x: 4, y: 0, z: 0 },
+  },
+  {
+    poiId: 'flywheel-studio-flywheel',
+    label: 'Flywheel',
+    floorId: 'ground',
+    worldPosition: { x: 6, y: 0, z: 0 },
+  },
+  {
+    poiId: 'upper',
+    label: 'Upper',
+    floorId: 'upper',
+    worldPosition: { x: 8, y: 4, z: 0 },
+  },
+];
+
+function sequence(seed: string): string[] {
+  const network = new FlywheelEnergyNetwork(seed);
+  network.setTargets(targets);
+  return Array.from({ length: 8 }, () => {
+    const transfer = network.update(0.01);
+    const id = `${transfer?.direction}:${transfer?.targetPoiId}`;
+    network.update(10);
+    return id;
+  });
+}
+
+describe('FlywheelEnergyNetwork', () => {
+  it('selects deterministic seeded target sequences without mutating input', () => {
+    const before = structuredClone(targets);
+    expect(sequence('same-seed')).toEqual(sequence('same-seed'));
+    expect(sequence('same-seed')).not.toEqual(sequence('different-seed'));
+    expect(targets).toEqual(before);
+  });
+
+  it('filters Flywheel and upper-floor targets', () => {
+    expect(
+      filterFlywheelEnergyTargets(targets).map((target) => target.poiId)
+    ).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('runs exactly five incoming transfers before one stronger outgoing transfer', () => {
+    const network = new FlywheelEnergyNetwork('cycle');
+    network.setTargets(targets);
+    const transfers = Array.from(
+      { length: FLYWHEEL_INCOMING_PER_CYCLE + 1 },
+      () => {
+        const transfer = network.update(0.01);
+        network.update(10);
+        return transfer;
+      }
+    );
+    expect(
+      transfers
+        .slice(0, 5)
+        .every((transfer) => transfer?.direction === 'incoming')
+    ).toBe(true);
+    expect(transfers[5]?.direction).toBe('outgoing');
+    expect(transfers[5]?.window).toBeGreaterThan(FLYWHEEL_INCOMING_WINDOW);
+    expect(transfers[5]?.strength).toBe(FLYWHEEL_OUTGOING_STRENGTH);
+    expect(transfers[5]?.window).toBe(FLYWHEEL_OUTGOING_WINDOW);
+  });
+
+  it('avoids immediate repeats when alternatives exist and progresses phase', () => {
+    const network = new FlywheelEnergyNetwork('no-repeat');
+    network.setTargets(targets);
+    let previous: string | null = null;
+    for (let i = 0; i < 6; i += 1) {
+      const transfer = network.update(0.5);
+      expect(transfer?.phase).toBeGreaterThan(0);
+      expect(transfer?.targetPoiId).not.toBe(previous);
+      previous = transfer?.targetPoiId ?? null;
+      network.update(10);
+    }
+  });
+
+  it('reports a short incoming visible window and samples raised parabolic arcs', () => {
+    const network = new FlywheelEnergyNetwork('window');
+    network.setTargets(targets);
+    const transfer = network.update(0.5);
+    expect(transfer?.window).toBeCloseTo(0.1);
+    const visible = getFlywheelEnergyVisibleWindow(transfer!);
+    expect(visible.end - visible.start).toBeLessThanOrEqual(0.11);
+    const middle = sampleFlywheelEnergyArc(
+      { x: 0, y: 0.5, z: 0 },
+      { x: 4, y: 0.5, z: 0 },
+      0.5
+    );
+    expect(middle.y).toBeGreaterThan(0.5);
+  });
+});

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -202,6 +202,85 @@ describe('createFlywheelShowpiece', () => {
     build.dispose();
   });
 
+  it('renders one bounded moving energy packet from runtime targets', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 10, z: -2 },
+      orientationRadians: Math.PI / 4,
+      roomBounds,
+      detailPolicy: SCENE_DETAIL_POLICIES.balanced,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'jobbot-studio-terminal',
+        label: 'Jobbot',
+        floorId: 'ground',
+        worldPosition: { x: 12, y: 0, z: -2 },
+      },
+    ]);
+    build.update({
+      elapsed: 1,
+      delta: 0.5,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const state = build.getDebugState().energy;
+    expect(state.targetCount).toBe(1);
+    expect(state.direction).toBe('incoming');
+    expect(state.selectedTargetId).toBe('jobbot-studio-terminal');
+    expect(
+      state.visibleWindowEnd - state.visibleWindowStart
+    ).toBeLessThanOrEqual(0.11);
+    expect(state.activeNodeCount).toBeGreaterThan(0);
+    expect(state.activeNodeCount).toBeLessThanOrEqual(10);
+    const packetGroups = build.group.children.filter(
+      (child) => child.name === 'FlywheelEnergyTransferPacket' && child.visible
+    );
+    expect(packetGroups).toHaveLength(1);
+    expect(state.sourceWorldPosition?.x).toBeCloseTo(12);
+    expect(state.destinationWorldPosition?.x).toBeGreaterThan(10);
+    build.dispose();
+  });
+
+  it('fails open with diagnostics for filtered targets and preserves reduced semantics', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'flywheel-studio-flywheel',
+        label: 'Flywheel',
+        floorId: 'ground',
+        worldPosition: { x: 0, y: 0, z: 0 },
+      },
+      {
+        poiId: 'upper-poi',
+        label: 'Upper',
+        floorId: 'upper',
+        worldPosition: { x: 1, y: 4, z: 1 },
+      },
+      {
+        poiId: 'ground-poi',
+        label: 'Ground',
+        floorId: 'ground',
+        worldPosition: { x: 2, y: 0, z: 0 },
+      },
+    ]);
+    build.update({
+      elapsed: 1,
+      delta: 0.25,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const state = build.getDebugState().energy;
+    expect(state.targetCount).toBe(1);
+    expect(state.missingTargetDiagnostics).toHaveLength(1);
+    expect(state.selectedTargetId).toBe('ground-poi');
+    expect(state.direction).toBe('incoming');
+    build.dispose();
+    build.dispose();
+  });
+
   it('keeps miniature proxy semantics in sync', () => {
     const proxy = MINIATURE_POI_PROXY_REGISTRY['flywheel-studio-flywheel'];
     const names = proxy.primitives.map((primitive) => primitive.name);
@@ -212,6 +291,8 @@ describe('createFlywheelShowpiece', () => {
         'flywheel-crank-arm',
         'flywheel-planetary-gear-cluster',
         'flywheel-energy-port',
+        'flywheel-incoming-arc-hint',
+        'flywheel-outgoing-arc-hint',
       ])
     );
   });


### PR DESCRIPTION
### Motivation
- Implement P6c: add the metaphorical Flywheel energy-transfer layer (glowing blue parabolic arcs) that deterministically cycles five incoming transfers into one outgoing transfer while preserving the physical crank/gear/flywheel motion. 
- Keep the network deterministic, ground-floor-only, performant (pooled geometry), and accessible (pulse/flicker scaling) per the design doc.

### Description
- Add a pure deterministic energy network module `src/scene/structures/flywheelEnergyNetwork.ts` with seeded PRNG, target filtering, 5-in/1-out cycle state, visible-window helpers, parabolic arc sampling, repeat avoidance, and debug snapshots. 
- Integrate runtime target resolution in `src/main.ts` using `poiInstances`, the scene floor resolver, `resolvePoiVisualAnchor(...)`, and `Object3D.getWorldPosition(...)`, then call `flywheelShowpiece.setEnergyTargets(...)` after anchors are registered. 
- Extend the Flywheel showpiece in `src/scene/structures/flywheel.ts` to expose `setEnergyTargets(...)`, render a single pooled `FlywheelEnergyTransferPacket` (preallocated nodes/connectors), sample/move a short visible window along a parabolic arc, apply accessibility scales via `getPulseScale()`/`getFlickerScale()`, and surface expanded debug state via `getDebugState().energy`. 
- Update the miniature proxy with static incoming/outgoing arc hints, regenerate the miniature manifest, add `src/tests/flywheelEnergyNetwork.test.ts`, and extend `src/tests/flywheelShowpiece.test.ts` to cover runtime integration and diagnostics; document final implementation in `docs/architecture/flywheel-energy-transfer.md`.

### Testing
- Ran focused unit and integration tests: `npm run test:ci -- src/tests/flywheelEnergyNetwork.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts` — passed. 
- Ran additional scene checks: `npm run test:ci -- src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts` — passed. 
- Ran lint/build/docs/smoke flows: `npm run lint`, `npm run build`, `npm run docs:check`, `npm run smoke`, `npm run format:check` — all passed (docs link-check produced external fetch warnings but completed). 
- Miniature manifest updated and validated with `npm run miniature:manifest:update` and `npm run miniature:check` — passed. 
- Type-check: `npm run typecheck` still reports unrelated pre-existing project-wide TypeScript errors; no Flywheel-related type errors were introduced. 
- Playwright screenshot attempt for visual verification failed in this environment because Playwright browsers were not installed (`npx playwright install` required), so headless screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f2cc400832f9b6a121774a1e13c)