### PR TITLE
🛋️ Polish lower-floor furnishings QA

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1047,6 +1047,7 @@ const colliderSourceMetadata = new Map<
     sourceType: 'wall' | 'safetyCollider' | 'sceneObject' | 'generatedCollider';
     purpose?: string;
     role?: string;
+    category?: string;
     intent?: string;
     debugId?: string;
   }
@@ -2285,6 +2286,7 @@ function initializeImmersiveScene(
       sourceType: 'generatedCollider',
       purpose: 'lower-floor-furnishing',
       role: collider.category,
+      category: collider.category,
     });
   });
 

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 16,
-      "syncNote": "Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.",
-      "sourceFingerprint": "3f6fde04e6fde403cf17736466f95891ff79fe2066181925f76913189440bd40",
+      "syncRevision": 17,
+      "syncNote": "Kitchen stove detail collider cleanup remains source-only while furniture proxy coverage is deferred.",
+      "sourceFingerprint": "b9325f2de9558c9ab27db0d68fbcc144037b7d1662ed5274046df1fde5889975",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "38f2e4ffdf791e5045d86a2f3214016e1b8a09a560357c6a1c8778b49c0732b6"
+      "metadataFingerprint": "dbb557613c28098beea1f0538d63a32d8dc7866ed9dca89a955091dd98e85ade"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 16,
+    syncRevision: 17,
     syncNote:
-      'Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.',
+      'Kitchen stove detail collider cleanup remains source-only while furniture proxy coverage is deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -235,7 +235,6 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         color: 0x687282,
         accentColor: 0xd8ccb8,
         height: 0.9,
-        allowSolidOverlapWithIds: ['kitchen-stove-cabinet'],
       },
     },
     {
@@ -270,14 +269,11 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       roomId: 'kitchen',
       position: { x: -31.0, z: 7.0 },
       orientationRadians: Math.PI / 2,
-      solidFootprint: { width: 1.2, depth: 1.6 },
-      solidBounds: { minX: -31.6, maxX: -30.4, minZ: 6.2, maxZ: 7.8 },
       kind: 'kitchen-stove-cabinet',
       visual: {
         color: 0x5e6672,
         accentColor: 0x1d232b,
         height: 0.95,
-        allowSolidOverlapWithIds: ['kitchen-west-counter-run'],
       },
     },
     {
@@ -2065,6 +2061,10 @@ function createVisualDetailPrimitive(
       );
     });
     return group;
+  }
+
+  if (definition.kind === 'kitchen-stove-cabinet') {
+    return createKitchenFurnishing(definition);
   }
 
   if (definition.kind === 'pendant-lights-detail') {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -2,6 +2,10 @@ import { Box3 } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
+  createBackyardFenceColliders,
+  createBackyardFenceSegments,
+} from '../scene/level/backyardCollisionPolicies';
+import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
@@ -10,10 +14,6 @@ import {
   validateLowerFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
 } from '../scene/structures/lowerFloorFurnishings';
-import {
-  createBackyardFenceColliders,
-  createBackyardFenceSegments,
-} from '../scene/level/backyardCollisionPolicies';
 import type { RectCollider } from '../systems/collision';
 
 const validDefinitions: LowerFloorFurnishingDefinition[] = [
@@ -80,7 +80,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(40);
+    expect(build.colliders).toHaveLength(39);
     expect(build.decorativeFootprints).toHaveLength(3);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -850,12 +850,6 @@ describe('lower floor furnishings foundation', () => {
         minZ: -2.9,
         maxZ: -1.1,
       },
-      'kitchen-stove-cabinet': {
-        minX: -31.6,
-        maxX: -30.4,
-        minZ: 6.2,
-        maxZ: 7.8,
-      },
       'kitchen-island': {
         minX: -15.4,
         maxX: -10.6,
@@ -895,7 +889,8 @@ describe('lower floor furnishings foundation', () => {
 
   it('keeps kitchen solidBounds aligned with authored centers and footprints', () => {
     const kitchenDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
-      (definition) => definition.category === 'kitchenette'
+      (definition) =>
+        definition.category === 'kitchenette' && definition.solidFootprint
     );
 
     kitchenDefinitions.forEach((definition) => {
@@ -904,6 +899,32 @@ describe('lower floor furnishings foundation', () => {
         deriveAabbFromCenterSize(definition)
       );
     });
+  });
+
+  it('keeps stove detail visual-only inside the west counter footprint', () => {
+    const { colliders, group } = createLowerFloorFurnishings();
+    const stoveDefinition = DEFAULT_LOWER_FLOOR_FURNISHINGS.find(
+      (definition) => definition.id === 'kitchen-stove-cabinet'
+    );
+    const counter = colliders.find(
+      (collider) => collider.furnishingId === 'kitchen-west-counter-run'
+    );
+
+    expect(stoveDefinition?.solidFootprint).toBeUndefined();
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-stove-cabinet'
+      )
+    ).toBe(false);
+    expect(
+      group.getObjectByName('Furnishing:kitchen-stove-cabinet')
+    ).toBeDefined();
+    expect(group.getObjectByName('FurnishingPart:cooktop0-0')).toBeDefined();
+    expect(counter).toBeDefined();
+    expect(stoveDefinition!.position.x).toBeGreaterThan(counter!.minX);
+    expect(stoveDefinition!.position.x).toBeLessThan(counter!.maxX);
+    expect(stoveDefinition!.position.z).toBeGreaterThan(counter!.minZ);
+    expect(stoveDefinition!.position.z).toBeLessThan(counter!.maxZ);
   });
 
   it('keeps every kitchen collider inside the kitchen room bounds', () => {
@@ -933,22 +954,14 @@ describe('lower floor furnishings foundation', () => {
       });
   });
 
-  it('keeps kitchen solids disjoint except the authored stove counter integration', () => {
+  it('keeps kitchen solids disjoint after visual-only stove integration', () => {
     const { colliders } = createLowerFloorFurnishings();
     const kitchenColliders = colliders.filter(
       (collider) => collider.roomId === 'kitchen'
     );
-    const allowedOverlap = new Set([
-      'kitchen-stove-cabinet|kitchen-west-counter-run',
-      'kitchen-west-counter-run|kitchen-stove-cabinet',
-    ]);
-
     kitchenColliders.forEach((collider, index) => {
       kitchenColliders.slice(index + 1).forEach((other) => {
-        const pairKey = `${collider.furnishingId}|${other.furnishingId}`;
-        expect(rectanglesOverlap(collider, other)).toBe(
-          allowedOverlap.has(pairKey)
-        );
+        expect(rectanglesOverlap(collider, other)).toBe(false);
       });
     });
   });
@@ -1160,25 +1173,6 @@ describe('lower floor furnishings foundation', () => {
         expect(rectanglesOverlap(collider, blocker)).toBe(false);
       });
     });
-  });
-
-  it('requires solid overlap allowlists to be mutual', () => {
-    const oneSidedDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.map(
-      (definition) => {
-        if (definition.id !== 'kitchen-stove-cabinet') return definition;
-        return {
-          ...definition,
-          visual: {
-            ...definition.visual,
-            allowSolidOverlapWithIds: [],
-          },
-        };
-      }
-    );
-
-    expect(() => validateLowerFloorFurnishingPlan(oneSidedDefinitions)).toThrow(
-      /kitchen-west-counter-run overlaps kitchen-stove-cabinet/
-    );
   });
 
   it('allows decorative footprints to overlap associated solids only when explicit', () => {


### PR DESCRIPTION
### Motivation
- Final QA pass to tighten lower-floor furnishing colliders, decorative footprints, and visual polish while preserving P2–P7 intent. 
- Eliminate an authored blocking overlap between the stove detail and the west kitchen counter by making the stove a visual-only detail.

### Description
- Make `kitchen-stove-cabinet` visual-only by removing its `solidFootprint`/`solidBounds` and rendering it via the existing kitchen primitive so it no longer emits a blocking collider. (`src/scene/structures/lowerFloorFurnishings.ts`)
- Tighten tests in `src/tests/lowerFloorFurnishings.test.ts` to assert the updated collider inventory, verify the stove is visual-only and contained by the west counter, and ensure kitchen colliders remain disjoint after the change.
- Add `category` metadata to runtime collider source metadata so lower-floor furnishing colliders include category information at registration. (`src/main.ts`)
- Update miniature coverage metadata and regenerate the miniature manifest fingerprints / `syncRevision` to acknowledge the source-only change. (`src/scene/miniature/sceneComponentRegistry.ts`, `src/scene/miniature/miniatureManifest.generated.json`)

### Testing
- `npm run format:write` — ran (format applied where needed).
- `npm run typecheck` — NOT GREEN: fails on pre-existing, repo-wide TypeScript issues unrelated to this change (reported as existing errors from other areas).
- `npm run test:ci -- lowerFloorFurnishings` — passed (lower-floor furnishing focused suite).
- `npm run test:ci` — passed (full test run completed; lower-floor tests included).
- `npm run build` — passed (Vite production build succeeded).
- `npm run lint` — passed (ESLint run; one prior-order warning fixed by import ordering adjustment).
- `npm run docs:check` — passed (link-check warnings for external URLs reported but docs check passed).
- `npm run smoke` — passed (dist assertions OK).
- `npm run miniature:check` / `npm run miniature:manifest:update` — updated `syncRevision`/`syncNote` and regenerated manifest; `miniature:check` reports manifest current.
- `git diff --cached | ./scripts/scan-secrets.py` — ran (no high-risk secrets detected).
- `npm run collider:inspect -- --source-id <...>` — blocked in this environment because Playwright browser binaries are not installed (Playwright prompts to run `npx playwright install`).

Files changed (high level): `src/scene/structures/lowerFloorFurnishings.ts`, `src/tests/lowerFloorFurnishings.test.ts`, `src/main.ts`, `src/scene/miniature/sceneComponentRegistry.ts`, `src/scene/miniature/miniatureManifest.generated.json`.

Residual notes: `typecheck` fails reflect unrelated, pre-existing TS issues; collider inspection that requires Playwright is blocked in CI-like environment (install browsers locally with `npx playwright install` to run those checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42297dd400832fb1d594796e8b64c2)