### PR TITLE
🗄️ : – Add lower-floor storage furnishings

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 6,
-      "syncNote": "Kitchenette collision and validation refinements do not add tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.",
-      "sourceFingerprint": "1723ff9c15b26bdec7751d8bb72e93e63beefaf90e8cedf4fe3c9d21e29ff227",
+      "syncRevision": 7,
+      "syncNote": "Lower-floor storage furnishings remain runtime-only detail; tabletop proxy coverage is deferred until the full furnishing set lands.",
+      "sourceFingerprint": "cb592e2d0884b1716cff217f273ee66407e927e0e91d07a378fe772690cde3be",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "c85e4ba35bea9c5ed0ef1d7c0c1d8cd9dc095ade6b9d7c2ec27a809a592e614e"
+      "metadataFingerprint": "975c77a38fa88411dc9d39ee006aec0f29015fc9823f21e706ac537403938900"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 6,
+    syncRevision: 7,
     reason:
-      'Kitchenette collision and validation refinements do not add tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.',
+      'Lower-floor storage furnishings remain runtime-only detail; tabletop proxy coverage is deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -283,6 +283,73 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'kitchen-trash-drawer',
       visual: { color: 0x586575, accentColor: 0x8fd0a6, height: 0.82 },
     },
+
+    {
+      id: 'living-room-south-bookcase-west',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -24.0, z: -31.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.75 },
+      solidBounds: { minX: -26.4, maxX: -21.6, minZ: -31.575, maxZ: -30.825 },
+      kind: 'storage-bookcase',
+      visual: { color: 0x4f392b, accentColor: 0xd2a85f, height: 1.65 },
+    },
+    {
+      id: 'living-room-south-open-shelf',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -15.5, z: -31.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.5, depth: 0.75 },
+      solidBounds: { minX: -17.75, maxX: -13.25, minZ: -31.575, maxZ: -30.825 },
+      kind: 'storage-open-shelf',
+      visual: { color: 0x465464, accentColor: 0x86a884, height: 1.32 },
+    },
+    {
+      id: 'living-room-drawer-console',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -2.5, z: -31.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.0, depth: 0.8 },
+      solidBounds: { minX: -4.5, maxX: -0.5, minZ: -31.5, maxZ: -30.7 },
+      kind: 'storage-drawer-console',
+      visual: { color: 0x5d4634, accentColor: 0xb9c0c7, height: 0.82 },
+    },
+    {
+      id: 'studio-north-bookcase-east',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 26.6, z: 15.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.8 },
+      solidBounds: { minX: 24.2, maxX: 29.0, minZ: 14.7, maxZ: 15.5 },
+      kind: 'storage-tall-bookcase',
+      visual: { color: 0x394455, accentColor: 0xc99554, height: 2.15 },
+    },
+    {
+      id: 'studio-drafting-drawers',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 5.8, z: 14.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.8 },
+      solidBounds: { minX: 3.4, maxX: 8.2, minZ: 14.5, maxZ: 15.3 },
+      kind: 'storage-drafting-drawers',
+      visual: { color: 0x59616c, accentColor: 0xc8ced4, height: 0.72 },
+    },
+    {
+      id: 'studio-east-dresser',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 31.0, z: 4.1 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.0, depth: 3.2 },
+      solidBounds: { minX: 30.5, maxX: 31.5, minZ: 2.5, maxZ: 5.7 },
+      kind: 'storage-dresser',
+      visual: { color: 0x51443a, accentColor: 0xb8a782, height: 1.12 },
+    },
     {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
@@ -481,6 +548,8 @@ function createSolidPrimitive(
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
   if (definition.kind.startsWith('kitchen-'))
     return createKitchenFurnishing(definition);
+  if (definition.kind.startsWith('storage-'))
+    return createStorageFurnishing(definition);
 
   const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
   const height = definition.visual?.height ?? 0.8;
@@ -686,6 +755,204 @@ function createFloorLamp(definition: LowerFloorFurnishingDefinition): Group {
   shade.position.y = 1.44;
   group.add(shade);
   return group;
+}
+
+function createStorageFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
+  const isQuarterTurn =
+    Math.abs(Math.sin(definition.orientationRadians)) >
+    Math.abs(Math.cos(definition.orientationRadians));
+  const visualFootprint = isQuarterTurn
+    ? { width: footprint.depth, depth: footprint.width }
+    : footprint;
+  const height = definition.visual?.height ?? 1.1;
+  const woodMaterial = createMaterial(definition.visual?.color ?? 0x4f392b);
+  const accentMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xb9c0c7,
+    {
+      metalness: 0.15,
+      roughness: 0.48,
+    }
+  );
+  const darkMaterial = createMaterial(0x29231f);
+  const bookMaterials = [
+    createMaterial(0x8b4e42),
+    createMaterial(0x3f6278),
+    createMaterial(0xc99554),
+    createMaterial(0x6f7f55),
+    createMaterial(0x7d5d84),
+  ];
+  const group = new Group();
+
+  addBox(
+    group,
+    'caseBody',
+    { width: visualFootprint.width, height, depth: visualFootprint.depth },
+    woodMaterial,
+    [0, height / 2, 0]
+  );
+  addBox(
+    group,
+    'frontRecess',
+    {
+      width: visualFootprint.width - 0.18,
+      height: Math.max(0.2, height - 0.22),
+      depth: 0.06,
+    },
+    darkMaterial,
+    [0, height / 2, -visualFootprint.depth / 2 - 0.01]
+  );
+
+  if (
+    definition.kind.includes('bookcase') ||
+    definition.kind.includes('shelf')
+  ) {
+    const shelfCount = definition.kind === 'storage-tall-bookcase' ? 4 : 3;
+    for (let index = 1; index < shelfCount; index += 1) {
+      addBox(
+        group,
+        `shelfDivider${index}`,
+        { width: visualFootprint.width - 0.16, height: 0.07, depth: 0.12 },
+        accentMaterial,
+        [0, (height / shelfCount) * index, -visualFootprint.depth / 2 - 0.04]
+      );
+    }
+    [-0.32, 0.32].forEach((xOffset, index) => {
+      addBox(
+        group,
+        `verticalDivider${index}`,
+        { width: 0.06, height: height - 0.18, depth: 0.1 },
+        accentMaterial,
+        [
+          xOffset * visualFootprint.width,
+          height / 2,
+          -visualFootprint.depth / 2 - 0.05,
+        ]
+      );
+    });
+    addBookRows(
+      group,
+      visualFootprint.width,
+      height,
+      shelfCount,
+      bookMaterials
+    );
+    addStorageBoxes(group, visualFootprint.width, height, accentMaterial);
+    if (definition.kind === 'storage-open-shelf') {
+      addBox(
+        group,
+        'tinyPlanter',
+        { width: 0.26, height: 0.16, depth: 0.2 },
+        accentMaterial,
+        [visualFootprint.width * 0.34, height + 0.08, -0.12]
+      );
+      addBox(
+        group,
+        'tinyPlant',
+        { width: 0.18, height: 0.28, depth: 0.14 },
+        createMaterial(0x6f8d5f),
+        [visualFootprint.width * 0.34, height + 0.3, -0.12]
+      );
+    }
+  } else {
+    const rows = definition.kind === 'storage-drafting-drawers' ? 5 : 3;
+    for (let row = 0; row < rows; row += 1) {
+      const y = 0.24 + row * ((height - 0.25) / rows);
+      addBox(
+        group,
+        `drawerFront${row}`,
+        { width: visualFootprint.width - 0.16, height: 0.08, depth: 0.07 },
+        accentMaterial,
+        [0, y, -visualFootprint.depth / 2 - 0.015]
+      );
+      addBox(
+        group,
+        `drawerPull${row}`,
+        { width: visualFootprint.width * 0.42, height: 0.035, depth: 0.08 },
+        darkMaterial,
+        [0, y + 0.02, -visualFootprint.depth / 2 - 0.07]
+      );
+    }
+    [-0.42, 0.42].forEach((x, index) => {
+      addBox(
+        group,
+        `consoleFoot${index}`,
+        { width: 0.16, height: 0.14, depth: 0.16 },
+        darkMaterial,
+        [x * visualFootprint.width, 0.07, visualFootprint.depth / 2 - 0.14]
+      );
+    });
+    if (definition.kind === 'storage-drawer-console') {
+      addBox(
+        group,
+        'topTray',
+        { width: 0.56, height: 0.06, depth: 0.3 },
+        accentMaterial,
+        [-1.1, height + 0.03, -0.04]
+      );
+      addBox(
+        group,
+        'stackedBooks',
+        { width: 0.42, height: 0.16, depth: 0.28 },
+        createMaterial(0x3f6278),
+        [1.15, height + 0.08, -0.04]
+      );
+    }
+  }
+
+  addBox(
+    group,
+    'topTrim',
+    {
+      width: visualFootprint.width,
+      height: 0.08,
+      depth: visualFootprint.depth,
+    },
+    accentMaterial,
+    [0, height + 0.04, 0]
+  );
+  return group;
+}
+
+function addBookRows(
+  group: Group,
+  width: number,
+  height: number,
+  shelfCount: number,
+  materials: MeshStandardMaterial[]
+): void {
+  for (let shelf = 0; shelf < shelfCount; shelf += 1) {
+    const shelfY = 0.22 + shelf * (height / shelfCount);
+    for (let book = 0; book < 9; book += 1) {
+      const bookHeight = 0.28 + ((book + shelf) % 4) * 0.07;
+      addBox(
+        group,
+        `book${shelf}-${book}`,
+        { width: 0.16, height: bookHeight, depth: 0.14 },
+        materials[(book + shelf) % materials.length],
+        [-width / 2 + 0.42 + book * 0.24, shelfY + bookHeight / 2, -0.43]
+      );
+    }
+  }
+}
+
+function addStorageBoxes(
+  group: Group,
+  width: number,
+  height: number,
+  material: MeshStandardMaterial
+): void {
+  [-0.18, 0.2].forEach((x, index) => {
+    addBox(
+      group,
+      `storageBin${index}`,
+      { width: 0.5, height: 0.28, depth: 0.22 },
+      material,
+      [width / 2 - 0.55 - index * 0.56, height * 0.32, -0.42]
+    );
+  });
 }
 
 function createKitchenFurnishing(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,7 +76,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(14);
+    expect(build.colliders).toHaveLength(20);
     expect(build.decorativeFootprints).toHaveLength(1);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -93,6 +93,12 @@ describe('lower floor furnishings foundation', () => {
       'kitchen-bar-stool-west',
       'kitchen-bar-stool-east',
       'kitchen-trash-drawer',
+      'living-room-south-bookcase-west',
+      'living-room-south-open-shelf',
+      'living-room-drawer-console',
+      'studio-north-bookcase-east',
+      'studio-drafting-drawers',
+      'studio-east-dresser',
       'living-room-media-rug',
     ]);
   });
@@ -294,6 +300,119 @@ describe('lower floor furnishings foundation', () => {
         (footprint) => footprint.furnishingId === 'living-room-media-rug'
       )?.allowSolidOverlap
     ).toBe(true);
+  });
+
+  it('adds the requested lower-floor storage pieces with exact AABBs', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const expectedStorageBounds: Record<string, RectCollider> = {
+      'living-room-south-bookcase-west': {
+        minX: -26.4,
+        maxX: -21.6,
+        minZ: -31.575,
+        maxZ: -30.825,
+      },
+      'living-room-south-open-shelf': {
+        minX: -17.75,
+        maxX: -13.25,
+        minZ: -31.575,
+        maxZ: -30.825,
+      },
+      'living-room-drawer-console': {
+        minX: -4.5,
+        maxX: -0.5,
+        minZ: -31.5,
+        maxZ: -30.7,
+      },
+      'studio-north-bookcase-east': {
+        minX: 24.2,
+        maxX: 29.0,
+        minZ: 14.7,
+        maxZ: 15.5,
+      },
+      'studio-drafting-drawers': {
+        minX: 3.4,
+        maxX: 8.2,
+        minZ: 14.5,
+        maxZ: 15.3,
+      },
+      'studio-east-dresser': {
+        minX: 30.5,
+        maxX: 31.5,
+        minZ: 2.5,
+        maxZ: 5.7,
+      },
+    };
+
+    Object.entries(expectedStorageBounds).forEach(([id, expected]) => {
+      const collider = colliders.find((item) => item.furnishingId === id);
+
+      expect(collider).toMatchObject({
+        ...expected,
+        category: 'storage',
+      });
+      expect(collider!.maxX - collider!.minX).toBeGreaterThan(0);
+      expect(collider!.maxZ - collider!.minZ).toBeGreaterThan(0);
+    });
+    expect(
+      new Set(colliders.map(({ category }) => category)).has('storage')
+    ).toBe(true);
+  });
+
+  it('keeps storage colliders within their room bounds and clear of conflicts', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const p4Ids = new Set([
+      'living-room-south-bookcase-west',
+      'living-room-south-open-shelf',
+      'living-room-drawer-console',
+      'studio-north-bookcase-east',
+      'studio-drafting-drawers',
+      'studio-east-dresser',
+    ]);
+    const p2AndP3Categories = new Set(['living-room-seating', 'kitchenette']);
+    const p4Colliders = colliders.filter((collider) =>
+      p4Ids.has(collider.furnishingId)
+    );
+    const p2AndP3Colliders = colliders.filter((collider) =>
+      p2AndP3Categories.has(collider.category)
+    );
+
+    p4Colliders.forEach((collider, index) => {
+      expect(
+        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[collider.roomId], collider)
+      ).toBe(true);
+      p4Colliders.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+      p2AndP3Colliders.forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+      });
+    });
+  });
+
+  it('creates one parent storage collider without child detail colliders', () => {
+    const build = createLowerFloorFurnishings();
+    const storageDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.category === 'storage'
+    );
+    const storageColliders = build.colliders.filter(
+      (collider) => collider.category === 'storage'
+    );
+    const sourceIds = new Set(
+      build.colliders.map((collider) => collider.sourceId)
+    );
+
+    expect(storageColliders).toHaveLength(storageDefinitions.length);
+    expect(sourceIds.size).toBe(build.colliders.length);
+    storageDefinitions.forEach((definition) => {
+      expect(
+        storageColliders.filter(
+          (collider) => collider.furnishingId === definition.id
+        )
+      ).toHaveLength(1);
+    });
   });
 
   it('keeps the media sofa visual inside its authored collider', () => {


### PR DESCRIPTION
### Motivation
- Populate the living room and studio with storage furnishings (bookcases, open shelves, drawer console, drafting drawers, dresser) while preserving existing POIs, P2 seating, P3 kitchen pieces, doorways, and navigation buffers.
- Ensure each storage piece has an exact authored blocking AABB and that visual details are deterministic, low-poly, and contained within the parent footprint.

### Description
- Added six `storage` definitions to `DEFAULT_LOWER_FLOOR_FURNISHINGS` with the requested IDs, room assignments, centers, footprints, orientation, and exact authored `solidBounds` AABBs (file: `src/scene/structures/lowerFloorFurnishings.ts`).
- Implemented `createStorageFurnishing(...)` plus `addBookRows`/`addStorageBoxes` helpers and integrated storage-kind dispatch into `createSolidPrimitive` to produce low-poly book/drawer/box/trim visuals as child geometry (no extra colliders) (file: `src/scene/structures/lowerFloorFurnishings.ts`).
- Expanded `src/tests/lowerFloorFurnishings.test.ts` to assert presence of all six storage IDs, verify their exact AABBs, confirm they remain inside room bounds and clear of P2/P3/reserved blockers, and assert single parent colliders (file: `src/tests/lowerFloorFurnishings.test.ts`).
- Acknowledged the runtime-only nature of these furnishing details by bumping the `decor:lower-floor-furnishings` `syncRevision` and `syncNote` in the miniature registry and regenerating the miniature manifest (files: `src/scene/miniature/sceneComponentRegistry.ts`, `src/scene/miniature/miniatureManifest.generated.json`).

### Testing
- Ran formatting: `npm run format:write` (succeeded for changed files).
- Typecheck: `npm run typecheck` (did not pass; failures are pre-existing, unrelated TypeScript issues outside this change set in other areas of the codebase).
- Targeted tests: `npm run test:ci -- lowerFloorFurnishings` (passed: test file ran 20 tests and succeeded).
- Full test run: initially `npm run test:ci` failed due to a stale miniature manifest after source edits; updated `syncRevision` and regenerated manifest with `npm run miniature:manifest:update` to acknowledge runtime-only detail, then re-ran `npm run test:ci -- lowerFloorFurnishings miniatureManifest` (both passed).
- Build: `npm run build` (succeeded; produced dist with build-size warning only).
- Lint: `npm run lint` (succeeded for repository linting in CI run).
- Docs check: `npm run docs:check` (passed with external link fetch warnings reported).
- Smoke: `npm run smoke` (succeeded).
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).

Files changed (high level):
- Modified: `src/scene/structures/lowerFloorFurnishings.ts` (added definitions, storage visuals, helpers, dispatch).
- Modified: `src/tests/lowerFloorFurnishings.test.ts` (added assertions for storage colliders and conflicts).
- Modified: `src/scene/miniature/sceneComponentRegistry.ts` and regenerated `src/scene/miniature/miniatureManifest.generated.json` (bumped `syncRevision`/note to acknowledge runtime-only furnishing detail).

Residual notes: `npm run typecheck` surfaces pre-existing TypeScript errors unrelated to this change; these were not introduced by this PR and were not modified here. Manual visual review in the immersive scene is recommended to verify book/drawer readability from the default isometric camera.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e58363a0832fa406ac29ce9b38d2)