### PR TITLE
Finalize Flywheel hardening: mechanical sync, energy network, performance & QA

### DIFF
--- a/docs/architecture/flywheel-energy-transfer.md
+++ b/docs/architecture/flywheel-energy-transfer.md
@@ -1,658 +1,113 @@
-# Flywheel kinetic energy installation and transfer network design
+# Flywheel energy transfer implementation
 
-This documentation-only design specifies the architecture for
-upgrading `flywheel-studio-flywheel` from the current abstract automation kiosk
-into a grounded kinetic energy installation with a deterministic cross-POI energy
-transfer packet. Follow-up implementation work should build this design without
-adding external models, external textures, audio, live network data, upper-floor
-arcs, or an
-all-arcs-visible spiderweb.
+The `flywheel-studio-flywheel` POI is a completed kinetic installation built by
+`createFlywheelShowpiece(...)` in `src/scene/structures/flywheel.ts`. The builder
+returns the bottom-centered `FlywheelEnergyInstallation` root, its physical
+colliders, a per-frame `update(...)` hook, `setEnergyTargets(...)`,
+`getDebugState()`, and an idempotent `dispose()` method.
 
-## 1. Current-state audit
+## Runtime integration and root contract
 
-### Builder API and runtime contract
+`main.ts` creates exactly one Flywheel showpiece during immersive scene assembly,
+positions it at the Flywheel POI placement, copies the POI rotation, applies
+scene-object source metadata, registers its physical colliders, and attaches the
+root via `addPoiStructure(...)`. That helper registers the same root as both the
+POI visual anchor and model root, so marker placement, target resolution, and
+triangle accounting all reference the visible installation.
 
-`src/scene/structures/flywheel.ts` currently exposes:
+Energy targets are resolved after ground-floor structures have registered their
+visual anchors. Resolution excludes the Flywheel itself and upper-floor POIs,
+prefers `resolvePoiVisualAnchor(...)`, falls back to the POI group when an
+optional anchor is missing, and records diagnostics instead of throwing. The
+showpiece stores sanitized target snapshots, so quality reloads can dispose the
+old root, materials, geometries, colliders, and target state before a fresh build.
 
-```ts
-interface FlywheelShowpieceOptions {
-  centerX: number;
-  centerZ: number;
-  roomBounds: Bounds2D;
-  orientationRadians?: number;
-  detailPolicy?: SceneDetailPolicy;
-}
+## Physical dimensions and colliders
 
-interface FlywheelShowpieceBuild {
-  group: Group;
-  colliders: RectCollider[];
-  update(context: { elapsed: number; delta: number; emphasis: number }): void;
-}
-```
+Shared dimensions live in `src/scene/structures/flywheelEnergyContract.ts`:
 
-The build has no public `dispose()`, `setEnergyTargets(...)`, or debug-state
-surface. It registers browser selection listeners internally when `window` exists
-and removes them only when the root group receives a `removed` event. Follow-up
-implementation should replace that implicit lifecycle with an idempotent
-`dispose()` and keep any
-selection-driven presentation secondary to the main mechanical animation.
+- installation bounds: 2.6m wide, 2.2m deep, 2.55m high;
+- base: 2.25m × 1.35m × 0.22m;
+- wheel: 0.82m radius with a 0.1m tube and 0.24m thickness;
+- energy port: `(0.48, 1.58, 0.34)` with a 0.13m radius;
+- marker minimum height: 2.75m.
 
-### Current `group`, `colliders`, and update behavior
+The root scale remains `[1, 1, 1]`. The collider set covers the physical base
+and gear footprint, not the nonphysical energy arcs, preserving avatar routing
+around the installation while keeping marker/orb clearance above the machine.
 
-The current root group is named `FlywheelShowpiece` and is created at the origin.
-Many child meshes and groups are then positioned with `options.centerX` and
-`options.centerZ` baked directly into child transforms. Examples include the
-`FlywheelDais`, `FlywheelPedestal`, `FlywheelRotorGroup`, `FlywheelCounterGroup`,
-`FlywheelAutomationPillars`, `FlywheelTechStackGroup`, and the clamped
-`FlywheelInfoPanelGroup`. The returned colliders are factory colliders for the
-dais/showpiece and info panel footprint. The `update(...)` method animates the
-rotor/counter rings, orbit chips, automation pillars, tech-stack chips, and the
-selection-revealed docs callout.
+## Gear ratio and animation math
 
-Important architectural issue for implementation:
-
-- The current Flywheel builder authors many child objects directly in world
-  coordinates under a root group at the origin.
-- Newer POIs should instead use a bottom-centered, unit-scale root at the POI
-  anchor with child geometry authored in local coordinates.
-- Implementation must refactor Flywheel to that contract so visual anchors,
-  colliders, miniature placement, model-root triangle accounting, and target resolution
-  remain reliable.
-
-### Main-scene wiring
-
-`src/main.ts` resolves `flywheel-studio-flywheel` from `poiInstances`, falls back
-to the studio room center when the POI is missing, and calls
-`createFlywheelShowpiece({ centerX, centerZ, roomBounds, orientationRadians,
-detailPolicy })`. It then applies scene-object metadata, registers factory
-colliders against the `flywheel-studio-flywheel` scene-object definition when
-present, attaches the group with `addPoiStructure(...)` when the POI exists, and
-stores the build in `flywheelShowpiece`.
-
-`addPoiStructure(...)` adds the structure to the ground or upper structure group,
-registers the group as the POI model root via `registerPoiModelRoot(...)`, and
-registers the same group as the floor visual anchor via
-`registerPoiVisualAnchor(...)`. Because the current root is still at the origin,
-that visual anchor/model-root behavior is only correct by convention for triangle
-counting and incorrect for position-based consumers. Implementation should make the root
-itself the true anchor.
-
-The frame loop currently gates the entire Flywheel `update(...)` behind
-`sceneDetailController.shouldRunDecorativeUpdate(...)`. That is acceptable for the
-old decorative rotor but not for the new machine. Implementation should call
-`flywheelShowpiece.update(...)` every rendered frame for flywheel rotor and
-packet phase progression; only expensive secondary glow/halo work should use a
-`runDecorativeEffects` boolean.
-
-The teardown path currently sets `flywheelShowpiece = null` but does not call a
-Flywheel-owned disposer. Implementation must add `dispose()` and main teardown should call it
-when available, including partial-initialization teardown.
-
-### Placement, metadata, and scene objects
-
-The POI registry defines `flywheel-studio-flywheel` in the studio at
-`{ x: 10, y: 0, z: -2 }`, heading `0`, interaction radius `2.2`, and footprint
-`2 x 2`. The Flywheel keeps a POI-specific blue/teal hologram pedestal as the
-large readable body shell for the exhibit. The physical
-`FlywheelEnergyInstallation` supplies the inner spinning rotor, energy port, and
-energy-transfer packets, while the orb, halo, and label remain UI affordances.
-The Flywheel pedestal explicitly opts into a simplified Performance-mode render
-so low-detail graphics keep the large body silhouette; other hologram pedestals
-remain hidden in Performance unless they opt in.
-`src/scene/poi/placements.ts` can override placements from declarative scene
-objects; Flywheel's effective production placement should always come from the
-resolved POI instance rather than a hardcoded duplicate coordinate list.
-
-`src/scene/poi/physicalMetadata.ts` does not currently define a Flywheel physical
-metadata entry. Implementation should add one that references the shared Flywheel contract,
-records bottom-center anchoring, marker height, avatar clearance, and intended
-bounds.
-
-The Flywheel is represented by both the intentional POI hologram body shell and
-the physical `FlywheelEnergyInstallation` rotor. The body shell is not a gear
-train; it is the large blue/teal visual envelope that makes the exhibit readable.
-It uses reduced opacity and existing low-segment marker geometry in Performance
-mode rather than disappearing entirely. Energy arcs continue to resolve their
-endpoint through `FlywheelEnergyPort`.
-
-### Visual anchors, model triangles, and miniature proxy
-
-`src/scene/poi/visualAnchors.ts` stores a POI id to `Object3D` anchor map and
-resolves world position/yaw with `getWorldPosition(...)` and
-`getWorldQuaternion(...)`. Target resolution should use this machinery rather
-than a duplicate coordinate table.
-
-`src/scene/poi/modelTriangles.ts` tracks POI model roots and counts triangles via
-`countObjectTriangles(root)`. Keeping a single true root is essential for future
-triangle budgets.
-
-The current miniature proxy in `src/scene/miniature/poiProxyRegistry.ts` is a
-static abstract dais, rotor ring, spoke, and counterweight. The generated
-manifest lists `src/scene/structures/flywheel.ts` as a source file with
-`syncRevision: 3`. Follow-up implementation should update it for the physical
-wheel body, add static arc hints, and bump
-`syncRevision`, update `syncNote`, and regenerate the manifest.
-
-### Current animation and selection behavior
-
-Flywheel animation is presentation-driven: rotor rings spin, orbit chips rotate,
-automation pillars pulse, and tech-stack chips/docs callouts are revealed by
-emphasis plus `poi:selected`/`poi:selected:analytics` browser events.
-Implementation should keep the new mechanical motion active at baseline even when
-unfocused. Selection
-may increase glow or reveal minor secondary details, but it must not desynchronize
-mechanical ratios.
-
-## 2. Physical-size and root contract
-
-### Root contract
-
-The production builder root is `FlywheelEnergyInstallation`, placed at the
-resolved POI anchor with local +Y up and local +Z as the service/front axis after
-POI heading. All visible geometry is authored in local coordinates, and child
-mesh positions must not include resolved world `centerX`/`centerZ`. Conservative
-physical colliders cover the compact base and wheel footprint only; energy arcs
-are visual transfer effects and are not colliders.
-
-### Approximate dimensions and constants
-
-The shared source of truth is `src/scene/structures/flywheelEnergyContract.ts`.
-That contract feeds the builder, physical metadata, colliders, tests, and
-miniature proxy. Do not duplicate scene-unit numbers across files.
-
-The current visible baseline is intentionally simplified for readability:
-
-- a low physical base supports the installation;
-- front/back bearing yokes cradle a Z-axis axle;
-- the large wheel sits near the POI center with a dark heavy rim, hub, spokes,
-  counterweights, and asymmetric rim motion ticks;
-- a slim blue `FlywheelEnergyGlowRing` accents the rotor without replacing it;
-- `FlywheelEnergyPort` remains the endpoint for transfer arcs;
-- the POI-specific blue/teal hologram pedestal is intentional and provides the
-  large Flywheel body shell around the simple rotor baseline.
-
-## 3. Physical assembly design
-
-Stable semantic names are part of the contract and are covered by tests:
+The crank is the input shaft and drives the sun gear directly. The documented
+planetary reduction is `FLYWHEEL_GEAR_RATIO.sunToCarrier = 4`, so:
 
 ```text
-FlywheelEnergyInstallation
-├─ FlywheelBase
-├─ FlywheelBearingYokeFront
-│  └─ FlywheelBearingYokeFrontBridge
-├─ FlywheelBearingYokeBack
-│  └─ FlywheelBearingYokeBackBridge
-├─ FlywheelAxle
-├─ FlywheelAxleCapFront
-├─ FlywheelAxleCapBack
-├─ FlywheelWheelGroup
-│  ├─ FlywheelHeavyRim
-│  ├─ FlywheelInnerHub
-│  ├─ FlywheelSpoke-0..N
-│  ├─ FlywheelCounterweight-0..N
-│  ├─ FlywheelRimMotionTick-0..N
-│  └─ FlywheelEnergyGlowRing
-└─ FlywheelEnergyPort
+crankAngle = sunGearAngle = flywheelAngle * 4
+planetCarrierAngle = outputShaftAngle = flywheelAngle
+planetGearAngle = -(sunGearAngle - planetCarrierAngle) * 2
 ```
 
-The current implementation intentionally has no visible hand crank, planetary
-gearbox, ring gear, sun gear, planet gears, gear teeth, gearbox pedestal, long
-torque shaft, or couplers. Those mechanical concepts are deferred for a future
-design pass. Tests assert those object names remain absent so a partial gear
-layout cannot obscure the restored rotor body.
-
-## 4. Rotor animation
-
-Animation uses one stateful `flywheelAngle` accumulator advanced from nonnegative
-`delta`. Emphasis may mildly increase `spinVelocity` and glow intensity, but it
-does not affect the energy-transfer cadence or target selection.
-
-`FlywheelWheelGroup.rotation.z` is the visible rotor motion. Counterweights and
-`FlywheelRimMotionTick-*` markers are children of `FlywheelWheelGroup`, so their
-world positions visibly move as the wheel rotates. Debug state exposes
-`flywheelAngle`, `spinVelocity`, `triangleCount`, and the energy-network debug
-state; gear-only debug fields are intentionally absent.
-
-## 5. Detail-level plan
-
-All detail levels preserve the same root contract, rotor semantics, target
-selector, transfer cycle, direction, timings, and debug state. Lower detail
-levels reduce only presentation cost through fewer segments, fewer spokes, and
-fewer packet nodes/connectors. Accessibility pulse and flicker preferences are
-read through `getPulseScale()` and `getFlickerScale()` for opacity/scale
-presentation only; reduced settings do not pause the cycle or alter targets.
-
-## 6. Energy-transfer concept
-
-The energy network is added as follow-up implementation work. Eligible targets
-are every other ground-floor POI at runtime:
-
-- include POIs whose resolved floor is `ground`;
-- exclude `flywheel-studio-flywheel`;
-- exclude upper-floor POIs for this baseline;
-- use actual visual anchors or resolved POI positions, not hardcoded duplicate
-  coordinates;
-- fail open if optional targets are missing and expose diagnostics rather than
-  crashing immersive mode.
-
-The exact production list must be resolved from runtime floor data. Expected
-examples in the current scene may include Futur Optimist, token.place,
-Sugarkube, PR Reaper, DSPACE, Jobbot if on ground floor, Axel if on ground floor,
-Wove, f2clipboard, Sigma, Gitshelves if on ground floor, and the
-danielsmith.io table. Some of those examples are currently upper-floor via manual
-placements; the resolver must decide from current placement data rather than this
-text.
-
-### Deterministic selector
-
-Create a pure module such as `src/scene/structures/flywheelEnergyNetwork.ts`.
-It should use a seeded PRNG (for example mulberry32/xmur3 from a string seed) and
-must not call `Math.random()` at runtime. Recommended defaults:
-
-```ts
-export const FLYWHEEL_ENERGY_DEFAULT_SEED = 'flywheel-energy:v1';
-export const FLYWHEEL_INCOMING_BEFORE_OUTGOING = 5;
-export const FLYWHEEL_INCOMING_WINDOW = 0.1;
-export const FLYWHEEL_OUTGOING_WINDOW = 0.16;
-export const FLYWHEEL_INCOMING_STRENGTH = 1;
-export const FLYWHEEL_OUTGOING_STRENGTH = 1.65;
-```
-
-Selector rules:
-
-- stable sequence for the same seed and target list;
-- different seeds produce different orders when enough targets exist;
-- avoid immediate repeats when at least two eligible targets exist;
-- keep the exact rhythm: five completed incoming transfers followed by one
-  completed outgoing transfer, then repeat;
-- copy target data on input and debug output to prevent mutation leaks.
-
-## 7. Arc geometry and animation
-
-### Parabolic path
-
-Each active transfer is a quadratic Bezier sampled between world source and
-destination points:
-
-```ts
-const source = liftEndpoint(sourceWorld);
-const destination = liftEndpoint(destinationWorld);
-const midpoint = lerp(source, destination, 0.5);
-const distance = horizontalDistance(source, destination);
-const apexY = clamp(
-  Math.max(source.y, destination.y) + 0.75 + distance * 0.08,
-  1.15,
-  WALL_HEIGHT - CEILING_COVE_OFFSET - 0.35
-);
-const control = { x: midpoint.x, y: apexY, z: midpoint.z };
-```
-
-Endpoint lifts should keep packets readable above furniture: target POIs can use
-visual-anchor position plus `0.9-1.3` scene units; the Flywheel endpoint should be
-`FlywheelEnergyPort` transformed to world space. The packet root may live under
-`FlywheelEnergyInstallation`; if so, convert sampled world points to Flywheel
-local space before writing mesh positions. Alternatively use a stable world-space
-arc group attached to the same floor structure group, but keep ownership and
-disposal in the Flywheel build.
-
-### Visible packet window
-
-Only a moving subsection is rendered:
-
-```ts
-const visibleWindow = direction === 'incoming' ? 0.1 : 0.16;
-const head = clamp01(phase);
-const start = clamp01(head - visibleWindow);
-const end = head;
-```
-
-Sample only between `start` and `end`; never draw the full curve. Incoming
-packets travel selected target -> Flywheel. Outgoing packets travel Flywheel ->
-selected target and use the larger window, larger node scale, higher opacity, and
-stronger blue emissive material.
-
-Recommended fade rule for `N` visible samples:
-
-```ts
-const normalized = index / Math.max(1, N - 1);
-const edgeFade = Math.sin(Math.PI * normalized); // 0 at tail/head, 1 mid-packet
-const opacity = baseOpacity * (0.25 + 0.75 * edgeFade) * flickerScale;
-const scale = baseScale * (0.65 + 0.35 * edgeFade) * strength;
-```
-
-Use pooled procedural geometry:
-
-- preallocated node meshes, one maximum pool sized by detail level;
-- optional preallocated connector cylinders/capsules between adjacent nodes;
-- optional halo node pool in Cinematic/Balanced;
-- no per-frame `TubeGeometry`;
-- no per-frame material or geometry creation;
-- no dynamic point lights.
-
-Connector cylinders should be hidden when adjacent samples are hidden. Updating
-connector transforms is acceptable; rebuilding geometry is not.
-
-## 8. Runtime integration design
-
-Recommended final builder API:
-
-```ts
-export interface FlywheelShowpieceOptions {
-  position: { x: number; y?: number; z: number };
-  orientationRadians?: number;
-  roomBounds: Bounds2D;
-  detailPolicy?: SceneDetailPolicy;
-  energySeed?: string;
-}
-
-export interface FlywheelEnergyTarget {
-  poiId: string;
-  label: string;
-  floor: 'ground' | 'upper';
-  worldPosition: { x: number; y: number; z: number };
-}
-
-export interface FlywheelDebugState {
-  flywheelAngle: number;
-  spinVelocity: number;
-  triangleCount: number;
-  energy: {
-    direction: 'incoming' | 'outgoing' | null;
-    selectedTargetId: string | null;
-    phase: number;
-    activeNodeCount: number;
-  };
-}
-
-export interface FlywheelShowpieceBuild {
-  group: Group;
-  colliders: RectCollider[];
-  update(context: {
-    elapsed: number;
-    delta: number;
-    emphasis: number;
-    runDecorativeEffects?: boolean;
-  }): void;
-  setEnergyTargets(targets: readonly FlywheelEnergyTarget[]): void;
-  getDebugState(): FlywheelDebugState;
-  dispose(): void;
-}
-```
-
-`main.ts` integration plan:
-
-1. resolve the Flywheel POI instance from `poiInstances`;
-2. build once from the resolved POI position and heading;
-3. attach with `addPoiStructure(flywheelPoi, showpiece.group)` so model root and
-   visual anchor share the true root;
-4. register factory colliders with scene-object metadata exactly as today;
-5. after all ground-floor POI structures and visual anchors are created, call
-   `resolveFlywheelEnergyTargets(...)` and then
-   `flywheelShowpiece.setEnergyTargets(...)`;
-6. update Flywheel every rendered frame;
-7. pass `runDecorativeEffects` from
-   `sceneDetailController.shouldRunDecorativeUpdate(...)` for secondary glow/halo
-   throttling only;
-8. call `flywheelShowpiece.dispose()` during full and partial teardown.
-
-Core mechanism updates that must run every frame: crank angle, sun gear, carrier,
-planets, output shaft, flywheel, active transfer phase, and active packet
-positions. Secondary effects that may be throttled: halo pulse opacity, decorative
-bolt glints, optional labels, and other non-semantic glow layers.
-
-## 9. Target resolution design
-
-Create a helper such as `resolveFlywheelEnergyTargets(...)` near the runtime POI
-integration or in a small POI-target resolver module. It should accept resolved
-POI instances and return both targets and diagnostics:
-
-```ts
-interface ResolvedFlywheelEnergyTargets {
-  targets: FlywheelEnergyTarget[];
-  diagnostics: string[];
-}
-```
-
-Resolver requirements:
-
-- inspect the resolved `poiInstances` array;
-- use the same floor resolver as the scene (`getPoiFloorId(...)`);
-- include only ground-floor POIs;
-- exclude `flywheel-studio-flywheel`;
-- prefer `resolvePoiVisualAnchor(poi.definition.id)`;
-- call `anchor.object.getWorldPosition(reusableVector)` or use the resolved
-  anchor world position;
-- fall back to the resolved POI group world position if the visual anchor is
-  missing;
-- include `poiId`, title/label, floor, and copied world position;
-- add diagnostics for missing visual anchors, excluded upper-floor POIs if useful
-  in debug, or zero eligible targets;
-- never hardcode a production coordinate list.
-
-If no eligible targets are available, the Flywheel machine should still animate
-physically and hide the energy packet pool. `getDebugState()` should report zero
-targets and diagnostics.
-
-## 10. Accessibility
-
-Use `getPulseScale()` and `getFlickerScale()` for presentation only. Reduced
-settings must not alter the target order, transfer counts, direction, or 5-in /
-1-out rhythm.
-
-Reduced-motion/reduced-flicker behavior:
-
-- flywheel motion remains visible but may use a lower shared speed
-  scale or smoother interpolation;
-- all gear ratios remain synchronized;
-- energy packets continue moving;
-- glow/halo pulses soften and opacity changes are eased;
-- outgoing transfer remains distinct through stable size/thickness/opacity rather
-  than sudden flashes;
-- no strobing, no full-bright burst, no dynamic point-light flashes;
-- connectors/halos may be reduced or hidden, but core packet nodes stay readable.
-
-## 11. Miniature proxy design
-
-The Flywheel miniature proxy remains static and must not run gear animation,
-target selection, or the energy network. Follow-up implementation should update it to show:
-
-- base and bearing silhouette;
-- heavy flywheel rim/hub/spokes;
-- deferred hand crank;
-- small gear cluster;
-- energy port/glow;
-- one thin incoming blue arc hint;
-- one thicker outgoing blue arc hint.
-
-`sourceFiles` should include the shared contract and, once added, the energy
-network module if proxy semantics depend on its constants. Each implementation PR
-should bump `syncRevision`, write a concrete `syncNote`, and run
-`npm run miniature:manifest:update` followed by `npm run miniature:check`.
-
-## 12. Tests and PR decomposition
-
-### Physical assembly and planetary gear train scope
-
-Implement the bottom-centered root, shared contract module, physical hierarchy,
-colliders, physical metadata, every-frame update integration, disposal,
-miniature physical proxy, and related doc corrections. Do not implement runtime
-cross-POI arcs.
-
-Required tests:
-
-- root anchoring and root scale `[1, 1, 1]`;
-- no world-coordinate child placement for core geometry;
-- semantic hierarchy names exist;
-- obsolete abstract elements are removed or intentionally renamed;
-- physical bounds and colliders fit the contract;
-- physical metadata marker/path clearances;
-- gear tooth constants and torque ratio formula;
-- crank/sun/carrier/output/flywheel synchronization;
-- planet orbit and counter-spin;
-- all five detail levels build finite geometry;
-- public detail levels reduce triangle counts meaningfully;
-- update at zero emphasis still animates;
-- no geometry/material rebuild during update;
-- disposal is idempotent;
-- miniature proxy contains wheel/crank/gear semantics;
-- manifest freshness.
-
-### Energy-transfer arcs scope
-
-Add the pure `flywheelEnergyNetwork` module, deterministic seeded selector,
-5-in/1-out state machine, target resolver, pooled one-packet arc renderer,
-accessibility presentation scaling, debug state, miniature arc hints, and doc
-updates.
-
-Required tests:
-
-- deterministic target sequence for the same seed;
-- different seeds produce different orders when possible;
-- Flywheel excluded and upper floors filtered by resolver/integration tests;
-- immediate repeats avoided when enough targets exist;
-- exactly five incoming transfers before one outgoing;
-- direction, selected target, phase, and completion state;
-- incoming visible window near `0.10` and outgoing window larger;
-- outgoing strength/thickness greater than incoming;
-- packet endpoints map to target visual anchor and Flywheel energy port;
-- exactly one packet group visible, no full-arc spiderweb;
-- bounded node counts by detail level;
-- no per-frame mesh/geometry/material creation;
-- nonzero Flywheel heading transforms correctly;
-- reduced pulse/flicker preserves semantics;
-- disposal is idempotent;
-- miniature proxy contains incoming/outgoing arc hints;
-- manifest freshness.
-
-### Hardening and final QA scope
-
-Audit runtime integration, quality reloads, partial teardown, performance hot
-paths, accessibility combinations, colliders, physical metadata, triangle/model
-root registration, miniature sync, and final documentation. Do not redesign the
-concept.
-
-Required tests/final matrix:
-
-- root anchoring/unit scale;
-- physical bounds;
-- gear ratio math;
-- synchronized crank/sun/planet/carrier/flywheel motion;
-- detail-level reductions;
-- collider placement and no arc colliders;
-- target resolution from visual anchors;
-- exact 5-in / 1-out deterministic cycle;
-- arc window length;
-- outgoing/incoming visual difference;
-- one packet visible at a time and no all-arc spiderweb;
-- hot-path allocation/pooling;
-- accessibility semantics;
-- miniature proxy semantics;
-- manifest freshness;
-- model-root triangle registration;
-- disposal and quality-reload cleanup.
-
-Manual QA for the complete baseline should use:
-
-```bash
-npm run dev -- --host 127.0.0.1 --port 5173
-```
-
-and open:
-
-```text
-http://localhost:5173/?mode=immersive&disablePerformanceFailover=1
-```
-
-Confirm the machine reads as heavy and physical, gear motion is synchronized,
-only one short blue parabolic packet is visible at a time, five incoming packets
-precede one larger outgoing packet, reduced motion/flicker remains comfortable,
-the POI marker clears the machine, the miniature proxy is static and current, and
-there are no obvious frame spikes.
-
-## Physical machine implementation update
-
-The implementation presents the Flywheel as `FlywheelEnergyInstallation`, a
-bottom-centered, physical rotor exhibit. The visible baseline is intentionally
-simple: a low base, front/back bearing yokes, axle caps, a large heavy
-`FlywheelWheelGroup`, `FlywheelHeavyRim`, `FlywheelInnerHub`, spokes,
-asymmetric `FlywheelCounterweight-*` and `FlywheelRimMotionTick-*` markers, a
-slim `FlywheelEnergyGlowRing`, and `FlywheelEnergyPort`. The wheel is the hero
-object and rotates every update so the attached asymmetric markers make motion
-readable from the normal camera.
-
-The experimental gear and hand-crank assembly is deferred for a future design
-pass. The current machine has no visible planetary gearbox, ring gear, sun gear,
-planet gears, gear teeth, hand crank, gearbox pedestal, torque shaft, output
-coupler, or long shaft. Tests assert those object names remain absent so the
-readable rotor body cannot be obscured by a partially connected mechanism.
-
-The energy-transfer arcs remain the metaphorical layer. `setEnergyTargets(...)`,
-the deterministic target resolver, the five-in/one-out transfer cadence, visible
-packet window, and energy timing semantics continue to resolve through
-`FlywheelEnergyPort`; physical colliders describe only the compact base/wheel
-footprint and do not include arcs. The miniature proxy mirrors the simplified
-rotor body with static incoming/outgoing arc hints.
-
-## 8. Energy-transfer implementation notes
-
-The implemented energy-transfer layer is split between the pure state module and
-runtime rendering integration:
-
-- `src/scene/structures/flywheelEnergyNetwork.ts` owns deterministic seeded
-  target selection, the five-in/one-out cycle, active-transfer phase, visible
-  window math, parabolic arc sampling, and debug snapshots. It has no DOM,
-  Three.js scene-object, or `main.ts` dependency and never uses `Math.random()`
-  for runtime target choice.
-- `src/scene/structures/flywheel.ts` owns the pooled presentation objects:
-  one `FlywheelEnergyTransferPacket` group, preallocated packet nodes, and
-  preallocated connector cylinders. The update loop advances the mechanical
-  flywheel state and the active energy-transfer phase every rendered
-  frame; `runDecorativeEffects` only gates secondary glow presentation.
-- `src/main.ts` resolves targets after ground-floor structures and visual
-  anchors have been created. It iterates the resolved `poiInstances`, uses the
-  scene floor resolver to keep only ground-floor POIs, excludes
-  `flywheel-studio-flywheel`, prefers `resolvePoiVisualAnchor(...)`, and reads
-  target world coordinates through `Object3D.getWorldPosition(...)`. Missing
-  optional anchors are diagnostics rather than immersive-mode blockers.
-
-Transfer timing is deterministic: five incoming packets travel from eligible
-POIs into the Flywheel energy port, followed by one outgoing packet from the port
-to an eligible POI. Incoming transfers use an approximately `0.10` phase window,
-while outgoing transfers use a wider `0.16` window and higher strength so they
-render thicker and brighter. Only samples inside the moving window are visible;
-the full curve is never rendered and all other potential arcs stay hidden.
-
-All five scene-detail levels preserve target order, direction, phase, transfer
-counts, and timing. Lower detail levels reduce only presentation cost by using
-fewer packet nodes/connectors and softer opacity. Accessibility pulse and flicker
-preferences are read through `getPulseScale()` and `getFlickerScale()` for
-opacity/scale presentation only; reduced settings do not pause the cycle or alter
-its targets.
-
-`getDebugState()` now reports target count, target-resolution diagnostics, cycle
-index, current direction/target/phase, visible window start/end, incoming and
-outgoing completion counts, source/destination world and local positions, active
-node count, detail level, and reduced pulse/flicker scale values. Returned arrays
-and points are copies so callers cannot mutate internal network state.
-
-## Geometry/readability correction
-
-The readability correction is a simplification rather than another gear-layout
-attempt. The physical Flywheel now reads as a large exposed rotor with a heavy
-rim, hub, spokes, counterweights, rim ticks, modest glow, and an energy port. The
-experimental hand-crank and planetary gear assembly was removed entirely from
-the current visible implementation.
-
-Regression tests build the actual showpiece, assert the restored rotor hierarchy
-exists, assert deleted gear/crank/tooth/shaft/coupler object names are absent,
-verify the asymmetric markers are children of the rotating wheel group, and check
-that the glow ring remains smaller than the physical rim. The POI marker tests
-also build the actual registry marker and assert the intentional Flywheel
-pedestal body, accent, ring, orb, and label remain present in Cinematic,
-Balanced, and the Flywheel opt-in Performance mode. A companion marker test
-asserts hologram pedestals without the Flywheel opt-in remain hidden in
-Performance.
-
-The miniature proxy mirrors this baseline with a heavy wheel, spoke, motion tick,
-energy port, and static incoming/outgoing arc hints. It does not include crank,
-gearbox, shaft, or coupler primitives.
+`update(...)` advances a single flywheel angle from nonnegative `delta` and the
+base spin velocity. Emphasis increases speed by the contract boost but does not
+change ratios. Reduced pulse/flicker settings soften glow and packet opacity;
+they do not pause the machine or alter crank, sun, planet, carrier, output, or
+flywheel synchronization.
+
+## Energy network state machine
+
+`src/scene/structures/flywheelEnergyNetwork.ts` owns the deterministic network.
+For a given seed and sanitized target list it selects targets in a stable order,
+avoids immediate repeats when multiple targets are available, and runs exactly
+five incoming transfers before one outgoing transfer. Incoming transfers move
+from POI anchor to Flywheel port. The outgoing transfer moves from the port back
+to the selected POI, uses a larger window, and has stronger/brighter rendering.
+
+Only the active packet window is rendered. Incoming windows are about 10% of the
+arc; outgoing windows are larger. Full parabolic arcs are never instantiated as
+visible geometry, preventing an all-target spiderweb.
+
+## Arc rendering, pooling, and performance
+
+All Flywheel geometry, materials, packet nodes, and packet connectors are built
+at setup time. Per-frame work reuses vectors, packet meshes, connector meshes,
+and materials. No `TubeGeometry`, transfer material, gear geometry, or canvas is
+created in `update(...)`. `getDebugState()` returns cloned snapshots and is the
+only intentionally allocation-friendly diagnostic path.
+
+Detail policy reduces rendering cost while preserving semantics: every level
+keeps the same gear ratio, five-in/one-out energy cycle, target ordering,
+directionality, and root contract. Lower levels reduce cylinder/torus segments,
+spokes, teeth, packet sample nodes, connector visibility, and decorative glow
+layers.
+
+## Accessibility behavior
+
+Normal, reduced pulse, reduced flicker, and combined reduced settings preserve
+the transfer rhythm and target sequence. Reduced pulse dampens scale changes;
+reduced flicker lowers opacity modulation and avoids flashes. The core crank,
+gear train, output shaft, flywheel, and packet direction remain readable and
+continuous.
+
+## Miniature proxy rule
+
+The miniature table uses the static proxy in
+`src/scene/miniature/poiProxyRegistry.ts`. It depicts the heavy wheel, crank,
+planetary gear cluster, base, bearings, energy port, a thin incoming arc hint,
+and a thicker outgoing arc hint. It intentionally does not run gear animation,
+target selection, or energy-network updates. The generated manifest must be
+refreshed whenever the runtime or proxy sources change.
+
+## Lifecycle and QA checklist
+
+- Build exactly one Flywheel root and attach it through `addPoiStructure(...)`.
+- Confirm the root is the visual anchor and model root.
+- Confirm crank, sun gear, planets, carrier, output shaft, and flywheel stay in
+  ratio in Cinematic, Balanced, and Performance detail modes.
+- Confirm five incoming packets precede one larger outgoing packet.
+- Confirm only a short packet subsection is visible and no arc spiderweb appears.
+- Confirm reduced pulse/flicker settings remain comfortable without pausing the
+  machine or hiding all transfer feedback.
+- Confirm the POI marker/orb clears the physical bounds.
+- Confirm colliders cover only physical machine areas.
+- Confirm miniature proxy remains static and manifest checks pass.
+- Confirm `dispose()` is safe to call repeatedly and after partial setup.

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "2aa5f688e1dd8ecd34ec8f046260f2ff9ab44f844915f565f7b6ebdbe5fc0ba0",
+      "proxyFingerprint": "ba281d1cd367af5ac34d851839cc9e4f3a92f19e1b7451cc2f537efb9e25921a",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "2f1e8a7fc3deaa111e16e6a03013527965119b92d97b09f1b78648b577b36584",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "d26b6a4ba77b15fc7de9913416e8e1774991bdfec8c0a49076feaf91359841eb"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 22,
-      "syncNote": "Tracks the simplified Flywheel rotor body plus performance-visible blue/teal POI shell, energy port, and static energy-arc hints without the deferred gear/crank assembly.",
-      "sourceFingerprint": "b3a7df0b3e13d5b3d3921edc5a3c1c7f65e1d215f15caf65137ad5f8966c6c66",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
-      "metadataFingerprint": "e015836380f2e0a5245506b6c10cdf8539a3d8846d4274890502c15d51a7cf49"
+      "syncRevision": 23,
+      "syncNote": "Tracks the final Flywheel rotor, crank, static planetary gear cluster, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.",
+      "sourceFingerprint": "ab15e640e9d1e669fade8b41d7c1acce8f24e5eb823362c4cc4ae8094436a651",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "metadataFingerprint": "af5ee04fedaf4148801db5e88fad688dd60f41b5f3ec444c5fe8add463c364e2"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bf8dc4d58f614431c0731f4de2fdaed1f971a42de96daac7e20bc190462915a2",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "3e4b8bcbebde225bf212394ecc8ad0e4a5e6681aba55b39cfc355ee27e8d971b"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "4436803d33b425c66c24c5c9ce6f34ce6d67d5787d64b0230a0386b6de1c669b",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "4fdf722cfeb551ce21463442ffcd4924a18671b22b3ef31dd3d105d032203967"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "d6696b8379112b6fe19fe420102d841a1ddcbe747713c2175452aec94fb26ba0",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "bad6d659009fad48a9ffdf335cbcb3aa993925cc575da14a599d2a05f6b35380"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "368e4459e1d9575bc4aea20b20394057cbffda2aaa2db23df46b59a3a397edf5",
+      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "a5e20bf0ec4334b247acd320b8a987781a95e33e58e23c414e8c7093ff1c2b01",
+      "proxyFingerprint": "3dafe605d375241fb47f921bc9845cbf35dbe00e24958d04cbc948dbf548828c",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "2f1e8a7fc3deaa111e16e6a03013527965119b92d97b09f1b78648b577b36584",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "d26b6a4ba77b15fc7de9913416e8e1774991bdfec8c0a49076feaf91359841eb"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 25,
-      "syncNote": "Acknowledges Flywheel hot-path allocation hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
-      "sourceFingerprint": "51c7d3163dcb0beea3c779dc4478c91568fba19f771f708746428baf7531744e",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
-      "metadataFingerprint": "1529b4f600c828b9498a544ff05b26727c8c3e35f191d509434ea02af3037853"
+      "syncRevision": 26,
+      "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
+      "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bf8dc4d58f614431c0731f4de2fdaed1f971a42de96daac7e20bc190462915a2",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "3e4b8bcbebde225bf212394ecc8ad0e4a5e6681aba55b39cfc355ee27e8d971b"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "4436803d33b425c66c24c5c9ce6f34ce6d67d5787d64b0230a0386b6de1c669b",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "4fdf722cfeb551ce21463442ffcd4924a18671b22b3ef31dd3d105d032203967"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "d6696b8379112b6fe19fe420102d841a1ddcbe747713c2175452aec94fb26ba0",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "bad6d659009fad48a9ffdf335cbcb3aa993925cc575da14a599d2a05f6b35380"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "088a284c134409005d3726c0183d7b9d9eceb2232c4f92b1230d9e423f5cd570",
+      "proxyFingerprint": "a5e20bf0ec4334b247acd320b8a987781a95e33e58e23c414e8c7093ff1c2b01",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "2f1e8a7fc3deaa111e16e6a03013527965119b92d97b09f1b78648b577b36584",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "d26b6a4ba77b15fc7de9913416e8e1774991bdfec8c0a49076feaf91359841eb"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 24,
-      "syncNote": "Tracks the final Flywheel rotor, crank, static planetary gear cluster, legible output shaft key mark, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.",
-      "sourceFingerprint": "4ac4d513adbb2fa7460ce2db3dd7bcffec7a80bf7caa443facc2398067a566b4",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
-      "metadataFingerprint": "144fd70f2ec774bccfe57c99c23a769bf34fac3bd097d7255ca98db297861430"
+      "syncRevision": 25,
+      "syncNote": "Acknowledges Flywheel hot-path allocation hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
+      "sourceFingerprint": "51c7d3163dcb0beea3c779dc4478c91568fba19f771f708746428baf7531744e",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
+      "metadataFingerprint": "1529b4f600c828b9498a544ff05b26727c8c3e35f191d509434ea02af3037853"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bf8dc4d58f614431c0731f4de2fdaed1f971a42de96daac7e20bc190462915a2",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "3e4b8bcbebde225bf212394ecc8ad0e4a5e6681aba55b39cfc355ee27e8d971b"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "4436803d33b425c66c24c5c9ce6f34ce6d67d5787d64b0230a0386b6de1c669b",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "4fdf722cfeb551ce21463442ffcd4924a18671b22b3ef31dd3d105d032203967"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "d6696b8379112b6fe19fe420102d841a1ddcbe747713c2175452aec94fb26ba0",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "bad6d659009fad48a9ffdf335cbcb3aa993925cc575da14a599d2a05f6b35380"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "proxyFingerprint": "3a308ab69c4fbe6b0bfd399ec1f520b1bdeea5f0718c8b094ab2b1b087b9b102",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -514,7 +514,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -534,7 +534,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "ba281d1cd367af5ac34d851839cc9e4f3a92f19e1b7451cc2f537efb9e25921a",
+      "proxyFingerprint": "088a284c134409005d3726c0183d7b9d9eceb2232c4f92b1230d9e423f5cd570",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -549,7 +549,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -564,7 +564,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "2f1e8a7fc3deaa111e16e6a03013527965119b92d97b09f1b78648b577b36584",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "d26b6a4ba77b15fc7de9913416e8e1774991bdfec8c0a49076feaf91359841eb"
     },
     {
@@ -578,11 +578,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 23,
-      "syncNote": "Tracks the final Flywheel rotor, crank, static planetary gear cluster, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.",
-      "sourceFingerprint": "ab15e640e9d1e669fade8b41d7c1acce8f24e5eb823362c4cc4ae8094436a651",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
-      "metadataFingerprint": "af5ee04fedaf4148801db5e88fad688dd60f41b5f3ec444c5fe8add463c364e2"
+      "syncRevision": 24,
+      "syncNote": "Tracks the final Flywheel rotor, crank, static planetary gear cluster, legible output shaft key mark, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.",
+      "sourceFingerprint": "4ac4d513adbb2fa7460ce2db3dd7bcffec7a80bf7caa443facc2398067a566b4",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
+      "metadataFingerprint": "144fd70f2ec774bccfe57c99c23a769bf34fac3bd097d7255ca98db297861430"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -596,7 +596,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -611,7 +611,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bf8dc4d58f614431c0731f4de2fdaed1f971a42de96daac7e20bc190462915a2",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "3e4b8bcbebde225bf212394ecc8ad0e4a5e6681aba55b39cfc355ee27e8d971b"
     },
     {
@@ -626,7 +626,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "4436803d33b425c66c24c5c9ce6f34ce6d67d5787d64b0230a0386b6de1c669b",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "4fdf722cfeb551ce21463442ffcd4924a18671b22b3ef31dd3d105d032203967"
     },
     {
@@ -641,7 +641,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -676,7 +676,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -691,7 +691,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "d6696b8379112b6fe19fe420102d841a1ddcbe747713c2175452aec94fb26ba0",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "bad6d659009fad48a9ffdf335cbcb3aa993925cc575da14a599d2a05f6b35380"
     },
     {
@@ -706,7 +706,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -721,7 +721,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -736,7 +736,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "f1bb87b8da55972a25a20d44c4be8356af2afb56a224cbde71f5d1ccccf60329",
+      "proxyFingerprint": "9741a6b74ee9b316cb1ec35c7bd0d655da40a630e60c6aafb1b14c751c40bf26",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 22,
+    syncRevision: 23,
     syncNote:
-      'Tracks the simplified Flywheel rotor body plus performance-visible blue/teal POI shell, energy port, and static energy-arc hints without the deferred gear/crank assembly.',
+      'Tracks the final Flywheel rotor, crank, static planetary gear cluster, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
@@ -131,6 +131,19 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
         0xf59e0b
       ),
       sphere('flywheel-energy-port', 0.07, [0.24, 0.82, 0.18], 0x38bdf8),
+      box(
+        'flywheel-crank-arm',
+        [0.24, 0.035, 0.035],
+        [-0.36, 0.56, 0.24],
+        0xd19a3a
+      ),
+      cyl(
+        'flywheel-planetary-gear-cluster',
+        0.13,
+        0.08,
+        [-0.36, 0.56, 0.18],
+        0x94a3b8
+      ),
       {
         kind: 'tube',
         name: 'flywheel-incoming-arc-hint',

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 23,
+    syncRevision: 24,
     syncNote:
-      'Tracks the final Flywheel rotor, crank, static planetary gear cluster, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.',
+      'Tracks the final Flywheel rotor, crank, static planetary gear cluster, legible output shaft key mark, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 24,
+    syncRevision: 25,
     syncNote:
-      'Tracks the final Flywheel rotor, crank, static planetary gear cluster, legible output shaft key mark, base, bearings, energy port, and one incoming/outgoing arc hint without running animation or target selection.',
+      'Acknowledges Flywheel hot-path allocation hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 25,
+    syncRevision: 26,
     syncNote:
-      'Acknowledges Flywheel hot-path allocation hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.',
+      'Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -557,12 +557,13 @@ export function createFlywheelShowpiece(
     position.z,
     options.orientationRadians ?? 0
   );
-  let state: FlywheelDebugState = {
+  const planetGearAngles = planetGears.map(() => 0);
+  const state: FlywheelDebugState = {
     flywheelAngle: 0,
     crankAngle: 0,
     sunGearAngle: 0,
     planetCarrierAngle: 0,
-    planetGearAngles: [0, 0, 0],
+    planetGearAngles,
     outputShaftAngle: 0,
     spinVelocity: FLYWHEEL_SPIN_RAD_PER_SECOND,
     triangleCount: countTriangles(group),
@@ -602,7 +603,6 @@ export function createFlywheelShowpiece(
   const sourceLocalPosition = new Vector3();
   const destinationLocalPosition = new Vector3();
   const localPoint = new Vector3();
-  const planetGearAngles = planetGears.map(() => 0);
 
   const hideEnergyPacket = () => {
     for (let i = 0; i < packetNodes.length; i += 1) {
@@ -808,20 +808,17 @@ export function createFlywheelShowpiece(
       }
       const transfer = energyNetwork.update(delta);
       const energyDebug = renderEnergyTransfer(transfer);
-      state = {
-        flywheelAngle,
-        crankAngle: nextCrankAngle,
-        sunGearAngle,
-        planetCarrierAngle: carrierAngle,
-        planetGearAngles: [...planetGearAngles],
-        outputShaftAngle: carrierAngle,
-        spinVelocity,
-        triangleCount: state.triangleCount,
-        energy: energyDebug,
-      };
+      state.flywheelAngle = flywheelAngle;
+      state.crankAngle = nextCrankAngle;
+      state.sunGearAngle = sunGearAngle;
+      state.planetCarrierAngle = carrierAngle;
+      state.outputShaftAngle = carrierAngle;
+      state.spinVelocity = spinVelocity;
+      state.energy = energyDebug;
     },
     getDebugState: () => ({
       ...state,
+      planetGearAngles: [...state.planetGearAngles],
       energy: {
         ...state.energy,
         missingTargetDiagnostics: [...state.energy.missingTargetDiagnostics],

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -29,6 +29,7 @@ import {
   FLYWHEEL_BEARING_STAND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
   FLYWHEEL_ENERGY_PORT,
+  FLYWHEEL_GEAR_RATIO,
   FLYWHEEL_SPIN_RAD_PER_SECOND,
   FLYWHEEL_WHEEL,
 } from './flywheelEnergyContract';
@@ -67,6 +68,11 @@ export interface FlywheelShowpieceOptions {
 
 export interface FlywheelDebugState {
   flywheelAngle: number;
+  crankAngle: number;
+  sunGearAngle: number;
+  planetCarrierAngle: number;
+  planetGearAngles: number[];
+  outputShaftAngle: number;
   spinVelocity: number;
   triangleCount: number;
   energy: {
@@ -338,6 +344,134 @@ export function createFlywheelShowpiece(
     wheelGroup.add(marker);
   }
 
+  const gearbox = new Group();
+  gearbox.name = 'FlywheelPlanetaryGearbox';
+  gearbox.position.set(-0.72, 0.82, FLYWHEEL_WHEEL.centerZ + 0.5);
+  group.add(gearbox);
+
+  const gearboxPedestal = mesh(
+    'FlywheelGearboxPedestal',
+    new BoxGeometry(0.68, 0.62, 0.18),
+    dark
+  );
+  gearboxPedestal.position.y = -0.28;
+  gearbox.add(gearboxPedestal);
+
+  const ringGear = mesh(
+    'FlywheelRingGear',
+    new TorusGeometry(0.32, 0.035, Math.max(4, cylSeg / 2), torusSeg),
+    steel
+  );
+  gearbox.add(ringGear);
+
+  const gearToothCount =
+    detailPolicy.level === 'cinematic'
+      ? 16
+      : detailPolicy.level === 'balanced'
+        ? 12
+        : detailPolicy.level === 'performance'
+          ? 8
+          : 6;
+  for (let i = 0; i < gearToothCount; i += 1) {
+    const tooth = mesh(
+      `FlywheelRingGearTooth-${i}`,
+      new BoxGeometry(0.04, 0.065, 0.04),
+      brass
+    );
+    const angle = (i / gearToothCount) * Math.PI * 2;
+    tooth.position.set(Math.cos(angle) * 0.32, Math.sin(angle) * 0.32, 0.02);
+    tooth.rotation.z = angle;
+    gearbox.add(tooth);
+  }
+
+  const sunGearGroup = new Group();
+  sunGearGroup.name = 'FlywheelSunGearGroup';
+  gearbox.add(sunGearGroup);
+  const sunGear = mesh(
+    'FlywheelSunGear',
+    new CylinderGeometry(0.11, 0.11, 0.08, cylSeg),
+    brass
+  );
+  sunGear.rotation.x = Math.PI / 2;
+  sunGearGroup.add(sunGear);
+
+  const planetCarrier = new Group();
+  planetCarrier.name = 'FlywheelPlanetCarrier';
+  gearbox.add(planetCarrier);
+  const planetGears: Object3D[] = [];
+  for (let i = 0; i < 3; i += 1) {
+    const angle = (i / 3) * Math.PI * 2;
+    const planet = mesh(
+      `FlywheelPlanetGear-${i}`,
+      new CylinderGeometry(0.075, 0.075, 0.075, cylSeg),
+      steel
+    );
+    planet.position.set(Math.cos(angle) * 0.21, Math.sin(angle) * 0.21, 0.04);
+    planet.rotation.x = Math.PI / 2;
+    planetCarrier.add(planet);
+    planetGears.push(planet);
+  }
+
+  const crankGroup = new Group();
+  crankGroup.name = 'FlywheelCrankGroup';
+  crankGroup.position.set(0, 0, 0.12);
+  gearbox.add(crankGroup);
+  const crankDisc = mesh(
+    'FlywheelCrankDisc',
+    new CylinderGeometry(0.12, 0.12, 0.035, cylSeg),
+    brass
+  );
+  crankDisc.rotation.x = Math.PI / 2;
+  crankGroup.add(crankDisc);
+  const crankArm = mesh(
+    'FlywheelCrankArm',
+    new BoxGeometry(0.28, 0.035, 0.035),
+    brass
+  );
+  crankArm.position.x = 0.15;
+  crankGroup.add(crankArm);
+  const crankHandle = mesh(
+    'FlywheelCrankHandle',
+    new CylinderGeometry(0.025, 0.025, 0.12, Math.max(6, cylSeg / 2)),
+    steel
+  );
+  crankHandle.position.set(0.3, 0, 0.05);
+  crankHandle.rotation.x = Math.PI / 2;
+  crankGroup.add(crankHandle);
+
+  const outputShaft = new Group();
+  outputShaft.name = 'FlywheelOutputShaft';
+  outputShaft.position.set(
+    -0.36,
+    FLYWHEEL_WHEEL.centerY,
+    FLYWHEEL_WHEEL.centerZ + 0.26
+  );
+  group.add(outputShaft);
+  const torqueShaftBody = mesh(
+    'FlywheelTorqueShaftBody',
+    new CylinderGeometry(0.035, 0.035, 0.72, Math.max(6, cylSeg / 2)),
+    steel
+  );
+  torqueShaftBody.name = 'FlywheelTorqueShaft';
+  torqueShaftBody.rotation.z = Math.PI / 2;
+  outputShaft.add(torqueShaftBody);
+  const outputCoupler = mesh(
+    'FlywheelGearboxOutputCoupler',
+    new CylinderGeometry(0.08, 0.08, 0.06, cylSeg),
+    brass
+  );
+  outputCoupler.rotation.z = Math.PI / 2;
+  outputCoupler.position.x = -0.36;
+  outputShaft.add(outputCoupler);
+  const hubCoupler = mesh(
+    'FlywheelFlywheelHubCoupler',
+    new CylinderGeometry(0.09, 0.09, 0.06, cylSeg),
+    brass
+  );
+  hubCoupler.rotation.z = Math.PI / 2;
+  hubCoupler.position.x = 0.36;
+  outputShaft.add(hubCoupler);
+
   const port = mesh(
     'FlywheelEnergyPort',
     new SphereGeometry(
@@ -419,6 +553,11 @@ export function createFlywheelShowpiece(
   );
   let state: FlywheelDebugState = {
     flywheelAngle: 0,
+    crankAngle: 0,
+    sunGearAngle: 0,
+    planetCarrierAngle: 0,
+    planetGearAngles: [0, 0, 0],
+    outputShaftAngle: 0,
     spinVelocity: FLYWHEEL_SPIN_RAD_PER_SECOND,
     triangleCount: countTriangles(group),
     energy: {
@@ -457,14 +596,15 @@ export function createFlywheelShowpiece(
   const sourceLocalPosition = new Vector3();
   const destinationLocalPosition = new Vector3();
   const localPoint = new Vector3();
+  const planetGearAngles = planetGears.map(() => 0);
 
   const hideEnergyPacket = () => {
-    packetNodes.forEach((node) => {
-      node.visible = false;
-    });
-    packetConnectors.forEach((connector) => {
-      connector.visible = false;
-    });
+    for (let i = 0; i < packetNodes.length; i += 1) {
+      packetNodes[i].visible = false;
+    }
+    for (let i = 0; i < packetConnectors.length; i += 1) {
+      packetConnectors[i].visible = false;
+    }
   };
 
   const clonePoint = (point: Vector3) => ({
@@ -566,13 +706,13 @@ export function createFlywheelShowpiece(
       }
       const fraction = activeNodeCount === 1 ? 0.5 : i / (activeNodeCount - 1);
       const phase = visible.start + span * fraction;
-      const world = sampleFlywheelEnergyArc(
+      sampleFlywheelEnergyArc(
         sourceWorldPosition,
         destinationWorldPosition,
         phase,
-        lift
+        lift,
+        localPoint
       );
-      localPoint.set(world.x, world.y, world.z);
       group.worldToLocal(localPoint);
       node.position.copy(localPoint);
       const edgeFade = Math.sin(fraction * Math.PI);
@@ -640,7 +780,21 @@ export function createFlywheelShowpiece(
       const spinVelocity =
         FLYWHEEL_SPIN_RAD_PER_SECOND *
         (1 + emphasisBoost * FLYWHEEL_EMPHASIS_SPEED_BOOST);
-      flywheelAngle += spinVelocity * Math.max(0, delta);
+      const safeDelta = Math.max(0, delta);
+      flywheelAngle += spinVelocity * safeDelta;
+      const nextCrankAngle = flywheelAngle * FLYWHEEL_GEAR_RATIO.sunToCarrier;
+      const sunGearAngle = nextCrankAngle;
+      const carrierAngle = flywheelAngle;
+      const planetSpin =
+        -(sunGearAngle - carrierAngle) * FLYWHEEL_GEAR_RATIO.planetCounterSpin;
+      crankGroup.rotation.z = nextCrankAngle;
+      sunGearGroup.rotation.z = sunGearAngle;
+      planetCarrier.rotation.z = carrierAngle;
+      for (let i = 0; i < planetGears.length; i += 1) {
+        planetGears[i].rotation.z = planetSpin;
+        planetGearAngles[i] = planetSpin;
+      }
+      outputShaft.rotation.x = carrierAngle;
       wheelGroup.rotation.z = flywheelAngle;
       if (runDecorativeEffects) {
         glow.opacity =
@@ -650,6 +804,11 @@ export function createFlywheelShowpiece(
       const energyDebug = renderEnergyTransfer(transfer);
       state = {
         flywheelAngle,
+        crankAngle: nextCrankAngle,
+        sunGearAngle,
+        planetCarrierAngle: carrierAngle,
+        planetGearAngles: [...planetGearAngles],
+        outputShaftAngle: carrierAngle,
         spinVelocity,
         triangleCount: state.triangleCount,
         energy: energyDebug,

--- a/src/scene/structures/flywheel.ts
+++ b/src/scene/structures/flywheel.ts
@@ -379,7 +379,7 @@ export function createFlywheelShowpiece(
       brass
     );
     const angle = (i / gearToothCount) * Math.PI * 2;
-    tooth.position.set(Math.cos(angle) * 0.32, Math.sin(angle) * 0.32, 0.02);
+    tooth.position.set(Math.cos(angle) * 0.285, Math.sin(angle) * 0.285, 0.02);
     tooth.rotation.z = angle;
     gearbox.add(tooth);
   }
@@ -448,11 +448,10 @@ export function createFlywheelShowpiece(
   );
   group.add(outputShaft);
   const torqueShaftBody = mesh(
-    'FlywheelTorqueShaftBody',
+    'FlywheelTorqueShaft',
     new CylinderGeometry(0.035, 0.035, 0.72, Math.max(6, cylSeg / 2)),
     steel
   );
-  torqueShaftBody.name = 'FlywheelTorqueShaft';
   torqueShaftBody.rotation.z = Math.PI / 2;
   outputShaft.add(torqueShaftBody);
   const outputCoupler = mesh(
@@ -471,6 +470,13 @@ export function createFlywheelShowpiece(
   hubCoupler.rotation.z = Math.PI / 2;
   hubCoupler.position.x = 0.36;
   outputShaft.add(hubCoupler);
+  const shaftKeyMark = mesh(
+    'FlywheelOutputShaftKeyMark',
+    new BoxGeometry(0.012, 0.11, 0.018),
+    brass
+  );
+  shaftKeyMark.position.set(0.405, 0.055, 0);
+  outputShaft.add(shaftKeyMark);
 
   const port = mesh(
     'FlywheelEnergyPort',

--- a/src/scene/structures/flywheelEnergyContract.ts
+++ b/src/scene/structures/flywheelEnergyContract.ts
@@ -35,3 +35,8 @@ export const FLYWHEEL_SPIN_RAD_PER_SECOND = 0.92;
 export const FLYWHEEL_EMPHASIS_SPEED_BOOST = 0.18;
 export const FLYWHEEL_AVATAR_PATH_RADIUS = 1.15;
 export const FLYWHEEL_BASE_COLLIDER = { width: 2.25, depth: 1.35 } as const;
+
+export const FLYWHEEL_GEAR_RATIO = {
+  sunToCarrier: 4,
+  planetCounterSpin: 2,
+} as const;

--- a/src/scene/structures/flywheelEnergyNetwork.ts
+++ b/src/scene/structures/flywheelEnergyNetwork.ts
@@ -247,7 +247,8 @@ export function sampleFlywheelEnergyArc(
   source: FlywheelEnergyPoint,
   destination: FlywheelEnergyPoint,
   t: number,
-  lift = 1.35
+  lift = 1.35,
+  target?: FlywheelEnergyPoint
 ): FlywheelEnergyPoint {
   const phase = clamp01(t);
   const mid = {
@@ -258,11 +259,11 @@ export function sampleFlywheelEnergyArc(
   const a = (1 - phase) * (1 - phase);
   const b = 2 * (1 - phase) * phase;
   const c = phase * phase;
-  return {
-    x: a * source.x + b * mid.x + c * destination.x,
-    y: a * source.y + b * mid.y + c * destination.y,
-    z: a * source.z + b * mid.z + c * destination.z,
-  };
+  const point = target ?? { x: 0, y: 0, z: 0 };
+  point.x = a * source.x + b * mid.x + c * destination.x;
+  point.y = a * source.y + b * mid.y + c * destination.y;
+  point.z = a * source.z + b * mid.z + c * destination.z;
+  return point;
 }
 
 function cloneTarget(target: FlywheelEnergyTarget): FlywheelEnergyTarget {

--- a/src/scene/structures/flywheelEnergyNetwork.ts
+++ b/src/scene/structures/flywheelEnergyNetwork.ts
@@ -251,18 +251,16 @@ export function sampleFlywheelEnergyArc(
   target?: FlywheelEnergyPoint
 ): FlywheelEnergyPoint {
   const phase = clamp01(t);
-  const mid = {
-    x: (source.x + destination.x) / 2,
-    y: Math.max(source.y, destination.y) + lift,
-    z: (source.z + destination.z) / 2,
-  };
+  const midX = (source.x + destination.x) / 2;
+  const midY = Math.max(source.y, destination.y) + lift;
+  const midZ = (source.z + destination.z) / 2;
   const a = (1 - phase) * (1 - phase);
   const b = 2 * (1 - phase) * phase;
   const c = phase * phase;
   const point = target ?? { x: 0, y: 0, z: 0 };
-  point.x = a * source.x + b * mid.x + c * destination.x;
-  point.y = a * source.y + b * mid.y + c * destination.y;
-  point.z = a * source.z + b * mid.z + c * destination.z;
+  point.x = a * source.x + b * midX + c * destination.x;
+  point.y = a * source.y + b * midY + c * destination.y;
+  point.z = a * source.z + b * midZ + c * destination.z;
   return point;
 }
 

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -11,6 +11,7 @@ import {
   FLYWHEEL_BEARING_STAND,
   FLYWHEEL_EMPHASIS_SPEED_BOOST,
   FLYWHEEL_ENERGY_PORT,
+  FLYWHEEL_GEAR_RATIO,
   FLYWHEEL_INSTALLATION_BOUNDS,
   FLYWHEEL_MARKER_MIN_HEIGHT,
   FLYWHEEL_SPIN_RAD_PER_SECOND,
@@ -19,24 +20,19 @@ import {
 
 const roomBounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
 
-const deletedGearNames = [
+const mechanicalAssemblyNames = [
   'FlywheelPlanetaryGearbox',
   'FlywheelRingGear',
   'FlywheelSunGear',
   'FlywheelSunGearGroup',
   'FlywheelPlanetCarrier',
   'FlywheelCrankGroup',
-  'FlywheelCrankDisc',
   'FlywheelCrankArm',
   'FlywheelCrankHandle',
-  'FlywheelGearboxPedestal',
   'FlywheelOutputShaft',
   'FlywheelGearboxOutputCoupler',
   'FlywheelFlywheelHubCoupler',
   'FlywheelTorqueShaft',
-  'FlywheelTorqueShaftBody',
-  'FlywheelTorqueShaftSpinGroup',
-  'FlywheelTorqueShaftSpinStripe',
 ];
 
 describe('createFlywheelShowpiece', () => {
@@ -53,7 +49,7 @@ describe('createFlywheelShowpiece', () => {
     build.dispose();
   });
 
-  it('builds the restored wheel body and removes gear/crank assembly objects', () => {
+  it('builds the heavy wheel body with the crank and planetary gear assembly', () => {
     const build = createFlywheelShowpiece({
       position: { x: 0, z: 0 },
       roomBounds,
@@ -71,12 +67,9 @@ describe('createFlywheelShowpiece', () => {
     ]) {
       expect(build.group.getObjectByName(name)).toBeInstanceOf(Object3D);
     }
-    for (const name of deletedGearNames) {
-      expect(build.group.getObjectByName(name)).toBeUndefined();
+    for (const name of mechanicalAssemblyNames) {
+      expect(build.group.getObjectByName(name)).toBeInstanceOf(Object3D);
     }
-    build.group.traverse((object) => {
-      expect(object.name).not.toMatch(/Gear|Crank|Tooth|TorqueShaft|Coupler/);
-    });
     build.dispose();
   });
 
@@ -105,6 +98,33 @@ describe('createFlywheelShowpiece', () => {
       FLYWHEEL_SPIN_RAD_PER_SECOND
     );
     expect(after.distanceTo(before)).toBeGreaterThan(0.1);
+    build.dispose();
+  });
+
+  it('keeps the crank, gears, carrier, output shaft, and flywheel synchronized', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.update({
+      elapsed: 1,
+      delta: 1,
+      emphasis: 0.75,
+      runDecorativeEffects: false,
+    });
+    const debug = build.getDebugState();
+    expect(debug.crankAngle).toBeCloseTo(
+      debug.flywheelAngle * FLYWHEEL_GEAR_RATIO.sunToCarrier
+    );
+    expect(debug.sunGearAngle).toBeCloseTo(debug.crankAngle);
+    expect(debug.planetCarrierAngle).toBeCloseTo(debug.flywheelAngle);
+    expect(debug.outputShaftAngle).toBeCloseTo(debug.flywheelAngle);
+    for (const planetAngle of debug.planetGearAngles) {
+      expect(planetAngle).toBeCloseTo(
+        -(debug.sunGearAngle - debug.planetCarrierAngle) *
+          FLYWHEEL_GEAR_RATIO.planetCounterSpin
+      );
+    }
     build.dispose();
   });
 
@@ -414,7 +434,7 @@ describe('createFlywheelShowpiece', () => {
         'flywheel-outgoing-arc-hint',
       ])
     );
-    expect(names).not.toEqual(
+    expect(names).toEqual(
       expect.arrayContaining([
         'flywheel-crank-arm',
         'flywheel-planetary-gear-cluster',

--- a/src/tests/flywheelShowpiece.test.ts
+++ b/src/tests/flywheelShowpiece.test.ts
@@ -128,6 +128,27 @@ describe('createFlywheelShowpiece', () => {
     build.dispose();
   });
 
+  it('defensively snapshots planet gear debug angles', () => {
+    const build = createFlywheelShowpiece({
+      position: { x: 0, z: 0 },
+      roomBounds,
+    });
+    build.update({
+      elapsed: 1,
+      delta: 1,
+      emphasis: 0.5,
+      runDecorativeEffects: false,
+    });
+    const debug = build.getDebugState();
+    const expectedAngle = debug.planetGearAngles[0];
+    debug.planetGearAngles[0] = 999;
+
+    expect(build.getDebugState().planetGearAngles[0]).toBeCloseTo(
+      expectedAngle
+    );
+    build.dispose();
+  });
+
   it('keeps glow subordinate to the heavy physical rim', () => {
     const build = createFlywheelShowpiece({
       position: { x: 0, z: 0 },


### PR DESCRIPTION
### Motivation

- Finalize the Flywheel POI as a production-ready baseline by hardening runtime integration, performance, accessibility, miniature sync, and QA artifacts.
- Restore and verify mechanical correctness so crank/sun/planet/carrier/output/flywheel motion remains synchronized and deterministic under emphasis and detail changes.
- Reduce hot-path allocations and ensure pooled arc/packet rendering while keeping accessibility and detail-level semantics unchanged.

### Description

- Restored a static planetary gearbox and hand-crank presentation and exposed mechanical debug angles, and added `FLYWHEEL_GEAR_RATIO` to the contract for authoritative ratio math used in `update(...)` (see `src/scene/structures/flywheel.ts` and `src/scene/structures/flywheelEnergyContract.ts`).
- Hardened the energy-transfer presentation by reusing sampling objects (`sampleFlywheelEnergyArc` now accepts a caller target), pooling packet nodes/connectors, avoiding per-frame geometry/material construction, and preserving the deterministic 5-in/1-out state machine (`src/scene/structures/flywheelEnergyNetwork.ts` and `src/scene/structures/flywheel.ts`).
- Updated the static miniature proxy to include the final rotor, crank, planetary cluster, base/bearings, energy port, and incoming/outgoing arc hints and regenerated the miniature manifest (`src/scene/miniature/poiProxyRegistry.ts`, `src/scene/miniature/miniatureManifest.generated.json`).
- Strengthened tests and docs: expanded `src/tests/flywheelShowpiece.test.ts` to assert assembly and synchronization, preserved and expanded Flywheel network tests, and updated `docs/architecture/flywheel-energy-transfer.md` to match implementation and lifecycle/QA guidance.

### Testing

- Ran formatting and checks: `npm run format:write` and `npm run format:check` (passed).
- Updated and validated miniature manifest: `npm run miniature:manifest:update` and `npm run miniature:check` (passed).
- Unit tests: `npm run test:ci -- src/tests/flywheelEnergyContract.test.ts src/tests/flywheelEnergyNetwork.test.ts src/tests/flywheelShowpiece.test.ts` (passed) and `npm run test:ci` for related miniature/metadata/collider/perf suites (all passed).
- Lint/build/docs/smoke: `npm run lint`, `npm run build`, `npm run docs:check` (passed; `links:check` emitted external fetch warnings), and `npm run smoke` (passed).
- Dev preview: launched `npm run dev -- --host 127.0.0.1 --port 5173` and fetched `http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1` successfully (HTML returned), but no human visual inspection performed here.
- Typecheck: `npm run typecheck` reported existing, pre-existing project-wide TypeScript errors unrelated to this change (first observed: `src/main.ts(3555,33): error TS2345: Argument of type 'null' is not assignable to parameter of type 'AudioNode'`).

Known residuals and notes: `typecheck` remains noisy due to repository-wide typing issues that predate this PR; external link fetches in `docs:check` produced warnings but did not block docs validity; visual QA should be performed locally in the immersive preview to confirm appearance and motion comfort under accessibility prefs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a405b7513b4832fa7762be8f771df0a)