### PR TITLE
⚡ Implement Flywheel energy-transfer arcs

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -723,3 +723,45 @@ gearbox, and energy port without individual tooth blocks. The core update runs
 every rendered frame, while decorative glow updates can still be throttled by the
 scene detail controller. Cross-POI blue transfer arcs remain future P6c scope and
 are not implemented here.
+
+## 8. P6c implementation notes
+
+The implemented energy-transfer layer is split between the pure state module and
+runtime rendering integration:
+
+- `src/scene/structures/flywheelEnergyNetwork.ts` owns deterministic seeded
+  target selection, the five-in/one-out cycle, active-transfer phase, visible
+  window math, parabolic arc sampling, and debug snapshots. It has no DOM,
+  Three.js scene-object, or `main.ts` dependency and never uses `Math.random()`
+  for runtime target choice.
+- `src/scene/structures/flywheel.ts` owns the pooled presentation objects:
+  one `FlywheelEnergyTransferPacket` group, preallocated packet nodes, and
+  preallocated connector cylinders. The update loop advances the mechanical
+  crank/gear/flywheel state and the active energy-transfer phase every rendered
+  frame; `runDecorativeEffects` only gates secondary glow presentation.
+- `src/main.ts` resolves targets after ground-floor structures and visual
+  anchors have been created. It iterates the resolved `poiInstances`, uses the
+  scene floor resolver to keep only ground-floor POIs, excludes
+  `flywheel-studio-flywheel`, prefers `resolvePoiVisualAnchor(...)`, and reads
+  target world coordinates through `Object3D.getWorldPosition(...)`. Missing
+  optional anchors are diagnostics rather than immersive-mode blockers.
+
+Transfer timing is deterministic: five incoming packets travel from eligible
+POIs into the Flywheel energy port, followed by one outgoing packet from the port
+to an eligible POI. Incoming transfers use an approximately `0.10` phase window,
+while outgoing transfers use a wider `0.16` window and higher strength so they
+render thicker and brighter. Only samples inside the moving window are visible;
+the full curve is never rendered and all other potential arcs stay hidden.
+
+All five scene-detail levels preserve target order, direction, phase, transfer
+counts, and timing. Lower detail levels reduce only presentation cost by using
+fewer packet nodes/connectors and softer opacity. Accessibility pulse and flicker
+preferences are read through `getPulseScale()` and `getFlickerScale()` for
+opacity/scale presentation only; reduced settings do not pause the cycle or alter
+its targets.
+
+`getDebugState()` now reports target count, target-resolution diagnostics, cycle
+index, current direction/target/phase, visible window start/end, incoming and
+outgoing completion counts, source/destination world and local positions, active
+node count, detail level, and reduced pulse/flicker scale values. Returned arrays
+and points are copies so callers cannot mutate internal network state.

--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -721,8 +721,8 @@ procedural tooth hints with different segment budgets; Performance samples every
 third tooth; Low and Micro retain iconic rings/discs, base, bearings, crank,
 gearbox, and energy port without individual tooth blocks. The core update runs
 every rendered frame, while decorative glow updates can still be throttled by the
-scene detail controller. Cross-POI blue transfer arcs remain future P6c scope and
-are not implemented here.
+scene detail controller. The P6c layer now adds deterministic cross-POI blue
+transfer arcs while preserving the physical crank, gear, and flywheel motion.
 
 ## 8. P6c implementation notes
 

--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -721,10 +721,11 @@ procedural tooth hints with different segment budgets; Performance samples every
 third tooth; Low and Micro retain iconic rings/discs, base, bearings, crank,
 gearbox, and energy port without individual tooth blocks. The core update runs
 every rendered frame, while decorative glow updates can still be throttled by the
-scene detail controller. The P6c layer now adds deterministic cross-POI blue
-transfer arcs while preserving the physical crank, gear, and flywheel motion.
+scene detail controller. The energy-transfer layer adds deterministic
+cross-POI blue transfer arcs while preserving the physical crank, gear, and
+flywheel motion.
 
-## 8. P6c implementation notes
+## 8. Energy-transfer implementation notes
 
 The implemented energy-transfer layer is split between the pure state module and
 runtime rendering integration:

--- a/src/main.ts
+++ b/src/main.ts
@@ -280,6 +280,7 @@ import {
   createFlywheelShowpiece,
   type FlywheelShowpieceBuild,
 } from './scene/structures/flywheel';
+import type { FlywheelEnergyTarget } from './scene/structures/flywheelEnergyNetwork';
 import {
   createGabrielSentry,
   type GabrielSentryBuild,
@@ -3022,6 +3023,47 @@ function initializeImmersiveScene(
     getPoiFloorId(poi.definition) === 'upper'
       ? upperFloorColliders
       : groundColliders;
+
+  const resolveFlywheelEnergyTargets = (): {
+    targets: FlywheelEnergyTarget[];
+    diagnostics: string[];
+  } => {
+    const targets: FlywheelEnergyTarget[] = [];
+    const diagnostics: string[] = [];
+    for (const poi of poiInstances) {
+      const poiId = poi.definition.id;
+      if (poiId === 'flywheel-studio-flywheel') continue;
+      const floorId = getPoiFloorId(poi.definition);
+      if (floorId !== 'ground') continue;
+      const anchor = resolvePoiVisualAnchor(poiId);
+      const source = anchor?.object ?? poi.group;
+      if (!anchor) {
+        diagnostics.push(`missing-visual-anchor:${poiId}`);
+      }
+      try {
+        source.updateMatrixWorld(true);
+        const worldPosition = source.getWorldPosition(new Vector3());
+        targets.push({
+          poiId,
+          label: poi.definition.title ?? poiId,
+          floorId,
+          worldPosition: {
+            x: worldPosition.x,
+            y: worldPosition.y,
+            z: worldPosition.z,
+          },
+        });
+      } catch (error) {
+        diagnostics.push(
+          `target-resolution-failed:${poiId}:${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
+    return { targets, diagnostics };
+  };
+
   if (studioRoom) {
     const showpiece = createFlywheelShowpiece({
       position: {
@@ -3391,6 +3433,22 @@ function initializeImmersiveScene(
       'PortfolioMiniatureTableCollider'
     );
     portfolioMiniatureTable = table;
+  }
+
+  if (flywheelShowpiece) {
+    const { targets, diagnostics } = resolveFlywheelEnergyTargets();
+    if (targets.length === 0) {
+      diagnostics.push('no-ground-floor-energy-targets');
+    }
+    flywheelShowpiece.setEnergyTargets(targets, diagnostics);
+    if (diagnostics.length > 0) {
+      crashBreadcrumbs.record({
+        type: 'snapshot',
+        message: `flywheel-energy-target-diagnostics:${diagnostics.join(',')}`,
+        renderer: rendererInfo,
+        softwareRendererPolicy,
+      });
+    }
   }
 
   poiInteractionManager = new PoiInteractionManager(

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "c35e134ca28c1414da7edefdda9afa4c0614d730fb72862516295e77cfc42b6c",
+      "proxyFingerprint": "b8e9b7daf711ccaca265c2c51d03646fc3ea7b6208956cc98d435f3b71495840",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -574,14 +574,15 @@
         "src/scene/poi/placements.ts",
         "src/scene/poi/registry.ts",
         "src/scene/structures/flywheel.ts",
-        "src/scene/structures/flywheelEnergyContract.ts"
+        "src/scene/structures/flywheelEnergyContract.ts",
+        "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.",
-      "sourceFingerprint": "d3e1970e2658dd17f500590a86ba91d4cf1804d3cf1e2ce5cf614288716582bc",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
-      "metadataFingerprint": "5b6d936a1b778dcba5f2b4f08afff8969f07ad60dc6f9dfe915bf13f5ba02980"
+      "syncRevision": 8,
+      "syncNote": "Syncs the pooled runtime transfer packet implementation with static incoming/outgoing arc hints.",
+      "sourceFingerprint": "c3ab6c40dfca475e933d9876797918cc81f36fcc157ab68a0d799964c4ab39cb",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "metadataFingerprint": "a06759f70920dc3b4b2361f30ee1d786b3f193d51a04c243d64eee6abe0b65f1"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -595,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -610,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -625,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -640,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -675,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -690,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -705,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -720,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -735,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "0dd98ff9b087067152142e3ba603ecd2280fa467cd6101b9264a06c1aca8fe7b",
+      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "b8e9b7daf711ccaca265c2c51d03646fc3ea7b6208956cc98d435f3b71495840",
+      "proxyFingerprint": "8719cf12668745d043361e32da42ef82a169cde2ddb910d72f043dc6768e2c1b",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 8,
-      "syncNote": "Syncs the pooled runtime transfer packet implementation with static incoming/outgoing arc hints.",
-      "sourceFingerprint": "c3ab6c40dfca475e933d9876797918cc81f36fcc157ab68a0d799964c4ab39cb",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
-      "metadataFingerprint": "a06759f70920dc3b4b2361f30ee1d786b3f193d51a04c243d64eee6abe0b65f1"
+      "syncRevision": 9,
+      "syncNote": "Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.",
+      "sourceFingerprint": "6c5e609c0f5d6983f705d164bae47ef76bb114f76c23c90b52a04c4d8f9de4b1",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "metadataFingerprint": "0e744e5f1efca45fe87a9d153b90c1d29b1f114d2288047d8d44c60d0c01e934"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "edba762edd3ab81dd7a6771b2b4ed5633131391e4c01e9b6259b02b06e7bdcfb",
+      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,13 +90,14 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 6,
+    syncRevision: 8,
     syncNote:
-      'Acknowledges delta-only flywheel phase integration and shared Z-axis shaft alignment; proxy geometry remains aligned.',
+      'Syncs the pooled runtime transfer packet implementation with static incoming/outgoing arc hints.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
       'src/scene/structures/flywheelEnergyContract.ts',
+      'src/scene/structures/flywheelEnergyNetwork.ts',
     ],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -137,6 +138,28 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         0xd1d5db
       ),
       sphere('flywheel-energy-port', 0.07, [0.56, 0.8, 0.28], 0x38bdf8),
+      {
+        kind: 'tube',
+        name: 'flywheel-incoming-arc-hint',
+        radius: 0.012,
+        points: [
+          [-0.95, 0.18, -0.62],
+          [-0.42, 1.06, -0.18],
+          [0.56, 0.8, 0.28],
+        ],
+        color: 0x38bdf8,
+      },
+      {
+        kind: 'tube',
+        name: 'flywheel-outgoing-arc-hint',
+        radius: 0.024,
+        points: [
+          [0.56, 0.8, 0.28],
+          [0.12, 1.22, 0.58],
+          [1.05, 0.22, 0.76],
+        ],
+        color: 0x7dd3fc,
+      },
     ],
   },
   'jobbot-studio-terminal': {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 8,
+    syncRevision: 9,
     syncNote:
-      'Syncs the pooled runtime transfer packet implementation with static incoming/outgoing arc hints.',
+      'Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -9,10 +9,15 @@ import {
   MeshStandardMaterial,
   Object3D,
   SphereGeometry,
+  Vector3,
   TorusGeometry,
 } from 'three';
 
 import type { Bounds2D } from '../../assets/floorPlan';
+import {
+  getFlickerScale,
+  getPulseScale,
+} from '../../ui/accessibility/animationPreferences';
 import type { RectCollider } from '../collision';
 import type { SceneDetailPolicy } from '../graphics/sceneDetailPolicy';
 import { getSceneDetailPolicy } from '../graphics/sceneDetailPolicy';
@@ -40,6 +45,12 @@ import {
   getFlywheelCarrierAngle,
   getFlywheelPlanetLocalSpin,
 } from './flywheelEnergyContract';
+import {
+  createSeededFlywheelEnergyNetwork,
+  getFlywheelEnergyVisibleWindow,
+  sampleFlywheelEnergyArc,
+  type FlywheelEnergyTarget,
+} from './flywheelEnergyNetwork';
 
 export interface FlywheelShowpieceBuild {
   group: Group;
@@ -50,6 +61,10 @@ export interface FlywheelShowpieceBuild {
     emphasis: number;
     runDecorativeEffects?: boolean;
   }): void;
+  setEnergyTargets(
+    targets: readonly FlywheelEnergyTarget[],
+    diagnostics?: readonly string[]
+  ): void;
   getDebugState(): FlywheelDebugState;
   dispose(): void;
 }
@@ -71,6 +86,26 @@ export interface FlywheelDebugState {
   planetLocalSpin: number;
   torqueRatio: number;
   triangleCount: number;
+  energy: {
+    targetCount: number;
+    missingTargetDiagnostics: string[];
+    cycleIndex: number;
+    direction: string | null;
+    selectedTargetId: string | null;
+    phase: number;
+    visibleWindowStart: number | null;
+    visibleWindowEnd: number | null;
+    incomingCompletedCount: number;
+    outgoingCompletedCount: number;
+    sourceWorldPosition: { x: number; y: number; z: number } | null;
+    destinationWorldPosition: { x: number; y: number; z: number } | null;
+    sourceLocalPosition: { x: number; y: number; z: number } | null;
+    destinationLocalPosition: { x: number; y: number; z: number } | null;
+    activeNodeCount: number;
+    detailLevel: string;
+    pulseScale: number;
+    flickerScale: number;
+  };
 }
 
 const MATERIALS = {
@@ -417,6 +452,65 @@ export function createFlywheelShowpiece(
   );
   group.add(port);
 
+  const energyNetwork = createSeededFlywheelEnergyNetwork();
+  let energyTargets: FlywheelEnergyTarget[] = [];
+  let missingTargetDiagnostics: string[] = [];
+  const energyPacket = new Group();
+  energyPacket.name = 'FlywheelEnergyTransferPacket';
+  group.add(energyPacket);
+  const detailNodeCount =
+    detailPolicy.level === 'cinematic'
+      ? 12
+      : detailPolicy.level === 'balanced'
+        ? 10
+        : detailPolicy.level === 'performance'
+          ? 7
+          : detailPolicy.level === 'low'
+            ? 5
+            : 4;
+  const connectorCount = Math.max(0, detailNodeCount - 1);
+  const packetNodeGeometry = own(
+    new SphereGeometry(0.045, Math.max(6, cylSeg), 6)
+  );
+  const packetConnectorGeometry = own(
+    new CylinderGeometry(0.018, 0.018, 1, Math.max(5, cylSeg / 2))
+  );
+  const packetMaterials = Array.from({ length: detailNodeCount }, (_, index) =>
+    mat(
+      new MeshBasicMaterial({
+        color: MATERIALS.glow,
+        transparent: true,
+        opacity: index === 0 ? 0.7 : 0.5,
+        depthWrite: false,
+      })
+    )
+  );
+  const connectorMaterial = mat(
+    new MeshBasicMaterial({
+      color: MATERIALS.glow,
+      transparent: true,
+      opacity: 0.34,
+      depthWrite: false,
+    })
+  );
+  const packetNodes = packetMaterials.map((material, index) => {
+    const node = new Mesh(packetNodeGeometry, material);
+    node.name = `FlywheelEnergyPacketNode-${index}`;
+    node.visible = false;
+    energyPacket.add(node);
+    return node;
+  });
+  const packetConnectors = Array.from(
+    { length: connectorCount },
+    (_, index) => {
+      const connector = new Mesh(packetConnectorGeometry, connectorMaterial);
+      connector.name = `FlywheelEnergyPacketConnector-${index}`;
+      connector.visible = false;
+      energyPacket.add(connector);
+      return connector;
+    }
+  );
+
   const colliders = createFlywheelColliders(
     position.x,
     position.z,
@@ -430,13 +524,200 @@ export function createFlywheelShowpiece(
     planetLocalSpin: 0,
     torqueRatio: FLYWHEEL_TORQUE_RATIO,
     triangleCount: countTriangles(group),
+    energy: {
+      targetCount: 0,
+      missingTargetDiagnostics: [],
+      cycleIndex: 0,
+      direction: null,
+      selectedTargetId: null,
+      phase: 0,
+      visibleWindowStart: null,
+      visibleWindowEnd: null,
+      incomingCompletedCount: 0,
+      outgoingCompletedCount: 0,
+      sourceWorldPosition: null,
+      destinationWorldPosition: null,
+      sourceLocalPosition: null,
+      destinationLocalPosition: null,
+      activeNodeCount: 0,
+      detailLevel: detailPolicy.level,
+      pulseScale: 1,
+      flickerScale: 1,
+    },
   };
   let disposed = false;
   let crankAngle = 0;
 
+  const vectorA = new Vector3();
+  const vectorB = new Vector3();
+  const vectorMid = new Vector3();
+  const vectorDirection = new Vector3();
+  const vectorUp = new Vector3(0, 1, 0);
+  const portWorldPosition = new Vector3();
+  const targetWorldPosition = new Vector3();
+  const sourceWorldPosition = new Vector3();
+  const destinationWorldPosition = new Vector3();
+  const sourceLocalPosition = new Vector3();
+  const destinationLocalPosition = new Vector3();
+  const localPoint = new Vector3();
+
+  const hideEnergyPacket = () => {
+    packetNodes.forEach((node) => {
+      node.visible = false;
+    });
+    packetConnectors.forEach((connector) => {
+      connector.visible = false;
+    });
+  };
+
+  const clonePoint = (point: Vector3) => ({
+    x: point.x,
+    y: point.y,
+    z: point.z,
+  });
+
+  const renderEnergyTransfer = (
+    transfer: ReturnType<typeof energyNetwork.getActiveTransfer>
+  ) => {
+    const pulseScale = getPulseScale();
+    const flickerScale = getFlickerScale();
+    const networkDebug = energyNetwork.getDebugSnapshot();
+    if (!transfer) {
+      hideEnergyPacket();
+      return {
+        targetCount: networkDebug.targetCount,
+        missingTargetDiagnostics: [...missingTargetDiagnostics],
+        cycleIndex: networkDebug.cycleIndex,
+        direction: null,
+        selectedTargetId: null,
+        phase: 0,
+        visibleWindowStart: null,
+        visibleWindowEnd: null,
+        incomingCompletedCount: networkDebug.incomingCompletedCount,
+        outgoingCompletedCount: networkDebug.outgoingCompletedCount,
+        sourceWorldPosition: null,
+        destinationWorldPosition: null,
+        sourceLocalPosition: null,
+        destinationLocalPosition: null,
+        activeNodeCount: 0,
+        detailLevel: detailPolicy.level,
+        pulseScale,
+        flickerScale,
+      };
+    }
+    const target = energyNetwork.getTarget(transfer.targetPoiId);
+    if (!target) {
+      hideEnergyPacket();
+      return { ...state.energy, targetCount: networkDebug.targetCount };
+    }
+    port.getWorldPosition(portWorldPosition);
+    targetWorldPosition.set(
+      target.worldPosition.x,
+      target.worldPosition.y + 0.95,
+      target.worldPosition.z
+    );
+    sourceWorldPosition.copy(
+      transfer.direction === 'incoming'
+        ? targetWorldPosition
+        : portWorldPosition
+    );
+    destinationWorldPosition.copy(
+      transfer.direction === 'incoming'
+        ? portWorldPosition
+        : targetWorldPosition
+    );
+    const distance = sourceWorldPosition.distanceTo(destinationWorldPosition);
+    const lift = Math.min(3.4, Math.max(1.1, distance * 0.18));
+    const visible = getFlywheelEnergyVisibleWindow(transfer);
+    const span = Math.max(0.001, visible.end - visible.start);
+    const activeNodeCount = Math.max(
+      2,
+      Math.min(
+        packetNodes.length,
+        Math.ceil((packetNodes.length * span) / transfer.window)
+      )
+    );
+    const strength = transfer.strength;
+    sourceLocalPosition.copy(sourceWorldPosition);
+    group.worldToLocal(sourceLocalPosition);
+    destinationLocalPosition.copy(destinationWorldPosition);
+    group.worldToLocal(destinationLocalPosition);
+    for (let i = 0; i < packetNodes.length; i += 1) {
+      const node = packetNodes[i];
+      if (i >= activeNodeCount) {
+        node.visible = false;
+        continue;
+      }
+      const fraction = activeNodeCount === 1 ? 0.5 : i / (activeNodeCount - 1);
+      const phase = visible.start + span * fraction;
+      const world = sampleFlywheelEnergyArc(
+        sourceWorldPosition,
+        destinationWorldPosition,
+        phase,
+        lift
+      );
+      localPoint.set(world.x, world.y, world.z);
+      group.worldToLocal(localPoint);
+      node.position.copy(localPoint);
+      const edgeFade = Math.sin(fraction * Math.PI);
+      const scale =
+        (0.75 + edgeFade * 0.45) * strength * (0.75 + pulseScale * 0.25);
+      node.scale.setScalar(scale);
+      node.visible = true;
+      const material = node.material as MeshBasicMaterial;
+      material.opacity = (0.18 + edgeFade * 0.54 * flickerScale) * strength;
+    }
+    for (let i = 0; i < packetConnectors.length; i += 1) {
+      const connector = packetConnectors[i];
+      if (i >= activeNodeCount - 1) {
+        connector.visible = false;
+        continue;
+      }
+      vectorA.copy(packetNodes[i].position);
+      vectorB.copy(packetNodes[i + 1].position);
+      vectorMid.copy(vectorA).add(vectorB).multiplyScalar(0.5);
+      vectorDirection.copy(vectorB).sub(vectorA);
+      connector.position.copy(vectorMid);
+      connector.scale.set(strength, vectorDirection.length(), strength);
+      connector.quaternion.setFromUnitVectors(
+        vectorUp,
+        vectorDirection.normalize()
+      );
+      connector.visible = detailPolicy.level !== 'micro';
+    }
+    return {
+      targetCount: networkDebug.targetCount,
+      missingTargetDiagnostics: [...missingTargetDiagnostics],
+      cycleIndex: networkDebug.cycleIndex,
+      direction: transfer.direction,
+      selectedTargetId: transfer.targetPoiId,
+      phase: transfer.phase,
+      visibleWindowStart: visible.start,
+      visibleWindowEnd: visible.end,
+      incomingCompletedCount: networkDebug.incomingCompletedCount,
+      outgoingCompletedCount: networkDebug.outgoingCompletedCount,
+      sourceWorldPosition: clonePoint(sourceWorldPosition),
+      destinationWorldPosition: clonePoint(destinationWorldPosition),
+      sourceLocalPosition: clonePoint(sourceLocalPosition),
+      destinationLocalPosition: clonePoint(destinationLocalPosition),
+      activeNodeCount,
+      detailLevel: detailPolicy.level,
+      pulseScale,
+      flickerScale,
+    };
+  };
+
   return {
     group,
     colliders,
+    setEnergyTargets(targets, diagnostics = []) {
+      energyTargets = targets.map((target) => ({
+        ...target,
+        worldPosition: { ...target.worldPosition },
+      }));
+      missingTargetDiagnostics = [...diagnostics];
+      energyNetwork.setTargets(energyTargets);
+    },
     update({ elapsed, delta = 0, emphasis, runDecorativeEffects = true }) {
       const emphasisBoost = Math.min(1, Math.max(0, emphasis));
       const angularVelocity =
@@ -460,6 +741,8 @@ export function createFlywheelShowpiece(
         glow.opacity =
           0.45 + Math.min(0.4, emphasis * 0.35) + Math.sin(elapsed * 2) * 0.05;
       }
+      const transfer = energyNetwork.update(delta);
+      const energyDebug = renderEnergyTransfer(transfer);
       state = {
         crankAngle,
         sunAngle: crankAngle,
@@ -468,9 +751,28 @@ export function createFlywheelShowpiece(
         planetLocalSpin,
         torqueRatio: FLYWHEEL_TORQUE_RATIO,
         triangleCount: state.triangleCount,
+        energy: energyDebug,
       };
     },
-    getDebugState: () => ({ ...state }),
+    getDebugState: () => ({
+      ...state,
+      energy: {
+        ...state.energy,
+        missingTargetDiagnostics: [...state.energy.missingTargetDiagnostics],
+        sourceWorldPosition: state.energy.sourceWorldPosition
+          ? { ...state.energy.sourceWorldPosition }
+          : null,
+        destinationWorldPosition: state.energy.destinationWorldPosition
+          ? { ...state.energy.destinationWorldPosition }
+          : null,
+        sourceLocalPosition: state.energy.sourceLocalPosition
+          ? { ...state.energy.sourceLocalPosition }
+          : null,
+        destinationLocalPosition: state.energy.destinationLocalPosition
+          ? { ...state.energy.destinationLocalPosition }
+          : null,
+      },
+    }),
     dispose() {
       if (disposed) return;
       disposed = true;

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -453,7 +453,6 @@ export function createFlywheelShowpiece(
   group.add(port);
 
   const energyNetwork = createSeededFlywheelEnergyNetwork();
-  let energyTargets: FlywheelEnergyTarget[] = [];
   let missingTargetDiagnostics: string[] = [];
   const energyPacket = new Group();
   energyPacket.name = 'FlywheelEnergyTransferPacket';
@@ -608,7 +607,26 @@ export function createFlywheelShowpiece(
     const target = energyNetwork.getTarget(transfer.targetPoiId);
     if (!target) {
       hideEnergyPacket();
-      return { ...state.energy, targetCount: networkDebug.targetCount };
+      return {
+        targetCount: networkDebug.targetCount,
+        missingTargetDiagnostics: [...missingTargetDiagnostics],
+        cycleIndex: networkDebug.cycleIndex,
+        direction: null,
+        selectedTargetId: null,
+        phase: 0,
+        visibleWindowStart: null,
+        visibleWindowEnd: null,
+        incomingCompletedCount: networkDebug.incomingCompletedCount,
+        outgoingCompletedCount: networkDebug.outgoingCompletedCount,
+        sourceWorldPosition: null,
+        destinationWorldPosition: null,
+        sourceLocalPosition: null,
+        destinationLocalPosition: null,
+        activeNodeCount: 0,
+        detailLevel: detailPolicy.level,
+        pulseScale,
+        flickerScale,
+      };
     }
     port.getWorldPosition(portWorldPosition);
     targetWorldPosition.set(
@@ -677,11 +695,16 @@ export function createFlywheelShowpiece(
       vectorB.copy(packetNodes[i + 1].position);
       vectorMid.copy(vectorA).add(vectorB).multiplyScalar(0.5);
       vectorDirection.copy(vectorB).sub(vectorA);
+      const segmentLength = vectorDirection.length();
+      if (segmentLength < 1e-6) {
+        connector.visible = false;
+        continue;
+      }
       connector.position.copy(vectorMid);
-      connector.scale.set(strength, vectorDirection.length(), strength);
+      connector.scale.set(strength, segmentLength, strength);
       connector.quaternion.setFromUnitVectors(
         vectorUp,
-        vectorDirection.normalize()
+        vectorDirection.multiplyScalar(1 / segmentLength)
       );
       connector.visible = detailPolicy.level !== 'micro';
     }
@@ -711,12 +734,8 @@ export function createFlywheelShowpiece(
     group,
     colliders,
     setEnergyTargets(targets, diagnostics = []) {
-      energyTargets = targets.map((target) => ({
-        ...target,
-        worldPosition: { ...target.worldPosition },
-      }));
       missingTargetDiagnostics = [...diagnostics];
-      energyNetwork.setTargets(energyTargets);
+      energyNetwork.setTargets(targets);
     },
     update({ elapsed, delta = 0, emphasis, runDecorativeEffects = true }) {
       const emphasisBoost = Math.min(1, Math.max(0, emphasis));

--- a/src/scene/structures/flywheelEnergyNetwork.ts
+++ b/src/scene/structures/flywheelEnergyNetwork.ts
@@ -51,6 +51,9 @@ const DEFAULT_INCOMING_WINDOW = 0.1;
 const DEFAULT_OUTGOING_WINDOW = 0.16;
 const DEFAULT_INCOMING_STRENGTH = 1;
 const DEFAULT_OUTGOING_STRENGTH = 1.65;
+const MIN_TRANSFER_DURATION = 0.001;
+const MIN_TRANSFER_WINDOW = 0.001;
+const DEBUG_TARGET_SEQUENCE_LIMIT = 48;
 
 export function createSeededFlywheelEnergyNetwork(
   options: FlywheelEnergyNetworkOptions = {}
@@ -63,13 +66,36 @@ export function createSeededFlywheelEnergyNetwork(
   let outgoingCompletedCount = 0;
   let lastTargetPoiId: string | null = null;
   const targetSequence: string[] = [];
-  const incomingPerCycle =
-    options.incomingPerCycle ?? DEFAULT_INCOMING_PER_CYCLE;
+  const incomingPerCycle = Math.max(
+    1,
+    Math.floor(
+      positiveFiniteOrDefault(
+        options.incomingPerCycle,
+        DEFAULT_INCOMING_PER_CYCLE
+      )
+    )
+  );
   const config = {
-    incomingDuration: options.incomingDuration ?? DEFAULT_INCOMING_DURATION,
-    outgoingDuration: options.outgoingDuration ?? DEFAULT_OUTGOING_DURATION,
-    incomingWindow: options.incomingWindow ?? DEFAULT_INCOMING_WINDOW,
-    outgoingWindow: options.outgoingWindow ?? DEFAULT_OUTGOING_WINDOW,
+    incomingDuration: positiveFiniteOrDefault(
+      options.incomingDuration,
+      DEFAULT_INCOMING_DURATION,
+      MIN_TRANSFER_DURATION
+    ),
+    outgoingDuration: positiveFiniteOrDefault(
+      options.outgoingDuration,
+      DEFAULT_OUTGOING_DURATION,
+      MIN_TRANSFER_DURATION
+    ),
+    incomingWindow: positiveFiniteOrDefault(
+      options.incomingWindow,
+      DEFAULT_INCOMING_WINDOW,
+      MIN_TRANSFER_WINDOW
+    ),
+    outgoingWindow: positiveFiniteOrDefault(
+      options.outgoingWindow,
+      DEFAULT_OUTGOING_WINDOW,
+      MIN_TRANSFER_WINDOW
+    ),
     incomingStrength: options.incomingStrength ?? DEFAULT_INCOMING_STRENGTH,
     outgoingStrength: options.outgoingStrength ?? DEFAULT_OUTGOING_STRENGTH,
   };
@@ -89,6 +115,12 @@ export function createSeededFlywheelEnergyNetwork(
     }
     lastTargetPoiId = candidate.poiId;
     targetSequence.push(candidate.poiId);
+    if (targetSequence.length > DEBUG_TARGET_SEQUENCE_LIMIT) {
+      targetSequence.splice(
+        0,
+        targetSequence.length - DEBUG_TARGET_SEQUENCE_LIMIT
+      );
+    }
     return candidate;
   };
 
@@ -185,15 +217,18 @@ export function sanitizeFlywheelEnergyTargets(
     .filter((target) => target.poiId !== FLYWHEEL_POI_ID)
     .filter((target) => target.floorId !== 'upper')
     .filter((target) => {
-      const valid =
-        target.poiId &&
-        target.label &&
-        Number.isFinite(target.worldPosition.x) &&
-        Number.isFinite(target.worldPosition.y) &&
-        Number.isFinite(target.worldPosition.z) &&
-        !seen.has(target.poiId);
+      if (
+        !target.poiId ||
+        !target.label ||
+        !Number.isFinite(target.worldPosition.x) ||
+        !Number.isFinite(target.worldPosition.y) ||
+        !Number.isFinite(target.worldPosition.z) ||
+        seen.has(target.poiId)
+      ) {
+        return false;
+      }
       seen.add(target.poiId);
-      return valid;
+      return true;
     })
     .map(cloneTarget);
 }
@@ -237,6 +272,16 @@ function cloneTarget(target: FlywheelEnergyTarget): FlywheelEnergyTarget {
     floorId: target.floorId,
     worldPosition: { ...target.worldPosition },
   };
+}
+
+function positiveFiniteOrDefault(
+  value: number | undefined,
+  fallback: number,
+  minimum = 1
+): number {
+  return Number.isFinite(value) && value! > 0
+    ? Math.max(minimum, value!)
+    : fallback;
 }
 
 function clamp01(value: number): number {

--- a/src/scene/structures/flywheelEnergyNetwork.ts
+++ b/src/scene/structures/flywheelEnergyNetwork.ts
@@ -1,0 +1,262 @@
+export type FlywheelEnergyDirection = 'incoming' | 'outgoing';
+
+export interface FlywheelEnergyPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface FlywheelEnergyTarget {
+  poiId: string;
+  label: string;
+  worldPosition: FlywheelEnergyPoint;
+  floorId?: string;
+}
+
+export interface FlywheelEnergyTransfer {
+  direction: FlywheelEnergyDirection;
+  targetPoiId: string;
+  phase: number;
+  duration: number;
+  window: number;
+  strength: number;
+}
+
+export interface FlywheelEnergyNetworkOptions {
+  seed?: number | string;
+  incomingPerCycle?: number;
+  incomingDuration?: number;
+  outgoingDuration?: number;
+  incomingWindow?: number;
+  outgoingWindow?: number;
+  incomingStrength?: number;
+  outgoingStrength?: number;
+}
+
+export interface FlywheelEnergyNetworkDebugSnapshot {
+  targetCount: number;
+  cycleIndex: number;
+  incomingCompletedCount: number;
+  outgoingCompletedCount: number;
+  activeTransfer: FlywheelEnergyTransfer | null;
+  visibleWindow: { start: number; end: number } | null;
+  targetSequence: string[];
+}
+
+export const FLYWHEEL_POI_ID = 'flywheel-studio-flywheel';
+const DEFAULT_INCOMING_PER_CYCLE = 5;
+const DEFAULT_INCOMING_DURATION = 2.8;
+const DEFAULT_OUTGOING_DURATION = 2.35;
+const DEFAULT_INCOMING_WINDOW = 0.1;
+const DEFAULT_OUTGOING_WINDOW = 0.16;
+const DEFAULT_INCOMING_STRENGTH = 1;
+const DEFAULT_OUTGOING_STRENGTH = 1.65;
+
+export function createSeededFlywheelEnergyNetwork(
+  options: FlywheelEnergyNetworkOptions = {}
+) {
+  let randomState = hashSeed(options.seed ?? 'flywheel-energy-network');
+  let targets: FlywheelEnergyTarget[] = [];
+  let active: FlywheelEnergyTransfer | null = null;
+  let cycleIndex = 0;
+  let incomingCompletedCount = 0;
+  let outgoingCompletedCount = 0;
+  let lastTargetPoiId: string | null = null;
+  const targetSequence: string[] = [];
+  const incomingPerCycle =
+    options.incomingPerCycle ?? DEFAULT_INCOMING_PER_CYCLE;
+  const config = {
+    incomingDuration: options.incomingDuration ?? DEFAULT_INCOMING_DURATION,
+    outgoingDuration: options.outgoingDuration ?? DEFAULT_OUTGOING_DURATION,
+    incomingWindow: options.incomingWindow ?? DEFAULT_INCOMING_WINDOW,
+    outgoingWindow: options.outgoingWindow ?? DEFAULT_OUTGOING_WINDOW,
+    incomingStrength: options.incomingStrength ?? DEFAULT_INCOMING_STRENGTH,
+    outgoingStrength: options.outgoingStrength ?? DEFAULT_OUTGOING_STRENGTH,
+  };
+
+  const chooseTarget = (): FlywheelEnergyTarget | null => {
+    if (targets.length === 0) return null;
+    if (targets.length === 1) return targets[0];
+    let candidate = targets[nextRandomInt(targets.length)];
+    if (candidate.poiId === lastTargetPoiId) {
+      const startIndex = targets.findIndex(
+        (target) => target.poiId === candidate.poiId
+      );
+      candidate =
+        targets[
+          (startIndex + 1 + nextRandomInt(targets.length - 1)) % targets.length
+        ];
+    }
+    lastTargetPoiId = candidate.poiId;
+    targetSequence.push(candidate.poiId);
+    return candidate;
+  };
+
+  const nextRandomInt = (exclusiveMax: number): number => {
+    const next = mulberry32Step(randomState);
+    randomState = next.value;
+    return Math.floor(next.normalized * exclusiveMax);
+  };
+
+  const startNextTransfer = () => {
+    const target = chooseTarget();
+    if (!target) {
+      active = null;
+      return;
+    }
+    const direction: FlywheelEnergyDirection =
+      incomingCompletedCount >= incomingPerCycle ? 'outgoing' : 'incoming';
+    active = {
+      direction,
+      targetPoiId: target.poiId,
+      phase: 0,
+      duration:
+        direction === 'incoming'
+          ? config.incomingDuration
+          : config.outgoingDuration,
+      window:
+        direction === 'incoming'
+          ? config.incomingWindow
+          : config.outgoingWindow,
+      strength:
+        direction === 'incoming'
+          ? config.incomingStrength
+          : config.outgoingStrength,
+    };
+  };
+
+  return {
+    setTargets(nextTargets: readonly FlywheelEnergyTarget[]) {
+      targets = sanitizeFlywheelEnergyTargets(nextTargets);
+      if (
+        active &&
+        !targets.some((target) => target.poiId === active?.targetPoiId)
+      ) {
+        active = null;
+      }
+      if (!active) startNextTransfer();
+    },
+    update(delta: number): FlywheelEnergyTransfer | null {
+      if (!active) startNextTransfer();
+      if (!active) return null;
+      const safeDelta = Math.max(0, Number.isFinite(delta) ? delta : 0);
+      active = {
+        ...active,
+        phase: Math.min(1, active.phase + safeDelta / active.duration),
+      };
+      if (active.phase >= 1) {
+        if (active.direction === 'incoming') {
+          incomingCompletedCount += 1;
+        } else {
+          outgoingCompletedCount += 1;
+          incomingCompletedCount = 0;
+          cycleIndex += 1;
+        }
+        startNextTransfer();
+      }
+      return active ? { ...active } : null;
+    },
+    getActiveTransfer(): FlywheelEnergyTransfer | null {
+      return active ? { ...active } : null;
+    },
+    getTarget(poiId: string): FlywheelEnergyTarget | null {
+      const target = targets.find((candidate) => candidate.poiId === poiId);
+      return target ? cloneTarget(target) : null;
+    },
+    getDebugSnapshot(): FlywheelEnergyNetworkDebugSnapshot {
+      return {
+        targetCount: targets.length,
+        cycleIndex,
+        incomingCompletedCount,
+        outgoingCompletedCount,
+        activeTransfer: active ? { ...active } : null,
+        visibleWindow: active ? getFlywheelEnergyVisibleWindow(active) : null,
+        targetSequence: [...targetSequence],
+      };
+    },
+  };
+}
+
+export function sanitizeFlywheelEnergyTargets(
+  targets: readonly FlywheelEnergyTarget[]
+): FlywheelEnergyTarget[] {
+  const seen = new Set<string>();
+  return targets
+    .filter((target) => target.poiId !== FLYWHEEL_POI_ID)
+    .filter((target) => target.floorId !== 'upper')
+    .filter((target) => {
+      const valid =
+        target.poiId &&
+        target.label &&
+        Number.isFinite(target.worldPosition.x) &&
+        Number.isFinite(target.worldPosition.y) &&
+        Number.isFinite(target.worldPosition.z) &&
+        !seen.has(target.poiId);
+      seen.add(target.poiId);
+      return valid;
+    })
+    .map(cloneTarget);
+}
+
+export function getFlywheelEnergyVisibleWindow(
+  transfer: FlywheelEnergyTransfer
+) {
+  const half = transfer.window / 2;
+  return {
+    start: clamp01(transfer.phase - half),
+    end: clamp01(transfer.phase + half),
+  };
+}
+
+export function sampleFlywheelEnergyArc(
+  source: FlywheelEnergyPoint,
+  destination: FlywheelEnergyPoint,
+  t: number,
+  lift = 1.35
+): FlywheelEnergyPoint {
+  const phase = clamp01(t);
+  const mid = {
+    x: (source.x + destination.x) / 2,
+    y: Math.max(source.y, destination.y) + lift,
+    z: (source.z + destination.z) / 2,
+  };
+  const a = (1 - phase) * (1 - phase);
+  const b = 2 * (1 - phase) * phase;
+  const c = phase * phase;
+  return {
+    x: a * source.x + b * mid.x + c * destination.x,
+    y: a * source.y + b * mid.y + c * destination.y,
+    z: a * source.z + b * mid.z + c * destination.z,
+  };
+}
+
+function cloneTarget(target: FlywheelEnergyTarget): FlywheelEnergyTarget {
+  return {
+    poiId: target.poiId,
+    label: target.label,
+    floorId: target.floorId,
+    worldPosition: { ...target.worldPosition },
+  };
+}
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function hashSeed(seed: number | string): number {
+  const text = String(seed);
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function mulberry32Step(state: number): { value: number; normalized: number } {
+  const value = (state + 0x6d2b79f5) >>> 0;
+  let t = value;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return { value, normalized: ((t ^ (t >>> 14)) >>> 0) / 4294967296 };
+}

--- a/src/tests/flywheelEnergyNetwork.test.ts
+++ b/src/tests/flywheelEnergyNetwork.test.ts
@@ -114,6 +114,56 @@ describe('flywheel energy network', () => {
     expect(JSON.stringify(input)).toBe(before);
   });
 
+  it('keeps debug target sequence bounded during long sessions', () => {
+    const network = createSeededFlywheelEnergyNetwork({
+      seed: 'bounded-debug',
+      incomingDuration: 1,
+      outgoingDuration: 1,
+    });
+    network.setTargets(targets);
+    for (let i = 0; i < 90; i += 1) {
+      network.update(1);
+    }
+    expect(
+      network.getDebugSnapshot().targetSequence.length
+    ).toBeLessThanOrEqual(48);
+  });
+
+  it('accepts later valid duplicate IDs after rejecting invalid coordinates', () => {
+    const sanitized = sanitizeFlywheelEnergyTargets([
+      {
+        poiId: 'duplicate',
+        label: 'Broken duplicate',
+        floorId: 'ground',
+        worldPosition: { x: Number.NaN, y: 0, z: 0 },
+      },
+      {
+        poiId: 'duplicate',
+        label: 'Valid duplicate',
+        floorId: 'ground',
+        worldPosition: { x: 1, y: 0, z: 0 },
+      },
+    ]);
+    expect(sanitized).toHaveLength(1);
+    expect(sanitized[0].label).toBe('Valid duplicate');
+  });
+
+  it('clamps invalid durations and windows to finite positive values', () => {
+    const network = createSeededFlywheelEnergyNetwork({
+      seed: 'safe-options',
+      incomingDuration: 0,
+      outgoingDuration: Number.NaN,
+      incomingWindow: 0,
+      outgoingWindow: Number.POSITIVE_INFINITY,
+      incomingPerCycle: 0,
+    });
+    network.setTargets(targets);
+    const active = network.update(0);
+    expect(active?.duration).toBeGreaterThan(0);
+    expect(active?.window).toBeGreaterThan(0);
+    expect(active?.phase).toBe(0);
+  });
+
   it('avoids immediate repeats when multiple targets are eligible', () => {
     const sequence = collectSequence('repeat-check').map(
       (entry) => entry.split(':')[1]

--- a/src/tests/flywheelEnergyNetwork.test.ts
+++ b/src/tests/flywheelEnergyNetwork.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createSeededFlywheelEnergyNetwork,
+  getFlywheelEnergyVisibleWindow,
+  sanitizeFlywheelEnergyTargets,
+  sampleFlywheelEnergyArc,
+  type FlywheelEnergyTarget,
+} from '../scene/structures/flywheelEnergyNetwork';
+
+const targets: FlywheelEnergyTarget[] = [
+  {
+    poiId: 'a',
+    label: 'A',
+    floorId: 'ground',
+    worldPosition: { x: 0, y: 0, z: 0 },
+  },
+  {
+    poiId: 'b',
+    label: 'B',
+    floorId: 'ground',
+    worldPosition: { x: 4, y: 0, z: 0 },
+  },
+  {
+    poiId: 'c',
+    label: 'C',
+    floorId: 'ground',
+    worldPosition: { x: 0, y: 0, z: 4 },
+  },
+  {
+    poiId: 'd',
+    label: 'D',
+    floorId: 'ground',
+    worldPosition: { x: -4, y: 0, z: 0 },
+  },
+];
+
+function collectSequence(seed: string) {
+  const network = createSeededFlywheelEnergyNetwork({
+    seed,
+    incomingDuration: 1,
+    outgoingDuration: 1,
+  });
+  network.setTargets(targets);
+  const sequence: string[] = [];
+  for (let i = 0; i < 8; i += 1) {
+    const active = network.getActiveTransfer();
+    if (active) sequence.push(`${active.direction}:${active.targetPoiId}`);
+    network.update(1);
+  }
+  return sequence;
+}
+
+describe('flywheel energy network', () => {
+  it('selects the same seeded target sequence and different seeds diverge', () => {
+    expect(collectSequence('same')).toEqual(collectSequence('same'));
+    expect(collectSequence('same')).not.toEqual(collectSequence('different'));
+  });
+
+  it('runs exactly five incoming transfers before one stronger outgoing transfer', () => {
+    const network = createSeededFlywheelEnergyNetwork({
+      seed: 'cycle',
+      incomingDuration: 1,
+      outgoingDuration: 1,
+    });
+    network.setTargets(targets);
+    const directions: string[] = [];
+    const windows: number[] = [];
+    const strengths: number[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      const active = network.getActiveTransfer();
+      expect(active).not.toBeNull();
+      directions.push(active?.direction ?? 'missing');
+      windows.push(active?.window ?? 0);
+      strengths.push(active?.strength ?? 0);
+      network.update(1);
+    }
+    expect(directions).toEqual([
+      'incoming',
+      'incoming',
+      'incoming',
+      'incoming',
+      'incoming',
+      'outgoing',
+    ]);
+    expect(windows[0]).toBeCloseTo(0.1);
+    expect(windows[5]).toBeGreaterThan(windows[0]);
+    expect(strengths[5]).toBeGreaterThan(strengths[0]);
+  });
+
+  it('excludes flywheel and upper-floor targets without mutating input data', () => {
+    const input: FlywheelEnergyTarget[] = [
+      ...targets,
+      {
+        poiId: 'flywheel-studio-flywheel',
+        label: 'Flywheel',
+        floorId: 'ground',
+        worldPosition: { x: 1, y: 2, z: 3 },
+      },
+      {
+        poiId: 'upper',
+        label: 'Upper',
+        floorId: 'upper',
+        worldPosition: { x: 9, y: 9, z: 9 },
+      },
+    ];
+    const before = JSON.stringify(input);
+    const sanitized = sanitizeFlywheelEnergyTargets(input);
+    expect(sanitized.map((target) => target.poiId)).not.toContain(
+      'flywheel-studio-flywheel'
+    );
+    expect(sanitized.map((target) => target.poiId)).not.toContain('upper');
+    sanitized[0].worldPosition.x = 999;
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  it('avoids immediate repeats when multiple targets are eligible', () => {
+    const sequence = collectSequence('repeat-check').map(
+      (entry) => entry.split(':')[1]
+    );
+    for (let i = 1; i < sequence.length; i += 1) {
+      expect(sequence[i]).not.toBe(sequence[i - 1]);
+    }
+  });
+
+  it('progresses phase, reports a short visible window, and samples a parabolic arc', () => {
+    const network = createSeededFlywheelEnergyNetwork({
+      seed: 'phase',
+      incomingDuration: 10,
+    });
+    network.setTargets(targets);
+    const active = network.update(2);
+    expect(active?.phase).toBeCloseTo(0.2);
+    const window = getFlywheelEnergyVisibleWindow(active!);
+    expect(window.end - window.start).toBeCloseTo(0.1);
+    const start = sampleFlywheelEnergyArc(
+      { x: 0, y: 1, z: 0 },
+      { x: 4, y: 1, z: 0 },
+      0,
+      2
+    );
+    const middle = sampleFlywheelEnergyArc(
+      { x: 0, y: 1, z: 0 },
+      { x: 4, y: 1, z: 0 },
+      0.5,
+      2
+    );
+    expect(start).toEqual({ x: 0, y: 1, z: 0 });
+    expect(middle.y).toBeGreaterThan(start.y);
+  });
+});

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -202,6 +202,106 @@ describe('createFlywheelShowpiece', () => {
     build.dispose();
   });
 
+  it('accepts runtime energy targets and renders one bounded packet subsection', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 10, z: -2 },
+      orientationRadians: Math.PI / 6,
+      roomBounds,
+      detailPolicy: SCENE_DETAIL_POLICIES.balanced,
+    });
+    build.setEnergyTargets(
+      [
+        {
+          poiId: 'tokenplace-studio-cluster',
+          label: 'TokenPlace',
+          floorId: 'ground',
+          worldPosition: { x: 0, y: 0, z: -2 },
+        },
+        {
+          poiId: 'jobbot-studio-terminal',
+          label: 'Jobbot',
+          floorId: 'ground',
+          worldPosition: { x: 14, y: 0, z: 6 },
+        },
+      ],
+      ['missing-visual-anchor:optional']
+    );
+    build.update({
+      elapsed: 1,
+      delta: 0.2,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const debug = build.getDebugState().energy;
+    expect(debug.targetCount).toBe(2);
+    expect(debug.missingTargetDiagnostics).toEqual([
+      'missing-visual-anchor:optional',
+    ]);
+    expect(debug.direction).toBe('incoming');
+    expect(debug.selectedTargetId).toBeTruthy();
+    expect(debug.visibleWindowStart).not.toBeNull();
+    expect(
+      debug.visibleWindowEnd! - debug.visibleWindowStart!
+    ).toBeLessThanOrEqual(0.11);
+    expect(debug.activeNodeCount).toBeLessThanOrEqual(10);
+    expect(debug.sourceWorldPosition?.x).not.toBeCloseTo(
+      debug.destinationWorldPosition?.x ?? 0
+    );
+
+    const packet = build.group.getObjectByName('FlywheelEnergyTransferPacket')!;
+    const visibleNodes = packet.children.filter(
+      (child) =>
+        child.name.startsWith('FlywheelEnergyPacketNode') && child.visible
+    );
+    expect(visibleNodes.length).toBe(debug.activeNodeCount);
+    expect(
+      build.group.children.filter(
+        (child) => child.name === 'FlywheelEnergyTransferPacket'
+      )
+    ).toHaveLength(1);
+    build.dispose();
+  });
+
+  it('keeps transfer semantics under reduced presentation scales and reaches outgoing direction', () => {
+    document.documentElement.dataset.accessibilityPulseScale = '0';
+    document.documentElement.dataset.accessibilityFlickerScale = '0';
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'a',
+        label: 'A',
+        floorId: 'ground',
+        worldPosition: { x: 1, y: 0, z: 0 },
+      },
+      {
+        poiId: 'b',
+        label: 'B',
+        floorId: 'ground',
+        worldPosition: { x: 2, y: 0, z: 0 },
+      },
+    ]);
+    for (let i = 0; i < 5; i += 1) {
+      expect(build.getDebugState().energy.direction ?? 'incoming').toBe(
+        'incoming'
+      );
+      build.update({
+        elapsed: i,
+        delta: 3,
+        emphasis: 0,
+        runDecorativeEffects: false,
+      });
+    }
+    expect(build.getDebugState().energy.direction).toBe('outgoing');
+    expect(build.getDebugState().energy.pulseScale).toBe(0);
+    expect(build.getDebugState().energy.flickerScale).toBe(0);
+    delete document.documentElement.dataset.accessibilityPulseScale;
+    delete document.documentElement.dataset.accessibilityFlickerScale;
+    build.dispose();
+  });
+
   it('keeps miniature proxy semantics in sync', () => {
     const proxy = MINIATURE_POI_PROXY_REGISTRY['flywheel-studio-flywheel'];
     const names = proxy.primitives.map((primitive) => primitive.name);
@@ -212,6 +312,8 @@ describe('createFlywheelShowpiece', () => {
         'flywheel-crank-arm',
         'flywheel-planetary-gear-cluster',
         'flywheel-energy-port',
+        'flywheel-incoming-arc-hint',
+        'flywheel-outgoing-arc-hint',
       ])
     );
   });

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -263,43 +263,61 @@ describe('createFlywheelShowpiece', () => {
   });
 
   it('keeps transfer semantics under reduced presentation scales and reaches outgoing direction', () => {
-    document.documentElement.dataset.accessibilityPulseScale = '0';
-    document.documentElement.dataset.accessibilityFlickerScale = '0';
+    const previousPulseScale =
+      document.documentElement.dataset.accessibilityPulseScale;
+    const previousFlickerScale =
+      document.documentElement.dataset.accessibilityFlickerScale;
     const build = createFlywheelShowpiece({
       position: { x: 0, z: 0 },
       roomBounds,
     });
-    build.setEnergyTargets([
-      {
-        poiId: 'a',
-        label: 'A',
-        floorId: 'ground',
-        worldPosition: { x: 1, y: 0, z: 0 },
-      },
-      {
-        poiId: 'b',
-        label: 'B',
-        floorId: 'ground',
-        worldPosition: { x: 2, y: 0, z: 0 },
-      },
-    ]);
-    for (let i = 0; i < 5; i += 1) {
-      expect(build.getDebugState().energy.direction ?? 'incoming').toBe(
-        'incoming'
-      );
-      build.update({
-        elapsed: i,
-        delta: 3,
-        emphasis: 0,
-        runDecorativeEffects: false,
-      });
+
+    try {
+      document.documentElement.dataset.accessibilityPulseScale = '0';
+      document.documentElement.dataset.accessibilityFlickerScale = '0';
+      build.setEnergyTargets([
+        {
+          poiId: 'a',
+          label: 'A',
+          floorId: 'ground',
+          worldPosition: { x: 1, y: 0, z: 0 },
+        },
+        {
+          poiId: 'b',
+          label: 'B',
+          floorId: 'ground',
+          worldPosition: { x: 2, y: 0, z: 0 },
+        },
+      ]);
+      for (let i = 0; i < 5; i += 1) {
+        expect(build.getDebugState().energy.direction ?? 'incoming').toBe(
+          'incoming'
+        );
+        build.update({
+          elapsed: i,
+          delta: 3,
+          emphasis: 0,
+          runDecorativeEffects: false,
+        });
+      }
+      expect(build.getDebugState().energy.direction).toBe('outgoing');
+      expect(build.getDebugState().energy.pulseScale).toBe(0);
+      expect(build.getDebugState().energy.flickerScale).toBe(0);
+    } finally {
+      if (previousPulseScale === undefined) {
+        delete document.documentElement.dataset.accessibilityPulseScale;
+      } else {
+        document.documentElement.dataset.accessibilityPulseScale =
+          previousPulseScale;
+      }
+      if (previousFlickerScale === undefined) {
+        delete document.documentElement.dataset.accessibilityFlickerScale;
+      } else {
+        document.documentElement.dataset.accessibilityFlickerScale =
+          previousFlickerScale;
+      }
+      build.dispose();
     }
-    expect(build.getDebugState().energy.direction).toBe('outgoing');
-    expect(build.getDebugState().energy.pulseScale).toBe(0);
-    expect(build.getDebugState().energy.flickerScale).toBe(0);
-    delete document.documentElement.dataset.accessibilityPulseScale;
-    delete document.documentElement.dataset.accessibilityFlickerScale;
-    build.dispose();
   });
 
   it('keeps miniature proxy semantics in sync', () => {

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -1,4 +1,4 @@
-import { MathUtils, Object3D } from 'three';
+import { MathUtils, Mesh, Object3D } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { SCENE_DETAIL_POLICIES } from '../scene/graphics/sceneDetailPolicy';
@@ -9,6 +9,7 @@ import {
   FLYWHEEL_BASE_COLLIDER,
   FLYWHEEL_CRANK_RAD_PER_SECOND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
+  FLYWHEEL_ENERGY_PORT,
   FLYWHEEL_GEARBOX_COLLIDER,
   FLYWHEEL_INSTALLATION_BOUNDS,
   FLYWHEEL_MARKER_MIN_HEIGHT,
@@ -318,6 +319,204 @@ describe('createFlywheelShowpiece', () => {
       }
       build.dispose();
     }
+  });
+
+  it('reuses the pooled energy packet meshes, geometry, and materials across updates', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+      detailPolicy: SCENE_DETAIL_POLICIES.balanced,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'tokenplace-studio-cluster',
+        label: 'TokenPlace',
+        floorId: 'ground',
+        worldPosition: { x: -2, y: 0, z: 1 },
+      },
+      {
+        poiId: 'jobbot-studio-terminal',
+        label: 'Jobbot',
+        floorId: 'ground',
+        worldPosition: { x: 3, y: 0, z: -1 },
+      },
+    ]);
+    build.update({
+      elapsed: 0,
+      delta: 0.2,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+
+    const collectPacketState = () => {
+      const packets = build.group.children.filter(
+        (child) => child.name === 'FlywheelEnergyTransferPacket'
+      );
+      const packet = packets[0]!;
+      const nodes = packet.children.filter((child) =>
+        child.name.startsWith('FlywheelEnergyPacketNode')
+      ) as Mesh[];
+      const connectors = packet.children.filter((child) =>
+        child.name.startsWith('FlywheelEnergyPacketConnector')
+      ) as Mesh[];
+      return {
+        packetCount: packets.length,
+        nodeUuids: nodes.map((node) => node.uuid),
+        connectorUuids: connectors.map((connector) => connector.uuid),
+        geometryUuids: [...nodes, ...connectors].map(
+          (item) => item.geometry.uuid
+        ),
+        materialUuids: [...nodes, ...connectors].map((item) => {
+          const material = item.material;
+          return Array.isArray(material)
+            ? material.map((entry) => entry.uuid).join('|')
+            : material.uuid;
+        }),
+      };
+    };
+
+    const before = collectPacketState();
+    expect(before.packetCount).toBe(1);
+    expect(before.nodeUuids.length).toBeGreaterThanOrEqual(2);
+    expect(before.connectorUuids.length).toBeGreaterThanOrEqual(1);
+
+    for (const [index, delta] of [2.6, 2.8, 2.8, 2.8, 2.8, 0.5].entries()) {
+      build.update({
+        elapsed: index + 1,
+        delta,
+        emphasis: 0,
+        runDecorativeEffects: false,
+      });
+    }
+
+    expect(build.getDebugState().energy.direction).toBe('outgoing');
+    expect(collectPacketState()).toEqual(before);
+    build.dispose();
+  });
+
+  it('renders outgoing transfers from the port to the POI with a stronger wider packet', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+      detailPolicy: SCENE_DETAIL_POLICIES.balanced,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'tokenplace-studio-cluster',
+        label: 'TokenPlace',
+        floorId: 'ground',
+        worldPosition: { x: -2, y: 0, z: 1 },
+      },
+      {
+        poiId: 'jobbot-studio-terminal',
+        label: 'Jobbot',
+        floorId: 'ground',
+        worldPosition: { x: 3, y: 0, z: -1 },
+      },
+    ]);
+    build.update({
+      elapsed: 0,
+      delta: 0.2,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const incoming = build.getDebugState().energy;
+    const packet = build.group.getObjectByName('FlywheelEnergyTransferPacket')!;
+    const maxVisibleNodeScale = () =>
+      Math.max(
+        ...packet.children
+          .filter(
+            (child) =>
+              child.name.startsWith('FlywheelEnergyPacketNode') && child.visible
+          )
+          .map((child) => child.scale.x)
+      );
+    const incomingScale = maxVisibleNodeScale();
+
+    for (const [index, delta] of [2.6, 2.8, 2.8, 2.8, 2.8].entries()) {
+      build.update({
+        elapsed: index + 1,
+        delta,
+        emphasis: 0,
+        runDecorativeEffects: false,
+      });
+    }
+    build.update({
+      elapsed: 6,
+      delta: 0.5,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+
+    const outgoing = build.getDebugState().energy;
+    const outgoingTarget =
+      outgoing.selectedTargetId === 'tokenplace-studio-cluster'
+        ? { x: -2, y: 0.95, z: 1 }
+        : { x: 3, y: 0.95, z: -1 };
+    expect(outgoing.direction).toBe('outgoing');
+    expect(outgoing.sourceWorldPosition).toEqual({
+      x: FLYWHEEL_ENERGY_PORT.x,
+      y: FLYWHEEL_ENERGY_PORT.y,
+      z: FLYWHEEL_ENERGY_PORT.z,
+    });
+    expect(outgoing.destinationWorldPosition).toEqual(outgoingTarget);
+    expect(
+      outgoing.visibleWindowEnd! - outgoing.visibleWindowStart!
+    ).toBeGreaterThan(
+      incoming.visibleWindowEnd! - incoming.visibleWindowStart!
+    );
+    expect(outgoing.activeNodeCount).toBeGreaterThanOrEqual(
+      incoming.activeNodeCount
+    );
+    expect(maxVisibleNodeScale()).toBeGreaterThan(incomingScale);
+    build.dispose();
+  });
+
+  it('returns defensive copies for energy debug state', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.setEnergyTargets(
+      [
+        {
+          poiId: 'tokenplace-studio-cluster',
+          label: 'TokenPlace',
+          floorId: 'ground',
+          worldPosition: { x: -2, y: 0, z: 1 },
+        },
+        {
+          poiId: 'jobbot-studio-terminal',
+          label: 'Jobbot',
+          floorId: 'ground',
+          worldPosition: { x: 3, y: 0, z: -1 },
+        },
+      ],
+      ['missing-visual-anchor:optional']
+    );
+    build.update({
+      elapsed: 0,
+      delta: 0.2,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+
+    const first = build.getDebugState().energy;
+    first.missingTargetDiagnostics.push('mutated');
+    first.sourceWorldPosition!.x = 999;
+    first.destinationWorldPosition!.z = 999;
+    first.sourceLocalPosition!.y = 999;
+    first.destinationLocalPosition!.y = 999;
+
+    const second = build.getDebugState().energy;
+    expect(second.missingTargetDiagnostics).toEqual([
+      'missing-visual-anchor:optional',
+    ]);
+    expect(second.sourceWorldPosition?.x).not.toBe(999);
+    expect(second.destinationWorldPosition?.z).not.toBe(999);
+    expect(second.sourceLocalPosition?.y).not.toBe(999);
+    expect(second.destinationLocalPosition?.y).not.toBe(999);
+    build.dispose();
   });
 
   it('keeps miniature proxy semantics in sync', () => {


### PR DESCRIPTION
### Motivation
- Add the metaphorical Flywheel energy-transfer layer (glowing blue parabolic arcs) that deterministically cycles five incoming transfers into the Flywheel and one outgoing transfer back to a ground-floor POI while preserving the physical crank/gear/flywheel motion.
- Keep the selection and cycle deterministic and pure so rendering and tests can reason about target order and phase without using `Math.random()` at runtime.
- Use pooled, detail-aware presentation objects so the arcs are performant across detail policies and accessibility settings.

### Description
- Introduces a pure deterministic network `src/scene/structures/flywheelEnergyNetwork.ts` which provides seeded target selection, 5-in/1-out cycle state, active-transfer state, visible-window math, parabolic arc sampling helpers, sanitization, and debug snapshots.
- Extends the Flywheel showpiece API with `setEnergyTargets(...)`, integrates the network into `src/scene/structures/flywheel.ts`, and adds a pooled `FlywheelEnergyTransferPacket` (preallocated node meshes and connectors) that renders only the moving visible window subsection of the active arc in local space.
- Adds runtime target resolution to `src/main.ts` to gather ground-floor POIs (using the floor resolver and `resolvePoiVisualAnchor(...)`), compute `Object3D.getWorldPosition(...)` coordinates, fail open with diagnostics, and call `flywheelShowpiece.setEnergyTargets(...)` after structures/anchors are created.
- Updates the Flywheel miniature proxy and regenerates the miniature manifest to include static incoming/outgoing arc hints and records the network source in the manifest; documents the P6c implementation in `docs/architecture/flywheel-energy-transfer.md`.
- Adds focused tests: `src/tests/flywheelEnergyNetwork.test.ts` (seeded determinism, 5-in/1-out cadence, exclusions, no input mutation, visible-window and sampling) and updates `src/tests/flywheelShowpiece.test.ts` to assert runtime `setEnergyTargets(...)`, bounded packet rendering, accessibility scales, and miniature hints.

### Testing
- Ran formatting: `npm run format:write` — succeeded.
- Updated miniature manifest and validated: `npm run miniature:manifest:update` and `npm run miniature:check` — succeeded and manifest updated to include arc hints.
- Unit tests (focused): `npm run test:ci -- src/tests/flywheelEnergyNetwork.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts` — all passed.
- Additional CI tests: `npm run test:ci -- src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts` — passed.
- Lint, build, docs and smoke: `npm run lint`, `npm run build`, `npm run docs:check`, `npm run smoke`, `npm run format:check` — all completed (docs link-check produced external fetch warnings; not caused by this change).
- Security scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.
- Typecheck: `npm run typecheck -- --pretty false` — reported pre-existing, project-wide TypeScript errors unrelated to this change (documented in PR notes) and therefore not blocked by this feature work.

If you want I can split follow-ups (performance/accessibility hardening, additional integration tests, or visual QA checklist) into dedicated PRs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f3afafc832fa6cc668713e871ff)