### PR TITLE
Add lower-floor plants, lamps, and small decor

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 11,
-      "syncNote": "Sleeping nook mesh names remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.",
-      "sourceFingerprint": "996ac2753ac18b07253866eda65eee556cbd7e579f132ae70e431b0553119cc3",
+      "syncRevision": 12,
+      "syncNote": "Plants, lamps, and visual-only kitchen decor reviewed; furnishing proxy work stays deferred until the full furnishing set lands.",
+      "sourceFingerprint": "1d2ad4949c2c95f1b3f84c23f3af8b2cde6424ab7295f96705703a4a4309d058",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "e2fd9544a6dbdce90993b407a449a233ecb002ae7ec826c2707614df5d63031d"
+      "metadataFingerprint": "27fd25c237c4d1d1841cfea255ec474488f5e6025bf7f22e5f6a2cb19dece157"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 11,
+    syncRevision: 12,
     reason:
-      'Sleeping nook mesh names remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
+      'Plants, lamps, and visual-only kitchen decor reviewed; furnishing proxy work stays deferred until the full furnishing set lands.',
   },
   {
     id: 'avatar:overworld-player',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -182,6 +182,29 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
     },
 
     {
+      id: 'living-room-large-plant',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: -28.6, z: -26.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -28.95, maxX: -28.25, minZ: -26.55, maxZ: -25.85 },
+      kind: 'large-potted-plant',
+      visual: { color: 0x8a5b36, accentColor: 0x5f8f47, height: 1.65 },
+    },
+    {
+      id: 'living-room-plant-stool',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: 5.8, z: -30.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: 5.3, maxX: 6.3, minZ: -31.3, maxZ: -30.3 },
+      kind: 'plant-stool',
+      visual: { color: 0x5c4a3c, accentColor: 0x6e9b58, height: 1.1 },
+    },
+
+    {
       id: 'kitchen-west-counter-run',
       category: 'kitchenette',
       roomId: 'kitchen',
@@ -250,6 +273,25 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'kitchen-island',
       visual: { color: 0x526171, accentColor: 0xd0bea2, height: 0.92 },
     },
+    {
+      id: 'kitchen-herb-planter',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -30.4, z: 9.2 },
+      orientationRadians: Math.PI / 2,
+      kind: 'kitchen-herb-planter',
+      visual: { color: 0xc28d52, accentColor: 0x5f9a57, height: 1.08 },
+    },
+    {
+      id: 'kitchen-pendant-lights',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -13.0, z: 10.9 },
+      orientationRadians: 0,
+      kind: 'kitchen-pendant-lights',
+      visual: { color: 0x27231f, accentColor: 0xffd48a, height: 2.25 },
+    },
+
     {
       id: 'kitchen-bar-stool-west',
       category: 'kitchenette',
@@ -394,6 +436,29 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'sleeping-reading-chair',
       visual: { color: 0x7d6f89, accentColor: 0xd8c7a7, height: 0.82 },
     },
+    {
+      id: 'studio-floor-lamp',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 24.4, z: 14.1 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.55, depth: 0.55 },
+      solidBounds: { minX: 24.125, maxX: 24.675, minZ: 13.825, maxZ: 14.375 },
+      kind: 'floor-lamp',
+      visual: { color: 0x2b2b2f, accentColor: 0xffd48a, height: 1.75 },
+    },
+    {
+      id: 'studio-monstera',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 30.6, z: -5.4 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: 30.1, maxX: 31.1, minZ: -5.9, maxZ: -4.9 },
+      kind: 'monstera-plant',
+      visual: { color: 0x8a5b36, accentColor: 0x4f8a43, height: 1.85 },
+    },
+
     {
       id: 'studio-bedside-rug',
       category: 'sleeping-nook',
@@ -577,6 +642,10 @@ export function createLowerFloorFurnishings(
       });
     }
 
+    if (!definition.solidFootprint && !definition.decorativeFootprint) {
+      furnishing.add(createVisualOnlyPrimitive(definition));
+    }
+
     if (definition.decorativeFootprint) {
       furnishing.add(createDecorativePrimitive(definition));
       decorativeFootprints.push({
@@ -598,6 +667,18 @@ export function createLowerFloorFurnishings(
   return { group, colliders, decorativeFootprints };
 }
 
+function createVisualOnlyPrimitive(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const group = new Group();
+  if (definition.kind === 'kitchen-herb-planter') {
+    addHerbPlanter(group, 0, definition.visual?.height ?? 1.08, 0);
+  } else if (definition.kind === 'kitchen-pendant-lights') {
+    addPendantLights(group, definition.visual?.height ?? 2.25);
+  }
+  return group;
+}
+
 function createSolidPrimitive(
   definition: LowerFloorFurnishingDefinition
 ): Group {
@@ -606,6 +687,11 @@ function createSolidPrimitive(
   if (definition.kind === 'side-table') return createSideTable(definition);
   if (definition.kind === 'lounge-chair') return createLoungeChair(definition);
   if (definition.kind === 'floor-lamp') return createFloorLamp(definition);
+  if (definition.kind === 'large-potted-plant')
+    return createLargePottedPlant(definition);
+  if (definition.kind === 'plant-stool') return createPlantStool(definition);
+  if (definition.kind === 'monstera-plant')
+    return createMonsteraPlant(definition);
   if (definition.kind.startsWith('sleeping-'))
     return createSleepingNookFurnishing(definition);
   if (definition.kind.startsWith('kitchen-'))
@@ -817,6 +903,184 @@ function createFloorLamp(definition: LowerFloorFurnishingDefinition): Group {
   shade.position.y = 1.44;
   group.add(shade);
   return group;
+}
+
+function createLargePottedPlant(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const potMaterial = createMaterial(definition.visual?.color ?? 0x8a5b36);
+  const leafMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x5f8f47
+  );
+  const trunkMaterial = createMaterial(0x5a3b24);
+  const group = new Group();
+
+  addPlanterPot(group, 'largePlant', potMaterial, 0.34, 0.42);
+  addBox(
+    group,
+    'largePlantTrunk',
+    { width: 0.12, height: 0.9, depth: 0.12 },
+    trunkMaterial,
+    [0, 0.84, 0]
+  );
+  addLeafCluster(group, 'largePlant', leafMaterial, 1.22, 0.56);
+  return group;
+}
+
+function createPlantStool(definition: LowerFloorFurnishingDefinition): Group {
+  const stoolMaterial = createMaterial(definition.visual?.color ?? 0x5c4a3c);
+  const potMaterial = createMaterial(0xc28d52);
+  const leafMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x6e9b58
+  );
+  const group = new Group();
+
+  addBox(
+    group,
+    'plantStoolSeat',
+    { width: 0.72, height: 0.14, depth: 0.72 },
+    stoolMaterial,
+    [0, 0.48, 0]
+  );
+  [-0.24, 0.24].forEach((x, xIndex) => {
+    [-0.24, 0.24].forEach((z, zIndex) => {
+      addBox(
+        group,
+        `plantStoolLeg${xIndex}-${zIndex}`,
+        { width: 0.08, height: 0.48, depth: 0.08 },
+        stoolMaterial,
+        [x, 0.24, z]
+      );
+    });
+  });
+  addPlanterPot(group, 'stoolPlant', potMaterial, 0.24, 0.28, 0.56);
+  addLeafCluster(group, 'stoolPlant', leafMaterial, 0.98, 0.36);
+  return group;
+}
+
+function createMonsteraPlant(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const potMaterial = createMaterial(definition.visual?.color ?? 0x8a5b36);
+  const leafMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0x4f8a43
+  );
+  const stemMaterial = createMaterial(0x4d6f35);
+  const group = new Group();
+
+  addPlanterPot(group, 'monstera', potMaterial, 0.38, 0.46);
+  [-0.18, 0, 0.18].forEach((x, index) => {
+    addBox(
+      group,
+      `monsteraStem${index}`,
+      { width: 0.07, height: 1.15, depth: 0.07 },
+      stemMaterial,
+      [x, 0.95, 0]
+    );
+  });
+  addLeafCluster(group, 'monstera', leafMaterial, 1.38, 0.72);
+  return group;
+}
+
+function addPlanterPot(
+  group: Group,
+  prefix: string,
+  material: MeshStandardMaterial,
+  radius: number,
+  height: number,
+  baseY = 0
+): void {
+  const pot = new Mesh(
+    new CylinderGeometry(radius * 0.78, radius, height, 16),
+    material
+  );
+  pot.name = `FurnishingPart:${prefix}Pot`;
+  pot.position.y = baseY + height / 2;
+  group.add(pot);
+  addBox(
+    group,
+    `${prefix}PotRim`,
+    { width: radius * 1.9, height: 0.08, depth: radius * 1.9 },
+    material,
+    [0, baseY + height + 0.04, 0]
+  );
+}
+
+function addLeafCluster(
+  group: Group,
+  prefix: string,
+  material: MeshStandardMaterial,
+  centerY: number,
+  spread: number
+): void {
+  const positions: Array<[number, number, number, number, number]> = [
+    [0, centerY + 0.22, 0, spread, 0.26],
+    [-spread * 0.42, centerY, -0.06, spread * 0.72, 0.22],
+    [spread * 0.42, centerY + 0.04, 0.08, spread * 0.72, 0.22],
+    [0.08, centerY - 0.12, spread * 0.35, spread * 0.64, 0.2],
+    [-0.08, centerY - 0.06, -spread * 0.35, spread * 0.64, 0.2],
+  ];
+  positions.forEach(([x, y, z, width, depth], index) => {
+    addBox(
+      group,
+      `${prefix}Leaf${index}`,
+      { width, height: 0.08, depth },
+      material,
+      [x, y, z]
+    );
+  });
+}
+
+function addHerbPlanter(group: Group, x: number, y: number, z: number): void {
+  const potMaterial = createMaterial(0xc28d52);
+  const leafMaterial = createMaterial(0x5f9a57);
+  addBox(
+    group,
+    'kitchen-herb-planter-box',
+    { width: 0.7, height: 0.18, depth: 0.24 },
+    potMaterial,
+    [x, y, z]
+  );
+  [-0.22, 0, 0.22].forEach((offset, index) => {
+    addBox(
+      group,
+      `kitchen-herb-planter-stem${index}`,
+      { width: 0.05, height: 0.24, depth: 0.05 },
+      leafMaterial,
+      [x + offset, y + 0.2, z]
+    );
+    addBox(
+      group,
+      `kitchen-herb-planter-leaf${index}`,
+      { width: 0.18, height: 0.06, depth: 0.12 },
+      leafMaterial,
+      [x + offset, y + 0.34, z]
+    );
+  });
+}
+
+function addPendantLights(group: Group, ceilingY: number): void {
+  const cordMaterial = createMaterial(0x27231f);
+  const shadeMaterial = createMaterial(0xffd48a, {
+    emissive: 0xffd48a,
+    emissiveIntensity: 0.32,
+  });
+  [-1.15, 0, 1.15].forEach((x, index) => {
+    addBox(
+      group,
+      `kitchen-pendant-lights-cord${index}`,
+      { width: 0.035, height: 0.75, depth: 0.035 },
+      cordMaterial,
+      [x, ceilingY, 0]
+    );
+    const shade = new Mesh(
+      new CylinderGeometry(0.18, 0.32, 0.24, 14),
+      shadeMaterial
+    );
+    shade.name = `FurnishingPart:kitchen-pendant-lights-shade${index}`;
+    shade.position.set(x, ceilingY - 0.48, 0);
+    group.add(shade);
+  });
 }
 
 function createKitchenFurnishing(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,7 +76,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(24);
+    expect(build.colliders).toHaveLength(28);
     expect(build.decorativeFootprints).toHaveLength(2);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -85,11 +85,15 @@ describe('lower floor furnishings foundation', () => {
       'living-room-lounge-chair-north',
       'living-room-lounge-chair-east',
       'living-room-floor-lamp',
+      'living-room-large-plant',
+      'living-room-plant-stool',
       'kitchen-west-counter-run',
       'kitchen-fridge',
       'kitchen-sink-cabinet',
       'kitchen-stove-cabinet',
       'kitchen-island',
+      'kitchen-herb-planter',
+      'kitchen-pendant-lights',
       'kitchen-bar-stool-west',
       'kitchen-bar-stool-east',
       'kitchen-trash-drawer',
@@ -103,6 +107,8 @@ describe('lower floor furnishings foundation', () => {
       'studio-nightstand-south',
       'studio-nightstand-north',
       'studio-reading-chair',
+      'studio-floor-lamp',
+      'studio-monstera',
       'studio-bedside-rug',
       'living-room-media-rug',
     ]);
@@ -194,6 +200,96 @@ describe('lower floor furnishings foundation', () => {
         expect(rectanglesOverlap(storage, blocker)).toBe(false);
       });
     });
+  });
+
+  it('adds plants, lamps, and small decor without extra child colliders', () => {
+    const { colliders, group } = createLowerFloorFurnishings();
+    const expectedDecorBounds: Record<string, RectCollider> = {
+      'living-room-large-plant': {
+        minX: -28.95,
+        maxX: -28.25,
+        minZ: -26.55,
+        maxZ: -25.85,
+      },
+      'living-room-plant-stool': {
+        minX: 5.3,
+        maxX: 6.3,
+        minZ: -31.3,
+        maxZ: -30.3,
+      },
+      'studio-floor-lamp': {
+        minX: 24.125,
+        maxX: 24.675,
+        minZ: 13.825,
+        maxZ: 14.375,
+      },
+      'studio-monstera': {
+        minX: 30.1,
+        maxX: 31.1,
+        minZ: -5.9,
+        maxZ: -4.9,
+      },
+    };
+    const decorColliders = colliders.filter(
+      (collider) => collider.category === 'plants-lighting-decor'
+    );
+
+    expect(new Set(colliders.map(({ category }) => category))).toContain(
+      'plants-lighting-decor'
+    );
+    Object.entries(expectedDecorBounds).forEach(([id, expected]) => {
+      const matchingColliders = colliders.filter(
+        (collider) => collider.furnishingId === id
+      );
+      expect(matchingColliders).toHaveLength(1);
+      expect(matchingColliders[0]).toMatchObject({
+        ...expected,
+        category: 'plants-lighting-decor',
+      });
+      expect(
+        matchingColliders[0].maxX - matchingColliders[0].minX
+      ).toBeGreaterThan(0);
+      expect(
+        matchingColliders[0].maxZ - matchingColliders[0].minZ
+      ).toBeGreaterThan(0);
+      expect(
+        isContainedBy(
+          LOWER_FLOOR_ROOM_BOUNDS[matchingColliders[0].roomId],
+          matchingColliders[0]
+        )
+      ).toBe(true);
+    });
+
+    decorColliders.forEach((collider, index) => {
+      decorColliders.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+      colliders
+        .filter((other) => other.category !== 'plants-lighting-decor')
+        .forEach((other) => {
+          expect(rectanglesOverlap(collider, other)).toBe(false);
+        });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+      });
+    });
+
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-herb-planter'
+      )
+    ).toBe(false);
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-pendant-lights'
+      )
+    ).toBe(false);
+    expect(
+      group.getObjectByName('FurnishingPart:kitchen-herb-planter-box')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:kitchen-pendant-lights-shade0')
+    ).toBeDefined();
   });
 
   it('keeps collider source IDs valid and unique for the default plan', () => {


### PR DESCRIPTION
### Motivation
- Warm up the lower floor with plants, lamps, and small decorative details so the space reads as lived-in while preserving existing POIs, seating, kitchen, storage, and sleeping-nook pieces.
- Provide deterministic authored AABBs and exactly one blocking collider per floor-standing decor item so collision and navigation validation remain strict.

### Description
- Add four floor-standing decor definitions in `DEFAULT_LOWER_FLOOR_FURNISHINGS` with authored AABBs and blocking colliders: `living-room-large-plant` (x[-28.95,-28.25], z[-26.55,-25.85]), `living-room-plant-stool` (x[5.3,6.3], z[-31.3,-30.3]), `studio-floor-lamp` (x[24.125,24.675], z[13.825,14.375]), and `studio-monstera` (x[30.1,31.1], z[-5.9,-4.9]).
- Add kitchen visual-only details `kitchen-herb-planter` and `kitchen-pendant-lights` that render as child geometry and intentionally do not produce separate movement colliders, and wire `createVisualOnlyPrimitive(...)` support into the furnishing builder.
- Implement compact helper geometry for pots, stools, stems, leaf clusters, and pendant shades using low-poly `BoxGeometry`/`CylinderGeometry` and emissive materials for warm bulbs, and reuse `createMaterial` for palette coherence.
- Update tests in `src/tests/lowerFloorFurnishings.test.ts` to assert presence of the four P6 solids, their positive-area AABBs and room containment, non-overlap with other solids and reserved blockers, that kitchen details are visual-only, and that no extra colliders were added.
- Bump the miniature manifest acknowledgement and `sceneComponentRegistry` entry for `decor:lower-floor-furnishings` to record the source-only change and defer proxy updates.

### Testing
- Ran formatting with `npm run format:write` and lint with `npm run lint` (both succeeded). 
- Ran targeted unit tests `npm run test:ci -- lowerFloorFurnishings` which passed, and the expanded Vitest suite `npm run test:ci` which completed with all tests passing (`182` files, `1427` tests passed in this environment). 
- Updated miniature manifest with `npm run miniature:manifest:update` and validated `npm run test:ci -- miniatureManifest lowerFloorFurnishings` which passed after bumping the `decor:lower-floor-furnishings` sync revision and note. 
- Ran docs validation (`npm run docs:check`), production build (`npm run build`), and smoke (`npm run smoke`) which all completed successfully (link checker reported external fetch warnings only). 
- `npm run typecheck` was attempted but fails due to pre-existing, repository-wide TypeScript issues unrelated to this change and therefore was not fixed here. 
- Attempted an automated Playwright screenshot of the preview but the browser executable is not available in this environment, so visual capture was not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41a435621c832f9411102dcb24d1a8)