### PR TITLE
🏠 : – add upper-floor furnishing authoring & reflow token.place

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -293,7 +293,10 @@ import {
   createJobbotTerminal,
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
-import { createLowerFloorFurnishings } from './scene/structures/lowerFloorFurnishings';
+import {
+  createLowerFloorFurnishings,
+  createUpperFloorFurnishings,
+} from './scene/structures/lowerFloorFurnishings';
 import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
@@ -2284,6 +2287,19 @@ function initializeImmersiveScene(
       sourceId: assertLevelSourceId(collider.sourceId),
       sourceType: 'generatedCollider',
       purpose: 'lower-floor-furnishing',
+      role: collider.category,
+    });
+  });
+
+  const upperFloorFurnishings = createUpperFloorFurnishings();
+  upperStructureGroup.add(upperFloorFurnishings.group);
+  upperFloorFurnishings.colliders.forEach((collider) => {
+    upperFloorColliders.push(collider);
+    namedColliderDebugNames.set(collider, collider.debugName);
+    colliderSourceMetadata.set(collider, {
+      sourceId: assertLevelSourceId(collider.sourceId),
+      sourceType: 'generatedCollider',
+      purpose: 'upper-floor-furnishing',
       role: collider.category,
     });
   });

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 18,
-      "syncNote": "Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.",
-      "sourceFingerprint": "2152c8d288227bea8b088e9da6474ee781f1b8ef24d7e55660856f67a3adb61a",
+      "syncRevision": 19,
+      "syncNote": "Adds upper-floor furnishing authoring while furniture proxy coverage remains deferred.",
+      "sourceFingerprint": "416581881bf5090459c508bdebd89865e08630900364ad21c74dd1efec9e9423",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "3d6b130cd99fb62fde66e6951c50e0f41ffd63ac13825bbb1dea1b3939c89d63"
+      "metadataFingerprint": "84cf8fb07ce2dbcb63ea35fbca816e12ce7fd5ec6542d49c35631fd4629a89b2"
     },
     {
       "id": "environment:backyard",
@@ -523,8 +523,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "89086f102559baa055f93f88d427c1a0419da43ddbc6ec3fa9ae70cb6a0455b3",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
     },
     {
@@ -543,8 +543,8 @@
       ],
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "4a4ff9e8191dc7a2877a6e047f1069ce1f8459bc37a2fa3b129819d8cb9eb40f",
+      "sourceFingerprint": "f0a1fab98b8f1a5bd648de469084e8d9b19e020aaf72d3c255cec5647b3e6c91",
+      "proxyFingerprint": "fe2f138402742b557c870cc5619c63d38270013cd6ed51dbca3f2d563811ac30",
       "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
     },
     {
@@ -558,8 +558,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "c87383d3a6f49d502eb783e065ef22b959f13462848666216d3277db98321501",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
     },
     {
@@ -573,8 +573,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 7,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "d338953e130bb55599de8591f7c3c585f3deccf6ad1071e42092668115c1721b",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "d9c99df1cd61da12890dc0b6e14a548964dc78e8abdbea2ea974e0cfe2eb3ce4",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "203724c45bb66fbd270e45ab7a70e1dbafba3029e5c7564acd9d086d805da04e"
     },
     {
@@ -590,8 +590,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 26,
       "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
-      "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "51673f968397b8576b9770c51e483dbd9df4908f34becfc97e86382f9964a284",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
     },
     {
@@ -605,8 +605,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "dc0353e20df47adc0fc603239278aeb743d789f8206dfef0fa5afd3dc205dc3a",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
     },
     {
@@ -620,8 +620,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 7,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "5519bd57ed38839a83979ca24e37884834fd8fcef58414f43c2590aa395f445f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "77148305c61fe9d51393213a2872dfe423e200281087d58d766be8a61b23133d",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "e211ac43acb6c5ba1c68752d59b2710f4f99ec7cfff4ebcd119ca5008e631fc3"
     },
     {
@@ -635,8 +635,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 7,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "23d44ccb3594b8a61cd8a971ac292ab08d66bd7eea213141e96b36f44224946f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "a6a4d7481948a838178a30b12945d9da638262d4df7ded6620f1a9a00d80d210",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "088235cd162b79a0a99f9ce58f500e3d67358bb03db4d57b739e452775f4113a"
     },
     {
@@ -650,8 +650,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "11f0a7b30d7648491804a44c0379a34f727f76661f62fab5503ef237350ee20b",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
     },
     {
@@ -685,8 +685,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 20,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "2446a3daca1cbc958edb093eb97e35c61f386d919800f8d772ca239d19bf7b4f",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
     },
     {
@@ -700,8 +700,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 7,
       "syncNote": "Adds the printed enclosure shell around the Sigma AI pin silhouette.",
-      "sourceFingerprint": "69151e3d9000e5e8d3c0dc2ea3b817ca6e5b008b44aa03cbe5e09026ced2f23f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "ae2d13695f8011c7cdd9380a518859e6d114857b8ac3217ca9b25dabbd6773a5",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "aa5a817cf4f5ca8f131522be446bec1762932a4c9d6bb42b4f537fa410bc7980"
     },
     {
@@ -715,8 +715,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 4,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "ac4eb79207c4d2f70796e6b980bb8663d2e694f42a69ce6a04bca7c371f05436",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
     },
     {
@@ -728,11 +728,11 @@
         "src/scene/structures/tokenPlaceWorkstation.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 4,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
+      "syncRevision": 5,
+      "syncNote": "Acknowledges same-room living-room workstation reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "f02ec6225ba49f587b5cf95fa2e9f4871e58d6328d3b123cec2972685e6f2f47",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
+      "metadataFingerprint": "d4dd85659a355f50730610731f8acd44619c6742e92c02fc69c6ce1ffaf3b831"
     },
     {
       "id": "poi:wove-kitchen-loom",
@@ -745,8 +745,8 @@
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
       "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
+      "sourceFingerprint": "47b5e6a824a3e87cdfa764593ff4c578245e579d90b1dbe83c7121d1555f263d",
+      "proxyFingerprint": "44d2fdc4df0c8a215354252d7408eb5ed62773ca05e968c640bf08f14b1527dd",
       "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
     },
     {

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -306,9 +306,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'tokenplace-studio-cluster',
     id: 'poi:tokenplace-studio-cluster',
     displayName: 'token.place workstation proxy',
-    syncRevision: 4,
+    syncRevision: 5,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges same-room living-room workstation reflow while preserving this proxy silhouette.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/tokenPlaceWorkstation.ts',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 18,
+    syncRevision: 19,
     syncNote:
-      'Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.',
+      'Adds upper-floor furnishing authoring while furniture proxy coverage remains deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -40,7 +40,7 @@ describe('applyManualPoiPlacements', () => {
         roomId: 'livingRoom',
         floorId: 'ground',
         anchorY: 0.75,
-        position: { x: -22.34, y: 0, z: -22.61 },
+        position: { x: 1.8, y: 0, z: -21.2 },
       },
       {
         id: 'sugarkube-backyard-greenhouse',

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -83,13 +83,13 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   },
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
-    position: { x: -22.34, y: getFloorTopElevation('ground'), z: -22.61 },
+    position: { x: 1.8, y: getFloorTopElevation('ground'), z: -21.2 },
     interactionAnchorPosition: {
-      x: -22.34,
+      x: 1.8,
       y: getFloorStandingInteractionAnchorY('ground'),
-      z: -22.61,
+      z: -21.2,
     },
-    headingRadians: Math.PI * 0.05,
+    headingRadians: -Math.PI * 0.18,
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -11,6 +11,15 @@ import {
 import type { RectCollider } from '../collision';
 import { isLevelSourceId } from '../level/sourceIds';
 
+export type FloorFurnishingFloorId = 'ground' | 'upper';
+
+export type UpperFloorFurnishingCategory =
+  | 'upper-landing'
+  | 'creators-studio'
+  | 'loft-library'
+  | 'focus-pods'
+  | 'plants-lighting-decor';
+
 export type LowerFloorFurnishingCategory =
   | 'living-room-seating'
   | 'kitchenette'
@@ -21,6 +30,17 @@ export type LowerFloorFurnishingCategory =
 
 export type LowerFloorRoomId = 'livingRoom' | 'kitchen' | 'studio' | 'backyard';
 
+export type UpperFloorRoomId =
+  | 'upperLanding'
+  | 'creatorsStudio'
+  | 'loftLibrary'
+  | 'focusPods';
+
+type FloorFurnishingCategory =
+  | LowerFloorFurnishingCategory
+  | UpperFloorFurnishingCategory;
+type FloorFurnishingRoomId = LowerFloorRoomId | UpperFloorRoomId;
+
 export interface LowerFloorFurnishingFootprint {
   width: number;
   depth: number;
@@ -28,8 +48,8 @@ export interface LowerFloorFurnishingFootprint {
 
 export interface LowerFloorFurnishingDefinition {
   id: string;
-  category: LowerFloorFurnishingCategory;
-  roomId: LowerFloorRoomId;
+  category: FloorFurnishingCategory;
+  roomId: FloorFurnishingRoomId;
   position: { x: number; y?: number; z: number };
   orientationRadians: number;
   solidFootprint?: LowerFloorFurnishingFootprint;
@@ -51,27 +71,33 @@ export interface LowerFloorFurnishingDefinition {
 export interface DecorativeFootprintRecord {
   id: string;
   furnishingId: string;
-  category: LowerFloorFurnishingCategory;
-  roomId: LowerFloorRoomId;
+  category: FloorFurnishingCategory;
+  roomId: FloorFurnishingRoomId;
   bounds: RectCollider;
   allowSolidOverlap: boolean;
 }
 
 export interface LowerFloorFurnishingCollider extends RectCollider {
   furnishingId: string;
-  category: LowerFloorFurnishingCategory;
-  roomId: LowerFloorRoomId;
+  category: FloorFurnishingCategory;
+  roomId: FloorFurnishingRoomId;
+  floorId: FloorFurnishingFloorId;
   sourceId: string;
   debugName: string;
 }
 
 export interface LowerFloorFurnishingValidationOptions {
-  roomBounds?: Partial<Record<LowerFloorRoomId, RectCollider>>;
+  roomBounds?: Partial<Record<FloorFurnishingRoomId, RectCollider>>;
   reservedBlockers?: readonly RectCollider[];
   tolerance?: number;
 }
 
 export interface LowerFloorFurnishingsCreateOptions
+  extends LowerFloorFurnishingValidationOptions {
+  definitions?: readonly LowerFloorFurnishingDefinition[];
+}
+
+export interface UpperFloorFurnishingsCreateOptions
   extends LowerFloorFurnishingValidationOptions {
   definitions?: readonly LowerFloorFurnishingDefinition[];
 }
@@ -89,6 +115,13 @@ export const LOWER_FLOOR_ROOM_BOUNDS: Record<LowerFloorRoomId, RectCollider> = {
   backyard: { minX: -32, maxX: 32, minZ: 16, maxZ: 32 },
 };
 
+export const UPPER_FLOOR_ROOM_BOUNDS: Record<UpperFloorRoomId, RectCollider> = {
+  upperLanding: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+  creatorsStudio: { minX: -20, maxX: 4, minZ: -32, maxZ: 0 },
+  loftLibrary: { minX: 4, maxX: 24, minZ: -16, maxZ: 12 },
+  focusPods: { minX: -20, maxX: 24, minZ: 12, maxZ: 28 },
+};
+
 export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
   { minX: -22, maxX: -14, minZ: -9.2, maxZ: -6.8 },
   { minX: 11, maxX: 19, minZ: -9.2, maxZ: -6.8 },
@@ -96,7 +129,7 @@ export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
   { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
   { minX: 11, maxX: 19, minZ: 14.8, maxZ: 17.2 },
   { minX: -32.0, maxX: -30.9, minZ: -23.2, maxZ: -16.8 },
-  { minX: -24.74, maxX: -19.94, minZ: -24.61, maxZ: -20.61 },
+  { minX: 0.8, maxX: 4.2, minZ: -23.2, maxZ: -19.2 },
   { minX: -12.34, maxX: -5.14, minZ: -26.12, maxZ: -19.72 },
   { minX: -24.0, maxX: -19.2, minZ: -0.77, maxZ: 4.03 },
   { minX: 26.4, maxX: 31.2, minZ: -24.4, maxZ: -21.2 },
@@ -106,6 +139,17 @@ export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
   { minX: -18.5, maxX: -10.0, minZ: 18.0, maxZ: 24.2 },
   { minX: 10.0, maxX: 18.2, minZ: 22.4, maxZ: 30.4 },
 ];
+
+export const UPPER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
+  { minX: 4.4, maxX: 8.2, minZ: -17.2, maxZ: -14.8 },
+  { minX: -18.9, maxX: -15.7, minZ: -8.6, maxZ: -5.5 },
+  { minX: -18.7, maxX: -15.0, minZ: 15.6, maxZ: 18.9 },
+  { minX: -2.4, maxX: 1.2, minZ: 12.4, maxZ: 15.7 },
+  { minX: 14.9, maxX: 18.4, minZ: 16.0, maxZ: 19.3 },
+];
+
+export const DEFAULT_UPPER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] =
+  [];
 
 export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] =
   [
@@ -676,12 +720,14 @@ function containsPoint(
   );
 }
 
-export function validateLowerFloorFurnishingPlan(
+function validateFloorFurnishingPlan(
   definitions: readonly LowerFloorFurnishingDefinition[],
+  defaultRoomBounds: Partial<Record<FloorFurnishingRoomId, RectCollider>>,
+  defaultBlockers: readonly RectCollider[],
   options: LowerFloorFurnishingValidationOptions = {}
 ): void {
-  const roomBounds = { ...LOWER_FLOOR_ROOM_BOUNDS, ...options.roomBounds };
-  const blockers = options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS;
+  const roomBounds = { ...defaultRoomBounds, ...options.roomBounds };
+  const blockers = options.reservedBlockers ?? defaultBlockers;
   const tolerance = options.tolerance ?? 0.001;
   definitions.forEach((definition) => {
     if (!isLevelSourceId(definition.id)) {
@@ -693,6 +739,7 @@ export function validateLowerFloorFurnishingPlan(
     if (!definition.solidFootprint) return [];
     const bounds = createRotatedAabb(definition, definition.solidFootprint);
     const room = roomBounds[definition.roomId];
+    if (!room) throw new Error(`${definition.roomId} has no room bounds.`);
     if (!hasPositiveArea(bounds))
       throw new Error(`${definition.id} has an empty solid footprint.`);
     if (!containsBounds(room, bounds, tolerance)) {
@@ -733,7 +780,7 @@ export function validateLowerFloorFurnishingPlan(
     if (definition.solidFootprint || definition.decorativeFootprint) return;
     if (
       !containsPoint(
-        roomBounds[definition.roomId],
+        roomBounds[definition.roomId] ?? { minX: 0, maxX: 0, minZ: 0, maxZ: 0 },
         definition.position,
         tolerance
       )
@@ -753,7 +800,9 @@ export function validateLowerFloorFurnishingPlan(
     if (!hasPositiveArea(bounds)) {
       throw new Error(`${definition.id} has an empty decorative footprint.`);
     }
-    if (!containsBounds(roomBounds[definition.roomId], bounds, tolerance)) {
+    const room = roomBounds[definition.roomId];
+    if (!room) throw new Error(`${definition.roomId} has no room bounds.`);
+    if (!containsBounds(room, bounds, tolerance)) {
       throw new Error(
         `${definition.id} decorative footprint is outside ${definition.roomId}.`
       );
@@ -780,14 +829,42 @@ export function validateLowerFloorFurnishingPlan(
   });
 }
 
-export function createLowerFloorFurnishings(
-  options: LowerFloorFurnishingsCreateOptions = {}
+export function validateLowerFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingValidationOptions = {}
+): void {
+  validateFloorFurnishingPlan(
+    definitions,
+    LOWER_FLOOR_ROOM_BOUNDS,
+    LOWER_FLOOR_RESERVED_BLOCKERS,
+    options
+  );
+}
+
+export function validateUpperFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingValidationOptions = {}
+): void {
+  validateFloorFurnishingPlan(
+    definitions,
+    UPPER_FLOOR_ROOM_BOUNDS,
+    UPPER_FLOOR_RESERVED_BLOCKERS,
+    options
+  );
+}
+
+function createFloorFurnishings(
+  floorId: FloorFurnishingFloorId,
+  groupName: string,
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingValidationOptions
 ): LowerFloorFurnishingsBuild {
-  const definitions = options.definitions ?? DEFAULT_LOWER_FLOOR_FURNISHINGS;
-  validateLowerFloorFurnishingPlan(definitions, options);
+  if (floorId === 'upper')
+    validateUpperFloorFurnishingPlan(definitions, options);
+  else validateLowerFloorFurnishingPlan(definitions, options);
 
   const group = new Group();
-  group.name = 'LowerFloorFurnishings';
+  group.name = groupName;
   const colliders: LowerFloorFurnishingCollider[] = [];
   const decorativeFootprints: DecorativeFootprintRecord[] = [];
 
@@ -809,8 +886,9 @@ export function createLowerFloorFurnishings(
         furnishingId: definition.id,
         category: definition.category,
         roomId: definition.roomId,
-        sourceId: `ground.furnishings.${definition.category}.${definition.id}.generated_collider`,
-        debugName: `LowerFloorFurnishingCollider:${definition.id}`,
+        floorId,
+        sourceId: `${floorId}.furnishings.${definition.category}.${definition.id}.generated_collider`,
+        debugName: `${groupName}Collider:${definition.id}`,
       });
     }
 
@@ -837,6 +915,28 @@ export function createLowerFloorFurnishings(
   });
 
   return { group, colliders, decorativeFootprints };
+}
+
+export function createLowerFloorFurnishings(
+  options: LowerFloorFurnishingsCreateOptions = {}
+): LowerFloorFurnishingsBuild {
+  return createFloorFurnishings(
+    'ground',
+    'LowerFloorFurnishings',
+    options.definitions ?? DEFAULT_LOWER_FLOOR_FURNISHINGS,
+    options
+  );
+}
+
+export function createUpperFloorFurnishings(
+  options: UpperFloorFurnishingsCreateOptions = {}
+): LowerFloorFurnishingsBuild {
+  return createFloorFurnishings(
+    'upper',
+    'UpperFloorFurnishings',
+    options.definitions ?? DEFAULT_UPPER_FLOOR_FURNISHINGS,
+    options
+  );
 }
 
 function createSolidPrimitive(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -6,14 +6,21 @@ import {
   createBackyardFenceSegments,
 } from '../scene/level/backyardCollisionPolicies';
 import { isLevelSourceId } from '../scene/level/sourceIds';
+import { MANUAL_POI_PLACEMENTS } from '../scene/poi/placements';
 import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
+  UPPER_FLOOR_RESERVED_BLOCKERS,
+  UPPER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
   createLowerFloorFurnishings,
+  createUpperFloorFurnishings,
   rectanglesOverlap,
   validateLowerFloorFurnishingPlan,
+  validateUpperFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
+  type LowerFloorRoomId,
+  type UpperFloorRoomId,
 } from '../scene/structures/lowerFloorFurnishings';
 import type { RectCollider } from '../systems/collision';
 
@@ -73,6 +80,45 @@ const validDefinitions: LowerFloorFurnishingDefinition[] = [
     orientationRadians: 0,
     solidFootprint: { width: 2.2, depth: 2.2 },
     kind: 'plant-pot',
+  },
+];
+
+const upperDefinitions: LowerFloorFurnishingDefinition[] = [
+  {
+    id: 'upper-landing-console-foundation',
+    category: 'upper-landing',
+    roomId: 'upperLanding',
+    position: { x: 14, z: -28 },
+    orientationRadians: 0,
+    solidFootprint: { width: 3, depth: 1 },
+    kind: 'upper-console',
+  },
+  {
+    id: 'creators-studio-worktable-foundation',
+    category: 'creators-studio',
+    roomId: 'creatorsStudio',
+    position: { x: -8, z: -24 },
+    orientationRadians: Math.PI / 2,
+    solidFootprint: { width: 4, depth: 1.4 },
+    kind: 'upper-worktable',
+  },
+  {
+    id: 'loft-library-rug-foundation',
+    category: 'loft-library',
+    roomId: 'loftLibrary',
+    position: { x: 16, z: -4 },
+    orientationRadians: 0,
+    decorativeFootprint: { width: 5, depth: 3 },
+    kind: 'upper-rug',
+  },
+  {
+    id: 'focus-pods-plant-foundation',
+    category: 'plants-lighting-decor',
+    roomId: 'focusPods',
+    position: { x: 22, z: 26 },
+    orientationRadians: 0,
+    solidFootprint: { width: 0.8, depth: 0.8 },
+    kind: 'upper-potted-plant',
   },
 ];
 
@@ -454,7 +500,10 @@ describe('lower floor furnishings foundation', () => {
 
     storageColliders.forEach((storage, index) => {
       expect(
-        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[storage.roomId], storage)
+        isContainedBy(
+          LOWER_FLOOR_ROOM_BOUNDS[storage.roomId as LowerFloorRoomId],
+          storage
+        )
       ).toBe(true);
       storageColliders.slice(index + 1).forEach((otherStorage) => {
         expect(rectanglesOverlap(storage, otherStorage)).toBe(false);
@@ -627,9 +676,12 @@ describe('lower floor furnishings foundation', () => {
     );
 
     decorColliders.forEach((decor, index) => {
-      expect(isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[decor.roomId], decor)).toBe(
-        true
-      );
+      expect(
+        isContainedBy(
+          LOWER_FLOOR_ROOM_BOUNDS[decor.roomId as LowerFloorRoomId],
+          decor
+        )
+      ).toBe(true);
       decorColliders.slice(index + 1).forEach((otherDecor) => {
         expect(rectanglesOverlap(decor, otherDecor)).toBe(false);
       });
@@ -1153,7 +1205,7 @@ describe('lower floor furnishings foundation', () => {
     });
 
     colliders.forEach((collider) => {
-      const room = LOWER_FLOOR_ROOM_BOUNDS[collider.roomId];
+      const room = LOWER_FLOOR_ROOM_BOUNDS[collider.roomId as LowerFloorRoomId];
       expect(isContainedBy(room, collider)).toBe(true);
     });
   });
@@ -1264,6 +1316,142 @@ describe('lower floor furnishings foundation', () => {
         },
       ])
     ).toThrow(/empty decorative footprint/);
+  });
+});
+
+describe('upper floor furnishings foundation', () => {
+  it('builds an empty default upper furnishing group', () => {
+    const build = createUpperFloorFurnishings();
+
+    expect(build.group.name).toBe('UpperFloorFurnishings');
+    expect(build.colliders).toEqual([]);
+    expect(build.decorativeFootprints).toEqual([]);
+  });
+
+  it('defines valid upper room bounds for every supported upper room', () => {
+    expect(Object.keys(UPPER_FLOOR_ROOM_BOUNDS).sort()).toEqual([
+      'creatorsStudio',
+      'focusPods',
+      'loftLibrary',
+      'upperLanding',
+    ]);
+
+    Object.values(UPPER_FLOOR_ROOM_BOUNDS).forEach((bounds) => {
+      expect(bounds.maxX - bounds.minX).toBeGreaterThan(0);
+      expect(bounds.maxZ - bounds.minZ).toBeGreaterThan(0);
+    });
+  });
+
+  it('creates valid unique upper source IDs and upper-floor collider metadata', () => {
+    const { colliders, group } = createUpperFloorFurnishings({
+      definitions: upperDefinitions,
+    });
+    const sourceIds = new Set(colliders.map((collider) => collider.sourceId));
+
+    expect(group.children.map((child) => child.name)).toEqual(
+      upperDefinitions.map((definition) => `Furnishing:${definition.id}`)
+    );
+    expect(sourceIds.size).toBe(colliders.length);
+    colliders.forEach((collider) => {
+      expect(collider.floorId).toBe('upper');
+      expect(isLevelSourceId(collider.sourceId)).toBe(true);
+      expect(collider.sourceId).toBe(
+        `upper.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
+      );
+      expect(collider.debugName).toBe(
+        `UpperFloorFurnishingsCollider:${collider.furnishingId}`
+      );
+      expect(
+        isContainedBy(
+          UPPER_FLOOR_ROOM_BOUNDS[collider.roomId as UpperFloorRoomId],
+          collider
+        )
+      ).toBe(true);
+      UPPER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+      });
+    });
+  });
+
+  it('keeps upper decorative footprints non-blocking', () => {
+    const { colliders, decorativeFootprints } = createUpperFloorFurnishings({
+      definitions: upperDefinitions,
+    });
+
+    expect(
+      colliders.some(
+        (collider) => collider.furnishingId === 'loft-library-rug-foundation'
+      )
+    ).toBe(false);
+    const rug = decorativeFootprints.find(
+      (footprint) => footprint.furnishingId === 'loft-library-rug-foundation'
+    );
+    expect(rug).toBeDefined();
+    expect(rug?.bounds).toEqual({
+      minX: 13.5,
+      maxX: 18.5,
+      minZ: -5.5,
+      maxZ: -2.5,
+    });
+  });
+
+  it('validates upper room containment and solid collisions', () => {
+    expect(() =>
+      validateUpperFloorFurnishingPlan(upperDefinitions)
+    ).not.toThrow();
+    expect(() =>
+      validateUpperFloorFurnishingPlan([
+        {
+          ...upperDefinitions[0],
+          id: 'upper-landing-outside',
+          position: { x: 2, z: -28 },
+        },
+      ])
+    ).toThrow(/outside upperLanding/);
+    expect(() =>
+      validateUpperFloorFurnishingPlan([
+        upperDefinitions[0],
+        {
+          ...upperDefinitions[0],
+          id: 'upper-landing-overlap',
+          position: { x: 14.2, z: -28 },
+        },
+      ])
+    ).toThrow(
+      /upper-landing-console-foundation overlaps upper-landing-overlap/
+    );
+  });
+});
+
+describe('token.place POI placement reflow', () => {
+  it('keeps the manual token.place placement in the living room at the reflowed workstation', () => {
+    const placement = MANUAL_POI_PLACEMENTS['tokenplace-studio-cluster'];
+
+    expect(placement?.roomId).toBe('livingRoom');
+    expect(placement?.position.x).toBeCloseTo(1.8);
+    expect(placement?.position.z).toBeCloseTo(-21.2);
+    expect(placement?.headingRadians).toBeCloseTo(-Math.PI * 0.18);
+  });
+
+  it('keeps the token.place blocker out of the media seating cluster', () => {
+    const tokenBlocker = LOWER_FLOOR_RESERVED_BLOCKERS[6];
+    const mediaCluster = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.category === 'living-room-seating'
+    );
+
+    mediaCluster.forEach((definition) => {
+      const bounds = definition.solidBounds ?? definition.decorativeBounds;
+      if (bounds) expect(rectanglesOverlap(tokenBlocker, bounds)).toBe(false);
+    });
+  });
+
+  it('keeps the moved token.place blocker clear of lower solid furnishings', () => {
+    const tokenBlocker = LOWER_FLOOR_RESERVED_BLOCKERS[6];
+    const { colliders } = createLowerFloorFurnishings();
+
+    colliders.forEach((collider) => {
+      expect(rectanglesOverlap(tokenBlocker, collider)).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prepare the furnishing system for an upper-floor authoring path and the next dense furnishing wave while keeping the existing lower-floor API intact. 
- Move the `tokenplace-studio-cluster` POI out of the living-room media seating cluster to a dedicated living-room workstation spot without changing its room.

### Description
- Added shared floor furnishing plumbing and types and implemented `createUpperFloorFurnishings()` alongside a generalized `createFloorFurnishings(...)` to validate/build either floor with consistent collider metadata and predictable group names. (`src/scene/structures/lowerFloorFurnishings.ts`)
- Introduced `UPPER_FLOOR_ROOM_BOUNDS`, `UPPER_FLOOR_RESERVED_BLOCKERS`, and `DEFAULT_UPPER_FLOOR_FURNISHINGS` scaffolding for upper rooms. (`src/scene/structures/lowerFloorFurnishings.ts`)
- Validation consolidated into `validateFloorFurnishingPlan(...)` and exposed `validateLowerFloorFurnishingPlan` / `validateUpperFloorFurnishingPlan` to preserve the previous API and reuse logic. (`src/scene/structures/lowerFloorFurnishings.ts`)
- Wired upper-floor visuals into `upperStructureGroup` and pushed generated upper colliders to `upperFloorColliders` with `sourceType: 'generatedCollider'` and `purpose: 'upper-floor-furnishing'`. (`src/main.ts`)
- Reflowed `tokenplace-studio-cluster` placement to `roomId: 'livingRoom'`, position `{ x: 1.8, z: -21.2 }`, and heading `-Math.PI * 0.18`, and adjusted the reserved-blocker so it no longer overlaps the media seating cluster. (`src/scene/poi/placements.ts`, `src/scene/structures/lowerFloorFurnishings.ts`)
- Updated miniature proxy acknowledgements and bumped `syncRevision`/`syncNote` entries for affected miniature manifest entries and POI proxies. (`src/scene/miniature/sceneComponentRegistry.ts`, `src/scene/miniature/poiProxyRegistry.ts`, `src/scene/miniature/miniatureManifest.generated.json`)
- Tests: added/extended unit tests covering empty default upper build, upper room bounds, source IDs and collider metadata, non-blocking decorative footprints, upper validation, and token.place reflow/collider expectations. (`src/tests/lowerFloorFurnishings.test.ts`, `src/scene/poi/placements.test.ts`)

### Testing
- Ran `npm run format:write` and `npm run lint` — both completed (lint reported one unrelated order warning earlier and then passed after reordering imports).
- Ran focused tests: `npm run test:ci -- lowerFloorFurnishings placements miniatureManifest` — passed (all focused tests green).
- Ran full test suite: `npm run test:ci` — passed (all tests passed in CI run after miniature manifest update).
- Verified build: `npm run build` — succeeded and produced dist artifacts.
- Verified smoke: `npm run smoke` — succeeded.
- Note: `npm run typecheck -- --pretty false` shows pre-existing TypeScript errors in other areas of the repo unrelated to these changes; those errors were present before this work and do not block the furnishing tests or runtime build performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42a5fdf1a0832fa82782aeaec19299)