### PR TITLE
Polish lower-floor furnishing QA

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 16,
-      "syncNote": "Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.",
-      "sourceFingerprint": "3f6fde04e6fde403cf17736466f95891ff79fe2066181925f76913189440bd40",
+      "syncRevision": 17,
+      "syncNote": "Kitchen stove detail remains source-only while furniture proxy coverage is deferred.",
+      "sourceFingerprint": "14f36fa8c908f84e8dcf276f75b942f21ec7d69a6a0114bd2aebca442c764d51",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "38f2e4ffdf791e5045d86a2f3214016e1b8a09a560357c6a1c8778b49c0732b6"
+      "metadataFingerprint": "d900d149e7e12f47bec425fe4cf8155e89453babe64dfd3a01fae3a5bf9ea360"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 17,
-      "syncNote": "Kitchen stove detail remains source-only while furniture proxy coverage is deferred.",
-      "sourceFingerprint": "14f36fa8c908f84e8dcf276f75b942f21ec7d69a6a0114bd2aebca442c764d51",
+      "syncRevision": 18,
+      "syncNote": "Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.",
+      "sourceFingerprint": "2152c8d288227bea8b088e9da6474ee781f1b8ef24d7e55660856f67a3adb61a",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "d900d149e7e12f47bec425fe4cf8155e89453babe64dfd3a01fae3a5bf9ea360"
+      "metadataFingerprint": "3d6b130cd99fb62fde66e6951c50e0f41ffd63ac13825bbb1dea1b3939c89d63"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 16,
+    syncRevision: 17,
     syncNote:
-      'Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.',
+      'Kitchen stove detail remains source-only while furniture proxy coverage is deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 17,
+    syncRevision: 18,
     syncNote:
-      'Kitchen stove detail remains source-only while furniture proxy coverage is deferred.',
+      'Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -235,7 +235,6 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         color: 0x687282,
         accentColor: 0xd8ccb8,
         height: 0.9,
-        allowSolidOverlapWithIds: ['kitchen-stove-cabinet'],
       },
     },
     {
@@ -270,14 +269,11 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       roomId: 'kitchen',
       position: { x: -31.0, z: 7.0 },
       orientationRadians: Math.PI / 2,
-      solidFootprint: { width: 1.2, depth: 1.6 },
-      solidBounds: { minX: -31.6, maxX: -30.4, minZ: 6.2, maxZ: 7.8 },
-      kind: 'kitchen-stove-cabinet',
+      kind: 'kitchen-stove-cabinet-detail',
       visual: {
         color: 0x5e6672,
         accentColor: 0x1d232b,
         height: 0.95,
-        allowSolidOverlapWithIds: ['kitchen-west-counter-run'],
       },
     },
     {
@@ -2064,6 +2060,35 @@ function createVisualDetailPrimitive(
         [x, 1.38, 0]
       );
     });
+    return group;
+  }
+
+  if (definition.kind === 'kitchen-stove-cabinet-detail') {
+    [-0.26, 0.26].forEach((x, index) => {
+      [-0.32, 0.32].forEach((z, innerIndex) => {
+        addBox(
+          group,
+          `stoveCooktop${index}-${innerIndex}`,
+          { width: 0.22, height: 0.035, depth: 0.22 },
+          accentMaterial,
+          [x, 1.085, z]
+        );
+      });
+    });
+    addBox(
+      group,
+      'stoveOvenFace',
+      { width: 0.08, height: 0.48, depth: 0.95 },
+      accentMaterial,
+      [-0.61, 0.48, 0]
+    );
+    addBox(
+      group,
+      'stoveHoodPanel',
+      { width: 1.2, height: 0.16, depth: 0.28 },
+      baseMaterial,
+      [0, 1.55, 0.66]
+    );
     return group;
   }
 

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -2064,16 +2064,21 @@ function createVisualDetailPrimitive(
   }
 
   if (definition.kind === 'kitchen-stove-cabinet-detail') {
-    [-0.26, 0.26].forEach((x, index) => {
-      [-0.32, 0.32].forEach((z, innerIndex) => {
-        addBox(
-          group,
-          `stoveCooktop${index}-${innerIndex}`,
-          { width: 0.22, height: 0.035, depth: 0.22 },
-          accentMaterial,
-          [x, 1.085, z]
-        );
-      });
+    (
+      [
+        [-0.26, -0.32],
+        [-0.26, 0.32],
+        [0.26, -0.32],
+        [0.26, 0.32],
+      ] as Array<[number, number]>
+    ).forEach(([x, z], index) => {
+      addBox(
+        group,
+        `stoveCooktop${index}`,
+        { width: 0.22, height: 0.035, depth: 0.22 },
+        accentMaterial,
+        [x, 1.085, z]
+      );
     });
     addBox(
       group,

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -654,7 +654,6 @@ describe('lower floor furnishings foundation', () => {
       expect(collider.sourceId).toBe(
         `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
       );
-      expect(isLevelSourceId(collider.sourceId)).toBe(true);
     });
   });
 
@@ -962,9 +961,7 @@ describe('lower floor furnishings foundation', () => {
     expect(
       group.getObjectByName('Furnishing:kitchen-stove-cabinet')
     ).toBeDefined();
-    expect(
-      group.getObjectByName('FurnishingPart:stoveCooktop0-0')
-    ).toBeDefined();
+    expect(group.getObjectByName('FurnishingPart:stoveCooktop0')).toBeDefined();
   });
 
   it('keeps the wall counter visual narrow in world X and long in world Z', () => {
@@ -1147,7 +1144,6 @@ describe('lower floor furnishings foundation', () => {
       expect(collider.sourceId).toBe(
         `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
       );
-      expect(isLevelSourceId(collider.sourceId)).toBe(true);
     });
   });
 

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -2,6 +2,11 @@ import { Box3 } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
+  createBackyardFenceColliders,
+  createBackyardFenceSegments,
+} from '../scene/level/backyardCollisionPolicies';
+import { isLevelSourceId } from '../scene/level/sourceIds';
+import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
@@ -10,10 +15,6 @@ import {
   validateLowerFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
 } from '../scene/structures/lowerFloorFurnishings';
-import {
-  createBackyardFenceColliders,
-  createBackyardFenceSegments,
-} from '../scene/level/backyardCollisionPolicies';
 import type { RectCollider } from '../systems/collision';
 
 const validDefinitions: LowerFloorFurnishingDefinition[] = [
@@ -80,7 +81,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(40);
+    expect(build.colliders).toHaveLength(39);
     expect(build.decorativeFootprints).toHaveLength(3);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -646,10 +647,14 @@ describe('lower floor furnishings foundation', () => {
     const sourceIds = colliders.map((collider) => collider.sourceId);
 
     expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(
+      colliders.every((collider) => isLevelSourceId(collider.sourceId))
+    ).toBe(true);
     colliders.forEach((collider) => {
       expect(collider.sourceId).toBe(
         `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
       );
+      expect(isLevelSourceId(collider.sourceId)).toBe(true);
     });
   });
 
@@ -850,12 +855,6 @@ describe('lower floor furnishings foundation', () => {
         minZ: -2.9,
         maxZ: -1.1,
       },
-      'kitchen-stove-cabinet': {
-        minX: -31.6,
-        maxX: -30.4,
-        minZ: 6.2,
-        maxZ: 7.8,
-      },
       'kitchen-island': {
         minX: -15.4,
         maxX: -10.6,
@@ -891,6 +890,11 @@ describe('lower floor furnishings foundation', () => {
         roomId: 'kitchen',
       });
     });
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-stove-cabinet'
+      )
+    ).toBe(false);
   });
 
   it('keeps kitchen solidBounds aligned with authored centers and footprints', () => {
@@ -899,6 +903,12 @@ describe('lower floor furnishings foundation', () => {
     );
 
     kitchenDefinitions.forEach((definition) => {
+      if (definition.id === 'kitchen-stove-cabinet') {
+        expect(definition.solidFootprint).toBeUndefined();
+        expect(definition.solidBounds).toBeUndefined();
+        return;
+      }
+
       expect(definition.solidFootprint).toBeDefined();
       expect(definition.solidBounds).toMatchObject(
         deriveAabbFromCenterSize(definition)
@@ -933,24 +943,28 @@ describe('lower floor furnishings foundation', () => {
       });
   });
 
-  it('keeps kitchen solids disjoint except the authored stove counter integration', () => {
-    const { colliders } = createLowerFloorFurnishings();
+  it('keeps kitchen solids disjoint while stove details stay visual-only', () => {
+    const { colliders, group } = createLowerFloorFurnishings();
     const kitchenColliders = colliders.filter(
       (collider) => collider.roomId === 'kitchen'
     );
-    const allowedOverlap = new Set([
-      'kitchen-stove-cabinet|kitchen-west-counter-run',
-      'kitchen-west-counter-run|kitchen-stove-cabinet',
-    ]);
 
     kitchenColliders.forEach((collider, index) => {
       kitchenColliders.slice(index + 1).forEach((other) => {
-        const pairKey = `${collider.furnishingId}|${other.furnishingId}`;
-        expect(rectanglesOverlap(collider, other)).toBe(
-          allowedOverlap.has(pairKey)
-        );
+        expect(rectanglesOverlap(collider, other)).toBe(false);
       });
     });
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-stove-cabinet'
+      )
+    ).toBe(false);
+    expect(
+      group.getObjectByName('Furnishing:kitchen-stove-cabinet')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:stoveCooktop0-0')
+    ).toBeDefined();
   });
 
   it('keeps the wall counter visual narrow in world X and long in world Z', () => {
@@ -1133,6 +1147,7 @@ describe('lower floor furnishings foundation', () => {
       expect(collider.sourceId).toBe(
         `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
       );
+      expect(isLevelSourceId(collider.sourceId)).toBe(true);
     });
   });
 
@@ -1163,22 +1178,31 @@ describe('lower floor furnishings foundation', () => {
   });
 
   it('requires solid overlap allowlists to be mutual', () => {
-    const oneSidedDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.map(
-      (definition) => {
-        if (definition.id !== 'kitchen-stove-cabinet') return definition;
-        return {
-          ...definition,
-          visual: {
-            ...definition.visual,
-            allowSolidOverlapWithIds: [],
-          },
-        };
-      }
-    );
+    const overlappingDefinitions: LowerFloorFurnishingDefinition[] = [
+      {
+        id: 'living-overlap-a',
+        category: 'living-room-seating',
+        roomId: 'livingRoom',
+        position: { x: -2, z: -21 },
+        orientationRadians: 0,
+        solidFootprint: { width: 2, depth: 2 },
+        kind: 'couch',
+        visual: { allowSolidOverlapWithIds: ['living-overlap-b'] },
+      },
+      {
+        id: 'living-overlap-b',
+        category: 'living-room-seating',
+        roomId: 'livingRoom',
+        position: { x: -1.5, z: -21 },
+        orientationRadians: 0,
+        solidFootprint: { width: 2, depth: 2 },
+        kind: 'couch',
+      },
+    ];
 
-    expect(() => validateLowerFloorFurnishingPlan(oneSidedDefinitions)).toThrow(
-      /kitchen-west-counter-run overlaps kitchen-stove-cabinet/
-    );
+    expect(() =>
+      validateLowerFloorFurnishingPlan(overlappingDefinitions)
+    ).toThrow(/living-overlap-a overlaps living-overlap-b/);
   });
 
   it('allows decorative footprints to overlap associated solids only when explicit', () => {

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -61,7 +61,9 @@ describe('main module imports', () => {
   it('wires lower-floor furnishings once with generated collider metadata', () => {
     const source = readMainSource();
 
-    expect(source.match(/createLowerFloorFurnishings\(/g)).toHaveLength(1);
+    expect(source.match(/createLowerFloorFurnishings\(/g) ?? []).toHaveLength(
+      1
+    );
     expect(source).toContain(
       'groundStructureGroup.add(lowerFloorFurnishings.group);'
     );

--- a/src/tests/mainImports.test.ts
+++ b/src/tests/mainImports.test.ts
@@ -58,6 +58,25 @@ describe('main module imports', () => {
     expect(source).toContain('intent: sourceMetadata?.intent,');
   });
 
+  it('wires lower-floor furnishings once with generated collider metadata', () => {
+    const source = readMainSource();
+
+    expect(source.match(/createLowerFloorFurnishings\(/g)).toHaveLength(1);
+    expect(source).toContain(
+      'groundStructureGroup.add(lowerFloorFurnishings.group);'
+    );
+    expect(source).toContain(
+      'lowerFloorFurnishings.colliders.forEach((collider) => {'
+    );
+    expect(source).toContain('groundColliders.push(collider);');
+    expect(source).toContain("sourceType: 'generatedCollider',");
+    expect(source).toContain("purpose: 'lower-floor-furnishing',");
+    expect(source).toContain('role: collider.category,');
+    expect(source).not.toContain(
+      'lowerFloorFurnishings.decorativeFootprints.forEach'
+    );
+  });
+
   it('keeps the SelfieMirror collider source-backed while preserving debug ID 101A', () => {
     const source = readMainSource();
 


### PR DESCRIPTION
### Motivation
- Final QA pass to tighten lower-floor furnishing colliders, decorative footprints, and runtime metadata while preserving the P2–P7 scene intent.
- Ensure visual-only details (pendants, herbs, stove detail) do not create movement-blocking colliders and avoid unintended overlaps.
- Improve test coverage to prove inventory, unique generated source IDs, non-blocking decorative footprints, and runtime wiring into `groundColliders`.

### Description
- Converted `kitchen-stove-cabinet` to a visual-only detail (`kitchen-stove-cabinet-detail`) and removed its authored solid footprint/allowlist so the stove is decorative-only at runtime.
- Added deterministic stove visual parts (`stoveCooktop*`, `stoveOvenFace`, `stoveHoodPanel`) to the existing `createVisualDetailPrimitive` builder and kept predictable `FurnishingPart:` names.
- Tightened tests in `src/tests/lowerFloorFurnishings.test.ts` to expect the adjusted collider count, assert `sourceId` validity/uniqueness, confirm the stove detail is visual-only (no collider) while still present in the scene graph, and strengthen overlap/mutual-allowlist checks with a synthetic overlapping pair.
- Added a runtime wiring assertion in `src/tests/mainImports.test.ts` that verifies `createLowerFloorFurnishings()` is invoked once, colliders are pushed into `groundColliders`, and generated collider metadata includes `sourceId`, `sourceType: 'generatedCollider'`, `purpose: 'lower-floor-furnishing'`, and `role`.
- Updated miniature metadata: bumped `decor:lower-floor-furnishings` `syncRevision` and updated `syncNote` in `sceneComponentRegistry.ts` and regenerated `miniatureManifest.generated.json` to acknowledge the source-only stove detail.

### Testing
- `npm run format:write` — passed and formatting applied to modified files; `npm run miniature:manifest:update` — passed and updated generated manifest.
- `npm run test:ci -- lowerFloorFurnishings` and `npm run test:ci -- lowerFloorFurnishings mainImports` — both passed; full `npm run test:ci` — green (all suites passed after manifest update).
- `npm run build` and `npm run smoke` — both passed; `npm run lint` — passed (no blocking errors after import-order fixups).
- `npm run typecheck` — reported pre-existing unrelated TypeScript errors elsewhere in the codebase but did not indicate issues introduced by these changes; `npm run docs:check` — passed with external link fetch warnings.

Commands used during verification: `npm run format:write`, `npx prettier --write`, `npm run miniature:manifest:update`, `npm run typecheck`, `npm run test:ci -- lowerFloorFurnishings mainImports`, `npm run test:ci`, `npm run build`, `npm run lint`, `npm run docs:check`, `npm run smoke`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4229753604832f87282a04b8032e71)