### PR TITLE
🛠️ : – fix flywheel geometry readability

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -766,3 +766,45 @@ index, current direction/target/phase, visible window start/end, incoming and
 outgoing completion counts, source/destination world and local positions, active
 node count, detail level, and reduced pulse/flicker scale values. Returned arrays
 and points are copies so callers cannot mutate internal network state.
+
+## P6b.1 geometry/readability correction
+
+P6b.1 keeps the P6c five-in/one-out energy-transfer network intact while
+correcting the physical Flywheel silhouette. The local layout is now explicitly
+wheel-left, gearbox-right, and crank-front: `+X` runs toward the side-mounted
+planetary gearbox, `+Y` is up, and `+Z` is the front face where the hand crank
+sits. The flywheel and gearbox faces both lie in X/Y planes, and the crank is
+mounted in front of the gearbox instead of sharing the wheel envelope.
+
+The final physical constants in `flywheelEnergyContract.ts` place the heavy
+wheel at `(-0.78, 1.28, 0)` with radius `0.82` and rim tube `0.11`. The
+planetary gearbox is centered at `(1.08, 1.26, 0.38)` with radius `0.46`, and
+the crank front plane is at `z = 0.74`. The energy port moves slightly forward
+and right to `(1.42, 1.68, 0.72)` so P6c arcs still target a stable
+`FlywheelEnergyPort` without covering the wheel face.
+
+Non-overlap is enforced with formula-derived contract exports rather than
+visual guesswork:
+
+```ts
+const wheelOuterRadius = FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube;
+const gearboxOuterRadius =
+  FLYWHEEL_RING_RADIUS +
+  FLYWHEEL_GEAR_TOOTH_LENGTH +
+  FLYWHEEL_GEARBOX_HOUSING_PAD;
+const wheelRightEdge = FLYWHEEL_WHEEL.centerX + wheelOuterRadius;
+const gearboxLeftEdge = FLYWHEEL_GEARBOX.centerX - gearboxOuterRadius;
+const wheelGearClearance = gearboxLeftEdge - wheelRightEdge;
+```
+
+`FLYWHEEL_WHEEL_GEAR_CLEARANCE` must remain at least
+`FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE` (`0.18`) so ring teeth, housing padding,
+and isometric projection do not clip the flywheel rim.
+
+The hierarchy now uses front/back bearing yokes (`FlywheelBearingYokeFront` and
+`FlywheelBearingYokeBack`) around the Z-axis axle instead of left/right posts
+across the wheel face. A `FlywheelGearboxPedestal` supports the right-side gear
+cluster, and `FlywheelOutputShaft` / `FlywheelTorqueShaft` visibly bridges from
+the planet carrier toward the flywheel hub. The cyan accent is reduced to a slim
+inner `FlywheelEnergyGlowRing` behind the rotor so the dark metal rim, hub,
+spokes, and brass counterweights dominate the read.

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "d560aa2ab7929bed228d38439cd6c26566a34f397df1b14d99205bd780c47766",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "47ac5aef40df0e5279529d33e08cd23b88265a8bcc44951f3e2b92872515806d"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 3,
       "syncNote": "Outer exhibit now uses the shared ground-floor layout and visual-anchor placement pipeline; inner proxy remains only the nonrecursive shell.",
       "sourceFingerprint": "37a605bb70036671d249e3c956b764048ee2c8700333b23437291b064d964a7d",
-      "proxyFingerprint": "8719cf12668745d043361e32da42ef82a169cde2ddb910d72f043dc6768e2c1b",
+      "proxyFingerprint": "3931a4432fb0b8e3a8ba2065e6378ca4fb7679a0af508e7eedb05c0db9b87e50",
       "metadataFingerprint": "1d21e34769e8710485c27e83cb91e841a1b751619ea1057bb3f0a90f36138aeb"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e28ad477f31ed8573defb67f2d33efffb55b1278cf25c0903519fefdff81c048",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "786ee7c818049bdc258d05a3720b0c24b331bf3b74fff51b103266627458eb00"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "efa55c8aad112ebbcf5537f7be09f3e89a3cf569106949c34c3e5ad5bf8b2daf",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "7e59b35d752bfbac5558f84e3c35b8ef71c6ef05e05375b0d9633ff41094ab62"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 9,
-      "syncNote": "Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.",
-      "sourceFingerprint": "6c5e609c0f5d6983f705d164bae47ef76bb114f76c23c90b52a04c4d8f9de4b1",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
-      "metadataFingerprint": "0e744e5f1efca45fe87a9d153b90c1d29b1f114d2288047d8d44c60d0c01e934"
+      "syncRevision": 11,
+      "syncNote": "Tracks formatted separated wheel-left, gearbox-right, crank-front silhouette.",
+      "sourceFingerprint": "354657749ebfb45711d6e2c4bd848ee3552c57ab6dad836ca84992bbf64b2da8",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
+      "metadataFingerprint": "78b9cef4da0efa9510be68ceb2ce878bb2c0bd0d0e131a13c9ca8c713028fbc5"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 3,
       "syncNote": "Tracks the explicit media-wall visual anchor used by the tabletop miniature.",
       "sourceFingerprint": "72c492eddd65cef451b846584cde3463abf5024c18f6b8d5867aa8f52e4f5629",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "72267991166e4246f3dfb2241ca7a6efdd1786e634e788716c1c6cb2265f42fa"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "4b77621cf846fc09c4ab487937ad582a6a2a7ee46c02e33f8065111a8bb1c6b1",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "3ca6a37892e29885feb436031dd15d32030afee5b58f4ad7e675c47a5637cb32"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "c23e5326459e9b7cc34e7ef59d58a42539979f1b05fcd1e2c838498b2ad86111",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "039970c412196a3415fde6f4132ce00cc756ab663a9e4f10160646777eb280e7"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "e19928707238c6fa17a3c300222f3ff026f394b9089dc77b4776b6cb3f456160",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "c6f08c624d272c62a0643814ec2eb881480df8b86860aea00c13b84ae60c9305"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 18,
       "syncNote": "Runtime hardening keeps the static 3:1 proxy synchronized with lifecycle, detail, and accessibility files.",
       "sourceFingerprint": "264ca5ea94f10f62ca6efa8f20b211a2b718ffbe10b970ce205a3188c78ba45e",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "a016a246521e144e01d8fd6a573f13791b7e4900ba32e5970f7437c5db851852"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "8cd993c2721e563594af4ccaf388a7cf21c9799dc22a22f5ecfff1f23e75ef15",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "1e233a900e029d5c325e1b60a9b3537e7136c9cf74a035916ec8a03101dafbde"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged table, switch, yellow rack, nodes, and cable silhouette.",
       "sourceFingerprint": "eafb07327be3977472284d683752b2f901e21301fe9ef5bb9f746f008ccecdb0",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "17f75919aefb4f157b4531af581f3c89661f599e2bfdd160c9a5233ad17a8f5d"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 2,
       "syncNote": "Covers merged desk, tower, chair, dual monitors, keyboard, and mouse.",
       "sourceFingerprint": "4c3ac975f22f4516da92e183f4e7170c9357251ab8692bb84a68923d8bdf52be",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "5c533bce1d7817805ce4afd0df758d534529e7e441e8823ead1acfb5b43b97a6"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 3,
       "syncNote": "Registry footprint source reviewed after PR Reaper full-width footprint alignment; proxy geometry remains representative.",
       "sourceFingerprint": "a38743e6e36f75f6b9e2077d9f55fd12bd1ee7646fe1223422f6d1c41b604bee",
-      "proxyFingerprint": "e68e454d63b09c39c965d766456c9ae62b5b3bd7a96270fa4d5f9387893b8f7c",
+      "proxyFingerprint": "0b8833e61b00b5ad68e1cf602ba708d2ba479908d88de469dfe3e24bed5ebb53",
       "metadataFingerprint": "4109c32d634025eac2d183df2d439687eefbc52bdb24d91d392eb5898dc62776"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 9,
+    syncRevision: 11,
     syncNote:
-      'Tracks hardened runtime transfer diagnostics while keeping the static arc hints unchanged.',
+      'Tracks formatted separated wheel-left, gearbox-right, crank-front silhouette.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
@@ -103,15 +103,15 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     primitives: [
       box('flywheel-base', [1.35, 0.12, 0.64], [0, 0.06, 0], 0x17202a),
       box(
-        'flywheel-bearing-left',
-        [0.1, 0.72, 0.18],
-        [-0.48, 0.42, 0],
+        'flywheel-bearing-yoke-front',
+        [0.32, 0.62, 0.08],
+        [-0.34, 0.4, 0.24],
         0x94a3b8
       ),
       box(
-        'flywheel-bearing-right',
-        [0.1, 0.72, 0.18],
-        [0.04, 0.42, 0],
+        'flywheel-bearing-yoke-back',
+        [0.32, 0.62, 0.08],
+        [-0.34, 0.4, -0.24],
         0x94a3b8
       ),
       {
@@ -119,25 +119,31 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         name: 'flywheel-heavy-wheel',
         radius: FLYWHEEL_WHEEL.radius * 0.35,
         tube: 0.055,
-        position: [-0.22, 0.64, 0],
+        position: [-0.34, 0.64, 0],
         rotation: [0, 0, 0],
         color: 0x1f2937,
       },
-      box('flywheel-spoke', [0.56, 0.04, 0.04], [-0.22, 0.64, 0], 0xcbd5e1),
+      box('flywheel-spoke', [0.56, 0.04, 0.04], [-0.34, 0.64, 0], 0xcbd5e1),
+      box(
+        'flywheel-output-coupler',
+        [0.62, 0.035, 0.035],
+        [0.08, 0.64, 0.1],
+        0x94a3b8
+      ),
       box(
         'flywheel-crank-arm',
         [0.36, 0.035, 0.035],
-        [0.42, 0.64, 0.24],
+        [0.52, 0.64, 0.34],
         0xf59e0b
       ),
       cyl(
         'flywheel-planetary-gear-cluster',
         0.18,
         0.12,
-        [0.38, 0.58, 0],
+        [0.48, 0.61, 0.18],
         0xd1d5db
       ),
-      sphere('flywheel-energy-port', 0.07, [0.56, 0.8, 0.28], 0x38bdf8),
+      sphere('flywheel-energy-port', 0.07, [0.62, 0.84, 0.36], 0x38bdf8),
       {
         kind: 'tube',
         name: 'flywheel-incoming-arc-hint',
@@ -145,7 +151,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         points: [
           [-0.95, 0.18, -0.62],
           [-0.42, 1.06, -0.18],
-          [0.56, 0.8, 0.28],
+          [0.62, 0.84, 0.36],
         ],
         color: 0x38bdf8,
       },
@@ -154,7 +160,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         name: 'flywheel-outgoing-arc-hint',
         radius: 0.024,
         points: [
-          [0.56, 0.8, 0.28],
+          [0.62, 0.84, 0.36],
           [0.12, 1.22, 0.58],
           [1.05, 0.22, 0.76],
         ],

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -33,6 +33,7 @@ import {
   FLYWHEEL_ENERGY_PORT,
   FLYWHEEL_GEARBOX,
   FLYWHEEL_GEARBOX_COLLIDER,
+  FLYWHEEL_GEARBOX_OUTER_RADIUS,
   FLYWHEEL_PLANET_ORBIT_RADIUS,
   FLYWHEEL_PLANET_RADIUS,
   FLYWHEEL_PLANET_TEETH,
@@ -197,7 +198,8 @@ export function createFlywheelShowpiece(
     new MeshBasicMaterial({
       color: MATERIALS.glow,
       transparent: true,
-      opacity: 0.62,
+      opacity: 0.3,
+      depthWrite: false,
     })
   );
 
@@ -223,25 +225,41 @@ export function createFlywheelShowpiece(
   base.position.y = FLYWHEEL_BASE_DIMENSIONS.height / 2;
   group.add(base);
 
-  for (const [name, x] of [
-    ['FlywheelBearingStandLeft', FLYWHEEL_WHEEL.centerX - 0.62],
-    ['FlywheelBearingStandRight', FLYWHEEL_WHEEL.centerX + 0.62],
+  for (const [name, z] of [
+    ['FlywheelBearingYokeFront', FLYWHEEL_WHEEL.centerZ + 0.46],
+    ['FlywheelBearingYokeBack', FLYWHEEL_WHEEL.centerZ - 0.46],
   ] as const) {
-    const stand = mesh(
-      name,
-      new BoxGeometry(
-        FLYWHEEL_BEARING_STAND.width,
-        FLYWHEEL_BEARING_STAND.height,
-        FLYWHEEL_BEARING_STAND.depth
-      ),
+    const yoke = new Group();
+    yoke.name = name;
+    yoke.position.set(FLYWHEEL_WHEEL.centerX, 0, z);
+    for (const [postName, xOffset] of [
+      ['LeftPost', -0.24],
+      ['RightPost', 0.24],
+    ] as const) {
+      const post = mesh(
+        `${name}-${postName}`,
+        new BoxGeometry(
+          FLYWHEEL_BEARING_STAND.width,
+          FLYWHEEL_BEARING_STAND.height,
+          FLYWHEEL_BEARING_STAND.depth
+        ),
+        steel
+      );
+      post.position.set(
+        xOffset,
+        FLYWHEEL_BASE_DIMENSIONS.height + FLYWHEEL_BEARING_STAND.height / 2,
+        0
+      );
+      yoke.add(post);
+    }
+    const bridge = mesh(
+      `${name}-Bridge`,
+      new BoxGeometry(0.62, 0.12, FLYWHEEL_BEARING_STAND.depth),
       steel
     );
-    stand.position.set(
-      x,
-      FLYWHEEL_BASE_DIMENSIONS.height + FLYWHEEL_BEARING_STAND.height / 2,
-      0
-    );
-    group.add(stand);
+    bridge.position.y = FLYWHEEL_WHEEL.centerY + 0.24;
+    yoke.add(bridge);
+    group.add(yoke);
   }
 
   const axle = mesh(
@@ -303,9 +321,10 @@ export function createFlywheelShowpiece(
   }
   const glowRing = mesh(
     'FlywheelEnergyGlowRing',
-    new TorusGeometry(FLYWHEEL_WHEEL.radius * 0.82, 0.018, 4, torusSeg),
+    new TorusGeometry(FLYWHEEL_WHEEL.radius * 0.58, 0.012, 4, torusSeg),
     glow
   );
+  glowRing.position.z = -0.035;
   wheelGroup.add(glowRing);
 
   const gearbox = new Group();
@@ -359,13 +378,42 @@ export function createFlywheelShowpiece(
     carrier.add(planet);
     planetGears.push(planet);
   }
-  const output = mesh(
-    'FlywheelOutputShaft',
-    new CylinderGeometry(0.055, 0.055, 0.95, cylSeg),
+  const output = new Group();
+  output.name = 'FlywheelOutputShaft';
+  const shaftLength =
+    FLYWHEEL_GEARBOX.centerX -
+    FLYWHEEL_GEARBOX_OUTER_RADIUS -
+    FLYWHEEL_WHEEL.centerX;
+  const shaft = mesh(
+    'FlywheelTorqueShaft',
+    new CylinderGeometry(0.055, 0.055, shaftLength, cylSeg),
     steel
   );
-  output.rotation.x = Math.PI / 2;
-  gearbox.add(output);
+  shaft.rotation.z = Math.PI / 2;
+  output.position.set(
+    FLYWHEEL_WHEEL.centerX + shaftLength / 2,
+    FLYWHEEL_WHEEL.centerY,
+    FLYWHEEL_GEARBOX.centerZ * 0.45
+  );
+  output.add(shaft);
+  group.add(output);
+
+  const gearboxPedestal = mesh(
+    'FlywheelGearboxPedestal',
+    new BoxGeometry(
+      0.52,
+      FLYWHEEL_GEARBOX.centerY - FLYWHEEL_GEARBOX.radius,
+      0.3
+    ),
+    steel
+  );
+  gearboxPedestal.position.set(
+    FLYWHEEL_GEARBOX.centerX,
+    FLYWHEEL_BASE_DIMENSIONS.height +
+      (FLYWHEEL_GEARBOX.centerY - FLYWHEEL_GEARBOX.radius) / 2,
+    FLYWHEEL_GEARBOX.centerZ
+  );
+  group.add(gearboxPedestal);
 
   addTeeth(
     gearbox,
@@ -405,7 +453,7 @@ export function createFlywheelShowpiece(
   crankGroup.position.set(
     FLYWHEEL_GEARBOX.centerX,
     FLYWHEEL_GEARBOX.centerY,
-    FLYWHEEL_GEARBOX.centerZ + 0.34
+    FLYWHEEL_CRANK.centerZ
   );
   group.add(crankGroup);
   const crankDisc = mesh(
@@ -751,7 +799,7 @@ export function createFlywheelShowpiece(
       crankGroup.rotation.z = crankAngle;
       sunGear.rotation.z = crankAngle;
       carrier.rotation.z = carrierAngle;
-      output.rotation.z = carrierAngle;
+      output.rotation.x = carrierAngle;
       wheelGroup.rotation.z = carrierAngle;
       planetGears.forEach((planet) => {
         planet.rotation.z = planetLocalSpin;

--- a/src/scene/structures/flywheelEnergyContract.ts
+++ b/src/scene/structures/flywheelEnergyContract.ts
@@ -9,35 +9,36 @@ export const FLYWHEEL_BASE_DIMENSIONS = {
   height: 0.22,
 } as const;
 export const FLYWHEEL_WHEEL = {
-  radius: 0.92,
-  rimTube: 0.12,
+  radius: 0.82,
+  rimTube: 0.11,
   thickness: 0.24,
-  centerX: -0.58,
-  centerY: 1.35,
+  centerX: -0.78,
+  centerY: 1.28,
   centerZ: 0,
 } as const;
-export const FLYWHEEL_AXLE = { radius: 0.075, length: 2.35 } as const;
+export const FLYWHEEL_AXLE = { radius: 0.075, length: 1.35 } as const;
 export const FLYWHEEL_BEARING_STAND = {
-  width: 0.18,
-  depth: 0.42,
-  height: 1.34,
+  width: 0.28,
+  depth: 0.16,
+  height: 1.16,
 } as const;
 export const FLYWHEEL_CRANK = {
   radius: 0.38,
   handleLength: 0.24,
   handleRadius: 0.045,
+  centerZ: 0.74,
 } as const;
 export const FLYWHEEL_GEARBOX = {
-  centerX: 0.78,
-  centerY: 1.24,
-  centerZ: 0,
-  radius: 0.52,
+  centerX: 1.08,
+  centerY: 1.26,
+  centerZ: 0.38,
+  radius: 0.46,
   depth: 0.26,
 } as const;
 export const FLYWHEEL_ENERGY_PORT = {
-  x: 1.32,
-  y: 1.62,
-  z: 0.62,
+  x: 1.42,
+  y: 1.68,
+  z: 0.72,
   radius: 0.13,
 } as const;
 export const FLYWHEEL_SUN_TEETH = 18;
@@ -53,16 +54,31 @@ export const FLYWHEEL_PLANET_RADIUS =
   (FLYWHEEL_SUN_RADIUS * FLYWHEEL_PLANET_TEETH) / FLYWHEEL_SUN_TEETH;
 export const FLYWHEEL_RING_RADIUS =
   FLYWHEEL_SUN_RADIUS + FLYWHEEL_PLANET_RADIUS * 2;
+export const FLYWHEEL_GEAR_TOOTH_LENGTH = 0.06;
+export const FLYWHEEL_GEARBOX_HOUSING_PAD = 0.08;
+export const FLYWHEEL_WHEEL_OUTER_RADIUS =
+  FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube;
+export const FLYWHEEL_GEARBOX_OUTER_RADIUS =
+  FLYWHEEL_RING_RADIUS +
+  FLYWHEEL_GEAR_TOOTH_LENGTH +
+  FLYWHEEL_GEARBOX_HOUSING_PAD;
+export const FLYWHEEL_WHEEL_RIGHT_EDGE =
+  FLYWHEEL_WHEEL.centerX + FLYWHEEL_WHEEL_OUTER_RADIUS;
+export const FLYWHEEL_GEARBOX_LEFT_EDGE =
+  FLYWHEEL_GEARBOX.centerX - FLYWHEEL_GEARBOX_OUTER_RADIUS;
+export const FLYWHEEL_WHEEL_GEAR_CLEARANCE =
+  FLYWHEEL_GEARBOX_LEFT_EDGE - FLYWHEEL_WHEEL_RIGHT_EDGE;
+export const FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE = 0.18;
 export const FLYWHEEL_PLANET_ORBIT_RADIUS =
   FLYWHEEL_SUN_RADIUS + FLYWHEEL_PLANET_RADIUS;
 export const FLYWHEEL_MARKER_MIN_HEIGHT = 2.95;
 export const FLYWHEEL_AVATAR_PATH_RADIUS = 1.2;
 export const FLYWHEEL_BASE_COLLIDER = { width: 3.25, depth: 1.55 } as const;
 export const FLYWHEEL_GEARBOX_COLLIDER = {
-  centerX: 0.92,
-  centerZ: 0.42,
-  width: 0.95,
-  depth: 0.74,
+  centerX: 1.08,
+  centerZ: 0.5,
+  width: 1.12,
+  depth: 0.86,
 } as const;
 
 export function getFlywheelCarrierAngle(sunAngle: number): number {

--- a/src/tests/flywheelEnergyContract.test.ts
+++ b/src/tests/flywheelEnergyContract.test.ts
@@ -2,11 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import {
   FLYWHEEL_BASE_DIMENSIONS,
+  FLYWHEEL_GEARBOX_LEFT_EDGE,
+  FLYWHEEL_GEARBOX_OUTER_RADIUS,
   FLYWHEEL_INSTALLATION_BOUNDS,
+  FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE,
   FLYWHEEL_PLANET_TEETH,
   FLYWHEEL_RING_TEETH,
   FLYWHEEL_SUN_TEETH,
   FLYWHEEL_TORQUE_RATIO,
+  FLYWHEEL_WHEEL,
+  FLYWHEEL_WHEEL_GEAR_CLEARANCE,
+  FLYWHEEL_WHEEL_OUTER_RADIUS,
+  FLYWHEEL_WHEEL_RIGHT_EDGE,
   getFlywheelCarrierAngle,
   getFlywheelPlanetLocalSpin,
 } from '../scene/structures/flywheelEnergyContract';
@@ -18,6 +25,22 @@ describe('flywheel energy contract', () => {
     );
     expect(FLYWHEEL_INSTALLATION_BOUNDS.height).toBeGreaterThan(2);
     expect(Number.isFinite(FLYWHEEL_INSTALLATION_BOUNDS.depth)).toBe(true);
+  });
+
+  it('keeps the gearbox envelope outside the flywheel rim with explicit clearance', () => {
+    expect(FLYWHEEL_WHEEL_OUTER_RADIUS).toBeCloseTo(
+      FLYWHEEL_WHEEL.radius + FLYWHEEL_WHEEL.rimTube
+    );
+    expect(FLYWHEEL_WHEEL_RIGHT_EDGE).toBeCloseTo(
+      FLYWHEEL_WHEEL.centerX + FLYWHEEL_WHEEL_OUTER_RADIUS
+    );
+    expect(FLYWHEEL_GEARBOX_LEFT_EDGE).toBeCloseTo(
+      FLYWHEEL_WHEEL_RIGHT_EDGE + FLYWHEEL_WHEEL_GEAR_CLEARANCE
+    );
+    expect(FLYWHEEL_GEARBOX_OUTER_RADIUS).toBeGreaterThan(0.6);
+    expect(FLYWHEEL_WHEEL_GEAR_CLEARANCE).toBeGreaterThanOrEqual(
+      FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE
+    );
   });
 
   it('uses plausible planetary gear teeth and torque ratio math', () => {

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -1,4 +1,4 @@
-import { MathUtils, Mesh, Object3D } from 'three';
+import { MathUtils, Mesh, Object3D, Vector3 } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import { SCENE_DETAIL_POLICIES } from '../scene/graphics/sceneDetailPolicy';
@@ -10,18 +10,22 @@ import {
   FLYWHEEL_CRANK_RAD_PER_SECOND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
   FLYWHEEL_ENERGY_PORT,
+  FLYWHEEL_GEARBOX,
   FLYWHEEL_GEARBOX_COLLIDER,
+  FLYWHEEL_GEARBOX_LEFT_EDGE,
   FLYWHEEL_INSTALLATION_BOUNDS,
   FLYWHEEL_MARKER_MIN_HEIGHT,
   FLYWHEEL_TORQUE_RATIO,
+  FLYWHEEL_WHEEL,
+  FLYWHEEL_WHEEL_RIGHT_EDGE,
 } from '../scene/structures/flywheelEnergyContract';
 
 const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
 
 const coreNames = [
   'FlywheelBase',
-  'FlywheelBearingStandLeft',
-  'FlywheelBearingStandRight',
+  'FlywheelBearingYokeFront',
+  'FlywheelBearingYokeBack',
   'FlywheelAxle',
   'FlywheelWheelGroup',
   'FlywheelHeavyRim',
@@ -37,6 +41,8 @@ const coreNames = [
   'FlywheelPlanetCarrier',
   'FlywheelPlanetGear-0',
   'FlywheelOutputShaft',
+  'FlywheelTorqueShaft',
+  'FlywheelGearboxPedestal',
   'FlywheelEnergyPort',
 ];
 
@@ -116,11 +122,61 @@ describe('createFlywheelShowpiece', () => {
     );
     expect(
       MathUtils.euclideanModulo(output.rotation.x, Math.PI * 2)
-    ).toBeCloseTo(Math.PI / 2);
+    ).toBeCloseTo(0);
 
     build.update({ elapsed: 1, delta: 0.25, emphasis: 0 });
     expect(wheel.rotation.z).toBeCloseTo(build.getDebugState().carrierAngle);
-    expect(output.rotation.z).toBeCloseTo(build.getDebugState().carrierAngle);
+    expect(output.rotation.x).toBeCloseTo(build.getDebugState().carrierAngle);
+    build.dispose();
+  });
+
+  it('separates wheel, gearbox, crank, bearings, and torque shaft for readability', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    const gearbox = build.group.getObjectByName('FlywheelPlanetaryGearbox')!;
+    const crank = build.group.getObjectByName('FlywheelCrankGroup')!;
+    const torqueShaft = build.group.getObjectByName('FlywheelTorqueShaft')!;
+    const frontYoke = build.group.getObjectByName('FlywheelBearingYokeFront')!;
+    const backYoke = build.group.getObjectByName('FlywheelBearingYokeBack')!;
+
+    expect(gearbox.position.x - FLYWHEEL_GEARBOX.radius).toBeGreaterThan(
+      FLYWHEEL_WHEEL_RIGHT_EDGE
+    );
+    expect(FLYWHEEL_GEARBOX_LEFT_EDGE).toBeGreaterThan(
+      FLYWHEEL_WHEEL_RIGHT_EDGE
+    );
+    const torqueShaftWorld = new Vector3();
+    torqueShaft.getWorldPosition(torqueShaftWorld);
+
+    expect(crank.position.z).toBeGreaterThan(FLYWHEEL_GEARBOX.centerZ);
+    expect(torqueShaftWorld.x).toBeLessThan(0);
+    expect(torqueShaftWorld.x).toBeGreaterThan(FLYWHEEL_WHEEL.centerX);
+    expect(frontYoke.position.z).toBeGreaterThan(FLYWHEEL_WHEEL.centerZ);
+    expect(backYoke.position.z).toBeLessThan(FLYWHEEL_WHEEL.centerZ);
+    expect(frontYoke.position.x).toBeCloseTo(FLYWHEEL_WHEEL.centerX);
+    expect(backYoke.position.x).toBeCloseTo(FLYWHEEL_WHEEL.centerX);
+    build.dispose();
+  });
+
+  it('keeps asymmetric wheel markers attached to the spinning wheel group', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    const wheel = build.group.getObjectByName('FlywheelWheelGroup')!;
+    const counterweights = wheel.children.filter((child) =>
+      child.name.startsWith('FlywheelCounterweight-')
+    );
+    expect(counterweights.length).toBeGreaterThanOrEqual(2);
+    build.update({
+      elapsed: 1,
+      delta: 0.5,
+      emphasis: 0,
+      runDecorativeEffects: false,
+    });
+    expect(wheel.rotation.z).toBeGreaterThan(0.1);
     build.dispose();
   });
 


### PR DESCRIPTION
### Motivation
- The Flywheel POI was hard to read after P6b because the planetary gearbox and supporting geometry overlapped the wheel envelope and a large translucent glow dominated the silhouette.
- Make the power path and mechanical relationships immediately legible from the default isometric view while preserving P6c energy-arc semantics.

### Description
- Move and shrink core physical constants in `flywheelEnergyContract.ts` so the wheel is left (`centerX = -0.78`, `radius = 0.82`) and the gearbox is right/front (`centerX = 1.08`, `centerZ = 0.38`, `radius = 0.46`), and add formula-derived exports (`FLYWHEEL_WHEEL_OUTER_RADIUS`, `FLYWHEEL_GEARBOX_OUTER_RADIUS`, `FLYWHEEL_WHEEL_RIGHT_EDGE`, `FLYWHEEL_GEARBOX_LEFT_EDGE`, `FLYWHEEL_WHEEL_GEAR_CLEARANCE`) plus `FLYWHEEL_MIN_WHEEL_GEAR_CLEARANCE = 0.18` to prevent overlap.
- Replace left/right face-crossing bearing posts with front/back axle yokes in `flywheel.ts`, add a visible `FlywheelGearboxPedestal`, and introduce `FlywheelOutputShaft` / `FlywheelTorqueShaft` that bridge the gearbox carrier toward the wheel hub while moving the crank forward of the gearbox and reducing the cyan glow to a slim inner ring.
- Update the miniature proxy (`src/scene/miniature/poiProxyRegistry.ts`) and regenerate the miniature manifest so the tabletop silhouette matches the new wheel-left / gearbox-right / crank-front layout, and update `docs/architecture/flywheel-energy-transfer.md` to record the corrected arrangement and the non-overlap invariant.
- Strengthen and add focused tests under `src/tests/` to assert the clearance invariant, presence of semantic nodes (yokes, torque shaft, pedestal), non-overlap/readability checks, and continued synchronization of crank/sun/carrier/flywheel animation.

### Testing
- Ran formatting and precommit-style checks: `npm run format:write` and `npm run format:check` both succeeded.
- Updated and validated the miniature manifest with `npm run miniature:manifest:update` and `npm run miniature:check`, and the generated `miniatureManifest.generated.json` was updated to reflect the proxy changes.
- Ran focused unit tests: `npm run test:ci -- src/tests/flywheelEnergyContract.test.ts src/tests/flywheelShowpiece.test.ts` and the extended suite `src/tests/flywheelEnergyNetwork.test.ts src/tests/miniatureProxyRegistry.test.ts src/tests/miniatureManifest.test.ts src/tests/poiPhysicalMetadata.test.ts src/tests/sceneObjectColliderPolicies.test.ts src/tests/poiModelTriangles.test.ts`; all executed tests passed.
- Lint (`npm run lint`), build (`npm run build`), docs check (`npm run docs:check`), and smoke test (`npm run smoke`) completed successfully (docs link check emitted external fetch warnings but passed); a local dev start was smoke-tested with a successful HTTP response to the immersive preview URL.
- `npm run typecheck` still reports pre-existing, project-wide TypeScript issues outside this Flywheel change (not introduced by this PR) and is documented as a residual warning in the notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f5dca2634832fb607e7e817ff8f64)