### PR TITLE
🌿 : – add lower-floor plants and warm decor

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 11,
-      "syncNote": "Sleeping nook mesh names remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.",
-      "sourceFingerprint": "996ac2753ac18b07253866eda65eee556cbd7e579f132ae70e431b0553119cc3",
+      "syncRevision": 12,
+      "syncNote": "Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.",
+      "sourceFingerprint": "86c76da16b6874fe017946e7674017fa56d4ecec50bc6ba7ab4bd999c3eead71",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "e2fd9544a6dbdce90993b407a449a233ecb002ae7ec826c2707614df5d63031d"
+      "metadataFingerprint": "ca00a44903f70c588bc7a4b265fe1872b176e90f549536e52f623ce95ed4b4ec"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 12,
-      "syncNote": "Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.",
-      "sourceFingerprint": "86c76da16b6874fe017946e7674017fa56d4ecec50bc6ba7ab4bd999c3eead71",
+      "syncRevision": 13,
+      "syncNote": "Review feedback tightened validation and mesh naming without adding miniature proxies.",
+      "sourceFingerprint": "5df5d198774eda1c657978400b32832f31ee6e3c011bae787f0b761f170add3a",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "ca00a44903f70c588bc7a4b265fe1872b176e90f549536e52f623ce95ed4b4ec"
+      "metadataFingerprint": "66a90d85c5dabdcc456d60f2074f602e47c2587051c3b8bf1f2c0ef4c84841cd"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 11,
+    syncRevision: 12,
     reason:
-      'Sleeping nook mesh names remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
+      'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,7 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 12,
+    syncRevision: 13,
+    syncNote:
+      'Review feedback tightened validation and mesh naming without adding miniature proxies.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -207,7 +207,7 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       id: 'kitchen-herb-planter',
       category: 'plants-lighting-decor',
       roomId: 'kitchen',
-      position: { x: -30.4, z: 9.2 },
+      position: { x: -31.0, z: 7.9 },
       orientationRadians: 0,
       kind: 'herb-planter-detail',
       visual: { color: 0xb7834f, accentColor: 0x6f9f5d, height: 1.0 },
@@ -519,6 +519,19 @@ export function rectanglesOverlap(
   );
 }
 
+function containsPoint(
+  bounds: RectCollider,
+  point: { x: number; z: number },
+  tolerance = 0
+): boolean {
+  return (
+    point.x >= bounds.minX - tolerance &&
+    point.x <= bounds.maxX + tolerance &&
+    point.z >= bounds.minZ - tolerance &&
+    point.z <= bounds.maxZ + tolerance
+  );
+}
+
 export function validateLowerFloorFurnishingPlan(
   definitions: readonly LowerFloorFurnishingDefinition[],
   options: LowerFloorFurnishingValidationOptions = {}
@@ -570,6 +583,21 @@ export function validateLowerFloorFurnishingPlan(
         );
       }
     });
+  });
+
+  definitions.forEach((definition) => {
+    if (definition.solidFootprint || definition.decorativeFootprint) return;
+    if (
+      !containsPoint(
+        roomBounds[definition.roomId],
+        definition.position,
+        tolerance
+      )
+    ) {
+      throw new Error(
+        `${definition.id} visual detail position is outside ${definition.roomId}.`
+      );
+    }
   });
 
   definitions.forEach((definition) => {
@@ -951,8 +979,8 @@ function createMonsteraPlant(
     potMaterial,
     [0, 0.46, 0]
   );
-  addPlantLeaves(group, leafMaterial, 0.72, 1.05);
-  addPlantLeaves(group, leafMaterial, 0.56, 1.38);
+  addPlantLeaves(group, leafMaterial, 0.72, 1.05, 'lower');
+  addPlantLeaves(group, leafMaterial, 0.56, 1.38, 'upper');
   return group;
 }
 
@@ -960,7 +988,8 @@ function addPlantLeaves(
   group: Group,
   material: MeshStandardMaterial,
   spread: number,
-  y: number
+  y: number,
+  namePrefix = 'leaf'
 ): void {
   const leafPositions: Array<[number, number, number]> = [
     [0, y, 0],
@@ -972,7 +1001,7 @@ function addPlantLeaves(
   leafPositions.forEach(([x, leafY, z], index) => {
     addBox(
       group,
-      `plantLeaf${index}`,
+      `plantLeaf${namePrefix}${index}`,
       { width: spread, height: 0.08, depth: 0.24 },
       material,
       [x, leafY, z]
@@ -1667,9 +1696,12 @@ function createVisualDetailPrimitive(
         [x, 1.58, 0]
       );
     });
+    return group;
   }
 
-  return group;
+  throw new Error(
+    `Unsupported visual-only furnishing kind: ${definition.kind}.`
+  );
 }
 
 function createDecorativePrimitive(

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -182,6 +182,47 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
     },
 
     {
+      id: 'living-room-large-plant',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: -28.6, z: -26.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -28.95, maxX: -28.25, minZ: -26.55, maxZ: -25.85 },
+      kind: 'large-potted-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x5f8f48, height: 1.65 },
+    },
+    {
+      id: 'living-room-plant-stool',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: 5.8, z: -30.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: 5.3, maxX: 6.3, minZ: -31.3, maxZ: -30.3 },
+      kind: 'plant-stool',
+      visual: { color: 0x6a4a32, accentColor: 0x6e9b58, height: 1.05 },
+    },
+    {
+      id: 'kitchen-herb-planter',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -30.4, z: 9.2 },
+      orientationRadians: 0,
+      kind: 'herb-planter-detail',
+      visual: { color: 0xb7834f, accentColor: 0x6f9f5d, height: 1.0 },
+    },
+    {
+      id: 'kitchen-pendant-lights',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -13.0, z: 10.9 },
+      orientationRadians: 0,
+      kind: 'pendant-lights-detail',
+      visual: { color: 0x2f3740, accentColor: 0xffd48a, height: 2.45 },
+    },
+
+    {
       id: 'kitchen-west-counter-run',
       category: 'kitchenette',
       roomId: 'kitchen',
@@ -350,6 +391,30 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'storage-east-dresser',
       visual: { color: 0x4d3a2b, accentColor: 0xb8c0c8, height: 1.05 },
     },
+
+    {
+      id: 'studio-floor-lamp',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 24.4, z: 14.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.55, depth: 0.55 },
+      solidBounds: { minX: 24.125, maxX: 24.675, minZ: 13.825, maxZ: 14.375 },
+      kind: 'floor-lamp',
+      visual: { color: 0x2b2b2f, accentColor: 0xffd48a, height: 1.75 },
+    },
+    {
+      id: 'studio-monstera',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 30.6, z: -5.4 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: 30.1, maxX: 31.1, minZ: -5.9, maxZ: -4.9 },
+      kind: 'monstera-plant',
+      visual: { color: 0x7a5134, accentColor: 0x4f8f4f, height: 1.55 },
+    },
+
     {
       id: 'studio-daybed',
       category: 'sleeping-nook',
@@ -592,6 +657,10 @@ export function createLowerFloorFurnishings(
       });
     }
 
+    if (!definition.solidFootprint && !definition.decorativeFootprint) {
+      furnishing.add(createVisualDetailPrimitive(definition));
+    }
+
     group.add(furnishing);
   });
 
@@ -606,6 +675,11 @@ function createSolidPrimitive(
   if (definition.kind === 'side-table') return createSideTable(definition);
   if (definition.kind === 'lounge-chair') return createLoungeChair(definition);
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
+  if (definition.kind === 'large-potted-plant')
+    return createLargePottedPlant(definition);
+  if (definition.kind === 'plant-stool') return createPlantStool(definition);
+  if (definition.kind === 'monstera-plant')
+    return createMonsteraPlant(definition);
   if (definition.kind.startsWith('sleeping-'))
     return createSleepingNookFurnishing(definition);
   if (definition.kind.startsWith('kitchen-'))
@@ -783,6 +857,127 @@ function createLoungeChair(definition: LowerFloorFurnishingDefinition): Group {
     [0, 0.72, 0.4]
   );
   return group;
+}
+
+function createLargePottedPlant(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const group = new Group();
+  const potMaterial = createMaterial(definition.visual?.color ?? 0x8a5a36);
+  const leafMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x5f8f48
+  );
+  const trunkMaterial = createMaterial(0x5b3a24);
+  addBox(
+    group,
+    'plantPotBase',
+    { width: 0.46, height: 0.36, depth: 0.46 },
+    potMaterial,
+    [0, 0.18, 0]
+  );
+  addBox(
+    group,
+    'plantPotRim',
+    { width: 0.58, height: 0.08, depth: 0.58 },
+    potMaterial,
+    [0, 0.4, 0]
+  );
+  addBox(
+    group,
+    'plantTrunk',
+    { width: 0.1, height: 0.75, depth: 0.1 },
+    trunkMaterial,
+    [0, 0.8, 0]
+  );
+  addPlantLeaves(group, leafMaterial, 0.58, 1.1);
+  return group;
+}
+
+function createPlantStool(definition: LowerFloorFurnishingDefinition): Group {
+  const group = new Group();
+  const woodMaterial = createMaterial(definition.visual?.color ?? 0x6a4a32);
+  const potMaterial = createMaterial(0xb7834f);
+  const leafMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x6e9b58
+  );
+  addBox(
+    group,
+    'plantStoolSeat',
+    { width: 0.62, height: 0.12, depth: 0.62 },
+    woodMaterial,
+    [0, 0.48, 0]
+  );
+  [-0.22, 0.22].forEach((x, xIndex) => {
+    [-0.22, 0.22].forEach((z, zIndex) => {
+      addBox(
+        group,
+        `plantStoolLeg${xIndex}-${zIndex}`,
+        { width: 0.08, height: 0.48, depth: 0.08 },
+        woodMaterial,
+        [x, 0.24, z]
+      );
+    });
+  });
+  addBox(
+    group,
+    'stoolPlantPot',
+    { width: 0.38, height: 0.28, depth: 0.38 },
+    potMaterial,
+    [0, 0.68, 0]
+  );
+  addPlantLeaves(group, leafMaterial, 0.34, 0.92);
+  return group;
+}
+
+function createMonsteraPlant(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const group = new Group();
+  const potMaterial = createMaterial(definition.visual?.color ?? 0x7a5134);
+  const leafMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x4f8f4f
+  );
+  addBox(
+    group,
+    'monsteraPot',
+    { width: 0.58, height: 0.42, depth: 0.58 },
+    potMaterial,
+    [0, 0.21, 0]
+  );
+  addBox(
+    group,
+    'monsteraPotRim',
+    { width: 0.7, height: 0.08, depth: 0.7 },
+    potMaterial,
+    [0, 0.46, 0]
+  );
+  addPlantLeaves(group, leafMaterial, 0.72, 1.05);
+  addPlantLeaves(group, leafMaterial, 0.56, 1.38);
+  return group;
+}
+
+function addPlantLeaves(
+  group: Group,
+  material: MeshStandardMaterial,
+  spread: number,
+  y: number
+): void {
+  const leafPositions: Array<[number, number, number]> = [
+    [0, y, 0],
+    [-spread * 0.35, y + 0.12, 0.08],
+    [spread * 0.35, y + 0.08, -0.08],
+    [0.08, y + 0.18, spread * 0.32],
+    [-0.06, y + 0.16, -spread * 0.32],
+  ];
+  leafPositions.forEach(([x, leafY, z], index) => {
+    addBox(
+      group,
+      `plantLeaf${index}`,
+      { width: spread, height: 0.08, depth: 0.24 },
+      material,
+      [x, leafY, z]
+    );
+  });
 }
 
 function createFloorLamp(definition: LowerFloorFurnishingDefinition): Group {
@@ -1404,6 +1599,77 @@ function addBox(
   mesh.name = `FurnishingPart:${name}`;
   mesh.position.set(...position);
   group.add(mesh);
+}
+
+function createVisualDetailPrimitive(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const group = new Group();
+  const baseMaterial = createMaterial(definition.visual?.color ?? 0x8a5a36);
+  const accentMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x6f9f5d,
+    {
+      emissive: definition.kind.includes('pendant')
+        ? (definition.visual?.accentColor ?? 0xffd48a)
+        : 0x000000,
+      emissiveIntensity: definition.kind.includes('pendant') ? 0.35 : 0,
+    }
+  );
+
+  if (definition.kind === 'herb-planter-detail') {
+    addBox(
+      group,
+      'kitchenHerbPlanterBox',
+      { width: 0.62, height: 0.18, depth: 0.28 },
+      baseMaterial,
+      [0, 0.98, 0]
+    );
+    [-0.2, 0, 0.2].forEach((x, index) => {
+      addBox(
+        group,
+        `kitchenHerbStem${index}`,
+        { width: 0.04, height: 0.3, depth: 0.04 },
+        accentMaterial,
+        [x, 1.22, 0]
+      );
+      addBox(
+        group,
+        `kitchenHerbLeaves${index}`,
+        { width: 0.18, height: 0.08, depth: 0.16 },
+        accentMaterial,
+        [x, 1.38, 0]
+      );
+    });
+    return group;
+  }
+
+  if (definition.kind === 'pendant-lights-detail') {
+    [-0.9, 0, 0.9].forEach((x, index) => {
+      addBox(
+        group,
+        `pendantCord${index}`,
+        { width: 0.035, height: 0.72, depth: 0.035 },
+        baseMaterial,
+        [x, 2.25, 0]
+      );
+      addBox(
+        group,
+        `pendantShade${index}`,
+        { width: 0.38, height: 0.24, depth: 0.38 },
+        accentMaterial,
+        [x, 1.78, 0]
+      );
+      addBox(
+        group,
+        `pendantBulb${index}`,
+        { width: 0.16, height: 0.12, depth: 0.16 },
+        accentMaterial,
+        [x, 1.58, 0]
+      );
+    });
+  }
+
+  return group;
 }
 
 function createDecorativePrimitive(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -274,6 +274,67 @@ describe('lower floor furnishings foundation', () => {
       group.getObjectByName('FurnishingPart:kitchenHerbPlanterBox')
     ).toBeDefined();
     expect(group.getObjectByName('FurnishingPart:pendantShade0')).toBeDefined();
+
+    const herbPlanter = DEFAULT_LOWER_FLOOR_FURNISHINGS.find(
+      (definition) => definition.id === 'kitchen-herb-planter'
+    );
+    const kitchenCounter = colliders.find(
+      (collider) => collider.furnishingId === 'kitchen-west-counter-run'
+    );
+    expect(herbPlanter?.position).toMatchObject({ x: -31, z: 7.9 });
+    expect(kitchenCounter).toBeDefined();
+    expect(herbPlanter!.position.x).toBeGreaterThan(kitchenCounter!.minX);
+    expect(herbPlanter!.position.x).toBeLessThan(kitchenCounter!.maxX);
+    expect(herbPlanter!.position.z).toBeGreaterThan(kitchenCounter!.minZ);
+    expect(herbPlanter!.position.z).toBeLessThan(kitchenCounter!.maxZ);
+  });
+
+  it('uses unique leaf mesh names across stacked monstera leaves', () => {
+    const { group } = createLowerFloorFurnishings();
+    const monstera = group.getObjectByName('Furnishing:studio-monstera');
+    const leafNames: string[] = [];
+
+    monstera?.traverse((object) => {
+      if (object.name.startsWith('FurnishingPart:plantLeaf')) {
+        leafNames.push(object.name);
+      }
+    });
+
+    expect(leafNames).toHaveLength(10);
+    expect(new Set(leafNames)).toHaveLength(10);
+    expect(leafNames).toContain('FurnishingPart:plantLeaflower0');
+    expect(leafNames).toContain('FurnishingPart:plantLeafupper0');
+  });
+
+  it('validates visual-only details before building visible geometry', () => {
+    const baseVisualDetail: LowerFloorFurnishingDefinition = {
+      id: 'kitchen-window-herb-detail',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -31, z: 7.9 },
+      orientationRadians: 0,
+      kind: 'herb-planter-detail',
+    };
+
+    expect(() =>
+      validateLowerFloorFurnishingPlan([
+        {
+          ...baseVisualDetail,
+          position: { x: -33, z: 7.9 },
+        },
+      ])
+    ).toThrow(/visual detail position is outside kitchen/);
+
+    expect(() =>
+      createLowerFloorFurnishings({
+        definitions: [
+          {
+            ...baseVisualDetail,
+            kind: 'herb-planter-detial',
+          },
+        ],
+      })
+    ).toThrow(/Unsupported visual-only furnishing kind: herb-planter-detial/);
   });
 
   it('keeps plants and floor lamps within room bounds and collision exclusions', () => {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,7 +76,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(24);
+    expect(build.colliders).toHaveLength(28);
     expect(build.decorativeFootprints).toHaveLength(2);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -85,6 +85,10 @@ describe('lower floor furnishings foundation', () => {
       'living-room-lounge-chair-north',
       'living-room-lounge-chair-east',
       'living-room-floor-lamp',
+      'living-room-large-plant',
+      'living-room-plant-stool',
+      'kitchen-herb-planter',
+      'kitchen-pendant-lights',
       'kitchen-west-counter-run',
       'kitchen-fridge',
       'kitchen-sink-cabinet',
@@ -99,6 +103,8 @@ describe('lower floor furnishings foundation', () => {
       'studio-north-bookcase-east',
       'studio-drafting-drawers',
       'studio-east-dresser',
+      'studio-floor-lamp',
+      'studio-monstera',
       'studio-daybed',
       'studio-nightstand-south',
       'studio-nightstand-north',
@@ -192,6 +198,119 @@ describe('lower floor furnishings foundation', () => {
       });
       LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
         expect(rectanglesOverlap(storage, blocker)).toBe(false);
+      });
+    });
+  });
+
+  it('adds plants, lamps, and non-blocking decor with requested AABBs', () => {
+    const { colliders, group } = createLowerFloorFurnishings();
+    const expectedDecorBounds: Record<string, RectCollider> = {
+      'living-room-large-plant': {
+        minX: -28.95,
+        maxX: -28.25,
+        minZ: -26.55,
+        maxZ: -25.85,
+      },
+      'living-room-plant-stool': {
+        minX: 5.3,
+        maxX: 6.3,
+        minZ: -31.3,
+        maxZ: -30.3,
+      },
+      'studio-floor-lamp': {
+        minX: 24.125,
+        maxX: 24.675,
+        minZ: 13.825,
+        maxZ: 14.375,
+      },
+      'studio-monstera': {
+        minX: 30.1,
+        maxX: 31.1,
+        minZ: -5.9,
+        maxZ: -4.9,
+      },
+    };
+
+    expect(
+      new Set(colliders.map(({ category }) => category)).has(
+        'plants-lighting-decor'
+      )
+    ).toBe(true);
+
+    Object.entries(expectedDecorBounds).forEach(([id, expected]) => {
+      const matchingColliders = colliders.filter(
+        (collider) => collider.furnishingId === id
+      );
+      expect(matchingColliders).toHaveLength(1);
+      expect(matchingColliders[0]).toMatchObject({
+        ...expected,
+        category: 'plants-lighting-decor',
+      });
+      expect(
+        matchingColliders[0].maxX - matchingColliders[0].minX
+      ).toBeGreaterThan(0);
+      expect(
+        matchingColliders[0].maxZ - matchingColliders[0].minZ
+      ).toBeGreaterThan(0);
+    });
+
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-herb-planter'
+      )
+    ).toBe(false);
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-pendant-lights'
+      )
+    ).toBe(false);
+    expect(
+      group.getObjectByName('Furnishing:kitchen-herb-planter')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName('Furnishing:kitchen-pendant-lights')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:kitchenHerbPlanterBox')
+    ).toBeDefined();
+    expect(group.getObjectByName('FurnishingPart:pendantShade0')).toBeDefined();
+  });
+
+  it('keeps plants and floor lamps within room bounds and collision exclusions', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const decorIds = new Set([
+      'living-room-large-plant',
+      'living-room-plant-stool',
+      'studio-floor-lamp',
+      'studio-monstera',
+    ]);
+    const decorColliders = colliders.filter((collider) =>
+      decorIds.has(collider.furnishingId)
+    );
+    const priorPassColliders = colliders.filter(
+      (collider) =>
+        !decorIds.has(collider.furnishingId) &&
+        [
+          'living-room-seating',
+          'kitchenette',
+          'storage',
+          'sleeping-nook',
+          'plants-lighting-decor',
+        ].includes(collider.category)
+    );
+
+    decorColliders.forEach((decor, index) => {
+      expect(isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[decor.roomId], decor)).toBe(
+        true
+      );
+      decorColliders.slice(index + 1).forEach((otherDecor) => {
+        expect(rectanglesOverlap(decor, otherDecor)).toBe(false);
+      });
+      priorPassColliders.forEach((other) => {
+        expect(rectanglesOverlap(decor, other)).toBe(false);
+      });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(decor, blocker)).toBe(false);
       });
     });
   });


### PR DESCRIPTION
### Motivation
- Warm up the lower-floor scene with plants, lamps, and small visual details while preserving existing POIs, navigation, and prior furnishing collision behavior.
- Provide deterministic blocking AABBs for floor-standing decor and visual-only child details for tabletop/pendant elements to avoid introducing new movement colliders.

### Description
- Add four P6 floor-standing decor definitions with exact centers and blocking AABBs: `living-room-large-plant`, `living-room-plant-stool`, `studio-floor-lamp`, and `studio-monstera` in `DEFAULT_LOWER_FLOOR_FURNISHINGS` (file: `src/scene/structures/lowerFloorFurnishings.ts`).
- Add visual-only kitchen details `kitchen-herb-planter` and `kitchen-pendant-lights` and a `createVisualDetailPrimitive` codepath to attach non-blocking detail geometry when a definition has no solid/decorative footprint.
- Implement low-poly plant and stool/monstera helper geometry (`createLargePottedPlant`, `createPlantStool`, `createMonsteraPlant`, `addPlantLeaves`) and wire those kinds into the existing `createSolidPrimitive` factory and visual building pipeline.
- Update miniature metadata to acknowledge the source-only furnishing decor change by bumping the `decor:lower-floor-furnishings` sync revision and manifest (`src/scene/miniature/sceneComponentRegistry.ts` and `src/scene/miniature/miniatureManifest.generated.json`).
- Expand `src/tests/lowerFloorFurnishings.test.ts` to assert the new decor IDs exist, verify each P6 blocking AABB matches the requested bounds, confirm decorations stay inside room bounds and avoid overlaps, and assert kitchen herb/pendant details are visual-only.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed successfully.
- Ran focused tests and build steps: `npm run test:ci -- lowerFloorFurnishings` passed, `npm run test:ci -- miniatureManifest lowerFloorFurnishings` passed after updating the miniature manifest, and `npm run build` / `npm run smoke` passed; the added lower-floor tests show the expected colliders and visual-only details.
- The full `npm run test:ci` initially failed because the miniature manifest became stale (fixed by bumping the manifest), and `npm run typecheck` still fails due to unrelated existing TypeScript errors elsewhere in the repo (error begins at `src/main.ts`), so `typecheck` was not used as a gate for this change.
- Security scan `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.

Files changed (high level): `src/scene/structures/lowerFloorFurnishings.ts`, `src/tests/lowerFloorFurnishings.test.ts`, `src/scene/miniature/sceneComponentRegistry.ts`, and `src/scene/miniature/miniatureManifest.generated.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41a44c2354832fb9618af1283fc49d)