### PR TITLE
Add kitchen kitchenette and dining furnishings

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 4,
-      "syncNote": "Living-room media seating orientation and layout were refined; tabletop proxy coverage can stay deferred until the full furnishing set lands.",
-      "sourceFingerprint": "c922d1e92740de3b10064c2055903f5c00dd50f8fb492212acd3e8e00020689e",
+      "syncRevision": 5,
+      "syncNote": "Kitchenette furnishings were added to the lower floor; tabletop proxy coverage can stay deferred until the full furnishing set lands.",
+      "sourceFingerprint": "568d973ed0cd47338744d1972b2c15915b0a2b140744f8c91f3984ec161f0f56",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "5dd6df783971b5c258d8ea20b294ba5521bd5ec3cb40d09046443673d7d7fbfa"
+      "metadataFingerprint": "fa3fa9326113ae3c48b49976ad052d065512c3fd580b182ba03bc0fe52cb5683"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 5,
-      "syncNote": "Kitchenette furnishings were added to the lower floor; tabletop proxy coverage can stay deferred until the full furnishing set lands.",
-      "sourceFingerprint": "568d973ed0cd47338744d1972b2c15915b0a2b140744f8c91f3984ec161f0f56",
+      "syncRevision": 6,
+      "syncNote": "Kitchenette collision and validation refinements do not add tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.",
+      "sourceFingerprint": "1723ff9c15b26bdec7751d8bb72e93e63beefaf90e8cedf4fe3c9d21e29ff227",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "fa3fa9326113ae3c48b49976ad052d065512c3fd580b182ba03bc0fe52cb5683"
+      "metadataFingerprint": "c85e4ba35bea9c5ed0ef1d7c0c1d8cd9dc095ade6b9d7c2ec27a809a592e614e"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 5,
+    syncRevision: 6,
     reason:
-      'Kitchenette furnishings were added to the lower floor; tabletop proxy coverage can stay deferred until the full furnishing set lands.',
+      'Kitchenette collision and validation refinements do not add tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 4,
+    syncRevision: 5,
     reason:
-      'Living-room media seating orientation and layout were refined; tabletop proxy coverage can stay deferred until the full furnishing set lands.',
+      'Kitchenette furnishings were added to the lower floor; tabletop proxy coverage can stay deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -194,10 +194,7 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         color: 0x687282,
         accentColor: 0xd8ccb8,
         height: 0.9,
-        allowSolidOverlapWithIds: [
-          'kitchen-sink-cabinet',
-          'kitchen-stove-cabinet',
-        ],
+        allowSolidOverlapWithIds: ['kitchen-stove-cabinet'],
       },
     },
     {
@@ -224,7 +221,6 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         color: 0x667382,
         accentColor: 0xd7dce0,
         height: 0.95,
-        allowSolidOverlapWithIds: ['kitchen-west-counter-run'],
       },
     },
     {

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -44,6 +44,7 @@ export interface LowerFloorFurnishingDefinition {
     decorativeHeight?: number;
     allowDecorativeOverlapWithSolid?: boolean;
     allowDecorativeOverlapWithAnySolid?: boolean;
+    allowSolidOverlapWithIds?: readonly string[];
   };
 }
 
@@ -179,6 +180,103 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'floor-lamp',
       visual: { color: 0x2b2b2f, accentColor: 0xffd48a, height: 1.75 },
     },
+
+    {
+      id: 'kitchen-west-counter-run',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -31.0, z: 3.8 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.25, depth: 9.2 },
+      solidBounds: { minX: -31.625, maxX: -30.375, minZ: -0.8, maxZ: 8.4 },
+      kind: 'kitchen-counter-run',
+      visual: {
+        color: 0x687282,
+        accentColor: 0xd8ccb8,
+        height: 0.9,
+        allowSolidOverlapWithIds: [
+          'kitchen-sink-cabinet',
+          'kitchen-stove-cabinet',
+        ],
+      },
+    },
+    {
+      id: 'kitchen-fridge',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -31.0, z: -5.6 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.35, depth: 1.5 },
+      solidBounds: { minX: -31.675, maxX: -30.325, minZ: -6.35, maxZ: -4.85 },
+      kind: 'kitchen-fridge',
+      visual: { color: 0xc7d0d6, accentColor: 0x35404a, height: 2.35 },
+    },
+    {
+      id: 'kitchen-sink-cabinet',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -31.0, z: -2.0 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.2, depth: 1.8 },
+      solidBounds: { minX: -31.6, maxX: -30.4, minZ: -2.9, maxZ: -1.1 },
+      kind: 'kitchen-sink-cabinet',
+      visual: { color: 0x667382, accentColor: 0xd7dce0, height: 0.95 },
+    },
+    {
+      id: 'kitchen-stove-cabinet',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -31.0, z: 7.0 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.2, depth: 1.6 },
+      solidBounds: { minX: -31.6, maxX: -30.4, minZ: 6.2, maxZ: 7.8 },
+      kind: 'kitchen-stove-cabinet',
+      visual: { color: 0x5e6672, accentColor: 0x1d232b, height: 0.95 },
+    },
+    {
+      id: 'kitchen-island',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -13.0, z: 10.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 1.6 },
+      solidBounds: { minX: -15.4, maxX: -10.6, minZ: 10.1, maxZ: 11.7 },
+      kind: 'kitchen-island',
+      visual: { color: 0x526171, accentColor: 0xd0bea2, height: 0.92 },
+    },
+    {
+      id: 'kitchen-bar-stool-west',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -15.9, z: 12.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -16.25, maxX: -15.55, minZ: 12.55, maxZ: 13.25 },
+      kind: 'kitchen-bar-stool',
+      visual: { color: 0x2f3740, accentColor: 0xc28d52, height: 0.86 },
+    },
+    {
+      id: 'kitchen-bar-stool-east',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -10.1, z: 12.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -10.45, maxX: -9.75, minZ: 12.55, maxZ: 13.25 },
+      kind: 'kitchen-bar-stool',
+      visual: { color: 0x2f3740, accentColor: 0xc28d52, height: 0.86 },
+    },
+    {
+      id: 'kitchen-trash-drawer',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -30.8, z: 10.7 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.0, depth: 1.2 },
+      solidBounds: { minX: -31.3, maxX: -30.3, minZ: 10.1, maxZ: 11.3 },
+      kind: 'kitchen-trash-drawer',
+      visual: { color: 0x586575, accentColor: 0x8fd0a6, height: 0.82 },
+    },
     {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
@@ -257,7 +355,19 @@ export function validateLowerFloorFurnishingPlan(
 
   solids.forEach((solid, index) => {
     solids.slice(index + 1).forEach((other) => {
-      if (rectanglesOverlap(solid.bounds, other.bounds, tolerance)) {
+      const solidAllowed =
+        solid.definition.visual?.allowSolidOverlapWithIds?.includes(
+          other.definition.id
+        );
+      const otherAllowed =
+        other.definition.visual?.allowSolidOverlapWithIds?.includes(
+          solid.definition.id
+        );
+      if (
+        !solidAllowed &&
+        !otherAllowed &&
+        rectanglesOverlap(solid.bounds, other.bounds, tolerance)
+      ) {
         throw new Error(
           `${solid.definition.id} overlaps ${other.definition.id}.`
         );
@@ -364,6 +474,8 @@ function createSolidPrimitive(
   if (definition.kind === 'side-table') return createSideTable(definition);
   if (definition.kind === 'lounge-chair') return createLoungeChair(definition);
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
+  if (definition.kind.startsWith('kitchen-'))
+    return createKitchenFurnishing(definition);
 
   const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
   const height = definition.visual?.height ?? 0.8;
@@ -568,6 +680,166 @@ function createFloorLamp(definition: LowerFloorFurnishingDefinition): Group {
   shade.name = `Furnishing:${definition.id}:shade`;
   shade.position.y = 1.44;
   group.add(shade);
+  return group;
+}
+
+function createKitchenFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
+  const isQuarterTurn =
+    Math.abs(Math.sin(definition.orientationRadians)) >
+    Math.abs(Math.cos(definition.orientationRadians));
+  const visualFootprint = isQuarterTurn
+    ? { width: footprint.depth, depth: footprint.width }
+    : footprint;
+  const height = definition.visual?.height ?? 0.9;
+  const cabinetMaterial = createMaterial(definition.visual?.color ?? 0x647181);
+  const counterMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xd8ccb8
+  );
+  const darkMaterial = createMaterial(0x202833);
+  const metalMaterial = createMaterial(0xc9d1d6, {
+    metalness: 0.25,
+    roughness: 0.38,
+  });
+  const group = new Group();
+
+  if (definition.kind === 'kitchen-fridge') {
+    addBox(
+      group,
+      'fridgeBody',
+      { width: visualFootprint.width, height, depth: visualFootprint.depth },
+      metalMaterial,
+      [0, height / 2, 0]
+    );
+    addBox(
+      group,
+      'fridgeHandle',
+      { width: 0.08, height: 1.25, depth: 0.08 },
+      darkMaterial,
+      [visualFootprint.width / 2 - 0.14, 1.2, -visualFootprint.depth / 2 - 0.01]
+    );
+    return group;
+  }
+
+  addBox(
+    group,
+    'cabinetBody',
+    { width: visualFootprint.width, height, depth: visualFootprint.depth },
+    cabinetMaterial,
+    [0, height / 2, 0]
+  );
+  addBox(
+    group,
+    'countertop',
+    {
+      width: visualFootprint.width + 0.06,
+      height: 0.12,
+      depth: visualFootprint.depth + 0.06,
+    },
+    counterMaterial,
+    [0, height + 0.06, 0]
+  );
+
+  if (definition.kind === 'kitchen-counter-run') {
+    addBox(
+      group,
+      'backsplash',
+      { width: visualFootprint.width, height: 0.55, depth: 0.08 },
+      counterMaterial,
+      [0, 1.25, visualFootprint.depth / 2 - 0.04]
+    );
+    [-3.2, -1.6, 0, 1.6, 3.2].forEach((x, index) => {
+      addBox(
+        group,
+        `cabinetPull${index}`,
+        { width: 0.42, height: 0.08, depth: 0.06 },
+        darkMaterial,
+        [x, 0.58, -visualFootprint.depth / 2 - 0.01]
+      );
+    });
+  } else if (definition.kind === 'kitchen-sink-cabinet') {
+    addBox(
+      group,
+      'sinkBasin',
+      { width: 0.08, height: 0.08, depth: 0.82 },
+      metalMaterial,
+      [-0.1, height + 0.14, 0]
+    );
+    addBox(
+      group,
+      'faucet',
+      { width: 0.08, height: 0.42, depth: 0.08 },
+      metalMaterial,
+      [0.08, height + 0.32, 0]
+    );
+  } else if (definition.kind === 'kitchen-stove-cabinet') {
+    [-0.26, 0.26].forEach((x, index) => {
+      [-0.32, 0.32].forEach((z, innerIndex) => {
+        addBox(
+          group,
+          `cooktop${index}-${innerIndex}`,
+          { width: 0.22, height: 0.035, depth: 0.22 },
+          darkMaterial,
+          [x, height + 0.135, z]
+        );
+      });
+    });
+    addBox(
+      group,
+      'ovenFace',
+      { width: 0.08, height: 0.48, depth: 0.95 },
+      darkMaterial,
+      [-visualFootprint.width / 2 - 0.01, 0.48, 0]
+    );
+    addBox(
+      group,
+      'hoodPanel',
+      { width: visualFootprint.width, height: 0.16, depth: 0.28 },
+      metalMaterial,
+      [0, 1.55, visualFootprint.depth / 2 - 0.14]
+    );
+  } else if (definition.kind === 'kitchen-island') {
+    [-1.5, 0, 1.5].forEach((x, index) => {
+      addBox(
+        group,
+        `islandDrawer${index}`,
+        { width: 0.72, height: 0.08, depth: 0.06 },
+        darkMaterial,
+        [x, 0.62, footprint.depth / 2 + 0.01]
+      );
+    });
+  } else if (definition.kind === 'kitchen-bar-stool') {
+    group.clear();
+    const seat = new Mesh(
+      new CylinderGeometry(0.32, 0.32, 0.12, 20),
+      counterMaterial
+    );
+    seat.name = `Furnishing:${definition.id}:roundSeat`;
+    seat.position.y = height;
+    group.add(seat);
+    [-0.2, 0.2].forEach((x, xIndex) => {
+      [-0.2, 0.2].forEach((z, zIndex) => {
+        addBox(
+          group,
+          `stoolLeg${xIndex}-${zIndex}`,
+          { width: 0.06, height: height, depth: 0.06 },
+          darkMaterial,
+          [x, height / 2, z]
+        );
+      });
+    });
+  } else if (definition.kind === 'kitchen-trash-drawer') {
+    addBox(
+      group,
+      'recyclingPull',
+      { width: 0.08, height: 0.08, depth: 0.55 },
+      counterMaterial,
+      [-visualFootprint.width / 2 - 0.01, 0.5, 0]
+    );
+  }
+
   return group;
 }
 

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -220,7 +220,12 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       solidFootprint: { width: 1.2, depth: 1.8 },
       solidBounds: { minX: -31.6, maxX: -30.4, minZ: -2.9, maxZ: -1.1 },
       kind: 'kitchen-sink-cabinet',
-      visual: { color: 0x667382, accentColor: 0xd7dce0, height: 0.95 },
+      visual: {
+        color: 0x667382,
+        accentColor: 0xd7dce0,
+        height: 0.95,
+        allowSolidOverlapWithIds: ['kitchen-west-counter-run'],
+      },
     },
     {
       id: 'kitchen-stove-cabinet',
@@ -231,7 +236,12 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       solidFootprint: { width: 1.2, depth: 1.6 },
       solidBounds: { minX: -31.6, maxX: -30.4, minZ: 6.2, maxZ: 7.8 },
       kind: 'kitchen-stove-cabinet',
-      visual: { color: 0x5e6672, accentColor: 0x1d232b, height: 0.95 },
+      visual: {
+        color: 0x5e6672,
+        accentColor: 0x1d232b,
+        height: 0.95,
+        allowSolidOverlapWithIds: ['kitchen-west-counter-run'],
+      },
     },
     {
       id: 'kitchen-island',
@@ -364,8 +374,7 @@ export function validateLowerFloorFurnishingPlan(
           solid.definition.id
         );
       if (
-        !solidAllowed &&
-        !otherAllowed &&
+        !(solidAllowed && otherAllowed) &&
         rectanglesOverlap(solid.bounds, other.bounds, tolerance)
       ) {
         throw new Error(
@@ -705,6 +714,28 @@ function createKitchenFurnishing(
   });
   const group = new Group();
 
+  if (definition.kind === 'kitchen-bar-stool') {
+    const seat = new Mesh(
+      new CylinderGeometry(0.32, 0.32, 0.12, 20),
+      counterMaterial
+    );
+    seat.name = `Furnishing:${definition.id}:roundSeat`;
+    seat.position.y = height;
+    group.add(seat);
+    [-0.2, 0.2].forEach((x, xIndex) => {
+      [-0.2, 0.2].forEach((z, zIndex) => {
+        addBox(
+          group,
+          `stoolLeg${xIndex}-${zIndex}`,
+          { width: 0.06, height, depth: 0.06 },
+          darkMaterial,
+          [x, height / 2, z]
+        );
+      });
+    });
+    return group;
+  }
+
   if (definition.kind === 'kitchen-fridge') {
     addBox(
       group,
@@ -807,28 +838,8 @@ function createKitchenFurnishing(
         `islandDrawer${index}`,
         { width: 0.72, height: 0.08, depth: 0.06 },
         darkMaterial,
-        [x, 0.62, footprint.depth / 2 + 0.01]
+        [x, 0.62, visualFootprint.depth / 2 + 0.01]
       );
-    });
-  } else if (definition.kind === 'kitchen-bar-stool') {
-    group.clear();
-    const seat = new Mesh(
-      new CylinderGeometry(0.32, 0.32, 0.12, 20),
-      counterMaterial
-    );
-    seat.name = `Furnishing:${definition.id}:roundSeat`;
-    seat.position.y = height;
-    group.add(seat);
-    [-0.2, 0.2].forEach((x, xIndex) => {
-      [-0.2, 0.2].forEach((z, zIndex) => {
-        addBox(
-          group,
-          `stoolLeg${xIndex}-${zIndex}`,
-          { width: 0.06, height: height, depth: 0.06 },
-          darkMaterial,
-          [x, height / 2, z]
-        );
-      });
     });
   } else if (definition.kind === 'kitchen-trash-drawer') {
     addBox(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,7 +76,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(6);
+    expect(build.colliders).toHaveLength(14);
     expect(build.decorativeFootprints).toHaveLength(1);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -85,8 +85,80 @@ describe('lower floor furnishings foundation', () => {
       'living-room-lounge-chair-north',
       'living-room-lounge-chair-east',
       'living-room-floor-lamp',
+      'kitchen-west-counter-run',
+      'kitchen-fridge',
+      'kitchen-sink-cabinet',
+      'kitchen-stove-cabinet',
+      'kitchen-island',
+      'kitchen-bar-stool-west',
+      'kitchen-bar-stool-east',
+      'kitchen-trash-drawer',
       'living-room-media-rug',
     ]);
+  });
+
+  it('uses the requested kitchen kitchenette and dining AABBs', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const expectedKitchenBounds: Record<string, RectCollider> = {
+      'kitchen-west-counter-run': {
+        minX: -31.625,
+        maxX: -30.375,
+        minZ: -0.8,
+        maxZ: 8.4,
+      },
+      'kitchen-fridge': {
+        minX: -31.675,
+        maxX: -30.325,
+        minZ: -6.35,
+        maxZ: -4.85,
+      },
+      'kitchen-sink-cabinet': {
+        minX: -31.6,
+        maxX: -30.4,
+        minZ: -2.9,
+        maxZ: -1.1,
+      },
+      'kitchen-stove-cabinet': {
+        minX: -31.6,
+        maxX: -30.4,
+        minZ: 6.2,
+        maxZ: 7.8,
+      },
+      'kitchen-island': {
+        minX: -15.4,
+        maxX: -10.6,
+        minZ: 10.1,
+        maxZ: 11.7,
+      },
+      'kitchen-bar-stool-west': {
+        minX: -16.25,
+        maxX: -15.55,
+        minZ: 12.55,
+        maxZ: 13.25,
+      },
+      'kitchen-bar-stool-east': {
+        minX: -10.45,
+        maxX: -9.75,
+        minZ: 12.55,
+        maxZ: 13.25,
+      },
+      'kitchen-trash-drawer': {
+        minX: -31.3,
+        maxX: -30.3,
+        minZ: 10.1,
+        maxZ: 11.3,
+      },
+    };
+
+    Object.entries(expectedKitchenBounds).forEach(([id, expected]) => {
+      expect(
+        colliders.find((collider) => collider.furnishingId === id)
+      ).toMatchObject({
+        ...expected,
+        category: 'kitchenette',
+        roomId: 'kitchen',
+      });
+    });
   });
 
   it('uses the requested living-room media seating AABBs', () => {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -174,6 +174,70 @@ describe('lower floor furnishings foundation', () => {
     });
   });
 
+  it('keeps every kitchen collider inside the kitchen room bounds', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const kitchen = LOWER_FLOOR_ROOM_BOUNDS.kitchen;
+
+    colliders
+      .filter((collider) => collider.roomId === 'kitchen')
+      .forEach((collider) => {
+        expect(isContainedBy(kitchen, collider)).toBe(true);
+      });
+  });
+
+  it('keeps both kitchen doorway buffers clear', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const kitchenDoorwayBuffers: RectCollider[] = [
+      { minX: -5.2, maxX: -2.8, minZ: 0, maxZ: 8 },
+      { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
+    ];
+
+    colliders
+      .filter((collider) => collider.roomId === 'kitchen')
+      .forEach((collider) => {
+        kitchenDoorwayBuffers.forEach((buffer) => {
+          expect(rectanglesOverlap(collider, buffer)).toBe(false);
+        });
+      });
+  });
+
+  it('keeps kitchen solids disjoint except the authored stove counter integration', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const kitchenColliders = colliders.filter(
+      (collider) => collider.roomId === 'kitchen'
+    );
+    const allowedOverlap = new Set([
+      'kitchen-stove-cabinet|kitchen-west-counter-run',
+      'kitchen-west-counter-run|kitchen-stove-cabinet',
+    ]);
+
+    kitchenColliders.forEach((collider, index) => {
+      kitchenColliders.slice(index + 1).forEach((other) => {
+        const pairKey = `${collider.furnishingId}|${other.furnishingId}`;
+        expect(rectanglesOverlap(collider, other)).toBe(
+          allowedOverlap.has(pairKey)
+        );
+      });
+    });
+  });
+
+  it('keeps the wall counter visual narrow in world X and long in world Z', () => {
+    const build = createLowerFloorFurnishings();
+    const counterGroup = build.group.children.find(
+      (child) => child.name === 'Furnishing:kitchen-west-counter-run'
+    );
+
+    expect(counterGroup).toBeDefined();
+
+    const visualBounds = new Box3().setFromObject(counterGroup!);
+    const visualWidthX = visualBounds.max.x - visualBounds.min.x;
+    const visualDepthZ = visualBounds.max.z - visualBounds.min.z;
+
+    expect(visualWidthX).toBeLessThan(1.5);
+    expect(visualDepthZ).toBeGreaterThan(9);
+    expect(visualDepthZ).toBeGreaterThan(visualWidthX * 5);
+  });
+
   it('uses the requested living-room media seating AABBs', () => {
     const { colliders, decorativeFootprints } = createLowerFloorFurnishings();
     const expectedSolidBounds: Record<string, RectCollider> = {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -161,6 +161,19 @@ describe('lower floor furnishings foundation', () => {
     });
   });
 
+  it('keeps kitchen solidBounds aligned with authored centers and footprints', () => {
+    const kitchenDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.category === 'kitchenette'
+    );
+
+    kitchenDefinitions.forEach((definition) => {
+      expect(definition.solidFootprint).toBeDefined();
+      expect(definition.solidBounds).toMatchObject(
+        deriveAabbFromCenterSize(definition)
+      );
+    });
+  });
+
   it('uses the requested living-room media seating AABBs', () => {
     const { colliders, decorativeFootprints } = createLowerFloorFurnishings();
     const expectedSolidBounds: Record<string, RectCollider> = {
@@ -353,6 +366,25 @@ describe('lower floor furnishings foundation', () => {
     });
   });
 
+  it('requires solid overlap allowlists to be mutual', () => {
+    const oneSidedDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.map(
+      (definition) => {
+        if (definition.id !== 'kitchen-stove-cabinet') return definition;
+        return {
+          ...definition,
+          visual: {
+            ...definition.visual,
+            allowSolidOverlapWithIds: [],
+          },
+        };
+      }
+    );
+
+    expect(() => validateLowerFloorFurnishingPlan(oneSidedDefinitions)).toThrow(
+      /kitchen-west-counter-run overlaps kitchen-stove-cabinet/
+    );
+  });
+
   it('allows decorative footprints to overlap associated solids only when explicit', () => {
     const { decorativeFootprints, colliders } = createLowerFloorFurnishings({
       definitions: validDefinitions,
@@ -418,6 +450,24 @@ describe('lower floor furnishings foundation', () => {
     ).toThrow(/empty decorative footprint/);
   });
 });
+
+function deriveAabbFromCenterSize(
+  definition: LowerFloorFurnishingDefinition
+): RectCollider {
+  const footprint = definition.solidFootprint;
+  if (!footprint)
+    throw new Error(`${definition.id} is missing a solid footprint.`);
+  return {
+    minX: roundAabbCoordinate(definition.position.x - footprint.width / 2),
+    maxX: roundAabbCoordinate(definition.position.x + footprint.width / 2),
+    minZ: roundAabbCoordinate(definition.position.z - footprint.depth / 2),
+    maxZ: roundAabbCoordinate(definition.position.z + footprint.depth / 2),
+  };
+}
+
+function roundAabbCoordinate(value: number): number {
+  return Number(value.toFixed(6));
+}
 
 function isContainedBy(container: RectCollider, bounds: RectCollider): boolean {
   return (


### PR DESCRIPTION
### Motivation
- Make the lower-floor kitchen read as a modern kitchenette and compact dining/bar space from the isometric camera while preserving existing doorways and POI constraints.

### Description
- Add kitchen furnishing definitions for `kitchen-west-counter-run`, `kitchen-fridge`, `kitchen-sink-cabinet`, `kitchen-stove-cabinet`, `kitchen-island`, two `kitchen-bar-stool` entries, and `kitchen-trash-drawer` with the requested centers and AABBs in `src/scene/structures/lowerFloorFurnishings.ts`.
- Add a per-furnishing allowlist (`visual.allowSolidOverlapWithIds`) and update validation to permit explicit overlap pairs (used so the long counter run can adjoin sink/stove cabinets) without weakening other blocker checks.
- Implement kitchen-specific visual primitives (cabinets, countertop, backsplash, pulls, sink, faucet, cooktop/oven/hood, island drawers, stool seat/legs, fridge handle, and trash drawer detail) and wire them into `createSolidPrimitive` via `createKitchenFurnishing`.
- Update `src/tests/lowerFloorFurnishings.test.ts` to assert the presence of all kitchen furnishing IDs and their exact expected AABBs.

### Testing
- Ran formatting with `npm run format:write` for the touched files (succeeded).
- Ran the focused suite with `npm run test:ci -- lowerFloorFurnishings` and the tests passed (11 tests, 1 file).
- Built the app with `npm run build` and the build completed successfully (dist generated; chunk-size warnings only).
- Ran `npm run typecheck` and it failed due to pre-existing, unrelated repository-wide TypeScript errors outside this change (reported but not introduced by this PR).
- Run a secret scan with `git diff --cached | ./scripts/scan-secrets.py` and no high-risk secrets were detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40cdb54e64832f9104bb3fa4ce0696)