### PR TITLE
Add studio sleeping nook furnishings

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 9,
-      "syncNote": "Storage furnishing visuals stay source-only after drawer-console foot detailing; furnishing proxy work remains deferred until the full furnishing set lands.",
-      "sourceFingerprint": "e5ebfa1c5e4f46611401b3038a62a5172dfda7bcbad2e5fa4b5f0f1aaa6ba04f",
+      "syncRevision": 10,
+      "syncNote": "Studio sleeping nook furnishings stay source-only while furnishing proxy work remains deferred until the full furnishing set lands.",
+      "sourceFingerprint": "7b32a55cc80cbf0fac74be5defc4141b1c8da5200db0b79697abaa71ba3504c9",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "bb47a8be819b22feb6afd01adb4ede16da982c286c71ea647a195d86a616823a"
+      "metadataFingerprint": "260fde76fd5d0f995e4c6a5f9e270b8d62a5418908ca5ab2c2260cf367c1b1b6"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 9,
+    syncRevision: 10,
     reason:
-      'Storage furnishing visuals stay source-only after drawer-console foot detailing; furnishing proxy work remains deferred until the full furnishing set lands.',
+      'Studio sleeping nook furnishings stay source-only while furnishing proxy work remains deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -350,6 +350,67 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'storage-east-dresser',
       visual: { color: 0x4d3a2b, accentColor: 0xb8c0c8, height: 1.05 },
     },
+
+    {
+      id: 'studio-daybed',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 27.6, z: 10.6 },
+      orientationRadians: -Math.PI / 2,
+      solidFootprint: { width: 3.8, depth: 2.0 },
+      solidBounds: { minX: 25.7, maxX: 29.5, minZ: 9.6, maxZ: 11.6 },
+      kind: 'studio-daybed',
+      visual: { color: 0x6f7f92, accentColor: 0xd8c7a7, height: 0.72 },
+    },
+    {
+      id: 'studio-nightstand-south',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 27.6, z: 8.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      solidBounds: { minX: 27.2, maxX: 28.0, minZ: 8.2, maxZ: 9.0 },
+      kind: 'studio-nightstand-lamp',
+      visual: { color: 0x4d3a2b, accentColor: 0xf0c56d, height: 0.58 },
+    },
+    {
+      id: 'studio-nightstand-north',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 27.6, z: 12.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      solidBounds: { minX: 27.2, maxX: 28.0, minZ: 12.2, maxZ: 13.0 },
+      kind: 'studio-nightstand-books',
+      visual: { color: 0x4d3a2b, accentColor: 0x8fb3c9, height: 0.58 },
+    },
+    {
+      id: 'studio-reading-chair',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 22.2, z: 12.6 },
+      orientationRadians: Math.PI * 0.3,
+      solidFootprint: { width: 1.4, depth: 1.4 },
+      solidBounds: { minX: 21.5, maxX: 22.9, minZ: 11.9, maxZ: 13.3 },
+      kind: 'studio-reading-chair',
+      visual: { color: 0x7d6f89, accentColor: 0xd8c7a7, height: 0.76 },
+    },
+    {
+      id: 'studio-bedside-rug',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 25.5, z: 10.8 },
+      orientationRadians: 0,
+      decorativeFootprint: { width: 4.8, depth: 3.0 },
+      decorativeBounds: { minX: 23.1, maxX: 27.9, minZ: 9.3, maxZ: 12.3 },
+      kind: 'studio-bedside-rug',
+      visual: {
+        color: 0x48596b,
+        accentColor: 0xcaa66a,
+        decorativeHeight: 0.024,
+        allowDecorativeOverlapWithAnySolid: true,
+      },
+    },
     {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
@@ -550,6 +611,8 @@ function createSolidPrimitive(
     return createKitchenFurnishing(definition);
   if (definition.kind.startsWith('storage-'))
     return createStorageFurnishing(definition);
+  if (definition.kind.startsWith('studio-'))
+    return createStudioSleepingNookFurnishing(definition);
 
   const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
   const height = definition.visual?.height ?? 0.8;
@@ -1089,6 +1152,195 @@ function createStorageFurnishing(
       [visualFootprint.width / 2 - 0.52, height + 0.12, 0]
     );
   }
+
+  return group;
+}
+
+function createStudioSleepingNookFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  if (definition.kind === 'studio-daybed')
+    return createStudioDaybed(definition);
+  if (definition.kind.startsWith('studio-nightstand'))
+    return createStudioNightstand(definition);
+  if (definition.kind === 'studio-reading-chair')
+    return createStudioReadingChair(definition);
+
+  return new Group();
+}
+
+function createStudioDaybed(definition: LowerFloorFurnishingDefinition): Group {
+  const footprint = definition.solidFootprint ?? { width: 3.8, depth: 2.0 };
+  const frameMaterial = createMaterial(definition.visual?.color ?? 0x6f7f92);
+  const beddingMaterial = createMaterial(0xe6dcc9);
+  const blanketMaterial = createMaterial(0x6b8798);
+  const pillowMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xd8c7a7
+  );
+  const darkMaterial = createMaterial(0x2d2520);
+  const group = new Group();
+
+  addBox(
+    group,
+    'daybedFrame',
+    { width: footprint.width, height: 0.34, depth: footprint.depth },
+    frameMaterial,
+    [0, 0.22, 0]
+  );
+  addBox(
+    group,
+    'daybedMattress',
+    {
+      width: footprint.width - 0.28,
+      height: 0.22,
+      depth: footprint.depth - 0.28,
+    },
+    beddingMaterial,
+    [0, 0.5, -0.02]
+  );
+  addBox(
+    group,
+    'daybedBackPanel',
+    { width: footprint.width, height: 1.05, depth: 0.16 },
+    darkMaterial,
+    [0, 0.72, footprint.depth / 2 - 0.08]
+  );
+  addBox(
+    group,
+    'daybedBlanket',
+    { width: footprint.width - 0.52, height: 0.08, depth: 0.72 },
+    blanketMaterial,
+    [0.16, 0.67, -0.32]
+  );
+  [-1.0, 0.05, 1.1].forEach((x, index) => {
+    addBox(
+      group,
+      `daybedPillow${index}`,
+      { width: 0.78, height: 0.24, depth: 0.28 },
+      pillowMaterial,
+      [x, 0.76, 0.56]
+    );
+  });
+
+  return group;
+}
+
+function createStudioNightstand(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 0.8, depth: 0.8 };
+  const woodMaterial = createMaterial(definition.visual?.color ?? 0x4d3a2b);
+  const accentMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x8fb3c9
+  );
+  const darkMaterial = createMaterial(0x252321);
+  const group = new Group();
+  const height = definition.visual?.height ?? 0.58;
+
+  addBox(
+    group,
+    'nightstandBody',
+    { width: footprint.width, height, depth: footprint.depth },
+    woodMaterial,
+    [0, height / 2, 0]
+  );
+  addBox(
+    group,
+    'nightstandDrawer',
+    { width: footprint.width - 0.16, height: 0.08, depth: 0.05 },
+    accentMaterial,
+    [0, height * 0.58, -footprint.depth / 2 - 0.01]
+  );
+  addBox(
+    group,
+    'nightstandHandle',
+    { width: 0.26, height: 0.04, depth: 0.04 },
+    darkMaterial,
+    [0, height * 0.62, -footprint.depth / 2 - 0.04]
+  );
+
+  if (definition.kind === 'studio-nightstand-lamp') {
+    addBox(
+      group,
+      'nightstandLampBase',
+      { width: 0.16, height: 0.12, depth: 0.16 },
+      darkMaterial,
+      [-0.18, height + 0.06, 0.05]
+    );
+    addBox(
+      group,
+      'nightstandLampShade',
+      { width: 0.28, height: 0.22, depth: 0.28 },
+      accentMaterial,
+      [-0.18, height + 0.26, 0.05]
+    );
+  } else {
+    [0, 1, 2].forEach((index) => {
+      addBox(
+        group,
+        `nightstandBook${index}`,
+        { width: 0.38, height: 0.055, depth: 0.24 },
+        accentMaterial,
+        [0.04, height + 0.035 + index * 0.055, 0.02]
+      );
+    });
+  }
+
+  return group;
+}
+
+function createStudioReadingChair(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const material = createMaterial(definition.visual?.color ?? 0x7d6f89);
+  const pillowMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xd8c7a7
+  );
+  const darkMaterial = createMaterial(0x2d2520);
+  const group = new Group();
+
+  addBox(
+    group,
+    'readingChairSeat',
+    { width: 1.12, height: 0.32, depth: 1.0 },
+    material,
+    [0, 0.34, 0]
+  );
+  addBox(
+    group,
+    'readingChairBack',
+    { width: 1.14, height: 0.78, depth: 0.18 },
+    material,
+    [0, 0.72, 0.48]
+  );
+  addBox(
+    group,
+    'readingChairLeftArm',
+    { width: 0.18, height: 0.52, depth: 0.92 },
+    material,
+    [-0.56, 0.52, 0]
+  );
+  addBox(
+    group,
+    'readingChairRightArm',
+    { width: 0.18, height: 0.52, depth: 0.92 },
+    material,
+    [0.56, 0.52, 0]
+  );
+  addBox(
+    group,
+    'readingChairPillow',
+    { width: 0.58, height: 0.28, depth: 0.16 },
+    pillowMaterial,
+    [0.08, 0.73, 0.35]
+  );
+  addBox(
+    group,
+    'readingChairBook',
+    { width: 0.34, height: 0.06, depth: 0.22 },
+    darkMaterial,
+    [-0.14, 0.54, -0.18]
+  );
 
   return group;
 }

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,8 +76,8 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(20);
-    expect(build.decorativeFootprints).toHaveLength(1);
+    expect(build.colliders).toHaveLength(24);
+    expect(build.decorativeFootprints).toHaveLength(2);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
       'living-room-coffee-table',
@@ -99,6 +99,11 @@ describe('lower floor furnishings foundation', () => {
       'studio-north-bookcase-east',
       'studio-drafting-drawers',
       'studio-east-dresser',
+      'studio-daybed',
+      'studio-nightstand-south',
+      'studio-nightstand-north',
+      'studio-reading-chair',
+      'studio-bedside-rug',
       'living-room-media-rug',
     ]);
   });
@@ -164,6 +169,126 @@ describe('lower floor furnishings foundation', () => {
         matchingColliders[0].maxZ - matchingColliders[0].minZ
       ).toBeGreaterThan(0);
     });
+  });
+
+  it('adds the requested studio sleeping nook AABBs and non-blocking rug', () => {
+    const { colliders, decorativeFootprints } = createLowerFloorFurnishings();
+    const expectedSleepingNookBounds: Record<string, RectCollider> = {
+      'studio-daybed': {
+        minX: 25.7,
+        maxX: 29.5,
+        minZ: 9.6,
+        maxZ: 11.6,
+      },
+      'studio-nightstand-south': {
+        minX: 27.2,
+        maxX: 28.0,
+        minZ: 8.2,
+        maxZ: 9.0,
+      },
+      'studio-nightstand-north': {
+        minX: 27.2,
+        maxX: 28.0,
+        minZ: 12.2,
+        maxZ: 13.0,
+      },
+      'studio-reading-chair': {
+        minX: 21.5,
+        maxX: 22.9,
+        minZ: 11.9,
+        maxZ: 13.3,
+      },
+    };
+
+    Object.entries(expectedSleepingNookBounds).forEach(([id, expected]) => {
+      const matchingColliders = colliders.filter(
+        (collider) => collider.furnishingId === id
+      );
+      expect(matchingColliders).toHaveLength(1);
+      expect(matchingColliders[0]).toMatchObject({
+        ...expected,
+        category: 'sleeping-nook',
+        roomId: 'studio',
+      });
+    });
+
+    expect(
+      decorativeFootprints.find(
+        (footprint) => footprint.furnishingId === 'studio-bedside-rug'
+      )?.bounds
+    ).toMatchObject({ minX: 23.1, maxX: 27.9, minZ: 9.3, maxZ: 12.3 });
+    expect(
+      decorativeFootprints.find(
+        (footprint) => footprint.furnishingId === 'studio-bedside-rug'
+      )?.allowSolidOverlap
+    ).toBe(true);
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'studio-bedside-rug'
+      )
+    ).toBe(false);
+  });
+
+  it('keeps the studio sleeping nook clear of blockers and other solids', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const sleepingNookColliders = colliders.filter(
+      (collider) => collider.category === 'sleeping-nook'
+    );
+    const otherColliders = colliders.filter(
+      (collider) => collider.category !== 'sleeping-nook'
+    );
+    const studioBackyardDoorwayBuffer: RectCollider = {
+      minX: 11,
+      maxX: 19,
+      minZ: 14.8,
+      maxZ: 17.2,
+    };
+
+    sleepingNookColliders.forEach((collider, index) => {
+      expect(isContainedBy(LOWER_FLOOR_ROOM_BOUNDS.studio, collider)).toBe(
+        true
+      );
+      expect(rectanglesOverlap(collider, studioBackyardDoorwayBuffer)).toBe(
+        false
+      );
+      sleepingNookColliders.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+      otherColliders.forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+      });
+    });
+  });
+
+  it('renders layered sleeping nook visual details without extra colliders', () => {
+    const { group, colliders } = createLowerFloorFurnishings();
+    const daybed = group.children.find(
+      (child) => child.name === 'Furnishing:studio-daybed'
+    );
+    const southNightstand = group.children.find(
+      (child) => child.name === 'Furnishing:studio-nightstand-south'
+    );
+    const chair = group.children.find(
+      (child) => child.name === 'Furnishing:studio-reading-chair'
+    );
+    const partNames = new Set<string>();
+
+    [daybed, southNightstand, chair].forEach((furnishing) => {
+      expect(furnishing).toBeDefined();
+      furnishing!.traverse((child) => partNames.add(child.name));
+    });
+
+    expect(partNames.has('FurnishingPart:daybedMattress')).toBe(true);
+    expect(partNames.has('FurnishingPart:daybedBlanket')).toBe(true);
+    expect(partNames.has('FurnishingPart:daybedPillow0')).toBe(true);
+    expect(partNames.has('FurnishingPart:nightstandLampShade')).toBe(true);
+    expect(partNames.has('FurnishingPart:readingChairPillow')).toBe(true);
+    expect(
+      colliders.filter((collider) => collider.category === 'sleeping-nook')
+    ).toHaveLength(4);
   });
 
   it('keeps storage colliders in room bounds and away from solids and blockers', () => {


### PR DESCRIPTION
### Motivation
- Make the lower-floor studio feel lived-in by adding a compact sleeping/rest nook while preserving POI, doorway, and reserved-blocker clearances using exact authored AABBs.

### Description
- Added furnishing definitions to `DEFAULT_LOWER_FLOOR_FURNISHINGS` for `studio-daybed`, `studio-nightstand-south`, `studio-nightstand-north`, `studio-reading-chair`, and `studio-bedside-rug` with the requested centers, footprints, AABBs, orientations, and visual flags in `src/scene/structures/lowerFloorFurnishings.ts`.
- Implemented visual builders and dispatch wiring: `createStudioSleepingNookFurnishing` plus `createStudioDaybed`, `createStudioNightstand`, and `createStudioReadingChair`, and hooked them into `createSolidPrimitive` for `studio-` kinds.
- Updated tests in `src/tests/lowerFloorFurnishings.test.ts` to assert the new collider counts, exact sleeping-nook AABBs, non-blocking bedside rug behavior, clearance from the studio->backyard doorway and reserved blockers, and presence of layered visual parts without extra colliders.
- Bumped miniature coverage acknowledgement and updated generated miniature manifest entries (`src/scene/miniature/sceneComponentRegistry.ts` and `src/scene/miniature/miniatureManifest.generated.json`) to record the source-only status for lower-floor furnishings.

### Testing
- Ran `npm run format:write` and `npm run lint`, both completed successfully.
- Ran targeted tests with `npm run test:ci -- lowerFloorFurnishings` and `npm run test:ci -- lowerFloorFurnishings miniatureManifest`, and both passed after updating the miniature manifest acknowledgment.
- Ran `npm run build`, `npm run docs:check` (passed with external-link warnings), and `npm run smoke`, all of which completed successfully.
- Ran `git diff --cached | ./scripts/scan-secrets.py` with no high-risk secrets detected.
- Attempted `npm run typecheck` which failed due to pre-existing repository-wide TypeScript errors unrelated to these changes; initial `npm run test:ci` also failed until the miniature manifest was updated, after which targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a415f5d8458832f89fda66bb3440a92)