### PR TITLE
Add lower-floor furnishings foundation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -293,6 +293,7 @@ import {
   createJobbotTerminal,
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
+import { createLowerFloorFurnishings } from './scene/structures/lowerFloorFurnishings';
 import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
@@ -2273,6 +2274,23 @@ function initializeImmersiveScene(
     playerRadius: PLAYER_RADIUS,
     guardThickness: stairGuardThickness,
   }).forEach(registerSafetyCollider);
+
+  const lowerFloorFurnishings = createLowerFloorFurnishings();
+  groundStructureGroup.add(lowerFloorFurnishings.group);
+  lowerFloorFurnishings.colliders.forEach((furnishingCollider) => {
+    groundColliders.push(furnishingCollider.bounds);
+    namedColliderDebugNames.set(
+      furnishingCollider.bounds,
+      `LowerFloorFurnishing:${furnishingCollider.furnishingId}`
+    );
+    colliderSourceMetadata.set(furnishingCollider.bounds, {
+      sourceId: furnishingCollider.sourceId,
+      sourceType: 'generatedCollider',
+      purpose: 'lower-floor-furnishing',
+      role: furnishingCollider.category,
+      intent: furnishingCollider.kind,
+    });
+  });
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -1,0 +1,365 @@
+import {
+  BoxGeometry,
+  CylinderGeometry,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  type Material,
+} from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+import { assertLevelSourceId, type LevelSourceId } from '../level/sourceIds';
+
+export type LowerFloorFurnishingCategory =
+  | 'living-room-seating'
+  | 'kitchenette'
+  | 'storage'
+  | 'sleeping-nook'
+  | 'plants-lighting-decor'
+  | 'backyard';
+
+export interface LowerFloorFurnishingFootprint {
+  width: number;
+  depth: number;
+}
+
+export interface LowerFloorFurnishingDefinition {
+  id: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: 'livingRoom' | 'kitchen' | 'studio' | 'backyard' | string;
+  position: { x: number; y?: number; z: number };
+  orientationRadians: number;
+  solidFootprint?: LowerFloorFurnishingFootprint;
+  decorativeFootprint?: LowerFloorFurnishingFootprint;
+  kind: string;
+  visual?: {
+    color?: number;
+    height?: number;
+    trimColor?: number;
+    shape?: 'box' | 'cylinder' | 'flat';
+  };
+  allowDecorativeOverlapWith?: readonly string[];
+}
+
+export interface LowerFloorFurnishingDecorativeFootprint {
+  id: string;
+  furnishingId: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: string;
+  bounds: RectCollider;
+  allowOverlapWith: readonly string[];
+}
+
+export interface LowerFloorFurnishingCollider {
+  furnishingId: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: string;
+  kind: string;
+  bounds: RectCollider;
+  sourceId: LevelSourceId;
+}
+
+export interface LowerFloorFurnishingsBuild {
+  group: Group;
+  colliders: LowerFloorFurnishingCollider[];
+  decorativeFootprints: LowerFloorFurnishingDecorativeFootprint[];
+}
+
+export interface LowerFloorFurnishingsOptions {
+  definitions?: readonly LowerFloorFurnishingDefinition[];
+}
+
+export interface LowerFloorFurnishingPlanValidationOptions {
+  roomBounds?: Readonly<Record<string, RectCollider>>;
+  reservedBlockers?: readonly RectCollider[];
+  tolerance?: number;
+}
+
+export interface LowerFloorFurnishingPlanValidationResult {
+  valid: boolean;
+  errors: string[];
+  solidAabbs: Array<{
+    definition: LowerFloorFurnishingDefinition;
+    bounds: RectCollider;
+  }>;
+  decorativeFootprints: LowerFloorFurnishingDecorativeFootprint[];
+}
+
+export const LOWER_FLOOR_ROOM_BOUNDS: Readonly<Record<string, RectCollider>> = {
+  livingRoom: { minX: -32, maxX: 32, minZ: -32, maxZ: -8 },
+  kitchen: { minX: -32, maxX: -4, minZ: -8, maxZ: 16 },
+  studio: { minX: -4, maxX: 32, minZ: -8, maxZ: 16 },
+  backyard: { minX: -32, maxX: 32, minZ: 16, maxZ: 32 },
+};
+
+export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
+  { minX: -22, maxX: -14, minZ: -9.2, maxZ: -6.8 },
+  { minX: 11, maxX: 19, minZ: -9.2, maxZ: -6.8 },
+  { minX: -5.2, maxX: -2.8, minZ: 0, maxZ: 8 },
+  { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
+  { minX: 11, maxX: 19, minZ: 14.8, maxZ: 17.2 },
+  { minX: -32.0, maxX: -30.9, minZ: -23.2, maxZ: -16.8 },
+  { minX: -24.74, maxX: -19.94, minZ: -24.61, maxZ: -20.61 },
+  { minX: -12.34, maxX: -5.14, minZ: -26.12, maxZ: -19.72 },
+  { minX: -24.0, maxX: -19.2, minZ: -0.77, maxZ: 4.03 },
+  { minX: 26.4, maxX: 31.2, minZ: -24.4, maxZ: -21.2 },
+  { minX: 8.4, maxX: 16.4, minZ: -27.0, maxZ: -9.4 },
+  { minX: 15.8, maxX: 20.4, minZ: -1.1, maxZ: 3.8 },
+  { minX: 0.0, maxX: 6.4, minZ: -2.2, maxZ: 4.6 },
+  { minX: -18.5, maxX: -10.0, minZ: 18.0, maxZ: 24.2 },
+  { minX: 10.0, maxX: 18.2, minZ: 22.4, maxZ: 30.4 },
+];
+
+export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] =
+  [];
+
+export function createAabbFromCenterSize(
+  center: { x: number; z: number },
+  size: LowerFloorFurnishingFootprint
+): RectCollider {
+  return {
+    minX: center.x - size.width / 2,
+    maxX: center.x + size.width / 2,
+    minZ: center.z - size.depth / 2,
+    maxZ: center.z + size.depth / 2,
+  };
+}
+
+export function rectanglesOverlap(
+  a: RectCollider,
+  b: RectCollider,
+  tolerance = 0
+): boolean {
+  return !(
+    a.maxX <= b.minX + tolerance ||
+    a.minX >= b.maxX - tolerance ||
+    a.maxZ <= b.minZ + tolerance ||
+    a.minZ >= b.maxZ - tolerance
+  );
+}
+
+const contains = (
+  outer: RectCollider,
+  inner: RectCollider,
+  tolerance = 0
+): boolean =>
+  inner.minX >= outer.minX - tolerance &&
+  inner.maxX <= outer.maxX + tolerance &&
+  inner.minZ >= outer.minZ - tolerance &&
+  inner.maxZ <= outer.maxZ + tolerance;
+
+export function getLowerFloorFurnishingColliderSourceId(
+  definition: Pick<LowerFloorFurnishingDefinition, 'category' | 'id'>
+): LevelSourceId {
+  return assertLevelSourceId(
+    `ground.furnishings.${definition.category}.${definition.id}.generated_collider`
+  );
+}
+
+export function validateLowerFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingPlanValidationOptions = {}
+): LowerFloorFurnishingPlanValidationResult {
+  const roomBounds = options.roomBounds ?? LOWER_FLOOR_ROOM_BOUNDS;
+  const reservedBlockers =
+    options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS;
+  const tolerance = options.tolerance ?? 0;
+  const errors: string[] = [];
+  const solidAabbs: LowerFloorFurnishingPlanValidationResult['solidAabbs'] = [];
+  const decorativeFootprints: LowerFloorFurnishingDecorativeFootprint[] = [];
+
+  definitions.forEach((definition) => {
+    if (definition.solidFootprint) {
+      const bounds = createAabbFromCenterSize(
+        definition.position,
+        definition.solidFootprint
+      );
+      if (bounds.maxX <= bounds.minX || bounds.maxZ <= bounds.minZ) {
+        errors.push(`${definition.id} has a non-positive solid footprint.`);
+      }
+      const room = roomBounds[definition.roomId];
+      if (!room)
+        errors.push(`${definition.id} uses unknown room ${definition.roomId}.`);
+      else if (!contains(room, bounds, tolerance)) {
+        errors.push(
+          `${definition.id} solid footprint is outside ${definition.roomId}.`
+        );
+      }
+      reservedBlockers.forEach((blocker, index) => {
+        if (rectanglesOverlap(bounds, blocker, tolerance)) {
+          errors.push(`${definition.id} overlaps reserved blocker ${index}.`);
+        }
+      });
+      solidAabbs.push({ definition, bounds });
+    }
+
+    if (definition.decorativeFootprint) {
+      decorativeFootprints.push({
+        id: `${definition.id}.decorative`,
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        bounds: createAabbFromCenterSize(
+          definition.position,
+          definition.decorativeFootprint
+        ),
+        allowOverlapWith: definition.allowDecorativeOverlapWith ?? [],
+      });
+    }
+  });
+
+  solidAabbs.forEach((entry, index) => {
+    solidAabbs.slice(index + 1).forEach((other) => {
+      if (rectanglesOverlap(entry.bounds, other.bounds, tolerance)) {
+        errors.push(`${entry.definition.id} overlaps ${other.definition.id}.`);
+      }
+    });
+  });
+
+  decorativeFootprints.forEach((decorative) => {
+    solidAabbs.forEach((solid) => {
+      if (
+        solid.definition.id !== decorative.furnishingId &&
+        !decorative.allowOverlapWith.includes(solid.definition.id) &&
+        rectanglesOverlap(decorative.bounds, solid.bounds, tolerance)
+      ) {
+        errors.push(
+          `${decorative.id} overlaps ${solid.definition.id} without permission.`
+        );
+      }
+    });
+  });
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    solidAabbs,
+    decorativeFootprints,
+  };
+}
+
+const materialCache = new Map<number, MeshStandardMaterial>();
+
+function getMaterial(color: number): MeshStandardMaterial {
+  const cached = materialCache.get(color);
+  if (cached) return cached;
+  const material = new MeshStandardMaterial({
+    color,
+    roughness: 0.74,
+    metalness: 0.06,
+  });
+  materialCache.set(color, material);
+  return material;
+}
+
+function addBox(
+  parent: Group,
+  name: string,
+  size: [number, number, number],
+  color: number | Material
+) {
+  const mesh = new Mesh(
+    new BoxGeometry(...size),
+    typeof color === 'number' ? getMaterial(color) : color
+  );
+  mesh.name = name;
+  parent.add(mesh);
+  return mesh;
+}
+
+function addPrimitiveVisual(
+  parent: Group,
+  definition: LowerFloorFurnishingDefinition
+): void {
+  const footprint = definition.solidFootprint ??
+    definition.decorativeFootprint ?? { width: 1, depth: 1 };
+  const height =
+    definition.visual?.height ??
+    (definition.visual?.shape === 'flat' ? 0.05 : 0.8);
+  const color = definition.visual?.color ?? 0x52627a;
+  const y = definition.position.y ?? 0;
+
+  if (definition.visual?.shape === 'cylinder') {
+    const mesh = new Mesh(
+      new CylinderGeometry(
+        footprint.width / 2,
+        footprint.width / 2,
+        height,
+        12
+      ),
+      getMaterial(color)
+    );
+    mesh.name = `Furnishing:${definition.id}:cylinder`;
+    mesh.position.set(0, y + height / 2, 0);
+    parent.add(mesh);
+    return;
+  }
+
+  const body = addBox(
+    parent,
+    `Furnishing:${definition.id}:body`,
+    [footprint.width, height, footprint.depth],
+    color
+  );
+  body.position.set(0, y + height / 2, 0);
+
+  if (definition.visual?.shape !== 'flat' && definition.solidFootprint) {
+    const trimColor = definition.visual?.trimColor ?? 0x6e7d93;
+    const trim = addBox(
+      parent,
+      `Furnishing:${definition.id}:trim`,
+      [footprint.width + 0.08, 0.08, 0.08],
+      trimColor
+    );
+    trim.position.set(0, y + height + 0.04, -footprint.depth / 2);
+  }
+}
+
+export function createLowerFloorFurnishings(
+  options: LowerFloorFurnishingsOptions = {}
+): LowerFloorFurnishingsBuild {
+  const definitions = options.definitions ?? DEFAULT_LOWER_FLOOR_FURNISHINGS;
+  const group = new Group();
+  group.name = 'LowerFloorFurnishings';
+  const colliders: LowerFloorFurnishingCollider[] = [];
+
+  definitions.forEach((definition) => {
+    const furnishingGroup = new Group();
+    furnishingGroup.name = `Furnishing:${definition.id}`;
+    furnishingGroup.position.set(
+      definition.position.x,
+      definition.position.y ?? 0,
+      definition.position.z
+    );
+    furnishingGroup.rotation.y = definition.orientationRadians;
+    furnishingGroup.userData.lowerFloorFurnishing = {
+      id: definition.id,
+      category: definition.category,
+      roomId: definition.roomId,
+      kind: definition.kind,
+    };
+    addPrimitiveVisual(furnishingGroup, definition);
+    group.add(furnishingGroup);
+
+    if (definition.solidFootprint) {
+      colliders.push({
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        kind: definition.kind,
+        bounds: createAabbFromCenterSize(
+          definition.position,
+          definition.solidFootprint
+        ),
+        sourceId: getLowerFloorFurnishingColliderSourceId(definition),
+      });
+    }
+  });
+
+  return {
+    group,
+    colliders,
+    decorativeFootprints:
+      validateLowerFloorFurnishingPlan(definitions).decorativeFootprints,
+  };
+}

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOWER_FLOOR_RESERVED_BLOCKERS,
+  LOWER_FLOOR_ROOM_BOUNDS,
+  createLowerFloorFurnishings,
+  rectanglesOverlap,
+  validateLowerFloorFurnishingPlan,
+  type LowerFloorFurnishingDefinition,
+} from '../scene/structures/lowerFloorFurnishings';
+
+const TEST_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] = [
+  {
+    id: 'test-living-couch',
+    category: 'living-room-seating',
+    roomId: 'livingRoom',
+    position: { x: -4, z: -18 },
+    orientationRadians: 0,
+    solidFootprint: { width: 5.2, depth: 1.4 },
+    kind: 'couch',
+    visual: { color: 0x4c668f, height: 0.9 },
+  },
+  {
+    id: 'test-kitchen-counter',
+    category: 'kitchenette',
+    roomId: 'kitchen',
+    position: { x: -29, z: 8 },
+    orientationRadians: Math.PI / 2,
+    solidFootprint: { width: 3.2, depth: 1.1 },
+    kind: 'counter',
+  },
+  {
+    id: 'test-studio-storage',
+    category: 'storage',
+    roomId: 'studio',
+    position: { x: 27, z: 8 },
+    orientationRadians: -Math.PI / 2,
+    solidFootprint: { width: 2.4, depth: 1 },
+    kind: 'cabinet',
+  },
+  {
+    id: 'test-backyard-planter',
+    category: 'backyard',
+    roomId: 'backyard',
+    position: { x: 26, z: 24 },
+    orientationRadians: 0,
+    solidFootprint: { width: 1.6, depth: 1.6 },
+    kind: 'planter',
+    visual: { shape: 'cylinder', color: 0x556b49, height: 1 },
+  },
+  {
+    id: 'test-living-rug',
+    category: 'plants-lighting-decor',
+    roomId: 'livingRoom',
+    position: { x: -4, z: -18 },
+    orientationRadians: 0,
+    decorativeFootprint: { width: 7, depth: 3.4 },
+    kind: 'rug',
+    visual: { shape: 'flat', color: 0x7a5a42, height: 0.04 },
+    allowDecorativeOverlapWith: ['test-living-couch'],
+  },
+];
+
+const area = (bounds: {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}) => (bounds.maxX - bounds.minX) * (bounds.maxZ - bounds.minZ);
+
+const contains = (
+  outer: { minX: number; maxX: number; minZ: number; maxZ: number },
+  inner: { minX: number; maxX: number; minZ: number; maxZ: number }
+) =>
+  inner.minX >= outer.minX &&
+  inner.maxX <= outer.maxX &&
+  inner.minZ >= outer.minZ &&
+  inner.maxZ <= outer.maxZ;
+
+describe('lower-floor furnishings', () => {
+  it('renders an empty default plan without movement colliders', () => {
+    const build = createLowerFloorFurnishings();
+
+    expect(build.group.name).toBe('LowerFloorFurnishings');
+    expect(build.colliders).toEqual([]);
+    expect(build.decorativeFootprints).toEqual([]);
+  });
+
+  it('creates blocking colliders only for solid furnishings', () => {
+    const build = createLowerFloorFurnishings({
+      definitions: TEST_FURNISHINGS,
+    });
+
+    expect(build.group.children.map((child) => child.name)).toContain(
+      'Furnishing:test-living-couch'
+    );
+    expect(build.colliders).toHaveLength(4);
+    expect(build.decorativeFootprints).toHaveLength(1);
+    expect(build.decorativeFootprints[0].furnishingId).toBe('test-living-rug');
+    expect(
+      build.colliders.map((collider) => collider.furnishingId)
+    ).not.toContain('test-living-rug');
+  });
+
+  it('validates solid furnishing AABBs against rooms, peers, and reserved blockers', () => {
+    const validation = validateLowerFloorFurnishingPlan(TEST_FURNISHINGS);
+
+    expect(validation.errors).toEqual([]);
+    expect(validation.valid).toBe(true);
+
+    validation.solidAabbs.forEach(({ definition, bounds }) => {
+      expect(area(bounds)).toBeGreaterThan(0);
+      expect(contains(LOWER_FLOOR_ROOM_BOUNDS[definition.roomId], bounds)).toBe(
+        true
+      );
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(bounds, blocker)).toBe(false);
+      });
+    });
+
+    validation.solidAabbs.forEach((entry, index) => {
+      validation.solidAabbs.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(entry.bounds, other.bounds)).toBe(false);
+      });
+    });
+  });
+
+  it('requires decorative footprints to explicitly allow solid furniture overlaps', () => {
+    const allowed = validateLowerFloorFurnishingPlan(TEST_FURNISHINGS);
+    expect(allowed.valid).toBe(true);
+
+    const disallowed = validateLowerFloorFurnishingPlan(
+      TEST_FURNISHINGS.map((definition) =>
+        definition.id === 'test-living-rug'
+          ? { ...definition, allowDecorativeOverlapWith: [] }
+          : definition
+      )
+    );
+
+    expect(disallowed.valid).toBe(false);
+    expect(disallowed.errors).toContain(
+      'test-living-rug.decorative overlaps test-living-couch without permission.'
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Prepare the ground-floor for upcoming furniture and decor passes by adding a typed, testable foundation for lower-floor furnishings and footprints.
- Ensure generated furnishing colliders can be produced and registered as runtime movement blockers without altering existing POIs, walls, stairs, or interaction behavior.

### Description
- Add `src/scene/structures/lowerFloorFurnishings.ts` which defines furnishing categories, typed definition/collider/decorative models, room bounds, reserved blockers, AABB helpers (`createAabbFromCenterSize`, `rectanglesOverlap`), plan validation (`validateLowerFloorFurnishingPlan`), primitive visual helpers, and `createLowerFloorFurnishings` returning `{ group, colliders, decorativeFootprints }`.
- Implement predictable naming for groups/meshes (e.g. `LowerFloorFurnishings`, `Furnishing:<id>`) and generate level source IDs for colliders via `ground.furnishings.<category>.<id>.generated_collider`.
- Wire the default furnishings build into `src/main.ts` after ground stair safety colliders so the furnishings group is added to `groundStructureGroup` and generated solid colliders are pushed into `groundColliders` with `colliderSourceMetadata` entries (sourceType `generatedCollider`, purpose `lower-floor-furnishing`).
- Add `src/tests/lowerFloorFurnishings.test.ts` with focused Vitest coverage for empty rendering, solid vs decorative footprints, room-bound checks, reserved-blocker checks, and decorated-overlap allowances.

### Testing
- Ran formatting: `npm run format:write` (succeeded).
- Ran lint for the new files: `npm run lint -- src/scene/structures/lowerFloorFurnishings.ts src/tests/lowerFloorFurnishings.test.ts` (succeeded with one import-order warning fixed during the rollout).
- Ran targeted tests: `npm run test:ci -- lowerFloorFurnishings` which ran `src/tests/lowerFloorFurnishings.test.ts` and passed all 4 tests.
- Built the app: `npm run build` (production build completed successfully with standard chunk-size warning only).
- Scanned staged changes for secrets: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).
- Type check: `npm run typecheck` failed due to existing repo-wide TypeScript errors unrelated to these new files, and the new furnishing files/tests were not among the reported failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40aad26bd0832f873fdc740811a3f4)