### PR TITLE
Add lower-floor furnishing foundation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -293,6 +293,7 @@ import {
   createJobbotTerminal,
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
+import { createLowerFloorFurnishings } from './scene/structures/lowerFloorFurnishings';
 import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
@@ -1048,6 +1049,7 @@ const colliderSourceMetadata = new Map<
     role?: string;
     intent?: string;
     debugId?: string;
+    category?: string;
   }
 >();
 const upperFloorColliders: RectCollider[] = [];
@@ -2273,6 +2275,24 @@ function initializeImmersiveScene(
     playerRadius: PLAYER_RADIUS,
     guardThickness: stairGuardThickness,
   }).forEach(registerSafetyCollider);
+
+  const lowerFloorFurnishings = createLowerFloorFurnishings();
+  groundFloorGroup.add(lowerFloorFurnishings.group);
+  lowerFloorFurnishings.colliders.forEach((collider) => {
+    groundColliders.push(collider.bounds);
+    namedColliderDebugNames.set(
+      collider.bounds,
+      `LowerFloorFurnishing:${collider.id}`
+    );
+    colliderSourceMetadata.set(collider.bounds, {
+      sourceId: assertLevelSourceId(collider.sourceId),
+      sourceType: 'generatedCollider',
+      purpose: 'lower-floor-furnishing',
+      role: collider.kind,
+      category: collider.category,
+      debugId: collider.sourceId,
+    });
+  });
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -1,0 +1,378 @@
+import {
+  BoxGeometry,
+  CylinderGeometry,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  type Material,
+} from 'three';
+
+import type { RectCollider } from '../collision';
+
+export type LowerFloorFurnishingCategory =
+  | 'living-room-seating'
+  | 'kitchenette'
+  | 'storage'
+  | 'sleeping-nook'
+  | 'plants-lighting-decor'
+  | 'backyard';
+
+export type LowerFloorFurnishingRoomId =
+  | 'livingRoom'
+  | 'kitchen'
+  | 'studio'
+  | 'backyard';
+
+export interface LowerFloorFurnishingFootprint {
+  width: number;
+  depth: number;
+}
+
+export interface LowerFloorFurnishingDefinition {
+  id: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorFurnishingRoomId;
+  position: { x: number; y?: number; z: number };
+  orientationRadians: number;
+  solidFootprint?: LowerFloorFurnishingFootprint;
+  decorativeFootprint?: LowerFloorFurnishingFootprint;
+  kind: string;
+  visual?: {
+    color?: number;
+    height?: number;
+    trimColor?: number;
+    shape?: 'box' | 'cylinder' | 'flat';
+  };
+  allowDecorativeOverlapWithSolidIds?: readonly string[];
+}
+
+export interface LowerFloorDecorativeFootprint {
+  id: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorFurnishingRoomId;
+  kind: string;
+  bounds: RectCollider;
+  allowedSolidOverlapIds: readonly string[];
+}
+
+export interface LowerFloorFurnishingCollider {
+  id: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorFurnishingRoomId;
+  kind: string;
+  sourceId: `ground.furnishings.${LowerFloorFurnishingCategory}.${string}.generated_collider`;
+  bounds: RectCollider;
+}
+
+export interface LowerFloorFurnishingsBuild {
+  group: Group;
+  colliders: LowerFloorFurnishingCollider[];
+  decorativeFootprints: LowerFloorDecorativeFootprint[];
+}
+
+export interface LowerFloorFurnishingsOptions {
+  definitions?: readonly LowerFloorFurnishingDefinition[];
+  material?: Material;
+}
+
+export interface LowerFloorFurnishingValidationOptions {
+  roomBounds: Record<LowerFloorFurnishingRoomId, RectCollider>;
+  reservedBlockers?: readonly RectCollider[];
+  tolerance?: number;
+}
+
+export interface LowerFloorFurnishingValidationResult {
+  valid: boolean;
+  errors: string[];
+  solidAabbs: Array<LowerFloorFurnishingCollider>;
+  decorativeFootprints: LowerFloorDecorativeFootprint[];
+}
+
+export const LOWER_FLOOR_ROOM_BOUNDS: Record<
+  LowerFloorFurnishingRoomId,
+  RectCollider
+> = {
+  livingRoom: { minX: -32, maxX: 32, minZ: -32, maxZ: -8 },
+  kitchen: { minX: -32, maxX: -4, minZ: -8, maxZ: 16 },
+  studio: { minX: -4, maxX: 32, minZ: -8, maxZ: 16 },
+  backyard: { minX: -32, maxX: 32, minZ: 16, maxZ: 32 },
+};
+
+export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] =
+  [];
+
+export function createAabbFromCenterSize(
+  center: { x: number; z: number },
+  size: LowerFloorFurnishingFootprint,
+  orientationRadians = 0
+): RectCollider {
+  const halfWidth = size.width / 2;
+  const halfDepth = size.depth / 2;
+  const cos = Math.cos(orientationRadians);
+  const sin = Math.sin(orientationRadians);
+  const corners = [
+    { x: -halfWidth, z: -halfDepth },
+    { x: halfWidth, z: -halfDepth },
+    { x: halfWidth, z: halfDepth },
+    { x: -halfWidth, z: halfDepth },
+  ];
+  return corners.reduce<RectCollider>(
+    (bounds, corner) => {
+      const x = center.x + corner.x * cos + corner.z * sin;
+      const z = center.z - corner.x * sin + corner.z * cos;
+      return {
+        minX: Math.min(bounds.minX, x),
+        maxX: Math.max(bounds.maxX, x),
+        minZ: Math.min(bounds.minZ, z),
+        maxZ: Math.max(bounds.maxZ, z),
+      };
+    },
+    {
+      minX: Number.POSITIVE_INFINITY,
+      maxX: Number.NEGATIVE_INFINITY,
+      minZ: Number.POSITIVE_INFINITY,
+      maxZ: Number.NEGATIVE_INFINITY,
+    }
+  );
+}
+
+export function rectanglesOverlap(
+  a: RectCollider,
+  b: RectCollider,
+  tolerance = 0
+): boolean {
+  return !(
+    a.maxX <= b.minX + tolerance ||
+    a.minX >= b.maxX - tolerance ||
+    a.maxZ <= b.minZ + tolerance ||
+    a.minZ >= b.maxZ - tolerance
+  );
+}
+
+export function validateLowerFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingValidationOptions
+): LowerFloorFurnishingValidationResult {
+  const tolerance = options.tolerance ?? 0;
+  const errors: string[] = [];
+  const solidAabbs = definitions
+    .filter((definition) => definition.solidFootprint)
+    .map(createColliderRecord);
+  const decorativeFootprints = definitions
+    .filter((definition) => definition.decorativeFootprint)
+    .map(createDecorativeFootprintRecord);
+
+  solidAabbs.forEach((solid) => {
+    if (!hasPositiveArea(solid.bounds)) {
+      errors.push(`${solid.id} has a non-positive solid footprint.`);
+    }
+    if (
+      !containsRect(options.roomBounds[solid.roomId], solid.bounds, tolerance)
+    ) {
+      errors.push(
+        `${solid.id} is outside its declared ${solid.roomId} bounds.`
+      );
+    }
+  });
+
+  for (let index = 0; index < solidAabbs.length; index += 1) {
+    for (
+      let otherIndex = index + 1;
+      otherIndex < solidAabbs.length;
+      otherIndex += 1
+    ) {
+      if (
+        rectanglesOverlap(
+          solidAabbs[index].bounds,
+          solidAabbs[otherIndex].bounds,
+          tolerance
+        )
+      ) {
+        errors.push(
+          `${solidAabbs[index].id} overlaps ${solidAabbs[otherIndex].id}.`
+        );
+      }
+    }
+  }
+
+  options.reservedBlockers?.forEach((blocker, blockerIndex) => {
+    solidAabbs.forEach((solid) => {
+      if (rectanglesOverlap(solid.bounds, blocker, tolerance)) {
+        errors.push(`${solid.id} overlaps reserved blocker ${blockerIndex}.`);
+      }
+    });
+  });
+
+  decorativeFootprints.forEach((decorative) => {
+    solidAabbs.forEach((solid) => {
+      if (!rectanglesOverlap(decorative.bounds, solid.bounds, tolerance))
+        return;
+      if (!decorative.allowedSolidOverlapIds.includes(solid.id)) {
+        errors.push(
+          `${decorative.id} decor overlaps ${solid.id} without an allow-list entry.`
+        );
+      }
+    });
+  });
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    solidAabbs,
+    decorativeFootprints,
+  };
+}
+
+export function createLowerFloorFurnishings({
+  definitions = DEFAULT_LOWER_FLOOR_FURNISHINGS,
+  material,
+}: LowerFloorFurnishingsOptions = {}): LowerFloorFurnishingsBuild {
+  const group = new Group();
+  group.name = 'LowerFloorFurnishings';
+  const sharedMaterial =
+    material ?? new MeshStandardMaterial({ color: 0x62748a });
+  const colliders = definitions
+    .filter((definition) => definition.solidFootprint)
+    .map(createColliderRecord);
+  const decorativeFootprints = definitions
+    .filter((definition) => definition.decorativeFootprint)
+    .map(createDecorativeFootprintRecord);
+
+  definitions.forEach((definition) => {
+    group.add(createFurnishingMesh(definition, sharedMaterial));
+  });
+
+  return { group, colliders, decorativeFootprints };
+}
+
+function createColliderRecord(
+  definition: LowerFloorFurnishingDefinition
+): LowerFloorFurnishingCollider {
+  const bounds = createAabbFromCenterSize(
+    definition.position,
+    definition.solidFootprint ?? { width: 0, depth: 0 },
+    definition.orientationRadians
+  );
+  return {
+    id: definition.id,
+    category: definition.category,
+    roomId: definition.roomId,
+    kind: definition.kind,
+    sourceId: `ground.furnishings.${definition.category}.${definition.id}.generated_collider`,
+    bounds,
+  };
+}
+
+function createDecorativeFootprintRecord(
+  definition: LowerFloorFurnishingDefinition
+): LowerFloorDecorativeFootprint {
+  return {
+    id: definition.id,
+    category: definition.category,
+    roomId: definition.roomId,
+    kind: definition.kind,
+    bounds: createAabbFromCenterSize(
+      definition.position,
+      definition.decorativeFootprint ?? { width: 0, depth: 0 },
+      definition.orientationRadians
+    ),
+    allowedSolidOverlapIds: definition.allowDecorativeOverlapWithSolidIds ?? [],
+  };
+}
+
+function createFurnishingMesh(
+  definition: LowerFloorFurnishingDefinition,
+  sharedMaterial: Material
+): Group {
+  const group = new Group();
+  group.name = `Furnishing:${definition.id}`;
+  group.position.set(
+    definition.position.x,
+    definition.position.y ?? 0,
+    definition.position.z
+  );
+  group.rotation.y = definition.orientationRadians;
+
+  const footprint = definition.solidFootprint ??
+    definition.decorativeFootprint ?? { width: 1, depth: 1 };
+  const height =
+    definition.visual?.height ?? (definition.solidFootprint ? 0.8 : 0.04);
+  const material = definition.visual?.color
+    ? new MeshStandardMaterial({ color: definition.visual.color })
+    : sharedMaterial;
+  const shape =
+    definition.visual?.shape ??
+    (definition.decorativeFootprint ? 'flat' : 'box');
+  const mesh =
+    shape === 'cylinder'
+      ? new Mesh(
+          new CylinderGeometry(
+            footprint.width / 2,
+            footprint.width / 2,
+            height,
+            16
+          ),
+          material
+        )
+      : new Mesh(
+          new BoxGeometry(footprint.width, height, footprint.depth),
+          material
+        );
+  mesh.name = `Furnishing:${definition.id}:body`;
+  mesh.position.y = height / 2;
+  group.add(mesh);
+
+  if (definition.solidFootprint && shape === 'box') {
+    addTrimBoxes(
+      group,
+      footprint,
+      height,
+      definition.visual?.trimColor ?? 0x94a3b8
+    );
+  }
+
+  return group;
+}
+
+function addTrimBoxes(
+  group: Group,
+  footprint: LowerFloorFurnishingFootprint,
+  height: number,
+  color: number
+): void {
+  const material = new MeshStandardMaterial({ color });
+  const trimHeight = Math.min(0.08, height / 4);
+  const trimDepth = 0.08;
+  const trimGeometry = new BoxGeometry(
+    footprint.width + trimDepth,
+    trimHeight,
+    trimDepth
+  );
+  [-1, 1].forEach((direction) => {
+    const trim = new Mesh(trimGeometry, material);
+    trim.name = `${group.name}:trim:${direction}`;
+    trim.position.set(
+      0,
+      height + trimHeight / 2,
+      (direction * footprint.depth) / 2
+    );
+    group.add(trim);
+  });
+}
+
+function hasPositiveArea(bounds: RectCollider): boolean {
+  return bounds.maxX > bounds.minX && bounds.maxZ > bounds.minZ;
+}
+
+function containsRect(
+  container: RectCollider,
+  candidate: RectCollider,
+  tolerance: number
+): boolean {
+  return (
+    candidate.minX >= container.minX - tolerance &&
+    candidate.maxX <= container.maxX + tolerance &&
+    candidate.minZ >= container.minZ - tolerance &&
+    candidate.maxZ <= container.maxZ + tolerance
+  );
+}

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOWER_FLOOR_ROOM_BOUNDS,
+  createAabbFromCenterSize,
+  createLowerFloorFurnishings,
+  rectanglesOverlap,
+  validateLowerFloorFurnishingPlan,
+  type LowerFloorFurnishingDefinition,
+} from '../scene/structures/lowerFloorFurnishings';
+import type { RectCollider } from '../systems/collision';
+
+const RESERVED_BLOCKERS: readonly RectCollider[] = [
+  { minX: -22, maxX: -14, minZ: -9.2, maxZ: -6.8 },
+  { minX: 11, maxX: 19, minZ: -9.2, maxZ: -6.8 },
+  { minX: -5.2, maxX: -2.8, minZ: 0, maxZ: 8 },
+  { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
+  { minX: 11, maxX: 19, minZ: 14.8, maxZ: 17.2 },
+  { minX: -32.0, maxX: -30.9, minZ: -23.2, maxZ: -16.8 },
+  { minX: -24.74, maxX: -19.94, minZ: -24.61, maxZ: -20.61 },
+  { minX: -12.34, maxX: -5.14, minZ: -26.12, maxZ: -19.72 },
+  { minX: -24.0, maxX: -19.2, minZ: -0.77, maxZ: 4.03 },
+  { minX: 26.4, maxX: 31.2, minZ: -24.4, maxZ: -21.2 },
+  { minX: 8.4, maxX: 16.4, minZ: -27.0, maxZ: -9.4 },
+  { minX: 15.8, maxX: 20.4, minZ: -1.1, maxZ: 3.8 },
+  { minX: 0.0, maxX: 6.4, minZ: -2.2, maxZ: 4.6 },
+  { minX: -18.5, maxX: -10.0, minZ: 18.0, maxZ: 24.2 },
+  { minX: 10.0, maxX: 18.2, minZ: 22.4, maxZ: 30.4 },
+];
+
+const VALID_FOUNDATION_PLAN: readonly LowerFloorFurnishingDefinition[] = [
+  {
+    id: 'living-sectional-anchor',
+    category: 'living-room-seating',
+    roomId: 'livingRoom',
+    position: { x: -2, z: -22 },
+    orientationRadians: 0,
+    solidFootprint: { width: 4, depth: 2 },
+    decorativeFootprint: { width: 7, depth: 4 },
+    allowDecorativeOverlapWithSolidIds: ['living-sectional-anchor'],
+    kind: 'couch-foundation',
+  },
+  {
+    id: 'kitchenette-counter-anchor',
+    category: 'kitchenette',
+    roomId: 'kitchen',
+    position: { x: -27, z: 9 },
+    orientationRadians: 0,
+    solidFootprint: { width: 4, depth: 2 },
+    kind: 'counter-foundation',
+  },
+  {
+    id: 'studio-shelf-anchor',
+    category: 'storage',
+    roomId: 'studio',
+    position: { x: 26, z: 7 },
+    orientationRadians: Math.PI / 2,
+    solidFootprint: { width: 4, depth: 1.2 },
+    kind: 'shelf-foundation',
+  },
+  {
+    id: 'studio-bed-anchor',
+    category: 'sleeping-nook',
+    roomId: 'studio',
+    position: { x: 25, z: 13 },
+    orientationRadians: 0,
+    solidFootprint: { width: 4, depth: 3 },
+    kind: 'bed-foundation',
+  },
+  {
+    id: 'kitchen-planter-anchor',
+    category: 'plants-lighting-decor',
+    roomId: 'kitchen',
+    position: { x: -29, z: -5 },
+    orientationRadians: 0,
+    solidFootprint: { width: 1, depth: 1 },
+    kind: 'plant-pot-foundation',
+    visual: { shape: 'cylinder' },
+  },
+  {
+    id: 'backyard-bistro-anchor',
+    category: 'backyard',
+    roomId: 'backyard',
+    position: { x: 25, z: 20 },
+    orientationRadians: Math.PI / 4,
+    solidFootprint: { width: 3, depth: 3 },
+    kind: 'patio-table-foundation',
+  },
+];
+
+describe('lower-floor furnishing foundations', () => {
+  it('renders an empty/default plan without errors', () => {
+    const build = createLowerFloorFurnishings();
+
+    expect(build.group.name).toBe('LowerFloorFurnishings');
+    expect(build.colliders).toEqual([]);
+    expect(build.decorativeFootprints).toEqual([]);
+  });
+
+  it('creates positive-area AABBs for every solid furnishing', () => {
+    const build = createLowerFloorFurnishings({
+      definitions: VALID_FOUNDATION_PLAN,
+    });
+
+    expect(build.colliders).toHaveLength(
+      VALID_FOUNDATION_PLAN.filter((definition) => definition.solidFootprint)
+        .length
+    );
+    build.colliders.forEach((collider) => {
+      expect(collider.bounds.maxX).toBeGreaterThan(collider.bounds.minX);
+      expect(collider.bounds.maxZ).toBeGreaterThan(collider.bounds.minZ);
+      expect(collider.sourceId).toBe(
+        `ground.furnishings.${collider.category}.${collider.id}.generated_collider`
+      );
+    });
+  });
+
+  it('keeps every solid AABB inside its declared room and clear of blockers', () => {
+    const result = validateLowerFloorFurnishingPlan(VALID_FOUNDATION_PLAN, {
+      roomBounds: LOWER_FLOOR_ROOM_BOUNDS,
+      reservedBlockers: RESERVED_BLOCKERS,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('detects solid-to-solid and reserved-blocker overlaps', () => {
+    const result = validateLowerFloorFurnishingPlan(
+      [
+        ...VALID_FOUNDATION_PLAN,
+        {
+          id: 'bad-overlap',
+          category: 'living-room-seating',
+          roomId: 'livingRoom',
+          position: { x: -2, z: -22 },
+          orientationRadians: 0,
+          solidFootprint: { width: 2, depth: 2 },
+          kind: 'bad-chair',
+        },
+        {
+          id: 'bad-blocker',
+          category: 'backyard',
+          roomId: 'backyard',
+          position: { x: -14, z: 20 },
+          orientationRadians: 0,
+          solidFootprint: { width: 2, depth: 2 },
+          kind: 'bad-grill',
+        },
+      ],
+      {
+        roomBounds: LOWER_FLOOR_ROOM_BOUNDS,
+        reservedBlockers: RESERVED_BLOCKERS,
+      }
+    );
+
+    expect(result.errors).toContain(
+      'living-sectional-anchor overlaps bad-overlap.'
+    );
+    expect(result.errors).toContain(
+      'bad-blocker overlaps reserved blocker 13.'
+    );
+  });
+
+  it('requires decorative overlaps with solids to be explicitly allowed', () => {
+    const result = validateLowerFloorFurnishingPlan(
+      [
+        {
+          id: 'chair',
+          category: 'living-room-seating',
+          roomId: 'livingRoom',
+          position: { x: 0, z: -18 },
+          orientationRadians: 0,
+          solidFootprint: { width: 2, depth: 2 },
+          kind: 'chair',
+        },
+        {
+          id: 'rug',
+          category: 'plants-lighting-decor',
+          roomId: 'livingRoom',
+          position: { x: 0, z: -18 },
+          orientationRadians: 0,
+          decorativeFootprint: { width: 4, depth: 4 },
+          kind: 'rug',
+        },
+      ],
+      { roomBounds: LOWER_FLOOR_ROOM_BOUNDS }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      'rug decor overlaps chair without an allow-list entry.'
+    );
+  });
+
+  it('keeps decorative footprints out of movement colliders', () => {
+    const build = createLowerFloorFurnishings({
+      definitions: VALID_FOUNDATION_PLAN,
+    });
+
+    expect(build.decorativeFootprints).toHaveLength(1);
+    const decorativeBounds = build.decorativeFootprints[0].bounds;
+
+    expect(build.colliders.map((collider) => collider.bounds)).not.toContain(
+      decorativeBounds
+    );
+  });
+
+  it('detects rotated rectangle intersections with tolerance support', () => {
+    const first = createAabbFromCenterSize(
+      { x: 0, z: 0 },
+      { width: 2, depth: 4 },
+      Math.PI / 4
+    );
+    const second = createAabbFromCenterSize(
+      { x: 1, z: 1 },
+      { width: 2, depth: 2 }
+    );
+
+    expect(rectanglesOverlap(first, second)).toBe(true);
+    expect(
+      rectanglesOverlap(first, { minX: 4, maxX: 5, minZ: 4, maxZ: 5 })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a typed foundation for placing lower-floor furnishings and decor so future passes can add furniture without moving existing POIs, walls, stairs, or interaction behavior.

### Description
- Add `src/scene/structures/lowerFloorFurnishings.ts` which defines furnishing types, room/category enums, footprint records, AABB helpers (`createAabbFromCenterSize`), overlap utilities (`rectanglesOverlap`), plan validation (`validateLowerFloorFurnishingPlan`), and a builder API `createLowerFloorFurnishings` that returns `{ group, colliders, decorativeFootprints }`.
- Implement simple low-poly rendering primitives (box/cylinder/flat) and lightweight visual trim helpers so each furnishing is added as a `Group` named `Furnishing:<id>` and the overall container is `LowerFloorFurnishings`.
- Produce blocking `LowerFloorFurnishingCollider` records with `sourceId` values like ``ground.furnishings.<category>.<id>.generated_collider`` and wire generated colliders into the runtime pipeline from `src/main.ts` by pushing bounds into `groundColliders` and recording metadata in `colliderSourceMetadata` with `sourceType: 'generatedCollider'`, `purpose: 'lower-floor-furnishing'`, and `category`/`role`.
- Add `src/tests/lowerFloorFurnishings.test.ts` (Vitest) to cover empty build, positive-area AABBs, room containment, inter-solid and reserved-blocker overlap detection, decorative overlap allow-list semantics, and rotated-AABB/tolerance checks.

### Testing
- Ran formatting: `npm run format:write` (succeeded).
- Ran lint: `npm run lint` (succeeded; initial import-order warning was fixed as part of the change).
- Ran focused unit tests: `npm run test:ci -- lowerFloorFurnishings` and full Vitest for that file (all tests passed).
- Built production bundle: `npm run build` (succeeded; Vite warnings about large chunks are unrelated to this change).
- Ran type-check: `npm run typecheck` (noted repository-wide TypeScript errors unrelated to this change; the new furnishing module and the import were type-correct and did not introduce new furnishing-specific type errors).

Notes: the change is intentionally additive and non-destructive — it renders an empty/default plan without errors, exposes decorative footprints for validation (these are not added to movement colliders), and wires generated furnishing colliders into `groundColliders` with source metadata for downstream audits and debug visualization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40aadb8f88832f98b9b9f3eaa8da94)