### PR TITLE
✨ : – add Flywheel energy-transfer arcs

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -723,3 +723,50 @@ gearbox, and energy port without individual tooth blocks. The core update runs
 every rendered frame, while decorative glow updates can still be throttled by the
 scene detail controller. Cross-POI blue transfer arcs remain future P6c scope and
 are not implemented here.
+
+## 10. P6c implementation notes
+
+P6c implements the transfer packet in `src/scene/structures/flywheelEnergyNetwork.ts`
+and renders it from `src/scene/structures/flywheel.ts`. The network module is pure:
+it owns seeded selection, the five-in/one-out cycle, active transfer phase, visible
+window math, and parabolic sampling without importing DOM APIs or Three.js scene
+objects.
+
+Runtime targets are resolved in `src/main.ts` by `resolveFlywheelEnergyTargets(...)`
+after ground-floor structures and visual anchors are registered. The resolver uses
+the scene floor resolver, excludes `flywheel-studio-flywheel`, prefers
+`resolvePoiVisualAnchor(...)`, falls back to the POI group with diagnostics, and
+copies `Object3D.getWorldPosition(...)` into `FlywheelEnergyTarget` records. Missing
+optional anchors therefore fail open and do not block immersive mode.
+
+Selection uses `FLYWHEEL_ENERGY_NETWORK_SEED` with a local seeded random source; no
+runtime `Math.random()` is used by the network. Eligible ground-floor POIs are
+chosen deterministically while avoiding immediate repeats when more than one target
+is available. The cycle emits five incoming transfers followed by one outgoing
+transfer, then resets the incoming count and repeats. Incoming transfers use a
+phase window of `0.10`; outgoing transfers use `0.16`, a shorter duration, and a
+higher strength so the outgoing packet reads brighter and thicker.
+
+Rendering shows only `FlywheelEnergyPacketRoot`, a single moving packet subsection.
+The Flywheel builder preallocates packet node meshes and connector cylinders once;
+updates reposition and rescale that pool along the sampled parabola. It never builds
+per-frame `TubeGeometry`, per-frame materials/geometries, dynamic point lights, or
+an all-arcs spiderweb. Detail policy changes only rendering cost: node count,
+connector visibility, opacity, and decorative intensity. It does not change target
+order, timing, direction, phase, or the five-in/one-out rhythm.
+
+Accessibility scales from `getPulseScale()` and `getFlickerScale()` affect only
+presentation opacity and connector intensity. Reduced pulse/flicker settings do not
+pause transfers, alter targets, or change the cycle semantics. The packet is a
+smooth moving glow with tapered leading/trailing samples and no flashing/strobing.
+
+`FlywheelShowpieceBuild.getDebugState()` now includes an `energy` snapshot with
+target count, diagnostics, cycle count, direction, selected target, phase, visible
+window, completed incoming/outgoing counts, source/destination world and local
+positions, active node count, detail level, and current pulse/flicker scales. The
+snapshot copies arrays and position objects so callers cannot mutate internal state.
+
+The miniature proxy remains static and does not run the energy network. Its manifest
+now includes the physical Flywheel source files plus the energy network source, and
+the proxy includes the heavy wheel, crank, gear cluster, energy port/glow, a thin
+incoming blue arc hint, and a thicker outgoing blue arc hint.

--- a/src/main.ts
+++ b/src/main.ts
@@ -280,6 +280,7 @@ import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
 } from './scene/structures/flywheel';
+import type { FlywheelEnergyTarget } from './scene/structures/flywheelEnergyNetwork';
 import {
   createGabrielSentry,
   type GabrielSentryBuild,
@@ -1135,6 +1136,43 @@ function getLevelFloor(floorId: FloorId) {
   );
   if (!floor) throw new Error(`Portfolio level is missing floor "${floorId}".`);
   return floor;
+}
+
+export function resolveFlywheelEnergyTargets(options: {
+  poiInstances: readonly PoiInstance[];
+  getPoiFloorId: (poi: PoiInstance['definition']) => FloorId;
+  resolvePoiVisualAnchor: typeof import('./scene/poi/visualAnchors').resolvePoiVisualAnchor;
+}): { targets: FlywheelEnergyTarget[]; diagnostics: string[] } {
+  const targets: FlywheelEnergyTarget[] = [];
+  const diagnostics: string[] = [];
+  for (const poi of options.poiInstances) {
+    if (poi.definition.id === 'flywheel-studio-flywheel') continue;
+    if (options.getPoiFloorId(poi.definition) !== 'ground') continue;
+    const anchor = options.resolvePoiVisualAnchor(poi.definition.id);
+    const object = anchor?.object ?? poi.group;
+    if (!anchor) {
+      diagnostics.push(
+        `Missing visual anchor for ${poi.definition.id}; using POI group.`
+      );
+    }
+    try {
+      const worldPosition = object.getWorldPosition(new Vector3());
+      targets.push({
+        poiId: poi.definition.id,
+        label: poi.definition.title,
+        worldPosition: {
+          x: worldPosition.x,
+          y: worldPosition.y,
+          z: worldPosition.z,
+        },
+      });
+    } catch (error) {
+      diagnostics.push(
+        `Failed to resolve Flywheel energy target ${poi.definition.id}: ${String(error)}`
+      );
+    }
+  }
+  return { targets, diagnostics };
 }
 
 const container = document.getElementById('app');
@@ -3391,6 +3429,18 @@ function initializeImmersiveScene(
       'PortfolioMiniatureTableCollider'
     );
     portfolioMiniatureTable = table;
+  }
+
+  if (flywheelShowpiece) {
+    const { targets, diagnostics } = resolveFlywheelEnergyTargets({
+      poiInstances,
+      getPoiFloorId,
+      resolvePoiVisualAnchor,
+    });
+    flywheelShowpiece.setEnergyTargets(targets, diagnostics);
+    if (diagnostics.length > 0) {
+      console.info('[flywheel] energy target diagnostics', diagnostics);
+    }
   }
 
   poiInteractionManager = new PoiInteractionManager(

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "c35e134ca28c1414da7edefdda9afa4c0614d730fb72862516295e77cfc42b6c",
+      "proxyFingerprint": "25c7a3c2f42b6781ce56de165002507c98fc49db1f53a7d69a0bf6180ffba7af",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -574,14 +574,15 @@
         "src/scene/poi/placements.ts",
         "src/scene/poi/registry.ts",
         "src/scene/structures/flywheel.ts",
-        "src/scene/structures/flywheelEnergyContract.ts"
+        "src/scene/structures/flywheelEnergyContract.ts",
+        "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.",
-      "sourceFingerprint": "d3e1970e2658dd17f500590a86ba91d4cf1804d3cf1e2ce5cf614288716582bc",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
-      "metadataFingerprint": "5b6d936a1b778dcba5f2b4f08afff8969f07ad60dc6f9dfe915bf13f5ba02980"
+      "syncRevision": 9,
+      "syncNote": "Adds static incoming/outgoing blue energy arc hints for the implemented transfer layer.",
+      "sourceFingerprint": "fa97c20b4457d94f3f632eee68414d678dea3197b81a92d4818e9b7000aa84ca",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
+      "metadataFingerprint": "8b48e965f94ced80d54bf034ab6b19056c2b7893cd661202f303cd2bdc98c4b6"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -595,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -610,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -625,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -640,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -675,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -690,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -705,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -720,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -735,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "4d75be3d5b82f83b0d8542226960f57b40265068621ce7151d56775d2a8998a0",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,13 +90,14 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 6,
+    syncRevision: 9,
     syncNote:
-      'Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.',
+      'Adds static incoming/outgoing blue energy arc hints for the implemented transfer layer.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
       'src/scene/structures/flywheelEnergyContract.ts',
+      'src/scene/structures/flywheelEnergyNetwork.ts',
     ],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -137,6 +138,28 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         0xd1d5db
       ),
       sphere('flywheel-energy-port', 0.07, [0.56, 0.8, 0.28], 0x38bdf8),
+      {
+        kind: 'tube',
+        name: 'flywheel-thin-incoming-blue-arc-hint',
+        radius: 0.012,
+        points: [
+          [-0.72, 0.48, -0.48],
+          [-0.16, 1.08, -0.16],
+          [0.56, 0.8, 0.28],
+        ],
+        color: 0x60a5fa,
+      },
+      {
+        kind: 'tube',
+        name: 'flywheel-thicker-outgoing-blue-arc-hint',
+        radius: 0.022,
+        points: [
+          [0.56, 0.82, 0.28],
+          [0.1, 1.28, 0.12],
+          [-0.78, 0.62, 0.5],
+        ],
+        color: 0x38bdf8,
+      },
     ],
   },
   'jobbot-studio-terminal': {

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -8,11 +8,17 @@ import {
   MeshBasicMaterial,
   MeshStandardMaterial,
   Object3D,
+  Quaternion,
   SphereGeometry,
+  Vector3,
   TorusGeometry,
 } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
+import {
+  getFlickerScale,
+  getPulseScale,
+} from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
@@ -40,6 +46,12 @@ import {
   getFlywheelCarrierAngle,
   getFlywheelPlanetLocalSpin,
 } from './flywheelEnergyContract';
+import {
+  createFlywheelEnergyNetwork,
+  getFlywheelEnergyVisibleWindow,
+  sampleFlywheelEnergyArc,
+  type FlywheelEnergyTarget,
+} from './flywheelEnergyNetwork';
 
 export interface FlywheelShowpieceBuild {
   group: Group;
@@ -50,6 +62,10 @@ export interface FlywheelShowpieceBuild {
     emphasis: number;
     runDecorativeEffects?: boolean;
   }): void;
+  setEnergyTargets(
+    targets: readonly FlywheelEnergyTarget[],
+    diagnostics?: readonly string[]
+  ): void;
   getDebugState(): FlywheelDebugState;
   dispose(): void;
 }
@@ -71,6 +87,25 @@ export interface FlywheelDebugState {
   planetLocalSpin: number;
   torqueRatio: number;
   triangleCount: number;
+  energy: {
+    targetCount: number;
+    missingTargetDiagnostics: string[];
+    cycleCount: number;
+    direction: 'incoming' | 'outgoing';
+    selectedTargetId: string;
+    phase: number;
+    visibleWindow: { start: number; end: number };
+    incomingCompletedCount: number;
+    outgoingCompletedCount: number;
+    sourceWorldPosition: { x: number; y: number; z: number } | null;
+    destinationWorldPosition: { x: number; y: number; z: number } | null;
+    sourceLocalPosition: { x: number; y: number; z: number } | null;
+    destinationLocalPosition: { x: number; y: number; z: number } | null;
+    activeNodeCount: number;
+    detailLevel: string;
+    pulseScale: number;
+    flickerScale: number;
+  };
 }
 
 const MATERIALS = {
@@ -401,6 +436,88 @@ export function createFlywheelShowpiece(
   crankHandle.rotation.x = Math.PI / 2;
   crankGroup.add(crankHandle);
 
+  const energyNetwork = createFlywheelEnergyNetwork();
+  let missingTargetDiagnostics: string[] = [];
+  let resolvedEnergyTargets: FlywheelEnergyTarget[] = [];
+  const energyPacketRoot = new Group();
+  energyPacketRoot.name = 'FlywheelEnergyPacketRoot';
+  group.add(energyPacketRoot);
+  const packetNodeCount =
+    detailPolicy.level === 'cinematic'
+      ? 12
+      : detailPolicy.level === 'balanced'
+        ? 10
+        : detailPolicy.level === 'performance'
+          ? 7
+          : detailPolicy.level === 'low'
+            ? 5
+            : 4;
+  const connectorCount = Math.max(0, packetNodeCount - 1);
+  const packetGeometry = own(
+    new SphereGeometry(1, Math.max(6, cylSeg), Math.max(4, cylSeg / 2))
+  );
+  const connectorGeometry = own(
+    new CylinderGeometry(1, 1, 1, Math.max(5, cylSeg / 2))
+  );
+  const packetMaterial = mat(
+    new MeshBasicMaterial({ color: 0x4dd8ff, transparent: true, opacity: 0 })
+  );
+  const connectorMaterial = mat(
+    new MeshBasicMaterial({ color: 0x38bdf8, transparent: true, opacity: 0 })
+  );
+  const energyNodes: Mesh[] = [];
+  const energyConnectors: Mesh[] = [];
+  for (let i = 0; i < packetNodeCount; i += 1) {
+    const node = new Mesh(packetGeometry, packetMaterial.clone());
+    ownedMaterials.add(node.material as MeshBasicMaterial);
+    node.name = `FlywheelEnergyPacketNode-${i}`;
+    node.visible = false;
+    energyPacketRoot.add(node);
+    energyNodes.push(node);
+  }
+  for (let i = 0; i < connectorCount; i += 1) {
+    const connector = new Mesh(connectorGeometry, connectorMaterial.clone());
+    ownedMaterials.add(connector.material as MeshBasicMaterial);
+    connector.name = `FlywheelEnergyPacketConnector-${i}`;
+    connector.visible = false;
+    energyPacketRoot.add(connector);
+    energyConnectors.push(connector);
+  }
+  const localPoint = new Vector3();
+  const sourceLocal = new Vector3();
+  const destinationLocal = new Vector3();
+  const connectorMid = new Vector3();
+  const connectorDelta = new Vector3();
+  const connectorQuat = new Quaternion();
+  const yAxis = new Vector3(0, 1, 0);
+  let energyDebug = {
+    targetCount: 0,
+    missingTargetDiagnostics: [] as string[],
+    cycleCount: 0,
+    direction: 'incoming' as 'incoming' | 'outgoing',
+    selectedTargetId: '',
+    phase: 0,
+    visibleWindow: { start: 0, end: 0 },
+    incomingCompletedCount: 0,
+    outgoingCompletedCount: 0,
+    sourceWorldPosition: null as { x: number; y: number; z: number } | null,
+    destinationWorldPosition: null as {
+      x: number;
+      y: number;
+      z: number;
+    } | null,
+    sourceLocalPosition: null as { x: number; y: number; z: number } | null,
+    destinationLocalPosition: null as {
+      x: number;
+      y: number;
+      z: number;
+    } | null,
+    activeNodeCount: 0,
+    detailLevel: detailPolicy.level,
+    pulseScale: 1,
+    flickerScale: 1,
+  };
+
   const port = mesh(
     'FlywheelEnergyPort',
     new SphereGeometry(
@@ -430,9 +547,139 @@ export function createFlywheelShowpiece(
     planetLocalSpin: 0,
     torqueRatio: FLYWHEEL_TORQUE_RATIO,
     triangleCount: countTriangles(group),
+    energy: energyDebug,
   };
   let disposed = false;
   let crankAngle = 0;
+
+  const toPlain = (v: Vector3) => ({ x: v.x, y: v.y, z: v.z });
+  const hideEnergyPacket = () => {
+    energyNodes.forEach((node) => {
+      node.visible = false;
+    });
+    energyConnectors.forEach((connector) => {
+      connector.visible = false;
+    });
+  };
+  const updateEnergyPacket = (delta: number) => {
+    const transfer = energyNetwork.update(delta);
+    const target = energyNetwork.getTargetByPoiId(transfer.targetPoiId);
+    const networkDebug = energyNetwork.getDebugState();
+    const pulseScale = getPulseScale();
+    const flickerScale = getFlickerScale();
+    if (!target) {
+      hideEnergyPacket();
+      energyDebug = {
+        ...energyDebug,
+        ...networkDebug,
+        direction: transfer.direction,
+        selectedTargetId: transfer.targetPoiId,
+        missingTargetDiagnostics: [...missingTargetDiagnostics],
+        activeNodeCount: 0,
+        pulseScale,
+        flickerScale,
+      };
+      return;
+    }
+    const portWorld = port.getWorldPosition(new Vector3());
+    const liftedTarget = {
+      x: target.worldPosition.x,
+      y: Math.max(target.worldPosition.y + 1.1, 1.1),
+      z: target.worldPosition.z,
+    };
+    const liftedPort = { x: portWorld.x, y: portWorld.y, z: portWorld.z };
+    const sourceWorld =
+      transfer.direction === 'incoming' ? liftedTarget : liftedPort;
+    const destinationWorld =
+      transfer.direction === 'incoming' ? liftedPort : liftedTarget;
+    sourceLocal.copy(
+      group.worldToLocal(
+        new Vector3(sourceWorld.x, sourceWorld.y, sourceWorld.z)
+      )
+    );
+    destinationLocal.copy(
+      group.worldToLocal(
+        new Vector3(destinationWorld.x, destinationWorld.y, destinationWorld.z)
+      )
+    );
+    const visibleWindow = getFlywheelEnergyVisibleWindow(transfer);
+    const activeNodes = Math.min(
+      packetNodeCount,
+      Math.max(2, Math.ceil((packetNodeCount * transfer.window) / 0.16))
+    );
+    const nodePositions: Vector3[] = [];
+    for (let i = 0; i < packetNodeCount; i += 1) {
+      const node = energyNodes[i];
+      if (i >= activeNodes) {
+        node.visible = false;
+        continue;
+      }
+      const denom = Math.max(1, activeNodes - 1);
+      const u = i / denom;
+      const t =
+        visibleWindow.start + (visibleWindow.end - visibleWindow.start) * u;
+      const sampled = sampleFlywheelEnergyArc(sourceWorld, destinationWorld, t);
+      localPoint.copy(
+        group.worldToLocal(new Vector3(sampled.x, sampled.y, sampled.z))
+      );
+      node.position.copy(localPoint);
+      const taper = Math.sin(Math.PI * u);
+      const radius =
+        (0.035 + 0.035 * transfer.strength) * (0.75 + taper * 0.45);
+      node.scale.setScalar(radius);
+      (node.material as MeshBasicMaterial).opacity =
+        (0.2 + taper * 0.48) * transfer.strength * (0.7 + 0.3 * pulseScale);
+      node.visible = true;
+      nodePositions.push(node.position.clone());
+    }
+    for (let i = 0; i < connectorCount; i += 1) {
+      const connector = energyConnectors[i];
+      if (
+        i >= nodePositions.length - 1 ||
+        (!detailPolicy.effects.decorativeHalos &&
+          detailPolicy.level === 'micro')
+      ) {
+        connector.visible = false;
+        continue;
+      }
+      connectorDelta.copy(nodePositions[i + 1]).sub(nodePositions[i]);
+      const length = connectorDelta.length();
+      connectorMid
+        .copy(nodePositions[i])
+        .add(nodePositions[i + 1])
+        .multiplyScalar(0.5);
+      connector.position.copy(connectorMid);
+      connectorQuat.setFromUnitVectors(yAxis, connectorDelta.normalize());
+      connector.quaternion.copy(connectorQuat);
+      connector.scale.set(
+        0.015 * transfer.strength,
+        length,
+        0.015 * transfer.strength
+      );
+      (connector.material as MeshBasicMaterial).opacity =
+        0.18 * transfer.strength * flickerScale;
+      connector.visible = true;
+    }
+    energyDebug = {
+      targetCount: networkDebug.targetCount,
+      missingTargetDiagnostics: [...missingTargetDiagnostics],
+      cycleCount: networkDebug.cycleCount,
+      direction: transfer.direction,
+      selectedTargetId: transfer.targetPoiId,
+      phase: transfer.phase,
+      visibleWindow,
+      incomingCompletedCount: networkDebug.incomingCompletedCount,
+      outgoingCompletedCount: networkDebug.outgoingCompletedCount,
+      sourceWorldPosition: { ...sourceWorld },
+      destinationWorldPosition: { ...destinationWorld },
+      sourceLocalPosition: toPlain(sourceLocal),
+      destinationLocalPosition: toPlain(destinationLocal),
+      activeNodeCount: activeNodes,
+      detailLevel: detailPolicy.level,
+      pulseScale,
+      flickerScale,
+    };
+  };
 
   return {
     group,
@@ -456,6 +703,7 @@ export function createFlywheelShowpiece(
       planetGears.forEach((planet) => {
         planet.rotation.z = planetLocalSpin;
       });
+      updateEnergyPacket(Math.max(0, delta));
       if (runDecorativeEffects) {
         glow.opacity =
           0.45 + Math.min(0.4, emphasis * 0.35) + Math.sin(elapsed * 2) * 0.05;
@@ -468,9 +716,28 @@ export function createFlywheelShowpiece(
         planetLocalSpin,
         torqueRatio: FLYWHEEL_TORQUE_RATIO,
         triangleCount: state.triangleCount,
+        energy: {
+          ...energyDebug,
+          missingTargetDiagnostics: [...energyDebug.missingTargetDiagnostics],
+        },
       };
     },
-    getDebugState: () => ({ ...state }),
+    setEnergyTargets(targets, diagnostics = []) {
+      resolvedEnergyTargets = targets.map((target) => ({
+        poiId: target.poiId,
+        label: target.label,
+        worldPosition: { ...target.worldPosition },
+      }));
+      missingTargetDiagnostics = [...diagnostics];
+      energyNetwork.setTargets(resolvedEnergyTargets);
+    },
+    getDebugState: () => ({
+      ...state,
+      energy: {
+        ...energyDebug,
+        missingTargetDiagnostics: [...energyDebug.missingTargetDiagnostics],
+      },
+    }),
     dispose() {
       if (disposed) return;
       disposed = true;

--- a/src/scene/structures/flywheelEnergyNetwork.ts
+++ b/src/scene/structures/flywheelEnergyNetwork.ts
@@ -1,0 +1,245 @@
+export type FlywheelEnergyDirection = 'incoming' | 'outgoing';
+
+export interface FlywheelEnergyTarget {
+  poiId: string;
+  label: string;
+  worldPosition: { x: number; y: number; z: number };
+}
+
+export interface FlywheelEnergyTransfer {
+  direction: FlywheelEnergyDirection;
+  targetPoiId: string;
+  phase: number;
+  duration: number;
+  window: number;
+  strength: number;
+}
+
+export interface FlywheelEnergyNetworkDebugState
+  extends FlywheelEnergyTransfer {
+  targetCount: number;
+  cycleCount: number;
+  incomingCompletedCount: number;
+  outgoingCompletedCount: number;
+  visibleWindow: { start: number; end: number };
+  targetSequence: string[];
+}
+
+export const FLYWHEEL_ENERGY_POI_ID = 'flywheel-studio-flywheel';
+export const FLYWHEEL_INCOMING_PER_CYCLE = 5;
+export const FLYWHEEL_INCOMING_WINDOW = 0.1;
+export const FLYWHEEL_OUTGOING_WINDOW = 0.16;
+export const FLYWHEEL_INCOMING_DURATION = 2.8;
+export const FLYWHEEL_OUTGOING_DURATION = 2.35;
+export const FLYWHEEL_INCOMING_STRENGTH = 1;
+export const FLYWHEEL_OUTGOING_STRENGTH = 1.65;
+export const FLYWHEEL_ENERGY_NETWORK_SEED = 'flywheel-energy-network:v1';
+
+export function createFlywheelSeededRandom(seed: string): () => number {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return () => {
+    hash += 0x6d2b79f5;
+    let t = hash;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function normalizeFlywheelEnergyTargets(
+  targets: readonly FlywheelEnergyTarget[]
+): FlywheelEnergyTarget[] {
+  return targets
+    .filter((target) => target.poiId !== FLYWHEEL_ENERGY_POI_ID)
+    .map((target) => ({
+      poiId: target.poiId,
+      label: target.label,
+      worldPosition: { ...target.worldPosition },
+    }));
+}
+
+export class FlywheelEnergyNetworkState {
+  private readonly random: () => number;
+  private targets: FlywheelEnergyTarget[] = [];
+  private transfer: FlywheelEnergyTransfer = this.createTransfer(
+    'incoming',
+    ''
+  );
+  private lastTargetPoiId = '';
+  private incomingCompletedCount = 0;
+  private outgoingCompletedCount = 0;
+  private cycleCount = 0;
+  private targetSequence: string[] = [];
+
+  constructor(
+    options: { seed?: string; targets?: readonly FlywheelEnergyTarget[] } = {}
+  ) {
+    this.random = createFlywheelSeededRandom(
+      options.seed ?? FLYWHEEL_ENERGY_NETWORK_SEED
+    );
+    this.setTargets(options.targets ?? []);
+  }
+
+  setTargets(targets: readonly FlywheelEnergyTarget[]): void {
+    this.targets = normalizeFlywheelEnergyTargets(targets);
+    if (this.targets.length === 0) {
+      this.transfer = this.createTransfer('incoming', '');
+      return;
+    }
+    if (
+      !this.targets.some((target) => target.poiId === this.transfer.targetPoiId)
+    ) {
+      this.transfer = this.createTransfer(
+        this.nextDirection(),
+        this.pickTarget()
+      );
+    }
+  }
+
+  update(delta: number): FlywheelEnergyTransfer {
+    if (this.targets.length === 0) return { ...this.transfer };
+    this.transfer.phase += Math.max(0, delta) / this.transfer.duration;
+    while (this.transfer.phase >= 1) {
+      this.completeTransfer();
+    }
+    return { ...this.transfer };
+  }
+
+  getActiveTransfer(): FlywheelEnergyTransfer {
+    return { ...this.transfer };
+  }
+
+  getTargetByPoiId(poiId: string): FlywheelEnergyTarget | null {
+    const target = this.targets.find((candidate) => candidate.poiId === poiId);
+    return target
+      ? { ...target, worldPosition: { ...target.worldPosition } }
+      : null;
+  }
+
+  getDebugState(): FlywheelEnergyNetworkDebugState {
+    return {
+      ...this.transfer,
+      targetCount: this.targets.length,
+      cycleCount: this.cycleCount,
+      incomingCompletedCount: this.incomingCompletedCount,
+      outgoingCompletedCount: this.outgoingCompletedCount,
+      visibleWindow: getFlywheelEnergyVisibleWindow(this.transfer),
+      targetSequence: [...this.targetSequence],
+    };
+  }
+
+  private completeTransfer(): void {
+    this.lastTargetPoiId = this.transfer.targetPoiId;
+    this.targetSequence.push(this.transfer.targetPoiId);
+    const overflow = this.transfer.phase - 1;
+    if (this.transfer.direction === 'incoming') {
+      this.incomingCompletedCount += 1;
+    } else {
+      this.outgoingCompletedCount += 1;
+      this.incomingCompletedCount = 0;
+      this.cycleCount += 1;
+    }
+    this.transfer = this.createTransfer(
+      this.nextDirection(),
+      this.pickTarget()
+    );
+    this.transfer.phase = overflow;
+  }
+
+  private nextDirection(): FlywheelEnergyDirection {
+    return this.incomingCompletedCount >= FLYWHEEL_INCOMING_PER_CYCLE
+      ? 'outgoing'
+      : 'incoming';
+  }
+
+  private createTransfer(
+    direction: FlywheelEnergyDirection,
+    targetPoiId: string
+  ): FlywheelEnergyTransfer {
+    return {
+      direction,
+      targetPoiId,
+      phase: 0,
+      duration:
+        direction === 'outgoing'
+          ? FLYWHEEL_OUTGOING_DURATION
+          : FLYWHEEL_INCOMING_DURATION,
+      window:
+        direction === 'outgoing'
+          ? FLYWHEEL_OUTGOING_WINDOW
+          : FLYWHEEL_INCOMING_WINDOW,
+      strength:
+        direction === 'outgoing'
+          ? FLYWHEEL_OUTGOING_STRENGTH
+          : FLYWHEEL_INCOMING_STRENGTH,
+    };
+  }
+
+  private pickTarget(): string {
+    if (this.targets.length === 0) return '';
+    const candidates =
+      this.targets.length > 1
+        ? this.targets.filter((target) => target.poiId !== this.lastTargetPoiId)
+        : this.targets;
+    const index =
+      Math.floor(this.random() * candidates.length) % candidates.length;
+    return candidates[index].poiId;
+  }
+}
+
+export function createFlywheelEnergyNetwork(
+  options?: ConstructorParameters<typeof FlywheelEnergyNetworkState>[0]
+): FlywheelEnergyNetworkState {
+  return new FlywheelEnergyNetworkState(options);
+}
+
+export function getFlywheelEnergyVisibleWindow(
+  transfer: FlywheelEnergyTransfer
+): {
+  start: number;
+  end: number;
+} {
+  const half = transfer.window / 2;
+  return {
+    start: Math.max(0, transfer.phase - half),
+    end: Math.min(1, transfer.phase + half),
+  };
+}
+
+export function sampleFlywheelEnergyArc(
+  source: { x: number; y: number; z: number },
+  destination: { x: number; y: number; z: number },
+  t: number
+): { x: number; y: number; z: number } {
+  const clampedT = Math.min(1, Math.max(0, t));
+  const inv = 1 - clampedT;
+  const dx = destination.x - source.x;
+  const dz = destination.z - source.z;
+  const distance = Math.hypot(dx, dz);
+  const control = {
+    x: (source.x + destination.x) / 2,
+    y: Math.min(
+      Math.max(source.y, destination.y) + Math.max(1.2, distance * 0.18),
+      3.25
+    ),
+    z: (source.z + destination.z) / 2,
+  };
+  return {
+    x:
+      inv * inv * source.x +
+      2 * inv * clampedT * control.x +
+      clampedT * clampedT * destination.x,
+    y:
+      inv * inv * source.y +
+      2 * inv * clampedT * control.y +
+      clampedT * clampedT * destination.y,
+    z:
+      inv * inv * source.z +
+      2 * inv * clampedT * control.z +
+      clampedT * clampedT * destination.z,
+  };
+}

--- a/src/tests/flywheelEnergyNetwork.test.ts
+++ b/src/tests/flywheelEnergyNetwork.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLYWHEEL_ENERGY_POI_ID,
+  FLYWHEEL_INCOMING_DURATION,
+  FLYWHEEL_INCOMING_PER_CYCLE,
+  FLYWHEEL_INCOMING_WINDOW,
+  createFlywheelEnergyNetwork,
+  normalizeFlywheelEnergyTargets,
+} from '../scene/structures/flywheelEnergyNetwork';
+
+const targets = [
+  { poiId: 'a', label: 'A', worldPosition: { x: 1, y: 0, z: 1 } },
+  { poiId: 'b', label: 'B', worldPosition: { x: 2, y: 0, z: 2 } },
+  { poiId: 'c', label: 'C', worldPosition: { x: 3, y: 0, z: 3 } },
+  {
+    poiId: FLYWHEEL_ENERGY_POI_ID,
+    label: 'Flywheel',
+    worldPosition: { x: 0, y: 0, z: 0 },
+  },
+];
+
+function completeCurrent(
+  network: ReturnType<typeof createFlywheelEnergyNetwork>
+) {
+  const duration = network.getActiveTransfer().duration;
+  network.update(duration + 0.001);
+}
+
+describe('FlywheelEnergyNetworkState', () => {
+  it('selects deterministic target sequences for the same seed', () => {
+    const a = createFlywheelEnergyNetwork({ seed: 'same', targets });
+    const b = createFlywheelEnergyNetwork({ seed: 'same', targets });
+    const seqA: string[] = [];
+    const seqB: string[] = [];
+    for (let i = 0; i < 8; i += 1) {
+      seqA.push(a.getActiveTransfer().targetPoiId);
+      seqB.push(b.getActiveTransfer().targetPoiId);
+      completeCurrent(a);
+      completeCurrent(b);
+    }
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('uses different seeded orders when possible', () => {
+    const a = createFlywheelEnergyNetwork({ seed: 'alpha', targets });
+    const b = createFlywheelEnergyNetwork({ seed: 'beta', targets });
+    const seqA: string[] = [];
+    const seqB: string[] = [];
+    for (let i = 0; i < 8; i += 1) {
+      seqA.push(a.getActiveTransfer().targetPoiId);
+      seqB.push(b.getActiveTransfer().targetPoiId);
+      completeCurrent(a);
+      completeCurrent(b);
+    }
+    expect(seqA).not.toEqual(seqB);
+  });
+
+  it('runs exactly five incoming transfers before one stronger outgoing transfer', () => {
+    const network = createFlywheelEnergyNetwork({ seed: 'cycle', targets });
+    const directions: string[] = [];
+    const windows: number[] = [];
+    const strengths: number[] = [];
+    for (let i = 0; i < FLYWHEEL_INCOMING_PER_CYCLE + 1; i += 1) {
+      const transfer = network.getActiveTransfer();
+      directions.push(transfer.direction);
+      windows.push(transfer.window);
+      strengths.push(transfer.strength);
+      completeCurrent(network);
+    }
+    expect(directions).toEqual([
+      'incoming',
+      'incoming',
+      'incoming',
+      'incoming',
+      'incoming',
+      'outgoing',
+    ]);
+    expect(windows[0]).toBeCloseTo(FLYWHEEL_INCOMING_WINDOW);
+    expect(windows[5]).toBeGreaterThan(windows[0]);
+    expect(strengths[5]).toBeGreaterThan(strengths[0]);
+    expect(network.getDebugState().incomingCompletedCount).toBe(0);
+    expect(network.getDebugState().outgoingCompletedCount).toBe(1);
+  });
+
+  it('excludes Flywheel, avoids immediate repeats, progresses phase, and does not mutate inputs', () => {
+    const original = structuredClone(targets);
+    const normalized = normalizeFlywheelEnergyTargets(targets);
+    expect(normalized.map((target) => target.poiId)).not.toContain(
+      FLYWHEEL_ENERGY_POI_ID
+    );
+
+    const network = createFlywheelEnergyNetwork({ seed: 'repeats', targets });
+    expect(network.getActiveTransfer().phase).toBe(0);
+    network.update(FLYWHEEL_INCOMING_DURATION / 2);
+    expect(network.getActiveTransfer().phase).toBeCloseTo(0.5);
+    const ids: string[] = [];
+    for (let i = 0; i < 8; i += 1) {
+      ids.push(network.getActiveTransfer().targetPoiId);
+      completeCurrent(network);
+    }
+    for (let i = 1; i < ids.length; i += 1) {
+      expect(ids[i]).not.toBe(ids[i - 1]);
+    }
+    expect(targets).toEqual(original);
+  });
+});

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -202,6 +202,64 @@ describe('createFlywheelShowpiece', () => {
     build.dispose();
   });
 
+  it('accepts runtime energy targets and renders one bounded packet subsection', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'jobbot-studio-terminal',
+        label: 'Jobbot',
+        worldPosition: { x: 4, y: 0, z: 0 },
+      },
+      {
+        poiId: 'sigma-kitchen-workbench',
+        label: 'Sigma',
+        worldPosition: { x: -4, y: 0, z: 0 },
+      },
+    ]);
+    build.update({
+      elapsed: 1,
+      delta: 0.25,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const root = build.group.getObjectByName('FlywheelEnergyPacketRoot');
+    const visibleNodes = root?.children.filter(
+      (child) =>
+        child.name.startsWith('FlywheelEnergyPacketNode') && child.visible
+    );
+    const state = build.getDebugState().energy;
+    expect(state.targetCount).toBe(2);
+    expect(state.direction).toBe('incoming');
+    expect(
+      state.visibleWindow.end - state.visibleWindow.start
+    ).toBeLessThanOrEqual(0.11);
+    expect(state.activeNodeCount).toBeGreaterThan(1);
+    expect(visibleNodes?.length).toBe(state.activeNodeCount);
+    expect(state.sourceWorldPosition?.x).not.toBeCloseTo(
+      state.destinationWorldPosition?.x ?? 0
+    );
+    build.dispose();
+  });
+
+  it('fails open with diagnostics when energy targets are missing', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.setEnergyTargets([], ['Missing visual anchor for optional target.']);
+    build.update({ elapsed: 1, delta: 1, emphasis: 0 });
+    const state = build.getDebugState().energy;
+    expect(state.targetCount).toBe(0);
+    expect(state.activeNodeCount).toBe(0);
+    expect(state.missingTargetDiagnostics).toEqual([
+      'Missing visual anchor for optional target.',
+    ]);
+    build.dispose();
+  });
+
   it('keeps miniature proxy semantics in sync', () => {
     const proxy = MINIATURE_POI_PROXY_REGISTRY['flywheel-studio-flywheel'];
     const names = proxy.primitives.map((primitive) => primitive.name);


### PR DESCRIPTION
### Motivation
- Implement P6c: add a metaphorical Flywheel energy-transfer layer that renders glowing blue parabolic packet arcs between ground-floor POIs and the Flywheel while preserving the physical crank/gear/flywheel motion from P6b.  
- Make the transfer sequence deterministic (5 incoming → 1 outgoing), ensure only a small moving subsection of the arc is visible, and keep rendering and accessibility costs controllable by detail policy.

### Description
- Add a pure deterministic energy network in `src/scene/structures/flywheelEnergyNetwork.ts` providing seeded target selection, a five-in/one-out cycle, active-transfer state, visible-window math, parabolic arc sampling, and debug snapshots.  
- Extend the Flywheel showpiece (`src/scene/structures/flywheel.ts`) with `setEnergyTargets(...)`, a pooled packet node/connector renderer that shows a single moving subsection of the parabolic arc, directionality (incoming/outgoing) with different window/strength, accessibility presentation via `getPulseScale()` / `getFlickerScale()`, and expanded `getDebugState()` energy snapshot.  
- Resolve runtime ground-floor targets in `src/main.ts` via `resolveFlywheelEnergyTargets(...)` which uses `poiInstances`, the floor resolver, and `resolvePoiVisualAnchor(...)`, fails open with diagnostics, and calls `flywheelShowpiece.setEnergyTargets(...)` only after visual anchors/structures are ready.  
- Update the miniature proxy (`src/scene/miniature/poiProxyRegistry.ts`) and regenerate the manifest to include static incoming/outgoing arc hints (static, not running the network), and add focused tests: `src/tests/flywheelEnergyNetwork.test.ts` and extended `src/tests/flywheelShowpiece.test.ts`; also update docs `docs/architecture/flywheel-energy-transfer.md`.

### Testing
- Ran formatting and manifest tasks: `npm run format:write`, `npm run miniature:manifest:update`, and `npm run miniature:check` — all succeeded.  
- Unit/CI tests: `npm run test:ci -- src/tests/flywheelEnergyNetwork.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts` and `npm run test:ci -- src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts` — focused suites passed (all new/updated tests green).  
- Project checks: `npm run lint`, `npm run build`, `npm run docs:check`, `npm run smoke`, and `npm run format:check` all completed successfully (link checker produced external fetch warnings but the docs check passed).  
- Typecheck: `npm run typecheck` returned failures that are unrelated, pre-existing TypeScript project-wide errors (documented in-run); these were not introduced by this change.  

Notes: manual interactive `npm run dev` / visual QA was not performed in this non-interactive environment; please run `npm run dev -- --host 127.0.0.1 --port 5173` and open `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1` to visually verify one full 5-in / 1-out cycle locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f330aa8832fa443c82fe503d3b9)