### PR TITLE
🧪 Add Flywheel energy packet QA regressions

### DIFF
--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -1,4 +1,4 @@
-import { MathUtils, Object3D } from 'three';
+import { MathUtils, Mesh, Object3D } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { SCENE_DETAIL_POLICIES } from '../scene/graphics/sceneDetailPolicy';
@@ -9,6 +9,7 @@ import {
   FLYWHEEL_BASE_COLLIDER,
   FLYWHEEL_CRANK_RAD_PER_SECOND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
+  FLYWHEEL_ENERGY_PORT,
   FLYWHEEL_GEARBOX_COLLIDER,
   FLYWHEEL_INSTALLATION_BOUNDS,
   FLYWHEEL_MARKER_MIN_HEIGHT,
@@ -318,6 +319,204 @@ describe('createFlywheelShowpiece', () => {
       }
       build.dispose();
     }
+  });
+
+  it('reuses the pooled energy packet meshes, geometry, and materials across updates', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+      detailPolicy: SCENE_DETAIL_POLICIES.balanced,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'tokenplace-studio-cluster',
+        label: 'TokenPlace',
+        floorId: 'ground',
+        worldPosition: { x: -2, y: 0, z: 1 },
+      },
+      {
+        poiId: 'jobbot-studio-terminal',
+        label: 'Jobbot',
+        floorId: 'ground',
+        worldPosition: { x: 3, y: 0, z: -1 },
+      },
+    ]);
+    build.update({
+      elapsed: 0,
+      delta: 0.2,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+
+    const collectPacketState = () => {
+      const packets = build.group.children.filter(
+        (child) => child.name === 'FlywheelEnergyTransferPacket'
+      );
+      const packet = packets[0]!;
+      const nodes = packet.children.filter((child) =>
+        child.name.startsWith('FlywheelEnergyPacketNode')
+      ) as Mesh[];
+      const connectors = packet.children.filter((child) =>
+        child.name.startsWith('FlywheelEnergyPacketConnector')
+      ) as Mesh[];
+      return {
+        packetCount: packets.length,
+        nodeUuids: nodes.map((node) => node.uuid),
+        connectorUuids: connectors.map((connector) => connector.uuid),
+        geometryUuids: [...nodes, ...connectors].map(
+          (item) => item.geometry.uuid
+        ),
+        materialUuids: [...nodes, ...connectors].map((item) => {
+          const material = item.material;
+          return Array.isArray(material)
+            ? material.map((entry) => entry.uuid).join('|')
+            : material.uuid;
+        }),
+      };
+    };
+
+    const before = collectPacketState();
+    expect(before.packetCount).toBe(1);
+    expect(before.nodeUuids.length).toBeGreaterThanOrEqual(2);
+    expect(before.connectorUuids.length).toBeGreaterThanOrEqual(1);
+
+    for (const [index, delta] of [2.6, 2.8, 2.8, 2.8, 2.8, 0.5].entries()) {
+      build.update({
+        elapsed: index + 1,
+        delta,
+        emphasis: 0,
+        runDecorativeEffects: false,
+      });
+    }
+
+    expect(build.getDebugState().energy.direction).toBe('outgoing');
+    expect(collectPacketState()).toEqual(before);
+    build.dispose();
+  });
+
+  it('renders outgoing transfers from the port to the POI with a stronger wider packet', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+      detailPolicy: SCENE_DETAIL_POLICIES.balanced,
+    });
+    build.setEnergyTargets([
+      {
+        poiId: 'tokenplace-studio-cluster',
+        label: 'TokenPlace',
+        floorId: 'ground',
+        worldPosition: { x: -2, y: 0, z: 1 },
+      },
+      {
+        poiId: 'jobbot-studio-terminal',
+        label: 'Jobbot',
+        floorId: 'ground',
+        worldPosition: { x: 3, y: 0, z: -1 },
+      },
+    ]);
+    build.update({
+      elapsed: 0,
+      delta: 0.2,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    const incoming = build.getDebugState().energy;
+    const packet = build.group.getObjectByName('FlywheelEnergyTransferPacket')!;
+    const maxVisibleNodeScale = () =>
+      Math.max(
+        ...packet.children
+          .filter(
+            (child) =>
+              child.name.startsWith('FlywheelEnergyPacketNode') && child.visible
+          )
+          .map((child) => child.scale.x)
+      );
+    const incomingScale = maxVisibleNodeScale();
+
+    for (const [index, delta] of [2.6, 2.8, 2.8, 2.8, 2.8].entries()) {
+      build.update({
+        elapsed: index + 1,
+        delta,
+        emphasis: 0,
+        runDecorativeEffects: false,
+      });
+    }
+    build.update({
+      elapsed: 6,
+      delta: 0.5,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+
+    const outgoing = build.getDebugState().energy;
+    const outgoingTarget =
+      outgoing.selectedTargetId === 'tokenplace-studio-cluster'
+        ? { x: -2, y: 0.95, z: 1 }
+        : { x: 3, y: 0.95, z: -1 };
+    expect(outgoing.direction).toBe('outgoing');
+    expect(outgoing.sourceWorldPosition).toEqual({
+      x: FLYWHEEL_ENERGY_PORT.x,
+      y: FLYWHEEL_ENERGY_PORT.y,
+      z: FLYWHEEL_ENERGY_PORT.z,
+    });
+    expect(outgoing.destinationWorldPosition).toEqual(outgoingTarget);
+    expect(
+      outgoing.visibleWindowEnd! - outgoing.visibleWindowStart!
+    ).toBeGreaterThan(
+      incoming.visibleWindowEnd! - incoming.visibleWindowStart!
+    );
+    expect(outgoing.activeNodeCount).toBeGreaterThanOrEqual(
+      incoming.activeNodeCount
+    );
+    expect(maxVisibleNodeScale()).toBeGreaterThan(incomingScale);
+    build.dispose();
+  });
+
+  it('returns defensive copies for energy debug state', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.setEnergyTargets(
+      [
+        {
+          poiId: 'tokenplace-studio-cluster',
+          label: 'TokenPlace',
+          floorId: 'ground',
+          worldPosition: { x: -2, y: 0, z: 1 },
+        },
+        {
+          poiId: 'jobbot-studio-terminal',
+          label: 'Jobbot',
+          floorId: 'ground',
+          worldPosition: { x: 3, y: 0, z: -1 },
+        },
+      ],
+      ['missing-visual-anchor:optional']
+    );
+    build.update({
+      elapsed: 0,
+      delta: 0.2,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+
+    const first = build.getDebugState().energy;
+    first.missingTargetDiagnostics.push('mutated');
+    first.sourceWorldPosition!.x = 999;
+    first.destinationWorldPosition!.z = 999;
+    first.sourceLocalPosition!.y = 999;
+    first.destinationLocalPosition!.y = 999;
+
+    const second = build.getDebugState().energy;
+    expect(second.missingTargetDiagnostics).toEqual([
+      'missing-visual-anchor:optional',
+    ]);
+    expect(second.sourceWorldPosition?.x).not.toBe(999);
+    expect(second.destinationWorldPosition?.z).not.toBe(999);
+    expect(second.sourceLocalPosition?.y).not.toBe(999);
+    expect(second.destinationLocalPosition?.y).not.toBe(999);
+    build.dispose();
   });
 
   it('keeps miniature proxy semantics in sync', () => {


### PR DESCRIPTION
### Motivation
- Close the last prompt-scoped QA gaps for the Flywheel P6c energy-transfer surface by adding focused regression tests that exercise pooled presentation, outgoing rendering, and defensive debug-copy behavior.

### Description
- Add three focused tests to `src/tests/flywheelShowpiece.test.ts` that verify pooled `FlywheelEnergyTransferPacket` reuse across updates, assert outgoing-transfer geometry/visibility/strength semantics, and confirm `getDebugState().energy` returns defensive copies.
- Import `Mesh` and `FLYWHEEL_ENERGY_PORT` in the test file to inspect packet nodes/connectors and to assert outgoing source coordinates.
- Keep changes narrowly scoped to the single test file (`src/tests/flywheelShowpiece.test.ts`) so the runtime code and unrelated systems are untouched.

### Testing
- Ran formatting and manifest workflows: `npm run format:write`, `npm run miniature:manifest:update`, and `npm run miniature:check` — passed and manifest updated as expected.
- Ran focused unit suites: `npm run test:ci -- src/tests/flywheelEnergyNetwork.test.ts src/tests/flywheelShowpiece.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts` and `npm run test:ci -- src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts` — all passed (total 39 + 8 tests shown passing in the run logs).
- Ran `npm run lint`, `npm run build`, `npm run docs:check`, `npm run smoke`, and `npm run format:check` — all completed (build produced an existing Vite chunk-size warning; docs link-check emitted external fetch warnings).
- Ran `npm run typecheck` — failed due to pre-existing, project-wide TypeScript errors unrelated to Flywheel/P6c; grepping the typecheck output showed no Flywheel/P6c-related type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f598615c4832f8ad0b593ebf5fe68)