### PR TITLE
🛋️ : – Add lower-floor furnishings foundation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -293,6 +293,7 @@ import {
   createJobbotTerminal,
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
+import { createLowerFloorFurnishings } from './scene/structures/lowerFloorFurnishings';
 import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
@@ -2273,6 +2274,20 @@ function initializeImmersiveScene(
     playerRadius: PLAYER_RADIUS,
     guardThickness: stairGuardThickness,
   }).forEach(registerSafetyCollider);
+
+  const lowerFloorFurnishings = createLowerFloorFurnishings();
+  groundFloorGroup.add(lowerFloorFurnishings.group);
+  lowerFloorFurnishings.colliders.forEach((collider) => {
+    groundColliders.push(collider);
+    namedColliderDebugNames.set(collider, collider.name);
+    colliderSourceMetadata.set(collider, {
+      sourceId: assertLevelSourceId(collider.sourceId),
+      sourceType: 'generatedCollider',
+      purpose: collider.purpose,
+      role: collider.role,
+      debugId: collider.sourceId,
+    });
+  });
 
   const upperFloorGroup = new Group();
   upperFloorGroup.visible = false;

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -1,0 +1,354 @@
+import {
+  BoxGeometry,
+  CylinderGeometry,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  type Material,
+} from 'three';
+
+import type { RectCollider } from '../../systems/collision';
+
+export type LowerFloorFurnishingCategory =
+  | 'living-room-seating'
+  | 'kitchenette'
+  | 'storage'
+  | 'sleeping-nook'
+  | 'plants-lighting-decor'
+  | 'backyard';
+
+export type LowerFloorRoomId = 'livingRoom' | 'kitchen' | 'studio' | 'backyard';
+
+export interface LowerFloorFurnishingPosition {
+  x: number;
+  y?: number;
+  z: number;
+}
+
+export interface LowerFloorFurnishingFootprintSize {
+  width: number;
+  depth: number;
+}
+
+export interface LowerFloorFurnishingVisualDetail {
+  color?: number;
+  trimColor?: number;
+  height?: number;
+  trimHeight?: number;
+  shape?: 'box' | 'cylinder' | 'flat';
+  allowDecorativeOverlapWith?: readonly string[];
+}
+
+export interface LowerFloorFurnishingDefinition {
+  id: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorRoomId;
+  position: LowerFloorFurnishingPosition;
+  orientationRadians: number;
+  solidFootprint?: LowerFloorFurnishingFootprintSize;
+  decorativeFootprint?: LowerFloorFurnishingFootprintSize;
+  kind: string;
+  visual?: LowerFloorFurnishingVisualDetail;
+}
+
+export interface LowerFloorFurnishingDecorativeFootprint {
+  id: string;
+  furnishingId: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorRoomId;
+  kind: string;
+  bounds: RectCollider;
+  allowOverlapWith: readonly string[];
+}
+
+export type LowerFloorFurnishingCollider = RectCollider & {
+  furnishingId: string;
+  category: LowerFloorFurnishingCategory;
+  roomId: LowerFloorRoomId;
+  kind: string;
+  sourceId: string;
+  sourceType: 'generatedCollider';
+  purpose: 'lower-floor-furnishing';
+  role: LowerFloorFurnishingCategory;
+  name: string;
+};
+
+export interface LowerFloorFurnishingsBuild {
+  group: Group;
+  colliders: LowerFloorFurnishingCollider[];
+  decorativeFootprints: LowerFloorFurnishingDecorativeFootprint[];
+}
+
+export interface LowerFloorFurnishingValidationOptions {
+  roomBounds?: Readonly<Record<LowerFloorRoomId, RectCollider>>;
+  reservedBlockers?: readonly RectCollider[];
+  overlapTolerance?: number;
+}
+
+export interface LowerFloorFurnishingsOptions {
+  definitions?: readonly LowerFloorFurnishingDefinition[];
+  y?: number;
+  materials?: {
+    solid?: Material;
+    trim?: Material;
+    decorative?: Material;
+  };
+}
+
+export const LOWER_FLOOR_ROOM_BOUNDS: Readonly<
+  Record<LowerFloorRoomId, RectCollider>
+> = {
+  livingRoom: { minX: -32, maxX: 32, minZ: -32, maxZ: -8 },
+  kitchen: { minX: -32, maxX: -4, minZ: -8, maxZ: 16 },
+  studio: { minX: -4, maxX: 32, minZ: -8, maxZ: 16 },
+  backyard: { minX: -32, maxX: 32, minZ: 16, maxZ: 32 },
+};
+
+export const LOWER_FLOOR_FURNISHING_DEFINITIONS: readonly LowerFloorFurnishingDefinition[] =
+  [];
+
+export const createAabbFromCenterSize = (
+  center: Pick<LowerFloorFurnishingPosition, 'x' | 'z'>,
+  size: LowerFloorFurnishingFootprintSize
+): RectCollider => ({
+  minX: center.x - size.width / 2,
+  maxX: center.x + size.width / 2,
+  minZ: center.z - size.depth / 2,
+  maxZ: center.z + size.depth / 2,
+});
+
+export const rectanglesOverlap = (
+  a: RectCollider,
+  b: RectCollider,
+  tolerance = 0
+): boolean =>
+  a.minX < b.maxX - tolerance &&
+  a.maxX > b.minX + tolerance &&
+  a.minZ < b.maxZ - tolerance &&
+  a.maxZ > b.minZ + tolerance;
+
+export function validateLowerFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingValidationOptions = {}
+): string[] {
+  const roomBounds = options.roomBounds ?? LOWER_FLOOR_ROOM_BOUNDS;
+  const reservedBlockers = options.reservedBlockers ?? [];
+  const tolerance = options.overlapTolerance ?? 0;
+  const errors: string[] = [];
+  const solidRecords = definitions.flatMap((definition) => {
+    if (!definition.solidFootprint) {
+      return [];
+    }
+
+    const bounds = createAabbFromCenterSize(
+      definition.position,
+      definition.solidFootprint
+    );
+    return [{ definition, bounds }];
+  });
+
+  for (const { definition, bounds } of solidRecords) {
+    if (bounds.maxX <= bounds.minX || bounds.maxZ <= bounds.minZ) {
+      errors.push(
+        `Furnishing ${definition.id} has a non-positive solid footprint.`
+      );
+    }
+
+    const room = roomBounds[definition.roomId];
+    if (
+      bounds.minX < room.minX - tolerance ||
+      bounds.maxX > room.maxX + tolerance ||
+      bounds.minZ < room.minZ - tolerance ||
+      bounds.maxZ > room.maxZ + tolerance
+    ) {
+      errors.push(
+        `Furnishing ${definition.id} is outside declared room ${definition.roomId}.`
+      );
+    }
+  }
+
+  for (let index = 0; index < solidRecords.length; index += 1) {
+    const current = solidRecords[index];
+    for (
+      let otherIndex = index + 1;
+      otherIndex < solidRecords.length;
+      otherIndex += 1
+    ) {
+      const other = solidRecords[otherIndex];
+      if (rectanglesOverlap(current.bounds, other.bounds, tolerance)) {
+        errors.push(
+          `Furnishings ${current.definition.id} and ${other.definition.id} overlap.`
+        );
+      }
+    }
+  }
+
+  for (const { definition, bounds } of solidRecords) {
+    reservedBlockers.forEach((blocker, index) => {
+      if (rectanglesOverlap(bounds, blocker, tolerance)) {
+        errors.push(
+          `Furnishing ${definition.id} overlaps reserved blocker ${index}.`
+        );
+      }
+    });
+  }
+
+  for (const definition of definitions) {
+    if (!definition.decorativeFootprint) {
+      continue;
+    }
+
+    const decorativeBounds = createAabbFromCenterSize(
+      definition.position,
+      definition.decorativeFootprint
+    );
+    const allowed = new Set(
+      definition.visual?.allowDecorativeOverlapWith ?? []
+    );
+    solidRecords.forEach(({ definition: solid, bounds }) => {
+      if (solid.id === definition.id || allowed.has(solid.id)) {
+        return;
+      }
+
+      if (rectanglesOverlap(decorativeBounds, bounds, tolerance)) {
+        errors.push(
+          `Decorative footprint ${definition.id} overlaps solid furnishing ${solid.id}.`
+        );
+      }
+    });
+  }
+
+  return errors;
+}
+
+export function createLowerFloorFurnishings(
+  options: LowerFloorFurnishingsOptions = {}
+): LowerFloorFurnishingsBuild {
+  const definitions = options.definitions ?? LOWER_FLOOR_FURNISHING_DEFINITIONS;
+  const group = new Group();
+  group.name = 'LowerFloorFurnishings';
+  const colliders: LowerFloorFurnishingCollider[] = [];
+  const decorativeFootprints: LowerFloorFurnishingDecorativeFootprint[] = [];
+  const solidMaterial =
+    options.materials?.solid ??
+    new MeshStandardMaterial({ color: 0x5f6f89, roughness: 0.62 });
+  const trimMaterial =
+    options.materials?.trim ??
+    new MeshStandardMaterial({ color: 0x273244, roughness: 0.58 });
+  const decorativeMaterial =
+    options.materials?.decorative ??
+    new MeshStandardMaterial({ color: 0x46566f, roughness: 0.78 });
+
+  definitions.forEach((definition) => {
+    const furnishingGroup = new Group();
+    furnishingGroup.name = `Furnishing:${definition.id}`;
+    furnishingGroup.position.set(
+      definition.position.x,
+      definition.position.y ?? options.y ?? 0,
+      definition.position.z
+    );
+    furnishingGroup.rotation.y = definition.orientationRadians;
+
+    if (definition.solidFootprint) {
+      addPrimitiveFurnishingMesh(
+        furnishingGroup,
+        definition,
+        solidMaterial,
+        trimMaterial
+      );
+      const bounds = createAabbFromCenterSize(
+        definition.position,
+        definition.solidFootprint
+      );
+      colliders.push({
+        ...bounds,
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        kind: definition.kind,
+        sourceId: `ground.furnishings.${definition.category}.${definition.id}.generated_collider`,
+        sourceType: 'generatedCollider',
+        purpose: 'lower-floor-furnishing',
+        role: definition.category,
+        name: `LowerFloorFurnishingCollider:${definition.id}`,
+      });
+    }
+
+    if (definition.decorativeFootprint) {
+      addFlatDecorativeMesh(furnishingGroup, definition, decorativeMaterial);
+      decorativeFootprints.push({
+        id: `decorative:${definition.id}`,
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        kind: definition.kind,
+        bounds: createAabbFromCenterSize(
+          definition.position,
+          definition.decorativeFootprint
+        ),
+        allowOverlapWith: definition.visual?.allowDecorativeOverlapWith ?? [],
+      });
+    }
+
+    group.add(furnishingGroup);
+  });
+
+  return { group, colliders, decorativeFootprints };
+}
+
+function addPrimitiveFurnishingMesh(
+  group: Group,
+  definition: LowerFloorFurnishingDefinition,
+  material: Material,
+  trimMaterial: Material
+): void {
+  const footprint = definition.solidFootprint;
+  if (!footprint) return;
+
+  const height = definition.visual?.height ?? 1.1;
+  if (definition.visual?.shape === 'cylinder') {
+    const radius = Math.min(footprint.width, footprint.depth) / 2;
+    const mesh = new Mesh(
+      new CylinderGeometry(radius, radius * 0.86, height, 16),
+      material
+    );
+    mesh.name = `Furnishing:${definition.id}:cylinder`;
+    mesh.position.y = height / 2;
+    group.add(mesh);
+    return;
+  }
+
+  const mesh = new Mesh(
+    new BoxGeometry(footprint.width, height, footprint.depth),
+    material
+  );
+  mesh.name = `Furnishing:${definition.id}:body`;
+  mesh.position.y = height / 2;
+  group.add(mesh);
+
+  const trimHeight = definition.visual?.trimHeight ?? 0.08;
+  const trim = new Mesh(
+    new BoxGeometry(footprint.width + 0.08, trimHeight, 0.08),
+    trimMaterial
+  );
+  trim.name = `Furnishing:${definition.id}:front-trim`;
+  trim.position.set(0, height + trimHeight / 2, footprint.depth / 2 + 0.04);
+  group.add(trim);
+}
+
+function addFlatDecorativeMesh(
+  group: Group,
+  definition: LowerFloorFurnishingDefinition,
+  material: Material
+): void {
+  const footprint = definition.decorativeFootprint;
+  if (!footprint) return;
+
+  const mesh = new Mesh(
+    new BoxGeometry(footprint.width, 0.04, footprint.depth),
+    material
+  );
+  mesh.name = `Furnishing:${definition.id}:decorative-footprint`;
+  mesh.position.y = 0.02;
+  group.add(mesh);
+}

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOWER_FLOOR_FURNISHING_DEFINITIONS,
+  LOWER_FLOOR_ROOM_BOUNDS,
+  createAabbFromCenterSize,
+  createLowerFloorFurnishings,
+  rectanglesOverlap,
+  validateLowerFloorFurnishingPlan,
+  type LowerFloorFurnishingDefinition,
+} from '../scene/structures/lowerFloorFurnishings';
+import type { RectCollider } from '../systems/collision';
+
+const RESERVED_BLOCKERS: readonly RectCollider[] = [
+  { minX: -22, maxX: -14, minZ: -9.2, maxZ: -6.8 },
+  { minX: 11, maxX: 19, minZ: -9.2, maxZ: -6.8 },
+  { minX: -5.2, maxX: -2.8, minZ: 0, maxZ: 8 },
+  { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
+  { minX: 11, maxX: 19, minZ: 14.8, maxZ: 17.2 },
+  { minX: -32.0, maxX: -30.9, minZ: -23.2, maxZ: -16.8 },
+  { minX: -24.74, maxX: -19.94, minZ: -24.61, maxZ: -20.61 },
+  { minX: -12.34, maxX: -5.14, minZ: -26.12, maxZ: -19.72 },
+  { minX: -24.0, maxX: -19.2, minZ: -0.77, maxZ: 4.03 },
+  { minX: 26.4, maxX: 31.2, minZ: -24.4, maxZ: -21.2 },
+  { minX: 8.4, maxX: 16.4, minZ: -27.0, maxZ: -9.4 },
+  { minX: 15.8, maxX: 20.4, minZ: -1.1, maxZ: 3.8 },
+  { minX: 0.0, maxX: 6.4, minZ: -2.2, maxZ: 4.6 },
+  { minX: -18.5, maxX: -10.0, minZ: 18.0, maxZ: 24.2 },
+  { minX: 10.0, maxX: 18.2, minZ: 22.4, maxZ: 30.4 },
+];
+
+const SAMPLE_PLAN: readonly LowerFloorFurnishingDefinition[] = [
+  {
+    id: 'foundation-couch-placeholder',
+    category: 'living-room-seating',
+    roomId: 'livingRoom',
+    position: { x: -2, z: -28 },
+    orientationRadians: 0,
+    solidFootprint: { width: 4, depth: 2 },
+    kind: 'couch-placeholder',
+  },
+  {
+    id: 'foundation-rug-placeholder',
+    category: 'living-room-seating',
+    roomId: 'livingRoom',
+    position: { x: -2, z: -28 },
+    orientationRadians: 0,
+    decorativeFootprint: { width: 6, depth: 4 },
+    kind: 'rug-placeholder',
+    visual: { allowDecorativeOverlapWith: ['foundation-couch-placeholder'] },
+  },
+  {
+    id: 'foundation-pot-placeholder',
+    category: 'plants-lighting-decor',
+    roomId: 'kitchen',
+    position: { x: -29, z: 12 },
+    orientationRadians: 0,
+    solidFootprint: { width: 1, depth: 1 },
+    kind: 'plant-pot-placeholder',
+    visual: { shape: 'cylinder' },
+  },
+];
+
+describe('lower-floor furnishings foundation', () => {
+  it('renders the default empty plan without blocking or decorative records', () => {
+    const build = createLowerFloorFurnishings();
+
+    expect(LOWER_FLOOR_FURNISHING_DEFINITIONS).toHaveLength(0);
+    expect(build.group.name).toBe('LowerFloorFurnishings');
+    expect(build.colliders).toHaveLength(0);
+    expect(build.decorativeFootprints).toHaveLength(0);
+  });
+
+  it('creates positive-area AABBs for every solid furnishing', () => {
+    const build = createLowerFloorFurnishings({ definitions: SAMPLE_PLAN });
+
+    expect(build.colliders.length).toBeGreaterThan(0);
+    build.colliders.forEach((collider) => {
+      expect(collider.maxX - collider.minX).toBeGreaterThan(0);
+      expect(collider.maxZ - collider.minZ).toBeGreaterThan(0);
+      expect(collider.sourceId).toBe(
+        `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
+      );
+    });
+  });
+
+  it('keeps every solid AABB inside its declared lower-floor room', () => {
+    for (const definition of SAMPLE_PLAN) {
+      if (!definition.solidFootprint) continue;
+
+      const bounds = createAabbFromCenterSize(
+        definition.position,
+        definition.solidFootprint
+      );
+      const room = LOWER_FLOOR_ROOM_BOUNDS[definition.roomId];
+      expect(bounds.minX).toBeGreaterThanOrEqual(room.minX);
+      expect(bounds.maxX).toBeLessThanOrEqual(room.maxX);
+      expect(bounds.minZ).toBeGreaterThanOrEqual(room.minZ);
+      expect(bounds.maxZ).toBeLessThanOrEqual(room.maxZ);
+    }
+  });
+
+  it('prevents solid furnishings from overlapping each other', () => {
+    const solidBounds = SAMPLE_PLAN.filter(
+      (definition) => definition.solidFootprint
+    ).map((definition) => ({
+      id: definition.id,
+      bounds: createAabbFromCenterSize(
+        definition.position,
+        definition.solidFootprint!
+      ),
+    }));
+
+    for (let index = 0; index < solidBounds.length; index += 1) {
+      for (
+        let otherIndex = index + 1;
+        otherIndex < solidBounds.length;
+        otherIndex += 1
+      ) {
+        expect(
+          rectanglesOverlap(
+            solidBounds[index].bounds,
+            solidBounds[otherIndex].bounds
+          )
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('prevents solid furnishings from overlapping reserved blockers', () => {
+    const errors = validateLowerFloorFurnishingPlan(SAMPLE_PLAN, {
+      reservedBlockers: RESERVED_BLOCKERS,
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it('allows decorative footprints to overlap associated furniture only when explicit', () => {
+    expect(validateLowerFloorFurnishingPlan(SAMPLE_PLAN)).toEqual([]);
+
+    const disallowedPlan = SAMPLE_PLAN.map((definition) =>
+      definition.id === 'foundation-rug-placeholder'
+        ? { ...definition, visual: { allowDecorativeOverlapWith: [] } }
+        : definition
+    );
+
+    expect(validateLowerFloorFurnishingPlan(disallowedPlan)).toContain(
+      'Decorative footprint foundation-rug-placeholder overlaps solid furnishing foundation-couch-placeholder.'
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal, testable foundation for placing lower-floor furniture and decor (data model, validation, render helpers, and colliders) so subsequent furnishing passes can add items without moving existing POIs, rooms, walls, stairs, or interaction behavior.

### Description
- Add `src/scene/structures/lowerFloorFurnishings.ts` which defines furnishing types, room bounds, `createAabbFromCenterSize`, `rectanglesOverlap`, `validateLowerFloorFurnishingPlan`, and `createLowerFloorFurnishings` that returns a `group`, blocking `colliders`, and non-blocking `decorativeFootprints` while rendering low-poly box/cylinder/flat primitives with predictable names (e.g. `LowerFloorFurnishings`, `Furnishing:<id>`).
- Wire `createLowerFloorFurnishings()` into `src/main.ts` after ground stair safety colliders, pushing generated solid colliders into `groundColliders` and registering source metadata using the `ground.furnishings.<category>.<id>.generated_collider` pattern.
- Add focused tests in `src/tests/lowerFloorFurnishings.test.ts` that assert empty-plan rendering, positive-area AABBs, room containment, inter-furnishing non-overlap, reserved-blocker avoidance, and explicit decorative-overlap allowances.
- Respect project conventions (Three.js primitives, `MeshStandardMaterial`, `Group`, `RectCollider` AABBs) and do not reference external assets.

### Testing
- `npm run format:write` — passed.
- `npm run lint` — passed (import-order warning addressed in test file).
- `npm run typecheck` — failed due to unrelated, pre-existing TypeScript errors elsewhere in the repo and not caused by these additions.
- `npm run test:ci -- lowerFloorFurnishings` — passed (1 test file, 6 tests).
- `npm run test:ci` — passed (full suite: 181 files, 1407 tests passed).
- `npm run build` — passed.
- `npm run docs:check` — passed (link checker emitted external fetch warnings but completed successfully).
- `npm run smoke` — passed.
- `git diff --cached | ./scripts/scan-secrets.py` — passed (no high-risk secrets found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40aaefd32c832fb52c63c5a9768e1d)