### PR TITLE
🗄️ : – add lower-floor storage furnishings

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 6,
-      "syncNote": "Kitchenette collision and validation refinements do not add tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.",
-      "sourceFingerprint": "1723ff9c15b26bdec7751d8bb72e93e63beefaf90e8cedf4fe3c9d21e29ff227",
+      "syncRevision": 7,
+      "syncNote": "Storage furnishings add lower-floor detail without tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.",
+      "sourceFingerprint": "13fa7bd3bfd4a4b1cab5bdf7034d04496d1c67cbdd068d3a8adeb2b781ba949f",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "c85e4ba35bea9c5ed0ef1d7c0c1d8cd9dc095ade6b9d7c2ec27a809a592e614e"
+      "metadataFingerprint": "e628ac932aa61d88fd2c82fc91077305cfcc9c5705795e64468407a87a164845"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 7,
-      "syncNote": "Storage furnishings add lower-floor detail without tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.",
-      "sourceFingerprint": "13fa7bd3bfd4a4b1cab5bdf7034d04496d1c67cbdd068d3a8adeb2b781ba949f",
+      "syncRevision": 8,
+      "syncNote": "Storage furnishing visuals stay source-only after shelf detail hardening; furnishing proxy work remains deferred until the full furnishing set lands.",
+      "sourceFingerprint": "e17dcc14a660225f4cb6595ec886dd2db06cf6b7e709764b00d62c04280315fc",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "e628ac932aa61d88fd2c82fc91077305cfcc9c5705795e64468407a87a164845"
+      "metadataFingerprint": "21e762c9de0f1483f75392436096a0111ddd91e05e7ef651c0eb8b0caa24a7b9"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 8,
-      "syncNote": "Storage furnishing visuals stay source-only after shelf detail hardening; furnishing proxy work remains deferred until the full furnishing set lands.",
-      "sourceFingerprint": "e17dcc14a660225f4cb6595ec886dd2db06cf6b7e709764b00d62c04280315fc",
+      "syncRevision": 9,
+      "syncNote": "Storage furnishing visuals stay source-only after drawer-console foot detailing; furnishing proxy work remains deferred until the full furnishing set lands.",
+      "sourceFingerprint": "e5ebfa1c5e4f46611401b3038a62a5172dfda7bcbad2e5fa4b5f0f1aaa6ba04f",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "21e762c9de0f1483f75392436096a0111ddd91e05e7ef651c0eb8b0caa24a7b9"
+      "metadataFingerprint": "bb47a8be819b22feb6afd01adb4ede16da982c286c71ea647a195d86a616823a"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 6,
+    syncRevision: 7,
     reason:
-      'Kitchenette collision and validation refinements do not add tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.',
+      'Storage furnishings add lower-floor detail without tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 7,
+    syncRevision: 8,
     reason:
-      'Storage furnishings add lower-floor detail without tabletop proxy coverage; furnishing proxy work remains deferred until the full furnishing set lands.',
+      'Storage furnishing visuals stay source-only after shelf detail hardening; furnishing proxy work remains deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 8,
+    syncRevision: 9,
     reason:
-      'Storage furnishing visuals stay source-only after shelf detail hardening; furnishing proxy work remains deferred until the full furnishing set lands.',
+      'Storage furnishing visuals stay source-only after drawer-console foot detailing; furnishing proxy work remains deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -1003,6 +1003,7 @@ function createStorageFurnishing(
     if (definition.kind === 'storage-open-shelf') {
       addTinyPlant(
         group,
+        'openShelfTop',
         visualFootprint.width / 2 - 0.45,
         height + 0.16,
         frontZ + 0.05
@@ -1066,20 +1067,27 @@ function addBookRows(
   frontZ: number,
   materials: MeshStandardMaterial[]
 ): void {
-  const rowYs = [height * 0.28, height * 0.54, height * 0.78];
-  rowYs.forEach((y, rowIndex) => {
+  const rowCount = 3;
+  const verticalPadding = 0.14;
+  const availableHeight = Math.max(0.1, height - verticalPadding * 2);
+  const shelfHeight = availableHeight / rowCount;
+  const maxBookHeight = Math.max(0.08, shelfHeight - 0.08);
+
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+    const baselineY = verticalPadding + rowIndex * shelfHeight + 0.04;
     const startX = -width / 2 + 0.35;
     for (let index = 0; index < 12; index += 1) {
-      const bookHeight = 0.22 + ((index + rowIndex) % 4) * 0.055;
+      const preferredHeight = 0.22 + ((index + rowIndex) % 4) * 0.055;
+      const bookHeight = Math.min(preferredHeight, maxBookHeight);
       addBox(
         group,
         `book${rowIndex}-${index}`,
         { width: 0.12, height: bookHeight, depth: 0.12 },
         materials[(index + rowIndex) % materials.length],
-        [startX + index * 0.22, y + bookHeight / 2, frontZ - 0.01]
+        [startX + index * 0.22, baselineY + bookHeight / 2, frontZ - 0.01]
       );
     }
-  });
+  }
 }
 
 function addStorageBins(
@@ -1100,19 +1108,25 @@ function addStorageBins(
   });
 }
 
-function addTinyPlant(group: Group, x: number, y: number, z: number): void {
+function addTinyPlant(
+  group: Group,
+  suffix: string,
+  x: number,
+  y: number,
+  z: number
+): void {
   const potMaterial = createMaterial(0xc28d52);
   const leafMaterial = createMaterial(0x6e8f5f);
   addBox(
     group,
-    'tinyPlantPot',
+    `tinyPlantPot-${suffix}`,
     { width: 0.2, height: 0.16, depth: 0.2 },
     potMaterial,
     [x, y, z]
   );
   addBox(
     group,
-    'tinyPlantLeaves',
+    `tinyPlantLeaves-${suffix}`,
     { width: 0.28, height: 0.18, depth: 0.18 },
     leafMaterial,
     [x, y + 0.16, z]

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -1037,6 +1037,39 @@ function createStorageFurnishing(
         );
       }
     }
+    if (definition.id === 'living-room-drawer-console') {
+      const footInsetX = 0.34;
+      const footInsetZ = 0.18;
+      const footPositions: Array<[number, number]> = [
+        [
+          -visualFootprint.width / 2 + footInsetX,
+          -visualFootprint.depth / 2 + footInsetZ,
+        ],
+        [
+          visualFootprint.width / 2 - footInsetX,
+          -visualFootprint.depth / 2 + footInsetZ,
+        ],
+        [
+          -visualFootprint.width / 2 + footInsetX,
+          visualFootprint.depth / 2 - footInsetZ,
+        ],
+        [
+          visualFootprint.width / 2 - footInsetX,
+          visualFootprint.depth / 2 - footInsetZ,
+        ],
+      ];
+
+      footPositions.forEach(([x, z], index) => {
+        addBox(
+          group,
+          `drawerConsoleFoot${index}`,
+          { width: 0.16, height: 0.16, depth: 0.16 },
+          darkMaterial,
+          [x, 0.08, z]
+        );
+      });
+    }
+
     addBox(
       group,
       'topTray',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -283,6 +283,73 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'kitchen-trash-drawer',
       visual: { color: 0x586575, accentColor: 0x8fd0a6, height: 0.82 },
     },
+
+    {
+      id: 'living-room-south-bookcase-west',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -24.0, z: -31.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.75 },
+      solidBounds: { minX: -26.4, maxX: -21.6, minZ: -31.575, maxZ: -30.825 },
+      kind: 'storage-bookcase',
+      visual: { color: 0x4f3828, accentColor: 0xb88a52, height: 1.35 },
+    },
+    {
+      id: 'living-room-south-open-shelf',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -15.5, z: -31.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.5, depth: 0.75 },
+      solidBounds: { minX: -17.75, maxX: -13.25, minZ: -31.575, maxZ: -30.825 },
+      kind: 'storage-open-shelf',
+      visual: { color: 0x5c4a3c, accentColor: 0x7c91a5, height: 1.18 },
+    },
+    {
+      id: 'living-room-drawer-console',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: -2.5, z: -31.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.0, depth: 0.8 },
+      solidBounds: { minX: -4.5, maxX: -0.5, minZ: -31.5, maxZ: -30.7 },
+      kind: 'storage-drawer-console',
+      visual: { color: 0x4b5563, accentColor: 0xc4955a, height: 0.82 },
+    },
+    {
+      id: 'studio-north-bookcase-east',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 26.6, z: 15.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.8 },
+      solidBounds: { minX: 24.2, maxX: 29.0, minZ: 14.7, maxZ: 15.5 },
+      kind: 'storage-tall-bookcase',
+      visual: { color: 0x3f4a56, accentColor: 0xa66f43, height: 2.15 },
+    },
+    {
+      id: 'studio-drafting-drawers',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 5.8, z: 14.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 4.8, depth: 0.8 },
+      solidBounds: { minX: 3.4, maxX: 8.2, minZ: 14.5, maxZ: 15.3 },
+      kind: 'storage-drafting-drawers',
+      visual: { color: 0x56616f, accentColor: 0xd8ccb8, height: 0.78 },
+    },
+    {
+      id: 'studio-east-dresser',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 31.0, z: 4.1 },
+      orientationRadians: Math.PI / 2,
+      solidFootprint: { width: 1.0, depth: 3.2 },
+      solidBounds: { minX: 30.5, maxX: 31.5, minZ: 2.5, maxZ: 5.7 },
+      kind: 'storage-east-dresser',
+      visual: { color: 0x4d3a2b, accentColor: 0xb8c0c8, height: 1.05 },
+    },
     {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
@@ -481,6 +548,8 @@ function createSolidPrimitive(
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
   if (definition.kind.startsWith('kitchen-'))
     return createKitchenFurnishing(definition);
+  if (definition.kind.startsWith('storage-'))
+    return createStorageFurnishing(definition);
 
   const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
   const height = definition.visual?.height ?? 0.8;
@@ -848,6 +917,206 @@ function createKitchenFurnishing(
   }
 
   return group;
+}
+
+function createStorageFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
+  const isQuarterTurn =
+    Math.abs(Math.sin(definition.orientationRadians)) >
+    Math.abs(Math.cos(definition.orientationRadians));
+  const visualFootprint = isQuarterTurn
+    ? { width: footprint.depth, depth: footprint.width }
+    : footprint;
+  const height = definition.visual?.height ?? 1.1;
+  const bodyMaterial = createMaterial(definition.visual?.color ?? 0x4f4237);
+  const accentMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xb88a52
+  );
+  const darkMaterial = createMaterial(0x252321);
+  const bookMaterials = [
+    createMaterial(0x8b4d42),
+    createMaterial(0x3f6f86),
+    createMaterial(0xc29249),
+    createMaterial(0x6e7d55),
+    createMaterial(0x7d5f8a),
+  ];
+  const group = new Group();
+
+  addBox(
+    group,
+    'storageBody',
+    { width: visualFootprint.width, height, depth: visualFootprint.depth },
+    bodyMaterial,
+    [0, height / 2, 0]
+  );
+
+  const frontZ = -visualFootprint.depth / 2 + 0.04;
+  addBox(
+    group,
+    'topTrim',
+    { width: visualFootprint.width - 0.08, height: 0.08, depth: 0.08 },
+    accentMaterial,
+    [0, height + 0.04, frontZ + 0.03]
+  );
+  addBox(
+    group,
+    'toeKick',
+    { width: visualFootprint.width - 0.3, height: 0.1, depth: 0.08 },
+    darkMaterial,
+    [0, 0.05, frontZ + 0.03]
+  );
+
+  if (
+    definition.kind.includes('bookcase') ||
+    definition.kind.includes('shelf')
+  ) {
+    const shelfCount = definition.kind === 'storage-tall-bookcase' ? 4 : 3;
+    for (let shelf = 1; shelf < shelfCount; shelf += 1) {
+      const y = (height / shelfCount) * shelf;
+      addBox(
+        group,
+        `shelfDivider${shelf}`,
+        { width: visualFootprint.width - 0.18, height: 0.055, depth: 0.12 },
+        accentMaterial,
+        [0, y, frontZ + 0.04]
+      );
+    }
+    [-1, 0, 1].forEach((ratio, index) => {
+      addBox(
+        group,
+        `verticalDivider${index}`,
+        { width: 0.06, height: height - 0.12, depth: 0.12 },
+        accentMaterial,
+        [(visualFootprint.width / 4) * ratio, height / 2, frontZ + 0.04]
+      );
+    });
+    addBookRows(group, visualFootprint.width, height, frontZ, bookMaterials);
+    addStorageBins(
+      group,
+      visualFootprint.width,
+      height,
+      frontZ,
+      accentMaterial
+    );
+    if (definition.kind === 'storage-open-shelf') {
+      addTinyPlant(
+        group,
+        visualFootprint.width / 2 - 0.45,
+        height + 0.16,
+        frontZ + 0.05
+      );
+    }
+  } else {
+    const rows = definition.kind === 'storage-drafting-drawers' ? 5 : 3;
+    const columns = definition.kind === 'storage-east-dresser' ? 2 : 4;
+    for (let row = 0; row < rows; row += 1) {
+      for (let column = 0; column < columns; column += 1) {
+        const drawerWidth = (visualFootprint.width - 0.28) / columns;
+        const x =
+          -visualFootprint.width / 2 +
+          0.14 +
+          drawerWidth / 2 +
+          column * drawerWidth;
+        const y = 0.22 + row * ((height - 0.28) / rows);
+        addBox(
+          group,
+          `drawerFront${row}-${column}`,
+          { width: drawerWidth - 0.05, height: 0.035, depth: 0.04 },
+          accentMaterial,
+          [x, y, frontZ]
+        );
+        addBox(
+          group,
+          `drawerPull${row}-${column}`,
+          { width: drawerWidth * 0.42, height: 0.035, depth: 0.035 },
+          darkMaterial,
+          [x, y + 0.04, frontZ]
+        );
+      }
+    }
+    addBox(
+      group,
+      'topTray',
+      {
+        width: Math.min(0.72, visualFootprint.width * 0.22),
+        height: 0.08,
+        depth: 0.28,
+      },
+      accentMaterial,
+      [-visualFootprint.width / 2 + 0.55, height + 0.08, 0]
+    );
+    addBox(
+      group,
+      'smallVase',
+      { width: 0.18, height: 0.24, depth: 0.18 },
+      bookMaterials[1],
+      [visualFootprint.width / 2 - 0.52, height + 0.12, 0]
+    );
+  }
+
+  return group;
+}
+
+function addBookRows(
+  group: Group,
+  width: number,
+  height: number,
+  frontZ: number,
+  materials: MeshStandardMaterial[]
+): void {
+  const rowYs = [height * 0.28, height * 0.54, height * 0.78];
+  rowYs.forEach((y, rowIndex) => {
+    const startX = -width / 2 + 0.35;
+    for (let index = 0; index < 12; index += 1) {
+      const bookHeight = 0.22 + ((index + rowIndex) % 4) * 0.055;
+      addBox(
+        group,
+        `book${rowIndex}-${index}`,
+        { width: 0.12, height: bookHeight, depth: 0.12 },
+        materials[(index + rowIndex) % materials.length],
+        [startX + index * 0.22, y + bookHeight / 2, frontZ - 0.01]
+      );
+    }
+  });
+}
+
+function addStorageBins(
+  group: Group,
+  width: number,
+  height: number,
+  frontZ: number,
+  material: MeshStandardMaterial
+): void {
+  [-0.32, 0.34].forEach((ratio, index) => {
+    addBox(
+      group,
+      `storageBin${index}`,
+      { width: 0.58, height: 0.24, depth: 0.18 },
+      material,
+      [width * ratio, height * 0.18, frontZ - 0.02]
+    );
+  });
+}
+
+function addTinyPlant(group: Group, x: number, y: number, z: number): void {
+  const potMaterial = createMaterial(0xc28d52);
+  const leafMaterial = createMaterial(0x6e8f5f);
+  addBox(
+    group,
+    'tinyPlantPot',
+    { width: 0.2, height: 0.16, depth: 0.2 },
+    potMaterial,
+    [x, y, z]
+  );
+  addBox(
+    group,
+    'tinyPlantLeaves',
+    { width: 0.28, height: 0.18, depth: 0.18 },
+    leafMaterial,
+    [x, y + 0.16, z]
+  );
 }
 
 function createMaterial(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -171,7 +171,7 @@ describe('lower floor furnishings foundation', () => {
     const storageColliders = colliders.filter(
       (collider) => collider.category === 'storage'
     );
-    const p2AndP3Colliders = colliders.filter((collider) =>
+    const seatingAndKitchenColliders = colliders.filter((collider) =>
       ['living-room-seating', 'kitchenette'].includes(collider.category)
     );
 
@@ -182,7 +182,7 @@ describe('lower floor furnishings foundation', () => {
       storageColliders.slice(index + 1).forEach((otherStorage) => {
         expect(rectanglesOverlap(storage, otherStorage)).toBe(false);
       });
-      p2AndP3Colliders.forEach((other) => {
+      seatingAndKitchenColliders.forEach((other) => {
         expect(rectanglesOverlap(storage, other)).toBe(false);
       });
       LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -203,6 +203,28 @@ describe('lower floor furnishings foundation', () => {
     });
   });
 
+  it('adds named foot meshes to the living-room drawer console visual', () => {
+    const { group } = createLowerFloorFurnishings();
+    const drawerConsole = group.children.find(
+      (child) => child.name === 'Furnishing:living-room-drawer-console'
+    );
+    const footMeshNames: string[] = [];
+
+    expect(drawerConsole).toBeDefined();
+    drawerConsole!.traverse((child) => {
+      if (child.name.startsWith('FurnishingPart:drawerConsoleFoot')) {
+        footMeshNames.push(child.name);
+      }
+    });
+
+    expect(footMeshNames.sort()).toEqual([
+      'FurnishingPart:drawerConsoleFoot0',
+      'FurnishingPart:drawerConsoleFoot1',
+      'FurnishingPart:drawerConsoleFoot2',
+      'FurnishingPart:drawerConsoleFoot3',
+    ]);
+  });
+
   it('does not create extra colliders for storage visual details', () => {
     const { colliders } = createLowerFloorFurnishings();
     const storageDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,7 +76,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(14);
+    expect(build.colliders).toHaveLength(20);
     expect(build.decorativeFootprints).toHaveLength(1);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -93,8 +93,134 @@ describe('lower floor furnishings foundation', () => {
       'kitchen-bar-stool-west',
       'kitchen-bar-stool-east',
       'kitchen-trash-drawer',
+      'living-room-south-bookcase-west',
+      'living-room-south-open-shelf',
+      'living-room-drawer-console',
+      'studio-north-bookcase-east',
+      'studio-drafting-drawers',
+      'studio-east-dresser',
       'living-room-media-rug',
     ]);
+  });
+
+  it('adds the requested lower-floor storage AABBs with one collider each', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const expectedStorageBounds: Record<string, RectCollider> = {
+      'living-room-south-bookcase-west': {
+        minX: -26.4,
+        maxX: -21.6,
+        minZ: -31.575,
+        maxZ: -30.825,
+      },
+      'living-room-south-open-shelf': {
+        minX: -17.75,
+        maxX: -13.25,
+        minZ: -31.575,
+        maxZ: -30.825,
+      },
+      'living-room-drawer-console': {
+        minX: -4.5,
+        maxX: -0.5,
+        minZ: -31.5,
+        maxZ: -30.7,
+      },
+      'studio-north-bookcase-east': {
+        minX: 24.2,
+        maxX: 29.0,
+        minZ: 14.7,
+        maxZ: 15.5,
+      },
+      'studio-drafting-drawers': {
+        minX: 3.4,
+        maxX: 8.2,
+        minZ: 14.5,
+        maxZ: 15.3,
+      },
+      'studio-east-dresser': {
+        minX: 30.5,
+        maxX: 31.5,
+        minZ: 2.5,
+        maxZ: 5.7,
+      },
+    };
+
+    expect(
+      new Set(colliders.map(({ category }) => category)).has('storage')
+    ).toBe(true);
+
+    Object.entries(expectedStorageBounds).forEach(([id, expected]) => {
+      const matchingColliders = colliders.filter(
+        (collider) => collider.furnishingId === id
+      );
+      expect(matchingColliders).toHaveLength(1);
+      expect(matchingColliders[0]).toMatchObject({
+        ...expected,
+        category: 'storage',
+      });
+      expect(
+        matchingColliders[0].maxX - matchingColliders[0].minX
+      ).toBeGreaterThan(0);
+      expect(
+        matchingColliders[0].maxZ - matchingColliders[0].minZ
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  it('keeps storage colliders in room bounds and away from solids and blockers', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const storageColliders = colliders.filter(
+      (collider) => collider.category === 'storage'
+    );
+    const p2AndP3Colliders = colliders.filter((collider) =>
+      ['living-room-seating', 'kitchenette'].includes(collider.category)
+    );
+
+    storageColliders.forEach((storage, index) => {
+      expect(
+        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[storage.roomId], storage)
+      ).toBe(true);
+      storageColliders.slice(index + 1).forEach((otherStorage) => {
+        expect(rectanglesOverlap(storage, otherStorage)).toBe(false);
+      });
+      p2AndP3Colliders.forEach((other) => {
+        expect(rectanglesOverlap(storage, other)).toBe(false);
+      });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(storage, blocker)).toBe(false);
+      });
+    });
+  });
+
+  it('keeps collider source IDs valid and unique for the default plan', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const sourceIds = colliders.map((collider) => collider.sourceId);
+
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    colliders.forEach((collider) => {
+      expect(collider.sourceId).toBe(
+        `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
+      );
+    });
+  });
+
+  it('does not create extra colliders for storage visual details', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const storageDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.category === 'storage'
+    );
+    const storageColliders = colliders.filter(
+      (collider) => collider.category === 'storage'
+    );
+
+    expect(storageColliders).toHaveLength(storageDefinitions.length);
+    storageDefinitions.forEach((definition) => {
+      expect(definition.solidFootprint).toBeDefined();
+      expect(
+        storageColliders.filter(
+          ({ furnishingId }) => furnishingId === definition.id
+        )
+      ).toHaveLength(1);
+    });
   });
 
   it('uses the requested kitchen kitchenette and dining AABBs', () => {


### PR DESCRIPTION
### Motivation
- Add the P4 storage pass to the existing lower-floor furnishings plan so the living room and studio have bookshelves, shelves, dressers/drawers, and consoles with authored colliders and readable visual detail.

### Description
- Added six storage furnishing definitions to `DEFAULT_LOWER_FLOOR_FURNISHINGS` with the exact centers, footprints, and authored AABBs for the living room and studio in `src/scene/structures/lowerFloorFurnishings.ts`.
- Implemented `createStorageFurnishing(...)` and helper visuals (`addBookRows`, `addStorageBins`, `addTinyPlant`) to produce low-poly books, shelf dividers, drawer fronts/pulls, bins, trim, and small decor without creating additional blocking colliders.
- Wired storage kinds into the existing `createSolidPrimitive(...)` flow so visuals reuse materials/geometry conventions and honor rotated footprints.
- Extended `src/tests/lowerFloorFurnishings.test.ts` to assert presence of all six storage IDs, exact positive-area AABBs, one collider per storage item, room containment, non-overlap with P2/P3/reserved blockers, valid unique collider `sourceId`s, and that child visual details do not create extra colliders.
- Updated miniature bookkeeping to acknowledge the source-only change by bumping `decor:lower-floor-furnishings` `syncRevision` and updating the generated manifest (`src/scene/miniature/sceneComponentRegistry.ts` and `src/scene/miniature/miniatureManifest.generated.json`).

### Testing
- Ran formatting: `npm run format:write` (passed).
- Lint: `npm run lint` (passed).
- Focused unit tests: `npm run test:ci -- lowerFloorFurnishings` (passed; suite containing the new storage assertions returned all passing tests).
- Miniature manifest tests: after updating the registry, `npm run test:ci -- miniatureManifest lowerFloorFurnishings` (passed).
- Build: `npm run build` (passed) and `npm run smoke` (passed).
- Docs check: `npm run docs:check` (passed; link checker reported external fetch warnings only).
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` (passed; no high-risk secrets).
- Typecheck: `npm run typecheck` (did not pass due to pre-existing unrelated TypeScript errors outside this change set; these are known and not caused by this PR).

All tests relevant to the storage pass (furnishing tests, miniature manifest acknowledgement, build, and smoke checks) passed after the manifest update; unrelated pre-existing type errors remain in the repo and were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e58e3c98832f91c65ce0b27c2360)