### PR TITLE
✨ Refresh upstairs POI geometry

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -524,7 +524,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -544,7 +544,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "3dafe605d375241fb47f921bc9845cbf35dbe00e24958d04cbc948dbf548828c",
+      "proxyFingerprint": "f91e4046b9ef7e13043a678a49d15be1b7d0dba82c27bdd3f68bb63b123316ea",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -559,7 +559,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -571,11 +571,11 @@
         "src/scene/structures/f2ClipboardConsole.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "2f1e8a7fc3deaa111e16e6a03013527965119b92d97b09f1b78648b577b36584",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "d26b6a4ba77b15fc7de9913416e8e1774991bdfec8c0a49076feaf91359841eb"
+      "syncRevision": 6,
+      "syncNote": "Refreshes f2clipboard as a multi-file prompt clipboard and plugin console.",
+      "sourceFingerprint": "cbaf02027b6c07dfa678d60b5168d078c1ac6c1198711108388d83d2b14a1719",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
+      "metadataFingerprint": "dc0112cd489d9959a2a651b7b36258272838d4cac3000080b1c7de5d5ba217ce"
     },
     {
       "id": "poi:flywheel-studio-flywheel",
@@ -591,7 +591,7 @@
       "syncRevision": 26,
       "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
       "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
     },
     {
@@ -603,11 +603,11 @@
         "src/scene/structures/mediaWall.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
+      "syncRevision": 6,
+      "syncNote": "Refreshes Gabriel as a local privacy coaching guardian with actionable shield cards.",
       "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
+      "metadataFingerprint": "a12c58ebed736e4cbe76291d6ad7153e86d2a98e3718f3657c8355ec5e48d55f"
     },
     {
       "id": "poi:gabriel-studio-sentry",
@@ -618,11 +618,11 @@
         "src/scene/structures/gabrielSentry.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "bf8dc4d58f614431c0731f4de2fdaed1f971a42de96daac7e20bc190462915a2",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "3e4b8bcbebde225bf212394ecc8ad0e4a5e6681aba55b39cfc355ee27e8d971b"
+      "syncRevision": 6,
+      "syncNote": "Refreshes Gabriel as a local privacy coaching guardian with actionable shield cards.",
+      "sourceFingerprint": "40d95c34dbff786702fd7bde3b294eddabd9d02af883c1030e41d95709e23fdb",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
+      "metadataFingerprint": "8b448713cfe1e4c57bee01ed6a5849583b62ba0b6d62ac38348e5ce24a0d3a60"
     },
     {
       "id": "poi:gitshelves-living-room-installation",
@@ -633,11 +633,11 @@
         "src/scene/structures/gitshelves.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "4436803d33b425c66c24c5c9ce6f34ce6d67d5787d64b0230a0386b6de1c669b",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "4fdf722cfeb551ce21463442ffcd4924a18671b22b3ef31dd3d105d032203967"
+      "syncRevision": 6,
+      "syncNote": "Refreshes Gitshelves as 42 mm Gridfinity contribution baseplates.",
+      "sourceFingerprint": "148495d18b90b2c1f8e5e81aa2ef8ec23b43f14b33033b294387948635232a9c",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
+      "metadataFingerprint": "ed4a849e31fe1a3bc9e138141799cd88eb245c2c66aca4f594e02e774685cf06"
     },
     {
       "id": "poi:jobbot-studio-terminal",
@@ -651,7 +651,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -686,7 +686,7 @@
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -698,11 +698,11 @@
         "src/scene/structures/sigmaWorkbench.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "d6696b8379112b6fe19fe420102d841a1ddcbe747713c2175452aec94fb26ba0",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
-      "metadataFingerprint": "bad6d659009fad48a9ffdf335cbcb3aa993925cc575da14a599d2a05f6b35380"
+      "syncRevision": 6,
+      "syncNote": "Refreshes Sigma as an ESP32 AI pin workbench with printed enclosure details.",
+      "sourceFingerprint": "faac1e6a0f4a2ed78ebd495b97a5743b8b8accb9b21e7d9131157eddd82f77b9",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
+      "metadataFingerprint": "d46538e7ef7e120fa0812d0632dd6464b2a57a16c076857b0770128612ebd274"
     },
     {
       "id": "poi:sugarkube-backyard-greenhouse",
@@ -716,7 +716,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -731,7 +731,7 @@
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
     },
     {
@@ -746,7 +746,7 @@
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
       "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "cf3d79e9718ead39de2e9c5ee128022b36226fe4f4810d7f54c44bae589c5c78",
+      "proxyFingerprint": "bb46adc13e78c39a58f5db8b252ae53b0a472e3e174a074143024c4927902d64",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -69,9 +69,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'futuroptimist-living-room-tv',
     id: 'poi:futuroptimist-living-room-tv',
     displayName: 'Futur Optimist TV proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes Gabriel as a local privacy coaching guardian with actionable shield cards.',
     sourceFiles: [...baseFiles, 'src/scene/structures/mediaWall.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -348,9 +348,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gabriel-studio-sentry',
     id: 'poi:gabriel-studio-sentry',
     displayName: 'Gabriel sentry proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes Gabriel as a local privacy coaching guardian with actionable shield cards.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gabrielSentry.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -358,21 +358,28 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
       cyl('gabriel-core', 0.28, 0.9, [0, 0.55, 0], 0x334155),
       sphere('gabriel-sensor-eye', 0.24, [0, 1.08, 0], 0x60a5fa),
       box('gabriel-shield', [0.85, 0.2, 0.12], [0, 0.55, -0.38], 0x93c5fd),
+      box(
+        'gabriel-action-card',
+        [0.28, 0.38, 0.04],
+        [0.42, 0.78, 0.28],
+        0x5eead4
+      ),
     ],
   },
   'f2clipboard-kitchen-console': {
     poiId: 'f2clipboard-kitchen-console',
     id: 'poi:f2clipboard-kitchen-console',
     displayName: 'f2clipboard console proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes f2clipboard as a multi-file prompt clipboard and plugin console.',
     sourceFiles: [...baseFiles, 'src/scene/structures/f2ClipboardConsole.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
       box('f2-console', [1.1, 0.5, 0.55], [0, 0.25, 0], 0x475569),
       box('f2-clipboard-screen', [0.5, 0.7, 0.06], [0, 0.78, -0.16], 0xf8fafc),
       box('f2-clip', [0.22, 0.08, 0.08], [0, 1.16, -0.2], 0xfbbf24),
+      box('f2-file-stack', [0.42, 0.12, 0.28], [-0.34, 0.58, 0.08], 0x38bdf8),
     ],
   },
   'axel-studio-tracker': {
@@ -402,24 +409,35 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sigma-kitchen-workbench',
     id: 'poi:sigma-kitchen-workbench',
     displayName: 'Sigma workbench proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes Sigma as an ESP32 AI pin workbench with printed enclosure details.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sigmaWorkbench.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
       box('sigma-workbench', [1.15, 0.18, 0.7], [0, 0.45, 0], 0x854d0e),
-      cyl('sigma-flask', 0.13, 0.42, [-0.28, 0.72, 0], 0xa78bfa),
-      sphere('sigma-orbital-sample', 0.16, [0.28, 0.72, 0.06], 0x14b8a6),
+      box(
+        'sigma-printed-shell',
+        [0.3, 0.42, 0.08],
+        [-0.2, 0.76, 0.08],
+        0xf8fafc
+      ),
+      cyl(
+        'sigma-push-to-talk-button',
+        0.08,
+        0.05,
+        [-0.2, 0.83, 0.02],
+        0x14b8a6
+      ),
     ],
   },
   'gitshelves-living-room-installation': {
     poiId: 'gitshelves-living-room-installation',
     id: 'poi:gitshelves-living-room-installation',
     displayName: 'Gitshelves proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Refreshes Gitshelves as 42 mm Gridfinity contribution baseplates.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gitshelves.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -427,6 +445,12 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
       box('gitshelves-shelf-top', [1.2, 0.06, 0.2], [0, 0.82, 0], 0xf59e0b),
       box('gitshelves-shelf-middle', [1.2, 0.06, 0.2], [0, 0.56, 0], 0xf59e0b),
       box('gitshelves-repo-books', [0.85, 0.22, 0.16], [0, 0.68, 0], 0x38bdf8),
+      box(
+        'gitshelves-gridfinity-baseplate',
+        [0.42, 0.05, 0.42],
+        [0, 0.32, 0.22],
+        0x26364a
+      ),
     ],
   },
   'wove-kitchen-loom': {

--- a/src/scene/structures/f2ClipboardConsole.ts
+++ b/src/scene/structures/f2ClipboardConsole.ts
@@ -231,8 +231,8 @@ export function createF2ClipboardConsole(
   clipboardPivot.add(calloutGlow);
 
   const clipboardCalloutEntries: Array<{ title: string; detail: string }> = [
-    { title: 'Queue synced', detail: 'Codex diffs summarised' },
-    { title: 'Clipboard ready', detail: '3 incidents triaged' },
+    { title: 'File set staged', detail: 'Selected paths bundled' },
+    { title: 'Clipboard ready', detail: 'Multi-file prompt copied' },
   ];
 
   clipboardCalloutEntries.forEach((entry, index) => {
@@ -311,9 +311,9 @@ export function createF2ClipboardConsole(
 
   const floatingLogs: FloatingLog[] = [];
   const logEntries: Array<{ title: string; status: string }> = [
-    { title: 'Incident 204', status: 'SLA recovered · 00:32' },
-    { title: 'Triage queue', status: '3 items → clipboard' },
-    { title: 'Codex sync', status: 'Diff summarized ✓' },
+    { title: 'Codex task page', status: 'Clean brief extracted' },
+    { title: 'GitHub logs', status: 'Failure context clipped' },
+    { title: 'Jira issue', status: 'Description summarized ✓' },
   ];
   logEntries.forEach((entry, index) => {
     const texture = createLogCardTexture(entry.title, entry.status);
@@ -539,14 +539,14 @@ function createConsoleScreenTexture(): CanvasTexture {
 
   context.font = '52px "Inter", "Segoe UI", sans-serif';
   context.fillStyle = '#b7f3ff';
-  context.fillText('Incident digest pipeline', 70, 180);
+  context.fillText('Multi-file prompt clipboard', 70, 180);
 
   context.font = '42px "Inter", "Segoe UI", sans-serif';
   context.fillStyle = '#8ad4ff';
   const bullets = [
-    'Tail logs → summarise in Markdown',
-    'Copy to clipboard in 3 seconds',
-    'Annotate follow-up actions automatically',
+    'Select files → bundle context',
+    'Paste-ready prompt in seconds',
+    'Plugins summarize Jira + CI logs',
   ];
   bullets.forEach((line, index) => {
     const y = 260 + index * 80;

--- a/src/scene/structures/gabrielSentry.ts
+++ b/src/scene/structures/gabrielSentry.ts
@@ -112,6 +112,35 @@ export function createGabrielSentry(
   sensor.position.y = core.position.y + 0.64;
   group.add(sensor);
 
+  const privacyShieldMaterial = new MeshStandardMaterial({
+    color: new Color(0x5eead4),
+    emissive: new Color(0x0f766e),
+    emissiveIntensity: 0.28,
+    roughness: 0.42,
+    metalness: 0.18,
+    transparent: true,
+    opacity: 0.72,
+  });
+  const shieldArcGroup = new Group();
+  shieldArcGroup.name = 'GabrielSentryPrivacyCoachingArc';
+  shieldArcGroup.position.y = core.position.y + 0.12;
+  group.add(shieldArcGroup);
+  for (let index = 0; index < 3; index += 1) {
+    const card = new Mesh(
+      new BoxGeometry(0.38, 0.54, 0.045),
+      privacyShieldMaterial.clone()
+    );
+    card.name = `GabrielSentryActionCard-${index}`;
+    const angle = -0.55 + index * 0.55;
+    card.position.set(
+      Math.sin(angle) * 0.7,
+      index * 0.08,
+      Math.cos(angle) * 0.7
+    );
+    card.rotation.y = angle;
+    shieldArcGroup.add(card);
+  }
+
   const headGroup = new Group();
   headGroup.name = 'GabrielSentryScanner';
   headGroup.position.y = sensor.position.y + 0.42;
@@ -130,8 +159,8 @@ export function createGabrielSentry(
 
   const scannerMaterial = new MeshStandardMaterial({
     color: new Color(0x272f3f),
-    emissive: new Color(0xff2e45),
-    emissiveIntensity: 0.7,
+    emissive: new Color(0x38bdf8),
+    emissiveIntensity: 0.56,
     roughness: 0.28,
     metalness: 0.36,
   });
@@ -144,9 +173,9 @@ export function createGabrielSentry(
   headGroup.add(scannerBar);
 
   const beaconMaterial = new MeshStandardMaterial({
-    color: new Color(0xff4b4b),
-    emissive: new Color(0xff1a1a),
-    emissiveIntensity: 1.2,
+    color: new Color(0x38bdf8),
+    emissive: new Color(0x0ea5e9),
+    emissiveIntensity: 0.95,
     roughness: 0.22,
     metalness: 0.4,
   });
@@ -158,7 +187,7 @@ export function createGabrielSentry(
   beacon.position.y = 0.44;
   headGroup.add(beacon);
 
-  const beaconLight = new PointLight(0xff3a3a, 4.5, 6.5, 2.4);
+  const beaconLight = new PointLight(0x38bdf8, 3.2, 6.5, 2.4);
   beaconLight.name = 'GabrielSentryBeaconLight';
   beaconLight.position.set(0, 0.64, 0);
   headGroup.add(beaconLight);

--- a/src/scene/structures/gitshelves.ts
+++ b/src/scene/structures/gitshelves.ts
@@ -210,6 +210,27 @@ export function createGitshelvesInstallation(
   pedestal.receiveShadow = true;
   group.add(pedestal);
 
+  const gridfinityMaterial = new MeshStandardMaterial({
+    color: new Color(0x26364a),
+    emissive: new Color(0x0a5f9a),
+    emissiveIntensity: 0.16,
+    roughness: 0.5,
+    metalness: 0.18,
+  });
+  const baseplateGeometry = new BoxGeometry(0.42, 0.045, 0.42);
+  for (let month = 0; month < 3; month += 1) {
+    const baseplate = new Mesh(baseplateGeometry, gridfinityMaterial.clone());
+    baseplate.name = `GitshelvesGridfinityBaseplate-${month}`;
+    baseplate.position.set(
+      (month - 1) * 0.48,
+      baseHeight + pedestal.geometry.parameters.height + 0.03,
+      baseDepth * 0.18
+    );
+    baseplate.castShadow = true;
+    baseplate.receiveShadow = true;
+    group.add(baseplate);
+  }
+
   const panelHeight = rows * 0.36 + 1.1;
   const panelWidth = columns * 0.34 + 0.8;
   const panelThickness = 0.12;

--- a/src/scene/structures/sigmaWorkbench.ts
+++ b/src/scene/structures/sigmaWorkbench.ts
@@ -180,6 +180,37 @@ export function createSigmaWorkbench(
   pinBase.position.set(0, workSurface.position.y + 0.11, 0);
   group.add(pinBase);
 
+  const enclosureMaterial = new MeshStandardMaterial({
+    color: new Color(0xf4f7fb),
+    roughness: 0.36,
+    metalness: 0.08,
+  });
+  const shell = new Mesh(new BoxGeometry(0.42, 0.54, 0.1), enclosureMaterial);
+  shell.name = 'SigmaWorkbenchPrintedEnclosureShell';
+  shell.position.set(0, workSurface.position.y + 0.3, tableDepth * 0.18);
+  shell.rotation.x = -Math.PI * 0.04;
+  group.add(shell);
+
+  const pushToTalkButtonMaterial = new MeshStandardMaterial({
+    color: new Color(0x1df2ff),
+    emissive: new Color(0x16b4ff),
+    emissiveIntensity: 0.72,
+    roughness: 0.2,
+    metalness: 0.28,
+  });
+  const pushToTalkButton = new Mesh(
+    new CylinderGeometry(0.085, 0.085, 0.035, 24),
+    pushToTalkButtonMaterial
+  );
+  pushToTalkButton.name = 'SigmaWorkbenchPushToTalkButton';
+  pushToTalkButton.rotation.x = Math.PI / 2;
+  pushToTalkButton.position.set(
+    0,
+    shell.position.y + 0.06,
+    shell.position.z - 0.055
+  );
+  group.add(pushToTalkButton);
+
   const pinCoreMaterial = new MeshStandardMaterial({
     color: new Color(0x48fff1),
     emissive: new Color(0x1dffe3),

--- a/src/tests/f2ClipboardConsole.test.ts
+++ b/src/tests/f2ClipboardConsole.test.ts
@@ -128,10 +128,10 @@ describe('createF2ClipboardConsole', () => {
 
     const capturedText = contexts.flatMap((ctx) => ctx.fillTextCalls);
     expect(capturedText).toContain('f2clipboard');
-    expect(capturedText).toContain('Incident digest pipeline');
-    expect(capturedText).toContain('Queue synced');
-    expect(capturedText).toContain('Codex diffs summarised');
-    expect(capturedText).toContain('3 incidents triaged');
+    expect(capturedText).toContain('Multi-file prompt clipboard');
+    expect(capturedText).toContain('File set staged');
+    expect(capturedText).toContain('Selected paths bundled');
+    expect(capturedText).toContain('Multi-file prompt copied');
   });
 
   it('animates hologram and ticker with emphasis changes', () => {

--- a/src/tests/gabrielSentry.test.ts
+++ b/src/tests/gabrielSentry.test.ts
@@ -1,0 +1,44 @@
+import { Group, Mesh } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { createGabrielSentry } from '../scene/structures/gabrielSentry';
+
+describe('createGabrielSentry', () => {
+  it('builds a privacy coaching guardian with actionable local cards', () => {
+    const build = createGabrielSentry({
+      position: { x: -2, z: 3 },
+      orientationRadians: Math.PI / 5,
+    });
+
+    expect(build.group.name).toBe('GabrielSentry');
+    expect(build.group.getObjectByName('GabrielSentrySensor')).toBeInstanceOf(
+      Mesh
+    );
+    expect(
+      build.group.getObjectByName('GabrielSentryPrivacyCoachingArc')
+    ).toBeInstanceOf(Group);
+    expect(
+      build.group.getObjectByName('GabrielSentryActionCard-0')
+    ).toBeInstanceOf(Mesh);
+    expect(build.colliders).toHaveLength(1);
+    expect(build.colliders[0].minX).toBeLessThan(build.colliders[0].maxX);
+  });
+
+  it('animates scanner and beacon intensity with emphasis', () => {
+    const build = createGabrielSentry({ position: { x: 0, z: 0 } });
+    const scanner = build.group.getObjectByName(
+      'GabrielSentryScanner'
+    ) as Group;
+    const beacon = build.group.getObjectByName('GabrielSentryBeacon') as Mesh;
+    const material = beacon.material as { emissiveIntensity: number };
+
+    build.update({ elapsed: 0.1, delta: 0.016, emphasis: 0 });
+    const lowRotation = scanner.rotation.y;
+    const lowIntensity = material.emissiveIntensity;
+
+    build.update({ elapsed: 1.1, delta: 0.016, emphasis: 1 });
+
+    expect(scanner.rotation.y).not.toBeCloseTo(lowRotation);
+    expect(material.emissiveIntensity).toBeGreaterThan(lowIntensity);
+  });
+});

--- a/src/tests/gitshelves.test.ts
+++ b/src/tests/gitshelves.test.ts
@@ -62,6 +62,9 @@ describe('createGitshelvesInstallation', () => {
     expect(build.group.getObjectByName('GitshelvesBase')).toBeTruthy();
     expect(build.group.getObjectByName('GitshelvesPanel')).toBeTruthy();
     expect(build.group.getObjectByName('GitshelvesLabel')).toBeTruthy();
+    expect(
+      build.group.getObjectByName('GitshelvesGridfinityBaseplate-0')
+    ).toBeTruthy();
 
     const commits = getCommitMeshes(build.group);
     expect(commits).toHaveLength(12);

--- a/src/tests/sigmaWorkbench.test.ts
+++ b/src/tests/sigmaWorkbench.test.ts
@@ -71,6 +71,12 @@ describe('createSigmaWorkbench', () => {
 
     const pinCore = build.group.getObjectByName('SigmaWorkbenchPinCore');
     expect(pinCore).toBeInstanceOf(Mesh);
+    expect(
+      build.group.getObjectByName('SigmaWorkbenchPrintedEnclosureShell')
+    ).toBeInstanceOf(Mesh);
+    expect(
+      build.group.getObjectByName('SigmaWorkbenchPushToTalkButton')
+    ).toBeInstanceOf(Mesh);
 
     const hologram = build.group.getObjectByName('SigmaWorkbenchHologram');
     expect(hologram).toBeInstanceOf(Mesh);


### PR DESCRIPTION
### Motivation
- The upstairs POIs were visually and semantically out of sync with the repositories they represent, producing confusing or generic artifacts. 
- The goal is to refresh upper-floor POI geometry and copy so each POI reads as a physically realistic and (literally or metaphorically) repo-representative artifact.

### Description
- Revamped `f2clipboard` POI copy and holographic callouts to represent multi-file prompt bundling, selected-path staging, CI log context, and Jira/plugin summarization. 
- Added Sigma workbench details: a printed enclosure shell and an explicit push‑to‑talk button to better match the ESP32 AI pin repo concept. 
- Added Gitshelves Gridfinity-style baseplates to the Gitshelves installation and recast Gabriel as a privacy‑coaching guardian by adding actionable shield/action cards and adjusted beacon/scanner materials. 
- Synced miniature proxies and regenerated the miniature manifest (`src/scene/miniature/poiProxyRegistry.ts` + `miniatureManifest.generated.json`), and added/updated focused tests (new `src/tests/gabrielSentry.test.ts` and updates to POI tests) to cover the changed geometry and animation behaviours.

### Testing
- Ran formatting and checks with `npm run format:write` (targeted files), `npm run lint`, and `git diff --cached | ./scripts/scan-secrets.py`, and the secret scan reported no high‑risk secrets. (Succeeded.)
- Updated miniature proxies and regenerated the manifest with `npm run miniature:manifest:update` which updated `src/scene/miniature/miniatureManifest.generated.json` and completed successfully. (Succeeded.)
- Executed the focused and full test matrix via `npm run test:ci` including `src/tests/miniatureManifest.test.ts`, `src/tests/miniatureProxyRegistry.test.ts`, `src/tests/f2ClipboardConsole.test.ts`, `src/tests/sigmaWorkbench.test.ts`, `src/tests/gitshelves.test.ts`, and the new `src/tests/gabrielSentry.test.ts`, and then the full suite; all tests passed in the environment (final run: 182 test files, 1420 tests passed). (Succeeded.)
- Ran `npm run docs:check` and `npm run smoke` (build + dist assertions); both completed successfully, though attempting a runtime Playwright screenshot failed because Playwright browsers are not installed in this environment (`npx playwright install` required). (Docs/smoke succeeded; Playwright screenshot not run.)

Notes: visual verification in a local preview is recommended for reviewers (open `http://localhost:5173/?mode=immersive&disablePerformanceFailover=1` and inspect the upper floor), and the miniature proxy sync notes in `poiProxyRegistry.ts` explain the deliberate silhouette updates made for the proxies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e752a054832fa1c2f5a8bc5ce603)