### PR TITLE
🪽 : – Refresh upstairs POI geometry

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -524,7 +524,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -544,7 +544,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "3dafe605d375241fb47f921bc9845cbf35dbe00e24958d04cbc948dbf548828c",
+      "proxyFingerprint": "e1c4991d123e6dc80fae5d7f89e05c8907e27334fba9e72d03ba774817513e6f",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -559,7 +559,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -571,11 +571,11 @@
         "src/scene/structures/f2ClipboardConsole.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "2f1e8a7fc3deaa111e16e6a03013527965119b92d97b09f1b78648b577b36584",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "d26b6a4ba77b15fc7de9913416e8e1774991bdfec8c0a49076feaf91359841eb"
+      "syncRevision": 6,
+      "syncNote": "Adds selected file cards flowing into the clipboard to mirror the console refresh.",
+      "sourceFingerprint": "3c5bf25cbf43df6b5cceb9f21d97e0f5f588c785951d3de2c4706a38165c429f",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
+      "metadataFingerprint": "351e0d2da7e140e46ad1ac3c395ff33c920205b4d0f90acab0df6351031a8bdf"
     },
     {
       "id": "poi:flywheel-studio-flywheel",
@@ -591,7 +591,7 @@
       "syncRevision": 26,
       "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
       "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
     },
     {
@@ -606,7 +606,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -618,11 +618,11 @@
         "src/scene/structures/gabrielSentry.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "bf8dc4d58f614431c0731f4de2fdaed1f971a42de96daac7e20bc190462915a2",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "3e4b8bcbebde225bf212394ecc8ad0e4a5e6681aba55b39cfc355ee27e8d971b"
+      "syncRevision": 6,
+      "syncNote": "Adds guardian-angel halo, wings, and shield cues to match the upstairs sentry refresh.",
+      "sourceFingerprint": "4095dfbc49f659d368390c5774773bd04768bbd84d9aed1f2f8f7cdead1abb86",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
+      "metadataFingerprint": "63d2e5ba6382af592faa2a49d95ea41cce124ac4c6e39fd0492efd86c48dd0e6"
     },
     {
       "id": "poi:gitshelves-living-room-installation",
@@ -633,11 +633,11 @@
         "src/scene/structures/gitshelves.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "4436803d33b425c66c24c5c9ce6f34ce6d67d5787d64b0230a0386b6de1c669b",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "4fdf722cfeb551ce21463442ffcd4924a18671b22b3ef31dd3d105d032203967"
+      "syncRevision": 6,
+      "syncNote": "Adds Gridfinity contribution blocks to match the physical GitHub shelf refresh.",
+      "sourceFingerprint": "07dbeadc2839f0fd2ae41478edada42f839cbce733cf4c6382ecd3e2e15b6960",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
+      "metadataFingerprint": "224ca0246e5c10d504c71965d3681dfd1bf1b38f34fcffe9f81544c4c709176f"
     },
     {
       "id": "poi:jobbot-studio-terminal",
@@ -651,7 +651,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -686,7 +686,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -698,11 +698,11 @@
         "src/scene/structures/sigmaWorkbench.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "d6696b8379112b6fe19fe420102d841a1ddcbe747713c2175452aec94fb26ba0",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "bad6d659009fad48a9ffdf335cbcb3aa993925cc575da14a599d2a05f6b35380"
+      "syncRevision": 6,
+      "syncNote": "Replaces lab-only cues with the physical ESP32 AI pin enclosure and lanyard.",
+      "sourceFingerprint": "3b486649420f8092db0a73066003ee1141ca8f6e3df5294812222653225b55f5",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
+      "metadataFingerprint": "3b3cd40b856ce1e6777cc8d843552ac1dc2fc3a65492c7394acc8edca62f069a"
     },
     {
       "id": "poi:sugarkube-backyard-greenhouse",
@@ -716,7 +716,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -731,7 +731,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -746,7 +746,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bc1672a6b38aadaa073e6d80836583064df2da08e7b745bc141ef8a24e15c119",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -348,9 +348,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gabriel-studio-sentry',
     id: 'poi:gabriel-studio-sentry',
     displayName: 'Gabriel sentry proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Adds guardian-angel halo, wings, and shield cues to match the upstairs sentry refresh.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gabrielSentry.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -358,21 +358,54 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
       cyl('gabriel-core', 0.28, 0.9, [0, 0.55, 0], 0x334155),
       sphere('gabriel-sensor-eye', 0.24, [0, 1.08, 0], 0x60a5fa),
       box('gabriel-shield', [0.85, 0.2, 0.12], [0, 0.55, -0.38], 0x93c5fd),
+      {
+        kind: 'ring',
+        name: 'gabriel-guardian-halo',
+        radius: 0.28,
+        tube: 0.025,
+        position: [0, 1.46, 0],
+        rotation: [Math.PI / 2, 0, 0],
+        color: 0xffd166,
+      },
+      box(
+        'gabriel-left-wing',
+        [0.16, 0.56, 0.06],
+        [-0.44, 0.86, 0.05],
+        0xdbeafe
+      ),
+      box(
+        'gabriel-right-wing',
+        [0.16, 0.56, 0.06],
+        [0.44, 0.86, 0.05],
+        0xdbeafe
+      ),
     ],
   },
   'f2clipboard-kitchen-console': {
     poiId: 'f2clipboard-kitchen-console',
     id: 'poi:f2clipboard-kitchen-console',
     displayName: 'f2clipboard console proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Adds selected file cards flowing into the clipboard to mirror the console refresh.',
     sourceFiles: [...baseFiles, 'src/scene/structures/f2ClipboardConsole.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
       box('f2-console', [1.1, 0.5, 0.55], [0, 0.25, 0], 0x475569),
       box('f2-clipboard-screen', [0.5, 0.7, 0.06], [0, 0.78, -0.16], 0xf8fafc),
       box('f2-clip', [0.22, 0.08, 0.08], [0, 1.16, -0.2], 0xfbbf24),
+      box(
+        'f2-selected-file-a',
+        [0.28, 0.38, 0.03],
+        [-0.38, 0.82, 0.1],
+        0xe0f2fe
+      ),
+      box(
+        'f2-selected-file-b',
+        [0.28, 0.38, 0.03],
+        [-0.16, 0.9, 0.16],
+        0xbae6fd
+      ),
     ],
   },
   'axel-studio-tracker': {
@@ -402,24 +435,38 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sigma-kitchen-workbench',
     id: 'poi:sigma-kitchen-workbench',
     displayName: 'Sigma workbench proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Replaces lab-only cues with the physical ESP32 AI pin enclosure and lanyard.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sigmaWorkbench.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
       box('sigma-workbench', [1.15, 0.18, 0.7], [0, 0.45, 0], 0x854d0e),
-      cyl('sigma-flask', 0.13, 0.42, [-0.28, 0.72, 0], 0xa78bfa),
-      sphere('sigma-orbital-sample', 0.16, [0.28, 0.72, 0.06], 0x14b8a6),
+      box(
+        'sigma-wearable-enclosure',
+        [0.38, 0.56, 0.1],
+        [0, 0.82, 0],
+        0xf8fafc
+      ),
+      cyl('sigma-talk-button', 0.1, 0.05, [0, 0.86, -0.08], 0x14b8a6),
+      {
+        kind: 'ring',
+        name: 'sigma-lanyard-loop',
+        radius: 0.24,
+        tube: 0.018,
+        position: [0, 1.12, 0],
+        rotation: [Math.PI / 2, 0, 0],
+        color: 0x334155,
+      },
     ],
   },
   'gitshelves-living-room-installation': {
     poiId: 'gitshelves-living-room-installation',
     id: 'poi:gitshelves-living-room-installation',
     displayName: 'Gitshelves proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Adds Gridfinity contribution blocks to match the physical GitHub shelf refresh.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gitshelves.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -427,6 +474,24 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
       box('gitshelves-shelf-top', [1.2, 0.06, 0.2], [0, 0.82, 0], 0xf59e0b),
       box('gitshelves-shelf-middle', [1.2, 0.06, 0.2], [0, 0.56, 0], 0xf59e0b),
       box('gitshelves-repo-books', [0.85, 0.22, 0.16], [0, 0.68, 0], 0x38bdf8),
+      box(
+        'gitshelves-gridfinity-a',
+        [0.26, 0.16, 0.26],
+        [-0.36, 0.28, 0.18],
+        0x22d3ee
+      ),
+      box(
+        'gitshelves-gridfinity-b',
+        [0.26, 0.24, 0.26],
+        [0, 0.32, 0.18],
+        0x38bdf8
+      ),
+      box(
+        'gitshelves-gridfinity-c',
+        [0.26, 0.32, 0.26],
+        [0.36, 0.36, 0.18],
+        0x0ea5e9
+      ),
     ],
   },
   'wove-kitchen-loom': {

--- a/src/scene/structures/f2ClipboardConsole.ts
+++ b/src/scene/structures/f2ClipboardConsole.ts
@@ -216,6 +216,43 @@ export function createF2ClipboardConsole(
   clip.position.set(0, 0.56, 0.02);
   clipboardPivot.add(clip);
 
+  const fileCardMaterial = new MeshStandardMaterial({
+    color: new Color(0xe8f6ff),
+    emissive: new Color(0x4dbdff),
+    emissiveIntensity: 0.14,
+    roughness: 0.36,
+    metalness: 0.04,
+  });
+  const fileLineMaterial = new MeshStandardMaterial({
+    color: new Color(0x39a8ff),
+    emissive: new Color(0x39a8ff),
+    emissiveIntensity: 0.36,
+    roughness: 0.28,
+    metalness: 0.08,
+  });
+  for (let index = 0; index < 4; index += 1) {
+    const fileCard = new Mesh(
+      new BoxGeometry(0.32, 0.42, 0.015),
+      fileCardMaterial.clone()
+    );
+    fileCard.name = `F2ClipboardSelectedFileCard-${index}`;
+    fileCard.position.set(
+      -deckWidth * 0.3 + index * 0.18,
+      deckHeight + 0.34 + index * 0.04,
+      -deckDepth * 0.18 + index * 0.06
+    );
+    fileCard.rotation.set(-Math.PI * 0.08, Math.PI * 0.08, -Math.PI * 0.04);
+    group.add(fileCard);
+
+    const fileLine = new Mesh(
+      new BoxGeometry(0.2, 0.018, 0.018),
+      fileLineMaterial.clone()
+    );
+    fileLine.name = `F2ClipboardSelectedFileLine-${index}`;
+    fileLine.position.set(0, 0.06, 0.016);
+    fileCard.add(fileLine);
+  }
+
   const calloutGlowGeometry = new PlaneGeometry(0.42, 0.36);
   const calloutGlowMaterial = new MeshBasicMaterial({
     color: new Color(0x52d0ff),

--- a/src/scene/structures/gabrielSentry.ts
+++ b/src/scene/structures/gabrielSentry.ts
@@ -7,6 +7,7 @@ import {
   Mesh,
   MeshStandardMaterial,
   PointLight,
+  PlaneGeometry,
   SphereGeometry,
   TorusGeometry,
   Vector3,
@@ -173,6 +174,58 @@ export function createGabrielSentry(
   shield.position.set(0, 0.32, 0);
   core.add(shield);
 
+  const haloMaterial = new MeshStandardMaterial({
+    color: new Color(0xfff0a6),
+    emissive: new Color(0xffc94d),
+    emissiveIntensity: 0.7,
+    roughness: 0.24,
+    metalness: 0.5,
+  });
+  const halo = new Mesh(new TorusGeometry(0.38, 0.035, 12, 48), haloMaterial);
+  halo.name = 'GabrielSentryGuardianHalo';
+  halo.rotation.x = Math.PI / 2;
+  halo.position.y = 0.72;
+  headGroup.add(halo);
+
+  const wingMaterial = new MeshStandardMaterial({
+    color: new Color(0xd9ecff),
+    emissive: new Color(0x5aa8ff),
+    emissiveIntensity: 0.2,
+    roughness: 0.4,
+    metalness: 0.08,
+    transparent: true,
+    opacity: 0.78,
+  });
+  const wingGeometry = new PlaneGeometry(0.58, 0.9);
+  const leftWing = new Mesh(wingGeometry, wingMaterial);
+  leftWing.name = 'GabrielSentryLeftGuardianWing';
+  leftWing.position.set(-0.54, core.position.y + 0.22, 0.08);
+  leftWing.rotation.set(0.18, -0.4, 0.48);
+  group.add(leftWing);
+
+  const rightWing = new Mesh(wingGeometry, wingMaterial.clone());
+  rightWing.name = 'GabrielSentryRightGuardianWing';
+  rightWing.position.set(0.54, core.position.y + 0.22, 0.08);
+  rightWing.rotation.set(0.18, 0.4, -0.48);
+  group.add(rightWing);
+
+  const privacyPaneMaterial = new MeshStandardMaterial({
+    color: new Color(0x5fb7ff),
+    emissive: new Color(0x2b82ff),
+    emissiveIntensity: 0.36,
+    roughness: 0.18,
+    metalness: 0.12,
+    transparent: true,
+    opacity: 0.34,
+  });
+  const privacyPane = new Mesh(
+    new BoxGeometry(1.22, 0.78, 0.04),
+    privacyPaneMaterial
+  );
+  privacyPane.name = 'GabrielSentryPrivacyShieldPane';
+  privacyPane.position.set(0, core.position.y + 0.04, -0.56);
+  group.add(privacyPane);
+
   const update = ({
     elapsed,
     emphasis,
@@ -200,6 +253,13 @@ export function createGabrielSentry(
       emphasis + pulse * 0.6
     );
     ringMaterial.emissiveIntensity = MathUtils.lerp(0.35, 0.85, emphasis);
+    haloMaterial.emissiveIntensity = MathUtils.lerp(0.7, 1.35, emphasis);
+    wingMaterial.emissiveIntensity = MathUtils.lerp(0.2, 0.72, emphasis);
+    (rightWing.material as MeshStandardMaterial).emissiveIntensity =
+      wingMaterial.emissiveIntensity;
+    privacyPaneMaterial.opacity = MathUtils.lerp(0.34, 0.62, emphasis);
+    leftWing.rotation.z = 0.48 + Math.sin(elapsed * 1.6) * 0.05 * emphasis;
+    rightWing.rotation.z = -0.48 - Math.sin(elapsed * 1.6) * 0.05 * emphasis;
   };
 
   const colliderCenter = new Vector3(basePosition.x, 0, basePosition.z);

--- a/src/scene/structures/gitshelves.ts
+++ b/src/scene/structures/gitshelves.ts
@@ -360,6 +360,45 @@ export function createGitshelvesInstallation(
     }
   }
 
+  const gridfinityBaseMaterial = new MeshStandardMaterial({
+    color: new Color(0x263247),
+    roughness: 0.5,
+    metalness: 0.2,
+  });
+  const gridfinityLabelMaterial = new MeshStandardMaterial({
+    color: new Color(0x66e7ff),
+    emissive: new Color(0x2bbdff),
+    emissiveIntensity: 0.42,
+    roughness: 0.24,
+    metalness: 0.28,
+  });
+  for (let index = 0; index < 3; index += 1) {
+    const block = new Mesh(
+      new BoxGeometry(0.48, 0.18 + index * 0.08, 0.48),
+      gridfinityBaseMaterial.clone()
+    );
+    block.name = `GitshelvesGridfinityRepoBlock-${index}`;
+    block.position.set(
+      -0.62 + index * 0.62,
+      baseHeight + block.geometry.parameters.height / 2 + 0.05,
+      0.18
+    );
+    block.castShadow = true;
+    group.add(block);
+
+    const contributionCap = new Mesh(
+      new BoxGeometry(0.32, 0.035, 0.32),
+      gridfinityLabelMaterial.clone()
+    );
+    contributionCap.name = `GitshelvesContributionGraphCap-${index}`;
+    contributionCap.position.set(
+      0,
+      block.geometry.parameters.height / 2 + 0.02,
+      0
+    );
+    block.add(contributionCap);
+  }
+
   const spotlightMaterial = new MeshStandardMaterial({
     color: new Color(0x1c3048),
     emissive: new Color(0x2cb2ff),

--- a/src/scene/structures/sigmaWorkbench.ts
+++ b/src/scene/structures/sigmaWorkbench.ts
@@ -195,6 +195,55 @@ export function createSigmaWorkbench(
   pinCore.position.set(0, pinBase.position.y + 0.19, 0);
   group.add(pinCore);
 
+  const enclosureMaterial = new MeshStandardMaterial({
+    color: new Color(0xf5f7fb),
+    roughness: 0.34,
+    metalness: 0.06,
+  });
+  const enclosure = new Mesh(
+    new BoxGeometry(0.46, 0.64, 0.12),
+    enclosureMaterial
+  );
+  enclosure.name = 'SigmaWorkbenchWearableEnclosure';
+  enclosure.position.set(0, workSurface.position.y + 0.38, 0.02);
+  enclosure.rotation.x = -Math.PI * 0.06;
+  group.add(enclosure);
+
+  const micMaterial = new MeshStandardMaterial({
+    color: new Color(0x111827),
+    roughness: 0.5,
+    metalness: 0.18,
+  });
+  for (let index = 0; index < 5; index += 1) {
+    const micHole = new Mesh(
+      new CylinderGeometry(0.018, 0.018, 0.012, 12),
+      micMaterial
+    );
+    micHole.name = `SigmaWorkbenchMicrophonePort-${index}`;
+    micHole.rotation.x = Math.PI / 2;
+    micHole.position.set(
+      (index - 2) * 0.07,
+      enclosure.position.y - 0.16,
+      enclosure.position.z - 0.07
+    );
+    group.add(micHole);
+  }
+
+  const lanyardMaterial = new MeshStandardMaterial({
+    color: new Color(0x243244),
+    roughness: 0.48,
+    metalness: 0.14,
+  });
+  const lanyard = new Mesh(
+    new TorusGeometry(0.28, 0.018, 12, 64),
+    lanyardMaterial
+  );
+  lanyard.name = 'SigmaWorkbenchWearableLanyardLoop';
+  lanyard.scale.set(0.72, 1, 0.18);
+  lanyard.rotation.x = Math.PI / 2;
+  lanyard.position.set(0, enclosure.position.y + 0.3, enclosure.position.z);
+  group.add(lanyard);
+
   const pinHaloMaterial = new MeshBasicMaterial({
     color: new Color(0x76fff8),
     transparent: true,
@@ -359,6 +408,7 @@ export function createSigmaWorkbench(
       targetPinIntensity,
       smoothing
     );
+    enclosure.rotation.z = Math.sin(elapsed * 1.5) * 0.025 * clampedEmphasis;
 
     pinHaloMaterial.opacity = MathUtils.lerp(
       pinHaloMaterial.opacity,


### PR DESCRIPTION
### Motivation
- Upstairs POIs were visually inconsistent and did not clearly represent their source repositories or physical footprints. 
- Update the upper-floor POI geometry so they read as physically plausible, repository-representative exhibits and keep miniature/proxy geometry in sync.

### Description
- Gabriel sentry: added guardian-angel halo, translucent wings, and a privacy shield pane inside `src/scene/structures/gabrielSentry.ts` and updated its miniature proxy entry. 
- f2clipboard console: added selected-file cards and accent lines in `src/scene/structures/f2ClipboardConsole.ts` and updated its miniature proxy entry. 
- Sigma workbench: added a wearable ESP32 AI pin enclosure, mic ports, and a lanyard loop in `src/scene/structures/sigmaWorkbench.ts` and updated its miniature proxy entry. 
- Gitshelves: added Gridfinity-style contribution blocks in `src/scene/structures/gitshelves.ts`, bumped proxy revisions in `src/scene/miniature/poiProxyRegistry.ts`, and regenerated `src/scene/miniature/miniatureManifest.generated.json` so tabletop proxies match runtime geometry.

### Testing
- Formatting and quick checks were applied with `npm run format:write` (ran successfully). 
- Ran lightweight unit smoke for touched areas with `npm run test:ci -- src/tests/f2ClipboardConsole.test.ts src/tests/gitshelves.test.ts src/tests/sigmaWorkbench.test.ts src/tests/mainImports.test.ts` and those tests passed. 
- Executed full repo gates with `npm run lint && npm run test:ci && npm run docs:check && npm run smoke` and the suite completed successfully (Vitest: all tests passed, `docs:check` emitted external-link warnings but exited OK, `smoke` build passed). 
- Updated miniature manifest with `npm run miniature:manifest:update` after bumping proxy `syncRevision` entries, and validated the regenerated `src/scene/miniature/miniatureManifest.generated.json` (manifest update required and was applied).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e70f8920832f87e827141c5c0382)