### PR TITLE
🛋️ : – add lower-floor furnishing foundation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -294,6 +294,10 @@ import {
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
 import {
+  createLowerFloorFurnishings,
+  type LowerFloorFurnishingCollider,
+} from './scene/structures/lowerFloorFurnishings';
+import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
 } from './scene/structures/mediaWall';
@@ -2273,6 +2277,22 @@ function initializeImmersiveScene(
     playerRadius: PLAYER_RADIUS,
     guardThickness: stairGuardThickness,
   }).forEach(registerSafetyCollider);
+
+  const lowerFloorFurnishings = createLowerFloorFurnishings();
+  groundStructureGroup.add(lowerFloorFurnishings.group);
+  lowerFloorFurnishings.colliders.forEach(
+    (collider: LowerFloorFurnishingCollider) => {
+      groundColliders.push(collider);
+      namedColliderDebugNames.set(collider, collider.debugName);
+      colliderSourceMetadata.set(collider, {
+        sourceId: assertLevelSourceId(collider.sourceId),
+        sourceType: 'generatedCollider',
+        purpose: 'lower-floor-furnishing',
+        role: collider.category,
+        debugId: collider.debugName,
+      });
+    }
+  );
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -293,10 +293,7 @@ import {
   createJobbotTerminal,
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
-import {
-  createLowerFloorFurnishings,
-  type LowerFloorFurnishingCollider,
-} from './scene/structures/lowerFloorFurnishings';
+import { createLowerFloorFurnishings } from './scene/structures/lowerFloorFurnishings';
 import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
@@ -2280,19 +2277,16 @@ function initializeImmersiveScene(
 
   const lowerFloorFurnishings = createLowerFloorFurnishings();
   groundStructureGroup.add(lowerFloorFurnishings.group);
-  lowerFloorFurnishings.colliders.forEach(
-    (collider: LowerFloorFurnishingCollider) => {
-      groundColliders.push(collider);
-      namedColliderDebugNames.set(collider, collider.debugName);
-      colliderSourceMetadata.set(collider, {
-        sourceId: assertLevelSourceId(collider.sourceId),
-        sourceType: 'generatedCollider',
-        purpose: 'lower-floor-furnishing',
-        role: collider.category,
-        debugId: collider.debugName,
-      });
-    }
-  );
+  lowerFloorFurnishings.colliders.forEach((collider) => {
+    groundColliders.push(collider);
+    namedColliderDebugNames.set(collider, collider.debugName);
+    colliderSourceMetadata.set(collider, {
+      sourceId: assertLevelSourceId(collider.sourceId),
+      sourceType: 'generatedCollider',
+      purpose: 'lower-floor-furnishing',
+      role: collider.category,
+    });
+  });
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -436,6 +436,16 @@
       "metadataFingerprint": "73cc34b6ec09ede01419bf028fe4d2a8e6b227520c61098398daaa25ffe91566"
     },
     {
+      "id": "decor:lower-floor-furnishings",
+      "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
+      "proxyFiles": [],
+      "syncRevision": 1,
+      "syncNote": "Lower-floor furnishing geometry is currently an empty authoring foundation; future populated furniture plans will need proxy coverage.",
+      "sourceFingerprint": "032b014637ad0bb63901a5c2eff5229e4c084efafd3ef8e5f908c5b5d4a801e0",
+      "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "metadataFingerprint": "ffd3f7fb4847bf16a8d1931ff1edc7e8e8b98a1b94596854178e5af3946fd6ac"
+    },
+    {
       "id": "environment:backyard",
       "sourceFiles": ["src/scene/environments/backyard.ts"],
       "proxyFiles": [],

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -80,6 +80,14 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     syncNote: 'Ceiling panel fixtures need simplified caps in the tabletop.',
   },
   {
+    id: 'decor:lower-floor-furnishings',
+    kind: 'excluded',
+    sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
+    syncRevision: 1,
+    reason:
+      'Lower-floor furnishing geometry is currently an empty authoring foundation; future populated furniture plans will need proxy coverage.',
+  },
+  {
     id: 'avatar:overworld-player',
     kind: 'excluded',
     sourceFiles: [

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -8,6 +8,7 @@ import {
 } from 'three';
 
 import type { RectCollider } from '../collision';
+import { isLevelSourceId } from '../level/sourceIds';
 
 export type LowerFloorFurnishingCategory =
   | 'living-room-seating'
@@ -136,6 +137,12 @@ export function validateLowerFloorFurnishingPlan(
   const roomBounds = { ...LOWER_FLOOR_ROOM_BOUNDS, ...options.roomBounds };
   const blockers = options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS;
   const tolerance = options.tolerance ?? 0.001;
+  definitions.forEach((definition) => {
+    if (!isLevelSourceId(definition.id)) {
+      throw new Error(`${definition.id} is not a valid furnishing ID.`);
+    }
+  });
+
   const solids = definitions.flatMap((definition) => {
     if (!definition.solidFootprint) return [];
     const bounds = createRotatedAabb(definition, definition.solidFootprint);
@@ -171,13 +178,22 @@ export function validateLowerFloorFurnishingPlan(
       definition,
       definition.decorativeFootprint
     );
+    if (!hasPositiveArea(bounds)) {
+      throw new Error(`${definition.id} has an empty decorative footprint.`);
+    }
     if (!containsBounds(roomBounds[definition.roomId], bounds, tolerance)) {
       throw new Error(
         `${definition.id} decorative footprint is outside ${definition.roomId}.`
       );
     }
-    if (definition.visual?.allowDecorativeOverlapWithSolid) return;
     solids.forEach((solid) => {
+      const isAssociatedSolid = solid.definition.id === definition.id;
+      if (
+        isAssociatedSolid &&
+        definition.visual?.allowDecorativeOverlapWithSolid
+      ) {
+        return;
+      }
       if (rectanglesOverlap(bounds, solid.bounds, tolerance)) {
         throw new Error(
           `${definition.id} decorative footprint overlaps ${solid.definition.id}.`

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -1,0 +1,333 @@
+import {
+  BoxGeometry,
+  CylinderGeometry,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  type ColorRepresentation,
+} from 'three';
+
+import type { RectCollider } from '../collision';
+
+export type LowerFloorFurnishingCategory =
+  | 'living-room-seating'
+  | 'kitchenette'
+  | 'storage'
+  | 'sleeping-nook'
+  | 'plants-lighting-decor'
+  | 'backyard';
+
+export type LowerFloorRoomId = 'livingRoom' | 'kitchen' | 'studio' | 'backyard';
+
+export interface LowerFloorFurnishingFootprint {
+  width: number;
+  depth: number;
+}
+
+export interface LowerFloorFurnishingDefinition {
+  id: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorRoomId;
+  position: { x: number; y?: number; z: number };
+  orientationRadians: number;
+  solidFootprint?: LowerFloorFurnishingFootprint;
+  decorativeFootprint?: LowerFloorFurnishingFootprint;
+  kind: string;
+  visual?: {
+    color?: ColorRepresentation;
+    accentColor?: ColorRepresentation;
+    height?: number;
+    decorativeHeight?: number;
+    allowDecorativeOverlapWithSolid?: boolean;
+  };
+}
+
+export interface DecorativeFootprintRecord {
+  id: string;
+  furnishingId: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorRoomId;
+  bounds: RectCollider;
+  allowSolidOverlap: boolean;
+}
+
+export interface LowerFloorFurnishingCollider extends RectCollider {
+  furnishingId: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorRoomId;
+  sourceId: string;
+  debugName: string;
+}
+
+export interface LowerFloorFurnishingValidationOptions {
+  roomBounds?: Partial<Record<LowerFloorRoomId, RectCollider>>;
+  reservedBlockers?: readonly RectCollider[];
+  tolerance?: number;
+}
+
+export interface LowerFloorFurnishingsCreateOptions
+  extends LowerFloorFurnishingValidationOptions {
+  definitions?: readonly LowerFloorFurnishingDefinition[];
+}
+
+export interface LowerFloorFurnishingsBuild {
+  group: Group;
+  colliders: LowerFloorFurnishingCollider[];
+  decorativeFootprints: DecorativeFootprintRecord[];
+}
+
+export const LOWER_FLOOR_ROOM_BOUNDS: Record<LowerFloorRoomId, RectCollider> = {
+  livingRoom: { minX: -32, maxX: 32, minZ: -32, maxZ: -8 },
+  kitchen: { minX: -32, maxX: -4, minZ: -8, maxZ: 16 },
+  studio: { minX: -4, maxX: 32, minZ: -8, maxZ: 16 },
+  backyard: { minX: -32, maxX: 32, minZ: 16, maxZ: 32 },
+};
+
+export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
+  { minX: -22, maxX: -14, minZ: -9.2, maxZ: -6.8 },
+  { minX: 11, maxX: 19, minZ: -9.2, maxZ: -6.8 },
+  { minX: -5.2, maxX: -2.8, minZ: 0, maxZ: 8 },
+  { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
+  { minX: 11, maxX: 19, minZ: 14.8, maxZ: 17.2 },
+  { minX: -32.0, maxX: -30.9, minZ: -23.2, maxZ: -16.8 },
+  { minX: -24.74, maxX: -19.94, minZ: -24.61, maxZ: -20.61 },
+  { minX: -12.34, maxX: -5.14, minZ: -26.12, maxZ: -19.72 },
+  { minX: -24.0, maxX: -19.2, minZ: -0.77, maxZ: 4.03 },
+  { minX: 26.4, maxX: 31.2, minZ: -24.4, maxZ: -21.2 },
+  { minX: 8.4, maxX: 16.4, minZ: -27.0, maxZ: -9.4 },
+  { minX: 15.8, maxX: 20.4, minZ: -1.1, maxZ: 3.8 },
+  { minX: 0.0, maxX: 6.4, minZ: -2.2, maxZ: 4.6 },
+  { minX: -18.5, maxX: -10.0, minZ: 18.0, maxZ: 24.2 },
+  { minX: 10.0, maxX: 18.2, minZ: 22.4, maxZ: 30.4 },
+];
+
+export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] =
+  [];
+
+export function createAabbFromCenterSize(
+  center: { x: number; z: number },
+  size: LowerFloorFurnishingFootprint
+): RectCollider {
+  return {
+    minX: center.x - size.width / 2,
+    maxX: center.x + size.width / 2,
+    minZ: center.z - size.depth / 2,
+    maxZ: center.z + size.depth / 2,
+  };
+}
+
+export function rectanglesOverlap(
+  a: RectCollider,
+  b: RectCollider,
+  tolerance = 0
+): boolean {
+  return !(
+    a.maxX <= b.minX + tolerance ||
+    a.minX >= b.maxX - tolerance ||
+    a.maxZ <= b.minZ + tolerance ||
+    a.minZ >= b.maxZ - tolerance
+  );
+}
+
+export function validateLowerFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingValidationOptions = {}
+): void {
+  const roomBounds = { ...LOWER_FLOOR_ROOM_BOUNDS, ...options.roomBounds };
+  const blockers = options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS;
+  const tolerance = options.tolerance ?? 0.001;
+  const solids = definitions.flatMap((definition) => {
+    if (!definition.solidFootprint) return [];
+    const bounds = createRotatedAabb(definition, definition.solidFootprint);
+    const room = roomBounds[definition.roomId];
+    if (!hasPositiveArea(bounds))
+      throw new Error(`${definition.id} has an empty solid footprint.`);
+    if (!containsBounds(room, bounds, tolerance)) {
+      throw new Error(
+        `${definition.id} solid footprint is outside ${definition.roomId}.`
+      );
+    }
+    blockers.forEach((blocker, index) => {
+      if (rectanglesOverlap(bounds, blocker, tolerance)) {
+        throw new Error(`${definition.id} overlaps reserved blocker ${index}.`);
+      }
+    });
+    return [{ definition, bounds }];
+  });
+
+  solids.forEach((solid, index) => {
+    solids.slice(index + 1).forEach((other) => {
+      if (rectanglesOverlap(solid.bounds, other.bounds, tolerance)) {
+        throw new Error(
+          `${solid.definition.id} overlaps ${other.definition.id}.`
+        );
+      }
+    });
+  });
+
+  definitions.forEach((definition) => {
+    if (!definition.decorativeFootprint) return;
+    const bounds = createRotatedAabb(
+      definition,
+      definition.decorativeFootprint
+    );
+    if (!containsBounds(roomBounds[definition.roomId], bounds, tolerance)) {
+      throw new Error(
+        `${definition.id} decorative footprint is outside ${definition.roomId}.`
+      );
+    }
+    if (definition.visual?.allowDecorativeOverlapWithSolid) return;
+    solids.forEach((solid) => {
+      if (rectanglesOverlap(bounds, solid.bounds, tolerance)) {
+        throw new Error(
+          `${definition.id} decorative footprint overlaps ${solid.definition.id}.`
+        );
+      }
+    });
+  });
+}
+
+export function createLowerFloorFurnishings(
+  options: LowerFloorFurnishingsCreateOptions = {}
+): LowerFloorFurnishingsBuild {
+  const definitions = options.definitions ?? DEFAULT_LOWER_FLOOR_FURNISHINGS;
+  validateLowerFloorFurnishingPlan(definitions, options);
+
+  const group = new Group();
+  group.name = 'LowerFloorFurnishings';
+  const colliders: LowerFloorFurnishingCollider[] = [];
+  const decorativeFootprints: DecorativeFootprintRecord[] = [];
+
+  definitions.forEach((definition) => {
+    const furnishing = new Group();
+    furnishing.name = `Furnishing:${definition.id}`;
+    furnishing.position.set(
+      definition.position.x,
+      definition.position.y ?? 0,
+      definition.position.z
+    );
+    furnishing.rotation.y = definition.orientationRadians;
+
+    if (definition.solidFootprint) {
+      furnishing.add(createSolidPrimitive(definition));
+      const bounds = createRotatedAabb(definition, definition.solidFootprint);
+      colliders.push({
+        ...bounds,
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        sourceId: `ground.furnishings.${definition.category}.${definition.id}.generated_collider`,
+        debugName: `LowerFloorFurnishingCollider:${definition.id}`,
+      });
+    }
+
+    if (definition.decorativeFootprint) {
+      furnishing.add(createDecorativePrimitive(definition));
+      decorativeFootprints.push({
+        id: `DecorativeFootprint:${definition.id}`,
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        bounds: createRotatedAabb(definition, definition.decorativeFootprint),
+        allowSolidOverlap:
+          definition.visual?.allowDecorativeOverlapWithSolid ?? false,
+      });
+    }
+
+    group.add(furnishing);
+  });
+
+  return { group, colliders, decorativeFootprints };
+}
+
+function createSolidPrimitive(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
+  const height = definition.visual?.height ?? 0.8;
+  const material = new MeshStandardMaterial({
+    color: definition.visual?.color ?? 0x6f7f92,
+    roughness: 0.7,
+  });
+  const accent = new MeshStandardMaterial({
+    color: definition.visual?.accentColor ?? 0x9aa8b7,
+    roughness: 0.64,
+  });
+  const group = new Group();
+  const body = new Mesh(
+    new BoxGeometry(footprint.width, height, footprint.depth),
+    material
+  );
+  body.name = `Furnishing:${definition.id}:body`;
+  body.position.y = height / 2;
+  group.add(body);
+  const trim = new Mesh(
+    new BoxGeometry(footprint.width + 0.08, 0.08, 0.08),
+    accent
+  );
+  trim.name = `Furnishing:${definition.id}:trim`;
+  trim.position.set(0, height + 0.04, -footprint.depth / 2);
+  group.add(trim);
+  if (definition.kind.includes('plant') || definition.kind.includes('lamp')) {
+    const base = new Mesh(
+      new CylinderGeometry(
+        footprint.width / 3,
+        footprint.width / 2.8,
+        height * 0.55,
+        16
+      ),
+      material
+    );
+    base.name = `Furnishing:${definition.id}:cylinderBase`;
+    base.position.y = height * 0.275;
+    group.add(base);
+  }
+  return group;
+}
+
+function createDecorativePrimitive(
+  definition: LowerFloorFurnishingDefinition
+): Mesh {
+  const footprint = definition.decorativeFootprint ?? { width: 1, depth: 1 };
+  const height = definition.visual?.decorativeHeight ?? 0.035;
+  const material = new MeshStandardMaterial({
+    color: definition.visual?.color ?? 0x56616f,
+    roughness: 0.85,
+  });
+  const mesh = new Mesh(
+    new BoxGeometry(footprint.width, height, footprint.depth),
+    material
+  );
+  mesh.name = `Furnishing:${definition.id}:decorativeFootprint`;
+  mesh.position.y = height / 2;
+  return mesh;
+}
+
+function createRotatedAabb(
+  definition: LowerFloorFurnishingDefinition,
+  footprint: LowerFloorFurnishingFootprint
+): RectCollider {
+  const cos = Math.abs(Math.cos(definition.orientationRadians));
+  const sin = Math.abs(Math.sin(definition.orientationRadians));
+  return createAabbFromCenterSize(definition.position, {
+    width: footprint.width * cos + footprint.depth * sin,
+    depth: footprint.width * sin + footprint.depth * cos,
+  });
+}
+
+function hasPositiveArea(bounds: RectCollider): boolean {
+  return bounds.maxX > bounds.minX && bounds.maxZ > bounds.minZ;
+}
+
+function containsBounds(
+  container: RectCollider,
+  bounds: RectCollider,
+  tolerance: number
+): boolean {
+  return (
+    bounds.minX >= container.minX - tolerance &&
+    bounds.maxX <= container.maxX + tolerance &&
+    bounds.minZ >= container.minZ - tolerance &&
+    bounds.maxZ <= container.maxZ + tolerance
+  );
+}

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOWER_FLOOR_RESERVED_BLOCKERS,
+  LOWER_FLOOR_ROOM_BOUNDS,
+  createLowerFloorFurnishings,
+  rectanglesOverlap,
+  validateLowerFloorFurnishingPlan,
+  type LowerFloorFurnishingDefinition,
+} from '../scene/structures/lowerFloorFurnishings';
+import type { RectCollider } from '../systems/collision';
+
+const validDefinitions: LowerFloorFurnishingDefinition[] = [
+  {
+    id: 'living-couch-foundation',
+    category: 'living-room-seating',
+    roomId: 'livingRoom',
+    position: { x: -2, z: -21 },
+    orientationRadians: 0,
+    solidFootprint: { width: 5.2, depth: 1.4 },
+    kind: 'couch',
+  },
+  {
+    id: 'kitchen-counter-foundation',
+    category: 'kitchenette',
+    roomId: 'kitchen',
+    position: { x: -9, z: 11 },
+    orientationRadians: Math.PI / 2,
+    solidFootprint: { width: 4, depth: 1.2 },
+    kind: 'counter',
+  },
+  {
+    id: 'studio-storage-foundation',
+    category: 'storage',
+    roomId: 'studio',
+    position: { x: 25, z: 11 },
+    orientationRadians: 0,
+    solidFootprint: { width: 3, depth: 1.1 },
+    kind: 'cabinet',
+  },
+  {
+    id: 'studio-bed-foundation',
+    category: 'sleeping-nook',
+    roomId: 'studio',
+    position: { x: 22, z: 6 },
+    orientationRadians: 0,
+    solidFootprint: { width: 4.5, depth: 2.2 },
+    decorativeFootprint: { width: 5.2, depth: 2.8 },
+    kind: 'bed-with-rug',
+    visual: { allowDecorativeOverlapWithSolid: true },
+  },
+  {
+    id: 'living-rug-foundation',
+    category: 'plants-lighting-decor',
+    roomId: 'livingRoom',
+    position: { x: -2, z: -15 },
+    orientationRadians: 0,
+    decorativeFootprint: { width: 6, depth: 3 },
+    kind: 'rug',
+  },
+  {
+    id: 'backyard-planter-foundation',
+    category: 'backyard',
+    roomId: 'backyard',
+    position: { x: 24, z: 21 },
+    orientationRadians: 0,
+    solidFootprint: { width: 2.2, depth: 2.2 },
+    kind: 'plant-pot',
+  },
+];
+
+describe('lower floor furnishings foundation', () => {
+  it('renders an empty default plan without colliders or decorative footprints', () => {
+    const build = createLowerFloorFurnishings();
+
+    expect(build.group.name).toBe('LowerFloorFurnishings');
+    expect(build.colliders).toEqual([]);
+    expect(build.decorativeFootprints).toEqual([]);
+  });
+
+  it('creates positive-area AABBs for every solid furnishing', () => {
+    const build = createLowerFloorFurnishings({
+      definitions: validDefinitions,
+    });
+    const solidCount = validDefinitions.filter(
+      (definition) => definition.solidFootprint
+    ).length;
+
+    expect(build.colliders).toHaveLength(solidCount);
+    build.colliders.forEach((collider) => {
+      expect(collider.maxX - collider.minX).toBeGreaterThan(0);
+      expect(collider.maxZ - collider.minZ).toBeGreaterThan(0);
+      expect(collider.sourceId).toBe(
+        `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
+      );
+    });
+  });
+
+  it('keeps every solid AABB within its declared room bounds', () => {
+    const { colliders } = createLowerFloorFurnishings({
+      definitions: validDefinitions,
+    });
+
+    colliders.forEach((collider) => {
+      const room = LOWER_FLOOR_ROOM_BOUNDS[collider.roomId];
+      expect(isContainedBy(room, collider)).toBe(true);
+    });
+  });
+
+  it('prevents solid AABBs from overlapping other solids or reserved blockers', () => {
+    const { colliders } = createLowerFloorFurnishings({
+      definitions: validDefinitions,
+    });
+
+    colliders.forEach((collider, index) => {
+      colliders.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+      });
+    });
+  });
+
+  it('allows decorative footprints to overlap associated solids only when explicit', () => {
+    const { decorativeFootprints, colliders } = createLowerFloorFurnishings({
+      definitions: validDefinitions,
+    });
+
+    const bedRug = decorativeFootprints.find(
+      (footprint) => footprint.furnishingId === 'studio-bed-foundation'
+    );
+    const bedCollider = colliders.find(
+      (collider) => collider.furnishingId === 'studio-bed-foundation'
+    );
+
+    expect(bedRug).toBeDefined();
+    expect(bedCollider).toBeDefined();
+    expect(bedRug?.allowSolidOverlap).toBe(true);
+    expect(rectanglesOverlap(bedRug!.bounds, bedCollider!)).toBe(true);
+
+    expect(() =>
+      validateLowerFloorFurnishingPlan([
+        {
+          ...validDefinitions[3],
+          id: 'studio-bed-rug-without-allowance',
+          visual: { allowDecorativeOverlapWithSolid: false },
+        },
+      ])
+    ).toThrow(/decorative footprint overlaps/);
+  });
+});
+
+function isContainedBy(container: RectCollider, bounds: RectCollider): boolean {
+  return (
+    bounds.minX >= container.minX &&
+    bounds.maxX <= container.maxX &&
+    bounds.minZ >= container.minZ &&
+    bounds.maxZ <= container.maxZ
+  );
+}

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -151,19 +151,20 @@ describe('lower floor furnishings foundation', () => {
 
     expect(() =>
       validateLowerFloorFurnishingPlan([
-        ...validDefinitions,
+        validDefinitions[3],
         {
-          id: 'studio-bedspread-over-unrelated-cabinet',
-          category: 'plants-lighting-decor',
+          id: 'studio-storage-under-bed-rug',
+          category: 'storage',
           roomId: 'studio',
-          position: { x: 25, z: 11 },
+          position: { x: 24.45, z: 6 },
           orientationRadians: 0,
-          decorativeFootprint: { width: 2, depth: 1 },
-          kind: 'bedspread-shadow',
-          visual: { allowDecorativeOverlapWithSolid: true },
+          solidFootprint: { width: 0.2, depth: 1.2 },
+          kind: 'cabinet',
         },
       ])
-    ).toThrow(/decorative footprint overlaps studio-storage-foundation/);
+    ).toThrow(
+      /studio-bed-foundation decorative footprint overlaps studio-storage-under-bed-rug/
+    );
   });
 
   it('validates authoring IDs and decorative footprint area before building', () => {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -148,6 +148,42 @@ describe('lower floor furnishings foundation', () => {
         },
       ])
     ).toThrow(/decorative footprint overlaps/);
+
+    expect(() =>
+      validateLowerFloorFurnishingPlan([
+        ...validDefinitions,
+        {
+          id: 'studio-bedspread-over-unrelated-cabinet',
+          category: 'plants-lighting-decor',
+          roomId: 'studio',
+          position: { x: 25, z: 11 },
+          orientationRadians: 0,
+          decorativeFootprint: { width: 2, depth: 1 },
+          kind: 'bedspread-shadow',
+          visual: { allowDecorativeOverlapWithSolid: true },
+        },
+      ])
+    ).toThrow(/decorative footprint overlaps studio-storage-foundation/);
+  });
+
+  it('validates authoring IDs and decorative footprint area before building', () => {
+    expect(() =>
+      validateLowerFloorFurnishingPlan([
+        {
+          ...validDefinitions[0],
+          id: 'Invalid furnishing id',
+        },
+      ])
+    ).toThrow(/not a valid furnishing ID/);
+
+    expect(() =>
+      validateLowerFloorFurnishingPlan([
+        {
+          ...validDefinitions[4],
+          decorativeFootprint: { width: 0, depth: 3 },
+        },
+      ])
+    ).toThrow(/empty decorative footprint/);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prepare the ground-floor scene for later furniture and decor passes by introducing a validated, typed foundation for lower-floor furnishings while leaving existing POIs, rooms, walls, stairs, and interactions unchanged.
- Provide a safe authoring surface that emits blocking colliders and non-blocking decorative footprints so future visual/content passes can add pieces without breaking navigation or reachability policies.

### Description
- Add `src/scene/structures/lowerFloorFurnishings.ts` which defines typed furnishing records, room categories, reserved blockers, AABB helpers (`createAabbFromCenterSize`), overlap helpers (`rectanglesOverlap`), plan validation (`validateLowerFloorFurnishingPlan`), and a builder `createLowerFloorFurnishings` that returns `{ group, colliders, decorativeFootprints }` and low-poly Three.js primitives.
- Implement rendering helpers (box body + trim, cylinder bases for plants/lamps, thin decorative planes) and predictable naming (`LowerFloorFurnishings`, `Furnishing:<id>`) and collider source ids like `ground.furnishings.<category>.<id>.generated_collider`.
- Wire a default empty build into `src/main.ts` immediately after ground stair/safety colliders are registered, pushing generated blocking colliders into `groundColliders` and registering entries in `colliderSourceMetadata` with `sourceType: 'generatedCollider'` and `purpose: 'lower-floor-furnishing'`.
- Add `src/tests/lowerFloorFurnishings.test.ts` with Vitest coverage for empty/default rendering, positive-area solid AABBs, room containment, no solid/solid or solid/reserved-blocker overlaps, and explicit decorative-overlap allowance behavior.

### Testing
- Formatting and lint: ran `npm run format:write` and `npm run lint` and both completed successfully.
- Unit tests: `npm run test:ci -- lowerFloorFurnishings` passed (1 file, 5 tests), and the repository-wide `npm run test:ci` also completed successfully (all tests green during the run recorded here).
- Typecheck: `npm run typecheck` was executed but failed due to existing repository-wide TypeScript errors unrelated to this change (the failures pre-existed in unrelated modules and tests).
- Build/docs/smoke: `npm run build`, `npm run docs:check`, and `npm run smoke` succeeded; `docs:check` produced external link reachability warnings from the link checker but no blocking failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40aae74f3c832f8f47546becd3496b)