### PR TITLE
🪴 Add lower-floor plants, lamps, and small decor (P6)

### DIFF
--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -410,6 +410,69 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         allowDecorativeOverlapWithAnySolid: true,
       },
     },
+
+    {
+      id: 'living-room-large-plant',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: -28.6, z: -26.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -28.95, maxX: -28.25, minZ: -26.55, maxZ: -25.85 },
+      kind: 'large-potted-plant',
+      visual: { color: 0x5f4734, accentColor: 0x4f8f52, height: 1.65 },
+    },
+    {
+      id: 'living-room-plant-stool',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: 5.8, z: -30.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: 5.3, maxX: 6.3, minZ: -31.3, maxZ: -30.3 },
+      kind: 'plant-stool',
+      visual: { color: 0x6c4c32, accentColor: 0x66a15e, height: 1.15 },
+    },
+    {
+      id: 'studio-floor-lamp',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 24.4, z: 14.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.55, depth: 0.55 },
+      solidBounds: { minX: 24.125, maxX: 24.675, minZ: 13.825, maxZ: 14.375 },
+      kind: 'floor-lamp',
+      visual: { color: 0x2b2b2f, accentColor: 0xffd48a, height: 1.75 },
+    },
+    {
+      id: 'studio-monstera',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 30.6, z: -5.4 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: 30.1, maxX: 31.1, minZ: -5.9, maxZ: -4.9 },
+      kind: 'monstera-plant',
+      visual: { color: 0x5f4734, accentColor: 0x3f8a4c, height: 1.55 },
+    },
+    {
+      id: 'kitchen-herb-planter',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -30.4, y: 0.98, z: 9.2 },
+      orientationRadians: 0,
+      kind: 'herb-planter-decor',
+      visual: { color: 0x7a5538, accentColor: 0x6fae62, height: 0.45 },
+    },
+    {
+      id: 'kitchen-pendant-lights',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -13.0, y: 2.2, z: 10.9 },
+      orientationRadians: 0,
+      kind: 'pendant-lights-decor',
+      visual: { color: 0x2b2b2f, accentColor: 0xffd48a, height: 0.9 },
+    },
     {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
@@ -577,6 +640,10 @@ export function createLowerFloorFurnishings(
       });
     }
 
+    if (!definition.solidFootprint && !definition.decorativeFootprint) {
+      furnishing.add(createVisualOnlyPrimitive(definition));
+    }
+
     if (definition.decorativeFootprint) {
       furnishing.add(createDecorativePrimitive(definition));
       decorativeFootprints.push({
@@ -606,6 +673,8 @@ function createSolidPrimitive(
   if (definition.kind === 'side-table') return createSideTable(definition);
   if (definition.kind === 'lounge-chair') return createLoungeChair(definition);
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
+  if (definition.kind.includes('plant'))
+    return createPlantFurnishing(definition);
   if (definition.kind.startsWith('sleeping-'))
     return createSleepingNookFurnishing(definition);
   if (definition.kind.startsWith('kitchen-'))
@@ -782,6 +851,148 @@ function createLoungeChair(definition: LowerFloorFurnishingDefinition): Group {
     pillowMaterial,
     [0, 0.72, 0.4]
   );
+  return group;
+}
+
+function createPlantFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 0.8, depth: 0.8 };
+  const potMaterial = createMaterial(definition.visual?.color ?? 0x5f4734);
+  const foliageMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x4f8f52
+  );
+  const stemMaterial = createMaterial(0x4b3525);
+  const group = new Group();
+  const potRadius = Math.min(footprint.width, footprint.depth) * 0.28;
+
+  const pot = new Mesh(
+    new CylinderGeometry(potRadius * 0.78, potRadius, 0.42, 16),
+    potMaterial
+  );
+  pot.name = `Furnishing:${definition.id}:pot`;
+  pot.position.y = 0.21;
+  group.add(pot);
+
+  const rim = new Mesh(
+    new CylinderGeometry(potRadius * 1.05, potRadius * 1.05, 0.08, 16),
+    potMaterial
+  );
+  rim.name = `Furnishing:${definition.id}:potRim`;
+  rim.position.y = 0.45;
+  group.add(rim);
+
+  const trunkHeight = definition.kind === 'plant-stool' ? 0.54 : 0.84;
+  if (definition.kind === 'plant-stool') {
+    addBox(
+      group,
+      'plantStoolTop',
+      { width: 0.78, height: 0.1, depth: 0.78 },
+      stemMaterial,
+      [0, 0.48, 0]
+    );
+    [-0.24, 0.24].forEach((x, xIndex) => {
+      [-0.24, 0.24].forEach((z, zIndex) => {
+        addBox(
+          group,
+          `plantStoolLeg${xIndex}-${zIndex}`,
+          { width: 0.07, height: 0.48, depth: 0.07 },
+          stemMaterial,
+          [x, 0.24, z]
+        );
+      });
+    });
+    pot.position.y += 0.54;
+    rim.position.y += 0.54;
+  }
+
+  const stemBaseY = definition.kind === 'plant-stool' ? 0.9 : 0.46;
+  const stem = new Mesh(
+    new CylinderGeometry(0.035, 0.045, trunkHeight, 8),
+    stemMaterial
+  );
+  stem.name = `Furnishing:${definition.id}:stem`;
+  stem.position.y = stemBaseY + trunkHeight / 2;
+  group.add(stem);
+
+  const leafCount = definition.kind === 'monstera-plant' ? 8 : 6;
+  for (let index = 0; index < leafCount; index += 1) {
+    const angle = (Math.PI * 2 * index) / leafCount;
+    const leaf = new Mesh(new BoxGeometry(0.12, 0.36, 0.04), foliageMaterial);
+    leaf.name = `Furnishing:${definition.id}:leaf${index}`;
+    leaf.position.set(
+      Math.cos(angle) * 0.22,
+      stemBaseY + trunkHeight + 0.06 + (index % 2) * 0.12,
+      Math.sin(angle) * 0.22
+    );
+    leaf.rotation.y = -angle;
+    leaf.rotation.z = Math.PI / 5;
+    group.add(leaf);
+  }
+
+  return group;
+}
+
+function createVisualOnlyPrimitive(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const group = new Group();
+  if (definition.kind === 'herb-planter-decor') {
+    const planterMaterial = createMaterial(
+      definition.visual?.color ?? 0x7a5538
+    );
+    const leafMaterial = createMaterial(
+      definition.visual?.accentColor ?? 0x6fae62
+    );
+    addBox(
+      group,
+      'herbPlanterBox',
+      { width: 0.72, height: 0.16, depth: 0.28 },
+      planterMaterial,
+      [0, 0.08, 0]
+    );
+    [-0.24, -0.08, 0.08, 0.24].forEach((x, index) => {
+      addBox(
+        group,
+        `herbStem${index}`,
+        { width: 0.04, height: 0.34, depth: 0.04 },
+        leafMaterial,
+        [x, 0.32, 0]
+      );
+      addBox(
+        group,
+        `herbLeaf${index}`,
+        { width: 0.14, height: 0.04, depth: 0.08 },
+        leafMaterial,
+        [x + 0.04, 0.48, 0.02]
+      );
+    });
+  } else if (definition.kind === 'pendant-lights-decor') {
+    const cordMaterial = createMaterial(definition.visual?.color ?? 0x2b2b2f);
+    const shadeMaterial = createMaterial(
+      definition.visual?.accentColor ?? 0xffd48a,
+      {
+        emissive: definition.visual?.accentColor ?? 0xffd48a,
+        emissiveIntensity: 0.4,
+      }
+    );
+    [-0.8, 0, 0.8].forEach((x, index) => {
+      addBox(
+        group,
+        `pendantCord${index}`,
+        { width: 0.035, height: 0.62, depth: 0.035 },
+        cordMaterial,
+        [x, 0.31, 0]
+      );
+      const shade = new Mesh(
+        new CylinderGeometry(0.22, 0.32, 0.24, 16),
+        shadeMaterial
+      );
+      shade.name = `FurnishingPart:pendantShade${index}`;
+      shade.position.set(x, 0.72, 0);
+      group.add(shade);
+    });
+  }
   return group;
 }
 

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,7 +76,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(24);
+    expect(build.colliders).toHaveLength(28);
     expect(build.decorativeFootprints).toHaveLength(2);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -104,6 +104,12 @@ describe('lower floor furnishings foundation', () => {
       'studio-nightstand-north',
       'studio-reading-chair',
       'studio-bedside-rug',
+      'living-room-large-plant',
+      'living-room-plant-stool',
+      'studio-floor-lamp',
+      'studio-monstera',
+      'kitchen-herb-planter',
+      'kitchen-pendant-lights',
       'living-room-media-rug',
     ]);
   });
@@ -194,6 +200,108 @@ describe('lower floor furnishings foundation', () => {
         expect(rectanglesOverlap(storage, blocker)).toBe(false);
       });
     });
+  });
+
+  it('adds P6 plants, lamps, and decor with intended solid and visual-only behavior', () => {
+    const { colliders, group } = createLowerFloorFurnishings();
+    const expectedDecorBounds: Record<string, RectCollider> = {
+      'living-room-large-plant': {
+        minX: -28.95,
+        maxX: -28.25,
+        minZ: -26.55,
+        maxZ: -25.85,
+      },
+      'living-room-plant-stool': {
+        minX: 5.3,
+        maxX: 6.3,
+        minZ: -31.3,
+        maxZ: -30.3,
+      },
+      'studio-floor-lamp': {
+        minX: 24.125,
+        maxX: 24.675,
+        minZ: 13.825,
+        maxZ: 14.375,
+      },
+      'studio-monstera': {
+        minX: 30.1,
+        maxX: 31.1,
+        minZ: -5.9,
+        maxZ: -4.9,
+      },
+    };
+    const p6SolidIds = Object.keys(expectedDecorBounds);
+    const p6Colliders = colliders.filter((collider) =>
+      p6SolidIds.includes(collider.furnishingId)
+    );
+
+    expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([
+        ...p6SolidIds,
+        'kitchen-herb-planter',
+        'kitchen-pendant-lights',
+      ])
+    );
+    expect(new Set(colliders.map(({ category }) => category))).toContain(
+      'plants-lighting-decor'
+    );
+
+    Object.entries(expectedDecorBounds).forEach(([id, expected]) => {
+      const matchingColliders = colliders.filter(
+        (collider) => collider.furnishingId === id
+      );
+      expect(matchingColliders).toHaveLength(1);
+      expect(matchingColliders[0]).toMatchObject({
+        ...expected,
+        category: 'plants-lighting-decor',
+      });
+      expect(
+        matchingColliders[0].maxX - matchingColliders[0].minX
+      ).toBeGreaterThan(0);
+      expect(
+        matchingColliders[0].maxZ - matchingColliders[0].minZ
+      ).toBeGreaterThan(0);
+      expect(
+        isContainedBy(
+          LOWER_FLOOR_ROOM_BOUNDS[matchingColliders[0].roomId],
+          matchingColliders[0]
+        )
+      ).toBe(true);
+    });
+
+    p6Colliders.forEach((p6Collider, index) => {
+      p6Colliders.slice(index + 1).forEach((otherP6Collider) => {
+        expect(rectanglesOverlap(p6Collider, otherP6Collider)).toBe(false);
+      });
+      colliders
+        .filter(
+          (collider) =>
+            !p6SolidIds.includes(collider.furnishingId) &&
+            [
+              'living-room-seating',
+              'kitchenette',
+              'storage',
+              'sleeping-nook',
+            ].includes(collider.category)
+        )
+        .forEach((otherCollider) => {
+          expect(rectanglesOverlap(p6Collider, otherCollider)).toBe(false);
+        });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(p6Collider, blocker)).toBe(false);
+      });
+    });
+
+    ['kitchen-herb-planter', 'kitchen-pendant-lights'].forEach((id) => {
+      expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
+      expect(colliders.some((collider) => collider.furnishingId === id)).toBe(
+        false
+      );
+    });
+    expect(group.getObjectByName('FurnishingPart:pendantShade0')).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:herbPlanterBox')
+    ).toBeDefined();
   });
 
   it('keeps collider source IDs valid and unique for the default plan', () => {


### PR DESCRIPTION
### Motivation
- Warm the merged lower-floor furnishing plan by adding targeted plants, lamps, and small decorative details while preserving existing POIs, furniture, and navigation buffers.
- Provide authored blocking colliders for floor-standing decor and visual-only attachments for tabletop/ceiling details to keep movement geometry correct and performant.

### Description
- Add four P6 solid floor-standing definitions to `DEFAULT_LOWER_FLOOR_FURNISHINGS` with the requested IDs, rooms, exact centers, and authored AABBs: `living-room-large-plant`, `living-room-plant-stool`, `studio-floor-lamp`, and `studio-monstera` in `src/scene/structures/lowerFloorFurnishings.ts`.
- Add two visual-only kitchen details `kitchen-herb-planter` and `kitchen-pendant-lights` and render them as non-blocking child geometry (no movement colliders) via a new `createVisualOnlyPrimitive` helper.
- Implement low-poly plant and stool visuals with pot/rim/stem/leaves and add `createPlantFurnishing` for floor-standing plant meshes, plus wire up a small builder branch so definitions without footprints produce visual-only meshes.
- Update `src/tests/lowerFloorFurnishings.test.ts` to expect the expanded default plan, the new collider count, and to validate the P6 AABBs, room containment, no-overlap constraints, `plants-lighting-decor` category presence, and that kitchen details remain non-blocking.

### Testing
- Ran formatting: `npm run format:write -- src/scene/structures/lowerFloorFurnishings.ts src/tests/lowerFloorFurnishings.test.ts` (passed).
- Lint: `npm run lint` (passed).
- Typecheck: `npm run typecheck` (failed due to pre-existing, unrelated TypeScript baseline errors outside the changed files).
- Focused unit tests: `npm run test:ci -- lowerFloorFurnishings` (passed; 25 tests, 25 passed) which verifies the new P6 colliders, bounds, overlaps, and non-blocking visual details.
- Build: `npm run build` (passed) and smoke check `npm run smoke` (passed); docs check `npm run docs:check` passed with external-link fetch warnings reported by the checker.
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).
- Preview screenshot attempt using Playwright failed because the Playwright browser binaries are not installed in this environment (`npx playwright install` required), so visual verification was not captured here.

Files changed: `src/scene/structures/lowerFloorFurnishings.ts`, `src/tests/lowerFloorFurnishings.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41a4451a00832f9425709daaba0e44)