### PR TITLE
📚 : – add lower-floor storage furnishings

### DIFF
--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -283,6 +283,73 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'kitchen-trash-drawer',
       visual: { color: 0x586575, accentColor: 0x8fd0a6, height: 0.82 },
     },
+
+    {
+      id: 'living-room-south-bookcase-west',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -24.0, z: -31.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.75 },
+      solidBounds: { minX: -26.4, maxX: -21.6, minZ: -31.575, maxZ: -30.825 },
+      kind: 'storage-bookcase',
+      visual: { color: 0x4b3628, accentColor: 0xc8a76a, height: 1.45 },
+    },
+    {
+      id: 'living-room-south-open-shelf',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -15.5, z: -31.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.5, depth: 0.75 },
+      solidBounds: { minX: -17.75, maxX: -13.25, minZ: -31.575, maxZ: -30.825 },
+      kind: 'storage-open-shelf',
+      visual: { color: 0x536171, accentColor: 0x8fd0a6, height: 1.22 },
+    },
+    {
+      id: 'living-room-drawer-console',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -2.5, z: -31.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.0, depth: 0.8 },
+      solidBounds: { minX: -4.5, maxX: -0.5, minZ: -31.5, maxZ: -30.7 },
+      kind: 'storage-drawer-console',
+      visual: { color: 0x5a4030, accentColor: 0xb8c2c9, height: 0.82 },
+    },
+    {
+      id: 'studio-north-bookcase-east',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 26.6, z: 15.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.8 },
+      solidBounds: { minX: 24.2, maxX: 29.0, minZ: 14.7, maxZ: 15.5 },
+      kind: 'storage-bookcase',
+      visual: { color: 0x48586a, accentColor: 0xc28d52, height: 2.15 },
+    },
+    {
+      id: 'studio-drafting-drawers',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 5.8, z: 14.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.8 },
+      solidBounds: { minX: 3.4, maxX: 8.2, minZ: 14.5, maxZ: 15.3 },
+      kind: 'storage-drafting-drawers',
+      visual: { color: 0x697483, accentColor: 0xd0bea2, height: 0.72 },
+    },
+    {
+      id: 'studio-east-dresser',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 31.0, z: 4.1 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.0, depth: 3.2 },
+      solidBounds: { minX: 30.5, maxX: 31.5, minZ: 2.5, maxZ: 5.7 },
+      kind: 'storage-east-dresser',
+      visual: { color: 0x594434, accentColor: 0xb8c2c9, height: 1.05 },
+    },
     {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
@@ -481,6 +548,8 @@ function createSolidPrimitive(
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
   if (definition.kind.startsWith('kitchen-'))
     return createKitchenFurnishing(definition);
+  if (definition.kind.startsWith('storage-'))
+    return createStorageFurnishing(definition);
 
   const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
   const height = definition.visual?.height ?? 0.8;
@@ -847,6 +916,165 @@ function createKitchenFurnishing(
     );
   }
 
+  return group;
+}
+
+function createStorageFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
+  const isQuarterTurn =
+    Math.abs(Math.sin(definition.orientationRadians)) >
+    Math.abs(Math.cos(definition.orientationRadians));
+  const visualFootprint = isQuarterTurn
+    ? { width: footprint.depth, depth: footprint.width }
+    : footprint;
+  const height = definition.visual?.height ?? 1;
+  const caseMaterial = createMaterial(definition.visual?.color ?? 0x534234);
+  const accentMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xb8c2c9
+  );
+  const darkMaterial = createMaterial(0x26211d);
+  const bookMaterials = [
+    createMaterial(0x8f4e43),
+    createMaterial(0x3f5f78),
+    createMaterial(0xd0a85a),
+    createMaterial(0x6f7d56),
+    createMaterial(0xbec6cc),
+  ];
+  const group = new Group();
+
+  addBox(
+    group,
+    'storageBody',
+    { width: visualFootprint.width, height, depth: visualFootprint.depth },
+    caseMaterial,
+    [0, height / 2, 0]
+  );
+
+  const frontZ = -visualFootprint.depth / 2 + 0.04;
+  addBox(
+    group,
+    'topTrim',
+    { width: visualFootprint.width, height: 0.08, depth: 0.08 },
+    accentMaterial,
+    [0, height + 0.04, frontZ]
+  );
+  addBox(
+    group,
+    'toeKick',
+    { width: visualFootprint.width - 0.24, height: 0.08, depth: 0.08 },
+    darkMaterial,
+    [0, 0.08, frontZ]
+  );
+
+  if (
+    definition.kind.includes('bookcase') ||
+    definition.kind.includes('open-shelf')
+  ) {
+    const shelfCount = definition.kind.includes('open-shelf') ? 3 : 4;
+    for (let index = 1; index < shelfCount; index += 1) {
+      addBox(
+        group,
+        `shelfDivider${index}`,
+        { width: visualFootprint.width - 0.18, height: 0.06, depth: 0.08 },
+        accentMaterial,
+        [0, (height / shelfCount) * index, frontZ]
+      );
+    }
+    [-0.33, 0, 0.33].forEach((offset, index) => {
+      addBox(
+        group,
+        `verticalDivider${index}`,
+        { width: 0.05, height: height - 0.18, depth: 0.08 },
+        accentMaterial,
+        [visualFootprint.width * offset, height / 2, frontZ]
+      );
+    });
+    const rows = definition.kind.includes('open-shelf') ? 2 : 3;
+    for (let row = 0; row < rows; row += 1) {
+      for (let index = 0; index < 12; index += 1) {
+        const bookHeight = 0.24 + ((row + index) % 4) * 0.045;
+        const x = -visualFootprint.width / 2 + 0.32 + index * 0.28;
+        if (x > visualFootprint.width / 2 - 0.22) continue;
+        addBox(
+          group,
+          `book${row}-${index}`,
+          { width: 0.12, height: bookHeight, depth: 0.11 },
+          bookMaterials[(row + index) % bookMaterials.length],
+          [x, 0.34 + row * 0.42 + bookHeight / 2, frontZ - 0.02]
+        );
+      }
+    }
+    if (definition.kind.includes('open-shelf')) {
+      addBox(
+        group,
+        'storageBox',
+        { width: 0.52, height: 0.28, depth: 0.12 },
+        accentMaterial,
+        [1.55, 0.58, frontZ - 0.02]
+      );
+      addBox(
+        group,
+        'tinyPlantPot',
+        { width: 0.18, height: 0.16, depth: 0.16 },
+        darkMaterial,
+        [-1.55, 1.05, frontZ - 0.02]
+      );
+      addBox(
+        group,
+        'tinyPlantLeaf',
+        { width: 0.28, height: 0.18, depth: 0.08 },
+        bookMaterials[3],
+        [-1.55, 1.22, frontZ - 0.02]
+      );
+    }
+    return group;
+  }
+
+  const rows = definition.kind.includes('drafting') ? 5 : 3;
+  const columns = definition.kind.includes('dresser') ? 2 : 3;
+  for (let row = 0; row < rows; row += 1) {
+    for (let column = 0; column < columns; column += 1) {
+      const drawerWidth = visualFootprint.width / columns - 0.16;
+      const x =
+        -visualFootprint.width / 2 +
+        drawerWidth / 2 +
+        0.1 +
+        column * (drawerWidth + 0.12);
+      const y = 0.28 + row * ((height - 0.28) / rows);
+      addBox(
+        group,
+        `drawerFace${row}-${column}`,
+        { width: drawerWidth, height: 0.07, depth: 0.055 },
+        accentMaterial,
+        [x, y, frontZ - 0.01]
+      );
+      addBox(
+        group,
+        `drawerPull${row}-${column}`,
+        { width: drawerWidth * 0.45, height: 0.035, depth: 0.06 },
+        darkMaterial,
+        [x, y + 0.055, frontZ - 0.04]
+      );
+    }
+  }
+  if (definition.kind.includes('console')) {
+    addBox(
+      group,
+      'topBowl',
+      { width: 0.32, height: 0.12, depth: 0.22 },
+      accentMaterial,
+      [-1.25, height + 0.1, 0]
+    );
+    addBox(
+      group,
+      'stackedBooks',
+      { width: 0.52, height: 0.12, depth: 0.24 },
+      bookMaterials[2],
+      [1.1, height + 0.08, 0]
+    );
+  }
   return group;
 }
 

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -12,6 +12,47 @@ import {
 } from '../scene/structures/lowerFloorFurnishings';
 import type { RectCollider } from '../systems/collision';
 
+const p4StorageBounds: Record<string, RectCollider> = {
+  'living-room-south-bookcase-west': {
+    minX: -26.4,
+    maxX: -21.6,
+    minZ: -31.575,
+    maxZ: -30.825,
+  },
+  'living-room-south-open-shelf': {
+    minX: -17.75,
+    maxX: -13.25,
+    minZ: -31.575,
+    maxZ: -30.825,
+  },
+  'living-room-drawer-console': {
+    minX: -4.5,
+    maxX: -0.5,
+    minZ: -31.5,
+    maxZ: -30.7,
+  },
+  'studio-north-bookcase-east': {
+    minX: 24.2,
+    maxX: 29.0,
+    minZ: 14.7,
+    maxZ: 15.5,
+  },
+  'studio-drafting-drawers': {
+    minX: 3.4,
+    maxX: 8.2,
+    minZ: 14.5,
+    maxZ: 15.3,
+  },
+  'studio-east-dresser': {
+    minX: 30.5,
+    maxX: 31.5,
+    minZ: 2.5,
+    maxZ: 5.7,
+  },
+};
+
+const p4StorageIds = Object.keys(p4StorageBounds);
+
 const validDefinitions: LowerFloorFurnishingDefinition[] = [
   {
     id: 'living-couch-foundation',
@@ -76,7 +117,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(14);
+    expect(build.colliders).toHaveLength(20);
     expect(build.decorativeFootprints).toHaveLength(1);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -93,6 +134,12 @@ describe('lower floor furnishings foundation', () => {
       'kitchen-bar-stool-west',
       'kitchen-bar-stool-east',
       'kitchen-trash-drawer',
+      'living-room-south-bookcase-west',
+      'living-room-south-open-shelf',
+      'living-room-drawer-console',
+      'studio-north-bookcase-east',
+      'studio-drafting-drawers',
+      'studio-east-dresser',
       'living-room-media-rug',
     ]);
   });
@@ -158,6 +205,89 @@ describe('lower floor furnishings foundation', () => {
         category: 'kitchenette',
         roomId: 'kitchen',
       });
+    });
+  });
+
+  it('adds the requested lower-floor storage AABBs and category', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const colliderById = new Map(
+      colliders.map((collider) => [collider.furnishingId, collider])
+    );
+
+    p4StorageIds.forEach((id) => {
+      const collider = colliderById.get(id);
+      const expectedRoom = id.startsWith('living-room')
+        ? 'livingRoom'
+        : 'studio';
+
+      expect(collider).toMatchObject({
+        ...p4StorageBounds[id],
+        category: 'storage',
+        roomId: expectedRoom,
+      });
+      expect(collider!.maxX - collider!.minX).toBeGreaterThan(0);
+      expect(collider!.maxZ - collider!.minZ).toBeGreaterThan(0);
+    });
+    expect(colliders.some((collider) => collider.category === 'storage')).toBe(
+      true
+    );
+  });
+
+  it('keeps storage solids inside room bounds and away from blockers', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const storageColliders = colliders.filter(
+      (collider) => collider.category === 'storage'
+    );
+
+    expect(
+      storageColliders.map(({ furnishingId }) => furnishingId).sort()
+    ).toEqual([...p4StorageIds].sort());
+    storageColliders.forEach((collider, index) => {
+      expect(
+        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[collider.roomId], collider)
+      ).toBe(true);
+      storageColliders.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+      });
+    });
+  });
+
+  it('keeps storage solids disjoint from seating and kitchen solids', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const storageColliders = colliders.filter(
+      (collider) => collider.category === 'storage'
+    );
+    const previousPassColliders = colliders.filter((collider) =>
+      ['living-room-seating', 'kitchenette'].includes(collider.category)
+    );
+
+    storageColliders.forEach((storageCollider) => {
+      previousPassColliders.forEach((other) => {
+        expect(rectanglesOverlap(storageCollider, other)).toBe(false);
+      });
+    });
+  });
+
+  it('keeps storage collider source IDs unique and visual details non-blocking', () => {
+    const build = createLowerFloorFurnishings();
+    const storageColliders = build.colliders.filter(
+      (collider) => collider.category === 'storage'
+    );
+    const sourceIds = storageColliders.map((collider) => collider.sourceId);
+
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    p4StorageIds.forEach((id) => {
+      expect(
+        storageColliders.filter((collider) => collider.furnishingId === id)
+      ).toHaveLength(1);
+      const group = build.group.children.find(
+        (child) => child.name === `Furnishing:${id}`
+      );
+      expect(group).toBeDefined();
+      expect(group!.children[0]?.children.length).toBeGreaterThan(1);
     });
   });
 


### PR DESCRIPTION
### Motivation
- Populate the lower floor with P4 storage: bookshelves, open shelving, drawer console, drafting drawers, and a dresser so the space reads as lived-in while keeping navigation and prior passes intact.
- Ensure every storage piece has a single authored solid collider (AABB) that respects room bounds and reserved doorway/blocker buffers.

### Description
- Added six storage definitions to `DEFAULT_LOWER_FLOOR_FURNISHINGS` with exact centers, footprints, orientations, and authored `solidBounds` for the requested AABBs (living-room and studio). (`src/scene/structures/lowerFloorFurnishings.ts`)
- Implemented `createStorageFurnishing(...)` renderer and wired `storage-*` kinds through `createSolidPrimitive(...)` to produce low-poly, deterministic shelf/drawer/book/box/trim visuals as child geometry of the parent footprint, avoiding extra blocking colliders. (`src/scene/structures/lowerFloorFurnishings.ts`)
- Expanded the focused furnishing test suite to assert presence of the six P4 storage IDs, exact AABBs, room containment, non-overlap with other solids and reserved blockers, unique collider `sourceId`s, and that visual children do not create extra colliders. (`src/tests/lowerFloorFurnishings.test.ts`)
- Kept changes scoped to the requested files and preserved existing P2/P3 items, POIs, doorways, and behaviors.

### Testing
- Ran formatting and linting: `npm run format:write` (passed), `npm run lint` (passed), and `npm run format:check` (passed). 
- Ran focused furnishing tests: `npm run test:ci -- lowerFloorFurnishings` and observed all tests in that file passed (21 tests all green). 
- Ran build and smoke: `npm run build` (succeeded) and `npm run smoke` (succeeded). 
- Ran docs check: `npm run docs:check` (passed, link checker emitted external fetch warnings unrelated to these changes). 
- Verified secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets). 
- Notable non-blocking failures outside this change: `npm run typecheck` failed on pre-existing unrelated TypeScript issues elsewhere in the repo, and full `npm run test:ci` failed due to an existing stale miniature manifest test; these are unrelated to the storage additions and the focused lower-floor furnishing suite passes. 
- Playwright screenshot attempt was not possible in this environment because Playwright browsers are not installed (`npx playwright install` required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e579b5e0832f8c2cd9cf528b2cd2)