### PR TITLE
🌿 – add backyard patio furnishings and rock garden

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 13,
-      "syncNote": "Review feedback tightened validation and mesh naming without adding miniature proxies.",
-      "sourceFingerprint": "5df5d198774eda1c657978400b32832f31ee6e3c011bae787f0b761f170add3a",
+      "syncRevision": 14,
+      "syncNote": "Backyard patio furnishings remain source-only while furniture proxy coverage is deferred.",
+      "sourceFingerprint": "44d5ecc25585934affded65b75bd65bbe5b2d14c6c9d909223083a3e86d20d4f",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "66a90d85c5dabdcc456d60f2074f602e47c2587051c3b8bf1f2c0ef4c84841cd"
+      "metadataFingerprint": "65a7854222c87c1e39300b8cff77d5cfbfda7f5cd66ae5c2286067ec4975282e"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 14,
-      "syncNote": "Backyard patio furnishings remain source-only while furniture proxy coverage is deferred.",
-      "sourceFingerprint": "44d5ecc25585934affded65b75bd65bbe5b2d14c6c9d909223083a3e86d20d4f",
+      "syncRevision": 15,
+      "syncNote": "Backyard furnishing collision hardening remains source-only while furniture proxy coverage is deferred.",
+      "sourceFingerprint": "1da17e931eb9fae2cead581dfa60d892437177d02977f769fdddb1dbfc96476a",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "65a7854222c87c1e39300b8cff77d5cfbfda7f5cd66ae5c2286067ec4975282e"
+      "metadataFingerprint": "b04b94bc6c383765b0aaaa2f1c842eb61e59ed8190fc9c052a07e0c8c67bc0f6"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 15,
-      "syncNote": "Backyard furnishing collision hardening remains source-only while furniture proxy coverage is deferred.",
-      "sourceFingerprint": "1da17e931eb9fae2cead581dfa60d892437177d02977f769fdddb1dbfc96476a",
+      "syncRevision": 16,
+      "syncNote": "Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.",
+      "sourceFingerprint": "3f6fde04e6fde403cf17736466f95891ff79fe2066181925f76913189440bd40",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "b04b94bc6c383765b0aaaa2f1c842eb61e59ed8190fc9c052a07e0c8c67bc0f6"
+      "metadataFingerprint": "38f2e4ffdf791e5045d86a2f3214016e1b8a09a560357c6a1c8778b49c0732b6"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 15,
+    syncRevision: 16,
     syncNote:
-      'Backyard furnishing collision hardening remains source-only while furniture proxy coverage is deferred.',
+      'Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 13,
+    syncRevision: 14,
     syncNote:
-      'Review feedback tightened validation and mesh naming without adding miniature proxies.',
+      'Backyard patio furnishings remain source-only while furniture proxy coverage is deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 14,
+    syncRevision: 15,
     syncNote:
-      'Backyard patio furnishings remain source-only while furniture proxy coverage is deferred.',
+      'Backyard furnishing collision hardening remains source-only while furniture proxy coverage is deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -499,12 +499,7 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       position: { x: -27.0, z: 27.3 },
       orientationRadians: Math.PI * 0.35,
       solidFootprint: { width: 1.2, depth: 1.8 },
-      solidBounds: {
-        minX: -28.07430017161326,
-        maxX: -25.92569982838674,
-        minZ: 26.35680463572139,
-        maxZ: 28.243195364278613,
-      },
+      solidBounds: { minX: -27.6, maxX: -26.4, minZ: 26.4, maxZ: 28.2 },
       kind: 'backyard-lawn-chair',
       visual: { color: 0x6f8aa0, accentColor: 0xd8c7a7, height: 0.64 },
     },
@@ -515,12 +510,7 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       position: { x: -24.2, z: 27.6 },
       orientationRadians: -Math.PI * 0.25,
       solidFootprint: { width: 1.2, depth: 1.8 },
-      solidBounds: {
-        minX: -25.260660171779822,
-        maxX: -23.139339828220177,
-        minZ: 26.53933982822018,
-        maxZ: 28.660660171779824,
-      },
+      solidBounds: { minX: -24.8, maxX: -23.6, minZ: 26.7, maxZ: 28.5 },
       kind: 'backyard-lawn-chair',
       visual: { color: 0x78966f, accentColor: 0xd8c7a7, height: 0.64 },
     },
@@ -542,7 +532,7 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       position: { x: 26.7, z: 18.8 },
       orientationRadians: -Math.PI / 2,
       solidFootprint: { width: 1.4, depth: 0.9 },
-      solidBounds: { minX: 26.25, maxX: 27.15, minZ: 18.1, maxZ: 19.5 },
+      solidBounds: { minX: 26.0, maxX: 27.4, minZ: 18.35, maxZ: 19.25 },
       kind: 'backyard-grill',
       visual: { color: 0x2f3740, accentColor: 0xc9d1d6, height: 1.1 },
     },
@@ -1715,38 +1705,38 @@ function createBackyardFurnishing(
       group,
       `${definition.id}:chairSeatFabric`,
       {
-        width: footprint.width * 0.82,
+        width: footprint.width * 0.58,
         height: 0.1,
-        depth: footprint.depth * 0.58,
+        depth: footprint.depth * 0.36,
       },
       primaryMaterial,
-      [0, 0.34, 0.1]
+      [0, 0.34, 0.04]
     );
     addBox(
       group,
       `${definition.id}:chairBackFabric`,
-      { width: footprint.width * 0.82, height: 0.58, depth: 0.1 },
+      { width: footprint.width * 0.58, height: 0.58, depth: 0.08 },
       primaryMaterial,
-      [0, 0.68, footprint.depth * 0.37]
+      [0, 0.68, footprint.depth * 0.22]
     );
-    [-0.36, 0, 0.36].forEach((x, index) => {
+    [-0.24, 0, 0.24].forEach((x, index) => {
       addBox(
         group,
         `${definition.id}:chairSeatSlat${index}`,
-        { width: 0.08, height: 0.08, depth: footprint.depth * 0.54 },
+        { width: 0.08, height: 0.08, depth: footprint.depth * 0.32 },
         accentMaterial,
-        [x, 0.42, 0.08]
+        [x, 0.42, 0.04]
       );
       addBox(
         group,
         `${definition.id}:chairBackSlat${index}`,
         { width: 0.08, height: 0.48, depth: 0.08 },
         accentMaterial,
-        [x, 0.74, footprint.depth * 0.31]
+        [x, 0.74, footprint.depth * 0.2]
       );
     });
-    [-0.46, 0.46].forEach((x, xIndex) => {
-      [-0.55, 0.55].forEach((z, zIndex) => {
+    [-0.28, 0.28].forEach((x, xIndex) => {
+      [-0.42, 0.42].forEach((z, zIndex) => {
         addBox(
           group,
           `${definition.id}:chairLeg${xIndex}-${zIndex}`,
@@ -1792,14 +1782,14 @@ function createBackyardFurnishing(
     addBox(
       group,
       'grillFirebox',
-      { width: 1.15, height: 0.42, depth: 0.62 },
+      { width: 0.8, height: 0.42, depth: 0.62 },
       darkMaterial,
       [0, 0.78, 0]
     );
     addBox(
       group,
       'grillLid',
-      { width: 1.18, height: 0.36, depth: 0.58 },
+      { width: 0.82, height: 0.36, depth: 0.58 },
       primaryMaterial,
       [0, 1.14, 0.03]
     );
@@ -1810,7 +1800,7 @@ function createBackyardFurnishing(
       metalMaterial,
       [0, 1.3, -0.34]
     );
-    [-0.36, 0, 0.36].forEach((x, index) => {
+    [-0.24, 0, 0.24].forEach((x, index) => {
       addBox(
         group,
         `grillGrate${index}`,
@@ -1819,7 +1809,7 @@ function createBackyardFurnishing(
         [x, 1.02, 0]
       );
     });
-    [-0.44, 0.44].forEach((x, index) => {
+    [-0.32, 0.32].forEach((x, index) => {
       addBox(
         group,
         `grillLeg${index}`,
@@ -1840,7 +1830,7 @@ function createBackyardFurnishing(
       'grillSideHandle',
       { width: 0.08, height: 0.08, depth: 0.5 },
       metalMaterial,
-      [0.68, 0.86, 0]
+      [0.4, 0.86, 0]
     );
     return group;
   }

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -499,7 +499,12 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       position: { x: -27.0, z: 27.3 },
       orientationRadians: Math.PI * 0.35,
       solidFootprint: { width: 1.2, depth: 1.8 },
-      solidBounds: { minX: -27.6, maxX: -26.4, minZ: 26.4, maxZ: 28.2 },
+      solidBounds: {
+        minX: -28.07430017161326,
+        maxX: -25.92569982838674,
+        minZ: 26.35680463572139,
+        maxZ: 28.243195364278613,
+      },
       kind: 'backyard-lawn-chair',
       visual: { color: 0x6f8aa0, accentColor: 0xd8c7a7, height: 0.64 },
     },
@@ -510,7 +515,12 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       position: { x: -24.2, z: 27.6 },
       orientationRadians: -Math.PI * 0.25,
       solidFootprint: { width: 1.2, depth: 1.8 },
-      solidBounds: { minX: -24.8, maxX: -23.6, minZ: 26.7, maxZ: 28.5 },
+      solidBounds: {
+        minX: -25.260660171779822,
+        maxX: -23.139339828220177,
+        minZ: 26.53933982822018,
+        maxZ: 28.660660171779824,
+      },
       kind: 'backyard-lawn-chair',
       visual: { color: 0x78966f, accentColor: 0xd8c7a7, height: 0.64 },
     },
@@ -532,7 +542,7 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       position: { x: 26.7, z: 18.8 },
       orientationRadians: -Math.PI / 2,
       solidFootprint: { width: 1.4, depth: 0.9 },
-      solidBounds: { minX: 26.0, maxX: 27.4, minZ: 18.35, maxZ: 19.25 },
+      solidBounds: { minX: 26.25, maxX: 27.15, minZ: 18.1, maxZ: 19.5 },
       kind: 'backyard-grill',
       visual: { color: 0x2f3740, accentColor: 0xc9d1d6, height: 1.1 },
     },
@@ -1881,40 +1891,40 @@ function createBackyardFurnishing(
   if (definition.kind === 'backyard-potted-plant') {
     addBox(
       group,
-      'backyardPlantPot',
+      `${definition.id}:backyardPlantPot`,
       { width: 0.46, height: 0.36, depth: 0.46 },
       primaryMaterial,
       [0, 0.18, 0]
     );
     addBox(
       group,
-      'backyardPlantPotRim',
+      `${definition.id}:backyardPlantPotRim`,
       { width: 0.58, height: 0.08, depth: 0.58 },
       primaryMaterial,
       [0, 0.4, 0]
     );
     addBox(
       group,
-      'backyardPlantStem',
+      `${definition.id}:backyardPlantStem`,
       { width: 0.08, height: 0.58, depth: 0.08 },
       darkMaterial,
       [0, 0.74, 0]
     );
-    addPlantLeaves(group, accentMaterial, 0.5, 1.03);
+    addPlantLeaves(group, accentMaterial, 0.5, 1.03, `${definition.id}:leaf`);
     return group;
   }
 
   if (definition.kind === 'backyard-rock') {
     addBox(
       group,
-      'gardenRockCore',
+      `${definition.id}:gardenRockCore`,
       { width: footprint.width * 0.85, height, depth: footprint.depth * 0.75 },
       primaryMaterial,
       [0, height / 2, 0]
     );
     addBox(
       group,
-      'gardenRockFacet',
+      `${definition.id}:gardenRockFacet`,
       {
         width: footprint.width * 0.5,
         height: height * 0.55,

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -621,10 +621,10 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       id: 'backyard-planter-west-north',
       category: 'backyard',
       roomId: 'backyard',
-      position: { x: -30.1, z: 29.7 },
+      position: { x: -30.1, z: 29.55 },
       orientationRadians: 0,
       solidFootprint: { width: 0.7, depth: 0.7 },
-      solidBounds: { minX: -30.45, maxX: -29.75, minZ: 29.35, maxZ: 30.05 },
+      solidBounds: { minX: -30.45, maxX: -29.75, minZ: 29.2, maxZ: 29.9 },
       kind: 'backyard-potted-plant',
       visual: { color: 0x8a5a36, accentColor: 0x6e9b58, height: 1.1 },
     },
@@ -1936,7 +1936,7 @@ function createBackyardFurnishing(
     return group;
   }
 
-  return group;
+  throw new Error(`Unsupported backyard furnishing kind: ${definition.kind}`);
 }
 
 function addBookRows(

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -492,6 +492,154 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         allowDecorativeOverlapWithAnySolid: true,
       },
     },
+    {
+      id: 'backyard-lawn-chair-west-a',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -27.0, z: 27.3 },
+      orientationRadians: Math.PI * 0.35,
+      solidFootprint: { width: 1.2, depth: 1.8 },
+      solidBounds: { minX: -27.6, maxX: -26.4, minZ: 26.4, maxZ: 28.2 },
+      kind: 'backyard-lawn-chair',
+      visual: { color: 0x6f8aa0, accentColor: 0xd8c7a7, height: 0.64 },
+    },
+    {
+      id: 'backyard-lawn-chair-west-b',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -24.2, z: 27.6 },
+      orientationRadians: -Math.PI * 0.25,
+      solidFootprint: { width: 1.2, depth: 1.8 },
+      solidBounds: { minX: -24.8, maxX: -23.6, minZ: 26.7, maxZ: 28.5 },
+      kind: 'backyard-lawn-chair',
+      visual: { color: 0x78966f, accentColor: 0xd8c7a7, height: 0.64 },
+    },
+    {
+      id: 'backyard-side-table',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -25.6, z: 25.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: -26.1, maxX: -25.1, minZ: 24.7, maxZ: 25.7 },
+      kind: 'backyard-side-table',
+      visual: { color: 0x5d4330, accentColor: 0x2f3740, height: 0.55 },
+    },
+    {
+      id: 'backyard-grill',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 26.7, z: 18.8 },
+      orientationRadians: -Math.PI / 2,
+      solidFootprint: { width: 1.4, depth: 0.9 },
+      solidBounds: { minX: 26.0, maxX: 27.4, minZ: 18.35, maxZ: 19.25 },
+      kind: 'backyard-grill',
+      visual: { color: 0x2f3740, accentColor: 0xc9d1d6, height: 1.1 },
+    },
+    {
+      id: 'backyard-prep-cart',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 24.4, z: 18.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.2, depth: 0.8 },
+      solidBounds: { minX: 23.8, maxX: 25.0, minZ: 18.4, maxZ: 19.2 },
+      kind: 'backyard-prep-cart',
+      visual: { color: 0x6b4a33, accentColor: 0x2f3740, height: 0.85 },
+    },
+    {
+      id: 'backyard-rock-garden-gravel',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 3.5, z: 29.1 },
+      orientationRadians: 0,
+      decorativeFootprint: { width: 7.0, depth: 2.1 },
+      decorativeBounds: { minX: 0.0, maxX: 7.0, minZ: 28.05, maxZ: 30.15 },
+      kind: 'backyard-rock-garden-gravel',
+      visual: {
+        color: 0x9a9688,
+        accentColor: 0x6d6a60,
+        decorativeHeight: 0.025,
+        allowDecorativeOverlapWithAnySolid: true,
+      },
+    },
+    {
+      id: 'backyard-rock-01',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 1.1, z: 29.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.5, depth: 0.5 },
+      solidBounds: { minX: 0.85, maxX: 1.35, minZ: 28.75, maxZ: 29.25 },
+      kind: 'backyard-rock',
+      visual: { color: 0x77736a, accentColor: 0xa39d91, height: 0.32 },
+    },
+    {
+      id: 'backyard-rock-02',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 3.5, z: 28.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: 3.15, maxX: 3.85, minZ: 28.25, maxZ: 28.95 },
+      kind: 'backyard-rock',
+      visual: { color: 0x6f6b63, accentColor: 0x9b968c, height: 0.42 },
+    },
+    {
+      id: 'backyard-rock-03',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 5.9, z: 29.4 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.6, depth: 0.6 },
+      solidBounds: { minX: 5.6, maxX: 6.2, minZ: 29.1, maxZ: 29.7 },
+      kind: 'backyard-rock',
+      visual: { color: 0x807b72, accentColor: 0xaaa397, height: 0.36 },
+    },
+    {
+      id: 'backyard-planter-west-south',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -30.2, z: 20.3 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -30.55, maxX: -29.85, minZ: 19.95, maxZ: 20.65 },
+      kind: 'backyard-potted-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x5f8f48, height: 1.1 },
+    },
+    {
+      id: 'backyard-planter-west-north',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -30.1, z: 29.7 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -30.45, maxX: -29.75, minZ: 29.35, maxZ: 30.05 },
+      kind: 'backyard-potted-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x6e9b58, height: 1.1 },
+    },
+    {
+      id: 'backyard-planter-east-south',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 30.1, z: 21.5 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: 29.75, maxX: 30.45, minZ: 21.15, maxZ: 21.85 },
+      kind: 'backyard-potted-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x5f8f48, height: 1.1 },
+    },
+    {
+      id: 'backyard-planter-east-north',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 30.0, z: 29.5 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: 29.65, maxX: 30.35, minZ: 29.15, maxZ: 29.85 },
+      kind: 'backyard-potted-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x6e9b58, height: 1.1 },
+    },
   ];
 
 export function createAabbFromCenterSize(
@@ -714,6 +862,8 @@ function createSolidPrimitive(
     return createKitchenFurnishing(definition);
   if (definition.kind.startsWith('storage-'))
     return createStorageFurnishing(definition);
+  if (definition.kind.startsWith('backyard-'))
+    return createBackyardFurnishing(definition);
 
   const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
   const height = definition.visual?.height ?? 0.8;
@@ -1534,6 +1684,251 @@ function createStorageFurnishing(
   return group;
 }
 
+function createBackyardFurnishing(
+  definition: LowerFloorFurnishingDefinition
+): Group {
+  const footprint = definition.solidFootprint ?? { width: 1, depth: 1 };
+  const height = definition.visual?.height ?? 0.8;
+  const primaryMaterial = createMaterial(definition.visual?.color ?? 0x6f7f92);
+  const accentMaterial = createMaterial(
+    definition.visual?.accentColor ?? 0xd8c7a7
+  );
+  const darkMaterial = createMaterial(0x25292f);
+  const metalMaterial = createMaterial(0xb8c0c8, {
+    metalness: 0.25,
+    roughness: 0.42,
+  });
+  const group = new Group();
+
+  if (definition.kind === 'backyard-lawn-chair') {
+    addBox(
+      group,
+      `${definition.id}:chairSeatFabric`,
+      {
+        width: footprint.width * 0.82,
+        height: 0.1,
+        depth: footprint.depth * 0.58,
+      },
+      primaryMaterial,
+      [0, 0.34, 0.1]
+    );
+    addBox(
+      group,
+      `${definition.id}:chairBackFabric`,
+      { width: footprint.width * 0.82, height: 0.58, depth: 0.1 },
+      primaryMaterial,
+      [0, 0.68, footprint.depth * 0.37]
+    );
+    [-0.36, 0, 0.36].forEach((x, index) => {
+      addBox(
+        group,
+        `${definition.id}:chairSeatSlat${index}`,
+        { width: 0.08, height: 0.08, depth: footprint.depth * 0.54 },
+        accentMaterial,
+        [x, 0.42, 0.08]
+      );
+      addBox(
+        group,
+        `${definition.id}:chairBackSlat${index}`,
+        { width: 0.08, height: 0.48, depth: 0.08 },
+        accentMaterial,
+        [x, 0.74, footprint.depth * 0.31]
+      );
+    });
+    [-0.46, 0.46].forEach((x, xIndex) => {
+      [-0.55, 0.55].forEach((z, zIndex) => {
+        addBox(
+          group,
+          `${definition.id}:chairLeg${xIndex}-${zIndex}`,
+          { width: 0.08, height: 0.36, depth: 0.08 },
+          darkMaterial,
+          [x, 0.18, z]
+        );
+      });
+    });
+    return group;
+  }
+
+  if (definition.kind === 'backyard-side-table') {
+    addBox(
+      group,
+      'patioTableTop',
+      { width: 0.92, height: 0.12, depth: 0.92 },
+      primaryMaterial,
+      [0, height, 0]
+    );
+    addBox(
+      group,
+      'patioTableTrim',
+      { width: 1.0, height: 0.08, depth: 1.0 },
+      accentMaterial,
+      [0, height + 0.09, 0]
+    );
+    [-0.32, 0.32].forEach((x, xIndex) => {
+      [-0.32, 0.32].forEach((z, zIndex) => {
+        addBox(
+          group,
+          `patioTableLeg${xIndex}-${zIndex}`,
+          { width: 0.08, height, depth: 0.08 },
+          darkMaterial,
+          [x, height / 2, z]
+        );
+      });
+    });
+    return group;
+  }
+
+  if (definition.kind === 'backyard-grill') {
+    addBox(
+      group,
+      'grillFirebox',
+      { width: 1.15, height: 0.42, depth: 0.62 },
+      darkMaterial,
+      [0, 0.78, 0]
+    );
+    addBox(
+      group,
+      'grillLid',
+      { width: 1.18, height: 0.36, depth: 0.58 },
+      primaryMaterial,
+      [0, 1.14, 0.03]
+    );
+    addBox(
+      group,
+      'grillHandle',
+      { width: 0.78, height: 0.08, depth: 0.08 },
+      metalMaterial,
+      [0, 1.3, -0.34]
+    );
+    [-0.36, 0, 0.36].forEach((x, index) => {
+      addBox(
+        group,
+        `grillGrate${index}`,
+        { width: 0.06, height: 0.04, depth: 0.5 },
+        metalMaterial,
+        [x, 1.02, 0]
+      );
+    });
+    [-0.44, 0.44].forEach((x, index) => {
+      addBox(
+        group,
+        `grillLeg${index}`,
+        { width: 0.08, height: 0.68, depth: 0.08 },
+        metalMaterial,
+        [x, 0.34, 0.22]
+      );
+      addBox(
+        group,
+        `grillWheel${index}`,
+        { width: 0.18, height: 0.18, depth: 0.08 },
+        darkMaterial,
+        [x, 0.1, -0.3]
+      );
+    });
+    addBox(
+      group,
+      'grillSideHandle',
+      { width: 0.08, height: 0.08, depth: 0.5 },
+      metalMaterial,
+      [0.68, 0.86, 0]
+    );
+    return group;
+  }
+
+  if (definition.kind === 'backyard-prep-cart') {
+    addBox(
+      group,
+      'prepCartTopShelf',
+      { width: 1.12, height: 0.12, depth: 0.72 },
+      primaryMaterial,
+      [0, height, 0]
+    );
+    addBox(
+      group,
+      'prepCartLowerShelf',
+      { width: 0.98, height: 0.1, depth: 0.62 },
+      primaryMaterial,
+      [0, 0.36, 0]
+    );
+    [-0.45, 0.45].forEach((x, xIndex) => {
+      [-0.25, 0.25].forEach((z, zIndex) => {
+        addBox(
+          group,
+          `prepCartPost${xIndex}-${zIndex}`,
+          { width: 0.06, height, depth: 0.06 },
+          darkMaterial,
+          [x, height / 2, z]
+        );
+        addBox(
+          group,
+          `prepCartWheel${xIndex}-${zIndex}`,
+          { width: 0.14, height: 0.14, depth: 0.08 },
+          metalMaterial,
+          [x, 0.08, z]
+        );
+      });
+    });
+    addBox(
+      group,
+      'prepCartHandle',
+      { width: 0.08, height: 0.08, depth: 0.58 },
+      accentMaterial,
+      [0.64, 0.72, 0]
+    );
+    return group;
+  }
+
+  if (definition.kind === 'backyard-potted-plant') {
+    addBox(
+      group,
+      'backyardPlantPot',
+      { width: 0.46, height: 0.36, depth: 0.46 },
+      primaryMaterial,
+      [0, 0.18, 0]
+    );
+    addBox(
+      group,
+      'backyardPlantPotRim',
+      { width: 0.58, height: 0.08, depth: 0.58 },
+      primaryMaterial,
+      [0, 0.4, 0]
+    );
+    addBox(
+      group,
+      'backyardPlantStem',
+      { width: 0.08, height: 0.58, depth: 0.08 },
+      darkMaterial,
+      [0, 0.74, 0]
+    );
+    addPlantLeaves(group, accentMaterial, 0.5, 1.03);
+    return group;
+  }
+
+  if (definition.kind === 'backyard-rock') {
+    addBox(
+      group,
+      'gardenRockCore',
+      { width: footprint.width * 0.85, height, depth: footprint.depth * 0.75 },
+      primaryMaterial,
+      [0, height / 2, 0]
+    );
+    addBox(
+      group,
+      'gardenRockFacet',
+      {
+        width: footprint.width * 0.5,
+        height: height * 0.55,
+        depth: footprint.depth * 0.45,
+      },
+      accentMaterial,
+      [footprint.width * 0.12, height * 0.72, -footprint.depth * 0.08]
+    );
+    return group;
+  }
+
+  return group;
+}
+
 function addBookRows(
   group: Group,
   width: number,
@@ -1706,13 +2101,48 @@ function createVisualDetailPrimitive(
 
 function createDecorativePrimitive(
   definition: LowerFloorFurnishingDefinition
-): Mesh {
+): Group | Mesh {
   const footprint = definition.decorativeFootprint ?? { width: 1, depth: 1 };
   const height = definition.visual?.decorativeHeight ?? 0.035;
   const material = new MeshStandardMaterial({
     color: definition.visual?.color ?? 0x56616f,
     roughness: 0.85,
   });
+  if (definition.kind === 'backyard-rock-garden-gravel') {
+    const group = new Group();
+    const gravel = new Mesh(
+      new BoxGeometry(footprint.width, height, footprint.depth),
+      material
+    );
+    gravel.name = `Furnishing:${definition.id}:decorativeFootprint`;
+    gravel.position.y = height / 2;
+    group.add(gravel);
+
+    const stoneMaterial = createMaterial(
+      definition.visual?.accentColor ?? 0x6d6a60
+    );
+    const stonePositions: Array<[number, number, number, number]> = [
+      [-2.9, height + 0.025, -0.64, 0.1],
+      [-2.1, height + 0.025, 0.42, 0.08],
+      [-1.2, height + 0.025, -0.18, 0.12],
+      [-0.35, height + 0.025, 0.62, 0.08],
+      [0.55, height + 0.025, -0.52, 0.11],
+      [1.35, height + 0.025, 0.15, 0.09],
+      [2.25, height + 0.025, -0.35, 0.1],
+      [2.9, height + 0.025, 0.52, 0.08],
+    ];
+    stonePositions.forEach(([x, y, z, size], index) => {
+      addBox(
+        group,
+        `gravelSpeckle${index}`,
+        { width: size, height: 0.035, depth: size * 0.7 },
+        stoneMaterial,
+        [x, y, z]
+      );
+    });
+    return group;
+  }
+
   const mesh = new Mesh(
     new BoxGeometry(footprint.width, height, footprint.depth),
     material

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -136,16 +136,16 @@ describe('lower floor furnishings foundation', () => {
       createLowerFloorFurnishings();
     const expectedBackyardBounds: Record<string, RectCollider> = {
       'backyard-lawn-chair-west-a': {
-        minX: -28.07430017161326,
-        maxX: -25.92569982838674,
-        minZ: 26.35680463572139,
-        maxZ: 28.243195364278613,
+        minX: -27.6,
+        maxX: -26.4,
+        minZ: 26.4,
+        maxZ: 28.2,
       },
       'backyard-lawn-chair-west-b': {
-        minX: -25.260660171779822,
-        maxX: -23.139339828220177,
-        minZ: 26.53933982822018,
-        maxZ: 28.660660171779824,
+        minX: -24.8,
+        maxX: -23.6,
+        minZ: 26.7,
+        maxZ: 28.5,
       },
       'backyard-side-table': {
         minX: -26.1,
@@ -154,10 +154,10 @@ describe('lower floor furnishings foundation', () => {
         maxZ: 25.7,
       },
       'backyard-grill': {
-        minX: 26.25,
-        maxX: 27.15,
-        minZ: 18.1,
-        maxZ: 19.5,
+        minX: 26.0,
+        maxX: 27.4,
+        minZ: 18.35,
+        maxZ: 19.25,
       },
       'backyard-prep-cart': {
         minX: 23.8,
@@ -272,6 +272,37 @@ describe('lower floor furnishings foundation', () => {
     expect(
       group.getObjectByName('FurnishingPart:gravelSpeckle0')
     ).toBeDefined();
+  });
+
+  it('keeps angled backyard chair and grill visuals inside authored colliders', () => {
+    const { colliders, group } = createLowerFloorFurnishings();
+    const ids = [
+      'backyard-lawn-chair-west-a',
+      'backyard-lawn-chair-west-b',
+      'backyard-grill',
+    ];
+    const epsilon = 0.000001;
+
+    ids.forEach((id) => {
+      const collider = colliders.find(
+        ({ furnishingId }) => furnishingId === id
+      );
+      const furnishing = group.getObjectByName(`Furnishing:${id}`);
+
+      expect(collider).toBeDefined();
+      expect(furnishing).toBeDefined();
+
+      const visualBounds = new Box3().setFromObject(furnishing!);
+
+      expect(visualBounds.min.x).toBeGreaterThanOrEqual(
+        collider!.minX - epsilon
+      );
+      expect(visualBounds.max.x).toBeLessThanOrEqual(collider!.maxX + epsilon);
+      expect(visualBounds.min.z).toBeGreaterThanOrEqual(
+        collider!.minZ - epsilon
+      );
+      expect(visualBounds.max.z).toBeLessThanOrEqual(collider!.maxZ + epsilon);
+    });
   });
 
   it('rejects unsupported backyard furnishing kinds instead of building empty groups', () => {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -76,8 +76,8 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(28);
-    expect(build.decorativeFootprints).toHaveLength(2);
+    expect(build.colliders).toHaveLength(40);
+    expect(build.decorativeFootprints).toHaveLength(3);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
       'living-room-coffee-table',
@@ -111,7 +111,193 @@ describe('lower floor furnishings foundation', () => {
       'studio-reading-chair',
       'studio-bedside-rug',
       'living-room-media-rug',
+      'backyard-lawn-chair-west-a',
+      'backyard-lawn-chair-west-b',
+      'backyard-side-table',
+      'backyard-grill',
+      'backyard-prep-cart',
+      'backyard-rock-garden-gravel',
+      'backyard-rock-01',
+      'backyard-rock-02',
+      'backyard-rock-03',
+      'backyard-planter-west-south',
+      'backyard-planter-west-north',
+      'backyard-planter-east-south',
+      'backyard-planter-east-north',
     ]);
+  });
+
+  it('adds backyard patio and landscaping AABBs with non-blocking gravel', () => {
+    const { colliders, decorativeFootprints, group } =
+      createLowerFloorFurnishings();
+    const expectedBackyardBounds: Record<string, RectCollider> = {
+      'backyard-lawn-chair-west-a': {
+        minX: -27.6,
+        maxX: -26.4,
+        minZ: 26.4,
+        maxZ: 28.2,
+      },
+      'backyard-lawn-chair-west-b': {
+        minX: -24.8,
+        maxX: -23.6,
+        minZ: 26.7,
+        maxZ: 28.5,
+      },
+      'backyard-side-table': {
+        minX: -26.1,
+        maxX: -25.1,
+        minZ: 24.7,
+        maxZ: 25.7,
+      },
+      'backyard-grill': {
+        minX: 26.0,
+        maxX: 27.4,
+        minZ: 18.35,
+        maxZ: 19.25,
+      },
+      'backyard-prep-cart': {
+        minX: 23.8,
+        maxX: 25.0,
+        minZ: 18.4,
+        maxZ: 19.2,
+      },
+      'backyard-rock-01': {
+        minX: 0.85,
+        maxX: 1.35,
+        minZ: 28.75,
+        maxZ: 29.25,
+      },
+      'backyard-rock-02': {
+        minX: 3.15,
+        maxX: 3.85,
+        minZ: 28.25,
+        maxZ: 28.95,
+      },
+      'backyard-rock-03': {
+        minX: 5.6,
+        maxX: 6.2,
+        minZ: 29.1,
+        maxZ: 29.7,
+      },
+      'backyard-planter-west-south': {
+        minX: -30.55,
+        maxX: -29.85,
+        minZ: 19.95,
+        maxZ: 20.65,
+      },
+      'backyard-planter-west-north': {
+        minX: -30.45,
+        maxX: -29.75,
+        minZ: 29.35,
+        maxZ: 30.05,
+      },
+      'backyard-planter-east-south': {
+        minX: 29.75,
+        maxX: 30.45,
+        minZ: 21.15,
+        maxZ: 21.85,
+      },
+      'backyard-planter-east-north': {
+        minX: 29.65,
+        maxX: 30.35,
+        minZ: 29.15,
+        maxZ: 29.85,
+      },
+    };
+
+    expect(
+      new Set(colliders.map(({ category }) => category)).has('backyard')
+    ).toBe(true);
+
+    Object.entries(expectedBackyardBounds).forEach(([id, expected]) => {
+      const matchingColliders = colliders.filter(
+        (collider) => collider.furnishingId === id
+      );
+      expect(matchingColliders).toHaveLength(1);
+      expect(matchingColliders[0]).toMatchObject({
+        ...expected,
+        category: 'backyard',
+        roomId: 'backyard',
+      });
+      expect(
+        matchingColliders[0].maxX - matchingColliders[0].minX
+      ).toBeGreaterThan(0);
+      expect(
+        matchingColliders[0].maxZ - matchingColliders[0].minZ
+      ).toBeGreaterThan(0);
+    });
+
+    const gravel = decorativeFootprints.find(
+      (footprint) => footprint.furnishingId === 'backyard-rock-garden-gravel'
+    );
+    expect(gravel).toMatchObject({
+      category: 'backyard',
+      roomId: 'backyard',
+      bounds: { minX: 0.0, maxX: 7.0, minZ: 28.05, maxZ: 30.15 },
+      allowSolidOverlap: true,
+    });
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'backyard-rock-garden-gravel'
+      )
+    ).toBe(false);
+
+    Object.keys(expectedBackyardBounds).forEach((id) => {
+      expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
+    });
+    expect(
+      group.getObjectByName('Furnishing:backyard-rock-garden-gravel')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName(
+        'FurnishingPart:backyard-lawn-chair-west-a:chairSeatSlat0'
+      )
+    ).toBeDefined();
+    expect(group.getObjectByName('FurnishingPart:grillLid')).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:prepCartLowerShelf')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:gravelSpeckle0')
+    ).toBeDefined();
+  });
+
+  it('keeps backyard solids bounded, disjoint, and limited to parent colliders', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const backyardColliders = colliders.filter(
+      (collider) => collider.category === 'backyard'
+    );
+    const priorPassColliders = colliders.filter(
+      (collider) => collider.category !== 'backyard'
+    );
+    const backyardSolidDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) =>
+        definition.category === 'backyard' && definition.solidFootprint
+    );
+
+    expect(backyardColliders).toHaveLength(backyardSolidDefinitions.length);
+    backyardSolidDefinitions.forEach((definition) => {
+      expect(
+        backyardColliders.filter(
+          (collider) => collider.furnishingId === definition.id
+        )
+      ).toHaveLength(1);
+    });
+
+    backyardColliders.forEach((backyard, index) => {
+      expect(isContainedBy(LOWER_FLOOR_ROOM_BOUNDS.backyard, backyard)).toBe(
+        true
+      );
+      backyardColliders.slice(index + 1).forEach((otherBackyard) => {
+        expect(rectanglesOverlap(backyard, otherBackyard)).toBe(false);
+      });
+      priorPassColliders.forEach((other) => {
+        expect(rectanglesOverlap(backyard, other)).toBe(false);
+      });
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(backyard, blocker)).toBe(false);
+      });
+    });
   });
 
   it('adds the requested lower-floor storage AABBs with one collider each', () => {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -132,16 +132,16 @@ describe('lower floor furnishings foundation', () => {
       createLowerFloorFurnishings();
     const expectedBackyardBounds: Record<string, RectCollider> = {
       'backyard-lawn-chair-west-a': {
-        minX: -27.6,
-        maxX: -26.4,
-        minZ: 26.4,
-        maxZ: 28.2,
+        minX: -28.07430017161326,
+        maxX: -25.92569982838674,
+        minZ: 26.35680463572139,
+        maxZ: 28.243195364278613,
       },
       'backyard-lawn-chair-west-b': {
-        minX: -24.8,
-        maxX: -23.6,
-        minZ: 26.7,
-        maxZ: 28.5,
+        minX: -25.260660171779822,
+        maxX: -23.139339828220177,
+        minZ: 26.53933982822018,
+        maxZ: 28.660660171779824,
       },
       'backyard-side-table': {
         minX: -26.1,
@@ -150,10 +150,10 @@ describe('lower floor furnishings foundation', () => {
         maxZ: 25.7,
       },
       'backyard-grill': {
-        minX: 26.0,
-        maxX: 27.4,
-        minZ: 18.35,
-        maxZ: 19.25,
+        minX: 26.25,
+        maxX: 27.15,
+        minZ: 18.1,
+        maxZ: 19.5,
       },
       'backyard-prep-cart': {
         minX: 23.8,
@@ -254,6 +254,14 @@ describe('lower floor furnishings foundation', () => {
       )
     ).toBeDefined();
     expect(group.getObjectByName('FurnishingPart:grillLid')).toBeDefined();
+    expect(
+      group.getObjectByName(
+        'FurnishingPart:backyard-planter-west-south:backyardPlantPot'
+      )
+    ).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:backyard-rock-01:gardenRockCore')
+    ).toBeDefined();
     expect(
       group.getObjectByName('FurnishingPart:prepCartLowerShelf')
     ).toBeDefined();

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -10,6 +10,10 @@ import {
   validateLowerFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
 } from '../scene/structures/lowerFloorFurnishings';
+import {
+  createBackyardFenceColliders,
+  createBackyardFenceSegments,
+} from '../scene/level/backyardCollisionPolicies';
 import type { RectCollider } from '../systems/collision';
 
 const validDefinitions: LowerFloorFurnishingDefinition[] = [
@@ -188,8 +192,8 @@ describe('lower floor furnishings foundation', () => {
       'backyard-planter-west-north': {
         minX: -30.45,
         maxX: -29.75,
-        minZ: 29.35,
-        maxZ: 30.05,
+        minZ: 29.2,
+        maxZ: 29.9,
       },
       'backyard-planter-east-south': {
         minX: 29.75,
@@ -268,6 +272,42 @@ describe('lower floor furnishings foundation', () => {
     expect(
       group.getObjectByName('FurnishingPart:gravelSpeckle0')
     ).toBeDefined();
+  });
+
+  it('rejects unsupported backyard furnishing kinds instead of building empty groups', () => {
+    const typoBackyardFurnishing: LowerFloorFurnishingDefinition = {
+      id: 'backyard-typo-grill',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 0, z: 22 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1, depth: 1 },
+      solidBounds: { minX: -0.5, maxX: 0.5, minZ: 21.5, maxZ: 22.5 },
+      kind: 'backyard-girll',
+    };
+
+    expect(() =>
+      createLowerFloorFurnishings({ definitions: [typoBackyardFurnishing] })
+    ).toThrow(/Unsupported backyard furnishing kind: backyard-girll/);
+  });
+
+  it('keeps backyard solid colliders clear of generated fence colliders', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const fenceColliders = createBackyardFenceColliders(
+      createBackyardFenceSegments(LOWER_FLOOR_ROOM_BOUNDS.backyard)
+    );
+    const backyardColliders = colliders.filter(
+      (collider) => collider.category === 'backyard'
+    );
+
+    expect(
+      fenceColliders.some((collider) => collider.role === 'backFenceBoundary')
+    ).toBe(true);
+    backyardColliders.forEach((backyard) => {
+      fenceColliders.forEach((fence) => {
+        expect(rectanglesOverlap(backyard, fence)).toBe(false);
+      });
+    });
   });
 
   it('keeps backyard solids bounded, disjoint, and limited to parent colliders', () => {


### PR DESCRIPTION
### Motivation
- Populate the backyard with patio seating, a small grill station, prep cart, potted planters, and a rock garden so the outdoor area reads as a lived-in space and fits the lower-floor furnishing system.
- Provide deterministic authored AABBs for all new solids and a decorative gravel bed that intentionally allows overlap with the rock details while preserving global no-overlap validation.

### Description
- Added P7 backyard definitions to `DEFAULT_LOWER_FLOOR_FURNISHINGS` in `src/scene/structures/lowerFloorFurnishings.ts` for the following IDs with authored bounds and orientations: `backyard-lawn-chair-west-a`, `backyard-lawn-chair-west-b`, `backyard-side-table`, `backyard-grill`, `backyard-prep-cart`, `backyard-rock-garden-gravel`, `backyard-rock-01`, `backyard-rock-02`, `backyard-rock-03`, `backyard-planter-west-south`, `backyard-planter-west-north`, `backyard-planter-east-south`, and `backyard-planter-east-north`.
- Implemented low-poly visual builders and deterministic decorative gravel details via `createBackyardFurnishing(...)` and an augmented `createDecorativePrimitive(...)` that produces the gravel group and speckles, while keeping each solid furnishing exactly one blocking collider.
- Updated `src/tests/lowerFloorFurnishings.test.ts` to assert presence of all P7 IDs, exact authored AABBs, that the gravel bed is decorative/non-blocking and allows solid overlap, containment within backyard bounds, and non-overlap with prior-pass solids and reserved blockers.
- Acknowledged the source-only change in the miniature coverage by bumping the `decor:lower-floor-furnishings` `syncRevision` and `syncNote` in `src/scene/miniature/sceneComponentRegistry.ts` and regenerating `src/scene/miniature/miniatureManifest.generated.json` via the repo helper.

### Testing
- Ran formatting: `npm run format:write` for the modified files (succeeded).
- Ran lint: `npm run lint` (succeeded with no lint failures from the touched files).
- Ran focused unit tests: `npm run test:ci -- lowerFloorFurnishings` (all `lowerFloorFurnishings` tests passed).
- Updated miniature manifest and ran its tests: `npm run miniature:manifest:update` then `npm run test:ci -- lowerFloorFurnishings miniatureManifest` (manifest update required bumping `syncRevision`, after which the targeted tests passed).
- Built and smoke-checked the app: `npm run build`, `npm run docs:check`, and `npm run smoke` (all succeeded; `docs:check` emitted external fetch warnings unrelated to the change).
- Captured a local review screenshot via a preview + Playwright run (Playwright browsers and deps were installed as part of the verification commands) and left the artifact untracked for reviewer inspection.
- Noted limitation: `npm run typecheck` fails on pre-existing repository-wide TypeScript issues unrelated to this PR, so typecheck was not used as a blocker for these focused functional changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41c545a304832fa65d9e100340f2a1)