### PR TITLE
🛠️ : – clarify flywheel machine geometry

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -766,3 +766,50 @@ index, current direction/target/phase, visible window start/end, incoming and
 outgoing completion counts, source/destination world and local positions, active
 node count, detail level, and reduced pulse/flicker scale values. Returned arrays
 and points are copies so callers cannot mutate internal network state.
+
+## P6b.1 visual QA correction: separated physical flywheel layout
+
+P6b.1 keeps the P6c five-in/one-out blue packet network intact and only adjusts
+physical readability. The local coordinate contract is now explicit: +X is the
+right side of the machine, +Y is up, +Z is the front face, and both the flywheel
+and planetary gearbox faces lie in the X/Y plane with their spin axes along Z.
+The hand crank is mounted on the gearbox front face.
+
+The corrected physical constants place the heavy wheel left of the root at
+`centerX = -0.78`, `centerY = 1.30`, `radius = 0.84`, and `rimTube = 0.11`.
+The planetary gearbox is separated to the right and slightly forward at
+`centerX = 1.08`, `centerY = 1.26`, `centerZ = 0.38`, with `radius = 0.46`.
+The crank center uses the contract formula
+`gearbox.centerZ + gearbox.depth / 2 + gearbox.crankClearance`, putting the
+handle in front of the gearbox instead of inside the flywheel silhouette.
+
+The layout is guarded by formula-based non-overlap invariants in
+`flywheelEnergyContract.ts`:
+
+```ts
+const wheelOuterRadius = FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube;
+const gearboxOuterRadius =
+  FLYWHEEL_RING_RADIUS +
+  FLYWHEEL_GEAR_TOOTH_LENGTH +
+  FLYWHEEL_GEARBOX_HOUSING_PAD;
+const wheelGearClearance =
+  FLYWHEEL_GEARBOX.centerX -
+  gearboxOuterRadius -
+  (FLYWHEEL_WHEEL.centerX + wheelOuterRadius);
+```
+
+`wheelGearClearance` must remain at least `0.18`, so the visible ring gear,
+teeth, housing, crank, and glow accents stay outside the flywheel rim envelope.
+The old large cyan visual accent is reduced to a slim inner energy ring, leaving
+the dark heavy rim, hub, spokes, brass counterweights, gearbox, and crank as the
+dominant silhouette.
+
+The hierarchy now uses front/back axle support names that match the Z-axis axle:
+`FlywheelBearingYokeFront`, `FlywheelBearingYokeBack`, `FlywheelAxleCapFront`,
+and `FlywheelAxleCapBack`. The gearbox sits on `FlywheelGearboxPedestal`, and
+`FlywheelOutputShaft` plus `FlywheelOutputCoupler` visibly bridge the horizontal
+power path from the planet carrier toward the flywheel hub. Animation remains
+mechanically grounded: crank and sun share the crank angle, carrier/output and
+flywheel use the fixed-ring torque ratio, and the asymmetric counterweights are
+children of `FlywheelWheelGroup` so their rotation makes the slower flywheel
+motion readable.

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "8719cf12668745d043361e32da42ef82a169cde2ddb910d72f043dc6768e2c1b",
+      "proxyFingerprint": "69e921e0927896220862ec8c3ec03dba16c37baed9917d894f9c985612c5eca0",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 9,
-      "syncNote": "Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.",
-      "sourceFingerprint": "6c5e609c0f5d6983f705d164bae47ef76bb114f76c23c90b52a04c4d8f9de4b1",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
-      "metadataFingerprint": "0e744e5f1efca45fe87a9d153b90c1d29b1f114d2288047d8d44c60d0c01e934"
+      "syncRevision": 10,
+      "syncNote": "Tracks wheel-left gearbox-right geometry with front crank and torque coupler silhouette.",
+      "sourceFingerprint": "53b045e502ae1e5efc92577cc2d98487b6dad5ac57a3320a4b7e3df2bc98be29",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
+      "metadataFingerprint": "564884a1ac71cef1bd8aa1a17bed6efd451de940192c76e397c580319f15c4eb"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "011559a0e31ec5116e4369d2f8807e04e66a8317e06d6f611bef063161202b47",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 9,
+    syncRevision: 10,
     syncNote:
-      'Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.',
+      'Tracks wheel-left gearbox-right geometry with front crank and torque coupler silhouette.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
@@ -103,15 +103,15 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     primitives: [
       box('flywheel-base', [1.35, 0.12, 0.64], [0, 0.06, 0], 0x17202a),
       box(
-        'flywheel-bearing-left',
-        [0.1, 0.72, 0.18],
-        [-0.48, 0.42, 0],
+        'flywheel-bearing-yoke-front',
+        [0.28, 0.72, 0.08],
+        [-0.34, 0.42, 0.17],
         0x94a3b8
       ),
       box(
-        'flywheel-bearing-right',
-        [0.1, 0.72, 0.18],
-        [0.04, 0.42, 0],
+        'flywheel-bearing-yoke-back',
+        [0.28, 0.72, 0.08],
+        [-0.34, 0.42, -0.17],
         0x94a3b8
       ),
       {
@@ -119,25 +119,31 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         name: 'flywheel-heavy-wheel',
         radius: FLYWHEEL_WHEEL.radius * 0.35,
         tube: 0.055,
-        position: [-0.22, 0.64, 0],
+        position: [-0.34, 0.64, 0],
         rotation: [0, 0, 0],
         color: 0x1f2937,
       },
-      box('flywheel-spoke', [0.56, 0.04, 0.04], [-0.22, 0.64, 0], 0xcbd5e1),
+      box('flywheel-spoke', [0.56, 0.04, 0.04], [-0.34, 0.64, 0], 0xcbd5e1),
       box(
         'flywheel-crank-arm',
         [0.36, 0.035, 0.035],
-        [0.42, 0.64, 0.24],
+        [0.5, 0.62, 0.3],
         0xf59e0b
       ),
       cyl(
         'flywheel-planetary-gear-cluster',
-        0.18,
+        0.17,
         0.12,
-        [0.38, 0.58, 0],
+        [0.48, 0.61, 0.18],
         0xd1d5db
       ),
-      sphere('flywheel-energy-port', 0.07, [0.56, 0.8, 0.28], 0x38bdf8),
+      box(
+        'flywheel-output-coupler',
+        [0.58, 0.04, 0.04],
+        [0.08, 0.64, 0.18],
+        0xd97706
+      ),
+      sphere('flywheel-energy-port', 0.07, [0.62, 0.8, 0.36], 0x38bdf8),
       {
         kind: 'tube',
         name: 'flywheel-incoming-arc-hint',
@@ -145,7 +151,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         points: [
           [-0.95, 0.18, -0.62],
           [-0.42, 1.06, -0.18],
-          [0.56, 0.8, 0.28],
+          [0.62, 0.8, 0.36],
         ],
         color: 0x38bdf8,
       },
@@ -154,7 +160,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         name: 'flywheel-outgoing-arc-hint',
         radius: 0.024,
         points: [
-          [0.56, 0.8, 0.28],
+          [0.62, 0.8, 0.36],
           [0.12, 1.22, 0.58],
           [1.05, 0.22, 0.76],
         ],

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -28,11 +28,13 @@ import {
   FLYWHEEL_BASE_DIMENSIONS,
   FLYWHEEL_BEARING_STAND,
   FLYWHEEL_CRANK,
+  FLYWHEEL_CRANK_CENTER_Z,
   FLYWHEEL_CRANK_RAD_PER_SECOND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
   FLYWHEEL_ENERGY_PORT,
   FLYWHEEL_GEARBOX,
   FLYWHEEL_GEARBOX_COLLIDER,
+  FLYWHEEL_GEARBOX_OUTER_RADIUS,
   FLYWHEEL_PLANET_ORBIT_RADIUS,
   FLYWHEEL_PLANET_RADIUS,
   FLYWHEEL_PLANET_TEETH,
@@ -223,25 +225,50 @@ export function createFlywheelShowpiece(
   base.position.y = FLYWHEEL_BASE_DIMENSIONS.height / 2;
   group.add(base);
 
-  for (const [name, x] of [
-    ['FlywheelBearingStandLeft', FLYWHEEL_WHEEL.centerX - 0.62],
-    ['FlywheelBearingStandRight', FLYWHEEL_WHEEL.centerX + 0.62],
+  for (const [name, z] of [
+    [
+      'FlywheelBearingYokeFront',
+      FLYWHEEL_WHEEL.centerZ + FLYWHEEL_BEARING_STAND.yokeSpan / 2,
+    ],
+    [
+      'FlywheelBearingYokeBack',
+      FLYWHEEL_WHEEL.centerZ - FLYWHEEL_BEARING_STAND.yokeSpan / 2,
+    ],
   ] as const) {
-    const stand = mesh(
-      name,
-      new BoxGeometry(
-        FLYWHEEL_BEARING_STAND.width,
-        FLYWHEEL_BEARING_STAND.height,
-        FLYWHEEL_BEARING_STAND.depth
-      ),
-      steel
+    const yoke = new Group();
+    yoke.name = name;
+    yoke.position.set(FLYWHEEL_WHEEL.centerX, 0, z);
+    group.add(yoke);
+    for (const [postName, x] of [
+      ['LeftPost', -0.18],
+      ['RightPost', 0.18],
+    ] as const) {
+      const post = mesh(
+        `${name}${postName}`,
+        new BoxGeometry(
+          FLYWHEEL_BEARING_STAND.width,
+          FLYWHEEL_BEARING_STAND.height,
+          FLYWHEEL_BEARING_STAND.depth
+        ),
+        steel
+      );
+      post.position.set(
+        x,
+        FLYWHEEL_BASE_DIMENSIONS.height + FLYWHEEL_BEARING_STAND.height / 2,
+        0
+      );
+      yoke.add(post);
+    }
+    const cap = mesh(
+      name === 'FlywheelBearingYokeFront'
+        ? 'FlywheelAxleCapFront'
+        : 'FlywheelAxleCapBack',
+      new CylinderGeometry(0.13, 0.13, 0.08, cylSeg),
+      brass
     );
-    stand.position.set(
-      x,
-      FLYWHEEL_BASE_DIMENSIONS.height + FLYWHEEL_BEARING_STAND.height / 2,
-      0
-    );
-    group.add(stand);
+    cap.position.set(0, FLYWHEEL_WHEEL.centerY, 0);
+    cap.rotation.x = Math.PI / 2;
+    yoke.add(cap);
   }
 
   const axle = mesh(
@@ -303,7 +330,7 @@ export function createFlywheelShowpiece(
   }
   const glowRing = mesh(
     'FlywheelEnergyGlowRing',
-    new TorusGeometry(FLYWHEEL_WHEEL.radius * 0.82, 0.018, 4, torusSeg),
+    new TorusGeometry(FLYWHEEL_WHEEL.radius * 0.68, 0.012, 4, torusSeg),
     glow
   );
   wheelGroup.add(glowRing);
@@ -316,6 +343,12 @@ export function createFlywheelShowpiece(
     FLYWHEEL_GEARBOX.centerZ
   );
   group.add(gearbox);
+  const gearboxHousing = mesh(
+    'FlywheelGearboxHousing',
+    new TorusGeometry(FLYWHEEL_GEARBOX_OUTER_RADIUS, 0.025, 4, torusSeg),
+    dark
+  );
+  gearbox.add(gearboxHousing);
   const ringGear = mesh(
     'FlywheelRingGear',
     new TorusGeometry(FLYWHEEL_RING_RADIUS, 0.045, 4, torusSeg),
@@ -359,13 +392,48 @@ export function createFlywheelShowpiece(
     carrier.add(planet);
     planetGears.push(planet);
   }
+  const outputLength = FLYWHEEL_GEARBOX.centerX - FLYWHEEL_WHEEL.centerX;
   const output = mesh(
     'FlywheelOutputShaft',
-    new CylinderGeometry(0.055, 0.055, 0.95, cylSeg),
+    new CylinderGeometry(0.055, 0.055, outputLength, cylSeg),
     steel
   );
-  output.rotation.x = Math.PI / 2;
-  gearbox.add(output);
+  output.position.set(
+    (FLYWHEEL_WHEEL.centerX + FLYWHEEL_GEARBOX.centerX) / 2,
+    FLYWHEEL_WHEEL.centerY,
+    FLYWHEEL_GEARBOX.centerZ
+  );
+  output.rotation.z = Math.PI / 2;
+  group.add(output);
+  const coupler = mesh(
+    'FlywheelOutputCoupler',
+    new CylinderGeometry(0.13, 0.13, 0.08, cylSeg),
+    brass
+  );
+  coupler.position.set(
+    FLYWHEEL_WHEEL.centerX,
+    FLYWHEEL_WHEEL.centerY,
+    FLYWHEEL_GEARBOX.centerZ
+  );
+  coupler.rotation.x = Math.PI / 2;
+  group.add(coupler);
+
+  const gearboxPedestal = mesh(
+    'FlywheelGearboxPedestal',
+    new BoxGeometry(
+      0.46,
+      FLYWHEEL_GEARBOX.centerY - FLYWHEEL_GEARBOX_OUTER_RADIUS,
+      0.34
+    ),
+    steel
+  );
+  gearboxPedestal.position.set(
+    FLYWHEEL_GEARBOX.centerX,
+    FLYWHEEL_BASE_DIMENSIONS.height +
+      (FLYWHEEL_GEARBOX.centerY - FLYWHEEL_GEARBOX_OUTER_RADIUS) / 2,
+    FLYWHEEL_GEARBOX.centerZ
+  );
+  group.add(gearboxPedestal);
 
   addTeeth(
     gearbox,
@@ -405,7 +473,7 @@ export function createFlywheelShowpiece(
   crankGroup.position.set(
     FLYWHEEL_GEARBOX.centerX,
     FLYWHEEL_GEARBOX.centerY,
-    FLYWHEEL_GEARBOX.centerZ + 0.34
+    FLYWHEEL_CRANK_CENTER_Z
   );
   group.add(crankGroup);
   const crankDisc = mesh(
@@ -751,7 +819,8 @@ export function createFlywheelShowpiece(
       crankGroup.rotation.z = crankAngle;
       sunGear.rotation.z = crankAngle;
       carrier.rotation.z = carrierAngle;
-      output.rotation.z = carrierAngle;
+      output.rotation.x = carrierAngle;
+      coupler.rotation.z = carrierAngle;
       wheelGroup.rotation.z = carrierAngle;
       planetGears.forEach((planet) => {
         planet.rotation.z = planetLocalSpin;

--- a/src/scene/structures/flywheelEnergyContract.ts
+++ b/src/scene/structures/flywheelEnergyContract.ts
@@ -9,18 +9,19 @@ export const FLYWHEEL_BASE_DIMENSIONS = {
   height: 0.22,
 } as const;
 export const FLYWHEEL_WHEEL = {
-  radius: 0.92,
-  rimTube: 0.12,
+  radius: 0.84,
+  rimTube: 0.11,
   thickness: 0.24,
-  centerX: -0.58,
-  centerY: 1.35,
+  centerX: -0.78,
+  centerY: 1.3,
   centerZ: 0,
 } as const;
-export const FLYWHEEL_AXLE = { radius: 0.075, length: 2.35 } as const;
+export const FLYWHEEL_AXLE = { radius: 0.075, length: 1.42 } as const;
 export const FLYWHEEL_BEARING_STAND = {
-  width: 0.18,
-  depth: 0.42,
-  height: 1.34,
+  width: 0.16,
+  depth: 0.16,
+  height: 1.22,
+  yokeSpan: 0.52,
 } as const;
 export const FLYWHEEL_CRANK = {
   radius: 0.38,
@@ -28,17 +29,19 @@ export const FLYWHEEL_CRANK = {
   handleRadius: 0.045,
 } as const;
 export const FLYWHEEL_GEARBOX = {
-  centerX: 0.78,
-  centerY: 1.24,
-  centerZ: 0,
-  radius: 0.52,
-  depth: 0.26,
+  centerX: 1.08,
+  centerY: 1.26,
+  centerZ: 0.38,
+  radius: 0.46,
+  depth: 0.28,
+  housingPad: 0.07,
+  crankClearance: 0.12,
 } as const;
 export const FLYWHEEL_ENERGY_PORT = {
-  x: 1.32,
-  y: 1.62,
-  z: 0.62,
-  radius: 0.13,
+  x: 1.42,
+  y: 1.58,
+  z: 0.76,
+  radius: 0.12,
 } as const;
 export const FLYWHEEL_SUN_TEETH = 18;
 export const FLYWHEEL_PLANET_TEETH = 24;
@@ -46,23 +49,42 @@ export const FLYWHEEL_RING_TEETH =
   FLYWHEEL_SUN_TEETH + FLYWHEEL_PLANET_TEETH * 2;
 export const FLYWHEEL_TORQUE_RATIO =
   1 + FLYWHEEL_RING_TEETH / FLYWHEEL_SUN_TEETH;
-export const FLYWHEEL_CRANK_RAD_PER_SECOND = 1.2;
+export const FLYWHEEL_CRANK_RAD_PER_SECOND = 1.65;
 export const FLYWHEEL_EMPHASIS_SPEED_BOOST = 0.14;
 export const FLYWHEEL_SUN_RADIUS = 0.14;
 export const FLYWHEEL_PLANET_RADIUS =
   (FLYWHEEL_SUN_RADIUS * FLYWHEEL_PLANET_TEETH) / FLYWHEEL_SUN_TEETH;
 export const FLYWHEEL_RING_RADIUS =
   FLYWHEEL_SUN_RADIUS + FLYWHEEL_PLANET_RADIUS * 2;
+export const FLYWHEEL_GEAR_TOOTH_LENGTH = 0.055;
+export const FLYWHEEL_GEARBOX_HOUSING_PAD = FLYWHEEL_GEARBOX.housingPad;
+export const FLYWHEEL_WHEEL_OUTER_RADIUS =
+  FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube;
+export const FLYWHEEL_GEARBOX_OUTER_RADIUS =
+  FLYWHEEL_RING_RADIUS +
+  FLYWHEEL_GEAR_TOOTH_LENGTH +
+  FLYWHEEL_GEARBOX_HOUSING_PAD;
+export const FLYWHEEL_WHEEL_RIGHT_EDGE =
+  FLYWHEEL_WHEEL.centerX + FLYWHEEL_WHEEL_OUTER_RADIUS;
+export const FLYWHEEL_GEARBOX_LEFT_EDGE =
+  FLYWHEEL_GEARBOX.centerX - FLYWHEEL_GEARBOX_OUTER_RADIUS;
+export const FLYWHEEL_WHEEL_GEAR_CLEARANCE =
+  FLYWHEEL_GEARBOX_LEFT_EDGE - FLYWHEEL_WHEEL_RIGHT_EDGE;
+export const FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE = 0.18;
+export const FLYWHEEL_CRANK_CENTER_Z =
+  FLYWHEEL_GEARBOX.centerZ +
+  FLYWHEEL_GEARBOX.depth / 2 +
+  FLYWHEEL_GEARBOX.crankClearance;
 export const FLYWHEEL_PLANET_ORBIT_RADIUS =
   FLYWHEEL_SUN_RADIUS + FLYWHEEL_PLANET_RADIUS;
 export const FLYWHEEL_MARKER_MIN_HEIGHT = 2.95;
 export const FLYWHEEL_AVATAR_PATH_RADIUS = 1.2;
 export const FLYWHEEL_BASE_COLLIDER = { width: 3.25, depth: 1.55 } as const;
 export const FLYWHEEL_GEARBOX_COLLIDER = {
-  centerX: 0.92,
-  centerZ: 0.42,
-  width: 0.95,
-  depth: 0.74,
+  centerX: 1.08,
+  centerZ: 0.43,
+  width: 0.92,
+  depth: 0.94,
 } as const;
 
 export function getFlywheelCarrierAngle(sunAngle: number): number {

--- a/src/tests/flywheelEnergyContract.test.ts
+++ b/src/tests/flywheelEnergyContract.test.ts
@@ -2,11 +2,20 @@ import { describe, expect, it } from 'vitest';
 
 import {
   FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_CRANK,
+  FLYWHEEL_CRANK_CENTER_Z,
+  FLYWHEEL_GEARBOX,
+  FLYWHEEL_GEARBOX_LEFT_EDGE,
+  FLYWHEEL_GEARBOX_OUTER_RADIUS,
   FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE,
   FLYWHEEL_PLANET_TEETH,
   FLYWHEEL_RING_TEETH,
   FLYWHEEL_SUN_TEETH,
   FLYWHEEL_TORQUE_RATIO,
+  FLYWHEEL_WHEEL,
+  FLYWHEEL_WHEEL_GEAR_CLEARANCE,
+  FLYWHEEL_WHEEL_RIGHT_EDGE,
   getFlywheelCarrierAngle,
   getFlywheelPlanetLocalSpin,
 } from '../scene/structures/flywheelEnergyContract';
@@ -28,6 +37,29 @@ describe('flywheel energy contract', () => {
       1 + FLYWHEEL_RING_TEETH / FLYWHEEL_SUN_TEETH
     );
     expect(FLYWHEEL_TORQUE_RATIO).toBeGreaterThan(4);
+  });
+
+  it('separates the gearbox envelope from the flywheel rim', () => {
+    expect(FLYWHEEL_GEARBOX_LEFT_EDGE).toBeGreaterThan(
+      FLYWHEEL_WHEEL_RIGHT_EDGE
+    );
+    expect(FLYWHEEL_WHEEL_GEAR_CLEARANCE).toBeGreaterThanOrEqual(
+      FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE
+    );
+    expect(FLYWHEEL_GEARBOX.centerX - FLYWHEEL_GEARBOX_OUTER_RADIUS).toBe(
+      FLYWHEEL_GEARBOX_LEFT_EDGE
+    );
+    expect(
+      FLYWHEEL_WHEEL.centerX + FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube
+    ).toBe(FLYWHEEL_WHEEL_RIGHT_EDGE);
+  });
+
+  it('places the front crank outside the wheel and gearbox faces', () => {
+    const crankLeftEdge = FLYWHEEL_GEARBOX.centerX - FLYWHEEL_CRANK.radius;
+    expect(crankLeftEdge).toBeGreaterThan(FLYWHEEL_WHEEL_RIGHT_EDGE);
+    expect(FLYWHEEL_CRANK_CENTER_Z).toBeGreaterThan(
+      FLYWHEEL_GEARBOX.centerZ + FLYWHEEL_GEARBOX.depth / 2
+    );
   });
 
   it('keeps carrier and planet spin synchronized from one sun angle', () => {

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -10,18 +10,24 @@ import {
   FLYWHEEL_CRANK_RAD_PER_SECOND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
   FLYWHEEL_ENERGY_PORT,
+  FLYWHEEL_GEARBOX,
   FLYWHEEL_GEARBOX_COLLIDER,
+  FLYWHEEL_GEARBOX_LEFT_EDGE,
   FLYWHEEL_INSTALLATION_BOUNDS,
   FLYWHEEL_MARKER_MIN_HEIGHT,
   FLYWHEEL_TORQUE_RATIO,
+  FLYWHEEL_WHEEL,
+  FLYWHEEL_WHEEL_RIGHT_EDGE,
 } from '../scene/structures/flywheelEnergyContract';
 
 const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
 
 const coreNames = [
   'FlywheelBase',
-  'FlywheelBearingStandLeft',
-  'FlywheelBearingStandRight',
+  'FlywheelBearingYokeFront',
+  'FlywheelBearingYokeBack',
+  'FlywheelAxleCapFront',
+  'FlywheelAxleCapBack',
   'FlywheelAxle',
   'FlywheelWheelGroup',
   'FlywheelHeavyRim',
@@ -37,6 +43,8 @@ const coreNames = [
   'FlywheelPlanetCarrier',
   'FlywheelPlanetGear-0',
   'FlywheelOutputShaft',
+  'FlywheelOutputCoupler',
+  'FlywheelGearboxPedestal',
   'FlywheelEnergyPort',
 ];
 
@@ -115,12 +123,55 @@ describe('createFlywheelShowpiece', () => {
       Math.PI / 2
     );
     expect(
-      MathUtils.euclideanModulo(output.rotation.x, Math.PI * 2)
+      MathUtils.euclideanModulo(output.rotation.z, Math.PI * 2)
     ).toBeCloseTo(Math.PI / 2);
 
     build.update({ elapsed: 1, delta: 0.25, emphasis: 0 });
     expect(wheel.rotation.z).toBeCloseTo(build.getDebugState().carrierAngle);
-    expect(output.rotation.z).toBeCloseTo(build.getDebugState().carrierAngle);
+    expect(output.rotation.x).toBeCloseTo(build.getDebugState().carrierAngle);
+    build.dispose();
+  });
+
+  it('places the gearbox, crank, yokes, and output shaft in readable separated envelopes', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    const gearbox = build.group.getObjectByName('FlywheelPlanetaryGearbox')!;
+    const crank = build.group.getObjectByName('FlywheelCrankGroup')!;
+    const output = build.group.getObjectByName('FlywheelOutputShaft')!;
+    const frontYoke = build.group.getObjectByName('FlywheelBearingYokeFront')!;
+    const backYoke = build.group.getObjectByName('FlywheelBearingYokeBack')!;
+
+    expect(gearbox.position.x).toBe(FLYWHEEL_GEARBOX.centerX);
+    expect(FLYWHEEL_GEARBOX_LEFT_EDGE).toBeGreaterThan(
+      FLYWHEEL_WHEEL_RIGHT_EDGE
+    );
+    expect(crank.position.z).toBeGreaterThan(gearbox.position.z);
+    expect(crank.position.x - 0.38).toBeGreaterThan(FLYWHEEL_WHEEL_RIGHT_EDGE);
+    expect(output.position.x).toBeCloseTo(
+      (FLYWHEEL_WHEEL.centerX + FLYWHEEL_GEARBOX.centerX) / 2
+    );
+    expect(output.position.x - FLYWHEEL_WHEEL.centerX).toBeGreaterThan(0.7);
+    expect(FLYWHEEL_GEARBOX.centerX - output.position.x).toBeGreaterThan(0.7);
+    expect(frontYoke.position.z).toBeGreaterThan(FLYWHEEL_WHEEL.centerZ);
+    expect(backYoke.position.z).toBeLessThan(FLYWHEEL_WHEEL.centerZ);
+    build.dispose();
+  });
+
+  it('keeps asymmetric motion markers attached to the rotating wheel', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    const wheel = build.group.getObjectByName('FlywheelWheelGroup')!;
+    const markers = wheel.children.filter((child) =>
+      child.name.startsWith('FlywheelCounterweight-')
+    );
+    expect(markers.length).toBeGreaterThanOrEqual(2);
+    const before = wheel.rotation.z;
+    build.update({ elapsed: 1, delta: 0.5, emphasis: 0 });
+    expect(wheel.rotation.z - before).toBeGreaterThan(0.15);
     build.dispose();
   });
 


### PR DESCRIPTION
### Motivation
- Visual QA showed the planetary gearbox and crank intruding on the flywheel silhouette and a dominant translucent glow hiding the rotor; the goal is to make the machine read immediately as a heavy flywheel with a side-mounted planetary gearbox and visible power path. 
- Introduce formulaic non-overlap invariants so wheel/gearbox/crank placement is mechanically consistent and testable instead of eyeballed constants.

### Description
- Move and resize core contract constants in `src/scene/structures/flywheelEnergyContract.ts` to place the wheel left and gearbox right/front, add `FLYWHEEL_*_OUTER_RADIUS`, `FLYWHEEL_WHEEL_RIGHT_EDGE`, `FLYWHEEL_GEARBOX_LEFT_EDGE`, `FLYWHEEL_WHEEL_GEAR_CLEARANCE`, and `FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE`, and increase baseline crank speed. 
- Rework the scene builder in `src/scene/structures/flywheel.ts` to replace left/right bearing posts with front/back yokes and axle caps, shrink the inner glow ring, add a visible gearbox housing and pedestal, and add `FlywheelOutputCoupler` / `FlywheelOutputShaft` bridging the gearbox to the wheel hub while keeping local-root coordinates and animation wiring. 
- Update the miniature proxy (`src/scene/miniature/poiProxyRegistry.ts`) and regenerated `miniatureManifest` to reflect the new silhouette (wheel-left, gearbox-right, front crank, coupler). 
- Augment and adjust tests in `src/tests/flywheelEnergyContract.test.ts` and `src/tests/flywheelShowpiece.test.ts` to assert the clearance invariant, crank placement, yoke names, output coupler/pedestal presence, and that asymmetric wheel markers remain attached and rotate.

### Testing
- Ran focused unit tests: `npm run test:ci -- src/tests/flywheelEnergyContract.test.ts src/tests/flywheelShowpiece.test.ts` and broader related suites: `src/tests/flywheelEnergyNetwork.test.ts`, `src/tests/miniatureProxyRegistry.test.ts`, `src/tests/miniatureManifest.test.ts`, `src/tests/poiPhysicalMetadata.test.ts`, `src/tests/sceneObjectColliderPolicies.test.ts`, and `src/tests/poiModelTriangles.test.ts`; all executed tests passed. 
- Ran manifest updates and checks: `npm run miniature:manifest:update` and `npm run miniature:check` succeeded and the generated `miniatureManifest` was updated. 
- Project quality gates: `npm run format:write`, `npm run lint`, `npm run build`, `npm run docs:check` (link checker emitted external fetch warnings but the docs check completed), `npm run smoke`, and `npm run format:check` all succeeded. 
- `npm run typecheck` failed with pre-existing, unrelated project-wide TypeScript errors (beginning in `src/main.ts` and multiple legacy tests); this appears to be outside the P6b.1 scope and is reported as a known repo-level issue. 

Residual notes: development server started (`npm run dev`) and manual screenshot capture was attempted but blocked because Playwright browsers are not installed in this environment; visual QA should be done locally or in CI with browsers available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f5dad1b98832f9abc6aa173c710be)