### PR TITLE
🏠 Refresh upstairs POI geometry

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -524,7 +524,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -544,7 +544,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "be4eabd9f1d063d24d7be521332a9cc255dd84bc50c65a47f2b4bfaae75fb5aa",
+      "proxyFingerprint": "b9decd66bb484cb21f7689a672a828ef1704b36851172c72659fef65ff5210ed",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -559,7 +559,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -571,11 +571,11 @@
         "src/scene/structures/f2ClipboardConsole.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
-      "sourceFingerprint": "f54fbe8f5ebfed2d93585594e13afa9356374d8715151d8b4cb5a3ba1c66dfd8",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
-      "metadataFingerprint": "785e47b0429d185c808b21e5cc94c768ab5ecddf24372fb922777b3dc6bef589"
+      "syncRevision": 7,
+      "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
+      "sourceFingerprint": "4882793d604f19a466664403fe46a72e84372bfcbb9df67ae49c33adb46e6ffa",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "metadataFingerprint": "203724c45bb66fbd270e45ab7a70e1dbafba3029e5c7564acd9d086d805da04e"
     },
     {
       "id": "poi:flywheel-studio-flywheel",
@@ -591,7 +591,7 @@
       "syncRevision": 26,
       "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
       "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
     },
     {
@@ -606,7 +606,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -618,11 +618,11 @@
         "src/scene/structures/gabrielSentry.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
-      "sourceFingerprint": "78bb70c8f28a8b91d12d81abe85b9b2860619eb651fd0e5f41ded100e1babfe5",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
-      "metadataFingerprint": "988fe798ae6d2f2288c860176d7533a1e4a43bc60b8b5cdc016185b65b19f271"
+      "syncRevision": 7,
+      "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
+      "sourceFingerprint": "5519bd57ed38839a83979ca24e37884834fd8fcef58414f43c2590aa395f445f",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "metadataFingerprint": "e211ac43acb6c5ba1c68752d59b2710f4f99ec7cfff4ebcd119ca5008e631fc3"
     },
     {
       "id": "poi:gitshelves-living-room-installation",
@@ -633,11 +633,11 @@
         "src/scene/structures/gitshelves.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
-      "sourceFingerprint": "1baac57c9423a6b36d3389563ffee34a66526080c50076f00010bc01bbf3bd2f",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
-      "metadataFingerprint": "9675c396ddcf08fb85f797dc175400b54d3a89becb583d3a28d5cba382894bd8"
+      "syncRevision": 7,
+      "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
+      "sourceFingerprint": "23d44ccb3594b8a61cd8a971ac292ab08d66bd7eea213141e96b36f44224946f",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "metadataFingerprint": "088235cd162b79a0a99f9ce58f500e3d67358bb03db4d57b739e452775f4113a"
     },
     {
       "id": "poi:jobbot-studio-terminal",
@@ -651,7 +651,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -686,7 +686,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -701,7 +701,7 @@
       "syncRevision": 6,
       "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
       "sourceFingerprint": "dad7030bd71ed860ea5ade93780d44bf5f665e9dd3c04ee301a781910d0691c4",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "7d67deba88fd2e1b1393f559c79f19f1e0d13f229cc5e47b92e598729b97ace4"
     },
     {
@@ -716,7 +716,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -731,7 +731,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -746,7 +746,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -524,7 +524,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -544,7 +544,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "b9decd66bb484cb21f7689a672a828ef1704b36851172c72659fef65ff5210ed",
+      "proxyFingerprint": "4a4ff9e8191dc7a2877a6e047f1069ce1f8459bc37a2fa3b129819d8cb9eb40f",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -559,7 +559,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -573,8 +573,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 7,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "4882793d604f19a466664403fe46a72e84372bfcbb9df67ae49c33adb46e6ffa",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "sourceFingerprint": "d338953e130bb55599de8591f7c3c585f3deccf6ad1071e42092668115c1721b",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "203724c45bb66fbd270e45ab7a70e1dbafba3029e5c7564acd9d086d805da04e"
     },
     {
@@ -591,7 +591,7 @@
       "syncRevision": 26,
       "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
       "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
     },
     {
@@ -606,7 +606,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -621,7 +621,7 @@
       "syncRevision": 7,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
       "sourceFingerprint": "5519bd57ed38839a83979ca24e37884834fd8fcef58414f43c2590aa395f445f",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "e211ac43acb6c5ba1c68752d59b2710f4f99ec7cfff4ebcd119ca5008e631fc3"
     },
     {
@@ -636,7 +636,7 @@
       "syncRevision": 7,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
       "sourceFingerprint": "23d44ccb3594b8a61cd8a971ac292ab08d66bd7eea213141e96b36f44224946f",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "088235cd162b79a0a99f9ce58f500e3d67358bb03db4d57b739e452775f4113a"
     },
     {
@@ -651,7 +651,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -686,7 +686,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -698,11 +698,11 @@
         "src/scene/structures/sigmaWorkbench.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
-      "sourceFingerprint": "dad7030bd71ed860ea5ade93780d44bf5f665e9dd3c04ee301a781910d0691c4",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
-      "metadataFingerprint": "7d67deba88fd2e1b1393f559c79f19f1e0d13f229cc5e47b92e598729b97ace4"
+      "syncRevision": 7,
+      "syncNote": "Adds the printed enclosure shell around the Sigma AI pin silhouette.",
+      "sourceFingerprint": "69151e3d9000e5e8d3c0dc2ea3b817ca6e5b008b44aa03cbe5e09026ced2f23f",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "metadataFingerprint": "aa5a817cf4f5ca8f131522be446bec1762932a4c9d6bb42b4f537fa410bc7980"
     },
     {
       "id": "poi:sugarkube-backyard-greenhouse",
@@ -716,7 +716,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -731,7 +731,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -746,7 +746,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "3acf3e5924868b9b126c15254493e7d3bfbae096df5363268b87c6eb95751caa",
+      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -524,7 +524,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -544,7 +544,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "3dafe605d375241fb47f921bc9845cbf35dbe00e24958d04cbc948dbf548828c",
+      "proxyFingerprint": "be4eabd9f1d063d24d7be521332a9cc255dd84bc50c65a47f2b4bfaae75fb5aa",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -559,7 +559,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -571,11 +571,11 @@
         "src/scene/structures/f2ClipboardConsole.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "2f1e8a7fc3deaa111e16e6a03013527965119b92d97b09f1b78648b577b36584",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "d26b6a4ba77b15fc7de9913416e8e1774991bdfec8c0a49076feaf91359841eb"
+      "syncRevision": 6,
+      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
+      "sourceFingerprint": "f54fbe8f5ebfed2d93585594e13afa9356374d8715151d8b4cb5a3ba1c66dfd8",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "metadataFingerprint": "785e47b0429d185c808b21e5cc94c768ab5ecddf24372fb922777b3dc6bef589"
     },
     {
       "id": "poi:flywheel-studio-flywheel",
@@ -591,7 +591,7 @@
       "syncRevision": 26,
       "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
       "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
     },
     {
@@ -606,7 +606,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -618,11 +618,11 @@
         "src/scene/structures/gabrielSentry.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "bf8dc4d58f614431c0731f4de2fdaed1f971a42de96daac7e20bc190462915a2",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "3e4b8bcbebde225bf212394ecc8ad0e4a5e6681aba55b39cfc355ee27e8d971b"
+      "syncRevision": 6,
+      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
+      "sourceFingerprint": "78bb70c8f28a8b91d12d81abe85b9b2860619eb651fd0e5f41ded100e1babfe5",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "metadataFingerprint": "988fe798ae6d2f2288c860176d7533a1e4a43bc60b8b5cdc016185b65b19f271"
     },
     {
       "id": "poi:gitshelves-living-room-installation",
@@ -633,11 +633,11 @@
         "src/scene/structures/gitshelves.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "4436803d33b425c66c24c5c9ce6f34ce6d67d5787d64b0230a0386b6de1c669b",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "4fdf722cfeb551ce21463442ffcd4924a18671b22b3ef31dd3d105d032203967"
+      "syncRevision": 6,
+      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
+      "sourceFingerprint": "1baac57c9423a6b36d3389563ffee34a66526080c50076f00010bc01bbf3bd2f",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "metadataFingerprint": "9675c396ddcf08fb85f797dc175400b54d3a89becb583d3a28d5cba382894bd8"
     },
     {
       "id": "poi:jobbot-studio-terminal",
@@ -651,7 +651,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -686,7 +686,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -698,11 +698,11 @@
         "src/scene/structures/sigmaWorkbench.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "d6696b8379112b6fe19fe420102d841a1ddcbe747713c2175452aec94fb26ba0",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "bad6d659009fad48a9ffdf335cbcb3aa993925cc575da14a599d2a05f6b35380"
+      "syncRevision": 6,
+      "syncNote": "Refreshes the upper-floor POI geometry with repository-specific physical details.",
+      "sourceFingerprint": "dad7030bd71ed860ea5ade93780d44bf5f665e9dd3c04ee301a781910d0691c4",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
+      "metadataFingerprint": "7d67deba88fd2e1b1393f559c79f19f1e0d13f229cc5e47b92e598729b97ace4"
     },
     {
       "id": "poi:sugarkube-backyard-greenhouse",
@@ -716,7 +716,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -731,7 +731,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -746,7 +746,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "ca041b37141b96c367afed50020aedec7898ac6e1f437c8049287970e98322b6",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -348,9 +348,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gabriel-studio-sentry',
     id: 'poi:gabriel-studio-sentry',
     displayName: 'Gabriel sentry proxy',
-    syncRevision: 6,
+    syncRevision: 7,
     syncNote:
-      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
+      'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gabrielSentry.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -364,9 +364,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'f2clipboard-kitchen-console',
     id: 'poi:f2clipboard-kitchen-console',
     displayName: 'f2clipboard console proxy',
-    syncRevision: 6,
+    syncRevision: 7,
     syncNote:
-      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
+      'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/f2ClipboardConsole.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -417,9 +417,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gitshelves-living-room-installation',
     id: 'poi:gitshelves-living-room-installation',
     displayName: 'Gitshelves proxy',
-    syncRevision: 6,
+    syncRevision: 7,
     syncNote:
-      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
+      'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gitshelves.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -348,9 +348,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gabriel-studio-sentry',
     id: 'poi:gabriel-studio-sentry',
     displayName: 'Gabriel sentry proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gabrielSentry.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -364,9 +364,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'f2clipboard-kitchen-console',
     id: 'poi:f2clipboard-kitchen-console',
     displayName: 'f2clipboard console proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
     sourceFiles: [...baseFiles, 'src/scene/structures/f2ClipboardConsole.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -402,9 +402,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sigma-kitchen-workbench',
     id: 'poi:sigma-kitchen-workbench',
     displayName: 'Sigma workbench proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sigmaWorkbench.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -417,9 +417,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gitshelves-living-room-installation',
     id: 'poi:gitshelves-living-room-installation',
     displayName: 'Gitshelves proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gitshelves.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -402,9 +402,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sigma-kitchen-workbench',
     id: 'poi:sigma-kitchen-workbench',
     displayName: 'Sigma workbench proxy',
-    syncRevision: 6,
+    syncRevision: 7,
     syncNote:
-      'Refreshes the upper-floor POI geometry with repository-specific physical details.',
+      'Adds the printed enclosure shell around the Sigma AI pin silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sigmaWorkbench.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [

--- a/src/scene/structures/f2ClipboardConsole.ts
+++ b/src/scene/structures/f2ClipboardConsole.ts
@@ -231,8 +231,8 @@ export function createF2ClipboardConsole(
   clipboardPivot.add(calloutGlow);
 
   const clipboardCalloutEntries: Array<{ title: string; detail: string }> = [
-    { title: 'Queue synced', detail: 'Codex diffs summarised' },
-    { title: 'Clipboard ready', detail: '3 incidents triaged' },
+    { title: 'Task pages', detail: 'Codex prompts staged' },
+    { title: 'Markdown ready', detail: 'PR notes copied' },
   ];
 
   clipboardCalloutEntries.forEach((entry, index) => {
@@ -574,14 +574,14 @@ function createConsoleScreenTexture(): CanvasTexture {
 
   context.font = '52px "Inter", "Segoe UI", sans-serif';
   context.fillStyle = '#b7f3ff';
-  context.fillText('Incident digest pipeline', 70, 180);
+  context.fillText('Codex PR clipboard pipeline', 70, 180);
 
   context.font = '42px "Inter", "Segoe UI", sans-serif';
   context.fillStyle = '#8ad4ff';
   const bullets = [
-    'Tail logs → summarise in Markdown',
-    'Copy to clipboard in 3 seconds',
-    'Annotate follow-up actions automatically',
+    'Codex task pages → PR-ready notes',
+    'GitHub checks + logs → concise Markdown',
+    'Redact secrets before paste',
   ];
   bullets.forEach((line, index) => {
     const y = 260 + index * 80;
@@ -663,10 +663,10 @@ function createTickerTexture(): CanvasTexture {
   context.textBaseline = 'middle';
   context.textAlign = 'left';
   const messages = [
-    'Queue synced',
-    'Clipboard primed',
-    'Incident resolved',
-    'Codex summary ready',
+    'Task page copied',
+    'PR checks parsed',
+    'Secrets redacted',
+    'Markdown ready',
   ];
   const spacing = canvas.width / messages.length;
   messages.forEach((message, index) => {

--- a/src/scene/structures/f2ClipboardConsole.ts
+++ b/src/scene/structures/f2ClipboardConsole.ts
@@ -348,7 +348,7 @@ export function createF2ClipboardConsole(
   pipelineSteps.forEach((step, index) => {
     const stepMesh = new Mesh(
       new BoxGeometry(0.22, 0.1, 0.16),
-      pipelineMaterial.clone()
+      pipelineMaterial
     );
     stepMesh.name = `F2ClipboardPipelineStep-${step}`;
     stepMesh.position.set(
@@ -360,7 +360,7 @@ export function createF2ClipboardConsole(
     if (index > 0) {
       const link = new Mesh(
         new BoxGeometry(0.14, 0.035, 0.035),
-        pipelineMaterial.clone()
+        pipelineMaterial
       );
       link.name = `F2ClipboardPipelineLink-${index}`;
       link.position.set(

--- a/src/scene/structures/f2ClipboardConsole.ts
+++ b/src/scene/structures/f2ClipboardConsole.ts
@@ -311,9 +311,9 @@ export function createF2ClipboardConsole(
 
   const floatingLogs: FloatingLog[] = [];
   const logEntries: Array<{ title: string; status: string }> = [
-    { title: 'Incident 204', status: 'SLA recovered · 00:32' },
-    { title: 'Triage queue', status: '3 items → clipboard' },
-    { title: 'Codex sync', status: 'Diff summarized ✓' },
+    { title: 'PR URL', status: 'query + hash stripped' },
+    { title: 'Failed CI log', status: '150 kB gate → summary' },
+    { title: 'Secrets redacted', status: 'ghp_… / sk-… masked' },
   ];
   logEntries.forEach((entry, index) => {
     const texture = createLogCardTexture(entry.title, entry.status);
@@ -335,6 +335,41 @@ export function createF2ClipboardConsole(
       baseHeight: log.position.y,
       baseRotation: log.rotation.y,
     });
+  });
+
+  const pipelineMaterial = new MeshStandardMaterial({
+    color: new Color(0x0f2f46),
+    emissive: new Color(0x38bdf8),
+    emissiveIntensity: 0.4,
+    roughness: 0.32,
+    metalness: 0.34,
+  });
+  const pipelineSteps = ['task', 'PR', 'checks', 'MD'];
+  pipelineSteps.forEach((step, index) => {
+    const stepMesh = new Mesh(
+      new BoxGeometry(0.22, 0.1, 0.16),
+      pipelineMaterial.clone()
+    );
+    stepMesh.name = `F2ClipboardPipelineStep-${step}`;
+    stepMesh.position.set(
+      -0.42 + index * 0.28,
+      deckHeight + 0.18,
+      deckDepth * 0.43
+    );
+    group.add(stepMesh);
+    if (index > 0) {
+      const link = new Mesh(
+        new BoxGeometry(0.14, 0.035, 0.035),
+        pipelineMaterial.clone()
+      );
+      link.name = `F2ClipboardPipelineLink-${index}`;
+      link.position.set(
+        stepMesh.position.x - 0.14,
+        stepMesh.position.y,
+        stepMesh.position.z
+      );
+      group.add(link);
+    }
   });
 
   const haloGeometry = new RingGeometry(0.75, 0.95, 64, 1);

--- a/src/scene/structures/gabrielSentry.ts
+++ b/src/scene/structures/gabrielSentry.ts
@@ -190,7 +190,7 @@ export function createGabrielSentry(
 
   const privacyRing = new Mesh(
     new TorusGeometry(0.56, 0.025, 12, 48),
-    ringMaterial.clone()
+    ringMaterial
   );
   privacyRing.name = 'GabrielPrivacyBoundaryRing';
   privacyRing.rotation.x = Math.PI / 2;

--- a/src/scene/structures/gabrielSentry.ts
+++ b/src/scene/structures/gabrielSentry.ts
@@ -173,6 +173,52 @@ export function createGabrielSentry(
   shield.position.set(0, 0.32, 0);
   core.add(shield);
 
+  const localModelMaterial = new MeshStandardMaterial({
+    color: new Color(0x0b1220),
+    emissive: new Color(0x38bdf8),
+    emissiveIntensity: 0.32,
+    roughness: 0.34,
+    metalness: 0.42,
+  });
+  const localModelCore = new Mesh(
+    new BoxGeometry(0.34, 0.22, 0.22),
+    localModelMaterial
+  );
+  localModelCore.name = 'GabrielLocalInferenceCore';
+  localModelCore.position.set(0, 0.32, -0.15);
+  core.add(localModelCore);
+
+  const privacyRing = new Mesh(
+    new TorusGeometry(0.56, 0.025, 12, 48),
+    ringMaterial.clone()
+  );
+  privacyRing.name = 'GabrielPrivacyBoundaryRing';
+  privacyRing.rotation.x = Math.PI / 2;
+  privacyRing.position.y = baseHeight + 0.08;
+  group.add(privacyRing);
+
+  const swordMaterial = new MeshStandardMaterial({
+    color: new Color(0xcbd5e1),
+    emissive: new Color(0x60a5fa),
+    emissiveIntensity: 0.2,
+    roughness: 0.26,
+    metalness: 0.62,
+  });
+  const swordBlade = new Mesh(
+    new BoxGeometry(0.045, 0.82, 0.045),
+    swordMaterial
+  );
+  swordBlade.name = 'GabrielDamoclesBlade';
+  swordBlade.position.set(0, sensor.position.y + 0.7, 0);
+  group.add(swordBlade);
+  const swordGuard = new Mesh(
+    new BoxGeometry(0.34, 0.035, 0.06),
+    swordMaterial
+  );
+  swordGuard.name = 'GabrielDamoclesGuard';
+  swordGuard.position.set(0, sensor.position.y + 0.28, 0);
+  group.add(swordGuard);
+
   const update = ({
     elapsed,
     emphasis,

--- a/src/scene/structures/gitshelves.ts
+++ b/src/scene/structures/gitshelves.ts
@@ -2,6 +2,7 @@ import {
   BoxGeometry,
   CanvasTexture,
   Color,
+  CylinderGeometry,
   DoubleSide,
   Group,
   MathUtils,
@@ -209,6 +210,25 @@ export function createGitshelvesInstallation(
   pedestal.castShadow = true;
   pedestal.receiveShadow = true;
   group.add(pedestal);
+
+  const baseplateMaterial = new MeshStandardMaterial({
+    color: new Color(0x1e293b),
+    roughness: 0.5,
+    metalness: 0.18,
+  });
+  for (let column = 0; column < columns; column += 1) {
+    const socket = new Mesh(
+      new CylinderGeometry(0.08, 0.08, 0.035, 16),
+      baseplateMaterial
+    );
+    socket.name = `GitshelvesGridfinitySocket-${column}`;
+    socket.position.set(
+      (column - (columns - 1) / 2) * 0.32,
+      baseHeight + 0.03,
+      0.28
+    );
+    group.add(socket);
+  }
 
   const panelHeight = rows * 0.36 + 1.1;
   const panelWidth = columns * 0.34 + 0.8;

--- a/src/scene/structures/gitshelves.ts
+++ b/src/scene/structures/gitshelves.ts
@@ -227,6 +227,8 @@ export function createGitshelvesInstallation(
       baseHeight + 0.03,
       0.28
     );
+    socket.castShadow = true;
+    socket.receiveShadow = true;
     group.add(socket);
   }
 

--- a/src/scene/structures/sigmaWorkbench.ts
+++ b/src/scene/structures/sigmaWorkbench.ts
@@ -187,6 +187,21 @@ export function createSigmaWorkbench(
     roughness: 0.22,
     metalness: 0.38,
   });
+  const enclosureShellMaterial = new MeshStandardMaterial({
+    color: new Color(0x172033),
+    emissive: new Color(0x0f3f5c),
+    emissiveIntensity: 0.18,
+    roughness: 0.52,
+    metalness: 0.18,
+  });
+  const enclosureShell = new Mesh(
+    new BoxGeometry(0.38, 0.3, 0.06),
+    enclosureShellMaterial
+  );
+  enclosureShell.name = 'SigmaPrintedEnclosureShell';
+  enclosureShell.position.set(0, pinBase.position.y + 0.18, -0.15);
+  group.add(enclosureShell);
+
   const pinCore = new Mesh(
     new CylinderGeometry(0.12, 0.12, 0.24, 32),
     pinCoreMaterial

--- a/src/scene/structures/sigmaWorkbench.ts
+++ b/src/scene/structures/sigmaWorkbench.ts
@@ -211,6 +211,52 @@ export function createSigmaWorkbench(
   pinHalo.position.set(0, pinCore.position.y + 0.16, 0);
   group.add(pinHalo);
 
+  const buttonMaterial = new MeshStandardMaterial({
+    color: new Color(0xff7a18),
+    emissive: new Color(0xff9f1c),
+    emissiveIntensity: 0.45,
+    roughness: 0.3,
+    metalness: 0.18,
+  });
+  const talkButton = new Mesh(
+    new CylinderGeometry(0.075, 0.075, 0.03, 20),
+    buttonMaterial
+  );
+  talkButton.name = 'SigmaPushToTalkButton';
+  talkButton.position.set(0, pinCore.position.y + 0.135, 0);
+  group.add(talkButton);
+
+  const grilleMaterial = new MeshStandardMaterial({
+    color: new Color(0x020617),
+    roughness: 0.42,
+    metalness: 0.36,
+  });
+  for (let index = 0; index < 5; index += 1) {
+    const slot = new Mesh(new BoxGeometry(0.018, 0.012, 0.17), grilleMaterial);
+    slot.name = `SigmaSpeakerGrilleSlot-${index}`;
+    slot.position.set(
+      -0.075 + index * 0.0375,
+      pinCore.position.y + 0.02,
+      0.123
+    );
+    group.add(slot);
+  }
+
+  for (let index = 0; index < 3; index += 1) {
+    const mic = new Mesh(
+      new CylinderGeometry(0.014, 0.014, 0.012, 12),
+      grilleMaterial
+    );
+    mic.name = `SigmaMicrophonePort-${index}`;
+    mic.rotation.x = Math.PI / 2;
+    mic.position.set(
+      -0.055 + index * 0.055,
+      pinCore.position.y + 0.045,
+      -0.125
+    );
+    group.add(mic);
+  }
+
   const hologramGroup = new Group();
   hologramGroup.name = 'SigmaWorkbenchHologramGroup';
   hologramGroup.position.set(

--- a/src/tests/f2ClipboardConsole.test.ts
+++ b/src/tests/f2ClipboardConsole.test.ts
@@ -134,10 +134,10 @@ describe('createF2ClipboardConsole', () => {
 
     const capturedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
     expect(capturedText).toContain('f2clipboard');
-    expect(capturedText).toContain('Incident digest pipeline');
-    expect(capturedText).toContain('Queue synced');
-    expect(capturedText).toContain('Codex diffs summarised');
-    expect(capturedText).toContain('3 incidents triaged');
+    expect(capturedText).toContain('Codex PR clipboard pipeline');
+    expect(capturedText).toContain('Task pages');
+    expect(capturedText).toContain('Codex prompts staged');
+    expect(capturedText).toContain('PR notes copied');
     expect(capturedText).toContain('PR URL');
     expect(capturedText).toContain('query + hash stripped');
     expect(capturedText).toContain('Failed CI log');

--- a/src/tests/f2ClipboardConsole.test.ts
+++ b/src/tests/f2ClipboardConsole.test.ts
@@ -125,6 +125,12 @@ describe('createF2ClipboardConsole', () => {
     expect(build.group.getObjectByName('F2ClipboardLogCard-0')).toBeInstanceOf(
       Mesh
     );
+    expect(
+      build.group.getObjectByName('F2ClipboardPipelineStep-task')
+    ).toBeInstanceOf(Mesh);
+    expect(
+      build.group.getObjectByName('F2ClipboardPipelineStep-checks')
+    ).toBeInstanceOf(Mesh);
 
     const capturedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
     expect(capturedText).toContain('f2clipboard');
@@ -132,6 +138,10 @@ describe('createF2ClipboardConsole', () => {
     expect(capturedText).toContain('Queue synced');
     expect(capturedText).toContain('Codex diffs summarised');
     expect(capturedText).toContain('3 incidents triaged');
+    expect(capturedText).toContain('PR URL');
+    expect(capturedText).toContain('query + hash stripped');
+    expect(capturedText).toContain('Failed CI log');
+    expect(capturedText).toContain('Secrets redacted');
   });
 
   it('animates hologram and ticker with emphasis changes', () => {

--- a/src/tests/gabrielSentry.test.ts
+++ b/src/tests/gabrielSentry.test.ts
@@ -1,0 +1,31 @@
+import { Mesh } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createGabrielSentry } from '../scene/structures/gabrielSentry';
+
+describe('createGabrielSentry', () => {
+  it('builds a privacy-first local guardian silhouette', () => {
+    const build = createGabrielSentry({
+      position: { x: 1, z: 2 },
+      orientationRadians: Math.PI / 5,
+    });
+
+    expect(build.group.name).toBe('GabrielSentry');
+    expect(build.colliders).toHaveLength(1);
+    expect(build.group.getObjectByName('GabrielSentrySensor')).toBeInstanceOf(
+      Mesh
+    );
+    expect(
+      build.group.getObjectByName('GabrielLocalInferenceCore')
+    ).toBeInstanceOf(Mesh);
+    expect(
+      build.group.getObjectByName('GabrielPrivacyBoundaryRing')
+    ).toBeInstanceOf(Mesh);
+    expect(build.group.getObjectByName('GabrielDamoclesBlade')).toBeInstanceOf(
+      Mesh
+    );
+    expect(build.group.getObjectByName('GabrielDamoclesGuard')).toBeInstanceOf(
+      Mesh
+    );
+  });
+});

--- a/src/tests/gitshelves.test.ts
+++ b/src/tests/gitshelves.test.ts
@@ -62,6 +62,12 @@ describe('createGitshelvesInstallation', () => {
     expect(build.group.getObjectByName('GitshelvesBase')).toBeTruthy();
     expect(build.group.getObjectByName('GitshelvesPanel')).toBeTruthy();
     expect(build.group.getObjectByName('GitshelvesLabel')).toBeTruthy();
+    expect(
+      build.group.getObjectByName('GitshelvesGridfinitySocket-0')
+    ).toBeTruthy();
+    expect(
+      build.group.getObjectByName('GitshelvesGridfinitySocket-3')
+    ).toBeTruthy();
 
     const commits = getCommitMeshes(build.group);
     expect(commits).toHaveLength(12);

--- a/src/tests/sigmaWorkbench.test.ts
+++ b/src/tests/sigmaWorkbench.test.ts
@@ -71,6 +71,15 @@ describe('createSigmaWorkbench', () => {
 
     const pinCore = build.group.getObjectByName('SigmaWorkbenchPinCore');
     expect(pinCore).toBeInstanceOf(Mesh);
+    expect(build.group.getObjectByName('SigmaPushToTalkButton')).toBeInstanceOf(
+      Mesh
+    );
+    expect(
+      build.group.getObjectByName('SigmaSpeakerGrilleSlot-4')
+    ).toBeInstanceOf(Mesh);
+    expect(build.group.getObjectByName('SigmaMicrophonePort-2')).toBeInstanceOf(
+      Mesh
+    );
 
     const hologram = build.group.getObjectByName('SigmaWorkbenchHologram');
     expect(hologram).toBeInstanceOf(Mesh);

--- a/src/tests/sigmaWorkbench.test.ts
+++ b/src/tests/sigmaWorkbench.test.ts
@@ -71,6 +71,9 @@ describe('createSigmaWorkbench', () => {
 
     const pinCore = build.group.getObjectByName('SigmaWorkbenchPinCore');
     expect(pinCore).toBeInstanceOf(Mesh);
+    expect(
+      build.group.getObjectByName('SigmaPrintedEnclosureShell')
+    ).toBeInstanceOf(Mesh);
     expect(build.group.getObjectByName('SigmaPushToTalkButton')).toBeInstanceOf(
       Mesh
     );


### PR DESCRIPTION
### Motivation
- Upstairs POIs were vague and not representative of the repositories they point to, making the upper floor feel nonsensical. 
- The goal is to refresh POI geometry so each upstairs POI is physically realistic and literally or metaphorically tied to the repository it represents. 
- Keep changes small and reviewable while preserving existing scene/test conventions.

### Description
- Update `F2Clipboard` POI visuals to show a diagnostics/PR pipeline (log cards, pipeline steps, secret-redaction hint, oversized-log summarization cues) in `src/scene/structures/f2ClipboardConsole.ts` and corresponding tests. 
- Add Gabriel-specific elements (local inference core, privacy boundary ring, Damocles blade motif) to `src/scene/structures/gabrielSentry.ts` with a focused structure test. 
- Add Gitshelves baseplate sockets (Gridfinity-style) beneath commit shelves in `src/scene/structures/gitshelves.ts` and update its test to assert sockets exist. 
- Add Sigma hardware details (push-to-talk button, speaker grille, microphone ports) to `src/scene/structures/sigmaWorkbench.ts` and extend its test to validate the new parts. 
- Bump proxy `syncRevision` and update `syncNote` entries for affected miniature proxies and regenerate the miniature manifest (`src/scene/miniature/miniatureManifest.generated.json` and `src/scene/miniature/poiProxyRegistry.ts`). 
- Add/update focused unit tests that assert the new geometry and silhouettes for the upstairs POIs (`src/tests/*` additions/updates).

### Testing
- Ran formatting with `npm run format:write` and linting with `npm run lint`, both completed successfully. 
- Ran unit suite with `npm run test:ci` (full run) and all tests passed: `182` test files and `1419` tests succeeded. 
- Verified docs and links with `npm run docs:check` and the link checker, which passed with warnings for unreachable external targets (network warnings only). 
- Built and validated the production bundle via `npm run smoke`, which completed and reported a valid `dist` output. 
- Regenerated and checked the miniature manifest with `npm run miniature:check` / `npm run miniature:manifest:update`, and the manifest is current. 
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py` against the staged changes with no high-risk secrets detected. 
- Captured a review screenshot of the immersive preview at `/tmp/upstairs-poi-geometry.png` using the preview URL `http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1` for visual review. 

All automated checks listed in the repo playbook were executed and succeeded (format, lint, tests, docs check, smoke, miniature check, secret scan).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e741260c832f815daeef3a8cb743)