### PR TITLE
🛋️ : – polish lower-floor furnishing QA

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 16,
-      "syncNote": "Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.",
-      "sourceFingerprint": "3f6fde04e6fde403cf17736466f95891ff79fe2066181925f76913189440bd40",
+      "syncRevision": 17,
+      "syncNote": "Stove detail remains source-only because miniature furniture proxy coverage is deferred.",
+      "sourceFingerprint": "8bed2c4384b4ff980e7ed4fd13dacae967f085a25572b66d4b1904ee83627399",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "38f2e4ffdf791e5045d86a2f3214016e1b8a09a560357c6a1c8778b49c0732b6"
+      "metadataFingerprint": "6d2d2b2e6be5a583f5849b415077dcfa19080285e25df456cbe49258d508aac5"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 16,
+    syncRevision: 17,
     syncNote:
-      'Backyard rotated-furnishing containment remains source-only while furniture proxy coverage is deferred.',
+      'Stove detail remains source-only because miniature furniture proxy coverage is deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -270,14 +270,11 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       roomId: 'kitchen',
       position: { x: -31.0, z: 7.0 },
       orientationRadians: Math.PI / 2,
-      solidFootprint: { width: 1.2, depth: 1.6 },
-      solidBounds: { minX: -31.6, maxX: -30.4, minZ: 6.2, maxZ: 7.8 },
       kind: 'kitchen-stove-cabinet',
       visual: {
         color: 0x5e6672,
         accentColor: 0x1d232b,
         height: 0.95,
-        allowSolidOverlapWithIds: ['kitchen-west-counter-run'],
       },
     },
     {
@@ -2039,6 +2036,35 @@ function createVisualDetailPrimitive(
       emissiveIntensity: definition.kind.includes('pendant') ? 0.35 : 0,
     }
   );
+
+  if (definition.kind === 'kitchen-stove-cabinet') {
+    addBox(
+      group,
+      'kitchenStoveInsetPanel',
+      { width: 1.12, height: 0.08, depth: 1.42 },
+      baseMaterial,
+      [0, 0.98, 0]
+    );
+    [-0.26, 0.26].forEach((x, index) => {
+      [-0.32, 0.32].forEach((z, innerIndex) => {
+        addBox(
+          group,
+          `kitchenStoveCooktop${index}-${innerIndex}`,
+          { width: 0.22, height: 0.04, depth: 0.22 },
+          accentMaterial,
+          [x, 1.05, z]
+        );
+      });
+    });
+    addBox(
+      group,
+      'kitchenStoveHoodPanel',
+      { width: 1.18, height: 0.14, depth: 0.28 },
+      accentMaterial,
+      [0, 1.55, 0.55]
+    );
+    return group;
+  }
 
   if (definition.kind === 'herb-planter-detail') {
     addBox(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -2,6 +2,10 @@ import { Box3 } from 'three';
 import { describe, expect, it } from 'vitest';
 
 import {
+  createBackyardFenceColliders,
+  createBackyardFenceSegments,
+} from '../scene/level/backyardCollisionPolicies';
+import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
@@ -10,10 +14,6 @@ import {
   validateLowerFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
 } from '../scene/structures/lowerFloorFurnishings';
-import {
-  createBackyardFenceColliders,
-  createBackyardFenceSegments,
-} from '../scene/level/backyardCollisionPolicies';
 import type { RectCollider } from '../systems/collision';
 
 const validDefinitions: LowerFloorFurnishingDefinition[] = [
@@ -80,7 +80,7 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(40);
+    expect(build.colliders).toHaveLength(39);
     expect(build.decorativeFootprints).toHaveLength(3);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
@@ -539,6 +539,17 @@ describe('lower floor furnishings foundation', () => {
       group.getObjectByName('FurnishingPart:kitchenHerbPlanterBox')
     ).toBeDefined();
     expect(group.getObjectByName('FurnishingPart:pendantShade0')).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:kitchenStoveInsetPanel')
+    ).toBeDefined();
+    expect(
+      group.getObjectByName('FurnishingPart:kitchenStoveCooktop0-0')
+    ).toBeDefined();
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'kitchen-stove-cabinet'
+      )
+    ).toBe(false);
 
     const herbPlanter = DEFAULT_LOWER_FLOOR_FURNISHINGS.find(
       (definition) => definition.id === 'kitchen-herb-planter'
@@ -850,12 +861,6 @@ describe('lower floor furnishings foundation', () => {
         minZ: -2.9,
         maxZ: -1.1,
       },
-      'kitchen-stove-cabinet': {
-        minX: -31.6,
-        maxX: -30.4,
-        minZ: 6.2,
-        maxZ: 7.8,
-      },
       'kitchen-island': {
         minX: -15.4,
         maxX: -10.6,
@@ -898,12 +903,19 @@ describe('lower floor furnishings foundation', () => {
       (definition) => definition.category === 'kitchenette'
     );
 
-    kitchenDefinitions.forEach((definition) => {
-      expect(definition.solidFootprint).toBeDefined();
-      expect(definition.solidBounds).toMatchObject(
-        deriveAabbFromCenterSize(definition)
-      );
-    });
+    kitchenDefinitions
+      .filter((definition) => definition.solidFootprint)
+      .forEach((definition) => {
+        expect(definition.solidBounds).toMatchObject(
+          deriveAabbFromCenterSize(definition)
+        );
+      });
+
+    expect(
+      kitchenDefinitions.find(
+        (definition) => definition.id === 'kitchen-stove-cabinet'
+      )?.solidFootprint
+    ).toBeUndefined();
   });
 
   it('keeps every kitchen collider inside the kitchen room bounds', () => {
@@ -933,22 +945,14 @@ describe('lower floor furnishings foundation', () => {
       });
   });
 
-  it('keeps kitchen solids disjoint except the authored stove counter integration', () => {
+  it('keeps kitchen solids disjoint, with stove details riding the parent counter', () => {
     const { colliders } = createLowerFloorFurnishings();
     const kitchenColliders = colliders.filter(
       (collider) => collider.roomId === 'kitchen'
     );
-    const allowedOverlap = new Set([
-      'kitchen-stove-cabinet|kitchen-west-counter-run',
-      'kitchen-west-counter-run|kitchen-stove-cabinet',
-    ]);
-
     kitchenColliders.forEach((collider, index) => {
       kitchenColliders.slice(index + 1).forEach((other) => {
-        const pairKey = `${collider.furnishingId}|${other.furnishingId}`;
-        expect(rectanglesOverlap(collider, other)).toBe(
-          allowedOverlap.has(pairKey)
-        );
+        expect(rectanglesOverlap(collider, other)).toBe(false);
       });
     });
   });
@@ -1163,21 +1167,31 @@ describe('lower floor furnishings foundation', () => {
   });
 
   it('requires solid overlap allowlists to be mutual', () => {
-    const oneSidedDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.map(
-      (definition) => {
-        if (definition.id !== 'kitchen-stove-cabinet') return definition;
-        return {
-          ...definition,
-          visual: {
-            ...definition.visual,
-            allowSolidOverlapWithIds: [],
-          },
-        };
-      }
-    );
+    const oneSidedDefinitions: LowerFloorFurnishingDefinition[] = [
+      {
+        id: 'kitchen-test-counter-parent',
+        category: 'kitchenette',
+        roomId: 'kitchen',
+        position: { x: -27, z: 12 },
+        orientationRadians: 0,
+        solidFootprint: { width: 2, depth: 2 },
+        kind: 'counter',
+        visual: { allowSolidOverlapWithIds: ['kitchen-test-inset-detail'] },
+      },
+      {
+        id: 'kitchen-test-inset-detail',
+        category: 'kitchenette',
+        roomId: 'kitchen',
+        position: { x: -27, z: 12 },
+        orientationRadians: 0,
+        solidFootprint: { width: 1, depth: 1 },
+        kind: 'counter',
+        visual: { allowSolidOverlapWithIds: [] },
+      },
+    ];
 
     expect(() => validateLowerFloorFurnishingPlan(oneSidedDefinitions)).toThrow(
-      /kitchen-west-counter-run overlaps kitchen-stove-cabinet/
+      /kitchen-test-counter-parent overlaps kitchen-test-inset-detail/
     );
   });
 


### PR DESCRIPTION
### Motivation
- Final QA pass to ensure lower-floor furnishings from P1–P7 ship with correct blocking colliders and no accidental overlapping movement blockers.
- Make the kitchen stove a visual-only detail so the authored counter run remains the single blocking collider and preserve intended scene layout.
- Tighten tests to prove the full P2–P7 inventory, collider metadata, disjointness, room containment, and decorative non-blocking behavior.

### Description
- Converted `kitchen-stove-cabinet` to a visual-only detail (no solid footprint) and added deterministic inset/cooktop/hood meshes via the visual-detail builder in `src/scene/structures/lowerFloorFurnishings.ts`.
- Removed the stove blocking collider/allowlist and kept the stove visuals riding the existing `kitchen-west-counter-run` so kitchen solids remain disjoint.
- Updated `src/tests/lowerFloorFurnishings.test.ts` to expect 39 blocking colliders, assert stove visual parts exist and have no collider, enforce kitchen-collider disjointness, and add a focused mutual-overlap allowlist test fixture.
- Bumped miniature coverage acknowledgement in `src/scene/miniature/sceneComponentRegistry.ts` and regenerated `src/scene/miniature/miniatureManifest.generated.json` to record the source-only stove detail change.

### Testing
- Ran formatting with `npm run format:write` (succeeded).
- Ran targeted tests with `npm run test:ci -- lowerFloorFurnishings` (33 tests passed).
- Ran full test suite with `npm run test:ci` (all tests passed after manifest update; 1435 tests passed overall in CI runs shown).
- Verified miniature sync with `npm run miniature:check` and updated the generated manifest with `npm run miniature:manifest:update` (manifest updated and check passed).
- Built and smoke-checked the app with `npm run build` and `npm run smoke` (build and smoke checks passed; build emitted chunk-size warning only).
- Linted with `npm run lint` (passed) and docs check with `npm run docs:check` (passed with external link fetch warnings from the environment).
- Performed a repo secret scan via `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets detected).
- Note: `npm run typecheck` reported unrelated existing TypeScript strictness errors elsewhere in the codebase and is not caused by these lower-floor furnishing changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a422960b1a4832fb06f3a26ecfec22d)