### PR TITLE
🧪 : – finalize lower-floor furnishing QA

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 16,
-      "syncNote": "Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.",
-      "sourceFingerprint": "3f6fde04e6fde403cf17736466f95891ff79fe2066181925f76913189440bd40",
+      "syncRevision": 17,
+      "syncNote": "Lower-floor sink and stove details remain source-only while furniture proxy coverage is deferred.",
+      "sourceFingerprint": "71cfbc9b90f17b8ecc0749f3725ffdb2ea12cef57f766bcd5bfdecd66e9148ce",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "38f2e4ffdf791e5045d86a2f3214016e1b8a09a560357c6a1c8778b49c0732b6"
+      "metadataFingerprint": "cbd9ded0dab602798574bc1b33461f1ff9334171fa962251caa81761d2a9a7b9"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 16,
+    syncRevision: 17,
     syncNote:
-      'Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.',
+      'Lower-floor sink and stove details remain source-only while furniture proxy coverage is deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -62,6 +62,9 @@ export interface LowerFloorFurnishingCollider extends RectCollider {
   category: LowerFloorFurnishingCategory;
   roomId: LowerFloorRoomId;
   sourceId: string;
+  sourceType: 'generatedCollider';
+  purpose: 'lower-floor-furnishing';
+  role: LowerFloorFurnishingCategory;
   debugName: string;
 }
 
@@ -235,7 +238,6 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         color: 0x687282,
         accentColor: 0xd8ccb8,
         height: 0.9,
-        allowSolidOverlapWithIds: ['kitchen-stove-cabinet'],
       },
     },
     {
@@ -255,8 +257,6 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       roomId: 'kitchen',
       position: { x: -31.0, z: -2.0 },
       orientationRadians: Math.PI / 2,
-      solidFootprint: { width: 1.2, depth: 1.8 },
-      solidBounds: { minX: -31.6, maxX: -30.4, minZ: -2.9, maxZ: -1.1 },
       kind: 'kitchen-sink-cabinet',
       visual: {
         color: 0x667382,
@@ -270,14 +270,11 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       roomId: 'kitchen',
       position: { x: -31.0, z: 7.0 },
       orientationRadians: Math.PI / 2,
-      solidFootprint: { width: 1.2, depth: 1.6 },
-      solidBounds: { minX: -31.6, maxX: -30.4, minZ: 6.2, maxZ: 7.8 },
       kind: 'kitchen-stove-cabinet',
       visual: {
         color: 0x5e6672,
         accentColor: 0x1d232b,
         height: 0.95,
-        allowSolidOverlapWithIds: ['kitchen-west-counter-run'],
       },
     },
     {
@@ -697,6 +694,9 @@ export function validateLowerFloorFurnishingPlan(
     if (!definition.solidFootprint) return [];
     const bounds = createRotatedAabb(definition, definition.solidFootprint);
     const room = roomBounds[definition.roomId];
+    if (!hasFiniteBounds(bounds)) {
+      throw new Error(`${definition.id} has non-finite solid bounds.`);
+    }
     if (!hasPositiveArea(bounds))
       throw new Error(`${definition.id} has an empty solid footprint.`);
     if (!containsBounds(room, bounds, tolerance)) {
@@ -754,6 +754,9 @@ export function validateLowerFloorFurnishingPlan(
       definition,
       definition.decorativeFootprint
     );
+    if (!hasFiniteBounds(bounds)) {
+      throw new Error(`${definition.id} has non-finite decorative bounds.`);
+    }
     if (!hasPositiveArea(bounds)) {
       throw new Error(`${definition.id} has an empty decorative footprint.`);
     }
@@ -814,6 +817,9 @@ export function createLowerFloorFurnishings(
         category: definition.category,
         roomId: definition.roomId,
         sourceId: `ground.furnishings.${definition.category}.${definition.id}.generated_collider`,
+        sourceType: 'generatedCollider',
+        purpose: 'lower-floor-furnishing',
+        role: definition.category,
         debugName: `LowerFloorFurnishingCollider:${definition.id}`,
       });
     }
@@ -2067,6 +2073,10 @@ function createVisualDetailPrimitive(
     return group;
   }
 
+  if (definition.kind.startsWith('kitchen-')) {
+    return createKitchenFurnishing(definition);
+  }
+
   if (definition.kind === 'pendant-lights-detail') {
     [-0.9, 0, 0.9].forEach((x, index) => {
       addBox(
@@ -2171,6 +2181,12 @@ function createRotatedAabb(
     width: footprint.width * cos + footprint.depth * sin,
     depth: footprint.width * sin + footprint.depth * cos,
   });
+}
+
+function hasFiniteBounds(bounds: RectCollider): boolean {
+  return [bounds.minX, bounds.maxX, bounds.minZ, bounds.maxZ].every(
+    Number.isFinite
+  );
 }
 
 function hasPositiveArea(bounds: RectCollider): boolean {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -2,6 +2,10 @@ import { Box3 } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
+  createBackyardFenceColliders,
+  createBackyardFenceSegments,
+} from '../scene/level/backyardCollisionPolicies';
+import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
@@ -10,10 +14,6 @@ import {
   validateLowerFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
 } from '../scene/structures/lowerFloorFurnishings';
-import {
-  createBackyardFenceColliders,
-  createBackyardFenceSegments,
-} from '../scene/level/backyardCollisionPolicies';
 import type { RectCollider } from '../systems/collision';
 
 const validDefinitions: LowerFloorFurnishingDefinition[] = [
@@ -80,7 +80,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(40);
+    expect(build.colliders).toHaveLength(38);
     expect(build.decorativeFootprints).toHaveLength(3);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -650,6 +650,9 @@ describe('lower floor furnishings foundation', () => {
       expect(collider.sourceId).toBe(
         `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
       );
+      expect(collider.sourceType).toBe('generatedCollider');
+      expect(collider.purpose).toBe('lower-floor-furnishing');
+      expect(collider.role).toBe(collider.category);
     });
   });
 
@@ -844,18 +847,6 @@ describe('lower floor furnishings foundation', () => {
         minZ: -6.35,
         maxZ: -4.85,
       },
-      'kitchen-sink-cabinet': {
-        minX: -31.6,
-        maxX: -30.4,
-        minZ: -2.9,
-        maxZ: -1.1,
-      },
-      'kitchen-stove-cabinet': {
-        minX: -31.6,
-        maxX: -30.4,
-        minZ: 6.2,
-        maxZ: 7.8,
-      },
       'kitchen-island': {
         minX: -15.4,
         maxX: -10.6,
@@ -891,6 +882,16 @@ describe('lower floor furnishings foundation', () => {
         roomId: 'kitchen',
       });
     });
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-sink-cabinet'
+      )
+    ).toBe(false);
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-stove-cabinet'
+      )
+    ).toBe(false);
   });
 
   it('keeps kitchen solidBounds aligned with authored centers and footprints', () => {
@@ -899,6 +900,16 @@ describe('lower floor furnishings foundation', () => {
     );
 
     kitchenDefinitions.forEach((definition) => {
+      if (
+        ['kitchen-sink-cabinet', 'kitchen-stove-cabinet'].includes(
+          definition.id
+        )
+      ) {
+        expect(definition.solidFootprint).toBeUndefined();
+        expect(definition.solidBounds).toBeUndefined();
+        return;
+      }
+
       expect(definition.solidFootprint).toBeDefined();
       expect(definition.solidBounds).toMatchObject(
         deriveAabbFromCenterSize(definition)
@@ -1128,6 +1139,10 @@ describe('lower floor furnishings foundation', () => {
 
     expect(build.colliders).toHaveLength(solidCount);
     build.colliders.forEach((collider) => {
+      expect(Number.isFinite(collider.minX)).toBe(true);
+      expect(Number.isFinite(collider.maxX)).toBe(true);
+      expect(Number.isFinite(collider.minZ)).toBe(true);
+      expect(Number.isFinite(collider.maxZ)).toBe(true);
       expect(collider.maxX - collider.minX).toBeGreaterThan(0);
       expect(collider.maxZ - collider.minZ).toBeGreaterThan(0);
       expect(collider.sourceId).toBe(
@@ -1162,23 +1177,14 @@ describe('lower floor furnishings foundation', () => {
     });
   });
 
-  it('requires solid overlap allowlists to be mutual', () => {
-    const oneSidedDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.map(
-      (definition) => {
-        if (definition.id !== 'kitchen-stove-cabinet') return definition;
-        return {
-          ...definition,
-          visual: {
-            ...definition.visual,
-            allowSolidOverlapWithIds: [],
-          },
-        };
-      }
-    );
+  it('rejects any default solid-solid furnishing overlaps', () => {
+    const { colliders } = createLowerFloorFurnishings();
 
-    expect(() => validateLowerFloorFurnishingPlan(oneSidedDefinitions)).toThrow(
-      /kitchen-west-counter-run overlaps kitchen-stove-cabinet/
-    );
+    colliders.forEach((collider, index) => {
+      colliders.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
+    });
   });
 
   it('allows decorative footprints to overlap associated solids only when explicit', () => {


### PR DESCRIPTION
### Motivation
- Finish QA/polish for the merged P2–P7 lower-floor furnishing pass to ensure colliders, decorative footprints, and runtime metadata are correct.
- Prevent authored kitchen visual details (sink/stove) from introducing overlapping blocking colliders while keeping them visually present.
- Improve validation robustness by catching non-finite AABB values early and make collider debug/runtime metadata explicit.

### Description
- Converted `kitchen-sink-cabinet` and `kitchen-stove-cabinet` to visual-only details (removed their `solidFootprint`/`solidBounds`) so they do not add blocking colliders and instead reuse the existing `createKitchenFurnishing(...)` visual builder.
- Added explicit collider metadata fields on generated colliders: `sourceType: 'generatedCollider'`, `purpose: 'lower-floor-furnishing'`, and `role` (category) to match runtime expectations.
- Tightened validation by adding `hasFiniteBounds(...)` and rejecting non-finite decorative/solid bounds before positive-area and containment checks.
- Updated `createLowerFloorFurnishings()` to push colliders with the new metadata and to keep decorative footprints separate from movement colliders.
- Expanded tests in `src/tests/lowerFloorFurnishings.test.ts` to assert collider metadata, finite coordinates, the kitchen visual-only behavior (no sink/stove colliders), and that default solids are disjoint; adjusted expected collider counts accordingly.
- Bumped miniature manifest acknowledgement for the lower-floor furnishings entry and updated `sceneComponentRegistry.ts` `syncRevision`/`syncNote` to reflect the source-only visual detail change.

### Testing
- Ran formatting: `npm run format:write -- src/scene/structures/lowerFloorFurnishings.ts src/tests/lowerFloorFurnishings.test.ts src/scene/miniature/sceneComponentRegistry.ts src/scene/miniature/miniatureManifest.generated.json` (completed successfully).
- Ran lint: `npm run lint` (no blocking errors; one import-order warning surfaced and was left as-is).
- Ran targeted tests: `npm run test:ci -- lowerFloorFurnishings` (passed: all 33 tests in that file passed after updates).
- Ran targeted manifest checks: `npm run test:ci -- lowerFloorFurnishings miniatureManifest` (passed after updating miniature manifest `syncRevision`).
- Ran full test suite: `npm run test:ci` (ran; initially failed due to stale miniature manifest which was then updated; overall repository tests passed in the final run except for an unrelated intermittent runtime logging noise; see below).
- Built production bundle: `npm run build` (succeeded; produced the `dist/` output with a bundle-size warning only).
- Typecheck: `npm run typecheck` (failed due to existing unrelated repository-wide TypeScript issues in other areas such as `src/main.ts` and several legacy test typings; these pre-existed and were not introduced by this change).

All CI-facing verification commands above were executed in the branch `codex/final-lower-floor-qa` and the focused end-to-end acceptance for lower-floor furnishing behavior and miniature manifest sync passed after the manifest bump.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42296d4130832f8f73680f8cc86e2b)