### PR TITLE
🛏️ : – add studio sleeping nook

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 9,
-      "syncNote": "Storage furnishing visuals stay source-only after drawer-console foot detailing; furnishing proxy work remains deferred until the full furnishing set lands.",
-      "sourceFingerprint": "e5ebfa1c5e4f46611401b3038a62a5172dfda7bcbad2e5fa4b5f0f1aaa6ba04f",
+      "syncRevision": 10,
+      "syncNote": "Sleeping nook furnishings remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.",
+      "sourceFingerprint": "c019b0c4e9bbc02c43ebab60927fdd3894c385a18ad78e4560eabdd295c07d4b",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "bb47a8be819b22feb6afd01adb4ede16da982c286c71ea647a195d86a616823a"
+      "metadataFingerprint": "aacda4182bbeff2a704ebbb9930da8ecf7f1e1f0d3f11125287af3c275e1ca0a"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 10,
-      "syncNote": "Sleeping nook furnishings remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.",
-      "sourceFingerprint": "c019b0c4e9bbc02c43ebab60927fdd3894c385a18ad78e4560eabdd295c07d4b",
+      "syncRevision": 11,
+      "syncNote": "Sleeping nook mesh names remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.",
+      "sourceFingerprint": "996ac2753ac18b07253866eda65eee556cbd7e579f132ae70e431b0553119cc3",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "aacda4182bbeff2a704ebbb9930da8ecf7f1e1f0d3f11125287af3c275e1ca0a"
+      "metadataFingerprint": "e2fd9544a6dbdce90993b407a449a233ecb002ae7ec826c2707614df5d63031d"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 9,
+    syncRevision: 10,
     reason:
-      'Storage furnishing visuals stay source-only after drawer-console foot detailing; furnishing proxy work remains deferred until the full furnishing set lands.',
+      'Sleeping nook furnishings remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 10,
+    syncRevision: 11,
     reason:
-      'Sleeping nook furnishings remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
+      'Sleeping nook mesh names remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -351,6 +351,66 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       visual: { color: 0x4d3a2b, accentColor: 0xb8c0c8, height: 1.05 },
     },
     {
+      id: 'studio-daybed',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 27.6, z: 10.6 },
+      orientationRadians: -Math.PI / 2,
+      solidFootprint: { width: 3.8, depth: 2.0 },
+      solidBounds: { minX: 25.7, maxX: 29.5, minZ: 9.6, maxZ: 11.6 },
+      kind: 'sleeping-daybed',
+      visual: { color: 0x6f7f92, accentColor: 0xd8c7a7, height: 0.72 },
+    },
+    {
+      id: 'studio-nightstand-south',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 27.6, z: 8.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      solidBounds: { minX: 27.2, maxX: 28.0, minZ: 8.2, maxZ: 9.0 },
+      kind: 'sleeping-nightstand-lamp',
+      visual: { color: 0x4d3a2b, accentColor: 0xffd48a, height: 0.62 },
+    },
+    {
+      id: 'studio-nightstand-north',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 27.6, z: 12.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      solidBounds: { minX: 27.2, maxX: 28.0, minZ: 12.2, maxZ: 13.0 },
+      kind: 'sleeping-nightstand-books',
+      visual: { color: 0x4d3a2b, accentColor: 0xb8c0c8, height: 0.62 },
+    },
+    {
+      id: 'studio-reading-chair',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 22.2, z: 12.6 },
+      orientationRadians: Math.PI * 0.3,
+      solidFootprint: { width: 1.4, depth: 1.4 },
+      solidBounds: { minX: 21.5, maxX: 22.9, minZ: 11.9, maxZ: 13.3 },
+      kind: 'sleeping-reading-chair',
+      visual: { color: 0x7d6f89, accentColor: 0xd8c7a7, height: 0.82 },
+    },
+    {
+      id: 'studio-bedside-rug',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 25.5, z: 10.8 },
+      orientationRadians: 0,
+      decorativeFootprint: { width: 4.8, depth: 3.0 },
+      decorativeBounds: { minX: 23.1, maxX: 27.9, minZ: 9.3, maxZ: 12.3 },
+      kind: 'sleeping-bedside-rug',
+      visual: {
+        color: 0x42546a,
+        accentColor: 0xd6c3a3,
+        decorativeHeight: 0.025,
+        allowDecorativeOverlapWithAnySolid: true,
+      },
+    },
+    {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
       roomId: 'livingRoom',
@@ -546,6 +606,8 @@ function createSolidPrimitive(
   if (definition.kind === 'side-table') return createSideTable(definition);
   if (definition.kind === 'lounge-chair') return createLoungeChair(definition);
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
+  if (definition.kind.startsWith('sleeping-'))
+    return createSleepingNookFurnishing(definition);
   if (definition.kind.startsWith('kitchen-'))
     return createKitchenFurnishing(definition);
   if (definition.kind.startsWith('storage-'))
@@ -914,6 +976,159 @@ function createKitchenFurnishing(
       counterMaterial,
       [-visualFootprint.width / 2 - 0.01, 0.5, 0]
     );
+  }
+
+  return group;
+}
+
+function createSleepingNookFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
+  const isQuarterTurn =
+    Math.abs(Math.sin(definition.orientationRadians)) >
+    Math.abs(Math.cos(definition.orientationRadians));
+  const visualFootprint = isQuarterTurn
+    ? { width: footprint.depth, depth: footprint.width }
+    : footprint;
+  const height = definition.visual?.height ?? 0.72;
+  const frameMaterial = createMaterial(definition.visual?.color ?? 0x6f7f92);
+  const beddingMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xd8c7a7
+  );
+  const darkMaterial = createMaterial(0x27231f);
+  const pillowMaterial = createMaterial(0xf1e9da);
+  const group = new Group();
+
+  if (definition.kind === 'sleeping-daybed') {
+    addBox(
+      group,
+      'daybedLowFrame',
+      {
+        width: visualFootprint.width,
+        height: 0.24,
+        depth: visualFootprint.depth,
+      },
+      frameMaterial,
+      [0, 0.16, 0]
+    );
+    addBox(
+      group,
+      'daybedMattress',
+      {
+        width: visualFootprint.width - 0.24,
+        height: 0.22,
+        depth: visualFootprint.depth - 0.32,
+      },
+      pillowMaterial,
+      [0, 0.39, -0.02]
+    );
+    addBox(
+      group,
+      'daybedBlanket',
+      {
+        width: visualFootprint.width - 0.34,
+        height: 0.08,
+        depth: visualFootprint.depth * 0.5,
+      },
+      beddingMaterial,
+      [0.05, 0.56, visualFootprint.depth * 0.16]
+    );
+    [-0.42, 0.42].forEach((x, index) => {
+      addBox(
+        group,
+        `daybedPillow${index}`,
+        { width: 0.58, height: 0.18, depth: 0.36 },
+        pillowMaterial,
+        [x, 0.61, -visualFootprint.depth / 2 + 0.34]
+      );
+    });
+    addBox(
+      group,
+      'murphyWallPanel',
+      { width: visualFootprint.width, height: 1.15, depth: 0.12 },
+      frameMaterial,
+      [0, 0.86, -visualFootprint.depth / 2 + 0.06]
+    );
+  } else if (definition.kind.startsWith('sleeping-nightstand')) {
+    addBox(
+      group,
+      'nightstandBody',
+      { width: visualFootprint.width, height, depth: visualFootprint.depth },
+      frameMaterial,
+      [0, height / 2, 0]
+    );
+    addBox(
+      group,
+      'nightstandDrawer',
+      { width: visualFootprint.width - 0.16, height: 0.08, depth: 0.05 },
+      beddingMaterial,
+      [0, height * 0.55, -visualFootprint.depth / 2 - 0.01]
+    );
+    addBox(
+      group,
+      'nightstandHandle',
+      { width: 0.26, height: 0.04, depth: 0.04 },
+      darkMaterial,
+      [0, height * 0.6, -visualFootprint.depth / 2 - 0.04]
+    );
+    if (definition.kind === 'sleeping-nightstand-lamp') {
+      addBox(
+        group,
+        'nightstandLampBase',
+        { width: 0.18, height: 0.18, depth: 0.18 },
+        darkMaterial,
+        [0.18, height + 0.09, 0]
+      );
+      addBox(
+        group,
+        'nightstandLampShade',
+        { width: 0.32, height: 0.22, depth: 0.32 },
+        beddingMaterial,
+        [0.18, height + 0.29, 0]
+      );
+    } else {
+      [-0.16, 0.02, 0.2].forEach((x, index) => {
+        addBox(
+          group,
+          `nightstandBook${index}`,
+          { width: 0.16, height: 0.06, depth: 0.34 },
+          beddingMaterial,
+          [x, height + 0.03 + index * 0.04, 0]
+        );
+      });
+    }
+  } else if (definition.kind === 'sleeping-reading-chair') {
+    addBox(
+      group,
+      'readingChairSeat',
+      { width: 1.05, height: 0.32, depth: 1.0 },
+      frameMaterial,
+      [0, 0.32, 0]
+    );
+    addBox(
+      group,
+      'readingChairBack',
+      { width: 1.1, height: 0.72, depth: 0.2 },
+      frameMaterial,
+      [0, 0.72, 0.42]
+    );
+    addBox(
+      group,
+      'readingChairCushion',
+      { width: 0.88, height: 0.14, depth: 0.82 },
+      beddingMaterial,
+      [0, 0.55, -0.05]
+    );
+    [-0.52, 0.52].forEach((x, index) => {
+      addBox(
+        group,
+        `readingChairArm${index}`,
+        { width: 0.18, height: 0.48, depth: 0.9 },
+        frameMaterial,
+        [x, 0.48, -0.02]
+      );
+    });
   }
 
   return group;

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -1045,29 +1045,31 @@ function createSleepingNookFurnishing(
     });
     addBox(
       group,
-      'murphyWallPanel',
+      'daybedHeadboardPanel',
       { width: visualFootprint.width, height: 1.15, depth: 0.12 },
       frameMaterial,
       [0, 0.86, -visualFootprint.depth / 2 + 0.06]
     );
   } else if (definition.kind.startsWith('sleeping-nightstand')) {
+    const nightstandPartPrefix = definition.id;
+
     addBox(
       group,
-      'nightstandBody',
+      `${nightstandPartPrefix}:nightstandBody`,
       { width: visualFootprint.width, height, depth: visualFootprint.depth },
       frameMaterial,
       [0, height / 2, 0]
     );
     addBox(
       group,
-      'nightstandDrawer',
+      `${nightstandPartPrefix}:nightstandDrawer`,
       { width: visualFootprint.width - 0.16, height: 0.08, depth: 0.05 },
       beddingMaterial,
       [0, height * 0.55, -visualFootprint.depth / 2 - 0.01]
     );
     addBox(
       group,
-      'nightstandHandle',
+      `${nightstandPartPrefix}:nightstandHandle`,
       { width: 0.26, height: 0.04, depth: 0.04 },
       darkMaterial,
       [0, height * 0.6, -visualFootprint.depth / 2 - 0.04]
@@ -1075,14 +1077,14 @@ function createSleepingNookFurnishing(
     if (definition.kind === 'sleeping-nightstand-lamp') {
       addBox(
         group,
-        'nightstandLampBase',
+        `${nightstandPartPrefix}:nightstandLampBase`,
         { width: 0.18, height: 0.18, depth: 0.18 },
         darkMaterial,
         [0.18, height + 0.09, 0]
       );
       addBox(
         group,
-        'nightstandLampShade',
+        `${nightstandPartPrefix}:nightstandLampShade`,
         { width: 0.32, height: 0.22, depth: 0.32 },
         beddingMaterial,
         [0.18, height + 0.29, 0]
@@ -1091,7 +1093,7 @@ function createSleepingNookFurnishing(
       [-0.16, 0.02, 0.2].forEach((x, index) => {
         addBox(
           group,
-          `nightstandBook${index}`,
+          `${nightstandPartPrefix}:nightstandBook${index}`,
           { width: 0.16, height: 0.06, depth: 0.34 },
           beddingMaterial,
           [x, height + 0.03 + index * 0.04, 0]

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -328,6 +328,62 @@ describe('lower floor furnishings foundation', () => {
     ).toBeDefined();
   });
 
+  it('keeps the rotated studio daybed visual aligned with its authored collider', () => {
+    const { colliders, group } = createLowerFloorFurnishings();
+    const epsilon = 0.000001;
+    const requestedDaybedBounds = {
+      minX: 25.7,
+      maxX: 29.5,
+      minZ: 9.6,
+      maxZ: 11.6,
+    };
+    const daybedDefinition = DEFAULT_LOWER_FLOOR_FURNISHINGS.find(
+      ({ id }) => id === 'studio-daybed'
+    );
+    const daybedCollider = colliders.find(
+      ({ furnishingId }) => furnishingId === 'studio-daybed'
+    );
+    const nightstandSouthCollider = colliders.find(
+      ({ furnishingId }) => furnishingId === 'studio-nightstand-south'
+    );
+    const nightstandNorthCollider = colliders.find(
+      ({ furnishingId }) => furnishingId === 'studio-nightstand-north'
+    );
+    const daybed = group.getObjectByName('Furnishing:studio-daybed');
+
+    expect(daybedDefinition?.orientationRadians).toBe(-Math.PI / 2);
+    expect(daybedDefinition?.solidBounds).toMatchObject(requestedDaybedBounds);
+    expect(daybedCollider).toMatchObject(requestedDaybedBounds);
+    expect(daybed).toBeDefined();
+    expect(nightstandSouthCollider).toBeDefined();
+    expect(nightstandNorthCollider).toBeDefined();
+
+    const visualBounds = new Box3().setFromObject(daybed!);
+
+    expect(visualBounds.min.x).toBeCloseTo(daybedCollider!.minX, 6);
+    expect(visualBounds.max.x).toBeCloseTo(daybedCollider!.maxX, 6);
+    expect(visualBounds.min.z).toBeCloseTo(daybedCollider!.minZ, 6);
+    expect(visualBounds.max.z).toBeCloseTo(daybedCollider!.maxZ, 6);
+    expect(Math.abs(visualBounds.min.x - daybedCollider!.minX)).toBeLessThan(
+      epsilon
+    );
+    expect(Math.abs(visualBounds.max.x - daybedCollider!.maxX)).toBeLessThan(
+      epsilon
+    );
+    expect(Math.abs(visualBounds.min.z - daybedCollider!.minZ)).toBeLessThan(
+      epsilon
+    );
+    expect(Math.abs(visualBounds.max.z - daybedCollider!.maxZ)).toBeLessThan(
+      epsilon
+    );
+    expect(visualBounds.min.z).toBeGreaterThanOrEqual(
+      nightstandSouthCollider!.maxZ
+    );
+    expect(visualBounds.max.z).toBeLessThanOrEqual(
+      nightstandNorthCollider!.minZ
+    );
+  });
+
   it('uses the requested kitchen kitchenette and dining AABBs', () => {
     const { colliders } = createLowerFloorFurnishings();
     const expectedKitchenBounds: Record<string, RectCollider> = {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,8 +76,8 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(20);
-    expect(build.decorativeFootprints).toHaveLength(1);
+    expect(build.colliders).toHaveLength(24);
+    expect(build.decorativeFootprints).toHaveLength(2);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
       'living-room-coffee-table',
@@ -99,6 +99,11 @@ describe('lower floor furnishings foundation', () => {
       'studio-north-bookcase-east',
       'studio-drafting-drawers',
       'studio-east-dresser',
+      'studio-daybed',
+      'studio-nightstand-south',
+      'studio-nightstand-north',
+      'studio-reading-chair',
+      'studio-bedside-rug',
       'living-room-media-rug',
     ]);
   });
@@ -243,6 +248,70 @@ describe('lower floor furnishings foundation', () => {
         )
       ).toHaveLength(1);
     });
+  });
+
+  it('adds the requested studio sleeping nook AABBs and non-blocking rug', () => {
+    const { colliders, decorativeFootprints, group } =
+      createLowerFloorFurnishings();
+    const expectedSleepingBounds: Record<string, RectCollider> = {
+      'studio-daybed': { minX: 25.7, maxX: 29.5, minZ: 9.6, maxZ: 11.6 },
+      'studio-nightstand-south': {
+        minX: 27.2,
+        maxX: 28.0,
+        minZ: 8.2,
+        maxZ: 9.0,
+      },
+      'studio-nightstand-north': {
+        minX: 27.2,
+        maxX: 28.0,
+        minZ: 12.2,
+        maxZ: 13.0,
+      },
+      'studio-reading-chair': {
+        minX: 21.5,
+        maxX: 22.9,
+        minZ: 11.9,
+        maxZ: 13.3,
+      },
+    };
+
+    Object.entries(expectedSleepingBounds).forEach(([id, expected]) => {
+      const matchingColliders = colliders.filter(
+        (collider) => collider.furnishingId === id
+      );
+      expect(matchingColliders).toHaveLength(1);
+      expect(matchingColliders[0]).toMatchObject({
+        ...expected,
+        category: 'sleeping-nook',
+        roomId: 'studio',
+      });
+    });
+
+    const rug = decorativeFootprints.find(
+      (footprint) => footprint.furnishingId === 'studio-bedside-rug'
+    );
+    expect(rug).toMatchObject({
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      bounds: { minX: 23.1, maxX: 27.9, minZ: 9.3, maxZ: 12.3 },
+      allowSolidOverlap: true,
+    });
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'studio-bedside-rug'
+      )
+    ).toBe(false);
+
+    [
+      'studio-daybed',
+      'studio-nightstand-south',
+      'studio-nightstand-north',
+    ].forEach((id) => {
+      expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
+    });
+    expect(
+      group.getObjectByName('FurnishingPart:readingChairCushion')
+    ).toBeDefined();
   });
 
   it('uses the requested kitchen kitchenette and dining AABBs', () => {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -306,9 +306,23 @@ describe('lower floor furnishings foundation', () => {
       'studio-daybed',
       'studio-nightstand-south',
       'studio-nightstand-north',
+      'studio-reading-chair',
     ].forEach((id) => {
       expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
     });
+    expect(
+      group.getObjectByName('FurnishingPart:daybedHeadboardPanel')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName(
+        'FurnishingPart:studio-nightstand-south:nightstandBody'
+      )
+    ).toBeDefined();
+    expect(
+      group.getObjectByName(
+        'FurnishingPart:studio-nightstand-north:nightstandBody'
+      )
+    ).toBeDefined();
     expect(
       group.getObjectByName('FurnishingPart:readingChairCushion')
     ).toBeDefined();


### PR DESCRIPTION
### Motivation
- Make the studio feel lived-in by adding a compact sleeping/rest nook while preserving studio POI access, doorway buffers, and existing collider safety rules.

### Description
- Add five new furnishings to `DEFAULT_LOWER_FLOOR_FURNISHINGS` in `src/scene/structures/lowerFloorFurnishings.ts`: `studio-daybed`, `studio-nightstand-south`, `studio-nightstand-north`, `studio-reading-chair`, and a decorative `studio-bedside-rug` with the requested centers, footprints, and exact AABBs.
- Implement `createSleepingNookFurnishing(...)` and route `sleeping-*` kinds through it from `createSolidPrimitive(...)` to build simple layered box visuals (frame, mattress, blanket, pillows, lamp/books, chair cushions) without adding extra movement colliders.
- Extend `src/tests/lowerFloorFurnishings.test.ts` to assert the new IDs, one collider per solid furnishing, the non-blocking bedside rug, and the precise AABBs; add scene-component acknowledgement by bumping the `decor:lower-floor-furnishings` `syncRevision` and updating `miniatureManifest.generated.json`.

### Testing
- `npm run typecheck` — FAILED: reported pre-existing unrelated TypeScript errors elsewhere in the codebase and not introduced by this change.  
- `npm run test:ci -- lowerFloorFurnishings` — PASSED: new sleeping-nook tests ran and passed.  
- `npm run test:ci -- lowerFloorFurnishings miniatureManifest` — PASSED after updating miniature manifest sources and `sceneComponentRegistry.ts`.  
- `npm run test:ci` / `npm run build` / `npm run format:write` / `npm run format:check` / `npm run lint` / `npm run docs:check` / `npm run smoke` — ALL PASSED (docs link checker emitted external-link warnings unrelated to these changes).  
- `git diff --cached | ./scripts/scan-secrets.py` — PASSED (no high-risk secrets found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a415f6b046c832fa7da215b91b9c10e)