### PR TITLE
Fix flywheel geometry and readability — separate gearbox, add yokes & torque shaft

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -695,19 +695,37 @@ and the active scene detail policy; all child geometry is authored in local
 coordinates under that root.
 
 The shared implementation contract lives in
-`src/scene/structures/flywheelEnergyContract.ts`. Final P6b constants keep the
-P6a envelope: 3.4 × 2.4 × 2.75 scene units overall, a 3.25 × 1.55 × 0.22 base,
-a 0.92 radius heavy wheel, a 0.52 radius gearbox, and a marker minimum height of
-2.95. Physical metadata and miniature proxy data import those constants instead
-of duplicating dimensions.
+`src/scene/structures/flywheelEnergyContract.ts`. The P6b.1 readability pass
+keeps the bottom-centered local root while widening the physical envelope to
+3.55 × 2.4 × 2.75 scene units overall. The final layout uses a 3.4 × 1.55 ×
+0.22 base, a left-mounted heavy wheel at `centerX = -0.78`, `centerY = 1.28`
+with `radius = 0.82` and `rimTube = 0.1`, and a right-mounted planetary gearbox
+at `centerX = 0.98`, `centerY = 1.28`, `centerZ = 0.38` with `radius = 0.46`.
+The hand crank sits on the front face at the gearbox depth plus crank clearance,
+and the energy port remains above/front of the gearbox so P6c transfer endpoints
+continue to resolve to `FlywheelEnergyPort`.
 
-The final hierarchy is the physical assembly from the P6a design:
-`FlywheelBase`, two bearing stands, `FlywheelAxle`, `FlywheelWheelGroup` with
-rim/hub/spokes/counterweights/glow ring, `FlywheelCrankGroup`,
+P6b.1 makes the physical non-overlap invariant explicit instead of relying on
+visual eyeballing. The wheel envelope is
+`FLYWHEEL_WHEEL.centerX + FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube`; the
+gearbox envelope is `FLYWHEEL_GEARBOX.centerX - (FLYWHEEL_RING_RADIUS +
+FLYWHEEL_GEAR_TOOTH_LENGTH + FLYWHEEL_GEARBOX_HOUSING_PAD)`. Tests require the
+resulting wheel-to-gear clearance to be at least `0.18` scene units, and the
+crank envelope is also kept outside the wheel rim. This preserves the readable
+power path: crank on the front of the gearbox, sun/planet carrier inside the
+right-side ring gear, output shaft/coupler running leftward, and flywheel axle on
+the left.
+
+The final hierarchy is the physical assembly from the P6a design updated for the
+separated P6b.1 silhouette: `FlywheelBase`, `FlywheelBearingYokeFront`,
+`FlywheelBearingYokeBack`, `FlywheelAxleCapFront`, `FlywheelAxleCapBack`,
+`FlywheelAxle`, `FlywheelWheelGroup` with rim/hub/spokes/counterweights/slim
+glow ring, `FlywheelGearboxPedestal`, `FlywheelCrankGroup`,
 `FlywheelPlanetaryGearbox`, fixed `FlywheelRingGear`, driven `FlywheelSunGear`,
 `FlywheelPlanetCarrier`, three `FlywheelPlanetGear-*` meshes,
-`FlywheelOutputShaft`, and `FlywheelEnergyPort`. The previous abstract rotor,
-orbit chips, automation pillars, and info panel are intentionally removed.
+`FlywheelOutputShaft`/`FlywheelTorqueShaft`, and `FlywheelEnergyPort`. The
+previous abstract rotor, orbit chips, automation pillars, info panel, and
+left/right bearing posts are intentionally removed.
 
 The implemented gear train uses the P6a planetary constants: sun 18 teeth,
 planet 24 teeth, ring 66 teeth, and a fixed-ring torque ratio of

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "8719cf12668745d043361e32da42ef82a169cde2ddb910d72f043dc6768e2c1b",
+      "proxyFingerprint": "98e5ec44c7d1403cfe2b94a466bd23d58fd9e3f04f12ccee9d3f62ceaa4e25e8",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 9,
-      "syncNote": "Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.",
-      "sourceFingerprint": "6c5e609c0f5d6983f705d164bae47ef76bb114f76c23c90b52a04c4d8f9de4b1",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
-      "metadataFingerprint": "0e744e5f1efca45fe87a9d153b90c1d29b1f114d2288047d8d44c60d0c01e934"
+      "syncRevision": 10,
+      "syncNote": "Tracks separated wheel-left, gearbox-right, crank-front silhouette and coupler geometry.",
+      "sourceFingerprint": "5f585dbb0068cfc7e529ec8f24a72098a7af985908cc8ac46b4e02554d3a7ea3",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
+      "metadataFingerprint": "8feea16c6de0a07a9e6d8f31290bedc276bd6a5c8fa2ebe686c4c6cad9934518"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "65690f52651041c3b2d52812db5b6648a41e8e33f8bf3e3e69cc4197caa191f5",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 9,
+    syncRevision: 10,
     syncNote:
-      'Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.',
+      'Tracks separated wheel-left, gearbox-right, crank-front silhouette and coupler geometry.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
@@ -103,15 +103,15 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     primitives: [
       box('flywheel-base', [1.35, 0.12, 0.64], [0, 0.06, 0], 0x17202a),
       box(
-        'flywheel-bearing-left',
-        [0.1, 0.72, 0.18],
-        [-0.48, 0.42, 0],
+        'flywheel-bearing-yoke-front',
+        [0.16, 0.62, 0.08],
+        [-0.3, 0.43, 0.18],
         0x94a3b8
       ),
       box(
-        'flywheel-bearing-right',
-        [0.1, 0.72, 0.18],
-        [0.04, 0.42, 0],
+        'flywheel-bearing-yoke-back',
+        [0.16, 0.62, 0.08],
+        [-0.3, 0.43, -0.18],
         0x94a3b8
       ),
       {
@@ -119,25 +119,31 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         name: 'flywheel-heavy-wheel',
         radius: FLYWHEEL_WHEEL.radius * 0.35,
         tube: 0.055,
-        position: [-0.22, 0.64, 0],
+        position: [-0.36, 0.64, 0],
         rotation: [0, 0, 0],
         color: 0x1f2937,
       },
-      box('flywheel-spoke', [0.56, 0.04, 0.04], [-0.22, 0.64, 0], 0xcbd5e1),
+      box('flywheel-spoke', [0.5, 0.04, 0.04], [-0.36, 0.64, 0], 0xcbd5e1),
+      box(
+        'flywheel-torque-coupler',
+        [0.58, 0.035, 0.035],
+        [0.0, 0.64, 0.14],
+        0xcbd5e1
+      ),
       box(
         'flywheel-crank-arm',
         [0.36, 0.035, 0.035],
-        [0.42, 0.64, 0.24],
+        [0.48, 0.64, 0.34],
         0xf59e0b
       ),
       cyl(
         'flywheel-planetary-gear-cluster',
         0.18,
         0.12,
-        [0.38, 0.58, 0],
+        [0.42, 0.64, 0.14],
         0xd1d5db
       ),
-      sphere('flywheel-energy-port', 0.07, [0.56, 0.8, 0.28], 0x38bdf8),
+      sphere('flywheel-energy-port', 0.07, [0.6, 0.8, 0.34], 0x38bdf8),
       {
         kind: 'tube',
         name: 'flywheel-incoming-arc-hint',
@@ -145,7 +151,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         points: [
           [-0.95, 0.18, -0.62],
           [-0.42, 1.06, -0.18],
-          [0.56, 0.8, 0.28],
+          [0.6, 0.8, 0.34],
         ],
         color: 0x38bdf8,
       },
@@ -154,7 +160,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         name: 'flywheel-outgoing-arc-hint',
         radius: 0.024,
         points: [
-          [0.56, 0.8, 0.28],
+          [0.6, 0.8, 0.34],
           [0.12, 1.22, 0.58],
           [1.05, 0.22, 0.76],
         ],

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -26,7 +26,7 @@ import {
   FLYWHEEL_AXLE,
   FLYWHEEL_BASE_COLLIDER,
   FLYWHEEL_BASE_DIMENSIONS,
-  FLYWHEEL_BEARING_STAND,
+  FLYWHEEL_BEARING_YOKE,
   FLYWHEEL_CRANK,
   FLYWHEEL_CRANK_RAD_PER_SECOND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
@@ -223,25 +223,35 @@ export function createFlywheelShowpiece(
   base.position.y = FLYWHEEL_BASE_DIMENSIONS.height / 2;
   group.add(base);
 
-  for (const [name, x] of [
-    ['FlywheelBearingStandLeft', FLYWHEEL_WHEEL.centerX - 0.62],
-    ['FlywheelBearingStandRight', FLYWHEEL_WHEEL.centerX + 0.62],
+  for (const [name, z] of [
+    ['FlywheelBearingYokeFront', FLYWHEEL_BEARING_YOKE.centerZOffset],
+    ['FlywheelBearingYokeBack', -FLYWHEEL_BEARING_YOKE.centerZOffset],
   ] as const) {
-    const stand = mesh(
+    const yoke = mesh(
       name,
       new BoxGeometry(
-        FLYWHEEL_BEARING_STAND.width,
-        FLYWHEEL_BEARING_STAND.height,
-        FLYWHEEL_BEARING_STAND.depth
+        FLYWHEEL_BEARING_YOKE.width,
+        FLYWHEEL_BEARING_YOKE.height,
+        FLYWHEEL_BEARING_YOKE.depth
       ),
       steel
     );
-    stand.position.set(
-      x,
-      FLYWHEEL_BASE_DIMENSIONS.height + FLYWHEEL_BEARING_STAND.height / 2,
-      0
+    yoke.position.set(
+      FLYWHEEL_WHEEL.centerX,
+      FLYWHEEL_BASE_DIMENSIONS.height + FLYWHEEL_BEARING_YOKE.height / 2,
+      z
     );
-    group.add(stand);
+    group.add(yoke);
+    const cap = mesh(
+      name === 'FlywheelBearingYokeFront'
+        ? 'FlywheelAxleCapFront'
+        : 'FlywheelAxleCapBack',
+      new CylinderGeometry(0.14, 0.14, 0.06, cylSeg),
+      brass
+    );
+    cap.position.set(FLYWHEEL_WHEEL.centerX, FLYWHEEL_WHEEL.centerY, z);
+    cap.rotation.x = Math.PI / 2;
+    group.add(cap);
   }
 
   const axle = mesh(
@@ -359,12 +369,17 @@ export function createFlywheelShowpiece(
     carrier.add(planet);
     planetGears.push(planet);
   }
-  const output = mesh(
-    'FlywheelOutputShaft',
-    new CylinderGeometry(0.055, 0.055, 0.95, cylSeg),
+  const output = new Group();
+  output.name = 'FlywheelOutputShaft';
+  const shaftLength = FLYWHEEL_GEARBOX.centerX - FLYWHEEL_WHEEL.centerX;
+  const shaft = mesh(
+    'FlywheelTorqueShaft',
+    new CylinderGeometry(0.055, 0.055, shaftLength, cylSeg),
     steel
   );
-  output.rotation.x = Math.PI / 2;
+  shaft.position.x = -shaftLength / 2;
+  shaft.rotation.z = Math.PI / 2;
+  output.add(shaft);
   gearbox.add(output);
 
   addTeeth(
@@ -400,12 +415,29 @@ export function createFlywheelShowpiece(
     )
   );
 
+  const pedestal = mesh(
+    'FlywheelGearboxPedestal',
+    new BoxGeometry(
+      0.58,
+      FLYWHEEL_GEARBOX.centerY - FLYWHEEL_GEARBOX.radius,
+      0.32
+    ),
+    steel
+  );
+  pedestal.position.set(
+    FLYWHEEL_GEARBOX.centerX,
+    FLYWHEEL_BASE_DIMENSIONS.height +
+      (FLYWHEEL_GEARBOX.centerY - FLYWHEEL_GEARBOX.radius) / 2,
+    FLYWHEEL_GEARBOX.centerZ
+  );
+  group.add(pedestal);
+
   const crankGroup = new Group();
   crankGroup.name = 'FlywheelCrankGroup';
   crankGroup.position.set(
     FLYWHEEL_GEARBOX.centerX,
     FLYWHEEL_GEARBOX.centerY,
-    FLYWHEEL_GEARBOX.centerZ + 0.34
+    FLYWHEEL_GEARBOX.centerZ + FLYWHEEL_GEARBOX.depth / 2 + 0.25
   );
   group.add(crankGroup);
   const crankDisc = mesh(

--- a/src/scene/structures/flywheelEnergyContract.ts
+++ b/src/scene/structures/flywheelEnergyContract.ts
@@ -1,26 +1,27 @@
 export const FLYWHEEL_INSTALLATION_BOUNDS = {
-  width: 3.4,
+  width: 3.55,
   depth: 2.4,
   height: 2.75,
 } as const;
 export const FLYWHEEL_BASE_DIMENSIONS = {
-  width: 3.25,
+  width: 3.4,
   depth: 1.55,
   height: 0.22,
 } as const;
 export const FLYWHEEL_WHEEL = {
-  radius: 0.92,
-  rimTube: 0.12,
+  radius: 0.82,
+  rimTube: 0.1,
   thickness: 0.24,
-  centerX: -0.58,
-  centerY: 1.35,
+  centerX: -0.78,
+  centerY: 1.28,
   centerZ: 0,
 } as const;
-export const FLYWHEEL_AXLE = { radius: 0.075, length: 2.35 } as const;
-export const FLYWHEEL_BEARING_STAND = {
-  width: 0.18,
-  depth: 0.42,
-  height: 1.34,
+export const FLYWHEEL_AXLE = { radius: 0.075, length: 1.2 } as const;
+export const FLYWHEEL_BEARING_YOKE = {
+  width: 0.34,
+  depth: 0.12,
+  height: 1.08,
+  centerZOffset: 0.42,
 } as const;
 export const FLYWHEEL_CRANK = {
   radius: 0.38,
@@ -28,16 +29,16 @@ export const FLYWHEEL_CRANK = {
   handleRadius: 0.045,
 } as const;
 export const FLYWHEEL_GEARBOX = {
-  centerX: 0.78,
-  centerY: 1.24,
-  centerZ: 0,
-  radius: 0.52,
+  centerX: 0.98,
+  centerY: 1.28,
+  centerZ: 0.38,
+  radius: 0.46,
   depth: 0.26,
 } as const;
 export const FLYWHEEL_ENERGY_PORT = {
   x: 1.32,
   y: 1.62,
-  z: 0.62,
+  z: 0.74,
   radius: 0.13,
 } as const;
 export const FLYWHEEL_SUN_TEETH = 18;
@@ -46,23 +47,25 @@ export const FLYWHEEL_RING_TEETH =
   FLYWHEEL_SUN_TEETH + FLYWHEEL_PLANET_TEETH * 2;
 export const FLYWHEEL_TORQUE_RATIO =
   1 + FLYWHEEL_RING_TEETH / FLYWHEEL_SUN_TEETH;
-export const FLYWHEEL_CRANK_RAD_PER_SECOND = 1.2;
+export const FLYWHEEL_CRANK_RAD_PER_SECOND = 1.65;
 export const FLYWHEEL_EMPHASIS_SPEED_BOOST = 0.14;
 export const FLYWHEEL_SUN_RADIUS = 0.14;
 export const FLYWHEEL_PLANET_RADIUS =
   (FLYWHEEL_SUN_RADIUS * FLYWHEEL_PLANET_TEETH) / FLYWHEEL_SUN_TEETH;
 export const FLYWHEEL_RING_RADIUS =
   FLYWHEEL_SUN_RADIUS + FLYWHEEL_PLANET_RADIUS * 2;
+export const FLYWHEEL_GEAR_TOOTH_LENGTH = 0.055;
+export const FLYWHEEL_GEARBOX_HOUSING_PAD = 0.06;
 export const FLYWHEEL_PLANET_ORBIT_RADIUS =
   FLYWHEEL_SUN_RADIUS + FLYWHEEL_PLANET_RADIUS;
 export const FLYWHEEL_MARKER_MIN_HEIGHT = 2.95;
 export const FLYWHEEL_AVATAR_PATH_RADIUS = 1.2;
-export const FLYWHEEL_BASE_COLLIDER = { width: 3.25, depth: 1.55 } as const;
+export const FLYWHEEL_BASE_COLLIDER = { width: 3.4, depth: 1.55 } as const;
 export const FLYWHEEL_GEARBOX_COLLIDER = {
-  centerX: 0.92,
-  centerZ: 0.42,
-  width: 0.95,
-  depth: 0.74,
+  centerX: 0.98,
+  centerZ: 0.48,
+  width: 1.08,
+  depth: 0.9,
 } as const;
 
 export function getFlywheelCarrierAngle(sunAngle: number): number {

--- a/src/tests/flywheelEnergyContract.test.ts
+++ b/src/tests/flywheelEnergyContract.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, it } from 'vitest';
 
 import {
   FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_CRANK,
+  FLYWHEEL_GEARBOX,
+  FLYWHEEL_GEARBOX_HOUSING_PAD,
+  FLYWHEEL_GEAR_TOOTH_LENGTH,
   FLYWHEEL_INSTALLATION_BOUNDS,
   FLYWHEEL_PLANET_TEETH,
   FLYWHEEL_RING_TEETH,
   FLYWHEEL_SUN_TEETH,
+  FLYWHEEL_RING_RADIUS,
   FLYWHEEL_TORQUE_RATIO,
+  FLYWHEEL_WHEEL,
   getFlywheelCarrierAngle,
   getFlywheelPlanetLocalSpin,
 } from '../scene/structures/flywheelEnergyContract';
@@ -28,6 +34,22 @@ describe('flywheel energy contract', () => {
       1 + FLYWHEEL_RING_TEETH / FLYWHEEL_SUN_TEETH
     );
     expect(FLYWHEEL_TORQUE_RATIO).toBeGreaterThan(4);
+  });
+
+  it('keeps the gearbox and crank outside the flywheel envelope', () => {
+    const wheelOuterRadius = FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube;
+    const gearboxOuterRadius =
+      FLYWHEEL_RING_RADIUS +
+      FLYWHEEL_GEAR_TOOTH_LENGTH +
+      FLYWHEEL_GEARBOX_HOUSING_PAD;
+    const wheelRightEdge = FLYWHEEL_WHEEL.centerX + wheelOuterRadius;
+    const gearboxLeftEdge = FLYWHEEL_GEARBOX.centerX - gearboxOuterRadius;
+    const wheelGearClearance = gearboxLeftEdge - wheelRightEdge;
+    const crankLeftEdge = FLYWHEEL_GEARBOX.centerX - FLYWHEEL_CRANK.radius;
+
+    expect(wheelGearClearance).toBeGreaterThanOrEqual(0.18);
+    expect(crankLeftEdge - wheelRightEdge).toBeGreaterThanOrEqual(0.18);
+    expect(FLYWHEEL_GEARBOX.centerZ).toBeGreaterThan(0);
   });
 
   it('keeps carrier and planet spin synchronized from one sun angle', () => {

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -10,8 +10,10 @@ import {
   FLYWHEEL_CRANK_RAD_PER_SECOND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
   FLYWHEEL_ENERGY_PORT,
+  FLYWHEEL_GEARBOX,
   FLYWHEEL_GEARBOX_COLLIDER,
   FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_WHEEL,
   FLYWHEEL_MARKER_MIN_HEIGHT,
   FLYWHEEL_TORQUE_RATIO,
 } from '../scene/structures/flywheelEnergyContract';
@@ -20,8 +22,10 @@ const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
 
 const coreNames = [
   'FlywheelBase',
-  'FlywheelBearingStandLeft',
-  'FlywheelBearingStandRight',
+  'FlywheelBearingYokeFront',
+  'FlywheelBearingYokeBack',
+  'FlywheelAxleCapFront',
+  'FlywheelAxleCapBack',
   'FlywheelAxle',
   'FlywheelWheelGroup',
   'FlywheelHeavyRim',
@@ -37,6 +41,8 @@ const coreNames = [
   'FlywheelPlanetCarrier',
   'FlywheelPlanetGear-0',
   'FlywheelOutputShaft',
+  'FlywheelTorqueShaft',
+  'FlywheelGearboxPedestal',
   'FlywheelEnergyPort',
 ];
 
@@ -67,6 +73,12 @@ describe('createFlywheelShowpiece', () => {
       build.group.getObjectByName('FlywheelAutomationPillars')
     ).toBeUndefined();
     expect(build.group.getObjectByName('FlywheelInfoPanel')).toBeUndefined();
+    expect(
+      build.group.getObjectByName('FlywheelBearingStandLeft')
+    ).toBeUndefined();
+    expect(
+      build.group.getObjectByName('FlywheelBearingStandRight')
+    ).toBeUndefined();
     const childXs: number[] = [];
     build.group.traverse((object) => {
       if (object !== build.group) childXs.push(object.position.x);
@@ -114,13 +126,73 @@ describe('createFlywheelShowpiece', () => {
     expect(MathUtils.euclideanModulo(axle.rotation.x, Math.PI * 2)).toBeCloseTo(
       Math.PI / 2
     );
-    expect(
-      MathUtils.euclideanModulo(output.rotation.x, Math.PI * 2)
-    ).toBeCloseTo(Math.PI / 2);
+    expect(output.getObjectByName('FlywheelTorqueShaft')).toBeInstanceOf(
+      Object3D
+    );
 
     build.update({ elapsed: 1, delta: 0.25, emphasis: 0 });
     expect(wheel.rotation.z).toBeCloseTo(build.getDebugState().carrierAngle);
     expect(output.rotation.z).toBeCloseTo(build.getDebugState().carrierAngle);
+    build.dispose();
+  });
+
+  it('separates the gearbox silhouette and bridges it back to the flywheel hub', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    const wheel = build.group.getObjectByName('FlywheelWheelGroup') as Object3D;
+    const gearbox = build.group.getObjectByName(
+      'FlywheelPlanetaryGearbox'
+    ) as Object3D;
+    const shaft = gearbox.getObjectByName('FlywheelTorqueShaft') as Object3D;
+    const wheelRightEdge =
+      FLYWHEEL_WHEEL.centerX + FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube;
+    const gearboxLeftEdge = FLYWHEEL_GEARBOX.centerX - FLYWHEEL_GEARBOX.radius;
+
+    expect(gearbox.position.x).toBeGreaterThan(wheel.position.x);
+    expect(gearboxLeftEdge - wheelRightEdge).toBeGreaterThan(0);
+    expect(shaft.position.x).toBeLessThan(0);
+    expect(shaft.scale.x).toBe(1);
+
+    const frontYoke = build.group.getObjectByName(
+      'FlywheelBearingYokeFront'
+    ) as Object3D;
+    const backYoke = build.group.getObjectByName(
+      'FlywheelBearingYokeBack'
+    ) as Object3D;
+    expect(Math.abs(frontYoke.position.z)).toBeGreaterThan(
+      FLYWHEEL_WHEEL.thickness / 2
+    );
+    expect(Math.abs(backYoke.position.z)).toBeGreaterThan(
+      FLYWHEEL_WHEEL.thickness / 2
+    );
+    expect(frontYoke.position.x).toBeCloseTo(FLYWHEEL_WHEEL.centerX);
+    expect(backYoke.position.x).toBeCloseTo(FLYWHEEL_WHEEL.centerX);
+    build.dispose();
+  });
+
+  it('keeps asymmetric wheel markers attached to the spinning wheel group', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    const wheel = build.group.getObjectByName('FlywheelWheelGroup') as Object3D;
+    const counterweight = wheel.getObjectByName(
+      'FlywheelCounterweight-0'
+    ) as Object3D;
+    const before = wheel.rotation.z;
+    build.update({
+      elapsed: 1,
+      delta: 1,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+
+    expect(counterweight).toBeInstanceOf(Object3D);
+    expect(wheel.rotation.z - before).toBeGreaterThan(0.3);
+    expect(counterweight.parent).toBe(wheel);
+    expect(wheel.rotation.z).toBeCloseTo(build.getDebugState().carrierAngle);
     build.dispose();
   });
 


### PR DESCRIPTION
### Motivation
- The Flywheel POI read poorly after P6b because the planetary gearbox and associated geometry overlapped the wheel envelope and a large glow shell dominated the silhouette. 
- The goal is to make the mechanism immediately readable (wheel left, gearbox right, crank front) and enforce a formula-driven non-overlap invariant so the gearbox, crank, and teeth do not clip the wheel. 
- Changes must preserve the P6c energy-transfer endpoints/semantics and keep the assembly local to the `FlywheelEnergyInstallation` root.

### Description
- Changed layout constants and colliders in `src/scene/structures/flywheelEnergyContract.ts` (wheel moved left, reduced rim, gearbox moved right/front, added `FLYWHEEL_GEAR_TOOTH_LENGTH` and `FLYWHEEL_GEARBOX_HOUSING_PAD`, widened base and installation bounds, bumped crank speed). 
- Reworked runtime geometry in `src/scene/structures/flywheel.ts` to replace left/right bearing posts with front/back bearing yokes and axle caps, add a visible `FlywheelGearboxPedestal`, and add a `FlywheelTorqueShaft`/`FlywheelOutputShaft` group bridging gearbox → flywheel. 
- Updated the miniature proxy in `src/scene/miniature/poiProxyRegistry.ts` and the generated miniature manifest to match the new wheel-left / gearbox-right / crank-front silhouette. 
- Strengthened and added tests in `src/tests/flywheelEnergyContract.test.ts` and `src/tests/flywheelShowpiece.test.ts` that assert the wheel/gear non-overlap invariant, crank/gearbox placement, yokes/axle cap presence, torque shaft coupling, and that counterweights remain children of the rotating wheel group; also updated docs at `docs/architecture/flywheel-energy-transfer.md` to record the new layout and invariant.

### Testing
- Ran formatting and manifest update: `npm run format:write` and `npm run miniature:manifest:update` and `npm run miniature:check`, all completed successfully. 
- Ran focused unit tests: `npm run test:ci -- src/tests/flywheelEnergyContract.test.ts src/tests/flywheelShowpiece.test.ts`, and broader flywheel/miniature/metadata tests: `npm run test:ci -- src/tests/flywheelEnergyNetwork.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts`; all executed and passed. 
- Lint, build, docs, smoke, and format checks passed: `npm run lint`, `npm run build`, `npm run docs:check` (link checker emitted external fetch warnings but completed), `npm run smoke`, and `npm run format:check` all succeeded. 
- `npm run typecheck` failed due to pre-existing project-wide TypeScript issues unrelated to this Flywheel change (errors originate in `src/main.ts`, several test typing suites, and other areas outside the modified files). 
- Secret scan was run via `git diff --cached | ./scripts/scan-secrets.py` and returned no high-risk secrets.

Residual risks / follow-ups: the repo-wide `tsc --noEmit` errors remain and should be addressed separately; visual QA in the running app (`http://localhost:5173/?mode=immersive&disablePerformanceFailover=1`) is recommended to validate subtle clipping/lighting across detail policies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f5dbbb6c8832f9e872fbad896db9b)