### PR TITLE
🏠 Add upper-floor furnishing foundation and reflow token.place

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -293,7 +293,10 @@ import {
   createJobbotTerminal,
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
-import { createLowerFloorFurnishings } from './scene/structures/lowerFloorFurnishings';
+import {
+  createLowerFloorFurnishings,
+  createUpperFloorFurnishings,
+} from './scene/structures/lowerFloorFurnishings';
 import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
@@ -2284,6 +2287,19 @@ function initializeImmersiveScene(
       sourceId: assertLevelSourceId(collider.sourceId),
       sourceType: 'generatedCollider',
       purpose: 'lower-floor-furnishing',
+      role: collider.category,
+    });
+  });
+
+  const upperFloorFurnishings = createUpperFloorFurnishings();
+  upperStructureGroup.add(upperFloorFurnishings.group);
+  upperFloorFurnishings.colliders.forEach((collider) => {
+    upperFloorColliders.push(collider);
+    namedColliderDebugNames.set(collider, collider.debugName);
+    colliderSourceMetadata.set(collider, {
+      sourceId: assertLevelSourceId(collider.sourceId),
+      sourceType: 'generatedCollider',
+      purpose: 'upper-floor-furnishing',
       role: collider.category,
     });
   });

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 18,
-      "syncNote": "Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.",
-      "sourceFingerprint": "2152c8d288227bea8b088e9da6474ee781f1b8ef24d7e55660856f67a3adb61a",
+      "syncRevision": 20,
+      "syncNote": "Acknowledges upper furnishing foundation and token.place reflow; tabletop furniture proxy coverage remains deferred.",
+      "sourceFingerprint": "1f64f1b5ffe830b15ee9320b47209334c83a454008b675dae4d47df833b475cf",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "3d6b130cd99fb62fde66e6951c50e0f41ffd63ac13825bbb1dea1b3939c89d63"
+      "metadataFingerprint": "5fdabe921eab0696f6964464b89de6af3cbb0fe3c7b7bbd7145f446176f9d972"
     },
     {
       "id": "environment:backyard",
@@ -521,11 +521,11 @@
         "src/scene/structures/axelNavigator.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
+      "syncRevision": 6,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "89086f102559baa055f93f88d427c1a0419da43ddbc6ec3fa9ae70cb6a0455b3",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "91768a8ca098ea3ba5134de0fde6cfbc86a6ac6952bc7c01d765a10dba4bd771"
     },
     {
       "id": "poi:danielsmith-portfolio-table",
@@ -541,11 +541,11 @@
         "src/scene/miniature/poiProxyRegistry.ts",
         "src/scene/structures/portfolioMiniatureTable.ts"
       ],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "4a4ff9e8191dc7a2877a6e047f1069ce1f8459bc37a2fa3b129819d8cb9eb40f",
-      "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
+      "syncRevision": 6,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "f0a1fab98b8f1a5bd648de469084e8d9b19e020aaf72d3c255cec5647b3e6c91",
+      "proxyFingerprint": "1ded4cb9339a4c379329b25898d85c2a07c796b5664e4a9fc5a110762f5a1ee2",
+      "metadataFingerprint": "fe8232af919eed571ca00c595f8e4c49d9dc75717bf2790f47e13de58d935f69"
     },
     {
       "id": "poi:dspace-backyard-rocket",
@@ -556,11 +556,11 @@
         "src/scene/structures/modelRocket.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
+      "syncRevision": 6,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "c87383d3a6f49d502eb783e065ef22b959f13462848666216d3277db98321501",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "59a88363aa73e2c9a86b63646fc2884765c1b81054e06dbaeea3ac065a52ae75"
     },
     {
       "id": "poi:f2clipboard-kitchen-console",
@@ -571,11 +571,11 @@
         "src/scene/structures/f2ClipboardConsole.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
-      "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "d338953e130bb55599de8591f7c3c585f3deccf6ad1071e42092668115c1721b",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "203724c45bb66fbd270e45ab7a70e1dbafba3029e5c7564acd9d086d805da04e"
+      "syncRevision": 8,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "d9c99df1cd61da12890dc0b6e14a548964dc78e8abdbea2ea974e0cfe2eb3ce4",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "635d84ed52cfc5e948d70f7a8281899633bfdc918befd7303b63af1b9f3660d5"
     },
     {
       "id": "poi:flywheel-studio-flywheel",
@@ -588,11 +588,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 26,
-      "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
-      "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
+      "syncRevision": 27,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "51673f968397b8576b9770c51e483dbd9df4908f34becfc97e86382f9964a284",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "6e01efe5ff91f07aed5123be15717697665f742a11bdafe2978c337e568380c8"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -603,11 +603,11 @@
         "src/scene/structures/mediaWall.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
+      "syncRevision": 6,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "dc0353e20df47adc0fc603239278aeb743d789f8206dfef0fa5afd3dc205dc3a",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "0eed1bca3fe380847459dad227fcc0aac51f946645699aa323a9777a16d5e26a"
     },
     {
       "id": "poi:gabriel-studio-sentry",
@@ -618,11 +618,11 @@
         "src/scene/structures/gabrielSentry.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
-      "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "5519bd57ed38839a83979ca24e37884834fd8fcef58414f43c2590aa395f445f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "e211ac43acb6c5ba1c68752d59b2710f4f99ec7cfff4ebcd119ca5008e631fc3"
+      "syncRevision": 8,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "77148305c61fe9d51393213a2872dfe423e200281087d58d766be8a61b23133d",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "ea0e3800afb32ee8b8ebcc8a1557f310932f7e99fd1ae2c136233eb9e32c13ad"
     },
     {
       "id": "poi:gitshelves-living-room-installation",
@@ -633,11 +633,11 @@
         "src/scene/structures/gitshelves.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
-      "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "23d44ccb3594b8a61cd8a971ac292ab08d66bd7eea213141e96b36f44224946f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "088235cd162b79a0a99f9ce58f500e3d67358bb03db4d57b739e452775f4113a"
+      "syncRevision": 8,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "a6a4d7481948a838178a30b12945d9da638262d4df7ded6620f1a9a00d80d210",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "edee68288cea4600a0d0fb9a7e6076559366847e648df745ad47a75a6e2f44f2"
     },
     {
       "id": "poi:jobbot-studio-terminal",
@@ -648,11 +648,11 @@
         "src/scene/structures/jobbotTerminal.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
+      "syncRevision": 6,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "11f0a7b30d7648491804a44c0379a34f727f76661f62fab5503ef237350ee20b",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "7293c97ccf3d414168cbdb4927a21ff6f2fbc6aa1f5592c0c88122deb4ac0443"
     },
     {
       "id": "poi:markers-labels",
@@ -683,11 +683,11 @@
         "src/ui/accessibility/animationPreferences.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 20,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
+      "syncRevision": 21,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "2446a3daca1cbc958edb093eb97e35c61f386d919800f8d772ca239d19bf7b4f",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "cab22fb9c9c91f6564c7044e57cf39f34508965045bc617ada369b771aa2b500"
     },
     {
       "id": "poi:sigma-kitchen-workbench",
@@ -698,11 +698,11 @@
         "src/scene/structures/sigmaWorkbench.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
-      "syncNote": "Adds the printed enclosure shell around the Sigma AI pin silhouette.",
-      "sourceFingerprint": "69151e3d9000e5e8d3c0dc2ea3b817ca6e5b008b44aa03cbe5e09026ced2f23f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "aa5a817cf4f5ca8f131522be446bec1762932a4c9d6bb42b4f537fa410bc7980"
+      "syncRevision": 8,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "ae2d13695f8011c7cdd9380a518859e6d114857b8ac3217ca9b25dabbd6773a5",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "30fad7b8f3efabce97b5545ddf979ff002094a03d0b48f51c9dda396b83c8511"
     },
     {
       "id": "poi:sugarkube-backyard-greenhouse",
@@ -713,11 +713,11 @@
         "src/scene/structures/sugarkubeDeployment.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 4,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
+      "syncRevision": 5,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "ac4eb79207c4d2f70796e6b980bb8663d2e694f42a69ce6a04bca7c371f05436",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "de110d3c97afccde5c14e90795df453f8a53f1ac43f11b68ef3df8f44aaee310"
     },
     {
       "id": "poi:tokenplace-studio-cluster",
@@ -728,11 +728,11 @@
         "src/scene/structures/tokenPlaceWorkstation.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 4,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
+      "syncRevision": 5,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "f02ec6225ba49f587b5cf95fa2e9f4871e58d6328d3b123cec2972685e6f2f47",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "4044101428f910927cc8b4503af3277fcce37c39ae48b2371809d2d06abd10fe"
     },
     {
       "id": "poi:wove-kitchen-loom",
@@ -743,11 +743,11 @@
         "src/scene/structures/woveLoom.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
+      "syncRevision": 6,
+      "syncNote": "Acknowledges token.place placement reflow while preserving this proxy silhouette.",
+      "sourceFingerprint": "47b5e6a824a3e87cdfa764593ff4c578245e579d90b1dbe83c7121d1555f263d",
+      "proxyFingerprint": "c8b01dc17ad9436706826731eb7732c72b8b9d0976ec3bd8043cafa42fe8801c",
+      "metadataFingerprint": "bf9c021299c452739730b3e27ff6ab9c71a129b831beec463811217fcc4edebd"
     },
     {
       "id": "structure:greenhouse",

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -69,9 +69,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'futuroptimist-living-room-tv',
     id: 'poi:futuroptimist-living-room-tv',
     displayName: 'Futur Optimist TV proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/mediaWall.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -90,9 +90,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 26,
+    syncRevision: 27,
     syncNote:
-      'Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/flywheel.ts',
@@ -172,9 +172,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'jobbot-studio-terminal',
     id: 'poi:jobbot-studio-terminal',
     displayName: 'Jobbot terminal proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/jobbotTerminal.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -193,9 +193,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'dspace-backyard-rocket',
     id: 'poi:dspace-backyard-rocket',
     displayName: 'dSpace rocket proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/modelRocket.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -210,9 +210,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sugarkube-backyard-greenhouse',
     id: 'poi:sugarkube-backyard-greenhouse',
     displayName: 'Sugarkube deployment proxy',
-    syncRevision: 4,
+    syncRevision: 5,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sugarkubeDeployment.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -306,9 +306,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'tokenplace-studio-cluster',
     id: 'poi:tokenplace-studio-cluster',
     displayName: 'token.place workstation proxy',
-    syncRevision: 4,
+    syncRevision: 5,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/tokenPlaceWorkstation.ts',
@@ -348,9 +348,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gabriel-studio-sentry',
     id: 'poi:gabriel-studio-sentry',
     displayName: 'Gabriel sentry proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
-      'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gabrielSentry.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -364,9 +364,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'f2clipboard-kitchen-console',
     id: 'poi:f2clipboard-kitchen-console',
     displayName: 'f2clipboard console proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
-      'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/f2ClipboardConsole.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -379,9 +379,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'axel-studio-tracker',
     id: 'poi:axel-studio-tracker',
     displayName: 'Axel tracker proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/axelNavigator.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -402,9 +402,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sigma-kitchen-workbench',
     id: 'poi:sigma-kitchen-workbench',
     displayName: 'Sigma workbench proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
-      'Adds the printed enclosure shell around the Sigma AI pin silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sigmaWorkbench.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -417,9 +417,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gitshelves-living-room-installation',
     id: 'poi:gitshelves-living-room-installation',
     displayName: 'Gitshelves proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
-      'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gitshelves.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -433,9 +433,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'wove-kitchen-loom',
     id: 'poi:wove-kitchen-loom',
     displayName: 'Wove loom proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/woveLoom.ts'],
     proxyFiles: [SELF_FILE],
     primitives: [
@@ -448,9 +448,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'pr-reaper-backyard-console',
     id: 'poi:pr-reaper-backyard-console',
     displayName: 'PR Reaper holographic reaper installation proxy',
-    syncRevision: 20,
+    syncRevision: 21,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/prReaperConsole.ts',
@@ -519,9 +519,9 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     id: 'poi:danielsmith-portfolio-table',
     displayName: 'danielsmith.io recursion boundary table proxy',
     recursionBoundary: true,
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
+      'Acknowledges token.place placement reflow while preserving this proxy silhouette.',
     sourceFiles: [
       ...baseFiles,
       'src/scene/structures/selfieMirror.ts',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 18,
+    syncRevision: 20,
     syncNote:
-      'Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.',
+      'Acknowledges upper furnishing foundation and token.place reflow; tabletop furniture proxy coverage remains deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -40,7 +40,7 @@ describe('applyManualPoiPlacements', () => {
         roomId: 'livingRoom',
         floorId: 'ground',
         anchorY: 0.75,
-        position: { x: -22.34, y: 0, z: -22.61 },
+        position: { x: 1.8, y: 0, z: -21.2 },
       },
       {
         id: 'sugarkube-backyard-greenhouse',

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -83,13 +83,13 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   },
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
-    position: { x: -22.34, y: getFloorTopElevation('ground'), z: -22.61 },
+    position: { x: 1.8, y: getFloorTopElevation('ground'), z: -21.2 },
     interactionAnchorPosition: {
-      x: -22.34,
+      x: 1.8,
       y: getFloorStandingInteractionAnchorY('ground'),
-      z: -22.61,
+      z: -21.2,
     },
-    headingRadians: Math.PI * 0.05,
+    headingRadians: -Math.PI * 0.18,
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -21,6 +21,14 @@ export type LowerFloorFurnishingCategory =
 
 export type LowerFloorRoomId = 'livingRoom' | 'kitchen' | 'studio' | 'backyard';
 
+export type UpperFloorRoomId =
+  | 'upperLanding'
+  | 'creatorsStudio'
+  | 'loftLibrary'
+  | 'focusPods';
+
+type FloorFurnishingRoomId = LowerFloorRoomId | UpperFloorRoomId;
+
 export interface LowerFloorFurnishingFootprint {
   width: number;
   depth: number;
@@ -29,7 +37,7 @@ export interface LowerFloorFurnishingFootprint {
 export interface LowerFloorFurnishingDefinition {
   id: string;
   category: LowerFloorFurnishingCategory;
-  roomId: LowerFloorRoomId;
+  roomId: FloorFurnishingRoomId;
   position: { x: number; y?: number; z: number };
   orientationRadians: number;
   solidFootprint?: LowerFloorFurnishingFootprint;
@@ -52,7 +60,7 @@ export interface DecorativeFootprintRecord {
   id: string;
   furnishingId: string;
   category: LowerFloorFurnishingCategory;
-  roomId: LowerFloorRoomId;
+  roomId: FloorFurnishingRoomId;
   bounds: RectCollider;
   allowSolidOverlap: boolean;
 }
@@ -60,7 +68,7 @@ export interface DecorativeFootprintRecord {
 export interface LowerFloorFurnishingCollider extends RectCollider {
   furnishingId: string;
   category: LowerFloorFurnishingCategory;
-  roomId: LowerFloorRoomId;
+  roomId: FloorFurnishingRoomId;
   sourceId: string;
   debugName: string;
 }
@@ -76,6 +84,12 @@ export interface LowerFloorFurnishingsCreateOptions
   definitions?: readonly LowerFloorFurnishingDefinition[];
 }
 
+export interface FloorFurnishingsBuild {
+  group: Group;
+  colliders: LowerFloorFurnishingCollider[];
+  decorativeFootprints: DecorativeFootprintRecord[];
+}
+
 export interface LowerFloorFurnishingsBuild {
   group: Group;
   colliders: LowerFloorFurnishingCollider[];
@@ -89,6 +103,24 @@ export const LOWER_FLOOR_ROOM_BOUNDS: Record<LowerFloorRoomId, RectCollider> = {
   backyard: { minX: -32, maxX: 32, minZ: 16, maxZ: 32 },
 };
 
+export const UPPER_FLOOR_ROOM_BOUNDS: Record<UpperFloorRoomId, RectCollider> = {
+  upperLanding: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+  creatorsStudio: { minX: -20, maxX: 4, minZ: -32, maxZ: 0 },
+  loftLibrary: { minX: 4, maxX: 24, minZ: -16, maxZ: 12 },
+  focusPods: { minX: -20, maxX: 24, minZ: 12, maxZ: 28 },
+};
+
+export const UPPER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
+  { minX: -2.8, maxX: 1.6, minZ: 11.8, maxZ: 16.2 },
+  { minX: 14.2, maxX: 18.8, minZ: 15.6, maxZ: 20.0 },
+  { minX: -19.2, maxX: -14.6, minZ: 15.2, maxZ: 19.4 },
+  { minX: -19.4, maxX: -15.0, minZ: -9.0, maxZ: -5.0 },
+  { minX: 4.2, maxX: 8.4, minZ: -16.8, maxZ: -13.6 },
+];
+
+export const DEFAULT_UPPER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] =
+  [];
+
 export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
   { minX: -22, maxX: -14, minZ: -9.2, maxZ: -6.8 },
   { minX: 11, maxX: 19, minZ: -9.2, maxZ: -6.8 },
@@ -96,7 +128,7 @@ export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
   { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
   { minX: 11, maxX: 19, minZ: 14.8, maxZ: 17.2 },
   { minX: -32.0, maxX: -30.9, minZ: -23.2, maxZ: -16.8 },
-  { minX: -24.74, maxX: -19.94, minZ: -24.61, maxZ: -20.61 },
+  { minX: -0.6, maxX: 4.2, minZ: -23.2, maxZ: -19.2 },
   { minX: -12.34, maxX: -5.14, minZ: -26.12, maxZ: -19.72 },
   { minX: -24.0, maxX: -19.2, minZ: -0.77, maxZ: 4.03 },
   { minX: 26.4, maxX: 31.2, minZ: -24.4, maxZ: -21.2 },
@@ -676,12 +708,16 @@ function containsPoint(
   );
 }
 
-export function validateLowerFloorFurnishingPlan(
+function validateFloorFurnishingPlan(
   definitions: readonly LowerFloorFurnishingDefinition[],
-  options: LowerFloorFurnishingValidationOptions = {}
+  options: {
+    roomBounds: Partial<Record<FloorFurnishingRoomId, RectCollider>>;
+    reservedBlockers: readonly RectCollider[];
+    tolerance?: number;
+  }
 ): void {
-  const roomBounds = { ...LOWER_FLOOR_ROOM_BOUNDS, ...options.roomBounds };
-  const blockers = options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS;
+  const roomBounds = options.roomBounds;
+  const blockers = options.reservedBlockers;
   const tolerance = options.tolerance ?? 0.001;
   definitions.forEach((definition) => {
     if (!isLevelSourceId(definition.id)) {
@@ -693,6 +729,8 @@ export function validateLowerFloorFurnishingPlan(
     if (!definition.solidFootprint) return [];
     const bounds = createRotatedAabb(definition, definition.solidFootprint);
     const room = roomBounds[definition.roomId];
+    if (!room)
+      throw new Error(`${definition.roomId} is not a known furnishing room.`);
     if (!hasPositiveArea(bounds))
       throw new Error(`${definition.id} has an empty solid footprint.`);
     if (!containsBounds(room, bounds, tolerance)) {
@@ -731,13 +769,10 @@ export function validateLowerFloorFurnishingPlan(
 
   definitions.forEach((definition) => {
     if (definition.solidFootprint || definition.decorativeFootprint) return;
-    if (
-      !containsPoint(
-        roomBounds[definition.roomId],
-        definition.position,
-        tolerance
-      )
-    ) {
+    const room = roomBounds[definition.roomId];
+    if (!room)
+      throw new Error(`${definition.roomId} is not a known furnishing room.`);
+    if (!containsPoint(room, definition.position, tolerance)) {
       throw new Error(
         `${definition.id} visual detail position is outside ${definition.roomId}.`
       );
@@ -753,7 +788,10 @@ export function validateLowerFloorFurnishingPlan(
     if (!hasPositiveArea(bounds)) {
       throw new Error(`${definition.id} has an empty decorative footprint.`);
     }
-    if (!containsBounds(roomBounds[definition.roomId], bounds, tolerance)) {
+    const room = roomBounds[definition.roomId];
+    if (!room)
+      throw new Error(`${definition.roomId} is not a known furnishing room.`);
+    if (!containsBounds(room, bounds, tolerance)) {
       throw new Error(
         `${definition.id} decorative footprint is outside ${definition.roomId}.`
       );
@@ -780,14 +818,50 @@ export function validateLowerFloorFurnishingPlan(
   });
 }
 
-export function createLowerFloorFurnishings(
-  options: LowerFloorFurnishingsCreateOptions = {}
-): LowerFloorFurnishingsBuild {
-  const definitions = options.definitions ?? DEFAULT_LOWER_FLOOR_FURNISHINGS;
-  validateLowerFloorFurnishingPlan(definitions, options);
+export function validateLowerFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: LowerFloorFurnishingValidationOptions = {}
+): void {
+  validateFloorFurnishingPlan(definitions, {
+    roomBounds: { ...LOWER_FLOOR_ROOM_BOUNDS, ...options.roomBounds },
+    reservedBlockers: options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS,
+    tolerance: options.tolerance,
+  });
+}
+
+export function validateUpperFloorFurnishingPlan(
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: {
+    roomBounds?: Partial<Record<UpperFloorRoomId, RectCollider>>;
+    reservedBlockers?: readonly RectCollider[];
+    tolerance?: number;
+  } = {}
+): void {
+  validateFloorFurnishingPlan(definitions, {
+    roomBounds: { ...UPPER_FLOOR_ROOM_BOUNDS, ...options.roomBounds },
+    reservedBlockers: options.reservedBlockers ?? UPPER_FLOOR_RESERVED_BLOCKERS,
+    tolerance: options.tolerance,
+  });
+}
+
+function createFloorFurnishings(
+  floorId: 'ground' | 'upper',
+  groupName: string,
+  definitions: readonly LowerFloorFurnishingDefinition[],
+  options: {
+    roomBounds?: Partial<Record<FloorFurnishingRoomId, RectCollider>>;
+    reservedBlockers?: readonly RectCollider[];
+    tolerance?: number;
+  } = {}
+): FloorFurnishingsBuild {
+  if (floorId === 'upper') {
+    validateUpperFloorFurnishingPlan(definitions, options);
+  } else {
+    validateLowerFloorFurnishingPlan(definitions, options);
+  }
 
   const group = new Group();
-  group.name = 'LowerFloorFurnishings';
+  group.name = groupName;
   const colliders: LowerFloorFurnishingCollider[] = [];
   const decorativeFootprints: DecorativeFootprintRecord[] = [];
 
@@ -809,8 +883,8 @@ export function createLowerFloorFurnishings(
         furnishingId: definition.id,
         category: definition.category,
         roomId: definition.roomId,
-        sourceId: `ground.furnishings.${definition.category}.${definition.id}.generated_collider`,
-        debugName: `LowerFloorFurnishingCollider:${definition.id}`,
+        sourceId: `${floorId}.furnishings.${definition.category}.${definition.id}.generated_collider`,
+        debugName: `${groupName}Collider:${definition.id}`,
       });
     }
 
@@ -837,6 +911,30 @@ export function createLowerFloorFurnishings(
   });
 
   return { group, colliders, decorativeFootprints };
+}
+
+export function createLowerFloorFurnishings(
+  options: LowerFloorFurnishingsCreateOptions = {}
+): LowerFloorFurnishingsBuild {
+  const definitions = options.definitions ?? DEFAULT_LOWER_FLOOR_FURNISHINGS;
+  return createFloorFurnishings(
+    'ground',
+    'LowerFloorFurnishings',
+    definitions,
+    options
+  );
+}
+
+export function createUpperFloorFurnishings(
+  options: LowerFloorFurnishingsCreateOptions = {}
+): LowerFloorFurnishingsBuild {
+  const definitions = options.definitions ?? DEFAULT_UPPER_FLOOR_FURNISHINGS;
+  return createFloorFurnishings(
+    'upper',
+    'UpperFloorFurnishings',
+    definitions,
+    options
+  );
 }
 
 function createSolidPrimitive(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -9,10 +9,14 @@ import { isLevelSourceId } from '../scene/level/sourceIds';
 import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
+  UPPER_FLOOR_RESERVED_BLOCKERS,
+  UPPER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
   createLowerFloorFurnishings,
+  createUpperFloorFurnishings,
   rectanglesOverlap,
   validateLowerFloorFurnishingPlan,
+  validateUpperFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
 } from '../scene/structures/lowerFloorFurnishings';
 import type { RectCollider } from '../systems/collision';
@@ -22,7 +26,7 @@ const validDefinitions: LowerFloorFurnishingDefinition[] = [
     id: 'living-couch-foundation',
     category: 'living-room-seating',
     roomId: 'livingRoom',
-    position: { x: -2, z: -21 },
+    position: { x: 22, z: -18 },
     orientationRadians: 0,
     solidFootprint: { width: 5.2, depth: 1.4 },
     kind: 'couch',
@@ -454,7 +458,12 @@ describe('lower floor furnishings foundation', () => {
 
     storageColliders.forEach((storage, index) => {
       expect(
-        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[storage.roomId], storage)
+        isContainedBy(
+          LOWER_FLOOR_ROOM_BOUNDS[
+            storage.roomId as keyof typeof LOWER_FLOOR_ROOM_BOUNDS
+          ],
+          storage
+        )
       ).toBe(true);
       storageColliders.slice(index + 1).forEach((otherStorage) => {
         expect(rectanglesOverlap(storage, otherStorage)).toBe(false);
@@ -627,9 +636,14 @@ describe('lower floor furnishings foundation', () => {
     );
 
     decorColliders.forEach((decor, index) => {
-      expect(isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[decor.roomId], decor)).toBe(
-        true
-      );
+      expect(
+        isContainedBy(
+          LOWER_FLOOR_ROOM_BOUNDS[
+            decor.roomId as keyof typeof LOWER_FLOOR_ROOM_BOUNDS
+          ],
+          decor
+        )
+      ).toBe(true);
       decorColliders.slice(index + 1).forEach((otherDecor) => {
         expect(rectanglesOverlap(decor, otherDecor)).toBe(false);
       });
@@ -1153,7 +1167,10 @@ describe('lower floor furnishings foundation', () => {
     });
 
     colliders.forEach((collider) => {
-      const room = LOWER_FLOOR_ROOM_BOUNDS[collider.roomId];
+      const room =
+        LOWER_FLOOR_ROOM_BOUNDS[
+          collider.roomId as keyof typeof LOWER_FLOOR_ROOM_BOUNDS
+        ];
       expect(isContainedBy(room, collider)).toBe(true);
     });
   });
@@ -1179,7 +1196,7 @@ describe('lower floor furnishings foundation', () => {
         id: 'living-overlap-a',
         category: 'living-room-seating',
         roomId: 'livingRoom',
-        position: { x: -2, z: -21 },
+        position: { x: 22, z: -18 },
         orientationRadians: 0,
         solidFootprint: { width: 2, depth: 2 },
         kind: 'couch',
@@ -1189,7 +1206,7 @@ describe('lower floor furnishings foundation', () => {
         id: 'living-overlap-b',
         category: 'living-room-seating',
         roomId: 'livingRoom',
-        position: { x: -1.5, z: -21 },
+        position: { x: 22.5, z: -18 },
         orientationRadians: 0,
         solidFootprint: { width: 2, depth: 2 },
         kind: 'couch',
@@ -1293,3 +1310,137 @@ function isContainedBy(container: RectCollider, bounds: RectCollider): boolean {
     bounds.maxZ <= container.maxZ
   );
 }
+
+describe('upper floor furnishings foundation', () => {
+  const upperDefinitions: LowerFloorFurnishingDefinition[] = [
+    {
+      id: 'upper-landing-console-foundation',
+      category: 'storage',
+      roomId: 'upperLanding',
+      position: { x: 14, z: -26 },
+      orientationRadians: 0,
+      solidFootprint: { width: 2.2, depth: 0.8 },
+      kind: 'storage-drawer-console',
+    },
+    {
+      id: 'creators-studio-rug-foundation',
+      category: 'plants-lighting-decor',
+      roomId: 'creatorsStudio',
+      position: { x: -8, z: -12 },
+      orientationRadians: 0,
+      decorativeFootprint: { width: 4, depth: 3 },
+      kind: 'rug',
+    },
+  ];
+
+  it('builds an empty default upper furnishing group', () => {
+    const build = createUpperFloorFurnishings();
+
+    expect(build.group.name).toBe('UpperFloorFurnishings');
+    expect(build.colliders).toHaveLength(0);
+    expect(build.decorativeFootprints).toHaveLength(0);
+  });
+
+  it('defines valid upper room bounds', () => {
+    expect(UPPER_FLOOR_ROOM_BOUNDS).toEqual({
+      upperLanding: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+      creatorsStudio: { minX: -20, maxX: 4, minZ: -32, maxZ: 0 },
+      loftLibrary: { minX: 4, maxX: 24, minZ: -16, maxZ: 12 },
+      focusPods: { minX: -20, maxX: 24, minZ: 12, maxZ: 28 },
+    });
+
+    Object.values(UPPER_FLOOR_ROOM_BOUNDS).forEach((bounds) => {
+      expect(bounds.maxX - bounds.minX).toBeGreaterThan(0);
+      expect(bounds.maxZ - bounds.minZ).toBeGreaterThan(0);
+    });
+  });
+
+  it('creates valid unique upper generated source IDs', () => {
+    const { colliders } = createUpperFloorFurnishings({
+      definitions: upperDefinitions,
+    });
+
+    const sourceIds = colliders.map((collider) => collider.sourceId);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    colliders.forEach((collider) => {
+      expect(collider.sourceId).toBe(
+        `upper.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
+      );
+      expect(isLevelSourceId(collider.sourceId)).toBe(true);
+      expect(collider.debugName).toBe(
+        `UpperFloorFurnishingsCollider:${collider.furnishingId}`
+      );
+    });
+  });
+
+  it('keeps upper decorative footprints non-blocking', () => {
+    const { colliders, decorativeFootprints } = createUpperFloorFurnishings({
+      definitions: upperDefinitions,
+    });
+
+    expect(
+      colliders.some(({ furnishingId }) => furnishingId.includes('rug'))
+    ).toBe(false);
+    expect(decorativeFootprints).toHaveLength(1);
+    expect(decorativeFootprints[0]).toMatchObject({
+      furnishingId: 'creators-studio-rug-foundation',
+      roomId: 'creatorsStudio',
+      allowSolidOverlap: false,
+    });
+  });
+
+  it('rejects upper solid overlaps with reserved blockers', () => {
+    expect(UPPER_FLOOR_RESERVED_BLOCKERS.length).toBeGreaterThan(0);
+    expect(() =>
+      validateUpperFloorFurnishingPlan([
+        {
+          id: 'upper-poi-overlap-foundation',
+          category: 'storage',
+          roomId: 'focusPods',
+          position: { x: -0.6, z: 14 },
+          orientationRadians: 0,
+          solidFootprint: { width: 1, depth: 1 },
+          kind: 'storage-drawer-console',
+        },
+      ])
+    ).toThrow(/overlaps reserved blocker/);
+  });
+});
+
+const movedTokenPlaceReservedBlocker: RectCollider = {
+  minX: -0.6,
+  maxX: 4.2,
+  minZ: -23.2,
+  maxZ: -19.2,
+};
+
+const mediaSeatingClusterBounds: RectCollider = {
+  minX: -29.2,
+  maxX: -21.4,
+  minZ: -23.8,
+  maxZ: -15.2,
+};
+
+describe('token.place living-room reflow blocker', () => {
+  it('keeps token.place in the living room away from media seating', () => {
+    expect(LOWER_FLOOR_RESERVED_BLOCKERS).toContainEqual(
+      movedTokenPlaceReservedBlocker
+    );
+    expect(
+      rectanglesOverlap(
+        movedTokenPlaceReservedBlocker,
+        mediaSeatingClusterBounds
+      )
+    ).toBe(false);
+  });
+
+  it('does not overlap any current lower-floor solid furnishing collider', () => {
+    const { colliders } = createLowerFloorFurnishings();
+
+    colliders.forEach((collider) => {
+      expect(rectanglesOverlap(movedTokenPlaceReservedBlocker, collider)).toBe(
+        false
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prepare the furnishing pipeline to author, validate, and render upper-floor furniture with the same collider/validation rigor used for the ground floor.
- Move the `tokenplace-studio-cluster` POI out of the living-room media/sofa cluster while keeping it in the same room to avoid furniture collisions.

### Description
- Add upper-floor room types, world bounds, reserved blockers, and an empty default upper furnishing set (`UPPER_FLOOR_ROOM_BOUNDS`, `UPPER_FLOOR_RESERVED_BLOCKERS`, `DEFAULT_UPPER_FLOOR_FURNISHINGS`) and expose `createUpperFloorFurnishings()` while preserving `createLowerFloorFurnishings()`; extract a shared `createFloorFurnishings()`/`validateFloorFurnishingPlan()` helper to avoid duplication (`src/scene/structures/lowerFloorFurnishings.ts`).
- Wire upper-floor visuals into the scene and register their colliders into `upperFloorColliders` with matching generated-collider metadata and purpose `upper-floor-furnishing` (`src/main.ts`).
- Reflow `tokenplace-studio-cluster` POI into the living room at `x=1.8, z=-21.2` with heading `-Math.PI * 0.18` and update its interaction anchor; add a conservative reserved blocker for the moved placement and adjust lower-floor reserved blockers to avoid overlap with the media seating cluster (`src/scene/poi/placements.ts`, `src/scene/structures/lowerFloorFurnishings.ts`).
- Add tests for the upper-floor foundation and token.place reflow, and update miniature manifest / POI proxy acknowledgements to reflect placement and furnishing-authoring changes (`src/tests/lowerFloorFurnishings.test.ts`, `src/scene/miniature/*`).

### Testing
- Ran formatting and linting: `npm run format:write` (OK), `npm run lint` (OK), `npm run docs:check` (OK).
- Focused tests: `npm run test:ci -- lowerFloorFurnishings placements` (both suites passed locally).
- Full test suite: `npm run test:ci` (all tests passed; final run: 182 test files, 1,443 tests passed).
- Build and smoke: `npm run build` (OK) and `npm run smoke` (OK).
- Miniature manifest: updated via `npm run miniature:manifest:update` and checked; manifest regenerated and committed to acknowledge proxy coverage changes.
- Typecheck: `npm run typecheck` was run but failed with pre-existing, repo-wide TypeScript errors unrelated to these changes (reported and left unchanged to avoid scope creep).
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no high-risk secrets found).

If you want I can split the upper-floor authoring helpers into a separate module or add a small README note describing the `createUpperFloorFurnishings()` shape and the expected source ID pattern for generated colliders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42a5dfb898832fba0f30a4a82d4f15)